### PR TITLE
feat(plugin-sdk): author-facing sdk package, example plugin, quickstart docs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -174,6 +174,33 @@
         "typescript": "^5.8.0",
       },
     },
+    "packages/plugin-example": {
+      "name": "@stwd/plugin-example",
+      "version": "0.1.0",
+      "dependencies": {
+        "@stwd/plugin-sdk": "workspace:*",
+      },
+      "devDependencies": {
+        "@stwd/adapters": "workspace:*",
+        "@stwd/db": "workspace:*",
+        "@stwd/policy-engine": "workspace:*",
+        "@stwd/shared": "workspace:*",
+        "@types/node": "^25.5.0",
+        "hono": "^4.12.18",
+      },
+    },
+    "packages/plugin-sdk": {
+      "name": "@stwd/plugin-sdk",
+      "version": "0.1.0",
+      "dependencies": {
+        "@stwd/api": "workspace:*",
+        "@stwd/shared": "workspace:*",
+      },
+      "devDependencies": {
+        "@stwd/db": "workspace:*",
+        "@types/node": "^25.5.0",
+      },
+    },
     "packages/plugin-trading": {
       "name": "@stwd/plugin-trading",
       "version": "0.1.0",
@@ -310,7 +337,7 @@
     },
     "packages/sdk": {
       "name": "@stwd/sdk",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "dependencies": {
         "bs58": "^6.0.0",
       },
@@ -1557,6 +1584,10 @@
 
     "@stwd/mcp": ["@stwd/mcp@workspace:packages/mcp"],
 
+    "@stwd/plugin-example": ["@stwd/plugin-example@workspace:packages/plugin-example"],
+
+    "@stwd/plugin-sdk": ["@stwd/plugin-sdk@workspace:packages/plugin-sdk"],
+
     "@stwd/plugin-trading": ["@stwd/plugin-trading@workspace:packages/plugin-trading"],
 
     "@stwd/policy-engine": ["@stwd/policy-engine@workspace:packages/policy-engine"],
@@ -1979,7 +2010,7 @@
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
-    "camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
+    "camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
 
     "camelcase-css": ["camelcase-css@2.0.1", "", {}, "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="],
 
@@ -2013,7 +2044,7 @@
 
     "client-only": ["client-only@0.0.1", "", {}, "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="],
 
-    "cliui": ["cliui@9.0.1", "", { "dependencies": { "string-width": "^7.2.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w=="],
+    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
     "cloudflare": ["cloudflare@4.5.0", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" } }, "sha512-fPcbPKx4zF45jBvQ0z7PCdgejVAPBBCZxwqk1k7krQNfpM07Cfj97/Q6wBzvYqlWXx/zt1S9+m8vnfCe06umbQ=="],
 
@@ -2033,7 +2064,7 @@
 
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
-    "commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
+    "commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
 
     "comment-json": ["comment-json@4.6.2", "", { "dependencies": { "array-timsort": "^1.0.3", "esprima": "^4.0.1" } }, "sha512-R2rze/hDX30uul4NZoIZ76ImSJLFxn/1/ZxtKC1L77y2X1k+yYu1joKbAtMA2Fg3hZrTOiw0I5mwVMo0cf250w=="],
 
@@ -2173,7 +2204,7 @@
 
     "elliptic": ["elliptic@6.6.1", "", { "dependencies": { "bn.js": "^4.11.9", "brorand": "^1.1.0", "hash.js": "^1.0.0", "hmac-drbg": "^1.0.1", "inherits": "^2.0.4", "minimalistic-assert": "^1.0.1", "minimalistic-crypto-utils": "^1.0.1" } }, "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g=="],
 
-    "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "encode-utf8": ["encode-utf8@1.0.3", "", {}, "sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw=="],
 
@@ -3123,7 +3154,7 @@
 
     "strict-uri-encode": ["strict-uri-encode@2.0.0", "", {}, "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ=="],
 
-    "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -3331,7 +3362,7 @@
 
     "wrangler": ["wrangler@4.105.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.28.1", "miniflare": "4.20260625.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260625.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260625.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "cf-wrangler": "bin/cf-wrangler.js", "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-7dXFH6OLj1Fv0y6ZeRPUxFTkp+duWD7/xxVi/1c0vfOeEYwIFKWB7cdqnY05DvY1Ta3BnqAwRkXfLs8PDj538g=="],
 
-    "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
@@ -3363,7 +3394,7 @@
 
     "yaml-ast-parser": ["yaml-ast-parser@0.0.43", "", {}, "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A=="],
 
-    "yargs": ["yargs@18.0.0", "", { "dependencies": { "cliui": "^9.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "string-width": "^7.2.0", "y18n": "^5.0.5", "yargs-parser": "^22.0.0" } }, "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg=="],
+    "yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
 
     "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
@@ -3505,6 +3536,8 @@
 
     "@opennextjs/aws/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
+    "@opennextjs/cloudflare/yargs": ["yargs@18.0.0", "", { "dependencies": { "cliui": "^9.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "string-width": "^7.2.0", "y18n": "^5.0.5", "yargs-parser": "^22.0.0" } }, "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg=="],
+
     "@particle-network/solana-wallet/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
 
     "@polymarket/abstract-signer/ethers": ["ethers@5.7.2", "", { "dependencies": { "@ethersproject/abi": "5.7.0", "@ethersproject/abstract-provider": "5.7.0", "@ethersproject/abstract-signer": "5.7.0", "@ethersproject/address": "5.7.0", "@ethersproject/base64": "5.7.0", "@ethersproject/basex": "5.7.0", "@ethersproject/bignumber": "5.7.0", "@ethersproject/bytes": "5.7.0", "@ethersproject/constants": "5.7.0", "@ethersproject/contracts": "5.7.0", "@ethersproject/hash": "5.7.0", "@ethersproject/hdnode": "5.7.0", "@ethersproject/json-wallets": "5.7.0", "@ethersproject/keccak256": "5.7.0", "@ethersproject/logger": "5.7.0", "@ethersproject/networks": "5.7.1", "@ethersproject/pbkdf2": "5.7.0", "@ethersproject/properties": "5.7.0", "@ethersproject/providers": "5.7.2", "@ethersproject/random": "5.7.0", "@ethersproject/rlp": "5.7.0", "@ethersproject/sha2": "5.7.0", "@ethersproject/signing-key": "5.7.0", "@ethersproject/solidity": "5.7.0", "@ethersproject/strings": "5.7.0", "@ethersproject/transactions": "5.7.0", "@ethersproject/units": "5.7.0", "@ethersproject/wallet": "5.7.0", "@ethersproject/web": "5.7.1", "@ethersproject/wordlists": "5.7.0" } }, "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg=="],
@@ -3522,8 +3555,6 @@
     "@project-serum/sol-wallet-adapter/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
 
     "@project-serum/sol-wallet-adapter/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
-
-    "@react-native/codegen/yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
 
     "@react-native/dev-middleware/serve-static": ["serve-static@1.16.3", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "~0.19.1" } }, "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA=="],
 
@@ -3805,8 +3836,6 @@
 
     "cbw-sdk/preact": ["preact@10.29.3", "", {}, "sha512-D9NL1GAnJZhc3RndVs4gDdxEeU9TcHgywMrhhOsnpdlvFjdbx0gAsLUnH6JEhlJH5giL7Tx5biWPUSEXE/HPzw=="],
 
-    "cliui/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
-
     "cloudflare/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
 
     "connect/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
@@ -3871,8 +3900,6 @@
 
     "jest-util/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
-    "jest-validate/camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
-
     "jest-validate/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
@@ -3890,8 +3917,6 @@
     "metro/hermes-parser": ["hermes-parser@0.35.0", "", { "dependencies": { "hermes-estree": "0.35.0" } }, "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA=="],
 
     "metro/source-map": ["source-map@0.5.7", "", {}, "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="],
-
-    "metro/yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
 
     "metro-babel-transformer/hermes-parser": ["hermes-parser@0.35.0", "", { "dependencies": { "hermes-estree": "0.35.0" } }, "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA=="],
 
@@ -3925,13 +3950,9 @@
 
     "qrcode.react/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 
-    "react-native/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
-
     "react-native/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 
     "react-native/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
-
-    "react-native/yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
 
     "react-qr-reader/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 
@@ -3955,11 +3976,9 @@
 
     "stream-browserify/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
-    "string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
-
-    "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
     "string_decoder/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
+    "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
     "tailwindcss/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
@@ -3989,21 +4008,15 @@
 
     "wif/bs58check": ["bs58check@4.0.0", "", { "dependencies": { "@noble/hashes": "^1.2.0", "bs58": "^6.0.0" } }, "sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g=="],
 
-    "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
-
-    "wrap-ansi/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+    "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
-    "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "xml-crypto/xpath": ["xpath@0.0.33", "", {}, "sha512-NNXnzrkDrAzalLhIUc01jO2mOzXGXh1JwPgkihcLLzw98c0WgYDmmjSh1Kl3wzaxSVWMuA+fe0WTWOBDWCBmNA=="],
 
     "xml-encryption/xpath": ["xpath@0.0.32", "", {}, "sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw=="],
 
     "xml2js/xmlbuilder": ["xmlbuilder@11.0.1", "", {}, "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="],
-
-    "yargs/yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
 
     "youch/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
@@ -4111,15 +4124,17 @@
 
     "@metamask/utils/@ethereumjs/tx/@ethereumjs/common": ["@ethereumjs/common@3.2.0", "", { "dependencies": { "@ethereumjs/util": "^8.1.0", "crc-32": "^1.2.0" } }, "sha512-pksvzI0VyLgmuEF2FA/JR/4/y6hcPq8OUail3/AvycBaW1d5VSauOZzqGvJ3RTmR4MU35lWE8KseKOsEhrFRBA=="],
 
+    "@opennextjs/cloudflare/yargs/cliui": ["cliui@9.0.1", "", { "dependencies": { "string-width": "^7.2.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w=="],
+
+    "@opennextjs/cloudflare/yargs/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "@opennextjs/cloudflare/yargs/yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
+
     "@particle-network/solana-wallet/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
 
     "@polymarket/builder-signing-sdk/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
     "@project-serum/sol-wallet-adapter/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
-
-    "@react-native/codegen/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
-
-    "@react-native/codegen/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "@react-native/dev-middleware/serve-static/send": ["send@0.19.2", "", { "dependencies": { "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "fresh": "~0.5.2", "http-errors": "~2.0.1", "mime": "1.6.0", "ms": "2.1.3", "on-finished": "~2.4.1", "range-parser": "~1.2.1", "statuses": "~2.0.2" } }, "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg=="],
 
@@ -4547,8 +4562,6 @@
 
     "bs58check/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
 
-    "cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
-
     "cloudflare/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
     "connect/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
@@ -4587,37 +4600,21 @@
 
     "metro/hermes-parser/hermes-estree": ["hermes-estree@0.35.0", "", {}, "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg=="],
 
-    "metro/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
-
-    "metro/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
     "porto/ox/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
 
     "qrcode/yargs/cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
-
-    "qrcode/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "qrcode/yargs/y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
 
     "qrcode/yargs/yargs-parser": ["yargs-parser@18.1.3", "", { "dependencies": { "camelcase": "^5.0.0", "decamelize": "^1.2.0" } }, "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ=="],
 
-    "react-native/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
-
-    "react-native/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
     "react-qr-reader/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
-
-    "string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "tailwindcss/chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "tailwindcss/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
     "unstorage/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
-
-    "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "@coinbase/cdp-sdk/@solana/kit/@solana/accounts/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
 
@@ -4753,9 +4750,13 @@
 
     "@metamask/providers/@metamask/utils/@ethereumjs/tx/@ethereumjs/common": ["@ethereumjs/common@3.2.0", "", { "dependencies": { "@ethereumjs/util": "^8.1.0", "crc-32": "^1.2.0" } }, "sha512-pksvzI0VyLgmuEF2FA/JR/4/y6hcPq8OUail3/AvycBaW1d5VSauOZzqGvJ3RTmR4MU35lWE8KseKOsEhrFRBA=="],
 
-    "@react-native/codegen/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+    "@opennextjs/cloudflare/yargs/cliui/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
-    "@react-native/codegen/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "@opennextjs/cloudflare/yargs/cliui/wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+
+    "@opennextjs/cloudflare/yargs/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "@opennextjs/cloudflare/yargs/string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "@react-native/dev-middleware/serve-static/send/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
@@ -4798,8 +4799,6 @@
     "@reown/appkit-pay/@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils": ["@walletconnect/utils@2.21.0", "", { "dependencies": { "@noble/ciphers": "1.2.1", "@noble/curves": "1.8.1", "@noble/hashes": "1.7.1", "@walletconnect/jsonrpc-utils": "1.0.8", "@walletconnect/keyvaluestorage": "1.1.1", "@walletconnect/relay-api": "1.0.11", "@walletconnect/relay-auth": "1.1.0", "@walletconnect/safe-json": "1.0.2", "@walletconnect/time": "1.0.2", "@walletconnect/types": "2.21.0", "@walletconnect/window-getters": "1.0.1", "@walletconnect/window-metadata": "1.0.1", "bs58": "6.0.0", "detect-browser": "5.3.0", "query-string": "7.1.3", "uint8arrays": "3.1.0", "viem": "2.23.2" } }, "sha512-zfHLiUoBrQ8rP57HTPXW7rQMnYxYI4gT9yTACxVW6LhIFROTF6/ytm5SKNoIvi4a5nX5dfXG4D9XwQUCu8Ilig=="],
 
     "@reown/appkit-ui/qrcode/yargs/cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
-
-    "@reown/appkit-ui/qrcode/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "@reown/appkit-ui/qrcode/yargs/y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
 
@@ -5365,17 +5364,9 @@
 
     "eth-block-tracker/@metamask/utils/@ethereumjs/tx/@ethereumjs/common": ["@ethereumjs/common@3.2.0", "", { "dependencies": { "@ethereumjs/util": "^8.1.0", "crc-32": "^1.2.0" } }, "sha512-pksvzI0VyLgmuEF2FA/JR/4/y6hcPq8OUail3/AvycBaW1d5VSauOZzqGvJ3RTmR4MU35lWE8KseKOsEhrFRBA=="],
 
-    "metro/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
-
-    "metro/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
     "qrcode/yargs/cliui/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
-    "qrcode/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "react-native/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
-
-    "react-native/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "qrcode/yargs/yargs-parser/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
     "tailwindcss/chokidar/readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
@@ -5407,7 +5398,11 @@
 
     "@metamask/providers/@metamask/rpc-errors/@metamask/utils/@ethereumjs/tx/@ethereumjs/common": ["@ethereumjs/common@3.2.0", "", { "dependencies": { "@ethereumjs/util": "^8.1.0", "crc-32": "^1.2.0" } }, "sha512-pksvzI0VyLgmuEF2FA/JR/4/y6hcPq8OUail3/AvycBaW1d5VSauOZzqGvJ3RTmR4MU35lWE8KseKOsEhrFRBA=="],
 
-    "@react-native/codegen/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+    "@opennextjs/cloudflare/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "@opennextjs/cloudflare/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "@opennextjs/cloudflare/yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "@react-native/dev-middleware/serve-static/send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
@@ -5433,8 +5428,6 @@
 
     "@reown/appkit-pay/@reown/appkit-ui/qrcode/yargs/cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
 
-    "@reown/appkit-pay/@reown/appkit-ui/qrcode/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
     "@reown/appkit-pay/@reown/appkit-ui/qrcode/yargs/y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
 
     "@reown/appkit-pay/@reown/appkit-ui/qrcode/yargs/yargs-parser": ["yargs-parser@18.1.3", "", { "dependencies": { "camelcase": "^5.0.0", "decamelize": "^1.2.0" } }, "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ=="],
@@ -5451,7 +5444,7 @@
 
     "@reown/appkit-ui/qrcode/yargs/cliui/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
-    "@reown/appkit-ui/qrcode/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "@reown/appkit-ui/qrcode/yargs/yargs-parser/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
     "@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils/viem/@scure/bip32": ["@scure/bip32@1.6.2", "", { "dependencies": { "@noble/curves": "~1.8.1", "@noble/hashes": "~1.7.1", "@scure/base": "~1.2.2" } }, "sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw=="],
 
@@ -5581,11 +5574,7 @@
 
     "@walletconnect/utils/viem/ox/@scure/bip39/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 
-    "metro/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
     "qrcode/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
-    "react-native/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "@metamask/eth-json-rpc-provider/@metamask/json-rpc-engine/@metamask/rpc-errors/@metamask/utils/@ethereumjs/tx/@ethereumjs/common": ["@ethereumjs/common@3.2.0", "", { "dependencies": { "@ethereumjs/util": "^8.1.0", "crc-32": "^1.2.0" } }, "sha512-pksvzI0VyLgmuEF2FA/JR/4/y6hcPq8OUail3/AvycBaW1d5VSauOZzqGvJ3RTmR4MU35lWE8KseKOsEhrFRBA=="],
 
@@ -5615,7 +5604,7 @@
 
     "@reown/appkit-pay/@reown/appkit-ui/qrcode/yargs/cliui/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
-    "@reown/appkit-pay/@reown/appkit-ui/qrcode/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "@reown/appkit-pay/@reown/appkit-ui/qrcode/yargs/yargs-parser/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
     "@reown/appkit-pay/@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils/viem/@scure/bip32": ["@scure/bip32@1.6.2", "", { "dependencies": { "@noble/curves": "~1.8.1", "@noble/hashes": "~1.7.1", "@scure/base": "~1.2.2" } }, "sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw=="],
 
@@ -5662,8 +5651,6 @@
     "@walletconnect/core/@walletconnect/utils/viem/ox/@scure/bip39/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 
     "@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode/yargs/cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
-
-    "@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode/yargs/y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
 
@@ -5731,7 +5718,7 @@
 
     "@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode/yargs/cliui/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
-    "@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode/yargs/yargs-parser/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
     "@walletconnect/ethereum-provider/@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils/viem/@scure/bip32/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -1,0 +1,160 @@
+# steward plugins
+
+steward is a lean open core plus opt-in plugins. there are two doors.
+
+- door 1: you want a turnkey core (auth + embedded wallet + policy). run it, point your app at it, done.
+- door 2: you want to extend it. write a plugin that contributes routes, policy rules, webhook events, db migrations, or provider adapters, and register it at the composition root.
+
+the core never imports a plugin, and a plugin never imports the core. everything a plugin needs is injected. that keeps the dependency one-directional (no cycle), and an install that only wants the core never pulls a plugin's transitive deps (smaller install, smaller supply-chain + audit surface).
+
+---
+
+## door 1 - use the turnkey core (operator)
+
+the lean core gives you, out of the box:
+
+- auth (sessions, jwts, the login methods you enable)
+- an embedded wallet / vault (key custody + signing, fail-closed)
+- a policy engine (spending limits, address allow/blocklists, rate limits, time windows, and more)
+- a proxy + webhooks surface
+
+you compose the deployable app from the core and any plugins you want. the entrypoint calls `composeApp()`, which builds the lean core and registers this repo's opt-in plugins:
+
+```ts
+// the deployable server entrypoint (already wired in @stwd/api).
+import { composeApp } from "@stwd/api/compose";
+
+const app = await composeApp(); // lean core + opt-in plugins
+// serve `app` with your runtime (Bun.serve, Workers, ...).
+```
+
+minimum env to boot the core:
+
+- `DATABASE_URL` - your Postgres connection string (or run the bundled PGLite for local/dev).
+- `STEWARD_MASTER_PASSWORD` - the vault master secret. required; the hardened guard rejects dev-weak values.
+- `STEWARD_JWT_SECRET` - the jwt signing secret (full entropy).
+- `STEWARD_AUDIT_HMAC_KEY` - the audit-log hmac key.
+
+migrations run at boot before the server accepts traffic. that's it - the core is up.
+
+---
+
+## door 2 - write a plugin (author)
+
+a plugin is one object. you import everything from a single package:
+
+```ts
+import type { StewardApiPlugin } from "@stwd/plugin-sdk";
+```
+
+`@stwd/plugin-sdk` is the one import for writing a plugin. it re-exports the plugin contract + the host runtime. a plugin contributes any of five things, each optional, each fail-closed:
+
+### the plugin object
+
+```ts
+import type { StewardApiPlugin } from "@stwd/plugin-sdk";
+
+export const myPlugin: StewardApiPlugin = {
+  name: "my-plugin",
+  version: "0.1.0",
+  // dependsOn: ["other-plugin"], // optional: ordered + fail-closed on missing/cyclic
+  // ...contributions below
+};
+```
+
+### 1. route - `register(app, ctx)`
+
+mount hono routes/middleware onto the core app. `ctx` is injected: it carries the shared service singletons (db, vault, policy engine, ...) and the auth middleware to gate your routes (`requireAgentJwt`, `operatorAuth`, `tenantAuth`).
+
+```ts
+register(app, ctx) {
+  app.get("/example/ping", (c) => c.json({ ok: true }));
+  // gate a route: app.post("/example/do", ctx.requireAgentJwt, handler);
+}
+```
+
+### 2. policy rule
+
+contribute a custom rule `type` the core's closed policy union does not enumerate. the engine consults your evaluator for that type and uses the verdict.
+
+```ts
+policyRules: [
+  {
+    type: "example-business-hours",
+    description: "passes only inside a configured UTC hour window.",
+    evaluate(rule, ctx) {
+      const passed = new Date().getUTCHours() < 17;
+      return { policyId: rule.id, type: rule.type, passed };
+    },
+  },
+],
+```
+
+### 3. webhook event
+
+declare event-type names your plugin emits. the host merges them into the runtime registry (core union ∪ plugin-declared) so the webhook config/dispatch path accepts them.
+
+```ts
+webhookEvents: ["example.pinged"],
+```
+
+### 4. migration
+
+point at your plugin's OWN drizzle migrations folder (with its own `meta/_journal.json`). the host applies it after the core migrator, into a per-plugin namespaced bookkeeping table - never the core journal.
+
+```ts
+import { fileURLToPath } from "node:url";
+
+migrations: {
+  id: "example",
+  migrationsFolder: fileURLToPath(new URL("../drizzle", import.meta.url)),
+},
+```
+
+### 5. adapter
+
+contribute a real provider integration under a known adapter category (swap, earn, onramp, offramp, kyc, tos, custodial, push, bridge, spark, exchange).
+
+```ts
+adapters: [
+  {
+    category: "push",
+    provider: "example-push",
+    adapter: myPushAdapter, // implements the category's interface
+  },
+],
+```
+
+### register it (composition root)
+
+an operator enables your plugin where the app is composed - not inside the core:
+
+```ts
+import { buildPluginContext, registerPlugin } from "@stwd/plugin-sdk";
+import { myPlugin } from "my-plugin";
+
+await registerPlugin(app, myPlugin, buildPluginContext());
+```
+
+compose several plugins with `PluginHost` for dependency ordering + diagnostics:
+
+```ts
+import { PluginHost, buildPluginContext } from "@stwd/plugin-sdk";
+
+const host = new PluginHost();
+await host.register(app, buildPluginContext(), pluginA, pluginB);
+console.log(host.describe()); // loaded plugins + every contribution
+```
+
+### fail-closed guarantees
+
+the host refuses to compose an ambiguous or unsafe surface. a plugin:
+
+- cannot shadow a core policy rule type, and cannot reuse a rule type another plugin already registered.
+- cannot write into or read from the core migration journal - its migration ledger lives in its own namespaced table (`drizzle.__drizzle_migrations_plugin_<id>`).
+- cannot silently overwrite a registered adapter - a `(category, provider)` collision throws, as does an unknown category, an empty provider, or a missing adapter instance.
+- cannot register against a half-built dependency - a missing or cyclic `dependsOn`, or a duplicate plugin name, throws before anything registers.
+
+### runnable reference
+
+`@stwd/plugin-example` is the smallest honest plugin: it exercises all five contribution points and imports only from `@stwd/plugin-sdk`. read `packages/plugin-example/src/index.ts` and its end-to-end test for a working template.

--- a/packages/plugin-example/README.md
+++ b/packages/plugin-example/README.md
@@ -1,0 +1,24 @@
+# @stwd/plugin-example
+
+the smallest honest Steward plugin. the runnable reference for writing one.
+
+it exercises all of the plugin contract's contribution points in the minimal way, importing ONLY from `@stwd/plugin-sdk`:
+
+1. route - `register(app, ctx)` mounts `GET /example/ping` -> `{ ok: true }`.
+2. policy rule - a custom `example-business-hours` rule the engine evaluates.
+3. webhook event - declares `example.pinged`.
+4. migration - points at this package's own `drizzle/` folder (one `CREATE TABLE example_log`), applied into a per-plugin namespaced bookkeeping table, isolated from the core journal.
+5. adapter - a trivial `push` provider (`example-push`).
+
+enable it at the composition root:
+
+```ts
+import { buildPluginContext, registerPlugin } from "@stwd/plugin-sdk";
+import { examplePlugin } from "@stwd/plugin-example";
+
+await registerPlugin(app, examplePlugin, buildPluginContext());
+```
+
+the end-to-end test (`src/__tests__/example-plugin.test.ts`) registers the plugin through the public sdk surface and asserts every contribution point landed: the route responds, the policy rule is consulted, the webhook event is in the registry, the adapter resolves, and the migration source is collected. that test is the proof an end-to-end plugin works through `@stwd/plugin-sdk` alone.
+
+see `docs/plugins/README.md` for the full quickstart.

--- a/packages/plugin-example/bunfig.toml
+++ b/packages/plugin-example/bunfig.toml
@@ -1,0 +1,10 @@
+# test config for @stwd/plugin-example.
+#
+# the end-to-end test registers the example via the sdk's registerPlugin, which
+# re-exports the host runtime from @stwd/api/plugin. that module graph evaluates
+# @stwd/api's services/context at import time (it resolves DATABASE_URL + master
+# password + a db handle). the preload makes that first evaluation deterministic
+# (pglite + full-entropy test secrets) so the test imports the surface without a
+# real database.
+[test]
+preload = ["./test-preload.ts"]

--- a/packages/plugin-example/drizzle/0000_example_log.sql
+++ b/packages/plugin-example/drizzle/0000_example_log.sql
@@ -1,0 +1,8 @@
+-- the example plugin's OWN schema. applied by the host into a per-plugin
+-- namespaced bookkeeping table (drizzle.__drizzle_migrations_plugin_example),
+-- never into the core's drizzle.__drizzle_migrations journal.
+CREATE TABLE "example_log" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"note" text NOT NULL,
+	"created_at" timestamptz DEFAULT now() NOT NULL
+);

--- a/packages/plugin-example/drizzle/meta/_journal.json
+++ b/packages/plugin-example/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1782700000000,
+      "tag": "0000_example_log",
+      "breakpoints": true
+    }
+  ]
+}

--- a/packages/plugin-example/package.json
+++ b/packages/plugin-example/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@stwd/plugin-example",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "tsc --noEmit",
+    "dev": "tsc --watch",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@stwd/plugin-sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@stwd/adapters": "workspace:*",
+    "@stwd/db": "workspace:*",
+    "@stwd/policy-engine": "workspace:*",
+    "@stwd/shared": "workspace:*",
+    "@types/node": "^25.5.0",
+    "hono": "^4.12.18"
+  },
+  "description": "Minimal hello-world Steward plugin: the smallest honest plugin exercising all four declarative contribution points (route, policy rule, webhook event, migration, adapter) through @stwd/plugin-sdk alone. The runnable reference for writing a plugin."
+}

--- a/packages/plugin-example/src/__tests__/example-plugin.test.ts
+++ b/packages/plugin-example/src/__tests__/example-plugin.test.ts
@@ -1,0 +1,123 @@
+/**
+ * example-plugin.test.ts - the end-to-end proof that a plugin works through the
+ * PUBLIC sdk surface alone.
+ *
+ * it registers `examplePlugin` via `registerPlugin` (re-exported by
+ * @stwd/plugin-sdk) against a real hono app + an injected, hermetic context, then
+ * asserts each contribution point landed:
+ *   - the GET /example/ping route responds { ok: true };
+ *   - the "example-business-hours" policy rule is registered + consulted (its
+ *     evaluator returns a proper ContributedPolicyResult for its own type);
+ *   - the "example.pinged" webhook event is in the merged registry;
+ *   - the "push::example-push" adapter is registered into the injected registry;
+ *   - the migration source is collected (id "example", isolated bookkeeping table).
+ *
+ * the context is built by hand (not via the live buildPluginContext) so the test
+ * is hermetic - it injects a fresh AdapterRegistry + isolated webhook/policy
+ * registries, mirroring the api host tests.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { AdapterRegistry } from "@stwd/adapters";
+import { PluginHost, registerPlugin, type StewardApp } from "@stwd/plugin-sdk";
+import { PolicyRuleRegistry } from "@stwd/policy-engine";
+import { WebhookEventRegistry } from "@stwd/shared";
+import { Hono } from "hono";
+import { examplePlugin } from "../index";
+
+/**
+ * a minimal injected context. the example's `register` ignores ctx, and the host
+ * only reads `ctx.adapterRegistry` for adapter wiring, so a fresh registry is the
+ * only field the test must supply. cast through `unknown` because the test does
+ * not stand up the full StewardAppContext (db/vault/...): the host's adapter path
+ * is structural (`ctxAdapterRegistry`), it does not require the full shape.
+ */
+function buildTestCtx(registry: AdapterRegistry): unknown {
+  return { adapterRegistry: registry };
+}
+
+describe("@stwd/plugin-example through the public sdk surface", () => {
+  it("registers all contribution points and serves its route", async () => {
+    const app = new Hono() as unknown as StewardApp;
+    // env selects the example provider for the push category so resolution is
+    // deterministic.
+    const registry = new AdapterRegistry({ env: { STEWARD_PUSH_ADAPTER: "example-push" } });
+    const eventRegistry = new WebhookEventRegistry(new Set<string>());
+    const policyRegistry = new PolicyRuleRegistry();
+    const ctx = buildTestCtx(registry);
+
+    // register through the SDK's registerPlugin (not @stwd/api directly).
+    const host = await registerPlugin(
+      app as Parameters<typeof registerPlugin>[0],
+      examplePlugin,
+      ctx,
+      eventRegistry,
+      policyRegistry,
+    );
+
+    // ── 1. ROUTE ──────────────────────────────────────────────────────────────
+    const res = await (app as unknown as Hono).request("/example/ping");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+
+    // ── 2. POLICY RULE ─────────────────────────────────────────────────────────
+    // the host registered the contributed evaluator for the plugin's own type.
+    expect(policyRegistry.has("example-business-hours")).toBe(true);
+    const evaluator = policyRegistry.get("example-business-hours");
+    expect(evaluator).toBeDefined();
+    // consult it as the engine would: a rule inside the window passes, outside
+    // denies with a reason. the example reads `nowUtcHour` off the eval context.
+    const passing = await evaluator?.evaluate(
+      {
+        id: "r1",
+        type: "example-business-hours",
+        enabled: true,
+        config: { openHourUtc: 9, closeHourUtc: 17 },
+      },
+      { nowUtcHour: 12 } as never,
+    );
+    expect(passing?.passed).toBe(true);
+    expect(passing?.policyId).toBe("r1");
+    expect(passing?.type).toBe("example-business-hours");
+    const denying = await evaluator?.evaluate(
+      {
+        id: "r2",
+        type: "example-business-hours",
+        enabled: true,
+        config: { openHourUtc: 9, closeHourUtc: 17 },
+      },
+      { nowUtcHour: 3 } as never,
+    );
+    expect(denying?.passed).toBe(false);
+    expect(typeof denying?.reason).toBe("string");
+
+    // ── 3. WEBHOOK EVENT ────────────────────────────────────────────────────────
+    expect(eventRegistry.has("example.pinged")).toBe(true);
+    expect(host.describe().webhookEventContributions.example).toEqual(["example.pinged"]);
+
+    // ── 4. ADAPTER ──────────────────────────────────────────────────────────────
+    // resolves through the registry's own env-driven selection to the plugin's
+    // provider, proving the contribution reached the real resolution path.
+    expect(registry.push().provider).toBe("example-push");
+    expect(host.describe().adapterContributions.example).toEqual(["push::example-push"]);
+
+    // ── 5. MIGRATION SOURCE ─────────────────────────────────────────────────────
+    // collected (not applied - applying needs a live db). diagnostics show the id
+    // + the isolated per-plugin bookkeeping table.
+    const migrations = host.describe().migrationSources.example;
+    expect(migrations).toBeDefined();
+    expect(migrations.id).toBe("example");
+    expect(migrations.migrationsTable).toBe("__drizzle_migrations_plugin_example");
+  });
+
+  it("collects the migration source via a standalone host (migrate-only path)", () => {
+    const host = new PluginHost<unknown>();
+    host.collectMigrations(examplePlugin);
+    const sources = host.pluginMigrationSources;
+    expect(sources).toHaveLength(1);
+    expect(sources[0]?.pluginName).toBe("example");
+    expect(sources[0]?.source.id).toBe("example");
+    // the folder path is absolute (resolved against the package), not relative.
+    expect(sources[0]?.source.migrationsFolder.endsWith("/drizzle")).toBe(true);
+  });
+});

--- a/packages/plugin-example/src/index.ts
+++ b/packages/plugin-example/src/index.ts
@@ -1,0 +1,160 @@
+/**
+ * @stwd/plugin-example - the smallest honest Steward plugin.
+ *
+ * this is the runnable hello-world that proves "anyone can write a plugin." it
+ * exercises ALL of the plugin contract's contribution points in the minimal way,
+ * importing ONLY from `@stwd/plugin-sdk` (the example is the forcing function for
+ * the sdk's completeness: if the example needs a symbol, the sdk re-exports it).
+ *
+ * contribution points demonstrated:
+ *   1. route       - `register(app, ctx)` mounts GET /example/ping -> { ok: true }.
+ *   2. policy rule - a custom "example-business-hours" rule the engine evaluates.
+ *   3. webhook     - declares the "example.pinged" event type.
+ *   4. migration   - points at this package's own drizzle folder (one CREATE TABLE).
+ *   5. adapter     - a trivial "push" provider ("example-push").
+ *
+ * to enable it, an operator registers it at the composition root:
+ *
+ *   import { buildPluginContext, registerPlugin } from "@stwd/plugin-sdk";
+ *   import { examplePlugin } from "@stwd/plugin-example";
+ *
+ *   await registerPlugin(app, examplePlugin, buildPluginContext());
+ *
+ * the core never imports this package; everything the plugin needs is INJECTED via
+ * the `ctx` the core hands `register`. that keeps the dependency one-directional.
+ */
+
+import { fileURLToPath } from "node:url";
+import type {
+  ContributedPolicyResult,
+  ContributedPolicyRule,
+  StewardApiPlugin,
+  StewardApp,
+  StewardAppContext,
+} from "@stwd/plugin-sdk";
+
+/**
+ * the example plugin's migrations folder, resolved to an ABSOLUTE path at runtime.
+ * the host applies it via the per-plugin migration runner; a relative path would
+ * break depending on the process cwd, so it is resolved against this module.
+ */
+const MIGRATIONS_FOLDER = fileURLToPath(new URL("../drizzle", import.meta.url));
+
+/**
+ * config shape for the "example-business-hours" rule. trivially demonstrates a
+ * plugin OWNING a rule type the core's closed policy union does not enumerate.
+ */
+interface ExampleBusinessHoursConfig {
+  /** UTC hour (0-23) the window opens, inclusive. defaults to 0. */
+  readonly openHourUtc?: number;
+  /** UTC hour (0-23) the window closes, exclusive. defaults to 24. */
+  readonly closeHourUtc?: number;
+}
+
+/**
+ * read the request's UTC hour from the evaluator context if present, else fall
+ * back to now. the example keeps this loose (the eval context is intentionally
+ * `unknown` at the contract boundary) - a real plugin binds the engine's
+ * `EvaluatorContext` and reads typed fields.
+ */
+function requestHourUtc(ctx: unknown): number {
+  if (ctx && typeof ctx === "object" && "nowUtcHour" in ctx) {
+    const h = (ctx as { nowUtcHour: unknown }).nowUtcHour;
+    if (typeof h === "number" && Number.isInteger(h) && h >= 0 && h <= 23) return h;
+  }
+  return new Date().getUTCHours();
+}
+
+/**
+ * the minimal "hello-world" plugin. typed `StewardApiPlugin` so it is bound to the
+ * steward app, the injected context, and the policy engine's evaluator context.
+ */
+export const examplePlugin: StewardApiPlugin = {
+  name: "example",
+  version: "0.1.0",
+
+  // 1. ROUTE - mount one trivial route using the injected ctx for nothing more
+  //    than to prove the seam works. real plugins gate routes with ctx auth
+  //    middleware (ctx.requireAgentJwt / ctx.operatorAuth / ctx.tenantAuth).
+  register(app: StewardApp, _ctx: StewardAppContext): void {
+    app.get("/example/ping", (c) => c.json({ ok: true }));
+  },
+
+  // 3. WEBHOOK - declare the event type this plugin emits. the host merges it
+  //    into the runtime registry (core union ∪ plugin-declared) so the webhook
+  //    config/dispatch path accepts it without the core's closed union knowing it.
+  webhookEvents: ["example.pinged"],
+
+  // 2. POLICY RULE - contribute a custom rule type. the host registers it into
+  //    the policy engine's evaluator registry (fail-closed on a collision with a
+  //    core rule type or another plugin's). the engine evaluates a rule of this
+  //    `type` via `evaluate` and uses the returned ContributedPolicyResult.
+  policyRules: [
+    {
+      type: "example-business-hours",
+      description: "passes only inside a configured UTC hour window.",
+      evaluate(rule: ContributedPolicyRule, evalCtx: unknown): ContributedPolicyResult {
+        const config = rule.config as ExampleBusinessHoursConfig;
+        const open = config.openHourUtc ?? 0;
+        const close = config.closeHourUtc ?? 24;
+        const hour = requestHourUtc(evalCtx);
+        const passed = hour >= open && hour < close;
+        return {
+          policyId: rule.id,
+          type: rule.type,
+          passed,
+          ...(passed ? {} : { reason: `outside business hours (${open}:00-${close}:00 UTC)` }),
+        };
+      },
+    },
+  ],
+
+  // 4. MIGRATION - point at this package's own drizzle folder. the host applies
+  //    it AFTER the core migrator, into a per-plugin namespaced bookkeeping table
+  //    (drizzle.__drizzle_migrations_plugin_example), isolated from the core
+  //    journal. one CREATE TABLE example_log.
+  migrations: {
+    id: "example",
+    migrationsFolder: MIGRATIONS_FOLDER,
+  },
+
+  // 5. ADAPTER - contribute a trivial "push" provider. the adapter is typed
+  //    `unknown` at the contract boundary (to avoid a contract -> adapters
+  //    dependency cycle), so the example builds a structurally-valid PushAdapter
+  //    WITHOUT importing @stwd/adapters. the host validates the category +
+  //    provider + instance and registers it into the core adapter registry.
+  adapters: [
+    {
+      category: "push",
+      provider: "example-push",
+      adapter: createExamplePushAdapter(),
+    },
+  ],
+};
+
+/**
+ * a minimal, structurally-valid `push` adapter. it implements the push adapter's
+ * shape (`category`/`provider`/`enabled` + a `send`) without importing the
+ * concrete `PushAdapter` type, so the example stays sdk-only. it records nothing
+ * real - it just acknowledges the send so the registry has a working provider.
+ */
+function createExamplePushAdapter() {
+  return {
+    category: "push" as const,
+    provider: "example-push",
+    enabled: true,
+    async send(request: { readonly target: { readonly id: string } }): Promise<{
+      ok: boolean;
+      provider: string;
+      subscriptionId: string;
+      deliveredAt: number;
+    }> {
+      return {
+        ok: true,
+        provider: "example-push",
+        subscriptionId: request.target.id,
+        deliveredAt: Date.now(),
+      };
+    },
+  };
+}

--- a/packages/plugin-example/test-preload.ts
+++ b/packages/plugin-example/test-preload.ts
@@ -1,0 +1,38 @@
+/**
+ * bun test preload for @stwd/plugin-example - runs ONCE per `bun test` process,
+ * before any test file's module graph is evaluated.
+ *
+ * the e2e test registers the example through @stwd/plugin-sdk's registerPlugin,
+ * which re-exports the host runtime from @stwd/api/plugin. that module graph
+ * eagerly evaluates @stwd/api's `services/context`, which resolves env-dependent
+ * invariants at module-init (DATABASE_URL, STEWARD_MASTER_PASSWORD, a db handle).
+ * this preload supplies a pglite runtime + full-entropy test secrets so the
+ * import succeeds without a real database, mirroring @stwd/api's own test preload.
+ *
+ * every value is set with `??=` so a real environment is never overridden, and
+ * the pglite bootstrap is skipped when a real DATABASE_URL is present. no
+ * production guard is weakened.
+ */
+
+import { afterAll } from "bun:test";
+import { closeDb } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+
+process.env.STEWARD_MASTER_PASSWORD ??= "steward-plugin-example-test-master-password";
+process.env.STEWARD_JWT_SECRET ??=
+  "steward-plugin-example-test-shared-jwt-secret-with-enough-entropy-0123456789";
+process.env.STEWARD_AUDIT_HMAC_KEY ??= "a".repeat(64);
+
+if (!process.env.DATABASE_URL) {
+  process.env.STEWARD_PGLITE_MEMORY ??= "true";
+  process.env.STEWARD_DB_MODE ??= "pglite";
+
+  const { db, client } = await createPGLiteDb("memory://");
+  setPGLiteOverride(db, async () => {
+    await client.close();
+  });
+
+  afterAll(async () => {
+    await closeDb();
+  });
+}

--- a/packages/plugin-example/tsconfig.json
+++ b/packages/plugin-example/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/__tests__"]
+}

--- a/packages/plugin-sdk/README.md
+++ b/packages/plugin-sdk/README.md
@@ -1,0 +1,32 @@
+# @stwd/plugin-sdk
+
+the one import for writing a Steward plugin.
+
+a plugin contributes any of: routes (the `register` hook), policy rules, webhook events, db migrations, provider adapters. each is fail-closed.
+
+this package is a thin facade. it re-exports:
+
+- the framework-agnostic contract from `@stwd/shared` (`StewardPlugin`, `PolicyRuleContribution`, `ContributedPolicyRule`, `ContributedPolicyResult`, `PluginMigrationSource`, `AdapterContribution`).
+- the concrete, app-bound types + host runtime from `@stwd/api` (`StewardApiPlugin`, `StewardApp`, `StewardAppContext`, `PluginHostDiagnostics`, `LoadedPluginInfo`, plus `buildPluginContext`, `registerPlugin`, `PluginHost`, `PluginHostError`).
+
+```ts
+import type { StewardApiPlugin } from "@stwd/plugin-sdk";
+
+export const myPlugin: StewardApiPlugin = {
+  name: "my-plugin",
+  register(app, ctx) {
+    app.get("/my-plugin/ping", (c) => c.json({ ok: true }));
+  },
+};
+```
+
+register it at the composition root:
+
+```ts
+import { buildPluginContext, registerPlugin } from "@stwd/plugin-sdk";
+import { myPlugin } from "my-plugin";
+
+await registerPlugin(app, myPlugin, buildPluginContext());
+```
+
+see `@stwd/plugin-example` for a runnable hello-world, and `docs/plugins/README.md` for the full two-door quickstart.

--- a/packages/plugin-sdk/bunfig.toml
+++ b/packages/plugin-sdk/bunfig.toml
@@ -1,0 +1,9 @@
+# test config for @stwd/plugin-sdk.
+#
+# the sdk re-exports the host runtime from @stwd/api/plugin, whose module graph
+# evaluates @stwd/api's services/context at import time (it resolves DATABASE_URL
+# + master password + a db handle at module-init). the preload makes that first
+# evaluation deterministic (pglite + full-entropy test secrets) so a pure facade
+# smoke test can import the surface without a real database.
+[test]
+preload = ["./test-preload.ts"]

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@stwd/plugin-sdk",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "tsc --noEmit",
+    "dev": "tsc --watch",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@stwd/api": "workspace:*",
+    "@stwd/shared": "workspace:*"
+  },
+  "devDependencies": {
+    "@stwd/db": "workspace:*",
+    "@types/node": "^25.5.0"
+  },
+  "description": "Author-facing SDK for writing a Steward plugin: the single curated import for the plugin contract + host. A thin facade over @stwd/shared (generic contract) and @stwd/api (concrete app-bound types + host)."
+}

