### PR TITLE
feat(auth): bump access token TTL from 15m to 24h

### DIFF
--- a/packages/api/src/__tests__/auth-oauth-nonce-exchange.test.ts
+++ b/packages/api/src/__tests__/auth-oauth-nonce-exchange.test.ts
@@ -65,7 +65,7 @@ describe("POST /auth/oauth/exchange", () => {
     expect(json.token).toBe("access-jwt");
     expect(json.refreshToken).toBe("refresh-raw");
     expect(typeof json.expiresAt).toBe("number");
-    expect(json.expiresIn).toBe(900);
+    expect(json.expiresIn).toBe(86400);
   });
 
   it("rejects unknown / already-consumed codes with code_invalid", async () => {

--- a/packages/api/src/__tests__/session-revocation.test.ts
+++ b/packages/api/src/__tests__/session-revocation.test.ts
@@ -91,7 +91,7 @@ describe("API access-token revocation", () => {
       expiresIn: number;
     };
     expect(json.ok).toBe(true);
-    expect(json.expiresIn).toBe(900);
+    expect(json.expiresIn).toBe(86400);
     expect(await verifySessionToken(json.token)).toMatchObject({ userId, tenantId });
   });
 

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -136,9 +136,9 @@ async function checkAuthRateLimit(
 
 // ─── JWT helpers ──────────────────────────────────────────────────────────────
 
-/** Access token lifetime: 15 minutes */
-const ACCESS_TOKEN_EXPIRY = "15m";
-const ACCESS_TOKEN_EXPIRY_SECONDS = 900;
+/** Access token lifetime: 24 hours */
+const ACCESS_TOKEN_EXPIRY = "24h";
+const ACCESS_TOKEN_EXPIRY_SECONDS = 86400;
 
 /** Refresh token lifetime: 30 days */
 const REFRESH_TOKEN_EXPIRY_DAYS = 30;
@@ -1655,7 +1655,7 @@ auth.post("/refresh", async (c) => {
   const walletAddress = user?.walletAddress ?? "";
   const email = user?.email ?? undefined;
 
-  // Issue new access token (15min)
+  // Issue new access token (24h)
   const newAccessToken = await createSessionToken(walletAddress, record.tenantId, {
     userId: record.userId,
     ...(email ? { email } : {}),

--- a/packages/api/src/services/context.ts
+++ b/packages/api/src/services/context.ts
@@ -43,10 +43,9 @@ export const isWorkersRuntime =
 // ─── JWT helpers ──────────────────────────────────────────────────────────────
 
 /**
- * User access token TTL. Reduced from 24h → 15m to limit blast radius of
- * stolen access tokens. Refresh tokens (30d) handle long-lived sessions.
+ * User access token TTL. Refresh tokens (30d) handle long-lived sessions.
  */
-export const JWT_EXPIRY = "15m";
+export const JWT_EXPIRY = "24h";
 export const AGENT_SCOPE = "agent";
 export const PROXY_SCOPE = "api:proxy";
 


### PR DESCRIPTION
Aligns with standard consumer-app session lifetimes (Twitter, Discord
use hours-to-days for access JWTs). Refresh token stays 30 days, so
revocation via DB still works.

Motivation: waifu.fun wraps the Steward JWT in an HttpOnly wf_session
cookie with 30-day Max-Age. The 15m TTL meant every user got signed
out of waifu.fun every 15 min because the cookie outlived the JWT
inside it. No refresh mechanism currently re-mints the cookie when
the FE refreshes the localStorage JWT. Bumping the access TTL makes
the cookie practically session-stable for daily use.

Trade-off: longer JWT abuse window if leaked. Mitigated by:
- HttpOnly + Secure + SameSite=Lax on the cookie
- Refresh tokens are still rotated on every refresh (one-time use)
- DB-side session revocation still works (refresh_tokens table)

Co-authored-by: wakesync <shadow@shad0w.xyz>
