### PR TITLE
feat(proxy): enforce api:proxy scope on gateway tokens

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,12 @@ STEWARD_PROXY_URL=http://steward-proxy:8080
 STEWARD_AGENT_TOKEN=stwd_jwt_...
 ```
 
+Proxy-bound agent tokens must be minted with the explicit `api:proxy` scope
+(`scopes: ["agent", "api:proxy"]`). Legacy tokens that only carry
+`scope: "agent"` are still accepted by the proxy with a deprecation warning for
+the next 1-2 release cycles, but new deployments should opt in when creating the
+token.
+
 Every transaction and every API call flows through Steward, where it is authenticated, policy-checked, logged, and metered before being forwarded with real credentials injected at the proxy.
 
 ## Core Primitives

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -469,6 +469,24 @@ For agents that should only be able to sign transactions for a specific agent ID
 POST /agents/{agentId}/token
 X-Steward-Tenant: my-tenant
 X-Steward-Key: stw_abc123...
+Content-Type: application/json
+
+{}
+```
+
+Agent tokens keep the legacy singular `scope: "agent"` claim and also include a
+plural `scopes` claim. By default, new tokens have `scopes: ["agent"]`.
+
+To mint a token that can call the credential-injection proxy, explicitly opt in
+to the proxy scope using the request body or `?scopes=api:proxy`:
+
+```http
+POST /agents/{agentId}/token
+X-Steward-Tenant: my-tenant
+X-Steward-Key: stw_abc123...
+Content-Type: application/json
+
+{ "scopes": ["api:proxy"] }
 ```
 
 **Response:**
