### PR TITLE
fix(deploy): supply proxy REDIS_URL + signing secret; pipe provision secrets over stdin

### DIFF
--- a/deploy/DEPLOYMENT.md
+++ b/deploy/DEPLOYMENT.md
@@ -105,7 +105,8 @@ chmod 600 /opt/steward/.env"
 | `STEWARD_JWT_SECRET` | JWT signing secret (separate from master password!) | Yes |
 | `STEWARD_PLATFORM_KEYS` | Platform admin API key for tenant management | Yes |
 | `STEWARD_BIND_HOST` | Must be `0.0.0.0` for Docker containers to reach it | Yes |
-| `REDIS_URL` | Redis connection string for rate limiting + spend tracking | No |
+| `REDIS_URL` | Redis connection string for rate limiting + spend tracking | Yes (production) |
+| `STEWARD_PROXY_REQUEST_SIGNING_SECRETS` | Shared secret(s) the proxy uses to verify every request signature | Yes (production) |
 | `RPC_URL` | EVM RPC endpoint (default: Base mainnet) | No |
 
 ### Step 4: Create systemd services
@@ -546,9 +547,9 @@ curl -H "Authorization: Bearer $TOKEN" localhost:8080/openai/v1/models
 
 ---
 
-## Redis Setup (Optional)
+## Redis Setup (required in production)
 
-Redis enables persistent rate limiting and spend tracking that survives API restarts. Without Redis, rate limits and spend counters are in-memory only (reset on restart).
+Redis enables persistent rate limiting and spend tracking that survives API restarts. The Docker Compose deploy ships a `redis` service and sets `REDIS_URL` on `steward-proxy`; **in production the proxy fails closed without Redis** (see below). Redis is only optional in non-production or when `STEWARD_ALLOW_PROXY_REDIS_SOFT_FAIL=true` is set, in which case rate-limit/spend counters are in-memory only and reset on restart.
 
 ### Install Redis on a node
 
@@ -582,7 +583,7 @@ Redis is used for:
 - **Spend tracking** — daily/weekly spend totals survive restarts
 - **Webhook delivery queue** — retries are queued in Redis
 
-Without Redis, these features still work using in-memory fallbacks, but counters reset on restart.
+In **production** (`NODE_ENV=production`) the proxy treats Redis as **required** and fails **closed** without it: `checkProxyRateLimit`/`checkProxySpendLimit` reject requests (429/402/503) unless you explicitly set `STEWARD_ALLOW_PROXY_REDIS_SOFT_FAIL=true`. The compose deploy therefore ships a `redis` service and sets `REDIS_URL`. Only in non-production (or with the soft-fail override) do rate-limit/spend counters fall back to in-memory and reset on restart.
 
 ---
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -59,11 +59,19 @@ services:
       STEWARD_PROXY_PORT: "8080"
       DATABASE_URL: "${DATABASE_URL:-postgresql://steward:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@steward-db:5432/steward}"
       STEWARD_MASTER_PASSWORD: "${STEWARD_MASTER_PASSWORD:?Set STEWARD_MASTER_PASSWORD in .env}"
-      STEWARD_JWT_SECRET: "${STEWARD_JWT_SECRET:-}"
+      # JWT secret is required in production (auth verifyToken refuses dev fallback).
+      STEWARD_JWT_SECRET: "${STEWARD_JWT_SECRET:?Set STEWARD_JWT_SECRET in .env}"
+      # NODE_ENV=production makes request signing + Redis enforcement fail CLOSED,
+      # so both REDIS_URL and a request-signing secret are REQUIRED here. Without
+      # them the proxy returns 500/429 on 100% of traffic. See deploy/DEPLOYMENT.md.
+      REDIS_URL: "${REDIS_URL:-redis://redis:6379}"
+      STEWARD_PROXY_REQUEST_SIGNING_SECRETS: "${STEWARD_PROXY_REQUEST_SIGNING_SECRETS:?Set STEWARD_PROXY_REQUEST_SIGNING_SECRETS in .env (proxy signs/verifies every request in production)}"
       NODE_ENV: production
     command: ["bun", "run", "packages/proxy/src/index.ts"]
     depends_on:
       steward:
+        condition: service_healthy
+      redis:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "bun", "-e", "const r=await fetch('http://localhost:8080/health');process.exit(r.ok?0:1)"]
@@ -71,6 +79,22 @@ services:
       timeout: 5s
       start_period: 10s
       retries: 3
