### PR TITLE
fix(api): chain-scope native spend stats so multi-chain spend caps enforce correctly

### DIFF
--- a/packages/api/src/__tests__/transaction-stats-chain-scope.test.ts
+++ b/packages/api/src/__tests__/transaction-stats-chain-scope.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Regression for issue #110: getTransactionStats must NOT conflate native
+ * `value` across chains.
+ *
+ * The `transactions.value` column holds raw per-chain base units (wei for EVM,
+ * lamports / SPL base units for Solana). Summing it across chains and feeding
+ * that single scalar to the spending-limit evaluator caused the cross-chain
+ * total to be re-priced at the CURRENT request chain's native USD price (USD
+ * path) or compared as one unit against a wei cap (wei fallback) — silently
+ * over- or under-counting multi-chain spend caps.
+ *
+ * This drives the REAL getTransactionStats against an in-memory PGLite DB. It
+ * seeds two committed (signed) transactions for one agent on two different
+ * chains, then asserts the spend counters are scoped to the requested chain.
+ *
+ * WITHOUT the fix `getTransactionStats(agentId, chainId)` ignores chainId and
+ * returns the cross-chain sum, so `spentToday`/`spentThisWeek` come back as the
+ * combined total and the chain-A / chain-B assertions FAIL. WITH the fix each
+ * chain's counter is isolated, and the no-arg call still returns the combined
+ * total (display behaviour preserved).
+ */
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { agents, closeDb, getDb, tenants, transactions } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { getTransactionStats } from "../services/context";
+
+const TENANT_ID = `txstats-chain-tenant-${Date.now()}`;
+const AGENT_ID = `txstats-chain-agent-${Date.now()}`;
+const RECIPIENT = "0x1234567890123456789012345678901234567890";
+
+// Two chains whose native base units are NOT comparable in raw form. We use
+// deliberately different magnitudes so a cross-chain sum is obviously wrong:
+//   chain ETH_MAINNET: 3 ETH worth of wei (3e18)
+//   chain SOLANA:      5 SOL worth of lamports (5e9)
+const ETH_MAINNET = 1;
+const SOLANA = 1399811149; // Steward's Solana chain id sentinel; any distinct id works
+const UNRELATED_CHAIN = 137;
+
+const ETH_SPEND = "3000000000000000000"; // 3e18 wei
+const SOL_SPEND = "5000000000"; // 5e9 lamports
+
+async function seedTx(idSuffix: string, chainId: number, value: string) {
+  await getDb()
+    .insert(transactions)
+    .values({
+      id: `${AGENT_ID}-${idSuffix}`,
+      agentId: AGENT_ID,
+      status: "signed",
+      toAddress: RECIPIENT,
+      value,
+      chainId,
+      policyResults: [],
+      signedAt: new Date(),
+    });
+}
+
+describe("getTransactionStats chain scoping (issue #110)", () => {
+  beforeAll(async () => {
+    process.env.STEWARD_PGLITE_MEMORY = "true";
+    process.env.STEWARD_MASTER_PASSWORD ??= "txstats-chain-master-password";
+    const { db, client } = await createPGLiteDb("memory://");
+    setPGLiteOverride(db, async () => {
+      await client.close();
+    });
+
+    await getDb()
+      .insert(tenants)
+      .values({ id: TENANT_ID, name: "TxStats Chain Tenant", apiKeyHash: `hash-${TENANT_ID}` });
+    await getDb().insert(agents).values({
+      id: AGENT_ID,
+      tenantId: TENANT_ID,
+      name: "TxStats Chain Agent",
+      walletAddress: RECIPIENT,
+    });
+
+    // One committed spend on each chain, both inside the rolling day/week window.
+    await seedTx("eth", ETH_MAINNET, ETH_SPEND);
+    await seedTx("sol", SOLANA, SOL_SPEND);
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    delete process.env.STEWARD_PGLITE_MEMORY;
+  });
+
+  it("scopes spentToday/spentThisWeek to the requested chain (EVM)", async () => {
+    const stats = await getTransactionStats(AGENT_ID, ETH_MAINNET);
+    // Must be ONLY the ETH-chain wei, not ETH wei + SOL lamports.
+    expect(stats.spentToday.toString()).toBe(ETH_SPEND);
+    expect(stats.spentThisWeek.toString()).toBe(ETH_SPEND);
+  });
+
+  it("scopes spentToday/spentThisWeek to the requested chain (Solana)", async () => {
+    const stats = await getTransactionStats(AGENT_ID, SOLANA);
+    expect(stats.spentToday.toString()).toBe(SOL_SPEND);
+    expect(stats.spentThisWeek.toString()).toBe(SOL_SPEND);
+  });
+
+  it("returns zero spend for a chain the agent has not transacted on", async () => {
+    const stats = await getTransactionStats(AGENT_ID, UNRELATED_CHAIN);
+    expect(stats.spentToday.toString()).toBe("0");
+    expect(stats.spentThisWeek.toString()).toBe("0");
+  });
+
+  it("preserves the cross-chain total when no chainId is supplied (display path)", async () => {
+    const stats = await getTransactionStats(AGENT_ID);
+    const combined = (BigInt(ETH_SPEND) + BigInt(SOL_SPEND)).toString();
+    expect(stats.spentToday.toString()).toBe(combined);
+    expect(stats.spentThisWeek.toString()).toBe(combined);
+    // Counts remain agent-wide (chain-agnostic) regardless of chain scoping.
+    expect(stats.recentTxCount24h).toBe(2);
+  });
+});

