### PR TITLE
fix(api,webhooks): don't cache 5xx idempotency replays; add per-attempt webhook sent-at

### DIFF
--- a/packages/api/src/__tests__/idempotency-5xx-no-cache.test.ts
+++ b/packages/api/src/__tests__/idempotency-5xx-no-cache.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "bun:test";
+import { Hono } from "hono";
+import { idempotencyMiddleware, MemoryIdempotencyStore } from "../middleware/idempotency";
+import type { ApiResponse, AppVariables } from "../services/context";
+
+const AUTHORIZATION = "Bearer idempotency-5xx-test-token";
+
+// Regression for Steward-Fi/steward#103: the global idempotency middleware must
+// NOT cache a transient 5xx response as a permanent, replayable "completed"
+// outcome — that poisons every legitimate retry of the same Idempotency-Key for
+// the full TTL. A handler that *returns* a 5xx should release the reservation so
+// a retry re-executes.
+describe("idempotencyMiddleware 5xx handling", () => {
+  function makeApp(statusByCall: number[]) {
+    const app = new Hono<{ Variables: AppVariables }>();
+    const store = new MemoryIdempotencyStore(100);
+    let count = 0;
+
+    app.use("*", async (c, next) => {
+      c.set("authType", "api-key");
+      await next();
+    });
+    app.use("*", idempotencyMiddleware({ store, ttlMs: 60_000 }));
+    app.post("/mutate", (c) => {
+      const status = statusByCall[count] ?? 200;
+      count += 1;
+      if (status >= 400) {
+        return c.json<ApiResponse>({ ok: false, error: "store unavailable" }, status as 503);
+      }
+      return c.json({ ok: true, count });
+    });
+
+    return { app, getCount: () => count };
+  }
+
+  const init = {
+    method: "POST",
+    headers: {
+      Authorization: AUTHORIZATION,
+      "Content-Type": "application/json",
+      "Idempotency-Key": "idem-key-5xx",
+    },
+    body: JSON.stringify({ value: "first" }),
+  };
+
+  it("does not cache a returned 503 and lets a retry re-execute the handler", async () => {
+    // First call returns 503 (transient), second call returns 200.
+    const { app, getCount } = makeApp([503, 200]);
+
+    const first = await app.request("/mutate", init);
+    expect(first.status).toBe(503);
+    // The 5xx ran fresh; it is not a replay.
+    expect(first.headers.get("Idempotency-Replayed")).toBe("false");
+    expect(await first.json()).toEqual({ ok: false, error: "store unavailable" });
+
+    // Same key, same request — without the fix this replays the cached 503.
+    const second = await app.request("/mutate", init);
+    expect(second.status).toBe(200);
+    expect(second.headers.get("Idempotency-Replayed")).toBe("false");
+    expect(await second.json()).toEqual({ ok: true, count: 2 });
+
+    // Handler executed twice: the 503 was not cached as a permanent outcome.
+    expect(getCount()).toBe(2);
+  });
+
+  it("still caches and replays a successful 2xx response", async () => {
+    const { app, getCount } = makeApp([200]);
+
+    const first = await app.request("/mutate", init);
+    const second = await app.request("/mutate", init);
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(first.headers.get("Idempotency-Replayed")).toBe("false");
+    expect(second.headers.get("Idempotency-Replayed")).toBe("true");
+    expect(await first.json()).toEqual({ ok: true, count: 1 });
+    expect(await second.json()).toEqual({ ok: true, count: 1 });
+    // Only the first call reached the handler; the second was replayed.
+    expect(getCount()).toBe(1);
+  });
+});

