### PR TITLE
feat: fail-closed cookie injection with explicit opt-in (resolves #157 decision)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -197,6 +197,12 @@ NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=
 # URL of the Steward Proxy service (for credential injection).
 STEWARD_PROXY_URL=http://localhost:8080
 
+# WARNING: allows secret routes to inject raw `Cookie`/`Set-Cookie` headers
+# (whole-session replay, no revocation/rotation). Blocked by default; prefer a
+# scoped broker read token via `Authorization: Bearer`. Only set if a target
+# host speaks nothing but cookies.
+# STEWARD_ALLOW_COOKIE_INJECTION=false
+
 # API key for the Steward agent (used by the web app's server-side API routes).
 STEWARD_AGENT_TOKEN=
 

--- a/docs/api-reference/routes.mdx
+++ b/docs/api-reference/routes.mdx
@@ -205,3 +205,21 @@ A route matches when:
 
 A request to `api.example.com/v2/trading/orders` matches the priority-10 route.
 A request to `api.example.com/v1/data` matches the priority-0 fallback.
+
+## Restricted inject headers
+
+Some `injectKey` header names are rejected at route-create time. Hop-by-hop and
+framing-sensitive headers (`connection`, `content-length`, `host`,
+`transfer-encoding`, etc.) are unconditionally blocked.
+
+Session-cookie headers (`Cookie` and `Set-Cookie`, matched case-insensitively)
+are **blocked by default** and only become injectable when the operator sets
+`STEWARD_ALLOW_COOKIE_INJECTION=true`. Injecting a raw `Cookie` replays a whole
+browser session: there is no scoping, no revocation handle, and no `Set-Cookie`
+rotation path, so the blast radius is the entire session. The preferred pattern
+is a **scoped broker read token** injected as `Authorization: Bearer <token>` —
+revocable, auditable, and narrowed per grant. Raw session replay stays available
+for hosts that only speak cookies, but as a deliberate operator opt-in rather
+than an implicit default. Existing routes are validated at create time, so a
+route created before this default took effect keeps working; the flag only
+gates creation of new cookie-injecting routes.

--- a/packages/vault/src/__tests__/secret-route-validator.test.ts
+++ b/packages/vault/src/__tests__/secret-route-validator.test.ts
@@ -181,6 +181,81 @@ describe("validateSecretRouteConfig — core rules", () => {
   });
 });
 
