### PR TITLE
Add OAuth nonce-exchange flow (response_type=code)

### DIFF
--- a/packages/api/src/__tests__/auth-oauth-nonce-exchange.test.ts
+++ b/packages/api/src/__tests__/auth-oauth-nonce-exchange.test.ts
@@ -1,0 +1,197 @@
+/**
+ * /oauth/exchange — nonce-exchange round-trip.
+ *
+ * Covers the new `response_type=code` flow: a one-time code is bound to
+ * {redirectUri, tenantId} at issue time and consumed atomically by the
+ * exchange route. Tests focus on the validation contract — single-use,
+ * redirect/tenant binding, TTL — without standing up a real provider.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { Hono } from "hono";
+import {
+  _clearOAuthCodeStoreForTests,
+  _seedOAuthExchangeCodeForTests,
+  authRoutes,
+} from "../routes/auth";
+
+const REDIRECT_URI = "https://app.example.test/checkout";
+const TENANT_ID = "elizacloud";
+
+function makeApp(): Hono {
+  const app = new Hono();
+  app.route("/auth", authRoutes);
+  return app;
+}
+
+async function postExchange(
+  app: Hono,
+  body: Record<string, unknown>,
+): Promise<{ status: number; json: Record<string, unknown> }> {
+  const res = await app.request("/auth/oauth/exchange", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return { status: res.status, json: (await res.json()) as Record<string, unknown> };
+}
+
+describe("POST /auth/oauth/exchange", () => {
+  beforeEach(() => {
+    _clearOAuthCodeStoreForTests();
+  });
+
+  afterEach(() => {
+    _clearOAuthCodeStoreForTests();
+  });
+
+  it("returns the bound tokens when code + redirect_uri + tenant_id all match", async () => {
+    const app = makeApp();
+    _seedOAuthExchangeCodeForTests("nonce-happy-path", {
+      token: "access-jwt",
+      refreshToken: "refresh-raw",
+      redirectUri: REDIRECT_URI,
+      tenantId: TENANT_ID,
+    });
+
+    const { status, json } = await postExchange(app, {
+      code: "nonce-happy-path",
+      redirect_uri: REDIRECT_URI,
+      tenant_id: TENANT_ID,
+    });
+
+    expect(status).toBe(200);
+    expect(json.ok).toBe(true);
+    expect(json.token).toBe("access-jwt");
+    expect(json.refreshToken).toBe("refresh-raw");
+    expect(typeof json.expiresAt).toBe("number");
+    expect(json.expiresIn).toBe(900);
+  });
+
+  it("rejects unknown / already-consumed codes with code_invalid", async () => {
+    const app = makeApp();
+    const { status, json } = await postExchange(app, {
+      code: "never-issued",
+      redirect_uri: REDIRECT_URI,
+    });
+    expect(status).toBe(401);
+    expect(json.code).toBe("code_invalid");
+  });
+
+  it("is single-use: a second exchange of the same code fails with code_invalid", async () => {
+    const app = makeApp();
+    _seedOAuthExchangeCodeForTests("nonce-once", {
+      token: "t",
+      refreshToken: "r",
+      redirectUri: REDIRECT_URI,
+      tenantId: TENANT_ID,
+    });
+
+    const first = await postExchange(app, {
+      code: "nonce-once",
+      redirect_uri: REDIRECT_URI,
+      tenant_id: TENANT_ID,
+    });
+    expect(first.status).toBe(200);
+
+    const second = await postExchange(app, {
+      code: "nonce-once",
+      redirect_uri: REDIRECT_URI,
+      tenant_id: TENANT_ID,
+    });
+    expect(second.status).toBe(401);
+    expect(second.json.code).toBe("code_invalid");
+  });
+
+  it("rejects a redirect_uri mismatch with code_redirect_mismatch and still burns the nonce", async () => {
+    const app = makeApp();
+    _seedOAuthExchangeCodeForTests("nonce-bad-redirect", {
+      token: "t",
+      refreshToken: "r",
+      redirectUri: REDIRECT_URI,
+      tenantId: TENANT_ID,
+    });
+
+    const bad = await postExchange(app, {
+      code: "nonce-bad-redirect",
+      redirect_uri: "https://attacker.example/landing",
+      tenant_id: TENANT_ID,
+    });
+    expect(bad.status).toBe(401);
+    expect(bad.json.code).toBe("code_redirect_mismatch");
+
+    // Defense in depth: even the correct redirect_uri cannot retry — the
+    // first lookup consumed (deleted) the code.
+    const retry = await postExchange(app, {
+      code: "nonce-bad-redirect",
+      redirect_uri: REDIRECT_URI,
+      tenant_id: TENANT_ID,
+    });
+    expect(retry.status).toBe(401);
+    expect(retry.json.code).toBe("code_invalid");
+  });
+
+  it("rejects a tenant_id mismatch with code_tenant_mismatch", async () => {
+    const app = makeApp();
+    _seedOAuthExchangeCodeForTests("nonce-bad-tenant", {
+      token: "t",
+      refreshToken: "r",
+      redirectUri: REDIRECT_URI,
+      tenantId: TENANT_ID,
+    });
+
+    const bad = await postExchange(app, {
+      code: "nonce-bad-tenant",
+      redirect_uri: REDIRECT_URI,
+      tenant_id: "different-tenant",
+    });
+    expect(bad.status).toBe(401);
+    expect(bad.json.code).toBe("code_tenant_mismatch");
+  });
+
+  it("rejects an expired code with code_expired", async () => {
+    const app = makeApp();
+    _seedOAuthExchangeCodeForTests("nonce-expired", {
+      token: "t",
+      refreshToken: "r",
+      redirectUri: REDIRECT_URI,
+      tenantId: TENANT_ID,
+      expiresAt: Date.now() - 1000,
+    });
+
+    const { status, json } = await postExchange(app, {
+      code: "nonce-expired",
+      redirect_uri: REDIRECT_URI,
+      tenant_id: TENANT_ID,
+    });
+    expect(status).toBe(401);
+    expect(json.code).toBe("code_expired");
+  });
+
+  it("treats a missing/null tenant on issue as matching no tenant on exchange", async () => {
+    const app = makeApp();
+    _seedOAuthExchangeCodeForTests("nonce-no-tenant", {
+      token: "t",
+      refreshToken: "r",
+      redirectUri: REDIRECT_URI,
+      tenantId: null,
+    });
+
+    const { status, json } = await postExchange(app, {
+      code: "nonce-no-tenant",
+      redirect_uri: REDIRECT_URI,
+      // tenant_id omitted
+    });
+    expect(status).toBe(200);
+    expect(json.ok).toBe(true);
+  });
+
+  it("400s when code or redirect_uri is missing", async () => {
+    const app = makeApp();
+    const missingCode = await postExchange(app, { redirect_uri: REDIRECT_URI });
+    expect(missingCode.status).toBe(400);
+
+    const missingRedirect = await postExchange(app, { code: "x" });
+    expect(missingRedirect.status).toBe(400);
+  });
+});

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -282,6 +282,16 @@ async function consumeSiweNonce(nonce: string): Promise<boolean> {
 
 let _challengeStore: ChallengeStore | null = null;
 let _tokenStore: TokenStore | null = null;
+let _oauthCodeStore: ChallengeStore | null = null;
+
+/**
+ * One-time OAuth nonce-exchange codes (response_type=code) live for 60s —
+ * long enough for the user's browser to redirect back and the caller's
+ * backend to POST the code to /oauth/exchange, short enough that a captured
+ * code in an access log or Referer leak is useless by the time anyone reads
+ * it. Codes are single-use (consume() deletes on first read).
+ */
+const OAUTH_CODE_TTL_MS = 60 * 1000;
 
 /**
  * Initialize auth token/challenge stores with the best available backend.
@@ -311,6 +321,13 @@ export async function initAuthStores(usePostgres = false): Promise<void> {
   _challengeStore = new ChallengeStore({ backend: challengeBackend });
   _tokenStore = new TokenStore({ backend: tokenBackend });
   _nonceBackend = nonceBackend;
+  // Reuse the challenge backend (Redis when available) for OAuth nonce codes
+  // so they survive worker restarts and round-robin between isolates. The
+  // 60s TTL is enforced at write time by ChallengeStore.
+  _oauthCodeStore = new ChallengeStore({
+    backend: challengeBackend,
+    ttlMs: OAUTH_CODE_TTL_MS,
+  });
 
   // Reset singletons so they pick up the new stores on next use
   _passkeyAuth = null;
@@ -321,6 +338,11 @@ export async function initAuthStores(usePostgres = false): Promise<void> {
 function getChallengeStore(): ChallengeStore {
   _challengeStore ??= new ChallengeStore();
   return _challengeStore;
+}
+
+function getOAuthCodeStore(): ChallengeStore {
+  _oauthCodeStore ??= new ChallengeStore({ ttlMs: OAUTH_CODE_TTL_MS });
+  return _oauthCodeStore;
 }
 
 function getTokenStore(): TokenStore {
@@ -662,6 +684,40 @@ export function clearEmailAuthTenantCacheForTests(): void {
 
 export function clearOAuthTokenKeyStoreForTests(): void {
   _oauthKeyStore = null;
+}
+
+/**
+ * Test-only seam: write a fully-formed OAuth nonce payload into the code
+ * store so the /oauth/exchange route can be exercised end-to-end without
+ * running a real provider callback. Production callers should never use
+ * this — the only writer of the code store is the `/oauth/<provider>/callback`
+ * handler.
+ */
+export function _seedOAuthExchangeCodeForTests(
+  code: string,
+  payload: {
+    token: string;
+    refreshToken: string;
+    redirectUri: string;
+    tenantId: string | null;
+    expiresAt?: number;
+    expiresIn?: number;
+  },
+): void {
+  const fullPayload = {
+    token: payload.token,
+    refreshToken: payload.refreshToken,
+    redirectUri: payload.redirectUri,
+    tenantId: payload.tenantId,
+    expiresAt: payload.expiresAt ?? Date.now() + OAUTH_CODE_TTL_MS,
+    expiresIn: payload.expiresIn ?? ACCESS_TOKEN_EXPIRY_SECONDS,
+  };
+  getOAuthCodeStore().set(`oauth-code:${code}`, JSON.stringify(fullPayload));
+}
+
+export function _clearOAuthCodeStoreForTests(): void {
+  _oauthCodeStore?.destroy();
+  _oauthCodeStore = null;
 }
 
 // ─── Vault helper ─────────────────────────────────────────────────────────────
