### PR TITLE
feat(capabilities): agent invoke route with policy gating and proxy delegation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,9 @@ COPY packages/db/package.json                packages/db/package.json
 COPY packages/eliza-plugin/package.json      packages/eliza-plugin/package.json
 COPY packages/erc8004/package.json           packages/erc8004/package.json
 COPY packages/erc8183/package.json           packages/erc8183/package.json
+COPY packages/plugin-capabilities/package.json packages/plugin-capabilities/package.json
 COPY packages/plugin-trading/package.json     packages/plugin-trading/package.json
+COPY packages/proxy-client/package.json       packages/proxy-client/package.json
 COPY packages/policy-engine/package.json     packages/policy-engine/package.json
 COPY packages/proxy/package.json             packages/proxy/package.json
 COPY packages/react/package.json             packages/react/package.json
@@ -82,7 +84,9 @@ COPY packages/db/package.json                packages/db/package.json
 COPY packages/eliza-plugin/package.json      packages/eliza-plugin/package.json
 COPY packages/erc8004/package.json           packages/erc8004/package.json
 COPY packages/erc8183/package.json           packages/erc8183/package.json
+COPY packages/plugin-capabilities/package.json packages/plugin-capabilities/package.json
 COPY packages/plugin-trading/package.json     packages/plugin-trading/package.json
+COPY packages/proxy-client/package.json       packages/proxy-client/package.json
 COPY packages/policy-engine/package.json     packages/policy-engine/package.json
 COPY packages/proxy/package.json             packages/proxy/package.json
 COPY packages/react/package.json             packages/react/package.json
@@ -108,7 +112,9 @@ COPY packages/adapters    packages/adapters
 COPY packages/api         packages/api
 COPY packages/auth        packages/auth
 COPY packages/db          packages/db
+COPY packages/plugin-capabilities packages/plugin-capabilities
 COPY packages/plugin-trading packages/plugin-trading
+COPY packages/proxy-client packages/proxy-client
 COPY packages/policy-engine packages/policy-engine
 COPY packages/proxy       packages/proxy
 COPY packages/redis       packages/redis
@@ -132,7 +138,9 @@ RUN mkdir -p node_modules/@stwd && \
     ln -sf ../../../packages/proxy         node_modules/@stwd/proxy && \
     ln -sf ../../../packages/webhooks      node_modules/@stwd/webhooks && \
     ln -sf ../../../packages/policy-engine     node_modules/@stwd/policy-engine && \
+    ln -sf ../../../packages/plugin-capabilities node_modules/@stwd/plugin-capabilities && \
     ln -sf ../../../packages/plugin-trading    node_modules/@stwd/plugin-trading && \
+    ln -sf ../../../packages/proxy-client      node_modules/@stwd/proxy-client && \
     ln -sf ../../../packages/trade-sessions    node_modules/@stwd/trade-sessions && \
     ln -sf ../../../packages/venue-hyperliquid node_modules/@stwd/venue-hyperliquid && \
     ln -sf ../../../packages/venue-polymarket  node_modules/@stwd/venue-polymarket
@@ -162,7 +170,9 @@ COPY packages/db/package.json                packages/db/package.json
 COPY packages/eliza-plugin/package.json      packages/eliza-plugin/package.json
 COPY packages/erc8004/package.json           packages/erc8004/package.json
 COPY packages/erc8183/package.json           packages/erc8183/package.json
+COPY packages/plugin-capabilities/package.json packages/plugin-capabilities/package.json
 COPY packages/plugin-trading/package.json     packages/plugin-trading/package.json
+COPY packages/proxy-client/package.json       packages/proxy-client/package.json
 COPY packages/policy-engine/package.json     packages/policy-engine/package.json
 COPY packages/proxy/package.json             packages/proxy/package.json
 COPY packages/react/package.json             packages/react/package.json
@@ -185,7 +195,9 @@ COPY --from=build /app/packages/adapters    packages/adapters
 COPY --from=build /app/packages/api         packages/api
 COPY --from=build /app/packages/auth        packages/auth
 COPY --from=build /app/packages/db          packages/db
+COPY --from=build /app/packages/plugin-capabilities packages/plugin-capabilities
 COPY --from=build /app/packages/plugin-trading packages/plugin-trading
+COPY --from=build /app/packages/proxy-client packages/proxy-client
 COPY --from=build /app/packages/policy-engine packages/policy-engine
 COPY --from=build /app/packages/proxy       packages/proxy
 COPY --from=build /app/packages/redis       packages/redis
@@ -210,7 +222,9 @@ RUN mkdir -p node_modules/@stwd && \
     ln -sf ../../../packages/proxy         node_modules/@stwd/proxy && \
     ln -sf ../../../packages/webhooks      node_modules/@stwd/webhooks && \
     ln -sf ../../../packages/policy-engine node_modules/@stwd/policy-engine && \
+    ln -sf ../../../packages/plugin-capabilities node_modules/@stwd/plugin-capabilities && \
     ln -sf ../../../packages/plugin-trading    node_modules/@stwd/plugin-trading && \
+    ln -sf ../../../packages/proxy-client      node_modules/@stwd/proxy-client && \
     ln -sf ../../../packages/trade-sessions    node_modules/@stwd/trade-sessions && \
     ln -sf ../../../packages/venue-hyperliquid node_modules/@stwd/venue-hyperliquid && \
     ln -sf ../../../packages/venue-polymarket  node_modules/@stwd/venue-polymarket && \

--- a/bun.lock
+++ b/bun.lock
@@ -191,6 +191,7 @@
         "zod": "^4.3.6",
       },
       "devDependencies": {
+        "@stwd/proxy": "workspace:*",
         "@types/node": "^25.5.0",
       },
     },

--- a/bun.lock
+++ b/bun.lock
@@ -53,6 +53,7 @@
         "@stwd/adapters": "workspace:*",
         "@stwd/auth": "workspace:*",
         "@stwd/db": "workspace:*",
+        "@stwd/plugin-capabilities": "workspace:*",
         "@stwd/plugin-trading": "workspace:*",
         "@stwd/policy-engine": "workspace:*",
         "@stwd/redis": "workspace:*",
@@ -178,7 +179,10 @@
       "name": "@stwd/plugin-capabilities",
       "version": "0.1.0",
       "dependencies": {
+        "@stwd/auth": "workspace:*",
         "@stwd/db": "workspace:*",
+        "@stwd/policy-engine": "workspace:*",
+        "@stwd/proxy-client": "workspace:*",
         "@stwd/redis": "workspace:*",
         "@stwd/shared": "workspace:*",
         "@stwd/vault": "workspace:*",
@@ -187,8 +191,6 @@
         "zod": "^4.3.6",
       },
       "devDependencies": {
-        "@stwd/plugin-sdk": "workspace:*",
-        "@stwd/policy-engine": "workspace:*",
         "@types/node": "^25.5.0",
       },
     },

--- a/docs/deploy/railway-lean-full.md
+++ b/docs/deploy/railway-lean-full.md
@@ -123,6 +123,38 @@ flipping `STEWARD_PLUGINS=trading` and adding the venue vars it actually uses.
 > `STEWARD_PM_TEST_CREDS`) are NOT production env — do not set them on a prod
 > trading service.
 
+### capabilities-only (FULL service running the capabilities plugin)
+
+the capabilities plugin (agent-facing credential-invoke layer) is an opt-in
+plugin toggled the SAME way as trading, through `STEWARD_PLUGINS`. it may run
+alongside trading (`STEWARD_PLUGINS=trading,capabilities`) or alone
+(`STEWARD_PLUGINS=capabilities`). its operator CRUD + agent invoke routes 404 in
+lean; its `capability_invocations` migration runs on boot only in full (parity).
+
+set these ONLY on a service that enables `capabilities`. the agent invoke route
+delegates the allowed call THROUGH the proxy via `@stwd/proxy-client` (it NEVER
+decrypts a secret in-process); these vars are how it reaches the proxy. fail-
+closed: if any is missing, the invoke route returns **503** and forwards nothing.
+
+| var | severity | why | source |
+|-----|----------|-----|--------|
+| `STEWARD_PLUGINS=capabilities` (or `trading,capabilities`) | required (full) | enables the capabilities plugin (routes + migrations) | `packages/api/src/plugin-config.ts` |
+| `STEWARD_PROXY_URL` | required (full) | base URL of the Steward proxy service the invoke route delegates to (e.g. `https://proxy.internal`). ABSENT => invoke returns 503 | `packages/plugin-capabilities/src/invoke.ts` |
+| `STEWARD_PROXY_REQUEST_SIGNING_SECRET` | required (full) | HMAC secret the invoke route signs its proxy requests with. MUST be one of the secrets the proxy verifies (`STEWARD_PROXY_REQUEST_SIGNING_SECRET(S)` on the proxy). ABSENT => invoke returns 503 | `packages/plugin-capabilities/src/invoke.ts` |
+
+notes:
+- the invoke route mints a SHORT-LIVED `api:proxy`-scoped agent token per call
+  using the shared `STEWARD_JWT_SECRET` (already in the mode-independent set) —
+  the SAME secret the proxy verifies tokens with. no extra token var is needed.
+- `STEWARD_PROXY_REQUEST_SIGNING_SECRETS` (comma-separated, plural) is also
+  accepted; the invoke route uses the FIRST entry. run the proxy with request
+  signing enabled (`STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE=true`) in prod.
+- the capabilities plugin also reads `DATABASE_URL`, `STEWARD_MASTER_PASSWORD`,
+  `STEWARD_AUDIT_HMAC_KEY` — already in the mode-independent set (no extra action
+  beyond `STEWARD_PLUGINS`, `STEWARD_PROXY_URL`, and the signing secret).
+- the proxy itself needs a credential route materialized for the agent (the
+  capability GRANT does this) + the target host in its allowlist / a named alias.
+
 ---
 
 ## 3. build the image

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -29,6 +29,7 @@
     "@stwd/adapters": "workspace:*",
     "@stwd/auth": "workspace:*",
     "@stwd/db": "workspace:*",
+    "@stwd/plugin-capabilities": "workspace:*",
     "@stwd/plugin-trading": "workspace:*",
     "@stwd/policy-engine": "workspace:*",
     "@stwd/redis": "workspace:*",

--- a/packages/api/src/__tests__/capabilities-lean-full-parity.test.ts
+++ b/packages/api/src/__tests__/capabilities-lean-full-parity.test.ts
@@ -19,8 +19,17 @@
  *   ~/.bun/bin/bun test src/__tests__/capabilities-lean-full-parity.test.ts
  */
 
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { policyRuleRegistry } from "@stwd/policy-engine";
 import { composeApp, runComposedPluginMigrations } from "../compose";
+
+// the capabilities plugin contributes the `capability-intent` policy rule into the
+// PROCESS-WIDE policy-rule registry (fail-closed on double-register: a second
+// plugin, or a second boot, that registers the SAME type throws). in PRODUCTION
+// composeApp runs ONCE per process, so this never fires; in this suite we boot
+// composeApp multiple times, so we CLEAR the (contributed-only) registry before a
+// FULL boot to keep each boot hermetic. clearing is safe: core rule types are NOT
+// in this registry (only plugin contributions are).
 
 // capabilities routes, enumerated from packages/plugin-capabilities/src/:
 //   - routes.ts        → CRUD + grants (createCapabilityRoutes), agent-scoped read
@@ -87,17 +96,28 @@ afterEach(() => {
 });
 
 describe("capabilities parity — routes 404 in LEAN (genuinely not mounted)", () => {
+  // LEAN boots register NO policy rules, so no registry hygiene needed here.
+  let leanApp: Awaited<ReturnType<typeof bootApp>>;
+  beforeAll(async () => {
+    leanApp = await bootApp(undefined);
+  });
   it.each(CAP_ROUTES)("LEAN 404: $method $path", async ({ method, path }) => {
-    const app = await bootApp(undefined);
-    expect(await probe(app, method, path)).toBe(404);
+    expect(await probe(leanApp, method, path)).toBe(404);
   });
 });
 
 describe("capabilities parity — routes MOUNTED in FULL (reach plugin, NOT 404)", () => {
+  // boot FULL ONCE (the capability-intent contribution registers into the
+  // process-wide registry, which fail-closes on a second same-type register).
+  // clear the contributed-rule registry first for hermeticity across files.
+  let fullApp: Awaited<ReturnType<typeof bootApp>>;
+  beforeAll(async () => {
+    policyRuleRegistry.clear();
+    fullApp = await bootApp("capabilities");
+  });
   it.each(CAP_ROUTES)("FULL mounted: $method $path", async ({ method, path }) => {
-    const app = await bootApp("capabilities");
     // mounted → reaches plugin auth/handler: 400/401/403/200 etc, just NOT 404.
-    expect(await probe(app, method, path)).not.toBe(404);
+    expect(await probe(fullApp, method, path)).not.toBe(404);
   });
 });
 
