### PR TITLE
feat(proxy): enforce spend limits before forwarding requests

### DIFF
--- a/packages/db/drizzle/0020_proxy_audit_reason.sql
+++ b/packages/db/drizzle/0020_proxy_audit_reason.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "proxy_audit_log" ADD COLUMN IF NOT EXISTS "reason" text;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1775098700000,
       "tag": "0019_harden_erc8004_policy_schemas",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1777026834865,
+      "tag": "0020_proxy_audit_reason",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -680,6 +680,7 @@ export const proxyAuditLog = pgTable(
     method: varchar("method", { length: 10 }).notNull(),
     statusCode: integer("status_code").notNull(),
     latencyMs: integer("latency_ms").notNull(),
+    reason: text("reason"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({

--- a/packages/proxy/src/__tests__/redis-enforcement.test.ts
+++ b/packages/proxy/src/__tests__/redis-enforcement.test.ts
@@ -5,7 +5,7 @@
  * and cost estimation integration.
  */
 
-import { describe, expect, it } from "bun:test";
+import { beforeEach, describe, expect, it } from "bun:test";
 import { estimateCost, isKnownHost } from "@stwd/redis";
 import {
   checkProxyRateLimit,
@@ -13,6 +13,10 @@ import {
   isProxyRedisAvailable,
   trackProxySpend,
 } from "../middleware/redis-enforcement";
+
+beforeEach(() => {
+  delete process.env.REDIS_REQUIRED;
+});
 
 // ─── Graceful degradation (no Redis) ─────────────────────────────────────────
 
@@ -47,6 +51,15 @@ describe("proxy Redis enforcement (no Redis)", () => {
   it("checkProxySpendLimit allows when limit is 0 (no limit)", async () => {
     const result = await checkProxySpendLimit("agent-1", 0);
     expect(result.allowed).toBe(true);
+  });
+
+  it("checkProxySpendLimit fails closed when Redis is required", async () => {
+    process.env.REDIS_REQUIRED = "true";
+
+    const result = await checkProxySpendLimit("agent-1", 100);
+
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain("Redis unavailable");
   });
 });
 

--- a/packages/proxy/src/__tests__/zz-proxy-spend-limit.test.ts
+++ b/packages/proxy/src/__tests__/zz-proxy-spend-limit.test.ts
@@ -48,6 +48,9 @@ mock.module("@stwd/db", () => {
   };
   const proxyAuditLog = {};
   return {
+    and: (...args: unknown[]) => args,
+    desc: (arg: unknown) => arg,
+    eq: (...args: unknown[]) => args,
     secretRoutes,
     secrets,
     policies,

--- a/packages/proxy/src/__tests__/zz-proxy-spend-limit.test.ts
+++ b/packages/proxy/src/__tests__/zz-proxy-spend-limit.test.ts
@@ -1,0 +1,231 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+let spendResult: any = {
+  allowed: true,
+  configured: true,
+  period: "day",
+  limit: 1,
+  spent: 0,
+  remaining: 1,
+};
+let fetchCalls = 0;
+const audits: any[] = [];
+const originalFetch = globalThis.fetch;
+
+const route = {
+  id: "route-1",
+  tenantId: "tenant-1",
+  secretId: "secret-1",
+  hostPattern: "example.com",
+  pathPattern: "/*",
+  method: "*",
+  injectAs: "header",
+  injectKey: "x-api-key",
+  injectFormat: "Bearer {value}",
+  priority: 0,
+  enabled: true,
+  createdAt: new Date(),
+};
+
+mock.module("drizzle-orm", () => ({
+  and: (...args: unknown[]) => args,
+  desc: (arg: unknown) => arg,
+  eq: (...args: unknown[]) => args,
+}));
+
+mock.module("@stwd/db", () => {
+  const secretRoutes = {
+    tenantId: "tenantId",
+    enabled: "enabled",
+    priority: "priority",
+  };
+  const secrets = { id: "id" };
+  const policies = {
+    agentId: "agentId",
+    type: "type",
+    enabled: "enabled",
+    config: "config",
+  };
+  const proxyAuditLog = {};
+  return {
+    secretRoutes,
+    secrets,
+    policies,
+    proxyAuditLog,
+    getDb: () => ({
+      select: () => ({
+        from: (table: unknown) => ({
+          where: () => {
+            if (table === secretRoutes) {
+              return { orderBy: async () => [route] };
+            }
+            return {
+              limit: async () => [
+                {
+                  id: "secret-1",
+                  ciphertext: "ciphertext",
+                  iv: "iv",
+                  authTag: "tag",
+                  salt: "salt",
+                },
+              ],
+            };
+          },
+        }),
+      }),
+      insert: () => ({
+        values: async (entry: any) => {
+          audits.push(entry);
+        },
+      }),
+    }),
+  };
+});
+
+mock.module("@stwd/vault", () => ({
+  KeyStore: class {
+    decrypt() {
+      return "test-secret";
+    }
+  },
+}));
+
+function makeContext(path = "/proxy/example.com/v1/echo") {
+  const headers = new Headers({ authorization: "Bearer steward-token" });
+  return {
+    req: {
+      path,
+      method: "GET",
+      raw: new Request(`https://proxy.test${path}`, { headers }),
+    },
+    get(key: string) {
+      if (key === "agentId") return "agent-1";
+      if (key === "tenantId") return "tenant-1";
+      return undefined;
+    },
+    header() {},
+    json(body: unknown, status: number) {
+      return Response.json(body, { status });
+    },
+  } as any;
+}
+
+describe("proxy spend-limit enforcement", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  beforeEach(() => {
+    process.env.STEWARD_MASTER_PASSWORD = "test-master-password";
+    spendResult = {
+      allowed: true,
+      configured: true,
+      period: "day",
+      limit: 1,
+      spent: 0,
+      remaining: 1,
+    };
+    fetchCalls = 0;
+    audits.length = 0;
+    globalThis.fetch = (async (
+      url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      fetchCalls++;
+      expect(String(url)).toBe("https://example.com/v1/echo");
+      expect(new Headers(init?.headers).get("x-api-key")).toBe(
+        "Bearer test-secret",
+      );
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "text/plain" },
+      });
+    }) as typeof fetch;
+  });
+
+  test("agent under spend limit proceeds to upstream", async () => {
+    const { handleProxy, __setCheckProxySpendLimitForTests } =
+      await import("../handlers/proxy");
+    __setCheckProxySpendLimitForTests(async () => spendResult);
+
+    const res = await handleProxy(makeContext());
+
+    expect(res.status).toBe(200);
+    expect(fetchCalls).toBe(1);
+  });
+
+  test("agent over daily budget returns 402 and does not call upstream", async () => {
+    spendResult = {
+      allowed: false,
+      configured: true,
+      period: "day",
+      limit: 0.1,
+      spent: 0.12,
+      remaining: 0,
+      reason:
+        "Daily proxy spend limit exceeded for example.com: spent $0.1200 of $0.1000",
+    };
+    const { handleProxy, __setCheckProxySpendLimitForTests } =
+      await import("../handlers/proxy");
+    __setCheckProxySpendLimitForTests(async () => spendResult);
+
+    const res = await handleProxy(makeContext());
+    const body = await res.json();
+
+    expect(res.status).toBe(402);
+    expect(fetchCalls).toBe(0);
+    expect(body).toEqual({
+      ok: false,
+      error:
+        "Daily proxy spend limit exceeded for example.com: spent $0.1200 of $0.1000",
+      limit: {
+        type: "spend",
+        period: "day",
+        limitUsd: 0.1,
+        spentUsd: 0.12,
+        remainingUsd: 0,
+      },
+    });
+    expect(audits[0]).toMatchObject({
+      agentId: "agent-1",
+      tenantId: "tenant-1",
+      targetHost: "example.com",
+      statusCode: 402,
+      reason:
+        "Daily proxy spend limit exceeded for example.com: spent $0.1200 of $0.1000",
+    });
+  });
+
+  test("Redis down with REDIS_REQUIRED=false allows when spend check is permissive", async () => {
+    const { handleProxy, __setCheckProxySpendLimitForTests } =
+      await import("../handlers/proxy");
+    __setCheckProxySpendLimitForTests(async () => spendResult);
+
+    const res = await handleProxy(makeContext());
+
+    expect(res.status).toBe(200);
+    expect(fetchCalls).toBe(1);
+  });
+
+  test("Redis down with REDIS_REQUIRED=true fails closed when spend check denies", async () => {
+    spendResult = {
+      allowed: false,
+      configured: true,
+      period: "day",
+      limit: 1,
+      spent: 0,
+      remaining: 0,
+      reason: "Redis unavailable; spend-limit enforcement is required",
+    };
+    const { handleProxy, __setCheckProxySpendLimitForTests } =
+      await import("../handlers/proxy");
+    __setCheckProxySpendLimitForTests(async () => spendResult);
+
+    const res = await handleProxy(makeContext());
+    const body = await res.json();
+
+    expect(res.status).toBe(402);
+    expect(fetchCalls).toBe(0);
+    expect(body.error).toContain("Redis unavailable");
+  });
+});

--- a/packages/proxy/src/__tests__/zz-proxy-spend-limit.test.ts
+++ b/packages/proxy/src/__tests__/zz-proxy-spend-limit.test.ts
@@ -127,15 +127,10 @@ describe("proxy spend-limit enforcement", () => {
     };
     fetchCalls = 0;
     audits.length = 0;
-    globalThis.fetch = (async (
-      url: string | URL | Request,
-      init?: RequestInit,
-    ) => {
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
       fetchCalls++;
       expect(String(url)).toBe("https://example.com/v1/echo");
-      expect(new Headers(init?.headers).get("x-api-key")).toBe(
-        "Bearer test-secret",
-      );
+      expect(new Headers(init?.headers).get("x-api-key")).toBe("Bearer test-secret");
       return new Response(JSON.stringify({ ok: true }), {
         status: 200,
         headers: { "content-type": "text/plain" },
@@ -144,8 +139,7 @@ describe("proxy spend-limit enforcement", () => {
   });
 
   test("agent under spend limit proceeds to upstream", async () => {
-    const { handleProxy, __setCheckProxySpendLimitForTests } =
-      await import("../handlers/proxy");
+    const { handleProxy, __setCheckProxySpendLimitForTests } = await import("../handlers/proxy");
     __setCheckProxySpendLimitForTests(async () => spendResult);
 
     const res = await handleProxy(makeContext());
@@ -162,11 +156,9 @@ describe("proxy spend-limit enforcement", () => {
       limit: 0.1,
       spent: 0.12,
       remaining: 0,
-      reason:
-        "Daily proxy spend limit exceeded for example.com: spent $0.1200 of $0.1000",
+      reason: "Daily proxy spend limit exceeded for example.com: spent $0.1200 of $0.1000",
     };
-    const { handleProxy, __setCheckProxySpendLimitForTests } =
-      await import("../handlers/proxy");
+    const { handleProxy, __setCheckProxySpendLimitForTests } = await import("../handlers/proxy");
     __setCheckProxySpendLimitForTests(async () => spendResult);
 
     const res = await handleProxy(makeContext());
@@ -176,8 +168,7 @@ describe("proxy spend-limit enforcement", () => {
     expect(fetchCalls).toBe(0);
     expect(body).toEqual({
       ok: false,
-      error:
-        "Daily proxy spend limit exceeded for example.com: spent $0.1200 of $0.1000",
+      error: "Daily proxy spend limit exceeded for example.com: spent $0.1200 of $0.1000",
       limit: {
         type: "spend",
         period: "day",
@@ -191,14 +182,12 @@ describe("proxy spend-limit enforcement", () => {
       tenantId: "tenant-1",
       targetHost: "example.com",
       statusCode: 402,
-      reason:
-        "Daily proxy spend limit exceeded for example.com: spent $0.1200 of $0.1000",
+      reason: "Daily proxy spend limit exceeded for example.com: spent $0.1200 of $0.1000",
     });
   });
 
   test("Redis down with REDIS_REQUIRED=false allows when spend check is permissive", async () => {
-    const { handleProxy, __setCheckProxySpendLimitForTests } =
-      await import("../handlers/proxy");
+    const { handleProxy, __setCheckProxySpendLimitForTests } = await import("../handlers/proxy");
     __setCheckProxySpendLimitForTests(async () => spendResult);
 
     const res = await handleProxy(makeContext());
@@ -217,8 +206,7 @@ describe("proxy spend-limit enforcement", () => {
       remaining: 0,
       reason: "Redis unavailable; spend-limit enforcement is required",
     };
-    const { handleProxy, __setCheckProxySpendLimitForTests } =
-      await import("../handlers/proxy");
+    const { handleProxy, __setCheckProxySpendLimitForTests } = await import("../handlers/proxy");
     __setCheckProxySpendLimitForTests(async () => spendResult);
 
     const res = await handleProxy(makeContext());

--- a/packages/proxy/src/handlers/proxy.ts
+++ b/packages/proxy/src/handlers/proxy.ts
@@ -34,9 +34,7 @@ function getKeyStore(): KeyStore {
   if (!_keyStore) {
     const masterPassword = process.env.STEWARD_MASTER_PASSWORD;
     if (!masterPassword) {
-      throw new Error(
-        "STEWARD_MASTER_PASSWORD is required for secret decryption",
-      );
+      throw new Error("STEWARD_MASTER_PASSWORD is required for secret decryption");
     }
     _keyStore = new KeyStore(masterPassword);
   }
@@ -69,20 +67,14 @@ async function findMatchingRoute(
   const routes = await db
     .select()
     .from(secretRoutes)
-    .where(
-      and(eq(secretRoutes.tenantId, tenantId), eq(secretRoutes.enabled, true)),
-    )
+    .where(and(eq(secretRoutes.tenantId, tenantId), eq(secretRoutes.enabled, true)))
     .orderBy(desc(secretRoutes.priority));
 
   // Match in priority order (first match wins)
   for (const route of routes) {
     if (!matchHost(route.hostPattern, host)) continue;
     if (!matchPath(route.pathPattern ?? "/*", path)) continue;
-    if (
-      route.method !== "*" &&
-      route.method?.toUpperCase() !== method.toUpperCase()
-    )
-      continue;
+    if (route.method !== "*" && route.method?.toUpperCase() !== method.toUpperCase()) continue;
     return route;
   }
 
@@ -99,11 +91,7 @@ async function findMatchingRoute(
  */
 async function decryptSecret(secretId: string): Promise<string> {
   const db = getDb();
-  const [secret] = await db
-    .select()
-    .from(secrets)
-    .where(eq(secrets.id, secretId))
-    .limit(1);
+  const [secret] = await db.select().from(secrets).where(eq(secrets.id, secretId)).limit(1);
 
   if (!secret) {
     throw new Error(`Secret ${secretId} not found`);
@@ -130,10 +118,7 @@ function injectCredential(
   route: SecretRoute,
   credential: string,
 ): { headers: Headers; url: URL; body: ReadableStream<Uint8Array> | null } {
-  const formattedValue = (route.injectFormat ?? "{value}").replace(
-    "{value}",
-    credential,
-  );
+  const formattedValue = (route.injectFormat ?? "{value}").replace("{value}", credential);
 
   switch (route.injectAs) {
     case "header":
@@ -163,9 +148,7 @@ function injectCredential(
 let checkProxySpendLimitForHandler = checkProxySpendLimit;
 
 /** Test hook for overriding spend-limit enforcement without module mocks. */
-export function __setCheckProxySpendLimitForTests(
-  checker: typeof checkProxySpendLimit,
-): void {
+export function __setCheckProxySpendLimitForTests(checker: typeof checkProxySpendLimit): void {
   checkProxySpendLimitForHandler = checker;
 }
 
@@ -197,12 +180,7 @@ export async function handleProxy(c: Context): Promise<Response> {
   }
 
   // 2. Find matching secret route
-  const route = await findMatchingRoute(
-    tenantId,
-    target.host,
-    target.path,
-    method,
-  );
+  const route = await findMatchingRoute(tenantId, target.host, target.path, method);
   if (!route) {
     return c.json(
       {
@@ -229,8 +207,11 @@ export async function handleProxy(c: Context): Promise<Response> {
   }
 
   // 2.6. Redis spend-limit check (per agent, configured by spending-limit policy)
-  const spendResult: ProxySpendLimitResult =
-    await checkProxySpendLimitForHandler(agentId, tenantId, target.host);
+  const spendResult: ProxySpendLimitResult = await checkProxySpendLimitForHandler(
+    agentId,
+    tenantId,
+    target.host,
+  );
   if (!spendResult.allowed) {
     const latencyMs = Date.now() - startTime;
     const limit = spendResult.limit ?? 0;
@@ -356,8 +337,7 @@ export async function handleProxy(c: Context): Promise<Response> {
   // the cost, and still return the body to the client.
   //
   // For non-LLM hosts or streaming responses, we pass through without buffering.
-  let responseBody: ReadableStream<Uint8Array> | ArrayBuffer | null =
-    response.body;
+  let responseBody: ReadableStream<Uint8Array> | ArrayBuffer | null = response.body;
   const contentType = response.headers.get("content-type") || "";
   const isJsonResponse = contentType.includes("application/json");
   const isLLMHost =
@@ -387,13 +367,9 @@ export async function handleProxy(c: Context): Promise<Response> {
       }
 
       // Track spend asynchronously
-      trackProxySpend(
-        agentId,
-        tenantId,
-        target.host,
-        requestBodyParsed,
-        parsedResponse,
-      ).catch((err) => console.error("[proxy] Spend tracking failed:", err));
+      trackProxySpend(agentId, tenantId, target.host, requestBodyParsed, parsedResponse).catch(
+        (err) => console.error("[proxy] Spend tracking failed:", err),
+      );
 
       responseBody = bodyBuffer;
     } catch {

--- a/packages/proxy/src/handlers/proxy.ts
+++ b/packages/proxy/src/handlers/proxy.ts
@@ -18,7 +18,9 @@ import type { Context } from "hono";
 import { recordAudit } from "../middleware/audit";
 import {
   checkProxyRateLimit,
+  checkProxySpendLimit,
   isProxyRedisAvailable,
+  type ProxySpendLimitResult,
   trackProxySpend,
 } from "../middleware/redis-enforcement";
 import { resolveTarget } from "./alias";
@@ -32,7 +34,9 @@ function getKeyStore(): KeyStore {
   if (!_keyStore) {
     const masterPassword = process.env.STEWARD_MASTER_PASSWORD;
     if (!masterPassword) {
-      throw new Error("STEWARD_MASTER_PASSWORD is required for secret decryption");
+      throw new Error(
+        "STEWARD_MASTER_PASSWORD is required for secret decryption",
+      );
     }
     _keyStore = new KeyStore(masterPassword);
   }
@@ -65,14 +69,20 @@ async function findMatchingRoute(
   const routes = await db
     .select()
     .from(secretRoutes)
-    .where(and(eq(secretRoutes.tenantId, tenantId), eq(secretRoutes.enabled, true)))
+    .where(
+      and(eq(secretRoutes.tenantId, tenantId), eq(secretRoutes.enabled, true)),
+    )
     .orderBy(desc(secretRoutes.priority));
 
   // Match in priority order (first match wins)
   for (const route of routes) {
     if (!matchHost(route.hostPattern, host)) continue;
     if (!matchPath(route.pathPattern ?? "/*", path)) continue;
-    if (route.method !== "*" && route.method?.toUpperCase() !== method.toUpperCase()) continue;
+    if (
+      route.method !== "*" &&
+      route.method?.toUpperCase() !== method.toUpperCase()
+    )
+      continue;
     return route;
   }
 
@@ -89,7 +99,11 @@ async function findMatchingRoute(
  */
 async function decryptSecret(secretId: string): Promise<string> {
   const db = getDb();
-  const [secret] = await db.select().from(secrets).where(eq(secrets.id, secretId)).limit(1);
+  const [secret] = await db
+    .select()
+    .from(secrets)
+    .where(eq(secrets.id, secretId))
+    .limit(1);
 
   if (!secret) {
     throw new Error(`Secret ${secretId} not found`);
@@ -116,7 +130,10 @@ function injectCredential(
   route: SecretRoute,
   credential: string,
 ): { headers: Headers; url: URL; body: ReadableStream<Uint8Array> | null } {
-  const formattedValue = (route.injectFormat ?? "{value}").replace("{value}", credential);
+  const formattedValue = (route.injectFormat ?? "{value}").replace(
+    "{value}",
+    credential,
+  );
 
   switch (route.injectAs) {
     case "header":
@@ -141,6 +158,15 @@ function injectCredential(
   }
 
   return { headers, url, body };
+}
+
+let checkProxySpendLimitForHandler = checkProxySpendLimit;
+
+/** Test hook for overriding spend-limit enforcement without module mocks. */
+export function __setCheckProxySpendLimitForTests(
+  checker: typeof checkProxySpendLimit,
+): void {
+  checkProxySpendLimitForHandler = checker;
 }
 
 // ─── Main proxy handler ──────────────────────────────────────────────────────
@@ -171,7 +197,12 @@ export async function handleProxy(c: Context): Promise<Response> {
   }
 
   // 2. Find matching secret route
-  const route = await findMatchingRoute(tenantId, target.host, target.path, method);
+  const route = await findMatchingRoute(
+    tenantId,
+    target.host,
+    target.path,
+    method,
+  );
   if (!route) {
     return c.json(
       {
@@ -194,6 +225,44 @@ export async function handleProxy(c: Context): Promise<Response> {
         error: `Rate limit exceeded for ${target.host}. Retry after ${Math.ceil(rlResult.resetMs / 1000)}s`,
       },
       429,
+    );
+  }
+
+  // 2.6. Redis spend-limit check (per agent, configured by spending-limit policy)
+  const spendResult: ProxySpendLimitResult =
+    await checkProxySpendLimitForHandler(agentId, tenantId, target.host);
+  if (!spendResult.allowed) {
+    const latencyMs = Date.now() - startTime;
+    const limit = spendResult.limit ?? 0;
+    const period = spendResult.period ?? "day";
+    const reason =
+      spendResult.reason ??
+      `${period === "day" ? "Daily" : "Monthly"} proxy spend limit exceeded for ${target.host}`;
+
+    recordAudit({
+      agentId,
+      tenantId,
+      targetHost: target.host,
+      targetPath: target.path,
+      method,
+      statusCode: 402,
+      latencyMs,
+      reason,
+    });
+
+    return c.json(
+      {
+        ok: false,
+        error: reason,
+        limit: {
+          type: "spend",
+          period,
+          limitUsd: limit,
+          spentUsd: spendResult.spent,
+          remainingUsd: spendResult.remaining,
+        },
+      },
+      402,
     );
   }
 
@@ -287,7 +356,8 @@ export async function handleProxy(c: Context): Promise<Response> {
   // the cost, and still return the body to the client.
   //
   // For non-LLM hosts or streaming responses, we pass through without buffering.
-  let responseBody: ReadableStream<Uint8Array> | ArrayBuffer | null = response.body;
+  let responseBody: ReadableStream<Uint8Array> | ArrayBuffer | null =
+    response.body;
   const contentType = response.headers.get("content-type") || "";
   const isJsonResponse = contentType.includes("application/json");
   const isLLMHost =
@@ -317,9 +387,13 @@ export async function handleProxy(c: Context): Promise<Response> {
       }
 
       // Track spend asynchronously
-      trackProxySpend(agentId, tenantId, target.host, requestBodyParsed, parsedResponse).catch(
-        (err) => console.error("[proxy] Spend tracking failed:", err),
-      );
+      trackProxySpend(
+        agentId,
+        tenantId,
+        target.host,
+        requestBodyParsed,
+        parsedResponse,
+      ).catch((err) => console.error("[proxy] Spend tracking failed:", err));
 
       responseBody = bodyBuffer;
     } catch {

--- a/packages/proxy/src/middleware/audit.ts
+++ b/packages/proxy/src/middleware/audit.ts
@@ -16,6 +16,7 @@ export interface AuditEntry {
   method: string;
   statusCode: number;
   latencyMs: number;
+  reason?: string;
 }
 
 /**
@@ -33,6 +34,7 @@ export async function recordAudit(entry: AuditEntry): Promise<void> {
       method: entry.method,
       statusCode: entry.statusCode,
       latencyMs: entry.latencyMs,
+      reason: entry.reason,
     });
   } catch (err) {
     // Never let audit logging break the proxy

--- a/packages/proxy/src/middleware/redis-enforcement.ts
+++ b/packages/proxy/src/middleware/redis-enforcement.ts
@@ -14,7 +14,10 @@ import {
   isKnownHost,
   type RateLimitResult,
   recordSpend,
+  type SpendPeriod,
 } from "@stwd/redis";
+import { getDb, policies } from "@stwd/db";
+import { and, eq } from "drizzle-orm";
 
 // ─── State ───────────────────────────────────────────────────────────────────
 
@@ -26,6 +29,7 @@ let redisAvailable = false;
 export async function initProxyRedis(): Promise<boolean> {
   const url = process.env.REDIS_URL;
   if (!url) {
+    redisAvailable = false;
     console.log("[proxy:redis] REDIS_URL not set — Redis enforcement disabled");
     return false;
   }
@@ -34,9 +38,12 @@ export async function initProxyRedis(): Promise<boolean> {
     const client = getRedis();
     await client.ping();
     redisAvailable = true;
-    console.log("[proxy:redis] Redis connected — rate limiting and spend tracking enabled");
+    console.log(
+      "[proxy:redis] Redis connected — rate limiting and spend tracking enabled",
+    );
     return true;
   } catch (err) {
+    redisAvailable = false;
     console.warn("[proxy:redis] Failed to connect:", (err as Error).message);
     return false;
   }
@@ -64,6 +71,10 @@ const PERMISSIVE: RateLimitResult = {
   resetMs: 0,
 };
 
+function isRedisRequired(): boolean {
+  return process.env.REDIS_REQUIRED === "true";
+}
+
 /**
  * Check rate limit for a proxy request.
  * Uses a per-agent, per-host sliding window.
@@ -80,7 +91,10 @@ export async function checkProxyRateLimit(
     const key = `ratelimit:proxy:${agentId}:${host}:${windowMs}`;
     return await checkRateLimit(key, windowMs, maxRequests);
   } catch (err) {
-    console.error("[proxy:redis] Rate limit check failed:", (err as Error).message);
+    console.error(
+      "[proxy:redis] Rate limit check failed:",
+      (err as Error).message,
+    );
     return PERMISSIVE;
   }
 }
@@ -114,29 +128,203 @@ export async function trackProxySpend(
     }
     return cost;
   } catch (err) {
-    console.error("[proxy:redis] Spend tracking failed:", (err as Error).message);
+    console.error(
+      "[proxy:redis] Spend tracking failed:",
+      (err as Error).message,
+    );
     return 0;
   }
 }
 
+interface ProxySpendLimits {
+  day?: number;
+  month?: number;
+}
+
+export interface ProxySpendLimitResult {
+  allowed: boolean;
+  /** False when no enabled spend-limit policy with USD API budget is configured. */
+  configured: boolean;
+  period?: SpendPeriod;
+  limit?: number;
+  spent: number;
+  remaining: number;
+  reason?: string;
+}
+
+const NO_SPEND_POLICY: ProxySpendLimitResult = {
+  allowed: true,
+  configured: false,
+  spent: 0,
+  remaining: Infinity,
+};
+
+function toPositiveNumber(value: unknown): number | undefined {
+  if (value === undefined || value === null || value === "") return undefined;
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? n : undefined;
+}
+
+function extractProxySpendLimits(
+  config: Record<string, unknown>,
+): ProxySpendLimits {
+  return {
+    day: toPositiveNumber(
+      config.dailyLimitUsd ??
+        config.maxPerDayUsd ??
+        config.maxDailyUsd ??
+        config.proxyDailyLimitUsd ??
+        config.apiDailyLimitUsd,
+    ),
+    month: toPositiveNumber(
+      config.monthlyLimitUsd ??
+        config.maxPerMonthUsd ??
+        config.maxMonthlyUsd ??
+        config.proxyMonthlyLimitUsd ??
+        config.apiMonthlyLimitUsd,
+    ),
+  };
+}
+
+async function getConfiguredProxySpendLimits(
+  agentId: string,
+): Promise<ProxySpendLimits | null> {
+  const db = getDb();
+  const rows = await db
+    .select({ config: policies.config })
+    .from(policies)
+    .where(
+      and(
+        eq(policies.agentId, agentId),
+        eq(policies.type, "spending-limit"),
+        eq(policies.enabled, true),
+      ),
+    );
+
+  const merged: ProxySpendLimits = {};
+  for (const row of rows) {
+    const limits = extractProxySpendLimits(
+      row.config as Record<string, unknown>,
+    );
+    if (limits.day !== undefined)
+      merged.day = Math.min(merged.day ?? Infinity, limits.day);
+    if (limits.month !== undefined)
+      merged.month = Math.min(merged.month ?? Infinity, limits.month);
+  }
+
+  return merged.day !== undefined || merged.month !== undefined ? merged : null;
+}
+
 /**
- * Check if an agent has exceeded their API spend budget.
+ * Check if an agent has exceeded their proxy API spend budget.
  *
- * @param agentId - The agent ID
- * @param dailyLimitUsd - Maximum daily spend in USD (0 = no limit)
+ * Looks up enabled spending-limit policies for the agent and enforces USD API
+ * budgets when present. On-chain wei policies are ignored for proxy API spend.
+ *
+ * Backward-compatible helper form: checkProxySpendLimit(agentId, dailyLimitUsd).
  */
 export async function checkProxySpendLimit(
   agentId: string,
-  dailyLimitUsd: number,
-): Promise<{ allowed: boolean; spent: number; remaining: number }> {
-  if (!redisAvailable || dailyLimitUsd <= 0) {
-    return { allowed: true, spent: 0, remaining: dailyLimitUsd };
+  tenantIdOrDailyLimit?: string | number,
+  host?: string,
+): Promise<ProxySpendLimitResult> {
+  let limits: ProxySpendLimits | null;
+  if (typeof tenantIdOrDailyLimit === "number") {
+    limits = tenantIdOrDailyLimit > 0 ? { day: tenantIdOrDailyLimit } : null;
+  } else {
+    limits = await getConfiguredProxySpendLimits(agentId);
+  }
+
+  if (!limits) return NO_SPEND_POLICY;
+
+  const firstLimit = limits.day ?? limits.month ?? 0;
+  if (!redisAvailable) {
+    const message = `[proxy:redis] Redis unavailable while checking spend limit for agent=${agentId}${host ? ` host=${host}` : ""}`;
+    if (isRedisRequired()) {
+      console.error(`${message}; REDIS_REQUIRED=true, failing closed`);
+      return {
+        allowed: false,
+        configured: true,
+        period: limits.day !== undefined ? "day" : "month",
+        limit: firstLimit,
+        spent: 0,
+        remaining: 0,
+        reason: "Redis unavailable; spend-limit enforcement is required",
+      };
+    }
+
+    console.warn(`${message}; REDIS_REQUIRED=false, allowing request`);
+    return {
+      allowed: true,
+      configured: true,
+      limit: firstLimit,
+      spent: 0,
+      remaining: firstLimit,
+    };
   }
 
   try {
-    return await checkSpendLimit(agentId, dailyLimitUsd, "day");
+    let lastAllowed: ProxySpendLimitResult | null = null;
+    for (const period of ["day", "month"] as const) {
+      const limit = limits[period];
+      if (limit === undefined) continue;
+      const result = await checkSpendLimit(agentId, limit, period);
+      lastAllowed = {
+        allowed: true,
+        configured: true,
+        period,
+        limit,
+        spent: result.spent,
+        remaining: result.remaining,
+      };
+      if (!result.allowed) {
+        return {
+          allowed: false,
+          configured: true,
+          period,
+          limit,
+          spent: result.spent,
+          remaining: result.remaining,
+          reason: `${period === "day" ? "Daily" : "Monthly"} proxy spend limit exceeded for ${host ?? "host"}: spent $${result.spent.toFixed(4)} of $${limit.toFixed(4)}`,
+        };
+      }
+    }
+
+    return (
+      lastAllowed ?? {
+        allowed: true,
+        configured: true,
+        limit: firstLimit,
+        spent: 0,
+        remaining: firstLimit,
+      }
+    );
   } catch (err) {
-    console.error("[proxy:redis] Spend limit check failed:", (err as Error).message);
-    return { allowed: true, spent: 0, remaining: dailyLimitUsd };
+    console.error(
+      "[proxy:redis] Spend limit check failed:",
+      (err as Error).message,
+    );
+    if (isRedisRequired()) {
+      return {
+        allowed: false,
+        configured: true,
+        period: limits.day !== undefined ? "day" : "month",
+        limit: firstLimit,
+        spent: 0,
+        remaining: 0,
+        reason: "Redis spend-limit check failed; REDIS_REQUIRED=true",
+      };
+    }
+
+    console.warn(
+      "[proxy:redis] REDIS_REQUIRED=false, allowing request after spend limit check failure",
+    );
+    return {
+      allowed: true,
+      configured: true,
+      limit: firstLimit,
+      spent: 0,
+      remaining: firstLimit,
+    };
   }
 }

--- a/packages/proxy/src/middleware/redis-enforcement.ts
+++ b/packages/proxy/src/middleware/redis-enforcement.ts
@@ -5,6 +5,7 @@
  * API costs after receiving responses (using the cost estimator).
  */
 
+import { getDb, policies } from "@stwd/db";
 import {
   checkRateLimit,
   checkSpendLimit,
@@ -16,7 +17,6 @@ import {
   recordSpend,
   type SpendPeriod,
 } from "@stwd/redis";
-import { getDb, policies } from "@stwd/db";
 import { and, eq } from "drizzle-orm";
 
 // ─── State ───────────────────────────────────────────────────────────────────
@@ -38,9 +38,7 @@ export async function initProxyRedis(): Promise<boolean> {
     const client = getRedis();
     await client.ping();
     redisAvailable = true;
-    console.log(
-      "[proxy:redis] Redis connected — rate limiting and spend tracking enabled",
-    );
+    console.log("[proxy:redis] Redis connected — rate limiting and spend tracking enabled");
     return true;
   } catch (err) {
     redisAvailable = false;
@@ -91,10 +89,7 @@ export async function checkProxyRateLimit(
     const key = `ratelimit:proxy:${agentId}:${host}:${windowMs}`;
     return await checkRateLimit(key, windowMs, maxRequests);
   } catch (err) {
-    console.error(
-      "[proxy:redis] Rate limit check failed:",
-      (err as Error).message,
-    );
+    console.error("[proxy:redis] Rate limit check failed:", (err as Error).message);
     return PERMISSIVE;
   }
 }
@@ -128,10 +123,7 @@ export async function trackProxySpend(
     }
     return cost;
   } catch (err) {
-    console.error(
-      "[proxy:redis] Spend tracking failed:",
-      (err as Error).message,
-    );
+    console.error("[proxy:redis] Spend tracking failed:", (err as Error).message);
     return 0;
   }
 }
@@ -165,9 +157,7 @@ function toPositiveNumber(value: unknown): number | undefined {
   return Number.isFinite(n) && n > 0 ? n : undefined;
 }
 
-function extractProxySpendLimits(
-  config: Record<string, unknown>,
-): ProxySpendLimits {
+function extractProxySpendLimits(config: Record<string, unknown>): ProxySpendLimits {
   return {
     day: toPositiveNumber(
       config.dailyLimitUsd ??
@@ -186,9 +176,7 @@ function extractProxySpendLimits(
   };
 }
 
-async function getConfiguredProxySpendLimits(
-  agentId: string,
-): Promise<ProxySpendLimits | null> {
+async function getConfiguredProxySpendLimits(agentId: string): Promise<ProxySpendLimits | null> {
   const db = getDb();
   const rows = await db
     .select({ config: policies.config })
@@ -203,13 +191,9 @@ async function getConfiguredProxySpendLimits(
 
   const merged: ProxySpendLimits = {};
   for (const row of rows) {
-    const limits = extractProxySpendLimits(
-      row.config as Record<string, unknown>,
-    );
-    if (limits.day !== undefined)
-      merged.day = Math.min(merged.day ?? Infinity, limits.day);
-    if (limits.month !== undefined)
-      merged.month = Math.min(merged.month ?? Infinity, limits.month);
+    const limits = extractProxySpendLimits(row.config as Record<string, unknown>);
+    if (limits.day !== undefined) merged.day = Math.min(merged.day ?? Infinity, limits.day);
+    if (limits.month !== undefined) merged.month = Math.min(merged.month ?? Infinity, limits.month);
   }
 
   return merged.day !== undefined || merged.month !== undefined ? merged : null;
@@ -300,10 +284,7 @@ export async function checkProxySpendLimit(
       }
     );
   } catch (err) {
-    console.error(
-      "[proxy:redis] Spend limit check failed:",
-      (err as Error).message,
-    );
+    console.error("[proxy:redis] Spend limit check failed:", (err as Error).message);
     if (isRedisRequired()) {
       return {
         allowed: false,


### PR DESCRIPTION
## Summary

`checkProxySpendLimit` existed in `redis-enforcement.ts` but `handleProxy` never called it. Daily/monthly budgets configured in policies did nothing at the proxy layer.

## Changes

- Wired `checkProxySpendLimit(agentId, tenantId, host)` into `handleProxy` right after rate-limit check, before upstream forward
- Looks up enabled `spending-limit` policies, enforces USD daily + monthly budgets
- Agents with no proxy spend budget configured: silently skip
- Redis graceful-fail:
  - `REDIS_REQUIRED=false` → permissive with warning log
  - `REDIS_REQUIRED=true` → fail closed
- `proxy_audit_log` gets a `reason` column, blocked requests recorded at status 402

## Error response shape

```json
{
  "ok": false,
  "error": "Daily proxy spend limit exceeded for example.com: spent $0.1200 of $0.1000",
  "limit": {
    "type": "spend",
    "period": "day",
    "limitUsd": 0.1,
    "spentUsd": 0.12,
    "remainingUsd": 0
  }
}
```
Status: `402 Payment Required`.

## Validation

- `bun run build` ✅ 16/16
- `bun test packages/proxy packages/redis` ✅ 56 pass, 18 skip (gated real-Redis), 0 fail

Co-authored-by: wakesync <shadow@shad0w.xyz>