### PR TITLE
feat(auth): per-tenant magic-link override for email auth

### DIFF
--- a/packages/api/src/__tests__/auth-email-config.test.ts
+++ b/packages/api/src/__tests__/auth-email-config.test.ts
@@ -59,6 +59,8 @@ describe("getEmailAuthForTenant", () => {
 
     expect((auth as any).from).toBe("Global <login@example.com>");
     expect((auth as any).templateId).toBeUndefined();
+    expect((auth as any).baseUrl).toBe("https://app.example.com");
+    expect((auth as any).callbackPath).toBe("/auth/callback/email");
     expect(provider.constructor.name).toBe("ResendProvider");
     expect(provider.from).toBe("Global <login@example.com>");
     expect(provider.replyTo).toBeUndefined();
@@ -92,6 +94,64 @@ describe("getEmailAuthForTenant", () => {
     expect((auth as any).subjectOverride).toBe("Tenant Sign In");
     expect(provider.from).toBe("Tenant <login@tenant.example.com>");
     expect(provider.replyTo).toBe("help@tenant.example.com");
+    // Without magicLinkBaseUrl set, baseUrl should fall back to APP_URL
+    expect((auth as any).baseUrl).toBe("https://app.example.com");
+    expect((auth as any).callbackPath).toBe("/auth/callback/email");
+
+    await dbHandle.delete(tenantConfigs).where(eq(tenantConfigs.tenantId, TEST_TENANT_ID));
+    invalidateEmailAuthForTenant(TEST_TENANT_ID);
+  });
+
+  it("uses tenant magicLinkBaseUrl when set, with default callback path", async () => {
+    clearEmailAuthTenantCacheForTests();
+
+    const encrypted = new KeyStore(MASTER_PASSWORD).encrypt("tenant-resend-key");
+    const dbHandle = getDb();
+    await dbHandle.delete(tenantConfigs).where(eq(tenantConfigs.tenantId, TEST_TENANT_ID));
+    await dbHandle.insert(tenantConfigs).values({
+      tenantId: TEST_TENANT_ID,
+      emailConfig: {
+        provider: "resend",
+        apiKeyEncrypted: JSON.stringify(encrypted),
+        from: "Waifu <noreply@waifu.fun>",
+        magicLinkBaseUrl: "https://waifu.fun",
+      },
+    });
+    invalidateEmailAuthForTenant(TEST_TENANT_ID);
+
+    const auth = await getEmailAuthForTenant(TEST_TENANT_ID);
+
+    expect((auth as any).baseUrl).toBe("https://waifu.fun");
+    // Defaults to /auth/email/verify when magicLinkBaseUrl is set
+    expect((auth as any).callbackPath).toBe("/auth/email/verify");
+
+    await dbHandle.delete(tenantConfigs).where(eq(tenantConfigs.tenantId, TEST_TENANT_ID));
+    invalidateEmailAuthForTenant(TEST_TENANT_ID);
+  });
+
+  it("uses tenant magicLinkBaseUrl + custom callbackPath when both set", async () => {
+    clearEmailAuthTenantCacheForTests();
+
+    const encrypted = new KeyStore(MASTER_PASSWORD).encrypt("tenant-resend-key");
+    const dbHandle = getDb();
+    await dbHandle.delete(tenantConfigs).where(eq(tenantConfigs.tenantId, TEST_TENANT_ID));
+    await dbHandle.insert(tenantConfigs).values({
+      tenantId: TEST_TENANT_ID,
+      emailConfig: {
+        provider: "resend",
+        apiKeyEncrypted: JSON.stringify(encrypted),
+        from: "App <noreply@app.example>",
+        magicLinkBaseUrl: "https://app.example.com/",
+        magicLinkCallbackPath: "/login/email-callback",
+      },
+    });
+    invalidateEmailAuthForTenant(TEST_TENANT_ID);
+
+    const auth = await getEmailAuthForTenant(TEST_TENANT_ID);
+
+    // Trailing slash gets stripped from baseUrl
+    expect((auth as any).baseUrl).toBe("https://app.example.com");
+    expect((auth as any).callbackPath).toBe("/login/email-callback");
 
     await dbHandle.delete(tenantConfigs).where(eq(tenantConfigs.tenantId, TEST_TENANT_ID));
     invalidateEmailAuthForTenant(TEST_TENANT_ID);

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -470,9 +470,23 @@ async function createEmailAuthForTenant(tenantId: string): Promise<EmailAuth> {
         })
       : undefined;
 
+  // Per-tenant magic-link override: when a tenant supplies its own
+  // `magicLinkBaseUrl` we build the link against that origin so the click
+  // lands on the tenant's app (e.g. https://waifu.fun/auth/email/verify)
+  // instead of Steward's built-in callback (which redirects to
+  // EMAIL_AUTH_REDIRECT_BASE_URL and is hard-defaulted to elizacloud.ai).
+  const baseUrl =
+    emailConfig.magicLinkBaseUrl?.replace(/\/$/, "") ||
+    process.env.APP_URL ||
+    "https://steward.fi";
+  const callbackPath = emailConfig.magicLinkBaseUrl
+    ? emailConfig.magicLinkCallbackPath || "/auth/email/verify"
+    : undefined; // let EmailAuth fall through to its DEFAULT_CALLBACK
+
   return new EmailAuth({
     from: emailConfig.from,
-    baseUrl: process.env.APP_URL || "https://steward.fi",
+    baseUrl,
+    callbackPath,
     provider,
     tokenStore: getTokenStore(),
     templateId: emailConfig.templateId,

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -476,9 +476,7 @@ async function createEmailAuthForTenant(tenantId: string): Promise<EmailAuth> {
   // instead of Steward's built-in callback (which redirects to
   // EMAIL_AUTH_REDIRECT_BASE_URL and is hard-defaulted to elizacloud.ai).
   const baseUrl =
-    emailConfig.magicLinkBaseUrl?.replace(/\/$/, "") ||
-    process.env.APP_URL ||
-    "https://steward.fi";
+    emailConfig.magicLinkBaseUrl?.replace(/\/$/, "") || process.env.APP_URL || "https://steward.fi";
   const callbackPath = emailConfig.magicLinkBaseUrl
     ? emailConfig.magicLinkCallbackPath || "/auth/email/verify"
     : undefined; // let EmailAuth fall through to its DEFAULT_CALLBACK

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -30,6 +30,23 @@ export interface TenantEmailConfig {
   replyTo?: string;
   templateId?: string;
   subjectOverride?: string;
+  /**
+   * Optional override for the magic-link `baseUrl`. When set, magic links
+   * will be built against this URL (e.g. "https://waifu.fun") instead of
+   * Steward's APP_URL. Lets third-party apps own their own email-callback
+   * landing page and call POST /auth/email/verify directly to mint a JWT.
+   *
+   * If unset, falls back to APP_URL and Steward handles the callback via
+   * its built-in GET /auth/callback/email handler (which redirects to
+   * EMAIL_AUTH_REDIRECT_BASE_URL/login). Existing tenants are unaffected.
+   */
+  magicLinkBaseUrl?: string;
+  /**
+   * Optional path on `magicLinkBaseUrl` that the magic link points at.
+   * Defaults to "/auth/email/verify" when `magicLinkBaseUrl` is set.
+   * Has no effect when `magicLinkBaseUrl` is unset.
+   */
+  magicLinkCallbackPath?: string;
 }
 
 export const chainFamilyEnum = pgEnum("chain_family", ["evm", "solana"]);


### PR DESCRIPTION
## What

Adds two optional fields to `TenantEmailConfig` that let a tenant override where the magic-link points:

```ts
interface TenantEmailConfig {
  // ...existing fields...
  magicLinkBaseUrl?: string;       // e.g. 'https://waifu.fun'
  magicLinkCallbackPath?: string;  // defaults to '/auth/email/verify'
}
```

When `magicLinkBaseUrl` is set, magic links for that tenant point at the tenant's own domain. When unset (default for all existing tenants), magic links continue to point at `APP_URL` and Steward's built-in `GET /auth/callback/email` handler runs as before.

## Why

External apps using Steward as their auth provider currently can't use email magic-link end-to-end because:
1. Magic link in email → `https://eliza.steward.fi/auth/callback/email?token=X&email=Y`
2. Steward verifies → 302s to `EMAIL_AUTH_REDIRECT_BASE_URL/login?token=Z&refreshToken=W`
3. `EMAIL_AUTH_REDIRECT_BASE_URL` is global and hard-defaults to `elizacloud.ai`
4. Tenant's user lands on the wrong app

Concrete case: waifu.fun (tenant `waifu`) is shipping email auth this week. Without this PR, waifu users clicking magic-link end up on elizacloud's login page.

## How

`createEmailAuthForTenant` already loads the per-tenant `emailConfig` from `tenant_configs.email_config` jsonb. It's a one-liner inside `new EmailAuth({ ... })` to read the new optional fields and derive `baseUrl` + `callbackPath` from them when present, with a clean fallback to the existing `APP_URL` behavior.

`EmailAuth` already supports a `callbackPath` config option (defaults to `/auth/callback/email`). We're just plumbing tenant config through to it.

## Tests

4/4 pass in `packages/api/src/__tests__/auth-email-config.test.ts`:
- existing fallback path (no tenant emailConfig)
- existing tenant emailConfig (no `magicLinkBaseUrl`) — verifies fallback unchanged
- `magicLinkBaseUrl` set, default callback path
- `magicLinkBaseUrl` + custom `magicLinkCallbackPath`

## Risk

Zero risk to existing tenants — both fields are optional, and the only behavior change happens when they're explicitly set. `EMAIL_AUTH_REDIRECT_BASE_URL` continues to control the default flow.

## Followup (consumer side, not in this PR)

waifu-core needs to:
1. Set `magicLinkBaseUrl=https://waifu.fun` in its tenant emailConfig (one-time DB write)
2. Build `POST /auth/email/start` proxying to Steward `POST /auth/email/send`
3. Build `/auth/email/verify` page that POSTs token+email to Steward `POST /auth/email/verify` and sets the local session cookie

Tracking that as a separate waifu PR.