### PR TITLE
fix(api): pass venue at top-level of withdraw policy eval context

### DIFF
--- a/packages/api/src/routes/operator-recovery.ts
+++ b/packages/api/src/routes/operator-recovery.ts
@@ -310,8 +310,11 @@ operatorRecoveryRoutes.post("/:venue/withdraw", async (c) => {
       to: destination,
       value: "0",
       chainId: 42161, // Arbitrum — HL withdraw destination chain
-      venue: "hyperliquid" as const,
     },
+    // `venue` must be top-level on the evaluation context: the engine reads
+    // `ctx.venue` (engine.ts) for the venue-allowlist evaluator. Nesting it
+    // inside `request` leaves ctx.venue undefined → venue-allowlist fails closed.
+    venue: "hyperliquid" as const,
     recentTxCount1h: 0,
     recentTxCount24h: 0,
     spentToday: 0n,


### PR DESCRIPTION
Caught in the $10 live recovery test. The operator withdraw handler nested `venue` inside `request`, but the policy engine reads `ctx.venue` (engine.ts:138) for the venue-allowlist evaluator. Result: ctx.venue undefined → venue-allowlist failed closed → ALL withdrawals rejected (even approved destinations) with 'missing venue in eval context'. close-all was unaffected (no transaction-policy eval). One-line move of venue to top-level. Co-authored-by: wakesync <shadow@shad0w.xyz>