### PR TITLE
feat(api): plugin adapter contributions (phase 2d)

### DIFF
--- a/packages/api/src/__tests__/plugin-host-adapters.test.ts
+++ b/packages/api/src/__tests__/plugin-host-adapters.test.ts
@@ -1,0 +1,185 @@
+/**
+ * plugin-host-adapters.test.ts — focused unit tests for the Phase 2d plugin
+ * adapter contribution wiring.
+ *
+ * Covers the host's load-bearing guarantees for `adapters`:
+ *   - a plugin-contributed adapter is REGISTERED into the injected adapter
+ *     registry and RESOLVES (via the registry's own env-driven selection) to the
+ *     plugin's adapter — proving the contribution reaches the real money-route
+ *     resolution path without the host touching the registry's resolution logic;
+ *   - FAIL-CLOSED on a `(category, provider)` collision (two plugins, or one
+ *     plugin twice) — the host refuses to silently overwrite a registered adapter;
+ *   - FAIL-CLOSED on an unknown category;
+ *   - FAIL-CLOSED on a missing adapter instance;
+ *   - back-compat: a plugin with NO `adapters` registers fine.
+ *
+ * The host is exercised with an INJECTED `AdapterRegistry` (with a controlled
+ * env) so adapter resolution is hermetic and the test owns provider selection.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { AdapterRegistry } from "@stwd/adapters";
+import type { AdapterContribution } from "@stwd/shared";
+import type { StewardApp } from "../plugin";
+import { PluginHost, PluginHostError } from "../plugin";
+
+// A minimal stub app. The fake plugins never mount routes; we assert only on the
+// adapter registry, so an `unknown`-cast is safe.
+const app = {} as StewardApp;
+
+/** A fake swap adapter that just echoes its provider name. */
+function fakeSwapAdapter(provider: string) {
+  return {
+    category: "swap" as const,
+    provider,
+    enabled: true,
+    async getQuote() {
+      throw new Error("not implemented in test");
+    },
+    async buildSwap() {
+      throw new Error("not implemented in test");
+    },
+  };
+}
+
+/** Build a plugin that contributes the given adapter contributions. */
+function adapterPlugin(name: string, adapters: readonly AdapterContribution[]) {
+  return { name, adapters };
+}
+
+/**
+ * The minimal ctx the host's adapter wiring reads: an `adapterRegistry`. Built
+ * around an injected {@link AdapterRegistry} with a controlled env so resolution
+ * is hermetic.
+ */
+function ctxWith(registry: AdapterRegistry) {
+  return { adapterRegistry: registry };
+}
+
+describe("PluginHost — adapter contributions (Phase 2d)", () => {
+  it("registers a contributed adapter that resolves via the injected registry", async () => {
+    // env selects the contributed provider for the swap category.
+    const registry = new AdapterRegistry({
+      env: { STEWARD_SWAP_ADAPTER: "test-swap" },
+    });
+    const ctx = ctxWith(registry);
+
+    const plugin = adapterPlugin("trading", [
+      { category: "swap", provider: "test-swap", adapter: fakeSwapAdapter("test-swap") },
+    ]);
+
+    const host = new PluginHost<typeof ctx>();
+    await host.register(app, ctx, plugin);
+
+    // The registry resolves swap() to the plugin's contributed adapter (NOT the
+    // built-in mock), proving the contribution reached the real resolution path.
+    expect(registry.swap().provider).toBe("test-swap");
+
+    // Diagnostics surface the contribution.
+    expect(host.describe().adapterContributions.trading).toEqual(["swap::test-swap"]);
+  });
+
+  it("registers without env disambiguation when a single provider is contributed", async () => {
+    // No STEWARD_SWAP_ADAPTER set; a single registered provider is used as-is.
+    const registry = new AdapterRegistry({ env: {} });
+    const ctx = ctxWith(registry);
+
+    const plugin = adapterPlugin("trading", [
+      { category: "swap", provider: "solo-swap", adapter: fakeSwapAdapter("solo-swap") },
+    ]);
+
+    const host = new PluginHost<typeof ctx>();
+    await host.register(app, ctx, plugin);
+
+    expect(registry.swap().provider).toBe("solo-swap");
+  });
+
+  it("FAILS CLOSED on a (category, provider) collision between two plugins", async () => {
+    const registry = new AdapterRegistry({ env: {} });
+    const ctx = ctxWith(registry);
+
+    const a = adapterPlugin("plugin-a", [
+      { category: "swap", provider: "dup", adapter: fakeSwapAdapter("a") },
+    ]);
+    const b = adapterPlugin("plugin-b", [
+      { category: "swap", provider: "dup", adapter: fakeSwapAdapter("b") },
+    ]);
+
+    const host = new PluginHost<typeof ctx>();
+    await expect(host.register(app, ctx, a, b)).rejects.toThrow(PluginHostError);
+  });
+
+  it("FAILS CLOSED on a (category, provider) collision within one plugin", async () => {
+    const registry = new AdapterRegistry({ env: {} });
+    const ctx = ctxWith(registry);
+
+    const plugin = adapterPlugin("trading", [
+      { category: "swap", provider: "dup", adapter: fakeSwapAdapter("first") },
+      { category: "swap", provider: "dup", adapter: fakeSwapAdapter("second") },
+    ]);
+
+    const host = new PluginHost<typeof ctx>();
+    await expect(host.register(app, ctx, plugin)).rejects.toThrow(PluginHostError);
+  });
+
+  it("FAILS CLOSED on an unknown adapter category", async () => {
+    const registry = new AdapterRegistry({ env: {} });
+    const ctx = ctxWith(registry);
+
+    const plugin = adapterPlugin("trading", [
+      { category: "not-a-category", provider: "x", adapter: fakeSwapAdapter("x") },
+    ]);
+
+    const host = new PluginHost<typeof ctx>();
+    await expect(host.register(app, ctx, plugin)).rejects.toThrow(PluginHostError);
+  });
+
+  it("FAILS CLOSED on a missing adapter instance", async () => {
+    const registry = new AdapterRegistry({ env: {} });
+    const ctx = ctxWith(registry);
+
+    const plugin = adapterPlugin("trading", [
+      // adapter is null — fail closed rather than register a non-adapter.
+      { category: "swap", provider: "x", adapter: null },
+    ]);
+
+    const host = new PluginHost<typeof ctx>();
+    await expect(host.register(app, ctx, plugin)).rejects.toThrow(PluginHostError);
+  });
+
+  it("FAILS CLOSED on an empty provider name", async () => {
+    const registry = new AdapterRegistry({ env: {} });
+    const ctx = ctxWith(registry);
+
+    const plugin = adapterPlugin("trading", [
+      { category: "swap", provider: "   ", adapter: fakeSwapAdapter("x") },
+    ]);
+
+    const host = new PluginHost<typeof ctx>();
+    await expect(host.register(app, ctx, plugin)).rejects.toThrow(PluginHostError);
+  });
+
+  it("FAILS CLOSED when a plugin contributes adapters but ctx has no registry", async () => {
+    const ctx = {} as { adapterRegistry?: AdapterRegistry };
+
+    const plugin = adapterPlugin("trading", [
+      { category: "swap", provider: "x", adapter: fakeSwapAdapter("x") },
+    ]);
+
+    const host = new PluginHost<typeof ctx>();
+    await expect(host.register(app, ctx, plugin)).rejects.toThrow(PluginHostError);
+  });
+
+  it("BACK-COMPAT: a plugin with no adapters registers fine", async () => {
+    const registry = new AdapterRegistry({ env: {} });
+    const ctx = ctxWith(registry);
+
+    const plugin = { name: "no-adapters", register() {} };
+
+    const host = new PluginHost<typeof ctx>();
+    await host.register(app, ctx, plugin);
+
+    expect(host.describe().plugins.map((p) => p.name)).toEqual(["no-adapters"]);
+    expect(host.describe().adapterContributions).toEqual({});
+  });
+});

