### PR TITLE
feat(api): operator close-all + withdraw recovery endpoints

### DIFF
--- a/packages/api/src/__tests__/operator-recovery.test.ts
+++ b/packages/api/src/__tests__/operator-recovery.test.ts
@@ -1,0 +1,244 @@
+/**
+ * operator-recovery.test.ts — Operator close-all + withdraw endpoint tests.
+ *
+ * Covers:
+ *   - auth: no key → 401, wrong platform key → 403, valid platform key → proceeds
+ *   - withdraw with destination NOT in approved-addresses → policy-violation
+ *   - happy-path close-all + withdraw with a MOCKED adapter (no network),
+ *     asserting closeAllPositions / signWithdraw are invoked.
+ *
+ * The HyperliquidAdapter is mocked via `mock.module` so no real signing or
+ * network I/O occurs. The vault never signs because the adapter is replaced.
+ */
+
+import { afterAll, beforeAll, describe, expect, it, mock } from "bun:test";
+import { agents, agentWallets, closeDb, getDb, policies as policiesTable, tenants } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { Hono } from "hono";
+
+const PLATFORM_KEY = "stw_platform_test_operator_key";
+
+// ── Mock the Hyperliquid adapter (no signing / no network) ─────────────────────
+const closeAllCalls: number[] = [];
+const signWithdrawCalls: Array<{ amount: string | number; destination: string }> = [];
+const submitWithdrawCalls: unknown[] = [];
+
+class MockHyperliquidAdapter {
+  constructor(
+    public vault: unknown,
+    public agentId: string,
+    public walletAddress: string,
+  ) {}
+
+  async closeAllPositions() {
+    closeAllCalls.push(Date.now());
+    return [
+      { coin: "BTC", result: { status: "filled", orderId: "1001" } },
+      { coin: "ETH", result: { status: "filled", orderId: "1002" } },
+    ];
+  }
+
+  async signWithdraw(params: { amount: string | number; destination: string }) {
+    signWithdrawCalls.push(params);
+    return {
+      action: { type: "withdraw3", destination: params.destination },
+      nonce: 1,
+      signature: { r: "0x1", s: "0x2", v: 27 },
+    };
+  }
+
+  async submitWithdraw(signed: unknown) {
+    submitWithdrawCalls.push(signed);
+    return { status: "ok", response: { type: "default" } };
+  }
+}
+
+mock.module("@stwd/venue-hyperliquid", () => ({
+  HyperliquidAdapter: MockHyperliquidAdapter,
+}));
+
+beforeAll(async () => {
+  process.env.STEWARD_PGLITE_MEMORY = "true";
+  process.env.STEWARD_PLATFORM_KEYS = PLATFORM_KEY;
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+  process.env.STEWARD_MASTER_PASSWORD ??= "test-master-password";
+  const { db, client } = await createPGLiteDb("memory://");
+  setPGLiteOverride(db, async () => {
+    await client.close();
+  });
+});
+
+afterAll(async () => {
+  await closeDb();
+});
+
+async function seedAgent(opts: {
+  tenantId: string;
+  agentId: string;
+  approvedAddresses?: string[];
+}) {
+  await getDb().insert(tenants).values({
+    id: opts.tenantId,
+    name: "Operator Recovery Tenant",
+    apiKeyHash: "test-hash",
+    ownerAddress: "0x0000000000000000000000000000000000000000",
+  });
+  await getDb().insert(agents).values({
+    id: opts.agentId,
+    tenantId: opts.tenantId,
+    name: "Recovery Agent",
+    walletAddress: "0x00000000000000000000000000000000000000aa",
+  });
+  await getDb().insert(agentWallets).values({
+    agentId: opts.agentId,
+    chainFamily: "evm",
+    address: "0x00000000000000000000000000000000000000bb",
+    venue: "hyperliquid",
+    purpose: "perp",
+  });
+  if (opts.approvedAddresses) {
+    await getDb()
+      .insert(policiesTable)
+      .values({
+        id: `pol_${opts.agentId}`,
+        agentId: opts.agentId,
+        type: "approved-addresses",
+        enabled: true,
+        config: { mode: "whitelist", addresses: opts.approvedAddresses },
+      });
+  }
+}
+
+/**
+ * Build a Hono app that wires the operator gate exactly like app.ts:
+ * platform key OR tenant-admin (here we only exercise the platform-key arm
+ * plus the unauthenticated/wrong-key rejections, which is what production
+ * operator recovery uses).
+ */
+async function buildApp() {
+  const { isValidPlatformKey } = await import("@stwd/auth");
+  const { operatorRecoveryRoutes } = await import("../routes/operator-recovery");
+  const app = new Hono();
+  app.use("/v1/trade/*", async (c, next) => {
+    const key = c.req.header("X-Steward-Platform-Key");
+    if (!key) {
+      return c.json({ ok: false, error: "X-Steward-Platform-Key header is required" }, 401);
+    }
+    if (!isValidPlatformKey(key)) {
+      return c.json({ ok: false, error: "Invalid platform key" }, 403);
+    }
+    const tenantId = c.req.header("X-Steward-Tenant") || "default";
+    c.set("tenantId", tenantId);
+    c.set("authType", "platform");
+    return next();
+  });
+  app.route("/v1/trade", operatorRecoveryRoutes);
+  return app;
+}
+
+describe("operator recovery — auth", () => {
+  it("rejects close-all with no auth (401)", async () => {
+    const app = await buildApp();
+    const res = await app.request("/v1/trade/hyperliquid/close-all", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ agentId: "agent-x" }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects close-all with a wrong platform key (403)", async () => {
+    const app = await buildApp();
+    const res = await app.request("/v1/trade/hyperliquid/close-all", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Steward-Platform-Key": "stw_platform_wrong_key",
+      },
+      body: JSON.stringify({ agentId: "agent-x" }),
+    });
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("operator recovery — close-all", () => {
+  it("closes all positions with a valid platform key and audits each close", async () => {
+    const tenantId = `tenant-close-${Date.now()}`;
+    const agentId = `agent-close-${Date.now()}`;
+    await seedAgent({ tenantId, agentId });
+    closeAllCalls.length = 0;
+
+    const app = await buildApp();
+    const res = await app.request("/v1/trade/hyperliquid/close-all", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Steward-Platform-Key": PLATFORM_KEY,
+        "X-Steward-Tenant": tenantId,
+      },
+      body: JSON.stringify({ agentId }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; data: { closed: unknown[] } };
+    expect(body.ok).toBe(true);
+    expect(body.data.closed).toHaveLength(2);
+    expect(closeAllCalls.length).toBe(1);
+  });
+});
+
+describe("operator recovery — withdraw", () => {
+  it("rejects a withdraw to a destination NOT in approved-addresses", async () => {
+    const tenantId = `tenant-wd-bad-${Date.now()}`;
+    const agentId = `agent-wd-bad-${Date.now()}`;
+    const approved = "0x1111111111111111111111111111111111111111";
+    const badDest = "0x2222222222222222222222222222222222222222";
+    await seedAgent({ tenantId, agentId, approvedAddresses: [approved] });
+    signWithdrawCalls.length = 0;
+
+    const app = await buildApp();
+    const res = await app.request("/v1/trade/hyperliquid/withdraw", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Steward-Platform-Key": PLATFORM_KEY,
+        "X-Steward-Tenant": tenantId,
+      },
+      body: JSON.stringify({ agentId, amount: "100", destination: badDest }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { code: string; reason: string };
+    expect(body.code).toBe("policy-violation");
+    // Signing must never happen on a policy rejection.
+    expect(signWithdrawCalls.length).toBe(0);
+  });
+
+  it("signs + submits a withdraw to an approved destination", async () => {
+    const tenantId = `tenant-wd-ok-${Date.now()}`;
+    const agentId = `agent-wd-ok-${Date.now()}`;
+    const approved = "0x3333333333333333333333333333333333333333";
+    await seedAgent({ tenantId, agentId, approvedAddresses: [approved] });
+    signWithdrawCalls.length = 0;
+    submitWithdrawCalls.length = 0;
+
+    const app = await buildApp();
+    const res = await app.request("/v1/trade/hyperliquid/withdraw", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Steward-Platform-Key": PLATFORM_KEY,
+        "X-Steward-Tenant": tenantId,
+      },
+      body: JSON.stringify({ agentId, amount: "100", destination: approved }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; data: { destination: string } };
+    expect(body.ok).toBe(true);
+    expect(body.data.destination).toBe(approved);
+    expect(signWithdrawCalls.length).toBe(1);
+    expect(signWithdrawCalls[0]).toMatchObject({ amount: "100", destination: approved });
+    expect(submitWithdrawCalls.length).toBe(1);
+  });
+});

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -22,6 +22,7 @@ import { bodyLimit } from "hono/body-limit";
 import { logger } from "hono/logger";
 import { requireAgentJwt } from "./middleware/agent-jwt";
 import { correlationId } from "./middleware/correlation";
+import { operatorAuth } from "./middleware/operator-auth";
 import { securityHeaders } from "./middleware/security-headers";
 import { tenantCors } from "./middleware/tenant-cors";
 import { agentRoutes } from "./routes/agents";
@@ -30,6 +31,7 @@ import { auditRoutes } from "./routes/audit";
 import { authRoutes } from "./routes/auth";
 import { dashboardRoutes } from "./routes/dashboard";
 import { discoveryRoutes, erc8004Routes } from "./routes/erc8004";
+import { operatorRecoveryRoutes } from "./routes/operator-recovery";
 import { platformRoutes } from "./routes/platform";
 import { policiesStandaloneRoutes } from "./routes/policies-standalone";
 import { secretsRoutes } from "./routes/secrets";
@@ -122,16 +124,25 @@ app.use("/audit", (c, next) => tenantAuth(c, next));
 app.use("/audit/*", (c, next) => tenantAuth(c, next));
 app.use("/policies", (c, next) => tenantAuth(c, next));
 app.use("/policies/*", (c, next) => tenantAuth(c, next));
+// Operator fund-recovery endpoints use the operator gate (platform key OR
+// tenant-admin), NOT requireAgentJwt. See middleware/operator-auth.ts.
+const isOperatorRecoveryPath = (path: string): boolean =>
+  path.endsWith("/close-all") || path.endsWith("/withdraw");
+
 app.use("/trade/hyperliquid/order", (c, next) => requireAgentJwt(c, next));
 app.use("/v1/trade/hyperliquid/order", (c, next) => requireAgentJwt(c, next));
 app.use("/trade", (c, next) => tenantAuth(c, next));
-app.use("/trade/*", (c, next) =>
-  c.req.path.endsWith("/trade/hyperliquid/order") ? next() : tenantAuth(c, next),
-);
+app.use("/trade/*", (c, next) => {
+  if (c.req.path.endsWith("/trade/hyperliquid/order")) return next();
+  if (isOperatorRecoveryPath(c.req.path)) return operatorAuth(c, next);
+  return tenantAuth(c, next);
+});
 app.use("/v1/trade", (c, next) => tenantAuth(c, next));
-app.use("/v1/trade/*", (c, next) =>
-  c.req.path.endsWith("/v1/trade/hyperliquid/order") ? next() : tenantAuth(c, next),
-);
+app.use("/v1/trade/*", (c, next) => {
+  if (c.req.path.endsWith("/v1/trade/hyperliquid/order")) return next();
+  if (isOperatorRecoveryPath(c.req.path)) return operatorAuth(c, next);
+  return tenantAuth(c, next);
+});
 
 // ─── Health & root ────────────────────────────────────────────────────────────
 
@@ -164,6 +175,8 @@ app.route("/audit", auditRoutes);
 app.route("/policies", policiesStandaloneRoutes);
 app.route("/trade", tradeRoutes);
 app.route("/v1/trade", tradeRoutes);
+app.route("/trade", operatorRecoveryRoutes);
+app.route("/v1/trade", operatorRecoveryRoutes);
 app.route("/agents", erc8004Routes);
 app.route("/discovery", discoveryRoutes);
 

--- a/packages/api/src/middleware/operator-auth.ts
+++ b/packages/api/src/middleware/operator-auth.ts
@@ -1,0 +1,57 @@
+/**
+ * operator-auth.ts — Auth gate for operator fund-recovery endpoints.
+ *
+ * The operator close-all + withdraw endpoints must be reachable by a HUMAN
+ * operator even when no valid agent JWT exists (the expired-token / control-
+ * plane-down scenario the recovery feature exists to solve).
+ *
+ * This middleware accepts EITHER credential:
+ *   1. A platform key — header `X-Steward-Platform-Key`, validated by
+ *      `isValidPlatformKey`. This is the cross-tenant operator credential
+ *      (issued out-of-band to trusted operators such as Eliza Cloud).
+ *   2. A tenant-admin credential — falls through to `tenantAuth`, which
+ *      accepts a tenant API key (`X-Steward-Key` + `X-Steward-Tenant`) or a
+ *      user session JWT.
+ *
+ * It deliberately does NOT use `requireAgentJwt`. That RS256 path is exactly
+ * what stranded funds when the agent token expired.
+ *
+ * On platform-key auth we still need a tenant context. The platform operator
+ * supplies it via `X-Steward-Tenant`; we look the tenant up and set the
+ * standard context vars so downstream handlers behave identically to the
+ * tenant-auth path.
+ */
+
+import { isValidPlatformKey } from "@stwd/auth";
+import type { Context, Next } from "hono";
+import {
+  type ApiResponse,
+  type AppVariables,
+  DEFAULT_TENANT_ID,
+  findTenant,
+  tenantAuth,
+  tenantConfigs,
+} from "../services/context";
+
+export async function operatorAuth(c: Context<{ Variables: AppVariables }>, next: Next) {
+  const platformKey = c.req.header("X-Steward-Platform-Key");
+
+  if (platformKey) {
+    if (!isValidPlatformKey(platformKey)) {
+      return c.json<ApiResponse>({ ok: false, error: "Invalid platform key" }, 403);
+    }
+
+    const tenantId = c.req.header("X-Steward-Tenant") || DEFAULT_TENANT_ID;
+    const tenant = await findTenant(tenantId);
+    if (!tenant) return c.json<ApiResponse>({ ok: false, error: "Tenant not found" }, 404);
+
+    c.set("tenantId", tenantId);
+    c.set("tenant", tenant);
+    c.set("tenantConfig", tenantConfigs.get(tenantId) || { id: tenant.id, name: tenant.name });
+    c.set("authType", "platform");
+    return next();
+  }
+
+  // No platform key supplied — require tenant-admin auth instead.
+  return tenantAuth(c, next);
+}

--- a/packages/api/src/routes/operator-recovery.ts
+++ b/packages/api/src/routes/operator-recovery.ts
@@ -1,0 +1,391 @@
+/**
+ * operator-recovery.ts — Operator fund-recovery endpoints.
+ *
+ * These routes implement the core promise of Steward: a HUMAN OPERATOR must
+ * ALWAYS be able to close an agent's positions and withdraw its funds, even
+ * when the agent's RS256 trade token is expired or the eliza-cloud control
+ * plane is down. The Hyperliquid incident proved this capability was missing.
+ *
+ * ── Auth (deliberate) ────────────────────────────────────────────────────────
+ * These are OPERATOR endpoints, NOT agent endpoints. They are gated by
+ * `operatorAuth` (see app.ts), which accepts EITHER:
+ *   - a platform key (header `X-Steward-Platform-Key`, validated by
+ *     `isValidPlatformKey`), OR
+ *   - a tenant-admin credential (tenant API key `X-Steward-Key` +
+ *     `X-Steward-Tenant`, or a user session JWT) via `tenantAuth`.
+ *
+ * They MUST NOT be gated behind `requireAgentJwt`. That is exactly the broken
+ * path that stranded funds when the agent token expired. A human recovering
+ * funds has no valid agent JWT — that's the whole point.
+ *
+ * ── Signing (unchanged invariant) ──────────────────────────────────────────────
+ * The raw signing key NEVER touches this route. We build the same
+ * `vaultClient` shim used by POST /hyperliquid/order and hand it to the
+ * `HyperliquidAdapter`; the vault decrypts in-memory, signs, and zeroes the
+ * key internally. We reuse the Wave-1 adapter methods (closeAllPositions,
+ * signWithdraw, submitWithdraw) — no signing is reimplemented here.
+ */
+
+import { proxyAuditLog } from "@stwd/db";
+import { HyperliquidAdapter } from "@stwd/venue-hyperliquid";
+import type { Context } from "hono";
+import { Hono } from "hono";
+import { z } from "zod";
+import { writeAuditEvent } from "../services/audit";
+import {
+  type ApiResponse,
+  type AppVariables,
+  db,
+  ensureAgentForTenant,
+  getPolicySet,
+  isValidAnyAddress,
+  policyEngine,
+  priceOracle,
+  safeJsonParse,
+  vault,
+} from "../services/context";
+
+export const operatorRecoveryRoutes = new Hono<{ Variables: AppVariables }>();
+
+// ── Idempotency (mirrors trade.ts in-memory helper) ───────────────────────────
+const operatorIdempotency = new Map<
+  string,
+  { bodyHash: string; response: unknown; expiresAt: number }
+>();
+
+function getOperatorIdempotency(
+  scope: string,
+  key: string | undefined,
+  body: unknown,
+): { conflict?: boolean; response?: unknown; store?: (response: unknown) => void } {
+  if (!key) return {};
+  const now = Date.now();
+  const mapKey = `${scope}:${key}`;
+  const bodyHash = JSON.stringify(body);
+  const existing = operatorIdempotency.get(mapKey);
+  if (existing && existing.expiresAt > now) {
+    if (existing.bodyHash !== bodyHash) return { conflict: true };
+    return { response: existing.response };
+  }
+  return {
+    store(response: unknown) {
+      operatorIdempotency.set(mapKey, {
+        bodyHash,
+        response,
+        expiresAt: now + 24 * 60 * 60 * 1000,
+      });
+    },
+  };
+}
+
+function operatorActor(c: Context<{ Variables: AppVariables }>): {
+  actorType: "platform" | "user" | "agent";
+  actorId: string;
+} {
+  // operatorAuth sets authType to "platform" when authenticated via platform key.
+  if (c.get("authType") === "platform") {
+    return { actorType: "platform", actorId: "platform-operator" };
+  }
+  const userId = c.get("userId");
+  if (userId) return { actorType: "user", actorId: userId };
+  return { actorType: "user", actorId: c.get("tenantId") ?? "operator" };
+}
+
+async function auditRecoveryEvent(
+  c: Context<{ Variables: AppVariables }>,
+  tenantId: string,
+  agentId: string,
+  action: string,
+  metadata: Record<string, unknown>,
+): Promise<void> {
+  const actor = operatorActor(c);
+  await writeAuditEvent({
+    tenantId,
+    actorType: actor.actorType,
+    actorId: actor.actorId,
+    action,
+    resourceType: "trade",
+    resourceId: agentId,
+    metadata,
+  });
+  await db
+    .insert(proxyAuditLog)
+    .values({
+      tenantId,
+      agentId,
+      targetHost: action,
+      targetPath: JSON.stringify(metadata),
+      method: "AUDIT",
+      statusCode: 200,
+      latencyMs: 0,
+      reason: action,
+    })
+    .catch(() => undefined);
+}
+
+/**
+ * Resolve the agent's Hyperliquid venue wallet address. Prefers the explicit
+ * venue-scoped wallet (vault.getWallet) and falls back to the agent's EVM
+ * wallet — same resolution priority as POST /sessions in trade.ts.
+ */
+async function resolveVenueWallet(
+  tenantId: string,
+  agentId: string,
+  venue: string,
+): Promise<string | null> {
+  try {
+    const wallet = await vault.getWallet({ agentId, venue });
+    if (wallet?.address) return wallet.address;
+  } catch {
+    // fall through to agent EVM wallet
+  }
+  const agent = await ensureAgentForTenant(tenantId, agentId);
+  if (!agent) return null;
+  const evm = agent.walletAddresses?.evm;
+  if (evm) return evm;
+  return agent.walletAddress?.startsWith("0x") ? agent.walletAddress : null;
+}
+
+function buildAdapter(tenantId: string, agentId: string, walletAddress: string) {
+  const vaultClient = {
+    signTypedData: (input: Omit<Parameters<typeof vault.signTypedData>[0], "tenantId">) =>
+      vault.signTypedData({ ...input, tenantId, venue: "hyperliquid" as const }),
+  };
+  return new HyperliquidAdapter(vaultClient, agentId, walletAddress);
+}
+
+const closeAllSchema = z.object({
+  agentId: z.string().min(1),
+  idempotencyKey: z.string().min(1).max(256).optional(),
+});
+
+const withdrawSchema = z.object({
+  agentId: z.string().min(1),
+  amount: z.union([z.string(), z.number()]).optional(),
+  destination: z.string().min(1),
+  idempotencyKey: z.string().min(1).max(256).optional(),
+});
+
+// ── POST /v1/trade/:venue/close-all ────────────────────────────────────────────
+operatorRecoveryRoutes.post("/:venue/close-all", async (c) => {
+  const tenantId = c.get("tenantId");
+  const venue = c.req.param("venue");
+  if (venue !== "hyperliquid") {
+    return c.json<ApiResponse>({ ok: false, error: `Unsupported venue: ${venue}` }, 400);
+  }
+
+  const raw = await safeJsonParse(c);
+  const parsed = closeAllSchema.safeParse(raw);
+  if (!parsed.success) {
+    return c.json<ApiResponse>({ ok: false, error: parsed.error.message }, 400);
+  }
+  const body = {
+    ...parsed.data,
+    idempotencyKey: c.req.header("Idempotency-Key") ?? parsed.data.idempotencyKey,
+  };
+  const { agentId } = body;
+
+  const idempotency = getOperatorIdempotency(`${tenantId}:close-all`, body.idempotencyKey, {
+    agentId,
+    venue,
+  });
+  if (idempotency.conflict) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Idempotency key reused with a different body" },
+      409,
+    );
+  }
+  if (idempotency.response) {
+    return c.json<ApiResponse>({ ok: true, data: idempotency.response });
+  }
+
+  const agent = await ensureAgentForTenant(tenantId, agentId);
+  if (!agent) return c.json<ApiResponse>({ ok: false, error: "Agent not found" }, 404);
+
+  const walletAddress = await resolveVenueWallet(tenantId, agentId, venue);
+  if (!walletAddress) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Hyperliquid venue wallet not found for agent" },
+      404,
+    );
+  }
+
+  const adapter = buildAdapter(tenantId, agentId, walletAddress);
+
+  let results: Awaited<ReturnType<HyperliquidAdapter["closeAllPositions"]>>;
+  try {
+    results = await adapter.closeAllPositions();
+  } catch (err) {
+    await auditRecoveryEvent(c, tenantId, agentId, "trade.recovery.close-all.failed", {
+      venue,
+      walletAddress,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return c.json<ApiResponse>({ ok: false, error: "Failed to close positions" }, 502);
+  }
+
+  // Audit every per-coin close so the recovery action is fully traceable.
+  for (const r of results) {
+    await auditRecoveryEvent(c, tenantId, agentId, "trade.recovery.position-closed", {
+      venue,
+      walletAddress,
+      coin: r.coin,
+      status: r.result.status,
+      orderId: r.result.orderId ?? null,
+    });
+  }
+
+  const response = { venue, walletAddress, closed: results };
+  idempotency.store?.(response);
+  return c.json<ApiResponse>({ ok: true, data: response });
+});
+
+/**
+ * Read the agent's withdrawable USDC balance from the Hyperliquid
+ * clearinghouseState. HL exposes a top-level `withdrawable` string. We reach
+ * it via the same /info endpoint the adapter uses; if the shape is unexpected
+ * we return null so the caller must supply an explicit amount.
+ */
+async function fetchWithdrawable(walletAddress: string): Promise<string | null> {
+  try {
+    const r = await fetch("https://api.hyperliquid.xyz/info", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ type: "clearinghouseState", user: walletAddress }),
+    });
+    if (!r.ok) return null;
+    const j = (await r.json()) as { withdrawable?: unknown };
+    const w = j?.withdrawable;
+    if (typeof w === "string" && w.length > 0) return w;
+    if (typeof w === "number") return String(w);
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// ── POST /v1/trade/:venue/withdraw ─────────────────────────────────────────────
+operatorRecoveryRoutes.post("/:venue/withdraw", async (c) => {
+  const tenantId = c.get("tenantId");
+  const venue = c.req.param("venue");
+  if (venue !== "hyperliquid") {
+    return c.json<ApiResponse>({ ok: false, error: `Unsupported venue: ${venue}` }, 400);
+  }
+
+  const raw = await safeJsonParse(c);
+  const parsed = withdrawSchema.safeParse(raw);
+  if (!parsed.success) {
+    return c.json<ApiResponse>({ ok: false, error: parsed.error.message }, 400);
+  }
+  const body = {
+    ...parsed.data,
+    idempotencyKey: c.req.header("Idempotency-Key") ?? parsed.data.idempotencyKey,
+  };
+  const { agentId, destination } = body;
+
+  if (!isValidAnyAddress(destination)) {
+    return c.json<ApiResponse>({ ok: false, error: "Invalid destination address" }, 400);
+  }
+
+  const agent = await ensureAgentForTenant(tenantId, agentId);
+  if (!agent) return c.json<ApiResponse>({ ok: false, error: "Agent not found" }, 404);
+
+  const walletAddress = await resolveVenueWallet(tenantId, agentId, venue);
+  if (!walletAddress) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Hyperliquid venue wallet not found for agent" },
+      404,
+    );
+  }
+
+  // ── Approved-addresses policy gate (BEFORE signing) ──────────────────────────
+  // The withdraw destination must be on the agent's approved list. We evaluate
+  // the full policy set the same way POST /vault/sign does; the policy engine's
+  // approved-addresses evaluator reads `request.to`.
+  const policySet = await getPolicySet(tenantId, agentId);
+  const evaluation = await policyEngine.evaluate(policySet, {
+    request: {
+      agentId,
+      tenantId,
+      to: destination,
+      value: "0",
+      chainId: 42161, // Arbitrum — HL withdraw destination chain
+      venue: "hyperliquid" as const,
+    },
+    recentTxCount1h: 0,
+    recentTxCount24h: 0,
+    spentToday: 0n,
+    spentThisWeek: 0n,
+    priceOracle,
+  });
+  if (!evaluation.approved) {
+    const failed = evaluation.results.find((r) => !r.passed);
+    const reason = failed?.reason ?? "withdraw destination violates policy";
+    await auditRecoveryEvent(c, tenantId, agentId, "trade.recovery.withdraw.policy-rejected", {
+      venue,
+      walletAddress,
+      destination,
+      reason,
+    });
+    return c.json({ code: "policy-violation", reason }, 400);
+  }
+
+  // Idempotency keyed on (agent, destination, amount). Computed after the policy
+  // gate so a rejected withdraw is never cached as a success.
+  const idempotency = getOperatorIdempotency(`${tenantId}:withdraw`, body.idempotencyKey, {
+    agentId,
+    venue,
+    destination,
+    amount: body.amount ?? null,
+  });
+  if (idempotency.conflict) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Idempotency key reused with a different body" },
+      409,
+    );
+  }
+  if (idempotency.response) {
+    return c.json<ApiResponse>({ ok: true, data: idempotency.response });
+  }
+
+  // Resolve amount: explicit, or full withdrawable balance.
+  let amount = body.amount;
+  if (amount === undefined) {
+    const withdrawable = await fetchWithdrawable(walletAddress);
+    if (!withdrawable || Number(withdrawable) <= 0) {
+      return c.json<ApiResponse>(
+        { ok: false, error: "No withdrawable balance and no amount specified" },
+        400,
+      );
+    }
+    amount = withdrawable;
+  }
+
+  const adapter = buildAdapter(tenantId, agentId, walletAddress);
+
+  let result: unknown;
+  try {
+    const signed = await adapter.signWithdraw({ amount, destination });
+    result = await adapter.submitWithdraw(signed);
+  } catch (err) {
+    await auditRecoveryEvent(c, tenantId, agentId, "trade.recovery.withdraw.failed", {
+      venue,
+      walletAddress,
+      destination,
+      amount,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return c.json<ApiResponse>({ ok: false, error: "Failed to submit withdraw" }, 502);
+  }
+
+  await auditRecoveryEvent(c, tenantId, agentId, "trade.recovery.withdraw.submitted", {
+    venue,
+    walletAddress,
+    destination,
+    amount,
+  });
+
+  const response = { venue, walletAddress, destination, amount, result };
+  idempotency.store?.(response);
+  return c.json<ApiResponse>({ ok: true, data: response });
+});

