### PR TITLE
feat(web+docs): neutral authority-plane positioning, remove enforcement overclaims

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,52 +1,36 @@
 # Steward
 
-auth + wallet infrastructure for autonomous agents. open source. self-hostable. policy enforced at the signing layer.
+Steward is the self-hostable authority plane for private enterprise agents. It gives agents scoped wallet and API capabilities without exposing secrets, routes sensitive actions through policy and human approval, and produces signed execution evidence. Bring your own agent runtime, cloud, and custodian.
 
 [![npm](https://img.shields.io/npm/v/@stwd/sdk)](https://www.npmjs.com/package/@stwd/sdk)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![API](https://img.shields.io/badge/API-live-brightgreen)](https://api.steward.fi)
 [![Docs](https://img.shields.io/badge/docs-steward.fi-blue)](https://docs.steward.fi)
 
----
+## what exists today
 
-## the problem
+Steward provides encrypted wallet and credential storage, authenticated multi-tenant APIs, policy evaluation and approval workflows, a credential-injecting proxy, operator freeze controls, and an HMAC-chained execution record. Wallet and API capabilities are the core. Trading venue packages are optional extensions.
 
-AI agents need wallet keys, API keys, database credentials. today these live as plaintext environment variables, one prompt injection away from exfiltration. no spending controls, no audit trail, no kill switch.
-
-existing embedded-wallet platforms were built for consumer apps, not agents. they're closed source, can't be self-hosted, charge per-transaction fees, and have no concept of policy enforcement or autonomous operation.
-
-## the solution
-
-Steward sits between agents and everything they access. four pillars:
-
-1. **vault.** AES-256-GCM encrypted keys. EVM (7 chains) + Solana. keys never exist in plaintext outside a signing operation.
-2. **policy engine.** 6 composable rule types evaluated before every action. spending limits, rate limits, address whitelists, time windows, auto-approve thresholds.
-3. **auth.** passkeys, email magic links, SIWE, Google/Discord OAuth. JWT sessions with refresh token rotation.
-4. **proxy gateway.** credential injection for any third-party API. agents never see raw keys. full audit trail.
-
-## how it works in practice
-
-an agent (or the app delegating to one) holds only a Steward URL and a scoped JWT. it never holds private keys. when it wants to act, its LLM sends a signing request; the policy engine evaluates the request against the agent's policy; the vault signs or refuses; an audit event is emitted either way.
-
-the key never reaches the model, and compromised app code cannot exceed the policy. spend caps, allowlists, rate limits, and an atomic freeze switch are enforced in the vault itself, before any signature is produced.
-
----
+| Area | Current implementation |
+|---|---|
+| **Custody** | Wallet keys are encrypted at rest under an operator-held root. An optional KMS envelope is available, with an adapter seam for third-party custody providers. |
+| **Policy boundary** | Policy is evaluated in API route handlers before governed routes call signing operations. The vault primitive does not independently enforce policy. |
+| **Approvals** | Sensitive actions can be held for human review, then approved or denied through API and UI workflows. |
+| **Execution record** | Steward writes a machine-readable, HMAC-chained audit record. Offline, independently verifiable Ed25519 evidence bundles are roadmap work. |
+| **Deployment** | Self-hosted Docker and embedded PGLite modes are available. Operators bring their own runtime, cloud, and custody configuration. |
 
 ## architecture
 
+```text
+agent runtime              Steward authority plane             target systems
+┌─────────────┐      ┌────────────────────────────┐      ┌──────────────────┐
+│ scoped token│─────>│ auth + route policy checks │─────>│ chains and APIs  │
+│ no raw keys │      │ approvals                  │      │ custody provider │
+│ no API keys │      │ encrypted wallet/secrets   │      └──────────────────┘
+└─────────────┘      │ credential proxy           │
+                     │ HMAC-chained audit record  │
+                     └────────────────────────────┘
 ```
-agent / app              Steward                        third-party
-┌─────────────┐    ┌──────────────────────┐    ┌──────────────────┐
-│ STEWARD_URL │───>│ auth (JWT/passkey)   │    │ chains (EVM/Sol) │
-│ STEWARD_JWT │    │ policy engine        │───>│ OpenAI/Anthropic │
-│             │    │ wallet vault         │    │ any API          │
-│ no API keys │    │ secret vault         │    └──────────────────┘
-│ no priv keys│    │ proxy gateway        │
-└─────────────┘    │ audit log            │
-                   └──────────────────────┘
-```
-
----
 
 ## quick start
 
@@ -67,7 +51,7 @@ const steward = new StewardClient({
 const agent = await steward.createWallet("trading-bot", "Trading Bot");
 console.log(agent.walletAddresses); // { evm: "0x...", solana: "..." }
 
-// sign a transaction (policy-enforced)
+// request signing through a policy-evaluating API route
 const result = await steward.signTransaction("trading-bot", {
   to: "0xRecipient",
   value: "10000000000000000", // 0.01 ETH
@@ -193,7 +177,7 @@ full list in [`.env.example`](.env.example). see [deployment guide](docs/deploym
 - **open source.** MIT licensed, full source available.
 - **self-hostable.** docker, embedded PGLite, or hosted.
 - **full auth surface.** passkey / email / SIWE / OAuth.
-- **policy enforcement at the vault layer.** 6 composable rule types evaluated before any signature is produced. compromised app code cannot bypass.
+- **policy evaluation in governed API routes.** 6 composable rule types are evaluated before those routes call the vault. The vault primitive is not an independent policy boundary.
 - **agent-native.** built from day one for autonomous operation: approval queues, audit log, kill-switch.
 - **credential proxy.** inject keys for any third-party API. agents never see raw secrets.
 
@@ -203,7 +187,7 @@ full list in [`.env.example`](.env.example). see [deployment guide](docs/deploym
 
 Ethereum, Base, Polygon, Arbitrum, BSC, Gnosis, Base Sepolia, BSC Testnet, Solana, Bitcoin,
 Monero (self-hosted deployments; official `monero-wallet-rpc` sidecar against remote public
-nodes — keys never leave your host, policy enforced before every relay)
+nodes: keys never leave your host, policy evaluated by the relay route)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Steward
 
-Steward is the self-hostable authority plane for private enterprise agents. It gives agents scoped wallet and API capabilities without exposing secrets, routes sensitive actions through policy and human approval, and produces signed execution evidence. Bring your own agent runtime, cloud, and custodian.
+Steward is the self-hostable authority plane for private enterprise agents. It gives agents scoped wallet and API capabilities without exposing secrets, routes sensitive actions through policy and human approval, and records execution evidence. Bring your own agent runtime, cloud, and custodian.
 
 [![npm](https://img.shields.io/npm/v/@stwd/sdk)](https://www.npmjs.com/package/@stwd/sdk)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)

--- a/VISION.md
+++ b/VISION.md
@@ -1,12 +1,14 @@
 # Steward Vision
 
+Steward is the self-hostable authority plane for private enterprise agents. It gives agents scoped wallet and API capabilities without exposing secrets, routes sensitive actions through policy and human approval, and produces signed execution evidence. Bring your own agent runtime, cloud, and custodian.
+
 ## Mission
 
-Every agent deserves a bank account it can't be robbed of.
+Every agent deserves scoped authority without direct access to the underlying secrets.
 
 AI agents are managing real money, signing real transactions, calling paid APIs. The infrastructure securing those operations is a `.env` file with plaintext keys. One prompt injection, one leaked log, one compromised dependency, and everything is gone.
 
-Steward exists to make that impossible. Not through trust, through architecture: encrypted vaults, policy enforcement at the signing layer, credential isolation at the proxy layer. Agents operate autonomously within constraints their operators define. No exceptions, no workarounds.
+Steward reduces exposure by combining encrypted vaults, policy evaluation in API route handlers before signing, and credential isolation at the proxy layer. Agents operate within constraints their operators define. A signer-level authorization boundary is on the roadmap.
 
 ---
 
@@ -18,7 +20,7 @@ Four pillars. Each solves a distinct problem. Together they form a complete secu
 AES-256-GCM encrypted key storage. Per-agent encryption keys derived from master password + agent ID via PBKDF2. Private keys are decrypted ephemerally for signing and never returned to callers. Supports EVM (7 chains) and Solana (Ed25519).
 
 ### Policy Engine
-Composable rules evaluated synchronously before every signing operation. Six types: spending limits (per-tx, daily, weekly), approved address lists, rate limits, time windows, auto-approve thresholds, and allowed chains. Hard policies reject. Soft policies (auto-approve-threshold) queue for human review. All policies must pass for a transaction to be signed. The engine is stateless; spend and rate context are pre-fetched and injected.
+Composable rules evaluated synchronously by Steward API routes before they call the vault for governed signing operations. Six types: spending limits (per-tx, daily, weekly), approved address lists, rate limits, time windows, auto-approve thresholds, and allowed chains. Hard policies reject. Soft policies (auto-approve-threshold) queue for human review. A failed policy evaluation stops the governed API request before signing. The engine is stateless; spend and rate context are pre-fetched and injected.
 
 ### Auth
 User authentication with passkeys (WebAuthn), email magic links, Sign-In With Ethereum, and OAuth (Google, Discord). JWT sessions with refresh token rotation. Users are global identities that can belong to multiple tenants. On first login, users get an auto-provisioned embedded wallet.
@@ -41,11 +43,11 @@ Six capabilities define the space. Most platforms cover two or three:
 | **Open source** | Audit the code. Fork it. No black boxes. |
 | **Self-hostable** | Run it on your infra. No vendor dependency. No token required. |
 | **Auth** | User login (passkeys, email, OAuth, SIWE). Not just API keys. |
-| **Policy enforcement** | Rules enforced at the vault, not the application layer. |
+| **Policy evaluation** | Rules evaluated in Steward API signing routes before the vault is called. |
 | **Agent-native** | Built for autonomous operation, not retrofitted from consumer auth. |
 | **Credential proxy** | Manages all sensitive credentials, not just wallet keys. |
 
-Steward checks all six. Existing platforms each miss critical boxes — most are closed and hosted-only, depend on an external MPC network, lack auth or policy enforcement, or expose only low-level signing primitives without auth, policies, or a credential proxy.
+Steward checks all six. Existing platforms each miss critical boxes: most are closed and hosted-only, depend on an external MPC network, lack auth or policy enforcement, or expose only low-level signing primitives without auth, policies, or a credential proxy.
 
 ---
 
@@ -96,4 +98,4 @@ Same API surface. Same guarantees. Write the integration once.
 
 **No token required.** Steward is infrastructure, not a protocol. No governance token, no staking requirement, no on-chain dependency for basic operations.
 
-**Policy is architecture, not advice.** Rules are enforced at the cryptographic signing layer. Not in middleware. Not in application code. Not as suggestions. If the policy says no, the vault won't sign it.
+**Policy is first-class.** Steward API signing routes evaluate policies before calling the vault, and a failed evaluation stops that request before key decryption. Moving authorization into a signer-level boundary is a roadmap item.

--- a/VISION.md
+++ b/VISION.md
@@ -1,6 +1,6 @@
 # Steward Vision
 
-Steward is the self-hostable authority plane for private enterprise agents. It gives agents scoped wallet and API capabilities without exposing secrets, routes sensitive actions through policy and human approval, and produces signed execution evidence. Bring your own agent runtime, cloud, and custodian.
+Steward is the self-hostable authority plane for private enterprise agents. It gives agents scoped wallet and API capabilities without exposing secrets, routes sensitive actions through policy and human approval, and records execution evidence. Bring your own agent runtime, cloud, and custodian.
 
 ## Mission
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -1,13 +1,11 @@
 ---
 title: "what is Steward?"
-description: "the policy-bound signing layer for autonomous AI agents. encrypted wallets, credential management, audit trail, embeddable React UI."
+description: "a self-hostable authority plane for private enterprise agents, with scoped wallet and API capabilities, policy, approvals, and execution records."
 ---
 
-Steward is a governance layer for autonomous AI agents. it provides
-encrypted wallet management, credential storage, policy enforcement, API
-proxy with credential injection, and audit logging, so agents can interact
-with blockchains and third-party APIs without ever touching raw private keys
-or API credentials.
+Steward is the self-hostable authority plane for private enterprise agents. It gives agents scoped wallet and API capabilities without exposing secrets, routes sensitive actions through policy and human approval, and produces an HMAC-chained execution record. Bring your own agent runtime, cloud, and custodian.
+
+Today, keys are stored encrypted under an operator-held root, with an optional KMS envelope and a seam for third-party custody providers. Policy is evaluated in API route handlers before governed signing operations call the vault. Steward records requests, decisions, and effects in an HMAC-chained audit log. Offline independently verifiable evidence bundles are roadmap work.
 
 <CardGroup cols={2}>
   <Card title="wallet vault" icon="vault" href="/concepts/wallet-vault">
@@ -20,7 +18,7 @@ or API credentials.
     declarative policies evaluated before every action. spending limits, rate limits, address whitelists, time windows, all configurable per agent.
   </Card>
   <Card title="API proxy" icon="shuffle" href="/concepts/proxy-gateway">
-    all third-party API calls flow through Steward. credentials injected at the proxy, costs tracked, everything audited.
+    configured third-party API calls flow through Steward. credentials are injected at the proxy, with cost tracking and audit events.
   </Card>
 </CardGroup>
 
@@ -48,11 +46,12 @@ STEWARD_PROXY_URL=http://steward-proxy:8080
 STEWARD_AGENT_TOKEN=stwd_jwt_...
 ```
 
-every API call and every transaction flows through Steward, where it is authenticated, policy-checked, logged, and metered before being forwarded with the real credentials injected.
+configured API calls and wallet actions enter Steward through authenticated routes. governed routes evaluate policy and approvals before calling signing or proxy operations, then record the result.
 
 ## who uses Steward?
 
-- **constrained trading agents.** an agent trading Hyperliquid perps under a tight Steward policy: long-only, major pairs, $100 per position, 5x max leverage, $300 daily open budget. the LLM never holds the key.
+- **private enterprise agents.** agents using scoped wallet or API capabilities for treasury operations, vendor payments, internal systems, and other sensitive workflows.
+- **constrained trading agents.** optional venue packages support bounded financial workflows without making trading the core platform.
 - **production multi-agent deployments.** platforms managing dozens of agents across a node fleet with on-chain transactions on Base mainnet.
 - **agent developers** building autonomous agents that need wallet access or API credential management.
 - **platform operators** running multi-tenant agent hosting who need security, cost control, and compliance.
@@ -60,7 +59,7 @@ every API call and every transaction flows through Steward, where it is authenti
 
 ## what's new
 
-Steward has grown beyond wallet management into a full agent infrastructure platform:
+Current authority-plane capabilities include:
 
 - **API proxy.** route any HTTP API call through Steward for credential injection, cost tracking, and audit logging.
 - **webhook events.** get notified on `tx.pending`, `tx.signed`, `spend.threshold`, `policy.violation`, and more.

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -44,9 +44,9 @@ const metadataBase = (() => {
 
 export const metadata: Metadata = {
   metadataBase,
-  title: "Steward: the open authority and execution layer for AI agents",
+  title: "Steward: self-hostable authority plane for enterprise agents",
   description:
-    "The open-source authority and execution layer for AI agents. Steward holds wallets and credentials, enforces policy before every privileged action, routes approvals, executes across APIs and financial rails, and produces a complete audit trail.",
+    "Steward gives private enterprise agents scoped wallet and API capabilities without exposing secrets, routes sensitive actions through policy and human approval, and records execution evidence. Bring your own runtime, cloud, and custodian.",
   icons: {
     icon: [
       { url: "/favicon.ico", sizes: "32x32" },
@@ -57,9 +57,9 @@ export const metadata: Metadata = {
   },
   manifest: "/site.webmanifest",
   openGraph: {
-    title: "Steward: the open authority and execution layer for AI agents",
+    title: "Steward: self-hostable authority plane for enterprise agents",
     description:
-      "Open-source authority and execution for AI agents. Any model, any runtime, any cloud, any chain, on infrastructure you control.",
+      "A self-hostable authority plane for private enterprise agents. Bring your own agent runtime, cloud, and custodian.",
     type: "website",
     images: [
       {

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -57,21 +57,22 @@ function Hero() {
               className="hero-rise mt-6 text-lg text-text-secondary max-w-lg leading-relaxed text-pretty"
               style={{ animationDelay: "0.3s" }}
             >
-              The open authority and execution layer for AI agents. Policy before every privileged
-              action. Human approval when it matters. A full audit trail, always.
+              The self-hostable authority plane for private enterprise agents. Give agents scoped
+              wallet and API capabilities without exposing secrets, with policy checks, human
+              approval, and an HMAC-chained execution record.
             </p>
 
             <div
               className="hero-fade mt-6 flex flex-wrap items-center gap-x-3 gap-y-1.5 font-mono text-[0.7rem] uppercase tracking-wider text-text-tertiary"
               style={{ animationDelay: "0.42s" }}
             >
-              <span>Any model</span>
+              <span>Your runtime</span>
               <span className="text-border">/</span>
-              <span>Any runtime</span>
+              <span>Your cloud</span>
               <span className="text-border">/</span>
-              <span>Any chain</span>
+              <span>Your custodian</span>
               <span className="text-border">/</span>
-              <span className={accent}>Your infrastructure</span>
+              <span className={accent}>Your authority plane</span>
             </div>
 
             <div
@@ -105,12 +106,12 @@ function Hero() {
               <CodeBlock
                 filename="agent.ts"
                 language="typescript"
-                code={`// Agent asks. Steward decides.
-const swap = await steward.signTransaction(agentId, {
-  to: "0xUniswapRouter",
+                code={`// Agent asks. Steward evaluates.
+const payment = await steward.signTransaction(agentId, {
+  to: "0xApprovedVendor",
   value: "500000000000000000",
 })
-// -> policy check -> sign -> "0x9f3c..."
+// -> route policy check -> sign -> "0x9f3c..."
 
 // Over the daily cap: held for a human
 // -> { status: "pending_approval" }
@@ -222,13 +223,13 @@ function PipelineSection() {
     {
       idx: "03",
       label: "Simulation + execution",
-      body: "The action is simulated, then signed and executed across the target rail.",
+      body: "Where supported, the action is simulated, then signed and executed across the target rail.",
       decision: true,
     },
     {
       idx: "04",
       label: "Audit + reconciliation",
-      body: "Every decision and effect lands in an append-only, tamper-evident record.",
+      body: "Requests, decisions, and effects land in an HMAC-chained, machine-readable record.",
       decision: false,
     },
   ];
@@ -248,8 +249,9 @@ function PipelineSection() {
           </Reveal>
           <Reveal delay={0.1}>
             <p className="mt-6 text-text-secondary leading-relaxed max-w-md text-pretty">
-              Every privileged action crosses the same boundary. The model never needs custody of
-              the underlying authority. It asks, and Steward decides, executes, and records.
+              Privileged actions enter Steward through authenticated API routes. Those routes
+              evaluate policy and approvals before calling the relevant signing or proxy operation,
+              then record the request, decision, and effect.
             </p>
           </Reveal>
           <Reveal delay={0.18}>
@@ -322,12 +324,12 @@ function ExecutionSection() {
     {
       tag: "evm.swap",
       title: "Governed EVM swap",
-      body: "Prepare, execute, reconcile with simulation gates and durable intents. A dropped connection never means a lost or double transaction.",
+      body: "Prepare and execute an EVM swap through policy-aware API routes, with durable intents for reconciliation.",
     },
     {
       tag: "trade.session",
       title: "Venue-scoped trading",
-      body: "Hyperliquid and Polymarket sessions with spend caps and a freeze switch. Authority is bounded to a venue, a size, and a window.",
+      body: "Optional Hyperliquid and Polymarket packages support venue-scoped sessions, spend caps, and operator controls.",
     },
     {
       tag: "proxy.inject",
@@ -342,7 +344,7 @@ function ExecutionSection() {
     {
       tag: "sign.freeze",
       title: "Atomic freeze",
-      body: "One kill switch halts all signing across every wallet and session, instantly, without redeploying the agent.",
+      body: "An operator freeze control can halt signing without redeploying the agent.",
     },
     {
       tag: "audit.log",
@@ -360,14 +362,14 @@ function ExecutionSection() {
               Execution
             </p>
             <h2 className="font-display text-hero-sm font-extrabold tracking-[-0.02em] leading-[1.02] text-balance">
-              From API access to financial execution.{" "}
-              <span className={accent}>One policy plane.</span>
+              Wallet and API authority. <span className={accent}>One operator plane.</span>
             </h2>
           </Reveal>
           <Reveal delay={0.1}>
             <p className="mt-6 text-text-secondary leading-relaxed max-w-sm text-pretty">
-              These are not roadmap items. Signing, trading, proxying, and grants all run behind the
-              same boundary and land in the same audit trail.
+              Today Steward provides wallet signing, credential proxying, capability grants,
+              approval workflows, and an HMAC-chained audit record. Trading packages are optional
+              extensions.
             </p>
           </Reveal>
         </div>
@@ -456,13 +458,13 @@ const res = await openai.chat.completions.create({
             <h2 className="font-display text-hero-sm font-extrabold tracking-[-0.02em] leading-[1.02]">
               Ask for the action.
               <br />
-              <span className={accent}>Steward enforces it.</span>
+              <span className={accent}>Steward evaluates it.</span>
             </h2>
           </Reveal>
           <Reveal delay={0.15}>
             <p className="mt-6 text-text-secondary leading-relaxed text-pretty">
-              One TypeScript client for signing, trading, grants, and proxying. It works with any
-              agent framework and any model, because the authority lives in Steward, not the prompt.
+              One TypeScript client for signing, grants, proxying, and optional trading extensions.
+              Bring your own agent framework, model, cloud, and custody integration.
             </p>
           </Reveal>
           <Reveal delay={0.25}>
@@ -501,7 +503,7 @@ function AgentsSection() {
     },
     {
       t: "Bounded financial permissions",
-      d: "Caps, allowlists, and windows are enforced in the vault, not suggested in a prompt.",
+      d: "Caps, allowlists, and windows are evaluated in Steward API routes before those routes call the vault.",
     },
     {
       t: "Ambiguous-outcome recovery",
@@ -572,8 +574,8 @@ function SpecsSection() {
       <div className="max-w-[1400px] mx-auto">
         <Reveal>
           <p className="text-text-secondary text-sm mb-8 max-w-2xl">
-            Built to enterprise security standards. Audited paths, encrypted at rest, fast enough to
-            sit in front of every call.
+            Designed for private enterprise deployments, with encrypted storage, explicit policy
+            paths, and operator-controlled infrastructure.
           </p>
         </Reveal>
         <div className="grid grid-cols-2 lg:grid-cols-4 border-t border-l border-border-subtle">
@@ -602,13 +604,17 @@ function ComparisonSection() {
   const rows = [
     { feature: "Source", steward: "Open source, MIT", vendor: "Closed, proprietary" },
     { feature: "Hosting", steward: "Self-host or managed", vendor: "Hosted only" },
-    { feature: "Keys and data", steward: "You own them", vendor: "On their infrastructure" },
+    {
+      feature: "Custody",
+      steward: "Operator-held root, optional KMS envelope",
+      vendor: "Vendor-defined",
+    },
     {
       feature: "Policy engine",
-      steward: "Enforced before every action",
-      vendor: "Bolted on, if any",
+      steward: "Evaluated in API action routes",
+      vendor: "Vendor-defined",
     },
-    { feature: "Agents", steward: "First-class actors", vendor: "Human-paced pricing" },
+    { feature: "Agent runtime", steward: "Bring your own", vendor: "Vendor-dependent" },
     {
       feature: "Pricing",
       steward: "No per-transaction toll",
@@ -630,8 +636,9 @@ function ComparisonSection() {
           </Reveal>
           <Reveal delay={0.1}>
             <p className="mt-6 text-text-secondary leading-relaxed max-w-sm text-pretty">
-              Closed custody vendors hold your keys, meter your growth, and give you no way out.
-              Steward is the same authority on infrastructure you control.
+              Steward is self-hostable and vendor-neutral. It stores keys encrypted under an
+              operator-held root, supports an optional KMS envelope, and exposes a seam for
+              third-party custody providers.
             </p>
           </Reveal>
         </div>
@@ -728,8 +735,9 @@ function OpenSourceSection() {
         </Reveal>
         <Reveal delay={0.1}>
           <p className="mt-7 text-lg text-text-secondary leading-relaxed max-w-xl mx-auto text-pretty">
-            MIT-licensed, self-hostable, and vendor-neutral, with no per-transaction toll. Own your
-            keys, your policies, your data, and your audit trail, on infrastructure you control.
+            MIT-licensed, self-hostable, and vendor-neutral, with no per-transaction toll. Choose
+            your runtime, cloud, and custodian while keeping policy, approvals, and execution
+            records under operator control.
           </p>
         </Reveal>
         <Reveal delay={0.16}>
@@ -783,7 +791,7 @@ function Footer() {
             <span className="font-display text-base font-bold tracking-tight">steward</span>
           </div>
           <p className="text-xs text-text-tertiary mt-1.5">
-            The open authority and execution layer for AI agents.
+            The self-hostable authority plane for private enterprise agents.
           </p>
         </div>
         <div className="flex items-center gap-6 text-sm text-text-secondary">


### PR DESCRIPTION
## Summary

- reposition the landing page, metadata, README, and docs introduction around Steward as a self-hostable authority plane for private enterprise agents
- preserve the shipped landing-page layout and hero headline while shifting body copy from trading toward scoped wallet and API capabilities, policy, approvals, and execution records
- describe current custody, policy enforcement, and audit boundaries plainly
- retain trading and venue packages as optional extensions rather than the primary frame
- correct VISION.md claims that policy is enforced in the vault or cryptographic signing layer, and label signer-level authorization as roadmap work

## Before / after samples

**Hero subhead**

Before:
> The open authority and execution layer for AI agents. Policy before every privileged action. Human approval when it matters. A full audit trail, always.

After:
> The self-hostable authority plane for private enterprise agents. Give agents scoped wallet and API capabilities without exposing secrets, with policy checks, human approval, and an HMAC-chained execution record.

**Policy boundary**

Before:
> Rules are enforced at the cryptographic signing layer. ... If the policy says no, the vault won't sign it.

After:
> Steward API signing routes evaluate policies before calling the vault, and a failed evaluation stops that request before key decryption. Moving authorization into a signer-level boundary is a roadmap item.

**Custody**

Before:
> You own [the keys].

After:
> Wallet keys are encrypted at rest under an operator-held root. An optional KMS envelope is available, with an adapter seam for third-party custody providers.

## Verification

- `bun run typecheck` passed: 26 package builds succeeded, followed by `tsc --noEmit --project web/tsconfig.json`
- `bunx @biomejs/biome check web/src/app/page.tsx web/src/app/layout.tsx` passed
- `git diff --check` passed
- Codex review found one P2 wording issue around signed evidence; resolved by using `HMAC-chained execution record` in live landing and docs copy while keeping independently verifiable bundles explicitly labeled as roadmap

[sol-orch]
