### PR TITLE
feat(erc8183): ERC-8183 agentic commerce client (escrow/jobs) — testnet scaffolding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ COPY packages/auth/package.json              packages/auth/package.json
 COPY packages/db/package.json                packages/db/package.json
 COPY packages/eliza-plugin/package.json      packages/eliza-plugin/package.json
 COPY packages/erc8004/package.json           packages/erc8004/package.json
+COPY packages/erc8183/package.json           packages/erc8183/package.json
 COPY packages/policy-engine/package.json     packages/policy-engine/package.json
 COPY packages/proxy/package.json             packages/proxy/package.json
 COPY packages/react/package.json             packages/react/package.json
@@ -76,6 +77,7 @@ COPY packages/auth/package.json              packages/auth/package.json
 COPY packages/db/package.json                packages/db/package.json
 COPY packages/eliza-plugin/package.json      packages/eliza-plugin/package.json
 COPY packages/erc8004/package.json           packages/erc8004/package.json
+COPY packages/erc8183/package.json           packages/erc8183/package.json
 COPY packages/policy-engine/package.json     packages/policy-engine/package.json
 COPY packages/proxy/package.json             packages/proxy/package.json
 COPY packages/react/package.json             packages/react/package.json
@@ -146,6 +148,7 @@ COPY packages/auth/package.json              packages/auth/package.json
 COPY packages/db/package.json                packages/db/package.json
 COPY packages/eliza-plugin/package.json      packages/eliza-plugin/package.json
 COPY packages/erc8004/package.json           packages/erc8004/package.json
+COPY packages/erc8183/package.json           packages/erc8183/package.json
 COPY packages/policy-engine/package.json     packages/policy-engine/package.json
 COPY packages/proxy/package.json             packages/proxy/package.json
 COPY packages/react/package.json             packages/react/package.json

--- a/bun.lock
+++ b/bun.lock
@@ -108,6 +108,17 @@
         "typescript": "^5.0.0",
       },
     },
