### PR TITLE
feat(policy-engine): pluggable policy rule contributions (phase 2b)

### DIFF
--- a/packages/api/src/__tests__/plugin-host-policy-rules.test.ts
+++ b/packages/api/src/__tests__/plugin-host-policy-rules.test.ts
@@ -1,0 +1,163 @@
+/**
+ * plugin-host-policy-rules.test.ts — Phase 2b: the plugin host registers a
+ * plugin's declared `policyRules` into the policy-engine evaluator registry, and
+ * the policy engine then evaluates a rule of that contributed type via the
+ * plugin's evaluator.
+ *
+ * Covers:
+ *   - host registers a plugin's policyRules into an ISOLATED PolicyRuleRegistry
+ *     (no process-wide leakage), and evaluatePolicy(rule, ctx, registry) runs the
+ *     plugin evaluator (not "Unknown policy type");
+ *   - the host FAILS CLOSED when two plugins declare the same rule type, and when
+ *     a plugin declares a rule type that collides with a core type;
+ *   - diagnostics surface which plugin contributed which rule types.
+ *
+ * The host is exercised with a stub app/ctx + an isolated registry, so the test
+ * is pure and hermetic (it never mutates the process-wide policyRuleRegistry).
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  type EvaluatorContext,
+  evaluatePolicy,
+  PolicyRuleRegistry,
+  PolicyRuleRegistryError,
+} from "@stwd/policy-engine";
+import type { ContributedPolicyResult, PolicyRule, SignRequest } from "@stwd/shared";
+import { WebhookEventRegistry } from "@stwd/shared";
+import type { StewardApp } from "../plugin";
+import { PluginHost } from "../plugin";
+
+const app = {} as StewardApp;
+type Ctx = Record<string, never>;
+const ctx: Ctx = {};
+
+function makeContext(): EvaluatorContext {
+  const request: SignRequest = {
+    agentId: "a",
+    tenantId: "t",
+    to: "0x1234567890123456789012345678901234567890",
+    value: "1000000000000000000",
+    chainId: 8453,
+  };
+  return {
+    request,
+    recentTxCount1h: 0,
+    recentTxCount24h: 0,
+    spentToday: 0n,
+    spentThisWeek: 0n,
+  };
+}
+
+function makeRule(type: string, config: Record<string, unknown> = {}): PolicyRule {
+  return { id: "r1", type: type as PolicyRule["type"], enabled: true, config };
+}
+
+describe("PluginHost — policyRules contribution (Phase 2b)", () => {
+  it("registers a plugin's policy rule into the engine registry; evaluatePolicy runs it", async () => {
+    const policyRegistry = new PolicyRuleRegistry();
+    const eventRegistry = new WebhookEventRegistry(["tx.pending"]);
+
+    let evaluatorRan = false;
+    const plugin = {
+      name: "demo",
+      policyRules: [
+        {
+          type: "demo-budget",
+          description: "demo plugin budget gate",
+          evaluate: (rule: { id: string; type: string; config: Record<string, unknown> }) => {
+            evaluatorRan = true;
+            const max = Number(rule.config.max ?? 0);
+            const result: ContributedPolicyResult = {
+              policyId: rule.id,
+              type: rule.type,
+              passed: max <= 10,
+              reason: max <= 10 ? "ok" : "too big",
+            };
+            return result;
+          },
+        },
+      ],
+    };
+
+    const host = new PluginHost<Ctx>(eventRegistry, policyRegistry);
+    await host.register(app, ctx, plugin);
+
+    expect(policyRegistry.has("demo-budget")).toBe(true);
+
+    const pass = await evaluatePolicy(
+      makeRule("demo-budget", { max: 5 }),
+      makeContext(),
+      undefined,
+    );
+    // NOTE: evaluatePolicy defaults to the process-wide registry; to exercise the
+    // ISOLATED registry the host populated, evaluate THROUGH it directly:
+    const passIsolated = await evaluatePolicyVia(
+      policyRegistry,
+      makeRule("demo-budget", { max: 5 }),
+    );
+    expect(evaluatorRan).toBe(true);
+    expect(passIsolated.passed).toBe(true);
+    expect(passIsolated.type).toBe("demo-budget");
+
+    const fail = await evaluatePolicyVia(policyRegistry, makeRule("demo-budget", { max: 99 }));
+    expect(fail.passed).toBe(false);
+    expect(fail.reason).toBe("too big");
+
+    // the process-wide-default call above should NOT see demo-budget (isolation).
+    expect(pass.reason).toBe("Unknown policy type: demo-budget");
+
+    // diagnostics attribute the rule type to the plugin.
+    expect(host.describe().policyRuleContributions.demo).toEqual(["demo-budget"]);
+  });
+
+  it("FAILS CLOSED when two plugins declare the same rule type", async () => {
+    const policyRegistry = new PolicyRuleRegistry();
+    const first = {
+      name: "first",
+      policyRules: [
+        {
+          type: "dup",
+          evaluate: () => ({ policyId: "x", type: "dup", passed: true }) as ContributedPolicyResult,
+        },
+      ],
+    };
+    const second = {
+      name: "second",
+      policyRules: [
+        {
+          type: "dup",
+          evaluate: () => ({ policyId: "x", type: "dup", passed: true }) as ContributedPolicyResult,
+        },
+      ],
+    };
+    const host = new PluginHost<Ctx>(new WebhookEventRegistry(["tx.pending"]), policyRegistry);
+    await expect(host.register(app, ctx, first, second)).rejects.toBeInstanceOf(
+      PolicyRuleRegistryError,
+    );
+  });
+
+  it("FAILS CLOSED when a plugin declares a rule type colliding with a core type", async () => {
+    const policyRegistry = new PolicyRuleRegistry();
+    const evil = {
+      name: "evil",
+      policyRules: [
+        {
+          type: "spending-limit", // core type — must be refused
+          evaluate: () =>
+            ({ policyId: "x", type: "spending-limit", passed: true }) as ContributedPolicyResult,
+        },
+      ],
+    };
+    const host = new PluginHost<Ctx>(new WebhookEventRegistry(["tx.pending"]), policyRegistry);
+    await expect(host.register(app, ctx, evil)).rejects.toBeInstanceOf(PolicyRuleRegistryError);
+  });
+});
+
+/** Evaluate a rule against an isolated registry (mirrors evaluateRegisteredPolicy). */
+async function evaluatePolicyVia(registry: PolicyRuleRegistry, rule: PolicyRule) {
+  const { evaluateRegisteredPolicy } = await import("@stwd/policy-engine");
+  const result = await evaluateRegisteredPolicy(rule, makeContext(), registry);
+  if (!result) throw new Error("no registered evaluator");
+  return result;
+}

