### PR TITLE
docs: session broker integration runbook and e2e harness

### DIFF
--- a/docs/guides/session-broker-integration.mdx
+++ b/docs/guides/session-broker-integration.mdx
@@ -1,0 +1,305 @@
+---
+title: "Session Broker Integration"
+description: "Give an agent scoped, credential-injected access to a session broker — store the broker token as a secret, grant a capability, and invoke through the proxy without ever exposing the token."
+---
+
+# Session Broker Integration
+
+A **session broker** is an third-party service that turns a stored session (a cookie
+jar, an OAuth session, a headless-browser session) into a small, scoped HTTP API:
+the agent asks the broker to `list`, `fetch`, or `render` something on a site that
+only has an unofficial web API, and the broker replies with structured JSON. The
+broker holds the live session; the agent never does.
+
+Steward is the governance layer in front of that broker. This guide wires an agent
+to a session broker **config-only** — no product-code changes — so that:
+
+- the broker's scoped token is stored as an encrypted Steward **secret** and
+  injected on the outbound request by the **proxy** (the agent never sees it),
+- a **capability** + **grant** + an **allow policy** decide, per agent, whether a
+  given broker call is permitted (deny-by-default),
+- every attempt writes one durable **audit** row (allow / deny / approval / error).
+
+The moving parts mirror the reference implementation in
+[teleport-computer/oauth3-server](https://github.com/teleport-computer/oauth3-server):
+a broker exposes scoped read/fetch endpoints behind a bearer token, and a
+delegating gateway (here, Steward) attaches that token to allowed calls only.
+
+## Architecture
+
+```
+┌────────┐   POST /capabilities/:name/invoke   ┌──────────────────────┐
+│ agent  │ ─────────────────────────────────▶ │ steward api          │
+│(no key)│   { args, body, query }             │  plugin-capabilities │
+└────────┘                                     │  - resolve grant     │
+                                               │  - policy default-deny│
+                                               │  - audit row          │
+                                               └───────────┬──────────┘
+                                                           │ minted api:proxy
+                                                           │ token (HMAC-signed)
+                                                           ▼
+                                               ┌──────────────────────┐
+                                               │ steward proxy        │
+                                               │  - match secret_route │
+                                               │  - decrypt secret     │
+                                               │  - inject Authorization│
+                                               │  - SSRF guard + scrub │
+                                               └───────────┬──────────┘
+                                                           │ https 443
+                                                           ▼
+                                               ┌──────────────────────┐
+                                               │ session broker (public)│
+                                               │  GET  /sessions/:id    │
+                                               │  POST /render          │
+                                               └──────────────────────┘
+```
+
+The agent only ever holds an agent token. The broker's bearer token lives encrypted
+in the vault, is decrypted **only** inside the proxy, is attached **only** to a
+matching outbound request, and is **scrubbed** from the response body before the
+proxy returns it. The plugin never decrypts anything.
+
+## Prerequisites
+
+- A Steward tenant with a tenant-admin session (secrets, capabilities, and grants
+  are all MFA-gated tenant-admin operations).
+- An agent already created in the tenant (see [Setting Up an Agent](/guides/agent-setup)).
+- A **publicly reachable** session broker on `https://<broker-host>` port `443`.
+  See [Constraints](#constraints) — a `localhost` / LAN / private-IP broker is
+  rejected by the proxy's SSRF guard and cannot be integrated as-is.
+- A scoped broker token (the credential the broker expects in `Authorization`).
+
+## Step 1: Configure the environment
+
+Add these to the Steward API + proxy environment. The first three are the only
+required additions; the timeout is recommended for brokers that render.
+
+```bash
+# Allow the proxy to route to your broker host at all (SSRF allowlist, layer 1).
+STEWARD_PROXY_ALLOWED_HOSTS=broker.example.com
+
+# Allow a credential-injection route to attach a secret to that host (layer 2,
+# the secret-route host allowlist — extends the code defaults).
+STEWARD_SECRET_ROUTE_ALLOWED_HOSTS=broker.example.com
+
+# Recommended for render/fetch brokers: the proxy's default upstream timeout is
+# 30s. A headless render can exceed that; raise it (value in milliseconds).
+STEWARD_PROXY_UPSTREAM_TIMEOUT_MS=120000
+
+# Optional: the response cap defaults to 25 MiB (fits screenshot / rendered
+# payloads). Only raise it if a broker returns larger bodies.
+# STEWARD_PROXY_RESPONSE_BYTES=26214400
+```
+
+<Warning>
+  Both host allowlists take a **comma-separated** list. `STEWARD_PROXY_ALLOWED_HOSTS`
+  gates whether the proxy will dial the host at all; `STEWARD_SECRET_ROUTE_ALLOWED_HOSTS`
+  gates whether a credential may be injected on it. A broker host must be in **both**.
+</Warning>
+
+## Step 2: Store the broker token as a secret
+
+The scoped broker token is stored encrypted. It is never returned in any response.
+
+```bash
+curl -X POST https://api.steward.fi/secrets \
+  -H "X-Steward-Key: your-tenant-key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "session-broker-token",
+    "value": "brk_live_...scoped-broker-token...",
+    "description": "Scoped session-broker bearer token"
+  }'
+```
+
+The response returns `data.id` (a UUID) and `data.name` — never the value. Keep the
+`data.id`; the capability references it as `secretId`.
+
+## Step 3: Create the capability
+
+A **capability** binds `(secret, host, path, method, injection)` into a named,
+grantable unit. Creating it also validates the injection route against the
+secret-route rules (host must be allowlisted, `injectAs` is header-only, framing
+headers are blocked).
+
+```bash
+curl -X POST https://api.steward.fi/capabilities \
+  -H "X-Steward-Key: your-tenant-key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "broker.session.render",
+    "secretId": "550e8400-...",
+    "host": "broker.example.com",
+    "pathPattern": "/render",
+    "method": "POST",
+    "injectAs": "header",
+    "injectKey": "authorization",
+    "injectFormat": "Bearer {value}"
+  }'
+```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `name` | string | Dotted lowercase identifier, e.g. `broker.session.render`. |
+| `secretId` | uuid | The secret ID from Step 2. |
+| `host` | string | The broker host, lower-cased. Must be public https (see Constraints). |
+| `pathPattern` | string | v1 is **exact-path**: the forwarded path is this value verbatim. |
+| `method` | string | `POST` for a body-carrying broker call (see the GET note below). |
+| `injectAs` | string | `header` only. Query/body injection is unsupported (reflection risk). |
+| `injectKey` | string | The header name to set, e.g. `authorization`. |
+| `injectFormat` | string | `{value}` is replaced with the decrypted secret, e.g. `Bearer {value}`. |
+
+<Note>
+  `injectAs` defaults to `header` and `injectFormat` defaults to `{value}` if
+  omitted. Both are shown here for clarity.
+</Note>
+
+## Step 4: Grant the capability to the agent
+
+A capability is inert until an agent is granted it. Grants are per-agent and may
+carry an optional expiry.
+
+```bash
+curl -X POST https://api.steward.fi/capabilities/<capabilityId>/grants \
+  -H "X-Steward-Key: your-tenant-key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "agentId": "my-agent",
+    "expiresAt": "2027-01-01T00:00:00Z"
+  }'
+```
+
+`expiresAt` is optional (omit for a non-expiring grant). Deleting the grant, or
+disabling the capability, immediately revokes access with no redeploy.
+
+## Step 5: Add an allow policy
+
+Even with a grant, an invoke is **denied by default**. Authorization requires at
+least one enabled `capability-intent` policy rule whose `effect` is `allow` and
+whose patterns govern the capability name. Policies are set with the full-set
+`PUT` (it **replaces** the agent's policy set — include every rule).
+
+```bash
+curl -X PUT https://api.steward.fi/agents/my-agent/policies \
+  -H "X-Steward-Key: your-tenant-key" \
+  -H "Content-Type: application/json" \
+  -d '[
+    {
+      "id": "allow-broker-render",
+      "type": "capability-intent",
+      "enabled": true,
+      "config": {
+        "capabilities": ["broker.session.render"],
+        "effect": "allow",
+        "constraints": { "maxCallsPerHour": 60 }
+      }
+    }
+  ]'
+```
+
+| Config Field | Type | Description |
+|--------------|------|-------------|
+| `capabilities` | string[] | Exact names, or a single trailing `.*` prefix glob (`broker.*`). Case-sensitive. |
+| `effect` | string | `allow`, `deny`, or `require-approval`. A matched `deny` always wins; `require-approval` routes to a `202` queued outcome. |
+| `constraints.maxCallsPerHour` | number | Cap on invokes per trailing hour for this (agent, capability). |
+| `constraints.argEquals` | object | Each key must exist in the invoke `args` and strictly equal the value. |
+| `constraints.argMatches` | object | Each key must match the (anchored) regex. |
+
+<Warning>
+  `PUT /agents/:id/policies` **replaces** the entire policy set. Always send the
+  complete set, or you will drop rules the agent still needs.
+</Warning>
+
+## Step 6: Invoke from the agent
+
+The agent calls the invoke route with its **agent token** (not the tenant key). The
+agent never references the broker token — the proxy attaches it.
+
+```bash
+curl -X POST https://api.steward.fi/capabilities/broker.session.render/invoke \
+  -H "Authorization: Bearer <agent-token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "args": { "sessionId": "sess_123" },
+    "body": { "url": "https://example.com/dashboard", "format": "png" }
+  }'
+```
+
+The envelope is `{ args?, body?, query? }`:
+
+- `args` drive policy constraints (`argEquals` / `argMatches`) — they are **not**
+  forwarded to the broker.
+- `body` is the JSON request body forwarded to the broker (for `POST`/`PUT`/`PATCH`).
+- `query` is appended to the forwarded URL as a query string.
+
+On an allowed call the proxy returns the broker's status and body **verbatim** (the
+injected credential already scrubbed). A `403` means denied by policy or missing
+grant; a `503` means the proxy delegation env is not configured; a `502` means the
+broker call itself failed.
+
+## Constraints
+
+Read these before integrating — they are hard limits, not tunables.
+
+- **The broker must be a public HTTPS host on 443.** The proxy enforces SSRF
+  defense in two layers, and there is **no** flag to disable it:
+  1. a string-level guard rejects `localhost`, `*.localhost`, `*.local`,
+     `*.internal`, and bare IPs, and requires the host to be in
+     `STEWARD_PROXY_ALLOWED_HOSTS`;
+  2. a DNS-level guard resolves the host and rejects any private/reserved address,
+     then pins the dial to the vetted record.
+  A broker on `localhost`, a LAN address, or a private/reserved IP **cannot** be
+  integrated. Put the broker behind a public HTTPS hostname (the proxy forces
+  `https://`).
+
+- **Use `POST`, not `GET`, for broker capabilities.** Two things make `GET`
+  capabilities unusable for a credential-injected broker call under production
+  request-signing:
+  1. a `GET` (or `HEAD`) capability does **not** forward a request body — the
+     invoke path omits the body for those verbs, so a render payload in `body`
+     never reaches the broker;
+  2. more importantly, when the proxy runs with request signing enabled
+     (`STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE=true`, the production posture), it
+     requires an `Idempotency-Key` header on **any signed request — including safe
+     `GET` methods**. The proxy client does not auto-attach an idempotency key on
+     `GET`, and the invoke path supplies none, so a **signed `GET` capability
+     invoke fails closed with a `400` before it ever forwards** (`Idempotency-Key
+     header is required for signed proxy requests`).
+
+  `POST` both carries the request body and receives an auto-attached idempotency
+  key, so a `POST` capability works end to end. Do not work around the `GET` block
+  by smuggling the payload into `query` (query strings can reflect into upstream
+  responses and are not the injection surface). Model every broker capability as
+  `POST`. This limitation is pinned by a test in
+  `session-broker-e2e.test.ts`.
+
+- **Responses are capped at 25 MiB** (`STEWARD_PROXY_RESPONSE_BYTES`). This
+  comfortably fits screenshot / rendered-image payloads. Raise it only if a broker
+  legitimately returns larger bodies. The proxy buffers the response for its
+  reflection scan (an `includes()` check that the injected credential did not leak
+  back), so very large bodies cost proportional memory.
+
+- **Raise the upstream timeout for render brokers.** The default is 30s
+  (`STEWARD_PROXY_UPSTREAM_TIMEOUT_MS`). Headless rendering can exceed that; a
+  value like `120000` (120s) avoids premature upstream aborts.
+
+- **Injection is header-only.** `injectAs` supports `header` and nothing else, and
+  framing / hop-by-hop headers (`host`, `content-length`, `transfer-encoding`, …)
+  cannot be the injection key.
+
+## Zero-code claim
+
+Everything above is **configuration**: environment variables, secrets, a
+capability, a grant, and a policy rule. No Steward product code is modified to
+integrate a session broker. The one honest caveat is the **signed-`GET`
+limitation** above — a `GET` capability is not usable for a credential-injected
+broker call under production request-signing (it fails closed with a `400` for the
+missing idempotency key, and would not forward a body regardless), so a broker
+integration must be modeled as `POST`. That is a design boundary of the invoke +
+proxy request-signing path, not something the runbook works around.
+
+## See also
+
+- [Managing Secrets](/guides/secrets) — the secret + route primitives this builds on.
+- [Policies](/guides/policies) — the policy engine and rule-set semantics.
+- [Setting Up an Agent](/guides/agent-setup) — creating the agent and minting its token.

--- a/packages/plugin-capabilities/src/__tests__/session-broker-e2e.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/session-broker-e2e.test.ts
@@ -1,0 +1,426 @@
+/**
+ * session-broker-e2e.test.ts - the session-broker integration arc, in-process:
+ *
+ *   agent -> invoke route -> policy default-deny -> @stwd/proxy-client ->
+ *   REAL @stwd/proxy (auth + route-match + decrypt + inject + scrub) -> stub broker
+ *
+ * This is the runbook's executable proof (steward#157). It mirrors invoke-e2e.test.ts
+ * but models a SESSION BROKER capability (`broker.session.render`) instead of the
+ * GitHub example, and asserts the properties the runbook promises:
+ *
+ *   1. an ALLOWED POST invoke forwards to the broker with the stored broker token
+ *      injected as `Authorization: Bearer <token>`, returns the broker's JSON body
+ *      passthrough, the token is NEVER visible to the agent caller, and an
+ *      invocation row (decision=allow) is recorded.
+ *   2. a FAT base64 body (a rendered-screenshot-shaped payload) passes through
+ *      intact and under the 25 MiB response cap.
+ *   3. deny-by-default: an ungranted capability => 403, never forwards.
+ *   4. an explicit `effect: "deny"` policy rule => 403, never forwards.
+ *   5. the GET-signed limitation: a GET capability does NOT forward a request
+ *      body (the invoke path omits it for GET/HEAD), which is why the runbook
+ *      says "use POST for body-carrying broker calls".
+ *
+ * The SSRF guard is prod defense with NO disable flag, so the broker cannot be a
+ * localhost mock. We use the shipped in-process test hooks
+ * (`__setResolveProxyHostForTests` + `__setForwardProxyRequestForTests`) plus a
+ * public-DNS-shaped hostname (`broker.cap-e2e.test`, which passes the string-level
+ * host guard) — exactly the escape hatch the shipped invoke-e2e uses.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, setDefaultTimeout } from "bun:test";
+import { fileURLToPath } from "node:url";
+import { agents, closeDb, eq, getDb, runPluginMigrations, tenants } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import type { AppVariables, PolicyRule } from "@stwd/shared";
+import { SecretVault } from "@stwd/vault";
+import { migrate as pgliteMigrate } from "drizzle-orm/pglite/migrator";
+import { Hono } from "hono";
+import type { StewardAppContext } from "../context";
+import { createInvokeRoutes } from "../invoke";
+import { capabilityInvocations } from "../schema";
+import { CapabilityStore } from "../store";
+
+setDefaultTimeout(30000);
+
+const MASTER_PASSWORD = "broker-e2e-master-password-with-enough-bytes";
+const SIGNING_SECRET = "broker-e2e-signing-secret-with-enough-bytes-0123";
+// a scoped broker token — the credential the broker expects in Authorization.
+const BROKER_TOKEN = "brk_live_e2e_do_not_use_0123456789abcdef";
+const PROXY_URL = "https://proxy.broker-e2e.test";
+// public-DNS-shaped host: passes the proxy's string-level SSRF guard (has a dot,
+// not localhost/.local/.internal, in the allowlist below). The DNS-level guard is
+// short-circuited by __setResolveProxyHostForTests to a fixed public IP.
+const BROKER_HOST = "broker.cap-e2e.test";
+const CAP_NAME = "broker.session.render";
+const MIGRATIONS_FOLDER = fileURLToPath(new URL("../../drizzle", import.meta.url));
+
+let authMiddleware: typeof import("@stwd/proxy/src/middleware/auth")["authMiddleware"];
+let handleProxy: typeof import("@stwd/proxy/src/handlers/proxy")["handleProxy"];
+let setForwardProxyRequestForTests: typeof import("@stwd/proxy/src/handlers/proxy")["__setForwardProxyRequestForTests"];
+let setResolveProxyHostForTests: typeof import("@stwd/proxy/src/handlers/proxy")["__setResolveProxyHostForTests"];
+
+interface ForwardedCapture {
+  url: string;
+  method: string;
+  headers: Headers;
+  body: string | null;
+}
+let lastForwarded: ForwardedCapture | null = null;
+// the broker's next response body (a test may seed a fat body).
+let brokerResponseBody: string = JSON.stringify({ ok: true, rendered: "small" });
+let proxyApp: Hono | null = null;
+const realFetch = globalThis.fetch;
+
+// the policy set the injected getPolicySet returns for the current test.
+let currentPolicySet: PolicyRule[] = [];
+
+function capRule(
+  id: string,
+  effect: "allow" | "deny" | "require-approval",
+  constraints?: Record<string, unknown>,
+): PolicyRule {
+  return {
+    id,
+    type: "capability-intent" as unknown as PolicyRule["type"],
+    enabled: true,
+    config: {
+      capabilities: [CAP_NAME],
+      effect,
+      ...(constraints ? { constraints } : {}),
+    },
+  };
+}
+
+beforeAll(async () => {
+  process.env.STEWARD_PGLITE_MEMORY = "true";
+  process.env.STEWARD_MASTER_PASSWORD = MASTER_PASSWORD;
+  process.env.STEWARD_JWT_SECRET = "broker-e2e-jwt-secret-with-enough-bytes-0123456789ab";
+  process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE = "true";
+  process.env.STEWARD_PROXY_REQUEST_SIGNING_SECRET = SIGNING_SECRET;
+  // the broker host must be in the proxy allowlist (SSRF layer 1) AND the
+  // secret-route host allowlist (so a credential may be injected on it).
+  process.env.STEWARD_PROXY_ALLOWED_HOSTS = BROKER_HOST;
+  process.env.STEWARD_SECRET_ROUTE_ALLOWED_HOSTS = BROKER_HOST;
+  process.env.STEWARD_PROXY_URL = PROXY_URL;
+
+  const { db, client } = await createPGLiteDb("memory://");
+  setPGLiteOverride(db, async () => {
+    await client.close();
+  });
+  await runPluginMigrations(
+    { id: "capabilities", migrationsFolder: MIGRATIONS_FOLDER },
+    { db, client, useAdvisoryLock: false, migrateFn: pgliteMigrate as never },
+  );
+
+  ({ authMiddleware } = await import("@stwd/proxy/src/middleware/auth"));
+  ({
+    handleProxy,
+    __setForwardProxyRequestForTests: setForwardProxyRequestForTests,
+    __setResolveProxyHostForTests: setResolveProxyHostForTests,
+  } = await import("@stwd/proxy/src/handlers/proxy"));
+
+  // deterministic public ip so the DNS-level SSRF guard passes with no network.
+  setResolveProxyHostForTests(async () => [{ address: "93.184.216.34", family: 4 }]);
+  // the stub broker: capture the forwarded request (to assert the injected token +
+  // that the agent body reached the broker), return the seeded JSON body. The
+  // forwarder signature is (url, method, headers, body: ReadableStream|null,
+  // records); we drain the stream to a string to assert body passthrough.
+  setForwardProxyRequestForTests(async (url, method, headers, body) => {
+    let capturedBody: string | null = null;
+    if (body != null) {
+      capturedBody = await new Response(body as ReadableStream<Uint8Array>).text();
+    }
+    lastForwarded = { url: url.toString(), method, headers, body: capturedBody };
+    return new Response(brokerResponseBody, {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  });
+
+  proxyApp = new Hono();
+  proxyApp.use("*", authMiddleware);
+  proxyApp.all("*", handleProxy);
+
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url =
+      typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    if (url.startsWith(PROXY_URL) && proxyApp) {
+      const path = url.slice(PROXY_URL.length) || "/";
+      return proxyApp.request(path, init as RequestInit);
+    }
+    return realFetch(input as RequestInfo, init);
+  }) as typeof fetch;
+});
+
+afterAll(async () => {
+  globalThis.fetch = realFetch;
+  await closeDb().catch(() => {});
+  delete process.env.STEWARD_PGLITE_MEMORY;
+  delete process.env.STEWARD_MASTER_PASSWORD;
+  delete process.env.STEWARD_JWT_SECRET;
+  delete process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE;
+  delete process.env.STEWARD_PROXY_REQUEST_SIGNING_SECRET;
+  delete process.env.STEWARD_PROXY_ALLOWED_HOSTS;
+  delete process.env.STEWARD_SECRET_ROUTE_ALLOWED_HOSTS;
+  delete process.env.STEWARD_PROXY_URL;
+});
+
+let tenantId: string;
+let agentId: string;
+
+async function seedTenantAgent(): Promise<void> {
+  tenantId = `tenant-broker-e2e-${crypto.randomUUID()}`;
+  agentId = `agent-broker-e2e-${crypto.randomUUID()}`;
+  await getDb()
+    .insert(tenants)
+    .values({ id: tenantId, name: tenantId, apiKeyHash: `hash-${tenantId}` });
+  await getDb()
+    .insert(agents)
+    .values({ id: agentId, tenantId, name: agentId, walletAddress: `0x${"3".repeat(40)}` });
+}
+
+/**
+ * Seed the broker capability + a grant for the agent. `method` defaults to POST
+ * (the runbook's recommended verb); the GET-limitation test overrides it.
+ */
+async function seedBrokerCapability(method: "POST" | "GET" = "POST"): Promise<string> {
+  const vault = new SecretVault(MASTER_PASSWORD);
+  const secret = await vault.createSecret(tenantId, "session-broker-token", BROKER_TOKEN);
+  const store = new CapabilityStore(getDb());
+  const cap = await store.createCapability({
+    tenantId,
+    name: CAP_NAME,
+    spec: {
+      secretId: secret.id,
+      host: BROKER_HOST,
+      pathPattern: "/render",
+      method,
+      injectAs: "header",
+      injectKey: "authorization",
+      injectFormat: "Bearer {value}",
+    },
+    constraints: {},
+    enabled: true,
+  });
+  await store.createGrant({ tenantId, capabilityId: cap.id, agentId, expiresAt: null });
+  return cap.id;
+}
+
+function buildCtx(): StewardAppContext {
+  return {
+    db: getDb(),
+    vault: {} as never,
+    policyEngine: {} as never,
+    priceOracle: {} as never,
+    async ensureAgentForTenant() {
+      return undefined;
+    },
+    async getPolicySet() {
+      return currentPolicySet;
+    },
+    async safeJsonParse<T>(c: { req: { json(): Promise<unknown> } }): Promise<T | null> {
+      try {
+        return (await c.req.json()) as T;
+      } catch {
+        return null;
+      }
+    },
+    isValidAnyAddress() {
+      return false;
+    },
+    async writeAuditEvent() {},
+    async getAgentTokenStatus() {
+      return null;
+    },
+    getRedisClient() {
+      return null;
+    },
+    async requireAgentJwt() {},
+    async operatorAuth() {},
+    async tenantAuth() {},
+  } as unknown as StewardAppContext;
+}
+
+function buildInvokeApp(): Hono<{ Variables: AppVariables }> {
+  const app = new Hono<{ Variables: AppVariables }>();
+  app.use("*", async (c, next) => {
+    c.set("tenantId", tenantId);
+    c.set("agentScope", agentId);
+    c.set("authType", "agent-token" as never);
+    await next();
+  });
+  app.route("/capabilities", createInvokeRoutes(buildCtx()));
+  return app;
+}
+
+async function agentInvocations(capabilityId: string) {
+  const rows = await getDb()
+    .select()
+    .from(capabilityInvocations)
+    .where(eq(capabilityInvocations.agentId, agentId));
+  return rows.filter((r: { capabilityId: string | null }) => r.capabilityId === capabilityId);
+}
+
+beforeEach(async () => {
+  await seedTenantAgent();
+  currentPolicySet = [];
+  lastForwarded = null;
+  brokerResponseBody = JSON.stringify({ ok: true, rendered: "small" });
+});
+
+describe("session-broker e2e: full arc through the real proxy", () => {
+  it("allowed POST invoke injects the broker token, passes the JSON body through, token never seen by agent, records allow", async () => {
+    const capId = await seedBrokerCapability("POST");
+    currentPolicySet = [capRule("r1", "allow", { argEquals: { sessionId: "sess_123" } })];
+    const app = buildInvokeApp();
+
+    const res = await app.request(`/capabilities/${CAP_NAME}/invoke`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        args: { sessionId: "sess_123" },
+        body: { url: "https://example.com/dashboard", format: "png" },
+      }),
+    });
+
+    // broker 200 passed through verbatim.
+    expect(res.status).toBe(200);
+    const passthrough = await res.text();
+    const parsed = JSON.parse(passthrough) as { ok: boolean; rendered: string };
+    expect(parsed.ok).toBe(true);
+    // the broker token NEVER appears in the agent-facing passthrough.
+    expect(passthrough).not.toContain(BROKER_TOKEN);
+
+    // the proxy forwarded to the real broker URL with the token injected + the
+    // agent's request body carried through.
+    expect(lastForwarded).not.toBeNull();
+    expect(lastForwarded?.method).toBe("POST");
+    expect(lastForwarded?.url).toBe(`https://${BROKER_HOST}/render`);
+    expect(lastForwarded?.headers.get("authorization")).toBe(`Bearer ${BROKER_TOKEN}`);
+    expect(lastForwarded?.body ?? "").toContain("example.com/dashboard");
+
+    // one durable allow audit row.
+    const rows = await agentInvocations(capId);
+    expect(rows.length).toBe(1);
+    expect(rows[0].decision).toBe("allow");
+  });
+
+  it("fat base64 body passes through intact and under the 25 MiB cap", async () => {
+    const capId = await seedBrokerCapability("POST");
+    // ~1.5 MiB of base64 (a rendered-screenshot-shaped payload). Well under the
+    // 25 MiB cap; asserts the buffered passthrough handles a fat body.
+    const fatB64 = Buffer.alloc(1_500_000, 0x41).toString("base64");
+    brokerResponseBody = JSON.stringify({ ok: true, format: "png", data: fatB64 });
+    currentPolicySet = [capRule("r1", "allow")];
+    const app = buildInvokeApp();
+
+    const res = await app.request(`/capabilities/${CAP_NAME}/invoke`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ body: { url: "https://example.com", format: "png" } }),
+    });
+
+    expect(res.status).toBe(200);
+    const passthrough = await res.text();
+    const parsed = JSON.parse(passthrough) as { ok: boolean; data: string };
+    // the fat body survived the round trip byte-for-byte.
+    expect(parsed.data).toBe(fatB64);
+    expect(parsed.data.length).toBeGreaterThan(1_000_000);
+    // and still no token leak in a large body (the reflection scan holds).
+    expect(passthrough).not.toContain(BROKER_TOKEN);
+
+    const rows = await agentInvocations(capId);
+    expect(rows.filter((r) => r.decision === "allow").length).toBe(1);
+  });
+
+  it("deny-by-default: ungranted capability => 403, never forwards", async () => {
+    // seed a capability + secret but NO grant for this agent.
+    const vault = new SecretVault(MASTER_PASSWORD);
+    const secret = await vault.createSecret(tenantId, "session-broker-token-2", BROKER_TOKEN);
+    const store = new CapabilityStore(getDb());
+    await store.createCapability({
+      tenantId,
+      name: CAP_NAME,
+      spec: {
+        secretId: secret.id,
+        host: BROKER_HOST,
+        pathPattern: "/render",
+        method: "POST",
+        injectAs: "header",
+        injectKey: "authorization",
+        injectFormat: "Bearer {value}",
+      },
+      constraints: {},
+      enabled: true,
+    });
+    // even with an allow policy present, the missing grant => deny.
+    currentPolicySet = [capRule("r1", "allow")];
+    const app = buildInvokeApp();
+    const res = await app.request(`/capabilities/${CAP_NAME}/invoke`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ body: { url: "https://example.com" } }),
+    });
+    expect(res.status).toBe(403);
+    // no credential was ever attached because we never reached the proxy.
+    expect(lastForwarded).toBeNull();
+  });
+
+  it("explicit deny policy => 403, never forwards", async () => {
+    const capId = await seedBrokerCapability("POST");
+    // grant is present, but a matched deny rule short-circuits.
+    currentPolicySet = [capRule("r1", "deny")];
+    const app = buildInvokeApp();
+    const res = await app.request(`/capabilities/${CAP_NAME}/invoke`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ body: { url: "https://example.com" } }),
+    });
+    expect(res.status).toBe(403);
+    expect(lastForwarded).toBeNull();
+
+    const rows = await agentInvocations(capId);
+    expect(rows.length).toBe(1);
+    expect(rows[0].decision).toBe("deny");
+  });
+
+  it("documents the GET-signed limitation: a signed GET capability invoke is BLOCKED (400) under production request-signing", async () => {
+    // The runbook's honest caveat, proven. TWO things conspire against a GET
+    // capability when the proxy runs with request signing enabled (production,
+    // STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE=true, set in beforeAll):
+    //
+    //   1. the invoke path computes
+    //        hasBody = method !== "GET" && method !== "HEAD" && body !== undefined,
+    //      so a GET capability NEVER forwards a request body -- a broker needing a
+    //      render payload in the body could not receive it via GET anyway.
+    //   2. MORE IMPORTANTLY: the proxy requires an `Idempotency-Key` header for
+    //      ANY *signed* request -- including safe/GET methods (proxy.ts
+    //      claimUnsafeProxyRequest: `signedRequest` forces the key even for
+    //      SAFE_PROXY_METHODS). But StewardProxyClient does NOT auto-attach an
+    //      idempotency key on GET, and the invoke path supplies none. So a signed
+    //      GET capability invoke fails CLOSED with a 400 before it ever forwards.
+    //
+    // Net: under production request-signing, a GET capability is not usable for a
+    // credential-injected broker call. USE POST (which carries the body AND gets
+    // an auto-attached idempotency key). This test pins that behavior so a future
+    // change that silently "fixes" GET must update the runbook.
+    await seedBrokerCapability("GET");
+    currentPolicySet = [capRule("r1", "allow")];
+    const app = buildInvokeApp();
+
+    const res = await app.request(`/capabilities/${CAP_NAME}/invoke`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ body: { url: "https://example.com/dashboard", format: "png" } }),
+    });
+
+    // policy authorized the invoke, but the proxy rejected the signed GET for the
+    // missing idempotency key. The invoke path forwards the upstream/proxy status
+    // verbatim. The request NEVER reached the broker.
+    expect(res.status).toBe(400);
+    const bodyText = await res.text();
+    expect(bodyText).toContain("Idempotency-Key");
+    // the broker was never called: no credential was ever attached/forwarded.
+    expect(lastForwarded).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes the Phase 1 deliverable for #157: a **config-only** path to give an agent scoped, credential-injected access to an third-party session broker, plus an in-process e2e harness that proves it end to end.

