### PR TITLE
feat(trade): add NEAR HYPE ZEC XMR assets

### DIFF
--- a/packages/api/src/routes/trade.ts
+++ b/packages/api/src/routes/trade.ts
@@ -32,7 +32,7 @@ const createSessionSchema = z.object({
   perOrderCap: z.number().positive().max(10_000).default(100),
   leverageCap: z.number().positive().max(50).default(5),
   allowedAssets: z
-    .array(z.enum(["BTC", "ETH", "BNB", "SOL", "AVAX", "ARB", "OP"]))
+    .array(z.enum(["BTC", "ETH", "BNB", "SOL", "AVAX", "ARB", "OP", "NEAR", "HYPE", "ZEC", "XMR"]))
     .min(1)
     .default(["BTC", "ETH", "BNB"]),
   ttlSeconds: z.number().int().positive().max(86_400).default(3_600),

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Expands Hyperliquid trade asset types to include NEAR, HYPE, ZEC, XMR.
 - Expands Hyperliquid trade asset types to include BNB, SOL, AVAX, ARB, and OP.
 
 ## 0.10.0

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -94,7 +94,18 @@ export interface SignMessageResult {
   signature: string;
 }
 
-export type HyperliquidAsset = "BTC" | "ETH" | "BNB" | "SOL" | "AVAX" | "ARB" | "OP";
+export type HyperliquidAsset =
+  | "BTC"
+  | "ETH"
+  | "BNB"
+  | "SOL"
+  | "AVAX"
+  | "ARB"
+  | "OP"
+  | "NEAR"
+  | "HYPE"
+  | "ZEC"
+  | "XMR";
 
 export interface CreateTradeSessionInput {
   agentId?: string;

--- a/packages/trade-sessions/src/index.ts
+++ b/packages/trade-sessions/src/index.ts
@@ -6,7 +6,19 @@ import { z } from "zod";
 export const tradeSessionStatusSchema = z.enum(["active", "revoked", "expired"]);
 export type TradeSessionStatus = z.infer<typeof tradeSessionStatusSchema>;
 
-export const allowedAssetSchema = z.enum(["BTC", "ETH", "BNB", "SOL", "AVAX", "ARB", "OP"]);
+export const allowedAssetSchema = z.enum([
+  "BTC",
+  "ETH",
+  "BNB",
+  "SOL",
+  "AVAX",
+  "ARB",
+  "OP",
+  "NEAR",
+  "HYPE",
+  "ZEC",
+  "XMR",
+]);
 export type AllowedAsset = z.infer<typeof allowedAssetSchema>;
 
 export const tradeSessionSchema = z.object({

--- a/packages/venue-hyperliquid/src/index.ts
+++ b/packages/venue-hyperliquid/src/index.ts
@@ -2,10 +2,23 @@ import { concatBytes, type Hex, keccak256, parseSignature, toBytes } from "viem"
 import { privateKeyToAccount } from "viem/accounts";
 import { z } from "zod";
 
-export const hyperliquidAssetSchema = z.enum(["BTC", "ETH", "BNB", "SOL", "AVAX", "ARB", "OP"]);
+export const hyperliquidAssetSchema = z.enum([
+  "BTC",
+  "ETH",
+  "BNB",
+  "SOL",
+  "AVAX",
+  "ARB",
+  "OP",
+  "NEAR",
+  "HYPE",
+  "ZEC",
+  "XMR",
+]);
 export type HyperliquidAsset = z.infer<typeof hyperliquidAssetSchema>;
-// HL perp universe indices. Verified live 2026-05-26:
-// 0=BTC, 1=ETH, 5=SOL, 6=AVAX, 7=BNB, 9=OP, 11=ARB.
+// HL perp universe indices. Verified live 2026-05-27:
+// 0=BTC, 1=ETH, 5=SOL, 6=AVAX, 7=BNB, 9=OP, 11=ARB,
+// 74=NEAR, 159=HYPE, 214=ZEC, 224=XMR.
 // Source: POST api.hyperliquid.xyz/info {"type":"meta"}.universe
 const ASSET_INDEX: Record<HyperliquidAsset, number> = {
   BTC: 0,
@@ -15,6 +28,10 @@ const ASSET_INDEX: Record<HyperliquidAsset, number> = {
   BNB: 7,
   OP: 9,
   ARB: 11,
+  NEAR: 74,
+  HYPE: 159,
+  ZEC: 214,
+  XMR: 224,
 };
 const DEFAULT_BASE_URL = "https://api.hyperliquid.xyz";
 


### PR DESCRIPTION
## Summary
- add NEAR, HYPE, ZEC, and XMR to Hyperliquid asset schemas
- add verified Hyperliquid universe indices for the new assets
- expand SDK asset types and changelog

## Tests
- bun run lint
- bun run typecheck
- bun test packages/venue-hyperliquid/src/index.test.ts

Co-authored-by: wakesync <shadow@shad0w.xyz>