### PR TITLE
feat(steward): Sprint 4 Day 5 — eliza-plugin submitTrade action + provisioning

### DIFF
--- a/packages/eliza-plugin/package.json
+++ b/packages/eliza-plugin/package.json
@@ -31,6 +31,8 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "test": "vitest run"
+    "lint": "bunx @biomejs/biome check src package.json tsconfig.json tsup.config.ts vitest.config.ts",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
   }
 }

--- a/packages/eliza-plugin/src/__tests__/plugin.test.ts
+++ b/packages/eliza-plugin/src/__tests__/plugin.test.ts
@@ -15,6 +15,7 @@ describe("@stwd/eliza-plugin", () => {
     const names = stewardPlugin.actions?.map((a) => a.name);
     expect(names).toContain("STEWARD_SIGN_TRANSACTION");
     expect(names).toContain("STEWARD_TRANSFER");
+    expect(names).toContain("SUBMIT_TRADE");
   });
 
   it("registers expected providers", () => {

--- a/packages/eliza-plugin/src/__tests__/submit-trade.test.ts
+++ b/packages/eliza-plugin/src/__tests__/submit-trade.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { parseSubmitTrade, submitTradeAction } from "../actions/submit-trade.js";
+
+const OLD_ENV = { ...process.env };
+
+function setTradeEnv() {
+  process.env.STEWARD_API_URL = "https://steward.example";
+  process.env.STEWARD_JWT = "jwt-test";
+  process.env.STEWARD_TRADE_SESSION_ID = "ses_test";
+}
+
+function mockMemory(text: string) {
+  return { content: { text } } as any;
+}
+
+describe("SUBMIT_TRADE action", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.env = { ...OLD_ENV };
+    setTradeEnv();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.env = { ...OLD_ENV };
+  });
+
+  it("has the expected Eliza action metadata", () => {
+    expect(submitTradeAction.name).toBe("SUBMIT_TRADE");
+    expect(submitTradeAction.similes).toEqual(["buy", "sell", "long", "short", "perp", "trade"]);
+    expect(submitTradeAction.description).toContain("Requires active trade session");
+    expect(submitTradeAction.examples?.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("parses buy/long market orders from text", () => {
+    expect(parseSubmitTrade(mockMemory("buy 0.05 BTC long"), undefined, {} as any)).toMatchObject({
+      coin: "BTC",
+      side: "buy",
+      size: 0.05,
+      sessionId: "ses_test",
+    });
+  });
+
+  it("parses sell/short limit orders from text", () => {
+    expect(
+      parseSubmitTrade(mockMemory("sell 0.1 ETH short limit 3450"), undefined, {} as any),
+    ).toMatchObject({
+      coin: "ETH",
+      side: "sell",
+      size: 0.1,
+      limitPx: 3450,
+    });
+  });
+
+  it("validate checks env and active session", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ ok: true, data: { status: "active" } }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      submitTradeAction.validate({} as any, mockMemory("buy 0.01 BTC") as any),
+    ).resolves.toBe(true);
+    expect(fetchMock).toHaveBeenCalledWith("https://steward.example/v1/trade/sessions/ses_test", {
+      headers: { Authorization: "Bearer jwt-test", Accept: "application/json" },
+    });
+  });
+
+  it("posts parsed order with Bearer JWT and returns confirmation", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            ok: true,
+            data: { orderId: "oid_1", status: "open", filledQty: 0, avgPrice: 0, txHash: null },
+          }),
+          { status: 200 },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await submitTradeAction.handler(
+      {} as any,
+      mockMemory("buy 0.01 BTC long") as any,
+    );
+
+    expect(result?.success).toBe(true);
+    expect(result?.text).toBe(
+      "submitted: long 0.01 BTC at market via hyperliquid. order id oid_1.",
+    );
+    const [, request] = fetchMock.mock.calls[0];
+    expect(fetchMock.mock.calls[0][0]).toBe("https://steward.example/v1/trade/hyperliquid/order");
+    expect(request.headers.Authorization).toBe("Bearer jwt-test");
+    expect(JSON.parse(request.body)).toMatchObject({
+      sessionId: "ses_test",
+      coin: "BTC",
+      side: "buy",
+      size: 0.01,
+      leverage: 1,
+      reduceOnly: false,
+    });
+  });
+
+  it("surfaces policy violations from Steward", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({ code: "policy-violation", reason: "leverage-cap: max 2x" }),
+            {
+              status: 400,
+            },
+          ),
+      ),
+    );
+
+    const result = await submitTradeAction.handler({} as any, mockMemory("buy 1 BTC 3x") as any);
+    expect(result?.success).toBe(false);
+    expect(result?.text).toBe("policy rejected: leverage-cap: max 2x");
+  });
+
+  it("handles expired JWT gracefully", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(JSON.stringify({ error: "invalid-jwt" }), { status: 401 })),
+    );
+
+    const result = await submitTradeAction.handler({} as any, mockMemory("buy 0.01 BTC") as any);
+    expect(result?.success).toBe(false);
+    expect(result?.text).toBe("session expired or invalid, ask shadow to refresh");
+  });
+
+  it("handles venue/server errors gracefully", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(JSON.stringify({ error: "HL unavailable" }), { status: 502 })),
+    );
+
+    const result = await submitTradeAction.handler({} as any, mockMemory("buy 0.01 BTC") as any);
+    expect(result?.success).toBe(false);
+    expect(result?.text).toBe("venue error, will retry later");
+  });
+});