--- a/packages/api/src/__tests__/transaction-stats-chain-scope.test.ts
+++ b/packages/api/src/__tests__/transaction-stats-chain-scope.test.ts
@@ -22,7 +22,17 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { agents, closeDb, getDb, tenants, transactions } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
-import { getTransactionStats } from "../services/context";
+
+// context.ts reads required env and touches the DB at module import time, so
+// install the PGLite override before importing it.
+process.env.STEWARD_PGLITE_MEMORY = "true";
+process.env.STEWARD_MASTER_PASSWORD ??= "txstats-chain-master-password";
+const { db: pgliteDb, client: pgliteClient } = await createPGLiteDb("memory://");
+setPGLiteOverride(pgliteDb, async () => {
+  await pgliteClient.close();
+});
+
+const { getTransactionStats } = await import("../services/context");
 
 const TENANT_ID = `txstats-chain-tenant-${Date.now()}`;
 const AGENT_ID = `txstats-chain-agent-${Date.now()}`;
@@ -56,13 +66,6 @@ async function seedTx(idSuffix: string, chainId: number, value: string) {
 
 describe("getTransactionStats chain scoping (issue #110)", () => {
   beforeAll(async () => {
-    process.env.STEWARD_PGLITE_MEMORY = "true";
-    process.env.STEWARD_MASTER_PASSWORD ??= "txstats-chain-master-password";
-    const { db, client } = await createPGLiteDb("memory://");
-    setPGLiteOverride(db, async () => {
-      await client.close();
-    });
-
     await getDb()
       .insert(tenants)
       .values({ id: TENANT_ID, name: "TxStats Chain Tenant", apiKeyHash: `hash-${TENANT_ID}` });

--- a/packages/api/src/routes/intents.ts
+++ b/packages/api/src/routes/intents.ts
@@ -540,7 +540,7 @@ async function executeTransferIntent(row: typeof intents.$inferSelect) {
   }
 
   return withAgentSpendLock(request.agentId, async () => {
-    const stats = await getTransactionStats(request.agentId);
+    const stats = await getTransactionStats(request.agentId, request.chainId);
     const evaluation = await policyEngine.evaluate(policySet, {
       request,
       recentTxCount1h: stats.recentTxCount1h,
@@ -632,7 +632,7 @@ async function executeSendCallsIntent(row: typeof intents.$inferSelect) {
   }
 
   return withAgentSpendLock(request.agentId, async () => {
-    const stats = await getTransactionStats(request.agentId);
+    const stats = await getTransactionStats(request.agentId, request.chainId);
     let runningSpentToday = BigInt(stats.spentToday);
     let runningSpentThisWeek = BigInt(stats.spentThisWeek);
     const evaluations = [];

--- a/packages/api/src/routes/policies-standalone.ts
+++ b/packages/api/src/routes/policies-standalone.ts
@@ -967,7 +967,9 @@ policiesStandaloneRoutes.post("/simulate", async (c) => {
 
   try {
     const conditionSets = await loadConditionSetsForPolicies(tenantId, rules);
-    const liveStats = hasAgentSelector ? await getTransactionStats(body.agentId as string) : null;
+    const liveStats = hasAgentSelector
+      ? await getTransactionStats(body.agentId as string, (request as { chainId?: number }).chainId)
+      : null;
     const result = await policyEngine.simulate(rules, {
       request: request as any,
       recentTxCount24h: liveStats?.recentTxCount24h ?? 0,

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -1453,7 +1453,7 @@ vaultRoutes.post("/:agentId/sign", async (c) => {
   }
 
   return withAgentSpendLock(agentId, async () => {
-    const stats = await getTransactionStats(agentId);
+    const stats = await getTransactionStats(agentId, signRequest.chainId);
 
     // Authoritative cumulative aggregates (Redis-sourced) for any aggregation
     // policies on this agent. Loaded INSIDE the per-agent spend lock so the
@@ -1883,7 +1883,7 @@ vaultRoutes.post("/:agentId/actions/send-calls", async (c) => {
       );
     }
 
-    const stats = await getTransactionStats(agentId);
+    const stats = await getTransactionStats(agentId, parsed.chainId);
     let runningSpentToday = stats.spentToday;
     let runningSpentThisWeek = stats.spentThisWeek;
     const evaluations = [];
@@ -2243,7 +2243,7 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
       });
     }
 
-    const stats = await getTransactionStats(agentId);
+    const stats = await getTransactionStats(agentId, signRequest.chainId);
     const erc20PrecheckFailure = isTokenTransfer
       ? erc20TransferPolicyPrecheck(policySet, transfer.token)
       : null;
@@ -2824,7 +2824,7 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
         }
       }
       const currentConditionSets = await loadConditionSetsForPolicies(tenantId, currentPolicySet);
-      const stats = await getTransactionStats(agentId);
+      const stats = await getTransactionStats(agentId, approvalSignRequest.chainId);
       const currentEvaluation = await policyEngine.evaluate(currentPolicySet, {
         request: approvalSignRequest,
         recentTxCount1h: stats.recentTxCount1h,
@@ -4208,7 +4208,7 @@ vaultRoutes.post("/:agentId/sign-raw-digest", async (c) => {
   if (rateLimitResult.headers) {
     for (const [key, value] of Object.entries(rateLimitResult.headers)) c.header(key, value);
   }
-  const stats = await getTransactionStats(agentId);
+  const stats = await getTransactionStats(agentId, 0);
   const evaluation = await policyEngine.evaluate(policySet, {
     request: {
       agentId,
@@ -4410,7 +4410,7 @@ vaultRoutes.post("/:agentId/sign-typed-data", async (c) => {
     return c.json<ApiResponse>({ ok: false, error: rlResult.reason || "Rate limit exceeded" }, 429);
   }
 
-  const stats = await getTransactionStats(agentId);
+  const stats = await getTransactionStats(agentId, signRequest.chainId);
 
   const evaluation = await policyEngine.evaluate(policySet, {
     request: signRequest,
@@ -4712,7 +4712,7 @@ vaultRoutes.post("/:agentId/sign-user-operation", async (c) => {
   }
 
   return withAgentSpendLock(agentId, async () => {
-    const stats = await getTransactionStats(agentId);
+    const stats = await getTransactionStats(agentId, signRequest.chainId);
     const evaluation = await policyEngine.evaluate(policySet, {
       request: signRequest,
       recentTxCount1h: stats.recentTxCount1h,
@@ -5034,7 +5034,7 @@ vaultRoutes.post("/:agentId/sign-authorization", async (c) => {
   }
 
   return withAgentSpendLock(agentId, async () => {
-    const stats = await getTransactionStats(agentId);
+    const stats = await getTransactionStats(agentId, signRequest.chainId);
     const evaluation = await policyEngine.evaluate(policySet, {
       request: signRequest,
       recentTxCount1h: stats.recentTxCount1h,
@@ -5267,7 +5267,7 @@ async function signSolanaBlind(
   // Same per-agent advisory spend lock as the parsed path: serialize eval+sign+
   // commit so concurrent blind-sign requests cannot race the spend cap.
   return withAgentSpendLock(agentId, async () => {
-    const stats = await getTransactionStats(agentId);
+    const stats = await getTransactionStats(agentId, signRequest.chainId);
     const evaluation = await policyEngine.evaluate(policySet, {
       request: signRequest,
       recentTxCount1h: stats.recentTxCount1h,

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -5646,7 +5646,7 @@ vaultRoutes.post("/:agentId/sign-solana", async (c) => {
   // both sign — overspending the cap. This mirrors the EVM sign/transfer/
   // user-operation/authorization paths, which all wrap eval+sign under the lock.
   return withAgentSpendLock(agentId, async () => {
-    const stats = await getTransactionStats(agentId);
+    const stats = await getTransactionStats(agentId, signRequest.chainId);
 
     const evaluation = await policyEngine.evaluate(policySet, {
       request: signRequest,

--- a/packages/api/src/services/context.ts
+++ b/packages/api/src/services/context.ts
@@ -650,7 +650,7 @@ export async function loadAggregationsForPolicies(
   return aggregationLookupFromMap(snapshots);
 }
 
-export async function getTransactionStats(agentId: string) {
+export async function getTransactionStats(agentId: string, chainId?: number) {
   const now = new Date();
   const oneHourAgo = new Date(now.getTime() - 3600_000);
   const oneDayAgo = new Date(now.getTime() - 86400_000);
@@ -658,6 +658,16 @@ export async function getTransactionStats(agentId: string) {
 
   const oneHourAgoStr = oneHourAgo.toISOString();
   const oneDayAgoStr = oneDayAgo.toISOString();
+
+  // Spend caps for native value are denominated in a single chain's base unit
+  // (wei for EVM, lamports/SPL base units for Solana). The `value` column holds
+  // raw per-chain base units, so summing across chains and re-pricing the total
+  // at one chain's native price corrupts the cap (issue #110). When a chainId is
+  // supplied, scope the spend aggregates to that chain so the counters stay in a
+  // single consistent unit. When omitted, the fragment is empty and the result
+  // is byte-for-byte the prior cross-chain sum (used by display-only callers).
+  const chainFilter =
+    chainId === undefined ? sql`` : sql` and ${transactions.chainId} = ${chainId}`;
 
   const [stats] = await db
     .select({
@@ -667,14 +677,14 @@ export async function getTransactionStats(agentId: string) {
         coalesce(
           sum(
             case
-              when ${transactions.createdAt} >= ${oneDayAgoStr}::timestamptz then (${transactions.value})::numeric
+              when ${transactions.createdAt} >= ${oneDayAgoStr}::timestamptz${chainFilter} then (${transactions.value})::numeric
               else 0
             end
           ),
           0
         )::text
       `,
-      spentThisWeek: sql<string>`coalesce(sum((${transactions.value})::numeric), 0)::text`,
+      spentThisWeek: sql<string>`coalesce(sum((${transactions.value})::numeric) filter (where true${chainFilter}), 0)::text`,
     })
     .from(transactions)
     .where(


### PR DESCRIPTION
Closes #110. `getTransactionStats` summed `transactions.value` filtered only by agent/status/time — mixing EVM wei (18-dec) and Solana lamports (9-dec) into one scalar that the USD path then re-priced at the *request chain's* native price (e.g. ~$1500 of prior SOL spend valued at ~$0.00003 on a Base tx). So a native daily/weekly cap was silently exceedable via cheap-native revaluation (or over-blocking). Scopes the native spend stats by `chainId`; the no-arg signature is unchanged (backward compatible). Regression test added; spend-cap/dashboard/intents tests green; api typecheck clean. (Pre-existing CI red unrelated.)