+
+  # ── Redis (rate-limit + spend enforcement) ───────────────────────────────────
+  # Required by steward-proxy in production: with NODE_ENV=production and no
+  # STEWARD_ALLOW_PROXY_REDIS_SOFT_FAIL=true, the proxy fails CLOSED without Redis.
+  redis:
+    image: redis:7-alpine
+    container_name: steward-redis
+    restart: unless-stopped
+    networks:
+      - milady-isolated
+    command: ["redis-server", "--save", "", "--appendonly", "no"]
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   # ── PostgreSQL (managed) ─────────────────────────────────────────────────────
   steward-db:

--- a/deploy/provision-steward-node.sh
+++ b/deploy/provision-steward-node.sh
@@ -66,14 +66,48 @@ echo "  ✓ Source synced"
 # ── Step 3: Write .env file on node ─────────────────────────────────────────
 echo ""
 echo "▸ Step 3: Writing environment config..."
-${SSH_CMD} "cat > ${REMOTE_DIR}/deploy/.env << 'ENVEOF'
+
+# Read the existing remote .env (if any) so re-runs are idempotent and do NOT
+# rotate generated secrets (rotating STEWARD_KDF_SALT/STEWARD_JWT_SECRET would
+# brick an existing vault / invalidate sessions).
+EXISTING_ENV="$(${SSH_CMD} "cat ${REMOTE_DIR}/deploy/.env 2>/dev/null || true")"
+
+# env_get <KEY>: echo the value of KEY from the existing remote .env, else empty.
+env_get() {
+  printf '%s\n' "${EXISTING_ENV}" | sed -n "s/^$1=//p" | head -n1
+}
+
+# Reuse already-generated secrets if present, otherwise generate fresh ones.
+STEWARD_JWT_SECRET="${STEWARD_JWT_SECRET:-$(env_get STEWARD_JWT_SECRET)}"
+[[ -n "${STEWARD_JWT_SECRET}" ]] || STEWARD_JWT_SECRET="$(openssl rand -hex 32)"
+STEWARD_KDF_SALT="${STEWARD_KDF_SALT:-$(env_get STEWARD_KDF_SALT)}"
+[[ -n "${STEWARD_KDF_SALT}" ]] || STEWARD_KDF_SALT="$(openssl rand -hex 32)"
+POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-$(env_get POSTGRES_PASSWORD)}"
+[[ -n "${POSTGRES_PASSWORD}" ]] || POSTGRES_PASSWORD="$(openssl rand -hex 32)"
+STEWARD_PROXY_REQUEST_SIGNING_SECRETS="${STEWARD_PROXY_REQUEST_SIGNING_SECRETS:-$(env_get STEWARD_PROXY_REQUEST_SIGNING_SECRETS)}"
+[[ -n "${STEWARD_PROXY_REQUEST_SIGNING_SECRETS}" ]] || STEWARD_PROXY_REQUEST_SIGNING_SECRETS="$(openssl rand -hex 32)"
+PLATFORM_KEY="${STEWARD_PLATFORM_KEY:-$(env_get STEWARD_PLATFORM_KEY)}"
+[[ -n "${PLATFORM_KEY}" ]] || PLATFORM_KEY="$(openssl rand -hex 32)"
+
+# Render the .env LOCALLY into a mode-0600 temp file, then stream it to the node
+# over ssh stdin. Secrets never appear on any command line (local or remote).
+LOCAL_ENV_FILE="$(umask 077 && mktemp)"
+trap 'rm -f "${LOCAL_ENV_FILE}"' EXIT
+cat > "${LOCAL_ENV_FILE}" << ENVEOF
 STEWARD_MASTER_PASSWORD=${STEWARD_MASTER_PASSWORD}
+STEWARD_JWT_SECRET=${STEWARD_JWT_SECRET}
+STEWARD_KDF_SALT=${STEWARD_KDF_SALT}
+STEWARD_PLATFORM_KEY=${PLATFORM_KEY}
+STEWARD_PROXY_REQUEST_SIGNING_SECRETS=${STEWARD_PROXY_REQUEST_SIGNING_SECRETS}
+POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
 DATABASE_URL=${DATABASE_URL:-}