+    "packages/erc8183": {
+      "name": "@stwd/erc8183",
+      "version": "0.1.0",
+      "dependencies": {
+        "viem": "^2.30.0",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5.0.0",
+      },
+    },
     "packages/examples/waifu-integration": {
       "name": "@stwd/example-waifu-integration",
       "version": "0.3.0",
@@ -1317,6 +1328,8 @@
     "@stwd/eliza-plugin": ["@stwd/eliza-plugin@workspace:packages/eliza-plugin"],
 
     "@stwd/erc8004": ["@stwd/erc8004@workspace:packages/erc8004"],
+
+    "@stwd/erc8183": ["@stwd/erc8183@workspace:packages/erc8183"],
 
     "@stwd/example-waifu-integration": ["@stwd/example-waifu-integration@workspace:packages/examples/waifu-integration"],
 

--- a/packages/erc8183/package.json
+++ b/packages/erc8183/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@stwd/erc8183",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
+    "lint": "bunx @biomejs/biome check src package.json tsconfig.json",
+    "test": "bun test src/__tests__"
+  },
+  "dependencies": {
+    "viem": "^2.30.0"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/erc8183/src/__tests__/client.test.ts
+++ b/packages/erc8183/src/__tests__/client.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, test } from "bun:test";
+import {
+  type Address,
+  decodeFunctionData,
+  encodeAbiParameters,
+  encodeEventTopics,
+  type Hex,
+} from "viem";
+import { AGENTIC_COMMERCE_ABI, ERC20_ABI, ERC8183Client, EVALUATOR_ROUTER_ABI } from "../client";
+import type { JobConfig, SignerAdapter } from "../types";
+
+const AGENTIC_COMMERCE = "0x0000000000000000000000000000000000008183" as Address;
+const EVALUATOR_ROUTER = "0x0000000000000000000000000000000000008184" as Address;
+const OPTIMISTIC_POLICY = "0x0000000000000000000000000000000000008185" as Address;
+const PAYMENT_TOKEN = "0x0000000000000000000000000000000000000006" as Address;
+const PROVIDER = "0x0000000000000000000000000000000000000007" as Address;
+const CLIENT = "0x0000000000000000000000000000000000000008" as Address;
+
+const TX_HASH_1 = `0x${"1".repeat(64)}` as Hex;
+const TX_HASH_2 = `0x${"2".repeat(64)}` as Hex;
+
+describe("ERC8183Client", () => {
+  test("createJob encodes calldata and decodes the JobCreated jobId", async () => {
+    const sent: Array<{ to: Address; data: Hex }> = [];
+    const client = makeClient({
+      signer: {
+        async sendTransaction(tx) {
+          sent.push(tx);
+          return TX_HASH_1;
+        },
+      },
+      publicClient: {
+        async waitForTransactionReceipt() {
+          return { logs: [jobCreatedLog(42n)] };
+        },
+      },
+    });
+
+    const result = await client.createJob({
+      provider: PROVIDER,
+      expiredAt: 1_800_000_000n,
+      description: "agent delivery",
+    });
+
+    expect(result).toEqual({ jobId: 42n, txHash: TX_HASH_1 });
+    expect(sent).toHaveLength(1);
+    expect(sent[0].to).toBe(AGENTIC_COMMERCE);
+    const decoded = decodeFunctionData({ abi: AGENTIC_COMMERCE_ABI, data: sent[0].data });
+    expect(decoded.functionName).toBe("createJob");
+    expect(decoded.args).toEqual([PROVIDER, EVALUATOR_ROUTER, 1_800_000_000n, "agent delivery"]);
+  });
+
+  test("fund approves the ERC-20 and then funds the job", async () => {
+    const sent: Array<{ to: Address; data: Hex }> = [];
+    const client = makeClient({
+      signer: {
+        async sendTransaction(tx) {
+          sent.push(tx);
+          return sent.length === 1 ? TX_HASH_1 : TX_HASH_2;
+        },
+      },
+    });
+
+    const result = await client.fund(42n, 1_000n);
+
+    expect(result).toEqual({ approveTxHash: TX_HASH_1, fundTxHash: TX_HASH_2 });
+    expect(sent).toHaveLength(2);
+    expect(sent[0].to).toBe(PAYMENT_TOKEN);
+    expect(decodeFunctionData({ abi: ERC20_ABI, data: sent[0].data })).toEqual({
+      functionName: "approve",
+      args: [AGENTIC_COMMERCE, 1_000n],
+    });
+    expect(sent[1].to).toBe(AGENTIC_COMMERCE);
+    expect(decodeFunctionData({ abi: AGENTIC_COMMERCE_ABI, data: sent[1].data })).toEqual({
+      functionName: "fund",
+      args: [42n, 1_000n],
+    });
+  });
+
+  test("settle encodes EvaluatorRouter settle calldata", async () => {
+    const sent: Array<{ to: Address; data: Hex }> = [];
+    const client = makeClient({
+      signer: {
+        async sendTransaction(tx) {
+          sent.push(tx);
+          return TX_HASH_1;
+        },
+      },
+    });
+
+    await client.settle(42n);
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0].to).toBe(EVALUATOR_ROUTER);
+    expect(decodeFunctionData({ abi: EVALUATOR_ROUTER_ABI, data: sent[0].data })).toEqual({
+      functionName: "settle",
+      args: [42n],
+    });
+  });
+
+  test("claimRefund encodes AgenticCommerce claimRefund calldata", async () => {
+    const sent: Array<{ to: Address; data: Hex }> = [];
+    const client = makeClient({
+      signer: {
+        async sendTransaction(tx) {
+          sent.push(tx);
+          return TX_HASH_1;
+        },
+      },
+    });
+
+    await client.claimRefund(42n);
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0].to).toBe(AGENTIC_COMMERCE);
+    expect(decodeFunctionData({ abi: AGENTIC_COMMERCE_ABI, data: sent[0].data })).toEqual({
+      functionName: "claimRefund",
+      args: [42n],
+    });
+  });
+
+  test("constructor rejects missing explicit deployment addresses", () => {
+    expect(() => {
+      new ERC8183Client({
+        publicClient: {} as JobConfig["publicClient"],
+        signer: mockSigner(),
+        addresses: { agenticCommerce: AGENTIC_COMMERCE } as JobConfig["addresses"],
+      });
+    }).toThrow("missing evaluatorRouter, optimisticPolicy, paymentToken");
+  });
+});
+
+function makeClient(overrides: {
+  signer?: SignerAdapter;
+  publicClient?: Record<string, unknown>;
+}): ERC8183Client {
+  return new ERC8183Client({
+    publicClient: (overrides.publicClient ?? {
+      async waitForTransactionReceipt() {
+        return { logs: [] };
+      },
+    }) as JobConfig["publicClient"],
+    signer: overrides.signer ?? mockSigner(),
+    addresses: {
+      agenticCommerce: AGENTIC_COMMERCE,
+      evaluatorRouter: EVALUATOR_ROUTER,
+      optimisticPolicy: OPTIMISTIC_POLICY,
+      paymentToken: PAYMENT_TOKEN,
+    },
+  });
+}
+
+function mockSigner(): SignerAdapter {
+  return {
+    async sendTransaction() {
+      return TX_HASH_1;
+    },
+  };
+}
+
+function jobCreatedLog(jobId: bigint): { data: Hex; topics: Hex[] } {
+  const topics = encodeEventTopics({
+    abi: AGENTIC_COMMERCE_ABI,
+    eventName: "JobCreated",
+    args: { jobId, client: CLIENT, provider: PROVIDER },
+  });
+  const data = encodeAbiParameters(
+    [
+      { name: "router", type: "address" },
+      { name: "expiredAt", type: "uint64" },
+      { name: "description", type: "string" },
+    ],
+    [EVALUATOR_ROUTER, 1_800_000_000n, "agent delivery"],
+  );
+  return { data, topics: topics.filter((topic): topic is Hex => typeof topic === "string") };
+}

