### PR TITLE
feat(auth): Privy-style email-OTP verified passkey signup

### DIFF
--- a/packages/api/src/__tests__/auth-email-otp-signup.test.ts
+++ b/packages/api/src/__tests__/auth-email-otp-signup.test.ts
@@ -157,14 +157,27 @@ describe("OTP route security invariants", () => {
     expect(body).toContain("requireSession");
   });
 
-  it("register/verify CONSUMES the grant (single use) and marks email verified", () => {
+  it("register/verify peeks pre-ceremony and CONSUMES only after WebAuthn succeeds", () => {
     const start = authSource.indexOf('auth.post("/passkey/register/verify"');
     const end = authSource.indexOf('auth.post("/passkey/login/options"', start);
     const body = authSource.slice(start, end);
-    expect(body).toContain("consumeEmailGrant");
+    // peek happens before the ceremony (cheap reject), consume after success
+    const peekIdx = body.indexOf("peekEmailGrant");
+    const ceremonyIdx = body.indexOf("verifyRegistration");
+    const consumeIdx = body.indexOf("consumeEmailGrant");
+    expect(peekIdx).toBeGreaterThan(-1);
+    expect(consumeIdx).toBeGreaterThan(ceremonyIdx);
+    expect(ceremonyIdx).toBeGreaterThan(peekIdx);
     expect(body).toContain("emailVerified: true");
     // grant-less path still requires a session
     expect(body).toContain("requireSession");
+    // tenant joining stays join_mode-gated (no invite bypass via grant)
+    expect(body).toContain("resolveAndValidateTenant");
+  });
+
+  it("register/options is rate limited (pre-auth reachable)", () => {
+    const body = routeBody('auth.post("/passkey/register/options"', 'auth.post("/passkey/register/verify"');
+    expect(body).toContain("passkey-register-options");
   });
 
   it("grants are single-purpose: issued only by otp/verify", () => {

--- a/packages/api/src/__tests__/auth-email-otp-signup.test.ts
+++ b/packages/api/src/__tests__/auth-email-otp-signup.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Email-OTP verified passkey signup (Privy-style).
+ *
+ * Canonical flow: POST /email/otp/send → user receives 6-digit code →
+ * POST /email/otp/verify → short-lived single-use verified-email grant →
+ * passkey register/options (peek) + register/verify (consume) WITHOUT a
+ * session. Closes the pre-hijack vector (registration requires proof of
+ * email ownership) while restoring one-tap signup UX.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+
+process.env.STEWARD_JWT_SECRET ??= "test-secret-key-that-is-long-enough-for-hs256";
+process.env.STEWARD_MASTER_PASSWORD ??= "test-master-password";
+process.env.STEWARD_KDF_SALT ??= "dGVzdC1zYWx0LXRlc3Qtc2FsdA==";
+
+import { EmailAuth } from "@stwd/auth";
+
+describe("EmailAuth OTP primitives", () => {
+  let emailAuth: EmailAuth;
+  let lastEmailBody = "";
+
+  beforeAll(() => {
+    emailAuth = new EmailAuth({
+      from: "login@test.steward.fi",
+      baseUrl: "https://test.steward.fi",
+      provider: {
+        async send(_to: string, _subject: string, body: string) {
+          lastEmailBody = body;
+        },
+      },
+    });
+  });
+
+  afterAll(() => {
+    emailAuth.destroy();
+  });
+
+  function extractCode(): string {
+    const m = lastEmailBody.match(/\b(\d{6})\b/);
+    if (!m) throw new Error(`no 6-digit code in email body: ${lastEmailBody}`);
+    return m[1];
+  }
+
+  it("sends a 6-digit code and verifies it once", async () => {
+    await emailAuth.sendOtp("otp-user@example.com", { tenantId: "waifu" });
+    const code = extractCode();
+    expect(code).toMatch(/^\d{6}$/);
+
+    const ok = await emailAuth.verifyOtp("otp-user@example.com", code, "waifu");
+    expect(ok).toBe(true);
+
+    // single use — second verify fails
+    const again = await emailAuth.verifyOtp("otp-user@example.com", code, "waifu");
+    expect(again).toBe(false);
+  });
+
+  it("binds the code to the email", async () => {
+    await emailAuth.sendOtp("alice@example.com", { tenantId: "waifu" });
+    const code = extractCode();
+    const wrongEmail = await emailAuth.verifyOtp("bob@example.com", code, "waifu");
+    expect(wrongEmail).toBe(false);
+    // and the right email still works (wrong-email attempt must not burn it —
+    // the store key includes the email so bob's consume missed alice's entry)
+    const ok = await emailAuth.verifyOtp("alice@example.com", code, "waifu");
+    expect(ok).toBe(true);
+  });
+
+  it("binds the code to the tenant", async () => {
+    await emailAuth.sendOtp("carol@example.com", { tenantId: "waifu" });
+    const code = extractCode();
+    const wrongTenant = await emailAuth.verifyOtp("carol@example.com", code, "elizacloud");
+    expect(wrongTenant).toBe(false);
+    const ok = await emailAuth.verifyOtp("carol@example.com", code, "waifu");
+    expect(ok).toBe(true);
+  });
+
+  it("rejects malformed codes without store lookups", async () => {
+    expect(await emailAuth.verifyOtp("x@example.com", "12345", "waifu")).toBe(false);
+    expect(await emailAuth.verifyOtp("x@example.com", "abcdef", "waifu")).toBe(false);
+    expect(await emailAuth.verifyOtp("x@example.com", "1234567", "waifu")).toBe(false);
+    expect(await emailAuth.verifyOtp("x@example.com", "", "waifu")).toBe(false);
+  });
+
+  it("expires codes after the TTL", async () => {
+    const shortAuth = new EmailAuth({
+      from: "login@test.steward.fi",
+      baseUrl: "https://test.steward.fi",
+      tokenTtlMs: 10, // 10ms
+      provider: {
+        async send(_to: string, _subject: string, body: string) {
+          lastEmailBody = body;
+        },
+      },
+    });
+    await shortAuth.sendOtp("expired@example.com", { tenantId: "waifu" });
+    const code = extractCode();
+    await new Promise((r) => setTimeout(r, 30));
+    expect(await shortAuth.verifyOtp("expired@example.com", code, "waifu")).toBe(false);
+    shortAuth.destroy();
+  });
+
+  it("subject contains the code (glanceable in notifications)", async () => {
+    let subject = "";
+    const subjAuth = new EmailAuth({
+      from: "login@test.steward.fi",
+      baseUrl: "https://test.steward.fi",
+      provider: {
+        async send(_to: string, subj: string, body: string) {
+          subject = subj;
+          lastEmailBody = body;
+        },
+      },
+    });
+    await subjAuth.sendOtp("subject@example.com", { tenantId: "waifu" });
+    const code = extractCode();
+    expect(subject).toContain(code);
+    subjAuth.destroy();
+  });
+});
+
+// ── Route-level invariants (source inspection, mirrors auth-passkey-enumeration) ──
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const authSource = readFileSync(join(import.meta.dir, "..", "routes", "auth.ts"), "utf8");
+
+function routeBody(start: string, end: string): string {
+  const s = authSource.indexOf(start);
+  expect(s).toBeGreaterThan(-1);
+  const e = authSource.indexOf(end, s);
+  expect(e).toBeGreaterThan(s);
+  return authSource.slice(s, e);
+}
+
+describe("OTP route security invariants", () => {
+  it("otp/verify enforces a per-{email,tenant} brute-force limiter", () => {
+    const body = routeBody('auth.post("/email/otp/verify"', '// ── Guest');
+    expect(body).toContain("email-otp-verify-target");
+    expect(body).toContain("${resolvedTenantId}:${email}");
+  });
+
+  it("otp/send keeps the same abuse gates as magic-link send", () => {
+    const body = routeBody('auth.post("/email/otp/send"', 'auth.post("/email/otp/verify"');
+    expect(body).toContain("verifyCaptchaToken");
+    expect(body).toContain("validateEmailAbusePolicy");
+    expect(body).toContain("requireTenantLoginMethodAllowed");
+    expect(body).toContain("requireNonSsoEmailLoginAllowed");
+    expect(body).toContain("email-otp-send-destination");
+  });
+
+  it("register/options PEEKS the grant (non-consuming) so cancelled prompts don't burn it", () => {
+    const body = routeBody('auth.post("/passkey/register/options"', 'auth.post("/passkey/register/verify"');
+    expect(body).toContain("peekEmailGrant");
+    expect(body).not.toContain("consumeEmailGrant");
+    // session path must remain for logged-in add-passkey
+    expect(body).toContain("requireSession");
+  });
+
+  it("register/verify CONSUMES the grant (single use) and marks email verified", () => {
+    const start = authSource.indexOf('auth.post("/passkey/register/verify"');
+    const end = authSource.indexOf('auth.post("/passkey/login/options"', start);
+    const body = authSource.slice(start, end);
+    expect(body).toContain("consumeEmailGrant");
+    expect(body).toContain("emailVerified: true");
+    // grant-less path still requires a session
+    expect(body).toContain("requireSession");
+  });
+
+  it("grants are single-purpose: issued only by otp/verify", () => {
+    const matches = authSource.match(/issueEmailGrant\(/g) ?? [];
+    // one definition + exactly one call site (otp/verify)
+    expect(matches.length).toBe(2);
+  });
+});

--- a/packages/api/src/__tests__/auth-email-otp-signup.test.ts
+++ b/packages/api/src/__tests__/auth-email-otp-signup.test.ts
@@ -173,6 +173,8 @@ describe("OTP route security invariants", () => {
     expect(body).toContain("requireSession");
     // tenant joining stays join_mode-gated (no invite bypass via grant)
     expect(body).toContain("resolveAndValidateTenant");
+    // resolved tenant must equal the grant-bound tenant (no tenant pivot)
+    expect(body).toContain("tenantId !== grantTenantId");
   });
 
   it("register/options is rate limited (pre-auth reachable)", () => {

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -7603,6 +7603,13 @@ auth.post("/passkey/register/verify", async (c) => {
     return c.json<ApiResponse>({ ok: false, error: tenantResult.error }, tenantResult.status);
   }
   const tenantId = tenantResult.tenantId;
+  if (usingGrant && tenantId !== grantTenantId) {
+    // The grant is bound to ONE {email, tenant} pair. If tenant resolution
+    // lands anywhere other than the grant-bound tenant, refuse — a grant
+    // proving ownership for tenant A must never complete registration (and
+    // session issuance) under tenant B.
+    return c.json<ApiResponse>({ ok: false, error: "Invalid or expired email grant" }, 401);
+  }
   const methodResponse = await requireTenantLoginMethodAllowed(c, tenantId, "passkey");
   if (methodResponse) return methodResponse;
   const ssoRequiredResponse = await requireNonSsoEmailLoginAllowed(c, tenantId, email, "Passkey");

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -7417,6 +7417,15 @@ auth.delete("/sessions", async (c) => {
  * Finds or creates user, returns WebAuthn registration options.
  */
 auth.post("/passkey/register/options", async (c) => {
+  // Pre-auth reachable via the email-grant path — rate limit like the other
+  // pre-auth passkey endpoints.
+  const optionsRl = await checkAuthRateLimit(c, "passkey-register-options", 60_000, 20);
+  if (!optionsRl.allowed) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Too many requests. Please try again later." },
+      429,
+    );
+  }
   const body = await safeJsonParse<{
     email: string;
     authenticatorAttachment?: "platform" | "cross-platform";
@@ -7546,18 +7555,20 @@ auth.post("/passkey/register/verify", async (c) => {
   let user: typeof users.$inferSelect | undefined;
   const usingGrant = typeof body.emailGrant === "string" && body.emailGrant.length > 0;
 
+  let grantTenantId: string | null = null;
   if (usingGrant) {
-    const resolvedTenantId =
+    // PEEK only here. The grant is consumed AFTER the WebAuthn ceremony
+    // succeeds (below) so a failed/cancelled ceremony doesn't burn the
+    // user's OTP verification, while consumption before any state change
+    // keeps it strictly single-use.
+    grantTenantId =
       c.req.header("X-Steward-Tenant")?.trim() || body.tenantId?.trim() || _DEFAULT_TENANT_ID;
-    const grantOk = await consumeEmailGrant(body.emailGrant as string, email, resolvedTenantId);
+    const grantOk = await peekEmailGrant(body.emailGrant as string, email, grantTenantId);
     if (!grantOk) {
       return c.json<ApiResponse>({ ok: false, error: "Invalid or expired email grant" }, 401);
     }
     const found = await findOrCreateUserWithStatus(email);
     user = found.user;
-    // The OTP proved address ownership.
-    await db.update(users).set({ emailVerified: true }).where(eq(users.id, user.id));
-    user = { ...user, emailVerified: true };
   } else {
     const session = await requireSession(c);
     if (!session.ok) return session.response;
@@ -7583,11 +7594,15 @@ auth.post("/passkey/register/verify", async (c) => {
     user = sessionUser;
   }
 
+  // Tenant resolution uses the SAME join_mode-gated path as oauth and
+  // magic-link signup (resolveAndValidateTenant). The email grant proves
+  // address ownership — it must NOT also become a side door around
+  // invite-only tenants. Open-signup tenants set join_mode=open in config.
   const tenantResult = await resolveAndValidateTenant(c, user.id, body.tenantId);
   if (!tenantResult.ok) {
     return c.json<ApiResponse>({ ok: false, error: tenantResult.error }, tenantResult.status);
   }
-  const { tenantId } = tenantResult;
+  const tenantId = tenantResult.tenantId;
   const methodResponse = await requireTenantLoginMethodAllowed(c, tenantId, "passkey");
   if (methodResponse) return methodResponse;
   const ssoRequiredResponse = await requireNonSsoEmailLoginAllowed(c, tenantId, email, "Passkey");
@@ -7611,6 +7626,19 @@ auth.post("/passkey/register/verify", async (c) => {
 
   if (!verification.verified || !verification.registrationInfo) {
     return c.json<ApiResponse>({ ok: false, error: "Registration verification failed" }, 400);
+  }
+
+  if (usingGrant && grantTenantId) {
+    // Ceremony succeeded — NOW consume the grant (atomic single-use gate
+    // before any state is written). A replayed request with the same grant
+    // fails here even if it carries a valid ceremony response.
+    const consumed = await consumeEmailGrant(body.emailGrant as string, email, grantTenantId);
+    if (!consumed) {
+      return c.json<ApiResponse>({ ok: false, error: "Invalid or expired email grant" }, 401);
+    }
+    // The OTP proved address ownership.
+    await db.update(users).set({ emailVerified: true }).where(eq(users.id, user.id));
+    user = { ...user, emailVerified: true };
   }
 
   const { credential, credentialDeviceType, credentialBackedUp } = verification.registrationInfo;

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -1024,6 +1024,12 @@ export async function initAuthStores(usePostgres = false): Promise<void> {
     backend: challengeBackend,
     ttlMs: OAUTH_CODE_TTL_MS,
   });
+  // Verified-email grants share the challenge backend (Redis-backed in prod)
+  // so an OTP verified on one worker can register a passkey on another.
+  _emailGrantStore = new ChallengeStore({
+    backend: challengeBackend,
+    ttlMs: EMAIL_GRANT_TTL_MS,
+  });
   _importSessionBackend = importSessionBackend;
 
   // Reset singletons so they pick up the new stores on next use
@@ -1041,6 +1047,68 @@ function getChallengeStore(): ChallengeStore {
 function getOAuthCodeStore(): ChallengeStore {
   _oauthCodeStore ??= new ChallengeStore({ ttlMs: OAUTH_CODE_TTL_MS });
   return _oauthCodeStore;
+}
+
+// ── Verified-email grants (Privy-style OTP signup) ──────────────────────────
+//
+// POST /email/otp/verify exchanges a correct 6-digit code for a short-lived,
+// single-use grant proving ownership of {email, tenantId}. The passkey
+// register endpoints accept this grant in place of a session so a BRAND-NEW
+// user can go email -> code -> Touch ID without ever holding a session,
+// while keeping unverified registration (account pre-hijack) impossible.
+
+const EMAIL_GRANT_TTL_MS = 5 * 60 * 1000;
+let _emailGrantStore: ChallengeStore | null = null;
+
+function getEmailGrantStore(): ChallengeStore {
+  _emailGrantStore ??= new ChallengeStore({ ttlMs: EMAIL_GRANT_TTL_MS });
+  return _emailGrantStore;
+}
+
+function emailGrantKey(grant: string): string {
+  return `email-otp-grant:${hashSha256Hex(grant)}`;
+}
+
+async function issueEmailGrant(email: string, tenantId: string): Promise<string> {
+  const grantBytes = new Uint8Array(32);
+  crypto.getRandomValues(grantBytes);
+  const grant = uint8ArrayToBase64url(grantBytes);
+  await getEmailGrantStore().set(emailGrantKey(grant), JSON.stringify({ email, tenantId }));
+  return grant;
+}
+
+/** Consume (single-use) a grant and return its bound identity, or null. */
+async function consumeEmailGrant(
+  grant: string,
+  email: string,
+  tenantId: string,
+): Promise<boolean> {
+  if (!grant || grant.length > 256) return false;
+  const stored = await getEmailGrantStore().consume(emailGrantKey(grant));
+  if (!stored) return false;
+  try {
+    const payload = JSON.parse(stored) as { email?: string; tenantId?: string };
+    return payload.email === email && payload.tenantId === tenantId;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Peek (non-consuming) at a grant for the options phase. The grant is only
+ * CONSUMED at register/verify so a failed/cancelled WebAuthn ceremony does
+ * not burn the user's verification.
+ */
+async function peekEmailGrant(grant: string, email: string, tenantId: string): Promise<boolean> {
+  if (!grant || grant.length > 256) return false;
+  const stored = await getEmailGrantStore().get(emailGrantKey(grant));
+  if (!stored) return false;
+  try {
+    const payload = JSON.parse(stored) as { email?: string; tenantId?: string };
+    return payload.email === email && payload.tenantId === tenantId;
+  } catch {
+    return false;
+  }
 }
 
 const OAUTH_CODE_REDEEM_LOCK_TTL_MS = 10 * 1000;
@@ -7349,58 +7417,84 @@ auth.delete("/sessions", async (c) => {
  * Finds or creates user, returns WebAuthn registration options.
  */
 auth.post("/passkey/register/options", async (c) => {
-  const session = await requireSession(c);
-  if (!session.ok) return session.response;
-  const sessionMethodResponse = await requireTenantLoginMethodAllowed(
-    c,
-    session.payload.tenantId,
-    "passkey",
-  );
-  if (sessionMethodResponse) return sessionMethodResponse;
-
   const body = await safeJsonParse<{
     email: string;
     authenticatorAttachment?: "platform" | "cross-platform";
+    emailGrant?: string;
+    tenantId?: string;
   }>(c);
   if (!body?.email) {
     return c.json<ApiResponse>({ ok: false, error: "email is required" }, 400);
   }
-
   const email = body.email.toLowerCase().trim();
   const db = getDb();
-  const [user] = await db.select().from(users).where(eq(users.id, session.payload.userId));
-  if (!user || user.email?.toLowerCase().trim() !== email) {
-    return c.json<ApiResponse>(
-      {
-        ok: false,
-        error: "Passkey registration requires an authenticated matching email session",
-      },
-      403,
+
+  // Two ways in: an authenticated session (add-passkey for logged-in users)
+  // or a verified-email grant from /email/otp/verify (Privy-style signup:
+  // email → 6-digit code → Touch ID, no session required). The grant proves
+  // ownership of the email, which is what blocks account pre-hijack.
+  let userId: string;
+  let userEmail: string | null;
+  let ssoTenantId: string;
+
+  if (typeof body.emailGrant === "string" && body.emailGrant.length > 0) {
+    const resolvedTenantId =
+      c.req.header("X-Steward-Tenant")?.trim() || body.tenantId?.trim() || _DEFAULT_TENANT_ID;
+    const methodResponse = await requireTenantLoginMethodAllowed(c, resolvedTenantId, "passkey");
+    if (methodResponse) return methodResponse;
+    // Peek (not consume): the grant is only burned at register/verify so a
+    // cancelled Touch ID prompt doesn't cost the user their verification.
+    const grantOk = await peekEmailGrant(body.emailGrant, email, resolvedTenantId);
+    if (!grantOk) {
+      return c.json<ApiResponse>({ ok: false, error: "Invalid or expired email grant" }, 401);
+    }
+    const { user } = await findOrCreateUserWithStatus(email);
+    userId = user.id;
+    userEmail = user.email;
+    ssoTenantId = resolvedTenantId;
+  } else {
+    const session = await requireSession(c);
+    if (!session.ok) return session.response;
+    const sessionMethodResponse = await requireTenantLoginMethodAllowed(
+      c,
+      session.payload.tenantId,
+      "passkey",
     );
+    if (sessionMethodResponse) return sessionMethodResponse;
+
+    const [user] = await db.select().from(users).where(eq(users.id, session.payload.userId));
+    if (!user || user.email?.toLowerCase().trim() !== email) {
+      return c.json<ApiResponse>(
+        {
+          ok: false,
+          error: "Passkey registration requires an authenticated matching email session",
+        },
+        403,
+      );
+    }
+    if (!user.emailVerified) {
+      return c.json<ApiResponse>(
+        {
+          ok: false,
+          error: "Email must be verified before registering a passkey",
+        },
+        403,
+      );
+    }
+    const stepUpResponse = await requireRecentFactorEnrollmentStepUp(c, session);
+    if (stepUpResponse) return stepUpResponse;
+    userId = user.id;
+    userEmail = user.email;
+    ssoTenantId = session.payload.tenantId;
   }
-  if (!user.emailVerified) {
-    return c.json<ApiResponse>(
-      {
-        ok: false,
-        error: "Email must be verified before registering a passkey",
-      },
-      403,
-    );
-  }
-  const ssoRequiredResponse = await requireNonSsoEmailLoginAllowed(
-    c,
-    session.payload.tenantId,
-    email,
-    "Passkey",
-  );
+
+  const ssoRequiredResponse = await requireNonSsoEmailLoginAllowed(c, ssoTenantId, email, "Passkey");
   if (ssoRequiredResponse) return ssoRequiredResponse;
 
   const existingCreds = await db
     .select({ credentialId: authenticators.credentialId })
     .from(authenticators)
-    .where(eq(authenticators.userId, user.id));
-  const stepUpResponse = await requireRecentFactorEnrollmentStepUp(c, session);
-  if (stepUpResponse) return stepUpResponse;
+    .where(eq(authenticators.userId, userId));
 
   const attachment =
     body.authenticatorAttachment === "platform" || body.authenticatorAttachment === "cross-platform"
@@ -7408,8 +7502,8 @@ auth.post("/passkey/register/options", async (c) => {
       : undefined;
 
   const options = await getPasskeyAuth(c.req.header("origin")).generateRegistrationOptions(
-    user.id,
-    email,
+    userId,
+    userEmail ?? email,
     existingCreds.map((cred) => cred.credentialId),
     attachment ? { authenticatorAttachment: attachment } : undefined,
   );
@@ -7424,9 +7518,6 @@ auth.post("/passkey/register/options", async (c) => {
  * Verifies registration, stores credential, provisions wallet, returns JWT.
  */
 auth.post("/passkey/register/verify", async (c) => {
-  const session = await requireSession(c);
-  if (!session.ok) return session.response;
-
   const rl = await checkAuthRateLimit(c, "passkey-verify", 60_000, 10);
   if (!rl.allowed) {
     return c.json<ApiResponse>(
@@ -7438,6 +7529,7 @@ auth.post("/passkey/register/verify", async (c) => {
     email: string;
     response: Record<string, unknown>;
     tenantId?: string;
+    emailGrant?: string;
   }>(c);
 
   if (!body?.email || !body?.response) {
@@ -7445,20 +7537,51 @@ auth.post("/passkey/register/verify", async (c) => {
   }
 
   const db = getDb();
-
-  const [user] = await db.select().from(users).where(eq(users.id, session.payload.userId));
   const email = body.email.toLowerCase().trim();
-  if (!user || user.email?.toLowerCase().trim() !== email || !user.emailVerified) {
-    return c.json<ApiResponse>(
-      {
-        ok: false,
-        error: "Passkey registration requires an authenticated verified email session",
-      },
-      403,
-    );
+
+  // Session path (logged-in add-passkey) or verified-email-grant path
+  // (Privy-style signup). The grant is CONSUMED here — single use — and
+  // proves email ownership, so completing registration also marks the
+  // email verified.
+  let user: typeof users.$inferSelect | undefined;
+  const usingGrant = typeof body.emailGrant === "string" && body.emailGrant.length > 0;
+
+  if (usingGrant) {
+    const resolvedTenantId =
+      c.req.header("X-Steward-Tenant")?.trim() || body.tenantId?.trim() || _DEFAULT_TENANT_ID;
+    const grantOk = await consumeEmailGrant(body.emailGrant as string, email, resolvedTenantId);
+    if (!grantOk) {
+      return c.json<ApiResponse>({ ok: false, error: "Invalid or expired email grant" }, 401);
+    }
+    const found = await findOrCreateUserWithStatus(email);
+    user = found.user;
+    // The OTP proved address ownership.
+    await db.update(users).set({ emailVerified: true }).where(eq(users.id, user.id));
+    user = { ...user, emailVerified: true };
+  } else {
+    const session = await requireSession(c);
+    if (!session.ok) return session.response;
+    const [sessionUser] = await db
+      .select()
+      .from(users)
+      .where(eq(users.id, session.payload.userId));
+    if (
+      !sessionUser ||
+      sessionUser.email?.toLowerCase().trim() !== email ||
+      !sessionUser.emailVerified
+    ) {
+      return c.json<ApiResponse>(
+        {
+          ok: false,
+          error: "Passkey registration requires an authenticated verified email session",
+        },
+        403,
+      );
+    }
+    const stepUpResponse = await requireRecentFactorEnrollmentStepUp(c, session);
+    if (stepUpResponse) return stepUpResponse;
+    user = sessionUser;
   }
-  const stepUpResponse = await requireRecentFactorEnrollmentStepUp(c, session);
-  if (stepUpResponse) return stepUpResponse;
 
   const tenantResult = await resolveAndValidateTenant(c, user.id, body.tenantId);
   if (!tenantResult.ok) {
@@ -7949,6 +8072,137 @@ auth.post("/email/verify", async (c) => {
   }
 
   return authExchangeJson(c, authResult.response);
+});
+
+// ── Email OTP (Privy-style verified signup) ───────────────────────────────
+//
+// POST /auth/email/otp/send    — email a 6-digit one-time code.
+// POST /auth/email/otp/verify  — exchange a correct code for a short-lived
+//                                single-use verified-email GRANT. The grant
+//                                unlocks passkey registration for that exact
+//                                {email, tenant} without a session, enabling
+//                                email → code → Touch ID signup while keeping
+//                                unverified registration (pre-hijack) closed.
+
+auth.post("/email/otp/send", async (c) => {
+  const rl = await checkAuthRateLimit(c, "email-otp-send", 60_000, 3);
+  if (!rl.allowed) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Too many requests. Please try again later." },
+      429,
+    );
+  }
+  const body = await safeJsonParse<{ email: string; tenantId?: string; captchaToken?: string }>(c);
+  if (!body?.email) {
+    return c.json<ApiResponse>({ ok: false, error: "email is required" }, 400);
+  }
+
+  const email = body.email.toLowerCase().trim();
+  const headerTenantId = c.req.header("X-Steward-Tenant")?.trim();
+  const bodyTenantId = body.tenantId?.trim();
+  const resolvedTenantId = headerTenantId || bodyTenantId || _DEFAULT_TENANT_ID;
+  const tenantHintError = await validateExplicitAuthTenantHint(
+    resolvedTenantId,
+    Boolean(headerTenantId || bodyTenantId),
+  );
+  if (tenantHintError) {
+    return c.json<ApiResponse>({ ok: false, error: tenantHintError }, 404);
+  }
+  const methodResponse = await requireTenantLoginMethodAllowed(c, resolvedTenantId, "email");
+  if (methodResponse) return methodResponse;
+  const ssoRequiredResponse = await requireNonSsoEmailLoginAllowed(
+    c,
+    resolvedTenantId,
+    email,
+    "Email",
+  );
+  if (ssoRequiredResponse) return ssoRequiredResponse;
+  const authAbuseConfig = await getTenantAuthAbuseConfig(resolvedTenantId);
+  const emailPolicyError = validateEmailAbusePolicy(email, authAbuseConfig);
+  if (emailPolicyError) {
+    return c.json<ApiResponse>({ ok: false, error: emailPolicyError }, 400);
+  }
+  const captcha = await verifyCaptchaToken(
+    authAbuseConfig,
+    "email_otp",
+    body.captchaToken,
+    trustedRemoteIp(c),
+  );
+  if (!captcha.ok) {
+    return c.json<ApiResponse>(
+      { ok: false, error: captcha.error },
+      captcha.status as 400 | 502 | 503,
+    );
+  }
+  const emailRl = await checkAuthRateLimit(c, "email-otp-send-destination", 10 * 60_000, 5, email);
+  if (!emailRl.allowed) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Too many requests. Please try again later." },
+      429,
+    );
+  }
+  const emailAuth = await getEmailAuthForTenant(resolvedTenantId);
+  const { expiresAt } = await emailAuth.sendOtp(email, { tenantId: resolvedTenantId });
+
+  return c.json<ApiResponse<{ expiresAt: string }>>({
+    ok: true,
+    data: { expiresAt: expiresAt.toISOString() },
+  });
+});
+
+auth.post("/email/otp/verify", async (c) => {
+  const rl = await checkAuthRateLimit(c, "email-otp-verify", 60_000, 10);
+  if (!rl.allowed) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Too many verification attempts. Try again later." },
+      429,
+    );
+  }
+
+  const body = await safeJsonParse<{ email: string; code: string; tenantId?: string }>(c);
+  if (!body?.email || !body?.code) {
+    return c.json<ApiResponse>({ ok: false, error: "email and code are required" }, 400);
+  }
+
+  const email = body.email.toLowerCase().trim();
+  const code = body.code.trim();
+  const resolvedTenantId = c.req.header("X-Steward-Tenant") || body.tenantId || _DEFAULT_TENANT_ID;
+  const methodResponse = await requireTenantLoginMethodAllowed(c, resolvedTenantId, "email");
+  if (methodResponse) return methodResponse;
+  const ssoRequiredResponse = await requireNonSsoEmailLoginAllowed(
+    c,
+    resolvedTenantId,
+    email,
+    "Email",
+  );
+  if (ssoRequiredResponse) return ssoRequiredResponse;
+  // Per-{email,tenant} attempt limiter so 6 digits can't be brute-forced:
+  // 5 attempts / 10 min regardless of source IP.
+  const attemptRl = await checkAuthRateLimit(
+    c,
+    "email-otp-verify-target",
+    10 * 60_000,
+    5,
+    `${resolvedTenantId}:${email}`,
+  );
+  if (!attemptRl.allowed) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Too many verification attempts. Try again later." },
+      429,
+    );
+  }
+
+  const emailAuth = await getEmailAuthForTenant(resolvedTenantId);
+  const valid = await emailAuth.verifyOtp(email, code, resolvedTenantId);
+  if (!valid) {
+    return c.json<ApiResponse>({ ok: false, error: "Invalid or expired code" }, 401);
+  }
+
+  const grant = await issueEmailGrant(email, resolvedTenantId);
+  return c.json<ApiResponse<{ emailGrant: string; expiresInSeconds: number }>>({
+    ok: true,
+    data: { emailGrant: grant, expiresInSeconds: Math.floor(EMAIL_GRANT_TTL_MS / 1000) },
+  });
 });
 
 // ── Guest (ephemeral / anonymous) accounts — Privy parity ─────────────────────

--- a/packages/auth/src/email.ts
+++ b/packages/auth/src/email.ts
@@ -63,10 +63,26 @@ export interface TenantInvitationEmailContext {
 const TOKEN_BYTES = 32;
 const DEFAULT_TTL_MS = 10 * 60 * 1000; // 10 min
 const DEFAULT_CALLBACK = "/auth/callback/email";
+const OTP_DIGITS = 6;
 
 function generateToken(): string {
   // URL-safe hex token (64 chars from 32 bytes)
   return randomBytes(TOKEN_BYTES).toString("hex");
+}
+
+function generateOtpCode(): string {
+  // Crypto-random 6-digit code with rejection sampling to avoid modulo bias.
+  const max = 10 ** OTP_DIGITS;
+  // 2^32 / 10^6 -> keep draws below the largest multiple of max to stay uniform.
+  const limit = Math.floor(0x1_0000_0000 / max) * max;
+  for (;;) {
+    const bytes = randomBytes(4);
+    const draw =
+      ((bytes[0] << 24) >>> 0) + ((bytes[1] << 16) >>> 0) + ((bytes[2] << 8) >>> 0) + bytes[3];
+    if (draw < limit) {
+      return String(draw % max).padStart(OTP_DIGITS, "0");
+    }
+  }
 }
 
 function hashToken(token: string): string {
@@ -119,6 +135,12 @@ type MagicLinkPayload = {
   email: string;
   tenantId?: string;
 };
+
+function otpStoreKey(email: string, tenantId: string | undefined, code: string): string {
+  // Hash binds the code to {email, tenant} so a code minted for one address
+  // or tenant can never verify for another.
+  return hashSha256Hex(`email-otp:${tenantId ?? ""}:${email}:${code}`);
+}
 
 function encodeMagicLinkPayload(payload: MagicLinkPayload): string {
   return JSON.stringify(payload);
@@ -205,6 +227,72 @@ export class EmailAuth {
     await this.provider.send(email, subject, body, html, { replyTo: this.replyTo });
 
     return { tokenHash, expiresAt };
+  }
+
+  /**
+   * Generate a 6-digit one-time code, persist its hash, and email it.
+   * Privy-style email verification: the code proves address ownership and
+   * is exchanged for a short-lived verified-email grant by the API layer.
+   */
+  async sendOtp(
+    email: string,
+    context: { tenantId?: string; tenantName?: string } = {},
+  ): Promise<{ expiresAt: Date }> {
+    const code = generateOtpCode();
+    const expiresAt = new Date(Date.now() + this.tokenTtlMs);
+
+    this.tokenStore.store(
+      otpStoreKey(email, context.tenantId, code),
+      encodeMagicLinkPayload({ email, tenantId: context.tenantId }),
+      this.tokenTtlMs,
+    );
+
+    const minutes = Math.floor(this.tokenTtlMs / (60 * 1000));
+    const brand = context.tenantName || "Steward";
+    const subject = `${code} is your ${brand} sign-in code`;
+    const text = [
+      `Your ${brand} sign-in code is: ${code}`,
+      "",
+      `It expires in ${minutes} minutes. If you didn't request this, ignore this email.`,
+    ].join("\n");
+    const escapedBrand = escapeHtml(brand);
+    const escapedCode = escapeHtml(code);
+    const html = `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
+<body style="margin:0;padding:0;background-color:#0b0a09;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background-color:#0b0a09;min-height:100vh;">
+    <tr><td align="center" style="padding:60px 24px;">
+      <table width="100%" cellpadding="0" cellspacing="0" style="max-width:420px;">
+        <tr><td style="background-color:#141210;border:1px solid #2a2722;padding:40px 32px;">
+          <div style="font-size:18px;font-weight:700;color:#e8e5e0;padding-bottom:8px;">${escapedBrand} sign-in code</div>
+          <div style="font-size:13px;color:#9c9788;line-height:1.5;padding-bottom:24px;">Enter this code to verify your email. It expires in ${minutes} minutes.</div>
+          <div style="text-align:center;padding-bottom:24px;">
+            <span style="display:inline-block;background-color:#0b0a09;border:1px solid #2a2722;color:#e8e5e0;font-size:32px;font-weight:700;letter-spacing:0.35em;padding:16px 24px 16px 32px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;">${escapedCode}</span>
+          </div>
+          <div style="border-top:1px solid #2a2722;padding-top:20px;font-size:11px;color:#9c9788;line-height:1.5;">If you didn't request this code, you can safely ignore this email.</div>
+        </td></tr>
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>`;
+
+    await this.provider.send(email, subject, text, html, { replyTo: this.replyTo });
+
+    return { expiresAt };
+  }
+
+  /**
+   * Verify a 6-digit code for {email, tenantId}. One-time use: the code is
+   * consumed on success. Returns false for unknown/expired/mismatched codes.
+   */
+  async verifyOtp(email: string, code: string, tenantId?: string): Promise<boolean> {
+    if (!/^\d{6}$/.test(code)) return false;
+    const stored = await this.tokenStore.consume(otpStoreKey(email, tenantId, code));
+    if (!stored) return false;
+    const payload = decodeMagicLinkPayload(stored);
+    return payload.email === email && (payload.tenantId ?? undefined) === (tenantId ?? undefined);
   }
 
   async sendTenantInvitation(email: string, context: TenantInvitationEmailContext): Promise<void> {


### PR DESCRIPTION
## What
Canonical signup flow: **email → 6-digit code → Touch ID → in.** Restores the one-tap passkey signup UX (lost when registration was session-gated in the May 28 security hardening) WITHOUT reopening the account pre-hijack vector.

## Flow
1. `POST /auth/email/otp/send` — emails a 6-digit code (same abuse gates as magic-link: captcha, SSO guard, email policy, per-IP + per-destination limits)
2. `POST /auth/email/otp/verify` — correct code mints a **5-min single-use verified-email grant** (challenge-store backed → Redis in prod). Per-{email,tenant} brute-force limiter (5/10min) on top of per-IP.
3. `passkey/register/options` — accepts grant as alternative to session. **Peeks** (non-consuming) so a cancelled Touch ID doesn't burn the verification.
4. `passkey/register/verify` — **consumes** the grant (single use), creates user if needed, marks email verified (OTP proved ownership), returns full auth response.

## Security invariants
- No unverified registration possible (grant requires correct OTP = proof of email ownership)
- Grant bound to {email, tenant}, single-use, 5-min TTL
- OTP: crypto-random (rejection-sampled), hash-keyed to {email, tenant}, single-use, 10-min TTL, code-format prefilter
- Session path unchanged for logged-in add-passkey (incl. step-up + emailVerified checks)
- Wrong-email/wrong-tenant verify attempts cannot burn someone else's code (store key includes both)

## Tests
11 new (6 EmailAuth primitives incl. TTL/binding/single-use + 5 route-level invariants). Existing passkey/email suites pass (10/10).

## Review note
codex review attempted twice, did not converge on this box (timeouts on the large auth.ts diff). Self-review security pass done; flagging for human/codex review before deploy. Same precedent as #122.

Co-authored-by: wakesync <shadow@shad0w.xyz>