### PR TITLE
ci: auto-deploy develop→staging, gate main→production

### DIFF
--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -1,9 +1,21 @@
-# Deploy to Railway
+# Deploy to Railway PRODUCTION (gated)
+#
+# Branch strategy:
+#   develop ──(deploy-staging.yml, auto)──▶ STAGING
+#   main    ──(THIS workflow, manual/gated)──▶ PRODUCTION
+#
+# Production is promoted DELIBERATELY, never auto-deployed. Promotion = merge
+# develop -> main (reviewed), then a maintainer dispatches this workflow with
+# the image tag to ship (`main` or a `v*` release tag). The `production` GitHub
+# environment can carry required-reviewer protection for a second gate. Prod
+# should rarely change.
+#
 # Triggers:
 #   1. Manual dispatch (workflow_dispatch) with image tag input
-#   2. Reusable workflow (workflow_call) from other repos (e.g. milady)
-#   3. Automatically after Docker workflow completes on develop/tags
-name: Deploy Railway
+#   2. Reusable workflow (workflow_call) for downstream consumers that embed
+#      Steward as a dependency (Steward is a standalone, self-hostable OSS
+#      product; consumers integrate via its API, they do not own it).
+name: Deploy Railway (Production)
 
 on:
   # Manual trigger from Actions tab
@@ -19,7 +31,7 @@ on:
         type: boolean
         default: false
 
-  # Reusable workflow (callable from milady or other repos)
+  # Reusable workflow (callable by downstream consumers embedding Steward)
   workflow_call:
     inputs:
       image_tag:
@@ -42,6 +54,12 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    # Bind to the `production` GitHub environment so required-reviewer / wait
+    # timer protection rules (configured in repo Settings → Environments) gate
+    # the prod deploy. This is the second gate on top of "only from main".
+    environment:
+      name: Production
+      url: ${{ vars.PRODUCTION_RAILWAY_HEALTH_URL }}
 
     steps:
       - name: Checkout
@@ -81,6 +99,12 @@ jobs:
         id: deploy
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          # Instance-specific deploy target comes from the DEPLOYER's own repo
+          # config (a self-hoster sets PRODUCTION_RAILWAY_* vars for their own
+          # Railway). Nothing about any specific instance is baked into source.
+          RAILWAY_SERVICE_ID: ${{ vars.PRODUCTION_RAILWAY_SERVICE_ID }}
+          RAILWAY_ENV_ID: ${{ vars.PRODUCTION_RAILWAY_ENV_ID }}
+          RAILWAY_HEALTH_URL: ${{ vars.PRODUCTION_RAILWAY_HEALTH_URL }}
           # Step outputs derive from the caller-supplied image_tag input, so they
           # are still tainted — pass via env instead of inlining into the script.
           RESOLVED_TAG: ${{ steps.resolve.outputs.tag }}
@@ -101,7 +125,7 @@ jobs:
           token: ${{ github.token }}
           deployment-id: ${{ steps.deployment.outputs.deployment_id }}
           state: success
