### PR TITLE
fix(compose): defer Monero password validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,6 +310,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Validate Monero compose profile contract
+        run: scripts/test-compose-monero.sh
+
       - name: Start compose stack
         env:
           POSTGRES_DB: "steward_test"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -364,6 +364,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Validate Monero compose profile contract
+        run: scripts/test-compose-monero.sh
+
       - name: Start compose stack
         env:
           POSTGRES_DB: "steward_test"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -149,23 +149,37 @@ services:
   #   STEWARD_MONERO_WALLET_RPC_URL=http://monero-wallet-rpc:18083/json_rpc in .env
   monero-wallet-rpc:
     # Pinned to the Monero release this integration was validated against.
-    image: ghcr.io/sethforprivacy/simple-monero-wallet-rpc:v0.18.5.0
+    image: ghcr.io/sethforprivacy/simple-monero-wallet-rpc:v0.18.5.0@sha256:7ed1d6c565313de6a8afc33f75f7b1ca31aebd15f59558428d2bbc6b6de16950
     container_name: steward-monero-wallet-rpc
     profiles: ["monero"]
     restart: unless-stopped
+    entrypoint: ["/bin/sh", "-ec"]
     command:
-      - "--daemon-address=${MONERO_DAEMON_ADDRESS:-node.sethforprivacy.com:18089}"
-      - "--untrusted-daemon"
-      # The image runs as monero:monero and prepares /home/monero/wallet —
-      # mounting the volume anywhere else leaves it root-owned and unwritable.
-      - "--wallet-dir=/home/monero/wallet"
-      - "--rpc-bind-ip=0.0.0.0"
-      - "--rpc-bind-port=18083"
-      - "--confirm-external-bind"
-      - "--rpc-login=steward:${MONERO_WALLET_RPC_PASSWORD:?MONERO_WALLET_RPC_PASSWORD must be set when the monero profile is enabled}"
-      - "--log-level=0"
+      - |
+        secret_file=/run/secrets/monero_wallet_rpc_password
+        if [ ! -r "$$secret_file" ]; then
+          echo "MONERO_WALLET_RPC_PASSWORD must be set and non-empty when the monero profile is enabled" >&2
+          exit 1
+        fi
+        password=$$(cat "$$secret_file")
+        if [ -z "$$password" ]; then
+          echo "MONERO_WALLET_RPC_PASSWORD must be set and non-empty when the monero profile is enabled" >&2
+          exit 1
+        fi
+        exec /entrypoint.sh \
+          "--daemon-address=${MONERO_DAEMON_ADDRESS:-node.sethforprivacy.com:18089}" \
+          "--untrusted-daemon" \
+          "--wallet-dir=/home/monero/wallet" \
+          "--rpc-bind-ip=0.0.0.0" \
+          "--rpc-bind-port=18083" \
+          "--confirm-external-bind" \
+          "--rpc-login=steward:$$password" \
+          "--log-level=0"
     volumes:
       - monero-wallet-cache:/home/monero/wallet
+    secrets:
+      - source: monero-wallet-rpc-password
+        target: monero_wallet_rpc_password
     # Dual-homed like steward-api: `backend` is internal-only (so only
     # steward-api can reach the RPC port), `public` provides egress to the
     # remote daemon. No host port is published.
@@ -241,6 +255,11 @@ volumes:
   # Disposable Monero wallet scan cache (canonical keys live in Postgres).
   monero-wallet-cache:
     driver: local
+
+# ── Secrets ───────────────────────────────────────────────────────────────────
+secrets:
+  monero-wallet-rpc-password:
+    environment: MONERO_WALLET_RPC_PASSWORD
 
 # ── Networks ──────────────────────────────────────────────────────────────────
 networks:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -198,7 +198,7 @@ any other operator's instance.
 | `STEWARD_AGENT_TOKEN` | Agent token for web/server-side routes | none | Required only by app paths that call Steward as an agent. |
 | `SKIP_MIGRATIONS` | Disable API startup migrations | false | Set `true` or `1` only when another process applies migrations. |
 | `STEWARD_MONERO_WALLET_RPC_URL` | monero-wallet-rpc sidecar endpoint | none | Empty disables Monero: every Monero endpoint fails closed with 503. In Compose use `http://monero-wallet-rpc:18083/json_rpc`. |
