### PR TITLE
feat(steward): Sprint 4 Day 3 — policy evaluators + audit log

### DIFF
--- a/packages/api/src/__tests__/trade-policy-audit.test.ts
+++ b/packages/api/src/__tests__/trade-policy-audit.test.ts
@@ -1,0 +1,103 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { agents, auditEvents, closeDb, getDb, tenants, tradeSessions } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { eq } from "drizzle-orm";
+import { Hono } from "hono";
+
+beforeAll(async () => {
+  process.env.STEWARD_PGLITE_MEMORY = "true";
+  const { db, client } = await createPGLiteDb("memory://");
+  setPGLiteOverride(db, async () => {
+    await client.close();
+  });
+});
+
+afterAll(async () => {
+  await closeDb();
+});
+
+describe("trade policy audit", () => {
+  it("rejects out-of-policy Hyperliquid orders before submission and writes audit", async () => {
+    const tenantId = `tenant-trade-policy-${Date.now()}`;
+    const agentId = `agent-trade-policy-${Date.now()}`;
+    const sessionId = `ses_${crypto.randomUUID()}`;
+
+    await getDb().insert(tenants).values({
+      id: tenantId,
+      name: "Trade Policy Test Tenant",
+      apiKeyHash: "test-hash",
+      ownerAddress: "0x0000000000000000000000000000000000000000",
+    });
+    await getDb().insert(agents).values({
+      id: agentId,
+      tenantId,
+      name: "Trade Policy Test Agent",
+      walletAddress: "0x0000000000000000000000000000000000000001",
+    });
+    await getDb()
+      .insert(tradeSessions)
+      .values({
+        id: sessionId,
+        tenantId,
+        agentId,
+        venue: "hyperliquid",
+        walletId: "0x0000000000000000000000000000000000000001",
+        status: "active",
+        dailySpendUsd: "0",
+        dailyCapUsd: "100",
+        perOrderCapUsd: "50",
+        leverageCap: "2",
+        allowedAssets: ["BTC", "ETH"],
+        expiresAt: new Date(Date.now() + 60_000),
+      });
+
+    process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+    process.env.STEWARD_MASTER_PASSWORD ??= "test-master-password";
+    const { tradeRoutes } = await import("../routes/trade");
+    const app = new Hono<{
+      Variables: {
+        tenantId: string;
+        agentScope: string;
+        authType: string;
+      };
+    }>();
+    app.use("*", async (c, next) => {
+      c.set("tenantId", tenantId);
+      c.set("agentScope", agentId);
+      c.set("authType", "agent");
+      await next();
+    });
+    app.route("/v1/trade", tradeRoutes);
+
+    const res = await app.request("/v1/trade/hyperliquid/order", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sessionId,
+        asset: "ETH",
+        side: "buy",
+        size: 1,
+        limitPx: 200,
+        leverage: 3,
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      code: "policy-violation",
+      reason: "leverage-cap: leverage 3 exceeds cap 2",
+    });
+
+    const rows = await getDb()
+      .select()
+      .from(auditEvents)
+      .where(eq(auditEvents.action, "trade.order.policy-rejected"));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ tenantId, actorId: agentId, requestId: sessionId });
+    expect(rows[0]?.metadata).toMatchObject({
+      sessionId,
+      reason: "leverage-cap: leverage 3 exceeds cap 2",
+      correlationId: sessionId,
+    });
+  });
+});

--- a/packages/api/src/routes/trade.ts
+++ b/packages/api/src/routes/trade.ts
@@ -46,7 +46,10 @@ const submitOrderSchema = z
     size: z.number().positive(),
     limitPx: z.union([z.string(), z.number()]).optional(),
     limitPrice: z.union([z.string(), z.number()]).optional(),
-    leverage: z.number().positive().max(2).default(1),
+    // No max here: the policy engine (`evaluateTradeOrder`) is the source of
+    // truth for leverage caps. Schema-level rejection would short-circuit the
+    // policy audit trail.
+    leverage: z.number().positive().default(1),
     reduceOnly: z.boolean().default(false),
     idempotencyKey: z.string().min(1).max(256).optional(),
   })


### PR DESCRIPTION
## Summary
- add trade-order policy evaluators and `evaluateTradeOrder` composition helper
- wire Hyperliquid order submission to synchronous policy rejection with `policy-violation` responses
- write `trade.order.policy-rejected` to the tamper-evident audit chain with session correlation metadata
- add evaluator and policy-rejection audit tests

## Validation
- `bun test packages/api/src/__tests__/trade-policy-audit.test.ts packages/policy-engine/src/__tests__/trade-order.test.ts`
- `bun run --filter @stwd/venue-hyperliquid build && bun run --filter @stwd/api build && bun run --filter @stwd/policy-engine build`
- `bun run lint`

## Notes
- Stacked on Day 1 PR #68 because this workspace branch includes the trade-session foundation.
- Do not auto-merge.