### PR TITLE
chore(react): tpot copy overhaul on <StewardLogin> (W3)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -215,7 +215,7 @@
     },
     "packages/sdk": {
       "name": "@stwd/sdk",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "dependencies": {
         "bs58": "^6.0.0",
       },

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -158,7 +158,7 @@ export default function Login() {
   return (
     <StewardProvider auth={{ baseUrl: "https://api.steward.fi" }}>
       <StewardLoginWithWallets
-        title="Sign in"
+        title="sign in"
         showPasskey
         showEmail
         showGoogle
@@ -252,8 +252,8 @@ export function SolanaLogin() {
 | `onError` | `(error, kind) => void` | - | Fires on wallet reject, network errors, etc. |
 | `className` | `string` | - | Appended to the root element. |
 | `classes` | `WalletLoginClassOverrides` | - | Per-slot className overrides. |
-| `evmLabel` | `string` | `"Ethereum"` | Column heading for EVM. |
-| `solanaLabel` | `string` | `"Solana"` | Column heading for Solana. |
+| `evmLabel` | `string` | `"ethereum"` | Column heading for EVM. |
+| `solanaLabel` | `string` | `"solana"` | Column heading for Solana. |
 | `evmSignLabel` | `(walletName) => string` | - | Override the sign button label. |
 | `solanaSignLabel` | `(walletName) => string` | - | Override the sign button label. |
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stwd/react",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Embeddable React components for Steward agent wallet management",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/react/src/__tests__/StewardLogin.test.tsx
+++ b/packages/react/src/__tests__/StewardLogin.test.tsx
@@ -1,10 +1,10 @@
 /**
- * StewardLogin tests, Rules-of-Hooks regression coverage.
+ * StewardLogin tests: rules-of-hooks regression coverage.
  *
  * The previously-fixed bug placed `useRef` + `useEffect` after an early
  * return on `!ctx`. This test locks in the correct structure by mounting
- * the component in each branch, missing auth context, signed-in, and
- * signed-out , and asserting no throw.
+ * the component in each branch (missing auth context, signed-in, and
+ * signed-out) and asserting no throw.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -97,7 +97,7 @@ function wrap(value: AuthCtx | null, node: React.ReactNode) {
   );
 }
 
-describe("<StewardLogin /> , rules-of-hooks branch coverage", () => {
+describe("<StewardLogin /> rules-of-hooks branch coverage", () => {
   test("mounts when no auth context is present (renders inline error)", () => {
     // Provider missing → ctx is null → component shows error message.
     // Critically, this path must still call all hooks unconditionally before
@@ -140,7 +140,7 @@ describe("<StewardLogin /> , rules-of-hooks branch coverage", () => {
   });
 
   test("hook order is stable across ctx transitions", () => {
-    // Render three different ctx shapes, with the old bug (hooks after
+    // Render three different ctx shapes. With the old bug (hooks after
     // early return), the null ctx path would have called fewer hooks than
     // the authed path. Each render is fresh (SSR), but the invariant we
     // care about is that hook calls are unconditional. If they weren't,

--- a/packages/react/src/__tests__/StewardLogin.test.tsx
+++ b/packages/react/src/__tests__/StewardLogin.test.tsx
@@ -1,10 +1,10 @@
 /**
- * StewardLogin tests — Rules-of-Hooks regression coverage.
+ * StewardLogin tests, Rules-of-Hooks regression coverage.
  *
  * The previously-fixed bug placed `useRef` + `useEffect` after an early
  * return on `!ctx`. This test locks in the correct structure by mounting
- * the component in each branch — missing auth context, signed-in, and
- * signed-out — and asserting no throw.
+ * the component in each branch, missing auth context, signed-in, and
+ * signed-out , and asserting no throw.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -97,7 +97,7 @@ function wrap(value: AuthCtx | null, node: React.ReactNode) {
   );
 }
 
-describe("<StewardLogin /> — rules-of-hooks branch coverage", () => {
+describe("<StewardLogin /> , rules-of-hooks branch coverage", () => {
   test("mounts when no auth context is present (renders inline error)", () => {
     // Provider missing → ctx is null → component shows error message.
     // Critically, this path must still call all hooks unconditionally before
@@ -110,11 +110,11 @@ describe("<StewardLogin /> — rules-of-hooks branch coverage", () => {
     const html = renderToString(
       wrap(
         baseCtx({ isAuthenticated: false }),
-        React.createElement(StewardLogin, { title: "Welcome" }),
+        React.createElement(StewardLogin, { title: "welcome" }),
       ),
     );
-    expect(html).toContain("Welcome");
-    expect(html).toContain("Sign in with Passkey");
+    expect(html).toContain("welcome");
+    expect(html).toContain("passkey");
   });
 
   test("mounts in signed-in branch (renders nothing)", () => {
@@ -140,7 +140,7 @@ describe("<StewardLogin /> — rules-of-hooks branch coverage", () => {
   });
 
   test("hook order is stable across ctx transitions", () => {
-    // Render three different ctx shapes — with the old bug (hooks after
+    // Render three different ctx shapes, with the old bug (hooks after
     // early return), the null ctx path would have called fewer hooks than
     // the authed path. Each render is fresh (SSR), but the invariant we
     // care about is that hook calls are unconditional. If they weren't,

--- a/packages/react/src/__tests__/StewardLoginWithWallets.test.tsx
+++ b/packages/react/src/__tests__/StewardLoginWithWallets.test.tsx
@@ -59,7 +59,7 @@ describe("<StewardLoginWithWallets />", () => {
   test("wraps both EVM and Solana providers by default and renders <StewardLogin>", () => {
     const html = renderToString(
       React.createElement(StewardLoginWithWallets, {
-        title: "Sign in",
+        title: "sign in",
         evm: { projectId: "test-pid" },
       }),
     );
@@ -124,11 +124,11 @@ describe("<StewardLoginWithWallets />", () => {
   test("forwards StewardLogin props (title)", () => {
     const html = renderToString(
       React.createElement(StewardLoginWithWallets, {
-        title: "Custom Title",
+        title: "custom title",
         evm: { projectId: "p" },
       }),
     );
-    expect(html).toContain('data-title="Custom Title"');
+    expect(html).toContain('data-title="custom title"');
   });
 
   test("explicit showWallets prop wins over the auto default", () => {

--- a/packages/react/src/__tests__/WalletLogin.test.tsx
+++ b/packages/react/src/__tests__/WalletLogin.test.tsx
@@ -162,19 +162,19 @@ describe("EVM panel (direct render)", () => {
     const html = renderToString(
       wrap(
         React.createElement(WalletLoginEVM, {
-          label: "Ethereum",
+          label: "ethereum",
         }),
       ),
     );
-    expect(html).toContain("Ethereum");
+    expect(html).toContain("ethereum");
     expect(html).toContain("[ConnectButton]");
-    expect(html).toContain("Sign in with MetaMask");
+    expect(html).toContain("sign in with MetaMask");
   });
 
   test("renders hint when not connected", () => {
     mockEvmConnected = false;
-    const html = renderToString(wrap(React.createElement(WalletLoginEVM, { label: "Ethereum" })));
-    expect(html).toContain("Connect a wallet to continue");
+    const html = renderToString(wrap(React.createElement(WalletLoginEVM, { label: "ethereum" })));
+    expect(html).toContain("connect a wallet");
   });
 
   test("signInWithSIWE is invoked via panel signer callback", async () => {
@@ -204,13 +204,13 @@ describe("Solana panel (direct render)", () => {
     const html = renderToString(
       wrap(
         React.createElement(WalletLoginSolana, {
-          label: "Solana",
+          label: "solana",
         }),
       ),
     );
-    expect(html).toContain("Solana");
+    expect(html).toContain("solana");
     expect(html).toContain("[WalletMultiButton]");
-    expect(html).toContain("Sign in with Phantom");
+    expect(html).toContain("sign in with Phantom");
   });
 
   test("signInWithSolana is invoked via panel signer callback", async () => {
@@ -230,7 +230,7 @@ describe("Solana panel (direct render)", () => {
 
   test("sign button is disabled when signInWithSolana is not on context", () => {
     const html = renderToString(
-      wrap(React.createElement(WalletLoginSolana, { label: "Solana" }), {
+      wrap(React.createElement(WalletLoginSolana, { label: "solana" }), {
         signInWithSolana: undefined,
       }),
     );

--- a/packages/react/src/components/StewardLogin.tsx
+++ b/packages/react/src/components/StewardLogin.tsx
@@ -104,7 +104,7 @@ function useDynamicWalletPanel(
  * <StewardProvider client={client} agentId="..." auth={{ baseUrl: "https://api.steward.fi" }}>
  *   <StewardLogin
  *     variant="card"
- *     title="Welcome back"
+ *     title="welcome back"
  *     showWallets
  *     showGoogle
  *     showDiscord
@@ -205,7 +205,7 @@ export function StewardLogin({
 
   const handleWalletError = useCallback(
     (err: Error, kind: "evm" | "solana") => {
-      setErrorMsg(err.message || "Wallet sign-in failed.");
+      setErrorMsg(err.message || "wallet sign-in failed");
       setStep("error");
       setLoadingBtn(null);
       composeWalletError(onError)(err, kind);
@@ -231,7 +231,7 @@ export function StewardLogin({
     return (
       <div className={`stwd-login stwd-login--error ${className ?? ""}`}>
         <p className="stwd-login__error">
-          StewardLogin must be used inside a &lt;StewardProvider&gt; with an <code>auth</code> prop.
+          StewardLogin needs a &lt;StewardProvider&gt; with an <code>auth</code> prop.
         </p>
       </div>
     );
@@ -266,7 +266,7 @@ export function StewardLogin({
 
   const handlePasskey = async () => {
     if (!email.trim()) {
-      setErrorMsg("Enter your email address first.");
+      setErrorMsg("enter your email first");
       setStep("error");
       return;
     }
@@ -283,7 +283,7 @@ export function StewardLogin({
 
   const handleEmail = async () => {
     if (!email.trim()) {
-      setErrorMsg("Enter your email address.");
+      setErrorMsg("enter your email");
       setStep("error");
       return;
     }
@@ -305,7 +305,7 @@ export function StewardLogin({
     setErrorMsg(null);
     try {
       if (typeof ctx.signInWithOAuth !== "function") {
-        throw new Error("OAuth not available. Update @stwd/sdk.");
+        throw new Error("oauth unavailable. update @stwd/sdk");
       }
       const result = await ctx.signInWithOAuth(provider, tenantId ? { tenantId } : undefined);
       onSuccess?.(result);
@@ -321,11 +321,10 @@ export function StewardLogin({
     return (
       <div className={`stwd-login ${variantClass} stwd-login--sent ${className ?? ""}`}>
         <div className="stwd-login__notice">
-          <span className="stwd-login__notice-icon">✉️</span>
           <p>
-            Magic link sent to <strong>{email}</strong>
+            link sent to <strong>{email}</strong>
           </p>
-          <p className="stwd-login__notice-sub">Check your inbox and click the link to sign in.</p>
+          <p className="stwd-login__notice-sub">check your inbox, then tap the link</p>
         </div>
         <button
           className="stwd-login__btn stwd-login__btn--back"
@@ -335,7 +334,7 @@ export function StewardLogin({
           }}
           type="button"
         >
-          ← Back to login
+          back to login
         </button>
       </div>
     );
@@ -354,7 +353,7 @@ export function StewardLogin({
             (() => {
               const tenant = ctx.tenants.find((t) => t.tenantId === tenantId);
               return tenant ? (
-                <p className="stwd-login__tenant-name">Signing in to {tenant.tenantName}</p>
+                <p className="stwd-login__tenant-name">signing in to {tenant.tenantName}</p>
               ) : null;
             })()}
         </div>
@@ -377,7 +376,7 @@ export function StewardLogin({
             }}
             disabled={isLoading}
             autoComplete="email webauthn"
-            aria-label="Email address"
+            aria-label="email"
           />
         </div>
       )}
@@ -396,7 +395,7 @@ export function StewardLogin({
             ) : (
               <PasskeyIcon size={18} />
             )}
-            <span>Sign in with Passkey</span>
+            <span>passkey</span>
           </button>
         )}
 
@@ -412,7 +411,7 @@ export function StewardLogin({
             ) : (
               <EmailIcon size={18} />
             )}
-            <span>Send Magic Link</span>
+            <span>email me a link</span>
           </button>
         )}
       </div>
@@ -428,8 +427,8 @@ export function StewardLogin({
                 classes={walletClasses}
                 onSuccess={handleWalletSuccess}
                 onError={handleWalletError}
-                label="Ethereum"
-                signLabel={(name) => (name ? `Sign in with ${name}` : "Sign in with EVM wallet")}
+                label="ethereum"
+                signLabel={(name) => (name ? `sign in with ${name}` : "sign in with EVM wallet")}
               />
             ) : (
               <button
@@ -439,7 +438,7 @@ export function StewardLogin({
                 data-testid="stwd-login-wallet-evm-loading"
               >
                 <EthereumIcon size={18} />
-                <span>Loading EVM wallet...</span>
+                <span>loading EVM wallet...</span>
               </button>
             ))}
           {solanaReady &&
@@ -448,8 +447,8 @@ export function StewardLogin({
                 classes={walletClasses}
                 onSuccess={handleWalletSuccess}
                 onError={handleWalletError}
-                label="Solana"
-                signLabel={(name) => (name ? `Sign in with ${name}` : "Sign in with Solana wallet")}
+                label="solana"
+                signLabel={(name) => (name ? `sign in with ${name}` : "sign in with solana wallet")}
               />
             ) : (
               <button
@@ -458,7 +457,7 @@ export function StewardLogin({
                 disabled
                 data-testid="stwd-login-wallet-sol-loading"
               >
-                <span>Loading Solana wallet...</span>
+                <span>loading solana wallet...</span>
               </button>
             ))}
         </div>
@@ -494,7 +493,7 @@ export function StewardLogin({
               ) : (
                 <GoogleIcon size={18} />
               )}
-              <span>Google</span>
+              <span>google</span>
             </button>
           )}
 
@@ -510,7 +509,7 @@ export function StewardLogin({
               ) : (
                 <DiscordIcon size={18} />
               )}
-              <span>Discord</span>
+              <span>discord</span>
             </button>
           )}
 
@@ -526,7 +525,7 @@ export function StewardLogin({
               ) : (
                 <GitHubIcon size={18} />
               )}
-              <span>GitHub</span>
+              <span>github</span>
             </button>
           )}
 
@@ -542,7 +541,7 @@ export function StewardLogin({
               ) : (
                 <XIcon size={16} />
               )}
-              <span>X</span>
+              <span>x</span>
             </button>
           )}
         </div>
@@ -557,10 +556,10 @@ export function StewardLogin({
             className="stwd-login__btn stwd-login__btn--siwe"
             disabled={true}
             type="button"
-            title="Connect your wallet to sign in with Ethereum"
+            title="connect a wallet to sign in"
           >
             <EthereumIcon size={18} />
-            <span>Sign in with Ethereum</span>
+            <span>sign in with ethereum</span>
           </button>
         </div>
       )}

--- a/packages/react/src/components/StewardLogin.tsx
+++ b/packages/react/src/components/StewardLogin.tsx
@@ -305,7 +305,7 @@ export function StewardLogin({
     setErrorMsg(null);
     try {
       if (typeof ctx.signInWithOAuth !== "function") {
-        throw new Error("oauth unavailable. update @stwd/sdk");
+        throw new Error("OAuth unavailable. update @stwd/sdk");
       }
       const result = await ctx.signInWithOAuth(provider, tenantId ? { tenantId } : undefined);
       onSuccess?.(result);
@@ -493,7 +493,7 @@ export function StewardLogin({
               ) : (
                 <GoogleIcon size={18} />
               )}
-              <span>google</span>
+              <span>Google</span>
             </button>
           )}
 
@@ -509,7 +509,7 @@ export function StewardLogin({
               ) : (
                 <DiscordIcon size={18} />
               )}
-              <span>discord</span>
+              <span>Discord</span>
             </button>
           )}
 
@@ -525,7 +525,7 @@ export function StewardLogin({
               ) : (
                 <GitHubIcon size={18} />
               )}
-              <span>github</span>
+              <span>GitHub</span>
             </button>
           )}
 
@@ -541,7 +541,7 @@ export function StewardLogin({
               ) : (
                 <XIcon size={16} />
               )}
-              <span>x</span>
+              <span>X</span>
             </button>
           )}
         </div>

--- a/packages/react/src/components/WalletLogin.EVM.tsx
+++ b/packages/react/src/components/WalletLogin.EVM.tsx
@@ -29,13 +29,13 @@ export default function WalletLoginEVM({
   const handleSignIn = useCallback(async () => {
     setError(null);
     if (!ctx) {
-      const err = new Error("WalletLogin must be used inside <StewardProvider auth={...}>.");
+      const err = new Error("WalletLogin needs <StewardProvider auth={...}>.");
       setError(err.message);
       onError?.(err, "evm");
       return;
     }
     if (!address) {
-      const err = new Error("No EVM wallet connected.");
+      const err = new Error("no EVM wallet connected");
       setError(err.message);
       onError?.(err, "evm");
       return;
@@ -46,7 +46,7 @@ export default function WalletLoginEVM({
       onSuccess?.(result, "evm");
     } catch (e) {
       const err = e instanceof Error ? e : new Error(String(e));
-      setError(err.message || "Sign-in failed.");
+      setError(err.message || "sign-in failed");
       onError?.(err, "evm");
     } finally {
       setBusy(false);
@@ -57,15 +57,15 @@ export default function WalletLoginEVM({
   const labelText = signLabel
     ? signLabel(walletName)
     : walletName
-      ? `Sign in with ${walletName}`
-      : "Sign in";
+      ? `sign in with ${walletName}`
+      : "sign in";
 
   return (
     <div className={cx("stwd-wallet-col", classes?.column)}>
       <h3 className={cx("stwd-wallet-heading", classes?.heading)}>{label}</h3>
       <div className="stwd-wallet-connector">
         <ConnectButton
-          label="Connect wallet"
+          label="connect wallet"
           accountStatus="address"
           chainStatus="name"
           showBalance={false}
@@ -85,7 +85,7 @@ export default function WalletLoginEVM({
             onClick={handleSignIn}
             disabled={busy}
           >
-            {busy ? "Signing…" : labelText}
+            {busy ? "signing..." : labelText}
           </button>
           <button
             type="button"
@@ -93,12 +93,12 @@ export default function WalletLoginEVM({
             onClick={() => disconnect()}
             disabled={busy}
           >
-            Disconnect
+            disconnect
           </button>
         </>
       )}
       {!isConnected && (
-        <p className={cx("stwd-wallet-hint", classes?.hint)}>Connect a wallet to continue.</p>
+        <p className={cx("stwd-wallet-hint", classes?.hint)}>connect a wallet</p>
       )}
       {error && (
         <div className={cx("stwd-wallet-error", classes?.error)} role="alert">

--- a/packages/react/src/components/WalletLogin.EVM.tsx
+++ b/packages/react/src/components/WalletLogin.EVM.tsx
@@ -97,9 +97,7 @@ export default function WalletLoginEVM({
           </button>
         </>
       )}
-      {!isConnected && (
-        <p className={cx("stwd-wallet-hint", classes?.hint)}>connect a wallet</p>
-      )}
+      {!isConnected && <p className={cx("stwd-wallet-hint", classes?.hint)}>connect a wallet</p>}
       {error && (
         <div className={cx("stwd-wallet-error", classes?.error)} role="alert">
           {error}

--- a/packages/react/src/components/WalletLogin.Solana.tsx
+++ b/packages/react/src/components/WalletLogin.Solana.tsx
@@ -25,9 +25,7 @@ export default function WalletLoginSolana({
       return;
     }
     if (!ctx.signInWithSolana) {
-      const err = new Error(
-        "solana sign-in unavailable. upgrade @stwd/sdk to >= 0.8.0",
-      );
+      const err = new Error("solana sign-in unavailable. upgrade @stwd/sdk to >= 0.8.0");
       setError(err.message);
       onError?.(err, "solana");
       return;

--- a/packages/react/src/components/WalletLogin.Solana.tsx
+++ b/packages/react/src/components/WalletLogin.Solana.tsx
@@ -19,21 +19,21 @@ export default function WalletLoginSolana({
   const handleSignIn = useCallback(async () => {
     setError(null);
     if (!ctx) {
-      const err = new Error("WalletLogin must be used inside <StewardProvider auth={...}>.");
+      const err = new Error("WalletLogin needs <StewardProvider auth={...}>.");
       setError(err.message);
       onError?.(err, "solana");
       return;
     }
     if (!ctx.signInWithSolana) {
       const err = new Error(
-        "Solana sign-in is not available in this build of @stwd/sdk. Upgrade @stwd/sdk to ≥ 0.8.0.",
+        "solana sign-in unavailable. upgrade @stwd/sdk to >= 0.8.0",
       );
       setError(err.message);
       onError?.(err, "solana");
       return;
     }
     if (!wallet.publicKey || !wallet.signMessage) {
-      const err = new Error("Connected wallet does not support message signing.");
+      const err = new Error("wallet can't sign messages");
       setError(err.message);
       onError?.(err, "solana");
       return;
@@ -44,14 +44,14 @@ export default function WalletLoginSolana({
       const publicKey = wallet.publicKey.toBase58();
       const signMessageFn = async (msg: Uint8Array): Promise<Uint8Array> => {
         const out = await wallet.signMessage?.(msg);
-        if (!out) throw new Error("Wallet returned an empty signature.");
+        if (!out) throw new Error("wallet returned an empty signature");
         return out;
       };
       const result = await ctx.signInWithSolana(publicKey, signMessageFn);
       onSuccess?.(result, "solana");
     } catch (e) {
       const err = e instanceof Error ? e : new Error(String(e));
-      setError(err.message || "Sign-in failed.");
+      setError(err.message || "sign-in failed");
       onError?.(err, "solana");
     } finally {
       setBusy(false);
@@ -62,8 +62,8 @@ export default function WalletLoginSolana({
   const labelText = signLabel
     ? signLabel(walletName)
     : walletName
-      ? `Sign in with ${walletName}`
-      : "Sign in";
+      ? `sign in with ${walletName}`
+      : "sign in";
   const addr = wallet.publicKey?.toBase58();
 
   return (
@@ -85,12 +85,12 @@ export default function WalletLoginSolana({
             onClick={handleSignIn}
             disabled={busy || !ctx?.signInWithSolana}
           >
-            {busy ? "Signing…" : labelText}
+            {busy ? "signing..." : labelText}
           </button>
         </>
       )}
       {!wallet.connected && (
-        <p className={cx("stwd-wallet-hint", classes?.hint)}>Connect a wallet to continue.</p>
+        <p className={cx("stwd-wallet-hint", classes?.hint)}>connect a wallet</p>
       )}
       {error && (
         <div className={cx("stwd-wallet-error", classes?.error)} role="alert">

--- a/packages/react/src/components/WalletLogin.tsx
+++ b/packages/react/src/components/WalletLogin.tsx
@@ -1,7 +1,6 @@
 import type { StewardAuthResult } from "@stwd/sdk";
 import React, { useEffect, useMemo, useState } from "react";
 
-
 export type WalletChains = "evm" | "solana" | "both";
 
 export interface WalletLoginClassOverrides {
@@ -79,7 +78,7 @@ function useDynamicPanel(
 }
 
 /**
- * WalletLogin, first-class Steward wallet sign-in.
+ * WalletLogin: first-class Steward wallet sign-in.
  *
  * Supports EVM (wagmi + RainbowKit) and Solana (@solana/wallet-adapter-react).
  * Must live inside a `<StewardProvider auth={...}>` and, for each enabled chain,

--- a/packages/react/src/components/WalletLogin.tsx
+++ b/packages/react/src/components/WalletLogin.tsx
@@ -1,7 +1,6 @@
 import type { StewardAuthResult } from "@stwd/sdk";
 import React, { useEffect, useMemo, useState } from "react";
 
-// ─── Props ───────────────────────────────────────────────────────────────────
 
 export type WalletChains = "evm" | "solana" | "both";
 
@@ -14,11 +13,11 @@ export interface WalletLoginClassOverrides {
   heading?: string;
   /** Status line under the connector (address, chain name). */
   status?: string;
-  /** The "Sign in with..." action button. */
+  /** The sign action button. */
   signButton?: string;
   /** Inline error row. */
   error?: string;
-  /** Muted hint text ("Connect a wallet to continue"). */
+  /** Muted hint text ("connect a wallet"). */
   hint?: string;
 }
 
@@ -33,13 +32,13 @@ export interface WalletLoginProps {
   className?: string;
   /** Fine-grained className overrides for internal slots. */
   classes?: WalletLoginClassOverrides;
-  /** Label for the EVM column. Default: "Ethereum". */
+  /** Label for the EVM column. Default: "ethereum". */
   evmLabel?: string;
-  /** Label for the Solana column. Default: "Solana". */
+  /** Label for the Solana column. Default: "solana". */
   solanaLabel?: string;
-  /** Override the EVM sign button label. Default: "Sign in with {wallet}". */
+  /** Override the EVM sign button label. Default: "sign in with {wallet}". */
   evmSignLabel?: (walletName: string | undefined) => string;
-  /** Override the Solana sign button label. Default: "Sign in with {wallet}". */
+  /** Override the Solana sign button label. Default: "sign in with {wallet}". */
   solanaSignLabel?: (walletName: string | undefined) => string;
 }
 
@@ -98,8 +97,8 @@ export function WalletLogin({
   onError,
   className,
   classes,
-  evmLabel = "Ethereum",
-  solanaLabel = "Solana",
+  evmLabel = "ethereum",
+  solanaLabel = "solana",
   evmSignLabel,
   solanaSignLabel,
 }: WalletLoginProps) {

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -378,7 +378,7 @@ export interface StewardLoginProps {
   variant?: "card" | "inline";
   /** Custom logo element rendered at top of the login widget */
   logo?: React.ReactNode;
-  /** Title text (default: "Sign in") */
+  /** Title text (e.g. "sign in", "welcome back"). */
   title?: string;
   /** Subtitle text below the title */
   subtitle?: string;


### PR DESCRIPTION
## summary

TPOT-adjacent voice pass on `<StewardLogin>` and the `<WalletLogin>` panels: lowercase free-form copy, no em-dashes, shorter button labels, and de-corporate-speak the error strings. Two commits:

1. **wip(react): mechanical copy lowercase pass (gpt-5.5 baseline)** — first-pass mechanical lowercase + em-dash strip from a worker.
2. **chore(react): restore brand caps and fix mangled comments (W3 taste pass)** — opus refinement on top.

## voice rules applied

- lowercase free-form copy (`welcome back`, `passkey`, `email me a link`, `back to login`, `connect a wallet`)
- **brand names stay capitalized**: Google, Discord, GitHub, X, MetaMask, Phantom, etc.
- **initialisms stay caps**: EVM, SIWE, OAuth (e.g. `loading EVM wallet...`, `OAuth unavailable. update @stwd/sdk`)
- **chain category labels lowercase**: `ethereum`, `solana` (read like categories, not products)
- no em-dashes anywhere in the touched files
- short error strings: `no EVM wallet connected`, `sign-in failed`, `wallet can't sign messages`

## taste decisions

**reverted from gpt 5.5's overcorrect:**
- `<span>google</span>` -> `<span>Google</span>` (and the same for Discord, GitHub, X)
- `"oauth unavailable..."` -> `"OAuth unavailable..."` (initialism)
- `types.ts` JSDoc default-title hint reflowed (was still referencing `"Sign in"`)
- `WalletLogin` JSDoc header `WalletLogin, first-class...` -> `WalletLogin: first-class...` (the comma-as-em-dash-replacement read like a list)
- `StewardLogin.test.tsx` block comment `tests, Rules-of-Hooks` -> `tests: rules-of-hooks`, and the mangled `, missing auth context, signed-in, and signed-out ,` insert reflowed with parens

**kept from gpt 5.5:**
- `passkey` / `email me a link` / `back to login` button copy
- `welcome back` default header
- removing the ✉️ emoji from the email-sent screen
- simplified email-sent state copy (`link sent to`, `check your inbox, then tap the link`)
- `enter your email` / `enter your email first` validation strings
- chain labels `ethereum` / `solana`
- `signing...` / `disconnect` / `connect a wallet`

**no new copy added** beyond what gpt 5.5 produced — this is purely a taste pass on the lowercase decisions, not a third revision of the copy itself.

## verification

- `bun run lint` ✅ (also auto-fixed three biome formatter nits left over from the wip commit)
- `cd packages/react && bun test` ✅ (55 pass, 0 fail)
- `bunx turbo run build --filter='@stwd/react'` ✅

## not touched

- class names, test ids (`stwd-login__btn--google`)
- protocol values (provider IDs like `"google"` in API calls)
- variable / type / constant names
- `package.json` versions (already bumped to 0.8.2)

## context

Worker pipeline: GPT 5.5 mechanical pass → Opus taste pass (this PR) → Sol does codex review iteration after merge of any review-driven follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)