### PR TITLE
feat(trading): add governed Polymarket lifecycle

### DIFF
--- a/packages/plugin-trading/src/__tests__/operator-path-allowlist.test.ts
+++ b/packages/plugin-trading/src/__tests__/operator-path-allowlist.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "bun:test";
 import { Hono } from "hono";
 
-import { isAgentOrderPath, isOperatorRecoveryPath, tradingPlugin } from "../index";
+import {
+  isAgentOrderPath,
+  isAgentOrOperatorTradeWritePath,
+  isAgentPolymarketReadPath,
+  isOperatorRecoveryPath,
+  tradingPlugin,
+} from "../index";
 
 /**
  * Regression guard for the "added an operator route but forgot the auth
@@ -24,6 +30,40 @@ const OPERATOR_ROUTES = [
   "usd-send",
 ];
 
+function jwtWithHeaderAlg(alg: string, payload: Record<string, unknown> = {}) {
+  const encode = (value: unknown) =>
+    btoa(JSON.stringify(value)).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  return `${encode({ alg, kid: "k" })}.${encode(payload)}.sig`;
+}
+
+function mountedAuthApp() {
+  const app = new Hono();
+  const ctx = {
+    requireAgentJwt: () => new Response("agent-jwt", { status: 418 }),
+    operatorAuth: () => new Response("operator", { status: 419 }),
+    tenantAuth: () => new Response("tenant", { status: 420 }),
+  };
+  tradingPlugin.register(app as never, ctx as never);
+  return app;
+}
+
+function mountedLegacyAgentFallbackApp() {
+  const app = new Hono();
+  const legacyAgentFallback = async (c: never, next: () => Promise<Response | void>) => {
+    const context = c as { set: (key: string, value: unknown) => void };
+    context.set("authType", "agent-token");
+    context.set("agentScope", "legacy-agent");
+    return next();
+  };
+  const ctx = {
+    requireAgentJwt: () => new Response("agent-jwt", { status: 418 }),
+    operatorAuth: legacyAgentFallback,
+    tenantAuth: legacyAgentFallback,
+  };
+  tradingPlugin.register(app as never, ctx as never);
+  return app;
+}
+
 describe("operator-recovery auth allowlist", () => {
   for (const route of OPERATOR_ROUTES) {
     it(`gates /v1/trade/hyperliquid/${route} as an operator path`, () => {
@@ -41,24 +81,135 @@ describe("operator-recovery auth allowlist", () => {
     }
   });
 
+  it("classifies Polymarket cancel routes for agent-or-operator write auth", () => {
+    for (const prefix of ["/trade", "/v1/trade"]) {
+      expect(isAgentOrOperatorTradeWritePath(`${prefix}/polymarket/orders/order-1/cancel`)).toBe(
+        true,
+      );
+      expect(isAgentOrOperatorTradeWritePath(`${prefix}/polymarket/cancel-all`)).toBe(true);
+      expect(isOperatorRecoveryPath(`${prefix}/polymarket/orders/order-1/cancel`)).toBe(false);
+      expect(isOperatorRecoveryPath(`${prefix}/polymarket/cancel-all`)).toBe(false);
+    }
+  });
+
+  it("classifies Polymarket order and position reads for agent-or-tenant auth", () => {
+    for (const prefix of ["/trade", "/v1/trade"]) {
+      expect(isAgentPolymarketReadPath(`${prefix}/polymarket/orders`)).toBe(true);
+      expect(isAgentPolymarketReadPath(`${prefix}/polymarket/positions`)).toBe(true);
+      expect(isOperatorRecoveryPath(`${prefix}/polymarket/orders`)).toBe(false);
+      expect(isOperatorRecoveryPath(`${prefix}/polymarket/positions`)).toBe(false);
+    }
+  });
+
   it("does NOT treat unrelated paths as operator paths", () => {
     expect(isOperatorRecoveryPath("/v1/trade/sessions")).toBe(false);
     expect(isOperatorRecoveryPath("/v1/agents/sol-waifu/policy")).toBe(false);
   });
 
   it("actually mounts the strict agent-JWT middleware on Polymarket order routes", async () => {
-    const app = new Hono();
-    const ctx = {
-      requireAgentJwt: () => new Response("agent-jwt", { status: 418 }),
-      operatorAuth: () => new Response("operator", { status: 419 }),
-      tenantAuth: () => new Response("tenant", { status: 420 }),
-    };
-    tradingPlugin.register(app as never, ctx as never);
+    const app = mountedAuthApp();
 
     for (const path of ["/trade/polymarket/order", "/v1/trade/polymarket/order"]) {
       const res = await app.request(path, { method: "POST" });
       expect(res.status).toBe(418);
       expect(await res.text()).toBe("agent-jwt");
+    }
+  });
+
+  it("mounts Polymarket reads on strict RS256 agent JWT or tenant auth for both prefixes", async () => {
+    const app = mountedAuthApp();
+
+    for (const prefix of ["/trade", "/v1/trade"]) {
+      for (const readPath of ["/polymarket/orders", "/polymarket/positions"]) {
+        const agent = await app.request(`${prefix}${readPath}`, {
+          method: "GET",
+          headers: { Authorization: `Bearer ${jwtWithHeaderAlg("RS256", { scope: "agent" })}` },
+        });
+        expect(agent.status).toBe(418);
+        expect(await agent.text()).toBe("agent-jwt");
+
+        const tenant = await app.request(`${prefix}${readPath}`, {
+          method: "GET",
+          headers: { "X-Steward-Key": "tenant-key", "X-Steward-Tenant": "tenant-1" },
+        });
+        expect(tenant.status).toBe(420);
+        expect(await tenant.text()).toBe("tenant");
+
+        const forgedPayload = await app.request(`${prefix}${readPath}`, {
+          method: "GET",
+          headers: {
+            Authorization: `Bearer ${jwtWithHeaderAlg("HS256", {
+              alg: "RS256",
+              scope: "agent",
+            })}`,
+          },
+        });
+        expect(forgedPayload.status).toBe(420);
+        expect(await forgedPayload.text()).toBe("tenant");
+      }
+    }
+  });
+
+  it("mounts Polymarket cancel writes on strict RS256 agent JWT or operator auth for both prefixes", async () => {
+    const app = mountedAuthApp();
+
+    for (const prefix of ["/trade", "/v1/trade"]) {
+      const agent = await app.request(`${prefix}/polymarket/cancel-all`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${jwtWithHeaderAlg("RS256", { scope: "agent" })}` },
+      });
+      expect(agent.status).toBe(418);
+      expect(await agent.text()).toBe("agent-jwt");
+
+      const tenantAdmin = await app.request(`${prefix}/polymarket/cancel-all`, {
+        method: "POST",
+        headers: { "X-Steward-Key": "tenant-key", "X-Steward-Tenant": "tenant-1" },
+      });
+      expect(tenantAdmin.status).toBe(419);
+      expect(await tenantAdmin.text()).toBe("operator");
+
+      const platform = await app.request(`${prefix}/polymarket/orders/order-1/cancel`, {
+        method: "POST",
+        headers: { "X-Steward-Platform-Key": "test" },
+      });
+      expect(platform.status).toBe(419);
+      expect(await platform.text()).toBe("operator");
+
+      const forgedPayload = await app.request(`${prefix}/polymarket/orders/order-1/cancel`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${jwtWithHeaderAlg("HS256", {
+            alg: "RS256",
+            scope: "agent",
+          })}`,
+        },
+      });
+      expect(forgedPayload.status).toBe(419);
+      expect(await forgedPayload.text()).toBe("operator");
+    }
+  });
+
+  it("rejects legacy non-RS256 agent tokens accepted by tenant/operator fallbacks", async () => {
+    const app = mountedLegacyAgentFallbackApp();
+    const legacyAgent = `Bearer ${jwtWithHeaderAlg("HS256", { scope: "agent" })}`;
+
+    for (const prefix of ["/trade", "/v1/trade"]) {
+      for (const path of [
+        `${prefix}/polymarket/orders`,
+        `${prefix}/polymarket/positions`,
+        `${prefix}/polymarket/cancel-all`,
+        `${prefix}/polymarket/orders/order-1/cancel`,
+      ]) {
+        const res = await app.request(path, {
+          method: path.endsWith("cancel") || path.endsWith("cancel-all") ? "POST" : "GET",
+          headers: { Authorization: legacyAgent },
+        });
+        expect(res.status).toBe(403);
+        expect((await res.json()) as unknown).toMatchObject({
+          ok: false,
+          error: "RS256 agent JWT required",
+        });
+      }
     }
   });
 });

--- a/packages/plugin-trading/src/__tests__/trade-polymarket-order.test.ts
+++ b/packages/plugin-trading/src/__tests__/trade-polymarket-order.test.ts
@@ -149,6 +149,22 @@ function postOrder(
   });
 }
 
+function cancelOrder(app: Hono, sessionId: string, orderId: string, idempotencyKey: string) {
+  return app.request(`/v1/trade/polymarket/orders/${orderId}/cancel`, {
+    method: "POST",
+    headers: { "content-type": "application/json", "Idempotency-Key": idempotencyKey },
+    body: JSON.stringify({ sessionId }),
+  });
+}
+
+function cancelAll(app: Hono, sessionId: string, idempotencyKey: string, market?: string) {
+  return app.request("/v1/trade/polymarket/cancel-all", {
+    method: "POST",
+    headers: { "content-type": "application/json", "Idempotency-Key": idempotencyKey },
+    body: JSON.stringify({ sessionId, ...(market ? { market } : {}) }),
+  });
+}
+
 async function dailySpendOf(sessionId: string): Promise<number> {
   const [row] = await getDb()
     .select({ spent: tradeSessions.dailySpendUsd })
@@ -395,6 +411,431 @@ describe("POST /v1/trade/polymarket/order", () => {
       expect(await auditCount(tenantId, "trade.order.canceled")).toBe(0);
     } finally {
       delete process.env.STEWARD_PM_TEST_CREDS;
+    }
+  });
+
+  it("lists open orders through the real governed agent/session/wallet binding", async () => {
+    const { tenantId, agentId, sessionId } = await seedSession({});
+    const app = makeApp(tenantId, agentId, tradeRoutes);
+
+    process.env.STEWARD_PM_TEST_CREDS = "1";
+    stubWallet(true);
+    const listSpy = spyOn(PolymarketExecutionAdapter.prototype, "listOrders").mockResolvedValue([
+      {
+        id: "pm-open-1",
+        market: COND_ID,
+        asset_id: TOKEN_ID,
+        side: "BUY",
+        price: "0.5",
+        original_size: "20",
+        size_matched: "0",
+        status: "LIVE",
+      },
+    ] as never);
+
+    try {
+      const res = await app.request(
+        `/v1/trade/polymarket/orders?sessionId=${encodeURIComponent(sessionId)}`,
+      );
+      expect(res.status).toBe(200);
+      expect((await res.json()) as unknown).toMatchObject({
+        ok: true,
+        data: { agentId, orders: [{ id: "pm-open-1", asset_id: TOKEN_ID }] },
+      });
+      expect(listSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      listSpy.mockRestore();
+      delete process.env.STEWARD_PM_TEST_CREDS;
+    }
+  });
+
+  it("lists positions by funder address without deriving CLOB credentials", async () => {
+    const { tenantId, agentId, sessionId } = await seedSession({});
+    const app = makeApp(tenantId, agentId, tradeRoutes);
+
+    stubWallet(true);
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation((async (input: string | URL) => {
+      const url = new URL(String(input));
+      expect(url.pathname).toBe("/positions");
+      expect(url.searchParams.get("user")?.toLowerCase()).toBe(FUNDER.toLowerCase());
+      return new Response(
+        JSON.stringify([
+          {
+            asset: TOKEN_ID,
+            title: "Will lifecycle pass?",
+            outcome: "Yes",
+            size: 3,
+            avgPrice: 0.4,
+            curPrice: 0.5,
+          },
+        ]),
+        { status: 200 },
+      );
+    }) as never);
+
+    try {
+      const res = await app.request(
+        `/v1/trade/polymarket/positions?sessionId=${encodeURIComponent(sessionId)}`,
+      );
+      expect(res.status).toBe(200);
+      expect((await res.json()) as unknown).toMatchObject({
+        ok: true,
+        data: {
+          agentId,
+          funderAddress: FUNDER,
+          positions: [{ tokenId: TOKEN_ID, balance: 3, currentValue: 1.5 }],
+        },
+      });
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("cancel order is governed, audited, idempotent, and does not reserve spend", async () => {
+    const { tenantId, agentId, sessionId } = await seedSession({});
+    const app = makeApp(tenantId, agentId, tradeRoutes);
+
+    process.env.STEWARD_PM_TEST_CREDS = "1";
+    stubWallet(true);
+    const cancelSpy = spyOn(PolymarketExecutionAdapter.prototype, "cancelOrder").mockResolvedValue({
+      venue: "polymarket" as const,
+      orderId: "pm-open-1",
+      raw: { canceled: ["pm-open-1"] },
+    });
+
+    try {
+      const key = crypto.randomUUID();
+      const first = await cancelOrder(app, sessionId, "pm-open-1", key);
+      expect(first.status).toBe(200);
+      expect((await first.json()) as unknown).toMatchObject({
+        ok: true,
+        data: { status: "cancel_requested", orderId: "pm-open-1" },
+      });
+      const replay = await cancelOrder(app, sessionId, "pm-open-1", key);
+      expect(replay.status).toBe(200);
+      expect(replay.headers.get("Idempotency-Replayed")).toBe("true");
+      expect(cancelSpy).toHaveBeenCalledTimes(1);
+      expect(await dailySpendOf(sessionId)).toBe(0);
+      expect(await auditCount(tenantId, "trade.order.cancel.authorized")).toBe(1);
+      expect(await auditCount(tenantId, "trade.order.canceled")).toBe(1);
+    } finally {
+      cancelSpy.mockRestore();
+      delete process.env.STEWARD_PM_TEST_CREDS;
+    }
+  });
+
+  it("cancel unknown status is replayed and not retried", async () => {
+    const { tenantId, agentId, sessionId } = await seedSession({});
+    const app = makeApp(tenantId, agentId, tradeRoutes);
+
+    process.env.STEWARD_PM_TEST_CREDS = "1";
+    stubWallet(true);
+    const cancelSpy = spyOn(PolymarketExecutionAdapter.prototype, "cancelOrder").mockRejectedValue(
+      new Error("cancel timeout"),
+    );
+
+    try {
+      const key = crypto.randomUUID();
+      const first = await cancelOrder(app, sessionId, "pm-open-unknown", key);
+      expect(first.status).toBe(502);
+      expect((await first.json()) as unknown).toMatchObject({
+        ok: false,
+        error: "Polymarket cancel status unknown",
+        data: { status: "unknown" },
+      });
+      const replay = await cancelOrder(app, sessionId, "pm-open-unknown", key);
+      expect(replay.status).toBe(502);
+      expect(replay.headers.get("Idempotency-Replayed")).toBe("true");
+      expect(cancelSpy).toHaveBeenCalledTimes(1);
+      expect(await auditCount(tenantId, "trade.order.canceled")).toBe(1);
+    } finally {
+      cancelSpy.mockRestore();
+      delete process.env.STEWARD_PM_TEST_CREDS;
+    }
+  });
+
+  it("cancel refuses a revoked session before touching credentials or the adapter", async () => {
+    const { tenantId, agentId, sessionId } = await seedSession({ status: "revoked" });
+    const app = makeApp(tenantId, agentId, tradeRoutes);
+
+    process.env.STEWARD_PM_TEST_CREDS = "1";
+    const cancelSpy = spyOn(PolymarketExecutionAdapter.prototype, "cancelOrder").mockResolvedValue(
+      {} as never,
+    );
+
+    try {
+      const res = await cancelOrder(app, sessionId, "pm-open-1", crypto.randomUUID());
+      expect(res.status).toBe(403);
+      expect(((await res.json()) as { error?: string }).error).toContain(
+        "Active Polymarket session required",
+      );
+      expect(getWalletSpy).toBeUndefined();
+      expect(cancelSpy).not.toHaveBeenCalled();
+      expect(await dailySpendOf(sessionId)).toBe(0);
+    } finally {
+      cancelSpy.mockRestore();
+      delete process.env.STEWARD_PM_TEST_CREDS;
+    }
+  });
+
+  it("cancel-all composes real list/cancel adapter support", async () => {
+    const { tenantId, agentId, sessionId } = await seedSession({});
+    const app = makeApp(tenantId, agentId, tradeRoutes);
+
+    process.env.STEWARD_PM_TEST_CREDS = "1";
+    stubWallet(true);
+    const requests: Array<{ method: string; path: string; body?: unknown }> = [];
+    type ClobHttpOptions = {
+      headers?: Record<string, string>;
+      data?: unknown;
+      params?: Record<string, unknown>;
+    };
+    type ClobHttpPrototype = {
+      get(endpoint: string, options?: ClobHttpOptions): Promise<unknown>;
+      del(endpoint: string, options?: ClobHttpOptions): Promise<unknown>;
+    };
+    const clobPrototype = ClobClient.prototype as unknown as ClobHttpPrototype;
+    const getSpy = spyOn(clobPrototype, "get").mockImplementation((async (
+      endpoint: string,
+      options?: ClobHttpOptions,
+    ) => {
+      const path = new URL(endpoint).pathname;
+      requests.push({ method: "GET", path });
+      expect(path).toBe("/data/orders");
+      expect(options?.params?.market).toBe(COND_ID);
+      expect(options?.params?.next_cursor).toBe("MA==");
+      return {
+        data: [
+          {
+            id: "pm-open-1",
+            market: COND_ID,
+            asset_id: TOKEN_ID,
+            side: "BUY",
+            price: "0.5",
+            original_size: "20",
+            size_matched: "0",
+            status: "LIVE",
+          },
+          {
+            id: "pm-open-2",
+            market: COND_ID,
+            asset_id: TOKEN_ID,
+            side: "SELL",
+            price: "0.6",
+            original_size: "5",
+            size_matched: "0",
+            status: "LIVE",
+          },
+        ],
+        next_cursor: "LTE=",
+      };
+    }) as never);
+    const delSpy = spyOn(clobPrototype, "del").mockImplementation((async (
+      endpoint: string,
+      options?: ClobHttpOptions,
+    ) => {
+      const path = new URL(endpoint).pathname;
+      requests.push({ method: "DELETE", path, body: options?.data });
+      expect(path).toBe("/order");
+      return { canceled: [(options?.data as { orderID?: string } | undefined)?.orderID] };
+    }) as never);
+
+    try {
+      const res = await cancelAll(app, sessionId, crypto.randomUUID(), COND_ID);
+      expect(res.status).toBe(200);
+      expect((await res.json()) as unknown).toMatchObject({
+        ok: true,
+        data: { status: "cancel_requested", canceledCount: 2 },
+      });
+      expect(requests.filter((r) => r.path === "/data/orders")).toHaveLength(1);
+      expect(requests.filter((r) => r.method === "DELETE")).toHaveLength(2);
+    } finally {
+      getSpy.mockRestore();
+      delSpy.mockRestore();
+      delete process.env.STEWARD_PM_TEST_CREDS;
+    }
+  });
+
+  it("cancel refuses stale session wallet binding before touching the adapter", async () => {
+    const { tenantId, agentId, sessionId } = await seedSession({
+      walletId: "0x2222222222222222222222222222222222222222",
+    });
+    const app = makeApp(tenantId, agentId, tradeRoutes);
+
+    process.env.STEWARD_PM_TEST_CREDS = "1";
+    stubWallet(true);
+    const cancelSpy = spyOn(PolymarketExecutionAdapter.prototype, "cancelOrder").mockResolvedValue(
+      {} as never,
+    );
+
+    try {
+      const res = await cancelOrder(app, sessionId, "pm-open-1", crypto.randomUUID());
+      expect(res.status).toBe(409);
+      expect(cancelSpy).not.toHaveBeenCalled();
+      expect(await auditCount(tenantId, "trade.order.policy-rejected")).toBe(1);
+    } finally {
+      cancelSpy.mockRestore();
+      delete process.env.STEWARD_PM_TEST_CREDS;
+    }
+  });
+
+  it("deterministic lifecycle E2E: real vault creds, CLOB list/cancel, and Data positions", async () => {
+    const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const tenantId = `pm-life-tenant-${suffix}`;
+    const agentId = `pm-life-agent-${suffix}`;
+    await getDb()
+      .insert(tenants)
+      .values({ id: tenantId, name: "PM Lifecycle Tenant", apiKeyHash: `hash-${tenantId}` });
+    await getDb().insert(agents).values({
+      id: agentId,
+      tenantId,
+      name: "PM Lifecycle Agent",
+      walletAddress: "0x0000000000000000000000000000000000000001",
+    });
+    await getDb()
+      .insert(agentPolicies)
+      .values({
+        agentId,
+        tenantId,
+        dailyCapUsd: "100",
+        perOrderCapUsd: "25",
+        leverageCap: "1",
+        allowedAssets: [`pm:${TOKEN_ID}`],
+        allowedVenues: ["polymarket"],
+        updatedBy: "lifecycle-human-policy",
+      });
+
+    const wallet = await sharedTestContext.vault.createWallet({
+      agentId,
+      venue: "polymarket",
+      chainType: "evm",
+    });
+    await getDb()
+      .update(agentWallets)
+      .set({ metadata: { funderAddress: FUNDER } })
+      .where(and(eq(agentWallets.agentId, agentId), eq(agentWallets.venue, "polymarket")));
+
+    const requests: Array<{ method: string; path: string; body?: unknown }> = [];
+    type ClobHttpOptions = { headers?: Record<string, string>; data?: unknown };
+    type ClobHttpPrototype = {
+      get(endpoint: string, options?: ClobHttpOptions): Promise<unknown>;
+      post(endpoint: string, options?: ClobHttpOptions): Promise<unknown>;
+      del(endpoint: string, options?: ClobHttpOptions): Promise<unknown>;
+    };
+    const clobPrototype = ClobClient.prototype as unknown as ClobHttpPrototype;
+    const getSpy = spyOn(clobPrototype, "get").mockImplementation((async (
+      endpoint: string,
+      options?: { params?: Record<string, unknown> },
+    ) => {
+      const path = new URL(endpoint).pathname;
+      requests.push({ method: "GET", path });
+      if (path === "/data/orders") {
+        expect(options?.params?.next_cursor).toBe("MA==");
+        expect(options?.params?.market).toBeUndefined();
+        return {
+          data: [
+            {
+              id: "pm-life-open-1",
+              market: COND_ID,
+              asset_id: TOKEN_ID,
+              side: "BUY",
+              price: "0.5",
+              original_size: "20",
+              size_matched: "0",
+              status: "LIVE",
+            },
+          ],
+          next_cursor: "LTE=",
+        };
+      }
+      throw new Error(`unexpected deterministic CLOB GET ${path}`);
+    }) as never);
+    const postSpy = spyOn(clobPrototype, "post").mockImplementation((async (
+      endpoint: string,
+      options?: ClobHttpOptions,
+    ) => {
+      const path = new URL(endpoint).pathname;
+      requests.push({ method: "POST", path, body: options?.data });
+      const headers = new Headers(options?.headers);
+      if (path === "/auth/api-key") {
+        expect(headers.get("poly_address")?.toLowerCase()).toBe(wallet.address.toLowerCase());
+        return {
+          apiKey: "deterministic-life-key",
+          secret: "ZGV0ZXJtaW5pc3RpYy1saWZlLXNlY3JldA==",
+          passphrase: "deterministic-life-passphrase",
+        };
+      }
+      throw new Error(`unexpected deterministic CLOB POST ${path}`);
+    }) as never);
+    const deleteSpy = spyOn(clobPrototype, "del").mockImplementation((async (
+      endpoint: string,
+      options?: ClobHttpOptions,
+    ) => {
+      const path = new URL(endpoint).pathname;
+      requests.push({ method: "DELETE", path, body: options?.data });
+      const headers = new Headers(options?.headers);
+      expect(headers.get("poly_api_key")).toBe("deterministic-life-key");
+      return { canceled: ["pm-life-open-1"] };
+    }) as never);
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation((async (input: string | URL) => {
+      const url = new URL(String(input));
+      requests.push({ method: "GET", path: url.pathname });
+      expect(url.pathname).toBe("/positions");
+      expect(url.searchParams.get("user")?.toLowerCase()).toBe(FUNDER.toLowerCase());
+      return new Response(
+        JSON.stringify([{ asset: TOKEN_ID, outcome: "Yes", size: 4, curPrice: 0.25 }]),
+        { status: 200 },
+      );
+    }) as never);
+
+    process.env.POLYMARKET_CLOB_API_URL = "https://clob.lifecycle.invalid";
+    try {
+      const app = makeApp(tenantId, agentId, tradeRoutes);
+      const sessionRes = await app.request("/v1/trade/sessions", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          agentId,
+          venue: "polymarket",
+          dailyCap: 40,
+          perOrderCap: 20,
+          allowedAssets: [`pm:${TOKEN_ID}`],
+        }),
+      });
+      expect(sessionRes.status).toBe(201);
+      const sessionBody = (await sessionRes.json()) as { data: { sessionId: string } };
+
+      const list = await app.request(
+        `/v1/trade/polymarket/orders?sessionId=${encodeURIComponent(sessionBody.data.sessionId)}`,
+      );
+      expect(list.status).toBe(200);
+      expect((await list.json()) as unknown).toMatchObject({
+        ok: true,
+        data: { orders: [{ id: "pm-life-open-1" }] },
+      });
+
+      const positions = await app.request(
+        `/v1/trade/polymarket/positions?sessionId=${encodeURIComponent(sessionBody.data.sessionId)}`,
+      );
+      expect(positions.status).toBe(200);
+      expect((await positions.json()) as unknown).toMatchObject({
+        ok: true,
+        data: { positions: [{ tokenId: TOKEN_ID, balance: 4, currentValue: 1 }] },
+      });
+
+      const key = `pm-life-cancel-${crypto.randomUUID()}`;
+      const cancel = await cancelOrder(app, sessionBody.data.sessionId, "pm-life-open-1", key);
+      expect(cancel.status).toBe(200);
+      const replay = await cancelOrder(app, sessionBody.data.sessionId, "pm-life-open-1", key);
+      expect(replay.headers.get("Idempotency-Replayed")).toBe("true");
+      expect(requests.filter((r) => r.path === "/auth/api-key")).toHaveLength(2);
+      expect(requests.filter((r) => r.method === "DELETE")).toHaveLength(1);
+    } finally {
+      delete process.env.POLYMARKET_CLOB_API_URL;
+      getSpy.mockRestore();
+      postSpy.mockRestore();
+      deleteSpy.mockRestore();
+      fetchSpy.mockRestore();
     }
   });
 

--- a/packages/plugin-trading/src/index.ts
+++ b/packages/plugin-trading/src/index.ts
@@ -45,6 +45,13 @@ export type StewardApiPlugin = StewardPlugin<StewardApp, StewardAppContext>;
 export const isAgentOrderPath = (path: string): boolean =>
   path.endsWith("/trade/hyperliquid/order") || path.endsWith("/trade/polymarket/order");
 
+export const isAgentPolymarketReadPath = (path: string): boolean =>
+  path.endsWith("/trade/polymarket/orders") || path.endsWith("/trade/polymarket/positions");
+
+export const isAgentOrOperatorTradeWritePath = (path: string): boolean =>
+  path.endsWith("/trade/polymarket/cancel-all") ||
+  /\/trade\/polymarket\/orders\/[^/]+\/cancel$/.test(path);
+
 export const isOperatorRecoveryPath = (path: string): boolean =>
   path.endsWith("/close-all") ||
   path.endsWith("/withdraw") ||
@@ -54,6 +61,19 @@ export const isOperatorRecoveryPath = (path: string): boolean =>
   path.endsWith("/add-margin") ||
   path.endsWith("/approve-builder") ||
   path.endsWith("/usd-send");
+
+function decodeJwtHeaderAlg(token: string | undefined): string | undefined {
+  const encoded = token?.split(".")[0];
+  if (!encoded) return undefined;
+  try {
+    const normalized = encoded.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = normalized.padEnd(normalized.length + ((4 - (normalized.length % 4)) % 4), "=");
+    const json = atob(padded);
+    return (JSON.parse(json) as { alg?: unknown }).alg as string | undefined;
+  } catch {
+    return undefined;
+  }
+}
 
 /**
  * Webhook event-type names the trading plugin's domain produces. These are
@@ -100,6 +120,24 @@ export const tradingPlugin: StewardApiPlugin = {
   register(app, ctx) {
     const { requireAgentJwt, operatorAuth, tenantAuth } = ctx;
 
+    const rejectAgentTokenFallback: typeof requireAgentJwt = async (c, next) => {
+      if (c.get("authType") === "agent-token" || c.get("agentScope")) {
+        return c.json({ ok: false, error: "RS256 agent JWT required" }, 403);
+      }
+      return next();
+    };
+    const agentOrOperatorAuth: typeof requireAgentJwt = (c, next) => {
+      if (c.req.header("X-Steward-Platform-Key")) return operatorAuth(c, next);
+      const token = c.req.header("Authorization")?.replace(/^Bearer\s+/i, "");
+      if (decodeJwtHeaderAlg(token) === "RS256") return requireAgentJwt(c, next);
+      return operatorAuth(c, (() => rejectAgentTokenFallback(c, next)) as never);
+    };
+    const agentOrTenantReadAuth: typeof requireAgentJwt = (c, next) => {
+      const token = c.req.header("Authorization")?.replace(/^Bearer\s+/i, "");
+      if (decodeJwtHeaderAlg(token) === "RS256") return requireAgentJwt(c, next);
+      return tenantAuth(c, (() => rejectAgentTokenFallback(c, next)) as never);
+    };
+
     // ── trade-specific auth middleware (verbatim from app.ts ~lines 172-182) ──
     for (const path of [
       "/trade/hyperliquid/order",
@@ -109,15 +147,27 @@ export const tradingPlugin: StewardApiPlugin = {
     ]) {
       app.use(path, (c, next) => requireAgentJwt(c, next));
     }
+    for (const path of [
+      "/trade/polymarket/orders/:orderId/cancel",
+      "/v1/trade/polymarket/orders/:orderId/cancel",
+      "/trade/polymarket/cancel-all",
+      "/v1/trade/polymarket/cancel-all",
+    ]) {
+      app.use(path, (c, next) => agentOrOperatorAuth(c, next));
+    }
     app.use("/trade", (c, next) => tenantAuth(c, next));
     app.use("/trade/*", (c, next) => {
       if (isAgentOrderPath(c.req.path)) return next();
+      if (isAgentOrOperatorTradeWritePath(c.req.path)) return next();
+      if (isAgentPolymarketReadPath(c.req.path)) return agentOrTenantReadAuth(c, next);
       if (isOperatorRecoveryPath(c.req.path)) return operatorAuth(c, next);
       return tenantAuth(c, next);
     });
     app.use("/v1/trade", (c, next) => tenantAuth(c, next));
     app.use("/v1/trade/*", (c, next) => {
       if (isAgentOrderPath(c.req.path)) return next();
+      if (isAgentOrOperatorTradeWritePath(c.req.path)) return next();
+      if (isAgentPolymarketReadPath(c.req.path)) return agentOrTenantReadAuth(c, next);
       if (isOperatorRecoveryPath(c.req.path)) return operatorAuth(c, next);
       return tenantAuth(c, next);
     });

--- a/packages/plugin-trading/src/routes/trade.ts
+++ b/packages/plugin-trading/src/routes/trade.ts
@@ -34,6 +34,7 @@ import {
   type EthersSignerLike,
   isPolymarketPostNotAttempted,
   isPolymarketUnauthorized,
+  listPositions as listPolymarketPositions,
   POLY_EOA_SIGNATURE_TYPE,
   POLY_GNOSIS_SAFE_SIGNATURE_TYPE,
   type PolymarketAccount,
@@ -147,6 +148,41 @@ const pmSubmitOrderSchema = z.object({
 
 type PmSubmitOrderBody = z.infer<typeof pmSubmitOrderSchema>;
 
+const pmListOrdersSchema = z.object({
+  agentId: z.string().min(1).optional(),
+  sessionId: z.string().min(1).optional(),
+  market: z.string().min(1).optional(),
+});
+
+const pmListPositionsSchema = z.object({
+  agentId: z.string().min(1).optional(),
+  sessionId: z.string().min(1).optional(),
+  limit: z.coerce.number().int().positive().max(500).optional(),
+  minBalance: z.coerce.number().nonnegative().optional(),
+});
+
+const pmCancelOrderSchema = z.object({
+  agentId: z.string().min(1).optional(),
+  sessionId: z.string().min(1),
+  idempotencyKey: z.string().min(1).max(256).optional(),
+});
+
+type PmCancelOrderBody = z.infer<typeof pmCancelOrderSchema> & {
+  orderId: string;
+  cancelAll?: false;
+};
+
+const pmCancelAllSchema = z.object({
+  agentId: z.string().min(1).optional(),
+  sessionId: z.string().min(1),
+  market: z.string().min(1).optional(),
+  idempotencyKey: z.string().min(1).max(256).optional(),
+});
+
+type PmCancelAllBody = z.infer<typeof pmCancelAllSchema> & {
+  cancelAll: true;
+};
+
 /**
  * Build the trade router, closing over the injected core context. Every helper
  * + route that used a core service (db, vault, redis, audit, token status) reads
@@ -171,6 +207,10 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
     { bodyHash: string; response: TradeIdempotencyResponse; expiresAt: number }
   >();
   const pmMemoryIdempotency = new Map<
+    string,
+    { bodyHash: string; response: TradeIdempotencyResponse; expiresAt: number }
+  >();
+  const pmCancelMemoryIdempotency = new Map<
     string,
     { bodyHash: string; response: TradeIdempotencyResponse; expiresAt: number }
   >();
@@ -228,6 +268,29 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
     return !scopedAgent || scopedAgent === agentId;
   }
 
+  function isOperatorRecoveryCaller(c: Context<{ Variables: AppVariables }>): boolean {
+    if (c.get("authType") === "platform" || c.get("authType") === "api-key") return true;
+    return (
+      c.get("authType") === "session-jwt" &&
+      (c.get("tenantRole") === "owner" || c.get("tenantRole") === "admin")
+    );
+  }
+
+  function tradeActor(
+    c: Context<{ Variables: AppVariables }>,
+    agentId: string,
+  ): {
+    actorType: "agent" | "user" | "api-key";
+    actorId: string;
+  } {
+    const scoped = callerAgentId(c);
+    if (scoped) return { actorType: "agent", actorId: scoped };
+    const control = controlPlaneAuditActor(c);
+    return control.actorType === "api-key"
+      ? { actorType: "api-key", actorId: control.actorId }
+      : { actorType: "user", actorId: control.actorId ?? agentId };
+  }
+
   function hasOwnBodyValue(body: unknown, key: string): boolean {
     return typeof body === "object" && body !== null && Object.hasOwn(body, key);
   }
@@ -249,6 +312,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
       | "trade.order.policy-rejected"
       | "trade.order.builder.stamped"
       | "trade.builder.approved"
+      | "trade.order.cancel.authorized"
       | "trade.order.canceled",
     details: Record<string, unknown>,
     actor: { actorType: "agent" | "user" | "api-key"; actorId: string } = {
@@ -1437,6 +1501,115 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
     };
   }
 
+  type PolymarketWalletResolution =
+    | {
+        ok: true;
+        funderAddress: string;
+        walletAddress: string;
+      }
+    | { ok: false; reason: "wallet-not-found" };
+
+  async function resolvePolymarketWalletBinding(
+    agentId: string,
+  ): Promise<PolymarketWalletResolution> {
+    try {
+      const wallet = await vault.getWallet({ agentId, venue: "polymarket" });
+      const meta = wallet.metadata as { funderAddress?: unknown } | undefined;
+      const funderAddress =
+        typeof meta?.funderAddress === "string" ? meta.funderAddress : wallet.address;
+      return { ok: true, funderAddress, walletAddress: wallet.address };
+    } catch {
+      return { ok: false, reason: "wallet-not-found" };
+    }
+  }
+
+  function polymarketCredsError(
+    reason: "wallet-not-found" | "creds-not-provisioned" | "derive-failed",
+  ): string {
+    return reason === "wallet-not-found"
+      ? "Polymarket venue wallet not found. Provision a polymarket wallet before trading."
+      : "Polymarket credentials are not provisioned for this agent.";
+  }
+
+  function createPolymarketAdapter(
+    tenantId: string,
+    agentId: string,
+    creds: Extract<PolymarketCredsResolution, { ok: true }>,
+  ): PolymarketExecutionAdapter {
+    const signer = buildPolymarketVaultSigner(tenantId, agentId, creds.walletAddress);
+    const account: PolymarketAccount = {
+      apiCredentials: creds.apiCredentials,
+      funderAddress: creds.funderAddress,
+      signer,
+      signatureType: creds.signatureType,
+    };
+    return new PolymarketExecutionAdapter(account, {
+      builder: resolveBuilderConfig(),
+      ...(creds.clobUrl ? { clobUrl: creds.clobUrl } : {}),
+    });
+  }
+
+  async function resolvePolymarketReadAgent(
+    c: Context<{ Variables: AppVariables }>,
+    input: { agentId?: string; sessionId?: string },
+  ): Promise<
+    | { ok: true; agentId: string; session?: TradeSession }
+    | { ok: false; status: 400 | 403 | 404; error: string }
+  > {
+    const tenantId = c.get("tenantId");
+    const scoped = callerAgentId(c);
+    const requestedAgentId = input.agentId ?? scoped;
+    let session: TradeSession | undefined;
+    if (input.sessionId) {
+      const loaded = await getSessionManager().getSession({ tenantId, id: input.sessionId });
+      if (!loaded || loaded.venue !== "polymarket") {
+        return { ok: false, status: 404, error: "Polymarket session not found" };
+      }
+      session = loaded;
+      if (requestedAgentId && requestedAgentId !== loaded.agentId) {
+        return { ok: false, status: 403, error: "Forbidden: session belongs to another agent" };
+      }
+    }
+    const agentId = session?.agentId ?? requestedAgentId;
+    if (!agentId) return { ok: false, status: 400, error: "agentId or sessionId is required" };
+    if (!canAccessAgent(c, agentId)) {
+      return { ok: false, status: 403, error: "Forbidden: agent token cannot access this agent" };
+    }
+    const agent = await ensureAgentForTenant(tenantId, agentId);
+    if (!agent) return { ok: false, status: 404, error: "Agent not found" };
+    return { ok: true, agentId, ...(session ? { session } : {}) };
+  }
+
+  function getPmCancelIdempotency(
+    tenantId: string,
+    agentId: string,
+    key: string | undefined,
+    body: PmCancelOrderBody | PmCancelAllBody,
+  ): {
+    conflict?: boolean;
+    response?: TradeIdempotencyResponse;
+    store?: (response: TradeIdempotencyResponse) => void;
+  } {
+    if (!key) return {};
+    const now = Date.now();
+    const mapKey = `${tenantId}:${agentId}:pm-cancel:${key}`;
+    const bodyHash = hashBody({ ...body, idempotencyKey: undefined });
+    const existing = pmCancelMemoryIdempotency.get(mapKey);
+    if (existing && existing.expiresAt > now) {
+      if (existing.bodyHash !== bodyHash) return { conflict: true };
+      return { response: existing.response };
+    }
+    return {
+      store(response: TradeIdempotencyResponse) {
+        pmCancelMemoryIdempotency.set(mapKey, {
+          bodyHash,
+          response,
+          expiresAt: now + 24 * 60 * 60 * 1000,
+        });
+      },
+    };
+  }
+
   /**
    * The vault→ethers-signer bridge.
    *
@@ -1498,6 +1671,305 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
       _signTypedData,
     };
   }
+
+  tradeRoutes.get("/polymarket/orders", async (c) => {
+    const tenantId = c.get("tenantId");
+    const parsed = pmListOrdersSchema.safeParse({
+      agentId: c.req.query("agentId") ?? undefined,
+      sessionId: c.req.query("sessionId") ?? undefined,
+      market: c.req.query("market") ?? undefined,
+    });
+    if (!parsed.success) {
+      return c.json<ApiResponse>({ ok: false, error: parsed.error.message }, 400);
+    }
+
+    const access = await resolvePolymarketReadAgent(c, parsed.data);
+    if (!access.ok) return c.json<ApiResponse>({ ok: false, error: access.error }, access.status);
+
+    const creds = await resolvePolymarketCreds(tenantId, access.agentId);
+    if (!creds.ok) {
+      return c.json<ApiResponse>({ ok: false, error: polymarketCredsError(creds.reason) }, 409);
+    }
+    if (
+      access.session &&
+      creds.walletAddress.toLowerCase() !== access.session.walletId.toLowerCase()
+    ) {
+      return c.json<ApiResponse>(
+        {
+          ok: false,
+          error:
+            "Session wallet binding no longer matches the provisioned wallet. Re-create the session.",
+        },
+        409,
+      );
+    }
+
+    const adapter = createPolymarketAdapter(tenantId, access.agentId, creds);
+    const orders = parsed.data.market
+      ? await adapter.listOrders({ market: parsed.data.market })
+      : await adapter.listOrders();
+    return c.json(responseData({ agentId: access.agentId, orders }));
+  });
+
+  tradeRoutes.get("/polymarket/positions", async (c) => {
+    const parsed = pmListPositionsSchema.safeParse({
+      agentId: c.req.query("agentId") ?? undefined,
+      sessionId: c.req.query("sessionId") ?? undefined,
+      limit: c.req.query("limit") ?? undefined,
+      minBalance: c.req.query("minBalance") ?? undefined,
+    });
+    if (!parsed.success) {
+      return c.json<ApiResponse>({ ok: false, error: parsed.error.message }, 400);
+    }
+
+    const access = await resolvePolymarketReadAgent(c, parsed.data);
+    if (!access.ok) return c.json<ApiResponse>({ ok: false, error: access.error }, access.status);
+
+    const wallet = await resolvePolymarketWalletBinding(access.agentId);
+    if (!wallet.ok) {
+      return c.json<ApiResponse>(
+        {
+          ok: false,
+          error: "Polymarket venue wallet not found. Provision a polymarket wallet before trading.",
+        },
+        409,
+      );
+    }
+    if (
+      access.session &&
+      wallet.walletAddress.toLowerCase() !== access.session.walletId.toLowerCase()
+    ) {
+      return c.json<ApiResponse>(
+        {
+          ok: false,
+          error:
+            "Session wallet binding no longer matches the provisioned wallet. Re-create the session.",
+        },
+        409,
+      );
+    }
+
+    const positions = await listPolymarketPositions({
+      user: wallet.funderAddress,
+      ...(parsed.data.limit !== undefined ? { limit: parsed.data.limit } : {}),
+      ...(parsed.data.minBalance !== undefined ? { minBalance: parsed.data.minBalance } : {}),
+    });
+    return c.json(
+      responseData({
+        agentId: access.agentId,
+        walletAddress: wallet.walletAddress,
+        funderAddress: wallet.funderAddress,
+        positions,
+      }),
+    );
+  });
+
+  async function cancelPolymarketOrders(
+    c: Context<{ Variables: AppVariables }>,
+    body: PmCancelOrderBody | PmCancelAllBody,
+  ): Promise<Response> {
+    const tenantId = c.get("tenantId");
+    const scopedAgentId = callerAgentId(c);
+    const operator = isOperatorRecoveryCaller(c);
+    const requestedAgentId = body.agentId ?? scopedAgentId;
+    if (!requestedAgentId && !operator) {
+      return c.json<ApiResponse>({ ok: false, error: "Agent JWT required for trading" }, 403);
+    }
+
+    const session = await getSessionManager().getSession({ tenantId, id: body.sessionId });
+    if (
+      !session ||
+      session.venue !== "polymarket" ||
+      session.status !== "active" ||
+      session.expiresAt.getTime() <= Date.now()
+    ) {
+      return c.json<ApiResponse>({ ok: false, error: "Active Polymarket session required" }, 403);
+    }
+    const agentId = session.agentId;
+    if (requestedAgentId && requestedAgentId !== agentId) {
+      return c.json<ApiResponse>(
+        { ok: false, error: "Forbidden: session belongs to another agent" },
+        403,
+      );
+    }
+    if (scopedAgentId && scopedAgentId !== agentId) {
+      return c.json<ApiResponse>(
+        { ok: false, error: "Forbidden: agent token cannot cancel for another agent" },
+        403,
+      );
+    }
+    if (!scopedAgentId && !operator) {
+      return c.json<ApiResponse>({ ok: false, error: "Operator recovery auth required" }, 403);
+    }
+
+    const idempotency = getPmCancelIdempotency(tenantId, agentId, body.idempotencyKey, body);
+    if (idempotency.conflict) {
+      return c.json<ApiResponse>(
+        { ok: false, error: "Idempotency key reused with a different body" },
+        409,
+      );
+    }
+    if (idempotency.response) {
+      return tradeReplayResponse(c, idempotency.response);
+    }
+
+    if (!body.idempotencyKey) {
+      return c.json<ApiResponse>({ ok: false, error: "Idempotency-Key is required" }, 400);
+    }
+
+    const creds = await resolvePolymarketCreds(tenantId, agentId);
+    if (!creds.ok) {
+      return c.json<ApiResponse>({ ok: false, error: polymarketCredsError(creds.reason) }, 409);
+    }
+    if (creds.walletAddress.toLowerCase() !== session.walletId.toLowerCase()) {
+      await auditTradeEvent(tenantId, agentId, "trade.order.policy-rejected", {
+        sessionId: session.id,
+        venue: "polymarket",
+        reason: "wallet-binding-mismatch",
+        sessionWallet: session.walletId,
+        resolvedWallet: creds.walletAddress,
+      });
+      return c.json<ApiResponse>(
+        {
+          ok: false,
+          error:
+            "Session wallet binding no longer matches the provisioned wallet. Re-create the session.",
+        },
+        409,
+      );
+    }
+
+    const adapter = createPolymarketAdapter(tenantId, agentId, creds);
+    const actor = tradeActor(c, agentId);
+    const manager = getSessionManager();
+    const fenced = await manager.withActiveSubmissionFence(
+      { tenantId, id: session.id },
+      async () => {
+        await auditTradeEvent(
+          tenantId,
+          agentId,
+          "trade.order.cancel.authorized",
+          {
+            sessionId: session.id,
+            venue: "polymarket",
+            orderId: body.cancelAll ? null : body.orderId,
+            cancelAll: body.cancelAll === true,
+            market: body.cancelAll ? (body.market ?? null) : null,
+          },
+          actor,
+        );
+
+        try {
+          const result = body.cancelAll
+            ? body.market
+              ? await adapter.cancelAllOrders({ market: body.market })
+              : await adapter.cancelAllOrders()
+            : await adapter.cancelOrder({ orderId: body.orderId });
+          const response = body.cancelAll
+            ? {
+                status: "cancel_requested" as const,
+                canceledCount: Array.isArray(result) ? result.length : 0,
+                results: result,
+              }
+            : {
+                status: "cancel_requested" as const,
+                orderId: body.orderId,
+                result,
+              };
+          const envelope: TradeIdempotencyResponse = {
+            status: 200,
+            body: responseData(response),
+          };
+          idempotency.store?.(envelope);
+          await auditTradeEvent(
+            tenantId,
+            agentId,
+            "trade.order.canceled",
+            {
+              sessionId: session.id,
+              venue: "polymarket",
+              orderId: body.cancelAll ? null : body.orderId,
+              cancelAll: body.cancelAll === true,
+              market: body.cancelAll ? (body.market ?? null) : null,
+              canceledCount: body.cancelAll && Array.isArray(result) ? result.length : 1,
+            },
+            actor,
+          );
+          return envelope;
+        } catch (err) {
+          if (isPolymarketUnauthorized(err)) {
+            await invalidatePolymarketCredsCache(
+              tenantId,
+              agentId,
+              creds.walletAddress,
+              creds.clobUrl,
+            );
+          }
+          const envelope: TradeIdempotencyResponse = {
+            status: 502,
+            body: {
+              ok: false,
+              error: "Polymarket cancel status unknown",
+              data: { status: "unknown" },
+            },
+          };
+          idempotency.store?.(envelope);
+          await auditTradeEvent(
+            tenantId,
+            agentId,
+            "trade.order.canceled",
+            {
+              sessionId: session.id,
+              venue: "polymarket",
+              orderId: body.cancelAll ? null : body.orderId,
+              cancelAll: body.cancelAll === true,
+              market: body.cancelAll ? (body.market ?? null) : null,
+              reason: "cancel-status-unknown",
+              error: err instanceof Error ? err.message : String(err),
+            },
+            actor,
+          );
+          return envelope;
+        }
+      },
+    );
+
+    if (!fenced) {
+      const envelope: TradeIdempotencyResponse = {
+        status: 409,
+        body: { ok: false, error: "Trade session was revoked before cancel submission" },
+      };
+      idempotency.store?.(envelope);
+      return c.json(envelope.body, envelope.status);
+    }
+    return c.json(fenced.body, fenced.status);
+  }
+
+  tradeRoutes.post("/polymarket/orders/:orderId/cancel", async (c) => {
+    const raw = await safeJsonParse(c);
+    const parsed = pmCancelOrderSchema.safeParse(raw);
+    if (!parsed.success) {
+      return c.json<ApiResponse>({ ok: false, error: parsed.error.message }, 400);
+    }
+    return cancelPolymarketOrders(c, {
+      ...parsed.data,
+      idempotencyKey: c.req.header("Idempotency-Key") ?? parsed.data.idempotencyKey,
+      orderId: c.req.param("orderId"),
+    });
+  });
+
+  tradeRoutes.post("/polymarket/cancel-all", async (c) => {
+    const raw = await safeJsonParse(c);
+    const parsed = pmCancelAllSchema.safeParse(raw);
+    if (!parsed.success) {
+      return c.json<ApiResponse>({ ok: false, error: parsed.error.message }, 400);
+    }
+    return cancelPolymarketOrders(c, {
+      ...parsed.data,
+      idempotencyKey: c.req.header("Idempotency-Key") ?? parsed.data.idempotencyKey,
+      cancelAll: true,
+    });
+  });
 
   tradeRoutes.post("/polymarket/order", async (c) => {
     const tenantId = c.get("tenantId");

--- a/packages/venue-polymarket/src/execution.ts
+++ b/packages/venue-polymarket/src/execution.ts
@@ -429,6 +429,16 @@ export class PolymarketExecutionAdapter {
     const raw = await client.cancelOrder({ orderID: params.orderId });
     return { venue: "polymarket", orderId: params.orderId, raw };
   }
+
+  /** Cancel every currently open order visible to this CLOB account. */
+  async cancelAllOrders(params: { market?: string } = {}): Promise<PolymarketCancelResult[]> {
+    const orders = await this.listOrders(params);
+    const results: PolymarketCancelResult[] = [];
+    for (const order of orders) {
+      results.push(await this.cancelOrder({ orderId: order.id }));
+    }
+    return results;
+  }
 }
 
 export function createPolymarketExecutionAdapter(

--- a/packages/venue-polymarket/src/index.test.ts
+++ b/packages/venue-polymarket/src/index.test.ts
@@ -527,6 +527,88 @@ describe("PolymarketExecutionAdapter order build", () => {
     ).rejects.toThrow("socket hang up");
   });
 
