### PR TITLE
fix(auth): platform passkey UX + advertise OAuth providers correctly

### DIFF
--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -43,6 +43,7 @@
 // If any of these fail at runtime on Workers, fall back to tweetnacl for
 // ed25519 verify (lightweight, edge-compatible).
 import { createPublicKey, randomBytes, verify as verifySignature } from "node:crypto";
+import type { AuthenticatorTransportFuture } from "@stwd/auth";
 import {
   assertTokenNotRevoked,
   buildBackend,
@@ -1099,15 +1100,21 @@ const auth = new Hono();
  * server so a client SDK (e.g. @stwd/sdk) can render the right sign-in UI.
  *
  * Passkey/email/SIWE/SIWS are always wired in this build. OAuth providers are
- * advertised only when their corresponding STEWARD_OAUTH_<PROVIDER>_CLIENT_ID
- * env var is present, so a stripped-down deployment honestly reports what it
- * supports rather than offering a broken Google button.
+ * advertised when their credentials are configured.
+ *
+ * Env var resolution mirrors `getProviderConfig` in @stwd/auth/oauth.ts: the
+ * canonical names are `<PROVIDER>_CLIENT_ID` / `<PROVIDER>_CLIENT_SECRET`.
+ * `STEWARD_OAUTH_<PROVIDER>_CLIENT_ID` is also accepted for backwards-compat
+ * with older deployments. Reading only the prefixed form caused production
+ * to advertise OAuth as disabled even though the underlying authorize
+ * endpoints had working credentials.
  */
 auth.get("/providers", (c) => {
   const oauthClientIds: Record<string, string | undefined> = {
-    google: process.env.STEWARD_OAUTH_GOOGLE_CLIENT_ID,
-    discord: process.env.STEWARD_OAUTH_DISCORD_CLIENT_ID,
-    github: process.env.STEWARD_OAUTH_GITHUB_CLIENT_ID,
+    google: process.env.GOOGLE_CLIENT_ID || process.env.STEWARD_OAUTH_GOOGLE_CLIENT_ID,
+    discord: process.env.DISCORD_CLIENT_ID || process.env.STEWARD_OAUTH_DISCORD_CLIENT_ID,
+    github: process.env.GITHUB_CLIENT_ID || process.env.STEWARD_OAUTH_GITHUB_CLIENT_ID,
+    twitter: process.env.TWITTER_CLIENT_ID || process.env.STEWARD_OAUTH_TWITTER_CLIENT_ID,
   };
   const oauth = Object.entries(oauthClientIds)
     .filter(([, value]) => typeof value === "string" && value.trim().length > 0)
@@ -1122,6 +1129,7 @@ auth.get("/providers", (c) => {
       google: boolean;
       discord: boolean;
       github: boolean;
+      twitter: boolean;
       oauth: string[];
     }>
   >({
@@ -1134,6 +1142,7 @@ auth.get("/providers", (c) => {
       google: oauth.includes("google"),
       discord: oauth.includes("discord"),
       github: oauth.includes("github"),
+      twitter: oauth.includes("twitter"),
       oauth,
     },
   });
@@ -1650,8 +1659,16 @@ auth.post("/passkey/login/options", async (c) => {
     return c.json<ApiResponse>({ ok: false, error: "No account found for this email" }, 404);
   }
 
+  // Select transports alongside credentialId. WebAuthn browsers use the
+  // transports hint to know that a credential lives on the local platform
+  // authenticator (e.g. Touch ID, Windows Hello). Without it the browser
+  // conservatively shows the cross-device QR picker even for credentials
+  // that were registered on this device, which is a major UX regression.
   const creds = await db
-    .select({ credentialId: authenticators.credentialId })
+    .select({
+      credentialId: authenticators.credentialId,
+      transports: authenticators.transports,
+    })
     .from(authenticators)
     .where(eq(authenticators.userId, user.id));
 
@@ -1662,7 +1679,12 @@ auth.post("/passkey/login/options", async (c) => {
   const options = await getPasskeyAuth(c.req.header("origin")).generateAuthenticationOptions(
     email,
     {
-      allowCredentials: creds.map((cred) => ({ id: cred.credentialId })),
+      allowCredentials: creds.map((cred) => ({
+        id: cred.credentialId,
+        ...(cred.transports && cred.transports.length > 0
+          ? { transports: cred.transports as AuthenticatorTransportFuture[] }
+          : {}),
+      })),
     },
   );
 

--- a/packages/auth/src/passkey.ts
+++ b/packages/auth/src/passkey.ts
@@ -11,6 +11,7 @@
 
 import type {
   AuthenticationResponseJSON,
+  AuthenticatorTransportFuture,
   PublicKeyCredentialCreationOptionsJSON,
   PublicKeyCredentialRequestOptionsJSON,
   RegistrationResponseJSON,
@@ -28,6 +29,7 @@ export type {
 } from "@simplewebauthn/server";
 export type {
   AuthenticationResponseJSON,
+  AuthenticatorTransportFuture,
   PublicKeyCredentialCreationOptionsJSON,
   PublicKeyCredentialRequestOptionsJSON,
   RegistrationResponseJSON,
@@ -181,12 +183,27 @@ export class PasskeyAuth {
    */
   async generateAuthenticationOptions(
     email: string,
-    options?: { allowCredentials?: Array<{ id: string }> },
+    options?: {
+      allowCredentials?: Array<{
+        id: string;
+        /**
+         * Stored transports for this credential. Including these is what
+         * tells the browser the credential lives on the local platform
+         * authenticator (e.g. Touch ID) vs roaming (e.g. phone via QR). When
+         * omitted, browsers conservatively show the QR/cross-device picker
+         * even for credentials that were registered on this device.
+         */
+        transports?: AuthenticatorTransportFuture[];
+      }>;
+    },
   ): Promise<PublicKeyCredentialRequestOptionsJSON> {
     const authOptions = await swGenAuth({
       rpID: this.config.rpID,
       userVerification: "preferred",
-      allowCredentials: options?.allowCredentials?.map((c) => ({ id: c.id })),
+      allowCredentials: options?.allowCredentials?.map((c) => ({
+        id: c.id,
+        ...(c.transports && c.transports.length > 0 ? { transports: c.transports } : {}),
+      })),
     });
 
     this.challenges.set(email, authOptions.challenge);


### PR DESCRIPTION
Three bugs were preventing Eliza Cloud login from working end-to-end. Reproed against `eliza.steward.fi` from `https://www.elizacloud.ai`.

## 1. Passkey QR fallback instead of Touch ID (the most visible)

`/auth/passkey/login/options` returned `allowCredentials` like this:
```json
{ "id": "1378NSXyIaoaSaXEHo-xag", "type": "public-key" }
```

No `transports` field. WebAuthn browsers use the transports hint to know whether a credential lives on the local platform authenticator (Touch ID / Windows Hello / Face ID). When omitted, the browser conservatively shows the cross-device QR/security-key picker, even for credentials that were registered on the current device.

Symptom: `@stwd/sdk` calls `navigator.credentials.get()` with the server-provided options, browser shows QR, user gets stuck.

Two-line fix:
- `PasskeyAuth.generateAuthenticationOptions` now accepts an optional `transports` per allowed credential and forwards it to `@simplewebauthn/server`.
- `/passkey/login/options` selects `authenticators.transports` from the DB (the column has existed since the schema was first written) and passes it through.

After the fix the response includes `transports: ["internal", "hybrid"]` (or whatever was registered) and the browser surfaces native Touch ID directly.

## 2. /providers advertises OAuth as disabled even when credentials are set

```json
{ "google": false, "discord": false, "github": false, "oauth": [] }
```

Production Railway has `GOOGLE_CLIENT_ID`, `DISCORD_CLIENT_ID`, `GITHUB_CLIENT_ID`, `TWITTER_CLIENT_ID` all set. `getProviderConfig` in `@stwd/auth/oauth.ts` reads those unprefixed names and the `/oauth/:provider/authorize` route works fine. But the `/providers` discovery route was reading `STEWARD_OAUTH_GOOGLE_CLIENT_ID` etc, which aren't set anywhere. SPAs trust `/providers` to decide which buttons to render, so all OAuth buttons were hidden.

Fix: read the canonical unprefixed form first, fall back to `STEWARD_OAUTH_<PROVIDER>_CLIENT_ID` for backwards compat. Mirrors the precedence `getProviderConfig` uses.

## 3. Twitter missing from /providers

Twitter is a registered `BUILT_IN_PROVIDERS` member and `/oauth/twitter/authorize` works, but `/providers` never listed it. Added it.

## Verification

- `bun run typecheck` clean
- `bun test packages/auth` 30 pass / 0 fail
- `bun test packages/api/src/__tests__/auth-email-config.test.ts agent-auth.test.ts` 5 pass / 23 skip
- Manually exercised `/auth/passkey/login/options` + `/auth/providers` against this branch's local build — transports come through, all four OAuth providers advertised when env vars present.

Co-authored-by: wakesync <shadow@shad0w.xyz>