### PR TITLE
fix: accept typed-data policies in API policy validation

### DIFF
--- a/packages/api/scripts/typed-data-policy-validation-mutation-proofs.sh
+++ b/packages/api/scripts/typed-data-policy-validation-mutation-proofs.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+TARGET="$ROOT/packages/api/src/services/policy-validation.ts"
+TEST="$ROOT/packages/api/src/__tests__/policy-validation.test.ts"
+BACKUP="$(mktemp)"
+cp "$TARGET" "$BACKUP"
+
+restore() {
+  cp "$BACKUP" "$TARGET"
+  rm -f "$BACKUP"
+}
+trap restore EXIT
+
+expect_test_failure() {
+  local label="$1"
+  if (cd "$ROOT" && bun test "$TEST" >/tmp/steward-typed-data-mutation.log 2>&1); then
+    echo "MUTATION SURVIVED: $label" >&2
+    cat /tmp/steward-typed-data-mutation.log >&2
+    exit 1
+  fi
+  echo "MUTATION KILLED: $label"
+}
+
+python3 - "$TARGET" <<'PY'
+from pathlib import Path
+import sys
+path = Path(sys.argv[1])
+text = path.read_text()
+old = '    case "typed-data": {'
+assert text.count(old) == 1
+path.write_text(text.replace(old, '    case "typed-data-disabled": {', 1))
+PY
+expect_test_failure "missing typed-data switch arm"
+cp "$BACKUP" "$TARGET"
+
+python3 - "$TARGET" <<'PY'
+from pathlib import Path
+import sys
+path = Path(sys.argv[1])
+text = path.read_text()
+old = '          config.messageConditions.length === 0 ||'
+assert text.count(old) == 1
+path.write_text(text.replace(old, '          false ||', 1))
+PY
+expect_test_failure "empty messageConditions permissive guard"
+cp "$BACKUP" "$TARGET"
+
+echo "All typed-data policy validation mutations were killed."

--- a/packages/api/src/__tests__/agent-policy-rules.test.ts
+++ b/packages/api/src/__tests__/agent-policy-rules.test.ts
@@ -7,6 +7,7 @@ import type { AppVariables } from "../services/context";
 
 const TENANT_ID = `policy-rules-tenant-${Date.now()}`;
 const AGENT_ID = `policy-rules-agent-${Date.now()}`;
