### PR TITLE
Preserve wei formatting precision

### DIFF
--- a/web/src/lib/utils.test.ts
+++ b/web/src/lib/utils.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "bun:test";
+
+import { formatWei } from "./utils";
+
+describe("formatWei", () => {
+  it("formats whole and fractional ETH values", () => {
+    expect(formatWei("1000000000000000000")).toBe("1.0000");
+    expect(formatWei("1500000000000000000", "ETH")).toBe("1.5000 ETH");
+  });
+
+  it("formats small nonzero values without floating point conversion", () => {
+    expect(formatWei("99999999999999")).toBe("<0.0001");
+  });
+
+  it("preserves large wei precision", () => {
+    expect(formatWei("123456789012345678901234567890")).toBe(
+      "123456789012.3456",
+    );
+  });
+
+  it("returns zero for malformed input", () => {
+    expect(formatWei("abc", "ETH")).toBe("0 ETH");
+  });
+});

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -3,16 +3,32 @@ export function shortenAddress(addr: string, chars = 4): string {
   return `${addr.slice(0, chars + 2)}...${addr.slice(-chars)}`;
 }
 
+const WEI_PER_ETH = 10n ** 18n;
+
+function formatWeiValue(value: bigint): string {
+  if (value === 0n) return "0";
+
+  const sign = value < 0n ? "-" : "";
+  const absolute = value < 0n ? -value : value;
+
+  if (absolute > 0n && absolute < 100_000_000_000_000n) {
+    return `${sign}<0.0001`;
+  }
+
+  const scale = WEI_PER_ETH / 10_000n;
+  const scaled = absolute / scale;
+  const whole = scaled / 10_000n;
+  const fraction = (scaled % 10_000n).toString().padStart(4, "0");
+  return `${sign}${whole}.${fraction}`;
+}
+
 export function formatWei(wei: string, symbol?: string): string {
   if (!wei) return "0";
   try {
-    const eth = Number(BigInt(wei)) / 1e18;
-    const formatted = eth === 0 ? "0" : eth < 0.0001 ? "<0.0001" : eth.toFixed(4);
+    const formatted = formatWeiValue(BigInt(wei));
     return symbol ? `${formatted} ${symbol}` : formatted;
   } catch {
-    const eth = Number(wei) / 1e18;
-    const formatted = eth === 0 ? "0" : eth < 0.0001 ? "<0.0001" : eth.toFixed(4);
-    return symbol ? `${formatted} ${symbol}` : formatted;
+    return symbol ? `0 ${symbol}` : "0";
   }
 }
 


### PR DESCRIPTION
The dashboard formatter currently converts wei through Number before scaling to ETH. Large onchain values can lose precision before display, and malformed values fall back to another Number conversion path.\n\nThis keeps formatting in bigint arithmetic, preserves the existing four decimal display behavior, and adds focused coverage for large and malformed inputs.