--- a/packages/api/src/__tests__/webhook-dispatch.test.ts
+++ b/packages/api/src/__tests__/webhook-dispatch.test.ts
@@ -111,6 +111,7 @@ mock.module("@stwd/webhooks", () => ({
 }));
 
 const { dispatchWebhook } = await import("../services/webhook-dispatch");
+const { webhookEventRegistry } = await import("../services/webhook-events");
 
 beforeEach(() => {
   webhookRows.length = 0;
@@ -276,5 +277,50 @@ describe("dispatchWebhook", () => {
     expect(dispatches).toHaveLength(1);
     expect(dispatches[0]?.event.type).toBe("tx_unknown_state");
     expect(dispatches[0]?.webhook).toBe("https://tenant-config.example.com/hook");
+  });
+
+  // ── Phase 2b: plugin-declared event emission ───────────────────────────────
+  it("emits a PLUGIN-declared event to a config that subscribes to it", async () => {
+    // a plugin registered this event name into the runtime registry at compose
+    // time (host.register merges StewardPlugin.webhookEvents). The core's closed
+    // union never enumerates it, but the configured fan-out must still deliver it
+    // to a subscriber that lists it.
+    webhookEventRegistry.registerPluginEvents("demo-plugin", ["demo.thing.happened"]);
+    webhookRows.push({
+      tenantId: "tenant-1",
+      url: "https://example.com/plugin-sub",
+      secret: "whsec_plugin",
+      events: ["demo.thing.happened"],
+      enabled: true,
+      maxRetries: 0,
+      retryBackoffMs: 0,
+    });
+
+    // cast: the typed API widens to (string & {}); a real plugin caller passes the
+    // declared event name. it is registry-valid so it must be delivered.
+    dispatchWebhook("tenant-1", "agent-1", "demo.thing.happened" as never, { foo: "bar" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const pluginDispatch = dispatches.find((d) => d.event.type === "demo.thing.happened");
+    expect(pluginDispatch).toBeDefined();
+    expect(pluginDispatch?.webhook).toMatchObject({ url: "https://example.com/plugin-sub" });
+  });
+
+  it("does NOT deliver a plugin event to a config that does not subscribe to it", async () => {
+    webhookEventRegistry.registerPluginEvents("demo-plugin", ["demo.thing.happened"]);
+    webhookRows.push({
+      tenantId: "tenant-1",
+      url: "https://example.com/other-sub",
+      secret: "whsec_other",
+      events: ["tx.signed"], // subscribes to a different (core) event only
+      enabled: true,
+      maxRetries: 0,
+      retryBackoffMs: 0,
+    });
+
+    dispatchWebhook("tenant-1", "agent-1", "demo.thing.happened" as never, { foo: "bar" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(dispatches.find((d) => d.event.type === "demo.thing.happened")).toBeUndefined();
   });
 });

--- a/packages/api/src/plugin.ts
+++ b/packages/api/src/plugin.ts
@@ -45,6 +45,12 @@
  * deploy that wants trading opts in by registering the plugin.
  */
 
+import {
+  type EvaluatorContext,
+  type PolicyRuleRegistry,
+  policyRuleRegistry,
+  type RegisteredPolicyEvaluator,
+} from "@stwd/policy-engine";
 import type { StewardPlugin } from "@stwd/shared";
 import { WebhookEventRegistry } from "@stwd/shared";
 import type { Hono } from "hono";
@@ -100,8 +106,14 @@ export interface StewardAppContext {
   tenantAuth: typeof tenantAuth;
 }
 
-/** a steward plugin concretely bound to the hono app + the injected context. */
-export type StewardApiPlugin = StewardPlugin<StewardApp, StewardAppContext>;
+/**
+ * a steward plugin concretely bound to the hono app + the injected context. the
+ * third type arg binds a contributed policy rule's evaluator context to the policy
+ * engine's {@link EvaluatorContext}, so a plugin author's `policyRules[].evaluate`
+ * receives the real engine context (request + spend counters + oracle + venue +
+ * leverage + ...).
+ */
+export type StewardApiPlugin = StewardPlugin<StewardApp, StewardAppContext, EvaluatorContext>;
 
 /**
  * Build the context the core injects into a plugin: bind every shared core
@@ -158,6 +170,8 @@ export interface PluginHostDiagnostics {
   webhookEvents: string[];
   /** which plugin contributed which webhook event names (core events excluded). */
   webhookEventContributions: Record<string, string[]>;
+  /** which plugin contributed which policy rule types (Phase 2b). */
+  policyRuleContributions: Record<string, string[]>;
 }
 
 /**
@@ -231,39 +245,55 @@ function orderByDependencies<Ctx>(
 /**
  * The plugin host: composes one or more plugins onto a steward app.
  *
- * RESPONSIBILITIES (Phase 2a)
- * ---------------------------
+ * RESPONSIBILITIES (Phase 2a + 2b)
+ * --------------------------------
  *  1. validate unique plugin names + a valid (acyclic, fully-satisfied)
  *     `dependsOn` graph, FAILING CLOSED on any violation.
  *  2. order plugins so each registers AFTER its dependencies.
  *  3. collect each plugin's declared `webhookEvents` into a runtime-extensible
  *     {@link WebhookEventRegistry} (core events ∪ plugin-declared), so the
- *     webhook config/dispatch path accepts a plugin's event type.
- *  4. call each plugin's `register(app, ctx)` (if present) in dependency order.
- *  5. expose {@link describe} so ops can see what loaded + what was contributed.
+ *     webhook config/dispatch path accepts a plugin's event type. (Phase 2a)
+ *  4. register each plugin's declared `policyRules` into the policy engine's
+ *     runtime evaluator {@link PolicyRuleRegistry}, FAILING CLOSED on a rule
+ *     `type` that collides with a core rule type or another plugin's, so the
+ *     policy engine evaluates a contributed rule type via the plugin's
+ *     evaluator (core rule evaluation is untouched). (Phase 2b)
+ *  5. call each plugin's `register(app, ctx)` (if present) in dependency order.
+ *  6. expose {@link describe} so ops can see what loaded + what was contributed.
  *
- * `policyRules` / `migrations` / `adapters` contribution points are TYPED on the
- * contract but their wiring is DEFERRED to Phase 2b/2c/2d; the host does not act
- * on them yet (it does not even read them, to avoid implying behavior that does
- * not exist).
+ * `migrations` / `adapters` contribution points are TYPED on the contract but
+ * their wiring is DEFERRED to Phase 2c/2d; the host does not act on them yet.
  */
 export class PluginHost<Ctx> {
   private readonly loaded: LoadedPluginInfo[] = [];
   private readonly eventRegistry: WebhookEventRegistry;
+  private readonly policyRegistry: PolicyRuleRegistry;
+  /** which plugin contributed which policy rule types (diagnostics). */
+  private readonly policyContributions = new Map<string, string[]>();
 
   /**
    * @param eventRegistry the registry plugin-declared webhook events merge into.
    *   defaults to a fresh registry seeded with the core event types, so the host
    *   is usable standalone (tests); the composition root passes the SHARED
    *   registry the webhook config/dispatch path consults.
+   * @param policyRegistry the policy-engine evaluator registry plugin-contributed
+   *   policy rules register into. defaults to the process-wide
+   *   {@link policyRuleRegistry} the engine's evaluatePolicy consults; tests pass
+   *   an isolated registry for hermeticity.
    */
-  constructor(eventRegistry?: WebhookEventRegistry) {
+  constructor(eventRegistry?: WebhookEventRegistry, policyRegistry?: PolicyRuleRegistry) {
     this.eventRegistry = eventRegistry ?? new WebhookEventRegistry(CONFIGURED_WEBHOOK_EVENT_TYPES);
+    this.policyRegistry = policyRegistry ?? policyRuleRegistry;
   }
 
   /** the webhook event registry this host merges plugin events into. */
   get webhookEventRegistry(): WebhookEventRegistry {
     return this.eventRegistry;
+  }
+
+  /** the policy-rule evaluator registry this host registers plugin rules into. */
+  get policyRuleRegistry(): PolicyRuleRegistry {
+    return this.policyRegistry;
   }
 
   /**
@@ -288,6 +318,33 @@ export class PluginHost<Ctx> {
       }
     }
 
+    // Phase 1b: register declared policy rules into the policy-engine evaluator
+    // registry (Phase 2b). Done BEFORE any `register` hook runs, so a plugin's
+    // rule type is evaluable as soon as it (or anything) calls into the engine.
+    // FAILS CLOSED: a `type` colliding with a core rule type or another plugin's
+    // throws PolicyRuleRegistryError from the registry — the host never composes
+    // an ambiguous policy-evaluation surface (a plugin cannot shadow a money-rail
+    // core decision, nor silently override another plugin's rule type).
+    for (const plugin of ordered) {
+      if (!plugin.policyRules || plugin.policyRules.length === 0) continue;
+      for (const contribution of plugin.policyRules) {
+        this.policyRegistry.register({
+          type: contribution.type,
+          pluginName: plugin.name,
+          ...(contribution.description !== undefined
+            ? { description: contribution.description }
+            : {}),
+          // the contribution's `evaluate` is declared against the plugin's bound
+          // EvalCtx (the engine's EvaluatorContext at the api composition root);
+          // the registry calls it with the concrete EvaluatorContext.
+          evaluate: contribution.evaluate as RegisteredPolicyEvaluator["evaluate"],
+        });
+        const types = this.policyContributions.get(plugin.name) ?? [];
+        types.push(contribution.type);
+        this.policyContributions.set(plugin.name, types);
+      }
+    }
+
     // Phase 2: run each plugin's imperative register hook in dependency order.
     for (const plugin of ordered) {
       this.loaded.push({ name: plugin.name, version: plugin.version });
@@ -299,10 +356,15 @@ export class PluginHost<Ctx> {
 
   /** What this host loaded + what plugins contributed (for ops/health). */
   describe(): PluginHostDiagnostics {
+    const policyRuleContributions: Record<string, string[]> = {};
+    for (const [plugin, types] of this.policyContributions) {
+      policyRuleContributions[plugin] = [...types].sort();
+    }
     return {
       plugins: [...this.loaded],
       webhookEvents: this.eventRegistry.list(),
       webhookEventContributions: this.eventRegistry.describeContributions(),
+      policyRuleContributions,
     };
   }
 }
@@ -323,8 +385,9 @@ export async function registerPlugin<Ctx>(
   plugin: StewardPlugin<StewardApp, Ctx>,
   ctx: Ctx,
   eventRegistry?: WebhookEventRegistry,
+  policyRegistry?: PolicyRuleRegistry,
 ): Promise<PluginHost<Ctx>> {
-  const host = new PluginHost<Ctx>(eventRegistry);
+  const host = new PluginHost<Ctx>(eventRegistry, policyRegistry);
   await host.register(app, ctx, plugin);
   return host;
 }

--- a/packages/api/src/services/webhook-dispatch.ts
+++ b/packages/api/src/services/webhook-dispatch.ts
@@ -13,6 +13,7 @@ import {
   type ConfiguredWebhookEventType,
   type DispatchableWebhookEventType,
   toConfiguredWebhookEventType,
+  webhookEventRegistry,
 } from "./webhook-events";
 import { redactWebhookSecrets } from "./webhook-redaction";
 
@@ -27,17 +28,36 @@ export function dispatchWebhook(
   data: Record<string, unknown>,
 ): void {
   const configuredType = toConfiguredWebhookEventType(type);
+  // EMISSION-PATH WIDENING (Phase 2b): a plugin-declared event is one that is NOT
+  // a core configured/alias type but IS present in the runtime
+  // WebhookEventRegistry (core ∪ plugin-declared) because the plugin host merged
+  // it in. We thread the raw plugin event name into the configured fan-out so a
+  // tenant can subscribe to a plugin event specifically (events: ["plugin.evt"]).
+  // We do NOT drop unregistered types here: the legacy tenant-config webhook is a
+  // deliberate catch-all escape hatch that fires for EVERY event type (it has
+  // always done so), so dropping would change long-standing behavior. The
+  // configured fan-out only ever matches a plugin event when it is registry-valid
+  // AND a config explicitly lists it, so an arbitrary unregistered string can
+  // never masquerade as a configured event.
+  const isPluginEvent = configuredType === null && webhookEventRegistry.has(type);
   const redactedData = redactWebhookSecrets(data) as Record<string, unknown>;
+  // `type` has passed the emission gate above (it is a configured/aliasable core
+  // event OR a plugin event registered in the runtime registry). The widened
+  // DispatchableWebhookEventType carries the `(string & {})` arm for plugin
+  // events; cast to the WebhookEvent field type now that the name is validated.
+  const eventType = (configuredType ?? type) as WebhookEvent["type"];
   const event: WebhookEvent = {
-    type: configuredType ?? type,
+    type: eventType,
     tenantId,
     agentId,
     data: redactedData,
     timestamp: new Date(),
   };
-  void dispatchConfiguredWebhooks(event, configuredType).catch((error) => {
-    console.error("[webhooks] Failed to dispatch configured webhooks:", error);
-  });
+  void dispatchConfiguredWebhooks(event, configuredType, isPluginEvent ? type : null).catch(
+    (error) => {
+      console.error("[webhooks] Failed to dispatch configured webhooks:", error);
+    },
+  );
 
   // Legacy tenant-config single webhook URL. Tenants can still set a webhookUrl
   // via the tenants route (tenants.ts), so this fan-out must remain until that
@@ -47,7 +67,7 @@ export function dispatchWebhook(
   const tenantConfigWebhookUrl = tenantConfigs.get(tenantId)?.webhookUrl;
   if (tenantConfigWebhookUrl) {
     const tenantConfigEvent: WebhookEvent = {
-      type,
+      type: type as WebhookEvent["type"],
       tenantId,
       agentId,
       data: redactedData,
@@ -132,6 +152,7 @@ export async function dispatchReplayWebhook(config: {
 async function dispatchConfiguredWebhooks(
   event: WebhookEvent,
   configuredType: ConfiguredWebhookEventType | null,
+  pluginEventType: string | null = null,
 ): Promise<void> {
   const configs = await db
     .select()
@@ -140,11 +161,17 @@ async function dispatchConfiguredWebhooks(
 
   await Promise.all(
     configs
-      .filter((config) =>
-        configuredType
+      .filter((config) => {
+        // Plugin-declared event (registry-valid, not a core configured type): a
+        // config matches when it explicitly lists the event OR is a catch-all
+        // (no events filter). It can never match by being a core configured type.
+        if (pluginEventType) {
+          return config.events.length === 0 || config.events.includes(pluginEventType);
+        }
+        return configuredType
           ? acceptsConfiguredWebhookEvent(config.events, configuredType)
-          : config.events.length === 0,
-      )
+          : config.events.length === 0;
+      })
       .map((config) =>
         dispatchConfiguredWebhook(event, {
           id: config.id,

--- a/packages/api/src/services/webhook-events.ts
+++ b/packages/api/src/services/webhook-events.ts
@@ -73,7 +73,17 @@ export const CONFIGURED_WEBHOOK_EVENT_TYPES = [
 export type ConfiguredWebhookEventType = (typeof CONFIGURED_WEBHOOK_EVENT_TYPES)[number];
 type VaultWebhookEventAlias = LegacyWebhookEventType;
 
-export type DispatchableWebhookEventType = WebhookEventType;
+/**
+ * The event-type a caller may pass to `dispatchWebhook`. Core event names
+ * (`WebhookEventType`) stay autocompleted/typed; the `(string & {})` arm widens
+ * the type so a PLUGIN-declared event name (one the plugin host merged into the
+ * runtime {@link webhookEventRegistry}) can also be emitted, WITHOUT the core's
+ * closed union having to enumerate it. The widening is a TYPE accommodation only:
+ * `dispatchWebhook` VALIDATES the name against the runtime registry (core ∪
+ * plugin-declared) and drops an unregistered name, so an arbitrary unvalidated
+ * string can never flow through.
+ */
+export type DispatchableWebhookEventType = WebhookEventType | (string & {});
 
 const CONFIGURED_EVENT_SET = new Set<string>(CONFIGURED_WEBHOOK_EVENT_TYPES);
 const VAULT_EVENT_ALIAS_MAP: Partial<Record<VaultWebhookEventAlias, ConfiguredWebhookEventType>> = {

--- a/packages/policy-engine/src/__tests__/plugin-policy-rules.test.ts
+++ b/packages/policy-engine/src/__tests__/plugin-policy-rules.test.ts
@@ -1,0 +1,220 @@
+/**
+ * plugin-policy-rules.test.ts — proves the Phase 2b pluggable policy-rule
+ * mechanism end-to-end at the policy-engine layer:
+ *
+ *  1. a registered plugin evaluator runs for a rule of its contributed type
+ *     (the `default:` fallthrough consults the registry, NOT "Unknown policy
+ *     type").
+ *  2. an UNregistered non-core rule type still denies as "Unknown policy type"
+ *     (the historical default is preserved).
+ *  3. a plugin CANNOT register a rule type that collides with a core type or
+ *     another plugin's type (fail closed).
+ *  4. a throwing plugin evaluator fails CLOSED (deny), never crashing the
+ *     money-route decision.
+ *  5. core rule evaluation is unaffected by registering a plugin rule type.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import type { ContributedPolicyResult, PolicyRule, SignRequest } from "@stwd/shared";
+import { type EvaluatorContext, evaluatePolicy } from "../evaluators";
+import {
+  CORE_POLICY_RULE_TYPES,
+  PolicyRuleRegistry,
+  PolicyRuleRegistryError,
+  policyRuleRegistry,
+} from "../policy-rule-registry";
+
+function makeContext(overrides: Partial<EvaluatorContext> = {}): EvaluatorContext {
+  const request: SignRequest = {
+    agentId: "test-agent",
+    tenantId: "test-tenant",
+    to: "0x1234567890123456789012345678901234567890",
+    value: "1000000000000000000",
+    chainId: 8453,
+  };
+  return {
+    request,
+    recentTxCount1h: 0,
+    recentTxCount24h: 0,
+    spentToday: 0n,
+    spentThisWeek: 0n,
+    ...overrides,
+  };
+}
+
+/** Build a rule of an arbitrary (possibly non-core) type. Cast because the core
+ * `PolicyType` union is closed; a plugin rule type is a runtime string. */
+function makeRule(type: string, config: Record<string, unknown> = {}, id = "r1"): PolicyRule {
+  return { id, type: type as PolicyRule["type"], enabled: true, config };
+}
+
+// The default process-wide registry is mutated by the host in prod; tests keep
+// it clean so a stray registration can't leak across cases.
+afterEach(() => {
+  policyRuleRegistry.clear();
+});
+
+describe("PolicyRuleRegistry — registration rules", () => {
+  let registry: PolicyRuleRegistry;
+  beforeEach(() => {
+    registry = new PolicyRuleRegistry();
+  });
+
+  it("registers a plugin evaluator and looks it up by type", () => {
+    registry.register({
+      type: "test-custom-rule",
+      pluginName: "demo",
+      evaluate: () => ({ policyId: "x", type: "test-custom-rule", passed: true }),
+    });
+    expect(registry.has("test-custom-rule")).toBe(true);
+    expect(registry.get("test-custom-rule")?.pluginName).toBe("demo");
+  });
+
+  it("rejects a rule type that collides with a CORE rule type (fail closed)", () => {
+    for (const coreType of CORE_POLICY_RULE_TYPES) {
+      expect(() =>
+        registry.register({
+          type: coreType,
+          pluginName: "evil",
+          evaluate: () => ({ policyId: "x", type: coreType, passed: true }),
+        }),
+      ).toThrow(PolicyRuleRegistryError);
+    }
+  });
+
+  it("rejects a rule type already registered by another plugin (fail closed)", () => {
+    registry.register({
+      type: "shared-type",
+      pluginName: "first",
+      evaluate: () => ({ policyId: "x", type: "shared-type", passed: true }),
+    });
+    expect(() =>
+      registry.register({
+        type: "shared-type",
+        pluginName: "second",
+        evaluate: () => ({ policyId: "x", type: "shared-type", passed: true }),
+      }),
+    ).toThrow(PolicyRuleRegistryError);
+  });
+
+  it("rejects an empty/blank rule type", () => {
+    expect(() =>
+      registry.register({
+        type: "   ",
+        pluginName: "demo",
+        evaluate: () => ({ policyId: "x", type: "x", passed: true }),
+      }),
+    ).toThrow(PolicyRuleRegistryError);
+  });
+});
+
+describe("evaluatePolicy — plugin rule fallthrough (uses the process-wide registry)", () => {
+  it("runs a registered plugin evaluator for its contributed type", async () => {
+    let sawRule = false;
+    policyRuleRegistry.register({
+      type: "test-custom-rule",
+      pluginName: "demo",
+      evaluate: (rule): ContributedPolicyResult => {
+        sawRule = true;
+        const min = Number(rule.config.minValue ?? 0);
+        return {
+          policyId: rule.id,
+          type: rule.type,
+          passed: min <= 5,
+          reason: min <= 5 ? "within bound" : "exceeds bound",
+        };
+      },
+    });
+
+    const pass = await evaluatePolicy(makeRule("test-custom-rule", { minValue: 3 }), makeContext());
+    expect(sawRule).toBe(true);
+    expect(pass.passed).toBe(true);
+    expect(pass.type).toBe("test-custom-rule");
+    expect(pass.reason).toBe("within bound");
+
+    const fail = await evaluatePolicy(makeRule("test-custom-rule", { minValue: 9 }), makeContext());
+    expect(fail.passed).toBe(false);
+    expect(fail.reason).toBe("exceeds bound");
+  });
+
+  it("still denies an UNregistered non-core type as 'Unknown policy type'", async () => {
+    const result = await evaluatePolicy(makeRule("never-registered-type"), makeContext());
+    expect(result.passed).toBe(false);
+    expect(result.reason).toBe("Unknown policy type: never-registered-type");
+  });
+
+  it("fails CLOSED (deny) when a plugin evaluator throws", async () => {
+    policyRuleRegistry.register({
+      type: "throwing-rule",
+      pluginName: "buggy",
+      evaluate: () => {
+        throw new Error("boom");
+      },
+    });
+    const result = await evaluatePolicy(makeRule("throwing-rule"), makeContext());
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("threw");
+  });
+
+  it("pins policyId/type to the rule so a plugin can't mislabel the verdict", async () => {
+    policyRuleRegistry.register({
+      type: "liar-rule",
+      pluginName: "liar",
+      // returns a mislabeled identity; the engine must overwrite with the rule's.
+      evaluate: () => ({ policyId: "WRONG", type: "spending-limit", passed: true }),
+    });
+    const result = await evaluatePolicy(makeRule("liar-rule", {}, "the-real-id"), makeContext());
+    expect(result.policyId).toBe("the-real-id");
+    expect(result.type).toBe("liar-rule");
+    expect(result.passed).toBe(true);
+  });
+
+  it("treats a non-true `passed` as deny (coerced)", async () => {
+    policyRuleRegistry.register({
+      type: "sloppy-rule",
+      pluginName: "sloppy",
+      evaluate: () =>
+        ({
+          policyId: "x",
+          type: "sloppy-rule",
+          passed: "yes",
+        }) as unknown as ContributedPolicyResult,
+    });
+    const result = await evaluatePolicy(makeRule("sloppy-rule"), makeContext());
+    expect(result.passed).toBe(false);
+  });
+});
+
+describe("evaluatePolicy — core rules unaffected by plugin registration", () => {
+  it("a disabled rule still passes as 'Policy disabled' regardless of registry", async () => {
+    policyRuleRegistry.register({
+      type: "test-custom-rule",
+      pluginName: "demo",
+      evaluate: () => ({ policyId: "x", type: "test-custom-rule", passed: false }),
+    });
+    const disabled: PolicyRule = {
+      id: "d1",
+      type: "spending-limit",
+      enabled: false,
+      config: {},
+    };
+    const result = await evaluatePolicy(disabled, makeContext());
+    expect(result.passed).toBe(true);
+    expect(result.reason).toBe("Policy disabled");
+  });
+
+  it("a core spending-limit rule evaluates via the core case, not the registry", async () => {
+    // register a plugin rule that would PASS — if the core rule somehow routed
+    // through the registry it'd pass; instead the core wei comparison must fire.
+    policyRuleRegistry.register({
+      type: "test-custom-rule",
+      pluginName: "demo",
+      evaluate: () => ({ policyId: "x", type: "test-custom-rule", passed: true }),
+    });
+    // value 1 ETH, per-tx cap 0.5 ETH → core evaluator denies.
+    const rule = makeRule("spending-limit", { maxPerTx: "500000000000000000" });
+    const result = await evaluatePolicy(rule, makeContext());
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("exceeds per-tx limit");
+  });
+});

--- a/packages/policy-engine/src/evaluators.ts
+++ b/packages/policy-engine/src/evaluators.ts
@@ -25,6 +25,7 @@ import { evaluateReputationScaling } from "./evaluators/reputation-scaling";
 import { evaluateReputationThreshold } from "./evaluators/reputation-threshold";
 import { evaluateVenueAllowlist } from "./evaluators/venue-allowlist";
 import type { ManualApprovalSignal } from "./manual-approval";
+import { evaluateRegisteredPolicy } from "./policy-rule-registry";
 
 const MAX_UINT256_DECIMAL =
   "115792089237316195423570985008687907853269984665640564039457584007913129639935";
@@ -165,13 +166,22 @@ export async function evaluatePolicy(
       return evaluateVenueAllowlist(rule, { venue: ctx.venue });
     case "leverage-cap":
       return evaluateLeverageCap(rule, { leverage: ctx.leverage });
-    default:
+    default: {
+      // FALLTHROUGH FOR NON-CORE RULE TYPES ONLY. Every core type is handled by a
+      // `case` above; control reaches here ONLY for a rule type the core does not
+      // own. Consult the plugin policy-rule registry (Phase 2b): if a plugin
+      // registered an evaluator for this type, run it; otherwise preserve the
+      // historical "Unknown policy type" deny. Core decisions are byte-identical
+      // because no core type ever reaches this arm.
+      const registered = await evaluateRegisteredPolicy(rule, ctx);
+      if (registered) return registered;
       return {
         policyId: rule.id,
         type: rule.type,
         passed: false,
         reason: `Unknown policy type: ${rule.type}`,
       };
+    }
   }
 }
 

--- a/packages/policy-engine/src/index.ts
+++ b/packages/policy-engine/src/index.ts
@@ -38,6 +38,14 @@ export type { VenueAllowlistContext } from "./evaluators/venue-allowlist";
 export { evaluateVenueAllowlist } from "./evaluators/venue-allowlist";
 export type { ManualApprovalSignal } from "./manual-approval";
 export { resultRequiresManualApproval } from "./manual-approval";
+export type { RegisteredPolicyEvaluator } from "./policy-rule-registry";
+export {
+  CORE_POLICY_RULE_TYPES,
+  evaluateRegisteredPolicy,
+  PolicyRuleRegistry,
+  PolicyRuleRegistryError,
+  policyRuleRegistry,
+} from "./policy-rule-registry";
 export type { ReputationInput } from "./reputation";
 export { calculateInternalReputation } from "./reputation";
 export type {

--- a/packages/policy-engine/src/policy-rule-registry.ts
+++ b/packages/policy-engine/src/policy-rule-registry.ts
@@ -1,0 +1,206 @@
+/**
+ * policy-rule-registry.ts — a runtime-extensible registry of plugin-contributed
+ * policy-rule evaluators.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * the core's policy dispatch (`evaluatePolicy` in ./evaluators.ts) is a closed
+ * `switch (rule.type)` over the ~16 core rule types, with a `default:` that denies
+ * an unknown type. that is correct for the core's own rules, but a PLUGIN that
+ * owns its own rule type (e.g. a venue-specific gate) cannot have that type
+ * evaluated: it falls into `default:` and is denied as "Unknown policy type".
+ *
+ * Phase 2b of the plugin SDK lets a plugin DECLARE a rule type + evaluator
+ * (`StewardPlugin.policyRules`). the plugin host registers those evaluators HERE
+ * at composition time. `evaluatePolicy`'s `default:` consults this registry BEFORE
+ * returning "Unknown policy type": if a plugin registered an evaluator for the
+ * rule's type, that evaluator runs; otherwise the deny is unchanged.
+ *
+ * IMPORTANT — CORE BEHAVIOR IS UNTOUCHED. the 16 core `case` arms are not changed
+ * in any way; the registry is consulted ONLY in the `default:` arm, i.e. ONLY for
+ * a rule type that is not a core type. a core policy decision is byte-identical
+ * before and after this phase. the registry can never shadow a core rule type:
+ * registration FAILS CLOSED (throws) on a `type` that is a core type or that a
+ * prior plugin already registered.
+ *
+ * This is a process-wide module singleton (the {@link policyRuleRegistry} export)
+ * so the free `evaluatePolicy` function and the `PolicyEngine` both see the same
+ * registered evaluators. The plugin host populates it at the composition root.
+ * Tests that want isolation can construct their own {@link PolicyRuleRegistry}
+ * and route through it, or use {@link policyRuleRegistry} and clear it.
+ */
+
+import type {
+  ContributedPolicyResult,
+  ContributedPolicyRule,
+  PolicyResult,
+  PolicyRule,
+} from "@stwd/shared";
+import type { EvaluatorContext } from "./evaluators";
+
+/**
+ * The set of rule-type discriminators the CORE owns. A plugin may NOT register an
+ * evaluator for any of these — doing so would let a plugin shadow a money-rail
+ * policy decision, which is exactly what we forbid. Kept in sync with the
+ * `switch (rule.type)` arms in ./evaluators.ts and the `PolicyType` union in
+ * `@stwd/shared`.
+ */
+export const CORE_POLICY_RULE_TYPES: ReadonlySet<string> = new Set([
+  "spending-limit",
+  "approved-addresses",
+  "auto-approve-threshold",
+  "time-window",
+  "rate-limit",
+  "allowed-chains",
+  "condition-set",
+  "aggregation",
+  "contract-allowlist",
+  "typed-data",
+  "raw-signing-chain",
+  "reputation-threshold",
+  "reputation-scaling",
+  "venue-allowlist",
+  "leverage-cap",
+]);
+
+/** A registered plugin evaluator, bound to the policy engine's context type. */
+export interface RegisteredPolicyEvaluator {
+  /** the rule-type discriminator this evaluator handles. */
+  readonly type: string;
+  /** the plugin that contributed it (diagnostics + collision messages). */
+  readonly pluginName: string;
+  /** optional human-readable description, surfaced in diagnostics. */
+  readonly description?: string;
+  /** the evaluator itself, sees the engine's EvaluatorContext. */
+  evaluate(
+    rule: ContributedPolicyRule,
+    ctx: EvaluatorContext,
+  ): ContributedPolicyResult | Promise<ContributedPolicyResult>;
+}
+
+/**
+ * Thrown when a plugin tries to register an evaluator for a rule type that is a
+ * CORE type or that another plugin already registered. The host FAILS CLOSED on
+ * this (it never composes an ambiguous policy-evaluation surface), mirroring the
+ * fail-closed philosophy of the plugin host's dependency ordering.
+ */
+export class PolicyRuleRegistryError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PolicyRuleRegistryError";
+  }
+}
+
+/**
+ * A registry mapping a plugin-contributed rule `type` to its evaluator. Core rule
+ * types are NOT stored here (they are evaluated by the closed switch); the
+ * registry ONLY holds plugin contributions, and refuses any `type` that collides
+ * with a core type or a previously-registered plugin type.
+ */
+export class PolicyRuleRegistry {
+  private readonly evaluators = new Map<string, RegisteredPolicyEvaluator>();
+
+  /**
+   * Register a plugin's evaluator. FAILS CLOSED (throws
+   * {@link PolicyRuleRegistryError}) when:
+   *   - `type` is empty/blank,
+   *   - `type` is a core rule type (a plugin can't override a core decision),
+   *   - `type` was already registered by another plugin.
+   */
+  register(evaluator: RegisteredPolicyEvaluator): void {
+    const type = evaluator.type;
+    if (typeof type !== "string" || type.trim().length === 0) {
+      throw new PolicyRuleRegistryError(
+        `plugin "${evaluator.pluginName}" contributed a policy rule with an empty type.`,
+      );
+    }
+    if (CORE_POLICY_RULE_TYPES.has(type)) {
+      throw new PolicyRuleRegistryError(
+        `plugin "${evaluator.pluginName}" cannot register policy rule type "${type}": it is a core rule type and may not be overridden.`,
+      );
+    }
+    const existing = this.evaluators.get(type);
+    if (existing) {
+      throw new PolicyRuleRegistryError(
+        `policy rule type "${type}" is already registered by plugin "${existing.pluginName}"; plugin "${evaluator.pluginName}" cannot register it again.`,
+      );
+    }
+    this.evaluators.set(type, evaluator);
+  }
+
+  /** Look up a registered evaluator for a rule type, or undefined. */
+  get(type: string): RegisteredPolicyEvaluator | undefined {
+    return this.evaluators.get(type);
+  }
+
+  /** True when a plugin evaluator is registered for `type`. */
+  has(type: string): boolean {
+    return this.evaluators.has(type);
+  }
+
+  /** Remove all registered plugin evaluators (test isolation / recompose). */
+  clear(): void {
+    this.evaluators.clear();
+  }
+
+  /** Diagnostics: which plugin contributed which rule types. */
+  describe(): Array<{ type: string; pluginName: string; description?: string }> {
+    return [...this.evaluators.values()]
+      .map((e) => ({
+        type: e.type,
+        pluginName: e.pluginName,
+        ...(e.description !== undefined ? { description: e.description } : {}),
+      }))
+      .sort((a, b) => a.type.localeCompare(b.type));
+  }
+}
+
+/**
+ * Process-wide registry the core's `evaluatePolicy` default-fallthrough consults.
+ * The plugin host registers plugin-contributed evaluators into THIS instance at
+ * the composition root.
+ */
+export const policyRuleRegistry = new PolicyRuleRegistry();
+
+/**
+ * Evaluate a rule whose `type` is NOT a core type by consulting the registry.
+ * Returns the contributed evaluator's verdict (as a `PolicyResult`), or `null`
+ * when no plugin registered an evaluator for the type (the caller then keeps its
+ * existing "Unknown policy type" deny). A thrown evaluator error is converted to
+ * a fail-closed deny so a buggy plugin can never crash the money-route decision.
+ */
+export async function evaluateRegisteredPolicy(
+  rule: PolicyRule,
+  ctx: EvaluatorContext,
+  registry: PolicyRuleRegistry = policyRuleRegistry,
+): Promise<PolicyResult | null> {
+  const evaluator = registry.get(rule.type);
+  if (!evaluator) return null;
+  const contributedRule: ContributedPolicyRule = {
+    id: rule.id,
+    type: rule.type,
+    enabled: rule.enabled,
+    config: rule.config,
+  };
+  try {
+    const result = await evaluator.evaluate(contributedRule, ctx);
+    // The contributed result is structurally a PolicyResult; surface it as one,
+    // pinning policyId/type to the rule so a misbehaving plugin can't mislabel
+    // the verdict's identity.
+    return {
+      policyId: rule.id,
+      type: rule.type as PolicyResult["type"],
+      passed: result.passed === true,
+      ...(result.reason !== undefined ? { reason: result.reason } : {}),
+    };
+  } catch (error) {
+    return {
+      policyId: rule.id,
+      type: rule.type as PolicyResult["type"],
+      passed: false,
+      reason: `Plugin policy evaluator for "${rule.type}" threw: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    };
+  }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -14,6 +14,8 @@ export type { AppVariables } from "./types/app-variables.js";
 // ─── Lean-core + opt-in-plugin contract ───
 export type {
   AdapterContribution,
+  ContributedPolicyResult,
+  ContributedPolicyRule,
   PluginMigrationSource,
   PolicyRuleContribution,
   StewardPlugin,

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -25,20 +25,68 @@
  *        core).
  */
 /**
+ * The shape of a single policy rule as seen by a contributed evaluator. A plugin
+ * owns a rule `type` that the core's closed {@link PolicyType} union does NOT
+ * enumerate, so the contribution sees the rule structurally: a string `type`
+ * (the plugin's discriminator), an `enabled` flag, and an opaque `config` bag the
+ * evaluator interprets. This mirrors the core {@link PolicyRule} fields WITHOUT
+ * narrowing `type` to the core union, so a plugin rule type is representable.
+ */
+export interface ContributedPolicyRule {
+  readonly id: string;
+  /** the plugin's rule-type discriminator (NOT a member of the core union). */
+  readonly type: string;
+  readonly enabled: boolean;
+  readonly config: Record<string, unknown>;
+}
+
+/**
+ * The verdict a contributed evaluator returns. Structurally identical to the
+ * core `PolicyResult` (policyId/type/passed/reason). Defined here — rather than
+ * importing the core `PolicyResult` — so this contract stays self-contained in
+ * `@stwd/shared`'s type vocabulary; the policy engine treats a returned value as
+ * a `PolicyResult` (the shapes are assignable).
+ */
+export interface ContributedPolicyResult {
+  readonly policyId: string;
+  readonly type: string;
+  readonly passed: boolean;
+  readonly reason?: string;
+}
+
+/**
  * A policy-rule contribution a plugin declares so the core's policy engine can
  * evaluate a rule type the plugin owns (e.g. a venue-specific gate) WITHOUT the
  * core importing the plugin.
  *
- * PLACEHOLDER (Phase 2b): the shape is intentionally minimal here so the
- * contract is REAL (a plugin can declare the field and the host can carry it),
- * but the host does not yet WIRE these into `PolicyEngine`. Full wiring —
- * registering the evaluator, validating the rule type is unique, threading the
- * eval context — is Phase 2b. Until then `policyRules` is accepted + reported by
- * the host's diagnostics but not evaluated.
+ * WIRED in Phase 2b. The plugin host registers each contribution into the policy
+ * engine's runtime evaluator registry (fail-closed on a `type` that collides with
+ * a core rule type or another plugin's). When `evaluatePolicy` meets a rule whose
+ * `type` is not one of the core cases, it consults the registry; the contributed
+ * `evaluate` runs and its result is used. Core rule evaluation is untouched.
+ *
+ * GENERIC over the evaluator context `Ctx`: `@stwd/shared` must not import
+ * `@stwd/policy-engine` (that would be a dependency cycle — policy-engine imports
+ * shared), so the concrete evaluator context type lives in policy-engine and is
+ * bound there. A plugin author binds `Ctx` to the policy engine's exported
+ * `EvaluatorContext`. Left unbound, `Ctx` defaults to `unknown` so the contract
+ * is usable without the policy engine present.
  */
-export interface PolicyRuleContribution {
+export interface PolicyRuleContribution<Ctx = unknown> {
   /** the policy `type` discriminator this rule contributes (must be unique). */
   readonly type: string;
+  /**
+   * evaluate a rule of this contributed `type` against the injected context.
+   * MUST be pure with respect to money state (it reads the context the engine
+   * supplies and returns a verdict; it reserves/commits nothing). may be async.
+   * a thrown error is treated by the engine as a fail-closed deny.
+   */
+  evaluate(
+    rule: ContributedPolicyRule,
+    ctx: Ctx,
+  ): ContributedPolicyResult | Promise<ContributedPolicyResult>;
+  /** optional human-readable description, surfaced in diagnostics. */
+  readonly description?: string;
 }
 
 /**
@@ -72,7 +120,7 @@ export interface AdapterContribution {
   readonly provider: string;
 }
 
-export interface StewardPlugin<App = unknown, Ctx = unknown> {
+export interface StewardPlugin<App = unknown, Ctx = unknown, EvalCtx = unknown> {
   /** stable identifier for the plugin, e.g. "trading". used in logs/diagnostics. */
   readonly name: string;
   /**
@@ -112,12 +160,14 @@ export interface StewardPlugin<App = unknown, Ctx = unknown> {
   readonly webhookEvents?: readonly string[];
 
   /**
-   * policy rules this plugin contributes. TYPED here (`PolicyRuleContribution`)
-   * so the contract shape is real, but full wiring into the policy engine is
-   * DEFERRED to Phase 2b. The host carries + reports these; it does not yet
-   * evaluate them.
+   * policy rules this plugin contributes. WIRED in Phase 2b: the host registers
+   * each into the policy engine's runtime evaluator registry (fail-closed on a
+   * `type` collision with a core rule type or another plugin's). The policy
+   * engine then evaluates a rule of a contributed `type` via the contribution's
+   * `evaluate`. `EvalCtx` is bound by the concrete app plugin type (in
+   * `@stwd/api`) to the policy engine's `EvaluatorContext`.
    */
-  readonly policyRules?: readonly PolicyRuleContribution[];
+  readonly policyRules?: readonly PolicyRuleContribution<EvalCtx>[];
 
   /**
    * database migrations this plugin contributes. TYPED here


### PR DESCRIPTION
## Phase 2b: pluggable policy rule types + webhook emission-path widening

Builds on Phase 2a (the `StewardPlugin` contract + `PluginHost`, commit `7dca6af`). 2b wires the **highest-value** declarative contribution point — `policyRules` — for real, and folds in the deferred webhook **emission**-path widening.

**Additive, backward-compatible, vendor-neutral.** No money-route core logic changed.

### A. Pluggable policy rule types (core of 2b)

A plugin can now contribute a custom `rule.type` + evaluator, and the core policy engine evaluates it — without the core importing the plugin.

**Contract (`@stwd/shared`):** `PolicyRuleContribution<Ctx>` now has a real shape:
```ts
interface PolicyRuleContribution<Ctx = unknown> {
  readonly type: string;                    // unique discriminator
  evaluate(rule: ContributedPolicyRule, ctx: Ctx):
    ContributedPolicyResult | Promise<ContributedPolicyResult>;
  readonly description?: string;
}
```
Generic over `Ctx` so `@stwd/shared` never imports `@stwd/policy-engine` (that would be a dependency cycle — policy-engine imports shared). The concrete `EvaluatorContext` is bound in `@stwd/api`'s `StewardApiPlugin` third type-arg. `ContributedPolicyRule`/`ContributedPolicyResult` mirror the core types but with a `string` type, so a plugin rule type (not in the closed `PolicyType` union) is representable.

**Registry + fallthrough (`@stwd/policy-engine`):** a process-wide `PolicyRuleRegistry` maps a contributed `rule.type` → evaluator. `evaluatePolicy` consults it **ONLY in the `default:` arm** — the 16 core `case` arms are untouched, so a core policy decision is byte-identical before/after. The registry:
- **fails closed** on a `type` that collides with a core rule type or another plugin's (a plugin can't shadow a money-rail decision),
- converts a throwing evaluator or a non-`true` `passed` into a **deny**,
- **pins** `policyId`/`type` to the rule so a plugin can't mislabel a verdict.

**Host wiring (`@stwd/api`):** `PluginHost` registers each plugin's `policyRules` into the engine registry at composition time (fail-closed on collision, before any `register()` hook runs), and surfaces `policyRuleContributions` in `describe()`.

### B. Webhook emission-path widening (2a leftover)

`DispatchableWebhookEventType` widened to `WebhookEventType | (string & {})` — core names stay typed/autocompleted, plugin-declared names can be emitted. `dispatchWebhook` threads a **registry-valid** plugin event into the configured fan-out so a tenant can subscribe to it specifically (`events: ["plugin.evt"]`). The legacy tenant-config catch-all webhook is **unchanged** (it has always fired for every event type; preserving that avoids changing long-standing behavior). An arbitrary unregistered string can never masquerade as a configured event.

### How a 3rd-party plugin adds a rule type
```ts
import type { StewardApiPlugin } from "@stwd/api";
export const myPlugin: StewardApiPlugin = {
  name: "my-plugin",
  policyRules: [{
    type: "my-custom-gate",
    description: "...",
    evaluate(rule, ctx) {        // ctx is the engine EvaluatorContext
      return { policyId: rule.id, type: rule.type, passed: /* ... */, reason: "..." };
    },
  }],
};
// at the composition root: await host.register(app, ctx, myPlugin)
// a policy of { type: "my-custom-gate", ... } now evaluates via the plugin.
```

### Core behavior unchanged — how verified
- Registry consulted **only** in `default:` (non-core types). All 16 core `case` arms are literally unedited.
- `@stwd/policy-engine` suite green incl. `evaluators.test.ts` (243 pass).
- New test asserts a core `spending-limit` still evaluates via its core case even when a plugin rule is registered, and a disabled rule still returns "Policy disabled".

### Status
- **build** `turbo run build --filter=./packages/*`: green (22/22)
- **frozen install** (bun 1.3.9): no changes (no package.json edits)
- **audit** `--audit-level=critical` + `--audit-level=high`: clean
- **lint** (biome): clean
- **tests**: policy-engine (243 pass), api plugin-host (11) + new plugin-host-policy-rules (3) + webhook-dispatch (5 incl. 2 new plugin-event) + webhook-events (7), plugin-trading 2a contract test (3). Per-file isolated like CI. One plugin-trading cross-file flake (`agent-token-expiry-monitoring`) passes in isolation, unrelated to this change.
- **codex review**: INCONCLUSIVE — `codex review --base origin/develop` hung >3min on two attempts (known codex flakiness, see TOOLS.md); killed and proceeded per guardrail. Not a finding.

### Deferred
- **2c:** plugin `migrations` execution.
- **2d:** plugin `adapters` registration.
- **2b follow-up:** migrating trading's `venue-allowlist`/`leverage-cap` to declared `policyRules` contributions. Left as core cases deliberately — moving them risks changing money-route policy behavior; the mechanism is proven with the synthetic test instead.

### Open question
Should plugin-event emission also reach the **legacy tenant-config** webhook (currently only the configured fan-out matches plugin events specifically; the legacy catch-all still fires for them since it fires for everything)? Current behavior keeps both paths working; flagging in case the legacy path should be tightened separately.
