### PR TITLE
feat(vault): provision venue wallets with policies from birth

### DIFF
--- a/packages/policy-engine/src/__tests__/evaluators.test.ts
+++ b/packages/policy-engine/src/__tests__/evaluators.test.ts
@@ -436,6 +436,46 @@ describe("Approved Addresses Policy", () => {
 
     expect(result.passed).toBe(true);
   });
+
+  it("passes withdrawal when destination is approved", async () => {
+    const destination = "0xfeed00000000000000000000000000000000beef";
+    const rule = makeAddressRule({
+      addresses: [destination],
+      mode: "whitelist",
+    });
+
+    const ctx = makeContext({
+      request: {
+        ...makeContext().request,
+        to: "0x0000000000000000000000000000000000000000",
+        destination,
+      } as SignRequest & { destination: string },
+    });
+    const result = await evaluatePolicy(rule, ctx);
+
+    expect(result.passed).toBe(true);
+  });
+
+  it("rejects withdrawal when destination is not approved", async () => {
+    const destination = "0xfeed00000000000000000000000000000000beef";
+    const rule = makeAddressRule({
+      addresses: ["0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"],
+      mode: "whitelist",
+    });
+
+    const ctx = makeContext({
+      request: {
+        ...makeContext().request,
+        to: "0x0000000000000000000000000000000000000000",
+        destination,
+      } as SignRequest & { destination: string },
+    });
+    const result = await evaluatePolicy(rule, ctx);
+
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("Destination address");
+    expect(result.reason).toContain("not in whitelist");
+  });
 });
 
 // ─── Rate Limit Tests ─────────────────────────────────────────────────────

