### PR TITLE
feat(vault): pluggable KMS/BYOK keystore backend (close the custody gap)

### DIFF
--- a/packages/vault/KEYSTORE-BACKENDS.md
+++ b/packages/vault/KEYSTORE-BACKENDS.md
@@ -1,0 +1,91 @@
+# Keystore backends
+
+`@stwd/vault` stores private signing keys as encrypted records. The vault accepts a `keystoreBackend` in `VaultConfig` so operators can choose where key wrapping happens.
+
+## Default AES backend
+
+If `keystoreBackend` is not set, the vault uses `KeyStore` with `masterPassword` exactly as before. This path derives an AES-256-GCM key from the master password with scrypt, then encrypts each private key locally.
+
+Tradeoff: simple deployment and no network dependency. The application process can decrypt the raw private key during signing, so anyone with the master password and database contents can recover keys.
+
+```ts
+import { Vault } from "@stwd/vault";
+
+const vault = new Vault({ masterPassword: process.env.STEWARD_MASTER_PASSWORD! });
+```
+
+## AWS KMS envelope backend
+
+`KmsEnvelopeKeystore` creates a random 256-bit data key per record, encrypts the private key locally with AES-256-GCM, then asks AWS KMS to wrap the data key. The KMS root key never enters the application process. The plaintext data key is present only during encrypt or decrypt.
+
+Tradeoff: the database alone is not enough to decrypt keys. The application still receives plaintext private keys at sign time, and availability depends on AWS KMS.
+
+```ts
+import { KmsEnvelopeKeystore, Vault } from "@stwd/vault";
+
+const vault = new Vault({
+  masterPassword: process.env.STEWARD_MASTER_PASSWORD!,
+  keystoreBackend: new KmsEnvelopeKeystore({
+    provider: "aws",
+    keyId: process.env.STEWARD_AWS_KMS_KEY_ARN,
+    region: process.env.STEWARD_AWS_REGION,
+  }),
+});
+```
+
+The AWS SDK is lazy loaded only when this backend is used. It is not required for default AES deployments.
+
+Environment variables:
+
+- `STEWARD_KMS_PROVIDER=aws`
+- `STEWARD_KMS_KEY_ID` or `STEWARD_AWS_KMS_KEY_ARN`, the KMS key id or ARN
+- `STEWARD_AWS_REGION`, the AWS region
+
+You can also use `KmsEnvelopeKeystore.fromEnv()`.
+
+## PKCS#11 backend
+
+The PKCS#11 mode is for operators that use a hardware module or a PKCS#11 compatible service for wrapping data keys. The backend shape is present and accepts a `Pkcs11ClientLike` implementation with `wrapKey` and `unwrapKey` methods. This release does not include a full generic session manager for every PKCS#11 module.
+
+Tradeoff: the wrapping root can live in hardware or a managed HSM. Operators must provide and test the module specific PKCS#11 adapter.
+
+```ts
+import { KmsEnvelopeKeystore } from "@stwd/vault";
+
+const backend = new KmsEnvelopeKeystore({
+  provider: "pkcs11",
+  modulePath: process.env.STEWARD_PKCS11_MODULE,
+  pin: process.env.STEWARD_PKCS11_PIN,
+  keyLabel: process.env.STEWARD_PKCS11_KEY_LABEL,
+  client: myPkcs11Client,
+});
+```
+
+Environment variables:
+
+- `STEWARD_KMS_PROVIDER=pkcs11`
+- `STEWARD_PKCS11_MODULE`, path to the module
+- `STEWARD_PKCS11_PIN`, user PIN or token PIN
+- `STEWARD_PKCS11_KEY_LABEL`, label of the wrapping key
+
+## Custom backend
+
+Implement `KeystoreBackend` and pass it to the vault.
+
+```ts
+import type { EncryptedKey, KeystoreBackend } from "@stwd/vault";
+
+const backend: KeystoreBackend = {
+  id: "custom:v1",
+  async encrypt(privateKey): Promise<EncryptedKey> {
+    return encryptSomewhere(privateKey);
+  },
+  async decrypt(encrypted): Promise<string> {
+    return decryptSomewhere(encrypted);
+  },
+};
+
+const vault = new Vault({ masterPassword: "unused-by-custom", keystoreBackend: backend });
+```
+
+Backends should reject records produced by another backend. KMS envelope records include backend metadata so an AES backend cannot silently decrypt them and a PKCS#11 backend cannot silently decrypt AWS KMS records.

--- a/packages/vault/package.json
+++ b/packages/vault/package.json
@@ -21,6 +21,18 @@
     "drizzle-orm": "^0.44.5",
     "viem": "^2.30.0"
   },
