### PR TITLE
feat(trade-sessions+hyperliquid): @stwd/trade-sessions package + HL adapter (sprint 4 phase 1 days 1-2, rebased on #60)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,16 +40,18 @@ COPY package.json bun.lock turbo.json tsconfig.json ./
 RUN mkdir -p web && echo '{"name":"web","version":"0.0.0","private":true}' > web/package.json
 
 # Package manifests for every workspace package
-COPY packages/api/package.json       packages/api/package.json
-COPY packages/auth/package.json      packages/auth/package.json
-COPY packages/db/package.json        packages/db/package.json
-COPY packages/policy-engine/package.json packages/policy-engine/package.json
-COPY packages/proxy/package.json     packages/proxy/package.json
-COPY packages/redis/package.json     packages/redis/package.json
-COPY packages/shared/package.json    packages/shared/package.json
-COPY packages/sdk/package.json       packages/sdk/package.json
-COPY packages/vault/package.json     packages/vault/package.json
-COPY packages/webhooks/package.json  packages/webhooks/package.json
+COPY packages/api/package.json               packages/api/package.json
+COPY packages/auth/package.json              packages/auth/package.json
+COPY packages/db/package.json                packages/db/package.json
+COPY packages/policy-engine/package.json     packages/policy-engine/package.json
+COPY packages/proxy/package.json             packages/proxy/package.json
+COPY packages/redis/package.json             packages/redis/package.json
+COPY packages/shared/package.json            packages/shared/package.json
+COPY packages/sdk/package.json               packages/sdk/package.json
+COPY packages/trade-sessions/package.json    packages/trade-sessions/package.json
+COPY packages/vault/package.json             packages/vault/package.json
+COPY packages/venue-hyperliquid/package.json packages/venue-hyperliquid/package.json
+COPY packages/webhooks/package.json          packages/webhooks/package.json
 
 RUN BUN_FROZEN_LOCKFILE=0 bun install
 
@@ -59,16 +61,18 @@ FROM base AS build
 COPY package.json bun.lock turbo.json tsconfig.json ./
 
 # Copy package.json files for workspace resolution
-COPY packages/api/package.json       packages/api/package.json
-COPY packages/auth/package.json      packages/auth/package.json
-COPY packages/db/package.json        packages/db/package.json
-COPY packages/policy-engine/package.json packages/policy-engine/package.json
-COPY packages/proxy/package.json     packages/proxy/package.json
-COPY packages/redis/package.json     packages/redis/package.json
-COPY packages/shared/package.json    packages/shared/package.json
-COPY packages/sdk/package.json       packages/sdk/package.json
-COPY packages/vault/package.json     packages/vault/package.json
-COPY packages/webhooks/package.json  packages/webhooks/package.json
+COPY packages/api/package.json               packages/api/package.json
+COPY packages/auth/package.json              packages/auth/package.json
+COPY packages/db/package.json                packages/db/package.json
+COPY packages/policy-engine/package.json     packages/policy-engine/package.json
+COPY packages/proxy/package.json             packages/proxy/package.json
+COPY packages/redis/package.json             packages/redis/package.json
+COPY packages/shared/package.json            packages/shared/package.json
+COPY packages/sdk/package.json               packages/sdk/package.json
+COPY packages/trade-sessions/package.json    packages/trade-sessions/package.json
+COPY packages/vault/package.json             packages/vault/package.json
+COPY packages/venue-hyperliquid/package.json packages/venue-hyperliquid/package.json
+COPY packages/webhooks/package.json          packages/webhooks/package.json
 
 # Create stub for excluded workspaces
 RUN mkdir -p web && echo '{"name":"web","version":"0.0.0","private":true}' > web/package.json
@@ -85,7 +89,9 @@ COPY packages/proxy       packages/proxy
 COPY packages/redis       packages/redis
 COPY packages/shared      packages/shared
 COPY packages/sdk         packages/sdk
+COPY packages/trade-sessions    packages/trade-sessions
 COPY packages/vault       packages/vault
+COPY packages/venue-hyperliquid packages/venue-hyperliquid
 COPY packages/webhooks    packages/webhooks
 
 # Create workspace symlinks (Bun 1.3 doesn't auto-link in Docker)
@@ -98,7 +104,9 @@ RUN mkdir -p node_modules/@stwd && \
     ln -sf ../../../packages/redis         node_modules/@stwd/redis && \
     ln -sf ../../../packages/proxy         node_modules/@stwd/proxy && \
     ln -sf ../../../packages/webhooks      node_modules/@stwd/webhooks && \
-    ln -sf ../../../packages/policy-engine node_modules/@stwd/policy-engine
+    ln -sf ../../../packages/policy-engine     node_modules/@stwd/policy-engine && \
+    ln -sf ../../../packages/trade-sessions    node_modules/@stwd/trade-sessions && \
+    ln -sf ../../../packages/venue-hyperliquid node_modules/@stwd/venue-hyperliquid
 
 # Build api and proxy (and their deps) via turborepo
 RUN bunx turbo run build --filter=@stwd/api --filter=@stwd/proxy
@@ -117,16 +125,18 @@ COPY package.json bun.lock turbo.json tsconfig.json ./
 # Create stub for excluded workspaces
 RUN mkdir -p web && echo '{"name":"web","version":"0.0.0","private":true}' > web/package.json
 
-COPY packages/api/package.json       packages/api/package.json
-COPY packages/auth/package.json      packages/auth/package.json
-COPY packages/db/package.json        packages/db/package.json
-COPY packages/policy-engine/package.json packages/policy-engine/package.json
-COPY packages/proxy/package.json     packages/proxy/package.json
-COPY packages/redis/package.json     packages/redis/package.json
-COPY packages/shared/package.json    packages/shared/package.json
-COPY packages/sdk/package.json       packages/sdk/package.json
-COPY packages/vault/package.json     packages/vault/package.json
-COPY packages/webhooks/package.json  packages/webhooks/package.json
+COPY packages/api/package.json               packages/api/package.json
+COPY packages/auth/package.json              packages/auth/package.json
+COPY packages/db/package.json                packages/db/package.json
+COPY packages/policy-engine/package.json     packages/policy-engine/package.json
+COPY packages/proxy/package.json             packages/proxy/package.json
+COPY packages/redis/package.json             packages/redis/package.json
+COPY packages/shared/package.json            packages/shared/package.json
+COPY packages/sdk/package.json               packages/sdk/package.json
+COPY packages/trade-sessions/package.json    packages/trade-sessions/package.json
+COPY packages/vault/package.json             packages/vault/package.json
+COPY packages/venue-hyperliquid/package.json packages/venue-hyperliquid/package.json
+COPY packages/webhooks/package.json          packages/webhooks/package.json
 
 COPY --from=deps /app/bun.lock ./bun.lock
 RUN bun install --production
@@ -140,7 +150,9 @@ COPY --from=build /app/packages/proxy       packages/proxy
 COPY --from=build /app/packages/redis       packages/redis
 COPY --from=build /app/packages/shared      packages/shared
 COPY --from=build /app/packages/sdk         packages/sdk
+COPY --from=build /app/packages/trade-sessions    packages/trade-sessions
 COPY --from=build /app/packages/vault       packages/vault
+COPY --from=build /app/packages/venue-hyperliquid packages/venue-hyperliquid
 COPY --from=build /app/packages/webhooks    packages/webhooks
 
 # Create workspace symlinks manually — bun 1.3 doesn't auto-link workspace packages
@@ -155,6 +167,8 @@ RUN mkdir -p node_modules/@stwd && \
     ln -sf ../../../packages/proxy         node_modules/@stwd/proxy && \
     ln -sf ../../../packages/webhooks      node_modules/@stwd/webhooks && \
     ln -sf ../../../packages/policy-engine node_modules/@stwd/policy-engine && \
+    ln -sf ../../../packages/trade-sessions    node_modules/@stwd/trade-sessions && \
+    ln -sf ../../../packages/venue-hyperliquid node_modules/@stwd/venue-hyperliquid && \
     ln -sf ../../../packages/eliza-plugin  node_modules/@stwd/eliza-plugin 2>/dev/null; true
 
 # ── Non-root user ─────────────────────────────────────────────────────────────

--- a/bun.lock
+++ b/bun.lock
@@ -36,12 +36,15 @@
         "@stwd/policy-engine": "workspace:*",
         "@stwd/redis": "workspace:*",
         "@stwd/shared": "workspace:*",
+        "@stwd/trade-sessions": "workspace:*",
         "@stwd/vault": "workspace:*",
+        "@stwd/venue-hyperliquid": "workspace:*",
         "@stwd/webhooks": "workspace:*",
         "bs58": "^6.0.0",
         "drizzle-orm": "^0.44.5",
         "hono": "^4.7.0",
         "viem": "^2.30.0",
+        "zod": "^4.3.6",
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20241218.0",
@@ -215,7 +218,7 @@
     },
     "packages/sdk": {
       "name": "@stwd/sdk",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "dependencies": {
         "bs58": "^6.0.0",
       },
@@ -240,6 +243,20 @@
         "@types/bun": "latest",
       },
     },
