### PR TITLE
feat(platform): GET/PATCH /tenants/:id/join-mode — operator surface for tenant join policy

### DIFF
--- a/packages/api/src/routes/platform.ts
+++ b/packages/api/src/routes/platform.ts
@@ -1204,6 +1204,125 @@ platform.get("/tenants/:tenantId/email-config", async (c) => {
   });
 });
 
+/**
+ * GET /tenants/:tenantId/join-mode
+ * Returns the tenant's join_mode ('open' | 'invite' | 'closed'; null when no
+ * tenant_configs row exists — the join gate then treats it as not self-joinable).
+ */
+platform.get("/tenants/:tenantId/join-mode", async (c) => {
+  const scopeResponse = requirePlatformRouteScope(c, "platform:tenant-join-mode:read");
+  if (scopeResponse) return scopeResponse;
+
+  const db = getDb();
+  const tenantId = c.req.param("tenantId");
+
+  if (!isValidTenantId(tenantId)) {
+    return c.json<ApiResponse>({ ok: false, error: "Invalid tenant id format" }, 400);
+  }
+
+  if (!(await getTenantOr404(tenantId))) {
+    return c.json<ApiResponse>({ ok: false, error: "Tenant not found" }, 404);
+  }
+
+  const [config] = await db
+    .select({ joinMode: tenantConfigs.joinMode })
+    .from(tenantConfigs)
+    .where(eq(tenantConfigs.tenantId, tenantId));
+
+  return c.json<ApiResponse<{ tenantId: string; joinMode: string | null }>>({
+    ok: true,
+    data: { tenantId, joinMode: config?.joinMode ?? null },
+  });
+});
+
+/**
+ * PATCH /tenants/:tenantId/join-mode
+ * Sets how users may join the tenant: 'open' (anyone authenticating with this
+ * tenantId is auto-linked), 'invite' (existing user_tenants link required), or
+ * 'closed' (no new members).
+ *
+ * This is the ONLY write surface for join_mode: the column was previously
+ * settable by nothing but raw SQL, so the 0048 hardening backfill (every
+ * 'open' tenant force-flipped to 'invite') left public-product tenants —
+ * e.g. a consumer cloud's primary tenant — silently rejecting all NEW signups
+ * after any fresh-environment migration replay, with no operator remedy short
+ * of psql. Mirrors the email-config PATCH (scope gate, audit pair,
+ * snapshot/restore on audit failure, update-or-insert).
+ */
+platform.patch("/tenants/:tenantId/join-mode", async (c) => {
+  const scopeResponse = requirePlatformRouteScope(c, "platform:tenant-join-mode:write");
+  if (scopeResponse) return scopeResponse;
+
+  const db = getDb();
+  const tenantId = c.req.param("tenantId");
+
+  if (!isValidTenantId(tenantId)) {
+    return c.json<ApiResponse>({ ok: false, error: "Invalid tenant id format" }, 400);
+  }
+
+  if (!(await getTenantOr404(tenantId))) {
+    return c.json<ApiResponse>({ ok: false, error: "Tenant not found" }, 404);
+  }
+
+  const body = await safeJsonParse<{ joinMode: string }>(c);
+  if (!body) {
+    return c.json<ApiResponse>({ ok: false, error: "Invalid JSON in request body" }, 400);
+  }
+
+  const joinMode = typeof body.joinMode === "string" ? body.joinMode.trim() : "";
+  if (!["open", "invite", "closed"].includes(joinMode)) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "joinMode must be one of 'open', 'invite', 'closed'" },
+      400,
+    );
+  }
+
+  await writeAuditEvent({
+    tenantId,
+    actorType: "platform",
+    action: "tenant.join_mode.update.authorized",
+    resourceType: "tenant",
+    resourceId: tenantId,
+    metadata: { joinMode },
+    ...auditCtx(c),
+  });
+
+  const previousConfigRow = await snapshotPlatformTenantConfigRow(tenantId);
+  const [existingConfig] = await db
+    .select({ tenantId: tenantConfigs.tenantId })
+    .from(tenantConfigs)
+    .where(eq(tenantConfigs.tenantId, tenantId));
+
+  if (existingConfig) {
+    await db
+      .update(tenantConfigs)
+      .set({ joinMode, updatedAt: new Date() })
+      .where(eq(tenantConfigs.tenantId, tenantId));
+  } else {
+    await db.insert(tenantConfigs).values({ tenantId, joinMode });
+  }
+
+  try {
+    await writeAuditEvent({
+      tenantId,
+      actorType: "platform",
+      action: "tenant.join_mode.update",
+      resourceType: "tenant",
+      resourceId: tenantId,
+      metadata: { joinMode },
+      ...auditCtx(c),
+    });
+  } catch (error) {
+    await restorePlatformTenantConfigRow(tenantId, previousConfigRow);
+    throw error;
+  }
+
+  return c.json<ApiResponse<{ tenantId: string; joinMode: string }>>({
+    ok: true,
+    data: { tenantId, joinMode },
+  });
+});
+
 platform.get("/tenants/:tenantId/oidc-providers", async (c) => {
   const scopeResponse = requirePlatformRouteScope(c, "platform:tenant-oidc:read");
   if (scopeResponse) return scopeResponse;


### PR DESCRIPTION
## Why
`tenant_configs.join_mode` is **read everywhere but writable by nothing except raw SQL** — no platform route, no tenant route, nothing. That gap just caused a production incident on elizacloud: migration `0048_harden_tenant_join_default.sql` (the PR #79 hardening) bulk-flips every `open` tenant to `invite` —

```sql
UPDATE tenant_configs SET join_mode = 'invite' WHERE join_mode = 'open';
```

— so when a fresh environment replays the migration chain, public-product tenants silently lose self-signup: **every NEW user gets `Tenant 'x' requires an invitation to join`** while existing members (existing-link bypass) keep working, making it look like a partial mystery failure. The only remedy today is psql against the prod DB.

(To be clear: the 0048 hardening default is *right* for arbitrary tenants — the missing piece is an operator surface to opt specific tenants back into `open`.)

## What
Mirrors the `PATCH /tenants/:tenantId/email-config` pattern exactly:

- **`GET /platform/tenants/:tenantId/join-mode`** → `{ tenantId, joinMode }` (null when no config row) — scope `platform:tenant-join-mode:read`
- **`PATCH /platform/tenants/:tenantId/join-mode`** — body `{ joinMode: "open" | "invite" | "closed" }` (strictly validated) — scope `platform:tenant-join-mode:write`, plus the router-level `platform:write` gate
- Same conventions as email-config: tenant-id validation, 404 on unknown tenant, **audit pair** (`.authorized` before / `.update` after), config-row **snapshot + restore on audit failure**, update-or-insert.

## Verification
- `packages/api` typecheck clean after workspace build (zero diagnostics in `routes/platform.ts`); biome clean.
- The local bun suite's failures are env-dependent (no `DATABASE_URL`/Redis here) and identical in kind to a clean `develop` worktree — none touch this surface. Happy to add a DB-gated integration test alongside `tenant-config.test.ts` if you'd like one.

## Ops note
For the live elizacloud incident the immediate fix is still one statement on the prod DB (`UPDATE tenant_configs SET join_mode='open' WHERE tenant_id='elizacloud';`) — this PR is the durable path so the next environment rebuild is a `PATCH` with a platform key instead of psql. cc @0xSolace