### PR TITLE
feat(proxy-client): agent-side signed proxy client + deploy runbook + e2e injection proof

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -246,6 +246,19 @@
         "typescript": "^5",
       },
     },
+    "packages/proxy-client": {
+      "name": "@stwd/proxy-client",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@stwd/auth": "workspace:*",
+        "@stwd/db": "workspace:*",
+        "@stwd/proxy": "workspace:*",
+        "@stwd/vault": "workspace:*",
+        "@types/bun": "latest",
+        "hono": "^4.12.18",
+        "typescript": "^5.8.0",
+      },
+    },
     "packages/react": {
       "name": "@stwd/react",
       "version": "0.10.0",
@@ -1595,6 +1608,8 @@
     "@stwd/policy-engine": ["@stwd/policy-engine@workspace:packages/policy-engine"],
 
     "@stwd/proxy": ["@stwd/proxy@workspace:packages/proxy"],
+
+    "@stwd/proxy-client": ["@stwd/proxy-client@workspace:packages/proxy-client"],
 
     "@stwd/react": ["@stwd/react@workspace:packages/react"],
 

--- a/docs/deploy/railway-lean-full.md
+++ b/docs/deploy/railway-lean-full.md
@@ -286,3 +286,113 @@ and isolated, so it does not corrupt the core schema.
 
 that single column of differences is the entire lean-vs-full contract. the image
 is byte-identical.
+
+---
+
+## 8. the proxy service (separate process, same image)
+
+the **proxy gateway** (`packages/proxy/src/index.ts`) is a SEPARATE process from
+the API. it sits between agent containers and third-party APIs: agents send it a
+request with a scoped JWT (and, in prod, an HMAC request signature), it matches a
+credential route, decrypts the tenant's secret, injects it as a header, forwards
+upstream, and scrubs the credential from the response. it runs the SAME
+`ghcr.io/steward-fi/steward:<tag>` image as the API — only the start command and
+env differ.
+
+> agents talk to the proxy via the `@stwd/proxy-client` client (`proxyUrl` +
+> `token` + `signingSecret`); it computes the signature/idempotency headers the
+> proxy expects. see `packages/proxy-client/README.md`.
+
+### 8.1 start command override
+
+the API image's default `CMD` runs the API. for the proxy service, override the
+start command:
+
+```
+bun packages/proxy/src/index.ts
+```
+
+on Railway: set the service's **Custom Start Command** to the line above. nothing
+else in the image changes.
+
+### 8.2 required-env checklist (proxy service)
+
+read directly from proxy source: `packages/proxy/src/index.ts`,
+`packages/proxy/src/config.ts`, `packages/proxy/src/middleware/auth.ts`,
+`packages/proxy/src/middleware/redis-enforcement.ts`, and
+`packages/vault/src/keystore.ts` (the decrypt path).
+
+| var | severity | why | source |
+|-----|----------|-----|--------|
+| `NODE_ENV=production` | required | turns OFF dev-secret fallbacks AND turns ON the mandatory request-signature check + Redis fail-closed. this is the single flag that hardens the proxy | `packages/proxy/src/middleware/auth.ts` (`proxyRequestSignatureRequired`), `redis-enforcement.ts` |
+| `STEWARD_BIND_HOST=0.0.0.0` | required on Railway | Bun binds `0.0.0.0` by default, but set it explicitly so Railway's proxy can reach the container | Bun.serve default; mirror the API service |
+| `STEWARD_PROXY_PORT` | required | listen port for the proxy (default `8080`). point Railway's health check + target port here | `packages/proxy/src/config.ts` (`PROXY_PORT`), `index.ts` |
+| `DATABASE_URL` | **[boot-fatal]** | same Postgres as the API. `index.ts` exits(1) if unset. reads `secret_routes` + `secrets`, writes `proxy_audit_log`. use the SAME database as the API service | `packages/proxy/src/index.ts` (`getDatabaseUrl`) |
+| `STEWARD_JWT_SECRET` | **[boot-fatal in prod]** | `validateJwtSecretEnv()` runs at boot; verifies the agent bearer tokens. MUST equal the API's value (same tokens) | `packages/proxy/src/index.ts`, `@stwd/auth` |
+| `STEWARD_MASTER_PASSWORD` | **[boot-fatal / functional]** | derives the vault key that decrypts injected secrets. MUST equal the API's value or decryption fails | `packages/proxy/src/handlers/proxy.ts` (`getSecretVault`), `packages/vault/src/keystore.ts` |
+| `STEWARD_KDF_SALT` | **[boot-fatal in prod]** | per-deploy KDF salt for vault key derivation; `keystore.ts` THROWS in production if unset (≥32 hex chars). MUST equal the API's value | `packages/vault/src/keystore.ts` |
+| `STEWARD_PROXY_REQUEST_SIGNING_SECRET` (or `_SECRETS` for rotation, plural = comma-separated) | required in prod | HMAC secret the proxy verifies the agent's `X-Steward-Signature` against. without it, prod requests get 500 (`Proxy request signing is not configured`). the agent's `@stwd/proxy-client` must be given the SAME secret | `packages/proxy/src/middleware/auth.ts` (`configuredProxySigningSecrets`) |
+| `REDIS_URL` | required in prod (fail-closed) | rate limit + spend tracking + idempotency replay store. in prod the proxy FAILS CLOSED when Redis is configured-but-unreachable. LLM-host spend tracking only runs when Redis is available | `packages/proxy/src/middleware/redis-enforcement.ts` |
+
+recommended-but-optional (proxy service):
+
+| var | why | source |
+|-----|-----|--------|
+| `STEWARD_PROXY_ALLOWED_HOSTS` | comma-separated extra hosts for `/proxy/<host>/...` direct proxying, beyond the built-in aliases. `api.openai.com` + `api.anthropic.com` (and the birdeye/coingecko/helius aliases) are ALREADY allowed by default; set this only to add hosts | `packages/proxy/src/config.ts` (`DEFAULT_ALIASES`), `handlers/alias.ts` |
+| `STEWARD_SECRET_ROUTE_ALLOWED_HOSTS` | extra hosts a `secret_route` may target, beyond the vault default allowlist (openai/anthropic/birdeye/coingecko/helius already default-allowed) | `packages/vault/src/secret-vault.ts` |
+| `REDIS_REQUIRED=true` | force Redis to be mandatory even outside prod | `redis-enforcement.ts` |
+| `STEWARD_PROXY_UPSTREAM_TIMEOUT_MS` / `STEWARD_PROXY_RESPONSE_BYTES` / `STEWARD_PROXY_STREAM_DURATION_MS` | upstream timeout + response-size + stream-duration caps | `packages/proxy/src/handlers/proxy.ts` |
+| `STEWARD_PROXY_MAX_IN_FLIGHT_PER_AGENT` / `_PER_TENANT` | in-flight concurrency caps (overflow → 429) | `packages/proxy/src/handlers/proxy.ts` |
+
+**leave UNSET in prod (break-glass / weakens security):**
+`STEWARD_PROXY_ALLOW_UNSIGNED_REQUESTS` (prod ignores it and still requires
+signatures, but do not set it), `STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE=false`
+(prod forces it on regardless), `STEWARD_ALLOW_PROXY_REDIS_SOFT_FAIL`,
+`STEWARD_ALLOW_BROAD_SECRET_ROUTES`, `STEWARD_PGLITE_MEMORY`.
+
+### 8.3 master-password co-location tradeoff (honest note)
+
+the proxy holds `STEWARD_MASTER_PASSWORD` + `STEWARD_KDF_SALT` because it
+decrypts injected secrets itself. that means the proxy and the API currently
+share the same encryption trust domain: a full compromise of either process can
+decrypt tenant secrets. this is acceptable for now (both run the same image, same
+operator, same VPC) but it is NOT isolation — a future hardening step is to move
+decryption behind a dedicated KMS/enclave so neither the API nor the proxy holds
+the raw master password. document this in the threat model when the split lands.
+
+the proxy's own defense-in-depth (independent of that tradeoff): mandatory JWT
+`api:proxy` scope, HMAC proof-of-possession request signatures (prod), an
+idempotency-key requirement on mutating methods, a host allowlist on both the
+route and the resolver, SSRF guards on outbound DNS, and response scrubbing that
+returns 502 if the upstream ever reflects the injected credential.
+
+### 8.4 health + smoke
+
+the proxy exposes an unauthenticated `GET /health` returning
+`{ ok, service: "steward-proxy", version, aliases }`. point Railway's health
+check at `/health` on `STEWARD_PROXY_PORT`.
+
+after deploy:
+
+```sh
+# health 200 + unauthenticated request -> 401 (auth guard live)
+scripts/deploy/smoke-proxy.sh https://<proxy-host> <api-proxy-scoped-jwt>
+
+# optional: also exercise a signed request path (needs the signing secret)
+STEWARD_PROXY_REQUEST_SIGNING_SECRET=<secret> \
+  scripts/deploy/smoke-proxy.sh --signed https://<proxy-host> <jwt> <tenantId> <agentId>
+```
+
+### 8.5 rollback (proxy service)
+
+the proxy is **stateless** (all state is in Postgres/Redis). rollback = redeploy
+the previous good image tag via the same `scripts/railway-deploy.sh <tag>` /
+Railway native rollback, exactly like the API service (§6, levers 2 and 3). the
+mode-flip lever (§6 lever 1) does not apply — the proxy has no plugin toggle. env
+is unchanged across a rollback, so it comes back in the same posture. after
+rollback: re-run `smoke-proxy.sh` and confirm `/health` is 200.
+
+> keep `STEWARD_MASTER_PASSWORD` / `STEWARD_KDF_SALT` / `STEWARD_JWT_SECRET`
+> IDENTICAL between the API and proxy services and STABLE across rollbacks —
+> rotating them requires re-encrypting vault keys (master/salt) or reissuing
+> tokens (jwt).

--- a/packages/proxy-client/README.md
+++ b/packages/proxy-client/README.md
@@ -1,0 +1,60 @@
+# @stwd/proxy-client
+
+Agent-side client for the Steward proxy.
+
+The proxy holds the upstream API credentials. Agents never see them: they send
+requests to the proxy with a scoped JWT and (in production) an HMAC
+proof-of-possession signature. The proxy authenticates, matches a credential
+route, decrypts the secret, injects it as the configured header, forwards
+upstream, and scrubs the credential from the response.
+
+This package is a thin, dependency-light `fetch` wrapper that computes exactly
+the headers the proxy expects.
+
+## Usage
+
+```ts
+import { StewardProxyClient } from "@stwd/proxy-client";
+
+const client = new StewardProxyClient({
+  proxyUrl: "https://proxy.example.com",
+  token: agentJwt,            // api:proxy-scoped JWT
+  signingSecret: signingKey,  // required when the proxy enforces request signing
+  tenantId,                   // bound into the signature (must match JWT claims)
+  agentId,
+});
+
+// Generic signed request. The path is proxy-relative (alias or /proxy/<host>/...).
+const res = await client.fetch("/openai/v1/chat/completions", {
+  method: "POST",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify({ model: "gpt-4o-mini", messages: [{ role: "user", content: "hi" }] }),
+});
+
+// Liveness probe (unauthenticated).
+const health = await client.proxyHealth();
+```
+
+## What the client does
+
+- attaches `Authorization: Bearer <token>`
+- auto-generates an `Idempotency-Key` (UUID) for `POST`/`PUT`/`PATCH`/`DELETE`
+  when the caller did not supply one
+- when `signingSecret` is set, computes `X-Steward-Signature` +
+  `X-Steward-Request-Timestamp` using the proxy's canonical form
+
+## Signing
+
+The canonical request form and HMAC live in `src/signature.ts`. They mirror the
+proxy verifier (`@stwd/proxy`, `middleware/auth.ts`). Golden-vector tests in
+`src/__tests__/signature.test.ts` sign identical inputs with both this client
+and the proxy's own signer and assert byte-equality, so the two cannot drift.
+
+For signed requests, pass a pre-serialized body (`string` / `Uint8Array` /
+`ArrayBuffer`). Serialize objects with `JSON.stringify` before calling.
+
+## Notes
+
+- This is a generic HTTP client by design. There is no vendor-specific helper.
+- `requireHttps` defaults to `true` under `NODE_ENV=production`; set it `false`
+  for local http proxies in dev/test.

--- a/packages/proxy-client/package.json
+++ b/packages/proxy-client/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@stwd/proxy-client",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Agent-side client for the Steward proxy: signed, idempotency-keyed HTTP with credential injection handled server-side",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "bun test src/__tests__/"
+  },
+  "author": "Steward-Fi",
+  "license": "MIT",
+  "devDependencies": {
+    "@stwd/auth": "workspace:*",
+    "@stwd/db": "workspace:*",
+    "@stwd/proxy": "workspace:*",
+    "@stwd/vault": "workspace:*",
+    "@types/bun": "latest",
+    "hono": "^4.12.18",
+    "typescript": "^5.8.0"
+  }
+}

