### PR TITLE
feat(adapters): add governed 0x Swap API v2 adapter

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -43328,6 +43328,9 @@
                     "minimum": 0,
                     "maximum": 10000
                   },
+                  "taker": {
+                    "type": "string"
+                  },
                   "estimatedUsd": {
                     "type": "number",
                     "minimum": 0
@@ -51194,6 +51197,9 @@
                     "type": "integer",
                     "minimum": 0,
                     "maximum": 10000
+                  },
+                  "taker": {
+                    "type": "string"
                   },
                   "estimatedUsd": {
                     "type": "number",

--- a/packages/adapters/src/__tests__/registry.test.ts
+++ b/packages/adapters/src/__tests__/registry.test.ts
@@ -8,6 +8,7 @@ const FRESH_TOKENS = {
   toToken: { address: "0x4200000000000000000000000000000000000006" },
   amount: "1000",
   chainId: 8453,
+  taker: "0x1111111111111111111111111111111111111111",
 };
 
 describe("AdapterRegistry resolution", () => {
@@ -53,6 +54,55 @@ describe("AdapterRegistry resolution", () => {
     const swap = reg.swap();
     expect(swap.enabled).toBe(false);
     expect(() => swap.getQuote(FRESH_TOKENS)).toThrow(AdapterNotConfiguredError);
+  });
+
+  test("PRODUCTION + zeroex selected without complete config: FAILS CLOSED", () => {
+    const reg = new AdapterRegistry({
+      env: { NODE_ENV: "production", STEWARD_SWAP_ADAPTER: "zeroex" },
+    });
+    const swap = reg.swap();
+    expect(swap.provider).toBe("disabled");
+    expect(swap.enabled).toBe(false);
+    expect(() => swap.getQuote(FRESH_TOKENS)).toThrow(AdapterNotConfiguredError);
+  });
+
+  test("PRODUCTION + zeroex selected with explicit config resolves real adapter", () => {
+    const reg = new AdapterRegistry({
+      env: {
+        NODE_ENV: "production",
+        STEWARD_SWAP_ADAPTER: "zeroex",
+        STEWARD_ZEROEX_API_KEY: "test-key",
+        STEWARD_ZEROEX_SUPPORTED_CHAINS_JSON: JSON.stringify({
+          8453: {
+            allowanceTarget: "0x2222222222222222222222222222222222222222",
+            transactionTargets: ["0x3333333333333333333333333333333333333333"],
+          },
+        }),
+      },
+    });
+    const swap = reg.swap();
+    expect(swap.provider).toBe("zeroex");
+    expect(swap.enabled).toBe(true);
+  });
+
+  test("PRODUCTION + zeroex selected with malformed fee config: FAILS CLOSED", () => {
+    const reg = new AdapterRegistry({
+      env: {
+        NODE_ENV: "production",
+        STEWARD_SWAP_ADAPTER: "zeroex",
+        STEWARD_ZEROEX_API_KEY: "test-key",
+        STEWARD_ZEROEX_SUPPORTED_CHAINS_JSON: JSON.stringify({
+          8453: {
+            allowanceTarget: "0x2222222222222222222222222222222222222222",
+            transactionTargets: ["0x3333333333333333333333333333333333333333"],
+          },
+        }),
+        STEWARD_ZEROEX_SWAP_FEE_RECIPIENT: "0x4444444444444444444444444444444444444444",
+      },
+    });
+    const swap = reg.swap();
+    expect(swap.provider).toBe("disabled");
+    expect(swap.enabled).toBe(false);
   });
 
   test("DEV + env names an unknown provider: STILL fails closed (operator intent honored)", () => {

--- a/packages/adapters/src/__tests__/swap.test.ts
+++ b/packages/adapters/src/__tests__/swap.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { MockSwapAdapter } from "../adapters/swap.js";
-import { AdapterValidationError } from "../types.js";
+import { MockSwapAdapter, type SwapQuote, ZeroExSwapAdapter } from "../adapters/swap.js";
+import { AdapterUnavailableError, AdapterValidationError } from "../types.js";
 
 const USDC = { address: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", symbol: "USDC", decimals: 6 };
 const WETH = {
@@ -8,6 +8,11 @@ const WETH = {
   symbol: "WETH",
   decimals: 18,
 };
+const TAKER = "0x1111111111111111111111111111111111111111";
+const ALLOWANCE_HOLDER = "0x2222222222222222222222222222222222222222";
+const ROUTER = "0x3333333333333333333333333333333333333333";
+const OTHER = "0x4444444444444444444444444444444444444444";
+const CALLDATA = `0x12345678${"00".repeat(32)}`;
 
 function fixedClock(ms: number): { now: () => number } {
   return { now: () => ms };
@@ -139,5 +144,233 @@ describe("MockSwapAdapter.buildSwap", () => {
     await expect(swap.buildSwap(quote, "not-an-address")).rejects.toBeInstanceOf(
       AdapterValidationError,
     );
+  });
+});
+
+function zeroExFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    chainId: 8453,
+    sellToken: USDC.address,
+    buyToken: WETH.address,
+    sellAmount: "1000000",
+    buyAmount: "500000000000000000",
+    minBuyAmount: "497500000000000000",
+    allowanceTarget: ALLOWANCE_HOLDER,
+    issues: { allowance: { spender: ALLOWANCE_HOLDER } },
+    transaction: {
+      to: ROUTER,
+      data: CALLDATA,
+      value: "0",
+      from: TAKER,
+    },
+    ...overrides,
+  };
+}
+
+function makeZeroEx(
+  responses: Array<Response | Record<string, unknown> | ((url: URL) => Response)>,
+  options: Partial<ConstructorParameters<typeof ZeroExSwapAdapter>[0]> = {},
+) {
+  const calls: Array<{ url: URL; headers: Headers }> = [];
+  const fetchImpl = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url = new URL(String(input));
+    calls.push({ url, headers: new Headers(init?.headers) });
+    const next = responses.shift();
+    if (!next) throw new Error("unexpected fetch");
+    if (typeof next === "function") return next(url);
+    if (next instanceof Response) return next;
+    return Response.json(next);
+  };
+  const adapter = new ZeroExSwapAdapter({
+    apiKey: "test-key",
+    baseUrl: "https://unit.test",
+    supportedChains: {
+      8453: { allowanceTarget: ALLOWANCE_HOLDER, transactionTargets: [ROUTER] },
+    },
+    now: () => 1_000,
+    fetch: fetchImpl,
+    ...options,
+  });
+  return { adapter, calls };
+}
+
+async function getZeroExQuote(adapter: ZeroExSwapAdapter) {
+  return adapter.getQuote({
+    fromToken: USDC,
+    toToken: WETH,
+    amount: "1000000",
+    chainId: 8453,
+    taker: TAKER,
+    slippageBps: 50,
+  });
+}
+
+describe("ZeroExSwapAdapter", () => {
+  test("quotes and builds from recorded 0x v2 fixtures with strict headers and query params", async () => {
+    const { adapter, calls } = makeZeroEx([zeroExFixture(), zeroExFixture()]);
+    const quote = await getZeroExQuote(adapter);
+    const intent = await adapter.buildSwap(quote, TAKER);
+
+    expect(quote.provider).toBe("zeroex");
+    expect(quote.amountIn).toBe("1000000");
+    expect(quote.amountOut).toBe("500000000000000000");
+    expect(quote.minAmountOut).toBe("497500000000000000");
+    expect(quote.expiresAt).toBe(31_000);
+    expect(intent).toMatchObject({
+      signed: false,
+      kind: "evm-tx",
+      chainId: 8453,
+      to: ROUTER.toLowerCase(),
+      value: "0",
+      data: CALLDATA,
+      owner: TAKER.toLowerCase(),
+      category: "swap",
+      provider: "zeroex",
+    });
+    expect(intent.metadata).toMatchObject({
+      quoteId: quote.quoteId,
+      amountIn: quote.amountIn,
+      minAmountOut: quote.minAmountOut,
+      allowanceTarget: ALLOWANCE_HOLDER.toLowerCase(),
+    });
+
+    expect(calls.map((call) => call.url.pathname)).toEqual([
+      "/swap/allowance-holder/price",
+      "/swap/allowance-holder/quote",
+    ]);
+    for (const call of calls) {
+      expect(call.headers.get("0x-api-key")).toBe("test-key");
+      expect(call.headers.get("0x-version")).toBe("v2");
+      expect(call.url.searchParams.get("chainId")).toBe("8453");
+      expect(call.url.searchParams.get("sellToken")).toBe(USDC.address.toLowerCase());
+      expect(call.url.searchParams.get("buyToken")).toBe(WETH.address.toLowerCase());
+      expect(call.url.searchParams.get("sellAmount")).toBe("1000000");
+      expect(call.url.searchParams.get("taker")).toBe(TAKER.toLowerCase());
+    }
+  });
+
+  test("rejects malformed or mutated semantic response fields", async () => {
+    for (const patch of [
+      { chainId: 1 },
+      { sellToken: OTHER },
+      { buyToken: OTHER },
+      { sellAmount: "999" },
+      { taker: OTHER },
+      { buyAmount: "not-a-number" },
+    ]) {
+      const { adapter } = makeZeroEx([zeroExFixture(patch)]);
+      await expect(getZeroExQuote(adapter)).rejects.toBeInstanceOf(AdapterValidationError);
+    }
+  });
+
+  test("allows v2 responses without legacy allowanceTarget while binding the configured spender", async () => {
+    const price = zeroExFixture();
+    const build = zeroExFixture();
+    delete price.allowanceTarget;
+    delete build.allowanceTarget;
+    const { adapter } = makeZeroEx([price, build]);
+    const quote = await getZeroExQuote(adapter);
+    const intent = await adapter.buildSwap(quote, TAKER);
+    expect(intent.metadata).toMatchObject({ allowanceTarget: ALLOWANCE_HOLDER.toLowerCase() });
+  });
+
+  test("rejects wrong quote response amount, owner, expired quote, and unsupported chain", async () => {
+    const wrongAmount = makeZeroEx([zeroExFixture(), zeroExFixture({ minBuyAmount: "1" })]).adapter;
+    const quote = await getZeroExQuote(wrongAmount);
+    await expect(wrongAmount.buildSwap(quote, TAKER)).rejects.toBeInstanceOf(
+      AdapterValidationError,
+    );
+
+    const wrongOwner = makeZeroEx([zeroExFixture()]).adapter;
+    const ownerQuote = await getZeroExQuote(wrongOwner);
+    await expect(wrongOwner.buildSwap(ownerQuote, OTHER)).rejects.toBeInstanceOf(
+      AdapterValidationError,
+    );
+
+    const mutatedMetadataAdapter = makeZeroEx([zeroExFixture()]).adapter;
+    const mutatedMetadataQuote = await getZeroExQuote(mutatedMetadataAdapter);
+    const mutableQuote = mutatedMetadataQuote as SwapQuote & {
+      zeroEx: { request: { chainId: number } };
+    };
+    mutableQuote.zeroEx.request.chainId = 1;
+    await expect(mutatedMetadataAdapter.buildSwap(mutableQuote, TAKER)).rejects.toBeInstanceOf(
+      AdapterValidationError,
+    );
+
+    const expired = makeZeroEx([zeroExFixture()], { now: () => 1_000, quoteTtlMs: 10 }).adapter;
+    const expiredQuote = await getZeroExQuote(expired);
+    const later = makeZeroEx([], { now: () => expiredQuote.expiresAt + 1 }).adapter;
+    await expect(later.buildSwap(expiredQuote, TAKER)).rejects.toBeInstanceOf(
+      AdapterValidationError,
+    );
+
+    await expect(
+      makeZeroEx([]).adapter.getQuote({
+        fromToken: USDC,
+        toToken: WETH,
+        amount: "1",
+        chainId: 1,
+        taker: TAKER,
+      }),
+    ).rejects.toBeInstanceOf(AdapterValidationError);
+  });
+
+  test("rejects unsafe allowance holder, allowance spender, transaction target, calldata, and value", async () => {
+    for (const patch of [
+      { allowanceTarget: OTHER },
+      { issues: { allowance: { spender: OTHER } } },
+      { transaction: { ...zeroExFixture().transaction, to: OTHER } },
+      { transaction: { ...zeroExFixture().transaction, data: "0x" } },
+      { transaction: { ...zeroExFixture().transaction, value: "1.5" } },
+      { transaction: { ...zeroExFixture().transaction, from: OTHER } },
+    ]) {
+      const { adapter } = makeZeroEx([zeroExFixture(), zeroExFixture(patch)]);
+      const quote = await getZeroExQuote(adapter);
+      await expect(adapter.buildSwap(quote, TAKER)).rejects.toBeInstanceOf(AdapterValidationError);
+    }
+  });
+
+  test("maps 4xx, 5xx, and timeout to provider unavailable", async () => {
+    for (const status of [400, 500]) {
+      const { adapter } = makeZeroEx([new Response("{}", { status })]);
+      await expect(getZeroExQuote(adapter)).rejects.toBeInstanceOf(AdapterUnavailableError);
+    }
+
+    const timeoutFetch = (_input: RequestInfo | URL, init?: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(Object.assign(new Error("aborted"), { name: "AbortError" }));
+        });
+      });
+    const adapter = new ZeroExSwapAdapter({
+      apiKey: "test-key",
+      baseUrl: "https://unit.test",
+      supportedChains: {
+        8453: { allowanceTarget: ALLOWANCE_HOLDER, transactionTargets: [ROUTER] },
+      },
+      timeoutMs: 1,
+      fetch: timeoutFetch as typeof fetch,
+    });
+    await expect(getZeroExQuote(adapter)).rejects.toBeInstanceOf(AdapterUnavailableError);
+  });
+
+  test("adds affiliate fee params and rejects fee token outside buy/sell tokens", async () => {
+    const { adapter, calls } = makeZeroEx([zeroExFixture()], {
+      affiliateFee: { recipient: OTHER, bps: 25, token: "buy" },
+    });
+    await getZeroExQuote(adapter);
+    expect(calls[0].url.searchParams.get("swapFeeRecipient")).toBe(OTHER.toLowerCase());
+    expect(calls[0].url.searchParams.get("swapFeeBps")).toBe("25");
+    expect(calls[0].url.searchParams.get("swapFeeToken")).toBe(WETH.address.toLowerCase());
+
+    const invalidToken = makeZeroEx([zeroExFixture()], {
+      affiliateFee: { recipient: OTHER, bps: 25, token: OTHER },
+    }).adapter;
+    await expect(getZeroExQuote(invalidToken)).rejects.toBeInstanceOf(AdapterValidationError);
+
+    const invalidBps = makeZeroEx([zeroExFixture()], {
+      affiliateFee: { recipient: OTHER, bps: 1_001, token: "sell" },
+    }).adapter;
+    await expect(getZeroExQuote(invalidBps)).rejects.toBeInstanceOf(AdapterValidationError);
   });
 });