+const TYPED_DATA_AGENT_ID = `typed-data-policy-agent-${Date.now()}`;
 
 async function makeApp() {
   const { agentRoutes } = await import("../routes/agents");
@@ -29,6 +30,8 @@ describe("agent policy rule CRUD", () => {
   beforeAll(async () => {
     process.env.STEWARD_PGLITE_MEMORY = "true";
     process.env.STEWARD_MASTER_PASSWORD = "agent-policy-rules-master-password";
+    process.env.STEWARD_AUDIT_HMAC_KEY =
+      "agent-policy-rules-test-audit-hmac-key-0123456789abcdef0123456789";
     const { db, client } = await createPGLiteDb("memory://");
     setPGLiteOverride(db, async () => {
       await client.close();
@@ -38,12 +41,22 @@ describe("agent policy rule CRUD", () => {
       name: "Policy Rules Tenant",
       apiKeyHash: "hash",
     });
-    await getDb().insert(agents).values({
-      id: AGENT_ID,
-      tenantId: TENANT_ID,
-      name: "Policy Rules Agent",
-      walletAddress: "0x1234567890123456789012345678901234567890",
-    });
+    await getDb()
+      .insert(agents)
+      .values([
+        {
+          id: AGENT_ID,
+          tenantId: TENANT_ID,
+          name: "Policy Rules Agent",
+          walletAddress: "0x1234567890123456789012345678901234567890",
+        },
+        {
+          id: TYPED_DATA_AGENT_ID,
+          tenantId: TENANT_ID,
+          name: "Typed Data Policy Agent",
+          walletAddress: "0x1234567890123456789012345678901234567891",
+        },
+      ]);
     await getDb()
       .insert(policies)
       .values({
@@ -60,6 +73,7 @@ describe("agent policy rule CRUD", () => {
     await closeDb();
     delete process.env.STEWARD_PGLITE_MEMORY;
     delete process.env.STEWARD_MASTER_PASSWORD;
+    delete process.env.STEWARD_AUDIT_HMAC_KEY;
   });
 
   it("creates, lists, gets, updates, and deletes nested policy rules", async () => {
@@ -163,5 +177,89 @@ describe("agent policy rule CRUD", () => {
     expect(response.status).toBe(201);
     expect(body.ok).toBe(true);
     expect(body.data.id).not.toBe("existing-spend");
+  });
+
+  it("stores a valid typed-data policy, rejects malformed replacement, and gates the public sign route", async () => {
+    const malformedResponse = await app.request(`/agents/${TYPED_DATA_AGENT_ID}/policies`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify([
+        {
+          id: "malformed",
+          type: "typed-data",
+          enabled: true,
+          config: { allowedChainIds: ["8453"] },
+        },
+      ]),
+    });
+    expect(malformedResponse.status).toBe(400);
+    expect(
+      await getDb().select().from(policies).where(eq(policies.agentId, TYPED_DATA_AGENT_ID)),
+    ).toHaveLength(0);
+
+    const allowedContract = "0x000000000022d473030f116ddee9f6b43ac78ba3";
+    const allowedSpender = "0x1111111111111111111111111111111111111111";
+    const storeResponse = await app.request(`/agents/${TYPED_DATA_AGENT_ID}/policies`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify([
+        {
+          id: "permit-policy",
+          type: "typed-data",
+          enabled: true,
+          config: {
+            verifyingContractAllowlist: [allowedContract],
+            allowedChainIds: [8453],
+            allowedPrimaryTypes: ["PermitSingle"],
+            messageConditions: [
+              { field: "spender", operator: "address_in", values: [allowedSpender] },
+              { field: "amount", operator: "uint_max", value: "1000" },
+            ],
+          },
+        },
+      ]),
+    });
+    expect(storeResponse.status).toBe(200);
+    const stored = await getDb()
+      .select()
+      .from(policies)
+      .where(eq(policies.agentId, TYPED_DATA_AGENT_ID));
+    expect(stored).toHaveLength(1);
+    expect(stored[0]?.type).toBe("typed-data");
+
+    const { vaultRoutes } = await import("../routes/vault");
+    const vaultApp = new Hono<{ Variables: AppVariables }>();
+    vaultApp.use("*", async (c, next) => {
+      c.set("tenantId", TENANT_ID);
+      c.set("authType", "session-jwt");
+      c.set("tenantRole", "owner");
+      c.set("userId", "00000000-0000-4000-8000-000000000001");
+      c.set("sessionMfaVerifiedAt", Date.now());
+      await next();
+    });
+    vaultApp.route("/vault", vaultRoutes);
+
+    const deniedResponse = await vaultApp.request(`/vault/${TYPED_DATA_AGENT_ID}/sign-typed-data`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        domain: { name: "Permit2", chainId: 8453, verifyingContract: allowedContract },
+        types: {
+          PermitSingle: [
+            { name: "spender", type: "address" },
+            { name: "amount", type: "uint256" },
+          ],
+        },
+        primaryType: "PermitSingle",
+        value: {
+          spender: "0x2222222222222222222222222222222222222222",
+          amount: "1001",
+        },
+      }),
+    });
+    expect(deniedResponse.status).toBe(403);
+    const deniedBody = (await deniedResponse.json()) as { ok: boolean; error?: string };
+    expect(deniedBody.ok).toBe(false);
+    expect(deniedBody.error).toBe("Transaction rejected by policy");
   });
 });

--- a/packages/api/src/__tests__/policy-validation.test.ts
+++ b/packages/api/src/__tests__/policy-validation.test.ts
@@ -364,46 +364,117 @@ describe("policy rule validation", () => {
     ).toBeNull();
   });
 
-  it("rejects malformed typed-data configs", () => {
+  it("accepts every typed-data message operator with evaluator-parity shapes", () => {
+    const address = "0x752B7AaD0089286EB7b553d84D05233d80c9FCB4";
     expect(
       getPolicyRulesValidationError([
         {
-          id: "td",
-          type: "typed-data",
-          enabled: true,
-          config: { verifyingContractAllowlist: ["not-an-address"] },
-        },
-      ]),
-    ).toContain("typed-data.verifyingContractAllowlist");
-
-    expect(
-      getPolicyRulesValidationError([
-        { id: "td", type: "typed-data", enabled: true, config: { allowedChainIds: [0] } },
-      ]),
-    ).toContain("typed-data.allowedChainIds");
-
-    expect(
-      getPolicyRulesValidationError([
-        {
-          id: "td",
+          id: "td-operators",
           type: "typed-data",
           enabled: true,
           config: {
-            messageConditions: [{ field: "value", operator: "uint_maximum", value: "1" }],
+            messageConditions: [
+              { field: "details.to", operator: "address_in", values: [address, address] },
+              { field: "from", operator: "address_not_in", values: [address] },
+              { field: "memo", operator: "eq", value: "" },
+              { field: "nonce", operator: "in", values: ["1", "01"] },
+              { field: "state", operator: "not_in", values: ["cancelled"] },
+              {
+                field: "amount",
+                operator: "uint_max",
+                value: ` 0x${"0".repeat(80)}ffff `,
+              },
+            ],
           },
         },
       ]),
-    ).toContain("typed-data.messageConditions");
+    ).toBeNull();
+  });
 
+  it("rejects typed-data values whose evaluator meaning would be absent or ambiguous", () => {
+    const invalidConfigs: unknown[] = [
+      { verifyingContractAllowlist: [] },
+      { verifyingContractBlocklist: [] },
+      { allowedChainIds: [] },
+      { allowedChainIds: [0] },
+      { allowedChainIds: [-1] },
+      { allowedChainIds: [1.5] },
+      { allowedChainIds: [Number.MAX_SAFE_INTEGER + 1] },
+      { allowedChainIds: ["8453"] },
+      { allowedDomainNames: [] },
+      { allowedDomainNames: [""] },
+      { allowedDomainNames: ["   "] },
+      { allowedDomainNames: [" Permit2 "] },
+      { allowedPrimaryTypes: [] },
+      { allowedPrimaryTypes: [""] },
+      { allowedPrimaryTypes: ["Permit Type"] },
+      { messageConditions: [] },
+      { messageConditions: [{ field: "to", operator: "address_in", values: [] }] },
+      { messageConditions: [{ field: "to", operator: "address_not_in", values: [] }] },
+      { messageConditions: [{ field: "state", operator: "in", values: [] }] },
+      { messageConditions: [{ field: "state", operator: "not_in", values: [] }] },
+      { messageConditions: [{ field: "amount", operator: "uint_max", value: "-1" }] },
+      { messageConditions: [{ field: "amount", operator: "uint_max", value: "1.5" }] },
+      {
+        messageConditions: [
+          {
+            field: "amount",
+            operator: "uint_max",
+            value: "115792089237316195423570985008687907853269984665640564039457584007913129639936",
+          },
+        ],
+      },
+    ];
+
+    for (const config of invalidConfigs) {
+      expect(
+        getPolicyRulesValidationError([
+          { id: "td-invalid", type: "typed-data", enabled: true, config },
+        ]),
+      ).toContain("typed-data");
+    }
+  });
+
+  it("rejects unknown keys, wrong operator shapes, unsafe paths, and malformed addresses", () => {
+    const address = "0x752B7AaD0089286EB7b553d84D05233d80c9FCB4";
+    const invalidConfigs: unknown[] = [
+      { allowedChainId: [8453] },
+      { verifyingContractAllowlist: ["not-an-address"] },
+      { verifyingContractAllowlist: [`${address}00`] },
+      { messageConditions: [{ field: "to", operator: "unknown", value: "x" }] },
+      { messageConditions: [{ field: "to", operator: "address_in", value: address }] },
+      {
+        messageConditions: [
+          { field: "to", operator: "address_in", values: [address], value: address },
+        ],
+      },
+      { messageConditions: [{ field: "memo", operator: "eq", values: ["x"] }] },
+      { messageConditions: [{ field: "memo", operator: "eq", value: "x", ignored: true }] },
+      { messageConditions: [{ field: "", operator: "eq", value: "x" }] },
+      { messageConditions: [{ field: "details..to", operator: "eq", value: "x" }] },
+      { messageConditions: [{ field: "__proto__.admin", operator: "eq", value: "true" }] },
+      { messageConditions: [{ field: "constructor.prototype", operator: "eq", value: "x" }] },
+    ];
+
+    for (const config of invalidConfigs) {
+      expect(
+        getPolicyRulesValidationError([
+          { id: "td-invalid", type: "typed-data", enabled: true, config },
+        ]),
+      ).toContain("typed-data");
+    }
+  });
+
+  it("rejects oversized typed-data strings at the policy-list boundary", () => {
     expect(
       getPolicyRulesValidationError([
         {
-          id: "td",
+          id: "td-large",
           type: "typed-data",
           enabled: true,
-          config: { messageConditions: [{ field: "to", operator: "address_in" }] },
+          config: { allowedDomainNames: ["x".repeat(70_000)] },
         },
       ]),
-    ).toContain("typed-data.messageConditions");
+    ).toContain("65536 bytes");
   });
 });

--- a/packages/api/src/__tests__/policy-validation.test.ts
+++ b/packages/api/src/__tests__/policy-validation.test.ts
@@ -329,4 +329,81 @@ describe("policy rule validation", () => {
       ]),
     ).toContain("65536 bytes");
   });
