### PR TITLE
feat(capabilities): OpenAI-compatible capability adapter (chat/completions + models) with policy gating (#150)

### DIFF
--- a/packages/plugin-capabilities/src/__tests__/invoke-e2e.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/invoke-e2e.test.ts
@@ -447,6 +447,42 @@ describe("OpenAI-compatible capability adapter", () => {
     expect(rows[0].decision).toBe("allow");
   });
 
+  it("stream:true is rejected at the adapter with an OpenAI-error (proxy blocks streaming after credential injection)", async () => {
+    const capId = await seedOpenAIChatCapability();
+    currentPolicySet = [capRule("r-openai", "allow", undefined, ["openai.chat"])];
+    const app = buildInvokeApp();
+
+    const res = await app.request("/capabilities/openai.chat/openai/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${STEWARD_TOKEN_SENTINEL}`,
+      },
+      body: JSON.stringify({
+        model: "gpt-test",
+        stream: true,
+        messages: [{ role: "user", content: "ping" }],
+      }),
+    });
+
+    // The credential-injection proxy fails closed on streaming responses; the
+    // adapter rejects stream:true up front with a clean, SDK-parseable error and
+    // never forwards.
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as {
+      error?: { message?: string; type?: string };
+      ok?: boolean;
+    };
+    expect(body.ok).toBeUndefined();
+    expect(body.error?.type).toBe("invalid_request_error");
+    expect(body.error?.message).toContain("streaming");
+    expect(lastForwarded).toBeNull();
+
+    // no invocation recorded: the guard runs before the policy/proxy path.
+    const rows = await agentInvocations(capId);
+    expect(rows.length).toBe(0);
+  });
+
   it("missing grant => 403 and no proxy forward", async () => {
     await seedOpenAIChatCapability({ grant: false });
     currentPolicySet = [capRule("r-openai", "allow", undefined, ["openai.chat"])];

--- a/packages/plugin-capabilities/src/__tests__/invoke-e2e.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/invoke-e2e.test.ts
@@ -460,7 +460,7 @@ describe("OpenAI-compatible capability adapter", () => {
     expect(lastForwarded).toBeNull();
   });
 
-  it("no matching allow => 403 default-deny", async () => {
+  it("no matching allow => 403 default-deny in OpenAI-error shape", async () => {
     await seedOpenAIChatCapability();
     currentPolicySet = [];
     const app = buildInvokeApp();
@@ -470,6 +470,32 @@ describe("OpenAI-compatible capability adapter", () => {
       body: JSON.stringify({ model: "gpt-test", messages: [] }),
     });
     expect(res.status).toBe(403);
+    expect(lastForwarded).toBeNull();
+    // OpenAI-SDK-parseable error shape (not the Steward {ok:false} wrapper).
+    const body = (await res.json()) as {
+      error?: { message?: string; type?: string };
+      ok?: boolean;
+    };
+    expect(body.ok).toBeUndefined();
+    expect(typeof body.error?.message).toBe("string");
+    expect(body.error?.type).toBe("permission_error");
+    // the internal gate marker must not leak to the client.
+    expect(res.headers.get("x-steward-cap-gate")).toBeNull();
+  });
+
+  it("unauthenticated adapter request => 401 in OpenAI-error shape", async () => {
+    await seedOpenAIChatCapability();
+    currentPolicySet = [capRule("r-openai", "allow", undefined, ["openai.chat"])];
+    const app = buildInvokeApp(false);
+    const res = await app.request("/capabilities/openai.chat/openai/v1/chat/completions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ model: "gpt-test", messages: [] }),
+    });
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error?: { message?: string; type?: string } };
+    expect(typeof body.error?.message).toBe("string");
+    expect(body.error?.type).toBe("invalid_request_error");
     expect(lastForwarded).toBeNull();
   });
 

--- a/packages/plugin-capabilities/src/__tests__/invoke-e2e.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/invoke-e2e.test.ts
@@ -447,6 +447,34 @@ describe("OpenAI-compatible capability adapter", () => {
     expect(rows[0].decision).toBe("allow");
   });
 
+  it("argEquals on model gates the adapter: matching model allowed, other model denied", async () => {
+    const capId = await seedOpenAIChatCapability();
+    currentPolicySet = [
+      capRule("r-openai", "allow", { argEquals: { model: "gpt-allowed" } }, ["openai.chat"]),
+    ];
+    const app = buildInvokeApp();
+
+    const okRes = await app.request("/capabilities/openai.chat/openai/v1/chat/completions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ model: "gpt-allowed", messages: [{ role: "user", content: "hi" }] }),
+    });
+    expect(okRes.status).toBe(200);
+
+    const denyRes = await app.request("/capabilities/openai.chat/openai/v1/chat/completions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ model: "gpt-forbidden", messages: [{ role: "user", content: "hi" }] }),
+    });
+    expect(denyRes.status).toBe(403);
+    const denyBody = (await denyRes.json()) as { error?: { type?: string } };
+    expect(denyBody.error?.type).toBe("permission_error");
+
+    const rows = await agentInvocations(capId);
+    expect(rows.filter((r) => r.decision === "allow").length).toBe(1);
+    expect(rows.filter((r) => r.decision === "deny").length).toBe(1);
+  });
+
   it("stream:true is rejected at the adapter with an OpenAI-error (proxy blocks streaming after credential injection)", async () => {
     const capId = await seedOpenAIChatCapability();
     currentPolicySet = [capRule("r-openai", "allow", undefined, ["openai.chat"])];

--- a/packages/plugin-capabilities/src/__tests__/invoke-e2e.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/invoke-e2e.test.ts
@@ -41,6 +41,8 @@ setDefaultTimeout(30000);
 const MASTER_PASSWORD = "cap-invoke-e2e-master-password";
 const SIGNING_SECRET = "cap-invoke-e2e-signing-secret-with-enough-bytes";
 const FAKE_PAT = "ghp_test_e2e_do_not_use_0123456789abcdef";
+const FAKE_OPENAI_KEY = "sk-test-openai-e2e-do-not-use-0123456789abcdef";
+const STEWARD_TOKEN_SENTINEL = "steward-agent-token-sentinel-never-upstream";
 const PROXY_URL = "https://proxy.cap-e2e.test";
 const MIGRATIONS_FOLDER = fileURLToPath(new URL("../../drizzle", import.meta.url));
 
@@ -53,6 +55,7 @@ interface ForwardedCapture {
   url: string;
   method: string;
   headers: Headers;
+  bodyText: string | null;
 }
 let lastForwarded: ForwardedCapture | null = null;
 let proxyApp: Hono | null = null;
@@ -65,13 +68,14 @@ function capRule(
   id: string,
   effect: "allow" | "deny" | "require-approval",
   constraints?: Record<string, unknown>,
+  capabilities: string[] = ["github.pr.comment"],
 ): PolicyRule {
   return {
     id,
     type: "capability-intent" as unknown as PolicyRule["type"],
     enabled: true,
     config: {
-      capabilities: ["github.pr.comment"],
+      capabilities,
       effect,
       ...(constraints ? { constraints } : {}),
     },
@@ -84,7 +88,7 @@ beforeAll(async () => {
   process.env.STEWARD_JWT_SECRET = "cap-invoke-e2e-jwt-secret-with-enough-bytes-0123456789";
   process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE = "true";
   process.env.STEWARD_PROXY_REQUEST_SIGNING_SECRET = SIGNING_SECRET;
-  process.env.STEWARD_PROXY_ALLOWED_HOSTS = "api.github.com";
+  process.env.STEWARD_PROXY_ALLOWED_HOSTS = "api.github.com,api.openai.com";
   // the invoke route reads these to build its proxy client (fail-closed if absent).
   process.env.STEWARD_PROXY_URL = PROXY_URL;
 
@@ -108,8 +112,21 @@ beforeAll(async () => {
   // deterministic public ip so route-match -> decrypt -> inject -> forward runs
   // with no external network (mirrors the #149 e2e).
   setResolveProxyHostForTests(async () => [{ address: "93.184.216.34", family: 4 }]);
-  setForwardProxyRequestForTests(async (url, method, headers) => {
-    lastForwarded = { url: url.toString(), method, headers };
+  setForwardProxyRequestForTests(async (url, method, headers, body) => {
+    const bodyText = body ? await new Response(body).text() : null;
+    lastForwarded = { url: url.toString(), method, headers, bodyText };
+    if (url.hostname === "api.openai.com") {
+      return new Response(
+        JSON.stringify({
+          id: "chatcmpl-test",
+          object: "chat.completion",
+          choices: [
+            { index: 0, message: { role: "assistant", content: "ok" }, finish_reason: "stop" },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
     return new Response(JSON.stringify({ id: 12345, body: "ok" }), {
       status: 201,
       headers: { "content-type": "application/json" },
@@ -220,16 +237,43 @@ function buildCtx(): StewardAppContext {
 }
 
 /** the invoke app (test mw stamps the agent-token context). */
-function buildInvokeApp(): Hono<{ Variables: AppVariables }> {
+function buildInvokeApp(auth = true): Hono<{ Variables: AppVariables }> {
   const app = new Hono<{ Variables: AppVariables }>();
   app.use("*", async (c, next) => {
-    c.set("tenantId", tenantId);
-    c.set("agentScope", agentId);
-    c.set("authType", "agent-token" as never);
+    if (auth) {
+      c.set("tenantId", tenantId);
+      c.set("agentScope", agentId);
+      c.set("authType", "agent-token" as never);
+    }
     await next();
   });
   app.route("/capabilities", createInvokeRoutes(buildCtx()));
   return app;
+}
+
+async function seedOpenAIChatCapability(opts?: { grant?: boolean }): Promise<string> {
+  const vault = new SecretVault(MASTER_PASSWORD);
+  const secret = await vault.createSecret(tenantId, "openai-key", FAKE_OPENAI_KEY);
+  const store = new CapabilityStore(getDb());
+  const cap = await store.createCapability({
+    tenantId,
+    name: "openai.chat",
+    spec: {
+      secretId: secret.id,
+      host: "api.openai.com",
+      pathPattern: "/v1/chat/completions",
+      method: "POST",
+      injectAs: "header",
+      injectKey: "authorization",
+      injectFormat: "Bearer {value}",
+    },
+    constraints: {},
+    enabled: true,
+  });
+  if (opts?.grant !== false) {
+    await store.createGrant({ tenantId, capabilityId: cap.id, agentId, expiresAt: null });
+  }
+  return cap.id;
 }
 
 async function agentInvocations(capabilityId: string) {
@@ -364,5 +408,138 @@ describe("invoke e2e: full arc through the real proxy", () => {
     const rows = await agentInvocations(capId);
     expect(rows.filter((r) => r.decision === "allow").length).toBe(1);
     expect(rows.filter((r) => r.decision === "deny").length).toBe(1);
+  });
+});
+
+describe("OpenAI-compatible capability adapter", () => {
+  it("chat completions forwards via proxy and returns upstream JSON directly", async () => {
+    const capId = await seedOpenAIChatCapability();
+    currentPolicySet = [capRule("r-openai", "allow", undefined, ["openai.chat"])];
+    const app = buildInvokeApp();
+
+    const res = await app.request("/capabilities/openai.chat/openai/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${STEWARD_TOKEN_SENTINEL}`,
+      },
+      body: JSON.stringify({
+        model: "gpt-test",
+        messages: [{ role: "user", content: "ping" }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { id: string; object: string; ok?: boolean };
+    expect(body.id).toBe("chatcmpl-test");
+    expect(body.object).toBe("chat.completion");
+    expect(body.ok).toBeUndefined();
+
+    expect(lastForwarded).not.toBeNull();
+    expect(lastForwarded?.url).toBe("https://api.openai.com/v1/chat/completions");
+    expect(lastForwarded?.method).toBe("POST");
+    expect(lastForwarded?.headers.get("authorization")).toBe(`Bearer ${FAKE_OPENAI_KEY}`);
+    expect(lastForwarded?.headers.get("authorization")).not.toContain(STEWARD_TOKEN_SENTINEL);
+    expect(lastForwarded?.bodyText).toContain("gpt-test");
+
+    const rows = await agentInvocations(capId);
+    expect(rows.length).toBe(1);
+    expect(rows[0].decision).toBe("allow");
+  });
+
+  it("missing grant => 403 and no proxy forward", async () => {
+    await seedOpenAIChatCapability({ grant: false });
+    currentPolicySet = [capRule("r-openai", "allow", undefined, ["openai.chat"])];
+    const app = buildInvokeApp();
+    const res = await app.request("/capabilities/openai.chat/openai/v1/chat/completions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ model: "gpt-test", messages: [] }),
+    });
+    expect(res.status).toBe(403);
+    expect(lastForwarded).toBeNull();
+  });
+
+  it("no matching allow => 403 default-deny", async () => {
+    await seedOpenAIChatCapability();
+    currentPolicySet = [];
+    const app = buildInvokeApp();
+    const res = await app.request("/capabilities/openai.chat/openai/v1/chat/completions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ model: "gpt-test", messages: [] }),
+    });
+    expect(res.status).toBe(403);
+    expect(lastForwarded).toBeNull();
+  });
+
+  it("require-approval => 202 and no proxy forward", async () => {
+    const capId = await seedOpenAIChatCapability();
+    currentPolicySet = [capRule("r-openai", "require-approval", undefined, ["openai.chat"])];
+    const app = buildInvokeApp();
+    const res = await app.request("/capabilities/openai.chat/openai/v1/chat/completions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ model: "gpt-test", messages: [] }),
+    });
+    expect(res.status).toBe(202);
+    expect(lastForwarded).toBeNull();
+    const rows = await agentInvocations(capId);
+    expect(rows.length).toBe(1);
+    expect(rows[0].decision).toBe("approval");
+  });
+
+  it("maxCallsPerHour=1 denies the second adapter request", async () => {
+    const capId = await seedOpenAIChatCapability();
+    currentPolicySet = [capRule("r-openai", "allow", { maxCallsPerHour: 1 }, ["openai.chat"])];
+    const app = buildInvokeApp();
+
+    const first = await app.request("/capabilities/openai.chat/openai/v1/chat/completions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ model: "gpt-test", messages: [{ role: "user", content: "one" }] }),
+    });
+    expect(first.status).toBe(200);
+
+    const second = await app.request("/capabilities/openai.chat/openai/v1/chat/completions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ model: "gpt-test", messages: [{ role: "user", content: "two" }] }),
+    });
+    expect(second.status).toBe(403);
+
+    const rows = await agentInvocations(capId);
+    expect(rows.filter((r) => r.decision === "allow").length).toBe(1);
+    expect(rows.filter((r) => r.decision === "deny").length).toBe(1);
+  });
+
+  it("models list requires agent auth + active grant and does not use proxy env or secret", async () => {
+    await seedOpenAIChatCapability();
+    const originalProxyUrl = process.env.STEWARD_PROXY_URL;
+    delete process.env.STEWARD_PROXY_URL;
+    try {
+      const authed = buildInvokeApp();
+      const res = await authed.request("/capabilities/openai.chat/openai/v1/models", {
+        method: "GET",
+      });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ object: "list", data: [] });
+      expect(lastForwarded).toBeNull();
+
+      const unauthed = buildInvokeApp(false);
+      const noAuth = await unauthed.request("/capabilities/openai.chat/openai/v1/models", {
+        method: "GET",
+      });
+      expect(noAuth.status).toBe(401);
+    } finally {
+      process.env.STEWARD_PROXY_URL = originalProxyUrl;
+    }
+  });
+
+  it("models list fails closed without an active grant", async () => {
+    await seedOpenAIChatCapability({ grant: false });
+    const app = buildInvokeApp();
+    const res = await app.request("/capabilities/openai.chat/openai/v1/models", { method: "GET" });
+    expect(res.status).toBe(403);
   });
 });

--- a/packages/plugin-capabilities/src/__tests__/invoke-e2e.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/invoke-e2e.test.ts
@@ -330,6 +330,8 @@ describe("invoke e2e: full arc through the real proxy", () => {
     });
     expect(res.status).toBe(403);
     expect(lastForwarded).toBeNull();
+    // the internal gate marker must never leak on the envelope route either.
+    expect(res.headers.get("x-steward-cap-gate")).toBeNull();
   });
 
   it("ungranted capability => 403", async () => {

--- a/packages/plugin-capabilities/src/index.ts
+++ b/packages/plugin-capabilities/src/index.ts
@@ -130,6 +130,8 @@ export const capabilitiesPlugin: StewardApiPlugin = {
     // anything that is not exactly the invoke subpath falls through to tenantAuth.
     app.use("/capabilities/:name/invoke", (c, next) => requireAgentJwt(c, next));
     app.use("/v1/capabilities/:name/invoke", (c, next) => requireAgentJwt(c, next));
+    app.use("/capabilities/:name/openai/v1/*", (c, next) => requireAgentJwt(c, next));
+    app.use("/v1/capabilities/:name/openai/v1/*", (c, next) => requireAgentJwt(c, next));
     app.use("/capabilities", (c, next) => tenantAuth(c, next));
     app.use("/capabilities/*", (c, next) => tenantGateSkippingInvoke(c, next, tenantAuth));
     app.use("/v1/capabilities", (c, next) => tenantAuth(c, next));
@@ -154,14 +156,15 @@ export const capabilitiesPlugin: StewardApiPlugin = {
 };
 
 /** the invoke subpath predicate: `/capabilities/<name>/invoke` (any single name segment). */
-const INVOKE_SUBPATH = /\/(?:v1\/)?capabilities\/[^/]+\/invoke\/?$/;
+const INVOKE_SUBPATH =
+  /\/(?:v1\/)?capabilities\/[^/]+\/(?:invoke|openai\/v1\/(?:chat\/completions|models))\/?$/;
 
 /**
- * Apply the operator tenant gate to a `/capabilities/*` request UNLESS it is the
- * agent-facing invoke subpath (which is authed by its own agent-jwt middleware).
- * Skipping the invoke subpath here prevents the broad operator gate from
- * rejecting a valid agent token. Fail-closed: only the exact invoke subpath is
- * exempted; every other path is gated.
+ * Apply the operator tenant gate to a `/capabilities/*` request UNLESS it is an
+ * agent-facing invoke/adapter subpath (which is authed by its own agent-jwt
+ * middleware). Skipping those exact subpaths here prevents the broad operator
+ * gate from rejecting a valid agent token. Fail-closed: only exact agent subpaths
+ * are exempted; every other path is gated.
  */
 async function tenantGateSkippingInvoke(
   c: Context<{ Variables: AppVariables }>,

--- a/packages/plugin-capabilities/src/invoke.ts
+++ b/packages/plugin-capabilities/src/invoke.ts
@@ -402,6 +402,13 @@ export async function invokeCapabilityThroughProxy(
     // audit write failed: do NOT block the already-authorized upstream response.
   }
 
+  // Return the upstream status/body passthrough verbatim (the proxy already
+  // scrubbed the credential). Built with a raw Response so it never carries the
+  // gate marker: the OpenAI adapter treats an unmarked response as an upstream
+  // body and passes it through untouched. NOTE: the credential-injection proxy
+  // fails closed on streaming (text/event-stream) responses, so this path only
+  // ever carries a buffered upstream body; the OpenAI adapter rejects
+  // `stream: true` up front (see createInvokeRoutes) to surface that cleanly.
   return new Response(upstreamBody, {
     status: upstreamStatus,
     headers: upstreamContentType ? { "content-type": upstreamContentType } : undefined,
@@ -493,6 +500,23 @@ export function createInvokeRoutes(ctx: StewardAppContext): Hono<{ Variables: Ap
       body = await c.req.json();
     } catch {
       return openAIError("invalid JSON in request body", 400);
+    }
+
+    // Streaming is NOT supported through the credential-injection proxy: it blocks
+    // any streaming (text/event-stream) response after a credential injection
+    // (reason `credential-streaming-response-blocked`, a 502) because it cannot
+    // buffer-and-verify the credential was not reflected in an un-materialized
+    // stream. Reject `stream: true` at the adapter with a clean OpenAI-error so
+    // the SDK surfaces a clear message instead of an opaque upstream 502.
+    if (
+      typeof body === "object" &&
+      body !== null &&
+      (body as { stream?: unknown }).stream === true
+    ) {
+      return openAIError(
+        "streaming responses are not supported through this capability adapter; set stream: false",
+        400,
+      );
     }
     const query = Object.fromEntries(new URL(c.req.url).searchParams.entries());
 

--- a/packages/plugin-capabilities/src/invoke.ts
+++ b/packages/plugin-capabilities/src/invoke.ts
@@ -45,10 +45,70 @@ export interface CapabilityInvokeRequest {
   query?: Record<string, string>;
 }
 
+/**
+ * Internal marker on Steward-wrapped ({ok:...}) gate responses. The upstream
+ * passthrough (verbatim provider body) is built with a raw `new Response` and
+ * therefore never carries this header, so the OpenAI adapter can distinguish a
+ * Steward gate decision (translate to OpenAI-error shape) from an upstream body
+ * (pass through untouched). Stripped before the response leaves the adapter.
+ */
+const GATE_MARKER_HEADER = "x-steward-cap-gate";
+
 function jsonResponse(payload: ApiResponse, status: number): Response {
   return new Response(JSON.stringify(payload), {
     status,
-    headers: { "content-type": "application/json" },
+    headers: { "content-type": "application/json", [GATE_MARKER_HEADER]: "1" },
+  });
+}
+
+/** OpenAI-error `type` bucket for a Steward gate status, so the SDK surfaces it cleanly. */
+function openAIErrorType(status: number): string {
+  if (status === 401) return "invalid_request_error";
+  if (status === 403) return "permission_error";
+  if (status === 429) return "rate_limit_error";
+  if (status === 400) return "invalid_request_error";
+  return "api_error";
+}
+
+/**
+ * Translate a Steward-gated adapter response into an OpenAI-compatible response
+ * the OpenAI SDK can parse. Upstream passthroughs (no gate marker) and the 202
+ * approval envelope pass through unchanged; only Steward-wrapped {ok:false,error}
+ * gate DENIALS are reshaped to {error:{message,type}} with the same status. The
+ * gate marker header is always stripped.
+ */
+/** Strip the internal gate marker so it never leaks to a client. No-op if absent. */
+function stripGateMarker(res: Response): Response {
+  if (!res.headers.has(GATE_MARKER_HEADER)) return res;
+  const headers = new Headers(res.headers);
+  headers.delete(GATE_MARKER_HEADER);
+  return new Response(res.body, { status: res.status, headers });
+}
+
+async function toOpenAICompatible(res: Response): Promise<Response> {
+  const isGate = res.headers.get(GATE_MARKER_HEADER) === "1";
+  if (!isGate) return res;
+
+  const headers = new Headers(res.headers);
+  headers.delete(GATE_MARKER_HEADER);
+
+  // approval (202) and any success wrapper keep their Steward shape (there is no
+  // OpenAI-error equivalent for "pending approval"); only reshape error bodies.
+  if (res.ok) {
+    return new Response(res.body, { status: res.status, headers });
+  }
+
+  let message = "request denied";
+  try {
+    const parsed = (await res.clone().json()) as { error?: unknown };
+    if (typeof parsed.error === "string" && parsed.error.trim() !== "") message = parsed.error;
+  } catch {
+    // non-JSON gate body (should not happen): keep the default message.
+  }
+  headers.set("content-type", "application/json");
+  return new Response(JSON.stringify({ error: { message, type: openAIErrorType(res.status) } }), {
+    status: res.status,
+    headers,
   });
 }
 
@@ -401,7 +461,7 @@ export function createInvokeRoutes(ctx: StewardAppContext): Hono<{ Variables: Ap
         ? (envelope.query as Record<string, string>)
         : undefined;
 
-    return invokeCapabilityThroughProxy(ctx, {
+    const res = await invokeCapabilityThroughProxy(ctx, {
       tenantId,
       agentId,
       name: c.req.param("name"),
@@ -409,24 +469,34 @@ export function createInvokeRoutes(ctx: StewardAppContext): Hono<{ Variables: Ap
       body: envelope.body,
       query,
     });
+    return stripGateMarker(res);
   });
+
+  // OpenAI-error-shaped response for the adapter's OWN inline gate errors, so the
+  // OpenAI SDK surfaces them cleanly (the shared core's wrapped errors are
+  // reshaped separately via toOpenAICompatible).
+  const openAIError = (message: string, status: number): Response =>
+    new Response(JSON.stringify({ error: { message, type: openAIErrorType(status) } }), {
+      status,
+      headers: { "content-type": "application/json" },
+    });
 
   routes.post("/:name/openai/v1/chat/completions", async (c) => {
     const tenantId = c.get("tenantId");
     const agentId = c.get("agentScope");
     if (!tenantId || !agentId) {
-      return jsonResponse({ ok: false, error: "agent authentication required" }, 401);
+      return openAIError("agent authentication required", 401);
     }
 
     let body: unknown;
     try {
       body = await c.req.json();
     } catch {
-      return jsonResponse({ ok: false, error: "invalid JSON in request body" }, 400);
+      return openAIError("invalid JSON in request body", 400);
     }
     const query = Object.fromEntries(new URL(c.req.url).searchParams.entries());
 
-    return invokeCapabilityThroughProxy(ctx, {
+    const res = await invokeCapabilityThroughProxy(ctx, {
       tenantId,
       agentId,
       name: c.req.param("name"),
@@ -434,16 +504,17 @@ export function createInvokeRoutes(ctx: StewardAppContext): Hono<{ Variables: Ap
       body,
       query: Object.keys(query).length > 0 ? query : undefined,
     });
+    return toOpenAICompatible(res);
   });
 
   routes.get("/:name/openai/v1/models", async (c) => {
     const tenantId = c.get("tenantId");
     const agentId = c.get("agentScope");
     if (!tenantId || !agentId) {
-      return jsonResponse({ ok: false, error: "agent authentication required" }, 401);
+      return openAIError("agent authentication required", 401);
     }
     const ok = await hasActiveGrant(ctx, { tenantId, agentId, name: c.req.param("name") });
-    if (!ok) return jsonResponse({ ok: false, error: "capability not available to agent" }, 403);
+    if (!ok) return openAIError("capability not available to agent", 403);
 
     return new Response(JSON.stringify({ object: "list", data: [] }), {
       status: 200,

--- a/packages/plugin-capabilities/src/invoke.ts
+++ b/packages/plugin-capabilities/src/invoke.ts
@@ -2,48 +2,13 @@
  * invoke.ts - the AGENT-FACING capability invoke path (W-1c).
  *
  * POST /capabilities/:name/invoke  { args?, body?, query? }
+ * POST /capabilities/:name/openai/v1/chat/completions  <OpenAI chat body>
+ * GET  /capabilities/:name/openai/v1/models
  *
- * this is the one route in the plugin that an AGENT (not an operator) calls. it
- * turns "agent X wants to invoke capability Y with these args" into a policy
- * decision and, when allowed, a delegated call THROUGH THE PROXY (never an
- * in-process credential touch). the agent identity is taken from the agent token
- * (c.get("agentScope")), NEVER from the request body.
- *
- * THE ARC (fail-closed at every seam)
- * -----------------------------------
- *  a. auth: agent-jwt (installed by the plugin's register on this subpath). the
- *     acting agent + tenant come from the verified token context.
- *  b. resolve the capability by (tenant, name) + enabled, and the ACTIVE,
- *     unexpired GRANT for THIS agent via the fail-closed usable-by-agent surface.
- *     any miss => 404/403, recorded as a denied invocation.
- *  c. compute the trailing-hour invoke count for (agent, capability) from the
- *     invocations table => ctx.capabilityInvokeCount1h.
- *  d. build the policy context with ctx.capability = {name, args, host, path,
- *     method} + the count, and evaluate the tenant's `capability-intent` rules
- *     through the engine's EXISTING entry point (PolicyEngine.evaluate). only the
- *     capability-intent rules are fed to the engine here: tx-shaped rules
- *     (spending-limit, approved-addresses, ...) govern tx SIGNS, not capability
- *     invokes, and would produce meaningless verdicts against a synthetic tx.
- *     the capability-intent rule is the rule that governs a capability invoke.
- *  e. DEFAULT-DENY: engine-approved is NOT sufficient (a capability-intent rule
- *     PASSES for any capability it does not govern). the invoke layer INDEPENDENTLY
- *     requires >=1 capability-intent rule that GOVERNS this capability name with
- *     effect "allow" AND whose per-rule evaluation PASSED. a matched deny or a
- *     matched require-approval short-circuits first (deny => 403; approval => 202).
- *     no matched allow rule => deny.
- *  f. ALLOW => forward THROUGH THE PROXY via @stwd/proxy-client. the target is the
- *     capability's (host, path, method); the agent's api:proxy token is minted
- *     server-side (shared STEWARD_JWT_SECRET, the same token the proxy verifies) +
- *     HMAC-signed. the proxy matches the paired secret_route (agentId = this agent,
- *     materialized by the grant), decrypts + injects the credential, and scrubs it
- *     from the response. the plugin NEVER decrypts. proxy env absent => 503.
- *  g. return the upstream status/body passthrough. emit capability.invoked /
- *     .denied / .approval_queued (declared by this package's webhookEvents).
- *
- * every terminal outcome records ONE capability_invocations row with its decision
- * (allow/deny/approval/error) BEFORE the response — the durable audit trail + the
- * rate-limit source. money-rail-adjacent: on ANY ambiguity (no proxy env, count
- * query error, enqueue error) we DENY (or 503) and audit.
+ * Agent identity comes from the agent token (c.get("agentScope")), never from the
+ * request body. Allowed calls are delegated through @stwd/proxy-client, which
+ * mints/signs the proxy call server-side so agents never receive raw upstream
+ * keys or proxy HMAC material.
  */
 
 import { signAgentToken } from "@stwd/auth";
@@ -56,7 +21,6 @@ import {
 } from "@stwd/policy-engine";
 import { StewardProxyClient } from "@stwd/proxy-client";
 import type { ApiResponse, AppVariables, PolicyRule, SignRequest } from "@stwd/shared";
-import type { Context } from "hono";
 import { Hono } from "hono";
 import type { StewardAppContext } from "./context";
 import type { Capability, InvocationDecision } from "./schema";
@@ -67,27 +31,29 @@ const PROXY_SCOPE = "api:proxy";
 /** short-lived: the token only needs to survive the single proxied call. */
 const PROXY_TOKEN_TTL = "2m";
 
-/**
- * The proxy delegation configuration read from the environment. FAIL-CLOSED: any
- * missing value => the invoke path returns 503 (never an in-process credential
- * touch). Documented in the deploy runbook.
- */
 interface ProxyEnv {
   proxyUrl: string;
   signingSecret: string;
 }
 
-/**
- * Read + validate the proxy env. Returns null when any required var is missing/
- * empty (=> the caller 503s). We require BOTH the proxy URL and a request-signing
- * secret: the proxy runs with request signing enabled in production, so an invoke
- * without a signing secret would be rejected by the proxy anyway — failing closed
- * here (503, no forward) is clearer than forwarding a request the proxy will 401.
- */
+export interface CapabilityInvokeRequest {
+  tenantId: string;
+  agentId: string;
+  name: string;
+  args?: Record<string, unknown>;
+  body?: unknown;
+  query?: Record<string, string>;
+}
+
+function jsonResponse(payload: ApiResponse, status: number): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
 function readProxyEnv(env: NodeJS.ProcessEnv = process.env): ProxyEnv | null {
   const proxyUrl = (env.STEWARD_PROXY_URL ?? "").trim();
-  // accept either the dedicated invoke signing secret or the proxy's own
-  // configured signing secret (single-secret deploys set only the latter).
   const signingSecret = (
     env.STEWARD_PROXY_REQUEST_SIGNING_SECRET ??
     env.STEWARD_PROXY_REQUEST_SIGNING_SECRETS?.split(",")[0] ??
@@ -97,13 +63,6 @@ function readProxyEnv(env: NodeJS.ProcessEnv = process.env): ProxyEnv | null {
   return { proxyUrl, signingSecret };
 }
 
-/**
- * Build the proxy-relative path for a capability's (host, path). Uses the
- * direct-proxy form `/proxy/<host><path>` so ANY allowed host works without
- * depending on a named alias existing. v1 capabilities are EXACT-path: the
- * forwarded path is the capability's `pathPattern` verbatim (path templating from
- * args is a documented TODO). Query params (if any) are appended.
- */
 function buildProxyPath(cap: Capability, query: Record<string, string> | undefined): string {
   const host = cap.host.toLowerCase();
   const basePath = cap.pathPattern.startsWith("/") ? cap.pathPattern : `/${cap.pathPattern}`;
@@ -115,13 +74,6 @@ function buildProxyPath(cap: Capability, query: Record<string, string> | undefin
   return path;
 }
 
-/**
- * A synthetic SignRequest for the engine's evaluator context. The engine's
- * `request` field is typed as a SignRequest; capability-intent rules ignore it
- * entirely (they gate on `ctx.capability`), and only capability-intent rules are
- * evaluated on the invoke path, so this sentinel never drives a decision. It
- * carries the real agent/tenant ids (for the audit event) + zeroed tx fields.
- */
 function syntheticSignRequest(tenantId: string, agentId: string): SignRequest {
   return {
     agentId,
@@ -133,35 +85,16 @@ function syntheticSignRequest(tenantId: string, agentId: string): SignRequest {
   };
 }
 
-/**
- * Match a capability name against a single capability-intent pattern. Mirrors the
- * engine's `patternMatches` (a single trailing `.*` prefix glob, else exact). Kept
- * local so the invoke layer's default-deny match detection reuses ONLY the stable
- * exported `CapabilityIntentConfig` shape (policy-engine stays 0-diff). The
- * authoritative PASS/constraint verdict is delegated to `evaluateCapabilityIntent`.
- */
 function patternMatches(pattern: string, name: string): boolean {
   if (typeof pattern !== "string" || pattern.length === 0) return false;
   if (pattern.endsWith(".*")) return name.startsWith(pattern.slice(0, -1));
   return pattern === name;
 }
 
-/**
- * True when a rule is a capability-intent rule. `PolicyRule.type` is the CORE
- * closed union which does NOT include the contributed "capability-intent"
- * discriminator (it is a plugin-registered type stored as an arbitrary string in
- * the DB), so we compare the type as a plain string.
- */
 function isCapabilityIntentRule(rule: PolicyRule): boolean {
   return (rule.type as string) === (CAPABILITY_INTENT_RULE_TYPE as string);
 }
 
-/**
- * True when `rule` is a well-formed capability-intent rule with effect "allow"
- * whose configured patterns GOVERN `name`. This is the local "does an allow rule
- * match this capability" test; whether that allow rule PASSES (args/rate
- * constraints) is decided by the engine evaluator, not here.
- */
 function isMatchingAllowRule(rule: PolicyRule, name: string): boolean {
   if (!isCapabilityIntentRule(rule)) return false;
   const cfg = rule.config as Partial<CapabilityIntentConfig>;
@@ -170,7 +103,6 @@ function isMatchingAllowRule(rule: PolicyRule, name: string): boolean {
   return cfg.capabilities.some((p) => patternMatches(p, name));
 }
 
-/** True when a rule (of any effect) is a capability-intent rule governing `name`. */
 function isGoverningRule(rule: PolicyRule, name: string): boolean {
   if (!isCapabilityIntentRule(rule)) return false;
   const cfg = rule.config as Partial<CapabilityIntentConfig>;
@@ -178,77 +110,271 @@ function isGoverningRule(rule: PolicyRule, name: string): boolean {
   return cfg.capabilities.some((p) => patternMatches(p, name));
 }
 
-/**
- * Build the agent invoke router. Mounted (behind the plugin's agent-jwt gate on
- * `/capabilities/:name/invoke`) by the plugin's `register`.
- */
-export function createInvokeRoutes(ctx: StewardAppContext): Hono<{ Variables: AppVariables }> {
-  const routes = new Hono<{ Variables: AppVariables }>();
-  const store = new CapabilityStore(ctx.db);
-  // a single engine instance for the invoke path. no audit hook here (the plugin
-  // writes its OWN capability_invocations audit row per attempt).
-  const engine = new PolicyEngine();
+async function recordAndJson(
+  store: CapabilityStore,
+  args: {
+    tenantId: string;
+    agentId: string;
+    capabilityId: string | null;
+    decision: InvocationDecision;
+    status: number;
+    payload: ApiResponse;
+  },
+): Promise<Response> {
+  try {
+    await store.recordInvocation({
+      tenantId: args.tenantId,
+      agentId: args.agentId,
+      capabilityId: args.capabilityId,
+      decision: args.decision,
+    });
+  } catch {
+    // audit write failed: do NOT block the already fail-closed decision.
+  }
+  return jsonResponse(args.payload, args.status);
+}
 
-  /**
-   * Record the terminal decision and return the response. Central so EVERY exit
-   * records exactly one invocation row first (fail-closed audit trail + the
-   * rate-limit source). A record failure is swallowed AFTER the decision is
-   * already fail-closed (we never upgrade a deny to an allow on a record error;
-   * a denied attempt simply may not be counted toward the hourly cap).
-   *
-   * `webhookEvents` (capability.invoked / .denied / .approval_queued) are DECLARED
-   * by this package (index.ts) so the event types are valid; actual dispatch runs
-   * through the core webhook config/dispatch path (which the plugin does not hold
-   * an injected handle to) exactly as the CRUD lifecycle events do — the plugin's
-   * job is the durable decision record, not the transport.
-   */
-  async function finish(
-    c: Context<{ Variables: AppVariables }>,
-    args: {
-      tenantId: string;
-      agentId: string;
-      capabilityId: string | null;
-      decision: InvocationDecision;
-      status: number;
-      payload: ApiResponse;
-    },
-  ): Promise<Response> {
-    try {
-      await store.recordInvocation({
-        tenantId: args.tenantId,
-        agentId: args.agentId,
-        capabilityId: args.capabilityId,
-        decision: args.decision,
-      });
-    } catch {
-      // audit write failed: do NOT block the (already fail-closed) decision.
-    }
-    return c.json<ApiResponse>(args.payload, args.status as never);
+/**
+ * Shared capability invoke core. This preserves the W-1c invariants for both the
+ * envelope invoke route and the OpenAI-compatible adapter: resolve enabled
+ * capability + active grant, count invocations, default-deny capability-intent
+ * policy, approval 202, proxy env 503, server-side proxy signing, and exactly one
+ * invocation row for every terminal outcome.
+ */
+export async function invokeCapabilityThroughProxy(
+  ctx: StewardAppContext,
+  request: CapabilityInvokeRequest,
+): Promise<Response> {
+  const store = new CapabilityStore(ctx.db);
+  const engine = new PolicyEngine();
+  const { tenantId, agentId, name } = request;
+  const invokeArgs = request.args ?? {};
+
+  const usable = await store.listUsableCapabilitiesForAgent(tenantId, agentId);
+  const match = usable.find((u) => u.capability.name === name);
+  if (!match) {
+    return recordAndJson(store, {
+      tenantId,
+      agentId,
+      capabilityId: null,
+      decision: "deny",
+      status: 403,
+      payload: { ok: false, error: "capability not available to agent" } satisfies ApiResponse,
+    });
+  }
+  const cap = match.capability;
+
+  let count1h: number;
+  try {
+    count1h = await store.countInvocations1h(agentId, cap.id);
+  } catch {
+    return recordAndJson(store, {
+      tenantId,
+      agentId,
+      capabilityId: cap.id,
+      decision: "deny",
+      status: 403,
+      payload: { ok: false, error: "policy evaluation unavailable" } satisfies ApiResponse,
+    });
   }
 
-  // ── POST /:name/invoke ──────────────────────────────────────────────────────
+  const capabilityCtx: NonNullable<EvaluatorContext["capability"]> = {
+    name: cap.name,
+    args: invokeArgs,
+    host: cap.host,
+    path: cap.pathPattern,
+    method: cap.method,
+  };
+
+  let policySet: PolicyRule[];
+  try {
+    policySet = await ctx.getPolicySet(tenantId, agentId);
+  } catch {
+    return recordAndJson(store, {
+      tenantId,
+      agentId,
+      capabilityId: cap.id,
+      decision: "deny",
+      status: 403,
+      payload: { ok: false, error: "policy evaluation unavailable" } satisfies ApiResponse,
+    });
+  }
+  const capRules = policySet.filter((r) => isCapabilityIntentRule(r) && r.enabled !== false);
+
+  const evaluatorCtx: EvaluatorContext = {
+    request: syntheticSignRequest(tenantId, agentId),
+    recentTxCount1h: 0,
+    recentTxCount24h: 0,
+    spentToday: 0n,
+    spentThisWeek: 0n,
+    capability: capabilityCtx,
+    capabilityInvokeCount1h: count1h,
+  };
+
+  await engine.evaluate(capRules, evaluatorCtx);
+
+  const governing = capRules.filter((r) => isGoverningRule(r, cap.name));
+  if (governing.length === 0) {
+    return recordAndJson(store, {
+      tenantId,
+      agentId,
+      capabilityId: cap.id,
+      decision: "deny",
+      status: 403,
+      payload: { ok: false, error: "no policy authorizes this capability" } satisfies ApiResponse,
+    });
+  }
+
+  let sawApproval = false;
+  let matchedAllowPassed = false;
+  let sawDeny = false;
+  let denyReason: string | undefined;
+  for (const rule of governing) {
+    const result = evaluateCapabilityIntent(
+      { id: rule.id, type: rule.type as string, enabled: rule.enabled, config: rule.config },
+      evaluatorCtx,
+    );
+    if (result.requiresManualApproval) {
+      sawApproval = true;
+      continue;
+    }
+    if (!result.passed) {
+      sawDeny = true;
+      denyReason = result.reason ?? "denied by policy";
+      continue;
+    }
+    if (isMatchingAllowRule(rule, cap.name)) matchedAllowPassed = true;
+  }
+
+  if (!sawDeny && matchedAllowPassed) {
+    // proceed to proxy delegation.
+  } else if (!sawDeny && sawApproval) {
+    let approvalId: string | null = null;
+    try {
+      approvalId = await store.recordInvocation({
+        tenantId,
+        agentId,
+        capabilityId: cap.id,
+        decision: "approval",
+      });
+    } catch {
+      approvalId = null;
+    }
+    if (!approvalId) {
+      return recordAndJson(store, {
+        tenantId,
+        agentId,
+        capabilityId: cap.id,
+        decision: "deny",
+        status: 403,
+        payload: { ok: false, error: "approval enqueue failed" } satisfies ApiResponse,
+      });
+    }
+    return jsonResponse({ ok: true, data: { approvalId, status: "pending" } }, 202);
+  } else {
+    return recordAndJson(store, {
+      tenantId,
+      agentId,
+      capabilityId: cap.id,
+      decision: "deny",
+      status: 403,
+      payload: {
+        ok: false,
+        error: denyReason ?? "capability invoke denied by policy",
+      } satisfies ApiResponse,
+    });
+  }
+
+  const proxyEnv = readProxyEnv();
+  if (!proxyEnv) {
+    return recordAndJson(store, {
+      tenantId,
+      agentId,
+      capabilityId: cap.id,
+      decision: "error",
+      status: 503,
+      payload: { ok: false, error: "capability delegation unavailable" } satisfies ApiResponse,
+    });
+  }
+
+  let upstreamStatus: number;
+  let upstreamBody: string;
+  let upstreamContentType: string | null;
+  try {
+    const token = await signAgentToken(
+      { agentId, tenantId, scopes: ["agent", PROXY_SCOPE] },
+      PROXY_TOKEN_TTL,
+    );
+    const client = new StewardProxyClient({
+      proxyUrl: proxyEnv.proxyUrl,
+      token,
+      signingSecret: proxyEnv.signingSecret,
+      tenantId,
+      agentId,
+    });
+
+    const method = cap.method.toUpperCase();
+    const path = buildProxyPath(cap, request.query);
+    const hasBody = method !== "GET" && method !== "HEAD" && request.body !== undefined;
+    const init: RequestInit = { method };
+    if (hasBody) {
+      init.body = typeof request.body === "string" ? request.body : JSON.stringify(request.body);
+      init.headers = { "content-type": "application/json" };
+    }
+    const res = await client.fetch(path, init);
+    upstreamStatus = res.status;
+    upstreamContentType = res.headers.get("content-type");
+    upstreamBody = await res.text();
+  } catch {
+    return recordAndJson(store, {
+      tenantId,
+      agentId,
+      capabilityId: cap.id,
+      decision: "error",
+      status: 502,
+      payload: { ok: false, error: "capability delegation failed" } satisfies ApiResponse,
+    });
+  }
+
+  try {
+    await store.recordInvocation({ tenantId, agentId, capabilityId: cap.id, decision: "allow" });
+  } catch {
+    // audit write failed: do NOT block the already-authorized upstream response.
+  }
+
+  return new Response(upstreamBody, {
+    status: upstreamStatus,
+    headers: upstreamContentType ? { "content-type": upstreamContentType } : undefined,
+  });
+}
+
+/** Active-grant check for compatibility routes that must not touch proxy/secret material. */
+async function hasActiveGrant(
+  ctx: StewardAppContext,
+  args: CapabilityInvokeRequest,
+): Promise<boolean> {
+  const store = new CapabilityStore(ctx.db);
+  const usable = await store.listUsableCapabilitiesForAgent(args.tenantId, args.agentId);
+  return usable.some((u) => u.capability.name === args.name);
+}
+
+export function createInvokeRoutes(ctx: StewardAppContext): Hono<{ Variables: AppVariables }> {
+  const routes = new Hono<{ Variables: AppVariables }>();
+
   routes.post("/:name/invoke", async (c) => {
-    // agent identity from the TOKEN, never the body (agent-jwt set these).
     const tenantId = c.get("tenantId");
     const agentId = c.get("agentScope");
     if (!tenantId || !agentId) {
-      // the agent-jwt middleware should have populated these; if not, fail closed.
-      return c.json<ApiResponse>({ ok: false, error: "agent authentication required" }, 401);
+      return jsonResponse({ ok: false, error: "agent authentication required" }, 401);
     }
-    const name = c.req.param("name");
 
-    // parse the optional body envelope. an EMPTY body is allowed (no args); a
-    // PRESENT-but-invalid JSON body is a 400 (do not silently coerce malformed
-    // client input to `{}` and then authorize/forward it). we distinguish the two
-    // by reading the raw body: empty/whitespace => no envelope; non-empty =>
-    // JSON.parse (a parse failure => 400).
     type InvokeEnvelope = {
       args?: Record<string, unknown>;
       body?: unknown;
       query?: Record<string, string>;
     };
     let envelope: InvokeEnvelope = {};
-    let rawBody: string;
+    let rawBody = "";
     try {
       rawBody = await c.req.text();
     } catch {
@@ -258,17 +384,15 @@ export function createInvokeRoutes(ctx: StewardAppContext): Hono<{ Variables: Ap
       try {
         const parsedBody = JSON.parse(rawBody);
         if (parsedBody === null || typeof parsedBody !== "object" || Array.isArray(parsedBody)) {
-          return c.json<ApiResponse>(
-            { ok: false, error: "invoke body must be a JSON object" },
-            400,
-          );
+          return jsonResponse({ ok: false, error: "invoke body must be a JSON object" }, 400);
         }
         envelope = parsedBody as InvokeEnvelope;
       } catch {
-        return c.json<ApiResponse>({ ok: false, error: "invalid JSON in request body" }, 400);
+        return jsonResponse({ ok: false, error: "invalid JSON in request body" }, 400);
       }
     }
-    const invokeArgs =
+
+    const args =
       envelope.args && typeof envelope.args === "object" && !Array.isArray(envelope.args)
         ? (envelope.args as Record<string, unknown>)
         : {};
@@ -277,280 +401,53 @@ export function createInvokeRoutes(ctx: StewardAppContext): Hono<{ Variables: Ap
         ? (envelope.query as Record<string, string>)
         : undefined;
 
-    // a. resolve capability + active grant fail-closed via the usable-by-agent
-    //    surface (active + unexpired grant to an ENABLED capability).
-    const usable = await store.listUsableCapabilitiesForAgent(tenantId, agentId);
-    const match = usable.find((u) => u.capability.name === name);
-    if (!match) {
-      // no usable grant: could be unknown capability, disabled, or no/expired/
-      // revoked grant. all collapse to a fail-closed 403 (do not leak which).
-      return finish(c, {
-        tenantId,
-        agentId,
-        capabilityId: null,
-        decision: "deny",
-        status: 403,
-        payload: { ok: false, error: "capability not available to agent" } satisfies ApiResponse,
-      });
-    }
-    const cap = match.capability;
-
-    // b. trailing-hour invoke count for (agent, capability). a query error =>
-    //    DENY (the maxCallsPerHour constraint would otherwise fail open).
-    let count1h: number;
-    try {
-      count1h = await store.countInvocations1h(agentId, cap.id);
-    } catch {
-      return finish(c, {
-        tenantId,
-        agentId,
-        capabilityId: cap.id,
-        decision: "deny",
-        status: 403,
-        payload: { ok: false, error: "policy evaluation unavailable" } satisfies ApiResponse,
-      });
-    }
-
-    // c. build the policy context. ctx.capability drives capability-intent rules;
-    //    only capability-intent rules are evaluated on the invoke path.
-    const capabilityCtx: NonNullable<EvaluatorContext["capability"]> = {
-      name: cap.name,
-      args: invokeArgs,
-      host: cap.host,
-      path: cap.pathPattern,
-      method: cap.method,
-    };
-
-    let policySet: PolicyRule[];
-    try {
-      policySet = await ctx.getPolicySet(tenantId, agentId);
-    } catch {
-      return finish(c, {
-        tenantId,
-        agentId,
-        capabilityId: cap.id,
-        decision: "deny",
-        status: 403,
-        payload: { ok: false, error: "policy evaluation unavailable" } satisfies ApiResponse,
-      });
-    }
-    // only the ENABLED capability-intent rules govern a capability invoke. an
-    // operator who disables an allow rule (enabled:false) to revoke access must
-    // NOT have it still authorize — the engine skips disabled rules, and the
-    // authoritative per-rule loop below reuses THIS filtered set, so a disabled
-    // allow/deny/require-approval rule has no effect (fail-closed on the allow
-    // side: a disabled allow no longer sets matchedAllowPassed).
-    const capRules = policySet.filter((r) => isCapabilityIntentRule(r) && r.enabled !== false);
-
-    // d. evaluate through the engine's existing entry point.
-    // e. DEFAULT-DENY + effect resolution.
-    //
-    // build the per-rule evaluator context (identical for the engine pass and the
-    // authoritative per-rule loop). we run BOTH:
-    //   - engine.evaluate over the capability-intent rules: the EXISTING entry
-    //     point (all-must-pass composition), so any global engine hooks/audit fire
-    //     exactly as they do for tx signing. it is a consistency/audit pass.
-    //   - the AUTHORITATIVE per-rule loop below: the invoke layer OWNS default-deny
-    //     (the contract) — engine-approved alone is not enough, and the engine's
-    //     dispatch of a contributed rule depends on the plugin having registered
-    //     the evaluator into the registry (true at the compose root; the direct
-    //     loop makes the decision robust regardless of registry state). the loop
-    //     computes matched-allow/deny/approval directly via evaluateCapabilityIntent.
-    const evaluatorCtx: EvaluatorContext = {
-      request: syntheticSignRequest(tenantId, agentId),
-      recentTxCount1h: 0,
-      recentTxCount24h: 0,
-      spentToday: 0n,
-      spentThisWeek: 0n,
-      capability: capabilityCtx,
-      capabilityInvokeCount1h: count1h,
-    };
-    // consistency/audit pass through the existing entry point (result inspected
-    // for parity, but the AUTHORITATIVE decision is the per-rule loop below).
-    await engine.evaluate(capRules, {
-      request: evaluatorCtx.request,
-      recentTxCount1h: 0,
-      recentTxCount24h: 0,
-      spentToday: 0n,
-      spentThisWeek: 0n,
-      capability: capabilityCtx,
-      capabilityInvokeCount1h: count1h,
+    return invokeCapabilityThroughProxy(ctx, {
+      tenantId,
+      agentId,
+      name: c.req.param("name"),
+      args,
+      body: envelope.body,
+      query,
     });
+  });
 
-    const governing = capRules.filter((r) => isGoverningRule(r, cap.name));
-    if (governing.length === 0) {
-      // no capability-intent rule governs this capability => default-deny.
-      return finish(c, {
-        tenantId,
-        agentId,
-        capabilityId: cap.id,
-        decision: "deny",
-        status: 403,
-        payload: {
-          ok: false,
-          error: "no policy authorizes this capability",
-        } satisfies ApiResponse,
-      });
+  routes.post("/:name/openai/v1/chat/completions", async (c) => {
+    const tenantId = c.get("tenantId");
+    const agentId = c.get("agentScope");
+    if (!tenantId || !agentId) {
+      return jsonResponse({ ok: false, error: "agent authentication required" }, 401);
     }
 
-    // evaluate each governing rule with the authoritative evaluator. all-must-pass:
-    // a matched deny OR a matched allow that failed a constraint is a hard deny
-    // (takes precedence over any other rule). a require-approval routes to 202
-    // only when nothing hard-denied. authorization requires >=1 allow rule that
-    // matched AND passed, with no hard deny.
-    let sawApproval = false;
-    let matchedAllowPassed = false;
-    let sawDeny = false;
-    let denyReason: string | undefined;
-    for (const rule of governing) {
-      const result = evaluateCapabilityIntent(
-        { id: rule.id, type: rule.type as string, enabled: rule.enabled, config: rule.config },
-        evaluatorCtx,
-      );
-      if (result.requiresManualApproval) {
-        sawApproval = true;
-        continue;
-      }
-      if (!result.passed) {
-        // a matched deny, OR a matched allow that failed its constraints => hard deny.
-        sawDeny = true;
-        denyReason = result.reason ?? "denied by policy";
-        continue;
-      }
-      // passed. only an ALLOW-effect rule authorizes (deny/require-approval never
-      // pass; re-check the effect defensively).
-      if (isMatchingAllowRule(rule, cap.name)) matchedAllowPassed = true;
-    }
-
-    // precedence (all-must-pass): ANY hard deny wins. else a require-approval => 202.
-    // else a matched-allow that passed => authorize. else default-deny.
-    if (!sawDeny && matchedAllowPassed) {
-      // proceed to forward (below).
-    } else if (!sawDeny && sawApproval) {
-      // f-approval: enqueue via the plugin's own invocation record (the core
-      // approval_queue is tx-shaped and cannot hold a capability invoke). the
-      // 202 returns the invocation id as the approvalId. an enqueue (record)
-      // error => DENY + audit (handled inside finish: a null id would drop the
-      // approval, so on record failure we return a deny instead).
-      let approvalId: string | null = null;
-      try {
-        approvalId = await store.recordInvocation({
-          tenantId,
-          agentId,
-          capabilityId: cap.id,
-          decision: "approval",
-        });
-      } catch {
-        approvalId = null;
-      }
-      if (!approvalId) {
-        return finish(c, {
-          tenantId,
-          agentId,
-          capabilityId: cap.id,
-          decision: "deny",
-          status: 403,
-          payload: {
-            ok: false,
-            error: "approval enqueue failed",
-          } satisfies ApiResponse,
-        });
-      }
-      // already recorded (decision=approval); emit + return WITHOUT double-recording.
-      return c.json<ApiResponse>({ ok: true, data: { approvalId, status: "pending" } }, 202);
-    } else {
-      return finish(c, {
-        tenantId,
-        agentId,
-        capabilityId: cap.id,
-        decision: "deny",
-        status: 403,
-        payload: {
-          ok: false,
-          error: denyReason ?? "capability invoke denied by policy",
-        } satisfies ApiResponse,
-      });
-    }
-
-    // f. ALLOW => forward THROUGH THE PROXY. fail-closed if proxy env absent.
-    const proxyEnv = readProxyEnv();
-    if (!proxyEnv) {
-      return finish(c, {
-        tenantId,
-        agentId,
-        capabilityId: cap.id,
-        decision: "error",
-        status: 503,
-        payload: {
-          ok: false,
-          error: "capability delegation unavailable",
-        } satisfies ApiResponse,
-      });
-    }
-
-    let upstreamStatus: number;
-    let upstreamBody: string;
-    let upstreamContentType: string | null;
+    let body: unknown;
     try {
-      // mint a short-lived api:proxy token for THIS agent (the same HS256 token
-      // the proxy verifies). the proxy matches the grant's paired secret_route
-      // (agentId = this agent) and injects the credential. the plugin never sees
-      // the secret.
-      const token = await signAgentToken(
-        { agentId, tenantId, scopes: ["agent", PROXY_SCOPE] },
-        PROXY_TOKEN_TTL,
-      );
-      const client = new StewardProxyClient({
-        proxyUrl: proxyEnv.proxyUrl,
-        token,
-        signingSecret: proxyEnv.signingSecret,
-        tenantId,
-        agentId,
-      });
-
-      const method = cap.method.toUpperCase();
-      const path = buildProxyPath(cap, query);
-      const hasBody = method !== "GET" && method !== "HEAD" && envelope.body !== undefined;
-      const init: RequestInit = { method };
-      if (hasBody) {
-        init.body =
-          typeof envelope.body === "string" ? envelope.body : JSON.stringify(envelope.body);
-        init.headers = { "content-type": "application/json" };
-      }
-      const res = await client.fetch(path, init);
-      upstreamStatus = res.status;
-      upstreamContentType = res.headers.get("content-type");
-      upstreamBody = await res.text();
+      body = await c.req.json();
     } catch {
-      // a forward failure is an error outcome (recorded), surfaced as 502.
-      return finish(c, {
-        tenantId,
-        agentId,
-        capabilityId: cap.id,
-        decision: "error",
-        status: 502,
-        payload: { ok: false, error: "capability delegation failed" } satisfies ApiResponse,
-      });
+      return jsonResponse({ ok: false, error: "invalid JSON in request body" }, 400);
     }
+    const query = Object.fromEntries(new URL(c.req.url).searchParams.entries());
 
-    // record the allow (durable) BEFORE returning the passthrough.
-    try {
-      await store.recordInvocation({
-        tenantId,
-        agentId,
-        capabilityId: cap.id,
-        decision: "allow",
-      });
-    } catch {
-      // audit write failed: do NOT block the response (the credential already
-      // forwarded), but the decision itself was already made + policy-authorized.
+    return invokeCapabilityThroughProxy(ctx, {
+      tenantId,
+      agentId,
+      name: c.req.param("name"),
+      args: { provider: "openai", operation: "chat.completions" },
+      body,
+      query: Object.keys(query).length > 0 ? query : undefined,
+    });
+  });
+
+  routes.get("/:name/openai/v1/models", async (c) => {
+    const tenantId = c.get("tenantId");
+    const agentId = c.get("agentScope");
+    if (!tenantId || !agentId) {
+      return jsonResponse({ ok: false, error: "agent authentication required" }, 401);
     }
+    const ok = await hasActiveGrant(ctx, { tenantId, agentId, name: c.req.param("name") });
+    if (!ok) return jsonResponse({ ok: false, error: "capability not available to agent" }, 403);
 
-    // g. passthrough the upstream status + body verbatim. never re-wrap (the
-    //    proxy already scrubbed the credential from the body).
-    return new Response(upstreamBody, {
-      status: upstreamStatus,
-      headers: upstreamContentType ? { "content-type": upstreamContentType } : undefined,
+    return new Response(JSON.stringify({ object: "list", data: [] }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
     });
   });
 

--- a/packages/plugin-capabilities/src/invoke.ts
+++ b/packages/plugin-capabilities/src/invoke.ts
@@ -520,11 +520,27 @@ export function createInvokeRoutes(ctx: StewardAppContext): Hono<{ Variables: Ap
     }
     const query = Object.fromEntries(new URL(c.req.url).searchParams.entries());
 
+    // Surface OpenAI request fields to the policy layer so existing
+    // argEquals/argMatches capability-intent constraints can gate on them (e.g.
+    // restrict `model`). Only lift scalar top-level fields (string/number/boolean)
+    // — nested structures like `messages` are not policy args — and always keep
+    // provider/operation. The body itself is still forwarded verbatim.
+    const args: Record<string, unknown> = {};
+    if (typeof body === "object" && body !== null && !Array.isArray(body)) {
+      for (const [key, value] of Object.entries(body as Record<string, unknown>)) {
+        const t = typeof value;
+        if (t === "string" || t === "number" || t === "boolean") args[key] = value;
+      }
+    }
+    // provider/operation are adapter-asserted and cannot be spoofed by the body.
+    args.provider = "openai";
+    args.operation = "chat.completions";
+
     const res = await invokeCapabilityThroughProxy(ctx, {
       tenantId,
       agentId,
       name: c.req.param("name"),
-      args: { provider: "openai", operation: "chat.completions" },
+      args,
       body,
       query: Object.keys(query).length > 0 ? query : undefined,
     });

--- a/packages/plugin-capabilities/src/invoke.ts
+++ b/packages/plugin-capabilities/src/invoke.ts
@@ -432,7 +432,9 @@ export function createInvokeRoutes(ctx: StewardAppContext): Hono<{ Variables: Ap
     const tenantId = c.get("tenantId");
     const agentId = c.get("agentScope");
     if (!tenantId || !agentId) {
-      return jsonResponse({ ok: false, error: "agent authentication required" }, 401);
+      return stripGateMarker(
+        jsonResponse({ ok: false, error: "agent authentication required" }, 401),
+      );
     }
 
     type InvokeEnvelope = {
@@ -451,11 +453,15 @@ export function createInvokeRoutes(ctx: StewardAppContext): Hono<{ Variables: Ap
       try {
         const parsedBody = JSON.parse(rawBody);
         if (parsedBody === null || typeof parsedBody !== "object" || Array.isArray(parsedBody)) {
-          return jsonResponse({ ok: false, error: "invoke body must be a JSON object" }, 400);
+          return stripGateMarker(
+            jsonResponse({ ok: false, error: "invoke body must be a JSON object" }, 400),
+          );
         }
         envelope = parsedBody as InvokeEnvelope;
       } catch {
-        return jsonResponse({ ok: false, error: "invalid JSON in request body" }, 400);
+        return stripGateMarker(
+          jsonResponse({ ok: false, error: "invalid JSON in request body" }, 400),
+        );
       }
     }
 


### PR DESCRIPTION
## OpenAI-compatible capability adapter (S3-OAI)

Adds an OpenAI-compatible surface on top of the W-1c agent invoke path (#154) so an unmodified OpenAI SDK can call a broker-registered capability, with full policy gating and audit preserved. Part of the universal credential plane (#150).

### Routes

- `POST /capabilities/:name/openai/v1/chat/completions` — agent-scoped bearer in `Authorization` (the OpenAI SDK sends its "api key" here); the adapter authenticates the agent from the token, never the body. Delegates to the shared invoke core with `args:{provider,operation:"chat.completions"}` plus lifted request scalars (see below). Returns the **upstream OpenAI-shaped body + status verbatim** (no `{ok:true}` wrapper), so the SDK parses it directly.
- `GET /capabilities/:name/openai/v1/models` — agent auth + active-grant check only. Never touches proxy env or credential material. Returns `{object:"list",data:[]}`.

### Contract details

- **Agent identity from token, never body.** Same W-1c invariant as the envelope route: capability resolved from an enabled capability + active grant; miss => 403 deny + audit row.
- **Policy gating per invoke.** Capability-intent default-deny: no governing rule => deny; `require-approval` => 202 with `approvalId`; `maxCallsPerHour` enforced (second call denied). Every terminal outcome writes exactly one `capability_invocations` row.
- **Model/field gating.** Top-level scalar request fields (string/number/boolean, e.g. `model`) are lifted into the policy `args` so existing `argEquals`/`argMatches` capability-intent constraints can gate on them. `provider`/`operation` are adapter-asserted last and cannot be spoofed by the body. Nested fields (`messages`, `tools`) are not policy args; the body is still forwarded verbatim.
- **Server-side credential injection only.** Allowed calls go through `@stwd/proxy-client`, which mints/signs the proxy call server-side; the agent never receives raw upstream keys or proxy HMAC material. The capability still pins exact `(host,path,method)` — no wildcard forwarding.

### Error shaping

- The adapter's own inline gate errors (auth, invalid JSON, denials) are returned in **OpenAI-error shape** `{error:{message,type}}` with an appropriate `type` bucket (`invalid_request_error` / `permission_error` / `rate_limit_error` / `api_error`) so the OpenAI SDK surfaces them cleanly instead of the Steward `{ok:false}` wrapper.
- Steward gate decisions carry an internal `x-steward-cap-gate` marker so the adapter can distinguish a gate decision (reshape to OpenAI-error) from a verbatim upstream body (pass through untouched). The marker is **always stripped before the response leaves the broker** — including on the envelope invoke route's own inline errors (this PR's top commit closes that leak, with an e2e assertion).

### Streaming

- `stream:true` is **rejected up front** with a clean OpenAI-error (`invalid_request_error`, 400), no forward, no invocation row. Rationale: the credential-injection proxy deliberately fails closed on `text/event-stream` responses after a credential injection (`credential-streaming-response-blocked`, 502) because it cannot buffer-and-verify the injected credential is not reflected in an un-materialized stream. Rejecting at the adapter surfaces a clear message instead of an opaque upstream 502. The shared W-1c invoke core stays byte-identical to develop (move-not-rewrite).

### Gate results

- `bun test` (@stwd/plugin-capabilities): **81 pass / 0 fail**, 213 assertions
- `tsc --noEmit` (typecheck): clean
- `biome check` (touched files): clean
- `codex review --uncommitted`: no findings

### Notes

- Vendor-neutral: Steward is a reference broker; operators register the exact `(host,path,method)` for the OpenAI case (`api.openai.com`, `/v1/chat/completions`, `POST`).
- Serves elizaOS/eliza#11536 E1 consumers (OpenAI-compatible capability calls).
- **Do not merge** — wakesync reviews/merges on Steward.

Refs #150.

[sol-keymaker] — [sol-orch]
