### PR TITLE
feat(erc8004): real on-chain ERC-8004 identity + reputation client (was stub)

### DIFF
--- a/packages/erc8004/package.json
+++ b/packages/erc8004/package.json
@@ -5,9 +5,13 @@
   "type": "module",
   "main": "src/index.ts",
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "bun test src/__tests__"
   },
-  "dependencies": {},
+  "dependencies": {
+    "viem": "^2.30.0"
+  },
   "devDependencies": {
     "typescript": "^5.0.0"
   }

--- a/packages/erc8004/src/__tests__/identity.test.ts
+++ b/packages/erc8004/src/__tests__/identity.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+import {
+  encodeAbiParameters,
+  encodeEventTopics,
+  encodeFunctionData,
+  getAddress,
+  parseAbiParameters,
+  zeroHash,
+} from "viem";
+import { REGISTRY_CONFIGS } from "../chains";
+import {
+  buildAgentURI,
+  decodeRegisteredLog,
+  encodeRegisterCalldata,
+  IDENTITY_REGISTRY_ABI,
+  IdentityRegistryClient,
+} from "../identity";
+import type { Eip8004Signer } from "../types";
+
+const txHash = "0x1111111111111111111111111111111111111111111111111111111111111111";
+const owner = getAddress("0x1234567890123456789012345678901234567890");
+
+describe("ERC-8004 identity client", () => {
+  test("encodes register(agentURI) calldata", () => {
+    const card = {
+      name: "Sol",
+      description: "Steward agent",
+      walletAddress: owner,
+      apiUrl: "https://agent.example",
+      capabilities: [],
+      services: [],
+    };
+    const { agentURI } = buildAgentURI(card);
+
+    expect(encodeRegisterCalldata(agentURI)).toBe(
+      encodeFunctionData({
+        abi: IDENTITY_REGISTRY_ABI,
+        functionName: "register",
+        args: [agentURI],
+      }),
+    );
+  });
+
+  test("decodes Registered event receipt into real agent id", async () => {
+    const config = REGISTRY_CONFIGS[56];
+    const card = {
+      name: "Sol",
+      description: "Steward agent",
+      walletAddress: owner,
+      apiUrl: "https://agent.example",
+      capabilities: [],
+      services: [],
+    };
+    const { agentURI } = buildAgentURI(card);
+    const topics = encodeEventTopics({
+      abi: IDENTITY_REGISTRY_ABI,
+      eventName: "Registered",
+      args: { agentId: 42n, owner },
+    });
+    const data = encodeAbiParameters(parseAbiParameters("string"), [agentURI]);
+    const publicClient = {
+      waitForTransactionReceipt: async () => ({
+        status: "success",
+        logs: [{ address: config.identityRegistry, topics, data }],
+      }),
+    };
+    let sentData = zeroHash;
+    const signer: Eip8004Signer = {
+      sendTransaction: async ({ to, data }) => {
+        expect(to).toBe(config.identityRegistry);
+        sentData = data;
+        return txHash;
+      },
+    };
+
+    const result = await new IdentityRegistryClient(config, publicClient as never).register(
+      card,
+      signer,
+    );
+
+    expect(sentData).toBe(encodeRegisterCalldata(agentURI));
+    expect(result.tokenId).toBe("42");
+    expect(result.txHash).toBe(txHash);
+    expect(result.agentURI).toBe(agentURI);
+    expect(decodeRegisteredLog({ data, topics })?.args.agentId).toBe(42n);
+  });
+
+  test("getRegistration returns null when token is genuinely absent", async () => {
+    const config = REGISTRY_CONFIGS[56];
+    const publicClient = {
+      readContract: async () => {
+        throw new Error("ERC721: invalid token ID");
+      },
+    };
+
+    const result = await new IdentityRegistryClient(config, publicClient as never).getRegistration(
+      "999",
+    );
+
+    expect(result).toBeNull();
+  });
+});

--- a/packages/erc8004/src/chains.ts
+++ b/packages/erc8004/src/chains.ts
@@ -1,42 +1,56 @@
 /**
  * Known ERC-8004 registry deployments per chain.
- *
- * All addresses are placeholders until contracts are deployed.
  */
 
+import type { Address } from "viem";
 import type { RegistryConfig } from "./types";
 
