### PR TITLE
feat(react): compose <WalletLogin> into <StewardLogin> behind showWallets prop

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stwd/react",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Embeddable React components for Steward agent wallet management",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/react/src/__tests__/StewardLogin.test.tsx
+++ b/packages/react/src/__tests__/StewardLogin.test.tsx
@@ -15,6 +15,19 @@ const { StewardLogin, composeWalletSuccess, composeWalletError } = await import(
   "../components/StewardLogin.js"
 );
 const { StewardAuthContext } = await import("../provider.js");
+const { registerEvmWalletPanel, registerSolanaWalletPanel, _resetWalletPanelRegistry } =
+  await import("../internal/walletPanelRegistry.js");
+
+// Register dummy panel loaders. The registry isolates root entry from
+// wallet peer deps; tests just need a pair of registered loaders so the
+// `<StewardLogin>` wallet UI gates open. Real loaders live in
+// `@stwd/react/wallet`.
+const dummyPanel = ((): React.ComponentType<unknown> => {
+  return () => null;
+})();
+registerEvmWalletPanel({ load: async () => ({ default: dummyPanel }) });
+registerSolanaWalletPanel({ load: async () => ({ default: dummyPanel }) });
+void _resetWalletPanelRegistry; // silence unused (used in registry-empty tests below)
 
 type AuthCtx = {
   isAuthenticated: boolean;
@@ -236,6 +249,26 @@ describe("<StewardLogin /> showWallets prop", () => {
     expect(html).not.toContain("stwd-login-wallets");
     expect(html).not.toContain("stwd-login-wallet-evm-loading");
     expect(html).not.toContain("stwd-login-wallet-sol-loading");
+  });
+
+  test("empty wallet panel registry hides wallet buttons even when providers report siwe + siws", () => {
+    // Reset the registry to simulate a consumer who imported `@stwd/react`
+    // but not `@stwd/react/wallet`. Without registered loaders, rendering
+    // a wallet button would produce a permanently-disabled placeholder,
+    // which is worse than hiding the button.
+    _resetWalletPanelRegistry();
+    try {
+      const html = renderToString(
+        wrap(baseCtx({}), React.createElement(StewardLogin, { showWallets: true })),
+      );
+      expect(html).not.toContain("stwd-login-wallets");
+      expect(html).not.toContain("stwd-login-wallet-evm-loading");
+      expect(html).not.toContain("stwd-login-wallet-sol-loading");
+    } finally {
+      // Restore for subsequent tests.
+      registerEvmWalletPanel({ load: async () => ({ default: dummyPanel }) });
+      registerSolanaWalletPanel({ load: async () => ({ default: dummyPanel }) });
+    }
   });
 });
 

--- a/packages/react/src/__tests__/StewardLogin.test.tsx
+++ b/packages/react/src/__tests__/StewardLogin.test.tsx
@@ -11,7 +11,9 @@ import { describe, expect, test } from "bun:test";
 import * as React from "react";
 import { renderToString } from "react-dom/server";
 