-| `MONERO_WALLET_RPC_PASSWORD` | Password for the sidecar's `--rpc-login` (username `steward`) | none | Required when the `monero` Compose profile is enabled; Compose derives `STEWARD_MONERO_WALLET_RPC_LOGIN` from it. |
+| `MONERO_WALLET_RPC_PASSWORD` | Password for the sidecar's `--rpc-login` (username `steward`) | none | Required when the `monero` Compose profile is enabled; Compose mounts it into the sidecar as a secret and derives `STEWARD_MONERO_WALLET_RPC_LOGIN` from it. |
 | `STEWARD_MONERO_DAEMON_URL` | Remote Monero daemon used for chain height at wallet creation | `http://node.sethforprivacy.com:18089` | Restricted public RPC is sufficient; keys never reach the daemon. Stagenet: `:38089`. |
 | `MONERO_DAEMON_ADDRESS` | Daemon `host:port` the sidecar syncs wallets against | `node.sethforprivacy.com:18089` | Keep consistent with `STEWARD_MONERO_DAEMON_URL`. A public node operator can correlate your IP with wallet activity — run your own daemon or Tor if that matters. |
 | `STEWARD_MONERO_NETWORK` | Monero network of the sidecar | `mainnet` | `mainnet` or `stagenet`; must match the sidecar's flags (add `--stagenet` there for stagenet). |