@@ -1983,8 +2039,24 @@ auth.get("/oauth/:provider/authorize", async (c) => {
   // is trimmed defensively for the same reason we trim headers elsewhere.
   const tenantId = c.req.query("tenant_id")?.trim() || c.req.query("tenantId")?.trim() || undefined;
 
+  // `response_type=code` opts the caller into the nonce-exchange flow. Instead
+  // of leaking `?token=...&refreshToken=...` in the redirect URL (which gets
+  // captured by browser history, server access logs, Referer headers from any
+  // resource the landing page loads, and the user clipboard), the callback
+  // issues a one-time `?code=<nonce>` that the caller's backend exchanges for
+  // the real tokens server-side via POST /oauth/exchange. Legacy callers that
+  // omit response_type still get the token-in-query redirect for one release.
+  const responseType = c.req.query("response_type")?.trim() || undefined;
+
   if (!redirectUri) {
     return c.json<ApiResponse>({ ok: false, error: "redirect_uri is required" }, 400);
+  }
+
+  if (responseType !== undefined && responseType !== "code" && responseType !== "token") {
+    return c.json<ApiResponse>(
+      { ok: false, error: "response_type must be 'code' or 'token'" },
+      400,
+    );
   }
 
   // Generate a cryptographically random state value
@@ -2002,6 +2074,7 @@ auth.get("/oauth/:provider/authorize", async (c) => {
     provider: providerName,
     tenantId,
     redirectUri,
+    responseType,
     ...(codeVerifier ? { codeVerifier } : {}),
   });
   getChallengeStore().set(`oauth:${state}`, statePayload);
@@ -2050,6 +2123,7 @@ auth.get("/oauth/:provider/callback", async (c) => {
     provider: string;
     tenantId?: string;
     redirectUri: string;
+    responseType?: string;
     codeVerifier?: string;
   };
   try {
@@ -2134,11 +2208,159 @@ auth.get("/oauth/:provider/callback", async (c) => {
     return c.json<ApiResponse>({ ok: false, error: result.error }, 500);
   }
 
-  // Redirect to the app with the JWT
+  // Branch: nonce-exchange (`response_type=code`) vs legacy token-in-query.
+  //
+  // Nonce-exchange path: issue a one-time, short-lived (60s) code that the
+  // caller's backend trades for the real tokens via POST /oauth/exchange.
+  // This keeps the tokens off the address bar / browser history / Referer /
+  // upstream access logs / any window the user copy-pastes. The pair
+  // {redirectUri, tenantId} is bound to the code so a stolen code cannot be
+  // redeemed against a different redirect_uri or pivoted to another tenant.
+  if (stateData.responseType === "code") {
+    const nonceBytes = new Uint8Array(32);
+    crypto.getRandomValues(nonceBytes);
+    const code = uint8ArrayToBase64url(nonceBytes);
+    const issuedAt = Date.now();
+    const expiresAt = issuedAt + OAUTH_CODE_TTL_MS;
+    const codePayload = JSON.stringify({
+      token: result.token,
+      refreshToken: result.refreshToken,
+      redirectUri: stateData.redirectUri,
+      tenantId: stateData.tenantId ?? null,
+      expiresAt,
+      expiresIn: ACCESS_TOKEN_EXPIRY_SECONDS,
+    });
+    getOAuthCodeStore().set(`oauth-code:${code}`, codePayload);
+    const redirectUrl = new URL(stateData.redirectUri);
+    redirectUrl.searchParams.set("code", code);
+    return c.redirect(redirectUrl.toString(), 302);
+  }
+
+  // Legacy: redirect with tokens directly in the query string. Kept for one
+  // release cycle so existing integrators don't break. Mark for removal in a
+  // follow-up once all callers have moved to `response_type=code`.
   const redirectUrl = new URL(stateData.redirectUri);
   redirectUrl.searchParams.set("token", result.token);
   redirectUrl.searchParams.set("refreshToken", result.refreshToken);
   return c.redirect(redirectUrl.toString(), 302);
+});
+
+/**
+ * POST /auth/oauth/exchange
+ *
+ * Nonce-exchange endpoint for the `response_type=code` OAuth flow above.
+ * Trades a one-time `code` for the real `{token, refreshToken, expiresAt}`
+ * payload. The code is bound to the `redirect_uri` and `tenant_id` that were
+ * supplied at /authorize time; both must match or the exchange is rejected.
+ *
+ * Body: { code: string; redirect_uri: string; tenant_id?: string | null }
+ * Returns 200 { ok: true, token, refreshToken, expiresIn, expiresAt }
+ * Errors:
+ *   400 invalid_request        — missing/blank `code` or `redirect_uri`
+ *   401 code_invalid           — unknown / already-consumed / expired code
+ *   401 code_expired           — found but past `expiresAt` (defense-in-depth;
+ *                                the store TTL already evicts these)
+ *   401 code_redirect_mismatch — `redirect_uri` does not match
+ *   401 code_tenant_mismatch   — `tenant_id` does not match
+ *
+ * The code is consumed (deleted) on the FIRST lookup, before any validation,
+ * so a redirect_uri / tenant mismatch still burns the nonce. This prevents an
+ * attacker who guesses or steals a code from probing for the bound redirect.
+ */
+auth.post("/oauth/exchange", async (c) => {
+  const body = await safeJsonParse<{
+    code?: unknown;
+    redirect_uri?: unknown;
+    redirectUri?: unknown;
+    tenant_id?: unknown;
+    tenantId?: unknown;
+  }>(c);
+
+  const code = typeof body?.code === "string" ? body.code.trim() : "";
+  const redirectUri =
+    typeof body?.redirect_uri === "string"
+      ? body.redirect_uri.trim()
+      : typeof body?.redirectUri === "string"
+        ? body.redirectUri.trim()
+        : "";
+  const rawTenantId =
+    typeof body?.tenant_id === "string"
+      ? body.tenant_id.trim()
+      : typeof body?.tenantId === "string"
+        ? body.tenantId.trim()
+        : "";
+  const tenantId = rawTenantId.length > 0 ? rawTenantId : null;
+
+  if (!code || !redirectUri) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "code and redirect_uri are required" },
+      400,
+    );
+  }
+
+  // One-shot consume — even on mismatch, the code is burned so an attacker
+  // cannot retry with corrected parameters.
+  const raw = await getOAuthCodeStore().consume(`oauth-code:${code}`);
+  if (!raw) {
+    return c.json<ApiResponse & { code: string }>(
+      { ok: false, error: "Invalid or already-used code", code: "code_invalid" },
+      401,
+    );
+  }
+
+  let payload: {
+    token: string;
+    refreshToken: string;
+    redirectUri: string;
+    tenantId: string | null;
+    expiresAt: number;
+    expiresIn: number;
+  };
+  try {
+    payload = JSON.parse(raw);
+  } catch {
+    return c.json<ApiResponse & { code: string }>(
+      { ok: false, error: "Malformed code payload", code: "code_invalid" },
+      401,
+    );
+  }
+
+  if (Date.now() > payload.expiresAt) {
+    return c.json<ApiResponse & { code: string }>(
+      { ok: false, error: "Code expired", code: "code_expired" },
+      401,
+    );
+  }
+
+  if (payload.redirectUri !== redirectUri) {
+    return c.json<ApiResponse & { code: string }>(
+      {
+        ok: false,
+        error: "redirect_uri does not match the one issued with the code",
+        code: "code_redirect_mismatch",
+      },
+      401,
+    );
+  }
+
+  if ((payload.tenantId ?? null) !== tenantId) {
+    return c.json<ApiResponse & { code: string }>(
+      {
+        ok: false,
+        error: "tenant_id does not match the one issued with the code",
+        code: "code_tenant_mismatch",
+      },
+      401,
+    );
+  }
+
+  return c.json({
+    ok: true,
+    token: payload.token,
+    refreshToken: payload.refreshToken,
+    expiresIn: payload.expiresIn,
+    expiresAt: payload.expiresAt,
+  });
 });
 
 /**


### PR DESCRIPTION
## Summary

Adds an opt-in OAuth nonce-exchange (authorization-code) flow so callers can keep access and refresh tokens **off the URL** of the post-OAuth redirect. The existing \`?token=&refreshToken=\` query-string redirect is preserved unchanged for one release cycle.

### Why

Today \`GET /auth/oauth/<provider>/callback\` redirects to the caller-supplied \`redirect_uri\` with \`?token=<jwt>&refreshToken=<raw>\`. Those tokens land in:

- browser history (sticks around long after the user signs out)
- server access logs / CDN logs / WAF logs at every hop the redirect crosses
- the \`Referer\` header on every resource the landing page loads
- the user's clipboard if they share the URL
- any third-party script (Sentry, analytics, etc.) that reads \`location.href\`

The fragment (\`#token=\`) workaround already in place at the caller side helps, but it still requires every consumer to land tokens in client-side JS before sending them to a server. A server-side exchange is the standard fix.

### Flow (opt-in via \`response_type=code\`)

1. Caller appends \`response_type=code\` to \`GET /auth/oauth/<provider>/authorize\`.
2. After the provider callback finishes user provisioning, the API mints a 32-byte base64url \`code\` and stores \`{token, refreshToken, redirectUri, tenantId, expiresAt}\` in the challenge store with a 60-second TTL.
3. The user is redirected to \`redirect_uri?code=<NONCE>\` — **no tokens in the URL**.
4. The caller's backend exchanges the code via \`POST /auth/oauth/exchange\` with \`{ code, redirect_uri, tenant_id }\`. The code is **consumed (deleted) on the first lookup**, so a stolen code is useless after one read regardless of whether the bound parameters match.

### Error contract

| Code | Meaning |
| --- | --- |
| \`code_invalid\` | unknown / already-consumed |
| \`code_expired\` | past \`expiresAt\` (defense-in-depth; the store TTL also evicts) |
| \`code_redirect_mismatch\` | \`redirect_uri\` does not match issue |
| \`code_tenant_mismatch\` | \`tenant_id\` does not match issue |

### Backwards compatibility

Callers that omit \`response_type\` keep getting the token-in-query redirect. Plan is to flip the legacy branch off in a follow-up after consumers (Eliza Cloud's \`elizaos.ai\` checkout and \`elizacloud.ai\` dashboard) have moved over.

## Files

- \`packages/api/src/routes/auth.ts\`
  - new \`getOAuthCodeStore()\` (60s-TTL \`ChallengeStore\`, reuses the Redis backend when available so codes survive worker restarts)
  - \`response_type\` handling in \`/oauth/:provider/authorize\`
  - nonce branch in \`/oauth/:provider/callback\`
  - new \`POST /oauth/exchange\` route
  - test seam: \`_seedOAuthExchangeCodeForTests\`, \`_clearOAuthCodeStoreForTests\`
- \`packages/api/src/__tests__/auth-oauth-nonce-exchange.test.ts\` — 8 round-trip cases (happy path, single-use, redirect mismatch, tenant mismatch, TTL, missing-field 400s)

## Test plan

- [x] \`bun test packages/api/src/__tests__/auth-oauth-nonce-exchange.test.ts\` — 8/8 pass
- [x] \`bun run build\` — full typecheck across the monorepo
- [ ] Manual smoke against staging once a consumer is wired up

🤖 Generated with [Claude Code](https://claude.com/claude-code)