### PR TITLE
fix(vault): sign v0 (versioned) Solana transactions

### DIFF
--- a/packages/vault/src/__tests__/solana-v0-signing.test.ts
+++ b/packages/vault/src/__tests__/solana-v0-signing.test.ts
@@ -25,11 +25,19 @@ import {
 const RECENT_BLOCKHASH = new PublicKey(new Uint8Array(32).fill(7)).toBase58();
 
 function v0TransferBytes(from: Keypair, to: PublicKey, lamports: number): Uint8Array {
-  const ix = SystemProgram.transfer({ fromPubkey: from.publicKey, toPubkey: to, lamports });
+  return v0TransferSetBytes(from, [{ to, lamports }]);
+}
+
+function v0TransferSetBytes(
+  from: Keypair,
+  transfers: Array<{ to: PublicKey; lamports: number }>,
+): Uint8Array {
   const msg = new TransactionMessage({
     payerKey: from.publicKey,
     recentBlockhash: RECENT_BLOCKHASH,
-    instructions: [ix],
+    instructions: transfers.map(({ to, lamports }) =>
+      SystemProgram.transfer({ fromPubkey: from.publicKey, toPubkey: to, lamports }),
+    ),
   }).compileToV0Message();
   return new VersionedTransaction(msg).serialize();
 }
@@ -63,17 +71,43 @@ describe("v0 (versioned) Solana signing", () => {
     ).not.toThrow();
   });
 