--- a/packages/api/src/services/context.ts
+++ b/packages/api/src/services/context.ts
@@ -279,7 +279,7 @@ export type AppVariables = {
   tenantRole?: string;
   agentScope?: string;
   agentSubject?: string;
-  authType?: "api-key" | "session-jwt" | "agent-token" | "dashboard-jwt";
+  authType?: "api-key" | "session-jwt" | "agent-token" | "dashboard-jwt" | "platform";
 };
 
 // ─── Shared query helpers ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Wave 2 — Operator fund-recovery API endpoints

Adds the operator close-all + withdraw endpoints so a **human operator can always recover an agent's funds**, even when the agent's RS256 trade token is expired or the eliza-cloud control plane is down. Builds on Wave 1's adapter signing (#86).

### Endpoints
- `POST /v1/trade/:venue/close-all` — body `{ agentId, idempotencyKey? }`. Resolves the agent's venue wallet, builds the vaultClient shim, calls `adapter.closeAllPositions()`, audits every per-coin close. Returns per-coin results.
- `POST /v1/trade/:venue/withdraw` — body `{ agentId, amount?, destination, idempotencyKey? }`. Evaluates the **approved-addresses policy BEFORE signing** (destination must be whitelisted). If `amount` omitted, withdraws full withdrawable balance. Calls `adapter.signWithdraw` + `submitWithdraw`, audits.