--- a/packages/api/src/plugin.ts
+++ b/packages/api/src/plugin.ts
@@ -45,6 +45,7 @@
  * deploy that wants trading opts in by registering the plugin.
  */
 
+import { type AdapterCategory, AdapterRegistry, adapterRegistry } from "@stwd/adapters";
 import { pluginMigrationsTable, runPluginMigrations } from "@stwd/db";
 import {
   type EvaluatorContext,
@@ -78,6 +79,65 @@ import { CONFIGURED_WEBHOOK_EVENT_TYPES } from "./services/webhook-events";
 export type StewardApp = Hono<{ Variables: AppVariables }>;
 
 /**
+ * The closed set of adapter categories the core registry knows, mirrored here so
+ * the host can VALIDATE a plugin's structural `category: string` before casting
+ * it to {@link AdapterCategory} and calling `register`. Kept in sync with
+ * `@stwd/adapters`' `AdapterCategory` union (a compile-time exhaustiveness check
+ * below fails the build if the union grows and this set doesn't).
+ */
+const KNOWN_ADAPTER_CATEGORIES = new Set<string>([
+  "swap",
+  "earn",
+  "onramp",
+  "offramp",
+  "kyc",
+  "tos",
+  "custodial",
+  "push",
+  "bridge",
+  "spark",
+  "exchange",
+]);
+
+// Compile-time guard: every AdapterCategory must be present in the runtime set
+// above. If the `@stwd/adapters` union grows a member not listed here, this
+// assignment fails to type-check, forcing the set to be updated in lockstep.
+const _ADAPTER_CATEGORY_EXHAUSTIVE: Record<AdapterCategory, true> = {
+  swap: true,
+  earn: true,
+  onramp: true,
+  offramp: true,
+  kyc: true,
+  tos: true,
+  custodial: true,
+  push: true,
+  bridge: true,
+  spark: true,
+  exchange: true,
+};
+void _ADAPTER_CATEGORY_EXHAUSTIVE;
+
+/** True if `c` is a known adapter category (narrows to {@link AdapterCategory}). */
+function isAdapterCategory(c: string): c is AdapterCategory {
+  return KNOWN_ADAPTER_CATEGORIES.has(c);
+}
+
+/**
+ * Structural check that an injected context carries an adapter registry, so the
+ * host can wire a plugin's `adapters` contributions WITHOUT the host's `Ctx`
+ * type parameter having to be {@link StewardAppContext} (the host stays generic;
+ * tests pass a minimal ctx + a fresh registry). A plugin that declares `adapters`
+ * REQUIRES a registry in ctx; the host fails closed if one isn't present.
+ */
+function ctxAdapterRegistry(ctx: unknown): AdapterRegistry | undefined {
+  if (ctx && typeof ctx === "object" && "adapterRegistry" in ctx) {
+    const reg = (ctx as { adapterRegistry: unknown }).adapterRegistry;
+    if (reg instanceof AdapterRegistry) return reg;
+  }
+  return undefined;
+}
+
+/**
  * The injected context the core hands a plugin's `register(app, ctx)`. Every
  * member is a CORE singleton/helper a plugin would otherwise have had to import
  * from `@stwd/api` (which would be a circular dependency for a plugin in its own
@@ -105,6 +165,15 @@ export interface StewardAppContext {
   requireAgentJwt: typeof requireAgentJwt;
   operatorAuth: typeof operatorAuth;
   tenantAuth: typeof tenantAuth;
+  /**
+   * the core's adapter registry — the seam a plugin's `adapters` contributions
+   * register a real provider integration into (Phase 2d). defaults to the
+   * process-wide {@link adapterRegistry} routes consult; tests inject a fresh
+   * {@link AdapterRegistry} (with a controlled env) so adapter resolution is
+   * hermetic. the host only CALLS `register(category, provider, adapter)` on it;
+   * the registry's fail-closed-in-production resolution is untouched.
+   */
+  adapterRegistry: AdapterRegistry;
 }
 
 /**
@@ -137,6 +206,7 @@ export function buildPluginContext(): StewardAppContext {
     requireAgentJwt,
     operatorAuth,
     tenantAuth,
+    adapterRegistry,
   };
 }
 
@@ -173,6 +243,11 @@ export interface PluginHostDiagnostics {
   webhookEventContributions: Record<string, string[]>;
   /** which plugin contributed which policy rule types (Phase 2b). */
   policyRuleContributions: Record<string, string[]>;