@@ -144,6 +164,9 @@ describe("capabilities parity — migration composition (both-on/both-off)", () 
 
 describe("capabilities parity — multi-plugin (trading + capabilities)", () => {
   it("STEWARD_PLUGINS=trading,capabilities mounts BOTH", async () => {
+    // fresh registry: this boot re-registers capability-intent, which would
+    // collide with a prior FULL boot's registration in the same process.
+    policyRuleRegistry.clear();
     const app = await bootApp("trading,capabilities");
     // a trading route is mounted…
     expect(await probe(app, "GET", "/v1/trade/token-status")).not.toBe(404);

--- a/packages/api/src/__tests__/capabilities-lean-full-parity.test.ts
+++ b/packages/api/src/__tests__/capabilities-lean-full-parity.test.ts
@@ -1,0 +1,153 @@
+/**
+ * capabilities-lean-full-parity.test.ts — the go-live gate for the capabilities
+ * plugin's deploy toggle. The SAME composition root (`composeApp()`) runs LEAN
+ * (STEWARD_PLUGINS unset → core only) or FULL (STEWARD_PLUGINS="capabilities" →
+ * core + capabilities) purely by environment. This proves:
+ *
+ *   1. EVERY capabilities route (operator CRUD + agent-scoped read + the agent
+ *      invoke path) 404s in LEAN (genuinely not mounted — core notFound) and is
+ *      MOUNTED in FULL (reaches the plugin auth/handler → NOT 404).
+ *   2. Migration parity: LEAN collects NO capability migrations; FULL collects the
+ *      capabilities plugin without throwing (routes + migrations both-on/both-off).
+ *   3. Multi-plugin: STEWARD_PLUGINS="trading,capabilities" mounts BOTH.
+ *
+ * SEPARATE from lean-full-parity.test.ts (which owns the trading enumeration) so
+ * neither file has to know about the other's routes. SELF-CONTAINED +
+ * ISOLATION-SAFE: composeApp reads process.env.STEWARD_PLUGINS directly, so every
+ * case set/restores it. DB/secret bootstrap comes from test-preload.ts (PGLite).
+ * Run from packages/api so bunfig's preload applies:
+ *   ~/.bun/bin/bun test src/__tests__/capabilities-lean-full-parity.test.ts
+ */
+
+import { afterEach, describe, expect, it } from "bun:test";
+import { composeApp, runComposedPluginMigrations } from "../compose";
+
+// capabilities routes, enumerated from packages/plugin-capabilities/src/:
+//   - routes.ts        → CRUD + grants (createCapabilityRoutes), agent-scoped read
+//   - invoke.ts        → the agent invoke path (createInvokeRoutes)
+//   index.ts mounts CRUD/invoke at "/capabilities" AND "/v1/capabilities", and the
+//   agent read at "/agents" AND "/v1/agents". A leaf is probed at both prefixes.
+const CAP_ROUTE_LEAVES: ReadonlyArray<{ method: string; suffix: string }> = [
+  { method: "GET", suffix: "/capabilities" },
+  { method: "POST", suffix: "/capabilities" },
+  { method: "GET", suffix: "/capabilities/cap_probe" }, // /:id
+  { method: "PATCH", suffix: "/capabilities/cap_probe" },
+  { method: "DELETE", suffix: "/capabilities/cap_probe" },
+  { method: "POST", suffix: "/capabilities/cap_probe/grants" },
+  { method: "DELETE", suffix: "/capabilities/grants/grant_probe" },
+  { method: "POST", suffix: "/capabilities/github.pr.comment/invoke" }, // the agent invoke path
+];
+
+// NOTE on the agent-scoped read (/agents/:agentId/capabilities): the CORE already
+// owns the `/agents/*` prefix (agent management routes), so that subpath is NOT
+// plugin-EXCLUSIVE — in LEAN it hits the core /agents gate (403, not 404). The
+// plugin-exclusive proof therefore uses the /capabilities/* leaves (CRUD + grants
+// + invoke), which the core does not own at all. The agent-read mount is still
+// covered by the plugin's own routes.test.ts.
+const CAP_PREFIXES = ["", "/v1"] as const;
+
+const CAP_ROUTES: ReadonlyArray<{ method: string; path: string }> = CAP_ROUTE_LEAVES.flatMap(
+  (leaf) => CAP_PREFIXES.map((p) => ({ method: leaf.method, path: `${p}${leaf.suffix}` })),
+);
+
+function withPlugins(value: string | undefined): () => void {
+  const prev = process.env.STEWARD_PLUGINS;
+  if (value === undefined) delete process.env.STEWARD_PLUGINS;
+  else process.env.STEWARD_PLUGINS = value;
+  return () => {
+    if (prev === undefined) delete process.env.STEWARD_PLUGINS;
+    else process.env.STEWARD_PLUGINS = prev;
+  };
+}
+
+async function bootApp(plugins: string | undefined) {
+  const restore = withPlugins(plugins);
+  try {
+    return await composeApp();
+  } finally {
+    restore();
+  }
+}
+
+async function probe(
+  app: Awaited<ReturnType<typeof bootApp>>,
+  method: string,
+  path: string,
+): Promise<number> {
+  const init: RequestInit =
+    method === "GET" || method === "HEAD"
+      ? { method }
+      : { method, headers: { "Content-Type": "application/json" }, body: "{}" };
+  const res = await app.request(path, init);
+  return res.status;
+}
+
+afterEach(() => {
+  delete process.env.STEWARD_PLUGINS;
+});
+
+describe("capabilities parity — routes 404 in LEAN (genuinely not mounted)", () => {
+  it.each(CAP_ROUTES)("LEAN 404: $method $path", async ({ method, path }) => {
+    const app = await bootApp(undefined);
+    expect(await probe(app, method, path)).toBe(404);
+  });
+});
+
+describe("capabilities parity — routes MOUNTED in FULL (reach plugin, NOT 404)", () => {
+  it.each(CAP_ROUTES)("FULL mounted: $method $path", async ({ method, path }) => {
+    const app = await bootApp("capabilities");
+    // mounted → reaches plugin auth/handler: 400/401/403/200 etc, just NOT 404.
+    expect(await probe(app, method, path)).not.toBe(404);
+  });
+});
+
+describe("capabilities parity — migration composition (both-on/both-off)", () => {
+  it("LEAN: runComposedPluginMigrations returns [] (no attempt, no throw)", async () => {
+    const restore = withPlugins(undefined);
+    try {
+      const results = await runComposedPluginMigrations();
+      expect(results).toEqual([]);
+    } finally {
+      restore();
+    }
+  });
+
+  it("FULL(capabilities): the migration seam COLLECTS + ATTEMPTS the capabilities plugin", async () => {
+    // capabilities declares a REAL migration source (unlike trading, whose tables
+    // ship via core migrations), so FULL mode ATTEMPTS to apply it. in this unit
+    // env there is no real migration DB handle, so the attempt surfaces as
+    // `DATABASE_URL is required` — which PROVES the capabilities plugin was
+    // collected + run by the SAME resolver composeApp uses (parity). LEAN (above)
+    // makes NO such attempt (returns [] cleanly). the real applied-into-namespaced
+    // -table behavior is proven by the plugin's migration-isolation.test.ts.
+    const restore = withPlugins("capabilities");
+    try {
+      let attempted = false;
+      try {
+        await runComposedPluginMigrations();
+        // if it did not throw (a real DB was present), that is also fine — the
+        // collection ran either way.
+        attempted = true;
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        // the throw must be the capabilities migration attempt (collection ran),
+        // not a resolver/boot error.
+        expect(msg).toContain("capabilities");
+        attempted = true;
+      }
+      expect(attempted).toBe(true);
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe("capabilities parity — multi-plugin (trading + capabilities)", () => {
+  it("STEWARD_PLUGINS=trading,capabilities mounts BOTH", async () => {
+    const app = await bootApp("trading,capabilities");
+    // a trading route is mounted…
+    expect(await probe(app, "GET", "/v1/trade/token-status")).not.toBe(404);
+    // …and a capabilities route is mounted.
+    expect(await probe(app, "GET", "/v1/capabilities")).not.toBe(404);
+  });
+});

--- a/packages/api/src/__tests__/lean-full-parity.test.ts
+++ b/packages/api/src/__tests__/lean-full-parity.test.ts
@@ -462,8 +462,11 @@ describe("parity — LEAN preserves global mw → core auth → idempotency → 
     // so the lean order is exactly createApp()'s [global mw + core auth] ->
     // idempotency -> core routes.
     expect(composeSource).toContain("mountCoreIdempotencyAndRoutes(app)");
-    // the lean early-return happens before any trading import/registration
-    const leanReturnIdx = composeSource.indexOf('if (!enabled.has("trading"))');
+    // the lean early-return happens before any trading import/registration. the
+    // lean guard is now `enabled.size === 0` (no opt-in plugins), generalized from
+    // the historical trading-only `!enabled.has("trading")` when the capabilities
+    // plugin was added to the enabled set (W-1c).
+    const leanReturnIdx = composeSource.indexOf("if (enabled.size === 0)");
     const tradingImportIdx = composeSource.indexOf('import("@stwd/plugin-trading")');
     expect(leanReturnIdx).toBeGreaterThanOrEqual(0);
     expect(tradingImportIdx).toBeGreaterThanOrEqual(0);

--- a/packages/api/src/__tests__/plugin-config.test.ts
+++ b/packages/api/src/__tests__/plugin-config.test.ts
@@ -120,6 +120,7 @@ describe("resolveEnabledPlugins — fail-closed on unknown plugin", () => {
 describe("KNOWN_PLUGIN_NAMES", () => {
   it("contains trading and nothing unexpected", () => {
     expect(KNOWN_PLUGIN_NAMES.has("trading")).toBe(true);
-    expect([...KNOWN_PLUGIN_NAMES]).toEqual(["trading"]);
+    expect(KNOWN_PLUGIN_NAMES.has("capabilities")).toBe(true);
+    expect([...KNOWN_PLUGIN_NAMES]).toEqual(["trading", "capabilities"]);
   });
 });

--- a/packages/api/src/compose.ts
+++ b/packages/api/src/compose.ts
@@ -116,55 +116,76 @@ export async function composeApp(): Promise<Hono<{ Variables: AppVariables }>> {
   // 1) lean core: global mw + all core auth mw (NO idempotency, NO routes yet).
   const app = createApp();
 
-  if (!enabled.has("trading")) {
+  if (enabled.size === 0) {
     // LEAN MODE: no opt-in plugins to register. the deferred-route machinery only
     // exists to slot a plugin's auth mw before idempotency and its routes after;
     // with no plugins there is nothing to defer, so mount core idempotency +
     // core routes directly. ordering is identical to FULL minus the (absent)
     // plugin contributions: [global mw + core auth mw (createApp)] -> idempotency
-    // -> core routes. the trading plugin is NOT imported in this path, so its
-    // module is never evaluated when trading is disabled.
+    // -> core routes. no opt-in plugin module is imported in this path, so none
+    // is ever evaluated in lean mode.
     mountCoreIdempotencyAndRoutes(app);
     return app;
   }
 
-  // FULL MODE: register the trading plugin. behavior-identical to the historical
-  // hardcoded path — same registration, same ordering, same migrations.
+  // FULL MODE: register this deploy's enabled opt-in plugins. behavior-identical
+  // to the historical hardcoded path for trading — same registration, same
+  // ordering, same migrations — plus any other enabled plugin (capabilities).
   //
-  // 2) plugin auth-middleware phase + buffered routes. trade auth mw lands now,
-  //    before idempotency; trade routes are buffered for after.
+  // 2) plugin auth-middleware phase + buffered routes. each plugin's auth mw lands
+  //    now, before idempotency; its routes are buffered for after.
   //
-  // the trading plugin is imported with a STATIC, bundler-discoverable specifier so
-  // Wrangler/esbuild include `@stwd/plugin-trading` in the Worker bundle (a
-  // non-analyzable dynamic specifier would be omitted, and the Worker would fail at
-  // runtime with a missing module on the first request). gating is on the
-  // EXECUTION (the `if (enabled.has("trading"))` guard around this block), NOT on
-  // the import specifier — the literal `import("@stwd/plugin-trading")` string is
-  // still statically analyzable so the bundler always includes the module; it is
-  // simply not EVALUATED when trading is disabled. this is the DEPLOY-ONLY
-  // composition root, so it is allowed to reference the plugin; the LIBRARY entry
-  // (lib.ts) does NOT re-export composeApp, so a consumer importing `@stwd/api`
-  // never pulls the plugin into its graph and the lean core stays trading-free.
+  // each opt-in plugin is imported with a STATIC, bundler-discoverable specifier so
+  // Wrangler/esbuild include it in the Worker bundle (a non-analyzable dynamic
+  // specifier would be omitted, and the Worker would fail at runtime with a
+  // missing module on the first request). gating is on the EXECUTION (the
+  // `enabled.has(...)` guards below), NOT on the import specifier — the literal
+  // `import("@stwd/plugin-...")` strings are still statically analyzable so the
+  // bundler always includes the modules; they are simply not EVALUATED when the
+  // plugin is disabled. this is the DEPLOY-ONLY composition root, so it is allowed
+  // to reference the plugins; the LIBRARY entry (lib.ts) does NOT re-export
+  // composeApp, so a consumer importing `@stwd/api` never pulls a plugin into its
+  // graph and the lean core stays plugin-free.
   const ctx = buildPluginContext();
-  const { tradingPlugin } = (await import("@stwd/plugin-trading")) as {
-    tradingPlugin: Parameters<PluginHost<typeof ctx>["register"]>[2];
-  };
+  type ComposedPlugin = Parameters<PluginHost<typeof ctx>["register"]>[2];
+  const plugins: ComposedPlugin[] = [];
+
+  if (enabled.has("trading")) {
+    const { tradingPlugin } = (await import("@stwd/plugin-trading")) as {
+      tradingPlugin: ComposedPlugin;
+    };
+    plugins.push(tradingPlugin);
+  }
+
+  if (enabled.has("capabilities")) {
+    // PARITY: gated by the SAME resolver as its migrations (see
+    // runComposedPluginMigrations). the capabilities plugin also contributes the
+    // `capability-intent` policy rule declaratively (plugin.policyRules); the host
+    // registers it into the policy-engine evaluator registry BEFORE any route
+    // runs, so the agent invoke path can evaluate capability-intent rules.
+    const { capabilitiesPlugin } = (await import("@stwd/plugin-capabilities")) as {
+      capabilitiesPlugin: ComposedPlugin;
+    };
+    plugins.push(capabilitiesPlugin);
+  }
+
   const { deferred, flush } = makeDeferredRouteApp(app);
 
   // The plugin host composes the plugin(s): it orders by `dependsOn` (failing
   // closed on a missing/cyclic dep), merges each plugin's declared
   // `webhookEvents` into the SHARED process-wide registry the webhook config/
-  // dispatch path consults (so a plugin's event type is accepted), then runs
-  // each plugin's `register`. It registers onto the DEFERRED-ROUTE proxy so the
-  // load-bearing ordering is preserved: plugin auth mw lands now (before
+  // dispatch path consults (so a plugin's event type is accepted), registers each
+  // plugin's declared `policyRules` into the policy-engine evaluator registry,
+  // then runs each plugin's `register`. It registers onto the DEFERRED-ROUTE proxy
+  // so the load-bearing ordering is preserved: plugin auth mw lands now (before
   // idempotency), plugin routes are buffered and flushed after.
   const host = new PluginHost<typeof ctx>(webhookEventRegistry);
-  await host.register(deferred, ctx, tradingPlugin);
+  await host.register(deferred, ctx, ...plugins);
 
   // 3) core idempotency + core routes.
   mountCoreIdempotencyAndRoutes(app);
 
-  // 4) flush the plugin's buffered routes (now AFTER idempotency).
+  // 4) flush the plugins' buffered routes (now AFTER idempotency).
   flush();
 
   return app;
@@ -195,19 +216,32 @@ export async function composeApp(): Promise<Hono<{ Variables: AppVariables }>> {
 export async function runComposedPluginMigrations(): Promise<
   Array<{ pluginName: string; id: string; migrationsTable: string }>
 > {
-  // PARITY with composeApp: resolve the SAME enabled set from the SAME resolver.
-  // if trading is disabled, collect NO trading migrations (its routes are also
-  // not mounted by composeApp) — the two paths can never drift.
+  // PARITY with composeApp: resolve the SAME enabled set from the SAME resolver,
+  // and collect migrations for EXACTLY the plugins composeApp registers. a plugin
+  // that is disabled contributes NO migrations (its routes are also not mounted)
+  // — the two paths can never drift (both-on or both-off, per plugin).
   const enabled = resolveEnabledPlugins();
-  if (!enabled.has("trading")) {
+  if (enabled.size === 0) {
     return [];
   }
 
   const ctx = buildPluginContext();
-  const { tradingPlugin } = (await import("@stwd/plugin-trading")) as {
-    tradingPlugin: Parameters<PluginHost<typeof ctx>["register"]>[2];
-  };
+  type ComposedPlugin = Parameters<PluginHost<typeof ctx>["register"]>[2];
   const host = new PluginHost<typeof ctx>();
-  host.collectMigrations(tradingPlugin);
+
+  if (enabled.has("trading")) {
+    const { tradingPlugin } = (await import("@stwd/plugin-trading")) as {
+      tradingPlugin: ComposedPlugin;
+    };
+    host.collectMigrations(tradingPlugin);
+  }
+
+  if (enabled.has("capabilities")) {
+    const { capabilitiesPlugin } = (await import("@stwd/plugin-capabilities")) as {
+      capabilitiesPlugin: ComposedPlugin;
+    };
+    host.collectMigrations(capabilitiesPlugin);
+  }
+
   return host.runMigrations();
 }

--- a/packages/api/src/plugin-config.ts
+++ b/packages/api/src/plugin-config.ts
@@ -42,7 +42,7 @@
  * authority for "what can be enabled" so adding a plugin is a one-line change
  * here plus its registration in compose.ts.
  */
-export const KNOWN_PLUGIN_NAMES = new Set<string>(["trading"]);
+export const KNOWN_PLUGIN_NAMES = new Set<string>(["trading", "capabilities"]);
 
 /**
  * Error thrown when `STEWARD_PLUGINS` names a plugin this composition root does

--- a/packages/plugin-capabilities/drizzle/0001_capability_invocations.sql
+++ b/packages/plugin-capabilities/drizzle/0001_capability_invocations.sql
@@ -1,0 +1,29 @@
+-- @stwd/plugin-capabilities migration 0001: capability_invocations.
+--
+-- the append-only audit + rate-limit source for the agent invoke path (W-1c).
+-- EVERY invoke attempt records exactly one row with its terminal decision
+-- (allow / deny / approval / error), regardless of outcome:
+--   - audit trail: who invoked what, and how it was decided;
+--   - rate source: the trailing-hour invoke count the `capability-intent`
+--     `maxCallsPerHour` constraint reads (count of this agent+capability rows in
+--     the last hour). recording the attempt BEFORE forwarding keeps the count
+--     fail-closed (a decision is durable before any credential leaves).
+--
+-- plugin-owned + namespaced (applied into
+-- drizzle.__drizzle_migrations_plugin_capabilities). no FK to core tables: an
+-- invocation is a self-contained decision record keyed by tenant/agent/capability
+-- ids (capability_id nullable so an attempt denied before capability resolution
+-- is still recorded).
+CREATE TABLE "capability_invocations" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" text NOT NULL,
+	"agent_id" varchar(64) NOT NULL,
+	"capability_id" uuid,
+	"decision" text NOT NULL,
+	"created_at" timestamptz DEFAULT now() NOT NULL,
+	CONSTRAINT "capability_invocations_decision_check" CHECK ("decision" IN ('allow','deny','approval','error'))
+);
+--> statement-breakpoint
+CREATE INDEX "capability_invocations_rate_idx" ON "capability_invocations" ("agent_id","capability_id","created_at");
+--> statement-breakpoint
+CREATE INDEX "capability_invocations_tenant_idx" ON "capability_invocations" ("tenant_id");

--- a/packages/plugin-capabilities/drizzle/meta/_journal.json
+++ b/packages/plugin-capabilities/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1782800000000,
       "tag": "0000_capabilities",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1782900000000,
+      "tag": "0001_capability_invocations",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/plugin-capabilities/package.json
+++ b/packages/plugin-capabilities/package.json
@@ -27,6 +27,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@stwd/proxy": "workspace:*",
     "@types/node": "^25.5.0"
   },
   "description": "Opt-in capability plugin for Steward: named narrowly-scoped credential uses (capabilities) + per-agent grants, each paired to a narrow secret_route the proxy injects through. Operator/tenant-auth CRUD with plugin-owned namespaced migrations. The core does not depend on this package."

--- a/packages/plugin-capabilities/package.json
+++ b/packages/plugin-capabilities/package.json
@@ -15,7 +15,10 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
+    "@stwd/auth": "workspace:*",
     "@stwd/db": "workspace:*",
+    "@stwd/policy-engine": "workspace:*",
+    "@stwd/proxy-client": "workspace:*",
     "@stwd/redis": "workspace:*",
     "@stwd/shared": "workspace:*",
     "@stwd/vault": "workspace:*",
@@ -24,8 +27,6 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@stwd/plugin-sdk": "workspace:*",
-    "@stwd/policy-engine": "workspace:*",
     "@types/node": "^25.5.0"
   },
   "description": "Opt-in capability plugin for Steward: named narrowly-scoped credential uses (capabilities) + per-agent grants, each paired to a narrow secret_route the proxy injects through. Operator/tenant-auth CRUD with plugin-owned namespaced migrations. The core does not depend on this package."

--- a/packages/plugin-capabilities/src/__tests__/invoke-e2e.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/invoke-e2e.test.ts
@@ -1,0 +1,359 @@
+/**
+ * invoke-e2e.test.ts - the FULL arc, end to end, in-process:
+ *
+ *   agent -> invoke route -> policy default-deny -> @stwd/proxy-client ->
+ *   REAL @stwd/proxy (auth + route-match + decrypt + inject + scrub) -> stub upstream
+ *
+ * we DO NOT hit real GitHub. the proxy's outbound forwarder is replaced via the
+ * shipped `__setForwardProxyRequestForTests` hook (same pattern as the #149
+ * proxy-client e2e), so we assert:
+ *   1. an ALLOWED invoke forwards to the proxy with the seeded PAT injected as the
+ *      upstream Authorization header, and the PAT is NEVER visible to the agent
+ *      caller (the agent only ever sent the invoke body; the plugin minted the
+ *      api:proxy token server-side; the credential lives only on the OUTBOUND
+ *      proxy->upstream request). an invocation row (decision=allow) is recorded.
+ *   2. a wrong argEquals value => 403 (never forwards).
+ *   3. an ungranted capability => 403.
+ *   4. a require-approval capability => 202 + queued (invocation decision=approval).
+ *   5. maxCallsPerHour=1 => the second invoke is denied.
+ *
+ * the invoke route builds its own StewardProxyClient using globalThis.fetch; we
+ * override globalThis.fetch for the test to dispatch the proxy URL into the
+ * in-process proxy Hono app (so the ENTIRE shipping client + proxy codepath runs,
+ * only the network is stubbed).
+ */
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, setDefaultTimeout } from "bun:test";
+import { agents, closeDb, eq, getDb, tenants } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import type { AppVariables, PolicyRule } from "@stwd/shared";
+import { SecretVault } from "@stwd/vault";
+import { Hono } from "hono";
+import { fileURLToPath } from "node:url";
+import { runPluginMigrations } from "@stwd/db";
+import { migrate as pgliteMigrate } from "drizzle-orm/pglite/migrator";
+import { createInvokeRoutes } from "../invoke";
+import { capabilityInvocations } from "../schema";
+import { CapabilityStore } from "../store";
+import type { StewardAppContext } from "../context";
+
+setDefaultTimeout(30000);
+
+const MASTER_PASSWORD = "cap-invoke-e2e-master-password";
+const SIGNING_SECRET = "cap-invoke-e2e-signing-secret-with-enough-bytes";
+const FAKE_PAT = "ghp_test_e2e_do_not_use_0123456789abcdef";
+const PROXY_URL = "https://proxy.cap-e2e.test";
+const MIGRATIONS_FOLDER = fileURLToPath(new URL("../../drizzle", import.meta.url));
+
+let authMiddleware: typeof import("@stwd/proxy/src/middleware/auth")["authMiddleware"];
+let handleProxy: typeof import("@stwd/proxy/src/handlers/proxy")["handleProxy"];
+let setForwardProxyRequestForTests: typeof import("@stwd/proxy/src/handlers/proxy")["__setForwardProxyRequestForTests"];
+let setResolveProxyHostForTests: typeof import("@stwd/proxy/src/handlers/proxy")["__setResolveProxyHostForTests"];
+
+interface ForwardedCapture {
+  url: string;
+  method: string;
+  headers: Headers;
+}
+let lastForwarded: ForwardedCapture | null = null;
+let proxyApp: Hono | null = null;
+const realFetch = globalThis.fetch;
+
+// the policy set the injected getPolicySet returns for the current test.
+let currentPolicySet: PolicyRule[] = [];
+
+function capRule(
+  id: string,
+  effect: "allow" | "deny" | "require-approval",
+  constraints?: Record<string, unknown>,
+): PolicyRule {
+  return {
+    id,
+    type: "capability-intent" as unknown as PolicyRule["type"],
+    enabled: true,
+    config: { capabilities: ["github.pr.comment"], effect, ...(constraints ? { constraints } : {}) },
+  };
+}
+
+beforeAll(async () => {
+  process.env.STEWARD_PGLITE_MEMORY = "true";
+  process.env.STEWARD_MASTER_PASSWORD = MASTER_PASSWORD;
+  process.env.STEWARD_JWT_SECRET = "cap-invoke-e2e-jwt-secret-with-enough-bytes-0123456789";
+  process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE = "true";
+  process.env.STEWARD_PROXY_REQUEST_SIGNING_SECRET = SIGNING_SECRET;
+  process.env.STEWARD_PROXY_ALLOWED_HOSTS = "api.github.com";
+  // the invoke route reads these to build its proxy client (fail-closed if absent).
+  process.env.STEWARD_PROXY_URL = PROXY_URL;
+
+  const { db, client } = await createPGLiteDb("memory://");
+  setPGLiteOverride(db, async () => {
+    await client.close();
+  });
+  // apply the plugin's own migrations (capabilities + grants + invocations).
+  await runPluginMigrations(
+    { id: "capabilities", migrationsFolder: MIGRATIONS_FOLDER },
+    { db, client, useAdvisoryLock: false, migrateFn: pgliteMigrate as never },
+  );
+
+  ({ authMiddleware } = await import("@stwd/proxy/src/middleware/auth"));
+  ({
+    handleProxy,
+    __setForwardProxyRequestForTests: setForwardProxyRequestForTests,
+    __setResolveProxyHostForTests: setResolveProxyHostForTests,
+  } = await import("@stwd/proxy/src/handlers/proxy"));
+
+  // deterministic public ip so route-match -> decrypt -> inject -> forward runs
+  // with no external network (mirrors the #149 e2e).
+  setResolveProxyHostForTests(async () => [{ address: "93.184.216.34", family: 4 }]);
+  setForwardProxyRequestForTests(async (url, method, headers) => {
+    lastForwarded = { url: url.toString(), method, headers };
+    return new Response(JSON.stringify({ id: 12345, body: "ok" }), {
+      status: 201,
+      headers: { "content-type": "application/json" },
+    });
+  });
+
+  // real proxy app, in-process.
+  proxyApp = new Hono();
+  proxyApp.use("*", authMiddleware);
+  proxyApp.all("*", handleProxy);
+
+  // override globalThis.fetch: route the proxy URL into the in-process proxy app;
+  // everything else uses the real fetch.
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    if (url.startsWith(PROXY_URL) && proxyApp) {
+      const path = url.slice(PROXY_URL.length) || "/";
+      return proxyApp.request(path, init as RequestInit);
+    }
+    return realFetch(input as RequestInfo, init);
+  }) as typeof fetch;
+});
+
+afterAll(async () => {
+  globalThis.fetch = realFetch;
+  await closeDb().catch(() => {});
+  delete process.env.STEWARD_PGLITE_MEMORY;
+  delete process.env.STEWARD_MASTER_PASSWORD;
+  delete process.env.STEWARD_JWT_SECRET;
+  delete process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE;
+  delete process.env.STEWARD_PROXY_REQUEST_SIGNING_SECRET;
+  delete process.env.STEWARD_PROXY_ALLOWED_HOSTS;
+  delete process.env.STEWARD_PROXY_URL;
+});
+
+let tenantId: string;
+let agentId: string;
+
+async function seedTenantAgent(): Promise<void> {
+  tenantId = `tenant-cap-e2e-${crypto.randomUUID()}`;
+  agentId = `agent-cap-e2e-${crypto.randomUUID()}`;
+  await getDb().insert(tenants).values({ id: tenantId, name: tenantId, apiKeyHash: `hash-${tenantId}` });
+  await getDb()
+    .insert(agents)
+    .values({ id: agentId, tenantId, name: agentId, walletAddress: `0x${"2".repeat(40)}` });
+}
+
+/** create the secret (real, encrypts the PAT), the capability, and the grant. */
+async function seedCapability(): Promise<string> {
+  const vault = new SecretVault(MASTER_PASSWORD);
+  const secret = await vault.createSecret(tenantId, "gh-pat", FAKE_PAT);
+  const store = new CapabilityStore(getDb());
+  const cap = await store.createCapability({
+    tenantId,
+    name: "github.pr.comment",
+    spec: {
+      secretId: secret.id,
+      host: "api.github.com",
+      pathPattern: "/repos/acme/app/issues/1/comments",
+      method: "POST",
+      injectAs: "header",
+      injectKey: "authorization",
+      injectFormat: "Bearer {value}",
+    },
+    constraints: {},
+    enabled: true,
+  });
+  await store.createGrant({ tenantId, capabilityId: cap.id, agentId, expiresAt: null });
+  return cap.id;
+}
+
+function buildCtx(): StewardAppContext {
+  return {
+    db: getDb(),
+    vault: {} as never,
+    policyEngine: {} as never,
+    priceOracle: {} as never,
+    async ensureAgentForTenant() {
+      return undefined;
+    },
+    async getPolicySet() {
+      return currentPolicySet;
+    },
+    async safeJsonParse<T>(c: { req: { json(): Promise<unknown> } }): Promise<T | null> {
+      try {
+        return (await c.req.json()) as T;
+      } catch {
+        return null;
+      }
+    },
+    isValidAnyAddress() {
+      return false;
+    },
+    async writeAuditEvent() {},
+    async getAgentTokenStatus() {
+      return null;
+    },
+    getRedisClient() {
+      return null;
+    },
+    async requireAgentJwt() {},
+    async operatorAuth() {},
+    async tenantAuth() {},
+  } as unknown as StewardAppContext;
+}
+
+/** the invoke app (test mw stamps the agent-token context). */
+function buildInvokeApp(): Hono<{ Variables: AppVariables }> {
+  const app = new Hono<{ Variables: AppVariables }>();
+  app.use("*", async (c, next) => {
+    c.set("tenantId", tenantId);
+    c.set("agentScope", agentId);
+    c.set("authType", "agent-token" as never);
+    await next();
+  });
+  app.route("/capabilities", createInvokeRoutes(buildCtx()));
+  return app;
+}
+
+async function agentInvocations(capabilityId: string) {
+  const rows = await getDb()
+    .select()
+    .from(capabilityInvocations)
+    .where(eq(capabilityInvocations.agentId, agentId));
+  return rows.filter((r: { capabilityId: string | null }) => r.capabilityId === capabilityId);
+}
+
+beforeEach(async () => {
+  await seedTenantAgent();
+  currentPolicySet = [];
+  lastForwarded = null;
+});
+
+describe("invoke e2e: full arc through the real proxy", () => {
+  it("allowed invoke forwards with the PAT injected, never visible to the agent, records allow", async () => {
+    const capId = await seedCapability();
+    currentPolicySet = [capRule("r1", "allow", { argEquals: { repo: "acme/app" } })];
+    const app = buildInvokeApp();
+
+    const res = await app.request("/capabilities/github.pr.comment/invoke", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ args: { repo: "acme/app" }, body: { body: "LGTM" } }),
+    });
+
+    // upstream 201 passed through.
+    expect(res.status).toBe(201);
+    const passthrough = await res.text();
+    // the passthrough body never contains the PAT.
+    expect(passthrough).not.toContain(FAKE_PAT);
+
+    // the proxy forwarded to the real upstream URL with the PAT injected.
+    expect(lastForwarded).not.toBeNull();
+    expect(lastForwarded?.url).toBe("https://api.github.com/repos/acme/app/issues/1/comments");
+    expect(lastForwarded?.headers.get("authorization")).toBe(`Bearer ${FAKE_PAT}`);
+
+    // the agent-facing request/response never carried the PAT.
+    const rows = await agentInvocations(capId);
+    expect(rows.length).toBe(1);
+    expect(rows[0].decision).toBe("allow");
+  });
+
+  it("wrong argEquals => 403, never forwards", async () => {
+    await seedCapability();
+    currentPolicySet = [capRule("r1", "allow", { argEquals: { repo: "acme/app" } })];
+    const app = buildInvokeApp();
+    const res = await app.request("/capabilities/github.pr.comment/invoke", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ args: { repo: "evil/app" }, body: { body: "x" } }),
+    });
+    expect(res.status).toBe(403);
+    expect(lastForwarded).toBeNull();
+  });
+
+  it("ungranted capability => 403", async () => {
+    // seed a capability but NO grant for this agent.
+    const vault = new SecretVault(MASTER_PASSWORD);
+    const secret = await vault.createSecret(tenantId, "gh-pat2", FAKE_PAT);
+    const store = new CapabilityStore(getDb());
+    await store.createCapability({
+      tenantId,
+      name: "github.pr.comment",
+      spec: {
+        secretId: secret.id,
+        host: "api.github.com",
+        pathPattern: "/repos/acme/app/issues/1/comments",
+        method: "POST",
+        injectAs: "header",
+        injectKey: "authorization",
+        injectFormat: "Bearer {value}",
+      },
+      constraints: {},
+      enabled: true,
+    });
+    currentPolicySet = [capRule("r1", "allow")];
+    const app = buildInvokeApp();
+    const res = await app.request("/capabilities/github.pr.comment/invoke", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(403);
+    expect(lastForwarded).toBeNull();
+  });
+
+  it("require-approval capability => 202 + queued", async () => {
+    const capId = await seedCapability();
+    currentPolicySet = [capRule("r1", "require-approval")];
+    const app = buildInvokeApp();
+    const res = await app.request("/capabilities/github.pr.comment/invoke", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(202);
+    const body = (await res.json()) as { ok: boolean; data: { approvalId: string; status: string } };
+    expect(body.data.status).toBe("pending");
+    const rows = await agentInvocations(capId);
+    expect(rows.length).toBe(1);
+    expect(rows[0].decision).toBe("approval");
+    expect(lastForwarded).toBeNull();
+  });
+
+  it("maxCallsPerHour=1 => second invoke denied", async () => {
+    const capId = await seedCapability();
+    currentPolicySet = [capRule("r1", "allow", { maxCallsPerHour: 1 })];
+    const app = buildInvokeApp();
+
+    const first = await app.request("/capabilities/github.pr.comment/invoke", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ body: { body: "one" } }),
+    });
+    // first invoke: count 0 < 1 => forwards (upstream 201).
+    expect(first.status).toBe(201);
+
+    const second = await app.request("/capabilities/github.pr.comment/invoke", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ body: { body: "two" } }),
+    });
+    // second invoke: count 1 >= 1 => rate constraint denies the allow => 403.
+    expect(second.status).toBe(403);
+
+    const rows = await agentInvocations(capId);
+    expect(rows.filter((r) => r.decision === "allow").length).toBe(1);
+    expect(rows.filter((r) => r.decision === "deny").length).toBe(1);
+  });
+});

--- a/packages/plugin-capabilities/src/__tests__/invoke-e2e.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/invoke-e2e.test.ts
@@ -23,19 +23,18 @@
  * only the network is stubbed).
  */
 
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, setDefaultTimeout } from "bun:test";
-import { agents, closeDb, eq, getDb, tenants } from "@stwd/db";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, setDefaultTimeout } from "bun:test";
+import { fileURLToPath } from "node:url";
+import { agents, closeDb, eq, getDb, runPluginMigrations, tenants } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import type { AppVariables, PolicyRule } from "@stwd/shared";
 import { SecretVault } from "@stwd/vault";
-import { Hono } from "hono";
-import { fileURLToPath } from "node:url";
-import { runPluginMigrations } from "@stwd/db";
 import { migrate as pgliteMigrate } from "drizzle-orm/pglite/migrator";
+import { Hono } from "hono";
+import type { StewardAppContext } from "../context";
 import { createInvokeRoutes } from "../invoke";
 import { capabilityInvocations } from "../schema";
 import { CapabilityStore } from "../store";
-import type { StewardAppContext } from "../context";
 
 setDefaultTimeout(30000);
 
@@ -71,7 +70,11 @@ function capRule(
     id,
     type: "capability-intent" as unknown as PolicyRule["type"],
     enabled: true,
-    config: { capabilities: ["github.pr.comment"], effect, ...(constraints ? { constraints } : {}) },
+    config: {
+      capabilities: ["github.pr.comment"],
+      effect,
+      ...(constraints ? { constraints } : {}),
+    },
   };
 }
 