--- a/packages/plugin-sdk/src/__tests__/smoke.test.ts
+++ b/packages/plugin-sdk/src/__tests__/smoke.test.ts
@@ -1,0 +1,72 @@
+/**
+ * smoke.test.ts - the facade can't silently lose an export.
+ *
+ * the sdk is a curated re-export surface; a refactor in @stwd/shared or @stwd/api
+ * could drop a symbol the sdk promises. this asserts every RUNTIME symbol the sdk
+ * re-exports is defined, and (at compile time) that every TYPE the sdk promises is
+ * importable + usable. if either regresses, this file fails to typecheck/run.
+ */
+
+import { describe, expect, it } from "bun:test";
+// types the sdk re-exports. imported type-only; the `_typeProbe` below references
+// each so an accidental removal is a compile error, not a silent drop.
+import type {
+  AdapterContribution,
+  ContributedPolicyResult,
+  ContributedPolicyRule,
+  LoadedPluginInfo,
+  PluginHostDiagnostics,
+  PluginMigrationSource,
+  PolicyRuleContribution,
+  StewardApiPlugin,
+  StewardApp,
+  StewardAppContext,
+  StewardPlugin,
+} from "../index";
+// runtime values the sdk re-exports (the host runtime).
+import { buildPluginContext, PluginHost, PluginHostError, registerPlugin } from "../index";
+
+describe("@stwd/plugin-sdk facade", () => {
+  it("re-exports every runtime symbol (defined, correct kind)", () => {
+    expect(typeof buildPluginContext).toBe("function");
+    expect(typeof registerPlugin).toBe("function");
+    expect(typeof PluginHost).toBe("function"); // class constructor
+    expect(typeof PluginHostError).toBe("function"); // class constructor
+  });
+
+  it("PluginHostError is a real Error subclass", () => {
+    const err = new PluginHostError("boom");
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("PluginHostError");
+    expect(err.message).toBe("boom");
+  });
+
+  it("a fresh PluginHost describes an empty load", () => {
+    const host = new PluginHost<Record<string, never>>();
+    const d = host.describe();
+    expect(d.plugins).toEqual([]);
+    expect(Array.isArray(d.webhookEvents)).toBe(true);
+    expect(d.policyRuleContributions).toEqual({});
+    expect(d.adapterContributions).toEqual({});
+  });
+});
+
+// ── compile-time probe: every promised TYPE is importable + usable ────────────
+//
+// this never runs; it exists so `tsc --noEmit` fails if the sdk drops a type
+// re-export. each type is referenced once.
+type _TypeProbe = {
+  plugin: StewardPlugin;
+  apiPlugin: StewardApiPlugin;
+  app: StewardApp;
+  ctx: StewardAppContext;
+  policyContribution: PolicyRuleContribution;
+  contributedRule: ContributedPolicyRule;
+  contributedResult: ContributedPolicyResult;
+  migration: PluginMigrationSource;
+  adapter: AdapterContribution;
+  diagnostics: PluginHostDiagnostics;
+  loaded: LoadedPluginInfo;
+};
+// reference the probe so it isn't an "unused type" lint hit.
+export type __SdkTypeProbe = _TypeProbe;

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -1,0 +1,61 @@
+/**
+ * @stwd/plugin-sdk - the one import for writing a Steward plugin.
+ *
+ * a plugin contributes any of:
+ *   - routes (via the `register(app, ctx)` hook)
+ *   - policy rules (custom rule types the policy engine evaluates)
+ *   - webhook events (event-type names the plugin emits)
+ *   - db migrations (the plugin's own drizzle migrations folder)
+ *   - provider adapters (a real swap/earn/onramp/push/... integration)
+ *
+ * each contribution is fail-closed: a plugin can never shadow a core policy rule
+ * type, never write into the core migration journal, never silently overwrite a
+ * registered adapter, and never register against a half-built dependency.
+ *
+ * this package is a thin FACADE. it re-exports the framework-agnostic contract
+ * from `@stwd/shared` and the concrete, app-bound types + host runtime from
+ * `@stwd/api`. an author depends on this ONE package and types their plugin as
+ * `StewardApiPlugin`; an operator uses `registerPlugin` (or `PluginHost`) at the
+ * composition root to mount it.
+ *
+ * see `@stwd/plugin-example` for a runnable hello-world that exercises all four
+ * declarative contribution points plus a route through this surface alone.
+ */
+
+export type {
+  LoadedPluginInfo,
+  PluginHostDiagnostics,
+  StewardApiPlugin,
+  StewardApp,
+  StewardAppContext,
+} from "@stwd/api/plugin";
+
+// ── the concrete, app-bound plugin type + host runtime (owned by @stwd/api) ───
+//
+// `StewardApiPlugin` is `StewardPlugin` bound to the steward hono app, the
+// injected `StewardAppContext`, and the policy engine's evaluator context - this
+// is the type an author annotates their plugin object with.
+//
+// `StewardApp` / `StewardAppContext` are the `app` / `ctx` a plugin's `register`
+// hook receives. `buildPluginContext` builds that ctx at the composition root,
+// and `registerPlugin` / `PluginHost` mount one or more plugins fail-closed.
+export {
+  buildPluginContext,
+  PluginHost,
+  PluginHostError,
+  registerPlugin,
+} from "@stwd/api/plugin";
+// ── the generic, framework-agnostic contract (owned by @stwd/shared) ──────────
+//
+// these describe a contribution structurally so the contract carries no http
+// framework or money-rail types. an author rarely binds these directly (the
+// concrete `StewardApiPlugin` below already binds them to the steward app), but
+// they are exported so an author can name a single contribution's shape.
+export type {
+  AdapterContribution,
+  ContributedPolicyResult,
+  ContributedPolicyRule,
+  PluginMigrationSource,
+  PolicyRuleContribution,
+  StewardPlugin,
+} from "@stwd/shared";