--- a/packages/eliza-plugin/src/actions/submit-trade.ts
+++ b/packages/eliza-plugin/src/actions/submit-trade.ts
@@ -1,48 +1,309 @@
+import { existsSync, readFileSync } from "node:fs";
 import type {
   Action,
   ActionExample,
   ActionResult,
+  HandlerCallback,
   HandlerOptions,
   IAgentRuntime,
   Memory,
   State,
 } from "@elizaos/core";
-import type { StewardService } from "../services/StewardService.js";
+
+const ACTION_NAME = "SUBMIT_TRADE";
+const DEFAULT_LEVERAGE = 1;
+
+type Coin = "BTC" | "ETH";
+type Side = "buy" | "sell";
+
+interface ParsedTrade {
+  coin: Coin;
+  side: Side;
+  size: number;
+  leverage: number;
+  sessionId: string;
+  limitPx?: number;
+  reduceOnly?: boolean;
+}
+
+interface StewardOrderResponse {
+  orderId?: string;
+  status?: string;
+  filledQty?: number;
+  avgPrice?: number;
+  txHash?: string | null;
+  [key: string]: unknown;
+}
+
+interface StewardErrorResponse {
+  code?: string;
+  reason?: string;
+  error?: string;
+  message?: string;
+  [key: string]: unknown;
+}
+
+function optionParameters(
+  options?: HandlerOptions | Record<string, unknown>,
+): Record<string, unknown> {
+  const maybe = options as { parameters?: Record<string, unknown> } | undefined;
+  return maybe?.parameters ?? {};
+}
+
+function messageText(message: Memory): string {
+  const content = message.content as { text?: unknown } | undefined;
+  return typeof content?.text === "string" ? content.text : "";
+}
+
+function envValue(runtime: IAgentRuntime, key: string): string | undefined {
+  const runtimeWithGetSetting = runtime as IAgentRuntime & {
+    getSetting?: (name: string) => string | undefined;
+  };
+  const setting = runtimeWithGetSetting.getSetting?.(key);
+  if (typeof setting === "string" && setting.trim()) return setting.trim();
+  const value = process.env[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function stewardJwt(runtime: IAgentRuntime): string | undefined {
+  const file = envValue(runtime, "STEWARD_JWT_FILE");
+  if (file && existsSync(file)) {
+    const value = readFileSync(file, "utf8").trim();
+    if (value) return value;
+  }
+  return envValue(runtime, "STEWARD_JWT");
+}
+
+function stewardApiUrl(runtime: IAgentRuntime): string | undefined {
+  return envValue(runtime, "STEWARD_API_URL")?.replace(/\/+$/, "");
+}
+
+function configuredSessionId(runtime: IAgentRuntime): string | undefined {
+  return (
+    envValue(runtime, "STEWARD_TRADE_SESSION_ID") ??
+    envValue(runtime, "STEWARD_SESSION_ID") ??
+    envValue(runtime, "TRADE_SESSION_ID")
+  );
+}
+
+function parseNumber(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value.replace(/[$,]/g, ""));
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+function parseBoolean(value: unknown): boolean | undefined {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    if (/^(true|yes|1)$/i.test(value)) return true;
+    if (/^(false|no|0)$/i.test(value)) return false;
+  }
+  return undefined;
+}
+
+function parseSide(text: string, rawSide?: unknown): Side | undefined {
+  if (typeof rawSide === "string") {
+    if (/^(buy|long)$/i.test(rawSide)) return "buy";
+    if (/^(sell|short)$/i.test(rawSide)) return "sell";
+  }
+  if (/\b(buy|long)\b/i.test(text)) return "buy";
+  if (/\b(sell|short)\b/i.test(text)) return "sell";
+  return undefined;
+}
+
+function parseCoin(text: string, rawCoin?: unknown): Coin | undefined {
+  const value = typeof rawCoin === "string" ? rawCoin : undefined;
+  const source = `${value ?? ""} ${text}`;
+  if (/\bBTC\b|\bbitcoin\b/i.test(source)) return "BTC";
+  if (/\bETH\b|\bethereum\b/i.test(source)) return "ETH";
+  return undefined;
+}
+
+function parseSize(text: string, params: Record<string, unknown>, coin?: Coin): number | undefined {
+  const explicit = parseNumber(params.size ?? params.amount ?? params.qty ?? params.quantity);
+  if (explicit !== undefined) return explicit;
+
+  if (coin) {
+    const beforeCoin = new RegExp(
+      `(?:^|\\s)([$]?[0-9][0-9_,]*(?:\\.[0-9]+)?)\\s*${coin}\\b`,
+      "i",
+    ).exec(text);
+    if (beforeCoin?.[1]) return parseNumber(beforeCoin[1]);
+  }
+
+  const firstNumber = /(?:^|\s)([$]?[0-9][0-9_,]*(?:\.[0-9]+)?)(?=\s|$)/.exec(text);
+  return firstNumber?.[1] ? parseNumber(firstNumber[1]) : undefined;
+}
+
+function parseLimitPx(text: string, params: Record<string, unknown>): number | undefined {
+  const explicit = parseNumber(params.limitPx ?? params.limitPrice ?? params.price);
+  if (explicit !== undefined) return explicit;
+  const match = /(?:limit(?:\s*(?:price|px))?|at|@)\s*[$]?([0-9][0-9_,]*(?:\.[0-9]+)?)/i.exec(text);
+  return match?.[1] ? parseNumber(match[1]) : undefined;
+}
+
+function parseLeverage(text: string, params: Record<string, unknown>): number {
+  const explicit = parseNumber(params.leverage);
+  if (explicit !== undefined) return explicit;
+  const match = /\b([0-9]+(?:\.[0-9]+)?)\s*x\b/i.exec(text);
+  return match?.[1] ? (parseNumber(match[1]) ?? DEFAULT_LEVERAGE) : DEFAULT_LEVERAGE;
+}
+
+export function parseSubmitTrade(
+  message: Memory,
+  options?: HandlerOptions | Record<string, unknown>,
+  runtime?: IAgentRuntime,
+): ParsedTrade | null {
+  const text = messageText(message);
+  const params = optionParameters(options);
+  const coin = parseCoin(text, params.coin ?? params.asset);
+  const side = parseSide(text, params.side);
+  const size = parseSize(text, params, coin);
+  const sessionId =
+    (typeof params.sessionId === "string" && params.sessionId.trim()) ||
+    (runtime ? configuredSessionId(runtime) : undefined);
+
+  if (!coin || !side || size === undefined || !Number.isFinite(size) || size <= 0 || !sessionId) {
+    return null;
+  }
+
+  return {
+    coin,
+    side,
+    size,
+    leverage: parseLeverage(text, params),
+    sessionId,
+    limitPx: parseLimitPx(text, params),
+    reduceOnly: parseBoolean(params.reduceOnly) ?? /\b(reduce[- ]?only|close)\b/i.test(text),
+  };
+}
+
+async function parseResponseJson(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return undefined;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { error: text };
+  }
+}
+
+function unwrapOrderResponse(data: unknown): StewardOrderResponse {
+  if (data && typeof data === "object" && "data" in data) {
+    return ((data as { data?: unknown }).data ?? {}) as StewardOrderResponse;
+  }
+  return (data ?? {}) as StewardOrderResponse;
+}
+
+function policyReason(data: unknown): string {
+  const error = (data ?? {}) as StewardErrorResponse;
+  return error.reason ?? error.error ?? error.message ?? "order violates trading policy";
+}
+
+function confirmation(parsed: ParsedTrade, order: StewardOrderResponse): string {
+  const direction = parsed.side === "buy" ? "long" : "short";
+  const px = parsed.limitPx ? ` limit ${parsed.limitPx}` : " at market";
+  const orderId = order.orderId ?? "unknown";
+  return `submitted: ${direction} ${parsed.size} ${parsed.coin}${px} via hyperliquid. order id ${orderId}.`;
+}
+
+async function postOrder(
+  runtime: IAgentRuntime,
+  parsed: ParsedTrade,
+): Promise<{ status: number; data: unknown }> {
+  const apiUrl = stewardApiUrl(runtime);
+  const jwt = stewardJwt(runtime);
+  if (!apiUrl || !jwt) {
+    throw new Error("STEWARD_API_URL and STEWARD_JWT are required");
+  }
+
+  const idempotencyKey = crypto.randomUUID();
+  const response = await fetch(`${apiUrl}/v1/trade/hyperliquid/order`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${jwt}`,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      "Idempotency-Key": idempotencyKey,
+    },
+    body: JSON.stringify({
+      sessionId: parsed.sessionId,
+      coin: parsed.coin,
+      side: parsed.side,
+      size: parsed.size,
+      leverage: parsed.leverage,
+      limitPx: parsed.limitPx,
+      reduceOnly: parsed.reduceOnly ?? false,
+      idempotencyKey,
+    }),
+  });
+  return { status: response.status, data: await parseResponseJson(response) };
+}
+
+async function hasActiveSession(runtime: IAgentRuntime): Promise<boolean> {
+  const apiUrl = stewardApiUrl(runtime);
+  const jwt = stewardJwt(runtime);
+  const sessionId = configuredSessionId(runtime);
+  if (!apiUrl || !jwt || !sessionId) return false;
+
+  try {
+    const response = await fetch(`${apiUrl}/v1/trade/sessions/${encodeURIComponent(sessionId)}`, {
+      headers: { Authorization: `Bearer ${jwt}`, Accept: "application/json" },
+    });
+    if (!response.ok) return false;
+    const data = await parseResponseJson(response);
+    const session =
+      data && typeof data === "object" && "data" in data
+        ? (data as { data?: Record<string, unknown> }).data
+        : data;
+    return (
+      !!session &&
+      typeof session === "object" &&
+      (session as { status?: unknown }).status === "active"
+    );
+  } catch {
+    return false;
+  }
+}
 
 export const submitTradeAction: Action = {
-  name: "STEWARD_SUBMIT_TRADE",
-  description: "Submit a Hyperliquid BTC or ETH perp order through Steward trade sessions",
-  similes: ["submit trade", "place perp order", "trade hyperliquid"],
+  name: ACTION_NAME,
+  description:
+    "Submit a perp order via Steward custodial. Requires active trade session. Subject to policy: $/day cap, allowed assets, leverage cap.",
+  similes: ["buy", "sell", "long", "short", "perp", "trade"],
   parameters: [
     {
-      name: "sessionId",
-      description: "Active Steward trade session id",
-      required: true,
-      schema: { type: "string" },
-    },
-    {
-      name: "asset",
-      description: "BTC or ETH",
-      required: true,
+      name: "coin",
+      description: "Perp market coin, BTC or ETH",
+      required: false,
       schema: { type: "string", enum: ["BTC", "ETH"] },
     },
     {
       name: "side",
-      description: "buy or sell",
-      required: true,
-      schema: { type: "string", enum: ["buy", "sell"] },
+      description: "buy/long or sell/short",
+      required: false,
+      schema: { type: "string", enum: ["buy", "sell", "long", "short"] },
     },
     {
       name: "size",
-      description: "Order size in USD for MVP policy accounting",
-      required: true,
+      description: "Order size in base coin units",
+      required: false,
+      schema: { type: "number" },
+    },
+    {
+      name: "limitPx",
+      description: "Optional Hyperliquid limit price. Omit for market order.",
+      required: false,
       schema: { type: "number" },
     },
     {
       name: "leverage",
-      description: "Leverage, max 2",
-      required: true,
-      schema: { type: "number" },
+      description: "Order leverage, max 2x by Phase 1 policy",
+      required: false,
+      schema: { type: "number", default: DEFAULT_LEVERAGE },
     },
     {
       name: "reduceOnly",
@@ -50,69 +311,129 @@ export const submitTradeAction: Action = {
       required: false,
       schema: { type: "boolean" },
     },
+    {
+      name: "sessionId",
+      description: "Active Steward trade session id. Defaults to STEWARD_TRADE_SESSION_ID.",
+      required: false,
+      schema: { type: "string" },
+    },
   ],
   examples: [
     [
+      { name: "{{user1}}", content: { text: "buy 0.01 BTC long" } },
       {
-        name: "{{user1}}",
+        name: "{{agent}}",
         content: {
-          text: "Buy $25 BTC perp at 2x using session ses_123",
-          action: "STEWARD_SUBMIT_TRADE",
+          text: "submitted: long 0.01 BTC at market via hyperliquid. order id <id>.",
+          action: ACTION_NAME,
+        },
+      },
+    ],
+    [
+      { name: "{{user1}}", content: { text: "sell 0.02 ETH short" } },
+      {
+        name: "{{agent}}",
+        content: {
+          text: "submitted: short 0.02 ETH at market via hyperliquid. order id <id>.",
+          action: ACTION_NAME,
+        },
+      },
+    ],
+    [
+      { name: "{{user1}}", content: { text: "buy 0.01 BTC limit 65000" } },
+      {
+        name: "{{agent}}",
+        content: {
+          text: "submitted: long 0.01 BTC limit 65000 via hyperliquid. order id <id>.",
+          action: ACTION_NAME,
+        },
+      },
+    ],
+    [
+      { name: "{{user1}}", content: { text: "buy 2 BTC long 10x" } },
+      {
+        name: "{{agent}}",
+        content: {
+          text: "policy rejected: leverage-cap: leverage 10 exceeds max 2.",
+          action: ACTION_NAME,
+        },
+      },
+    ],
+    [
+      { name: "{{user1}}", content: { text: "long 0.01 BTC" } },
+      {
+        name: "{{agent}}",
+        content: {
+          text: "venue error, will retry later",
+          action: ACTION_NAME,
         },
       },
     ],
   ] as ActionExample[][],
 
   async validate(runtime: IAgentRuntime, _message: Memory, _state?: State): Promise<boolean> {
-    const steward = runtime.getService("steward" as any) as StewardService | null;
-    return steward?.isConnected() ?? false;
+    return hasActiveSession(runtime);
   },
 
   async handler(
     runtime: IAgentRuntime,
-    _message: Memory,
+    message: Memory,
     _state?: State,
-    options?: HandlerOptions,
+    options?: HandlerOptions | Record<string, unknown>,
+    callback?: HandlerCallback,
   ): Promise<ActionResult> {
-    const steward = runtime.getService("steward" as any) as StewardService | null;
-    if (!steward?.isConnected()) {
-      return {
-        success: false,
-        error: "Steward SDK is not configured",
-        text: "Trading is unavailable because Steward is not configured for this agent.",
-      };
+    const parsed = parseSubmitTrade(message, options, runtime);
+    if (!parsed) {
+      const text =
+        "I need coin, side, size, and an active Steward trade session to submit a trade.";
+      await callback?.({ text, action: ACTION_NAME }, ACTION_NAME);
+      return { success: false, error: "Missing required trade fields", text };
     }
 
-    const params = options?.parameters ?? {};
-    if (!params.sessionId || !params.asset || !params.side || !params.size || !params.leverage) {
-      return {
-        success: false,
-        error: "Missing required trade parameters",
-        text: "I need sessionId, asset, side, size, and leverage to submit a trade.",
-      };
-    }
-
+    let status: number;
+    let data: unknown;
     try {
-      const result = await steward.submitHyperliquidOrder({
-        sessionId: String(params.sessionId),
-        asset: params.asset as "BTC" | "ETH",
-        side: params.side as "buy" | "sell",
-        size: Number(params.size),
-        leverage: Number(params.leverage),
-        reduceOnly: Boolean(params.reduceOnly),
-      });
-      return {
-        success: true,
-        text: `Hyperliquid order submitted. Status: ${result.status}. Order: ${result.orderId}`,
-        data: result as any,
-      };
+      const result = await postOrder(runtime, parsed);
+      status = result.status;
+      data = result.data;
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return {
-        success: false,
-        error: msg,
-        text: `Trade was not submitted: ${msg}`,
-      };
+      const text =
+        err instanceof Error && /STEWARD_API_URL|STEWARD_JWT/.test(err.message)
+          ? "Trading is unavailable because Steward JWT/API env is not configured."
+          : "venue error, will retry later";
+      await callback?.({ text, action: ACTION_NAME }, ACTION_NAME);
+      return { success: false, error: err instanceof Error ? err.message : String(err), text };
     }
+
+    if (status >= 200 && status < 300) {
+      const order = unwrapOrderResponse(data);
+      const text = confirmation(parsed, order);
+      await callback?.({ text, action: ACTION_NAME }, ACTION_NAME);
+      return { success: true, text, data: order as any };
+    }
+
+    if (status === 400) {
+      const reason = policyReason(data);
+      const text = `policy rejected: ${reason}`;
+      await callback?.({ text, action: ACTION_NAME }, ACTION_NAME);
+      return { success: false, error: reason, text, data: data as any };
+    }
+
+    if (status === 401) {
+      const text = "session expired or invalid, ask shadow to refresh";
+      await callback?.({ text, action: ACTION_NAME }, ACTION_NAME);
+      return { success: false, error: "unauthorized", text };
+    }
+
+    if (status >= 500) {
+      const text = "venue error, will retry later";
+      await callback?.({ text, action: ACTION_NAME }, ACTION_NAME);
+      return { success: false, error: `steward ${status}`, text };
+    }
+
+    const reason = policyReason(data);
+    const text = `Trade was not submitted: ${reason}`;
+    await callback?.({ text, action: ACTION_NAME }, ACTION_NAME);
+    return { success: false, error: reason, text, data: data as any };
   },
 };

--- a/packages/eliza-plugin/src/services/StewardService.ts
+++ b/packages/eliza-plugin/src/services/StewardService.ts
@@ -74,6 +74,7 @@ export class StewardService extends Service {
     this.client = new StewardClient({
       baseUrl: this.pluginConfig.apiUrl,
       apiKey: this.pluginConfig.apiKey,
+      bearerToken: this.pluginConfig.bearerToken,
       tenantId: this.pluginConfig.tenantId,
     });
 
@@ -119,6 +120,7 @@ export class StewardService extends Service {
     return {
       apiUrl,
       apiKey: settings.apiKey ?? env.STEWARD_API_KEY,
+      bearerToken: settings.bearerToken ?? env.STEWARD_JWT,
       agentId: settings.agentId ?? env.STEWARD_AGENT_ID ?? runtimeState.agentId ?? "default",
       tenantId: settings.tenantId ?? env.STEWARD_TENANT_ID,
       autoRegister: settings.autoRegister ?? env.STEWARD_AUTO_REGISTER !== "false",

--- a/packages/eliza-plugin/src/types.ts
+++ b/packages/eliza-plugin/src/types.ts
@@ -5,6 +5,7 @@
 export interface StewardPluginConfig {
   apiUrl: string;
   apiKey?: string;
+  bearerToken?: string;
   agentId: string;
   tenantId?: string;
   autoRegister: boolean;

--- a/scripts/provision-agent.ts
+++ b/scripts/provision-agent.ts
@@ -1,0 +1,121 @@
+#!/usr/bin/env bun
+import { createHash } from "node:crypto";
+import { getDb, tenants } from "@stwd/db";
+import { eq } from "drizzle-orm";
+import { createAgentToken, DEFAULT_TENANT_ID, vault } from "../packages/api/src/services/context";
+import { TradeSessionManager } from "../packages/trade-sessions/src/index";
+
+const USAGE = `Usage:
+  bun run scripts/provision-agent.ts <agentId> <ownerAddress>
+
+Example:
+  bun run scripts/provision-agent.ts sol 0x15fc6086064afe50ccf4c70000c55cecb6e17777`;
+
+function requireArg(value: string | undefined, name: string): string {
+  if (!value?.trim()) {
+    console.error(`Missing ${name}\n\n${USAGE}`);
+    process.exit(1);
+  }
+  return value.trim();
+}
+
+async function ensureDefaultTenant(ownerAddress: string) {
+  const db = getDb();
+  const [existing] = await db
+    .select({ id: tenants.id })
+    .from(tenants)
+    .where(eq(tenants.id, DEFAULT_TENANT_ID));
+  if (existing) return;
+
+  await db.insert(tenants).values({
+    id: DEFAULT_TENANT_ID,
+    name: "Default Steward Tenant",
+    apiKeyHash: createHash("sha256").update(`provision-agent:${DEFAULT_TENANT_ID}`).digest("hex"),
+    ownerAddress,
+  });
+}
+
+async function ensureAgent(agentId: string, ownerAddress: string) {
+  try {
+    const created = await vault.createAgent(
+      DEFAULT_TENANT_ID,
+      agentId,
+      agentId === "sol" ? "Sol" : agentId,
+      ownerAddress,
+    );
+    return { agent: created, created: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (!/already exists/i.test(message)) throw err;
+    const existing = await vault.getAgent(DEFAULT_TENANT_ID, agentId);
+    if (!existing) throw new Error(`Agent ${agentId} already exists but could not be loaded`);
+    return { agent: existing, created: false };
+  }
+}
+
+async function ensureHyperliquidWallet(agentId: string) {
+  try {
+    const existing = await vault.getWallet({ agentId, venue: "hyperliquid" });
+    return { wallet: existing, created: false };
+  } catch {
+    const created = await vault.createWallet({
+      agentId,
+      venue: "hyperliquid",
+      chainType: "evm",
+      purpose: "hyperliquid-deposit",
+    });
+    return { wallet: created, created: true };
+  }
+}
+
+async function main() {
+  const agentId = requireArg(process.argv[2], "agentId");
+  const ownerAddress = requireArg(process.argv[3], "ownerAddress");
+
+  await ensureDefaultTenant(ownerAddress);
+
+  const { agent, created: agentCreated } = await ensureAgent(agentId, ownerAddress);
+  const { wallet, created: walletCreated } = await ensureHyperliquidWallet(agentId);
+
+  const sessions = new TradeSessionManager();
+  const session = await sessions.createSession({
+    agentId,
+    tenantId: DEFAULT_TENANT_ID,
+    venue: "hyperliquid",
+    walletId: wallet.address,
+    ttlSeconds: 15 * 60,
+    dailyCapUsd: 100,
+    perOrderCapUsd: 100,
+    leverageCap: 2,
+    allowedAssets: ["BTC", "ETH"],
+  });
+
+  const jwt = await createAgentToken(agentId, DEFAULT_TENANT_ID, "15m", [
+    "trade:read",
+    "trade:hyperliquid:write",
+  ]);
+
+  console.log("Steward Sol provisioning complete");
+  console.log("================================");
+  console.log(`Agent ID: ${agent.id} (${agentCreated ? "created" : "existing"})`);
+  console.log(`Owner address: ${ownerAddress}`);
+  console.log(`HL deposit address: ${wallet.address} (${walletCreated ? "created" : "existing"})`);
+  console.log(`Trade session ID: ${session.id}`);
+  console.log(`Trade session expires: ${session.expiresAt.toISOString()}`);
+  console.log("Policy: $100/day cap, $100/order cap, BTC+ETH only, max 2x leverage");
+  console.log("");
+  console.log("Set these in Sol's eliza-cloud container env:");
+  console.log(`STEWARD_AGENT_ID=${agentId}`);
+  console.log("STEWARD_API_URL=https://api.steward.fi");
+  console.log(`STEWARD_TRADE_SESSION_ID=${session.id}`);
+  console.log(`STEWARD_JWT=${jwt}`);
+  console.log("");
+  console.log(
+    "Manual funding step: bridge/fund the HL deposit address above with $20 USDC on Arbitrum first. Do not submit live orders from automation.",
+  );
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.stack || err.message : err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- replaces the placeholder eliza-plugin trade action with `SUBMIT_TRADE` using the ElizaOS Action interface
- parses natural language orders like `buy 0.01 BTC long`, optional limit price/reduce-only/leverage, then POSTs to `/v1/trade/hyperliquid/order` with `Authorization: Bearer $STEWARD_JWT`
- handles policy 400s, JWT/session 401s, and 5xx venue failures with trainer-friendly replies
- adds unit coverage for parsing, active-session validation, successful mocked order submission, policy rejection, expired JWT, and venue error paths
- adds `scripts/provision-agent.ts` to create/confirm Sol, create/reuse the Hyperliquid venue wallet, create a $100/day BTC+ETH 2x session, and print env for Sol's container

## Action API
- Action name: `SUBMIT_TRADE`
- Similes: `buy`, `sell`, `long`, `short`, `perp`, `trade`
- Env: `STEWARD_API_URL`, `STEWARD_JWT` or `STEWARD_JWT_FILE`, plus `STEWARD_TRADE_SESSION_ID`/`STEWARD_SESSION_ID`
- Endpoint: `POST $STEWARD_API_URL/v1/trade/hyperliquid/order`

## Provisioning usage
```bash
cd /home/shad0w/projects/steward-fi
bun run scripts/provision-agent.ts sol 0x15fc6086064afe50ccf4c70000c55cecb6e17777
```

The script prints:
- HL deposit address for Shadow to fund manually with $20 USDC on Arbitrum
- Trade session ID
- `STEWARD_AGENT_ID`, `STEWARD_API_URL`, `STEWARD_TRADE_SESSION_ID`, and `STEWARD_JWT` env values

## Sample E2E flow
1. Run the provisioning script.
2. Shadow funds the printed HL deposit address manually.
3. Sol container has `@stwd/eliza-plugin`, `STEWARD_API_URL`, refreshed JWT env/file, and `STEWARD_TRADE_SESSION_ID`.
4. Agent says `buy 0.01 BTC long`.
5. Plugin submits to Steward, Steward checks policy/session, vault signs, Hyperliquid adapter submits.
6. Plugin replies: `submitted: long 0.01 BTC at market via hyperliquid. order id <id>.`

## Verification
- `bun run --filter @stwd/eliza-plugin lint`
- `bun run --filter @stwd/eliza-plugin typecheck`
- `bun run --filter @stwd/eliza-plugin test`

No live Hyperliquid orders were submitted.
