### PR TITLE
fix: reject agent tokens on dashboard routes

### DIFF
--- a/packages/api/src/__tests__/dashboard-auth.test.ts
+++ b/packages/api/src/__tests__/dashboard-auth.test.ts
@@ -1,0 +1,76 @@
+import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
+import { signAccessToken, signAgentToken } from "@stwd/auth";
+import { closeDb, getDb, tenants } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+
+setDefaultTimeout(30000);
+
+const TENANT_ID = "dashboard-auth-tenant";
+let app: typeof import("../app")["app"];
+
+beforeAll(async () => {
+  process.env.DATABASE_URL = "pglite://embedded";
+  process.env.STEWARD_PGLITE_MEMORY = "true";
+  process.env.STEWARD_MASTER_PASSWORD = "dashboard-auth-master-password";
+  process.env.STEWARD_JWT_SECRET = "dashboard-auth-jwt-secret-with-enough-bytes";
+
+  const { db, client } = await createPGLiteDb("memory://");
+  setPGLiteOverride(db, async () => {
+    await client.close();
+  });
+
+  ({ app } = await import("../app"));
+
+  await getDb().insert(tenants).values({
+    id: TENANT_ID,
+    name: "Dashboard Auth Tenant",
+    apiKeyHash: "hash",
+  });
+});
+
+afterAll(async () => {
+  await closeDb().catch(() => {});
+  delete process.env.DATABASE_URL;
+  delete process.env.STEWARD_PGLITE_MEMORY;
+  delete process.env.STEWARD_MASTER_PASSWORD;
+  delete process.env.STEWARD_JWT_SECRET;
+});
+
+describe("dashboardAuthMiddleware", () => {
+  it("explicitly rejects agent tokens", async () => {
+    const token = await signAgentToken({ agentId: "agent-1", tenantId: TENANT_ID }, "1h");
+
+    const res = await app.request("/dashboard/nonexistent-agent", {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain("agent tokens");
+  });
+
+  it("still allows user session tokens to reach the dashboard route", async () => {
+    const token = await signAccessToken(
+      {
+        address: `0x${"1".repeat(40)}`,
+        tenantId: TENANT_ID,
+        userId: "user-1",
+      },
+      "1h",
+    );
+
+    const res = await app.request("/dashboard/nonexistent-agent", {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain("Agent not found");
+  });
+});

--- a/packages/api/src/__tests__/dashboard-auth.test.ts
+++ b/packages/api/src/__tests__/dashboard-auth.test.ts
@@ -1,42 +1,51 @@
 import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
 import { signAccessToken, signAgentToken } from "@stwd/auth";
-import { closeDb, getDb, tenants } from "@stwd/db";
-import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { getDb, tenants } from "@stwd/db";
+import { eq } from "drizzle-orm";
 
 setDefaultTimeout(30000);
 
-const TENANT_ID = "dashboard-auth-tenant";
+/**
+ * NOTE on test isolation:
+ *   This file deliberately uses the ambient `DATABASE_URL` set by the
+ *   `Integration Tests (Postgres)` CI job and does NOT swap pglite via
+ *   `setPGLiteOverride`. An earlier version of this file replaced the
+ *   global db handle in `beforeAll` and closed it in `afterAll`, which
+ *   broke every subsequent test in `bun test packages/api` with
+ *   `error: PGlite is closed`. We use a unique tenant id and clean up
+ *   the row instead of swapping the connection.
+ */
+
+const TENANT_ID = "test-dashboard-auth";
+const hasDatabaseUrl = Boolean(process.env.DATABASE_URL);
+const describeWithDatabase = hasDatabaseUrl ? describe : describe.skip;
+
 let app: typeof import("../app")["app"];
 
 beforeAll(async () => {
-  process.env.DATABASE_URL = "pglite://embedded";
-  process.env.STEWARD_PGLITE_MEMORY = "true";
-  process.env.STEWARD_MASTER_PASSWORD = "dashboard-auth-master-password";
-  process.env.STEWARD_JWT_SECRET = "dashboard-auth-jwt-secret-with-enough-bytes";
-
-  const { db, client } = await createPGLiteDb("memory://");
-  setPGLiteOverride(db, async () => {
-    await client.close();
-  });
+  if (!hasDatabaseUrl) return;
 
   ({ app } = await import("../app"));
 
-  await getDb().insert(tenants).values({
-    id: TENANT_ID,
-    name: "Dashboard Auth Tenant",
-    apiKeyHash: "hash",
-  });
+  await getDb()
+    .insert(tenants)
+    .values({
+      id: TENANT_ID,
+      name: "Dashboard Auth Tenant",
+      apiKeyHash: "hash",
+    })
+    .onConflictDoNothing();
 });
 
 afterAll(async () => {
-  await closeDb().catch(() => {});
-  delete process.env.DATABASE_URL;
-  delete process.env.STEWARD_PGLITE_MEMORY;
-  delete process.env.STEWARD_MASTER_PASSWORD;
-  delete process.env.STEWARD_JWT_SECRET;
+  if (!hasDatabaseUrl) return;
+  await getDb()
+    .delete(tenants)
+    .where(eq(tenants.id, TENANT_ID))
+    .catch(() => {});
 });
 
-describe("dashboardAuthMiddleware", () => {
+describeWithDatabase("dashboardAuthMiddleware", () => {
   it("explicitly rejects agent tokens", async () => {
     const token = await signAgentToken({ agentId: "agent-1", tenantId: TENANT_ID }, "1h");
 

--- a/packages/api/src/__tests__/tenant-config.test.ts
+++ b/packages/api/src/__tests__/tenant-config.test.ts
@@ -237,7 +237,14 @@ describe.skipIf(SKIP)("Tenant Config API", () => {
 describe.skipIf(SKIP)("Dashboard API", () => {
   it("returns 404 for non-existent agent", async () => {
     const { createSessionToken } = await import("../routes/auth");
-    const token = await createSessionToken("0x0000000000000000000000000000000000000000", TENANT_ID);
+    // dashboardAuthMiddleware requires a userId on session tokens, so we
+    // mint a session that includes one. The dashboard route itself only
+    // cares about the agent lookup result, hence the synthetic userId.
+    const token = await createSessionToken(
+      "0x0000000000000000000000000000000000000000",
+      TENANT_ID,
+      { userId: "test-dashboard-404-user" },
+    );
     const res = await fetch(`${BASE_URL}/dashboard/nonexistent-agent`, {
       headers: { Authorization: `Bearer ${token}` },
     });

--- a/packages/api/src/services/context.ts
+++ b/packages/api/src/services/context.ts
@@ -476,6 +476,20 @@ export async function dashboardAuthMiddleware(c: Context<{ Variables: AppVariabl
     return c.json<ApiResponse>({ ok: false, error: "Invalid or expired session token" }, 401);
   }
 
+  if (payload.scope === "agent" || payload.agentId) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Dashboard routes do not accept agent tokens" },
+      403,
+    );
+  }
+
+  if (!payload.userId) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Dashboard routes require a user session token" },
+      401,
+    );
+  }
+
   const tenant = await findTenant(payload.tenantId);
   if (!tenant) {
     return c.json<ApiResponse>({ ok: false, error: "Tenant not found" }, 404);


### PR DESCRIPTION
## Summary
- make `dashboardAuthMiddleware()` explicitly reject agent JWTs
- require a real user session on dashboard routes
- add regression coverage for both the deny path and the normal user-session path

## Security issue
`/dashboard/*` was documented and intended as a user-facing dashboard surface, but the middleware accepted any JWT with a valid `tenantId`.

That included agent-scoped tokens. Because the middleware never set `agentScope`, downstream dashboard handlers treated the request as unrestricted and an agent token could fetch dashboard data for other agents in the same tenant.

## Fix
This PR tightens `dashboardAuthMiddleware()` so it now:
- rejects JWTs carrying agent claims (`scope=agent` / `agentId`)
- requires a user session identity (`userId`) before the request reaches dashboard handlers
- preserves the existing behavior for valid user session tokens

With this change, agent tokens fail fast at the middleware boundary instead of falling through into user-only dashboard routes.

## Tests
- `bun test src/__tests__/dashboard-auth.test.ts`
- `bunx tsc -p packages/api/tsconfig.json --noEmit`