+  "peerDependencies": {
+    "@aws-sdk/client-kms": "^3.700.0",
+    "graphene-pk11": "^2.2.0"
+  },
+  "peerDependenciesMeta": {
+    "@aws-sdk/client-kms": {
+      "optional": true
+    },
+    "graphene-pk11": {
+      "optional": true
+    }
+  },
   "description": "AES-256-GCM encrypted keystore and transaction signing via viem",
   "devDependencies": {
     "@types/node": "^25.5.0"

--- a/packages/vault/src/__tests__/keystore-kms.test.ts
+++ b/packages/vault/src/__tests__/keystore-kms.test.ts
@@ -1,0 +1,186 @@
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+
+import { encryptedKeys, eq, getDb, tenants } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { KeyStore } from "../keystore";
+import { backendFromKeyStore } from "../keystore-backend";
+import { type AwsKmsClientLike, KmsEnvelopeKeystore } from "../keystore-kms";
+import { Vault } from "../vault";
+
+const MASTER_PASSWORD = "test-kms-keystore-master";
+const TENANT_ID = "test-kms-tenant";
+
+const openClients: Array<{ close: () => Promise<void> }> = [];
+
+class MockAwsKmsClient implements AwsKmsClientLike {
+  private readonly rootKey = randomBytes(32);
+
+  encryptCalls = 0;
+
+  decryptCalls = 0;
+
+  async send(command: unknown): Promise<unknown> {
+    const typed = command as { commandName?: string; input?: Record<string, unknown> };
+    if (typed.commandName === "EncryptCommand") {
+      this.encryptCalls += 1;
+      const plaintext = Buffer.from(typed.input?.Plaintext as Uint8Array);
+      const iv = randomBytes(12);
+      const cipher = createCipheriv("aes-256-gcm", this.rootKey, iv);
+      const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+      const tag = cipher.getAuthTag();
+      return {
+        CiphertextBlob: Buffer.from(
+          JSON.stringify({
+            iv: iv.toString("base64"),
+            tag: tag.toString("base64"),
+            ciphertext: ciphertext.toString("base64"),
+          }),
+        ),
+      };
+    }
+
+    if (typed.commandName === "DecryptCommand") {
+      this.decryptCalls += 1;
+      const blob = JSON.parse(
+        Buffer.from(typed.input?.CiphertextBlob as Uint8Array).toString("utf8"),
+      ) as {
+        iv: string;
+        tag: string;
+        ciphertext: string;
+      };
+      const decipher = createDecipheriv(
+        "aes-256-gcm",
+        this.rootKey,
+        Buffer.from(blob.iv, "base64"),
+      );
+      decipher.setAuthTag(Buffer.from(blob.tag, "base64"));
+      return {
+        Plaintext: Buffer.concat([
+          decipher.update(Buffer.from(blob.ciphertext, "base64")),
+          decipher.final(),
+        ]),
+      };
+    }
+
+    throw new Error("Unexpected mock KMS command");
+  }
+}
+
+async function freshVault(keystoreBackend?: KmsEnvelopeKeystore): Promise<Vault> {
+  const { db, client } = await createPGLiteDb("memory://");
+  openClients.push(client);
+  setPGLiteOverride(db as never, async () => {
+    await client.close();
+  });
+
+  await getDb().insert(tenants).values({
+    id: TENANT_ID,
+    name: "KMS Test Tenant",
+    apiKeyHash: "test-hash",
+  });
+
+  return new Vault({ masterPassword: MASTER_PASSWORD, keystoreBackend });
+}
+
+describe("KMS envelope keystore", () => {
+  beforeEach(() => {
+    process.env.NODE_ENV = "test";
+  });
+
+  afterAll(async () => {
+    for (const client of openClients) {
+      await client.close().catch(() => {});
+    }
+    openClients.length = 0;
+  });
+
+  test("default AES backend round-trips through the backend seam", async () => {
+    const backend = backendFromKeyStore(new KeyStore(MASTER_PASSWORD));
+    const privateKey = "0x" + "1".repeat(64);
+
+    const encrypted = await backend.encrypt(privateKey);
+    const decrypted = await backend.decrypt(encrypted);
+
+    expect(decrypted).toBe(privateKey);
+    expect(encrypted.backend).toBeUndefined();
+  });
+
+  test("AWS KMS envelope round-trips with a mocked client", async () => {
+    const client = new MockAwsKmsClient();
+    const backend = new KmsEnvelopeKeystore({
+      provider: "aws",
+      keyId: "alias/steward-test",
+      client,
+    });
+    const privateKey = "0x" + "2".repeat(64);
+
+    const encrypted = await backend.encrypt(privateKey, { tenantId: "t1", agentId: "a1" });
+    const decrypted = await backend.decrypt(encrypted, { tenantId: "t1", agentId: "a1" });
+
+    expect(decrypted).toBe(privateKey);
+    expect(encrypted.backend).toBe("kms-envelope:aws-kms");
+    expect(encrypted.wrappedDataKey).toBeTruthy();
+    expect(encrypted.salt.startsWith("kms-envelope:v1:")).toBe(true);
+    expect(client.encryptCalls).toBe(1);
+    expect(client.decryptCalls).toBe(1);
+  });
+
+  test("KMS records reject cross-backend decrypt and tampered wrapped keys", async () => {
+    const client = new MockAwsKmsClient();
+    const kms = new KmsEnvelopeKeystore({ provider: "aws", keyId: "alias/steward-test", client });
+    const aes = backendFromKeyStore(new KeyStore(MASTER_PASSWORD));
+    const encrypted = await kms.encrypt("0x" + "3".repeat(64));
+
+    expect(() => aes.decrypt(encrypted)).toThrow();
+
+    const tampered = {
+      ...encrypted,
+      wrappedDataKey: Buffer.from("tampered", "utf8").toString("hex"),
+    };
+    await expect(kms.decrypt(tampered)).rejects.toThrow();
+  });
+
+  test("vault uses a configured KMS backend and persists envelope metadata", async () => {
+    const backend = new KmsEnvelopeKeystore({
+      provider: "aws",
+      keyId: "alias/steward-test",
+      client: new MockAwsKmsClient(),
+    });
+    const vault = await freshVault(backend);
+    await vault.createAgent(TENANT_ID, "kms-agent", "KMS Agent");
+
+    const [row] = await getDb()
+      .select()
+      .from(encryptedKeys)
+      .where(eq(encryptedKeys.agentId, "kms-agent"));
+
+    expect(row.salt.startsWith("kms-envelope:v1:")).toBe(true);
+    const decrypted = await backend.decrypt({
+      ciphertext: row.ciphertext,
+      iv: row.iv,
+      tag: row.tag,
+      salt: row.salt,
+    });
+    expect(decrypted.startsWith("0x")).toBe(true);
+  });
+
+  test("vault constructor falls back to AES when no backend is configured", async () => {
+    const vault = await freshVault();
+    await vault.createAgent(TENANT_ID, "fallback-agent", "Fallback Agent");
+
+    const [row] = await getDb()
+      .select()
+      .from(encryptedKeys)
+      .where(eq(encryptedKeys.agentId, "fallback-agent"));
+
+    const decrypted = new KeyStore(MASTER_PASSWORD).decrypt({
+      ciphertext: row.ciphertext,
+      iv: row.iv,
+      tag: row.tag,
+      salt: row.salt,
+    });
+
+    expect(decrypted.startsWith("0x")).toBe(true);
+  });
+});

--- a/packages/vault/src/index.ts
+++ b/packages/vault/src/index.ts
@@ -2,6 +2,14 @@ export type { EncryptedKey } from "./keystore";
 export { KeyStore } from "./keystore";
 export type { KeystoreBackend, KeystoreContext } from "./keystore-backend";
 export { backendFromKeyStore } from "./keystore-backend";
+export type {
+  AwsKmsClientLike,
+  AwsKmsEnvelopeOptions,
+  KmsEnvelopeOptions,
+  Pkcs11ClientLike,
+  Pkcs11KmsEnvelopeOptions,
+} from "./keystore-kms";
+export { KmsEnvelopeKeystore, resolveKmsEnvelopeOptions } from "./keystore-kms";
 export type { MatchedRoute } from "./route-matcher";
 export {
   findMatchingRoute,

--- a/packages/vault/src/keystore-kms.ts
+++ b/packages/vault/src/keystore-kms.ts
@@ -1,0 +1,319 @@
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+
+import type { EncryptedKey } from "./keystore";
+import type { KeystoreBackend, KeystoreContext } from "./keystore-backend";
+
+const ENVELOPE_PREFIX = "kms-envelope:v1:";
+const AWS_BACKEND_ID = "kms-envelope:aws-kms";
+const PKCS11_BACKEND_ID = "kms-envelope:pkcs11";
+
+type KmsProvider = "aws" | "pkcs11";
+
+export interface AwsKmsClientLike {
+  send(command: unknown): Promise<unknown>;
+}
+
+export interface AwsKmsEnvelopeOptions {
+  provider: "aws";
+  keyId?: string;
+  region?: string;
+  client?: AwsKmsClientLike;
+}
+
+export interface Pkcs11ClientLike {
+  wrapKey(dataKey: Uint8Array, context?: KeystoreContext): Promise<Uint8Array> | Uint8Array;
+  unwrapKey(
+    wrappedDataKey: Uint8Array,
+    context?: KeystoreContext,
+  ): Promise<Uint8Array> | Uint8Array;
+}
+
+export interface Pkcs11KmsEnvelopeOptions {
+  provider: "pkcs11";
+  modulePath?: string;
+  pin?: string;
+  keyLabel?: string;
+  client?: Pkcs11ClientLike;
+}
+
+export type KmsEnvelopeOptions = AwsKmsEnvelopeOptions | Pkcs11KmsEnvelopeOptions;
+
+interface EnvelopeMetadata {
+  backend: string;
+  provider: KmsProvider;
+  keyId?: string;
+  wrappedDataKey: string;
+}
+
+interface AwsEncryptCommandInput {
+  KeyId: string;
+  Plaintext: Uint8Array;
+  EncryptionContext?: Record<string, string>;
+}
+
+interface AwsDecryptCommandInput {
+  CiphertextBlob: Uint8Array;
+  EncryptionContext?: Record<string, string>;
+}
+
+function bytesToHex(value: Uint8Array): string {
+  return Array.from(value, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function hexToBytes(value: string): Uint8Array {
+  return Buffer.from(value, "hex");
+}
+
+function encodeMetadata(metadata: EnvelopeMetadata): string {
+  return `${ENVELOPE_PREFIX}${Buffer.from(JSON.stringify(metadata), "utf8").toString("hex")}`;
+}
+
+function decodeMetadata(encrypted: EncryptedKey): EnvelopeMetadata | undefined {
+  if (encrypted.backend && encrypted.wrappedDataKey) {
+    return {
+      backend: encrypted.backend,
+      provider: encrypted.provider === "pkcs11" ? "pkcs11" : "aws",
+      keyId: encrypted.keyId,
+      wrappedDataKey: encrypted.wrappedDataKey,
+    };
+  }
+
+  if (!encrypted.salt.startsWith(ENVELOPE_PREFIX)) {
+    return undefined;
+  }
+
+  const encoded = encrypted.salt.slice(ENVELOPE_PREFIX.length);
+  return JSON.parse(Buffer.from(encoded, "hex").toString("utf8")) as EnvelopeMetadata;
+}
+
+function contextToAwsEncryptionContext(
+  context?: KeystoreContext,
+): Record<string, string> | undefined {
+  if (!context) return undefined;
+  const entries = Object.entries({
+    tenantId: context.tenantId,
+    agentId: context.agentId,
+    venue: context.venue ?? undefined,
+  }).filter((entry): entry is [string, string] => typeof entry[1] === "string");
+  if (entries.length === 0) return undefined;
+  return Object.fromEntries(entries);
+}
+
+function encryptWithDataKey(
+  privateKey: string,
+  dataKey: Buffer,
+): Pick<EncryptedKey, "ciphertext" | "iv" | "tag"> {
+  const iv = randomBytes(16);
+  const cipher = createCipheriv("aes-256-gcm", dataKey, iv);
+  let ciphertext = cipher.update(privateKey, "utf8", "hex");
+  ciphertext += cipher.final("hex");
+  return {
+    ciphertext,
+    iv: iv.toString("hex"),
+    tag: cipher.getAuthTag().toString("hex"),
+  };
+}
+
+function decryptWithDataKey(encrypted: EncryptedKey, dataKey: Buffer): string {
+  const decipher = createDecipheriv("aes-256-gcm", dataKey, Buffer.from(encrypted.iv, "hex"));
+  decipher.setAuthTag(Buffer.from(encrypted.tag, "hex"));
+  let plaintext = decipher.update(encrypted.ciphertext, "hex", "utf8");
+  plaintext += decipher.final("utf8");
+  return plaintext;
+}
+
+export class KmsEnvelopeKeystore implements KeystoreBackend {
+  readonly id: string;
+
+  private readonly options: KmsEnvelopeOptions;
+
+  private readonly awsClientIsInjected: boolean;
+
+  private awsClient?: AwsKmsClientLike;
+
+  constructor(options?: Partial<KmsEnvelopeOptions>) {
+    const resolved = resolveKmsEnvelopeOptions(options);
+    this.options = resolved;
+    this.id = resolved.provider === "aws" ? AWS_BACKEND_ID : PKCS11_BACKEND_ID;
+    this.awsClientIsInjected = resolved.provider === "aws" && Boolean(resolved.client);
+    if (resolved.provider === "aws") {
+      this.awsClient = resolved.client;
+    }
+  }
+
+  static fromEnv(): KmsEnvelopeKeystore {
+    return new KmsEnvelopeKeystore();
+  }
+
+  async encrypt(privateKey: string, context?: KeystoreContext): Promise<EncryptedKey> {
+    const dataKey = randomBytes(32);
+    try {
+      const wrappedDataKey = await this.wrapDataKey(dataKey, context);
+      const encrypted = encryptWithDataKey(privateKey, dataKey);
+      const metadata: EnvelopeMetadata = {
+        backend: this.id,
+        provider: this.options.provider,
+        keyId: getConfiguredKeyId(this.options),
+        wrappedDataKey: bytesToHex(wrappedDataKey),
+      };
+      return {
+        ...encrypted,
+        salt: encodeMetadata(metadata),
+        backend: metadata.backend,
+        provider: metadata.provider,
+        keyId: metadata.keyId,
+        wrappedDataKey: metadata.wrappedDataKey,
+      };
+    } finally {
+      dataKey.fill(0);
+    }
+  }
+
+  async decrypt(encrypted: EncryptedKey, context?: KeystoreContext): Promise<string> {
+    const metadata = decodeMetadata(encrypted);
+    if (!metadata) {
+      throw new Error("Encrypted key was not produced by a KMS envelope backend");
+    }
+    if (metadata.backend !== this.id) {
+      throw new Error(
+        `Encrypted key backend mismatch: expected ${this.id}, got ${metadata.backend}`,
+      );
+    }
+    if (metadata.provider !== this.options.provider) {
+      throw new Error(
+        `Encrypted key provider mismatch: expected ${this.options.provider}, got ${metadata.provider}`,
+      );
+    }
+
+    const unwrappedDataKey = await this.unwrapDataKey(hexToBytes(metadata.wrappedDataKey), context);
+    const dataKey = Buffer.from(bytesToHex(unwrappedDataKey), "hex");
+    try {
+      if (dataKey.length !== 32) {
+        throw new Error("KMS provider returned an invalid data key length");
+      }
+      return decryptWithDataKey(encrypted, dataKey);
+    } finally {
+      dataKey.fill(0);
+    }
+  }
+
+  private async wrapDataKey(dataKey: Uint8Array, context?: KeystoreContext): Promise<Uint8Array> {
+    if (this.options.provider === "aws") {
+      const keyId = getConfiguredKeyId(this.options);
+      if (!keyId) {
+        throw new Error("STEWARD_KMS_KEY_ID or STEWARD_AWS_KMS_KEY_ARN is required for AWS KMS");
+      }
+      const client = await this.getAwsClient();
+      const command = await this.createAwsEncryptCommand({
+        KeyId: keyId,
+        Plaintext: dataKey,
+        EncryptionContext: contextToAwsEncryptionContext(context),
+      });
+      const response = (await client.send(command)) as { CiphertextBlob?: Uint8Array };
+      if (!response.CiphertextBlob) {
+        throw new Error("AWS KMS Encrypt did not return CiphertextBlob");
+      }
+      return response.CiphertextBlob;
+    }
+
+    const client = await this.getPkcs11Client();
+    return client.wrapKey(dataKey, context);
+  }
+
+  private async unwrapDataKey(
+    wrappedDataKey: Uint8Array,
+    context?: KeystoreContext,
+  ): Promise<Uint8Array> {
+    if (this.options.provider === "aws") {
+      const client = await this.getAwsClient();
+      const command = await this.createAwsDecryptCommand({
+        CiphertextBlob: wrappedDataKey,
+        EncryptionContext: contextToAwsEncryptionContext(context),
+      });
+      const response = (await client.send(command)) as { Plaintext?: Uint8Array };
+      if (!response.Plaintext) {
+        throw new Error("AWS KMS Decrypt did not return Plaintext");
+      }
+      return response.Plaintext;
+    }
+
+    const client = await this.getPkcs11Client();
+    return client.unwrapKey(wrappedDataKey, context);
+  }
+
+  private async getAwsClient(): Promise<AwsKmsClientLike> {
+    if (this.options.provider !== "aws") {
+      throw new Error("AWS KMS client requested for non AWS provider");
+    }
+    if (this.awsClient) return this.awsClient;
+
+    const moduleName = "@aws-sdk/client-kms";
+    const aws = (await import(moduleName)) as {
+      KMSClient: new (config: { region?: string }) => AwsKmsClientLike;
+    };
+    this.awsClient = new aws.KMSClient({ region: this.options.region });
+    return this.awsClient;
+  }
+
+  private async createAwsEncryptCommand(input: AwsEncryptCommandInput): Promise<unknown> {
+    if (this.awsClientIsInjected) return { input, commandName: "EncryptCommand" };
+    const moduleName = "@aws-sdk/client-kms";
+    const aws = (await import(moduleName)) as {
+      EncryptCommand: new (input: AwsEncryptCommandInput) => unknown;
+    };
+    return new aws.EncryptCommand(input);
+  }
+
+  private async createAwsDecryptCommand(input: AwsDecryptCommandInput): Promise<unknown> {
+    if (this.awsClientIsInjected) return { input, commandName: "DecryptCommand" };
+    const moduleName = "@aws-sdk/client-kms";
+    const aws = (await import(moduleName)) as {
+      DecryptCommand: new (input: AwsDecryptCommandInput) => unknown;
+    };
+    return new aws.DecryptCommand(input);
+  }
+
+  private async getPkcs11Client(): Promise<Pkcs11ClientLike> {
+    if (this.options.provider !== "pkcs11") {
+      throw new Error("PKCS#11 client requested for non PKCS#11 provider");
+    }
+    if (this.options.client) return this.options.client;
+
+    const moduleName = "graphene-pk11";
+    await import(moduleName);
+    throw new Error(
+      "PKCS#11 support requires a Pkcs11ClientLike adapter for C_WrapKey and C_UnwrapKey in this release",
+    );
+  }
+}
+
+export function resolveKmsEnvelopeOptions(
+  options?: Partial<KmsEnvelopeOptions>,
+): KmsEnvelopeOptions {
+  const provider = (options?.provider ?? process.env.STEWARD_KMS_PROVIDER ?? "aws") as KmsProvider;
+  if (provider === "aws") {
+    const awsOptions = options as Partial<AwsKmsEnvelopeOptions> | undefined;
+    return {
+      provider: "aws",
+      keyId:
+        awsOptions?.keyId ?? process.env.STEWARD_KMS_KEY_ID ?? process.env.STEWARD_AWS_KMS_KEY_ARN,
+      region: awsOptions?.region ?? process.env.STEWARD_AWS_REGION ?? process.env.AWS_REGION,
+      client: awsOptions?.client,
+    };
+  }
+  if (provider === "pkcs11") {
+    const pkcs11Options = options as Partial<Pkcs11KmsEnvelopeOptions> | undefined;
+    return {
+      provider: "pkcs11",
+      modulePath: pkcs11Options?.modulePath ?? process.env.STEWARD_PKCS11_MODULE,
+      pin: pkcs11Options?.pin ?? process.env.STEWARD_PKCS11_PIN,
+      keyLabel: pkcs11Options?.keyLabel ?? process.env.STEWARD_PKCS11_KEY_LABEL,
+      client: pkcs11Options?.client,
+    };
+  }
+  throw new Error(`Unsupported STEWARD_KMS_PROVIDER: ${provider}`);
+}
+
+function getConfiguredKeyId(options: KmsEnvelopeOptions): string | undefined {
+  return options.provider === "aws" ? options.keyId : options.keyLabel;
+}

--- a/packages/vault/src/keystore.ts
+++ b/packages/vault/src/keystore.ts
@@ -1,11 +1,11 @@
 // node:crypto under Cloudflare nodejs_compat:
-//   - createCipheriv / createDecipheriv (AES-256-GCM) — supported.
-//   - randomBytes                                      — supported.
-//   - scryptSync                                       — supported. Sync work
+//   - createCipheriv / createDecipheriv (AES-256-GCM) - supported.
+//   - randomBytes                                      - supported.
+//   - scryptSync                                       - supported. Sync work
 //     runs on the request CPU budget (~10ms by default, configurable). Default
 //     N=16384 derivation is well under budget. If a future caller raises N,
 //     consider crypto.subtle.deriveBits with PBKDF2-SHA256 as an async
-//     alternative — note that switching KDFs invalidates existing encrypted
+//     alternative - note that switching KDFs invalidates existing encrypted
 //     records (operator decision, not a transparent migration).
 import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from "node:crypto";
 
@@ -21,7 +21,11 @@ export interface EncryptedKey {
   ciphertext: string; // hex
   iv: string; // hex
   tag: string; // hex
-  salt: string; // hex
+  salt: string; // hex for AES default, envelope metadata for KMS backends
+  backend?: string;
+  wrappedDataKey?: string; // hex
+  provider?: string;
+  keyId?: string;
 }
 
 export class KeyStore {
@@ -87,7 +91,7 @@ export class KeyStore {
   }
 
   /**
-   * Decrypt a private key for signing (ephemeral — caller should zero after use)
+   * Decrypt a private key for signing (ephemeral - caller should zero after use)
    */
   decrypt(encrypted: EncryptedKey): string {
     const iv = Buffer.from(encrypted.iv, "hex");

--- a/packages/vault/src/vault.ts
+++ b/packages/vault/src/vault.ts
@@ -40,6 +40,7 @@ import {
 } from "viem/chains";
 
 import { type EncryptedKey, KeyStore } from "./keystore";
+import { backendFromKeyStore, type KeystoreBackend } from "./keystore-backend";
 import {
   generateSolanaKeypair,
   getSolanaBalance,
@@ -53,6 +54,7 @@ export interface VaultConfig {
   masterPassword: string;
   rpcUrl?: string;
   chainId?: number;
+  keystoreBackend?: KeystoreBackend;
 }
 
 const CHAINS: Record<number, Chain> = {
@@ -139,12 +141,13 @@ export interface SignTransactionOptions {
  * of a signing operation and never exposed to agent containers.
  */
 export class Vault {
-  private keyStore: KeyStore;
+  private keyStore: KeystoreBackend;
   private config: VaultConfig;
 
   constructor(config: VaultConfig) {
     this.config = config;
-    this.keyStore = new KeyStore(config.masterPassword);
+    this.keyStore =
+      config.keystoreBackend ?? backendFromKeyStore(new KeyStore(config.masterPassword));
   }
 
   /**
@@ -183,8 +186,8 @@ export class Vault {
     const solanaAddress = solKp.publicKey;
 
     // ── Encrypt both keys ────────────────────────────────────────────────
-    const evmEncrypted = this.keyStore.encrypt(evmPrivateKey);
-    const solEncrypted = this.keyStore.encrypt(solKp.secretKey);
+    const evmEncrypted = await this.keyStore.encrypt(evmPrivateKey);
+    const solEncrypted = await this.keyStore.encrypt(solKp.secretKey);
 
     const createdAt = new Date();
 
@@ -403,7 +406,7 @@ export class Vault {
       );
 
     if (chainKey) {
-      secretKey = this.keyStore.decrypt({
+      secretKey = await this.keyStore.decrypt({
         ciphertext: chainKey.ciphertext,
         iv: chainKey.iv,
         tag: chainKey.tag,
@@ -421,7 +424,7 @@ export class Vault {
       if (!legacyKey) {
         throw missingSigningKeyError(request.agentId, chainFamilyToUse);
       }
-      secretKey = this.keyStore.decrypt(legacyKey as EncryptedKey);
+      secretKey = await this.keyStore.decrypt(legacyKey as EncryptedKey);
     }
 
     // Also resolve the wallet address for this chain (for Solana tx signing)
@@ -668,7 +671,7 @@ export class Vault {
       walletAddress = account.address;
     }
 
-    const encryptedKey = this.keyStore.encrypt(privateKey);
+    const encryptedKey = await this.keyStore.encrypt(privateKey);
     const now = new Date();
 
     // Check if agent already exists
@@ -797,7 +800,7 @@ export class Vault {
       );
 
     if (chainKey) {
-      secretKey = this.keyStore.decrypt({
+      secretKey = await this.keyStore.decrypt({
         ciphertext: chainKey.ciphertext,
         iv: chainKey.iv,
         tag: chainKey.tag,
@@ -812,7 +815,7 @@ export class Vault {
       if (!legacyKey) {
         throw new Error(`No signing key found for agent ${agentId}`);
       }
-      secretKey = this.keyStore.decrypt(legacyKey as EncryptedKey);
+      secretKey = await this.keyStore.decrypt(legacyKey as EncryptedKey);
     }
 
     if (isSolana) {
@@ -830,7 +833,7 @@ export class Vault {
    * Returns { contractAddress, chainId, nonce, r, s, yParity, v } which the
    * caller attaches to the `authorizationList` of a type-4 transaction.
    *
-   * Per EIP-7702, signing chainId=0 designates "any chain" — useful when the
+   * Per EIP-7702, signing chainId=0 designates "any chain" - useful when the
    * delegation target is chain-agnostic. The vault accepts 0 explicitly so
    * callers can opt in; default is the chainId on the request.
    */
@@ -878,7 +881,7 @@ export class Vault {
         ),
       );
     if (chainKey) {
-      secretKey = this.keyStore.decrypt({
+      secretKey = await this.keyStore.decrypt({
         ciphertext: chainKey.ciphertext,
         iv: chainKey.iv,
         tag: chainKey.tag,
@@ -890,7 +893,7 @@ export class Vault {
         .from(encryptedKeys)
         .where(eq(encryptedKeys.agentId, agentId));
       if (!legacyKey) throw new Error(`No EVM signing key for agent ${agentId}`);
-      secretKey = this.keyStore.decrypt(legacyKey as EncryptedKey);
+      secretKey = await this.keyStore.decrypt(legacyKey as EncryptedKey);
     }
 
     const account = privateKeyToAccount(secretKey as `0x${string}`);
@@ -948,7 +951,7 @@ export class Vault {
       );
 
     if (chainKey) {
-      secretKey = this.keyStore.decrypt({
+      secretKey = await this.keyStore.decrypt({
         ciphertext: chainKey.ciphertext,
         iv: chainKey.iv,
         tag: chainKey.tag,
@@ -968,7 +971,7 @@ export class Vault {
       if (!legacyKey) {
         throw new Error(`No signing key found for agent ${request.agentId}`);
       }
-      secretKey = this.keyStore.decrypt(legacyKey as EncryptedKey);
+      secretKey = await this.keyStore.decrypt(legacyKey as EncryptedKey);
     }
 
     const account = privateKeyToAccount(secretKey as `0x${string}`);
@@ -1029,7 +1032,7 @@ export class Vault {
       );
 
     if (chainKey) {
-      secretKey = this.keyStore.decrypt({
+      secretKey = await this.keyStore.decrypt({
         ciphertext: chainKey.ciphertext,
         iv: chainKey.iv,
         tag: chainKey.tag,
@@ -1049,7 +1052,7 @@ export class Vault {
       if (!legacyKey) {
         throw new Error(`No Solana signing key found for agent ${request.agentId}`);
       }
-      secretKey = this.keyStore.decrypt(legacyKey as EncryptedKey);
+      secretKey = await this.keyStore.decrypt(legacyKey as EncryptedKey);
     }
 
     const keypair = restoreSolanaKeypair(secretKey);
@@ -1140,7 +1143,7 @@ export class Vault {
       );
 
     if (evmChainKey) {
-      const pk = this.keyStore.decrypt({
+      const pk = await this.keyStore.decrypt({
         ciphertext: evmChainKey.ciphertext,
         iv: evmChainKey.iv,
         tag: evmChainKey.tag,
@@ -1167,7 +1170,7 @@ export class Vault {
         .from(encryptedKeys)
         .where(eq(encryptedKeys.agentId, agentId));
       if (legacyKey) {
-        const pk = this.keyStore.decrypt(legacyKey as EncryptedKey);
+        const pk = await this.keyStore.decrypt(legacyKey as EncryptedKey);
         result.evm = {
           privateKey: pk,
           address: privateKeyToAccount(pk as `0x${string}`).address,
@@ -1188,7 +1191,7 @@ export class Vault {
       );
 
     if (solChainKey) {
-      const pk = this.keyStore.decrypt({
+      const pk = await this.keyStore.decrypt({
         ciphertext: solChainKey.ciphertext,
         iv: solChainKey.iv,
         tag: solChainKey.tag,
@@ -1402,7 +1405,7 @@ export class Vault {
       secret = kp.secretKey;
     }
 
-    const encrypted = this.keyStore.encrypt(secret);
+    const encrypted = await this.keyStore.encrypt(secret);
     const createdAt = new Date();
 
     await db.transaction(async (tx) => {


### PR DESCRIPTION
## Why

Steward's biggest competitive weakness vs Privy / Turnkey / Circle / Para is key custody: the default `KeyStore` is app-layer AES-256-GCM with the plaintext private key in process memory at sign time, recoverable by anyone with the master password + DB. Every incumbent uses TEE / HSM / MPC so the raw key is never extractable under one party.

The open-source-preserving fix: the repo already defined an (unimplemented) `KeystoreBackend` interface for exactly this. This PR fills it with the first concrete production backend, a KMS-backed envelope-encryption adapter, and wires the seam into the vault. Operators point Steward at their own AWS KMS / HSM; the wrapping root never enters the app process. "As strong as the backend you choose, and you choose," while staying self-hostable MIT.

## What

### 1. The backend seam (the real refactor)
- Added `VaultConfig.keystoreBackend?: KeystoreBackend`.
- Constructor defaults to `backendFromKeyStore(new KeyStore(config.masterPassword))` when no backend is set, so masterPassword-only deployments behave identically (backward compatible).
- Routed all 17 `keyStore.encrypt/decrypt` call sites in `vault.ts` through the async-capable backend (KMS round-trips are async over the network). Vault methods were already async; awaiting the backend was clean. Legacy-key decrypt fallback preserved.

### 2. KMS envelope adapter (`keystore-kms.ts`)
- Per-record random 256-bit data key, AES-256-GCM encrypts the private key, the data key is WRAPPED by the configured KMS. Plaintext data key + unwrapped key are the only in-process secrets and only momentarily; the KMS root key never enters the process.
- AWS KMS path fully functional, lazy-imports `@aws-sdk/client-kms`.
- Wrapped data key stored inside the existing `EncryptedKey.salt` envelope field, so the current DB schema is unchanged.
- Backend/provider metadata + cross-backend rejection (a KMS record cannot be decrypted by the AES backend and vice versa).
- `@aws-sdk/client-kms` and `graphene-pk11` are peerDependencies (optional, lazy-imported); the core vault keeps zero hard cloud-SDK deps.

### 3. Tests + docs
- `keystore-kms.test.ts`: 5 tests / 13 assertions, all green. Covers AES seam round-trip, AWS KMS round-trip (mocked KMS client, no real AWS needed in CI), cross-backend rejection, tampered-wrapped-key rejection, vault KMS persistence via existing schema, and AES constructor fallback (backward compat).
- `KEYSTORE-BACKENDS.md`: neutral docs of the per-backend trust tradeoff + env config.

## Verification (re-run by Sol, not just the worker)
- `bun test packages/vault/src/__tests__/keystore-kms.test.ts --isolate`: 5 pass, 0 fail.
- `bunx turbo run build --filter=@stwd/vault --filter=@stwd/api`: 10/10 tasks pass (confirms the async refactor did not break the api callers).
- `bun run lint`: clean. Biome clean.

## Honest scope flag
AWS KMS is the fully-working reference path. PKCS#11 (for YubiHSM2 / CloudHSM / SoftHSM / GCP-KMS-via-PKCS#11) ships as a real typed adapter seam with working client-injected wrap/unwrap, but the generic `graphene-pk11` session manager + direct `C_WrapKey`/`C_UnwrapKey` are not fully implemented here, it throws clearly if no client adapter is supplied. That is a clean follow-up. An AWS Nitro Enclave attested signer backend is the other planned follow-up.

Co-authored-by: wakesync <shadow@shad0w.xyz>