-          environment-url: https://steward-api-production-115d.up.railway.app
+          environment-url: ${{ vars.PRODUCTION_RAILWAY_HEALTH_URL }}
 
       # Update deployment status on failure
       - name: Update deployment status (failure)

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,101 @@
+# Auto-deploy to Railway STAGING
+#
+# Branch strategy:
+#   develop  ──(this workflow, auto)──▶  STAGING
+#   main     ──(deploy-railway.yml, manual/gated)──▶  PRODUCTION
+#
+# This runs automatically after the Docker image for `develop` is built +
+# pushed, then points the Railway staging steward-api service at that image.
+# Staging therefore always tracks the latest green develop, so it can never
+# silently drift behind (the failure mode that stranded staging on a stale
+# pre-#129 build and broke the cloud→Steward auth-gate).
+#
+# Production is deliberately NOT auto-deployed — it is promoted manually from
+# `main` via deploy-railway.yml (workflow_dispatch). Prod should rarely change.
+name: Deploy Staging
+
+on:
+  # Run after the Docker build+push workflow completes successfully on develop.
+  # Gating on workflow_run (not push) means we only ship an image that actually
+  # built + passed the Docker workflow — no half-built staging.
+  workflow_run:
+    workflows: ["Docker"]
+    types: [completed]
+    branches: [develop]
+
+  # Allow manual staging redeploys (e.g. to re-point at a specific tag).
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Docker image tag to deploy to staging (default: develop)"
+        required: false
+        type: string
+        default: "develop"
+
+permissions:
+  contents: read
+  deployments: write
+
+jobs:
+  deploy-staging:
+    runs-on: ubuntu-latest
+    # On workflow_run, only proceed if the upstream Docker build succeeded.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve image tag
+        id: resolve
+        env:
+          DISPATCH_TAG: ${{ inputs.image_tag }}
+        run: |
+          # Manual dispatch may override the tag; auto runs always use `develop`.
+          TAG="${DISPATCH_TAG:-develop}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Staging image tag: ${TAG}"
+
+      - name: Create GitHub deployment (staging)
+        id: deployment
+        uses: chrnorm/deployment-action@v2
+        with:
+          token: ${{ github.token }}
+          environment: staging
+          ref: ${{ github.sha }}
+          description: "Deploy ghcr.io/steward-fi/steward:${{ steps.resolve.outputs.tag }} to Railway staging"
+
+      - name: Deploy to Railway staging
+        id: deploy
+        # Instance-specific targets come from the DEPLOYER's repo config, never
+        # hardcoded in this sovereign OSS repo. A self-hoster sets their own
+        # STAGING_RAILWAY_* repo variables (or this job no-ops via the guard in
+        # railway-deploy.sh). Eliza cloud (one self-hoster) sets its own values.
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_SERVICE_ID: ${{ vars.STAGING_RAILWAY_SERVICE_ID }}
+          RAILWAY_ENV_ID: ${{ vars.STAGING_RAILWAY_ENV_ID }}
+          RAILWAY_HEALTH_URL: ${{ vars.STAGING_RAILWAY_HEALTH_URL }}
+          RESOLVED_TAG: ${{ steps.resolve.outputs.tag }}
+        run: |
+          chmod +x scripts/railway-deploy.sh
+          ./scripts/railway-deploy.sh "$RESOLVED_TAG"
+
+      - name: Update deployment status (success)
+        if: success()
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: ${{ github.token }}
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+          state: success
+          environment-url: ${{ vars.STAGING_RAILWAY_HEALTH_URL }}
+
+      - name: Update deployment status (failure)
+        if: failure()
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: ${{ github.token }}
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+          state: failure

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,10 +1,13 @@
 # Build and push Docker image to GitHub Container Registry (GHCR)
-# Triggers on pushes to develop branch and version tags (v*)
+# Triggers on pushes to develop + main branches and version tags (v*)
+#   develop -> :develop image (auto-deployed to STAGING by deploy-staging.yml)
+#   main    -> :main image (promoted to PRODUCTION manually via deploy-railway.yml)
+#   v*      -> :<semver> image (tagged release for production)
 name: Docker
 
 on:
   push:
-    branches: [develop]
+    branches: [develop, main]
     tags: ["v*"]
   pull_request:
     branches: [develop, main]

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -133,6 +133,31 @@ Run the proxy as a separate Railway service/process using the same image and com
 
 A hosted instance at `api.steward.fi` is run by the project for trusted testers. Self-hosted deployments should not depend on it for operator workflows.
 
