### PR TITLE
feat(audit): Ed25519 checkpoints + offline-verifiable evidence bundles

### DIFF
--- a/packages/api/src/__tests__/audit-bundle-signing-gate.test.ts
+++ b/packages/api/src/__tests__/audit-bundle-signing-gate.test.ts
@@ -1,0 +1,78 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { closeDb, getDb, tenants } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { Hono } from "hono";
+import { writeAuditEvent } from "../services/audit";
+import { resetCheckpointSignerCache } from "../services/audit-checkpoint";
+import type { AppVariables } from "../services/context";
+
+const TENANT_ID = "audit-bundle-gate-tenant";
+let auditRoutesModule: Awaited<typeof import("../routes/audit")>;
+let priorNodeEnv: string | undefined;
+
+describe("audit bundle signing-key gate", () => {
+  beforeAll(async () => {
+    priorNodeEnv = process.env.NODE_ENV;
+    process.env.STEWARD_PGLITE_MEMORY = "true";
+    process.env.STEWARD_AUDIT_HMAC_KEY = "audit-bundle-gate-hmac-key-0123456789abcdef";
+    process.env.STEWARD_MASTER_PASSWORD = "audit-bundle-gate-master-password";
+    delete process.env.STEWARD_AUDIT_SIGNING_KEY;
+    resetCheckpointSignerCache();
+
+    const { db, client } = await createPGLiteDb("memory://");
+    setPGLiteOverride(db, async () => {
+      await client.close();
+    });
+    auditRoutesModule = await import("../routes/audit");
+    await getDb()
+      .insert(tenants)
+      .values([{ id: TENANT_ID, name: "Audit Bundle Gate", apiKeyHash: "audit-bundle-gate" }]);
+    await writeAuditEvent({
+      tenantId: TENANT_ID,
+      actorType: "user",
+      action: "wallet.action.1",
+      metadata: {},
+    });
+  }, 120_000);
+
+  afterAll(async () => {
+    await closeDb();
+    if (priorNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = priorNodeEnv;
+    delete process.env.STEWARD_PGLITE_MEMORY;
+    delete process.env.STEWARD_AUDIT_HMAC_KEY;
+    delete process.env.STEWARD_MASTER_PASSWORD;
+    resetCheckpointSignerCache();
+  });
+
+  function app() {
+    const a = new Hono<{ Variables: AppVariables }>();
+    a.use("*", async (c, next) => {
+      c.set("authType", "session-jwt");
+      c.set("tenantRole", "admin");
+      c.set("tenantId", TENANT_ID);
+      c.set("sessionMfaVerifiedAt", Date.now());
+      await next();
+    });
+    a.route("/audit", auditRoutesModule.auditRoutes);
+    return a;
+  }
+
+  it("returns 503 with a hard error in production when signing key is unset", async () => {
+    process.env.NODE_ENV = "production";
+    const res = await app().request("/audit/bundle");
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain("STEWARD_AUDIT_SIGNING_KEY");
+  });
+
+  it("returns 503 disabled-with-warning in development when signing key is unset", async () => {
+    process.env.NODE_ENV = "development";
+    const res = await app().request("/audit/bundle");
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error.toLowerCase()).toContain("disabled");
+  });
+});

--- a/packages/api/src/__tests__/audit-bundle.integration.test.ts
+++ b/packages/api/src/__tests__/audit-bundle.integration.test.ts
@@ -1,0 +1,205 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { generateKeyPairSync } from "node:crypto";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { auditCheckpoints, closeDb, getDb, tenants } from "@stwd/db";
+import { eq } from "drizzle-orm";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { Hono } from "hono";
+import { writeAuditEvent } from "../services/audit";
+import { resetCheckpointSignerCache } from "../services/audit-checkpoint";
+import type { AppVariables } from "../services/context";
+
+const TENANT_ID = "audit-bundle-tenant";
+const OTHER_TENANT_ID = "audit-bundle-other-tenant";
+const VERIFIER = join(import.meta.dir, "..", "..", "..", "..", "scripts", "verify-evidence-bundle.mjs");
+
+let auditRoutesModule: Awaited<typeof import("../routes/audit")>;
+let tmpDir: string;
+
+interface BundleEvent {
+  seq: number;
+  prevHash: string;
+  hmac: string;
+  action: string;
+}
+interface Bundle {
+  version: number;
+  tenantId: string;
+  range: { from: number; to: number; includesHead: boolean };
+  canonicalizationSpec: string;
+  events: BundleEvent[];
+  checkpoint: { payload: Record<string, unknown>; signature: string; publicKey: string };
+  generatedAt: string;
+}
+
+function runVerifier(bundle: unknown): { code: number; stdout: string; stderr: string } {
+  const file = join(tmpDir, `bundle-${Math.random().toString(36).slice(2)}.json`);
+  writeFileSync(file, JSON.stringify(bundle));
+  const res = spawnSync("node", [VERIFIER, file], { encoding: "utf8" });
+  return { code: res.status ?? -1, stdout: res.stdout ?? "", stderr: res.stderr ?? "" };
+}
+
+describe("audit evidence bundle endpoint + offline verifier", () => {
+  beforeAll(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "audit-bundle-"));
+    process.env.STEWARD_PGLITE_MEMORY = "true";
+    process.env.STEWARD_AUDIT_HMAC_KEY = "audit-bundle-hmac-key-0123456789abcdef0123";
+    process.env.STEWARD_MASTER_PASSWORD = "audit-bundle-master-password";
+
+    // Deterministic Ed25519 signing key for the run (PKCS#8 PEM path).
+    const { privateKey } = generateKeyPairSync("ed25519");
+    process.env.STEWARD_AUDIT_SIGNING_KEY = privateKey
+      .export({ format: "pem", type: "pkcs8" })
+      .toString();
+    resetCheckpointSignerCache();
+
+    const { db, client } = await createPGLiteDb("memory://");
+    setPGLiteOverride(db, async () => {
+      await client.close();
+    });
+    auditRoutesModule = await import("../routes/audit");
+
+    await getDb()
+      .insert(tenants)
+      .values([
+        { id: TENANT_ID, name: "Audit Bundle", apiKeyHash: "audit-bundle" },
+        { id: OTHER_TENANT_ID, name: "Audit Bundle Other", apiKeyHash: "audit-bundle-other" },
+      ]);
+
+    for (let i = 1; i <= 4; i++) {
+      await writeAuditEvent({
+        tenantId: TENANT_ID,
+        actorType: "user",
+        actorId: `user-${i}`,
+        action: `wallet.action.${i}`,
+        resourceType: "wallet",
+        resourceId: `wallet-${i}`,
+        requestId: `req-${i}`,
+        metadata: { i },
+      });
+    }
+    // A second tenant's event that must never leak into TENANT_ID's bundle.
+    await writeAuditEvent({
+      tenantId: OTHER_TENANT_ID,
+      actorType: "user",
+      action: "wallet.action.other",
+      metadata: { other: true },
+    });
+  }, 120_000);
+
+  afterAll(async () => {
+    await closeDb();
+    if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+    delete process.env.STEWARD_PGLITE_MEMORY;
+    delete process.env.STEWARD_AUDIT_HMAC_KEY;
+    delete process.env.STEWARD_MASTER_PASSWORD;
+    delete process.env.STEWARD_AUDIT_SIGNING_KEY;
+    resetCheckpointSignerCache();
+  });
+
+  function app(tenantId = TENANT_ID) {
+    const a = new Hono<{ Variables: AppVariables }>();
+    a.use("*", async (c, next) => {
+      c.set("authType", "session-jwt");
+      c.set("tenantRole", "admin");
+      c.set("tenantId", tenantId);
+      c.set("sessionMfaVerifiedAt", Date.now());
+      await next();
+    });
+    a.route("/audit", auditRoutesModule.auditRoutes);
+    return a;
+  }
+
+  async function fetchBundle(query = "", tenantId = TENANT_ID): Promise<Bundle> {
+    const res = await app(tenantId).request(`/audit/bundle${query}`);
+    expect(res.status).toBe(200);
+    return (await res.json()) as Bundle;
+  }
+
+  it("returns a well-formed bundle for the full chain", async () => {
+    const bundle = await fetchBundle();
+    expect(bundle.version).toBe(1);
+    expect(bundle.tenantId).toBe(TENANT_ID);
+    expect(bundle.events).toHaveLength(4);
+    expect(bundle.events.map((e) => e.seq)).toEqual([1, 2, 3, 4]);
+    expect(bundle.range.includesHead).toBe(true);
+    expect(bundle.canonicalizationSpec).toContain("HMAC-SHA256");
+    expect(bundle.checkpoint.publicKey).toContain("BEGIN PUBLIC KEY");
+    expect(bundle.checkpoint.payload.tenantId).toBe(TENANT_ID);
+    expect(bundle.checkpoint.payload.seq).toBe(4);
+    // Head binding: last event hmac equals signed headHmac.
+    expect(bundle.events[3].hmac).toBe(bundle.checkpoint.payload.headHmac as string);
+    // No cross-tenant leakage.
+    expect(JSON.stringify(bundle)).not.toContain("wallet.action.other");
+  });
+
+  it("does not leak other tenants and scopes the checkpoint per tenant", async () => {
+    const other = await fetchBundle("", OTHER_TENANT_ID);
+    expect(other.tenantId).toBe(OTHER_TENANT_ID);
+    expect(other.events).toHaveLength(1);
+    expect(other.events[0].action).toBe("wallet.action.other");
+    expect(other.checkpoint.payload.tenantId).toBe(OTHER_TENANT_ID);
+  });
+
+  it("supports a partial range that does not include the head", async () => {
+    const bundle = await fetchBundle("?from=1&to=2");
+    expect(bundle.events.map((e) => e.seq)).toEqual([1, 2]);
+    expect(bundle.range.includesHead).toBe(false);
+    // Checkpoint still commits to the FULL chain head (seq 4).
+    expect(bundle.checkpoint.payload.seq).toBe(4);
+  });
+
+  it("persists a checkpoint row on bundle generation", async () => {
+    await fetchBundle();
+    const rows = await getDb()
+      .select()
+      .from(auditCheckpoints)
+      .where(eq(auditCheckpoints.tenantId, TENANT_ID));
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+    expect(rows[0].signature.length).toBeGreaterThan(0);
+    expect(rows[0].publicKey).toContain("BEGIN PUBLIC KEY");
+  });
+
+  it("PASSES the standalone offline verifier for a genuine bundle", async () => {
+    const bundle = await fetchBundle();
+    const { code, stdout } = runVerifier(bundle);
+    expect(stdout).toContain("PASS");
+    expect(code).toBe(0);
+  });
+
+  it("FAILS the verifier at the right seq when an event byte is flipped", async () => {
+    const bundle = await fetchBundle();
+    // Flip a hex nibble in event seq=3's prevHash to break linkage there.
+    const target = bundle.events[2];
+    const first = target.prevHash[0] === "a" ? "b" : "a";
+    target.prevHash = first + target.prevHash.slice(1);
+    const { code, stderr } = runVerifier(bundle);
+    expect(code).toBe(1);
+    expect(stderr).toContain("FAIL");
+    expect(stderr).toContain("seq 3");
+  });
+
+  it("FAILS the verifier when the checkpoint payload is tampered", async () => {
+    const bundle = await fetchBundle();
+    bundle.checkpoint.payload.expectedCount =
+      (bundle.checkpoint.payload.expectedCount as number) + 1;
+    const { code, stderr } = runVerifier(bundle);
+    expect(code).toBe(1);
+    expect(stderr).toContain("signature does not verify");
+  });
+
+  it("FAILS the verifier when the signed head no longer matches the last event", async () => {
+    const bundle = await fetchBundle();
+    // Corrupt the last event's hmac (keeps signature valid, breaks head binding).
+    const last = bundle.events[bundle.events.length - 1];
+    const first = last.hmac[0] === "a" ? "b" : "a";
+    last.hmac = first + last.hmac.slice(1);
+    const { code, stderr } = runVerifier(bundle);
+    expect(code).toBe(1);
+    // Either linkage (if it were mid-chain) or head-binding; here it's the head.
+    expect(stderr).toContain("FAIL");
+  });
+});

