### PR TITLE
feat(auth): magic-link override works without per-tenant Resend creds

### DIFF
--- a/packages/api/src/__tests__/auth-email-config.test.ts
+++ b/packages/api/src/__tests__/auth-email-config.test.ts
@@ -156,4 +156,34 @@ describe("getEmailAuthForTenant", () => {
     await dbHandle.delete(tenantConfigs).where(eq(tenantConfigs.tenantId, TEST_TENANT_ID));
     invalidateEmailAuthForTenant(TEST_TENANT_ID);
   });
+
+  it("uses global Resend creds + per-tenant magicLinkBaseUrl when no apiKeyEncrypted", async () => {
+    clearEmailAuthTenantCacheForTests();
+
+    const dbHandle = getDb();
+    await dbHandle.delete(tenantConfigs).where(eq(tenantConfigs.tenantId, TEST_TENANT_ID));
+    // Magic-link-only tenant config (no per-tenant Resend key).
+    // This is the waifu.fun shape: tenant doesn't bring its own Resend
+    // account, just wants its own magic-link landing URL.
+    await dbHandle.insert(tenantConfigs).values({
+      tenantId: TEST_TENANT_ID,
+      emailConfig: {
+        magicLinkBaseUrl: "https://waifu.fun",
+      },
+    });
+    invalidateEmailAuthForTenant(TEST_TENANT_ID);
+
+    const auth = await getEmailAuthForTenant(TEST_TENANT_ID);
+    const provider = (auth as any).provider;
+
+    // Magic-link target overridden to the tenant's domain
+    expect((auth as any).baseUrl).toBe("https://waifu.fun");
+    expect((auth as any).callbackPath).toBe("/auth/email/verify");
+    // Provider falls back to the global Resend key
+    expect(provider.constructor.name).toBe("ResendProvider");
+    expect(provider.from).toBe("Global <login@example.com>");
+
+    await dbHandle.delete(tenantConfigs).where(eq(tenantConfigs.tenantId, TEST_TENANT_ID));
+    invalidateEmailAuthForTenant(TEST_TENANT_ID);
+  });
 });

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -401,7 +401,7 @@ function getEmailKeyStore(): KeyStore {
   return _emailKeyStore;
 }
 
