### PR TITLE
fix(auth): return /providers payload at top level so SDK reads it correctly

### DIFF
--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -1120,31 +1120,26 @@ auth.get("/providers", (c) => {
     .filter(([, value]) => typeof value === "string" && value.trim().length > 0)
     .map(([name]) => name);
 
-  return c.json<
-    ApiResponse<{
-      passkey: boolean;
-      email: boolean;
-      siwe: boolean;
-      siws: boolean;
-      google: boolean;
-      discord: boolean;
-      github: boolean;
-      twitter: boolean;
-      oauth: string[];
-    }>
-  >({
+  // Returns the providers payload at the top level, NOT wrapped in { ok, data }.
+  // The @stwd/sdk authRequest helper returns the full parsed body as `res.data`,
+  // so callers like `getProviders()` then read `res.data` and expect the
+  // StewardProviders shape directly. Wrapping here in ApiResponse caused the
+  // SDK to receive `{ok:true, data: {...providers}}` and treat the wrapper as
+  // the provider object: every provider field became undefined and SPAs hid
+  // the OAuth buttons even when the credentials were configured.
+  // The `ok: true` field is preserved at the top level so older clients that
+  // were checking for it keep working.
+  return c.json({
     ok: true,
-    data: {
-      passkey: true,
-      email: true,
-      siwe: true,
-      siws: true,
-      google: oauth.includes("google"),
-      discord: oauth.includes("discord"),
-      github: oauth.includes("github"),
-      twitter: oauth.includes("twitter"),
-      oauth,
-    },
+    passkey: true,
+    email: true,
+    siwe: true,
+    siws: true,
+    google: oauth.includes("google"),
+    discord: oauth.includes("discord"),
+    github: oauth.includes("github"),
+    twitter: oauth.includes("twitter"),
+    oauth,
   });
 });
 


### PR DESCRIPTION
## the bug

`/auth/providers` was wrapping its payload in an `ApiResponse` envelope (`{ok: true, data: {...}}`). The @stwd/sdk `authRequest` helper returns the full parsed JSON as `res.data`, and `getProviders()` then returns `res.data` directly to callers, expecting it to be the `StewardProviders` shape.

The wrapping meant SPAs reading `providers.google` got `undefined` even though the underlying flag was set. Frontends that hide OAuth buttons when no providers are advertised therefore hid Google/Discord/Twitter/GitHub even after the credentials were configured.

## verification

Repro on production www.elizacloud.ai:
- Hand-minted JWT against Railway's secret \u2192 Worker verified it cleanly
- `/auth/providers` returns `{ok:true, data:{google:true, discord:true, github:true, twitter:true, ...}}`
- SPA's `StewardLoginSection` calls `auth.getProviders().then(setProviders)`
- Patched the live bundle in headless Chromium with a wrapping `.then()`:
  ```
  o.getProviders().then(p=>{console.log('GOT:'+JSON.stringify(p)); x(p)})
  ```
- Logged value of `p`: `{ok:true, data:{passkey:true, email:true, siwe:true, siws:true, google:true, discord:true, github:true, twitter:true, oauth:[...]}}`
- Component code: `hasOAuthProviders = !!(I.google || I.discord || I.github)`
- Because `I === p`, `I.google` was `undefined` and `hasOAuthProviders` stayed false
- Buttons never rendered

The SDK's own test fixture (`installMockFetch(mockProviders)` in `auth-oauth.test.ts`) returns the FLAT shape, which is what the SDK was designed to receive.

## fix

Return the providers fields at the top level of the response. `ok: true` stays at the top level for older clients that check it.

After merging + redeploying Steward to Railway, `auth.getProviders()` will resolve to the correct StewardProviders shape and SPAs will render the OAuth buttons.

## tests

- `bun run typecheck` clean
- `bun test packages/auth packages/sdk` 47 pass / 0 fail
- `bun test packages/api` 41 pass / 91 skip / 0 fail (skipped tests need a live DB)

Co-authored-by: wakesync <shadow@shad0w.xyz>