### PR TITLE
feat(react): wagmi v3 support + MetaMask Connect connector

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -179,6 +179,52 @@ const connector = createStewardGlobalWalletConnector({
 });
 ```
 
+### MetaMask Connect (wagmi v3)
+
+Steward ships a first-class MetaMask Connect (EVM) connector path. It wraps
+wagmi v3's built-in `metaMask()` connector with Steward defaults and is
+RainbowKit-free, so it works on wagmi v3 today without waiting for RainbowKit v3.
+
+This path targets wagmi v3. `@stwd/react` accepts `wagmi@^2 || ^3` as an optional
+peer, so existing v2 + RainbowKit apps keep working untouched. The MetaMask
+Connect connector needs the wagmi-native `metaMask()` connector, which pulls in
+`@metamask/connect-evm` (also an optional peer).
+
+```bash
+bun add wagmi@3 viem @metamask/connect-evm
+```
+
+```tsx
+import { createConfig, http } from "wagmi";
+import { mainnet, base } from "wagmi/chains";
+import { createStewardMetaMaskConnector } from "@stwd/react/wallet/evm";
+
+const config = createConfig({
+  chains: [mainnet, base],
+  connectors: [
+    createStewardMetaMaskConnector({
+      dapp: {
+        name: "My Steward App",
+        url: "https://app.example.com",
+        iconUrl: "https://app.example.com/icon.png",
+      },
+    }),
+  ],
+  transports: {
+    [mainnet.id]: http(),
+    [base.id]: http(),
+  },
+});
+```
+
+The `dapp` metadata is what MetaMask Connect surfaces during the connection
+handshake. Steward defaults the name to `Steward` and, in the browser, the url
+to `location.origin`. Override either field per app. Any other MetaMask Connect
+parameters (`connectAndSign`, `connectWith`, etc) pass straight through.
+
+This connector is standalone: it drops into any wagmi v3 `createConfig` and does
+not change the existing RainbowKit-based EVM path.
+
 If you render `WalletLogin` directly, it is already the wallet UI. To enable wallet sign-in inside the broader `<StewardLogin>` modal (alongside passkey, email, OAuth), pass the `showWallets` prop on `<StewardLogin>` instead.
 
 ### Drop-in: `<StewardLoginWithWallets>`

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stwd/react",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Embeddable React components for Steward agent wallet management",
   "type": "module",
   "main": "dist/index.js",
@@ -48,9 +48,10 @@
   "peerDependencies": {
     "react": ">=18.0.0",
     "react-dom": ">=18.0.0",
-    "wagmi": "^2.0.0",
+    "wagmi": "^2.0.0 || ^3.0.0",
     "viem": "^2.0.0",
     "@rainbow-me/rainbowkit": "^2.0.0",
+    "@metamask/connect-evm": "^2.1.0",
     "@tanstack/react-query": "^5.0.0",
     "@solana/wallet-adapter-react": "^0.15.0",
     "@solana/wallet-adapter-react-ui": "^0.9.0",
@@ -65,6 +66,9 @@
   },
   "peerDependenciesMeta": {
     "wagmi": {
+      "optional": true
+    },
+    "@metamask/connect-evm": {
       "optional": true
     },
     "viem": {

--- a/packages/react/src/__tests__/MetaMaskConnector.test.ts
+++ b/packages/react/src/__tests__/MetaMaskConnector.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, mock, test } from "bun:test";
+
+// Mirror the GlobalWallet test: mock the wagmi-native connector so we can assert
+// the dapp params Steward passes through. metaMask() returns a CreateConnectorFn,
+// here a tagged factory we can inspect.
+const mockMetaMask = mock((params: unknown) => {
+  const fn = () => ({ id: "metaMask", type: "metaMask" });
+  (fn as unknown as { params: unknown }).params = params;
+  return fn;
+});
+
+mock.module("wagmi/connectors", () => ({
+  metaMask: mockMetaMask,
+}));
+
+const { createStewardMetaMaskConnector } = await import("../wallet/metamask.js");
+
+describe("createStewardMetaMaskConnector", () => {
+  test("returns a wagmi connector factory", () => {
+    const connector = createStewardMetaMaskConnector();
+    expect(typeof connector).toBe("function");
+  });
+
+  test("defaults the dapp name to Steward", () => {
+    createStewardMetaMaskConnector();
+    const lastCall = mockMetaMask.mock.calls.at(-1)?.[0] as { dapp?: { name?: string } };
+    expect(lastCall.dapp?.name).toBe("Steward");
+  });
+
+  test("passes the caller dapp metadata through, overriding defaults", () => {
+    createStewardMetaMaskConnector({
+      dapp: { name: "My Steward App", url: "https://app.example.com", iconUrl: "https://app.example.com/icon.png" },
+    });
+    const lastCall = mockMetaMask.mock.calls.at(-1)?.[0] as {
+      dapp?: { name?: string; url?: string; iconUrl?: string };
+    };
+    expect(lastCall.dapp).toMatchObject({
+      name: "My Steward App",
+      url: "https://app.example.com",
+      iconUrl: "https://app.example.com/icon.png",
+    });
+  });
+
+  test("forwards extra MetaMask parameters alongside dapp", () => {
+    createStewardMetaMaskConnector({ connectAndSign: "hello" });
+    const lastCall = mockMetaMask.mock.calls.at(-1)?.[0] as {
+      dapp?: { name?: string };
+      connectAndSign?: string;
+    };
+    expect(lastCall.connectAndSign).toBe("hello");
+    expect(lastCall.dapp?.name).toBe("Steward");
+  });
+});

--- a/packages/react/src/types/wallet-shims.d.ts
+++ b/packages/react/src/types/wallet-shims.d.ts
@@ -62,6 +62,30 @@ declare module "wagmi" {
   export function useDisconnect(): { disconnect: () => void };
 }
 
+declare module "wagmi/connectors" {
+  // wagmi v3 ships the MetaMask Connect (EVM) connector built in. We only
+  // surface `metaMask` and keep the param/return types loose so the package
+  // typechecks without the real connector installed. The consumer's install of
+  // wagmi@3 + @metamask/connect-evm shadows these with the precise types.
+  import type { CreateConnectorFn } from "wagmi";
+  export function metaMask(parameters?: unknown): CreateConnectorFn;
+}
+
+declare module "@metamask/connect-evm" {
+  // Optional peer required by wagmi v3's metaMask() connector. We don't import
+  // from it directly; this stub just keeps any transitive reference resolvable
+  // when the real package isn't installed at typecheck time.
+  export interface MetaMaskDappMetadata {
+    name?: string;
+    url?: string;
+    iconUrl?: string;
+  }
+  export interface MetaMaskParameters {
+    dapp?: MetaMaskDappMetadata;
+    [key: string]: unknown;
+  }
+}
+
 declare module "viem" {
   export type Address = `0x${string}`;
   export interface Chain {

--- a/packages/react/src/wallet/evm.ts
+++ b/packages/react/src/wallet/evm.ts
@@ -42,3 +42,8 @@ export type {
   StewardGlobalWalletProviderFactory,
 } from "./global.js";
 export { createStewardGlobalWallet, createStewardGlobalWalletConnector } from "./global.js";
+export type {
+  StewardMetaMaskConnectorOptions,
+  StewardMetaMaskDappMetadata,
+} from "./metamask.js";
+export { createStewardMetaMaskConnector } from "./metamask.js";

--- a/packages/react/src/wallet/index.ts
+++ b/packages/react/src/wallet/index.ts
@@ -54,3 +54,8 @@ export type {
   StewardGlobalWalletProviderFactory,
 } from "./global.js";
 export { createStewardGlobalWallet, createStewardGlobalWalletConnector } from "./global.js";
+export type {
+  StewardMetaMaskConnectorOptions,
+  StewardMetaMaskDappMetadata,
+} from "./metamask.js";
+export { createStewardMetaMaskConnector } from "./metamask.js";

--- a/packages/react/src/wallet/metamask.ts
+++ b/packages/react/src/wallet/metamask.ts
@@ -1,0 +1,72 @@
+import { metaMask } from "wagmi/connectors";
+import type { CreateConnectorFn } from "wagmi";
+
+/**
+ * dApp metadata MetaMask Connect surfaces during the connection handshake.
+ * This is the modern `dapp` field (the old `dappMetadata` alias is deprecated).
+ */
+export interface StewardMetaMaskDappMetadata {
+  /** App name shown in the MetaMask Connect prompt. */
+  name?: string;
+  /** App URL. Defaults to the host page origin in the browser. */
+  url?: string;
+  /** Optional icon URL shown alongside the name. */
+  iconUrl?: string;
+}
+
+export interface StewardMetaMaskConnectorOptions {
+  /**
+   * dApp metadata. Steward fills in a sensible default name/url, callers can
+   * override either field. In the browser, `url` defaults to `location.origin`.
+   */
+  dapp?: StewardMetaMaskDappMetadata;
+  /**
+   * Pass-through for any other MetaMask Connect parameters (connectAndSign,
+   * connectWith, etc.). Kept loose so we don't pin a connector minor version.
+   */
+  [key: string]: unknown;
+}
+
+const DEFAULT_DAPP_NAME = "Steward";
+
+function defaultDappUrl(): string | undefined {
+  if (typeof window !== "undefined" && window.location?.origin) {
+    return window.location.origin;
+  }
+  return undefined;
+}
+
+/**
+ * MetaMask Connect (EVM) connector for Steward, RainbowKit-free.
+ *
+ * Wraps wagmi v3's built-in `metaMask()` connector with Steward-friendly
+ * defaults so it drops straight into a wagmi v3 `createConfig`. Because it does
+ * not touch RainbowKit, it works on wagmi v3 today without waiting for a
+ * RainbowKit v3 release.
+ *
+ * Requires the optional peers `wagmi@^3` and `@metamask/connect-evm@^2.1.0`.
+ *
+ * Usage:
+ *   import { createConfig, http } from "wagmi";
+ *   import { mainnet, base } from "wagmi/chains";
+ *   import { createStewardMetaMaskConnector } from "@stwd/react/wallet/evm";
+ *
+ *   const config = createConfig({
+ *     chains: [mainnet, base],
+ *     connectors: [
+ *       createStewardMetaMaskConnector({ dapp: { name: "My Steward App" } }),
+ *     ],
+ *     transports: { [mainnet.id]: http(), [base.id]: http() },
+ *   });
+ */
+export function createStewardMetaMaskConnector(
+  options: StewardMetaMaskConnectorOptions = {},
+): CreateConnectorFn {
+  const { dapp, ...rest } = options;
+  const mergedDapp: StewardMetaMaskDappMetadata = {
+    name: DEFAULT_DAPP_NAME,
+    url: defaultDappUrl(),
+    ...dapp,
+  };
+  return metaMask({ dapp: mergedDapp, ...rest }) as CreateConnectorFn;
+}


### PR DESCRIPTION
## What

Makes `@stwd/react` wagmi v3-ready and adds a first-class, RainbowKit-free **MetaMask Connect (EVM)** connector path. This is the integration MetaMask dev rel asked for ("support MM Connect directly").

## Changes

- **Peer range widened:** `wagmi` `^2.0.0` -> `^2.0.0 || ^3.0.0`. `viem` stays `^2` (wagmi v3 still uses viem 2.x). RainbowKit stays `^2` and optional.
- **`@metamask/connect-evm`** added as an optional peer (`^2.1.0`).
- **`createStewardMetaMaskConnector()`** (`src/wallet/metamask.ts`): wraps wagmi v3's built-in `metaMask()` connector with Steward defaults (sensible `dapp` name/url, caller override, loose pass-through). Returns a `CreateConnectorFn` that drops straight into a wagmi v3 `createConfig`. Exported from `@stwd/react/wallet` and `@stwd/react/wallet/evm`.
- **Loose ambient shims** for `wagmi/connectors` + `@metamask/connect-evm` so the package typechecks standalone without the optional peers installed (mirrors the existing shim pattern).
- README MetaMask Connect section with the consumer snippet.
- One new test (`MetaMaskConnector.test.ts`); version `0.9.1` -> `0.10.0`.

## Why it works without RainbowKit

RainbowKit (2.2.11) has no wagmi v3 support yet, but `@stwd/react` treats RainbowKit as an optional peer. This connector is RainbowKit-free, so it works on wagmi v3 today. It's an additional standalone option; the existing v2 RainbowKit path in `EVMProvider.tsx` is untouched.

## Verified

- `tsc --noEmit` clean.
- Full `@stwd/react` test suite green (no regressions), new connector test 4/4.
- wagmi v3 facts confirmed against a real install: v3 still uses viem 2.x; `metaMask` exported from `wagmi/connectors`; `useAccount`/`createConnector`/`CreateConnectorFn` unchanged.

## Out of scope (intentional)

- No RainbowKit v3 migration (not recommended by MetaMask dev rel; RainbowKit isn't ready).
- No changes to the waifu repo or any other Steward package.

## Usage

```ts
import { createConfig, http } from "wagmi";
import { mainnet, base } from "wagmi/chains";
import { createStewardMetaMaskConnector } from "@stwd/react/wallet/evm";

const config = createConfig({
  chains: [mainnet, base],
  connectors: [createStewardMetaMaskConnector({ dapp: { name: "My Steward App" } })],
  transports: { [mainnet.id]: http(), [base.id]: http() },
});
```

Co-authored-by: wakesync <shadow@shad0w.xyz>