-const { StewardLogin } = await import("../components/StewardLogin.js");
+const { StewardLogin, composeWalletSuccess, composeWalletError } = await import(
+  "../components/StewardLogin.js"
+);
 const { StewardAuthContext } = await import("../provider.js");
 
 type AuthCtx = {
@@ -19,7 +21,12 @@ type AuthCtx = {
   isLoading: boolean;
   user: null;
   session: null | { token: string; user: { id: string; email: string } };
-  providers: null | { google?: boolean; discord?: boolean };
+  providers: null | {
+    google?: boolean;
+    discord?: boolean;
+    siwe?: boolean;
+    siws?: boolean;
+  };
   isProvidersLoading: boolean;
   signOut: () => void;
   getToken: () => null;
@@ -44,7 +51,7 @@ function baseCtx(overrides: Partial<AuthCtx> = {}): AuthCtx {
     isLoading: false,
     user: null,
     session: null,
-    providers: { google: true, discord: true },
+    providers: { google: true, discord: true, siwe: true, siws: true },
     isProvidersLoading: false,
     signOut: () => {},
     getToken: () => null,
@@ -141,5 +148,142 @@ describe("<StewardLogin /> — rules-of-hooks branch coverage", () => {
         ),
       ),
     ).not.toThrow();
+  });
+});
+
+describe("<StewardLogin /> showWallets prop", () => {
+  // The wallet panels (<WalletLogin.EVM>, <WalletLogin.Solana>) are pulled in
+  // via dynamic import inside an effect, so they do not appear in SSR output.
+  // Instead we assert against the loading-fallback markers (`stwd-login-wallet-evm-loading`
+  // / `stwd-login-wallet-sol-loading`) and the wallet container testid
+  // (`stwd-login-wallets`). This is enough to verify the gating logic without
+  // pulling in jsdom or wagmi/solana mocks (those are exercised by
+  // WalletLogin.test.tsx).
+
+  test("showWallets={true} renders both wallet placeholders when providers report siwe + siws", () => {
+    const html = renderToString(
+      wrap(baseCtx({}), React.createElement(StewardLogin, { showWallets: true })),
+    );
+    expect(html).toContain("stwd-login-wallets");
+    expect(html).toContain("stwd-login-wallet-evm-loading");
+    expect(html).toContain("stwd-login-wallet-sol-loading");
+  });
+
+  test("default (showWallets undefined) renders no wallet buttons", () => {
+    const html = renderToString(wrap(baseCtx({}), React.createElement(StewardLogin, {})));
+    expect(html).not.toContain("stwd-login-wallets");
+    expect(html).not.toContain("stwd-login-wallet-evm-loading");
+    expect(html).not.toContain("stwd-login-wallet-sol-loading");
+  });
+
+  test("showWallets={false} renders no wallet buttons", () => {
+    const html = renderToString(
+      wrap(baseCtx({}), React.createElement(StewardLogin, { showWallets: false })),
+    );
+    expect(html).not.toContain("stwd-login-wallets");
+  });
+
+  test("showWallets={{ evm: true }} renders only EVM", () => {
+    const html = renderToString(
+      wrap(baseCtx({}), React.createElement(StewardLogin, { showWallets: { evm: true } })),
+    );
+    expect(html).toContain("stwd-login-wallets");
+    expect(html).toContain("stwd-login-wallet-evm-loading");
+    expect(html).not.toContain("stwd-login-wallet-sol-loading");
+  });
+
+  test("showWallets={{ solana: true }} renders only Solana", () => {
+    const html = renderToString(
+      wrap(baseCtx({}), React.createElement(StewardLogin, { showWallets: { solana: true } })),
+    );
+    expect(html).toContain("stwd-login-wallets");
+    expect(html).toContain("stwd-login-wallet-sol-loading");
+    expect(html).not.toContain("stwd-login-wallet-evm-loading");
+  });
+
+  test("providers.siwe=false hides EVM even when showWallets={true}", () => {
+    const html = renderToString(
+      wrap(
+        baseCtx({
+          providers: { google: true, discord: true, siwe: false, siws: true },
+        }),
+        React.createElement(StewardLogin, { showWallets: true }),
+      ),
+    );
+    expect(html).toContain("stwd-login-wallets");
+    expect(html).not.toContain("stwd-login-wallet-evm-loading");
+    expect(html).toContain("stwd-login-wallet-sol-loading");
+  });
+
+  test("providers.siws=false hides Solana even when showWallets={true}", () => {
+    const html = renderToString(
+      wrap(
+        baseCtx({
+          providers: { google: true, discord: true, siwe: true, siws: false },
+        }),
+        React.createElement(StewardLogin, { showWallets: true }),
+      ),
+    );
+    expect(html).toContain("stwd-login-wallets");
+    expect(html).toContain("stwd-login-wallet-evm-loading");
+    expect(html).not.toContain("stwd-login-wallet-sol-loading");
+  });
+});
+
+describe("<StewardLogin /> wallet success/error bubbling", () => {
+  // The bubble adapters (`composeWalletSuccess`, `composeWalletError`) are
+  // exported precisely so the contract is testable without spinning up
+  // wagmi/@solana mocks. They mirror what `<StewardLogin>` wires into the
+  // panel `onSuccess` / `onError` props verbatim. The full integration is
+  // exercised end-to-end in WalletLogin.test.tsx (panel-level).
+
+  test("wallet sign success bubbles to onSuccess as { token, user }", () => {
+    let received: { token: string; user: { id: string; email: string } } | null = null;
+    const handler = composeWalletSuccess((res) => {
+      received = res;
+    });
+    handler(
+      {
+        token: "jwt-abc",
+        refreshToken: "refresh-xyz",
+        expiresIn: 900,
+        user: { id: "user-1", email: "a@b.io" },
+      },
+      "evm",
+    );
+    expect(received).not.toBeNull();
+    expect(received!.token).toBe("jwt-abc");
+    expect(received!.user.id).toBe("user-1");
+    expect(received!.user.email).toBe("a@b.io");
+  });
+
+  test("wallet sign success is a no-op when consumer onSuccess is undefined", () => {
+    const handler = composeWalletSuccess(undefined);
+    expect(() =>
+      handler(
+        {
+          token: "t",
+          refreshToken: "r",
+          expiresIn: 900,
+          user: { id: "u", email: "u@x.io" },
+        },
+        "solana",
+      ),
+    ).not.toThrow();
+  });
+
+  test("wallet sign error bubbles to onError", () => {
+    let received: Error | null = null;
+    const handler = composeWalletError((err) => {
+      received = err;
+    });
+    const boom = new Error("user rejected signature");
+    handler(boom, "evm");
+    expect(received).toBe(boom);
+  });
+
+  test("wallet sign error is a no-op when consumer onError is undefined", () => {
+    const handler = composeWalletError(undefined);
+    expect(() => handler(new Error("x"), "solana")).not.toThrow();
   });
 });