## What's here

**1. `docs/guides/session-broker-integration.mdx`** — vendor-neutral runbook
- Store the broker's scoped token as an encrypted vault **secret** (agent never sees it).
- Register a **secret_route** for `Authorization: Bearer {value}` injection at the proxy.
- Env: `STEWARD_PROXY_ALLOWED_HOSTS`, `STEWARD_SECRET_ROUTE_ALLOWED_HOSTS`, `STEWARD_PROXY_UPSTREAM_TIMEOUT_MS` (~120000 for render brokers).
- Create **capability + grant + allow policy** (deny-by-default), invoke via `POST /capabilities/:name/invoke`.
- **Constraints** grounded in the real code: broker must be public HTTPS on 443 (the proxy's two-layer SSRF guard rejects localhost/LAN/private-IP and has no disable flag); 25 MiB response cap; the signed-`GET` limitation (a signed GET capability fails closed on the missing `Idempotency-Key`, and GET omits the body) → model every broker capability as `POST`; header-only injection.
- Links teleport-computer/oauth3-server once as a reference impl.

**2. `packages/plugin-capabilities/src/__tests__/session-broker-e2e.test.ts`** — in-process harness
Mirrors `invoke-e2e.test.ts`: agent → invoke route → policy default-deny → `@stwd/proxy-client` → the **real** `@stwd/proxy` (auth + route-match + decrypt + inject + scrub) → stub broker. Uses the shipped `__setResolveProxyHostForTests` / `__setForwardProxyRequestForTests` hooks + a public-DNS-shaped `*.test` host (the SSRF guard has no disable flag, so no localhost mock is possible).

Asserts:
- allowed `POST` injects the broker bearer, passes the JSON body through, token **never** visible to the agent, one `allow` audit row;
- a ~1.5 MiB base64 body survives the buffered passthrough under the 25 MiB cap with no token reflection;
- deny-by-default (ungranted → `403`, never forwards);
- explicit `deny` policy → `403`;
- pins the signed-`GET` limitation (signed GET capability invoke → `400` on missing `Idempotency-Key`, never forwards).

## Zero-code claim
No Steward product code is modified. Everything is configuration (env + secret + capability + grant + policy) plus a new docs page and a new additive test file. The one honest caveat, documented and pinned by a test, is the signed-`GET` limitation → broker capabilities must be `POST`.

## Test status
- `session-broker-e2e.test.ts`: **5/5 pass**.
- The 2 `invoke-e2e` failures that surface only in a full-suite run are pre-existing cross-file test pollution (a vault AES-GCM "Unsupported state" race under parallel e2e files); `invoke-e2e` passes **5/5 in isolation**, and this PR is purely additive (a new docs file + a new test file), so it does not touch that path.

Refs #157.