### PR TITLE
feat(steward): Sprint 4 Day 2 — HL order signing + submission

### DIFF
--- a/packages/api/src/routes/trade.ts
+++ b/packages/api/src/routes/trade.ts
@@ -40,13 +40,13 @@ const createSessionSchema = z.object({
 const submitOrderSchema = z
   .object({
     sessionId: z.string().min(1),
-    coin: z.string().min(1).optional(),
-    asset: z.string().min(1).optional(),
+    coin: hyperliquidAssetSchema.optional(),
+    asset: hyperliquidAssetSchema.optional(),
     side: z.enum(["buy", "sell"]),
     size: z.number().positive(),
-    leverage: z.number().positive(),
     limitPx: z.union([z.string(), z.number()]).optional(),
     limitPrice: z.union([z.string(), z.number()]).optional(),
+    leverage: z.number().positive().max(2).default(1),
     reduceOnly: z.boolean().default(false),
     idempotencyKey: z.string().min(1).max(256).optional(),
   })
@@ -376,6 +376,10 @@ tradeRoutes.post("/hyperliquid/order", async (c) => {
     return c.json({ code: "policy-violation", reason }, 400);
   }
 
+  // Re-validate against the Hyperliquid adapter's strict asset enum. The
+  // session-level allowlist (BTC/ETH) is covered by evaluateTradeOrder; this
+  // second check defends the adapter contract if the session ever permits
+  // a coin the adapter does not implement.
   const parsedAsset = hyperliquidAssetSchema.safeParse(coin);
   if (!parsedAsset.success) {
     const reason = `asset-allowlist: asset ${coin} is not supported by Hyperliquid adapter`;
@@ -399,6 +403,7 @@ tradeRoutes.post("/hyperliquid/order", async (c) => {
     asset: parsedAsset.data,
     side: body.side,
     size: body.size,
+    limitPx: body.limitPx ?? body.limitPrice,
     leverage: body.leverage,
     reduceOnly: body.reduceOnly,
   };

--- a/packages/venue-hyperliquid/src/index.test.ts
+++ b/packages/venue-hyperliquid/src/index.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, test } from "bun:test";
+import { privateKeyToAccount } from "viem/accounts";
+import {
+  actionHash,
+  cancelOrder,
+  createL1TypedData,
+  getOpenOrders,
+  HyperliquidAdapter,
+  type HyperliquidTransport,
+  signOrder,
+  submitOrder,
+  toExchangeAction,
+} from "./index";
+
+const PRIVATE_KEY = "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" as const;
+const WALLET = privateKeyToAccount(PRIVATE_KEY).address;
+const NONCE = 1_700_000_000_000;
+
+describe("Hyperliquid L1 signing", () => {
+  test("builds the documented wire action and deterministic L1 typed data", async () => {
+    const action = toExchangeAction({
+      coin: "BTC",
+      side: "buy",
+      size: 0.02,
+      limitPx: "30000",
+      reduceOnly: false,
+    });
+    expect(action).toEqual({
+      type: "order",
+      orders: [{ a: 0, b: true, p: "30000", s: "0.02", r: false, t: { limit: { tif: "Ioc" } } }],
+      grouping: "na",
+    });
+
+    const typedData = createL1TypedData(action, NONCE, false);
+    expect(typedData).toEqual({
+      domain: {
+        name: "Exchange",
+        version: "1",
+        chainId: 1337,
+        verifyingContract: "0x0000000000000000000000000000000000000000",
+      },
+      types: {
+        Agent: [
+          { name: "source", type: "string" },
+          { name: "connectionId", type: "bytes32" },
+        ],
+      },
+      primaryType: "Agent",
+      value: {
+        source: "b",
+        connectionId: actionHash(action, NONCE),
+      },
+    });
+
+    const signed = await signOrder(
+      PRIVATE_KEY,
+      { coin: "BTC", side: "buy", size: 0.02, limitPx: "30000" },
+      { nonce: NONCE, isMainnet: false },
+    );
+    expect(signed.action).toEqual(action);
+    expect(signed.nonce).toBe(NONCE);
+    expect(signed.signature.r).toMatch(/^0x[0-9a-f]{64}$/);
+    expect(signed.signature.s).toMatch(/^0x[0-9a-f]{64}$/);
+    expect([27, 28]).toContain(signed.signature.v);
+  });
+
+  test("adapter signs with vault-provided EIP-712 and submits HL payload", async () => {
+    let posted: unknown;
+    const transport: HyperliquidTransport = {
+      async fetch(_input, init) {
+        posted = JSON.parse(String(init?.body));
+        return new Response(
+          JSON.stringify({
+            status: "ok",
+            response: { type: "order", data: { statuses: [{ resting: { oid: 77738308 } }] } },
+          }),
+          { status: 200 },
+        );
+      },
+    };
+    const account = privateKeyToAccount(PRIVATE_KEY);
+    const adapter = new HyperliquidAdapter(
+      {
+        async signTypedData(input) {
+          return account.signTypedData({
+            domain: input.domain,
+            types: input.types,
+            primaryType: input.primaryType,
+            message: input.value,
+          });
+        },
+      },
+      "sol",
+      WALLET,
+      { transport, baseUrl: "https://api.hyperliquid-testnet.xyz", isMainnet: false },
+    );
+
+    const signed = await adapter.signOrder({
+      coin: "ETH",
+      side: "sell",
+      size: 0.5,
+      limitPx: "2500",
+      reduceOnly: true,
+      nonce: NONCE,
+    });
+    const result = await adapter.submitOrder(signed);
+    expect(posted).toMatchObject({
+      action: signed.action,
+      nonce: NONCE,
+      signature: signed.signature,
+    });
+    expect(result).toMatchObject({ orderId: "77738308", status: "resting" });
+  });
+});
+
+describe("Hyperliquid HTTP helpers", () => {
+  test("normalizes venue order rejection without throwing", async () => {
+    const result = await submitOrder(
+      await signOrder(
+        PRIVATE_KEY,
+        { coin: "BTC", side: "buy", size: 0.001, limitPx: "100" },
+        { nonce: NONCE },
+      ),
+      {
+        transport: {
+          async fetch() {
+            return new Response(
+              JSON.stringify({
+                status: "ok",
+                response: {
+                  type: "order",
+                  data: { statuses: [{ error: "Order must have minimum value of $10." }] },
+                },
+              }),
+              { status: 200 },
+            );
+          },
+        },
+      },
+    );
+    expect(result).toMatchObject({
+      status: "rejected",
+      error: "Order must have minimum value of $10.",
+    });
+  });
+
+  test("fetches open orders from info endpoint", async () => {
+    const orders = await getOpenOrders(WALLET, {
+      transport: {
+        async fetch(_input, init) {
+          expect(JSON.parse(String(init?.body))).toEqual({ type: "openOrders", user: WALLET });
+          return new Response(
+            JSON.stringify([
+              {
+                coin: "BTC",
+                limitPx: "29792.0",
+                oid: 91490942,
+                side: "A",
+                sz: "5.0",
+                timestamp: 1681247412573,
+              },
+            ]),
+            { status: 200 },
+          );
+        },
+      },
+    });
+    expect(orders[0]?.oid).toBe(91490942);
+  });
+
+  test("normalizes cancel errors", async () => {
+    const result = await cancelOrder(
+      PRIVATE_KEY,
+      { coin: "BTC", orderId: 123, nonce: NONCE },
+      {
+        transport: {
+          async fetch() {
+            return new Response(
+              JSON.stringify({
+                status: "ok",
+                response: {
+                  type: "cancel",
+                  data: {
+                    statuses: [{ error: "Order was never placed, already canceled, or filled." }],
+                  },
+                },
+              }),
+              { status: 200 },
+            );
+          },
+        },
+      },
+    );
+    expect(result).toMatchObject({
+      orderId: "123",
+      status: "rejected",
+      error: "Order was never placed, already canceled, or filled.",
+    });
+  });
+});

--- a/packages/venue-hyperliquid/src/index.ts
+++ b/packages/venue-hyperliquid/src/index.ts
@@ -1,31 +1,45 @@
-import { type Hex, parseSignature } from "viem";
+import { concatBytes, type Hex, keccak256, parseSignature, toBytes } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
 import { z } from "zod";
 
 export const hyperliquidAssetSchema = z.enum(["BTC", "ETH"]);
 export type HyperliquidAsset = z.infer<typeof hyperliquidAssetSchema>;
+const ASSET_INDEX: Record<HyperliquidAsset, number> = { BTC: 0, ETH: 1 };
+const DEFAULT_BASE_URL = "https://api.hyperliquid.xyz";
 
 export const hyperliquidOrderSchema = z.object({
-  asset: hyperliquidAssetSchema,
-  side: z.enum(["buy", "sell"]),
-  size: z.number().positive(),
-  leverage: z.number().positive().max(2),
+  coin: hyperliquidAssetSchema.optional(),
+  asset: hyperliquidAssetSchema.optional(),
+  side: z.enum(["buy", "sell"]).optional(),
+  isBuy: z.boolean().optional(),
+  size: z.number().positive().optional(),
+  sz: z.union([z.string(), z.number()]).optional(),
+  limitPx: z.union([z.string(), z.number()]).optional(),
+  limitPrice: z.union([z.string(), z.number()]).optional(),
+  orderType: z
+    .object({ limit: z.object({ tif: z.enum(["Alo", "Ioc", "Gtc"]) }).optional() })
+    .optional(),
   reduceOnly: z.boolean().default(false),
-  limitPrice: z.string().optional(),
+  leverage: z.number().positive().max(2).optional(),
   nonce: z.number().int().positive().optional(),
 });
-export type HyperliquidOrder = z.infer<typeof hyperliquidOrderSchema>;
+export type HyperliquidOrder = z.input<typeof hyperliquidOrderSchema>;
+export type CancelOrderInput = { coin: HyperliquidAsset; orderId: number | string; nonce?: number };
+export type SignOptions = {
+  nonce?: number;
+  isMainnet?: boolean;
+  vaultAddress?: string;
+  expiresAfter?: number;
+};
 
 export const signedOrderSchema = z.object({
   action: z.record(z.string(), z.unknown()),
   nonce: z.number().int().positive(),
-  signature: z.object({
-    r: z.string(),
-    s: z.string(),
-    v: z.number(),
-  }),
+  signature: z.object({ r: z.string(), s: z.string(), v: z.number() }),
+  vaultAddress: z.string().optional(),
+  expiresAfter: z.number().int().positive().optional(),
 });
 export type SignedOrder = z.infer<typeof signedOrderSchema>;
-
 export const orderResultSchema = z.object({
   orderId: z.string().optional(),
   status: z.string(),
@@ -33,9 +47,26 @@ export const orderResultSchema = z.object({
   avgPrice: z.number().optional(),
   txHash: z.string().nullable().optional(),
   raw: z.unknown().optional(),
+  error: z.string().optional(),
 });
 export type OrderResult = z.infer<typeof orderResultSchema>;
-
+export const cancelResultSchema = z.object({
+  orderId: z.string(),
+  status: z.string(),
+  raw: z.unknown().optional(),
+  error: z.string().optional(),
+});
+export type CancelResult = z.infer<typeof cancelResultSchema>;
+export const openOrderSchema = z.object({
+  coin: z.string(),
+  limitPx: z.string(),
+  oid: z.number(),
+  side: z.string(),
+  sz: z.string(),
+  timestamp: z.number().optional(),
+  raw: z.unknown().optional(),
+});
+export type Order = z.infer<typeof openOrderSchema>;
 export const positionSchema = z.object({
   asset: z.string(),
   side: z.enum(["long", "short", "flat"]).default("flat"),
@@ -59,58 +90,122 @@ export interface VaultSignTypedDataInput {
   primaryType: string;
   value: Record<string, unknown>;
 }
-
 export interface VaultClient {
   signTypedData(input: VaultSignTypedDataInput): Promise<string>;
   getWallet?(input: { agentId: string; venue: "hyperliquid" }): Promise<{ address: string } | null>;
 }
-
 export interface HyperliquidTransport {
   fetch(input: string | URL | Request, init?: RequestInit): Promise<Response>;
 }
-
 export interface HyperliquidAdapterOptions {
   transport?: HyperliquidTransport;
   baseUrl?: string;
+  isMainnet?: boolean;
+  vaultAddress?: string;
+  expiresAfter?: number;
 }
 
-const ASSET_INDEX: Record<HyperliquidAsset, number> = {
-  BTC: 0,
-  ETH: 1,
-};
-
-const DEFAULT_BASE_URL = "https://api.hyperliquid.xyz";
-
-function toExchangeAction(order: HyperliquidOrder): Record<string, unknown> {
-  const parsed = hyperliquidOrderSchema.parse(order);
+function dec(v: unknown, fallback?: string) {
+  if (v == null) {
+    if (fallback !== undefined) return fallback;
+    throw new Error("missing decimal");
+  }
+  if (typeof v === "string") return v;
+  return Number(v)
+    .toFixed(8)
+    .replace(/\.0+$/, "")
+    .replace(/(\.\d*?)0+$/, "$1");
+}
+function normalized(order: HyperliquidOrder) {
+  const p = hyperliquidOrderSchema.parse(order);
+  const coin = p.coin ?? p.asset;
+  if (!coin) throw new Error("coin is required");
+  const isBuy = p.isBuy ?? (p.side ? p.side === "buy" : undefined);
+  if (isBuy === undefined) throw new Error("side is required");
+  return {
+    coin,
+    isBuy,
+    sz: dec(p.sz ?? p.size),
+    limitPx: dec(p.limitPx ?? p.limitPrice, "0"),
+    reduceOnly: p.reduceOnly ?? false,
+    tif: p.orderType?.limit?.tif ?? "Ioc",
+    nonce: p.nonce,
+  };
+}
+export function toExchangeAction(order: HyperliquidOrder): Record<string, unknown> {
+  const o = normalized(order);
   return {
     type: "order",
     orders: [
       {
-        a: ASSET_INDEX[parsed.asset],
-        b: parsed.side === "buy",
-        p: parsed.limitPrice ?? "0",
-        s: String(parsed.size),
-        r: parsed.reduceOnly,
-        t: {
-          limit: {
-            tif: "Ioc",
-          },
-        },
+        a: ASSET_INDEX[o.coin],
+        b: o.isBuy,
+        p: o.limitPx,
+        s: o.sz,
+        r: o.reduceOnly,
+        t: { limit: { tif: o.tif } },
       },
     ],
     grouping: "na",
   };
 }
+function toCancelAction(input: CancelOrderInput): Record<string, unknown> {
+  return { type: "cancel", cancels: [{ a: ASSET_INDEX[input.coin], o: Number(input.orderId) }] };
+}
 
-function createTypedData(
-  order: HyperliquidOrder,
+const u8 = (...b: number[]) => new Uint8Array(b);
+const uint = (n: number, l: number) => {
+  const out = new Uint8Array(l);
+  let x = BigInt(n);
+  for (let i = l - 1; i >= 0; i--) {
+    out[i] = Number(x & 255n);
+    x >>= 8n;
+  }
+  return out;
+};
+function mp(v: unknown): Uint8Array {
+  if (v == null) return u8(0xc0);
+  if (typeof v === "boolean") return u8(v ? 0xc3 : 0xc2);
+  if (typeof v === "number") {
+    if (v <= 0x7f) return u8(v);
+    if (v <= 0xff) return u8(0xcc, v);
+    if (v <= 0xffff) return concatBytes([u8(0xcd), uint(v, 2)]);
+    return concatBytes([u8(0xce), uint(v, 4)]);
+  }
+  if (typeof v === "string") {
+    const e = new TextEncoder().encode(v);
+    if (e.length <= 31) return concatBytes([u8(0xa0 | e.length), e]);
+    return concatBytes([u8(0xd9, e.length), e]);
+  }
+  if (Array.isArray(v)) return concatBytes([u8(0x90 | v.length), ...v.map(mp)]);
+  if (typeof v === "object") {
+    const ent = Object.entries(v as Record<string, unknown>).filter(([, x]) => x !== undefined);
+    return concatBytes([u8(0x80 | ent.length), ...ent.flatMap(([k, x]) => [mp(k), mp(x)])]);
+  }
+  throw new Error("bad msgpack");
+}
+export function actionHash(
   action: Record<string, unknown>,
-  walletAddress: string,
   nonce: number,
-): VaultSignTypedDataInput {
+  vaultAddress?: string,
+  expiresAfter?: number,
+): Hex {
+  const parts = [mp(action), uint(nonce, 8), vaultAddress ? u8(1) : u8(0)];
+  if (vaultAddress)
+    parts.push(
+      toBytes((vaultAddress.startsWith("0x") ? vaultAddress : `0x${vaultAddress}`) as Hex),
+    );
+  if (expiresAfter !== undefined) parts.push(u8(0), uint(expiresAfter, 8));
+  return keccak256(concatBytes(parts));
+}
+export function createL1TypedData(
+  action: Record<string, unknown>,
+  nonce: number,
+  isMainnet = true,
+  vaultAddress?: string,
+  expiresAfter?: number,
+): Omit<VaultSignTypedDataInput, "agentId"> {
   return {
-    agentId: "",
     domain: {
       name: "Exchange",
       version: "1",
@@ -118,129 +213,236 @@ function createTypedData(
       verifyingContract: "0x0000000000000000000000000000000000000000",
     },
     types: {
-      HyperliquidOrder: [
-        { name: "wallet", type: "address" },
-        { name: "asset", type: "string" },
-        { name: "side", type: "string" },
-        { name: "size", type: "string" },
-        { name: "leverage", type: "uint256" },
-        { name: "reduceOnly", type: "bool" },
-        { name: "nonce", type: "uint64" },
-        { name: "action", type: "string" },
+      Agent: [
+        { name: "source", type: "string" },
+        { name: "connectionId", type: "bytes32" },
       ],
     },
-    primaryType: "HyperliquidOrder",
+    primaryType: "Agent",
     value: {
-      wallet: walletAddress,
-      asset: order.asset,
-      side: order.side,
-      size: String(order.size),
-      leverage: order.leverage,
-      reduceOnly: order.reduceOnly ?? false,
-      nonce,
-      action: JSON.stringify(action),
+      source: isMainnet ? "a" : "b",
+      connectionId: actionHash(action, nonce, vaultAddress, expiresAfter),
     },
   };
+}
+async function signAction(
+  pk: Hex,
+  action: Record<string, unknown>,
+  opts: SignOptions = {},
+): Promise<SignedOrder> {
+  const nonce = opts.nonce ?? Date.now();
+  const td = createL1TypedData(
+    action,
+    nonce,
+    opts.isMainnet ?? true,
+    opts.vaultAddress,
+    opts.expiresAfter,
+  );
+  const hex = await privateKeyToAccount(pk).signTypedData({
+    domain: td.domain,
+    types: td.types,
+    primaryType: td.primaryType,
+    message: td.value,
+  } as never);
+  const s = parseSignature(hex);
+  return signedOrderSchema.parse({
+    action,
+    nonce,
+    signature: { r: s.r, s: s.s, v: Number(s.v) },
+    vaultAddress: opts.vaultAddress,
+    expiresAfter: opts.expiresAfter,
+  });
+}
+export const signOrder = (
+  walletPrivateKey: Hex,
+  order: HyperliquidOrder,
+  options: SignOptions = {},
+) =>
+  signAction(walletPrivateKey, toExchangeAction(order), {
+    ...options,
+    nonce: options.nonce ?? order.nonce,
+  });
+async function postExchange(signed: SignedOrder, transport: HyperliquidTransport, baseUrl: string) {
+  const r = await transport.fetch(`${baseUrl}/exchange`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(signedOrderSchema.parse(signed)),
+  });
+  const j = await r.json().catch(() => null);
+  if (!r.ok) throw new Error(`Hyperliquid exchange returned ${r.status}: ${JSON.stringify(j)}`);
+  return j;
+}
+export async function submitOrder(
+  signedOrder: SignedOrder,
+  options: { transport?: HyperliquidTransport; baseUrl?: string } = {},
+) {
+  return normalizeOrderResult(
+    await postExchange(
+      signedOrder,
+      options.transport ?? { fetch },
+      options.baseUrl ?? DEFAULT_BASE_URL,
+    ),
+  );
+}
+export async function getOpenOrders(
+  userAddress: string,
+  options: { transport?: HyperliquidTransport; baseUrl?: string } = {},
+): Promise<Order[]> {
+  const r = await (options.transport ?? { fetch }).fetch(
+    `${options.baseUrl ?? DEFAULT_BASE_URL}/info`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ type: "openOrders", user: userAddress }),
+    },
+  );
+  const j = await r.json().catch(() => null);
+  if (!r.ok) throw new Error(`Hyperliquid info returned ${r.status}`);
+  return (Array.isArray(j) ? j : []).map((o) =>
+    openOrderSchema.parse({ ...(o as Record<string, unknown>), raw: o }),
+  );
+}
+export async function cancelOrder(
+  walletPrivateKey: Hex,
+  input: CancelOrderInput,
+  options: SignOptions & { transport?: HyperliquidTransport; baseUrl?: string } = {},
+) {
+  const raw = await postExchange(
+    await signAction(walletPrivateKey, toCancelAction(input), {
+      ...options,
+      nonce: options.nonce ?? input.nonce,
+    }),
+    options.transport ?? { fetch },
+    options.baseUrl ?? DEFAULT_BASE_URL,
+  );
+  return normalizeCancelResult(raw, String(input.orderId));
 }
 
 export class HyperliquidAdapter {
   private readonly transport: HyperliquidTransport;
   private readonly baseUrl: string;
-
+  private readonly isMainnet: boolean;
   constructor(
     private readonly vault: VaultClient,
     private readonly agentId: string,
     private readonly walletAddress: string,
-    options: HyperliquidAdapterOptions = {},
+    private readonly options: HyperliquidAdapterOptions = {},
   ) {
     this.transport = options.transport ?? { fetch };
     this.baseUrl = options.baseUrl ?? DEFAULT_BASE_URL;
+    this.isMainnet = options.isMainnet ?? !/testnet/i.test(this.baseUrl);
   }
-
   async signOrder(order: HyperliquidOrder): Promise<SignedOrder> {
-    const parsed = hyperliquidOrderSchema.parse(order);
-    const nonce = parsed.nonce ?? Date.now();
-    const action = toExchangeAction(parsed);
-    const typedData = createTypedData(parsed, action, this.walletAddress, nonce);
-    const signatureHex = await this.vault.signTypedData({
-      ...typedData,
-      agentId: this.agentId,
-    });
-    const signature = parseSignature(signatureHex as Hex);
-    if (signature.v === undefined) {
-      throw new Error("Vault returned an EIP-712 signature without a recovery id");
-    }
-
+    const nonce = order.nonce ?? Date.now();
+    const action = toExchangeAction(order);
+    const td = createL1TypedData(
+      action,
+      nonce,
+      this.isMainnet,
+      this.options.vaultAddress,
+      this.options.expiresAfter,
+    );
+    const hex = await this.vault.signTypedData({ ...td, agentId: this.agentId });
+    const s = parseSignature(hex as Hex);
     return signedOrderSchema.parse({
       action,
       nonce,
-      signature: {
-        r: signature.r,
-        s: signature.s,
-        v: Number(signature.v),
-      },
+      signature: { r: s.r, s: s.s, v: Number(s.v) },
+      vaultAddress: this.options.vaultAddress,
+      expiresAfter: this.options.expiresAfter,
     });
   }
-
-  async submitOrder(signed: SignedOrder): Promise<OrderResult> {
-    const body = signedOrderSchema.parse(signed);
-    const response = await this.transport.fetch(`${this.baseUrl}/exchange`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-    });
-    const json = (await response.json().catch(() => null)) as unknown;
-    if (!response.ok) {
-      throw new Error(`Hyperliquid exchange returned ${response.status}`);
-    }
-    return normalizeOrderResult(json);
+  submitOrder(signed: SignedOrder) {
+    return submitOrder(signed, { transport: this.transport, baseUrl: this.baseUrl });
   }
-
+  getOpenOrders(userAddress = this.walletAddress) {
+    return getOpenOrders(userAddress, { transport: this.transport, baseUrl: this.baseUrl });
+  }
+  async cancelOrder(input: CancelOrderInput) {
+    const nonce = input.nonce ?? Date.now();
+    const action = toCancelAction(input);
+    const td = createL1TypedData(
+      action,
+      nonce,
+      this.isMainnet,
+      this.options.vaultAddress,
+      this.options.expiresAfter,
+    );
+    const hex = await this.vault.signTypedData({ ...td, agentId: this.agentId });
+    const s = parseSignature(hex as Hex);
+    return normalizeCancelResult(
+      await postExchange(
+        signedOrderSchema.parse({
+          action,
+          nonce,
+          signature: { r: s.r, s: s.s, v: Number(s.v) },
+          vaultAddress: this.options.vaultAddress,
+          expiresAfter: this.options.expiresAfter,
+        }),
+        this.transport,
+        this.baseUrl,
+      ),
+      String(input.orderId),
+    );
+  }
   async getPositions(): Promise<Position[]> {
-    const response = await this.transport.fetch(`${this.baseUrl}/info`, {
+    const r = await this.transport.fetch(`${this.baseUrl}/info`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ type: "clearinghouseState", user: this.walletAddress }),
     });
-    const json = (await response.json().catch(() => null)) as unknown;
-    if (!response.ok) {
-      throw new Error(`Hyperliquid info returned ${response.status}`);
-    }
-    return normalizePositions(json);
+    const j = await r.json().catch(() => null);
+    if (!r.ok) throw new Error(`Hyperliquid info returned ${r.status}`);
+    return normalizePositions(j);
   }
 }
-
+function firstStatus(raw: unknown) {
+  const data = ((raw as any).response?.data?.statuses ?? []) as unknown[];
+  return data[0];
+}
 function normalizeOrderResult(raw: unknown): OrderResult {
-  const payload = raw as Record<string, unknown>;
-  const statuses = Array.isArray((payload.response as Record<string, unknown> | undefined)?.data)
-    ? ((payload.response as Record<string, unknown>).data as unknown[])
-    : [];
-  const first = statuses[0] as Record<string, unknown> | undefined;
+  const st = firstStatus(raw);
+  if (st && typeof st === "object" && "error" in st)
+    return orderResultSchema.parse({
+      status: "rejected",
+      error: String((st as any).error),
+      txHash: null,
+      raw,
+    });
+  const resting = (st as any)?.resting,
+    filled = (st as any)?.filled,
+    src = filled ?? resting ?? {};
   return orderResultSchema.parse({
-    orderId: String(first?.oid ?? first?.orderId ?? crypto.randomUUID()),
-    status: String(payload.status ?? "submitted"),
-    filledQty: typeof first?.totalSz === "number" ? first.totalSz : undefined,
-    avgPrice: typeof first?.avgPx === "number" ? first.avgPx : undefined,
+    orderId: src.oid !== undefined ? String(src.oid) : undefined,
+    status: filled ? "filled" : resting ? "resting" : String((raw as any).status ?? "submitted"),
+    filledQty: filled?.totalSz ? Number(filled.totalSz) : undefined,
+    avgPrice: filled?.avgPx ? Number(filled.avgPx) : undefined,
     txHash: null,
     raw,
   });
 }
-
+function normalizeCancelResult(raw: unknown, orderId: string): CancelResult {
+  const st = firstStatus(raw);
+  if (st && typeof st === "object" && "error" in st)
+    return cancelResultSchema.parse({
+      orderId,
+      status: "rejected",
+      error: String((st as any).error),
+      raw,
+    });
+  return cancelResultSchema.parse({ orderId, status: String(st ?? "submitted"), raw });
+}
 function normalizePositions(raw: unknown): Position[] {
-  const payload = raw as { assetPositions?: Array<{ position?: Record<string, unknown> }> };
-  return (payload.assetPositions ?? []).map((entry) => {
-    const position = entry.position ?? {};
-    const size = Number(position.szi ?? 0);
+  return (((raw as any).assetPositions ?? []) as any[]).map((e) => {
+    const p = e.position ?? {};
+    const size = Number(p.szi ?? 0);
     return positionSchema.parse({
-      asset: String(position.coin ?? ""),
+      asset: String(p.coin ?? ""),
       side: size > 0 ? "long" : size < 0 ? "short" : "flat",
       size: Math.abs(size),
-      entryPrice: position.entryPx ? Number(position.entryPx) : undefined,
-      unrealizedPnlUsd: position.unrealizedPnl ? Number(position.unrealizedPnl) : undefined,
-      leverage:
-        typeof position.leverage === "object" && position.leverage
-          ? Number((position.leverage as Record<string, unknown>).value ?? 0)
-          : undefined,
+      entryPrice: p.entryPx ? Number(p.entryPx) : undefined,
+      unrealizedPnlUsd: p.unrealizedPnl ? Number(p.unrealizedPnl) : undefined,
+      leverage: p.leverage ? Number(p.leverage.value ?? 0) : undefined,
     });
   });
 }

--- a/packages/venue-hyperliquid/src/testnet.integration.test.ts
+++ b/packages/venue-hyperliquid/src/testnet.integration.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import { getOpenOrders } from "./index";
+
+const TESTNET_URL = "https://api.hyperliquid-testnet.xyz";
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+describe("Hyperliquid testnet smoke", () => {
+  test("reads open orders without submitting a live order", async () => {
+    if (process.env.HL_TESTNET_SMOKE !== "1") {
+      expect(true).toBe(true);
+      return;
+    }
+    const orders = await getOpenOrders(process.env.HL_TESTNET_USER ?? ZERO_ADDRESS, {
+      baseUrl: TESTNET_URL,
+    });
+    expect(Array.isArray(orders)).toBe(true);
+  });
+});

--- a/packages/venue-hyperliquid/tsconfig.json
+++ b/packages/venue-hyperliquid/tsconfig.json
@@ -1,9 +1,6 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": "src",
-    "types": ["node"]
-  },
-  "include": ["src"]
+  "compilerOptions": { "outDir": "dist", "rootDir": "src", "types": ["node"] },
+  "include": ["src/index.ts"],
+  "exclude": ["src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary

- Implements Hyperliquid L1 action signing in `@stwd/venue-hyperliquid` using msgpack action hashing + viem EIP-712 `Agent` signatures.
- Adds order submission, open-order retrieval, and cancel helpers against Hyperliquid `/exchange` and `/info`.
- Wires Steward `POST /v1/trade/hyperliquid/order` to accept the Day 2 request shape (`coin`, `side`, `size`, optional `limitPx`, `reduceOnly`) while preserving legacy `asset`/`leverage` compatibility.
- Updates vault EIP-712 signing to honor the venue-scoped wallet (`venue: "hyperliquid"`).

## Signing reference vectors

Unit coverage verifies the documented HL wire action:

```json
{
  "type": "order",
  "orders": [{ "a": 0, "b": true, "p": "30000", "s": "0.02", "r": false, "t": { "limit": { "tif": "Ioc" } } }],
  "grouping": "na"
}
```

The L1 EIP-712 payload uses:

```json
{
  "domain": { "name": "Exchange", "version": "1", "chainId": 1337, "verifyingContract": "0x0000000000000000000000000000000000000000" },
  "primaryType": "Agent",
  "message": { "source": "b", "connectionId": "keccak(msgpack(action) || nonce || vault flag)" }
}
```

## Sample request / response

Request:

```json
{
  "sessionId": "ses_...",
  "coin": "BTC",
  "side": "buy",
  "size": 0.02,
  "limitPx": "30000",
  "reduceOnly": false
}
```

Response:

```json
{
  "ok": true,
  "data": {
    "orderId": "77738308",
    "status": "resting",
    "filledQty": 0,
    "avgPrice": 0,
    "txHash": null
  }
}
```

## Testnet smoke

- Added gated smoke test for `https://api.hyperliquid-testnet.xyz` (`HL_TESTNET_SMOKE=1`) that only calls `/info` `openOrders`.
- No live or testnet orders are submitted by automated tests.

## Verification

- `bun test packages/venue-hyperliquid/src/index.test.ts packages/venue-hyperliquid/src/testnet.integration.test.ts`
- `bun run --filter @stwd/venue-hyperliquid build`
- `bun run --filter @stwd/api build`

## Notes

- Base: `feat/sprint4-day1-trade-sessions-2026-05-22`.
- Unrelated local change remains in `packages/react/src/components/WalletLogin.EVM.tsx` and is not included in this PR.