--- a/packages/policy-engine/src/evaluators.ts
+++ b/packages/policy-engine/src/evaluators.ts
@@ -262,15 +262,25 @@ async function evaluateSpendingLimit(
 function evaluateApprovedAddresses(rule: PolicyRule, ctx: EvaluatorContext): PolicyResult {
   const config = rule.config as unknown as ApprovedAddressesConfig;
   const base = { policyId: rule.id, type: rule.type } as const;
-  const target = ctx.request.to.toLowerCase();
-  const listed = config.addresses.map((a) => a.toLowerCase());
+  const targetAddress = getApprovedAddressTarget(ctx.request);
+  if (!targetAddress) {
+    return {
+      ...base,
+      passed: false,
+      reason: "No destination address found for approved-addresses policy",
+    };
+  }
 
-  if (config.mode === "whitelist") {
+  const target = targetAddress.toLowerCase();
+  const listed = config.addresses.map((a) => a.toLowerCase());
+  const mode = config.mode ?? "whitelist";
+
+  if (mode === "whitelist") {
     if (!listed.includes(target)) {
       return {
         ...base,
         passed: false,
-        reason: `Address ${ctx.request.to} not in whitelist`,
+        reason: `Destination address ${targetAddress} not in whitelist`,
       };
     }
   } else {
@@ -278,12 +288,30 @@ function evaluateApprovedAddresses(rule: PolicyRule, ctx: EvaluatorContext): Pol
       return {
         ...base,
         passed: false,
-        reason: `Address ${ctx.request.to} is blacklisted`,
+        reason: `Destination address ${targetAddress} is blacklisted`,
       };
     }
   }
 
   return { ...base, passed: true };
+}
+
+function getApprovedAddressTarget(request: SignRequest): string | undefined {
+  const withdrawalRequest = request as SignRequest & {
+    destination?: unknown;
+    action?: { destination?: unknown };
+    withdraw?: { destination?: unknown };
+  };
+
+  if (typeof withdrawalRequest.destination === "string") return withdrawalRequest.destination;
+  if (typeof withdrawalRequest.action?.destination === "string") {
+    return withdrawalRequest.action.destination;
+  }
+  if (typeof withdrawalRequest.withdraw?.destination === "string") {
+    return withdrawalRequest.withdraw.destination;
+  }
+
+  return request.to;
 }
 
 async function evaluateAutoApprove(rule: PolicyRule, ctx: EvaluatorContext): Promise<PolicyResult> {

--- a/packages/vault/src/__tests__/venue-scoping.test.ts
+++ b/packages/vault/src/__tests__/venue-scoping.test.ts
@@ -7,7 +7,7 @@
 
 import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 
-import { getDb, tenants } from "@stwd/db";
+import { agentWallets, eq, getDb, policies, tenants } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { Vault } from "../vault";
 
@@ -47,6 +47,56 @@ describe("Vault venue scoping (Sprint 4 Day 1)", () => {
       await client.close().catch(() => {});
     }
     openClients.length = 0;
+  });
+
+  test("provisionVenueWallet creates a venue wallet with all default policies enabled", async () => {
+    await vault.createAgent(TENANT_ID, "sol", "Sol");
+
+    const result = await vault.provisionVenueWallet({
+      tenantId: TENANT_ID,
+      agentId: "sol",
+      venue: "hyperliquid",
+      chainFamily: "evm",
+      approvedAddresses: ["0x1111111111111111111111111111111111111111"],
+    });
+
+    expect(result.address).toMatch(/^0x[0-9a-fA-F]{40}$/);
+
+    const walletRows = await getDb()
+      .select()
+      .from(agentWallets)
+      .where(eq(agentWallets.agentId, "sol"));
+    expect(
+      walletRows.some(
+        (row) =>
+          row.address === result.address &&
+          row.chainFamily === "evm" &&
+          row.venue === "hyperliquid",
+      ),
+    ).toBe(true);
+
+    const policyRows = await getDb().select().from(policies).where(eq(policies.agentId, "sol"));
+    const venuePolicies = policyRows.filter((row) =>
+      ["leverage-cap", "venue-allowlist", "spending-limit", "approved-addresses"].includes(
+        row.type,
+      ),
+    );
+
+    expect(venuePolicies).toHaveLength(4);
+    expect(venuePolicies.every((row) => row.enabled)).toBe(true);
+    expect(venuePolicies.map((row) => row.type).sort()).toEqual(
+      ["approved-addresses", "leverage-cap", "spending-limit", "venue-allowlist"].sort(),
+    );
+
+    const venueAllowlist = venuePolicies.find((row) => row.type === "venue-allowlist");
+    expect(venueAllowlist?.enabled).toBe(true);
+    expect(venueAllowlist?.config).toEqual({ allowedVenues: ["hyperliquid"] });
+
+    const approvedAddresses = venuePolicies.find((row) => row.type === "approved-addresses");
+    expect(approvedAddresses?.config).toEqual({
+      addresses: ["0x1111111111111111111111111111111111111111"],
+      mode: "whitelist",
+    });
   });
 
   test("createWallet provisions a venue-scoped EVM wallet and returns the address", async () => {

--- a/packages/vault/src/vault.ts
+++ b/packages/vault/src/vault.ts
@@ -1,9 +1,11 @@
+import { randomUUID } from "node:crypto";
 import {
   agents,
   agentWallets,
   encryptedChainKeys,
   encryptedKeys,
   getDb,
+  policies,
   toAgentIdentity,
   transactions,
 } from "@stwd/db";
@@ -1345,6 +1347,115 @@ export class Vault {
       purpose: row.purpose,
       address: row.address,
     };
+  }
+
+  /**
+   * Provision a fresh, venue-scoped wallet for an agent with default safety
+   * policies attached in the same DB transaction.
+   *
+   * This is the preferred onboarding path for venue wallets: the wallet is
+   * never born without its venue allowlist, leverage cap, spend limits, and
+   * withdrawal destination allowlist enabled.
+   */
+  async provisionVenueWallet(args: {
+    tenantId: string;
+    agentId: string;
+    venue: string;
+    chainFamily: "evm" | "solana";
+    approvedAddresses: string[];
+  }): Promise<{ address: string }> {
+    const { tenantId, agentId, venue, chainFamily, approvedAddresses } = args;
+    if (!tenantId) throw new Error("provisionVenueWallet requires a tenantId");
+    if (!agentId) throw new Error("provisionVenueWallet requires an agentId");
+    if (!venue) throw new Error("provisionVenueWallet requires a venue");
+    if (chainFamily !== "evm" && chainFamily !== "solana") {
+      throw new Error(`provisionVenueWallet: unsupported chainFamily ${chainFamily}`);
+    }
+    if (!Array.isArray(approvedAddresses)) {
+      throw new Error("provisionVenueWallet requires approvedAddresses");
+    }
+
+    const db = getDb();
+
+    const [agentRow] = await db
+      .select({ id: agents.id })
+      .from(agents)
+      .where(and(eq(agents.id, agentId), eq(agents.tenantId, tenantId)));
+    if (!agentRow) {
+      throw new Error(`Agent ${agentId} not found for tenant ${tenantId}`);
+    }
+
+    let address: string;
+    let secret: string;
+    if (chainFamily === "evm") {
+      const pk = generatePrivateKey();
+      const account = privateKeyToAccount(pk);
+      address = account.address;
+      secret = pk;
+    } else {
+      const kp = generateSolanaKeypair();
+      address = kp.publicKey;
+      secret = kp.secretKey;
+    }
+
+    const encrypted = await this.keyStore.encrypt(secret);
+    const createdAt = new Date();
+    const policyRows = [
+      {
+        id: randomUUID(),
+        agentId,
+        type: "leverage-cap" as const,
+        enabled: true,
+        config: { maxLeverage: 5 },
+      },
+      {
+        id: randomUUID(),
+        agentId,
+        type: "venue-allowlist" as const,
+        enabled: true,
+        config: { allowedVenues: [venue] },
+      },
+      {
+        id: randomUUID(),
+        agentId,
+        type: "spending-limit" as const,
+        enabled: true,
+        config: { maxPerTxUsd: 2000, maxPerDayUsd: 2000, maxPerWeekUsd: 5000 },
+      },
+      {
+        id: randomUUID(),
+        agentId,
+        type: "approved-addresses" as const,
+        enabled: true,
+        config: { addresses: approvedAddresses, mode: "whitelist" },
+      },
+    ];
+
+    await db.transaction(async (tx) => {
+      await tx.insert(encryptedChainKeys).values({
+        agentId,
+        chainFamily,
+        venue,
+        purpose: "venue",
+        ciphertext: encrypted.ciphertext,
+        iv: encrypted.iv,
+        tag: encrypted.tag,
+        salt: encrypted.salt,
+      });
+
+      await tx.insert(agentWallets).values({
+        agentId,
+        chainFamily,
+        venue,
+        purpose: "venue",
+        address,
+        createdAt,
+      });
+
+      await tx.insert(policies).values(policyRows);
+    });
+
+    return { address };
   }
 
   /**


### PR DESCRIPTION
## Summary
- wire approved-addresses policy evaluation to withdrawal destination shapes before falling back to request.to
- add Vault.provisionVenueWallet to atomically create venue-scoped wallet/key rows and attach default enabled policies
- cover withdrawal allowlist and policies-from-birth provisioning with tests

## Tests
- bun run --cwd packages/policy-engine test
- bun run --cwd packages/vault test
- bun run --cwd packages/policy-engine build
- bun run --cwd packages/vault build
- bunx @biomejs/biome check packages/policy-engine/src/evaluators.ts packages/policy-engine/src/__tests__/evaluators.test.ts packages/vault/src/vault.ts packages/vault/src/__tests__/venue-scoping.test.ts