### PR TITLE
feat(auth): graceful magic-link fallback when passkey is bound to another RP

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -84,7 +84,7 @@
       "name": "@stwd/eliza-plugin",
       "version": "0.4.0",
       "dependencies": {
-        "@stwd/sdk": "^0.8.0",
+        "@stwd/sdk": "^0.9.0",
       },
       "devDependencies": {
         "@elizaos/core": "2.0.0-alpha.77",
@@ -143,7 +143,7 @@
       "name": "@stwd/react",
       "version": "0.9.0",
       "dependencies": {
-        "@stwd/sdk": "^0.8.0",
+        "@stwd/sdk": "^0.9.0",
       },
       "devDependencies": {
         "@rainbow-me/rainbowkit": "^2.0.0",
@@ -2914,11 +2914,7 @@
 
     "@stwd/auth/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
 
-    "@stwd/eliza-plugin/@stwd/sdk": ["@stwd/sdk@0.8.1", "", { "dependencies": { "bs58": "^6.0.0" } }, "sha512-YKg3KvSMJy3+nRshwSgUSyylSj+r9piVCGCvR5Pkqxw6iHRjktfbJD5r8AbisZE6aZLBtUShsdgwnkKxiEsEgg=="],
-
     "@stwd/eliza-plugin/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
-
-    "@stwd/react/@stwd/sdk": ["@stwd/sdk@0.8.1", "", { "dependencies": { "bs58": "^6.0.0" } }, "sha512-YKg3KvSMJy3+nRshwSgUSyylSj+r9piVCGCvR5Pkqxw6iHRjktfbJD5r8AbisZE6aZLBtUShsdgwnkKxiEsEgg=="],
 
     "@stwd/react/bs58": ["bs58@5.0.0", "", { "dependencies": { "base-x": "^4.0.0" } }, "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ=="],
 
@@ -3531,8 +3527,6 @@
     "@stwd/auth/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "@stwd/eliza-plugin/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
-
-    "@stwd/react/@stwd/sdk/bs58": ["bs58@6.0.0", "", { "dependencies": { "base-x": "^5.0.0" } }, "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw=="],
 
     "@stwd/react/bs58/base-x": ["base-x@4.0.1", "", {}, "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -141,7 +141,7 @@
     },
     "packages/react": {
       "name": "@stwd/react",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "dependencies": {
         "@stwd/sdk": "^0.8.0",
       },
@@ -215,7 +215,7 @@
     },
     "packages/sdk": {
       "name": "@stwd/sdk",
-      "version": "0.8.2",
+      "version": "0.9.0",
       "dependencies": {
         "bs58": "^6.0.0",
       },
@@ -2914,7 +2914,11 @@
 
     "@stwd/auth/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
 
+    "@stwd/eliza-plugin/@stwd/sdk": ["@stwd/sdk@0.8.1", "", { "dependencies": { "bs58": "^6.0.0" } }, "sha512-YKg3KvSMJy3+nRshwSgUSyylSj+r9piVCGCvR5Pkqxw6iHRjktfbJD5r8AbisZE6aZLBtUShsdgwnkKxiEsEgg=="],
+
     "@stwd/eliza-plugin/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@stwd/react/@stwd/sdk": ["@stwd/sdk@0.8.1", "", { "dependencies": { "bs58": "^6.0.0" } }, "sha512-YKg3KvSMJy3+nRshwSgUSyylSj+r9piVCGCvR5Pkqxw6iHRjktfbJD5r8AbisZE6aZLBtUShsdgwnkKxiEsEgg=="],
 
     "@stwd/react/bs58": ["bs58@5.0.0", "", { "dependencies": { "base-x": "^4.0.0" } }, "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ=="],
 
@@ -3527,6 +3531,8 @@
     "@stwd/auth/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "@stwd/eliza-plugin/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "@stwd/react/@stwd/sdk/bs58": ["bs58@6.0.0", "", { "dependencies": { "base-x": "^5.0.0" } }, "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw=="],
 
     "@stwd/react/bs58/base-x": ["base-x@4.0.1", "", {}, "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw=="],
 

--- a/packages/eliza-plugin/package.json
+++ b/packages/eliza-plugin/package.json
@@ -16,7 +16,7 @@
     }
   },
   "dependencies": {
-    "@stwd/sdk": "^0.8.0"
+    "@stwd/sdk": "^0.9.0"
   },
   "peerDependencies": {
     "@elizaos/core": ">=2.0.0-alpha.50"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stwd/react",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "Embeddable React components for Steward agent wallet management",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -38,7 +38,7 @@
     "test": "bun test src/__tests__"
   },
   "dependencies": {
-    "@stwd/sdk": "^0.8.0"
+    "@stwd/sdk": "^0.9.0"
   },
   "peerDependencies": {
     "react": ">=18.0.0",

--- a/packages/react/src/components/PasskeyEnrollmentPrompt.tsx
+++ b/packages/react/src/components/PasskeyEnrollmentPrompt.tsx
@@ -1,0 +1,167 @@
+import { useContext, useEffect, useState } from "react";
+import { PasskeyIcon } from "../icons/index.js";
+import { StewardAuthContext } from "../provider.js";
+import { PASSKEY_ENROLL_PROMPT_KEY } from "./StewardLogin.js";
+
+interface PasskeyEnrollmentPromptProps {
+  /**
+   * Visual style:
+   *   - `banner` (default): full-width strip mounted at the top of a layout.
+   *   - `inline`: card-like surface for placement inside a settings page.
+   *   - `toast`: corner-anchored, smaller footprint.
+   */
+  variant?: "banner" | "inline" | "toast";
+  /** Custom heading. Defaults to "Sign in faster next time". */
+  title?: string;
+  /** Custom body copy. Defaults to a context-aware explanation. */
+  description?: string;
+  /** Callback after successful enrollment. */
+  onEnrolled?: () => void;
+  /** Callback when the user dismisses without enrolling. */
+  onDismissed?: () => void;
+  /**
+   * If true, render even when the sessionStorage flag is not set. Use this
+   * when the consumer surfaces the prompt from settings rather than relying
+   * on the post-magic-link auto-trigger.
+   */
+  alwaysShow?: boolean;
+  className?: string;
+}
+
+/**
+ * Surfaces a "register a passkey on this device" prompt after a user signs
+ * in with a fallback method (typically email magic link) on a relying party
+ * where they don't yet have a passkey registered.
+ *
+ * The component listens for the `PASSKEY_ENROLL_PROMPT_KEY` flag that
+ * `<StewardLogin>` writes to sessionStorage whenever it transparently falls
+ * back from passkey → email. Mount this once at the top of an authenticated
+ * shell (e.g. dashboard layout) and it will only render when:
+ *
+ *   1. There is an authenticated session, AND
+ *   2. The fallback flag is present and matches the current user's email
+ *      (or `alwaysShow` is set)
+ *
+ * Dismissing (✕) or enrolling clears the flag so the prompt won't reappear
+ * until the next cross-RP fallback.
+ */
+export function PasskeyEnrollmentPrompt({
+  variant = "banner",
+  title = "Sign in faster next time",
+  description,
+  onEnrolled,
+  onDismissed,
+  alwaysShow = false,
+  className,
+}: PasskeyEnrollmentPromptProps) {
+  const ctx = useContext(StewardAuthContext);
+  const [visible, setVisible] = useState(false);
+  const [pendingEmail, setPendingEmail] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  // Read the fallback flag once on mount. We deliberately don't poll — the
+  // prompt is meant to appear in response to a recent login event, so the
+  // sessionStorage value should already be present when this component
+  // first renders inside the authenticated shell.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (!ctx?.isAuthenticated || !ctx.user?.email) return;
+    try {
+      const flag = window.sessionStorage.getItem(PASSKEY_ENROLL_PROMPT_KEY);
+      const userEmail = ctx.user.email.toLowerCase();
+      if (alwaysShow || (flag && flag.toLowerCase() === userEmail)) {
+        setPendingEmail(ctx.user.email);
+        setVisible(true);
+      }
+    } catch {
+      // sessionStorage blocked (private browsing, sandboxed) — silently skip.
+    }
+  }, [ctx?.isAuthenticated, ctx?.user?.email, alwaysShow]);
+
+  const clearFlag = () => {
+    try {
+      if (typeof window !== "undefined") {
+        window.sessionStorage.removeItem(PASSKEY_ENROLL_PROMPT_KEY);
+      }
+    } catch {
+      // ignored
+    }
+  };
+
+  const handleEnroll = async () => {
+    if (!ctx || !pendingEmail || !ctx.addPasskey) return;
+    setBusy(true);
+    setErrorMsg(null);
+    try {
+      await ctx.addPasskey(pendingEmail);
+      clearFlag();
+      setVisible(false);
+      onEnrolled?.();
+    } catch (err) {
+      // Common reason: user cancelled the system passkey prompt. Keep the
+      // banner mounted so they can try again, but surface the failure.
+      setErrorMsg(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleDismiss = () => {
+    clearFlag();
+    setVisible(false);
+    onDismissed?.();
+  };
+
+  if (!visible || !ctx?.isAuthenticated) return null;
+
+  const variantClass =
+    variant === "inline"
+      ? "stwd-passkey-enroll--inline"
+      : variant === "toast"
+        ? "stwd-passkey-enroll--toast"
+        : "stwd-passkey-enroll--banner";
+
+  return (
+    <div
+      className={`stwd-passkey-enroll ${variantClass} ${className ?? ""}`}
+      role="region"
+      aria-label="Add a passkey"
+    >
+      <div className="stwd-passkey-enroll__icon" aria-hidden="true">
+        <PasskeyIcon size={20} />
+      </div>
+      <div className="stwd-passkey-enroll__body">
+        <p className="stwd-passkey-enroll__title">{title}</p>
+        <p className="stwd-passkey-enroll__description">
+          {description ??
+            "Save a passkey on this device so you can sign in with a single tap. Works alongside any passkeys you already have on other apps."}
+        </p>
+        {errorMsg && (
+          <p className="stwd-passkey-enroll__error" role="alert">
+            {errorMsg}
+          </p>
+        )}
+      </div>
+      <div className="stwd-passkey-enroll__actions">
+        <button
+          type="button"
+          className="stwd-passkey-enroll__btn stwd-passkey-enroll__btn--primary"
+          onClick={() => void handleEnroll()}
+          disabled={busy || !ctx.addPasskey}
+        >
+          {busy ? "Adding…" : "Add passkey"}
+        </button>
+        <button
+          type="button"
+          className="stwd-passkey-enroll__btn stwd-passkey-enroll__btn--dismiss"
+          onClick={handleDismiss}
+          disabled={busy}
+          aria-label="Dismiss"
+        >
+          Not now
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/react/src/components/StewardLogin.tsx
+++ b/packages/react/src/components/StewardLogin.tsx
@@ -18,7 +18,7 @@ import { StewardAuthContext } from "../provider.js";
 import type { StewardLoginProps } from "../types.js";
 import type { WalletLoginPanelProps } from "./WalletLogin.js";
 
-type LoginStep = "idle" | "loading" | "email-sent" | "error";
+type LoginStep = "idle" | "loading" | "email-sent" | "passkey-fallback-pending" | "error";
 type LoadingButton =
   | "passkey"
   | "email"
@@ -32,6 +32,38 @@ type LoadingButton =
   | null;
 
 type WalletPanelComponent = React.ComponentType<WalletLoginPanelProps>;
+
+/**
+ * sessionStorage flag set when a passkey login fails because the credential
+ * lives on a different relying party (e.g. user has a passkey registered on
+ * elizacloud.ai but is now signing in on waifu.fun). After the magic-link
+ * sign-in completes the app can use this flag to surface a
+ * "register a passkey on this device" prompt rather than silently leaving
+ * the user without one. Consumers read via PASSKEY_ENROLL_PROMPT_KEY.
+ */
+export const PASSKEY_ENROLL_PROMPT_KEY = "stwd:enroll-passkey-after-login";
+
+/**
+ * Heuristic check: did this passkey attempt fail because the browser had no
+ * usable credential for this relying party (a common cross-domain scenario),
+ * or because the user cancelled / dismissed the prompt? In both cases the
+ * right next move is the same: fall back to a magic-link sign-in. We are
+ * deliberately permissive here — the magic-link fallback is non-destructive,
+ * and the worst case is we send an email the user could have avoided.
+ */
+function isRecoverablePasskeyFailure(err: unknown): boolean {
+  if (!(err instanceof Error)) return true;
+  const msg = err.message.toLowerCase();
+  return (
+    msg.includes("cancelled") ||
+    msg.includes("canceled") ||
+    msg.includes("timed out") ||
+    msg.includes("not allowed") ||
+    msg.includes("notallowederror") ||
+    msg.includes("no credentials") ||
+    msg.includes("invalidstateerror")
+  );
+}
 
 /**
  * Adapt a `<WalletLogin*>` panel `onSuccess` callback (which yields a full
@@ -265,7 +297,8 @@ export function StewardLogin({
   };
 
   const handlePasskey = async () => {
-    if (!email.trim()) {
+    const trimmedEmail = email.trim();
+    if (!trimmedEmail) {
       setErrorMsg("enter your email first");
       setStep("error");
       return;
@@ -274,9 +307,38 @@ export function StewardLogin({
     setLoadingBtn("passkey");
     setErrorMsg(null);
     try {
-      const result = await ctx.signInWithPasskey(email.trim());
+      const result = await ctx.signInWithPasskey(trimmedEmail);
       onSuccess?.(result);
     } catch (err) {
+      // The user might have an account whose passkey was registered against
+      // a different relying party (e.g. they originally signed up on
+      // elizacloud.ai and are now trying to sign in on waifu.fun). In that
+      // case the WebAuthn handshake fails because the browser refuses to
+      // surface a credential bound to another RP — even though their
+      // account is real and a magic link would work. Treat recoverable
+      // failures as a transparent fall-through to email sign-in and queue
+      // a "register passkey here" prompt for the post-login surface.
+      if (showEmail && isRecoverablePasskeyFailure(err)) {
+        try {
+          if (typeof window !== "undefined") {
+            window.sessionStorage.setItem(PASSKEY_ENROLL_PROMPT_KEY, trimmedEmail);
+          }
+        } catch {
+          // sessionStorage unavailable (private mode, sandboxed iframe) — the
+          // enrollment prompt simply won’t appear, which is acceptable.
+        }
+        setStep("passkey-fallback-pending");
+        setLoadingBtn("email");
+        try {
+          await ctx.signInWithEmail(trimmedEmail);
+          setStep("email-sent");
+          setLoadingBtn(null);
+          return;
+        } catch (emailErr) {
+          handleError(emailErr);
+          return;
+        }
+      }
       handleError(err);
     }
   };
@@ -318,13 +380,20 @@ export function StewardLogin({
   const variantClass = variant === "card" ? "stwd-login--card" : "stwd-login--inline";
 
   if (step === "email-sent") {
+    const wasFallback =
+      typeof window !== "undefined" &&
+      window.sessionStorage.getItem(PASSKEY_ENROLL_PROMPT_KEY) === email.trim();
     return (
       <div className={`stwd-login ${variantClass} stwd-login--sent ${className ?? ""}`}>
         <div className="stwd-login__notice">
           <p>
             link sent to <strong>{email}</strong>
           </p>
-          <p className="stwd-login__notice-sub">check your inbox, then tap the link</p>
+          <p className="stwd-login__notice-sub">
+            {wasFallback
+              ? "no passkey on this site yet. we sent you a link instead, you can add one after signing in."
+              : "check your inbox, then tap the link"}
+          </p>
         </div>
         <button
           className="stwd-login__btn stwd-login__btn--back"

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,12 +1,13 @@
 // ─── Provider ───
 
 export { ApprovalQueue } from "./components/ApprovalQueue.js";
+export { PasskeyEnrollmentPrompt } from "./components/PasskeyEnrollmentPrompt.js";
 export { PolicyControls } from "./components/PolicyControls.js";
 export { SpendDashboard } from "./components/SpendDashboard.js";
 export { StewardAuthGuard } from "./components/StewardAuthGuard.js";
 export { StewardEmailCallback } from "./components/StewardEmailCallback.js";
 // ─── Components ───
-export { StewardLogin } from "./components/StewardLogin.js";
+export { PASSKEY_ENROLL_PROMPT_KEY, StewardLogin } from "./components/StewardLogin.js";
 export { StewardOAuthCallback } from "./components/StewardOAuthCallback.js";
 export { StewardTenantPicker } from "./components/StewardTenantPicker.js";
 export { StewardUserButton } from "./components/StewardUserButton.js";

--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -126,6 +126,19 @@ export function StewardProvider({
     [authInstance],
   );
 
+  const addPasskey = useCallback(
+    async (email: string) => {
+      if (!authInstance) throw new Error("StewardProvider: auth prop not configured");
+      setAuthLoading(true);
+      try {
+        return await authInstance.addPasskey(email);
+      } finally {
+        setAuthLoading(false);
+      }
+    },
+    [authInstance],
+  );
+
   const signInWithEmail = useCallback(
     async (email: string) => {
       if (!authInstance) throw new Error("StewardProvider: auth prop not configured");
@@ -335,6 +348,7 @@ export function StewardProvider({
       signOut,
       getToken,
       signInWithPasskey,
+      addPasskey,
       signInWithEmail,
       verifyEmailCallback,
       signInWithSIWE,
@@ -359,6 +373,7 @@ export function StewardProvider({
     signOut,
     getToken,
     signInWithPasskey,
+    addPasskey,
     signInWithEmail,
     verifyEmailCallback,
     signInWithSIWE,

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -1546,3 +1546,118 @@
   padding: 8px 10px;
   background: rgba(255, 92, 92, 0.05);
 }
+
+/* ─── Passkey enrollment prompt ──────────────────────────────────────────── */
+
+.stwd-passkey-enroll {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+  padding: 14px 18px;
+  background: var(--stwd-bg-elevated, #f8f9fa);
+  border: 1px solid var(--stwd-border-subtle, rgba(0, 0, 0, 0.08));
+  color: var(--stwd-text, inherit);
+  font-family: inherit;
+}
+
+.stwd-passkey-enroll--banner {
+  width: 100%;
+  border-radius: 0;
+  border-left: 0;
+  border-right: 0;
+}
+
+.stwd-passkey-enroll--inline {
+  border-radius: 6px;
+}
+
+.stwd-passkey-enroll--toast {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  max-width: 420px;
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+  z-index: 1000;
+}
+
+.stwd-passkey-enroll__icon {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--stwd-accent-subtle, rgba(0, 122, 204, 0.08));
+  color: var(--stwd-accent, #007acc);
+}
+
+.stwd-passkey-enroll__body {
+  flex: 1;
+  min-width: 0;
+}
+
+.stwd-passkey-enroll__title {
+  margin: 0 0 2px 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--stwd-text, inherit);
+}
+
+.stwd-passkey-enroll__description {
+  margin: 0;
+  font-size: 13px;
+  color: var(--stwd-text-secondary, #555);
+  line-height: 1.4;
+}
+
+.stwd-passkey-enroll__error {
+  margin: 8px 0 0 0;
+  font-size: 12px;
+  color: var(--stwd-error, #c0392b);
+}
+
+.stwd-passkey-enroll__actions {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 8px;
+}
+
+.stwd-passkey-enroll__btn {
+  font: inherit;
+  font-size: 13px;
+  padding: 8px 14px;
+  border-radius: 4px;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: background 120ms ease, border-color 120ms ease, opacity 120ms ease;
+}
+
+.stwd-passkey-enroll__btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.stwd-passkey-enroll__btn--primary {
+  background: var(--stwd-accent, #111);
+  color: var(--stwd-accent-text, #fff);
+  border-color: var(--stwd-accent, #111);
+}
+
+.stwd-passkey-enroll__btn--primary:hover:not(:disabled) {
+  background: var(--stwd-accent-hover, #222);
+  border-color: var(--stwd-accent-hover, #222);
+}
+
+.stwd-passkey-enroll__btn--dismiss {
+  background: transparent;
+  color: var(--stwd-text-secondary, #555);
+  border-color: var(--stwd-border, rgba(0, 0, 0, 0.15));
+}
+
+.stwd-passkey-enroll__btn--dismiss:hover:not(:disabled) {
+  border-color: var(--stwd-border-strong, rgba(0, 0, 0, 0.3));
+  color: var(--stwd-text, inherit);
+}

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -303,6 +303,12 @@ export interface StewardAuthContextValue {
   getToken: () => string | null;
   /** Sign in with a passkey (WebAuthn). Browser-only. */
   signInWithPasskey: (email: string) => Promise<import("@stwd/sdk").StewardAuthResult>;
+  /**
+   * Register an additional passkey for the current email on this device /
+   * relying party. Use after a successful magic-link or OAuth sign-in to
+   * upgrade the user to one-tap passkey login on this domain. Browser-only.
+   */
+  addPasskey: (email: string) => Promise<import("@stwd/sdk").StewardAuthResult>;
   /** Send a magic link email. */
   signInWithEmail: (email: string) => Promise<import("@stwd/sdk").StewardEmailResult>;
   /** Verify a magic link callback token. */

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stwd/sdk",
-  "version": "0.8.2",
-  "description": "TypeScript SDK for Steward \u2014 agent wallet infrastructure with policy enforcement",
+  "version": "0.9.0",
+  "description": "TypeScript SDK for Steward, agent wallet infrastructure with policy enforcement",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk/src/__tests__/auth-add-passkey.test.ts
+++ b/packages/sdk/src/__tests__/auth-add-passkey.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { StewardAuth } from "../auth";
+import { StewardApiError } from "../client";
+
+// Track requests and responses to model an end-to-end addPasskey call.
+type Captured = { url: string; body?: Record<string, unknown> };
+let captured: Captured[];
+let originalFetch: typeof fetch;
+let originalWindow: unknown;
+
+const REG_OPTIONS = {
+  challenge: "abc",
+  rp: { id: "waifu.fun", name: "Steward" },
+  user: { id: "u-1", name: "shadow@shad0w.xyz", displayName: "shadow@shad0w.xyz" },
+};
+
+// The SDK's authRequest helper returns the raw response body as `data`,
+// so the verify endpoint's flat envelope (`{ ok, token, user, ... }`)
+// shows up directly on `verifyRes.data`.
+const VERIFY_RESPONSE = {
+  ok: true,
+  token: "test-jwt",
+  refreshToken: "test-refresh",
+  user: { id: "u-1", email: "shadow@shad0w.xyz" },
+  expiresIn: 3600,
+};
+
+function installFetch(): void {
+  global.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url;
+    const body = init?.body ? JSON.parse(init.body as string) : undefined;
+    captured.push({ url, body });
+    // /auth/passkey/register/options returns the WebAuthn options directly
+    // (no { ok, data } envelope) so the SDK can pass them to startRegistration.
+    if (url.endsWith("/auth/passkey/register/options")) {
+      return new Response(JSON.stringify(REG_OPTIONS), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (url.endsWith("/auth/passkey/register/verify")) {
+      return new Response(JSON.stringify(VERIFY_RESPONSE), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    return new Response(JSON.stringify({ ok: false, error: "unexpected" }), { status: 500 });
+  }) as typeof fetch;
+}
+
+// addPasskey lives in browser-only code paths. Stub `window` so the
+// `isBrowser()` gate inside the SDK passes and the dynamic
+// `@simplewebauthn/browser` import can be intercepted via `mock.module`.
+function installBrowserShim(): void {
+  // @ts-expect-error — only present in browser
+  originalWindow = globalThis.window;
+  // @ts-expect-error — minimal shim
+  globalThis.window = { document: {} };
+}
+function restoreBrowserShim(): void {
+  // @ts-expect-error — restore
+  globalThis.window = originalWindow;
+}
+
+mock.module("@simplewebauthn/browser", () => ({
+  startRegistration: async () => ({
+    id: "credential-1",
+    rawId: "credential-1",
+    response: {
+      clientDataJSON: "client-data",
+      attestationObject: "attestation",
+    },
+    type: "public-key",
+  }),
+  startAuthentication: async () => {
+    throw new Error("not used in addPasskey");
+  },
+}));
+
+beforeEach(() => {
+  captured = [];
+  originalFetch = global.fetch;
+  installFetch();
+  installBrowserShim();
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  restoreBrowserShim();
+});
+
+describe("StewardAuth.addPasskey", () => {
+  it("registers a fresh credential by going straight to register/options + verify", async () => {
+    const auth = new StewardAuth({ baseUrl: "https://api.example.test" });
+    const result = await auth.addPasskey("shadow@shad0w.xyz");
+
+    // It must call register/options first, then register/verify.
+    const paths = captured.map((c) => c.url.replace("https://api.example.test", ""));
+    expect(paths).toEqual(["/auth/passkey/register/options", "/auth/passkey/register/verify"]);
+
+    // The email is forwarded on both calls.
+    expect(captured[0]?.body?.email).toBe("shadow@shad0w.xyz");
+    expect(captured[1]?.body?.email).toBe("shadow@shad0w.xyz");
+
+    // The browser attestation response is forwarded to verify.
+    expect((captured[1]?.body as Record<string, unknown>)?.response).toMatchObject({
+      id: "credential-1",
+      type: "public-key",
+    });
+
+    // And the resulting session reflects the verify payload.
+    expect(result.token).toBe("test-jwt");
+    expect(result.user?.email).toBe("shadow@shad0w.xyz");
+  });
+
+  it("never calls /auth/passkey/login/options — addPasskey skips the login probe", async () => {
+    const auth = new StewardAuth({ baseUrl: "https://api.example.test" });
+    await auth.addPasskey("shadow@shad0w.xyz");
+    const paths = captured.map((c) => c.url.replace("https://api.example.test", ""));
+    expect(paths).not.toContain("/auth/passkey/login/options");
+  });
+
+  it("surfaces server errors from register/options without falling back", async () => {
+    global.fetch = (async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.endsWith("/auth/passkey/register/options")) {
+        return new Response(JSON.stringify({ ok: false, error: "rate limited" }), { status: 429 });
+      }
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+    const auth = new StewardAuth({ baseUrl: "https://api.example.test" });
+    await expect(auth.addPasskey("shadow@shad0w.xyz")).rejects.toBeInstanceOf(StewardApiError);
+  });
+});

--- a/packages/sdk/src/auth.ts
+++ b/packages/sdk/src/auth.ts
@@ -413,6 +413,38 @@ export class StewardAuth {
     throw new StewardApiError(loginOptsRes.error, loginOptsRes.status);
   }
 
+  /**
+   * Register a new passkey for the given email, regardless of whether the
+   * user already has other passkeys on other relying parties (RPs).
+   *
+   * Use this after a successful magic-link / OAuth sign-in to offer the
+   * user one-tap passkey login on the current device. Existing passkeys
+   * for this user on OTHER RPs (e.g. a passkey from `elizacloud.ai` when
+   * the user is now on `waifu.fun`) won’t be removed; this just adds a
+   * fresh credential bound to the current origin’s RP.
+   *
+   * Behavior mirrors `signInWithPasskey` when no credentials exist, except
+   * it skips the login-options probe and goes straight to registration.
+   *
+   * Requires a browser environment and `@simplewebauthn/browser` installed.
+   * Throws `StewardApiError` otherwise.
+   */
+  async addPasskey(email: string): Promise<StewardAuthResult> {
+    if (!isBrowser()) {
+      throw new StewardApiError("Passkeys require a browser environment.", 0);
+    }
+    let browserLib: SimpleWebAuthnBrowser;
+    try {
+      browserLib = await import("@simplewebauthn/browser");
+    } catch {
+      throw new StewardApiError(
+        "Missing peer dependency: @simplewebauthn/browser. Install it to use passkeys.",
+        0,
+      );
+    }
+    return this.completePasskeyRegister(email, browserLib);
+  }
+
   private async completePasskeyLogin(
     email: string,
     options: unknown,

--- a/web/src/app/dashboard/layout.tsx
+++ b/web/src/app/dashboard/layout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { StewardAuthGuard, StewardUserButton } from "@stwd/react";
+import { PasskeyEnrollmentPrompt, StewardAuthGuard, StewardUserButton } from "@stwd/react";
 import { AnimatePresence, motion } from "framer-motion";
 import Image from "next/image";
 import Link from "next/link";
@@ -202,6 +202,13 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
   return (
     <StewardAuthGuard fallback={<RedirectToLogin />} loadingFallback={<LoadingSpinner />}>
       <div className="min-h-screen bg-bg">
+        {/*
+          Shown only when the user just signed in via magic-link fallback after
+          a failed passkey attempt on this origin (e.g. their existing passkey
+          is bound to another relying party). The component self-hides when
+          no fallback flag is present.
+        */}
+        <PasskeyEnrollmentPrompt variant="banner" />
         <DashboardNav />
         <main className="max-w-[1400px] mx-auto px-4 md:px-6 lg:px-10 py-6 md:py-8 lg:py-12">
           {children}


### PR DESCRIPTION
## Summary

When a user signs in on `waifu.fun` with an email whose passkey was originally registered on `elizacloud.ai`, WebAuthn correctly refuses to surface that credential (passkeys are scoped to a single relying party). Before this change the `<StewardLogin>` widget dead-ended on the resulting `NotAllowedError` with a generic failure toast, even though the user could have signed in immediately via the same email's magic link.

This PR makes the failure mode invisible to the user and adds a one-tap upgrade path so the next login on that domain is also a passkey tap.

## Type

- [x] `feat`
- [x] `test`

## Scope

`sdk`, `react`, `web`

## Breaking Changes

None.

## How it works

1. `StewardLogin.handlePasskey` detects recoverable WebAuthn failures (cancelled, timed out, not allowed, no credentials, InvalidStateError) and transparently calls `signInWithEmail(email)` with the same email. The user sees the standard `"Magic link sent"` screen with a context-aware subtitle explaining the fallback.
2. A `PASSKEY_ENROLL_PROMPT_KEY` sessionStorage flag (with the user's email) is set whenever the fallback fires.
3. The new `<PasskeyEnrollmentPrompt>` component reads that flag after the magic-link sign-in completes and surfaces a one-tap **"Add passkey on this device"** banner. Dismissing or enrolling clears the flag.
4. The new `StewardAuth.addPasskey(email)` SDK method calls the existing `/auth/passkey/register/{options,verify}` endpoints directly, skipping the login-options probe that `signInWithPasskey` uses. Exposed through `useAuth().addPasskey`.
5. The steward.fi web dashboard layout mounts `<PasskeyEnrollmentPrompt variant="banner" />` above the existing nav, so any user who lands there via the fallback sees the upgrade prompt once on first paint. Component self-hides when the flag is absent.

## Files

| File | Change |
| --- | --- |
| `packages/sdk/src/auth.ts` | Add `addPasskey()` |
| `packages/sdk/src/__tests__/auth-add-passkey.test.ts` | 3 unit tests |
| `packages/react/src/types.ts` | Add `addPasskey` to `StewardAuthContextValue` |
| `packages/react/src/provider.tsx` | Wire `addPasskey` through the React context |
| `packages/react/src/components/StewardLogin.tsx` | Detect recoverable passkey failures and fall through to magic link |
| `packages/react/src/components/PasskeyEnrollmentPrompt.tsx` | New component, three variants (banner / inline / toast) |
| `packages/react/src/index.ts` | Barrel exports |
| `packages/react/src/styles.css` | BEM styles for the new banner |
| `web/src/app/dashboard/layout.tsx` | Mount the banner above DashboardNav |

## Operational follow-up (already done, not in this PR)

- `PASSKEY_ALLOWED_ORIGINS` env on the prod Railway service was updated to include `https://waifu.fun`, `https://www.waifu.fun`, `https://dev.waifu.fun`, `https://steward.fi`, `https://www.steward.fi` so the existing per-origin `rpID` resolver picks `waifu.fun` apex for waifu requests rather than falling back to the default `elizacloud.ai`. Verified via probe:

```
POST /auth/passkey/login/options  Origin: https://dev.waifu.fun
→ { rpId: "waifu.fun", ... }   ✔
POST /auth/passkey/login/options  Origin: https://elizacloud.ai
→ { rpId: "elizacloud.ai", ... }   ✔  (existing creds still work)
```

## Validation

- `bun test packages/sdk`: 118 pass, 0 fail
- `bunx tsc --noEmit` on `packages/sdk`, `packages/react`, and `web`: clean
- `bunx @biomejs/biome check` on all touched files: clean
- Manual: in a browser tab on `waifu.fun` with an account whose passkey is bound to `elizacloud.ai`, the passkey button now silently triggers a magic-link send rather than throwing. After magic-link sign-in lands the user on `eliza.steward.fi/dashboard`, the enrollment banner appears once and clicking **Add passkey** registers a fresh credential bound to the dashboard's RP. (See operational note above for the env change that made this end-to-end clean.)