-  test("assertParsedSolanaTransferMatches rejects a mismatched recipient or amount (v0)", () => {
+  test("assertParsedSolanaTransferMatches rejects a mismatched source, recipient, or amount (v0)", () => {
     const from = Keypair.generate();
     const to = Keypair.generate().publicKey;
     const attacker = Keypair.generate().publicKey;
     const b64 = toBase64(v0TransferBytes(from, to, 5000));
+    expect(() =>
+      assertParsedSolanaTransferMatches(b64, {
+        from: attacker.toBase58(),
+        to: to.toBase58(),
+        lamports: 5000n,
+      }),
+    ).toThrow(/source does not match/i);
     expect(() =>
       assertParsedSolanaTransferMatches(b64, { to: attacker.toBase58(), lamports: 5000n }),
     ).toThrow(/does not match/i);
     expect(() =>
       assertParsedSolanaTransferMatches(b64, { to: to.toBase58(), lamports: 9999n }),
     ).toThrow(/does not match/i);
+  });
+
+  test("assertParsedSolanaTransferMatches rejects v0 transactions with extra recipients", () => {
+    const from = Keypair.generate();
+    const approved = Keypair.generate().publicKey;
+    const attacker = Keypair.generate().publicKey;
+    const b64 = toBase64(
+      v0TransferSetBytes(from, [
+        { to: approved, lamports: 1 },
+        { to: attacker, lamports: 99 },
+      ]),
+    );
+    expect(() =>
+      assertParsedSolanaTransferMatches(b64, {
+        from: from.publicKey.toBase58(),
+        to: approved.toBase58(),
+        lamports: 100n,
+      }),
+    ).toThrow(/single policy-checked transfer/i);
   });
 
   test("the envelope helper also verifies legacy transfers", () => {

--- a/packages/vault/src/__tests__/solana-v0-signing.test.ts
+++ b/packages/vault/src/__tests__/solana-v0-signing.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Regression: v0 (versioned) Solana transactions must be signable.
+ *
+ * The sign-solana policy gate deserializes with VersionedTransaction (handles v0),
+ * but the vault sign path used legacy `Transaction.from()`, which throws on a
+ * versioned message — so every v0 tx (the modern default, mandatory for ALT DeFi
+ * like Jupiter) passed policy then 500'd at signing. The fix branches on the
+ * version byte and verifies the v0 transfer envelope via the version-aware parser
+ * (assertParsedSolanaTransferMatches) since the legacy byte assertion can't read v0.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+  TransactionMessage,
+  VersionedTransaction,
+} from "@solana/web3.js";
+import {
+  assertParsedSolanaTransferMatches,
+  isVersionedTransactionBytes,
+} from "../solana-instructions";
+
+const RECENT_BLOCKHASH = new PublicKey(new Uint8Array(32).fill(7)).toBase58();
+
+function v0TransferBytes(from: Keypair, to: PublicKey, lamports: number): Uint8Array {
+  const ix = SystemProgram.transfer({ fromPubkey: from.publicKey, toPubkey: to, lamports });
+  const msg = new TransactionMessage({
+    payerKey: from.publicKey,
+    recentBlockhash: RECENT_BLOCKHASH,
+    instructions: [ix],
+  }).compileToV0Message();
+  return new VersionedTransaction(msg).serialize();
+}
+
+function toBase64(bytes: Uint8Array): string {
+  return btoa(Array.from(bytes, (b) => String.fromCharCode(b)).join(""));
+}
+
+describe("v0 (versioned) Solana signing", () => {
+  test("a v0 transfer deserializes + signs (legacy Transaction.from throws on it)", () => {
+    const from = Keypair.generate();
+    const to = Keypair.generate().publicKey;
+    const bytes = v0TransferBytes(from, to, 1000);
+
+    // The version detection the sign path branches on (shortvec-aware).
+    expect(isVersionedTransactionBytes(bytes)).toBe(true);
+    // The bug: the legacy deserializer throws on a versioned message.
+    expect(() => Transaction.from(bytes)).toThrow(/Versioned messages/i);
+    // The fix path: deserialize + sign as a VersionedTransaction works.
+    const vtx = VersionedTransaction.deserialize(bytes);
+    vtx.sign([from]);
+    expect(vtx.signatures.some((s) => s.some((b) => b !== 0))).toBe(true);
+  });
+
+  test("assertParsedSolanaTransferMatches accepts a matching v0 transfer", () => {
+    const from = Keypair.generate();
+    const to = Keypair.generate().publicKey;
+    const b64 = toBase64(v0TransferBytes(from, to, 5000));
+    expect(() =>
+      assertParsedSolanaTransferMatches(b64, { to: to.toBase58(), lamports: 5000n }),
+    ).not.toThrow();
+  });
+
+  test("assertParsedSolanaTransferMatches rejects a mismatched recipient or amount (v0)", () => {
+    const from = Keypair.generate();
+    const to = Keypair.generate().publicKey;
+    const attacker = Keypair.generate().publicKey;
+    const b64 = toBase64(v0TransferBytes(from, to, 5000));
+    expect(() =>
+      assertParsedSolanaTransferMatches(b64, { to: attacker.toBase58(), lamports: 5000n }),
+    ).toThrow(/does not match/i);
+    expect(() =>
+      assertParsedSolanaTransferMatches(b64, { to: to.toBase58(), lamports: 9999n }),
+    ).toThrow(/does not match/i);
+  });
+
+  test("the envelope helper also verifies legacy transfers", () => {
+    const from = Keypair.generate();
+    const to = Keypair.generate().publicKey;
+    const tx = new Transaction({ feePayer: from.publicKey, recentBlockhash: RECENT_BLOCKHASH }).add(
+      SystemProgram.transfer({ fromPubkey: from.publicKey, toPubkey: to, lamports: 7000 }),
+    );
+    const bytes = tx.serialize({ requireAllSignatures: false, verifySignatures: false });
+    expect(isVersionedTransactionBytes(bytes)).toBe(false); // legacy
+    expect(() =>
+      assertParsedSolanaTransferMatches(toBase64(bytes), { to: to.toBase58(), lamports: 7000n }),
+    ).not.toThrow();
+  });
+});

--- a/packages/vault/src/solana-instructions.ts
+++ b/packages/vault/src/solana-instructions.ts
@@ -877,3 +877,62 @@ export function detectSolanaPolicyConflicts(
 
   return conflicts;
 }
+
+/**
+ * Version-agnostic transfer-envelope assertion (works for legacy AND v0/versioned
+ * transactions, since the parser deserializes both). Throws unless the serialized
+ * transaction fully parses and its derived (to, value) match the expected policy
+ * envelope. Used by the vault's sign path for v0 transactions, where the legacy
+ * byte-level `assertSolanaTransferTransactionMatches` cannot apply.
+ */
+export function assertParsedSolanaTransferMatches(
+  serialized: string,
+  expected: { to: string; lamports: bigint },
+): void {
+  if (expected.lamports < 0n) {
+    throw new Error("expected Solana transfer lamports must be non-negative");
+  }
+  const summary = parseSolanaTransaction(serialized);
+  if (!summary.fullyParsed) {
+    throw new Error(
+      "Solana transaction is not fully parseable; cannot verify it against the policy envelope",
+    );
+  }
+  const derived = deriveSolanaPolicyFields(summary);
+  const conflicts = detectSolanaPolicyConflicts(derived, {
+    to: expected.to,
+    value: expected.lamports.toString(),
+  });
+  if (conflicts.length > 0) {
+    throw new Error(`Solana transfer does not match the policy envelope: ${conflicts.join("; ")}`);
+  }
+}
+
+/** Read a shortvec / compact-u16 length prefix. Returns the value + bytes consumed. */
+function readCompactU16(bytes: Uint8Array, offset: number): { value: number; bytesRead: number } {
+  let value = 0;
+  let bytesRead = 0;
+  for (;;) {
+    const byte = bytes[offset + bytesRead];
+    if (byte === undefined) break;
+    value |= (byte & 0x7f) << (7 * bytesRead);
+    bytesRead += 1;
+    if ((byte & 0x80) === 0) break;
+  }
+  return { value, bytesRead };
+}
+
+/**
+ * True if a serialized transaction carries a versioned (v0+) message. The wire
+ * format is `[sig_count (shortvec)][sig_count × 64 bytes][message]`, and a
+ * versioned message sets the high bit of its first byte while a legacy message's
+ * first byte (numRequiredSignatures) is < 128. The signature array MUST be skipped
+ * first — the transaction's own leading byte is the signature COUNT, not the
+ * version — so naive `bytes[0] & 0x80` is wrong.
+ */
+export function isVersionedTransactionBytes(bytes: Uint8Array): boolean {
+  if (bytes.length === 0) return false;
+  const { value: sigCount, bytesRead } = readCompactU16(bytes, 0);
+  const firstMessageByte = bytes[bytesRead + sigCount * 64];
+  return firstMessageByte !== undefined && (firstMessageByte & 0x80) !== 0;
+}

--- a/packages/vault/src/solana-instructions.ts
+++ b/packages/vault/src/solana-instructions.ts
@@ -887,7 +887,7 @@ export function detectSolanaPolicyConflicts(
  */
 export function assertParsedSolanaTransferMatches(
   serialized: string,
-  expected: { to: string; lamports: bigint },
+  expected: { from?: string; to: string; lamports: bigint },
 ): void {
   if (expected.lamports < 0n) {
     throw new Error("expected Solana transfer lamports must be non-negative");
@@ -898,13 +898,22 @@ export function assertParsedSolanaTransferMatches(
       "Solana transaction is not fully parseable; cannot verify it against the policy envelope",
     );
   }
-  const derived = deriveSolanaPolicyFields(summary);
-  const conflicts = detectSolanaPolicyConflicts(derived, {
-    to: expected.to,
-    value: expected.lamports.toString(),
-  });
-  if (conflicts.length > 0) {
-    throw new Error(`Solana transfer does not match the policy envelope: ${conflicts.join("; ")}`);
+  if (summary.instructions.length !== 1) {
+    throw new Error("Solana signing only supports a single policy-checked transfer instruction");
+  }
+
+  const [instruction] = summary.instructions;
+  if (instruction.instructionType !== "system:Transfer") {
+    throw new Error("Solana transaction instruction must be a SystemProgram transfer");
+  }
+  if (expected.from && instruction.fields.from !== expected.from) {
+    throw new Error("Solana transfer source does not match the vault wallet");
+  }
+  if (instruction.fields.to !== expected.to) {
+    throw new Error("Solana transfer recipient does not match the policy envelope");
+  }
+  if (BigInt(String(instruction.fields.lamports ?? "0")) !== expected.lamports) {
+    throw new Error("Solana transfer amount does not match the policy envelope");
   }
 }
 

--- a/packages/vault/src/vault.ts
+++ b/packages/vault/src/vault.ts
@@ -52,6 +52,10 @@ import {
   signSolanaMessage,
   signSolanaTransaction,
 } from "./solana";
+import {
+  assertParsedSolanaTransferMatches,
+  isVersionedTransactionBytes,
+} from "./solana-instructions";
 import { getTokenBalances as fetchTokenBalances, type TokenBalance } from "./tokens";
 import {
   ENTRY_POINT_V07,
@@ -1742,28 +1746,55 @@ export class Vault {
     const rpcUrl = this.config.rpcUrl ?? resolveSolanaRpc(chainId);
     const shouldBroadcast = request.broadcast !== false;
 
-    // Deserialize the transaction from base64
-    const { Transaction: SolTransaction, Connection } = await import("@solana/web3.js");
+    // Deserialize the transaction (legacy OR v0/versioned). A versioned message
+    // sets the high bit of its first byte; legacy Transaction.from() throws on it
+    // ("Versioned messages must be deserialized with VersionedMessage..."), so
+    // every v0 tx — the modern default, mandatory for address-lookup-table DeFi
+    // like Jupiter — would 500 at signing after passing the (version-aware)
+    // policy gate. Branch on the version byte so both shapes sign.
+    const {
+      Transaction: SolTransaction,
+      VersionedTransaction,
+      Connection,
+    } = await import("@solana/web3.js");
     const txBytes = Uint8Array.from(atob(request.transaction), (c) => c.charCodeAt(0));
-    const tx = SolTransaction.from(txBytes);
-    if (request.expectedTo !== undefined || request.expectedValue !== undefined) {
+
+    const requireEnvelope = (): { to: string; lamports: bigint } | null => {
+      if (request.expectedTo === undefined && request.expectedValue === undefined) return null;
       if (request.expectedTo === undefined || request.expectedValue === undefined) {
         throw new Error("Solana transaction policy envelope requires expectedTo and expectedValue");
       }
-      assertSolanaTransferTransactionMatches(tx, {
-        from: keypair.publicKey,
-        to: request.expectedTo,
-        lamports: BigInt(request.expectedValue),
-      });
-    }
+      return { to: request.expectedTo, lamports: BigInt(request.expectedValue) };
+    };
 
-    // Sign the transaction
-    tx.partialSign(keypair);
+    let signedBytes: Uint8Array;
+    if (isVersionedTransactionBytes(txBytes)) {
+      const vtx = VersionedTransaction.deserialize(txBytes);
+      const envelope = requireEnvelope();
+      if (envelope) {
+        // The byte-level legacy assertion can't read a v0 message; verify the
+        // envelope via the version-aware parser instead.
+        assertParsedSolanaTransferMatches(request.transaction, envelope);
+      }
+      vtx.sign([keypair]);
+      signedBytes = vtx.serialize();
+    } else {
+      const tx = SolTransaction.from(txBytes);
+      const envelope = requireEnvelope();
+      if (envelope) {
+        assertSolanaTransferTransactionMatches(tx, {
+          from: keypair.publicKey,
+          to: envelope.to,
+          lamports: envelope.lamports,
+        });
+      }
+      tx.partialSign(keypair);
+      signedBytes = tx.serialize();
+    }
 
     if (shouldBroadcast) {
       const connection = new Connection(rpcUrl, "confirmed");
-      const rawTx = tx.serialize();
-      const sig = await connection.sendRawTransaction(rawTx, {
+      const sig = await connection.sendRawTransaction(signedBytes, {
         skipPreflight: false,
         preflightCommitment: "confirmed",
       });
@@ -1783,8 +1814,7 @@ export class Vault {
     }
 
     // Return serialized signed transaction as base64
-    const rawBytes = tx.serialize();
-    const serialized = btoa(Array.from(rawBytes, (b) => String.fromCharCode(b)).join(""));
+    const serialized = btoa(Array.from(signedBytes, (b) => String.fromCharCode(b)).join(""));
     return {
       signature: serialized,
       broadcast: false,

--- a/packages/vault/src/vault.ts
+++ b/packages/vault/src/vault.ts
@@ -1759,12 +1759,16 @@ export class Vault {
     } = await import("@solana/web3.js");
     const txBytes = Uint8Array.from(atob(request.transaction), (c) => c.charCodeAt(0));
 
-    const requireEnvelope = (): { to: string; lamports: bigint } | null => {
+    const requireEnvelope = (): { from: string; to: string; lamports: bigint } | null => {
       if (request.expectedTo === undefined && request.expectedValue === undefined) return null;
       if (request.expectedTo === undefined || request.expectedValue === undefined) {
         throw new Error("Solana transaction policy envelope requires expectedTo and expectedValue");
       }
-      return { to: request.expectedTo, lamports: BigInt(request.expectedValue) };
+      return {
+        from: keypair.publicKey.toBase58(),
+        to: request.expectedTo,
+        lamports: BigInt(request.expectedValue),
+      };
     };
 
     let signedBytes: Uint8Array;


### PR DESCRIPTION
Closes #98. The sign-solana policy gate deserializes with `VersionedTransaction` (handles v0), but the vault sign path used legacy `Transaction.from()`, which throws on a versioned message — so every v0 transaction (the modern default, mandatory for ALT DeFi like Jupiter) passed policy then **500'd at signing**. Branches on a shortvec-aware version detection (the version bit is in the message, *after* the signature array): v0 deserializes via `VersionedTransaction` and verifies its transfer envelope through the version-aware parser (the legacy byte assertion can't read a v0 message); the legacy path is byte-for-byte unchanged. Regression tests added; existing sign-solana + delegated-signer tests green. (Pre-existing CI red unrelated.)