### PR TITLE
fix(api): cast Date param to ISO string in trade checkDailyCap

### DIFF
--- a/packages/api/src/routes/trade.ts
+++ b/packages/api/src/routes/trade.ts
@@ -107,13 +107,16 @@ async function enforceOrderRateLimit(
 async function checkDailyCap(agentId: string, sizeUsd: number): Promise<boolean> {
   const since = new Date();
   since.setUTCHours(0, 0, 0, 0);
+  // postgres-js does not auto-stringify Date objects in raw sql template
+  // params. Convert to ISO and cast on the SQL side instead.
+  const sinceIso = since.toISOString();
   const [row] = await db
     .select({
       total: sql<string>`coalesce(sum((${proxyAuditLog.targetPath}::jsonb ->> 'sizeUsd')::numeric), 0)::text`,
     })
     .from(proxyAuditLog)
     .where(
-      sql`${proxyAuditLog.agentId} = ${agentId} and ${proxyAuditLog.reason} = 'trade.order.submitted' and ${proxyAuditLog.createdAt} >= ${since}`,
+      sql`${proxyAuditLog.agentId} = ${agentId} and ${proxyAuditLog.reason} = 'trade.order.submitted' and ${proxyAuditLog.createdAt} >= ${sinceIso}::timestamptz`,
     );
   const spent = Number(row?.total ?? 0);
   return spent + sizeUsd <= 100;


### PR DESCRIPTION
## Bug

`POST /v1/trade/hyperliquid/order` returns 500 on every call:

```
TypeError: The "string" argument must be of type string or an instance
of Buffer or ArrayBuffer. Received an instance of Date
```

Reproduced with Sol's first real smoke test (size=0.001, leverage=2 on BTC).

## Root cause

`checkDailyCap` interpolates `new Date()` into a Drizzle `sql` template. The postgres-js driver does not auto-stringify Date objects in raw template params.

## Fix

Convert to ISO string + cast to `timestamptz` SQL-side.

## Sprint 4 progress

- Day 1 vault venue scoping ✅ (#60)
- Day 2 trade-sessions + HL ✅ (#63)
- Day 3 Sol default policy ✅ (#60)
- Day 4 venue wallet endpoint ✅ (#64) + Sol agent provisioned + HL wallet 0x30641cD7c2E0997AcBd8789b86aDE9B381da048b + policies seeded
- **This PR: unblock Day 5 smoke test**

Co-authored-by: wakesync <shadow@shad0w.xyz>