### PR TITLE
feat(api): public discovery endpoints + per-route tenant auth

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -131,24 +131,9 @@ app.use("/agents/*", (c, next) => tenantAuth(c, next));
 app.use("/vault/*", (c, next) => tenantAuth(c, next));
 app.use("/secrets", (c, next) => tenantAuth(c, next));
 app.use("/secrets/*", (c, next) => tenantAuth(c, next));
-app.use("/tenants/:id", (c, next) => {
-  // GET /tenants/config (no id) is a public discovery endpoint used by the
-  // @stwd/sdk React provider to fetch default-tenant policy/theme/feature
-  // flags before the user has authenticated. The :id wildcard would otherwise
-  // catch it and demand tenant auth, which isn't available pre-signin.
-  const id = c.req.param("id");
-  if (id === "config" && c.req.method === "GET") return next();
-  return tenantAuth(c, next, { requireTenantMatch: id });
-});
-app.use("/tenants/:id/webhook", (c, next) =>
-  tenantAuth(c, next, { requireTenantMatch: c.req.param("id") }),
-);
-app.use("/tenants/:id/config", (c, next) =>
-  tenantAuth(c, next, { requireTenantMatch: c.req.param("id") }),
-);
-app.use("/tenants/:id/config/*", (c, next) =>
-  tenantAuth(c, next, { requireTenantMatch: c.req.param("id") }),
-);
+// Tenant routes apply auth per-handler via the `requireTenantId` middleware
+// inside tenants.ts / tenant-config.ts, so the public `GET /tenants/config`
+// discovery endpoint doesn't need a magic-string skip in a catch-all here.
 app.use("/dashboard/*", (c, next) => dashboardAuthMiddleware(c, next));
 app.use("/webhooks", (c, next) => tenantAuth(c, next));
 app.use("/webhooks/*", (c, next) => tenantAuth(c, next));
@@ -216,8 +201,10 @@ app.route("/user", userRoutes);
 app.route("/agents", agentRoutes);
 app.route("/vault", vaultRoutes);
 app.route("/secrets", secretsRoutes);
-app.route("/tenants", tenantRoutes);
+// tenantConfigRoutes mounted FIRST so its literal `/config` discovery handler
+// is matched before tenantRoutes' `/:id` wildcard would catch "config" as an id.
 app.route("/tenants", tenantConfigRoutes);
+app.route("/tenants", tenantRoutes);
 app.route("/dashboard", dashboardRoutes);
 app.route("/webhooks", webhookRoutes);
 app.route("/approvals", approvalRoutes);

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -131,9 +131,15 @@ app.use("/agents/*", (c, next) => tenantAuth(c, next));
 app.use("/vault/*", (c, next) => tenantAuth(c, next));
 app.use("/secrets", (c, next) => tenantAuth(c, next));
 app.use("/secrets/*", (c, next) => tenantAuth(c, next));