+
+  it("accepts a valid typed-data policy (regression: previously rejected as unknown type)", () => {
+    expect(
+      getPolicyRulesValidationError([
+        {
+          id: "td",
+          type: "typed-data",
+          enabled: true,
+          config: {
+            verifyingContractAllowlist: ["0xE7C3D8C9a439feDe00D2600032D5dB0Be71C3c29"],
+            allowedChainIds: [80002],
+            allowedDomainNames: ["JPY Coin"],
+            allowedPrimaryTypes: ["ReceiveWithAuthorization"],
+            messageConditions: [
+              {
+                field: "to",
+                operator: "address_in",
+                values: ["0x752B7AaD0089286EB7b553d84D05233d80c9FCB4"],
+              },
+              { field: "value", operator: "uint_max", value: "3000000000000000000" },
+            ],
+          },
+        },
+      ]),
+    ).toBeNull();
+
+    // An empty config is a valid (vacuously-passing) typed-data policy; its real
+    // value is that its existence enables typed-data signing at all.
+    expect(
+      getPolicyRulesValidationError([
+        { id: "td-empty", type: "typed-data", enabled: true, config: {} },
+      ]),
+    ).toBeNull();
+  });
+
+  it("rejects malformed typed-data configs", () => {
+    expect(
+      getPolicyRulesValidationError([
+        {
+          id: "td",
+          type: "typed-data",
+          enabled: true,
+          config: { verifyingContractAllowlist: ["not-an-address"] },
+        },
+      ]),
+    ).toContain("typed-data.verifyingContractAllowlist");
+
+    expect(
+      getPolicyRulesValidationError([
+        { id: "td", type: "typed-data", enabled: true, config: { allowedChainIds: [0] } },
+      ]),
+    ).toContain("typed-data.allowedChainIds");
+
+    expect(
+      getPolicyRulesValidationError([
+        {
+          id: "td",
+          type: "typed-data",
+          enabled: true,
+          config: {
+            messageConditions: [{ field: "value", operator: "uint_maximum", value: "1" }],
+          },
+        },
+      ]),
+    ).toContain("typed-data.messageConditions");
+
+    expect(
+      getPolicyRulesValidationError([
+        {
+          id: "td",
+          type: "typed-data",
+          enabled: true,
+          config: { messageConditions: [{ field: "to", operator: "address_in" }] },
+        },
+      ]),
+    ).toContain("typed-data.messageConditions");
+  });
 });

