### PR TITLE
fix(vault): Solana parser fund-safety (CreateAccount counting, fail-closed multi-recipient/mint)

### DIFF
--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -5576,6 +5576,33 @@ vaultRoutes.post("/:agentId/sign-solana", async (c) => {
     });
   }
 
+  // ── Fail-closed gate: more than one value recipient / mint ──────────────────
+  // The policy engine evaluates a single (to, value) envelope. A fully-parsed tx
+  // that pays MULTIPLE distinct recipients, or moves MULTIPLE token mints, cannot
+  // be fully policy-checked — only the first recipient/mint would be enforced, so
+  // the approved-address allowlist (and per-mint accounting) would be bypassed for
+  // the rest. Reject unless an audited blind-signing opt-in is set.
+  const distinctValueRecipients = new Set<string>([
+    ...derived.summary.lamportRecipients,
+    ...derived.summary.tokenTransfers.map((t) => t.destination),
+  ]);
+  if (distinctValueRecipients.size > 1 || derived.mints.length > 1) {
+    if (!allowUnsafeSolanaBlindSigning()) {
+      return c.json<ApiResponse>(
+        {
+          ok: false,
+          error:
+            "Solana transaction pays multiple recipients or moves multiple token mints; the policy engine can only enforce a single recipient/mint, so it was rejected (fail-closed). Set STEWARD_ALLOW_UNSAFE_SOLANA_BLIND_SIGNING=true only for audited multi-recipient flows.",
+          data: {
+            recipients: [...distinctValueRecipients],
+            mints: derived.mints,
+          },
+        },
+        422,
+      );
+    }
+  }
+
   // ── Spoof check: caller hints must not CONFLICT with the parsed truth ───────
   const conflicts = detectSolanaPolicyConflicts(derived, { to: body.to, value: body.value });
   if (conflicts.length > 0) {

--- a/packages/vault/src/__tests__/solana-instructions.test.ts
+++ b/packages/vault/src/__tests__/solana-instructions.test.ts
@@ -375,3 +375,92 @@ describe("recognised value-neutral programs", () => {
     expect(summary.totalLamports).toBe("0");
   });
 });
+
+// ─── Fund-safety: CreateAccount counting + multi-recipient/multi-mint exposure ──
+
+describe("parseSolanaTransaction — CreateAccount funding is counted", () => {
+  test("system:CreateAccount funding lamports count toward totalLamports + recipient", () => {
+    const from = Keypair.generate().publicKey;
+    const newAccount = Keypair.generate().publicKey;
+    const lamports = 100_000_000n; // 0.1 SOL
+    const ix = SystemProgram.createAccount({
+      fromPubkey: from,
+      newAccountPubkey: newAccount,
+      lamports: Number(lamports),
+      space: 0,
+      programId: SystemProgram.programId,
+    });
+    const tx = new Transaction({ feePayer: from, recentBlockhash: RECENT_BLOCKHASH }).add(ix);
+
+    const summary = parseSolanaTransaction(legacyToBase64(tx));
+    expect(summary.fullyParsed).toBe(true);
+    // Before the fix this was "0" (CreateAccount lamports were parsed but never summed).
+    expect(summary.totalLamports).toBe(lamports.toString());
+    expect(summary.lamportRecipients).toContain(newAccount.toBase58());
+
+    const derived = deriveSolanaPolicyFields(summary);
+    expect(derived.value).toBe(lamports.toString());
+    expect(derived.movesNativeSol).toBe(true);
+  });
+
+  test("system:CreateAccountWithSeed is fail-closed (lamports not decodable)", () => {
+    // disc 3 = CreateAccountWithSeed; accounts [from, newAccount]. Its funding
+    // lamports sit at a variable offset after the seed, so the parser must NOT
+    // mark it fully parsed.
+    const from = Keypair.generate().publicKey;
+    const newAccount = Keypair.generate().publicKey;
+    const data = new Uint8Array(4 + 32 + 8);
+    data[0] = 3;
+    const ix = rawIx(SystemProgram.programId, [from, newAccount], data);
+    const tx = new Transaction({ feePayer: from, recentBlockhash: RECENT_BLOCKHASH }).add(ix);
+
+    const summary = parseSolanaTransaction(legacyToBase64(tx));
+    expect(summary.fullyParsed).toBe(false);
+  });
+});
+
+describe("parseSolanaTransaction — multi-recipient / multi-mint are exposed", () => {
+  test("a 2-recipient SOL transfer exposes BOTH recipients", () => {
+    const from = Keypair.generate().publicKey;
+    const r1 = Keypair.generate().publicKey;
+    const r2 = Keypair.generate().publicKey;
+    const tx = new Transaction({ feePayer: from, recentBlockhash: RECENT_BLOCKHASH })
+      .add(SystemProgram.transfer({ fromPubkey: from, toPubkey: r1, lamports: 1000 }))
+      .add(SystemProgram.transfer({ fromPubkey: from, toPubkey: r2, lamports: 2000 }));
+
+    const summary = parseSolanaTransaction(legacyToBase64(tx));
+    expect([...summary.lamportRecipients].sort()).toEqual([r1.toBase58(), r2.toBase58()].sort());
+    // The single (to,value) envelope only carries the first recipient — which is
+    // exactly why the route fails closed when there is more than one.
+    const derived = deriveSolanaPolicyFields(summary);
+    expect(derived.to).toBe(summary.lamportRecipients[0]);
+  });
+
+  test("a 2-mint token transfer exposes BOTH mints", () => {
+    const from = Keypair.generate().publicKey;
+    const mintA = Keypair.generate().publicKey;
+    const mintB = Keypair.generate().publicKey;
+    const acc = () => Keypair.generate().publicKey;
+    const ixs = [
+      tokenTransferCheckedIx({
+        source: acc(),
+        mint: mintA,
+        destination: acc(),
+        owner: from,
+        amount: 10n,
+        decimals: 6,
+      }),
+      tokenTransferCheckedIx({
+        source: acc(),
+        mint: mintB,
+        destination: acc(),
+        owner: from,
+        amount: 20n,
+        decimals: 6,
+      }),
+    ];
+    const summary = parseSolanaTransaction(v0ToBase64(ixs, from));
+    const derived = deriveSolanaPolicyFields(summary);
+    expect([...derived.mints].sort()).toEqual([mintA.toBase58(), mintB.toBase58()].sort());
+  });
+});