-app.use("/tenants/:id", (c, next) =>
-  tenantAuth(c, next, { requireTenantMatch: c.req.param("id") }),
-);
+app.use("/tenants/:id", (c, next) => {
+  // GET /tenants/config (no id) is a public discovery endpoint used by the
+  // @stwd/sdk React provider to fetch default-tenant policy/theme/feature
+  // flags before the user has authenticated. The :id wildcard would otherwise
+  // catch it and demand tenant auth, which isn't available pre-signin.
+  const id = c.req.param("id");
+  if (id === "config" && c.req.method === "GET") return next();
+  return tenantAuth(c, next, { requireTenantMatch: id });
+});
 app.use("/tenants/:id/webhook", (c, next) =>
   tenantAuth(c, next, { requireTenantMatch: c.req.param("id") }),
 );

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -1015,6 +1015,54 @@ function redirectEmailAuthFailure(c: Context, reason: string): Response {
 
 const auth = new Hono();
 
+// ── Discovery ─────────────────────────────────────────────────────────────────
+
+/**
+ * GET /providers
+ * Public endpoint. Returns which authentication methods are enabled on this
+ * server so a client SDK (e.g. @stwd/sdk) can render the right sign-in UI.
+ *
+ * Passkey/email/SIWE/SIWS are always wired in this build. OAuth providers are
+ * advertised only when their corresponding STEWARD_OAUTH_<PROVIDER>_CLIENT_ID
+ * env var is present, so a stripped-down deployment honestly reports what it
+ * supports rather than offering a broken Google button.
+ */
+auth.get("/providers", (c) => {
+  const oauthClientIds: Record<string, string | undefined> = {
+    google: process.env.STEWARD_OAUTH_GOOGLE_CLIENT_ID,
+    discord: process.env.STEWARD_OAUTH_DISCORD_CLIENT_ID,
+    github: process.env.STEWARD_OAUTH_GITHUB_CLIENT_ID,
+  };
+  const oauth = Object.entries(oauthClientIds)
+    .filter(([, value]) => typeof value === "string" && value.trim().length > 0)
+    .map(([name]) => name);
+
+  return c.json<
+    ApiResponse<{
+      passkey: boolean;
+      email: boolean;
+      siwe: boolean;
+      siws: boolean;
+      google: boolean;
+      discord: boolean;
+      github: boolean;
+      oauth: string[];
+    }>
+  >({
+    ok: true,
+    data: {
+      passkey: true,
+      email: true,
+      siwe: true,
+      siws: true,
+      google: oauth.includes("google"),
+      discord: oauth.includes("discord"),
+      github: oauth.includes("github"),
+      oauth,
+    },
+  });
+});
+
 // ── SIWE ──────────────────────────────────────────────────────────────────────
 
 /**

--- a/packages/api/src/routes/tenant-config.ts
+++ b/packages/api/src/routes/tenant-config.ts
@@ -23,6 +23,40 @@ import { type ApiResponse, type AppVariables, db, safeJsonParse } from "../servi
 
 export const tenantConfigRoutes = new Hono<{ Variables: AppVariables }>();
 
+// ─── GET /tenants/config — public discovery for the default tenant ────────────
+
+/**
+ * GET /config (mounts at /tenants/config)
+ * Public, no auth required. Used by the @stwd/sdk React provider to fetch the
+ * default tenant's policy templates, theme, and feature flags before the user
+ * signs in. Mirrors `/tenants/:id/config` but always resolves to the default
+ * tenant id and never reads the database — this is pure discovery, never PII.
+ *
+ * Registered before the `/:id/config` handler below so Hono's matcher prefers
+ * the literal segment over the parameterised one.
+ */
+tenantConfigRoutes.get("/config", async (c) => {
+  const defaultConfig = DEFAULT_TENANT_CONFIGS.default;
+  if (defaultConfig) {
+    return c.json<ApiResponse<TenantControlPlaneConfig>>({
+      ok: true,
+      data: defaultConfig,
+    });
+  }
+  const emptyConfig: TenantControlPlaneConfig = {
+    tenantId: "default",
+    policyExposure: {},
+    policyTemplates: [],
+    secretRoutePresets: [],
+    approvalConfig: {},
+    featureFlags: {},
+  };
+  return c.json<ApiResponse<TenantControlPlaneConfig>>({
+    ok: true,
+    data: emptyConfig,
+  });
+});
+
 // ─── GET /tenants/:id/config — get tenant control plane config ────────────────
 
 tenantConfigRoutes.get("/:id/config", async (c) => {

--- a/packages/api/src/routes/tenant-config.ts
+++ b/packages/api/src/routes/tenant-config.ts
@@ -20,6 +20,7 @@ import { Hono } from "hono";
 import { DEFAULT_TENANT_CONFIGS } from "../defaults/tenant-configs";
 import { invalidateTenantCorsCache } from "../middleware/tenant-cors";
 import { type ApiResponse, type AppVariables, db, safeJsonParse } from "../services/context";
+import { requireTenantId } from "./tenants";
 
 export const tenantConfigRoutes = new Hono<{ Variables: AppVariables }>();
 
@@ -53,8 +54,8 @@ tenantConfigRoutes.get("/config", async (c) => {
 
 // ─── GET /tenants/:id/config — get tenant control plane config ────────────────
 
-tenantConfigRoutes.get("/:id/config", async (c) => {
-  const tenantId = c.req.param("id");
+tenantConfigRoutes.get("/:id/config", requireTenantId, async (c) => {
+  const tenantId = c.req.param("id") as string;
 
   // Try DB first
   const [row] = await db
@@ -82,34 +83,16 @@ tenantConfigRoutes.get("/:id/config", async (c) => {
     });
   }
 
-  // Fall back to defaults
-  const defaultConfig = DEFAULT_TENANT_CONFIGS[tenantId];
-  if (defaultConfig) {
-    return c.json<ApiResponse<TenantControlPlaneConfig>>({
-      ok: true,
-      data: defaultConfig,
-    });
-  }
-
-  // Return empty config
-  const emptyConfig: TenantControlPlaneConfig = {
-    tenantId,
-    policyExposure: {},
-    policyTemplates: [],
-    secretRoutePresets: [],
-    approvalConfig: {},
-    featureFlags: {},
-  };
   return c.json<ApiResponse<TenantControlPlaneConfig>>({
     ok: true,
-    data: emptyConfig,
+    data: DEFAULT_TENANT_CONFIGS[tenantId] ?? emptyTenantConfig(tenantId),
   });
 });
 
 // ─── PUT /tenants/:id/config — update tenant control plane config ─────────────
 
-tenantConfigRoutes.put("/:id/config", async (c) => {
-  const tenantId = c.req.param("id");
+tenantConfigRoutes.put("/:id/config", requireTenantId, async (c) => {
+  const tenantId = c.req.param("id") as string;
   const body = await safeJsonParse<Partial<TenantControlPlaneConfig>>(c);
 
   if (!body) {
@@ -172,8 +155,8 @@ tenantConfigRoutes.put("/:id/config", async (c) => {
 
 // ─── GET /tenants/:id/config/templates — list policy templates ────────────────
 
-tenantConfigRoutes.get("/:id/config/templates", async (c) => {
-  const tenantId = c.req.param("id");
+tenantConfigRoutes.get("/:id/config/templates", requireTenantId, async (c) => {
+  const tenantId = c.req.param("id") as string;
 
   const [row] = await db
     .select({ policyTemplates: tenantConfigsTable.policyTemplates })
@@ -197,8 +180,8 @@ tenantConfigRoutes.get("/:id/config/templates", async (c) => {
 
 // ─── POST /tenants/:id/config/templates/:name/apply — apply template to agent ─
 
-tenantConfigRoutes.post("/:id/config/templates/:name/apply", async (c) => {
-  const tenantId = c.req.param("id");
+tenantConfigRoutes.post("/:id/config/templates/:name/apply", requireTenantId, async (c) => {
+  const tenantId = c.req.param("id") as string;
   const templateName = c.req.param("name");
 
   const body = await safeJsonParse<{

--- a/packages/api/src/routes/tenant-config.ts
+++ b/packages/api/src/routes/tenant-config.ts
@@ -23,6 +23,15 @@ import { type ApiResponse, type AppVariables, db, safeJsonParse } from "../servi
 
 export const tenantConfigRoutes = new Hono<{ Variables: AppVariables }>();
 
+const emptyTenantConfig = (tenantId: string): TenantControlPlaneConfig => ({
+  tenantId,
+  policyExposure: {},
+  policyTemplates: [],
+  secretRoutePresets: [],
+  approvalConfig: {},
+  featureFlags: {},
+});
+
 // ─── GET /tenants/config — public discovery for the default tenant ────────────
 
 /**
@@ -36,24 +45,9 @@ export const tenantConfigRoutes = new Hono<{ Variables: AppVariables }>();
  * the literal segment over the parameterised one.
  */
 tenantConfigRoutes.get("/config", async (c) => {
-  const defaultConfig = DEFAULT_TENANT_CONFIGS.default;
-  if (defaultConfig) {
-    return c.json<ApiResponse<TenantControlPlaneConfig>>({
-      ok: true,
-      data: defaultConfig,
-    });
-  }
-  const emptyConfig: TenantControlPlaneConfig = {
-    tenantId: "default",
-    policyExposure: {},
-    policyTemplates: [],
-    secretRoutePresets: [],
-    approvalConfig: {},
-    featureFlags: {},
-  };
   return c.json<ApiResponse<TenantControlPlaneConfig>>({
     ok: true,
-    data: emptyConfig,
+    data: DEFAULT_TENANT_CONFIGS.default ?? emptyTenantConfig("default"),
   });
 });
 

--- a/packages/api/src/routes/tenants.ts
+++ b/packages/api/src/routes/tenants.ts
@@ -90,7 +90,13 @@ tenantRoutes.post("/", async (c) => {
   });
 });
 
-tenantRoutes.get("/:id", (c) => {
+tenantRoutes.get("/:id", async (c, next) => {
+  // /tenants/config is a public discovery endpoint handled by tenantConfigRoutes.
+  // Fall through so its registered handler runs instead of treating "config"
+  // as a tenant id (which crashes because no tenant context was attached).
+  if (c.req.param("id") === "config") {
+    return next();
+  }
   const tenant = c.get("tenant");
   return c.json<ApiResponse<Tenant & TenantConfig>>({
     ok: true,

--- a/packages/api/src/routes/tenants.ts
+++ b/packages/api/src/routes/tenants.ts
@@ -5,7 +5,7 @@
  */
 
 import { hashApiKey } from "@stwd/auth";
-import { Hono } from "hono";
+import { type Context, Hono, type Next } from "hono";
 import {
   type ApiResponse,
   type AppVariables,
@@ -18,11 +18,19 @@ import {
   safeJsonParse,
   type Tenant,
   type TenantConfig,
+  tenantAuth,
   tenantConfigs,
   tenants,
 } from "../services/context";
 
 export const tenantRoutes = new Hono<{ Variables: AppVariables }>();
+
+// Per-route auth that pins the JWT's tenantId to the URL :id path param.
+// Applied directly on handlers below so the "public discovery" route in
+// tenantConfigRoutes (mounted before this router) doesn't need a magic-string
+// skip in a catch-all middleware.
+export const requireTenantId = (c: Context<{ Variables: AppVariables }>, next: Next) =>
+  tenantAuth(c, next, { requireTenantMatch: c.req.param("id") });
 
 tenantRoutes.post("/", async (c) => {
   const body = await safeJsonParse<{
@@ -90,13 +98,7 @@ tenantRoutes.post("/", async (c) => {
   });
 });
 
-tenantRoutes.get("/:id", async (c, next) => {
-  // /tenants/config is a public discovery endpoint handled by tenantConfigRoutes.
-  // Fall through so its registered handler runs instead of treating "config"
-  // as a tenant id (which crashes because no tenant context was attached).
-  if (c.req.param("id") === "config") {
-    return next();
-  }
+tenantRoutes.get("/:id", requireTenantId, async (c) => {
   const tenant = c.get("tenant");
   return c.json<ApiResponse<Tenant & TenantConfig>>({
     ok: true,
@@ -104,7 +106,7 @@ tenantRoutes.get("/:id", async (c, next) => {
   });
 });
 
-tenantRoutes.put("/:id/webhook", async (c) => {
+tenantRoutes.put("/:id/webhook", requireTenantId, async (c) => {
   const tenant = c.get("tenant");
   const tenantConfig = c.get("tenantConfig");
   const body = await safeJsonParse<{


### PR DESCRIPTION
## TL;DR

Two adjacent improvements to the API auth surface that fell out of integrating Steward with eliza-cloud's mini-app marketplace:

1. **Public discovery endpoints**: \`GET /auth/providers\` and \`GET /tenants/config\` so a downstream client (e.g. \`@stwd/sdk\`'s \`<StewardLogin>\` component) can fetch which auth methods are enabled and the default-tenant policy/theme/feature-flag config **before the user has signed in**. Previously the SDK tried these and got 404s, so the login UI showed nothing.
2. **Per-route tenant auth**: replaced the catch-all \`app.use(\"/tenants/:id\", tenantAuth)\` middleware (which had to special-case \`id === \"config\"\` with a magic-string skip) with explicit \`requireTenantId\` middleware on each handler that needs it. Cleaner, no global rule with carve-outs.

## What changed

### \`GET /auth/providers\` (new, public)
Returns which sign-in methods this server offers:

\`\`\`json
{
  \"ok\": true,
  \"data\": {
    \"passkey\": true,
    \"email\": true,
    \"siwe\": true,
    \"siws\": true,
    \"google\": false,
    \"discord\": false,
    \"github\": false,
    \"oauth\": []
  }
}
\`\`\`

OAuth providers are advertised only when their corresponding \`STEWARD_OAUTH_<PROVIDER>_CLIENT_ID\` env var is set, so a stripped-down deployment honestly reports what it supports rather than offering a broken Google button.

### \`GET /tenants/config\` (new, public)
Public default-tenant discovery — returns the \`TenantControlPlaneConfig\` for \`DEFAULT_TENANT_ID\` (policy templates, theme, feature flags). Pure config, never PII, no DB read. Used by \`@stwd/sdk\`'s React provider to bootstrap a sign-in UI before the user authenticates.

### Per-route auth refactor
Before:
\`\`\`ts
// index.ts — catch-all middleware with magic-string skip
app.use(\"/tenants/:id\", (c, next) => {
  const id = c.req.param(\"id\");
  if (id === \"config\" && c.req.method === \"GET\") return next(); // ← public discovery dodge
  return tenantAuth(c, next, { requireTenantMatch: id });
});
app.use(\"/tenants/:id/webhook\", ...);
app.use(\"/tenants/:id/config\", ...);
app.use(\"/tenants/:id/config/*\", ...);
\`\`\`

Plus a fall-through inside \`tenants.ts\`'s GET handler to defer when \`id === \"config\"\`.

After:
\`\`\`ts
// tenants.ts — small per-route helper
export const requireTenantId = (c, next) =>
  tenantAuth(c, next, { requireTenantMatch: c.req.param(\"id\") });

tenantRoutes.get(\"/:id\", requireTenantId, async (c) => { ... });
tenantRoutes.put(\"/:id/webhook\", requireTenantId, async (c) => { ... });
\`\`\`

And mount the public discovery router **before** the wildcard router in \`index.ts\` so Hono's matcher prefers the literal \`/config\` segment:

\`\`\`ts
app.route(\"/tenants\", tenantConfigRoutes);  // /config wins
app.route(\"/tenants\", tenantRoutes);        // /:id catches the rest
\`\`\`

The catch-all middleware is gone. Each handler declares its own auth requirement; the public discovery handler doesn't need to be excluded by name in a global rule.

Also collapsed the duplicated empty \`TenantControlPlaneConfig\` literal in \`tenant-config.ts\` down to one \`emptyTenantConfig(tenantId)\` helper.

## Verification
\`\`\`
GET /auth/providers          → 200 (public, no auth)
GET /tenants/config          → 200 (public, no auth — default tenant config)
GET /tenants/abc             → 403 (auth required, tenant mismatch)
GET /tenants/abc/config      → 403 (auth required, tenant mismatch)
\`\`\`

## Migration notes

- **No breaking changes** for existing authed routes. \`requireTenantMatch\` semantics are identical; just the placement moves from a catch-all to per-handler.
- **No DB changes**.
- **No new env vars**. (Optional: setting \`STEWARD_OAUTH_GOOGLE_CLIENT_ID\` etc. flips the corresponding boolean in \`/auth/providers\` to true.)
- The \`StewardProviders\` shape returned by \`/auth/providers\` matches the \`StewardProviders\` interface that \`@stwd/sdk\` already declares — frontend code that uses \`getProviders()\` will start working without changes.

## What I want maintainer eyes on
- Whether \`/tenants/config\` (public) and \`/tenants/:id/config\` (auth-gated) sharing the \`/tenants\` mount is OK with the upstream router-versioning plan, or if you'd prefer the public discovery to live under a separate \`/discovery/*\` namespace.
- The \`StewardProviders\` response type is currently inlined as a Hono \`ApiResponse<{ ... }>\` because the interface lives in \`@stwd/sdk\` (downstream). If you want the canonical type to live in \`@stwd/shared\` and be imported here, happy to do that as a follow-up.

## Test plan
- [ ] \`curl https://eliza.steward.fi/auth/providers\` returns 200 with the expected shape
- [ ] \`curl https://eliza.steward.fi/tenants/config\` returns 200 with the default tenant's config (or empty config if not seeded)
- [ ] An unauthenticated request to \`/tenants/<some-real-id>\` still gets 403
- [ ] An authenticated request with the correct tenant scope still gets 200