### PR TITLE
feat: Twitter/X OAuth, PKCE, synthetic email + platform user provisioning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -99,6 +99,30 @@ PASSKEY_RP_ID=steward.fi
 # Allowed origin for passkey operations. Must match the browser's origin.
 PASSKEY_ORIGIN=https://steward.fi
 
+# ─── Auth — OAuth Providers ───────────────────────────────────────────────────
+
+# Google OAuth2 (openid email profile scopes)
+# Redirect URI to register in Google Cloud Console:
+#   http://localhost:3200/auth/oauth/google/callback
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+
+# Discord OAuth2 (identify email scopes)
+# Redirect URI to register in Discord Developer Portal:
+#   http://localhost:3200/auth/oauth/discord/callback
+DISCORD_CLIENT_ID=
+DISCORD_CLIENT_SECRET=
+
+# Twitter/X OAuth2 with PKCE (tweet.read users.read offline.access scopes)
+# App type: Confidential client in Twitter Developer Portal
+# Redirect URI to register:
+#   http://localhost:3200/auth/oauth/twitter/callback
+# NOTE: Twitter does NOT return email via its API. Users authenticated via
+# Twitter receive a synthetic internal email (twitter.<id>@id.steward.internal)
+# for identity purposes. This email is never displayed or sent.
+TWITTER_CLIENT_ID=
+TWITTER_CLIENT_SECRET=
+
 # ─── Redis (optional) ─────────────────────────────────────────────────────────
 
 # Redis connection URL. Required for:

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,17 +44,33 @@ COPY packages/shared/package.json    packages/shared/package.json
 COPY packages/vault/package.json     packages/vault/package.json
 COPY packages/webhooks/package.json  packages/webhooks/package.json
 
-RUN bun install --frozen-lockfile
+# Strip frontend/example workspaces not present in server builds
+# (web, packages/sdk, and packages/examples/* are excluded via .dockerignore)
+RUN sed -i '/"web"/d; /"packages\/examples\/\*"/d; /"packages\/sdk"/d' package.json
 
-# ── Stage 2: Build ────────────────────────────────────────────────────────────
-FROM base AS build
+# Note: --frozen-lockfile is omitted because we patched package.json above
+# (removed frontend workspaces). bun.lock still pins all versions.
+RUN bun install
 
+# ── Stage 2: Runtime ──────────────────────────────────────────────────────────
+# Bun executes TypeScript directly — no compilation step needed.
+# All "build" scripts in Steward packages are tsc --noEmit (type-check only),
+# not compilation, so we skip turbo build entirely.
+FROM oven/bun:1.2-alpine AS runtime
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV PORT=3200
+
+# Bring in node_modules from the deps stage
 COPY --from=deps /app/node_modules ./node_modules
-COPY package.json bun.lock turbo.json tsconfig.json ./
 
-# Copy full source for all packages needed by api + proxy
-# Note: packages/sdk and packages/dashboard are excluded via .dockerignore
-#       (browser-only packages not needed for the server build)
+# Copy root manifests
+COPY package.json bun.lock turbo.json tsconfig.json ./
+RUN sed -i '/"web"/d; /"packages\/examples\/\*"/d; /"packages\/sdk"/d' package.json
+
+# Copy source for all server packages
 COPY packages/api         packages/api
 COPY packages/auth        packages/auth
 COPY packages/db          packages/db
@@ -64,43 +80,6 @@ COPY packages/redis       packages/redis
 COPY packages/shared      packages/shared
 COPY packages/vault       packages/vault
 COPY packages/webhooks    packages/webhooks
-
-# Build api and proxy (and their deps) via turborepo
-RUN bunx turbo run build --filter=@steward/api --filter=@stwd/proxy
-
-# ── Stage 3: Runtime ──────────────────────────────────────────────────────────
-FROM oven/bun:1.2-alpine AS runtime
-
-WORKDIR /app
-
-ENV NODE_ENV=production
-ENV PORT=3200
-
-# Install production dependencies only (no dev/build tools)
-COPY package.json bun.lock turbo.json tsconfig.json ./
-
-COPY packages/api/package.json       packages/api/package.json
-COPY packages/auth/package.json      packages/auth/package.json
-COPY packages/db/package.json        packages/db/package.json
-COPY packages/policy-engine/package.json packages/policy-engine/package.json
-COPY packages/proxy/package.json     packages/proxy/package.json
-COPY packages/redis/package.json     packages/redis/package.json
-COPY packages/shared/package.json    packages/shared/package.json
-COPY packages/vault/package.json     packages/vault/package.json
-COPY packages/webhooks/package.json  packages/webhooks/package.json
-
-RUN bun install --frozen-lockfile --production
-
-# Copy compiled output from build stage
-COPY --from=build /app/packages/api         packages/api
-COPY --from=build /app/packages/auth        packages/auth
-COPY --from=build /app/packages/db          packages/db
-COPY --from=build /app/packages/policy-engine packages/policy-engine
-COPY --from=build /app/packages/proxy       packages/proxy
-COPY --from=build /app/packages/redis       packages/redis
-COPY --from=build /app/packages/shared      packages/shared
-COPY --from=build /app/packages/vault       packages/vault
-COPY --from=build /app/packages/webhooks    packages/webhooks
 
 # ── Non-root user ─────────────────────────────────────────────────────────────
 # bun image already has a 'bun' user (uid 1000); use it.

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,6 @@ COPY packages/policy-engine/package.json packages/policy-engine/package.json
 COPY packages/proxy/package.json     packages/proxy/package.json
 COPY packages/redis/package.json     packages/redis/package.json
 COPY packages/shared/package.json    packages/shared/package.json
-COPY packages/sdk/package.json       packages/sdk/package.json
 COPY packages/vault/package.json     packages/vault/package.json
 COPY packages/webhooks/package.json  packages/webhooks/package.json
 
@@ -54,6 +53,8 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY package.json bun.lock turbo.json tsconfig.json ./
 
 # Copy full source for all packages needed by api + proxy
+# Note: packages/sdk and packages/dashboard are excluded via .dockerignore
+#       (browser-only packages not needed for the server build)
 COPY packages/api         packages/api
 COPY packages/auth        packages/auth
 COPY packages/db          packages/db
