### PR TITLE
fix(trade): raise session caps and price market IOC orders

### DIFF
--- a/packages/api/src/routes/trade.ts
+++ b/packages/api/src/routes/trade.ts
@@ -3,6 +3,7 @@ import { evaluateTradeOrder } from "@stwd/policy-engine";
 import { checkRateLimit } from "@stwd/redis";
 import { TradeSessionManager } from "@stwd/trade-sessions";
 import {
+  getMarketableLimitPx,
   HyperliquidAdapter,
   type HyperliquidOrder,
   hyperliquidAssetSchema,
@@ -27,11 +28,11 @@ const createSessionSchema = z.object({
   agentId: z.string().min(1).optional(),
   venue: z.literal("hyperliquid"),
   walletAddress: z.string().min(1).optional(),
-  dailyCap: z.number().positive().max(1_000).default(300),
-  perOrderCap: z.number().positive().max(500).default(100),
-  leverageCap: z.number().positive().max(10).default(5),
+  dailyCap: z.number().positive().max(50_000).default(300),
+  perOrderCap: z.number().positive().max(10_000).default(100),
+  leverageCap: z.number().positive().max(50).default(5),
   allowedAssets: z
-    .array(z.enum(["BTC", "ETH", "BNB", "SOL"]))
+    .array(z.enum(["BTC", "ETH", "BNB", "SOL", "AVAX", "ARB", "OP"]))
     .min(1)
     .default(["BTC", "ETH", "BNB"]),
   ttlSeconds: z.number().int().positive().max(86_400).default(3_600),
@@ -345,44 +346,11 @@ tradeRoutes.post("/hyperliquid/order", async (c) => {
     return c.json<ApiResponse>({ ok: false, error: "Active Hyperliquid session required" }, 403);
   }
   const coin = body.coin ?? body.asset;
-  const sizeUsd = body.size * Number(body.limitPx ?? body.limitPrice ?? 1);
-  const policy = evaluateTradeOrder(
-    {
-      venue: session.venue,
-      allowedVenues: [session.venue],
-      leverageCap: session.leverageCap,
-      allowedAssets: session.allowedAssets,
-      dailySpendUsd: session.dailySpendUsd,
-      dailyCapUsd: session.dailyCapUsd,
-      perOrderCapUsd: session.perOrderCapUsd,
-    },
-    {
-      venue: "hyperliquid",
-      asset: coin,
-      leverage: body.leverage,
-      estimatedOrderUsd: sizeUsd,
-    },
-  );
-  if (!policy.allow) {
-    const reason = policy.reason ?? "order violates trading policy";
-    await auditTradeEvent(tenantId, agentId, "trade.order.policy-rejected", {
-      sessionId: session.id,
-      venue: "hyperliquid",
-      asset: coin,
-      leverage: body.leverage,
-      size: body.size,
-      limitPx: body.limitPx ?? body.limitPrice,
-      sizeUsd,
-      dailySpendUsd: session.dailySpendUsd,
-      reason,
-    });
-    return c.json({ code: "policy-violation", reason }, 400);
-  }
 
   // Re-validate against the Hyperliquid adapter's strict asset enum. The
-  // session-level allowlist (BTC/ETH) is covered by evaluateTradeOrder; this
-  // second check defends the adapter contract if the session ever permits
-  // a coin the adapter does not implement.
+  // session-level allowlist is covered by evaluateTradeOrder; this second check
+  // defends the adapter contract if the session ever permits a coin the adapter
+  // does not implement.
   const parsedAsset = hyperliquidAssetSchema.safeParse(coin);
   if (!parsedAsset.success) {
     const reason = `asset-allowlist: asset ${coin} is not supported by Hyperliquid adapter`;
@@ -393,6 +361,52 @@ tradeRoutes.post("/hyperliquid/order", async (c) => {
       reason,
     });
     return c.json({ code: "policy-violation", reason }, 400);
+  }
+
+  const sessionPolicy = {
+    venue: session.venue,
+    allowedVenues: [session.venue],
+    leverageCap: session.leverageCap,
+    allowedAssets: session.allowedAssets,
+    dailySpendUsd: session.dailySpendUsd,
+    dailyCapUsd: session.dailyCapUsd,
+    perOrderCapUsd: session.perOrderCapUsd,
+  };
+  const orderPolicy = (estimatedOrderUsd: number) =>
+    evaluateTradeOrder(sessionPolicy, {
+      venue: "hyperliquid",
+      asset: coin,
+      leverage: body.leverage,
+      estimatedOrderUsd,
+    });
+  const rejectPolicy = async (reason: string, sizeUsd: number, limitPx?: string | number) => {
+    await auditTradeEvent(tenantId, agentId, "trade.order.policy-rejected", {
+      sessionId: session.id,
+      venue: "hyperliquid",
+      asset: coin,
+      leverage: body.leverage,
+      size: body.size,
+      limitPx,
+      sizeUsd,
+      dailySpendUsd: session.dailySpendUsd,
+      reason,
+    });
+    return c.json({ code: "policy-violation", reason }, 400);
+  };
+
+  const limitPx = body.limitPx ?? body.limitPrice;
+  if (limitPx === undefined) {
+    const preliminaryPolicy = orderPolicy(0);
+    if (!preliminaryPolicy.allow) {
+      return rejectPolicy(preliminaryPolicy.reason ?? "order violates trading policy", 0);
+    }
+  }
+  const policyLimitPx =
+    limitPx ?? (await getMarketableLimitPx(parsedAsset.data, body.side === "buy"));
+  const sizeUsd = body.size * Number(policyLimitPx);
+  const policy = orderPolicy(sizeUsd);
+  if (!policy.allow) {
+    return rejectPolicy(policy.reason ?? "order violates trading policy", sizeUsd, policyLimitPx);
   }
 
   const walletAddress = session.walletId;
@@ -406,7 +420,7 @@ tradeRoutes.post("/hyperliquid/order", async (c) => {
     asset: parsedAsset.data,
     side: body.side,
     size: body.size,
-    limitPx: body.limitPx ?? body.limitPrice,
+    limitPx: policyLimitPx,
     leverage: body.leverage,
     reduceOnly: body.reduceOnly,
   };

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @stwd/sdk Changelog
 
+## Unreleased
+
+- Expands Hyperliquid trade asset types to include BNB, SOL, AVAX, ARB, and OP.
+
 ## 0.10.0
 
 BREAKING-CHANGES:

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -94,6 +94,8 @@ export interface SignMessageResult {
   signature: string;
 }
 
+export type HyperliquidAsset = "BTC" | "ETH" | "BNB" | "SOL" | "AVAX" | "ARB" | "OP";
+
 export interface CreateTradeSessionInput {
   agentId?: string;
   venue: "hyperliquid";
@@ -101,7 +103,7 @@ export interface CreateTradeSessionInput {
   dailyCap?: number;
   perOrderCap?: number;
   leverageCap?: number;
-  allowedAssets?: Array<"BTC" | "ETH">;
+  allowedAssets?: HyperliquidAsset[];
   ttlSeconds?: number;
 }
 
@@ -127,7 +129,7 @@ export interface TradeSessionState {
   remainingCapUsd: number;
   perOrderCapUsd: number;
   leverageCap: number;
-  allowedAssets: Array<"BTC" | "ETH">;
+  allowedAssets: HyperliquidAsset[];
   createdAt: string;
   expiresAt: string;
   revokedAt?: string | null;
@@ -136,7 +138,7 @@ export interface TradeSessionState {
 
 export interface HyperliquidSubmitOrderInput {
   sessionId: string;
-  asset: "BTC" | "ETH";
+  asset: HyperliquidAsset;
   side: "buy" | "sell";
   size: number;
   leverage: number;

--- a/packages/trade-sessions/src/index.ts
+++ b/packages/trade-sessions/src/index.ts
@@ -6,7 +6,7 @@ import { z } from "zod";
 export const tradeSessionStatusSchema = z.enum(["active", "revoked", "expired"]);
 export type TradeSessionStatus = z.infer<typeof tradeSessionStatusSchema>;
 
-export const allowedAssetSchema = z.enum(["BTC", "ETH", "BNB", "SOL"]);
+export const allowedAssetSchema = z.enum(["BTC", "ETH", "BNB", "SOL", "AVAX", "ARB", "OP"]);
 export type AllowedAsset = z.infer<typeof allowedAssetSchema>;
 
 export const tradeSessionSchema = z.object({

--- a/packages/venue-hyperliquid/src/index.test.ts
+++ b/packages/venue-hyperliquid/src/index.test.ts
@@ -4,6 +4,7 @@ import {
   actionHash,
   cancelOrder,
   createL1TypedData,
+  getMarketableLimitPx,
   getOpenOrders,
   HyperliquidAdapter,
   type HyperliquidTransport,
@@ -62,6 +63,63 @@ describe("Hyperliquid L1 signing", () => {
     expect(signed.signature.r).toMatch(/^0x[0-9a-f]{64}$/);
     expect(signed.signature.s).toMatch(/^0x[0-9a-f]{64}$/);
     expect([27, 28]).toContain(signed.signature.v);
+  });
+
+  test("uses explicit limit price without fetching the book", async () => {
+    const signed = await signOrder(
+      PRIVATE_KEY,
+      { coin: "BTC", side: "buy", size: 0.02, limitPx: "30000" },
+      {
+        nonce: NONCE,
+        isMainnet: false,
+        transport: {
+          async fetch() {
+            throw new Error("unexpected fetch");
+          },
+        },
+      },
+    );
+    expect(signed.action).toMatchObject({
+      orders: [{ p: "30000" }],
+    });
+  });
+
+  test("auto-computes marketable IOC price from best ask for buys", async () => {
+    const signed = await signOrder(
+      PRIVATE_KEY,
+      { coin: "BTC", side: "buy", size: 0.02 },
+      {
+        nonce: NONCE,
+        isMainnet: false,
+        transport: {
+          async fetch(_input, init) {
+            expect(JSON.parse(String(init?.body))).toEqual({ type: "l2Book", coin: "BTC" });
+            return new Response(
+              JSON.stringify({ levels: [[{ px: "29900", sz: "1" }], [{ px: "30000", sz: "1" }]] }),
+              { status: 200 },
+            );
+          },
+        },
+      },
+    );
+    expect(signed.action).toMatchObject({
+      orders: [{ b: true, p: "30150" }],
+    });
+  });
+
+  test("auto-computes marketable IOC price from best bid for sells", async () => {
+    const px = await getMarketableLimitPx("ETH", false, {
+      transport: {
+        async fetch(_input, init) {
+          expect(JSON.parse(String(init?.body))).toEqual({ type: "l2Book", coin: "ETH" });
+          return new Response(
+            JSON.stringify({ levels: [[{ px: "2500", sz: "1" }], [{ px: "2510", sz: "1" }]] }),
+            { status: 200 },
+          );
+        },
+      },
+    });
+    expect(px).toBe("2487.5");
   });
 
   test("adapter signs with vault-provided EIP-712 and submits HL payload", async () => {

--- a/packages/venue-hyperliquid/src/index.ts
+++ b/packages/venue-hyperliquid/src/index.ts
@@ -2,11 +2,20 @@ import { concatBytes, type Hex, keccak256, parseSignature, toBytes } from "viem"
 import { privateKeyToAccount } from "viem/accounts";
 import { z } from "zod";
 
-export const hyperliquidAssetSchema = z.enum(["BTC", "ETH", "BNB", "SOL"]);
+export const hyperliquidAssetSchema = z.enum(["BTC", "ETH", "BNB", "SOL", "AVAX", "ARB", "OP"]);
 export type HyperliquidAsset = z.infer<typeof hyperliquidAssetSchema>;
-// HL perp universe indices. Verified live 2026-05-24:
-// 0=BTC, 1=ETH, 5=SOL, 7=BNB. Source: POST api.hyperliquid.xyz/info {"type":"meta"}.universe
-const ASSET_INDEX: Record<HyperliquidAsset, number> = { BTC: 0, ETH: 1, SOL: 5, BNB: 7 };
+// HL perp universe indices. Verified live 2026-05-26:
+// 0=BTC, 1=ETH, 5=SOL, 6=AVAX, 7=BNB, 9=OP, 11=ARB.
+// Source: POST api.hyperliquid.xyz/info {"type":"meta"}.universe
+const ASSET_INDEX: Record<HyperliquidAsset, number> = {
+  BTC: 0,
+  ETH: 1,
+  SOL: 5,
+  AVAX: 6,
+  BNB: 7,
+  OP: 9,
+  ARB: 11,
+};
 const DEFAULT_BASE_URL = "https://api.hyperliquid.xyz";
 
 export const hyperliquidOrderSchema = z.object({
@@ -22,7 +31,7 @@ export const hyperliquidOrderSchema = z.object({
     .object({ limit: z.object({ tif: z.enum(["Alo", "Ioc", "Gtc"]) }).optional() })
     .optional(),
   reduceOnly: z.boolean().default(false),
-  leverage: z.number().positive().max(20).optional(),
+  leverage: z.number().positive().max(50).optional(),
   nonce: z.number().int().positive().optional(),
 });
 export type HyperliquidOrder = z.input<typeof hyperliquidOrderSchema>;
@@ -117,6 +126,52 @@ function dec(v: unknown, fallback?: string) {
     .toFixed(8)
     .replace(/\.0+$/, "")
     .replace(/(\.\d*?)0+$/, "$1");
+}
+function hasExplicitLimitPx(order: HyperliquidOrder): boolean {
+  return order.limitPx !== undefined || order.limitPrice !== undefined;
+}
+function bestBookPrice(levels: unknown, side: "bid" | "ask"): number {
+  const index = side === "bid" ? 0 : 1;
+  const level = (levels as unknown[])?.[index] as unknown[] | undefined;
+  const px = (level?.[0] as { px?: unknown } | undefined)?.px;
+  const n = Number(px);
+  if (!Number.isFinite(n) || n <= 0) throw new Error(`missing Hyperliquid best ${side}`);
+  return n;
+}
+function roundMarketablePx(px: number, isBuy: boolean): string {
+  const sigFigs = 5;
+  const scale = 10 ** (Math.floor(Math.log10(px)) - sigFigs + 1);
+  const rounded = (isBuy ? Math.ceil(px / scale) : Math.floor(px / scale)) * scale;
+  return dec(rounded);
+}
+export async function getMarketableLimitPx(
+  coin: HyperliquidAsset,
+  isBuy: boolean,
+  options: { transport?: HyperliquidTransport; baseUrl?: string } = {},
+): Promise<string> {
+  const transport = options.transport ?? { fetch };
+  const r = await transport.fetch(`${options.baseUrl ?? DEFAULT_BASE_URL}/info`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ type: "l2Book", coin }),
+  });
+  const j = await r.json().catch(() => null);
+  if (!r.ok) throw new Error(`Hyperliquid info returned ${r.status}`);
+  const levels = (j as { levels?: unknown })?.levels;
+  const px = isBuy ? bestBookPrice(levels, "ask") * 1.005 : bestBookPrice(levels, "bid") * 0.995;
+  return roundMarketablePx(px, isBuy);
+}
+async function withMarketableLimitPx(
+  order: HyperliquidOrder,
+  options: { transport?: HyperliquidTransport; baseUrl?: string } = {},
+): Promise<HyperliquidOrder> {
+  if (hasExplicitLimitPx(order)) return order;
+  const p = hyperliquidOrderSchema.parse(order);
+  const coin = p.coin ?? p.asset;
+  if (!coin) throw new Error("coin is required");
+  const isBuy = p.isBuy ?? (p.side ? p.side === "buy" : undefined);
+  if (isBuy === undefined) throw new Error("side is required");
+  return { ...order, limitPx: await getMarketableLimitPx(coin, isBuy, options) };
 }
 function normalized(order: HyperliquidOrder) {
   const p = hyperliquidOrderSchema.parse(order);
@@ -255,15 +310,17 @@ async function signAction(
     expiresAfter: opts.expiresAfter,
   });
 }
-export const signOrder = (
+export const signOrder = async (
   walletPrivateKey: Hex,
   order: HyperliquidOrder,
-  options: SignOptions = {},
-) =>
-  signAction(walletPrivateKey, toExchangeAction(order), {
+  options: SignOptions & { transport?: HyperliquidTransport; baseUrl?: string } = {},
+) => {
+  const resolved = await withMarketableLimitPx(order, options);
+  return signAction(walletPrivateKey, toExchangeAction(resolved), {
     ...options,
     nonce: options.nonce ?? order.nonce,
   });
+};
 async function postExchange(signed: SignedOrder, transport: HyperliquidTransport, baseUrl: string) {
   const r = await transport.fetch(`${baseUrl}/exchange`, {
     method: "POST",
@@ -336,7 +393,11 @@ export class HyperliquidAdapter {
   }
   async signOrder(order: HyperliquidOrder): Promise<SignedOrder> {
     const nonce = order.nonce ?? Date.now();
-    const action = toExchangeAction(order);
+    const resolved = await withMarketableLimitPx(order, {
+      transport: this.transport,
+      baseUrl: this.baseUrl,
+    });
+    const action = toExchangeAction(resolved);
     const td = createL1TypedData(
       action,
       nonce,


### PR DESCRIPTION
## Summary
- raise Hyperliquid trade session schema ceilings while keeping conservative defaults
- extend Hyperliquid asset allowlists to BTC, ETH, BNB, SOL, AVAX, ARB, and OP
- price missing market IOC limits from the L2 book with 50 bps tolerance and use the resolved price for policy notional checks

## Tests
- bun run lint
- bun run typecheck
- bun test packages/venue-hyperliquid/src/index.test.ts
- cd packages/api && bun test src/__tests__/trade-policy-audit.test.ts

Co-authored-by: wakesync <shadow@shad0w.xyz>