### PR TITLE
feat(sdk): email-OTP + emailGrant passkey signup (Privy-style first-time)

### DIFF
--- a/packages/sdk/src/__tests__/auth-email-otp.test.ts
+++ b/packages/sdk/src/__tests__/auth-email-otp.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { StewardAuth } from "../auth";
+import { StewardApiError } from "../client";
+
+// Captures each outbound request so assertions can verify the SDK hit the
+// right Steward endpoints with the right bodies (Privy-style email-OTP +
+// emailGrant passkey signup).
+type Captured = { url: string; body?: Record<string, unknown> };
+let captured: Captured[];
+let originalFetch: typeof fetch;
+let originalWindow: unknown;
+
+const REG_OPTIONS = {
+  challenge: "abc",
+  rp: { id: "elizacloud.ai", name: "Eliza Cloud" },
+  user: { id: "u-1", name: "new@user.test", displayName: "new@user.test" },
+};
+
+const VERIFY_RESPONSE = {
+  ok: true,
+  token: "test-jwt",
+  refreshToken: "test-refresh",
+  user: { id: "u-1", email: "new@user.test" },
+  expiresIn: 3600,
+};
+
+// Lets each test override the response for a given path.
+let routes: Record<string, () => Response>;
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function installFetch(): void {
+  global.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url;
+    const body = init?.body ? JSON.parse(init.body as string) : undefined;
+    captured.push({ url, body });
+    const path = url.replace("https://api.example.test", "");
+    const handler = routes[path];
+    if (handler) return handler();
+    return jsonResponse({ ok: false, error: "unexpected" }, 500);
+  }) as typeof fetch;
+}
+
+function installBrowserShim(): void {
+  // @ts-expect-error — only present in browser
+  originalWindow = globalThis.window;
+  // @ts-expect-error — minimal shim so isBrowser() passes
+  globalThis.window = { document: {} };
+}
+function restoreBrowserShim(): void {
+  // @ts-expect-error — restore
+  globalThis.window = originalWindow;
+}
+
+mock.module("@simplewebauthn/browser", () => ({
+  startRegistration: async () => ({
+    id: "credential-1",
+    rawId: "credential-1",
+    response: { clientDataJSON: "client-data", attestationObject: "attestation" },
+    type: "public-key",
+  }),
+  startAuthentication: async () => ({
+    id: "credential-login",
+    rawId: "credential-login",
+    response: {
+      clientDataJSON: "client-data",
+      authenticatorData: "authenticator-data",
+      signature: "signature",
+      userHandle: "u-1",
+    },
+    type: "public-key",
+  }),
+}));
+
+beforeEach(() => {
+  captured = [];
+  originalFetch = global.fetch;
+  routes = {
+    "/auth/email/otp/send": () => jsonResponse({ ok: true, data: { expiresAt: "2026-01-01T00:00:00Z" } }),
+    "/auth/email/otp/verify": () =>
+      jsonResponse({ ok: true, data: { emailGrant: "grant-xyz", expiresInSeconds: 300 } }),
+    "/auth/passkey/register/options": () => jsonResponse(REG_OPTIONS),
+    "/auth/passkey/register/verify": () => jsonResponse(VERIFY_RESPONSE),
+  };
+  installFetch();
+  installBrowserShim();
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  restoreBrowserShim();
+});
+
+describe("StewardAuth.sendEmailOtp", () => {
+  it("POSTs email (+ tenant) to /auth/email/otp/send", async () => {
+    const auth = new StewardAuth({ baseUrl: "https://api.example.test", tenantId: "elizacloud" });
+    const res = await auth.sendEmailOtp("new@user.test");
+
+    expect(captured[0]?.url).toBe("https://api.example.test/auth/email/otp/send");
+    expect(captured[0]?.body?.email).toBe("new@user.test");
+    expect(captured[0]?.body?.tenantId).toBe("elizacloud");
+    expect(res.ok).toBe(true);
+  });
+
+  it("forwards an optional captchaToken", async () => {
+    const auth = new StewardAuth({ baseUrl: "https://api.example.test" });
+    await auth.sendEmailOtp("new@user.test", "captcha-123");
+    expect(captured[0]?.body?.captchaToken).toBe("captcha-123");
+  });
+
+  it("throws StewardApiError on a rate-limited send", async () => {
+    routes["/auth/email/otp/send"] = () =>
+      jsonResponse({ ok: false, error: "Too many requests. Please try again later." }, 429);
+    const auth = new StewardAuth({ baseUrl: "https://api.example.test" });
+    await expect(auth.sendEmailOtp("new@user.test")).rejects.toBeInstanceOf(StewardApiError);
+  });
+});
+
+describe("StewardAuth.verifyEmailOtp", () => {
+  it("exchanges a code for an emailGrant", async () => {
+    const auth = new StewardAuth({ baseUrl: "https://api.example.test", tenantId: "elizacloud" });
+    const res = await auth.verifyEmailOtp("new@user.test", "123456");
+
+    expect(captured[0]?.url).toBe("https://api.example.test/auth/email/otp/verify");
+    expect(captured[0]?.body?.email).toBe("new@user.test");
+    expect(captured[0]?.body?.code).toBe("123456");
+    expect(res.emailGrant).toBe("grant-xyz");
+    expect(res.expiresInSeconds).toBe(300);
+  });
+
+  it("throws StewardApiError on a wrong/expired code", async () => {
+    routes["/auth/email/otp/verify"] = () =>
+      jsonResponse({ ok: false, error: "Invalid or expired code" }, 401);
+    const auth = new StewardAuth({ baseUrl: "https://api.example.test" });
+    await expect(auth.verifyEmailOtp("new@user.test", "000000")).rejects.toBeInstanceOf(
+      StewardApiError,
+    );
+  });
+});
+
+describe("StewardAuth.addPasskey with emailGrant (signed-out first-time signup)", () => {
+  it("forwards the emailGrant on BOTH register/options and register/verify", async () => {
+    const auth = new StewardAuth({ baseUrl: "https://api.example.test", tenantId: "elizacloud" });
+    const result = await auth.addPasskey("new@user.test", { emailGrant: "grant-xyz" });
+
+    const paths = captured.map((c) => c.url.replace("https://api.example.test", ""));
+    expect(paths).toEqual(["/auth/passkey/register/options", "/auth/passkey/register/verify"]);
+
+    // The grant must ride along on both calls — Steward peeks it on options
+    // and consumes it on verify, in place of a session.
+    expect(captured[0]?.body?.emailGrant).toBe("grant-xyz");
+    expect(captured[1]?.body?.emailGrant).toBe("grant-xyz");
+    expect(captured[0]?.body?.email).toBe("new@user.test");
+
+    expect(result.token).toBe("test-jwt");
+    expect(result.user?.email).toBe("new@user.test");
+  });
+
+  it("omits emailGrant when none is supplied (session-based add-passkey)", async () => {
+    const auth = new StewardAuth({ baseUrl: "https://api.example.test" });
+    await auth.addPasskey("existing@user.test");
+    expect(captured[0]?.body?.emailGrant).toBeUndefined();
+    expect(captured[1]?.body?.emailGrant).toBeUndefined();
+  });
+});
+
+describe("end-to-end Privy-style passkey signup", () => {
+  it("send OTP → verify OTP → register passkey with the grant", async () => {
+    const auth = new StewardAuth({ baseUrl: "https://api.example.test", tenantId: "elizacloud" });
+
+    await auth.sendEmailOtp("new@user.test");
+    const { emailGrant } = await auth.verifyEmailOtp("new@user.test", "123456");
+    const result = await auth.addPasskey("new@user.test", { emailGrant });
+
+    const paths = captured.map((c) => c.url.replace("https://api.example.test", ""));
+    expect(paths).toEqual([
+      "/auth/email/otp/send",
+      "/auth/email/otp/verify",
+      "/auth/passkey/register/options",
+      "/auth/passkey/register/verify",
+    ]);
+    expect(result.token).toBe("test-jwt");
+  });
+});