-function buildGlobalEmailAuth(): EmailAuth {
+function buildGlobalEmailAuth(overrides?: { baseUrl?: string; callbackPath?: string }): EmailAuth {
   const resendKey = process.env.RESEND_API_KEY;
   const provider = resendKey
     ? new ResendProvider({
@@ -412,7 +412,8 @@ function buildGlobalEmailAuth(): EmailAuth {
 
   return new EmailAuth({
     from: process.env.EMAIL_FROM || "login@steward.fi",
-    baseUrl: process.env.APP_URL || "https://steward.fi",
+    baseUrl: overrides?.baseUrl?.replace(/\/$/, "") || process.env.APP_URL || "https://steward.fi",
+    callbackPath: overrides?.callbackPath,
     provider,
     tokenStore: getTokenStore(),
   });
@@ -455,34 +456,47 @@ async function loadTenantEmailConfig(tenantId: string): Promise<TenantEmailConfi
 
 async function createEmailAuthForTenant(tenantId: string): Promise<EmailAuth> {
   const emailConfig = await loadTenantEmailConfig(tenantId);
-  if (!emailConfig) {
-    return buildGlobalEmailAuth();
-  }
-
-  const provider =
-    emailConfig.provider === "resend"
-      ? new ResendProvider({
-          apiKey: getEmailKeyStore().decrypt(
-            parseEncryptedEmailApiKey(emailConfig.apiKeyEncrypted),
-          ),
-          from: emailConfig.from,
-          replyTo: emailConfig.replyTo,
-        })
-      : undefined;
 
   // Per-tenant magic-link override: when a tenant supplies its own
   // `magicLinkBaseUrl` we build the link against that origin so the click
   // lands on the tenant's app (e.g. https://waifu.fun/auth/email/verify)
   // instead of Steward's built-in callback (which redirects to
   // EMAIL_AUTH_REDIRECT_BASE_URL and is hard-defaulted to elizacloud.ai).
-  const baseUrl =
-    emailConfig.magicLinkBaseUrl?.replace(/\/$/, "") || process.env.APP_URL || "https://steward.fi";
-  const callbackPath = emailConfig.magicLinkBaseUrl
-    ? emailConfig.magicLinkCallbackPath || "/auth/email/verify"
+  const magicLinkBaseUrl = emailConfig?.magicLinkBaseUrl;
+  const callbackPath = magicLinkBaseUrl
+    ? emailConfig?.magicLinkCallbackPath || "/auth/email/verify"
     : undefined; // let EmailAuth fall through to its DEFAULT_CALLBACK
 
+  if (!emailConfig || !emailConfig.apiKeyEncrypted) {
+    // No per-tenant Resend config (or only magic-link override) — use the
+    // global env-backed provider but still honor the per-tenant magic-link
+    // overrides if present.
+    return buildGlobalEmailAuth({
+      baseUrl: magicLinkBaseUrl,
+      callbackPath,
+    });
+  }
+
+  // We've already returned via buildGlobalEmailAuth above when apiKeyEncrypted
+  // is missing, so it's safe to assume `emailConfig.from + apiKeyEncrypted`
+  // are both present here.
+  const from = emailConfig.from || process.env.EMAIL_FROM || "login@steward.fi";
+  const provider =
+    emailConfig.provider === "resend" && emailConfig.apiKeyEncrypted
+      ? new ResendProvider({
+          apiKey: getEmailKeyStore().decrypt(
+            parseEncryptedEmailApiKey(emailConfig.apiKeyEncrypted),
+          ),
+          from,
+          replyTo: emailConfig.replyTo,
+        })
+      : undefined;
+
+  const baseUrl =
+    magicLinkBaseUrl?.replace(/\/$/, "") || process.env.APP_URL || "https://steward.fi";
+
   return new EmailAuth({
-    from: emailConfig.from,
+    from,
     baseUrl,
     callbackPath,
     provider,

--- a/packages/api/src/routes/platform.ts
+++ b/packages/api/src/routes/platform.ts
@@ -422,11 +422,13 @@ platform.get("/tenants/:tenantId/email-config", async (c) => {
   return c.json<
     ApiResponse<{
       emailConfig: {
-        provider: "resend";
-        from: string;
+        provider?: "resend";
+        from?: string;
         replyTo?: string;
         templateId?: string;
         subjectOverride?: string;
+        magicLinkBaseUrl?: string;
+        magicLinkCallbackPath?: string;
       } | null;
       hasApiKey: boolean;
     }>
@@ -440,6 +442,8 @@ platform.get("/tenants/:tenantId/email-config", async (c) => {
             replyTo: emailConfig.replyTo,
             templateId: emailConfig.templateId,
             subjectOverride: emailConfig.subjectOverride,
+            magicLinkBaseUrl: emailConfig.magicLinkBaseUrl,
+            magicLinkCallbackPath: emailConfig.magicLinkCallbackPath,
           },
           hasApiKey: Boolean(emailConfig.apiKeyEncrypted),
         }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -24,9 +24,14 @@ import {
 } from "drizzle-orm/pg-core";
 
 export interface TenantEmailConfig {
-  provider: "resend";
-  apiKeyEncrypted: string;
-  from: string;
+  /**
+   * Per-tenant Resend provider config. Optional — a tenant can also leave
+   * this entirely empty and only set `magicLinkBaseUrl` to override the
+   * magic-link target while continuing to use the global RESEND_API_KEY.
+   */
+  provider?: "resend";
+  apiKeyEncrypted?: string;
+  from?: string;
   replyTo?: string;
   templateId?: string;
   subjectOverride?: string;


### PR DESCRIPTION
Follow-up to #28.

The original PR required a tenant to bring its own Resend account (`apiKeyEncrypted` + `provider` + `from`) in order to override `magicLinkBaseUrl`. That's the wrong shape for tenants who just want a different magic-link target URL but are happy using the global Steward Resend account (e.g. waifu.fun).

## Changes
- `TenantEmailConfig.{provider, apiKeyEncrypted, from}` are now optional
- `createEmailAuthForTenant()` falls through to `buildGlobalEmailAuth()` when `apiKeyEncrypted` is missing, but still passes the per-tenant `magicLinkBaseUrl` + `callbackPath` overrides through
- `buildGlobalEmailAuth()` accepts optional `{baseUrl, callbackPath}` overrides
- `GET /platform/tenants/:id/email-config` response now exposes `magicLinkBaseUrl` + `magicLinkCallbackPath` for management UIs

## Tests
5/5 pass (4 existing + 1 new for the magic-link-only case).

## Backward compat
- Tenants with full per-tenant Resend config: **unchanged**
- Tenants with no `email_config` row at all: **unchanged** (still fall through to global)
- New: tenants with `email_config = {magicLinkBaseUrl: '...'}` now work