### PR TITLE
fix(auth): bind tenant into magic-link callback URL (fixes elizacloud magic-link sign-in)

### DIFF
--- a/packages/auth/src/__tests__/email.test.ts
+++ b/packages/auth/src/__tests__/email.test.ts
@@ -39,6 +39,39 @@ describe("EmailAuth.sendMagicLink", () => {
     auth.destroy();
   });
 
+  it("binds the tenant into the magic link for non-default tenants (and omits it otherwise)", async () => {
+    const sent = mock(async () => undefined);
+    const templateRenderer = mock(() => ({
+      subject: "subject",
+      text: "text",
+      html: "<p>html</p>",
+    }));
+    const provider: EmailProvider = { send: sent };
+    const auth = new EmailAuth({
+      from: "login@steward.fi",
+      baseUrl: "https://steward.fi",
+      provider,
+      templateId: "elizacloud",
+      tokenTtlMs: 10 * 60 * 1000,
+      templateRenderer,
+    });
+
+    // Non-default tenant: the emailed link must carry ?tenantId so
+    // GET /auth/callback/email resolves the SAME tenant the token was minted
+    // for (otherwise the verify guard fires tenant_mismatch and the exchange
+    // code is stored under the wrong tenant).
+    await auth.sendMagicLink("user@example.com", { tenantId: "elizacloud" });
+    const [, withTenant] = templateRenderer.mock.calls[0]!;
+    expect(withTenant.magicLink).toContain("tenantId=elizacloud");
+
+    // No tenant context: byte-for-byte back-compat — no tenantId param at all.
+    await auth.sendMagicLink("user@example.com");
+    const [, withoutTenant] = templateRenderer.mock.calls[1]!;
+    expect(withoutTenant.magicLink).not.toContain("tenantId");
+
+    auth.destroy();
+  });
+
   it("sends tenant invitation emails with a one-time accept link", async () => {
     const sent = mock(async () => undefined);
     const provider: EmailProvider = { send: sent };

--- a/packages/auth/src/email.ts
+++ b/packages/auth/src/email.ts
@@ -78,10 +78,17 @@ function buildMagicLink(
   callbackPath: string,
   token: string,
   email: string,
+  tenantId?: string,
 ): string {
   const url = new URL(callbackPath, baseUrl);
   url.searchParams.set("token", token);
   url.searchParams.set("email", email);
+  // Carry the tenant so GET /auth/callback/email resolves the SAME tenant the
+  // token was minted for (mirrors buildInvitationLink). Without it the callback
+  // falls back to the default tenant, the verify tenant guard fires
+  // tenant_mismatch, and the issued exchange-code is stored with the wrong
+  // tenant -> the SPA's /oauth/exchange then 401s code_tenant_mismatch.
+  if (tenantId) url.searchParams.set("tenantId", tenantId);
   return url.toString();
 }
 
@@ -178,7 +185,13 @@ export class EmailAuth {
     );
 
     // Build and send the email
-    const magicLink = buildMagicLink(this.baseUrl, this.callbackPath, token, email);
+    const magicLink = buildMagicLink(
+      this.baseUrl,
+      this.callbackPath,
+      token,
+      email,
+      context.tenantId,
+    );
     const rendered = this.templateRenderer(this.templateId, {
       magicLink,
       email,


### PR DESCRIPTION
## What

`buildMagicLink()` (`packages/auth/src/email.ts`) set only `?token` and `?email` on the emailed link, unlike its sibling `buildInvitationLink()` which sets `?tenantId`. This change passes `context.tenantId` through and sets `?tenantId` on the magic link (conditionally, so default-tenant links are byte-for-byte unchanged).

## Why

`GET /auth/callback/email` resolves the tenant from the query: `resolvedTenantId = tenantId || _DEFAULT_TENANT_ID`. With no `tenantId` on the link, a magic link minted for a **non-default** tenant (e.g. `elizacloud`) resolves to the default tenant, which causes two cascading failures:

1. **`tenant_mismatch`** — the verify guard `result.tenantId !== resolvedTenantId` fires (`'elizacloud' !== 'default'`) → `redirect ?error=email_auth_failed&reason=tenant_mismatch`.
2. **`code_tenant_mismatch`** — the one-time exchange code is stored from the same query `tenantId` (`tenantId ?? null` → `null`), but the SPA's `POST /auth/oauth/exchange` replays the real `tenantId='elizacloud'`, and the exchange does strict equality → 401.

Setting `?tenantId` on the link fixes **both** at once: the callback now resolves the correct tenant for the verify guard *and* stores it on the exchange code. Mirrors `buildInvitationLink`. Back-compat: links without a tenant (default tenant) are unchanged; in-flight links already failed `tenant_mismatch` and are not regressed.

## Surfaced while debugging live elizacloud magic-link sign-in — related items for your awareness (NOT in this PR)

These were found in the same investigation; flagging so the full flow can go green. They are **ops/config or follow-ups**, not part of this code change:

- **(ops, the *current* live symptom) magic-link returns `invalid_link`** — on Workers, `initAuthStores(false)` means Redis is the only durable store (`worker.ts`). If `initRedis()` doesn't succeed, magic-link tokens land in an **in-process MemoryBackend per isolate** (`worker.ts` even warns this), so `/email/send` stores the token in isolate A and the click load-balances to isolate B → `tokenStore.consume()` returns null → `invalid_link`. OAuth survives because its nonce store is Redis-backed in prod. **Action: confirm the boot log `[steward:auth] … token store: <source>` reads `redis`, not `memory`, for the elizacloud deployment.** This PR does not address it (and can't — it's deploy config).
- **(ops) redirect mismatch on the email exchange** — `EMAIL_AUTH_REDIRECT_BASE_URL` defaults to `https://www.elizacloud.ai`, but the SPA is served from the **apex** `https://elizacloud.ai` (`www` 308-redirects to apex), so it replays `redirect_uri=https://elizacloud.ai/login` → `code_redirect_mismatch` at `/oauth/exchange` once the tenant fix lands. **Action: set `EMAIL_AUTH_REDIRECT_BASE_URL=https://elizacloud.ai`.**
- **(follow-up, optional) defensive store** — consider storing `resolvedTenantId` (not the raw `tenantId ?? null`) on the email exchange code in `GET /callback/email`, so the stored tenant is correct even if a link arrives without the query param. Note: with this PR's link change, email exchange codes now reach the `method: 'oauth'` guard in `/oauth/exchange` — fine for tenants with OAuth enabled (elizacloud), but worth confirming for email-only tenants.
- **(follow-up, hardening) `TokenStore.store()` is fire-and-forget** (`void this.backend.set(...)`, not awaited in `sendMagicLink`), so `/email/send` can 200 before the write lands. Consider awaiting durable persistence.

The eliza-side return-leg handling (consume `#code=` fragment + surface the real `reason`) is covered in elizaOS/eliza#8281.

Happy to split the ops notes into an issue if you'd prefer — kept them here for traceability.