+    "packages/trade-sessions": {
+      "name": "@stwd/trade-sessions",
+      "version": "0.1.0",
+      "dependencies": {
+        "@stwd/db": "workspace:*",
+        "@stwd/redis": "workspace:*",
+        "@stwd/shared": "workspace:*",
+        "drizzle-orm": "^0.44.5",
+        "zod": "^4.3.6",
+      },
+      "devDependencies": {
+        "@types/node": "^25.5.0",
+      },
+    },
     "packages/vault": {
       "name": "@stwd/vault",
       "version": "0.3.0",
@@ -249,6 +266,18 @@
         "@stwd/shared": "workspace:*",
         "drizzle-orm": "^0.44.5",
         "viem": "^2.30.0",
+      },
+      "devDependencies": {
+        "@types/node": "^25.5.0",
+      },
+    },
+    "packages/venue-hyperliquid": {
+      "name": "@stwd/venue-hyperliquid",
+      "version": "0.1.0",
+      "dependencies": {
+        "@stwd/shared": "workspace:*",
+        "viem": "^2.30.0",
+        "zod": "^4.3.6",
       },
       "devDependencies": {
         "@types/node": "^25.5.0",
@@ -1073,7 +1102,11 @@
 
     "@stwd/shared": ["@stwd/shared@workspace:packages/shared"],
 
+    "@stwd/trade-sessions": ["@stwd/trade-sessions@workspace:packages/trade-sessions"],
+
     "@stwd/vault": ["@stwd/vault@workspace:packages/vault"],
+
+    "@stwd/venue-hyperliquid": ["@stwd/venue-hyperliquid@workspace:packages/venue-hyperliquid"],
 
     "@stwd/web": ["@stwd/web@workspace:web"],
 
@@ -2919,9 +2952,15 @@
 
     "@stwd/react/bs58": ["bs58@5.0.0", "", { "dependencies": { "base-x": "^4.0.0" } }, "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ=="],
 
+    "@stwd/redis/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "@stwd/shared/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
+    "@stwd/trade-sessions/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
     "@stwd/vault/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@stwd/venue-hyperliquid/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "@stwd/web/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
@@ -3533,9 +3572,15 @@
 
     "@stwd/react/bs58/base-x": ["base-x@4.0.1", "", {}, "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw=="],
 
+    "@stwd/redis/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
     "@stwd/shared/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
+    "@stwd/trade-sessions/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
     "@stwd/vault/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "@stwd/venue-hyperliquid/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "@stwd/web/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
@@ -4097,6 +4142,8 @@
 
     "@solana/instruction-plans/@solana/transactions/@solana/addresses/@solana/assertions": ["@solana/assertions@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-YTCSWAlGwSlVPnWtWLm3ukz81wH4j2YaCveK+TjpvUU88hTy6fmUqxi0+hvAMAe4zKXpJyj3Az7BrLJRxbIm4Q=="],
 
+    "@stwd/redis/@types/bun/bun-types/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
     "@stwd/shared/@types/bun/bun-types/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "@trezor/blockchain-link-utils/@trezor/protobuf/protobufjs/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
@@ -4282,6 +4329,8 @@
     "@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils/viem/ox": ["ox@0.6.7", "", { "dependencies": { "@adraffy/ens-normalize": "^1.10.1", "@noble/curves": "^1.6.0", "@noble/hashes": "^1.5.0", "@scure/bip32": "^1.5.0", "@scure/bip39": "^1.4.0", "abitype": "^1.0.6", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-17Gk/eFsFRAZ80p5eKqv89a57uXjd3NgIf1CaXojATPBuujVc/fQSVhBeAU9JCRB+k7J50WQAyWTxK19T9GgbA=="],
 
     "@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils/viem/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
+
+    "@stwd/redis/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "@stwd/shared/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -19,17 +19,20 @@
     "@stwd/redis": "workspace:*",
     "@stwd/policy-engine": "workspace:*",
     "@stwd/shared": "workspace:*",
+    "@stwd/trade-sessions": "workspace:*",
+    "@stwd/venue-hyperliquid": "workspace:*",
     "@stwd/vault": "workspace:*",
     "@stwd/webhooks": "workspace:*",
     "bs58": "^6.0.0",
     "drizzle-orm": "^0.44.5",
     "hono": "^4.7.0",
-    "viem": "^2.30.0"
+    "viem": "^2.30.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20241218.0",
     "@types/node": "^25.5.0",
     "wrangler": "^4.0.0"
   },
-  "description": "Hono REST API for Steward — agents, policies, approvals, and transaction signing"
+  "description": "Hono REST API for Steward - agents, policies, approvals, and transaction signing"
 }

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -1,17 +1,17 @@
 /**
- * app.ts — Runtime-agnostic Hono app construction.
+ * app.ts - Runtime-agnostic Hono app construction.
  *
  * This module exports the fully-configured `Hono` instance with all routes,
  * middleware, and per-route auth wired up. It deliberately contains NO server
  * boot code (no `Bun.serve`, no `setInterval` GC, no signal handlers, no
  * blocking `runMigrations()` call) so that it can be reused by:
  *
- *   - `index.ts`   — Bun entry point (long-lived process; runs migrations,
+ *   - `index.ts`   - Bun entry point (long-lived process; runs migrations,
  *                    sets up GC timers, wires SIGINT/SIGTERM, calls
  *                    `Bun.serve`).
- *   - `worker.ts`  — Cloudflare Workers entry point (per-request fetch,
+ *   - `worker.ts`  - Cloudflare Workers entry point (per-request fetch,
  *                    no setInterval/Bun, migrations run out-of-band).
- *   - `embedded.ts`— Electrobun/desktop entry point.
+ *   - `embedded.ts`- Electrobun/desktop entry point.
  *
  * Anything that must NOT run on Workers (timers, blocking I/O at module init,
  * Node-only APIs) belongs in `index.ts`, not here.
@@ -33,6 +33,7 @@ import { policiesStandaloneRoutes } from "./routes/policies-standalone";
 import { secretsRoutes } from "./routes/secrets";
 import { tenantConfigRoutes } from "./routes/tenant-config";
 import { tenantRoutes } from "./routes/tenants";
+import { tradeRoutes } from "./routes/trade";
 import { userRoutes } from "./routes/user";
 import { vaultRoutes } from "./routes/vault";
 import { webhookRoutes } from "./routes/webhooks";
@@ -116,6 +117,10 @@ app.use("/audit", (c, next) => tenantAuth(c, next));
 app.use("/audit/*", (c, next) => tenantAuth(c, next));
 app.use("/policies", (c, next) => tenantAuth(c, next));
 app.use("/policies/*", (c, next) => tenantAuth(c, next));
+app.use("/trade", (c, next) => tenantAuth(c, next));
+app.use("/trade/*", (c, next) => tenantAuth(c, next));
+app.use("/v1/trade", (c, next) => tenantAuth(c, next));
+app.use("/v1/trade/*", (c, next) => tenantAuth(c, next));
 
 // ─── Health & root ────────────────────────────────────────────────────────────
 
@@ -145,6 +150,8 @@ app.route("/webhooks", webhookRoutes);
 app.route("/approvals", approvalRoutes);
 app.route("/audit", auditRoutes);
 app.route("/policies", policiesStandaloneRoutes);
+app.route("/trade", tradeRoutes);
+app.route("/v1/trade", tradeRoutes);
 app.route("/agents", erc8004Routes);
 app.route("/discovery", discoveryRoutes);
 

--- a/packages/api/src/routes/trade.ts
+++ b/packages/api/src/routes/trade.ts
@@ -1,0 +1,350 @@
+import { signAgentToken } from "@stwd/auth";
+import { proxyAuditLog } from "@stwd/db";
+import { checkRateLimit } from "@stwd/redis";
+import { TradeSessionManager, tradeSessionScopeSchema } from "@stwd/trade-sessions";
+import {
+  HyperliquidAdapter,
+  type HyperliquidOrder,
+  hyperliquidAssetSchema,
+} from "@stwd/venue-hyperliquid";
+import { sql } from "drizzle-orm";
+import type { Context } from "hono";
+import { Hono } from "hono";
+import { z } from "zod";
+import { getRedisClient } from "../middleware/redis";
+import {
+  type ApiResponse,
+  type AppVariables,
+  db,
+  ensureAgentForTenant,
+  safeJsonParse,
+  vault,
+} from "../services/context";
+
+export const tradeRoutes = new Hono<{ Variables: AppVariables }>();
+
+const createSessionSchema = z.object({
+  venue: z.literal("hyperliquid"),
+  scopes: z.array(tradeSessionScopeSchema).min(1),
+  ttlSeconds: z.number().int().positive().max(3600).default(900),
+});
+
+const submitOrderSchema = z.object({
+  sessionId: z.string().min(1),
+  asset: hyperliquidAssetSchema,
+  side: z.enum(["buy", "sell"]),
+  size: z.number().positive(),
+  leverage: z.number().positive().max(2),
+  reduceOnly: z.boolean().default(false),
+  idempotencyKey: z.string().min(1).max(256).optional(),
+});
+
+type SubmitOrderBody = z.infer<typeof submitOrderSchema>;
+
+const memoryRateLimit = new Map<string, { count: number; resetAt: number }>();
+const memoryIdempotency = new Map<
+  string,
+  { bodyHash: string; response: unknown; expiresAt: number }
+>();
+
+function getSessionManager(): TradeSessionManager {
+  return new TradeSessionManager({ redis: getRedisClient() });
+}
+
+function callerAgentId(c: Context<{ Variables: AppVariables }>): string | null {
+  return c.get("agentScope") ?? null;
+}
+
+function responseData<T>(data: T): ApiResponse<T> {
+  return { ok: true, data };
+}
+
+async function auditTradeEvent(
+  tenantId: string,
+  agentId: string,
+  event: "trade.session.created" | "trade.session.revoked" | "trade.order.submitted",
+  details: Record<string, unknown>,
+): Promise<void> {
+  await db
+    .insert(proxyAuditLog)
+    .values({
+      tenantId,
+      agentId,
+      targetHost: event,
+      targetPath: JSON.stringify(details),
+      method: "AUDIT",
+      statusCode: 200,
+      latencyMs: 0,
+      reason: event,
+    })
+    .catch(() => undefined);
+}
+
+function hashBody(body: unknown): string {
+  return JSON.stringify(body);
+}
+
+async function enforceOrderRateLimit(
+  agentId: string,
+): Promise<{ allowed: boolean; resetMs: number }> {
+  const redis = getRedisClient();
+  if (redis) {
+    const result = await checkRateLimit(`ratelimit:trade:hyperliquid:${agentId}:1000`, 1000, 10);
+    return { allowed: result.allowed, resetMs: result.resetMs };
+  }
+
+  const now = Date.now();
+  const current = memoryRateLimit.get(agentId);
+  if (!current || current.resetAt <= now) {
+    memoryRateLimit.set(agentId, { count: 1, resetAt: now + 1000 });
+    return { allowed: true, resetMs: 1000 };
+  }
+  if (current.count >= 10) return { allowed: false, resetMs: current.resetAt - now };
+  current.count += 1;
+  return { allowed: true, resetMs: current.resetAt - now };
+}
+
+async function checkDailyCap(agentId: string, sizeUsd: number): Promise<boolean> {
+  const since = new Date();
+  since.setUTCHours(0, 0, 0, 0);
+  const [row] = await db
+    .select({
+      total: sql<string>`coalesce(sum((${proxyAuditLog.targetPath}::jsonb ->> 'sizeUsd')::numeric), 0)::text`,
+    })
+    .from(proxyAuditLog)
+    .where(
+      sql`${proxyAuditLog.agentId} = ${agentId} and ${proxyAuditLog.reason} = 'trade.order.submitted' and ${proxyAuditLog.createdAt} >= ${since}`,
+    );
+  const spent = Number(row?.total ?? 0);
+  return spent + sizeUsd <= 100;
+}
+
+function getIdempotency(
+  tenantId: string,
+  agentId: string,
+  key: string | undefined,
+  body: SubmitOrderBody,
+): { conflict?: boolean; response?: unknown; store?: (response: unknown) => void } {
+  if (!key) return {};
+  const now = Date.now();
+  const mapKey = `${tenantId}:${agentId}:${key}`;
+  const bodyHash = hashBody({ ...body, idempotencyKey: undefined });
+  const existing = memoryIdempotency.get(mapKey);
+  if (existing && existing.expiresAt > now) {
+    if (existing.bodyHash !== bodyHash) return { conflict: true };
+    return { response: existing.response };
+  }
+  return {
+    store(response: unknown) {
+      memoryIdempotency.set(mapKey, {
+        bodyHash,
+        response,
+        expiresAt: now + 24 * 60 * 60 * 1000,
+      });
+    },
+  };
+}
+
+async function resolveHyperliquidWallet(
+  agentId: string,
+  agent: { walletAddress: string; walletAddresses?: { evm?: string } },
+): Promise<string | null> {
+  if ("getWallet" in vault && typeof vault.getWallet === "function") {
+    try {
+      const wallet = await vault.getWallet({ agentId, venue: "hyperliquid" });
+      return wallet.address;
+    } catch {
+      return null;
+    }
+  }
+  return (
+    agent.walletAddresses?.evm ??
+    (agent.walletAddress.startsWith("0x") ? agent.walletAddress : null)
+  );
+}
+
+tradeRoutes.post("/sessions", async (c) => {
+  const tenantId = c.get("tenantId");
+  const agentId = callerAgentId(c);
+  if (!agentId) {
+    return c.json<ApiResponse>({ ok: false, error: "Agent JWT required for trade sessions" }, 403);
+  }
+  const raw = await safeJsonParse(c);
+  const parsed = createSessionSchema.safeParse(raw);
+  if (!parsed.success) {
+    return c.json<ApiResponse>({ ok: false, error: parsed.error.message }, 400);
+  }
+
+  const agent = await ensureAgentForTenant(tenantId, agentId);
+  if (!agent) return c.json<ApiResponse>({ ok: false, error: "Agent not found" }, 404);
+  const walletAddress = await resolveHyperliquidWallet(agentId, agent);
+  if (!walletAddress) {
+    return c.json<ApiResponse>(
+      {
+        ok: false,
+        error: "Hyperliquid venue wallet not found. Create a venue-scoped wallet before trading.",
+      },
+      404,
+    );
+  }
+
+  const session = await getSessionManager().create({
+    agentId,
+    tenantId,
+    venue: parsed.data.venue,
+    scopes: parsed.data.scopes,
+    ttlSeconds: parsed.data.ttlSeconds,
+  });
+  const jwt = await signAgentToken(
+    {
+      agentId,
+      tenantId,
+      scopes: ["agent", "trade:read", "trade:hyperliquid:write"],
+      ses: session.id,
+    },
+    `${parsed.data.ttlSeconds}s`,
+  );
+  await auditTradeEvent(tenantId, agentId, "trade.session.created", {
+    sessionId: session.id,
+    venue: session.venue,
+    scopes: session.scopes,
+  });
+
+  return c.json(
+    responseData({
+      sessionId: session.id,
+      jwt,
+      expiresAt: session.expiresAt.toISOString(),
+    }),
+    201,
+  );
+});
+
+tradeRoutes.post("/sessions/:id/revoke", async (c) => {
+  const tenantId = c.get("tenantId");
+  const agentId = callerAgentId(c);
+  if (!agentId) return c.body(null, 204);
+  const existing = await getSessionManager().getActive(tenantId, c.req.param("id"));
+  if (existing && existing.agentId !== agentId) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Forbidden: session belongs to another agent" },
+      403,
+    );
+  }
+  const revoked = await getSessionManager().revoke({
+    id: c.req.param("id"),
+    tenantId,
+    revokedBy: agentId,
+  });
+  if (revoked) {
+    await auditTradeEvent(tenantId, revoked.agentId, "trade.session.revoked", {
+      sessionId: revoked.id,
+      revokedBy: agentId,
+    });
+  }
+  return c.body(null, 204);
+});
+
+tradeRoutes.post("/hyperliquid/order", async (c) => {
+  const tenantId = c.get("tenantId");
+  const agentId = callerAgentId(c);
+  if (!agentId) {
+    return c.json<ApiResponse>({ ok: false, error: "Agent JWT required for trading" }, 403);
+  }
+
+  const rate = await enforceOrderRateLimit(agentId);
+  if (!rate.allowed) {
+    c.header("Retry-After", String(Math.ceil(rate.resetMs / 1000)));
+    return c.json<ApiResponse>({ ok: false, error: "Trade order rate limit exceeded" }, 429);
+  }
+
+  const raw = await safeJsonParse(c);
+  const parsed = submitOrderSchema.safeParse(raw);
+  if (!parsed.success) {
+    return c.json<ApiResponse>({ ok: false, error: parsed.error.message }, 400);
+  }
+  const body = {
+    ...parsed.data,
+    idempotencyKey: c.req.header("Idempotency-Key") ?? parsed.data.idempotencyKey,
+  };
+
+  const idempotency = getIdempotency(tenantId, agentId, body.idempotencyKey, body);
+  if (idempotency.conflict) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Idempotency key reused with a different body" },
+      409,
+    );
+  }
+  if (idempotency.response) {
+    return c.json(responseData(idempotency.response));
+  }
+
+  const session = await getSessionManager().getActive(tenantId, body.sessionId);
+  if (!session || session.agentId !== agentId || session.venue !== "hyperliquid") {
+    return c.json<ApiResponse>({ ok: false, error: "Active Hyperliquid session required" }, 403);
+  }
+  if (!session.scopes.includes("write")) {
+    return c.json<ApiResponse>({ ok: false, error: "Trade session missing write scope" }, 403);
+  }
+
+  if (body.leverage > 2 || !["BTC", "ETH"].includes(body.asset)) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Policy rejected: BTC/ETH only and leverage <= 2" },
+      412,
+    );
+  }
+  const sizeUsd = body.size;
+  if (!(await checkDailyCap(agentId, sizeUsd))) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Policy rejected: daily cap $100 exceeded" },
+      412,
+    );
+  }
+
+  const agent = await ensureAgentForTenant(tenantId, agentId);
+  if (!agent) return c.json<ApiResponse>({ ok: false, error: "Agent not found" }, 404);
+  const walletAddress = await resolveHyperliquidWallet(agentId, agent);
+  if (!walletAddress) {
+    return c.json<ApiResponse>(
+      {
+        ok: false,
+        error: "Hyperliquid venue wallet not found. Create a venue-scoped wallet before trading.",
+      },
+      404,
+    );
+  }
+
+  const vaultClient = {
+    signTypedData: (input: Omit<Parameters<typeof vault.signTypedData>[0], "tenantId">) =>
+      vault.signTypedData({ ...input, tenantId, venue: "hyperliquid" }),
+  };
+  const adapter = new HyperliquidAdapter(vaultClient, agentId, walletAddress);
+  const order: HyperliquidOrder = {
+    asset: body.asset,
+    side: body.side,
+    size: body.size,
+    leverage: body.leverage,
+    reduceOnly: body.reduceOnly,
+  };
+  const signed = await adapter.signOrder(order);
+  const result = await adapter.submitOrder(signed);
+  const response = {
+    orderId: result.orderId ?? crypto.randomUUID(),
+    status: result.status,
+    filledQty: result.filledQty ?? 0,
+    avgPrice: result.avgPrice ?? 0,
+    txHash: result.txHash ?? null,
+  };
+
+  await auditTradeEvent(tenantId, agentId, "trade.order.submitted", {
+    sessionId: session.id,
+    venue: "hyperliquid",
+    asset: body.asset,
+    leverage: body.leverage,
+    size: body.size,
+    sizeUsd,
+    orderId: response.orderId,
+  });
+  idempotency.store?.(response);
+  return c.json(responseData(response));
+});

--- a/packages/db/drizzle/0023_trade_sessions.sql
+++ b/packages/db/drizzle/0023_trade_sessions.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS "trade_sessions" (
+  "id" varchar(128) PRIMARY KEY NOT NULL,
+  "agent_id" varchar(64) NOT NULL,
+  "tenant_id" varchar(64) NOT NULL,
+  "venue" varchar(64) NOT NULL,
+  "scopes" jsonb DEFAULT '[]'::jsonb NOT NULL,
+  "status" varchar(32) NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "expires_at" timestamp with time zone NOT NULL,
+  "revoked_at" timestamp with time zone,
+  "revoked_by" varchar(255)
+);
+--> statement-breakpoint
+ALTER TABLE "trade_sessions" ADD CONSTRAINT "trade_sessions_agent_id_agents_id_fk" FOREIGN KEY ("agent_id") REFERENCES "public"."agents"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "trade_sessions" ADD CONSTRAINT "trade_sessions_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "trade_sessions_agent_venue_status_idx" ON "trade_sessions" USING btree ("agent_id","venue","status");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "trade_sessions_tenant_idx" ON "trade_sessions" USING btree ("tenant_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "trade_sessions_expires_at_idx" ON "trade_sessions" USING btree ("expires_at");

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1779671100000,
       "tag": "0022_vault_venue_scope",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1779671700000,
+      "tag": "0023_trade_sessions",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -26,7 +26,7 @@ import {
 
 export interface TenantEmailConfig {
   /**
-   * Per-tenant Resend provider config. Optional — a tenant can also leave
+   * Per-tenant Resend provider config. Optional - a tenant can also leave
    * this entirely empty and only set `magicLinkBaseUrl` to override the
    * magic-link target while continuing to use the global RESEND_API_KEY.
    */
@@ -241,10 +241,6 @@ export const encryptedChainKeys = pgTable(
       table.chainFamily,
       sql`COALESCE(${table.venue}, '')`,
     ),
-    /** Sprint 4: partial unique index for legacy upsert targets. */
-    agentChainLegacyIdx: uniqueIndex("encrypted_chain_keys_agent_chain_legacy_idx")
-      .on(table.agentId, table.chainFamily)
-      .where(sql`${table.venue} IS NULL`),
     agentIdIdx: index("encrypted_chain_keys_agent_id_idx").on(table.agentId),
   }),
 );
