### PR TITLE
fix: enforce tenant membership and role checks

### DIFF
--- a/packages/api/src/__tests__/tenant-role-auth.test.ts
+++ b/packages/api/src/__tests__/tenant-role-auth.test.ts
@@ -1,51 +1,77 @@
 import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
 import { signAccessToken } from "@stwd/auth";
-import { closeDb, getDb, tenants, users, userTenants } from "@stwd/db";
-import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { getDb, tenants, users, userTenants } from "@stwd/db";
 import { and, eq } from "drizzle-orm";
 
 setDefaultTimeout(30000);
 
-const TENANT_ID = "tenant-role-auth";
+/**
+ * NOTE on test isolation:
+ *   Uses the ambient `DATABASE_URL` set by the `Integration Tests (Postgres)`
+ *   CI job. The original implementation called `setPGLiteOverride` in
+ *   `beforeAll` and `closeDb()` in `afterAll`, which poisoned every
+ *   subsequent test in `bun test packages/api` with `error: PGlite is
+ *   closed`. We use a unique tenant id and clean up rows in afterAll
+ *   instead of swapping the connection.
+ */
+
+const TENANT_ID = "test-tenant-role-auth";
 const OWNER_USER_ID = crypto.randomUUID();
 const MEMBER_USER_ID = crypto.randomUUID();
+const hasDatabaseUrl = Boolean(process.env.DATABASE_URL);
+const describeWithDatabase = hasDatabaseUrl ? describe : describe.skip;
+
 let app: typeof import("../app")["app"];
 
 beforeAll(async () => {
-  process.env.DATABASE_URL = "pglite://embedded";
-  process.env.STEWARD_PGLITE_MEMORY = "true";
-  process.env.STEWARD_MASTER_PASSWORD = "tenant-role-auth-master-password";
-  process.env.STEWARD_JWT_SECRET = "tenant-role-auth-jwt-secret-with-enough-bytes";
-
-  const { db, client } = await createPGLiteDb("memory://");
-  setPGLiteOverride(db, async () => {
-    await client.close();
-  });
+  if (!hasDatabaseUrl) return;
 
   ({ app } = await import("../app"));
 
   const dbHandle = getDb();
-  await dbHandle.insert(tenants).values({
-    id: TENANT_ID,
-    name: "Tenant Role Auth",
-    apiKeyHash: "hash",
-  });
-  await dbHandle.insert(users).values([
-    { id: OWNER_USER_ID, email: "owner@example.test" },
-    { id: MEMBER_USER_ID, email: "member@example.test" },
-  ]);
-  await dbHandle.insert(userTenants).values([
-    { userId: OWNER_USER_ID, tenantId: TENANT_ID, role: "owner" },
-    { userId: MEMBER_USER_ID, tenantId: TENANT_ID, role: "member" },
-  ]);
+  await dbHandle
+    .insert(tenants)
+    .values({
+      id: TENANT_ID,
+      name: "Tenant Role Auth",
+      apiKeyHash: "hash",
+    })
+    .onConflictDoNothing();
+  await dbHandle
+    .insert(users)
+    .values([
+      { id: OWNER_USER_ID, email: `owner-${OWNER_USER_ID}@example.test` },
+      { id: MEMBER_USER_ID, email: `member-${MEMBER_USER_ID}@example.test` },
+    ])
+    .onConflictDoNothing();
+  await dbHandle
+    .insert(userTenants)
+    .values([
+      { userId: OWNER_USER_ID, tenantId: TENANT_ID, role: "owner" },
+      { userId: MEMBER_USER_ID, tenantId: TENANT_ID, role: "member" },
+    ])
+    .onConflictDoNothing();
 });
 
 afterAll(async () => {
-  await closeDb().catch(() => {});
-  delete process.env.DATABASE_URL;
-  delete process.env.STEWARD_PGLITE_MEMORY;
-  delete process.env.STEWARD_MASTER_PASSWORD;
-  delete process.env.STEWARD_JWT_SECRET;
+  if (!hasDatabaseUrl) return;
+  const dbHandle = getDb();
+  await dbHandle
+    .delete(userTenants)
+    .where(eq(userTenants.tenantId, TENANT_ID))
+    .catch(() => {});
+  await dbHandle
+    .delete(users)
+    .where(eq(users.id, OWNER_USER_ID))
+    .catch(() => {});
+  await dbHandle
+    .delete(users)
+    .where(eq(users.id, MEMBER_USER_ID))
+    .catch(() => {});
+  await dbHandle
+    .delete(tenants)
+    .where(eq(tenants.id, TENANT_ID))
+    .catch(() => {});
 });
 
 async function createUserToken(userId: string) {
@@ -59,7 +85,7 @@ async function createUserToken(userId: string) {
   );
 }
 