### Auth (deliberate)
New `operatorAuth` middleware accepts **EITHER**:
- a platform key (`X-Steward-Platform-Key` → `isValidPlatformKey`), OR
- a tenant-admin credential (`tenantAuth`: `X-Steward-Key` + `X-Steward-Tenant`, or user session JWT).

These paths are **excluded from `requireAgentJwt`** in `app.ts` — that broken RS256 path is exactly what stranded funds. A human recovering funds has no valid agent JWT, by design.

### Signing invariant
Reuses the exact `POST /hyperliquid/order` pattern: `vaultClient = { signTypedData: i => vault.signTypedData({...i, tenantId, venue}) }` → `new HyperliquidAdapter(...)`. **The raw key never touches the route**; the vault decrypts/signs/zeroes internally. No signing is reimplemented — it reuses the Wave-1 `closeAllPositions` / `signWithdraw` / `submitWithdraw`.

### Tests (5, all green under `bun test --isolate`)
- no auth → 401
- wrong platform key → 403
- valid platform key → proceeds (close-all happy path; asserts `closeAllPositions` called)
- withdraw to non-approved destination → `policy-violation` (asserts signing never happens)
- withdraw to approved destination → signs + submits (asserts `signWithdraw`/`submitWithdraw` called) — adapter MOCKED, no network

### Verification
- `tsc --noEmit` clean (turbo build @stwd/api)
- biome lint clean
- full `bun test --isolate packages/api` → 84 pass, 0 fail (CI mode)

Co-authored-by: wakesync <shadow@shad0w.xyz>