+REDIS_URL=${REDIS_URL:-redis://redis:6379}
 RPC_URL=${RPC_URL:-https://mainnet.base.org}
 CHAIN_ID=${CHAIN_ID:-8453}
 SOLANA_RPC_URL=${SOLANA_RPC_URL:-https://api.mainnet-beta.solana.com}
 ENVEOF
-chmod 600 ${REMOTE_DIR}/deploy/.env"
+
+${SSH_CMD} "umask 077; cat > ${REMOTE_DIR}/deploy/.env" < "${LOCAL_ENV_FILE}"
 echo "  ✓ Environment configured"
 
 # ── Step 4: Build and start services ────────────────────────────────────────
@@ -107,22 +141,14 @@ done
 echo ""
 echo "▸ Step 7: Creating milady-cloud tenant..."
 
-# Read the platform key from the running container
-PLATFORM_KEY=$(${SSH_CMD} "docker exec steward printenv STEWARD_PLATFORM_KEY 2>/dev/null || echo ''")
-
-if [[ -z "${PLATFORM_KEY}" ]]; then
-  echo "  ⚠  No STEWARD_PLATFORM_KEY set — generating one..."
-  PLATFORM_KEY=$(openssl rand -hex 32)
-  # Update .env and restart
-  ${SSH_CMD} "echo 'STEWARD_PLATFORM_KEY=${PLATFORM_KEY}' >> ${REMOTE_DIR}/deploy/.env"
-  ${SSH_CMD} "cd ${REMOTE_DIR} && docker compose -f deploy/docker-compose.yml up -d steward"
-  sleep 5
-fi
-
-# Create tenant (ignore 409 conflict = already exists)
-TENANT_RESP=$(${SSH_CMD} "curl -sf -X POST http://localhost:3200/platform/tenants \
+# The platform key was written to deploy/.env in Step 3 and picked up by the
+# container at boot. Create the tenant by reading the key on the REMOTE side
+# (PK=$(...)) so the secret is never placed on the local->remote command line
+# nor printed to this script's stdout / CI logs.
+TENANT_RESP=$(${SSH_CMD} "set -e; PK=\$(sed -n 's/^STEWARD_PLATFORM_KEY=//p' ${REMOTE_DIR}/deploy/.env | head -n1); \
+curl -sf -X POST http://localhost:3200/platform/tenants \
   -H 'Content-Type: application/json' \
-  -H 'X-Steward-Platform-Key: ${PLATFORM_KEY}' \
+  -H \"X-Steward-Platform-Key: \${PK}\" \
   -d '{\"id\": \"milady-cloud\", \"name\": \"Milady Cloud\"}'" 2>&1 || true)
 
 if echo "${TENANT_RESP}" | grep -q '"ok":true'; then
@@ -140,7 +166,7 @@ echo "  ✅ Steward deployed successfully!"
 echo ""
 echo "  Steward URL:    http://${NODE_IP}:3200"
 echo "  Health check:   http://${NODE_IP}:3200/health"
-echo "  Platform Key:   ${PLATFORM_KEY}"
+echo "  Platform Key:   (written to ${REMOTE_DIR}/deploy/.env, mode 0600, on the node — retrieve it there; not printed here)"
 echo ""
 echo "  Agent config (add to container env):"
 echo "    STEWARD_API_URL=http://steward:3200"

--- a/deploy/provision-steward-node.sh
+++ b/deploy/provision-steward-node.sh
@@ -59,6 +59,7 @@ rsync -az --delete \
   --exclude='.next' \
   --exclude='web' \
   --exclude='.turbo' \
+  --exclude='deploy/.env' \
   -e "ssh ${SSH_OPTS}" \
   "${REPO_ROOT}/" "root@${NODE_IP}:${REMOTE_DIR}/"
 echo "  ✓ Source synced"

--- a/packages/proxy/src/__tests__/deploy-artifacts.test.ts
+++ b/packages/proxy/src/__tests__/deploy-artifacts.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Regression test for issues #101 and #111.
+ *
+ * These guard the shipped deploy artifacts (no app logic is exercised), so the
+ * test is dependency-free: it reads the files as text and asserts on their
+ * content. It FAILS against the pre-fix artifacts and passes after the fix.
+ *
+ * #101 — steward-proxy runs NODE_ENV=production, which makes request signing and
+ *        Redis enforcement fail CLOSED. The compose proxy service must therefore
+ *        supply REDIS_URL and a request-signing secret (or set the explicit
+ *        soft-fail / no-signature overrides), and the docs must not call
+ *        REDIS_URL optional while the code treats production as requiring it.
+ *
+ * #111 — provision-steward-node.sh must not interpolate secret variables into an
+ *        ssh / ${SSH_CMD} "..." command-line argument, and must not echo the
+ *        platform admin key to stdout.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const DEPLOY_DIR = join(import.meta.dir, "..", "..", "..", "..", "deploy");
+
+function read(name: string): string {
+  return readFileSync(join(DEPLOY_DIR, name), "utf8");
+}
+
+/**
+ * Extract the `steward-proxy:` service block from the compose file (everything
+ * from the `steward-proxy:` key up to the next top-level service or section).
+ */
+function extractProxyService(compose: string): string {
+  const lines = compose.split("\n");
+  const start = lines.findIndex((l) => /^\s{2}steward-proxy:\s*$/.test(l));
+  expect(start).toBeGreaterThanOrEqual(0);
+  const body: string[] = [];
+  for (let i = start + 1; i < lines.length; i += 1) {
+    const l = lines[i];
+    // Stop at the next 2-space-indented key (next service) or a 0-indent line.
+    if (/^\s{2}\S/.test(l) || /^\S/.test(l)) break;
+    body.push(l);
+  }
+  return body.join("\n");
+}
+
+describe("#101 deploy/docker-compose.yml proxy production env", () => {
+  const compose = read("docker-compose.yml");
+  const proxy = extractProxyService(compose);
+
+  test("proxy service runs NODE_ENV=production (precondition for fail-closed)", () => {
+    expect(/NODE_ENV:\s*production/.test(proxy)).toBe(true);
+  });
+
+  test("production proxy supplies a request-signing secret or opts out explicitly", () => {
+    const hasSigningSecret =
+      /STEWARD_PROXY_REQUEST_SIGNING_SECRETS?\s*:/.test(proxy) ||
+      /STEWARD_REQUEST_SIGNING_SECRETS?\s*:/.test(proxy);
+    const optsOutOfSigning = /STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE\s*:\s*["']?false/.test(proxy);
+    expect(hasSigningSecret || optsOutOfSigning).toBe(true);
+  });
+
+  test("production proxy supplies REDIS_URL or opts out of Redis enforcement", () => {
+    const hasRedisUrl = /REDIS_URL\s*:/.test(proxy);
+    const optsOutOfRedis = /STEWARD_ALLOW_PROXY_REDIS_SOFT_FAIL\s*:\s*["']?true/.test(proxy);
+    expect(hasRedisUrl || optsOutOfRedis).toBe(true);
+  });
+
+  test("a redis service is defined when REDIS_URL points at the redis host", () => {
+    if (/REDIS_URL\s*:\s*["']?\S*redis:\/\/redis(:|\b)/.test(proxy)) {
+      expect(/^\s{2}redis:\s*$/m.test(compose)).toBe(true);
+    }
+  });
+});
+
+describe("#101 deploy/DEPLOYMENT.md docs reconciled with fail-closed code", () => {
+  const doc = read("DEPLOYMENT.md");
+
+  test("REDIS_URL is not marked optional in the critical-env table", () => {
+    // Pre-fix row: `| `REDIS_URL` | ... | No |`
+    const optionalRow = /\|\s*`REDIS_URL`\s*\|[^|]*\|\s*No\s*\|/i;
+    expect(optionalRow.test(doc)).toBe(false);
+  });
+
+  test("docs do not claim Redis-absent uses in-memory fallbacks without noting prod fails closed", () => {
+    // The misleading sentence asserts in-memory fallback as the unconditional
+    // behavior. After the fix the surrounding text must mention fail-closed.
+    const claimsFallback = /in-memory fallback/i.test(doc);
+    if (claimsFallback) {
+      expect(/fail(s)?\s*closed/i.test(doc)).toBe(true);
+    }
+  });
+});
+
+describe("#111 deploy/provision-steward-node.sh does not leak secrets", () => {
+  const script = read("provision-steward-node.sh");
+  const lines = script.split("\n");
+
+  const SECRET_VARS = [
+    "STEWARD_MASTER_PASSWORD",
+    "STEWARD_PLATFORM_KEY",
+    "STEWARD_JWT_SECRET",
+    "STEWARD_KDF_SALT",
+    "POSTGRES_PASSWORD",
+    "STEWARD_PROXY_REQUEST_SIGNING_SECRETS",
+    "PLATFORM_KEY",
+  ];
+
+  test('no secret is interpolated inside an ssh / ${SSH_CMD} "..." command argument', () => {
+    // Flag any line that invokes ssh (directly or via ${SSH_CMD}) AND, on the
+    // same line, interpolates a secret var (${VAR} or 'literal=${VAR}'). This
+    // is the heredoc-in-double-quoted-ssh leak from #111. We allow ssh lines
+    // that pipe a file over stdin ( ... < "${LOCAL_ENV_FILE}" ) and lines that
+    // read the secret on the REMOTE side ($(sed ...)/$(grep ...)).
+    const offenders: string[] = [];
+    for (const line of lines) {
+      const isSshLine = /\$\{SSH_CMD\}|(^|\s)ssh\s/.test(line);
+      if (!isSshLine) continue;
+      // Remote-side capture (PK=$(...)) or stdin pipe is fine — skip those.
+      const pipesStdin = /<\s*"?\$\{LOCAL_ENV_FILE\}"?/.test(line);
+      if (pipesStdin) continue;
+      for (const v of SECRET_VARS) {
+        // Local interpolation of the secret on the ssh command line:
+        //   ...${VAR}...  (but NOT the escaped remote form \${VAR})
+        const localInterp = new RegExp(`(^|[^\\\\])\\$\\{${v}(:-[^}]*)?\\}`);
+        if (localInterp.test(line)) {
+          offenders.push(line.trim());
+          break;
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  test("the platform key is never echoed to stdout", () => {
+    // Pre-fix:  echo "  Platform Key:   ${PLATFORM_KEY}"
+    const echoesKey = lines.some(
+      (l) =>
+        /^\s*echo\b/.test(l) &&
+        /\$\{PLATFORM_KEY(:-[^}]*)?\}|\$\{STEWARD_PLATFORM_KEY(:-[^}]*)?\}/.test(l),
+    );
+    expect(echoesKey).toBe(false);
+  });
+
+  test(".env is rendered locally and piped over ssh stdin", () => {
+    // The fixed flow writes a local temp env file and streams it to the node.
+    expect(/LOCAL_ENV_FILE/.test(script)).toBe(true);
+    expect(/<\s*"?\$\{LOCAL_ENV_FILE\}"?/.test(script)).toBe(true);
+  });
+
+  test("rendered .env includes the keys the production image requires", () => {
+    for (const key of [
+      "STEWARD_MASTER_PASSWORD",
+      "STEWARD_JWT_SECRET",
+      "STEWARD_KDF_SALT",
+      "POSTGRES_PASSWORD",
+    ]) {
+      expect(new RegExp(`^${key}=`, "m").test(script)).toBe(true);
+    }
+  });
+});

--- a/packages/proxy/src/__tests__/deploy-artifacts.test.ts
+++ b/packages/proxy/src/__tests__/deploy-artifacts.test.ts
@@ -147,6 +147,14 @@ describe("#111 deploy/provision-steward-node.sh does not leak secrets", () => {
     expect(/<\s*"?\$\{LOCAL_ENV_FILE\}"?/.test(script)).toBe(true);
   });
 
+  test("rsync does not delete an existing remote deploy/.env before secret reuse", () => {
+    expect(/--delete/.test(script)).toBe(true);
+    expect(/--exclude=['"]deploy\/\.env['"]/.test(script)).toBe(true);
+    expect(script.indexOf("--exclude='deploy/.env'")).toBeLessThan(
+      script.indexOf('"${REPO_ROOT}/" "root@${NODE_IP}:${REMOTE_DIR}/"'),
+    );
+  });
+
   test("rendered .env includes the keys the production image requires", () => {
     for (const key of [
       "STEWARD_MASTER_PASSWORD",


### PR DESCRIPTION
Closes #101 and #111. (1) The shipped `docker-compose` proxy ran with `NODE_ENV=production` (which requires Redis + a request-signing secret to not fail closed) but supplied neither, so the gateway rejected 100% of agent traffic dead-on-arrival; adds `REDIS_URL` + the signing secret (+ `POSTGRES_PASSWORD`/`STEWARD_JWT_SECRET`) and reconciles the docs that called `REDIS_URL` optional. (2) `provision-steward-node.sh` interpolated the vault master password + platform admin key into the ssh command line and stdout (visible in `ps` / CI logs) — now piped over stdin, platform key never echoed. Config/docs only; a deploy-artifacts assertion test added; proxy suite (99) green. (Pre-existing CI red unrelated.)