### PR TITLE
fix(ci): run api integration suite per-file to stop OOM (exit 137)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,22 +187,20 @@ jobs:
           exit 1
 
       - name: Integration tests (API)
-        # ~60 of the api test files force an in-memory PGLite (a WASM Postgres)
-        # in their own beforeAll even though DATABASE_URL points at real Postgres.
+        # ~57 of the api test files force an in-memory PGLite (a WASM Postgres) in
+        # their own beforeAll even though DATABASE_URL points at real Postgres.
         # `bun test --isolate` runs every file in ONE process (it only gives each
         # file a fresh global object, not a fresh process), so those WASM heaps
-        # accumulate and OOM the 7GB runner (exit 137) around file ~140. Running
-        # the suite as sequential --shard processes caps peak memory at one
-        # shard's worth: each shard is a separate `bun test` process that frees
-        # its WASM heap on exit before the next starts. --shard requires bun
-        # >= 1.3.13. --timeout=30000 absorbs per-file PGLite migration latency.
-        run: |
-          shards=6
-          for i in $(seq 1 "$shards"); do
-            echo "::group::API integration tests — shard $i/$shards"
-            bun test --isolate --timeout=30000 --shard="$i/$shards" packages/api
-            echo "::endgroup::"
-          done
+        # accumulate and SIGKILL the 7GB runner (exit 137) around file ~140.
+        # run-tests-isolated.ts spawns a fresh `bun test` process PER FILE, so
+        # peak memory is bounded by TEST_JOBS concurrent files (not the suite
+        # size) and each process frees its WASM heap on exit. Reproduced in a
+        # 6GB-capped Linux container: the single `--isolate` process is killed
+        # at exit 137; a 6-way --shard split still OOMs (25 files/shard is too
+        # much); this runner at TEST_JOBS=2 finishes the full suite with zero
+        # OOM in ~2.3min. TEST_TIMEOUT=30000 absorbs per-file PGLite migration
+        # latency.
+        run: TEST_JOBS=2 TEST_TIMEOUT=30000 bun packages/api/scripts/run-tests-isolated.ts
         env:
           DATABASE_URL: "postgres://steward:steward_ci@localhost:5432/steward_test"
           PORT: "3299"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -241,22 +241,20 @@ jobs:
           exit 1
 
       - name: Integration tests (API)
-        # ~60 of the api test files force an in-memory PGLite (a WASM Postgres)
-        # in their own beforeAll even though DATABASE_URL points at real Postgres.
+        # ~57 of the api test files force an in-memory PGLite (a WASM Postgres) in
+        # their own beforeAll even though DATABASE_URL points at real Postgres.
         # `bun test --isolate` runs every file in ONE process (it only gives each
         # file a fresh global object, not a fresh process), so those WASM heaps
-        # accumulate and OOM the 7GB runner (exit 137) around file ~140. Running
-        # the suite as sequential --shard processes caps peak memory at one
-        # shard's worth: each shard is a separate `bun test` process that frees
-        # its WASM heap on exit before the next starts. --shard requires bun
-        # >= 1.3.13. --timeout=30000 absorbs per-file PGLite migration latency.
-        run: |
-          shards=6
-          for i in $(seq 1 "$shards"); do
-            echo "::group::API integration tests — shard $i/$shards"
-            bun test --isolate --timeout=30000 --shard="$i/$shards" packages/api
-            echo "::endgroup::"
-          done
+        # accumulate and SIGKILL the 7GB runner (exit 137) around file ~140.
+        # run-tests-isolated.ts spawns a fresh `bun test` process PER FILE, so
+        # peak memory is bounded by TEST_JOBS concurrent files (not the suite
+        # size) and each process frees its WASM heap on exit. Reproduced in a
+        # 6GB-capped Linux container: the single `--isolate` process is killed
+        # at exit 137; a 6-way --shard split still OOMs (25 files/shard is too
+        # much); this runner at TEST_JOBS=2 finishes the full suite with zero
+        # OOM in ~2.3min. TEST_TIMEOUT=30000 absorbs per-file PGLite migration
+        # latency.
+        run: TEST_JOBS=2 TEST_TIMEOUT=30000 bun packages/api/scripts/run-tests-isolated.ts
         env:
           DATABASE_URL: "postgres://steward:steward_ci@localhost:5432/steward_test"
           PORT: "3299"


### PR DESCRIPTION
## Problem

The **Integration Tests (Postgres)** job ran `bun test --isolate --timeout=30000 packages/api` and was SIGKILLed (**exit 137**) on the 7GB GitHub runner, consistently dying ~file 140 at `vault-delegated-transaction-signer.test.ts`. The suite passes 905/0 on an unconstrained machine, so this is a runner memory/scale issue (acute since #79 grew the api suite from ~181 → 905 tests).

## Root cause

`bun test --isolate` only gives each file a **fresh global object — not a fresh process**, so all 148 files run in **one** process. ~57 of them force an in-memory **PGLite (WASM Postgres)** in their own `beforeAll` even when `DATABASE_URL` points at real Postgres; those WASM heaps accumulate in the single process until the runner OOM-kills it.

## Fix

Switch `ci.yml` and `pr.yml` to the repo's existing per-file runner `packages/api/scripts/run-tests-isolated.ts`, which spawns a fresh `bun test` process **per file**. Peak memory is bounded by `TEST_JOBS` concurrent files instead of suite size; each process frees its WASM heap on exit.

```
run: TEST_JOBS=2 TEST_TIMEOUT=30000 bun packages/api/scripts/run-tests-isolated.ts
```

## Validation (6GB-capped Linux container: postgres + redis + API server, mirroring the runner)

| Approach | Result |
|---|---|
| `bun test --isolate packages/api` (old) | **Killed, exit 137** while loading a PGLite file |
| 6-way `--shard` split | **still OOMs** (shards 1/2/6 killed — 25 files/shard too much) |
| per-file runner, `TEST_JOBS=2` | **0 OOM, full suite in ~2.3 min** |

(The only failures in the container were the 3 web-dashboard source-introspection tests, which `readFileSync("web/...")` — that container has no `web/` checkout; they pass in CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)