### PR TITLE
feat(capabilities): plugin package with grants and paired route lifecycle

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -174,6 +174,24 @@
         "typescript": "^5.8.0",
       },
     },
+    "packages/plugin-capabilities": {
+      "name": "@stwd/plugin-capabilities",
+      "version": "0.1.0",
+      "dependencies": {
+        "@stwd/db": "workspace:*",
+        "@stwd/redis": "workspace:*",
+        "@stwd/shared": "workspace:*",
+        "@stwd/vault": "workspace:*",
+        "drizzle-orm": "^0.44.5",
+        "hono": "^4.12.18",
+        "zod": "^4.3.6",
+      },
+      "devDependencies": {
+        "@stwd/plugin-sdk": "workspace:*",
+        "@stwd/policy-engine": "workspace:*",
+        "@types/node": "^25.5.0",
+      },
+    },
     "packages/plugin-example": {
       "name": "@stwd/plugin-example",
       "version": "0.1.0",
@@ -1598,6 +1616,8 @@
     "@stwd/example-waifu-integration": ["@stwd/example-waifu-integration@workspace:packages/examples/waifu-integration"],
 
     "@stwd/mcp": ["@stwd/mcp@workspace:packages/mcp"],
+
+    "@stwd/plugin-capabilities": ["@stwd/plugin-capabilities@workspace:packages/plugin-capabilities"],
 
     "@stwd/plugin-example": ["@stwd/plugin-example@workspace:packages/plugin-example"],
 

--- a/packages/plugin-capabilities/bunfig.toml
+++ b/packages/plugin-capabilities/bunfig.toml
@@ -1,0 +1,9 @@
+# test config for @stwd/plugin-capabilities.
+#
+# the plugin's tests exercise the store + routes against a PGLite core schema
+# (createPGLiteDb runs the core migrations) plus this package's OWN plugin
+# migrations (applied via runPluginMigrations + the pglite migrator). the preload
+# supplies full-entropy test secrets + marks the PGLite runtime so any module that
+# resolves env-dependent invariants at import time evaluates deterministically.
+[test]
+preload = ["./test-preload.ts"]

--- a/packages/plugin-capabilities/drizzle/0000_capabilities.sql
+++ b/packages/plugin-capabilities/drizzle/0000_capabilities.sql
@@ -1,0 +1,56 @@
+-- @stwd/plugin-capabilities OWN schema. applied by the host into a per-plugin
+-- namespaced bookkeeping table (drizzle.__drizzle_migrations_plugin_capabilities),
+-- never into the core's drizzle.__drizzle_migrations journal.
+--
+-- a capability is a NAMED, narrowly-scoped use of a stored secret:
+--   name (e.g. "github.pr.comment") -> (secret_id, host, path_pattern, method)
+--   + the header-injection config the paired secret_route needs, so a capability
+--   compiles to exactly one legal narrow secret_route (the proxy's injection
+--   mechanism). host/path/method/inject_* are validated by the SHARED
+--   secret-route validator (incl. per-host strict rules) at create/update time,
+--   so a capability can never be broader than a legal route.
+--
+-- a grant is: agent X may use capability Y (optionally until expires_at).
+CREATE TABLE "capabilities" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" text NOT NULL,
+	"name" text NOT NULL,
+	"secret_id" uuid NOT NULL,
+	"host" text NOT NULL,
+	"path_pattern" text NOT NULL,
+	"method" text NOT NULL,
+	"inject_as" text DEFAULT 'header' NOT NULL,
+	"inject_key" text NOT NULL,
+	"inject_format" text DEFAULT '{value}' NOT NULL,
+	"constraints" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"enabled" boolean DEFAULT true NOT NULL,
+	"created_at" timestamptz DEFAULT now() NOT NULL,
+	"updated_at" timestamptz DEFAULT now() NOT NULL,
+	CONSTRAINT "capabilities_tenant_name_uniq" UNIQUE("tenant_id","name")
+);
+--> statement-breakpoint
+CREATE TABLE "capability_grants" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" text NOT NULL,
+	"agent_id" varchar(64) NOT NULL,
+	"capability_id" uuid NOT NULL,
+	"secret_route_id" uuid,
+	"expires_at" timestamptz,
+	"status" text DEFAULT 'active' NOT NULL,
+	"created_at" timestamptz DEFAULT now() NOT NULL,
+	CONSTRAINT "capability_grants_status_check" CHECK ("status" IN ('active','revoked')),
+	CONSTRAINT "capability_grants_tenant_agent_capability_uniq" UNIQUE("tenant_id","agent_id","capability_id"),
+	CONSTRAINT "capability_grants_capability_fk" FOREIGN KEY ("capability_id") REFERENCES "capabilities"("id") ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX "capabilities_tenant_idx" ON "capabilities" ("tenant_id");
+--> statement-breakpoint
+CREATE INDEX "capabilities_secret_idx" ON "capabilities" ("secret_id");
+--> statement-breakpoint
+CREATE INDEX "capability_grants_tenant_idx" ON "capability_grants" ("tenant_id");
+--> statement-breakpoint
+CREATE INDEX "capability_grants_agent_idx" ON "capability_grants" ("agent_id");
+--> statement-breakpoint
+CREATE INDEX "capability_grants_capability_idx" ON "capability_grants" ("capability_id");
+--> statement-breakpoint
+CREATE INDEX "capability_grants_route_idx" ON "capability_grants" ("secret_route_id");

--- a/packages/plugin-capabilities/drizzle/meta/_journal.json
+++ b/packages/plugin-capabilities/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1782800000000,
+      "tag": "0000_capabilities",
+      "breakpoints": true
+    }
+  ]
+}

--- a/packages/plugin-capabilities/package.json
+++ b/packages/plugin-capabilities/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@stwd/plugin-capabilities",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "tsc --noEmit",
+    "dev": "tsc --watch",
+    "test": "bun test --timeout 30000",
+    "typecheck": "tsc --noEmit",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@stwd/db": "workspace:*",
+    "@stwd/redis": "workspace:*",
+    "@stwd/shared": "workspace:*",
+    "@stwd/vault": "workspace:*",
+    "drizzle-orm": "^0.44.5",
+    "hono": "^4.12.18",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@stwd/plugin-sdk": "workspace:*",
+    "@stwd/policy-engine": "workspace:*",
+    "@types/node": "^25.5.0"
+  },
+  "description": "Opt-in capability plugin for Steward: named narrowly-scoped credential uses (capabilities) + per-agent grants, each paired to a narrow secret_route the proxy injects through. Operator/tenant-auth CRUD with plugin-owned namespaced migrations. The core does not depend on this package."
+}

--- a/packages/plugin-capabilities/src/__tests__/_harness.ts
+++ b/packages/plugin-capabilities/src/__tests__/_harness.ts
@@ -1,0 +1,111 @@
+/**
+ * _harness.ts — shared test setup for the capability plugin.
+ *
+ * builds a hermetic PGLite database carrying BOTH the core schema (createPGLiteDb
+ * runs the core migrations: tenants, agents, secrets, secret_routes, ...) and
+ * THIS package's own plugin migrations (capabilities, capability_grants), applied
+ * via the per-plugin migration runner + the pglite migrator. that mirrors how the
+ * host applies plugin migrations in production, into a per-plugin namespaced
+ * bookkeeping table isolated from the core journal.
+ */
+
+import { agents, secrets, secretRoutes, tenants } from "@stwd/db";
+import { runPluginMigrations } from "@stwd/db";
+import { createPGLiteDb } from "@stwd/db/pglite";
+import { migrate as pgliteMigrate } from "drizzle-orm/pglite/migrator";
+import { fileURLToPath } from "node:url";
+import { and, eq } from "drizzle-orm";
+
+const MIGRATIONS_FOLDER = fileURLToPath(new URL("../../drizzle", import.meta.url));
+
+// biome-ignore lint/suspicious/noExplicitAny: pglite db/client handles are driver-typed.
+export type TestDb = any;
+
+export interface Harness {
+  db: TestDb;
+  // biome-ignore lint/suspicious/noExplicitAny: pglite client is driver-typed.
+  client: any;
+  close(): Promise<void>;
+}
+
+/** stand up a fresh in-memory pglite with core + capability plugin schema. */
+export async function makeHarness(): Promise<Harness> {
+  process.env.STEWARD_PGLITE_MEMORY = "true";
+  const { db, client } = await createPGLiteDb("memory://");
+  // apply THIS plugin's migrations into its own namespaced ledger (driver-neutral
+  // runner, pglite migrator injected, no advisory lock — pglite has none).
+  await runPluginMigrations(
+    { id: "capabilities", migrationsFolder: MIGRATIONS_FOLDER },
+    { db, client, useAdvisoryLock: false, migrateFn: pgliteMigrate as never },
+  );
+  return {
+    db,
+    client,
+    async close() {
+      await client.close().catch(() => {});
+    },
+  };
+}
+
+export async function ensureTenant(db: TestDb, tenantId: string): Promise<void> {
+  await db
+    .insert(tenants)
+    .values({ id: tenantId, name: tenantId, apiKeyHash: `hash-${tenantId}` })
+    .onConflictDoNothing();
+}
+
+export async function ensureAgent(db: TestDb, tenantId: string, agentId: string): Promise<void> {
+  await db
+    .insert(agents)
+    .values({
+      id: agentId,
+      tenantId,
+      name: agentId,
+      walletAddress: "0x0000000000000000000000000000000000000001",
+    })
+    .onConflictDoNothing();
+}
+
+/** insert a bare secret row (the plugin only references its id, never decrypts). */
+export async function ensureSecret(
+  db: TestDb,
+  tenantId: string,
+  name: string,
+): Promise<string> {
+  const [row] = await db
+    .insert(secrets)
+    .values({
+      tenantId,
+      name,
+      ciphertext: "x",
+      iv: "x",
+      authTag: "x",
+      salt: "x",
+    })
+    .returning();
+  return row.id as string;
+}
+
+/** count the ENABLED secret_routes for a tenant (the orphan-route invariant). */
+export async function enabledRouteCount(db: TestDb, tenantId: string): Promise<number> {
+  const rows = await db
+    .select()
+    .from(secretRoutes)
+    .where(and(eq(secretRoutes.tenantId, tenantId), eq(secretRoutes.enabled, true)));
+  return rows.length;
+}
+
+/** count ALL secret_routes for a tenant (enabled or not). */
+export async function totalRouteCount(db: TestDb, tenantId: string): Promise<number> {
+  const rows = await db
+    .select()
+    .from(secretRoutes)
+    .where(eq(secretRoutes.tenantId, tenantId));
+  return rows.length;
+}
+
+/** fetch a single secret_route row by id (or null). */
+export async function getRoute(db: TestDb, id: string) {
+  const [row] = await db.select().from(secretRoutes).where(eq(secretRoutes.id, id));
+  return row ?? null;
+}

--- a/packages/plugin-capabilities/src/__tests__/_harness.ts
+++ b/packages/plugin-capabilities/src/__tests__/_harness.ts
@@ -1,5 +1,5 @@
 /**
- * _harness.ts — shared test setup for the capability plugin.
+ * _harness.ts - shared test setup for the capability plugin.
  *
  * builds a hermetic PGLite database carrying BOTH the core schema (createPGLiteDb
  * runs the core migrations: tenants, agents, secrets, secret_routes, ...) and
@@ -9,21 +9,20 @@
  * bookkeeping table isolated from the core journal.
  */
 
-import { agents, secrets, secretRoutes, tenants } from "@stwd/db";
-import { runPluginMigrations } from "@stwd/db";
-import { createPGLiteDb } from "@stwd/db/pglite";
-import { migrate as pgliteMigrate } from "drizzle-orm/pglite/migrator";
 import { fileURLToPath } from "node:url";
+import { agents, runPluginMigrations, secretRoutes, secrets, tenants } from "@stwd/db";
+import { createPGLiteDb } from "@stwd/db/pglite";
 import { and, eq } from "drizzle-orm";
+import { migrate as pgliteMigrate } from "drizzle-orm/pglite/migrator";
 
 const MIGRATIONS_FOLDER = fileURLToPath(new URL("../../drizzle", import.meta.url));
 
-// biome-ignore lint/suspicious/noExplicitAny: pglite db/client handles are driver-typed.
+// note (any is intentional): pglite db/client handles are driver-typed.
 export type TestDb = any;
 
 export interface Harness {
   db: TestDb;
-  // biome-ignore lint/suspicious/noExplicitAny: pglite client is driver-typed.
+  // note (any is intentional): pglite client is driver-typed.
   client: any;
   close(): Promise<void>;
 }