--- a/packages/api/src/__tests__/audit-bundle.integration.test.ts
+++ b/packages/api/src/__tests__/audit-bundle.integration.test.ts
@@ -5,8 +5,8 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { auditCheckpoints, closeDb, getDb, tenants } from "@stwd/db";
-import { eq } from "drizzle-orm";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { writeAuditEvent } from "../services/audit";
 import { resetCheckpointSignerCache } from "../services/audit-checkpoint";
@@ -14,7 +14,15 @@ import type { AppVariables } from "../services/context";
 
 const TENANT_ID = "audit-bundle-tenant";
 const OTHER_TENANT_ID = "audit-bundle-other-tenant";
-const VERIFIER = join(import.meta.dir, "..", "..", "..", "..", "scripts", "verify-evidence-bundle.mjs");
+const VERIFIER = join(
+  import.meta.dir,
+  "..",
+  "..",
+  "..",
+  "..",
+  "scripts",
+  "verify-evidence-bundle.mjs",
+);
 
 let auditRoutesModule: Awaited<typeof import("../routes/audit")>;
 let tmpDir: string;
@@ -180,6 +188,30 @@ describe("audit evidence bundle endpoint + offline verifier", () => {
     expect(code).toBe(1);
     expect(stderr).toContain("FAIL");
     expect(stderr).toContain("seq 3");
+  });
+
+  it("FAILS the verifier when an event CONTENT field is altered (no HMAC key needed)", async () => {
+    const bundle = await fetchBundle();
+    // Change a content field (action) while leaving hmac/prevHash intact. This
+    // must be caught by the signed content digest, not linkage.
+    bundle.events[1].action = `${bundle.events[1].action}-tampered`;
+    const { code, stderr } = runVerifier(bundle);
+    expect(code).toBe(1);
+    expect(stderr).toContain("content digest");
+  });
+
+  it("FAILS the verifier when the unsigned includesHead flag is flipped to hide a bad head", async () => {
+    const bundle = await fetchBundle();
+    // Attacker corrupts the head event's hmac AND flips the advisory flag to
+    // false, hoping to skip head binding. Head inclusion is derived from the
+    // SIGNED seq, so this must still FAIL.
+    const last = bundle.events[bundle.events.length - 1];
+    const first = last.hmac[0] === "a" ? "b" : "a";
+    last.hmac = first + last.hmac.slice(1);
+    bundle.range.includesHead = false;
+    const { code, stderr } = runVerifier(bundle);
+    expect(code).toBe(1);
+    expect(stderr).toContain("FAIL");
   });
 
   it("FAILS the verifier when the checkpoint payload is tampered", async () => {

--- a/packages/api/src/__tests__/audit-checkpoint.test.ts
+++ b/packages/api/src/__tests__/audit-checkpoint.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "bun:test";
+import { generateKeyPairSync, sign as edSign } from "node:crypto";
+import {
+  AuditSigningKeyError,
+  canonicalCheckpointBytes,
+  type CheckpointPayload,
+  createCheckpointSigner,
+  parseSigningKey,
+  publicKeyPem,
+  verifyCheckpoint,
+} from "../services/audit-checkpoint";
+
+function ed25519() {
+  const { privateKey } = generateKeyPairSync("ed25519");
+  const pkcs8Pem = privateKey.export({ format: "pem", type: "pkcs8" }).toString();
+  const der = privateKey.export({ format: "der", type: "pkcs8" }) as Buffer;
+  // The raw 32-byte seed is the last 32 bytes of the PKCS#8 DER (16-byte prefix).
+  const seed = Uint8Array.prototype.slice.call(der, der.length - 32);
+  return { privateKey, pkcs8Pem, seedHex: Buffer.from(seed).toString("hex") };
+}
+
+const basePayload: CheckpointPayload = {
+  v: 1,
+  tenantId: "tenant-ckpt",
+  seq: 42,
+  headHmac: "ab".repeat(32),
+  expectedCount: 42,
+  floorSeq: 0,
+  timestamp: "2026-01-01T00:00:00.000Z",
+  softwareVersion: "0.0.0-test",
+};
+
+describe("audit checkpoint signer", () => {
+  it("signs and self-verifies with a PKCS#8 PEM key", () => {
+    const { pkcs8Pem } = ed25519();
+    const signer = createCheckpointSigner(pkcs8Pem);
+    const signed = signer.sign(basePayload);
+    expect(signed.publicKey).toContain("BEGIN PUBLIC KEY");
+    expect(signed.payload).toEqual(basePayload);
+    expect(verifyCheckpoint(signed)).toBe(true);
+  });
+
+  it("accepts a raw 32-byte hex seed and produces the same key as its PEM", () => {
+    const { pkcs8Pem, seedHex } = ed25519();
+    const fromPem = createCheckpointSigner(pkcs8Pem);
+    const fromSeed = createCheckpointSigner(seedHex);
+    // Same private key -> identical public key + identical signature bytes.
+    expect(fromSeed.publicKeyPem).toBe(fromPem.publicKeyPem);
+    expect(fromSeed.sign(basePayload).signature).toBe(fromPem.sign(basePayload).signature);
+  });
+
+  it("accepts a base64 seed", () => {
+    const { seedHex } = ed25519();
+    const seedB64 = Buffer.from(seedHex, "hex").toString("base64");
+    const signer = createCheckpointSigner(seedB64);
+    expect(verifyCheckpoint(signer.sign(basePayload))).toBe(true);
+  });
+
+  it("canonical bytes are key-order independent and whitespace-free", () => {
+    const bytes = canonicalCheckpointBytes(basePayload);
+    const text = Buffer.from(bytes).toString("utf8");
+    expect(text).not.toContain(" ");
+    expect(text).not.toContain("\n");
+    // Keys sorted: expectedCount before floorSeq before headHmac ...
+    const parsed = JSON.parse(text);
+    expect(Object.keys(parsed)).toEqual([...Object.keys(parsed)].sort());
+    // Reordering the source object must not change the canonical bytes.
+    const reordered: CheckpointPayload = {
+      softwareVersion: basePayload.softwareVersion,
+      timestamp: basePayload.timestamp,
+      floorSeq: basePayload.floorSeq,
+      expectedCount: basePayload.expectedCount,
+      headHmac: basePayload.headHmac,
+      seq: basePayload.seq,
+      tenantId: basePayload.tenantId,
+      v: 1,
+    };
+    expect(Buffer.from(canonicalCheckpointBytes(reordered)).toString("utf8")).toBe(text);
+  });
+
+  it("verifyCheckpoint fails when the payload is mutated after signing", () => {
+    const { pkcs8Pem } = ed25519();
+    const signed = createCheckpointSigner(pkcs8Pem).sign(basePayload);
+    const tampered = {
+      ...signed,
+      payload: { ...signed.payload, expectedCount: signed.payload.expectedCount + 1 },
+    };
+    expect(verifyCheckpoint(tampered)).toBe(false);
+  });
+
+  it("verifyCheckpoint fails when the signature is from a different key", () => {
+    const a = ed25519();
+    const b = ed25519();
+    const signed = createCheckpointSigner(a.pkcs8Pem).sign(basePayload);
+    // Re-sign with key B but keep A's published public key.
+    const forgedSig = edSign(null, canonicalCheckpointBytes(basePayload), b.privateKey);
+    const forged = { ...signed, signature: Buffer.from(forgedSig).toString("base64") };
+    expect(verifyCheckpoint(forged)).toBe(false);
+  });
+
+  describe("bad key inputs throw AuditSigningKeyError", () => {
+    it("empty key", () => {
+      expect(() => parseSigningKey("")).toThrow(AuditSigningKeyError);
+    });
+
+    it("garbage string", () => {
+      expect(() => parseSigningKey("not-a-key-at-all")).toThrow(AuditSigningKeyError);
+    });
+
+    it("wrong-length hex seed", () => {
+      expect(() => parseSigningKey("abcd")).toThrow(AuditSigningKeyError);
+    });
+
+    it("a non-Ed25519 PEM (RSA) is rejected", () => {
+      const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+      const rsaPem = privateKey.export({ format: "pem", type: "pkcs8" }).toString();
+      expect(() => parseSigningKey(rsaPem)).toThrow(AuditSigningKeyError);
+    });
+
+    it("a malformed PEM is rejected", () => {
+      expect(() =>
+        parseSigningKey("-----BEGIN PRIVATE KEY-----\nnope\n-----END PRIVATE KEY-----"),
+      ).toThrow(AuditSigningKeyError);
+    });
+  });
+
+  it("publicKeyPem derives the same public key from PEM and seed inputs", () => {
+    const { pkcs8Pem, seedHex } = ed25519();
+    expect(publicKeyPem(parseSigningKey(seedHex))).toBe(publicKeyPem(parseSigningKey(pkcs8Pem)));
+  });
+});

--- a/packages/api/src/__tests__/audit-checkpoint.test.ts
+++ b/packages/api/src/__tests__/audit-checkpoint.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "bun:test";
-import { generateKeyPairSync, sign as edSign } from "node:crypto";
+import { sign as edSign, generateKeyPairSync } from "node:crypto";
 import {
   AuditSigningKeyError,
-  canonicalCheckpointBytes,
+  type CheckpointEventContent,
   type CheckpointPayload,
+  canonicalCheckpointBytes,
   createCheckpointSigner,
+  eventsContentDigest,
   parseSigningKey,
   publicKeyPem,
   verifyCheckpoint,
@@ -28,7 +30,28 @@ const basePayload: CheckpointPayload = {
   floorSeq: 0,
   timestamp: "2026-01-01T00:00:00.000Z",
   softwareVersion: "0.0.0-test",
+  eventsDigest: "",
+  eventsFromSeq: 0,
+  eventsToSeq: 0,
 };
+
+function ev(seq: number, over: Partial<CheckpointEventContent> = {}): CheckpointEventContent {
+  return {
+    tenantId: "tenant-ckpt",
+    seq,
+    actorType: "user",
+    actorId: `user-${seq}`,
+    action: `act.${seq}`,
+    resourceType: "wallet",
+    resourceId: `w-${seq}`,
+    metadata: { seq },
+    ipAddress: null,
+    userAgent: null,
+    requestId: `r-${seq}`,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    ...over,
+  };
+}
 
 describe("audit checkpoint signer", () => {
   it("signs and self-verifies with a PKCS#8 PEM key", () => {
@@ -73,6 +96,9 @@ describe("audit checkpoint signer", () => {
       headHmac: basePayload.headHmac,
       seq: basePayload.seq,
       tenantId: basePayload.tenantId,
+      eventsToSeq: basePayload.eventsToSeq,
+      eventsFromSeq: basePayload.eventsFromSeq,
+      eventsDigest: basePayload.eventsDigest,
       v: 1,
     };
     expect(Buffer.from(canonicalCheckpointBytes(reordered)).toString("utf8")).toBe(text);
@@ -127,5 +153,37 @@ describe("audit checkpoint signer", () => {
   it("publicKeyPem derives the same public key from PEM and seed inputs", () => {
     const { pkcs8Pem, seedHex } = ed25519();
     expect(publicKeyPem(parseSigningKey(seedHex))).toBe(publicKeyPem(parseSigningKey(pkcs8Pem)));
+  });
+});
+
+describe("eventsContentDigest", () => {
+  it("returns empty string for no events", () => {
+    expect(eventsContentDigest([])).toBe("");
+  });
+
+  it("is deterministic for the same ordered events", () => {
+    const list = [ev(1), ev(2), ev(3)];
+    expect(eventsContentDigest(list)).toBe(eventsContentDigest([ev(1), ev(2), ev(3)]));
+    expect(eventsContentDigest(list)).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("changes when ANY content field changes", () => {
+    const base = eventsContentDigest([ev(1), ev(2)]);
+    expect(eventsContentDigest([ev(1), ev(2, { action: "different" })])).not.toBe(base);
+    expect(eventsContentDigest([ev(1), ev(2, { metadata: { seq: 999 } })])).not.toBe(base);
+    expect(eventsContentDigest([ev(1), ev(2, { actorId: "x" })])).not.toBe(base);
+    expect(eventsContentDigest([ev(1), ev(2, { createdAt: "2030-01-01T00:00:00.000Z" })])).not.toBe(
+      base,
+    );
+  });
+
+  it("is order-sensitive (reordering breaks the digest)", () => {
+    expect(eventsContentDigest([ev(1), ev(2)])).not.toBe(eventsContentDigest([ev(2), ev(1)]));
+  });
+
+  it("detects insertion/removal of an event", () => {
+    const base = eventsContentDigest([ev(1), ev(2), ev(3)]);
+    expect(eventsContentDigest([ev(1), ev(2)])).not.toBe(base);
+    expect(eventsContentDigest([ev(1), ev(2), ev(3), ev(4)])).not.toBe(base);
   });
 });

--- a/packages/api/src/routes/audit.ts
+++ b/packages/api/src/routes/audit.ts
@@ -5,11 +5,24 @@
  * Mount: app.route("/audit", auditRoutes)
  */
 
-import { proxyAuditLog } from "@stwd/db";
+import { auditCheckpoints, proxyAuditLog } from "@stwd/db";
 import { and, count, desc, eq, gte, inArray, lte, type SQL, sql } from "drizzle-orm";
 import { type Context, Hono } from "hono";
-import { verifyAuditChain } from "../services/audit";
 import {
+  type AuditBundleData,
+  type BundleEvent,
+  readAuditBundleData,
+  verifyAuditChain,
+} from "../services/audit";
+import {
+  AuditSigningKeyError,
+  type CheckpointPayload,
+  getCheckpointSigner,
+  isCheckpointSigningConfigured,
+  type SignedCheckpoint,
+} from "../services/audit-checkpoint";
+import {
+  API_VERSION,
   type ApiResponse,
   type AppVariables,
   agents,
@@ -24,6 +37,19 @@ export const auditRoutes = new Hono<{ Variables: AppVariables }>();
 const MAX_AUDIT_PAGE = 5_000;
 const MAX_AUDIT_OFFSET = 1_000_000;
 const MAX_AUDIT_VERIFY_RANGE = 10_000;
+// An evidence bundle inlines every event in the range as JSON; cap it so a
+// single request can't materialize an unbounded chain in memory.
+const MAX_AUDIT_BUNDLE_EVENTS = 10_000;
+// The canonicalization the offline verifier must reproduce for each event.
+// Bumped only alongside a verifier change.
+const BUNDLE_CANONICALIZATION_SPEC =
+  "steward-audit-hmac-chain/v1: hmac = HMAC-SHA256(key, prev_hash_bytes || " +
+  "canonical_json(event)); canonical_json sorts object keys, drops whitespace, " +
+  "encodes null for absent fields and ISO-8601 for timestamps. Offline verifier " +
+  "checks event linkage (each prevHash === prior hmac) + head == checkpoint, and " +
+  "the Ed25519 signature over the canonical checkpoint payload. Per-row HMAC " +
+  "recomputation requires the operator's secret key and is NOT part of offline " +
+  "verification.";
 const MAX_AUDIT_EXPORT_RANGE_MS = 31 * 24 * 60 * 60 * 1000;
 const AUDIT_READ_MFA_MAX_AGE_MS = 5 * 60_000;
 const MAX_AUDIT_METADATA_FILTERS = 5;
@@ -198,6 +224,16 @@ function rowsFromExecute<T>(result: unknown): T[] {
     return (result as { rows: T[] }).rows;
   }
   return [];
+}
+
+// Node's `Buffer` is shadowed by @cloudflare/workers-types in this package, so
+// decode hex to a Uint8Array for the bytea column by hand.
+function hexToBytes(hex: string): Uint8Array {
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
 }
 
 /** Resolve the set of agentIds belonging to the authenticated tenant. */
@@ -816,6 +852,150 @@ auditRoutes.post("/verify", async (c) => {
           ? undefined
           : "Partial verification is anchored to the stored predecessor hash and is not proof that earlier audit rows are intact.",
     },
+  });
+});
+
+// ─── GET /audit/bundle ────────────────────────────────────────────────────
+//
+// Offline-verifiable evidence bundle. Returns the tenant's audit events in the
+// requested seq range plus an Ed25519-signed checkpoint over the chain head, so
+// an third-party auditor can verify the export offline (no Steward access, no
+// secret) with scripts/verify-evidence-bundle.mjs. The signature commits to the
+// head HMAC; the event list lets the verifier confirm linkage and that the head
+// row matches the signed checkpoint.
+auditRoutes.get("/bundle", async (c) => {
+  const tenantId = c.get("tenantId");
+
+  if (!isCheckpointSigningConfigured()) {
+    if (process.env.NODE_ENV === "production") {
+      return c.json<ApiResponse>(
+        {
+          ok: false,
+          error:
+            "Offline evidence bundles require STEWARD_AUDIT_SIGNING_KEY. Generate an " +
+            "Ed25519 key (openssl genpkey -algorithm ed25519) and configure it.",
+        },
+        503,
+      );
+    }
+    console.warn(
+      "⚠️ [audit] STEWARD_AUDIT_SIGNING_KEY not set — /audit/bundle disabled. " +
+        "Set it to produce offline-verifiable evidence bundles.",
+    );
+    return c.json<ApiResponse>(
+      {
+        ok: false,
+        error:
+          "Offline evidence bundles are disabled: STEWARD_AUDIT_SIGNING_KEY is not " +
+          "configured (development).",
+      },
+      503,
+    );
+  }
+
+  const parsedFromSeq = parsePositiveIntegerParam(
+    c.req.query("from"),
+    "from",
+    1,
+    Number.MAX_SAFE_INTEGER,
+  );
+  if (!parsedFromSeq.ok) {
+    return c.json<ApiResponse>({ ok: false, error: parsedFromSeq.error }, 400);
+  }
+  const fromSeq = parsedFromSeq.value;
+  const toRaw = c.req.query("to");
+  const parsedToSeq = toRaw
+    ? parsePositiveIntegerParam(toRaw, "to", fromSeq, Number.MAX_SAFE_INTEGER)
+    : ({ ok: true, value: undefined } as const);
+  if (!parsedToSeq.ok) {
+    return c.json<ApiResponse>({ ok: false, error: parsedToSeq.error }, 400);
+  }
+  const requestedToSeq = parsedToSeq.value;
+  const toSeq = requestedToSeq ?? fromSeq + MAX_AUDIT_BUNDLE_EVENTS - 1;
+  if (toSeq < fromSeq) {
+    return c.json<ApiResponse>({ ok: false, error: "to must be greater than from" }, 400);
+  }
+  if (toSeq - fromSeq + 1 > MAX_AUDIT_BUNDLE_EVENTS) {
+    return c.json<ApiResponse>(
+      { ok: false, error: `audit bundle range must not exceed ${MAX_AUDIT_BUNDLE_EVENTS} events` },
+      400,
+    );
+  }
+
+  let bundleData: AuditBundleData;
+  try {
+    bundleData = await readAuditBundleData(tenantId, fromSeq, toSeq);
+  } catch (err) {
+    console.error(`[audit] bundle read failed for tenant ${tenantId}:`, err);
+    return c.json<ApiResponse>({ ok: false, error: "Failed to read audit chain" }, 500);
+  }
+
+  const { head, events } = bundleData;
+
+  // Sign a checkpoint over the CHAIN head (the newest event overall), not the
+  // bundle's upper bound — the checkpoint attests to the full head so a partial
+  // export can still be tied to the operator's committed head. The verifier only
+  // enforces head==checkpoint when the export INCLUDES the head event.
+  let checkpointPayload: CheckpointPayload;
+  let signed: SignedCheckpoint;
+  try {
+    const signer = getCheckpointSigner();
+    const nowIso = new Date().toISOString();
+    checkpointPayload = {
+      v: 1,
+      tenantId,
+      seq: head?.expectedSeq ?? 0,
+      headHmac: head?.headHmac ?? "",
+      expectedCount: head?.expectedCount ?? 0,
+      floorSeq: head?.floorSeq ?? 0,
+      timestamp: nowIso,
+      softwareVersion: API_VERSION,
+    };
+    signed = signer.sign(checkpointPayload);
+  } catch (err) {
+    if (err instanceof AuditSigningKeyError) {
+      return c.json<ApiResponse>({ ok: false, error: err.message }, 503);
+    }
+    console.error(`[audit] checkpoint signing failed for tenant ${tenantId}:`, err);
+    return c.json<ApiResponse>({ ok: false, error: "Failed to sign checkpoint" }, 500);
+  }
+
+  // Persist the checkpoint (append-only provenance). Best-effort: a persistence
+  // failure must not deny the auditor their signed bundle, which is fully
+  // self-contained. head may be null for a tenant with zero events.
+  if (head) {
+    try {
+      await db.insert(auditCheckpoints).values({
+        tenantId,
+        seq: checkpointPayload.seq,
+        headHmac: hexToBytes(checkpointPayload.headHmac),
+        payload: checkpointPayload as unknown as Record<string, unknown>,
+        signature: signed.signature,
+        publicKey: signed.publicKey,
+      });
+    } catch (err) {
+      console.error(`[audit] checkpoint persistence failed for tenant ${tenantId}:`, err);
+    }
+  }
+
+  const bundleEvents: BundleEvent[] = events;
+  const includesHead =
+    head != null &&
+    bundleData.bundleHeadSeq != null &&
+    bundleData.bundleHeadSeq === head.expectedSeq;
+
+  return c.json({
+    version: 1 as const,
+    tenantId,
+    range: { from: fromSeq, to: toSeq, includesHead },
+    canonicalizationSpec: BUNDLE_CANONICALIZATION_SPEC,
+    events: bundleEvents,
+    checkpoint: {
+      payload: signed.payload,
+      signature: signed.signature,
+      publicKey: signed.publicKey,
+    },
+    generatedAt: new Date().toISOString(),
   });
 });
 

--- a/packages/api/src/routes/audit.ts
+++ b/packages/api/src/routes/audit.ts
@@ -16,7 +16,9 @@ import {
 } from "../services/audit";
 import {
   AuditSigningKeyError,
+  type CheckpointEventContent,
   type CheckpointPayload,
+  eventsContentDigest,
   getCheckpointSigner,
   isCheckpointSigningConfigured,
   type SignedCheckpoint,
@@ -936,6 +938,25 @@ auditRoutes.get("/bundle", async (c) => {
   // bundle's upper bound — the checkpoint attests to the full head so a partial
   // export can still be tied to the operator's committed head. The verifier only
   // enforces head==checkpoint when the export INCLUDES the head event.
+  // Content commitment over EVERY exported event's canonical fields (not just
+  // the chain pointers). Signing this authenticates each event to an offline
+  // auditor who lacks the HMAC key: any post-export field mutation breaks the
+  // signature. The verifier recomputes this digest independently.
+  const digestEvents: CheckpointEventContent[] = events.map((ev) => ({
+    tenantId,
+    seq: ev.seq,
+    actorType: ev.actorType,
+    actorId: ev.actorId,
+    action: ev.action,
+    resourceType: ev.resourceType,
+    resourceId: ev.resourceId,
+    metadata: ev.metadata,
+    ipAddress: ev.ipAddress,
+    userAgent: ev.userAgent,
+    requestId: ev.requestId,
+    createdAt: ev.createdAt,
+  }));
+
   let checkpointPayload: CheckpointPayload;
   let signed: SignedCheckpoint;
   try {
@@ -950,6 +971,9 @@ auditRoutes.get("/bundle", async (c) => {
       floorSeq: head?.floorSeq ?? 0,
       timestamp: nowIso,
       softwareVersion: API_VERSION,
+      eventsDigest: eventsContentDigest(digestEvents),
+      eventsFromSeq: events.length > 0 ? events[0].seq : 0,
+      eventsToSeq: events.length > 0 ? events[events.length - 1].seq : 0,
     };
     signed = signer.sign(checkpointPayload);
   } catch (err) {

--- a/packages/api/src/services/audit-checkpoint.ts
+++ b/packages/api/src/services/audit-checkpoint.ts
@@ -31,6 +31,45 @@
 
 import { createPrivateKey, createPublicKey, type KeyObject, sign, verify } from "node:crypto";
 
+// This package is typechecked with @cloudflare/workers-types in scope, whose
+// `Buffer` shadows Node's and lacks `concat` / "base64". We therefore avoid
+// `Buffer` entirely and work with `Uint8Array` + the tiny encoders below.
+
+function hexToBytes(hex: string): Uint8Array {
+  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
+  if (clean.length % 2 !== 0) throw new Error("hex string has odd length");
+  const out = new Uint8Array(clean.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = Number.parseInt(clean.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+  return btoa(binary);
+}
+
+function base64ToBytes(value: string): Uint8Array {
+  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+  const binary = atob(normalized);
+  const out = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i);
+  return out;
+}
+
+function utf8ToBytes(str: string): Uint8Array {
+  return new TextEncoder().encode(str);
+}
+
+function concatBytes(a: Uint8Array, b: Uint8Array): Uint8Array {
+  const out = new Uint8Array(a.length + b.length);
+  out.set(a, 0);
+  out.set(b, a.length);
+  return out;
+}
+
 /** Canonical checkpoint payload. Field order here is NOT authoritative — the
  * signed bytes come from `canonicalCheckpointBytes`, which sorts keys. */
 export interface CheckpointPayload {
@@ -68,12 +107,13 @@ export interface SignedCheckpoint {
  * change to a field (or key ordering) changes the signed bytes, so a verifier
  * that reconstructs it independently detects any post-signing mutation.
  */
-export function canonicalCheckpointBytes(payload: CheckpointPayload): Buffer {
+export function canonicalCheckpointBytes(payload: CheckpointPayload): Uint8Array {
   const ordered: Record<string, unknown> = {};
-  for (const key of Object.keys(payload).sort()) {
-    ordered[key] = (payload as Record<string, unknown>)[key];
+  const source = payload as unknown as Record<string, unknown>;
+  for (const key of Object.keys(source).sort()) {
+    ordered[key] = source[key];
   }
-  return Buffer.from(JSON.stringify(ordered), "utf8");
+  return utf8ToBytes(JSON.stringify(ordered));
 }
 
 class AuditSigningKeyError extends Error {
@@ -90,34 +130,31 @@ const ED25519_SEED_LEN = 32;
 // (SEQUENCE { INTEGER 0, SEQUENCE { OID 1.3.101.112 }, OCTET STRING { OCTET
 // STRING <32 bytes> } }). Prepending this to a raw seed yields a DER a
 // KeyObject can import — lets us accept bare 32-byte seeds with no new deps.
-const PKCS8_ED25519_SEED_PREFIX = Buffer.from(
-  "302e020100300506032b657004220420",
-  "hex",
-);
+const PKCS8_ED25519_SEED_PREFIX = hexToBytes("302e020100300506032b657004220420");
 
-function seedToPkcs8Der(seed: Buffer): Buffer {
-  return Buffer.concat([PKCS8_ED25519_SEED_PREFIX, seed]);
+function seedToPkcs8Der(seed: Uint8Array): Uint8Array {
+  return concatBytes(PKCS8_ED25519_SEED_PREFIX, seed);
 }
 
 function looksLikePem(value: string): boolean {
   return value.includes("-----BEGIN");
 }
 
-function tryDecodeHex(value: string): Buffer | null {
+function tryDecodeHex(value: string): Uint8Array | null {
   const trimmed = value.trim();
   if (trimmed.length === ED25519_SEED_LEN * 2 && /^[0-9a-fA-F]+$/.test(trimmed)) {
-    return Buffer.from(trimmed, "hex");
+    return hexToBytes(trimmed);
   }
   return null;
 }
 
-function tryDecodeBase64Seed(value: string): Buffer | null {
+function tryDecodeBase64Seed(value: string): Uint8Array | null {
   const trimmed = value.trim();
   // Base64 (or base64url) of a 32-byte seed is 43 chars (no pad) or 44 (padded).
   if (!/^[A-Za-z0-9+/_-]+={0,2}$/.test(trimmed)) return null;
-  let decoded: Buffer;
+  let decoded: Uint8Array;
   try {
-    decoded = Buffer.from(trimmed.replace(/-/g, "+").replace(/_/g, "/"), "base64");
+    decoded = base64ToBytes(trimmed);
   } catch {
     return null;
   }
@@ -158,7 +195,14 @@ export function parseSigningKey(raw: string): KeyObject {
       );
     }
     try {
-      key = createPrivateKey({ key: seedToPkcs8Der(seed), format: "der", type: "pkcs8" });
+      // Node accepts a Uint8Array here at runtime; the DER key-input type is
+      // narrowed to Buffer, which @cloudflare/workers-types shadows in this
+      // package, so widen through unknown.
+      key = createPrivateKey({
+        key: seedToPkcs8Der(seed) as unknown as string,
+        format: "der",
+        type: "pkcs8",
+      });
     } catch (err) {
       throw new AuditSigningKeyError(
         `STEWARD_AUDIT_SIGNING_KEY seed could not be imported: ${(err as Error).message}`,
@@ -201,7 +245,7 @@ export function createCheckpointSigner(rawKey: string): AuditCheckpointSigner {
       const signature = sign(null, bytes, privateKey);
       return {
         payload,
-        signature: signature.toString("base64"),
+        signature: bytesToBase64(new Uint8Array(signature)),
         publicKey: pubPem,
       };
     },
@@ -261,7 +305,7 @@ export function verifyCheckpoint(checkpoint: SignedCheckpoint): boolean {
       null,
       canonicalCheckpointBytes(checkpoint.payload),
       pub,
-      Buffer.from(checkpoint.signature, "base64"),
+      base64ToBytes(checkpoint.signature),
     );
   } catch {
     return false;

--- a/packages/api/src/services/audit-checkpoint.ts
+++ b/packages/api/src/services/audit-checkpoint.ts
@@ -1,0 +1,269 @@
+/**
+ * Ed25519 audit checkpoint signer.
+ *
+ * The per-tenant audit chain (services/audit.ts) is tamper-evident but keyed
+ * with a SYMMETRIC HMAC secret: only the operator (who holds
+ * STEWARD_AUDIT_HMAC_KEY) can verify it. An third-party auditor cannot
+ * independently confirm the chain without being handed that secret — which
+ * would also let them forge it.
+ *
+ * A checkpoint fixes this. At bundle time we sign a small, canonical statement
+ * about the chain head with an Ed25519 PRIVATE key (STEWARD_AUDIT_SIGNING_KEY)
+ * whose PUBLIC key can be published freely. Anyone holding only the public key
+ * can verify:
+ *   - the operator asserted "at time T, tenant X's chain head was seq=N with
+ *     hmac=H, containing `expectedCount` events above `floorSeq`",
+ *   - and that assertion has not been altered.
+ *
+ * Combined with the exported event list (whose linkage an auditor recomputes
+ * locally — see scripts/verify-evidence-bundle.mjs), this proves the exported
+ * set is exactly the set the operator committed to at signing time.
+ *
+ * WHAT A CHECKPOINT DOES NOT PROVE: it does not prevent an operator who holds
+ * BOTH the HMAC key and the signing key from constructing a self-consistent but
+ * fabricated history and then signing it. The Ed25519 signature raises the bar
+ * from "trust the operator's secret HMAC" to "trust the operator's published,
+ * append-only, third-partyly-witnessable checkpoints"; anchoring beyond that
+ * (third-party timestamping / transparency log) is explicitly out of scope for v1.
+ *
+ * Zero new dependencies: uses node:crypto Ed25519 primitives.
+ */
+
+import { createPrivateKey, createPublicKey, type KeyObject, sign, verify } from "node:crypto";
+
+/** Canonical checkpoint payload. Field order here is NOT authoritative — the
+ * signed bytes come from `canonicalCheckpointBytes`, which sorts keys. */
+export interface CheckpointPayload {
+  /** Schema version of the checkpoint payload. */
+  v: 1;
+  /** Tenant whose chain this checkpoint commits to. */
+  tenantId: string;
+  /** Sequence number of the chain head at checkpoint time. */
+  seq: number;
+  /** Hex-encoded HMAC of the head event. */
+  headHmac: string;
+  /** Number of live events at/above `floorSeq` committed by this checkpoint. */
+  expectedCount: number;
+  /** Retention floor: events at or below this seq have been archived+dropped. */
+  floorSeq: number;
+  /** ISO-8601 timestamp the checkpoint was produced. */
+  timestamp: string;
+  /** Software version that produced the checkpoint (provenance breadcrumb). */
+  softwareVersion: string;
+}
+
+export interface SignedCheckpoint {
+  payload: CheckpointPayload;
+  /** Base64 Ed25519 signature over `canonicalCheckpointBytes(payload)`. */
+  signature: string;
+  /** SPKI PEM of the Ed25519 public key (safe to publish). */
+  publicKey: string;
+}
+
+/**
+ * Deterministic canonical JSON encoding of a checkpoint payload.
+ *
+ * Keys are sorted; there is no insignificant whitespace. This is the EXACT byte
+ * sequence that gets signed and that the offline verifier must reconstruct. Any
+ * change to a field (or key ordering) changes the signed bytes, so a verifier
+ * that reconstructs it independently detects any post-signing mutation.
+ */
+export function canonicalCheckpointBytes(payload: CheckpointPayload): Buffer {
+  const ordered: Record<string, unknown> = {};
+  for (const key of Object.keys(payload).sort()) {
+    ordered[key] = (payload as Record<string, unknown>)[key];
+  }
+  return Buffer.from(JSON.stringify(ordered), "utf8");
+}
+
+class AuditSigningKeyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AuditSigningKeyError";
+  }
+}
+
+export { AuditSigningKeyError };
+
+const ED25519_SEED_LEN = 32;
+// PKCS#8 DER prefix for an Ed25519 private key carrying a raw 32-byte seed.
+// (SEQUENCE { INTEGER 0, SEQUENCE { OID 1.3.101.112 }, OCTET STRING { OCTET
+// STRING <32 bytes> } }). Prepending this to a raw seed yields a DER a
+// KeyObject can import — lets us accept bare 32-byte seeds with no new deps.
+const PKCS8_ED25519_SEED_PREFIX = Buffer.from(
+  "302e020100300506032b657004220420",
+  "hex",
+);
+
+function seedToPkcs8Der(seed: Buffer): Buffer {
+  return Buffer.concat([PKCS8_ED25519_SEED_PREFIX, seed]);
+}
+
+function looksLikePem(value: string): boolean {
+  return value.includes("-----BEGIN");
+}
+
+function tryDecodeHex(value: string): Buffer | null {
+  const trimmed = value.trim();
+  if (trimmed.length === ED25519_SEED_LEN * 2 && /^[0-9a-fA-F]+$/.test(trimmed)) {
+    return Buffer.from(trimmed, "hex");
+  }
+  return null;
+}
+
+function tryDecodeBase64Seed(value: string): Buffer | null {
+  const trimmed = value.trim();
+  // Base64 (or base64url) of a 32-byte seed is 43 chars (no pad) or 44 (padded).
+  if (!/^[A-Za-z0-9+/_-]+={0,2}$/.test(trimmed)) return null;
+  let decoded: Buffer;
+  try {
+    decoded = Buffer.from(trimmed.replace(/-/g, "+").replace(/_/g, "/"), "base64");
+  } catch {
+    return null;
+  }
+  return decoded.length === ED25519_SEED_LEN ? decoded : null;
+}
+
+/**
+ * Parse STEWARD_AUDIT_SIGNING_KEY into an Ed25519 private KeyObject. Accepts:
+ *   - PKCS#8 PEM ("-----BEGIN PRIVATE KEY-----")
+ *   - raw 32-byte seed as hex (64 chars)
+ *   - raw 32-byte seed as base64 / base64url
+ *
+ * Throws AuditSigningKeyError on anything that isn't one of those, or that
+ * parses but isn't an Ed25519 key.
+ */
+export function parseSigningKey(raw: string): KeyObject {
+  const value = (raw ?? "").trim();
+  if (value.length === 0) {
+    throw new AuditSigningKeyError("STEWARD_AUDIT_SIGNING_KEY is empty");
+  }
+
+  let key: KeyObject;
+  if (looksLikePem(value)) {
+    try {
+      key = createPrivateKey({ key: value, format: "pem" });
+    } catch (err) {
+      throw new AuditSigningKeyError(
+        `STEWARD_AUDIT_SIGNING_KEY is not a valid PEM private key: ${(err as Error).message}`,
+      );
+    }
+  } else {
+    const seed = tryDecodeHex(value) ?? tryDecodeBase64Seed(value);
+    if (!seed) {
+      throw new AuditSigningKeyError(
+        "STEWARD_AUDIT_SIGNING_KEY must be a PKCS#8 PEM, a 32-byte hex seed (64 hex chars), " +
+          "or a 32-byte base64/base64url seed. Generate one with: " +
+          "openssl genpkey -algorithm ed25519 -out audit-signing.pem",
+      );
+    }
+    try {
+      key = createPrivateKey({ key: seedToPkcs8Der(seed), format: "der", type: "pkcs8" });
+    } catch (err) {
+      throw new AuditSigningKeyError(
+        `STEWARD_AUDIT_SIGNING_KEY seed could not be imported: ${(err as Error).message}`,
+      );
+    }
+  }
+
+  if (key.asymmetricKeyType !== "ed25519") {
+    throw new AuditSigningKeyError(
+      `STEWARD_AUDIT_SIGNING_KEY must be an Ed25519 key, got ${key.asymmetricKeyType ?? "unknown"}`,
+    );
+  }
+  return key;
+}
+
+/** SPKI PEM of the public half of an Ed25519 private key. */
+export function publicKeyPem(privateKey: KeyObject): string {
+  const pub = createPublicKey(privateKey);
+  return pub.export({ format: "pem", type: "spki" }).toString();
+}
+
+export interface AuditCheckpointSigner {
+  sign(payload: CheckpointPayload): SignedCheckpoint;
+  readonly publicKeyPem: string;
+}
+
+/**
+ * Build a signer from an explicit key string. Prefer `getCheckpointSigner`
+ * (env-backed, cached) in application code; this exists for tests and for the
+ * bundle route to construct a signer from configured env.
+ */
+export function createCheckpointSigner(rawKey: string): AuditCheckpointSigner {
+  const privateKey = parseSigningKey(rawKey);
+  const pubPem = publicKeyPem(privateKey);
+  return {
+    publicKeyPem: pubPem,
+    sign(payload: CheckpointPayload): SignedCheckpoint {
+      const bytes = canonicalCheckpointBytes(payload);
+      // Ed25519 uses `null` for the digest algorithm (PureEdDSA).
+      const signature = sign(null, bytes, privateKey);
+      return {
+        payload,
+        signature: signature.toString("base64"),
+        publicKey: pubPem,
+      };
+    },
+  };
+}
+
+let cachedSigner: AuditCheckpointSigner | null = null;
+let cachedSignerKeySource: string | null = null;
+
+/**
+ * Whether an audit signing key is configured. Callers (bundle route) use this
+ * to decide between hard-fail (production) and disabled-with-warning (dev).
+ */
+export function isCheckpointSigningConfigured(): boolean {
+  const env = process.env.STEWARD_AUDIT_SIGNING_KEY;
+  return typeof env === "string" && env.trim().length > 0;
+}
+
+/**
+ * Cached env-backed signer. Throws AuditSigningKeyError if
+ * STEWARD_AUDIT_SIGNING_KEY is unset or invalid — callers must gate on
+ * `isCheckpointSigningConfigured()` first if they want to handle absence
+ * gracefully.
+ */
+export function getCheckpointSigner(): AuditCheckpointSigner {
+  const env = process.env.STEWARD_AUDIT_SIGNING_KEY ?? "";
+  if (env.trim().length === 0) {
+    throw new AuditSigningKeyError(
+      "STEWARD_AUDIT_SIGNING_KEY is not configured. Generate one with: " +
+        "openssl genpkey -algorithm ed25519 -out audit-signing.pem",
+    );
+  }
+  if (cachedSigner && cachedSignerKeySource === env) {
+    return cachedSigner;
+  }
+  cachedSigner = createCheckpointSigner(env);
+  cachedSignerKeySource = env;
+  return cachedSigner;
+}
+
+/** Test hook: drop the cached signer so a changed env var takes effect. */
+export function resetCheckpointSignerCache(): void {
+  cachedSigner = null;
+  cachedSignerKeySource = null;
+}
+
+/**
+ * Verify a signed checkpoint with its embedded public key. Used by the online
+ * bundle path as a self-check; the authoritative third-party check is the
+ * standalone offline verifier.
+ */
+export function verifyCheckpoint(checkpoint: SignedCheckpoint): boolean {
+  try {
+    const pub = createPublicKey({ key: checkpoint.publicKey, format: "pem" });
+    if (pub.asymmetricKeyType !== "ed25519") return false;
+    return verify(
+      null,
+      canonicalCheckpointBytes(checkpoint.payload),
+      pub,
+      Buffer.from(checkpoint.signature, "base64"),
+    );
+  } catch {
+    return false;
+  }
+}

--- a/packages/api/src/services/audit-checkpoint.ts
+++ b/packages/api/src/services/audit-checkpoint.ts
@@ -29,7 +29,14 @@
  * Zero new dependencies: uses node:crypto Ed25519 primitives.
  */
 
-import { createPrivateKey, createPublicKey, type KeyObject, sign, verify } from "node:crypto";
+import {
+  createHash,
+  createPrivateKey,
+  createPublicKey,
+  type KeyObject,
+  sign,
+  verify,
+} from "node:crypto";
 
 // This package is typechecked with @cloudflare/workers-types in scope, whose
 // `Buffer` shadows Node's and lacks `concat` / "base64". We therefore avoid
@@ -70,6 +77,89 @@ function concatBytes(a: Uint8Array, b: Uint8Array): Uint8Array {
   return out;
 }
 
+function sha256Hex(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+/**
+ * The canonical CONTENT fields of one audit event, matching (field-for-field,
+ * name-for-name) the encoding that services/audit.ts commits to in the HMAC
+ * chain. The offline verifier reproduces this exact shape from the bundle so it
+ * can recompute the content digest WITHOUT the HMAC key.
+ */
+export interface CheckpointEventContent {
+  tenantId: string;
+  seq: number;
+  actorType: string;
+  actorId: string | null;
+  action: string;
+  resourceType: string | null;
+  resourceId: string | null;
+  metadata: Record<string, unknown>;
+  ipAddress: string | null;
+  userAgent: string | null;
+  requestId: string | null;
+  createdAt: string;
+}
+
+/** Recursively canonicalize a JSON value: sort keys, null for undefined. Mirrors
+ * `canonicalJsonValue` in services/audit.ts and the verifier. */
+function canonicalJsonValue(value: unknown): unknown {
+  if (value === undefined || value === null) return null;
+  if (Array.isArray(value)) return value.map((item) => canonicalJsonValue(item));
+  if (typeof value === "object") {
+    const ordered: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      ordered[key] = canonicalJsonValue((value as Record<string, unknown>)[key]);
+    }
+    return ordered;
+  }
+  return value;
+}
+
+/** Canonical byte encoding of one event's content. Uses snake_case field names
+ * to match the HMAC chain's canonicalization exactly. */
+export function canonicalEventContentBytes(ev: CheckpointEventContent): Uint8Array {
+  const fields = {
+    tenant_id: ev.tenantId,
+    seq: ev.seq,
+    actor_type: ev.actorType,
+    actor_id: ev.actorId ?? null,
+    action: ev.action,
+    resource_type: ev.resourceType ?? null,
+    resource_id: ev.resourceId ?? null,
+    metadata: ev.metadata ?? {},
+    ip_address: ev.ipAddress ?? null,
+    user_agent: ev.userAgent ?? null,
+    request_id: ev.requestId ?? null,
+    created_at: ev.createdAt,
+  };
+  return utf8ToBytes(JSON.stringify(canonicalJsonValue(fields)));
+}
+
+/**
+ * SHA-256 content commitment over an ordered list of events. Computed as a
+ * rolling hash: digest_0 = SHA-256("steward-audit-events/v1"); digest_i =
+ * SHA-256(digest_{i-1} || SHA-256(canonical_event_i)). Order-sensitive and
+ * content-sensitive, so any insertion, removal, reorder, or field mutation
+ * changes the result. Returns "" for an empty list. The verifier recomputes
+ * this identically from the bundle events.
+ */
+export function eventsContentDigest(events: CheckpointEventContent[]): string {
+  if (events.length === 0) return "";
+  // Work in hex strings end-to-end so we never touch the workers-types-shadowed
+  // Buffer. acc/leaf are 64-char hex; feeding them as utf8 to the next hash is
+  // fine as long as the verifier does the SAME thing (it does).
+  let acc = createHash("sha256").update("steward-audit-events/v1").digest("hex");
+  for (const ev of events) {
+    const leaf = createHash("sha256").update(canonicalEventContentBytes(ev)).digest("hex");
+    acc = createHash("sha256").update(acc).update(leaf).digest("hex");
+  }
+  return acc;
+}
+
+export { sha256Hex };
+
 /** Canonical checkpoint payload. Field order here is NOT authoritative — the
  * signed bytes come from `canonicalCheckpointBytes`, which sorts keys. */
 export interface CheckpointPayload {
@@ -89,6 +179,19 @@ export interface CheckpointPayload {
   timestamp: string;
   /** Software version that produced the checkpoint (provenance breadcrumb). */
   softwareVersion: string;
+  /**
+   * Hex SHA-256 commitment over the canonical CONTENT of every event in the
+   * bundle (not just the chain pointers). Signing this authenticates each
+   * exported event's fields to an offline auditor who lacks the HMAC key: any
+   * post-export mutation of an event's action/metadata/actor/timestamp/etc.
+   * changes this digest and breaks the signature. Empty-string when the bundle
+   * carries no events. See `eventsContentDigest`.
+   */
+  eventsDigest: string;
+  /** Seq of the first event committed by `eventsDigest` (0 when none). */
+  eventsFromSeq: number;
+  /** Seq of the last event committed by `eventsDigest` (0 when none). */
+  eventsToSeq: number;
 }
 
 export interface SignedCheckpoint {

--- a/packages/api/src/services/audit.ts
+++ b/packages/api/src/services/audit.ts
@@ -569,8 +569,7 @@ export async function readAuditBundleData(
   );
 
   const events: BundleEvent[] = rows.map((row) => {
-    const created =
-      row.created_at instanceof Date ? row.created_at : new Date(row.created_at);
+    const created = row.created_at instanceof Date ? row.created_at : new Date(row.created_at);
     return {
       seq: Number(row.seq),
       prevHash: toHex(row.prev_hash),

--- a/packages/api/src/services/audit.ts
+++ b/packages/api/src/services/audit.ts
@@ -455,3 +455,145 @@ export async function verifyAuditChain(
 
   return { valid: true, count };
 }
+
+// ─── Evidence bundle support ──────────────────────────────────────────────────
+
+function toHex(value: unknown): string {
+  const bytes = toU8(value);
+  let hex = "";
+  for (let i = 0; i < bytes.length; i++) {
+    hex += bytes[i].toString(16).padStart(2, "0");
+  }
+  return hex;
+}
+
+/**
+ * A single event as it appears in an offline-verifiable evidence bundle. All
+ * fields that feed the row's canonicalization are included so an third-party
+ * verifier can reconstruct linkage (prevHash === prior hmac) WITHOUT the HMAC
+ * key. `prevHash`/`hmac` are hex. Row HMACs are NOT recomputable offline (that
+ * needs the secret key) — the bundle proves linkage + head match, not per-row
+ * recomputation.
+ */
+export interface BundleEvent {
+  seq: number;
+  prevHash: string;
+  hmac: string;
+  actorType: string;
+  actorId: string | null;
+  action: string;
+  resourceType: string | null;
+  resourceId: string | null;
+  metadata: Record<string, unknown>;
+  ipAddress: string | null;
+  userAgent: string | null;
+  requestId: string | null;
+  createdAt: string;
+}
+
+export interface AuditChainHeadInfo {
+  /** Head sequence per the out-of-band high-water-mark. */
+  expectedSeq: number;
+  /** Live event count committed by the high-water-mark. */
+  expectedCount: number;
+  /** Hex HMAC of the head event. */
+  headHmac: string;
+  /** Retention floor (0 when nothing archived). */
+  floorSeq: number;
+}
+
+export interface AuditBundleData {
+  head: AuditChainHeadInfo | null;
+  events: BundleEvent[];
+  /** Hex HMAC of the newest event actually present in `events` (bundle head). */
+  bundleHeadHmac: string | null;
+  /** Seq of the newest event in `events`. */
+  bundleHeadSeq: number | null;
+}
+
+/**
+ * Read the events in [fromSeq, toSeq] for a tenant plus the chain-head
+ * high-water-mark, formatted for an evidence bundle. Pure read; does not touch
+ * the HMAC writer or verifier state.
+ */
+export async function readAuditBundleData(
+  tenantId: string,
+  fromSeq: number,
+  toSeq: number,
+): Promise<AuditBundleData> {
+  const db = getDb();
+
+  const headRows = rowsFromExecute<{
+    expected_seq: number | string;
+    expected_count: number | string;
+    head_hmac: unknown;
+    floor_seq: number | string | null;
+  }>(
+    await db.execute(
+      sql`SELECT expected_seq, expected_count, head_hmac, floor_seq
+          FROM audit_chain_heads WHERE tenant_id = ${tenantId} LIMIT 1`,
+    ),
+  );
+  const headRow = headRows[0];
+  const head: AuditChainHeadInfo | null = headRow
+    ? {
+        expectedSeq: Number(headRow.expected_seq),
+        expectedCount: Number(headRow.expected_count),
+        headHmac: toHex(headRow.head_hmac),
+        floorSeq: headRow.floor_seq != null ? Number(headRow.floor_seq) : 0,
+      }
+    : null;
+
+  const rows = rowsFromExecute<{
+    seq: number | string;
+    prev_hash: unknown;
+    hmac: unknown;
+    actor_type: string;
+    actor_id: string | null;
+    action: string;
+    resource_type: string | null;
+    resource_id: string | null;
+    metadata: Record<string, unknown> | null;
+    ip_address: string | null;
+    user_agent: string | null;
+    request_id: string | null;
+    created_at: Date | string;
+  }>(
+    await db.execute(
+      sql`SELECT seq, prev_hash, hmac, actor_type, actor_id, action, resource_type,
+                 resource_id, metadata, ip_address, user_agent, request_id, created_at
+          FROM audit_events
+          WHERE tenant_id = ${tenantId} AND seq BETWEEN ${fromSeq} AND ${toSeq}
+          ORDER BY seq ASC`,
+    ),
+  );
+
+  const events: BundleEvent[] = rows.map((row) => {
+    const created =
+      row.created_at instanceof Date ? row.created_at : new Date(row.created_at);
+    return {
+      seq: Number(row.seq),
+      prevHash: toHex(row.prev_hash),
+      hmac: toHex(row.hmac),
+      actorType: row.actor_type,
+      actorId: row.actor_id,
+      action: row.action,
+      resourceType: row.resource_type,
+      resourceId: row.resource_id,
+      metadata: row.metadata ?? {},
+      ipAddress: row.ip_address,
+      userAgent: row.user_agent,
+      requestId: row.request_id,
+      createdAt: created.toISOString(),
+    };
+  });
+
+  const last = events.length > 0 ? events[events.length - 1] : null;
+
+  return {
+    head,
+    events,
+    bundleHeadHmac: last ? last.hmac : null,
+    bundleHeadSeq: last ? last.seq : null,
+  };
+}

--- a/packages/db/drizzle/0076_audit_checkpoints.sql
+++ b/packages/db/drizzle/0076_audit_checkpoints.sql
@@ -1,0 +1,32 @@
+-- Ed25519 audit checkpoints.
+--
+-- The per-tenant audit_events HMAC chain is tamper-evident but SYMMETRIC:
+-- verification needs STEWARD_AUDIT_HMAC_KEY, so an third-party auditor cannot
+-- confirm the chain without the operator's secret. A checkpoint signs a
+-- canonical statement about the chain head with an Ed25519 PRIVATE key
+-- (STEWARD_AUDIT_SIGNING_KEY) whose PUBLIC half is publishable. Bundling the
+-- signed checkpoint with the exported events lets an auditor verify offline,
+-- with no Steward access and no secret. See:
+--   packages/api/src/services/audit-checkpoint.ts (signer)
+--   packages/api/src/routes/audit.ts             (GET /audit/bundle)
+--   scripts/verify-evidence-bundle.mjs           (standalone verifier)
+--
+-- Append-only: rows are never mutated. `payload` is the exact JSON that was
+-- canonicalized+signed; `signature` is base64 Ed25519 over the canonical bytes;
+-- `public_key` is the SPKI PEM (denormalized per row so bundles are
+-- self-contained and key rotation is auditable).
+
+CREATE TABLE IF NOT EXISTS "audit_checkpoints" (
+  "id" bigserial PRIMARY KEY NOT NULL,
+  "tenant_id" varchar(64) NOT NULL,
+  "seq" bigint NOT NULL,
+  "head_hmac" bytea NOT NULL,
+  "payload" jsonb NOT NULL,
+  "signature" text NOT NULL,
+  "public_key" text NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "audit_checkpoints_tenant_seq_idx" ON "audit_checkpoints" USING btree ("tenant_id","seq");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "audit_checkpoints_tenant_created_idx" ON "audit_checkpoints" USING btree ("tenant_id","created_at");

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -393,6 +393,13 @@
       "when": 1780137000000,
       "tag": "0075_monero_chain_family",
       "breakpoints": true
+    },
+    {
+      "idx": 76,
+      "version": "7",
+      "when": 1780137600000,
+      "tag": "0076_audit_checkpoints",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1743,3 +1743,35 @@ export const auditChainHeads = pgTable("audit_chain_heads", {
 
 export type AuditChainHead = typeof auditChainHeads.$inferSelect;
 export type NewAuditChainHead = typeof auditChainHeads.$inferInsert;
+
+// Ed25519 checkpoints over the audit chain head. The HMAC chain is symmetric
+// (verifiable only with STEWARD_AUDIT_HMAC_KEY); a checkpoint signs a canonical
+// statement about the chain head with an Ed25519 key whose PUBLIC half can be
+// published, so an third-party auditor can verify a signed evidence bundle offline
+// without any Steward secret. `payload` is the exact JSON object that was
+// canonicalized+signed; `signature` is base64 Ed25519 over the canonical bytes;
+// `publicKey` is the SPKI PEM (denormalized per row so a bundle is
+// self-contained and key rotation is auditable). Append-only, never mutated.
+export const auditCheckpoints = pgTable(
+  "audit_checkpoints",
+  {
+    id: bigserial("id", { mode: "number" }).primaryKey(),
+    tenantId: varchar("tenant_id", { length: 64 }).notNull(),
+    seq: bigint("seq", { mode: "number" }).notNull(),
+    headHmac: bytea("head_hmac").notNull(),
+    payload: jsonb("payload").$type<Record<string, unknown>>().notNull(),
+    signature: text("signature").notNull(),
+    publicKey: text("public_key").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    tenantSeqIdx: index("audit_checkpoints_tenant_seq_idx").on(table.tenantId, table.seq),
+    tenantCreatedIdx: index("audit_checkpoints_tenant_created_idx").on(
+      table.tenantId,
+      table.createdAt,
+    ),
+  }),
+);
+
+export type AuditCheckpointRow = typeof auditCheckpoints.$inferSelect;
+export type NewAuditCheckpointRow = typeof auditCheckpoints.$inferInsert;

--- a/scripts/verify-evidence-bundle.mjs
+++ b/scripts/verify-evidence-bundle.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+
 /**
  * Standalone offline verifier for a Steward audit evidence bundle.
  *
@@ -16,15 +17,20 @@
  *   (a) Ed25519 signature: the checkpoint payload was signed by the holder of
  *       the private key matching the bundle's published public key, and has not
  *       been altered since (any change to a payload field breaks the signature).
- *   (b) Event linkage: within the exported list, each event's `prevHash` equals
+ *   (b) Event content authentication: the checkpoint signs `eventsDigest`, a
+ *       SHA-256 commitment over EVERY exported event's canonical fields. The
+ *       verifier recomputes it from the bundle events and requires a match, so
+ *       mutating ANY field (action, metadata, actorId, createdAt, ...) or
+ *       inserting/removing/reordering events breaks verification, even without
+ *       the operator's secret HMAC key.
+ *   (c) Event linkage: within the exported list, each event's `prevHash` equals
  *       the previous event's `hmac` — the exported rows form an unbroken
- *       segment of one hash chain (no row inserted, removed, or reordered
- *       inside the exported range without detection).
- *   (c) Head binding: when the export includes the chain head (range.includesHead),
- *       the last event's `hmac` equals the checkpoint's signed `headHmac`. This
- *       ties the exported set to the exact head the operator committed to at
- *       signing time.
- *   (d) Sequence continuity: seqs increase by exactly 1 with no gaps.
+ *       segment of one hash chain.
+ *   (d) Head binding: head inclusion is DERIVED from the signed checkpoint
+ *       (`lastEvent.seq === payload.seq`), never from an unsigned envelope flag.
+ *       When the export reaches the head, the last event's `hmac` MUST equal the
+ *       signed `headHmac`, tying the exported set to the operator's committed head.
+ *   (e) Sequence continuity: seqs increase by exactly 1 with no gaps.
  *
  * ─── WHAT THIS DOES NOT PROVE ────────────────────────────────────────────────
  *   • It does not recompute the per-row HMACs. Those are keyed with the
@@ -34,13 +40,14 @@
  *     raises the bar from "trust the operator's secret" to "trust the operator's
  *     published, append-only, third-partyly-witnessable checkpoints."
  *   • It does not prove the exported range is the WHOLE history — only that what
- *     is present is internally consistent and (if includesHead) reaches the
- *     signed head. A gap BELOW range.from is expected for partial exports.
+ *     is present is internally consistent, its contents are authentic, and (when
+ *     it reaches the head) it matches the signed head. A gap BELOW the first
+ *     exported seq is expected for partial exports.
  *   • It does not timestamp-anchor the checkpoint externally (out of scope v1).
  */
 
+import { createHash, createPublicKey, verify as edVerify } from "node:crypto";
 import { readFileSync } from "node:fs";
-import { createPublicKey, verify as edVerify } from "node:crypto";
 
 function fail(msg, seq) {
   const at = seq === undefined ? "" : ` (seq ${seq})`;
@@ -90,12 +97,62 @@ function canonicalCheckpointBytes(payload) {
   return Buffer.from(JSON.stringify(ordered), "utf8");
 }
 
+// Recursively canonicalize a JSON value: sort keys, null for undefined/null.
+// MUST match canonicalJsonValue in services/audit.ts + audit-checkpoint.ts.
+function canonicalJsonValue(value) {
+  if (value === undefined || value === null) return null;
+  if (Array.isArray(value)) return value.map((item) => canonicalJsonValue(item));
+  if (typeof value === "object") {
+    const ordered = {};
+    for (const key of Object.keys(value).sort()) {
+      ordered[key] = canonicalJsonValue(value[key]);
+    }
+    return ordered;
+  }
+  return value;
+}
+
+// Canonical bytes of one event's CONTENT. Field names are snake_case to match
+// the server's HMAC-chain canonicalization and audit-checkpoint.ts exactly.
+function canonicalEventContentBytes(ev, tenantId) {
+  const fields = {
+    tenant_id: tenantId,
+    seq: ev.seq,
+    actor_type: ev.actorType ?? null,
+    actor_id: ev.actorId ?? null,
+    action: ev.action ?? null,
+    resource_type: ev.resourceType ?? null,
+    resource_id: ev.resourceId ?? null,
+    metadata: ev.metadata ?? {},
+    ip_address: ev.ipAddress ?? null,
+    user_agent: ev.userAgent ?? null,
+    request_id: ev.requestId ?? null,
+    created_at: ev.createdAt ?? null,
+  };
+  return Buffer.from(JSON.stringify(canonicalJsonValue(fields)), "utf8");
+}
+
+// Rolling SHA-256 content commitment over the ordered events. MUST match
+// eventsContentDigest in services/audit-checkpoint.ts: "" for empty; else
+// acc = SHA256("steward-audit-events/v1"); acc = SHA256(acc_hex || leaf_hex).
+function eventsContentDigest(events, tenantId) {
+  if (events.length === 0) return "";
+  let acc = createHash("sha256").update("steward-audit-events/v1").digest("hex");
+  for (const ev of events) {
+    const leaf = createHash("sha256")
+      .update(canonicalEventContentBytes(ev, tenantId))
+      .digest("hex");
+    acc = createHash("sha256").update(acc).update(leaf).digest("hex");
+  }
+  return acc;
+}
+
 function main() {
   const bundle = loadBundle();
 
   if (!bundle || typeof bundle !== "object") fail("bundle is not an object");
   if (bundle.version !== 1) fail(`unsupported bundle version: ${bundle.version}`);
-  const { checkpoint, events, range, tenantId } = bundle;
+  const { checkpoint, events, tenantId } = bundle;
   if (!checkpoint || typeof checkpoint !== "object") fail("bundle.checkpoint missing");
   if (!Array.isArray(events)) fail("bundle.events is not an array");
 
@@ -128,7 +185,7 @@ function main() {
     fail(`checkpoint tenantId (${payload.tenantId}) != bundle tenantId (${tenantId})`);
   }
 
-  // ── (b)+(d) Event linkage + sequence continuity ──────────────────────────
+  // ── (c)+(e) Event linkage + sequence continuity ──────────────────────────
   let prevHmac = null; // hmac (hex) of the previous event; null before first
   let prevSeq = null;
   for (const ev of events) {
@@ -146,22 +203,50 @@ function main() {
     prevSeq = ev.seq;
   }
 
-  // ── (c) Head binding (only when the export reaches the chain head) ────────
-  const includesHead = range && range.includesHead === true;
-  if (includesHead) {
-    if (events.length === 0) {
-      fail("range.includesHead is true but the event list is empty");
+  // ── (b) Event content authentication ─────────────────────────────────────
+  // Recompute the signed content digest from the bundle events. This is the
+  // check that catches mutation of any event FIELD (action, metadata, actorId,
+  // createdAt, ...) even though the offline verifier has no HMAC key. The
+  // recomputation uses the CHECKPOINT'S tenantId (which is signed), so an
+  // attacker cannot dodge it by rewriting the unsigned envelope tenantId.
+  const recomputedDigest = eventsContentDigest(events, payload.tenantId);
+  if (typeof payload.eventsDigest !== "string") {
+    fail("checkpoint payload is missing eventsDigest (unsupported/old bundle)");
+  }
+  if (recomputedDigest !== payload.eventsDigest) {
+    fail("event content digest does not match the signed checkpoint (events tampered)");
+  }
+  // The signed eventsFromSeq/eventsToSeq must bracket exactly the present events.
+  if (events.length > 0) {
+    if (payload.eventsFromSeq !== events[0].seq) {
+      fail(
+        `signed eventsFromSeq (${payload.eventsFromSeq}) != first event seq (${events[0].seq})`,
+        events[0].seq,
+      );
     }
+    if (payload.eventsToSeq !== events[events.length - 1].seq) {
+      fail(
+        `signed eventsToSeq (${payload.eventsToSeq}) != last event seq (${events[events.length - 1].seq})`,
+        events[events.length - 1].seq,
+      );
+    }
+  } else if (payload.eventsFromSeq !== 0 || payload.eventsToSeq !== 0) {
+    fail("signed eventsFromSeq/eventsToSeq are non-zero but the bundle has no events");
+  }
+
+  // ── (d) Head binding: DERIVE inclusion from signed data, never the envelope.
+  // The export reaches the chain head iff its last event's seq equals the
+  // checkpoint's signed head seq. `range.includesHead` in the envelope is
+  // unsigned and advisory only — we ignore it for the security decision.
+  const includesHead =
+    events.length > 0 &&
+    typeof payload.seq === "number" &&
+    events[events.length - 1].seq === payload.seq;
+  if (includesHead) {
     const lastHmac = events[events.length - 1].hmac;
     if (lastHmac !== payload.headHmac) {
       fail(
         `last event hmac (${lastHmac}) != checkpoint headHmac (${payload.headHmac})`,
-        events[events.length - 1].seq,
-      );
-    }
-    if (typeof payload.seq === "number" && events[events.length - 1].seq !== payload.seq) {
-      fail(
-        `last event seq (${events[events.length - 1].seq}) != checkpoint seq (${payload.seq})`,
         events[events.length - 1].seq,
       );
     }
@@ -173,19 +258,29 @@ function main() {
     : "partial range (does NOT include chain head — head binding not checked)";
   console.log("PASS");
   console.log(`  tenant:        ${payload.tenantId}`);
-  console.log(`  events:        ${events.length}` +
-    (events.length ? ` (seq ${events[0].seq}..${events[events.length - 1].seq})` : ""));
-  console.log(`  checkpoint:    seq=${payload.seq} count=${payload.expectedCount} floorSeq=${payload.floorSeq}`);
+  console.log(
+    `  events:        ${events.length}` +
+      (events.length ? ` (seq ${events[0].seq}..${events[events.length - 1].seq})` : ""),
+  );
+  console.log(
+    `  checkpoint:    seq=${payload.seq} count=${payload.expectedCount} floorSeq=${payload.floorSeq}`,
+  );
   console.log(`  signed at:     ${payload.timestamp} (software ${payload.softwareVersion})`);
   console.log(`  signature:     Ed25519 OK`);
+  console.log(`  content:       SHA-256 events digest OK`);
   console.log(`  linkage:       OK`);
   console.log(`  head:          ${headNote}`);
   console.log("");
-  console.log("Proven: exported rows form an unbroken hash-chain segment; " +
-    (includesHead ? "the head matches the operator's signed checkpoint; " : "") +
-    "the checkpoint is authentically Ed25519-signed and unaltered.");
-  console.log("NOT proven: per-row HMAC recomputation (needs the operator's secret key); " +
-    "that the export is the complete history; third-party timestamp anchoring.");
+  console.log(
+    "Proven: exported event contents are authentic (signed SHA-256 digest); " +
+      "rows form an unbroken hash-chain segment; " +
+      (includesHead ? "the head matches the operator's signed checkpoint; " : "") +
+      "the checkpoint is authentically Ed25519-signed and unaltered.",
+  );
+  console.log(
+    "NOT proven: per-row HMAC recomputation (needs the operator's secret key); " +
+      "that the export is the complete history; third-party timestamp anchoring.",
+  );
   process.exit(0);
 }
 

--- a/scripts/verify-evidence-bundle.mjs
+++ b/scripts/verify-evidence-bundle.mjs
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+/**
+ * Standalone offline verifier for a Steward audit evidence bundle.
+ *
+ * ZERO project imports, ZERO third-party dependencies — only Node builtins.
+ * An auditor can run this on any machine with Node, holding nothing but the
+ * bundle JSON (which carries its own Ed25519 public key). No Steward access, no
+ * secret HMAC key.
+ *
+ *   node scripts/verify-evidence-bundle.mjs <bundle.json>
+ *   cat bundle.json | node scripts/verify-evidence-bundle.mjs
+ *
+ * Exit code 0 = PASS, 1 = FAIL, 2 = usage/parse error.
+ *
+ * ─── WHAT THIS PROVES ────────────────────────────────────────────────────────
+ *   (a) Ed25519 signature: the checkpoint payload was signed by the holder of
+ *       the private key matching the bundle's published public key, and has not
+ *       been altered since (any change to a payload field breaks the signature).
+ *   (b) Event linkage: within the exported list, each event's `prevHash` equals
+ *       the previous event's `hmac` — the exported rows form an unbroken
+ *       segment of one hash chain (no row inserted, removed, or reordered
+ *       inside the exported range without detection).
+ *   (c) Head binding: when the export includes the chain head (range.includesHead),
+ *       the last event's `hmac` equals the checkpoint's signed `headHmac`. This
+ *       ties the exported set to the exact head the operator committed to at
+ *       signing time.
+ *   (d) Sequence continuity: seqs increase by exactly 1 with no gaps.
+ *
+ * ─── WHAT THIS DOES NOT PROVE ────────────────────────────────────────────────
+ *   • It does not recompute the per-row HMACs. Those are keyed with the
+ *     operator's SECRET HMAC key, which (correctly) is not in the bundle. So
+ *     this verifier cannot detect an operator who, holding BOTH the HMAC key and
+ *     the signing key, fabricates a self-consistent chain and signs it. It
+ *     raises the bar from "trust the operator's secret" to "trust the operator's
+ *     published, append-only, third-partyly-witnessable checkpoints."
+ *   • It does not prove the exported range is the WHOLE history — only that what
+ *     is present is internally consistent and (if includesHead) reaches the
+ *     signed head. A gap BELOW range.from is expected for partial exports.
+ *   • It does not timestamp-anchor the checkpoint externally (out of scope v1).
+ */
+
+import { readFileSync } from "node:fs";
+import { createPublicKey, verify as edVerify } from "node:crypto";
+
+function fail(msg, seq) {
+  const at = seq === undefined ? "" : ` (seq ${seq})`;
+  console.error(`FAIL: ${msg}${at}`);
+  process.exit(1);
+}
+
+function usage(msg) {
+  console.error(`usage error: ${msg}`);
+  console.error("  node scripts/verify-evidence-bundle.mjs <bundle.json>");
+  console.error("  cat bundle.json | node scripts/verify-evidence-bundle.mjs");
+  process.exit(2);
+}
+
+// ─── Load bundle (file arg or stdin) ────────────────────────────────────────
+function loadBundle() {
+  const arg = process.argv[2];
+  let raw;
+  if (arg && arg !== "-") {
+    try {
+      raw = readFileSync(arg, "utf8");
+    } catch (err) {
+      usage(`could not read ${arg}: ${err.message}`);
+    }
+  } else {
+    try {
+      raw = readFileSync(0, "utf8");
+    } catch {
+      usage("no bundle file argument and nothing on stdin");
+    }
+  }
+  if (!raw || raw.trim().length === 0) usage("empty bundle input");
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    usage(`bundle is not valid JSON: ${err.message}`);
+  }
+}
+
+// Canonical bytes MUST match packages/api/src/services/audit-checkpoint.ts
+// canonicalCheckpointBytes: sort top-level keys, JSON.stringify, no whitespace.
+function canonicalCheckpointBytes(payload) {
+  const ordered = {};
+  for (const key of Object.keys(payload).sort()) {
+    ordered[key] = payload[key];
+  }
+  return Buffer.from(JSON.stringify(ordered), "utf8");
+}
+
+function main() {
+  const bundle = loadBundle();
+
+  if (!bundle || typeof bundle !== "object") fail("bundle is not an object");
+  if (bundle.version !== 1) fail(`unsupported bundle version: ${bundle.version}`);
+  const { checkpoint, events, range, tenantId } = bundle;
+  if (!checkpoint || typeof checkpoint !== "object") fail("bundle.checkpoint missing");
+  if (!Array.isArray(events)) fail("bundle.events is not an array");
+
+  const { payload, signature, publicKey } = checkpoint;
+  if (!payload || typeof payload !== "object") fail("checkpoint.payload missing");
+  if (typeof signature !== "string") fail("checkpoint.signature missing");
+  if (typeof publicKey !== "string") fail("checkpoint.publicKey missing");
+
+  // ── (a) Ed25519 signature over the canonical checkpoint payload ──────────
+  let pubKeyObj;
+  try {
+    pubKeyObj = createPublicKey({ key: publicKey, format: "pem" });
+  } catch (err) {
+    fail(`checkpoint.publicKey is not a valid PEM: ${err.message}`);
+  }
+  if (pubKeyObj.asymmetricKeyType !== "ed25519") {
+    fail(`checkpoint.publicKey is not Ed25519 (got ${pubKeyObj.asymmetricKeyType})`);
+  }
+  let sigBytes;
+  try {
+    sigBytes = Buffer.from(signature, "base64");
+  } catch (err) {
+    fail(`checkpoint.signature is not valid base64: ${err.message}`);
+  }
+  const sigOk = edVerify(null, canonicalCheckpointBytes(payload), pubKeyObj, sigBytes);
+  if (!sigOk) fail("Ed25519 checkpoint signature does not verify");
+
+  // Cross-check the payload's tenantId against the bundle envelope.
+  if (tenantId !== undefined && payload.tenantId !== tenantId) {
+    fail(`checkpoint tenantId (${payload.tenantId}) != bundle tenantId (${tenantId})`);
+  }
+
+  // ── (b)+(d) Event linkage + sequence continuity ──────────────────────────
+  let prevHmac = null; // hmac (hex) of the previous event; null before first
+  let prevSeq = null;
+  for (const ev of events) {
+    if (typeof ev.seq !== "number") fail("event has non-numeric seq", ev.seq);
+    if (typeof ev.hmac !== "string" || typeof ev.prevHash !== "string") {
+      fail("event missing hmac/prevHash hex", ev.seq);
+    }
+    if (prevSeq !== null && ev.seq !== prevSeq + 1) {
+      fail(`sequence gap: expected ${prevSeq + 1}, got ${ev.seq}`, ev.seq);
+    }
+    if (prevHmac !== null && ev.prevHash !== prevHmac) {
+      fail("prevHash does not match previous event's hmac (chain break)", ev.seq);
+    }
+    prevHmac = ev.hmac;
+    prevSeq = ev.seq;
+  }
+
+  // ── (c) Head binding (only when the export reaches the chain head) ────────
+  const includesHead = range && range.includesHead === true;
+  if (includesHead) {
+    if (events.length === 0) {
+      fail("range.includesHead is true but the event list is empty");
+    }
+    const lastHmac = events[events.length - 1].hmac;
+    if (lastHmac !== payload.headHmac) {
+      fail(
+        `last event hmac (${lastHmac}) != checkpoint headHmac (${payload.headHmac})`,
+        events[events.length - 1].seq,
+      );
+    }
+    if (typeof payload.seq === "number" && events[events.length - 1].seq !== payload.seq) {
+      fail(
+        `last event seq (${events[events.length - 1].seq}) != checkpoint seq (${payload.seq})`,
+        events[events.length - 1].seq,
+      );
+    }
+  }
+
+  // ── PASS ─────────────────────────────────────────────────────────────────
+  const headNote = includesHead
+    ? "includes chain head, bound to signed checkpoint"
+    : "partial range (does NOT include chain head — head binding not checked)";
+  console.log("PASS");
+  console.log(`  tenant:        ${payload.tenantId}`);
+  console.log(`  events:        ${events.length}` +
+    (events.length ? ` (seq ${events[0].seq}..${events[events.length - 1].seq})` : ""));
+  console.log(`  checkpoint:    seq=${payload.seq} count=${payload.expectedCount} floorSeq=${payload.floorSeq}`);
+  console.log(`  signed at:     ${payload.timestamp} (software ${payload.softwareVersion})`);
+  console.log(`  signature:     Ed25519 OK`);
+  console.log(`  linkage:       OK`);
+  console.log(`  head:          ${headNote}`);
+  console.log("");
+  console.log("Proven: exported rows form an unbroken hash-chain segment; " +
+    (includesHead ? "the head matches the operator's signed checkpoint; " : "") +
+    "the checkpoint is authentically Ed25519-signed and unaltered.");
+  console.log("NOT proven: per-row HMAC recomputation (needs the operator's secret key); " +
+    "that the export is the complete history; third-party timestamp anchoring.");
+  process.exit(0);
+}
+
+main();


### PR DESCRIPTION
## What & why

PR 3 of the Steward authority-plane plan: **offline-verifiable evidence bundles**.

The per-tenant audit chain (`packages/api/src/services/audit.ts`) is tamper-evident but **symmetric** — it's an HMAC-SHA256 chain keyed with `STEWARD_AUDIT_HMAC_KEY`. An third-party auditor cannot verify it without being handed that secret, which would also let them forge it. Export today is CSV; verify is an online `POST /audit/verify` that needs the operator's key.

This PR adds **Ed25519 checkpoint signatures + a self-contained signed evidence bundle + a standalone offline verifier**, so an auditor can verify an export on any machine with Node, holding nothing but the bundle JSON — no Steward access, no secret key.

The HMAC chain writer semantics are **unchanged**.

## What's in it

1. **Ed25519 checkpoint signer** — `packages/api/src/services/audit-checkpoint.ts`. Env `STEWARD_AUDIT_SIGNING_KEY` accepts a PKCS#8 PEM **or** a raw 32-byte seed as hex/base64/base64url. Signs a canonical `{v, tenantId, seq, headHmac, expectedCount, floorSeq, timestamp, softwareVersion, eventsDigest, eventsFromSeq, eventsToSeq}` payload with `crypto.sign(null, …, ed25519)`. Zero new deps.
2. **`audit_checkpoints` table** — Drizzle schema + migration `0076_audit_checkpoints.sql` (+ journal entry). Append-only: `id, tenantId, seq, headHmac, payload jsonb, signature, publicKey, createdAt`.
3. **`GET /audit/bundle?from=&to=`** — owner/admin + recent-MFA (same auth as CSV export). Returns `{version, tenantId, range, canonicalizationSpec, events[seq/prevHash/hmac hex + fields], checkpoint{payload, signature, publicKey}, generatedAt}`. Signs + persists a checkpoint over the chain head at bundle time. **503 with a clear error** when the signing key is unset (hard-fail in production, disabled-with-warning in dev).
4. **Standalone verifier** — `scripts/verify-evidence-bundle.mjs`. Pure Node, zero deps, zero project imports. Verifies (a) Ed25519 signature over the canonical checkpoint payload, (b) **event content authentication** via a signed SHA-256 digest over every event's canonical fields, (c) event linkage (each `prevHash === prior hmac`), (d) head binding derived from signed data, (e) seq continuity. Prints PASS/FAIL with the failing seq; exit 0/1/2. The header documents exactly what is and isn't proven.
5. **Tests** — signer unit tests (PEM/hex/base64 seeds, canonical-bytes order-independence, bad-key cases incl. RSA/malformed PEM), `eventsContentDigest` sensitivity, bundle endpoint integration on PGLite (well-formed bundle, tenant isolation, partial range, checkpoint persistence, signing-key gate), and verifier e2e via `node` child_process (genuine → PASS; flipped byte / content field / tampered payload / includesHead-flip → FAIL at the right seq).

## What is / isn't proven (documented in the verifier header)

**Proven offline (no HMAC key):** exported event contents are authentic (signed SHA-256 digest); rows form an unbroken hash-chain segment; when the export reaches the head, it matches the operator's signed head; the checkpoint is authentically Ed25519-signed and unaltered.

**Not proven:** per-row HMAC recomputation (needs the operator's secret key); that the export is the complete history; third-party timestamp anchoring (out of scope for v1 per the plan).

## Codex review

`codex review --base origin/develop` flagged **2 P1s** on the first pass, both now fixed (commit `de6b898`) with tests proving the fixes:
- **Authenticate event contents, not just chain pointers** → checkpoint now signs `eventsDigest` (rolling SHA-256 over each event's canonical fields); the verifier recomputes it and any field mutation FAILs offline.
- **Derive head binding from signed data** → verifier now computes head inclusion as `lastEvent.seq === payload.seq` (both signed) instead of trusting the unsigned `range.includesHead` flag.

A follow-up re-review run repeatedly hung on this box's infra past its time budget; the P1 fixes are covered by dedicated e2e tests (`FAILS … when an event CONTENT field is altered`, `FAILS … when the unsigned includesHead flag is flipped`).

## Test run

```
bun test src/__tests__/audit-checkpoint.test.ts \
         src/__tests__/audit-bundle.integration.test.ts \
         src/__tests__/audit-bundle-signing-gate.test.ts \
         src/__tests__/audit-events-filters.test.ts \
         src/__tests__/audit-chain-strict.test.ts
→ 41 pass, 0 fail, 154 expect() calls
```

Full `tsc --noEmit` on `@stwd/api` and `@stwd/db`: clean. Biome: clean.

`audit-chain.test.ts` self-skips without a real `DATABASE_URL` (needs Postgres, pre-existing) — not affected by this PR.

[sol-orch]