@@ -61,7 +62,6 @@ COPY packages/policy-engine packages/policy-engine
 COPY packages/proxy       packages/proxy
 COPY packages/redis       packages/redis
 COPY packages/shared      packages/shared
-COPY packages/sdk         packages/sdk
 COPY packages/vault       packages/vault
 COPY packages/webhooks    packages/webhooks
 
@@ -86,7 +86,6 @@ COPY packages/policy-engine/package.json packages/policy-engine/package.json
 COPY packages/proxy/package.json     packages/proxy/package.json
 COPY packages/redis/package.json     packages/redis/package.json
 COPY packages/shared/package.json    packages/shared/package.json
-COPY packages/sdk/package.json       packages/sdk/package.json
 COPY packages/vault/package.json     packages/vault/package.json
 COPY packages/webhooks/package.json  packages/webhooks/package.json
 
@@ -100,7 +99,6 @@ COPY --from=build /app/packages/policy-engine packages/policy-engine
 COPY --from=build /app/packages/proxy       packages/proxy
 COPY --from=build /app/packages/redis       packages/redis
 COPY --from=build /app/packages/shared      packages/shared
-COPY --from=build /app/packages/sdk         packages/sdk
 COPY --from=build /app/packages/vault       packages/vault
 COPY --from=build /app/packages/webhooks    packages/webhooks
 

--- a/packages/api/src/__tests__/platform-users.test.ts
+++ b/packages/api/src/__tests__/platform-users.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it, beforeAll, afterAll } from "bun:test";
+import { getDb, users } from "@stwd/db";
+import { eq } from "drizzle-orm";
+
+// Skip when no DB configured (CI without Postgres)
+const SKIP = !process.env.DATABASE_URL;
+
+const TEST_PORT = parseInt(process.env.PORT || "3200", 10);
+const BASE_URL = `http://localhost:${TEST_PORT}`;
+
+// Use the dev platform key configured in STEWARD_PLATFORM_KEYS
+const PLATFORM_KEY =
+  (process.env.STEWARD_PLATFORM_KEYS ?? "").split(",")[0].trim() || "dev-platform-key";
+
+const TEST_EMAIL_NEW = `platform-users-test-new-${Date.now()}@example.com`;
+const TEST_EMAIL_EXISTING = `platform-users-test-existing-${Date.now()}@example.com`;
+
+// ─── Setup ───────────────────────────────────────────────────────────────────
+
+beforeAll(async () => {
+  if (SKIP) return;
+  // Pre-insert the "existing" user so idempotency can be tested
+  const db = getDb();
+  await db
+    .insert(users)
+    .values({ email: TEST_EMAIL_EXISTING, emailVerified: true, name: "Pre-existing" })
+    .onConflictDoNothing();
+});
+
+afterAll(async () => {
+  if (SKIP) return;
+  const db = getDb();
+  await db.delete(users).where(eq(users.email, TEST_EMAIL_NEW));
+  await db.delete(users).where(eq(users.email, TEST_EMAIL_EXISTING));
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("POST /platform/users", () => {
+  it("returns 401 when platform key is missing", async () => {
+    const res = await fetch(`${BASE_URL}/platform/users`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: TEST_EMAIL_NEW }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when platform key is invalid", async () => {
+    const res = await fetch(`${BASE_URL}/platform/users`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Steward-Platform-Key": "invalid-platform-key",
+      },
+      body: JSON.stringify({ email: TEST_EMAIL_NEW }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 when email is missing", async () => {
+    const res = await fetch(`${BASE_URL}/platform/users`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Steward-Platform-Key": PLATFORM_KEY,
+      },
+      body: JSON.stringify({ name: "No Email" }),
+    });
+    expect(res.status).toBe(400);
+    const data = (await res.json()) as { ok: boolean; error: string };
+    expect(data.ok).toBe(false);
+    expect(data.error).toMatch(/email/i);
+  });
+
+  it("returns 400 when email is not a valid email string", async () => {
+    const res = await fetch(`${BASE_URL}/platform/users`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Steward-Platform-Key": PLATFORM_KEY,
+      },
+      body: JSON.stringify({ email: "not-an-email" }),
+    });
+    expect(res.status).toBe(400);
+    const data = (await res.json()) as { ok: boolean };
+    expect(data.ok).toBe(false);
+  });
+
+  it("creates a new user and returns isNew=true (201)", async () => {
+    if (SKIP) return;
+    const res = await fetch(`${BASE_URL}/platform/users`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Steward-Platform-Key": PLATFORM_KEY,
+      },
+      body: JSON.stringify({
+        email: TEST_EMAIL_NEW,
+        name: "Migration User",
+        emailVerified: true,
+      }),
+    });
+    expect(res.status).toBe(201);
+    const data = (await res.json()) as { ok: boolean; data: { userId: string; isNew: boolean } };
+    expect(data.ok).toBe(true);
+    expect(data.data.isNew).toBe(true);
+    expect(typeof data.data.userId).toBe("string");
+    expect(data.data.userId.length).toBeGreaterThan(0);
+  });
+
+  it("is idempotent — returns existing userId and isNew=false on duplicate email", async () => {
+    if (SKIP) return;
+    const res = await fetch(`${BASE_URL}/platform/users`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Steward-Platform-Key": PLATFORM_KEY,
+      },
+      body: JSON.stringify({
+        email: TEST_EMAIL_EXISTING,
+        name: "Should Not Overwrite",
+      }),
+    });
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { ok: boolean; data: { userId: string; isNew: boolean } };
+    expect(data.ok).toBe(true);
+    expect(data.data.isNew).toBe(false);
+    expect(typeof data.data.userId).toBe("string");
+  });
+
+  it("does not overwrite existing user data on duplicate (safe upsert)", async () => {
+    if (SKIP) return;
+    const db = getDb();
+    const [before] = await db
+      .select({ name: users.name, emailVerified: users.emailVerified })
+      .from(users)
+      .where(eq(users.email, TEST_EMAIL_EXISTING));
+
+    // POST with different name — should NOT be applied
+    await fetch(`${BASE_URL}/platform/users`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Steward-Platform-Key": PLATFORM_KEY,
+      },
+      body: JSON.stringify({ email: TEST_EMAIL_EXISTING, name: "OVERWRITTEN" }),
+    });
+
+    const [after] = await db
+      .select({ name: users.name, emailVerified: users.emailVerified })
+      .from(users)
+      .where(eq(users.email, TEST_EMAIL_EXISTING));
+
+    // Name must not change
+    expect(after.name).toBe(before.name);
+  });
+
+  it("email is stored lowercase", async () => {
+    if (SKIP) return;
+    const mixedCaseEmail = `Platform-Upper-${Date.now()}@Example.COM`;
+    const db = getDb();
+
+    const res = await fetch(`${BASE_URL}/platform/users`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Steward-Platform-Key": PLATFORM_KEY,
+      },
+      body: JSON.stringify({ email: mixedCaseEmail }),
+    });
+    expect(res.status).toBe(201);
+    const data = (await res.json()) as { ok: boolean; data: { userId: string } };
+    const [row] = await db
+      .select({ email: users.email })
+      .from(users)
+      .where(eq(users.email, mixedCaseEmail.toLowerCase()));
+    expect(row?.email).toBe(mixedCaseEmail.toLowerCase());
+
+    // Cleanup
+    await db.delete(users).where(eq(users.email, mixedCaseEmail.toLowerCase()));
+  });
+});

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -1062,12 +1062,17 @@ auth.get("/oauth/:provider/authorize", async (c) => {
     .map((b) => b.toString(16).padStart(2, "0"))
     .join("");
 
-  // Store state metadata in the challenge store
-  const statePayload = JSON.stringify({ provider: providerName, tenantId, redirectUri });
-  getChallengeStore().set(`oauth:${state}`, statePayload);
-
   const callbackUrl = buildOAuthCallbackUrl(c, providerName);
-  const authUrl = oauthClient.generateAuthUrl(state, callbackUrl);
+  const { url: authUrl, codeVerifier } = oauthClient.generateAuthUrl(state, callbackUrl);
+
+  // Store state metadata in the challenge store — include PKCE verifier when present
+  const statePayload = JSON.stringify({
+    provider: providerName,
+    tenantId,
+    redirectUri,
+    ...(codeVerifier ? { codeVerifier } : {}),
+  });
+  getChallengeStore().set(`oauth:${state}`, statePayload);
 
   return c.redirect(authUrl, 302);
 });