+  test("listOrders parses the SDK-returned flattened open-order array", async () => {
+    const adapter = new PolymarketExecutionAdapter(account, { fetch: notFetch() });
+    const stub = {
+      async getOpenOrders(params?: { market?: string }) {
+        expect(params).toEqual({ market: "0xabc" });
+        return [
+          {
+            id: "open-1",
+            market: "0xabc",
+            asset_id: bigToken,
+            side: "BUY",
+            price: "0.5",
+            original_size: "20",
+            size_matched: "0",
+            status: "LIVE",
+          },
+        ];
+      },
+    };
+    // @ts-expect-error private override for test
+    adapter.createClobClient = async () => ({ client: stub });
+
+    const orders = await adapter.listOrders({ market: "0xabc" });
+    expect(orders).toEqual([
+      {
+        id: "open-1",
+        market: "0xabc",
+        asset_id: bigToken,
+        side: "BUY",
+        price: "0.5",
+        original_size: "20",
+        size_matched: "0",
+        status: "LIVE",
+      },
+    ]);
+  });
+
+  test("cancelAllOrders lists then cancels each open order id", async () => {
+    const adapter = new PolymarketExecutionAdapter(account, { fetch: notFetch() });
+    const canceled: string[] = [];
+    const stub = {
+      async getOpenOrders(params?: { market?: string }) {
+        expect(params).toEqual({ market: "0xabc" });
+        return [
+          {
+            id: "open-1",
+            market: "0xabc",
+            asset_id: bigToken,
+            side: "BUY",
+            price: "0.5",
+            original_size: "20",
+            size_matched: "0",
+            status: "LIVE",
+          },
+          {
+            id: "open-2",
+            market: "0xabc",
+            asset_id: bigToken,
+            side: "SELL",
+            price: "0.4",
+            original_size: "10",
+            size_matched: "0",
+            status: "LIVE",
+          },
+        ];
+      },
+      async cancelOrder(payload: { orderID: string }) {
+        canceled.push(payload.orderID);
+        return { canceled: [payload.orderID] };
+      },
+    };
+    // @ts-expect-error private override for test
+    adapter.createClobClient = async () => ({ client: stub });
+
+    const results = await adapter.cancelAllOrders({ market: "0xabc" });
+    expect(canceled).toEqual(["open-1", "open-2"]);
+    expect(results).toEqual([
+      { venue: "polymarket", orderId: "open-1", raw: { canceled: ["open-1"] } },
+      { venue: "polymarket", orderId: "open-2", raw: { canceled: ["open-2"] } },
+    ]);
+  });
+
   test("resolveOrderOptions throws (no guess) when book lookup fails and caller didn't supply both", async () => {
     const failFetch = (async () => {
       throw new Error("book down");


### PR DESCRIPTION
## Summary

Stacked on #164. Adds governed Polymarket read/cancel lifecycle after the proven order-placement E2E.

- list open orders through agent/session/wallet binding
- list positions by authoritative funder address without deriving CLOB credentials
- cancel one order with session fence, idempotency, audit, and unknown-outcome replay
- cancel all by composing real paginated CLOB list/cancel behavior
- expose both `/trade` and `/v1/trade` route families
- preserve tenant-admin reads and platform/operator recovery writes

## Auth hardening

- strict RS256 agent JWTs can reach lifecycle routes
- tenant auth remains available for reads
- platform/operator auth remains available for cancel recovery
- forged payload claims and legacy/non-RS256 agent-token fallback are rejected
- revoked sessions and stale wallet bindings fail before credentials or adapter calls

## Deterministic verification

- auth middleware: 16 passed, 102 assertions
- plugin lifecycle: 31 passed, 158 assertions
- venue adapter: 57 passed, 111 assertions
- combined independent rerun: 104 passed, 371 assertions
- `@stwd/venue-polymarket` typecheck passed
- `@stwd/plugin-trading` typecheck passed
- Biome and diff checks passed
- final Codex review found no actionable issues

The CLOB mock uses the SDK's real `/data/orders` pagination envelope and cursors. No live venue calls, orders, or funds.

## Stack

Base: #164 / `feat/polymarket-e2e`

After #164 merges, this PR can be retargeted to `develop` and rebased without changing its lifecycle commit.

— [sol-orch]
