### PR TITLE
fix(auth): enforce SIWS expiry/not-before; handle verified-email-less OAuth providers

### DIFF
--- a/packages/api/src/__tests__/siws-temporal-bounds.test.ts
+++ b/packages/api/src/__tests__/siws-temporal-bounds.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// Source-introspection regression test for issue #103 (SIWS expiry / not-before).
+//
+// The Solana SIWS verify path historically ignored the signed message's own
+// `Expiration Time` / `Not Before` fields, while the EVM SIWE path enforces
+// both. This test asserts that:
+//   1. parseSiwsMessage captures expirationTime / notBefore from the message.
+//   2. POST /verify/solana rejects an expired or not-yet-valid message with the
+//      same error strings/status the EVM path uses.
+//   3. Those temporal checks run BEFORE the single-use nonce is consumed, so a
+//      stale message cannot burn a fresh nonce.
+//
+// This mirrors the existing structural style of auth-nonce-binding.test.ts and
+// fails on the pre-fix source (which has no expirationTime/notBefore handling).
+
+const authSource = readFileSync(join(import.meta.dir, "..", "routes", "auth.ts"), "utf8");
+
+describe("SIWS temporal bounds (issue #103)", () => {
+  it("parseSiwsMessage captures Expiration Time and Not Before fields", () => {
+    const parseStart = authSource.indexOf("function parseSiwsMessage");
+    expect(parseStart).toBeGreaterThanOrEqual(0);
+    const parseEnd = authSource.indexOf("\nfunction verifySolanaMessageSignature", parseStart);
+    const parseFn = authSource.slice(parseStart, parseEnd === -1 ? undefined : parseEnd);
+
+    // Field keys are lowercased with whitespace stripped, so the map keys are
+    // "expirationtime" and "notbefore".
+    expect(parseFn).toContain('fields.get("expirationtime")');
+    expect(parseFn).toContain('fields.get("notbefore")');
+    expect(parseFn).toContain("expirationTime:");
+    expect(parseFn).toContain("notBefore:");
+  });
+
+  it("ParsedSiwsMessage type carries expirationTime and notBefore", () => {
+    const typeStart = authSource.indexOf("type ParsedSiwsMessage = {");
+    expect(typeStart).toBeGreaterThanOrEqual(0);
+    const typeEnd = authSource.indexOf("};", typeStart);
+    const typeBlock = authSource.slice(typeStart, typeEnd);
+    expect(typeBlock).toContain("expirationTime?: string");
+    expect(typeBlock).toContain("notBefore?: string");
+  });
+
+  it("/verify/solana enforces expiry and not-before with the EVM error shapes", () => {
+    const siwsStart = authSource.indexOf('auth.post("/verify/solana"');
+    expect(siwsStart).toBeGreaterThanOrEqual(0);
+    const siwsEnd = authSource.indexOf('auth.post("', siwsStart + 1);
+    const route = authSource.slice(siwsStart, siwsEnd === -1 ? undefined : siwsEnd);
+
+    expect(route).toContain("parsed.expirationTime");
+    expect(route).toContain("parsed.notBefore");
+    // Same error strings as the EVM /verify/ethereum path.
+    expect(route).toContain('error: "Invalid expirationTime"');
+    expect(route).toContain('error: "Message expired"');
+    expect(route).toContain('error: "Invalid notBefore"');
+    expect(route).toContain('error: "Message not yet valid"');
+  });
+
+  it("rejects expired/not-yet-valid messages BEFORE consuming the nonce", () => {
+    const siwsStart = authSource.indexOf('auth.post("/verify/solana"');
+    expect(siwsStart).toBeGreaterThanOrEqual(0);
+    const siwsEnd = authSource.indexOf('auth.post("', siwsStart + 1);
+    const route = authSource.slice(siwsStart, siwsEnd === -1 ? undefined : siwsEnd);
+
+    const expCheck = route.indexOf("parsed.expirationTime");
+    const nbCheck = route.indexOf("parsed.notBefore");
+    const nonceConsume = route.indexOf("consumeSiweNonce(parsed.nonce)");
+    const signatureCheck = route.indexOf("verifySolanaMessageSignature");
+
+    expect(expCheck).toBeGreaterThanOrEqual(0);
+    expect(nbCheck).toBeGreaterThan(expCheck);
+    expect(nonceConsume).toBeGreaterThan(nbCheck);
+    // Preserve the existing invariant: nonce is consumed before signature check.
+    expect(signatureCheck).toBeGreaterThan(nonceConsume);
+  });
+});

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -1903,6 +1903,8 @@ type ParsedSiwsMessage = {
   publicKey: string;
   nonce: string;
   issuedAt?: string;
+  expirationTime?: string;
+  notBefore?: string;
   uri?: string;
   version?: string;
   chainId?: string;
@@ -1972,6 +1974,8 @@ function parseSiwsMessage(message: string): ParsedSiwsMessage | null {
     publicKey,
     nonce,
     issuedAt: fields.get("issuedat"),
+    expirationTime: fields.get("expirationtime"),
+    notBefore: fields.get("notbefore"),
     uri: fields.get("uri"),
     version: fields.get("version"),
     chainId: fields.get("chainid"),
@@ -5182,6 +5186,29 @@ auth.post("/verify/solana", async (c) => {
       },
       401,
     );
+  }
+
+  // Honor the signed message's own temporal bounds, mirroring the EVM SIWE
+  // path. Reject an already-expired or not-yet-valid message BEFORE consuming
+  // the single-use nonce, so a stale message cannot burn a fresh nonce.
+  const now = new Date();
+  if (parsed.expirationTime) {
+    const exp = new Date(parsed.expirationTime);
+    if (Number.isNaN(exp.getTime())) {
+      return c.json<ApiResponse>({ ok: false, error: "Invalid expirationTime" }, 401);
+    }
+    if (now >= exp) {
+      return c.json<ApiResponse>({ ok: false, error: "Message expired" }, 401);
+    }
+  }
+  if (parsed.notBefore) {
+    const nb = new Date(parsed.notBefore);
+    if (Number.isNaN(nb.getTime())) {
+      return c.json<ApiResponse>({ ok: false, error: "Invalid notBefore" }, 401);
+    }
+    if (now < nb) {
+      return c.json<ApiResponse>({ ok: false, error: "Message not yet valid" }, 401);
+    }
   }
 
   const requestedTenantId = c.req.header("X-Steward-Tenant")?.trim();

--- a/packages/auth/src/__tests__/oauth-spotify-verified-email.test.ts
+++ b/packages/auth/src/__tests__/oauth-spotify-verified-email.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "bun:test";
+import { getProviderConfig, OAuthClient } from "../oauth";
+
+// Regression test for issue #103 (Spotify OAuth fails closed with 403).
+//
+// Spotify's /v1/me returns a real, confirmed account email but NO per-response
+// verification flag, and the provider config has no emailUrl fallback. Before
+// the fix, getUserInfo() therefore reported verified_email=false, and the
+// account-takeover gate in provisionOAuthUser() rejected every Spotify login
+// with 403 "Provider email must be verified before OAuth sign-in is allowed".
+//
+// The fix adds an `assertsEmailVerified` provider flag (set on Spotify) that
+// marks a non-empty returned email as verified.
+
+function asFetchMock(impl: (...args: any[]) => Promise<Response>): typeof fetch {
+  return impl as unknown as typeof fetch;
+}
+
+function spotifyClient() {
+  return new OAuthClient({
+    clientId: "spotify-id",
+    clientSecret: "spotify-secret",
+    authorizationUrl: "https://accounts.spotify.com/authorize",
+    tokenUrl: "https://accounts.spotify.com/api/token",
+    userInfoUrl: "https://api.spotify.com/v1/me",
+    scopes: ["user-read-email"],
+    assertsEmailVerified: true,
+    profileMap: {
+      id: "id",
+      email: "email",
+      name: "display_name",
+      picture: "images.0.url",
+    },
+  });
+}
+
+describe("Spotify OAuth verified-email (issue #103)", () => {
+  it("built-in Spotify config asserts the returned email is verified", () => {
+    process.env.SPOTIFY_CLIENT_ID = "spotify-id";
+    process.env.SPOTIFY_CLIENT_SECRET = "spotify-secret";
+    const config = getProviderConfig("spotify");
+    expect(config.assertsEmailVerified).toBe(true);
+    delete process.env.SPOTIFY_CLIENT_ID;
+    delete process.env.SPOTIFY_CLIENT_SECRET;
+  });
+
+  it("marks verified_email=true for a real Spotify email with no verification flag", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = asFetchMock(
+      async () =>
+        new Response(
+          JSON.stringify({
+            id: "spotify-user-id",
+            display_name: "Spotify User",
+            email: "user@example.com",
+            images: [{ url: "https://i.scdn.co/image/avatar" }],
+            // Note: Spotify returns NO verified/email_verified field.
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+    const info = await spotifyClient().getUserInfo("tok");
+    expect(info.id).toBe("spotify-user-id");
+    expect(info.email).toBe("user@example.com");
+    expect(info.name).toBe("Spotify User");
+    // The fix: a confirmed-by-construction email is trusted as verified.
+    expect(info.verified_email).toBe(true);
+    globalThis.fetch = originalFetch;
+  });
+
+  it("does NOT fabricate verification when the provider returns no email", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = asFetchMock(
+      async () =>
+        new Response(JSON.stringify({ id: "spotify-user-id", display_name: "No Email" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    const info = await spotifyClient().getUserInfo("tok");
+    expect(info.email).toBe("");
+    // No email => nothing to trust; the gate must still see verified_email=false.
+    expect(info.verified_email).toBe(false);
+    globalThis.fetch = originalFetch;
+  });
+});

--- a/packages/auth/src/oauth.ts
+++ b/packages/auth/src/oauth.ts
@@ -44,6 +44,16 @@ export interface OAuthProvider {
    */
   clientIdParam?: string;
   /**
+   * Asserts that this provider only ever returns a confirmed/verified account
+   * email, even though its userinfo response carries no per-response
+   * verification flag (and it has no emailUrl fallback). Spotify is the
+   * canonical case: /v1/me returns the account's confirmed email but no
+   * `verified`/`email_verified` field, so without this the account-takeover
+   * gate in provisionOAuthUser() would reject every Spotify login. When true
+   * and a non-empty email is returned, getUserInfo() marks verified_email.
+   */
+  assertsEmailVerified?: boolean;
+  /**
    * Marks the provider as OIDC: the user's identity is derived from the
    * `id_token` returned by the token endpoint (verified against `oidcJwksUri`),
    * not from a userinfo endpoint. Used for "Sign in with Apple", which exposes
@@ -404,6 +414,11 @@ export function getProviderConfig(provider: string): OAuthProvider {
         tokenUrl: "https://accounts.spotify.com/api/token",
         userInfoUrl: "https://api.spotify.com/v1/me",
         scopes: ["user-read-email"],
+        // Spotify requires the account email to be confirmed before the account
+        // can be used, but /v1/me returns no per-response verification flag.
+        // Trust the returned email as verified so the OAuth sign-in gate can be
+        // satisfied (otherwise Spotify login fails closed with 403 forever).
+        assertsEmailVerified: true,
         profileMap: {
           id: "id",
           email: "email",
@@ -721,6 +736,13 @@ export class OAuthClient {
         userInfo.email = emailInfo.email;
         userInfo.verified_email = emailInfo.verified ?? userInfo.verified_email;
       }
+    }
+
+    // Providers that only ever return a confirmed account email (e.g. Spotify)
+    // expose no per-response verification flag. Treat a non-empty email from
+    // such a provider as verified so the OAuth sign-in gate is satisfiable.
+    if (this.provider.assertsEmailVerified && userInfo.email) {
+      userInfo.verified_email = true;
     }
 
     return userInfo;


### PR DESCRIPTION
From the hardening sweep (#103). (1) The Solana SIWS verify path ignored the signed message's `Expiration Time` / `Not Before` (the EVM SIWE path enforces both) — now parsed and enforced before the nonce is consumed. (2) An OAuth provider returning a real email with no `email_verified` flag (Spotify) failed closed forever on the verified-email account-takeover gate — now handled. Regression tests added (pass in isolation). Note: the auth package's single-process `bun test` has **pre-existing** cross-file pollution (same 11 failures on `develop`, unrelated to this change; CI runs the auth unit tests green). (Pre-existing CI red unrelated.)