### PR TITLE
fix(oauth): accept both tenant_id and tenantId on /auth/oauth/:provider/authorize

### DIFF
--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -1714,7 +1714,10 @@ auth.get("/oauth/:provider/authorize", async (c) => {
   }
 
   const redirectUri = c.req.query("redirect_uri");
-  const tenantId = c.req.query("tenant_id");
+  // Accept both `tenant_id` (snake_case, canonical) and `tenantId` (camelCase)
+  // so integrators sending either shape land on the right tenant. Whitespace
+  // is trimmed defensively for the same reason we trim headers elsewhere.
+  const tenantId = c.req.query("tenant_id")?.trim() || c.req.query("tenantId")?.trim() || undefined;
 
   if (!redirectUri) {
     return c.json<ApiResponse>({ ok: false, error: "redirect_uri is required" }, 400);


### PR DESCRIPTION
## the bug

`/auth/oauth/:provider/authorize` reads `c.req.query("tenant_id")` — snake_case only. If a consumer sends `tenantId` (camelCase), the check fails silently, tenant resolution falls back to `personal-<userId>`, and the issued refresh token is scoped to the personal tenant instead of the intended app tenant.

Elizacloud hit this exact case on its GitHub OAuth button — was sending `tenantId=elizacloud`. Refresh tokens got stored as `personal-<userId>` tenant. When those tokens were later used in elizacloud-scoped middleware, auth failed and the user was signed out.

## the fix

Accept both snake_case (canonical) and camelCase (compat). Trim whitespace as we do on the resolveTenant helper already.

## also shipping

PR on eliza-cloud side to actually send `tenant_id` so this server-side fallback doesn't keep catching it.

Co-authored-by: wakesync <shadow@shad0w.xyz>