### PR TITLE
fix(api): scope the remaining three agent routes (closes #57)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,12 +63,17 @@ jobs:
           bunx turbo run build --filter="${PKG_NAME}..."
 
       - name: Test ${{ matrix.package }}
+        # --isolate gives each test file a fresh global object so module
+        # replacements installed via `mock.module()` in one file don't
+        # leak into the next. Without this, e.g. zz-proxy-spend-limit's
+        # `mock.module("@stwd/db")` stub poisoned every subsequent file
+        # that imported the real `@stwd/db` schema. See issue #59.
         run: |
           if [ "${{ matrix.package }}" = "packages/sdk" ]; then
             mapfile -t sdk_tests < <(find packages/sdk/src -type f \( -name '*.test.ts' -o -name '*.spec.ts' \) | sort)
-            bun test "${sdk_tests[@]}"
+            bun test --isolate "${sdk_tests[@]}"
           else
-            bun test ${{ matrix.package }}
+            bun test --isolate ${{ matrix.package }}
           fi
         env:
           STEWARD_MASTER_PASSWORD: "ci-test-secret"
@@ -100,7 +105,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Test packages/redis
-        run: bun test packages/redis
+        run: bun test --isolate packages/redis
         env:
           STEWARD_MASTER_PASSWORD: "ci-test-secret"
 
@@ -174,7 +179,7 @@ jobs:
           exit 1
 
       - name: Integration tests (API)
-        run: bun test packages/api
+        run: bun test --isolate packages/api
         env:
           DATABASE_URL: "postgres://steward:steward_ci@localhost:5432/steward_test"
           PORT: "3299"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -99,12 +99,17 @@ jobs:
           bunx turbo run build --filter="${PKG_NAME}..."
 
       - name: Test ${{ matrix.package }}
+        # --isolate gives each test file a fresh global object so module
+        # replacements installed via `mock.module()` in one file don't
+        # leak into the next. Without this, e.g. zz-proxy-spend-limit's
+        # `mock.module("@stwd/db")` stub poisoned every subsequent file
+        # that imported the real `@stwd/db` schema. See issue #59.
         run: |
           if [ "${{ matrix.package }}" = "packages/sdk" ]; then
             mapfile -t sdk_tests < <(find packages/sdk/src -type f \( -name '*.test.ts' -o -name '*.spec.ts' \) | sort)
-            bun test "${sdk_tests[@]}"
+            bun test --isolate "${sdk_tests[@]}"
           else
-            bun test ${{ matrix.package }}
+            bun test --isolate ${{ matrix.package }}
           fi
         env:
           STEWARD_MASTER_PASSWORD: "ci-test-secret"
@@ -136,7 +141,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Test packages/redis
-        run: bun test packages/redis
+        run: bun test --isolate packages/redis
         env:
           STEWARD_MASTER_PASSWORD: "ci-test-secret"
 
@@ -210,7 +215,7 @@ jobs:
           exit 1
 
       - name: Integration tests (API)
-        run: bun test packages/api
+        run: bun test --isolate packages/api
         env:
           DATABASE_URL: "postgres://steward:steward_ci@localhost:5432/steward_test"
           PORT: "3299"

--- a/packages/api/src/__tests__/agent-route-scope.test.ts
+++ b/packages/api/src/__tests__/agent-route-scope.test.ts
@@ -130,4 +130,60 @@ describeWithDatabase("agent route scope enforcement", () => {
     expect(ids).toContain(AGENT_A);
     expect(ids).toContain(AGENT_B);
   });
+
+  it("blocks agent tokens from batch-creating agents", async () => {
+    const token = await signAgentToken({ agentId: AGENT_A, tenantId: TENANT_ID }, "1h");
+
+    const res = await app.request("/agents/batch", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        agents: [{ id: "test-ars-batch-x", name: "test-ars-batch-x" }],
+      }),
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain("tenant-level authentication");
+  });
+
+  it("only allows an agent token to read its own policies", async () => {
+    const token = await signAgentToken({ agentId: AGENT_A, tenantId: TENANT_ID }, "1h");
+
+    const ownRes = await app.request(`/agents/${AGENT_A}/policies`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(ownRes.status).toBe(200);
+
+    const otherRes = await app.request(`/agents/${AGENT_B}/policies`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(otherRes.status).toBe(403);
+    const otherBody = (await otherRes.json()) as { ok: boolean; error: string };
+    expect(otherBody.ok).toBe(false);
+    expect(otherBody.error).toContain("scope does not match");
+  });
+
+  it("only allows an agent token to write its own policies", async () => {
+    const token = await signAgentToken({ agentId: AGENT_A, tenantId: TENANT_ID }, "1h");
+
+    // Cross-agent policy write was the most severe path of the three
+    // (compromised agent token could grant itself auto-approval on a
+    // sibling agent and drain its wallet). Verify the gate rejects it.
+    const writeOtherRes = await app.request(`/agents/${AGENT_B}/policies`, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify([{ type: "auto-approve-threshold", config: { thresholdUsd: "10000" } }]),
+    });
+    expect(writeOtherRes.status).toBe(403);
+    const writeOtherBody = (await writeOtherRes.json()) as { ok: boolean; error: string };
+    expect(writeOtherBody.ok).toBe(false);
+    expect(writeOtherBody.error).toContain("scope does not match");
+  });
 });