+  /**
+   * which plugin contributed which adapters, as `"<category>::<provider>"` keys
+   * (Phase 2d). reflects what the host REGISTERED into the adapter registry.
+   */
+  adapterContributions: Record<string, string[]>;
   /**
    * which plugin declared a migration source, and the namespaced bookkeeping
    * table its ledger is (or will be) recorded in —
@@ -254,8 +329,8 @@ function orderByDependencies<Ctx>(
 /**
  * The plugin host: composes one or more plugins onto a steward app.
  *
- * RESPONSIBILITIES (Phase 2a + 2b)
- * --------------------------------
+ * RESPONSIBILITIES (Phase 2a + 2b + 2c + 2d)
+ * ------------------------------------------
  *  1. validate unique plugin names + a valid (acyclic, fully-satisfied)
  *     `dependsOn` graph, FAILING CLOSED on any violation.
  *  2. order plugins so each registers AFTER its dependencies.
@@ -274,10 +349,15 @@ function orderByDependencies<Ctx>(
  *     totally isolated from the core's `drizzle.__drizzle_migrations` journal
  *     (Phase 2c). Migrations are NOT run during `register` (route registration
  *     must not block on a schema migration) and NEVER per request.
- *  7. expose {@link describe} so ops can see what loaded + what was contributed.
- *
- * the `adapters` contribution point is TYPED on the contract but its wiring is
- * DEFERRED to Phase 2d; the host does not act on it yet.
+ *  7. register each plugin's declared `adapters` into the core adapter registry
+ *     (from `ctx.adapterRegistry`) via its existing `register(category, provider,
+ *     adapter)` seam, in dependency order, FAILING CLOSED on a `(category,
+ *     provider)` collision with another plugin's contribution (the host never
+ *     silently overwrites a real money-route adapter) or an invalid contribution
+ *     (unknown category, empty provider, missing adapter). The registry's
+ *     fail-closed-in-production RESOLUTION is untouched — the host only CALLS
+ *     register(). (Phase 2d)
+ *  8. expose {@link describe} so ops can see what loaded + what was contributed.
  */
 export class PluginHost<Ctx> {
   private readonly loaded: LoadedPluginInfo[] = [];
@@ -285,6 +365,11 @@ export class PluginHost<Ctx> {
   private readonly policyRegistry: PolicyRuleRegistry;
   /** which plugin contributed which policy rule types (diagnostics). */
   private readonly policyContributions = new Map<string, string[]>();
+  /**
+   * which plugin contributed which adapters, as `"<category>::<provider>"` keys
+   * (diagnostics). Phase 2d.
+   */
+  private readonly adapterContributions = new Map<string, string[]>();
   /**
    * declared plugin migration sources, in dependency (registration) order. The
    * host does NOT run these during `register` (route registration must not block
@@ -366,6 +451,80 @@ export class PluginHost<Ctx> {
         const types = this.policyContributions.get(plugin.name) ?? [];
         types.push(contribution.type);
         this.policyContributions.set(plugin.name, types);
+      }
+    }
+
+    // Phase 1b2: register declared adapter contributions into the core's adapter
+    // registry (Phase 2d), BEFORE any `register` hook runs (so a plugin route
+    // that resolves an adapter during its own registration sees the contributed
+    // provider). The registry is taken from `ctx.adapterRegistry`; a plugin that
+    // declares `adapters` REQUIRES it. The registry's own fail-closed-in-prod
+    // RESOLUTION is untouched — the host only CALLS register(category, provider,
+    // adapter).
+    //
+    // FAIL-CLOSED on a `(category, provider)` collision: the registry's own
+    // `register` would silently OVERWRITE by (category, provider); to prevent a
+    // plugin (or two plugins) from silently clobbering a real money-route
+    // adapter, the host tracks every (category, provider) it has registered
+    // across the plugin loop and throws PluginHostError BEFORE calling
+    // `registry.register` on a duplicate. Each contribution is also validated
+    // fail-closed: a known category, a non-empty provider, and a present adapter.
+    {
+      const hostRegistry = ctxAdapterRegistry(ctx);
+      const seenAdapters = new Set<string>();
+      for (const plugin of ordered) {
+        if (!plugin.adapters || plugin.adapters.length === 0) continue;
+        if (!hostRegistry) {
+          throw new PluginHostError(
+            `plugin "${plugin.name}" contributes adapters but the injected context ` +
+              "carries no `adapterRegistry`.",
+          );
+        }
+        for (const contribution of plugin.adapters) {
+          const category = contribution.category;
+          const provider = contribution.provider;
+          if (typeof category !== "string" || !isAdapterCategory(category)) {
+            throw new PluginHostError(
+              `plugin "${plugin.name}" contributes an adapter for unknown category ` +
+                `"${String(category)}".`,
+            );
+          }
+          if (typeof provider !== "string" || provider.trim() === "") {
+            throw new PluginHostError(
+              `plugin "${plugin.name}" contributes a "${category}" adapter with an ` +
+                "empty provider name.",
+            );
+          }
+          if (contribution.adapter === undefined || contribution.adapter === null) {
+            throw new PluginHostError(
+              `plugin "${plugin.name}" contributes a "${category}" adapter under ` +
+                `provider "${provider}" with no adapter instance.`,
+            );
+          }
+          const key = `${category}::${provider}`;
+          if (seenAdapters.has(key)) {
+            throw new PluginHostError(
+              `duplicate adapter contribution for (category="${category}", ` +
+                `provider="${provider}") — plugin "${plugin.name}" collides with an ` +
+                "already-registered contribution; refusing to overwrite a registered " +
+                "adapter.",
+            );
+          }
+          seenAdapters.add(key);
+          // category is narrowed to AdapterCategory; adapter is `unknown` at the
+          // shared boundary — cast to the registry's per-category type here, at
+          // the api boundary where @stwd/adapters is a legitimate dependency. The
+          // cast is unavoidable (see AdapterContribution's cycle note); the
+          // contribution author owns the adapter conforming to its category.
+          hostRegistry.register(
+            category,
+            provider,
+            contribution.adapter as Parameters<AdapterRegistry["register"]>[2],
+          );
+          const list = this.adapterContributions.get(plugin.name) ?? [];
+          list.push(key);
+          this.adapterContributions.set(plugin.name, list);
+        }
       }
     }
 
@@ -460,6 +619,10 @@ export class PluginHost<Ctx> {
     for (const [plugin, types] of this.policyContributions) {
       policyRuleContributions[plugin] = [...types].sort();
     }
+    const adapterContributions: Record<string, string[]> = {};
+    for (const [plugin, keys] of this.adapterContributions) {
+      adapterContributions[plugin] = [...keys].sort();
+    }
     const migrationSources: Record<string, { id: string; migrationsTable: string }> = {};
     for (const { pluginName, source } of this.migrationSources) {
       migrationSources[pluginName] = {
@@ -472,6 +635,7 @@ export class PluginHost<Ctx> {
       webhookEvents: this.eventRegistry.list(),
       webhookEventContributions: this.eventRegistry.describeContributions(),
       policyRuleContributions,
+      adapterContributions,
       migrationSources,
     };
   }

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -128,18 +128,44 @@ export interface PluginMigrationSource {
 /**
  * An adapter contribution a plugin registers into the core's adapter registry
  * (mirrors `packages/adapters` categories) so a plugin can supply a real
- * provider integration.
+ * provider integration (a concrete swap/earn/onramp/.../exchange adapter).
  *
- * PLACEHOLDER (Phase 2d): minimal shape so the contract is real; the host does
- * not yet REGISTER these into the adapter registry (category typing + the
- * fail-closed-in-production resolution are Phase 2d). Accepted + reported, not
- * registered.
+ * WIRED in Phase 2d. The host registers each contribution into the core's
+ * {@link AdapterRegistry} via its existing `register(category, provider, adapter)`
+ * seam, in `dependsOn` order, FAIL-CLOSED on a `(category, provider)` collision
+ * with another plugin's contribution (the host never silently overwrites a real
+ * money-route adapter — see the host's conflict detection). The registry's own
+ * fail-closed-in-production RESOLUTION is untouched: a contributed adapter is
+ * selected exactly as a core-registered one would be (env `STEWARD_<CAT>_ADAPTER`
+ * names the provider, or a single registered provider is used without env
+ * disambiguation).
+ *
+ * STRUCTURAL on purpose: `@stwd/shared` must NOT import `@stwd/adapters`
+ * (`@stwd/adapters` depends on `@stwd/shared`, so importing the concrete
+ * per-category adapter types here would create a dependency CYCLE). The category
+ * is therefore a plain `string` (assignable to the registry's `AdapterCategory`,
+ * validated by the host) and the concrete adapter instance is typed `unknown` —
+ * the host casts it to the registry's per-category type at the api boundary,
+ * where `@stwd/adapters` is a legitimate dependency.
  */
 export interface AdapterContribution {
-  /** the adapter category this contribution targets, e.g. "swap". */
+  /**
+   * the adapter category this contribution targets, e.g. "swap". a plain string
+   * (not the adapters' `AdapterCategory` union) to avoid a shared->adapters
+   * cycle; the host validates it is a known category and casts, fail-closed on
+   * an unknown category.
+   */
   readonly category: string;
-  /** the provider name this contribution registers under. */
+  /** the provider name this contribution registers under (must be non-empty). */
   readonly provider: string;
+  /**
+   * the concrete adapter instance to register under `(category, provider)`.
+   * typed `unknown` at the shared layer to avoid a shared->adapters cycle (the
+   * concrete per-category adapter types live in `@stwd/adapters`); the host
+   * casts it to the registry's expected per-category type when it calls
+   * `adapterRegistry.register(...)`.
+   */
+  readonly adapter: unknown;
 }
 
 export interface StewardPlugin<App = unknown, Ctx = unknown, EvalCtx = unknown> {
@@ -201,9 +227,12 @@ export interface StewardPlugin<App = unknown, Ctx = unknown, EvalCtx = unknown> 
   readonly migrations?: PluginMigrationSource;
 
   /**
-   * adapter integrations this plugin contributes. TYPED here
-   * (`AdapterContribution`); registration into the adapter registry is DEFERRED
-   * to Phase 2d.
+   * adapter integrations this plugin contributes. WIRED in Phase 2d: the host
+   * registers each into the core's adapter registry via its existing
+   * `register(category, provider, adapter)` seam, in `dependsOn` order,
+   * FAIL-CLOSED on a `(category, provider)` collision with another plugin's
+   * contribution (never silently overwrites a real money-route adapter). The
+   * registry's fail-closed-in-production RESOLUTION is untouched.
    */
   readonly adapters?: readonly AdapterContribution[];
 }


### PR DESCRIPTION
## Phase 2d — plugin adapter contributions

The LAST plugin-SDK contribution point. A plugin can now contribute a concrete provider adapter (swap/earn/onramp/offramp/kyc/tos/custodial/push/bridge/spark/exchange) into the core \`AdapterRegistry\` via its existing \`register()\` seam, so a plugin supplies a real provider integration.

Additive, backward-compatible, vendor-neutral. Builds on 2a (host+contract), 2b (policy rules), 2c (migrations), all merged on develop.

### What changed
- **shared** (\`packages/shared/src/types/plugin.ts\`): \`AdapterContribution\` fleshed out with \`adapter: unknown\` (the concrete instance) alongside \`category: string\` + \`provider: string\`. \`@stwd/shared\` must NOT import \`@stwd/adapters\` (adapters depends on shared → cycle), so the adapter stays \`unknown\` here and the host casts at the api boundary.
- **api** (\`packages/api/src/plugin.ts\`):
  - \`StewardAppContext\` + \`buildPluginContext()\` now carry \`adapterRegistry\` (the process-wide singleton; tests inject a fresh \`AdapterRegistry\` with a controlled env).
  - \`PluginHost.register\` wires each contribution into \`ctx.adapterRegistry\` in \`dependsOn\` order, **FAIL-CLOSED** on:
    - a \`(category, provider)\` collision across the plugin loop (never silently overwrites a registered money-route adapter — host-level dup detection, since the registry's own \`register\` overwrites by key);
    - an unknown category (validated against the known \`AdapterCategory\` set, with a compile-time exhaustiveness guard);
    - an empty provider name;
    - a missing adapter instance;
    - a plugin declaring \`adapters\` when \`ctx\` carries no registry.
  - \`describe()\` surfaces \`adapterContributions\` for ops.
- **adapters**: **0-diff.** The registry's fail-closed-in-production resolution is untouched; the host only CALLS \`register()\`.

### Tests (\`plugin-host-adapters.test.ts\`, 9 pass)
- a contributed swap adapter resolves via an injected registry (\`STEWARD_SWAP_ADAPTER=test-swap\` → \`.swap().provider === "test-swap"\`);
- single-provider resolution without env disambiguation;
- fail-closed on dup \`(category,provider)\` across two plugins AND within one plugin;
- fail-closed on unknown category / missing adapter / empty provider / no registry in ctx;
- back-compat: a plugin with no \`adapters\` registers fine.

### Verification
- \`turbo run build --filter=@stwd/shared --filter=@stwd/adapters --filter=@stwd/api\`: green (13/13).
- \`bun install --frozen-lockfile\`: clean (no package.json changes).
- \`bun audit\`: critical + high CLEAN (1 pre-existing low: elliptic, untouched transitive).
- \`bun run lint\`: exit 0 (3 pre-existing warnings in \`packages/db\`, not touched here).
- adapters \`registry.test.ts\` + api host suites green; registry.ts diff = 0 lines.
- codex review: inconclusive (process hang >3min, known VPS flakiness) — SIGKILLed and proceeded per protocol.

Co-authored-by: wakesync <shadow@shad0w.xyz>