### PR TITLE
fix(deploy): include tsconfig.json; harden workspace stripping

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,13 +1,13 @@
 # Steward – Docker image (API + Proxy)
 FROM oven/bun:1.3-alpine AS builder
 WORKDIR /app
-COPY package.json bun.lock* bunfig.toml* turbo.json ./
+COPY package.json bun.lock* bunfig.toml* turbo.json tsconfig.json ./
 COPY packages/ packages/
 
 # Remove packages not needed for API/proxy to avoid resolution errors.
 # sdk is excluded by .dockerignore but other packages reference it,
 # so we create a stub package.json for it.
-RUN sed -i '/"web"/d; /"packages\/examples/d' package.json && \
+RUN bun -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));if(Array.isArray(p.workspaces))p.workspaces=p.workspaces.filter(w=>w!=='web'&&!String(w).startsWith('packages/examples'));fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')" && \
     rm -rf packages/examples packages/agent-trader packages/react packages/eliza-plugin packages/seed && \
     if [ ! -d packages/sdk ]; then \
       mkdir -p packages/sdk && \

--- a/packages/erc8004/tsconfig.json
+++ b/packages/erc8004/tsconfig.json
@@ -3,7 +3,9 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "target": "ES2022",
+    "lib": ["ES2022"]
   },
   "include": ["src"],
   "exclude": ["src/__tests__"]


### PR DESCRIPTION
## Summary
- Adds `tsconfig.json` to `COPY` in `deploy/Dockerfile` so TypeScript builds inside the container can resolve the extended base config (previously failed with `TS5083: Cannot read file '/app/tsconfig.json'`).
- Replaces the fragile `sed` that stripped `"web"` and `"packages/examples"` workspace entries — it left a trailing comma and produced invalid JSON, breaking `bun install` / `bun run build`. Now uses a small `bun -e` script that filters the `workspaces` array properly.
- Pins explicit `target: ES2022` and `lib: ["ES2022"]` in `packages/erc8004/tsconfig.json` so `Promise` et al. are available even when the extended base config is temporarily unreachable (defense in depth — avoids TS2705).

## Motivation
Building `deploy/Dockerfile` from scratch (verified on Depot multi-arch `linux/amd64,linux/arm64`) failed on two separate issues chained together. With these fixes, the image builds cleanly and is saved to the Depot registry.

## Test plan
- [x] `depot build --platform linux/amd64,linux/arm64 -f deploy/Dockerfile .` succeeds end-to-end
- [x] No regressions in local `bun run build`