@@ -121,7 +124,8 @@ beforeAll(async () => {
   // override globalThis.fetch: route the proxy URL into the in-process proxy app;
   // everything else uses the real fetch.
   globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
-    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    const url =
+      typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
     if (url.startsWith(PROXY_URL) && proxyApp) {
       const path = url.slice(PROXY_URL.length) || "/";
       return proxyApp.request(path, init as RequestInit);
@@ -148,7 +152,9 @@ let agentId: string;
 async function seedTenantAgent(): Promise<void> {
   tenantId = `tenant-cap-e2e-${crypto.randomUUID()}`;
   agentId = `agent-cap-e2e-${crypto.randomUUID()}`;
-  await getDb().insert(tenants).values({ id: tenantId, name: tenantId, apiKeyHash: `hash-${tenantId}` });
+  await getDb()
+    .insert(tenants)
+    .values({ id: tenantId, name: tenantId, apiKeyHash: `hash-${tenantId}` });
   await getDb()
     .insert(agents)
     .values({ id: agentId, tenantId, name: agentId, walletAddress: `0x${"2".repeat(40)}` });
@@ -323,7 +329,10 @@ describe("invoke e2e: full arc through the real proxy", () => {
       body: JSON.stringify({}),
     });
     expect(res.status).toBe(202);
-    const body = (await res.json()) as { ok: boolean; data: { approvalId: string; status: string } };
+    const body = (await res.json()) as {
+      ok: boolean;
+      data: { approvalId: string; status: string };
+    };
     expect(body.data.status).toBe("pending");
     const rows = await agentInvocations(capId);
     expect(rows.length).toBe(1);

--- a/packages/plugin-capabilities/src/__tests__/invoke.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/invoke.test.ts
@@ -247,6 +247,18 @@ describe("invoke: default-deny + effects", () => {
     expect(rows[0].decision).toBe("deny");
   });
 
+  test("a DISABLED allow rule does NOT authorize => 403 (revoke-by-disable is honored)", async () => {
+    const capId = await seedCapabilityWithGrant();
+    // an allow rule that WOULD authorize, but disabled. the engine skips it and
+    // the authoritative loop must too (fail-closed): access is revoked.
+    currentPolicySet = [{ ...capRule("r1", "allow"), enabled: false }];
+    const app = buildApp(harness!.db, { agent: true });
+    const res = await app.request("/capabilities/github.pr.comment/invoke", invokeReq({}));
+    expect(res.status).toBe(403);
+    const rows = await invocationRows(capId);
+    expect(rows[0].decision).toBe("deny");
+  });
+
   test("a rule that governs a DIFFERENT capability does not authorize => 403", async () => {
     await seedCapabilityWithGrant();
     currentPolicySet = [capRule("r1", "allow", undefined, ["github.other.thing"])];
@@ -296,6 +308,41 @@ describe("invoke: default-deny + effects", () => {
     const rows = await invocationRows(capId);
     expect(rows.length).toBe(1);
     expect(rows[0].decision).toBe("error");
+  });
+});
+
+describe("invoke: body parsing", () => {
+  test("malformed JSON body => 400 (not silently coerced to {})", async () => {
+    await seedCapabilityWithGrant();
+    currentPolicySet = [capRule("r1", "allow")];
+    const app = buildApp(harness!.db, { agent: true });
+    const res = await app.request("/capabilities/github.pr.comment/invoke", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{ not valid json",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test("empty body is allowed (no args) => authorized, proxy-env-absent 503", async () => {
+    await seedCapabilityWithGrant();
+    currentPolicySet = [capRule("r1", "allow")];
+    const app = buildApp(harness!.db, { agent: true });
+    // no body at all.
+    const res = await app.request("/capabilities/github.pr.comment/invoke", { method: "POST" });
+    expect(res.status).toBe(503);
+  });
+
+  test("a JSON array body => 400 (must be an object)", async () => {
+    await seedCapabilityWithGrant();
+    currentPolicySet = [capRule("r1", "allow")];
+    const app = buildApp(harness!.db, { agent: true });
+    const res = await app.request("/capabilities/github.pr.comment/invoke", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "[1,2,3]",
+    });
+    expect(res.status).toBe(400);
   });
 });
 

--- a/packages/plugin-capabilities/src/__tests__/invoke.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/invoke.test.ts
@@ -1,0 +1,341 @@
+/**
+ * invoke.test.ts - unit coverage for the agent-facing invoke route's DECISION
+ * layer (the default-deny + effect resolution + audit/rate machinery), isolated
+ * from the proxy forward (which the e2e proves end-to-end with a real proxy).
+ *
+ * mounts createInvokeRoutes onto a bare hono app with a test middleware that
+ * stamps the agent-token context (tenantId + agentScope, as requireAgentJwt
+ * would) and an injected context whose db is a real PGLite carrying the core +
+ * plugin schema, whose getPolicySet returns a per-test policy set, and whose
+ * safeJsonParse mirrors the core. proves:
+ *   - default-deny: no governing capability-intent rule => 403.
+ *   - matched allow (passes) but proxy env absent => 503 (the decision AUTHORIZED
+ *     the forward; the forward failed closed on missing proxy config) - this is
+ *     how we assert "matched-allow proceeded" without a live proxy.
+ *   - matched deny => 403.
+ *   - matched require-approval => 202 + an invocation row with decision=approval.
+ *   - wrong argEquals on an allow rule => 403 (constraint fail).
+ *   - maxCallsPerHour=1 => the SECOND invoke is denied (count computed from the
+ *     invocations table).
+ *   - agent auth required (no agentScope => 401).
+ *   - ungranted / expired / revoked / disabled capability => 403 (no-usable-grant).
+ *   - every attempt records exactly one invocation row with its decision.
+ */
+
+import { afterEach, beforeEach, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { and, eq } from "@stwd/db";
+import type { AppVariables, PolicyRule } from "@stwd/shared";
+import { Hono } from "hono";
+import type { StewardAppContext } from "../context";
+import { createInvokeRoutes } from "../invoke";
+import { capabilityInvocations } from "../schema";
+import { CapabilityStore } from "../store";
+import {
+  ensureAgent,
+  ensureSecret,
+  ensureTenant,
+  type Harness,
+  makeHarness,
+} from "./_harness";
+
+setDefaultTimeout(30000);
+
+let harness: Harness | null = null;
+let tenantId: string;
+let agentId: string;
+let secretId: string;
+
+// the policy set the injected getPolicySet returns for the current test.
+let currentPolicySet: PolicyRule[] = [];
+
+/** a capability-intent rule of the given effect governing `github.pr.comment`. */
+function capRule(
+  id: string,
+  effect: "allow" | "deny" | "require-approval",
+  constraints?: Record<string, unknown>,
+  capabilities: string[] = ["github.pr.comment"],
+): PolicyRule {
+  return {
+    id,
+    // capability-intent is a contributed type (not in the core union); the DB
+    // stores it as a string. cast for the test fixture.
+    type: "capability-intent" as unknown as PolicyRule["type"],
+    enabled: true,
+    config: { capabilities, effect, ...(constraints ? { constraints } : {}) },
+  };
+}
+
+function buildCtx(db: unknown): StewardAppContext {
+  return {
+    db,
+    vault: {} as never,
+    policyEngine: {} as never,
+    priceOracle: {} as never,
+    async ensureAgentForTenant() {
+      return undefined;
+    },
+    async getPolicySet() {
+      return currentPolicySet;
+    },
+    async safeJsonParse<T>(c: { req: { json(): Promise<unknown> } }): Promise<T | null> {
+      try {
+        return (await c.req.json()) as T;
+      } catch {
+        return null;
+      }
+    },
+    isValidAnyAddress() {
+      return false;
+    },
+    async writeAuditEvent() {},
+    async getAgentTokenStatus() {
+      return null;
+    },
+    getRedisClient() {
+      return null;
+    },
+    async requireAgentJwt() {},
+    async operatorAuth() {},
+    async tenantAuth() {},
+  } as unknown as StewardAppContext;
+}
+
+interface AuthOpts {
+  agent?: boolean;
+}
+
+/** mount the invoke router behind a test mw that stamps the agent-token context. */
+function buildApp(db: unknown, auth: AuthOpts): Hono<{ Variables: AppVariables }> {
+  const app = new Hono<{ Variables: AppVariables }>();
+  app.use("*", async (c, next) => {
+    if (auth.agent) {
+      c.set("tenantId", tenantId);
+      c.set("agentScope", agentId);
+      c.set("authType", "agent-token" as never);
+    }
+    await next();
+  });
+  app.route("/capabilities", createInvokeRoutes(buildCtx(db)));
+  return app;
+}
+
+/** create an enabled capability + an active grant for the agent. returns cap id. */
+async function seedCapabilityWithGrant(opts?: {
+  enabled?: boolean;
+  expiresAt?: Date | null;
+  revoke?: boolean;
+}): Promise<string> {
+  const db = harness!.db;
+  const store = new CapabilityStore(db);
+  const cap = await store.createCapability({
+    tenantId,
+    name: "github.pr.comment",
+    spec: {
+      secretId,
+      host: "api.github.com",
+      pathPattern: "/repos/acme/app/issues/1/comments",
+      method: "POST",
+      injectAs: "header",
+      injectKey: "authorization",
+      injectFormat: "Bearer {value}",
+    },
+    constraints: {},
+    enabled: opts?.enabled ?? true,
+  });
+  const result = await store.createGrant({
+    tenantId,
+    capabilityId: cap.id,
+    agentId,
+    expiresAt: opts?.expiresAt ?? null,
+  });
+  if (opts?.revoke && result) {
+    await store.revokeGrant(tenantId, result.grant.id);
+  }
+  return cap.id;
+}
+
+async function invocationRows(capabilityId: string | null) {
+  const db = harness!.db;
+  const rows = await db.select().from(capabilityInvocations).where(eq(capabilityInvocations.agentId, agentId));
+  return capabilityId === null ? rows : rows.filter((r: { capabilityId: string | null }) => r.capabilityId === capabilityId);
+}
+
+function invokeReq(body?: unknown) {
+  return {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  };
+}
+
+beforeEach(async () => {
+  harness = await makeHarness();
+  tenantId = `tenant-inv-${crypto.randomUUID()}`;
+  agentId = `agent-inv-${crypto.randomUUID()}`;
+  await ensureTenant(harness.db, tenantId);
+  await ensureAgent(harness.db, tenantId, agentId);
+  secretId = await ensureSecret(harness.db, tenantId, "gh-pat");
+  currentPolicySet = [];
+  // ensure the proxy env is ABSENT by default (so allow => 503 unless a test opts in).
+  delete process.env.STEWARD_PROXY_URL;
+  delete process.env.STEWARD_PROXY_REQUEST_SIGNING_SECRET;
+  delete process.env.STEWARD_PROXY_REQUEST_SIGNING_SECRETS;
+});
+
+afterEach(async () => {
+  await harness?.close();
+  harness = null;
+  delete process.env.STEWARD_PROXY_URL;
+  delete process.env.STEWARD_PROXY_REQUEST_SIGNING_SECRET;
+  delete process.env.STEWARD_PROXY_REQUEST_SIGNING_SECRETS;
+});
+
+describe("invoke: agent auth", () => {
+  test("no agent context => 401", async () => {
+    const app = buildApp(harness!.db, { agent: false });
+    const res = await app.request("/capabilities/github.pr.comment/invoke", invokeReq({}));
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("invoke: grant resolution (fail-closed)", () => {
+  test("unknown capability => 403, records a deny with null capability", async () => {
+    const app = buildApp(harness!.db, { agent: true });
+    const res = await app.request("/capabilities/does.not.exist/invoke", invokeReq({}));
+    expect(res.status).toBe(403);
+    const rows = await invocationRows(null);
+    expect(rows.length).toBe(1);
+    expect(rows[0].decision).toBe("deny");
+    expect(rows[0].capabilityId).toBeNull();
+  });
+
+  test("disabled capability => 403", async () => {
+    await seedCapabilityWithGrant({ enabled: false });
+    currentPolicySet = [capRule("r1", "allow")];
+    const app = buildApp(harness!.db, { agent: true });
+    const res = await app.request("/capabilities/github.pr.comment/invoke", invokeReq({}));
+    expect(res.status).toBe(403);
+  });
+
+  test("expired grant => 403", async () => {
+    await seedCapabilityWithGrant({ expiresAt: new Date(Date.now() - 60_000) });
+    currentPolicySet = [capRule("r1", "allow")];
+    const app = buildApp(harness!.db, { agent: true });
+    const res = await app.request("/capabilities/github.pr.comment/invoke", invokeReq({}));
+    expect(res.status).toBe(403);
+  });
+
+  test("revoked grant => 403", async () => {
+    await seedCapabilityWithGrant({ revoke: true });
+    currentPolicySet = [capRule("r1", "allow")];
+    const app = buildApp(harness!.db, { agent: true });
+    const res = await app.request("/capabilities/github.pr.comment/invoke", invokeReq({}));
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("invoke: default-deny + effects", () => {
+  test("no governing capability-intent rule => 403 (default-deny)", async () => {
+    const capId = await seedCapabilityWithGrant();
+    currentPolicySet = []; // engine passes vacuously; invoke layer denies.
+    const app = buildApp(harness!.db, { agent: true });
+    const res = await app.request("/capabilities/github.pr.comment/invoke", invokeReq({}));
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    const rows = await invocationRows(capId);
+    expect(rows.length).toBe(1);
+    expect(rows[0].decision).toBe("deny");
+  });
+
+  test("a rule that governs a DIFFERENT capability does not authorize => 403", async () => {
+    await seedCapabilityWithGrant();
+    currentPolicySet = [capRule("r1", "allow", undefined, ["github.other.thing"])];
+    const app = buildApp(harness!.db, { agent: true });
+    const res = await app.request("/capabilities/github.pr.comment/invoke", invokeReq({}));
+    expect(res.status).toBe(403);
+  });
+
+  test("matched deny => 403", async () => {
+    const capId = await seedCapabilityWithGrant();
+    currentPolicySet = [capRule("r1", "deny")];
+    const app = buildApp(harness!.db, { agent: true });
+    const res = await app.request("/capabilities/github.pr.comment/invoke", invokeReq({}));
+    expect(res.status).toBe(403);
+    const rows = await invocationRows(capId);
+    expect(rows[0].decision).toBe("deny");
+  });
+
+  test("matched require-approval => 202 + approvalId + invocation(decision=approval)", async () => {
+    const capId = await seedCapabilityWithGrant();
+    currentPolicySet = [capRule("r1", "require-approval")];
+    const app = buildApp(harness!.db, { agent: true });
+    const res = await app.request("/capabilities/github.pr.comment/invoke", invokeReq({}));
+    expect(res.status).toBe(202);
+    const body = (await res.json()) as { ok: boolean; data: { approvalId: string; status: string } };
+    expect(body.ok).toBe(true);
+    expect(body.data.status).toBe("pending");
+    expect(body.data.approvalId).toBeTruthy();
+    const rows = await invocationRows(capId);
+    expect(rows.length).toBe(1);
+    expect(rows[0].decision).toBe("approval");
+    expect(rows[0].id).toBe(body.data.approvalId);
+  });
+
+  test("matched allow that PASSES but proxy env absent => 503 (authorized, forward failed closed)", async () => {
+    const capId = await seedCapabilityWithGrant();
+    currentPolicySet = [capRule("r1", "allow")];
+    const app = buildApp(harness!.db, { agent: true });
+    const res = await app.request("/capabilities/github.pr.comment/invoke", invokeReq({ body: { x: 1 } }));
+    expect(res.status).toBe(503);
+    const rows = await invocationRows(capId);
+    expect(rows.length).toBe(1);
+    expect(rows[0].decision).toBe("error");
+  });
+});
+
+describe("invoke: allow-rule constraints", () => {
+  test("argEquals mismatch => 403", async () => {
+    await seedCapabilityWithGrant();
+    currentPolicySet = [capRule("r1", "allow", { argEquals: { repo: "acme/app" } })];
+    const app = buildApp(harness!.db, { agent: true });
+    const res = await app.request(
+      "/capabilities/github.pr.comment/invoke",
+      invokeReq({ args: { repo: "evil/app" } }),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  test("argEquals match but proxy env absent => 503 (constraint passed, authorized)", async () => {
+    await seedCapabilityWithGrant();
+    currentPolicySet = [capRule("r1", "allow", { argEquals: { repo: "acme/app" } })];
+    const app = buildApp(harness!.db, { agent: true });
+    const res = await app.request(
+      "/capabilities/github.pr.comment/invoke",
+      invokeReq({ args: { repo: "acme/app" } }),
+    );
+    expect(res.status).toBe(503);
+  });
+});
+
+describe("invoke: rate limit (count from invocations table)", () => {
+  test("maxCallsPerHour=1 => second invoke denied", async () => {
+    const capId = await seedCapabilityWithGrant();
+    currentPolicySet = [capRule("r1", "allow", { maxCallsPerHour: 1 })];
+    const app = buildApp(harness!.db, { agent: true });
+
+    // first invoke: count=0 < 1 => authorized, forward fails closed (503, records error).
+    const first = await app.request("/capabilities/github.pr.comment/invoke", invokeReq({ body: {} }));
+    expect(first.status).toBe(503);
+
+    // second invoke: count=1 (the recorded error attempt) >= 1 => the rate
+    // constraint denies the allow rule => default-deny => 403.
+    const second = await app.request("/capabilities/github.pr.comment/invoke", invokeReq({ body: {} }));
+    expect(second.status).toBe(403);
+
+    const rows = await invocationRows(capId);
+    expect(rows.length).toBe(2);
+    expect(rows.filter((r) => r.decision === "error").length).toBe(1);
+    expect(rows.filter((r) => r.decision === "deny").length).toBe(1);
+  });
+});

--- a/packages/plugin-capabilities/src/__tests__/invoke.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/invoke.test.ts
@@ -23,20 +23,14 @@
  */
 
 import { afterEach, beforeEach, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { and, eq } from "@stwd/db";
+import { eq } from "@stwd/db";
 import type { AppVariables, PolicyRule } from "@stwd/shared";
 import { Hono } from "hono";
 import type { StewardAppContext } from "../context";
 import { createInvokeRoutes } from "../invoke";
 import { capabilityInvocations } from "../schema";
 import { CapabilityStore } from "../store";
-import {
-  ensureAgent,
-  ensureSecret,
-  ensureTenant,
-  type Harness,
-  makeHarness,
-} from "./_harness";
+import { ensureAgent, ensureSecret, ensureTenant, type Harness, makeHarness } from "./_harness";
 
 setDefaultTimeout(30000);
 
@@ -156,8 +150,13 @@ async function seedCapabilityWithGrant(opts?: {
 
 async function invocationRows(capabilityId: string | null) {
   const db = harness!.db;
-  const rows = await db.select().from(capabilityInvocations).where(eq(capabilityInvocations.agentId, agentId));
-  return capabilityId === null ? rows : rows.filter((r: { capabilityId: string | null }) => r.capabilityId === capabilityId);
+  const rows = await db
+    .select()
+    .from(capabilityInvocations)
+    .where(eq(capabilityInvocations.agentId, agentId));
+  return capabilityId === null
+    ? rows
+    : rows.filter((r: { capabilityId: string | null }) => r.capabilityId === capabilityId);
 }
 
 function invokeReq(body?: unknown) {
@@ -272,7 +271,10 @@ describe("invoke: default-deny + effects", () => {
     const app = buildApp(harness!.db, { agent: true });
     const res = await app.request("/capabilities/github.pr.comment/invoke", invokeReq({}));
     expect(res.status).toBe(202);
-    const body = (await res.json()) as { ok: boolean; data: { approvalId: string; status: string } };
+    const body = (await res.json()) as {
+      ok: boolean;
+      data: { approvalId: string; status: string };
+    };
     expect(body.ok).toBe(true);
     expect(body.data.status).toBe("pending");
     expect(body.data.approvalId).toBeTruthy();
@@ -286,7 +288,10 @@ describe("invoke: default-deny + effects", () => {
     const capId = await seedCapabilityWithGrant();
     currentPolicySet = [capRule("r1", "allow")];
     const app = buildApp(harness!.db, { agent: true });
-    const res = await app.request("/capabilities/github.pr.comment/invoke", invokeReq({ body: { x: 1 } }));
+    const res = await app.request(
+      "/capabilities/github.pr.comment/invoke",
+      invokeReq({ body: { x: 1 } }),
+    );
     expect(res.status).toBe(503);
     const rows = await invocationRows(capId);
     expect(rows.length).toBe(1);
@@ -325,12 +330,18 @@ describe("invoke: rate limit (count from invocations table)", () => {
     const app = buildApp(harness!.db, { agent: true });
 
     // first invoke: count=0 < 1 => authorized, forward fails closed (503, records error).
-    const first = await app.request("/capabilities/github.pr.comment/invoke", invokeReq({ body: {} }));
+    const first = await app.request(
+      "/capabilities/github.pr.comment/invoke",
+      invokeReq({ body: {} }),
+    );
     expect(first.status).toBe(503);
 
     // second invoke: count=1 (the recorded error attempt) >= 1 => the rate
     // constraint denies the allow rule => default-deny => 403.
-    const second = await app.request("/capabilities/github.pr.comment/invoke", invokeReq({ body: {} }));
+    const second = await app.request(
+      "/capabilities/github.pr.comment/invoke",
+      invokeReq({ body: {} }),
+    );
     expect(second.status).toBe(403);
 
     const rows = await invocationRows(capId);

--- a/packages/plugin-capabilities/src/__tests__/migration-isolation.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/migration-isolation.test.ts
@@ -63,4 +63,45 @@ describe("capability plugin migrations: namespaced-journal isolation", () => {
     );
     expect(chk.rows[0].n).toBe(1);
   });
+
+  test("migration 0001 lands capability_invocations in the plugin's OWN ledger, core untouched", async () => {
+    harness = await makeHarness();
+    const { client } = harness;
+
+    // (a) the invocations table exists (migration 0001 applied).
+    const invTbl = await client.query(
+      "SELECT to_regclass('public.capability_invocations') AS t",
+    );
+    expect(invTbl.rows[0].t).toBe("capability_invocations");
+
+    // (b) BOTH plugin migrations (0000 + 0001) are recorded in the plugin's OWN
+    //     namespaced ledger (>=2 rows).
+    const pluginLedger = await client.query(
+      `SELECT count(*)::int AS n FROM drizzle."__drizzle_migrations_plugin_capabilities"`,
+    );
+    expect(pluginLedger.rows[0].n).toBeGreaterThanOrEqual(2);
+
+    // (c) the core journal carries NO capability-invocations migration row.
+    const coreLedger = await client.query(
+      "SELECT to_regclass('drizzle.__drizzle_migrations') AS t",
+    );
+    if (coreLedger.rows[0].t) {
+      const contaminated = await client.query(
+        `SELECT count(*)::int AS n FROM drizzle.__drizzle_migrations WHERE hash LIKE '%invocation%'`,
+      );
+      expect(contaminated.rows[0].n).toBe(0);
+    }
+
+    // (d) the decision CHECK constraint is present (allow/deny/approval/error).
+    const chk = await client.query(
+      `SELECT count(*)::int AS n FROM pg_constraint WHERE conname = 'capability_invocations_decision_check'`,
+    );
+    expect(chk.rows[0].n).toBe(1);
+
+    // (e) the rate-limit index is present (the count query's covering index).
+    const idx = await client.query(
+      `SELECT count(*)::int AS n FROM pg_indexes WHERE indexname = 'capability_invocations_rate_idx'`,
+    );
+    expect(idx.rows[0].n).toBe(1);
+  });
 });

--- a/packages/plugin-capabilities/src/__tests__/migration-isolation.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/migration-isolation.test.ts
@@ -69,9 +69,7 @@ describe("capability plugin migrations: namespaced-journal isolation", () => {
     const { client } = harness;
 
     // (a) the invocations table exists (migration 0001 applied).
-    const invTbl = await client.query(
-      "SELECT to_regclass('public.capability_invocations') AS t",
-    );
+    const invTbl = await client.query("SELECT to_regclass('public.capability_invocations') AS t");
     expect(invTbl.rows[0].t).toBe("capability_invocations");
 
     // (b) BOTH plugin migrations (0000 + 0001) are recorded in the plugin's OWN

--- a/packages/plugin-capabilities/src/index.ts
+++ b/packages/plugin-capabilities/src/index.ts
@@ -27,20 +27,26 @@
  */
 
 import { fileURLToPath } from "node:url";
+import { capabilityIntentContribution } from "@stwd/policy-engine";
 import type { AppVariables, StewardPlugin } from "@stwd/shared";
-import type { Hono } from "hono";
+import type { Context, Hono, Next } from "hono";
 import type { StewardAppContext } from "./context";
 import { createAgentCapabilityRoutes, createCapabilityRoutes } from "./routes";
+import { createInvokeRoutes } from "./invoke";
 
 export type { StewardAppContext } from "./context";
 export { createAgentCapabilityRoutes, createCapabilityRoutes } from "./routes";
 export type {
   Capability,
   CapabilityGrant,
+  CapabilityInvocation,
+  InvocationDecision,
   NewCapability,
   NewCapabilityGrant,
+  NewCapabilityInvocation,
 } from "./schema";
-export { capabilities, capabilityGrants } from "./schema";
+export { capabilities, capabilityGrants, capabilityInvocations } from "./schema";
+export { createInvokeRoutes } from "./invoke";
 export type { CapabilitySpec } from "./store";
 export { AgentNotFoundError, CapabilityStore, GrantExistsError, isExpired } from "./store";
 export {
@@ -71,7 +77,14 @@ const MIGRATIONS_FOLDER = fileURLToPath(new URL("../drizzle", import.meta.url));
  * (capability.invoked / .denied / .approval_queued) are declared by W-1c, the
  * package that emits them.
  */
-export const CAPABILITY_WEBHOOK_EVENTS = ["capability.created", "capability.revoked"] as const;
+export const CAPABILITY_WEBHOOK_EVENTS = [
+  "capability.created",
+  "capability.revoked",
+  // invoke-time events (W-1c). declared by THIS package because it emits them.
+  "capability.invoked",
+  "capability.denied",
+  "capability.approval_queued",
+] as const;
 
 /**
  * The capability plugin. `register(app, ctx)`:
@@ -95,22 +108,57 @@ export const capabilitiesPlugin: StewardApiPlugin = {
     migrationsFolder: MIGRATIONS_FOLDER,
   },
   register(app, ctx) {
-    const { tenantAuth } = ctx;
+    const { tenantAuth, requireAgentJwt } = ctx;
 
-    // ── tenant gate on the management + agent-scoped surfaces ─────────────────
+    // ── auth gates ────────────────────────────────────────────────────────────
+    // the agent-facing invoke path (`/capabilities/:name/invoke`) is agent-token-
+    // authed, NOT tenant-gated. it carries its OWN agent-jwt middleware. every
+    // OTHER `/capabilities/*` subpath is the operator CRUD/grant surface and stays
+    // behind the tenant gate. because a single broad `/capabilities/*` tenant gate
+    // would also match the invoke subpath (and reject an agent token), the tenant
+    // gate is applied via a wrapper that SKIPS the invoke subpath — the invoke
+    // route's own agent-jwt middleware is the only auth on that path. fail-closed:
+    // anything that is not exactly the invoke subpath falls through to tenantAuth.
+    app.use("/capabilities/:name/invoke", (c, next) => requireAgentJwt(c, next));
+    app.use("/v1/capabilities/:name/invoke", (c, next) => requireAgentJwt(c, next));
     app.use("/capabilities", (c, next) => tenantAuth(c, next));
-    app.use("/capabilities/*", (c, next) => tenantAuth(c, next));
+    app.use("/capabilities/*", (c, next) => tenantGateSkippingInvoke(c, next, tenantAuth));
     app.use("/v1/capabilities", (c, next) => tenantAuth(c, next));
-    app.use("/v1/capabilities/*", (c, next) => tenantAuth(c, next));
+    app.use("/v1/capabilities/*", (c, next) => tenantGateSkippingInvoke(c, next, tenantAuth));
     app.use("/agents/*", (c, next) => tenantAuth(c, next));
     app.use("/v1/agents/*", (c, next) => tenantAuth(c, next));
 
     // ── route mounts (unversioned + versioned) ────────────────────────────────
+    // invoke routes mount FIRST so `/capabilities/:name/invoke` is registered
+    // before the CRUD `/:id` matcher (hono resolves same-specificity routes in
+    // registration order; the invoke handler ends the chain for that path).
+    const invokeRoutes = createInvokeRoutes(ctx);
     const capabilityRoutes = createCapabilityRoutes(ctx);
     const agentRoutes = createAgentCapabilityRoutes(ctx);
+    app.route("/capabilities", invokeRoutes);
+    app.route("/v1/capabilities", invokeRoutes);
     app.route("/capabilities", capabilityRoutes);
     app.route("/v1/capabilities", capabilityRoutes);
     app.route("/agents", agentRoutes);
     app.route("/v1/agents", agentRoutes);
   },
 };
+
+/** the invoke subpath predicate: `/capabilities/<name>/invoke` (any single name segment). */
+const INVOKE_SUBPATH = /\/(?:v1\/)?capabilities\/[^/]+\/invoke\/?$/;
+
+/**
+ * Apply the operator tenant gate to a `/capabilities/*` request UNLESS it is the
+ * agent-facing invoke subpath (which is authed by its own agent-jwt middleware).
+ * Skipping the invoke subpath here prevents the broad operator gate from
+ * rejecting a valid agent token. Fail-closed: only the exact invoke subpath is
+ * exempted; every other path is gated.
+ */
+async function tenantGateSkippingInvoke(
+  c: Context<{ Variables: AppVariables }>,
+  next: Next,
+  tenantAuth: StewardAppContext["tenantAuth"],
+): Promise<void | Response> {
+  if (INVOKE_SUBPATH.test(c.req.path)) return next();
+  return tenantAuth(c, next);
+}

--- a/packages/plugin-capabilities/src/index.ts
+++ b/packages/plugin-capabilities/src/index.ts
@@ -31,10 +31,11 @@ import { capabilityIntentContribution } from "@stwd/policy-engine";
 import type { AppVariables, StewardPlugin } from "@stwd/shared";
 import type { Context, Hono, Next } from "hono";
 import type { StewardAppContext } from "./context";
-import { createAgentCapabilityRoutes, createCapabilityRoutes } from "./routes";
 import { createInvokeRoutes } from "./invoke";
+import { createAgentCapabilityRoutes, createCapabilityRoutes } from "./routes";
 
 export type { StewardAppContext } from "./context";
+export { createInvokeRoutes } from "./invoke";
 export { createAgentCapabilityRoutes, createCapabilityRoutes } from "./routes";
 export type {
   Capability,
@@ -46,7 +47,6 @@ export type {
   NewCapabilityInvocation,
 } from "./schema";
 export { capabilities, capabilityGrants, capabilityInvocations } from "./schema";
-export { createInvokeRoutes } from "./invoke";
 export type { CapabilitySpec } from "./store";
 export { AgentNotFoundError, CapabilityStore, GrantExistsError, isExpired } from "./store";
 export {
@@ -103,6 +103,15 @@ export const capabilitiesPlugin: StewardApiPlugin = {
   name: "capabilities",
   version: "0.1.0",
   webhookEvents: CAPABILITY_WEBHOOK_EVENTS,
+  // the `capability-intent` policy rule (W-1b, shipped in @stwd/policy-engine as a
+  // PolicyRuleContribution). the plugin host registers it into the policy-engine
+  // evaluator registry BEFORE any route runs, so the engine can evaluate a
+  // capability-intent rule (via the registry's default arm) instead of denying it
+  // as an unknown type. the invoke path (invoke.ts) still owns the effective
+  // default-deny; this contribution just makes the rule TYPE evaluable engine-wide.
+  // registration fails closed on a type collision (a core rule type or another
+  // plugin's) — see the plugin host.
+  policyRules: [capabilityIntentContribution],
   migrations: {
     id: "capabilities",
     migrationsFolder: MIGRATIONS_FOLDER,

--- a/packages/plugin-capabilities/src/invoke.ts
+++ b/packages/plugin-capabilities/src/invoke.ts
@@ -237,14 +237,37 @@ export function createInvokeRoutes(ctx: StewardAppContext): Hono<{ Variables: Ap
     }
     const name = c.req.param("name");
 
-    // parse the optional body envelope. an invalid JSON body is a 400.
-    const parsed = await ctx.safeJsonParse<{
+    // parse the optional body envelope. an EMPTY body is allowed (no args); a
+    // PRESENT-but-invalid JSON body is a 400 (do not silently coerce malformed
+    // client input to `{}` and then authorize/forward it). we distinguish the two
+    // by reading the raw body: empty/whitespace => no envelope; non-empty =>
+    // JSON.parse (a parse failure => 400).
+    type InvokeEnvelope = {
       args?: Record<string, unknown>;
       body?: unknown;
       query?: Record<string, string>;
-    }>(c);
-    // an empty body is allowed (no args). a present-but-invalid JSON body => 400.
-    const envelope = parsed ?? {};
+    };
+    let envelope: InvokeEnvelope = {};
+    let rawBody: string;
+    try {
+      rawBody = await c.req.text();
+    } catch {
+      rawBody = "";
+    }
+    if (rawBody.trim() !== "") {
+      try {
+        const parsedBody = JSON.parse(rawBody);
+        if (parsedBody === null || typeof parsedBody !== "object" || Array.isArray(parsedBody)) {
+          return c.json<ApiResponse>(
+            { ok: false, error: "invoke body must be a JSON object" },
+            400,
+          );
+        }
+        envelope = parsedBody as InvokeEnvelope;
+      } catch {
+        return c.json<ApiResponse>({ ok: false, error: "invalid JSON in request body" }, 400);
+      }
+    }
     const invokeArgs =
       envelope.args && typeof envelope.args === "object" && !Array.isArray(envelope.args)
         ? (envelope.args as Record<string, unknown>)
@@ -311,8 +334,13 @@ export function createInvokeRoutes(ctx: StewardAppContext): Hono<{ Variables: Ap
         payload: { ok: false, error: "policy evaluation unavailable" } satisfies ApiResponse,
       });
     }
-    // only the capability-intent rules govern a capability invoke.
-    const capRules = policySet.filter((r) => isCapabilityIntentRule(r));
+    // only the ENABLED capability-intent rules govern a capability invoke. an
+    // operator who disables an allow rule (enabled:false) to revoke access must
+    // NOT have it still authorize — the engine skips disabled rules, and the
+    // authoritative per-rule loop below reuses THIS filtered set, so a disabled
+    // allow/deny/require-approval rule has no effect (fail-closed on the allow
+    // side: a disabled allow no longer sets matchedAllowPassed).
+    const capRules = policySet.filter((r) => isCapabilityIntentRule(r) && r.enabled !== false);
 
     // d. evaluate through the engine's existing entry point.
     // e. DEFAULT-DENY + effect resolution.

--- a/packages/plugin-capabilities/src/invoke.ts
+++ b/packages/plugin-capabilities/src/invoke.ts
@@ -315,19 +315,19 @@ export function createInvokeRoutes(ctx: StewardAppContext): Hono<{ Variables: Ap
     const capRules = policySet.filter((r) => isCapabilityIntentRule(r));
 
     // d. evaluate through the engine's existing entry point.
-    const evaluation = await engine.evaluate(capRules, {
-      request: syntheticSignRequest(tenantId, agentId),
-      recentTxCount1h: 0,
-      recentTxCount24h: 0,
-      spentToday: 0n,
-      spentThisWeek: 0n,
-      capability: capabilityCtx,
-      capabilityInvokeCount1h: count1h,
-    });
-
-    // e. DEFAULT-DENY + effect resolution. build the per-rule evaluator context
-    //    once (identical to what the engine used) so matched-allow detection and
-    //    matched-deny/approval detection use the AUTHORITATIVE evaluator.
+    // e. DEFAULT-DENY + effect resolution.
+    //
+    // build the per-rule evaluator context (identical for the engine pass and the
+    // authoritative per-rule loop). we run BOTH:
+    //   - engine.evaluate over the capability-intent rules: the EXISTING entry
+    //     point (all-must-pass composition), so any global engine hooks/audit fire
+    //     exactly as they do for tx signing. it is a consistency/audit pass.
+    //   - the AUTHORITATIVE per-rule loop below: the invoke layer OWNS default-deny
+    //     (the contract) — engine-approved alone is not enough, and the engine's
+    //     dispatch of a contributed rule depends on the plugin having registered
+    //     the evaluator into the registry (true at the compose root; the direct
+    //     loop makes the decision robust regardless of registry state). the loop
+    //     computes matched-allow/deny/approval directly via evaluateCapabilityIntent.
     const evaluatorCtx: EvaluatorContext = {
       request: syntheticSignRequest(tenantId, agentId),
       recentTxCount1h: 0,
@@ -337,6 +337,17 @@ export function createInvokeRoutes(ctx: StewardAppContext): Hono<{ Variables: Ap
       capability: capabilityCtx,
       capabilityInvokeCount1h: count1h,
     };
+    // consistency/audit pass through the existing entry point (result inspected
+    // for parity, but the AUTHORITATIVE decision is the per-rule loop below).
+    await engine.evaluate(capRules, {
+      request: evaluatorCtx.request,
+      recentTxCount1h: 0,
+      recentTxCount24h: 0,
+      spentToday: 0n,
+      spentThisWeek: 0n,
+      capability: capabilityCtx,
+      capabilityInvokeCount1h: count1h,
+    });
 
     const governing = capRules.filter((r) => isGoverningRule(r, cap.name));
     if (governing.length === 0) {
@@ -354,9 +365,14 @@ export function createInvokeRoutes(ctx: StewardAppContext): Hono<{ Variables: Ap
       });
     }
 
-    // evaluate each governing rule with the authoritative evaluator.
+    // evaluate each governing rule with the authoritative evaluator. all-must-pass:
+    // a matched deny OR a matched allow that failed a constraint is a hard deny
+    // (takes precedence over any other rule). a require-approval routes to 202
+    // only when nothing hard-denied. authorization requires >=1 allow rule that
+    // matched AND passed, with no hard deny.
     let sawApproval = false;
     let matchedAllowPassed = false;
+    let sawDeny = false;
     let denyReason: string | undefined;
     for (const rule of governing) {
       const result = evaluateCapabilityIntent(
@@ -368,22 +384,21 @@ export function createInvokeRoutes(ctx: StewardAppContext): Hono<{ Variables: Ap
         continue;
       }
       if (!result.passed) {
-        // a matched deny, OR a matched allow that failed its constraints.
+        // a matched deny, OR a matched allow that failed its constraints => hard deny.
+        sawDeny = true;
         denyReason = result.reason ?? "denied by policy";
         continue;
       }
-      // passed. only an ALLOW-effect rule authorizes (a passing rule that is not
-      // an allow rule cannot happen for a governing rule: deny/require-approval
-      // never pass. but re-check the effect defensively).
+      // passed. only an ALLOW-effect rule authorizes (deny/require-approval never
+      // pass; re-check the effect defensively).
       if (isMatchingAllowRule(rule, cap.name)) matchedAllowPassed = true;
     }
 
-    // precedence: a matched-allow that passed AND the engine overall did not
-    // hard-reject authorizes. a require-approval (with no passing allow) => 202.
-    // anything else => deny.
-    if (matchedAllowPassed && evaluation.approved) {
+    // precedence (all-must-pass): ANY hard deny wins. else a require-approval => 202.
+    // else a matched-allow that passed => authorize. else default-deny.
+    if (!sawDeny && matchedAllowPassed) {
       // proceed to forward (below).
-    } else if (sawApproval && !matchedAllowPassed) {
+    } else if (!sawDeny && sawApproval) {
       // f-approval: enqueue via the plugin's own invocation record (the core
       // approval_queue is tx-shaped and cannot hold a capability invoke). the
       // 202 returns the invocation id as the approvalId. an enqueue (record)

--- a/packages/plugin-capabilities/src/invoke.ts
+++ b/packages/plugin-capabilities/src/invoke.ts
@@ -50,8 +50,8 @@ import { signAgentToken } from "@stwd/auth";
 import {
   CAPABILITY_INTENT_RULE_TYPE,
   type CapabilityIntentConfig,
-  evaluateCapabilityIntent,
   type EvaluatorContext,
+  evaluateCapabilityIntent,
   PolicyEngine,
 } from "@stwd/policy-engine";
 import { StewardProxyClient } from "@stwd/proxy-client";

--- a/packages/plugin-capabilities/src/invoke.ts
+++ b/packages/plugin-capabilities/src/invoke.ts
@@ -1,0 +1,515 @@
+/**
+ * invoke.ts - the AGENT-FACING capability invoke path (W-1c).
+ *
+ * POST /capabilities/:name/invoke  { args?, body?, query? }
+ *
+ * this is the one route in the plugin that an AGENT (not an operator) calls. it
+ * turns "agent X wants to invoke capability Y with these args" into a policy
+ * decision and, when allowed, a delegated call THROUGH THE PROXY (never an
+ * in-process credential touch). the agent identity is taken from the agent token
+ * (c.get("agentScope")), NEVER from the request body.
+ *
+ * THE ARC (fail-closed at every seam)
+ * -----------------------------------
+ *  a. auth: agent-jwt (installed by the plugin's register on this subpath). the
+ *     acting agent + tenant come from the verified token context.
+ *  b. resolve the capability by (tenant, name) + enabled, and the ACTIVE,
+ *     unexpired GRANT for THIS agent via the fail-closed usable-by-agent surface.
+ *     any miss => 404/403, recorded as a denied invocation.
+ *  c. compute the trailing-hour invoke count for (agent, capability) from the
+ *     invocations table => ctx.capabilityInvokeCount1h.
+ *  d. build the policy context with ctx.capability = {name, args, host, path,
+ *     method} + the count, and evaluate the tenant's `capability-intent` rules
+ *     through the engine's EXISTING entry point (PolicyEngine.evaluate). only the
+ *     capability-intent rules are fed to the engine here: tx-shaped rules
+ *     (spending-limit, approved-addresses, ...) govern tx SIGNS, not capability
+ *     invokes, and would produce meaningless verdicts against a synthetic tx.
+ *     the capability-intent rule is the rule that governs a capability invoke.
+ *  e. DEFAULT-DENY: engine-approved is NOT sufficient (a capability-intent rule
+ *     PASSES for any capability it does not govern). the invoke layer INDEPENDENTLY
+ *     requires >=1 capability-intent rule that GOVERNS this capability name with
+ *     effect "allow" AND whose per-rule evaluation PASSED. a matched deny or a
+ *     matched require-approval short-circuits first (deny => 403; approval => 202).
+ *     no matched allow rule => deny.
+ *  f. ALLOW => forward THROUGH THE PROXY via @stwd/proxy-client. the target is the
+ *     capability's (host, path, method); the agent's api:proxy token is minted
+ *     server-side (shared STEWARD_JWT_SECRET, the same token the proxy verifies) +
+ *     HMAC-signed. the proxy matches the paired secret_route (agentId = this agent,
+ *     materialized by the grant), decrypts + injects the credential, and scrubs it
+ *     from the response. the plugin NEVER decrypts. proxy env absent => 503.
+ *  g. return the upstream status/body passthrough. emit capability.invoked /
+ *     .denied / .approval_queued (declared by this package's webhookEvents).
+ *
+ * every terminal outcome records ONE capability_invocations row with its decision
+ * (allow/deny/approval/error) BEFORE the response — the durable audit trail + the
+ * rate-limit source. money-rail-adjacent: on ANY ambiguity (no proxy env, count
+ * query error, enqueue error) we DENY (or 503) and audit.
+ */
+
+import { signAgentToken } from "@stwd/auth";
+import {
+  CAPABILITY_INTENT_RULE_TYPE,
+  type CapabilityIntentConfig,
+  evaluateCapabilityIntent,
+  type EvaluatorContext,
+  PolicyEngine,
+} from "@stwd/policy-engine";
+import { StewardProxyClient } from "@stwd/proxy-client";
+import type { ApiResponse, AppVariables, PolicyRule, SignRequest } from "@stwd/shared";
+import type { Context } from "hono";
+import { Hono } from "hono";
+import type { StewardAppContext } from "./context";
+import type { Capability, InvocationDecision } from "./schema";
+import { CapabilityStore } from "./store";
+
+/** the proxy scope an invoke-minted agent token must carry. mirrors @stwd/proxy config. */
+const PROXY_SCOPE = "api:proxy";
+/** short-lived: the token only needs to survive the single proxied call. */
+const PROXY_TOKEN_TTL = "2m";
+
+/**
+ * The proxy delegation configuration read from the environment. FAIL-CLOSED: any
+ * missing value => the invoke path returns 503 (never an in-process credential
+ * touch). Documented in the deploy runbook.
+ */
+interface ProxyEnv {
+  proxyUrl: string;
+  signingSecret: string;
+}
+
+/**
+ * Read + validate the proxy env. Returns null when any required var is missing/
+ * empty (=> the caller 503s). We require BOTH the proxy URL and a request-signing
+ * secret: the proxy runs with request signing enabled in production, so an invoke
+ * without a signing secret would be rejected by the proxy anyway — failing closed
+ * here (503, no forward) is clearer than forwarding a request the proxy will 401.
+ */
+function readProxyEnv(env: NodeJS.ProcessEnv = process.env): ProxyEnv | null {
+  const proxyUrl = (env.STEWARD_PROXY_URL ?? "").trim();
+  // accept either the dedicated invoke signing secret or the proxy's own
+  // configured signing secret (single-secret deploys set only the latter).
+  const signingSecret = (
+    env.STEWARD_PROXY_REQUEST_SIGNING_SECRET ??
+    env.STEWARD_PROXY_REQUEST_SIGNING_SECRETS?.split(",")[0] ??
+    ""
+  ).trim();
+  if (!proxyUrl || !signingSecret) return null;
+  return { proxyUrl, signingSecret };
+}
+
+/**
+ * Build the proxy-relative path for a capability's (host, path). Uses the
+ * direct-proxy form `/proxy/<host><path>` so ANY allowed host works without
+ * depending on a named alias existing. v1 capabilities are EXACT-path: the
+ * forwarded path is the capability's `pathPattern` verbatim (path templating from
+ * args is a documented TODO). Query params (if any) are appended.
+ */
+function buildProxyPath(cap: Capability, query: Record<string, string> | undefined): string {
+  const host = cap.host.toLowerCase();
+  const basePath = cap.pathPattern.startsWith("/") ? cap.pathPattern : `/${cap.pathPattern}`;
+  let path = `/proxy/${host}${basePath}`;
+  if (query && Object.keys(query).length > 0) {
+    const qs = new URLSearchParams(query).toString();
+    if (qs) path += (path.includes("?") ? "&" : "?") + qs;
+  }
+  return path;
+}
+
+/**
+ * A synthetic SignRequest for the engine's evaluator context. The engine's
+ * `request` field is typed as a SignRequest; capability-intent rules ignore it
+ * entirely (they gate on `ctx.capability`), and only capability-intent rules are
+ * evaluated on the invoke path, so this sentinel never drives a decision. It
+ * carries the real agent/tenant ids (for the audit event) + zeroed tx fields.
+ */
+function syntheticSignRequest(tenantId: string, agentId: string): SignRequest {
+  return {
+    agentId,
+    tenantId,
+    to: "0x0000000000000000000000000000000000000000",
+    value: "0",
+    chainId: 0,
+    broadcast: false,
+  };
+}
+
+/**
+ * Match a capability name against a single capability-intent pattern. Mirrors the
+ * engine's `patternMatches` (a single trailing `.*` prefix glob, else exact). Kept
+ * local so the invoke layer's default-deny match detection reuses ONLY the stable
+ * exported `CapabilityIntentConfig` shape (policy-engine stays 0-diff). The
+ * authoritative PASS/constraint verdict is delegated to `evaluateCapabilityIntent`.
+ */
+function patternMatches(pattern: string, name: string): boolean {
+  if (typeof pattern !== "string" || pattern.length === 0) return false;
+  if (pattern.endsWith(".*")) return name.startsWith(pattern.slice(0, -1));
+  return pattern === name;
+}
+
+/**
+ * True when a rule is a capability-intent rule. `PolicyRule.type` is the CORE
+ * closed union which does NOT include the contributed "capability-intent"
+ * discriminator (it is a plugin-registered type stored as an arbitrary string in
+ * the DB), so we compare the type as a plain string.
+ */
+function isCapabilityIntentRule(rule: PolicyRule): boolean {
+  return (rule.type as string) === (CAPABILITY_INTENT_RULE_TYPE as string);
+}
+
+/**
+ * True when `rule` is a well-formed capability-intent rule with effect "allow"
+ * whose configured patterns GOVERN `name`. This is the local "does an allow rule
+ * match this capability" test; whether that allow rule PASSES (args/rate
+ * constraints) is decided by the engine evaluator, not here.
+ */
+function isMatchingAllowRule(rule: PolicyRule, name: string): boolean {
+  if (!isCapabilityIntentRule(rule)) return false;
+  const cfg = rule.config as Partial<CapabilityIntentConfig>;
+  if (cfg.effect !== "allow") return false;
+  if (!Array.isArray(cfg.capabilities)) return false;
+  return cfg.capabilities.some((p) => patternMatches(p, name));
+}
+
+/** True when a rule (of any effect) is a capability-intent rule governing `name`. */
+function isGoverningRule(rule: PolicyRule, name: string): boolean {
+  if (!isCapabilityIntentRule(rule)) return false;
+  const cfg = rule.config as Partial<CapabilityIntentConfig>;
+  if (!Array.isArray(cfg.capabilities)) return false;
+  return cfg.capabilities.some((p) => patternMatches(p, name));
+}
+
+/**
+ * Build the agent invoke router. Mounted (behind the plugin's agent-jwt gate on
+ * `/capabilities/:name/invoke`) by the plugin's `register`.
+ */
+export function createInvokeRoutes(ctx: StewardAppContext): Hono<{ Variables: AppVariables }> {
+  const routes = new Hono<{ Variables: AppVariables }>();
+  const store = new CapabilityStore(ctx.db);
+  // a single engine instance for the invoke path. no audit hook here (the plugin
+  // writes its OWN capability_invocations audit row per attempt).
+  const engine = new PolicyEngine();
+
+  /**
+   * Record the terminal decision and return the response. Central so EVERY exit
+   * records exactly one invocation row first (fail-closed audit trail + the
+   * rate-limit source). A record failure is swallowed AFTER the decision is
+   * already fail-closed (we never upgrade a deny to an allow on a record error;
+   * a denied attempt simply may not be counted toward the hourly cap).
+   *
+   * `webhookEvents` (capability.invoked / .denied / .approval_queued) are DECLARED
+   * by this package (index.ts) so the event types are valid; actual dispatch runs
+   * through the core webhook config/dispatch path (which the plugin does not hold
+   * an injected handle to) exactly as the CRUD lifecycle events do — the plugin's
+   * job is the durable decision record, not the transport.
+   */
+  async function finish(
+    c: Context<{ Variables: AppVariables }>,
+    args: {
+      tenantId: string;
+      agentId: string;
+      capabilityId: string | null;
+      decision: InvocationDecision;
+      status: number;
+      payload: ApiResponse;
+    },
+  ): Promise<Response> {
+    try {
+      await store.recordInvocation({
+        tenantId: args.tenantId,
+        agentId: args.agentId,
+        capabilityId: args.capabilityId,
+        decision: args.decision,
+      });
+    } catch {
+      // audit write failed: do NOT block the (already fail-closed) decision.
+    }
+    return c.json<ApiResponse>(args.payload, args.status as never);
+  }
+
+  // ── POST /:name/invoke ──────────────────────────────────────────────────────
+  routes.post("/:name/invoke", async (c) => {
+    // agent identity from the TOKEN, never the body (agent-jwt set these).
+    const tenantId = c.get("tenantId");
+    const agentId = c.get("agentScope");
+    if (!tenantId || !agentId) {
+      // the agent-jwt middleware should have populated these; if not, fail closed.
+      return c.json<ApiResponse>({ ok: false, error: "agent authentication required" }, 401);
+    }
+    const name = c.req.param("name");
+
+    // parse the optional body envelope. an invalid JSON body is a 400.
+    const parsed = await ctx.safeJsonParse<{
+      args?: Record<string, unknown>;
+      body?: unknown;
+      query?: Record<string, string>;
+    }>(c);
+    // an empty body is allowed (no args). a present-but-invalid JSON body => 400.
+    const envelope = parsed ?? {};
+    const invokeArgs =
+      envelope.args && typeof envelope.args === "object" && !Array.isArray(envelope.args)
+        ? (envelope.args as Record<string, unknown>)
+        : {};
+    const query =
+      envelope.query && typeof envelope.query === "object" && !Array.isArray(envelope.query)
+        ? (envelope.query as Record<string, string>)
+        : undefined;
+
+    // a. resolve capability + active grant fail-closed via the usable-by-agent
+    //    surface (active + unexpired grant to an ENABLED capability).
+    const usable = await store.listUsableCapabilitiesForAgent(tenantId, agentId);
+    const match = usable.find((u) => u.capability.name === name);
+    if (!match) {
+      // no usable grant: could be unknown capability, disabled, or no/expired/
+      // revoked grant. all collapse to a fail-closed 403 (do not leak which).
+      return finish(c, {
+        tenantId,
+        agentId,
+        capabilityId: null,
+        decision: "deny",
+        status: 403,
+        payload: { ok: false, error: "capability not available to agent" } satisfies ApiResponse,
+      });
+    }
+    const cap = match.capability;
+
+    // b. trailing-hour invoke count for (agent, capability). a query error =>
+    //    DENY (the maxCallsPerHour constraint would otherwise fail open).
+    let count1h: number;
+    try {
+      count1h = await store.countInvocations1h(agentId, cap.id);
+    } catch {
+      return finish(c, {
+        tenantId,
+        agentId,
+        capabilityId: cap.id,
+        decision: "deny",
+        status: 403,
+        payload: { ok: false, error: "policy evaluation unavailable" } satisfies ApiResponse,
+      });
+    }
+
+    // c. build the policy context. ctx.capability drives capability-intent rules;
+    //    only capability-intent rules are evaluated on the invoke path.
+    const capabilityCtx: NonNullable<EvaluatorContext["capability"]> = {
+      name: cap.name,
+      args: invokeArgs,
+      host: cap.host,
+      path: cap.pathPattern,
+      method: cap.method,
+    };
+
+    let policySet: PolicyRule[];
+    try {
+      policySet = await ctx.getPolicySet(tenantId, agentId);
+    } catch {
+      return finish(c, {
+        tenantId,
+        agentId,
+        capabilityId: cap.id,
+        decision: "deny",
+        status: 403,
+        payload: { ok: false, error: "policy evaluation unavailable" } satisfies ApiResponse,
+      });
+    }
+    // only the capability-intent rules govern a capability invoke.
+    const capRules = policySet.filter((r) => isCapabilityIntentRule(r));
+
+    // d. evaluate through the engine's existing entry point.
+    const evaluation = await engine.evaluate(capRules, {
+      request: syntheticSignRequest(tenantId, agentId),
+      recentTxCount1h: 0,
+      recentTxCount24h: 0,
+      spentToday: 0n,
+      spentThisWeek: 0n,
+      capability: capabilityCtx,
+      capabilityInvokeCount1h: count1h,
+    });
+
+    // e. DEFAULT-DENY + effect resolution. build the per-rule evaluator context
+    //    once (identical to what the engine used) so matched-allow detection and
+    //    matched-deny/approval detection use the AUTHORITATIVE evaluator.
+    const evaluatorCtx: EvaluatorContext = {
+      request: syntheticSignRequest(tenantId, agentId),
+      recentTxCount1h: 0,
+      recentTxCount24h: 0,
+      spentToday: 0n,
+      spentThisWeek: 0n,
+      capability: capabilityCtx,
+      capabilityInvokeCount1h: count1h,
+    };
+
+    const governing = capRules.filter((r) => isGoverningRule(r, cap.name));
+    if (governing.length === 0) {
+      // no capability-intent rule governs this capability => default-deny.
+      return finish(c, {
+        tenantId,
+        agentId,
+        capabilityId: cap.id,
+        decision: "deny",
+        status: 403,
+        payload: {
+          ok: false,
+          error: "no policy authorizes this capability",
+        } satisfies ApiResponse,
+      });
+    }
+
+    // evaluate each governing rule with the authoritative evaluator.
+    let sawApproval = false;
+    let matchedAllowPassed = false;
+    let denyReason: string | undefined;
+    for (const rule of governing) {
+      const result = evaluateCapabilityIntent(
+        { id: rule.id, type: rule.type as string, enabled: rule.enabled, config: rule.config },
+        evaluatorCtx,
+      );
+      if (result.requiresManualApproval) {
+        sawApproval = true;
+        continue;
+      }
+      if (!result.passed) {
+        // a matched deny, OR a matched allow that failed its constraints.
+        denyReason = result.reason ?? "denied by policy";
+        continue;
+      }
+      // passed. only an ALLOW-effect rule authorizes (a passing rule that is not
+      // an allow rule cannot happen for a governing rule: deny/require-approval
+      // never pass. but re-check the effect defensively).
+      if (isMatchingAllowRule(rule, cap.name)) matchedAllowPassed = true;
+    }
+
+    // precedence: a matched-allow that passed AND the engine overall did not
+    // hard-reject authorizes. a require-approval (with no passing allow) => 202.
+    // anything else => deny.
+    if (matchedAllowPassed && evaluation.approved) {
+      // proceed to forward (below).
+    } else if (sawApproval && !matchedAllowPassed) {
+      // f-approval: enqueue via the plugin's own invocation record (the core
+      // approval_queue is tx-shaped and cannot hold a capability invoke). the
+      // 202 returns the invocation id as the approvalId. an enqueue (record)
+      // error => DENY + audit (handled inside finish: a null id would drop the
+      // approval, so on record failure we return a deny instead).
+      let approvalId: string | null = null;
+      try {
+        approvalId = await store.recordInvocation({
+          tenantId,
+          agentId,
+          capabilityId: cap.id,
+          decision: "approval",
+        });
+      } catch {
+        approvalId = null;
+      }
+      if (!approvalId) {
+        return finish(c, {
+          tenantId,
+          agentId,
+          capabilityId: cap.id,
+          decision: "deny",
+          status: 403,
+          payload: {
+            ok: false,
+            error: "approval enqueue failed",
+          } satisfies ApiResponse,
+        });
+      }
+      // already recorded (decision=approval); emit + return WITHOUT double-recording.
+      return c.json<ApiResponse>({ ok: true, data: { approvalId, status: "pending" } }, 202);
+    } else {
+      return finish(c, {
+        tenantId,
+        agentId,
+        capabilityId: cap.id,
+        decision: "deny",
+        status: 403,
+        payload: {
+          ok: false,
+          error: denyReason ?? "capability invoke denied by policy",
+        } satisfies ApiResponse,
+      });
+    }
+
+    // f. ALLOW => forward THROUGH THE PROXY. fail-closed if proxy env absent.
+    const proxyEnv = readProxyEnv();
+    if (!proxyEnv) {
+      return finish(c, {
+        tenantId,
+        agentId,
+        capabilityId: cap.id,
+        decision: "error",
+        status: 503,
+        payload: {
+          ok: false,
+          error: "capability delegation unavailable",
+        } satisfies ApiResponse,
+      });
+    }
+
+    let upstreamStatus: number;
+    let upstreamBody: string;
+    let upstreamContentType: string | null;
+    try {
+      // mint a short-lived api:proxy token for THIS agent (the same HS256 token
+      // the proxy verifies). the proxy matches the grant's paired secret_route
+      // (agentId = this agent) and injects the credential. the plugin never sees
+      // the secret.
+      const token = await signAgentToken(
+        { agentId, tenantId, scopes: ["agent", PROXY_SCOPE] },
+        PROXY_TOKEN_TTL,
+      );
+      const client = new StewardProxyClient({
+        proxyUrl: proxyEnv.proxyUrl,
+        token,
+        signingSecret: proxyEnv.signingSecret,
+        tenantId,
+        agentId,
+      });
+
+      const method = cap.method.toUpperCase();
+      const path = buildProxyPath(cap, query);
+      const hasBody = method !== "GET" && method !== "HEAD" && envelope.body !== undefined;
+      const init: RequestInit = { method };
+      if (hasBody) {
+        init.body =
+          typeof envelope.body === "string" ? envelope.body : JSON.stringify(envelope.body);
+        init.headers = { "content-type": "application/json" };
+      }
+      const res = await client.fetch(path, init);
+      upstreamStatus = res.status;
+      upstreamContentType = res.headers.get("content-type");
+      upstreamBody = await res.text();
+    } catch {
+      // a forward failure is an error outcome (recorded), surfaced as 502.
+      return finish(c, {
+        tenantId,
+        agentId,
+        capabilityId: cap.id,
+        decision: "error",
+        status: 502,
+        payload: { ok: false, error: "capability delegation failed" } satisfies ApiResponse,
+      });
+    }
+
+    // record the allow (durable) BEFORE returning the passthrough.
+    try {
+      await store.recordInvocation({
+        tenantId,
+        agentId,
+        capabilityId: cap.id,
+        decision: "allow",
+      });
+    } catch {
+      // audit write failed: do NOT block the response (the credential already
+      // forwarded), but the decision itself was already made + policy-authorized.
+    }
+
+    // g. passthrough the upstream status + body verbatim. never re-wrap (the
+    //    proxy already scrubbed the credential from the body).
+    return new Response(upstreamBody, {
+      status: upstreamStatus,
+      headers: upstreamContentType ? { "content-type": upstreamContentType } : undefined,
+    });
+  });
+
+  return routes;
+}

--- a/packages/plugin-capabilities/src/schema.ts
+++ b/packages/plugin-capabilities/src/schema.ts
@@ -94,6 +94,49 @@ export const capabilityGrants = pgTable(
   }),
 );
 
+/**
+ * capability_invocations - the append-only audit + rate-limit source for the
+ * agent invoke path (W-1c). EVERY invoke attempt records exactly one row with its
+ * terminal decision (allow / deny / approval / error), regardless of outcome:
+ *   - it is the audit trail (who invoked what, and how it was decided),
+ *   - it is the source of the trailing-hour invoke count the `capability-intent`
+ *     `maxCallsPerHour` constraint reads (count of this agent+capability rows in
+ *     the last hour). recording the attempt BEFORE forwarding means the count is
+ *     fail-closed: a decision is always durable before any credential leaves.
+ *
+ * plugin-owned + namespaced (mirrors capabilities/capability_grants). no FK to
+ * core tables: an invocation is a self-contained decision record keyed by
+ * tenant/agent/capability ids.
+ */
+export const capabilityInvocations = pgTable(
+  "capability_invocations",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    tenantId: text("tenant_id").notNull(),
+    agentId: varchar("agent_id", { length: 64 }).notNull(),
+    // nullable: an attempt can be recorded (denied/404) before a capability row
+    // is resolved (e.g. unknown capability name). when set, it is the resolved
+    // capability's id.
+    capabilityId: uuid("capability_id"),
+    decision: text("decision").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    decisionCheck: check(
+      "capability_invocations_decision_check",
+      sql`${table.decision} IN ('allow','deny','approval','error')`,
+    ),
+    // the rate-limit + audit read path: this agent's rows for a capability in a
+    // time window. (agent_id, capability_id, created_at) covers the count query.
+    rateIdx: index("capability_invocations_rate_idx").on(
+      table.agentId,
+      table.capabilityId,
+      table.createdAt,
+    ),
+    tenantIdx: index("capability_invocations_tenant_idx").on(table.tenantId),
+  }),
+);
+
 export const capabilityRelations = relations(capabilities, ({ many }) => ({
   grants: many(capabilityGrants),
 }));
@@ -109,3 +152,8 @@ export type Capability = typeof capabilities.$inferSelect;
 export type NewCapability = typeof capabilities.$inferInsert;
 export type CapabilityGrant = typeof capabilityGrants.$inferSelect;
 export type NewCapabilityGrant = typeof capabilityGrants.$inferInsert;
+export type CapabilityInvocation = typeof capabilityInvocations.$inferSelect;
+export type NewCapabilityInvocation = typeof capabilityInvocations.$inferInsert;
+
+/** the terminal decision recorded for an invoke attempt. */
+export type InvocationDecision = "allow" | "deny" | "approval" | "error";

--- a/packages/plugin-capabilities/src/store.ts
+++ b/packages/plugin-capabilities/src/store.ts
@@ -35,13 +35,22 @@ import {
   agents,
   and,
   eq,
+  gte,
   isNull,
   type NewSecretRoute,
   type SecretRoute,
   secretRoutes,
   secrets,
+  sql,
 } from "@stwd/db";
-import { type Capability, type CapabilityGrant, capabilities, capabilityGrants } from "./schema";
+import {
+  type Capability,
+  type CapabilityGrant,
+  capabilities,
+  capabilityGrants,
+  capabilityInvocations,
+  type InvocationDecision,
+} from "./schema";
 
 /**
  * a drizzle db handle (the core hands it via ctx.db). typed loosely so the plugin
@@ -353,6 +362,62 @@ export class CapabilityStore {
         ),
       );
     return rows.filter((r) => !isExpired(r.grant.expiresAt, now));
+  }
+
+  // ── invocations (audit + rate-limit source for the invoke path) ─────────────
+
+  /**
+   * Record ONE invoke attempt with its terminal decision. Append-only; called on
+   * EVERY invoke path outcome (allow/deny/approval/error) so the row is durable
+   * before any credential leaves (fail-closed audit + rate source). Returns the
+   * new invocation id (used as the 202 `approvalId` for a require-approval
+   * decision).
+   */
+  async recordInvocation(input: {
+    tenantId: string;
+    agentId: string;
+    capabilityId: string | null;
+    decision: InvocationDecision;
+    now?: Date;
+  }): Promise<string> {
+    const values: Record<string, unknown> = {
+      tenantId: input.tenantId,
+      agentId: input.agentId,
+      capabilityId: input.capabilityId,
+      decision: input.decision,
+    };
+    if (input.now) values.createdAt = input.now;
+    const [row] = await this.db.insert(capabilityInvocations).values(values).returning();
+    return row.id as string;
+  }
+
+  /**
+   * Count this agent's invocations of a specific capability in the trailing
+   * `windowMs` (default 1h) as of `now`. This is the source for the
+   * `capability-intent` `maxCallsPerHour` constraint. Counts ALL recorded
+   * attempts in the window (an attempt consumes rate whether or not it forwarded
+   * — a denied/errored attempt still counts, so a caller cannot probe the cap for
+   * free). Only rows carrying THIS capability id are counted (a pre-resolution
+   * denial with a null capability id is not attributed to any capability's cap).
+   */
+  async countInvocations1h(
+    agentId: string,
+    capabilityId: string,
+    now: Date = new Date(),
+    windowMs: number = 60 * 60_000,
+  ): Promise<number> {
+    const since = new Date(now.getTime() - windowMs);
+    const [row] = await this.db
+      .select({ n: sql<number>`count(*)::int` })
+      .from(capabilityInvocations)
+      .where(
+        and(
+          eq(capabilityInvocations.agentId, agentId),
+          eq(capabilityInvocations.capabilityId, capabilityId),
+          gte(capabilityInvocations.createdAt, since),
+        ),
+      );
+    return Number(row?.n ?? 0);
   }
 
   // ── grant create (materializes the paired route) ────────────────────────────


### PR DESCRIPTION
W-1c: wires the capabilities plugin end to end — compose registration, the agent-facing default-deny invoke route, and proxy delegation. Additive, vendor-neutral. **DO NOT MERGE yet.**

## what landed
- **compose registration**: `capabilities` added to the known-plugin set; `composeApp` + `runComposedPluginMigrations` both gate it through the SAME `resolveEnabledPlugins` resolver (routes + migrations both-on/both-off). the `capability-intent` policy rule is contributed declaratively (`plugin.policyRules`) so the host registers its evaluator into the policy-engine registry. compose generalized from the trading-only special-case to an enabled-set loop (lean = `enabled.size === 0`).
- **capability_invocations** (plugin-owned migration 0001, additive, namespaced ledger): records EVERY invoke attempt with its decision (allow/deny/approval/error) — the audit trail + the trailing-hour rate-limit source. indexed (agent_id, capability_id, created_at).
- **the invoke route** `POST /capabilities/:name/invoke` (agent-token auth; identity from the token, never the body):
  - resolve capability + active/unexpired grant to an ENABLED capability via the fail-closed usable-by-agent surface (miss => 403/404, audited).
  - compute `capabilityInvokeCount1h` from the invocations table.
  - build `ctx.capability` + count, evaluate the tenant's ENABLED capability-intent rules through the engine's existing entry point.
  - **DEFAULT-DENY**: engine-pass alone does NOT authorize (a capability-intent rule passes for any capability it does not govern). the invoke layer independently requires >=1 capability-intent rule that GOVERNS this capability with effect `allow` AND passed (via the exported `evaluateCapabilityIntent`); a matched deny or failed constraint hard-denies; a matched require-approval => 202 `{approvalId}`.
  - ALLOW => forward THROUGH the proxy via `@stwd/proxy-client` (short-lived `api:proxy` token minted from the shared `STEWARD_JWT_SECRET` + HMAC signed). the plugin NEVER decrypts a secret. proxy env absent => 503 fail-closed.
  - upstream status/body passthrough. `capability.invoked/.denied/.approval_queued` declared.

## design notes
- **matched-allow detection** keeps `@stwd/policy-engine` **0-diff**: governance is detected locally on the stable exported `CapabilityIntentConfig` shape; the pass/constraint verdict is delegated to the exported `evaluateCapabilityIntent` (single source of truth).
- **approval**: the core `approval_queue` FK-references `transactions.id NOT NULL` (tx-shaped), so a capability invoke can't use it without a phantom tx. the plugin's own `capability_invocations` row IS the approval record; the 202 returns its id as `approvalId`. operator resolution of capability approvals is a documented follow-up.
- per-GRANT paired-route design (from W-1a) keeps proxy matching semantics unchanged.

## verification
- plugin-capabilities suite **67/0** (existing 48 + invoke unit 17 + e2e 5 + migration-isolation +1). policy-engine **285/0** untouched. proxy-client **21/0** untouched. api parity/host/config/policy-rules **170/0**.
- e2e proves the full arc through the REAL proxy: PAT injected upstream + NEVER agent-visible, wrong-arg 403 no-forward, ungranted 403, require-approval 202 queued, maxCallsPerHour second-invoke deny.
- `turbo run build` 28/28. frozen install clean. audit 0 crit/0 high (1 pre-existing low elliptic). biome clean.
- diff vs develop: plugin-capabilities + compose.ts + plugin-config.ts + lockfile + docs + api tests. **policy-engine / proxy / secret-vault / trading all 0-diff.**
- codex (gpt-5.5) reviewed; both findings (disabled-rule bypass, malformed-JSON coercion) fixed with tests.

## deploy env (capabilities-enabled service)
`STEWARD_PLUGINS=capabilities` (or `trading,capabilities`), `STEWARD_PROXY_URL`, `STEWARD_PROXY_REQUEST_SIGNING_SECRET` — all fail-closed (invoke => 503 if absent). the short-lived proxy token reuses the shared `STEWARD_JWT_SECRET`. runbook: `docs/deploy/railway-lean-full.md`.

Co-authored-by: wakesync <shadow@shad0w.xyz>