### PR TITLE
fix(api): validate operator /withdraw amount + run spend-cap on real notional

### DIFF
--- a/packages/api/src/__tests__/operator-recovery-withdraw-validation.test.ts
+++ b/packages/api/src/__tests__/operator-recovery-withdraw-validation.test.ts
@@ -59,6 +59,7 @@ beforeAll(async () => {
   process.env.STEWARD_PLATFORM_KEYS = PLATFORM_KEY;
   process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
   process.env.STEWARD_MASTER_PASSWORD ??= "test-master-password";
+  process.env.STEWARD_AUDIT_HMAC_KEY ??= "test-audit-hmac-key-operator-withdraw-validation";
   const { db, client } = await createPGLiteDb("memory://");
   setPGLiteOverride(db, async () => {
     await client.close();

--- a/packages/api/src/__tests__/operator-recovery-withdraw-validation.test.ts
+++ b/packages/api/src/__tests__/operator-recovery-withdraw-validation.test.ts
@@ -1,0 +1,269 @@
+/**
+ * operator-recovery-withdraw-validation.test.ts — Regression tests for issue #109.
+ *
+ * Without the fix, POST /v1/trade/:venue/withdraw (operator fund-recovery):
+ *   - accepts an unvalidated explicit `amount` (negative / NaN / non-finite /
+ *     over-precision / whole-reserve), signing it verbatim, and
+ *   - evaluates the policy set with a hardcoded `value: "0"`, so the
+ *     spending-limit / spend-cap evaluator never sees the real withdraw amount.
+ *
+ * These tests assert the now-symmetric-with-/deposit validation AND that the
+ * real notional is fed into the policy gate. They FAIL on the unfixed route and
+ * pass with the fix. Harness mirrors operator-recovery.test.ts (PGLite +
+ * mock.module HyperliquidAdapter, no signing / no network).
+ */
+
+import { afterAll, beforeAll, describe, expect, it, mock } from "bun:test";
+import { agents, agentWallets, closeDb, getDb, policies as policiesTable, tenants } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { Hono } from "hono";
+
+const PLATFORM_KEY = "stw_platform_test_operator_key";
+
+// ── Mock the Hyperliquid adapter (no signing / no network) ─────────────────────
+const signWithdrawCalls: Array<{ amount: string | number; destination: string }> = [];
+const submitWithdrawCalls: unknown[] = [];
+
+class MockHyperliquidAdapter {
+  constructor(
+    public vault: unknown,
+    public agentId: string,
+    public walletAddress: string,
+  ) {}
+
+  async closeAllPositions() {
+    return [] as Array<{ coin: string; result: { status: string; orderId?: string } }>;
+  }
+
+  async signWithdraw(params: { amount: string | number; destination: string }) {
+    signWithdrawCalls.push(params);
+    return {
+      action: { type: "withdraw3", destination: params.destination },
+      nonce: 1,
+      signature: { r: "0x1", s: "0x2", v: 27 },
+    };
+  }
+
+  async submitWithdraw(signed: unknown) {
+    submitWithdrawCalls.push(signed);
+    return { status: "ok", response: { type: "default" } };
+  }
+}
+
+mock.module("@stwd/venue-hyperliquid", () => ({
+  HyperliquidAdapter: MockHyperliquidAdapter,
+}));
+
+beforeAll(async () => {
+  process.env.STEWARD_PGLITE_MEMORY = "true";
+  process.env.STEWARD_PLATFORM_KEYS = PLATFORM_KEY;
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+  process.env.STEWARD_MASTER_PASSWORD ??= "test-master-password";
+  const { db, client } = await createPGLiteDb("memory://");
+  setPGLiteOverride(db, async () => {
+    await client.close();
+  });
+});
+
+afterAll(async () => {
+  await closeDb();
+});
+
+async function seedAgent(opts: {
+  tenantId: string;
+  agentId: string;
+  approvedAddresses?: string[];
+  // spending-limit config in canonical wei format, e.g. { maxPerTx: "50000000" }.
+  // The withdraw amount is fed to the policy engine as USDC 6-decimal base units,
+  // so 100 USDC == 100000000 base units.
+  spendingLimit?: Record<string, unknown>;
+}) {
+  await getDb()
+    .insert(tenants)
+    .values({
+      id: opts.tenantId,
+      name: "Operator Recovery Tenant",
+      apiKeyHash: `test-hash-${opts.tenantId}`,
+      ownerAddress: `0x${opts.tenantId
+        .replace(/[^a-fA-F0-9]/g, "")
+        .padEnd(40, "0")
+        .slice(0, 40)}`,
+    });
+  await getDb().insert(agents).values({
+    id: opts.agentId,
+    tenantId: opts.tenantId,
+    name: "Recovery Agent",
+    walletAddress: "0x00000000000000000000000000000000000000aa",
+  });
+  await getDb().insert(agentWallets).values({
+    agentId: opts.agentId,
+    chainFamily: "evm",
+    address: "0x00000000000000000000000000000000000000bb",
+    venue: "hyperliquid",
+    purpose: "perp",
+  });
+  if (opts.approvedAddresses) {
+    await getDb()
+      .insert(policiesTable)
+      .values({
+        id: `pol_${opts.agentId}`,
+        agentId: opts.agentId,
+        type: "approved-addresses",
+        enabled: true,
+        config: { mode: "whitelist", addresses: opts.approvedAddresses },
+      });
+  }
+  if (opts.spendingLimit) {
+    await getDb()
+      .insert(policiesTable)
+      .values({
+        id: `pol_spend_${opts.agentId}`,
+        agentId: opts.agentId,
+        type: "spending-limit",
+        enabled: true,
+        config: opts.spendingLimit,
+      });
+  }
+}
+
+async function buildApp() {
+  const { isValidPlatformKey } = await import("@stwd/auth");
+  const { operatorRecoveryRoutes } = await import("../routes/operator-recovery");
+  const app = new Hono();
+  app.use("/v1/trade/*", async (c, next) => {
+    const key = c.req.header("X-Steward-Platform-Key");
+    if (!key) {
+      return c.json({ ok: false, error: "X-Steward-Platform-Key header is required" }, 401);
+    }
+    if (!isValidPlatformKey(key)) {
+      return c.json({ ok: false, error: "Invalid platform key" }, 403);
+    }
+    const tenantId = c.req.header("X-Steward-Tenant") || "default";
+    c.set("tenantId", tenantId);
+    c.set("authType", "platform");
+    return next();
+  });
+  app.route("/v1/trade", operatorRecoveryRoutes);
+  return app;
+}
+
+async function postWithdraw(
+  app: Awaited<ReturnType<typeof buildApp>>,
+  tenantId: string,
+  body: Record<string, unknown>,
+) {
+  return app.request("/v1/trade/hyperliquid/withdraw", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Steward-Platform-Key": PLATFORM_KEY,
+      "X-Steward-Tenant": tenantId,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("operator recovery — withdraw amount validation (issue #109)", () => {
+  const approved = "0x4444444444444444444444444444444444444444";
+
+  // Each bad amount must be rejected 400 and signWithdraw must NEVER be called.
+  const badAmounts: Array<{ label: string; amount: unknown }> = [
+    { label: "negative", amount: "-100" },
+    { label: "zero", amount: "0" },
+    { label: "NaN", amount: "NaN" },
+    { label: "non-finite-1e308", amount: 1e308 },
+    { label: "over-precision-7dp", amount: "1.0000001" },
+  ];
+
+  for (const { label, amount } of badAmounts) {
+    it(`rejects an explicit ${label} amount (400) without signing`, async () => {
+      const tenantId = `tenant-wd-bad-${label}-${Date.now()}`;
+      const agentId = `agent-wd-bad-${label}-${Date.now()}`;
+      await seedAgent({ tenantId, agentId, approvedAddresses: [approved] });
+      signWithdrawCalls.length = 0;
+
+      const app = await buildApp();
+      const res = await postWithdraw(app, tenantId, { agentId, amount, destination: approved });
+
+      expect(res.status).toBe(400);
+      expect(signWithdrawCalls.length).toBe(0);
+    });
+  }
+
+  it("rejects an amount above the per-withdraw maximum (400) without signing", async () => {
+    const tenantId = `tenant-wd-max-${Date.now()}`;
+    const agentId = `agent-wd-max-${Date.now()}`;
+    await seedAgent({ tenantId, agentId, approvedAddresses: [approved] });
+    signWithdrawCalls.length = 0;
+
+    const app = await buildApp();
+    // HL_MAX_WITHDRAW_USDC is 2000; 5000 must be rejected.
+    const res = await postWithdraw(app, tenantId, {
+      agentId,
+      amount: "5000",
+      destination: approved,
+    });
+
+    expect(res.status).toBe(400);
+    const bodyJson = (await res.json()) as { error?: string };
+    expect(bodyJson.error ?? "").toContain("maximum");
+    expect(signWithdrawCalls.length).toBe(0);
+  });
+});
+
+describe("operator recovery — withdraw spend-cap enforcement (issue #109)", () => {
+  const approved = "0x5555555555555555555555555555555555555555";
+
+  it("rejects an in-bounds amount that exceeds the spend-cap, even to an approved destination", async () => {
+    const tenantId = `tenant-wd-cap-${Date.now()}`;
+    const agentId = `agent-wd-cap-${Date.now()}`;
+    // maxPerTx = 50 USDC in base units; a 100 USDC withdraw (100000000 base
+    // units) exceeds it. Before the fix the policy saw value:"0" and PASSED.
+    await seedAgent({
+      tenantId,
+      agentId,
+      approvedAddresses: [approved],
+      spendingLimit: { maxPerTx: "50000000" },
+    });
+    signWithdrawCalls.length = 0;
+
+    const app = await buildApp();
+    const res = await postWithdraw(app, tenantId, {
+      agentId,
+      amount: "100",
+      destination: approved,
+    });
+
+    expect(res.status).toBe(400);
+    const bodyJson = (await res.json()) as { code?: string };
+    expect(bodyJson.code).toBe("policy-violation");
+    expect(signWithdrawCalls.length).toBe(0);
+  });
+
+  it("signs a withdraw whose amount is within the spend-cap", async () => {
+    const tenantId = `tenant-wd-cap-ok-${Date.now()}`;
+    const agentId = `agent-wd-cap-ok-${Date.now()}`;
+    // maxPerTx = 200 USDC base units; a 100 USDC withdraw is within the cap.
+    await seedAgent({
+      tenantId,
+      agentId,
+      approvedAddresses: [approved],
+      spendingLimit: { maxPerTx: "200000000" },
+    });
+    signWithdrawCalls.length = 0;
+    submitWithdrawCalls.length = 0;
+
+    const app = await buildApp();
+    const res = await postWithdraw(app, tenantId, {
+      agentId,
+      amount: "100",
+      destination: approved,
+    });
+
+    expect(res.status).toBe(200);
+    expect(signWithdrawCalls.length).toBe(1);
+    // The human-readable amount (not base units) is what gets signed.
+    expect(signWithdrawCalls[0]).toMatchObject({ amount: "100", destination: approved });
+    expect(submitWithdrawCalls.length).toBe(1);
+  });
+});

--- a/packages/api/src/routes/operator-recovery.ts
+++ b/packages/api/src/routes/operator-recovery.ts
@@ -180,6 +180,11 @@ const HL_MIN_DEPOSIT_USDC = 5;
 // a fat-finger/typo moving the whole reserve in one tx. Larger deposits must be
 // split into multiple deliberate calls. (Override per-tenant later if needed.)
 const HL_MAX_DEPOSIT_USDC = 2000;
+// Sane upper bound for a single OPERATOR withdraw. Mirrors HL_MAX_DEPOSIT_USDC:
+// defends against a fat-finger/typo (or a compromised operator client) draining
+// the whole venue balance in one call. Larger withdraws must be split into
+// multiple deliberate calls. (Override per-tenant later if needed.)
+const HL_MAX_WITHDRAW_USDC = 2000;
 const USDC_DECIMALS = 6;
 const ERC20_TRANSFER_SELECTOR = "0xa9059cbb";
 
@@ -452,6 +457,32 @@ operatorRecoveryRoutes.post("/:venue/withdraw", async (c) => {
     return c.json<ApiResponse>({ ok: false, error: "Invalid destination address" }, 400);
   }
 
+  // Validate the EXPLICIT withdraw amount the same way /deposit validates its
+  // amount: reject non-finite/NaN/<=0, enforce a per-call max cap, and reject
+  // sub-cent/over-precision values the 6-decimal conversion can't represent.
+  // (The no-amount path resolves the full withdrawable balance below.)
+  if (body.amount !== undefined) {
+    const amountNum = Number(body.amount);
+    if (!Number.isFinite(amountNum) || amountNum <= 0) {
+      return c.json<ApiResponse>({ ok: false, error: "amount must be a positive number" }, 400);
+    }
+    if (amountNum > HL_MAX_WITHDRAW_USDC) {
+      return c.json<ApiResponse>(
+        {
+          ok: false,
+          error: `amount exceeds the per-withdraw maximum of ${HL_MAX_WITHDRAW_USDC} USDC; split into smaller withdraws`,
+        },
+        400,
+      );
+    }
+    if (!Number.isInteger(amountNum * 10 ** USDC_DECIMALS)) {
+      return c.json<ApiResponse>(
+        { ok: false, error: "amount has more than 6 decimal places" },
+        400,
+      );
+    }
+  }
+
   const agent = await ensureAgentForTenant(tenantId, agentId);
   if (!agent) return c.json<ApiResponse>({ ok: false, error: "Agent not found" }, 404);
 
@@ -463,17 +494,44 @@ operatorRecoveryRoutes.post("/:venue/withdraw", async (c) => {
     );
   }
 
-  // ── Approved-addresses policy gate (BEFORE signing) ──────────────────────────
-  // The withdraw destination must be on the agent's approved list. We evaluate
-  // the full policy set the same way POST /vault/sign does; the policy engine's
-  // approved-addresses evaluator reads `request.to`.
+  // Resolve amount BEFORE the policy gate so the real notional is policy-checked:
+  // explicit (already validated above), or the full withdrawable balance.
+  // `amount` stays human-readable for signing; `amountBaseUnits` (USDC 6-decimal
+  // base units, a uint256 integer string) is what the policy spend-cap sees.
+  let amount = body.amount;
+  if (amount === undefined) {
+    const withdrawable = await fetchWithdrawable(walletAddress);
+    if (!withdrawable || Number(withdrawable) <= 0) {
+      return c.json<ApiResponse>(
+        { ok: false, error: "No withdrawable balance and no amount specified" },
+        400,
+      );
+    }
+    amount = withdrawable;
+  }
+  // Convert the resolved amount to USDC base units for the policy gate. The
+  // explicit path is exact (validated to <= 6 decimals above); the fallback
+  // (venue's own decimal string) is floored — used only for the policy `value`,
+  // never for signing.
+  const amountBaseUnits = (() => {
+    const n = Number(amount);
+    if (!Number.isFinite(n) || n <= 0) return 0n;
+    return BigInt(Math.floor(n * 10 ** USDC_DECIMALS));
+  })();
+
+  // ── Policy gate (BEFORE signing) ─────────────────────────────────────────────
+  // The withdraw destination must be on the agent's approved list AND the amount
+  // must satisfy the spend-cap. We evaluate the full policy set the same way POST
+  // /vault/sign does; the approved-addresses evaluator reads `request.to`, and the
+  // spending-limit evaluator reads `request.value` (the real USDC base-unit
+  // notional, NOT the previous hardcoded "0" which bypassed the spend-cap).
   const policySet = await getPolicySet(tenantId, agentId);
   const evaluation = await policyEngine.evaluate(policySet, {
     request: {
       agentId,
       tenantId,
       to: destination,
-      value: "0",
+      value: amountBaseUnits.toString(),
       chainId: 42161, // Arbitrum — HL withdraw destination chain
     },
     // `venue` must be top-level on the evaluation context: the engine reads
@@ -514,19 +572,6 @@ operatorRecoveryRoutes.post("/:venue/withdraw", async (c) => {
   }
   if (idempotency.response) {
     return c.json<ApiResponse>({ ok: true, data: idempotency.response });
-  }
-
-  // Resolve amount: explicit, or full withdrawable balance.
-  let amount = body.amount;
-  if (amount === undefined) {
-    const withdrawable = await fetchWithdrawable(walletAddress);
-    if (!withdrawable || Number(withdrawable) <= 0) {
-      return c.json<ApiResponse>(
-        { ok: false, error: "No withdrawable balance and no amount specified" },
-        400,
-      );
-    }
-    amount = withdrawable;
   }
 
   const adapter = buildAdapter(tenantId, agentId, walletAddress);


### PR DESCRIPTION
Closes #109. The operator `/withdraw` fund-recovery route accepted any amount with no positivity/finiteness/precision/max-cap check (asymmetric with the sibling `/deposit`, which explicitly guards a fat-finger from moving the whole reserve), and evaluated policy with `value:'0'` — so the spend-cap/max-value evaluators never saw the real amount and only the destination was policy-checked. This mirrors the deposit validation and feeds the real notional into the policy gate. Regression test added; existing operator-recovery test still green; api typecheck clean. (Pre-existing CI red unrelated.)