@@ -733,3 +729,35 @@ export const proxyAuditLog = pgTable(
 
 export type ProxyAuditLogEntry = typeof proxyAuditLog.$inferSelect;
 export type NewProxyAuditLogEntry = typeof proxyAuditLog.$inferInsert;
+
+export const tradeSessions = pgTable(
+  "trade_sessions",
+  {
+    id: varchar("id", { length: 128 }).primaryKey(),
+    agentId: varchar("agent_id", { length: 64 })
+      .notNull()
+      .references(() => agents.id, { onDelete: "cascade" }),
+    tenantId: varchar("tenant_id", { length: 64 })
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    venue: varchar("venue", { length: 64 }).notNull(),
+    scopes: jsonb("scopes").$type<string[]>().notNull().default([]),
+    status: varchar("status", { length: 32 }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+    revokedAt: timestamp("revoked_at", { withTimezone: true }),
+    revokedBy: varchar("revoked_by", { length: 255 }),
+  },
+  (table) => ({
+    agentVenueStatusIdx: index("trade_sessions_agent_venue_status_idx").on(
+      table.agentId,
+      table.venue,
+      table.status,
+    ),
+    tenantIdx: index("trade_sessions_tenant_idx").on(table.tenantId),
+    expiresAtIdx: index("trade_sessions_expires_at_idx").on(table.expiresAt),
+  }),
+);
+
+export type TradeSessionRow = typeof tradeSessions.$inferSelect;
+export type NewTradeSessionRow = typeof tradeSessions.$inferInsert;

--- a/packages/eliza-plugin/package.json
+++ b/packages/eliza-plugin/package.json
@@ -16,7 +16,7 @@
     }
   },
   "dependencies": {
-    "@stwd/sdk": "^0.9.0"
+    "@stwd/sdk": "^0.10.0"
   },
   "peerDependencies": {
     "@elizaos/core": ">=2.0.0-alpha.50"

--- a/packages/eliza-plugin/src/actions/submit-trade.ts
+++ b/packages/eliza-plugin/src/actions/submit-trade.ts
@@ -1,0 +1,118 @@
+import type {
+  Action,
+  ActionExample,
+  ActionResult,
+  HandlerOptions,
+  IAgentRuntime,
+  Memory,
+  State,
+} from "@elizaos/core";
+import type { StewardService } from "../services/StewardService.js";
+
+export const submitTradeAction: Action = {
+  name: "STEWARD_SUBMIT_TRADE",
+  description: "Submit a Hyperliquid BTC or ETH perp order through Steward trade sessions",
+  similes: ["submit trade", "place perp order", "trade hyperliquid"],
+  parameters: [
+    {
+      name: "sessionId",
+      description: "Active Steward trade session id",
+      required: true,
+      schema: { type: "string" },
+    },
+    {
+      name: "asset",
+      description: "BTC or ETH",
+      required: true,
+      schema: { type: "string", enum: ["BTC", "ETH"] },
+    },
+    {
+      name: "side",
+      description: "buy or sell",
+      required: true,
+      schema: { type: "string", enum: ["buy", "sell"] },
+    },
+    {
+      name: "size",
+      description: "Order size in USD for MVP policy accounting",
+      required: true,
+      schema: { type: "number" },
+    },
+    {
+      name: "leverage",
+      description: "Leverage, max 2",
+      required: true,
+      schema: { type: "number" },
+    },
+    {
+      name: "reduceOnly",
+      description: "Whether the order may only reduce exposure",
+      required: false,
+      schema: { type: "boolean" },
+    },
+  ],
+  examples: [
+    [
+      {
+        name: "{{user1}}",
+        content: {
+          text: "Buy $25 BTC perp at 2x using session ses_123",
+          action: "STEWARD_SUBMIT_TRADE",
+        },
+      },
+    ],
+  ] as ActionExample[][],
+
+  async validate(runtime: IAgentRuntime, _message: Memory, _state?: State): Promise<boolean> {
+    const steward = runtime.getService("steward" as any) as StewardService | null;
+    return steward?.isConnected() ?? false;
+  },
+
+  async handler(
+    runtime: IAgentRuntime,
+    _message: Memory,
+    _state?: State,
+    options?: HandlerOptions,
+  ): Promise<ActionResult> {
+    const steward = runtime.getService("steward" as any) as StewardService | null;
+    if (!steward?.isConnected()) {
+      return {
+        success: false,
+        error: "Steward SDK is not configured",
+        text: "Trading is unavailable because Steward is not configured for this agent.",
+      };
+    }
+
+    const params = options?.parameters ?? {};
+    if (!params.sessionId || !params.asset || !params.side || !params.size || !params.leverage) {
+      return {
+        success: false,
+        error: "Missing required trade parameters",
+        text: "I need sessionId, asset, side, size, and leverage to submit a trade.",
+      };
+    }
+
+    try {
+      const result = await steward.submitHyperliquidOrder({
+        sessionId: String(params.sessionId),
+        asset: params.asset as "BTC" | "ETH",
+        side: params.side as "buy" | "sell",
+        size: Number(params.size),
+        leverage: Number(params.leverage),
+        reduceOnly: Boolean(params.reduceOnly),
+      });
+      return {
+        success: true,
+        text: `Hyperliquid order submitted. Status: ${result.status}. Order: ${result.orderId}`,
+        data: result as any,
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return {
+        success: false,
+        error: msg,
+        text: `Trade was not submitted: ${msg}`,
+      };
+    }
+  },
+};

--- a/packages/eliza-plugin/src/index.ts
+++ b/packages/eliza-plugin/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @stwd/eliza-plugin — Steward wallet management for ElizaOS agents.
+ * @stwd/eliza-plugin - Steward wallet management for ElizaOS agents.
  *
  * Policy-enforced signing, balances, and approval flows.
  * Drop-in plugin: add to your character's plugins array and set STEWARD_API_URL.
@@ -8,6 +8,7 @@ import type { Plugin } from "@elizaos/core";
 import { checkSpendAction } from "./actions/check-spend.js";
 import { listApprovalsAction } from "./actions/list-approvals.js";
 import { signTransactionAction } from "./actions/sign-transaction.js";
+import { submitTradeAction } from "./actions/submit-trade.js";
 import { transferAction } from "./actions/transfer.js";
 import { approvalRequiredEvaluator } from "./evaluators/approval.js";
 import { balanceProvider } from "./providers/balance.js";
@@ -17,11 +18,17 @@ import { StewardService } from "./services/StewardService.js";
 export const stewardPlugin: Plugin = {
   name: "@stwd/eliza-plugin",
   description:
-    "Steward wallet management — policy-enforced signing, balances, and approval flows for ElizaOS agents",
+    "Steward wallet management - policy-enforced signing, balances, and approval flows for ElizaOS agents",
 
   services: [StewardService],
 
-  actions: [signTransactionAction, transferAction, checkSpendAction, listApprovalsAction],
+  actions: [
+    signTransactionAction,
+    transferAction,
+    checkSpendAction,
+    listApprovalsAction,
+    submitTradeAction,
+  ],
 
   providers: [walletStatusProvider, balanceProvider],
 
@@ -33,6 +40,7 @@ export default stewardPlugin;
 export { checkSpendAction } from "./actions/check-spend.js";
 export { listApprovalsAction } from "./actions/list-approvals.js";
 export { signTransactionAction } from "./actions/sign-transaction.js";
+export { submitTradeAction } from "./actions/submit-trade.js";
 export { transferAction } from "./actions/transfer.js";
 export { approvalRequiredEvaluator } from "./evaluators/approval.js";
 export { balanceProvider } from "./providers/balance.js";

--- a/packages/eliza-plugin/src/services/StewardService.ts
+++ b/packages/eliza-plugin/src/services/StewardService.ts
@@ -15,6 +15,24 @@ import {
 } from "@stwd/sdk";
 import type { StewardPluginConfig } from "../types.js";
 
+export interface HyperliquidSubmitOrderInput {
+  sessionId: string;
+  asset: "BTC" | "ETH";
+  side: "buy" | "sell";
+  size: number;
+  leverage: number;
+  reduceOnly?: boolean;
+  idempotencyKey?: string;
+}
+
+export interface HyperliquidOrderResult {
+  orderId: string;
+  status: string;
+  filledQty: number;
+  avgPrice: number;
+  txHash: string | null;
+}
+
 /**
  * Singleton service wrapping StewardClient for the ElizaOS runtime.
  *
@@ -24,7 +42,7 @@ import type { StewardPluginConfig } from "../types.js";
 export class StewardService extends Service {
   static serviceType = "steward" as const;
   capabilityDescription =
-    "Steward managed wallet — policy-enforced signing, balances, and approval flows";
+    "Steward managed wallet - policy-enforced signing, balances, and approval flows";
 
   private client: StewardClient | null = null;
   private pluginConfig: StewardPluginConfig | null = null;
@@ -154,6 +172,13 @@ export class StewardService extends Service {
   async getDashboard(): Promise<AgentDashboardResponse> {
     this.assertConnected();
     return this.getClient().getAgentDashboard(this.getAgentId());
+  }
+
+  async submitHyperliquidOrder(
+    input: HyperliquidSubmitOrderInput,
+  ): Promise<HyperliquidOrderResult> {
+    this.assertConnected();
+    return this.getClient().trade.hyperliquid.submitOrder(input);
   }
 
   async listApprovals(opts?: {

--- a/packages/eliza-plugin/tsup.config.ts
+++ b/packages/eliza-plugin/tsup.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
   dts: true,
   clean: true,
   sourcemap: true,
-  external: ["@elizaos/core"],
+  external: ["@elizaos/core", "@stwd/sdk"],
   target: "node22",
 });

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -38,7 +38,7 @@
     "test": "bun test src/__tests__"
   },
   "dependencies": {
-    "@stwd/sdk": "^0.9.0"
+    "@stwd/sdk": "^0.10.0"
   },
   "peerDependencies": {
     "react": ">=18.0.0",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @stwd/sdk Changelog
+
+## 0.10.0
+
+BREAKING-CHANGES:
+- Adds the Sprint 4 trade API surface under `StewardClient.tradeSessions` and `StewardClient.trade.hyperliquid`.
+- Consumers that pin exact SDK versions should upgrade to `0.10.0` before using trade session or Hyperliquid order helpers.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stwd/sdk",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "TypeScript SDK for Steward, agent wallet infrastructure with policy enforcement",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -48,7 +48,7 @@ export type GetBalanceResult = AgentBalance;
 export interface StewardClientConfig {
   baseUrl: string;
   apiKey?: string;
-  /** Agent-scoped JWT — sent as `Authorization: Bearer <token>`. Preferred over apiKey when both are set. */
+  /** Agent-scoped JWT - sent as `Authorization: Bearer <token>`. Preferred over apiKey when both are set. */
   bearerToken?: string;
   tenantId?: string;
 }
@@ -92,6 +92,36 @@ export interface StewardHistoryEntry {
 
 export interface SignMessageResult {
   signature: string;
+}
+
+export interface CreateTradeSessionInput {
+  venue: "hyperliquid";
+  scopes: Array<"read" | "write">;
+  ttlSeconds?: number;
+}
+
+export interface CreateTradeSessionResult {
+  sessionId: string;
+  jwt: string;
+  expiresAt: string;
+}
+
+export interface HyperliquidSubmitOrderInput {
+  sessionId: string;
+  asset: "BTC" | "ETH";
+  side: "buy" | "sell";
+  size: number;
+  leverage: number;
+  reduceOnly?: boolean;
+  idempotencyKey?: string;
+}
+
+export interface HyperliquidOrderResult {
+  orderId: string;
+  status: string;
+  filledQty: number;
+  avgPrice: number;
+  txHash: string | null;
 }
 
 /**
@@ -154,6 +184,50 @@ export class StewardClient {
     this.bearerToken = bearerToken;
     this.tenantId = tenantId;
   }
+
+  readonly tradeSessions = {
+    create: async (input: CreateTradeSessionInput): Promise<CreateTradeSessionResult> => {
+      const response = await this.request<CreateTradeSessionResult, StewardErrorResponse>(
+        "/v1/trade/sessions",
+        {
+          method: "POST",
+          body: JSON.stringify(input),
+        },
+      );
+      if (!response.ok) throw new StewardApiError(response.error, response.status, response.data);
+      return response.data;
+    },
+    revoke: async (sessionId: string): Promise<void> => {
+      const response = await this.request<undefined, StewardErrorResponse>(
+        `/v1/trade/sessions/${encodeURIComponent(sessionId)}/revoke`,
+        { method: "POST" },
+      );
+      if (!response.ok) throw new StewardApiError(response.error, response.status, response.data);
+    },
+  };
+
+  readonly trade = {
+    hyperliquid: {
+      submitOrder: async (
+        input: HyperliquidSubmitOrderInput,
+        options?: { idempotencyKey?: string },
+      ): Promise<HyperliquidOrderResult> => {
+        const idempotencyKey = options?.idempotencyKey ?? input.idempotencyKey;
+        const response = await this.request<HyperliquidOrderResult, StewardErrorResponse>(
+          "/v1/trade/hyperliquid/order",
+          {
+            method: "POST",
+            headers: idempotencyKey ? { "Idempotency-Key": idempotencyKey } : undefined,
+            body: JSON.stringify(input),
+          },
+        );
+        if (!response.ok) {
+          throw new StewardApiError(response.error, response.status, response.data);
+        }
+        return response.data;
+      },
+    },
+  };
 
   getBaseUrl(): string {
     return this.baseUrl;
@@ -253,7 +327,7 @@ export class StewardClient {
 
   /**
    * Return a compact history feed for an agent. Each entry is a
-   * `{ timestamp, value }` pair — suitable for trend charts and volume
+   * `{ timestamp, value }` pair - suitable for trend charts and volume
    * windows. For the full signed-transaction objects, prefer
    * {@link getTransactionHistory}.
    */
@@ -857,7 +931,7 @@ export class StewardClient {
 
   /**
    * Download the audit log as CSV. Returns the raw CSV body as a string.
-   * Does not use the `/api/v1` JSON envelope — streams text directly.
+   * Does not use the `/api/v1` JSON envelope - streams text directly.
    */
   async exportAuditCsv(params?: {
     agentId?: string;

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -16,10 +16,14 @@ export type {
 export type {
   BatchAgentSpec,
   BatchCreateResult,
+  CreateTradeSessionInput,
+  CreateTradeSessionResult,
   CreateWalletResult,
   GetAddressesResult,
   GetBalanceResult,
   GetHistoryResult,
+  HyperliquidOrderResult,
+  HyperliquidSubmitOrderInput,
   SignMessageResult,
   SignTransactionInput,
   SignTransactionResult,
@@ -29,7 +33,7 @@ export type {
   StewardPendingApproval,
 } from "./client.ts";
 export { StewardApiError, StewardClient } from "./client.ts";
-// v0.4.0 — Tenant config, dashboard, approvals, webhooks
+// v0.4.0 - Tenant config, dashboard, approvals, webhooks
 export type {
   AgentBalance,
   AgentDashboardResponse,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,5 +1,7 @@
 // @stwd/shared - types, constants, utils
 
+import type { VenueId } from "./types/venue.js";
+
 export type { PriceOracle } from "./price-oracle.js";
 export { createPriceOracle } from "./price-oracle.js";
 // ─── Token Registry & Price Oracle ───
@@ -326,6 +328,13 @@ export interface SignRequest {
 export interface SignTypedDataRequest {
   agentId: string;
   tenantId: string;
+  /**
+   * Sprint 4: optional venue scope. When set, vault.signTypedData will
+   * look up the venue-scoped wallet under (agentId, venue) instead of
+   * the legacy NULL-venue row. Phase 1 is hyperliquid-only; the field is
+   * accepted but not yet routed through the new lookup path.
+   */
+  venue?: VenueId;
   domain: TypedDataDomain;
   types: Record<string, TypedDataField[]>;
   primaryType: string;

--- a/packages/shared/src/types/venue.ts
+++ b/packages/shared/src/types/venue.ts
@@ -73,3 +73,17 @@ export const VENUE_METADATA: Record<VenueId, VenueMetadata> = {
     supportsLeverage: true,
   },
 };
+
+// ─── Sprint 4 Day 1-2 (Worker A): trade execution types ─────────────────────
+// TradeAsset is the asset enum that venue-hyperliquid + trade-sessions use.
+// Keep tight: only assets Steward will actively support for perps trading.
+
+export type TradeAsset = "BTC" | "ETH";
+
+export interface TradePolicyContext {
+  venue: VenueId;
+  asset: TradeAsset;
+  leverage: number;
+  size: number;
+  sizeUsd?: number;
+}

--- a/packages/trade-sessions/package.json
+++ b/packages/trade-sessions/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@stwd/trade-sessions",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "tsc --noEmit",
+    "dev": "tsc --watch",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@stwd/db": "workspace:*",
+    "@stwd/redis": "workspace:*",
+    "@stwd/shared": "workspace:*",
+    "drizzle-orm": "^0.44.5",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.0"
+  },
+  "description": "Venue-scoped trading session storage for Steward"
+}

--- a/packages/trade-sessions/src/index.ts
+++ b/packages/trade-sessions/src/index.ts
@@ -1,0 +1,201 @@
+import { getDb, tradeSessions } from "@stwd/db";
+import type { InferInsertModel } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+
+export const tradeSessionScopeSchema = z.enum(["read", "write"]);
+export type TradeSessionScope = z.infer<typeof tradeSessionScopeSchema>;
+
+export const tradeSessionStatusSchema = z.enum(["active", "revoked", "expired"]);
+export type TradeSessionStatus = z.infer<typeof tradeSessionStatusSchema>;
+
+export const tradeSessionSchema = z.object({
+  id: z.string(),
+  agentId: z.string(),
+  tenantId: z.string(),
+  venue: z.literal("hyperliquid"),
+  scopes: z.array(tradeSessionScopeSchema),
+  status: tradeSessionStatusSchema,
+  createdAt: z.date(),
+  expiresAt: z.date(),
+  revokedAt: z.date().nullable().optional(),
+  revokedBy: z.string().nullable().optional(),
+});
+
+export type TradeSession = z.infer<typeof tradeSessionSchema>;
+
+export interface TradeSessionRedisLike {
+  get(key: string): Promise<string | null>;
+  setex(key: string, ttlSeconds: number, value: string): Promise<string>;
+  del(...keys: string[]): Promise<number>;
+}
+
+export interface TradeSessionManagerOptions {
+  redis?: TradeSessionRedisLike | null;
+  now?: () => Date;
+}
+
+// Sprint 4 Phase 1: trade sessions are Hyperliquid-only. Broaden to
+// `VenueId` from `@stwd/shared` when Polymarket/Drift/etc are added.
+export interface CreateTradeSessionInput {
+  agentId: string;
+  tenantId: string;
+  venue: "hyperliquid";
+  scopes: TradeSessionScope[];
+  ttlSeconds: number;
+}
+
+export interface RevokeTradeSessionInput {
+  id: string;
+  tenantId: string;
+  revokedBy?: string;
+}
+
+const DEFAULT_TTL_SECONDS = 900;
+const MAX_TTL_SECONDS = 3600;
+
+function sessionKey(tenantId: string, id: string): string {
+  return `trade:session:${tenantId}:${id}`;
+}
+
+function serializeSession(session: TradeSession): string {
+  return JSON.stringify({
+    ...session,
+    createdAt: session.createdAt.toISOString(),
+    expiresAt: session.expiresAt.toISOString(),
+    revokedAt: session.revokedAt?.toISOString() ?? null,
+  });
+}
+
+function parseSession(raw: string): TradeSession | null {
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    return tradeSessionSchema.parse({
+      ...parsed,
+      createdAt: new Date(String(parsed.createdAt)),
+      expiresAt: new Date(String(parsed.expiresAt)),
+      revokedAt: parsed.revokedAt ? new Date(String(parsed.revokedAt)) : null,
+    });
+  } catch {
+    return null;
+  }
+}
+
+function normalizeTtl(ttlSeconds: number): number {
+  if (!Number.isFinite(ttlSeconds)) return DEFAULT_TTL_SECONDS;
+  return Math.max(60, Math.min(MAX_TTL_SECONDS, Math.floor(ttlSeconds)));
+}
+
+export class TradeSessionManager {
+  private readonly redis: TradeSessionRedisLike | null;
+  private readonly now: () => Date;
+
+  constructor(options: TradeSessionManagerOptions = {}) {
+    this.redis = options.redis ?? null;
+    this.now = options.now ?? (() => new Date());
+  }
+
+  async create(input: CreateTradeSessionInput): Promise<TradeSession> {
+    const ttlSeconds = normalizeTtl(input.ttlSeconds);
+    const createdAt = this.now();
+    const expiresAt = new Date(createdAt.getTime() + ttlSeconds * 1000);
+    const session: TradeSession = {
+      id: `ses_${crypto.randomUUID()}`,
+      agentId: input.agentId,
+      tenantId: input.tenantId,
+      venue: input.venue,
+      scopes: [...new Set(input.scopes)],
+      status: "active",
+      createdAt,
+      expiresAt,
+      revokedAt: null,
+      revokedBy: null,
+    };
+
+    const db = getDb();
+    const values: InferInsertModel<typeof tradeSessions> = {
+      id: session.id,
+      agentId: session.agentId,
+      tenantId: session.tenantId,
+      venue: session.venue,
+      scopes: session.scopes,
+      status: session.status,
+      createdAt,
+      expiresAt,
+    };
+    await db.insert(tradeSessions).values(values);
+    await this.writeRedis(session);
+    return session;
+  }
+
+  async getActive(tenantId: string, id: string): Promise<TradeSession | null> {
+    const cached = await this.readRedis(tenantId, id);
+    const session = cached ?? (await this.readDb(tenantId, id));
+    if (!session) return null;
+
+    const now = this.now();
+    if (session.status !== "active" || session.expiresAt <= now) {
+      if (session.status === "active") {
+        await this.markExpired(session);
+      }
+      return null;
+    }
+    return session;
+  }
+
+  async revoke(input: RevokeTradeSessionInput): Promise<TradeSession | null> {
+    const existing = await this.readDb(input.tenantId, input.id);
+    if (!existing) return null;
+    if (existing.status === "revoked") return existing;
+
+    const revokedAt = this.now();
+    const revoked: TradeSession = {
+      ...existing,
+      status: "revoked",
+      revokedAt,
+      revokedBy: input.revokedBy ?? null,
+    };
+
+    await getDb()
+      .update(tradeSessions)
+      .set({ status: "revoked", revokedAt, revokedBy: revoked.revokedBy })
+      .where(and(eq(tradeSessions.id, input.id), eq(tradeSessions.tenantId, input.tenantId)));
+    await this.redis?.del(sessionKey(input.tenantId, input.id)).catch(() => 0);
+    return revoked;
+  }
+
+  private async readRedis(tenantId: string, id: string): Promise<TradeSession | null> {
+    if (!this.redis) return null;
+    try {
+      const raw = await this.redis.get(sessionKey(tenantId, id));
+      return raw ? parseSession(raw) : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private async writeRedis(session: TradeSession): Promise<void> {
+    if (!this.redis) return;
+    const ttlSeconds = Math.max(1, Math.floor((session.expiresAt.getTime() - Date.now()) / 1000));
+    await this.redis
+      .setex(sessionKey(session.tenantId, session.id), ttlSeconds, serializeSession(session))
+      .catch(() => undefined);
+  }
+
+  private async readDb(tenantId: string, id: string): Promise<TradeSession | null> {
+    const [row] = await getDb()
+      .select()
+      .from(tradeSessions)
+      .where(and(eq(tradeSessions.id, id), eq(tradeSessions.tenantId, tenantId)));
+    if (!row) return null;
+    return tradeSessionSchema.parse(row);
+  }
+
+  private async markExpired(session: TradeSession): Promise<void> {
+    await getDb()
+      .update(tradeSessions)
+      .set({ status: "expired" })
+      .where(and(eq(tradeSessions.id, session.id), eq(tradeSessions.tenantId, session.tenantId)));
+    await this.redis?.del(sessionKey(session.tenantId, session.id)).catch(() => 0);
+  }
+}

--- a/packages/trade-sessions/tsconfig.json
+++ b/packages/trade-sessions/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/packages/venue-hyperliquid/package.json
+++ b/packages/venue-hyperliquid/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@stwd/venue-hyperliquid",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "tsc --noEmit",
+    "dev": "tsc --watch",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@stwd/shared": "workspace:*",
+    "viem": "^2.30.0",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.0"
+  },
+  "description": "Hyperliquid venue adapter for Steward"
+}

--- a/packages/venue-hyperliquid/src/index.ts
+++ b/packages/venue-hyperliquid/src/index.ts
@@ -1,0 +1,246 @@
+import { type Hex, parseSignature } from "viem";
+import { z } from "zod";
+
+export const hyperliquidAssetSchema = z.enum(["BTC", "ETH"]);
+export type HyperliquidAsset = z.infer<typeof hyperliquidAssetSchema>;
+
+export const hyperliquidOrderSchema = z.object({
+  asset: hyperliquidAssetSchema,
+  side: z.enum(["buy", "sell"]),
+  size: z.number().positive(),
+  leverage: z.number().positive().max(2),
+  reduceOnly: z.boolean().default(false),
+  limitPrice: z.string().optional(),
+  nonce: z.number().int().positive().optional(),
+});
+export type HyperliquidOrder = z.infer<typeof hyperliquidOrderSchema>;
+
+export const signedOrderSchema = z.object({
+  action: z.record(z.string(), z.unknown()),
+  nonce: z.number().int().positive(),
+  signature: z.object({
+    r: z.string(),
+    s: z.string(),
+    v: z.number(),
+  }),
+});
+export type SignedOrder = z.infer<typeof signedOrderSchema>;
+
+export const orderResultSchema = z.object({
+  orderId: z.string().optional(),
+  status: z.string(),
+  filledQty: z.number().optional(),
+  avgPrice: z.number().optional(),
+  txHash: z.string().nullable().optional(),
+  raw: z.unknown().optional(),
+});
+export type OrderResult = z.infer<typeof orderResultSchema>;
+
+export const positionSchema = z.object({
+  asset: z.string(),
+  side: z.enum(["long", "short", "flat"]).default("flat"),
+  size: z.number(),
+  entryPrice: z.number().optional(),
+  unrealizedPnlUsd: z.number().optional(),
+  leverage: z.number().optional(),
+});
+export type Position = z.infer<typeof positionSchema>;
+
+export interface VaultSignTypedDataInput {
+  agentId: string;
+  domain: {
+    name?: string;
+    version?: string;
+    chainId?: number;
+    verifyingContract?: string;
+    salt?: string;
+  };
+  types: Record<string, Array<{ name: string; type: string }>>;
+  primaryType: string;
+  value: Record<string, unknown>;
+}
+
+export interface VaultClient {
+  signTypedData(input: VaultSignTypedDataInput): Promise<string>;
+  getWallet?(input: { agentId: string; venue: "hyperliquid" }): Promise<{ address: string } | null>;
+}
+
+export interface HyperliquidTransport {
+  fetch(input: string | URL | Request, init?: RequestInit): Promise<Response>;
+}
+
+export interface HyperliquidAdapterOptions {
+  transport?: HyperliquidTransport;
+  baseUrl?: string;
+}
+
+const ASSET_INDEX: Record<HyperliquidAsset, number> = {
+  BTC: 0,
+  ETH: 1,
+};
+
+const DEFAULT_BASE_URL = "https://api.hyperliquid.xyz";
+
+function toExchangeAction(order: HyperliquidOrder): Record<string, unknown> {
+  const parsed = hyperliquidOrderSchema.parse(order);
+  return {
+    type: "order",
+    orders: [
+      {
+        a: ASSET_INDEX[parsed.asset],
+        b: parsed.side === "buy",
+        p: parsed.limitPrice ?? "0",
+        s: String(parsed.size),
+        r: parsed.reduceOnly,
+        t: {
+          limit: {
+            tif: "Ioc",
+          },
+        },
+      },
+    ],
+    grouping: "na",
+  };
+}
+
+function createTypedData(
+  order: HyperliquidOrder,
+  action: Record<string, unknown>,
+  walletAddress: string,
+  nonce: number,
+): VaultSignTypedDataInput {
+  return {
+    agentId: "",
+    domain: {
+      name: "Exchange",
+      version: "1",
+      chainId: 1337,
+      verifyingContract: "0x0000000000000000000000000000000000000000",
+    },
+    types: {
+      HyperliquidOrder: [
+        { name: "wallet", type: "address" },
+        { name: "asset", type: "string" },
+        { name: "side", type: "string" },
+        { name: "size", type: "string" },
+        { name: "leverage", type: "uint256" },
+        { name: "reduceOnly", type: "bool" },
+        { name: "nonce", type: "uint64" },
+        { name: "action", type: "string" },
+      ],
+    },
+    primaryType: "HyperliquidOrder",
+    value: {
+      wallet: walletAddress,
+      asset: order.asset,
+      side: order.side,
+      size: String(order.size),
+      leverage: order.leverage,
+      reduceOnly: order.reduceOnly ?? false,
+      nonce,
+      action: JSON.stringify(action),
+    },
+  };
+}
+
+export class HyperliquidAdapter {
+  private readonly transport: HyperliquidTransport;
+  private readonly baseUrl: string;
+
+  constructor(
+    private readonly vault: VaultClient,
+    private readonly agentId: string,
+    private readonly walletAddress: string,
+    options: HyperliquidAdapterOptions = {},
+  ) {
+    this.transport = options.transport ?? { fetch };
+    this.baseUrl = options.baseUrl ?? DEFAULT_BASE_URL;
+  }
+
+  async signOrder(order: HyperliquidOrder): Promise<SignedOrder> {
+    const parsed = hyperliquidOrderSchema.parse(order);
+    const nonce = parsed.nonce ?? Date.now();
+    const action = toExchangeAction(parsed);
+    const typedData = createTypedData(parsed, action, this.walletAddress, nonce);
+    const signatureHex = await this.vault.signTypedData({
+      ...typedData,
+      agentId: this.agentId,
+    });
+    const signature = parseSignature(signatureHex as Hex);
+    if (signature.v === undefined) {
+      throw new Error("Vault returned an EIP-712 signature without a recovery id");
+    }
+
+    return signedOrderSchema.parse({
+      action,
+      nonce,
+      signature: {
+        r: signature.r,
+        s: signature.s,
+        v: Number(signature.v),
+      },
+    });
+  }
+
+  async submitOrder(signed: SignedOrder): Promise<OrderResult> {
+    const body = signedOrderSchema.parse(signed);
+    const response = await this.transport.fetch(`${this.baseUrl}/exchange`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    const json = (await response.json().catch(() => null)) as unknown;
+    if (!response.ok) {
+      throw new Error(`Hyperliquid exchange returned ${response.status}`);
+    }
+    return normalizeOrderResult(json);
+  }
+
+  async getPositions(): Promise<Position[]> {
+    const response = await this.transport.fetch(`${this.baseUrl}/info`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ type: "clearinghouseState", user: this.walletAddress }),
+    });
+    const json = (await response.json().catch(() => null)) as unknown;
+    if (!response.ok) {
+      throw new Error(`Hyperliquid info returned ${response.status}`);
+    }
+    return normalizePositions(json);
+  }
+}
+
+function normalizeOrderResult(raw: unknown): OrderResult {
+  const payload = raw as Record<string, unknown>;
+  const statuses = Array.isArray((payload.response as Record<string, unknown> | undefined)?.data)
+    ? ((payload.response as Record<string, unknown>).data as unknown[])
+    : [];
+  const first = statuses[0] as Record<string, unknown> | undefined;
+  return orderResultSchema.parse({
+    orderId: String(first?.oid ?? first?.orderId ?? crypto.randomUUID()),
+    status: String(payload.status ?? "submitted"),
+    filledQty: typeof first?.totalSz === "number" ? first.totalSz : undefined,
+    avgPrice: typeof first?.avgPx === "number" ? first.avgPx : undefined,
+    txHash: null,
+    raw,
+  });
+}
+
+function normalizePositions(raw: unknown): Position[] {
+  const payload = raw as { assetPositions?: Array<{ position?: Record<string, unknown> }> };
+  return (payload.assetPositions ?? []).map((entry) => {
+    const position = entry.position ?? {};
+    const size = Number(position.szi ?? 0);
+    return positionSchema.parse({
+      asset: String(position.coin ?? ""),
+      side: size > 0 ? "long" : size < 0 ? "short" : "flat",
+      size: Math.abs(size),
+      entryPrice: position.entryPx ? Number(position.entryPx) : undefined,
+      unrealizedPnlUsd: position.unrealizedPnl ? Number(position.unrealizedPnl) : undefined,
+      leverage:
+        typeof position.leverage === "object" && position.leverage
+          ? Number((position.leverage as Record<string, unknown>).value ?? 0)
+          : undefined,
+    });
+  });
+}

--- a/packages/venue-hyperliquid/tsconfig.json
+++ b/packages/venue-hyperliquid/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

Sprint 4 Phase 1 Days 1-2 work, rebased onto develop after PR #60 (Worker B's vault venue scoping + policy evaluators) landed.

## What's new

- **`@stwd/trade-sessions`** package — short-lived JWT session manager for venue-scoped trading. TTL 15min default, 1hr max. Redis-backed if available, otherwise in-memory.
- **`@stwd/venue-hyperliquid`** adapter — HL EIP-712 typed-data signing + order submission via Steward vault.
- **`packages/api/src/routes/trade.ts`** — three new endpoints:
  - `POST /v1/trade/sessions` create session
  - `POST /v1/trade/sessions/:id/revoke` revoke
  - `POST /v1/trade/orders/hyperliquid` submit order (uses session JWT)
- **Eliza plugin `submitTradeAction`** — exposes `STEWARD_SUBMIT_TRADE` to ElizaOS agents (e.g. Sol).
- **SDK** — `StewardClient.tradeSessions.{create,revoke}` + `StewardClient.trade.hyperliquid.submitOrder`.
- **Migration 0023_trade_sessions.sql** — `trade_sessions` table + 3 indexes.
- **`SignTypedDataRequest`** extended with optional `venue?: VenueId` field (forward-compatible with venue-scoped vault lookup, ignored by current legacy lookup path).
- **`TradeAsset`** + **`TradePolicyContext`** types added to `@stwd/shared/types/venue.ts`.

## Conflict resolution notes (rebase on top of #60)

- Took develop's version (from #60) of `vault.ts`, `policy-engine/engine.ts`, `shared/types/venue.ts` (`VENUE_IDS` const + `VenueId` union), `evaluators/` directory, `vault/__tests__/venue-scoping.test.ts`, and migration `0022_vault_venue_scope.sql`.
- Kept this PR's additions: trade-sessions + venue-hyperliquid packages, trade route, eliza-plugin submit-trade action, 0023 migration, SDK additions, `TradeAsset`/`TradePolicyContext` types appended to venue.ts.
- Narrowed `CreateTradeSessionInput.venue` from `VenueId` to literal `"hyperliquid"` (Phase 1 is HL-only).

## Sprint 4 progress

- Day 1 (vault scoping + policy evaluators): #60 ✅
- Day 2 (trade-sessions + venue-hyperliquid): THIS PR
- Day 3 (Sol default policy seeder): #60 ✅
- Day 4 (Eliza Cloud JWT minting): pending
- Day 5 ($20 USDC warm-up): pending Day 4

## Risk

- `@stwd/trade-sessions` is a new package, no tests in this commit (was in Worker A's session, will land in follow-up PR).
- Vault `signTypedData` accepts `venue` but doesn't yet route through venue-scoped lookup. Phase 1 Sol uses the legacy NULL-venue Hyperliquid wallet path (until a separate `createWallet({ agentId, venue: 'hyperliquid' })` is invoked).

Co-authored-by: wakesync <shadow@shad0w.xyz>