--- a/packages/api/src/services/policy-validation.ts
+++ b/packages/api/src/services/policy-validation.ts
@@ -55,6 +55,48 @@ function areOptionalEvmAddresses(value: unknown): boolean {
   return value === undefined || (Array.isArray(value) && value.every(isEvmAddress));
 }
 
+function hasOnlyKeys(value: Record<string, unknown>, allowed: ReadonlySet<string>): boolean {
+  return Object.keys(value).every((key) => allowed.has(key));
+}
+
+function isNonEmptyArrayOf(value: unknown, predicate: (entry: unknown) => boolean): boolean {
+  return Array.isArray(value) && value.length > 0 && value.every(predicate);
+}
+
+const TYPED_DATA_CONFIG_KEYS = new Set([
+  "verifyingContractAllowlist",
+  "verifyingContractBlocklist",
+  "allowedChainIds",
+  "allowedDomainNames",
+  "allowedPrimaryTypes",
+  "messageConditions",
+]);
+const TYPED_DATA_CONDITION_BASE_KEYS = new Set(["field", "operator"]);
+const TYPED_DATA_CONDITION_VALUE_KEYS = new Set(["field", "operator", "value"]);
+const TYPED_DATA_CONDITION_VALUES_KEYS = new Set(["field", "operator", "values"]);
+const FORBIDDEN_TYPED_DATA_PATH_SEGMENTS = new Set(["__proto__", "prototype", "constructor"]);
+
+function isTypedDataFieldPath(value: unknown): value is string {
+  if (typeof value !== "string" || value.length === 0) return false;
+  const segments = value.split(".");
+  return segments.every(
+    (segment) =>
+      /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(segment) &&
+      !FORBIDDEN_TYPED_DATA_PATH_SEGMENTS.has(segment),
+  );
+}
+
+function isTypedDataUintBound(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const trimmed = value.trim();
+  const hex = /^0x([0-9a-fA-F]+)$/.exec(trimmed);
+  if (hex) {
+    const normalized = hex[1]?.replace(/^0+/, "") || "0";
+    return normalized.length <= 64;
+  }
+  return isWeiString(trimmed);
+}
+
 function validatePolicyConfig(policy: PolicyRule): string | null {
   const config = policy.config;
 
@@ -248,76 +290,84 @@ function validatePolicyConfig(policy: PolicyRule): string | null {
       return null;
 
     case "typed-data": {
+      if (!hasOnlyKeys(config, TYPED_DATA_CONFIG_KEYS)) {
+        return "typed-data.config contains an unknown key";
+      }
       if (
         config.verifyingContractAllowlist !== undefined &&
-        !areOptionalEvmAddresses(config.verifyingContractAllowlist)
+        !isNonEmptyArrayOf(config.verifyingContractAllowlist, isEvmAddress)
       ) {
-        return "typed-data.verifyingContractAllowlist must be an EVM address array";
+        return "typed-data.verifyingContractAllowlist must be a non-empty EVM address array";
       }
       if (
         config.verifyingContractBlocklist !== undefined &&
-        !areOptionalEvmAddresses(config.verifyingContractBlocklist)
+        !isNonEmptyArrayOf(config.verifyingContractBlocklist, isEvmAddress)
       ) {
-        return "typed-data.verifyingContractBlocklist must be an EVM address array";
+        return "typed-data.verifyingContractBlocklist must be a non-empty EVM address array";
       }
       if (
         config.allowedChainIds !== undefined &&
-        (!Array.isArray(config.allowedChainIds) ||
-          config.allowedChainIds.some(
-            (chainId) => typeof chainId !== "number" || !Number.isInteger(chainId) || chainId <= 0,
-          ))
+        !isNonEmptyArrayOf(config.allowedChainIds, isPositiveInteger)
       ) {
-        return "typed-data.allowedChainIds must be a positive integer array";
+        return "typed-data.allowedChainIds must be a non-empty positive safe-integer array";
       }
       if (
         config.allowedDomainNames !== undefined &&
-        (!Array.isArray(config.allowedDomainNames) ||
-          config.allowedDomainNames.some((name) => typeof name !== "string" || !name.trim()))
+        !isNonEmptyArrayOf(
+          config.allowedDomainNames,
+          (name) => typeof name === "string" && name.length > 0 && name === name.trim(),
+        )
       ) {
-        return "typed-data.allowedDomainNames must be a string array";
+        return "typed-data.allowedDomainNames must be a non-empty array of trimmed strings";
       }
       if (
         config.allowedPrimaryTypes !== undefined &&
-        (!Array.isArray(config.allowedPrimaryTypes) ||
-          config.allowedPrimaryTypes.some((type) => typeof type !== "string" || !type.trim()))
+        !isNonEmptyArrayOf(
+          config.allowedPrimaryTypes,
+          (type) => typeof type === "string" && /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(type),
+        )
       ) {
-        return "typed-data.allowedPrimaryTypes must be a string array";
+        return "typed-data.allowedPrimaryTypes must be a non-empty EIP-712 type-name array";
       }
       if (config.messageConditions !== undefined) {
-        const validOperators = new Set([
-          "address_in",
-          "address_not_in",
-          "eq",
-          "in",
-          "not_in",
-          "uint_max",
-        ]);
         if (
           !Array.isArray(config.messageConditions) ||
+          config.messageConditions.length === 0 ||
           config.messageConditions.some((condition) => {
             if (
               !isPlainObject(condition) ||
-              typeof condition.field !== "string" ||
-              !condition.field.trim() ||
+              !isTypedDataFieldPath(condition.field) ||
               typeof condition.operator !== "string" ||
-              !validOperators.has(condition.operator)
+              !hasOnlyKeys(
+                condition,
+                condition.operator === "address_in" ||
+                  condition.operator === "address_not_in" ||
+                  condition.operator === "in" ||
+                  condition.operator === "not_in"
+                  ? TYPED_DATA_CONDITION_VALUES_KEYS
+                  : condition.operator === "eq" || condition.operator === "uint_max"
+                    ? TYPED_DATA_CONDITION_VALUE_KEYS
+                    : TYPED_DATA_CONDITION_BASE_KEYS,
+              )
             ) {
               return true;
             }
             if (condition.operator === "address_in" || condition.operator === "address_not_in") {
-              return !areOptionalEvmAddresses(condition.values) || condition.values === undefined;
+              return !isNonEmptyArrayOf(condition.values, isEvmAddress);
             }
             if (condition.operator === "in" || condition.operator === "not_in") {
-              return (
-                !Array.isArray(condition.values) ||
-                condition.values.some((value) => typeof value !== "string")
-              );
+              return !isNonEmptyArrayOf(condition.values, (value) => typeof value === "string");
             }
-            // eq / uint_max take a single string value.
-            return typeof condition.value !== "string" || !condition.value.trim();
+            if (condition.operator === "eq") {
+              return typeof condition.value !== "string";
+            }
+            if (condition.operator === "uint_max") {
+              return !isTypedDataUintBound(condition.value);
+            }
+            return true;
           })
         ) {
-          return "typed-data.messageConditions must be valid conditions (field, operator, and matching value/values)";
+          return "typed-data.messageConditions must be a non-empty array of valid conditions with exactly the matching value/values shape";
         }
       }
       return null;

--- a/packages/api/src/services/policy-validation.ts
+++ b/packages/api/src/services/policy-validation.ts
@@ -247,6 +247,82 @@ function validatePolicyConfig(policy: PolicyRule): string | null {
       }
       return null;
 
+    case "typed-data": {
+      if (
+        config.verifyingContractAllowlist !== undefined &&
+        !areOptionalEvmAddresses(config.verifyingContractAllowlist)
+      ) {
+        return "typed-data.verifyingContractAllowlist must be an EVM address array";
+      }
+      if (
+        config.verifyingContractBlocklist !== undefined &&
+        !areOptionalEvmAddresses(config.verifyingContractBlocklist)
+      ) {
+        return "typed-data.verifyingContractBlocklist must be an EVM address array";
+      }
+      if (
+        config.allowedChainIds !== undefined &&
+        (!Array.isArray(config.allowedChainIds) ||
+          config.allowedChainIds.some(
+            (chainId) => typeof chainId !== "number" || !Number.isInteger(chainId) || chainId <= 0,
+          ))
+      ) {
+        return "typed-data.allowedChainIds must be a positive integer array";
+      }
+      if (
+        config.allowedDomainNames !== undefined &&
+        (!Array.isArray(config.allowedDomainNames) ||
+          config.allowedDomainNames.some((name) => typeof name !== "string" || !name.trim()))
+      ) {
+        return "typed-data.allowedDomainNames must be a string array";
+      }
+      if (
+        config.allowedPrimaryTypes !== undefined &&
+        (!Array.isArray(config.allowedPrimaryTypes) ||
+          config.allowedPrimaryTypes.some((type) => typeof type !== "string" || !type.trim()))
+      ) {
+        return "typed-data.allowedPrimaryTypes must be a string array";
+      }
+      if (config.messageConditions !== undefined) {
+        const validOperators = new Set([
+          "address_in",
+          "address_not_in",
+          "eq",
+          "in",
+          "not_in",
+          "uint_max",
+        ]);
+        if (
+          !Array.isArray(config.messageConditions) ||
+          config.messageConditions.some((condition) => {
+            if (
+              !isPlainObject(condition) ||
+              typeof condition.field !== "string" ||
+              !condition.field.trim() ||
+              typeof condition.operator !== "string" ||
+              !validOperators.has(condition.operator)
+            ) {
+              return true;
+            }
+            if (condition.operator === "address_in" || condition.operator === "address_not_in") {
+              return !areOptionalEvmAddresses(condition.values) || condition.values === undefined;
+            }
+            if (condition.operator === "in" || condition.operator === "not_in") {
+              return (
+                !Array.isArray(condition.values) ||
+                condition.values.some((value) => typeof value !== "string")
+              );
+            }
+            // eq / uint_max take a single string value.
+            return typeof condition.value !== "string" || !condition.value.trim();
+          })
+        ) {
+          return "typed-data.messageConditions must be valid conditions (field, operator, and matching value/values)";
+        }
+      }
+      return null;
+    }
+
     case "raw-signing-chain":
       if (
         config.allowedChains !== undefined &&


### PR DESCRIPTION
Fixes https://github.com/Steward-Fi/steward/issues/162

`getPolicyConfigValidationError` had no `case "typed-data"`, so API policy writes rejected a policy type already supported by the DB, policy engine, vault, and public `sign-typed-data` route.

## Changes

- Accept `typed-data` policy configs through the API validator.
- Keep validator and evaluator shapes aligned for all six operators: `address_in`, `address_not_in`, `in`, `not_in`, `eq`, and `uint_max`.
- Fail closed on unknown config keys/operators, wrong `value`/`values` shapes, empty no-op arrays, malformed addresses, unsafe chain IDs, invalid or prototype-like field paths, invalid uint256 bounds, and oversized policy payloads.
- Preserve legitimate evaluator behavior, including duplicate entries, empty-string `eq`, numeric-like string equality/membership, decimal uint256 bounds, hex bounds, and zero-padded hex bounds.
- Add a real API integration proof: malformed policy replacement is not stored; a valid policy is stored and reaches `POST /vault/:agentId/sign-typed-data`, where it rejects a disallowed payload before signing.
- Add mutation proofs for the original missing-switch defect and an empty-condition permissive guard.

## Verification

- Policy/API/vault focused isolated suites: 19/19 files passed.
- Proxy governed execution + approvals isolated suites: 2/2 passed.
- Plugin capability tests run one file per process.
- DB migration regression files run one file per process.
- `bun run lint` passed.
- `bun run typecheck` passed.
- Codex review found no actionable defects.
- Mutation proof script killed both mutations.
