### PR TITLE
fix(auth): accept tenant root api-key for provisioning agent admin routes

### DIFF
--- a/packages/api/src/__tests__/agent-policy.test.ts
+++ b/packages/api/src/__tests__/agent-policy.test.ts
@@ -197,11 +197,15 @@ describe("agent trade policy", () => {
     expect(body.error).toContain("dailyCap exceeds platform ceiling 50000");
   });
 
-
   it("requires allowBuilderPerps before adding builder symbols to allowedAssets", async () => {
-    const rejected = await putPolicy({ allowedAssets: ["xyz:SPCX"], reason: "try builder without explicit opt-in" });
+    const rejected = await putPolicy({
+      allowedAssets: ["xyz:SPCX"],
+      reason: "try builder without explicit opt-in",
+    });
     expect(rejected.status).toBe(400);
-    expect(((await rejected.json()) as { error: string }).error).toContain("allowBuilderPerps=true");
+    expect(((await rejected.json()) as { error: string }).error).toContain(
+      "allowBuilderPerps=true",
+    );
 
     const accepted = await putPolicy({
       allowedAssets: ["BTC", "xyz:SPCX"],
@@ -209,7 +213,9 @@ describe("agent trade policy", () => {
       reason: "explicitly allow Trade.xyz SPCX builder perp",
     });
     expect(accepted.status).toBe(200);
-    const body = (await accepted.json()) as { data: { policy: { allowedAssets: string[]; allowBuilderPerps: boolean } } };
+    const body = (await accepted.json()) as {
+      data: { policy: { allowedAssets: string[]; allowBuilderPerps: boolean } };
+    };
     expect(body.data.policy.allowedAssets).toEqual(["BTC", "xyz:SPCX"]);
     expect(body.data.policy.allowBuilderPerps).toBe(true);
   });

--- a/packages/api/src/__tests__/agent-route-scope.test.ts
+++ b/packages/api/src/__tests__/agent-route-scope.test.ts
@@ -23,9 +23,9 @@ setDefaultTimeout(30000);
 const TENANT_ID = "test-agent-route-scope";
 const AGENT_A = "test-ars-agent-a";
 const AGENT_B = "test-ars-agent-b";
-const OWNER_USER_ID = "test-ars-owner";
-const ADMIN_USER_ID = "test-ars-admin";
-const MEMBER_USER_ID = "test-ars-member";
+const OWNER_USER_ID = "00000000-0000-4000-8000-0000000000a1";
+const ADMIN_USER_ID = "00000000-0000-4000-8000-0000000000a2";
+const MEMBER_USER_ID = "00000000-0000-4000-8000-0000000000a3";
 const hasDatabaseUrl = Boolean(process.env.DATABASE_URL);
 const describeWithDatabase = hasDatabaseUrl ? describe : describe.skip;
 

--- a/packages/api/src/__tests__/agent-route-scope.test.ts
+++ b/packages/api/src/__tests__/agent-route-scope.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
 import { generateApiKey, signAgentToken } from "@stwd/auth";
-import { agents, getDb, tenants } from "@stwd/db";
-import { eq } from "drizzle-orm";
+import { agents, auditEvents, getDb, tenants, users, userTenants } from "@stwd/db";
+import { and, desc, eq } from "drizzle-orm";
 
 setDefaultTimeout(30000);
 
@@ -23,16 +23,24 @@ setDefaultTimeout(30000);
 const TENANT_ID = "test-agent-route-scope";
 const AGENT_A = "test-ars-agent-a";
 const AGENT_B = "test-ars-agent-b";
+const OWNER_USER_ID = "test-ars-owner";
+const ADMIN_USER_ID = "test-ars-admin";
+const MEMBER_USER_ID = "test-ars-member";
 const hasDatabaseUrl = Boolean(process.env.DATABASE_URL);
 const describeWithDatabase = hasDatabaseUrl ? describe : describe.skip;
 
 let apiKey = "";
 let app: typeof import("../app")["app"];
+let createSessionToken: typeof import("../routes/auth").createSessionToken;
+let ownerSessionToken = "";
+let adminSessionToken = "";
+let memberSessionToken = "";
 
 beforeAll(async () => {
   if (!hasDatabaseUrl) return;
 
   ({ app } = await import("../app"));
+  ({ createSessionToken } = await import("../routes/auth"));
 
   const apiKeyPair = generateApiKey();
   apiKey = apiKeyPair.key;
@@ -45,10 +53,56 @@ beforeAll(async () => {
     })
     .onConflictDoNothing();
 
-  // Agent creation now requires an owner/admin session (Shaw's hardening),
-  // not tenant API-key auth, so we seed the agents directly. This test is
-  // about agent-token scope on existing agents, not the creation path, so a
-  // direct insert is the correct fixture.
+  await getDb()
+    .insert(users)
+    .values([
+      { id: OWNER_USER_ID, email: "test-ars-owner@example.test", emailVerified: true },
+      { id: ADMIN_USER_ID, email: "test-ars-admin@example.test", emailVerified: true },
+      { id: MEMBER_USER_ID, email: "test-ars-member@example.test", emailVerified: true },
+    ])
+    .onConflictDoNothing();
+  await getDb()
+    .insert(userTenants)
+    .values([
+      { userId: OWNER_USER_ID, tenantId: TENANT_ID, role: "owner" },
+      { userId: ADMIN_USER_ID, tenantId: TENANT_ID, role: "admin" },
+      { userId: MEMBER_USER_ID, tenantId: TENANT_ID, role: "member" },
+    ])
+    .onConflictDoNothing();
+
+  ownerSessionToken = await createSessionToken(
+    "0x0000000000000000000000000000000000000001",
+    TENANT_ID,
+    {
+      userId: OWNER_USER_ID,
+      email: "test-ars-owner@example.test",
+      mfaVerifiedAt: Date.now(),
+      mfaMethod: "totp",
+    },
+  );
+  adminSessionToken = await createSessionToken(
+    "0x0000000000000000000000000000000000000002",
+    TENANT_ID,
+    {
+      userId: ADMIN_USER_ID,
+      email: "test-ars-admin@example.test",
+      mfaVerifiedAt: Date.now(),
+      mfaMethod: "totp",
+    },
+  );
+  memberSessionToken = await createSessionToken(
+    "0x0000000000000000000000000000000000000003",
+    TENANT_ID,
+    {
+      userId: MEMBER_USER_ID,
+      email: "test-ars-member@example.test",
+      mfaVerifiedAt: Date.now(),
+      mfaMethod: "totp",
+    },
+  );
+
+  // Seed agents directly so this test remains focused on agent-token scope and
+  // agent-token minting gates, not the agent creation payload validators.
   for (const agentId of [AGENT_A, AGENT_B]) {
     await getDb()
       .insert(agents)
@@ -70,6 +124,22 @@ afterAll(async () => {
   // Clean up the test tenant; the db connection itself is shared across the
   // package-wide test run and must NOT be closed here.
   const db = getDb();
+  await db
+    .delete(userTenants)
+    .where(eq(userTenants.tenantId, TENANT_ID))
+    .catch(() => {});
+  await db
+    .delete(users)
+    .where(eq(users.id, OWNER_USER_ID))
+    .catch(() => {});
+  await db
+    .delete(users)
+    .where(eq(users.id, ADMIN_USER_ID))
+    .catch(() => {});
+  await db
+    .delete(users)
+    .where(eq(users.id, MEMBER_USER_ID))
+    .catch(() => {});
   await db
     .delete(tenants)
     .where(eq(tenants.id, TENANT_ID))
@@ -172,6 +242,107 @@ describeWithDatabase("agent route scope enforcement", () => {
     // assert containment rather than exact equality.
     expect(ids).toContain(AGENT_A);
     expect(ids).toContain(AGENT_B);
+  });
+
+  it("lets the tenant root API key mint an agent token without session MFA", async () => {
+    const res = await app.request(`/agents/${AGENT_A}/token`, {
+      method: "POST",
+      headers: {
+        "X-Steward-Tenant": TENANT_ID,
+        "X-Steward-Key": apiKey,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      ok: boolean;
+      data: { token: string; agentId: string; tenantId: string; scope: string; scopes: string[] };
+    };
+    expect(body.ok).toBe(true);
+    expect(body.data.token).toBeDefined();
+    expect(body.data.agentId).toBe(AGENT_A);
+    expect(body.data.tenantId).toBe(TENANT_ID);
+    expect(body.data.scope).toBe("agent");
+    expect(body.data.scopes).toEqual(["agent"]);
+
+    const [audit] = await getDb()
+      .select({ actorType: auditEvents.actorType, actorId: auditEvents.actorId })
+      .from(auditEvents)
+      .where(
+        and(
+          eq(auditEvents.tenantId, TENANT_ID),
+          eq(auditEvents.resourceId, AGENT_A),
+          eq(auditEvents.action, "agent.token.create.authorized"),
+        ),
+      )
+      .orderBy(desc(auditEvents.seq));
+    expect(audit).toEqual({ actorType: "api-key", actorId: TENANT_ID });
+  });
+
+  it("keeps owner and admin sessions authorized to mint agent tokens", async () => {
+    for (const token of [ownerSessionToken, adminSessionToken]) {
+      const res = await app.request(`/agents/${AGENT_A}/token`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({}),
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { ok: boolean; data: { agentId: string } };
+      expect(body.ok).toBe(true);
+      expect(body.data.agentId).toBe(AGENT_A);
+    }
+  });
+
+  it("rejects agent-token, member session, missing credentials, and invalid API key for agent token minting", async () => {
+    const agentToken = await signAgentToken({ agentId: AGENT_A, tenantId: TENANT_ID }, "1h");
+    const cases: Array<{
+      name: string;
+      headers?: Record<string, string>;
+      expectedStatus: number;
+    }> = [
+      {
+        name: "agent-token",
+        headers: { Authorization: `Bearer ${agentToken}`, "Content-Type": "application/json" },
+        expectedStatus: 403,
+      },
+      {
+        name: "member-session",
+        headers: {
+          Authorization: `Bearer ${memberSessionToken}`,
+          "Content-Type": "application/json",
+        },
+        expectedStatus: 403,
+      },
+      {
+        name: "missing-credentials",
+        headers: { "Content-Type": "application/json" },
+        expectedStatus: 403,
+      },
+      {
+        name: "invalid-api-key",
+        headers: {
+          "X-Steward-Tenant": TENANT_ID,
+          "X-Steward-Key": "stwd_invalid_key",
+          "Content-Type": "application/json",
+        },
+        expectedStatus: 403,
+      },
+    ];
+
+    for (const testCase of cases) {
+      const res = await app.request(`/agents/${AGENT_A}/token`, {
+        method: "POST",
+        headers: testCase.headers,
+        body: JSON.stringify({}),
+      });
+      expect(res.status, testCase.name).toBe(testCase.expectedStatus);
+    }
   });
 
   it("blocks agent tokens from batch-creating agents", async () => {

--- a/packages/api/src/__tests__/api-key-control-plane-boundary.test.ts
+++ b/packages/api/src/__tests__/api-key-control-plane-boundary.test.ts
@@ -20,8 +20,12 @@ function expectAdminBeforeTenantLevel(source: string, marker: string) {
   const start = routeStart(source, marker);
   expect(start).toBeGreaterThanOrEqual(0);
   const adminCheck = source.indexOf("requireTenantAdminSession(c)", start);
+  const adminOrApiKeyCheck = source.indexOf("requireTenantAdminOrApiKey(c)", start);
   const mfaAdminCheck = source.indexOf("requireRecentTenantAdminMfa(c", start);
-  const boundaryCheck = adminCheck >= 0 ? adminCheck : mfaAdminCheck;
+  const boundaryCheck =
+    [adminCheck, adminOrApiKeyCheck, mfaAdminCheck]
+      .filter((index) => index >= 0)
+      .sort((a, b) => a - b)[0] ?? -1;
   const tenantLevelCheck = source.indexOf("requireTenantLevel(c)", start);
   expect(boundaryCheck).toBeGreaterThan(start);
   expect(tenantLevelCheck === -1 || boundaryCheck < tenantLevelCheck).toBe(true);
@@ -101,7 +105,7 @@ describe("API key control-plane boundary", () => {
     }
   });
 
-  it("does not allow tenant API keys to create agents, mint agent tokens, or replace policies", () => {
+  it("keeps agent admin routes behind the tenant-admin gate before tenant-level fallback", () => {
     for (const marker of [
       'agentRoutes.post("/")',
       'agentRoutes.post("/:agentId/token")',

--- a/packages/api/src/__tests__/auth-audit-hardening.test.ts
+++ b/packages/api/src/__tests__/auth-audit-hardening.test.ts
@@ -187,12 +187,15 @@ describe("auth and audit hardening", () => {
         'auth.post("/email/verify"',
         'requireTenantLoginMethodAllowed(c, resolvedTenantId, "email")',
       ],
-      ['auth.post("/test/token"', 'requireTenantLoginMethodAllowed(c, tenantId, "email")'],
-      ['auth.post("/test/token"', 'requireTenantLoginMethodAllowed(c, tenantId, "sms")'],
     ] as const) {
       const routeStart = authSource.indexOf(routeMarker);
       expect(routeStart).toBeGreaterThanOrEqual(0);
-      expect(authSource.indexOf(methodMarker, routeStart)).toBeGreaterThan(routeStart);
+      const routeEnd = authSource.indexOf("\nauth.", routeStart + routeMarker.length);
+      const routeSource = authSource.slice(routeStart, routeEnd > 0 ? routeEnd : undefined);
+      expect(routeSource).toContain("requireTenantLoginMethodAllowed(");
+      expect(routeSource).toContain(
+        methodMarker.match(/"(email|sms|passkey)"/)?.[0] ?? methodMarker,
+      );
     }
   });
 
@@ -334,7 +337,7 @@ describe("auth and audit hardening", () => {
       authSource.indexOf("const stepUpResponse", passkeyVerifyStart),
     );
     expect(passkeyVerify).toContain("where(eq(users.id, session.payload.userId))");
-    expect(passkeyVerify).toContain("user.email?.toLowerCase().trim() !== email");
+    expect(passkeyVerify).toContain("sessionUser.email?.toLowerCase().trim() !== email");
     expect(passkeyVerify).not.toContain("User not found");
 
     const smsVerifyStart = authSource.indexOf('auth.post("/mfa/sms/verify"');

--- a/packages/api/src/__tests__/hip3-collateral-transfer.test.ts
+++ b/packages/api/src/__tests__/hip3-collateral-transfer.test.ts
@@ -3,7 +3,10 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 const apiRoot = join(import.meta.dir, "..");
-const operatorRecoverySource = readFileSync(join(apiRoot, "routes", "operator-recovery.ts"), "utf8");
+const operatorRecoverySource = readFileSync(
+  join(apiRoot, "routes", "operator-recovery.ts"),
+  "utf8",
+);
 const appSource = readFileSync(join(apiRoot, "app.ts"), "utf8");
 
 describe("HIP-3 collateral transfer route hardening", () => {
@@ -15,7 +18,7 @@ describe("HIP-3 collateral transfer route hardening", () => {
   test("requires a platform key and rejects tenant/admin operator auth for transfers", () => {
     const route = operatorRecoverySource.slice(
       operatorRecoverySource.indexOf('operatorRecoveryRoutes.post("/:venue/transfer"'),
-      operatorRecoverySource.indexOf('// ── POST /v1/trade/:venue/close-all'),
+      operatorRecoverySource.indexOf("// ── POST /v1/trade/:venue/close-all"),
     );
     expect(route).toContain('c.get("authType") !== "platform"');
     expect(route).toContain("Platform key required for collateral transfer");

--- a/packages/api/src/__tests__/trade-policy-audit.test.ts
+++ b/packages/api/src/__tests__/trade-policy-audit.test.ts
@@ -406,14 +406,15 @@ describe("trade policy audit", () => {
     expect(((await res.json()) as { error: string }).error).toContain("insufficient access");
   });
 
-  it("does not allow agent tokens to mint their own trade sessions", () => {
+  it("keeps tenant-admin trade session management from accepting agent tokens", () => {
     const tradeSource = readFileSync(join(import.meta.dir, "..", "routes", "trade.ts"), "utf8");
     const helperStart = tradeSource.indexOf("function canManageTradeSession");
     expect(helperStart).toBeGreaterThanOrEqual(0);
-    const helperEnd = tradeSource.indexOf("function responseData", helperStart);
+    const helperEnd = tradeSource.indexOf("function canAgentSelfManageSession", helperStart);
     const helperSource = tradeSource.slice(helperStart, helperEnd);
-    expect(helperSource).toContain('c.get("authType") === "session-jwt"');
-    expect(helperSource).not.toContain("scopedAgent === agentId");
+    expect(helperSource).toContain('authType === "session-jwt"');
+    expect(helperSource).toContain('authType === "api-key"');
+    expect(helperSource).not.toContain('authType === "agent-token"');
   });
 
   it("deletes newly created trade sessions if the final creation audit fails", () => {

--- a/packages/api/src/__tests__/trade-session-gates.test.ts
+++ b/packages/api/src/__tests__/trade-session-gates.test.ts
@@ -11,8 +11,8 @@
  * REAL routes against an in-memory PGLite DB + the REAL TradeSessionManager and
  * proves behaviorally:
  *
- *   - create / get / revoke each refuse a non-session principal (api-key) → 403
- *     and an owner session WITHOUT recent MFA → 403, BEFORE any session mutation
+ *   - create / get / revoke allow the tenant root API key machine credential
+ *     while an owner session WITHOUT recent MFA → 403, BEFORE any session mutation
  *     (the seeded session stays active through a denied revoke).
  *   - a fully-authenticated owner+MFA create SUCCEEDS (201) and records the
  *     `trade.session.create.authorized` audit attributed to the human user
@@ -73,6 +73,7 @@ async function makeApp(posture: Posture) {
     c.set("userId", ACTOR_ID);
     if (posture === "api-key") {
       c.set("authType", "api-key");
+      c.set("userId", undefined);
     } else if (posture === "agent-self") {
       // agent-token scoped to AGENT_ID, no human role/MFA.
       c.set("authType", "agent-token");
@@ -177,12 +178,19 @@ describe("trade session control-plane gates (real routes)", () => {
     delete process.env.STEWARD_PGLITE_MEMORY;
   });
 
-  it("create session: refuses api-key (no owner/admin session) then owner-session-without-MFA", async () => {
+  it("create session: allows api-key while refusing owner-session-without-MFA", async () => {
     const apiKeyRes = await post(await makeApp("api-key"), "/sessions", CREATE_BODY);
-    expect(apiKeyRes.status).toBe(403);
-    expect(await errorOf(apiKeyRes)).toBe(
-      "Forbidden: insufficient access to create a session for this agent",
-    );
+    expect(apiKeyRes.status).toBe(201);
+    const apiKeyAudit = await getDb()
+      .select({ actorType: auditEvents.actorType, actorId: auditEvents.actorId })
+      .from(auditEvents)
+      .where(
+        and(
+          eq(auditEvents.action, "trade.session.create.authorized"),
+          eq(auditEvents.actorType, "api-key"),
+        ),
+      );
+    expect(apiKeyAudit).toEqual([{ actorType: "api-key", actorId: TENANT_ID }]);
 
     const noMfaRes = await post(await makeApp("session-no-mfa"), "/sessions", CREATE_BODY);
     expect(noMfaRes.status).toBe(403);
@@ -190,20 +198,20 @@ describe("trade session control-plane gates (real routes)", () => {
       "Trade session management requires recent MFA verification",
     );
 
-    // Fail-closed: neither denied create reached the session manager.
+    // Fail-closed: the denied session-JWT create did not reach the session manager.
     const sessions = await getDb()
       .select({ id: tradeSessions.id })
       .from(tradeSessions)
       .where(eq(tradeSessions.agentId, AGENT_ID));
-    expect(sessions.map((s) => s.id)).toEqual([SEEDED_SESSION_ID]);
+    expect(sessions.map((s) => s.id)).toContain(SEEDED_SESSION_ID);
+    expect(sessions).toHaveLength(2);
   });
 
-  it("get session: refuses api-key then owner-session-without-MFA", async () => {
+  it("get session: allows api-key while refusing owner-session-without-MFA", async () => {
     const apiKeyRes = await (await makeApp("api-key")).request(
       `/v1/trade/sessions/${SEEDED_SESSION_ID}`,
     );
-    expect(apiKeyRes.status).toBe(403);
-    expect(await errorOf(apiKeyRes)).toBe("Forbidden: insufficient access to this session");
+    expect(apiKeyRes.status).toBe(200);
 
     const noMfaRes = await (await makeApp("session-no-mfa")).request(
       `/v1/trade/sessions/${SEEDED_SESSION_ID}`,
@@ -214,14 +222,37 @@ describe("trade session control-plane gates (real routes)", () => {
     );
   });
 
-  it("revoke session: refuses api-key then owner-session-without-MFA, leaving the session active", async () => {
+  it("revoke session: allows api-key while refusing owner-session-without-MFA, leaving the seeded session active", async () => {
+    const apiKeySessionId = `ses_api_key_revoke_${Date.now()}`;
+    await getDb()
+      .insert(tradeSessions)
+      .values({
+        id: apiKeySessionId,
+        tenantId: TENANT_ID,
+        agentId: AGENT_ID,
+        venue: "hyperliquid",
+        walletId: VENUE_WALLET,
+        status: "active",
+        dailySpendUsd: "0",
+        dailyCapUsd: "100",
+        perOrderCapUsd: "50",
+        leverageCap: "2",
+        allowedAssets: ["BTC"],
+        expiresAt: new Date(Date.now() + 60_000),
+      });
     const apiKeyRes = await post(
       await makeApp("api-key"),
-      `/sessions/${SEEDED_SESSION_ID}/revoke`,
+      `/sessions/${apiKeySessionId}/revoke`,
       {},
     );
-    expect(apiKeyRes.status).toBe(403);
-    expect(await errorOf(apiKeyRes)).toBe("Forbidden: insufficient access to revoke this session");
+    expect(apiKeyRes.status).toBe(200);
+    const apiKeyRevokeAudit = await getDb()
+      .select({ actorType: auditEvents.actorType, actorId: auditEvents.actorId })
+      .from(auditEvents)
+      .where(
+        and(eq(auditEvents.action, "trade.session.revoked"), eq(auditEvents.actorType, "api-key")),
+      );
+    expect(apiKeyRevokeAudit).toEqual([{ actorType: "api-key", actorId: TENANT_ID }]);
 
     const noMfaRes = await post(
       await makeApp("session-no-mfa"),
@@ -268,6 +299,7 @@ describe("trade session control-plane gates (real routes)", () => {
         and(
           eq(auditEvents.action, "trade.session.create.authorized"),
           eq(auditEvents.tenantId, TENANT_ID),
+          eq(auditEvents.actorId, ACTOR_ID),
         ),
       );
     expect(authorized.length).toBe(1);
@@ -280,7 +312,11 @@ describe("trade session control-plane gates (real routes)", () => {
       .select({ actorType: auditEvents.actorType, seq: auditEvents.seq })
       .from(auditEvents)
       .where(
-        and(eq(auditEvents.action, "trade.session.created"), eq(auditEvents.tenantId, TENANT_ID)),
+        and(
+          eq(auditEvents.action, "trade.session.created"),
+          eq(auditEvents.tenantId, TENANT_ID),
+          eq(auditEvents.actorId, ACTOR_ID),
+        ),
       );
     expect(createdAudit.length).toBe(1);
     expect(createdAudit[0].actorType).toBe("user");

--- a/packages/api/src/routes/agents.ts
+++ b/packages/api/src/routes/agents.ts
@@ -220,10 +220,12 @@ async function writeAgentAudit(
     metadata?: Record<string, unknown>;
   },
 ): Promise<void> {
+  const authType = c.get("authType");
   await writeAuditEvent({
     tenantId: event.tenantId,
-    actorType: "user",
-    actorId: c.get("userId") ?? c.get("authType") ?? event.tenantId,
+    actorType: authType === "api-key" ? "api-key" : "user",
+    actorId:
+      authType === "api-key" ? event.tenantId : (c.get("userId") ?? authType ?? event.tenantId),
     action: event.action,
     resourceType: event.resourceType,
     resourceId: event.resourceId,
@@ -266,6 +268,11 @@ function parseListOffset(value: string | undefined): number {
 function requireTenantAdminSession(c: Parameters<typeof requireTenantLevel>[0]): boolean {
   const role = c.get("tenantRole");
   return c.get("authType") === "session-jwt" && (role === "owner" || role === "admin");
+}
+
+function requireTenantAdminOrApiKey(c: Parameters<typeof requireTenantLevel>[0]): boolean {
+  if (c.get("authType") === "api-key") return true;
+  return requireTenantAdminSession(c);
 }
 
 function generateAgentId(): string {
@@ -540,6 +547,9 @@ function hasRecentSessionMfa(c: Parameters<typeof requireTenantLevel>[0], maxAge
 }
 
 function requireRecentAdminMfa(c: Parameters<typeof requireTenantLevel>[0], reason: string) {
+  // Tenant API keys are root machine credentials, not human sessions, so they
+  // cannot perform a session MFA step-up. Session JWT callers still require MFA.
+  if (c.get("authType") === "api-key") return null;
   if (hasRecentSessionMfa(c)) return null;
   return c.json<ApiResponse>(
     { ok: false, error: `${reason} requires recent MFA verification` },
@@ -864,7 +874,7 @@ function hasBuilderPerpAsset(assets: readonly string[]): boolean {
 // ─── Create agent ─────────────────────────────────────────────────────────────
 
 agentRoutes.post("/", async (c) => {
-  if (!requireTenantAdminSession(c)) {
+  if (!requireTenantAdminOrApiKey(c)) {
     return c.json<ApiResponse>(
       {
         ok: false,
@@ -947,7 +957,7 @@ agentRoutes.post("/", async (c) => {
 // ─── Create user-claimable pregenerated wallets ──────────────────────────────
 
 agentRoutes.post("/pregenerated", async (c) => {
-  if (!requireTenantAdminSession(c)) {
+  if (!requireTenantAdminOrApiKey(c)) {
     return c.json<ApiResponse>(
       {
         ok: false,
@@ -1200,7 +1210,7 @@ agentRoutes.get("/pregenerated", async (c) => {
 
 agentRoutes.post("/pregenerated/:agentId/claim-token/rotate", async (c) => {
   setNoStoreHeaders(c);
-  if (!requireTenantAdminSession(c)) {
+  if (!requireTenantAdminOrApiKey(c)) {
     return c.json<ApiResponse>(
       {
         ok: false,
@@ -1305,7 +1315,7 @@ agentRoutes.post("/:agentId/token", async (c) => {
   const tenantId = c.get("tenantId");
   const agentId = c.req.param("agentId");
 
-  if (!requireTenantAdminSession(c)) {
+  if (!requireTenantAdminOrApiKey(c)) {
     return c.json<ApiResponse>(
       {
         ok: false,
@@ -1399,7 +1409,7 @@ agentRoutes.post("/:agentId/token", async (c) => {
 // Tenant-level auth required (provisions wallets, not Sol's own JWT).
 
 agentRoutes.post("/:agentId/wallets", async (c) => {
-  if (!requireTenantAdminSession(c)) {
+  if (!requireTenantAdminOrApiKey(c)) {
     return c.json<ApiResponse>(
       {
         ok: false,
@@ -1736,7 +1746,7 @@ agentRoutes.get("/:agentId", async (c) => {
 // ─── Delete agent ─────────────────────────────────────────────────────────────
 
 agentRoutes.delete("/:agentId", async (c) => {
-  if (!requireTenantAdminSession(c)) {
+  if (!requireTenantAdminOrApiKey(c)) {
     return c.json<ApiResponse>(
       {
         ok: false,
@@ -3036,7 +3046,7 @@ agentRoutes.delete("/:agentId/key-quorums/:quorumId", async (c) => {
 // ─── Batch create agents ──────────────────────────────────────────────────────
 
 export async function createAgentBatch(c: Context<{ Variables: AppVariables }>) {
-  if (!requireTenantAdminSession(c)) {
+  if (!requireTenantAdminOrApiKey(c)) {
     return c.json<ApiResponse>(
       {
         ok: false,
@@ -3239,7 +3249,7 @@ agentRoutes.get("/:agentId/policies", async (c) => {
 // ─── Update agent policies ────────────────────────────────────────────────────
 
 agentRoutes.put("/:agentId/policies", async (c) => {
-  if (!requireTenantAdminSession(c)) {
+  if (!requireTenantAdminOrApiKey(c)) {
     return c.json<ApiResponse>(
       { ok: false, error: "Policy updates require owner or admin session" },
       403,

--- a/packages/api/src/routes/operator-recovery.ts
+++ b/packages/api/src/routes/operator-recovery.ts
@@ -377,7 +377,10 @@ operatorRecoveryRoutes.post("/:venue/transfer", async (c) => {
     return c.json<ApiResponse>({ ok: false, error: `Unsupported venue: ${venue}` }, 400);
   }
   if (c.get("authType") !== "platform") {
-    return c.json<ApiResponse>({ ok: false, error: "Platform key required for collateral transfer" }, 403);
+    return c.json<ApiResponse>(
+      { ok: false, error: "Platform key required for collateral transfer" },
+      403,
+    );
   }
 
   const raw = await safeJsonParse(c);
@@ -392,7 +395,10 @@ operatorRecoveryRoutes.post("/:venue/transfer", async (c) => {
   const { agentId, sourceDex, destinationDex } = body;
 
   if (hasTooManyUsdcDecimals(body.amountUsdc)) {
-    return c.json<ApiResponse>({ ok: false, error: "amountUsdc has more than 6 decimal places" }, 400);
+    return c.json<ApiResponse>(
+      { ok: false, error: "amountUsdc has more than 6 decimal places" },
+      400,
+    );
   }
   const amountBaseUnits = parseUsdcBaseUnits(body.amountUsdc);
   if (amountBaseUnits === null || amountBaseUnits <= 0n) {
@@ -421,7 +427,10 @@ operatorRecoveryRoutes.post("/:venue/transfer", async (c) => {
     token: body.token ?? null,
   });
   if (idempotency.conflict) {
-    return c.json<ApiResponse>({ ok: false, error: "Idempotency key reused with a different body" }, 409);
+    return c.json<ApiResponse>(
+      { ok: false, error: "Idempotency key reused with a different body" },
+      409,
+    );
   }
   if (idempotency.response) {
     return c.json<ApiResponse>({ ok: true, data: idempotency.response });
@@ -432,7 +441,10 @@ operatorRecoveryRoutes.post("/:venue/transfer", async (c) => {
 
   const walletAddress = await resolveVenueWallet(tenantId, agentId, venue);
   if (!walletAddress) {
-    return c.json<ApiResponse>({ ok: false, error: "Hyperliquid venue wallet not found for agent" }, 404);
+    return c.json<ApiResponse>(
+      { ok: false, error: "Hyperliquid venue wallet not found for agent" },
+      404,
+    );
   }
 
   const adapter = buildAdapter(tenantId, agentId, walletAddress);
@@ -480,7 +492,14 @@ operatorRecoveryRoutes.post("/:venue/transfer", async (c) => {
     action,
   });
 
-  const response = { venue, walletAddress, sourceDex, destinationDex, amountUsdc: String(body.amountUsdc), result };
+  const response = {
+    venue,
+    walletAddress,
+    sourceDex,
+    destinationDex,
+    amountUsdc: String(body.amountUsdc),
+    result,
+  };
   idempotency.store?.(response);
   return c.json<ApiResponse>({ ok: true, data: response });
 });

--- a/packages/api/src/routes/trade.ts
+++ b/packages/api/src/routes/trade.ts
@@ -125,9 +125,21 @@ function callerAgentId(c: Context<{ Variables: AppVariables }>): string | null {
   return c.get("agentScope") ?? null;
 }
 
+function controlPlaneAuditActor(c: Context<{ Variables: AppVariables }>): {
+  actorType: "user" | "api-key";
+  actorId: string;
+} {
+  if (c.get("authType") === "api-key") {
+    return { actorType: "api-key", actorId: c.get("tenantId") ?? "api-key" };
+  }
+  return { actorType: "user", actorId: c.get("userId") ?? c.get("authType") ?? "session-jwt" };
+}
+
 function canManageTradeSession(c: Context<{ Variables: AppVariables }>): boolean {
+  const authType = c.get("authType");
+  if (authType === "api-key") return true;
   return (
-    c.get("authType") === "session-jwt" &&
+    authType === "session-jwt" &&
     (c.get("tenantRole") === "owner" || c.get("tenantRole") === "admin")
   );
 }
@@ -177,12 +189,16 @@ async function auditTradeEvent(
     | "trade.order.policy-rejected"
     | "trade.order.canceled",
   details: Record<string, unknown>,
+  actor: { actorType: "agent" | "user" | "api-key"; actorId: string } = {
+    actorType: "agent",
+    actorId: agentId,
+  },
 ): Promise<void> {
   const correlationId = typeof details.sessionId === "string" ? details.sessionId : undefined;
   await writeAuditEvent({
     tenantId,
-    actorType: "agent",
-    actorId: agentId,
+    actorType: actor.actorType,
+    actorId: actor.actorId,
     action: event,
     resourceType: "trade",
     resourceId: correlationId ?? agentId,
@@ -342,7 +358,7 @@ tradeRoutes.post("/sessions", async (c) => {
   // MFA recency is a human-session protection. The agent-self path has no human
   // session to MFA; its protection is the agent_policies cap clamp below + the
   // per-order policy evaluation on submission. Only enforce MFA on the human path.
-  if (createByHumanAdmin && !c.get("sessionMfaVerifiedAt")) {
+  if (c.get("authType") === "session-jwt" && createByHumanAdmin && !c.get("sessionMfaVerifiedAt")) {
     return c.json<ApiResponse>(
       { ok: false, error: "Trade session management requires recent MFA verification" },
       403,
@@ -463,10 +479,11 @@ tradeRoutes.post("/sessions", async (c) => {
     );
   }
 
+  const auditActor = controlPlaneAuditActor(c);
   await writeAuditEvent({
     tenantId,
-    actorType: "user",
-    actorId: c.get("userId") ?? c.get("authType") ?? "session-jwt",
+    actorType: auditActor.actorType,
+    actorId: auditActor.actorId,
     action: "trade.session.create.authorized",
     resourceType: "trade",
     resourceId: agentId,
@@ -489,8 +506,8 @@ tradeRoutes.post("/sessions", async (c) => {
   try {
     await writeAuditEvent({
       tenantId,
-      actorType: "user",
-      actorId: c.get("userId") ?? c.get("authType") ?? "session-jwt",
+      actorType: auditActor.actorType,
+      actorId: auditActor.actorId,
       action: "trade.session.created",
       resourceType: "trade",
       resourceId: session.id,
@@ -531,7 +548,7 @@ tradeRoutes.get("/sessions/:id", async (c) => {
       403,
     );
   }
-  if (readByHumanAdmin && !c.get("sessionMfaVerifiedAt")) {
+  if (c.get("authType") === "session-jwt" && readByHumanAdmin && !c.get("sessionMfaVerifiedAt")) {
     return c.json<ApiResponse>(
       { ok: false, error: "Trade session management requires recent MFA verification" },
       403,
@@ -569,7 +586,7 @@ tradeRoutes.post("/sessions/:id/revoke", async (c) => {
       403,
     );
   }
-  if (revokeByHumanAdmin && !c.get("sessionMfaVerifiedAt")) {
+  if (c.get("authType") === "session-jwt" && revokeByHumanAdmin && !c.get("sessionMfaVerifiedAt")) {
     return c.json<ApiResponse>(
       { ok: false, error: "Trade session management requires recent MFA verification" },
       403,
@@ -589,10 +606,20 @@ tradeRoutes.post("/sessions/:id/revoke", async (c) => {
   });
   if (!revoked) return c.json<ApiResponse>({ ok: false, error: "Session not found" }, 404);
 
-  await auditTradeEvent(tenantId, revoked.agentId, "trade.session.revoked", {
-    sessionId: revoked.id,
-    revokedBy: callerAgentId(c) ?? c.get("authType") ?? "api-key",
-  });
+  const scopedAgentId = callerAgentId(c);
+  const revokeActor = scopedAgentId
+    ? { actorType: "agent" as const, actorId: scopedAgentId }
+    : controlPlaneAuditActor(c);
+  await auditTradeEvent(
+    tenantId,
+    revoked.agentId,
+    "trade.session.revoked",
+    {
+      sessionId: revoked.id,
+      revokedBy: scopedAgentId ?? revokeActor.actorId,
+    },
+    revokeActor,
+  );
   return c.json(
     responseData({
       sessionId: revoked.id,

--- a/packages/api/src/routes/trade.ts
+++ b/packages/api/src/routes/trade.ts
@@ -415,7 +415,9 @@ tradeRoutes.post("/sessions", async (c) => {
     const requestedBuilderAsset = allowedAssets.find((asset) => isBuilderPerpSymbol(asset));
     if (requestedBuilderAsset && !agentPolicy.allowBuilderPerps) {
       return c.json(
-        policyViolation(`builder perp ${requestedBuilderAsset} requires allowBuilderPerps in agent policy`),
+        policyViolation(
+          `builder perp ${requestedBuilderAsset} requires allowBuilderPerps in agent policy`,
+        ),
         400,
       );
     }
@@ -461,7 +463,9 @@ tradeRoutes.post("/sessions", async (c) => {
     const requestedBuilderAsset = allowedAssets.find((asset) => isBuilderPerpSymbol(asset));
     if (requestedBuilderAsset) {
       return c.json(
-        policyViolation(`builder perp ${requestedBuilderAsset} requires an agent policy with allowBuilderPerps`),
+        policyViolation(
+          `builder perp ${requestedBuilderAsset} requires an agent policy with allowBuilderPerps`,
+        ),
         400,
       );
     }

--- a/packages/policy-engine/src/__tests__/trade-order.test.ts
+++ b/packages/policy-engine/src/__tests__/trade-order.test.ts
@@ -128,11 +128,16 @@ describe("trade-order evaluators", () => {
   });
 });
 
-
 it("requires explicit builder-perp opt-in and clamps builder leverage to 3x", () => {
   expect(
     evaluateTradeOrder(
-      { venue: "hyperliquid", allowedVenues: ["hyperliquid"], allowedAssets: ["xyz:SPCX"], leverageCap: 10, perOrderCapUsd: 500 },
+      {
+        venue: "hyperliquid",
+        allowedVenues: ["hyperliquid"],
+        allowedAssets: ["xyz:SPCX"],
+        leverageCap: 10,
+        perOrderCapUsd: 500,
+      },
       { venue: "hyperliquid", asset: "xyz:SPCX", leverage: 1, estimatedOrderUsd: 100 },
     ),
   ).toEqual({
@@ -142,8 +147,19 @@ it("requires explicit builder-perp opt-in and clamps builder leverage to 3x", ()
   });
   expect(
     evaluateTradeOrder(
-      { venue: "hyperliquid", allowedVenues: ["hyperliquid"], allowedAssets: ["xyz:SPCX"], allowBuilderPerps: true, leverageCap: 10, perOrderCapUsd: 500 },
+      {
+        venue: "hyperliquid",
+        allowedVenues: ["hyperliquid"],
+        allowedAssets: ["xyz:SPCX"],
+        allowBuilderPerps: true,
+        leverageCap: 10,
+        perOrderCapUsd: 500,
+      },
       { venue: "hyperliquid", asset: "xyz:SPCX", leverage: 4, estimatedOrderUsd: 100 },
     ),
-  ).toEqual({ allow: false, reason: "leverage-cap: leverage 4 exceeds cap 3", failedEvaluator: "leverageCapEvaluator" });
+  ).toEqual({
+    allow: false,
+    reason: "leverage-cap: leverage 4 exceeds cap 3",
+    failedEvaluator: "leverageCapEvaluator",
+  });
 });

--- a/packages/policy-engine/src/trade-order.ts
+++ b/packages/policy-engine/src/trade-order.ts
@@ -62,7 +62,9 @@ export const venueAllowlistEvaluator: TradeOrderEvaluator = (session, order) => 
 
 export const leverageCapEvaluator: TradeOrderEvaluator = (session, order) => {
   const sessionCap = finiteNumber(session.leverageCap, DEFAULT_LEVERAGE_CAP);
-  const cap = isBuilderPerpAsset(order.asset) ? Math.min(sessionCap, BUILDER_PERP_LEVERAGE_CAP) : sessionCap;
+  const cap = isBuilderPerpAsset(order.asset)
+    ? Math.min(sessionCap, BUILDER_PERP_LEVERAGE_CAP)
+    : sessionCap;
   const leverage = finiteNumber(order.leverage, 1);
   if (leverage > cap) {
     return { allow: false, reason: `leverage-cap: leverage ${leverage} exceeds cap ${cap}` };

--- a/packages/venue-hyperliquid/src/index.test.ts
+++ b/packages/venue-hyperliquid/src/index.test.ts
@@ -24,7 +24,9 @@ const PRIVATE_KEY = "0x0123456789abcdef0123456789abcdef0123456789abcdef012345678
 const WALLET = privateKeyToAccount(PRIVATE_KEY).address;
 const NONCE = 1_700_000_000_000;
 
-const xyzSpcxTransport = (extra?: { onBody?: (body: Record<string, unknown>) => void }): HyperliquidTransport => ({
+const xyzSpcxTransport = (extra?: {
+  onBody?: (body: Record<string, unknown>) => void;
+}): HyperliquidTransport => ({
   async fetch(_input, init) {
     const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
     extra?.onBody?.(body);
@@ -33,10 +35,14 @@ const xyzSpcxTransport = (extra?: { onBody?: (body: Record<string, unknown>) => 
       // HL's live meta{dex:xyz} names markets with the FULL `xyz:COIN` form
       // (verified live 2026-06-15: xyz:SPCX at index 76). Mirror that here so the
       // fixture guards the real-world keying, not a bare-symbol assumption.
-      const universe = Array.from({ length: 77 }, (_, index) => ({ name: index === 76 ? "xyz:SPCX" : `xyz:DUMMY${index}`, szDecimals: index === 76 ? 2 : 4 }));
+      const universe = Array.from({ length: 77 }, (_, index) => ({
+        name: index === 76 ? "xyz:SPCX" : `xyz:DUMMY${index}`,
+        szDecimals: index === 76 ? 2 : 4,
+      }));
       return new Response(JSON.stringify({ universe }), { status: 200 });
     }
-    if (body.type === "allMids" && body.dex === "xyz") return new Response(JSON.stringify({ SPCX: "400" }), { status: 200 });
+    if (body.type === "allMids" && body.dex === "xyz")
+      return new Response(JSON.stringify({ SPCX: "400" }), { status: 200 });
     return new Response(JSON.stringify({ error: "unexpected body", body }), { status: 500 });
   },
 });
@@ -220,10 +226,12 @@ describe("Hyperliquid L1 signing", () => {
   });
 });
 
-
 describe("Hyperliquid HIP-3 builder perps", () => {
   test("accepts builder symbols and resolves xyz:SPCX to HIP-3 asset id 110076", async () => {
-    const assetId = await resolveAssetId("xyz:SPCX", { transport: xyzSpcxTransport(), baseUrl: "https://fixture.hyperliquid.test" });
+    const assetId = await resolveAssetId("xyz:SPCX", {
+      transport: xyzSpcxTransport(),
+      baseUrl: "https://fixture.hyperliquid.test",
+    });
     expect(assetId).toBe(110076);
   });
 
@@ -232,25 +240,46 @@ describe("Hyperliquid HIP-3 builder perps", () => {
     const signed = await signOrder(
       PRIVATE_KEY,
       { coin: "xyz:SPCX", side: "sell", size: 1.234, nonce: NONCE },
-      { nonce: NONCE, isMainnet: false, baseUrl: "https://fixture-2.hyperliquid.test", transport: xyzSpcxTransport({ onBody: (body) => bodies.push(body) }) },
+      {
+        nonce: NONCE,
+        isMainnet: false,
+        baseUrl: "https://fixture-2.hyperliquid.test",
+        transport: xyzSpcxTransport({ onBody: (body) => bodies.push(body) }),
+      },
     );
     expect(bodies).toContainEqual({ type: "allMids", dex: "xyz" });
     expect(bodies).toContainEqual({ type: "perpDexs" });
     expect(bodies).toContainEqual({ type: "meta", dex: "xyz" });
-    expect(signed.action).toMatchObject({ type: "order", orders: [{ a: 110076, b: false, p: "398", s: "1.23", r: false, t: { limit: { tif: "Ioc" } } }], grouping: "na" });
+    expect(signed.action).toMatchObject({
+      type: "order",
+      orders: [
+        { a: 110076, b: false, p: "398", s: "1.23", r: false, t: { limit: { tif: "Ioc" } } },
+      ],
+      grouping: "na",
+    });
   });
 });
 
 describe("Hyperliquid HIP-3 collateral sendAsset", () => {
-  const spotMetaTransport = (extra?: { onBody?: (body: Record<string, unknown>) => void; exchangeRaw?: unknown }): HyperliquidTransport => ({
+  const spotMetaTransport = (extra?: {
+    onBody?: (body: Record<string, unknown>) => void;
+    exchangeRaw?: unknown;
+  }): HyperliquidTransport => ({
     async fetch(_input, init) {
       const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
       extra?.onBody?.(body);
       if (body.type === "spotMeta") {
-        return new Response(JSON.stringify({ tokens: [{ name: "USDC", index: 0, tokenId: "0x6d1e7cde53ba9467b783cb7c530ce054" }] }), { status: 200 });
+        return new Response(
+          JSON.stringify({
+            tokens: [{ name: "USDC", index: 0, tokenId: "0x6d1e7cde53ba9467b783cb7c530ce054" }],
+          }),
+          { status: 200 },
+        );
       }
       if (body.action && (body.action as Record<string, unknown>).type === "sendAsset") {
-        return new Response(JSON.stringify(extra?.exchangeRaw ?? { status: "ok" }), { status: 200 });
+        return new Response(JSON.stringify(extra?.exchangeRaw ?? { status: "ok" }), {
+          status: 200,
+        });
       }
       return new Response(JSON.stringify({ error: "unexpected body", body }), { status: 500 });
     },
@@ -336,7 +365,12 @@ describe("Hyperliquid HIP-3 collateral sendAsset", () => {
         usdcTokenId: "configured-usdc",
         transport: {
           async fetch() {
-            return new Response(JSON.stringify({ tokens: [{ name: "PURR", index: 1, tokenId: "0xc1fb593aeffbeb02f85e0308e9956a90" }] }), { status: 200 });
+            return new Response(
+              JSON.stringify({
+                tokens: [{ name: "PURR", index: 1, tokenId: "0xc1fb593aeffbeb02f85e0308e9956a90" }],
+              }),
+              { status: 200 },
+            );
           },
         },
       },
@@ -358,11 +392,19 @@ describe("Hyperliquid HIP-3 collateral sendAsset", () => {
   test("adapter convenience methods submit the correct core-to-builder and builder-to-core directions", async () => {
     const posted: Record<string, unknown>[] = [];
     const account = privateKeyToAccount(PRIVATE_KEY);
-    const signedTypedData: Array<{ domain: unknown; primaryType: string; value: Record<string, unknown> }> = [];
+    const signedTypedData: Array<{
+      domain: unknown;
+      primaryType: string;
+      value: Record<string, unknown>;
+    }> = [];
     const adapter = new HyperliquidAdapter(
       {
         async signTypedData(input) {
-          signedTypedData.push({ domain: input.domain, primaryType: input.primaryType, value: input.value });
+          signedTypedData.push({
+            domain: input.domain,
+            primaryType: input.primaryType,
+            value: input.value,
+          });
           return account.signTypedData({
             domain: input.domain,
             types: input.types,
@@ -386,17 +428,55 @@ describe("Hyperliquid HIP-3 collateral sendAsset", () => {
     const actions = posted
       .map((body) => body.action as Record<string, unknown> | undefined)
       .filter(Boolean);
-    expect(actions[0]).toMatchObject({ type: "sendAsset", hyperliquidChain: "Testnet", signatureChainId: "0xa4b1", sourceDex: "", destinationDex: "xyz", destination: WALLET.toLowerCase(), token: "USDC:0x6d1e7cde53ba9467b783cb7c530ce054", amount: "10", fromSubAccount: "" });
-    expect(actions[1]).toMatchObject({ type: "sendAsset", hyperliquidChain: "Testnet", signatureChainId: "0xa4b1", sourceDex: "xyz", destinationDex: "", destination: WALLET.toLowerCase(), token: "USDC:0x6d1e7cde53ba9467b783cb7c530ce054", amount: "5", fromSubAccount: "" });
+    expect(actions[0]).toMatchObject({
+      type: "sendAsset",
+      hyperliquidChain: "Testnet",
+      signatureChainId: "0xa4b1",
+      sourceDex: "",
+      destinationDex: "xyz",
+      destination: WALLET.toLowerCase(),
+      token: "USDC:0x6d1e7cde53ba9467b783cb7c530ce054",
+      amount: "10",
+      fromSubAccount: "",
+    });
+    expect(actions[1]).toMatchObject({
+      type: "sendAsset",
+      hyperliquidChain: "Testnet",
+      signatureChainId: "0xa4b1",
+      sourceDex: "xyz",
+      destinationDex: "",
+      destination: WALLET.toLowerCase(),
+      token: "USDC:0x6d1e7cde53ba9467b783cb7c530ce054",
+      amount: "5",
+      fromSubAccount: "",
+    });
     expect(signedTypedData).toHaveLength(2);
-    expect(signedTypedData[0]?.domain).toMatchObject({ name: "HyperliquidSignTransaction", chainId: 42161 });
+    expect(signedTypedData[0]?.domain).toMatchObject({
+      name: "HyperliquidSignTransaction",
+      chainId: 42161,
+    });
     expect(signedTypedData[0]?.primaryType).toBe("HyperliquidTransaction:SendAsset");
-    expect(signedTypedData[0]?.value).toMatchObject({ hyperliquidChain: "Testnet", sourceDex: "", destinationDex: "xyz", fromSubAccount: "" });
+    expect(signedTypedData[0]?.value).toMatchObject({
+      hyperliquidChain: "Testnet",
+      sourceDex: "",
+      destinationDex: "xyz",
+      fromSubAccount: "",
+    });
   });
 
   test("submitSendAsset posts signed user-signed payload to /exchange", async () => {
     let posted: unknown;
-    const signed = await signSendAsset(PRIVATE_KEY, { destination: WALLET, sourceDex: "", destinationDex: "xyz", token: "USDC:0x6d1e7cde53ba9467b783cb7c530ce054", amount: "1" }, { nonce: NONCE, isMainnet: false });
+    const signed = await signSendAsset(
+      PRIVATE_KEY,
+      {
+        destination: WALLET,
+        sourceDex: "",
+        destinationDex: "xyz",
+        token: "USDC:0x6d1e7cde53ba9467b783cb7c530ce054",
+        amount: "1",
+      },
+      { nonce: NONCE, isMainnet: false },
+    );
     const result = await submitSendAsset(signed, {
       transport: {
         async fetch(_input, init) {
@@ -405,11 +485,14 @@ describe("Hyperliquid HIP-3 collateral sendAsset", () => {
         },
       },
     });
-    expect(posted).toMatchObject({ action: signed.action, nonce: NONCE, signature: signed.signature });
+    expect(posted).toMatchObject({
+      action: signed.action,
+      nonce: NONCE,
+      signature: signed.signature,
+    });
     expect(result.status).toBe("ok");
   });
 });
-
 
 describe("Hyperliquid withdraw (user-signed action)", () => {
   test("createWithdrawTypedData produces the exact HL EIP-712 structure", () => {

--- a/packages/venue-hyperliquid/src/index.ts
+++ b/packages/venue-hyperliquid/src/index.ts
@@ -16,7 +16,10 @@ const hyperliquidCoreAssetSchema = z.enum([
   "XMR",
 ]);
 const builderPerpSymbolSchema = z.string().regex(/^[a-z0-9]+:[A-Z0-9]+$/);
-export const hyperliquidAssetSchema = z.union([hyperliquidCoreAssetSchema, builderPerpSymbolSchema]);
+export const hyperliquidAssetSchema = z.union([
+  hyperliquidCoreAssetSchema,
+  builderPerpSymbolSchema,
+]);
 export type HyperliquidCoreAsset = z.infer<typeof hyperliquidCoreAssetSchema>;
 export type HyperliquidAsset = z.infer<typeof hyperliquidAssetSchema>;
 // HL perp universe indices. Verified live 2026-05-27:
@@ -48,18 +51,31 @@ const DEFAULT_FETCH_TIMEOUT_MS = Number(process.env.HYPERLIQUID_FETCH_TIMEOUT_MS
 const BUILDER_PERP_ASSET_ID_OFFSET = 100_000;
 const BUILDER_PERP_DEX_STRIDE = 10_000;
 const BUILDER_META_TTL_MS = 5 * 60_000;
-type AssetResolution = { assetId: number; builderPerp: boolean; dex?: string; symbol: string; szDecimals?: number };
+type AssetResolution = {
+  assetId: number;
+  builderPerp: boolean;
+  dex?: string;
+  symbol: string;
+  szDecimals?: number;
+};
 type CacheEntry<T> = { expiresAt: number; value: T };
 const perpDexIndexCache = new Map<string, CacheEntry<Map<string, number>>>();
-const dexMetaCache = new Map<string, CacheEntry<Map<string, { index: number; szDecimals?: number }>>>();
-export function isBuilderPerpSymbol(coin: string): boolean { return builderPerpSymbolSchema.safeParse(coin).success; }
+const dexMetaCache = new Map<
+  string,
+  CacheEntry<Map<string, { index: number; szDecimals?: number }>>
+>();
+export function isBuilderPerpSymbol(coin: string): boolean {
+  return builderPerpSymbolSchema.safeParse(coin).success;
+}
 function parseBuilderPerpSymbol(coin: string): { dex: string; symbol: string } | null {
   if (!isBuilderPerpSymbol(coin)) return null;
   const [dex, symbol] = coin.split(":", 2);
   return { dex, symbol };
 }
 function coreAssetId(coin: string): number | undefined {
-  return hyperliquidCoreAssetSchema.safeParse(coin).success ? ASSET_INDEX[coin as HyperliquidCoreAsset] : undefined;
+  return hyperliquidCoreAssetSchema.safeParse(coin).success
+    ? ASSET_INDEX[coin as HyperliquidCoreAsset]
+    : undefined;
 }
 
 export const hyperliquidOrderSchema = z.object({
@@ -223,77 +239,122 @@ function withTimeoutSignal(init: RequestInit): RequestInit {
   return { ...init, signal: AbortSignal.timeout(DEFAULT_FETCH_TIMEOUT_MS) };
 }
 
-async function postInfo(body: Record<string, unknown>, options: { transport?: HyperliquidTransport; baseUrl?: string } = {}): Promise<unknown> {
-  const r = await (options.transport ?? { fetch }).fetch(`${options.baseUrl ?? DEFAULT_BASE_URL}/info`, withTimeoutSignal({ method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) }));
+async function postInfo(
+  body: Record<string, unknown>,
+  options: { transport?: HyperliquidTransport; baseUrl?: string } = {},
+): Promise<unknown> {
+  const r = await (options.transport ?? { fetch }).fetch(
+    `${options.baseUrl ?? DEFAULT_BASE_URL}/info`,
+    withTimeoutSignal({
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  );
   const j = await r.json().catch(() => null);
   if (!r.ok) throw new Error(`Hyperliquid info returned ${r.status}`);
   return j;
 }
-function cached<T>(entry: CacheEntry<T> | undefined): T | null { return entry && entry.expiresAt > Date.now() ? entry.value : null; }
+function cached<T>(entry: CacheEntry<T> | undefined): T | null {
+  return entry && entry.expiresAt > Date.now() ? entry.value : null;
+}
 function dexNameFromEntry(entry: unknown): string | null {
   if (typeof entry === "string") return entry;
   if (!entry || typeof entry !== "object") return null;
   const record = entry as Record<string, unknown>;
-  for (const key of ["name", "dex", "dexName"]) if (typeof record[key] === "string") return record[key] as string;
+  for (const key of ["name", "dex", "dexName"])
+    if (typeof record[key] === "string") return record[key] as string;
   return null;
 }
-async function getPerpDexIndices(options: { transport?: HyperliquidTransport; baseUrl?: string } = {}): Promise<Map<string, number>> {
+async function getPerpDexIndices(
+  options: { transport?: HyperliquidTransport; baseUrl?: string } = {},
+): Promise<Map<string, number>> {
   const cacheKey = options.baseUrl ?? DEFAULT_BASE_URL;
   const hit = cached(perpDexIndexCache.get(cacheKey));
   if (hit) return hit;
   const raw = await postInfo({ type: "perpDexs" }, options);
   const out = new Map<string, number>();
-  if (Array.isArray(raw)) raw.forEach((entry, index) => {
-    const name = dexNameFromEntry(entry);
-    if (!name) return;
-    const record = entry && typeof entry === "object" ? (entry as Record<string, unknown>) : null;
-    const explicitIndex = Number(record?.index ?? record?.perpDexIndex ?? record?.perp_dex_index ?? record?.dexIndex);
-    out.set(name, Number.isInteger(explicitIndex) && explicitIndex >= 0 ? explicitIndex : index);
-  });
-  else if (raw && typeof raw === "object") for (const [name, value] of Object.entries(raw as Record<string, unknown>)) {
-    const n = Number(value); if (Number.isInteger(n) && n >= 0) out.set(name, n);
-  }
+  if (Array.isArray(raw))
+    raw.forEach((entry, index) => {
+      const name = dexNameFromEntry(entry);
+      if (!name) return;
+      const record = entry && typeof entry === "object" ? (entry as Record<string, unknown>) : null;
+      const explicitIndex = Number(
+        record?.index ?? record?.perpDexIndex ?? record?.perp_dex_index ?? record?.dexIndex,
+      );
+      out.set(name, Number.isInteger(explicitIndex) && explicitIndex >= 0 ? explicitIndex : index);
+    });
+  else if (raw && typeof raw === "object")
+    for (const [name, value] of Object.entries(raw as Record<string, unknown>)) {
+      const n = Number(value);
+      if (Number.isInteger(n) && n >= 0) out.set(name, n);
+    }
   perpDexIndexCache.set(cacheKey, { expiresAt: Date.now() + BUILDER_META_TTL_MS, value: out });
   return out;
 }
-async function getDexMeta(dex: string, options: { transport?: HyperliquidTransport; baseUrl?: string } = {}): Promise<Map<string, { index: number; szDecimals?: number }>> {
+async function getDexMeta(
+  dex: string,
+  options: { transport?: HyperliquidTransport; baseUrl?: string } = {},
+): Promise<Map<string, { index: number; szDecimals?: number }>> {
   const cacheKey = `${options.baseUrl ?? DEFAULT_BASE_URL}:${dex}`;
   const hit = cached(dexMetaCache.get(cacheKey));
   if (hit) return hit;
-  const universe = ((await postInfo({ type: "meta", dex }, options)) as { universe?: unknown }).universe;
+  const universe = ((await postInfo({ type: "meta", dex }, options)) as { universe?: unknown })
+    .universe;
   if (!Array.isArray(universe)) throw new Error(`Hyperliquid meta for dex ${dex} missing universe`);
   const out = new Map<string, { index: number; szDecimals?: number }>();
   universe.forEach((entry, index) => {
     const record = entry as Record<string, unknown>;
     if (typeof record.name === "string") {
       const szDecimals = Number(record.szDecimals);
-      out.set(record.name, { index, szDecimals: Number.isInteger(szDecimals) && szDecimals >= 0 ? szDecimals : undefined });
+      out.set(record.name, {
+        index,
+        szDecimals: Number.isInteger(szDecimals) && szDecimals >= 0 ? szDecimals : undefined,
+      });
     }
   });
   dexMetaCache.set(cacheKey, { expiresAt: Date.now() + BUILDER_META_TTL_MS, value: out });
   return out;
 }
-export async function resolveAssetId(coin: HyperliquidAsset, options: { transport?: HyperliquidTransport; baseUrl?: string } = {}): Promise<number> { return (await resolveAsset(coin, options)).assetId; }
-async function resolveAsset(coin: HyperliquidAsset, options: { transport?: HyperliquidTransport; baseUrl?: string } = {}): Promise<AssetResolution> {
+export async function resolveAssetId(
+  coin: HyperliquidAsset,
+  options: { transport?: HyperliquidTransport; baseUrl?: string } = {},
+): Promise<number> {
+  return (await resolveAsset(coin, options)).assetId;
+}
+async function resolveAsset(
+  coin: HyperliquidAsset,
+  options: { transport?: HyperliquidTransport; baseUrl?: string } = {},
+): Promise<AssetResolution> {
   const core = coreAssetId(coin);
   if (core !== undefined) return { assetId: core, builderPerp: false, symbol: coin };
   const parsed = parseBuilderPerpSymbol(coin);
   if (!parsed) throw new Error(`unsupported Hyperliquid asset: ${coin}`);
   const dexIndex = (await getPerpDexIndices(options)).get(parsed.dex);
-  if (dexIndex === undefined) throw new Error(`unknown Hyperliquid builder perp dex: ${parsed.dex}`);
+  if (dexIndex === undefined)
+    throw new Error(`unknown Hyperliquid builder perp dex: ${parsed.dex}`);
   const dexMeta = await getDexMeta(parsed.dex, options);
   // HL's meta{dex} universe names markets as the FULL `dex:COIN` (e.g. `xyz:SPCX`).
   // Some builders/historical responses use the bare `COIN`. Accept both so a
   // `xyz:SPCX` symbol resolves whether meta is keyed full or bare.
   const market = dexMeta.get(coin) ?? dexMeta.get(parsed.symbol);
   if (!market) throw new Error(`unknown Hyperliquid builder perp market: ${coin}`);
-  return { assetId: BUILDER_PERP_ASSET_ID_OFFSET + dexIndex * BUILDER_PERP_DEX_STRIDE + market.index, builderPerp: true, dex: parsed.dex, symbol: parsed.symbol, szDecimals: market.szDecimals };
+  return {
+    assetId: BUILDER_PERP_ASSET_ID_OFFSET + dexIndex * BUILDER_PERP_DEX_STRIDE + market.index,
+    builderPerp: true,
+    dex: parsed.dex,
+    symbol: parsed.symbol,
+    szDecimals: market.szDecimals,
+  };
 }
 function formatSizeForAsset(size: string, asset: AssetResolution): string {
   if (!asset.builderPerp || asset.szDecimals === undefined) return size;
   const n = Number(size);
   if (!Number.isFinite(n) || n <= 0) throw new Error("invalid size");
-  return n.toFixed(asset.szDecimals).replace(/\.0+$/, "").replace(/(\.\d*?)0+$/, "$1");
+  return n
+    .toFixed(asset.szDecimals)
+    .replace(/\.0+$/, "")
+    .replace(/(\.\d*?)0+$/, "$1");
 }
 
 function dec(v: unknown, fallback?: string) {
@@ -332,12 +393,14 @@ export async function getMarketableLimitPx(
   const builder = parseBuilderPerpSymbol(coin);
   if (builder) {
     const mids = await postInfo({ type: "allMids", dex: builder.dex }, options);
-    const rawMid = (mids as Record<string, unknown>)[builder.symbol] ?? (mids as Record<string, unknown>)[coin];
+    const rawMid =
+      (mids as Record<string, unknown>)[builder.symbol] ?? (mids as Record<string, unknown>)[coin];
     const mid = Number(rawMid);
     if (!Number.isFinite(mid) || mid <= 0) throw new Error(`missing Hyperliquid mid for ${coin}`);
     return roundMarketablePx(isBuy ? mid * 1.005 : mid * 0.995, isBuy);
   }
-  const levels = ((await postInfo({ type: "l2Book", coin }, options)) as { levels?: unknown })?.levels;
+  const levels = ((await postInfo({ type: "l2Book", coin }, options)) as { levels?: unknown })
+    ?.levels;
   const px = isBuy ? bestBookPrice(levels, "ask") * 1.005 : bestBookPrice(levels, "bid") * 0.995;
   return roundMarketablePx(px, isBuy);
 }
@@ -388,8 +451,24 @@ function normalizedLeverageUpdate(input: LeverageUpdateInput) {
     nonce: p.nonce,
   };
 }
-function exchangeActionFromNormalized(o: ReturnType<typeof normalized>, asset: AssetResolution): Record<string, unknown> {
-  return { type: "order", orders: [{ a: asset.assetId, b: o.isBuy, p: o.limitPx, s: formatSizeForAsset(o.sz, asset), r: o.reduceOnly, t: { limit: { tif: o.tif } } }], grouping: "na" };
+function exchangeActionFromNormalized(
+  o: ReturnType<typeof normalized>,
+  asset: AssetResolution,
+): Record<string, unknown> {
+  return {
+    type: "order",
+    orders: [
+      {
+        a: asset.assetId,
+        b: o.isBuy,
+        p: o.limitPx,
+        s: formatSizeForAsset(o.sz, asset),
+        r: o.reduceOnly,
+        t: { limit: { tif: o.tif } },
+      },
+    ],
+    grouping: "na",
+  };
 }
 export function toExchangeAction(order: HyperliquidOrder): Record<string, unknown> {
   const o = normalized(order);
@@ -397,7 +476,10 @@ export function toExchangeAction(order: HyperliquidOrder): Record<string, unknow
   if (assetId === undefined) throw new Error("builder perp assets require async asset resolution");
   return exchangeActionFromNormalized(o, { assetId, builderPerp: false, symbol: o.coin });
 }
-async function toResolvedExchangeAction(order: HyperliquidOrder, options: { transport?: HyperliquidTransport; baseUrl?: string } = {}): Promise<Record<string, unknown>> {
+async function toResolvedExchangeAction(
+  order: HyperliquidOrder,
+  options: { transport?: HyperliquidTransport; baseUrl?: string } = {},
+): Promise<Record<string, unknown>> {
   const o = normalized(order);
   return exchangeActionFromNormalized(o, await resolveAsset(o.coin, options));
 }
@@ -407,13 +489,22 @@ export function toUpdateLeverageAction(input: LeverageUpdateInput): Record<strin
   if (assetId === undefined) throw new Error("builder perp assets require async asset resolution");
   return { type: "updateLeverage", asset: assetId, isCross: o.isCross, leverage: o.leverage };
 }
-async function toResolvedUpdateLeverageAction(input: LeverageUpdateInput, options: { transport?: HyperliquidTransport; baseUrl?: string } = {}): Promise<Record<string, unknown>> {
+async function toResolvedUpdateLeverageAction(
+  input: LeverageUpdateInput,
+  options: { transport?: HyperliquidTransport; baseUrl?: string } = {},
+): Promise<Record<string, unknown>> {
   const o = normalizedLeverageUpdate(input);
   const asset = await resolveAsset(o.coin, options);
   return { type: "updateLeverage", asset: asset.assetId, isCross: o.isCross, leverage: o.leverage };
 }
-async function toResolvedCancelAction(input: CancelOrderInput, options: { transport?: HyperliquidTransport; baseUrl?: string } = {}): Promise<Record<string, unknown>> {
-  return { type: "cancel", cancels: [{ a: await resolveAssetId(input.coin, options), o: Number(input.orderId) }] };
+async function toResolvedCancelAction(
+  input: CancelOrderInput,
+  options: { transport?: HyperliquidTransport; baseUrl?: string } = {},
+): Promise<Record<string, unknown>> {
+  return {
+    type: "cancel",
+    cancels: [{ a: await resolveAssetId(input.coin, options), o: Number(input.orderId) }],
+  };
 }
 
 const u8 = (...b: number[]) => new Uint8Array(b);
@@ -507,7 +598,8 @@ function tokenIdFromSpotToken(entry: unknown): string | null {
   // id from spotMeta (verified live 2026-06-15: USDC = `USDC:0x6d1e7cde53ba9467b783cb7c530ce054`),
   // exactly like the docs' `PURR:0xc4bf...` example. NOT the numeric spot index.
   const tokenId = record.tokenId;
-  if (typeof tokenId === "string" && /^0x[0-9a-fA-F]+$/.test(tokenId)) return `${display}:${tokenId}`;
+  if (typeof tokenId === "string" && /^0x[0-9a-fA-F]+$/.test(tokenId))
+    return `${display}:${tokenId}`;
   // Already-formatted `NAME:0x...` passthrough.
   for (const key of ["token", "id"]) {
     const value = record[key];
@@ -516,7 +608,9 @@ function tokenIdFromSpotToken(entry: unknown): string | null {
   return null;
 }
 
-export async function resolveUsdcTokenId(options: { transport?: HyperliquidTransport; baseUrl?: string; usdcTokenId?: string } = {}): Promise<string> {
+export async function resolveUsdcTokenId(
+  options: { transport?: HyperliquidTransport; baseUrl?: string; usdcTokenId?: string } = {},
+): Promise<string> {
   const raw = await postInfo({ type: "spotMeta" }, options).catch((err) => {
     if (options.usdcTokenId) return null;
     throw err;
@@ -529,7 +623,9 @@ export async function resolveUsdcTokenId(options: { transport?: HyperliquidTrans
     }
   }
   if (options.usdcTokenId) return options.usdcTokenId;
-  throw new Error("unable to resolve Hyperliquid USDC token id from spotMeta; configure usdcTokenId");
+  throw new Error(
+    "unable to resolve Hyperliquid USDC token id from spotMeta; configure usdcTokenId",
+  );
 }
 
 export async function toSendAssetAction(
@@ -696,10 +792,15 @@ async function signAction(
 export const signSendAsset = async (
   walletPrivateKey: Hex,
   params: SendAssetParams,
-  options: SignOptions & { transport?: HyperliquidTransport; baseUrl?: string; usdcTokenId?: string } = {},
+  options: SignOptions & {
+    transport?: HyperliquidTransport;
+    baseUrl?: string;
+    usdcTokenId?: string;
+  } = {},
 ): Promise<SignedSendAsset> => {
   const nonce = options.nonce ?? params.nonce ?? nextNonce();
-  const hyperliquidChain = params.hyperliquidChain ?? (options.isMainnet === false ? "Testnet" : "Mainnet");
+  const hyperliquidChain =
+    params.hyperliquidChain ?? (options.isMainnet === false ? "Testnet" : "Mainnet");
   const token = params.token ?? (await resolveUsdcTokenId(options));
   const normalizedParams = { ...params, token, nonce, hyperliquidChain };
   const action = normalizeSendAssetParams(normalizedParams, token, nonce);
@@ -770,7 +871,9 @@ export async function submitSendAsset(
   const status = String((raw as { status?: unknown })?.status ?? "");
   if (status === "err") {
     const detail = (raw as { response?: unknown })?.response;
-    throw new Error(`hyperliquid sendAsset rejected: ${typeof detail === "string" ? detail : JSON.stringify(detail ?? raw)}`);
+    throw new Error(
+      `hyperliquid sendAsset rejected: ${typeof detail === "string" ? detail : JSON.stringify(detail ?? raw)}`,
+    );
   }
   return sendAssetResultSchema.parse({ status: status || "submitted", raw });
 }
@@ -838,7 +941,10 @@ export class HyperliquidAdapter {
       transport: this.transport,
       baseUrl: this.baseUrl,
     });
-    const action = await toResolvedExchangeAction(resolved, { transport: this.transport, baseUrl: this.baseUrl });
+    const action = await toResolvedExchangeAction(resolved, {
+      transport: this.transport,
+      baseUrl: this.baseUrl,
+    });
     const td = createL1TypedData(
       action,
       nonce,
@@ -861,11 +967,13 @@ export class HyperliquidAdapter {
   }
   async signSendAsset(params: SendAssetParams): Promise<SignedSendAsset> {
     const nonce = params.nonce ?? nextNonce();
-    const token = params.token ?? (await resolveUsdcTokenId({
-      transport: this.transport,
-      baseUrl: this.baseUrl,
-      usdcTokenId: this.options.usdcTokenId,
-    }));
+    const token =
+      params.token ??
+      (await resolveUsdcTokenId({
+        transport: this.transport,
+        baseUrl: this.baseUrl,
+        usdcTokenId: this.options.usdcTokenId,
+      }));
     const hyperliquidChain = params.hyperliquidChain ?? (this.isMainnet ? "Mainnet" : "Testnet");
     const normalizedParams = { ...params, token, nonce, hyperliquidChain };
     const action = normalizeSendAssetParams(normalizedParams, token, nonce);
@@ -902,7 +1010,10 @@ export class HyperliquidAdapter {
   async updateLeverage(input: LeverageUpdateInput): Promise<LeverageUpdateResult> {
     const parsed = normalizedLeverageUpdate(input);
     const nonce = parsed.nonce ?? nextNonce();
-    const action = await toResolvedUpdateLeverageAction(parsed, { transport: this.transport, baseUrl: this.baseUrl });
+    const action = await toResolvedUpdateLeverageAction(parsed, {
+      transport: this.transport,
+      baseUrl: this.baseUrl,
+    });
     const td = createL1TypedData(
       action,
       nonce,
@@ -930,7 +1041,10 @@ export class HyperliquidAdapter {
   }
   async cancelOrder(input: CancelOrderInput) {
     const nonce = input.nonce ?? nextNonce();
-    const action = await toResolvedCancelAction(input, { transport: this.transport, baseUrl: this.baseUrl });
+    const action = await toResolvedCancelAction(input, {
+      transport: this.transport,
+      baseUrl: this.baseUrl,
+    });
     const td = createL1TypedData(
       action,
       nonce,

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalPassThroughEnv": [
+  "globalEnv": [
     "DATABASE_URL",
     "FAKE_OAUTH_PORT",
     "MILADY_SKIP_STEWARD_FI_LIVE_SMOKE",


### PR DESCRIPTION
## Summary

Fixes the P0 hosted-agent provisioning blocker where the cloud provisioning daemon authenticates with the tenant root API key (`X-Steward-Key`, `authType === "api-key"`) and then receives 403s on agent-admin routes needed to finish registration, especially `POST /v1/agents/:agentId/token`.

The daemon failure mode was:

- tenant API key is valid and resolves to the tenant
- `POST /v1/agents/:agentId/token` gates on the local tenant-admin helper
- that helper only accepted `session-jwt` owners/admins
- API-key callers were rejected with `Agent token creation requires owner or admin session`
- registration could not mint the agent token, sandbox boot never completed, patron chat hit 502s

## Safety / trust model

This aligns the agent/trade provisioning paths with Steward's existing tenant-root trust model:

- `packages/api/src/services/context.ts` validates the API key against `tenant.apiKeyHash`
- the sibling `requireTenantLevel` already treats `authType === "api-key"` as tenant-level/root access
- tenant root API keys are more privileged than a human admin session, not less
- `agent-token` remains rejected by the tenant-admin gate and by the new tenant-admin-or-api-key helper
- sensitive human-control-plane surfaces remain session-only where appropriate, including secrets, session signers, condition sets, policy templates, webhooks, tenant config, agent signers/key quorums, and policy rule CRUD

## What changed

- Added an agent-route helper that allows either:
  - tenant root API key, or
  - owner/admin `session-jwt`
- Applied that helper to provisioning-reachable agent admin operations:
  - agent creation
  - pregenerated wallet creation / claim-token rotation
  - agent token minting
  - venue wallet creation
  - agent deletion
  - batch agent creation
  - whole-agent policy replacement
- Kept signer/key-quorum and granular policy-rule mutations on the existing human admin-session helper.
- Updated trade session control-plane management to allow tenant root API key for create/read/revoke while keeping `agent-token` out of the tenant-admin helper.
- Updated audit attribution so newly allowed API-key agent/trade operations are written as `actorType: "api-key"`, not a synthetic user/agent.

## MFA finding

`requireRecentAdminMfa` in `agents.ts` did not previously no-op for `authType === "api-key"`. That would have kept the provisioning daemon blocked after the admin-session fix, because machine API-key callers cannot perform human MFA.

This PR scopes that MFA requirement to human session callers:

- `api-key` callers skip the session MFA step-up because the API key is the tenant root machine credential
- `session-jwt` callers still require recent MFA
- `agent-token` remains rejected before reaching the MFA path

Trade session control-plane MFA was updated the same way: session JWT owner/admin callers still need MFA; tenant root API-key callers do not.

## Tests

Added/updated coverage for:

- tenant root API key can mint agent tokens
- API-key agent-token minting skips session MFA
- owner/admin session JWT can still mint agent tokens
- member session is rejected
- agent-token is rejected and cannot mint its own tokens
- missing/invalid credentials are rejected
- API-key trade session create/read/revoke works and is audit-attributed to `api-key`
- owner/admin session without MFA is still rejected for trade session management
- static boundary tests still assert API keys do not get secrets/condition-set/policy-template control-plane surfaces

Local verification:

- `bunx @biomejs/biome check ...` on changed files: pass
- `bun run --cwd packages/api build`: pass
- `bun run --cwd packages/api test`: pass, 178/178 isolated test files
- `codex review --uncommitted`: pass, no remaining issues

## Notes

No production config, secrets, deployments, or trade orders touched.
