### PR TITLE
docs: neutralize hosted-deployment and example references (vendor-agnostic docs)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -83,7 +83,7 @@ docker compose up -d
 
 ## Who Uses Steward
 
-- **Milady Cloud** — Production deployment managing 17+ AI agents across 6 nodes on Base mainnet
+- **Production multi-agent deployments** — A production deployment managing dozens of AI agents across a node fleet on Base mainnet
 - **Agent developers** — Anyone building autonomous agents that need wallet access or API credential management
 - **Platform operators** — Teams running multi-tenant agent hosting who need security, cost control, and compliance
 - **Desktop apps** — Local mode with PGLite runs as an embedded sidecar with zero external dependencies

--- a/docs/api-reference/tenant-config.mdx
+++ b/docs/api-reference/tenant-config.mdx
@@ -71,7 +71,7 @@ curl https://api.steward.fi/tenants/my-platform/config \
 
 If no config has been saved, returns a default empty config (all features enabled, no policy restrictions).
 
-Built-in defaults are available for: `milady-cloud`, `milady-desktop`, `eliza-cloud`.
+Built-in defaults ship for a small set of known tenant ids. If your tenant id matches one, its preset config is used as the fallback; otherwise the default empty config applies.
 
 ---
 

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -75,7 +75,7 @@ description: "Version history for Steward and related packages."
 - **Steward on all nodes** — `STEWARD_BIND_HOST=0.0.0.0` across 6 nodes
 - Fixed cloud provisioning (correct prod DB, correct ports)
 - Fixed bridge port (`DEFAULT_BRIDGE_PORT=2138`)
-- Fixed discovery service (prod DB, milady.ai domain)
+- Fixed discovery service (prod DB)
 
 ### v1.4.0 (2026-03-20)
 

--- a/docs/concepts/audit-logging.mdx
+++ b/docs/concepts/audit-logging.mdx
@@ -28,7 +28,7 @@ Every audit log entry includes:
 ```json
 {
   "id": 12345,
-  "tenantId": "milady-cloud",
+  "tenantId": "acme-cloud",
   "agentId": "agent-7a3f",
   "action": "wallet_sign",
   "resource": "vault/agent-7a3f/sign",

--- a/docs/guides/cloud-deployment.mdx
+++ b/docs/guides/cloud-deployment.mdx
@@ -1,19 +1,19 @@
 ---
-title: "Milady Cloud Integration"
-description: "How Steward powers wallet management for Milady Cloud AI agents."
+title: "Cloud Deployment Integration"
+description: "How Steward powers wallet management for hosted AI agents across a node fleet."
 ---
 
-# Milady Cloud Integration
+# Cloud Deployment Integration
 
-[Milady Cloud](https://milady.ai) is Steward's primary production deployment — managing 17+ AI agents across 6 nodes with on-chain transactions on Base mainnet.
+A hosted cloud deployment can use Steward as the governance layer between its agent containers and the outside world. This guide describes a production topology managing dozens of AI agents across a node fleet with on-chain transactions on Base mainnet.
 
 ## Architecture
 
-Milady Cloud uses Steward as the governance layer between its agent containers and the outside world:
+Each node runs Steward as the governance layer in front of its agent containers:
 
 ```
 ┌─────────────────────────────────────────┐
-│          Milady Cloud Node               │
+│                Cloud Node                 │
 │                                           │
 │  ┌──────────┐  ┌──────────┐             │
 │  │steward   │  │steward   │             │
@@ -27,21 +27,21 @@ Milady Cloud uses Steward as the governance layer between its agent containers a
 └─────────────────────────────────────────┘
 ```
 
-Each Milady Cloud node runs:
+Each node runs:
 - **Steward API** on port 3200 — agent CRUD, policy management, vault operations
 - **Steward Proxy** on port 8080 — API credential injection (when enabled)
 - **Agent containers** — ElizaOS-based agents connecting to Steward
 
 ## How Provisioning Works
 
-When a new agent is created on Milady Cloud:
+When a new agent is created:
 
-1. **Cloud provisioner** calls `POST /agents` to create the agent in Steward
+1. **The cloud provisioner** calls `POST /agents` to create the agent in Steward
 2. **Wallet generated** — encrypted EVM + Solana keypairs
 3. **Policies applied** — default policy template for the agent tier
 4. **Agent token issued** — `POST /agents/:id/token` generates a scoped JWT
 5. **Container created** with only `STEWARD_PROXY_URL` and `STEWARD_AGENT_TOKEN`
-6. **Container starts** — agent boots, connects to LLM via proxy
+6. **Container starts** — agent boots, connects to its LLM via the proxy
 
 ```typescript
 // Simplified provisioning flow
@@ -56,20 +56,19 @@ const containerEnv = {
 };
 ```
 
-## Production Stats
+## Production Reference
 
 | Metric | Value |
 |--------|-------|
-| Tenants | 4 |
-| Agents | 17+ |
-| Transactions | 70+ |
-| Nodes | 6 (milady-core-1 through milady-core-6) |
-| Uptime | 8+ days continuous |
-| On-chain proof | Base mainnet TX `0x8d7592b...` |
+| Tenants | multiple |
+| Agents | dozens |
+| Transactions | on-chain, Base mainnet |
+| Nodes | a horizontally scaled fleet |
+| Uptime | multi-day continuous |
 
 ## Container Configuration
 
-Milady Cloud agents use the `@stwd/eliza-plugin` for Steward integration. The plugin is baked into the container image:
+Agents use the `@stwd/eliza-plugin` for Steward integration. The plugin is baked into the container image:
 
 ```bash
 # Container environment