--- a/scripts/test-compose-monero.sh
+++ b/scripts/test-compose-monero.sh
@@ -1,0 +1,100 @@
+#!/bin/sh
+set -eu
+
+if docker compose version >/dev/null 2>&1; then
+  compose() {
+    docker compose "$@"
+  }
+elif command -v docker-compose >/dev/null 2>&1; then
+  compose() {
+    docker-compose "$@"
+  }
+else
+  echo "docker compose or docker-compose is required" >&2
+  exit 1
+fi
+
+export POSTGRES_DB=steward_test
+export POSTGRES_USER=steward
+export POSTGRES_PASSWORD=steward_ci
+export STEWARD_MASTER_PASSWORD=compose-contract-master-password
+export STEWARD_JWT_SECRET=compose-contract-jwt-secret-32-chars
+export STEWARD_AUDIT_HMAC_KEY=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+export STEWARD_KDF_SALT=abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789
+# Keep one-off contract containers and resources isolated from any local stack.
+export COMPOSE_PROJECT_NAME=steward-compose-monero-contract-$$
+
+sentinel_password=compose-monero-contract-sentinel
+rendered_config=$(mktemp)
+sidecar_config=$(mktemp)
+unset_log=$(mktemp)
+empty_log=$(mktemp)
+cleanup() {
+  MONERO_WALLET_RPC_PASSWORD=cleanup compose --profile monero down --volumes --remove-orphans >/dev/null 2>&1 || true
+  rm -f "$rendered_config" "$sidecar_config" "$unset_log" "$empty_log"
+}
+trap cleanup EXIT HUP INT TERM
+
+echo "compose-monero: base config accepts unset MONERO_WALLET_RPC_PASSWORD"
+(
+  unset MONERO_WALLET_RPC_PASSWORD
+  unset COMPOSE_PROFILES
+  compose config >/dev/null
+)
+
+echo "compose-monero: profiled sidecar fails closed with unset MONERO_WALLET_RPC_PASSWORD"
+if (
+  unset MONERO_WALLET_RPC_PASSWORD
+  export COMPOSE_PROFILES=monero
+  compose run --rm --no-deps monero-wallet-rpc >/dev/null 2>"$unset_log"
+); then
+  echo "monero-wallet-rpc started with unset MONERO_WALLET_RPC_PASSWORD" >&2
+  exit 1
+fi
+if ! grep -F 'MONERO_WALLET_RPC_PASSWORD' "$unset_log" >/dev/null; then
+  echo "unset password failed for an unexpected reason" >&2
+  cat "$unset_log" >&2
+  exit 1
+fi
+
+echo "compose-monero: profiled sidecar fails closed with empty MONERO_WALLET_RPC_PASSWORD"
+if (
+  MONERO_WALLET_RPC_PASSWORD=
+  export MONERO_WALLET_RPC_PASSWORD COMPOSE_PROFILES=monero
+  compose run --rm --no-deps monero-wallet-rpc >/dev/null 2>"$empty_log"
+); then
+  echo "monero-wallet-rpc started with empty MONERO_WALLET_RPC_PASSWORD" >&2
+  exit 1
+fi
+if ! grep -F 'MONERO_WALLET_RPC_PASSWORD must be set and non-empty' "$empty_log" >/dev/null; then
+  echo "empty password failed for an unexpected reason" >&2
+  cat "$empty_log" >&2
+  exit 1
+fi
+
+echo "compose-monero: secret reaches one-off sidecar container"
+(
+  MONERO_WALLET_RPC_PASSWORD=$sentinel_password
+  EXPECTED_MONERO_SECRET=$sentinel_password
+  export MONERO_WALLET_RPC_PASSWORD EXPECTED_MONERO_SECRET COMPOSE_PROFILES=monero
+  compose run --rm --no-deps \
+    --entrypoint /bin/sh \
+    -e EXPECTED_MONERO_SECRET \
+    monero-wallet-rpc \
+    -ec 'test -s /run/secrets/monero_wallet_rpc_password && value=$(cat /run/secrets/monero_wallet_rpc_password) && test "$value" = "$EXPECTED_MONERO_SECRET"' \
+    >/dev/null
+)
+
+echo "compose-monero: rendered sidecar config does not contain the password"
+(
+  MONERO_WALLET_RPC_PASSWORD=$sentinel_password
+  export MONERO_WALLET_RPC_PASSWORD COMPOSE_PROFILES=monero
+  compose config >"$rendered_config"
+)
+sed -n '/^  monero-wallet-rpc:/,/^  [A-Za-z0-9_-][A-Za-z0-9_-]*:/p' "$rendered_config" >"$sidecar_config"
+if grep -F "$sentinel_password" "$sidecar_config" >/dev/null; then
+  echo "rendered monero-wallet-rpc config contains the password" >&2
+  exit 1
+fi
+
+echo "compose-monero: ok"


### PR DESCRIPTION
## Summary

Fixes the optional Monero profile breaking every normal Compose invocation before profile filtering.

- removes config-time required interpolation from the optional service
- passes the password as an environment-backed Compose secret
- validates readable + non-empty secret at container runtime before wallet-rpc starts
- delegates to the image's real `/entrypoint.sh`, preserving fixuid/startup behavior
- pins the validated image digest
- adds a deterministic Compose contract test to CI and PR E2E workflows

## Security invariants

- base Compose works with no Monero password
- enabling Monero with unset/empty password fails closed
- password is mounted only into the sidecar
- rendered sidecar config does not contain the password
- no Steward services or production stack started during tests

## Verification

`scripts/test-compose-monero.sh` proves:

- base config succeeds without password
- profiled sidecar rejects unset password
- profiled sidecar rejects empty password
- set password reaches one-off sidecar via secret
- sentinel does not appear in rendered config

Additional: `sh -n`, Compose config quiet checks, `git diff --check`, Codex review all green.

This unblocks the repo-wide `E2E Integration (Compose)` check currently failing on unrelated PRs.

— [sol-orch]
