### PR TITLE
feat(api): plugin host + declarative contribution contract (phase 2a)

### DIFF
--- a/packages/api/src/__tests__/plugin-host.test.ts
+++ b/packages/api/src/__tests__/plugin-host.test.ts
@@ -1,0 +1,204 @@
+/**
+ * plugin-host.test.ts — focused unit tests for the Phase 2a plugin host.
+ *
+ * Covers the host's load-bearing guarantees:
+ *   - `dependsOn` topological ordering (a plugin registers AFTER its deps);
+ *   - duplicate plugin-name rejection (fail closed);
+ *   - missing-dependency rejection (fail closed) BEFORE any register runs;
+ *   - dependency-cycle detection (fail closed);
+ *   - declared `webhookEvents` are merged into the runtime registry (core ∪
+ *     plugin-declared) and surfaced via diagnostics.
+ *
+ * The host is exercised with lightweight fake plugins + a stub app/ctx — it does
+ * not touch the db/vault, so these tests are pure and fast.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { WebhookEventRegistry } from "@stwd/shared";
+import type { StewardApp } from "../plugin";
+import { PluginHost, PluginHostError } from "../plugin";
+
+// A minimal stub app + ctx. The fake plugins below never touch them; we only
+// assert on registration order + the event registry, so `unknown`-casts are safe.
+const app = {} as StewardApp;
+type Ctx = Record<string, never>;
+const ctx: Ctx = {};
+
+/** Build a no-op plugin that records its registration order into `log`. */
+function recordingPlugin(
+  name: string,
+  log: string[],
+  opts: { dependsOn?: readonly string[]; webhookEvents?: readonly string[]; version?: string } = {},
+) {
+  return {
+    name,
+    version: opts.version,
+    dependsOn: opts.dependsOn,
+    webhookEvents: opts.webhookEvents,
+    register() {
+      log.push(name);
+    },
+  };
+}
+
+describe("PluginHost — dependency ordering", () => {
+  it("registers a plugin AFTER the plugins it depends on", async () => {
+    const log: string[] = [];
+    // declared order is intentionally reverse-topological to prove the host
+    // reorders by dependsOn, not by declaration order.
+    const c = recordingPlugin("c", log, { dependsOn: ["b"] });
+    const b = recordingPlugin("b", log, { dependsOn: ["a"] });
+    const a = recordingPlugin("a", log);
+
+    const host = new PluginHost<Ctx>();
+    await host.register(app, ctx, c, b, a);
+
+    expect(log).toEqual(["a", "b", "c"]);
+    expect(host.describe().plugins.map((p) => p.name)).toEqual(["a", "b", "c"]);
+  });
+
+  it("keeps independent plugins in declared order", async () => {
+    const log: string[] = [];
+    const x = recordingPlugin("x", log);
+    const y = recordingPlugin("y", log);
+    const z = recordingPlugin("z", log);
+
+    const host = new PluginHost<Ctx>();
+    await host.register(app, ctx, x, y, z);
+
+    expect(log).toEqual(["x", "y", "z"]);
+  });
+
+  it("orders a diamond dependency correctly (dep visited once)", async () => {
+    const log: string[] = [];
+    // d depends on b and c; both depend on a. a must run first, d last, exactly
+    // once each.
+    const d = recordingPlugin("d", log, { dependsOn: ["b", "c"] });
+    const c = recordingPlugin("c", log, { dependsOn: ["a"] });
+    const b = recordingPlugin("b", log, { dependsOn: ["a"] });
+    const a = recordingPlugin("a", log);
+
+    const host = new PluginHost<Ctx>();
+    await host.register(app, ctx, d, c, b, a);
+
+    expect(log[0]).toBe("a");
+    expect(log[log.length - 1]).toBe("d");
+    expect(log.filter((n) => n === "a")).toHaveLength(1);
+    expect(log.indexOf("b")).toBeLessThan(log.indexOf("d"));
+    expect(log.indexOf("c")).toBeLessThan(log.indexOf("d"));
+  });
+});
+
+describe("PluginHost — fail closed", () => {
+  it("rejects duplicate plugin names", async () => {
+    const log: string[] = [];
+    const host = new PluginHost<Ctx>();
+    await expect(
+      host.register(app, ctx, recordingPlugin("dup", log), recordingPlugin("dup", log)),
+    ).rejects.toBeInstanceOf(PluginHostError);
+    // nothing should have registered.
+    expect(log).toEqual([]);
+  });
+
+  it("rejects a missing dependency BEFORE registering anything", async () => {
+    const log: string[] = [];
+    const host = new PluginHost<Ctx>();
+    const needsGhost = recordingPlugin("real", log, { dependsOn: ["ghost"] });
+
+    await expect(host.register(app, ctx, needsGhost)).rejects.toBeInstanceOf(PluginHostError);
+    // fail closed: the real plugin's register must NOT have run.
+    expect(log).toEqual([]);
+  });
+
+  it("detects a dependency cycle", async () => {
+    const log: string[] = [];
+    const host = new PluginHost<Ctx>();
+    const p1 = recordingPlugin("p1", log, { dependsOn: ["p2"] });
+    const p2 = recordingPlugin("p2", log, { dependsOn: ["p1"] });
+
+    await expect(host.register(app, ctx, p1, p2)).rejects.toBeInstanceOf(PluginHostError);
+    expect(log).toEqual([]);
+  });
+
+  it("reports the missing dependency name in the error", async () => {
+    const host = new PluginHost<Ctx>();
+    const p = recordingPlugin("p", [], { dependsOn: ["absent-dep"] });
+    await expect(host.register(app, ctx, p)).rejects.toThrow(/absent-dep/);
+  });
+});
+
+describe("PluginHost — webhook event contribution", () => {
+  it("merges declared webhookEvents into a fresh registry (core ∪ plugin)", async () => {
+    // a registry seeded with one core event.
+    const registry = new WebhookEventRegistry(["tx.pending"]);
+    const host = new PluginHost<Ctx>(registry);
+
+    const plugin = recordingPlugin("emitter", [], {
+      webhookEvents: ["thing.created", "thing.failed"],
+    });
+    await host.register(app, ctx, plugin);
+
+    // core event still valid.
+    expect(registry.has("tx.pending")).toBe(true);
+    // plugin-declared events now valid.
+    expect(registry.has("thing.created")).toBe(true);
+    expect(registry.has("thing.failed")).toBe(true);
+    // an unknown event stays invalid.
+    expect(registry.has("not.declared")).toBe(false);
+  });
+
+  it("surfaces contributions + loaded plugins via describe()", async () => {
+    const registry = new WebhookEventRegistry(["tx.pending"]);
+    const host = new PluginHost<Ctx>(registry);
+
+    await host.register(
+      app,
+      ctx,
+      recordingPlugin("alpha", [], { version: "1.2.3", webhookEvents: ["alpha.ping"] }),
+      recordingPlugin("beta", [], { dependsOn: ["alpha"] }),
+    );
+
+    const diag = host.describe();
+    expect(diag.plugins).toEqual([
+      { name: "alpha", version: "1.2.3" },
+      { name: "beta", version: undefined },
+    ]);
+    expect(diag.webhookEventContributions).toEqual({ alpha: ["alpha.ping"] });
+    // the merged valid set includes both the core seed and the plugin event.
+    expect(diag.webhookEvents).toContain("tx.pending");
+    expect(diag.webhookEvents).toContain("alpha.ping");
+  });
+
+  it("registers events before running register hooks (events valid inside register)", async () => {
+    const registry = new WebhookEventRegistry([]);
+    const host = new PluginHost<Ctx>(registry);
+    let sawOwnEventValid = false;
+
+    const plugin = {
+      name: "self-aware",
+      webhookEvents: ["self.event"] as const,
+      register() {
+        // its own declared event must already be registered at register time.
+        sawOwnEventValid = registry.has("self.event");
+      },
+    };
+
+    await host.register(app, ctx, plugin);
+    expect(sawOwnEventValid).toBe(true);
+  });
+
+  it("a plugin with no register hook still contributes its events", async () => {
+    const registry = new WebhookEventRegistry([]);
+    const host = new PluginHost<Ctx>(registry);
+
+    // declarative-only plugin: no register() at all.
+    const declarativeOnly = {
+      name: "declarative-only",
+      webhookEvents: ["declared.only"] as const,
+    };
+    await host.register(app, ctx, declarativeOnly);
+
+    expect(registry.has("declared.only")).toBe(true);
+    expect(host.describe().plugins).toEqual([{ name: "declarative-only", version: undefined }]);
+  });
+});

