### PR TITLE
fix(trade): honor caller limitPx on sells

### DIFF
--- a/packages/api/src/__tests__/trade-policy-audit.test.ts
+++ b/packages/api/src/__tests__/trade-policy-audit.test.ts
@@ -192,7 +192,7 @@ describe("trade policy audit", () => {
     });
   });
 
-  it("uses live mids for sell-order notional so low limits cannot bypass caps", async () => {
+  it("honors explicit sell limitPx for policy notional instead of forcing marketable price", async () => {
     const tenantId = `tenant-trade-notional-${Date.now()}`;
     const agentId = `agent-trade-notional-${Date.now()}`;
     const sessionId = `ses_${crypto.randomUUID()}`;
@@ -229,10 +229,7 @@ describe("trade policy audit", () => {
       });
 
     globalThis.fetch = mock(async () => {
-      return new Response(JSON.stringify({ BTC: "60000", ETH: "3000" }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      });
+      throw new Error("explicit sell limitPx should not fetch a marketable price");
     }) as unknown as typeof fetch;
 
     process.env.STEWARD_MASTER_PASSWORD ??= "test-master-password";
@@ -260,7 +257,7 @@ describe("trade policy audit", () => {
         asset: "BTC",
         side: "sell",
         size: 1,
-        limitPx: 1,
+        limitPx: 60,
         leverage: 1,
       }),
     });
@@ -268,7 +265,7 @@ describe("trade policy audit", () => {
     expect(res.status).toBe(400);
     expect(await res.json()).toEqual({
       code: "policy-violation",
-      reason: "per-order-cap: order $60000 exceeds cap $50",
+      reason: "per-order-cap: order $60 exceeds cap $50",
     });
   });
 

--- a/packages/api/src/__tests__/trade-resolve-policy-limit-px.test.ts
+++ b/packages/api/src/__tests__/trade-resolve-policy-limit-px.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  mock.restore();
+  globalThis.fetch = originalFetch;
+});
+
+describe("resolvePolicyLimitPx", () => {
+  it("returns an explicit sell limitPx untouched", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error("explicit sell limitPx should not fetch a marketable price");
+    }) as unknown as typeof fetch;
+
+    const { resolvePolicyLimitPx } = await import("../routes/trade");
+
+    await expect(resolvePolicyLimitPx("BTC", "sell", "65000.5")).resolves.toBe("65000.5");
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("uses a marketable sell price when sell limitPx is omitted", async () => {
+    globalThis.fetch = mock(async () => {
+      return new Response(JSON.stringify({ levels: [[{ px: "60000" }], [{ px: "60100" }]] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    const { resolvePolicyLimitPx } = await import("../routes/trade");
+
+    await expect(resolvePolicyLimitPx("BTC", "sell", undefined)).resolves.toBe("59700");
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps buy behavior unchanged", async () => {
+    globalThis.fetch = mock(async () => {
+      return new Response(JSON.stringify({ levels: [[{ px: "60000" }], [{ px: "60100" }]] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    const { resolvePolicyLimitPx } = await import("../routes/trade");
+
+    await expect(resolvePolicyLimitPx("BTC", "buy", 61000)).resolves.toBe(61000);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    await expect(resolvePolicyLimitPx("BTC", "buy", undefined)).resolves.toBe("60401");
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/api/src/routes/trade.ts
+++ b/packages/api/src/routes/trade.ts
@@ -260,14 +260,14 @@ function getIdempotency(
   };
 }
 
-async function resolvePolicyLimitPx(
+export async function resolvePolicyLimitPx(
   asset: z.infer<typeof hyperliquidAssetSchema>,
   side: "buy" | "sell",
   limitPx: string | number | undefined,
 ): Promise<string | number> {
-  if (side !== "sell") return limitPx ?? (await getMarketableLimitPx(asset, true));
+  if (limitPx !== undefined) return limitPx;
   try {
-    return await getMarketableLimitPx(asset, false);
+    return await getMarketableLimitPx(asset, side === "buy");
   } catch (error) {
     const response = await fetch("https://api.hyperliquid.xyz/info");
     const prices = (await response.json()) as Record<string, unknown>;


### PR DESCRIPTION
## Summary

Fixes a critical trade-route bug where explicit sell `limitPx` values were ignored during policy/order price resolution. Before this change, `resolvePolicyLimitPx` always replaced sells with `getMarketableLimitPx(asset, false)`, which meant a caller could not place a resting limit sell or take-profit sell, even when they supplied an explicit price. Every sell was forced toward marketability.

This bug caused a real trading loss on 2026-06-10, estimated at about $550, because a sell intended to rest was resolved as marketable instead.

## Fix

- Honor caller-supplied `limitPx` for both buys and sells.
- Preserve the existing marketable-price fallback when `limitPx` is omitted.
- Preserve the existing live-price fallback when `limitPx` is omitted and `getMarketableLimitPx(...)` throws.
- Preserve `string | number` typing for explicit caller prices.

## Tests

Added/updated tests proving:

- Explicit sell `limitPx` is returned untouched and does not fetch a marketable price.
- Sell without `limitPx` still falls back to a marketable sell price.
- Buy behavior is unchanged, including explicit buy prices and omitted-price marketable fallback.
- The trade route policy audit now verifies explicit sell prices are honored for policy notional instead of being replaced with marketable prices.

Local test run:

```sh
bun test --timeout 30000 packages/api/src/__tests__/trade-*.test.ts packages/api/src/__tests__/vault-trade-audit-gates.test.ts
```

Result: 36 pass, 0 fail.

## Review notes

Ran `codex review --uncommitted`. Codex flagged that using explicit sell limits for policy notional can under-estimate notional for marketable low-limit sells. This PR intentionally implements the requested semantics so resting sell/take-profit orders are possible again; the explicit limit is honored, and omitted prices still use marketable fallback.
