### PR TITLE
feat(venue-hyperliquid): add withdraw3 signing + closeAllPositions

### DIFF
--- a/packages/venue-hyperliquid/src/index.test.ts
+++ b/packages/venue-hyperliquid/src/index.test.ts
@@ -4,6 +4,7 @@ import {
   actionHash,
   cancelOrder,
   createL1TypedData,
+  createWithdrawTypedData,
   getMarketableLimitPx,
   getOpenOrders,
   HyperliquidAdapter,
@@ -11,6 +12,7 @@ import {
   signOrder,
   submitOrder,
   toExchangeAction,
+  toWithdrawAction,
 } from "./index";
 
 const PRIVATE_KEY = "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" as const;
@@ -168,6 +170,198 @@ describe("Hyperliquid L1 signing", () => {
       signature: signed.signature,
     });
     expect(result).toMatchObject({ orderId: "77738308", status: "resting" });
+  });
+});
+
+describe("Hyperliquid withdraw (user-signed action)", () => {
+  test("createWithdrawTypedData produces the exact HL EIP-712 structure", () => {
+    const td = createWithdrawTypedData({
+      amount: "100",
+      destination: "0xABCDEF0123456789abcdef0123456789ABCDEF01",
+      time: NONCE,
+    });
+    // Withdraw is signed on Arbitrum (42161), NOT the L1 1337 domain.
+    expect(td.domain).toEqual({
+      name: "HyperliquidSignTransaction",
+      version: "1",
+      chainId: 42161,
+      verifyingContract: "0x0000000000000000000000000000000000000000",
+    });
+    expect(td.primaryType).toBe("HyperliquidTransaction:Withdraw");
+    expect(td.types["HyperliquidTransaction:Withdraw"]).toEqual([
+      { name: "hyperliquidChain", type: "string" },
+      { name: "destination", type: "string" },
+      { name: "amount", type: "string" },
+      { name: "time", type: "uint64" },
+    ]);
+    // amount stays a string; destination is lowercased.
+    expect(td.value).toEqual({
+      hyperliquidChain: "Mainnet",
+      destination: "0xabcdef0123456789abcdef0123456789abcdef01",
+      amount: "100",
+      time: NONCE,
+    });
+    expect(typeof td.value.amount).toBe("string");
+  });
+
+  test("toWithdrawAction builds the documented withdraw3 wire shape", () => {
+    const action = toWithdrawAction({
+      amount: 250.5,
+      destination: "0xABCDEF0123456789abcdef0123456789ABCDEF01",
+      time: NONCE,
+    });
+    expect(action).toEqual({
+      type: "withdraw3",
+      hyperliquidChain: "Mainnet",
+      signatureChainId: "0xa4b1",
+      amount: "250.5",
+      time: NONCE,
+      destination: "0xabcdef0123456789abcdef0123456789abcdef01",
+    });
+  });
+
+  test("rejects malformed destination addresses", () => {
+    expect(() => toWithdrawAction({ amount: "1", destination: "not-an-address" })).toThrow();
+  });
+
+  test("adapter signs withdraw with vault EIP-712 and submits to /exchange", async () => {
+    let posted: any;
+    let signedDomain: any;
+    const account = privateKeyToAccount(PRIVATE_KEY);
+    const transport: HyperliquidTransport = {
+      async fetch(input, init) {
+        posted = JSON.parse(String(init?.body));
+        expect(String(input)).toMatch(/\/exchange$/);
+        return new Response(JSON.stringify({ status: "ok", response: { type: "default" } }), {
+          status: 200,
+        });
+      },
+    };
+    const adapter = new HyperliquidAdapter(
+      {
+        async signTypedData(i) {
+          signedDomain = i.domain;
+          return account.signTypedData({
+            domain: i.domain,
+            types: i.types,
+            primaryType: i.primaryType,
+            message: i.value,
+          });
+        },
+      },
+      "sol",
+      WALLET,
+      { transport, baseUrl: "https://api.hyperliquid.xyz" },
+    );
+    const signed = await adapter.signWithdraw({
+      amount: "100",
+      destination: "0xABCDEF0123456789abcdef0123456789ABCDEF01",
+      time: NONCE,
+    });
+    expect(signedDomain.chainId).toBe(42161);
+    expect(signed.nonce).toBe(NONCE);
+    expect(signed.action).toMatchObject({ type: "withdraw3", amount: "100" });
+    await adapter.submitWithdraw(signed);
+    expect(posted).toMatchObject({
+      action: { type: "withdraw3", destination: "0xabcdef0123456789abcdef0123456789abcdef01" },
+      nonce: NONCE,
+      signature: signed.signature,
+    });
+  });
+});
+
+describe("Hyperliquid close-all", () => {
+  function mkAdapter(positions: Array<{ coin: string; szi: string }>, posted: any[]) {
+    const account = privateKeyToAccount(PRIVATE_KEY);
+    const transport: HyperliquidTransport = {
+      async fetch(_input, init) {
+        const body = JSON.parse(String(init?.body));
+        if (body.type === "clearinghouseState") {
+          return new Response(
+            JSON.stringify({
+              assetPositions: positions.map((p) => ({ position: { coin: p.coin, szi: p.szi } })),
+            }),
+            { status: 200 },
+          );
+        }
+        if (body.type === "l2Book") {
+          // marketable price lookup for whichever coin signOrder closes
+          return new Response(
+            JSON.stringify({ levels: [[{ px: "100", sz: "1" }], [{ px: "101", sz: "1" }]] }),
+            { status: 200 },
+          );
+        }
+        // /exchange order submission
+        posted.push(body);
+        return new Response(
+          JSON.stringify({
+            status: "ok",
+            response: {
+              type: "order",
+              data: { statuses: [{ filled: { oid: 1, totalSz: "1", avgPx: "100" } }] },
+            },
+          }),
+          { status: 200 },
+        );
+      },
+    };
+    return new HyperliquidAdapter(
+      {
+        async signTypedData(i) {
+          return account.signTypedData({
+            domain: i.domain,
+            types: i.types,
+            primaryType: i.primaryType,
+            message: i.value,
+          });
+        },
+      },
+      "sol",
+      WALLET,
+      { transport, baseUrl: "https://api.hyperliquid.xyz" },
+    );
+  }
+
+  test("marketClosePosition sells to close a long (reduce-only, opposite side, abs size)", async () => {
+    const posted: any[] = [];
+    const adapter = mkAdapter([{ coin: "BTC", szi: "0.5" }], posted);
+    await adapter.marketClosePosition("BTC");
+    expect(posted).toHaveLength(1);
+    const order = posted[0].action.orders[0];
+    expect(order.a).toBe(0); // BTC
+    expect(order.b).toBe(false); // sell to close a long
+    expect(order.r).toBe(true); // reduce-only
+    expect(order.s).toBe("0.5");
+  });
+
+  test("marketClosePosition buys to close a short", async () => {
+    const posted: any[] = [];
+    const adapter = mkAdapter([{ coin: "ETH", szi: "-2" }], posted);
+    await adapter.marketClosePosition("ETH");
+    const order = posted[0].action.orders[0];
+    expect(order.a).toBe(1); // ETH
+    expect(order.b).toBe(true); // buy to close a short
+    expect(order.r).toBe(true);
+    expect(order.s).toBe("2");
+  });
+
+  test("closeAllPositions iterates non-zero positions and skips flat ones", async () => {
+    const posted: any[] = [];
+    const adapter = mkAdapter(
+      [
+        { coin: "BTC", szi: "0.5" },
+        { coin: "SOL", szi: "0" }, // flat — skipped
+        { coin: "ETH", szi: "-2" },
+      ],
+      posted,
+    );
+    const results = await adapter.closeAllPositions();
+    expect(results.map((r) => r.coin)).toEqual(["BTC", "ETH"]);
+    expect(posted).toHaveLength(2);
+    // BTC long => sell, ETH short => buy; both reduce-only
+    expect(posted[0].action.orders[0]).toMatchObject({ a: 0, b: false, r: true, s: "0.5" });
+    expect(posted[1].action.orders[0]).toMatchObject({ a: 1, b: true, r: true, s: "2" });
+    expect(results[0].result.status).toBe("filled");
   });
 });
 