-describe("tenantAuth membership checks and requireTenantLevel role checks", () => {
+describeWithDatabase("tenantAuth membership checks and requireTenantLevel role checks", () => {
   it("allows owner sessions to use tenant-level routes but rejects member sessions", async () => {
     const ownerToken = await createUserToken(OWNER_USER_ID);
     const memberToken = await createUserToken(MEMBER_USER_ID);

--- a/packages/api/src/__tests__/tenant-role-auth.test.ts
+++ b/packages/api/src/__tests__/tenant-role-auth.test.ts
@@ -1,0 +1,101 @@
+import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
+import { signAccessToken } from "@stwd/auth";
+import { closeDb, getDb, tenants, users, userTenants } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { and, eq } from "drizzle-orm";
+
+setDefaultTimeout(30000);
+
+const TENANT_ID = "tenant-role-auth";
+const OWNER_USER_ID = crypto.randomUUID();
+const MEMBER_USER_ID = crypto.randomUUID();
+let app: typeof import("../app")["app"];
+
+beforeAll(async () => {
+  process.env.DATABASE_URL = "pglite://embedded";
+  process.env.STEWARD_PGLITE_MEMORY = "true";
+  process.env.STEWARD_MASTER_PASSWORD = "tenant-role-auth-master-password";
+  process.env.STEWARD_JWT_SECRET = "tenant-role-auth-jwt-secret-with-enough-bytes";
+
+  const { db, client } = await createPGLiteDb("memory://");
+  setPGLiteOverride(db, async () => {
+    await client.close();
+  });
+
+  ({ app } = await import("../app"));
+
+  const dbHandle = getDb();
+  await dbHandle.insert(tenants).values({
+    id: TENANT_ID,
+    name: "Tenant Role Auth",
+    apiKeyHash: "hash",
+  });
+  await dbHandle.insert(users).values([
+    { id: OWNER_USER_ID, email: "owner@example.test" },
+    { id: MEMBER_USER_ID, email: "member@example.test" },
+  ]);
+  await dbHandle.insert(userTenants).values([
+    { userId: OWNER_USER_ID, tenantId: TENANT_ID, role: "owner" },
+    { userId: MEMBER_USER_ID, tenantId: TENANT_ID, role: "member" },
+  ]);
+});
+
+afterAll(async () => {
+  await closeDb().catch(() => {});
+  delete process.env.DATABASE_URL;
+  delete process.env.STEWARD_PGLITE_MEMORY;
+  delete process.env.STEWARD_MASTER_PASSWORD;
+  delete process.env.STEWARD_JWT_SECRET;
+});
+
+async function createUserToken(userId: string) {
+  return signAccessToken(
+    {
+      address: `0x${"1".repeat(40)}`,
+      tenantId: TENANT_ID,
+      userId,
+    },
+    "1h",
+  );
+}
+
+describe("tenantAuth membership checks and requireTenantLevel role checks", () => {
+  it("allows owner sessions to use tenant-level routes but rejects member sessions", async () => {
+    const ownerToken = await createUserToken(OWNER_USER_ID);
+    const memberToken = await createUserToken(MEMBER_USER_ID);
+
+    const ownerRes = await app.request("/secrets", {
+      headers: { Authorization: `Bearer ${ownerToken}` },
+    });
+    expect(ownerRes.status).toBe(200);
+
+    const memberRes = await app.request("/secrets", {
+      headers: { Authorization: `Bearer ${memberToken}` },
+    });
+    expect(memberRes.status).toBe(403);
+    const memberBody = (await memberRes.json()) as { ok: boolean; error: string };
+    expect(memberBody.ok).toBe(false);
+    expect(memberBody.error).toContain("tenant-level authentication");
+  });
+
+  it("re-validates tenant membership on every request", async () => {
+    const memberToken = await createUserToken(MEMBER_USER_ID);
+
+    const beforeRemoval = await app.request("/agents", {
+      headers: { Authorization: `Bearer ${memberToken}` },
+    });
+    expect(beforeRemoval.status).toBe(200);
+
+    await getDb()
+      .delete(userTenants)
+      .where(and(eq(userTenants.userId, MEMBER_USER_ID), eq(userTenants.tenantId, TENANT_ID)));
+
+    const afterRemoval = await app.request("/agents", {
+      headers: { Authorization: `Bearer ${memberToken}` },
+    });
+    expect(afterRemoval.status).toBe(403);
+    const body = (await afterRemoval.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain("Not a member");
+  });
+});

--- a/packages/api/src/__tests__/tenant-role-auth.test.ts
+++ b/packages/api/src/__tests__/tenant-role-auth.test.ts
@@ -105,19 +105,23 @@ describeWithDatabase("tenantAuth membership checks and requireTenantLevel role c
   });
 
   it("re-validates tenant membership on every request", async () => {
-    const memberToken = await createUserToken(MEMBER_USER_ID);
+    // Use the OWNER token, because `/agents` is tenant-level (per #56) and
+    // the new requireTenantLevel gate enforces role=owner. The point of
+    // this test is to verify that revoking the user's membership rejects
+    // the very next request even though the JWT is otherwise still valid.
+    const ownerToken = await createUserToken(OWNER_USER_ID);
 
     const beforeRemoval = await app.request("/agents", {
-      headers: { Authorization: `Bearer ${memberToken}` },
+      headers: { Authorization: `Bearer ${ownerToken}` },
     });
     expect(beforeRemoval.status).toBe(200);
 
     await getDb()
       .delete(userTenants)
-      .where(and(eq(userTenants.userId, MEMBER_USER_ID), eq(userTenants.tenantId, TENANT_ID)));
+      .where(and(eq(userTenants.userId, OWNER_USER_ID), eq(userTenants.tenantId, TENANT_ID)));
 
     const afterRemoval = await app.request("/agents", {
-      headers: { Authorization: `Bearer ${memberToken}` },
+      headers: { Authorization: `Bearer ${ownerToken}` },
     });
     expect(afterRemoval.status).toBe(403);
     const body = (await afterRemoval.json()) as { ok: boolean; error: string };

--- a/packages/api/src/services/context.ts
+++ b/packages/api/src/services/context.ts
@@ -13,7 +13,7 @@ import {
   validateApiKey,
   verifyToken,
 } from "@stwd/auth";
-import { getDb, policies, tenants, toPolicyRule, transactions } from "@stwd/db";
+import { getDb, policies, tenants, toPolicyRule, transactions, userTenants } from "@stwd/db";
 import { PolicyEngine } from "@stwd/policy-engine";
 import {
   type AgentIdentity,
@@ -272,6 +272,7 @@ export type AppVariables = {
   tenantConfig: TenantConfig;
   tenantId: string;
   userId?: string;
+  tenantRole?: string;
   agentScope?: string;
   authType?: "api-key" | "session-jwt" | "agent-token" | "dashboard-jwt";
 };
@@ -291,6 +292,14 @@ export function getTenantPayload(tenant: Tenant): Tenant & TenantConfig {
 export async function findTenant(tenantId: string): Promise<Tenant | undefined> {
   const [tenant] = await db.select().from(tenants).where(eq(tenants.id, tenantId));
   return tenant;
+}
+
+async function findUserTenantMembership(userId: string, tenantId: string) {
+  const [membership] = await db
+    .select({ role: userTenants.role })
+    .from(userTenants)
+    .where(and(eq(userTenants.userId, userId), eq(userTenants.tenantId, tenantId)));
+  return membership ?? null;
 }
 
 export async function ensureAgentForTenant(
@@ -369,6 +378,23 @@ export async function tenantAuth(
         if (options?.requireTenantMatch && payload.tenantId !== options.requireTenantMatch) {
           return c.json<ApiResponse>({ ok: false, error: "Forbidden" }, 403);
         }
+
+        const isAgentToken = payload.scope === "agent" && typeof payload.agentId === "string";
+        if (!isAgentToken) {
+          if (!payload.userId) {
+            return c.json<ApiResponse>(
+              { ok: false, error: "User session token is missing userId" },
+              401,
+            );
+          }
+
+          const membership = await findUserTenantMembership(payload.userId, payload.tenantId);
+          if (!membership) {
+            return c.json<ApiResponse>({ ok: false, error: "Not a member of this tenant" }, 403);
+          }
+          c.set("tenantRole", membership.role);
+        }
+
         c.set("tenantId", payload.tenantId);
         c.set("tenant", jwtTenant);
         c.set(
@@ -380,7 +406,7 @@ export async function tenantAuth(
         );
 
         if (payload.userId) c.set("userId", payload.userId);
-        if (payload.scope === "agent" && payload.agentId) {
+        if (isAgentToken) {
           c.set("agentScope", payload.agentId);
           c.set("authType", "agent-token");
         } else {
@@ -451,7 +477,12 @@ export function requireAgentAccess(c: Context<{ Variables: AppVariables }>): boo
 }
 
 export function requireTenantLevel(c: Context<{ Variables: AppVariables }>): boolean {
-  return c.get("authType") !== "agent-token";
+  const authType = c.get("authType");
+  if (authType === "api-key") return true;
+  if (authType === "agent-token") return false;
+
+  const tenantRole = c.get("tenantRole");
+  return tenantRole === "owner" || tenantRole === "admin";
 }
 
 /**


### PR DESCRIPTION
## Summary
- make `tenantAuth()` re-check `user_tenants` membership for session JWTs on every request
- record the resolved tenant role in request context
- change `requireTenantLevel()` from a token-type gate into a real role gate
- add regression coverage for both membership revalidation and owner/member authorization differences

## Security issue
Two auth-model problems existed in the tenant-scoped API surface:

1. `tenantAuth()` trusted the `tenantId` claim inside a session token without re-checking whether the user still belonged to that tenant.
   - a removed member kept access until the JWT expired
2. `requireTenantLevel()` only rejected agent tokens
   - any session JWT for the tenant, including `role=member`, was treated as tenant-admin level

That allowed low-privilege or removed users to keep calling sensitive tenant routes.

## Fix
### `tenantAuth()`
- distinguishes agent tokens from user session tokens
- requires `userId` on user session tokens
- loads the current `user_tenants` row for `(userId, tenantId)` on every request
- denies the request if the membership no longer exists
- stores the live tenant role on the request context

### `requireTenantLevel()`
- still allows tenant API keys
- still rejects agent tokens
- now only returns `true` for user sessions whose live role is `owner` or `admin`

## Tests
- `bun test src/__tests__/tenant-role-auth.test.ts`
- `bunx tsc -p packages/api/tsconfig.json --noEmit`
