### PR TITLE
feat(trade-sessions+hyperliquid): @stwd/trade-sessions package + HL adapter (sprint 4 phase 1 days 1-2)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -36,12 +36,15 @@
         "@stwd/policy-engine": "workspace:*",
         "@stwd/redis": "workspace:*",
         "@stwd/shared": "workspace:*",
+        "@stwd/trade-sessions": "workspace:*",
         "@stwd/vault": "workspace:*",
+        "@stwd/venue-hyperliquid": "workspace:*",
         "@stwd/webhooks": "workspace:*",
         "bs58": "^6.0.0",
         "drizzle-orm": "^0.44.5",
         "hono": "^4.7.0",
         "viem": "^2.30.0",
+        "zod": "^4.3.6",
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20241218.0",
@@ -215,7 +218,7 @@
     },
     "packages/sdk": {
       "name": "@stwd/sdk",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "dependencies": {
         "bs58": "^6.0.0",
       },
@@ -239,6 +242,20 @@
         "@types/bun": "latest",
       },
     },
+    "packages/trade-sessions": {
+      "name": "@stwd/trade-sessions",
+      "version": "0.1.0",
+      "dependencies": {
+        "@stwd/db": "workspace:*",
+        "@stwd/redis": "workspace:*",
+        "@stwd/shared": "workspace:*",
+        "drizzle-orm": "^0.44.5",
+        "zod": "^4.3.6",
+      },
+      "devDependencies": {
+        "@types/node": "^25.5.0",
+      },
+    },
     "packages/vault": {
       "name": "@stwd/vault",
       "version": "0.3.0",
@@ -248,6 +265,18 @@
         "@stwd/shared": "workspace:*",
         "drizzle-orm": "^0.44.5",
         "viem": "^2.30.0",
+      },
+      "devDependencies": {
+        "@types/node": "^25.5.0",
+      },
+    },
+    "packages/venue-hyperliquid": {
+      "name": "@stwd/venue-hyperliquid",
+      "version": "0.1.0",
+      "dependencies": {
+        "@stwd/shared": "workspace:*",
+        "viem": "^2.30.0",
+        "zod": "^4.3.6",
       },
       "devDependencies": {
         "@types/node": "^25.5.0",
@@ -1072,7 +1101,11 @@
 
     "@stwd/shared": ["@stwd/shared@workspace:packages/shared"],
 
+    "@stwd/trade-sessions": ["@stwd/trade-sessions@workspace:packages/trade-sessions"],
+
     "@stwd/vault": ["@stwd/vault@workspace:packages/vault"],
+
+    "@stwd/venue-hyperliquid": ["@stwd/venue-hyperliquid@workspace:packages/venue-hyperliquid"],
 
     "@stwd/web": ["@stwd/web@workspace:web"],
 
@@ -2918,7 +2951,15 @@
 
     "@stwd/react/bs58": ["bs58@5.0.0", "", { "dependencies": { "base-x": "^4.0.0" } }, "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ=="],
 
+    "@stwd/redis/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@stwd/shared/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@stwd/trade-sessions/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
     "@stwd/vault/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@stwd/venue-hyperliquid/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "@stwd/web/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
@@ -3530,7 +3571,15 @@
 
     "@stwd/react/bs58/base-x": ["base-x@4.0.1", "", {}, "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw=="],
 
+    "@stwd/redis/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "@stwd/shared/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "@stwd/trade-sessions/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
     "@stwd/vault/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "@stwd/venue-hyperliquid/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "@stwd/web/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
@@ -4092,6 +4141,10 @@
 
     "@solana/instruction-plans/@solana/transactions/@solana/addresses/@solana/assertions": ["@solana/assertions@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-YTCSWAlGwSlVPnWtWLm3ukz81wH4j2YaCveK+TjpvUU88hTy6fmUqxi0+hvAMAe4zKXpJyj3Az7BrLJRxbIm4Q=="],
 
+    "@stwd/redis/@types/bun/bun-types/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@stwd/shared/@types/bun/bun-types/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
     "@trezor/blockchain-link-utils/@trezor/protobuf/protobufjs/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "@trezor/device-authenticity/@trezor/protobuf/protobufjs/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
@@ -4275,6 +4328,10 @@
     "@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils/viem/ox": ["ox@0.6.7", "", { "dependencies": { "@adraffy/ens-normalize": "^1.10.1", "@noble/curves": "^1.6.0", "@noble/hashes": "^1.5.0", "@scure/bip32": "^1.5.0", "@scure/bip39": "^1.4.0", "abitype": "^1.0.6", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-17Gk/eFsFRAZ80p5eKqv89a57uXjd3NgIf1CaXojATPBuujVc/fQSVhBeAU9JCRB+k7J50WQAyWTxK19T9GgbA=="],
 
     "@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils/viem/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
+
+    "@stwd/redis/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "@stwd/shared/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "@trezor/blockchain-link-utils/@trezor/protobuf/protobufjs/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -19,17 +19,20 @@
     "@stwd/redis": "workspace:*",
     "@stwd/policy-engine": "workspace:*",
     "@stwd/shared": "workspace:*",
+    "@stwd/trade-sessions": "workspace:*",
+    "@stwd/venue-hyperliquid": "workspace:*",
     "@stwd/vault": "workspace:*",
     "@stwd/webhooks": "workspace:*",
     "bs58": "^6.0.0",
     "drizzle-orm": "^0.44.5",
     "hono": "^4.7.0",
-    "viem": "^2.30.0"
+    "viem": "^2.30.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20241218.0",
     "@types/node": "^25.5.0",
     "wrangler": "^4.0.0"
   },
-  "description": "Hono REST API for Steward — agents, policies, approvals, and transaction signing"
+  "description": "Hono REST API for Steward - agents, policies, approvals, and transaction signing"
 }

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -1,17 +1,17 @@
 /**
- * app.ts — Runtime-agnostic Hono app construction.
+ * app.ts - Runtime-agnostic Hono app construction.
  *
  * This module exports the fully-configured `Hono` instance with all routes,
  * middleware, and per-route auth wired up. It deliberately contains NO server
  * boot code (no `Bun.serve`, no `setInterval` GC, no signal handlers, no
  * blocking `runMigrations()` call) so that it can be reused by:
  *
- *   - `index.ts`   — Bun entry point (long-lived process; runs migrations,
+ *   - `index.ts`   - Bun entry point (long-lived process; runs migrations,
  *                    sets up GC timers, wires SIGINT/SIGTERM, calls
  *                    `Bun.serve`).
- *   - `worker.ts`  — Cloudflare Workers entry point (per-request fetch,
+ *   - `worker.ts`  - Cloudflare Workers entry point (per-request fetch,
  *                    no setInterval/Bun, migrations run out-of-band).
- *   - `embedded.ts`— Electrobun/desktop entry point.
+ *   - `embedded.ts`- Electrobun/desktop entry point.
  *
  * Anything that must NOT run on Workers (timers, blocking I/O at module init,
  * Node-only APIs) belongs in `index.ts`, not here.
@@ -33,6 +33,7 @@ import { policiesStandaloneRoutes } from "./routes/policies-standalone";
 import { secretsRoutes } from "./routes/secrets";
 import { tenantConfigRoutes } from "./routes/tenant-config";
 import { tenantRoutes } from "./routes/tenants";
+import { tradeRoutes } from "./routes/trade";
 import { userRoutes } from "./routes/user";
 import { vaultRoutes } from "./routes/vault";
 import { webhookRoutes } from "./routes/webhooks";
@@ -116,6 +117,10 @@ app.use("/audit", (c, next) => tenantAuth(c, next));
 app.use("/audit/*", (c, next) => tenantAuth(c, next));
 app.use("/policies", (c, next) => tenantAuth(c, next));
 app.use("/policies/*", (c, next) => tenantAuth(c, next));
+app.use("/trade", (c, next) => tenantAuth(c, next));
+app.use("/trade/*", (c, next) => tenantAuth(c, next));
+app.use("/v1/trade", (c, next) => tenantAuth(c, next));
+app.use("/v1/trade/*", (c, next) => tenantAuth(c, next));
 
 // ─── Health & root ────────────────────────────────────────────────────────────
 
@@ -145,6 +150,8 @@ app.route("/webhooks", webhookRoutes);
 app.route("/approvals", approvalRoutes);
 app.route("/audit", auditRoutes);
 app.route("/policies", policiesStandaloneRoutes);
+app.route("/trade", tradeRoutes);
+app.route("/v1/trade", tradeRoutes);
 app.route("/agents", erc8004Routes);
 app.route("/discovery", discoveryRoutes);
 

--- a/packages/api/src/routes/trade.ts
+++ b/packages/api/src/routes/trade.ts
@@ -1,0 +1,350 @@
+import { signAgentToken } from "@stwd/auth";
+import { proxyAuditLog } from "@stwd/db";
+import { checkRateLimit } from "@stwd/redis";
+import { TradeSessionManager, tradeSessionScopeSchema } from "@stwd/trade-sessions";
+import {
+  HyperliquidAdapter,
+  type HyperliquidOrder,
+  hyperliquidAssetSchema,
+} from "@stwd/venue-hyperliquid";
+import { sql } from "drizzle-orm";
+import type { Context } from "hono";
+import { Hono } from "hono";
+import { z } from "zod";
+import { getRedisClient } from "../middleware/redis";
+import {
+  type ApiResponse,
+  type AppVariables,
+  db,
+  ensureAgentForTenant,
+  safeJsonParse,
+  vault,
+} from "../services/context";
+
+export const tradeRoutes = new Hono<{ Variables: AppVariables }>();
+
+const createSessionSchema = z.object({
+  venue: z.literal("hyperliquid"),
+  scopes: z.array(tradeSessionScopeSchema).min(1),
+  ttlSeconds: z.number().int().positive().max(3600).default(900),
+});
+
+const submitOrderSchema = z.object({
+  sessionId: z.string().min(1),
+  asset: hyperliquidAssetSchema,
+  side: z.enum(["buy", "sell"]),
+  size: z.number().positive(),
+  leverage: z.number().positive().max(2),
+  reduceOnly: z.boolean().default(false),
+  idempotencyKey: z.string().min(1).max(256).optional(),
+});
+
+type SubmitOrderBody = z.infer<typeof submitOrderSchema>;
+
+const memoryRateLimit = new Map<string, { count: number; resetAt: number }>();
+const memoryIdempotency = new Map<
+  string,
+  { bodyHash: string; response: unknown; expiresAt: number }
+>();
+
+function getSessionManager(): TradeSessionManager {
+  return new TradeSessionManager({ redis: getRedisClient() });
+}
+
+function callerAgentId(c: Context<{ Variables: AppVariables }>): string | null {
+  return c.get("agentScope") ?? null;
+}
+
+function responseData<T>(data: T): ApiResponse<T> {
+  return { ok: true, data };
+}
+
+async function auditTradeEvent(
+  tenantId: string,
+  agentId: string,
+  event: "trade.session.created" | "trade.session.revoked" | "trade.order.submitted",
+  details: Record<string, unknown>,
+): Promise<void> {
+  await db
+    .insert(proxyAuditLog)
+    .values({
+      tenantId,
+      agentId,
+      targetHost: event,
+      targetPath: JSON.stringify(details),
+      method: "AUDIT",
+      statusCode: 200,
+      latencyMs: 0,
+      reason: event,
+    })
+    .catch(() => undefined);
+}
+
+function hashBody(body: unknown): string {
+  return JSON.stringify(body);
+}
+
+async function enforceOrderRateLimit(
+  agentId: string,
+): Promise<{ allowed: boolean; resetMs: number }> {
+  const redis = getRedisClient();
+  if (redis) {
+    const result = await checkRateLimit(`ratelimit:trade:hyperliquid:${agentId}:1000`, 1000, 10);
+    return { allowed: result.allowed, resetMs: result.resetMs };
+  }
+
+  const now = Date.now();
+  const current = memoryRateLimit.get(agentId);
+  if (!current || current.resetAt <= now) {
+    memoryRateLimit.set(agentId, { count: 1, resetAt: now + 1000 });
+    return { allowed: true, resetMs: 1000 };
+  }
+  if (current.count >= 10) return { allowed: false, resetMs: current.resetAt - now };
+  current.count += 1;
+  return { allowed: true, resetMs: current.resetAt - now };
+}
+
+async function checkDailyCap(agentId: string, sizeUsd: number): Promise<boolean> {
+  const since = new Date();
+  since.setUTCHours(0, 0, 0, 0);
+  const [row] = await db
+    .select({
+      total: sql<string>`coalesce(sum((${proxyAuditLog.targetPath}::jsonb ->> 'sizeUsd')::numeric), 0)::text`,
+    })
+    .from(proxyAuditLog)
+    .where(
+      sql`${proxyAuditLog.agentId} = ${agentId} and ${proxyAuditLog.reason} = 'trade.order.submitted' and ${proxyAuditLog.createdAt} >= ${since}`,
+    );
+  const spent = Number(row?.total ?? 0);
+  return spent + sizeUsd <= 100;
+}
+
+function getIdempotency(
+  tenantId: string,
+  agentId: string,
+  key: string | undefined,
+  body: SubmitOrderBody,
+): { conflict?: boolean; response?: unknown; store?: (response: unknown) => void } {
+  if (!key) return {};
+  const now = Date.now();
+  const mapKey = `${tenantId}:${agentId}:${key}`;
+  const bodyHash = hashBody({ ...body, idempotencyKey: undefined });
+  const existing = memoryIdempotency.get(mapKey);
+  if (existing && existing.expiresAt > now) {
+    if (existing.bodyHash !== bodyHash) return { conflict: true };
+    return { response: existing.response };
+  }
+  return {
+    store(response: unknown) {
+      memoryIdempotency.set(mapKey, {
+        bodyHash,
+        response,
+        expiresAt: now + 24 * 60 * 60 * 1000,
+      });
+    },
+  };
+}
+
+async function resolveHyperliquidWallet(
+  agentId: string,
+  agent: { walletAddress: string; walletAddresses?: { evm?: string } },
+): Promise<string | null> {
+  if ("getWallet" in vault && typeof vault.getWallet === "function") {
+    try {
+      const wallet = await vault.getWallet({ agentId, venue: "hyperliquid" });
+      return wallet.address;
+    } catch {
+      return null;
+    }
+  }
+  return (
+    agent.walletAddresses?.evm ??
+    (agent.walletAddress.startsWith("0x") ? agent.walletAddress : null)
+  );
+}
+
+tradeRoutes.post("/sessions", async (c) => {
+  const tenantId = c.get("tenantId");
+  const agentId = callerAgentId(c);
+  if (!agentId) {
+    return c.json<ApiResponse>({ ok: false, error: "Agent JWT required for trade sessions" }, 403);
+  }
+  const raw = await safeJsonParse(c);
+  const parsed = createSessionSchema.safeParse(raw);
+  if (!parsed.success) {
+    return c.json<ApiResponse>({ ok: false, error: parsed.error.message }, 400);
+  }
+
+  const agent = await ensureAgentForTenant(tenantId, agentId);
+  if (!agent) return c.json<ApiResponse>({ ok: false, error: "Agent not found" }, 404);
+  const walletAddress = await resolveHyperliquidWallet(agentId, agent);
+  if (!walletAddress) {
+    return c.json<ApiResponse>(
+      {
+        ok: false,
+        error: "Hyperliquid venue wallet not found. Create a venue-scoped wallet before trading.",
+      },
+      404,
+    );
+  }
+
+  const session = await getSessionManager().create({
+    agentId,
+    tenantId,
+    venue: parsed.data.venue,
+    scopes: parsed.data.scopes,
+    ttlSeconds: parsed.data.ttlSeconds,
+  });
+  const jwt = await signAgentToken(
+    {
+      agentId,
+      tenantId,
+      scopes: ["agent", "trade:read", "trade:hyperliquid:write"],
+      ses: session.id,
+    },
+    `${parsed.data.ttlSeconds}s`,
+  );
+  await auditTradeEvent(tenantId, agentId, "trade.session.created", {
+    sessionId: session.id,
+    venue: session.venue,
+    scopes: session.scopes,
+  });
+
+  return c.json(
+    responseData({
+      sessionId: session.id,
+      jwt,
+      expiresAt: session.expiresAt.toISOString(),
+    }),
+    201,
+  );
+});
+
+tradeRoutes.post("/sessions/:id/revoke", async (c) => {
+  const tenantId = c.get("tenantId");
+  const agentId = callerAgentId(c);
+  if (!agentId) return c.body(null, 204);
+  const existing = await getSessionManager().getActive(tenantId, c.req.param("id"));
+  if (existing && existing.agentId !== agentId) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Forbidden: session belongs to another agent" },
+      403,
+    );
+  }
+  const revoked = await getSessionManager().revoke({
+    id: c.req.param("id"),
+    tenantId,
+    revokedBy: agentId,
+  });
+  if (revoked) {
+    await auditTradeEvent(tenantId, revoked.agentId, "trade.session.revoked", {
+      sessionId: revoked.id,
+      revokedBy: agentId,
+    });
+  }
+  return c.body(null, 204);
+});
+
+tradeRoutes.post("/hyperliquid/order", async (c) => {
+  const tenantId = c.get("tenantId");
+  const agentId = callerAgentId(c);
+  if (!agentId) {
+    return c.json<ApiResponse>({ ok: false, error: "Agent JWT required for trading" }, 403);
+  }
+
+  const rate = await enforceOrderRateLimit(agentId);
+  if (!rate.allowed) {
+    c.header("Retry-After", String(Math.ceil(rate.resetMs / 1000)));
+    return c.json<ApiResponse>({ ok: false, error: "Trade order rate limit exceeded" }, 429);
+  }
+
+  const raw = await safeJsonParse(c);
+  const parsed = submitOrderSchema.safeParse(raw);
+  if (!parsed.success) {
+    return c.json<ApiResponse>({ ok: false, error: parsed.error.message }, 400);
+  }
+  const body = {
+    ...parsed.data,
+    idempotencyKey: c.req.header("Idempotency-Key") ?? parsed.data.idempotencyKey,
+  };
+
+  const idempotency = getIdempotency(tenantId, agentId, body.idempotencyKey, body);
+  if (idempotency.conflict) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Idempotency key reused with a different body" },
+      409,
+    );
+  }
+  if (idempotency.response) {
+    return c.json(responseData(idempotency.response));
+  }
+
+  const session = await getSessionManager().getActive(tenantId, body.sessionId);
+  if (!session || session.agentId !== agentId || session.venue !== "hyperliquid") {
+    return c.json<ApiResponse>({ ok: false, error: "Active Hyperliquid session required" }, 403);
+  }
+  if (!session.scopes.includes("write")) {
+    return c.json<ApiResponse>({ ok: false, error: "Trade session missing write scope" }, 403);
+  }
+
+  if (body.leverage > 2 || !["BTC", "ETH"].includes(body.asset)) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Policy rejected: BTC/ETH only and leverage <= 2" },
+      412,
+    );
+  }
+  const sizeUsd = body.size;
+  if (!(await checkDailyCap(agentId, sizeUsd))) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Policy rejected: daily cap $100 exceeded" },
+      412,
+    );
+  }
+
+  const agent = await ensureAgentForTenant(tenantId, agentId);
+  if (!agent) return c.json<ApiResponse>({ ok: false, error: "Agent not found" }, 404);
+  const walletAddress = await resolveHyperliquidWallet(agentId, agent);
+  if (!walletAddress) {
+    return c.json<ApiResponse>(
+      {
+        ok: false,
+        error: "Hyperliquid venue wallet not found. Create a venue-scoped wallet before trading.",
+      },
+      404,
+    );
+  }
+
+  const vaultClient = {
+    signTypedData: (input: Omit<Parameters<typeof vault.signTypedData>[0], "tenantId">) =>
+      vault.signTypedData({ ...input, tenantId, venue: "hyperliquid" }),
+  };
+  const adapter = new HyperliquidAdapter(vaultClient, agentId, walletAddress);
+  const order: HyperliquidOrder = {
+    asset: body.asset,
+    side: body.side,
+    size: body.size,
+    leverage: body.leverage,
+    reduceOnly: body.reduceOnly,
+  };
+  const signed = await adapter.signOrder(order);
+  const result = await adapter.submitOrder(signed);
+  const response = {
+    orderId: result.orderId ?? crypto.randomUUID(),
+    status: result.status,
+    filledQty: result.filledQty ?? 0,
+    avgPrice: result.avgPrice ?? 0,
+    txHash: result.txHash ?? null,
+  };
+
+  await auditTradeEvent(tenantId, agentId, "trade.order.submitted", {
+    sessionId: session.id,
+    venue: "hyperliquid",
+    asset: body.asset,
+    leverage: body.leverage,
+    size: body.size,
+    sizeUsd,
+    orderId: response.orderId,
+  });
+  idempotency.store?.(response);
+  return c.json(responseData(response));
+});

--- a/packages/db/drizzle/0022_vault_venue_scope.sql
+++ b/packages/db/drizzle/0022_vault_venue_scope.sql
@@ -1,0 +1,92 @@
+-- Sprint 4 Phase 1 Day 1: venue scoping for vault wallets.
+--
+-- Today's vault keys wallets by (agentId, chainFamily). Sol's BSC wallet
+-- (chain) and Sol's Hyperliquid wallet (venue, signs EIP-712 on Arbitrum
+-- but routes through HL's exchange) need to be distinct. We introduce a
+-- nullable `venue` column on both `encrypted_chain_keys` and
+-- `agent_wallets`. Legacy rows keep `venue = NULL` and continue to be
+-- looked up by (agentId, chainFamily).
+--
+-- The previous primary keys / unique indexes on (agentId, chainFamily) are
+-- replaced with unique indexes over (agentId, chainFamily, COALESCE(venue,
+-- '')) so that:
+--   1. Legacy NULL-venue rows are still constrained to one per chain family
+--      (COALESCE collapses NULL into '', so the index treats them as equal).
+--   2. New venue-scoped rows can coexist with the legacy row for the same
+--      agent + chainFamily (e.g. one EVM legacy wallet AND one EVM
+--      hyperliquid wallet for Sol).
+--
+-- The `purpose` column is a human-readable label for the wallet (e.g.
+-- "perp", "spot", "ops"). Not enforced; useful for the dashboard and the
+-- audit trail.
+--
+-- Apply step (dev Neon):
+--   cd packages/db && DATABASE_URL=$NEON_DEV_URL bun run migrate:neon
+--
+-- Down: drop the new columns + indexes, restore the original PK / unique
+-- index. Manual; not provided here because production has no rows yet.
+
+ALTER TABLE "encrypted_chain_keys" ADD COLUMN IF NOT EXISTS "venue" text;
+--> statement-breakpoint
+ALTER TABLE "encrypted_chain_keys" ADD COLUMN IF NOT EXISTS "purpose" text;
+--> statement-breakpoint
+
+-- Drop the composite PK from 0010 / current schema. Drizzle named it
+-- `encrypted_chain_keys_agent_id_chain_family_pk`; the IF EXISTS guards
+-- against re-runs.
+ALTER TABLE "encrypted_chain_keys"
+    DROP CONSTRAINT IF EXISTS "encrypted_chain_keys_agent_id_chain_family_pk";
+--> statement-breakpoint
+
+-- Surrogate PK so multiple (agentId, chainFamily) rows can coexist (one
+-- per venue). DEFAULT gen_random_uuid() backfills existing rows.
+ALTER TABLE "encrypted_chain_keys"
+    ADD COLUMN IF NOT EXISTS "id" uuid DEFAULT gen_random_uuid();
+--> statement-breakpoint
+
+ALTER TABLE "encrypted_chain_keys"
+    ADD CONSTRAINT "encrypted_chain_keys_pkey" PRIMARY KEY ("id");
+--> statement-breakpoint
+
+-- Uniqueness invariant: at most one row per (agentId, chainFamily, venue).
+-- COALESCE(venue, '') so the legacy NULL-venue rows still get the
+-- one-per-chainFamily guarantee.
+CREATE UNIQUE INDEX IF NOT EXISTS "encrypted_chain_keys_agent_chain_venue_idx"
+    ON "encrypted_chain_keys" ("agent_id", "chain_family", (COALESCE("venue", '')));
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "encrypted_chain_keys_agent_id_idx"
+    ON "encrypted_chain_keys" ("agent_id");
+--> statement-breakpoint
+
+-- agent_wallets gets the same treatment. Its previous uniqueness lived in
+-- a uniqueIndex (`agent_wallets_agent_chain_idx`) not a PK, so we just
+-- swap the index.
+
+ALTER TABLE "agent_wallets" ADD COLUMN IF NOT EXISTS "venue" text;
+--> statement-breakpoint
+ALTER TABLE "agent_wallets" ADD COLUMN IF NOT EXISTS "purpose" text;
+--> statement-breakpoint
+
+-- The 0001 migration created uniqueness as a CONSTRAINT named
+-- `agent_wallets_agent_chain_idx`. Some environments (later schema
+-- regenerations) created it as a plain UNIQUE INDEX of the same name.
+-- Drop whichever shape is present; both DROP forms are idempotent.
+ALTER TABLE "agent_wallets"
+    DROP CONSTRAINT IF EXISTS "agent_wallets_agent_chain_idx";
+--> statement-breakpoint
+DROP INDEX IF EXISTS "agent_wallets_agent_chain_idx";
+--> statement-breakpoint
+
+CREATE UNIQUE INDEX IF NOT EXISTS "agent_wallets_agent_chain_venue_idx"
+    ON "agent_wallets" ("agent_id", "chain_family", (COALESCE("venue", '')));
+--> statement-breakpoint
+
+-- ALTER TYPE ... ADD VALUE cannot run inside a transaction in PG < 12.
+-- We rely on the Drizzle migrator running each statement-breakpoint
+-- chunk in its own transaction; the IF NOT EXISTS form is idempotent so
+-- re-runs are safe.
+
+ALTER TYPE "policy_type" ADD VALUE IF NOT EXISTS 'venue-allowlist';
+--> statement-breakpoint
+ALTER TYPE "policy_type" ADD VALUE IF NOT EXISTS 'leverage-cap';

--- a/packages/db/drizzle/0023_trade_sessions.sql
+++ b/packages/db/drizzle/0023_trade_sessions.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS "trade_sessions" (
+  "id" varchar(128) PRIMARY KEY NOT NULL,
+  "agent_id" varchar(64) NOT NULL,
+  "tenant_id" varchar(64) NOT NULL,
+  "venue" varchar(64) NOT NULL,
+  "scopes" jsonb DEFAULT '[]'::jsonb NOT NULL,
+  "status" varchar(32) NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "expires_at" timestamp with time zone NOT NULL,
+  "revoked_at" timestamp with time zone,
+  "revoked_by" varchar(255)
+);
+--> statement-breakpoint
+ALTER TABLE "trade_sessions" ADD CONSTRAINT "trade_sessions_agent_id_agents_id_fk" FOREIGN KEY ("agent_id") REFERENCES "public"."agents"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "trade_sessions" ADD CONSTRAINT "trade_sessions_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "trade_sessions_agent_venue_status_idx" ON "trade_sessions" USING btree ("agent_id","venue","status");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "trade_sessions_tenant_idx" ON "trade_sessions" USING btree ("tenant_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "trade_sessions_expires_at_idx" ON "trade_sessions" USING btree ("expires_at");

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -155,6 +155,20 @@
       "when": 1777018500000,
       "tag": "0021_oauth_account_token_encryption",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1779671100000,
+      "tag": "0022_vault_venue_scope",
+      "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1779671700000,
+      "tag": "0023_trade_sessions",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -16,7 +16,6 @@ import {
   numeric,
   pgEnum,
   pgTable,
-  primaryKey,
   serial,
   text,
   timestamp,
@@ -27,7 +26,7 @@ import {
 
 export interface TenantEmailConfig {
   /**
-   * Per-tenant Resend provider config. Optional — a tenant can also leave
+   * Per-tenant Resend provider config. Optional - a tenant can also leave
    * this entirely empty and only set `magicLinkBaseUrl` to override the
    * magic-link target while continuing to use the global RESEND_API_KEY.
    */
@@ -67,6 +66,8 @@ export const policyTypeEnum = pgEnum("policy_type", [
   "allowed-chains",
   "reputation-threshold",
   "reputation-scaling",
+  "venue-allowlist",
+  "leverage-cap",
 ]);
 
 export const transactionStatusEnum = pgEnum("transaction_status", [
@@ -174,12 +175,21 @@ export const agentWallets = pgTable(
       .references(() => agents.id, { onDelete: "cascade" }),
     chainFamily: chainFamilyEnum("chain_family").notNull(),
     address: varchar("address", { length: 128 }).notNull(),
+    /**
+     * Sprint 4: trading venue this wallet is scoped to (e.g. "hyperliquid").
+     * NULL on legacy rows; vault lookups fall back to chainFamily when
+     * venue isn't provided. See VenueId in @stwd/shared.
+     */
+    venue: text("venue"),
+    /** Optional human-readable label, e.g. "perp", "spot", "ops". */
+    purpose: text("purpose"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({
-    agentChainUniqueIdx: uniqueIndex("agent_wallets_agent_chain_idx").on(
+    agentChainVenueUniqueIdx: uniqueIndex("agent_wallets_agent_chain_venue_idx").on(
       table.agentId,
       table.chainFamily,
+      sql`COALESCE(${table.venue}, '')`,
     ),
     agentIdIdx: index("agent_wallets_agent_id_idx").on(table.agentId),
   }),
@@ -194,17 +204,36 @@ export const agentWallets = pgTable(
 export const encryptedChainKeys = pgTable(
   "encrypted_chain_keys",
   {
+    /**
+     * Sprint 4: surrogate PK so a single (agentId, chainFamily) can have
+     * multiple rows, one per venue. The uniqueness invariant moves to
+     * `agent_chain_venue_idx` below.
+     */
+    id: uuid("id").primaryKey().defaultRandom(),
     agentId: varchar("agent_id", { length: 64 })
       .notNull()
       .references(() => agents.id, { onDelete: "cascade" }),
     chainFamily: chainFamilyEnum("chain_family").notNull(),
+    /**
+     * Sprint 4: trading venue this key is scoped to (e.g. "hyperliquid").
+     * NULL on legacy rows; vault lookups fall back to chainFamily when
+     * venue isn't provided.
+     */
+    venue: text("venue"),
+    /** Optional human-readable label, e.g. "perp", "spot", "ops". */
+    purpose: text("purpose"),
     ciphertext: text("ciphertext").notNull(),
     iv: text("iv").notNull(),
     tag: text("tag").notNull(),
     salt: text("salt").notNull(),
   },
   (table) => ({
-    pk: primaryKey({ columns: [table.agentId, table.chainFamily] }),
+    agentChainVenueUniqueIdx: uniqueIndex("encrypted_chain_keys_agent_chain_venue_idx").on(
+      table.agentId,
+      table.chainFamily,
+      sql`COALESCE(${table.venue}, '')`,
+    ),
+    agentIdIdx: index("encrypted_chain_keys_agent_id_idx").on(table.agentId),
   }),
 );
 
@@ -692,3 +721,35 @@ export const proxyAuditLog = pgTable(
 
 export type ProxyAuditLogEntry = typeof proxyAuditLog.$inferSelect;
 export type NewProxyAuditLogEntry = typeof proxyAuditLog.$inferInsert;
+
+export const tradeSessions = pgTable(
+  "trade_sessions",
+  {
+    id: varchar("id", { length: 128 }).primaryKey(),
+    agentId: varchar("agent_id", { length: 64 })
+      .notNull()
+      .references(() => agents.id, { onDelete: "cascade" }),
+    tenantId: varchar("tenant_id", { length: 64 })
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    venue: varchar("venue", { length: 64 }).notNull(),
+    scopes: jsonb("scopes").$type<string[]>().notNull().default([]),
+    status: varchar("status", { length: 32 }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+    revokedAt: timestamp("revoked_at", { withTimezone: true }),
+    revokedBy: varchar("revoked_by", { length: 255 }),
+  },
+  (table) => ({
+    agentVenueStatusIdx: index("trade_sessions_agent_venue_status_idx").on(
+      table.agentId,
+      table.venue,
+      table.status,
+    ),
+    tenantIdx: index("trade_sessions_tenant_idx").on(table.tenantId),
+    expiresAtIdx: index("trade_sessions_expires_at_idx").on(table.expiresAt),
+  }),
+);
+
+export type TradeSessionRow = typeof tradeSessions.$inferSelect;
+export type NewTradeSessionRow = typeof tradeSessions.$inferInsert;

--- a/packages/eliza-plugin/package.json
+++ b/packages/eliza-plugin/package.json
@@ -16,7 +16,7 @@
     }
   },
   "dependencies": {
-    "@stwd/sdk": "^0.9.0"
+    "@stwd/sdk": "^0.10.0"
   },
   "peerDependencies": {
     "@elizaos/core": ">=2.0.0-alpha.50"

--- a/packages/eliza-plugin/src/actions/submit-trade.ts
+++ b/packages/eliza-plugin/src/actions/submit-trade.ts
@@ -1,0 +1,118 @@
+import type {
+  Action,
+  ActionExample,
+  ActionResult,
+  HandlerOptions,
+  IAgentRuntime,
+  Memory,
+  State,
+} from "@elizaos/core";
+import type { StewardService } from "../services/StewardService.js";
+
+export const submitTradeAction: Action = {
+  name: "STEWARD_SUBMIT_TRADE",
+  description: "Submit a Hyperliquid BTC or ETH perp order through Steward trade sessions",
+  similes: ["submit trade", "place perp order", "trade hyperliquid"],
+  parameters: [
+    {
+      name: "sessionId",
+      description: "Active Steward trade session id",
+      required: true,
+      schema: { type: "string" },
+    },
+    {
+      name: "asset",
+      description: "BTC or ETH",
+      required: true,
+      schema: { type: "string", enum: ["BTC", "ETH"] },
+    },
+    {
+      name: "side",
+      description: "buy or sell",
+      required: true,
+      schema: { type: "string", enum: ["buy", "sell"] },
+    },
+    {
+      name: "size",
+      description: "Order size in USD for MVP policy accounting",
+      required: true,
+      schema: { type: "number" },
+    },
+    {
+      name: "leverage",
+      description: "Leverage, max 2",
+      required: true,
+      schema: { type: "number" },
+    },
+    {
+      name: "reduceOnly",
+      description: "Whether the order may only reduce exposure",
+      required: false,
+      schema: { type: "boolean" },
+    },
+  ],
+  examples: [
+    [
+      {
+        name: "{{user1}}",
+        content: {
+          text: "Buy $25 BTC perp at 2x using session ses_123",
+          action: "STEWARD_SUBMIT_TRADE",
+        },
+      },
+    ],
+  ] as ActionExample[][],
+
+  async validate(runtime: IAgentRuntime, _message: Memory, _state?: State): Promise<boolean> {
+    const steward = runtime.getService("steward" as any) as StewardService | null;
+    return steward?.isConnected() ?? false;
+  },
+
+  async handler(
+    runtime: IAgentRuntime,
+    _message: Memory,
+    _state?: State,
+    options?: HandlerOptions,
+  ): Promise<ActionResult> {
+    const steward = runtime.getService("steward" as any) as StewardService | null;
+    if (!steward?.isConnected()) {
+      return {
+        success: false,
+        error: "Steward SDK is not configured",
+        text: "Trading is unavailable because Steward is not configured for this agent.",
+      };
+    }
+
+    const params = options?.parameters ?? {};
+    if (!params.sessionId || !params.asset || !params.side || !params.size || !params.leverage) {
+      return {
+        success: false,
+        error: "Missing required trade parameters",
+        text: "I need sessionId, asset, side, size, and leverage to submit a trade.",
+      };
+    }
+
+    try {
+      const result = await steward.submitHyperliquidOrder({
+        sessionId: String(params.sessionId),
+        asset: params.asset as "BTC" | "ETH",
+        side: params.side as "buy" | "sell",
+        size: Number(params.size),
+        leverage: Number(params.leverage),
+        reduceOnly: Boolean(params.reduceOnly),
+      });
+      return {
+        success: true,
+        text: `Hyperliquid order submitted. Status: ${result.status}. Order: ${result.orderId}`,
+        data: result as any,
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return {
+        success: false,
+        error: msg,
+        text: `Trade was not submitted: ${msg}`,
+      };
+    }
+  },
+};

--- a/packages/eliza-plugin/src/index.ts
+++ b/packages/eliza-plugin/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @stwd/eliza-plugin — Steward wallet management for ElizaOS agents.
+ * @stwd/eliza-plugin - Steward wallet management for ElizaOS agents.
  *
  * Policy-enforced signing, balances, and approval flows.
  * Drop-in plugin: add to your character's plugins array and set STEWARD_API_URL.
@@ -8,6 +8,7 @@ import type { Plugin } from "@elizaos/core";
 import { checkSpendAction } from "./actions/check-spend.js";
 import { listApprovalsAction } from "./actions/list-approvals.js";
 import { signTransactionAction } from "./actions/sign-transaction.js";
+import { submitTradeAction } from "./actions/submit-trade.js";
 import { transferAction } from "./actions/transfer.js";
 import { approvalRequiredEvaluator } from "./evaluators/approval.js";
 import { balanceProvider } from "./providers/balance.js";
@@ -17,11 +18,17 @@ import { StewardService } from "./services/StewardService.js";
 export const stewardPlugin: Plugin = {
   name: "@stwd/eliza-plugin",
   description:
-    "Steward wallet management — policy-enforced signing, balances, and approval flows for ElizaOS agents",
+    "Steward wallet management - policy-enforced signing, balances, and approval flows for ElizaOS agents",
 
   services: [StewardService],
 
-  actions: [signTransactionAction, transferAction, checkSpendAction, listApprovalsAction],
+  actions: [
+    signTransactionAction,
+    transferAction,
+    checkSpendAction,
+    listApprovalsAction,
+    submitTradeAction,
+  ],
 
   providers: [walletStatusProvider, balanceProvider],
 
@@ -33,6 +40,7 @@ export default stewardPlugin;
 export { checkSpendAction } from "./actions/check-spend.js";
 export { listApprovalsAction } from "./actions/list-approvals.js";
 export { signTransactionAction } from "./actions/sign-transaction.js";
+export { submitTradeAction } from "./actions/submit-trade.js";
 export { transferAction } from "./actions/transfer.js";
 export { approvalRequiredEvaluator } from "./evaluators/approval.js";
 export { balanceProvider } from "./providers/balance.js";

--- a/packages/eliza-plugin/src/services/StewardService.ts
+++ b/packages/eliza-plugin/src/services/StewardService.ts
@@ -15,6 +15,24 @@ import {
 } from "@stwd/sdk";
 import type { StewardPluginConfig } from "../types.js";
 
+export interface HyperliquidSubmitOrderInput {
+  sessionId: string;
+  asset: "BTC" | "ETH";
+  side: "buy" | "sell";
+  size: number;
+  leverage: number;
+  reduceOnly?: boolean;
+  idempotencyKey?: string;
+}
+
+export interface HyperliquidOrderResult {
+  orderId: string;
+  status: string;
+  filledQty: number;
+  avgPrice: number;
+  txHash: string | null;
+}
+
 /**
  * Singleton service wrapping StewardClient for the ElizaOS runtime.
  *
@@ -24,7 +42,7 @@ import type { StewardPluginConfig } from "../types.js";
 export class StewardService extends Service {
   static serviceType = "steward" as const;
   capabilityDescription =
-    "Steward managed wallet — policy-enforced signing, balances, and approval flows";
+    "Steward managed wallet - policy-enforced signing, balances, and approval flows";
 
   private client: StewardClient | null = null;
   private pluginConfig: StewardPluginConfig | null = null;
@@ -154,6 +172,13 @@ export class StewardService extends Service {
   async getDashboard(): Promise<AgentDashboardResponse> {
     this.assertConnected();
     return this.getClient().getAgentDashboard(this.getAgentId());
+  }
+
+  async submitHyperliquidOrder(
+    input: HyperliquidSubmitOrderInput,
+  ): Promise<HyperliquidOrderResult> {
+    this.assertConnected();
+    return this.getClient().trade.hyperliquid.submitOrder(input);
   }
 
   async listApprovals(opts?: {

--- a/packages/eliza-plugin/tsup.config.ts
+++ b/packages/eliza-plugin/tsup.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
   dts: true,
   clean: true,
   sourcemap: true,
-  external: ["@elizaos/core"],
+  external: ["@elizaos/core", "@stwd/sdk"],
   target: "node22",
 });

--- a/packages/policy-engine/src/__tests__/venue-leverage.test.ts
+++ b/packages/policy-engine/src/__tests__/venue-leverage.test.ts
@@ -1,0 +1,196 @@
+// Sprint 4 Phase 1 Day 3 tests: venue-allowlist + leverage-cap evaluators.
+
+import { describe, expect, it } from "bun:test";
+import type { PolicyRule, SignRequest } from "@stwd/shared";
+import { PolicyEngine } from "../engine";
+import { evaluateLeverageCap } from "../evaluators/leverage-cap";
+import { evaluateVenueAllowlist } from "../evaluators/venue-allowlist";
+
+function venueRule(allowedVenues: string[]): PolicyRule {
+  return {
+    id: "venue-1",
+    type: "venue-allowlist",
+    enabled: true,
+    config: { allowedVenues },
+  };
+}
+
+function leverageRule(maxLeverage: number): PolicyRule {
+  return {
+    id: "lev-1",
+    type: "leverage-cap",
+    enabled: true,
+    config: { maxLeverage },
+  };
+}
+
+describe("venue-allowlist evaluator", () => {
+  it("ALLOWs when the requested venue is in the allowlist", () => {
+    const result = evaluateVenueAllowlist(venueRule(["hyperliquid"]), { venue: "hyperliquid" });
+    expect(result.passed).toBe(true);
+    expect(result.reason).toContain("hyperliquid");
+  });
+
+  it("NACKs when the requested venue is NOT in the allowlist", () => {
+    const result = evaluateVenueAllowlist(venueRule(["hyperliquid"]), { venue: "polymarket" });
+    expect(result.passed).toBe(false);
+    expect(result.reason).toBe("venue-not-allowlisted: polymarket");
+  });
+
+  it("NACKs when the eval context omits the venue (trade-sessions must set it)", () => {
+    const result = evaluateVenueAllowlist(venueRule(["hyperliquid"]), {});
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("missing venue");
+  });
+
+  it("NACKs and surfaces misconfig when the allowlist is empty", () => {
+    const result = evaluateVenueAllowlist(venueRule([]), { venue: "hyperliquid" });
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("misconfigured");
+  });
+
+  it("ALLOWs when multiple venues are in the allowlist", () => {
+    const result = evaluateVenueAllowlist(venueRule(["hyperliquid", "polymarket"]), {
+      venue: "polymarket",
+    });
+    expect(result.passed).toBe(true);
+  });
+
+  it("returns passed=true when the policy itself is disabled (per evaluator contract)", async () => {
+    const { evaluatePolicy } = await import("../evaluators");
+    const rule: PolicyRule = {
+      id: "v",
+      type: "venue-allowlist",
+      enabled: false,
+      config: { allowedVenues: [] },
+    };
+    const ctx = makeEvaluatorCtx({ venue: "nope" });
+    const r = await evaluatePolicy(rule, ctx);
+    expect(r.passed).toBe(true);
+  });
+});
+
+describe("leverage-cap evaluator", () => {
+  it("ALLOWs when leverage is below the cap", () => {
+    const r = evaluateLeverageCap(leverageRule(2), { leverage: 1.5 });
+    expect(r.passed).toBe(true);
+  });
+
+  it("ALLOWs when leverage equals the cap (inclusive)", () => {
+    const r = evaluateLeverageCap(leverageRule(2), { leverage: 2 });
+    expect(r.passed).toBe(true);
+  });
+
+  it("NACKs when leverage exceeds the cap", () => {
+    const r = evaluateLeverageCap(leverageRule(2), { leverage: 3 });
+    expect(r.passed).toBe(false);
+    expect(r.reason).toBe("leverage-exceeds-cap: 3 > 2");
+  });
+
+  it("ALLOWs when leverage is undefined (non-leveraged trade)", () => {
+    const r = evaluateLeverageCap(leverageRule(2), {});
+    expect(r.passed).toBe(true);
+    expect(r.reason).toContain("non-leveraged");
+  });
+
+  it("ALLOWs when leverage is null (typed-edge case)", () => {
+    const r = evaluateLeverageCap(leverageRule(2), { leverage: undefined });
+    expect(r.passed).toBe(true);
+  });
+
+  it("NACKs when maxLeverage is not a finite number (misconfig)", () => {
+    const r = evaluateLeverageCap(
+      { ...leverageRule(2), config: { maxLeverage: NaN } as any },
+      {
+        leverage: 1,
+      },
+    );
+    expect(r.passed).toBe(false);
+    expect(r.reason).toContain("finite number");
+  });
+
+  it("NACKs when maxLeverage is less than 1 (misconfig)", () => {
+    const r = evaluateLeverageCap(leverageRule(0), { leverage: 0.5 });
+    expect(r.passed).toBe(false);
+    expect(r.reason).toContain("must be >= 1");
+  });
+
+  it("NACKs when leverage is not a finite number (malformed payload)", () => {
+    const r = evaluateLeverageCap(leverageRule(2), { leverage: Number.POSITIVE_INFINITY });
+    expect(r.passed).toBe(false);
+    expect(r.reason).toContain("not a finite number");
+  });
+});
+
+describe("PolicyEngine.evaluate (venue + leverage end-to-end)", () => {
+  it("ALLOWs when both evaluators pass", async () => {
+    const engine = new PolicyEngine();
+    const result = await engine.evaluate([venueRule(["hyperliquid"]), leverageRule(2)], {
+      request: makeSignRequest(),
+      recentTxCount1h: 0,
+      recentTxCount24h: 0,
+      spentToday: 0n,
+      spentThisWeek: 0n,
+      venue: "hyperliquid",
+      leverage: 2,
+    });
+    expect(result.approved).toBe(true);
+    expect(result.requiresManualApproval).toBe(false);
+    expect(result.results.every((r) => r.passed)).toBe(true);
+  });
+
+  it("rejects when venue-allowlist fails (hard policy)", async () => {
+    const engine = new PolicyEngine();
+    const result = await engine.evaluate([venueRule(["hyperliquid"]), leverageRule(2)], {
+      request: makeSignRequest(),
+      recentTxCount1h: 0,
+      recentTxCount24h: 0,
+      spentToday: 0n,
+      spentThisWeek: 0n,
+      venue: "polymarket",
+      leverage: 1,
+    });
+    expect(result.approved).toBe(false);
+    expect(result.requiresManualApproval).toBe(false);
+    const venueResult = result.results.find((r) => r.type === "venue-allowlist");
+    expect(venueResult?.passed).toBe(false);
+  });
+
+  it("rejects when leverage-cap fails (hard policy)", async () => {
+    const engine = new PolicyEngine();
+    const result = await engine.evaluate([venueRule(["hyperliquid"]), leverageRule(2)], {
+      request: makeSignRequest(),
+      recentTxCount1h: 0,
+      recentTxCount24h: 0,
+      spentToday: 0n,
+      spentThisWeek: 0n,
+      venue: "hyperliquid",
+      leverage: 5,
+    });
+    expect(result.approved).toBe(false);
+    const leverageResult = result.results.find((r) => r.type === "leverage-cap");
+    expect(leverageResult?.passed).toBe(false);
+    expect(leverageResult?.reason).toContain("5 > 2");
+  });
+});
+
+function makeSignRequest(): SignRequest {
+  return {
+    agentId: "sol",
+    tenantId: "test-tenant",
+    to: "0x0000000000000000000000000000000000000000",
+    value: "0",
+    chainId: 42161,
+  };
+}
+
+function makeEvaluatorCtx(overrides: { venue?: string; leverage?: number } = {}) {
+  return {
+    request: makeSignRequest(),
+    recentTxCount1h: 0,
+    recentTxCount24h: 0,
+    spentToday: 0n,
+    spentThisWeek: 0n,
+    ...overrides,
+  };
+}

--- a/packages/policy-engine/src/engine.ts
+++ b/packages/policy-engine/src/engine.ts
@@ -27,6 +27,12 @@ export interface PolicyEvaluationContext {
   priceOracle?: PriceOracle;
   /** Optional reputation score for reputation-based policies */
   reputationScore?: number;
+  /** Sprint 4: trading venue (for `venue-allowlist`). */
+  venue?: string;
+  /** Sprint 4: requested leverage multiple (for `leverage-cap`). */
+  leverage?: number;
+  /** Sprint 4: pre-computed USD value of the action. */
+  valueUsd?: number;
 }
 
 export interface EvaluationResult {
@@ -56,7 +62,7 @@ function extractProxyValue(request: ProxySimulationRequest): string {
 }
 
 /**
- * Policy Engine — evaluates a set of policy rules against a transaction request.
+ * Policy Engine - evaluates a set of policy rules against a transaction request.
  *
  * Logic:
  * - All enabled policies must pass for auto-approval
@@ -83,6 +89,9 @@ export class PolicyEngine {
       spentThisWeek: ctx.spentThisWeek,
       priceOracle: ctx.priceOracle,
       reputationScore: ctx.reputationScore,
+      venue: ctx.venue,
+      leverage: ctx.leverage,
+      valueUsd: ctx.valueUsd,
     };
 
     const results: PolicyResult[] = await Promise.all(
@@ -105,7 +114,7 @@ export class PolicyEngine {
       return { approved: false, results, requiresManualApproval: true };
     }
 
-    // Hard policy failed — reject
+    // Hard policy failed - reject
     return { approved: false, results, requiresManualApproval: false };
   }
 

--- a/packages/policy-engine/src/evaluators.ts
+++ b/packages/policy-engine/src/evaluators.ts
@@ -11,8 +11,10 @@ import {
   type TimeWindowConfig,
   toCaip2,
 } from "@stwd/shared";
+import { evaluateLeverageCap } from "./evaluators/leverage-cap";
 import { evaluateReputationScaling } from "./evaluators/reputation-scaling";
 import { evaluateReputationThreshold } from "./evaluators/reputation-threshold";
+import { evaluateVenueAllowlist } from "./evaluators/venue-allowlist";
 
 export interface EvaluatorContext {
   request: SignRequest;
@@ -24,6 +26,23 @@ export interface EvaluatorContext {
   priceOracle?: PriceOracle;
   /** Optional reputation score for reputation-based policies */
   reputationScore?: number;
+  /**
+   * Sprint 4: trading venue the request is destined for. Required by the
+   * `venue-allowlist` evaluator. Trade-sessions sets this from the venue
+   * adapter dispatch step; non-trade signing requests leave it undefined.
+   */
+  venue?: string;
+  /**
+   * Sprint 4: requested leverage multiple (e.g. 2 = 2x). Required by the
+   * `leverage-cap` evaluator. Undefined for non-leveraged trades and for
+   * spot transfers.
+   */
+  leverage?: number;
+  /**
+   * Optional pre-computed USD value of the action. Trade-sessions can
+   * populate this so evaluators don't all re-quote the oracle.
+   */
+  valueUsd?: number;
 }
 
 /**
@@ -67,6 +86,10 @@ export async function evaluatePolicy(
         reputationScore: ctx.reputationScore,
         txValue: BigInt(ctx.request.value),
       });
+    case "venue-allowlist":
+      return evaluateVenueAllowlist(rule, { venue: ctx.venue });
+    case "leverage-cap":
+      return evaluateLeverageCap(rule, { leverage: ctx.leverage });
     default:
       return {
         policyId: rule.id,
@@ -171,7 +194,7 @@ async function evaluateSpendingLimit(
         };
       }
 
-      // Daily USD limit — convert spentToday from wei to USD
+      // Daily USD limit - convert spentToday from wei to USD
       if (config.maxPerDayUsd !== undefined) {
         const spentTodayUsd = await ctx.priceOracle.weiToUsd(ctx.spentToday.toString(), chainId);
         if (spentTodayUsd !== null) {
@@ -185,7 +208,7 @@ async function evaluateSpendingLimit(
         }
       }
 
-      // Weekly USD limit — convert spentThisWeek from wei to USD
+      // Weekly USD limit - convert spentThisWeek from wei to USD
       if (config.maxPerWeekUsd !== undefined) {
         const spentWeekUsd = await ctx.priceOracle.weiToUsd(ctx.spentThisWeek.toString(), chainId);
         if (spentWeekUsd !== null) {
@@ -202,7 +225,7 @@ async function evaluateSpendingLimit(
       return { ...base, passed: true };
     }
 
-    // Price unavailable — fall through to wei comparison with a warning
+    // Price unavailable - fall through to wei comparison with a warning
     console.warn(
       `[policy] USD price unavailable for chain ${chainId}, falling back to wei comparison`,
     );
@@ -288,7 +311,7 @@ async function evaluateAutoApprove(rule: PolicyRule, ctx: EvaluatorContext): Pro
       };
     }
 
-    // Price unavailable — fall through to wei if available
+    // Price unavailable - fall through to wei if available
     console.warn(
       `[policy] USD price unavailable for chain ${chainId}, falling back to wei threshold`,
     );
@@ -306,7 +329,7 @@ async function evaluateAutoApprove(rule: PolicyRule, ctx: EvaluatorContext): Pro
     };
   }
 
-  // No threshold configured at all — pass (policy misconfigured but don't block)
+  // No threshold configured at all - pass (policy misconfigured but don't block)
   return { ...base, passed: true, reason: "No threshold configured" };
 }
 

--- a/packages/policy-engine/src/evaluators/leverage-cap.ts
+++ b/packages/policy-engine/src/evaluators/leverage-cap.ts
@@ -1,0 +1,66 @@
+// Sprint 4: leverage-cap policy evaluator.
+//
+// Caps requested leverage at config.maxLeverage. A request without an
+// explicit `leverage` field (spot transfer, non-leveraged perp) ALWAYS
+// passes: leverage-cap is meant to gate the act of taking leverage, not
+// to require that every signing call declare one. Trade-sessions sets
+// leverage from the order payload; @stwd/agent-trader and direct sign
+// requests leave it undefined.
+//
+// Per-venue refinement (e.g. 2x on Hyperliquid, 5x on Drift) is Phase 2.
+// For now a single cap per agent is sufficient for Sol's $100/day MVP.
+
+import type { LeverageCapConfig, PolicyResult, PolicyRule } from "@stwd/shared";
+
+export interface LeverageCapContext {
+  leverage?: number;
+}
+
+export function evaluateLeverageCap(rule: PolicyRule, ctx: LeverageCapContext): PolicyResult {
+  const config = rule.config as unknown as LeverageCapConfig;
+  const base = { policyId: rule.id, type: rule.type } as const;
+
+  if (typeof config.maxLeverage !== "number" || !Number.isFinite(config.maxLeverage)) {
+    return {
+      ...base,
+      passed: false,
+      reason: "leverage-cap: maxLeverage must be a finite number",
+    };
+  }
+  if (config.maxLeverage < 1) {
+    return {
+      ...base,
+      passed: false,
+      reason: `leverage-cap: maxLeverage ${config.maxLeverage} must be >= 1`,
+    };
+  }
+
+  if (ctx.leverage === undefined || ctx.leverage === null) {
+    return {
+      ...base,
+      passed: true,
+      reason: "no leverage requested (non-leveraged trade)",
+    };
+  }
+  if (!Number.isFinite(ctx.leverage)) {
+    return {
+      ...base,
+      passed: false,
+      reason: `leverage-cap: leverage ${ctx.leverage} is not a finite number`,
+    };
+  }
+
+  if (ctx.leverage <= config.maxLeverage) {
+    return {
+      ...base,
+      passed: true,
+      reason: `leverage ${ctx.leverage} within cap ${config.maxLeverage}`,
+    };
+  }
+
+  return {
+    ...base,
+    passed: false,
+    reason: `leverage-exceeds-cap: ${ctx.leverage} > ${config.maxLeverage}`,
+  };
+}

--- a/packages/policy-engine/src/evaluators/venue-allowlist.ts
+++ b/packages/policy-engine/src/evaluators/venue-allowlist.ts
@@ -1,0 +1,50 @@
+// Sprint 4: venue-allowlist policy evaluator.
+//
+// Allows trades only on the named venues. Without a venue on the context
+// (i.e. non-trade signing requests), the policy NACKs by default: this
+// evaluator is opt-in per agent, so the absence of a venue means a
+// trade-session caller forgot to set it, not that the request is benign.
+// If you want the evaluator to soft-pass when venue is unset, leave the
+// policy disabled or omit it from the agent's policy set.
+
+import type { PolicyResult, PolicyRule, VenueAllowlistConfig } from "@stwd/shared";
+
+export interface VenueAllowlistContext {
+  venue?: string;
+}
+
+export function evaluateVenueAllowlist(rule: PolicyRule, ctx: VenueAllowlistContext): PolicyResult {
+  const config = rule.config as unknown as VenueAllowlistConfig;
+  const base = { policyId: rule.id, type: rule.type } as const;
+
+  const allowed = Array.isArray(config.allowedVenues) ? config.allowedVenues : [];
+  if (allowed.length === 0) {
+    return {
+      ...base,
+      passed: false,
+      reason: "venue-allowlist: allowedVenues is empty (policy misconfigured)",
+    };
+  }
+
+  if (!ctx.venue) {
+    return {
+      ...base,
+      passed: false,
+      reason: "venue-not-allowlisted: <missing venue in eval context>",
+    };
+  }
+
+  if (allowed.includes(ctx.venue)) {
+    return {
+      ...base,
+      passed: true,
+      reason: `venue ${ctx.venue} allowlisted`,
+    };
+  }
+
+  return {
+    ...base,
+    passed: false,
+    reason: `venue-not-allowlisted: ${ctx.venue}`,
+  };
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -38,7 +38,7 @@
     "test": "bun test src/__tests__"
   },
   "dependencies": {
-    "@stwd/sdk": "^0.9.0"
+    "@stwd/sdk": "^0.10.0"
   },
   "peerDependencies": {
     "react": ">=18.0.0",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @stwd/sdk Changelog
+
+## 0.10.0
+
+BREAKING-CHANGES:
+- Adds the Sprint 4 trade API surface under `StewardClient.tradeSessions` and `StewardClient.trade.hyperliquid`.
+- Consumers that pin exact SDK versions should upgrade to `0.10.0` before using trade session or Hyperliquid order helpers.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stwd/sdk",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "TypeScript SDK for Steward, agent wallet infrastructure with policy enforcement",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -48,7 +48,7 @@ export type GetBalanceResult = AgentBalance;
 export interface StewardClientConfig {
   baseUrl: string;
   apiKey?: string;
-  /** Agent-scoped JWT — sent as `Authorization: Bearer <token>`. Preferred over apiKey when both are set. */
+  /** Agent-scoped JWT - sent as `Authorization: Bearer <token>`. Preferred over apiKey when both are set. */
   bearerToken?: string;
   tenantId?: string;
 }
@@ -92,6 +92,36 @@ export interface StewardHistoryEntry {
 
 export interface SignMessageResult {
   signature: string;
+}
+
+export interface CreateTradeSessionInput {
+  venue: "hyperliquid";
+  scopes: Array<"read" | "write">;
+  ttlSeconds?: number;
+}
+
+export interface CreateTradeSessionResult {
+  sessionId: string;
+  jwt: string;
+  expiresAt: string;
+}
+
+export interface HyperliquidSubmitOrderInput {
+  sessionId: string;
+  asset: "BTC" | "ETH";
+  side: "buy" | "sell";
+  size: number;
+  leverage: number;
+  reduceOnly?: boolean;
+  idempotencyKey?: string;
+}
+
+export interface HyperliquidOrderResult {
+  orderId: string;
+  status: string;
+  filledQty: number;
+  avgPrice: number;
+  txHash: string | null;
 }
 
 /**
@@ -154,6 +184,50 @@ export class StewardClient {
     this.bearerToken = bearerToken;
     this.tenantId = tenantId;
   }
+
+  readonly tradeSessions = {
+    create: async (input: CreateTradeSessionInput): Promise<CreateTradeSessionResult> => {
+      const response = await this.request<CreateTradeSessionResult, StewardErrorResponse>(
+        "/v1/trade/sessions",
+        {
+          method: "POST",
+          body: JSON.stringify(input),
+        },
+      );
+      if (!response.ok) throw new StewardApiError(response.error, response.status, response.data);
+      return response.data;
+    },
+    revoke: async (sessionId: string): Promise<void> => {
+      const response = await this.request<undefined, StewardErrorResponse>(
+        `/v1/trade/sessions/${encodeURIComponent(sessionId)}/revoke`,
+        { method: "POST" },
+      );
+      if (!response.ok) throw new StewardApiError(response.error, response.status, response.data);
+    },
+  };
+
+  readonly trade = {
+    hyperliquid: {
+      submitOrder: async (
+        input: HyperliquidSubmitOrderInput,
+        options?: { idempotencyKey?: string },
+      ): Promise<HyperliquidOrderResult> => {
+        const idempotencyKey = options?.idempotencyKey ?? input.idempotencyKey;
+        const response = await this.request<HyperliquidOrderResult, StewardErrorResponse>(
+          "/v1/trade/hyperliquid/order",
+          {
+            method: "POST",
+            headers: idempotencyKey ? { "Idempotency-Key": idempotencyKey } : undefined,
+            body: JSON.stringify(input),
+          },
+        );
+        if (!response.ok) {
+          throw new StewardApiError(response.error, response.status, response.data);
+        }
+        return response.data;
+      },
+    },
+  };
 
   getBaseUrl(): string {
     return this.baseUrl;
@@ -253,7 +327,7 @@ export class StewardClient {
 
   /**
    * Return a compact history feed for an agent. Each entry is a
-   * `{ timestamp, value }` pair — suitable for trend charts and volume
+   * `{ timestamp, value }` pair - suitable for trend charts and volume
    * windows. For the full signed-transaction objects, prefer
    * {@link getTransactionHistory}.
    */
@@ -857,7 +931,7 @@ export class StewardClient {
 
   /**
    * Download the audit log as CSV. Returns the raw CSV body as a string.
-   * Does not use the `/api/v1` JSON envelope — streams text directly.
+   * Does not use the `/api/v1` JSON envelope - streams text directly.
    */
   async exportAuditCsv(params?: {
     agentId?: string;

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -16,10 +16,14 @@ export type {
 export type {
   BatchAgentSpec,
   BatchCreateResult,
+  CreateTradeSessionInput,
+  CreateTradeSessionResult,
   CreateWalletResult,
   GetAddressesResult,
   GetBalanceResult,
   GetHistoryResult,
+  HyperliquidOrderResult,
+  HyperliquidSubmitOrderInput,
   SignMessageResult,
   SignTransactionInput,
   SignTransactionResult,
@@ -29,7 +33,7 @@ export type {
   StewardPendingApproval,
 } from "./client.ts";
 export { StewardApiError, StewardClient } from "./client.ts";
-// v0.4.0 — Tenant config, dashboard, approvals, webhooks
+// v0.4.0 - Tenant config, dashboard, approvals, webhooks
 export type {
   AgentBalance,
   AgentDashboardResponse,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,9 +1,14 @@
-// @stwd/shared — types, constants, utils
+// @stwd/shared - types, constants, utils
+
+import type { VenueId } from "./types/venue.js";
 
 export type { PriceOracle } from "./price-oracle.js";
 export { createPriceOracle } from "./price-oracle.js";
 // ─── Token Registry & Price Oracle ───
 export * from "./tokens.js";
+export type { TradeAsset, TradePolicyContext, VenueId } from "./types/venue.js";
+// ─── Trading venues (Sprint 4) ───
+export * from "./types/venue.js";
 
 // ─── Tenancy ───
 
@@ -79,7 +84,7 @@ export interface AgentIdentity {
   id: string;
   tenantId: string;
   name: string;
-  /** Primary EVM address — kept for backwards compatibility. */
+  /** Primary EVM address - kept for backwards compatibility. */
   walletAddress: string;
   /**
    * All addresses for this agent, keyed by chain family.
@@ -227,7 +232,9 @@ export type PolicyType =
   | "rate-limit"
   | "allowed-chains"
   | "reputation-threshold"
-  | "reputation-scaling";
+  | "reputation-scaling"
+  | "venue-allowlist"
+  | "leverage-cap";
 
 export interface PolicyRule {
   id: string;
@@ -241,7 +248,7 @@ export interface SpendingLimitConfig {
   maxPerTx?: string;
   maxPerDay?: string;
   maxPerWeek?: string;
-  // USD-based (preferred — takes precedence when price oracle is available)
+  // USD-based (preferred - takes precedence when price oracle is available)
   maxPerTxUsd?: number;
   maxPerDayUsd?: number;
   maxPerWeekUsd?: number;
@@ -253,8 +260,8 @@ export interface ApprovedAddressesConfig {
 }
 
 export interface AutoApproveConfig {
-  threshold?: string; // wei — below this, auto-approve (legacy)
-  thresholdUsd?: number; // USD — below this, auto-approve (preferred)
+  threshold?: string; // wei - below this, auto-approve (legacy)
+  thresholdUsd?: number; // USD - below this, auto-approve (preferred)
 }
 
 export interface TimeWindowConfig {
@@ -270,6 +277,27 @@ export interface RateLimitConfig {
 export interface AllowedChainsConfig {
   /** Array of CAIP-2 chain identifiers that are permitted. e.g. ["eip155:8453", "eip155:1"] */
   chains: string[];
+}
+
+/**
+ * `venue-allowlist` policy config (Sprint 4).
+ *
+ * Allows trades only on the named venues. Evaluator NACKs if the eval
+ * context's `venue` is absent or not in the list.
+ */
+export interface VenueAllowlistConfig {
+  allowedVenues: string[];
+}
+
+/**
+ * `leverage-cap` policy config (Sprint 4).
+ *
+ * Caps requested leverage at `maxLeverage`. Non-leveraged trades (no
+ * `leverage` in eval context) always pass. Per-venue refinement is
+ * Phase 2 work; for now this is a single cap per agent.
+ */
+export interface LeverageCapConfig {
+  maxLeverage: number;
 }
 
 // ─── Transactions ───
@@ -292,7 +320,7 @@ export interface SignRequest {
   chainId: number;
   nonce?: number;
   gasLimit?: string;
-  broadcast?: boolean; // default true — set false to return signed tx without broadcasting
+  broadcast?: boolean; // default true - set false to return signed tx without broadcasting
 }
 
 /**
@@ -301,6 +329,7 @@ export interface SignRequest {
 export interface SignTypedDataRequest {
   agentId: string;
   tenantId: string;
+  venue?: VenueId;
   domain: TypedDataDomain;
   types: Record<string, TypedDataField[]>;
   primaryType: string;
@@ -536,7 +565,7 @@ export const SUPPORTED_CHAINS = {
   base: 8453,
   arbitrum: 42161,
   baseSepolia: 84532,
-  // Solana — convention IDs (not EVM chainIds)
+  // Solana - convention IDs (not EVM chainIds)
   solana: 101,
   solanaDevnet: 102,
 } as const;

--- a/packages/shared/src/types/venue.ts
+++ b/packages/shared/src/types/venue.ts
@@ -1,0 +1,11 @@
+export type VenueId = "hyperliquid";
+
+export type TradeAsset = "BTC" | "ETH";
+
+export interface TradePolicyContext {
+  venue: VenueId;
+  asset: TradeAsset;
+  leverage: number;
+  size: number;
+  sizeUsd?: number;
+}

--- a/packages/trade-sessions/package.json
+++ b/packages/trade-sessions/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@stwd/trade-sessions",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "tsc --noEmit",
+    "dev": "tsc --watch",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@stwd/db": "workspace:*",
+    "@stwd/redis": "workspace:*",
+    "@stwd/shared": "workspace:*",
+    "drizzle-orm": "^0.44.5",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.0"
+  },
+  "description": "Venue-scoped trading session storage for Steward"
+}

--- a/packages/trade-sessions/src/index.ts
+++ b/packages/trade-sessions/src/index.ts
@@ -1,0 +1,200 @@
+import { getDb, tradeSessions } from "@stwd/db";
+import type { VenueId } from "@stwd/shared";
+import type { InferInsertModel } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+
+export const tradeSessionScopeSchema = z.enum(["read", "write"]);
+export type TradeSessionScope = z.infer<typeof tradeSessionScopeSchema>;
+
+export const tradeSessionStatusSchema = z.enum(["active", "revoked", "expired"]);
+export type TradeSessionStatus = z.infer<typeof tradeSessionStatusSchema>;
+
+export const tradeSessionSchema = z.object({
+  id: z.string(),
+  agentId: z.string(),
+  tenantId: z.string(),
+  venue: z.literal("hyperliquid"),
+  scopes: z.array(tradeSessionScopeSchema),
+  status: tradeSessionStatusSchema,
+  createdAt: z.date(),
+  expiresAt: z.date(),
+  revokedAt: z.date().nullable().optional(),
+  revokedBy: z.string().nullable().optional(),
+});
+
+export type TradeSession = z.infer<typeof tradeSessionSchema>;
+
+export interface TradeSessionRedisLike {
+  get(key: string): Promise<string | null>;
+  setex(key: string, ttlSeconds: number, value: string): Promise<string>;
+  del(...keys: string[]): Promise<number>;
+}
+
+export interface TradeSessionManagerOptions {
+  redis?: TradeSessionRedisLike | null;
+  now?: () => Date;
+}
+
+export interface CreateTradeSessionInput {
+  agentId: string;
+  tenantId: string;
+  venue: VenueId;
+  scopes: TradeSessionScope[];
+  ttlSeconds: number;
+}
+
+export interface RevokeTradeSessionInput {
+  id: string;
+  tenantId: string;
+  revokedBy?: string;
+}
+
+const DEFAULT_TTL_SECONDS = 900;
+const MAX_TTL_SECONDS = 3600;
+
+function sessionKey(tenantId: string, id: string): string {
+  return `trade:session:${tenantId}:${id}`;
+}
+
+function serializeSession(session: TradeSession): string {
+  return JSON.stringify({
+    ...session,
+    createdAt: session.createdAt.toISOString(),
+    expiresAt: session.expiresAt.toISOString(),
+    revokedAt: session.revokedAt?.toISOString() ?? null,
+  });
+}
+
+function parseSession(raw: string): TradeSession | null {
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    return tradeSessionSchema.parse({
+      ...parsed,
+      createdAt: new Date(String(parsed.createdAt)),
+      expiresAt: new Date(String(parsed.expiresAt)),
+      revokedAt: parsed.revokedAt ? new Date(String(parsed.revokedAt)) : null,
+    });
+  } catch {
+    return null;
+  }
+}
+
+function normalizeTtl(ttlSeconds: number): number {
+  if (!Number.isFinite(ttlSeconds)) return DEFAULT_TTL_SECONDS;
+  return Math.max(60, Math.min(MAX_TTL_SECONDS, Math.floor(ttlSeconds)));
+}
+
+export class TradeSessionManager {
+  private readonly redis: TradeSessionRedisLike | null;
+  private readonly now: () => Date;
+
+  constructor(options: TradeSessionManagerOptions = {}) {
+    this.redis = options.redis ?? null;
+    this.now = options.now ?? (() => new Date());
+  }
+
+  async create(input: CreateTradeSessionInput): Promise<TradeSession> {
+    const ttlSeconds = normalizeTtl(input.ttlSeconds);
+    const createdAt = this.now();
+    const expiresAt = new Date(createdAt.getTime() + ttlSeconds * 1000);
+    const session: TradeSession = {
+      id: `ses_${crypto.randomUUID()}`,
+      agentId: input.agentId,
+      tenantId: input.tenantId,
+      venue: input.venue,
+      scopes: [...new Set(input.scopes)],
+      status: "active",
+      createdAt,
+      expiresAt,
+      revokedAt: null,
+      revokedBy: null,
+    };
+
+    const db = getDb();
+    const values: InferInsertModel<typeof tradeSessions> = {
+      id: session.id,
+      agentId: session.agentId,
+      tenantId: session.tenantId,
+      venue: session.venue,
+      scopes: session.scopes,
+      status: session.status,
+      createdAt,
+      expiresAt,
+    };
+    await db.insert(tradeSessions).values(values);
+    await this.writeRedis(session);
+    return session;
+  }
+
+  async getActive(tenantId: string, id: string): Promise<TradeSession | null> {
+    const cached = await this.readRedis(tenantId, id);
+    const session = cached ?? (await this.readDb(tenantId, id));
+    if (!session) return null;
+
+    const now = this.now();
+    if (session.status !== "active" || session.expiresAt <= now) {
+      if (session.status === "active") {
+        await this.markExpired(session);
+      }
+      return null;
+    }
+    return session;
+  }
+
+  async revoke(input: RevokeTradeSessionInput): Promise<TradeSession | null> {
+    const existing = await this.readDb(input.tenantId, input.id);
+    if (!existing) return null;
+    if (existing.status === "revoked") return existing;
+
+    const revokedAt = this.now();
+    const revoked: TradeSession = {
+      ...existing,
+      status: "revoked",
+      revokedAt,
+      revokedBy: input.revokedBy ?? null,
+    };
+
+    await getDb()
+      .update(tradeSessions)
+      .set({ status: "revoked", revokedAt, revokedBy: revoked.revokedBy })
+      .where(and(eq(tradeSessions.id, input.id), eq(tradeSessions.tenantId, input.tenantId)));
+    await this.redis?.del(sessionKey(input.tenantId, input.id)).catch(() => 0);
+    return revoked;
+  }
+
+  private async readRedis(tenantId: string, id: string): Promise<TradeSession | null> {
+    if (!this.redis) return null;
+    try {
+      const raw = await this.redis.get(sessionKey(tenantId, id));
+      return raw ? parseSession(raw) : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private async writeRedis(session: TradeSession): Promise<void> {
+    if (!this.redis) return;
+    const ttlSeconds = Math.max(1, Math.floor((session.expiresAt.getTime() - Date.now()) / 1000));
+    await this.redis
+      .setex(sessionKey(session.tenantId, session.id), ttlSeconds, serializeSession(session))
+      .catch(() => undefined);
+  }
+
+  private async readDb(tenantId: string, id: string): Promise<TradeSession | null> {
+    const [row] = await getDb()
+      .select()
+      .from(tradeSessions)
+      .where(and(eq(tradeSessions.id, id), eq(tradeSessions.tenantId, tenantId)));
+    if (!row) return null;
+    return tradeSessionSchema.parse(row);
+  }
+
+  private async markExpired(session: TradeSession): Promise<void> {
+    await getDb()
+      .update(tradeSessions)
+      .set({ status: "expired" })
+      .where(and(eq(tradeSessions.id, session.id), eq(tradeSessions.tenantId, session.tenantId)));
+    await this.redis?.del(sessionKey(session.tenantId, session.id)).catch(() => 0);
+  }
+}

--- a/packages/trade-sessions/tsconfig.json
+++ b/packages/trade-sessions/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/packages/vault/src/__tests__/venue-scoping.test.ts
+++ b/packages/vault/src/__tests__/venue-scoping.test.ts
@@ -1,0 +1,224 @@
+// Sprint 4 Phase 1 Day 1 tests: venue-scoped vault API.
+//
+// Uses PGLite (in-process Postgres via WASM) so the test runs against the
+// real Drizzle schema and the real 0022_vault_venue_scope migration, with
+// no third-party infra. Master password is fixed for determinism; the
+// underlying KeyStore still adds per-record IV + salt randomness.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { getDb, tenants } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { Vault } from "../vault";
+
+const MASTER_PASSWORD = "test-vault-venue-scope";
+const TENANT_ID = "test-tenant";
+
+async function freshVault(): Promise<Vault> {
+  const { db, client } = await createPGLiteDb("memory://");
+  setPGLiteOverride(db as never, async () => {
+    await client.close();
+  });
+
+  // Seed the tenant the vault will write under.
+  await getDb().insert(tenants).values({
+    id: TENANT_ID,
+    name: "Test Tenant",
+    apiKeyHash: "test-hash",
+  });
+
+  return new Vault({ masterPassword: MASTER_PASSWORD });
+}
+
+describe("Vault venue scoping (Sprint 4 Day 1)", () => {
+  let vault: Vault;
+
+  beforeEach(async () => {
+    vault = await freshVault();
+  });
+
+  afterEach(async () => {
+    // Detaching the override + letting GC drop the PGLite instance is
+    // enough for our in-memory case; there's no global handle to close.
+  });
+
+  test("createWallet provisions a venue-scoped EVM wallet and returns the address", async () => {
+    await vault.createAgent(TENANT_ID, "sol", "Sol");
+
+    const wallet = await vault.createWallet({
+      agentId: "sol",
+      venue: "hyperliquid",
+      chainType: "evm",
+      purpose: "perp",
+    });
+
+    expect(wallet.agentId).toBe("sol");
+    expect(wallet.chainFamily).toBe("evm");
+    expect(wallet.venue).toBe("hyperliquid");
+    expect(wallet.purpose).toBe("perp");
+    expect(wallet.address).toMatch(/^0x[0-9a-fA-F]{40}$/);
+  });
+
+  test("createWallet provisions a venue-scoped Solana wallet", async () => {
+    await vault.createAgent(TENANT_ID, "sol", "Sol");
+
+    const wallet = await vault.createWallet({
+      agentId: "sol",
+      venue: "drift",
+      chainType: "solana",
+    });
+
+    expect(wallet.chainFamily).toBe("solana");
+    expect(wallet.venue).toBe("drift");
+    expect(wallet.purpose).toBeNull();
+    // Solana addresses are base58, not 0x-prefixed.
+    expect(wallet.address.startsWith("0x")).toBe(false);
+    expect(wallet.address.length).toBeGreaterThan(30);
+  });
+
+  test("getWallet({ agentId, venue }) returns the venue-scoped row", async () => {
+    await vault.createAgent(TENANT_ID, "sol", "Sol");
+    const created = await vault.createWallet({
+      agentId: "sol",
+      venue: "hyperliquid",
+      chainType: "evm",
+    });
+
+    const fetched = await vault.getWallet({ agentId: "sol", venue: "hyperliquid" });
+
+    expect(fetched.address).toBe(created.address);
+    expect(fetched.venue).toBe("hyperliquid");
+    expect(fetched.chainFamily).toBe("evm");
+  });
+
+  test("getWallet({ agentId, chainId }) returns the legacy NULL-venue row (backward compat)", async () => {
+    // createAgent writes legacy NULL-venue rows for both chain families.
+    const identity = await vault.createAgent(TENANT_ID, "legacy-agent", "Legacy");
+
+    const fetched = await vault.getWallet({ agentId: "legacy-agent", chainId: 8453 });
+
+    expect(fetched.venue).toBeNull();
+    expect(fetched.chainFamily).toBe("evm");
+    expect(fetched.address).toBe(identity.walletAddresses?.evm ?? identity.walletAddress);
+  });
+
+  test("getWallet({ chainId }) of a Solana chainId resolves to the Solana legacy row", async () => {
+    const identity = await vault.createAgent(TENANT_ID, "legacy-agent", "Legacy");
+
+    const fetched = await vault.getWallet({ agentId: "legacy-agent", chainId: 101 });
+
+    expect(fetched.chainFamily).toBe("solana");
+    expect(fetched.venue).toBeNull();
+    expect(fetched.address).toBe(identity.walletAddresses?.solana ?? "");
+  });
+
+  test("getWallet({ venue }) does NOT silently fall back to the legacy row", async () => {
+    await vault.createAgent(TENANT_ID, "legacy-agent", "Legacy");
+
+    // No hyperliquid wallet has been provisioned, so this MUST throw,
+    // not return the legacy EVM row. Trade-sessions relies on this.
+    await expect(
+      vault.getWallet({ agentId: "legacy-agent", venue: "hyperliquid" }),
+    ).rejects.toThrow(/No wallet found for agent legacy-agent on venue hyperliquid/);
+  });
+
+  test("getWallet with neither venue nor chainId throws", async () => {
+    await vault.createAgent(TENANT_ID, "sol", "Sol");
+    await expect(vault.getWallet({ agentId: "sol" })).rejects.toThrow(
+      /getWallet requires either `venue` or `chainId`/,
+    );
+  });
+
+  test("createWallet enforces venue uniqueness per (agentId, chainFamily)", async () => {
+    await vault.createAgent(TENANT_ID, "sol", "Sol");
+    await vault.createWallet({ agentId: "sol", venue: "hyperliquid", chainType: "evm" });
+
+    // Second insert for the same (agentId, chainFamily, venue) tuple must
+    // be rejected by the unique index from migration 0022.
+    await expect(
+      vault.createWallet({ agentId: "sol", venue: "hyperliquid", chainType: "evm" }),
+    ).rejects.toThrow();
+  });
+
+  test("two distinct venues for the same agent + chainFamily coexist (the whole point)", async () => {
+    await vault.createAgent(TENANT_ID, "sol", "Sol");
+    const hl = await vault.createWallet({
+      agentId: "sol",
+      venue: "hyperliquid",
+      chainType: "evm",
+      purpose: "perp",
+    });
+    const pm = await vault.createWallet({
+      agentId: "sol",
+      venue: "polymarket",
+      chainType: "evm",
+      purpose: "predictions",
+    });
+
+    expect(hl.address).not.toBe(pm.address);
+
+    const hlFetch = await vault.getWallet({ agentId: "sol", venue: "hyperliquid" });
+    const pmFetch = await vault.getWallet({ agentId: "sol", venue: "polymarket" });
+    expect(hlFetch.address).toBe(hl.address);
+    expect(pmFetch.address).toBe(pm.address);
+  });
+
+  test("legacy + venue-scoped wallets coexist for the same agent + chainFamily", async () => {
+    const identity = await vault.createAgent(TENANT_ID, "sol", "Sol");
+    await vault.createWallet({ agentId: "sol", venue: "hyperliquid", chainType: "evm" });
+
+    const legacy = await vault.getWallet({ agentId: "sol", chainId: 8453 });
+    const hl = await vault.getWallet({ agentId: "sol", venue: "hyperliquid" });
+
+    expect(legacy.address).toBe(identity.walletAddresses?.evm ?? "");
+    expect(hl.address).not.toBe(legacy.address);
+  });
+
+  test("listWallets returns every wallet across venues and chain families", async () => {
+    await vault.createAgent(TENANT_ID, "sol", "Sol");
+    await vault.createWallet({ agentId: "sol", venue: "hyperliquid", chainType: "evm" });
+    await vault.createWallet({ agentId: "sol", venue: "polymarket", chainType: "evm" });
+    await vault.createWallet({ agentId: "sol", venue: "drift", chainType: "solana" });
+
+    const all = await vault.listWallets({ agentId: "sol" });
+
+    // 2 legacy (EVM + Solana from createAgent) + 3 venue-scoped = 5
+    expect(all.length).toBe(5);
+
+    const venues = all.map((w) => w.venue);
+    expect(venues).toContain(null);
+    expect(venues).toContain("hyperliquid");
+    expect(venues).toContain("polymarket");
+    expect(venues).toContain("drift");
+
+    // Legacy NULL rows come first (NULLS FIRST in the ORDER BY).
+    expect(all[0]!.venue).toBeNull();
+  });
+
+  test("createWallet rejects unknown chainType", async () => {
+    await vault.createAgent(TENANT_ID, "sol", "Sol");
+    await expect(
+      vault.createWallet({ agentId: "sol", venue: "x", chainType: "bitcoin" as any }),
+    ).rejects.toThrow(/unsupported chainType/);
+  });
+
+  test("createWallet rejects unknown agentId with a clear error (no FK leak)", async () => {
+    await expect(
+      vault.createWallet({ agentId: "ghost", venue: "hyperliquid", chainType: "evm" }),
+    ).rejects.toThrow(/Agent ghost not found/);
+  });
+
+  test("private key is never returned by createWallet", async () => {
+    await vault.createAgent(TENANT_ID, "sol", "Sol");
+    const wallet = await vault.createWallet({
+      agentId: "sol",
+      venue: "hyperliquid",
+      chainType: "evm",
+    });
+    // Type-level: the return type has no `privateKey` / `secretKey`. Runtime:
+    // verify the returned object has no key-shaped fields.
+    expect(Object.keys(wallet).sort()).toEqual(
+      ["address", "agentId", "chainFamily", "purpose", "venue"].sort(),
+    );
+  });
+});

--- a/packages/vault/src/index.ts
+++ b/packages/vault/src/index.ts
@@ -25,4 +25,4 @@ export {
   USER_WALLET_DEFAULT_POLICIES,
 } from "./user-wallet";
 export type { VaultConfig } from "./vault";
-export { Vault } from "./vault";
+export { Vault, Vault as VaultClient } from "./vault";

--- a/packages/vault/src/vault.ts
+++ b/packages/vault/src/vault.ts
@@ -18,7 +18,7 @@ import type {
   TxStatus,
 } from "@stwd/shared";
 import { toCaip2 } from "@stwd/shared";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq, inArray, isNull, sql } from "drizzle-orm";
 import {
   type Chain,
   createPublicClient,
@@ -96,7 +96,7 @@ export interface SignTransactionOptions {
 }
 
 /**
- * Vault — the core signing service.
+ * Vault - the core signing service.
  *
  * Manages agent wallets: generates keypairs, stores encrypted private keys,
  * and signs transactions. The private key is decrypted only for the duration
@@ -152,7 +152,7 @@ export class Vault {
 
     const createdAt = new Date();
 
-    // ── Persist all rows atomically — roll back everything on any failure ─
+    // ── Persist all rows atomically - roll back everything on any failure ─
     await db.transaction(async (tx) => {
       // ── Persist agent row (walletAddress = EVM for backward compat) ────
       await tx.insert(agents).values({
@@ -432,7 +432,7 @@ export class Vault {
           gas: request.gasLimit ? BigInt(request.gasLimit) : undefined,
         });
       } else {
-        // Sign without broadcasting — return the serialized signed transaction
+        // Sign without broadcasting - return the serialized signed transaction
         const rpcUrl = CHAIN_RPCS[chainId] ?? this.config.rpcUrl;
         const publicClient = createPublicClient({
           chain,
@@ -607,11 +607,11 @@ export class Vault {
 
     if (chainType === "solana") {
       // For Solana, the private key should be a 64-byte hex string (seed + pubkey)
-      // or a 32-byte hex seed — we'll handle both
+      // or a 32-byte hex seed - we'll handle both
       const kp = restoreSolanaKeypair(privateKey);
       walletAddress = kp.publicKey.toBase58();
     } else {
-      // EVM — expect 0x-prefixed hex private key
+      // EVM - expect 0x-prefixed hex private key
       const normalizedKey = privateKey.startsWith("0x") ? privateKey : `0x${privateKey}`;
       const account = privateKeyToAccount(normalizedKey as `0x${string}`);
       walletAddress = account.address;
@@ -626,7 +626,7 @@ export class Vault {
       .from(agents)
       .where(and(eq(agents.id, agentId), eq(agents.tenantId, tenantId)));
 
-    // Wrap all writes atomically — roll back on any failure
+    // Wrap all writes atomically - roll back on any failure
     await db.transaction(async (tx) => {
       if (existingAgent) {
         // Update wallet address and replace encrypted key
@@ -787,15 +787,17 @@ export class Vault {
 
     // Resolve signing key: prefer encryptedChainKeys (multi-wallet), fall back to legacy encryptedKeys
     let secretKey: string;
-    const [chainKey] = await db
-      .select()
-      .from(encryptedChainKeys)
-      .where(
-        and(
+    const chainKeyWhere = request.venue
+      ? and(
           eq(encryptedChainKeys.agentId, request.agentId),
           eq(encryptedChainKeys.chainFamily, "evm"),
-        ),
-      );
+          eq(encryptedChainKeys.venue, request.venue),
+        )
+      : and(
+          eq(encryptedChainKeys.agentId, request.agentId),
+          eq(encryptedChainKeys.chainFamily, "evm"),
+        );
+    const [chainKey] = await db.select().from(encryptedChainKeys).where(chainKeyWhere);
 
     if (chainKey) {
       secretKey = this.keyStore.decrypt({
@@ -804,6 +806,10 @@ export class Vault {
         tag: chainKey.tag,
         salt: chainKey.salt,
       });
+    } else if (request.venue) {
+      throw new Error(
+        `No signing key found for agent ${request.agentId} on venue ${request.venue}`,
+      );
     } else {
       // Fallback: legacy encrypted_keys table
       const [legacyKey] = await db
@@ -1053,7 +1059,7 @@ export class Vault {
       throw new Error(`No RPC URL configured for chainId ${chainId}`);
     }
 
-    // Block signing/state-modifying methods — this is read-only passthrough
+    // Block signing/state-modifying methods - this is read-only passthrough
     const blockedMethods = [
       "eth_sendTransaction",
       "eth_sendRawTransaction",
@@ -1065,7 +1071,7 @@ export class Vault {
     ];
     if (blockedMethods.includes(request.method)) {
       throw new Error(
-        `Method ${request.method} is not allowed via RPC passthrough — use the signing endpoints`,
+        `Method ${request.method} is not allowed via RPC passthrough - use the signing endpoints`,
       );
     }
 
@@ -1086,4 +1092,223 @@ export class Vault {
 
     return (await response.json()) as RpcResponse;
   }
+
+  // ──────────────────────────────────────────────────────────────────────
+  // Sprint 4 Phase 1 Day 1: venue-scoped wallet API
+  // ──────────────────────────────────────────────────────────────────────
+  //
+  // Wallets used to be keyed by (agentId, chainFamily). Trade-sessions now
+  // need to address them per (agentId, venue) because Sol's BSC wallet
+  // and Sol's Hyperliquid wallet sit on the same chainFamily (EVM) but
+  // must hold distinct keys. `venue` is optional: legacy callers still
+  // pass `chainId` (mapped to chainFamily), which resolves to the
+  // NULL-venue row written by `createAgent`.
+
+  /**
+   * Look up a wallet for an agent.
+   *
+   * Priority:
+   *   1. If `venue` is provided, return the row with that exact venue. If
+   *      no row matches, throw - we never silently downgrade to a legacy
+   *      wallet when a venue was explicitly requested.
+   *   2. If only `chainId` is provided, map to chainFamily and return the
+   *      legacy (venue IS NULL) row for that family. This preserves
+   *      backward compat for @stwd/agent-trader and direct SDK callers.
+   *
+   * Throws if neither is provided, or if no matching row exists.
+   */
+  async getWallet(args: { agentId: string; venue?: string; chainId?: number }): Promise<{
+    agentId: string;
+    chainFamily: "evm" | "solana";
+    venue: string | null;
+    purpose: string | null;
+    address: string;
+  }> {
+    const { agentId, venue, chainId } = args;
+    if (!venue && chainId === undefined) {
+      throw new Error("getWallet requires either `venue` or `chainId`");
+    }
+
+    const db = getDb();
+
+    if (venue) {
+      const [row] = await db
+        .select()
+        .from(agentWallets)
+        .where(and(eq(agentWallets.agentId, agentId), eq(agentWallets.venue, venue)));
+
+      if (!row) {
+        throw new Error(`No wallet found for agent ${agentId} on venue ${venue}`);
+      }
+      return {
+        agentId: row.agentId,
+        chainFamily: row.chainFamily as "evm" | "solana",
+        venue: row.venue,
+        purpose: row.purpose,
+        address: row.address,
+      };
+    }
+
+    // Legacy fallback: chainId → chainFamily, then look up the NULL-venue row.
+    const chainFamily = chainIdToChainFamily(chainId as number);
+    const [row] = await db
+      .select()
+      .from(agentWallets)
+      .where(
+        and(
+          eq(agentWallets.agentId, agentId),
+          eq(agentWallets.chainFamily, chainFamily),
+          isNull(agentWallets.venue),
+        ),
+      );
+
+    if (!row) {
+      throw new Error(`No legacy wallet found for agent ${agentId} on chain family ${chainFamily}`);
+    }
+    return {
+      agentId: row.agentId,
+      chainFamily: row.chainFamily as "evm" | "solana",
+      venue: row.venue,
+      purpose: row.purpose,
+      address: row.address,
+    };
+  }
+
+  /**
+   * Provision a fresh, venue-scoped wallet for an agent.
+   *
+   * Generates a new keypair (EVM via viem's `generatePrivateKey`, Solana
+   * via Ed25519 in @solana/web3.js), encrypts the secret under the
+   * vault's master KDF (AES-256-GCM + scrypt), and writes one row to
+   * `agent_wallets` plus one to `encrypted_chain_keys`.
+   *
+   * Venue uniqueness is enforced by the DB index on
+   * (agent_id, chain_family, COALESCE(venue, '')). A duplicate venue
+   * request rejects at the DB layer.
+   *
+   * Returns the new public address. The private key is NEVER returned
+   * and NEVER logged.
+   */
+  async createWallet(args: {
+    agentId: string;
+    venue: string;
+    chainType: "evm" | "solana";
+    purpose?: string;
+  }): Promise<{
+    agentId: string;
+    chainFamily: "evm" | "solana";
+    venue: string;
+    purpose: string | null;
+    address: string;
+  }> {
+    const { agentId, venue, chainType, purpose } = args;
+    if (!venue) throw new Error("createWallet requires a venue");
+    if (chainType !== "evm" && chainType !== "solana") {
+      throw new Error(`createWallet: unsupported chainType ${chainType}`);
+    }
+
+    const db = getDb();
+
+    // Verify the agent exists. Surfacing a clear error here beats a
+    // foreign-key violation from Postgres.
+    const [agentRow] = await db
+      .select({ id: agents.id })
+      .from(agents)
+      .where(eq(agents.id, agentId));
+    if (!agentRow) {
+      throw new Error(`Agent ${agentId} not found`);
+    }
+
+    let address: string;
+    let secret: string;
+    if (chainType === "evm") {
+      const pk = generatePrivateKey();
+      const account = privateKeyToAccount(pk);
+      address = account.address;
+      secret = pk;
+    } else {
+      const kp = generateSolanaKeypair();
+      address = kp.publicKey;
+      secret = kp.secretKey;
+    }
+
+    const encrypted = this.keyStore.encrypt(secret);
+    const createdAt = new Date();
+
+    await db.transaction(async (tx) => {
+      await tx.insert(encryptedChainKeys).values({
+        agentId,
+        chainFamily: chainType,
+        venue,
+        purpose: purpose ?? null,
+        ciphertext: encrypted.ciphertext,
+        iv: encrypted.iv,
+        tag: encrypted.tag,
+        salt: encrypted.salt,
+      });
+
+      await tx.insert(agentWallets).values({
+        agentId,
+        chainFamily: chainType,
+        venue,
+        purpose: purpose ?? null,
+        address,
+        createdAt,
+      });
+    });
+
+    return {
+      agentId,
+      chainFamily: chainType,
+      venue,
+      purpose: purpose ?? null,
+      address,
+    };
+  }
+
+  /**
+   * List every wallet an agent owns, across venues and chain families.
+   * Used by the agent dashboard and by Worker A's trade-sessions package
+   * to enumerate available trading surfaces.
+   *
+   * Legacy NULL-venue rows are included. Order: legacy first, then
+   * venue-scoped, by creation time ascending.
+   */
+  async listWallets(args: { agentId: string }): Promise<
+    Array<{
+      agentId: string;
+      chainFamily: "evm" | "solana";
+      venue: string | null;
+      purpose: string | null;
+      address: string;
+      createdAt: Date;
+    }>
+  > {
+    const { agentId } = args;
+    const db = getDb();
+
+    const rows = await db
+      .select()
+      .from(agentWallets)
+      .where(eq(agentWallets.agentId, agentId))
+      .orderBy(sql`${agentWallets.venue} NULLS FIRST`, agentWallets.createdAt);
+
+    return rows.map((row) => ({
+      agentId: row.agentId,
+      chainFamily: row.chainFamily as "evm" | "solana",
+      venue: row.venue,
+      purpose: row.purpose,
+      address: row.address,
+      createdAt: row.createdAt,
+    }));
+  }
+}
+
+/**
+ * Map an EVM chainId (or 101/102 for Solana) to its chain family.
+ * Exposed at module scope so non-method callers (tests) can use it.
+ */
+function chainIdToChainFamily(chainId: number): "evm" | "solana" {
+  if (chainId === 101 || chainId === 102) return "solana";
+  return "evm";
 }

--- a/packages/venue-hyperliquid/package.json
+++ b/packages/venue-hyperliquid/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@stwd/venue-hyperliquid",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "tsc --noEmit",
+    "dev": "tsc --watch",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@stwd/shared": "workspace:*",
+    "viem": "^2.30.0",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.0"
+  },
+  "description": "Hyperliquid venue adapter for Steward"
+}

--- a/packages/venue-hyperliquid/src/index.ts
+++ b/packages/venue-hyperliquid/src/index.ts
@@ -1,0 +1,246 @@
+import { type Hex, parseSignature } from "viem";
+import { z } from "zod";
+
+export const hyperliquidAssetSchema = z.enum(["BTC", "ETH"]);
+export type HyperliquidAsset = z.infer<typeof hyperliquidAssetSchema>;
+
+export const hyperliquidOrderSchema = z.object({
+  asset: hyperliquidAssetSchema,
+  side: z.enum(["buy", "sell"]),
+  size: z.number().positive(),
+  leverage: z.number().positive().max(2),
+  reduceOnly: z.boolean().default(false),
+  limitPrice: z.string().optional(),
+  nonce: z.number().int().positive().optional(),
+});
+export type HyperliquidOrder = z.infer<typeof hyperliquidOrderSchema>;
+
+export const signedOrderSchema = z.object({
+  action: z.record(z.string(), z.unknown()),
+  nonce: z.number().int().positive(),
+  signature: z.object({
+    r: z.string(),
+    s: z.string(),
+    v: z.number(),
+  }),
+});
+export type SignedOrder = z.infer<typeof signedOrderSchema>;
+
+export const orderResultSchema = z.object({
+  orderId: z.string().optional(),
+  status: z.string(),
+  filledQty: z.number().optional(),
+  avgPrice: z.number().optional(),
+  txHash: z.string().nullable().optional(),
+  raw: z.unknown().optional(),
+});
+export type OrderResult = z.infer<typeof orderResultSchema>;
+
+export const positionSchema = z.object({
+  asset: z.string(),
+  side: z.enum(["long", "short", "flat"]).default("flat"),
+  size: z.number(),
+  entryPrice: z.number().optional(),
+  unrealizedPnlUsd: z.number().optional(),
+  leverage: z.number().optional(),
+});
+export type Position = z.infer<typeof positionSchema>;
+
+export interface VaultSignTypedDataInput {
+  agentId: string;
+  domain: {
+    name?: string;
+    version?: string;
+    chainId?: number;
+    verifyingContract?: string;
+    salt?: string;
+  };
+  types: Record<string, Array<{ name: string; type: string }>>;
+  primaryType: string;
+  value: Record<string, unknown>;
+}
+
+export interface VaultClient {
+  signTypedData(input: VaultSignTypedDataInput): Promise<string>;
+  getWallet?(input: { agentId: string; venue: "hyperliquid" }): Promise<{ address: string } | null>;
+}
+
+export interface HyperliquidTransport {
+  fetch(input: string | URL | Request, init?: RequestInit): Promise<Response>;
+}
+
+export interface HyperliquidAdapterOptions {
+  transport?: HyperliquidTransport;
+  baseUrl?: string;
+}
+
+const ASSET_INDEX: Record<HyperliquidAsset, number> = {
+  BTC: 0,
+  ETH: 1,
+};
+
+const DEFAULT_BASE_URL = "https://api.hyperliquid.xyz";
+
+function toExchangeAction(order: HyperliquidOrder): Record<string, unknown> {
+  const parsed = hyperliquidOrderSchema.parse(order);
+  return {
+    type: "order",
+    orders: [
+      {
+        a: ASSET_INDEX[parsed.asset],
+        b: parsed.side === "buy",
+        p: parsed.limitPrice ?? "0",
+        s: String(parsed.size),
+        r: parsed.reduceOnly,
+        t: {
+          limit: {
+            tif: "Ioc",
+          },
+        },
+      },
+    ],
+    grouping: "na",
+  };
+}
+
+function createTypedData(
+  order: HyperliquidOrder,
+  action: Record<string, unknown>,
+  walletAddress: string,
+  nonce: number,
+): VaultSignTypedDataInput {
+  return {
+    agentId: "",
+    domain: {
+      name: "Exchange",
+      version: "1",
+      chainId: 1337,
+      verifyingContract: "0x0000000000000000000000000000000000000000",
+    },
+    types: {
+      HyperliquidOrder: [
+        { name: "wallet", type: "address" },
+        { name: "asset", type: "string" },
+        { name: "side", type: "string" },
+        { name: "size", type: "string" },
+        { name: "leverage", type: "uint256" },
+        { name: "reduceOnly", type: "bool" },
+        { name: "nonce", type: "uint64" },
+        { name: "action", type: "string" },
+      ],
+    },
+    primaryType: "HyperliquidOrder",
+    value: {
+      wallet: walletAddress,
+      asset: order.asset,
+      side: order.side,
+      size: String(order.size),
+      leverage: order.leverage,
+      reduceOnly: order.reduceOnly ?? false,
+      nonce,
+      action: JSON.stringify(action),
+    },
+  };
+}
+
+export class HyperliquidAdapter {
+  private readonly transport: HyperliquidTransport;
+  private readonly baseUrl: string;
+
+  constructor(
+    private readonly vault: VaultClient,
+    private readonly agentId: string,
+    private readonly walletAddress: string,
+    options: HyperliquidAdapterOptions = {},
+  ) {
+    this.transport = options.transport ?? { fetch };
+    this.baseUrl = options.baseUrl ?? DEFAULT_BASE_URL;
+  }
+
+  async signOrder(order: HyperliquidOrder): Promise<SignedOrder> {
+    const parsed = hyperliquidOrderSchema.parse(order);
+    const nonce = parsed.nonce ?? Date.now();
+    const action = toExchangeAction(parsed);
+    const typedData = createTypedData(parsed, action, this.walletAddress, nonce);
+    const signatureHex = await this.vault.signTypedData({
+      ...typedData,
+      agentId: this.agentId,
+    });
+    const signature = parseSignature(signatureHex as Hex);
+    if (signature.v === undefined) {
+      throw new Error("Vault returned an EIP-712 signature without a recovery id");
+    }
+
+    return signedOrderSchema.parse({
+      action,
+      nonce,
+      signature: {
+        r: signature.r,
+        s: signature.s,
+        v: Number(signature.v),
+      },
+    });
+  }
+
+  async submitOrder(signed: SignedOrder): Promise<OrderResult> {
+    const body = signedOrderSchema.parse(signed);
+    const response = await this.transport.fetch(`${this.baseUrl}/exchange`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    const json = (await response.json().catch(() => null)) as unknown;
+    if (!response.ok) {
+      throw new Error(`Hyperliquid exchange returned ${response.status}`);
+    }
+    return normalizeOrderResult(json);
+  }
+
+  async getPositions(): Promise<Position[]> {
+    const response = await this.transport.fetch(`${this.baseUrl}/info`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ type: "clearinghouseState", user: this.walletAddress }),
+    });
+    const json = (await response.json().catch(() => null)) as unknown;
+    if (!response.ok) {
+      throw new Error(`Hyperliquid info returned ${response.status}`);
+    }
+    return normalizePositions(json);
+  }
+}
+
+function normalizeOrderResult(raw: unknown): OrderResult {
+  const payload = raw as Record<string, unknown>;
+  const statuses = Array.isArray((payload.response as Record<string, unknown> | undefined)?.data)
+    ? ((payload.response as Record<string, unknown>).data as unknown[])
+    : [];
+  const first = statuses[0] as Record<string, unknown> | undefined;
+  return orderResultSchema.parse({
+    orderId: String(first?.oid ?? first?.orderId ?? crypto.randomUUID()),
+    status: String(payload.status ?? "submitted"),
+    filledQty: typeof first?.totalSz === "number" ? first.totalSz : undefined,
+    avgPrice: typeof first?.avgPx === "number" ? first.avgPx : undefined,
+    txHash: null,
+    raw,
+  });
+}
+
+function normalizePositions(raw: unknown): Position[] {
+  const payload = raw as { assetPositions?: Array<{ position?: Record<string, unknown> }> };
+  return (payload.assetPositions ?? []).map((entry) => {
+    const position = entry.position ?? {};
+    const size = Number(position.szi ?? 0);
+    return positionSchema.parse({
+      asset: String(position.coin ?? ""),
+      side: size > 0 ? "long" : size < 0 ? "short" : "flat",
+      size: Math.abs(size),
+      entryPrice: position.entryPx ? Number(position.entryPx) : undefined,
+      unrealizedPnlUsd: position.unrealizedPnl ? Number(position.unrealizedPnl) : undefined,
+      leverage:
+        typeof position.leverage === "object" && position.leverage
+          ? Number((position.leverage as Record<string, unknown>).value ?? 0)
+          : undefined,
+    });
+  });
+}

--- a/packages/venue-hyperliquid/tsconfig.json
+++ b/packages/venue-hyperliquid/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Technical summary
- Adds @stwd/trade-sessions with TradeSession types, Redis TTL cache when available, and DB persistence.
- Adds @stwd/venue-hyperliquid with zod schemas, viem typed-data signing via vault, order submit, and positions fetch.
- Adds trade routes under /v1/trade and /trade for session create, session revoke, and Hyperliquid order submission.
- Adds venue-scoped vault wallet support and policy evaluators for venue allowlist and leverage cap so Worker B integration is concrete.
- Bumps @stwd/sdk to 0.10.0 and exposes tradeSessions.create, tradeSessions.revoke, and trade.hyperliquid.submitOrder.
- Adds Eliza submitTradeAction stub that calls the SDK when Steward is configured.

## Endpoints
- POST /v1/trade/sessions
- POST /v1/trade/sessions/{id}/revoke
- POST /v1/trade/hyperliquid/order

## Migration plan
1. Apply packages/db/drizzle/0022_vault_venue_scope.sql to add venue-scoped vault wallet columns and policy enum values.
2. Apply packages/db/drizzle/0023_trade_sessions.sql to create trade_sessions.
3. Provision a Hyperliquid venue wallet for Sol before calling trade session creation.
4. Deploy API and run a read-only Hyperliquid info check before live orders.

## Curl examples
```sh
curl -X POST "$STEWARD_API/v1/trade/sessions" \
  -H "Authorization: Bearer $AGENT_JWT" \
  -H "Content-Type: application/json" \
  -d '{"venue":"hyperliquid","scopes":["read","write"],"ttlSeconds":900}'\n```\n\n```sh\ncurl -X POST "$STEWARD_API/v1/trade/hyperliquid/order" \\\n  -H "Authorization: Bearer $SESSION_JWT" \\\n  -H "Idempotency-Key: $UUID" \\\n  -H "Content-Type: application/json" \\\n  -d '{"sessionId":"ses_x","asset":"BTC","side":"buy","size":25,"leverage":2,"reduceOnly":false}'\n```\n\n```sh\ncurl -X POST "$STEWARD_API/v1/trade/sessions/ses_x/revoke" \\\n  -H "Authorization: Bearer $SESSION_JWT"\n```\n\n## Validation\n- bun run --cwd packages/shared build: pass\n- bun run --cwd packages/vault build: pass\n- bun run --cwd packages/db build: pass\n- bun run --cwd packages/policy-engine build: pass\n- bun run --cwd packages/trade-sessions build: pass\n- bun run --cwd packages/venue-hyperliquid build: pass\n- bun run --cwd packages/api build: pass\n- bun run --cwd packages/sdk build: pass\n- bunx tsc --noEmit --project packages/eliza-plugin/tsconfig.json: pass\n- bun run lint: pass\n- bun test packages/policy-engine/src/__tests__/venue-leverage.test.ts: 17 pass\n- bun test packages/sdk/src/__tests__/client.test.ts: 43 pass\n- bun test packages/vault/src/__tests__/venue-scoping.test.ts: 14 pass, process exited 99 after pass due PGLite lifecycle\n- bun run --cwd packages/vault test: 83 pass, process exited 99 after pass due PGLite lifecycle\n- git diff --check: pass\n- rg "—" on changed files: no matches\n\n## Known Worker B integration TODOs and blockers\n- Dev Neon migration was not applied locally because live DATABASE_URL secrets are unavailable in this worker.\n- Real curl testing was not run because a live Steward JWT, venue wallet, Hyperliquid funded account, and dev API URL were not available.\n- Hyperliquid L1 order signing is scaffolded through vault EIP-712 and viem, but official L1 signing also requires exact action hashing/msgpack field ordering. Before sending real funds, verify against Hyperliquid official signing examples or replace with the official SDK action hash builder.\n- Redis-backed idempotency for order submission is still a follow-up. Current implementation stores successful idempotent responses in process memory.\n- Eliza plugin tsup JS bundle succeeds and tsc passes, but tsup dts worker exits without a diagnostic in this checkout.\n