### PR TITLE
fix(web): graceful self-host prompt when the API is unreachable

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,5 +27,4 @@ None
 - [ ] Documentation updated if needed
 - [ ] CI passes (`bun test`, typecheck)
 - [ ] PR targets `develop` (not `main`)
-- [ ] Commits include `Co-authored-by: wakesync <shadow@shad0w.xyz>`
 - [ ] Commit messages follow conventional format (`type(scope): description`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,19 +75,7 @@ docs(readme): update quickstart section
 chore(ci): add docker build workflow
 ```
 
-### 4. Include the co-author line
-
-All commits must include:
-```
-Co-authored-by: wakesync <shadow@shad0w.xyz>
-```
-
-Add it with:
-```bash
-git commit -m "feat(sdk): add batch support" -m "" -m "Co-authored-by: wakesync <shadow@shad0w.xyz>"
-```
-
-### 5. Open a PR
+### 4. Open a PR
 
 - Target branch: `develop` (not `main`)
 - Fill out the PR template completely

--- a/web/src/app/dashboard/layout.tsx
+++ b/web/src/app/dashboard/layout.tsx
@@ -6,6 +6,8 @@ import Image from "next/image";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { SelfHostPrompt } from "@/components/self-host-prompt";
+import { useApiReachability } from "@/lib/api-reachability";
 
 function RedirectToLogin() {
   const router = useRouter();
@@ -178,6 +180,25 @@ function LoadingSpinner() {
 }
 
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+  // The public steward.fi deployment does not run a control plane. If the
+  // configured API origin is unreachable, render the self-host CTA instead
+  // of letting users bounce off auth-guard → login → "Failed to fetch" toast.
+  // Self-hosted dashboards have NEXT_PUBLIC_STEWARD_API_URL pointed at their
+  // own API and will pass this probe.
+  const api = useApiReachability();
+
+  if (api.status === "checking") {
+    return <LoadingSpinner />;
+  }
+
+  if (api.status === "unreachable") {
+    return (
+      <div className="min-h-screen bg-bg">
+        <SelfHostPrompt detail={api.detail} onRetry={api.refresh} />
+      </div>
+    );
+  }
+
   return (
     <StewardAuthGuard fallback={<RedirectToLogin />} loadingFallback={<LoadingSpinner />}>
       <div className="min-h-screen bg-bg">

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -3,6 +3,8 @@
 import { StewardLogin } from "@stwd/react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
+import { SelfHostPrompt } from "@/components/self-host-prompt";
+import { useApiReachability } from "@/lib/api-reachability";
 
 const Logo = (
   <div className="flex items-center justify-center gap-2.5">
@@ -11,8 +13,30 @@ const Logo = (
   </div>
 );
 
+function LoginLoading() {
+  return (
+    <div className="min-h-screen bg-bg flex items-center justify-center">
+      <div className="w-5 h-5 border border-text-tertiary border-t-accent animate-spin" />
+    </div>
+  );
+}
+
 export default function LoginPage() {
   const router = useRouter();
+  // Same gate as dashboard: if the API is unreachable the public demo
+  // doesn’t have a control plane to log into. Surface the self-host CTA
+  // instead of rendering a login form whose every action will fail.
+  const api = useApiReachability();
+
+  if (api.status === "checking") return <LoginLoading />;
+
+  if (api.status === "unreachable") {
+    return (
+      <div className="min-h-screen bg-bg">
+        <SelfHostPrompt detail={api.detail} onRetry={api.refresh} />
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-bg flex items-center justify-center px-4 sm:px-6">

--- a/web/src/components/self-host-prompt.tsx
+++ b/web/src/components/self-host-prompt.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { API_URL } from "@/lib/api";
+
+const DOCS_URL = "https://docs.steward.fi";
+const REPO_URL = "https://github.com/Steward-Fi/steward";
+
+interface SelfHostPromptProps {
+  /** Optional underlying failure detail for ops/debug. Hidden in `<details>`. */
+  detail?: string;
+  /** Show a "Retry connection" button (e.g. when user spun up an instance). */
+  onRetry?: () => void;
+  /** Tighter layout for use inside an existing dashboard frame. */
+  variant?: "page" | "inline";
+}
+
+/**
+ * Renders the canonical "Steward is self-hostable; this demo doesn't run a
+ * control plane" prompt. Used by both the dashboard error fallback and the
+ * login page when the configured API origin is unreachable.
+ *
+ * WHY: steward.fi is a marketing site. The Steward API + dashboard are
+ * meant to run inside each org's own infrastructure. We want users who
+ * land on the public dashboard to understand that immediately, with a
+ * clear path to docs/source, not see a generic "Failed to connect" error.
+ */
+export function SelfHostPrompt({ detail, onRetry, variant = "page" }: SelfHostPromptProps) {
+  const wrapper =
+    variant === "page"
+      ? "min-h-[calc(100vh-6rem)] flex items-center justify-center px-6"
+      : "py-12 flex items-center justify-center px-6";
+
+  return (
+    <div className={wrapper}>
+      <motion.div
+        initial={{ opacity: 0, y: 12 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.45, ease: [0.16, 1, 0.3, 1] }}
+        className="max-w-xl w-full"
+      >
+        <p className="text-xs text-text-tertiary tracking-widest uppercase mb-6">
+          Self-hosted by design
+        </p>
+        <h2 className="font-display text-3xl md:text-4xl font-700 tracking-tight leading-[1.1]">
+          Steward runs on your infrastructure.
+        </h2>
+        <p className="mt-5 text-text-secondary leading-relaxed">
+          This public site doesn&apos;t host a Steward control plane. Each organization runs its own
+          instance to keep credentials, policies, and audit logs in its own perimeter. Spin one up,
+          point your dashboard at it, and you&apos;re done.
+        </p>
+
+        <div className="mt-8 grid grid-cols-1 sm:grid-cols-2 gap-px bg-border-subtle">
+          <a
+            href={DOCS_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="bg-bg p-5 hover:bg-bg-elevated transition-colors group"
+          >
+            <div className="text-sm font-display font-600 group-hover:text-accent transition-colors">
+              Read the deploy guide
+            </div>
+            <div className="text-xs text-text-tertiary mt-1">
+              Docker, Kubernetes, or any Node.js host
+            </div>
+          </a>
+          <a
+            href={REPO_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="bg-bg p-5 hover:bg-bg-elevated transition-colors group"
+          >
+            <div className="text-sm font-display font-600 group-hover:text-accent transition-colors">
+              Browse the source
+            </div>
+            <div className="text-xs text-text-tertiary mt-1">
+              MIT-licensed. No per-transaction fee.
+            </div>
+          </a>
+        </div>
+
+        <div className="mt-8 border border-border-subtle bg-bg-elevated/40 px-5 py-4">
+          <p className="text-xs text-text-tertiary tracking-wide uppercase mb-2">
+            Already self-hosted?
+          </p>
+          <p className="text-sm text-text-secondary leading-relaxed">
+            Point your dashboard at your instance by setting{" "}
+            <code className="font-mono text-xs text-text bg-bg px-1.5 py-0.5">
+              NEXT_PUBLIC_STEWARD_API_URL
+            </code>{" "}
+            before building, or run the dashboard locally alongside your API. Configured to reach{" "}
+            <code className="font-mono text-xs text-text bg-bg px-1.5 py-0.5 break-all">
+              {API_URL}
+            </code>{" "}
+            and the API didn&apos;t respond.
+          </p>
+          {onRetry && (
+            <button
+              type="button"
+              onClick={onRetry}
+              className="mt-4 text-xs px-3 py-1.5 border border-border text-text-secondary hover:text-text hover:border-text-tertiary transition-colors"
+            >
+              Retry connection
+            </button>
+          )}
+        </div>
+
+        {detail && (
+          <details className="mt-6 text-xs text-text-tertiary">
+            <summary className="cursor-pointer hover:text-text-secondary transition-colors">
+              Connection detail
+            </summary>
+            <pre className="mt-2 font-mono text-[11px] whitespace-pre-wrap break-words border border-border-subtle bg-bg-elevated/40 p-3">
+              {detail}
+            </pre>
+          </details>
+        )}
+      </motion.div>
+    </div>
+  );
+}

--- a/web/src/lib/api-reachability.ts
+++ b/web/src/lib/api-reachability.ts
@@ -1,0 +1,81 @@
+"use client";
+
+/**
+ * API reachability check.
+ *
+ * The public demo at https://steward.fi does NOT run a Steward control plane.
+ * Steward is self-hosted: each org runs their own instance and points their
+ * own dashboard at it. When the configured API base is unreachable (DNS
+ * NXDOMAIN, network error, refused connection, 5xx with no body), we surface
+ * a "self-host" prompt instead of an "internal error" UI.
+ *
+ * This module is a single source of truth for that detection so dashboard,
+ * login, and any other consumer treat the failure mode identically.
+ */
+
+import { useEffect, useState } from "react";
+import { API_URL } from "@/lib/api";
+
+export type ApiReachability =
+  | { status: "checking" }
+  | { status: "reachable" }
+  | { status: "unreachable"; reason: "network" | "server"; detail?: string };
+
+/**
+ * Lightweight probe — hits a no-auth public endpoint with a short timeout.
+ * Treats network errors and 5xx as unreachable; 2xx/4xx as reachable
+ * (a 4xx still means the server is up and routing correctly).
+ */
+export async function probeApi(baseUrl: string = API_URL): Promise<ApiReachability> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 4000);
+  try {
+    const res = await fetch(`${baseUrl.replace(/\/+$/, "")}/health`, {
+      method: "GET",
+      cache: "no-store",
+      signal: controller.signal,
+      headers: { Accept: "application/json" },
+    });
+    if (res.status >= 500) {
+      return {
+        status: "unreachable",
+        reason: "server",
+        detail: `${res.status} ${res.statusText || ""}`.trim(),
+      };
+    }
+    return { status: "reachable" };
+  } catch (err) {
+    return {
+      status: "unreachable",
+      reason: "network",
+      detail: err instanceof Error ? err.message : String(err),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * React hook variant. Re-checks on mount and whenever `baseUrl` changes.
+ * Does NOT poll on a timer — callers can re-invoke `refresh()` from a
+ * retry button.
+ */
+export function useApiReachability(baseUrl: string = API_URL): ApiReachability & {
+  refresh: () => void;
+} {
+  const [state, setState] = useState<ApiReachability>({ status: "checking" });
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setState({ status: "checking" });
+    probeApi(baseUrl).then((result) => {
+      if (!cancelled) setState(result);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [baseUrl, tick]);
+
+  return { ...state, refresh: () => setTick((t) => t + 1) };
+}


### PR DESCRIPTION
## Summary

`steward.fi` is a marketing site, not a Steward control plane. Steward is self-hosted by design — each org runs its own API and points its own dashboard at it. The public `/dashboard` and `/login` were calling a placeholder `api.steward.fi` and dead-ending on **\"Failed to fetch\"** toasts when that origin was unrouted.

This PR replaces that with a single API-reachability probe and a canonical \"Steward runs on your infrastructure\" CTA. Self-hosted deployments set `NEXT_PUBLIC_STEWARD_API_URL` to their own API and pass the probe untouched — zero behavior change for real users.

Also drops the `Co-authored-by: wakesync <shadow@shad0w.xyz>` requirement from `CONTRIBUTING.md` + `.github/pull_request_template.md`. It was applied here from an agent-workspace convention by mistake; outside contributors to a public OSS project shouldn't be auto-crediting a specific maintainer on every commit.

## Type

- [x] `fix` — Bug fix
- [x] `docs` — Documentation only (contributing template + pull-request template)

## Scope

`web`, `docs`

## Breaking Changes

None.

## Changes

### Reachability probe
- `web/src/lib/api-reachability.ts` — `probeApi()` / `useApiReachability()` hits `/health` with a 4s timeout. Network errors and 5xx are treated as unreachable; 4xx still counts as up (server is routing).

### Self-host CTA
- `web/src/components/self-host-prompt.tsx` — canonical \"Steward runs on your infrastructure\" page. Links to `docs.steward.fi` and the `Steward-Fi/steward` repo, surfaces the configured API origin, and optionally includes a Retry button + collapsible failure detail.

### Gating
- `web/src/app/dashboard/layout.tsx` — gates `StewardAuthGuard` behind the probe. Unreachable → `SelfHostPrompt`; reachable → existing flow.
- `web/src/app/login/page.tsx` — same gate; the public demo no longer renders a login form whose every action will fail.

### Contributor docs
- `CONTRIBUTING.md` — removed step 4 (\"Include the co-author line\"). Step 5 (\"Open a PR\") is now step 4.
- `.github/pull_request_template.md` — removed the matching checklist item.

## Local validation

- `bunx @biomejs/biome check` on all touched files (clean).
- `cd web && bunx tsc --noEmit -p tsconfig.json` (clean).
- Manual: with `NEXT_PUBLIC_STEWARD_API_URL` unset (so the probe hits a non-existent host) the public dashboard + login both render the self-host CTA. With it pointed at a live API the existing flows are unchanged.