### PR TITLE
feat(trade): agents can self-manage their OWN trade sessions (unblocks autonomous trading)

### DIFF
--- a/packages/api/src/__tests__/trade-session-gates.test.ts
+++ b/packages/api/src/__tests__/trade-session-gates.test.ts
@@ -29,6 +29,7 @@
 import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
 import {
   agents,
+  agentPolicies,
   agentWallets,
   auditEvents,
   closeDb,
@@ -53,7 +54,14 @@ const SEEDED_SESSION_ID = `ses_seeded_${Date.now()}`;
 
 setDefaultTimeout(30000);
 
-type Posture = "api-key" | "session-no-mfa" | "session-with-mfa";
+type Posture =
+  | "api-key"
+  | "session-no-mfa"
+  | "session-with-mfa"
+  // agent's own bearer, scoped to AGENT_ID — the autonomous self-service path.
+  | "agent-self"
+  // agent bearer scoped to a DIFFERENT agent — must be refused.
+  | "agent-other";
 
 async function makeApp(posture: Posture) {
   const { tradeRoutes } = await import("../routes/trade");
@@ -65,6 +73,15 @@ async function makeApp(posture: Posture) {
     c.set("userId", ACTOR_ID);
     if (posture === "api-key") {
       c.set("authType", "api-key");
+    } else if (posture === "agent-self") {
+      // agent-token scoped to AGENT_ID, no human role/MFA.
+      c.set("authType", "agent-token");
+      c.set("agentScope", AGENT_ID);
+      c.set("tenantRole", undefined);
+    } else if (posture === "agent-other") {
+      c.set("authType", "agent-token");
+      c.set("agentScope", `${AGENT_ID}-someone-else`);
+      c.set("tenantRole", undefined);
     } else {
       c.set("authType", "session-jwt");
       if (posture === "session-with-mfa") c.set("sessionMfaVerifiedAt", Date.now());
@@ -119,6 +136,21 @@ describe("trade session control-plane gates (real routes)", () => {
       chainFamily: "evm",
       venue: "hyperliquid",
       address: VENUE_WALLET,
+    });
+    // Seed a policy so the agent-self happy-path has caps to operate within.
+    // The agent-self path fails closed without a policy (tested separately).
+    await getDb().insert(agentPolicies).values({
+      agentId: AGENT_ID,
+      tenantId: TENANT_ID,
+      dailyCapUsd: "100",
+      perOrderCapUsd: "50",
+      leverageCap: "2",
+      // Include the schema's default allowedAssets so a bare create (which
+      // defaults to [BTC,ETH,BNB]) is not rejected by the asset allowlist.
+      allowedAssets: ["BTC", "ETH", "BNB"],
+      allowedVenues: ["hyperliquid"],
+      updatedBy: ACTOR_ID,
+      updatedReason: "test seed",
     });
     await getDb()
       .insert(tradeSessions)
@@ -251,5 +283,120 @@ describe("trade session control-plane gates (real routes)", () => {
     expect(createdAudit.length).toBe(1);
     expect(createdAudit[0].actorType).toBe("user");
     expect(authorized[0].seq).toBeLessThan(createdAudit[0].seq);
+  });
+
+  // ─── Agent self-service session path (autonomous trading) ──────────────────
+
+  it("create session (agent-self): an agent's own bearer creates its session WITHOUT human MFA", async () => {
+    const res = await post(await makeApp("agent-self"), "/sessions", CREATE_BODY);
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { ok: boolean; data?: { sessionId?: string } };
+    expect(body.ok).toBe(true);
+    expect(typeof body.data?.sessionId).toBe("string");
+  });
+
+  it("create session (agent-other): an agent bearer CANNOT create a session for a different agent", async () => {
+    // agent-other is scoped to a different agentId than the CREATE_BODY target.
+    const res = await post(await makeApp("agent-other"), "/sessions", CREATE_BODY);
+    expect(res.status).toBe(403);
+    expect(await errorOf(res)).toBe(
+      "Forbidden: insufficient access to create a session for this agent",
+    );
+  });
+
+  it("create session (agent-self): requested caps OVER agent policy are still rejected", async () => {
+    // Seed a restrictive policy, then have the agent ask for more than it allows.
+    await getDb()
+      .insert(agentPolicies)
+      .values({
+        agentId: AGENT_ID,
+        tenantId: TENANT_ID,
+        dailyCapUsd: "100",
+        perOrderCapUsd: "50",
+        leverageCap: "2",
+        allowedAssets: ["BTC"],
+        allowedVenues: ["hyperliquid"],
+        updatedBy: ACTOR_ID,
+        updatedReason: "test seed",
+      })
+      .onConflictDoNothing();
+    // 40_000 is within the schema max (50_000) but far over the seeded
+    // agent policy dailyCap (100), so it must be rejected by the POLICY clamp,
+    // not the schema. perOrderCap kept under dailyCap to avoid the ordering check.
+    const res = await post(await makeApp("agent-self"), "/sessions", {
+      agentId: AGENT_ID,
+      venue: "hyperliquid" as const,
+      dailyCap: 40_000,
+      perOrderCap: 50,
+    });
+    expect(res.status).toBe(400);
+    // The policy clamp returns a { code: "policy-violation", message } shape.
+    const body = (await res.json()) as { code?: string; message?: string };
+    expect(body.code).toBe("policy-violation");
+    expect(body.message).toContain("exceeds agent policy cap");
+  });
+
+  it("get session (agent-self): an agent reads its OWN session without human MFA", async () => {
+    const res = await (await makeApp("agent-self")).request(
+      `/v1/trade/sessions/${SEEDED_SESSION_ID}`,
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("create session (agent-self): an agent with NO policy is refused (fail-closed)", async () => {
+    const noPolicyAgent = `${AGENT_ID}-nopolicy`;
+    await getDb().insert(agents).values({
+      id: noPolicyAgent,
+      tenantId: TENANT_ID,
+      name: "No Policy Agent",
+      walletAddress: "0x0000000000000000000000000000000000000002",
+    });
+    await getDb().insert(agentWallets).values({
+      agentId: noPolicyAgent,
+      chainFamily: "evm",
+      venue: "hyperliquid",
+      address: "0x00000000000000000000000000000000000000bb",
+    });
+    const app = new Hono<{ Variables: AppVariables }>();
+    app.use("*", async (c, next) => {
+      c.set("tenantId", TENANT_ID);
+      c.set("authType", "agent-token");
+      c.set("agentScope", noPolicyAgent);
+      c.set("tenantRole", undefined);
+      await next();
+    });
+    const { tradeRoutes } = await import("../routes/trade");
+    app.route("/v1/trade", tradeRoutes);
+    const res = await app.request("/v1/trade/sessions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ agentId: noPolicyAgent, venue: "hyperliquid" }),
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { code?: string; message?: string };
+    expect(body.message).toContain("no trade policy");
+  });
+
+  it("revoke session (agent-self): an agent revokes its OWN session without human MFA", async () => {
+    // Seed a dedicated session so this revoke does not disturb SEEDED_SESSION_ID.
+    const ownSession = `ses_agent_self_${Date.now()}`;
+    await getDb()
+      .insert(tradeSessions)
+      .values({
+        id: ownSession,
+        tenantId: TENANT_ID,
+        agentId: AGENT_ID,
+        venue: "hyperliquid",
+        walletId: VENUE_WALLET,
+        status: "active",
+        dailySpendUsd: "0",
+        dailyCapUsd: "100",
+        perOrderCapUsd: "50",
+        leverageCap: "2",
+        allowedAssets: ["BTC"],
+        expiresAt: new Date(Date.now() + 60_000),
+      });
+    const res = await post(await makeApp("agent-self"), `/sessions/${ownSession}/revoke`, {});
+    expect(res.status).toBe(200);
   });
 });

--- a/packages/api/src/__tests__/trade-session-gates.test.ts
+++ b/packages/api/src/__tests__/trade-session-gates.test.ts
@@ -28,8 +28,8 @@
  */
 import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
 import {
-  agents,
   agentPolicies,
+  agents,
   agentWallets,
   auditEvents,
   closeDb,
@@ -139,19 +139,21 @@ describe("trade session control-plane gates (real routes)", () => {
     });
     // Seed a policy so the agent-self happy-path has caps to operate within.
     // The agent-self path fails closed without a policy (tested separately).
-    await getDb().insert(agentPolicies).values({
-      agentId: AGENT_ID,
-      tenantId: TENANT_ID,
-      dailyCapUsd: "100",
-      perOrderCapUsd: "50",
-      leverageCap: "2",
-      // Include the schema's default allowedAssets so a bare create (which
-      // defaults to [BTC,ETH,BNB]) is not rejected by the asset allowlist.
-      allowedAssets: ["BTC", "ETH", "BNB"],
-      allowedVenues: ["hyperliquid"],
-      updatedBy: ACTOR_ID,
-      updatedReason: "test seed",
-    });
+    await getDb()
+      .insert(agentPolicies)
+      .values({
+        agentId: AGENT_ID,
+        tenantId: TENANT_ID,
+        dailyCapUsd: "100",
+        perOrderCapUsd: "50",
+        leverageCap: "2",
+        // Include the schema's default allowedAssets so a bare create (which
+        // defaults to [BTC,ETH,BNB]) is not rejected by the asset allowlist.
+        allowedAssets: ["BTC", "ETH", "BNB"],
+        allowedVenues: ["hyperliquid"],
+        updatedBy: ACTOR_ID,
+        updatedReason: "test seed",
+      });
     await getDb()
       .insert(tradeSessions)
       .values({

--- a/packages/api/src/routes/trade.ts
+++ b/packages/api/src/routes/trade.ts
@@ -124,6 +124,23 @@ function canManageTradeSession(c: Context<{ Variables: AppVariables }>): boolean
   );
 }
 
+// An agent's own bearer (authType "agent-token", carrying agentScope) may
+// open/read/revoke a trade session FOR ITSELF only. This is the autonomous-agent
+// path: the order route already accepts agent-token, and session creation
+// already clamps every requested cap to the agent's stored agent_policies
+// ceilings (reject-if-over, then Math.min, plus asset/venue allowlist), so an
+// agent self-session can never exceed the caps a human set out-of-band in
+// agent_policies. Cross-agent management still requires a human owner/admin
+// session. No withdraw surface is touched here.
+function canAgentSelfManageSession(
+  c: Context<{ Variables: AppVariables }>,
+  targetAgentId: string | null | undefined,
+): boolean {
+  if (c.get("authType") !== "agent-token") return false;
+  const scoped = callerAgentId(c);
+  return Boolean(scoped) && scoped === targetAgentId;
+}
+
 function responseData<T>(data: T): ApiResponse<T> {
   return { ok: true, data };
 }
@@ -306,13 +323,18 @@ tradeRoutes.post("/sessions", async (c) => {
   if (!agentId) {
     return c.json<ApiResponse>({ ok: false, error: "Agent id required" }, 400);
   }
-  if (!canManageTradeSession(c)) {
+  const createByHumanAdmin = canManageTradeSession(c);
+  const createByAgentSelf = canAgentSelfManageSession(c, agentId);
+  if (!createByHumanAdmin && !createByAgentSelf) {
     return c.json<ApiResponse>(
       { ok: false, error: "Forbidden: insufficient access to create a session for this agent" },
       403,
     );
   }
-  if (!c.get("sessionMfaVerifiedAt")) {
+  // MFA recency is a human-session protection. The agent-self path has no human
+  // session to MFA; its protection is the agent_policies cap clamp below + the
+  // per-order policy evaluation on submission. Only enforce MFA on the human path.
+  if (createByHumanAdmin && !c.get("sessionMfaVerifiedAt")) {
     return c.json<ApiResponse>(
       { ok: false, error: "Trade session management requires recent MFA verification" },
       403,
@@ -337,6 +359,19 @@ tradeRoutes.post("/sessions", async (c) => {
     .select()
     .from(agentPolicies)
     .where(eq(agentPolicies.agentId, agentId));
+
+  // Fail-closed for the autonomous agent-self path: an agent may only open a
+  // session if a human has set an agent_policies row defining its ceilings.
+  // Without a policy there is nothing to clamp against, so a policy-less agent
+  // could otherwise self-grant caps up to the schema maximums. A human
+  // owner/admin may still create sessions for a policy-less agent (a deliberate
+  // human act); an agent cannot self-authorize without an explicit policy.
+  if (createByAgentSelf && !createByHumanAdmin && !agentPolicy) {
+    return c.json(
+      policyViolation("agent has no trade policy; a human must set agent caps before self-service trading"),
+      403,
+    );
+  }
 
   let sessionDailyCap = dailyCap;
   let sessionPerOrderCap = perOrderCap;
@@ -463,13 +498,15 @@ tradeRoutes.get("/sessions/:id", async (c) => {
   const tenantId = c.get("tenantId");
   const session = await getSessionManager().getSession({ tenantId, id: c.req.param("id") });
   if (!session) return c.json<ApiResponse>({ ok: false, error: "Session not found" }, 404);
-  if (!canManageTradeSession(c)) {
+  const readByHumanAdmin = canManageTradeSession(c);
+  const readByAgentSelf = canAgentSelfManageSession(c, session.agentId);
+  if (!readByHumanAdmin && !readByAgentSelf) {
     return c.json<ApiResponse>(
       { ok: false, error: "Forbidden: insufficient access to this session" },
       403,
     );
   }
-  if (!c.get("sessionMfaVerifiedAt")) {
+  if (readByHumanAdmin && !c.get("sessionMfaVerifiedAt")) {
     return c.json<ApiResponse>(
       { ok: false, error: "Trade session management requires recent MFA verification" },
       403,
@@ -496,13 +533,18 @@ tradeRoutes.get("/sessions/:id", async (c) => {
 tradeRoutes.post("/sessions/:id/revoke", async (c) => {
   const tenantId = c.get("tenantId");
   const existing = await getSessionManager().getSession({ tenantId, id: c.req.param("id") });
-  if (!canManageTradeSession(c)) {
+  const revokeByHumanAdmin = canManageTradeSession(c);
+  // Agent-self may revoke only its OWN existing session. If the session is
+  // missing we fall through to the human-admin requirement (no agent-self bypass
+  // on a non-existent/again-another-agent session).
+  const revokeByAgentSelf = Boolean(existing) && canAgentSelfManageSession(c, existing?.agentId);
+  if (!revokeByHumanAdmin && !revokeByAgentSelf) {
     return c.json<ApiResponse>(
       { ok: false, error: "Forbidden: insufficient access to revoke this session" },
       403,
     );
   }
-  if (!c.get("sessionMfaVerifiedAt")) {
+  if (revokeByHumanAdmin && !c.get("sessionMfaVerifiedAt")) {
     return c.json<ApiResponse>(
       { ok: false, error: "Trade session management requires recent MFA verification" },
       403,

--- a/packages/api/src/routes/trade.ts
+++ b/packages/api/src/routes/trade.ts
@@ -368,7 +368,9 @@ tradeRoutes.post("/sessions", async (c) => {
   // human act); an agent cannot self-authorize without an explicit policy.
   if (createByAgentSelf && !createByHumanAdmin && !agentPolicy) {
     return c.json(
-      policyViolation("agent has no trade policy; a human must set agent caps before self-service trading"),
+      policyViolation(
+        "agent has no trade policy; a human must set agent caps before self-service trading",
+      ),
       403,
     );
   }


### PR DESCRIPTION
## Why
The trade-session control plane gated create/get/revoke on a **human owner/admin session-jwt**. The order route already accepts an `agent-token`, so an agent could submit orders but could never **open** the session it needs → autonomous agent trading is blocked. (Same 403 auth-scope wall the agent-container restart hits: Steward gates agent-automation behind human-owner sessions.)

This is the `B` fix from the trading-rail unblock: make the rail actually usable by the agent.

## What
Allow `authType === "agent-token"` to create/read/revoke a trade session **for its OWN agentScope only**.

## Why it's safe (intentional, minimal blast radius)
- Session creation **already clamps** every requested cap to the agent's stored `agent_policies` ceilings (reject-if-over → Math.min → asset/venue allowlist). An agent self-session can never exceed caps a human set out-of-band.
- Order submission **already** runs `evaluateTradeOrder` against those same policies.
- **FAIL-CLOSED:** the agent-self path **requires** an `agent_policies` row. A policy-less agent cannot self-authorize (would otherwise default to schema-max caps). A human owner/admin can still create sessions for a policy-less agent.
- **MFA** recency is a human-session protection → now scoped to the human path only (the agent path has no human to MFA; its protection is the policy clamp).
- **Cross-agent** management still requires a human owner/admin session (`canAccessAgent`).
- **No withdraw surface touched.**

## Tests
- `trade-session-gates.test.ts`: **10/10** — agent-self create/get/revoke pass WITHOUT MFA; agent-other → 403; over-policy caps → rejected; **no-policy → 403 fail-closed**; all original human-path tests unchanged (api-key denied, no-MFA denied, owner+MFA audit attribution).
- **30/30** across all 5 trade/session suites, zero regressions.

## Deploy note
After review + merge: deploy steward-api on Railway from develop, verify version bump + an agent-token `POST /v1/trade/sessions` returns 201. THEN Sol can open sessions + trade autonomously.

⚠️ Auth-boundary + money-rail change — **NOT auto-merged.** Shadow reviews. Design doc: `~/.moltbot/projects/sol-trading/AGENT-SELF-SESSION-DESIGN-2026-06-10.md`.

🤖 Sol.

Co-authored-by: wakesync <shadow@shad0w.xyz>