### PR TITLE
feat(trading): persist governed EVM swap intents

### DIFF
--- a/packages/db/drizzle/0076_evm_prepared_intent_ledger.sql
+++ b/packages/db/drizzle/0076_evm_prepared_intent_ledger.sql
@@ -1,0 +1,15 @@
+ALTER TABLE "intents"
+  ADD COLUMN IF NOT EXISTS "idempotency_key" varchar(255),
+  ADD COLUMN IF NOT EXISTS "semantic_request_hash" varchar(128),
+  ADD COLUMN IF NOT EXISTS "intent_hash" varchar(128);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "intents_tenant_agent_type_idempotency_unique_idx"
+  ON "intents" ("tenant_id", "agent_id", "intent_type", "idempotency_key")
+  WHERE "idempotency_key" IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "intents_tenant_agent_type_intent_hash_unique_idx"
+  ON "intents" ("tenant_id", "agent_id", "intent_type", "intent_hash")
+  WHERE "intent_hash" IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS "intents_tenant_agent_semantic_request_idx"
+  ON "intents" ("tenant_id", "agent_id", "semantic_request_hash");

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -393,6 +393,13 @@
       "when": 1780137000000,
       "tag": "0075_monero_chain_family",
       "breakpoints": true
+    },
+    {
+      "idx": 76,
+      "version": "7",
+      "when": 1780137600000,
+      "tag": "0076_evm_prepared_intent_ledger",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/__tests__/pglite.test.ts
+++ b/packages/db/src/__tests__/pglite.test.ts
@@ -14,7 +14,7 @@ import { join } from "node:path";
 import { eq } from "drizzle-orm";
 
 import { createPGLiteDb } from "../pglite";
-import { agents, encryptedKeys, policies, tenants, transactions } from "../schema";
+import { agents, encryptedKeys, intents, policies, tenants, transactions } from "../schema";
 
 setDefaultTimeout(120000);
 
@@ -270,6 +270,58 @@ describe("PGLite Adapter", () => {
 
       expect(agentRows).toHaveLength(1);
       expect(agentRows[0].name).toBe("Persistent Agent");
+
+      await client.close();
+    }
+  });
+
+  test("prepared EVM intent ledger columns persist across close/reopen", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "steward-pglite-intents-"));
+
+    {
+      const { db, client } = await createPGLiteDb(tempDir);
+
+      await db.insert(tenants).values({
+        id: "intent-tenant",
+        name: "Intent Tenant",
+        apiKeyHash: "intent-hash",
+      });
+      await db.insert(agents).values({
+        id: "intent-agent",
+        tenantId: "intent-tenant",
+        name: "Intent Agent",
+        walletAddress: "0x0000000000000000000000000000000000000001",
+      });
+      await db.insert(intents).values({
+        id: "evm_persisted",
+        tenantId: "intent-tenant",
+        agentId: "intent-agent",
+        intentType: "evm_swap",
+        status: "prepared",
+        resourceType: "trade.evm.swap",
+        resourceId: "sha256:intent",
+        createdByType: "agent",
+        createdById: "intent-agent",
+        idempotencyKey: "idem-persisted",
+        semanticRequestHash: "sha256:request",
+        intentHash: "sha256:intent",
+        payload: { quoteHash: "sha256:quote" },
+      });
+
+      await client.close();
+    }
+
+    {
+      const { db, client } = await createPGLiteDb(tempDir);
+      const rows = await db.select().from(intents).where(eq(intents.id, "evm_persisted"));
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        idempotencyKey: "idem-persisted",
+        semanticRequestHash: "sha256:request",
+        intentHash: "sha256:intent",
+        status: "prepared",
+      });
 
       await client.close();
     }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -990,6 +990,9 @@ export const intents = pgTable(
       .default([]),
     payload: jsonb("payload").$type<Record<string, unknown>>().notNull().default({}),
     executionResult: jsonb("execution_result").$type<Record<string, unknown>>(),
+    idempotencyKey: varchar("idempotency_key", { length: 255 }),
+    semanticRequestHash: varchar("semantic_request_hash", { length: 128 }),
+    intentHash: varchar("intent_hash", { length: 128 }),
     expiresAt: timestamp("expires_at", { withTimezone: true }),
     authorizedBy: varchar("authorized_by", { length: 255 }),
     canceledAt: timestamp("canceled_at", { withTimezone: true }),
@@ -1014,6 +1017,17 @@ export const intents = pgTable(
     tenantCreatedIdx: index("intents_tenant_created_idx").on(table.tenantId, table.createdAt),
     agentIdx: index("intents_agent_idx").on(table.agentId),
     resourceIdx: index("intents_resource_idx").on(table.resourceType, table.resourceId),
+    idempotencyUniqueIdx: uniqueIndex("intents_tenant_agent_type_idempotency_unique_idx")
+      .on(table.tenantId, table.agentId, table.intentType, table.idempotencyKey)
+      .where(sql`${table.idempotencyKey} is not null`),
+    intentHashUniqueIdx: uniqueIndex("intents_tenant_agent_type_intent_hash_unique_idx")
+      .on(table.tenantId, table.agentId, table.intentType, table.intentHash)
+      .where(sql`${table.intentHash} is not null`),
+    semanticRequestIdx: index("intents_tenant_agent_semantic_request_idx").on(
+      table.tenantId,
+      table.agentId,
+      table.semanticRequestHash,
+    ),
     tenantAgentFk: foreignKey({
       columns: [table.tenantId, table.agentId],
       foreignColumns: [agents.tenantId, agents.id],

--- a/packages/plugin-trading/src/__tests__/evm-swap-prepare.test.ts
+++ b/packages/plugin-trading/src/__tests__/evm-swap-prepare.test.ts
@@ -16,11 +16,15 @@ process.env.STEWARD_PGLITE_MEMORY = "true";
 process.env.STEWARD_DB_MODE = "pglite";
 process.env.STEWARD_MASTER_PASSWORD = "evm-swap-master-password";
 process.env.STEWARD_AUDIT_HMAC_KEY = "evm-swap-audit-hmac-key-with-enough-entropy";
+process.env.STEWARD_PLATFORM_KEYS = "evm-swap-platform-key";
 
 const TENANT_ID = "evm-swap-tenant";
+const OTHER_TENANT_ID = "evm-swap-other-tenant";
 const AGENT_ID = "evm-swap-agent";
 const OTHER_AGENT_ID = "evm-swap-other-agent";
+const SESSION_ID = "evm-swap-session";
 const KID = "evm-swap-kid";
+const PLATFORM_KEY = "evm-swap-platform-key";
 const TARGET = "0x00000000000000000000000000000000000000bb";
 const FROM_TOKEN = "0x00000000000000000000000000000000000000cc";
 const TO_TOKEN = "0x00000000000000000000000000000000000000dd";
@@ -35,11 +39,14 @@ let testCtx: () => StewardAppContext;
 let tradingPlugin: typeof import("../index")["tradingPlugin"];
 let createEvmSwapRoutes: typeof import("../routes/evm-swap")["createEvmSwapRoutes"];
 let auditEvents: typeof import("@stwd/db")["auditEvents"];
+let intents: typeof import("@stwd/db")["intents"];
 let policies: typeof import("@stwd/db")["policies"];
 let tenants: typeof import("@stwd/db")["tenants"];
+let tradeSessions: typeof import("@stwd/db")["tradeSessions"];
 let closeDb: typeof import("@stwd/db")["closeDb"];
 let getDb: typeof import("@stwd/db")["getDb"];
 let pgliteDb: ReturnType<typeof getDb>;
+let agentWalletAddress: string;
 
 class FakeSwapAdapter implements SwapAdapter {
   readonly category = "swap" as const;
@@ -190,6 +197,7 @@ async function seedPolicy(
 function requestBody(agentId = AGENT_ID) {
   return {
     agentId,
+    sessionId: SESSION_ID,
     chainId: 8453,
     fromToken: { address: FROM_TOKEN, symbol: "A", decimals: 18 },
     toToken: { address: TO_TOKEN, symbol: "B", decimals: 18 },
@@ -221,7 +229,7 @@ async function buildApp(options?: {
       : null,
   };
   const app = new Hono();
-  app.use("/v1/trade/evm/swap/prepare", (c, next) => requireAgentJwt(c as never, next));
+  app.use("/v1/trade/evm/swap/*", (c, next) => requireAgentJwt(c as never, next));
   app.route("/v1/trade", createEvmSwapRoutes(ctx));
   return { app, adapter, simulationCalls: () => simulationCalls };
 }
@@ -261,6 +269,44 @@ async function postPrepare(
   });
 }
 
+async function getIntent(app: Hono, id: string, agentId = AGENT_ID) {
+  return app.request(`/v1/trade/evm/swap/intents/${id}`, {
+    headers: {
+      Authorization: `Bearer ${await signToken(agentId)}`,
+      "X-Steward-Tenant": TENANT_ID,
+    },
+  });
+}
+
+async function revokeIntent(app: Hono, id: string, agentId = AGENT_ID) {
+  return app.request(`/v1/trade/evm/swap/intents/${id}/revoke`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${await signToken(agentId)}`,
+      "X-Steward-Tenant": TENANT_ID,
+    },
+  });
+}
+
+async function getIntentWithPlatform(app: Hono, id: string, tenantId = TENANT_ID) {
+  return app.request(`/v1/trade/evm/swap/intents/${id}`, {
+    headers: {
+      "X-Steward-Tenant": tenantId,
+      "X-Steward-Platform-Key": PLATFORM_KEY,
+    },
+  });
+}
+
+async function revokeIntentWithPlatform(app: Hono, id: string, tenantId = TENANT_ID) {
+  return app.request(`/v1/trade/evm/swap/intents/${id}/revoke`, {
+    method: "POST",
+    headers: {
+      "X-Steward-Tenant": tenantId,
+      "X-Steward-Platform-Key": PLATFORM_KEY,
+    },
+  });
+}
+
 beforeAll(async () => {
   const { createPGLiteDb, setPGLiteOverride } = await import("@stwd/db/pglite");
   const { db, client } = await createPGLiteDb("memory://");
@@ -269,7 +315,9 @@ beforeAll(async () => {
   });
   pgliteDb = db as ReturnType<typeof getDb>;
 
-  ({ auditEvents, closeDb, getDb, policies, tenants } = await import("@stwd/db"));
+  ({ auditEvents, closeDb, getDb, intents, policies, tenants, tradeSessions } = await import(
+    "@stwd/db"
+  ));
   ({ testCtx } = await import("./_ctx"));
   ({ tradingPlugin } = await import("../index"));
   ({ createEvmSwapRoutes } = await import("../routes/evm-swap"));
@@ -290,10 +338,14 @@ beforeAll(async () => {
   const { vault } = await import("../../../api/src/services/context");
   await getDb()
     .insert(tenants)
-    .values({ id: TENANT_ID, name: "EVM Swap Tenant", apiKeyHash: "hash" })
+    .values([
+      { id: TENANT_ID, name: "EVM Swap Tenant", apiKeyHash: "hash" },
+      { id: OTHER_TENANT_ID, name: "Other EVM Swap Tenant", apiKeyHash: "other-hash" },
+    ])
     .onConflictDoNothing();
   await vault.createAgent(TENANT_ID, AGENT_ID, "EVM Swap Agent");
   await vault.createAgent(TENANT_ID, OTHER_AGENT_ID, "Other EVM Swap Agent");
+  agentWalletAddress = (await vault.getWallet({ agentId: AGENT_ID, chainId: 8453 })).address;
 });
 
 afterAll(async () => {
@@ -304,6 +356,24 @@ afterAll(async () => {
 beforeEach(async () => {
   clearAgentJwksCacheForTests();
   await getDb().delete(auditEvents).where(eq(auditEvents.tenantId, TENANT_ID));
+  await getDb().delete(intents).where(eq(intents.tenantId, TENANT_ID));
+  await getDb().delete(tradeSessions).where(eq(tradeSessions.tenantId, TENANT_ID));
+  await getDb()
+    .insert(tradeSessions)
+    .values({
+      id: SESSION_ID,
+      agentId: AGENT_ID,
+      tenantId: TENANT_ID,
+      venue: "evm",
+      walletId: agentWalletAddress,
+      status: "active",
+      dailySpendUsd: "0",
+      dailyCapUsd: "100",
+      perOrderCapUsd: "100",
+      leverageCap: "1",
+      allowedAssets: ["eip155:8453"],
+      expiresAt: new Date(Date.now() + 60_000),
+    });
   await seedPolicy();
 });
 
@@ -320,13 +390,20 @@ describe("governed EVM swap prepare", () => {
     const res = await postPrepare(app, requestBody(), key);
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
-      data: { intentHash: string; unsignedIntent: { data: string } };
+      data: { intentId: string; intentHash: string; unsignedIntent: { data: string } };
     };
+    expect(body.data.intentId).toMatch(/^evm_/);
     expect(body.data.intentHash).toMatch(/^sha256:/);
     expect(body.data.unsignedIntent.data).toBe(CALLDATA);
     expect(adapter.observedTaker).toMatch(/^0x[a-f0-9]{40}$/i);
     expect(adapter.buildCalls).toBe(1);
     expect(simulationCalls()).toBe(1);
+
+    const stored = await getDb().select().from(intents).where(eq(intents.id, body.data.intentId));
+    expect(stored).toHaveLength(1);
+    expect(stored[0]?.status).toBe("prepared");
+    expect(stored[0]?.idempotencyKey).toBe(key);
+    expect(stored[0]?.semanticRequestHash).toMatch(/^sha256:/);
 
     const replay = await postPrepare(app, requestBody(), key);
     expect(replay.status).toBe(200);
@@ -345,6 +422,28 @@ describe("governed EVM swap prepare", () => {
       "trade.evm.swap.prepare.prepared",
     ]);
     expect(JSON.stringify(rows.map((row) => row.metadata))).not.toContain(CALLDATA.slice(10));
+  });
+
+  it("persists replay and status across handler recreation", async () => {
+    const key = crypto.randomUUID();
+    const first = await buildApp({ simulator: { ok: true } });
+    const created = await postPrepare(first.app, requestBody(), key);
+    expect(created.status).toBe(200);
+    const createdBody = (await created.json()) as { data: { intentId: string } };
+
+    const second = await buildApp({ simulator: { ok: true } });
+    const replay = await postPrepare(second.app, requestBody(), key);
+    expect(replay.status).toBe(200);
+    expect(replay.headers.get("Idempotency-Replayed")).toBe("true");
+    expect((await replay.json()) as unknown).toEqual(createdBody);
+    expect(second.adapter.buildCalls).toBe(0);
+
+    const status = await getIntent(second.app, createdBody.data.intentId);
+    expect(status.status).toBe(200);
+    expect(await status.json()).toMatchObject({
+      ok: true,
+      data: { intentId: createdBody.data.intentId, status: "prepared" },
+    });
   });
 
   it("mounts through the trading plugin on unversioned and v1 prefixes", async () => {
@@ -366,7 +465,7 @@ describe("governed EVM swap prepare", () => {
     expect(adapter.buildCalls).toBe(2);
   });
 
-  it("coalesces concurrent same-key requests and rejects conflicting bodies", async () => {
+  it("handles concurrent same-key requests and rejects conflicting semantics", async () => {
     const { app, adapter, simulationCalls } = await buildApp({ simulator: { ok: true } });
     const key = crypto.randomUUID();
     const [a, b] = await Promise.all([
@@ -380,6 +479,124 @@ describe("governed EVM swap prepare", () => {
 
     const conflict = await postPrepare(app, { ...requestBody(), amount: "1001" }, key);
     expect(conflict.status).toBe(409);
+  });
+
+  it("durably replays non-5xx rejections across handler recreation and conflicts on semantic drift", async () => {
+    const key = crypto.randomUUID();
+    const rejectedAdapter = Object.assign(new FakeSwapAdapter(), {
+      target: "0x00000000000000000000000000000000000000ff",
+    });
+    const first = await buildApp({ adapter: rejectedAdapter, simulator: { ok: true } });
+    const rejected = await postPrepare(first.app, requestBody(), key);
+    expect(rejected.status).toBe(400);
+    const rejectedBody = await rejected.json();
+    expect(rejectedAdapter.buildCalls).toBe(1);
+
+    const second = await buildApp({ simulator: { ok: true } });
+    const replayed = await postPrepare(second.app, requestBody(), key);
+    expect(replayed.status).toBe(400);
+    expect(replayed.headers.get("Idempotency-Replayed")).toBe("true");
+    expect(await replayed.json()).toEqual(rejectedBody);
+    expect(second.adapter.quoteCalls).toBe(0);
+    expect(second.adapter.buildCalls).toBe(0);
+
+    const stored = await getDb().select().from(intents).where(eq(intents.idempotencyKey, key));
+    expect(stored).toHaveLength(1);
+    expect(stored[0]?.status).toBe("rejected");
+    expect(JSON.stringify(stored[0]?.payload)).not.toContain(CALLDATA.slice(10));
+
+    const conflict = await postPrepare(second.app, { ...requestBody(), amount: "1001" }, key);
+    expect(conflict.status).toBe(409);
+    expect(second.adapter.quoteCalls).toBe(0);
+  });
+
+  it("keeps 5xx prepare failures retryable", async () => {
+    const key = crypto.randomUUID();
+    const unavailableAdapter = Object.assign(new FakeSwapAdapter(), { failUnavailable: true });
+    const unavailable = await buildApp({
+      adapter: unavailableAdapter,
+      simulator: { ok: true },
+    });
+    const first = await postPrepare(unavailable.app, requestBody(), key);
+    expect(first.status).toBe(503);
+    expect(unavailableAdapter.quoteCalls).toBe(1);
+
+    const healthy = await buildApp({ simulator: { ok: true } });
+    const retry = await postPrepare(healthy.app, requestBody(), key);
+    expect(retry.status).toBe(200);
+    expect(retry.headers.get("Idempotency-Replayed")).toBe(null);
+    expect(healthy.adapter.quoteCalls).toBe(1);
+  });
+
+  it("revokes and expires prepared intents before execution", async () => {
+    const { app } = await buildApp({ simulator: { ok: true } });
+    const created = await postPrepare(app);
+    const body = (await created.json()) as { data: { intentId: string } };
+    const revoked = await revokeIntent(app, body.data.intentId);
+    expect(revoked.status).toBe(200);
+    expect(await revoked.json()).toMatchObject({
+      data: { intentId: body.data.intentId, status: "revoked" },
+    });
+
+    await getDb()
+      .update(intents)
+      .set({ status: "prepared", expiresAt: new Date(Date.now() - 1000) })
+      .where(eq(intents.id, body.data.intentId));
+    const expired = await getIntent(app, body.data.intentId);
+    expect(expired.status).toBe(200);
+    expect(await expired.json()).toMatchObject({
+      data: { intentId: body.data.intentId, status: "expired" },
+    });
+  });
+
+  it("allows platform recovery status and revoke while denying cross-agent and cross-tenant access", async () => {
+    const { app } = await buildPluginMountedApp({ simulator: { ok: true } });
+    const created = await postPrepare(app);
+    expect(created.status).toBe(200);
+    const body = (await created.json()) as { data: { intentId: string } };
+
+    const otherAgentStatus = await getIntent(app, body.data.intentId, OTHER_AGENT_ID);
+    expect(otherAgentStatus.status).toBe(404);
+
+    const wrongTenantStatus = await getIntentWithPlatform(app, body.data.intentId, OTHER_TENANT_ID);
+    expect(wrongTenantStatus.status).toBe(404);
+
+    const platformStatus = await getIntentWithPlatform(app, body.data.intentId);
+    expect(platformStatus.status).toBe(200);
+    expect(await platformStatus.json()).toMatchObject({
+      ok: true,
+      data: { intentId: body.data.intentId, status: "prepared" },
+    });
+
+    const platformRevoke = await revokeIntentWithPlatform(app, body.data.intentId);
+    expect(platformRevoke.status).toBe(200);
+    expect(await platformRevoke.json()).toMatchObject({
+      ok: true,
+      data: { intentId: body.data.intentId, status: "revoked" },
+    });
+  });
+
+  it("denies revoked session and wallet drift before persistence", async () => {
+    await getDb()
+      .update(tradeSessions)
+      .set({ status: "revoked", revokedAt: new Date(), revokedBy: "test" })
+      .where(eq(tradeSessions.id, SESSION_ID));
+    const revokedSession = await buildApp({ simulator: { ok: true } });
+    expect((await postPrepare(revokedSession.app)).status).toBe(403);
+    expect(revokedSession.adapter.buildCalls).toBe(0);
+
+    await getDb()
+      .update(tradeSessions)
+      .set({
+        status: "active",
+        revokedAt: null,
+        revokedBy: null,
+        walletId: "0x00000000000000000000000000000000000000aa",
+      })
+      .where(eq(tradeSessions.id, SESSION_ID));
+    const walletDrift = await buildApp({ simulator: { ok: true } });
+    expect((await postPrepare(walletDrift.app)).status).toBe(409);
+    expect(walletDrift.adapter.buildCalls).toBe(0);
   });
 
   it("denies cross-agent and caller-supplied transaction fields", async () => {

--- a/packages/plugin-trading/src/index.ts
+++ b/packages/plugin-trading/src/index.ts
@@ -20,8 +20,9 @@
  * keeps the dependency one-directional (no cycle).
  */
 
+import { Buffer } from "node:buffer";
 import type { AppVariables, StewardPlugin } from "@stwd/shared";
-import type { Hono } from "hono";
+import type { Context, Hono, Next } from "hono";
 import type { StewardAppContext } from "./context";
 import { createEvmSwapRoutes } from "./routes/evm-swap";
 import { createOperatorRecoveryRoutes } from "./routes/operator-recovery";
@@ -76,6 +77,21 @@ export const TRADING_WEBHOOK_EVENTS = [
   "trade.builder.approved",
 ] as const;
 
+function bearerLooksLikeExternalAgentJwt(c: Context<{ Variables: AppVariables }>): boolean {
+  const auth = c.req.header("Authorization");
+  if (!auth?.startsWith("Bearer ")) return false;
+  const [, payload] = auth.slice("Bearer ".length).split(".");
+  if (!payload) return false;
+  try {
+    const decoded = JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as {
+      agent_id?: unknown;
+    };
+    return typeof decoded.agent_id === "string" && decoded.agent_id.length > 0;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * The trading plugin. `register(app, ctx)`:
  *   1. installs the trade-specific auth middleware (MOVED verbatim from app.ts):
@@ -98,16 +114,21 @@ export const tradingPlugin: StewardApiPlugin = {
   webhookEvents: TRADING_WEBHOOK_EVENTS,
   register(app, ctx) {
     const { requireAgentJwt, operatorAuth, tenantAuth } = ctx;
+    const evmIntentAuth = (c: Context<{ Variables: AppVariables }>, next: Next) =>
+      bearerLooksLikeExternalAgentJwt(c) ? requireAgentJwt(c, next) : operatorAuth(c, next);
 
     // ── trade-specific auth middleware (verbatim from app.ts ~lines 172-182) ──
     app.use("/trade/hyperliquid/order", (c, next) => requireAgentJwt(c, next));
     app.use("/v1/trade/hyperliquid/order", (c, next) => requireAgentJwt(c, next));
     app.use("/trade/evm/swap/prepare", (c, next) => requireAgentJwt(c, next));
     app.use("/v1/trade/evm/swap/prepare", (c, next) => requireAgentJwt(c, next));
+    app.use("/trade/evm/swap/intents/*", evmIntentAuth);
+    app.use("/v1/trade/evm/swap/intents/*", evmIntentAuth);
     app.use("/trade", (c, next) => tenantAuth(c, next));
     app.use("/trade/*", (c, next) => {
       if (c.req.path.endsWith("/trade/hyperliquid/order")) return next();
       if (c.req.path.endsWith("/trade/evm/swap/prepare")) return next();
+      if (c.req.path.includes("/trade/evm/swap/intents/")) return next();
       if (isOperatorRecoveryPath(c.req.path)) return operatorAuth(c, next);
       return tenantAuth(c, next);
     });
@@ -115,6 +136,7 @@ export const tradingPlugin: StewardApiPlugin = {
     app.use("/v1/trade/*", (c, next) => {
       if (c.req.path.endsWith("/v1/trade/hyperliquid/order")) return next();
       if (c.req.path.endsWith("/v1/trade/evm/swap/prepare")) return next();
+      if (c.req.path.includes("/v1/trade/evm/swap/intents/")) return next();
       if (isOperatorRecoveryPath(c.req.path)) return operatorAuth(c, next);
       return tenantAuth(c, next);
     });

--- a/packages/plugin-trading/src/routes/evm-swap.ts
+++ b/packages/plugin-trading/src/routes/evm-swap.ts
@@ -5,6 +5,7 @@ import {
   AdapterValidationError,
   type SwapQuote,
 } from "@stwd/adapters";
+import { and, eq, intents, sql } from "@stwd/db";
 import {
   aggregationLookupFromMap,
   aggregationQueriesForPolicies,
@@ -13,15 +14,26 @@ import {
 import { getAggregationSnapshot } from "@stwd/redis";
 import type { ApiResponse, AppVariables, PolicyRule, SignRequest } from "@stwd/shared";
 import { toCaip2 } from "@stwd/shared";
+import { TradeSessionManager } from "@stwd/trade-sessions";
 import type { Context } from "hono";
 import { Hono } from "hono";
 import { z } from "zod";
 import type { StewardAppContext } from "../context";
 
 type PreparedSwapResponse = {
+  intentId: string;
   intentHash: string;
+  status: PreparedIntentStatus;
+  expiresAt: string;
+  requestDigest: string;
   quoteId: string;
+  quoteHash: string;
   simulation: { ok: true; gasEstimate?: string };
+  lifecycle: {
+    canExecute: boolean;
+    terminal: boolean;
+    executionStatus: string | null;
+  };
   unsignedIntent: {
     kind: "evm-tx";
     chainId: number;
@@ -34,20 +46,30 @@ type PreparedSwapResponse = {
   };
 };
 
+type PreparedIntentStatus =
+  | "prepared"
+  | "submitting"
+  | "submitted"
+  | "rejected"
+  | "unknown"
+  | "revoked"
+  | "expired";
+
 type StoredResponse = {
   status: 200 | 400 | 403 | 404 | 409 | 500 | 503;
   body: ApiResponse<PreparedSwapResponse> | ApiResponse | { code: string; reason: string };
 };
 
-type IdempotencyEntry = {
-  bodyHash: string;
-  expiresAt: number;
-  promise: Promise<StoredResponse>;
-  response?: StoredResponse;
+type RejectedPreparePayload = {
+  kind: "evm-swap-prepare-rejection";
+  requestDigest: string;
+  replay: StoredResponse;
 };
 
-const IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000;
-const MAX_IDEMPOTENCY_ENTRIES = 1_000;
+type InflightIdempotencyEntry = {
+  requestDigest: string;
+  promise: Promise<StoredResponse>;
+};
 
 const tokenRefSchema = z
   .object({
@@ -60,6 +82,7 @@ const tokenRefSchema = z
 const prepareSwapSchema = z
   .object({
     agentId: z.string().min(1).max(128),
+    sessionId: z.string().min(1).max(128),
     chainId: z.number().int().positive(),
     fromToken: tokenRefSchema,
     toToken: tokenRefSchema,
@@ -98,11 +121,31 @@ function sha256(value: unknown): string {
   return createHash("sha256").update(stableStringify(value)).digest("hex");
 }
 
+function prefixedSha256(value: unknown): string {
+  return `sha256:${sha256(value)}`;
+}
+
+function quoteHash(quote: SwapQuote): string {
+  return prefixedSha256({
+    provider: quote.provider,
+    quoteId: quote.quoteId,
+    chainId: quote.chainId,
+    fromToken: normalizeAddress(quote.fromToken.address),
+    toToken: normalizeAddress(quote.toToken.address),
+    amountIn: quote.amountIn,
+    amountOut: quote.amountOut,
+    minAmountOut: quote.minAmountOut,
+    slippageBps: quote.slippageBps,
+    feeAmount: quote.feeAmount ?? null,
+    expiresAt: quote.expiresAt,
+  });
+}
+
 function canonicalIntentHash(
   intent: SignRequest & { owner: string; category: string; provider: string },
   quote: SwapQuote,
 ): string {
-  return `sha256:${sha256({
+  return prefixedSha256({
     agentId: intent.agentId,
     tenantId: intent.tenantId,
     chainId: intent.chainId,
@@ -120,7 +163,7 @@ function canonicalIntentHash(
       minAmountOut: quote.minAmountOut,
       expiresAt: quote.expiresAt,
     },
-  })}`;
+  });
 }
 
 function json<T>(
@@ -358,35 +401,114 @@ function replay(c: Context<{ Variables: AppVariables }>, response: StoredRespons
   return c.json(response.body, response.status);
 }
 
+function getSessionManager(ctx: StewardAppContext): TradeSessionManager {
+  return new TradeSessionManager({ redis: ctx.getRedisClient() });
+}
+
+function isPreparedStatus(value: unknown): value is PreparedIntentStatus {
+  return (
+    value === "prepared" ||
+    value === "submitting" ||
+    value === "submitted" ||
+    value === "rejected" ||
+    value === "unknown" ||
+    value === "revoked" ||
+    value === "expired"
+  );
+}
+
+function preparedResponseFromRow(row: typeof intents.$inferSelect): PreparedSwapResponse {
+  const payload = row.payload as Record<string, unknown>;
+  const execution = (row.executionResult ?? {}) as Record<string, unknown>;
+  const unsignedIntent = payload.unsignedIntent as PreparedSwapResponse["unsignedIntent"];
+  const simulation = payload.simulation as PreparedSwapResponse["simulation"];
+  const quote = payload.quote as Record<string, unknown>;
+  return {
+    intentId: row.id,
+    intentHash: String(row.intentHash ?? payload.intentHash),
+    status: isPreparedStatus(row.status) ? row.status : "rejected",
+    expiresAt: (row.expiresAt ?? new Date()).toISOString(),
+    requestDigest: String(row.semanticRequestHash ?? payload.requestDigest),
+    quoteId: String(quote.quoteId),
+    quoteHash: String(payload.quoteHash),
+    simulation,
+    lifecycle: {
+      canExecute: row.status === "prepared" && (!row.expiresAt || row.expiresAt > new Date()),
+      terminal:
+        row.status === "submitted" ||
+        row.status === "rejected" ||
+        row.status === "revoked" ||
+        row.status === "expired",
+      executionStatus: typeof execution.status === "string" ? execution.status : null,
+    },
+    unsignedIntent,
+  };
+}
+
+function rejectedPrepareReplayFromRow(row: typeof intents.$inferSelect): StoredResponse | null {
+  const payload = row.payload as Partial<RejectedPreparePayload>;
+  if (payload.kind !== "evm-swap-prepare-rejection") return null;
+  const replayed = payload.replay;
+  if (!replayed || typeof replayed !== "object") return null;
+  const status = replayed.status;
+  if (status !== 400 && status !== 403 && status !== 404 && status !== 409) {
+    return null;
+  }
+  return { status, body: replayed.body };
+}
+
+async function loadPreparedIntent(
+  ctx: StewardAppContext,
+  tenantId: string,
+  agentId: string | null,
+  idOrHash: string,
+) {
+  const conditions = [
+    eq(intents.tenantId, tenantId),
+    eq(intents.intentType, "evm_swap"),
+    sql`(${intents.id} = ${idOrHash} or ${intents.intentHash} = ${idOrHash})`,
+  ];
+  if (agentId) conditions.push(eq(intents.agentId, agentId));
+  const [row] = await ctx.db
+    .select()
+    .from(intents)
+    .where(and(...conditions));
+  if (!row) return null;
+  if (row.status === "prepared" && row.expiresAt && row.expiresAt <= new Date()) {
+    const [expired] = await ctx.db
+      .update(intents)
+      .set({
+        status: "expired",
+        expiredAt: new Date(),
+        expiredBy: "system",
+        updatedAt: new Date(),
+        executionResult: {
+          ...((row.executionResult ?? {}) as Record<string, unknown>),
+          status: "expired",
+          reason: "prepared intent expired before execution",
+        },
+      })
+      .where(and(eq(intents.id, row.id), eq(intents.status, "prepared")))
+      .returning();
+    return expired ?? row;
+  }
+  return row;
+}
+
+function intentAuditActor(c: Context<{ Variables: AppVariables }>) {
+  const scopedAgent = c.get("agentScope");
+  if (scopedAgent) return { actorType: "agent" as const, actorId: scopedAgent };
+  if (c.get("authType") === "platform") {
+    return { actorType: "platform" as const, actorId: "platform" };
+  }
+  const userId = c.get("userId");
+  if (userId) return { actorType: "user" as const, actorId: userId };
+  return { actorType: "api-key" as const, actorId: c.get("tenantId") };
+}
+
 export function createEvmSwapRoutes(ctx: StewardAppContext): Hono<{ Variables: AppVariables }> {
   const routes = new Hono<{ Variables: AppVariables }>();
-  const idempotency = new Map<string, IdempotencyEntry>();
-
-  function remember(
-    tenantId: string,
-    agentId: string,
-    key: string,
-    bodyHash: string,
-    promise: Promise<StoredResponse>,
-  ) {
-    const now = Date.now();
-    for (const [entryKey, entry] of idempotency) {
-      if (entry.expiresAt <= now || idempotency.size >= MAX_IDEMPOTENCY_ENTRIES) {
-        idempotency.delete(entryKey);
-      }
-      if (idempotency.size < MAX_IDEMPOTENCY_ENTRIES) break;
-    }
-    const mapKey = `${tenantId}:${agentId}:${key}`;
-    const entry: IdempotencyEntry = { bodyHash, expiresAt: now + IDEMPOTENCY_TTL_MS, promise };
-    idempotency.set(mapKey, entry);
-    promise.then((response) => {
-      if (response.status >= 500) {
-        idempotency.delete(mapKey);
-        return;
-      }
-      entry.response = response;
-    });
-  }
+  const inflightIdempotency = new Map<string, InflightIdempotencyEntry>();
 
   routes.post("/evm/swap/prepare", async (c) => {
     const idempotencyKey = c.req.header("Idempotency-Key");
@@ -414,14 +536,55 @@ export function createEvmSwapRoutes(ctx: StewardAppContext): Hono<{ Variables: A
     const agent = await ctx.ensureAgentForTenant(tenantId, parsed.data.agentId);
     if (!agent) return json(c, { ok: false, error: "Agent not found" }, 404);
 
-    const bodyHash = sha256(parsed.data);
-    const mapKey = `${tenantId}:${parsed.data.agentId}:${idempotencyKey}`;
-    const existing = idempotency.get(mapKey);
-    if (existing && existing.expiresAt > Date.now()) {
-      if (existing.bodyHash !== bodyHash) {
-        return json(c, { ok: false, error: "Idempotency key reused with a different body" }, 409);
+    const requestDigest = prefixedSha256({
+      agentId: parsed.data.agentId,
+      sessionId: parsed.data.sessionId,
+      chainId: parsed.data.chainId,
+      fromToken: normalizeAddress(parsed.data.fromToken.address),
+      toToken: normalizeAddress(parsed.data.toToken.address),
+      amount: parsed.data.amount,
+      slippageBps: parsed.data.slippageBps ?? null,
+    });
+    const [existingByKey] = await ctx.db
+      .select()
+      .from(intents)
+      .where(
+        and(
+          eq(intents.tenantId, tenantId),
+          eq(intents.agentId, parsed.data.agentId),
+          eq(intents.intentType, "evm_swap"),
+          eq(intents.idempotencyKey, idempotencyKey),
+        ),
+      );
+    if (existingByKey) {
+      if (existingByKey.semanticRequestHash !== requestDigest) {
+        return json(
+          c,
+          { ok: false, error: "Idempotency key reused with different semantics" },
+          409,
+        );
       }
-      return replay(c, existing.response ?? (await existing.promise));
+      const rejectedReplay = rejectedPrepareReplayFromRow(existingByKey);
+      if (rejectedReplay) return replay(c, rejectedReplay);
+      const replayRow =
+        (await loadPreparedIntent(ctx, tenantId, parsed.data.agentId, existingByKey.id)) ??
+        existingByKey;
+      return replay(c, {
+        status: 200,
+        body: { ok: true, data: preparedResponseFromRow(replayRow) },
+      });
+    }
+    const idempotencyScope = `${tenantId}:${parsed.data.agentId}:${idempotencyKey}`;
+    const inflight = inflightIdempotency.get(idempotencyScope);
+    if (inflight) {
+      if (inflight.requestDigest !== requestDigest) {
+        return json(
+          c,
+          { ok: false, error: "Idempotency key reused with different semantics" },
+          409,
+        );
+      }
+      return replay(c, await inflight.promise);
     }
 
     const prepare = (async (): Promise<StoredResponse> => {
@@ -435,11 +598,13 @@ export function createEvmSwapRoutes(ctx: StewardAppContext): Hono<{ Variables: A
         resourceId: parsed.data.agentId,
         metadata: {
           agentId: parsed.data.agentId,
+          sessionId: parsed.data.sessionId,
           chainId: parsed.data.chainId,
           fromToken: parsed.data.fromToken.address,
           toToken: parsed.data.toToken.address,
           amount: parsed.data.amount,
           slippageBps: parsed.data.slippageBps ?? null,
+          requestDigest,
         },
       });
 
@@ -447,6 +612,10 @@ export function createEvmSwapRoutes(ctx: StewardAppContext): Hono<{ Variables: A
         status: StoredResponse["status"],
         reason: string,
       ): Promise<StoredResponse> => {
+        const response: StoredResponse = {
+          status,
+          body: status === 400 ? rejectReason(reason) : { ok: false, error: reason },
+        };
         await ctx.writeAuditEvent({
           tenantId,
           actorType: actor.actorType,
@@ -456,15 +625,87 @@ export function createEvmSwapRoutes(ctx: StewardAppContext): Hono<{ Variables: A
           resourceId: parsed.data.agentId,
           metadata: { reason, agentId: parsed.data.agentId, chainId: parsed.data.chainId },
         });
-        return {
-          status,
-          body: status === 400 ? rejectReason(reason) : { ok: false, error: reason },
-        };
+        if (status >= 500) return response;
+
+        const now = new Date();
+        const [created] = await ctx.db
+          .insert(intents)
+          .values({
+            id: `evm_rej_${crypto.randomUUID()}`,
+            tenantId,
+            agentId: parsed.data.agentId,
+            intentType: "evm_swap",
+            status: "rejected",
+            resourceType: "trade.evm.swap.prepare",
+            resourceId: requestDigest,
+            createdByType: "agent",
+            createdById: actor.actorId,
+            idempotencyKey,
+            semanticRequestHash: requestDigest,
+            authorizationDetails: [
+              {
+                kind: "evm-swap-prepare-rejection",
+                status,
+                sessionId: parsed.data.sessionId,
+                chainId: parsed.data.chainId,
+              },
+            ],
+            payload: {
+              kind: "evm-swap-prepare-rejection",
+              requestDigest,
+              replay: response,
+            } satisfies RejectedPreparePayload,
+            executionResult: { status: "rejected" },
+            rejectedAt: now,
+            rejectedBy: actor.actorId,
+            rejectionReason: reason,
+            createdAt: now,
+            updatedAt: now,
+          })
+          .onConflictDoNothing()
+          .returning();
+        if (created) return response;
+
+        const [existing] = await ctx.db
+          .select()
+          .from(intents)
+          .where(
+            and(
+              eq(intents.tenantId, tenantId),
+              eq(intents.agentId, parsed.data.agentId),
+              eq(intents.intentType, "evm_swap"),
+              eq(intents.idempotencyKey, idempotencyKey),
+            ),
+          );
+        if (existing?.semanticRequestHash && existing.semanticRequestHash !== requestDigest) {
+          return {
+            status: 409,
+            body: { ok: false, error: "Idempotency key reused with different semantics" },
+          };
+        }
+        return rejectedPrepareReplayFromRow(existing ?? created) ?? response;
       };
 
       if (!ctx.evmSimulator) return reject(503, "EVM simulator is not configured");
       const owner = await resolveEvmWallet(ctx, agent, parsed.data.chainId);
       if (!owner || !isEvmAddress(owner)) return reject(403, "Agent EVM wallet not found");
+      const sessionManager = getSessionManager(ctx);
+      const session = await sessionManager.getSession({ tenantId, id: parsed.data.sessionId });
+      if (
+        !session ||
+        session.agentId !== parsed.data.agentId ||
+        session.venue !== "evm" ||
+        session.status !== "active" ||
+        session.expiresAt <= new Date()
+      ) {
+        return reject(403, "Active EVM trade session required");
+      }
+      if (!session.allowedAssets.includes(toCaip2(parsed.data.chainId) ?? "")) {
+        return reject(403, "EVM trade session does not allow this chain");
+      }
+      if (normalizeAddress(session.walletId) !== normalizeAddress(owner)) {
+        return reject(409, "EVM trade session wallet no longer matches the agent wallet");
+      }
 
       const swap = ctx.adapterRegistry.swap();
       if (!swap.enabled) return reject(503, "Swap adapter is disabled");
@@ -560,6 +801,7 @@ export function createEvmSwapRoutes(ctx: StewardAppContext): Hono<{ Variables: A
         },
         quote,
       );
+      const qHash = quoteHash(quote);
       const simulation = await ctx.evmSimulator.simulate({
         chainId: intent.chainId,
         from: owner,
@@ -573,6 +815,141 @@ export function createEvmSwapRoutes(ctx: StewardAppContext): Hono<{ Variables: A
       }
 
       const sanitized = sanitizeIntent(intent);
+      const createdAt = new Date();
+      const expiresAt = new Date(Math.min(quote.expiresAt, session.expiresAt.getTime()));
+      const preparedRow = await sessionManager.withActiveSubmissionFence(
+        { tenantId, id: parsed.data.sessionId },
+        async (freshSession, db) => {
+          if (
+            freshSession.agentId !== parsed.data.agentId ||
+            freshSession.venue !== "evm" ||
+            normalizeAddress(freshSession.walletId) !== normalizeAddress(owner) ||
+            !freshSession.allowedAssets.includes(toCaip2(parsed.data.chainId) ?? "")
+          ) {
+            return null;
+          }
+          const [row] = await db
+            .insert(intents)
+            .values({
+              id: `evm_${crypto.randomUUID()}`,
+              tenantId,
+              agentId: parsed.data.agentId,
+              intentType: "evm_swap",
+              status: "prepared",
+              resourceType: "trade.evm.swap",
+              resourceId: intentHash,
+              createdByType: "agent",
+              createdById: actor.actorId,
+              idempotencyKey,
+              semanticRequestHash: requestDigest,
+              intentHash,
+              authorizationDetails: [
+                {
+                  kind: "evm-prepared-swap",
+                  sessionId: parsed.data.sessionId,
+                  wallet: normalizeAddress(owner),
+                  provider: intent.provider,
+                  chainId: intent.chainId,
+                  target: sanitized.target,
+                  selector: sanitized.selector,
+                  value: sanitized.value,
+                  minAmountOut: quote.minAmountOut,
+                  quoteHash: qHash,
+                  policyApproved: true,
+                  simulationOk: true,
+                },
+              ],
+              payload: {
+                requestDigest,
+                quoteHash: qHash,
+                intentHash,
+                sessionId: parsed.data.sessionId,
+                wallet: normalizeAddress(owner),
+                provider: intent.provider,
+                chainId: intent.chainId,
+                target: sanitized.target,
+                selector: sanitized.selector,
+                value: sanitized.value,
+                minAmountOut: quote.minAmountOut,
+                semanticRequest: {
+                  chainId: parsed.data.chainId,
+                  fromToken: {
+                    ...parsed.data.fromToken,
+                    address: normalizeAddress(parsed.data.fromToken.address),
+                  },
+                  toToken: {
+                    ...parsed.data.toToken,
+                    address: normalizeAddress(parsed.data.toToken.address),
+                  },
+                  amount: parsed.data.amount,
+                  slippageBps: parsed.data.slippageBps ?? null,
+                },
+                quote: {
+                  provider: quote.provider,
+                  quoteId: quote.quoteId,
+                  amountIn: quote.amountIn,
+                  amountOut: quote.amountOut,
+                  minAmountOut: quote.minAmountOut,
+                  expiresAt: new Date(quote.expiresAt).toISOString(),
+                },
+                simulation: { ok: true, gasEstimate: simulation.gasEstimate },
+                policy: {
+                  approved: true,
+                  resultCount: policyEvaluation.results.length,
+                  failedCount: policyEvaluation.results.filter((result) => !result.passed).length,
+                },
+                unsignedIntent: {
+                  kind: "evm-tx",
+                  chainId: intent.chainId,
+                  to: normalizeAddress(intent.to),
+                  value: intent.value,
+                  data,
+                  owner: normalizeAddress(owner),
+                  category: "swap",
+                  provider: intent.provider,
+                },
+                lifecycle: {
+                  allowedTransitions: {
+                    prepared: ["submitting", "revoked", "expired"],
+                    submitting: ["submitted", "rejected", "unknown"],
+                    unknown: ["submitted", "rejected"],
+                  },
+                  retry: "never blind retry unknown; reconcile by intent id or transaction hash",
+                },
+              },
+              executionResult: { status: "prepared", transactionHash: null },
+              expiresAt,
+              createdAt,
+              updatedAt: createdAt,
+            })
+            .onConflictDoNothing()
+            .returning();
+          if (row) return row;
+          const [existing] = await db
+            .select()
+            .from(intents)
+            .where(
+              and(
+                eq(intents.tenantId, tenantId),
+                eq(intents.agentId, parsed.data.agentId),
+                eq(intents.intentType, "evm_swap"),
+                eq(intents.idempotencyKey, idempotencyKey),
+              ),
+            );
+          return existing ?? null;
+        },
+      );
+      if (!preparedRow) {
+        return reject(409, "Trade session was revoked before intent persistence");
+      }
+      if (preparedRow.semanticRequestHash !== requestDigest) {
+        return {
+          status: 409,
+          body: { ok: false, error: "Idempotency key reused with different semantics" },
+        };
+      }
+      const rejectedReplay = rejectedPrepareReplayFromRow(preparedRow);
+      if (rejectedReplay) return rejectedReplay;
       await ctx.writeAuditEvent({
         tenantId,
         actorType: actor.actorType,
@@ -583,8 +960,12 @@ export function createEvmSwapRoutes(ctx: StewardAppContext): Hono<{ Variables: A
         metadata: {
           ...sanitized,
           agentId: parsed.data.agentId,
+          sessionId: parsed.data.sessionId,
+          intentId: preparedRow.id,
           intentHash,
           quoteId: quote.quoteId,
+          quoteHash: qHash,
+          requestDigest,
           gasEstimate: simulation.gasEstimate ?? null,
         },
         requestId: idempotencyKey,
@@ -594,21 +975,7 @@ export function createEvmSwapRoutes(ctx: StewardAppContext): Hono<{ Variables: A
         status: 200,
         body: {
           ok: true,
-          data: {
-            intentHash,
-            quoteId: quote.quoteId,
-            simulation: { ok: true, gasEstimate: simulation.gasEstimate },
-            unsignedIntent: {
-              kind: "evm-tx",
-              chainId: intent.chainId,
-              to: normalizeAddress(intent.to),
-              value: intent.value,
-              data,
-              owner: normalizeAddress(owner),
-              category: "swap",
-              provider: intent.provider,
-            },
-          },
+          data: preparedResponseFromRow(preparedRow),
         },
       };
     })().catch(async (error): Promise<StoredResponse> => {
@@ -637,9 +1004,84 @@ export function createEvmSwapRoutes(ctx: StewardAppContext): Hono<{ Variables: A
       return { status: 500, body: { ok: false, error: "Internal server error" } };
     });
 
-    remember(tenantId, parsed.data.agentId, idempotencyKey, bodyHash, prepare);
-    const response = await prepare;
+    inflightIdempotency.set(idempotencyScope, { requestDigest, promise: prepare });
+    const response = await prepare.finally(() => {
+      inflightIdempotency.delete(idempotencyScope);
+    });
     return c.json(response.body, response.status);
+  });
+
+  routes.get("/evm/swap/intents/:id", async (c) => {
+    const tenantId = c.get("tenantId");
+    const scopedAgent = c.get("agentScope");
+    const row = await loadPreparedIntent(ctx, tenantId, scopedAgent ?? null, c.req.param("id"));
+    if (!row) return json(c, { ok: false, error: "Prepared intent not found" }, 404);
+    return c.json({ ok: true, data: preparedResponseFromRow(row) }, 200);
+  });
+
+  routes.post("/evm/swap/intents/:id/revoke", async (c) => {
+    const tenantId = c.get("tenantId");
+    const scopedAgent = c.get("agentScope");
+    const existing = await loadPreparedIntent(
+      ctx,
+      tenantId,
+      scopedAgent ?? null,
+      c.req.param("id"),
+    );
+    if (!existing) return json(c, { ok: false, error: "Prepared intent not found" }, 404);
+    if (existing.status === "revoked" || existing.status === "expired") {
+      return c.json({ ok: true, data: preparedResponseFromRow(existing) }, 200);
+    }
+    if (existing.status !== "prepared") {
+      return json(
+        c,
+        { ok: false, error: `Cannot revoke prepared intent in ${existing.status} status` },
+        409,
+      );
+    }
+    const now = new Date();
+    const actor = intentAuditActor(c);
+    const [revoked] = await ctx.db
+      .update(intents)
+      .set({
+        status: "revoked",
+        canceledAt: now,
+        canceledBy: actor.actorId,
+        cancellationReason: scopedAgent ? "revoked by agent" : "revoked by recovery auth",
+        updatedAt: now,
+        executionResult: {
+          ...((existing.executionResult ?? {}) as Record<string, unknown>),
+          status: "revoked",
+          reason: "revoked before execution",
+        },
+      })
+      .where(and(eq(intents.id, existing.id), eq(intents.status, "prepared")))
+      .returning();
+    if (!revoked) {
+      const reloaded = await loadPreparedIntent(ctx, tenantId, scopedAgent ?? null, existing.id);
+      return json(
+        c,
+        {
+          ok: false,
+          error: `Cannot revoke prepared intent in ${reloaded?.status ?? "unknown"} status`,
+        },
+        409,
+      );
+    }
+    await ctx.writeAuditEvent({
+      tenantId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      action: "trade.evm.swap.intent.revoked",
+      resourceType: "trade.evm.swap",
+      resourceId: revoked.id,
+      metadata: {
+        intentId: revoked.id,
+        intentHash: revoked.intentHash,
+        status: revoked.status,
+      },
+    });
+    return c.json({ ok: true, data: preparedResponseFromRow(revoked) }, 200);
   });
 
   return routes;

--- a/packages/plugin-trading/src/routes/trade.ts
+++ b/packages/plugin-trading/src/routes/trade.ts
@@ -53,11 +53,12 @@ import type { StewardAppContext } from "../context";
 const sessionPredictionMarketAssetSchema = z
   .string()
   .regex(/^pm:(cond:0x[0-9a-fA-F]{1,64}|[0-9]{1,128})$/);
+const sessionEvmChainAssetSchema = z.string().regex(/^eip155:[1-9][0-9]{0,15}$/);
 
 const createSessionSchema = z
   .object({
     agentId: z.string().min(1).optional(),
-    venue: z.enum(["hyperliquid", "polymarket"]).default("hyperliquid"),
+    venue: z.enum(["hyperliquid", "polymarket", "evm"]).default("hyperliquid"),
     walletAddress: z.string().min(1).optional(),
     dailyCap: z.number().positive().max(50_000).default(300),
     perOrderCap: z.number().positive().max(10_000).default(100),
@@ -68,7 +69,13 @@ const createSessionSchema = z
     // venue-appropriate subset is validated in the handler. Optional so the
     // per-venue default below applies.
     allowedAssets: z
-      .array(z.union([hyperliquidAssetSchema, sessionPredictionMarketAssetSchema]))
+      .array(
+        z.union([
+          hyperliquidAssetSchema,
+          sessionPredictionMarketAssetSchema,
+          sessionEvmChainAssetSchema,
+        ]),
+      )
       .min(1)
       .optional(),
     ttlSeconds: z.number().int().positive().max(86_400).default(3_600),
@@ -468,6 +475,20 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
     }
   }
 
+  async function resolveEvmSessionWallet(
+    agentId: string,
+    agent: { walletAddress?: string; walletAddresses?: { evm?: string } },
+    allowedAssets: readonly string[],
+  ): Promise<string | null> {
+    const chainAsset = allowedAssets.find((asset) => asset.startsWith("eip155:"));
+    const chainId = chainAsset ? Number(chainAsset.slice("eip155:".length)) : undefined;
+    try {
+      return (await vault.getWallet({ agentId, chainId })).address;
+    } catch {
+      return agent.walletAddresses?.evm ?? agent.walletAddress ?? null;
+    }
+  }
+
   tradeRoutes.get("/token-status", async (c) => {
     const agentId = c.req.query("agentId")?.trim();
     if (!agentId) {
@@ -534,6 +555,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
     }
     const { venue, dailyCap, perOrderCap, leverageCap, allowedAssets, ttlSeconds } = parsed.data;
     const isPolymarket = venue === "polymarket";
+    const isEvm = venue === "evm";
 
     if (!canAccessAgent(c, agentId)) {
       return c.json<ApiResponse>(
@@ -563,6 +585,23 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
           400,
         );
       }
+    } else if (isEvm) {
+      if (allowedAssets.length === 0) {
+        return c.json<ApiResponse>(
+          { ok: false, error: "evm sessions require an explicit allowedAssets (eip155:<chainId>)" },
+          400,
+        );
+      }
+      const nonEvmAsset = allowedAssets.find((a) => !a.startsWith("eip155:"));
+      if (nonEvmAsset) {
+        return c.json<ApiResponse>(
+          {
+            ok: false,
+            error: `evm session asset must be an eip155:<chainId> identifier, got ${nonEvmAsset}`,
+          },
+          400,
+        );
+      }
     } else {
       const pmAsset = allowedAssets.find((a) => a.startsWith("pm:"));
       if (pmAsset) {
@@ -570,6 +609,16 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
           {
             ok: false,
             error: `hyperliquid session cannot allowlist a prediction market ${pmAsset}`,
+          },
+          400,
+        );
+      }
+      const evmAsset = allowedAssets.find((a) => a.startsWith("eip155:"));
+      if (evmAsset) {
+        return c.json<ApiResponse>(
+          {
+            ok: false,
+            error: `hyperliquid session cannot allowlist an EVM chain ${evmAsset}`,
           },
           400,
         );
@@ -614,9 +663,10 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
       const policyLeverageCap = Number(agentPolicy.leverageCap);
       // Builder-perp gating is Hyperliquid-only (isBuilderPerpSymbol matches HL
       // namespaced perps, never pm: assets).
-      const requestedBuilderAsset = isPolymarket
-        ? undefined
-        : allowedAssets.find((asset) => isBuilderPerpSymbol(asset));
+      const requestedBuilderAsset =
+        isPolymarket || isEvm
+          ? undefined
+          : allowedAssets.find((asset) => isBuilderPerpSymbol(asset));
       if (requestedBuilderAsset && !agentPolicy.allowBuilderPerps) {
         return c.json(
           policyViolation(
@@ -689,12 +739,15 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
 
     const venueWallet = isPolymarket
       ? await resolvePolymarketWallet(agentId)
-      : await resolveHyperliquidWallet(agentId, agent);
+      : isEvm
+        ? await resolveEvmSessionWallet(agentId, agent, allowedAssets)
+        : await resolveHyperliquidWallet(agentId, agent);
     // Polymarket order execution resolves creds strictly via the venue-scoped
     // wallet (vault.getWallet({venue:"polymarket"})). Allowing a caller-supplied
     // walletAddress fallback here would mint a session that can never execute
     // (order route would 409 wallet-not-found). Fail closed for polymarket.
-    const walletAddress = isPolymarket ? venueWallet : (venueWallet ?? parsed.data.walletAddress);
+    const walletAddress =
+      isPolymarket || isEvm ? venueWallet : (venueWallet ?? parsed.data.walletAddress);
     if (!walletAddress) {
       return c.json<ApiResponse>(
         {

--- a/packages/trade-sessions/src/index.ts
+++ b/packages/trade-sessions/src/index.ts
@@ -30,9 +30,11 @@ const namespacedAssetSchema = z.string().regex(/^[a-z0-9]+:[A-Z0-9]+$/);
 const predictionMarketAssetSchema = z
   .string()
   .regex(/^pm:(cond:0x[0-9a-fA-F]{1,64}|[0-9]{1,128})$/);
+const evmChainAssetSchema = z.string().regex(/^eip155:[1-9][0-9]{0,15}$/);
 export const allowedAssetSchema = z.union([
   coreAllowedAssetSchema,
   predictionMarketAssetSchema,
+  evmChainAssetSchema,
   namespacedAssetSchema,
 ]);
 export type AllowedAsset = z.infer<typeof allowedAssetSchema>;
@@ -206,6 +208,11 @@ export interface ListForAgentInput {
   tenantId: string;
   includeExpired?: boolean;
 }
+
+type TradeSessionDb = Pick<
+  ReturnType<typeof getDb>,
+  "delete" | "execute" | "insert" | "select" | "update"
+>;
 
 const DEFAULT_TTL_SECONDS = 900;
 const MAX_TTL_SECONDS = 24 * 60 * 60;
@@ -471,7 +478,7 @@ export class TradeSessionManager {
 
   async withActiveSubmissionFence<T>(
     input: SessionFenceInput,
-    callback: (session: TradeSession) => Promise<T>,
+    callback: (session: TradeSession, db: TradeSessionDb) => Promise<T>,
   ): Promise<T | null> {
     return getDb().transaction(async (tx) => {
       await tx.execute(
@@ -489,7 +496,7 @@ export class TradeSessionManager {
           ),
         );
       if (!row) return null;
-      return callback(rowToSession(row));
+      return callback(rowToSession(row), tx);
     });
   }
 


### PR DESCRIPTION
## Summary

Stacked on #168/#165. Adds the durable prepared-intent ledger required before governed EVM signing and broadcast can exist safely.

- reuses and extends Steward's existing `intents` infrastructure
- persists authoritative tenant, agent, session, wallet, provider, chain, semantic digest, quote/intent hashes, target, selector, value, minimum output, policy/simulation evidence, timestamps, expiry, and lifecycle state
- durable same-key replay across handler recreation
- same-key/different-semantics conflict before adapter/simulator work
- durable sanitized 4xx rejection replay; 5xx failures remain retryable
- governed status and revoke endpoints under `/trade` and `/v1/trade`
- strict agent JWT plus tenant/platform recovery access with tenant/agent isolation
- session advisory fencing and wallet/session revalidation before persistence

## Lifecycle

The state model supports:

- `prepared -> submitting -> submitted | rejected | unknown`
- `prepared -> revoked | expired`
- `unknown -> submitted | rejected` by reconciliation

This PR intentionally does not expose execute. It establishes the durable claim/revocation/expiry contract the later signer must honor.

## Safety boundary

- unsigned prepare/persist/status/revoke only
- no signing or nonce reservation
- no broadcast or live RPC/0x
- no caller-supplied target/calldata/transaction
- no funds moved
- zero vault-signing calls asserted

## Verification

Independent rerun:

- EVM prepared-intent suite: 20 passed, 103 assertions
- plugin-trading typecheck passed
- trade-sessions typecheck passed
- DB TypeScript check passed
- touched-file Biome and diff checks passed
- initial Codex finding on durable rejection replay fixed with regression tests
- final Codex review clean

## Stack

Base: #168 / `feat/zeroex-swap-adapter`

— [sol-orch]