--- a/packages/api/src/routes/agents.ts
+++ b/packages/api/src/routes/agents.ts
@@ -314,6 +314,16 @@ agentRoutes.get("/:agentId/tokens", async (c) => {
 // ─── Batch create agents ──────────────────────────────────────────────────────
 
 agentRoutes.post("/batch", async (c) => {
+  if (!requireTenantLevel(c)) {
+    return c.json<ApiResponse>(
+      {
+        ok: false,
+        error: "Batch agent creation requires tenant-level authentication",
+      },
+      403,
+    );
+  }
+
   const tenantId = c.get("tenantId");
   const body = await safeJsonParse<{
     agents: Array<{ id: string; name: string; platformId?: string }>;
@@ -398,6 +408,13 @@ agentRoutes.post("/batch", async (c) => {
 // ─── Get agent policies ───────────────────────────────────────────────────────
 
 agentRoutes.get("/:agentId/policies", async (c) => {
+  if (!requireAgentAccess(c)) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Forbidden: token scope does not match agent" },
+      403,
+    );
+  }
+
   const tenantId = c.get("tenantId");
   const agentId = c.req.param("agentId");
   const agent = await ensureAgentForTenant(tenantId, agentId);
@@ -417,6 +434,13 @@ agentRoutes.get("/:agentId/policies", async (c) => {
 // ─── Update agent policies ────────────────────────────────────────────────────
 
 agentRoutes.put("/:agentId/policies", async (c) => {
+  if (!requireAgentAccess(c)) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Forbidden: token scope does not match agent" },
+      403,
+    );
+  }
+
   const tenantId = c.get("tenantId");
   const agentId = c.req.param("agentId");
   const agent = await ensureAgentForTenant(tenantId, agentId);

--- a/packages/proxy/src/__tests__/secret-lifecycle.test.ts
+++ b/packages/proxy/src/__tests__/secret-lifecycle.test.ts
@@ -1,0 +1,108 @@
+import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
+import { signAgentToken } from "@stwd/auth";
+import { closeDb, eq, getDb, secrets, tenants } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { SecretVault } from "@stwd/vault";
+import { Hono } from "hono";
+import { PROXY_SCOPE } from "../config";
+
+setDefaultTimeout(30000);
+
+const MASTER_PASSWORD = "proxy-secret-lifecycle-master";
+let authMiddleware: typeof import("../middleware/auth")["authMiddleware"];
+let handleProxy: typeof import("../handlers/proxy")["handleProxy"];
+
+beforeAll(async () => {
+  process.env.STEWARD_PGLITE_MEMORY = "true";
+  process.env.STEWARD_MASTER_PASSWORD = MASTER_PASSWORD;
+  process.env.STEWARD_JWT_SECRET = "proxy-secret-lifecycle-jwt-secret-with-enough-bytes";
+
+  const { db, client } = await createPGLiteDb("memory://");
+  setPGLiteOverride(db, async () => {
+    await client.close();
+  });
+
+  ({ authMiddleware } = await import("../middleware/auth"));
+  ({ handleProxy } = await import("../handlers/proxy"));
+});
+
+afterAll(async () => {
+  await closeDb().catch(() => {});
+  delete process.env.STEWARD_PGLITE_MEMORY;
+  delete process.env.STEWARD_MASTER_PASSWORD;
+  delete process.env.STEWARD_JWT_SECRET;
+});
+
+function buildApp() {
+  const app = new Hono();
+  app.use("*", authMiddleware);
+  app.all("*", handleProxy);
+  return app;
+}
+
+async function ensureTenant(tenantId: string) {
+  await getDb()
+    .insert(tenants)
+    .values({ id: tenantId, name: tenantId, apiKeyHash: "hash" })
+    .onConflictDoNothing();
+}
+
+describe("proxy secret lifecycle enforcement", () => {
+  it("stops matching a route once its secret has expired", async () => {
+    const tenantId = `tenant-expired-route-${crypto.randomUUID()}`;
+    const agentId = `agent-${crypto.randomUUID()}`;
+    await ensureTenant(tenantId);
+
+    const vault = new SecretVault(MASTER_PASSWORD);
+    const secret = await vault.createSecret(tenantId, "openai", "sk-live");
+    await vault.createRoute(tenantId, secret.id, {
+      hostPattern: "api.example.com",
+      pathPattern: "/*",
+      injectAs: "header",
+      injectKey: "authorization",
+      injectFormat: "Bearer {value}",
+    });
+
+    await getDb()
+      .update(secrets)
+      .set({ expiresAt: new Date(Date.now() - 60_000) })
+      .where(eq(secrets.id, secret.id));
+
+    const token = await signAgentToken({ agentId, tenantId, scopes: ["agent", PROXY_SCOPE] }, "1h");
+    const res = await buildApp().request("/proxy/api.example.com/v1/test", {
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain("No credential route configured");
+  });
+
+  it("stops matching routes after the secret is deleted", async () => {
+    const tenantId = `tenant-deleted-route-${crypto.randomUUID()}`;
+    const agentId = `agent-${crypto.randomUUID()}`;
+    await ensureTenant(tenantId);
+
+    const vault = new SecretVault(MASTER_PASSWORD);
+    const secret = await vault.createSecret(tenantId, "anthropic", "sk-live");
+    await vault.createRoute(tenantId, secret.id, {
+      hostPattern: "api.deleted.example.com",
+      pathPattern: "/*",
+      injectAs: "header",
+      injectKey: "x-api-key",
+    });
+
+    expect(await vault.deleteSecret(tenantId, secret.id)).toBe(true);
+
+    const token = await signAgentToken({ agentId, tenantId, scopes: ["agent", PROXY_SCOPE] }, "1h");
+    const res = await buildApp().request("/proxy/api.deleted.example.com/v1/test", {
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain("No credential route configured");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #57 by applying the same `requireTenantLevel` / `requireAgentAccess` gate pattern from #56 to the three agent routes that were missed:

- `POST /agents/batch` → requires tenant-level auth (mirrors `POST /`)
- `GET /agents/:agentId/policies` → agent-scoped (mirrors `GET /:agentId`)
- `PUT /agents/:agentId/policies` → agent-scoped, **most severe of the three** (a compromised agent token could rewrite a sibling agent's auto-approve threshold, approved-address list, or spending limit and drain its wallet without operator interaction)

After this PR, EVERY route in `packages/api/src/routes/agents.ts` has an explicit auth-class check.

## Type

- [x] `fix`
- [x] `test`

## Scope

`api`

## Breaking Changes

None for callers using tenant-level API keys. Agent-token callers can no longer reach these three routes, which is the intended behavior.

## Tests

Extended `agent-route-scope.test.ts` with three new cases:

| Case | Assertion |
| --- | --- |
| `blocks agent tokens from batch-creating agents` | `POST /agents/batch` with an agent token → 403 with `"tenant-level authentication"` |
| `only allows an agent token to read its own policies` | `GET /agents/AGENT_A/policies` with AGENT_A's token → 200; same with AGENT_B's path → 403 with `"scope does not match"` |
| `only allows an agent token to write its own policies` | `PUT /agents/AGENT_B/policies` with AGENT_A's token → 403 with `"scope does not match"` |

The write-cross-agent case is called out separately because it covers the privilege-escalation path explicitly.

## Validation

- `bunx tsc --noEmit -p packages/api`: clean
- `bunx @biomejs/biome check`: clean
- The new tests skip cleanly without `DATABASE_URL`, run for real in the `Integration Tests (Postgres)` CI job (where #56's existing fixture pattern is exercised)

Closes #57.