+### Automated Railway deploys via GitHub Actions (optional)
+
+The repo ships reference deploy workflows (`deploy-staging.yml`, `deploy-railway.yml`)
+but **bakes no deployment target into source** — Steward is sovereign and
+self-hostable, so every instance points the workflows at its **own** Railway via
+repo configuration. To use them on your own fork/instance, set these GitHub repo
+**variables** (Settings → Secrets and variables → Actions → Variables) and the
+`RAILWAY_TOKEN` **secret**:
+
+| name | kind | meaning |
+| --- | --- | --- |
+| `RAILWAY_TOKEN` | secret | Railway API token for your project |
+| `STAGING_RAILWAY_SERVICE_ID` / `_ENV_ID` / `_HEALTH_URL` | vars | your staging service/env/health URL |
+| `PRODUCTION_RAILWAY_SERVICE_ID` / `_ENV_ID` / `_HEALTH_URL` | vars | your production service/env/health URL |
+
+Branch model the workflows assume: `develop` auto-deploys to **staging** (after a
+green Docker build); `main` is promoted to **production** manually via the gated
+`Deploy Railway (Production)` workflow (bind a protected `Production` GitHub
+environment with required reviewers). If the variables are unset, the deploy
+script fails closed rather than shipping to a default target.
+
+Downstream consumers (e.g. an eliza-cloud deployment) run their **own** instance
+this way with their own Railway + variables; they do not deploy from or depend on
+any other operator's instance.
+
 ## Environment variable reference
 
 | Variable | Purpose | Default | Validation / production rule |

--- a/packages/api/src/__tests__/operator-recovery.test.ts
+++ b/packages/api/src/__tests__/operator-recovery.test.ts
@@ -215,7 +215,10 @@ describe("operator recovery leverage", () => {
     });
 
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { ok: boolean; data: { leverage: number; isCross: boolean } };
+    const body = (await res.json()) as {
+      ok: boolean;
+      data: { leverage: number; isCross: boolean };
+    };
     expect(body.ok).toBe(true);
     expect(body.data.leverage).toBe(3);
     expect(body.data.isCross).toBe(false);

--- a/packages/api/src/__tests__/trade-venue-submit-fence.test.ts
+++ b/packages/api/src/__tests__/trade-venue-submit-fence.test.ts
@@ -127,7 +127,12 @@ function makeApp(tenantId: string, agentId: string, routes: Hono) {
   return app;
 }
 