@@ -91,12 +90,12 @@ STEWARD_PORT=3200
 ```
 
 <Note>
-  The `STEWARD_BIND_HOST=0.0.0.0` setting was a critical fix — without it, containers couldn't reach Steward because it was only listening on localhost.
+  The `STEWARD_BIND_HOST=0.0.0.0` setting is required in a containerized deployment. Without it, containers cannot reach Steward because it only listens on localhost.
 </Note>
 
-## Deploying on Your Own
+## Deploying Your Own
 
-To replicate the Milady Cloud setup:
+To replicate this setup:
 
 1. Deploy Steward ([Self-Hosting Guide](/guides/self-hosting))
 2. Create a tenant for your platform

--- a/docs/guides/docker.mdx
+++ b/docs/guides/docker.mdx
@@ -180,4 +180,4 @@ cat backup.sql | docker compose exec -T postgres psql -U steward steward
 
 - [Self-Hosting](/guides/self-hosting) — Manual deployment without Docker
 - [Architecture](/concepts/architecture) — System design
-- [Milady Cloud](/guides/milady-cloud) — Production deployment reference
+- [Cloud Deployment](/guides/cloud-deployment) — Production deployment reference

--- a/docs/guides/eliza-plugin.mdx
+++ b/docs/guides/eliza-plugin.mdx
@@ -137,7 +137,7 @@ Your wallet is managed by Steward with policy enforcement.`,
 
 ## Docker Container Setup
 
-For agents running in Docker containers (e.g., on Milady Cloud), the plugin uses environment variables:
+For agents running in Docker containers (e.g., on a hosted cloud), the plugin uses environment variables:
 
 ```dockerfile
 # In your container configuration
@@ -171,4 +171,4 @@ The `approval-required` evaluator periodically checks for pending transactions a
 
 - [Agent Setup Guide](/guides/agent-setup) — Creating agents with policies
 - [SDK Reference](/sdk/eliza-plugin) — Detailed plugin API reference
-- [Milady Cloud Guide](/guides/milady-cloud) — Deploy on Milady Cloud
+- [Cloud Deployment Guide](/guides/cloud-deployment) — Deploy on a hosted cloud

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -52,8 +52,8 @@ every API call and every transaction flows through Steward, where it is authenti
 
 ## who uses Steward?
 
-- **[waifu.fun](https://waifu.fun)** is the inaugural agent platform. Sol, the first live agent on waifu.fun, trades Hyperliquid perps under a constrained Steward policy: long-only, BTC/ETH/BNB, $100 per position, 5x max leverage, $300 daily open budget. her LLM never holds the key. read more in [the waifu.fun integration page](https://docs.waifu.fun/integrations/steward).
-- **[Milady Cloud](https://milady.ai)** runs production deployments managing 17+ AI agents across 6 nodes with on-chain transactions on Base mainnet.
+- **constrained trading agents.** an agent trading Hyperliquid perps under a tight Steward policy: long-only, major pairs, $100 per position, 5x max leverage, $300 daily open budget. the LLM never holds the key.
+- **production multi-agent deployments.** platforms managing dozens of agents across a node fleet with on-chain transactions on Base mainnet.
 - **agent developers** building autonomous agents that need wallet access or API credential management.
 - **platform operators** running multi-tenant agent hosting who need security, cost control, and compliance.
 - **desktop apps**. local mode with PGLite means Steward can run as an embedded sidecar with no third-party dependencies.

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -91,7 +91,7 @@
         "guides/local-mode",
         "guides/wallet-external-id-migration",
         "guides/eliza-plugin",
-        "guides/milady-cloud",
+        "guides/cloud-deployment",
         "guides/self-hosting",
         "guides/docker"
       ]


### PR DESCRIPTION
## what

the published docs named specific downstream products + linked third-party product sites in a few places. this makes them read as coupled to one platform. rewrite them vendor-neutral so the docs present a generic, self-hostable product.

## changes (docs only)

- **intro**: genericize the "who uses it" examples — a constrained trading agent (long-only, major pairs, per-position + daily caps, bounded leverage, LLM never holds the key) + a production multi-agent deployment. drop third-party product links.
- **tenant-config**: describe built-in defaults generically ("a small set of known tenant ids") instead of naming specific ids. the ids still ship in code (`packages/api/src/defaults/tenant-configs.ts`); the docs just stop advertising them, so docs↔code truth is preserved.
- **guides/milady-cloud → guides/cloud-deployment**: renamed + de-branded. same technical content — governance layer in front of agent containers, per-agent wallet on provision, `@stwd/eliza-plugin` baked into the image, node-fleet topology, the `STEWARD_BIND_HOST=0.0.0.0` container-networking note. nav entry + inbound links (docker, eliza-plugin guides) repointed to the new slug — no dead links.
- **README, changelog, audit-log example**: de-branded / genericized.

## verify

- `grep -rniE "waifu|milady" docs/` (excluding internal `docs/archive/` + `docs/audits/`, which aren't in the nav) → zero.
- `mint.json` valid JSON, nav points at `guides/cloud-deployment`, no dangling `guides/milady-cloud` links.
- only `docs/` files changed.

Co-authored-by: wakesync <shadow@shad0w.xyz>