--- a/packages/api/src/compose.ts
+++ b/packages/api/src/compose.ts
@@ -32,8 +32,9 @@
 
 import type { Hono } from "hono";
 import { createApp, mountCoreIdempotencyAndRoutes } from "./app";
-import { buildPluginContext, registerPlugin, type StewardApp } from "./plugin";
+import { buildPluginContext, PluginHost, type StewardApp } from "./plugin";
 import type { AppVariables } from "./services/context";
+import { webhookEventRegistry } from "./services/webhook-events";
 
 type RouteArgs = unknown[];
 
@@ -117,10 +118,19 @@ export async function composeApp(): Promise<Hono<{ Variables: AppVariables }>> {
   // plugin module is evaluated lazily at compose time, not at module load.
   const ctx = buildPluginContext();
   const { tradingPlugin } = (await import("@stwd/plugin-trading")) as {
-    tradingPlugin: Parameters<typeof registerPlugin<typeof ctx>>[1];
+    tradingPlugin: Parameters<PluginHost<typeof ctx>["register"]>[2];
   };
   const { deferred, flush } = makeDeferredRouteApp(app);
-  await registerPlugin(deferred, tradingPlugin, ctx);
+
+  // The plugin host composes the plugin(s): it orders by `dependsOn` (failing
+  // closed on a missing/cyclic dep), merges each plugin's declared
+  // `webhookEvents` into the SHARED process-wide registry the webhook config/
+  // dispatch path consults (so a plugin's event type is accepted), then runs
+  // each plugin's `register`. It registers onto the DEFERRED-ROUTE proxy so the
+  // load-bearing ordering is preserved: plugin auth mw lands now (before
+  // idempotency), plugin routes are buffered and flushed after.
+  const host = new PluginHost<typeof ctx>(webhookEventRegistry);
+  await host.register(deferred, ctx, tradingPlugin);
 
   // 3) core idempotency + core routes.
   mountCoreIdempotencyAndRoutes(app);

--- a/packages/api/src/plugin.ts
+++ b/packages/api/src/plugin.ts
@@ -46,6 +46,7 @@
  */
 
 import type { StewardPlugin } from "@stwd/shared";
+import { WebhookEventRegistry } from "@stwd/shared";
 import type { Hono } from "hono";
 import { requireAgentJwt } from "./middleware/agent-jwt";
 import { operatorAuth } from "./middleware/operator-auth";
@@ -64,6 +65,7 @@ import {
   tenantAuth,
   vault,
 } from "./services/context";
+import { CONFIGURED_WEBHOOK_EVENT_TYPES } from "./services/webhook-events";
 
 /** the steward app a plugin mounts onto: a hono app with the shared variables. */
 export type StewardApp = Hono<{ Variables: AppVariables }>;
@@ -126,15 +128,203 @@ export function buildPluginContext(): StewardAppContext {
 }
 
 /**
- * Register a plugin onto the steward app, injecting the core context. thin
- * `app.register(plugin)`-style helper (the ctx is injected rather than discovered)
- * — calling it is how a host OPTS IN to a plugin at the composition root. may be
- * async because a plugin's `register` may be async.
+ * Error thrown when the plugin host cannot build a valid registration order:
+ * a duplicate plugin name, a dependency on a plugin that was not provided, or a
+ * dependency cycle. The host FAILS CLOSED on any of these — it never registers a
+ * partial/ambiguous plugin set (mirrors the fail-closed-in-production philosophy
+ * of the adapter registry).
+ */
+export class PluginHostError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PluginHostError";
+  }
+}
+
+/** A loaded plugin's identity, surfaced by the host for diagnostics. */
+export interface LoadedPluginInfo {
+  name: string;
+  version?: string;
+}
+
+/**
+ * Diagnostics describing what a host run loaded + what plugins contributed.
+ * Returned by {@link PluginHost.describe} for ops/health endpoints.
+ */
+export interface PluginHostDiagnostics {
+  /** loaded plugins, in dependency (registration) order. */
+  plugins: LoadedPluginInfo[];
+  /** every valid webhook event name after merging plugin contributions. */
+  webhookEvents: string[];
+  /** which plugin contributed which webhook event names (core events excluded). */
+  webhookEventContributions: Record<string, string[]>;
+}
+
+/**
+ * Topologically order plugins by their `dependsOn` graph so every plugin is
+ * registered AFTER the plugins it depends on. FAILS CLOSED (throws
+ * {@link PluginHostError}) on a duplicate name, an unknown dependency, or a
+ * cycle — the host never registers a plugin against a half-built or missing
+ * dependency.
+ */
+function orderByDependencies<Ctx>(
+  plugins: ReadonlyArray<StewardPlugin<StewardApp, Ctx>>,
+): Array<StewardPlugin<StewardApp, Ctx>> {
+  const byName = new Map<string, StewardPlugin<StewardApp, Ctx>>();
+  for (const plugin of plugins) {
+    if (!plugin.name || typeof plugin.name !== "string") {
+      throw new PluginHostError("plugin is missing a non-empty string `name`.");
+    }
+    if (byName.has(plugin.name)) {
+      throw new PluginHostError(`duplicate plugin name: "${plugin.name}".`);
+    }
+    byName.set(plugin.name, plugin);
+  }
+
+  // Validate every declared dependency exists before ordering, so a missing dep
+  // fails closed with a clear message rather than surfacing as a phantom cycle.
+  for (const plugin of plugins) {
+    for (const dep of plugin.dependsOn ?? []) {
+      if (!byName.has(dep)) {
+        throw new PluginHostError(
+          `plugin "${plugin.name}" depends on "${dep}", which is not registered.`,
+        );
+      }
+    }
+  }
+
+  // Depth-first topological sort with cycle detection. `visiting` marks nodes on
+  // the current DFS stack; re-entering one is a cycle.
+  const ordered: Array<StewardPlugin<StewardApp, Ctx>> = [];
+  const visited = new Set<string>();
+  const visiting = new Set<string>();
+
+  const visit = (name: string, trail: string[]): void => {
+    if (visited.has(name)) return;
+    if (visiting.has(name)) {
+      throw new PluginHostError(
+        `plugin dependency cycle detected: ${[...trail, name].join(" -> ")}.`,
+      );
+    }
+    visiting.add(name);
+    const plugin = byName.get(name);
+    // Non-null: every name came from byName, and deps were validated above.
+    if (plugin) {
+      for (const dep of plugin.dependsOn ?? []) {
+        visit(dep, [...trail, name]);
+      }
+      ordered.push(plugin);
+    }
+    visiting.delete(name);
+    visited.add(name);
+  };
+
+  // Visit in the caller's declared order so independent plugins keep a stable,
+  // predictable registration order (only dependencies reorder them).
+  for (const plugin of plugins) {
+    visit(plugin.name, []);
+  }
+
+  return ordered;
+}
+
+/**
+ * The plugin host: composes one or more plugins onto a steward app.
+ *
+ * RESPONSIBILITIES (Phase 2a)
+ * ---------------------------
+ *  1. validate unique plugin names + a valid (acyclic, fully-satisfied)
+ *     `dependsOn` graph, FAILING CLOSED on any violation.
+ *  2. order plugins so each registers AFTER its dependencies.
+ *  3. collect each plugin's declared `webhookEvents` into a runtime-extensible
+ *     {@link WebhookEventRegistry} (core events ∪ plugin-declared), so the
+ *     webhook config/dispatch path accepts a plugin's event type.
+ *  4. call each plugin's `register(app, ctx)` (if present) in dependency order.
+ *  5. expose {@link describe} so ops can see what loaded + what was contributed.
+ *
+ * `policyRules` / `migrations` / `adapters` contribution points are TYPED on the
+ * contract but their wiring is DEFERRED to Phase 2b/2c/2d; the host does not act
+ * on them yet (it does not even read them, to avoid implying behavior that does
+ * not exist).
+ */
+export class PluginHost<Ctx> {
+  private readonly loaded: LoadedPluginInfo[] = [];
+  private readonly eventRegistry: WebhookEventRegistry;
+
+  /**
+   * @param eventRegistry the registry plugin-declared webhook events merge into.
+   *   defaults to a fresh registry seeded with the core event types, so the host
+   *   is usable standalone (tests); the composition root passes the SHARED
+   *   registry the webhook config/dispatch path consults.
+   */
+  constructor(eventRegistry?: WebhookEventRegistry) {
+    this.eventRegistry = eventRegistry ?? new WebhookEventRegistry(CONFIGURED_WEBHOOK_EVENT_TYPES);
+  }
+
+  /** the webhook event registry this host merges plugin events into. */
+  get webhookEventRegistry(): WebhookEventRegistry {
+    return this.eventRegistry;
+  }
+
+  /**
+   * Register one or more plugins onto `app` with the injected `ctx`. Orders by
+   * `dependsOn`, merges each plugin's declared webhook events into the registry,
+   * then calls each plugin's `register` (if present) in dependency order. Throws
+   * {@link PluginHostError} (fail closed) on a duplicate/missing/cyclic
+   * dependency BEFORE registering anything.
+   */
+  async register(
+    app: StewardApp,
+    ctx: Ctx,
+    ...plugins: Array<StewardPlugin<StewardApp, Ctx>>
+  ): Promise<void> {
+    const ordered = orderByDependencies(plugins);
+
+    // Phase 1: merge declared webhook events FIRST, so a plugin's `register`
+    // (and any concurrent dispatch) sees its own events as already valid.
+    for (const plugin of ordered) {
+      if (plugin.webhookEvents && plugin.webhookEvents.length > 0) {
+        this.eventRegistry.registerPluginEvents(plugin.name, plugin.webhookEvents);
+      }
+    }
+
+    // Phase 2: run each plugin's imperative register hook in dependency order.
+    for (const plugin of ordered) {
+      this.loaded.push({ name: plugin.name, version: plugin.version });
+      if (plugin.register) {
+        await plugin.register(app, ctx);
+      }
+    }
+  }
+
+  /** What this host loaded + what plugins contributed (for ops/health). */
+  describe(): PluginHostDiagnostics {
+    return {
+      plugins: [...this.loaded],
+      webhookEvents: this.eventRegistry.list(),
+      webhookEventContributions: this.eventRegistry.describeContributions(),
+    };
+  }
+}
+
+/**
+ * Register a SINGLE plugin onto the steward app, injecting the core context.
+ * Back-compat convenience that delegates to a {@link PluginHost} — the existing
+ * `app.register(plugin)`-style call site keeps working unchanged. Use
+ * {@link PluginHost} directly to compose multiple plugins with dependency
+ * ordering + contribution diagnostics.
+ *
+ * @returns the host that registered the plugin, so a caller can inspect what was
+ *   contributed via {@link PluginHost.describe}. (The return is additive; the
+ *   prior `Promise<void>` callers ignore it.)
  */
 export async function registerPlugin<Ctx>(
   app: StewardApp,
   plugin: StewardPlugin<StewardApp, Ctx>,
   ctx: Ctx,
-): Promise<void> {
-  await plugin.register(app, ctx);
+  eventRegistry?: WebhookEventRegistry,
+): Promise<PluginHost<Ctx>> {
+  const host = new PluginHost<Ctx>(eventRegistry);
+  await host.register(app, ctx, plugin);
+  return host;
 }