@@ -33,7 +32,7 @@ export async function makeHarness(): Promise<Harness> {
   process.env.STEWARD_PGLITE_MEMORY = "true";
   const { db, client } = await createPGLiteDb("memory://");
   // apply THIS plugin's migrations into its own namespaced ledger (driver-neutral
-  // runner, pglite migrator injected, no advisory lock — pglite has none).
+  // runner, pglite migrator injected, no advisory lock - pglite has none).
   await runPluginMigrations(
     { id: "capabilities", migrationsFolder: MIGRATIONS_FOLDER },
     { db, client, useAdvisoryLock: false, migrateFn: pgliteMigrate as never },
@@ -67,11 +66,7 @@ export async function ensureAgent(db: TestDb, tenantId: string, agentId: string)
 }
 
 /** insert a bare secret row (the plugin only references its id, never decrypts). */
-export async function ensureSecret(
-  db: TestDb,
-  tenantId: string,
-  name: string,
-): Promise<string> {
+export async function ensureSecret(db: TestDb, tenantId: string, name: string): Promise<string> {
   const [row] = await db
     .insert(secrets)
     .values({
@@ -97,10 +92,7 @@ export async function enabledRouteCount(db: TestDb, tenantId: string): Promise<n
 
 /** count ALL secret_routes for a tenant (enabled or not). */
 export async function totalRouteCount(db: TestDb, tenantId: string): Promise<number> {
-  const rows = await db
-    .select()
-    .from(secretRoutes)
-    .where(eq(secretRoutes.tenantId, tenantId));
+  const rows = await db.select().from(secretRoutes).where(eq(secretRoutes.tenantId, tenantId));
   return rows.length;
 }
 

--- a/packages/plugin-capabilities/src/__tests__/migration-isolation.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/migration-isolation.test.ts
@@ -1,5 +1,5 @@
 /**
- * migration-isolation.test.ts — proves the Phase 2c isolation guarantee for THIS
+ * migration-isolation.test.ts - proves the Phase 2c isolation guarantee for THIS
  * plugin: the capability migrations are recorded ONLY in the plugin's own
  * namespaced bookkeeping table, never in the core's `drizzle.__drizzle_migrations`
  * journal, and the tables land. mirrors the core 2c isolation test.
@@ -19,9 +19,7 @@ afterEach(async () => {
 
 describe("capability plugin migrations: namespaced-journal isolation", () => {
   test("derives the capability plugin's own bookkeeping table name", () => {
-    expect(pluginMigrationsTable("capabilities")).toBe(
-      "__drizzle_migrations_plugin_capabilities",
-    );
+    expect(pluginMigrationsTable("capabilities")).toBe("__drizzle_migrations_plugin_capabilities");
   });
 
   test("creates both tables and records them in the plugin's OWN ledger", async () => {

--- a/packages/plugin-capabilities/src/__tests__/migration-isolation.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/migration-isolation.test.ts
@@ -1,0 +1,68 @@
+/**
+ * migration-isolation.test.ts — proves the Phase 2c isolation guarantee for THIS
+ * plugin: the capability migrations are recorded ONLY in the plugin's own
+ * namespaced bookkeeping table, never in the core's `drizzle.__drizzle_migrations`
+ * journal, and the tables land. mirrors the core 2c isolation test.
+ */
+
+import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { pluginMigrationsTable } from "@stwd/db";
+import { type Harness, makeHarness } from "./_harness";
+
+setDefaultTimeout(30000);
+
+let harness: Harness | null = null;
+afterEach(async () => {
+  await harness?.close();
+  harness = null;
+});
+
+describe("capability plugin migrations: namespaced-journal isolation", () => {
+  test("derives the capability plugin's own bookkeeping table name", () => {
+    expect(pluginMigrationsTable("capabilities")).toBe(
+      "__drizzle_migrations_plugin_capabilities",
+    );
+  });
+
+  test("creates both tables and records them in the plugin's OWN ledger", async () => {
+    harness = await makeHarness();
+    const { client } = harness;
+
+    // (a) both plugin tables exist
+    const capTbl = await client.query("SELECT to_regclass('public.capabilities') AS t");
+    expect(capTbl.rows[0].t).toBe("capabilities");
+    const grantTbl = await client.query("SELECT to_regclass('public.capability_grants') AS t");
+    expect(grantTbl.rows[0].t).toBe("capability_grants");
+
+    // (b) recorded in the plugin's OWN namespaced bookkeeping table
+    const pluginLedger = await client.query(
+      `SELECT count(*)::int AS n FROM drizzle."__drizzle_migrations_plugin_capabilities"`,
+    );
+    expect(pluginLedger.rows[0].n).toBeGreaterThanOrEqual(1);
+
+    // (c) the plugin's migration was NOT written into the core journal. the core
+    //     journal MAY exist (createPGLiteDb ran the core migrations), so assert it
+    //     carries NO row tagged for the capability plugin's migration.
+    const coreLedger = await client.query(
+      "SELECT to_regclass('drizzle.__drizzle_migrations') AS t",
+    );
+    if (coreLedger.rows[0].t) {
+      const contaminated = await client.query(
+        `SELECT count(*)::int AS n FROM drizzle.__drizzle_migrations WHERE hash LIKE '%capabilit%'`,
+      );
+      expect(contaminated.rows[0].n).toBe(0);
+    }
+
+    // (d) the unique constraint on (tenant_id, name) is present (drives create 409)
+    const uniq = await client.query(
+      `SELECT count(*)::int AS n FROM pg_indexes WHERE indexname = 'capabilities_tenant_name_uniq'`,
+    );
+    expect(uniq.rows[0].n).toBe(1);
+
+    // (e) the status CHECK constraint is present (grants status enum guard)
+    const chk = await client.query(
+      `SELECT count(*)::int AS n FROM pg_constraint WHERE conname = 'capability_grants_status_check'`,
+    );
+    expect(chk.rows[0].n).toBe(1);
+  });
+});

--- a/packages/plugin-capabilities/src/__tests__/routes.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/routes.test.ts
@@ -229,6 +229,22 @@ describe("capability CRUD happy path (authorized)", () => {
     const res = await createCap(app, { name: "Bad Name!" });
     expect(res.status).toBe(400);
   });
+
+  test("unknown secretId -> 400 (secret must exist for the tenant)", async () => {
+    const app = authedApp(harness!.db);
+    const res = await createCap(app, { secretId: crypto.randomUUID() });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/secret not found or not usable/i);
+  });
+
+  test("foreign-tenant secretId -> 400 (no cross-tenant secret reference)", async () => {
+    const otherTenant = `tenant-other-${crypto.randomUUID()}`;
+    await ensureTenant(harness!.db, otherTenant);
+    const foreignSecret = await ensureSecret(harness!.db, otherTenant, "foreign-pat");
+    const app = authedApp(harness!.db);
+    const res = await createCap(app, { secretId: foreignSecret });
+    expect(res.status).toBe(400);
+  });
 });
 
 describe("grant + patch route behaviors (authorized)", () => {

--- a/packages/plugin-capabilities/src/__tests__/routes.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/routes.test.ts
@@ -1,0 +1,296 @@
+/**
+ * routes.test.ts — operator/tenant-auth CRUD route behavior + auth gates.
+ *
+ * mounts the capability + grant router (and the agent-scoped router) onto a bare
+ * hono app with an injected test context and a test middleware that stamps the
+ * per-request auth variables (tenantId, authType, tenantRole, sessionMfaVerifiedAt).
+ * proves: the MFA/admin gate on every mutating route (the same bar the core
+ * /secrets CRUD enforces), the create->grant->revoke->delete happy path with no
+ * orphaned enabled routes, validation rejections surfaced as 400, secret values
+ * never returned (there are none to return — only ids + routing metadata).
+ */
+
+import { afterEach, beforeEach, describe, expect, setDefaultTimeout, test } from "bun:test";
+import type { AppVariables } from "@stwd/shared";
+import { Hono } from "hono";
+import {
+  enabledRouteCount,
+  ensureAgent,
+  ensureSecret,
+  ensureTenant,
+  type Harness,
+  makeHarness,
+  totalRouteCount,
+} from "./_harness";
+import { createAgentCapabilityRoutes, createCapabilityRoutes } from "../routes";
+import type { StewardAppContext } from "../context";
+
+setDefaultTimeout(30000);
+
+let harness: Harness | null = null;
+let tenantId: string;
+let secretId: string;
+
+/** a minimal injected context: the routes use db + safeJsonParse + writeAuditEvent. */
+function buildCtx(db: unknown): StewardAppContext {
+  return {
+    db,
+    // biome-ignore lint/suspicious/noExplicitAny: unused-by-routes ctx members are stubbed.
+    vault: {} as any,
+    // biome-ignore lint/suspicious/noExplicitAny: unused-by-routes ctx members are stubbed.
+    policyEngine: {} as any,
+    // biome-ignore lint/suspicious/noExplicitAny: unused-by-routes ctx members are stubbed.
+    priceOracle: {} as any,
+    async ensureAgentForTenant() {
+      return undefined;
+    },
+    async getPolicySet() {
+      return [];
+    },
+    async safeJsonParse<T>(c: { req: { json(): Promise<unknown> } }): Promise<T | null> {
+      try {
+        return (await c.req.json()) as T;
+      } catch {
+        return null;
+      }
+    },
+    isValidAnyAddress() {
+      return false;
+    },
+    async writeAuditEvent() {
+      /* no-op audit sink for tests */
+    },
+    async getAgentTokenStatus() {
+      return null;
+    },
+    getRedisClient() {
+      return null;
+    },
+    async requireAgentJwt() {},
+    async operatorAuth() {},
+    async tenantAuth() {},
+    // biome-ignore lint/suspicious/noExplicitAny: the test ctx satisfies the used subset.
+  } as any;
+}
+
+type AuthOpts = {
+  authType?: string;
+  role?: string;
+  mfa?: boolean;
+};
+
+/** build an app whose test middleware stamps the auth variables per request. */
+function buildApp(db: unknown, auth: AuthOpts): Hono<{ Variables: AppVariables }> {
+  const app = new Hono<{ Variables: AppVariables }>();
+  app.use("*", async (c, next) => {
+    c.set("tenantId", tenantId);
+    if (auth.authType) c.set("authType", auth.authType as never);
+    if (auth.role) c.set("tenantRole", auth.role as never);
+    if (auth.mfa) c.set("sessionMfaVerifiedAt", Date.now() as never);
+    await next();
+  });
+  const ctx = buildCtx(db);
+  app.route("/capabilities", createCapabilityRoutes(ctx));
+  app.route("/agents", createAgentCapabilityRoutes(ctx));
+  return app;
+}
+
+/** an authorized (owner + recent MFA) app. */
+function authedApp(db: unknown) {
+  return buildApp(db, { authType: "session-jwt", role: "owner", mfa: true });
+}
+
+const GH_BODY = {
+  name: "github.pr.comment",
+  host: "api.github.com",
+  pathPattern: "/repos/acme/widgets/issues/1/comments",
+  method: "POST",
+  injectKey: "authorization",
+  injectFormat: "Bearer {value}",
+};
+
+beforeEach(async () => {
+  harness = await makeHarness();
+  tenantId = `tenant-${crypto.randomUUID()}`;
+  await ensureTenant(harness.db, tenantId);
+  secretId = await ensureSecret(harness.db, tenantId, "github-pat");
+});
+
+afterEach(async () => {
+  await harness?.close();
+  harness = null;
+});
+
+async function createCap(app: Hono<{ Variables: AppVariables }>, overrides: Record<string, unknown> = {}) {
+  return app.request("/capabilities", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ secretId, ...GH_BODY, ...overrides }),
+  });
+}
+
+describe("auth gates (same bar as core /secrets CRUD)", () => {
+  test("POST /capabilities without a session is 403", async () => {
+    const app = buildApp(harness!.db, {}); // no auth
+    const res = await createCap(app);
+    expect(res.status).toBe(403);
+  });
+
+  test("POST /capabilities as a non-admin session is 403", async () => {
+    const app = buildApp(harness!.db, { authType: "session-jwt", role: "member", mfa: true });
+    const res = await createCap(app);
+    expect(res.status).toBe(403);
+  });
+
+  test("POST /capabilities as admin WITHOUT recent MFA is 403", async () => {
+    const app = buildApp(harness!.db, { authType: "session-jwt", role: "owner", mfa: false });
+    const res = await createCap(app);
+    expect(res.status).toBe(403);
+  });
+
+  test("GET /agents/:id/capabilities without a session is 403", async () => {
+    const app = buildApp(harness!.db, {});
+    const res = await app.request("/agents/agent-a/capabilities");
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("capability CRUD happy path (authorized)", () => {
+  test("create -> read -> list -> grant -> revoke -> delete, no orphaned routes", async () => {
+    const app = authedApp(harness!.db);
+    await ensureAgent(harness!.db, tenantId, "agent-a");
+
+    // create
+    const created = await createCap(app);
+    expect(created.status).toBe(201);
+    const capId = (await created.json()).data.id as string;
+
+    // read
+    const read = await app.request(`/capabilities/${capId}`);
+    expect(read.status).toBe(200);
+    const readBody = await read.json();
+    expect(readBody.data.name).toBe("github.pr.comment");
+    // never leaks a secret VALUE (only the id + routing metadata)
+    expect(JSON.stringify(readBody)).not.toContain("Bearer sk");
+    expect(readBody.data.secretId).toBe(secretId);
+
+    // list
+    const list = await app.request("/capabilities");
+    expect((await list.json()).data).toHaveLength(1);
+
+    // grant
+    const grantRes = await app.request(`/capabilities/${capId}/grants`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ agentId: "agent-a" }),
+    });
+    expect(grantRes.status).toBe(201);
+    const grantId = (await grantRes.json()).data.id as string;
+    expect(await enabledRouteCount(harness!.db, tenantId)).toBe(1);
+
+    // agent-scoped usable listing shows it
+    const usable = await app.request("/agents/agent-a/capabilities");
+    expect((await usable.json()).data).toHaveLength(1);
+
+    // revoke -> route gone
+    const revoke = await app.request(`/capabilities/grants/${grantId}`, { method: "DELETE" });
+    expect(revoke.status).toBe(200);
+    expect(await totalRouteCount(harness!.db, tenantId)).toBe(0);
+
+    // delete
+    const del = await app.request(`/capabilities/${capId}`, { method: "DELETE" });
+    expect(del.status).toBe(200);
+    expect(await app.request(`/capabilities/${capId}`).then((r) => r.status)).toBe(404);
+  });
+
+  test("duplicate name -> 409", async () => {
+    const app = authedApp(harness!.db);
+    expect((await createCap(app)).status).toBe(201);
+    expect((await createCap(app)).status).toBe(409);
+  });
+
+  test("invalid github spec -> 400 (strict host)", async () => {
+    const app = authedApp(harness!.db);
+    const res = await createCap(app, { pathPattern: "/repos" });
+    expect(res.status).toBe(400);
+  });
+
+  test("off-allowlist host -> 400", async () => {
+    const app = authedApp(harness!.db);
+    const res = await createCap(app, { host: "evil.example.com", pathPattern: "/v1/x" });
+    expect(res.status).toBe(400);
+  });
+
+  test("bad capability name -> 400", async () => {
+    const app = authedApp(harness!.db);
+    const res = await createCap(app, { name: "Bad Name!" });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("grant + patch route behaviors (authorized)", () => {
+  test("grant to unknown agent -> 404", async () => {
+    const app = authedApp(harness!.db);
+    const capId = (await (await createCap(app)).json()).data.id as string;
+    const res = await app.request(`/capabilities/${capId}/grants`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ agentId: "ghost" }),
+    });
+    expect(res.status).toBe(404);
+    expect(await totalRouteCount(harness!.db, tenantId)).toBe(0);
+  });
+
+  test("duplicate grant -> 409", async () => {
+    const app = authedApp(harness!.db);
+    await ensureAgent(harness!.db, tenantId, "agent-a");
+    const capId = (await (await createCap(app)).json()).data.id as string;
+    const body = JSON.stringify({ agentId: "agent-a" });
+    const h = { "content-type": "application/json" };
+    expect((await app.request(`/capabilities/${capId}/grants`, { method: "POST", headers: h, body })).status).toBe(201);
+    expect((await app.request(`/capabilities/${capId}/grants`, { method: "POST", headers: h, body })).status).toBe(409);
+  });
+
+  test("PATCH disable -> paired routes disabled (no orphans)", async () => {
+    const app = authedApp(harness!.db);
+    await ensureAgent(harness!.db, tenantId, "agent-a");
+    const capId = (await (await createCap(app)).json()).data.id as string;
+    await app.request(`/capabilities/${capId}/grants`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ agentId: "agent-a" }),
+    });
+    expect(await enabledRouteCount(harness!.db, tenantId)).toBe(1);
+
+    const patch = await app.request(`/capabilities/${capId}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ enabled: false }),
+    });
+    expect(patch.status).toBe(200);
+    expect(await enabledRouteCount(harness!.db, tenantId)).toBe(0);
+  });
+
+  test("PATCH widening a github path to a wildcard -> 400 (no widen-by-patch)", async () => {
+    const app = authedApp(harness!.db);
+    const capId = (await (await createCap(app)).json()).data.id as string;
+    const patch = await app.request(`/capabilities/${capId}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ pathPattern: "/repos/acme/*" }),
+    });
+    expect(patch.status).toBe(400);
+  });
+
+  test("grant with a past expiresAt -> 400", async () => {
+    const app = authedApp(harness!.db);
+    await ensureAgent(harness!.db, tenantId, "agent-a");
+    const capId = (await (await createCap(app)).json()).data.id as string;
+    const res = await app.request(`/capabilities/${capId}/grants`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ agentId: "agent-a", expiresAt: new Date(Date.now() - 1000).toISOString() }),
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/plugin-capabilities/src/__tests__/routes.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/routes.test.ts
@@ -1,5 +1,5 @@
 /**
- * routes.test.ts — operator/tenant-auth CRUD route behavior + auth gates.
+ * routes.test.ts - operator/tenant-auth CRUD route behavior + auth gates.
  *
  * mounts the capability + grant router (and the agent-scoped router) onto a bare
  * hono app with an injected test context and a test middleware that stamps the
@@ -7,12 +7,14 @@
  * proves: the MFA/admin gate on every mutating route (the same bar the core
  * /secrets CRUD enforces), the create->grant->revoke->delete happy path with no
  * orphaned enabled routes, validation rejections surfaced as 400, secret values
- * never returned (there are none to return — only ids + routing metadata).
+ * never returned (there are none to return - only ids + routing metadata).
  */
 
 import { afterEach, beforeEach, describe, expect, setDefaultTimeout, test } from "bun:test";
 import type { AppVariables } from "@stwd/shared";
 import { Hono } from "hono";
+import type { StewardAppContext } from "../context";
+import { createAgentCapabilityRoutes, createCapabilityRoutes } from "../routes";
 import {
   enabledRouteCount,
   ensureAgent,
@@ -22,8 +24,6 @@ import {
   makeHarness,
   totalRouteCount,
 } from "./_harness";
-import { createAgentCapabilityRoutes, createCapabilityRoutes } from "../routes";
-import type { StewardAppContext } from "../context";
 
 setDefaultTimeout(30000);
 
@@ -35,11 +35,11 @@ let secretId: string;
 function buildCtx(db: unknown): StewardAppContext {
   return {
     db,
-    // biome-ignore lint/suspicious/noExplicitAny: unused-by-routes ctx members are stubbed.
+    // note (any is intentional): unused-by-routes ctx members are stubbed.
     vault: {} as any,
-    // biome-ignore lint/suspicious/noExplicitAny: unused-by-routes ctx members are stubbed.
+    // note (any is intentional): unused-by-routes ctx members are stubbed.
     policyEngine: {} as any,
-    // biome-ignore lint/suspicious/noExplicitAny: unused-by-routes ctx members are stubbed.
+    // note (any is intentional): unused-by-routes ctx members are stubbed.
     priceOracle: {} as any,
     async ensureAgentForTenant() {
       return undefined;
@@ -69,7 +69,7 @@ function buildCtx(db: unknown): StewardAppContext {
     async requireAgentJwt() {},
     async operatorAuth() {},
     async tenantAuth() {},
-    // biome-ignore lint/suspicious/noExplicitAny: the test ctx satisfies the used subset.
+    // note (any is intentional): the test ctx satisfies the used subset.
   } as any;
 }
 
@@ -121,7 +121,10 @@ afterEach(async () => {
   harness = null;
 });
 
-async function createCap(app: Hono<{ Variables: AppVariables }>, overrides: Record<string, unknown> = {}) {
+async function createCap(
+  app: Hono<{ Variables: AppVariables }>,
+  overrides: Record<string, unknown> = {},
+) {
   return app.request("/capabilities", {
     method: "POST",
     headers: { "content-type": "application/json" },
@@ -247,8 +250,14 @@ describe("grant + patch route behaviors (authorized)", () => {
     const capId = (await (await createCap(app)).json()).data.id as string;
     const body = JSON.stringify({ agentId: "agent-a" });
     const h = { "content-type": "application/json" };
-    expect((await app.request(`/capabilities/${capId}/grants`, { method: "POST", headers: h, body })).status).toBe(201);
-    expect((await app.request(`/capabilities/${capId}/grants`, { method: "POST", headers: h, body })).status).toBe(409);
+    expect(
+      (await app.request(`/capabilities/${capId}/grants`, { method: "POST", headers: h, body }))
+        .status,
+    ).toBe(201);
+    expect(
+      (await app.request(`/capabilities/${capId}/grants`, { method: "POST", headers: h, body }))
+        .status,
+    ).toBe(409);
   });
 
   test("PATCH disable -> paired routes disabled (no orphans)", async () => {
@@ -289,7 +298,10 @@ describe("grant + patch route behaviors (authorized)", () => {
     const res = await app.request(`/capabilities/${capId}/grants`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ agentId: "agent-a", expiresAt: new Date(Date.now() - 1000).toISOString() }),
+      body: JSON.stringify({
+        agentId: "agent-a",
+        expiresAt: new Date(Date.now() - 1000).toISOString(),
+      }),
     });
     expect(res.status).toBe(400);
   });

--- a/packages/plugin-capabilities/src/__tests__/store-lifecycle.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/store-lifecycle.test.ts
@@ -130,6 +130,36 @@ describe("validation matrix (shared secret-route validator, strict hosts)", () =
   });
 });
 
+describe("secret usability guard (fail-closed on bad/deleted/expired secret)", () => {
+  test("a fresh tenant secret is usable", async () => {
+    expect(await store.secretUsableForTenant(tenantId, secretId)).toBe(true);
+  });
+
+  test("an unknown secret id is not usable", async () => {
+    expect(await store.secretUsableForTenant(tenantId, crypto.randomUUID())).toBe(false);
+  });
+
+  test("a soft-deleted secret is not usable", async () => {
+    const { secrets } = await import("@stwd/db");
+    const { eq } = await import("drizzle-orm");
+    await harness!.db
+      .update(secrets)
+      .set({ deletedAt: new Date() })
+      .where(eq(secrets.id, secretId));
+    expect(await store.secretUsableForTenant(tenantId, secretId)).toBe(false);
+  });
+
+  test("an expired secret is not usable", async () => {
+    const { secrets } = await import("@stwd/db");
+    const { eq } = await import("drizzle-orm");
+    await harness!.db
+      .update(secrets)
+      .set({ expiresAt: new Date(Date.now() - 60_000) })
+      .where(eq(secrets.id, secretId));
+    expect(await store.secretUsableForTenant(tenantId, secretId)).toBe(false);
+  });
+});
+
 describe("capability create: no grants -> no routes (fail-closed by construction)", () => {
   test("creating a capability materializes zero routes", async () => {
     const cap = await createGithubCapability();

--- a/packages/plugin-capabilities/src/__tests__/store-lifecycle.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/store-lifecycle.test.ts
@@ -1,0 +1,383 @@
+/**
+ * store-lifecycle.test.ts — the paired secret_route lifecycle + validation matrix.
+ *
+ * proves the KEY invariant: NO orphaned enabled routes in any path (create ->
+ * route exists+enabled; disable/revoke/expire -> route disabled/gone; delete ->
+ * gone), grant-expiry semantics, and the validation matrix (strict-host github
+ * rejections, off-allowlist host rejected) via the shared validator.
+ */
+
+import { afterEach, beforeEach, describe, expect, setDefaultTimeout, test } from "bun:test";
+import {
+  enabledRouteCount,
+  ensureAgent,
+  ensureSecret,
+  ensureTenant,
+  getRoute,
+  type Harness,
+  makeHarness,
+  totalRouteCount,
+} from "./_harness";
+import { CapabilityStore } from "../store";
+import { validateCapabilitySpec } from "../validate";
+
+setDefaultTimeout(30000);
+
+let harness: Harness | null = null;
+let store: CapabilityStore;
+let tenantId: string;
+let secretId: string;
+
+const GH_SPEC = {
+  host: "api.github.com",
+  pathPattern: "/repos/acme/widgets/issues/1/comments",
+  method: "POST",
+  injectKey: "authorization",
+  injectFormat: "Bearer {value}",
+};
+
+beforeEach(async () => {
+  harness = await makeHarness();
+  store = new CapabilityStore(harness.db);
+  tenantId = `tenant-${crypto.randomUUID()}`;
+  await ensureTenant(harness.db, tenantId);
+  secretId = await ensureSecret(harness.db, tenantId, "github-pat");
+});
+
+afterEach(async () => {
+  await harness?.close();
+  harness = null;
+});
+
+async function createGithubCapability(name = "github.pr.comment", enabled = true) {
+  const v = validateCapabilitySpec({ secretId, ...GH_SPEC });
+  if (!v.ok) throw new Error(`spec invalid: ${v.error}`);
+  return store.createCapability({ tenantId, name, spec: v.spec, constraints: {}, enabled });
+}
+
+describe("validation matrix (shared secret-route validator, strict hosts)", () => {
+  test("accepts a narrow github capability", () => {
+    const v = validateCapabilitySpec({ secretId, ...GH_SPEC });
+    expect(v.ok).toBe(true);
+  });
+
+  test("rejects github with a wildcard method (broad-method + strict host)", () => {
+    const v = validateCapabilitySpec({ secretId, ...GH_SPEC, method: "*" });
+    expect(v.ok).toBe(false);
+    // rejected by the broad-method guard (evaluated before strict-host); either
+    // way a wildcard method never reaches a github capability.
+    if (!v.ok) expect(v.error).toMatch(/broad method|explicit HTTP method/i);
+  });
+
+  test("rejects github with a valid-but-non-github method omitted via GET narrowness still needs 2 segments", () => {
+    // a concrete method that is NOT the broad wildcard still must satisfy the
+    // strict-host path-depth rule; a shallow path is rejected with the strict msg.
+    const v = validateCapabilitySpec({ secretId, ...GH_SPEC, pathPattern: "/repos", method: "GET" });
+    expect(v.ok).toBe(false);
+    if (!v.ok) expect(v.error).toMatch(/at least 2 segments/i);
+  });
+
+  test("rejects github with < 2 path segments (strict host)", () => {
+    const v = validateCapabilitySpec({ secretId, ...GH_SPEC, pathPattern: "/repos" });
+    expect(v.ok).toBe(false);
+    if (!v.ok) expect(v.error).toMatch(/at least 2 segments/i);
+  });
+
+  test("rejects github with a path wildcard (strict host)", () => {
+    const v = validateCapabilitySpec({ secretId, ...GH_SPEC, pathPattern: "/repos/acme/*" });
+    expect(v.ok).toBe(false);
+    if (!v.ok) expect(v.error).toMatch(/exact path.*no.*wildcard/i);
+  });
+
+  test("rejects an off-allowlist host", () => {
+    const v = validateCapabilitySpec({
+      secretId,
+      host: "evil.example.com",
+      pathPattern: "/v1/x",
+      method: "POST",
+      injectKey: "authorization",
+    });
+    expect(v.ok).toBe(false);
+    if (!v.ok) expect(v.error).toMatch(/allowlist/i);
+  });
+
+  test("rejects localhost / internal host", () => {
+    const v = validateCapabilitySpec({
+      secretId,
+      host: "localhost",
+      pathPattern: "/v1/x",
+      method: "POST",
+      injectKey: "authorization",
+    });
+    expect(v.ok).toBe(false);
+    if (!v.ok) expect(v.error).toMatch(/localhost|internal|allowlist/i);
+  });
+
+  test("rejects a blocked inject header (host framing)", () => {
+    const v = validateCapabilitySpec({
+      secretId,
+      host: "api.openai.com",
+      pathPattern: "/v1/chat/completions",
+      method: "POST",
+      injectKey: "host",
+    });
+    expect(v.ok).toBe(false);
+  });
+});
+
+describe("capability create: no grants -> no routes (fail-closed by construction)", () => {
+  test("creating a capability materializes zero routes", async () => {
+    const cap = await createGithubCapability();
+    expect(cap.enabled).toBe(true);
+    expect(await totalRouteCount(harness!.db, tenantId)).toBe(0);
+  });
+});
+
+describe("grant create -> paired route exists + enabled", () => {
+  test("a grant to an enabled capability creates one enabled route", async () => {
+    const cap = await createGithubCapability();
+    await ensureAgent(harness!.db, tenantId, "agent-a");
+
+    const res = await store.createGrant({
+      tenantId,
+      capabilityId: cap.id,
+      agentId: "agent-a",
+      expiresAt: null,
+    });
+    expect(res).not.toBeNull();
+    expect(res?.route).not.toBeNull();
+    expect(res?.grant.secretRouteId).toBe(res?.route?.id ?? null);
+
+    const route = await getRoute(harness!.db, res!.route!.id);
+    expect(route.enabled).toBe(true);
+    expect(route.agentId).toBe("agent-a");
+    expect(route.hostPattern).toBe("api.github.com");
+    expect(route.method).toBe("POST");
+    expect(await enabledRouteCount(harness!.db, tenantId)).toBe(1);
+  });
+
+  test("two agents granted -> two routes (per-GRANT pairing)", async () => {
+    const cap = await createGithubCapability();
+    await ensureAgent(harness!.db, tenantId, "agent-a");
+    await ensureAgent(harness!.db, tenantId, "agent-b");
+    await store.createGrant({ tenantId, capabilityId: cap.id, agentId: "agent-a", expiresAt: null });
+    await store.createGrant({ tenantId, capabilityId: cap.id, agentId: "agent-b", expiresAt: null });
+    expect(await enabledRouteCount(harness!.db, tenantId)).toBe(2);
+  });
+
+  test("grant to an unknown agent throws and creates no route", async () => {
+    const cap = await createGithubCapability();
+    await expect(
+      store.createGrant({ tenantId, capabilityId: cap.id, agentId: "ghost", expiresAt: null }),
+    ).rejects.toThrow(/not found/i);
+    expect(await totalRouteCount(harness!.db, tenantId)).toBe(0);
+  });
+
+  test("grant to a missing capability returns null, no route", async () => {
+    await ensureAgent(harness!.db, tenantId, "agent-a");
+    const res = await store.createGrant({
+      tenantId,
+      capabilityId: crypto.randomUUID(),
+      agentId: "agent-a",
+      expiresAt: null,
+    });
+    expect(res).toBeNull();
+    expect(await totalRouteCount(harness!.db, tenantId)).toBe(0);
+  });
+
+  test("granting an expired-at-creation grant creates a DISABLED route", async () => {
+    const cap = await createGithubCapability();
+    await ensureAgent(harness!.db, tenantId, "agent-a");
+    const past = new Date(Date.now() - 60_000);
+    const res = await store.createGrant({
+      tenantId,
+      capabilityId: cap.id,
+      agentId: "agent-a",
+      expiresAt: past,
+      now: new Date(),
+    });
+    const route = await getRoute(harness!.db, res!.route!.id);
+    expect(route.enabled).toBe(false);
+    expect(await enabledRouteCount(harness!.db, tenantId)).toBe(0);
+  });
+});
+
+describe("capability disable/enable -> paired routes track fail-closed", () => {
+  test("disable disables every paired route; enable re-enables active grants", async () => {
+    const cap = await createGithubCapability();
+    await ensureAgent(harness!.db, tenantId, "agent-a");
+    await ensureAgent(harness!.db, tenantId, "agent-b");
+    await store.createGrant({ tenantId, capabilityId: cap.id, agentId: "agent-a", expiresAt: null });
+    await store.createGrant({ tenantId, capabilityId: cap.id, agentId: "agent-b", expiresAt: null });
+    expect(await enabledRouteCount(harness!.db, tenantId)).toBe(2);
+
+    // disable -> both routes off (no orphaned enabled route)
+    await store.updateCapability(tenantId, cap.id, { enabled: false });
+    expect(await enabledRouteCount(harness!.db, tenantId)).toBe(0);
+    expect(await totalRouteCount(harness!.db, tenantId)).toBe(2); // rows kept, disabled
+
+    // re-enable -> both active grants' routes back on
+    await store.updateCapability(tenantId, cap.id, { enabled: true });
+    expect(await enabledRouteCount(harness!.db, tenantId)).toBe(2);
+  });
+
+  test("enabling does NOT re-enable a revoked grant's route (there is none)", async () => {
+    const cap = await createGithubCapability();
+    await ensureAgent(harness!.db, tenantId, "agent-a");
+    const res = await store.createGrant({
+      tenantId,
+      capabilityId: cap.id,
+      agentId: "agent-a",
+      expiresAt: null,
+    });
+    await store.revokeGrant(tenantId, res!.grant.id);
+    await store.updateCapability(tenantId, cap.id, { enabled: false });
+    await store.updateCapability(tenantId, cap.id, { enabled: true });
+    // revoked grant's route was deleted; nothing to re-enable.
+    expect(await enabledRouteCount(harness!.db, tenantId)).toBe(0);
+    expect(await totalRouteCount(harness!.db, tenantId)).toBe(0);
+  });
+
+  test("enabling a capability with an expired grant leaves that route disabled", async () => {
+    const cap = await createGithubCapability("github.pr.comment", false);
+    await ensureAgent(harness!.db, tenantId, "agent-a");
+    const future = new Date(Date.now() + 3_600_000);
+    const res = await store.createGrant({
+      tenantId,
+      capabilityId: cap.id,
+      agentId: "agent-a",
+      expiresAt: future,
+    });
+    // capability was created disabled, so route starts disabled
+    expect((await getRoute(harness!.db, res!.route!.id)).enabled).toBe(false);
+    // enable the capability but evaluate expiry as if we are PAST the expiry
+    await store.updateCapability(
+      tenantId,
+      cap.id,
+      { enabled: true },
+      new Date(future.getTime() + 1000),
+    );
+    expect(await enabledRouteCount(harness!.db, tenantId)).toBe(0);
+  });
+});
+
+describe("capability update: routing narrows the live route (no widen-by-patch)", () => {
+  test("patching the path rewrites the paired route's path", async () => {
+    const cap = await createGithubCapability();
+    await ensureAgent(harness!.db, tenantId, "agent-a");
+    const res = await store.createGrant({
+      tenantId,
+      capabilityId: cap.id,
+      agentId: "agent-a",
+      expiresAt: null,
+    });
+    const newPath = "/repos/acme/widgets/issues/2/comments";
+    const v = validateCapabilitySpec({ secretId, ...GH_SPEC, pathPattern: newPath });
+    if (!v.ok) throw new Error(v.error);
+    await store.updateCapability(tenantId, cap.id, { spec: v.spec });
+    const route = await getRoute(harness!.db, res!.route!.id);
+    expect(route.pathPattern).toBe(newPath);
+    expect(route.enabled).toBe(true);
+  });
+});
+
+describe("grant revoke -> paired route deleted", () => {
+  test("revoke deletes the route and marks the grant revoked", async () => {
+    const cap = await createGithubCapability();
+    await ensureAgent(harness!.db, tenantId, "agent-a");
+    const res = await store.createGrant({
+      tenantId,
+      capabilityId: cap.id,
+      agentId: "agent-a",
+      expiresAt: null,
+    });
+    const ok = await store.revokeGrant(tenantId, res!.grant.id);
+    expect(ok).toBe(true);
+    expect(await getRoute(harness!.db, res!.route!.id)).toBeNull();
+    expect(await totalRouteCount(harness!.db, tenantId)).toBe(0);
+    const grant = await store.getGrantById(tenantId, res!.grant.id);
+    expect(grant?.status).toBe("revoked");
+    expect(grant?.secretRouteId).toBeNull();
+  });
+
+  test("revoke is idempotent and never leaves an orphaned enabled route", async () => {
+    const cap = await createGithubCapability();
+    await ensureAgent(harness!.db, tenantId, "agent-a");
+    const res = await store.createGrant({
+      tenantId,
+      capabilityId: cap.id,
+      agentId: "agent-a",
+      expiresAt: null,
+    });
+    await store.revokeGrant(tenantId, res!.grant.id);
+    await store.revokeGrant(tenantId, res!.grant.id); // second time: no-op
+    expect(await enabledRouteCount(harness!.db, tenantId)).toBe(0);
+  });
+
+  test("revoke of a nonexistent grant returns false", async () => {
+    const ok = await store.revokeGrant(tenantId, crypto.randomUUID());
+    expect(ok).toBe(false);
+  });
+});
+
+describe("capability delete -> all paired routes gone (no orphans)", () => {
+  test("delete removes every route + grant + the capability", async () => {
+    const cap = await createGithubCapability();
+    await ensureAgent(harness!.db, tenantId, "agent-a");
+    await ensureAgent(harness!.db, tenantId, "agent-b");
+    await store.createGrant({ tenantId, capabilityId: cap.id, agentId: "agent-a", expiresAt: null });
+    await store.createGrant({ tenantId, capabilityId: cap.id, agentId: "agent-b", expiresAt: null });
+    expect(await totalRouteCount(harness!.db, tenantId)).toBe(2);
+
+    const removed = await store.deleteCapability(tenantId, cap.id);
+    expect(removed).toBe(true);
+    expect(await totalRouteCount(harness!.db, tenantId)).toBe(0);
+    expect(await enabledRouteCount(harness!.db, tenantId)).toBe(0);
+    expect(await store.getCapabilityById(tenantId, cap.id)).toBeNull();
+    expect(await store.listGrantsForCapability(tenantId, cap.id)).toHaveLength(0);
+  });
+
+  test("delete of a nonexistent capability returns false", async () => {
+    const removed = await store.deleteCapability(tenantId, crypto.randomUUID());
+    expect(removed).toBe(false);
+  });
+});
+
+describe("grant expiry semantics (usable-by-agent listing)", () => {
+  test("expired grant is not listed as usable; unexpired is", async () => {
+    const cap = await createGithubCapability();
+    await ensureAgent(harness!.db, tenantId, "agent-a");
+    await ensureAgent(harness!.db, tenantId, "agent-b");
+    const future = new Date(Date.now() + 3_600_000);
+    await store.createGrant({ tenantId, capabilityId: cap.id, agentId: "agent-a", expiresAt: future });
+    await store.createGrant({ tenantId, capabilityId: cap.id, agentId: "agent-b", expiresAt: future });
+
+    // as of now: both usable
+    const now = new Date();
+    expect(await store.listUsableCapabilitiesForAgent(tenantId, "agent-a", now)).toHaveLength(1);
+    // as of after expiry: none usable
+    const later = new Date(future.getTime() + 1000);
+    expect(await store.listUsableCapabilitiesForAgent(tenantId, "agent-a", later)).toHaveLength(0);
+  });
+
+  test("revoked grant is not listed as usable", async () => {
+    const cap = await createGithubCapability();
+    await ensureAgent(harness!.db, tenantId, "agent-a");
+    const res = await store.createGrant({
+      tenantId,
+      capabilityId: cap.id,
+      agentId: "agent-a",
+      expiresAt: null,
+    });
+    await store.revokeGrant(tenantId, res!.grant.id);
+    expect(await store.listUsableCapabilitiesForAgent(tenantId, "agent-a")).toHaveLength(0);
+  });
+
+  test("disabled capability is not listed as usable", async () => {
+    const cap = await createGithubCapability("github.pr.comment", true);
+    await ensureAgent(harness!.db, tenantId, "agent-a");
+    await store.createGrant({ tenantId, capabilityId: cap.id, agentId: "agent-a", expiresAt: null });
+    await store.updateCapability(tenantId, cap.id, { enabled: false });
+    expect(await store.listUsableCapabilitiesForAgent(tenantId, "agent-a")).toHaveLength(0);
+  });
+});

--- a/packages/plugin-capabilities/src/__tests__/store-lifecycle.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/store-lifecycle.test.ts
@@ -1,5 +1,5 @@
 /**
- * store-lifecycle.test.ts — the paired secret_route lifecycle + validation matrix.
+ * store-lifecycle.test.ts - the paired secret_route lifecycle + validation matrix.
  *
  * proves the KEY invariant: NO orphaned enabled routes in any path (create ->
  * route exists+enabled; disable/revoke/expire -> route disabled/gone; delete ->
@@ -8,6 +8,8 @@
  */
 
 import { afterEach, beforeEach, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { CapabilityStore } from "../store";
+import { validateCapabilitySpec } from "../validate";
 import {
   enabledRouteCount,
   ensureAgent,
@@ -18,8 +20,6 @@ import {
   makeHarness,
   totalRouteCount,
 } from "./_harness";
-import { CapabilityStore } from "../store";
-import { validateCapabilitySpec } from "../validate";
 
 setDefaultTimeout(30000);
 
@@ -72,7 +72,12 @@ describe("validation matrix (shared secret-route validator, strict hosts)", () =
   test("rejects github with a valid-but-non-github method omitted via GET narrowness still needs 2 segments", () => {
     // a concrete method that is NOT the broad wildcard still must satisfy the
     // strict-host path-depth rule; a shallow path is rejected with the strict msg.
-    const v = validateCapabilitySpec({ secretId, ...GH_SPEC, pathPattern: "/repos", method: "GET" });
+    const v = validateCapabilitySpec({
+      secretId,
+      ...GH_SPEC,
+      pathPattern: "/repos",
+      method: "GET",
+    });
     expect(v.ok).toBe(false);
     if (!v.ok) expect(v.error).toMatch(/at least 2 segments/i);
   });
@@ -160,8 +165,18 @@ describe("grant create -> paired route exists + enabled", () => {
     const cap = await createGithubCapability();
     await ensureAgent(harness!.db, tenantId, "agent-a");
     await ensureAgent(harness!.db, tenantId, "agent-b");
-    await store.createGrant({ tenantId, capabilityId: cap.id, agentId: "agent-a", expiresAt: null });
-    await store.createGrant({ tenantId, capabilityId: cap.id, agentId: "agent-b", expiresAt: null });
+    await store.createGrant({
+      tenantId,
+      capabilityId: cap.id,
+      agentId: "agent-a",
+      expiresAt: null,
+    });
+    await store.createGrant({
+      tenantId,
+      capabilityId: cap.id,
+      agentId: "agent-b",
+      expiresAt: null,
+    });
     expect(await enabledRouteCount(harness!.db, tenantId)).toBe(2);
   });
 
@@ -207,8 +222,18 @@ describe("capability disable/enable -> paired routes track fail-closed", () => {
     const cap = await createGithubCapability();
     await ensureAgent(harness!.db, tenantId, "agent-a");
     await ensureAgent(harness!.db, tenantId, "agent-b");
-    await store.createGrant({ tenantId, capabilityId: cap.id, agentId: "agent-a", expiresAt: null });
-    await store.createGrant({ tenantId, capabilityId: cap.id, agentId: "agent-b", expiresAt: null });
+    await store.createGrant({
+      tenantId,
+      capabilityId: cap.id,
+      agentId: "agent-a",
+      expiresAt: null,
+    });
+    await store.createGrant({
+      tenantId,
+      capabilityId: cap.id,
+      agentId: "agent-b",
+      expiresAt: null,
+    });
     expect(await enabledRouteCount(harness!.db, tenantId)).toBe(2);
 
     // disable -> both routes off (no orphaned enabled route)
@@ -325,8 +350,18 @@ describe("capability delete -> all paired routes gone (no orphans)", () => {
     const cap = await createGithubCapability();
     await ensureAgent(harness!.db, tenantId, "agent-a");
     await ensureAgent(harness!.db, tenantId, "agent-b");
-    await store.createGrant({ tenantId, capabilityId: cap.id, agentId: "agent-a", expiresAt: null });
-    await store.createGrant({ tenantId, capabilityId: cap.id, agentId: "agent-b", expiresAt: null });
+    await store.createGrant({
+      tenantId,
+      capabilityId: cap.id,
+      agentId: "agent-a",
+      expiresAt: null,
+    });
+    await store.createGrant({
+      tenantId,
+      capabilityId: cap.id,
+      agentId: "agent-b",
+      expiresAt: null,
+    });
     expect(await totalRouteCount(harness!.db, tenantId)).toBe(2);
 
     const removed = await store.deleteCapability(tenantId, cap.id);
@@ -349,8 +384,18 @@ describe("grant expiry semantics (usable-by-agent listing)", () => {
     await ensureAgent(harness!.db, tenantId, "agent-a");
     await ensureAgent(harness!.db, tenantId, "agent-b");
     const future = new Date(Date.now() + 3_600_000);
-    await store.createGrant({ tenantId, capabilityId: cap.id, agentId: "agent-a", expiresAt: future });
-    await store.createGrant({ tenantId, capabilityId: cap.id, agentId: "agent-b", expiresAt: future });
+    await store.createGrant({
+      tenantId,
+      capabilityId: cap.id,
+      agentId: "agent-a",
+      expiresAt: future,
+    });
+    await store.createGrant({
+      tenantId,
+      capabilityId: cap.id,
+      agentId: "agent-b",
+      expiresAt: future,
+    });
 
     // as of now: both usable
     const now = new Date();
@@ -376,7 +421,12 @@ describe("grant expiry semantics (usable-by-agent listing)", () => {
   test("disabled capability is not listed as usable", async () => {
     const cap = await createGithubCapability("github.pr.comment", true);
     await ensureAgent(harness!.db, tenantId, "agent-a");
-    await store.createGrant({ tenantId, capabilityId: cap.id, agentId: "agent-a", expiresAt: null });
+    await store.createGrant({
+      tenantId,
+      capabilityId: cap.id,
+      agentId: "agent-a",
+      expiresAt: null,
+    });
     await store.updateCapability(tenantId, cap.id, { enabled: false });
     expect(await store.listUsableCapabilitiesForAgent(tenantId, "agent-a")).toHaveLength(0);
   });

--- a/packages/plugin-capabilities/src/context.ts
+++ b/packages/plugin-capabilities/src/context.ts
@@ -1,12 +1,12 @@
 /**
- * context.ts — the injected service context the lean core hands the capability
+ * context.ts - the injected service context the lean core hands the capability
  * plugin at registration.
  *
  * the plugin's routes need shared core singletons (db, audit writer, the agent
  * resolver, json parsing) and the auth middleware that gate operator/tenant
  * endpoints. those live in the CORE (`@stwd/api`). to avoid a circular dependency
  * (core must not import plugin; plugin must not import core), the core does NOT
- * export them to the plugin via an import — it BUILDS this context object and
+ * export them to the plugin via an import - it BUILDS this context object and
  * passes it to `register(app, ctx)`. the plugin codes against this interface only.
  *
  * this shape mirrors `@stwd/api`'s `StewardAppContext` (identical to

--- a/packages/plugin-capabilities/src/context.ts
+++ b/packages/plugin-capabilities/src/context.ts
@@ -1,0 +1,89 @@
+/**
+ * context.ts — the injected service context the lean core hands the capability
+ * plugin at registration.
+ *
+ * the plugin's routes need shared core singletons (db, audit writer, the agent
+ * resolver, json parsing) and the auth middleware that gate operator/tenant
+ * endpoints. those live in the CORE (`@stwd/api`). to avoid a circular dependency
+ * (core must not import plugin; plugin must not import core), the core does NOT
+ * export them to the plugin via an import — it BUILDS this context object and
+ * passes it to `register(app, ctx)`. the plugin codes against this interface only.
+ *
+ * this shape mirrors `@stwd/api`'s `StewardAppContext` (identical to
+ * `@stwd/plugin-trading`'s), so the context the core BUILDS (`buildPluginContext()`)
+ * is assignable to it at the W-1c composition root. every member is typed against
+ * the underlying `@stwd/*` package types, never `@stwd/api`.
+ */
+
+import type { getDb } from "@stwd/db";
+import type { PolicyEngine } from "@stwd/policy-engine";
+import type { IoredisLike } from "@stwd/redis";
+import type { AgentIdentity, AppVariables, PolicyRule, PriceOracle } from "@stwd/shared";
+import type { Vault } from "@stwd/vault";
+import type { Context, Next } from "hono";
+
+/** the live drizzle db handle (same shape the core's `db` proxy resolves to). */
+export type DbHandle = ReturnType<typeof getDb>;
+
+/** the audit event shape the core's `writeAuditEvent` accepts (mirrors @stwd/api). */
+export interface AuditEventInput {
+  tenantId: string;
+  actorType: "user" | "agent" | "platform" | "system" | "api-key";
+  actorId?: string | null;
+  action: string;
+  resourceType?: string | null;
+  resourceId?: string | null;
+  metadata?: Record<string, unknown>;
+  ipAddress?: string | null;
+  userAgent?: string | null;
+  requestId?: string | null;
+}
+
+/** last-observed agent trade-token expiry (part of the shared ctx shape). */
+export interface AgentTokenStatus {
+  agentId: string;
+  exp: number;
+  observedAt: number;
+}
+
+/** a hono middleware over the steward app's per-request variables. */
+export type StewardMiddleware = (
+  c: Context<{ Variables: AppVariables }>,
+  next: Next,
+) => Promise<void | Response>;
+
+/**
+ * the context the core injects into the capability plugin. structurally matches
+ * `@stwd/api`'s `StewardAppContext` (so the core-built context is assignable at
+ * the composition root); the capability routes use a subset (db, ensureAgentForTenant,
+ * safeJsonParse, writeAuditEvent, operatorAuth, tenantAuth).
+ */
+export interface StewardAppContext {
+  // ── shared singletons ─────────────────────────────────────────────────────
+  db: DbHandle;
+  vault: Vault;
+  policyEngine: PolicyEngine;
+  priceOracle: PriceOracle;
+
+  // ── core helpers (from @stwd/api services/context) ────────────────────────
+  ensureAgentForTenant(tenantId: string, agentId: string): Promise<AgentIdentity | undefined>;
+  getPolicySet(tenantId: string, agentId: string): Promise<PolicyRule[]>;
+  safeJsonParse<T>(c: Context): Promise<T | null>;
+  isValidAnyAddress(value: unknown): boolean;
+
+  // ── audit + token status (from @stwd/api services) ────────────────────────
+  writeAuditEvent(ev: AuditEventInput): Promise<void>;
+  getAgentTokenStatus(agentId: string): Promise<AgentTokenStatus | null>;
+
+  // ── redis (from @stwd/api middleware/redis) ───────────────────────────────
+  getRedisClient(): IoredisLike | null;
+
+  // ── auth middleware the plugin installs on its own routes ─────────────────
+  requireAgentJwt: StewardMiddleware;
+  operatorAuth: StewardMiddleware;
+  tenantAuth: (
+    c: Context<{ Variables: AppVariables }>,
+    next: Next,
+    options?: { requireTenantMatch?: string },
+  ) => Promise<void | Response>;
+}

--- a/packages/plugin-capabilities/src/index.ts
+++ b/packages/plugin-capabilities/src/index.ts
@@ -40,7 +40,7 @@ export type {
   NewCapabilityGrant,
 } from "./schema";
 export { capabilities, capabilityGrants } from "./schema";
-export { AgentNotFoundError, CapabilityStore, isExpired } from "./store";
+export { AgentNotFoundError, CapabilityStore, GrantExistsError, isExpired } from "./store";
 export type { CapabilitySpec } from "./store";
 export { createAgentCapabilityRoutes, createCapabilityRoutes } from "./routes";
 export {

--- a/packages/plugin-capabilities/src/index.ts
+++ b/packages/plugin-capabilities/src/index.ts
@@ -1,11 +1,11 @@
 /**
- * @stwd/plugin-capabilities — the opt-in capability plugin for Steward.
+ * @stwd/plugin-capabilities - the opt-in capability plugin for Steward.
  *
  * a CAPABILITY is a NAMED, narrowly-scoped use of a stored secret
  * (e.g. "github.pr.comment" -> secretId + host + path + method + header
  * injection). a GRANT says "agent X may use capability Y" (optionally until an
  * expiry). the plugin's job is to keep, per grant, exactly one legal narrow
- * secret_route — the row the already-defended proxy consumes to inject the
+ * secret_route - the row the already-defended proxy consumes to inject the
  * credential outbound. the plugin NEVER decrypts a secret and NEVER injects a
  * credential itself; it maintains the route rows the proxy matches.
  *
@@ -33,6 +33,7 @@ import type { StewardAppContext } from "./context";
 import { createAgentCapabilityRoutes, createCapabilityRoutes } from "./routes";
 
 export type { StewardAppContext } from "./context";
+export { createAgentCapabilityRoutes, createCapabilityRoutes } from "./routes";
 export type {
   Capability,
   CapabilityGrant,
@@ -40,9 +41,8 @@ export type {
   NewCapabilityGrant,
 } from "./schema";
 export { capabilities, capabilityGrants } from "./schema";
-export { AgentNotFoundError, CapabilityStore, GrantExistsError, isExpired } from "./store";
 export type { CapabilitySpec } from "./store";
-export { createAgentCapabilityRoutes, createCapabilityRoutes } from "./routes";
+export { AgentNotFoundError, CapabilityStore, GrantExistsError, isExpired } from "./store";
 export {
   createCapabilitySchema,
   createGrantSchema,
@@ -77,7 +77,7 @@ export const CAPABILITY_WEBHOOK_EVENTS = ["capability.created", "capability.revo
  * The capability plugin. `register(app, ctx)`:
  *   1. installs the tenant gate on /capabilities and /agents (operator-facing
  *      management surface; the routes additionally require recent tenant-admin
- *      MFA — the same bar the core /secrets + secret-route CRUD enforce, because
+ *      MFA - the same bar the core /secrets + secret-route CRUD enforce, because
  *      capabilities drive live credential injection).
  *   2. mounts the capability + grant CRUD router at /capabilities and /v1/capabilities.
  *   3. mounts the agent-scoped "usable capabilities" read at /agents and /v1/agents.

--- a/packages/plugin-capabilities/src/index.ts
+++ b/packages/plugin-capabilities/src/index.ts
@@ -1,0 +1,116 @@
+/**
+ * @stwd/plugin-capabilities — the opt-in capability plugin for Steward.
+ *
+ * a CAPABILITY is a NAMED, narrowly-scoped use of a stored secret
+ * (e.g. "github.pr.comment" -> secretId + host + path + method + header
+ * injection). a GRANT says "agent X may use capability Y" (optionally until an
+ * expiry). the plugin's job is to keep, per grant, exactly one legal narrow
+ * secret_route — the row the already-defended proxy consumes to inject the
+ * credential outbound. the plugin NEVER decrypts a secret and NEVER injects a
+ * credential itself; it maintains the route rows the proxy matches.
+ *
+ * this package uses the shipped plugin SDK contribution points:
+ *   - migrations (2c): plugin-owned, namespaced-journal `capabilities` +
+ *     `capability_grants` tables (isolated from the core migration ledger).
+ *   - routes (2a register): operator/tenant-auth capability + grant CRUD, plus
+ *     the agent-scoped "what may this agent use" read.
+ *   - webhookEvents (2a): the events THIS package emits at CRUD time.
+ *
+ * SCOPE (W-1a): schema + CRUD + grants + paired-route lifecycle ONLY. there is
+ * NO policy evaluation and NO invoke/forward path here (those are W-1b / W-1c).
+ * the package builds + tests STANDALONE and is NOT registered in the api
+ * composition root yet (that wiring is W-1c's job).
+ *
+ * the core never imports this package, and this package never imports `@stwd/api`:
+ * the shared service singletons + auth middleware the routes need are INJECTED via
+ * the `StewardAppContext` the core hands `register(app, ctx)` (no dependency cycle).
+ */
+
+import { fileURLToPath } from "node:url";
+import type { AppVariables, StewardPlugin } from "@stwd/shared";
+import type { Hono } from "hono";
+import type { StewardAppContext } from "./context";
+import { createAgentCapabilityRoutes, createCapabilityRoutes } from "./routes";
+
+export type { StewardAppContext } from "./context";
+export type {
+  Capability,
+  CapabilityGrant,
+  NewCapability,
+  NewCapabilityGrant,
+} from "./schema";
+export { capabilities, capabilityGrants } from "./schema";
+export { AgentNotFoundError, CapabilityStore, isExpired } from "./store";
+export type { CapabilitySpec } from "./store";
+export { createAgentCapabilityRoutes, createCapabilityRoutes } from "./routes";
+export {
+  createCapabilitySchema,
+  createGrantSchema,
+  updateCapabilitySchema,
+  validateCapabilitySpec,
+} from "./validate";
+
+/** the steward app the plugin mounts onto: a hono app with the shared variables. */
+export type StewardApp = Hono<{ Variables: AppVariables }>;
+
+/** a steward plugin concretely bound to the hono app + the injected context. */
+export type StewardApiPlugin = StewardPlugin<StewardApp, StewardAppContext>;
+
+/**
+ * the plugin's OWN drizzle migrations folder, resolved to an ABSOLUTE path at
+ * runtime (a relative path would break depending on process cwd). the host
+ * applies it AFTER the core migrator into a per-plugin namespaced bookkeeping
+ * table (drizzle.__drizzle_migrations_plugin_capabilities), isolated from the
+ * core journal.
+ */
+const MIGRATIONS_FOLDER = fileURLToPath(new URL("../drizzle", import.meta.url));
+
+/**
+ * Webhook event-type names this package emits (Phase 2a contribution). Only the
+ * CRUD lifecycle events W-1a produces are declared here; the invoke-time events
+ * (capability.invoked / .denied / .approval_queued) are declared by W-1c, the
+ * package that emits them.
+ */
+export const CAPABILITY_WEBHOOK_EVENTS = ["capability.created", "capability.revoked"] as const;
+
+/**
+ * The capability plugin. `register(app, ctx)`:
+ *   1. installs the tenant gate on /capabilities and /agents (operator-facing
+ *      management surface; the routes additionally require recent tenant-admin
+ *      MFA — the same bar the core /secrets + secret-route CRUD enforce, because
+ *      capabilities drive live credential injection).
+ *   2. mounts the capability + grant CRUD router at /capabilities and /v1/capabilities.
+ *   3. mounts the agent-scoped "usable capabilities" read at /agents and /v1/agents.
+ *
+ * NOTE: this plugin is NOT registered in the api composition root during W-1a; it
+ * is verified STANDALONE (its own tests register it onto a bare hono app with an
+ * injected context). the composition-root registration (compose.ts) is W-1c.
+ */
+export const capabilitiesPlugin: StewardApiPlugin = {
+  name: "capabilities",
+  version: "0.1.0",
+  webhookEvents: CAPABILITY_WEBHOOK_EVENTS,
+  migrations: {
+    id: "capabilities",
+    migrationsFolder: MIGRATIONS_FOLDER,
+  },
+  register(app, ctx) {
+    const { tenantAuth } = ctx;
+
+    // ── tenant gate on the management + agent-scoped surfaces ─────────────────
+    app.use("/capabilities", (c, next) => tenantAuth(c, next));
+    app.use("/capabilities/*", (c, next) => tenantAuth(c, next));
+    app.use("/v1/capabilities", (c, next) => tenantAuth(c, next));
+    app.use("/v1/capabilities/*", (c, next) => tenantAuth(c, next));
+    app.use("/agents/*", (c, next) => tenantAuth(c, next));
+    app.use("/v1/agents/*", (c, next) => tenantAuth(c, next));
+
+    // ── route mounts (unversioned + versioned) ────────────────────────────────
+    const capabilityRoutes = createCapabilityRoutes(ctx);
+    const agentRoutes = createAgentCapabilityRoutes(ctx);
+    app.route("/capabilities", capabilityRoutes);
+    app.route("/v1/capabilities", capabilityRoutes);
+    app.route("/agents", agentRoutes);
+    app.route("/v1/agents", agentRoutes);
+  },
+};

--- a/packages/plugin-capabilities/src/routes.ts
+++ b/packages/plugin-capabilities/src/routes.ts
@@ -1,0 +1,412 @@
+/**
+ * routes.ts — operator/tenant-auth CRUD for capabilities + grants.
+ *
+ * these are the OPERATOR-facing management routes (create/list/read/update/delete
+ * a capability, grant/revoke, and "what may an agent use"). the agent-facing
+ * invoke route is W-1c and is NOT here. mounted by the plugin's `register` behind
+ * the tenant gate (see index.ts), and each mutation additionally requires a
+ * recent tenant-admin MFA verification — the SAME bar the core /secrets + route
+ * CRUD requires, because capabilities drive live credential injection.
+ *
+ * the routes NEVER return a secret value (they only ever touch secret IDs +
+ * routing metadata). validation goes through the shared secret-route validator
+ * (validate.ts), so a capability can never be broader than a legal route.
+ */
+
+import type { ApiResponse, AppVariables } from "@stwd/shared";
+import type { Context } from "hono";
+import { Hono } from "hono";
+import type { StewardAppContext } from "./context";
+import type { Capability, CapabilityGrant } from "./schema";
+import { AgentNotFoundError, CapabilityStore } from "./store";
+import {
+  createCapabilitySchema,
+  createGrantSchema,
+  updateCapabilitySchema,
+  validateCapabilitySpec,
+} from "./validate";
+
+/** the public (never-secret) view of a capability returned by the API. */
+function toCapabilityView(cap: Capability) {
+  return {
+    id: cap.id,
+    name: cap.name,
+    secretId: cap.secretId,
+    host: cap.host,
+    pathPattern: cap.pathPattern,
+    method: cap.method,
+    injectAs: cap.injectAs,
+    injectKey: cap.injectKey,
+    injectFormat: cap.injectFormat,
+    constraints: cap.constraints,
+    enabled: cap.enabled,
+    createdAt: cap.createdAt,
+    updatedAt: cap.updatedAt,
+  };
+}
+
+/** the public view of a grant (route id included so an operator can trace it). */
+function toGrantView(grant: CapabilityGrant) {
+  return {
+    id: grant.id,
+    capabilityId: grant.capabilityId,
+    agentId: grant.agentId,
+    secretRouteId: grant.secretRouteId,
+    expiresAt: grant.expiresAt,
+    status: grant.status,
+    createdAt: grant.createdAt,
+  };
+}
+
+/** tenant-admin session predicate — mirrors the core /secrets route gate. */
+function isTenantAdminSession(c: Context<{ Variables: AppVariables }>): boolean {
+  const role = c.get("tenantRole");
+  return c.get("authType") === "session-jwt" && (role === "owner" || role === "admin");
+}
+
+/** recent-MFA check — mirrors the core /secrets route gate (5 min default). */
+function hasRecentSessionMfa(
+  c: Context<{ Variables: AppVariables }>,
+  maxAgeMs = 5 * 60_000,
+): boolean {
+  const verifiedAt = c.get("sessionMfaVerifiedAt");
+  return (
+    typeof verifiedAt === "number" &&
+    Number.isFinite(verifiedAt) &&
+    Date.now() - verifiedAt <= maxAgeMs
+  );
+}
+
+/**
+ * Gate a mutating capability route: require a tenant-admin session with recent
+ * MFA (the same bar the core /secrets + secret-route CRUD enforce). Returns a
+ * 403 Response to short-circuit, or null when authorized. Fail-closed.
+ */
+function requireCapabilityAdmin(
+  c: Context<{ Variables: AppVariables }>,
+  reason: string,
+): Response | null {
+  if (!isTenantAdminSession(c)) {
+    return c.json<ApiResponse>({ ok: false, error: `${reason} requires owner or admin session` }, 403);
+  }
+  if (!hasRecentSessionMfa(c)) {
+    return c.json<ApiResponse>(
+      { ok: false, error: `${reason} requires recent MFA verification` },
+      403,
+    );
+  }
+  return null;
+}
+
+/**
+ * Build the capability CRUD + grants router. `ctx` is the injected core context
+ * (db + audit + json parse). The router is mounted behind the tenant gate by the
+ * plugin's `register`.
+ */
+export function createCapabilityRoutes(
+  ctx: StewardAppContext,
+): Hono<{ Variables: AppVariables }> {
+  const routes = new Hono<{ Variables: AppVariables }>();
+  const store = new CapabilityStore(ctx.db);
+
+  async function audit(
+    c: Context<{ Variables: AppVariables }>,
+    event: {
+      tenantId: string;
+      action: string;
+      resourceType: string;
+      resourceId: string;
+      metadata?: Record<string, unknown>;
+    },
+  ): Promise<void> {
+    await ctx.writeAuditEvent({
+      tenantId: event.tenantId,
+      actorType: c.get("authType") === "api-key" ? "api-key" : "user",
+      actorId: c.get("userId") ?? c.get("authType") ?? event.tenantId,
+      action: event.action,
+      resourceType: event.resourceType,
+      resourceId: event.resourceId,
+      metadata: event.metadata,
+      ipAddress: c.req.header("x-forwarded-for") ?? null,
+      userAgent: c.req.header("user-agent") ?? null,
+      requestId: c.get("requestId") ?? null,
+    });
+  }
+
+  // ── POST /capabilities — create (validates, no grants -> no routes yet) ─────
+  routes.post("/", async (c) => {
+    const mfa = requireCapabilityAdmin(c, "Capability management");
+    if (mfa) return mfa;
+    const tenantId = c.get("tenantId");
+
+    const body = await ctx.safeJsonParse<Record<string, unknown>>(c);
+    if (!body) return c.json<ApiResponse>({ ok: false, error: "Invalid JSON in request body" }, 400);
+
+    const parsed = createCapabilitySchema.safeParse(body);
+    if (!parsed.success) {
+      return c.json<ApiResponse>({ ok: false, error: parsed.error.issues[0]?.message ?? "invalid body" }, 400);
+    }
+    const input = parsed.data;
+
+    const validated = validateCapabilitySpec({
+      secretId: input.secretId,
+      host: input.host,
+      pathPattern: input.pathPattern,
+      method: input.method,
+      injectAs: input.injectAs,
+      injectKey: input.injectKey,
+      injectFormat: input.injectFormat,
+    });
+    if (!validated.ok) return c.json<ApiResponse>({ ok: false, error: validated.error }, 400);
+
+    try {
+      const existing = await store.getCapabilityByName(tenantId, input.name);
+      if (existing) {
+        return c.json<ApiResponse>({ ok: false, error: `capability '${input.name}' already exists` }, 409);
+      }
+      const cap = await store.createCapability({
+        tenantId,
+        name: input.name,
+        spec: validated.spec,
+        constraints: input.constraints ?? {},
+        enabled: input.enabled ?? true,
+      });
+      await audit(c, {
+        tenantId,
+        action: "capability.create",
+        resourceType: "capability",
+        resourceId: cap.id,
+        metadata: {
+          name: cap.name,
+          secretId: cap.secretId,
+          host: cap.host,
+          pathPattern: cap.pathPattern,
+          method: cap.method,
+          enabled: cap.enabled,
+        },
+      });
+      return c.json<ApiResponse>({ ok: true, data: toCapabilityView(cap) }, 201);
+    } catch (e) {
+      return errorResponse(c, e);
+    }
+  });
+
+  // ── GET /capabilities — list ────────────────────────────────────────────────
+  routes.get("/", async (c) => {
+    const mfa = requireCapabilityAdmin(c, "Capability management");
+    if (mfa) return mfa;
+    const tenantId = c.get("tenantId");
+    const caps = await store.listCapabilities(tenantId);
+    return c.json<ApiResponse>({ ok: true, data: caps.map(toCapabilityView) });
+  });
+
+  // ── GET /capabilities/:id — read ─────────────────────────────────────────────
+  routes.get("/:id", async (c) => {
+    const mfa = requireCapabilityAdmin(c, "Capability management");
+    if (mfa) return mfa;
+    const tenantId = c.get("tenantId");
+    const cap = await store.getCapabilityById(tenantId, c.req.param("id"));
+    if (!cap) return c.json<ApiResponse>({ ok: false, error: "capability not found" }, 404);
+    return c.json<ApiResponse>({ ok: true, data: toCapabilityView(cap) });
+  });
+
+  // ── PATCH /capabilities/:id — enable/disable + constraint/routing update ────
+  routes.patch("/:id", async (c) => {
+    const mfa = requireCapabilityAdmin(c, "Capability management");
+    if (mfa) return mfa;
+    const tenantId = c.get("tenantId");
+    const id = c.req.param("id");
+
+    const body = await ctx.safeJsonParse<Record<string, unknown>>(c);
+    if (!body) return c.json<ApiResponse>({ ok: false, error: "Invalid JSON in request body" }, 400);
+
+    const parsed = updateCapabilitySchema.safeParse(body);
+    if (!parsed.success) {
+      return c.json<ApiResponse>({ ok: false, error: parsed.error.issues[0]?.message ?? "invalid body" }, 400);
+    }
+    const patch = parsed.data;
+
+    const current = await store.getCapabilityById(tenantId, id);
+    if (!current) return c.json<ApiResponse>({ ok: false, error: "capability not found" }, 404);
+
+    // if any routing/inject field is patched, re-validate the MERGED config with
+    // strict-host enforcement ON (no widen-by-patch: a strict host stays narrow).
+    const touchesRouting =
+      patch.secretId !== undefined ||
+      patch.host !== undefined ||
+      patch.pathPattern !== undefined ||
+      patch.method !== undefined ||
+      patch.injectAs !== undefined ||
+      patch.injectKey !== undefined ||
+      patch.injectFormat !== undefined;
+
+    let spec: ReturnType<typeof validateCapabilitySpec> | undefined;
+    if (touchesRouting) {
+      spec = validateCapabilitySpec({
+        secretId: patch.secretId ?? current.secretId,
+        host: patch.host ?? current.host,
+        pathPattern: patch.pathPattern ?? current.pathPattern,
+        method: patch.method ?? current.method,
+        injectAs: patch.injectAs ?? current.injectAs,
+        injectKey: patch.injectKey ?? current.injectKey,
+        injectFormat: patch.injectFormat ?? current.injectFormat,
+      });
+      if (!spec.ok) return c.json<ApiResponse>({ ok: false, error: spec.error }, 400);
+    }
+
+    try {
+      const updated = await store.updateCapability(tenantId, id, {
+        ...(spec?.ok ? { spec: spec.spec } : {}),
+        ...(patch.constraints !== undefined ? { constraints: patch.constraints } : {}),
+        ...(patch.enabled !== undefined ? { enabled: patch.enabled } : {}),
+      });
+      if (!updated) return c.json<ApiResponse>({ ok: false, error: "capability not found" }, 404);
+      await audit(c, {
+        tenantId,
+        action: "capability.update",
+        resourceType: "capability",
+        resourceId: updated.id,
+        metadata: {
+          enabled: updated.enabled,
+          routingChanged: touchesRouting,
+          constraintsChanged: patch.constraints !== undefined,
+        },
+      });
+      return c.json<ApiResponse>({ ok: true, data: toCapabilityView(updated) });
+    } catch (e) {
+      return errorResponse(c, e);
+    }
+  });
+
+  // ── DELETE /capabilities/:id — delete + tear down paired routes ─────────────
+  routes.delete("/:id", async (c) => {
+    const mfa = requireCapabilityAdmin(c, "Capability management");
+    if (mfa) return mfa;
+    const tenantId = c.get("tenantId");
+    const id = c.req.param("id");
+    try {
+      const removed = await store.deleteCapability(tenantId, id);
+      if (!removed) return c.json<ApiResponse>({ ok: false, error: "capability not found" }, 404);
+      await audit(c, {
+        tenantId,
+        action: "capability.delete",
+        resourceType: "capability",
+        resourceId: id,
+      });
+      return c.json<ApiResponse>({ ok: true, data: { id } });
+    } catch (e) {
+      return errorResponse(c, e);
+    }
+  });
+
+  // ── POST /capabilities/:id/grants — grant an agent (materializes route) ─────
+  routes.post("/:id/grants", async (c) => {
+    const mfa = requireCapabilityAdmin(c, "Capability grant management");
+    if (mfa) return mfa;
+    const tenantId = c.get("tenantId");
+    const capabilityId = c.req.param("id");
+
+    const body = await ctx.safeJsonParse<Record<string, unknown>>(c);
+    if (!body) return c.json<ApiResponse>({ ok: false, error: "Invalid JSON in request body" }, 400);
+
+    const parsed = createGrantSchema.safeParse(body);
+    if (!parsed.success) {
+      return c.json<ApiResponse>({ ok: false, error: parsed.error.issues[0]?.message ?? "invalid body" }, 400);
+    }
+    const { agentId, expiresAt } = parsed.data;
+    const expires = expiresAt ? new Date(expiresAt) : null;
+    if (expires && Number.isFinite(expires.getTime()) && expires.getTime() <= Date.now()) {
+      return c.json<ApiResponse>({ ok: false, error: "expiresAt must be in the future" }, 400);
+    }
+
+    try {
+      const result = await store.createGrant({ tenantId, capabilityId, agentId, expiresAt: expires });
+      if (!result) return c.json<ApiResponse>({ ok: false, error: "capability not found" }, 404);
+      await audit(c, {
+        tenantId,
+        action: "capability.grant.create",
+        resourceType: "capability_grant",
+        resourceId: result.grant.id,
+        metadata: {
+          capabilityId,
+          agentId,
+          secretRouteId: result.grant.secretRouteId,
+          expiresAt: result.grant.expiresAt,
+        },
+      });
+      return c.json<ApiResponse>({ ok: true, data: toGrantView(result.grant) }, 201);
+    } catch (e) {
+      if (e instanceof AgentNotFoundError) {
+        return c.json<ApiResponse>({ ok: false, error: e.message }, 404);
+      }
+      // unique-violation on (tenant, agent, capability) -> already granted.
+      const msg = e instanceof Error ? e.message : "";
+      if (/unique|duplicate/i.test(msg)) {
+        return c.json<ApiResponse>({ ok: false, error: "agent already granted this capability" }, 409);
+      }
+      return errorResponse(c, e);
+    }
+  });
+
+  // ── DELETE /grants/:grantId — revoke (tears down paired route) ──────────────
+  routes.delete("/grants/:grantId", async (c) => {
+    const mfa = requireCapabilityAdmin(c, "Capability grant management");
+    if (mfa) return mfa;
+    const tenantId = c.get("tenantId");
+    const grantId = c.req.param("grantId");
+    try {
+      const revoked = await store.revokeGrant(tenantId, grantId);
+      if (!revoked) return c.json<ApiResponse>({ ok: false, error: "grant not found" }, 404);
+      await audit(c, {
+        tenantId,
+        action: "capability.grant.revoke",
+        resourceType: "capability_grant",
+        resourceId: grantId,
+      });
+      return c.json<ApiResponse>({ ok: true, data: { id: grantId } });
+    } catch (e) {
+      return errorResponse(c, e);
+    }
+  });
+
+  return routes;
+}
+
+/**
+ * The agent-scoped read: what capabilities an agent may USE (active, unexpired
+ * grants to enabled capabilities). This is what the W-1c invoke path consults. It
+ * is a SEPARATE router mounted under a different prefix (/agents) — see index.ts.
+ * Never returns a secret value.
+ */
+export function createAgentCapabilityRoutes(
+  ctx: StewardAppContext,
+): Hono<{ Variables: AppVariables }> {
+  const routes = new Hono<{ Variables: AppVariables }>();
+  const store = new CapabilityStore(ctx.db);
+
+  // ── GET /agents/:agentId/capabilities — usable-by-agent listing ─────────────
+  routes.get("/:agentId/capabilities", async (c) => {
+    const mfa = requireCapabilityAdmin(c, "Capability management");
+    if (mfa) return mfa;
+    const tenantId = c.get("tenantId");
+    const agentId = c.req.param("agentId");
+    const usable = await store.listUsableCapabilitiesForAgent(tenantId, agentId);
+    return c.json<ApiResponse>({
+      ok: true,
+      data: usable.map(({ capability, grant }) => ({
+        ...toCapabilityView(capability),
+        grantId: grant.id,
+        grantExpiresAt: grant.expiresAt,
+      })),
+    });
+  });
+
+  return routes;
+}
+
+/** map an internal error to a fail-closed API response (never leaks internals). */
+function errorResponse(c: Context<{ Variables: AppVariables }>, e: unknown): Response {
+  const msg = e instanceof Error ? e.message : "Unknown error";
+  if (/not found/i.test(msg)) return c.json<ApiResponse>({ ok: false, error: msg }, 404);
+  return c.json<ApiResponse>({ ok: false, error: "internal error" }, 500);
+}

--- a/packages/plugin-capabilities/src/routes.ts
+++ b/packages/plugin-capabilities/src/routes.ts
@@ -164,6 +164,13 @@ export function createCapabilityRoutes(ctx: StewardAppContext): Hono<{ Variables
     });
     if (!validated.ok) return c.json<ApiResponse>({ ok: false, error: validated.error }, 400);
 
+    // the referenced secret must exist, belong to this tenant, and be usable
+    // (not deleted/expired). fail-closed: a bad secretId would otherwise create a
+    // route the proxy can never match/decrypt for this tenant.
+    if (!(await store.secretUsableForTenant(tenantId, validated.spec.secretId))) {
+      return c.json<ApiResponse>({ ok: false, error: "secret not found or not usable" }, 400);
+    }
+
     try {
       const existing = await store.getCapabilityByName(tenantId, input.name);
       if (existing) {
@@ -264,6 +271,13 @@ export function createCapabilityRoutes(ctx: StewardAppContext): Hono<{ Variables
         injectFormat: patch.injectFormat ?? current.injectFormat,
       });
       if (!spec.ok) return c.json<ApiResponse>({ ok: false, error: spec.error }, 400);
+      // if the patch points at a (possibly new) secret, it must be usable too.
+      if (
+        patch.secretId !== undefined &&
+        !(await store.secretUsableForTenant(tenantId, spec.spec.secretId))
+      ) {
+        return c.json<ApiResponse>({ ok: false, error: "secret not found or not usable" }, 400);
+      }
     }
 
     try {

--- a/packages/plugin-capabilities/src/routes.ts
+++ b/packages/plugin-capabilities/src/routes.ts
@@ -18,7 +18,7 @@ import type { Context } from "hono";
 import { Hono } from "hono";
 import type { StewardAppContext } from "./context";
 import type { Capability, CapabilityGrant } from "./schema";
-import { AgentNotFoundError, CapabilityStore } from "./store";
+import { AgentNotFoundError, CapabilityStore, GrantExistsError } from "./store";
 import {
   createCapabilitySchema,
   createGrantSchema,
@@ -339,9 +339,7 @@ export function createCapabilityRoutes(
       if (e instanceof AgentNotFoundError) {
         return c.json<ApiResponse>({ ok: false, error: e.message }, 404);
       }
-      // unique-violation on (tenant, agent, capability) -> already granted.
-      const msg = e instanceof Error ? e.message : "";
-      if (/unique|duplicate/i.test(msg)) {
+      if (e instanceof GrantExistsError) {
         return c.json<ApiResponse>({ ok: false, error: "agent already granted this capability" }, 409);
       }
       return errorResponse(c, e);

--- a/packages/plugin-capabilities/src/routes.ts
+++ b/packages/plugin-capabilities/src/routes.ts
@@ -1,11 +1,11 @@
 /**
- * routes.ts — operator/tenant-auth CRUD for capabilities + grants.
+ * routes.ts - operator/tenant-auth CRUD for capabilities + grants.
  *
  * these are the OPERATOR-facing management routes (create/list/read/update/delete
  * a capability, grant/revoke, and "what may an agent use"). the agent-facing
  * invoke route is W-1c and is NOT here. mounted by the plugin's `register` behind
  * the tenant gate (see index.ts), and each mutation additionally requires a
- * recent tenant-admin MFA verification — the SAME bar the core /secrets + route
+ * recent tenant-admin MFA verification - the SAME bar the core /secrets + route
  * CRUD requires, because capabilities drive live credential injection.
  *
  * the routes NEVER return a secret value (they only ever touch secret IDs +
@@ -58,13 +58,13 @@ function toGrantView(grant: CapabilityGrant) {
   };
 }
 
-/** tenant-admin session predicate — mirrors the core /secrets route gate. */
+/** tenant-admin session predicate - mirrors the core /secrets route gate. */
 function isTenantAdminSession(c: Context<{ Variables: AppVariables }>): boolean {
   const role = c.get("tenantRole");
   return c.get("authType") === "session-jwt" && (role === "owner" || role === "admin");
 }
 
-/** recent-MFA check — mirrors the core /secrets route gate (5 min default). */
+/** recent-MFA check - mirrors the core /secrets route gate (5 min default). */
 function hasRecentSessionMfa(
   c: Context<{ Variables: AppVariables }>,
   maxAgeMs = 5 * 60_000,
@@ -87,7 +87,10 @@ function requireCapabilityAdmin(
   reason: string,
 ): Response | null {
   if (!isTenantAdminSession(c)) {
-    return c.json<ApiResponse>({ ok: false, error: `${reason} requires owner or admin session` }, 403);
+    return c.json<ApiResponse>(
+      { ok: false, error: `${reason} requires owner or admin session` },
+      403,
+    );
   }
   if (!hasRecentSessionMfa(c)) {
     return c.json<ApiResponse>(
@@ -103,9 +106,7 @@ function requireCapabilityAdmin(
  * (db + audit + json parse). The router is mounted behind the tenant gate by the
  * plugin's `register`.
  */
-export function createCapabilityRoutes(
-  ctx: StewardAppContext,
-): Hono<{ Variables: AppVariables }> {
+export function createCapabilityRoutes(ctx: StewardAppContext): Hono<{ Variables: AppVariables }> {
   const routes = new Hono<{ Variables: AppVariables }>();
   const store = new CapabilityStore(ctx.db);
 
@@ -133,18 +134,22 @@ export function createCapabilityRoutes(
     });
   }
 
-  // ── POST /capabilities — create (validates, no grants -> no routes yet) ─────
+  // ── POST /capabilities - create (validates, no grants -> no routes yet) ─────
   routes.post("/", async (c) => {
     const mfa = requireCapabilityAdmin(c, "Capability management");
     if (mfa) return mfa;
     const tenantId = c.get("tenantId");
 
     const body = await ctx.safeJsonParse<Record<string, unknown>>(c);
-    if (!body) return c.json<ApiResponse>({ ok: false, error: "Invalid JSON in request body" }, 400);
+    if (!body)
+      return c.json<ApiResponse>({ ok: false, error: "Invalid JSON in request body" }, 400);
 
     const parsed = createCapabilitySchema.safeParse(body);
     if (!parsed.success) {
-      return c.json<ApiResponse>({ ok: false, error: parsed.error.issues[0]?.message ?? "invalid body" }, 400);
+      return c.json<ApiResponse>(
+        { ok: false, error: parsed.error.issues[0]?.message ?? "invalid body" },
+        400,
+      );
     }
     const input = parsed.data;
 
@@ -162,7 +167,10 @@ export function createCapabilityRoutes(
     try {
       const existing = await store.getCapabilityByName(tenantId, input.name);
       if (existing) {
-        return c.json<ApiResponse>({ ok: false, error: `capability '${input.name}' already exists` }, 409);
+        return c.json<ApiResponse>(
+          { ok: false, error: `capability '${input.name}' already exists` },
+          409,
+        );
       }
       const cap = await store.createCapability({
         tenantId,
@@ -191,7 +199,7 @@ export function createCapabilityRoutes(
     }
   });
 
-  // ── GET /capabilities — list ────────────────────────────────────────────────
+  // ── GET /capabilities - list ────────────────────────────────────────────────
   routes.get("/", async (c) => {
     const mfa = requireCapabilityAdmin(c, "Capability management");
     if (mfa) return mfa;
@@ -200,7 +208,7 @@ export function createCapabilityRoutes(
     return c.json<ApiResponse>({ ok: true, data: caps.map(toCapabilityView) });
   });
 
-  // ── GET /capabilities/:id — read ─────────────────────────────────────────────
+  // ── GET /capabilities/:id - read ─────────────────────────────────────────────
   routes.get("/:id", async (c) => {
     const mfa = requireCapabilityAdmin(c, "Capability management");
     if (mfa) return mfa;
@@ -210,7 +218,7 @@ export function createCapabilityRoutes(
     return c.json<ApiResponse>({ ok: true, data: toCapabilityView(cap) });
   });
 
-  // ── PATCH /capabilities/:id — enable/disable + constraint/routing update ────
+  // ── PATCH /capabilities/:id - enable/disable + constraint/routing update ────
   routes.patch("/:id", async (c) => {
     const mfa = requireCapabilityAdmin(c, "Capability management");
     if (mfa) return mfa;
@@ -218,11 +226,15 @@ export function createCapabilityRoutes(
     const id = c.req.param("id");
 
     const body = await ctx.safeJsonParse<Record<string, unknown>>(c);
-    if (!body) return c.json<ApiResponse>({ ok: false, error: "Invalid JSON in request body" }, 400);
+    if (!body)
+      return c.json<ApiResponse>({ ok: false, error: "Invalid JSON in request body" }, 400);
 
     const parsed = updateCapabilitySchema.safeParse(body);
     if (!parsed.success) {
-      return c.json<ApiResponse>({ ok: false, error: parsed.error.issues[0]?.message ?? "invalid body" }, 400);
+      return c.json<ApiResponse>(
+        { ok: false, error: parsed.error.issues[0]?.message ?? "invalid body" },
+        400,
+      );
     }
     const patch = parsed.data;
 
@@ -278,7 +290,7 @@ export function createCapabilityRoutes(
     }
   });
 
-  // ── DELETE /capabilities/:id — delete + tear down paired routes ─────────────
+  // ── DELETE /capabilities/:id - delete + tear down paired routes ─────────────
   routes.delete("/:id", async (c) => {
     const mfa = requireCapabilityAdmin(c, "Capability management");
     if (mfa) return mfa;
@@ -299,7 +311,7 @@ export function createCapabilityRoutes(
     }
   });
 
-  // ── POST /capabilities/:id/grants — grant an agent (materializes route) ─────
+  // ── POST /capabilities/:id/grants - grant an agent (materializes route) ─────
   routes.post("/:id/grants", async (c) => {
     const mfa = requireCapabilityAdmin(c, "Capability grant management");
     if (mfa) return mfa;
@@ -307,11 +319,15 @@ export function createCapabilityRoutes(
     const capabilityId = c.req.param("id");
 
     const body = await ctx.safeJsonParse<Record<string, unknown>>(c);
-    if (!body) return c.json<ApiResponse>({ ok: false, error: "Invalid JSON in request body" }, 400);
+    if (!body)
+      return c.json<ApiResponse>({ ok: false, error: "Invalid JSON in request body" }, 400);
 
     const parsed = createGrantSchema.safeParse(body);
     if (!parsed.success) {
-      return c.json<ApiResponse>({ ok: false, error: parsed.error.issues[0]?.message ?? "invalid body" }, 400);
+      return c.json<ApiResponse>(
+        { ok: false, error: parsed.error.issues[0]?.message ?? "invalid body" },
+        400,
+      );
     }
     const { agentId, expiresAt } = parsed.data;
     const expires = expiresAt ? new Date(expiresAt) : null;
@@ -320,7 +336,12 @@ export function createCapabilityRoutes(
     }
 
     try {
-      const result = await store.createGrant({ tenantId, capabilityId, agentId, expiresAt: expires });
+      const result = await store.createGrant({
+        tenantId,
+        capabilityId,
+        agentId,
+        expiresAt: expires,
+      });
       if (!result) return c.json<ApiResponse>({ ok: false, error: "capability not found" }, 404);
       await audit(c, {
         tenantId,
@@ -340,13 +361,16 @@ export function createCapabilityRoutes(
         return c.json<ApiResponse>({ ok: false, error: e.message }, 404);
       }
       if (e instanceof GrantExistsError) {
-        return c.json<ApiResponse>({ ok: false, error: "agent already granted this capability" }, 409);
+        return c.json<ApiResponse>(
+          { ok: false, error: "agent already granted this capability" },
+          409,
+        );
       }
       return errorResponse(c, e);
     }
   });
 
-  // ── DELETE /grants/:grantId — revoke (tears down paired route) ──────────────
+  // ── DELETE /grants/:grantId - revoke (tears down paired route) ──────────────
   routes.delete("/grants/:grantId", async (c) => {
     const mfa = requireCapabilityAdmin(c, "Capability grant management");
     if (mfa) return mfa;
@@ -373,7 +397,7 @@ export function createCapabilityRoutes(
 /**
  * The agent-scoped read: what capabilities an agent may USE (active, unexpired
  * grants to enabled capabilities). This is what the W-1c invoke path consults. It
- * is a SEPARATE router mounted under a different prefix (/agents) — see index.ts.
+ * is a SEPARATE router mounted under a different prefix (/agents) - see index.ts.
  * Never returns a secret value.
  */
 export function createAgentCapabilityRoutes(
@@ -382,7 +406,7 @@ export function createAgentCapabilityRoutes(
   const routes = new Hono<{ Variables: AppVariables }>();
   const store = new CapabilityStore(ctx.db);
 
-  // ── GET /agents/:agentId/capabilities — usable-by-agent listing ─────────────
+  // ── GET /agents/:agentId/capabilities - usable-by-agent listing ─────────────
   routes.get("/:agentId/capabilities", async (c) => {
     const mfa = requireCapabilityAdmin(c, "Capability management");
     if (mfa) return mfa;

--- a/packages/plugin-capabilities/src/schema.ts
+++ b/packages/plugin-capabilities/src/schema.ts
@@ -1,5 +1,5 @@
 /**
- * schema.ts — the capability plugin's OWN drizzle table definitions.
+ * schema.ts - the capability plugin's OWN drizzle table definitions.
  *
  * these mirror the SQL in `drizzle/0000_capabilities.sql` (the migration source
  * of truth the host applies into a per-plugin namespaced bookkeeping table). the
@@ -13,7 +13,7 @@
  *   so a capability can never be broader than a legal route.
  *
  * a grant is: agent X may use capability Y (optionally until expiresAt). the
- * grant carries the id of its paired secret_route (per-GRANT pairing — the proxy
+ * grant carries the id of its paired secret_route (per-GRANT pairing - the proxy
  * matches secret_routes by exact agentId, and capabilities are tenant-wide with
  * per-agent grants, so a route materializes once per grant; see PR / index.ts).
  */
@@ -48,9 +48,7 @@ export const capabilities = pgTable(
     injectAs: text("inject_as").notNull().default("header"),
     injectKey: text("inject_key").notNull(),
     injectFormat: text("inject_format").notNull().default("{value}"),
-    constraints: jsonb("constraints")
-      .notNull()
-      .default(sql`'{}'::jsonb`),
+    constraints: jsonb("constraints").notNull().default(sql`'{}'::jsonb`),
     enabled: boolean("enabled").notNull().default(true),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
@@ -73,7 +71,7 @@ export const capabilityGrants = pgTable(
     // proxy matches secret_routes by exact agentId, so one route per grant keeps
     // the proxy's matching semantics unchanged. nullable only transiently while a
     // grant is being torn down / for a route that failed to materialize (never
-    // left as an orphaned enabled route — see the lifecycle in store.ts + tests).
+    // left as an orphaned enabled route - see the lifecycle in store.ts + tests).
     secretRouteId: uuid("secret_route_id"),
     expiresAt: timestamp("expires_at", { withTimezone: true }),
     status: text("status").notNull().default("active"),

--- a/packages/plugin-capabilities/src/schema.ts
+++ b/packages/plugin-capabilities/src/schema.ts
@@ -1,0 +1,113 @@
+/**
+ * schema.ts — the capability plugin's OWN drizzle table definitions.
+ *
+ * these mirror the SQL in `drizzle/0000_capabilities.sql` (the migration source
+ * of truth the host applies into a per-plugin namespaced bookkeeping table). the
+ * plugin OWNS this schema; the lean core never imports it. the store (`store.ts`)
+ * queries through these definitions.
+ *
+ * a capability is a NAMED, narrowly-scoped use of a stored secret:
+ *   name -> (secretId, host, pathPattern, method) + the header-injection config
+ *   the paired secret_route needs. host/path/method/inject* are validated by the
+ *   SHARED secret-route validator (incl. per-host strict rules) at create/update,
+ *   so a capability can never be broader than a legal route.
+ *
+ * a grant is: agent X may use capability Y (optionally until expiresAt). the
+ * grant carries the id of its paired secret_route (per-GRANT pairing — the proxy
+ * matches secret_routes by exact agentId, and capabilities are tenant-wide with
+ * per-agent grants, so a route materializes once per grant; see PR / index.ts).
+ */
+
+import { relations, sql } from "drizzle-orm";
+import {
+  boolean,
+  check,
+  index,
+  jsonb,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+  varchar,
+} from "drizzle-orm/pg-core";
+
+export const capabilities = pgTable(
+  "capabilities",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    // No tenant FK: mirrors the core `secrets`/`secret_routes` convention
+    // (secrets are app-layer scoped by tenant_id; platform-scoped principals may
+    // not be present in `tenants`).
+    tenantId: text("tenant_id").notNull(),
+    name: text("name").notNull(),
+    secretId: uuid("secret_id").notNull(),
+    host: text("host").notNull(),
+    pathPattern: text("path_pattern").notNull(),
+    method: text("method").notNull(),
+    injectAs: text("inject_as").notNull().default("header"),
+    injectKey: text("inject_key").notNull(),
+    injectFormat: text("inject_format").notNull().default("{value}"),
+    constraints: jsonb("constraints")
+      .notNull()
+      .default(sql`'{}'::jsonb`),
+    enabled: boolean("enabled").notNull().default(true),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    tenantNameUniq: uniqueIndex("capabilities_tenant_name_uniq").on(table.tenantId, table.name),
+    tenantIdx: index("capabilities_tenant_idx").on(table.tenantId),
+    secretIdx: index("capabilities_secret_idx").on(table.secretId),
+  }),
+);
+
+export const capabilityGrants = pgTable(
+  "capability_grants",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    tenantId: text("tenant_id").notNull(),
+    agentId: varchar("agent_id", { length: 64 }).notNull(),
+    capabilityId: uuid("capability_id").notNull(),
+    // the paired secret_route this grant materialized (per-GRANT pairing). the
+    // proxy matches secret_routes by exact agentId, so one route per grant keeps
+    // the proxy's matching semantics unchanged. nullable only transiently while a
+    // grant is being torn down / for a route that failed to materialize (never
+    // left as an orphaned enabled route — see the lifecycle in store.ts + tests).
+    secretRouteId: uuid("secret_route_id"),
+    expiresAt: timestamp("expires_at", { withTimezone: true }),
+    status: text("status").notNull().default("active"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    statusCheck: check(
+      "capability_grants_status_check",
+      sql`${table.status} IN ('active','revoked')`,
+    ),
+    tenantAgentCapabilityUniq: uniqueIndex("capability_grants_tenant_agent_capability_uniq").on(
+      table.tenantId,
+      table.agentId,
+      table.capabilityId,
+    ),
+    tenantIdx: index("capability_grants_tenant_idx").on(table.tenantId),
+    agentIdx: index("capability_grants_agent_idx").on(table.agentId),
+    capabilityIdx: index("capability_grants_capability_idx").on(table.capabilityId),
+    routeIdx: index("capability_grants_route_idx").on(table.secretRouteId),
+  }),
+);
+
+export const capabilityRelations = relations(capabilities, ({ many }) => ({
+  grants: many(capabilityGrants),
+}));
+
+export const capabilityGrantRelations = relations(capabilityGrants, ({ one }) => ({
+  capability: one(capabilities, {
+    fields: [capabilityGrants.capabilityId],
+    references: [capabilities.id],
+  }),
+}));
+
+export type Capability = typeof capabilities.$inferSelect;
+export type NewCapability = typeof capabilities.$inferInsert;
+export type CapabilityGrant = typeof capabilityGrants.$inferSelect;
+export type NewCapabilityGrant = typeof capabilityGrants.$inferInsert;

--- a/packages/plugin-capabilities/src/store.ts
+++ b/packages/plugin-capabilities/src/store.ts
@@ -1,5 +1,5 @@
 /**
- * store.ts — the capability plugin's transactional data layer.
+ * store.ts - the capability plugin's transactional data layer.
  *
  * this owns the KEY architectural piece: the paired secret_route lifecycle. one
  * capability compiles to a legal narrow secret_route (the proxy's injection
@@ -24,7 +24,7 @@
  * materializing one route per grant (agentId = the grant's agent) keeps the
  * proxy UNCHANGED. documented in the PR body as the locked design call.
  *
- * the plugin NEVER decrypts a secret and NEVER injects a credential itself — it
+ * the plugin NEVER decrypts a secret and NEVER injects a credential itself - it
  * only maintains the secret_route ROWS the already-defended proxy consumes. the
  * injection config lives on the capability so a capability compiles to exactly
  * one legal route; every field is validated by the SHARED secret-route validator
@@ -32,20 +32,15 @@
  */
 
 import { agents, and, eq, type NewSecretRoute, type SecretRoute, secretRoutes } from "@stwd/db";
-import {
-  type Capability,
-  capabilities,
-  type CapabilityGrant,
-  capabilityGrants,
-} from "./schema";
+import { type Capability, type CapabilityGrant, capabilities, capabilityGrants } from "./schema";
 
 /**
  * a drizzle db handle (the core hands it via ctx.db). typed loosely so the plugin
- * does not couple to a specific driver — the core injects a real postgres-js /
+ * does not couple to a specific driver - the core injects a real postgres-js /
  * pglite handle. the members used here (select/insert/update/delete/transaction)
  * are common to every drizzle driver.
  */
-// biome-ignore lint/suspicious/noExplicitAny: drizzle's db handle is driver-typed
+// note (any is intentional): drizzle's db handle is driver-typed
 // (postgres-js/pglite/neon); the store accepts any drizzle db exposing the common
 // query builder + transaction. the core injects the concrete handle.
 export type Db = any;
@@ -119,7 +114,7 @@ export class CapabilityStore {
 
   /**
    * Create a capability. No grants yet, so NO paired routes are materialized (a
-   * capability with zero grants attaches the credential to nothing — fail-closed
+   * capability with zero grants attaches the credential to nothing - fail-closed
    * by construction). The caller MUST have validated the spec through the shared
    * secret-route validator first.
    */
@@ -160,7 +155,7 @@ export class CapabilityStore {
    *   route re-enabled (revoked/expired grants keep their route disabled).
    * - routing/inject fields changed: capability updated + every paired route's
    *   match/inject fields rewritten (a narrowing update narrows the live route
-   *   too — no widen-by-patch escaping the proxy).
+   *   too - no widen-by-patch escaping the proxy).
    *
    * `now` is injected for deterministic expiry evaluation in tests.
    */
@@ -207,9 +202,7 @@ export class CapabilityStore {
       const grants: CapabilityGrant[] = await tx
         .select()
         .from(capabilityGrants)
-        .where(
-          and(eq(capabilityGrants.tenantId, tenantId), eq(capabilityGrants.capabilityId, id)),
-        );
+        .where(and(eq(capabilityGrants.tenantId, tenantId), eq(capabilityGrants.capabilityId, id)));
 
       for (const grant of grants) {
         if (!grant.secretRouteId) continue;
@@ -255,9 +248,7 @@ export class CapabilityStore {
       const grants: CapabilityGrant[] = await tx
         .select()
         .from(capabilityGrants)
-        .where(
-          and(eq(capabilityGrants.tenantId, tenantId), eq(capabilityGrants.capabilityId, id)),
-        );
+        .where(and(eq(capabilityGrants.tenantId, tenantId), eq(capabilityGrants.capabilityId, id)));
 
       for (const grant of grants) {
         if (grant.secretRouteId) {
@@ -274,9 +265,7 @@ export class CapabilityStore {
       // FK cascade support.
       await tx
         .delete(capabilityGrants)
-        .where(
-          and(eq(capabilityGrants.tenantId, tenantId), eq(capabilityGrants.capabilityId, id)),
-        );
+        .where(and(eq(capabilityGrants.tenantId, tenantId), eq(capabilityGrants.capabilityId, id)));
       await tx
         .delete(capabilities)
         .where(and(eq(capabilities.id, id), eq(capabilities.tenantId, tenantId)));
@@ -355,10 +344,7 @@ export class CapabilityStore {
         .select()
         .from(capabilities)
         .where(
-          and(
-            eq(capabilities.id, input.capabilityId),
-            eq(capabilities.tenantId, input.tenantId),
-          ),
+          and(eq(capabilities.id, input.capabilityId), eq(capabilities.tenantId, input.tenantId)),
         );
       if (!cap) return null;
 
@@ -372,7 +358,7 @@ export class CapabilityStore {
 
       // reject a duplicate grant PROACTIVELY (before materializing a route), so
       // the unique(tenant, agent, capability) constraint is surfaced as a typed
-      // error rather than a driver-wrapped 500 — and no orphaned route is created
+      // error rather than a driver-wrapped 500 - and no orphaned route is created
       // (the insert is never attempted). fail-closed.
       const [existing] = await tx
         .select({ id: capabilityGrants.id })

--- a/packages/plugin-capabilities/src/store.ts
+++ b/packages/plugin-capabilities/src/store.ts
@@ -370,6 +370,22 @@ export class CapabilityStore {
         .where(and(eq(agents.id, input.agentId), eq(agents.tenantId, input.tenantId)));
       if (!agent) throw new AgentNotFoundError(input.agentId, input.tenantId);
 
+      // reject a duplicate grant PROACTIVELY (before materializing a route), so
+      // the unique(tenant, agent, capability) constraint is surfaced as a typed
+      // error rather than a driver-wrapped 500 — and no orphaned route is created
+      // (the insert is never attempted). fail-closed.
+      const [existing] = await tx
+        .select({ id: capabilityGrants.id })
+        .from(capabilityGrants)
+        .where(
+          and(
+            eq(capabilityGrants.tenantId, input.tenantId),
+            eq(capabilityGrants.agentId, input.agentId),
+            eq(capabilityGrants.capabilityId, input.capabilityId),
+          ),
+        );
+      if (existing) throw new GrantExistsError(input.agentId, input.capabilityId);
+
       const unexpired = !isExpired(input.expiresAt, now);
       const routeEnabled = cap.enabled && unexpired;
 
@@ -434,6 +450,18 @@ export class AgentNotFoundError extends Error {
   constructor(agentId: string, tenantId: string) {
     super(`Agent ${agentId} not found for tenant ${tenantId}`);
     this.name = "AgentNotFoundError";
+  }
+}
+
+/**
+ * Thrown when an agent is already granted a capability (the
+ * unique(tenant, agent, capability) invariant). The route layer maps this to a
+ * 409. Detected proactively so no orphaned route is created.
+ */
+export class GrantExistsError extends Error {
+  constructor(agentId: string, capabilityId: string) {
+    super(`Agent ${agentId} is already granted capability ${capabilityId}`);
+    this.name = "GrantExistsError";
   }
 }
 

--- a/packages/plugin-capabilities/src/store.ts
+++ b/packages/plugin-capabilities/src/store.ts
@@ -31,7 +31,16 @@
  * before any row is written.
  */
 
-import { agents, and, eq, type NewSecretRoute, type SecretRoute, secretRoutes } from "@stwd/db";
+import {
+  agents,
+  and,
+  eq,
+  isNull,
+  type NewSecretRoute,
+  type SecretRoute,
+  secretRoutes,
+  secrets,
+} from "@stwd/db";
 import { type Capability, type CapabilityGrant, capabilities, capabilityGrants } from "./schema";
 
 /**
@@ -108,6 +117,29 @@ export class CapabilityStore {
 
   async listCapabilities(tenantId: string): Promise<Capability[]> {
     return this.db.select().from(capabilities).where(eq(capabilities.tenantId, tenantId));
+  }
+
+  /**
+   * True if `secretId` names a secret that exists, belongs to `tenantId`, is not
+   * soft-deleted, and is not expired as of `now`. A capability MUST reference a
+   * usable secret so its paired routes are ones the proxy can actually match +
+   * decrypt for this tenant (fail-closed: a typo / foreign / deleted / expired
+   * secret is rejected at create/update, not silently accepted as a dead route).
+   */
+  async secretUsableForTenant(
+    tenantId: string,
+    secretId: string,
+    now: Date = new Date(),
+  ): Promise<boolean> {
+    const [row] = await this.db
+      .select({ id: secrets.id, expiresAt: secrets.expiresAt })
+      .from(secrets)
+      .where(
+        and(eq(secrets.id, secretId), eq(secrets.tenantId, tenantId), isNull(secrets.deletedAt)),
+      );
+    if (!row) return false;
+    if (row.expiresAt && new Date(row.expiresAt).getTime() <= now.getTime()) return false;
+    return true;
   }
 
   // ── capability create ─────────────────────────────────────────────────────

--- a/packages/plugin-capabilities/src/store.ts
+++ b/packages/plugin-capabilities/src/store.ts
@@ -1,0 +1,446 @@
+/**
+ * store.ts — the capability plugin's transactional data layer.
+ *
+ * this owns the KEY architectural piece: the paired secret_route lifecycle. one
+ * capability compiles to a legal narrow secret_route (the proxy's injection
+ * mechanism); a GRANT (agent X may use capability Y) materializes that route for
+ * that agent. every mutation that could leave a live injection path is done in a
+ * single DB transaction so there is never an orphaned ENABLED route:
+ *
+ *   - grant create      -> insert grant + insert its paired enabled secret_route (tx)
+ *   - grant revoke       -> mark grant revoked + delete its paired route (tx)
+ *   - capability disable -> disable capability + disable every grant's paired route (tx)
+ *   - capability enable  -> enable capability + re-enable every ACTIVE, unexpired
+ *                           grant's paired route (tx); revoked/expired stay off
+ *   - capability delete  -> delete every paired route + grants + the capability (tx)
+ *   - capability update  -> update capability + rewrite every paired route's
+ *                           match/inject fields (tx)
+ *
+ * WHY PER-GRANT (not per-capability): the proxy's route matcher selects
+ * secret_routes by EXACT (tenantId, agentId) equality (packages/proxy +
+ * packages/vault route-matcher). capabilities are tenant-wide (UNIQUE(tenant,
+ * name)) with per-agent grants, so a single tenant-wide route could not be
+ * matched for a specific agent without changing the proxy's matching semantics.
+ * materializing one route per grant (agentId = the grant's agent) keeps the
+ * proxy UNCHANGED. documented in the PR body as the locked design call.
+ *
+ * the plugin NEVER decrypts a secret and NEVER injects a credential itself — it
+ * only maintains the secret_route ROWS the already-defended proxy consumes. the
+ * injection config lives on the capability so a capability compiles to exactly
+ * one legal route; every field is validated by the SHARED secret-route validator
+ * before any row is written.
+ */
+
+import { agents, and, eq, type NewSecretRoute, type SecretRoute, secretRoutes } from "@stwd/db";
+import {
+  type Capability,
+  capabilities,
+  type CapabilityGrant,
+  capabilityGrants,
+} from "./schema";
+
+/**
+ * a drizzle db handle (the core hands it via ctx.db). typed loosely so the plugin
+ * does not couple to a specific driver — the core injects a real postgres-js /
+ * pglite handle. the members used here (select/insert/update/delete/transaction)
+ * are common to every drizzle driver.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: drizzle's db handle is driver-typed
+// (postgres-js/pglite/neon); the store accepts any drizzle db exposing the common
+// query builder + transaction. the core injects the concrete handle.
+export type Db = any;
+
+/** fields that define a capability's target + injection (validated together). */
+export interface CapabilitySpec {
+  secretId: string;
+  host: string;
+  pathPattern: string;
+  method: string;
+  injectAs: string;
+  injectKey: string;
+  injectFormat: string;
+}
+
+type CapabilityRouteFields = Pick<
+  Capability,
+  "secretId" | "host" | "pathPattern" | "method" | "injectAs" | "injectKey" | "injectFormat"
+>;
+
+/** map a capability's routing/injection fields onto a secret_route insert. */
+function routeValuesFor(
+  tenantId: string,
+  agentId: string,
+  cap: CapabilityRouteFields,
+  enabled: boolean,
+): NewSecretRoute {
+  return {
+    tenantId,
+    agentId,
+    secretId: cap.secretId,
+    hostPattern: cap.host,
+    pathPattern: cap.pathPattern,
+    method: cap.method,
+    injectAs: cap.injectAs,
+    injectKey: cap.injectKey,
+    injectFormat: cap.injectFormat,
+    // capabilities are pinned to an exact endpoint, so default 0 is fine (the
+    // matcher's specificity ordering handles precedence).
+    priority: 0,
+    enabled,
+  };
+}
+
+export class CapabilityStore {
+  constructor(private readonly db: Db) {}
+
+  // ── capability reads ────────────────────────────────────────────────────────
+
+  async getCapabilityById(tenantId: string, id: string): Promise<Capability | null> {
+    const [row] = await this.db
+      .select()
+      .from(capabilities)
+      .where(and(eq(capabilities.id, id), eq(capabilities.tenantId, tenantId)));
+    return row ?? null;
+  }
+
+  async getCapabilityByName(tenantId: string, name: string): Promise<Capability | null> {
+    const [row] = await this.db
+      .select()
+      .from(capabilities)
+      .where(and(eq(capabilities.name, name), eq(capabilities.tenantId, tenantId)));
+    return row ?? null;
+  }
+
+  async listCapabilities(tenantId: string): Promise<Capability[]> {
+    return this.db.select().from(capabilities).where(eq(capabilities.tenantId, tenantId));
+  }
+
+  // ── capability create ─────────────────────────────────────────────────────
+
+  /**
+   * Create a capability. No grants yet, so NO paired routes are materialized (a
+   * capability with zero grants attaches the credential to nothing — fail-closed
+   * by construction). The caller MUST have validated the spec through the shared
+   * secret-route validator first.
+   */
+  async createCapability(input: {
+    tenantId: string;
+    name: string;
+    spec: CapabilitySpec;
+    constraints: Record<string, unknown>;
+    enabled: boolean;
+  }): Promise<Capability> {
+    const [row] = await this.db
+      .insert(capabilities)
+      .values({
+        tenantId: input.tenantId,
+        name: input.name,
+        secretId: input.spec.secretId,
+        host: input.spec.host,
+        pathPattern: input.spec.pathPattern,
+        method: input.spec.method,
+        injectAs: input.spec.injectAs,
+        injectKey: input.spec.injectKey,
+        injectFormat: input.spec.injectFormat,
+        constraints: input.constraints,
+        enabled: input.enabled,
+      })
+      .returning();
+    return row;
+  }
+
+  // ── capability update (enable/disable + routing/inject/constraints) ─────────
+
+  /**
+   * Update a capability transactionally, rewriting every paired route so the
+   * proxy's injection stays exactly in sync with the capability.
+   *
+   * - `enabled` -> false: capability + every paired route disabled.
+   * - `enabled` -> true: capability enabled + every ACTIVE, unexpired grant's
+   *   route re-enabled (revoked/expired grants keep their route disabled).
+   * - routing/inject fields changed: capability updated + every paired route's
+   *   match/inject fields rewritten (a narrowing update narrows the live route
+   *   too — no widen-by-patch escaping the proxy).
+   *
+   * `now` is injected for deterministic expiry evaluation in tests.
+   */
+  async updateCapability(
+    tenantId: string,
+    id: string,
+    patch: {
+      spec?: CapabilitySpec;
+      constraints?: Record<string, unknown>;
+      enabled?: boolean;
+    },
+    now: Date = new Date(),
+  ): Promise<Capability | null> {
+    return this.db.transaction(async (tx: Db) => {
+      const [current] = await tx
+        .select()
+        .from(capabilities)
+        .where(and(eq(capabilities.id, id), eq(capabilities.tenantId, tenantId)));
+      if (!current) return null;
+
+      const set: Record<string, unknown> = { updatedAt: now };
+      if (patch.spec) {
+        set.secretId = patch.spec.secretId;
+        set.host = patch.spec.host;
+        set.pathPattern = patch.spec.pathPattern;
+        set.method = patch.spec.method;
+        set.injectAs = patch.spec.injectAs;
+        set.injectKey = patch.spec.injectKey;
+        set.injectFormat = patch.spec.injectFormat;
+      }
+      if (patch.constraints !== undefined) set.constraints = patch.constraints;
+      if (patch.enabled !== undefined) set.enabled = patch.enabled;
+
+      const [updated] = await tx
+        .update(capabilities)
+        .set(set)
+        .where(and(eq(capabilities.id, id), eq(capabilities.tenantId, tenantId)))
+        .returning();
+
+      // the capability's routing/inject fields as they are AFTER this patch.
+      const merged: CapabilityRouteFields = patch.spec ? { ...patch.spec } : current;
+      const willBeEnabled = patch.enabled ?? current.enabled;
+
+      const grants: CapabilityGrant[] = await tx
+        .select()
+        .from(capabilityGrants)
+        .where(
+          and(eq(capabilityGrants.tenantId, tenantId), eq(capabilityGrants.capabilityId, id)),
+        );
+
+      for (const grant of grants) {
+        if (!grant.secretRouteId) continue;
+        // a route stays enabled only if the capability is enabled AND the grant
+        // is active + unexpired. otherwise it is disabled (fail-closed).
+        const grantUsable = grant.status === "active" && !isExpired(grant.expiresAt, now);
+        const routeEnabled = willBeEnabled && grantUsable;
+        await tx
+          .update(secretRoutes)
+          .set({
+            secretId: merged.secretId,
+            hostPattern: merged.host,
+            pathPattern: merged.pathPattern,
+            method: merged.method,
+            injectAs: merged.injectAs,
+            injectKey: merged.injectKey,
+            injectFormat: merged.injectFormat,
+            enabled: routeEnabled,
+          })
+          .where(
+            and(eq(secretRoutes.id, grant.secretRouteId), eq(secretRoutes.tenantId, tenantId)),
+          );
+      }
+
+      return updated;
+    });
+  }
+
+  // ── capability delete ────────────────────────────────────────────────────
+
+  /**
+   * Delete a capability transactionally: remove every paired secret_route, then
+   * every grant, then the capability. No route can survive the delete.
+   */
+  async deleteCapability(tenantId: string, id: string): Promise<boolean> {
+    return this.db.transaction(async (tx: Db) => {
+      const [current] = await tx
+        .select()
+        .from(capabilities)
+        .where(and(eq(capabilities.id, id), eq(capabilities.tenantId, tenantId)));
+      if (!current) return false;
+
+      const grants: CapabilityGrant[] = await tx
+        .select()
+        .from(capabilityGrants)
+        .where(
+          and(eq(capabilityGrants.tenantId, tenantId), eq(capabilityGrants.capabilityId, id)),
+        );
+
+      for (const grant of grants) {
+        if (grant.secretRouteId) {
+          await tx
+            .delete(secretRoutes)
+            .where(
+              and(eq(secretRoutes.id, grant.secretRouteId), eq(secretRoutes.tenantId, tenantId)),
+            );
+        }
+      }
+
+      // grants would cascade on capability delete (FK ON DELETE CASCADE), but
+      // delete them explicitly first so behavior does not depend on the driver's
+      // FK cascade support.
+      await tx
+        .delete(capabilityGrants)
+        .where(
+          and(eq(capabilityGrants.tenantId, tenantId), eq(capabilityGrants.capabilityId, id)),
+        );
+      await tx
+        .delete(capabilities)
+        .where(and(eq(capabilities.id, id), eq(capabilities.tenantId, tenantId)));
+      return true;
+    });
+  }
+
+  // ── grant reads ────────────────────────────────────────────────────────────
+
+  async getGrantById(tenantId: string, grantId: string): Promise<CapabilityGrant | null> {
+    const [row] = await this.db
+      .select()
+      .from(capabilityGrants)
+      .where(and(eq(capabilityGrants.id, grantId), eq(capabilityGrants.tenantId, tenantId)));
+    return row ?? null;
+  }
+
+  async listGrantsForCapability(
+    tenantId: string,
+    capabilityId: string,
+  ): Promise<CapabilityGrant[]> {
+    return this.db
+      .select()
+      .from(capabilityGrants)
+      .where(
+        and(
+          eq(capabilityGrants.tenantId, tenantId),
+          eq(capabilityGrants.capabilityId, capabilityId),
+        ),
+      );
+  }
+
+  /**
+   * The capabilities an agent may USE right now: an ACTIVE, unexpired grant to an
+   * ENABLED capability. This is what the W-1c invoke path will consult. Expired
+   * or revoked grants, and disabled capabilities, are excluded (fail-closed).
+   */
+  async listUsableCapabilitiesForAgent(
+    tenantId: string,
+    agentId: string,
+    now: Date = new Date(),
+  ): Promise<Array<{ capability: Capability; grant: CapabilityGrant }>> {
+    const rows: Array<{ capability: Capability; grant: CapabilityGrant }> = await this.db
+      .select({ capability: capabilities, grant: capabilityGrants })
+      .from(capabilityGrants)
+      .innerJoin(capabilities, eq(capabilityGrants.capabilityId, capabilities.id))
+      .where(
+        and(
+          eq(capabilityGrants.tenantId, tenantId),
+          eq(capabilityGrants.agentId, agentId),
+          eq(capabilityGrants.status, "active"),
+          eq(capabilities.enabled, true),
+        ),
+      );
+    return rows.filter((r) => !isExpired(r.grant.expiresAt, now));
+  }
+
+  // ── grant create (materializes the paired route) ────────────────────────────
+
+  /**
+   * Grant `agentId` the use of a capability, materializing the paired
+   * secret_route transactionally. The route is enabled iff the capability is
+   * enabled and the grant is unexpired at creation. Verifies the agent belongs
+   * to the tenant (fail-closed: unknown agent = throw, no grant, no route).
+   */
+  async createGrant(input: {
+    tenantId: string;
+    capabilityId: string;
+    agentId: string;
+    expiresAt: Date | null;
+    now?: Date;
+  }): Promise<{ grant: CapabilityGrant; route: SecretRoute | null } | null> {
+    const now = input.now ?? new Date();
+    return this.db.transaction(async (tx: Db) => {
+      const [cap] = await tx
+        .select()
+        .from(capabilities)
+        .where(
+          and(
+            eq(capabilities.id, input.capabilityId),
+            eq(capabilities.tenantId, input.tenantId),
+          ),
+        );
+      if (!cap) return null;
+
+      // agent must exist under this tenant (mirrors SecretVault.createRoute's
+      // fail-closed agent check, so a grant never points a route at a phantom agent).
+      const [agent] = await tx
+        .select({ id: agents.id })
+        .from(agents)
+        .where(and(eq(agents.id, input.agentId), eq(agents.tenantId, input.tenantId)));
+      if (!agent) throw new AgentNotFoundError(input.agentId, input.tenantId);
+
+      const unexpired = !isExpired(input.expiresAt, now);
+      const routeEnabled = cap.enabled && unexpired;
+
+      const [route] = await tx
+        .insert(secretRoutes)
+        .values(routeValuesFor(input.tenantId, input.agentId, cap, routeEnabled))
+        .returning();
+
+      const [grant] = await tx
+        .insert(capabilityGrants)
+        .values({
+          tenantId: input.tenantId,
+          agentId: input.agentId,
+          capabilityId: input.capabilityId,
+          secretRouteId: route.id,
+          expiresAt: input.expiresAt,
+          status: "active",
+        })
+        .returning();
+
+      return { grant, route };
+    });
+  }
+
+  // ── grant revoke (tears down the paired route) ──────────────────────────────
+
+  /**
+   * Revoke a grant transactionally: mark it revoked and DELETE its paired route
+   * so the credential can no longer be injected for that agent. Idempotent on an
+   * already-revoked grant (route already gone). Returns false if the grant does
+   * not exist for the tenant.
+   */
+  async revokeGrant(tenantId: string, grantId: string): Promise<boolean> {
+    return this.db.transaction(async (tx: Db) => {
+      const [grant] = await tx
+        .select()
+        .from(capabilityGrants)
+        .where(and(eq(capabilityGrants.id, grantId), eq(capabilityGrants.tenantId, tenantId)));
+      if (!grant) return false;
+
+      if (grant.secretRouteId) {
+        await tx
+          .delete(secretRoutes)
+          .where(
+            and(eq(secretRoutes.id, grant.secretRouteId), eq(secretRoutes.tenantId, tenantId)),
+          );
+      }
+      await tx
+        .update(capabilityGrants)
+        .set({ status: "revoked", secretRouteId: null })
+        .where(and(eq(capabilityGrants.id, grantId), eq(capabilityGrants.tenantId, tenantId)));
+      return true;
+    });
+  }
+}
+
+/**
+ * Thrown when a grant targets an agent that does not exist under the tenant. The
+ * route layer maps this to a 404 (fail-closed: no grant, no route).
+ */
+export class AgentNotFoundError extends Error {
+  constructor(agentId: string, tenantId: string) {
+    super(`Agent ${agentId} not found for tenant ${tenantId}`);
+    this.name = "AgentNotFoundError";
+  }
+}
+
+/** true if `expiresAt` is set and at/before `now` (expired). null = never. */
+export function isExpired(expiresAt: Date | string | null, now: Date): boolean {
+  if (!expiresAt) return false;
+  const t = expiresAt instanceof Date ? expiresAt.getTime() : Date.parse(expiresAt);
+  if (!Number.isFinite(t)) return false;
+  return t <= now.getTime();
+}

--- a/packages/plugin-capabilities/src/validate.ts
+++ b/packages/plugin-capabilities/src/validate.ts
@@ -1,0 +1,128 @@
+/**
+ * validate.ts — capability create/update validation.
+ *
+ * a capability compiles to a legal narrow secret_route. so EVERY create/update
+ * that touches the routing/injection fields is validated through the SHARED
+ * secret-route validator (`@stwd/vault`'s `validateSecretRouteConfig`), INCLUDING
+ * the per-host STRICT_HOSTS narrowness rules. this is the single source of truth
+ * the proxy + the /secrets route CRUD already use; a capability can therefore
+ * never be broader than a legal route, and a strict host (e.g. api.github.com)
+ * forces an explicit method + >=2 path segments + no path wildcards here too.
+ *
+ * fail-closed: any missing/ambiguous field is rejected; a widen-by-patch on
+ * update is rejected because the MERGED config is re-validated with strict-host
+ * enforcement ON (never trusting a partial patch).
+ */
+
+import { validateSecretRouteConfig } from "@stwd/vault";
+import { z } from "zod";
+import type { CapabilitySpec } from "./store";
+
+/**
+ * Capability name: a dotted, lowercase, hierarchical identifier such as
+ * "github.pr.comment". kept strict so a capability name is a stable, greppable
+ * key (no whitespace, no injection-y characters). segments are alphanumeric +
+ * hyphen, joined by dots.
+ */
+const CAPABILITY_NAME = /^[a-z0-9]+([-][a-z0-9]+)*(\.[a-z0-9]+([-][a-z0-9]+)*)*$/;
+const MAX_CAPABILITY_NAME_LENGTH = 200;
+
+/** v1 constraints bag: intentionally small + opaque; the policy layer (W-1b) reads it. */
+const constraintsSchema = z.record(z.string(), z.unknown());
+
+/** create body: the full capability spec (all routing/inject fields required). */
+export const createCapabilitySchema = z.object({
+  name: z
+    .string()
+    .min(1)
+    .max(MAX_CAPABILITY_NAME_LENGTH)
+    .regex(CAPABILITY_NAME, "name must be a dotted lowercase identifier, e.g. github.pr.comment"),
+  secretId: z.string().uuid("secretId must be a uuid"),
+  host: z.string().min(1),
+  pathPattern: z.string().min(1),
+  method: z.string().min(1),
+  injectAs: z.string().optional(),
+  injectKey: z.string().min(1),
+  injectFormat: z.string().optional(),
+  constraints: constraintsSchema.optional(),
+  enabled: z.boolean().optional(),
+});
+
+export type CreateCapabilityBody = z.infer<typeof createCapabilitySchema>;
+
+/**
+ * update body: enable/disable + constraint updates + optional routing/inject
+ * edits. every routing/inject field is optional (partial patch), but the MERGED
+ * result is re-validated with strict-host enforcement ON (no widen-by-patch).
+ */
+export const updateCapabilitySchema = z
+  .object({
+    secretId: z.string().uuid().optional(),
+    host: z.string().min(1).optional(),
+    pathPattern: z.string().min(1).optional(),
+    method: z.string().min(1).optional(),
+    injectAs: z.string().optional(),
+    injectKey: z.string().min(1).optional(),
+    injectFormat: z.string().optional(),
+    constraints: constraintsSchema.optional(),
+    enabled: z.boolean().optional(),
+  })
+  .refine((b) => Object.keys(b).length > 0, {
+    message: "at least one capability field is required",
+  });
+
+export type UpdateCapabilityBody = z.infer<typeof updateCapabilitySchema>;
+
+/** grant body: which agent, optional expiry. */
+export const createGrantSchema = z.object({
+  agentId: z.string().min(1).max(64),
+  expiresAt: z.string().datetime().optional(),
+});
+
+export type CreateGrantBody = z.infer<typeof createGrantSchema>;
+
+/**
+ * Normalize + validate a full capability spec through the shared secret-route
+ * validator (strict hosts enforced). Returns the normalized spec, or an error
+ * string on the first failed rule. injectAs defaults to "header" (the proxy's
+ * only injection surface); injectFormat defaults to "{value}".
+ */
+export function validateCapabilitySpec(input: {
+  secretId: string;
+  host: string;
+  pathPattern: string;
+  method: string;
+  injectAs?: string;
+  injectKey: string;
+  injectFormat?: string;
+}): { ok: true; spec: CapabilitySpec } | { ok: false; error: string } {
+  const injectAs = input.injectAs ?? "header";
+  const injectFormat = input.injectFormat ?? "{value}";
+  // normalize the same way SecretVault.createRoute / the route validator expect:
+  // host lower-cased, method upper-cased. the shared validator re-checks both.
+  const spec: CapabilitySpec = {
+    secretId: input.secretId,
+    host: input.host.trim().toLowerCase(),
+    pathPattern: input.pathPattern.trim(),
+    method: input.method.trim().toUpperCase(),
+    injectAs,
+    injectKey: input.injectKey.trim(),
+    injectFormat,
+  };
+
+  const error = validateSecretRouteConfig(
+    {
+      hostPattern: spec.host,
+      pathPattern: spec.pathPattern,
+      method: spec.method,
+      injectAs: spec.injectAs,
+      injectKey: spec.injectKey,
+      injectFormat: spec.injectFormat,
+    },
+    // create/full-spec validation ALWAYS enforces strict hosts (the config is
+    // complete here — this is not a partial patch).
+    { enforceStrictHosts: true },
+  );
+  if (error) return { ok: false, error };
+  return { ok: true, spec };
+}

--- a/packages/plugin-capabilities/src/validate.ts
+++ b/packages/plugin-capabilities/src/validate.ts
@@ -1,5 +1,5 @@
 /**
- * validate.ts — capability create/update validation.
+ * validate.ts - capability create/update validation.
  *
  * a capability compiles to a legal narrow secret_route. so EVERY create/update
  * that touches the routing/injection fields is validated through the SHARED
@@ -120,7 +120,7 @@ export function validateCapabilitySpec(input: {
       injectFormat: spec.injectFormat,
     },
     // create/full-spec validation ALWAYS enforces strict hosts (the config is
-    // complete here — this is not a partial patch).
+    // complete here - this is not a partial patch).
     { enforceStrictHosts: true },
   );
   if (error) return { ok: false, error };

--- a/packages/plugin-capabilities/test-preload.ts
+++ b/packages/plugin-capabilities/test-preload.ts
@@ -1,0 +1,18 @@
+/**
+ * bun test preload for @stwd/plugin-capabilities — runs ONCE per `bun test`
+ * process, before any test file's module graph is evaluated.
+ *
+ * every value is set with `??=` so a real environment is never overridden, and
+ * the PGLite runtime is only marked when there is no real DATABASE_URL. no
+ * production guard is weakened; these are acceptable full-entropy test values.
+ */
+
+process.env.STEWARD_MASTER_PASSWORD ??= "steward-plugin-capabilities-test-master-password";
+process.env.STEWARD_JWT_SECRET ??=
+  "steward-plugin-capabilities-test-shared-jwt-secret-with-enough-entropy-0123456789";
+process.env.STEWARD_AUDIT_HMAC_KEY ??= "a".repeat(64);
+
+if (!process.env.DATABASE_URL) {
+  process.env.STEWARD_PGLITE_MEMORY ??= "true";
+  process.env.STEWARD_DB_MODE ??= "pglite";
+}

--- a/packages/plugin-capabilities/test-preload.ts
+++ b/packages/plugin-capabilities/test-preload.ts
@@ -1,5 +1,5 @@
 /**
- * bun test preload for @stwd/plugin-capabilities — runs ONCE per `bun test`
+ * bun test preload for @stwd/plugin-capabilities - runs ONCE per `bun test`
  * process, before any test file's module graph is evaluated.
  *
  * every value is set with `??=` so a real environment is never overridden, and

--- a/packages/plugin-capabilities/tsconfig.json
+++ b/packages/plugin-capabilities/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["src/__tests__"]
+}

--- a/turbo.json
+++ b/turbo.json
@@ -45,6 +45,10 @@
       "dependsOn": ["^build"],
       "outputs": []
     },
+    "@stwd/plugin-capabilities#build": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
     "@stwd/plugin-example#build": {
       "dependsOn": ["^build"],
       "outputs": []


### PR DESCRIPTION
## W-1a - capability plugin: schema + CRUD + grants + paired route lifecycle

Phase 1 of the universal credential plane (tracker #150). Adds `@stwd/plugin-capabilities`: a `StewardPlugin` that lets an operator define **capabilities** (named, narrowly-scoped uses of a stored secret, e.g. `github.pr.comment` -> secret + host + path + method + header injection) and **grants** (agent X may use capability Y, optionally with an expiry), each paired to exactly one narrow `secret_route` the already-defended proxy injects through.

**Scope:** schema + operator/tenant-auth CRUD + grants + the paired-route lifecycle **only**. NO policy evaluation, NO invoke/forward path (those are W-1b / W-1c). The package builds + tests **standalone** and is **not** registered in the api composition root yet (that wiring is W-1c).

Additive + vendor-neutral. The core is untouched; this plugin consumes the shipped plugin SDK contribution points and the shared secret-route validator.

### The paired-route design call (per-GRANT, grounded in the schema)
A capability is tenant-wide (`UNIQUE(tenant, name)`) with per-agent grants. The proxy's route matcher selects `secret_routes` by **exact `(tenantId, agentId)` equality** (packages/proxy + packages/vault route-matcher, `agent_id` is a real match key). A single tenant-wide route therefore could not be matched for a specific agent without changing the proxy's matching semantics.

**So the paired route is per-GRANT:** each grant to agent X materializes one `secret_route` with `agentId = X`. One capability with N grants = N routes. This keeps the proxy's matching semantics **completely unchanged** (I consume it, I do not modify it). The capability carries the injection config (`injectAs`/`injectKey`/`injectFormat`) so it compiles to exactly one legal route.

### What landed
- **New package** `packages/plugin-capabilities` (`@stwd/plugin-capabilities` v0.1.0), mirroring `@stwd/plugin-trading`'s plugin shape + `@stwd/plugin-example`'s migration wiring.
- **Plugin-owned namespaced migrations** (`drizzle/` with its own `meta/_journal.json`): `capabilities` (id, tenant_id, name, secret_id, host, path_pattern, method, inject_*, constraints jsonb, enabled, ts; `UNIQUE(tenant_id, name)`) + `capability_grants` (id, tenant_id, agent_id, capability_id FK cascade, secret_route_id, expires_at, status check `active|revoked`, `UNIQUE(tenant_id, agent_id, capability_id)`). Recorded in `drizzle.__drizzle_migrations_plugin_capabilities`, isolated from the core journal.
- **Validation** through the SHARED `validateSecretRouteConfig` from `@stwd/vault` (incl. per-host STRICT_HOSTS): a capability can never be broader than a legal route. Strict-host (github) rejections + off-allowlist host rejection enforced at create AND at PATCH (no widen-by-patch: merged config re-validated with strict-host ON).
- **Paired secret_route lifecycle (transactional, no orphaned enabled routes):** grant create -> insert grant + enabled route (tx); grant revoke -> mark revoked + delete route (tx); capability disable/enable -> disable/re-enable every active-unexpired grant's route (tx); capability delete -> delete every route + grant + capability (tx); capability update -> rewrite every paired route's match/inject fields (tx).
- **Routes** (operator/tenant-auth + recent tenant-admin MFA, the same bar the core `/secrets` CRUD enforces, because capabilities drive live credential injection): `POST/GET /capabilities`, `GET/PATCH/DELETE /capabilities/:id`, `POST /capabilities/:id/grants`, `DELETE /capabilities/grants/:grantId`, `GET /agents/:agentId/capabilities` (the usable-by-agent read W-1c will consult). Never returns a secret value.
- **Webhook events declared:** `capability.created`, `capability.revoked` (only the CRUD-lifecycle events this package emits; invoke-time events are W-1c's).
- **Secret usability guard (fail-closed):** create/update reject a `secretId` that does not exist, is foreign-tenant, soft-deleted, or expired, so a bad secret never produces a dead granted route.

### Verification (real numbers)
- `bun x turbo run build --filter='./packages/*'`: **26/26 successful** (also verified in a clean detached worktree of this branch: **26/26**, proving standalone build).
- `bun install --frozen-lockfile`: clean (lockfile committed).
- `bun audit`: **0 critical / 0 high** (1 pre-existing low: transitive `elliptic`, not from this package).
- `bun run lint` (tsc) + `biome check`: clean.
- New suite: **48 pass / 0 fail / 103 expect()** across 3 files (migration-isolation 3, store-lifecycle 29, routes 16), each run against a real PGLite core schema + this plugin's own migrations.
- Regressions untouched-green: `@stwd/vault` secret-route-validator + secret-vault-lifecycle **44/0**; `@stwd/api` secret-routes-validation + all 3 plugin-host suites **31/0**.
- Core files byte-untouched: `git diff origin/develop -- packages/policy-engine packages/proxy/src/handlers packages/vault/src/secret-vault.ts` is **EMPTY**.
- `git diff origin/develop --stat`: new package + `bun.lock` + `turbo.json` only.

### For W-1b / W-1c
- The `capabilities.constraints` jsonb is the small opaque bag W-1b's `capability-intent` rule reads.
- `GET /agents/:agentId/capabilities` (and `CapabilityStore.listUsableCapabilitiesForAgent`) is the fail-closed usable-by-agent surface the W-1c invoke path consults (active + unexpired grant to an enabled capability).
- The paired route already exists + is enabled for a usable grant, so W-1c's delegate-to-proxy step has a route to match; disabling/revoking/expiry already tears it down transactionally.

DO NOT MERGE yet (W-1b/W-1c pending). PR base: `develop`.

Co-authored-by: wakesync <shadow@shad0w.xyz>
Co-authored-by: Sol <sol@shad0w.xyz>