--- a/packages/adapters/src/adapters/swap.ts
+++ b/packages/adapters/src/adapters/swap.ts
@@ -2,11 +2,12 @@
  * SwapAdapter — DEX-aggregation seam.
  *
  * `getQuote` returns a price quote; `buildSwap` turns a quote into an
- * {@link UnsignedTxIntent} that the existing signing+policy path consumes. The
- * mock NEVER signs and NEVER broadcasts.
+ * {@link UnsignedTxIntent} that the existing signing+policy path consumes.
+ * Adapters NEVER sign and NEVER broadcast.
  */
 
 import {
+  AdapterUnavailableError,
   AdapterValidationError,
   type BaseAdapter,
   type TokenRef,
@@ -25,7 +26,9 @@ export interface SwapQuoteRequest {
   /** Input amount in base units (wei) of `fromToken`. */
   amount: string;
   chainId: number;
-  /** Max slippage in basis points (0–10000). Defaults to 50 (0.5%). */
+  /** EVM address bound as taker/owner for providers that require it. */
+  taker?: string;
+  /** Max slippage in basis points (0-10000). Defaults to 50 (0.5%). */
   slippageBps?: number;
 }
 
@@ -60,9 +63,128 @@ export interface SwapAdapter extends BaseAdapter {
   buildSwap(quote: SwapQuote, agentAddress: string): Promise<UnsignedTxIntent>;
 }
 
+export interface ZeroExChainConfig {
+  /** 0x AllowanceHolder spender for this chain. Never the Settler. */
+  allowanceTarget: string;
+  /** Explicit allowlist of transaction.to targets returned by 0x quotes. */
+  transactionTargets: readonly string[];
+}
+
+export interface ZeroExAffiliateFeeConfig {
+  recipient: string;
+  bps: number;
+  /** Must resolve to either the buy token or sell token. Defaults to buy. */
+  token?: "buy" | "sell" | string;
+}
+
+export interface ZeroExSwapAdapterOptions {
+  apiKey: string;
+  supportedChains: Readonly<Record<number, ZeroExChainConfig>>;
+  baseUrl?: string;
+  timeoutMs?: number;
+  quoteTtlMs?: number;
+  now?: () => number;
+  fetch?: typeof fetch;
+  affiliateFee?: ZeroExAffiliateFeeConfig;
+}
+
 const MOCK_QUOTE_TTL_MS = 60_000;
-// Deterministic mock pricing: 0.3% fee, 1:1 nominal rate. No external calls.
 const MOCK_FEE_BPS = 30n;
+const ZEROEX_PROVIDER = "zeroex";
+const ZEROEX_DEFAULT_BASE_URL = "https://api.0x.org";
+const ZEROEX_DEFAULT_TIMEOUT_MS = 3_000;
+const ZEROEX_DEFAULT_QUOTE_TTL_MS = 30_000;
+const HEX_DATA_RE = /^0x(?:[a-fA-F0-9]{2})+$/;
+
+type ZeroExResponse = Record<string, unknown>;
+type NormalizedZeroExChainConfig = {
+  allowanceTarget: string;
+  transactionTargets: ReadonlySet<string>;
+};
+type ZeroExRequestParams = {
+  chainId: number;
+  sellToken: string;
+  buyToken: string;
+  sellAmount: string;
+  taker: string;
+  slippageBps: number;
+};
+type ZeroExQuote = SwapQuote & {
+  readonly zeroEx: {
+    readonly taker: string;
+    readonly allowanceTarget: string;
+    readonly request: ZeroExRequestParams;
+  };
+};
+
+function normalizeAddress(value: string): string {
+  return value.toLowerCase();
+}
+
+function assertDifferentTokens(fromToken: TokenRef, toToken: TokenRef): void {
+  if (!fromToken?.address || !toToken?.address) {
+    throw new AdapterValidationError("fromToken and toToken addresses are required");
+  }
+  if (normalizeAddress(fromToken.address) === normalizeAddress(toToken.address)) {
+    throw new AdapterValidationError("fromToken and toToken must differ");
+  }
+}
+
+function assertHexData(value: unknown, field: string): string {
+  if (typeof value !== "string" || !HEX_DATA_RE.test(value)) {
+    throw new AdapterValidationError(`${field} must be non-empty 0x hex calldata`);
+  }
+  return value;
+}
+
+function responseObject(value: unknown): ZeroExResponse {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new AdapterValidationError("0x response must be an object");
+  }
+  return value as ZeroExResponse;
+}
+
+function responseString(response: ZeroExResponse, field: string): string {
+  const value = response[field];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new AdapterValidationError(`0x response ${field} is required`);
+  }
+  return value;
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  const obj = value as Record<string, unknown>;
+  return `{${Object.keys(obj)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stableStringify(obj[key])}`)
+    .join(",")}}`;
+}
+
+function quoteIdFrom(value: unknown): string {
+  let hash = 0xcbf29ce484222325n;
+  for (const char of stableStringify(value)) {
+    hash ^= BigInt(char.charCodeAt(0));
+    hash = (hash * 0x100000001b3n) & 0xffffffffffffffffn;
+  }
+  return `zeroex-v2:${hash.toString(16).padStart(16, "0")}`;
+}
+
+function feeTokenAddress(
+  fee: ZeroExAffiliateFeeConfig,
+  sellToken: string,
+  buyToken: string,
+): string {
+  const token = fee.token ?? "buy";
+  if (token === "buy") return buyToken;
+  if (token === "sell") return sellToken;
+  const address = normalizeAddress(assertEvmAddress(token, "swapFeeToken"));
+  if (address !== sellToken && address !== buyToken) {
+    throw new AdapterValidationError("swapFeeToken must be the buy token or sell token");
+  }
+  return address;
+}
 
 export class MockSwapAdapter implements SwapAdapter {
   readonly category = "swap" as const;
@@ -79,16 +201,11 @@ export class MockSwapAdapter implements SwapAdapter {
     const chainId = assertChainId(request.chainId);
     const amountIn = assertUint256(request.amount, "amount");
     const slippageBps = assertSlippageBps(request.slippageBps);
-    if (!request.fromToken?.address || !request.toToken?.address) {
-      throw new AdapterValidationError("fromToken and toToken addresses are required");
-    }
-    if (request.fromToken.address === request.toToken.address) {
-      throw new AdapterValidationError("fromToken and toToken must differ");
-    }
+    assertDifferentTokens(request.fromToken, request.toToken);
 
     const amount = BigInt(amountIn);
     const feeAmount = (amount * MOCK_FEE_BPS) / 10_000n;
-    const amountOut = amount - feeAmount; // deterministic 1:1 minus fee
+    const amountOut = amount - feeAmount;
     const minAmountOut = (amountOut * BigInt(10_000 - slippageBps)) / 10_000n;
 
     return {
@@ -121,13 +238,10 @@ export class MockSwapAdapter implements SwapAdapter {
     if (quote.expiresAt <= this.now()) {
       throw new AdapterValidationError("quote has expired; request a fresh quote");
     }
-    // Re-validate quote internals (untrusted even though we produced it).
     assertUint256(quote.amountIn, "quote.amountIn");
     assertUint256(quote.minAmountOut, "quote.minAmountOut", true);
     const to = assertEvmAddress(quote.toToken.address, "quote.toToken.address");
 
-    // The mock targets the toToken contract as a stand-in router. A real adapter
-    // would encode the aggregator's calldata. Crucially: this is UNSIGNED.
     return {
       signed: false,
       kind: "evm-tx",
@@ -145,5 +259,400 @@ export class MockSwapAdapter implements SwapAdapter {
         slippageBps: quote.slippageBps,
       },
     };
+  }
+}
+
+export class ZeroExSwapAdapter implements SwapAdapter {
+  readonly category = "swap" as const;
+  readonly provider = ZEROEX_PROVIDER;
+  readonly enabled = true;
+
+  private readonly apiKey: string;
+  private readonly baseUrl: string;
+  private readonly timeoutMs: number;
+  private readonly quoteTtlMs: number;
+  private readonly now: () => number;
+  private readonly fetchImpl: typeof fetch;
+  private readonly supportedChains: ReadonlyMap<number, NormalizedZeroExChainConfig>;
+  private readonly affiliateFee?: ZeroExAffiliateFeeConfig;
+
+  constructor(options: ZeroExSwapAdapterOptions) {
+    const apiKey = options.apiKey.trim();
+    if (!apiKey) throw new AdapterValidationError("0x api key is required");
+    this.apiKey = apiKey;
+    this.baseUrl = (options.baseUrl ?? ZEROEX_DEFAULT_BASE_URL).replace(/\/+$/, "");
+    this.timeoutMs = options.timeoutMs ?? ZEROEX_DEFAULT_TIMEOUT_MS;
+    this.quoteTtlMs = options.quoteTtlMs ?? ZEROEX_DEFAULT_QUOTE_TTL_MS;
+    if (!Number.isInteger(this.timeoutMs) || this.timeoutMs <= 0 || this.timeoutMs > 10_000) {
+      throw new AdapterValidationError("0x timeoutMs must be an integer between 1 and 10000");
+    }
+    if (!Number.isInteger(this.quoteTtlMs) || this.quoteTtlMs <= 0 || this.quoteTtlMs > 120_000) {
+      throw new AdapterValidationError("0x quoteTtlMs must be an integer between 1 and 120000");
+    }
+    this.now = options.now ?? (() => Date.now());
+    this.fetchImpl = options.fetch ?? fetch;
+    this.affiliateFee = options.affiliateFee;
+    this.supportedChains = this.normalizeSupportedChains(options.supportedChains);
+  }
+
+  async getQuote(request: SwapQuoteRequest): Promise<SwapQuote> {
+    const params = this.normalizeRequest(request);
+    const response = await this.fetchAllowanceHolder("price", params);
+    return this.parsePriceResponse(response, params);
+  }
+
+  async buildSwap(quote: SwapQuote, agentAddress: string): Promise<UnsignedTxIntent> {
+    const zeroExQuote = this.assertZeroExQuote(quote);
+    const owner = normalizeAddress(assertEvmAddress(agentAddress, "agentAddress"));
+    if (owner !== zeroExQuote.zeroEx.taker) {
+      throw new AdapterValidationError("agentAddress does not match quote taker");
+    }
+    if (quote.expiresAt <= this.now()) {
+      throw new AdapterValidationError("quote has expired; request a fresh quote");
+    }
+
+    const response = await this.fetchAllowanceHolder("quote", zeroExQuote.zeroEx.request);
+    const parsed = this.parseQuoteResponse(response, zeroExQuote);
+    return {
+      signed: false,
+      kind: "evm-tx",
+      chainId: quote.chainId,
+      to: parsed.to,
+      value: parsed.value,
+      data: parsed.data,
+      owner,
+      category: "swap",
+      provider: this.provider,
+      metadata: {
+        quoteId: quote.quoteId,
+        amountIn: quote.amountIn,
+        minAmountOut: quote.minAmountOut,
+        slippageBps: quote.slippageBps,
+        allowanceTarget: zeroExQuote.zeroEx.allowanceTarget,
+      },
+    };
+  }
+
+  private normalizeSupportedChains(
+    supportedChains: Readonly<Record<number, ZeroExChainConfig>>,
+  ): ReadonlyMap<number, NormalizedZeroExChainConfig> {
+    const entries = Object.entries(supportedChains);
+    if (entries.length === 0) {
+      throw new AdapterValidationError("0x supportedChains must not be empty");
+    }
+    const normalized = new Map<number, NormalizedZeroExChainConfig>();
+    for (const [rawChainId, rawConfig] of entries) {
+      const chainId = assertChainId(Number(rawChainId));
+      const allowanceTarget = normalizeAddress(
+        assertEvmAddress(
+          rawConfig.allowanceTarget,
+          `supportedChains.${rawChainId}.allowanceTarget`,
+        ),
+      );
+      const targets = rawConfig.transactionTargets.map((target) =>
+        normalizeAddress(
+          assertEvmAddress(target, `supportedChains.${rawChainId}.transactionTarget`),
+        ),
+      );
+      if (targets.length === 0) {
+        throw new AdapterValidationError(
+          `supportedChains.${rawChainId}.transactionTargets must not be empty`,
+        );
+      }
+      if (targets.includes(allowanceTarget)) {
+        throw new AdapterValidationError("0x transaction target must not be the AllowanceHolder");
+      }
+      normalized.set(chainId, { allowanceTarget, transactionTargets: new Set(targets) });
+    }
+    return normalized;
+  }
+
+  private normalizeRequest(request: SwapQuoteRequest): ZeroExRequestParams {
+    const chainId = assertChainId(request.chainId);
+    if (!this.supportedChains.has(chainId)) {
+      throw new AdapterValidationError(`0x does not support chainId ${chainId}`);
+    }
+    assertDifferentTokens(request.fromToken, request.toToken);
+    const sellToken = normalizeAddress(
+      assertEvmAddress(request.fromToken.address, "fromToken.address"),
+    );
+    const buyToken = normalizeAddress(assertEvmAddress(request.toToken.address, "toToken.address"));
+    const taker = normalizeAddress(assertEvmAddress(request.taker, "taker"));
+    return {
+      chainId,
+      sellToken,
+      buyToken,
+      sellAmount: assertUint256(request.amount, "amount"),
+      taker,
+      slippageBps: assertSlippageBps(request.slippageBps),
+    };
+  }
+
+  private parsePriceResponse(response: ZeroExResponse, request: ZeroExRequestParams): ZeroExQuote {
+    const chain = this.requireChain(request.chainId);
+    this.validateSemanticEcho(response, request);
+    const buyAmount = assertUint256(responseString(response, "buyAmount"), "buyAmount", true);
+    const minBuyAmount =
+      typeof response.minBuyAmount === "string"
+        ? assertUint256(response.minBuyAmount, "minBuyAmount", true)
+        : buyAmount;
+    const allowanceTarget = this.validateOptionalAllowanceTarget(response, chain);
+    const expiresAt = this.now() + this.quoteTtlMs;
+    const quoteId = quoteIdFrom({
+      provider: this.provider,
+      request,
+      buyAmount,
+      minBuyAmount,
+      allowanceTarget,
+      expiresAt,
+    });
+    return {
+      provider: this.provider,
+      fromToken: { address: request.sellToken },
+      toToken: { address: request.buyToken },
+      chainId: request.chainId,
+      amountIn: request.sellAmount,
+      amountOut: buyAmount,
+      minAmountOut: minBuyAmount,
+      route: [{ venue: "0x-swap-api-v2", fromToken: request.sellToken, toToken: request.buyToken }],
+      feeAmount: "0",
+      slippageBps: request.slippageBps,
+      expiresAt,
+      quoteId,
+      zeroEx: { taker: request.taker, allowanceTarget, request },
+    };
+  }
+
+  private parseQuoteResponse(
+    response: ZeroExResponse,
+    quote: ZeroExQuote,
+  ): { to: string; data: string; value: string } {
+    const chain = this.requireChain(quote.chainId);
+    this.validateSemanticEcho(response, quote.zeroEx.request);
+    const buyAmount = assertUint256(responseString(response, "buyAmount"), "buyAmount", true);
+    const minBuyAmount = assertUint256(
+      responseString(response, "minBuyAmount"),
+      "minBuyAmount",
+      true,
+    );
+    const sellAmount = assertUint256(responseString(response, "sellAmount"), "sellAmount");
+    if (
+      buyAmount !== quote.amountOut ||
+      minBuyAmount !== quote.minAmountOut ||
+      sellAmount !== quote.amountIn
+    ) {
+      throw new AdapterValidationError("0x quote response is not bound to the price quote");
+    }
+    const allowanceTarget = this.validateOptionalAllowanceTarget(response, chain);
+    if (allowanceTarget !== quote.zeroEx.allowanceTarget) {
+      throw new AdapterValidationError("0x allowanceTarget is not bound to the price quote");
+    }
+    const transaction = responseObject(response.transaction);
+    const to = normalizeAddress(assertEvmAddress(transaction.to, "transaction.to"));
+    if (!chain.transactionTargets.has(to)) {
+      throw new AdapterValidationError("0x transaction target is not allowlisted");
+    }
+    if (transaction.from !== undefined) {
+      const from = normalizeAddress(assertEvmAddress(transaction.from, "transaction.from"));
+      if (from !== quote.zeroEx.taker) {
+        throw new AdapterValidationError("0x transaction.from is not bound to taker");
+      }
+    }
+    const data = assertHexData(transaction.data, "transaction.data");
+    const value = assertUint256(responseString(transaction, "value"), "transaction.value", true);
+    return { to, data, value };
+  }
+
+  private validateSemanticEcho(response: ZeroExResponse, request: ZeroExRequestParams): void {
+    this.assertOptionalEchoAddress(response, "sellToken", request.sellToken);
+    this.assertOptionalEchoAddress(response, "buyToken", request.buyToken);
+    this.assertOptionalEchoAmount(response, "sellAmount", request.sellAmount);
+    if (response.chainId !== undefined && response.chainId !== request.chainId) {
+      throw new AdapterValidationError("0x response chainId is not bound to the request");
+    }
+    if (response.taker !== undefined) {
+      const taker = normalizeAddress(assertEvmAddress(response.taker, "taker"));
+      if (taker !== request.taker) {
+        throw new AdapterValidationError("0x response taker is not bound to the request");
+      }
+    }
+  }
+
+  private assertOptionalEchoAddress(
+    response: ZeroExResponse,
+    field: string,
+    expected: string,
+  ): void {
+    const value = response[field];
+    if (value !== undefined && normalizeAddress(assertEvmAddress(value, field)) !== expected) {
+      throw new AdapterValidationError(`0x response ${field} is not bound to the request`);
+    }
+  }
+
+  private assertOptionalEchoAmount(
+    response: ZeroExResponse,
+    field: string,
+    expected: string,
+  ): void {
+    const value = response[field];
+    if (value !== undefined && assertUint256(value, field) !== expected) {
+      throw new AdapterValidationError(`0x response ${field} is not bound to the request`);
+    }
+  }
+
+  private validateAllowanceTarget(
+    response: ZeroExResponse,
+    chain: NormalizedZeroExChainConfig,
+    expected = chain.allowanceTarget,
+  ): string {
+    const allowanceTarget = normalizeAddress(
+      assertEvmAddress(response.allowanceTarget, "allowanceTarget"),
+    );
+    if (allowanceTarget !== expected || allowanceTarget !== chain.allowanceTarget) {
+      throw new AdapterValidationError("0x allowanceTarget is not configured for this chain");
+    }
+    const issues = response.issues;
+    if (issues && typeof issues === "object" && !Array.isArray(issues)) {
+      const allowance = (issues as Record<string, unknown>).allowance;
+      if (allowance && typeof allowance === "object" && !Array.isArray(allowance)) {
+        const spender = (allowance as Record<string, unknown>).spender;
+        if (
+          spender !== undefined &&
+          normalizeAddress(assertEvmAddress(spender, "issues.allowance.spender")) !==
+            chain.allowanceTarget
+        ) {
+          throw new AdapterValidationError("0x allowance spender is not the AllowanceHolder");
+        }
+      }
+    }
+    return allowanceTarget;
+  }
+
+  private validateOptionalAllowanceTarget(
+    response: ZeroExResponse,
+    chain: NormalizedZeroExChainConfig,
+  ): string {
+    if (response.allowanceTarget !== undefined) {
+      return this.validateAllowanceTarget(response, chain);
+    }
+    this.validateAllowanceIssue(response, chain);
+    return chain.allowanceTarget;
+  }
+
+  private validateAllowanceIssue(
+    response: ZeroExResponse,
+    chain: NormalizedZeroExChainConfig,
+  ): void {
+    const issues = response.issues;
+    if (!issues || typeof issues !== "object" || Array.isArray(issues)) return;
+    const allowance = (issues as Record<string, unknown>).allowance;
+    if (!allowance || typeof allowance !== "object" || Array.isArray(allowance)) return;
+    const spender = (allowance as Record<string, unknown>).spender;
+    if (
+      spender !== undefined &&
+      normalizeAddress(assertEvmAddress(spender, "issues.allowance.spender")) !==
+        chain.allowanceTarget
+    ) {
+      throw new AdapterValidationError("0x allowance spender is not the AllowanceHolder");
+    }
+  }
+
+  private requireChain(chainId: number): NormalizedZeroExChainConfig {
+    const chain = this.supportedChains.get(chainId);
+    if (!chain) throw new AdapterValidationError(`0x does not support chainId ${chainId}`);
+    return chain;
+  }
+
+  private assertZeroExQuote(quote: SwapQuote): ZeroExQuote {
+    if (quote.provider !== this.provider) {
+      throw new AdapterValidationError("quote provider is not zeroex");
+    }
+    const maybe = quote as Partial<ZeroExQuote>;
+    if (!maybe.zeroEx?.request || !maybe.zeroEx.taker || !maybe.zeroEx.allowanceTarget) {
+      throw new AdapterValidationError("quote is missing zeroex binding metadata");
+    }
+    const zeroExQuote = quote as ZeroExQuote;
+    const request = zeroExQuote.zeroEx.request;
+    const chain = this.requireChain(assertChainId(quote.chainId));
+    const fromToken = normalizeAddress(
+      assertEvmAddress(quote.fromToken.address, "quote.fromToken"),
+    );
+    const toToken = normalizeAddress(assertEvmAddress(quote.toToken.address, "quote.toToken"));
+    const amountIn = assertUint256(quote.amountIn, "quote.amountIn");
+    assertUint256(quote.amountOut, "quote.amountOut", true);
+    assertUint256(quote.minAmountOut, "quote.minAmountOut", true);
+    const slippageBps = assertSlippageBps(quote.slippageBps);
+    const taker = normalizeAddress(assertEvmAddress(zeroExQuote.zeroEx.taker, "zeroEx.taker"));
+    const allowanceTarget = normalizeAddress(
+      assertEvmAddress(zeroExQuote.zeroEx.allowanceTarget, "zeroEx.allowanceTarget"),
+    );
+    if (
+      request.chainId !== quote.chainId ||
+      request.sellToken !== fromToken ||
+      request.buyToken !== toToken ||
+      request.sellAmount !== amountIn ||
+      request.slippageBps !== slippageBps ||
+      request.taker !== taker ||
+      allowanceTarget !== chain.allowanceTarget
+    ) {
+      throw new AdapterValidationError("quote zeroex metadata is not bound to the quote");
+    }
+    if (!Number.isSafeInteger(quote.expiresAt)) {
+      throw new AdapterValidationError("quote.expiresAt must be an integer timestamp");
+    }
+    return zeroExQuote;
+  }
+
+  private async fetchAllowanceHolder(
+    endpoint: "price" | "quote",
+    request: ZeroExRequestParams,
+  ): Promise<ZeroExResponse> {
+    const url = new URL(`/swap/allowance-holder/${endpoint}`, this.baseUrl);
+    url.searchParams.set("chainId", String(request.chainId));
+    url.searchParams.set("sellToken", request.sellToken);
+    url.searchParams.set("buyToken", request.buyToken);
+    url.searchParams.set("sellAmount", request.sellAmount);
+    url.searchParams.set("taker", request.taker);
+    url.searchParams.set("slippageBps", String(request.slippageBps));
+    if (this.affiliateFee) {
+      if (this.affiliateFee.bps < 0 || this.affiliateFee.bps > 1_000) {
+        throw new AdapterValidationError("swapFeeBps must be between 0 and 1000");
+      }
+      const recipient = normalizeAddress(
+        assertEvmAddress(this.affiliateFee.recipient, "swapFeeRecipient"),
+      );
+      url.searchParams.set("swapFeeRecipient", recipient);
+      url.searchParams.set("swapFeeBps", String(this.affiliateFee.bps));
+      url.searchParams.set(
+        "swapFeeToken",
+        feeTokenAddress(this.affiliateFee, request.sellToken, request.buyToken),
+      );
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const res = await this.fetchImpl(url, {
+        method: "GET",
+        headers: { "0x-api-key": this.apiKey, "0x-version": "v2" },
+        signal: controller.signal,
+      });
+      if (!res.ok) {
+        throw new AdapterUnavailableError("swap", `0x ${endpoint} failed with HTTP ${res.status}`);
+      }
+      return responseObject(await res.json());
+    } catch (error) {
+      if (error instanceof AdapterUnavailableError || error instanceof AdapterValidationError) {
+        throw error;
+      }
+      const isAbort =
+        error instanceof Error && (error.name === "AbortError" || error.message.includes("abort"));
+      throw new AdapterUnavailableError(
+        "swap",
+        isAbort ? `0x ${endpoint} timed out` : `0x ${endpoint} request failed`,
+      );
+    } finally {
+      clearTimeout(timeout);
+    }
   }
 }

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -111,6 +111,10 @@ export {
   type SwapAdapter,
   type SwapQuote,
   type SwapQuoteRequest,
+  type ZeroExAffiliateFeeConfig,
+  type ZeroExChainConfig,
+  ZeroExSwapAdapter,
+  type ZeroExSwapAdapterOptions,
 } from "./adapters/swap.js";
 export {
   MockTosAdapter,

--- a/packages/adapters/src/registry.ts
+++ b/packages/adapters/src/registry.ts
@@ -25,7 +25,7 @@ import { MockOfframpAdapter, type OfframpAdapter } from "./adapters/offramp.js";
 import { MockOnrampAdapter, type OnrampAdapter } from "./adapters/onramp.js";
 import { MockPushAdapter, type PushAdapter } from "./adapters/push.js";
 import { MockSparkAdapter, type SparkAdapter } from "./adapters/spark.js";
-import { MockSwapAdapter, type SwapAdapter } from "./adapters/swap.js";
+import { MockSwapAdapter, type SwapAdapter, ZeroExSwapAdapter } from "./adapters/swap.js";
 import { MockTosAdapter, type TosAdapter } from "./adapters/tos.js";
 import { type AdapterCategory, AdapterNotConfiguredError, type BaseAdapter } from "./types.js";
 
@@ -108,6 +108,50 @@ function makeMockAdapter<C extends AdapterCategory>(category: C): CategoryToAdap
   return MOCK_FACTORIES[category]();
 }
 
+function parsePositiveIntEnv(
+  env: Record<string, string | undefined>,
+  key: string,
+): number | undefined {
+  const raw = env[key]?.trim();
+  if (!raw) return undefined;
+  const parsed = Number(raw);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function parseZeroExAffiliateFee(env: Record<string, string | undefined>) {
+  const recipient = env.STEWARD_ZEROEX_SWAP_FEE_RECIPIENT?.trim();
+  const bpsRaw = env.STEWARD_ZEROEX_SWAP_FEE_BPS?.trim();
+  const token = env.STEWARD_ZEROEX_SWAP_FEE_TOKEN?.trim();
+  if (!recipient && !bpsRaw && !token) return undefined;
+  const bps = Number(bpsRaw);
+  if (!recipient || !Number.isInteger(bps)) {
+    throw new Error("invalid 0x affiliate fee config");
+  }
+  return {
+    recipient,
+    bps,
+    token: token || undefined,
+  };
+}
+
+function maybeMakeZeroExSwapAdapter(env: Record<string, string | undefined>): SwapAdapter | null {
+  const apiKey = env.STEWARD_ZEROEX_API_KEY?.trim();
+  const supportedChainsJson = env.STEWARD_ZEROEX_SUPPORTED_CHAINS_JSON?.trim();
+  if (!apiKey || !supportedChainsJson) return null;
+  try {
+    return new ZeroExSwapAdapter({
+      apiKey,
+      supportedChains: JSON.parse(supportedChainsJson),
+      baseUrl: env.STEWARD_ZEROEX_BASE_URL?.trim() || undefined,
+      timeoutMs: parsePositiveIntEnv(env, "STEWARD_ZEROEX_TIMEOUT_MS"),
+      quoteTtlMs: parsePositiveIntEnv(env, "STEWARD_ZEROEX_QUOTE_TTL_MS"),
+      affiliateFee: parseZeroExAffiliateFee(env),
+    });
+  } catch {
+    return null;
+  }
+}
+
 export class AdapterRegistry {
   private readonly env: Record<string, string | undefined>;
   // category -> (providerName -> adapter) for explicitly registered real adapters
@@ -151,6 +195,17 @@ export class AdapterRegistry {
 
     const configured = this.env[envKey(category)]?.trim();
     const byName = this.registered.get(category);
+
+    if (category === "swap" && configured === "zeroex") {
+      const zeroEx = maybeMakeZeroExSwapAdapter(this.env);
+      if (zeroEx) {
+        this.resolved.set(category, zeroEx);
+        return zeroEx as CategoryToAdapter[C];
+      }
+      const disabled = makeDisabledAdapter(category);
+      this.resolved.set(category, disabled);
+      return disabled;
+    }
 
     // 1. Explicit env selection of a registered provider.
     if (configured && configured !== "mock" && byName?.has(configured)) {

--- a/packages/api/src/openapi.ts
+++ b/packages/api/src/openapi.ts
@@ -4137,6 +4137,7 @@ function adapterPaths(prefix = ""): Record<string, unknown> {
       amount: stringSchema,
       chainId: { type: "integer", minimum: 1 },
       slippageBps: { type: "integer", minimum: 0, maximum: 10000 },
+      taker: stringSchema,
       estimatedUsd: { type: "number", minimum: 0 },
     },
   };

--- a/packages/api/src/routes/adapters.ts
+++ b/packages/api/src/routes/adapters.ts
@@ -457,6 +457,7 @@ const swapQuoteSchema = z.object({
   amount: z.string().min(1).max(80),
   chainId: z.number().int().positive(),
   slippageBps: z.number().int().min(0).max(10_000).optional(),
+  taker: z.string().min(1).max(128).optional(),
   /** Caller's USD notional estimate for the input amount (for the spend gate). */
   estimatedUsd: z.number().positive().max(1e12).optional(),
 });
@@ -646,6 +647,7 @@ adapterRoutes.post("/swap/quote", async (c) => {
       amount: parsed.data.amount,
       chainId: parsed.data.chainId,
       slippageBps: parsed.data.slippageBps,
+      taker: parsed.data.taker,
     });
     return c.json(ok({ quote }));
   } catch (err) {

--- a/packages/plugin-trading/src/__tests__/evm-swap-prepare.test.ts
+++ b/packages/plugin-trading/src/__tests__/evm-swap-prepare.test.ts
@@ -53,15 +53,30 @@ class FakeSwapAdapter implements SwapAdapter {
   chainId: number | null = null;
   mutateOwner = false;
   mutateQuoteId = false;
+  mutateQuoteFromToken = false;
+  mutateQuoteToToken = false;
+  mutateQuoteAmount = false;
+  expireQuote = false;
+  failUnavailable = false;
+  observedTaker: string | undefined;
 
   async getQuote(request: SwapQuoteRequest): Promise<SwapQuote> {
     this.quoteCalls += 1;
+    this.observedTaker = request.taker;
+    if (this.failUnavailable) {
+      const { AdapterUnavailableError } = await import("@stwd/adapters");
+      throw new AdapterUnavailableError("swap", "recorded provider failure");
+    }
     return {
       provider: this.provider,
-      fromToken: request.fromToken,
-      toToken: request.toToken,
+      fromToken: this.mutateQuoteFromToken
+        ? { ...request.fromToken, address: "0x00000000000000000000000000000000000000ef" }
+        : request.fromToken,
+      toToken: this.mutateQuoteToToken
+        ? { ...request.toToken, address: "0x00000000000000000000000000000000000000ef" }
+        : request.toToken,
       chainId: this.chainId ?? request.chainId,
-      amountIn: request.amount,
+      amountIn: this.mutateQuoteAmount ? "999" : request.amount,
       amountOut: request.amount,
       minAmountOut: request.amount,
       route: [
@@ -69,7 +84,7 @@ class FakeSwapAdapter implements SwapAdapter {
       ],
       feeAmount: "0",
       slippageBps: request.slippageBps ?? 50,
-      expiresAt: Date.now() + 60_000,
+      expiresAt: this.expireQuote ? Date.now() - 1 : Date.now() + 60_000,
       quoteId: `quote-${request.chainId}-${request.amount}`,
     };
   }
@@ -309,6 +324,7 @@ describe("governed EVM swap prepare", () => {
     };
     expect(body.data.intentHash).toMatch(/^sha256:/);
     expect(body.data.unsignedIntent.data).toBe(CALLDATA);
+    expect(adapter.observedTaker).toMatch(/^0x[a-f0-9]{40}$/i);
     expect(adapter.buildCalls).toBe(1);
     expect(simulationCalls()).toBe(1);
 
@@ -448,6 +464,24 @@ describe("governed EVM swap prepare", () => {
       const { app } = await buildApp({ adapter, simulator: { ok: true } });
       const res = await postPrepare(app);
       expect([400, 403]).toContain(res.status);
+    }
+  });
+
+  it("denies provider-returned quote mutation and unavailable failures before simulation", async () => {
+    const cases: Array<[Partial<FakeSwapAdapter>, number]> = [
+      [{ chainId: 1 }, 400],
+      [{ mutateQuoteFromToken: true }, 400],
+      [{ mutateQuoteToToken: true }, 400],
+      [{ mutateQuoteAmount: true }, 400],
+      [{ expireQuote: true }, 400],
+      [{ failUnavailable: true }, 503],
+    ];
+    for (const [adapterPatch, status] of cases) {
+      const adapter = Object.assign(new FakeSwapAdapter(), adapterPatch);
+      const { app, simulationCalls } = await buildApp({ adapter, simulator: { ok: true } });
+      const res = await postPrepare(app);
+      expect(res.status).toBe(status);
+      expect(simulationCalls()).toBe(0);
     }
   });
 

--- a/packages/plugin-trading/src/routes/evm-swap.ts
+++ b/packages/plugin-trading/src/routes/evm-swap.ts
@@ -1,5 +1,10 @@
 import { createHash } from "node:crypto";
-import type { SwapQuote } from "@stwd/adapters";
+import {
+  AdapterNotConfiguredError,
+  AdapterUnavailableError,
+  AdapterValidationError,
+  type SwapQuote,
+} from "@stwd/adapters";
 import {
   aggregationLookupFromMap,
   aggregationQueriesForPolicies,
@@ -468,6 +473,7 @@ export function createEvmSwapRoutes(ctx: StewardAppContext): Hono<{ Variables: A
         toToken: parsed.data.toToken,
         amount: parsed.data.amount,
         chainId: parsed.data.chainId,
+        taker: owner,
         slippageBps: parsed.data.slippageBps,
       });
       if (
@@ -605,8 +611,14 @@ export function createEvmSwapRoutes(ctx: StewardAppContext): Hono<{ Variables: A
           },
         },
       };
-    })().catch(async (): Promise<StoredResponse> => {
-      const reason = "EVM swap preparation failed";
+    })().catch(async (error): Promise<StoredResponse> => {
+      const adapterReason =
+        error instanceof AdapterValidationError ||
+        error instanceof AdapterNotConfiguredError ||
+        error instanceof AdapterUnavailableError
+          ? error.message
+          : null;
+      const reason = adapterReason ?? "EVM swap preparation failed";
       await ctx.writeAuditEvent({
         tenantId,
         actorType: "agent",
@@ -616,6 +628,12 @@ export function createEvmSwapRoutes(ctx: StewardAppContext): Hono<{ Variables: A
         resourceId: parsed.data.agentId,
         metadata: { reason, agentId: parsed.data.agentId, chainId: parsed.data.chainId },
       });
+      if (error instanceof AdapterValidationError) {
+        return { status: 400, body: rejectReason(error.message) };
+      }
+      if (error instanceof AdapterNotConfiguredError || error instanceof AdapterUnavailableError) {
+        return { status: 503, body: { ok: false, error: error.message } };
+      }
       return { status: 500, body: { ok: false, error: "Internal server error" } };
     });
 


### PR DESCRIPTION
## Summary

Stacked on #165. Adds an explicitly configured, fail-closed production 0x Swap API v2 adapter for governed EVM swap preparation.

- AllowanceHolder `/price` and `/quote` integration
- strict per-chain allowance-spender and transaction-target allowlists
- API key and v2 headers, bounded timeout, quote TTL
- authoritative taker propagation from the governed agent wallet
- semantic quote/request binding and minimum-output checks
- nested 0x metadata rebound before executable calldata is requested
- optional validated affiliate fee configuration
- generated OpenAPI update for semantic `taker`

## Safety boundary

This still prepares and simulates unsigned intents only. It does not sign, broadcast, move funds, deploy, or mutate production configuration.

Production activation fails closed unless all are explicit and valid:

- `STEWARD_SWAP_ADAPTER=zeroex`
- non-empty 0x API key
- supported-chain configuration
- chain-specific AllowanceHolder and transaction targets
- valid optional fee recipient/bps/token policy

Provider mutations, unsafe targets/spenders, malformed calldata/value, expiry, timeout, unsupported chains, and binding mismatches are rejected.

## Verification

Independent rerun:

- adapter + registry + API policy/OpenAPI + governed route: 68 passed, 1,192 assertions
- adapter TypeScript check passed
- API TypeScript check passed
- Biome and diff checks passed
- two Codex review passes completed; all findings fixed, final review clean

All provider behavior uses deterministic recorded fixtures. No live 0x calls or keys.

## Stack

Base: #165 / `feat/first-class-evm-execution`

— [sol-orch]
