### PR TITLE
fix: enforce proxy token revocation

### DIFF
--- a/packages/proxy/src/__tests__/auth.test.ts
+++ b/packages/proxy/src/__tests__/auth.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { revocationStore, verifyToken } from "@stwd/auth";
 import { Hono } from "hono";
 import { SignJWT } from "jose";
 import { PROXY_SCOPE } from "../config";
@@ -7,7 +8,7 @@ import { authMiddleware } from "../middleware/auth";
 const JWT_SECRET = new TextEncoder().encode(process.env.STEWARD_JWT_SECRET || "dev-secret");
 const JWT_ISSUER = "steward";
 
-async function signAgentToken(claims: Record<string, unknown>) {
+async function signAgentToken(claims: Record<string, unknown>, jti?: string) {
   return new SignJWT({
     agentId: "agent-1",
     tenantId: "tenant-1",
@@ -17,6 +18,7 @@ async function signAgentToken(claims: Record<string, unknown>) {
     .setProtectedHeader({ alg: "HS256" })
     .setIssuedAt()
     .setIssuer(JWT_ISSUER)
+    .setJti(jti ?? crypto.randomUUID())
     .setExpirationTime("1h")
     .sign(JWT_SECRET);
 }
@@ -70,5 +72,37 @@ describe("proxy auth middleware", () => {
     expect(warn).toHaveBeenCalledTimes(1);
     expect(warn.mock.calls[0]?.[0]).toContain("Legacy agent token without scopes accepted");
     expect(warn.mock.calls[0]?.[0]).toContain(PROXY_SCOPE);
+  });
+
+  test("rejects individually revoked agent tokens", async () => {
+    const jti = crypto.randomUUID();
+    const token = await signAgentToken({ scopes: ["agent", PROXY_SCOPE] }, jti);
+    await revocationStore.revokeToken(jti, Date.now() + 60_000);
+
+    const res = await app().request("/", {
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toContain("revoked");
+  });
+
+  test("rejects agent tokens revoked by the agent-wide revocation line", async () => {
+    const token = await signAgentToken({ scopes: ["agent", PROXY_SCOPE] });
+    const payload = await verifyToken(token);
+    await revocationStore.revokeAgentTokens(
+      String(payload.agentId),
+      Number(payload.iat) + 1,
+      Date.now() + 60_000,
+    );
+
+    const res = await app().request("/", {
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toContain("revoked");
   });
 });

--- a/packages/proxy/src/middleware/auth.ts
+++ b/packages/proxy/src/middleware/auth.ts
@@ -5,7 +5,7 @@
  * and sets them on the Hono context for downstream handlers.
  */
 
-import { verifyToken } from "@stwd/auth";
+import { assertTokenNotRevoked, verifyToken } from "@stwd/auth";
 import type { Context, Next } from "hono";
 import { PROXY_SCOPE } from "../config";
 
@@ -40,6 +40,7 @@ export async function authMiddleware(c: Context, next: Next) {
 
   try {
     const payload = await verifyToken(token);
+    await assertTokenNotRevoked(payload);
 
     const agentId = payload.agentId as string | undefined;
     const tenantId = payload.tenantId as string | undefined;


### PR DESCRIPTION
## Summary
- make proxy JWT auth consult the revocation store after signature verification
- reject both individually revoked tokens and tokens invalidated by an agent-wide revocation line
- add regression coverage for both revocation paths

## Security issue
The proxy validated JWT signatures and scopes, but it never checked whether a token had been revoked server-side.

That meant a token remained usable at the proxy even after logout / explicit revocation or after the platform rotated an agent-wide revocation line.

## Fix
This PR calls `assertTokenNotRevoked()` inside `packages/proxy/src/middleware/auth.ts` immediately after `verifyToken()` succeeds.

As a result, the proxy now enforces the same revocation semantics as the API auth surfaces:
- revoked JTIs are denied
- agent tokens issued before an agent-wide revocation cutoff are denied

## Tests
- `bun test src/__tests__/auth.test.ts`
- `bunx tsc -p packages/shared/tsconfig.json`
- `bunx tsc -p packages/redis/tsconfig.json`
- `bunx tsc -p packages/proxy/tsconfig.json --noEmit`
