### PR TITLE
fix(vault): use chain-specific RPC in broadcast path

### DIFF
--- a/packages/vault/src/vault.ts
+++ b/packages/vault/src/vault.ts
@@ -413,10 +413,16 @@ export class Vault {
       }
 
       if (shouldBroadcast) {
+        // Use chain-specific RPC. Prior versions fell back to
+        // `this.config.rpcUrl` which is tenant-wide and may not match
+        // the target chain (e.g. Steward config pointed at Base but
+        // the tx is for BSC), causing RPC-side balance checks to fail
+        // with 'total cost exceeds balance' (wrong chain's balance).
+        const rpcUrl = CHAIN_RPCS[chainId] ?? this.config.rpcUrl;
         const client = createWalletClient({
           account,
           chain,
-          transport: http(this.config.rpcUrl),
+          transport: http(rpcUrl),
         });
 
         hash = await client.sendTransaction({


### PR DESCRIPTION
Broadcast path used tenant-wide config.rpcUrl even for cross-chain txs. When Steward is configured for Base but tx targets BSC, the Base RPC rejects with misleading 'total cost exceeds balance' error.

Fix: use CHAIN_RPCS[chainId] as transport per tx. Mirrors the existing sign-without-broadcast path.

Unblocks waifu.fun agent launches.

Co-authored-by: wakesync <shadow@shad0w.xyz>