### PR TITLE
chore: bump @stwd/react to 0.6.7 (SDK dep pin)

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stwd/react",
-  "version": "0.6.5",
+  "version": "0.6.7",
   "description": "Embeddable React components for Steward agent wallet management",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Bumps `@stwd/react` to 0.6.7 and pins `@stwd/sdk` dep to `^0.7.3`.

Matches the versions just published to npm:
- `@stwd/sdk@0.7.3` (includes `StewardClient.getBaseUrl()` from the quality sweep)
- `@stwd/react@0.6.7` (consumes the new method)

This ensures downstream consumers can't install an incompatible SDK version with the new React package.

Co-authored-by: wakesync <shadow@shad0w.xyz>