--- a/packages/erc8183/src/chains.ts
+++ b/packages/erc8183/src/chains.ts
@@ -1,0 +1,24 @@
+import type { ERC8183ChainConfig } from "./types";
+
+// TODO: fill from BNB ERC-8183 deployment — testnet first.
+// Real AgenticCommerce, EvaluatorRouter, OptimisticPolicy, and payment token addresses
+// are intentionally left undefined. The client requires explicit addresses at runtime
+// and will throw rather than silently using fake mainnet deployments.
+export const ERC8183_CHAIN_CONFIGS: Record<number, ERC8183ChainConfig> = {
+  97: {
+    chainId: 97,
+    name: "BSC Testnet",
+    rpcUrl: "https://data-seed-prebsc-1-s1.binance.org:8545",
+    addresses: {},
+  },
+  56: {
+    chainId: 56,
+    name: "BSC",
+    rpcUrl: "https://bsc-dataseed.binance.org",
+    addresses: {},
+  },
+};
+
+export function getERC8183ChainConfig(chainId: number): ERC8183ChainConfig | undefined {
+  return ERC8183_CHAIN_CONFIGS[chainId];
+}

--- a/packages/erc8183/src/client.ts
+++ b/packages/erc8183/src/client.ts
@@ -1,0 +1,342 @@
+import {
+  type Address,
+  decodeEventLog,
+  encodeFunctionData,
+  type Hex,
+  type PublicClient,
+} from "viem";
+import type {
+  CreateJobParams,
+  CreateJobResult,
+  Job,
+  JobConfig,
+  RequiredERC8183Addresses,
+  SignerAdapter,
+} from "./types";
+import { JobStatus } from "./types";
+
+// ABI derived from ERC-8183 spec; verify against deployed contract before mainnet.
+export const AGENTIC_COMMERCE_ABI = [
+  {
+    type: "function",
+    name: "createJob",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "provider", type: "address" },
+      { name: "router", type: "address" },
+      { name: "expiredAt", type: "uint64" },
+      { name: "description", type: "string" },
+    ],
+    outputs: [{ name: "jobId", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "setBudget",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "jobId", type: "uint256" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "fund",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "jobId", type: "uint256" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "submit",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "jobId", type: "uint256" },
+      { name: "deliverableHash", type: "bytes32" },
+    ],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "dispute",
+    stateMutability: "nonpayable",
+    inputs: [{ name: "jobId", type: "uint256" }],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "claimRefund",
+    stateMutability: "nonpayable",
+    inputs: [{ name: "jobId", type: "uint256" }],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "getJob",
+    stateMutability: "view",
+    inputs: [{ name: "jobId", type: "uint256" }],
+    outputs: [
+      {
+        name: "job",
+        type: "tuple",
+        components: [
+          { name: "id", type: "uint256" },
+          { name: "status", type: "uint8" },
+          { name: "client", type: "address" },
+          { name: "provider", type: "address" },
+          { name: "router", type: "address" },
+          { name: "policy", type: "address" },
+          { name: "budget", type: "uint256" },
+          { name: "expiredAt", type: "uint64" },
+          { name: "deliverableHash", type: "bytes32" },
+        ],
+      },
+    ],
+  },
+  {
+    type: "function",
+    name: "getJobStatus",
+    stateMutability: "view",
+    inputs: [{ name: "jobId", type: "uint256" }],
+    outputs: [{ name: "status", type: "uint8" }],
+  },
+  {
+    type: "event",
+    name: "JobCreated",
+    inputs: [
+      { name: "jobId", type: "uint256", indexed: true },
+      { name: "client", type: "address", indexed: true },
+      { name: "provider", type: "address", indexed: true },
+      { name: "router", type: "address", indexed: false },
+      { name: "expiredAt", type: "uint64", indexed: false },
+      { name: "description", type: "string", indexed: false },
+    ],
+  },
+] as const;
+
+// ABI derived from ERC-8183 spec; verify against deployed contract before mainnet.
+export const EVALUATOR_ROUTER_ABI = [
+  {
+    type: "function",
+    name: "registerJob",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "jobId", type: "uint256" },
+      { name: "policy", type: "address" },
+    ],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "settle",
+    stateMutability: "nonpayable",
+    inputs: [{ name: "jobId", type: "uint256" }],
+    outputs: [],
+  },
+] as const;
+
+export const ERC20_ABI = [
+  {
+    type: "function",
+    name: "approve",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "spender", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [{ name: "ok", type: "bool" }],
+  },
+] as const;
+
+const STATUS_BY_CODE: Record<number, JobStatus> = {
+  0: JobStatus.OPEN,
+  1: JobStatus.FUNDED,
+  2: JobStatus.SUBMITTED,
+  3: JobStatus.SETTLED,
+  4: JobStatus.REJECTED,
+  5: JobStatus.REFUNDED,
+};
+
+type CommerceFunctionName = "setBudget" | "fund" | "submit" | "dispute" | "claimRefund";
+type RouterFunctionName = "registerJob" | "settle";
+
+export class ERC8183Client {
+  readonly publicClient: PublicClient;
+  readonly signer: SignerAdapter;
+  readonly addresses: RequiredERC8183Addresses;
+
+  constructor(config: JobConfig) {
+    this.publicClient = config.publicClient;
+    this.signer = config.signer;
+    this.addresses = validateAddresses(config.addresses);
+  }
+
+  async createJob(params: CreateJobParams): Promise<CreateJobResult> {
+    const router = params.router ?? this.addresses.evaluatorRouter;
+    const data = encodeFunctionData({
+      abi: AGENTIC_COMMERCE_ABI,
+      functionName: "createJob",
+      args: [params.provider, router, BigInt(params.expiredAt), params.description],
+    });
+    const txHash = await this.signer.sendTransaction({ to: this.addresses.agenticCommerce, data });
+    const receipt = await this.publicClient.waitForTransactionReceipt({ hash: txHash });
+    return { jobId: decodeJobCreatedId(receipt.logs), txHash };
+  }
+
+  registerJob(jobId: bigint, policy = this.addresses.optimisticPolicy): Promise<Hex> {
+    return this.writeRouter("registerJob", [jobId, policy]);
+  }
+
+  setBudget(jobId: bigint, amount: bigint): Promise<Hex> {
+    return this.writeCommerce("setBudget", [jobId, amount]);
+  }
+
+  async fund(jobId: bigint, amount: bigint): Promise<{ approveTxHash: Hex; fundTxHash: Hex }> {
+    const approveData = encodeFunctionData({
+      abi: ERC20_ABI,
+      functionName: "approve",
+      args: [this.addresses.agenticCommerce, amount],
+    });
+    const approveTxHash = await this.signer.sendTransaction({
+      to: this.addresses.paymentToken,
+      data: approveData,
+    });
+    await this.publicClient.waitForTransactionReceipt({ hash: approveTxHash });
+    const fundTxHash = await this.writeCommerce("fund", [jobId, amount]);
+    return { approveTxHash, fundTxHash };
+  }
+
+  submit(jobId: bigint, deliverableHash: Hex): Promise<Hex> {
+    return this.writeCommerce("submit", [jobId, deliverableHash]);
+  }
+
+  dispute(jobId: bigint): Promise<Hex> {
+    return this.writeCommerce("dispute", [jobId]);
+  }
+
+  settle(jobId: bigint): Promise<Hex> {
+    return this.writeRouter("settle", [jobId]);
+  }
+
+  claimRefund(jobId: bigint): Promise<Hex> {
+    return this.writeCommerce("claimRefund", [jobId]);
+  }
+
+  async getJob(jobId: bigint): Promise<Job> {
+    const raw = await this.publicClient.readContract({
+      address: this.addresses.agenticCommerce,
+      abi: AGENTIC_COMMERCE_ABI,
+      functionName: "getJob",
+      args: [jobId],
+    });
+    return normalizeJob(raw as RawJobTuple);
+  }
+
+  async getJobStatus(jobId: bigint): Promise<JobStatus> {
+    const raw = await this.publicClient.readContract({
+      address: this.addresses.agenticCommerce,
+      abi: AGENTIC_COMMERCE_ABI,
+      functionName: "getJobStatus",
+      args: [jobId],
+    });
+    return toJobStatus(Number(raw));
+  }
+
+  private writeCommerce(
+    functionName: CommerceFunctionName,
+    args: readonly unknown[],
+  ): Promise<Hex> {
+    const data = encodeFunctionData({
+      abi: AGENTIC_COMMERCE_ABI,
+      functionName,
+      args,
+    } as any);
+    return this.signer.sendTransaction({ to: this.addresses.agenticCommerce, data });
+  }
+
+  private writeRouter(functionName: RouterFunctionName, args: readonly unknown[]): Promise<Hex> {
+    const data = encodeFunctionData({
+      abi: EVALUATOR_ROUTER_ABI,
+      functionName,
+      args,
+    } as any);
+    return this.signer.sendTransaction({ to: this.addresses.evaluatorRouter, data });
+  }
+}
+
+function validateAddresses(addresses: Partial<RequiredERC8183Addresses>): RequiredERC8183Addresses {
+  const missing = ["agenticCommerce", "evaluatorRouter", "optimisticPolicy", "paymentToken"].filter(
+    (key) => !addresses[key as keyof RequiredERC8183Addresses],
+  );
+  if (missing.length > 0) {
+    throw new Error(
+      `ERC-8183 client requires explicit deployment addresses: missing ${missing.join(", ")}`,
+    );
+  }
+  return addresses as RequiredERC8183Addresses;
+}
+
+function decodeJobCreatedId(logs: readonly { data: Hex; topics: readonly Hex[] }[]): bigint {
+  for (const log of logs) {
+    try {
+      const decoded = decodeEventLog({
+        abi: AGENTIC_COMMERCE_ABI,
+        data: log.data,
+        topics: [...log.topics] as any,
+      });
+      if (decoded.eventName === "JobCreated") {
+        return decoded.args.jobId;
+      }
+    } catch {
+      // Skip unrelated logs in the same receipt.
+    }
+  }
+  throw new Error("JobCreated event not found in createJob receipt");
+}
+
+type RawJobTuple = readonly [
+  bigint,
+  number,
+  Address,
+  Address,
+  Address,
+  Address,
+  bigint,
+  bigint,
+  Hex,
+] & {
+  id?: bigint;
+  status?: number;
+  client?: Address;
+  provider?: Address;
+  router?: Address;
+  policy?: Address;
+  budget?: bigint;
+  expiredAt?: bigint;
+  deliverableHash?: Hex;
+};
+
+function normalizeJob(raw: RawJobTuple): Job {
+  return {
+    id: raw.id ?? raw[0],
+    status: toJobStatus(Number(raw.status ?? raw[1])),
+    client: raw.client ?? raw[2],
+    provider: raw.provider ?? raw[3],
+    router: raw.router ?? raw[4],
+    policy: raw.policy ?? raw[5],
+    budget: raw.budget ?? raw[6],
+    expiredAt: raw.expiredAt ?? raw[7],
+    deliverableHash: raw.deliverableHash ?? raw[8],
+  };
+}
+
+function toJobStatus(code: number): JobStatus {
+  const status = STATUS_BY_CODE[code];
+  if (!status) {
+    throw new Error(`Unknown ERC-8183 job status code: ${code}`);
+  }
+  return status;
+}

