### PR TITLE
feat(api): agent trade token expiry monitoring + token-status endpoint

### DIFF
--- a/packages/api/src/__tests__/agent-token-expiry-monitoring.test.ts
+++ b/packages/api/src/__tests__/agent-token-expiry-monitoring.test.ts
@@ -1,0 +1,218 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import { generateApiKey } from "@stwd/auth";
+import { closeDb, getDb, tenants } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { Hono } from "hono";
+import { exportJWK, generateKeyPair, SignJWT } from "jose";
+
+const TENANT_ID = "test-agent-token-expiry";
+const TENANT_NO_KEY_ID = "test-agent-token-expiry-no-key";
+const AGENT_ID = "test-token-watch-agent";
+const KID = "test-agent-token-kid";
+
+const auditEvents: Array<{ action: string; metadata?: Record<string, unknown>; actorId?: string }> =
+  [];
+
+mock.module("../services/audit", () => ({
+  trackAuditEvent: (event: {
+    action: string;
+    metadata?: Record<string, unknown>;
+    actorId?: string;
+  }) => {
+    auditEvents.push(event);
+  },
+  writeAuditEvent: async (event: {
+    action: string;
+    metadata?: Record<string, unknown>;
+    actorId?: string;
+  }) => {
+    auditEvents.push(event);
+  },
+}));
+
+let privateKey: CryptoKey;
+let publicJwk: JsonWebKey;
+let apiKey = "";
+let requireAgentJwt: typeof import("../middleware/agent-jwt")["requireAgentJwt"];
+let clearAgentJwksCacheForTests: typeof import("../middleware/agent-jwt")["clearAgentJwksCacheForTests"];
+let clearAgentTokenStatusForTests: typeof import("../services/agent-token-status")["clearAgentTokenStatusForTests"];
+let tradeRoutes: typeof import("../routes/trade")["tradeRoutes"];
+let tenantAuth: typeof import("../services/context")["tenantAuth"];
+
+beforeAll(async () => {
+  process.env.STEWARD_PGLITE_MEMORY = "true";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+  process.env.STEWARD_MASTER_PASSWORD ??= "test-master-password";
+
+  const { db, client } = await createPGLiteDb("memory://");
+  setPGLiteOverride(db, async () => {
+    await client.close();
+  });
+
+  const keys = await generateKeyPair("RS256", { extractable: true });
+  privateKey = keys.privateKey;
+  publicJwk = await exportJWK(keys.publicKey);
+  publicJwk.kid = KID;
+  publicJwk.alg = "RS256";
+  publicJwk.use = "sig";
+
+  globalThis.fetch = mock(async () =>
+    Response.json({ keys: [publicJwk] }),
+  ) as unknown as typeof fetch;
+
+  ({ requireAgentJwt, clearAgentJwksCacheForTests } = await import("../middleware/agent-jwt"));
+  ({ clearAgentTokenStatusForTests } = await import("../services/agent-token-status"));
+  ({ tradeRoutes } = await import("../routes/trade"));
+  ({ tenantAuth } = await import("../services/context"));
+
+  const apiKeyPair = generateApiKey();
+  apiKey = apiKeyPair.key;
+  await getDb()
+    .insert(tenants)
+    .values([
+      {
+        id: TENANT_ID,
+        name: "Agent Token Expiry Tenant",
+        apiKeyHash: apiKeyPair.hash,
+      },
+      {
+        id: TENANT_NO_KEY_ID,
+        name: "Agent Token Expiry No Key Tenant",
+        apiKeyHash: "",
+      },
+    ])
+    .onConflictDoNothing();
+});
+
+afterAll(async () => {
+  await closeDb();
+});
+
+beforeEach(() => {
+  auditEvents.length = 0;
+  clearAgentJwksCacheForTests?.();
+  clearAgentTokenStatusForTests?.();
+});
+
+async function signTradeToken(expiresAt: number): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  return new SignJWT({ agent_id: AGENT_ID })
+    .setProtectedHeader({ alg: "RS256", typ: "JWT", kid: KID })
+    .setSubject(`agent:${AGENT_ID}`)
+    .setIssuer("eliza-cloud")
+    .setAudience("steward")
+    .setIssuedAt(now - 10)
+    .setNotBefore(now - 10)
+    .setExpirationTime(expiresAt)
+    .sign(privateKey);
+}
+
+function buildAgentJwtApp() {
+  const app = new Hono();
+  app.use("/v1/trade/hyperliquid/order", (c, next) => requireAgentJwt(c as never, next));
+  app.post("/v1/trade/hyperliquid/order", (c) => c.json({ ok: true }));
+  return app;
+}
+
+function buildTokenStatusApp() {
+  const app = new Hono();
+  app.use("/v1/trade/*", (c, next) => tenantAuth(c as never, next));
+  app.route("/v1/trade", tradeRoutes);
+  return app;
+}
+
+describe("agent trade token expiry monitoring", () => {
+  it("emits an expiring event for a token inside the warning threshold", async () => {
+    const exp = Math.floor(Date.now() / 1000) + 120;
+    const token = await signTradeToken(exp);
+    const app = buildAgentJwtApp();
+
+    const res = await app.request("/v1/trade/hyperliquid/order", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "X-Steward-Tenant": TENANT_ID,
+      },
+    });
+
+    expect(res.status).toBe(200);
+    const event = auditEvents.find((entry) => entry.action === "agent.token.expiring");
+    expect(event?.actorId).toBe(AGENT_ID);
+    expect(event?.metadata?.agentId).toBe(AGENT_ID);
+    expect(event?.metadata?.exp).toBe(exp);
+    expect(event?.metadata?.expiresInSeconds).toBeGreaterThan(0);
+    expect(event?.metadata?.expiresInSeconds).toBeLessThanOrEqual(300);
+  });
+
+  it("keeps rejecting expired tokens and emits an expired event", async () => {
+    const exp = Math.floor(Date.now() / 1000) - 60;
+    const token = await signTradeToken(exp);
+    const app = buildAgentJwtApp();
+
+    const res = await app.request("/v1/trade/hyperliquid/order", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "X-Steward-Tenant": TENANT_ID,
+      },
+    });
+
+    expect(res.status).toBe(401);
+    const event = auditEvents.find((entry) => entry.action === "agent.token.expired");
+    expect(event?.actorId).toBe(AGENT_ID);
+    expect(event?.metadata?.agentId).toBe(AGENT_ID);
+    expect(event?.metadata?.exp).toBe(exp);
+    expect(event?.metadata?.expiresInSeconds).toBeLessThanOrEqual(0);
+  });
+
+  it("requires tenant auth for token-status and reports observed or unknown state", async () => {
+    const app = buildTokenStatusApp();
+
+    const unauthenticated = await app.request(
+      `/v1/trade/token-status?agentId=${encodeURIComponent(AGENT_ID)}`,
+      { headers: { "X-Steward-Tenant": TENANT_NO_KEY_ID } },
+    );
+    expect(unauthenticated.status).toBe(401);
+
+    const unknown = await app.request("/v1/trade/token-status?agentId=missing-agent", {
+      headers: {
+        "X-Steward-Tenant": TENANT_ID,
+        "X-Steward-Key": apiKey,
+      },
+    });
+    expect(unknown.status).toBe(200);
+    const unknownBody = (await unknown.json()) as { data: { status: string; exp: number | null } };
+    expect(unknownBody.data.status).toBe("unknown");
+    expect(unknownBody.data.exp).toBeNull();
+
+    const exp = Math.floor(Date.now() / 1000) + 600;
+    const token = await signTradeToken(exp);
+    const agentJwtApp = buildAgentJwtApp();
+    const observedWrite = await agentJwtApp.request("/v1/trade/hyperliquid/order", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "X-Steward-Tenant": TENANT_ID,
+      },
+    });
+    expect(observedWrite.status).toBe(200);
+
+    const observed = await app.request(
+      `/v1/trade/token-status?agentId=${encodeURIComponent(AGENT_ID)}`,
+      {
+        headers: {
+          "X-Steward-Tenant": TENANT_ID,
+          "X-Steward-Key": apiKey,
+        },
+      },
+    );
+    expect(observed.status).toBe(200);
+    const observedBody = (await observed.json()) as {
+      data: { status: string; agentId: string; exp: number; expiresInSeconds: number };
+    };
+    expect(observedBody.data.status).toBe("observed");
+    expect(observedBody.data.agentId).toBe(AGENT_ID);
+    expect(observedBody.data.exp).toBe(exp);
+    expect(observedBody.data.expiresInSeconds).toBeGreaterThan(0);
+  });
+});

