### PR TITLE
feat(policy-engine): capability-intent contributed rule + additive evaluator context

### DIFF
--- a/packages/policy-engine/src/__tests__/capability-intent.test.ts
+++ b/packages/policy-engine/src/__tests__/capability-intent.test.ts
@@ -265,12 +265,16 @@ describe("capability-intent — name matching (glob + exact + case)", () => {
   it("exact-only pattern matches only the exact name", () => {
     const denyExact = rule({ capabilities: ["github.pr.comment"], effect: "deny" });
     expect(
-      evaluateCapabilityIntent(denyExact, makeContext({ capability: cap({ name: "github.pr.comment" }) }))
-        .passed,
+      evaluateCapabilityIntent(
+        denyExact,
+        makeContext({ capability: cap({ name: "github.pr.comment" }) }),
+      ).passed,
     ).toBe(false);
     expect(
-      evaluateCapabilityIntent(denyExact, makeContext({ capability: cap({ name: "github.pr.delete" }) }))
-        .passed,
+      evaluateCapabilityIntent(
+        denyExact,
+        makeContext({ capability: cap({ name: "github.pr.delete" }) }),
+      ).passed,
     ).toBe(true); // not applicable
   });
 
@@ -286,11 +290,14 @@ describe("capability-intent — name matching (glob + exact + case)", () => {
 describe("capability-intent — config validation (fail closed)", () => {
   it("denies when capabilities is missing/empty", () => {
     expect(
-      evaluateCapabilityIntent(rule({ effect: "allow" }), makeContext({ capability: cap() })).passed,
+      evaluateCapabilityIntent(rule({ effect: "allow" }), makeContext({ capability: cap() }))
+        .passed,
     ).toBe(false);
     expect(
-      evaluateCapabilityIntent(rule({ capabilities: [], effect: "allow" }), makeContext({ capability: cap() }))
-        .passed,
+      evaluateCapabilityIntent(
+        rule({ capabilities: [], effect: "allow" }),
+        makeContext({ capability: cap() }),
+      ).passed,
     ).toBe(false);
   });
 

--- a/packages/policy-engine/src/__tests__/capability-intent.test.ts
+++ b/packages/policy-engine/src/__tests__/capability-intent.test.ts
@@ -329,6 +329,26 @@ describe("capability-intent — config validation (fail closed)", () => {
     expect(r.reason).toContain("argEquals");
   });
 
+  it("denies an unknown top-level config key (typo => fail closed)", () => {
+    const r = evaluateCapabilityIntent(
+      rule({ capabilities: ["github.*"], effect: "allow", effects: "deny" }),
+      makeContext({ capability: cap() }),
+    );
+    expect(r.passed).toBe(false);
+    expect(r.reason).toContain("unknown config key");
+  });
+
+  it("denies an unknown constraint key (misspelled maxCallPerHour => fail closed, not fail open)", () => {
+    const r = evaluateCapabilityIntent(
+      rule({ capabilities: ["github.*"], effect: "allow", constraints: { maxCallPerHour: 5 } }),
+      makeContext({ capability: cap(), capabilityInvokeCount1h: 999 }),
+    );
+    // without the guard this would ALLOW (the typo'd cap silently dropped); with
+    // it, the config is rejected and the action denied.
+    expect(r.passed).toBe(false);
+    expect(r.reason).toContain("unknown constraint key");
+  });
+
   it("config validation happens BEFORE effect, but AFTER the absent-capability short-circuit", () => {
     // absent capability => pass regardless of a bad config (inert on tx signs).
     const r = evaluateCapabilityIntent(rule({ effect: "banana" }), makeContext());

--- a/packages/policy-engine/src/__tests__/capability-intent.test.ts
+++ b/packages/policy-engine/src/__tests__/capability-intent.test.ts
@@ -329,6 +329,33 @@ describe("capability-intent — config validation (fail closed)", () => {
     expect(r.reason).toContain("argEquals");
   });
 
+  it("denies a malformed glob pattern (* not in trailing .* position => fail closed)", () => {
+    for (const bad of ["github.*.delete", "*.delete", "git*hub", "github.**", "*"]) {
+      const r = evaluateCapabilityIntent(
+        rule({ capabilities: [bad], effect: "deny" }),
+        makeContext({ capability: cap({ name: "github.pr.delete" }) }),
+      );
+      expect(r.passed).toBe(false);
+      expect(r.reason).toContain("unsupported glob");
+    }
+  });
+
+  it("accepts the supported trailing .* glob and a bare exact name", () => {
+    // sanity: valid patterns still parse (deny fires on match).
+    expect(
+      evaluateCapabilityIntent(
+        rule({ capabilities: ["github.*"], effect: "deny" }),
+        makeContext({ capability: cap({ name: "github.pr.delete" }) }),
+      ).passed,
+    ).toBe(false);
+    expect(
+      evaluateCapabilityIntent(
+        rule({ capabilities: ["github.pr.comment"], effect: "deny" }),
+        makeContext({ capability: cap({ name: "github.pr.comment" }) }),
+      ).passed,
+    ).toBe(false);
+  });
+
   it("denies an unknown top-level config key (typo => fail closed)", () => {
     const r = evaluateCapabilityIntent(
       rule({ capabilities: ["github.*"], effect: "allow", effects: "deny" }),

--- a/packages/policy-engine/src/__tests__/capability-intent.test.ts
+++ b/packages/policy-engine/src/__tests__/capability-intent.test.ts
@@ -23,6 +23,7 @@ import {
   capabilityIntentContribution,
   evaluateCapabilityIntent,
 } from "../capability-intent";
+import { PolicyEngine } from "../engine";
 import { type EvaluatorContext, evaluatePolicy } from "../evaluators";
 import { policyRuleRegistry } from "../policy-rule-registry";
 
@@ -404,6 +405,105 @@ describe("capability-intent — registry integration (end-to-end via evaluatePol
       makeContext(), // a normal transaction sign, no capability channel
     );
     expect(result.passed).toBe(true);
+  });
+});
+
+describe("capability-intent — PolicyEngine.evaluate seam (capability ctx must flow through)", () => {
+  function capRule(config: Record<string, unknown>, id = "cr1"): PolicyRule {
+    return { id, type: CAPABILITY_INTENT_RULE_TYPE as PolicyRule["type"], enabled: true, config };
+  }
+  function engineCtx(overrides: Partial<EvaluatorContext> = {}) {
+    return {
+      request: {
+        agentId: "a",
+        tenantId: "t",
+        to: "0x1234567890123456789012345678901234567890",
+        value: "0",
+        chainId: 8453,
+      } as SignRequest,
+      recentTxCount24h: 0,
+      recentTxCount1h: 0,
+      spentToday: 0n,
+      spentThisWeek: 0n,
+      ...overrides,
+    };
+  }
+
+  it("a deny rule ENFORCES through PolicyEngine.evaluate when capability ctx is present", async () => {
+    policyRuleRegistry.register({
+      type: capabilityIntentContribution.type,
+      pluginName: "capability-plugin",
+      evaluate: capabilityIntentContribution.evaluate,
+    });
+    const engine = new PolicyEngine();
+    const result = await engine.evaluate(
+      [capRule({ capabilities: ["github.*"], effect: "deny" })],
+      engineCtx({ capability: cap({ name: "github.pr.delete" }) }),
+    );
+    // if the engine dropped ctx.capability, this would be approved:true (inert pass).
+    expect(result.approved).toBe(false);
+    expect(result.requiresManualApproval).toBe(false);
+  });
+
+  it("require-approval routes to manual approval through the engine", async () => {
+    policyRuleRegistry.register({
+      type: capabilityIntentContribution.type,
+      pluginName: "capability-plugin",
+      evaluate: capabilityIntentContribution.evaluate,
+    });
+    const engine = new PolicyEngine();
+    const result = await engine.evaluate(
+      [capRule({ capabilities: ["github.*"], effect: "require-approval" })],
+      engineCtx({ capability: cap() }),
+    );
+    expect(result.approved).toBe(false);
+    expect(result.requiresManualApproval).toBe(true);
+  });
+
+  it("maxCallsPerHour reads capabilityInvokeCount1h through the engine seam", async () => {
+    policyRuleRegistry.register({
+      type: capabilityIntentContribution.type,
+      pluginName: "capability-plugin",
+      evaluate: capabilityIntentContribution.evaluate,
+    });
+    const engine = new PolicyEngine();
+    const over = await engine.evaluate(
+      [
+        capRule({
+          capabilities: ["github.*"],
+          effect: "allow",
+          constraints: { maxCallsPerHour: 2 },
+        }),
+      ],
+      engineCtx({ capability: cap(), capabilityInvokeCount1h: 2 }),
+    );
+    expect(over.approved).toBe(false);
+    const under = await engine.evaluate(
+      [
+        capRule({
+          capabilities: ["github.*"],
+          effect: "allow",
+          constraints: { maxCallsPerHour: 2 },
+        }),
+      ],
+      engineCtx({ capability: cap(), capabilityInvokeCount1h: 1 }),
+    );
+    expect(under.approved).toBe(true);
+  });
+
+  it("stays inert on an ordinary tx sign through the engine (no capability ctx)", async () => {
+    policyRuleRegistry.register({
+      type: capabilityIntentContribution.type,
+      pluginName: "capability-plugin",
+      evaluate: capabilityIntentContribution.evaluate,
+    });
+    const engine = new PolicyEngine();
+    const result = await engine.evaluate(
+      [capRule({ capabilities: ["github.*"], effect: "deny" })],
+      engineCtx(), // no capability channel
+    );
+    // rule is inert (passes); with only this rule, all hard policies pass => approved.
+    expect(result.approved).toBe(true);
   });
 });
 

--- a/packages/policy-engine/src/__tests__/capability-intent.test.ts
+++ b/packages/policy-engine/src/__tests__/capability-intent.test.ts
@@ -1,0 +1,436 @@
+/**
+ * capability-intent.test.ts — proves the `capability-intent` contributed rule
+ * (W-1b) at the policy-engine layer:
+ *
+ *  - APPLICABILITY: inert when ctx.capability is absent; not-applicable (pass)
+ *    when the invoked capability name doesn't match the rule's list.
+ *  - EFFECTS: allow / deny / require-approval (incl. the requiresManualApproval
+ *    signal shape, and that it survives the registry passthrough).
+ *  - CONSTRAINTS: argEquals (hit/miss/missing-arg), argMatches (match / no-match
+ *    / invalid-regex-in-config => deny-no-throw), maxCallsPerHour (absent count
+ *    => deny; under/over limit).
+ *  - GLOB: "github.*" prefix match, exact-only, case sensitivity.
+ *  - CONFIG VALIDATION: malformed config fails closed.
+ *  - REGISTRY INTEGRATION: registered under its type and driven end-to-end
+ *    through evaluatePolicy's default arm with ctx.capability set.
+ *  - COMPOSITION: multiple capability-intent rules under all-must-pass.
+ */
+
+import { afterEach, describe, expect, it } from "bun:test";
+import type { ContributedPolicyRule, PolicyRule, SignRequest } from "@stwd/shared";
+import {
+  CAPABILITY_INTENT_RULE_TYPE,
+  capabilityIntentContribution,
+  evaluateCapabilityIntent,
+} from "../capability-intent";
+import { type EvaluatorContext, evaluatePolicy } from "../evaluators";
+import { policyRuleRegistry } from "../policy-rule-registry";
+
+function makeContext(overrides: Partial<EvaluatorContext> = {}): EvaluatorContext {
+  const request: SignRequest = {
+    agentId: "test-agent",
+    tenantId: "test-tenant",
+    to: "0x1234567890123456789012345678901234567890",
+    value: "1000000000000000000",
+    chainId: 8453,
+  };
+  return {
+    request,
+    recentTxCount1h: 0,
+    recentTxCount24h: 0,
+    spentToday: 0n,
+    spentThisWeek: 0n,
+    ...overrides,
+  };
+}
+
+function cap(
+  overrides: Partial<NonNullable<EvaluatorContext["capability"]>> = {},
+): NonNullable<EvaluatorContext["capability"]> {
+  return {
+    name: "github.pr.comment",
+    args: {},
+    host: "api.github.com",
+    path: "/repos/x/y/issues/1/comments",
+    method: "POST",
+    ...overrides,
+  };
+}
+
+function rule(config: Record<string, unknown>, id = "cr1"): ContributedPolicyRule {
+  return { id, type: CAPABILITY_INTENT_RULE_TYPE, enabled: true, config };
+}
+
+afterEach(() => {
+  policyRuleRegistry.clear();
+});
+
+describe("capability-intent — applicability (fail-open only where safe)", () => {
+  it("passes (inert) when ctx.capability is absent — cannot interfere with tx signing", () => {
+    const r = evaluateCapabilityIntent(
+      rule({ capabilities: ["github.*"], effect: "deny" }),
+      makeContext(),
+    );
+    expect(r.passed).toBe(true);
+    expect(r.reason).toBe("not a capability invoke");
+  });
+
+  it("passes (not applicable) when the capability name is not governed by the rule", () => {
+    const r = evaluateCapabilityIntent(
+      rule({ capabilities: ["gitlab.*"], effect: "deny" }),
+      makeContext({ capability: cap({ name: "github.pr.comment" }) }),
+    );
+    expect(r.passed).toBe(true);
+    expect(r.reason).toContain("not governed");
+  });
+});
+
+describe("capability-intent — effects", () => {
+  it("allow: matched capability with no constraints passes", () => {
+    const r = evaluateCapabilityIntent(
+      rule({ capabilities: ["github.pr.comment"], effect: "allow" }),
+      makeContext({ capability: cap() }),
+    );
+    expect(r.passed).toBe(true);
+    expect(r.reason).toContain("allowed");
+  });
+
+  it("deny: matched capability is denied", () => {
+    const r = evaluateCapabilityIntent(
+      rule({ capabilities: ["github.pr.comment"], effect: "deny" }),
+      makeContext({ capability: cap() }),
+    );
+    expect(r.passed).toBe(false);
+    expect(r.reason).toContain("denied");
+  });
+
+  it("require-approval: matched capability fails with requiresManualApproval:true", () => {
+    const r = evaluateCapabilityIntent(
+      rule({ capabilities: ["github.pr.comment"], effect: "require-approval" }),
+      makeContext({ capability: cap() }),
+    );
+    expect(r.passed).toBe(false);
+    expect((r as { requiresManualApproval?: boolean }).requiresManualApproval).toBe(true);
+    expect(r.reason).toContain("manual approval");
+  });
+});
+
+describe("capability-intent — argEquals constraint", () => {
+  const base = { capabilities: ["github.*"], effect: "allow" as const };
+
+  it("passes when every configured arg strictly equals", () => {
+    const r = evaluateCapabilityIntent(
+      rule({ ...base, constraints: { argEquals: { repo: "steward" } } }),
+      makeContext({ capability: cap({ args: { repo: "steward" } }) }),
+    );
+    expect(r.passed).toBe(true);
+  });
+
+  it("denies on a mismatch", () => {
+    const r = evaluateCapabilityIntent(
+      rule({ ...base, constraints: { argEquals: { repo: "steward" } } }),
+      makeContext({ capability: cap({ args: { repo: "other" } }) }),
+    );
+    expect(r.passed).toBe(false);
+    expect(r.reason).toContain('must equal "steward"');
+  });
+
+  it("denies when the required arg is absent (fail closed)", () => {
+    const r = evaluateCapabilityIntent(
+      rule({ ...base, constraints: { argEquals: { repo: "steward" } } }),
+      makeContext({ capability: cap({ args: {} }) }),
+    );
+    expect(r.passed).toBe(false);
+    expect(r.reason).toContain("is absent");
+  });
+
+  it("denies a non-string arg (strict === against configured string)", () => {
+    const r = evaluateCapabilityIntent(
+      rule({ ...base, constraints: { argEquals: { count: "3" } } }),
+      makeContext({ capability: cap({ args: { count: 3 } }) }),
+    );
+    expect(r.passed).toBe(false);
+  });
+});
+
+describe("capability-intent — argMatches constraint", () => {
+  const base = { capabilities: ["github.*"], effect: "allow" as const };
+
+  it("passes when the arg matches the (anchored) regex", () => {
+    const r = evaluateCapabilityIntent(
+      rule({ ...base, constraints: { argMatches: { branch: "feat/.+" } } }),
+      makeContext({ capability: cap({ args: { branch: "feat/x" } }) }),
+    );
+    expect(r.passed).toBe(true);
+  });
+
+  it("denies a partial match (full-string anchored)", () => {
+    const r = evaluateCapabilityIntent(
+      rule({ ...base, constraints: { argMatches: { branch: "feat" } } }),
+      makeContext({ capability: cap({ args: { branch: "feature/x" } }) }),
+    );
+    expect(r.passed).toBe(false);
+  });
+
+  it("denies when the arg is absent", () => {
+    const r = evaluateCapabilityIntent(
+      rule({ ...base, constraints: { argMatches: { branch: ".+" } } }),
+      makeContext({ capability: cap({ args: {} }) }),
+    );
+    expect(r.passed).toBe(false);
+    expect(r.reason).toContain("is absent");
+  });
+
+  it("denies a non-string arg", () => {
+    const r = evaluateCapabilityIntent(
+      rule({ ...base, constraints: { argMatches: { n: "\\d+" } } }),
+      makeContext({ capability: cap({ args: { n: 5 } }) }),
+    );
+    expect(r.passed).toBe(false);
+  });
+
+  it("denies (never throws) on an invalid regex in config", () => {
+    const r = evaluateCapabilityIntent(
+      rule({ ...base, constraints: { argMatches: { branch: "(" } } }),
+      makeContext({ capability: cap({ args: { branch: "anything" } }) }),
+    );
+    expect(r.passed).toBe(false);
+    expect(r.reason).toContain("invalid regex");
+  });
+});
+
+describe("capability-intent — maxCallsPerHour constraint (fail closed)", () => {
+  const base = { capabilities: ["github.*"], effect: "allow" as const };
+
+  it("DENIES when maxCallsPerHour is set but capabilityInvokeCount1h is absent", () => {
+    const r = evaluateCapabilityIntent(
+      rule({ ...base, constraints: { maxCallsPerHour: 5 } }),
+      makeContext({ capability: cap() }), // no capabilityInvokeCount1h
+    );
+    expect(r.passed).toBe(false);
+    expect(r.reason).toContain("invoke count not wired");
+  });
+
+  it("passes when the invoke count is under the limit", () => {
+    const r = evaluateCapabilityIntent(
+      rule({ ...base, constraints: { maxCallsPerHour: 5 } }),
+      makeContext({ capability: cap(), capabilityInvokeCount1h: 4 }),
+    );
+    expect(r.passed).toBe(true);
+  });
+
+  it("denies when the invoke count has reached the limit", () => {
+    const r = evaluateCapabilityIntent(
+      rule({ ...base, constraints: { maxCallsPerHour: 5 } }),
+      makeContext({ capability: cap(), capabilityInvokeCount1h: 5 }),
+    );
+    expect(r.passed).toBe(false);
+    expect(r.reason).toContain("hourly invoke cap reached");
+  });
+});
+
+describe("capability-intent — name matching (glob + exact + case)", () => {
+  it('"github.*" matches "github.pr.comment"', () => {
+    const r = evaluateCapabilityIntent(
+      rule({ capabilities: ["github.*"], effect: "deny" }),
+      makeContext({ capability: cap({ name: "github.pr.comment" }) }),
+    );
+    expect(r.passed).toBe(false);
+  });
+
+  it('"github.*" does NOT match "gitlab.pr.x"', () => {
+    const r = evaluateCapabilityIntent(
+      rule({ capabilities: ["github.*"], effect: "deny" }),
+      makeContext({ capability: cap({ name: "gitlab.pr.x" }) }),
+    );
+    expect(r.passed).toBe(true); // not applicable
+  });
+
+  it('"github.*" does NOT match bare "github" (prefix requires the dot)', () => {
+    const r = evaluateCapabilityIntent(
+      rule({ capabilities: ["github.*"], effect: "deny" }),
+      makeContext({ capability: cap({ name: "github" }) }),
+    );
+    expect(r.passed).toBe(true);
+  });
+
+  it('"github.*" does NOT match "githubx.y" (no substring/general glob)', () => {
+    const r = evaluateCapabilityIntent(
+      rule({ capabilities: ["github.*"], effect: "deny" }),
+      makeContext({ capability: cap({ name: "githubx.y" }) }),
+    );
+    expect(r.passed).toBe(true);
+  });
+
+  it("exact-only pattern matches only the exact name", () => {
+    const denyExact = rule({ capabilities: ["github.pr.comment"], effect: "deny" });
+    expect(
+      evaluateCapabilityIntent(denyExact, makeContext({ capability: cap({ name: "github.pr.comment" }) }))
+        .passed,
+    ).toBe(false);
+    expect(
+      evaluateCapabilityIntent(denyExact, makeContext({ capability: cap({ name: "github.pr.delete" }) }))
+        .passed,
+    ).toBe(true); // not applicable
+  });
+
+  it("matching is case-sensitive", () => {
+    const r = evaluateCapabilityIntent(
+      rule({ capabilities: ["GitHub.*"], effect: "deny" }),
+      makeContext({ capability: cap({ name: "github.pr.comment" }) }),
+    );
+    expect(r.passed).toBe(true); // no case-insensitive match -> not applicable
+  });
+});
+
+describe("capability-intent — config validation (fail closed)", () => {
+  it("denies when capabilities is missing/empty", () => {
+    expect(
+      evaluateCapabilityIntent(rule({ effect: "allow" }), makeContext({ capability: cap() })).passed,
+    ).toBe(false);
+    expect(
+      evaluateCapabilityIntent(rule({ capabilities: [], effect: "allow" }), makeContext({ capability: cap() }))
+        .passed,
+    ).toBe(false);
+  });
+
+  it("denies an unknown effect", () => {
+    const r = evaluateCapabilityIntent(
+      rule({ capabilities: ["github.*"], effect: "maybe" }),
+      makeContext({ capability: cap() }),
+    );
+    expect(r.passed).toBe(false);
+    expect(r.reason).toContain("effect");
+  });
+
+  it("denies a non-integer maxCallsPerHour", () => {
+    const r = evaluateCapabilityIntent(
+      rule({ capabilities: ["github.*"], effect: "allow", constraints: { maxCallsPerHour: 1.5 } }),
+      makeContext({ capability: cap(), capabilityInvokeCount1h: 0 }),
+    );
+    expect(r.passed).toBe(false);
+    expect(r.reason).toContain("maxCallsPerHour");
+  });
+
+  it("denies non-string-record argEquals", () => {
+    const r = evaluateCapabilityIntent(
+      rule({ capabilities: ["github.*"], effect: "allow", constraints: { argEquals: { k: 3 } } }),
+      makeContext({ capability: cap() }),
+    );
+    expect(r.passed).toBe(false);
+    expect(r.reason).toContain("argEquals");
+  });
+
+  it("config validation happens BEFORE effect, but AFTER the absent-capability short-circuit", () => {
+    // absent capability => pass regardless of a bad config (inert on tx signs).
+    const r = evaluateCapabilityIntent(rule({ effect: "banana" }), makeContext());
+    expect(r.passed).toBe(true);
+    expect(r.reason).toBe("not a capability invoke");
+  });
+});
+
+describe("capability-intent — registry integration (end-to-end via evaluatePolicy)", () => {
+  function coreRule(type: string, config: Record<string, unknown> = {}, id = "r1"): PolicyRule {
+    return { id, type: type as PolicyRule["type"], enabled: true, config };
+  }
+
+  it("registers under its type and runs through the default arm with ctx.capability set", async () => {
+    policyRuleRegistry.register({
+      type: capabilityIntentContribution.type,
+      pluginName: "capability-plugin",
+      evaluate: capabilityIntentContribution.evaluate,
+    });
+
+    const allowed = await evaluatePolicy(
+      coreRule(CAPABILITY_INTENT_RULE_TYPE, { capabilities: ["github.*"], effect: "allow" }),
+      makeContext({ capability: cap() }),
+    );
+    expect(allowed.passed).toBe(true);
+    expect(allowed.type).toBe(CAPABILITY_INTENT_RULE_TYPE);
+
+    const denied = await evaluatePolicy(
+      coreRule(CAPABILITY_INTENT_RULE_TYPE, { capabilities: ["github.*"], effect: "deny" }),
+      makeContext({ capability: cap() }),
+    );
+    expect(denied.passed).toBe(false);
+  });
+
+  it("require-approval signal SURVIVES the registry passthrough", async () => {
+    policyRuleRegistry.register({
+      type: capabilityIntentContribution.type,
+      pluginName: "capability-plugin",
+      evaluate: capabilityIntentContribution.evaluate,
+    });
+    const result = await evaluatePolicy(
+      coreRule(CAPABILITY_INTENT_RULE_TYPE, {
+        capabilities: ["github.pr.delete"],
+        effect: "require-approval",
+      }),
+      makeContext({ capability: cap({ name: "github.pr.delete" }) }),
+    );
+    expect(result.passed).toBe(false);
+    expect(result.requiresManualApproval).toBe(true);
+  });
+
+  it("does NOT forward requiresManualApproval on a passing result", async () => {
+    policyRuleRegistry.register({
+      type: capabilityIntentContribution.type,
+      pluginName: "capability-plugin",
+      evaluate: capabilityIntentContribution.evaluate,
+    });
+    const result = await evaluatePolicy(
+      coreRule(CAPABILITY_INTENT_RULE_TYPE, { capabilities: ["github.*"], effect: "allow" }),
+      makeContext({ capability: cap() }),
+    );
+    expect(result.passed).toBe(true);
+    expect(result.requiresManualApproval).toBeUndefined();
+  });
+
+  it("inert on an ordinary tx sign (no ctx.capability) through the engine", async () => {
+    policyRuleRegistry.register({
+      type: capabilityIntentContribution.type,
+      pluginName: "capability-plugin",
+      evaluate: capabilityIntentContribution.evaluate,
+    });
+    const result = await evaluatePolicy(
+      coreRule(CAPABILITY_INTENT_RULE_TYPE, { capabilities: ["github.*"], effect: "deny" }),
+      makeContext(), // a normal transaction sign, no capability channel
+    );
+    expect(result.passed).toBe(true);
+  });
+});
+
+describe("capability-intent — multi-rule composition (all-must-pass)", () => {
+  // The engine composes rules with all-must-pass; the invoke layer (W-1c) adds
+  // the effective default-deny. These assertions model that composition at the
+  // rule level: a deny match fails; an allow match that passes constraints
+  // passes; a non-match is inert.
+  it("a deny rule fails even alongside an allow rule for the same capability", () => {
+    const allow = evaluateCapabilityIntent(
+      rule({ capabilities: ["github.*"], effect: "allow" }),
+      makeContext({ capability: cap() }),
+    );
+    const deny = evaluateCapabilityIntent(
+      rule({ capabilities: ["github.pr.comment"], effect: "deny" }),
+      makeContext({ capability: cap() }),
+    );
+    expect(allow.passed).toBe(true);
+    expect(deny.passed).toBe(false);
+    // all-must-pass => the composite is a deny.
+    expect(allow.passed && deny.passed).toBe(false);
+  });
+
+  it("rules that don't match are inert (pass) and don't block a matching allow", () => {
+    const other = evaluateCapabilityIntent(
+      rule({ capabilities: ["gitlab.*"], effect: "deny" }),
+      makeContext({ capability: cap() }),
+    );
+    const allow = evaluateCapabilityIntent(
+      rule({ capabilities: ["github.*"], effect: "allow" }),
+      makeContext({ capability: cap() }),
+    );
+    expect(other.passed).toBe(true);
+    expect(allow.passed).toBe(true);
+    expect(other.passed && allow.passed).toBe(true);
+  });
+});

--- a/packages/policy-engine/src/capability-intent.ts
+++ b/packages/policy-engine/src/capability-intent.ts
@@ -152,6 +152,21 @@ function parseConfig(raw: Record<string, unknown>): CapabilityIntentConfig | { e
     return { error: "capability-intent: `capabilities` must be a non-empty string[]" };
   }
 
+  // FAIL CLOSED on malformed patterns: `*` is supported ONLY as a single
+  // trailing `.*` prefix glob (e.g. `github.*`). Any other `*` usage (e.g.
+  // `github.*.delete`, `*.delete`, `git*hub`) would be treated by
+  // `patternMatches` as an exact literal that can never match, silently making
+  // a deny/require-approval rule inert. Reject it at parse so the misconfig
+  // denies instead of passing (codex P2).
+  const badPattern = (capabilities as string[]).find(
+    (p) => p.includes("*") && !(p.endsWith(".*") && !p.slice(0, -2).includes("*")),
+  );
+  if (badPattern !== undefined) {
+    return {
+      error: `capability-intent: unsupported glob "${badPattern}" (\`*\` allowed only as a single trailing ".*")`,
+    };
+  }
+
   const effect = raw.effect;
   if (effect !== "allow" && effect !== "deny" && effect !== "require-approval") {
     return {

--- a/packages/policy-engine/src/capability-intent.ts
+++ b/packages/policy-engine/src/capability-intent.ts
@@ -127,7 +127,22 @@ function capabilityMatches(config: CapabilityIntentConfig, name: string): boolea
  * Validate the (opaque) rule config into a typed shape, or return an error
  * reason. FAIL CLOSED: anything malformed is rejected (the caller denies).
  */
+const ALLOWED_CONFIG_KEYS: ReadonlySet<string> = new Set(["capabilities", "effect", "constraints"]);
+const ALLOWED_CONSTRAINT_KEYS: ReadonlySet<string> = new Set([
+  "maxCallsPerHour",
+  "argEquals",
+  "argMatches",
+]);
+
 function parseConfig(raw: Record<string, unknown>): CapabilityIntentConfig | { error: string } {
+  // FAIL CLOSED on unknown top-level keys: a misspelled key (e.g. `capabilties`
+  // or `effects`) must never be silently ignored, since that could drop the
+  // intended gate and let an action through unconstrained.
+  const unknownTop = Object.keys(raw).filter((k) => !ALLOWED_CONFIG_KEYS.has(k));
+  if (unknownTop.length > 0) {
+    return { error: `capability-intent: unknown config key(s): ${unknownTop.join(", ")}` };
+  }
+
   const capabilities = raw.capabilities;
   if (
     !Array.isArray(capabilities) ||
@@ -152,6 +167,15 @@ function parseConfig(raw: Record<string, unknown>): CapabilityIntentConfig | { e
       return { error: "capability-intent: `constraints` must be an object when present" };
     }
     const c = raw.constraints as Record<string, unknown>;
+
+    // FAIL CLOSED on unknown constraint keys: a typo like `maxCallPerHour` must
+    // deny, not silently drop the rate cap on an `allow` rule (codex P2).
+    const unknownConstraint = Object.keys(c).filter((k) => !ALLOWED_CONSTRAINT_KEYS.has(k));
+    if (unknownConstraint.length > 0) {
+      return {
+        error: `capability-intent: unknown constraint key(s): ${unknownConstraint.join(", ")}`,
+      };
+    }
 
     if (c.maxCallsPerHour !== undefined) {
       if (

--- a/packages/policy-engine/src/capability-intent.ts
+++ b/packages/policy-engine/src/capability-intent.ts
@@ -1,0 +1,355 @@
+/**
+ * capability-intent.ts — the `capability-intent` contributed policy rule.
+ *
+ * WHAT THIS GATES
+ * ---------------
+ * a `capability-intent` rule governs whether an agent may INVOKE a named
+ * capability (e.g. `github.pr.comment`) through Steward's capability layer. it
+ * is the per-call-intent policy the credential plane leans on before delegating
+ * to the proxy: the invoke route (W-1c) populates `ctx.capability` with the
+ * capability name/args/host/path/method, and this rule decides allow / deny /
+ * require-approval, plus argument- and rate-constraints.
+ *
+ * WHY IT LIVES HERE (policy-engine) BUT LOOKS LIKE A PLUGIN CONTRIBUTION
+ * ---------------------------------------------------------------------
+ * it is authored AS a {@link PolicyRuleContribution} — the exact shape a plugin
+ * registers via the Phase-2b registry — so W-1a's capability plugin can register
+ * it through the plugin host with ZERO rework. but the evaluator + config schema
+ * + tests are a library export of `@stwd/policy-engine` (not a route, not a
+ * package): W-1b ships the decision logic; the plugin package (W-1a) owns
+ * registration; the invoke path (W-1c) owns wiring the context + the effective
+ * default-deny (see the INVOKE-LAYER CONTRACT below).
+ *
+ * FAIL-CLOSED EVERYWHERE
+ * ----------------------
+ * this rule sits in front of live credentials (money-rail-adjacent), so every
+ * ambiguity denies: a missing/mistyped config, a constrained arg that is absent,
+ * an invalid regex in config, a rate cap without a count — all deny. the rule
+ * NEVER throws (a throw would be caught by the registry as a deny, but we prefer
+ * an explicit reason) and NEVER silently passes a governed action.
+ *
+ * APPLICABILITY (mirrors the typed-data pattern)
+ * ----------------------------------------------
+ *  - `ctx.capability` ABSENT  -> not a capability invoke -> PASS (this rule is
+ *    inert on ordinary transaction signs; it cannot interfere with tx signing).
+ *  - `ctx.capability` PRESENT but the capability NAME does not match this rule's
+ *    `capabilities` list -> NOT APPLICABLE -> PASS. this rule only evaluates the
+ *    capabilities it governs; whether an UNGOVERNED capability is allowed is the
+ *    invoke layer's default-deny decision, NOT this rule's.
+ *
+ * INVOKE-LAYER CONTRACT (what W-1c must implement)
+ * ------------------------------------------------
+ * the engine composes all rules with all-must-pass semantics, and this rule
+ * passes for any capability it does not name. that means "no rule allows this
+ * capability" evaluates to PASS at the engine level. therefore the EFFECTIVE
+ * DEFAULT-DENY must live in the INVOKE LAYER (W-1c):
+ *   1. resolve the grant fail-closed; if no grant, deny before policy runs.
+ *   2. after the engine's decision, REQUIRE that at least one `capability-intent`
+ *      rule MATCHED the invoked capability with `effect: "allow"` (and passed).
+ *      if the capability matched no allow rule, DENY — an invoke is permitted
+ *      only when explicitly allowed, never by the absence of a deny.
+ *   3. populate `ctx.capability` (name/args/host/path/method) AND
+ *      `ctx.capabilityInvokeCount1h` (trailing-hour invoke count for this agent)
+ *      so `maxCallsPerHour` can be enforced. absent count => this rule denies.
+ *   4. audit every invoke + decision.
+ */
+
+import type {
+  ContributedPolicyResult,
+  ContributedPolicyRule,
+  PolicyRuleContribution,
+} from "@stwd/shared";
+import type { EvaluatorContext } from "./evaluators";
+
+/** the contributed rule-type discriminator. */
+export const CAPABILITY_INTENT_RULE_TYPE = "capability-intent" as const;
+
+/** The effect a matching `capability-intent` rule applies. */
+export type CapabilityIntentEffect = "allow" | "deny" | "require-approval";
+
+/** Constraints evaluated ONLY on an `effect: "allow"` match. */
+export interface CapabilityIntentConstraints {
+  /**
+   * Max capability INVOKES per trailing hour. Evaluated against
+   * `ctx.capabilityInvokeCount1h` (NOT the tx counter). If this is set but the
+   * count is absent, the rule DENIES (fail closed) — the invoke layer (W-1c)
+   * must wire the count.
+   */
+  readonly maxCallsPerHour?: number;
+  /**
+   * Every key must exist in `ctx.capability.args` and STRICTLY (===) equal the
+   * configured string. A missing arg or a mismatch denies.
+   */
+  readonly argEquals?: Record<string, string>;
+  /**
+   * Every key must exist in `ctx.capability.args` and match the configured
+   * regex (full-string, anchored). A missing arg, a non-string arg, or a
+   * no-match denies. An INVALID regex in config denies (compiled defensively;
+   * never throws).
+   */
+  readonly argMatches?: Record<string, string>;
+}
+
+/** The jsonb config of a `capability-intent` rule. */
+export interface CapabilityIntentConfig {
+  /**
+   * Capability names this rule governs. Exact names (`github.pr.comment`) or a
+   * SINGLE trailing-`.*` prefix glob (`github.*` matches `github.pr.comment`).
+   * No general globbing. Case-sensitive.
+   */
+  readonly capabilities: string[];
+  readonly effect: CapabilityIntentEffect;
+  readonly constraints?: CapabilityIntentConstraints;
+}
+
+/**
+ * Match a capability name against a single pattern.
+ *   - trailing `.*` => prefix match on everything before the `.` (so `github.*`
+ *     matches `github.pr.comment` and `github.x`, but NOT `github` itself and
+ *     NOT `githubx.y`).
+ *   - otherwise exact, case-sensitive.
+ */
+function patternMatches(pattern: string, name: string): boolean {
+  if (typeof pattern !== "string" || pattern.length === 0) return false;
+  if (pattern.endsWith(".*")) {
+    const prefix = pattern.slice(0, -1); // keep the trailing "." e.g. "github."
+    return name.startsWith(prefix);
+  }
+  return pattern === name;
+}
+
+/** True when any configured pattern matches the invoked capability name. */
+function capabilityMatches(config: CapabilityIntentConfig, name: string): boolean {
+  return config.capabilities.some((pattern) => patternMatches(pattern, name));
+}
+
+/**
+ * Validate the (opaque) rule config into a typed shape, or return an error
+ * reason. FAIL CLOSED: anything malformed is rejected (the caller denies).
+ */
+function parseConfig(raw: Record<string, unknown>): CapabilityIntentConfig | { error: string } {
+  const capabilities = raw.capabilities;
+  if (
+    !Array.isArray(capabilities) ||
+    capabilities.length === 0 ||
+    !capabilities.every((c) => typeof c === "string" && c.length > 0)
+  ) {
+    return { error: "capability-intent: `capabilities` must be a non-empty string[]" };
+  }
+
+  const effect = raw.effect;
+  if (effect !== "allow" && effect !== "deny" && effect !== "require-approval") {
+    return {
+      error: `capability-intent: \`effect\` must be "allow" | "deny" | "require-approval" (got ${String(
+        effect,
+      )})`,
+    };
+  }
+
+  let constraints: CapabilityIntentConstraints | undefined;
+  if (raw.constraints !== undefined) {
+    if (typeof raw.constraints !== "object" || raw.constraints === null) {
+      return { error: "capability-intent: `constraints` must be an object when present" };
+    }
+    const c = raw.constraints as Record<string, unknown>;
+
+    if (c.maxCallsPerHour !== undefined) {
+      if (
+        typeof c.maxCallsPerHour !== "number" ||
+        !Number.isFinite(c.maxCallsPerHour) ||
+        c.maxCallsPerHour < 0 ||
+        !Number.isInteger(c.maxCallsPerHour)
+      ) {
+        return {
+          error: "capability-intent: `constraints.maxCallsPerHour` must be a non-negative integer",
+        };
+      }
+    }
+
+    if (c.argEquals !== undefined && !isStringRecord(c.argEquals)) {
+      return { error: "capability-intent: `constraints.argEquals` must be Record<string,string>" };
+    }
+    if (c.argMatches !== undefined && !isStringRecord(c.argMatches)) {
+      return { error: "capability-intent: `constraints.argMatches` must be Record<string,string>" };
+    }
+
+    constraints = {
+      ...(c.maxCallsPerHour !== undefined ? { maxCallsPerHour: c.maxCallsPerHour as number } : {}),
+      ...(c.argEquals !== undefined ? { argEquals: c.argEquals as Record<string, string> } : {}),
+      ...(c.argMatches !== undefined ? { argMatches: c.argMatches as Record<string, string> } : {}),
+    };
+  }
+
+  return {
+    capabilities: capabilities as string[],
+    effect,
+    ...(constraints !== undefined ? { constraints } : {}),
+  };
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  return Object.values(value).every((v) => typeof v === "string");
+}
+
+/**
+ * Evaluate the constraints on an `effect: "allow"` match. Returns a deny result
+ * on the FIRST failed constraint, or `null` when every constraint holds.
+ */
+function evaluateConstraints(
+  base: { policyId: string; type: string },
+  constraints: CapabilityIntentConstraints,
+  capability: NonNullable<EvaluatorContext["capability"]>,
+  ctx: EvaluatorContext,
+): ContributedPolicyResult | null {
+  const { args } = capability;
+
+  // argEquals: every key must exist and strictly equal the configured string.
+  if (constraints.argEquals) {
+    for (const [key, expected] of Object.entries(constraints.argEquals)) {
+      if (!Object.hasOwn(args, key)) {
+        return {
+          ...base,
+          passed: false,
+          reason: `capability-intent: required arg "${key}" is absent`,
+        };
+      }
+      if (args[key] !== expected) {
+        return {
+          ...base,
+          passed: false,
+          reason: `capability-intent: arg "${key}" must equal "${expected}"`,
+        };
+      }
+    }
+  }
+
+  // argMatches: every key must exist, be a string, and match the (defensively
+  // compiled) regex. Invalid regex in config => deny (never throw).
+  if (constraints.argMatches) {
+    for (const [key, pattern] of Object.entries(constraints.argMatches)) {
+      let re: RegExp;
+      try {
+        // anchor full-string so a partial match can't slip a governed arg.
+        re = new RegExp(`^(?:${pattern})$`);
+      } catch {
+        return {
+          ...base,
+          passed: false,
+          reason: `capability-intent: invalid regex for arg "${key}" in config`,
+        };
+      }
+      if (!Object.hasOwn(args, key)) {
+        return {
+          ...base,
+          passed: false,
+          reason: `capability-intent: required arg "${key}" is absent`,
+        };
+      }
+      const value = args[key];
+      if (typeof value !== "string" || !re.test(value)) {
+        return {
+          ...base,
+          passed: false,
+          reason: `capability-intent: arg "${key}" does not match required pattern`,
+        };
+      }
+    }
+  }
+
+  // maxCallsPerHour: evaluate against the capability-invoke counter. Absent
+  // count => DENY (fail closed): we never borrow the tx counter and never
+  // silently pass a rate cap.
+  if (constraints.maxCallsPerHour !== undefined) {
+    const count = ctx.capabilityInvokeCount1h;
+    if (typeof count !== "number" || !Number.isFinite(count)) {
+      return {
+        ...base,
+        passed: false,
+        reason:
+          "capability-intent: maxCallsPerHour set but capabilityInvokeCount1h is absent (invoke count not wired)",
+      };
+    }
+    if (count >= constraints.maxCallsPerHour) {
+      return {
+        ...base,
+        passed: false,
+        reason: `capability-intent: hourly invoke cap reached (${constraints.maxCallsPerHour})`,
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * The `capability-intent` evaluator. See the file header for the full semantics.
+ */
+export function evaluateCapabilityIntent(
+  rule: ContributedPolicyRule,
+  ctx: EvaluatorContext,
+): ContributedPolicyResult {
+  const base = { policyId: rule.id, type: rule.type };
+
+  // 1. Not a capability invoke -> inert (cannot interfere with tx signing).
+  if (!ctx.capability) {
+    return { ...base, passed: true, reason: "not a capability invoke" };
+  }
+
+  // 2. Config must be well-formed (fail closed).
+  const parsed = parseConfig(rule.config);
+  if ("error" in parsed) {
+    return { ...base, passed: false, reason: parsed.error };
+  }
+
+  const { name } = ctx.capability;
+
+  // 3. This rule only governs the capabilities it names. A non-match is NOT
+  //    APPLICABLE -> pass (the invoke layer's default-deny handles ungoverned
+  //    capabilities; a plain "no matching allow" is NOT this rule's job to deny).
+  if (!capabilityMatches(parsed, name)) {
+    return { ...base, passed: true, reason: `capability "${name}" not governed by this rule` };
+  }
+
+  // 4. Matched. Apply the effect.
+  switch (parsed.effect) {
+    case "deny":
+      return {
+        ...base,
+        passed: false,
+        reason: `capability-intent: capability "${name}" is denied by policy`,
+      };
+    case "require-approval":
+      return {
+        ...base,
+        passed: false,
+        // the engine honours this via ManualApprovalSignal (see manual-approval.ts):
+        // a non-passing result carrying requiresManualApproval routes to the queue.
+        requiresManualApproval: true,
+        reason: `capability-intent: capability "${name}" requires manual approval`,
+      } as ContributedPolicyResult;
+    case "allow": {
+      if (parsed.constraints) {
+        const denial = evaluateConstraints(base, parsed.constraints, ctx.capability, ctx);
+        if (denial) return denial;
+      }
+      return {
+        ...base,
+        passed: true,
+        reason: `capability-intent: capability "${name}" allowed`,
+      };
+    }
+  }
+}
+
+/**
+ * The `capability-intent` rule as a {@link PolicyRuleContribution}, ready for the
+ * W-1a plugin to register via the plugin host with zero rework. Bound to the
+ * policy engine's {@link EvaluatorContext}.
+ */
+export const capabilityIntentContribution: PolicyRuleContribution<EvaluatorContext> = {
+  type: CAPABILITY_INTENT_RULE_TYPE,
+  description:
+    "gate a named capability invoke: allow / deny / require-approval + arg and hourly-invoke constraints (fail-closed)",
+  evaluate: evaluateCapabilityIntent,
+};

--- a/packages/policy-engine/src/engine.ts
+++ b/packages/policy-engine/src/engine.ts
@@ -77,6 +77,25 @@ export interface PolicyEvaluationContext {
     chain: string;
     curve: string;
   };
+  /**
+   * Capability-invoke context for `capability-intent` policies. The capability
+   * invoke route (W-1c) wires this from the resolved capability; absent on
+   * ordinary transaction signs, so capability policies stay inert on tx signing
+   * (mirrors the `typedData` seam).
+   */
+  capability?: {
+    name: string;
+    args: Record<string, unknown>;
+    host: string;
+    path: string;
+    method: string;
+  };
+  /**
+   * Trailing-hour capability-invoke count (distinct from `recentTxCount1h`). The
+   * invoke route (W-1c) wires this so `capability-intent`'s `maxCallsPerHour`
+   * constraint can be enforced; absent => that constraint fails closed (deny).
+   */
+  capabilityInvokeCount1h?: number;
 }
 
 export interface EvaluationResult {
@@ -181,6 +200,8 @@ export class PolicyEngine {
       aggregations: ctx.aggregations,
       typedData: ctx.typedData,
       rawSigning: ctx.rawSigning,
+      capability: ctx.capability,
+      capabilityInvokeCount1h: ctx.capabilityInvokeCount1h,
     };
 
     const results: EnginePolicyResult[] = await Promise.all(

--- a/packages/policy-engine/src/evaluators.ts
+++ b/packages/policy-engine/src/evaluators.ts
@@ -81,6 +81,30 @@ export interface EvaluatorContext {
     chain: string;
     curve: string;
   };
+  /**
+   * Capability-invoke context for `capability-intent` policies. Populated ONLY
+   * by the capability invoke route (W-1c); absent on ordinary signing requests,
+   * so a `capability-intent` policy is "not applicable" (passes) when this is
+   * undefined. Symmetry with `typedData`: capability policies cannot interfere
+   * with transaction signing, and transaction policies cannot interfere with
+   * capability invokes.
+   */
+  capability?: {
+    name: string;
+    args: Record<string, unknown>;
+    host: string;
+    path: string;
+    method: string;
+  };
+  /**
+   * Rolling count of capability INVOKES in the trailing hour (distinct from
+   * `recentTxCount1h`, which counts transaction signs). Populated ONLY by the
+   * capability invoke route (W-1c) alongside `capability`. When a
+   * `capability-intent` rule sets `constraints.maxCallsPerHour` but this count
+   * is absent, the rule FAILS CLOSED (deny) rather than borrowing the tx
+   * counter, so an unwired invoke path can never silently pass a rate cap.
+   */
+  capabilityInvokeCount1h?: number;
 }
 
 function parseUint256Decimal(value: unknown): bigint | null {

--- a/packages/policy-engine/src/index.ts
+++ b/packages/policy-engine/src/index.ts
@@ -1,14 +1,4 @@
 export type {
-  AuditHook,
-  PolicyEngineOptions,
-  PolicyEvaluatedEvent,
-  PolicyEvaluationContext,
-  PolicySimulationRequest,
-  ProxySimulationRequest,
-  TransactionSimulationRequest,
-} from "./engine";
-export { PolicyEngine } from "./engine";
-export type {
   CapabilityIntentConfig,
   CapabilityIntentConstraints,
   CapabilityIntentEffect,
@@ -18,6 +8,16 @@ export {
   capabilityIntentContribution,
   evaluateCapabilityIntent,
 } from "./capability-intent";
+export type {
+  AuditHook,
+  PolicyEngineOptions,
+  PolicyEvaluatedEvent,
+  PolicyEvaluationContext,
+  PolicySimulationRequest,
+  ProxySimulationRequest,
+  TransactionSimulationRequest,
+} from "./engine";
+export { PolicyEngine } from "./engine";
 export type { EvaluatorContext } from "./evaluators";
 export { evaluatePolicy } from "./evaluators";
 export type {

--- a/packages/policy-engine/src/index.ts
+++ b/packages/policy-engine/src/index.ts
@@ -8,6 +8,16 @@ export type {
   TransactionSimulationRequest,
 } from "./engine";
 export { PolicyEngine } from "./engine";
+export type {
+  CapabilityIntentConfig,
+  CapabilityIntentConstraints,
+  CapabilityIntentEffect,
+} from "./capability-intent";
+export {
+  CAPABILITY_INTENT_RULE_TYPE,
+  capabilityIntentContribution,
+  evaluateCapabilityIntent,
+} from "./capability-intent";
 export type { EvaluatorContext } from "./evaluators";
 export { evaluatePolicy } from "./evaluators";
 export type {

--- a/packages/policy-engine/src/policy-rule-registry.ts
+++ b/packages/policy-engine/src/policy-rule-registry.ts
@@ -37,6 +37,7 @@ import type {
   PolicyRule,
 } from "@stwd/shared";
 import type { EvaluatorContext } from "./evaluators";
+import type { ManualApprovalSignal } from "./manual-approval";
 
 /**
  * The set of rule-type discriminators the CORE owns. A plugin may NOT register an
@@ -164,16 +165,18 @@ export const policyRuleRegistry = new PolicyRuleRegistry();
 
 /**
  * Evaluate a rule whose `type` is NOT a core type by consulting the registry.
- * Returns the contributed evaluator's verdict (as a `PolicyResult`), or `null`
- * when no plugin registered an evaluator for the type (the caller then keeps its
- * existing "Unknown policy type" deny). A thrown evaluator error is converted to
- * a fail-closed deny so a buggy plugin can never crash the money-route decision.
+ * Returns the contributed evaluator's verdict (as a `PolicyResult`, optionally
+ * carrying the `requiresManualApproval` signal on a non-passing result), or
+ * `null` when no plugin registered an evaluator for the type (the caller then
+ * keeps its existing "Unknown policy type" deny). A thrown evaluator error is
+ * converted to a fail-closed deny so a buggy plugin can never crash the
+ * money-route decision.
  */
 export async function evaluateRegisteredPolicy(
   rule: PolicyRule,
   ctx: EvaluatorContext,
   registry: PolicyRuleRegistry = policyRuleRegistry,
-): Promise<PolicyResult | null> {
+): Promise<(PolicyResult & ManualApprovalSignal) | null> {
   const evaluator = registry.get(rule.type);
   if (!evaluator) return null;
   const contributedRule: ContributedPolicyRule = {
@@ -187,11 +190,22 @@ export async function evaluateRegisteredPolicy(
     // The contributed result is structurally a PolicyResult; surface it as one,
     // pinning policyId/type to the rule so a misbehaving plugin can't mislabel
     // the verdict's identity.
+    const passed = result.passed === true;
+    // Forward the manual-approval signal ONLY on a non-passing result (mirrors
+    // ManualApprovalSignal's contract in ./manual-approval: the flag is
+    // meaningless on a pass, and the engine must never treat a hard failure as
+    // "needs approval" unless the evaluator explicitly opted in). This lets a
+    // contributed rule (e.g. capability-intent's require-approval effect) route
+    // to the approval queue through the same channel a core rule uses. Absence
+    // of the flag => hard deny (fail closed).
     return {
       policyId: rule.id,
       type: rule.type as PolicyResult["type"],
-      passed: result.passed === true,
+      passed,
       ...(result.reason !== undefined ? { reason: result.reason } : {}),
+      ...(!passed && result.requiresManualApproval === true
+        ? { requiresManualApproval: true }
+        : {}),
     };
   } catch (error) {
     return {

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -52,6 +52,16 @@ export interface ContributedPolicyResult {
   readonly type: string;
   readonly passed: boolean;
   readonly reason?: string;
+  /**
+   * Optional "route to manual approval instead of hard-denying" signal,
+   * structurally identical to the engine's internal `ManualApprovalSignal`.
+   * ONLY meaningful when `passed === false` (a passing result never needs
+   * approval). The engine's registry passthrough forwards this flag ONLY on a
+   * non-passing result, so a contributed rule (e.g. `capability-intent`'s
+   * `require-approval` effect) can queue an action for human review through the
+   * same channel a core rule uses. Absent => hard deny (fail closed).
+   */
+  readonly requiresManualApproval?: boolean;
 }
 
 /**


### PR DESCRIPTION
part of #150 (phase 1: capability + policy layer). **policy-engine-side only** — W-1a builds the plugin package, W-1c wires the invoke route. do not merge until W-1c can consume this.

## what landed

**additive ctx channel** (evaluators.ts + engine.ts, both interfaces + the passthrough): `capability?: { name, args, host, path, method }` and `capabilityInvokeCount1h?: number`, populated ONLY by the capability invoke route (W-1c), absent on ordinary signs — so capability policies stay inert on tx signing and vice versa (mirrors the `typedData` seam exactly). the 16 core rule arms + the engine decision logic are byte-identical.

**`capability-intent` contributed rule** (capability-intent.ts), authored as a `PolicyRuleContribution<EvaluatorContext>` so W-1a registers it via the plugin host with zero rework:
- effects: `allow` / `deny` / `require-approval` (the last routes to the existing manual-approval queue via `requiresManualApproval`).
- constraints: `argEquals` (strict ===), `argMatches` (anchored regex, invalid regex => deny), `maxCallsPerHour` (reads `capabilityInvokeCount1h`; absent => deny).
- names: exact or a single trailing `.*` prefix glob, case-sensitive.
- **fail-closed everywhere**: absent capability => inert pass; non-matching name => not-applicable pass; malformed config / unknown keys / malformed glob / invalid regex / missing arg / absent count => deny, never throw.

**registry passthrough** (policy-rule-registry.ts): `ContributedPolicyResult` widened with optional `requiresManualApproval`, forwarded by `evaluateRegisteredPolicy` ONLY on a non-passing result (mirrors manual-approval.ts's contract) — so a contributed rule can queue for approval through the same channel a core rule uses. this is the only `packages/shared` touch (a 1-field additive widen).

## the contract W-1c must implement
1. resolve grant fail-closed (no grant => deny before policy runs).
2. **effective default-deny lives here**: after the engine decision, require that ≥1 `capability-intent` rule MATCHED the invoked capability with `effect: allow` (and passed). no matching allow => deny. this rule passes for capabilities it doesn't name (all-must-pass composition), so the invoke layer owns 'no allow => deny'.
3. populate `ctx.capability` + `ctx.capabilityInvokeCount1h` on `PolicyEvaluationContext`.
4. audit every invoke + decision.

## verify
- policy-engine suite: **285 pass / 0 fail** (243 pre-existing + 42 new).
- build closure (shared, policy-engine, api, + 10 deps): 13/13 green. frozen install clean (zero dep changes). audit: 0 critical/high (1 pre-existing low: elliptic, transitive). lint clean.
- byte-identity: `git diff` on evaluators.ts = only the interface addition; engine.ts = interface + 2 passthrough lines; no core arm / decision-logic change.
- codex (gpt-5.5, --base origin/develop): clean after 3 rounds (fixed P1 engine-ctx plumbing, P2 unknown-key rejection, P2 malformed-glob rejection).

## receipts
report: `/home/shad0w/.moltbot/projects/steward/W1B-CAPABILITY-INTENT-REPORT.md`

Co-authored-by: wakesync <shadow@shad0w.xyz>