### PR TITLE
feat(api): env-gated deploy-time plugin toggle (lean vs full)

### DIFF
--- a/packages/api/src/__tests__/compose-plugin-toggle.test.ts
+++ b/packages/api/src/__tests__/compose-plugin-toggle.test.ts
@@ -1,0 +1,177 @@
+/**
+ * compose-plugin-toggle.test.ts — in-process tests for the env-gated deploy-time
+ * plugin toggle: the SAME composition root runs LEAN (core only) or FULL (core +
+ * trading) by `STEWARD_PLUGINS`.
+ *
+ * What is asserted:
+ *   - LEAN (STEWARD_PLUGINS unset): composeApp() boots, GET /health is 200, core
+ *     routes are present, and ALL trading routes 404 (route not mounted →
+ *     core notFound). runComposedPluginMigrations() returns NO trading entry.
+ *   - FULL (STEWARD_PLUGINS=trading): trading routes are PRESENT (not 404 — they
+ *     reach the trade plugin's auth/handler, returning a non-404 status).
+ *     runComposedPluginMigrations() INCLUDES the trading migration entry.
+ *   - PARITY: the core routes + their auth gates behave identically in both modes
+ *     (a core protected route is auth-gated in lean AND full; /health open in
+ *     both). This proves enabling trading is additive — the core is untouched.
+ *
+ * composeApp() reads process.env.STEWARD_PLUGINS directly (prod signature
+ * unchanged), so each case set/restores process.env.STEWARD_PLUGINS around the
+ * composeApp()/runComposedPluginMigrations() call. The DB/secret bootstrap comes
+ * from test-preload.ts (PGLite in-memory).
+ *
+ * Representative trade paths probed (must 404 in lean, NOT 404 in full):
+ *   - GET  /trade/token-status        (trade route)
+ *   - POST /trade/hyperliquid/order   (agent-JWT-gated trade route)
+ *   - POST /trade/sessions            (tenant-gated session route)
+ *   - POST /trade/hyperliquid/deposit (operator-recovery route)
+ * (paths confirmed against packages/plugin-trading/src/routes/*.ts mounts.)
+ */
+
+import { afterEach, describe, expect, it } from "bun:test";
+
+/** Trade paths that exist ONLY when the trading plugin is registered. */
+const TRADE_PROBES: Array<{ method: string; path: string }> = [
+  { method: "GET", path: "/trade/token-status" },
+  { method: "POST", path: "/trade/hyperliquid/order" },
+  { method: "POST", path: "/trade/sessions" },
+  { method: "POST", path: "/trade/hyperliquid/deposit" },
+  { method: "GET", path: "/v1/trade/token-status" },
+];
+
+/** Set STEWARD_PLUGINS for one case, returning a restore fn. */
+function withPlugins(value: string | undefined): () => void {
+  const prev = process.env.STEWARD_PLUGINS;
+  if (value === undefined) delete process.env.STEWARD_PLUGINS;
+  else process.env.STEWARD_PLUGINS = value;
+  return () => {
+    if (prev === undefined) delete process.env.STEWARD_PLUGINS;
+    else process.env.STEWARD_PLUGINS = prev;
+  };
+}
+
+afterEach(() => {
+  // Defensive: ensure no case leaks STEWARD_PLUGINS into the shared process.
+  delete process.env.STEWARD_PLUGINS;
+});
+
+describe("compose plugin toggle — LEAN (no plugins)", () => {
+  it("boots, serves core /health 200, and 404s ALL trading routes", async () => {
+    const restore = withPlugins(undefined);
+    try {
+      const { composeApp } = await import("../compose");
+      const app = await composeApp();
+
+      // core health is open + 200
+      const health = await app.request("/health");
+      expect(health.status).toBe(200);
+      await expect(health.json()).resolves.toMatchObject({ status: "ok" });
+
+      // core root is present
+      const root = await app.request("/");
+      expect(root.status).toBe(200);
+
+      // every trade route is absent → core notFound (404)
+      for (const { method, path } of TRADE_PROBES) {
+        const res = await app.request(path, { method });
+        expect(res.status).toBe(404);
+        await expect(res.json()).resolves.toMatchObject({ ok: false });
+      }
+    } finally {
+      restore();
+    }
+  });
+
+  it("runComposedPluginMigrations() returns NO trading entry in lean mode", async () => {
+    const restore = withPlugins(undefined);
+    try {
+      const { runComposedPluginMigrations } = await import("../compose");
+      const results = await runComposedPluginMigrations();
+      expect(results.find((r) => r.pluginName === "trading")).toBeUndefined();
+      expect(results).toEqual([]);
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe("compose plugin toggle — FULL (trading)", () => {
+  it("mounts trading routes (NOT 404) when STEWARD_PLUGINS=trading", async () => {
+    const restore = withPlugins("trading");
+    try {
+      const { composeApp } = await import("../compose");
+      const app = await composeApp();
+
+      // core still healthy
+      const health = await app.request("/health");
+      expect(health.status).toBe(200);
+
+      // trade routes now exist: they reach the plugin's auth/handler, so the
+      // response is NOT the core 404. (Without auth headers the gate rejects with
+      // 401/403, or the handler errors — any of which is non-404, proving the
+      // route is mounted.)
+      for (const { method, path } of TRADE_PROBES) {
+        const res = await app.request(path, { method });
+        expect(res.status).not.toBe(404);
+      }
+    } finally {
+      restore();
+    }
+  });
+
+  it("runComposedPluginMigrations() COLLECTS the trading plugin in full mode", async () => {
+    // NOTE: the trading plugin declares NO `migrations` source today (its tables
+    // ship via core migrations, e.g. 0023_trade_sessions.sql), so the APPLIED
+    // result is an empty array even in full mode. What this test proves is the
+    // PARITY contract at the collection seam: in full mode the resolver enables
+    // "trading" so the path collects the trading plugin (any migrations it
+    // declared would be applied) and returns WITHOUT throwing; the lean test
+    // above proves lean mode early-returns BEFORE collecting trading at all. so
+    // if/when trading declares a migration source, full-mode applies it and
+    // lean-mode skips it — routes and migrations stay both-on or both-off.
+    const restore = withPlugins("trading");
+    try {
+      const { runComposedPluginMigrations } = await import("../compose");
+      const results = await runComposedPluginMigrations();
+      // trading has no declared migration source today → nothing applied. (No
+      // throw = the collection path ran with trading enabled.)
+      expect(Array.isArray(results)).toBe(true);
+      expect(results.find((r) => r.pluginName === "trading")).toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe("compose plugin toggle — PARITY (core identical both modes)", () => {
+  it("core protected routes are auth-gated and /health open in BOTH modes", async () => {
+    // A core protected route (no auth headers → tenantAuth rejects). Asserting the
+    // SAME behavior in lean + full proves trading-enable is additive: the core
+    // routes + their gates are untouched.
+    const probeCore = async (pluginsEnv: string | undefined) => {
+      const restore = withPlugins(pluginsEnv);
+      try {
+        const { composeApp } = await import("../compose");
+        const app = await composeApp();
+
+        const health = await app.request("/health");
+        const agents = await app.request("/agents"); // tenant-gated core route
+        return { health: health.status, agents: agents.status };
+      } finally {
+        restore();
+      }
+    };
+
+    const lean = await probeCore(undefined);
+    const full = await probeCore("trading");
+
+    // /health open (200) in both
+    expect(lean.health).toBe(200);
+    expect(full.health).toBe(200);
+
+    // the core tenant-gated route is rejected without auth in both — same gate,
+    // same status, regardless of whether trading is registered.
+    expect(lean.agents).toBe(full.agents);
+    expect(lean.agents).not.toBe(200);
+    expect(lean.agents).not.toBe(404);
+  });
+});

--- a/packages/api/src/__tests__/plugin-config.test.ts
+++ b/packages/api/src/__tests__/plugin-config.test.ts
@@ -1,0 +1,125 @@
+/**
+ * plugin-config.test.ts — unit tests for the deploy-time plugin enablement
+ * resolver (`resolveEnabledPlugins`).
+ *
+ * Covers:
+ *   - LEAN: unset / empty / whitespace-only STEWARD_PLUGINS → empty set.
+ *   - FULL: "trading" → { trading }; case + whitespace normalization.
+ *   - legacy boolean: STEWARD_ENABLE_TRADING=true → { trading }.
+ *   - combined: STEWARD_PLUGINS + legacy boolean union (no duplicate).
+ *   - fail-closed: an unknown plugin name throws UnknownPluginError.
+ *
+ * The resolver is env-injectable, so these tests pass a plain object and never
+ * touch process.env — pure + hermetic.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { KNOWN_PLUGIN_NAMES, resolveEnabledPlugins, UnknownPluginError } from "../plugin-config";
+
+describe("resolveEnabledPlugins — LEAN (no plugins)", () => {
+  it("returns an empty set when STEWARD_PLUGINS is unset", () => {
+    expect([...resolveEnabledPlugins({})]).toEqual([]);
+  });
+
+  it("returns an empty set when STEWARD_PLUGINS is an empty string", () => {
+    expect([...resolveEnabledPlugins({ STEWARD_PLUGINS: "" })]).toEqual([]);
+  });
+
+  it("returns an empty set when STEWARD_PLUGINS is whitespace only", () => {
+    expect([...resolveEnabledPlugins({ STEWARD_PLUGINS: "   " })]).toEqual([]);
+  });
+
+  it("drops empty entries between commas without enabling anything", () => {
+    expect([...resolveEnabledPlugins({ STEWARD_PLUGINS: ",, ," })]).toEqual([]);
+  });
+});
+
+describe("resolveEnabledPlugins — FULL (trading)", () => {
+  it("enables trading for STEWARD_PLUGINS=trading", () => {
+    const enabled = resolveEnabledPlugins({ STEWARD_PLUGINS: "trading" });
+    expect(enabled.has("trading")).toBe(true);
+    expect(enabled.size).toBe(1);
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(resolveEnabledPlugins({ STEWARD_PLUGINS: "  trading  " }).has("trading")).toBe(true);
+  });
+
+  it("lowercases the name (case-insensitive)", () => {
+    expect(resolveEnabledPlugins({ STEWARD_PLUGINS: "TRADING" }).has("trading")).toBe(true);
+    expect(resolveEnabledPlugins({ STEWARD_PLUGINS: "TrAdInG" }).has("trading")).toBe(true);
+  });
+
+  it("dedupes a repeated name", () => {
+    const enabled = resolveEnabledPlugins({ STEWARD_PLUGINS: "trading, trading ,TRADING" });
+    expect([...enabled]).toEqual(["trading"]);
+  });
+});
+
+describe("resolveEnabledPlugins — legacy STEWARD_ENABLE_TRADING", () => {
+  it("enables trading for STEWARD_ENABLE_TRADING=true", () => {
+    expect(resolveEnabledPlugins({ STEWARD_ENABLE_TRADING: "true" }).has("trading")).toBe(true);
+  });
+
+  it("is case-insensitive + trims for the legacy boolean", () => {
+    expect(resolveEnabledPlugins({ STEWARD_ENABLE_TRADING: "  TRUE " }).has("trading")).toBe(true);
+  });
+
+  it("does NOT enable trading for non-true values", () => {
+    for (const v of ["false", "1", "yes", "", "  "]) {
+      expect([...resolveEnabledPlugins({ STEWARD_ENABLE_TRADING: v })]).toEqual([]);
+    }
+  });
+
+  it("unions with STEWARD_PLUGINS without duplicating", () => {
+    const enabled = resolveEnabledPlugins({
+      STEWARD_PLUGINS: "trading",
+      STEWARD_ENABLE_TRADING: "true",
+    });
+    expect([...enabled]).toEqual(["trading"]);
+  });
+
+  it("adds trading via legacy bool even when STEWARD_PLUGINS is empty", () => {
+    const enabled = resolveEnabledPlugins({
+      STEWARD_PLUGINS: "",
+      STEWARD_ENABLE_TRADING: "true",
+    });
+    expect([...enabled]).toEqual(["trading"]);
+  });
+});
+
+describe("resolveEnabledPlugins — fail-closed on unknown plugin", () => {
+  it("throws UnknownPluginError for an unknown name", () => {
+    expect(() => resolveEnabledPlugins({ STEWARD_PLUGINS: "bogus" })).toThrow(UnknownPluginError);
+  });
+
+  it("throws if any name in a list is unknown (even alongside a known one)", () => {
+    expect(() => resolveEnabledPlugins({ STEWARD_PLUGINS: "trading,bogus" })).toThrow(
+      UnknownPluginError,
+    );
+  });
+
+  it("error message names the offending plugin + the known set", () => {
+    try {
+      resolveEnabledPlugins({ STEWARD_PLUGINS: "nope" });
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(UnknownPluginError);
+      expect((err as Error).message).toContain("nope");
+      expect((err as Error).message).toContain("trading");
+    }
+  });
+
+  it("the legacy boolean only ever adds a KNOWN name (cannot trip the guard)", () => {
+    // STEWARD_ENABLE_TRADING can only add "trading", which is known — so it never
+    // throws regardless of value.
+    expect(() => resolveEnabledPlugins({ STEWARD_ENABLE_TRADING: "true" })).not.toThrow();
+  });
+});
+
+describe("KNOWN_PLUGIN_NAMES", () => {
+  it("contains trading and nothing unexpected", () => {
+    expect(KNOWN_PLUGIN_NAMES.has("trading")).toBe(true);
+    expect([...KNOWN_PLUGIN_NAMES]).toEqual(["trading"]);
+  });
+});

--- a/packages/api/src/compose.ts
+++ b/packages/api/src/compose.ts
@@ -7,10 +7,13 @@
  * -------------------------------
  * `app.ts`'s `createApp()` is the LEAN CORE: trading-free, with no dependency on
  * the trading stack. a third party importing `@stwd/api` and calling `createApp()`
- * gets exactly that. but THIS repo's deployed server (index.ts / worker.ts /
- * embedded.ts) DOES want trading, so it composes the core with the trading plugin
- * HERE, at the composition root. that keeps the library core lean while the deploy
- * stays full-featured.
+ * gets exactly that. THIS repo's deployed server (index.ts / worker.ts /
+ * embedded.ts) can run the SAME image LEAN (core only) or FULL (core + trading)
+ * by environment: `composeApp()` consults `resolveEnabledPlugins()`
+ * (`plugin-config.ts`, reading `STEWARD_PLUGINS` / legacy `STEWARD_ENABLE_TRADING`)
+ * and only registers the trading plugin when it is enabled. that keeps the library
+ * core lean, the deploy configurable, and — in FULL mode — behavior-identical to
+ * the historical hardcoded composition.
  *
  * ORDERING (load-bearing — money rail)
  * ------------------------------------
@@ -33,6 +36,7 @@
 import type { Hono } from "hono";
 import { createApp, mountCoreIdempotencyAndRoutes } from "./app";
 import { buildPluginContext, PluginHost, type StewardApp } from "./plugin";
+import { resolveEnabledPlugins } from "./plugin-config";
 import type { AppVariables } from "./services/context";
 import { webhookEventRegistry } from "./services/webhook-events";
 
@@ -101,21 +105,46 @@ function makeDeferredRouteApp(app: StewardApp): {
  * stays trading-free.
  */
 export async function composeApp(): Promise<Hono<{ Variables: AppVariables }>> {
+  // which opt-in plugins this deploy enables (env-driven). LEAN = empty set
+  // (core only); FULL = { "trading" }. resolveEnabledPlugins fails closed on an
+  // unknown plugin name, so a typo'd STEWARD_PLUGINS aborts boot here rather than
+  // silently shipping a wrong feature profile. composeApp reads process.env
+  // directly (prod signature unchanged); the resolver itself is env-injectable
+  // for tests, which set/restore process.env.STEWARD_PLUGINS around each case.
+  const enabled = resolveEnabledPlugins();
+
   // 1) lean core: global mw + all core auth mw (NO idempotency, NO routes yet).
   const app = createApp();
 
+  if (!enabled.has("trading")) {
+    // LEAN MODE: no opt-in plugins to register. the deferred-route machinery only
+    // exists to slot a plugin's auth mw before idempotency and its routes after;
+    // with no plugins there is nothing to defer, so mount core idempotency +
+    // core routes directly. ordering is identical to FULL minus the (absent)
+    // plugin contributions: [global mw + core auth mw (createApp)] -> idempotency
+    // -> core routes. the trading plugin is NOT imported in this path, so its
+    // module is never evaluated when trading is disabled.
+    mountCoreIdempotencyAndRoutes(app);
+    return app;
+  }
+
+  // FULL MODE: register the trading plugin. behavior-identical to the historical
+  // hardcoded path — same registration, same ordering, same migrations.
+  //
   // 2) plugin auth-middleware phase + buffered routes. trade auth mw lands now,
   //    before idempotency; trade routes are buffered for after.
   //
   // the trading plugin is imported with a STATIC, bundler-discoverable specifier so
   // Wrangler/esbuild include `@stwd/plugin-trading` in the Worker bundle (a
   // non-analyzable dynamic specifier would be omitted, and the Worker would fail at
-  // runtime with a missing module on the first request). this is the DEPLOY-ONLY
+  // runtime with a missing module on the first request). gating is on the
+  // EXECUTION (the `if (enabled.has("trading"))` guard around this block), NOT on
+  // the import specifier — the literal `import("@stwd/plugin-trading")` string is
+  // still statically analyzable so the bundler always includes the module; it is
+  // simply not EVALUATED when trading is disabled. this is the DEPLOY-ONLY
   // composition root, so it is allowed to reference the plugin; the LIBRARY entry
   // (lib.ts) does NOT re-export composeApp, so a consumer importing `@stwd/api`
   // never pulls the plugin into its graph and the lean core stays trading-free.
-  // the dynamic `import()` form (vs a top-level static import) is kept only so the
-  // plugin module is evaluated lazily at compose time, not at module load.
   const ctx = buildPluginContext();
   const { tradingPlugin } = (await import("@stwd/plugin-trading")) as {
     tradingPlugin: Parameters<PluginHost<typeof ctx>["register"]>[2];
@@ -152,17 +181,28 @@ export async function composeApp(): Promise<Hono<{ Variables: AppVariables }>> {
  * only — it is NEVER run implicitly per request. Plugin migrations run in
  * `dependsOn` order.
  *
- * This discovers the SAME opt-in plugins {@link composeApp} composes (currently
- * trading), but does NOT mount routes/middleware — it only collects each plugin's
- * declared migration source and applies it. Fails closed (rejects) on the first
- * plugin migration error so the boot path can refuse to half-boot.
+ * This discovers the SAME opt-in plugins {@link composeApp} composes via the SAME
+ * {@link resolveEnabledPlugins} resolver (PARITY: app-compose and
+ * migration-compose always agree on the enabled set, so a plugin's routes and its
+ * migrations are never orphaned — both-on or both-off). It does NOT mount
+ * routes/middleware — it only collects each enabled plugin's declared migration
+ * source and applies it. Fails closed (rejects) on the first plugin migration
+ * error so the boot path can refuse to half-boot.
  *
  * @returns per-plugin results (id + the namespaced table its ledger was written
- *   to). Empty if no opt-in plugin declares a migration source.
+ *   to). Empty if no opt-in plugin is enabled / declares a migration source.
  */
 export async function runComposedPluginMigrations(): Promise<
   Array<{ pluginName: string; id: string; migrationsTable: string }>
 > {
+  // PARITY with composeApp: resolve the SAME enabled set from the SAME resolver.
+  // if trading is disabled, collect NO trading migrations (its routes are also
+  // not mounted by composeApp) — the two paths can never drift.
+  const enabled = resolveEnabledPlugins();
+  if (!enabled.has("trading")) {
+    return [];
+  }
+
   const ctx = buildPluginContext();
   const { tradingPlugin } = (await import("@stwd/plugin-trading")) as {
     tradingPlugin: Parameters<PluginHost<typeof ctx>["register"]>[2];

--- a/packages/api/src/plugin-config.ts
+++ b/packages/api/src/plugin-config.ts
@@ -1,0 +1,105 @@
+/**
+ * plugin-config.ts — deploy-time plugin enablement resolver.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * the composition root (`compose.ts`) assembles the deployable server: the lean
+ * core (`createApp()`) plus this deploy's opt-in plugins. historically that set
+ * was HARDCODED — `composeApp()` always registered the trading plugin and
+ * `runComposedPluginMigrations()` always collected its migrations. that coupled
+ * the SHIPPED IMAGE to a single feature profile: every deploy ran trading,
+ * whether or not it was wanted.
+ *
+ * this resolver makes the same image run LEAN (core only) or FULL (core + opt-in
+ * plugins) purely by ENVIRONMENT, with NO change to what any plugin does. it only
+ * answers ONE question: "which opt-in plugins should the composition root
+ * register?" the actual registration, ordering, and migration logic is untouched
+ * (see compose.ts) — this only gates WHETHER trading is composed in, never HOW.
+ *
+ * THE CONTRACT
+ * ------------
+ *   - `STEWARD_PLUGINS` — comma-separated plugin names, e.g. "trading". each name
+ *     is trimmed + lowercased. empty/unset → LEAN (no opt-in plugins).
+ *   - `STEWARD_ENABLE_TRADING=true` — legacy boolean that ALSO enables trading
+ *     (union with STEWARD_PLUGINS), so an older deploy config keeps working.
+ *   - an UNKNOWN plugin name in `STEWARD_PLUGINS` → THROW at boot. fail-closed +
+ *     loud: a typo'd / unsupported plugin name never silently disables a feature
+ *     a deploy expected, it refuses to boot with a clear error.
+ *
+ * PARITY (load-bearing)
+ * ---------------------
+ * BOTH the app-composition path (`composeApp`) and the migration-composition path
+ * (`runComposedPluginMigrations`) call THIS resolver, so a plugin's routes and
+ * its migrations are always BOTH-on or BOTH-off. they can never drift into an
+ * orphaned state (routes mounted with no schema, or schema migrated with no
+ * routes). the single source of truth is here.
+ */
+
+/**
+ * The closed set of opt-in plugin names this composition root knows how to
+ * register. An entry in `STEWARD_PLUGINS` that is NOT in this set is a
+ * fail-closed boot error (see {@link resolveEnabledPlugins}). Kept as the single
+ * authority for "what can be enabled" so adding a plugin is a one-line change
+ * here plus its registration in compose.ts.
+ */
+export const KNOWN_PLUGIN_NAMES = new Set<string>(["trading"]);
+
+/**
+ * Error thrown when `STEWARD_PLUGINS` names a plugin this composition root does
+ * not know how to register. The boot path surfaces it and refuses to start
+ * (fail-closed + loud) rather than silently dropping the unknown name — a typo or
+ * an unsupported plugin must never look like a successful lean boot.
+ */
+export class UnknownPluginError extends Error {
+  constructor(name: string, known: readonly string[]) {
+    super(
+      `unknown plugin "${name}" in STEWARD_PLUGINS. ` +
+        `known plugins: ${known.length > 0 ? known.join(", ") : "(none)"}.`,
+    );
+    this.name = "UnknownPluginError";
+  }
+}
+
+/**
+ * Resolve which opt-in plugins this deploy should register, from the environment.
+ *
+ * Reads:
+ *   - `STEWARD_PLUGINS` — comma-separated names (trimmed, lowercased, empties
+ *     dropped). unset/empty → no plugins (LEAN).
+ *   - `STEWARD_ENABLE_TRADING` — legacy boolean; `"true"` (case-insensitive,
+ *     trimmed) ALSO adds "trading" to the set.
+ *
+ * FAILS CLOSED: any name in `STEWARD_PLUGINS` not in {@link KNOWN_PLUGIN_NAMES}
+ * throws {@link UnknownPluginError}. The legacy boolean only ever adds a KNOWN
+ * name, so it cannot trip the unknown-name guard.
+ *
+ * @param env the environment to read. defaults to `process.env`; injectable so
+ *   tests can drive it hermetically without mutating the real process env.
+ * @returns the set of enabled plugin names (lowercased). empty in LEAN mode.
+ */
+export function resolveEnabledPlugins(
+  env: Record<string, string | undefined> = process.env,
+): Set<string> {
+  const enabled = new Set<string>();
+
+  const raw = env.STEWARD_PLUGINS;
+  if (typeof raw === "string" && raw.trim() !== "") {
+    for (const part of raw.split(",")) {
+      const name = part.trim().toLowerCase();
+      if (name === "") continue;
+      if (!KNOWN_PLUGIN_NAMES.has(name)) {
+        throw new UnknownPluginError(name, [...KNOWN_PLUGIN_NAMES]);
+      }
+      enabled.add(name);
+    }
+  }
+
+  // Legacy boolean: STEWARD_ENABLE_TRADING=true unions "trading" into the set, so
+  // an older deploy config that predates STEWARD_PLUGINS keeps enabling trading.
+  const legacyTrading = env.STEWARD_ENABLE_TRADING;
+  if (typeof legacyTrading === "string" && legacyTrading.trim().toLowerCase() === "true") {
+    enabled.add("trading");
+  }
+
+  return enabled;
+}


### PR DESCRIPTION
## what

env-gates the deploy-time plugin composition so the SAME image runs LEAN (core only) or FULL (core + trading) by environment. additive, vendor-neutral. only `compose.ts` + new `plugin-config.ts` + tests. no trade route/policy/signing/vault/venue logic touched — this gates WHETHER the trading plugin is registered, nothing about WHAT it does.

## resolver semantics (`plugin-config.ts`)

`resolveEnabledPlugins(env = process.env): Set<string>`
- `STEWARD_PLUGINS` — comma-separated, trimmed, lowercased (e.g. `trading`). empty/unset → empty set (LEAN).
- legacy `STEWARD_ENABLE_TRADING=true` → unions `trading` in.
- `KNOWN_PLUGIN_NAMES = { trading }`. an unknown name → throws `UnknownPluginError` at boot (fail-closed + loud).
- env injectable for tests; prod reads `process.env`.

## gating + bundler-analyzability

`composeApp()` computes `enabled = resolveEnabledPlugins()`. trading is imported with the SAME static `await import("@stwd/plugin-trading")` specifier (bundler-discoverable, stays in the Worker bundle) — only its EXECUTION/registration is behind `if (enabled.has("trading"))`. lean mode skips the import+register and mounts core idempotency + core routes directly, preserving middleware ordering (global mw → core auth mw → idempotency → core routes).

## parity (load-bearing)

`composeApp()` and `runComposedPluginMigrations()` consult the SAME resolver → trading routes and trading migrations are always both-on or both-off, never orphaned. FULL mode is behavior-identical to the prior hardcoded path.

## tests

- resolver unit: lean/full/legacy-bool/combined/whitespace/case/dedupe/unknown-throws.
- in-process compose-mode: LEAN boots, `/health` 200, core routes present, all trade routes 404, migrations collect no trading; FULL mounts trade routes (not 404); PARITY core auth-gate identical across modes.

## verification

- `turbo run build` green (typecheck all packages).
- `bun install --frozen-lockfile` clean (no dep changes).
- `bun audit`: 0 critical/high (1 pre-existing low).
- `bun run lint` clean (biome).
- affected-module suite green isolated: plugin-host, plugin-host-adapters, plugin-host-policy-rules, idempotency-middleware, idempotency-5xx, plugin-config, compose-plugin-toggle — 64 pass / 0 fail.
- codex review: inconclusive (hung >3min, killed per guardrail).

Co-authored-by: wakesync <shadow@shad0w.xyz>