--- a/packages/vault/src/solana-instructions.ts
+++ b/packages/vault/src/solana-instructions.ts
@@ -374,18 +374,14 @@ function decodeSystemInstruction(
       });
     }
     case SYSTEM_IX.CreateAccountWithSeed: {
-      if (accounts.length < 2) return unparsed("system CreateAccountWithSeed missing accounts");
-      // lamports sits after disc(4) + base pubkey(32) + seed(u64 len + bytes).
-      // Seed length is variable; only decode lamports when layout is unambiguous.
-      // To stay fail-safe we decode just the funder/new-account + flag lamports
-      // as unknown rather than risk a wrong offset.
-      return base({
-        instructionType: "system:CreateAccountWithSeed",
-        fields: {
-          from: accounts[0].toBase58(),
-          newAccount: accounts[1].toBase58(),
-        },
-      });
+      // The funding lamports sit after a variable-length seed (disc + base pubkey
+      // + u64 seed-len + seed bytes), so the amount is at an offset we cannot
+      // decode safely. A "fully parsed" CreateAccountWithSeed would move SOL the
+      // policy never accounts for — fail closed so it requires an audited
+      // blind-sign opt-in rather than silently passing with value=0.
+      return unparsed(
+        "system CreateAccountWithSeed funds an account by a non-decodable (variable-offset) lamport amount",
+      );
     }
     case SYSTEM_IX.Assign: {
       if (accounts.length < 1) return unparsed("system Assign missing account");
@@ -704,10 +700,13 @@ function summarize(
     }
     if (
       ix.instructionType === "system:Transfer" ||
-      ix.instructionType === "system:TransferWithSeed"
+      ix.instructionType === "system:TransferWithSeed" ||
+      ix.instructionType === "system:CreateAccount"
     ) {
       const lamports = ix.fields.lamports;
-      const to = ix.fields.to;
+      // A Transfer sends to `to`; a CreateAccount funds a NEW account (`newAccount`).
+      // Both move native SOL and must be counted toward the spend cap / recipients.
+      const to = ix.fields.to ?? ix.fields.newAccount;
       if (typeof lamports === "string") totalLamports += BigInt(lamports);
       if (typeof to === "string" && !lamportRecipients.includes(to)) {
         lamportRecipients.push(to);


### PR DESCRIPTION
Closes #105, #107, #108 (filed from the security sweep).

- **#105** `system:CreateAccount` funding lamports are now counted into `totalLamports` + the new account recorded as a recipient (was parsed but never summed → a CreateAccount funding N SOL passed any spend cap with policy `value=0`). `CreateAccountWithSeed` (lamports at a non-decodable variable offset) is fail-closed.
- **#107 / #108** the sign-solana route fails closed on a fully-parsed tx with **multiple distinct recipients or multiple mints** — the policy engine evaluates a single `(to,value)` envelope, so the approved-address allowlist / per-mint accounting would be bypassed for recipients/mints 2..N. Requires the audited `STEWARD_ALLOW_UNSAFE_SOLANA_BLIND_SIGNING` opt-in.

Parser regression tests added (18/18 green); existing sign-solana tests unaffected; vault + api typecheck clean. (Pre-existing CI red — bun-audit vitest CVE, E2E-Compose, Vercel — is unrelated, same as the other PRs.)