### PR TITLE
test: raise @stwd/react coverage (56 -> 195 passing)

### DIFF
--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to `@stwd/react` are documented here.
+
+## Unreleased
+
+### Tests
+- Added test coverage for utilities (format, theme, walletPanelRegistry), context hooks (useAuth, useSteward), data hooks (useWallet, useTransactions, useApprovals, usePolicies, useSpend), and SSR branch coverage for the component surface (auth guard, user button, tenant picker, spend dashboard, approval queue, wallet overview, policy controls, email/OAuth callbacks, passkey enrollment). Suite goes from 56 to 195 passing. No source changes.

--- a/packages/react/src/__tests__/ApprovalQueue.test.tsx
+++ b/packages/react/src/__tests__/ApprovalQueue.test.tsx
@@ -1,0 +1,163 @@
+/**
+ * <ApprovalQueue /> branch coverage.
+ *
+ * Mock ../provider.js (feature flags) + ../hooks/useApprovals.js, render via
+ * SSR, assert on emitted HTML:
+ *   - feature flag OFF      → renders nothing
+ *   - loading               → loading shell
+ *   - error                 → error shell
+ *   - empty pending list    → "No pending approvals" empty state
+ *   - non-empty list        → renders rows with truncated addr, value, count
+ *   - policy reasons        → shows triggered (failed) policy results
+ *
+ * The confirm-dialog flow is driven by component state (setConfirmAction) and
+ * the approve/reject hook callbacks; that interaction is exercised at the hook
+ * level in hooks.useApprovals.test.tsx and in the browser e2e suite. SSR only
+ * renders the initial (no-dialog) tree.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import * as React from "react";
+import { renderToString } from "react-dom/server";
+
+type Features = { showApprovalQueue: boolean };
+let mockFeatures: Features = { showApprovalQueue: true };
+
+let mockApprovals: any = {
+  pending: [],
+  isLoading: true,
+  error: null,
+  approve: async () => {},
+  reject: async () => {},
+  isResolving: false,
+};
+
+// NOTE: bun's `mock.module` is process-global; this suite is run
+// one-file-per-process by the package's test script. Run individual files
+// (or `bun run test`), not a single `bun test <glob>`.
+mock.module("../provider.js", () => ({
+  useStewardContext: () => ({ features: mockFeatures }),
+  StewardAuthContext: React.createContext(null),
+  StewardProvider: ({ children }: { children?: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+}));
+
+mock.module("../hooks/useApprovals.js", () => ({
+  useApprovals: () => mockApprovals,
+}));
+
+const { ApprovalQueue } = await import("../components/ApprovalQueue.js");
+
+function render(props: Record<string, unknown> = {}): string {
+  return renderToString(React.createElement(ApprovalQueue, props));
+}
+
+describe("<ApprovalQueue /> branch coverage", () => {
+  beforeEach(() => {
+    mockFeatures = { showApprovalQueue: true };
+    mockApprovals = {
+      pending: [],
+      isLoading: true,
+      error: null,
+      approve: async () => {},
+      reject: async () => {},
+      isResolving: false,
+    };
+  });
+
+  test("feature flag OFF renders nothing", () => {
+    mockFeatures = { showApprovalQueue: false };
+    expect(render()).toBe("");
+  });
+
+  test("loading branch renders the loading shell", () => {
+    mockApprovals = { ...mockApprovals, isLoading: true };
+    expect(render()).toContain("Loading approvals");
+  });
+
+  test("error branch renders the error message", () => {
+    mockApprovals = { ...mockApprovals, isLoading: false, error: new Error("nope") };
+    const html = render();
+    expect(html).toContain("Failed to load approvals");
+    expect(html).toContain("nope");
+  });
+
+  test("empty pending list renders the empty state", () => {
+    mockApprovals = { ...mockApprovals, isLoading: false, pending: [] };
+    expect(render()).toContain("No pending approvals");
+  });
+
+  test("non-empty list renders rows with the pending count badge", () => {
+    mockApprovals = {
+      ...mockApprovals,
+      isLoading: false,
+      pending: [
+        {
+          id: "a1",
+          txId: "tx-1",
+          to: "0x1234567890abcdef1234567890abcdef12345678",
+          value: "1000000000000000000",
+          chainId: 8453,
+          createdAt: new Date(),
+          policyResults: [],
+        },
+      ],
+    };
+    const html = render();
+    expect(html).toContain("Pending Approvals");
+    expect(html).toContain("stwd-approval-list");
+    // truncated destination address
+    expect(html).toContain("0x1234...5678");
+    // value formatted to ETH (1.0000)
+    expect(html).toContain("1.0000");
+    expect(html).toContain("Approve");
+    expect(html).toContain("Deny");
+  });
+
+  test("renders triggered (failed) policy reasons when showPolicyReason is on", () => {
+    mockApprovals = {
+      ...mockApprovals,
+      isLoading: false,
+      pending: [
+        {
+          id: "a1",
+          txId: "tx-1",
+          to: "0xabc0000000000000000000000000000000000def",
+          value: "0",
+          chainId: 1,
+          createdAt: new Date(),
+          policyResults: [
+            { type: "spend_limit", passed: false, reason: "daily cap exceeded" },
+            { type: "allowlist", passed: true },
+          ],
+        },
+      ],
+    };
+    const html = render({ showPolicyReason: true });
+    expect(html).toContain("Triggered policies");
+    expect(html).toContain("spend_limit");
+    expect(html).toContain("daily cap exceeded");
+    // The passing policy should not surface as a triggered reason.
+    expect(html).not.toContain("allowlist");
+  });
+
+  test("hides policy reasons when showPolicyReason is false", () => {
+    mockApprovals = {
+      ...mockApprovals,
+      isLoading: false,
+      pending: [
+        {
+          id: "a1",
+          txId: "tx-1",
+          to: "0xabc0000000000000000000000000000000000def",
+          value: "0",
+          chainId: 1,
+          createdAt: new Date(),
+          policyResults: [{ type: "spend_limit", passed: false, reason: "x" }],
+        },
+      ],
+    };
+    const html = render({ showPolicyReason: false });
+    expect(html).not.toContain("Triggered policies");
+  });
+});

--- a/packages/react/src/__tests__/PasskeyEnrollmentPrompt.test.tsx
+++ b/packages/react/src/__tests__/PasskeyEnrollmentPrompt.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * <PasskeyEnrollmentPrompt /> initial-render coverage.
+ *
+ * The prompt's visibility is decided inside a `useEffect` that reads
+ * `window.sessionStorage`. SSR does not flush effects (and there is no DOM),
+ * so `visible` stays false and the component renders nothing on first render
+ * for every context shape. We assert that null-render contract and the
+ * rules-of-hooks invariant (the component reads ctx + runs three useState +
+ * one useEffect unconditionally before the early return). The enroll /
+ * dismiss interaction is effect + DOM driven and lives in the browser e2e
+ * suite.
+ */
+
+import { describe, expect, test } from "bun:test";
+import * as React from "react";
+import { renderToString } from "react-dom/server";
+
+const { PasskeyEnrollmentPrompt } = await import("../components/PasskeyEnrollmentPrompt.js");
+const { StewardAuthContext } = await import("../provider.js");
+
+function ctx(overrides: Record<string, unknown> = {}): any {
+  return {
+    isAuthenticated: false,
+    isLoading: false,
+    user: null,
+    session: null,
+    addPasskey: async () => ({}),
+    ...overrides,
+  };
+}
+
+function render(value: unknown, props: Record<string, unknown> = {}) {
+  return renderToString(
+    React.createElement(
+      StewardAuthContext.Provider,
+      { value: value as React.ContextType<typeof StewardAuthContext> },
+      React.createElement(PasskeyEnrollmentPrompt, props),
+    ),
+  );
+}
+
+describe("<PasskeyEnrollmentPrompt /> initial render", () => {
+  test("renders nothing when unauthenticated", () => {
+    expect(render(ctx({ isAuthenticated: false }))).toBe("");
+  });
+
+  test("renders nothing on first render even when authenticated (effect not flushed under SSR)", () => {
+    // visibility is set by the sessionStorage-reading effect, which SSR skips.
+    expect(render(ctx({ isAuthenticated: true, user: { id: "u", email: "u@x.io" } }))).toBe("");
+  });
+
+  test("renders nothing with no auth context at all", () => {
+    expect(
+      renderToString(
+        React.createElement(
+          StewardAuthContext.Provider,
+          { value: null },
+          React.createElement(PasskeyEnrollmentPrompt, {}),
+        ),
+      ),
+    ).toBe("");
+  });
+
+  test("does not throw across variant props and context shapes (rules-of-hooks)", () => {
+    for (const variant of ["banner", "inline", "toast"] as const) {
+      expect(() => render(ctx({ isAuthenticated: false }), { variant })).not.toThrow();
+      expect(() =>
+        render(ctx({ isAuthenticated: true, user: { id: "u", email: "u@x.io" } }), {
+          variant,
+          alwaysShow: true,
+        }),
+      ).not.toThrow();
+    }
+  });
+});

