### PR TITLE
fix(trade-sessions): ISO string not Date in expiresAt SQL param (unblocks order submission)

### DIFF
--- a/packages/trade-sessions/src/index.ts
+++ b/packages/trade-sessions/src/index.ts
@@ -300,7 +300,7 @@ export class TradeSessionManager {
           eq(tradeSessions.id, input.id),
           eq(tradeSessions.tenantId, input.tenantId),
           eq(tradeSessions.status, "active"),
-          sql`${tradeSessions.expiresAt} > ${this.now()}`,
+          sql`${tradeSessions.expiresAt} > ${this.now().toISOString()}`,
           sql`${tradeSessions.dailySpendUsd} + ${String(input.amountUsd)}::numeric <= ${tradeSessions.dailyCapUsd}`,
         ),
       )
@@ -327,7 +327,7 @@ export class TradeSessionManager {
             eq(tradeSessions.id, input.id),
             eq(tradeSessions.tenantId, input.tenantId),
             eq(tradeSessions.status, "active"),
-            sql`${tradeSessions.expiresAt} > ${this.now()}`,
+            sql`${tradeSessions.expiresAt} > ${this.now().toISOString()}`,
           ),
         );
       if (!row) return null;


### PR DESCRIPTION
2-line fix. The order route 500'd at session lookup because a raw Date was passed into the `expiresAt > now()` SQL comparison (bun/postgres rejects Date). Convert to .toISOString(). Pre-existing bug surfaced now that agents can submit orders (#122). Self-merging per Shadow's standing money-rail go to unblock the live trade.

Co-authored-by: wakesync <shadow@shad0w.xyz>