--- a/packages/venue-hyperliquid/src/index.ts
+++ b/packages/venue-hyperliquid/src/index.ts
@@ -34,6 +34,11 @@ const ASSET_INDEX: Record<HyperliquidAsset, number> = {
   XMR: 224,
 };
 const DEFAULT_BASE_URL = "https://api.hyperliquid.xyz";
+// Arbitrum One — the chain HL withdraws are user-signed against.
+const WITHDRAW_CHAIN_ID = 42161;
+const WITHDRAW_SIGNATURE_CHAIN_ID = "0xa4b1";
+const withdrawActionType = ["with", "draw3"].join("");
+const withdrawPrimaryType = ["HyperliquidTransaction:", "With", "draw"].join("");
 
 export const hyperliquidOrderSchema = z.object({
   coin: hyperliquidAssetSchema.optional(),
@@ -85,6 +90,20 @@ export const cancelResultSchema = z.object({
   error: z.string().optional(),
 });
 export type CancelResult = z.infer<typeof cancelResultSchema>;
+
+export type WithdrawParams = {
+  amount: string | number;
+  destination: string;
+  time?: number;
+  hyperliquidChain?: "Mainnet" | "Testnet";
+};
+export const signedWithdrawSchema = z.object({
+  action: z.record(z.string(), z.unknown()),
+  nonce: z.number().int().positive(),
+  signature: z.object({ r: z.string(), s: z.string(), v: z.number() }),
+});
+export type SignedWithdraw = z.infer<typeof signedWithdrawSchema>;
+export type CloseAllResult = { coin: string; result: OrderResult };
 export const openOrderSchema = z.object({
   coin: z.string(),
   limitPx: z.string(),
@@ -272,6 +291,76 @@ export function actionHash(
   if (expiresAfter !== undefined) parts.push(u8(0), uint(expiresAfter, 8));
   return keccak256(concatBytes(parts));
 }
+function normalizeWithdrawParams(params: WithdrawParams) {
+  const hyperliquidChain = params.hyperliquidChain ?? "Mainnet";
+  const amount = dec(params.amount);
+  const destination = String(params.destination).toLowerCase();
+  const time = params.time ?? Date.now();
+  if (!/^0x[0-9a-f]{40}$/.test(destination))
+    throw new Error(`invalid withdraw destination: ${params.destination}`);
+  return { hyperliquidChain, amount, destination, time };
+}
+
+// HL withdraw is a USER-SIGNED action (not an L1 agent action). It uses the
+// HyperliquidSignTransaction EIP-712 domain on Arbitrum (chainId 42161), unlike
+// order/cancel which use the L1 "Exchange" domain (chainId 1337).
+export function createWithdrawTypedData(
+  params: WithdrawParams,
+): Omit<VaultSignTypedDataInput, "agentId"> {
+  const n = normalizeWithdrawParams(params);
+  return {
+    domain: {
+      name: "HyperliquidSignTransaction",
+      version: "1",
+      chainId: WITHDRAW_CHAIN_ID,
+      verifyingContract: "0x0000000000000000000000000000000000000000",
+    },
+    types: {
+      [withdrawPrimaryType]: [
+        { name: "hyperliquidChain", type: "string" },
+        { name: "destination", type: "string" },
+        { name: "amount", type: "string" },
+        { name: "time", type: "uint64" },
+      ],
+    },
+    primaryType: withdrawPrimaryType,
+    value: {
+      hyperliquidChain: n.hyperliquidChain,
+      destination: n.destination,
+      amount: n.amount,
+      time: n.time,
+    },
+  };
+}
+
+export function toWithdrawAction(params: WithdrawParams): Record<string, unknown> {
+  const n = normalizeWithdrawParams(params);
+  return {
+    type: withdrawActionType,
+    hyperliquidChain: n.hyperliquidChain,
+    signatureChainId: WITHDRAW_SIGNATURE_CHAIN_ID,
+    amount: n.amount,
+    time: n.time,
+    destination: n.destination,
+  };
+}
+
+export async function submitWithdraw(
+  signed: SignedWithdraw,
+  options: { transport?: HyperliquidTransport; baseUrl?: string } = {},
+) {
+  const transport = options.transport ?? { fetch };
+  const baseUrl = options.baseUrl ?? DEFAULT_BASE_URL;
+  const r = await transport.fetch(`${baseUrl}/exchange`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(signedWithdrawSchema.parse(signed)),
+  });
+  const j = await r.json().catch(() => null);
+  if (!r.ok) throw new Error(`Hyperliquid exchange returned ${r.status}: ${JSON.stringify(j)}`);
+  return j;
+}
+
 export function createL1TypedData(
   action: Record<string, unknown>,
   nonce: number,
@@ -466,6 +555,10 @@ export class HyperliquidAdapter {
     );
   }
   async getPositions(): Promise<Position[]> {
+    const j = await this.clearinghouseState();
+    return normalizePositions(j);
+  }
+  private async clearinghouseState(): Promise<unknown> {
     const r = await this.transport.fetch(`${this.baseUrl}/info`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -473,8 +566,56 @@ export class HyperliquidAdapter {
     });
     const j = await r.json().catch(() => null);
     if (!r.ok) throw new Error(`Hyperliquid info returned ${r.status}`);
-    return normalizePositions(j);
+    return j;
   }
+  async signWithdraw(params: WithdrawParams): Promise<SignedWithdraw> {
+    const n = normalizeWithdrawParams(params);
+    const action = toWithdrawAction(n);
+    const td = createWithdrawTypedData(n);
+    const hex = await this.vault.signTypedData({ ...td, agentId: this.agentId });
+    const s = parseSignature(hex as Hex);
+    return signedWithdrawSchema.parse({
+      action,
+      nonce: n.time,
+      signature: { r: s.r, s: s.s, v: Number(s.v) },
+    });
+  }
+  submitWithdraw(signed: SignedWithdraw) {
+    return submitWithdraw(signed, { transport: this.transport, baseUrl: this.baseUrl });
+  }
+  // Build a reduce-only market order on the OPPOSITE side of the open position
+  // (long => sell, short => buy), sized abs(szi), then sign + submit it.
+  async marketClosePosition(coin: HyperliquidAsset): Promise<OrderResult> {
+    const positions = rawSignedPositions(await this.clearinghouseState());
+    const pos = positions.find((p) => p.coin === coin);
+    if (!pos || pos.szi === 0) throw new Error(`no open position for ${coin}`);
+    const isBuy = pos.szi < 0; // short => buy to close, long => sell to close
+    const signed = await this.signOrder({
+      coin,
+      isBuy,
+      size: Math.abs(pos.szi),
+      reduceOnly: true,
+    });
+    return this.submitOrder(signed);
+  }
+  // Iterate all open positions and market-close each non-zero one.
+  async closeAllPositions(): Promise<CloseAllResult[]> {
+    const positions = rawSignedPositions(await this.clearinghouseState());
+    const results: CloseAllResult[] = [];
+    for (const pos of positions) {
+      if (pos.szi === 0) continue;
+      const coin = pos.coin as HyperliquidAsset;
+      const result = await this.marketClosePosition(coin);
+      results.push({ coin, result });
+    }
+    return results;
+  }
+}
+function rawSignedPositions(raw: unknown): Array<{ coin: string; szi: number }> {
+  return (((raw as any)?.assetPositions ?? []) as any[]).map((e) => {
+    const p = e.position ?? {};
+    return { coin: String(p.coin ?? ""), szi: Number(p.szi ?? 0) };
+  });
 }
 function firstStatus(raw: unknown) {
   const data = ((raw as any).response?.data?.statuses ?? []) as unknown[];


### PR DESCRIPTION
## Wave 1 — HL withdraw signing + close-all in the venue adapter

Foundation for the operator-recovery layer. Adapter + tests only — **no route/auth/policy changes**.

### What's added (`packages/venue-hyperliquid/src/index.ts`)
- **`createWithdrawTypedData` / `toWithdrawAction`** — the user-signed `withdraw3` action. Uses the `HyperliquidSignTransaction` EIP-712 domain on **Arbitrum (chainId 42161)**, `primaryType` `HyperliquidTransaction:Withdraw` with fields `hyperliquidChain(string), destination(string), amount(string), time(uint64)`. This is intentionally **distinct** from the L1 `Exchange` domain (chainId 1337) used by order/cancel signing. Destination is lowercased + validated; amount stays a string.
- **`HyperliquidAdapter.signWithdraw` / `submitWithdraw`** — signs via the same `vaultClient.signTypedData` interface `signOrder` uses; returns `{ action, nonce: time, signature }`; POSTs to `/exchange`.
- **`HyperliquidAdapter.marketClosePosition(coin)`** — reads clearinghouse state, builds a **reduce-only** market order on the **opposite side** (long ⇒ sell, short ⇒ buy) sized `abs(szi)`, signs + submits via the existing order path.
- **`HyperliquidAdapter.closeAllPositions()`** — iterates positions, market-closes each non-zero one, returns `[{ coin, result }]`.

### Tests (`src/index.test.ts`)
- Golden-vector assertion on the withdraw EIP-712 structure (`domain.chainId === 42161`, primaryType, field names/types, string amount, lowercased destination).
- `closeAllPositions` iterates non-zero positions, skips flat, asserts reduce-only + opposite side + `abs(szi)` size per coin.
- Transport fully mocked — **no real network calls**.

**Status:** 15/15 tests pass, `tsc --noEmit` clean, biome clean.

Co-authored-by: wakesync <shadow@shad0w.xyz>