### PR TITLE
fix: P0 security findings from the 2026-05-30 audit (auth, tenants, vault, approvals)

### DIFF
--- a/packages/api/src/__tests__/approval-principals.test.ts
+++ b/packages/api/src/__tests__/approval-principals.test.ts
@@ -1,0 +1,190 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+
+const SKIP = !process.env.DATABASE_URL;
+
+import { signAccessToken } from "@stwd/auth";
+import {
+  agents,
+  approvalQueue,
+  getDb,
+  policies,
+  runMigrations,
+  tenants,
+  transactions,
+  users,
+  userTenants,
+} from "@stwd/db";
+import { and, eq, inArray } from "drizzle-orm";
+
+const unique = crypto.randomUUID();
+const TEST_TENANT = `test-4eyes-${unique}`;
+const TEST_AGENT = `test-4eyes-agent-${unique}`;
+const REQUESTER_USER_ID = crypto.randomUUID();
+const APPROVER_USER_ID = crypto.randomUUID();
+const POLICY_ID = `test-4eyes-policy-${unique}`;
+
+let app: { request: (input: string | Request, init?: RequestInit) => Promise<Response> };
+let requesterToken: string;
+let approverToken: string;
+let queuedTxId: string;
+
+beforeAll(async () => {
+  if (SKIP) return;
+
+  await runMigrations();
+
+  process.env.STEWARD_MASTER_PASSWORD ||= "test-master-password-for-4eyes";
+
+  const [{ Hono }, { tenantAuth }, { approvalRoutes }, { vaultRoutes }] = await Promise.all([
+    import("hono"),
+    import("../services/context"),
+    import("../routes/approvals"),
+    import("../routes/vault"),
+  ]);
+  const testApp = new Hono();
+  testApp.use("/vault/*", (c, next) => tenantAuth(c, next));
+  testApp.use("/approvals", (c, next) => tenantAuth(c, next));
+  testApp.use("/approvals/*", (c, next) => tenantAuth(c, next));
+  testApp.route("/vault", vaultRoutes);
+  testApp.route("/approvals", approvalRoutes);
+  app = testApp;
+
+  const db = getDb();
+
+  await db.insert(tenants).values({
+    id: TEST_TENANT,
+    name: "4-eyes Test Tenant",
+    apiKeyHash: `unused-${unique}`,
+  });
+
+  await db.insert(users).values([
+    {
+      id: REQUESTER_USER_ID,
+      email: `requester-${unique}@example.com`,
+      walletAddress: "0x0000000000000000000000000000000000000001",
+    },
+    {
+      id: APPROVER_USER_ID,
+      email: `approver-${unique}@example.com`,
+      walletAddress: "0x0000000000000000000000000000000000000002",
+    },
+  ]);
+
+  await db.insert(userTenants).values([
+    { userId: REQUESTER_USER_ID, tenantId: TEST_TENANT, role: "admin" },
+    { userId: APPROVER_USER_ID, tenantId: TEST_TENANT, role: "admin" },
+  ]);
+
+  await db.insert(agents).values({
+    id: TEST_AGENT,
+    tenantId: TEST_TENANT,
+    name: "4-eyes Test Agent",
+    walletAddress: "0x1234567890123456789012345678901234567890",
+  });
+
+  await db.insert(policies).values({
+    id: POLICY_ID,
+    agentId: TEST_AGENT,
+    type: "auto-approve-threshold",
+    enabled: true,
+    config: { threshold: "0" },
+  });
+
+  requesterToken = await signAccessToken({
+    address: "0x0000000000000000000000000000000000000001",
+    tenantId: TEST_TENANT,
+    userId: REQUESTER_USER_ID,
+  });
+  approverToken = await signAccessToken({
+    address: "0x0000000000000000000000000000000000000002",
+    tenantId: TEST_TENANT,
+    userId: APPROVER_USER_ID,
+  });
+});
+
+afterAll(async () => {
+  if (SKIP) return;
+
+  const db = getDb();
+  await db.delete(approvalQueue).where(eq(approvalQueue.agentId, TEST_AGENT));
+  await db.delete(transactions).where(eq(transactions.agentId, TEST_AGENT));
+  await db.delete(policies).where(eq(policies.agentId, TEST_AGENT));
+  await db.delete(agents).where(eq(agents.id, TEST_AGENT));
+  await db.delete(userTenants).where(eq(userTenants.tenantId, TEST_TENANT));
+  await db.delete(users).where(inArray(users.id, [REQUESTER_USER_ID, APPROVER_USER_ID]));
+  await db.delete(tenants).where(eq(tenants.id, TEST_TENANT));
+});
+
+function bearer(token: string) {
+  return {
+    Authorization: `Bearer ${token}`,
+    "Content-Type": "application/json",
+  };
+}
+
+describe.skipIf(SKIP)("approval principal tracking and 4-eyes enforcement", () => {
+  it("records the authenticated requester when approval is queued", async () => {
+    const res = await app.request(`/vault/${TEST_AGENT}/sign`, {
+      method: "POST",
+      headers: bearer(requesterToken),
+      body: JSON.stringify({
+        to: "0x0000000000000000000000000000000000000003",
+        value: "1",
+        chainId: 84532,
+      }),
+    });
+
+    expect(res.status).toBe(202);
+    const body = await res.json();
+    expect(body.data.status).toBe("pending_approval");
+    queuedTxId = body.data.txId;
+
+    const db = getDb();
+    const [approval] = await db
+      .select()
+      .from(approvalQueue)
+      .where(and(eq(approvalQueue.txId, queuedTxId), eq(approvalQueue.agentId, TEST_AGENT)));
+
+    expect(approval.requestedByType).toBe("user");
+    expect(approval.requestedById).toBe(REQUESTER_USER_ID);
+  });
+
+  it("rejects approval by the same authenticated principal", async () => {
+    const res = await app.request(`/approvals/${queuedTxId}/approve`, {
+      method: "POST",
+      headers: bearer(requesterToken),
+      body: JSON.stringify({ approvedBy: APPROVER_USER_ID }),
+    });
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toContain("separation of duties");
+  });
+
+  it("allows a different authenticated principal and ignores body-supplied approvedBy", async () => {
+    const res = await app.request(`/approvals/${queuedTxId}/approve`, {
+      method: "POST",
+      headers: bearer(approverToken),
+      body: JSON.stringify({ approvedBy: "spoofed-approver", comment: "approved" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.status).toBe("approved");
+    expect(body.data.resolvedByType).toBe("user");
+    expect(body.data.resolvedById).toBe(APPROVER_USER_ID);
+    expect(body.data.resolvedBy).toBe(`user:${APPROVER_USER_ID}`);
+    expect(body.data.resolvedBy).not.toBe("spoofed-approver");
+
+    const db = getDb();
+    const [approval] = await db
+      .select()
+      .from(approvalQueue)
+      .where(eq(approvalQueue.txId, queuedTxId));
+
+    expect(approval.resolvedByType).toBe("user");
+    expect(approval.resolvedById).toBe(APPROVER_USER_ID);
+    expect(approval.resolvedBy).toBe(`user:${APPROVER_USER_ID}`);
+  });
+});

--- a/packages/api/src/__tests__/auth-wallets.test.ts
+++ b/packages/api/src/__tests__/auth-wallets.test.ts
@@ -247,11 +247,16 @@ describeWithDatabase("wallet auth flows", () => {
       body: JSON.stringify({ message: domainMismatchMessage, signature: domainMismatchSignature }),
     });
 
+    // A domain claiming evil.com is rejected with 401. Depending on env config
+    // the rejection can come from the SIWE allowlist gate ("SIWE domain not
+    // allowed", which runs first when SIWE_ALLOWED_DOMAINS is set) or from the
+    // nonce-context domain binding ("Nonce context mismatch"). Both are valid
+    // rejections of an off-domain message; assert the security outcome (401 +
+    // one of the two domain-rejection errors) rather than coupling to gate order.
     expect(domainRes.status).toBe(401);
-    await expect(domainRes.json()).resolves.toMatchObject({
-      ok: false,
-      error: "Nonce context mismatch",
-    });
+    const domainBody = (await domainRes.json()) as { ok: boolean; error?: string };
+    expect(domainBody.ok).toBe(false);
+    expect(["SIWE domain not allowed", "Nonce context mismatch"]).toContain(domainBody.error);
   });
 
   it("rejects SIWS messages whose signed domain is not on the allowlist", async () => {

--- a/packages/api/src/__tests__/auth-wallets.test.ts
+++ b/packages/api/src/__tests__/auth-wallets.test.ts
@@ -1,8 +1,9 @@
 import { afterAll, beforeEach, describe, expect, it } from "bun:test";
 import { createPrivateKey, sign as cryptoSign } from "node:crypto";
+import { generateApiKey } from "@stwd/auth";
 import { getDb, refreshTokens, tenants, users, userTenants } from "@stwd/db";
 import bs58 from "bs58";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 
 const SKIP = !process.env.DATABASE_URL;
@@ -79,8 +80,18 @@ function signSolanaMessage(message: string): string {
   return bs58.encode(cryptoSign(null, Buffer.from(message, "utf8"), keyObject));
 }
 
-async function fetchNonce(): Promise<string> {
-  const res = await fetch(`${BASE_URL}/auth/nonce`);
+async function fetchNonce(params?: {
+  domain?: string;
+  chainId?: string | number;
+  tenantId?: string;
+}): Promise<string> {
+  const url = new URL(`${BASE_URL}/auth/nonce`);
+  if (params?.domain) url.searchParams.set("domain", params.domain);
+  if (params?.chainId !== undefined) url.searchParams.set("chainId", String(params.chainId));
+
+  const res = await fetch(url, {
+    headers: params?.tenantId ? { "X-Steward-Tenant": params.tenantId } : undefined,
+  });
   const json = (await res.json()) as { nonce: string };
   return json.nonce;
 }
@@ -152,12 +163,103 @@ describeWithDatabase("wallet auth flows", () => {
     expect(payload.userId).toBe(user?.id);
   });
 
+  it("rejects SIWE tenant header pivot when the wallet is not already a member", async () => {
+    const account = privateKeyToAccount(generatePrivateKey());
+    const address = account.address.toLowerCase();
+    const targetTenantId = `test-siwe-target-${address.slice(2, 10)}`;
+    const db = getDb();
+    const apiKeyPair = generateApiKey();
+
+    await db.insert(tenants).values({
+      id: targetTenantId,
+      name: "SIWE Target Tenant",
+      apiKeyHash: apiKeyPair.hash,
+    });
+
+    try {
+      const nonce = await fetchNonce({ chainId: 1, tenantId: targetTenantId });
+      const message = buildSiweMessage(account.address, nonce);
+      const signature = await account.signMessage({ message });
+
+      const res = await fetch(`${BASE_URL}/auth/verify`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Steward-Tenant": targetTenantId,
+        },
+        body: JSON.stringify({ message, signature }),
+      });
+
+      expect(res.status).toBe(403);
+      await expect(res.json()).resolves.toMatchObject({
+        ok: false,
+        error: `Tenant '${targetTenantId}' requires an existing membership`,
+      });
+      createdEvmAddresses.add(address);
+
+      const [user] = await db.select().from(users).where(eq(users.walletAddress, address));
+      expect(user).toBeDefined();
+
+      const targetLinks = user
+        ? await db
+            .select({ id: userTenants.id })
+            .from(userTenants)
+            .where(and(eq(userTenants.userId, user.id), eq(userTenants.tenantId, targetTenantId)))
+        : [];
+      expect(targetLinks).toHaveLength(0);
+    } finally {
+      await db.delete(userTenants).where(eq(userTenants.tenantId, targetTenantId));
+      await db.delete(tenants).where(eq(tenants.id, targetTenantId));
+    }
+  });
+
+  it("rejects SIWE verification when the nonce domain or chain does not match", async () => {
+    const account = privateKeyToAccount(generatePrivateKey());
+
+    const chainNonce = await fetchNonce({ chainId: 1 });
+    const chainMismatchMessage = buildSiweMessage(account.address, chainNonce, 137);
+    const chainMismatchSignature = await account.signMessage({ message: chainMismatchMessage });
+
+    const chainRes = await fetch(`${BASE_URL}/auth/verify`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: chainMismatchMessage, signature: chainMismatchSignature }),
+    });
+
+    expect(chainRes.status).toBe(401);
+    await expect(chainRes.json()).resolves.toMatchObject({
+      ok: false,
+      error: "Nonce context mismatch",
+    });
+
+    const domainNonce = await fetchNonce({ domain: "steward.fi", chainId: 1 });
+    const domainMismatchMessage = buildSiweMessage(account.address, domainNonce)
+      .replace(
+        "steward.fi wants you to sign in with your Ethereum account:",
+        "evil.com wants you to sign in with your Ethereum account:",
+      )
+      .replace("URI: https://steward.fi", "URI: https://evil.com");
+    const domainMismatchSignature = await account.signMessage({ message: domainMismatchMessage });
+
+    const domainRes = await fetch(`${BASE_URL}/auth/verify`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: domainMismatchMessage, signature: domainMismatchSignature }),
+    });
+
+    expect(domainRes.status).toBe(401);
+    await expect(domainRes.json()).resolves.toMatchObject({
+      ok: false,
+      error: "Nonce context mismatch",
+    });
+  });
+
   it("rejects SIWS messages whose signed domain is not on the allowlist", async () => {
     const previousAllowedDomains = process.env.SIWE_ALLOWED_DOMAINS;
     process.env.SIWE_ALLOWED_DOMAINS = "steward.fi";
 
     try {
-      const nonce = await fetchNonce();
+      const nonce = await fetchNonce({ domain: "evil.com", chainId: "mainnet" });
       // Construct a signed message whose domain AND uri both claim evil.com,
       // so the URI-vs-domain consistency check passes and only the domain
       // allowlist check can reject.
@@ -202,7 +304,7 @@ describeWithDatabase("wallet auth flows", () => {
   ]) {
     it(`accepts SIWE auth signed on ${name} (chainId ${chainId})`, async () => {
       const account = privateKeyToAccount(generatePrivateKey());
-      const nonce = await fetchNonce();
+      const nonce = await fetchNonce({ chainId });
       const message = buildSiweMessage(account.address, nonce, chainId);
       const signature = await account.signMessage({ message });
 
@@ -223,7 +325,7 @@ describeWithDatabase("wallet auth flows", () => {
   }
 
   it("verifies a known-good Solana signature and provisions a solana user/tenant", async () => {
-    const nonce = await fetchNonce();
+    const nonce = await fetchNonce({ chainId: "mainnet" });
     const message = buildSiwsMessage(SOLANA_TEST_KEYPAIR.publicKey, nonce);
     const signature = signSolanaMessage(message);
 

--- a/packages/api/src/__tests__/key-export-guards.test.ts
+++ b/packages/api/src/__tests__/key-export-guards.test.ts
@@ -1,0 +1,215 @@
+import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
+import { generateApiKey, signAccessToken } from "@stwd/auth";
+import { getDb, policies, tenants, users, userTenants } from "@stwd/db";
+import { provisionUserWallet, Vault } from "@stwd/vault";
+import { inArray, sql } from "drizzle-orm";
+
+setDefaultTimeout(30000);
+
+const hasDatabaseUrl = Boolean(process.env.DATABASE_URL);
+const describeWithDatabase = hasDatabaseUrl ? describe : describe.skip;
+
+process.env.STEWARD_MASTER_PASSWORD ??= "key-export-guard-master-password";
+process.env.STEWARD_JWT_SECRET ??= "key-export-guard-jwt-secret-with-enough-bytes";
+process.env.STEWARD_AUDIT_HMAC_KEY ??= "key-export-guard-audit-hmac-key-with-enough-bytes";
+
+const RUN_ID = crypto.randomUUID().slice(0, 8);
+const TENANT_ID = `kx-${RUN_ID}`;
+const AGENT_ID = `agent-${RUN_ID}`;
+const ADMIN_USER_ID = crypto.randomUUID();
+const WALLET_USER_ID = crypto.randomUUID();
+const PERSONAL_TENANT_ID = `personal-${WALLET_USER_ID}`;
+
+let app: typeof import("../app")["app"];
+let previousAllowKeyExport: string | undefined;
+
+function freshMfa() {
+  return new Date().toISOString();
+}
+
+async function tenantToken(mfaVerifiedAt?: string) {
+  return signAccessToken(
+    {
+      address: `0x${"1".repeat(40)}`,
+      tenantId: TENANT_ID,
+      userId: ADMIN_USER_ID,
+      ...(mfaVerifiedAt ? { sessionMfaVerifiedAt: mfaVerifiedAt } : {}),
+    },
+    "1h",
+  );
+}
+
+async function userToken(mfaVerifiedAt?: string) {
+  return signAccessToken(
+    {
+      address: `0x${"2".repeat(40)}`,
+      tenantId: PERSONAL_TENANT_ID,
+      userId: WALLET_USER_ID,
+      ...(mfaVerifiedAt ? { sessionMfaVerifiedAt: mfaVerifiedAt } : {}),
+    },
+    "1h",
+  );
+}
+
+async function auditCount(tenantId: string, action: string) {
+  const rows = (await getDb().execute(
+    sql`SELECT count(*)::int AS count FROM audit_events WHERE tenant_id = ${tenantId} AND action = ${action}`,
+  )) as Array<{ count: number }>;
+  return Number(rows[0]?.count ?? 0);
+}
+
+beforeAll(async () => {
+  if (!hasDatabaseUrl) return;
+
+  previousAllowKeyExport = process.env.STEWARD_ALLOW_KEY_EXPORT;
+  process.env.STEWARD_ALLOW_KEY_EXPORT = "true";
+
+  ({ app } = await import("../app"));
+
+  const db = getDb();
+  const { hash } = generateApiKey();
+  await db.insert(tenants).values([
+    { id: TENANT_ID, name: "Key Export Guard Tenant", apiKeyHash: hash },
+    { id: PERSONAL_TENANT_ID, name: "Key Export Personal Tenant", apiKeyHash: hash },
+  ]);
+  await db.insert(users).values([
+    { id: ADMIN_USER_ID, email: `admin-${RUN_ID}@example.test` },
+    { id: WALLET_USER_ID, email: `wallet-${RUN_ID}@example.test` },
+  ]);
+  await db.insert(userTenants).values([
+    { userId: ADMIN_USER_ID, tenantId: TENANT_ID, role: "admin" },
+    { userId: WALLET_USER_ID, tenantId: PERSONAL_TENANT_ID, role: "owner" },
+  ]);
+
+  const vault = new Vault({
+    masterPassword: process.env.STEWARD_MASTER_PASSWORD!,
+    rpcUrl: process.env.RPC_URL || "https://sepolia.base.org",
+    chainId: parseInt(process.env.CHAIN_ID || "84532", 10),
+  });
+  await vault.createAgent(TENANT_ID, AGENT_ID, "Key Export Guard Agent");
+  await provisionUserWallet(vault, WALLET_USER_ID, "Key Export Wallet User", PERSONAL_TENANT_ID);
+});
+
+afterAll(async () => {
+  if (!hasDatabaseUrl) return;
+
+  if (previousAllowKeyExport === undefined) {
+    delete process.env.STEWARD_ALLOW_KEY_EXPORT;
+  } else {
+    process.env.STEWARD_ALLOW_KEY_EXPORT = previousAllowKeyExport;
+  }
+
+  const db = getDb();
+  await db.execute(
+    sql`DELETE FROM audit_events WHERE tenant_id IN (${TENANT_ID}, ${PERSONAL_TENANT_ID})`,
+  );
+  await db
+    .delete(policies)
+    .where(inArray(policies.agentId, [AGENT_ID, `user-wallet-${WALLET_USER_ID}`]));
+  await db.delete(tenants).where(inArray(tenants.id, [TENANT_ID, PERSONAL_TENANT_ID]));
+  await db.delete(users).where(inArray(users.id, [ADMIN_USER_ID, WALLET_USER_ID]));
+});
+
+describeWithDatabase("key export guards", () => {
+  it("rejects tenant vault export without recent MFA", async () => {
+    process.env.STEWARD_ALLOW_KEY_EXPORT = "true";
+    const token = await tenantToken();
+
+    const res = await app.request(`/vault/${AGENT_ID}/export`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}`, "content-type": "application/json" },
+      body: JSON.stringify({ reason: "operator recovery drill" }),
+    });
+
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain("recent MFA");
+  });
+
+  it("allows tenant vault export with recent MFA and writes a blocking HIGH audit event", async () => {
+    process.env.STEWARD_ALLOW_KEY_EXPORT = "true";
+    const token = await tenantToken(freshMfa());
+    const before = await auditCount(TENANT_ID, "vault.key_export");
+
+    const res = await app.request(`/vault/${AGENT_ID}/export`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}`, "content-type": "application/json" },
+      body: JSON.stringify({ reason: "operator recovery drill" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; data?: { evm?: { privateKey: string } } };
+    expect(body.ok).toBe(true);
+    expect(body.data?.evm?.privateKey).toStartWith("0x");
+    expect(await auditCount(TENANT_ID, "vault.key_export")).toBe(before + 1);
+  });
+
+  it("rejects tenant vault export when the env kill switch is disabled", async () => {
+    process.env.STEWARD_ALLOW_KEY_EXPORT = "false";
+    const token = await tenantToken(freshMfa());
+
+    const res = await app.request(`/vault/${AGENT_ID}/export`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}`, "content-type": "application/json" },
+      body: JSON.stringify({ reason: "operator recovery drill" }),
+    });
+
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain("STEWARD_ALLOW_KEY_EXPORT");
+    process.env.STEWARD_ALLOW_KEY_EXPORT = "true";
+  });
+
+  it("rejects user wallet export without recent MFA", async () => {
+    process.env.STEWARD_ALLOW_KEY_EXPORT = "true";
+    const token = await userToken();
+
+    const res = await app.request("/user/me/wallet/export", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}`, "content-type": "application/json" },
+      body: JSON.stringify({ reason: "user recovery" }),
+    });
+
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain("recent MFA");
+  });
+
+  it("allows user wallet export with recent MFA and writes a blocking HIGH audit event", async () => {
+    process.env.STEWARD_ALLOW_KEY_EXPORT = "true";
+    const token = await userToken(freshMfa());
+    const before = await auditCount(PERSONAL_TENANT_ID, "user.wallet_key_export");
+
+    const res = await app.request("/user/me/wallet/export", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}`, "content-type": "application/json" },
+      body: JSON.stringify({ reason: "user recovery" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; data?: { evm?: { privateKey: string } } };
+    expect(body.ok).toBe(true);
+    expect(body.data?.evm?.privateKey).toStartWith("0x");
+    expect(await auditCount(PERSONAL_TENANT_ID, "user.wallet_key_export")).toBe(before + 1);
+  });
+
+  it("rejects user wallet export when the env kill switch is disabled", async () => {
+    process.env.STEWARD_ALLOW_KEY_EXPORT = "false";
+    const token = await userToken(freshMfa());
+
+    const res = await app.request("/user/me/wallet/export", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}`, "content-type": "application/json" },
+      body: JSON.stringify({ reason: "user recovery" }),
+    });
+
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain("STEWARD_ALLOW_KEY_EXPORT");
+    process.env.STEWARD_ALLOW_KEY_EXPORT = "true";
+  });
+});

--- a/packages/api/src/__tests__/tenant-create-auth.test.ts
+++ b/packages/api/src/__tests__/tenant-create-auth.test.ts
@@ -1,0 +1,97 @@
+import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
+import { getDb, tenants } from "@stwd/db";
+import { eq } from "drizzle-orm";
+
+setDefaultTimeout(30000);
+
+const hasDatabaseUrl = Boolean(process.env.DATABASE_URL);
+const describeWithDatabase = hasDatabaseUrl ? describe : describe.skip;
+
+const PLATFORM_KEY = "test-platform-tenant-create-key";
+const TENANT_PREFIX = `test-tenant-create-${process.pid}`;
+const UNAUTH_TENANT_ID = `${TENANT_PREFIX}-unauth`;
+const AUTH_TENANT_ID = `${TENANT_PREFIX}-auth`;
+
+let app: typeof import("../app")["app"];
+let previousPlatformKeys: string | undefined;
+
+function createBody(tenantId: string) {
+  return {
+    id: tenantId,
+    name: `Tenant Create Auth ${tenantId}`,
+    apiKeyHash: `tenant-create-key-${tenantId}`,
+    webhookUrl: "https://example.com/webhook",
+  };
+}
+
+beforeAll(async () => {
+  if (!hasDatabaseUrl) return;
+
+  previousPlatformKeys = process.env.STEWARD_PLATFORM_KEYS;
+  process.env.STEWARD_PLATFORM_KEYS = PLATFORM_KEY;
+
+  ({ app } = await import("../app"));
+});
+
+afterAll(async () => {
+  if (!hasDatabaseUrl) return;
+
+  const db = getDb();
+  await db
+    .delete(tenants)
+    .where(eq(tenants.id, UNAUTH_TENANT_ID))
+    .catch(() => {});
+  await db
+    .delete(tenants)
+    .where(eq(tenants.id, AUTH_TENANT_ID))
+    .catch(() => {});
+
+  if (previousPlatformKeys === undefined) {
+    delete process.env.STEWARD_PLATFORM_KEYS;
+  } else {
+    process.env.STEWARD_PLATFORM_KEYS = previousPlatformKeys;
+  }
+});
+
+describeWithDatabase("POST /tenants platform authentication", () => {
+  it("rejects unauthenticated tenant creation", async () => {
+    const res = await app.request("/tenants", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(createBody(UNAUTH_TENANT_ID)),
+    });
+
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { ok: boolean; error?: string };
+    expect(body.ok).toBe(false);
+
+    const rows = await getDb().select().from(tenants).where(eq(tenants.id, UNAUTH_TENANT_ID));
+    expect(rows).toHaveLength(0);
+  });
+
+  it("creates a tenant with a valid platform key", async () => {
+    const res = await app.request("/tenants", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Steward-Platform-Key": PLATFORM_KEY,
+      },
+      body: JSON.stringify(createBody(AUTH_TENANT_ID)),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      ok: boolean;
+      data?: { id: string; name: string; apiKeyHash: string };
+    };
+    expect(body.ok).toBe(true);
+    expect(body.data?.id).toBe(AUTH_TENANT_ID);
+    expect(body.data?.name).toBe(`Tenant Create Auth ${AUTH_TENANT_ID}`);
+    expect(body.data?.apiKeyHash).not.toBe(`tenant-create-key-${AUTH_TENANT_ID}`);
+
+    const rows = await getDb().select().from(tenants).where(eq(tenants.id, AUTH_TENANT_ID));
+    expect(rows).toHaveLength(1);
+  });
+});

--- a/packages/api/src/routes/approvals.ts
+++ b/packages/api/src/routes/approvals.ts
@@ -13,6 +13,9 @@ import {
   approvalQueue,
   autoApprovalRules,
   db,
+  formatAuthenticatedPrincipal,
+  getAuthenticatedPrincipal,
+  isSameAuthenticatedPrincipal,
   requireTenantLevel,
   safeJsonParse,
   transactions,
@@ -44,6 +47,10 @@ approvalRoutes.get("/", async (c) => {
       requestedAt: approvalQueue.requestedAt,
       resolvedAt: approvalQueue.resolvedAt,
       resolvedBy: approvalQueue.resolvedBy,
+      requestedByType: approvalQueue.requestedByType,
+      requestedById: approvalQueue.requestedById,
+      resolvedByType: approvalQueue.resolvedByType,
+      resolvedById: approvalQueue.resolvedById,
       // Transaction details
       toAddress: transactions.toAddress,
       value: transactions.value,
@@ -127,6 +134,8 @@ approvalRoutes.post("/:txId/approve", async (c) => {
       txId: approvalQueue.txId,
       agentId: approvalQueue.agentId,
       status: approvalQueue.status,
+      requestedByType: approvalQueue.requestedByType,
+      requestedById: approvalQueue.requestedById,
       tenantId: agents.tenantId,
     })
     .from(approvalQueue)
@@ -141,7 +150,15 @@ approvalRoutes.post("/:txId/approve", async (c) => {
     return c.json<ApiResponse>({ ok: false, error: `Approval already ${entry.status}` }, 400);
   }
 
-  const resolvedBy = body?.approvedBy || "tenant-admin";
+  const approver = getAuthenticatedPrincipal(c);
+
+  if (
+    entry.requestedByType &&
+    entry.requestedById &&
+    isSameAuthenticatedPrincipal({ type: entry.requestedByType, id: entry.requestedById }, approver)
+  ) {
+    return c.json<ApiResponse>({ ok: false, error: "Approval requires separation of duties" }, 403);
+  }
 
   // Update approval queue
   const [updated] = await db
@@ -149,7 +166,9 @@ approvalRoutes.post("/:txId/approve", async (c) => {
     .set({
       status: "approved",
       resolvedAt: new Date(),
-      resolvedBy,
+      resolvedBy: formatAuthenticatedPrincipal(approver),
+      resolvedByType: approver.type,
+      resolvedById: approver.id,
     })
     .where(eq(approvalQueue.id, entry.id))
     .returning();
@@ -208,7 +227,7 @@ approvalRoutes.post("/:txId/deny", async (c) => {
     return c.json<ApiResponse>({ ok: false, error: `Approval already ${entry.status}` }, 400);
   }
 
-  const resolvedBy = body.deniedBy || "tenant-admin";
+  const resolver = getAuthenticatedPrincipal(c);
 
   // Update approval queue
   const [updated] = await db
@@ -216,7 +235,9 @@ approvalRoutes.post("/:txId/deny", async (c) => {
     .set({
       status: "rejected",
       resolvedAt: new Date(),
-      resolvedBy: `${resolvedBy}: ${body.reason}`,
+      resolvedBy: `${formatAuthenticatedPrincipal(resolver)}: ${body.reason}`,
+      resolvedByType: resolver.type,
+      resolvedById: resolver.id,
     })
     .where(eq(approvalQueue.id, entry.id))
     .returning();

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -259,24 +259,87 @@ function getNonceBackend(): import("@stwd/auth").StoreBackend {
   return _nonceBackend;
 }
 
-async function setSiweNonce(nonce: string): Promise<void> {
-  await getNonceBackend().set(nonce, "1", SIWE_NONCE_TTL_MS);
+type SiweNonceContext = {
+  domain: string;
+  chainId: string;
+  tenantId?: string;
+};
+
+function normalizeNonceContextValue(value: string | number | undefined): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  const normalized = String(value).trim();
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function serializeSiweNonceContext(context: SiweNonceContext): string {
+  return JSON.stringify({
+    domain: context.domain.toLowerCase(),
+    chainId: context.chainId,
+    ...(context.tenantId ? { tenantId: context.tenantId } : {}),
+  });
+}
+
+function parseSiweNonceContext(raw: string): SiweNonceContext | null {
+  try {
+    const parsed = JSON.parse(raw) as Partial<SiweNonceContext>;
+    const domain = normalizeNonceContextValue(parsed.domain)?.toLowerCase();
+    const chainId = normalizeNonceContextValue(parsed.chainId);
+    if (!domain || !chainId) return null;
+    return {
+      domain,
+      chainId,
+      tenantId: normalizeNonceContextValue(parsed.tenantId),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function getNonceDomain(c: Context): string {
+  const queryDomain = normalizeNonceContextValue(c.req.query("domain"));
+  if (queryDomain) return queryDomain.toLowerCase();
+
+  const origin = normalizeNonceContextValue(c.req.header("Origin"));
+  if (origin) {
+    try {
+      return new URL(origin).host.toLowerCase();
+    } catch {
+      // Fall through to configured defaults below.
+    }
+  }
+
+  return getAllowedSiweDomains()?.[0]?.toLowerCase() ?? "steward.fi";
+}
+
+function getNonceChainId(c: Context): string {
+  return normalizeNonceContextValue(c.req.query("chainId")) ?? "1";
+}
+
+async function setSiweNonce(nonce: string, context: SiweNonceContext): Promise<void> {
+  await getNonceBackend().set(nonce, serializeSiweNonceContext(context), SIWE_NONCE_TTL_MS);
 }
 
 /**
- * Atomically consume a SIWE nonce. Returns true if the nonce was present and
- * unexpired (and is now deleted), false otherwise.
+ * Atomically consume a SIWE nonce. Returns the bound nonce context when the
+ * nonce was present and unexpired (and is now deleted), null otherwise.
  *
  * The check-then-delete is not strictly atomic across instances — Upstash and
  * Postgres do both, but with a small window. For SIWE this is acceptable: the
  * surrounding signature check is the actual authentication, and a leaked nonce
  * is useless without the corresponding wallet signature.
  */
-async function consumeSiweNonce(nonce: string): Promise<boolean> {
+async function consumeSiweNonce(nonce: string): Promise<SiweNonceContext | null> {
   const backend = getNonceBackend();
   const value = await backend.get(nonce);
-  if (!value) return false;
+  if (!value) return null;
   await backend.delete(nonce);
+  return parseSiweNonceContext(value);
+}
+
+function isSiweNonceContextMatch(stored: SiweNonceContext, actual: SiweNonceContext): boolean {
+  if (stored.domain !== actual.domain.toLowerCase()) return false;
+  if (stored.chainId !== actual.chainId) return false;
+  if ((stored.tenantId ?? undefined) !== (actual.tenantId ?? undefined)) return false;
   return true;
 }
 
@@ -1256,22 +1319,28 @@ auth.get("/test/inbox/:email", (c) => {
 
 /**
  * GET /nonce
- * Returns a fresh one-time nonce for SIWE message construction.
+ * Returns a fresh one-time nonce for SIWE/SIWS message construction, bound to
+ * the expected domain, chainId, and optional tenant hint.
  */
 auth.get("/nonce", async (c) => {
   const nonce = generateNonce();
-  await setSiweNonce(nonce);
+  await setSiweNonce(nonce, {
+    domain: getNonceDomain(c),
+    chainId: getNonceChainId(c),
+    tenantId: normalizeNonceContextValue(c.req.header("X-Steward-Tenant")),
+  });
   return c.json({ nonce });
 });
 
 /**
  * POST /verify
  * Body: { message: string; signature: string }
- * Verifies SIWE, auto-creates tenant (per wallet address), returns JWT.
+ * Verifies SIWE, auto-creates the wallet-owned tenant, returns JWT.
  *
  * SIWE flow is wallet-address-centric: each unique address gets its own tenant.
- * If X-Steward-Tenant is provided and the tenant exists, the user is also linked
- * to that tenant and the JWT reflects the requested tenant instead.
+ * If X-Steward-Tenant is provided, the JWT may target that tenant only when the
+ * wallet user already has an existing membership. Supplying a tenant header does
+ * not create a new membership.
  */
 auth.post("/verify", async (c) => {
   const db = getDb();
@@ -1327,9 +1396,20 @@ auth.post("/verify", async (c) => {
     return c.json<ApiResponse>({ ok: false, error: "SIWE domain not allowed" }, 401);
   }
 
-  const nonceOk = await consumeSiweNonce(siweMessage.nonce);
-  if (!nonceOk) {
+  const nonceContext = await consumeSiweNonce(siweMessage.nonce);
+  if (!nonceContext) {
     return c.json<ApiResponse>({ ok: false, error: "Invalid or expired nonce" }, 401);
+  }
+
+  const requestedTenantId = normalizeNonceContextValue(c.req.header("X-Steward-Tenant"));
+  if (
+    !isSiweNonceContextMatch(nonceContext, {
+      domain: siweMessage.domain,
+      chainId: String(siweMessage.chainId),
+      tenantId: requestedTenantId,
+    })
+  ) {
+    return c.json<ApiResponse>({ ok: false, error: "Nonce context mismatch" }, 401);
   }
 
   // Enforce SIWE temporal constraints before any signature verification path.
@@ -1409,24 +1489,35 @@ auth.post("/verify", async (c) => {
     return c.json<ApiResponse>({ ok: false, error: "Failed to create tenant" }, 500);
   }
 
-  const requestedTenantId = c.req.header("X-Steward-Tenant");
+  const user = await findOrCreateWalletUser(address, "ethereum");
+  await ensureUserTenantLink(user.id, tenantResult.tenant.id, "owner");
+
   let effectiveTenantId = tenantResult.tenant.id;
   if (requestedTenantId && requestedTenantId !== tenantResult.tenant.id) {
     const [requestedTenant] = await db
-      .select()
+      .select({ id: tenants.id })
       .from(tenants)
       .where(eq(tenants.id, requestedTenantId));
-    if (requestedTenant) {
-      effectiveTenantId = requestedTenantId;
+    if (!requestedTenant) {
+      return c.json<ApiResponse>(
+        { ok: false, error: `Tenant '${requestedTenantId}' not found` },
+        404,
+      );
     }
-  }
 
-  const user = await findOrCreateWalletUser(address, "ethereum");
-  await ensureUserTenantLink(
-    user.id,
-    effectiveTenantId,
-    effectiveTenantId === tenantResult.tenant.id ? "owner" : "member",
-  );
+    const [existingMembership] = await db
+      .select({ id: userTenants.id })
+      .from(userTenants)
+      .where(and(eq(userTenants.userId, user.id), eq(userTenants.tenantId, requestedTenantId)));
+    if (!existingMembership) {
+      return c.json<ApiResponse>(
+        { ok: false, error: `Tenant '${requestedTenantId}' requires an existing membership` },
+        403,
+      );
+    }
+
+    effectiveTenantId = requestedTenantId;
+  }
 
   const token = await createSessionToken(address, effectiveTenantId, {
     userId: user.id,
@@ -1505,9 +1596,20 @@ auth.post("/verify/solana", async (c) => {
     );
   }
 
-  const nonceOk = await consumeSiweNonce(parsed.nonce);
-  if (!nonceOk) {
+  const nonceContext = await consumeSiweNonce(parsed.nonce);
+  if (!nonceContext) {
     return c.json<ApiResponse>({ ok: false, error: "Invalid or expired nonce" }, 401);
+  }
+
+  const requestedTenantId = normalizeNonceContextValue(c.req.header("X-Steward-Tenant"));
+  if (
+    !isSiweNonceContextMatch(nonceContext, {
+      domain: parsed.domain,
+      chainId: parsed.chainId ?? "mainnet",
+      tenantId: requestedTenantId,
+    })
+  ) {
+    return c.json<ApiResponse>({ ok: false, error: "Nonce context mismatch" }, 401);
   }
 
   if (!verifySolanaMessageSignature(body.message, body.signature, body.publicKey)) {
@@ -1525,24 +1627,35 @@ auth.post("/verify/solana", async (c) => {
     return c.json<ApiResponse>({ ok: false, error: "Failed to create tenant" }, 500);
   }
 
-  const requestedTenantId = c.req.header("X-Steward-Tenant");
+  const user = await findOrCreateWalletUser(body.publicKey, "solana");
+  await ensureUserTenantLink(user.id, tenantResult.tenant.id, "owner");
+
   let effectiveTenantId = tenantResult.tenant.id;
   if (requestedTenantId && requestedTenantId !== tenantResult.tenant.id) {
     const [requestedTenant] = await db
-      .select()
+      .select({ id: tenants.id })
       .from(tenants)
       .where(eq(tenants.id, requestedTenantId));
-    if (requestedTenant) {
-      effectiveTenantId = requestedTenantId;
+    if (!requestedTenant) {
+      return c.json<ApiResponse>(
+        { ok: false, error: `Tenant '${requestedTenantId}' not found` },
+        404,
+      );
     }
-  }
 
-  const user = await findOrCreateWalletUser(body.publicKey, "solana");
-  await ensureUserTenantLink(
-    user.id,
-    effectiveTenantId,
-    effectiveTenantId === tenantResult.tenant.id ? "owner" : "member",
-  );
+    const [existingMembership] = await db
+      .select({ id: userTenants.id })
+      .from(userTenants)
+      .where(and(eq(userTenants.userId, user.id), eq(userTenants.tenantId, requestedTenantId)));
+    if (!existingMembership) {
+      return c.json<ApiResponse>(
+        { ok: false, error: `Tenant '${requestedTenantId}' requires an existing membership` },
+        403,
+      );
+    }
+
+    effectiveTenantId = requestedTenantId;
+  }
 
   const token = await createSessionToken(body.publicKey, effectiveTenantId, {
     userId: user.id,

--- a/packages/api/src/routes/tenants.ts
+++ b/packages/api/src/routes/tenants.ts
@@ -4,7 +4,7 @@
  * Mount: app.route("/tenants", tenantRoutes)
  */
 
-import { hashApiKey } from "@stwd/auth";
+import { hashApiKey, platformAuthMiddleware } from "@stwd/auth";
 import { type Context, Hono, type Next } from "hono";
 import { trackAuditEvent } from "../services/audit";
 import {
@@ -33,7 +33,14 @@ export const tenantRoutes = new Hono<{ Variables: AppVariables }>();
 export const requireTenantId = (c: Context<{ Variables: AppVariables }>, next: Next) =>
   tenantAuth(c, next, { requireTenantMatch: c.req.param("id") });
 
-tenantRoutes.post("/", async (c) => {
+const requirePlatformTenantCreate = (c: Context<{ Variables: AppVariables }>, next: Next) => {
+  if (!c.req.header("X-Steward-Platform-Key")) {
+    return c.json<ApiResponse>({ ok: false, error: "Forbidden" }, 403);
+  }
+  return platformAuthMiddleware()(c, next);
+};
+
+tenantRoutes.post("/", requirePlatformTenantCreate, async (c) => {
   const body = await safeJsonParse<{
     id: string;
     name: string;

--- a/packages/api/src/routes/user.ts
+++ b/packages/api/src/routes/user.ts
@@ -43,6 +43,7 @@ import {
 } from "@stwd/vault";
 import { and, eq, sql } from "drizzle-orm";
 import { type Context, Hono, type Next } from "hono";
+import { writeAuditEvent } from "../services/audit";
 import { createSessionToken } from "./auth";
 
 // ─── Session payload types ────────────────────────────────────────────────────
@@ -504,6 +505,43 @@ user.post("/me/wallet/sign-message", async (c) => {
 user.post("/me/wallet/export", async (c) => {
   const userId = c.get("userId");
 
+  const allowExport =
+    process.env.STEWARD_ALLOW_KEY_EXPORT !== undefined
+      ? process.env.STEWARD_ALLOW_KEY_EXPORT === "true"
+      : process.env.NODE_ENV !== "production";
+  if (!allowExport) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Key export is disabled by STEWARD_ALLOW_KEY_EXPORT" },
+      403,
+    );
+  }
+
+  const session = c.get("userSession");
+  const verifiedAt = session.sessionMfaVerifiedAt ?? session.mfaVerifiedAt;
+  const verifiedAtMs =
+    typeof verifiedAt === "number"
+      ? verifiedAt < 10_000_000_000
+        ? verifiedAt * 1000
+        : verifiedAt
+      : typeof verifiedAt === "string"
+        ? Date.parse(verifiedAt)
+        : Number.NaN;
+  const hasRecentMfa = Number.isFinite(verifiedAtMs) && Date.now() - verifiedAtMs <= 5 * 60 * 1000;
+  if (!hasRecentMfa) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Key export requires recent MFA or passkey step-up" },
+      403,
+    );
+  }
+
+  const body = await safeJsonParse<{ reason: string }>(c);
+  if (!body || !isNonEmptyString(body.reason)) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Key export requires a non-empty audited reason" },
+      400,
+    );
+  }
+
   let vault: Vault;
   try {
     vault = getVault();
@@ -525,6 +563,22 @@ user.post("/me/wallet/export", async (c) => {
   const personalTenantId = `personal-${userId}`;
 
   try {
+    await writeAuditEvent({
+      tenantId: personalTenantId,
+      actorType: "user",
+      actorId: userId,
+      action: "user.wallet_key_export",
+      resourceType: "wallet",
+      resourceId: wallet.id,
+      metadata: {
+        sensitivity: "HIGH",
+        reason: body.reason.trim(),
+      },
+      ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("cf-connecting-ip") ?? null,
+      userAgent: c.req.header("user-agent") ?? null,
+      requestId: c.req.header("x-request-id") ?? null,
+    });
+
     const keys = await vault.exportPrivateKey(personalTenantId, wallet.id);
 
     return c.json<

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -16,10 +16,13 @@ import {
   db,
   ensureAgentForTenant,
   extractRpcErrorMessage,
+  formatAuthenticatedPrincipal,
+  getAuthenticatedPrincipal,
   getPolicySet,
   getTransactionStats,
   isNonEmptyString,
   isRpcError,
+  isSameAuthenticatedPrincipal,
   isValidAddress,
   isValidAgentId,
   isValidAnyAddress,
@@ -88,6 +91,7 @@ vaultRoutes.post("/:agentId/sign", async (c) => {
     agentId,
     chainId: resolvedChainId,
   };
+  const requester = getAuthenticatedPrincipal(c);
   const policySet = await getPolicySet(tenantId, agentId);
 
   // ── Redis rate-limit check (before policy evaluation) ──────────────────────
@@ -141,6 +145,8 @@ vaultRoutes.post("/:agentId/sign", async (c) => {
           txId,
           agentId,
           status: "pending",
+          requestedByType: requester.type,
+          requestedById: requester.id,
         });
       });
 
@@ -334,17 +340,46 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
     return c.json<ApiResponse>({ ok: false, error: "Transaction not found" }, 404);
   }
 
+  const approver = getAuthenticatedPrincipal(c);
+  const [approvalEntry] = await db
+    .select({
+      id: approvalQueue.id,
+      status: approvalQueue.status,
+      requestedByType: approvalQueue.requestedByType,
+      requestedById: approvalQueue.requestedById,
+    })
+    .from(approvalQueue)
+    .where(and(eq(approvalQueue.txId, txId), eq(approvalQueue.agentId, agentId)));
+
+  if (!approvalEntry || approvalEntry.status !== "pending") {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Transaction already processed or not found" },
+      409,
+    );
+  }
+
+  if (
+    approvalEntry.requestedByType &&
+    approvalEntry.requestedById &&
+    isSameAuthenticatedPrincipal(
+      { type: approvalEntry.requestedByType, id: approvalEntry.requestedById },
+      approver,
+    )
+  ) {
+    return c.json<ApiResponse>({ ok: false, error: "Approval requires separation of duties" }, 403);
+  }
+
   const resolvedAt = new Date();
   const claimResult = await db
     .update(approvalQueue)
-    .set({ status: "approved", resolvedAt, resolvedBy: tenantId })
-    .where(
-      and(
-        eq(approvalQueue.txId, txId),
-        eq(approvalQueue.agentId, agentId),
-        eq(approvalQueue.status, "pending"),
-      ),
-    )
+    .set({
+      status: "approved",
+      resolvedAt,
+      resolvedBy: formatAuthenticatedPrincipal(approver),
+      resolvedByType: approver.type,
+      resolvedById: approver.id,
+    })
+    .where(and(eq(approvalQueue.id, approvalEntry.id), eq(approvalQueue.status, "pending")))
     .returning();
 
   if (claimResult.length === 0) {
@@ -390,8 +425,8 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
 
     trackAuditEvent({
       tenantId,
-      actorType: "user",
-      actorId: tenantId,
+      actorType: approver.type === "agent" ? "agent" : "user",
+      actorId: approver.id,
       action: "vault.approve",
       resourceType: "transaction",
       resourceId: txId,
@@ -411,7 +446,13 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
     // Revert the atomic claim so the approval can be retried
     await db
       .update(approvalQueue)
-      .set({ status: "pending", resolvedAt: null, resolvedBy: null })
+      .set({
+        status: "pending",
+        resolvedAt: null,
+        resolvedBy: null,
+        resolvedByType: null,
+        resolvedById: null,
+      })
       .where(and(eq(approvalQueue.txId, txId), eq(approvalQueue.agentId, agentId)));
 
     const requestId = c.get("requestId") || "unknown";
@@ -663,6 +704,7 @@ vaultRoutes.post("/:agentId/sign-typed-data", async (c) => {
     value: "0",
     chainId: resolvedChainId,
   };
+  const requester = getAuthenticatedPrincipal(c);
 
   const policySet = await getPolicySet(tenantId, agentId);
 
@@ -707,6 +749,8 @@ vaultRoutes.post("/:agentId/sign-typed-data", async (c) => {
           txId,
           agentId,
           status: "pending",
+          requestedByType: requester.type,
+          requestedById: requester.id,
         });
       });
 
@@ -921,6 +965,7 @@ vaultRoutes.post("/:agentId/sign-solana", async (c) => {
     value: txValue,
     chainId,
   };
+  const requester = getAuthenticatedPrincipal(c);
 
   const policySet = await getPolicySet(tenantId, agentId);
 
@@ -969,6 +1014,8 @@ vaultRoutes.post("/:agentId/sign-solana", async (c) => {
           txId,
           agentId,
           status: "pending",
+          requestedByType: requester.type,
+          requestedById: requester.id,
         });
       });
 

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -5,10 +5,11 @@
  * Mount: app.route("/vault", vaultRoutes)
  */
 
+import { verifyToken } from "@stwd/auth";
 import { and, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { enforceRateLimit, recordVaultSpend } from "../middleware/redis-enforcement";
-import { trackAuditEvent } from "../services/audit";
+import { trackAuditEvent, writeAuditEvent } from "../services/audit";
 import {
   type ApiResponse,
   type AppVariables,
@@ -1277,6 +1278,53 @@ vaultRoutes.post("/:agentId/export", async (c) => {
     );
   }
 
+  const allowExport =
+    process.env.STEWARD_ALLOW_KEY_EXPORT !== undefined
+      ? process.env.STEWARD_ALLOW_KEY_EXPORT === "true"
+      : process.env.NODE_ENV !== "production";
+  if (!allowExport) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Key export is disabled by STEWARD_ALLOW_KEY_EXPORT" },
+      403,
+    );
+  }
+
+  const authHeader = c.req.header("Authorization");
+  let actorId = c.get("userId") ?? null;
+  let hasRecentMfa = false;
+  if (authHeader?.startsWith("Bearer ")) {
+    try {
+      const payload = await verifyToken(authHeader.slice(7));
+      actorId = typeof payload.userId === "string" ? payload.userId : actorId;
+      const verifiedAt = payload.sessionMfaVerifiedAt ?? payload.mfaVerifiedAt;
+      const verifiedAtMs =
+        typeof verifiedAt === "number"
+          ? verifiedAt < 10_000_000_000
+            ? verifiedAt * 1000
+            : verifiedAt
+          : typeof verifiedAt === "string"
+            ? Date.parse(verifiedAt)
+            : Number.NaN;
+      hasRecentMfa = Number.isFinite(verifiedAtMs) && Date.now() - verifiedAtMs <= 5 * 60 * 1000;
+    } catch {
+      hasRecentMfa = false;
+    }
+  }
+  if (!hasRecentMfa) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Key export requires recent MFA or passkey step-up" },
+      403,
+    );
+  }
+
+  const body = await safeJsonParse<{ reason: string }>(c);
+  if (!body || !isNonEmptyString(body.reason)) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Key export requires a non-empty audited reason" },
+      400,
+    );
+  }
+
   const tenantId = c.get("tenantId");
   const agentId = c.req.param("agentId");
   const agent = await ensureAgentForTenant(tenantId, agentId);
@@ -1286,6 +1334,24 @@ vaultRoutes.post("/:agentId/export", async (c) => {
   }
 
   try {
+    const requestId = c.get("requestId") || null;
+    await writeAuditEvent({
+      tenantId,
+      actorType: "user",
+      actorId,
+      action: "vault.key_export",
+      resourceType: "agent",
+      resourceId: agentId,
+      metadata: {
+        sensitivity: "HIGH",
+        reason: body.reason.trim(),
+        authType: c.get("authType"),
+      },
+      ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("cf-connecting-ip") ?? null,
+      userAgent: c.req.header("user-agent") ?? null,
+      requestId,
+    });
+
     const keys = await vault.exportPrivateKey(tenantId, agentId);
 
     return c.json<

--- a/packages/api/src/services/context.ts
+++ b/packages/api/src/services/context.ts
@@ -266,6 +266,11 @@ export const defaultTenantReady = db
 
 // ─── App variable types ───────────────────────────────────────────────────────
 
+export type AuthenticatedPrincipal = {
+  type: "tenant" | "user" | "agent";
+  id: string;
+};
+
 export type AppVariables = {
   tenant: Tenant;
   tenantConfig: TenantConfig;
@@ -467,6 +472,33 @@ export async function sessionAuth(c: Context<{ Variables: AppVariables }>, next:
   );
 
   await next();
+}
+
+export function getAuthenticatedPrincipal(
+  c: Context<{ Variables: AppVariables }>,
+): AuthenticatedPrincipal {
+  const authType = c.get("authType");
+  if (authType === "agent-token") {
+    return { type: "agent", id: c.get("agentScope") || c.req.param("agentId") || "unknown" };
+  }
+
+  const userId = c.get("userId");
+  if ((authType === "session-jwt" || authType === "dashboard-jwt") && userId) {
+    return { type: "user", id: userId };
+  }
+
+  return { type: "tenant", id: c.get("tenantId") || DEFAULT_TENANT_ID };
+}
+
+export function isSameAuthenticatedPrincipal(
+  left: { type: string; id: string },
+  right: { type: string; id: string },
+): boolean {
+  return left.type === right.type && left.id === right.id;
+}
+
+export function formatAuthenticatedPrincipal(principal: AuthenticatedPrincipal): string {
+  return `${principal.type}:${principal.id}`;
 }
 
 export function requireAgentAccess(c: Context<{ Variables: AppVariables }>): boolean {

--- a/packages/db/drizzle/0025_approval_queue_principals.sql
+++ b/packages/db/drizzle/0025_approval_queue_principals.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "approval_queue" ADD COLUMN IF NOT EXISTS "requested_by_type" varchar(32);
+--> statement-breakpoint
+ALTER TABLE "approval_queue" ADD COLUMN IF NOT EXISTS "requested_by_id" varchar(255);
+--> statement-breakpoint
+ALTER TABLE "approval_queue" ADD COLUMN IF NOT EXISTS "resolved_by_type" varchar(32);
+--> statement-breakpoint
+ALTER TABLE "approval_queue" ADD COLUMN IF NOT EXISTS "resolved_by_id" varchar(255);

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1779672300000,
       "tag": "0024_audit_events",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1780119600000,
+      "tag": "0025_approval_queue_principals",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -304,8 +304,12 @@ export const approvalQueue = pgTable(
       .references(() => agents.id, { onDelete: "cascade" }),
     status: approvalQueueStatusEnum("status").notNull().default("pending"),
     requestedAt: timestamp("requested_at", { withTimezone: true }).notNull().defaultNow(),
+    requestedByType: varchar("requested_by_type", { length: 32 }),
+    requestedById: varchar("requested_by_id", { length: 255 }),
     resolvedAt: timestamp("resolved_at", { withTimezone: true }),
     resolvedBy: varchar("resolved_by", { length: 255 }),
+    resolvedByType: varchar("resolved_by_type", { length: 32 }),
+    resolvedById: varchar("resolved_by_id", { length: 255 }),
   },
   (table) => ({
     txIdUniqueIdx: uniqueIndex("approval_queue_tx_id_idx").on(table.txId),


### PR DESCRIPTION
## What

Fixes the four P0 HIGH findings from the 2026-05-30 multi-worker security audit. Each was an independent worker branch, merged here in dependency order (no conflicts).

### HIGH-001 — unauthenticated `POST /tenants` (`11fb24f`)
The legacy tenant-creation route had no auth guard; anyone could create tenants with a chosen API key/hash. Now gated behind platform auth (`platformAuthMiddleware`); unauthenticated returns 403.

### HIGH-002 / F-007 — SIWE tenant auto-join + unbound nonce (`5cafd8a`)
Any wallet could become a `member` of any existing tenant by passing `X-Steward-Tenant` during SIWE verify, and nonces were stored by string only. Now: nonces bound to domain + chainId + optional tenant (mismatch rejected on verify); auto-join removed (owned tenant or existing membership only, else 403; no silent membership row). Same fix applied to the Solana/SIWS path.

### HIGH-003 — plaintext key export with no step-up (`0665dd2`)
`POST /vault/:agentId/export` and `POST /user/me/wallet/export` returned plaintext private keys behind ordinary auth. Now: recent-MFA freshness gate (5 min), required audited `reason`, blocking `writeAuditEvent` (sensitivity HIGH) before returning key material, and a `STEWARD_ALLOW_KEY_EXPORT` kill switch (off by default in production).

### HIGH-004 / F-002 — no 4-eyes on approvals (`8a86788`)
Approver identity was caller-supplied and there was no persisted requester. Migration `0025_approval_queue_principals` adds `requested_by_type/id` + `resolved_by_type/id`; requester/resolver now captured from authenticated context (`user:` / `agent:` / `tenant:`), body-supplied `approvedBy` ignored, same-principal approval rejected (default-on for manual approvals). Migration applied + tests verified against a real Postgres.

## Verification
- Lint clean (`bun run lint`, 400 files).
- Typecheck clean (`turbo build --filter=@stwd/api --filter=@stwd/db`).
- 4eyes worker ran its tests against live Postgres (3 pass) + applied the migration.
- Other three workers wrote tests using the ambient-DATABASE_URL convention; they run in CI's integration job (the gating `pr.yml` workflow with platform-scope env + 30s timeout from the #79 CI fix).

## Notes
- Audit reports + synthesis live at `~/.moltbot/projects/steward/audit-2026-05-30/` (Sol's workspace).
- Remaining audit items (P1: scoped platform keys, strict token-type parsers, blocking-audit tiers; P2: cut/park trading + erc8004 + examples) are follow-ups, not in this PR.
- Side-finding: `packages/examples/waifu-integration` fails to typecheck (pre-existing `BufferSource` errors), reinforcing the audit's recommendation to cut it.

Co-authored-by: wakesync <shadow@shad0w.xyz>