### PR TITLE
fix(api): dispatch configured webhooks

### DIFF
--- a/packages/api/src/__tests__/webhook-dispatch.test.ts
+++ b/packages/api/src/__tests__/webhook-dispatch.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import type { WebhookEvent } from "@stwd/shared";
+
+type StoredWebhookConfig = {
+  tenantId: string;
+  url: string;
+  secret: string;
+  events: string[];
+  enabled: boolean;
+  maxRetries: number;
+  retryBackoffMs: number;
+};
+
+type DispatchRecord = {
+  event: WebhookEvent;
+  webhook: { url: string; secret: string; events?: string[] } | string;
+};
+
+const webhookRows: StoredWebhookConfig[] = [];
+const insertedDeliveries: Record<string, unknown>[] = [];
+const updatedDeliveries: Record<string, unknown>[] = [];
+const dispatches: DispatchRecord[] = [];
+const tenantConfigs = new Map<string, { webhookUrl?: string }>();
+
+const db = {
+  select: () => ({
+    from: () => ({
+      where: () => Promise.resolve(webhookRows.filter((row) => row.enabled)),
+    }),
+  }),
+  insert: () => ({
+    values: (value: Record<string, unknown>) => {
+      insertedDeliveries.push(value);
+      return { returning: () => Promise.resolve([{ id: "delivery-1" }]) };
+    },
+  }),
+  update: () => ({
+    set: (value: Record<string, unknown>) => {
+      updatedDeliveries.push(value);
+      return { where: () => Promise.resolve([]) };
+    },
+  }),
+};
+
+mock.module("../services/context", () => ({ db, tenantConfigs }));
+mock.module("@stwd/db", () => ({
+  and: () => true,
+  eq: () => true,
+  webhookConfigs: { tenantId: "tenantId", enabled: "enabled" },
+  webhookDeliveries: { id: "id" },
+}));
+mock.module("@stwd/webhooks", () => ({
+  WebhookDispatcher: class {
+    async dispatch(
+      event: WebhookEvent,
+      webhook: { url: string; secret: string; events?: string[] } | string,
+    ) {
+      dispatches.push({ event, webhook });
+      return { success: true, attempts: 1, deliveredAt: new Date("2026-05-20T00:00:00Z") };
+    }
+  },
+}));
+
+const { dispatchWebhook } = await import("../services/webhook-dispatch");
+
+beforeEach(() => {
+  webhookRows.length = 0;
+  insertedDeliveries.length = 0;
+  updatedDeliveries.length = 0;
+  dispatches.length = 0;
+  tenantConfigs.clear();
+});
+
+describe("dispatchWebhook", () => {
+  it("dispatches subscribed persisted webhook configs with their own secret", async () => {
+    webhookRows.push(
+      {
+        tenantId: "tenant-1",
+        url: "https://example.com/signed",
+        secret: "whsec_signed",
+        events: ["tx.signed"],
+        enabled: true,
+        maxRetries: 2,
+        retryBackoffMs: 1000,
+      },
+      {
+        tenantId: "tenant-1",
+        url: "https://example.com/pending",
+        secret: "whsec_pending",
+        events: ["tx.pending"],
+        enabled: true,
+        maxRetries: 2,
+        retryBackoffMs: 1000,
+      },
+    );
+
+    dispatchWebhook("tenant-1", "agent-1", "tx_signed", { txId: "tx-1" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(dispatches).toHaveLength(1);
+    expect(dispatches[0]?.event.type).toBe("tx.signed");
+    expect(dispatches[0]?.webhook).toMatchObject({
+      url: "https://example.com/signed",
+      secret: "whsec_signed",
+    });
+    expect(insertedDeliveries[0]).toMatchObject({
+      tenantId: "tenant-1",
+      agentId: "agent-1",
+      eventType: "tx.signed",
+      url: "https://example.com/signed",
+      status: "pending",
+    });
+    expect(updatedDeliveries[0]).toMatchObject({
+      status: "delivered",
+      attempts: 1,
+      lastError: null,
+    });
+  });
+
+  it("preserves tenant config webhook dispatch for unsupported configured events", async () => {
+    tenantConfigs.set("tenant-1", { webhookUrl: "https://tenant-config.example.com/hook" });
+
+    dispatchWebhook("tenant-1", "agent-1", "tx_failed", { txId: "tx-1" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(insertedDeliveries).toHaveLength(0);
+    expect(dispatches).toHaveLength(1);
+    expect(dispatches[0]?.event.type).toBe("tx_failed");
+    expect(dispatches[0]?.webhook).toBe("https://tenant-config.example.com/hook");
+  });
+});

--- a/packages/api/src/__tests__/webhook-events.test.ts
+++ b/packages/api/src/__tests__/webhook-events.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "bun:test";
+import {
+  acceptsConfiguredWebhookEvent,
+  toConfiguredWebhookEventType,
+} from "../services/webhook-events";
+
+describe("webhook event routing", () => {
+  it("keeps public configured event names unchanged", () => {
+    expect(toConfiguredWebhookEventType("tx.pending")).toBe("tx.pending");
+    expect(toConfiguredWebhookEventType("tx.approved")).toBe("tx.approved");
+    expect(toConfiguredWebhookEventType("tx.denied")).toBe("tx.denied");
+    expect(toConfiguredWebhookEventType("tx.signed")).toBe("tx.signed");
+    expect(toConfiguredWebhookEventType("policy.violation")).toBe("policy.violation");
+  });
+
+  it("maps vault event aliases to the configured webhook contract", () => {
+    expect(toConfiguredWebhookEventType("approval_required")).toBe("tx.pending");
+    expect(toConfiguredWebhookEventType("tx_signed")).toBe("tx.signed");
+    expect(toConfiguredWebhookEventType("tx_rejected")).toBe("policy.violation");
+  });
+
+  it("does not invent configured events for unsupported vault states", () => {
+    expect(toConfiguredWebhookEventType("tx_failed")).toBeNull();
+    expect(toConfiguredWebhookEventType("tx_confirmed")).toBeNull();
+  });
+
+  it("treats an empty subscription list as all events", () => {
+    expect(acceptsConfiguredWebhookEvent([], "tx.signed")).toBe(true);
+  });
+
+  it("filters configured subscriptions by event type", () => {
+    expect(acceptsConfiguredWebhookEvent(["tx.pending"], "tx.pending")).toBe(true);
+    expect(acceptsConfiguredWebhookEvent(["tx.pending"], "tx.signed")).toBe(false);
+  });
+});

--- a/packages/api/src/routes/approvals.ts
+++ b/packages/api/src/routes/approvals.ts
@@ -17,6 +17,7 @@ import {
   safeJsonParse,
   transactions,
 } from "../services/context";
+import { dispatchWebhook } from "../services/webhook-dispatch";
 
 export const approvalRoutes = new Hono<{ Variables: AppVariables }>();
 
@@ -156,6 +157,11 @@ approvalRoutes.post("/:txId/approve", async (c) => {
   // Update transaction status to approved
   await db.update(transactions).set({ status: "approved" }).where(eq(transactions.id, txId));
 
+  dispatchWebhook(tenantId, entry.agentId, "tx.approved", {
+    txId,
+    approvalId: entry.id,
+  });
+
   return c.json<ApiResponse>({
     ok: true,
     data: {
@@ -217,6 +223,12 @@ approvalRoutes.post("/:txId/deny", async (c) => {
 
   // Update transaction status to rejected
   await db.update(transactions).set({ status: "rejected" }).where(eq(transactions.id, txId));
+
+  dispatchWebhook(tenantId, entry.agentId, "tx.denied", {
+    txId,
+    approvalId: entry.id,
+    reason: body.reason,
+  });
 
   return c.json<ApiResponse>({
     ok: true,

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -33,13 +33,12 @@ import {
   type SignTypedDataRequest,
   safeJsonParse,
   sanitizeErrorMessage,
-  tenantConfigs,
   toSignRequest,
   toTxRecord,
   transactions,
   vault,
-  webhookDispatcher,
 } from "../services/context";
+import { dispatchWebhook } from "../services/webhook-dispatch";
 
 export const vaultRoutes = new Hono<{ Variables: AppVariables }>();
 
@@ -1117,26 +1116,3 @@ vaultRoutes.post("/:agentId/export", async (c) => {
     return c.json<ApiResponse>({ ok: false, error: sanitizeErrorMessage(e) }, 500);
   }
 });
-
-// ─── Webhook dispatch helper ──────────────────────────────────────────────────
-
-type WebhookEventType =
-  | "approval_required"
-  | "tx_signed"
-  | "tx_confirmed"
-  | "tx_failed"
-  | "tx_rejected";
-
-function dispatchWebhook(
-  tenantId: string,
-  agentId: string,
-  type: WebhookEventType,
-  data: Record<string, unknown>,
-) {
-  const webhookUrl = tenantConfigs.get(tenantId)?.webhookUrl;
-  if (webhookUrl) {
-    webhookDispatcher
-      .dispatch({ type, tenantId, agentId, data, timestamp: new Date() }, webhookUrl)
-      .catch(console.error);
-  }
-}

--- a/packages/api/src/routes/webhooks.ts
+++ b/packages/api/src/routes/webhooks.ts
@@ -17,18 +17,12 @@ import {
   webhookConfigs,
   webhookDeliveries,
 } from "../services/context";
+import { CONFIGURED_WEBHOOK_EVENT_TYPES } from "../services/webhook-events";
 
 export const webhookRoutes = new Hono<{ Variables: AppVariables }>();
 
 // Valid webhook event types
-const VALID_EVENTS = [
-  "tx.pending",
-  "tx.approved",
-  "tx.denied",
-  "tx.signed",
-  "spend.threshold",
-  "policy.violation",
-] as const;
+const VALID_EVENTS = CONFIGURED_WEBHOOK_EVENT_TYPES;
 
 function isValidUrl(url: string): boolean {
   try {

--- a/packages/api/src/services/webhook-dispatch.ts
+++ b/packages/api/src/services/webhook-dispatch.ts
@@ -1,0 +1,115 @@
+import { and, eq, webhookConfigs, webhookDeliveries } from "@stwd/db";
+import type { WebhookEvent } from "@stwd/shared";
+import { WebhookDispatcher } from "@stwd/webhooks";
+import { db, tenantConfigs } from "./context";
+import {
+  acceptsConfiguredWebhookEvent,
+  type ConfiguredWebhookEventType,
+  type DispatchableWebhookEventType,
+  toConfiguredWebhookEventType,
+} from "./webhook-events";
+
+export function dispatchWebhook(
+  tenantId: string,
+  agentId: string,
+  type: DispatchableWebhookEventType,
+  data: Record<string, unknown>,
+): void {
+  const configuredType = toConfiguredWebhookEventType(type);
+  if (configuredType) {
+    const event: WebhookEvent = {
+      type: configuredType,
+      tenantId,
+      agentId,
+      data,
+      timestamp: new Date(),
+    };
+    void dispatchConfiguredWebhooks(event).catch((error) => {
+      console.error("[webhooks] Failed to dispatch configured webhooks:", error);
+    });
+  }
+
+  const tenantConfigWebhookUrl = tenantConfigs.get(tenantId)?.webhookUrl;
+  if (tenantConfigWebhookUrl) {
+    const tenantConfigEvent: WebhookEvent = {
+      type,
+      tenantId,
+      agentId,
+      data,
+      timestamp: new Date(),
+    };
+    const dispatcher = new WebhookDispatcher();
+    dispatcher.dispatch(tenantConfigEvent, tenantConfigWebhookUrl).catch((error) => {
+      console.error("[webhooks] Failed to dispatch tenant config webhook:", error);
+    });
+  }
+}
+
+async function dispatchConfiguredWebhooks(event: WebhookEvent): Promise<void> {
+  const configs = await db
+    .select()
+    .from(webhookConfigs)
+    .where(and(eq(webhookConfigs.tenantId, event.tenantId), eq(webhookConfigs.enabled, true)));
+
+  const eventType = event.type as ConfiguredWebhookEventType;
+  await Promise.all(
+    configs
+      .filter((config) => acceptsConfiguredWebhookEvent(config.events, eventType))
+      .map((config) =>
+        dispatchConfiguredWebhook(event, {
+          url: config.url,
+          secret: config.secret,
+          events: config.events,
+          maxRetries: config.maxRetries,
+          retryBackoffMs: config.retryBackoffMs,
+        }),
+      ),
+  );
+}
+
+async function dispatchConfiguredWebhook(
+  event: WebhookEvent,
+  config: {
+    url: string;
+    secret: string;
+    events: string[];
+    maxRetries: number;
+    retryBackoffMs: number;
+  },
+): Promise<void> {
+  const [delivery] = await db
+    .insert(webhookDeliveries)
+    .values({
+      tenantId: event.tenantId,
+      agentId: event.agentId,
+      eventType: event.type,
+      payload: event as unknown as Record<string, unknown>,
+      url: config.url,
+      status: "pending",
+      attempts: 0,
+      maxAttempts: config.maxRetries + 1,
+      nextRetryAt: new Date(),
+    })
+    .returning();
+
+  if (!delivery) {
+    throw new Error("Failed to create webhook delivery record");
+  }
+
+  const dispatcher = new WebhookDispatcher({
+    maxRetries: config.maxRetries,
+    retryDelayMs: config.retryBackoffMs,
+  });
+  const result = await dispatcher.dispatch(event, config);
+
+  await db
+    .update(webhookDeliveries)
+    .set({
+      status: result.success ? "delivered" : "failed",
+      attempts: result.attempts,
+      deliveredAt: result.deliveredAt ?? null,
+      lastError: result.error ?? null,
+      nextRetryAt: null,
+    })
+    .where(eq(webhookDeliveries.id, delivery.id));
+}

--- a/packages/api/src/services/webhook-events.ts
+++ b/packages/api/src/services/webhook-events.ts
@@ -1,0 +1,41 @@
+import type { WebhookEventType } from "@stwd/shared";
+
+export const CONFIGURED_WEBHOOK_EVENT_TYPES = [
+  "tx.pending",
+  "tx.approved",
+  "tx.denied",
+  "tx.signed",
+  "spend.threshold",
+  "policy.violation",
+] as const satisfies readonly WebhookEventType[];
+
+export type ConfiguredWebhookEventType = (typeof CONFIGURED_WEBHOOK_EVENT_TYPES)[number];
+type VaultWebhookEventAlias = Extract<
+  WebhookEventType,
+  "approval_required" | "tx_signed" | "tx_confirmed" | "tx_failed" | "tx_rejected"
+>;
+
+export type DispatchableWebhookEventType = WebhookEventType;
+
+const CONFIGURED_EVENT_SET = new Set<string>(CONFIGURED_WEBHOOK_EVENT_TYPES);
+const VAULT_EVENT_ALIAS_MAP: Partial<Record<VaultWebhookEventAlias, ConfiguredWebhookEventType>> = {
+  approval_required: "tx.pending",
+  tx_signed: "tx.signed",
+  tx_rejected: "policy.violation",
+};
+
+export function toConfiguredWebhookEventType(
+  type: DispatchableWebhookEventType,
+): ConfiguredWebhookEventType | null {
+  if (CONFIGURED_EVENT_SET.has(type as WebhookEventType)) {
+    return type as ConfiguredWebhookEventType;
+  }
+  return VAULT_EVENT_ALIAS_MAP[type as VaultWebhookEventAlias] ?? null;
+}
+
+export function acceptsConfiguredWebhookEvent(
+  events: string[],
+  type: ConfiguredWebhookEventType,
+): boolean {
+  return events.length === 0 || events.includes(type);
+}


### PR DESCRIPTION
## Summary

Dispatch registered `/webhooks` configurations from vault and approval events, using per-webhook secrets, subscription filtering, and delivery history records while preserving legacy tenant webhook URLs.

## Type

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, dependencies
- [x] `test` — Adding or updating tests

## Scope

`api`, `webhooks`

## Breaking Changes

None

## Checklist

- [x] Tests added/updated for changes
- [x] Documentation updated if needed
- [x] CI passes (`bun test`, typecheck)
- [x] PR targets `develop` (not `main`)
- [x] Commits include `Co-authored-by: wakesync <shadow@shad0w.xyz>`
- [x] Commit messages follow conventional format (`type(scope): description`)

## Local validation

- `bunx @biomejs/biome check --write packages/api/src/services/webhook-events.ts packages/api/src/services/webhook-dispatch.ts packages/api/src/routes/vault.ts packages/api/src/routes/approvals.ts packages/api/src/__tests__/webhook-events.test.ts packages/api/src/__tests__/webhook-dispatch.test.ts`
- `bun test packages/api/src/__tests__/webhook-events.test.ts packages/api/src/__tests__/webhook-dispatch.test.ts packages/webhooks/src/__tests__/queue.test.ts`
- `bunx turbo run build --filter=@stwd/shared --filter=@stwd/db --filter=@stwd/webhooks --filter=@stwd/api`
- `bun test`