-const PLACEHOLDER_REGISTRY = "0x0000000000000000000000000000000000008004";
+export const ERC8004_IDENTITY_REGISTRY_ADDRESS: Address =
+  "0x8004A169FB4a3325136EB29fA0ceB6D2e539a432";
+
+export const ERC8004_REPUTATION_REGISTRY_ADDRESS: Address =
+  "0x8004BAa17C55a88189AE136b182e5fdA19dE9b63";
+
+function registryConfig(
+  params: Omit<RegistryConfig, "registryAddress" | "identityRegistry" | "reputationRegistry">,
+): RegistryConfig {
+  return {
+    ...params,
+    registryAddress: ERC8004_IDENTITY_REGISTRY_ADDRESS,
+    identityRegistry: ERC8004_IDENTITY_REGISTRY_ADDRESS,
+    reputationRegistry: ERC8004_REPUTATION_REGISTRY_ADDRESS,
+  };
+}
 
 export const REGISTRY_CONFIGS: Record<number, RegistryConfig> = {
-  8453: {
+  8453: registryConfig({
     chainId: 8453,
     name: "Base",
     rpcUrl: "https://mainnet.base.org",
-    registryAddress: PLACEHOLDER_REGISTRY,
-  },
-  1: {
+  }),
+  1: registryConfig({
     chainId: 1,
     name: "Ethereum",
     rpcUrl: "https://eth.llamarpc.com",
-    registryAddress: PLACEHOLDER_REGISTRY,
-  },
-  56: {
+  }),
+  56: registryConfig({
     chainId: 56,
     name: "BSC",
     rpcUrl: "https://bsc-dataseed.binance.org",
-    registryAddress: PLACEHOLDER_REGISTRY,
-  },
-  100: {
+  }),
+  97: registryConfig({
+    chainId: 97,
+    name: "BSC Testnet",
+    rpcUrl: "https://data-seed-prebsc-1-s1.binance.org:8545",
+  }),
+  100: registryConfig({
     chainId: 100,
     name: "Gnosis",
     rpcUrl: "https://rpc.gnosischain.com",
-    registryAddress: PLACEHOLDER_REGISTRY,
-  },
-  42161: {
+  }),
+  42161: registryConfig({
     chainId: 42161,
     name: "Arbitrum",
     rpcUrl: "https://arb1.arbitrum.io/rpc",
-    registryAddress: PLACEHOLDER_REGISTRY,
-  },
+  }),
 };

--- a/packages/erc8004/src/identity.ts
+++ b/packages/erc8004/src/identity.ts
@@ -1,15 +1,147 @@
 /**
  * ERC-8004 identity registry client.
- * Uses mock data until the registry contract is deployed.
  */
 
