### PR TITLE
feat(api,policy-engine): user-scoped tenant management + policy simulate proxy shape

### DIFF
--- a/packages/api/src/__tests__/cross-tenant.test.ts
+++ b/packages/api/src/__tests__/cross-tenant.test.ts
@@ -174,6 +174,73 @@ describeWithDatabase("Cross-Tenant Identity", () => {
     });
   });
 
+  describe("POST /user/me/tenants", () => {
+    it("creates a tenant and adds the user as owner", async () => {
+      const token = await getTestUserToken();
+      const tenantId = `test-ct-created-${Date.now()}`;
+
+      const res = await fetch(`${BASE_URL}/user/me/tenants`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "Created Tenant", slug: tenantId }),
+      });
+
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as {
+        ok: boolean;
+        data: { tenantId: string; role: string; apiKey: string };
+      };
+      expect(body.ok).toBe(true);
+      expect(body.data.tenantId).toBe(tenantId);
+      expect(body.data.role).toBe("owner");
+      expect(body.data.apiKey.startsWith("stw_")).toBe(true);
+
+      const db = getDb();
+      const [membership] = await db
+        .select({ role: userTenants.role })
+        .from(userTenants)
+        .where(eq(userTenants.tenantId, tenantId));
+      expect(membership?.role).toBe("owner");
+
+      await db.delete(userTenants).where(eq(userTenants.tenantId, tenantId));
+      await db.delete(tenants).where(eq(tenants.id, tenantId));
+    });
+  });
+
+  describe("POST /user/me/tenants/switch", () => {
+    it("validates membership and returns a new token", async () => {
+      const token = await getTestUserToken();
+
+      const res = await fetch(`${BASE_URL}/user/me/tenants/switch`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+        body: JSON.stringify({ tenantId: OPEN_TENANT }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        ok: boolean;
+        data: { token: string; tenantId: string; activeTenantId: string; role: string };
+      };
+      expect(body.ok).toBe(true);
+      expect(typeof body.data.token).toBe("string");
+      expect(body.data.tenantId).toBe(OPEN_TENANT);
+      expect(body.data.activeTenantId).toBe(OPEN_TENANT);
+    });
+
+    it("rejects switching to a tenant the user is not a member of", async () => {
+      const token = await getTestUserToken();
+
+      const res = await fetch(`${BASE_URL}/user/me/tenants/switch`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+        body: JSON.stringify({ tenantId: CLOSED_TENANT }),
+      });
+
+      expect(res.status).toBe(403);
+    });
+  });
+
   describe("GET /user/me/tenants/:tenantId", () => {
     it("returns membership info for a joined tenant", async () => {
       const token = await getTestUserToken();

--- a/packages/api/src/routes/policies-standalone.ts
+++ b/packages/api/src/routes/policies-standalone.ts
@@ -45,16 +45,39 @@ interface AssignBody {
   agentIds: string[];
 }
 
+type TransactionSimRequest = {
+  kind?: "transaction";
+  to: string;
+  value: string;
+  data?: string;
+  chainId?: number;
+};
+
+type ProxySimRequest = {
+  kind?: "proxy";
+  method: string;
+  url: string;
+  body?: unknown;
+  data?: unknown;
+  value?: string;
+  chainId?: number;
+};
+
+type SimRequest = TransactionSimRequest | ProxySimRequest;
+
 interface SimulateBody {
   policyId?: string;
   rules?: PolicyRule[];
-  agentId: string;
-  request: {
-    to: string;
-    value: string;
-    data?: string;
-    chainId?: number;
-  };
+  agentId?: string;
+  request?: SimRequest;
+  kind?: "transaction" | "proxy";
+  to?: string;
+  value?: string;
+  data?: unknown;
+  chainId?: number;
+  method?: string;
+  url?: string;
+  body?: unknown;
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -136,6 +159,39 @@ async function deleteTemplate(tenantId: string, id: string): Promise<boolean> {
     sql`DELETE FROM policy_templates WHERE id = ${id}::uuid AND tenant_id = ${tenantId} RETURNING id`,
   );
   return (result as any[]).length > 0;
+}
+
+function normalizeSimulationRequest(body: SimulateBody): SimRequest | null {
+  const request = (body.request ?? body) as Record<string, unknown>;
+  const kind = request.kind ?? body.kind;
+
+  if (kind === "proxy" || (isNonEmptyString(request.method) && isNonEmptyString(request.url))) {
+    if (!isNonEmptyString(request.method) || !isNonEmptyString(request.url)) return null;
+    return {
+      kind: "proxy",
+      method: request.method,
+      url: request.url,
+      body: "body" in request ? request.body : undefined,
+      data: "data" in request ? request.data : undefined,
+      value: request.value !== undefined ? String(request.value) : undefined,
+      chainId: typeof request.chainId === "number" ? request.chainId : undefined,
+    };
+  }
+
+  if (kind === "transaction" || (isNonEmptyString(request.to) && request.value !== undefined)) {
+    if (!isNonEmptyString(request.to) || request.value === undefined || request.value === null) {
+      return null;
+    }
+    return {
+      kind: "transaction",
+      to: request.to,
+      value: String(request.value),
+      data: typeof request.data === "string" ? request.data : undefined,
+      chainId: typeof request.chainId === "number" ? request.chainId : undefined,
+    };
+  }
+
+  return null;
 }
 
 // ─── Routes ───────────────────────────────────────────────────────────────────
@@ -326,9 +382,14 @@ policiesStandaloneRoutes.post("/simulate", async (c) => {
     return c.json<ApiResponse>({ ok: false, error: "Invalid JSON in request body" }, 400);
   }
 
-  if (!body.request?.to || !body.request?.value) {
+  const request = normalizeSimulationRequest(body);
+  if (!request) {
     return c.json<ApiResponse>(
-      { ok: false, error: "request.to and request.value are required" },
+      {
+        ok: false,
+        error:
+          "request must be either { to, value, chainId?, data? } or { method, url, body?, data? }",
+      },
       400,
     );
   }
@@ -359,19 +420,14 @@ policiesStandaloneRoutes.post("/simulate", async (c) => {
         approved: true,
         results: [],
         requiresManualApproval: false,
-        note: "No rules to evaluate, transaction would be auto-approved",
+        note: "No rules to evaluate, request would be auto-approved",
       },
     });
   }
 
   try {
-    const result = await policyEngine.evaluate(rules, {
-      request: {
-        to: body.request.to,
-        value: body.request.value,
-        data: body.request.data,
-        chainId: body.request.chainId ?? 84532,
-      } as any,
+    const result = await policyEngine.simulate(rules, {
+      request: request as any,
       recentTxCount24h: 0,
       recentTxCount1h: 0,
       spentToday: 0n,

--- a/packages/api/src/routes/user.ts
+++ b/packages/api/src/routes/user.ts
@@ -16,7 +16,7 @@
  *       This file exports a Hono route group ready for mounting.
  */
 
-import { assertTokenNotRevoked, verifyToken } from "@stwd/auth";
+import { assertTokenNotRevoked, generateApiKey, verifyToken } from "@stwd/auth";
 import {
   getDb,
   policies,
@@ -43,6 +43,7 @@ import {
 } from "@stwd/vault";
 import { and, eq, sql } from "drizzle-orm";
 import { type Context, Hono, type Next } from "hono";
+import { createSessionToken } from "./auth";
 
 // ─── Session payload types ────────────────────────────────────────────────────
 
@@ -75,6 +76,23 @@ function isValidAddress(value: unknown): boolean {
 
 function isNonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
+}
+
+function isValidTenantId(value: unknown): value is string {
+  return typeof value === "string" && /^[a-zA-Z0-9_\-.:]{1,64}$/.test(value);
+}
+
+function slugifyTenantId(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_.:-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64);
+}
+
+function userTenantCreationAllowed(): boolean {
+  return process.env.ALLOW_USER_TENANT_CREATION !== "false";
 }
 
 /** Build a Vault instance from environment. Same defaults as index.ts. */
@@ -553,6 +571,154 @@ user.get("/me/tenants", async (c) => {
   return c.json<ApiResponse<typeof memberships>>({
     ok: true,
     data: memberships,
+  });
+});
+
+/**
+ * POST /me/tenants
+ * Create a new self-serve tenant owned by the authenticated user.
+ */
+user.post("/me/tenants", async (c) => {
+  if (!userTenantCreationAllowed()) {
+    return c.json<ApiResponse>({ ok: false, error: "User tenant creation is disabled" }, 403);
+  }
+
+  const body = await safeJsonParse<{ name?: string; slug?: string; settings?: unknown }>(c);
+  if (!body) {
+    return c.json<ApiResponse>({ ok: false, error: "Invalid JSON in request body" }, 400);
+  }
+
+  if (!isNonEmptyString(body.name)) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "name is required and must be a non-empty string" },
+      400,
+    );
+  }
+
+  const tenantId = body.slug ? body.slug.trim() : slugifyTenantId(body.name);
+  if (!isValidTenantId(tenantId)) {
+    return c.json<ApiResponse>(
+      {
+        ok: false,
+        error: "Invalid tenant slug — must be 1-64 alphanumeric chars (plus _ - . :)",
+      },
+      400,
+    );
+  }
+
+  const userId = c.get("userId");
+  const session = c.get("userSession");
+  const db = getDb();
+
+  const [existing] = await db
+    .select({ id: tenants.id })
+    .from(tenants)
+    .where(eq(tenants.id, tenantId));
+  if (existing) {
+    return c.json<ApiResponse>({ ok: false, error: "Tenant already exists" }, 409);
+  }
+
+  const apiKeyPair = generateApiKey();
+
+  try {
+    const [tenant] = await db
+      .insert(tenants)
+      .values({
+        id: tenantId,
+        name: body.name.trim(),
+        apiKeyHash: apiKeyPair.hash,
+        ownerAddress: typeof session.address === "string" ? session.address : undefined,
+      })
+      .returning();
+
+    if (!tenant) {
+      return c.json<ApiResponse>({ ok: false, error: "Failed to create tenant" }, 500);
+    }
+
+    await db
+      .insert(userTenants)
+      .values({ userId, tenantId: tenant.id, role: "owner" })
+      .onConflictDoNothing();
+
+    return c.json<
+      ApiResponse<{
+        tenantId: string;
+        id: string;
+        name: string;
+        role: string;
+        apiKey: string;
+        createdAt: Date;
+        updatedAt: Date;
+      }>
+    >(
+      {
+        ok: true,
+        data: {
+          tenantId: tenant.id,
+          id: tenant.id,
+          name: tenant.name,
+          role: "owner",
+          apiKey: apiKeyPair.key,
+          createdAt: tenant.createdAt,
+          updatedAt: tenant.updatedAt,
+        },
+      },
+      201,
+    );
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : "Failed to create tenant";
+    return c.json<ApiResponse>({ ok: false, error: message }, 400);
+  }
+});
+
+/**
+ * POST /me/tenants/switch
+ * Mint a new session token scoped to an existing tenant membership.
+ */
+user.post("/me/tenants/switch", async (c) => {
+  const body = await safeJsonParse<{ tenantId?: string }>(c);
+  if (!body) {
+    return c.json<ApiResponse>({ ok: false, error: "Invalid JSON in request body" }, 400);
+  }
+
+  if (!isValidTenantId(body.tenantId)) {
+    return c.json<ApiResponse>({ ok: false, error: "tenantId is required" }, 400);
+  }
+
+  const userId = c.get("userId");
+  const session = c.get("userSession");
+  const db = getDb();
+
+  const [membership] = await db
+    .select({ tenantId: userTenants.tenantId, role: userTenants.role })
+    .from(userTenants)
+    .where(and(eq(userTenants.userId, userId), eq(userTenants.tenantId, body.tenantId)));
+
+  if (!membership) {
+    return c.json<ApiResponse>({ ok: false, error: "Not a member of this tenant" }, 403);
+  }
+
+  const token = await createSessionToken(
+    typeof session.address === "string" ? session.address : "",
+    membership.tenantId,
+    {
+      ...session,
+      userId,
+      tenantId: membership.tenantId,
+      activeTenantId: membership.tenantId,
+    },
+  );
+
+  return c.json<
+    ApiResponse<{ token: string; tenantId: string; activeTenantId: string; role: string }>
+  >({
+    ok: true,
+    data: {
+      token,
+      tenantId: membership.tenantId,
+      activeTenantId: membership.tenantId,
+      role: membership.role,
+    },
   });
 });
 

--- a/packages/policy-engine/src/__tests__/evaluators.test.ts
+++ b/packages/policy-engine/src/__tests__/evaluators.test.ts
@@ -1081,6 +1081,46 @@ describe("PolicyEngine.evaluate()", () => {
     expect(chainsResult?.reason).toContain("eip155:8453");
   });
 
+  it("simulate accepts transaction shape and evaluates as before", async () => {
+    const policies: PolicyRule[] = [
+      makeSpendingRule({
+        maxPerTx: "500000000000000000",
+        maxPerDay: "10000000000000000000",
+        maxPerWeek: "10000000000000000000",
+      }),
+    ];
+
+    const result = await engine.simulate(policies, makeEngineCtx());
+
+    expect(result.approved).toBe(false);
+    expect(result.results[0].type).toBe("spending-limit");
+  });
+
+  it("simulate accepts proxy shape and evaluates rate/spend policies", async () => {
+    const policies: PolicyRule[] = [
+      makeRateRule({ maxTxPerHour: 1, maxTxPerDay: 10 }),
+      makeSpendingRule({
+        maxPerTx: "100",
+        maxPerDay: "1000",
+        maxPerWeek: "1000",
+      }),
+      makeAddressRule({
+        addresses: ["0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"],
+        mode: "whitelist",
+      }),
+    ];
+
+    const result = await engine.simulate(policies, {
+      ...makeEngineCtx({ recentTxCount1h: 1 }),
+      request: { kind: "proxy", method: "POST", url: "/v1/orders", body: { value: "50" } },
+    });
+
+    expect(result.approved).toBe(false);
+    expect(result.results.map((r) => r.type)).toEqual(["rate-limit", "spending-limit"]);
+    expect(result.results.find((r) => r.type === "rate-limit")?.passed).toBe(false);
+    expect(result.results.find((r) => r.type === "spending-limit")?.passed).toBe(true);
+  });
+
   it("disabled policy inside engine is skipped (treated as passed)", async () => {
     const policies: PolicyRule[] = [
       {

--- a/packages/policy-engine/src/engine.ts
+++ b/packages/policy-engine/src/engine.ts
@@ -1,6 +1,22 @@
 import type { PolicyResult, PolicyRule, PriceOracle, SignRequest } from "@stwd/shared";
 import { type EvaluatorContext, evaluatePolicy } from "./evaluators";
 
+export interface TransactionSimulationRequest extends SignRequest {
+  kind?: "transaction";
+}
+
+export interface ProxySimulationRequest {
+  kind: "proxy";
+  method: string;
+  url: string;
+  body?: unknown;
+  data?: unknown;
+  value?: string;
+  chainId?: number;
+}
+
+export type PolicySimulationRequest = TransactionSimulationRequest | ProxySimulationRequest;
+
 export interface PolicyEvaluationContext {
   request: SignRequest;
   recentTxCount24h: number;
@@ -17,6 +33,26 @@ export interface EvaluationResult {
   approved: boolean;
   results: PolicyResult[];
   requiresManualApproval: boolean;
+}
+
+function isProxyRequest(request: PolicySimulationRequest): request is ProxySimulationRequest {
+  return (
+    request.kind === "proxy" || ("method" in request && "url" in request && !("to" in request))
+  );
+}
+
+function extractProxyValue(request: ProxySimulationRequest): string {
+  if (request.value !== undefined) return String(request.value);
+
+  const candidates = [request.body, request.data];
+  for (const candidate of candidates) {
+    if (candidate && typeof candidate === "object" && "value" in candidate) {
+      const value = (candidate as { value?: unknown }).value;
+      if (value !== undefined && value !== null) return String(value);
+    }
+  }
+
+  return "0";
 }
 
 /**
@@ -71,5 +107,35 @@ export class PolicyEngine {
 
     // Hard policy failed — reject
     return { approved: false, results, requiresManualApproval: false };
+  }
+
+  /**
+   * Evaluate policy simulation input. Transaction requests use the full policy set;
+   * proxy/API-call requests only apply rate/spend style controls that are meaningful
+   * without an on-chain recipient.
+   */
+  async simulate(
+    policies: PolicyRule[],
+    ctx: Omit<PolicyEvaluationContext, "request"> & { request: PolicySimulationRequest },
+  ): Promise<EvaluationResult> {
+    if (!isProxyRequest(ctx.request)) {
+      const { kind: _kind, ...request } = ctx.request;
+      return this.evaluate(policies, { ...ctx, request });
+    }
+
+    const proxyPolicies = policies.filter((policy) =>
+      ["rate-limit", "spending-limit", "auto-approve-threshold"].includes(policy.type),
+    );
+
+    const syntheticRequest: SignRequest = {
+      agentId: "proxy-simulation",
+      tenantId: "proxy-simulation",
+      to: "0x0000000000000000000000000000000000000000",
+      value: extractProxyValue(ctx.request),
+      data: typeof ctx.request.data === "string" ? ctx.request.data : undefined,
+      chainId: ctx.request.chainId ?? 84532,
+    };
+
+    return this.evaluate(proxyPolicies, { ...ctx, request: syntheticRequest });
   }
 }

--- a/packages/policy-engine/src/index.ts
+++ b/packages/policy-engine/src/index.ts
@@ -1,4 +1,9 @@
-export type { PolicyEvaluationContext } from "./engine";
+export type {
+  PolicyEvaluationContext,
+  PolicySimulationRequest,
+  ProxySimulationRequest,
+  TransactionSimulationRequest,
+} from "./engine";
 export { PolicyEngine } from "./engine";
 export type { EvaluatorContext } from "./evaluators";
 export { evaluatePolicy } from "./evaluators";

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -489,18 +489,42 @@ export interface PolicyTemplateCreate {
 
 export type PolicyTemplateUpdate = Partial<PolicyTemplateCreate>;
 
+/**
+ * Transaction-shaped policy simulation request.
+ * Used to evaluate signing policies against a hypothetical transaction.
+ */
+export interface PolicySimulateTransactionRequest {
+  kind?: "transaction";
+  to: string;
+  value: string;
+  data?: string;
+  chainId?: number;
+}
+
+/**
+ * Proxy-shaped policy simulation request.
+ * Used to evaluate proxy gateway policies against an outbound API call.
+ */
+export interface PolicySimulateProxyRequest {
+  kind: "proxy";
+  method?: string;
+  url?: string;
+  body?: unknown;
+  data?: unknown;
+  value?: string;
+}
+
+export type PolicySimulateRequest =
+  | PolicySimulateTransactionRequest
+  | PolicySimulateProxyRequest;
+
 export interface PolicySimulateInput {
   /** Simulate an existing saved template. */
   policyId?: string;
   /** Or simulate an inline rule set. */
   rules?: PolicyRule[];
   agentId: string;
-  request: {
-    to: string;
-    value: string;
-    data?: string;
-    chainId?: number;
-  };
+  request: PolicySimulateRequest;
 }
 
 export interface PolicySimulateResult {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -514,9 +514,7 @@ export interface PolicySimulateProxyRequest {
   value?: string;
 }
 
-export type PolicySimulateRequest =
-  | PolicySimulateTransactionRequest
-  | PolicySimulateProxyRequest;
+export type PolicySimulateRequest = PolicySimulateTransactionRequest | PolicySimulateProxyRequest;
 
 export interface PolicySimulateInput {
   /** Simulate an existing saved template. */

--- a/web/src/app/dashboard/policies/page.tsx
+++ b/web/src/app/dashboard/policies/page.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import type { AgentIdentity, PolicyRule, PolicyTemplate } from "@stwd/sdk";
+import type {
+  AgentIdentity,
+  PolicyRule,
+  PolicySimulateResult,
+  PolicyTemplate,
+} from "@stwd/sdk";
 import { AnimatePresence, motion } from "framer-motion";
 import { useCallback, useEffect, useState } from "react";
 import { steward } from "@/lib/api";
@@ -45,6 +50,7 @@ interface PolicySimulatePayload {
   policyId: string;
   agentId: string;
   request: {
+    kind?: "proxy" | "transaction";
     method?: string;
     url?: string;
     value?: string;
@@ -201,11 +207,7 @@ export default function PoliciesPage() {
     value: "",
     data: "",
   });
-  const [simResult, setSimResult] = useState<{
-    allowed: boolean;
-    reason?: string;
-    matchedRules: string[];
-  } | null>(null);
+  const [simResult, setSimResult] = useState<PolicySimulateResult | null>(null);
   const [simulating, setSimulating] = useState(false);
 
   // Delete
@@ -376,8 +378,9 @@ export default function PoliciesPage() {
         policyId: selected.id,
         agentId: simForm.agentId,
         request: {
-          method: simForm.method || undefined,
-          url: simForm.url || undefined,
+          kind: "proxy",
+          method: simForm.method || "GET",
+          url: simForm.url,
           value: simForm.value || undefined,
           data: simForm.data || undefined,
         },
@@ -391,13 +394,7 @@ export default function PoliciesPage() {
           data: payload.request.data,
         },
       });
-      // Re-shape to the dashboard's historical result type so the existing
-      // UI continues to render.
-      setSimResult({
-        allowed: result.approved,
-        reason: result.results.find((r) => !r.passed)?.reason,
-        matchedRules: result.results.filter((r) => r.passed).map((r) => r.policyId),
-      });
+      setSimResult(result);
     } catch (e: unknown) {
       toast(e instanceof Error ? e.message : "Simulation failed", "error");
     } finally {
@@ -1091,29 +1088,31 @@ export default function PoliciesPage() {
                               animate={{ opacity: 1, y: 0 }}
                               exit={{ opacity: 0 }}
                               className={`p-4 border space-y-2 ${
-                                simResult.allowed
+                                simResult.approved
                                   ? "border-emerald-400/30 bg-emerald-400/5"
                                   : "border-red-400/30 bg-red-400/5"
                               }`}
                             >
                               <div className="flex items-center gap-2">
                                 <span
-                                  className={`text-sm font-display font-700 ${simResult.allowed ? "text-emerald-400" : "text-red-400"}`}
+                                  className={`text-sm font-display font-700 ${simResult.approved ? "text-emerald-400" : "text-red-400"}`}
                                 >
-                                  {simResult.allowed ? "ALLOWED" : "DENIED"}
+                                  {simResult.approved ? "ALLOWED" : "DENIED"}
                                 </span>
                               </div>
-                              {simResult.reason && (
-                                <p className="text-xs text-text-secondary">{simResult.reason}</p>
+                              {simResult.requiresManualApproval && (
+                                <p className="text-xs text-text-secondary">
+                                  Manual approval would be required.
+                                </p>
                               )}
-                              {simResult.matchedRules.length > 0 && (
+                              {simResult.results.length > 0 && (
                                 <div className="flex flex-wrap gap-1.5">
-                                  {simResult.matchedRules.map((rule, i) => (
+                                  {simResult.results.map((rule, i) => (
                                     <span
                                       key={i}
                                       className="text-xs px-1.5 py-0.5 bg-bg border border-border font-mono text-text-tertiary"
                                     >
-                                      {rule}
+                                      {`${rule.type}: ${rule.passed ? "pass" : "fail"}${rule.reason ? ` — ${rule.reason}` : ""}`}
                                     </span>
                                   ))}
                                 </div>

--- a/web/src/app/dashboard/policies/page.tsx
+++ b/web/src/app/dashboard/policies/page.tsx
@@ -1,11 +1,6 @@
 "use client";
 
-import type {
-  AgentIdentity,
-  PolicyRule,
-  PolicySimulateResult,
-  PolicyTemplate,
-} from "@stwd/sdk";
+import type { AgentIdentity, PolicyRule, PolicySimulateResult, PolicyTemplate } from "@stwd/sdk";
 import { AnimatePresence, motion } from "framer-motion";
 import { useCallback, useEffect, useState } from "react";
 import { steward } from "@/lib/api";


### PR DESCRIPTION
## Summary

Fixes two backend gaps discovered during #18 (web-sdk consolidation):

1. Dashboard called `/user/me/tenants` + `POST`/`switch` but those endpoints didn't exist
2. `/policies/simulate` input shape didn't match the UI (UI sends `method/url/data`, backend wanted `to/value/chainId`)

## Changes

**User-scoped tenant endpoints**
- `GET /user/me/tenants` verified (already existed)
- `POST /user/me/tenants` self-serve create, gated by `ALLOW_USER_TENANT_CREATION` (default true, operator can disable). Creates tenant + owner membership, returns one-time API key.
- `POST /user/me/tenants/switch` validates user is a member, returns refreshed session token with `activeTenantId` claim.

**`POST /policies/simulate` flexible input**
- Accepts all of:
  - Legacy: `{ to, value, chainId?, data? }`
  - Discriminated transaction: `{ kind: "transaction", ... }`
  - Proxy/API shape: `{ kind: "proxy", method, url, body?/data?, value? }`
  - Nested: `{ request: {...} }`
- `PolicyEngine.simulate()` handles both transaction and proxy cases
- Proxy simulation checks rate + spend policies

**Dashboard update**
- `web/src/app/dashboard/policies/page.tsx` UI updated to send proxy shape
- FIXME comments removed, direct SDK calls replace shims

## Validation

- `bun run build` ✅ 16/16
- `bun test packages/api packages/policy-engine` ✅ 117 pass, 91 skip (DB integration gated), 0 fail

## Commits

1. `b8b2b10` feat(api): add user-scoped tenant management endpoints
2. `b38b93f` feat(api,policy-engine): policy simulate accepts proxy call shape

Co-authored-by: wakesync <shadow@shad0w.xyz>