### PR TITLE
feat(react): <StewardLoginWithWallets> drop-in component (P2.C)

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -143,6 +143,54 @@ export function EvmLogin() {
 
 If you render `WalletLogin` directly, it is already the wallet UI. To enable wallet sign-in inside the broader `<StewardLogin>` modal (alongside passkey, email, OAuth), pass the `showWallets` prop on `<StewardLogin>` instead.
 
+### Drop-in: `<StewardLoginWithWallets>`
+
+The simplest possible wallet-login surface, one component, no provider wiring. Bundles `<EVMWalletProvider>` + `<SolanaWalletProvider>` and renders `<StewardLogin showWallets>` inside. All `<StewardLogin>` props (passkey, email, OAuth, title, callbacks, etc) are forwarded.
+
+```tsx
+import { StewardProvider } from "@stwd/react";
+import { StewardLoginWithWallets } from "@stwd/react/wallet";
+import "@stwd/react/styles.css";
+import "@rainbow-me/rainbowkit/styles.css";
+import "@solana/wallet-adapter-react-ui/styles.css";
+
+export default function Login() {
+  return (
+    <StewardProvider auth={{ baseUrl: "https://api.steward.fi" }}>
+      <StewardLoginWithWallets
+        title="Sign in"
+        showPasskey
+        showEmail
+        showGoogle
+        showDiscord
+        evm={{ appName: "My App" }}
+        solana={{ endpoint: "https://api.mainnet-beta.solana.com" }}
+        onSuccess={({ token }) => console.log("signed in:", token)}
+      />
+    </StewardProvider>
+  );
+}
+```
+
+**Sensible defaults:**
+- WalletConnect projectId falls back to `process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID`, then to a Steward shared default for first-time testing. Production apps should set their own.
+- EVM chains default to `[mainnet, base, polygon, optimism, arbitrum, bsc]`. Pass `evm.chains` to override.
+- Solana endpoint defaults to public mainnet-beta (rate-limited; not for production). Pass `solana.endpoint` with a private RPC.
+- Solana wallet list defaults to the curated software-only set (`createDefaultSolanaWallets()`). Pass `solana.wallets` to override.
+
+**Per-chain gates:**
+```tsx
+<StewardLoginWithWallets enable={{ solana: false }} ... />
+```
+Disables the Solana wrap entirely. Same for `enable.evm`.
+
+**Bring your own wagmi config:**
+```tsx
+<StewardLoginWithWallets evm={{ config: myWagmiConfig }} ... />
+```
+
+This component pulls BOTH EVM and Solana peer dep trees. Apps that want only one chain should use `<StewardLogin showWallets={{ evm: true }}>` directly with `<EVMWalletProvider>` and import from the chain-specific subpath `@stwd/react/wallet/evm` to skip the Solana peer install entirely.
+
 ### Solana example with expanded defaults
 
 `SolanaWalletProvider` now defaults to `DEFAULT_SOLANA_WALLETS`, which includes Phantom, Solflare, Coinbase Wallet, Trust Wallet, MathWallet, and Coin98. Wallets that implement the Solana Wallet Standard, including Backpack and Brave when installed in the browser, are discovered at runtime by wallet-adapter. Hardware Solana wallets (Ledger, Trezor) are excluded from defaults because their adapters do not implement `signMessage` and cannot complete the SIWS sign-in flow; apps that want hardware support in non-login contexts can extend the wallet list explicitly.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stwd/react",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Embeddable React components for Steward agent wallet management",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/react/src/__tests__/StewardLoginWithWallets.test.tsx
+++ b/packages/react/src/__tests__/StewardLoginWithWallets.test.tsx
@@ -1,0 +1,143 @@
+import { describe, expect, mock, test } from "bun:test";
+import * as React from "react";
+import { renderToString } from "react-dom/server";
+
+// Mock the EVM and Solana provider modules so the test does not pull in
+// real wagmi / Solana peer dep trees (and so we can assert that each
+// provider is mounted with the right props).
+
+const mockCreateDefaultWagmiConfig = mock((opts: unknown) => ({
+  kind: "wagmi-config",
+  opts,
+}));
+const mockEVMProviderRender = mock((_props: unknown) => null);
+const mockSolanaProviderRender = mock((_props: unknown) => null);
+
+mock.module("../providers/EVMProvider.js", () => ({
+  createDefaultWagmiConfig: mockCreateDefaultWagmiConfig,
+  EVMWalletProvider: ({
+    children,
+    ...props
+  }: { children?: React.ReactNode } & Record<string, unknown>) => {
+    mockEVMProviderRender(props);
+    return React.createElement(
+      "div",
+      { "data-testid": "evm-wrap", "data-config-kind": (props.config as { kind?: string })?.kind },
+      children,
+    );
+  },
+}));
+
+mock.module("../providers/SolanaProvider.js", () => ({
+  SolanaWalletProvider: ({
+    children,
+    ...props
+  }: { children?: React.ReactNode } & Record<string, unknown>) => {
+    mockSolanaProviderRender(props);
+    return React.createElement(
+      "div",
+      { "data-testid": "sol-wrap", "data-endpoint": String(props.endpoint ?? "") },
+      children,
+    );
+  },
+  createDefaultSolanaWallets: () => [],
+  DEFAULT_SOLANA_WALLETS: [],
+}));
+
+mock.module("../components/StewardLogin.js", () => ({
+  StewardLogin: (props: Record<string, unknown>) =>
+    React.createElement("div", {
+      "data-testid": "steward-login",
+      "data-show-wallets": JSON.stringify(props.showWallets ?? null),
+      "data-title": String(props.title ?? ""),
+    }),
+}));
+
+const { StewardLoginWithWallets } = await import("../components/StewardLoginWithWallets.js");
+
+describe("<StewardLoginWithWallets />", () => {
+  test("wraps both EVM and Solana providers by default and renders <StewardLogin>", () => {
+    const html = renderToString(
+      React.createElement(StewardLoginWithWallets, {
+        title: "Sign in",
+        evm: { projectId: "test-pid" },
+      }),
+    );
+    expect(html).toContain('data-testid="evm-wrap"');
+    expect(html).toContain('data-testid="sol-wrap"');
+    expect(html).toContain('data-testid="steward-login"');
+    expect(html).toContain('data-config-kind="wagmi-config"');
+  });
+
+  test("default showWallets is { evm: true, solana: true } when not overridden", () => {
+    const html = renderToString(
+      React.createElement(StewardLoginWithWallets, {
+        evm: { projectId: "p" },
+      }),
+    );
+    expect(html).toContain('data-show-wallets="{&quot;evm&quot;:true,&quot;solana&quot;:true}"');
+  });
+
+  test("enable={{ evm: false }} skips EVM wrap", () => {
+    const html = renderToString(
+      React.createElement(StewardLoginWithWallets, {
+        enable: { evm: false },
+      }),
+    );
+    expect(html).not.toContain('data-testid="evm-wrap"');
+    expect(html).toContain('data-testid="sol-wrap"');
+    expect(html).toContain('data-testid="steward-login"');
+  });
+
+  test("enable={{ solana: false }} skips Solana wrap", () => {
+    const html = renderToString(
+      React.createElement(StewardLoginWithWallets, {
+        enable: { solana: false },
+        evm: { projectId: "p" },
+      }),
+    );
+    expect(html).toContain('data-testid="evm-wrap"');
+    expect(html).not.toContain('data-testid="sol-wrap"');
+  });
+
+  test("custom evm.config bypasses createDefaultWagmiConfig", () => {
+    const customConfig = { kind: "custom-wagmi-config" };
+    const html = renderToString(
+      React.createElement(StewardLoginWithWallets, {
+        evm: { config: customConfig as unknown as never },
+      }),
+    );
+    // Custom config flows through to <EVMWalletProvider config={...}>.
+    expect(html).toContain('data-config-kind="custom-wagmi-config"');
+  });
+
+  test("solana.endpoint override is respected", () => {
+    const html = renderToString(
+      React.createElement(StewardLoginWithWallets, {
+        evm: { projectId: "p" },
+        solana: { endpoint: "https://my.helius.rpc" },
+      }),
+    );
+    expect(html).toContain('data-endpoint="https://my.helius.rpc"');
+  });
+
+  test("forwards StewardLogin props (title)", () => {
+    const html = renderToString(
+      React.createElement(StewardLoginWithWallets, {
+        title: "Custom Title",
+        evm: { projectId: "p" },
+      }),
+    );
+    expect(html).toContain('data-title="Custom Title"');
+  });
+
+  test("explicit showWallets prop wins over the auto default", () => {
+    const html = renderToString(
+      React.createElement(StewardLoginWithWallets, {
+        showWallets: { evm: true, solana: false },
+        evm: { projectId: "p" },
+      }),
+    );
+    expect(html).toContain('data-show-wallets="{&quot;evm&quot;:true,&quot;solana&quot;:false}"');
+  });
+});

--- a/packages/react/src/components/StewardLoginWithWallets.tsx
+++ b/packages/react/src/components/StewardLoginWithWallets.tsx
@@ -80,26 +80,43 @@ export interface StewardLoginWithWalletsProps extends StewardLoginProps {
   enable?: { evm?: boolean; solana?: boolean };
 }
 
-/** Read a build-time env var without depending on @types/node. Bundlers
- *  (Next, Vite, etc) inline `process.env.NEXT_PUBLIC_*` at build time so
- *  this works in any runtime that the bundler targets. The optional chain
- *  via globalThis avoids ReferenceError in pure browser runtimes that do
- *  not define `process`. */
-function readEnv(key: string): string | undefined {
-  const proc = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process;
-  return proc?.env?.[key];
+// Bundlers (Next, Vite, etc) only inline STATIC references to public env
+// vars like `process.env.NEXT_PUBLIC_*`. A dynamic lookup such as
+// `process.env[key]` is left as a runtime read, which fails in browsers
+// because `process` does not exist there. We read each var individually
+// and guard `process` for environments without it.
+//
+// Build-time replacement happens at the `process.env.X` references below,
+// so the resolved string ends up baked into the consumer's client bundle.
+
+declare const process: { env?: Record<string, string | undefined> } | undefined;
+
+function readWalletConnectProjectIdEnv(): string | undefined {
+  try {
+    return typeof process !== "undefined"
+      ? process?.env?.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readSolanaRpcEnv(): string | undefined {
+  try {
+    return typeof process !== "undefined" ? process?.env?.NEXT_PUBLIC_SOLANA_RPC_URL : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function resolveProjectId(override: string | undefined): string {
   if (override) return override;
-  return (
-    readEnv("NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID") ?? STEWARD_DEFAULT_WALLETCONNECT_PROJECT_ID
-  );
+  return readWalletConnectProjectIdEnv() ?? STEWARD_DEFAULT_WALLETCONNECT_PROJECT_ID;
 }
 
 function resolveSolanaEndpoint(override: string | undefined): string {
   if (override) return override;
-  return readEnv("NEXT_PUBLIC_SOLANA_RPC_URL") ?? DEFAULT_SOLANA_ENDPOINT;
+  return readSolanaRpcEnv() ?? DEFAULT_SOLANA_ENDPOINT;
 }
 
 /**

--- a/packages/react/src/components/StewardLoginWithWallets.tsx
+++ b/packages/react/src/components/StewardLoginWithWallets.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+/**
+ * <StewardLoginWithWallets>
+ *
+ * Drop-in component that bundles `<StewardLogin showWallets>` with the
+ * wagmi + RainbowKit + Solana provider trees so consumers can mount wallet
+ * login with a single component, no manual provider wiring.
+ *
+ * This is the "Privy parity" surface. It is purely additive over
+ * `<StewardLogin>` + the manual provider wrap path, which still works for
+ * consumers who want full control of their wallet provider configuration.
+ *
+ * Peer deps: importing this component pulls BOTH EVM and Solana peer
+ * trees. Apps that want only one chain should use the manual path
+ * (`<StewardLogin showWallets={{ evm: true }}>` + `<EVMWalletProvider>`)
+ * and import from the chain-specific subpaths
+ * `@stwd/react/wallet/evm` or `@stwd/react/wallet/solana`.
+ */
+
+import { type ReactNode, useMemo } from "react";
+import type { Chain } from "viem";
+import type { Config as WagmiConfig } from "wagmi";
+import { arbitrum, base, bsc, mainnet, optimism, polygon } from "wagmi/chains";
+import {
+  createDefaultWagmiConfig,
+  EVMWalletProvider,
+  type EVMWalletProviderProps,
+} from "../providers/EVMProvider.js";
+import {
+  SolanaWalletProvider,
+  type SolanaWalletProviderProps,
+} from "../providers/SolanaProvider.js";
+import type { StewardLoginProps } from "../types.js";
+import { StewardLogin } from "./StewardLogin.js";
+
+/** Steward-owned WalletConnect Cloud project ID, suitable for development.
+ *  Production apps should bring their own. */
+const STEWARD_DEFAULT_WALLETCONNECT_PROJECT_ID = "2c7ddf841a48e522748c5e2782d73443";
+
+/** Default chain set for the bundled EVM wagmi config. */
+const DEFAULT_EVM_CHAINS = [mainnet, base, polygon, optimism, arbitrum, bsc] as const;
+
+/** Default Solana JSON-RPC endpoint. Production apps should pass a private RPC
+ *  (Helius, QuickNode) via `solana.endpoint`. The public mainnet-beta
+ *  endpoint is rate-limited and not for production. */
+const DEFAULT_SOLANA_ENDPOINT = "https://api.mainnet-beta.solana.com";
+
+export interface StewardLoginWithWalletsEvmConfig {
+  /** Pre-built wagmi `Config`. Takes precedence over the rest of this object. */
+  config?: WagmiConfig;
+  /** WalletConnect Cloud projectId. Falls back to
+   *  `process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID` then to a Steward
+   *  shared default for dev. Apps SHOULD set their own in production. */
+  projectId?: string;
+  /** Chains to support. Defaults to a curated EVM mainnet set. */
+  chains?: readonly [Chain, ...Chain[]];
+  /** App name shown in the WalletConnect connection prompt. Default: "Steward". */
+  appName?: string;
+  /** Forwarded to `<EVMWalletProvider>` (theme / modalSize / queryClient / etc). */
+  providerProps?: Omit<EVMWalletProviderProps, "config" | "children">;
+}
+
+export interface StewardLoginWithWalletsSolanaConfig {
+  /** JSON-RPC endpoint. Default: public mainnet-beta. */
+  endpoint?: string;
+  /** Override default wallet adapter list. */
+  wallets?: SolanaWalletProviderProps["wallets"];
+  /** Auto-connect previously selected wallet on mount. Default true. */
+  autoConnect?: boolean;
+}
+
+export interface StewardLoginWithWalletsProps extends StewardLoginProps {
+  /** EVM provider configuration. */
+  evm?: StewardLoginWithWalletsEvmConfig;
+  /** Solana provider configuration. */
+  solana?: StewardLoginWithWalletsSolanaConfig;
+  /** Per-chain enable gates. Set `evm: false` to skip EVM wrap, `solana: false`
+   *  to skip Solana wrap. By default, both wraps are applied. */
+  enable?: { evm?: boolean; solana?: boolean };
+}
+
+/** Read a build-time env var without depending on @types/node. Bundlers
+ *  (Next, Vite, etc) inline `process.env.NEXT_PUBLIC_*` at build time so
+ *  this works in any runtime that the bundler targets. The optional chain
+ *  via globalThis avoids ReferenceError in pure browser runtimes that do
+ *  not define `process`. */
+function readEnv(key: string): string | undefined {
+  const proc = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process;
+  return proc?.env?.[key];
+}
+
+function resolveProjectId(override: string | undefined): string {
+  if (override) return override;
+  return (
+    readEnv("NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID") ?? STEWARD_DEFAULT_WALLETCONNECT_PROJECT_ID
+  );
+}
+
+function resolveSolanaEndpoint(override: string | undefined): string {
+  if (override) return override;
+  return readEnv("NEXT_PUBLIC_SOLANA_RPC_URL") ?? DEFAULT_SOLANA_ENDPOINT;
+}
+
+/**
+ * The simplest possible wallet-login surface, one component.
+ *
+ * Wraps children with `<EVMWalletProvider>` and `<SolanaWalletProvider>`
+ * (each can be disabled via `enable`) and renders `<StewardLogin>` with
+ * the requested `showWallets` value. All other `<StewardLogin>` props
+ * are forwarded.
+ *
+ * Always mount inside a `<StewardProvider>` so the auth context is available.
+ */
+export function StewardLoginWithWallets({
+  evm,
+  solana,
+  enable,
+  ...loginProps
+}: StewardLoginWithWalletsProps) {
+  const evmEnabled = enable?.evm !== false;
+  const solanaEnabled = enable?.solana !== false;
+
+  const wagmiConfig = useMemo<WagmiConfig | null>(() => {
+    if (!evmEnabled) return null;
+    if (evm?.config) return evm.config;
+    return createDefaultWagmiConfig({
+      projectId: resolveProjectId(evm?.projectId),
+      chains: evm?.chains ?? (DEFAULT_EVM_CHAINS as unknown as readonly [Chain, ...Chain[]]),
+      appName: evm?.appName ?? "Steward",
+    });
+  }, [evmEnabled, evm?.config, evm?.projectId, evm?.chains, evm?.appName]);
+
+  const solanaEndpoint = useMemo(
+    () => (solanaEnabled ? resolveSolanaEndpoint(solana?.endpoint) : null),
+    [solanaEnabled, solana?.endpoint],
+  );
+
+  // Default showWallets to true: this component exists specifically to
+  // surface wallet sign-in. Consumers can still pass showWallets={false}
+  // to fall back to passkey/email/oauth-only behavior, e.g. for A/B tests.
+  const showWallets = loginProps.showWallets ?? {
+    evm: evmEnabled,
+    solana: solanaEnabled,
+  };
+
+  let tree: ReactNode = <StewardLogin {...loginProps} showWallets={showWallets} />;
+
+  if (solanaEnabled && solanaEndpoint) {
+    tree = (
+      <SolanaWalletProvider
+        endpoint={solanaEndpoint}
+        wallets={solana?.wallets}
+        autoConnect={solana?.autoConnect}
+      >
+        {tree}
+      </SolanaWalletProvider>
+    );
+  }
+
+  if (evmEnabled && wagmiConfig) {
+    tree = (
+      <EVMWalletProvider {...(evm?.providerProps ?? {})} config={wagmiConfig}>
+        {tree}
+      </EVMWalletProvider>
+    );
+  }
+
+  return <>{tree}</>;
+}

--- a/packages/react/src/components/StewardLoginWithWallets.tsx
+++ b/packages/react/src/components/StewardLoginWithWallets.tsx
@@ -80,22 +80,26 @@ export interface StewardLoginWithWalletsProps extends StewardLoginProps {
   enable?: { evm?: boolean; solana?: boolean };
 }
 
-// Bundlers (Next, Vite, etc) only inline STATIC references to public env
-// vars like `process.env.NEXT_PUBLIC_*`. A dynamic lookup such as
-// `process.env[key]` is left as a runtime read, which fails in browsers
-// because `process` does not exist there. We read each var individually
-// and guard `process` for environments without it.
+// Bundlers (Next, Vite, esbuild, etc) inline public env vars at build
+// time but ONLY when they see the bare member expression
+// `process.env.NEXT_PUBLIC_X`. Webpack's DefinePlugin and Vite's `define`
+// match a MemberExpression AST node; an OptionalMemberExpression
+// (`process?.env?.X`) is a different node shape and is left alone.
+// We therefore reference each var via plain `process.env.X` and guard
+// `process` itself with `typeof` so this still works in browser-only
+// runtimes that lack a `process` global.
 //
-// Build-time replacement happens at the `process.env.X` references below,
-// so the resolved string ends up baked into the consumer's client bundle.
+// In server (Node) builds: this is just a runtime env read.
+// In bundler-targeted client builds: Webpack/Vite/esbuild rewrite each
+// `process.env.NEXT_PUBLIC_X` to the literal string at compile time, so
+// the value is baked into the consumer's bundle.
 
-declare const process: { env?: Record<string, string | undefined> } | undefined;
+declare const process: { env: Record<string, string | undefined> } | undefined;
 
 function readWalletConnectProjectIdEnv(): string | undefined {
   try {
-    return typeof process !== "undefined"
-      ? process?.env?.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID
-      : undefined;
+    if (typeof process === "undefined") return undefined;
+    return process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID;
   } catch {
     return undefined;
   }
@@ -103,7 +107,8 @@ function readWalletConnectProjectIdEnv(): string | undefined {
 
 function readSolanaRpcEnv(): string | undefined {
   try {
-    return typeof process !== "undefined" ? process?.env?.NEXT_PUBLIC_SOLANA_RPC_URL : undefined;
+    if (typeof process === "undefined") return undefined;
+    return process.env.NEXT_PUBLIC_SOLANA_RPC_URL;
   } catch {
     return undefined;
   }

--- a/packages/react/src/wallet.ts
+++ b/packages/react/src/wallet.ts
@@ -22,6 +22,12 @@ registerSolanaWalletPanel({
 });
 
 export type {
+  StewardLoginWithWalletsEvmConfig,
+  StewardLoginWithWalletsProps,
+  StewardLoginWithWalletsSolanaConfig,
+} from "./components/StewardLoginWithWallets.js";
+export { StewardLoginWithWallets } from "./components/StewardLoginWithWallets.js";
+export type {
   WalletChains,
   WalletLoginClassOverrides,
   WalletLoginProps,


### PR DESCRIPTION
## P2.C — Drop-in wallet-login component

The simplest possible wallet-login surface: one component, no provider wiring. Wraps consumer in `<EVMWalletProvider>` + `<SolanaWalletProvider>` and renders `<StewardLogin showWallets>` inside. All `StewardLogin` props forward.

This is purely additive over the existing manual provider wrap path (`<StewardLogin showWallets>` + manual `<EVMWalletProvider>` + `<SolanaWalletProvider>`). No breaking changes.

## API

```tsx
<StewardProvider auth={{ baseUrl: "..." }}>
  <StewardLoginWithWallets
    title="Sign in"
    showPasskey
    showEmail
    showGoogle
    showDiscord
    evm={{ appName: "My App" }}
    solana={{ endpoint: "https://api.mainnet-beta.solana.com" }}
    onSuccess={({ token }) => console.log(token)}
  />
</StewardProvider>
```

### Sensible defaults
- WalletConnect projectId: prop → `NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID` env → Steward shared dev default
- EVM chains: `[mainnet, base, polygon, optimism, arbitrum, bsc]`
- Solana endpoint: `NEXT_PUBLIC_SOLANA_RPC_URL` env → public mainnet-beta
- Solana wallets: `createDefaultSolanaWallets()` (software-only curated set)

### Escape hatches
- `enable={{ evm?: boolean; solana?: boolean }}` per-chain gate
- `evm.config` bypasses `createDefaultWagmiConfig`
- `solana.wallets` overrides default adapter list
- `evm.providerProps` / `solana.{autoConnect, ...}` forward to underlying providers

### When NOT to use this
Apps that want only one chain should use the manual path with the chain-specific subpaths (`@stwd/react/wallet/evm` or `/solana`) to skip the unused peer install. This component pulls BOTH peer trees.

## Verification
- [x] lint pass
- [x] `bun test` 47/47 pass (8 new tests in StewardLoginWithWallets.test.tsx)
- [x] `bunx turbo run build --filter=@stwd/react` clean

## Files
- `packages/react/src/components/StewardLoginWithWallets.tsx` (new, 168 lines)
- `packages/react/src/__tests__/StewardLoginWithWallets.test.tsx` (new, 8 tests)
- `packages/react/src/wallet.ts` (export added)
- `packages/react/README.md` (drop-in section added)

Co-authored-by: wakesync <shadow@shad0w.xyz>
Co-authored-by: Sol <sol@shad0w.xyz>