--- a/packages/erc8183/src/index.ts
+++ b/packages/erc8183/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./chains";
+export * from "./client";
+export * from "./types";

--- a/packages/erc8183/src/types.ts
+++ b/packages/erc8183/src/types.ts
@@ -1,0 +1,66 @@
+import type { Address, Hex, PublicClient } from "viem";
+
+export enum JobStatus {
+  OPEN = "OPEN",
+  FUNDED = "FUNDED",
+  SUBMITTED = "SUBMITTED",
+  SETTLED = "SETTLED",
+  REJECTED = "REJECTED",
+  REFUNDED = "REFUNDED",
+}
+
+export interface ERC8183Addresses {
+  agenticCommerce?: Address;
+  evaluatorRouter?: Address;
+  optimisticPolicy?: Address;
+  paymentToken?: Address;
+}
+
+export interface ERC8183ChainConfig {
+  chainId: number;
+  name: string;
+  rpcUrl: string;
+  addresses: ERC8183Addresses;
+}
+
+export interface RequiredERC8183Addresses {
+  agenticCommerce: Address;
+  evaluatorRouter: Address;
+  optimisticPolicy: Address;
+  paymentToken: Address;
+}
+
+export interface SignerAdapter {
+  sendTransaction(params: { to: Address; data: Hex; value?: bigint }): Promise<Hex>;
+}
+
+export interface JobConfig {
+  chainId?: number;
+  publicClient: PublicClient;
+  signer: SignerAdapter;
+  addresses: RequiredERC8183Addresses;
+}
+
+export interface CreateJobParams {
+  provider: Address;
+  router?: Address;
+  expiredAt: bigint | number;
+  description: string;
+}
+
+export interface Job {
+  id: bigint;
+  status: JobStatus;
+  client?: Address;
+  provider: Address;
+  router?: Address;
+  policy?: Address;
+  budget: bigint;
+  expiredAt?: bigint;
+  deliverableHash?: Hex;
+}
+
+export interface CreateJobResult {
+  jobId: bigint;
+  txHash: Hex;
+}