--- a/packages/api/src/middleware/agent-jwt.ts
+++ b/packages/api/src/middleware/agent-jwt.ts
@@ -1,5 +1,7 @@
 import type { Context, Next } from "hono";
-import { importJWK, type JWTPayload, jwtVerify } from "jose";
+import { errors, importJWK, type JWTPayload, jwtVerify } from "jose";
+import { recordAgentTokenExp } from "../services/agent-token-status";
+import { trackAuditEvent } from "../services/audit";
 import type { ApiResponse, AppVariables, Tenant } from "../services/context";
 import { DEFAULT_TENANT_ID, findTenant, tenantConfigs } from "../services/context";
 
@@ -12,6 +14,7 @@ type CacheEntry = {
 };
 
 const JWKS_CACHE_MS = 5 * 60 * 1000;
+const AGENT_TOKEN_EXPIRING_THRESHOLD_SECONDS = 5 * 60;
 const ELIZA_CLOUD_JWKS_URL =
   process.env.ELIZA_CLOUD_JWKS_URL || "https://milady.shad0w.xyz/.well-known/jwks.json";
 
@@ -65,6 +68,16 @@ function decodeJwtHeader(token: string): { kid?: string; alg?: string } | null {
   }
 }
 
+function decodeJwtPayload(token: string): JWTPayload | null {
+  try {
+    const [, payload] = token.split(".");
+    if (!payload) return null;
+    return JSON.parse(base64UrlDecode(payload));
+  } catch {
+    return null;
+  }
+}
+
 function agentIdFromPayload(payload: JWTPayload): string | null {
   const agentId = payload.agent_id;
   if (typeof agentId !== "string" || !agentId.trim()) return null;
@@ -83,6 +96,56 @@ async function setTenantContext(
   c.set("tenantConfig", tenantConfigs.get(tenantId) || { id: tenant.id, name: tenant.name });
   c.set("agentScope", agentId);
   c.set("authType", "agent-token");
+}
+
+function emitAgentTokenEvent(
+  tenantId: string,
+  agentId: string,
+  action: "agent.token.expiring" | "agent.token.expired",
+  metadata: Record<string, unknown>,
+) {
+  trackAuditEvent({
+    tenantId,
+    actorType: "agent",
+    actorId: agentId,
+    action,
+    resourceType: "agent-token",
+    resourceId: agentId,
+    metadata,
+  });
+}
+
+async function observeAgentTokenExpiry(
+  tenantId: string,
+  agentId: string,
+  exp: JWTPayload["exp"],
+): Promise<void> {
+  if (typeof exp !== "number") return;
+
+  await recordAgentTokenExp(agentId, exp);
+
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const expiresInSeconds = exp - nowSeconds;
+  if (expiresInSeconds > AGENT_TOKEN_EXPIRING_THRESHOLD_SECONDS) return;
+
+  const metadata = { agentId, expiresInSeconds, exp };
+  console.warn("[steward:agent-token] agent token expiring", metadata);
+  emitAgentTokenEvent(tenantId, agentId, "agent.token.expiring", metadata);
+}
+
+function observeExpiredAgentToken(c: Context, token: string): void {
+  const payload = decodeJwtPayload(token);
+  if (!payload) return;
+  const agentId = agentIdFromPayload(payload);
+  if (!agentId) return;
+
+  const tenantId = c.req.header("X-Steward-Tenant") || DEFAULT_TENANT_ID;
+  const exp = typeof payload.exp === "number" ? payload.exp : undefined;
+  const expiresInSeconds =
+    typeof exp === "number" ? exp - Math.floor(Date.now() / 1000) : undefined;
+  const metadata = { agentId, expiresInSeconds, exp };
+  console.warn("[steward:agent-token] agent token expired", metadata);
+  emitAgentTokenEvent(tenantId, agentId, "agent.token.expired", metadata);
 }
 
 export async function requireAgentJwt(c: Context<{ Variables: AppVariables }>, next: Next) {
@@ -110,9 +173,11 @@ export async function requireAgentJwt(c: Context<{ Variables: AppVariables }>, n
     const tenant = await findTenant(tenantId);
     if (!tenant) return c.json<ApiResponse>({ ok: false, error: "Tenant not found" }, 404);
 
+    await observeAgentTokenExpiry(tenantId, agentId, payload.exp);
     await setTenantContext(c, tenant, tenantId, agentId);
     return next();
   } catch (error) {
+    if (error instanceof errors.JWTExpired) observeExpiredAgentToken(c, token);
     const reason = error instanceof Error ? error.message : "verification failed";
     return invalid(c, reason);
   }

--- a/packages/api/src/routes/trade.ts
+++ b/packages/api/src/routes/trade.ts
@@ -12,6 +12,7 @@ import type { Context } from "hono";
 import { Hono } from "hono";
 import { z } from "zod";
 import { getRedisClient } from "../middleware/redis";
+import { getAgentTokenStatus } from "../services/agent-token-status";
 import { writeAuditEvent } from "../services/audit";
 import {
   type ApiResponse,
@@ -23,6 +24,36 @@ import {
 } from "../services/context";
 
 export const tradeRoutes = new Hono<{ Variables: AppVariables }>();
+
+tradeRoutes.get("/token-status", async (c) => {
+  const agentId = c.req.query("agentId")?.trim();
+  if (!agentId) {
+    return c.json<ApiResponse>({ ok: false, error: "agentId is required" }, 400);
+  }
+
+  const status = await getAgentTokenStatus(agentId);
+  if (!status) {
+    return c.json(
+      responseData({
+        agentId,
+        status: "unknown" as const,
+        exp: null,
+        observedAt: null,
+        expiresInSeconds: null,
+      }),
+    );
+  }
+
+  return c.json(
+    responseData({
+      agentId,
+      status: "observed" as const,
+      exp: status.exp,
+      observedAt: status.observedAt,
+      expiresInSeconds: status.exp - Math.floor(Date.now() / 1000),
+    }),
+  );
+});
 
 const createSessionSchema = z.object({
   agentId: z.string().min(1).optional(),

--- a/packages/api/src/services/agent-token-status.ts
+++ b/packages/api/src/services/agent-token-status.ts
@@ -1,0 +1,72 @@
+import { getRedisClient } from "../middleware/redis";
+
+const TOKEN_STATUS_KEY_PREFIX = "agent-token-status";
+const LAST_OBSERVED_TTL_SECONDS = 7 * 24 * 60 * 60;
+
+type AgentTokenStatus = {
+  agentId: string;
+  exp: number;
+  observedAt: number;
+};
+
+const memoryLastObserved = new Map<string, AgentTokenStatus>();
+
+function statusKey(agentId: string): string {
+  return `${TOKEN_STATUS_KEY_PREFIX}:${agentId}`;
+}
+
+export async function recordAgentTokenExp(agentId: string, exp: number): Promise<void> {
+  if (!Number.isFinite(exp)) return;
+
+  const status: AgentTokenStatus = {
+    agentId,
+    exp,
+    observedAt: Math.floor(Date.now() / 1000),
+  };
+  memoryLastObserved.set(agentId, status);
+
+  const redis = getRedisClient();
+  if (!redis) return;
+
+  try {
+    await redis.setex(statusKey(agentId), LAST_OBSERVED_TTL_SECONDS, JSON.stringify(status));
+  } catch (error) {
+    console.warn("[steward:agent-token] failed to record token status in redis", {
+      agentId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+export async function getAgentTokenStatus(agentId: string): Promise<AgentTokenStatus | null> {
+  const redis = getRedisClient();
+  if (redis) {
+    try {
+      const raw = await redis.get(statusKey(agentId));
+      if (raw) {
+        const parsed = JSON.parse(raw) as Partial<AgentTokenStatus>;
+        if (parsed.agentId === agentId && typeof parsed.exp === "number") {
+          return {
+            agentId,
+            exp: parsed.exp,
+            observedAt:
+              typeof parsed.observedAt === "number"
+                ? parsed.observedAt
+                : Math.floor(Date.now() / 1000),
+          };
+        }
+      }
+    } catch (error) {
+      console.warn("[steward:agent-token] failed to read token status from redis", {
+        agentId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return memoryLastObserved.get(agentId) ?? null;
+}
+
+export function clearAgentTokenStatusForTests(): void {
+  memoryLastObserved.clear();
+}


### PR DESCRIPTION
## Summary
- emit agent.token.expiring audit events + structured warnings when RS256 trade tokens are within the 5-minute expiry threshold
- emit agent.token.expired audit events + structured warnings when requireAgentJwt rejects an expired token, preserving the existing 401 behavior
- record last observed agent token exp and expose GET /v1/trade/token-status?agentId=... behind tenantAuth for ops visibility

## Tests
- bun test --isolate packages/api
- bun run --cwd packages/api build
- bunx @biomejs/biome check packages/api/src/middleware/agent-jwt.ts packages/api/src/routes/trade.ts packages/api/src/services/agent-token-status.ts packages/api/src/__tests__/agent-token-expiry-monitoring.test.ts