### PR TITLE
ci: pass --isolate to bun test and reintroduce proxy lifecycle test (closes #59)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,12 +63,17 @@ jobs:
           bunx turbo run build --filter="${PKG_NAME}..."
 
       - name: Test ${{ matrix.package }}
+        # --isolate gives each test file a fresh global object so module
+        # replacements installed via `mock.module()` in one file don't
+        # leak into the next. Without this, e.g. zz-proxy-spend-limit's
+        # `mock.module("@stwd/db")` stub poisoned every subsequent file
+        # that imported the real `@stwd/db` schema. See issue #59.
         run: |
           if [ "${{ matrix.package }}" = "packages/sdk" ]; then
             mapfile -t sdk_tests < <(find packages/sdk/src -type f \( -name '*.test.ts' -o -name '*.spec.ts' \) | sort)
-            bun test "${sdk_tests[@]}"
+            bun test --isolate "${sdk_tests[@]}"
           else
-            bun test ${{ matrix.package }}
+            bun test --isolate ${{ matrix.package }}
           fi
         env:
           STEWARD_MASTER_PASSWORD: "ci-test-secret"
@@ -100,7 +105,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Test packages/redis
-        run: bun test packages/redis
+        run: bun test --isolate packages/redis
         env:
           STEWARD_MASTER_PASSWORD: "ci-test-secret"
 
@@ -174,7 +179,7 @@ jobs:
           exit 1
 
       - name: Integration tests (API)
-        run: bun test packages/api
+        run: bun test --isolate packages/api
         env:
           DATABASE_URL: "postgres://steward:steward_ci@localhost:5432/steward_test"
           PORT: "3299"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -99,12 +99,17 @@ jobs:
           bunx turbo run build --filter="${PKG_NAME}..."
 
       - name: Test ${{ matrix.package }}
+        # --isolate gives each test file a fresh global object so module
+        # replacements installed via `mock.module()` in one file don't
+        # leak into the next. Without this, e.g. zz-proxy-spend-limit's
+        # `mock.module("@stwd/db")` stub poisoned every subsequent file
+        # that imported the real `@stwd/db` schema. See issue #59.
         run: |
           if [ "${{ matrix.package }}" = "packages/sdk" ]; then
             mapfile -t sdk_tests < <(find packages/sdk/src -type f \( -name '*.test.ts' -o -name '*.spec.ts' \) | sort)
-            bun test "${sdk_tests[@]}"
+            bun test --isolate "${sdk_tests[@]}"
           else
-            bun test ${{ matrix.package }}
+            bun test --isolate ${{ matrix.package }}
           fi
         env:
           STEWARD_MASTER_PASSWORD: "ci-test-secret"
@@ -136,7 +141,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Test packages/redis
-        run: bun test packages/redis
+        run: bun test --isolate packages/redis
         env:
           STEWARD_MASTER_PASSWORD: "ci-test-secret"
 
@@ -210,7 +215,7 @@ jobs:
           exit 1
 
       - name: Integration tests (API)
-        run: bun test packages/api
+        run: bun test --isolate packages/api
         env:
           DATABASE_URL: "postgres://steward:steward_ci@localhost:5432/steward_test"
           PORT: "3299"

--- a/packages/proxy/src/__tests__/secret-lifecycle.test.ts
+++ b/packages/proxy/src/__tests__/secret-lifecycle.test.ts
@@ -1,0 +1,108 @@
+import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
+import { signAgentToken } from "@stwd/auth";
+import { closeDb, eq, getDb, secrets, tenants } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { SecretVault } from "@stwd/vault";
+import { Hono } from "hono";
+import { PROXY_SCOPE } from "../config";
+
+setDefaultTimeout(30000);
+
+const MASTER_PASSWORD = "proxy-secret-lifecycle-master";
+let authMiddleware: typeof import("../middleware/auth")["authMiddleware"];
+let handleProxy: typeof import("../handlers/proxy")["handleProxy"];
+
+beforeAll(async () => {
+  process.env.STEWARD_PGLITE_MEMORY = "true";
+  process.env.STEWARD_MASTER_PASSWORD = MASTER_PASSWORD;
+  process.env.STEWARD_JWT_SECRET = "proxy-secret-lifecycle-jwt-secret-with-enough-bytes";
+
+  const { db, client } = await createPGLiteDb("memory://");
+  setPGLiteOverride(db, async () => {
+    await client.close();
+  });
+
+  ({ authMiddleware } = await import("../middleware/auth"));
+  ({ handleProxy } = await import("../handlers/proxy"));
+});
+
+afterAll(async () => {
+  await closeDb().catch(() => {});
+  delete process.env.STEWARD_PGLITE_MEMORY;
+  delete process.env.STEWARD_MASTER_PASSWORD;
+  delete process.env.STEWARD_JWT_SECRET;
+});
+
+function buildApp() {
+  const app = new Hono();
+  app.use("*", authMiddleware);
+  app.all("*", handleProxy);
+  return app;
+}
+
+async function ensureTenant(tenantId: string) {
+  await getDb()
+    .insert(tenants)
+    .values({ id: tenantId, name: tenantId, apiKeyHash: "hash" })
+    .onConflictDoNothing();
+}
+
+describe("proxy secret lifecycle enforcement", () => {
+  it("stops matching a route once its secret has expired", async () => {
+    const tenantId = `tenant-expired-route-${crypto.randomUUID()}`;
+    const agentId = `agent-${crypto.randomUUID()}`;
+    await ensureTenant(tenantId);
+
+    const vault = new SecretVault(MASTER_PASSWORD);
+    const secret = await vault.createSecret(tenantId, "openai", "sk-live");
+    await vault.createRoute(tenantId, secret.id, {
+      hostPattern: "api.example.com",
+      pathPattern: "/*",
+      injectAs: "header",
+      injectKey: "authorization",
+      injectFormat: "Bearer {value}",
+    });
+
+    await getDb()
+      .update(secrets)
+      .set({ expiresAt: new Date(Date.now() - 60_000) })
+      .where(eq(secrets.id, secret.id));
+
+    const token = await signAgentToken({ agentId, tenantId, scopes: ["agent", PROXY_SCOPE] }, "1h");
+    const res = await buildApp().request("/proxy/api.example.com/v1/test", {
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain("No credential route configured");
+  });
+
+  it("stops matching routes after the secret is deleted", async () => {
+    const tenantId = `tenant-deleted-route-${crypto.randomUUID()}`;
+    const agentId = `agent-${crypto.randomUUID()}`;
+    await ensureTenant(tenantId);
+
+    const vault = new SecretVault(MASTER_PASSWORD);
+    const secret = await vault.createSecret(tenantId, "anthropic", "sk-live");
+    await vault.createRoute(tenantId, secret.id, {
+      hostPattern: "api.deleted.example.com",
+      pathPattern: "/*",
+      injectAs: "header",
+      injectKey: "x-api-key",
+    });
+
+    expect(await vault.deleteSecret(tenantId, secret.id)).toBe(true);
+
+    const token = await signAgentToken({ agentId, tenantId, scopes: ["agent", PROXY_SCOPE] }, "1h");
+    const res = await buildApp().request("/proxy/api.deleted.example.com/v1/test", {
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain("No credential route configured");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #59 by:
1. Passing `--isolate` to every `bun test` invocation in `pr.yml` and `ci.yml`
2. Reintroducing `packages/proxy/src/__tests__/secret-lifecycle.test.ts` (dropped from #54 due to mock pollution)

## Type

- [x] `fix` (CI hardening)
- [x] `test` (lifecycle test restoration)

## Scope

`ci`, `proxy`

## Breaking Changes

None.

## Why

`bun test` runs every matching test file in a single process, sharing the module cache. `mock.module("@stwd/db", () => ({ ... }))` in `zz-proxy-spend-limit.test.ts` installs a stub that replaces `secretRoutes` with a bare `{ tenantId, enabled, priority }` object — no column metadata. That stub stays installed for every subsequent file in the run, and `mock.restore()` in bun 1.3 does NOT undo `mock.module()`.

When #54 added a proxy-level lifecycle test alongside the spend-limit test, the lifecycle test's `beforeAll` called `createPGLiteDb()`, which made drizzle walk the schema and build the relations graph. The mocked `secretRoutes.secretId` had no `.notNull` property, and `extractTablesRelationalConfig` crashed:

```
TypeError: undefined is not an object (evaluating 'f.notNull')
  at one (drizzle-orm/relations.js:196)
  at extractTablesRelationalConfig (drizzle-orm/relations.js:154)
  at createPGLiteDb (packages/db/src/pglite.ts:137)
```

The failure was order-dependent (bun's filesystem enumeration differed between CI and local), which is why it slipped past pre-merge review in #54.

`--isolate` tells bun to give each test file a fresh global object, which clears `mock.module()` replacements between files. That's the right primitive for this class of bug.

## What ships

### CI workflows

Both `.github/workflows/pr.yml` and `.github/workflows/ci.yml` now pass `--isolate`:

```diff
- bun test "${sdk_tests[@]}"
+ bun test --isolate "${sdk_tests[@]}"
- bun test ${{ matrix.package }}
+ bun test --isolate ${{ matrix.package }}
- bun test packages/redis
+ bun test --isolate packages/redis
- bun test packages/api
+ bun test --isolate packages/api
```

Slight startup cost per file, but worth it for the cross-file safety. Verified locally: `bun test --isolate packages/proxy` runs all 52 tests cleanly (50 original + 2 newly restored).

### Reintroduced test

`packages/proxy/src/__tests__/secret-lifecycle.test.ts`, lifted from #54 commit `af05d8f` with one small cleanup: imports `eq` from `@stwd/db` (which re-exports it from drizzle-orm) instead of directly from `drizzle-orm`. Two cases exercise the proxy-side join enforcement that pairs with the vault-level lifecycle test landed in #54:

- `stops matching a route once its secret has expired`
- `stops matching routes after the secret is deleted`

## Validation

- `bun test --isolate packages/proxy` (local): 52 pass, 0 fail
- `bunx tsc --noEmit -p packages/api`: clean
- `bunx @biomejs/biome check`: clean

Closes #59.