### PR TITLE
feat(passkey): allow callers to hint authenticatorAttachment

### DIFF
--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -1300,7 +1300,10 @@ auth.delete("/sessions", async (c) => {
  * Finds or creates user, returns WebAuthn registration options.
  */
 auth.post("/passkey/register/options", async (c) => {
-  const body = await safeJsonParse<{ email: string }>(c);
+  const body = await safeJsonParse<{
+    email: string;
+    authenticatorAttachment?: "platform" | "cross-platform";
+  }>(c);
   if (!body?.email) {
     return c.json<ApiResponse>({ ok: false, error: "email is required" }, 400);
   }
@@ -1314,10 +1317,16 @@ auth.post("/passkey/register/options", async (c) => {
     .from(authenticators)
     .where(eq(authenticators.userId, user.id));
 
+  const attachment =
+    body.authenticatorAttachment === "platform" || body.authenticatorAttachment === "cross-platform"
+      ? body.authenticatorAttachment
+      : undefined;
+
   const options = await getPasskeyAuth(c.req.header("origin")).generateRegistrationOptions(
     user.id,
     email,
     existingCreds.map((cred) => cred.credentialId),
+    attachment ? { authenticatorAttachment: attachment } : undefined,
   );
 
   return c.json(options);

--- a/packages/auth/src/passkey.ts
+++ b/packages/auth/src/passkey.ts
@@ -90,8 +90,19 @@ export class PasskeyAuth {
     userId: string,
     email: string,
     existingCredentials: string[] = [],
+    options?: {
+      /**
+       * Hint to the browser about which authenticator to prefer.
+       *   - "platform":      built-in (Touch ID, Face ID, Windows Hello)
+       *   - "cross-platform": roaming (YubiKey, phone-QR, security key)
+       *   - undefined:        let the browser pick (shows both)
+       *
+       * Most consumer apps want "platform" so the OS surfaces native UX.
+       */
+      authenticatorAttachment?: "platform" | "cross-platform";
+    },
   ): Promise<PublicKeyCredentialCreationOptionsJSON> {
-    const options = await swGenReg({
+    const regOptions = await swGenReg({
       rpName: this.config.rpName,
       rpID: this.config.rpID,
       userName: email,
@@ -108,13 +119,16 @@ export class PasskeyAuth {
       authenticatorSelection: {
         residentKey: "preferred",
         userVerification: "preferred",
+        ...(options?.authenticatorAttachment
+          ? { authenticatorAttachment: options.authenticatorAttachment }
+          : {}),
       },
     });
 
     // Store the challenge so we can verify it later
-    this.challenges.set(userId, options.challenge);
+    this.challenges.set(userId, regOptions.challenge);
 
-    return options;
+    return regOptions;
   }
 
   /**


### PR DESCRIPTION
## What

Adds optional `authenticatorAttachment` to `PasskeyAuth.generateRegistrationOptions()` + `POST /passkey/register/options` body.

## Why

Without `authenticatorAttachment`, desktop Safari/Chrome shows the generic OS 'Passkeys & Security Keys' picker (QR + security key) for registration. Most consumer apps want `"platform"` so the OS surfaces native UX (Touch ID, Face ID, Windows Hello).

## Repro on waifu.fun

User clicks 'continue with passkey' on Mac Safari → currently sees the QR/security-key picker even though they have iCloud Keychain Touch ID. Should default to Touch ID prompt instead.

## Backward compat

- New 4th positional arg on `generateRegistrationOptions()` is optional
- New `authenticatorAttachment` body field on `POST /passkey/register/options` is optional
- Default behavior unchanged when caller doesn't pass anything

## Followup

waifu.fun (sibling PR) will pass `authenticatorAttachment: "platform"` from the modal. ElizaCloud already gets the right UX (likely because their flow is set up differently or browser already has a synced passkey).