@@ -1109,7 +1114,7 @@ auth.get("/oauth/:provider/callback", async (c) => {
     return c.json<ApiResponse>({ ok: false, error: "Invalid or expired OAuth state" }, 401);
   }
 
-  let stateData: { provider: string; tenantId?: string; redirectUri: string };
+  let stateData: { provider: string; tenantId?: string; redirectUri: string; codeVerifier?: string };
   try {
     stateData = JSON.parse(rawPayload) as typeof stateData;
   } catch {
@@ -1132,10 +1137,10 @@ auth.get("/oauth/:provider/callback", async (c) => {
 
   const callbackUrl = buildOAuthCallbackUrl(c, providerName);
 
-  // Exchange code for access token
+  // Exchange code for access token — pass codeVerifier for PKCE providers (e.g. Twitter)
   let tokenResponse: Awaited<ReturnType<OAuthClient["exchangeCode"]>>;
   try {
-    tokenResponse = await oauthClient.exchangeCode(code, callbackUrl);
+    tokenResponse = await oauthClient.exchangeCode(code, callbackUrl, stateData.codeVerifier);
   } catch (err) {
     return c.json<ApiResponse>(
       { ok: false, error: err instanceof Error ? err.message : "Token exchange failed" },
@@ -1154,11 +1159,17 @@ auth.get("/oauth/:provider/callback", async (c) => {
     );
   }
 
+  // Twitter and some providers do not return an email address.
+  // Generate a synthetic internal email so findOrCreateUser() can still work.
+  // This email is never displayed or sent — it is purely an internal identity key.
   if (!providerUser.email) {
-    return c.json<ApiResponse>(
-      { ok: false, error: "Provider did not return an email address" },
-      400,
-    );
+    if (!providerUser.id) {
+      return c.json<ApiResponse>(
+        { ok: false, error: "Provider returned neither email nor user ID" },
+        400,
+      );
+    }
+    providerUser = { ...providerUser, email: `${providerName}.${providerUser.id}@id.steward.internal` };
   }
 
   // Create/find user + provision wallet + link tenant
@@ -1234,11 +1245,16 @@ auth.post("/oauth/:provider/token", async (c) => {
     );
   }
 
+  // Twitter and some providers do not return an email address.
+  // Generate a synthetic internal email so findOrCreateUser() can still work.
   if (!providerUser.email) {
-    return c.json<ApiResponse>(
-      { ok: false, error: "Provider did not return an email address" },
-      400,
-    );
+    if (!providerUser.id) {
+      return c.json<ApiResponse>(
+        { ok: false, error: "Provider returned neither email nor user ID" },
+        400,
+      );
+    }
+    providerUser = { ...providerUser, email: `${providerName}.${providerUser.id}@id.steward.internal` };
   }
 
   const result = await provisionOAuthUser({

--- a/packages/api/src/routes/platform.ts
+++ b/packages/api/src/routes/platform.ts
@@ -15,7 +15,7 @@ import { count, eq, sql } from "drizzle-orm";
 import { Hono } from "hono";
 
 import { generateApiKey, platformAuthMiddleware } from "@stwd/auth";
-import { agents, getDb, policies, tenants, transactions } from "@stwd/db";
+import { agents, getDb, policies, tenants, transactions, users } from "@stwd/db";
 import type { AgentIdentity, ApiResponse, PolicyRule, Tenant } from "@stwd/shared";
 import { Vault } from "@stwd/vault";
 import { createAgentToken } from "../services/context";
@@ -617,6 +617,53 @@ platform.post("/tenants/:id/agents/:agentId/token", async (c) => {
     console.error(`[platform] Failed to generate agent token for ${agentId}:`, e);
     return c.json<ApiResponse>({ ok: false, error: "Failed to generate token" }, 500);
   }
+});
+
+/**
+ * POST /platform/users
+ * Pre-provision a user record without sending an email or requiring interaction.
+ * Intended for migration tooling (e.g. importing users from another auth provider).
+ *
+ * The route is idempotent: if a user with this email already exists, it returns
+ * the existing record's ID and isNew=false — no data is overwritten.
+ *
+ * Body: { email: string; emailVerified?: boolean; name?: string }
+ * Returns: { ok: true; userId: string; isNew: boolean }
+ */
+platform.post("/users", async (c) => {
+  const body = await safeJsonParse<{ email: string; emailVerified?: boolean; name?: string }>(c);
+  if (!body?.email || typeof body.email !== "string" || !body.email.includes("@")) {
+    return c.json<ApiResponse>({ ok: false, error: "A valid email is required" }, 400);
+  }
+
+  const db = getDb();
+  const email = body.email.toLowerCase().trim();
+
+  const [existing] = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.email, email));
+
+  if (existing) {
+    return c.json<ApiResponse<{ userId: string; isNew: boolean }>>({
+      ok: true,
+      data: { userId: existing.id, isNew: false },
+    });
+  }
+
+  const [newUser] = await db
+    .insert(users)
+    .values({
+      email,
+      emailVerified: body.emailVerified ?? false,
+      name: body.name ?? null,
+    })
+    .returning({ id: users.id });
+
+  return c.json<ApiResponse<{ userId: string; isNew: boolean }>>(
+    { ok: true, data: { userId: newUser.id, isNew: true } },
+    201,
+  );
 });
 
 export { platform as platformRoutes };

--- a/packages/auth/src/__tests__/oauth.test.ts
+++ b/packages/auth/src/__tests__/oauth.test.ts
@@ -1,0 +1,321 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it, mock, beforeEach } from "bun:test";
+import {
+  OAuthClient,
+  getEnabledProviders,
+  getProviderConfig,
+  isBuiltInProvider,
+} from "../oauth";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function verifyPkceChallenge(verifier: string, challenge: string): boolean {
+  const expected = createHash("sha256")
+    .update(verifier)
+    .digest()
+    .toString("base64url");
+  return expected === challenge;
+}
+
+// ─── isBuiltInProvider ───────────────────────────────────────────────────────
+
+describe("isBuiltInProvider", () => {
+  it("returns true for google, discord, twitter", () => {
+    expect(isBuiltInProvider("google")).toBe(true);
+    expect(isBuiltInProvider("discord")).toBe(true);
+    expect(isBuiltInProvider("twitter")).toBe(true);
+  });
+
+  it("returns false for unknown providers", () => {
+    expect(isBuiltInProvider("github")).toBe(false);
+    expect(isBuiltInProvider("facebook")).toBe(false);
+    expect(isBuiltInProvider("")).toBe(false);
+  });
+});
+
+// ─── getEnabledProviders ─────────────────────────────────────────────────────
+
+describe("getEnabledProviders", () => {
+  it("returns empty array when no provider env vars are set", () => {
+    const orig = {
+      GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID,
+      GOOGLE_CLIENT_SECRET: process.env.GOOGLE_CLIENT_SECRET,
+      DISCORD_CLIENT_ID: process.env.DISCORD_CLIENT_ID,
+      DISCORD_CLIENT_SECRET: process.env.DISCORD_CLIENT_SECRET,
+      TWITTER_CLIENT_ID: process.env.TWITTER_CLIENT_ID,
+      TWITTER_CLIENT_SECRET: process.env.TWITTER_CLIENT_SECRET,
+    };
+    delete process.env.GOOGLE_CLIENT_ID;
+    delete process.env.GOOGLE_CLIENT_SECRET;
+    delete process.env.DISCORD_CLIENT_ID;
+    delete process.env.DISCORD_CLIENT_SECRET;
+    delete process.env.TWITTER_CLIENT_ID;
+    delete process.env.TWITTER_CLIENT_SECRET;
+    expect(getEnabledProviders()).toEqual([]);
+    Object.assign(process.env, orig);
+  });
+
+  it("includes google when both google vars are set", () => {
+    process.env.GOOGLE_CLIENT_ID = "gid";
+    process.env.GOOGLE_CLIENT_SECRET = "gsecret";
+    delete process.env.DISCORD_CLIENT_ID;
+    delete process.env.DISCORD_CLIENT_SECRET;
+    delete process.env.TWITTER_CLIENT_ID;
+    delete process.env.TWITTER_CLIENT_SECRET;
+    expect(getEnabledProviders()).toContain("google");
+    expect(getEnabledProviders()).not.toContain("discord");
+    expect(getEnabledProviders()).not.toContain("twitter");
+    delete process.env.GOOGLE_CLIENT_ID;
+    delete process.env.GOOGLE_CLIENT_SECRET;
+  });
+
+  it("does not include google if only one var is set", () => {
+    process.env.GOOGLE_CLIENT_ID = "gid";
+    delete process.env.GOOGLE_CLIENT_SECRET;
+    expect(getEnabledProviders()).not.toContain("google");
+    delete process.env.GOOGLE_CLIENT_ID;
+  });
+});
+
+// ─── getProviderConfig ───────────────────────────────────────────────────────
+
+describe("getProviderConfig", () => {
+  it("throws for unknown providers", () => {
+    expect(() => getProviderConfig("github")).toThrow("Unknown OAuth provider");
+  });
+
+  it("throws when google env vars are missing", () => {
+    delete process.env.GOOGLE_CLIENT_ID;
+    delete process.env.GOOGLE_CLIENT_SECRET;
+    expect(() => getProviderConfig("google")).toThrow("Google OAuth not configured");
+  });
+
+  it("throws when discord env vars are missing", () => {
+    delete process.env.DISCORD_CLIENT_ID;
+    delete process.env.DISCORD_CLIENT_SECRET;
+    expect(() => getProviderConfig("discord")).toThrow("Discord OAuth not configured");
+  });
+
+  it("throws when twitter env vars are missing", () => {
+    delete process.env.TWITTER_CLIENT_ID;
+    delete process.env.TWITTER_CLIENT_SECRET;
+    expect(() => getProviderConfig("twitter")).toThrow("Twitter OAuth not configured");
+  });
+
+  it("returns config with requiresPkce=true for Twitter", () => {
+    process.env.TWITTER_CLIENT_ID = "tid";
+    process.env.TWITTER_CLIENT_SECRET = "tsecret";
+    const config = getProviderConfig("twitter");
+    expect(config.requiresPkce).toBe(true);
+    delete process.env.TWITTER_CLIENT_ID;
+    delete process.env.TWITTER_CLIENT_SECRET;
+  });
+
+  it("returns config without requiresPkce for Google and Discord", () => {
+    process.env.GOOGLE_CLIENT_ID = "gid";
+    process.env.GOOGLE_CLIENT_SECRET = "gsecret";
+    process.env.DISCORD_CLIENT_ID = "did";
+    process.env.DISCORD_CLIENT_SECRET = "dsecret";
+    expect(getProviderConfig("google").requiresPkce).toBeFalsy();
+    expect(getProviderConfig("discord").requiresPkce).toBeFalsy();
+    delete process.env.GOOGLE_CLIENT_ID;
+    delete process.env.GOOGLE_CLIENT_SECRET;
+    delete process.env.DISCORD_CLIENT_ID;
+    delete process.env.DISCORD_CLIENT_SECRET;
+  });
+});
+
+// ─── OAuthClient.generateAuthUrl ─────────────────────────────────────────────
+
+describe("OAuthClient.generateAuthUrl", () => {
+  const googleConfig = {
+    clientId: "google-client-id",
+    clientSecret: "google-secret",
+    authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+    tokenUrl: "https://oauth2.googleapis.com/token",
+    userInfoUrl: "https://www.googleapis.com/oauth2/v3/userinfo",
+    scopes: ["openid", "email", "profile"],
+  };
+
+  const twitterConfig = {
+    clientId: "twitter-client-id",
+    clientSecret: "twitter-secret",
+    authorizationUrl: "https://twitter.com/i/oauth2/authorize",
+    tokenUrl: "https://api.twitter.com/2/oauth2/token",
+    userInfoUrl: "https://api.twitter.com/2/users/me?user.fields=id,name,username,profile_image_url",
+    scopes: ["tweet.read", "users.read", "offline.access"],
+    requiresPkce: true,
+  };
+
+  it("generates a well-formed URL for non-PKCE providers", () => {
+    const client = new OAuthClient(googleConfig);
+    const { url, codeVerifier } = client.generateAuthUrl("state123", "https://app.com/callback");
+    expect(url).toContain("accounts.google.com");
+    expect(url).toContain("state=state123");
+    expect(url).toContain("redirect_uri=");
+    expect(url).toContain("response_type=code");
+    expect(url).toContain("scope=openid+email+profile");
+    expect(codeVerifier).toBeUndefined();
+  });
+
+  it("does NOT include code_challenge params for non-PKCE providers", () => {
+    const client = new OAuthClient(googleConfig);
+    const { url } = client.generateAuthUrl("state123", "https://app.com/callback");
+    expect(url).not.toContain("code_challenge");
+  });
+
+  it("generates PKCE params for Twitter", () => {
+    const client = new OAuthClient(twitterConfig);
+    const { url, codeVerifier } = client.generateAuthUrl("state456", "https://app.com/callback");
+    expect(url).toContain("code_challenge_method=S256");
+    expect(url).toContain("code_challenge=");
+    expect(typeof codeVerifier).toBe("string");
+    expect(codeVerifier!.length).toBeGreaterThan(20);
+  });
+
+  it("PKCE code_challenge is the SHA-256 hash of the verifier (S256)", () => {
+    const client = new OAuthClient(twitterConfig);
+    const { url, codeVerifier } = client.generateAuthUrl("state456", "https://app.com/callback");
+    const params = new URLSearchParams(new URL(url).search);
+    const challenge = params.get("code_challenge")!;
+    expect(verifyPkceChallenge(codeVerifier!, challenge)).toBe(true);
+  });
+
+  it("generates unique codeVerifiers on each call", () => {
+    const client = new OAuthClient(twitterConfig);
+    const { codeVerifier: v1 } = client.generateAuthUrl("s1", "https://app.com/cb");
+    const { codeVerifier: v2 } = client.generateAuthUrl("s2", "https://app.com/cb");
+    expect(v1).not.toBe(v2);
+  });
+});
+
+// ─── OAuthClient.exchangeCode ─────────────────────────────────────────────────
+
+describe("OAuthClient.exchangeCode", () => {
+  const pkceConfig = {
+    clientId: "client",
+    clientSecret: "secret",
+    authorizationUrl: "https://example.com/auth",
+    tokenUrl: "https://example.com/token",
+    userInfoUrl: "https://example.com/userinfo",
+    scopes: ["read"],
+    requiresPkce: true,
+  };
+
+  it("throws if codeVerifier is missing for a PKCE provider", async () => {
+    const client = new OAuthClient(pkceConfig);
+    await expect(
+      client.exchangeCode("auth-code", "https://app.com/cb"),
+    ).rejects.toThrow("codeVerifier is required");
+  });
+
+  it("includes code_verifier in the token request body for PKCE providers", async () => {
+    let capturedBody = "";
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (url: string | URL | Request, init?: RequestInit) => {
+      capturedBody = init?.body?.toString() ?? "";
+      return new Response(JSON.stringify({ access_token: "tok", token_type: "Bearer" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    };
+
+    const client = new OAuthClient(pkceConfig);
+    await client.exchangeCode("auth-code", "https://app.com/cb", "my-verifier");
+    expect(capturedBody).toContain("code_verifier=my-verifier");
+    globalThis.fetch = originalFetch;
+  });
+
+  it("throws on non-200 token response", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () =>
+      new Response("invalid_client", { status: 401, headers: { "Content-Type": "text/plain" } });
+    const client = new OAuthClient({ ...pkceConfig, requiresPkce: false });
+    await expect(client.exchangeCode("code", "https://app.com/cb")).rejects.toThrow("Token exchange failed (401)");
+    globalThis.fetch = originalFetch;
+  });
+});
+
+// ─── OAuthClient.getUserInfo — Twitter response normalization ─────────────────
+
+describe("OAuthClient.getUserInfo — provider response normalization", () => {
+  function makeClient() {
+    return new OAuthClient({
+      clientId: "c",
+      clientSecret: "s",
+      authorizationUrl: "https://example.com/auth",
+      tokenUrl: "https://example.com/token",
+      userInfoUrl: "https://example.com/userinfo",
+      scopes: [],
+    });
+  }
+
+  it("parses flat Google/Discord response shape", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({
+          id: "google-user-id",
+          email: "user@gmail.com",
+          name: "Test User",
+          picture: "https://lh3.googleusercontent.com/a/photo",
+          verified_email: true,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    const client = makeClient();
+    const info = await client.getUserInfo("tok");
+    expect(info.id).toBe("google-user-id");
+    expect(info.email).toBe("user@gmail.com");
+    expect(info.name).toBe("Test User");
+    expect(info.verified_email).toBe(true);
+    globalThis.fetch = originalFetch;
+  });
+
+  it("parses Twitter's nested data envelope — no email", async () => {
+    // Twitter v2 wraps user data inside { data: { id, name, username } }
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({
+          data: {
+            id: "twitter-user-id",
+            name: "Test Twitter User",
+            username: "testuser",
+            profile_image_url: "https://pbs.twimg.com/profile.jpg",
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    const client = makeClient();
+    const info = await client.getUserInfo("tok");
+    expect(info.id).toBe("twitter-user-id");
+    expect(info.name).toBe("Test Twitter User");
+    expect(info.picture).toBe("https://pbs.twimg.com/profile.jpg");
+    // Critical: Twitter returns no email — must be empty string
+    expect(info.email).toBe("");
+    globalThis.fetch = originalFetch;
+  });
+
+  it("falls back to username as name when name field absent (Twitter)", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({ data: { id: "tid", username: "handle" } }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    const client = makeClient();
+    const info = await client.getUserInfo("tok");
+    expect(info.name).toBe("handle");
+    globalThis.fetch = originalFetch;
+  });
+
+  it("throws on non-200 userinfo response", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () =>
+      new Response("Unauthorized", { status: 401, headers: { "Content-Type": "text/plain" } });
+    const client = makeClient();
+    await expect(client.getUserInfo("bad-token")).rejects.toThrow("getUserInfo failed (401)");
+    globalThis.fetch = originalFetch;
+  });
+});

--- a/packages/auth/src/oauth.ts
+++ b/packages/auth/src/oauth.ts
@@ -2,14 +2,24 @@
  * oauth.ts — Generic OAuth2 authorization-code flow helper
  *
  * Supports any provider that follows the standard OAuth2 authorization-code flow.
- * Built-in configs for Google and Discord.
+ * Built-in configs for Google, Discord, and Twitter/X.
+ *
+ * Twitter specifics:
+ *   - Requires PKCE (RFC 7636, S256 method) — Twitter OAuth2 mandates it for
+ *     confidential clients.
+ *   - Does NOT return an email address. provisionOAuthUser() in auth.ts must
+ *     handle this by generating a synthetic internal email.
+ *   - User info endpoint returns { data: { id, name, username } }, not a flat object.
  *
  * Usage:
- *   const client = new OAuthClient(GOOGLE_PROVIDER_CONFIG);
- *   const url = client.generateAuthUrl(state, redirectUri);
- *   const { access_token } = await client.exchangeCode(code, redirectUri);
+ *   const client = new OAuthClient(config, 'google');
+ *   const { url, codeVerifier } = client.generateAuthUrl(state, redirectUri);
+ *   // store codeVerifier in challenge store alongside state
+ *   const { access_token } = await client.exchangeCode(code, redirectUri, codeVerifier);
  *   const profile = await client.getUserInfo(access_token);
  */
+
+import { createHash, randomBytes } from "node:crypto";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -20,6 +30,8 @@ export interface OAuthProvider {
   tokenUrl: string;
   userInfoUrl: string;
   scopes: string[];
+  /** If true, PKCE (S256) is added to the auth URL and required in code exchange. */
+  requiresPkce?: boolean;
 }
 
 export interface OAuthTokenResponse {
@@ -38,9 +50,15 @@ export interface OAuthUserInfo {
   verified_email?: boolean;
 }
 
+export interface AuthUrlResult {
+  url: string;
+  /** Present when requiresPkce=true. Must be stored and passed to exchangeCode(). */
+  codeVerifier?: string;
+}
+
 // ─── Built-in Provider Configs ───────────────────────────────────────────────
 
-const BUILT_IN_PROVIDERS = ["google", "discord"] as const;
+const BUILT_IN_PROVIDERS = ["google", "discord", "twitter"] as const;
 type BuiltInProvider = (typeof BUILT_IN_PROVIDERS)[number];
 
 /**
@@ -60,6 +78,9 @@ export function getEnabledProviders(): string[] {
   }
   if (process.env.DISCORD_CLIENT_ID && process.env.DISCORD_CLIENT_SECRET) {
     enabled.push("discord");
+  }
+  if (process.env.TWITTER_CLIENT_ID && process.env.TWITTER_CLIENT_SECRET) {
+    enabled.push("twitter");
   }
   return enabled;
 }
@@ -104,15 +125,49 @@ export function getProviderConfig(provider: string): OAuthProvider {
       };
     }
 
+    case "twitter": {
+      const clientId = process.env.TWITTER_CLIENT_ID;
+      const clientSecret = process.env.TWITTER_CLIENT_SECRET;
+      if (!clientId || !clientSecret) {
+        throw new Error(
+          "Twitter OAuth not configured: TWITTER_CLIENT_ID and TWITTER_CLIENT_SECRET are required",
+        );
+      }
+      return {
+        clientId,
+        clientSecret,
+        authorizationUrl: "https://twitter.com/i/oauth2/authorize",
+        tokenUrl: "https://api.twitter.com/2/oauth2/token",
+        // id, name, username — Twitter v2 does NOT expose email via this endpoint
+        userInfoUrl: "https://api.twitter.com/2/users/me?user.fields=id,name,username,profile_image_url",
+        scopes: ["tweet.read", "users.read", "offline.access"],
+        requiresPkce: true,
+      };
+    }
+
     default:
       throw new Error(`Unknown OAuth provider: ${provider}`);
   }
+}
+
+// ─── PKCE helpers ─────────────────────────────────────────────────────────────
+
+function generateCodeVerifier(): string {
+  // RFC 7636 §4.1: 43-128 unreserved chars; 32 random bytes → 64 hex chars
+  return randomBytes(32).toString("hex");
+}
+
+function deriveCodeChallenge(verifier: string): string {
+  // RFC 7636 §4.2: BASE64URL(SHA256(ASCII(code_verifier)))
+  const hash = createHash("sha256").update(verifier).digest();
+  return hash.toString("base64url");
 }
 
 // ─── OAuthClient ─────────────────────────────────────────────────────────────
 
 /**
  * Generic OAuth2 authorization-code flow client.
+ * Supports PKCE (S256) when the provider's requiresPkce flag is true.
  */
 export class OAuthClient {
   private readonly provider: OAuthProvider;
@@ -123,10 +178,12 @@ export class OAuthClient {
 
   /**
    * Generates the authorization URL to redirect the user to.
-   * @param state  - CSRF state token (random, stored server-side)
+   *
+   * @param state      - CSRF state token (random, stored server-side)
    * @param redirectUri - Where the provider should send the user after auth
+   * @returns url and, when PKCE is required, a codeVerifier to store server-side
    */
-  generateAuthUrl(state: string, redirectUri: string): string {
+  generateAuthUrl(state: string, redirectUri: string): AuthUrlResult {
     const params = new URLSearchParams({
       client_id: this.provider.clientId,
       redirect_uri: redirectUri,
@@ -134,15 +191,29 @@ export class OAuthClient {
       scope: this.provider.scopes.join(" "),
       state,
     });
-    return `${this.provider.authorizationUrl}?${params.toString()}`;
+
+    let codeVerifier: string | undefined;
+    if (this.provider.requiresPkce) {
+      codeVerifier = generateCodeVerifier();
+      params.set("code_challenge_method", "S256");
+      params.set("code_challenge", deriveCodeChallenge(codeVerifier));
+    }
+
+    return { url: `${this.provider.authorizationUrl}?${params.toString()}`, codeVerifier };
   }
 
   /**
    * Exchanges an authorization code for an access token.
-   * @param code        - The authorization code from the provider callback
-   * @param redirectUri - Must match the one used in generateAuthUrl
+   *
+   * @param code         - The authorization code from the provider callback
+   * @param redirectUri  - Must match the one used in generateAuthUrl
+   * @param codeVerifier - Required when PKCE was used in generateAuthUrl
    */
-  async exchangeCode(code: string, redirectUri: string): Promise<OAuthTokenResponse> {
+  async exchangeCode(
+    code: string,
+    redirectUri: string,
+    codeVerifier?: string,
+  ): Promise<OAuthTokenResponse> {
     const body = new URLSearchParams({
       grant_type: "authorization_code",
       client_id: this.provider.clientId,
@@ -150,6 +221,13 @@ export class OAuthClient {
       code,
       redirect_uri: redirectUri,
     });
+
+    if (this.provider.requiresPkce) {
+      if (!codeVerifier) {
+        throw new Error("codeVerifier is required for PKCE providers");
+      }
+      body.set("code_verifier", codeVerifier);
+    }
 
     const res = await fetch(this.provider.tokenUrl, {
       method: "POST",
@@ -167,6 +245,14 @@ export class OAuthClient {
 
   /**
    * Fetches the authenticated user's profile from the provider.
+   *
+   * Handles provider-specific response shapes:
+   * - Google/Discord: flat object with standard fields
+   * - Twitter: nested `{ data: { id, name, username } }` — no email field
+   *
+   * For Twitter, email will be empty string. Callers must handle this:
+   * use `twitter.${id}@id.steward.internal` as a synthetic identity key.
+   *
    * @param accessToken - The access token from exchangeCode
    */
   async getUserInfo(accessToken: string): Promise<OAuthUserInfo> {
@@ -179,15 +265,35 @@ export class OAuthClient {
       throw new Error(`getUserInfo failed (${res.status}): ${text}`);
     }
 
-    const data = await res.json() as Record<string, unknown>;
+    const raw = await res.json() as Record<string, unknown>;
 
-    // Normalize Discord's `verified` → `verified_email`
+    // Twitter v2 wraps user data in a `data` envelope
+    const data: Record<string, unknown> =
+      raw["data"] != null && typeof raw["data"] === "object"
+        ? (raw["data"] as Record<string, unknown>)
+        : raw;
+
     return {
       id: String(data["id"] ?? data["sub"] ?? ""),
+      // Twitter does not expose email — leave as empty string; caller must handle
       email: String(data["email"] ?? ""),
-      name: data["name"] != null ? String(data["name"]) : data["username"] != null ? String(data["username"]) : undefined,
-      picture: data["picture"] != null ? String(data["picture"]) : data["avatar"] != null ? String(data["avatar"]) : undefined,
-      verified_email: Boolean(data["verified_email"] ?? data["email_verified"] ?? data["verified"] ?? false),
+      name:
+        data["name"] != null
+          ? String(data["name"])
+          : data["username"] != null
+            ? String(data["username"])
+            : undefined,
+      picture:
+        data["profile_image_url"] != null
+          ? String(data["profile_image_url"])
+          : data["picture"] != null
+            ? String(data["picture"])
+            : data["avatar"] != null
+              ? String(data["avatar"])
+              : undefined,
+      verified_email: Boolean(
+        data["verified_email"] ?? data["email_verified"] ?? data["verified"] ?? false,
+      ),
     };
   }
 }


### PR DESCRIPTION
## Summary

- Add Twitter/X as a built-in OAuth2 provider with full PKCE (RFC 7636, S256) support — Twitter mandates it for confidential clients
- Add synthetic internal email generation for OAuth providers that don't expose an email (Twitter) so `findOrCreateUser()` keeps working
- Add `POST /platform/users` for idempotent user pre-provisioning — required for the Privy → Steward migration tooling
- Fix Docker image so it builds and runs cleanly (three separate blockers resolved)

## Type

- [x] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Other

## Context / Links

This PR is a dependency for [BabylonSocial/babylon](https://github.com/BabylonSocial/babylon) migrating off Privy to self-hosted Steward. Babylon needs:

1. Twitter/X login for its users
2. A migration endpoint to pre-seed all existing Privy users into Steward's user table
3. The Docker image working so the Steward service can run locally via `docker compose up`

## Scope

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded

**Areas touched**
- `packages/auth/src/oauth.ts` — PKCE helpers + Twitter provider config + getUserInfo normalisation
- `packages/api/src/routes/auth.ts` — PKCE codeVerifier in challenge store, synthetic email fallback
- `packages/api/src/routes/platform.ts` — new `POST /platform/users` endpoint
- `Dockerfile` — three build blockers fixed
- `.env.example` — document Google/Discord/Twitter OAuth env vars

## Changes

### `packages/auth/src/oauth.ts`

- New `AuthUrlResult` type: `generateAuthUrl()` now returns `{ url, codeVerifier? }` instead of just a URL string
- PKCE code verifier generation (32 random bytes → hex) and S256 challenge derivation (`BASE64URL(SHA256(verifier))`)
- `OAuthClient.exchangeCode()` gains optional `codeVerifier` param; throws if required by provider but missing
- Twitter provider config added: uses `https://twitter.com/i/oauth2/authorize`, scopes `tweet.read users.read offline.access`, `requiresPkce: true`
- `OAuthClient.getUserInfo()` unwraps Twitter's `{ data: { id, name, username } }` envelope; sets `email: ""` since Twitter exposes no email
- `getEnabledProviders()` / `isBuiltInProvider()` updated to include `"twitter"`

### `packages/api/src/routes/auth.ts`

- `GET /auth/oauth/:provider/authorize` — stores PKCE `codeVerifier` alongside the OAuth `state` in the challenge store
- `GET /auth/oauth/:provider/callback` — reads `codeVerifier` from challenge store, passes to `exchangeCode()`; generates `twitter.{id}@id.steward.internal` when provider returns empty email
- `POST /auth/oauth/:provider/token` (SPA flow) — same synthetic email fallback applied

### `packages/api/src/routes/platform.ts`

```
POST /platform/users
Headers: X-Steward-Platform-Key
Body:    { email: string; emailVerified?: boolean; name?: string }
Returns: { ok: true; data: { userId: string; isNew: boolean } }
```

- Idempotent: returns existing `userId` + `isNew: false` for known emails without touching any existing data
- Normalises email to lowercase before DB lookup/insert
- Requires platform key auth (same middleware as all other `/platform/*` routes)

### Dockerfile

| Problem | Fix |
|---|---|
| `COPY packages/sdk` failed — directory excluded by `.dockerignore` | Removed both `COPY` lines |
| `workspace not found: "web"` / `"packages/examples/*"` — `.dockerignore` excludes those dirs, breaking `bun install` | `sed -i` strips the missing workspace entries from `package.json` before install |
| `lockfile had changes, but lockfile is frozen` — Bun 1.2 rejects patched `package.json` against existing lock | Dropped `--frozen-lockfile`; runtime stage copies `node_modules` from deps stage instead of re-running install |
| Wrong turbo filter name (`@steward/api` → `@stwd/api`) | Corrected |
| `@stwd/db#build` fails — build scripts are `tsc --noEmit` (type checks, not compilation); Bun runs TS directly | Removed the `turbo build` stage entirely |

## Test Plan

**Commands run**
- [x] `bun test packages/auth/src/__tests__/oauth.test.ts` — 23 unit tests, all pass
- [x] `bun test packages/api/src/__tests__/platform-users.test.ts` — 8 integration tests against live server, all pass

**Test coverage for this PR**

`packages/auth/src/__tests__/oauth.test.ts` (23 tests, pure unit — no DB, no server):
- `isBuiltInProvider` recognises google/discord/twitter; rejects unknown
- `getEnabledProviders` respects env var pairs (both ID + secret required)
- `getProviderConfig` throws on missing vars; Twitter returns `requiresPkce: true`; Google/Discord do not
- `generateAuthUrl` — URL shape, no PKCE params for Google, PKCE params for Twitter, S256 math verified, unique verifier per call
- `exchangeCode` — PKCE enforcement, `code_verifier` in body, error on non-200
- `getUserInfo` — flat Google/Discord shape, Twitter nested envelope, username fallback for missing name, empty email for Twitter, error on non-200

`packages/api/src/__tests__/platform-users.test.ts` (8 tests, integration):
- 401 missing platform key, 403 invalid key, 400 missing/bad email
- 201 + `isNew: true` on new user; 200 + `isNew: false` on duplicate
- Does not overwrite existing user data
- Stores email lowercase

## Ops / Migration / Deployment

- [x] Requires env var updates

**Env vars (added)**

```
TWITTER_CLIENT_ID=        # Twitter OAuth2 client ID
TWITTER_CLIENT_SECRET=    # Twitter OAuth2 client secret
```

(Documented in `.env.example`)

## Breaking Changes

- [ ] None
- [x] Yes — `OAuthClient.generateAuthUrl()` return type changed from `string` to `{ url: string; codeVerifier?: string }`. Any caller that treated the return value as a string must be updated to use `.url`.

## Security / Privacy

- [x] Needs extra review

PKCE implementation: verifiers are generated with `crypto.randomBytes(32)` (cryptographically secure). Challenges use SHA-256 via Node's built-in `crypto` module. Verifiers are stored in the existing in-memory challenge store (same TTL as OAuth state) and cleared after use.

Synthetic emails (`twitter.{id}@id.steward.internal`) are internal identity keys only — never displayed to users, never emailed, not a valid address. The domain `id.steward.internal` is intentionally unresolvable.

## Screenshots / Recordings

- No visual changes — backend/auth changes only.