--- a/packages/react/src/__tests__/StewardLogin.test.tsx
+++ b/packages/react/src/__tests__/StewardLogin.test.tsx
@@ -228,6 +228,15 @@ describe("<StewardLogin /> showWallets prop", () => {
     expect(html).toContain("stwd-login-wallet-evm-loading");
     expect(html).not.toContain("stwd-login-wallet-sol-loading");
   });
+
+  test("providers === null (initial load / discovery failed) hides wallet buttons", () => {
+    const html = renderToString(
+      wrap(baseCtx({ providers: null }), React.createElement(StewardLogin, { showWallets: true })),
+    );
+    expect(html).not.toContain("stwd-login-wallets");
+    expect(html).not.toContain("stwd-login-wallet-evm-loading");
+    expect(html).not.toContain("stwd-login-wallet-sol-loading");
+  });
 });
 
 describe("<StewardLogin /> wallet success/error bubbling", () => {

--- a/packages/react/src/components/StewardLogin.tsx
+++ b/packages/react/src/components/StewardLogin.tsx
@@ -1,20 +1,87 @@
-import { useContext, useEffect, useRef, useState } from "react";
+import type { StewardAuthResult } from "@stwd/sdk";
+import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { DiscordIcon, EmailIcon, EthereumIcon, GoogleIcon, PasskeyIcon } from "../icons/index.js";
 import { StewardAuthContext } from "../provider.js";
 import type { StewardLoginProps } from "../types.js";
+import type { WalletLoginPanelProps } from "./WalletLogin.js";
 
 type LoginStep = "idle" | "loading" | "email-sent" | "error";
-type LoadingButton = "passkey" | "email" | "google" | "discord" | "siwe" | null;
+type LoadingButton =
+  | "passkey"
+  | "email"
+  | "google"
+  | "discord"
+  | "siwe"
+  | "wallet-evm"
+  | "wallet-sol"
+  | null;
+
+type WalletPanelComponent = React.ComponentType<WalletLoginPanelProps>;
 
 /**
- * StewardLogin — Drop-in auth widget for Steward-powered apps.
+ * Adapt a `<WalletLogin*>` panel `onSuccess` callback (which yields a full
+ * `StewardAuthResult` plus a `kind` discriminator) to the shape consumers of
+ * `<StewardLogin>` expect (`{ token, user }`). Exported for direct unit
+ * testing of the bubble contract.
+ */
+export function composeWalletSuccess(
+  onSuccess?: StewardLoginProps["onSuccess"],
+): NonNullable<WalletLoginPanelProps["onSuccess"]> {
+  return (result, _kind) => {
+    onSuccess?.({ token: result.token, user: result.user });
+  };
+}
+
+/**
+ * Adapt a `<WalletLogin*>` panel `onError` callback to the shape that
+ * `<StewardLogin>` consumers expect. Exported for direct unit testing.
+ */
+export function composeWalletError(
+  onError?: StewardLoginProps["onError"],
+): NonNullable<WalletLoginPanelProps["onError"]> {
+  return (err, _kind) => {
+    onError?.(err);
+  };
+}
+
+/**
+ * Lazily load a `<WalletLogin*>` panel only when it is actually needed.
  *
- * Must be used inside a <StewardProvider auth={{ baseUrl: "..." }}>.
+ * The panels live in `WalletLogin.EVM.tsx` / `WalletLogin.Solana.tsx` so their
+ * `wagmi` / `@solana/*` peer-dep imports stay off the root bundle. We mirror
+ * the pattern from `<WalletLogin>` itself: dynamic import, fallback while
+ * loading. We avoid `React.lazy` here because `renderToString` does not
+ * support Suspense.
+ */
+function useDynamicWalletPanel(
+  enabled: boolean,
+  loader: () => Promise<{ default: WalletPanelComponent }>,
+): WalletPanelComponent | null {
+  const [Panel, setPanel] = useState<WalletPanelComponent | null>(null);
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+    loader().then((mod) => {
+      if (!cancelled) setPanel(() => mod.default);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, loader]);
+  return Panel;
+}
+
+/**
+ * StewardLogin, drop-in auth widget for Steward-powered apps.
+ *
+ * Must be used inside a `<StewardProvider auth={{ baseUrl: "..." }}>`.
  *
  * Supports:
- *   - Passkey (WebAuthn) — browser only
+ *   - Passkey (WebAuthn), browser only
  *   - Email magic link
- *   - SIWE (Sign-In With Ethereum) — requires caller to wire in a wallet
+ *   - Wallet sign-in (SIWE / SIWS), via `showWallets`. Requires the matching
+ *     wallet provider (see `EVMWalletProvider`, `SolanaWalletProvider` from
+ *     `@stwd/react/wallet`).
  *   - Google OAuth (popup)
  *   - Discord OAuth (popup)
  *
@@ -23,6 +90,7 @@ type LoadingButton = "passkey" | "email" | "google" | "discord" | "siwe" | null;
  *   <StewardLogin
  *     variant="card"
  *     title="Welcome back"
+ *     showWallets
  *     showGoogle
  *     showDiscord
  *     onSuccess={({ token }) => console.log("signed in:", token)}
@@ -35,6 +103,7 @@ export function StewardLogin({
   showPasskey = true,
   showEmail = true,
   showSIWE = false,
+  showWallets = false,
   showGoogle = true,
   showDiscord = true,
   variant = "card",
@@ -54,6 +123,34 @@ export function StewardLogin({
   // Track whether we've already fired onSuccess to avoid double-calling
   const didFireSuccess = useRef(false);
 
+  // Resolve `showWallets` into per-chain booleans. Done before any dynamic
+  // import hooks so loader hooks are called unconditionally.
+  const wantWalletEvm =
+    showWallets === true || (typeof showWallets === "object" && !!showWallets?.evm);
+  const wantWalletSolana =
+    showWallets === true || (typeof showWallets === "object" && !!showWallets?.solana);
+
+  // Provider feature-detect. Backend reports siwe/siws via GET /v1/auth/providers.
+  // If the backend explicitly says false, hide the corresponding button.
+  const providers = ctx?.providers;
+  const siweEnabled = wantWalletEvm && (providers?.siwe ?? true);
+  const siwsEnabled = wantWalletSolana && (providers?.siws ?? true);
+
+  const EVMPanel = useDynamicWalletPanel(
+    siweEnabled,
+    () =>
+      import("./WalletLogin.EVM.js") as Promise<{
+        default: WalletPanelComponent;
+      }>,
+  );
+  const SolanaPanel = useDynamicWalletPanel(
+    siwsEnabled,
+    () =>
+      import("./WalletLogin.Solana.js") as Promise<{
+        default: WalletPanelComponent;
+      }>,
+  );
+
   // When auth state changes to authenticated, fire onSuccess for redirect
   useEffect(() => {
     if (ctx?.isAuthenticated && ctx.session?.token && onSuccess && !didFireSuccess.current) {
@@ -62,6 +159,42 @@ export function StewardLogin({
       onSuccess({ token: ctx.session.token, user });
     }
   }, [ctx?.isAuthenticated, ctx?.session, onSuccess]);
+
+  // Wallet panel callbacks. Defined before any early return so hook order
+  // stays stable across the missing-context branch.
+  const handleWalletSuccess = useCallback(
+    (result: StewardAuthResult, kind: "evm" | "solana") => {
+      setLoadingBtn(null);
+      setStep("idle");
+      setErrorMsg(null);
+      composeWalletSuccess(onSuccess)(result, kind);
+    },
+    [onSuccess],
+  );
+
+  const handleWalletError = useCallback(
+    (err: Error, kind: "evm" | "solana") => {
+      setErrorMsg(err.message || "Wallet sign-in failed.");
+      setStep("error");
+      setLoadingBtn(null);
+      composeWalletError(onError)(err, kind);
+    },
+    [onError],
+  );
+
+  // Class overrides for the wallet panels so they slot into the card layout
+  // and look like siblings of the OAuth buttons.
+  const walletClasses = useMemo(
+    () => ({
+      column: "stwd-login__wallet-col",
+      heading: "stwd-login__wallet-heading",
+      status: "stwd-login__wallet-status",
+      signButton: "stwd-login__btn stwd-login__btn--wallet",
+      hint: "stwd-login__wallet-hint",
+      error: "stwd-login__error",
+    }),
+    [],
+  );
 
   if (!ctx) {
     return (
@@ -79,10 +212,10 @@ export function StewardLogin({
   }
 
   // Determine which OAuth providers to show based on API + props
-  const providers = ctx.providers;
   const googleEnabled = showGoogle && (providers?.google ?? false);
   const discordEnabled = showDiscord && (providers?.discord ?? false);
   const hasOAuth = googleEnabled || discordEnabled;
+  const hasWallet = siweEnabled || siwsEnabled;
 
   const handleError = (err: unknown) => {
     const error = err instanceof Error ? err : new Error(String(err));
@@ -102,8 +235,6 @@ export function StewardLogin({
     setLoadingBtn("passkey");
     setErrorMsg(null);
     try {
-      // If tenantId provided, pass through via OAuth config pattern
-      // The SDK will include it in the request body/headers
       const result = await ctx.signInWithPasskey(email.trim());
       onSuccess?.(result);
     } catch (err) {
@@ -247,8 +378,55 @@ export function StewardLogin({
         )}
       </div>
 
+      {/* Wallet sign-in. Renders inline panels (Approach A) so consumers reuse
+          the existing tested SIWE/SIWS flow. The wagmi / @solana/* peer-dep
+          imports stay isolated behind dynamic import. */}
+      {hasWallet && (
+        <div className="stwd-login__wallets" data-testid="stwd-login-wallets">
+          {siweEnabled &&
+            (EVMPanel ? (
+              <EVMPanel
+                classes={walletClasses}
+                onSuccess={handleWalletSuccess}
+                onError={handleWalletError}
+                label="Ethereum"
+                signLabel={(name) => (name ? `Sign in with ${name}` : "Sign in with EVM wallet")}
+              />
+            ) : (
+              <button
+                type="button"
+                className="stwd-login__btn stwd-login__btn--wallet"
+                disabled
+                data-testid="stwd-login-wallet-evm-loading"
+              >
+                <EthereumIcon size={18} />
+                <span>Loading EVM wallet...</span>
+              </button>
+            ))}
+          {siwsEnabled &&
+            (SolanaPanel ? (
+              <SolanaPanel
+                classes={walletClasses}
+                onSuccess={handleWalletSuccess}
+                onError={handleWalletError}
+                label="Solana"
+                signLabel={(name) => (name ? `Sign in with ${name}` : "Sign in with Solana wallet")}
+              />
+            ) : (
+              <button
+                type="button"
+                className="stwd-login__btn stwd-login__btn--wallet"
+                disabled
+                data-testid="stwd-login-wallet-sol-loading"
+              >
+                <span>Loading Solana wallet...</span>
+              </button>
+            ))}
+        </div>
+      )}
+
       {/* Divider */}
-      {hasOAuth && (showPasskey || showEmail) && (
+      {hasOAuth && (showPasskey || showEmail || hasWallet) && (
         <div className="stwd-login__divider">
           <span>or</span>
         </div>
@@ -291,8 +469,10 @@ export function StewardLogin({
         </div>
       )}
 
-      {/* SIWE (placeholder, requires wallet integration) */}
-      {showSIWE && (
+      {/* Legacy SIWE placeholder. Prefer `showWallets` instead. Kept for
+          backward compatibility with any consumer that was relying on the
+          (disabled) placeholder button. */}
+      {showSIWE && !hasWallet && (
         <div className="stwd-login__oauth">
           <button
             className="stwd-login__btn stwd-login__btn--siwe"

--- a/packages/react/src/components/StewardLogin.tsx
+++ b/packages/react/src/components/StewardLogin.tsx
@@ -234,7 +234,13 @@ export function StewardLogin({
   const googleEnabled = showGoogle && (providers?.google ?? false);
   const discordEnabled = showDiscord && (providers?.discord ?? false);
   const hasOAuth = googleEnabled || discordEnabled;
-  const hasWallet = siweEnabled || siwsEnabled;
+  // Wallet UI requires both: backend confirms support AND a panel loader is
+  // registered (i.e. consumer imported `@stwd/react/wallet`). Without
+  // a registered panel, rendering would show a permanently-disabled
+  // loading placeholder, which is worse than hiding the button.
+  const evmReady = siweEnabled && !!evmRegistered;
+  const solanaReady = siwsEnabled && !!solanaRegistered;
+  const hasWallet = evmReady || solanaReady;
 
   const handleError = (err: unknown) => {
     const error = err instanceof Error ? err : new Error(String(err));
@@ -402,7 +408,7 @@ export function StewardLogin({
           imports stay isolated behind dynamic import. */}
       {hasWallet && (
         <div className="stwd-login__wallets" data-testid="stwd-login-wallets">
-          {siweEnabled &&
+          {evmReady &&
             (EVMPanel ? (
               <EVMPanel
                 classes={walletClasses}
@@ -422,7 +428,7 @@ export function StewardLogin({
                 <span>Loading EVM wallet...</span>
               </button>
             ))}
-          {siwsEnabled &&
+          {solanaReady &&
             (SolanaPanel ? (
               <SolanaPanel
                 classes={walletClasses}

--- a/packages/react/src/components/StewardLogin.tsx
+++ b/packages/react/src/components/StewardLogin.tsx
@@ -407,7 +407,7 @@ export function StewardLogin({
           the existing tested SIWE/SIWS flow. The wagmi / @solana/* peer-dep
           imports stay isolated behind dynamic import. */}
       {hasWallet && (
-        <div className="stwd-login__wallets" data-testid="stwd-login-wallets">
+        <div className="stwd-login__wallets stwd-wallet-root" data-testid="stwd-login-wallets">
           {evmReady &&
             (EVMPanel ? (
               <EVMPanel

--- a/packages/react/src/components/StewardLogin.tsx
+++ b/packages/react/src/components/StewardLogin.tsx
@@ -1,6 +1,11 @@
 import type { StewardAuthResult } from "@stwd/sdk";
 import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { DiscordIcon, EmailIcon, EthereumIcon, GoogleIcon, PasskeyIcon } from "../icons/index.js";
+import {
+  getEvmWalletPanel,
+  getSolanaWalletPanel,
+  type WalletPanelLoader,
+} from "../internal/walletPanelRegistry.js";
 import { StewardAuthContext } from "../provider.js";
 import type { StewardLoginProps } from "../types.js";
 import type { WalletLoginPanelProps } from "./WalletLogin.js";
@@ -55,11 +60,11 @@ export function composeWalletError(
  */
 function useDynamicWalletPanel(
   enabled: boolean,
-  loader: () => Promise<{ default: WalletPanelComponent }>,
+  loader: (() => Promise<{ default: WalletPanelComponent }>) | undefined,
 ): WalletPanelComponent | null {
   const [Panel, setPanel] = useState<WalletPanelComponent | null>(null);
   useEffect(() => {
-    if (!enabled) return;
+    if (!enabled || !loader) return;
     let cancelled = false;
     loader().then((mod) => {
       if (!cancelled) setPanel(() => mod.default);
@@ -138,19 +143,25 @@ export function StewardLogin({
   const siweEnabled = wantWalletEvm && providers?.siwe === true;
   const siwsEnabled = wantWalletSolana && providers?.siws === true;
 
+  // Read panel loaders from the wallet registry. The registry is populated
+  // as a side effect when the consumer imports `@stwd/react/wallet`. If they
+  // didn't import that subpath, the loaders are undefined and we render no
+  // wallet buttons (consistent with optional peer dep contract).
+  const evmRegistered = useMemo<WalletPanelLoader | undefined>(
+    () => (siweEnabled ? getEvmWalletPanel() : undefined),
+    [siweEnabled],
+  );
+  const solanaRegistered = useMemo<WalletPanelLoader | undefined>(
+    () => (siwsEnabled ? getSolanaWalletPanel() : undefined),
+    [siwsEnabled],
+  );
   const EVMPanel = useDynamicWalletPanel(
-    siweEnabled,
-    () =>
-      import("./WalletLogin.EVM.js") as Promise<{
-        default: WalletPanelComponent;
-      }>,
+    siweEnabled && !!evmRegistered,
+    evmRegistered?.load as (() => Promise<{ default: WalletPanelComponent }>) | undefined,
   );
   const SolanaPanel = useDynamicWalletPanel(
-    siwsEnabled,
-    () =>
-      import("./WalletLogin.Solana.js") as Promise<{
-        default: WalletPanelComponent;
-      }>,
+    siwsEnabled && !!solanaRegistered,
+    solanaRegistered?.load as (() => Promise<{ default: WalletPanelComponent }>) | undefined,
   );
 
   // When auth state changes to authenticated, fire onSuccess for redirect
@@ -169,6 +180,12 @@ export function StewardLogin({
       setLoadingBtn(null);
       setStep("idle");
       setErrorMsg(null);
+      // Mark didFireSuccess BEFORE invoking onSuccess so the auth-state
+      // effect (which fires when ctx.isAuthenticated flips) does not
+      // double-invoke. The wallet sign helpers already wrote the session
+      // into the auth context, so the effect would otherwise see the new
+      // authenticated state on its next render and fire again.
+      didFireSuccess.current = true;
       composeWalletSuccess(onSuccess)(result, kind);
     },
     [onSuccess],

--- a/packages/react/src/components/StewardLogin.tsx
+++ b/packages/react/src/components/StewardLogin.tsx
@@ -131,10 +131,12 @@ export function StewardLogin({
     showWallets === true || (typeof showWallets === "object" && !!showWallets?.solana);
 
   // Provider feature-detect. Backend reports siwe/siws via GET /v1/auth/providers.
-  // If the backend explicitly says false, hide the corresponding button.
+  // Default to false until the backend confirms; we don't want to render wallet
+  // buttons during initial load (providers === null) or when discovery failed.
+  // This mirrors the OAuth gating pattern used elsewhere in this component.
   const providers = ctx?.providers;
-  const siweEnabled = wantWalletEvm && (providers?.siwe ?? true);
-  const siwsEnabled = wantWalletSolana && (providers?.siws ?? true);
+  const siweEnabled = wantWalletEvm && providers?.siwe === true;
+  const siwsEnabled = wantWalletSolana && providers?.siws === true;
 
   const EVMPanel = useDynamicWalletPanel(
     siweEnabled,

--- a/packages/react/src/internal/walletPanelRegistry.ts
+++ b/packages/react/src/internal/walletPanelRegistry.ts
@@ -1,0 +1,70 @@
+/**
+ * Wallet panel registry.
+ *
+ * Why this exists:
+ *   `<StewardLogin>` lives in the root entry (`@stwd/react`), but the EVM and
+ *   Solana wallet panels statically import optional peer deps (`wagmi`,
+ *   `@rainbow-me/rainbowkit`, `@solana/wallet-adapter-*`). If `<StewardLogin>`
+ *   even lazily references the panel modules by relative path, bundlers like
+ *   Vite/Rollup/Webpack walk those paths and pull the peer deps into the
+ *   root bundle's dep graph. Apps that don't install those peers fail at
+ *   build time even when `showWallets` is left false.
+ *
+ * The fix is a simple registry. The root entry only imports types. Importing
+ * `@stwd/react/wallet` triggers registration as a side effect (see
+ * `src/wallet.ts`). Bundlers that don't see the import never traverse the
+ * panel files. Apps that opt into wallets get the registration for free.
+ *
+ * SSR safety: registry state lives on a module-scoped object. Since panels
+ * are React components used only during render after `<StewardProvider>`
+ * mounts, registration timing is fine: the import happens at module load,
+ * the StewardLogin component reads at render.
+ */
+
+import type { ComponentType } from "react";
+
+// Mirror of the StewardLogin types/WalletLogin.tsx panel contract. Kept here
+// to avoid pulling WalletLogin.tsx (which dynamic-imports the panels) into
+// the root bundle.
+export interface WalletPanelLoader {
+  /** Loader returning the React panel component. Identity is stable; safe to
+   *  use as a useEffect dep. */
+  load: () => Promise<{ default: ComponentType<unknown> }>;
+}
+
+interface Registry {
+  evm?: WalletPanelLoader;
+  solana?: WalletPanelLoader;
+}
+
+const registry: Registry = {};
+
+/** Register the EVM wallet panel loader. Called as a side effect from
+ *  `@stwd/react/wallet`. */
+export function registerEvmWalletPanel(loader: WalletPanelLoader): void {
+  registry.evm = loader;
+}
+
+/** Register the Solana wallet panel loader. Called as a side effect from
+ *  `@stwd/react/wallet`. */
+export function registerSolanaWalletPanel(loader: WalletPanelLoader): void {
+  registry.solana = loader;
+}
+
+/** Read the currently-registered EVM panel loader. Returns undefined when
+ *  the consumer has not imported `@stwd/react/wallet`. */
+export function getEvmWalletPanel(): WalletPanelLoader | undefined {
+  return registry.evm;
+}
+
+/** Read the currently-registered Solana panel loader. Returns undefined when
+ *  the consumer has not imported `@stwd/react/wallet`. */
+export function getSolanaWalletPanel(): WalletPanelLoader | undefined {
+  return registry.solana;
+}
+
+/** Test helper. Not exported from public entry. */
+export function _resetWalletPanelRegistry(): void {
+  registry.evm = undefined;
+  registry.solana = undefined;
+}

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -354,6 +354,22 @@ export interface StewardLoginProps {
   showPasskey?: boolean;
   showEmail?: boolean;
   showSIWE?: boolean;
+  /**
+   * First-class wallet sign-in (SIWE / SIWS).
+   *
+   * - `true`  - render both EVM and Solana wallet panels (subject to provider feature-detect).
+   * - `false` (default) - hide both. Backwards-compatible.
+   * - `{ evm: true }` - only EVM.
+   * - `{ solana: true }` - only Solana.
+   *
+   * Backend feature flags from `GET /v1/auth/providers` (`siwe`, `siws`) act
+   * as a hard gate: if the backend reports `siwe: false`, the EVM button is
+   * hidden regardless of this prop.
+   *
+   * Requires the consumer to wrap the app in the matching wallet provider
+   * (see `EVMWalletProvider` and `SolanaWalletProvider` from `@stwd/react/wallet`).
+   */
+  showWallets?: boolean | { evm?: boolean; solana?: boolean };
   showGoogle?: boolean;
   showDiscord?: boolean;
   /** "card" adds bg/border/padding wrapper; "inline" renders with no container styling */

--- a/packages/react/src/wallet.ts
+++ b/packages/react/src/wallet.ts
@@ -1,3 +1,26 @@
+import {
+  registerEvmWalletPanel,
+  registerSolanaWalletPanel,
+} from "./internal/walletPanelRegistry.js";
+
+// Side-effect registration: importing `@stwd/react/wallet` registers the
+// wallet panel loaders so `<StewardLogin showWallets>` can find them.
+// This keeps the root entry (`@stwd/react`) free of any references to
+// wallet peer deps. Bundlers that don't see this subpath imported never
+// pull wagmi / RainbowKit / @solana/* into their dep graph.
+registerEvmWalletPanel({
+  load: () =>
+    import("./components/WalletLogin.EVM.js") as Promise<{
+      default: import("react").ComponentType<unknown>;
+    }>,
+});
+registerSolanaWalletPanel({
+  load: () =>
+    import("./components/WalletLogin.Solana.js") as Promise<{
+      default: import("react").ComponentType<unknown>;
+    }>,
+});
+
 export type {
   WalletChains,
   WalletLoginClassOverrides,


### PR DESCRIPTION
## W1.A — Compose `<WalletLogin>` into `<StewardLogin>`

Bring wallet login into the main StewardLogin modal as a first-class option.

### Changes
- `StewardLogin`: add `showWallets?: boolean | { evm?: boolean; solana?: boolean }` prop
- Internally render `<WalletLoginEVM>` + `<WalletLoginSolana>` panels alongside passkey/email/OAuth
- Feature-detect via `providers.siwe` and `providers.siws` (already reported by `GET /v1/auth/providers`)
- `onSuccess` and `onError` unified across all auth methods via small `composeWalletSuccess` / `composeWalletError` adapters
- New `LoadingButton` variants: `"wallet-evm" | "wallet-sol"` (reserved for future per-button busy UI; the panels manage their own busy state today)
- `@stwd/react` bumped 0.7.2 → 0.8.0

### Approach
**A — render panels inline with class overrides.** The wallet panels already encapsulate the entire SIWE/SIWS flow (connect button, status, sign button, error slot). Dropping them into the StewardLogin card via `classes` overrides reuses 100% of the tested signing logic with zero duplication. Their wagmi / `@solana/*` peer-deps stay isolated behind the same dynamic-import pattern `<WalletLogin>` already uses, so consumers who don't opt into `showWallets` pay nothing.

Approach B (compact buttons → expand panel) would duplicate the connector UI and add a state machine that doesn't earn its keep here. We can revisit if the dogfood site needs a denser layout.

### Migration note for consumers
- **No breaking changes.** `showWallets` defaults to `false` for backward compat.
- To enable wallet login, pass `showWallets={true}` and ensure your app is wrapped in the matching wallet provider (`<EVMWalletProvider>` and/or `<SolanaWalletProvider>` from `@stwd/react/wallet`).
- Granular forms: `showWallets={{ evm: true }}` or `showWallets={{ solana: true }}`.
- Backend gates: if `GET /v1/auth/providers` reports `siwe: false` or `siws: false`, the corresponding button is hidden regardless of prop. Safe default for staged rollouts.

### Layout / copy notes for W1 phase 2 (dogfood site)
- Wallet panels render in a `stwd-login__wallets` container between the email/passkey actions and the OAuth divider.
- Class overrides applied to the panels: `column → stwd-login__wallet-col`, `signButton → stwd-login__btn stwd-login__btn--wallet`, etc. The dogfood site can tune these in its own CSS without touching the panels.
- Default sign-button copy: `"Sign in with {WalletName}"` (Phantom, MetaMask, …) when a wallet is connected; `"Sign in with EVM wallet"` / `"Sign in with Solana wallet"` as the no-connector fallback.
- Legacy `showSIWE` placeholder is preserved when `showWallets` is unset, so existing consumers see no behavioral change.

### Verification
- [x] `bun run lint` — clean
- [x] `bunx turbo run build --filter='./packages/*'` — 14/14 successful
- [x] `cd packages/react && bun test` — 31/31 pass (16 in StewardLogin: 5 existing + 11 new)

Co-authored-by: wakesync <shadow@shad0w.xyz>
Co-authored-by: Sol <sol@shad0w.xyz>