--- a/packages/sdk/src/auth-types.ts
+++ b/packages/sdk/src/auth-types.ts
@@ -151,6 +151,29 @@ export interface StewardWhatsAppOtpResult {
   expiresAt: string;
 }
 
+/**
+ * Result of `sendEmailOtp` — a 6-digit code was emailed (Privy-style signup).
+ * The actual proof-of-ownership is obtained via `verifyEmailOtp`.
+ */
+export interface StewardEmailOtpResult {
+  ok: boolean;
+  /** ISO timestamp the emailed code expires at, when the server provides it. */
+  expiresAt?: string;
+}
+
+/**
+ * Result of `verifyEmailOtp` — a short-lived, single-use grant proving
+ * ownership of the email. Pass `emailGrant` to `addPasskey({ emailGrant })`
+ * so a brand-new, signed-out user can register a passkey WITHOUT a session.
+ */
+export interface StewardEmailGrantResult {
+  ok: boolean;
+  /** Single-use grant token bound to {email, tenant}. Expires shortly. */
+  emailGrant: string;
+  /** Seconds until the grant expires (server-provided). */
+  expiresInSeconds: number;
+}
+
 export interface StewardTestAccountLoginOptions {
   tenantId?: string;
   email?: string;

--- a/packages/sdk/src/auth.ts
+++ b/packages/sdk/src/auth.ts
@@ -24,6 +24,8 @@ import type {
   StewardDeviceTokenPendingResult,
   StewardDeviceVerifyResult,
   StewardEmailResult,
+  StewardEmailOtpResult,
+  StewardEmailGrantResult,
   StewardFarcasterLoginConfig,
   StewardFarcasterLoginPayload,
   StewardGuestDeleteResult,
@@ -754,7 +756,10 @@ export class StewardAuth {
    * Requires a browser environment and `@simplewebauthn/browser` installed.
    * Throws `StewardApiError` otherwise.
    */
-  async addPasskey(email: string): Promise<StewardAuthResult | StewardMfaRequiredResult> {
+  async addPasskey(
+    email: string,
+    options: { emailGrant?: string } = {},
+  ): Promise<StewardAuthResult | StewardMfaRequiredResult> {
     if (!isBrowser()) {
       throw new StewardApiError("Passkeys require a browser environment.", 0);
     }
@@ -767,7 +772,7 @@ export class StewardAuth {
         0,
       );
     }
-    return this.completePasskeyRegister(email, browserLib);
+    return this.completePasskeyRegister(email, browserLib, options.emailGrant);
   }
 
   private async completePasskeyLogin(
@@ -820,8 +825,13 @@ export class StewardAuth {
   private async completePasskeyRegister(
     email: string,
     lib: Pick<SimpleWebAuthnBrowser, "startRegistration">,
+    emailGrant?: string,
   ): Promise<StewardAuthResult | StewardMfaRequiredResult> {
-    // Fetch registration options
+    // Fetch registration options. When an `emailGrant` is supplied (from
+    // `verifyEmailOtp`), Steward accepts it in place of a session so a
+    // brand-new, signed-out user can register their FIRST passkey — the
+    // grant proves ownership of the email. Without it, register/options
+    // requires an authenticated session.
     const regOptsRes = await authRequest<Record<string, unknown>>(
       this.baseUrl,
       "/auth/passkey/register/options",
@@ -829,6 +839,7 @@ export class StewardAuth {
         method: "POST",
         body: JSON.stringify({
           email,
+          ...(emailGrant ? { emailGrant } : {}),
           ...(this.tenantId ? { tenantId: this.tenantId } : {}),
         }),
       },
@@ -859,6 +870,7 @@ export class StewardAuth {
         body: JSON.stringify({
           email,
           response: regResponse,
+          ...(emailGrant ? { emailGrant } : {}),
           ...(this.tenantId ? { tenantId: this.tenantId } : {}),
         }),
       },
@@ -1005,6 +1017,78 @@ export class StewardAuth {
     }
 
     return this.storeExchangeResponse(res.data);
+  }
+
+  // ─── Email OTP (Privy-style verified signup) ──────────────────────────
+
+  /**
+   * Email a 6-digit one-time code (Privy-style signup). Unlike
+   * `signInWithEmail` (magic link), this issues a code the user types back
+   * via `verifyEmailOtp` to obtain an `emailGrant`. The grant lets a
+   * brand-new, signed-out user register their first passkey with
+   * `addPasskey(email, { emailGrant })` — no prior session required.
+   */
+  async sendEmailOtp(email: string, captchaToken?: string): Promise<StewardEmailOtpResult> {
+    // authRequest returns the raw `{ ok, data }` envelope; the send route's
+    // payload (e.g. { expiresAt }) is nested under `data`.
+    const res = await authRequest<{ ok: boolean; data?: { expiresAt?: string } }>(
+      this.baseUrl,
+      "/auth/email/otp/send",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          email,
+          ...(captchaToken ? { captchaToken } : {}),
+          ...(this.tenantId ? { tenantId: this.tenantId } : {}),
+        }),
+      },
+    );
+
+    if (!res.ok) {
+      throw new StewardApiError(res.error, res.status);
+    }
+
+    return { ok: true, expiresAt: res.data?.data?.expiresAt };
+  }
+
+  /**
+   * Exchange the 6-digit code from `sendEmailOtp` for a short-lived,
+   * single-use `emailGrant` proving ownership of the email. Pass the grant
+   * to `addPasskey(email, { emailGrant })`.
+   *
+   * NOTE: this does NOT sign the user in by itself — it returns proof of
+   * email ownership, intentionally decoupled so the caller drives the
+   * passkey registration step.
+   */
+  async verifyEmailOtp(email: string, code: string): Promise<StewardEmailGrantResult> {
+    // The verify route returns { ok, data: { emailGrant, expiresInSeconds } }
+    // and authRequest hands back the raw envelope, so unwrap `.data`.
+    const res = await authRequest<{
+      ok: boolean;
+      data?: { emailGrant?: string; expiresInSeconds?: number };
+    }>(this.baseUrl, "/auth/email/otp/verify", {
+      method: "POST",
+      body: JSON.stringify({
+        email,
+        code,
+        ...(this.tenantId ? { tenantId: this.tenantId } : {}),
+      }),
+    });
+
+    if (!res.ok) {
+      throw new StewardApiError(res.error, res.status);
+    }
+
+    const grant = res.data?.data?.emailGrant;
+    if (typeof grant !== "string" || grant.length === 0) {
+      throw new StewardApiError("Email OTP verify did not return a grant.", res.status);
+    }
+
+    return {
+      ok: true,
+      emailGrant: grant,
+      expiresInSeconds: res.data?.data?.expiresInSeconds ?? 0,
+    };
   }
 
   async getTestAccessToken(

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -11,6 +11,8 @@ export type {
   StewardDeviceTokenPendingResult,
   StewardDeviceVerifyResult,
   StewardEmailResult,
+  StewardEmailOtpResult,
+  StewardEmailGrantResult,
   StewardEmbeddedWalletLoginConfig,
   StewardFarcasterLoginConfig,
   StewardFarcasterLoginPayload,


### PR DESCRIPTION
## Why
Replicating waifu.fun's **first-time passkey setup for new accounts** on eliza cloud. The Steward backend already supports the Privy-style flow (`/auth/email/otp/{send,verify}` + `emailGrant`-gated passkey register), but `@stwd/sdk` couldn't reach it:
- `addPasskey` assumed an authenticated session (no `emailGrant` support)
- no email-OTP methods existed (only SMS/WhatsApp)

So a signed-out new user couldn't register their first passkey via the SDK. waifu works around this with raw `fetch`; this brings the capability into the SDK so eliza cloud (and waifu, later) can use it cleanly.

## What
New on `StewardAuth`:
- `sendEmailOtp(email, captchaToken?)` → `POST /auth/email/otp/send` (6-digit code)
- `verifyEmailOtp(email, code)` → `POST /auth/email/otp/verify` → `{ emailGrant, expiresInSeconds }`
- `addPasskey(email, { emailGrant? })` → threads the grant into BOTH `/auth/passkey/register/{options,verify}`

Flow: `sendEmailOtp` → user types code → `verifyEmailOtp` → `addPasskey(email, { emailGrant })`.

New types `StewardEmailOtpResult` + `StewardEmailGrantResult` exported.

## Tests
8 new tests (send/verify happy paths + rate-limit/expired errors, grant forwarded on both register calls, no-grant path unchanged, full e2e signup). Existing `addPasskey` tests still green. SDK typechecks + builds clean.

## Notes
- Unwraps the `{ ok, data }` envelope correctly (authRequest returns the raw body).
- No backend changes needed — endpoints already exist.
- Next: a follow-up wires this into eliza cloud's login UI (OTP code entry + passkey-setup step for new accounts).

Co-authored-by: wakesync <shadow@shad0w.xyz>