@@ -477,12 +495,19 @@ X-Steward-Key: stw_abc123...
 {
   "ok": true,
   "data": {
-    "token": "eyJhbGciOiJIUzI1NiJ9..."
+    "token": "eyJhbGciOiJIUzI1NiJ9...",
+    "scope": "agent",
+    "scopes": ["agent", "api:proxy"]
   }
 }
 ```
 
-This token has an `agentScope` claim in the JWT payload. When used for vault operations, the API verifies that the requested `agentId` matches the scope — an agent cannot sign transactions for a different agent using this token.
+When used for vault operations, the API verifies that the requested `agentId`
+matches the token's `agentId` claim — an agent cannot sign transactions for a
+different agent using this token. The proxy additionally requires `scopes` to
+include `api:proxy`. Legacy tokens with no `scopes` array and `scope: "agent"`
+are accepted by the proxy with a deprecation warning for 1-2 release cycles,
+then will be rejected.
 
 ---
 

--- a/packages/api/src/__tests__/agent-auth.test.ts
+++ b/packages/api/src/__tests__/agent-auth.test.ts
@@ -97,12 +97,14 @@ describe.skipIf(SKIP)("POST /agents/:agentId/token", () => {
     expect(json.data.agentId).toBe(TEST_AGENT_ID);
     expect(json.data.tenantId).toBe(TEST_TENANT_ID);
     expect(json.data.scope).toBe("agent");
+    expect(json.data.scopes).toEqual(["agent"]);
 
     // Verify the JWT payload
     const payload = await verifyToken(json.data.token);
     expect(payload.agentId).toBe(TEST_AGENT_ID);
     expect(payload.tenantId).toBe(TEST_TENANT_ID);
     expect(payload.scope).toBe("agent");
+    expect(payload.scopes).toEqual(["agent"]);
   });
 
   it("returns 404 for non-existent agent", async () => {

--- a/packages/api/src/routes/agents.ts
+++ b/packages/api/src/routes/agents.ts
@@ -23,6 +23,7 @@ import {
   isNonEmptyString,
   isValidAgentId,
   type PolicyRule,
+  parseAgentTokenScopes,
   policies,
   requireAgentAccess,
   requireTenantLevel,
@@ -101,22 +102,30 @@ agentRoutes.post("/:agentId/token", async (c) => {
     return c.json<ApiResponse>({ ok: false, error: "Agent not found" }, 404);
   }
 
-  const body = await safeJsonParse<{ expiresIn?: string }>(c);
+  const body = await safeJsonParse<{ expiresIn?: string; scopes?: string[] | string }>(c);
   const expiresIn = body?.expiresIn || AGENT_TOKEN_EXPIRY;
+  const scopes = parseAgentTokenScopes(body?.scopes ?? c.req.query("scopes"));
+  if (!scopes) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Invalid scopes — supported values: agent, api:proxy" },
+      400,
+    );
+  }
 
   try {
-    const token = await createAgentToken(agentId, tenantId, expiresIn);
+    const token = await createAgentToken(agentId, tenantId, expiresIn, scopes);
     return c.json<
       ApiResponse<{
         token: string;
         agentId: string;
         tenantId: string;
         scope: string;
+        scopes: string[];
         expiresIn: string;
       }>
     >({
       ok: true,
-      data: { token, agentId, tenantId, scope: "agent", expiresIn },
+      data: { token, agentId, tenantId, scope: "agent", scopes, expiresIn },
     });
   } catch (e: unknown) {
     const requestId = c.get("requestId") || "unknown";

--- a/packages/api/src/routes/platform.ts
+++ b/packages/api/src/routes/platform.ts
@@ -28,7 +28,7 @@ import type { AgentIdentity, ApiResponse, PolicyRule, Tenant } from "@stwd/share
 import { KeyStore, Vault } from "@stwd/vault";
 import { and, count, eq } from "drizzle-orm";
 import { Hono } from "hono";
-import { createAgentToken } from "../services/context";
+import { createAgentToken, parseAgentTokenScopes } from "../services/context";
 import { invalidateEmailAuthForTenant } from "./auth";
 
 // ─── Vault singleton ──────────────────────────────────────────────────────────
@@ -805,7 +805,7 @@ platform.get("/tenants/:id/agents", async (c) => {
 
 /**
  * POST /tenants/:id/agents/:agentId/token
- * Body: { expiresIn?: string }
+ * Body: { expiresIn?: string, scopes?: string[] | string }
  *
  * Generates a scoped JWT for the specified agent.
  * Used by platform operators (e.g. Milady Cloud provisioner) to mint
@@ -836,21 +836,29 @@ platform.post("/tenants/:id/agents/:agentId/token", async (c) => {
     return c.json<ApiResponse>({ ok: false, error: "Agent not found in tenant" }, 404);
   }
 
-  const body = await safeJsonParse<{ expiresIn?: string }>(c);
+  const body = await safeJsonParse<{ expiresIn?: string; scopes?: string[] | string }>(c);
   const expiresIn = body?.expiresIn || undefined;
+  const scopes = parseAgentTokenScopes(body?.scopes ?? c.req.query("scopes"));
+  if (!scopes) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Invalid scopes — supported values: agent, api:proxy" },
+      400,
+    );
+  }
 
   try {
-    const token = await createAgentToken(agentId, tenantId, expiresIn);
+    const token = await createAgentToken(agentId, tenantId, expiresIn, scopes);
     return c.json<
       ApiResponse<{
         token: string;
         agentId: string;
         tenantId: string;
         scope: string;
+        scopes: string[];
       }>
     >({
       ok: true,
-      data: { token, agentId, tenantId, scope: "agent" },
+      data: { token, agentId, tenantId, scope: "agent", scopes },
     });
   } catch (e: unknown) {
     console.error(`[platform] Failed to generate agent token for ${agentId}:`, e);

--- a/packages/api/src/services/context.ts
+++ b/packages/api/src/services/context.ts
@@ -34,6 +34,38 @@ export const AGENT_TOKEN_EXPIRY = process.env.AGENT_TOKEN_EXPIRY || "30d";
 // ─── JWT helpers ──────────────────────────────────────────────────────────────
 
 export const JWT_EXPIRY = "24h";
+export const AGENT_SCOPE = "agent";
+export const PROXY_SCOPE = "api:proxy";
+
+export function normalizeAgentTokenScopes(scopes?: string[]): string[] {
+  const normalized = new Set([AGENT_SCOPE]);
+  for (const scope of scopes ?? []) {
+    if (typeof scope === "string" && scope.trim()) {
+      normalized.add(scope.trim());
+    }
+  }
+  return [...normalized];
+}
+
+export function parseAgentTokenScopes(value: unknown): string[] | null {
+  if (value === undefined || value === null || value === "") {
+    return [AGENT_SCOPE];
+  }
+
+  const requested = Array.isArray(value)
+    ? value
+    : typeof value === "string"
+      ? value.split(",")
+      : null;
+
+  if (!requested || !requested.every((scope) => typeof scope === "string")) return null;
+
+  const scopes = normalizeAgentTokenScopes(requested.map((scope) => scope.trim()).filter(Boolean));
+
+  // Agent tokens always include the legacy/base agent scope. The only opt-in
+  // privilege exposed by token minting endpoints today is proxy gateway access.
+  return scopes.every((scope) => scope === AGENT_SCOPE || scope === PROXY_SCOPE) ? scopes : null;
+}
 
 export async function createSessionToken(address: string, tenantId: string): Promise<string> {
   return signAccessToken({ address, tenantId }, JWT_EXPIRY);
@@ -43,8 +75,13 @@ export async function createAgentToken(
   agentId: string,
   tenantId: string,
   expiresIn?: string,
+  scopes?: string[],
 ): Promise<string> {
-  return signAgentToken({ agentId, tenantId }, expiresIn || AGENT_TOKEN_EXPIRY);
+  const tokenScopes = normalizeAgentTokenScopes(scopes);
+  return signAgentToken(
+    { agentId, tenantId, scopes: tokenScopes },
+    expiresIn || AGENT_TOKEN_EXPIRY,
+  );
 }
 
 export async function verifySessionToken(token: string) {
@@ -54,6 +91,7 @@ export async function verifySessionToken(token: string) {
       tenantId: string;
       agentId?: string;
       scope?: string;
+      scopes?: string[];
       userId?: string;
       email?: string;
     };

--- a/packages/auth/src/jwt.ts
+++ b/packages/auth/src/jwt.ts
@@ -26,6 +26,8 @@ export interface AgentTokenPayload extends StewardJwtPayload {
   agentId: string;
   tenantId: string;
   scope: "agent";
+  /** Plural permissions list. Required for proxy access ("api:proxy"). */
+  scopes?: string[];
 }
 
 export interface RefreshTokenPayload extends StewardJwtPayload {
@@ -178,10 +180,12 @@ export async function signAccessToken(
 }
 
 export async function signAgentToken(
-  payload: Omit<AgentTokenPayload, "scope"> & { scope?: "agent" },
+  payload: Omit<AgentTokenPayload, "scope"> & { scope?: "agent"; scopes?: string[] },
   expiresIn: string = AGENT_TOKEN_EXPIRY,
 ): Promise<string> {
-  return signJwtPayload({ ...payload, scope: "agent" }, expiresIn);
+  const merged: Record<string, unknown> = { ...payload, scope: "agent" };
+  if (Array.isArray(payload.scopes)) merged.scopes = payload.scopes;
+  return signJwtPayload(merged, expiresIn);
 }
 
 export async function signRefreshToken(

--- a/packages/proxy/src/__tests__/auth.test.ts
+++ b/packages/proxy/src/__tests__/auth.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { Hono } from "hono";
+import { SignJWT } from "jose";
+import { PROXY_SCOPE } from "../config";
+import { authMiddleware } from "../middleware/auth";
+
+const JWT_SECRET = new TextEncoder().encode(process.env.STEWARD_JWT_SECRET || "dev-secret");
+const JWT_ISSUER = "steward";
+
+async function signAgentToken(claims: Record<string, unknown>) {
+  return new SignJWT({
+    agentId: "agent-1",
+    tenantId: "tenant-1",
+    scope: "agent",
+    ...claims,
+  })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt()
+    .setIssuer(JWT_ISSUER)
+    .setExpirationTime("1h")
+    .sign(JWT_SECRET);
+}
+
+function app() {
+  const app = new Hono();
+  app.use("*", authMiddleware);
+  app.get("/", (c) => c.json({ ok: true, agentId: c.get("agentId"), tenantId: c.get("tenantId") }));
+  return app;
+}
+
+afterEach(() => {
+  // Restore console spies created by individual tests.
+  (console.warn as unknown as { mockRestore?: () => void }).mockRestore?.();
+});
+
+describe("proxy auth middleware", () => {
+  test("rejects token with scopes that omit api:proxy", async () => {
+    const token = await signAgentToken({ scopes: ["agent"] });
+
+    const res = await app().request("/", {
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toContain(PROXY_SCOPE);
+  });
+
+  test("accepts token with api:proxy scope", async () => {
+    const token = await signAgentToken({ scopes: ["agent", PROXY_SCOPE] });
+
+    const res = await app().request("/", {
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ ok: true, agentId: "agent-1", tenantId: "tenant-1" });
+  });
+
+  test("accepts legacy agent token without scopes and logs deprecation warning", async () => {
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+    const token = await signAgentToken({});
+
+    const res = await app().request("/", {
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(res.status).toBe(200);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toContain("Legacy agent token without scopes accepted");
+    expect(warn.mock.calls[0]?.[0]).toContain(PROXY_SCOPE);
+  });
+});

--- a/packages/proxy/src/middleware/auth.ts
+++ b/packages/proxy/src/middleware/auth.ts
@@ -7,13 +7,19 @@
 
 import { verifyToken } from "@stwd/auth";
 import type { Context, Next } from "hono";
+import { PROXY_SCOPE } from "../config";
+
+const AGENT_SCOPE = "agent";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 export interface AgentClaims {
   agentId: string;
   tenantId: string;
+  /** Legacy singular scope. Kept for backward compatibility. */
   scope: string;
+  /** New explicit permissions list. Proxy access requires api:proxy. */
+  scopes?: string[];
 }
 
 // ─── Middleware ───────────────────────────────────────────────────────────────
@@ -38,15 +44,25 @@ export async function authMiddleware(c: Context, next: Next) {
     const agentId = payload.agentId as string | undefined;
     const tenantId = payload.tenantId as string | undefined;
     const scope = payload.scope as string | undefined;
+    const scopes = payload.scopes;
 
     if (!agentId || !tenantId) {
       return c.json({ ok: false, error: "Token missing agentId or tenantId claims" }, 401);
     }
 
-    // For now, all agent tokens implicitly have api:proxy scope.
-    // In the future we'll check: scope === "agent" || scopes.includes("api:proxy")
-    if (scope !== "agent") {
-      return c.json({ ok: false, error: "Token does not have agent scope" }, 403);
+    if (Array.isArray(scopes)) {
+      if (!scopes.includes(PROXY_SCOPE)) {
+        return c.json({ ok: false, error: `Token missing required ${PROXY_SCOPE} scope` }, 403);
+      }
+    } else if (scopes === undefined && scope === AGENT_SCOPE) {
+      // Backward compatibility for legacy agent tokens minted before the plural
+      // scopes claim existed. Keep for 1-2 release cycles, then reject.
+      console.warn(
+        `[proxy:auth] Legacy agent token without scopes accepted for agent ${agentId}; ` +
+          `mint a replacement token with scopes including ${PROXY_SCOPE}. This fallback will be removed in a future release.`,
+      );
+    } else {
+      return c.json({ ok: false, error: `Token missing required ${PROXY_SCOPE} scope` }, 403);
     }
 
     // Set on context for downstream handlers


### PR DESCRIPTION
## Summary

Proxy was accepting ANY token with `scope: "agent"` as implicitly proxy-capable. Docs advertised `scopes: ["api:proxy"]` but it wasn't enforced. Least-privilege missing.

## Changes

- Added plural `scopes: string[]` claim to new tokens (`scope` singular kept for legacy compat)
- Agent token minting defaults to `scopes: ["agent"]`
- Proxy access requires explicit `api:proxy` in `scopes`
- Opt-in for proxy via `{ scopes: ["api:proxy"] }` body or `?scopes=api:proxy` query
- Legacy tokens (no `scopes` array, `scope: "agent"`) still accepted with deprecation warning log

## Deprecation plan

- v0.x (now): legacy tokens accepted with warning
- 1-2 release cycles: legacy tokens rejected

## Validation

- `bun run build` ✅ 16/16
- `bun test packages/proxy` ✅ 43 tests
- Proxy auth tests (reject-missing-scope, accept-valid, deprecation-legacy) all pass

Co-authored-by: wakesync <shadow@shad0w.xyz>