--- a/packages/react/src/__tests__/PolicyControls.test.tsx
+++ b/packages/react/src/__tests__/PolicyControls.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * <PolicyControls /> branch coverage.
+ *
+ * Mock ../provider.js (features + tenantConfig) and ../hooks/usePolicies.js,
+ * render via SSR:
+ *   - feature flag OFF        → renders nothing
+ *   - loading                 → loading shell
+ *   - error                   → error text
+ *   - loaded                  → renders the visible policy rows with labels +
+ *                               descriptions
+ *   - exposure: "hidden"      → that policy type is filtered out
+ *   - exposure: "enforced"    → row marked as set-by-platform
+ *   - label override          → custom label wins over the default
+ *
+ * The edit / save / template-modal flows are component-state driven and
+ * exercised by the browser e2e suite; SSR renders the initial (view) tree.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import * as React from "react";
+import { renderToString } from "react-dom/server";
+
+let mockFeatures = { showPolicyControls: true };
+let mockTenantConfig: any = null;
+
+let mockPolicies: any = {
+  policies: [],
+  isLoading: true,
+  isSaving: false,
+  error: null,
+  setPolicies: async () => {},
+  applyTemplate: async () => {},
+};
+
+// NOTE: bun's `mock.module` is process-global; this suite is run
+// one-file-per-process by the package's test script. Run individual files
+// (or `bun run test`), not a single `bun test <glob>`.
+mock.module("../provider.js", () => ({
+  useStewardContext: () => ({ features: mockFeatures, tenantConfig: mockTenantConfig }),
+  StewardAuthContext: React.createContext(null),
+  StewardProvider: ({ children }: { children?: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+}));
+
+mock.module("../hooks/usePolicies.js", () => ({
+  usePolicies: () => mockPolicies,
+}));
+
+const { PolicyControls } = await import("../components/PolicyControls.js");
+
+function render(props: Record<string, unknown> = {}): string {
+  return renderToString(React.createElement(PolicyControls, props));
+}
+
+describe("<PolicyControls /> branch coverage", () => {
+  beforeEach(() => {
+    mockFeatures = { showPolicyControls: true };
+    mockTenantConfig = null;
+    mockPolicies = {
+      policies: [],
+      isLoading: true,
+      isSaving: false,
+      error: null,
+      setPolicies: async () => {},
+      applyTemplate: async () => {},
+    };
+  });
+
+  test("feature flag OFF renders nothing", () => {
+    mockFeatures = { showPolicyControls: false };
+    expect(render()).toBe("");
+  });
+
+  test("loading branch renders the loading shell", () => {
+    mockPolicies = { ...mockPolicies, isLoading: true };
+    expect(render()).toContain("Loading policies");
+  });
+
+  test("loaded branch renders the header and the default policy labels", () => {
+    mockPolicies = { ...mockPolicies, isLoading: false, policies: [] };
+    const html = render();
+    expect(html).toContain("Policy Controls");
+    expect(html).toContain("Spending Limits");
+    expect(html).toContain("Approved Addresses");
+    expect(html).toContain("Rate Limit");
+    // a description string for one of the policy types
+    expect(html).toContain("Set maximum amounts per transaction");
+  });
+
+  test("error from the hook is surfaced as error text", () => {
+    mockPolicies = {
+      ...mockPolicies,
+      isLoading: false,
+      error: new Error("policy fetch failed"),
+    };
+    const html = render();
+    expect(html).toContain("policy fetch failed");
+  });
+
+  test('exposure "hidden" filters a policy type out of the list', () => {
+    mockTenantConfig = { exposedPolicies: { "rate-limit": "hidden" }, policyTemplates: [] };
+    mockPolicies = { ...mockPolicies, isLoading: false };
+    const html = render();
+    expect(html).toContain("Spending Limits");
+    expect(html).not.toContain("Rate Limit");
+  });
+
+  test('exposure "enforced" marks a policy row as set-by-platform', () => {
+    mockTenantConfig = {
+      exposedPolicies: { "spending-limit": "enforced" },
+      policyTemplates: [],
+    };
+    mockPolicies = { ...mockPolicies, isLoading: false };
+    const html = render();
+    expect(html).toContain("Set by platform");
+  });
+
+  test("label override wins over the default label", () => {
+    mockPolicies = { ...mockPolicies, isLoading: false };
+    const html = render({ labels: { "spending-limit": "Budget Caps" } });
+    expect(html).toContain("Budget Caps");
+    expect(html).not.toContain("Spending Limits");
+  });
+
+  test("showTemplates with templates renders the templates trigger button", () => {
+    mockTenantConfig = {
+      exposedPolicies: {},
+      policyTemplates: [{ id: "safe", name: "Safe Defaults", policies: [] }],
+    };
+    mockPolicies = { ...mockPolicies, isLoading: false };
+    const html = render({ showTemplates: true });
+    expect(html).toContain("stwd-policy-header");
+  });
+});

--- a/packages/react/src/__tests__/SpendDashboard.test.tsx
+++ b/packages/react/src/__tests__/SpendDashboard.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * <SpendDashboard /> branch coverage.
+ *
+ * Mirrors the TransactionHistory test style: mock ../provider.js (feature
+ * flags) and ../hooks/useSpend.js, then render via SSR and assert on the
+ * emitted HTML for each branch:
+ *   - feature flag OFF             → renders nothing
+ *   - loading                      → loading shell
+ *   - error                        → error shell
+ *   - no stats                     → empty state
+ *   - loaded with stats            → stat cards + range label + budget bars
+ *   - budget bar color thresholds  → exercised via dailyPercent values
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import * as React from "react";
+import { renderToString } from "react-dom/server";
+
+type Features = { showSpendDashboard: boolean };
+let mockFeatures: Features = { showSpendDashboard: true };
+
+let mockSpend: any = { stats: null, isLoading: true, error: null };
+
+// NOTE: bun's `mock.module` is process-global; this suite is run
+// one-file-per-process by the package's test script. Run individual files
+// (or `bun run test`), not a single `bun test <glob>`.
+mock.module("../provider.js", () => ({
+  useStewardContext: () => ({ features: mockFeatures }),
+  StewardAuthContext: React.createContext(null),
+  StewardProvider: ({ children }: { children?: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+}));
+
+mock.module("../hooks/useSpend.js", () => ({
+  useSpend: () => mockSpend,
+}));
+
+const { SpendDashboard } = await import("../components/SpendDashboard.js");
+
+function render(): string {
+  return renderToString(React.createElement(SpendDashboard, {}));
+}
+
+const FULL_STATS = {
+  range: "7d",
+  totalSpentFormatted: "1.25",
+  txCount: 7,
+  avgTxValueFormatted: "0.18",
+  largestTx: { value: "0.9" },
+  budgetUsage: {
+    dailyPercent: 40,
+    dailyUsed: "400",
+    dailyLimit: "1000",
+    weeklyPercent: 80,
+    weeklyUsed: "800",
+    weeklyLimit: "1000",
+  },
+  daily: [
+    { date: "2026-01-01", spentFormatted: "0.5", txCount: 2 },
+    { date: "2026-01-02", spentFormatted: "0.75", txCount: 5 },
+  ],
+  topDestinations: [
+    { address: "0x1234567890abcdef1234567890abcdef12345678", totalSent: "500", txCount: 3 },
+  ],
+};
+
+describe("<SpendDashboard /> branch coverage", () => {
+  beforeEach(() => {
+    mockFeatures = { showSpendDashboard: true };
+    mockSpend = { stats: null, isLoading: true, error: null };
+  });
+
+  test("feature flag OFF renders nothing", () => {
+    mockFeatures = { showSpendDashboard: false };
+    expect(render()).toBe("");
+  });
+
+  test("loading branch renders the loading shell", () => {
+    mockSpend = { stats: null, isLoading: true, error: null };
+    expect(render()).toContain("Loading spend data");
+  });
+
+  test("error branch renders the error message", () => {
+    mockSpend = { stats: null, isLoading: false, error: new Error("kaboom") };
+    const html = render();
+    expect(html).toContain("Failed to load spend data");
+    expect(html).toContain("kaboom");
+  });
+
+  test("no-stats branch renders the empty state", () => {
+    mockSpend = { stats: null, isLoading: false, error: null };
+    expect(render()).toContain("No spend data available");
+  });
+
+  test("loaded branch renders stat cards, range label, and budget bars", () => {
+    mockSpend = { stats: FULL_STATS, isLoading: false, error: null };
+    const html = render();
+    expect(html).toContain("Spend Dashboard");
+    expect(html).toContain("Last 7 Days");
+    expect(html).toContain("Total Spent");
+    // React SSR inserts a `<!-- -->` marker between adjacent text nodes, so we
+    // assert the numeric value and the ETH unit separately rather than as one
+    // contiguous "1.25 ETH" string.
+    expect(html).toContain("1.25");
+    expect(html).toContain("Budget Usage");
+    expect(html).toContain("Daily Spend");
+    expect(html).toContain("Top Destinations");
+    // truncated destination address
+    expect(html).toContain("0x1234...5678");
+  });
+
+  test("budget bar uses the error color above 90%", () => {
+    mockSpend = {
+      stats: { ...FULL_STATS, budgetUsage: { ...FULL_STATS.budgetUsage, dailyPercent: 95 } },
+      isLoading: false,
+      error: null,
+    };
+    const html = render();
+    expect(html).toContain("var(--stwd-error)");
+  });
+
+  test("budget bar uses the warning color between 70 and 90%", () => {
+    mockSpend = {
+      stats: {
+        ...FULL_STATS,
+        budgetUsage: {
+          ...FULL_STATS.budgetUsage,
+          dailyPercent: 75,
+          weeklyPercent: 10,
+        },
+      },
+      isLoading: false,
+      error: null,
+    };
+    const html = render();
+    expect(html).toContain("var(--stwd-warning)");
+  });
+
+  test("range label maps each preset", () => {
+    for (const [range, label] of [
+      ["24h", "Last 24 Hours"],
+      ["30d", "Last 30 Days"],
+      ["all", "All Time"],
+    ] as const) {
+      mockSpend = { stats: { ...FULL_STATS, range }, isLoading: false, error: null };
+      expect(render()).toContain(label);
+    }
+  });
+});

--- a/packages/react/src/__tests__/StewardAuthGuard.test.tsx
+++ b/packages/react/src/__tests__/StewardAuthGuard.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * <StewardAuthGuard /> branch coverage.
+ *
+ * Guard renders one of three trees based on the auth context:
+ *   - isLoading           → loadingFallback (or default spinner)
+ *   - !isAuthenticated    → fallback (or default <StewardLogin />)
+ *   - authenticated       → children
+ *
+ * We wrap the guard in the real StewardAuthContext.Provider (same approach as
+ * StewardLogin.test.tsx) and assert on SSR HTML. The default-unauthenticated
+ * branch renders <StewardLogin />, which needs the wallet-panel registry; we
+ * pass an explicit `fallback` to keep these tests focused on the guard's own
+ * branching and avoid coupling to StewardLogin internals.
+ */
+
+import { describe, expect, test } from "bun:test";
+import * as React from "react";
+import { renderToString } from "react-dom/server";
+
+const { StewardAuthGuard } = await import("../components/StewardAuthGuard.js");
+const { StewardAuthContext } = await import("../provider.js");
+
+function ctx(overrides: Record<string, unknown>): any {
+  return {
+    isAuthenticated: false,
+    isLoading: false,
+    user: null,
+    session: null,
+    providers: null,
+    isProvidersLoading: false,
+    signOut: () => {},
+    getToken: () => null,
+    activeTenantId: null,
+    tenants: null,
+    isTenantsLoading: false,
+    ...overrides,
+  };
+}
+
+function wrap(value: unknown, node: React.ReactNode) {
+  return React.createElement(
+    StewardAuthContext.Provider,
+    { value: value as React.ContextType<typeof StewardAuthContext> },
+    node,
+  );
+}
+
+const child = React.createElement("div", { "data-testid": "protected" }, "secret");
+
+describe("<StewardAuthGuard /> branch coverage", () => {
+  test("loading branch renders the default spinner", () => {
+    const html = renderToString(
+      wrap(ctx({ isLoading: true }), React.createElement(StewardAuthGuard, {}, child)),
+    );
+    expect(html).toContain("stwd-auth-guard__loading");
+    expect(html).toContain("Loading");
+    expect(html).not.toContain("secret");
+  });
+
+  test("loading branch renders a custom loadingFallback when provided", () => {
+    const html = renderToString(
+      wrap(
+        ctx({ isLoading: true }),
+        React.createElement(
+          StewardAuthGuard,
+          { loadingFallback: React.createElement("p", {}, "please wait") },
+          child,
+        ),
+      ),
+    );
+    expect(html).toContain("please wait");
+    expect(html).not.toContain("Loading…");
+  });
+
+  test("unauthenticated branch renders a custom fallback", () => {
+    const html = renderToString(
+      wrap(
+        ctx({ isAuthenticated: false, isLoading: false }),
+        React.createElement(
+          StewardAuthGuard,
+          { fallback: React.createElement("p", {}, "log in please") },
+          child,
+        ),
+      ),
+    );
+    expect(html).toContain("stwd-auth-guard");
+    expect(html).toContain("log in please");
+    expect(html).not.toContain("secret");
+  });
+
+  test("authenticated branch renders the children", () => {
+    const html = renderToString(
+      wrap(
+        ctx({ isAuthenticated: true, isLoading: false }),
+        React.createElement(StewardAuthGuard, {}, child),
+      ),
+    );
+    expect(html).toContain("secret");
+    expect(html).not.toContain("stwd-auth-guard__loading");
+  });
+});

--- a/packages/react/src/__tests__/StewardEmailCallback.test.tsx
+++ b/packages/react/src/__tests__/StewardEmailCallback.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * <StewardEmailCallback /> initial-render coverage.
+ *
+ * The component's verification logic lives entirely in a `useEffect` that
+ * reads `window.location.search` and calls `verifyEmailCallback`. The test
+ * runner has no DOM and SSR does not flush effects, so we cover the
+ * deterministic initial render (step === "loading") plus the rules-of-hooks
+ * invariant across auth-context shapes. The success / error / retry branches
+ * are effect + DOM driven and are exercised by the browser e2e suite.
+ */
+
+import { describe, expect, test } from "bun:test";
+import * as React from "react";
+import { renderToString } from "react-dom/server";
+
+const { StewardEmailCallback } = await import("../components/StewardEmailCallback.js");
+const { StewardAuthContext } = await import("../provider.js");
+
+function ctx(overrides: Record<string, unknown> = {}): any {
+  return {
+    isAuthenticated: false,
+    isLoading: false,
+    user: null,
+    session: null,
+    verifyEmailCallback: async () => ({}),
+    ...overrides,
+  };
+}
+
+function render(value: unknown, props: Record<string, unknown> = {}) {
+  return renderToString(
+    React.createElement(
+      StewardAuthContext.Provider,
+      { value: value as React.ContextType<typeof StewardAuthContext> },
+      React.createElement(StewardEmailCallback, props),
+    ),
+  );
+}
+
+describe("<StewardEmailCallback /> initial render", () => {
+  test("renders the loading shell on first render", () => {
+    const html = render(ctx());
+    expect(html).toContain("stwd-callback__loading");
+    expect(html).toContain("Verifying your sign-in link");
+  });
+
+  test("loading shell renders regardless of redirectTo prop", () => {
+    const html = render(ctx(), { redirectTo: "/dashboard" });
+    expect(html).toContain("stwd-callback__loading");
+  });
+
+  test("mounting does not throw when already authenticated", () => {
+    // The effect handles the already-authenticated short-circuit, but the
+    // initial render is still the loading shell (effect has not run under SSR).
+    expect(() => render(ctx({ isAuthenticated: true }))).not.toThrow();
+  });
+
+  test("hook order is stable across auth-context shapes (rules-of-hooks)", () => {
+    expect(() => render(ctx({ isAuthenticated: false }))).not.toThrow();
+    expect(() => render(ctx({ isAuthenticated: true }))).not.toThrow();
+  });
+});

--- a/packages/react/src/__tests__/StewardOAuthCallback.test.tsx
+++ b/packages/react/src/__tests__/StewardOAuthCallback.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * <StewardOAuthCallback /> initial-render coverage.
+ *
+ * Like StewardEmailCallback, all of the token-in-URL / code-in-URL / error
+ * handling lives in a `useEffect` that reads `window.location.search` and
+ * `localStorage`. SSR does not flush effects and the runner has no DOM, so we
+ * cover the deterministic initial render (the "Completing … sign-in" loading
+ * shell, optionally with the provider name) and the rules-of-hooks invariant.
+ * The branch logic is exercised by the browser e2e suite.
+ */
+
+import { describe, expect, test } from "bun:test";
+import * as React from "react";
+import { renderToString } from "react-dom/server";
+
+const { StewardOAuthCallback } = await import("../components/StewardOAuthCallback.js");
+const { StewardAuthContext } = await import("../provider.js");
+
+function ctx(overrides: Record<string, unknown> = {}): any {
+  return {
+    isAuthenticated: false,
+    isLoading: false,
+    user: null,
+    session: null,
+    ...overrides,
+  };
+}
+
+function render(value: unknown, props: Record<string, unknown> = {}) {
+  return renderToString(
+    React.createElement(
+      StewardAuthContext.Provider,
+      { value: value as React.ContextType<typeof StewardAuthContext> },
+      React.createElement(StewardOAuthCallback, props),
+    ),
+  );
+}
+
+describe("<StewardOAuthCallback /> initial render", () => {
+  test("renders the generic loading shell when no provider is given", () => {
+    const html = render(ctx());
+    expect(html).toContain("stwd-callback__loading");
+    expect(html).toContain("Completing");
+    expect(html).toContain("sign-in");
+  });
+
+  test("includes the provider name in the loading copy when provided", () => {
+    const html = render(ctx(), { provider: "google" });
+    expect(html).toContain("Completing");
+    expect(html).toContain("google");
+  });
+
+  test("mounting does not throw when already authenticated", () => {
+    expect(() => render(ctx({ isAuthenticated: true }))).not.toThrow();
+  });
+
+  test("hook order is stable across auth-context shapes (rules-of-hooks)", () => {
+    expect(() => render(ctx({ isAuthenticated: false, user: null }))).not.toThrow();
+    expect(() =>
+      render(ctx({ isAuthenticated: true, user: { id: "u", email: "u@x.io" } })),
+    ).not.toThrow();
+  });
+});

--- a/packages/react/src/__tests__/StewardTenantPicker.test.tsx
+++ b/packages/react/src/__tests__/StewardTenantPicker.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * <StewardTenantPicker /> branch coverage.
+ *
+ * The dropdown menu opens via state (starts closed) so SSR renders the closed
+ * trigger for the dropdown variant; the always-visible list variant renders
+ * its items directly. We assert:
+ *   - returns null when unauthenticated
+ *   - returns null when the SDK lacks tenant methods (no listTenants/switchTenant)
+ *   - loading state (tenants null + isTenantsLoading)
+ *   - empty state (tenants === [])
+ *   - list variant renders each membership with name + role
+ *   - active membership is marked + disabled
+ *   - dropdown variant renders the active tenant name in the trigger
+ */
+
+import { describe, expect, test } from "bun:test";
+import * as React from "react";
+import { renderToString } from "react-dom/server";
+
+const { StewardTenantPicker } = await import("../components/StewardTenantPicker.js");
+const { StewardAuthContext } = await import("../provider.js");
+
+const TENANTS = [
+  { tenantId: "app-a", tenantName: "Acme App", role: "owner" },
+  { tenantId: "app-b", tenantName: "Beta App", role: "member" },
+];
+
+function ctx(overrides: Record<string, unknown>): any {
+  return {
+    isAuthenticated: true,
+    isLoading: false,
+    user: { id: "u1", email: "u@x.io" },
+    session: null,
+    providers: null,
+    isProvidersLoading: false,
+    signOut: () => {},
+    getToken: () => null,
+    activeTenantId: null,
+    tenants: null,
+    isTenantsLoading: false,
+    listTenants: async () => [],
+    switchTenant: async () => false,
+    ...overrides,
+  };
+}
+
+function render(value: unknown, props: Record<string, unknown> = {}) {
+  return renderToString(
+    React.createElement(
+      StewardAuthContext.Provider,
+      { value: value as React.ContextType<typeof StewardAuthContext> },
+      React.createElement(StewardTenantPicker, props),
+    ),
+  );
+}
+
+describe("<StewardTenantPicker /> branch coverage", () => {
+  test("returns null when unauthenticated", () => {
+    expect(render(ctx({ isAuthenticated: false }))).toBe("");
+  });
+
+  test("returns null when the SDK lacks tenant methods", () => {
+    expect(render(ctx({ listTenants: undefined, switchTenant: undefined }))).toBe("");
+  });
+
+  test("loading state renders the loading label", () => {
+    const html = render(ctx({ tenants: null, isTenantsLoading: true }));
+    expect(html).toContain("Loading apps");
+  });
+
+  test("empty state renders 'No apps connected'", () => {
+    const html = render(ctx({ tenants: [] }));
+    expect(html).toContain("No apps connected");
+  });
+
+  test("list variant renders each membership name and role", () => {
+    const html = render(ctx({ tenants: TENANTS, activeTenantId: "app-a" }), { variant: "list" });
+    expect(html).toContain("stwd-tenant-picker--list");
+    expect(html).toContain("Acme App");
+    expect(html).toContain("Beta App");
+    expect(html).toContain("owner");
+    expect(html).toContain("member");
+  });
+
+  test("list variant marks the active membership and disables it", () => {
+    const html = render(ctx({ tenants: TENANTS, activeTenantId: "app-a" }), { variant: "list" });
+    expect(html).toContain("stwd-tenant-picker__item--active");
+    expect(html).toContain('aria-current="true"');
+    expect(html).toContain("disabled");
+  });
+
+  test("dropdown variant renders the active tenant name in the trigger (menu closed)", () => {
+    const html = render(ctx({ tenants: TENANTS, activeTenantId: "app-b" }), {
+      variant: "dropdown",
+    });
+    expect(html).toContain("stwd-tenant-picker--dropdown");
+    expect(html).toContain("stwd-tenant-picker__trigger");
+    expect(html).toContain("Beta App");
+    expect(html).toContain('aria-expanded="false"');
+    // closed menu => the expandable __menu container is not rendered yet
+    expect(html).not.toContain("stwd-tenant-picker__menu");
+  });
+
+  test("dropdown trigger falls back to activeTenantId when no matching membership name", () => {
+    const html = render(ctx({ tenants: TENANTS, activeTenantId: "app-zzz" }), {
+      variant: "dropdown",
+    });
+    expect(html).toContain("app-zzz");
+  });
+});

--- a/packages/react/src/__tests__/StewardUserButton.test.tsx
+++ b/packages/react/src/__tests__/StewardUserButton.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * <StewardUserButton /> branch coverage.
+ *
+ * The dropdown is gated behind `open` state (starts false) and the
+ * click-outside listener runs in an effect, so SSR renders only the closed
+ * trigger. We assert on the trigger derivation logic:
+ *   - returns null when there is no user (and no session fallback)
+ *   - derives display name + gravatar avatar from email
+ *   - derives an initials avatar + truncated wallet when there is no email
+ *   - falls back to session fields when auth.user is null (post-refresh)
+ */
+
+import { describe, expect, test } from "bun:test";
+import * as React from "react";
+import { renderToString } from "react-dom/server";
+
+const { StewardUserButton } = await import("../components/StewardUserButton.js");
+const { StewardAuthContext } = await import("../provider.js");
+
+function ctx(overrides: Record<string, unknown>): any {
+  return {
+    isAuthenticated: true,
+    isLoading: false,
+    user: null,
+    session: null,
+    providers: null,
+    isProvidersLoading: false,
+    signOut: () => {},
+    getToken: () => null,
+    activeTenantId: null,
+    tenants: null,
+    isTenantsLoading: false,
+    switchTenant: async () => false,
+    ...overrides,
+  };
+}
+
+function render(value: unknown, props: Record<string, unknown> = {}) {
+  return renderToString(
+    React.createElement(
+      StewardAuthContext.Provider,
+      { value: value as React.ContextType<typeof StewardAuthContext> },
+      React.createElement(StewardUserButton, props),
+    ),
+  );
+}
+
+describe("<StewardUserButton /> branch coverage", () => {
+  test("renders nothing when there is no user and no session", () => {
+    expect(render(ctx({ user: null, session: null }))).toBe("");
+  });
+
+  test("renders an email trigger with a gravatar avatar", () => {
+    const html = render(ctx({ user: { id: "u1", email: "alice@example.com" } }));
+    expect(html).toContain("stwd-user-button__trigger");
+    expect(html).toContain("alice@example.com");
+    // gravatar avatar URL is derived from the email
+    expect(html).toContain("gravatar.com/avatar/");
+    expect(html).toContain("stwd-user-button__avatar");
+  });
+
+  test("renders an initials avatar + truncated wallet when there is no email", () => {
+    const html = render(
+      ctx({
+        user: { id: "u1", email: "", walletAddress: "0x1234567890abcdef1234567890abcdef12345678" },
+      }),
+      { showWallet: true },
+    );
+    // initials avatar (no gravatar img)
+    expect(html).toContain("stwd-user-button__avatar--initials");
+    expect(html).not.toContain("gravatar.com");
+    // wallet truncated with the component's own 6/4 truncation + ellipsis char
+    expect(html).toContain("0x1234");
+  });
+
+  test("falls back to session fields when auth.user is null (post-refresh)", () => {
+    const html = render(
+      ctx({
+        user: null,
+        session: { userId: "u9", email: "bob@example.com", address: "0xdead" },
+      }),
+    );
+    expect(html).toContain("bob@example.com");
+    expect(html).toContain("gravatar.com/avatar/");
+  });
+
+  test("derives initials from the email local part for the default-name path", () => {
+    // No email, no wallet → displayName defaults to "User" → initial "U".
+    const html = render(ctx({ user: { id: "u1", email: "", walletAddress: undefined } }));
+    expect(html).toContain("stwd-user-button__avatar--initials");
+    // Initials circle should contain the uppercase first letter "U" of "User".
+    expect(html).toContain(">U<");
+  });
+
+  test("dropdown is closed on initial SSR render (no Sign Out item visible)", () => {
+    const html = render(ctx({ user: { id: "u1", email: "alice@example.com" } }));
+    // The dropdown (and its Sign Out item) only mounts when `open` is true.
+    expect(html).not.toContain("Sign Out");
+    // trigger advertises the closed state for a11y
+    expect(html).toContain('aria-expanded="false"');
+  });
+});

--- a/packages/react/src/__tests__/WalletOverview.test.tsx
+++ b/packages/react/src/__tests__/WalletOverview.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * <WalletOverview /> branch coverage.
+ *
+ * Mock ../provider.js (feature flags) + ../hooks/useWallet.js, render via SSR:
+ *   - loading                  → loading shell
+ *   - error                    → error shell
+ *   - null agent               → renders nothing
+ *   - loaded with addresses    → header, truncated address, chain badge
+ *   - balance present          → balance section (formatted + native fallback)
+ *   - funding QR gating        → showQR prop overrides features.showFundingQR
+ *   - chain filtering          → only requested chain families render
+ *   - address fallback         → agent.walletAddress used when none returned
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import * as React from "react";
+import { renderToString } from "react-dom/server";
+
+let mockFeatures = { showFundingQR: true };
+
+let mockWallet: any = {
+  agent: null,
+  balance: null,
+  addresses: [],
+  isLoading: true,
+  error: null,
+};
+
+// NOTE: bun's `mock.module` is process-global; this suite is run
+// one-file-per-process by the package's test script. Run individual files
+// (or `bun run test`), not a single `bun test <glob>`.
+mock.module("../provider.js", () => ({
+  useStewardContext: () => ({ features: mockFeatures }),
+  StewardAuthContext: React.createContext(null),
+  StewardProvider: ({ children }: { children?: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+}));
+
+mock.module("../hooks/useWallet.js", () => ({
+  useWallet: () => mockWallet,
+}));
+
+const { WalletOverview } = await import("../components/WalletOverview.js");
+
+function render(props: Record<string, unknown> = {}): string {
+  return renderToString(React.createElement(WalletOverview, props));
+}
+
+const AGENT = { id: "a1", name: "Treasury Agent", platformId: "discord:123" };
+
+describe("<WalletOverview /> branch coverage", () => {
+  beforeEach(() => {
+    mockFeatures = { showFundingQR: true };
+    mockWallet = {
+      agent: null,
+      balance: null,
+      addresses: [],
+      isLoading: true,
+      error: null,
+    };
+  });
+
+  test("loading branch renders the loading shell", () => {
+    expect(render()).toContain("Loading wallet");
+  });
+
+  test("error branch renders the error message", () => {
+    mockWallet = { ...mockWallet, isLoading: false, error: new Error("rpc down") };
+    const html = render();
+    expect(html).toContain("Failed to load wallet");
+    expect(html).toContain("rpc down");
+  });
+
+  test("null agent renders nothing", () => {
+    mockWallet = { ...mockWallet, isLoading: false, agent: null };
+    expect(render()).toBe("");
+  });
+
+  test("loaded branch renders the agent name, platform badge, and a truncated address", () => {
+    mockWallet = {
+      ...mockWallet,
+      isLoading: false,
+      agent: AGENT,
+      addresses: [{ chainFamily: "evm", address: "0x1234567890abcdef1234567890abcdef12345678" }],
+    };
+    const html = render();
+    expect(html).toContain("Treasury Agent");
+    expect(html).toContain("discord:123");
+    expect(html).toContain("EVM");
+    expect(html).toContain("0x1234...5678");
+  });
+
+  test("balance section renders the formatted native fallback when no nativeFormatted", () => {
+    mockWallet = {
+      ...mockWallet,
+      isLoading: false,
+      agent: AGENT,
+      addresses: [{ chainFamily: "evm", address: "0xabc0000000000000000000000000000000000def" }],
+      balance: { balances: { native: "1000000000000000000", symbol: "ETH", chainId: 8453 } },
+    };
+    const html = render();
+    expect(html).toContain("Balance");
+    expect(html).toContain("1.0000");
+    expect(html).toContain("Chain ID:");
+  });
+
+  test("balance section prefers nativeFormatted when present", () => {
+    mockWallet = {
+      ...mockWallet,
+      isLoading: false,
+      agent: AGENT,
+      addresses: [{ chainFamily: "evm", address: "0xabc0000000000000000000000000000000000def" }],
+      balance: {
+        balances: {
+          native: "1000000000000000000",
+          nativeFormatted: "1.23",
+          symbol: "ETH",
+          chainId: 1,
+        },
+      },
+    };
+    const html = render();
+    expect(html).toContain("1.23");
+  });
+
+  test("funding QR shows when features.showFundingQR is true and addresses exist", () => {
+    mockWallet = {
+      ...mockWallet,
+      isLoading: false,
+      agent: AGENT,
+      addresses: [{ chainFamily: "evm", address: "0xabc0000000000000000000000000000000000def" }],
+    };
+    const html = render();
+    expect(html).toContain("Fund this wallet");
+  });
+
+  test("showQR={false} prop overrides the feature flag", () => {
+    mockWallet = {
+      ...mockWallet,
+      isLoading: false,
+      agent: AGENT,
+      addresses: [{ chainFamily: "evm", address: "0xabc0000000000000000000000000000000000def" }],
+    };
+    const html = render({ showQR: false });
+    expect(html).not.toContain("Fund this wallet");
+  });
+
+  test("chains prop filters out non-matching chain families", () => {
+    mockWallet = {
+      ...mockWallet,
+      isLoading: false,
+      agent: AGENT,
+      addresses: [
+        { chainFamily: "evm", address: "0x1111111111111111111111111111111111111111" },
+        { chainFamily: "solana", address: "SoLPubKey1111111111111111111111111111111111" },
+      ],
+    };
+    const html = render({ chains: ["solana"] });
+    expect(html).toContain("SOLANA");
+    expect(html).not.toContain("EVM");
+  });
+
+  test("falls back to agent.walletAddress when no addresses are returned", () => {
+    mockWallet = {
+      ...mockWallet,
+      isLoading: false,
+      agent: { ...AGENT, walletAddress: "0x9999999999999999999999999999999999999999" },
+      addresses: [],
+    };
+    const html = render();
+    // truncated agent.walletAddress
+    expect(html).toContain("0x9999...9999");
+    expect(html).toContain("EVM");
+  });
+});

--- a/packages/react/src/__tests__/contextHooks.test.tsx
+++ b/packages/react/src/__tests__/contextHooks.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * Tests for the two context-access hooks: useAuth() and useSteward().
+ *
+ * Both throw a descriptive error when used outside their provider, and both
+ * return the context value when wrapped. We exercise the throw path by
+ * rendering a probe component without a provider (renderToString surfaces the
+ * thrown error), and the happy path by wrapping the probe in the relevant
+ * context provider and capturing the value the hook returns.
+ */
+
+import { describe, expect, test } from "bun:test";
+import * as React from "react";
+import { renderToString } from "react-dom/server";
+
+const { useAuth } = await import("../hooks/useAuth.js");
+const { useSteward } = await import("../hooks/useSteward.js");
+const { StewardAuthContext } = await import("../provider.js");
+
+// useSteward reads the *non-exported* StewardContext via useStewardContext().
+// Since we can't import that context directly, we drive the happy path of
+// useSteward only through <StewardProvider>-equivalent wrapping is not
+// possible here without the real provider tree; instead we assert the throw
+// path (no provider) which is the branch with real guard logic. The happy
+// path for the steward context is covered indirectly by the hook tests that
+// mock ../provider.js.
+
+function AuthProbe({ sink }: { sink: (v: unknown) => void }) {
+  const value = useAuth();
+  sink(value);
+  return null;
+}
+
+function StewardProbe() {
+  useSteward();
+  return null;
+}
+
+describe("useAuth()", () => {
+  test("throws a helpful error when no StewardAuthContext provider is present", () => {
+    expect(() => renderToString(React.createElement(AuthProbe, { sink: () => {} }))).toThrow(
+      /useAuth must be used within a <StewardProvider> with an `auth` prop/,
+    );
+  });
+
+  test("returns the auth context value when wrapped", () => {
+    let captured: unknown = null;
+    const authValue = {
+      isAuthenticated: true,
+      isLoading: false,
+      user: { id: "u1", email: "u@x.io" },
+      session: null,
+      providers: null,
+      isProvidersLoading: false,
+      signOut: () => {},
+      getToken: () => "tok",
+      signInWithPasskey: async () => ({}),
+      signInWithEmail: async () => ({}),
+      verifyEmailCallback: async () => ({}),
+      signInWithSIWE: async () => ({}),
+      signInWithOAuth: async () => ({}),
+      activeTenantId: null,
+      tenants: null,
+      isTenantsLoading: false,
+      listTenants: async () => [],
+      switchTenant: async () => false,
+      joinTenant: async () => ({}),
+      leaveTenant: async () => {},
+    };
+    renderToString(
+      React.createElement(
+        StewardAuthContext.Provider,
+        { value: authValue as unknown as React.ContextType<typeof StewardAuthContext> },
+        React.createElement(AuthProbe, {
+          sink: (v) => {
+            captured = v;
+          },
+        }),
+      ),
+    );
+    expect(captured).toBe(authValue as unknown);
+    expect((captured as typeof authValue).getToken()).toBe("tok");
+  });
+});
+
+describe("useSteward()", () => {
+  test("throws when used outside a <StewardProvider>", () => {
+    expect(() => renderToString(React.createElement(StewardProbe))).toThrow(
+      /useStewardContext must be used within a <StewardProvider>/,
+    );
+  });
+});

--- a/packages/react/src/__tests__/format.test.ts
+++ b/packages/react/src/__tests__/format.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Unit tests for the `utils/format` helpers.
+ *
+ * These are pure functions (no React, no DOM) so we exercise them directly.
+ * `copyToClipboard` is the one exception (it touches `navigator.clipboard`);
+ * we cover its failure path here and leave the success path to the browser
+ * e2e suite since the test runner has no clipboard API.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  calcPercent,
+  copyToClipboard,
+  formatBalance,
+  formatRelativeTime,
+  formatTimestamp,
+  formatWei,
+  getExplorerAddressUrl,
+  getExplorerTxUrl,
+  getStatusColor,
+  truncateAddress,
+} from "../utils/format.js";
+
+describe("truncateAddress", () => {
+  test("truncates a full 0x address with default 4 chars each side", () => {
+    expect(truncateAddress("0x1234567890abcdef1234567890abcdef12345678")).toBe("0x1234...5678");
+  });
+
+  test("respects a custom char count", () => {
+    expect(truncateAddress("0x1234567890abcdef1234567890abcdef12345678", 6)).toBe(
+      "0x123456...345678",
+    );
+  });
+
+  test("returns the input unchanged when shorter than the threshold", () => {
+    // chars*2 + 2 = 10, so a 10-char string is returned as-is.
+    expect(truncateAddress("0x12345678")).toBe("0x12345678");
+  });
+
+  test("returns input unchanged for an empty string", () => {
+    expect(truncateAddress("")).toBe("");
+  });
+});
+
+describe("formatWei", () => {
+  test("returns '0' for zero or empty input", () => {
+    expect(formatWei("0")).toBe("0");
+    expect(formatWei("")).toBe("0");
+  });
+
+  test("formats one ETH with default 4 decimals", () => {
+    expect(formatWei("1000000000000000000")).toBe("1.0000");
+  });
+
+  test("formats a fractional value truncating to the requested decimals", () => {
+    // 1.5 ETH
+    expect(formatWei("1500000000000000000", 2)).toBe("1.50");
+  });
+
+  test("decimals=0 drops the fractional component entirely", () => {
+    expect(formatWei("2500000000000000000", 0)).toBe("2");
+  });
+
+  test("handles sub-one-ETH values (leading zero whole part)", () => {
+    // 0.25 ETH
+    expect(formatWei("250000000000000000", 4)).toBe("0.2500");
+  });
+});
+
+describe("formatBalance", () => {
+  test("appends the default ETH symbol", () => {
+    expect(formatBalance("1000000000000000000")).toBe("1.0000 ETH");
+  });
+
+  test("uses a custom symbol", () => {
+    expect(formatBalance("1000000000000000000", "BNB", 2)).toBe("1.00 BNB");
+  });
+});
+
+describe("formatTimestamp", () => {
+  test("accepts a Date and produces a non-empty string", () => {
+    const out = formatTimestamp(new Date(2026, 0, 15, 13, 30));
+    expect(typeof out).toBe("string");
+    expect(out.length).toBeGreaterThan(0);
+  });
+
+  test("accepts an ISO string", () => {
+    const out = formatTimestamp("2026-01-15T13:30:00.000Z");
+    expect(typeof out).toBe("string");
+    expect(out.length).toBeGreaterThan(0);
+  });
+});
+
+describe("formatRelativeTime", () => {
+  test("returns 'just now' for the current moment", () => {
+    expect(formatRelativeTime(new Date())).toBe("just now");
+  });
+
+  test("returns minutes for a few minutes ago", () => {
+    const d = new Date(Date.now() - 5 * 60 * 1000);
+    expect(formatRelativeTime(d)).toBe("5m ago");
+  });
+
+  test("returns hours for a few hours ago", () => {
+    const d = new Date(Date.now() - 3 * 60 * 60 * 1000);
+    expect(formatRelativeTime(d)).toBe("3h ago");
+  });
+
+  test("returns days for a few days ago", () => {
+    const d = new Date(Date.now() - 4 * 24 * 60 * 60 * 1000);
+    expect(formatRelativeTime(d)).toBe("4d ago");
+  });
+
+  test("falls back to an absolute timestamp beyond 30 days", () => {
+    const d = new Date(Date.now() - 45 * 24 * 60 * 60 * 1000);
+    const out = formatRelativeTime(d);
+    expect(out).not.toContain("ago");
+    expect(out.length).toBeGreaterThan(0);
+  });
+
+  test("accepts an ISO string input", () => {
+    const iso = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+    expect(formatRelativeTime(iso)).toBe("10m ago");
+  });
+});
+
+describe("getExplorerTxUrl", () => {
+  test("maps known chain ids to the right explorer", () => {
+    expect(getExplorerTxUrl("0xhash", 1)).toBe("https://etherscan.io/tx/0xhash");
+    expect(getExplorerTxUrl("0xhash", 56)).toBe("https://bscscan.com/tx/0xhash");
+    expect(getExplorerTxUrl("0xhash", 8453)).toBe("https://basescan.org/tx/0xhash");
+    expect(getExplorerTxUrl("0xhash", 100)).toBe("https://gnosisscan.io/tx/0xhash");
+  });
+
+  test("falls back to etherscan for an unknown chain id", () => {
+    expect(getExplorerTxUrl("0xhash", 999999)).toBe("https://etherscan.io/tx/0xhash");
+  });
+});
+
+describe("getExplorerAddressUrl", () => {
+  test("maps known chain ids to the right explorer", () => {
+    expect(getExplorerAddressUrl("0xabc", 137)).toBe("https://polygonscan.com/address/0xabc");
+    expect(getExplorerAddressUrl("0xabc", 42161)).toBe("https://arbiscan.io/address/0xabc");
+  });
+
+  test("falls back to etherscan for an unknown chain id", () => {
+    expect(getExplorerAddressUrl("0xabc", 0)).toBe("https://etherscan.io/address/0xabc");
+  });
+});
+
+describe("getStatusColor", () => {
+  test("maps success-ish statuses", () => {
+    expect(getStatusColor("confirmed")).toBe("stwd-badge-success");
+    expect(getStatusColor("approved")).toBe("stwd-badge-success");
+  });
+
+  test("maps error-ish statuses", () => {
+    expect(getStatusColor("failed")).toBe("stwd-badge-error");
+    expect(getStatusColor("rejected")).toBe("stwd-badge-error");
+  });
+
+  test("maps warning-ish statuses", () => {
+    expect(getStatusColor("pending")).toBe("stwd-badge-warning");
+    expect(getStatusColor("broadcast")).toBe("stwd-badge-warning");
+  });
+
+  test("falls back to muted for anything unknown", () => {
+    expect(getStatusColor("weird-state")).toBe("stwd-badge-muted");
+  });
+});
+
+describe("calcPercent", () => {
+  test("returns 0 when limit is empty or zero", () => {
+    expect(calcPercent("100", "")).toBe(0);
+    expect(calcPercent("100", "0")).toBe(0);
+  });
+
+  test("computes a mid-range percentage", () => {
+    expect(calcPercent("50", "200")).toBe(25);
+  });
+
+  test("clamps above 100 down to 100", () => {
+    expect(calcPercent("500", "100")).toBe(100);
+  });
+
+  test("returns 0 for zero usage", () => {
+    expect(calcPercent("0", "100")).toBe(0);
+  });
+});
+
+describe("copyToClipboard", () => {
+  test("resolves false when the clipboard API is unavailable / throws", async () => {
+    // The test runner has no jsdom clipboard; navigator.clipboard is undefined
+    // so writeText() throws and the helper swallows it, returning false.
+    const result = await copyToClipboard("hello");
+    expect(result).toBe(false);
+  });
+});

--- a/packages/react/src/__tests__/hooks.useApprovals.test.tsx
+++ b/packages/react/src/__tests__/hooks.useApprovals.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * Tests for useApprovals().
+ *
+ * Effect-driven polling fetch is not flushed by SSR, so we focus on the
+ * approve() / reject() callbacks which call the global `fetch` with the right
+ * URL + method + body. We mock `fetch` per-test and capture the hook return
+ * via an SSR probe. The optimistic `setPending` filter is a post-render state
+ * update that SSR cannot observe; the network contract is what matters and is
+ * fully asserted here.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import * as React from "react";
+import { renderToString } from "react-dom/server";
+
+// NOTE: bun's `mock.module` is process-global; this suite is run
+// one-file-per-process by the package's test script. Run individual files
+// (or `bun run test`), not a single `bun test <glob>`.
+mock.module("../provider.js", () => ({
+  useStewardContext: () => ({
+    client: { getBaseUrl: () => "https://api.test" },
+    agentId: "agent x", // contains a space to verify URL encoding
+    pollInterval: 30000,
+    features: {},
+    theme: {},
+    isLoading: false,
+  }),
+  StewardAuthContext: React.createContext(null),
+  StewardProvider: ({ children }: { children?: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+}));
+
+const { useApprovals } = await import("../hooks/useApprovals.js");
+
+type UseApprovalsReturn = ReturnType<typeof useApprovals>;
+
+function captureHook(): UseApprovalsReturn {
+  let captured: UseApprovalsReturn | null = null;
+  function Probe() {
+    captured = useApprovals();
+    return null;
+  }
+  renderToString(React.createElement(Probe));
+  if (!captured) throw new Error("hook did not render");
+  return captured;
+}
+
+const originalFetch = globalThis.fetch;
+let fetchMock: ReturnType<typeof mock>;
+
+describe("useApprovals()", () => {
+  beforeEach(() => {
+    fetchMock = mock(async () => ({ ok: true, status: 200, json: async () => ({}) }));
+    globalThis.fetch = fetchMock as any;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("initial return shape: loading, empty pending, not resolving", () => {
+    const api = captureHook();
+    expect(api.isLoading).toBe(true);
+    expect(api.pending).toEqual([]);
+    expect(api.error).toBeNull();
+    expect(api.isResolving).toBe(false);
+    expect(typeof api.approve).toBe("function");
+    expect(typeof api.reject).toBe("function");
+    expect(typeof api.refetch).toBe("function");
+  });
+
+  test("approve() POSTs to the encoded approve endpoint", async () => {
+    const api = captureHook();
+    await api.approve("tx-123");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, opts] = fetchMock.mock.calls[0] as [string, RequestInit];
+    // agentId "agent x" must be percent-encoded.
+    expect(url).toBe("https://api.test/agents/agent%20x/approvals/tx-123/approve");
+    expect(opts.method).toBe("POST");
+  });
+
+  test("approve() throws on a non-ok response", async () => {
+    fetchMock = mock(async () => ({ ok: false, status: 500, json: async () => ({}) }));
+    globalThis.fetch = fetchMock as any;
+    const api = captureHook();
+    await expect(api.approve("tx-1")).rejects.toThrow("Approve failed: 500");
+  });
+
+  test("reject() POSTs the reason in the JSON body", async () => {
+    const api = captureHook();
+    await api.reject("tx-9", "looks sketchy");
+    const [url, opts] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://api.test/agents/agent%20x/approvals/tx-9/reject");
+    expect(opts.method).toBe("POST");
+    expect(JSON.parse(String(opts.body))).toEqual({ reason: "looks sketchy" });
+  });
+
+  test("reject() throws on a non-ok response", async () => {
+    fetchMock = mock(async () => ({ ok: false, status: 403, json: async () => ({}) }));
+    globalThis.fetch = fetchMock as any;
+    const api = captureHook();
+    await expect(api.reject("tx-2")).rejects.toThrow("Reject failed: 403");
+  });
+});

--- a/packages/react/src/__tests__/hooks.usePolicies.test.tsx
+++ b/packages/react/src/__tests__/hooks.usePolicies.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * Tests for usePolicies().
+ *
+ * The test runner has no jsdom and renderToString does not flush effects, so
+ * we focus on the logic that lives in the returned callbacks rather than
+ * effect-driven fetches. We mock ../provider.js to inject a fake
+ * StewardContext (client + tenantConfig) and capture the hook's return value
+ * via an SSR probe, then drive `setPolicies` / `applyTemplate` directly and
+ * assert against the mocked client + the thrown errors.
+ *
+ * Effect-driven initial fetch (fetchPolicies on mount) is covered by the
+ * browser e2e suite; SSR cannot flush it.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import * as React from "react";
+import { renderToString } from "react-dom/server";
+
+type PolicyRule = { type: string; config: Record<string, unknown> };
+
+const setPoliciesMock = mock(async (_agentId: string, _policies: PolicyRule[]) => {});
+const getPoliciesMock = mock(async (_agentId: string) => [] as PolicyRule[]);
+
+let mockTenantConfig: {
+  policyTemplates: Array<{ id: string; policies: PolicyRule[] }>;
+} | null = null;
+
+// NOTE on isolation: bun's `mock.module` is process-global. This suite is run
+// one-file-per-process by the package's test script
+// (`for f in src/__tests__/*.test.*; do bun test "$f"; done`), which is what
+// keeps each file's `../provider.js` / hook-module mocks from clobbering each
+// other. Run individual files (or via `bun run test`) rather than a single
+// `bun test <glob>` over the whole directory.
+mock.module("../provider.js", () => ({
+  useStewardContext: () => ({
+    client: {
+      getPolicies: getPoliciesMock,
+      setPolicies: setPoliciesMock,
+      getBaseUrl: () => "https://api.test",
+    },
+    agentId: "agent-1",
+    tenantConfig: mockTenantConfig,
+    pollInterval: 30000,
+    features: {},
+    theme: {},
+    isLoading: false,
+  }),
+  StewardAuthContext: React.createContext(null),
+  StewardProvider: ({ children }: { children?: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+}));
+
+const { usePolicies } = await import("../hooks/usePolicies.js");
+
+type UsePoliciesReturn = ReturnType<typeof usePolicies>;
+
+function captureHook(): UsePoliciesReturn {
+  let captured: UsePoliciesReturn | null = null;
+  function Probe() {
+    captured = usePolicies();
+    return null;
+  }
+  renderToString(React.createElement(Probe));
+  if (!captured) throw new Error("hook did not render");
+  return captured;
+}
+
+describe("usePolicies()", () => {
+  beforeEach(() => {
+    setPoliciesMock.mockClear();
+    getPoliciesMock.mockClear();
+    mockTenantConfig = null;
+  });
+
+  test("initial return shape: loading, empty policies, no error", () => {
+    const api = captureHook();
+    expect(api.isLoading).toBe(true);
+    expect(api.policies).toEqual([]);
+    expect(api.error).toBeNull();
+    expect(api.isSaving).toBe(false);
+    expect(typeof api.setPolicies).toBe("function");
+    expect(typeof api.applyTemplate).toBe("function");
+    expect(typeof api.refetch).toBe("function");
+  });
+
+  test("setPolicies forwards the policies to client.setPolicies", async () => {
+    const api = captureHook();
+    const next: PolicyRule[] = [{ type: "spend_limit", config: { daily: "1000" } }];
+    await api.setPolicies(next);
+    expect(setPoliciesMock).toHaveBeenCalledTimes(1);
+    expect(setPoliciesMock.mock.calls[0]).toEqual(["agent-1", next]);
+  });
+
+  test("setPolicies rethrows when the client rejects", async () => {
+    setPoliciesMock.mockImplementationOnce(async () => {
+      throw new Error("network down");
+    });
+    const api = captureHook();
+    await expect(api.setPolicies([])).rejects.toThrow("network down");
+  });
+
+  test("applyTemplate throws when the template id is unknown", async () => {
+    mockTenantConfig = { policyTemplates: [{ id: "conservative", policies: [] }] };
+    const api = captureHook();
+    await expect(api.applyTemplate("does-not-exist")).rejects.toThrow(
+      'Template "does-not-exist" not found',
+    );
+  });
+
+  test("applyTemplate clones the template and saves it (no overrides)", async () => {
+    const templatePolicies: PolicyRule[] = [{ type: "spend_limit", config: { daily: "5" } }];
+    mockTenantConfig = {
+      policyTemplates: [{ id: "default", policies: templatePolicies }],
+    };
+    const api = captureHook();
+    await api.applyTemplate("default");
+    expect(setPoliciesMock).toHaveBeenCalledTimes(1);
+    const savedArg = setPoliciesMock.mock.calls[0][1];
+    expect(savedArg).toEqual(templatePolicies);
+    // structuredClone => not the same reference as the template source.
+    expect(savedArg).not.toBe(templatePolicies);
+    expect(savedArg[0]).not.toBe(templatePolicies[0]);
+  });
+
+  test("applyTemplate applies a top-level field override before saving", async () => {
+    mockTenantConfig = {
+      policyTemplates: [{ id: "tpl", policies: [{ type: "spend_limit", config: { daily: "1" } }] }],
+    };
+    const api = captureHook();
+    await api.applyTemplate("tpl", { "spend_limit.daily": "999" });
+    const saved = setPoliciesMock.mock.calls[0][1] as PolicyRule[];
+    expect(saved[0].config.daily).toBe("999");
+  });
+
+  test("applyTemplate applies a nested field override before saving", async () => {
+    mockTenantConfig = {
+      policyTemplates: [
+        {
+          id: "tpl",
+          policies: [{ type: "allowlist", config: { limits: { perTx: "1" } } }],
+        },
+      ],
+    };
+    const api = captureHook();
+    await api.applyTemplate("tpl", { "allowlist.limits.perTx": "42" });
+    const saved = setPoliciesMock.mock.calls[0][1] as PolicyRule[];
+    expect((saved[0].config.limits as Record<string, unknown>).perTx).toBe("42");
+  });
+});

--- a/packages/react/src/__tests__/hooks.useSpend.test.tsx
+++ b/packages/react/src/__tests__/hooks.useSpend.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * Tests for useSpend().
+ *
+ * Covers the deterministic surface: initial return shape and the refetch()
+ * URL construction (encoded agentId + range query param). The mount-time
+ * polling fetch is effect-driven and covered by the browser e2e suite.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import * as React from "react";
+import { renderToString } from "react-dom/server";
+
+// NOTE: bun's `mock.module` is process-global; this suite is run
+// one-file-per-process by the package's test script. Run individual files
+// (or `bun run test`), not a single `bun test <glob>`.
+mock.module("../provider.js", () => ({
+  useStewardContext: () => ({
+    client: { getBaseUrl: () => "https://api.test" },
+    agentId: "a b", // space to verify encoding
+    pollInterval: 30000,
+    features: {},
+    theme: {},
+    isLoading: false,
+  }),
+  StewardAuthContext: React.createContext(null),
+  StewardProvider: ({ children }: { children?: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+}));
+
+const { useSpend } = await import("../hooks/useSpend.js");
+
+type UseSpendReturn = ReturnType<typeof useSpend>;
+
+function captureHook(range?: Parameters<typeof useSpend>[0]): UseSpendReturn {
+  let captured: UseSpendReturn | null = null;
+  function Probe() {
+    captured = useSpend(range);
+    return null;
+  }
+  renderToString(React.createElement(Probe));
+  if (!captured) throw new Error("hook did not render");
+  return captured;
+}
+
+const originalFetch = globalThis.fetch;
+let fetchMock: ReturnType<typeof mock>;
+
+describe("useSpend()", () => {
+  beforeEach(() => {
+    fetchMock = mock(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true, data: { range: "7d" } }),
+    }));
+    globalThis.fetch = fetchMock as any;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("initial return shape: loading, null stats, no error", () => {
+    const api = captureHook();
+    expect(api.isLoading).toBe(true);
+    expect(api.stats).toBeNull();
+    expect(api.error).toBeNull();
+    expect(typeof api.refetch).toBe("function");
+  });
+
+  test("refetch hits the spend-stats endpoint with the default 7d range", async () => {
+    const api = captureHook();
+    await api.refetch();
+    const url = String(fetchMock.mock.calls[0][0]);
+    expect(url).toBe("https://api.test/agents/a%20b/spend-stats?range=7d");
+  });
+
+  test("refetch honors a custom range", async () => {
+    const api = captureHook("30d");
+    await api.refetch();
+    const url = String(fetchMock.mock.calls[0][0]);
+    expect(url).toContain("range=30d");
+  });
+});

--- a/packages/react/src/__tests__/hooks.useTransactions.test.tsx
+++ b/packages/react/src/__tests__/hooks.useTransactions.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * Tests for useTransactions().
+ *
+ * SSR does not flush the polling effect, so state-driven pagination (page
+ * advancing) is out of scope here and lives in the browser e2e suite. We
+ * cover the deterministic surface:
+ *   - initial return shape
+ *   - refetch() builds the paginated-endpoint URL with the right query params
+ *     (page, pageSize, status, chainId), all properly encoded
+ *   - the getHistory() fallback path is taken when the paginated endpoint
+ *     returns a non-ok / malformed response
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import * as React from "react";
+import { renderToString } from "react-dom/server";
+
+const getHistoryMock = mock(
+  async (_agentId: string) => [] as Array<{ value: string; timestamp: number }>,
+);
+
+// NOTE: bun's `mock.module` is process-global; this suite is run
+// one-file-per-process by the package's test script. Run individual files
+// (or `bun run test`), not a single `bun test <glob>`.
+mock.module("../provider.js", () => ({
+  useStewardContext: () => ({
+    client: {
+      getBaseUrl: () => "https://api.test",
+      getHistory: getHistoryMock,
+    },
+    agentId: "agent/1", // slash to verify encoding
+    pollInterval: 30000,
+    features: {},
+    theme: {},
+    isLoading: false,
+  }),
+  StewardAuthContext: React.createContext(null),
+  StewardProvider: ({ children }: { children?: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+}));
+
+const { useTransactions } = await import("../hooks/useTransactions.js");
+
+type UseTxReturn = ReturnType<typeof useTransactions>;
+
+function captureHook(opts?: Parameters<typeof useTransactions>[0]): UseTxReturn {
+  let captured: UseTxReturn | null = null;
+  function Probe() {
+    captured = useTransactions(opts);
+    return null;
+  }
+  renderToString(React.createElement(Probe));
+  if (!captured) throw new Error("hook did not render");
+  return captured;
+}
+
+const originalFetch = globalThis.fetch;
+let fetchMock: ReturnType<typeof mock>;
+
+describe("useTransactions()", () => {
+  beforeEach(() => {
+    getHistoryMock.mockClear();
+    getHistoryMock.mockImplementation(async () => []);
+    fetchMock = mock(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true, data: { transactions: [] } }),
+    }));
+    globalThis.fetch = fetchMock as any;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("initial return shape: loading, empty list, page 1, totalPages 1", () => {
+    const api = captureHook();
+    expect(api.isLoading).toBe(true);
+    expect(api.transactions).toEqual([]);
+    expect(api.error).toBeNull();
+    expect(api.page).toBe(1);
+    expect(api.totalPages).toBe(1);
+    expect(typeof api.nextPage).toBe("function");
+    expect(typeof api.prevPage).toBe("function");
+    expect(typeof api.refetch).toBe("function");
+  });
+
+  test("refetch builds the paginated endpoint URL with default page/pageSize", async () => {
+    const api = captureHook();
+    await api.refetch();
+    const url = String(fetchMock.mock.calls[0][0]);
+    expect(url).toContain("https://api.test/agents/agent%2F1/transactions?");
+    expect(url).toContain("page=1");
+    expect(url).toContain("pageSize=20");
+  });
+
+  test("refetch includes status + chainId query params when provided", async () => {
+    const api = captureHook({
+      pageSize: 5,
+      status: ["pending", "confirmed"],
+      chainId: 8453,
+    });
+    await api.refetch();
+    const url = String(fetchMock.mock.calls[0][0]);
+    expect(url).toContain("pageSize=5");
+    // URLSearchParams encodes the comma in the joined status list.
+    expect(url).toContain("status=pending%2Cconfirmed");
+    expect(url).toContain("chainId=8453");
+  });
+
+  test("falls back to getHistory() when the paginated endpoint is not ok", async () => {
+    fetchMock = mock(async () => ({ ok: false, status: 404, json: async () => ({}) }));
+    globalThis.fetch = fetchMock as any;
+    getHistoryMock.mockImplementation(async () => [
+      { value: "1000000000000000000", timestamp: 1_700_000_000 },
+    ]);
+    const api = captureHook({ chainId: 56 });
+    await api.refetch();
+    expect(getHistoryMock).toHaveBeenCalledTimes(1);
+    expect(getHistoryMock.mock.calls[0][0]).toBe("agent/1");
+  });
+
+  test("falls back to getHistory() when the paginated payload lacks transactions", async () => {
+    fetchMock = mock(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true, data: {} }), // no transactions field
+    }));
+    globalThis.fetch = fetchMock as any;
+    const api = captureHook();
+    await api.refetch();
+    expect(getHistoryMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react/src/__tests__/hooks.useWallet.test.tsx
+++ b/packages/react/src/__tests__/hooks.useWallet.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * Tests for useWallet().
+ *
+ * Covers initial return shape and the refetch() wiring: it fans out to
+ * client.getAgent / getBalance / getAddresses in parallel, tolerating
+ * rejections from getBalance (→ null) and getAddresses (→ empty list). The
+ * mount-time polling effect is covered by the browser e2e suite.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import * as React from "react";
+import { renderToString } from "react-dom/server";
+
+const getAgentMock = mock(async (_id: string) => ({ id: "agent-1", name: "Test Agent" }));
+const getBalanceMock = mock(async (_id: string) => ({ balances: { native: "0" } }));
+const getAddressesMock = mock(async (_id: string) => ({
+  addresses: [{ chainFamily: "evm", address: "0xabc" }],
+}));
+
+// NOTE on isolation: bun's `mock.module` is process-global. This suite is run
+// one-file-per-process by the package's test script, which keeps each file's
+// `../provider.js` / hook-module mocks from clobbering each other. Run
+// individual files (or `bun run test`), not a single `bun test <glob>`.
+mock.module("../provider.js", () => ({
+  useStewardContext: () => ({
+    client: {
+      getAgent: getAgentMock,
+      getBalance: getBalanceMock,
+      getAddresses: getAddressesMock,
+      getBaseUrl: () => "https://api.test",
+    },
+    agentId: "agent-1",
+    pollInterval: 30000,
+    features: {},
+    theme: {},
+    isLoading: false,
+  }),
+  StewardAuthContext: React.createContext(null),
+  StewardProvider: ({ children }: { children?: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+}));
+
+const { useWallet } = await import("../hooks/useWallet.js");
+
+type UseWalletReturn = ReturnType<typeof useWallet>;
+
+function captureHook(): UseWalletReturn {
+  let captured: UseWalletReturn | null = null;
+  function Probe() {
+    captured = useWallet();
+    return null;
+  }
+  renderToString(React.createElement(Probe));
+  if (!captured) throw new Error("hook did not render");
+  return captured;
+}
+
+describe("useWallet()", () => {
+  beforeEach(() => {
+    getAgentMock.mockClear();
+    getBalanceMock.mockClear();
+    getAddressesMock.mockClear();
+    getAgentMock.mockImplementation(async () => ({ id: "agent-1", name: "Test Agent" }));
+    getBalanceMock.mockImplementation(async () => ({ balances: { native: "0" } }));
+    getAddressesMock.mockImplementation(async () => ({
+      addresses: [{ chainFamily: "evm", address: "0xabc" }],
+    }));
+  });
+
+  test("initial return shape: loading, nulls, empty addresses", () => {
+    const api = captureHook();
+    expect(api.isLoading).toBe(true);
+    expect(api.agent).toBeNull();
+    expect(api.balance).toBeNull();
+    expect(api.addresses).toEqual([]);
+    expect(api.error).toBeNull();
+    expect(typeof api.refetch).toBe("function");
+  });
+
+  test("refetch fans out to all three client calls with the agent id", async () => {
+    const api = captureHook();
+    await api.refetch();
+    expect(getAgentMock).toHaveBeenCalledTimes(1);
+    expect(getBalanceMock).toHaveBeenCalledTimes(1);
+    expect(getAddressesMock).toHaveBeenCalledTimes(1);
+    expect(getAgentMock.mock.calls[0][0]).toBe("agent-1");
+  });
+
+  test("refetch tolerates a getBalance rejection (does not reject overall)", async () => {
+    getBalanceMock.mockImplementation(async () => {
+      throw new Error("balance endpoint down");
+    });
+    const api = captureHook();
+    // The hook catches getBalance via .catch(() => null); refetch should
+    // resolve without throwing.
+    await expect(api.refetch()).resolves.toBeUndefined();
+    expect(getAgentMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("refetch tolerates a getAddresses rejection (falls back to empty list)", async () => {
+    getAddressesMock.mockImplementation(async () => {
+      throw new Error("addresses endpoint down");
+    });
+    const api = captureHook();
+    await expect(api.refetch()).resolves.toBeUndefined();
+  });
+
+  test("refetch surfaces a getAgent rejection by not throwing (error captured in state)", async () => {
+    getAgentMock.mockImplementation(async () => {
+      throw new Error("agent not found");
+    });
+    const api = captureHook();
+    // getAgent is the only non-catch call; the hook's try/catch swallows it
+    // into `error` state, so refetch still resolves.
+    await expect(api.refetch()).resolves.toBeUndefined();
+  });
+});

--- a/packages/react/src/__tests__/theme.test.ts
+++ b/packages/react/src/__tests__/theme.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Unit tests for the `utils/theme` helpers (pure functions, no React/DOM).
+ *
+ * Covers the CSS-variable projection and the merge precedence rules that
+ * <StewardProvider> relies on when combining tenant theme config with
+ * caller overrides.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { TenantTheme } from "../types.js";
+import { DEFAULT_THEME, mergeTheme, themeToCSS } from "../utils/theme.js";
+
+describe("DEFAULT_THEME", () => {
+  test("is a dark color scheme with the steward gold primary", () => {
+    expect(DEFAULT_THEME.colorScheme).toBe("dark");
+    expect(DEFAULT_THEME.primaryColor).toBe("#D4A054");
+    expect(DEFAULT_THEME.borderRadius).toBe(8);
+  });
+});
+
+describe("themeToCSS", () => {
+  test("projects every theme field onto its --stwd-* custom property", () => {
+    const css = themeToCSS(DEFAULT_THEME);
+    expect(css["--stwd-primary"]).toBe(DEFAULT_THEME.primaryColor);
+    expect(css["--stwd-accent"]).toBe(DEFAULT_THEME.accentColor);
+    expect(css["--stwd-bg"]).toBe(DEFAULT_THEME.backgroundColor);
+    expect(css["--stwd-surface"]).toBe(DEFAULT_THEME.surfaceColor);
+    expect(css["--stwd-text"]).toBe(DEFAULT_THEME.textColor);
+    expect(css["--stwd-muted"]).toBe(DEFAULT_THEME.mutedColor);
+    expect(css["--stwd-success"]).toBe(DEFAULT_THEME.successColor);
+    expect(css["--stwd-error"]).toBe(DEFAULT_THEME.errorColor);
+    expect(css["--stwd-warning"]).toBe(DEFAULT_THEME.warningColor);
+  });
+
+  test("suffixes borderRadius with px", () => {
+    const css = themeToCSS({ ...DEFAULT_THEME, borderRadius: 12 });
+    expect(css["--stwd-radius"]).toBe("12px");
+  });
+
+  test("falls back to the default font stack when fontFamily is empty", () => {
+    const css = themeToCSS({ ...DEFAULT_THEME, fontFamily: "" });
+    expect(css["--stwd-font"]).toBe("Inter, system-ui, sans-serif");
+  });
+
+  test("uses a provided fontFamily verbatim", () => {
+    const css = themeToCSS({ ...DEFAULT_THEME, fontFamily: "Comic Sans MS" });
+    expect(css["--stwd-font"]).toBe("Comic Sans MS");
+  });
+});
+
+describe("mergeTheme", () => {
+  test("returns the base theme untouched when no overrides are given", () => {
+    const merged = mergeTheme(DEFAULT_THEME);
+    expect(merged).toBe(DEFAULT_THEME);
+  });
+
+  test("returns the base theme untouched when overrides is undefined", () => {
+    const merged = mergeTheme(DEFAULT_THEME, undefined);
+    expect(merged).toBe(DEFAULT_THEME);
+  });
+
+  test("override fields win over base fields", () => {
+    const overrides: Partial<TenantTheme> = {
+      primaryColor: "#FF0000",
+      borderRadius: 0,
+    };
+    const merged = mergeTheme(DEFAULT_THEME, overrides);
+    expect(merged.primaryColor).toBe("#FF0000");
+    expect(merged.borderRadius).toBe(0);
+    // Untouched fields fall through from the base.
+    expect(merged.accentColor).toBe(DEFAULT_THEME.accentColor);
+    expect(merged.colorScheme).toBe(DEFAULT_THEME.colorScheme);
+  });
+
+  test("does not mutate the base theme object", () => {
+    const baseClone = { ...DEFAULT_THEME };
+    mergeTheme(DEFAULT_THEME, { primaryColor: "#123456" });
+    expect(DEFAULT_THEME).toEqual(baseClone);
+  });
+});

--- a/packages/react/src/__tests__/walletPanelRegistry.test.ts
+++ b/packages/react/src/__tests__/walletPanelRegistry.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Unit tests for the wallet panel registry.
+ *
+ * The registry decouples `<StewardLogin>` (root entry) from the optional
+ * wallet peer deps. These tests verify the register / read / reset cycle and
+ * the "consumer never imported @stwd/react/wallet" fallback (undefined).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { ComponentType } from "react";
+import {
+  _resetWalletPanelRegistry,
+  getEvmWalletPanel,
+  getSolanaWalletPanel,
+  registerEvmWalletPanel,
+  registerSolanaWalletPanel,
+  type WalletPanelLoader,
+} from "../internal/walletPanelRegistry.js";
+
+const noopPanel = (() => null) as ComponentType<unknown>;
+function makeLoader(): WalletPanelLoader {
+  return { load: async () => ({ default: noopPanel }) };
+}
+
+describe("walletPanelRegistry", () => {
+  beforeEach(() => {
+    _resetWalletPanelRegistry();
+  });
+  afterEach(() => {
+    _resetWalletPanelRegistry();
+  });
+
+  test("getters return undefined before any registration", () => {
+    expect(getEvmWalletPanel()).toBeUndefined();
+    expect(getSolanaWalletPanel()).toBeUndefined();
+  });
+
+  test("registerEvmWalletPanel makes the EVM loader readable", () => {
+    const loader = makeLoader();
+    registerEvmWalletPanel(loader);
+    expect(getEvmWalletPanel()).toBe(loader);
+    // Solana stays unregistered.
+    expect(getSolanaWalletPanel()).toBeUndefined();
+  });
+
+  test("registerSolanaWalletPanel makes the Solana loader readable", () => {
+    const loader = makeLoader();
+    registerSolanaWalletPanel(loader);
+    expect(getSolanaWalletPanel()).toBe(loader);
+    expect(getEvmWalletPanel()).toBeUndefined();
+  });
+
+  test("registering both keeps each loader independent", () => {
+    const evm = makeLoader();
+    const sol = makeLoader();
+    registerEvmWalletPanel(evm);
+    registerSolanaWalletPanel(sol);
+    expect(getEvmWalletPanel()).toBe(evm);
+    expect(getSolanaWalletPanel()).toBe(sol);
+    expect(getEvmWalletPanel()).not.toBe(getSolanaWalletPanel());
+  });
+
+  test("re-registering overwrites the previous loader", () => {
+    const first = makeLoader();
+    const second = makeLoader();
+    registerEvmWalletPanel(first);
+    registerEvmWalletPanel(second);
+    expect(getEvmWalletPanel()).toBe(second);
+  });
+
+  test("_resetWalletPanelRegistry clears both loaders", () => {
+    registerEvmWalletPanel(makeLoader());
+    registerSolanaWalletPanel(makeLoader());
+    _resetWalletPanelRegistry();
+    expect(getEvmWalletPanel()).toBeUndefined();
+    expect(getSolanaWalletPanel()).toBeUndefined();
+  });
+
+  test("a registered loader actually resolves to a component module", async () => {
+    const loader = makeLoader();
+    registerEvmWalletPanel(loader);
+    const mod = await getEvmWalletPanel()?.load();
+    expect(mod?.default).toBe(noopPanel);
+  });
+});


### PR DESCRIPTION
## What

Test-only PR from the 2026-05-30 hardening pass. No source changes. Raises coverage on `@stwd/react` (the embeddable login surface, the audit's biggest coverage gap: 37 source files, ~5,611 LOC).

**19 new test files, 139 new cases. Suite goes 56 -> 195 passing, 0 failures. Biome clean.**

### Now covered
- **Pure utils** (were zero): `format.ts` (truncateAddress, formatWei/Balance/Timestamp/RelativeTime, explorer URLs, status color, copyToClipboard), `theme.ts` (mergeTheme precedence/immutability), `walletPanelRegistry.ts`.
- **Context hooks:** `useAuth` + `useSteward` (outside-provider guard + happy path).
- **Data hooks:** `useWallet`, `useTransactions`, `useApprovals`, `usePolicies`, `useSpend` (return shape, URL encoding, fetch wiring, error rethrow, template/override logic).
- **Components (SSR branch coverage):** StewardAuthGuard, StewardUserButton (gravatar/initials/session fallback), StewardTenantPicker, SpendDashboard, ApprovalQueue, WalletOverview, PolicyControls (exposure hidden/enforced + label overrides), the email/OAuth callbacks, PasskeyEnrollmentPrompt.

### Conventions
Matched the package exactly: `bun:test` + `react-dom/server` renderToString (no jsdom), `mock.module` per-file, the package's one-file-per-process test runner.

### Deliberately left for e2e (noted in files)
Effect/DOM-driven branches (callback token-in-URL flows, interactive dropdowns/dialogs, StewardProvider's effect surface) and icons. The runner has no DOM and SSR doesn't flush effects; forcing these would mean introducing jsdom/testing-library, which breaks the existing convention. Covered deterministic initial-render + rules-of-hooks invariants instead.

Co-authored-by: wakesync <shadow@shad0w.xyz>