--- a/packages/api/src/routes/webhooks.ts
+++ b/packages/api/src/routes/webhooks.ts
@@ -27,6 +27,8 @@ import {
   acceptsConfiguredWebhookEvent,
   CONFIGURED_WEBHOOK_EVENT_TYPES,
   type ConfiguredWebhookEventType,
+  isValidConfigurableWebhookEvent,
+  listValidConfigurableWebhookEvents,
 } from "../services/webhook-events";
 import { validateWebhookUrl } from "../services/webhook-url";
 
@@ -37,7 +39,12 @@ webhookRoutes.use("*", async (c, next) => {
   await next();
 });
 
-// Valid webhook event types
+// Valid CORE webhook event types. Used as the default subscription set (a
+// webhook with no explicit `events` subscribes to all CORE events; plugin-
+// declared events are opt-in by name). Validation of a SUPPLIED `events` array
+// goes through the runtime-extensible registry (core ∪ plugin-declared) via
+// isValidConfigurableWebhookEvent, so a plugin's event name is accepted once the
+// plugin host has registered it at the composition root.
 const VALID_EVENTS = CONFIGURED_WEBHOOK_EVENT_TYPES;
 const MAX_WEBHOOKS_PER_TENANT = 50;
 const WEBHOOK_DELIVERY_STATUSES = ["pending", "processing", "delivered", "failed", "dead"] as const;