--- a/packages/api/src/middleware/idempotency.ts
+++ b/packages/api/src/middleware/idempotency.ts
@@ -681,6 +681,22 @@ export function idempotencyMiddleware(options?: { store?: IdempotencyStore; ttlM
 
     try {
       await next();
+      // Never cache transient server errors (5xx). A handler that *returns* a
+      // 500/502/503 as a normal Response is a retryable outcome, not a settled
+      // one — caching it as "completed" for the full TTL would replay the error
+      // and poison every legitimate retry of this Idempotency-Key. Release the
+      // reservation so a retry re-executes the handler.
+      if (c.res.status >= 500) {
+        try {
+          await store.delete(storageKey);
+          recordIdempotencyMetric(metricsTenantId, "releasedOnError");
+        } catch {
+          recordIdempotencyMetric(metricsTenantId, "storeErrors");
+          console.error("[steward:idempotency] Failed to release reservation after 5xx");
+        }
+        c.header("Idempotency-Replayed", "false");
+        return;
+      }
       try {
         if (isAuthTokenResponseReplaySuppressedPath(c.req.path)) {
           await store.setCompleted(storageKey);

--- a/packages/webhooks/src/__tests__/dispatcher-sent-at.test.ts
+++ b/packages/webhooks/src/__tests__/dispatcher-sent-at.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "bun:test";
+import { createServer, type IncomingMessage } from "node:http";
+import type { AddressInfo } from "node:net";
+import type { WebhookEvent } from "@stwd/shared";
+import { WebhookDispatcher } from "../dispatcher";
+
+const SECRET = "super-secret-webhook-key";
+
+const makeEvent = (overrides: Partial<WebhookEvent> = {}): WebhookEvent => ({
+  type: "tx_signed",
+  tenantId: "tenant-a",
+  agentId: "agent-a",
+  data: { txHash: "0xabc", amount: "100" },
+  timestamp: new Date("2026-05-30T09:00:00.000Z"),
+  ...overrides,
+});
+
+type CapturedRequest = { headers: IncomingMessage["headers"]; bodyText: string };
+
+async function readBody(req: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+async function withWebhookServer(statuses: number[]) {
+  const requests: CapturedRequest[] = [];
+  let index = 0;
+  const server = createServer(async (req, res) => {
+    requests.push({ headers: req.headers, bodyText: await readBody(req) });
+    const status = statuses[index] ?? statuses[statuses.length - 1] ?? 200;
+    index += 1;
+    res.writeHead(status, { "Content-Type": "text/plain" });
+    res.end(status >= 200 && status < 300 ? "ok" : "error");
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.listen(0, "127.0.0.1", (error?: Error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}/hook`,
+    requests,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+}
+
+// Regression for Steward-Fi/steward#103: a slow retry must carry a FRESH
+// per-attempt freshness header so a standard freshness-checking receiver does
+// not reject it as stale — while the signed timestamp / signature / delivery id
+// stay byte-stable across retries so the receiver can still verify and dedup.
+describe("WebhookDispatcher per-attempt sent-at freshness", () => {
+  it("emits X-Steward-Sent-At on every attempt while keeping the signed timestamp stable", async () => {
+    const server = await withWebhookServer([500, 200]);
+
+    try {
+      const dispatcher = new WebhookDispatcher({
+        maxRetries: 1,
+        retryDelayMs: 5,
+        timeoutMs: 1_000,
+        allowPrivateNetwork: true,
+        allowInsecureHttp: true,
+      });
+      const result = await dispatcher.dispatch(makeEvent(), { url: server.url, secret: SECRET });
+
+      expect(result.success).toBe(true);
+      expect(server.requests).toHaveLength(2);
+      const [first, second] = server.requests;
+
+      // Every attempt carries a numeric (unix seconds) sent-at header.
+      const firstSentAt = String(first?.headers["x-steward-sent-at"]);
+      const secondSentAt = String(second?.headers["x-steward-sent-at"]);
+      expect(firstSentAt).toMatch(/^\d+$/);
+      expect(secondSentAt).toMatch(/^\d+$/);
+
+      // Dedup material stays byte-stable across the retry.
+      expect(first?.headers["x-steward-timestamp"]).toBe(second?.headers["x-steward-timestamp"]);
+      expect(first?.headers["x-steward-signature"]).toBe(second?.headers["x-steward-signature"]);
+      expect(first?.headers["x-steward-delivery-id"]).toBe(
+        second?.headers["x-steward-delivery-id"],
+      );
+
+      // Sent-at is a real send-time clock, never older than the signed timestamp.
+      const signedTs = Number(first?.headers["x-steward-timestamp"]);
+      expect(Number(firstSentAt)).toBeGreaterThanOrEqual(signedTs);
+      expect(Number(secondSentAt)).toBeGreaterThanOrEqual(Number(firstSentAt));
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/packages/webhooks/src/dispatcher.ts
+++ b/packages/webhooks/src/dispatcher.ts
@@ -408,12 +408,23 @@ export class WebhookDispatcher {
     while (attempts <= this.maxRetries) {
       attempts += 1;
 
+      // `X-Steward-Timestamp` (signed) + `X-Steward-Delivery-Id` are fixed across
+      // retries so receivers can verify the byte-stable signature and dedup a
+      // retry against the original event. But the signed timestamp also drives
+      // the SDK verifier's freshness window (default 300s); reusing it on a slow
+      // retry would be rejected as stale. So we additionally emit an unsigned,
+      // per-attempt `X-Steward-Sent-At` (unix seconds) with the actual send time.
+      // Freshness-checking receivers should check `X-Steward-Sent-At` for
+      // transport recency and dedup on `X-Steward-Delivery-Id`.
+      const sentAt = Math.floor(Date.now() / 1000).toString();
+
       try {
         const response = await postWebhook(config.url, {
           headers: {
             "Content-Type": "application/json",
             "X-Steward-Event": event.type,
             "X-Steward-Timestamp": timestamp,
+            "X-Steward-Sent-At": sentAt,
             "X-Steward-Signature": signature,
             "X-Steward-Delivery-Id": deliveryId,
           },


### PR DESCRIPTION
From the hardening sweep (#103). (1) The global idempotency middleware cached 5xx/transient responses for the full 24h TTL, so a client retrying the same Idempotency-Key after an RPC blip got a poisoned stale error — now skips caching + releases the reservation on status >= 500. (2) Webhook retries reused a fixed signing timestamp across the 12h backoff, which Steward's own SDK verifier rejects as stale; adds a per-attempt `X-Steward-Sent-At` header (freshness per attempt; replay-dedup still on the stable delivery id + signature). Regression tests added; full webhooks suite (25) + api idempotency tests green. (Pre-existing CI red unrelated.)