### PR TITLE
DO NOT MERGE: Remove legacy ?token= branch from OAuth callback

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stwd/api",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "main": "src/index.ts",

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -2039,22 +2039,21 @@ auth.get("/oauth/:provider/authorize", async (c) => {
   // is trimmed defensively for the same reason we trim headers elsewhere.
   const tenantId = c.req.query("tenant_id")?.trim() || c.req.query("tenantId")?.trim() || undefined;
 
-  // `response_type=code` opts the caller into the nonce-exchange flow. Instead
-  // of leaking `?token=...&refreshToken=...` in the redirect URL (which gets
-  // captured by browser history, server access logs, Referer headers from any
-  // resource the landing page loads, and the user clipboard), the callback
-  // issues a one-time `?code=<nonce>` that the caller's backend exchanges for
-  // the real tokens server-side via POST /oauth/exchange. Legacy callers that
-  // omit response_type still get the token-in-query redirect for one release.
-  const responseType = c.req.query("response_type")?.trim() || undefined;
+  // The callback always uses the nonce-exchange flow: it issues a one-time
+  // `?code=<nonce>` that the caller's backend exchanges for the real tokens
+  // server-side via POST /oauth/exchange. This keeps tokens out of browser
+  // history, server access logs, Referer headers, and the clipboard. The
+  // only accepted `response_type` is `code`; it defaults to `code` when
+  // omitted so callers that don't set it still get the secure flow.
+  const responseType = c.req.query("response_type")?.trim() || "code";
 
   if (!redirectUri) {
     return c.json<ApiResponse>({ ok: false, error: "redirect_uri is required" }, 400);
   }
 
-  if (responseType !== undefined && responseType !== "code" && responseType !== "token") {
+  if (responseType !== "code") {
     return c.json<ApiResponse>(
-      { ok: false, error: "response_type must be 'code' or 'token'" },
+      { ok: false, error: "response_type must be 'code'" },
       400,
     );
   }
@@ -2074,7 +2073,6 @@ auth.get("/oauth/:provider/authorize", async (c) => {
     provider: providerName,
     tenantId,
     redirectUri,
-    responseType,
     ...(codeVerifier ? { codeVerifier } : {}),
   });
   getChallengeStore().set(`oauth:${state}`, statePayload);
@@ -2093,7 +2091,9 @@ auth.get("/oauth/:provider/authorize", async (c) => {
  *   4. Find/create user by email
  *   5. Upsert entry in `accounts` table
  *   6. Link user to requested tenant
- *   7. Mint JWT → redirect to app redirect_uri with ?token=<jwt>
+ *   7. Mint JWT → issue a one-time nonce, redirect to app redirect_uri with
+ *      ?code=<nonce> (the caller's backend then POSTs /oauth/exchange to
+ *      trade the nonce for the real tokens).
  */
 auth.get("/oauth/:provider/callback", async (c) => {
   const providerName = c.req.param("provider");
@@ -2123,7 +2123,6 @@ auth.get("/oauth/:provider/callback", async (c) => {
     provider: string;
     tenantId?: string;
     redirectUri: string;
-    responseType?: string;
     codeVerifier?: string;
   };
   try {
@@ -2208,40 +2207,28 @@ auth.get("/oauth/:provider/callback", async (c) => {
     return c.json<ApiResponse>({ ok: false, error: result.error }, 500);
   }
 
-  // Branch: nonce-exchange (`response_type=code`) vs legacy token-in-query.
-  //
-  // Nonce-exchange path: issue a one-time, short-lived (60s) code that the
-  // caller's backend trades for the real tokens via POST /oauth/exchange.
-  // This keeps the tokens off the address bar / browser history / Referer /
-  // upstream access logs / any window the user copy-pastes. The pair
+  // Nonce-exchange: issue a one-time, short-lived code that the caller's
+  // backend trades for the real tokens via POST /oauth/exchange. This keeps
+  // the tokens off the address bar / browser history / Referer / upstream
+  // access logs / any window the user copy-pastes. The pair
   // {redirectUri, tenantId} is bound to the code so a stolen code cannot be
   // redeemed against a different redirect_uri or pivoted to another tenant.
-  if (stateData.responseType === "code") {
-    const nonceBytes = new Uint8Array(32);
-    crypto.getRandomValues(nonceBytes);
-    const code = uint8ArrayToBase64url(nonceBytes);
-    const issuedAt = Date.now();
-    const expiresAt = issuedAt + OAUTH_CODE_TTL_MS;
-    const codePayload = JSON.stringify({
-      token: result.token,
-      refreshToken: result.refreshToken,
-      redirectUri: stateData.redirectUri,
-      tenantId: stateData.tenantId ?? null,
-      expiresAt,
-      expiresIn: ACCESS_TOKEN_EXPIRY_SECONDS,
-    });
-    getOAuthCodeStore().set(`oauth-code:${code}`, codePayload);
-    const redirectUrl = new URL(stateData.redirectUri);
-    redirectUrl.searchParams.set("code", code);
-    return c.redirect(redirectUrl.toString(), 302);
-  }
-
-  // Legacy: redirect with tokens directly in the query string. Kept for one
-  // release cycle so existing integrators don't break. Mark for removal in a
-  // follow-up once all callers have moved to `response_type=code`.
+  const nonceBytes = new Uint8Array(32);
+  crypto.getRandomValues(nonceBytes);
+  const code = uint8ArrayToBase64url(nonceBytes);
+  const issuedAt = Date.now();
+  const expiresAt = issuedAt + OAUTH_CODE_TTL_MS;
+  const codePayload = JSON.stringify({
+    token: result.token,
+    refreshToken: result.refreshToken,
+    redirectUri: stateData.redirectUri,
+    tenantId: stateData.tenantId ?? null,
+    expiresAt,
+    expiresIn: ACCESS_TOKEN_EXPIRY_SECONDS,
+  });
+  getOAuthCodeStore().set(`oauth-code:${code}`, codePayload);
   const redirectUrl = new URL(stateData.redirectUri);
-  redirectUrl.searchParams.set("token", result.token);
-  redirectUrl.searchParams.set("refreshToken", result.refreshToken);
+  redirectUrl.searchParams.set("code", code);
   return c.redirect(redirectUrl.toString(), 302);
 });
 


### PR DESCRIPTION
## DO NOT MERGE

**Blocked on:**
1. PR #45 (nonce-exchange-flow) merged into `develop`.
2. All Eliza callers (`os-homepage`, `cloud-frontend`) shipped and running on `response_type=code` for at least one release window — confirmed via access logs that no live caller is still hitting `/oauth/:provider/callback` without `response_type=code`.

Once both conditions hold, retarget this PR's base from `nonce-exchange-flow` to `develop` and merge.

## Why this is targeted at `nonce-exchange-flow`, not `develop`

The legacy branch only exists in `develop` *after* #45 lands. Basing this PR off `nonce-exchange-flow` keeps the diff scoped to exactly the cleanup (32 insertions / 45 deletions in two files) rather than dragging in all of #45's changes. GitHub will accept a base-branch retarget after #45 merges.

## Summary

This is the follow-up cleanup PR mentioned in #45's rollout plan. After #45 ships, the OAuth callback supports two response paths:
- `response_type=code` — secure nonce-exchange (the new default for all Eliza callers).
- omitted / `response_type=token` — legacy `?token=<jwt>&refreshToken=<raw>` redirect, kept temporarily for backward compatibility.

This PR removes the legacy branch.

## Changes

**`packages/api/src/routes/auth.ts`** (the only meaningful diff)

- `/oauth/:provider/authorize`:
  - `responseType` defaults to `"code"` when the query param is omitted, so callers that never set it still get the secure flow (no silent fallback to legacy).
  - `response_type=token` is now rejected with `400 response_type must be 'code'` (was previously accepted).
  - The state payload no longer carries `responseType` (it's redundant — only one flow exists).
- `/oauth/:provider/callback`:
  - The `if (stateData.responseType === "code") { ... }` branch is collapsed into the unconditional code path.
  - The legacy fall-through that did `redirectUrl.searchParams.set("token", ...); redirectUrl.searchParams.set("refreshToken", ...)` is **deleted**.
  - The route doc-comment that referenced `?token=<jwt>` is updated.

**`packages/api/package.json`**: `@stwd/api` 0.3.0 → 0.3.1 (patch — security cleanup, no break for callers already on `response_type=code`).

## Test changes

No legacy-flow coverage existed in `packages/api/src/__tests__/` to remove — `auth-oauth-nonce-exchange.test.ts` only covers the `POST /oauth/exchange` round-trip, and there were no tests for the authorize/callback legacy branch (it depended on real provider env). The existing nonce-exchange tests still pass unchanged. No new tests added: a default-to-code authorize test would require provider env scaffolding that isn't currently set up — recommend adding that scaffolding in a separate PR if desired.

## Rollback plan

If after merge it turns out a caller is still on the legacy flow:
1. Revert this commit on `develop` (it's a single, self-contained refactor).
2. Re-publish `@stwd/api` 0.3.0 (or 0.3.2 with the revert) to npm.
3. Notify the affected caller to cut over to `response_type=code` before re-applying.

The blast radius is bounded: any caller still on the legacy flow will see a `400 response_type must be 'code'` from `/authorize` (clear, actionable error) rather than silently failing partway through OAuth.

## Verification checklist before merge

- [ ] PR #45 merged into `develop`.
- [ ] `os-homepage` shipped with `response_type=code` in its OAuth start URL.
- [ ] `cloud-frontend` shipped with `response_type=code` in its OAuth start URL.
- [ ] At least one release window observed with zero callback hits lacking `response_type=code` (check access logs).
- [ ] Base branch on this PR retargeted from `nonce-exchange-flow` to `develop`.