@@ -345,14 +352,12 @@ webhookRoutes.post("/", async (c) => {
     if (!Array.isArray(body.events)) {
       return c.json<ApiResponse>({ ok: false, error: "events must be an array" }, 400);
     }
-    const invalidEvents = body.events.filter(
-      (e) => !(VALID_EVENTS as readonly string[]).includes(e),
-    );
+    const invalidEvents = body.events.filter((e) => !isValidConfigurableWebhookEvent(e));
     if (invalidEvents.length > 0) {
       return c.json<ApiResponse>(
         {
           ok: false,
-          error: `Invalid events: ${invalidEvents.join(", ")}. Valid: ${VALID_EVENTS.join(", ")}`,
+          error: `Invalid events: ${invalidEvents.join(", ")}. Valid: ${listValidConfigurableWebhookEvents().join(", ")}`,
         },
         400,
       );
@@ -537,9 +542,7 @@ webhookRoutes.put("/:id", async (c) => {
     if (!Array.isArray(body.events)) {
       return c.json<ApiResponse>({ ok: false, error: "events must be an array" }, 400);
     }
-    const invalidEvents = body.events.filter(
-      (e) => !(VALID_EVENTS as readonly string[]).includes(e),
-    );
+    const invalidEvents = body.events.filter((e) => !isValidConfigurableWebhookEvent(e));
     if (invalidEvents.length > 0) {
       return c.json<ApiResponse>(
         { ok: false, error: `Invalid events: ${invalidEvents.join(", ")}` },

--- a/packages/api/src/services/webhook-events.ts
+++ b/packages/api/src/services/webhook-events.ts
@@ -1,6 +1,7 @@
 import {
   type LegacyWebhookEventType,
   type WebhookCatalogEventType,
+  WebhookEventRegistry,
   type WebhookEventType,
 } from "@stwd/shared";
 
@@ -97,4 +98,32 @@ export function acceptsConfiguredWebhookEvent(
   type: ConfiguredWebhookEventType,
 ): boolean {
   return events.length === 0 || events.includes(type);
+}
+
+/**
+ * Process-wide registry of valid webhook event names, seeded with the core
+ * configured event types. The plugin host merges each enabled plugin's declared
+ * `webhookEvents` into THIS registry at the composition root, so the webhook
+ * config/dispatch validation accepts a plugin's event type (core ∪
+ * plugin-declared) without the core's closed union having to enumerate it.
+ *
+ * Core events are seeded here and can never be removed: a plugin can only ADD to
+ * the valid set. Tests that compose plugins against an isolated registry can
+ * construct their own {@link WebhookEventRegistry}.
+ */
+export const webhookEventRegistry = new WebhookEventRegistry(CONFIGURED_WEBHOOK_EVENT_TYPES);
+
+/**
+ * True when `type` is a valid webhook event name to CONFIGURE on a subscription:
+ * a core configured event OR an event a registered plugin declared. This is the
+ * runtime-extensible replacement for checking membership of the frozen
+ * `CONFIGURED_WEBHOOK_EVENT_TYPES` list directly.
+ */
+export function isValidConfigurableWebhookEvent(type: string): boolean {
+  return webhookEventRegistry.has(type);
+}
+
+/** Every currently-valid configurable webhook event name (core ∪ plugin), sorted. */
+export function listValidConfigurableWebhookEvents(): string[] {
+  return webhookEventRegistry.list();
 }

--- a/packages/plugin-trading/src/__tests__/plugin-webhook-events.test.ts
+++ b/packages/plugin-trading/src/__tests__/plugin-webhook-events.test.ts
@@ -1,0 +1,48 @@
+/**
+ * plugin-webhook-events.test.ts — proves the trading plugin DECLARES its webhook
+ * event names via the Phase 2a contribution point, and that registering it
+ * through the host makes those events valid in the runtime event registry (core
+ * ∪ plugin-declared) without the plugin's `register` having to run.
+ *
+ * This is the end-to-end demonstration of the `webhookEvents` contribution
+ * point: a plugin declares events, the host merges them, and the registry then
+ * accepts them as configurable webhook event types.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { WebhookEventRegistry } from "@stwd/shared";
+import { TRADING_WEBHOOK_EVENTS, tradingPlugin } from "../index";
+
+describe("trading plugin — webhookEvents declaration", () => {
+  it("declares its webhookEvents on the plugin contract", () => {
+    expect(tradingPlugin.webhookEvents).toBeDefined();
+    expect(tradingPlugin.webhookEvents).toEqual(TRADING_WEBHOOK_EVENTS);
+    // the declared names follow the plugin's trade.* vocabulary.
+    for (const event of tradingPlugin.webhookEvents ?? []) {
+      expect(event.startsWith("trade.")).toBe(true);
+    }
+  });
+
+  it("declares a version", () => {
+    expect(tradingPlugin.version).toBe("0.1.0");
+  });
+
+  it("merging the declared events into a registry makes them valid", () => {
+    // a registry seeded with a single core event — the trading events are NOT in
+    // the core union, so they are invalid until the plugin contributes them.
+    const registry = new WebhookEventRegistry(["tx.pending"]);
+    for (const event of TRADING_WEBHOOK_EVENTS) {
+      expect(registry.has(event)).toBe(false);
+    }
+
+    registry.registerPluginEvents(tradingPlugin.name, tradingPlugin.webhookEvents ?? []);
+
+    // core event still valid; every trading event now valid.
+    expect(registry.has("tx.pending")).toBe(true);
+    for (const event of TRADING_WEBHOOK_EVENTS) {
+      expect(registry.has(event)).toBe(true);
+    }
+    // diagnostics attribute the events to the trading plugin.
+    expect(registry.describeContributions().trading).toEqual([...TRADING_WEBHOOK_EVENTS].sort());
+  });
+});

--- a/packages/plugin-trading/src/index.ts
+++ b/packages/plugin-trading/src/index.ts
@@ -53,6 +53,28 @@ export const isOperatorRecoveryPath = (path: string): boolean =>
   path.endsWith("/usd-send");
 
 /**
+ * Webhook event-type names the trading plugin's domain produces. These are
+ * trading lifecycle events a subscriber may want delivered (order + session +
+ * operator-recovery transitions). The plugin DECLARES them via
+ * {@link tradingPlugin}'s `webhookEvents` so the plugin host merges them into the
+ * core's runtime event registry (core ∪ plugin-declared) — a webhook can then be
+ * configured for these event names even though the lean core's closed event
+ * union never enumerates them. This is the Phase 2a contribution point proven
+ * end-to-end.
+ *
+ * Naming mirrors the plugin's existing `trade.*` audit-action vocabulary so the
+ * webhook stream and the audit log speak the same event language.
+ */
+export const TRADING_WEBHOOK_EVENTS = [
+  "trade.session.created",
+  "trade.session.revoked",
+  "trade.order.submitted",
+  "trade.order.canceled",
+  "trade.order.leverage.set",
+  "trade.builder.approved",
+] as const;
+
+/**
  * The trading plugin. `register(app, ctx)`:
  *   1. installs the trade-specific auth middleware (MOVED verbatim from app.ts):
  *        - the agent-JWT gate on the order endpoints,
@@ -67,6 +89,11 @@ export const isOperatorRecoveryPath = (path: string): boolean =>
  */
 export const tradingPlugin: StewardApiPlugin = {
   name: "trading",
+  version: "0.1.0",
+  // declarative contribution: the trading lifecycle webhook event names. the host
+  // merges these into the core's runtime event registry so they are valid to
+  // subscribe to. register() below is unchanged (back-compat).
+  webhookEvents: TRADING_WEBHOOK_EVENTS,
   register(app, ctx) {
     const { requireAgentJwt, operatorAuth, tenantAuth } = ctx;
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -12,9 +12,16 @@ export * from "./tokens.js";
 // ─── Per-request app context shape (shared so plugins can type routes) ───
 export type { AppVariables } from "./types/app-variables.js";
 // ─── Lean-core + opt-in-plugin contract ───
-export type { StewardPlugin } from "./types/plugin.js";
+export type {
+  AdapterContribution,
+  PluginMigrationSource,
+  PolicyRuleContribution,
+  StewardPlugin,
+} from "./types/plugin.js";
 // ─── Trading venues (Sprint 4) ───
 export * from "./types/venue.js";
+// ─── Runtime-extensible webhook event registry (core ∪ plugin-declared) ───
+export { WebhookEventRegistry } from "./webhook-event-registry.js";
 
 // ─── Tenancy ───
 

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -24,13 +24,111 @@
  *        circular dependency: core does not import plugin, plugin does not import
  *        core).
  */
+/**
+ * A policy-rule contribution a plugin declares so the core's policy engine can
+ * evaluate a rule type the plugin owns (e.g. a venue-specific gate) WITHOUT the
+ * core importing the plugin.
+ *
+ * PLACEHOLDER (Phase 2b): the shape is intentionally minimal here so the
+ * contract is REAL (a plugin can declare the field and the host can carry it),
+ * but the host does not yet WIRE these into `PolicyEngine`. Full wiring —
+ * registering the evaluator, validating the rule type is unique, threading the
+ * eval context — is Phase 2b. Until then `policyRules` is accepted + reported by
+ * the host's diagnostics but not evaluated.
+ */
+export interface PolicyRuleContribution {
+  /** the policy `type` discriminator this rule contributes (must be unique). */
+  readonly type: string;
+}
+
+/**
+ * A database-migration source a plugin contributes so its tables/columns are
+ * created when the plugin is enabled, WITHOUT the core owning the plugin's
+ * schema.
+ *
+ * PLACEHOLDER (Phase 2c): minimal shape so the contract is real; the host does
+ * not yet RUN these (migration ordering, idempotency, and the drizzle journal
+ * integration are Phase 2c). Accepted + reported, not executed.
+ */
+export interface PluginMigrationSource {
+  /** a stable id for the plugin's migration namespace. */
+  readonly id: string;
+}
+
+/**
+ * An adapter contribution a plugin registers into the core's adapter registry
+ * (mirrors `packages/adapters` categories) so a plugin can supply a real
+ * provider integration.
+ *
+ * PLACEHOLDER (Phase 2d): minimal shape so the contract is real; the host does
+ * not yet REGISTER these into the adapter registry (category typing + the
+ * fail-closed-in-production resolution are Phase 2d). Accepted + reported, not
+ * registered.
+ */
+export interface AdapterContribution {
+  /** the adapter category this contribution targets, e.g. "swap". */
+  readonly category: string;
+  /** the provider name this contribution registers under. */
+  readonly provider: string;
+}
+
 export interface StewardPlugin<App = unknown, Ctx = unknown> {
   /** stable identifier for the plugin, e.g. "trading". used in logs/diagnostics. */
   readonly name: string;
   /**
+   * optional semantic version of the plugin. surfaced in the host's diagnostics
+   * so an operator can see which plugin versions a deploy composed.
+   */
+  readonly version?: string;
+  /**
+   * names of other plugins that must be registered BEFORE this one. the host
+   * topologically orders plugins by this graph and FAILS CLOSED (throws) on a
+   * missing or cyclic dependency — a plugin never silently registers against a
+   * half-built dependency.
+   */
+  readonly dependsOn?: readonly string[];
+  /**
    * mount the plugin's routes + middleware onto `app`, using the injected `ctx`
    * for shared services and auth gates. may be async (e.g. to lazily resolve a
    * provider). called once, at the composition root, after the core is built.
+   *
+   * OPTIONAL as of Phase 2: a plugin may contribute ONLY declaratively (via the
+   * contribution points below) without mounting any route/middleware. the
+   * trading plugin still uses `register` for back-compat.
    */
-  register(app: App, ctx: Ctx): void | Promise<void>;
+  register?(app: App, ctx: Ctx): void | Promise<void>;
+
+  // ── declarative contribution points (all optional) ──────────────────────────
+
+  /**
+   * webhook event-type names this plugin emits. the host merges these into the
+   * runtime registry of valid event types (core union ∪ plugin-declared) so the
+   * webhook dispatcher/config validation accepts a plugin's event without the
+   * core's closed union having to know about it ahead of time.
+   *
+   * WIRED in Phase 2a — this is the keystone contribution point proven
+   * end-to-end by the trading plugin.
+   */
+  readonly webhookEvents?: readonly string[];
+
+  /**
+   * policy rules this plugin contributes. TYPED here (`PolicyRuleContribution`)
+   * so the contract shape is real, but full wiring into the policy engine is
+   * DEFERRED to Phase 2b. The host carries + reports these; it does not yet
+   * evaluate them.
+   */
+  readonly policyRules?: readonly PolicyRuleContribution[];
+
+  /**
+   * database migrations this plugin contributes. TYPED here
+   * (`PluginMigrationSource`); execution is DEFERRED to Phase 2c.
+   */
+  readonly migrations?: PluginMigrationSource;
+
+  /**
+   * adapter integrations this plugin contributes. TYPED here
+   * (`AdapterContribution`); registration into the adapter registry is DEFERRED
+   * to Phase 2d.
+   */
+  readonly adapters?: readonly AdapterContribution[];
 }

--- a/packages/shared/src/webhook-event-registry.ts
+++ b/packages/shared/src/webhook-event-registry.ts
@@ -1,0 +1,93 @@
+/**
+ * webhook-event-registry.ts — a runtime-extensible set of valid webhook
+ * event-type names.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * the core's webhook event types are a CLOSED TypeScript union
+ * (`WebhookEventType` in ./index.ts) and the API's webhook-config validation
+ * checks a candidate event against a fixed list. that is correct for the core's
+ * own events, but it means a PLUGIN that emits its own event type ("foo.bar")
+ * cannot have that event accepted: the closed union rejects it at the type
+ * level, and the config validator rejects it at runtime.
+ *
+ * Phase 2 of the plugin SDK lets a plugin DECLARE the event-type names it emits
+ * (`StewardPlugin.webhookEvents`). the plugin host registers those names here at
+ * composition time, so the runtime set of valid event types becomes:
+ *
+ *     core event types  ∪  every enabled plugin's declared event types
+ *
+ * the webhook-config validator and dispatcher consult this set instead of a
+ * frozen list, so a plugin's event flows end-to-end without the core's union
+ * having to enumerate it ahead of time. core events are ALWAYS valid (they are
+ * seeded into the registry and can never be removed), so a plugin can only ADD
+ * to the valid set, never shrink it.
+ *
+ * This is intentionally a tiny, dependency-free runtime primitive in
+ * `@stwd/shared` so both the API (config validation) and the webhooks dispatcher
+ * can consult the same registry. It carries NO http/framework types.
+ */
+
+/**
+ * A registry of valid webhook event-type names. Seeded with the core event
+ * types (which can never be removed); plugins add their declared event names at
+ * composition time.
+ */
+export class WebhookEventRegistry {
+  /** core event names — always valid, never removable. */
+  private readonly core: ReadonlySet<string>;
+  /** plugin-declared event names, keyed for diagnostics by contributing plugin. */
+  private readonly pluginEvents = new Map<string, ReadonlySet<string>>();
+  /** flattened cache of every currently-valid event name; invalidated on change. */
+  private cache: Set<string> | null = null;
+
+  constructor(coreEventTypes: Iterable<string>) {
+    this.core = new Set(coreEventTypes);
+  }
+
+  /**
+   * Register the event-type names a plugin declares. Idempotent per plugin name:
+   * re-registering the same plugin replaces its previous declaration (so a
+   * recompose does not accumulate stale names). Registering core-overlapping
+   * names is harmless (the union already contains them).
+   */
+  registerPluginEvents(pluginName: string, eventTypes: Iterable<string>): void {
+    this.pluginEvents.set(pluginName, new Set(eventTypes));
+    this.cache = null;
+  }
+
+  /** True when `type` is a core event or any enabled plugin declared it. */
+  has(type: string): boolean {
+    if (this.core.has(type)) return true;
+    return this.all().has(type);
+  }
+
+  /** Every currently-valid event name (core ∪ all plugin-declared). */
+  all(): ReadonlySet<string> {
+    if (this.cache) return this.cache;
+    const merged = new Set<string>(this.core);
+    for (const names of this.pluginEvents.values()) {
+      for (const name of names) merged.add(name);
+    }
+    this.cache = merged;
+    return merged;
+  }
+
+  /** Sorted array of every valid event name — for error messages / diagnostics. */
+  list(): string[] {
+    return [...this.all()].sort();
+  }
+
+  /**
+   * Diagnostics: which plugin contributed which event names. Core events are not
+   * included (they are implicit). Used by the host's "what did plugins
+   * contribute" surface.
+   */
+  describeContributions(): Record<string, string[]> {
+    const out: Record<string, string[]> = {};
+    for (const [plugin, names] of this.pluginEvents) {
+      out[plugin] = [...names].sort();
+    }
+    return out;
+  }
+}


### PR DESCRIPTION
## What

Phase 2a of the Steward plugin SDK: turn the minimal register-only `StewardPlugin` seam (phase 1) into a real, **declarative** plugin SDK so a plugin can contribute behavior the way the core's own modules do, not just mount raw routes. This is the keystone of the "anyone can write a plugin and use it themselves" payoff and the architecture that makes Steward a credible open, self-hostable, vendor-neutral auth + wallet + policy rail.

**Additive + backward compatible.** The merged trading plugin (register-based) keeps working untouched at every step.

## Why it matters

Phase 1 extracted trading behind a seam that only exposed `register(app, ctx)` (raw route/middleware mounting). That proves a plugin can live in its own package without the core importing it, but it doesn't let a plugin *declare* what it contributes. Phase 2 makes the contract declarative: a plugin states the events it emits, the policy rules it owns, the migrations it ships, the adapters it provides, and a host composes them with dependency ordering and fail-closed validation. That's the difference between "a hook" and "an extensible rail."

## The contract (`packages/shared/src/types/plugin.ts`) — all additive

- `name` stays; add optional `version` and `dependsOn`.
- `register` is now **optional** (a plugin may contribute *only* declaratively, no routes).
- declarative contribution points:
  - `webhookEvents` — **WIRED in 2a** (the keystone, proven end-to-end).
  - `policyRules` / `migrations` / `adapters` — **TYPED** via `PolicyRuleContribution` / `PluginMigrationSource` / `AdapterContribution` so the contract shape is real, but their full wiring is **deferred to 2b / 2c / 2d**. The host carries/reports them where relevant but does not act on them yet (no implied behavior that doesn't exist).

## The plugin host (`packages/api/src/plugin.ts`)

`PluginHost` composes one or more plugins:
- validates **unique names**, orders by `dependsOn` (**topological sort**), and **FAILS CLOSED** (`PluginHostError`) on a duplicate name, a missing dependency, or a cycle — *before registering anything*. Mirrors the fail-closed-in-production philosophy of `packages/adapters/src/registry.ts`.
- merges each plugin's declared `webhookEvents` into the runtime event registry **first**, then runs each plugin's `register` (if present) in dependency order.
- `describe()` surfaces loaded plugins (name + version) and webhook-event contributions for diagnostics ("what did plugins contribute").
- `registerPlugin(app, plugin, ctx)` kept as a single-plugin convenience that delegates to the host, so the existing call site keeps working.

## Runtime-extensible webhook events

The core event types are a closed TypeScript union, and the webhook-config validator checked a frozen list — so a plugin's own event type ("trade.session.created") could never be subscribed to. Now:
- new `WebhookEventRegistry` in `@stwd/shared`: core event names are seeded and **immutable**; plugins can only **ADD** (the valid set is `core ∪ plugin-declared`, never shrinks).
- a process-wide registry instance lives in `webhook-events.ts`, seeded with the core configured types.
- the webhooks config route validates a *supplied* `events[]` against the registry (`isValidConfigurableWebhookEvent`) instead of the frozen list. The default subscription set (when `events` omitted) stays **core-only** — plugin events are opt-in by name.

Scope note: 2a wires **declaration + config-validation acceptance** of plugin events (a plugin's event can now be subscribed to, and the low-level dispatcher already accepts any string and only filters by the subscriber's `events` list). Widening the core `dispatchWebhook` input type / injecting a dispatcher into the plugin ctx so a plugin *emits* its events through the core path is a natural follow-on, not part of the 2a keystone.

## Composition root (`compose.ts`)

Wires the host through the existing `makeDeferredRouteApp` proxy, **preserving the load-bearing ordering** (plugin auth middleware lands before global idempotency, plugin routes buffered + flushed after), and passes the shared event registry so plugin-declared events become valid process-wide.

## Trading plugin proves it end-to-end

`tradingPlugin` now declares `webhookEvents` (`TRADING_WEBHOOK_EVENTS`, using its existing `trade.*` vocabulary) + a `version`. `register()` is unchanged. A test confirms the events are declared and become valid once merged into the registry.

## Tests

- `packages/api/src/__tests__/plugin-host.test.ts` — dependsOn ordering (incl. diamond), duplicate-name / missing-dependency / cycle fail-closed (and that nothing registers on failure), webhookEvents merged into the registry, events registered before register hooks run, declarative-only plugin (no register), diagnostics. **11 pass.**
- `packages/plugin-trading/src/__tests__/plugin-webhook-events.test.ts` — trading plugin declares its events + version, and merging them makes them valid. **3 pass.**

## Verification

- `bunx turbo run build --filter='./packages/*'` (bun 1.3.9) — **green**, all 22 packages.
- `bun install --frozen-lockfile` — **passes** (no dependency changes).
- `bun audit --audit-level=critical` and `--audit-level=high` — **clean** (no advisories).
- `bun run lint` (biome) — **clean**.
- `@stwd/api` webhook-events suite — **green**; plugin-host suite — **green**.
- `@stwd/plugin-trading` suite — 94 pass; the single-process run flaked one pre-existing cross-file test (`agent token expiry monitoring > requires tenant auth ...`) which **passes in isolation** (the plugin-trading package has no per-file isolated runner like `@stwd/api` does, so single-process module-registry contamination is a known existing issue, not introduced here).
- `codex review --base origin/develop` — **did not complete**: it hung past a 170s timeout (the documented VPS codex flakiness). Killed and proceeded. Changes are surgical, fully tsc-typechecked across all packages, lint-clean, and test-covered.

## Deferred to later phases
- **2b** — `PolicyRuleContribution`: register a plugin's policy evaluator into `PolicyEngine`, validate unique rule types, thread eval context.
- **2c** — `PluginMigrationSource`: run plugin migrations (ordering, idempotency, drizzle journal integration).
- **2d** — `AdapterContribution`: register plugin adapters into the adapter registry (category typing + fail-closed-in-prod resolution).

Co-authored-by: wakesync <shadow@shad0w.xyz>