### PR TITLE
fix: scope top-level agent routes correctly

### DIFF
--- a/packages/api/src/__tests__/agent-route-scope.test.ts
+++ b/packages/api/src/__tests__/agent-route-scope.test.ts
@@ -1,0 +1,107 @@
+import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
+import { generateApiKey, signAgentToken } from "@stwd/auth";
+import { closeDb, getDb, tenants } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+
+setDefaultTimeout(30000);
+
+const TENANT_ID = "agent-route-scope";
+const AGENT_A = "agent-a";
+const AGENT_B = "agent-b";
+let apiKey = "";
+let app: typeof import("../app")["app"];
+
+beforeAll(async () => {
+  process.env.DATABASE_URL = "pglite://embedded";
+  process.env.STEWARD_PGLITE_MEMORY = "true";
+  process.env.STEWARD_MASTER_PASSWORD = "agent-route-scope-master-password";
+  process.env.STEWARD_JWT_SECRET = "agent-route-scope-jwt-secret-with-enough-bytes";
+
+  const { db, client } = await createPGLiteDb("memory://");
+  setPGLiteOverride(db, async () => {
+    await client.close();
+  });
+
+  ({ app } = await import("../app"));
+
+  const apiKeyPair = generateApiKey();
+  apiKey = apiKeyPair.key;
+  await getDb().insert(tenants).values({
+    id: TENANT_ID,
+    name: "Agent Route Scope Tenant",
+    apiKeyHash: apiKeyPair.hash,
+  });
+
+  for (const agentId of [AGENT_A, AGENT_B]) {
+    const res = await app.request("/agents", {
+      method: "POST",
+      headers: {
+        "X-Steward-Tenant": TENANT_ID,
+        "X-Steward-Key": apiKey,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ id: agentId, name: agentId }),
+    });
+    expect(res.status).toBe(200);
+  }
+});
+
+afterAll(async () => {
+  await closeDb().catch(() => {});
+  delete process.env.DATABASE_URL;
+  delete process.env.STEWARD_PGLITE_MEMORY;
+  delete process.env.STEWARD_MASTER_PASSWORD;
+  delete process.env.STEWARD_JWT_SECRET;
+});
+
+describe("agent route scope enforcement", () => {
+  it("blocks agent tokens from listing agents and creating new agents", async () => {
+    const token = await signAgentToken({ agentId: AGENT_A, tenantId: TENANT_ID }, "1h");
+
+    const listRes = await app.request("/agents", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(listRes.status).toBe(403);
+
+    const createRes = await app.request("/agents", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ id: "agent-c", name: "agent-c" }),
+    });
+    expect(createRes.status).toBe(403);
+  });
+
+  it("only allows an agent token to read its own agent record", async () => {
+    const token = await signAgentToken({ agentId: AGENT_A, tenantId: TENANT_ID }, "1h");
+
+    const ownRes = await app.request(`/agents/${AGENT_A}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(ownRes.status).toBe(200);
+
+    const otherRes = await app.request(`/agents/${AGENT_B}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(otherRes.status).toBe(403);
+    const body = (await otherRes.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain("scope does not match");
+  });
+
+  it("keeps tenant-level agent listing working", async () => {
+    const res = await app.request("/agents", {
+      headers: {
+        "X-Steward-Tenant": TENANT_ID,
+        "X-Steward-Key": apiKey,
+      },
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; data: Array<{ id: string }> };
+    expect(body.ok).toBe(true);
+    expect(body.data.map((agent) => agent.id).sort()).toEqual([AGENT_A, AGENT_B]);
+  });
+});

--- a/packages/api/src/__tests__/agent-route-scope.test.ts
+++ b/packages/api/src/__tests__/agent-route-scope.test.ts
@@ -1,36 +1,49 @@
 import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
 import { generateApiKey, signAgentToken } from "@stwd/auth";
-import { closeDb, getDb, tenants } from "@stwd/db";
-import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { getDb, tenants } from "@stwd/db";
+import { eq } from "drizzle-orm";
 
 setDefaultTimeout(30000);
 
-const TENANT_ID = "agent-route-scope";
-const AGENT_A = "agent-a";
-const AGENT_B = "agent-b";
+/**
+ * Agent-token privilege-escalation regression coverage.
+ *
+ * NOTE on test isolation:
+ *   This file deliberately does NOT call `createPGLiteDb` or
+ *   `setPGLiteOverride`. The `Integration Tests (Postgres)` CI job provisions
+ *   a real Postgres before running `bun test packages/api`, and several
+ *   sibling tests rely on that shared db connection persisting across the
+ *   run. An earlier version of this file replaced the global pglite handle
+ *   in `beforeAll`, which broke every subsequent test in the suite once the
+ *   handle was closed in `afterAll`. We instead use the ambient `DATABASE_URL`
+ *   like `cross-tenant.test.ts` and rely on a unique TENANT_ID to avoid
+ *   colliding with other test fixtures.
+ */
+
+const TENANT_ID = "test-agent-route-scope";
+const AGENT_A = "test-ars-agent-a";
+const AGENT_B = "test-ars-agent-b";
+const hasDatabaseUrl = Boolean(process.env.DATABASE_URL);
+const describeWithDatabase = hasDatabaseUrl ? describe : describe.skip;
+
 let apiKey = "";
 let app: typeof import("../app")["app"];
 
 beforeAll(async () => {
-  process.env.DATABASE_URL = "pglite://embedded";
-  process.env.STEWARD_PGLITE_MEMORY = "true";
-  process.env.STEWARD_MASTER_PASSWORD = "agent-route-scope-master-password";
-  process.env.STEWARD_JWT_SECRET = "agent-route-scope-jwt-secret-with-enough-bytes";
-
-  const { db, client } = await createPGLiteDb("memory://");
-  setPGLiteOverride(db, async () => {
-    await client.close();
-  });
+  if (!hasDatabaseUrl) return;
 
   ({ app } = await import("../app"));
 
   const apiKeyPair = generateApiKey();
   apiKey = apiKeyPair.key;
-  await getDb().insert(tenants).values({
-    id: TENANT_ID,
-    name: "Agent Route Scope Tenant",
-    apiKeyHash: apiKeyPair.hash,
-  });
+  await getDb()
+    .insert(tenants)
+    .values({
+      id: TENANT_ID,
+      name: "Agent Route Scope Tenant",
+      apiKeyHash: apiKeyPair.hash,
+    })
+    .onConflictDoNothing();
 
   for (const agentId of [AGENT_A, AGENT_B]) {
     const res = await app.request("/agents", {
@@ -42,19 +55,28 @@ beforeAll(async () => {
       },
       body: JSON.stringify({ id: agentId, name: agentId }),
     });
-    expect(res.status).toBe(200);
+    // The fixture POST is the canary for "tenant-level auth is wired up
+    // correctly", so a non-200 here is interesting and we surface the
+    // server's error message instead of just an opaque status mismatch.
+    if (res.status !== 200) {
+      const body = await res.text();
+      throw new Error(`Fixture POST /agents for ${agentId} returned ${res.status}: ${body}`);
+    }
   }
 });
 
 afterAll(async () => {
-  await closeDb().catch(() => {});
-  delete process.env.DATABASE_URL;
-  delete process.env.STEWARD_PGLITE_MEMORY;
-  delete process.env.STEWARD_MASTER_PASSWORD;
-  delete process.env.STEWARD_JWT_SECRET;
+  if (!hasDatabaseUrl) return;
+  // Clean up the test tenant; the db connection itself is shared across the
+  // package-wide test run and must NOT be closed here.
+  const db = getDb();
+  await db
+    .delete(tenants)
+    .where(eq(tenants.id, TENANT_ID))
+    .catch(() => {});
 });
 
-describe("agent route scope enforcement", () => {
+describeWithDatabase("agent route scope enforcement", () => {
   it("blocks agent tokens from listing agents and creating new agents", async () => {
     const token = await signAgentToken({ agentId: AGENT_A, tenantId: TENANT_ID }, "1h");
 
@@ -69,7 +91,7 @@ describe("agent route scope enforcement", () => {
         Authorization: `Bearer ${token}`,
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ id: "agent-c", name: "agent-c" }),
+      body: JSON.stringify({ id: "test-ars-agent-c", name: "test-ars-agent-c" }),
     });
     expect(createRes.status).toBe(403);
   });
@@ -102,6 +124,10 @@ describe("agent route scope enforcement", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { ok: boolean; data: Array<{ id: string }> };
     expect(body.ok).toBe(true);
-    expect(body.data.map((agent) => agent.id).sort()).toEqual([AGENT_A, AGENT_B]);
+    const ids = body.data.map((agent) => agent.id).sort();
+    // Other tests may inject agents into this tenant in parallel, so we
+    // assert containment rather than exact equality.
+    expect(ids).toContain(AGENT_A);
+    expect(ids).toContain(AGENT_B);
   });
 });

--- a/packages/api/src/routes/agents.ts
+++ b/packages/api/src/routes/agents.ts
@@ -39,6 +39,16 @@ export const agentRoutes = new Hono<{ Variables: AppVariables }>();
 // ─── Create agent ─────────────────────────────────────────────────────────────
 
 agentRoutes.post("/", async (c) => {
+  if (!requireTenantLevel(c)) {
+    return c.json<ApiResponse>(
+      {
+        ok: false,
+        error: "Agent creation requires tenant-level authentication",
+      },
+      403,
+    );
+  }
+
   const tenantId = c.get("tenantId");
   const body = await safeJsonParse<{
     id: string;
@@ -79,6 +89,16 @@ agentRoutes.post("/", async (c) => {
 // ─── List agents ──────────────────────────────────────────────────────────────
 
 agentRoutes.get("/", async (c) => {
+  if (!requireTenantLevel(c)) {
+    return c.json<ApiResponse>(
+      {
+        ok: false,
+        error: "Agent listing requires tenant-level authentication",
+      },
+      403,
+    );
+  }
+
   const tenantId = c.get("tenantId");
   const tenantAgents = await vault.listAgentsByTenant(tenantId);
   return c.json<ApiResponse<AgentIdentity[]>>({ ok: true, data: tenantAgents });
@@ -137,6 +157,13 @@ agentRoutes.post("/:agentId/token", async (c) => {
 // ─── Get agent ────────────────────────────────────────────────────────────────
 
 agentRoutes.get("/:agentId", async (c) => {
+  if (!requireAgentAccess(c)) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Forbidden: token scope does not match agent" },
+      403,
+    );
+  }
+
   const tenantId = c.get("tenantId");
   const agent = await vault.getAgent(tenantId, c.req.param("agentId"));
   if (!agent) {


### PR DESCRIPTION
## Summary
- require tenant-level auth for `POST /agents`
- require tenant-level auth for `GET /agents`
- scope `GET /agents/:agentId` to the token's own agent when the caller uses an agent token
- add regression coverage for the blocked and allowed cases

## Security issue
Several top-level agent routes were missing scope enforcement:
- an agent token could list every agent in the tenant via `GET /agents`
- an agent token could read another agent's record via `GET /agents/:agentId`
- an agent token could create new agents via `POST /agents`

That broke the intended boundary between tenant-level management operations and an individual agent's scoped runtime token.

## Fix
This PR tightens the three affected routes:
- `POST /agents` now requires tenant-level authentication
- `GET /agents` now requires tenant-level authentication
- `GET /agents/:agentId` now runs `requireAgentAccess()` so an agent token can only read its own record

Tenant-level credentials still retain access to these endpoints.

## Tests
- `bun test src/__tests__/agent-route-scope.test.ts`
- `bunx tsc -p packages/api/tsconfig.json --noEmit`