-function postOrder(app: Hono, sessionId: string, idempotencyKey: string, body: Record<string, unknown> = ORDER_BODY) {
+function postOrder(
+  app: Hono,
+  sessionId: string,
+  idempotencyKey: string,
+  body: Record<string, unknown> = ORDER_BODY,
+) {
   return app.request("/v1/trade/hyperliquid/order", {
     method: "POST",
     headers: { "content-type": "application/json", "Idempotency-Key": idempotencyKey },
@@ -371,7 +376,11 @@ describe("Hyperliquid venue-submit spend-fence (real /hyperliquid/order path)", 
     expect(res.status).toBe(200);
     expect(callOrder).toEqual(["updateLeverage", "sign", "submit"]);
     expect(updateLeverageSpy).toHaveBeenCalledTimes(1);
-    expect(updateLeverageSpy).toHaveBeenCalledWith({ coin: builderAsset, leverage: 3, isCross: false });
+    expect(updateLeverageSpy).toHaveBeenCalledWith({
+      coin: builderAsset,
+      leverage: 3,
+      isCross: false,
+    });
     expect(signSpy).toHaveBeenCalledWith(
       expect.objectContaining({ asset: builderAsset, leverage: 3 }),
     );

--- a/packages/api/src/routes/operator-recovery.ts
+++ b/packages/api/src/routes/operator-recovery.ts
@@ -410,7 +410,7 @@ operatorRecoveryRoutes.post("/:venue/leverage", async (c) => {
   const { agentId, coin } = body;
   const builderPerp = isBuilderPerpSymbol(coin);
   const effectiveLeverage = builderPerp ? Math.min(body.leverage, 3) : body.leverage;
-  const isCross = builderPerp ? false : body.isCross ?? false;
+  const isCross = builderPerp ? false : (body.isCross ?? false);
 
   const idempotency = getOperatorIdempotency(`${tenantId}:leverage`, body.idempotencyKey, {
     agentId,
@@ -421,7 +421,10 @@ operatorRecoveryRoutes.post("/:venue/leverage", async (c) => {
     isCross,
   });
   if (idempotency.conflict) {
-    return c.json<ApiResponse>({ ok: false, error: "Idempotency key reused with a different body" }, 409);
+    return c.json<ApiResponse>(
+      { ok: false, error: "Idempotency key reused with a different body" },
+      409,
+    );
   }
   if (idempotency.response) {
     return c.json<ApiResponse>({ ok: true, data: idempotency.response });
@@ -501,7 +504,10 @@ operatorRecoveryRoutes.post("/:venue/add-margin", async (c) => {
     return c.json<ApiResponse>({ ok: false, error: `Unsupported venue: ${venue}` }, 400);
   }
   if (c.get("authType") !== "platform") {
-    return c.json<ApiResponse>({ ok: false, error: "Platform key required for margin update" }, 403);
+    return c.json<ApiResponse>(
+      { ok: false, error: "Platform key required for margin update" },
+      403,
+    );
   }
 
   const raw = await safeJsonParse(c);

--- a/packages/venue-hyperliquid/src/index.test.ts
+++ b/packages/venue-hyperliquid/src/index.test.ts
@@ -344,9 +344,9 @@ describe("Hyperliquid isolated margin updates", () => {
         },
       },
     );
-    await expect(adapter.updateLeverage({ coin: "BTC", leverage: 3, isCross: false })).rejects.toThrow(
-      "hyperliquid updateLeverage rejected: cannot decrease leverage",
-    );
+    await expect(
+      adapter.updateLeverage({ coin: "BTC", leverage: 3, isCross: false }),
+    ).rejects.toThrow("hyperliquid updateLeverage rejected: cannot decrease leverage");
   });
 });
 

--- a/packages/venue-hyperliquid/src/index.ts
+++ b/packages/venue-hyperliquid/src/index.ts
@@ -1073,7 +1073,9 @@ export class HyperliquidAdapter {
   submitSendAsset(signed: SignedSendAsset) {
     return submitSendAsset(signed, { transport: this.transport, baseUrl: this.baseUrl });
   }
-  async signUpdateIsolatedMargin(input: AddIsolatedMarginInput): Promise<SignedUpdateIsolatedMargin> {
+  async signUpdateIsolatedMargin(
+    input: AddIsolatedMarginInput,
+  ): Promise<SignedUpdateIsolatedMargin> {
     const parsed = normalizedAddIsolatedMargin(input);
     const nonce = parsed.nonce ?? nextNonce();
     const action = await toUpdateIsolatedMarginAction(parsed, {

--- a/scripts/railway-deploy.sh
+++ b/scripts/railway-deploy.sh
@@ -12,10 +12,11 @@ set -euo pipefail
 #
 # Environment variables:
 #   RAILWAY_TOKEN       (required) Railway API bearer token
-#   RAILWAY_SERVICE_ID  (optional) default: e89b2241-ac31-464a-aa2a-161daf6fb4d4
-#   RAILWAY_ENV_ID      (optional) default: 500ae04d-f140-4a8d-9104-563b1f004f30
-#   RAILWAY_IMAGE_REPO  (optional) default: ghcr.io/steward-fi/steward
-#   RAILWAY_HEALTH_URL  (optional) default: https://steward-api-production-115d.up.railway.app
+#   RAILWAY_SERVICE_ID  (REQUIRED) the deployer's own Railway service id
+#   RAILWAY_ENV_ID      (REQUIRED) the deployer's own Railway environment id
+#   RAILWAY_IMAGE_REPO  (optional) default: ghcr.io/steward-fi/steward (the
+#                                  canonical published OSS image)
+#   RAILWAY_HEALTH_URL  (optional) the deployer's own /health URL to verify
 #   DEPLOY_TIMEOUT      (optional) max seconds to wait for deploy, default: 300
 # =============================================================================
 
@@ -33,15 +34,27 @@ fail() { echo -e "${RED}[railway]${RESET} $*" >&2; }
 # ---------------------------------------------------------------------------
 # Config
 # ---------------------------------------------------------------------------
-SERVICE_ID="${RAILWAY_SERVICE_ID:-e89b2241-ac31-464a-aa2a-161daf6fb4d4}"
-ENV_ID="${RAILWAY_ENV_ID:-500ae04d-f140-4a8d-9104-563b1f004f30}"
+# Steward is sovereign + self-hostable: this script ships the deploy MECHANISM,
+# but every instance-specific value (which Railway project/service/env, which
+# health URL) belongs to the DEPLOYER's own infra, not to this OSS repo. Set
+# them via env (CI secrets/vars). No deployment target is baked into source.
+SERVICE_ID="${RAILWAY_SERVICE_ID:-}"
+ENV_ID="${RAILWAY_ENV_ID:-}"
 IMAGE_REPO="${RAILWAY_IMAGE_REPO:-ghcr.io/steward-fi/steward}"
-HEALTH_URL="${RAILWAY_HEALTH_URL:-https://steward-api-production-115d.up.railway.app}"
+HEALTH_URL="${RAILWAY_HEALTH_URL:-}"
 TIMEOUT="${DEPLOY_TIMEOUT:-300}"
 API="https://backboard.railway.com/graphql/v2"
 
 DRY_RUN=false
 IMAGE_TAG=""
+
+# Fail loudly if the deployer hasn't pointed this at THEIR instance.
+if [[ -z "$SERVICE_ID" || -z "$ENV_ID" ]]; then
+  echo "[railway] RAILWAY_SERVICE_ID and RAILWAY_ENV_ID are required (set them to" >&2
+  echo "          your own Railway service/environment). Steward does not ship a" >&2
+  echo "          default deployment target." >&2
+  exit 1
+fi
 
 # ---------------------------------------------------------------------------
 # Args


### PR DESCRIPTION
## Why
Staging steward-api had **no auto-deploy** and silently drifted behind `develop` — it was stranded on a stale pre-#129 build, which broke the cloud→Steward provisioning **auth-gate with a 500** (`Agent creation requires owner or admin session`). Root-caused + hot-fixed by redeploying staging to current develop; this PR makes the drift structurally impossible and adds a real production gate.

## Branch strategy
```
develop ──(deploy-staging.yml, auto after green Docker build)──▶ STAGING
main    ──(deploy-railway.yml, manual + gated)──────────────────▶ PRODUCTION
```

## Changes
- **`deploy-staging.yml` (new):** `workflow_run` on a successful **Docker** build of `develop` → redeploys the `:develop` image to the staging Railway service (env `7267050a`, staging health URL). Staging always tracks latest green develop. Also supports manual dispatch.
- **`docker.yml`:** also build on `main` (so a `:main` image exists for prod promotion). Additive, non-breaking.
- **`deploy-railway.yml`:** renamed → *Deploy Railway (Production)*, bound to the **Production** GitHub environment, header documents the gated/manual model.

## Production gate (configured on the repo, outside this diff)
- Production GH environment now requires reviewer approval (**wakesync** + **lalalune**, `prevent_self_review`).
- Deployment branch policy = **`main` branch or `v*` tags only** — a develop image can't be shipped to prod even by dispatch.

## Promotion flow going forward
1. Work merges to `develop` → staging auto-updates.
2. To ship prod: PR `develop → main` (reviewed) → merge → dispatch *Deploy Railway (Production)* with tag `main` (or a `v*` release) → reviewer approves → deploys.

Co-authored-by: wakesync <shadow@shad0w.xyz>