--- a/packages/proxy-client/src/__tests__/client.test.ts
+++ b/packages/proxy-client/src/__tests__/client.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Unit tests for StewardProxyClient: header shape, idempotency auto-attach,
+ * signature attachment, and https enforcement.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { StewardProxyClient } from "../client";
+
+interface Captured {
+  url: string;
+  method: string;
+  headers: Headers;
+  body: BodyInit | null | undefined;
+}
+
+function makeCapturingFetch(): { fetch: typeof fetch; calls: Captured[] } {
+  const calls: Captured[] = [];
+  const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    calls.push({
+      url: String(input),
+      method: (init?.method ?? "GET").toUpperCase(),
+      headers: new Headers(init?.headers),
+      body: init?.body ?? null,
+    });
+    return new Response(JSON.stringify({ ok: true }), {
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof fetch;
+  return { fetch: fetchImpl, calls };
+}
+
+describe("StewardProxyClient construction", () => {
+  test("requires proxyUrl and token", () => {
+    // @ts-expect-error missing token
+    expect(() => new StewardProxyClient({ proxyUrl: "https://p" })).toThrow("token is required");
+    // @ts-expect-error missing proxyUrl
+    expect(() => new StewardProxyClient({ token: "t" })).toThrow("proxyUrl is required");
+  });
+
+  test("rejects non-https proxyUrl when requireHttps=true (production mode)", () => {
+    expect(
+      () =>
+        new StewardProxyClient({
+          proxyUrl: "http://insecure.local:8080",
+          token: "t",
+          requireHttps: true,
+        }),
+    ).toThrow("proxyUrl must be https in production");
+  });
+
+  test("allows http proxyUrl when requireHttps=false (dev/test)", () => {
+    const client = new StewardProxyClient({
+      proxyUrl: "http://localhost:8080",
+      token: "t",
+      requireHttps: false,
+    });
+    expect(client).toBeInstanceOf(StewardProxyClient);
+  });
+
+  test("requires tenantId/agentId when signingSecret is set", () => {
+    expect(
+      () =>
+        new StewardProxyClient({
+          proxyUrl: "https://p",
+          token: "t",
+          signingSecret: "s",
+        }),
+    ).toThrow("tenantId and agentId are required");
+  });
+});
+
+describe("StewardProxyClient.fetch headers", () => {
+  test("attaches Authorization: Bearer <token>", async () => {
+    const { fetch, calls } = makeCapturingFetch();
+    const client = new StewardProxyClient({
+      proxyUrl: "https://proxy.test",
+      token: "tok-123",
+      fetch,
+    });
+    await client.fetch("/openai/v1/models");
+    expect(calls[0].headers.get("authorization")).toBe("Bearer tok-123");
+    expect(calls[0].url).toBe("https://proxy.test/openai/v1/models");
+    expect(calls[0].method).toBe("GET");
+  });
+
+  test("auto-attaches Idempotency-Key on POST when not supplied", async () => {
+    const { fetch, calls } = makeCapturingFetch();
+    const client = new StewardProxyClient({
+      proxyUrl: "https://proxy.test",
+      token: "tok",
+      fetch,
+    });
+    await client.fetch("/openai/v1/chat/completions", { method: "POST", body: "{}" });
+    const key = calls[0].headers.get("idempotency-key");
+    expect(key).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  test("does NOT auto-attach Idempotency-Key on GET", async () => {
+    const { fetch, calls } = makeCapturingFetch();
+    const client = new StewardProxyClient({
+      proxyUrl: "https://proxy.test",
+      token: "tok",
+      fetch,
+    });
+    await client.fetch("/openai/v1/models");
+    expect(calls[0].headers.get("idempotency-key")).toBeNull();
+  });
+
+  test("preserves a caller-supplied Idempotency-Key", async () => {
+    const { fetch, calls } = makeCapturingFetch();
+    const client = new StewardProxyClient({
+      proxyUrl: "https://proxy.test",
+      token: "tok",
+      fetch,
+    });
+    await client.fetch("/openai/v1/chat/completions", {
+      method: "POST",
+      body: "{}",
+      headers: { "idempotency-key": "caller-supplied-key" },
+    });
+    expect(calls[0].headers.get("idempotency-key")).toBe("caller-supplied-key");
+  });
+
+  test("attaches signature + timestamp headers when signingSecret is set", async () => {
+    const { fetch, calls } = makeCapturingFetch();
+    const client = new StewardProxyClient({
+      proxyUrl: "https://proxy.test",
+      token: "tok",
+      signingSecret: "signing-secret",
+      tenantId: "tenant-1",
+      agentId: "agent-1",
+      fetch,
+    });
+    await client.fetch("/openai/v1/chat/completions", { method: "POST", body: "{}" });
+    expect(calls[0].headers.get("x-steward-signature")).toMatch(/^v1=[0-9a-f]{64}$/);
+    expect(calls[0].headers.get("x-steward-request-timestamp")).toMatch(/^\d+$/);
+  });
+
+  test("does NOT attach signature headers when no signingSecret", async () => {
+    const { fetch, calls } = makeCapturingFetch();
+    const client = new StewardProxyClient({
+      proxyUrl: "https://proxy.test",
+      token: "tok",
+      fetch,
+    });
+    await client.fetch("/openai/v1/models");
+    expect(calls[0].headers.get("x-steward-signature")).toBeNull();
+    expect(calls[0].headers.get("x-steward-request-timestamp")).toBeNull();
+  });
+
+  test("rejects non-serialized bodies for signed requests", async () => {
+    const { fetch } = makeCapturingFetch();
+    const client = new StewardProxyClient({
+      proxyUrl: "https://proxy.test",
+      token: "tok",
+      signingSecret: "signing-secret",
+      tenantId: "tenant-1",
+      agentId: "agent-1",
+      fetch,
+    });
+    await expect(
+      client.fetch("/openai/v1/chat/completions", {
+        method: "POST",
+        body: new URLSearchParams({ a: "b" }),
+      }),
+    ).rejects.toThrow("Serialize before calling");
+  });
+});
+
+describe("StewardProxyClient.proxyHealth", () => {
+  test("GETs /health and returns parsed json", async () => {
+    const { fetch, calls } = makeCapturingFetch();
+    const client = new StewardProxyClient({
+      proxyUrl: "https://proxy.test",
+      token: "tok",
+      fetch,
+    });
+    const health = await client.proxyHealth();
+    expect(calls[0].url).toBe("https://proxy.test/health");
+    expect(calls[0].method).toBe("GET");
+    expect(health.ok).toBe(true);
+  });
+});

--- a/packages/proxy-client/src/__tests__/proxy-e2e.test.ts
+++ b/packages/proxy-client/src/__tests__/proxy-e2e.test.ts
@@ -35,6 +35,7 @@ const FAKE_OPENAI_KEY = "sk-test-e2e-do-not-use-0123456789abcdef";
 let authMiddleware: typeof import("@stwd/proxy/src/middleware/auth")["authMiddleware"];
 let handleProxy: typeof import("@stwd/proxy/src/handlers/proxy")["handleProxy"];
 let setForwardProxyRequestForTests: typeof import("@stwd/proxy/src/handlers/proxy")["__setForwardProxyRequestForTests"];
+let setResolveProxyHostForTests: typeof import("@stwd/proxy/src/handlers/proxy")["__setResolveProxyHostForTests"];
 
 // Capture what the proxy tried to forward upstream.
 interface ForwardedCapture {
@@ -64,9 +65,19 @@ beforeAll(async () => {
   });
 
   ({ authMiddleware } = await import("@stwd/proxy/src/middleware/auth"));
-  ({ handleProxy, __setForwardProxyRequestForTests: setForwardProxyRequestForTests } = await import(
-    "@stwd/proxy/src/handlers/proxy"
-  ));
+  ({
+    handleProxy,
+    __setForwardProxyRequestForTests: setForwardProxyRequestForTests,
+    __setResolveProxyHostForTests: setResolveProxyHostForTests,
+  } = await import("@stwd/proxy/src/handlers/proxy"));
+
+  // Hermeticity: the proxy resolves the target host via DNS BEFORE it calls the
+  // (stubbed) forwarder, and rejects private/reserved addresses. In a
+  // network-isolated CI box a real lookup of api.openai.com would 502 with
+  // "Unable to resolve proxy target host". Stub the resolver to a deterministic
+  // PUBLIC ip so route match -> decrypt -> inject -> forward is exercised with
+  // no third-party network.
+  setResolveProxyHostForTests(async () => [{ address: "93.184.216.34", family: 4 }]);
 
   // Replace the real outbound forwarder. Assert-friendly stub: capture the
   // outbound (already credential-injected) request and synthesize a response.

--- a/packages/proxy-client/src/__tests__/proxy-e2e.test.ts
+++ b/packages/proxy-client/src/__tests__/proxy-e2e.test.ts
@@ -1,0 +1,272 @@
+/**
+ * End-to-end proof: real @stwd/proxy-client -> proxy auth -> route match ->
+ * decrypt -> inject -> scrub, on the EXISTING OpenAI alias (zero new hosts).
+ *
+ * We DO NOT hit real OpenAI. The proxy's outbound forwarder is replaced via the
+ * built-in `__setForwardProxyRequestForTests` hook, so we can:
+ *   - assert the proxy injected the seeded (fake) OpenAI key as the
+ *     Authorization header on the OUTBOUND request,
+ *   - assert the AGENT-side request never carried the secret,
+ *   - assert a clean upstream response passes through and never contains it,
+ *   - assert that if the upstream DID reflect the secret, the proxy's scrubbing
+ *     blocks it (502) so the credential never reaches the agent.
+ *
+ * The client is the REAL StewardProxyClient. Its outbound fetch is routed into
+ * the in-process Hono app so every real header (Bearer, X-Steward-Signature,
+ * X-Steward-Request-Timestamp, Idempotency-Key) is computed by the shipping
+ * client code, then verified by the shipping proxy middleware.
+ */
+
+import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
+import { signAgentToken } from "@stwd/auth";
+import { agents, closeDb, getDb, tenants } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { PROXY_SCOPE } from "@stwd/proxy/src/config";
+import { SecretVault } from "@stwd/vault";
+import { Hono } from "hono";
+import { StewardProxyClient } from "../index";
+
+setDefaultTimeout(30000);
+
+const MASTER_PASSWORD = "proxy-client-e2e-master-password";
+const SIGNING_SECRET = "proxy-client-e2e-signing-secret-with-enough-bytes";
+const FAKE_OPENAI_KEY = "sk-test-e2e-do-not-use-0123456789abcdef";
+
+let authMiddleware: typeof import("@stwd/proxy/src/middleware/auth")["authMiddleware"];
+let handleProxy: typeof import("@stwd/proxy/src/handlers/proxy")["handleProxy"];
+let setForwardProxyRequestForTests: typeof import("@stwd/proxy/src/handlers/proxy")["__setForwardProxyRequestForTests"];
+
+// Capture what the proxy tried to forward upstream.
+interface ForwardedCapture {
+  url: string;
+  method: string;
+  headers: Headers;
+}
+let lastForwarded: ForwardedCapture | null = null;
+// Controls whether the stubbed upstream reflects the secret back (leak sim).
+let reflectSecretInResponse = false;
+
+beforeAll(async () => {
+  process.env.STEWARD_PGLITE_MEMORY = "true";
+  process.env.STEWARD_MASTER_PASSWORD = MASTER_PASSWORD;
+  process.env.STEWARD_JWT_SECRET = "proxy-client-e2e-jwt-secret-with-enough-bytes";
+  // Force the production-grade request-signature requirement so the e2e also
+  // exercises the client's HMAC signer against the proxy verifier.
+  process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE = "true";
+  process.env.STEWARD_PROXY_REQUEST_SIGNING_SECRET = SIGNING_SECRET;
+  // api.openai.com is already in the direct-proxy + secret-route default
+  // allowlists, but set it explicitly for hermeticity.
+  process.env.STEWARD_PROXY_ALLOWED_HOSTS = "api.openai.com";
+
+  const { db, client } = await createPGLiteDb("memory://");
+  setPGLiteOverride(db, async () => {
+    await client.close();
+  });
+
+  ({ authMiddleware } = await import("@stwd/proxy/src/middleware/auth"));
+  ({ handleProxy, __setForwardProxyRequestForTests: setForwardProxyRequestForTests } = await import(
+    "@stwd/proxy/src/handlers/proxy"
+  ));
+
+  // Replace the real outbound forwarder. Assert-friendly stub: capture the
+  // outbound (already credential-injected) request and synthesize a response.
+  setForwardProxyRequestForTests(async (url, method, headers) => {
+    lastForwarded = { url: url.toString(), method, headers };
+    const payload = reflectSecretInResponse
+      ? { echoedAuthorization: headers.get("authorization") }
+      : { id: "chatcmpl-test", object: "chat.completion", choices: [] };
+    return new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  });
+});
+
+afterAll(async () => {
+  await closeDb().catch(() => {});
+  delete process.env.STEWARD_PGLITE_MEMORY;
+  delete process.env.STEWARD_MASTER_PASSWORD;
+  delete process.env.STEWARD_JWT_SECRET;
+  delete process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE;
+  delete process.env.STEWARD_PROXY_REQUEST_SIGNING_SECRET;
+  delete process.env.STEWARD_PROXY_ALLOWED_HOSTS;
+});
+
+function buildProxyApp() {
+  const app = new Hono();
+  app.use("*", authMiddleware);
+  app.all("*", handleProxy);
+  return app;
+}
+
+/**
+ * Route the real client's outbound fetch into the in-process Hono app. This
+ * keeps the entire shipping client codepath (header + signature computation)
+ * while dispatching to the shipping proxy code instead of the network.
+ */
+function makeAppFetch(app: ReturnType<typeof buildProxyApp>): {
+  fetch: typeof fetch;
+  agentRequests: Array<{ url: string; method: string; headers: Headers; body: string | null }>;
+} {
+  const agentRequests: Array<{
+    url: string;
+    method: string;
+    headers: Headers;
+    body: string | null;
+  }> = [];
+  const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    const path = new URL(url).pathname + new URL(url).search;
+    const bodyStr = typeof init?.body === "string" ? init.body : null;
+    agentRequests.push({
+      url,
+      method: (init?.method ?? "GET").toUpperCase(),
+      headers: new Headers(init?.headers),
+      body: bodyStr,
+    });
+    return app.request(path, init as RequestInit);
+  }) as typeof fetch;
+  return { fetch: fetchImpl, agentRequests };
+}
+
+async function seedTenantAgentSecretRoute() {
+  const tenantId = `tenant-e2e-${crypto.randomUUID()}`;
+  const agentId = `agent-e2e-${crypto.randomUUID()}`;
+
+  await getDb()
+    .insert(tenants)
+    .values({ id: tenantId, name: tenantId, apiKeyHash: `hash-${tenantId}` });
+  await getDb()
+    .insert(agents)
+    .values({ id: agentId, tenantId, name: agentId, walletAddress: `0x${"1".repeat(40)}` });
+
+  const vault = new SecretVault(MASTER_PASSWORD);
+  const secret = await vault.createSecret(tenantId, "openai", FAKE_OPENAI_KEY);
+  // Specific host + path + method: avoids broad-route gating, api.openai.com is
+  // in the default secret-route allowlist.
+  await vault.createRoute(tenantId, secret.id, {
+    agentId,
+    hostPattern: "api.openai.com",
+    pathPattern: "/v1/chat/*",
+    method: "POST",
+    injectAs: "header",
+    injectKey: "authorization",
+    injectFormat: "Bearer {value}",
+  });
+
+  return { tenantId, agentId };
+}
+
+describe("proxy-client e2e: injection + scrub on the openai alias", () => {
+  it("injects the seeded secret upstream, never exposes it to the agent, passes clean responses", async () => {
+    lastForwarded = null;
+    reflectSecretInResponse = false;
+    const { tenantId, agentId } = await seedTenantAgentSecretRoute();
+
+    const token = await signAgentToken({ agentId, tenantId, scopes: ["agent", PROXY_SCOPE] }, "1h");
+
+    const app = buildProxyApp();
+    const { fetch, agentRequests } = makeAppFetch(app);
+
+    const client = new StewardProxyClient({
+      proxyUrl: "https://proxy.e2e.test",
+      token,
+      signingSecret: SIGNING_SECRET,
+      tenantId,
+      agentId,
+      requireHttps: true,
+      fetch,
+    });
+
+    const requestBody = JSON.stringify({
+      model: "gpt-4o-mini",
+      messages: [{ role: "user", content: "hello from the e2e test" }],
+    });
+
+    const res = await client.fetch("/openai/v1/chat/completions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: requestBody,
+    });
+
+    // 1. The proxy accepted the signed, idempotency-keyed request and forwarded.
+    expect(res.status).toBe(200);
+    expect(lastForwarded).not.toBeNull();
+
+    // 2. The proxy injected the decrypted secret as the Authorization header on
+    //    the OUTBOUND (upstream) request.
+    expect(lastForwarded?.url).toBe("https://api.openai.com/v1/chat/completions");
+    expect(lastForwarded?.headers.get("authorization")).toBe(`Bearer ${FAKE_OPENAI_KEY}`);
+
+    // 3. The AGENT-side request never carried the secret in any header or body.
+    expect(agentRequests.length).toBe(1);
+    const agentReq = agentRequests[0];
+    expect(agentReq.headers.get("authorization")).toBe(`Bearer ${token}`);
+    expect(agentReq.headers.get("authorization")).not.toContain(FAKE_OPENAI_KEY);
+    for (const [, value] of agentReq.headers.entries()) {
+      expect(value).not.toContain(FAKE_OPENAI_KEY);
+    }
+    expect(agentReq.body ?? "").not.toContain(FAKE_OPENAI_KEY);
+
+    // 3b. The real client attached the proof-of-possession signature +
+    //     idempotency key that the proxy required.
+    expect(agentReq.headers.get("x-steward-signature")).toMatch(/^v1=[0-9a-f]{64}$/);
+    expect(agentReq.headers.get("x-steward-request-timestamp")).toMatch(/^\d+$/);
+    expect(agentReq.headers.get("idempotency-key")).toMatch(/^[0-9a-f-]{36}$/);
+
+    // 4. The response returned to the agent never contains the secret.
+    const responseText = await res.text();
+    expect(responseText).not.toContain(FAKE_OPENAI_KEY);
+  });
+
+  it("blocks the response (502) if the upstream reflects the injected secret", async () => {
+    lastForwarded = null;
+    reflectSecretInResponse = true;
+    const { tenantId, agentId } = await seedTenantAgentSecretRoute();
+
+    const token = await signAgentToken({ agentId, tenantId, scopes: ["agent", PROXY_SCOPE] }, "1h");
+
+    const app = buildProxyApp();
+    const { fetch } = makeAppFetch(app);
+
+    const client = new StewardProxyClient({
+      proxyUrl: "https://proxy.e2e.test",
+      token,
+      signingSecret: SIGNING_SECRET,
+      tenantId,
+      agentId,
+      requireHttps: true,
+      fetch,
+    });
+
+    const res = await client.fetch("/openai/v1/chat/completions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ model: "gpt-4o-mini", messages: [] }),
+    });
+
+    // Proxy detected the reflected credential and refused to pass it through.
+    expect(res.status).toBe(502);
+    const body = await res.text();
+    expect(body).not.toContain(FAKE_OPENAI_KEY);
+    expect(body).toContain("reflected injected credential");
+  });
+
+  it("rejects an unsigned request when signing is required (proves the guard is live)", async () => {
+    const { tenantId, agentId } = await seedTenantAgentSecretRoute();
+    const token = await signAgentToken({ agentId, tenantId, scopes: ["agent", PROXY_SCOPE] }, "1h");
+    const app = buildProxyApp();
+
+    // Bypass the client and hit the app directly WITHOUT a signature.
+    const res = await app.request("/openai/v1/chat/completions", {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+      body: JSON.stringify({ model: "gpt-4o-mini", messages: [] }),
+    });
+
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain("X-Steward-Signature");
+  });
+});

--- a/packages/proxy-client/src/__tests__/signature.test.ts
+++ b/packages/proxy-client/src/__tests__/signature.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Golden-vector tests: pin this client's signer against the proxy's own signer.
+ *
+ * We import `createProxyAuthorizationSignature` directly from @stwd/proxy (the
+ * exact function the proxy verifier uses to build its expected signature) and
+ * assert our `signProxyRequest` produces byte-identical output for a spread of
+ * inputs. If the proxy canonical form ever drifts, these fail loudly.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { createProxyAuthorizationSignature } from "@stwd/proxy/src/middleware/auth";
+import { buildCanonicalRequest, signProxyRequest } from "../signature";
+
+const SECRET = "golden-vector-signing-secret-with-enough-bytes";
+
+const VECTORS: Array<{
+  name: string;
+  input: Parameters<typeof signProxyRequest>[0];
+}> = [
+  {
+    name: "GET no body, timestamp only",
+    input: {
+      method: "GET",
+      url: "https://proxy.test/openai/v1/models",
+      tenantId: "tenant-1",
+      agentId: "agent-1",
+      timestamp: "1751000000",
+    },
+  },
+  {
+    name: "POST json body + idempotency key",
+    input: {
+      method: "POST",
+      url: "https://proxy.test/openai/v1/chat/completions",
+      tenantId: "tenant-abc",
+      agentId: "agent-xyz",
+      timestamp: "1751000123",
+      idempotencyKey: "11111111-2222-3333-4444-555555555555",
+      body: JSON.stringify({ model: "gpt-4o", messages: [{ role: "user", content: "hi" }] }),
+    },
+  },
+  {
+    name: "PATCH with query string + expiresAt",
+    input: {
+      method: "patch",
+      url: "https://proxy.test/proxy/api.openai.com/v1/x?foo=bar&baz=1",
+      tenantId: "t",
+      agentId: "a",
+      expiresAt: "1751000999",
+      idempotencyKey: "abc",
+      body: "raw-string-body",
+    },
+  },
+  {
+    name: "relative url (path only)",
+    input: {
+      method: "POST",
+      url: "/openai/v1/chat/completions",
+      tenantId: "tenant-1",
+      agentId: "agent-1",
+      timestamp: "1751000000",
+      body: "{}",
+    },
+  },
+];
+
+describe("proxy-client signer golden vectors", () => {
+  for (const vector of VECTORS) {
+    test(`matches @stwd/proxy signer: ${vector.name}`, async () => {
+      const ours = await signProxyRequest(vector.input, SECRET);
+      const theirs = await createProxyAuthorizationSignature(vector.input, SECRET);
+      expect(ours).toBe(theirs);
+    });
+  }
+
+  test("canonical form is deterministic and version-tagged", async () => {
+    const canonical = await buildCanonicalRequest({
+      method: "GET",
+      url: "https://proxy.test/openai/v1/models",
+      tenantId: "tenant-1",
+      agentId: "agent-1",
+      timestamp: "1751000000",
+    });
+    const lines = canonical.split("\n");
+    expect(lines[0]).toBe("steward-proxy-request-signature-v1");
+    expect(lines[1]).toBe("GET");
+    expect(lines[2]).toBe("/openai/v1/models");
+    expect(lines[3]).toBe("tenant-1");
+    expect(lines[4]).toBe("agent-1");
+    expect(lines[5]).toBe("1751000000");
+    // empty expiresAt + empty idempotency-key
+    expect(lines[6]).toBe("");
+    expect(lines[7]).toBe("");
+    // sha256("") for empty body
+    expect(lines[8]).toBe("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+  });
+
+  test("signature has v1= prefix and 64-hex body", async () => {
+    const sig = await signProxyRequest(
+      {
+        method: "GET",
+        url: "/openai/v1/models",
+        tenantId: "t",
+        agentId: "a",
+        timestamp: "1751000000",
+      },
+      SECRET,
+    );
+    expect(sig).toMatch(/^v1=[0-9a-f]{64}$/);
+  });
+});

--- a/packages/proxy-client/src/client.ts
+++ b/packages/proxy-client/src/client.ts
@@ -1,0 +1,161 @@
+/**
+ * StewardProxyClient — agent-side HTTP client for the Steward proxy.
+ *
+ * The proxy sits between an agent and external APIs. Agents never hold the
+ * upstream API keys: they send requests here with a Bearer JWT (api:proxy
+ * scope) and, when request signing is enabled, an HMAC proof-of-possession
+ * signature. The proxy matches a credential route, decrypts the secret, injects
+ * it as the configured header, forwards upstream, and scrubs the credential
+ * from the response.
+ *
+ * This client is a thin, generic `fetch` wrapper. It:
+ *   - attaches `Authorization: Bearer <token>`
+ *   - when a `signingSecret` is configured, computes the HMAC
+ *     `X-Steward-Signature` + `X-Steward-Request-Timestamp` headers per the
+ *     proxy's canonical form (see ./signature.ts)
+ *   - auto-generates an `Idempotency-Key` (crypto.randomUUID) for mutating
+ *     methods (POST/PUT/PATCH/DELETE) when the caller did not supply one
+ *
+ * It is intentionally NOT vendor-specific: there is no openaiChat() helper.
+ * Callers build the path (e.g. "/openai/v1/chat/completions") and body.
+ */
+
+import { signProxyRequest } from "./signature";
+
+const MUTATING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+const SIGNATURE_MAX_AGE_MS = 5 * 60_000;
+
+export interface StewardProxyClientOptions {
+  /** Base URL of the proxy, e.g. https://proxy.example.com */
+  proxyUrl: string;
+  /** api:proxy-scoped agent JWT. */
+  token: string;
+  /**
+   * HMAC secret for request signing. Required when the proxy runs with request
+   * signing enabled (production). One of the values configured in
+   * STEWARD_PROXY_REQUEST_SIGNING_SECRET(S).
+   */
+  signingSecret?: string;
+  /**
+   * tenantId + agentId are bound into the signature canonical form and MUST
+   * match the JWT claims the proxy derives. Required when signingSecret is set.
+   */
+  tenantId?: string;
+  agentId?: string;
+  /**
+   * When true (default in production-like usage), reject non-https proxyUrl.
+   * Defaults to true when NODE_ENV === "production", false otherwise so local
+   * http proxies work in dev/test.
+   */
+  requireHttps?: boolean;
+  /** Injectable fetch for testing. Defaults to global fetch. */
+  fetch?: typeof fetch;
+}
+
+export interface ProxyHealth {
+  ok: boolean;
+  service?: string;
+  version?: string;
+  aliases?: string[];
+  [key: string]: unknown;
+}
+
+function normalizeBaseUrl(proxyUrl: string): string {
+  return proxyUrl.endsWith("/") ? proxyUrl.slice(0, -1) : proxyUrl;
+}
+
+function joinPath(base: string, path: string): string {
+  return path.startsWith("/") ? `${base}${path}` : `${base}/${path}`;
+}
+
+async function bodyToSignable(
+  body: BodyInit | null | undefined,
+): Promise<string | ArrayBuffer | Uint8Array> {
+  if (body === null || body === undefined) return "";
+  if (typeof body === "string") return body;
+  if (body instanceof Uint8Array) return body;
+  if (body instanceof ArrayBuffer) return body;
+  // Blobs / URLSearchParams / FormData etc. would need buffering that changes
+  // the outbound representation, so require a pre-serialized body for signed
+  // requests. Callers should JSON.stringify before calling.
+  throw new Error(
+    "Signed proxy requests require a string, Uint8Array, or ArrayBuffer body. Serialize before calling.",
+  );
+}
+
+export class StewardProxyClient {
+  private readonly baseUrl: string;
+  private readonly token: string;
+  private readonly signingSecret?: string;
+  private readonly tenantId?: string;
+  private readonly agentId?: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: StewardProxyClientOptions) {
+    if (!options.proxyUrl) throw new Error("proxyUrl is required");
+    if (!options.token) throw new Error("token is required");
+
+    const requireHttps = options.requireHttps ?? process.env.NODE_ENV === "production";
+    if (requireHttps && !/^https:\/\//i.test(options.proxyUrl)) {
+      throw new Error("proxyUrl must be https in production");
+    }
+
+    if (options.signingSecret && (!options.tenantId || !options.agentId)) {
+      throw new Error("tenantId and agentId are required when signingSecret is set");
+    }
+
+    this.baseUrl = normalizeBaseUrl(options.proxyUrl);
+    this.token = options.token;
+    this.signingSecret = options.signingSecret;
+    this.tenantId = options.tenantId;
+    this.agentId = options.agentId;
+    this.fetchImpl = options.fetch ?? globalThis.fetch;
+  }
+
+  /**
+   * Generic proxied fetch. `path` is the proxy-relative path (alias or /proxy/…),
+   * e.g. "/openai/v1/chat/completions". Attaches auth, idempotency, and (when
+   * configured) the request signature.
+   */
+  async fetch(path: string, init: RequestInit = {}): Promise<Response> {
+    const method = (init.method ?? "GET").toUpperCase();
+    const headers = new Headers(init.headers);
+
+    headers.set("authorization", `Bearer ${this.token}`);
+
+    // Auto idempotency key for mutating methods, if the caller did not set one.
+    if (MUTATING_METHODS.has(method) && !headers.has("idempotency-key")) {
+      headers.set("idempotency-key", crypto.randomUUID());
+    }
+
+    if (this.signingSecret && this.tenantId && this.agentId) {
+      const timestamp = String(Math.floor(Date.now() / 1000));
+      headers.set("x-steward-request-timestamp", timestamp);
+
+      const signable = await bodyToSignable(init.body ?? null);
+      const signature = await signProxyRequest(
+        {
+          method,
+          url: joinPath(this.baseUrl, path),
+          tenantId: this.tenantId,
+          agentId: this.agentId,
+          timestamp,
+          idempotencyKey: headers.get("idempotency-key") ?? undefined,
+          body: signable,
+        },
+        this.signingSecret,
+      );
+      headers.set("x-steward-signature", signature);
+    }
+
+    return this.fetchImpl(joinPath(this.baseUrl, path), { ...init, method, headers });
+  }
+
+  /** GET /health — unauthenticated liveness probe. */
+  async proxyHealth(): Promise<ProxyHealth> {
+    const res = await this.fetchImpl(joinPath(this.baseUrl, "/health"), { method: "GET" });
+    return (await res.json()) as ProxyHealth;
+  }
+}
+
+export { SIGNATURE_MAX_AGE_MS };

--- a/packages/proxy-client/src/index.ts
+++ b/packages/proxy-client/src/index.ts
@@ -1,0 +1,16 @@
+/**
+ * @stwd/proxy-client — agent-side client for the Steward proxy.
+ *
+ * The proxy holds the upstream credentials; agents authenticate with a scoped
+ * JWT and (in production) an HMAC request signature. This package provides a
+ * generic signed HTTP client plus the signing primitives, kept in lockstep with
+ * the proxy verifier via golden-vector tests.
+ */
+
+export type {
+  ProxyHealth,
+  StewardProxyClientOptions,
+} from "./client";
+export { SIGNATURE_MAX_AGE_MS, StewardProxyClient } from "./client";
+export type { ProxySignatureInput } from "./signature";
+export { buildCanonicalRequest, SIGNATURE_PREFIX, signProxyRequest } from "./signature";

--- a/packages/proxy-client/src/signature.ts
+++ b/packages/proxy-client/src/signature.ts
@@ -1,0 +1,106 @@
+/**
+ * Request signing for the Steward proxy.
+ *
+ * Replicates the proxy's canonical form and HMAC exactly. The proxy verifier
+ * lives in `@stwd/proxy` (middleware/auth.ts, `createProxyAuthorizationSignature`
+ * + the server-side `canonicalProxyRequest`). This module is a dependency-light
+ * mirror so agent containers do not have to import the whole proxy server.
+ *
+ * The two are pinned together by golden-vector tests
+ * (`src/__tests__/signature.test.ts`) that verify this signer against the
+ * proxy's own signer for identical inputs. If the proxy canonical form ever
+ * changes, those tests fail and force this file to be updated in lockstep.
+ */
+
+const SIGNATURE_PREFIX = "v1=";
+
+/** Canonical-form domain separator. Must match the proxy verifier. */
+const CANONICAL_VERSION = "steward-proxy-request-signature-v1";
+
+/** Placeholder base used only to parse a relative request path/search. */
+const RELATIVE_URL_BASE = "https://steward-proxy.local";
+
+export interface ProxySignatureInput {
+  method: string;
+  /** Request path (absolute URL or path+search). Only pathname+search are signed. */
+  url: string;
+  tenantId: string;
+  agentId: string;
+  /** Unix seconds. At least one of timestamp/expiresAt must be present at send time. */
+  timestamp?: string;
+  /** Unix seconds. */
+  expiresAt?: string;
+  idempotencyKey?: string;
+  body?: string | ArrayBuffer | Uint8Array;
+}
+
+function copyToArrayBuffer(view: Uint8Array): ArrayBuffer {
+  const out = new ArrayBuffer(view.byteLength);
+  new Uint8Array(out).set(view);
+  return out;
+}
+
+function toArrayBuffer(body: string | ArrayBuffer | Uint8Array | undefined): ArrayBuffer {
+  if (body === undefined) return new ArrayBuffer(0);
+  if (typeof body === "string") {
+    return copyToArrayBuffer(new TextEncoder().encode(body));
+  }
+  if (body instanceof Uint8Array) {
+    return copyToArrayBuffer(body);
+  }
+  return body;
+}
+
+async function sha256Hex(input: ArrayBuffer): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", input);
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+async function hmacSha256Hex(secret: string, canonical: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(canonical));
+  return [...new Uint8Array(signature)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+/**
+ * Build the canonical string that gets HMAC'd.
+ *
+ * MUST byte-match the proxy's `canonicalProxyRequest` /
+ * `createProxyAuthorizationSignature` in @stwd/proxy. Field order:
+ *   version, METHOD, path+search, tenantId, agentId, timestamp, expiresAt,
+ *   idempotencyKey, sha256(body). Missing optional fields serialize as "".
+ */
+export async function buildCanonicalRequest(input: ProxySignatureInput): Promise<string> {
+  const url = new URL(input.url, RELATIVE_URL_BASE);
+  const bodyHash = await sha256Hex(toArrayBuffer(input.body));
+  return [
+    CANONICAL_VERSION,
+    input.method.toUpperCase(),
+    `${url.pathname}${url.search}`,
+    input.tenantId,
+    input.agentId,
+    input.timestamp ?? "",
+    input.expiresAt ?? "",
+    input.idempotencyKey ?? "",
+    bodyHash,
+  ].join("\n");
+}
+
+/**
+ * Produce the `X-Steward-Signature` header value: `v1=<hex hmac>`.
+ */
+export async function signProxyRequest(
+  input: ProxySignatureInput,
+  secret: string,
+): Promise<string> {
+  const canonical = await buildCanonicalRequest(input);
+  return `${SIGNATURE_PREFIX}${await hmacSha256Hex(secret, canonical)}`;
+}
+
+export { SIGNATURE_PREFIX };

--- a/packages/proxy-client/tsconfig.json
+++ b/packages/proxy-client/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/__tests__", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/scripts/deploy/smoke-proxy.sh
+++ b/scripts/deploy/smoke-proxy.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# =============================================================================
+# Steward proxy post-deploy smoke
+#
+# Verifies a deployed proxy gateway is up and enforcing auth, from the OUTSIDE
+# via HTTP status codes.
+#
+#   1. GET /health            -> 200  (service is up; unauthenticated)
+#   2. unauthenticated proxy  -> 401  (auth guard is live; no Bearer token)
+#   3. (--signed) a signed,   -> NOT 401/403  (proves a valid signed request
+#      idempotency-keyed          reaches route matching rather than being
+#      request                    rejected at the auth/signature layer)
+#
+# Usage:
+#   smoke-proxy.sh <PROXY_URL> <TOKEN>
+#   smoke-proxy.sh --signed <PROXY_URL> <TOKEN> <TENANT_ID> <AGENT_ID>
+#
+#     PROXY_URL   e.g. https://steward-proxy.up.railway.app  (no trailing slash)
+#     TOKEN       an api:proxy-scoped agent JWT
+#     TENANT_ID   (--signed only) tenant id bound into the signature
+#     AGENT_ID    (--signed only) agent id bound into the signature
+#
+# For --signed you must also export the proxy's request-signing secret:
+#     STEWARD_PROXY_REQUEST_SIGNING_SECRET=<secret> smoke-proxy.sh --signed ...
+#
+# The signed check targets the openai alias path /openai/v1/chat/completions
+# with a POST + Idempotency-Key + X-Steward-Signature. It does NOT need a real
+# credential route to pass: a 401/403 means the signature/auth layer rejected it
+# (FAIL); anything else (200/404/5xx from route matching downstream) means the
+# request passed auth and is being processed (PASS).
+#
+# Exit code: 0 = all checks pass; non-zero on any failure.
+# Deps: curl, jq, openssl.
+# =============================================================================
+
+GREEN='\033[32m'; RED='\033[31m'; CYAN='\033[36m'; RESET='\033[0m'
+log()  { echo -e "${CYAN}[smoke-proxy]${RESET} $*"; }
+ok()   { echo -e "${GREEN}[smoke-proxy]${RESET} $*"; }
+err()  { echo -e "${RED}[smoke-proxy]${RESET} $*" >&2; }
+
+usage() {
+  echo "Usage: $0 <PROXY_URL> <TOKEN>" >&2
+  echo "       $0 --signed <PROXY_URL> <TOKEN> <TENANT_ID> <AGENT_ID>" >&2
+  echo "       (--signed also needs STEWARD_PROXY_REQUEST_SIGNING_SECRET in env)" >&2
+  exit 2
+}
+
+# --- deps --------------------------------------------------------------------
+for dep in curl jq openssl; do
+  if ! command -v "$dep" >/dev/null 2>&1; then
+    err "missing required dependency: $dep"
+    exit 2
+  fi
+done
+
+# --- args --------------------------------------------------------------------
+SIGNED="no"
+if [ "${1:-}" = "--signed" ]; then
+  SIGNED="yes"
+  shift
+fi
+
+PROXY_URL="${1:-}"
+TOKEN="${2:-}"
+TENANT_ID="${3:-}"
+AGENT_ID="${4:-}"
+
+[ -n "$PROXY_URL" ] || usage
+[ -n "$TOKEN" ] || usage
+PROXY_URL="${PROXY_URL%/}"
+
+if [ "$SIGNED" = "yes" ]; then
+  [ -n "$TENANT_ID" ] || { err "--signed requires TENANT_ID"; usage; }
+  [ -n "$AGENT_ID" ] || { err "--signed requires AGENT_ID"; usage; }
+  [ -n "${STEWARD_PROXY_REQUEST_SIGNING_SECRET:-}" ] || {
+    err "--signed requires STEWARD_PROXY_REQUEST_SIGNING_SECRET in the environment"
+    usage
+  }
+fi
+
+SIGNED_PATH="/openai/v1/chat/completions"
+
+PASS=0
+FAIL=0
+declare -a MATRIX=()
+
+record() { # record <name> <PASS|FAIL> <detail>
+  MATRIX+=("$1|$2|$3")
+  if [ "$2" = "PASS" ]; then PASS=$((PASS + 1)); else FAIL=$((FAIL + 1)); fi
+}
+
+# sha256 hex of a string (no trailing newline)
+sha256_hex() {
+  printf '%s' "$1" | openssl dgst -sha256 -hex | awk '{print $NF}'
+}
+
+# hmac-sha256 hex of <message> keyed by <secret>
+hmac_hex() {
+  local message="$1" secret="$2"
+  printf '%s' "$message" | openssl dgst -sha256 -hmac "$secret" -hex | awk '{print $NF}'
+}
+
+log "target: ${PROXY_URL}  (signed: ${SIGNED})"
+
+# --- check 1: /health -> 200 -------------------------------------------------
+HEALTH_CODE="$(curl --silent --show-error --max-time 15 --output /dev/null \
+  --write-out '%{http_code}' "${PROXY_URL}/health" 2>/dev/null || echo "000")"
+if [ "$HEALTH_CODE" = "200" ]; then
+  record "health" "PASS" "GET /health -> 200"
+else
+  record "health" "FAIL" "GET /health -> ${HEALTH_CODE} (want 200)"
+fi
+
+# --- check 2: unauthenticated proxy request -> 401 ---------------------------
+UNAUTH_CODE="$(curl --silent --show-error --max-time 15 --output /dev/null \
+  --write-out '%{http_code}' "${PROXY_URL}${SIGNED_PATH}" 2>/dev/null || echo "000")"
+if [ "$UNAUTH_CODE" = "401" ]; then
+  record "unauth-guard" "PASS" "GET ${SIGNED_PATH} (no token) -> 401"
+else
+  record "unauth-guard" "FAIL" "GET ${SIGNED_PATH} (no token) -> ${UNAUTH_CODE} (want 401)"
+fi
+
+# --- check 3 (optional): a valid signed request passes the auth layer --------
+if [ "$SIGNED" = "yes" ]; then
+  BODY='{"model":"gpt-4o-mini","messages":[{"role":"user","content":"smoke"}]}'
+  TS="$(date +%s)"
+  IDEMPOTENCY_KEY="$(cat /proc/sys/kernel/random/uuid 2>/dev/null || openssl rand -hex 16)"
+  BODY_HASH="$(sha256_hex "$BODY")"
+
+  # Canonical form MUST match packages/proxy/src/middleware/auth.ts:
+  #   version, METHOD, path+search, tenantId, agentId, timestamp, expiresAt,
+  #   idempotencyKey, sha256(body)  (joined by \n). expiresAt empty here.
+  CANONICAL="$(printf '%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s' \
+    "steward-proxy-request-signature-v1" \
+    "POST" \
+    "${SIGNED_PATH}" \
+    "$TENANT_ID" \
+    "$AGENT_ID" \
+    "$TS" \
+    "" \
+    "$IDEMPOTENCY_KEY" \
+    "$BODY_HASH")"
+
+  SIG_HEX="$(hmac_hex "$CANONICAL" "$STEWARD_PROXY_REQUEST_SIGNING_SECRET")"
+
+  SIGNED_CODE="$(curl --silent --show-error --max-time 15 --output /dev/null \
+    --write-out '%{http_code}' \
+    -X POST \
+    -H "authorization: Bearer ${TOKEN}" \
+    -H "content-type: application/json" \
+    -H "idempotency-key: ${IDEMPOTENCY_KEY}" \
+    -H "x-steward-request-timestamp: ${TS}" \
+    -H "x-steward-signature: v1=${SIG_HEX}" \
+    --data "$BODY" \
+    "${PROXY_URL}${SIGNED_PATH}" 2>/dev/null || echo "000")"
+
+  if [ "$SIGNED_CODE" = "401" ] || [ "$SIGNED_CODE" = "403" ]; then
+    record "signed-request" "FAIL" "POST ${SIGNED_PATH} (signed) -> ${SIGNED_CODE} (rejected at auth/signature layer)"
+  elif [ "$SIGNED_CODE" = "000" ]; then
+    record "signed-request" "FAIL" "POST ${SIGNED_PATH} (signed) -> ${SIGNED_CODE} (could not reach service)"
+  else
+    record "signed-request" "PASS" "POST ${SIGNED_PATH} (signed) -> ${SIGNED_CODE} (passed auth; processed downstream)"
+  fi
+fi
+
+# --- matrix ------------------------------------------------------------------
+echo
+echo "  CHECK            RESULT  DETAIL"
+echo "  ---------------  ------  --------------------------------------------"
+for row in "${MATRIX[@]}"; do
+  IFS='|' read -r name result detail <<<"$row"
+  if [ "$result" = "PASS" ]; then
+    printf "  %-15s  ${GREEN}%-6s${RESET}  %s\n" "$name" "$result" "$detail"
+  else
+    printf "  %-15s  ${RED}%-6s${RESET}  %s\n" "$name" "$result" "$detail"
+  fi
+done
+echo
+
+if [ "$FAIL" -eq 0 ]; then
+  ok "smoke passed: ${PASS}/${PASS} checks ok"
+  exit 0
+fi
+
+err "smoke FAILED: ${FAIL} check(s) failed, ${PASS} passed"
+exit 1

--- a/turbo.json
+++ b/turbo.json
@@ -61,6 +61,10 @@
       "dependsOn": ["^build"],
       "outputs": []
     },
+    "@stwd/proxy-client#build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"]
+    },
     "@stwd/vault#build": {
       "dependsOn": ["^build"],
       "outputs": []


### PR DESCRIPTION
## what

adds `@stwd/proxy-client` — the missing agent-side client that lets an agent actually use the proxy — plus a deploy runbook for the proxy service and an end-to-end proof of the credential-injection path on the existing openai route.

vendor-neutral, additive. **zero changes to proxy handler/policy/vault/trade logic** (the required signer + test hooks were already exported).

## parts

**1. `@stwd/proxy-client` (new package)**
- dependency-light `fetch` wrapper: attaches `Authorization: Bearer`, auto-generates an `Idempotency-Key` (uuid) on POST/PUT/PATCH/DELETE when the caller didn't supply one, and (when a signing secret is configured) computes the `X-Steward-Signature` + `X-Steward-Request-Timestamp` headers per the proxy's canonical form.
- generic HTTP client (no vendor-specific helpers) + a tiny `proxyHealth()`.
- rejects non-https `proxyUrl` in production, requires tenant/agent ids when signing.

**2. deploy prep (docs + script, no live changes)**
- `docs/deploy/railway-lean-full.md`: new proxy-service section with the exact env checklist (read from proxy source), start-command override (`bun packages/proxy/src/index.ts`), health endpoint, stateless rollback, and an honest note on the master-password co-location tradeoff.
- `scripts/deploy/smoke-proxy.sh`: health 200, unauthenticated → 401, optional `--signed` check that computes the signature in bash. shellcheck-clean.

**3. e2e injection proof**
- boots the proxy in-process against the pglite/vault test harness, seeds a tenant + agent + fake openai secret + secret_route, and drives the **real** `StewardProxyClient` through auth → route-match → decrypt → inject → scrub.
- asserts: the seeded secret is injected as the outbound `Authorization` header; the agent-side request never carried it (headers or body); the response never contains it; and a reflected-credential upstream is blocked (502).

## drift protection

golden-vector tests sign identical inputs with both this client and the proxy's own signer (`createProxyAuthorizationSignature`, imported from source) and assert byte-equality — the two can never drift silently.

## verify (bun 1.3.9)

- `turbo run build`: 27/27 green (incl. the new package)
- `bun install --frozen-lockfile`: clean
- `bun audit`: critical + high clean (1 pre-existing low: transitive elliptic)
- `bun run lint`: clean (3 pre-existing suppression warnings, not in these files)
- new unit + e2e: 21/21 pass; existing proxy tests unaffected
- `smoke-proxy.sh` verified end-to-end against a locally-booted proxy (health + unauth + signed all pass — the bash signer matches the proxy verifier)
- `codex review --base origin/develop`: clean (P1 hermeticity finding on the e2e dns path fixed and re-reviewed)

## what remains for a human

Railway service creation (§8 of the runbook): create a second service on the same image, set Custom Start Command to `bun packages/proxy/src/index.ts`, set the env checklist (same `STEWARD_MASTER_PASSWORD`/`STEWARD_KDF_SALT`/`STEWARD_JWT_SECRET` as the API, a `STEWARD_PROXY_REQUEST_SIGNING_SECRET`, `REDIS_URL`), point the health check at `/health` on `STEWARD_PROXY_PORT`.