--- a/packages/plugin-sdk/test-preload.ts
+++ b/packages/plugin-sdk/test-preload.ts
@@ -1,0 +1,38 @@
+/**
+ * bun test preload for @stwd/plugin-sdk - runs ONCE per `bun test` process,
+ * before any test file's module graph is evaluated.
+ *
+ * the sdk re-exports the plugin host runtime from @stwd/api/plugin. that module
+ * graph eagerly evaluates @stwd/api's `services/context`, which resolves
+ * env-dependent invariants at module-init (DATABASE_URL, STEWARD_MASTER_PASSWORD,
+ * a db handle). without a deterministic bootstrap, importing the facade throws
+ * "DATABASE_URL is required". this preload supplies a pglite runtime + full-
+ * entropy test secrets, mirroring @stwd/api's own test preload.
+ *
+ * every value is set with `??=` so a real environment (real DATABASE_URL / real
+ * secrets in CI) is never overridden, and the pglite bootstrap is skipped when a
+ * real DATABASE_URL is present. no production guard is weakened.
+ */
+
+import { afterAll } from "bun:test";
+import { closeDb } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+
+process.env.STEWARD_MASTER_PASSWORD ??= "steward-plugin-sdk-test-master-password";
+process.env.STEWARD_JWT_SECRET ??=
+  "steward-plugin-sdk-test-shared-jwt-secret-with-enough-entropy-0123456789";
+process.env.STEWARD_AUDIT_HMAC_KEY ??= "a".repeat(64);
+
+if (!process.env.DATABASE_URL) {
+  process.env.STEWARD_PGLITE_MEMORY ??= "true";
+  process.env.STEWARD_DB_MODE ??= "pglite";
+
+  const { db, client } = await createPGLiteDb("memory://");
+  setPGLiteOverride(db, async () => {
+    await client.close();
+  });
+
+  afterAll(async () => {
+    await closeDb();
+  });
+}