--- a/packages/erc8183/tsconfig.json
+++ b/packages/erc8183/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["bun"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

Adds a new `@stwd/erc8183` TypeScript client package for ERC-8183 agentic commerce, mirroring the `@stwd/erc8004` workspace shape while using viem for all calldata/event handling.

## Lifecycle implemented

- `createJob(provider, router, expiredAt, description)` on AgenticCommerce, returning the decoded `jobId` from `JobCreated`
- `registerJob(jobId, policy)` on EvaluatorRouter
- `setBudget(jobId, amount)` on AgenticCommerce
- `fund(jobId, amount)` with ERC-20 `approve` first, waits for approval receipt, then funds escrow
- `submit(jobId, deliverableHash)` for off-chain deliverable hash anchoring
- `dispute(jobId)`
- `settle(jobId)` on EvaluatorRouter
- `claimRefund(jobId)` universal escape hatch
- read helpers: `getJob(jobId)`, `getJobStatus(jobId)`

## Signer-adapter design

Writes accept a Steward-compatible signer adapter:

```ts
{ sendTransaction({ to, data, value }) => Promise<hash> }
```

No raw private keys are accepted by the client. Steward-managed wallets/proxy flows can own the signing surface and pass only the final encoded transaction through the adapter.

## Address gap, testnet first

The chain config intentionally does **not** ship fake AgenticCommerce, EvaluatorRouter, OptimisticPolicy, or payment token addresses. `packages/erc8183/src/chains.ts` leaves them undefined with a TODO:

```ts
// TODO: fill from BNB ERC-8183 deployment — testnet first.
```

The `ERC8183Client` constructor requires explicit deployment addresses and throws if any are missing. Real BNB ERC-8183 deployment addresses are needed before use.

## ABI caveat

The ABI is a reasonable TypeScript/viem scaffold derived from the ERC-8183 lifecycle/spec. It is marked in-code with:

```ts
// ABI derived from ERC-8183 spec; verify against deployed contract before mainnet.
```

It must be verified against deployed contract ABIs before any mainnet-money usage.

## Pairing with Steward

- `@stwd/erc8004` remains the identity/reputation side of the agent stack.
- `@stwd/erc8183` adds the escrow/job commerce rail.
- The signer-adapter keeps this compatible with the Steward proxy/W-2A path, where Steward-managed wallets can sign/broadcast behind explicit policy gates.

## Tests

Unit tests use mocked signer/public-client behavior only. No RPC calls and no transaction broadcasts.