-import type { AgentCard, RegistrationResult, RegistryConfig } from "./types";
+import {
+  type Address,
+  createPublicClient,
+  decodeEventLog,
+  encodeFunctionData,
+  getAddress,
+  type Hex,
+  http,
+  isAddress,
+  type PublicClient,
+  parseAbi,
+} from "viem";
+import type {
+  AgentCard,
+  AgentRegistrationPayload,
+  Eip8004Signer,
+  RegistrationResult,
+  RegistryConfig,
+} from "./types";
+
+export const EIP8004_REGISTRATION_TYPE = "https://eips.ethereum.org/EIPS/eip-8004#registration-v1";
+
+export const IDENTITY_REGISTRY_ABI = parseAbi([
+  "function register(string agentURI) returns (uint256 agentId)",
+  "function ownerOf(uint256 tokenId) view returns (address)",
+  "function tokenURI(uint256 tokenId) view returns (string)",
+  "function balanceOf(address owner) view returns (uint256)",
+  "function tokenOfOwnerByIndex(address owner, uint256 index) view returns (uint256)",
+  "event Registered(uint256 indexed agentId, string agentURI, address indexed owner)",
+]);
+
+type RegistrationLog = {
+  eventName: "Registered";
+  args: { agentId: bigint; agentURI: string; owner: Address };
+};
+
+function makePublicClient(config: RegistryConfig): PublicClient {
+  if (config.publicClient) return config.publicClient;
+  return createPublicClient({
+    transport: http(config.rpcUrl),
+  });
+}
+
+function toBase64(value: string): string {
+  if (typeof Buffer !== "undefined") return Buffer.from(value, "utf8").toString("base64");
+  const bytes = new TextEncoder().encode(value);
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+function fromBase64(value: string): string {
+  if (typeof Buffer !== "undefined") return Buffer.from(value, "base64").toString("utf8");
+  const binary = atob(value);
+  const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+}
+
+function parseAgentURI(agentURI: string): AgentRegistrationPayload | null {
+  const prefix = "data:application/json;base64,";
+  if (!agentURI.startsWith(prefix)) return null;
+
+  try {
+    const decoded = JSON.parse(
+      fromBase64(agentURI.slice(prefix.length)),
+    ) as Partial<AgentRegistrationPayload>;
+    if (typeof decoded.name !== "string") return null;
+    return {
+      type: typeof decoded.type === "string" ? decoded.type : EIP8004_REGISTRATION_TYPE,
+      name: decoded.name,
+      description: typeof decoded.description === "string" ? decoded.description : "",
+      image: typeof decoded.image === "string" ? decoded.image : "",
+      active: typeof decoded.active === "boolean" ? decoded.active : true,
+      supportedTrust: Array.isArray(decoded.supportedTrust) ? decoded.supportedTrust : [],
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function buildAgentURI(card: AgentCard): {
+  agentURI: string;
+  payload: AgentRegistrationPayload;
+} {
+  const payload: AgentRegistrationPayload = {
+    type: EIP8004_REGISTRATION_TYPE,
+    name: card.name ?? "",
+    description: card.description?.trim() ? card.description : "I'm four.meme trading agent",
+    image: card.image ?? "",
+    active: card.active ?? true,
+    supportedTrust: card.supportedTrust ?? [""],
+  };
+  const json = JSON.stringify(payload);
+  return {
+    agentURI: `data:application/json;base64,${toBase64(json)}`,
+    payload,
+  };
+}
+
+export function encodeRegisterCalldata(agentURI: string): Hex {
+  return encodeFunctionData({
+    abi: IDENTITY_REGISTRY_ABI,
+    functionName: "register",
+    args: [agentURI],
+  });
+}
+
+export function decodeRegisteredLog(log: {
+  address?: Address;
+  data: Hex;
+  topics: readonly Hex[];
+}): RegistrationLog | null {
+  try {
+    const decoded = decodeEventLog({
+      abi: IDENTITY_REGISTRY_ABI,
+      data: log.data,
+      topics: log.topics as [Hex, ...Hex[]],
+    });
+    if (decoded.eventName !== "Registered") return null;
+    return decoded as unknown as RegistrationLog;
+  } catch {
+    return null;
+  }
+}
 
 export class IdentityRegistryClient {
   readonly config: RegistryConfig;
+  readonly publicClient: PublicClient;
 
-  constructor(config: RegistryConfig) {
-    this.config = config;
+  constructor(config: RegistryConfig, publicClient?: PublicClient) {
+    const identityRegistry = getAddress(config.identityRegistry ?? config.registryAddress);
+    this.config = {
+      ...config,
+      registryAddress: identityRegistry,
+      identityRegistry,
+      reputationRegistry: config.reputationRegistry
+        ? getAddress(config.reputationRegistry)
+        : undefined,
+    };
+    this.publicClient = publicClient ?? makePublicClient(this.config);
   }
 
   /** Build an AgentCard from partial inputs. */
@@ -20,6 +152,9 @@ export class IdentityRegistryClient {
     apiUrl: string;
     capabilities?: string[];
     services?: string[];
+    image?: string;
+    active?: boolean;
+    supportedTrust?: string[];
   }): AgentCard {
     return {
       name: params.name,
@@ -28,25 +163,120 @@ export class IdentityRegistryClient {
       apiUrl: params.apiUrl,
       capabilities: params.capabilities ?? [],
       services: params.services ?? [],
+      image: params.image,
+      active: params.active,
+      supportedTrust: params.supportedTrust,
     };
   }
 
-  /**
-   * Return mock registration data until the registry contract is live.
-   */
-  async register(_agentCard: AgentCard, _privateKey?: string): Promise<RegistrationResult> {
-    const mockTokenId = `0x${Date.now().toString(16)}`;
-    return {
-      tokenId: mockTokenId,
-      txHash: `0x${"0".repeat(64)}`,
-      chainId: this.config.chainId,
-      registryAddress: this.config.registryAddress,
-      agentCardUri: `ipfs://placeholder/${mockTokenId}`,
-    };
+  buildAgentURI(agentCard: AgentCard): { agentURI: string; payload: AgentRegistrationPayload } {
+    return buildAgentURI(agentCard);
   }
 
-  /** Return null until on-chain lookups are implemented. */
-  async getRegistration(_tokenId: string): Promise<AgentCard | null> {
-    return null;
+  async register(agentCard: AgentCard, signer: Eip8004Signer): Promise<RegistrationResult> {
+    const { agentURI, payload } = this.buildAgentURI(agentCard);
+    const data = encodeRegisterCalldata(agentURI);
+    const txHash = await signer.sendTransaction({
+      to: this.config.identityRegistry,
+      data,
+      value: 0n,
+    });
+
+    const receipt = await this.publicClient.waitForTransactionReceipt({ hash: txHash });
+    if (receipt.status !== "success") {
+      throw new Error(`ERC-8004 register reverted (status=${receipt.status}, tx=${txHash})`);
+    }
+
+    const registryAddress = this.config.identityRegistry.toLowerCase();
+    for (const log of receipt.logs) {
+      if (log.address.toLowerCase() !== registryAddress) continue;
+      const decoded = decodeRegisteredLog(log);
+      if (!decoded) continue;
+      return {
+        tokenId: decoded.args.agentId.toString(),
+        txHash,
+        chainId: this.config.chainId,
+        registryAddress: this.config.identityRegistry,
+        agentCardUri: decoded.args.agentURI,
+        agentURI: decoded.args.agentURI,
+        payload,
+      };
+    }
+
+    throw new Error(`ERC-8004 register: Registered event not found in receipt (tx=${txHash})`);
+  }
+
+  async getRegistration(tokenId: string | bigint): Promise<AgentCard | null> {
+    const agentId = typeof tokenId === "bigint" ? tokenId : BigInt(tokenId);
+    try {
+      const [owner, tokenURI] = await Promise.all([
+        this.publicClient.readContract({
+          address: this.config.identityRegistry,
+          abi: IDENTITY_REGISTRY_ABI,
+          functionName: "ownerOf",
+          args: [agentId],
+        }),
+        this.publicClient.readContract({
+          address: this.config.identityRegistry,
+          abi: IDENTITY_REGISTRY_ABI,
+          functionName: "tokenURI",
+          args: [agentId],
+        }),
+      ]);
+      const payload = parseAgentURI(tokenURI);
+      return {
+        name: payload?.name ?? "",
+        description: payload?.description ?? "",
+        walletAddress: owner,
+        apiUrl: "",
+        capabilities: [],
+        services: [],
+        image: payload?.image,
+        active: payload?.active,
+        supportedTrust: payload?.supportedTrust,
+        agentURI: tokenURI,
+        tokenId: agentId.toString(),
+      };
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+      if (
+        message.includes("nonexistent") ||
+        message.includes("not found") ||
+        message.includes("invalid token")
+      ) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  async getRegistrationByOwner(owner: string): Promise<AgentCard | null> {
+    if (!isAddress(owner)) throw new Error(`Invalid owner address: ${owner}`);
+    const ownerAddress = getAddress(owner);
+    try {
+      const tokenId = await this.publicClient.readContract({
+        address: this.config.identityRegistry,
+        abi: IDENTITY_REGISTRY_ABI,
+        functionName: "tokenOfOwnerByIndex",
+        args: [ownerAddress, 0n],
+      });
+      return this.getRegistration(tokenId);
+    } catch {
+      try {
+        const balance = await this.publicClient.readContract({
+          address: this.config.identityRegistry,
+          abi: IDENTITY_REGISTRY_ABI,
+          functionName: "balanceOf",
+          args: [ownerAddress],
+        });
+        if (balance === 0n) return null;
+      } catch {
+        return null;
+      }
+      throw new Error(
+        "ERC-8004 identity registry does not expose tokenOfOwnerByIndex; cannot resolve owner to token id",
+      );
+    }
   }
 }

--- a/packages/erc8004/src/reputation.ts
+++ b/packages/erc8004/src/reputation.ts
@@ -1,36 +1,95 @@
 /**
- * ERC-8004 reputation registry client.
- * Uses mock data until the reputation contract is deployed.
+ * ERC-8004 reputation registry read-only client.
  */
 
+import { createPublicClient, getAddress, http, type PublicClient, parseAbi } from "viem";
+import { ERC8004_REPUTATION_REGISTRY_ADDRESS } from "./chains";
 import type { FeedbackSignal, RegistryConfig, ReputationScore } from "./types";
+
+export const REPUTATION_REGISTRY_ABI = parseAbi([
+  "function getReputation(uint256 agentId) view returns (uint256 score, uint256 feedbackCount, uint256 lastUpdated)",
+  "function reputationOf(uint256 agentId) view returns (uint256 score, uint256 feedbackCount, uint256 lastUpdated)",
+  "function feedbackCount(uint256 agentId) view returns (uint256)",
+]);
+
+function makePublicClient(config: RegistryConfig): PublicClient {
+  if (config.publicClient) return config.publicClient;
+  return createPublicClient({ transport: http(config.rpcUrl) });
+}
+
+function toIsoTimestamp(value: bigint): string {
+  if (value === 0n) return new Date(0).toISOString();
+  return new Date(Number(value) * 1000).toISOString();
+}
 
 export class ReputationRegistryClient {
   readonly config: RegistryConfig;
+  readonly publicClient: PublicClient;
 
-  constructor(config: RegistryConfig) {
-    this.config = config;
+  constructor(config: RegistryConfig, publicClient?: PublicClient) {
+    this.config = {
+      ...config,
+      registryAddress: getAddress(config.identityRegistry ?? config.registryAddress),
+      identityRegistry: getAddress(config.identityRegistry ?? config.registryAddress),
+      reputationRegistry: getAddress(
+        config.reputationRegistry ?? ERC8004_REPUTATION_REGISTRY_ADDRESS,
+      ),
+    };
+    this.publicClient = publicClient ?? makePublicClient(this.config);
   }
 
-  /** Return a mock transaction hash until on-chain submission is implemented. */
+  /** Writes are intentionally unsupported until Steward wires policy around feedback submission. */
   async postFeedback(_params: FeedbackSignal): Promise<string> {
-    return `0x${"0".repeat(64)}`;
+    throw new Error("ERC-8004 reputation writes are not implemented; this client is read-only");
   }
 
-  /** Return a zeroed reputation score until on-chain lookups are implemented. */
-  async getReputation(agentTokenId: string): Promise<ReputationScore> {
+  /** Read an agent's reputation summary from the canonical reputation registry. */
+  async getReputation(agentTokenId: string | bigint): Promise<ReputationScore> {
+    const agentId = typeof agentTokenId === "bigint" ? agentTokenId : BigInt(agentTokenId);
+    const [score, feedbackCount, lastUpdated] = await this.readReputationTuple(agentId);
+    const normalizedScore = Number(score);
     return {
-      agentId: agentTokenId,
-      scoreOnchain: 0,
+      agentId: agentId.toString(),
+      scoreOnchain: normalizedScore,
       scoreInternal: 0,
-      scoreCombined: 0,
-      feedbackCount: 0,
-      lastUpdated: new Date().toISOString(),
+      scoreCombined: normalizedScore,
+      feedbackCount: Number(feedbackCount),
+      lastUpdated: toIsoTimestamp(lastUpdated),
     };
   }
 
-  /** Return no history until feedback events are indexed. */
+  /** History requires an indexer. Keep the API stable but do not fake chain data. */
   async getFeedbackHistory(_agentTokenId: string, _limit?: number): Promise<FeedbackSignal[]> {
     return [];
+  }
+
+  private async readReputationTuple(agentId: bigint): Promise<readonly [bigint, bigint, bigint]> {
+    const reputationRegistry =
+      this.config.reputationRegistry ?? ERC8004_REPUTATION_REGISTRY_ADDRESS;
+    try {
+      return await this.publicClient.readContract({
+        address: reputationRegistry,
+        abi: REPUTATION_REGISTRY_ABI,
+        functionName: "getReputation",
+        args: [agentId],
+      });
+    } catch {
+      try {
+        return await this.publicClient.readContract({
+          address: reputationRegistry,
+          abi: REPUTATION_REGISTRY_ABI,
+          functionName: "reputationOf",
+          args: [agentId],
+        });
+      } catch {
+        const feedbackCount = await this.publicClient.readContract({
+          address: reputationRegistry,
+          abi: REPUTATION_REGISTRY_ABI,
+          functionName: "feedbackCount",
+          args: [agentId],
+        });
+        return [0n, feedbackCount, 0n];
+      }
+    }
   }
 }

--- a/packages/erc8004/src/types.ts
+++ b/packages/erc8004/src/types.ts
@@ -5,6 +5,8 @@
  * and discovery protocol defined in ERC-8004.
  */
 
+import type { Address, Hex, PublicClient } from "viem";
+
 /** Describes an agent's public identity card stored on-chain or off-chain (IPFS / HTTP). */
 export interface AgentCard {
   name: string;
@@ -13,15 +15,37 @@ export interface AgentCard {
   apiUrl: string;
   capabilities: string[];
   services: string[];
+  image?: string;
+  active?: boolean;
+  supportedTrust?: string[];
+  agentURI?: string;
+  tokenId?: string;
+}
+
+/** EIP-8004 registration JSON payload wrapped by the on-chain agentURI data URI. */
+export interface AgentRegistrationPayload {
+  type: string;
+  name: string;
+  description: string;
+  image: string;
+  active: boolean;
+  supportedTrust: string[];
+}
+
+/** Minimal signer adapter accepted by identity registration. */
+export interface Eip8004Signer {
+  sendTransaction(args: { to: Address; data: Hex; value?: bigint }): Promise<Hex>;
 }
 
 /** Result returned after successfully registering an agent on-chain. */
 export interface RegistrationResult {
   tokenId: string;
-  txHash: string;
+  txHash: Hex;
   chainId: number;
-  registryAddress: string;
+  registryAddress: Address;
   agentCardUri: string;
+  agentURI: string;
+  payload: AgentRegistrationPayload;
 }
 
 /** Aggregated reputation for a registered agent. */
@@ -50,5 +74,9 @@ export interface RegistryConfig {
   chainId: number;
   name: string;
   rpcUrl: string;
-  registryAddress: string;
+  /** Backward-compatible alias for identityRegistry. */
+  registryAddress: Address;
+  identityRegistry: Address;
+  reputationRegistry?: Address;
+  publicClient?: PublicClient;
 }


### PR DESCRIPTION
## Summary
- Promotes `@stwd/erc8004` from stubs to a viem-backed ERC-8004 client.
- Replaces placeholder `0x...8004` registry values with canonical CREATE2 addresses on every configured chain:
  - IdentityRegistry: `0x8004A169FB4a3325136EB29fA0ceB6D2e539a432`
  - ReputationRegistry: `0x8004BAa17C55a88189AE136b182e5fdA19dE9b63`
- Adds signer-adapter registration flow, no raw private key happy path and no package-side broadcast beyond calling the provided `sendTransaction` adapter.
- Adds `buildAgentURI`, `encodeRegisterCalldata`, `Registered` event decode, token readback via `ownerOf`/`tokenURI`, and owner lookup via ERC721 enumerable where available.
- Adds a read-only reputation client scaffold for registry summary reads, with writes explicitly unsupported.

## Stubbed before, real now
- `register()` no longer returns a fake timestamp token id or zero tx hash. It encodes `register(string agentURI)`, asks the provided signer adapter to send the transaction, waits for a receipt, and returns the on-chain `Registered.agentId` plus real tx hash.
- `getRegistration()` no longer always returns null. It reads `ownerOf` and `tokenURI`, returning null only for absent token paths.
- Chain config no longer uses placeholder registry addresses.

## Signer adapter design
`IdentityRegistryClient.register(agentCard, signer)` accepts a minimal adapter:

```ts
sendTransaction({ to, data, value }) => Promise<txHash>
```

This keeps Steward-managed wallets as the broadcast boundary and avoids accepting raw private keys in the package API.

## Tests
- Calldata encoding for `register(agentURI)`.
- Mock receipt `Registered` event decode into agent id.
- `getRegistration()` null path for absent token, no real RPC and no broadcast.

## Next
waifu will import this package next in W-1B so the Four.Meme EIP-8004 registration path can share the Steward client.
