### PR TITLE
feat(trading): execute governed EVM swaps

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -226,6 +226,7 @@
       "name": "@stwd/plugin-trading",
       "version": "0.1.0",
       "dependencies": {
+        "@stwd/adapters": "workspace:*",
         "@stwd/db": "workspace:*",
         "@stwd/policy-engine": "workspace:*",
         "@stwd/redis": "workspace:*",
@@ -236,6 +237,7 @@
         "@stwd/venue-polymarket": "workspace:*",
         "drizzle-orm": "^0.44.5",
         "hono": "^4.12.18",
+        "viem": "^2.30.0",
         "zod": "^4.3.6",
       },
       "devDependencies": {

--- a/packages/api/src/__tests__/transaction-stats-chain-scope.test.ts
+++ b/packages/api/src/__tests__/transaction-stats-chain-scope.test.ts
@@ -49,13 +49,18 @@ const UNRELATED_CHAIN = 137;
 const ETH_SPEND = "3000000000000000000"; // 3e18 wei
 const SOL_SPEND = "5000000000"; // 5e9 lamports
 
-async function seedTx(idSuffix: string, chainId: number, value: string) {
+async function seedTx(
+  idSuffix: string,
+  chainId: number,
+  value: string,
+  status: "signed" | "failed" = "signed",
+) {
   await getDb()
     .insert(transactions)
     .values({
       id: `${AGENT_ID}-${idSuffix}`,
       agentId: AGENT_ID,
-      status: "signed",
+      status,
       toAddress: RECIPIENT,
       value,
       chainId,
@@ -79,6 +84,7 @@ describe("getTransactionStats chain scoping (issue #110)", () => {
     // One committed spend on each chain, both inside the rolling day/week window.
     await seedTx("eth", ETH_MAINNET, ETH_SPEND);
     await seedTx("sol", SOLANA, SOL_SPEND);
+    await seedTx("failed-rejected-send", ETH_MAINNET, "999999999999999999999999", "failed");
   });
 
   afterAll(async () => {

--- a/packages/api/src/plugin.ts
+++ b/packages/api/src/plugin.ts
@@ -73,7 +73,12 @@ import {
   tenantAuth,
   vault,
 } from "./services/context";
-import { createEnvEvmSimulator, type EvmSimulator } from "./services/evm-simulator";
+import {
+  createEnvEvmRpcClient,
+  createEnvEvmSimulator,
+  type EvmRpcClient,
+  type EvmSimulator,
+} from "./services/evm-simulator";
 import { CONFIGURED_WEBHOOK_EVENT_TYPES } from "./services/webhook-events";
 
 /** the steward app a plugin mounts onto: a hono app with the shared variables. */
@@ -176,6 +181,7 @@ export interface StewardAppContext {
    */
   adapterRegistry: AdapterRegistry;
   evmSimulator: EvmSimulator | null;
+  evmRpc: EvmRpcClient | null;
 }
 
 /**
@@ -210,6 +216,7 @@ export function buildPluginContext(): StewardAppContext {
     tenantAuth,
     adapterRegistry,
     evmSimulator: createEnvEvmSimulator(),
+    evmRpc: createEnvEvmRpcClient(),
   };
 }
 

--- a/packages/api/src/services/evm-simulator.ts
+++ b/packages/api/src/services/evm-simulator.ts
@@ -17,7 +17,22 @@ export interface EvmSimulator {
   simulate(request: EvmSimulationRequest): Promise<EvmSimulationResult>;
 }
 
-function parseRpcUrls(raw: string | undefined): Record<string, string> {
+export interface EvmTransactionReceipt {
+  transactionHash?: string;
+  status?: string;
+  blockHash?: string | null;
+  blockNumber?: string | null;
+}
+
+export interface EvmRpcClient {
+  getPendingNonce(chainId: number, address: string): Promise<number>;
+  getGasPrice(chainId: number): Promise<string>;
+  sendRawTransaction(chainId: number, rawTransaction: string): Promise<string>;
+  getTransactionReceipt(chainId: number, txHash: string): Promise<EvmTransactionReceipt | null>;
+  getTransactionByHash(chainId: number, txHash: string): Promise<Record<string, unknown> | null>;
+}
+
+export function parseRpcUrls(raw: string | undefined): Record<string, string> {
   if (!raw?.trim()) return {};
   try {
     const parsed = JSON.parse(raw) as unknown;
@@ -34,10 +49,23 @@ function parseRpcUrls(raw: string | undefined): Record<string, string> {
   }
 }
 
-function rpcUrlForChain(chainId: number, env: Record<string, string | undefined>): string | null {
+export function rpcUrlForChain(
+  chainId: number,
+  env: Record<string, string | undefined>,
+): string | null {
   const keyed = env[`STEWARD_EVM_RPC_URL_${chainId}`]?.trim();
   if (keyed && /^https?:\/\//.test(keyed)) return keyed;
   return parseRpcUrls(env.STEWARD_EVM_RPC_URLS_JSON)[String(chainId)] ?? null;
+}
+
+export class EvmJsonRpcError extends Error {
+  constructor(
+    message: string,
+    readonly code?: number,
+  ) {
+    super(message);
+    this.name = "EvmJsonRpcError";
+  }
 }
 
 async function rpcCall(url: string, method: string, params: unknown[]): Promise<unknown> {
@@ -49,7 +77,7 @@ async function rpcCall(url: string, method: string, params: unknown[]): Promise<
   });
   if (!response.ok) throw new Error(`rpc-http-${response.status}`);
   const body = (await response.json()) as { result?: unknown; error?: { message?: string } };
-  if (body.error) throw new Error(body.error.message ?? "rpc-error");
+  if (body.error) throw new EvmJsonRpcError(body.error.message ?? "rpc-error");
   return body.result;
 }
 
@@ -84,9 +112,71 @@ export class JsonRpcEvmSimulator implements EvmSimulator {
   }
 }
 
+export class JsonRpcEvmClient implements EvmRpcClient {
+  constructor(private readonly env: Record<string, string | undefined> = process.env) {}
+
+  private url(chainId: number): string {
+    const url = rpcUrlForChain(chainId, this.env);
+    if (!url) throw new Error(`evm rpc not configured for chain ${chainId}`);
+    return url;
+  }
+
+  async getPendingNonce(chainId: number, address: string): Promise<number> {
+    const result = await rpcCall(this.url(chainId), "eth_getTransactionCount", [
+      address,
+      "pending",
+    ]);
+    if (typeof result !== "string" || !/^0x[0-9a-fA-F]+$/.test(result)) {
+      throw new Error("RPC returned an invalid pending nonce");
+    }
+    return Number(BigInt(result));
+  }
+
+  async getGasPrice(chainId: number): Promise<string> {
+    const result = await rpcCall(this.url(chainId), "eth_gasPrice", []);
+    if (typeof result !== "string" || !/^0x[0-9a-fA-F]+$/.test(result)) {
+      throw new Error("RPC returned an invalid gas price");
+    }
+    return BigInt(result).toString();
+  }
+
+  async sendRawTransaction(chainId: number, rawTransaction: string): Promise<string> {
+    const result = await rpcCall(this.url(chainId), "eth_sendRawTransaction", [rawTransaction]);
+    if (typeof result !== "string" || !/^0x[0-9a-fA-F]{64}$/.test(result)) {
+      throw new Error("RPC returned an invalid transaction hash");
+    }
+    return result.toLowerCase();
+  }
+
+  async getTransactionReceipt(
+    chainId: number,
+    txHash: string,
+  ): Promise<EvmTransactionReceipt | null> {
+    const result = await rpcCall(this.url(chainId), "eth_getTransactionReceipt", [txHash]);
+    if (result === null) return null;
+    return result && typeof result === "object" ? (result as EvmTransactionReceipt) : null;
+  }
+
+  async getTransactionByHash(
+    chainId: number,
+    txHash: string,
+  ): Promise<Record<string, unknown> | null> {
+    const result = await rpcCall(this.url(chainId), "eth_getTransactionByHash", [txHash]);
+    if (result === null) return null;
+    return result && typeof result === "object" ? (result as Record<string, unknown>) : null;
+  }
+}
+
 export function createEnvEvmSimulator(): EvmSimulator | null {
   const hasJson =
     Object.keys(parseRpcUrls(process.env.STEWARD_EVM_RPC_URLS_JSON)).length > 0 ||
     Object.keys(process.env).some((key) => /^STEWARD_EVM_RPC_URL_\d+$/.test(key));
   return hasJson ? new JsonRpcEvmSimulator() : null;
+}
+
+export function createEnvEvmRpcClient(): EvmRpcClient | null {
+  const hasJson =
+    Object.keys(parseRpcUrls(process.env.STEWARD_EVM_RPC_URLS_JSON)).length > 0 ||
+    Object.keys(process.env).some((key) => /^STEWARD_EVM_RPC_URL_\d+$/.test(key));
+  return hasJson ? new JsonRpcEvmClient() : null;
 }

--- a/packages/plugin-trading/package.json
+++ b/packages/plugin-trading/package.json
@@ -26,6 +26,7 @@
     "@stwd/venue-polymarket": "workspace:*",
     "drizzle-orm": "^0.44.5",
     "hono": "^4.12.18",
+    "viem": "^2.30.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/packages/plugin-trading/src/__tests__/evm-swap-prepare.test.ts
+++ b/packages/plugin-trading/src/__tests__/evm-swap-prepare.test.ts
@@ -43,6 +43,8 @@ let intents: typeof import("@stwd/db")["intents"];
 let policies: typeof import("@stwd/db")["policies"];
 let tenants: typeof import("@stwd/db")["tenants"];
 let tradeSessions: typeof import("@stwd/db")["tradeSessions"];
+let transactions: typeof import("@stwd/db")["transactions"];
+let vaultSigningFreezes: typeof import("@stwd/db")["vaultSigningFreezes"];
 let closeDb: typeof import("@stwd/db")["closeDb"];
 let getDb: typeof import("@stwd/db")["getDb"];
 let pgliteDb: ReturnType<typeof getDb>;
@@ -115,6 +117,40 @@ class FakeSwapAdapter implements SwapAdapter {
         slippageBps: quote.slippageBps,
       },
     };
+  }
+}
+
+class FakeEvmRpc {
+  pendingNonce = 0;
+  gasPrice = "1000000000";
+  sendCalls: string[] = [];
+  receipt: Record<string, unknown> | null = null;
+  transaction: Record<string, unknown> | null = null;
+  failSend: Error | null = null;
+  onBeforeSend?: () => Promise<void>;
+
+  async getPendingNonce() {
+    return this.pendingNonce;
+  }
+
+  async getGasPrice() {
+    return this.gasPrice;
+  }
+
+  async sendRawTransaction(_chainId: number, rawTransaction: string) {
+    this.sendCalls.push(rawTransaction);
+    await this.onBeforeSend?.();
+    if (this.failSend) throw this.failSend;
+    const { keccak256 } = await import("viem");
+    return keccak256(rawTransaction as `0x${string}`).toLowerCase();
+  }
+
+  async getTransactionReceipt() {
+    return this.receipt;
+  }
+
+  async getTransactionByHash() {
+    return this.transaction;
   }
 }
 
@@ -199,9 +235,9 @@ function requestBody(agentId = AGENT_ID) {
     agentId,
     sessionId: SESSION_ID,
     chainId: 8453,
-    fromToken: { address: FROM_TOKEN, symbol: "A", decimals: 18 },
+    fromToken: { address: FROM_TOKEN, symbol: "A", decimals: 0 },
     toToken: { address: TO_TOKEN, symbol: "B", decimals: 18 },
-    amount: "1000",
+    amount: "10",
     slippageBps: 50,
   };
 }
@@ -209,13 +245,23 @@ function requestBody(agentId = AGENT_ID) {
 async function buildApp(options?: {
   adapter?: FakeSwapAdapter;
   simulator?: { ok: boolean; revertReason?: string };
+  evmRpc?: FakeEvmRpc | null;
+  tokenUsdPrice?: number | null;
   auditLog?: unknown[];
+  auditFailureActions?: string[];
 }) {
   const adapter = options?.adapter ?? new FakeSwapAdapter();
   let simulationCalls = 0;
+  const baseCtx = testCtx();
   const ctx = {
-    ...testCtx(),
+    ...baseCtx,
     adapterRegistry: makeRegistry(adapter),
+    priceOracle: {
+      getNativeUsdPrice: async () => options?.tokenUsdPrice ?? 1,
+      getTokenUsdPrice: async () => options?.tokenUsdPrice ?? 1,
+      weiToUsd: async (value: string) => Number(value) * (options?.tokenUsdPrice ?? 1),
+      usdToWei: async (value: number) => String(value),
+    },
     evmSimulator: options?.simulator
       ? {
           simulate: async (request: unknown) => {
@@ -227,6 +273,13 @@ async function buildApp(options?: {
           },
         }
       : null,
+    evmRpc: options?.evmRpc ?? null,
+    writeAuditEvent: async (event: Parameters<typeof baseCtx.writeAuditEvent>[0]) => {
+      if (options?.auditFailureActions?.includes(event.action)) {
+        throw new Error(`audit failed for ${event.action}`);
+      }
+      return baseCtx.writeAuditEvent(event);
+    },
   };
   const app = new Hono();
   app.use("/v1/trade/evm/swap/*", (c, next) => requireAgentJwt(c as never, next));
@@ -237,14 +290,22 @@ async function buildApp(options?: {
 async function buildPluginMountedApp(options?: {
   adapter?: FakeSwapAdapter;
   simulator?: { ok: boolean; revertReason?: string };
+  evmRpc?: FakeEvmRpc | null;
 }) {
   const adapter = options?.adapter ?? new FakeSwapAdapter();
   const ctx = {
     ...testCtx(),
     adapterRegistry: makeRegistry(adapter),
+    priceOracle: {
+      getNativeUsdPrice: async () => 1,
+      getTokenUsdPrice: async () => 1,
+      weiToUsd: async (value: string) => Number(value),
+      usdToWei: async (value: number) => String(value),
+    },
     evmSimulator: options?.simulator
       ? { simulate: async () => ({ ok: true as const, gasEstimate: "0x5208" }) }
       : null,
+    evmRpc: options?.evmRpc ?? null,
   };
   const app = new Hono();
   tradingPlugin.register(app as never, ctx);
@@ -288,6 +349,39 @@ async function revokeIntent(app: Hono, id: string, agentId = AGENT_ID) {
   });
 }
 
+async function executeIntent(app: Hono, id: string, key = crypto.randomUUID(), agentId = AGENT_ID) {
+  return app.request(`/v1/trade/evm/swap/intents/${id}/execute`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${await signToken(agentId)}`,
+      "X-Steward-Tenant": TENANT_ID,
+      "Content-Type": "application/json",
+      "Idempotency-Key": key,
+    },
+    body: JSON.stringify({}),
+  });
+}
+
+async function reconcileIntent(app: Hono, id: string, agentId = AGENT_ID) {
+  return app.request(`/v1/trade/evm/swap/intents/${id}/reconcile`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${await signToken(agentId)}`,
+      "X-Steward-Tenant": TENANT_ID,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({}),
+  });
+}
+
+async function dailySpendOf(sessionId = SESSION_ID): Promise<number> {
+  const [row] = await getDb()
+    .select({ spent: tradeSessions.dailySpendUsd })
+    .from(tradeSessions)
+    .where(eq(tradeSessions.id, sessionId));
+  return Number(row?.spent ?? 0);
+}
+
 async function getIntentWithPlatform(app: Hono, id: string, tenantId = TENANT_ID) {
   return app.request(`/v1/trade/evm/swap/intents/${id}`, {
     headers: {
@@ -315,9 +409,17 @@ beforeAll(async () => {
   });
   pgliteDb = db as ReturnType<typeof getDb>;
 
-  ({ auditEvents, closeDb, getDb, intents, policies, tenants, tradeSessions } = await import(
-    "@stwd/db"
-  ));
+  ({
+    auditEvents,
+    closeDb,
+    getDb,
+    intents,
+    policies,
+    tenants,
+    tradeSessions,
+    transactions,
+    vaultSigningFreezes,
+  } = await import("@stwd/db"));
   ({ testCtx } = await import("./_ctx"));
   ({ tradingPlugin } = await import("../index"));
   ({ createEvmSwapRoutes } = await import("../routes/evm-swap"));
@@ -357,6 +459,8 @@ beforeEach(async () => {
   clearAgentJwksCacheForTests();
   await getDb().delete(auditEvents).where(eq(auditEvents.tenantId, TENANT_ID));
   await getDb().delete(intents).where(eq(intents.tenantId, TENANT_ID));
+  await getDb().delete(transactions).where(eq(transactions.agentId, AGENT_ID));
+  await getDb().delete(vaultSigningFreezes).where(eq(vaultSigningFreezes.tenantId, TENANT_ID));
   await getDb().delete(tradeSessions).where(eq(tradeSessions.tenantId, TENANT_ID));
   await getDb()
     .insert(tradeSessions)
@@ -732,5 +836,236 @@ describe("governed EVM swap prepare", () => {
     const res = await postPrepare(app);
     expect(res.status).toBe(200);
     expect(signSpy).not.toHaveBeenCalled();
+  });
+
+  it("executes a prepared swap once, persists tx identity before send, and never exposes raw tx", async () => {
+    const rpc = new FakeEvmRpc();
+    let persistedBeforeSend: string | null = null;
+    rpc.onBeforeSend = async () => {
+      const [row] = await getDb().select().from(intents).where(eq(intents.id, intentId));
+      const execution = (row?.executionResult ?? {}) as Record<string, unknown>;
+      persistedBeforeSend =
+        typeof execution.transactionHash === "string" ? execution.transactionHash : null;
+    };
+    const { app } = await buildApp({ simulator: { ok: true }, evmRpc: rpc });
+    const prepared = await postPrepare(app);
+    const preparedBody = (await prepared.json()) as { data: { intentId: string } };
+    const intentId = preparedBody.data.intentId;
+
+    const key = crypto.randomUUID();
+    const executed = await executeIntent(app, intentId, key);
+    expect(executed.status).toBe(200);
+    const body = (await executed.json()) as {
+      data: { status: string; executionStatus: string; transactionHash: string };
+    };
+    expect(body.data.status).toBe("submitted");
+    expect(body.data.executionStatus).toBe("submitted");
+    expect(body.data.transactionHash).toMatch(/^0x[a-f0-9]{64}$/);
+    expect(persistedBeforeSend).toBe(body.data.transactionHash);
+    expect(rpc.sendCalls).toHaveLength(1);
+    expect(JSON.stringify(body)).not.toContain(rpc.sendCalls[0] ?? "raw-missing");
+    expect(JSON.stringify(await getDb().select().from(intents))).not.toContain(
+      rpc.sendCalls[0] ?? "raw-missing",
+    );
+    expect(JSON.stringify(await getDb().select().from(transactions))).not.toContain(
+      rpc.sendCalls[0] ?? "raw-missing",
+    );
+    expect(await dailySpendOf()).toBeGreaterThan(0);
+
+    const replay = await executeIntent(app, intentId, key);
+    expect(replay.status).toBe(200);
+    expect((await replay.json()) as unknown).toEqual(body);
+    expect(rpc.sendCalls).toHaveLength(1);
+
+    const conflict = await executeIntent(app, intentId, crypto.randomUUID());
+    expect(conflict.status).toBe(409);
+    expect(rpc.sendCalls).toHaveLength(1);
+  });
+
+  it("preserves submitted identity when the post-submit audit write fails", async () => {
+    const rpc = new FakeEvmRpc();
+    const { app } = await buildApp({
+      simulator: { ok: true },
+      evmRpc: rpc,
+      auditFailureActions: ["trade.evm.swap.execute.submitted"],
+    });
+    const prepared = await postPrepare(app);
+    const { data } = (await prepared.json()) as { data: { intentId: string } };
+
+    const executed = await executeIntent(app, data.intentId);
+    expect(executed.status).toBe(200);
+    expect(await executed.json()).toMatchObject({
+      data: { status: "submitted", executionStatus: "submitted", retry: "not-retryable" },
+    });
+    expect(await dailySpendOf()).toBeGreaterThan(0);
+
+    const [intentRow] = await getDb().select().from(intents).where(eq(intents.id, data.intentId));
+    const [txRow] = await getDb()
+      .select()
+      .from(transactions)
+      .where(eq(transactions.id, data.intentId));
+    expect(intentRow?.status).toBe("submitted");
+    expect(txRow?.status).toBe("broadcast");
+    expect(txRow?.txHash).toMatch(/^0x[a-f0-9]{64}$/);
+  });
+
+  it("rejects execute for non-owning agents and pre-sign fences without reserving spend", async () => {
+    const rpc = new FakeEvmRpc();
+    const { app } = await buildApp({ simulator: { ok: true }, evmRpc: rpc });
+    const prepared = await postPrepare(app);
+    const { data } = (await prepared.json()) as { data: { intentId: string } };
+
+    expect(
+      (await executeIntent(app, data.intentId, crypto.randomUUID(), OTHER_AGENT_ID)).status,
+    ).toBe(404);
+
+    await getDb()
+      .update(tradeSessions)
+      .set({ status: "revoked", revokedAt: new Date(), revokedBy: "test" })
+      .where(eq(tradeSessions.id, SESSION_ID));
+    const revoked = await executeIntent(app, data.intentId);
+    expect(revoked.status).toBe(403);
+    expect(await dailySpendOf()).toBe(0);
+    expect(rpc.sendCalls).toHaveLength(0);
+  });
+
+  it("releases spend and drops nonce on pre-submit signing freeze rejection", async () => {
+    const rpc = new FakeEvmRpc();
+    const { app } = await buildApp({ simulator: { ok: true }, evmRpc: rpc });
+    const prepared = await postPrepare(app);
+    const { data } = (await prepared.json()) as { data: { intentId: string } };
+    await getDb().insert(vaultSigningFreezes).values({
+      tenantId: TENANT_ID,
+      scopeType: "agent",
+      agentId: AGENT_ID,
+      reason: "test freeze",
+      createdByType: "system",
+    });
+
+    const rejected = await executeIntent(app, data.intentId);
+    expect(rejected.status).toBe(409);
+    expect(await rejected.json()).toMatchObject({
+      data: { executionStatus: "not_attempted" },
+    });
+    expect(rpc.sendCalls).toHaveLength(0);
+    expect(await dailySpendOf()).toBe(0);
+    const [row] = await getDb().select().from(intents).where(eq(intents.id, data.intentId));
+    expect(row?.status).toBe("rejected");
+  });
+
+  it("classifies send timeout as unknown, retains spend, and never resubmits on replay", async () => {
+    const rpc = Object.assign(new FakeEvmRpc(), { failSend: new Error("network timeout") });
+    const { app } = await buildApp({ simulator: { ok: true }, evmRpc: rpc });
+    const prepared = await postPrepare(app);
+    const { data } = (await prepared.json()) as { data: { intentId: string } };
+    const key = crypto.randomUUID();
+
+    const unknown = await executeIntent(app, data.intentId, key);
+    expect(unknown.status).toBe(200);
+    expect(await unknown.json()).toMatchObject({
+      data: { status: "unknown", executionStatus: "unknown", retry: "reconcile-only" },
+    });
+    expect(await dailySpendOf()).toBeGreaterThan(0);
+    expect(rpc.sendCalls).toHaveLength(1);
+
+    const replay = await executeIntent(app, data.intentId, key);
+    expect(replay.status).toBe(200);
+    expect(rpc.sendCalls).toHaveLength(1);
+
+    const blindRetry = await executeIntent(app, data.intentId, crypto.randomUUID());
+    expect(blindRetry.status).toBe(409);
+    expect(rpc.sendCalls).toHaveLength(1);
+  });
+
+  it("marks definite RPC-rejected sends failed in the transaction ledger", async () => {
+    const rpc = Object.assign(new FakeEvmRpc(), {
+      failSend: new Error("insufficient funds for gas * price + value"),
+    });
+    const { app } = await buildApp({ simulator: { ok: true }, evmRpc: rpc });
+    const prepared = await postPrepare(app);
+    const { data } = (await prepared.json()) as { data: { intentId: string } };
+
+    const rejected = await executeIntent(app, data.intentId);
+    expect(rejected.status).toBe(409);
+    expect(await rejected.json()).toMatchObject({
+      data: { executionStatus: "rejected" },
+    });
+    expect(await dailySpendOf()).toBe(0);
+    const [intentRow] = await getDb().select().from(intents).where(eq(intents.id, data.intentId));
+    const [txRow] = await getDb()
+      .select()
+      .from(transactions)
+      .where(eq(transactions.id, data.intentId));
+    expect(intentRow?.status).toBe("rejected");
+    expect(txRow?.status).toBe("failed");
+  });
+
+  it("reconciles confirmed, reverted, and not-found ambiguity from persisted tx hash only", async () => {
+    const confirmedRpc = Object.assign(new FakeEvmRpc(), { failSend: new Error("timeout") });
+    const confirmedApp = await buildApp({ simulator: { ok: true }, evmRpc: confirmedRpc });
+    const confirmedPrepared = await postPrepare(confirmedApp.app);
+    const confirmedId = ((await confirmedPrepared.json()) as { data: { intentId: string } }).data
+      .intentId;
+    await executeIntent(confirmedApp.app, confirmedId);
+    const [confirmedRow] = await getDb().select().from(intents).where(eq(intents.id, confirmedId));
+    const confirmedHash = ((confirmedRow?.executionResult ?? {}) as Record<string, unknown>)
+      .transactionHash as string;
+    confirmedRpc.failSend = null;
+    confirmedRpc.receipt = { status: "0x1", transactionHash: confirmedHash, blockNumber: "0x1" };
+    expect((await reconcileIntent(confirmedApp.app, confirmedId)).status).toBe(200);
+    expect(await getIntent(confirmedApp.app, confirmedId).then((r) => r.json())).toMatchObject({
+      data: { status: "submitted" },
+    });
+
+    await getDb().delete(intents).where(eq(intents.tenantId, TENANT_ID));
+    await getDb()
+      .update(tradeSessions)
+      .set({ dailySpendUsd: "0", status: "active" })
+      .where(eq(tradeSessions.id, SESSION_ID));
+
+    const revertedRpc = Object.assign(new FakeEvmRpc(), { failSend: new Error("timeout") });
+    const revertedApp = await buildApp({ simulator: { ok: true }, evmRpc: revertedRpc });
+    const revertedPrepared = await postPrepare(revertedApp.app);
+    const revertedId = ((await revertedPrepared.json()) as { data: { intentId: string } }).data
+      .intentId;
+    await executeIntent(revertedApp.app, revertedId);
+    const [revertedRow] = await getDb().select().from(intents).where(eq(intents.id, revertedId));
+    const revertedHash = ((revertedRow?.executionResult ?? {}) as Record<string, unknown>)
+      .transactionHash as string;
+    expect(await dailySpendOf()).toBeGreaterThan(0);
+    revertedRpc.failSend = null;
+    revertedRpc.receipt = { status: "0x0", transactionHash: revertedHash, blockNumber: "0x2" };
+    await reconcileIntent(revertedApp.app, revertedId);
+    expect(await getIntent(revertedApp.app, revertedId).then((r) => r.json())).toMatchObject({
+      data: { status: "rejected" },
+    });
+    expect(await dailySpendOf()).toBe(0);
+    await getDb()
+      .update(tradeSessions)
+      .set({ dailySpendUsd: "10" })
+      .where(eq(tradeSessions.id, SESSION_ID));
+    await reconcileIntent(revertedApp.app, revertedId);
+    expect(await dailySpendOf()).toBe(10);
+
+    await getDb().delete(intents).where(eq(intents.tenantId, TENANT_ID));
+    await getDb()
+      .update(tradeSessions)
+      .set({ dailySpendUsd: "0", status: "active" })
+      .where(eq(tradeSessions.id, SESSION_ID));
+
+    const missingRpc = Object.assign(new FakeEvmRpc(), { failSend: new Error("timeout") });
+    const missingApp = await buildApp({ simulator: { ok: true }, evmRpc: missingRpc });
+    const missingPrepared = await postPrepare(missingApp.app);
+    const missingId = ((await missingPrepared.json()) as { data: { intentId: string } }).data
+      .intentId;
+    await executeIntent(missingApp.app, missingId);
+    missingRpc.failSend = null;
+    missingRpc.receipt = null;
+    missingRpc.transaction = null;
+    await reconcileIntent(missingApp.app, missingId);
+    expect(await getIntent(missingApp.app, missingId).then((r) => r.json())).toMatchObject({
+      data: { status: "unknown" },
+    });
+    expect(await dailySpendOf()).toBeGreaterThan(0);
   });
 });

--- a/packages/plugin-trading/src/context.ts
+++ b/packages/plugin-trading/src/context.ts
@@ -65,6 +65,21 @@ export interface EvmSimulator {
   simulate(request: EvmSimulationRequest): Promise<EvmSimulationResult>;
 }
 
+export interface EvmTransactionReceipt {
+  transactionHash?: string;
+  status?: string;
+  blockHash?: string | null;
+  blockNumber?: string | null;
+}
+
+export interface EvmRpcClient {
+  getPendingNonce(chainId: number, address: string): Promise<number>;
+  getGasPrice(chainId: number): Promise<string>;
+  sendRawTransaction(chainId: number, rawTransaction: string): Promise<string>;
+  getTransactionReceipt(chainId: number, txHash: string): Promise<EvmTransactionReceipt | null>;
+  getTransactionByHash(chainId: number, txHash: string): Promise<Record<string, unknown> | null>;
+}
+
 /** a hono middleware over the steward app's per-request variables. */
 export type StewardMiddleware = (
   c: Context<{ Variables: AppVariables }>,
@@ -85,6 +100,7 @@ export interface StewardAppContext {
   priceOracle: PriceOracle;
   adapterRegistry: AdapterRegistry;
   evmSimulator: EvmSimulator | null;
+  evmRpc: EvmRpcClient | null;
 
   // ── core helpers (from @stwd/api services/context) ────────────────────────
   ensureAgentForTenant(tenantId: string, agentId: string): Promise<AgentIdentity | undefined>;

--- a/packages/plugin-trading/src/index.ts
+++ b/packages/plugin-trading/src/index.ts
@@ -20,7 +20,6 @@
  * keeps the dependency one-directional (no cycle).
  */
 
-import { Buffer } from "node:buffer";
 import type { AppVariables, StewardPlugin } from "@stwd/shared";
 import type { Context, Hono, Next } from "hono";
 import type { StewardAppContext } from "./context";
@@ -83,7 +82,7 @@ function bearerLooksLikeExternalAgentJwt(c: Context<{ Variables: AppVariables }>
   const [, payload] = auth.slice("Bearer ".length).split(".");
   if (!payload) return false;
   try {
-    const decoded = JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as {
+    const decoded = JSON.parse(atob(payload.replace(/-/g, "+").replace(/_/g, "/"))) as {
       agent_id?: unknown;
     };
     return typeof decoded.agent_id === "string" && decoded.agent_id.length > 0;

--- a/packages/plugin-trading/src/routes/evm-swap.ts
+++ b/packages/plugin-trading/src/routes/evm-swap.ts
@@ -5,7 +5,7 @@ import {
   AdapterValidationError,
   type SwapQuote,
 } from "@stwd/adapters";
-import { and, eq, intents, sql } from "@stwd/db";
+import { and, eq, intents, sql, tradeSessions, transactions } from "@stwd/db";
 import {
   aggregationLookupFromMap,
   aggregationQueriesForPolicies,
@@ -15,8 +15,15 @@ import { getAggregationSnapshot } from "@stwd/redis";
 import type { ApiResponse, AppVariables, PolicyRule, SignRequest } from "@stwd/shared";
 import { toCaip2 } from "@stwd/shared";
 import { TradeSessionManager } from "@stwd/trade-sessions";
+import {
+  allocateEvmNonce,
+  confirmEvmNonce,
+  isVaultSigningFrozenError,
+  markEvmNonceDropped,
+} from "@stwd/vault";
 import type { Context } from "hono";
 import { Hono } from "hono";
+import { type Hex, keccak256 } from "viem";
 import { z } from "zod";
 import type { StewardAppContext } from "../context";
 
@@ -33,6 +40,7 @@ type PreparedSwapResponse = {
     canExecute: boolean;
     terminal: boolean;
     executionStatus: string | null;
+    transactionHash?: string | null;
   };
   unsignedIntent: {
     kind: "evm-tx";
@@ -71,6 +79,15 @@ type InflightIdempotencyEntry = {
   promise: Promise<StoredResponse>;
 };
 
+type ExecuteResponse = {
+  intentId: string;
+  intentHash: string;
+  status: PreparedIntentStatus;
+  executionStatus: "not_attempted" | "rejected" | "unknown" | "submitted";
+  transactionHash: string | null;
+  retry: "same-idempotency-key" | "reconcile-only" | "not-retryable";
+};
+
 const tokenRefSchema = z
   .object({
     address: z.string().regex(/^0x[a-fA-F0-9]{40}$/, "token address must be an EVM address"),
@@ -90,6 +107,8 @@ const prepareSwapSchema = z
     slippageBps: z.number().int().min(0).max(10_000).optional(),
   })
   .strict();
+
+const emptyBodySchema = z.object({}).strict();
 
 const evmAddressRe = /^0x[a-fA-F0-9]{40}$/;
 const calldataRe = /^0x(?:[a-fA-F0-9]{2})+$/;
@@ -440,9 +459,140 @@ function preparedResponseFromRow(row: typeof intents.$inferSelect): PreparedSwap
         row.status === "revoked" ||
         row.status === "expired",
       executionStatus: typeof execution.status === "string" ? execution.status : null,
+      transactionHash:
+        typeof execution.transactionHash === "string" ? execution.transactionHash : null,
     },
     unsignedIntent,
   };
+}
+
+function executeResponseFromRow(row: typeof intents.$inferSelect): ExecuteResponse {
+  const execution = (row.executionResult ?? {}) as Record<string, unknown>;
+  const status =
+    execution.status === "submitted" ||
+    execution.status === "unknown" ||
+    execution.status === "rejected" ||
+    execution.status === "not_attempted"
+      ? execution.status
+      : row.status === "submitted"
+        ? "submitted"
+        : row.status === "unknown" || row.status === "submitting"
+          ? "unknown"
+          : row.status === "rejected"
+            ? "rejected"
+            : "not_attempted";
+  return {
+    intentId: row.id,
+    intentHash: String(row.intentHash ?? ""),
+    status: isPreparedStatus(row.status) ? row.status : "rejected",
+    executionStatus: status as ExecuteResponse["executionStatus"],
+    transactionHash:
+      typeof execution.transactionHash === "string" ? execution.transactionHash : null,
+    retry:
+      status === "unknown"
+        ? "reconcile-only"
+        : status === "not_attempted"
+          ? "same-idempotency-key"
+          : "not-retryable",
+  };
+}
+
+function decimalAmountToUsd(amount: string, decimals: number | undefined, price: number): number {
+  const scale = 10n ** BigInt(decimals ?? 18);
+  const raw = BigInt(amount);
+  const whole = raw / scale;
+  const fraction = raw % scale;
+  return (Number(whole) + Number(fraction) / Number(scale)) * price;
+}
+
+async function executeSpendUsd(
+  ctx: StewardAppContext,
+  payload: Record<string, unknown>,
+): Promise<number | null> {
+  const semantic = payload.semanticRequest as Record<string, unknown> | undefined;
+  const token = semantic?.fromToken as Record<string, unknown> | undefined;
+  const chainId =
+    typeof semantic?.chainId === "number" ? semantic.chainId : Number(payload.chainId);
+  const amount = typeof semantic?.amount === "string" ? semantic.amount : null;
+  const address = typeof token?.address === "string" ? token.address : null;
+  if (!Number.isSafeInteger(chainId) || !amount || !address) return null;
+  const price = await ctx.priceOracle.getTokenUsdPrice(chainId, address);
+  if (!Number.isFinite(price) || !price || price <= 0) return null;
+  const decimals = typeof token?.decimals === "number" ? token.decimals : undefined;
+  const usd = decimalAmountToUsd(amount, decimals, price);
+  return Number.isFinite(usd) && usd > 0 ? usd : null;
+}
+
+function classifySendError(error: unknown): "rejected" | "unknown" {
+  const message =
+    error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+  if (
+    message.includes("already known") ||
+    message.includes("known transaction") ||
+    message.includes("already imported")
+  ) {
+    return "unknown";
+  }
+  if (
+    message.includes("insufficient funds") ||
+    message.includes("intrinsic gas") ||
+    message.includes("gas too low") ||
+    message.includes("nonce too low") ||
+    message.includes("replacement transaction underpriced") ||
+    message.includes("exceeds block gas limit") ||
+    message.includes("invalid sender")
+  ) {
+    return "rejected";
+  }
+  return "unknown";
+}
+
+async function markExecutionRejected(input: {
+  ctx: StewardAppContext;
+  row: typeof intents.$inferSelect;
+  actorId: string;
+  reason: string;
+  executionStatus: "not_attempted" | "rejected";
+  nonce?: number;
+  spendUsd?: number;
+}) {
+  const payload = input.row.payload as Record<string, unknown>;
+  const wallet = typeof payload.wallet === "string" ? payload.wallet : "";
+  const chainId = Number(payload.chainId);
+  await input.ctx.db
+    .update(intents)
+    .set({
+      status: "rejected",
+      rejectedAt: new Date(),
+      rejectedBy: input.actorId,
+      rejectionReason: input.reason,
+      updatedAt: new Date(),
+      executionResult: {
+        ...((input.row.executionResult ?? {}) as Record<string, unknown>),
+        status: input.executionStatus,
+        reason: input.reason,
+      },
+    })
+    .where(eq(intents.id, input.row.id));
+  if (input.spendUsd && input.spendUsd > 0) {
+    const sessionId = String(payload.sessionId);
+    await getSessionManager(input.ctx).releaseSpend({
+      tenantId: input.row.tenantId,
+      id: sessionId,
+      amountUsd: input.spendUsd,
+    });
+  }
+  await input.ctx.db
+    .update(transactions)
+    .set({ status: "failed" })
+    .where(eq(transactions.id, input.row.id));
+  if (input.nonce !== undefined && isEvmAddress(wallet) && Number.isSafeInteger(chainId)) {
+    await markEvmNonceDropped({
+      walletAddress: wallet as `0x${string}`,
+      chainId,
+      nonce: input.nonce,
+    }).catch(() => {});
+  }
 }
 
 function rejectedPrepareReplayFromRow(row: typeof intents.$inferSelect): StoredResponse | null {
@@ -504,6 +654,85 @@ function intentAuditActor(c: Context<{ Variables: AppVariables }>) {
   const userId = c.get("userId");
   if (userId) return { actorType: "user" as const, actorId: userId };
   return { actorType: "api-key" as const, actorId: c.get("tenantId") };
+}
+
+function quoteFromPayload(payload: Record<string, unknown>): SwapQuote | null {
+  const semantic = payload.semanticRequest as Record<string, unknown> | undefined;
+  const quote = payload.quote as Record<string, unknown> | undefined;
+  const fromToken = semantic?.fromToken as Record<string, unknown> | undefined;
+  const toToken = semantic?.toToken as Record<string, unknown> | undefined;
+  const chainId =
+    typeof semantic?.chainId === "number" ? semantic.chainId : Number(payload.chainId);
+  const expiresAt =
+    typeof quote?.expiresAt === "string" ? new Date(quote.expiresAt).getTime() : Number.NaN;
+  if (
+    !quote ||
+    !fromToken ||
+    !toToken ||
+    !Number.isSafeInteger(chainId) ||
+    !Number.isSafeInteger(expiresAt) ||
+    typeof quote.provider !== "string" ||
+    typeof quote.quoteId !== "string" ||
+    typeof quote.amountIn !== "string" ||
+    typeof quote.amountOut !== "string" ||
+    typeof quote.minAmountOut !== "string" ||
+    typeof fromToken.address !== "string" ||
+    typeof toToken.address !== "string"
+  ) {
+    return null;
+  }
+  return {
+    provider: quote.provider,
+    quoteId: quote.quoteId,
+    chainId,
+    fromToken: {
+      address: fromToken.address,
+      symbol: typeof fromToken.symbol === "string" ? fromToken.symbol : undefined,
+      decimals: typeof fromToken.decimals === "number" ? fromToken.decimals : undefined,
+    },
+    toToken: {
+      address: toToken.address,
+      symbol: typeof toToken.symbol === "string" ? toToken.symbol : undefined,
+      decimals: typeof toToken.decimals === "number" ? toToken.decimals : undefined,
+    },
+    amountIn: quote.amountIn,
+    amountOut: quote.amountOut,
+    minAmountOut: quote.minAmountOut,
+    feeAmount: typeof quote.feeAmount === "string" ? quote.feeAmount : "0",
+    slippageBps:
+      typeof (payload.semanticRequest as Record<string, unknown> | undefined)?.slippageBps ===
+      "number"
+        ? ((payload.semanticRequest as Record<string, unknown>).slippageBps as number)
+        : 0,
+    route: [],
+    expiresAt,
+  };
+}
+
+function unsignedIntentFromPayload(payload: Record<string, unknown>) {
+  const intent = payload.unsignedIntent as PreparedSwapResponse["unsignedIntent"] | undefined;
+  if (
+    !intent ||
+    intent.kind !== "evm-tx" ||
+    !Number.isSafeInteger(intent.chainId) ||
+    !isEvmAddress(intent.to) ||
+    !isEvmAddress(intent.owner) ||
+    !/^\d+$/.test(intent.value) ||
+    typeof intent.data !== "string" ||
+    !selectorOf(intent.data) ||
+    intent.category !== "swap" ||
+    typeof intent.provider !== "string"
+  ) {
+    return null;
+  }
+  return intent;
+}
+
+function gasLimitFromEstimate(estimate?: string): string {
+  if (estimate && /^0x[0-9a-fA-F]+$/.test(estimate)) {
+    return BigInt(estimate).toString();
+  }
+  return "21000";
 }
 
 export function createEvmSwapRoutes(ctx: StewardAppContext): Hono<{ Variables: AppVariables }> {
@@ -1009,6 +1238,654 @@ export function createEvmSwapRoutes(ctx: StewardAppContext): Hono<{ Variables: A
       inflightIdempotency.delete(idempotencyScope);
     });
     return c.json(response.body, response.status);
+  });
+
+  routes.post("/evm/swap/intents/:id/execute", async (c) => {
+    const tenantId = c.get("tenantId");
+    const scopedAgent = c.get("agentScope");
+    if (!scopedAgent) return json(c, { ok: false, error: "Agent JWT required" }, 403);
+    const idempotencyKey = c.req.header("Idempotency-Key");
+    if (!idempotencyKey) {
+      return json(c, { ok: false, error: "Idempotency-Key is required" }, 400);
+    }
+    if (idempotencyKey.length > 200) {
+      return json(c, { ok: false, error: "Idempotency-Key is too long" }, 400);
+    }
+    const raw = await ctx.safeJsonParse(c);
+    const parsed = emptyBodySchema.safeParse(raw ?? {});
+    if (!parsed.success) return json(c, { ok: false, error: parsed.error.message }, 400);
+    if (!ctx.evmSimulator || !ctx.evmRpc) {
+      return json(c, { ok: false, error: "EVM execution RPC is not configured" }, 503);
+    }
+
+    const id = c.req.param("id");
+    const existing = await loadPreparedIntent(ctx, tenantId, scopedAgent, id);
+    if (!existing) return json(c, { ok: false, error: "Prepared intent not found" }, 404);
+    const existingExecution = (existing.executionResult ?? {}) as Record<string, unknown>;
+    if (existing.status !== "prepared") {
+      if (existingExecution.executionIdempotencyKey === idempotencyKey) {
+        return c.json({ ok: true, data: executeResponseFromRow(existing) }, 200);
+      }
+      return json(
+        c,
+        {
+          ok: false,
+          error:
+            existing.status === "unknown"
+              ? "Execution status is unknown; reconcile instead of retrying"
+              : `Cannot execute intent in ${existing.status} status`,
+        },
+        409,
+      );
+    }
+
+    const payload = existing.payload as Record<string, unknown>;
+    const unsignedIntent = unsignedIntentFromPayload(payload);
+    const quote = quoteFromPayload(payload);
+    const sessionId = typeof payload.sessionId === "string" ? payload.sessionId : null;
+    const wallet = typeof payload.wallet === "string" ? payload.wallet : null;
+    if (!unsignedIntent || !quote || !sessionId || !wallet || !isEvmAddress(wallet)) {
+      return json(c, { ok: false, error: "Prepared intent payload is not executable" }, 409);
+    }
+    if (existing.expiresAt && existing.expiresAt <= new Date()) {
+      const expired = await loadPreparedIntent(ctx, tenantId, scopedAgent, existing.id);
+      return json(
+        c,
+        { ok: false, error: `Cannot execute intent in ${expired?.status ?? "expired"} status` },
+        409,
+      );
+    }
+
+    const spendUsd = await executeSpendUsd(ctx, payload);
+    if (!spendUsd) {
+      return json(
+        c,
+        { ok: false, error: "Unable to price EVM swap for session spend reservation" },
+        503,
+      );
+    }
+
+    const actor = auditActor(c, scopedAgent);
+    const sessionManager = getSessionManager(ctx);
+    const now = new Date();
+    const currentWallet = await resolveEvmWallet(
+      ctx,
+      { id: scopedAgent, walletAddress: wallet, walletAddresses: { evm: wallet } },
+      unsignedIntent.chainId,
+    );
+    if (!currentWallet || normalizeAddress(currentWallet) !== normalizeAddress(wallet)) {
+      return json(c, { ok: false, error: "Agent wallet no longer matches prepared intent" }, 409);
+    }
+    const policySet = await ctx.getPolicySet(tenantId, scopedAgent);
+    const selector = selectorOf(unsignedIntent.data);
+    if (!selector) return json(c, { ok: false, error: "Prepared intent calldata is invalid" }, 409);
+    const strict = validateGovernedEvmExecutionPolicy(policySet, {
+      agentId: scopedAgent,
+      tenantId,
+      chainId: unsignedIntent.chainId,
+      owner: unsignedIntent.owner,
+      target: unsignedIntent.to,
+      selector,
+      value: unsignedIntent.value,
+      provider: unsignedIntent.provider,
+      category: unsignedIntent.category,
+      quote,
+      intentMetadata: {
+        quoteId: quote.quoteId,
+        amountIn: quote.amountIn,
+        minAmountOut: quote.minAmountOut,
+      },
+    });
+    if (!strict.ok) {
+      return json(
+        c,
+        { ok: false, error: strict.reason, data: { executionStatus: "not_attempted" } },
+        403,
+      );
+    }
+
+    const request: SignRequest = {
+      agentId: scopedAgent,
+      tenantId,
+      to: unsignedIntent.to,
+      value: unsignedIntent.value,
+      data: unsignedIntent.data,
+      chainId: unsignedIntent.chainId,
+      broadcast: false,
+      walletAddress: wallet,
+    };
+    const [stats, conditionSets, aggregations] = await Promise.all([
+      getTransactionStats(ctx, scopedAgent, unsignedIntent.chainId),
+      loadConditionSets(ctx, tenantId, policySet),
+      loadAggregations(policySet, request),
+    ]);
+    const policyEvaluation = await ctx.policyEngine.evaluate(policySet, {
+      request,
+      ...stats,
+      conditionSets,
+      aggregations,
+      priceOracle: ctx.priceOracle,
+      correlationId: idempotencyKey,
+      venue: unsignedIntent.provider,
+    });
+    if (!policyEvaluation.approved) {
+      return json(
+        c,
+        {
+          ok: false,
+          error:
+            policyEvaluation.results.find((result) => !result.passed)?.reason ??
+            "EVM execution rejected by policy",
+          data: { executionStatus: "not_attempted" },
+        },
+        403,
+      );
+    }
+
+    const recomputedHash = canonicalIntentHash(
+      { ...request, owner: wallet, category: "swap", provider: unsignedIntent.provider },
+      quote,
+    );
+    if (recomputedHash !== existing.intentHash) {
+      return json(c, { ok: false, error: "Prepared intent digest no longer matches payload" }, 409);
+    }
+    const simulation = await ctx.evmSimulator.simulate({
+      chainId: unsignedIntent.chainId,
+      from: wallet,
+      to: unsignedIntent.to,
+      value: unsignedIntent.value,
+      data: unsignedIntent.data,
+      intentHash: recomputedHash,
+    });
+    if (!simulation.ok) {
+      return json(
+        c,
+        {
+          ok: false,
+          error: simulation.revertReason ?? "EVM simulation failed before signing",
+          data: { executionStatus: "not_attempted" },
+        },
+        503,
+      );
+    }
+    const claimed = await sessionManager.withActiveSubmissionFence(
+      { tenantId, id: sessionId },
+      async (freshSession, db) => {
+        if (
+          freshSession.agentId !== scopedAgent ||
+          freshSession.venue !== "evm" ||
+          !freshSession.allowedAssets.includes(toCaip2(unsignedIntent.chainId) ?? "") ||
+          normalizeAddress(freshSession.walletId) !== normalizeAddress(wallet)
+        ) {
+          return {
+            ok: false as const,
+            reason: "Active EVM trade session no longer matches intent",
+          };
+        }
+
+        const [reserved] = await db
+          .update(tradeSessions)
+          .set({
+            dailySpendUsd: sql`${tradeSessions.dailySpendUsd} + ${String(spendUsd)}::numeric`,
+          })
+          .where(
+            and(
+              eq(tradeSessions.id, sessionId),
+              eq(tradeSessions.tenantId, tenantId),
+              eq(tradeSessions.status, "active"),
+              sql`${tradeSessions.expiresAt} > ${now.toISOString()}`,
+              sql`${tradeSessions.dailySpendUsd} + ${String(spendUsd)}::numeric <= ${tradeSessions.dailyCapUsd}`,
+            ),
+          )
+          .returning();
+        if (!reserved) {
+          return { ok: false as const, reason: "EVM trade session spend cap exceeded" };
+        }
+
+        const [row] = await db
+          .update(intents)
+          .set({
+            status: "submitting",
+            executedBy: actor.actorId,
+            executedAt: now,
+            updatedAt: now,
+            executionResult: {
+              ...existingExecution,
+              status: "not_attempted",
+              executionIdempotencyKey: idempotencyKey,
+              spendUsd,
+              transactionHash: null,
+              retry: "same idempotency key only until transaction hash is known",
+            },
+          })
+          .where(
+            and(
+              eq(intents.id, existing.id),
+              eq(intents.tenantId, tenantId),
+              eq(intents.agentId, scopedAgent),
+              eq(intents.status, "prepared"),
+              sql`${intents.expiresAt} > ${now.toISOString()}`,
+            ),
+          )
+          .returning();
+        if (!row) {
+          await db
+            .update(tradeSessions)
+            .set({
+              dailySpendUsd: sql`greatest(${tradeSessions.dailySpendUsd} - ${String(spendUsd)}::numeric, 0)`,
+            })
+            .where(and(eq(tradeSessions.id, sessionId), eq(tradeSessions.tenantId, tenantId)));
+          return { ok: false as const, reason: "Prepared intent was already claimed" };
+        }
+        return { ok: true as const, row, policyResults: policyEvaluation.results, simulation };
+      },
+    );
+
+    if (!claimed) return json(c, { ok: false, error: "Active EVM trade session required" }, 403);
+    if (!claimed.ok) {
+      await ctx.writeAuditEvent({
+        tenantId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        action: "trade.evm.swap.execute.rejected",
+        resourceType: "trade.evm.swap",
+        resourceId: existing.id,
+        metadata: { intentId: existing.id, reason: claimed.reason },
+        requestId: idempotencyKey,
+      });
+      return json(
+        c,
+        { ok: false, error: claimed.reason, data: { executionStatus: "not_attempted" } },
+        403,
+      );
+    }
+
+    let nonce: number | undefined;
+    let submittedToProvider: { transactionHash: string; nonce: number } | null = null;
+    let persistedSubmitted = false;
+    try {
+      nonce = await allocateEvmNonce({
+        walletAddress: wallet as `0x${string}`,
+        chainId: unsignedIntent.chainId,
+        getPendingNonce: (address) => ctx.evmRpc!.getPendingNonce(unsignedIntent.chainId, address),
+      });
+      const gasPrice = await ctx.evmRpc.getGasPrice(unsignedIntent.chainId);
+      const rawTransaction = await ctx.vault.signEvmRawTransaction({
+        agentId: scopedAgent,
+        tenantId,
+        to: unsignedIntent.to,
+        value: unsignedIntent.value,
+        data: unsignedIntent.data,
+        chainId: unsignedIntent.chainId,
+        walletAddress: wallet,
+        broadcast: false,
+        nonce,
+        gasPrice,
+        gasLimit: gasLimitFromEstimate(claimed.simulation.gasEstimate),
+      });
+      const transactionHash = keccak256(rawTransaction as Hex).toLowerCase();
+      await ctx.db.transaction(async (tx) => {
+        await tx
+          .insert(transactions)
+          .values({
+            id: claimed.row.id,
+            agentId: scopedAgent,
+            status: "signed",
+            toAddress: unsignedIntent.to,
+            value: unsignedIntent.value,
+            data: unsignedIntent.data,
+            chainId: unsignedIntent.chainId,
+            txHash: transactionHash,
+            actionType: "evm_swap",
+            actionPayload: {
+              type: "evm_swap",
+              intentId: claimed.row.id,
+              intentHash: claimed.row.intentHash,
+              provider: unsignedIntent.provider,
+              sessionId,
+              nonce,
+            },
+            policyResults: claimed.policyResults,
+            signedAt: new Date(),
+            createdAt: new Date(),
+          })
+          .onConflictDoUpdate({
+            target: transactions.id,
+            set: {
+              status: "signed",
+              txHash: transactionHash,
+              policyResults: claimed.policyResults,
+              signedAt: new Date(),
+            },
+          });
+        await tx
+          .update(intents)
+          .set({
+            executionResult: {
+              ...((claimed.row.executionResult ?? {}) as Record<string, unknown>),
+              status: "unknown",
+              transactionHash,
+              nonce,
+              spendUsd,
+              retry: "never blind retry; reconcile by intent id or transaction hash",
+            },
+            updatedAt: new Date(),
+          })
+          .where(eq(intents.id, claimed.row.id));
+      });
+
+      let providerHash: string;
+      try {
+        providerHash = await ctx.evmRpc.sendRawTransaction(unsignedIntent.chainId, rawTransaction);
+      } catch (error) {
+        const classification = classifySendError(error);
+        if (classification === "rejected") {
+          await markExecutionRejected({
+            ctx,
+            row: claimed.row,
+            actorId: actor.actorId,
+            reason: error instanceof Error ? error.message : "EVM transaction rejected by RPC",
+            executionStatus: "rejected",
+            nonce,
+            spendUsd,
+          });
+          return json(
+            c,
+            {
+              ok: false,
+              error: "EVM transaction rejected by RPC",
+              data: { executionStatus: "rejected", transactionHash },
+            },
+            409,
+          );
+        }
+        await ctx.db
+          .update(intents)
+          .set({
+            status: "unknown",
+            executionResult: {
+              ...((claimed.row.executionResult ?? {}) as Record<string, unknown>),
+              status: "unknown",
+              transactionHash,
+              nonce,
+              spendUsd,
+              reason: error instanceof Error ? error.message : "EVM transaction submission unknown",
+              retry: "never blind retry; reconcile by intent id or transaction hash",
+            },
+            updatedAt: new Date(),
+          })
+          .where(eq(intents.id, claimed.row.id));
+        return c.json(
+          {
+            ok: true,
+            data: executeResponseFromRow({
+              ...claimed.row,
+              status: "unknown",
+              executionResult: { status: "unknown", transactionHash },
+            }),
+          },
+          200,
+        );
+      }
+
+      if (providerHash !== transactionHash) {
+        await ctx.db
+          .update(intents)
+          .set({
+            status: "unknown",
+            executionResult: {
+              ...((claimed.row.executionResult ?? {}) as Record<string, unknown>),
+              status: "unknown",
+              transactionHash,
+              providerHash,
+              nonce,
+              spendUsd,
+              reason: "RPC returned a different transaction hash",
+              retry: "never blind retry; reconcile by persisted transaction hash",
+            },
+            updatedAt: new Date(),
+          })
+          .where(eq(intents.id, claimed.row.id));
+        return c.json(
+          {
+            ok: true,
+            data: executeResponseFromRow({
+              ...claimed.row,
+              status: "unknown",
+              executionResult: { status: "unknown", transactionHash },
+            }),
+          },
+          200,
+        );
+      }
+
+      submittedToProvider = { transactionHash, nonce };
+      const [submitted] = await ctx.db
+        .update(intents)
+        .set({
+          status: "submitted",
+          executionResult: {
+            ...((claimed.row.executionResult ?? {}) as Record<string, unknown>),
+            status: "submitted",
+            transactionHash,
+            nonce,
+            spendUsd,
+          },
+          updatedAt: new Date(),
+        })
+        .where(eq(intents.id, claimed.row.id))
+        .returning();
+      await ctx.db
+        .update(transactions)
+        .set({ status: "broadcast", txHash: transactionHash })
+        .where(eq(transactions.id, claimed.row.id));
+      persistedSubmitted = true;
+      await confirmEvmNonce({
+        walletAddress: wallet as `0x${string}`,
+        chainId: unsignedIntent.chainId,
+        nonce,
+      }).catch(() => {});
+      await ctx.writeAuditEvent({
+        tenantId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        action: "trade.evm.swap.execute.submitted",
+        resourceType: "trade.evm.swap",
+        resourceId: claimed.row.id,
+        metadata: {
+          intentId: claimed.row.id,
+          intentHash: claimed.row.intentHash,
+          transactionHash,
+          chainId: unsignedIntent.chainId,
+          target: normalizeAddress(unsignedIntent.to),
+          selector: selectorOf(unsignedIntent.data),
+          provider: unsignedIntent.provider,
+        },
+        requestId: idempotencyKey,
+      });
+      return c.json({ ok: true, data: executeResponseFromRow(submitted ?? claimed.row) }, 200);
+    } catch (error) {
+      if (submittedToProvider) {
+        const reason =
+          error instanceof Error ? error.message : "EVM transaction post-submit bookkeeping failed";
+        const preservedStatus = persistedSubmitted ? "submitted" : "unknown";
+        try {
+          await ctx.db
+            .update(intents)
+            .set({
+              status: preservedStatus,
+              executionResult: {
+                ...((claimed.row.executionResult ?? {}) as Record<string, unknown>),
+                status: preservedStatus,
+                transactionHash: submittedToProvider.transactionHash,
+                nonce: submittedToProvider.nonce,
+                spendUsd,
+                reason,
+                retry: "never blind retry; reconcile by intent id or transaction hash",
+              },
+              updatedAt: new Date(),
+            })
+            .where(
+              and(
+                eq(intents.id, claimed.row.id),
+                sql`${intents.status} not in ('rejected','revoked','expired')`,
+              ),
+            );
+          await ctx.db
+            .update(transactions)
+            .set({ status: "broadcast", txHash: submittedToProvider.transactionHash })
+            .where(eq(transactions.id, claimed.row.id));
+        } catch (preserveError) {
+          console.warn("[evm-swap] failed to preserve post-submit state", preserveError);
+        }
+        return c.json(
+          {
+            ok: true,
+            data: executeResponseFromRow({
+              ...claimed.row,
+              status: preservedStatus,
+              executionResult: {
+                status: preservedStatus,
+                transactionHash: submittedToProvider.transactionHash,
+              },
+            }),
+          },
+          200,
+        );
+      }
+      const reason = isVaultSigningFrozenError(error)
+        ? "Vault signing is frozen"
+        : error instanceof Error
+          ? error.message
+          : "EVM execution failed before submission";
+      await markExecutionRejected({
+        ctx,
+        row: claimed.row,
+        actorId: actor.actorId,
+        reason,
+        executionStatus: "not_attempted",
+        nonce,
+        spendUsd,
+      });
+      await ctx.writeAuditEvent({
+        tenantId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        action: "trade.evm.swap.execute.rejected",
+        resourceType: "trade.evm.swap",
+        resourceId: claimed.row.id,
+        metadata: { intentId: claimed.row.id, reason, executionStatus: "not_attempted" },
+        requestId: idempotencyKey,
+      });
+      return json(c, { ok: false, error: reason, data: { executionStatus: "not_attempted" } }, 409);
+    }
+  });
+
+  routes.post("/evm/swap/intents/:id/reconcile", async (c) => {
+    const tenantId = c.get("tenantId");
+    const scopedAgent = c.get("agentScope");
+    if (!ctx.evmRpc)
+      return json(c, { ok: false, error: "EVM execution RPC is not configured" }, 503);
+    const row = await loadPreparedIntent(ctx, tenantId, scopedAgent ?? null, c.req.param("id"));
+    if (!row) return json(c, { ok: false, error: "Prepared intent not found" }, 404);
+    const execution = (row.executionResult ?? {}) as Record<string, unknown>;
+    const txHash = typeof execution.transactionHash === "string" ? execution.transactionHash : null;
+    if (!txHash) return c.json({ ok: true, data: preparedResponseFromRow(row) }, 200);
+    const payload = row.payload as Record<string, unknown>;
+    const chainId = Number(payload.chainId);
+    if (!Number.isSafeInteger(chainId)) {
+      return json(c, { ok: false, error: "Prepared intent chain is invalid" }, 409);
+    }
+    const receipt = await ctx.evmRpc.getTransactionReceipt(chainId, txHash);
+    const actor = intentAuditActor(c);
+    if (receipt?.status === "0x1") {
+      const [submitted] = await ctx.db
+        .update(intents)
+        .set({
+          status: "submitted",
+          executionResult: {
+            ...execution,
+            status: "submitted",
+            transactionHash: txHash,
+            receiptStatus: receipt.status,
+            blockHash: receipt.blockHash ?? null,
+            blockNumber: receipt.blockNumber ?? null,
+          },
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(intents.id, row.id),
+            sql`${intents.status} in ('submitting','unknown','submitted')`,
+          ),
+        )
+        .returning();
+      await ctx.db
+        .update(transactions)
+        .set({ status: "confirmed", confirmedAt: new Date() })
+        .where(eq(transactions.id, row.id));
+      return c.json({ ok: true, data: preparedResponseFromRow(submitted ?? row) }, 200);
+    }
+    if (receipt?.status === "0x0") {
+      const spendUsd = typeof execution.spendUsd === "number" ? execution.spendUsd : undefined;
+      const [rejected] = await ctx.db
+        .update(intents)
+        .set({
+          status: "rejected",
+          rejectedAt: new Date(),
+          rejectedBy: actor.actorId,
+          rejectionReason: "EVM transaction reverted",
+          executionResult: {
+            ...execution,
+            status: "rejected",
+            transactionHash: txHash,
+            receiptStatus: receipt.status,
+            blockHash: receipt.blockHash ?? null,
+            blockNumber: receipt.blockNumber ?? null,
+            reason: "EVM transaction reverted",
+          },
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(intents.id, row.id),
+            sql`${intents.status} in ('submitting','unknown','submitted')`,
+          ),
+        )
+        .returning();
+      if (rejected) {
+        if (spendUsd && spendUsd > 0) {
+          await getSessionManager(ctx).releaseSpend({
+            tenantId: row.tenantId,
+            id: String(payload.sessionId),
+            amountUsd: spendUsd,
+          });
+        }
+        await ctx.db
+          .update(transactions)
+          .set({ status: "failed" })
+          .where(eq(transactions.id, row.id));
+      }
+      return c.json({ ok: true, data: preparedResponseFromRow(rejected ?? row) }, 200);
+    }
+    const tx = await ctx.evmRpc.getTransactionByHash(chainId, txHash);
+    if (tx) {
+      const [submitted] = await ctx.db
+        .update(intents)
+        .set({
+          status: "submitted",
+          executionResult: { ...execution, status: "submitted", transactionHash: txHash },
+          updatedAt: new Date(),
+        })
+        .where(and(eq(intents.id, row.id), sql`${intents.status} in ('submitting','unknown')`))
+        .returning();
+      await ctx.db
+        .update(transactions)
+        .set({ status: "broadcast", txHash })
+        .where(eq(transactions.id, row.id));
+      return c.json({ ok: true, data: preparedResponseFromRow(submitted ?? row) }, 200);
+    }
+    return c.json({ ok: true, data: preparedResponseFromRow(row) }, 200);
   });
 
   routes.get("/evm/swap/intents/:id", async (c) => {

--- a/packages/vault/src/index.ts
+++ b/packages/vault/src/index.ts
@@ -22,7 +22,7 @@ export {
   serializeEip7702Transaction,
   toEip7702SignedAuthorization,
 } from "./eip7702-auth";
-export { allocateEvmNonce } from "./evm-nonce-manager";
+export { allocateEvmNonce, confirmEvmNonce, markEvmNonceDropped } from "./evm-nonce-manager";
 export type {
   ExternalKeyCustodyProvider,
   ExternalKeyHandleDescriptor,
@@ -180,6 +180,7 @@ export type {
   RelayMoneroTransferRequest,
   SignBitcoinPsbtRequest,
   SignBitcoinPsbtResult,
+  SignEvmRawTransactionRequest,
   VaultConfig,
 } from "./vault";
 export { Vault, Vault as VaultClient } from "./vault";

--- a/packages/vault/src/vault.ts
+++ b/packages/vault/src/vault.ts
@@ -309,6 +309,12 @@ export interface SignTransactionOptions {
   status?: TxStatus;
 }
 
+export interface SignEvmRawTransactionRequest extends SignRequest {
+  chainId: number;
+  nonce: number;
+  gasPrice: string;
+}
+
 interface MnemonicWalletMaterial {
   evmPrivateKey: `0x${string}`;
   evmAddress: string;
@@ -1443,6 +1449,152 @@ export class Vault {
     await this.recordSignedTransaction(request, chainId, shouldBroadcast, hash, options);
 
     return hash;
+  }
+
+  /**
+   * Sign one fully parameterized EVM transaction inside the Steward vault and
+   * return only the serialized signed transaction. This is for governed
+   * execution flows that must persist the transaction hash before submitting
+   * through their own idempotent/reconciliation state machine.
+   */
+  async signEvmRawTransaction(request: SignEvmRawTransactionRequest): Promise<string> {
+    const db = getDb();
+    const [agentRow] = await db
+      .select({ id: agents.id, walletAddress: agents.walletAddress })
+      .from(agents)
+      .where(and(eq(agents.id, request.agentId), eq(agents.tenantId, request.tenantId)));
+
+    if (!agentRow) {
+      throw new Error(`Agent ${request.agentId} not found for tenant ${request.tenantId}`);
+    }
+    if (request.chainId === 101 || request.chainId === 102) {
+      throw new Error("signEvmRawTransaction only supports EVM chains");
+    }
+    if (!Number.isSafeInteger(request.nonce) || request.nonce < 0) {
+      throw new Error("EVM nonce must be a non-negative safe integer");
+    }
+
+    const chain = CHAINS[request.chainId];
+    if (!chain) {
+      throw new Error(`Unsupported EVM chain: ${request.chainId}`);
+    }
+
+    const venue = resolveSignVenueSelector(request);
+    await assertVaultSigningActive({
+      tenantId: request.tenantId,
+      agentId: request.agentId,
+      chainFamily: "evm",
+      venue,
+      walletAddress: request.walletAddress,
+    });
+
+    let secretKey: string;
+    const [chainKey] = await db
+      .select()
+      .from(encryptedChainKeys)
+      .where(
+        and(
+          eq(encryptedChainKeys.agentId, request.agentId),
+          eq(encryptedChainKeys.chainFamily, "evm"),
+          venue ? eq(encryptedChainKeys.venue, venue) : isNull(encryptedChainKeys.venue),
+        ),
+      );
+
+    if (chainKey) {
+      secretKey = await this.keyStore.decrypt(
+        {
+          ciphertext: chainKey.ciphertext,
+          iv: chainKey.iv,
+          tag: chainKey.tag,
+          salt: chainKey.salt,
+        },
+        {
+          tenantId: request.tenantId,
+          agentId: request.agentId,
+          chainFamily: "evm",
+          venue: chainKey.venue ?? venue,
+        },
+      );
+    } else {
+      const externalWallet = await this.getExternalKeyWallet({
+        agentId: request.agentId,
+        chainFamily: "evm",
+        venue,
+      });
+      if (externalWallet) {
+        if (request.walletAddress && externalWallet.address) {
+          if (externalWallet.address.toLowerCase() !== request.walletAddress.toLowerCase()) {
+            throw new Error(
+              `Wallet address mismatch: resolved ${externalWallet.address} but request specified ${request.walletAddress}`,
+            );
+          }
+        }
+        if (
+          externalWallet.metadata.externalKey.signingAvailability !== "provider-signing" ||
+          !this.externalKeyCustodyProvider?.signTransaction
+        ) {
+          throw externalKeySigningUnavailableError();
+        }
+        const signed = await this.externalKeyCustodyProvider.signTransaction({
+          tenantId: request.tenantId,
+          agentId: request.agentId,
+          chainFamily: "evm",
+          address: externalWallet.address,
+          handle: {
+            providerId: externalWallet.metadata.externalKey.providerId,
+            keyId: externalWallet.metadata.externalKey.keyId,
+            version: externalWallet.metadata.externalKey.version,
+            region: externalWallet.metadata.externalKey.region,
+          },
+          venue,
+          chainId: request.chainId,
+          to: request.to,
+          value: request.value,
+          data: request.data,
+          gasLimit: request.gasLimit,
+          nonce: request.nonce,
+          broadcast: false,
+          rpcUrl: CHAIN_RPCS[request.chainId] ?? this.config.rpcUrl,
+        });
+        assertNoExternalPrivateKeyMaterial(signed, "externalSignTransactionResult");
+        if (signed.broadcast !== false) {
+          throw new Error("External key custody signer returned an unexpected broadcast mode");
+        }
+        if (!/^0x[0-9a-fA-F]+$/.test(signed.result)) {
+          throw new Error("External key custody signer returned an invalid signed transaction");
+        }
+        return signed.result;
+      }
+      if (venue) {
+        throw missingSigningKeyError(request.agentId, "evm", venue);
+      }
+      const [legacyKey] = await db
+        .select()
+        .from(encryptedKeys)
+        .where(eq(encryptedKeys.agentId, request.agentId));
+      if (!legacyKey) {
+        throw missingSigningKeyError(request.agentId, "evm");
+      }
+      secretKey = await this.keyStore.decrypt(legacyKey as EncryptedKey, {
+        tenantId: request.tenantId,
+        agentId: request.agentId,
+        chainFamily: "evm",
+        venue: null,
+      });
+    }
+
+    assertEvmWalletAddressMatches(secretKey, request.walletAddress);
+    const account = privateKeyToAccount(secretKey as `0x${string}`);
+    const txRequest: TransactionSerializable = {
+      to: request.to as `0x${string}`,
+      value: BigInt(request.value),
+      data: request.data as `0x${string}` | undefined,
+      gas: request.gasLimit ? BigInt(request.gasLimit) : 21000n,
+      nonce: request.nonce,
+      gasPrice: BigInt(request.gasPrice),
+      chainId: request.chainId,
+    };
+    return account.signTransaction(txRequest);
   }
 
   /**


### PR DESCRIPTION
## Summary

Stacked on #169/#168/#165. Adds governed EVM swap execution and reconciliation over durable prepared intents.

- strict owning-agent execute routes under `/trade` and `/v1/trade`
- atomic prepared-intent claim and durable execution idempotency
- session-fenced wallet, chain, venue, digest, policy, signing-freeze, and fresh-simulation revalidation
- transactional spend reservation with definite-release vs unknown-retention semantics
- existing Steward EVM nonce infrastructure reused
- raw transaction signing contained inside the vault
- transaction hash derived and durably persisted before network submission
- explicit `not_attempted`, `rejected`, and ambiguous `unknown` outcomes
- no blind retry after ambiguous submission
- receipt/hash-based authoritative reconciliation
- failed sends excluded from transaction spend statistics

## Safety invariants

- execution uses only the persisted internally generated intent
- callers cannot supply target, calldata, transaction, nonce, owner, or raw transaction
- raw signed transactions never enter API responses, audits, or persisted intent metadata
- absent RPC/signing/simulation configuration fails closed
- expired/revoked/session-drift/wallet-drift/freeze/policy failures occur before signing
- unknown and submitted states retain spend; definitive rejection/revert releases exactly once
- persisted transaction identity survives post-submit bookkeeping failures

## Verification

Independent rerun:

- governed EVM prepare/execute/reconcile suite: 27 passed, 154 assertions
- transaction stats suite: 4 passed, 9 assertions
- monorepo typecheck/build: 26 tasks passed
- touched-file Biome and `git diff --check`: passed
- Codex findings fixed: repeated reconciliation release, post-submit bookkeeping classification, failed-send accounting
- final Codex review: no actionable defect

All RPC and adapter edges are deterministic mocks. No production configuration, deployment, live RPC, funding, or funds were used.

## Stack

Base: #169 / `feat/evm-prepared-intent-ledger`

— [sol-orch]
