### PR TITLE
fix: enforce an OAuth redirect allowlist

### DIFF
--- a/packages/api/src/__tests__/auth-oauth-redirect-allowlist.test.ts
+++ b/packages/api/src/__tests__/auth-oauth-redirect-allowlist.test.ts
@@ -11,26 +11,29 @@ import {
 
 setDefaultTimeout(30000);
 
-import { closeDb, getDb, tenantConfigs, tenants } from "@stwd/db";
-import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { getDb, tenantConfigs, tenants } from "@stwd/db";
 import { eq } from "drizzle-orm";
 import { authRoutes, clearOAuthTokenKeyStoreForTests } from "../routes/auth";
 
-const TENANT_ID = "oauth-allowlist-tenant";
+/**
+ * NOTE on test isolation:
+ *   Uses the ambient `DATABASE_URL` from the `Integration Tests (Postgres)`
+ *   CI job rather than swapping pglite into the global handle. Closing a
+ *   pglite handle in `afterAll` previously poisoned every subsequent test
+ *   in `bun test packages/api` with `error: PGlite is closed`. We use a
+ *   unique tenant prefix and clean up the rows in `afterAll` instead.
+ */
 
-async function setupDb() {
-  process.env.STEWARD_PGLITE_MEMORY = "true";
-  const { db, client } = await createPGLiteDb("memory://");
-  setPGLiteOverride(db, async () => {
-    await client.close();
-  });
-}
+const TENANT_ID = "test-oauth-allowlist";
+const hasDatabaseUrl = Boolean(process.env.DATABASE_URL);
+const describeWithDatabase = hasDatabaseUrl ? describe : describe.skip;
 
-describe("OAuth redirect_uri allowlist", () => {
+describeWithDatabase("OAuth redirect_uri allowlist", () => {
   beforeAll(async () => {
-    process.env.STEWARD_PGLITE_MEMORY = "true";
-    process.env.STEWARD_MASTER_PASSWORD = "oauth-allowlist-master-password";
-    process.env.STEWARD_JWT_SECRET = "oauth-allowlist-jwt-secret-with-enough-bytes";
+    process.env.STEWARD_MASTER_PASSWORD =
+      process.env.STEWARD_MASTER_PASSWORD || "oauth-allowlist-master-password";
+    process.env.STEWARD_JWT_SECRET =
+      process.env.STEWARD_JWT_SECRET || "oauth-allowlist-jwt-secret-with-enough-bytes";
     process.env.APP_URL = "https://api.example.test";
     process.env.GOOGLE_CLIENT_ID = "google-client";
     process.env.GOOGLE_CLIENT_SECRET = "google-secret";
@@ -38,17 +41,22 @@ describe("OAuth redirect_uri allowlist", () => {
     delete process.env.STEWARD_OAUTH_REDIRECT_ALLOWLIST;
     clearOAuthTokenKeyStoreForTests();
 
-    await setupDb();
     const db = getDb();
-    await db.insert(tenants).values({
-      id: TENANT_ID,
-      name: "OAuth Allowlist Tenant",
-      apiKeyHash: "hash",
-    });
-    await db.insert(tenantConfigs).values({
-      tenantId: TENANT_ID,
-      allowedOrigins: ["https://app.example.test"],
-    });
+    await db
+      .insert(tenants)
+      .values({
+        id: TENANT_ID,
+        name: "OAuth Allowlist Tenant",
+        apiKeyHash: "hash",
+      })
+      .onConflictDoNothing();
+    await db
+      .insert(tenantConfigs)
+      .values({
+        tenantId: TENANT_ID,
+        allowedOrigins: ["https://app.example.test"],
+      })
+      .onConflictDoNothing();
   });
 
   afterEach(() => {
@@ -59,10 +67,15 @@ describe("OAuth redirect_uri allowlist", () => {
   });
 
   afterAll(async () => {
-    await closeDb().catch(() => {});
-    delete process.env.STEWARD_PGLITE_MEMORY;
-    delete process.env.STEWARD_MASTER_PASSWORD;
-    delete process.env.STEWARD_JWT_SECRET;
+    const db = getDb();
+    await db
+      .delete(tenantConfigs)
+      .where(eq(tenantConfigs.tenantId, TENANT_ID))
+      .catch(() => {});
+    await db
+      .delete(tenants)
+      .where(eq(tenants.id, TENANT_ID))
+      .catch(() => {});
     delete process.env.APP_URL;
     delete process.env.GOOGLE_CLIENT_ID;
     delete process.env.GOOGLE_CLIENT_SECRET;

--- a/packages/api/src/__tests__/auth-oauth-redirect-allowlist.test.ts
+++ b/packages/api/src/__tests__/auth-oauth-redirect-allowlist.test.ts
@@ -1,0 +1,148 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  mock,
+  setDefaultTimeout,
+} from "bun:test";
+
+setDefaultTimeout(30000);
+
+import { closeDb, getDb, tenantConfigs, tenants } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { eq } from "drizzle-orm";
+import { authRoutes, clearOAuthTokenKeyStoreForTests } from "../routes/auth";
+
+const TENANT_ID = "oauth-allowlist-tenant";
+
+async function setupDb() {
+  process.env.STEWARD_PGLITE_MEMORY = "true";
+  const { db, client } = await createPGLiteDb("memory://");
+  setPGLiteOverride(db, async () => {
+    await client.close();
+  });
+}
+
+describe("OAuth redirect_uri allowlist", () => {
+  beforeAll(async () => {
+    process.env.STEWARD_PGLITE_MEMORY = "true";
+    process.env.STEWARD_MASTER_PASSWORD = "oauth-allowlist-master-password";
+    process.env.STEWARD_JWT_SECRET = "oauth-allowlist-jwt-secret-with-enough-bytes";
+    process.env.APP_URL = "https://api.example.test";
+    process.env.GOOGLE_CLIENT_ID = "google-client";
+    process.env.GOOGLE_CLIENT_SECRET = "google-secret";
+    delete process.env.STEWARD_OAUTH_ALLOWED_REDIRECTS;
+    delete process.env.STEWARD_OAUTH_REDIRECT_ALLOWLIST;
+    clearOAuthTokenKeyStoreForTests();
+
+    await setupDb();
+    const db = getDb();
+    await db.insert(tenants).values({
+      id: TENANT_ID,
+      name: "OAuth Allowlist Tenant",
+      apiKeyHash: "hash",
+    });
+    await db.insert(tenantConfigs).values({
+      tenantId: TENANT_ID,
+      allowedOrigins: ["https://app.example.test"],
+    });
+  });
+
+  afterEach(() => {
+    mock.restore();
+    clearOAuthTokenKeyStoreForTests();
+    delete process.env.STEWARD_OAUTH_ALLOWED_REDIRECTS;
+    delete process.env.STEWARD_OAUTH_REDIRECT_ALLOWLIST;
+  });
+
+  afterAll(async () => {
+    await closeDb().catch(() => {});
+    delete process.env.STEWARD_PGLITE_MEMORY;
+    delete process.env.STEWARD_MASTER_PASSWORD;
+    delete process.env.STEWARD_JWT_SECRET;
+    delete process.env.APP_URL;
+    delete process.env.GOOGLE_CLIENT_ID;
+    delete process.env.GOOGLE_CLIENT_SECRET;
+    delete process.env.STEWARD_OAUTH_ALLOWED_REDIRECTS;
+    delete process.env.STEWARD_OAUTH_REDIRECT_ALLOWLIST;
+  });
+
+  it("rejects /authorize when redirect_uri origin is outside the tenant allowlist", async () => {
+    const db = getDb();
+    await db.delete(tenantConfigs).where(eq(tenantConfigs.tenantId, TENANT_ID));
+    await db.insert(tenantConfigs).values({
+      tenantId: TENANT_ID,
+      allowedOrigins: ["https://app.example.test"],
+    });
+
+    const res = await authRoutes.request(
+      `/oauth/google/authorize?tenant_id=${TENANT_ID}&redirect_uri=${encodeURIComponent("https://evil.example/callback")}`,
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain("redirect_uri is not allowed");
+  });
+
+  it("re-validates the stored redirect_uri during /callback before redirecting tokens", async () => {
+    const db = getDb();
+    await db.delete(tenantConfigs).where(eq(tenantConfigs.tenantId, TENANT_ID));
+    await db.insert(tenantConfigs).values({
+      tenantId: TENANT_ID,
+      allowedOrigins: ["https://app.example.test"],
+    });
+
+    const authorizeRes = await authRoutes.request(
+      `/oauth/google/authorize?tenant_id=${TENANT_ID}&redirect_uri=${encodeURIComponent("https://app.example.test/callback")}`,
+    );
+
+    expect(authorizeRes.status).toBe(302);
+    const location = authorizeRes.headers.get("location");
+    expect(location).toBeTruthy();
+    const state = new URL(location as string).searchParams.get("state");
+    expect(state).toBeTruthy();
+
+    await db.delete(tenantConfigs).where(eq(tenantConfigs.tenantId, TENANT_ID));
+    await db.insert(tenantConfigs).values({
+      tenantId: TENANT_ID,
+      allowedOrigins: ["https://other.example.test"],
+    });
+
+    const callbackRes = await authRoutes.request(
+      `/oauth/google/callback?code=test-code&state=${state as string}`,
+    );
+
+    expect(callbackRes.status).toBe(400);
+    const body = (await callbackRes.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain("redirect_uri is not allowed");
+  });
+
+  it("rejects /token when redirectUri is outside the tenant allowlist", async () => {
+    const db = getDb();
+    await db.delete(tenantConfigs).where(eq(tenantConfigs.tenantId, TENANT_ID));
+    await db.insert(tenantConfigs).values({
+      tenantId: TENANT_ID,
+      allowedOrigins: ["https://app.example.test"],
+    });
+
+    const res = await authRoutes.request("/oauth/google/token", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        code: "auth-code",
+        redirectUri: "https://evil.example/callback",
+        tenantId: TENANT_ID,
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain("redirect_uri is not allowed");
+  });
+});

--- a/packages/api/src/__tests__/auth-oauth-token-encryption.test.ts
+++ b/packages/api/src/__tests__/auth-oauth-token-encryption.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
-import { accounts, closeDb, tenants } from "@stwd/db";
+import { accounts, closeDb, tenantConfigs, tenants } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { eq } from "drizzle-orm";
 import {
@@ -84,6 +84,13 @@ describe("OAuth provider token encryption", () => {
       id: "oauth-test-tenant",
       name: "OAuth Test Tenant",
       apiKeyHash: "hash",
+    });
+    // OAuth redirect_uri allowlist now requires either a tenant config
+    // entry or the STEWARD_OAUTH_ALLOWED_REDIRECTS env var. Configure the
+    // tenant explicitly so the redirect target this test uses is allowed.
+    await db.insert(tenantConfigs).values({
+      tenantId: "oauth-test-tenant",
+      allowedOrigins: ["https://app.example.test"],
     });
 
     mock.restore();

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -1987,6 +1987,15 @@ auth.get("/oauth/:provider/authorize", async (c) => {
     return c.json<ApiResponse>({ ok: false, error: "redirect_uri is required" }, 400);
   }
 
+  try {
+    await assertAllowedOAuthRedirectUri(redirectUri, tenantId);
+  } catch (err) {
+    return c.json<ApiResponse>(
+      { ok: false, error: err instanceof Error ? err.message : "Invalid redirect_uri" },
+      400,
+    );
+  }
+
   // Generate a cryptographically random state value
   const stateBytes = new Uint8Array(16);
   crypto.getRandomValues(stateBytes);
@@ -2062,6 +2071,16 @@ auth.get("/oauth/:provider/callback", async (c) => {
     return c.json<ApiResponse>({ ok: false, error: "Provider mismatch in state" }, 400);
   }
 
+  let redirectUrl: URL;
+  try {
+    redirectUrl = await assertAllowedOAuthRedirectUri(stateData.redirectUri, stateData.tenantId);
+  } catch (err) {
+    return c.json<ApiResponse>(
+      { ok: false, error: err instanceof Error ? err.message : "Invalid redirect_uri" },
+      400,
+    );
+  }
+
   let oauthClient: OAuthClient;
   try {
     oauthClient = new OAuthClient(getProviderConfig(providerName));
@@ -2135,7 +2154,6 @@ auth.get("/oauth/:provider/callback", async (c) => {
   }
 
   // Redirect to the app with the JWT
-  const redirectUrl = new URL(stateData.redirectUri);
   redirectUrl.searchParams.set("token", result.token);
   redirectUrl.searchParams.set("refreshToken", result.refreshToken);
   return c.redirect(redirectUrl.toString(), 302);
@@ -2163,6 +2181,17 @@ auth.post("/oauth/:provider/token", async (c) => {
 
   if (!body?.code || !body?.redirectUri) {
     return c.json<ApiResponse>({ ok: false, error: "code and redirectUri are required" }, 400);
+  }
+
+  const requestedTenantId =
+    body.tenantId?.trim() || c.req.header("X-Steward-Tenant")?.trim() || undefined;
+  try {
+    await assertAllowedOAuthRedirectUri(body.redirectUri, requestedTenantId);
+  } catch (err) {
+    return c.json<ApiResponse>(
+      { ok: false, error: err instanceof Error ? err.message : "Invalid redirectUri" },
+      400,
+    );
   }
 
   let oauthClient: OAuthClient;
@@ -2352,6 +2381,110 @@ function buildOAuthCallbackUrl(c: Context, providerName: string): string {
     ? process.env.APP_URL.replace(/\/$/, "")
     : `${c.req.header("x-forwarded-proto") ?? "https"}://${c.req.header("host") ?? "localhost"}`;
   return `${appUrl}/auth/oauth/${providerName}/callback`;
+}
+
+const OAUTH_REDIRECT_ALLOWLIST_ENV_KEYS = [
+  "STEWARD_OAUTH_ALLOWED_REDIRECTS",
+  "STEWARD_OAUTH_REDIRECT_ALLOWLIST",
+] as const;
+
+function parseOAuthRedirectAllowlistEnv(): string[] {
+  const entries = new Set<string>();
+
+  for (const envName of OAUTH_REDIRECT_ALLOWLIST_ENV_KEYS) {
+    const raw = process.env[envName];
+    if (!raw) continue;
+
+    for (const entry of raw.split(",")) {
+      const trimmed = entry.trim();
+      if (trimmed && trimmed !== "*") {
+        entries.add(trimmed);
+      }
+    }
+  }
+
+  return [...entries];
+}
+
+function parseOAuthRedirectUri(redirectUri: string): URL {
+  let redirectUrl: URL;
+  try {
+    redirectUrl = new URL(redirectUri);
+  } catch {
+    throw new Error("redirect_uri must be a valid absolute URL");
+  }
+
+  if (redirectUrl.protocol !== "https:" && redirectUrl.protocol !== "http:") {
+    throw new Error("redirect_uri must use http or https");
+  }
+
+  if (redirectUrl.username || redirectUrl.password) {
+    throw new Error("redirect_uri must not contain credentials");
+  }
+
+  return redirectUrl;
+}
+
+function isOAuthRedirectEntryMatch(redirectUrl: URL, allowedEntry: string): boolean {
+  let allowedUrl: URL;
+  try {
+    allowedUrl = new URL(allowedEntry);
+  } catch {
+    return false;
+  }
+
+  if (allowedUrl.protocol !== "https:" && allowedUrl.protocol !== "http:") {
+    return false;
+  }
+
+  const isOriginOnly =
+    allowedUrl.pathname === "/" && !allowedUrl.search && !allowedUrl.hash && !allowedUrl.username;
+
+  if (isOriginOnly) {
+    return allowedUrl.origin === redirectUrl.origin;
+  }
+
+  return (
+    allowedUrl.origin === redirectUrl.origin &&
+    allowedUrl.pathname === redirectUrl.pathname &&
+    allowedUrl.search === redirectUrl.search
+  );
+}
+
+async function getAllowedOAuthRedirectEntries(tenantId?: string): Promise<string[]> {
+  const entries = new Set(parseOAuthRedirectAllowlistEnv());
+  const resolvedTenantId = tenantId?.trim() || _DEFAULT_TENANT_ID;
+
+  const [row] = await getDb()
+    .select({ allowedOrigins: tenantConfigs.allowedOrigins })
+    .from(tenantConfigs)
+    .where(eq(tenantConfigs.tenantId, resolvedTenantId));
+
+  for (const origin of row?.allowedOrigins ?? []) {
+    const trimmed = origin.trim();
+    if (trimmed && trimmed !== "*") {
+      entries.add(trimmed);
+    }
+  }
+
+  return [...entries];
+}
+
+async function assertAllowedOAuthRedirectUri(redirectUri: string, tenantId?: string): Promise<URL> {
+  const redirectUrl = parseOAuthRedirectUri(redirectUri);
+  const allowlist = await getAllowedOAuthRedirectEntries(tenantId);
+
+  if (allowlist.length === 0) {
+    throw new Error(
+      "OAuth redirect_uri allowlist is not configured for this tenant. Configure tenant allowedOrigins or STEWARD_OAUTH_ALLOWED_REDIRECTS.",
+    );
+  }
+
+  if (!allowlist.some((entry) => isOAuthRedirectEntryMatch(redirectUrl, entry))) {
+    throw new Error("redirect_uri is not allowed for this tenant");
+  }
+
+  return redirectUrl;
 }
 
 export { auth as authRoutes };


### PR DESCRIPTION
## Summary
- enforce an allowlist for OAuth `redirect_uri` values before the provider redirect starts
- re-validate the stored `redirect_uri` during the callback before Steward appends session tokens
- reject popup/token exchanges that use a `redirectUri` outside the tenant or operator allowlist
- add regression coverage for `/authorize`, `/callback`, and `/token`

## Security issue
Steward accepted an arbitrary post-auth `redirect_uri`, stored it in the OAuth state, and later redirected the browser there with `token` and `refreshToken` appended.

That meant an attacker could initiate a legitimate OAuth login and send the victim's newly minted Steward tokens to an attacker-controlled origin.

## Fix
This PR adds a centralized `assertAllowedOAuthRedirectUri()` guard and wires it into all three OAuth entry points:

1. `GET /auth/oauth/:provider/authorize`
   - rejects untrusted `redirect_uri` values before redirecting to the provider
2. `GET /auth/oauth/:provider/callback`
   - re-validates the stored redirect target before appending Steward tokens and issuing the final redirect
   - this closes the time-of-check/time-of-use gap if a tenant allowlist changes after the state is created
3. `POST /auth/oauth/:provider/token`
   - rejects direct code exchanges for unapproved redirect targets

Allowlist sources:
- tenant-level `tenant_configs.allowedOrigins`
- optional operator override via `STEWARD_OAUTH_ALLOWED_REDIRECTS`
  - `STEWARD_OAUTH_REDIRECT_ALLOWLIST` is also accepted as a compatibility alias

Implementation details:
- `*` is intentionally ignored for OAuth redirects; wildcard CORS is not safe for token-bearing redirects
- only absolute `http`/`https` URLs are accepted
- URLs with embedded credentials are rejected
- allowlist entries can match by origin or by an exact callback URL

## Tests
- `bun test src/__tests__/auth-oauth-redirect-allowlist.test.ts`
- `bunx tsc -p packages/shared/tsconfig.json`
- `bunx tsc -p packages/redis/tsconfig.json`
- `bunx tsc -p packages/api/tsconfig.json --noEmit`