+describe("cookie injection — fail-closed default with explicit opt-in (#157)", () => {
+  beforeEach(() => {
+    delete process.env.STEWARD_ALLOW_COOKIE_INJECTION;
+  });
+  afterEach(() => {
+    delete process.env.STEWARD_ALLOW_COOKIE_INJECTION;
+  });
+
+  it("blocks injectKey=cookie by default", () => {
+    expect(validateSecretRouteConfig({ ...okBase, injectKey: "cookie" })).toContain(
+      "STEWARD_ALLOW_COOKIE_INJECTION=true",
+    );
+  });
+
+  it("blocks injectKey=set-cookie by default", () => {
+    expect(validateSecretRouteConfig({ ...okBase, injectKey: "set-cookie" })).toContain(
+      "STEWARD_ALLOW_COOKIE_INJECTION=true",
+    );
+  });
+
+  it("blocks cookie case-insensitively (Cookie / COOKIE / cookie)", () => {
+    for (const key of ["Cookie", "COOKIE", "cookie", "CoOkIe"]) {
+      expect(validateSecretRouteConfig({ ...okBase, injectKey: key })).toContain(
+        "STEWARD_ALLOW_COOKIE_INJECTION=true",
+      );
+    }
+  });
+
+  it("blocks set-cookie case-insensitively (Set-Cookie / SET-COOKIE)", () => {
+    for (const key of ["Set-Cookie", "SET-COOKIE", "set-cookie"]) {
+      expect(validateSecretRouteConfig({ ...okBase, injectKey: key })).toContain(
+        "STEWARD_ALLOW_COOKIE_INJECTION=true",
+      );
+    }
+  });
+
+  it("allows injectKey=cookie only when the opt-in flag is set", () => {
+    process.env.STEWARD_ALLOW_COOKIE_INJECTION = "true";
+    expect(validateSecretRouteConfig({ ...okBase, injectKey: "cookie" })).toBeNull();
+  });
+
+  it("allows injectKey=Cookie (mixed case) when the opt-in flag is set", () => {
+    process.env.STEWARD_ALLOW_COOKIE_INJECTION = "true";
+    expect(validateSecretRouteConfig({ ...okBase, injectKey: "Cookie" })).toBeNull();
+  });
+
+  it("allows injectKey=set-cookie when the opt-in flag is set", () => {
+    process.env.STEWARD_ALLOW_COOKIE_INJECTION = "true";
+    expect(validateSecretRouteConfig({ ...okBase, injectKey: "set-cookie" })).toBeNull();
+  });
+
+  it("treats any non-'true' flag value as blocked (fail-closed)", () => {
+    for (const val of ["1", "yes", "TRUE", "", "false"]) {
+      process.env.STEWARD_ALLOW_COOKIE_INJECTION = val;
+      expect(validateSecretRouteConfig({ ...okBase, injectKey: "cookie" })).toContain(
+        "STEWARD_ALLOW_COOKIE_INJECTION=true",
+      );
+    }
+  });
+
+  it("leaves unconditionally-blocked hop-by-hop headers blocked even with the cookie flag on", () => {
+    process.env.STEWARD_ALLOW_COOKIE_INJECTION = "true";
+    expect(validateSecretRouteConfig({ ...okBase, injectKey: "host" })).toContain("is not allowed");
+    expect(validateSecretRouteConfig({ ...okBase, injectKey: "content-length" })).toContain(
+      "is not allowed",
+    );
+  });
+
+  it("does not affect other injectKeys — authorization stays valid regardless of the flag", () => {
+    expect(validateSecretRouteConfig({ ...okBase, injectKey: "authorization" })).toBeNull();
+    process.env.STEWARD_ALLOW_COOKIE_INJECTION = "true";
+    expect(validateSecretRouteConfig({ ...okBase, injectKey: "authorization" })).toBeNull();
+  });
+});
+
 describe("STRICT_HOSTS — api.github.com narrowness", () => {
   it("declares api.github.com as a strict host", () => {
     expect(STRICT_HOSTS["api.github.com"]).toEqual({
@@ -322,13 +397,20 @@ describe("validator parity across former call sites", () => {
       accept: false,
     },
     { name: "bad injectKey", input: { ...okBase, injectKey: "content-length" }, accept: false },
+    {
+      name: "cookie injectKey blocked by default",
+      input: { ...okBase, injectKey: "cookie" },
+      accept: false,
+    },
   ];
 
   beforeEach(() => {
     delete process.env.STEWARD_ALLOW_BROAD_SECRET_ROUTES;
+    delete process.env.STEWARD_ALLOW_COOKIE_INJECTION;
   });
   afterEach(() => {
     delete process.env.STEWARD_ALLOW_BROAD_SECRET_ROUTES;
+    delete process.env.STEWARD_ALLOW_COOKIE_INJECTION;
   });
 
   for (const c of matrix) {

--- a/packages/vault/src/secret-route-validator.ts
+++ b/packages/vault/src/secret-route-validator.ts
@@ -32,7 +32,8 @@ export const DEFAULT_SECRET_ROUTE_HOSTS = [
 
 /**
  * Header names that must never be settable via injectKey — hop-by-hop headers
- * and framing-sensitive headers whose injection could enable smuggling.
+ * and framing-sensitive headers whose injection could enable smuggling. These
+ * are unconditionally blocked; there is no operator escape valve.
  */
 const BLOCKED_INJECT_HEADERS = new Set([
   "connection",
@@ -45,6 +46,20 @@ const BLOCKED_INJECT_HEADERS = new Set([
   "transfer-encoding",
   "upgrade",
 ]);
+
+/**
+ * Session-material headers that are blocked by default but may be enabled by a
+ * deliberate operator opt-in (STEWARD_ALLOW_COOKIE_INJECTION=true).
+ *
+ * Injecting a raw `Cookie` header replays a whole browser session: no scoping,
+ * no revocation handle, no `Set-Cookie` rotation path on our side — the blast
+ * radius is the entire session. House style is fail-closed, so this is blocked
+ * by default. The preferred pattern is a scoped broker read token injected as
+ * `Authorization: Bearer <token>` (revocable, auditable, per-grant). Raw
+ * session replay remains a legitimate niche (some hosts only speak cookies), so
+ * it stays reachable — but only as an explicit operator choice, never implicit.
+ */
+const COOKIE_INJECT_HEADERS = new Set(["cookie", "set-cookie"]);
 
 const VALID_PROXY_METHODS = new Set(["*", "GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"]);
 const MAX_SECRET_INJECT_FORMAT_LENGTH = 255;
@@ -98,6 +113,16 @@ export type SecretRouteConfigInput = {
 
 function allowBroadSecretRoutes(): boolean {
   return process.env.STEWARD_ALLOW_BROAD_SECRET_ROUTES === "true";
+}
+
+/**
+ * Whether the operator has opted into raw session-cookie injection. Read at
+ * call time (same pattern as allowBroadSecretRoutes) so tests / operators can
+ * toggle it. Fail-closed: anything other than the exact string "true" leaves
+ * cookie injection blocked.
+ */
+function allowCookieInjection(): boolean {
+  return process.env.STEWARD_ALLOW_COOKIE_INJECTION === "true";
 }
 
 /**
@@ -250,6 +275,11 @@ export function validateSecretRouteConfig(
     // denylist; keep the allowlist.
     if (!key || !HTTP_HEADER_NAME.test(key)) return "injectKey is invalid";
     if (BLOCKED_INJECT_HEADERS.has(key)) return `injectKey '${input.injectKey}' is not allowed`;
+    // Session-cookie headers are blocked by default (fail-closed) and only
+    // reachable via a deliberate operator opt-in. See COOKIE_INJECT_HEADERS.
+    if (COOKIE_INJECT_HEADERS.has(key) && !allowCookieInjection()) {
+      return `injectKey '${input.injectKey}' requires STEWARD_ALLOW_COOKIE_INJECTION=true`;
+    }
   }
 
   if (input.injectFormat !== undefined) {


### PR DESCRIPTION
resolves the cookie-injection decision from #157: **fail-closed default, explicit opt-in**.

## what
`injectKey: Cookie` was an implicit capability — `cookie` wasn't in `BLOCKED_INJECT_HEADERS` and hop-by-hop stripping only filters *inbound* headers before injection, so a secret route could inject a raw `Cookie` today with nobody having deliberately decided that. #157 flagged it as "deliberate-sounding behavior nobody deliberately decided."

this ships **option 2 with an escape valve**: `cookie` and `set-cookie` are blocked as `injectKey` values at route-create/update time **unless** the operator sets `STEWARD_ALLOW_COOKIE_INJECTION=true`.

## why fail-closed
house style is fail-closed (stricter wins). a raw `Cookie` replays a whole browser session: no scoping, no revocation handle, no `Set-Cookie` rotation path on our side — the blast radius is the entire session. the documented preferred pattern is a **scoped broker read token** injected as `Authorization: Bearer <token>` (revocable, auditable, per-grant), which is exactly the scoped-session-read broker integration #157 is about.

raw session replay is still a legitimate niche (some hosts only speak cookies), so it stays reachable — but as a deliberate operator choice, never implicit.

## changes (tight diff, 4 files)
- **`packages/vault/src/secret-route-validator.ts`**: new `COOKIE_INJECT_HEADERS = {cookie, set-cookie}` (kept separate from the unconditional `BLOCKED_INJECT_HEADERS`) + an `allowCookieInjection()` env helper resolved at call time, mirroring the existing `allowBroadSecretRoutes()` pattern. match is case-insensitive for free: `injectKey` is already lowercased before the `Set.has()` check.
- **tests**: extended the validator suite (was 38-case parity from #151, now 49 pass). covers cookie/set-cookie blocked by default, allowed only with flag=true, case-insensitivity (`Cookie`/`COOKIE`/`CoOkIe`/`Set-Cookie`), any non-`"true"` flag value stays blocked (fail-closed), hop-by-hop headers stay blocked even with the flag on, other injectKeys unaffected, plus a new parity-matrix row.
- **`docs/api-reference/routes.mdx`**: new "Restricted inject headers" section (default + opt-in + why broker tokens are preferred, vendor-neutral).
- **`.env.example`**: `STEWARD_ALLOW_COOKIE_INJECTION` commented-out with a one-line warning.

## migration reality
validation runs at route **create/update** only (`secret-vault.ts` createRoute/updateRoute, `api/src/routes/secrets.ts` POST/PUT) — there is no injection-time re-validation of stored rows. so a deployment that already has a `Cookie` route keeps working; the flag only gates creation/update of new cookie-injecting routes. **no data migration.**

## gates
- validator suite: **49 pass / 0 fail** (64 expect calls).
- consumer suites green: `secret-vault` (18 pass), `secret-vault-lifecycle` (6 pass).
- `tsc --noEmit` clean for the touched file (pre-existing `@stwd/shared` workspace-build-order errors are unrelated and untouched).
- diff reviewed against `origin/develop`: zero drift outside scope. did not touch `packages/plugin-capabilities/src/invoke.ts`.

## notes
- codex review exceeded the 3min budget on the VPS (repo-index step) and was killed per the review policy; diff is small and manually reviewed.
- did NOT touch existing em-dash comment style in the file (kept consistent with surrounding code).

resolves the decision in #157.

[sol-orch]

Co-authored-by: wakesync <shadow@shad0w.xyz>