--- a/packages/plugin-sdk/tsconfig.json
+++ b/packages/plugin-sdk/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/__tests__"]
+}

--- a/turbo.json
+++ b/turbo.json
@@ -45,6 +45,14 @@
       "dependsOn": ["^build"],
       "outputs": []
     },
+    "@stwd/plugin-example#build": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
+    "@stwd/plugin-sdk#build": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
     "@stwd/policy-engine#build": {
       "dependsOn": ["^build"],
       "outputs": []


### PR DESCRIPTION
## what

the packaging payoff that makes "anyone can write a plugin" real. additive, backward-compatible, vendor-neutral.

### `@stwd/plugin-sdk` (new, leaf facade)
the ONE import for writing a plugin. a thin curated re-export package:
- generic contract from `@stwd/shared`: `StewardPlugin`, `PolicyRuleContribution`, `ContributedPolicyRule`, `ContributedPolicyResult`, `PluginMigrationSource`, `AdapterContribution`.
- concrete app-bound types + host runtime from `@stwd/api/plugin`: `StewardApiPlugin`, `StewardApp`, `StewardAppContext`, `PluginHostDiagnostics`, `LoadedPluginInfo`, plus `buildPluginContext`, `registerPlugin`, `PluginHost`, `PluginHostError`.
- a smoke test asserts every re-exported symbol is present so the facade can't silently lose an export.

### `@stwd/plugin-example` (new)
the smallest honest hello-world plugin. exercises ALL contribution points, importing ONLY from `@stwd/plugin-sdk`:
- route: `register` mounts `GET /example/ping`
- policy rule: a custom `example-business-hours` type
- webhook event: `example.pinged`
- migration: its own `drizzle/` folder (one `CREATE TABLE example_log`)
- adapter: a `push` provider (`example-push`)

an end-to-end test registers it through the public `registerPlugin` against a real hono app + hermetic ctx and asserts every contribution landed (route responds, policy rule consulted, webhook event in registry, adapter resolves, migration source collected).

### docs
`docs/plugins/README.md`: the two-door quickstart. door 1 = run the turnkey core. door 2 = write a plugin (sdk import, each contribution point with a snippet, register at the composition root, fail-closed guarantees).

## verification (bun 1.3.9)
- `turbo run build --filter='./packages/*'`: 24/24 green (incl. both new packages + api + plugin-trading). web typechecks clean; full `next build` is pre-existing VPS flakiness, unrelated (web does not depend on these packages).
- plugin-sdk smoke test: 3 pass / 0 fail. plugin-example e2e: 2 pass / 0 fail (20 assertions).
- `bun install --frozen-lockfile`: clean.
- `bun audit`: 0 critical, 0 high (1 pre-existing low in venue-polymarket/react deps).
- `bun run lint`: exit 0, new files clean (3 pre-existing warnings in `@stwd/db`, untouched).
- codex review: inconclusive (process hung >3min, SIGKILL per VPS-flakiness protocol).

## blast radius
no core/money-rail source changed. the existing `@stwd/shared`/`@stwd/api` exports were already sufficient, so no re-exports had to be added. diff is the two new leaf packages + 2 additive `turbo.json` entries + docs + lockfile resync (incl. a pre-existing `@stwd/sdk` 0.10.1->0.10.2 lockfile drift on develop, now corrected).

Co-authored-by: wakesync <shadow@shad0w.xyz>