### PR TITLE
feat(gateway): policy-bound execution authorization at the signing boundary (EVM tx path)

### DIFF
--- a/packages/api/src/__tests__/execution-authorization.test.ts
+++ b/packages/api/src/__tests__/execution-authorization.test.ts
@@ -165,15 +165,34 @@ describe("execution authorization service", () => {
       idempotencyKey: "idem-hmac-tamper",
     });
 
-    // Each mutation flips exactly one signed field; the HMAC verify must reject
-    // every one of them with an invalid-signature error. Context-checked fields
-    // (tenantId/agentId/capability/backend/payloadDigest/status) are verified
-    // separately via the context guard; here we prove the SIGNATURE itself binds
-    // the non-context fields the reviewer called out.
-    const tampers: Array<{
+    // The HMAC binds ALL 14 fields in signaturePayload():
+    //   id, requestId, tenantId, agentId, capability, payloadDigest, backend,
+    //   policyRevisionHash, approvalId, nonce, issuedAt, expiresAt, status,
+    //   idempotencyKey.
+    //
+    // verifyExecutionAuthorization checks a CONTEXT guard
+    // (tenantId/agentId/capability/backend/payloadDigest and the literal
+    // status==="active") BEFORE the HMAC verify. To prove the SIGNATURE itself
+    // covers each field:
+    //  - Non-context fields (id/requestId/policyRevisionHash/approvalId/nonce/
+    //    issuedAt/expiresAt/idempotencyKey) reach the HMAC directly, so tampering
+    //    them alone must fail with "signature is invalid".
+    //  - Context-bound fields (tenantId/agentId/capability/backend/payloadDigest)
+    //    would otherwise trip the context guard first, masking the signature
+    //    binding. We align `expected` to the tampered value so the context guard
+    //    passes and the case GENUINELY reaches the HMAC verify, which must then
+    //    reject because the stored signature was computed over the original
+    //    value.
+    //  - `status` cannot reach the HMAC: the context guard requires the LITERAL
+    //    status==="active", so any status mutation is a fail-closed context
+    //    rejection, asserted honestly as such below.
+    type VerifyContext = Parameters<typeof verifyExecutionAuthorization>[1];
+    const signatureTampers: Array<{
       field: string;
       mutate: (a: ExecutionAuthorization) => ExecutionAuthorization;
+      expectedOverride?: Partial<VerifyContext>;
     }> = [
+      // ── Non-context signed fields (reach HMAC directly) ──
       { field: "id", mutate: (a) => ({ ...a, id: "00000000-0000-4000-8000-000000000000" }) },
       { field: "requestId", mutate: (a) => ({ ...a, requestId: "tampered-request" }) },
       {
@@ -188,15 +207,53 @@ describe("execution authorization service", () => {
         mutate: (a) => ({ ...a, expiresAt: new Date(Date.now() + 3_600_000).toISOString() }),
       },
       { field: "idempotencyKey", mutate: (a) => ({ ...a, idempotencyKey: "tampered-idem" }) },
+      // ── Context-bound signed fields (expected aligned so the case reaches HMAC) ──
+      {
+        field: "tenantId",
+        mutate: (a) => ({ ...a, tenantId: "11111111-1111-4111-8111-111111111111" }),
+        expectedOverride: { tenantId: "11111111-1111-4111-8111-111111111111" },
+      },
+      {
+        field: "agentId",
+        mutate: (a) => ({ ...a, agentId: "22222222-2222-4222-8222-222222222222" }),
+        expectedOverride: { agentId: "22222222-2222-4222-8222-222222222222" },
+      },
+      {
+        field: "capability",
+        // The only other capability in the union; align expected so the context
+        // guard passes and the HMAC (bound to the original capability) rejects.
+        mutate: (a) => ({ ...a, capability: "wallet.sign_message" as const }),
+        expectedOverride: { capability: "wallet.sign_message" as const },
+      },
+      {
+        field: "payloadDigest",
+        mutate: (a) => ({ ...a, payloadDigest: "d".repeat(64) }),
+        expectedOverride: { payloadDigest: "d".repeat(64) },
+      },
+      {
+        field: "backend",
+        mutate: (a) => ({ ...a, backend: "third-party-custody" as const }),
+        expectedOverride: { backend: "third-party-custody" as const },
+      },
     ];
 
-    for (const { field, mutate } of tampers) {
+    for (const { field, mutate, expectedOverride } of signatureTampers) {
       const tampered = mutate(authorization);
+      const verifyContext: VerifyContext = { ...expected, ...(expectedOverride ?? {}) };
       expect(
-        () => verifyExecutionAuthorization(tampered, expected),
+        () => verifyExecutionAuthorization(tampered, verifyContext),
         `tampering ${field} must invalidate the signature`,
       ).toThrow("signature is invalid");
     }
+
+    // `status` is bound by the HMAC but the context guard rejects any non-active
+    // status BEFORE the signature is checked. Assert the honest fail-closed
+    // behaviour: a mutated status is a context rejection, not a signature pass.
+    expect(
+      () =>
+        verifyExecutionAuthorization({ ...authorization, status: "consumed" as const }, expected),
+      "tampering status must be rejected (context guard, fail closed)",
+    ).toThrow("context does not match");
 
     // Sanity: the untampered authorization still verifies.
     expect(() => verifyExecutionAuthorization(authorization, expected)).not.toThrow();

--- a/packages/api/src/__tests__/execution-authorization.test.ts
+++ b/packages/api/src/__tests__/execution-authorization.test.ts
@@ -1,6 +1,8 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { agents, closeDb, executionAuthorizationNonces, getDb, tenants } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import type { ExecutionAuthorization } from "@stwd/shared";
+import { ExecutionPayloadNormalizationError } from "@stwd/shared";
 import { eq } from "drizzle-orm";
 import {
   consumeExecutionAuthorization,
@@ -116,6 +118,150 @@ describe("execution authorization service", () => {
         payloadDigest: "d".repeat(64),
       }),
     ).rejects.toThrow("context does not match");
+  });
+
+  it("normalizes chainId/nonce as non-negative safe integers before digesting", () => {
+    const base = {
+      tenantId: TENANT_ID,
+      agentId: AGENT_ID,
+      to: "0x1111111111111111111111111111111111111111",
+      value: "1",
+      data: "0x",
+      chainId: 8453,
+      broadcast: false,
+    };
+    // Valid nonce digests fine and is stable.
+    expect(executionPayloadDigestForEvmSign({ ...base, nonce: 7 })).toBe(
+      executionPayloadDigestForEvmSign({ ...base, nonce: 7 }),
+    );
+    // Negative nonce rejected.
+    expect(() => executionPayloadDigestForEvmSign({ ...base, nonce: -1 })).toThrow(
+      ExecutionPayloadNormalizationError,
+    );
+    // Non-safe-integer nonce rejected.
+    expect(() =>
+      executionPayloadDigestForEvmSign({ ...base, nonce: Number.MAX_SAFE_INTEGER + 1 }),
+    ).toThrow(ExecutionPayloadNormalizationError);
+    // Negative chainId rejected.
+    expect(() => executionPayloadDigestForEvmSign({ ...base, chainId: -8453 })).toThrow(
+      ExecutionPayloadNormalizationError,
+    );
+  });
+
+  it("table-driven: HMAC signature covers every signed field (tamper detection)", async () => {
+    const payloadDigest = "a".repeat(64);
+    const expected = {
+      tenantId: TENANT_ID,
+      agentId: AGENT_ID,
+      capability: "wallet.sign_transaction" as const,
+      backend: "local-vault" as const,
+      payloadDigest,
+    };
+    const authorization = await mintExecutionAuthorization({
+      requestId: "tx-hmac-tamper-req",
+      ...expected,
+      policyRevisionHash: "b".repeat(64),
+      approvalId: "approval-hmac-tamper",
+      idempotencyKey: "idem-hmac-tamper",
+    });
+
+    // Each mutation flips exactly one signed field; the HMAC verify must reject
+    // every one of them with an invalid-signature error. Context-checked fields
+    // (tenantId/agentId/capability/backend/payloadDigest/status) are verified
+    // separately via the context guard; here we prove the SIGNATURE itself binds
+    // the non-context fields the reviewer called out.
+    const tampers: Array<{
+      field: string;
+      mutate: (a: ExecutionAuthorization) => ExecutionAuthorization;
+    }> = [
+      { field: "id", mutate: (a) => ({ ...a, id: "00000000-0000-4000-8000-000000000000" }) },
+      { field: "requestId", mutate: (a) => ({ ...a, requestId: "tampered-request" }) },
+      {
+        field: "policyRevisionHash",
+        mutate: (a) => ({ ...a, policyRevisionHash: "c".repeat(64) }),
+      },
+      { field: "approvalId", mutate: (a) => ({ ...a, approvalId: "tampered-approval" }) },
+      { field: "nonce", mutate: (a) => ({ ...a, nonce: "tampered-nonce" }) },
+      { field: "issuedAt", mutate: (a) => ({ ...a, issuedAt: new Date(0).toISOString() }) },
+      {
+        field: "expiresAt",
+        mutate: (a) => ({ ...a, expiresAt: new Date(Date.now() + 3_600_000).toISOString() }),
+      },
+      { field: "idempotencyKey", mutate: (a) => ({ ...a, idempotencyKey: "tampered-idem" }) },
+    ];
+
+    for (const { field, mutate } of tampers) {
+      const tampered = mutate(authorization);
+      expect(
+        () => verifyExecutionAuthorization(tampered, expected),
+        `tampering ${field} must invalidate the signature`,
+      ).toThrow("signature is invalid");
+    }
+
+    // Sanity: the untampered authorization still verifies.
+    expect(() => verifyExecutionAuthorization(authorization, expected)).not.toThrow();
+  });
+
+  it("consumes a nonce exactly once under concurrent replay (race)", async () => {
+    const payloadDigest = "1".repeat(64);
+    const expected = {
+      tenantId: TENANT_ID,
+      agentId: AGENT_ID,
+      capability: "wallet.sign_transaction" as const,
+      backend: "local-vault" as const,
+      payloadDigest,
+    };
+    const authorization = await mintExecutionAuthorization({
+      requestId: "tx-concurrent-consume",
+      ...expected,
+      policyRevisionHash: "2".repeat(64),
+    });
+
+    // Fire many concurrent consumes of the SAME authorization. The atomic
+    // conditional UPDATE (status='active' AND not expired) must let exactly one
+    // succeed; all others reject as already-consumed.
+    const attempts = 12;
+    const results = await Promise.allSettled(
+      Array.from({ length: attempts }, () =>
+        consumeExecutionAuthorization(authorization, expected),
+      ),
+    );
+    const fulfilled = results.filter((r) => r.status === "fulfilled").length;
+    const rejected = results.filter((r) => r.status === "rejected").length;
+    expect(fulfilled).toBe(1);
+    expect(rejected).toBe(attempts - 1);
+
+    const [row] = await getDb()
+      .select({ status: executionAuthorizationNonces.status })
+      .from(executionAuthorizationNonces)
+      .where(eq(executionAuthorizationNonces.authorizationId, authorization.id));
+    expect(row?.status).toBe("consumed");
+  });
+
+  it("never stores private key or secret material in the nonce row", async () => {
+    const payloadDigest = "3".repeat(64);
+    const authorization = await mintExecutionAuthorization({
+      requestId: "tx-no-secret-material",
+      tenantId: TENANT_ID,
+      agentId: AGENT_ID,
+      capability: "wallet.sign_transaction",
+      backend: "local-vault",
+      payloadDigest,
+      policyRevisionHash: "4".repeat(64),
+    });
+    const [row] = await getDb()
+      .select()
+      .from(executionAuthorizationNonces)
+      .where(eq(executionAuthorizationNonces.authorizationId, authorization.id));
+    const serialized = JSON.stringify(row).toLowerCase();
+    // The persisted authorization evidence must contain no private-key or raw
+    // secret material. The HMAC signature is derived from STEWARD_JWT_SECRET but
+    // never contains it; assert the secret itself does not leak.
+    for (const forbidden of ["privatekey", "private_key", "0x", "mnemonic", "seed phrase"]) {
+      expect(serialized.includes(forbidden)).toBe(false);
+    }
+    // The JWT secret used to derive the HMAC key must never appear.
+    expect(serialized.includes("execution-authorization-test-jwt-secret")).toBe(false);
   });
 
   it("rejects expired, tenant/backend-mismatched, and tampered authorizations", async () => {

--- a/packages/api/src/__tests__/execution-authorization.test.ts
+++ b/packages/api/src/__tests__/execution-authorization.test.ts
@@ -1,0 +1,119 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { agents, closeDb, executionAuthorizationNonces, getDb, tenants } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { eq } from "drizzle-orm";
+import {
+  consumeExecutionAuthorization,
+  executionPayloadDigestForEvmSign,
+  mintExecutionAuthorization,
+  sha256Hex,
+} from "../services/execution-authorization";
+
+const TENANT_ID = `exec-auth-tenant-${Date.now()}`;
+const AGENT_ID = `exec-auth-agent-${Date.now()}`;
+
+describe("execution authorization service", () => {
+  beforeAll(async () => {
+    process.env.STEWARD_PGLITE_MEMORY = "true";
+    process.env.STEWARD_DB_MODE = "pglite";
+    process.env.STEWARD_JWT_SECRET = "execution-authorization-test-jwt-secret-with-enough-entropy";
+    const { db, client } = await createPGLiteDb("memory://");
+    setPGLiteOverride(db, async () => {
+      await client.close();
+    });
+    await getDb()
+      .insert(tenants)
+      .values({
+        id: TENANT_ID,
+        name: "Execution Authorization Tenant",
+        apiKeyHash: `hash-${TENANT_ID}`,
+      });
+    await getDb().insert(agents).values({
+      id: AGENT_ID,
+      tenantId: TENANT_ID,
+      name: "Execution Authorization Agent",
+      walletAddress: "0x0000000000000000000000000000000000000001",
+    });
+  });
+
+  afterAll(async () => {
+    await closeDb();
+  });
+
+  it("canonicalizes JSON before digesting", () => {
+    expect(sha256Hex({ b: 2, a: { d: 4, c: 3 } })).toBe(sha256Hex({ a: { c: 3, d: 4 }, b: 2 }));
+  });
+
+  it("mints a signed 60s authorization and atomically consumes it once", async () => {
+    const payloadDigest = executionPayloadDigestForEvmSign({
+      tenantId: TENANT_ID,
+      agentId: AGENT_ID,
+      to: "0x1111111111111111111111111111111111111111",
+      value: "1",
+      data: "0x",
+      chainId: 8453,
+      broadcast: false,
+    });
+    const issuedAt = new Date();
+    const authorization = await mintExecutionAuthorization({
+      requestId: "tx-exec-auth-once",
+      tenantId: TENANT_ID,
+      agentId: AGENT_ID,
+      capability: "wallet.sign_transaction",
+      backend: "local-vault",
+      payloadDigest,
+      policyRevisionHash: "a".repeat(64),
+      idempotencyKey: "idem-exec-auth-once",
+      now: issuedAt,
+    });
+
+    expect(Date.parse(authorization.expiresAt) - Date.parse(authorization.issuedAt)).toBe(60_000);
+    expect(authorization.signature).toBeString();
+
+    await consumeExecutionAuthorization(authorization, {
+      tenantId: TENANT_ID,
+      agentId: AGENT_ID,
+      capability: "wallet.sign_transaction",
+      backend: "local-vault",
+      payloadDigest,
+    });
+
+    const [row] = await getDb()
+      .select({ status: executionAuthorizationNonces.status })
+      .from(executionAuthorizationNonces)
+      .where(eq(executionAuthorizationNonces.authorizationId, authorization.id));
+    expect(row?.status).toBe("consumed");
+
+    await expect(
+      consumeExecutionAuthorization(authorization, {
+        tenantId: TENANT_ID,
+        agentId: AGENT_ID,
+        capability: "wallet.sign_transaction",
+        backend: "local-vault",
+        payloadDigest,
+      }),
+    ).rejects.toThrow("expired or already consumed");
+  });
+
+  it("rejects a valid signature when the expected digest changes", async () => {
+    const authorization = await mintExecutionAuthorization({
+      requestId: "tx-exec-auth-digest",
+      tenantId: TENANT_ID,
+      agentId: AGENT_ID,
+      capability: "wallet.sign_transaction",
+      backend: "local-vault",
+      payloadDigest: "b".repeat(64),
+      policyRevisionHash: "c".repeat(64),
+    });
+
+    await expect(
+      consumeExecutionAuthorization(authorization, {
+        tenantId: TENANT_ID,
+        agentId: AGENT_ID,
+        capability: "wallet.sign_transaction",
+        backend: "local-vault",
+        payloadDigest: "d".repeat(64),
+      }),
+    ).rejects.toThrow("context does not match");
+  });
+});

--- a/packages/api/src/__tests__/execution-authorization.test.ts
+++ b/packages/api/src/__tests__/execution-authorization.test.ts
@@ -7,6 +7,7 @@ import {
   executionPayloadDigestForEvmSign,
   mintExecutionAuthorization,
   sha256Hex,
+  verifyExecutionAuthorization,
 } from "../services/execution-authorization";
 
 const TENANT_ID = `exec-auth-tenant-${Date.now()}`;
@@ -115,5 +116,38 @@ describe("execution authorization service", () => {
         payloadDigest: "d".repeat(64),
       }),
     ).rejects.toThrow("context does not match");
+  });
+
+  it("rejects expired, tenant/backend-mismatched, and tampered authorizations", async () => {
+    const payloadDigest = "e".repeat(64);
+    const expected = {
+      tenantId: TENANT_ID,
+      agentId: AGENT_ID,
+      capability: "wallet.sign_transaction" as const,
+      backend: "local-vault" as const,
+      payloadDigest,
+    };
+    const authorization = await mintExecutionAuthorization({
+      requestId: "tx-exec-auth-negative",
+      ...expected,
+      policyRevisionHash: "f".repeat(64),
+    });
+
+    expect(() =>
+      verifyExecutionAuthorization(authorization, { ...expected, tenantId: "other-tenant" }),
+    ).toThrow("context does not match");
+    expect(() =>
+      verifyExecutionAuthorization(authorization, { ...expected, backend: "external-custody" }),
+    ).toThrow("context does not match");
+    expect(() =>
+      verifyExecutionAuthorization({ ...authorization, signature: "tampered" }, expected),
+    ).toThrow("signature is invalid");
+
+    const expired = await mintExecutionAuthorization({
+      requestId: "tx-exec-auth-expired",
+      ...expected,
+      now: new Date(Date.now() - 61_000),
+    });
+    expect(() => verifyExecutionAuthorization(expired, expected)).toThrow("expired");
   });
 });

--- a/packages/api/src/__tests__/execution-gateway-inventory.test.ts
+++ b/packages/api/src/__tests__/execution-gateway-inventory.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+import { RAW_EVM_SIGN_EXPECTED_COUNTS, RAW_EVM_SIGN_INVENTORY } from "@stwd/shared";
+
+/**
+ * Repository-wide CI guard for the PR4 execution gateway raw-signer inventory.
+ *
+ * This scans EVERY production TypeScript file under packages/api/src (excluding
+ * __tests__) and counts raw `Vault.signTransaction(` call sites. It then asserts
+ * a one-for-one match against the shared inventory:
+ *
+ *  - every file that has a raw call is enumerated in RAW_EVM_SIGN_EXPECTED_COUNTS
+ *    with the EXACT count (adding a raw call to intents.ts / user.ts / a NEW file
+ *    fails until the inventory is updated),
+ *  - no inventory file may have fewer raw calls than enumerated (deleting an
+ *    inventory entry without removing the call, or vice versa, fails),
+ *  - each inventory row's stable marker is present in its file (so the
+ *    classification anchors to a real, findable call site rather than a brittle
+ *    line number).
+ *
+ * The scan lives in packages/api (not packages/shared) so it never statically
+ * imports across package rootDirs; it only reads source files off disk, which is
+ * exactly what a scanner should do (avoids the TS6059 cross-rootDir hazard).
+ */
+
+const API_ROOT = join(import.meta.dir, "..", ".."); // packages/api
+const SRC_DIR = join(API_ROOT, "src");
+const REPO_PREFIX = "packages/api/"; // inventory files are repo-relative
+
+// Matches the two raw invocation forms used in the codebase:
+//   vault.signTransaction(       (module-singleton proxy)
+//   getVault().signTransaction(  (lazy accessor)
+// Deliberately does NOT match `signTransactionAuthorized(` (the governed path)
+// or `signSolanaTransaction(` / `signTransactionOptions`.
+const RAW_SIGN_RE = /\b(?:vault|getVault\(\))\.signTransaction\(/g;
+
+function listTsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "__tests__" || entry.name === "node_modules") continue;
+      out.push(...listTsFiles(full));
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith(".ts") && !entry.name.endsWith(".d.ts")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function repoRelative(absPath: string): string {
+  // -> packages/api/src/routes/vault.ts
+  return REPO_PREFIX + relative(API_ROOT, absPath).split("\\").join("/");
+}
+
+describe("execution gateway raw-signer inventory (repository-wide)", () => {
+  test("actual per-file raw signTransaction counts match the shared inventory", () => {
+    const actualCounts: Record<string, number> = {};
+    for (const file of listTsFiles(SRC_DIR)) {
+      const source = readFileSync(file, "utf8");
+      const count = [...source.matchAll(RAW_SIGN_RE)].length;
+      if (count > 0) actualCounts[repoRelative(file)] = count;
+    }
+
+    // Exact one-for-one equality: every raw-sign file is enumerated with the
+    // exact count, and no enumerated file is missing / miscounted. A new raw
+    // call anywhere OR a stale inventory entry breaks this.
+    expect(actualCounts).toEqual({ ...RAW_EVM_SIGN_EXPECTED_COUNTS });
+  });
+
+  test("every inventory marker anchors to a real call site in its file", () => {
+    for (const site of RAW_EVM_SIGN_INVENTORY) {
+      const abs = join(API_ROOT, site.file.slice(REPO_PREFIX.length));
+      const source = readFileSync(abs, "utf8");
+      expect(
+        source,
+        `${site.file} must be readable for inventory marker "${site.marker}"`,
+      ).toBeTruthy();
+      expect(
+        source.includes(site.marker),
+        `inventory marker "${site.marker}" must be present in ${site.file}`,
+      ).toBe(true);
+    }
+  });
+
+  test("migrated-guarded vault call sites are preceded by an invariant guard", () => {
+    const vaultSource = readFileSync(join(SRC_DIR, "routes", "vault.ts"), "utf8");
+    for (const site of RAW_EVM_SIGN_INVENTORY) {
+      if (site.classification !== "migrated-invariant-guarded") continue;
+      if (site.file !== "packages/api/src/routes/vault.ts") continue;
+      // The marker for the guarded sites IS the invariant throw string, which
+      // must appear before the corresponding raw call. Presence is asserted
+      // above; here we assert the invariant strings the runtime relies on exist.
+      expect(vaultSource.includes(site.marker)).toBe(true);
+    }
+    // Both primary + approval invariant guards must exist.
+    expect(vaultSource).toContain(
+      "invariant: primary EVM sign reached raw signer without gateway authorization",
+    );
+    expect(vaultSource).toContain(
+      "invariant: primary EVM approval reached raw signer without gateway authorization",
+    );
+  });
+});

--- a/packages/api/src/__tests__/execution-gateway-inventory.test.ts
+++ b/packages/api/src/__tests__/execution-gateway-inventory.test.ts
@@ -7,33 +7,56 @@ import { RAW_EVM_SIGN_EXPECTED_COUNTS, RAW_EVM_SIGN_INVENTORY } from "@stwd/shar
  * Repository-wide CI guard for the PR4 execution gateway raw-signer inventory.
  *
  * This scans EVERY production TypeScript file under packages/api/src (excluding
- * __tests__) and counts raw `Vault.signTransaction(` call sites. It then asserts
- * a one-for-one match against the shared inventory:
+ * __tests__) and counts raw member-call `.signTransaction(` sites in ANY form
+ * (vault.signTransaction(, getVault().signTransaction(, signer.signTransaction(,
+ * this.vault.signTransaction(, someVault.signTransaction(, whitespace variants).
+ * It then asserts a one-for-one match against the shared inventory:
  *
  *  - every file that has a raw call is enumerated in RAW_EVM_SIGN_EXPECTED_COUNTS
  *    with the EXACT count (adding a raw call to intents.ts / user.ts / a NEW file
- *    fails until the inventory is updated),
+ *    fails until the inventory is updated and classifies the new hit),
  *  - no inventory file may have fewer raw calls than enumerated (deleting an
  *    inventory entry without removing the call, or vice versa, fails),
  *  - each inventory row's stable marker is present in its file (so the
  *    classification anchors to a real, findable call site rather than a brittle
  *    line number).
  *
- * The scan lives in packages/api (not packages/shared) so it never statically
- * imports across package rootDirs; it only reads source files off disk, which is
- * exactly what a scanner should do (avoids the TS6059 cross-rootDir hazard).
+ * It also guards against BARE-IDENTIFIER references (destructured / aliased
+ * forms such as `const { signTransaction } = vault`) that would smuggle a raw
+ * signer past the member-call scan. Every `signTransaction` occurrence that is
+ * NOT a governed `.signTransactionAuthorized(` call and NOT a counted raw
+ * member-call must be one of a tiny allow-list of benign non-call forms
+ * (an object-property capability key, a documentation comment). Anything else
+ * fails with an instruction to classify or remove it.
+ *
+ * The bar: adding a raw sign call in ANY form/file fails CI with a
+ * classification instruction. The scan lives in packages/api (not
+ * packages/shared) so it never statically imports across package rootDirs; it
+ * only reads source files off disk, which is exactly what a scanner should do
+ * (avoids the TS6059 cross-rootDir hazard).
  */
 
 const API_ROOT = join(import.meta.dir, "..", ".."); // packages/api
 const SRC_DIR = join(API_ROOT, "src");
 const REPO_PREFIX = "packages/api/"; // inventory files are repo-relative
 
-// Matches the two raw invocation forms used in the codebase:
-//   vault.signTransaction(       (module-singleton proxy)
-//   getVault().signTransaction(  (lazy accessor)
-// Deliberately does NOT match `signTransactionAuthorized(` (the governed path)
-// or `signSolanaTransaction(` / `signTransactionOptions`.
-const RAW_SIGN_RE = /\b(?:vault|getVault\(\))\.signTransaction\(/g;
+// Broadened raw-call matcher: ANY member call `<recv>.signTransaction(`, where
+// <recv> ends in an identifier char, a closing paren, or a closing bracket
+// (covers vault.x, getVault().x, this.vault.x, arr[i].x, someVault.x), with
+// arbitrary whitespace around the dot and before the paren. It deliberately
+// does NOT match `.signTransactionAuthorized(` (the governed path) because the
+// pattern requires `signTransaction` be immediately followed by `\s*\(`, and
+// the Authorized variant has `Authorized` in between.
+const RAW_SIGN_RE = /[\w$)\]]\s*\.\s*signTransaction\s*\(/g;
+
+// Governed path: `<recv>.signTransactionAuthorized(`. Counted separately and
+// never flagged as a raw signer.
+const GOVERNED_SIGN_RE = /[\w$)\]]\s*\.\s*signTransactionAuthorized\s*\(/g;
+
+// Any textual occurrence of the identifier `signTransaction` (word-bounded so
+// `signTransactionAuthorized` and `signTransactionOptions` are matched here and
+// classified below, not silently ignored).
+const ANY_SIGN_TOKEN_RE = /signTransaction/g;
 
 function listTsFiles(dir: string): string[] {
   const out: string[] = [];
@@ -56,8 +79,50 @@ function repoRelative(absPath: string): string {
   return REPO_PREFIX + relative(API_ROOT, absPath).split("\\").join("/");
 }
 
+/**
+ * Classify a single `signTransaction` token occurrence in a production source
+ * file into exactly one bucket. Returns a category plus a human-facing note so
+ * an unrecognized form fails with an instruction rather than a bare boolean.
+ */
+function classifyTokenAt(
+  source: string,
+  index: number,
+): { kind: "raw-call" | "governed-call" | "options-type" | "property-key" | "comment-ref"; note: string } | null {
+  const token = "signTransaction";
+  const after = source.slice(index + token.length);
+  const before = source.slice(Math.max(0, index - 64), index);
+
+  // 1. Governed call: signTransactionAuthorized( ...
+  if (/^Authorized\s*\(/.test(after)) {
+    // Only classify as governed when it is actually a member call (preceded by
+    // a member-access receiver), otherwise fall through to stricter checks.
+    if (/[\w$)\]]\s*\.\s*$/.test(before)) return { kind: "governed-call", note: "governed .signTransactionAuthorized( call" };
+  }
+
+  // 2. Options type reference: SignTransactionOptions etc. never appears as
+  //    lowercase `signTransaction` + `Options`, but guard anyway.
+  if (/^Options\b/.test(after)) return { kind: "options-type", note: "SignTransactionOptions type reference" };
+
+  // 3. Raw member call: <recv>.signTransaction( (NOT Authorized, NOT Options).
+  if (/^\s*\(/.test(after) && /[\w$)\]]\s*\.\s*$/.test(before)) {
+    return { kind: "raw-call", note: "raw member .signTransaction( call" };
+  }
+
+  // 4. Object-property capability key: `signTransaction:` in a policy/capability
+  //    map (e.g. routes/accounts.ts operation flags). Not a call, not a signer.
+  if (/^\s*:/.test(after)) return { kind: "property-key", note: "object-property capability key" };
+
+  // 5. Documentation reference inside a line comment (e.g. `raw Vault.signTransaction`).
+  //    The occurrence must sit on a line whose first non-space characters are `//`.
+  const lineStart = source.lastIndexOf("\n", index) + 1;
+  const lineHead = source.slice(lineStart, index);
+  if (/^\s*(\/\/|\*|\/\*)/.test(lineHead)) return { kind: "comment-ref", note: "documentation comment reference" };
+
+  return null;
+}
+
 describe("execution gateway raw-signer inventory (repository-wide)", () => {
-  test("actual per-file raw signTransaction counts match the shared inventory", () => {
+  test("actual per-file raw signTransaction counts match the shared inventory (any member-call form)", () => {
     const actualCounts: Record<string, number> = {};
     for (const file of listTsFiles(SRC_DIR)) {
       const source = readFileSync(file, "utf8");
@@ -68,7 +133,73 @@ describe("execution gateway raw-signer inventory (repository-wide)", () => {
     // Exact one-for-one equality: every raw-sign file is enumerated with the
     // exact count, and no enumerated file is missing / miscounted. A new raw
     // call anywhere OR a stale inventory entry breaks this.
-    expect(actualCounts).toEqual({ ...RAW_EVM_SIGN_EXPECTED_COUNTS });
+    expect(
+      actualCounts,
+      "A raw `.signTransaction(` call site changed. Every raw signer must be " +
+        "classified in RAW_EVM_SIGN_INVENTORY (packages/shared/src/security-surface.ts) " +
+        "with an exact per-file count. Add/remove the inventory entry (and its marker) " +
+        "to match, or migrate the call to the governed .signTransactionAuthorized( path.",
+    ).toEqual({ ...RAW_EVM_SIGN_EXPECTED_COUNTS });
+  });
+
+  test("every signTransaction token is classified (no smuggled bare/aliased raw signer)", () => {
+    // Cross-check: the number of raw-call classifications equals the total of
+    // the per-file inventory counts, and no token is left UNCLASSIFIED. This is
+    // what catches destructured/aliased forms and any novel call shape.
+    const expectedRawTotal = Object.values(RAW_EVM_SIGN_EXPECTED_COUNTS).reduce((a, b) => a + b, 0);
+    let rawCallTotal = 0;
+    const unclassified: string[] = [];
+
+    for (const file of listTsFiles(SRC_DIR)) {
+      const source = readFileSync(file, "utf8");
+      for (const match of source.matchAll(ANY_SIGN_TOKEN_RE)) {
+        const index = match.index ?? 0;
+        const classified = classifyTokenAt(source, index);
+        if (!classified) {
+          const lineNo = source.slice(0, index).split("\n").length;
+          const snippetStart = source.lastIndexOf("\n", index) + 1;
+          const snippetEnd = source.indexOf("\n", index);
+          const snippet = source.slice(snippetStart, snippetEnd === -1 ? source.length : snippetEnd).trim();
+          unclassified.push(`${repoRelative(file)}:${lineNo}  ${snippet}`);
+          continue;
+        }
+        if (classified.kind === "raw-call") rawCallTotal += 1;
+      }
+    }
+
+    expect(
+      unclassified,
+      "Unrecognized `signTransaction` reference(s) found. A raw signer must be a " +
+        "counted `.signTransaction(` member call (classified in RAW_EVM_SIGN_INVENTORY), " +
+        "the governed `.signTransactionAuthorized(` call, an object-property capability " +
+        "key, or a documentation comment. A bare/destructured/aliased reference " +
+        "(e.g. `const { signTransaction } = vault`) is NOT allowed — remove it or route " +
+        "through the governed path:\n" +
+        unclassified.join("\n"),
+    ).toEqual([]);
+
+    expect(
+      rawCallTotal,
+      "The classified raw member-call count must equal the inventory total. A drift " +
+        "here means a raw call was added/removed without updating RAW_EVM_SIGN_INVENTORY.",
+    ).toBe(expectedRawTotal);
+  });
+
+  test("no governed .signTransactionAuthorized( call is miscounted as a raw signer", () => {
+    // Belt-and-suspenders: the raw matcher must never match the governed form.
+    for (const file of listTsFiles(SRC_DIR)) {
+      const source = readFileSync(file, "utf8");
+      const governed = [...source.matchAll(GOVERNED_SIGN_RE)];
+      for (const g of governed) {
+        // Re-run the raw matcher against the exact governed slice; it must not
+        // produce a match, proving the raw regex excludes the Authorized form.
+        const slice = source.slice(g.index ?? 0, (g.index ?? 0) + (g[0]?.length ?? 0) + 1);
+        expect(
+          new RegExp(RAW_SIGN_RE.source).test(slice),
+          `governed call in ${repoRelative(file)} was matched by the raw signer regex`,
+        ).toBe(false);
+      }
+    }
   });
 
   test("every inventory marker anchors to a real call site in its file", () => {

--- a/packages/api/src/__tests__/execution-gateway-inventory.test.ts
+++ b/packages/api/src/__tests__/execution-gateway-inventory.test.ts
@@ -87,7 +87,10 @@ function repoRelative(absPath: string): string {
 function classifyTokenAt(
   source: string,
   index: number,
-): { kind: "raw-call" | "governed-call" | "options-type" | "property-key" | "comment-ref"; note: string } | null {
+): {
+  kind: "raw-call" | "governed-call" | "options-type" | "property-key" | "comment-ref";
+  note: string;
+} | null {
   const token = "signTransaction";
   const after = source.slice(index + token.length);
   const before = source.slice(Math.max(0, index - 64), index);
@@ -96,12 +99,14 @@ function classifyTokenAt(
   if (/^Authorized\s*\(/.test(after)) {
     // Only classify as governed when it is actually a member call (preceded by
     // a member-access receiver), otherwise fall through to stricter checks.
-    if (/[\w$)\]]\s*\.\s*$/.test(before)) return { kind: "governed-call", note: "governed .signTransactionAuthorized( call" };
+    if (/[\w$)\]]\s*\.\s*$/.test(before))
+      return { kind: "governed-call", note: "governed .signTransactionAuthorized( call" };
   }
 
   // 2. Options type reference: SignTransactionOptions etc. never appears as
   //    lowercase `signTransaction` + `Options`, but guard anyway.
-  if (/^Options\b/.test(after)) return { kind: "options-type", note: "SignTransactionOptions type reference" };
+  if (/^Options\b/.test(after))
+    return { kind: "options-type", note: "SignTransactionOptions type reference" };
 
   // 3. Raw member call: <recv>.signTransaction( (NOT Authorized, NOT Options).
   if (/^\s*\(/.test(after) && /[\w$)\]]\s*\.\s*$/.test(before)) {
@@ -116,7 +121,8 @@ function classifyTokenAt(
   //    The occurrence must sit on a line whose first non-space characters are `//`.
   const lineStart = source.lastIndexOf("\n", index) + 1;
   const lineHead = source.slice(lineStart, index);
-  if (/^\s*(\/\/|\*|\/\*)/.test(lineHead)) return { kind: "comment-ref", note: "documentation comment reference" };
+  if (/^\s*(\/\/|\*|\/\*)/.test(lineHead))
+    return { kind: "comment-ref", note: "documentation comment reference" };
 
   return null;
 }
@@ -159,7 +165,9 @@ describe("execution gateway raw-signer inventory (repository-wide)", () => {
           const lineNo = source.slice(0, index).split("\n").length;
           const snippetStart = source.lastIndexOf("\n", index) + 1;
           const snippetEnd = source.indexOf("\n", index);
-          const snippet = source.slice(snippetStart, snippetEnd === -1 ? source.length : snippetEnd).trim();
+          const snippet = source
+            .slice(snippetStart, snippetEnd === -1 ? source.length : snippetEnd)
+            .trim();
           unclassified.push(`${repoRelative(file)}:${lineNo}  ${snippet}`);
           continue;
         }

--- a/packages/api/src/__tests__/vault-aggregation-enforcement.test.ts
+++ b/packages/api/src/__tests__/vault-aggregation-enforcement.test.ts
@@ -153,19 +153,132 @@ describe("aggregation cap enforcement (vault.ts wiring)", () => {
     expect(ctxField).toBeGreaterThan(evaluate);
   });
 
-  it("records the authoritative aggregation event (awaited) on commit, in-lock", () => {
+  it("records the authoritative aggregation event (awaited) on commit, AFTER signing, in-lock", () => {
     const routeStart = vaultSource.indexOf('vaultRoutes.post("/:agentId/sign"');
     const routeEnd = vaultSource.indexOf('vaultRoutes.post("/:agentId/actions/transfer/quote"');
     const route = vaultSource.slice(routeStart, routeEnd);
 
-    const sign = route.indexOf("await vault.signTransaction(signRequest");
-    const record = route.indexOf("await recordAggregationEvent({");
+    assertRecordAfterSigning(route);
+  });
+});
 
-    expect(sign).toBeGreaterThanOrEqual(0);
-    // Recorded only AFTER the transaction is actually signed/committed …
-    expect(record).toBeGreaterThan(sign);
-    // … and AWAITED (not fire-and-forget) so the next in-lock snapshot includes it.
-    expect(route).toContain("await recordAggregationEvent({");
-    expect(route).toContain("valueRaw: signRequest.value");
+// ─── source-contract helper: signing precedes the awaited record ────────────────
+
+/**
+ * The signing ordering invariant this route MUST uphold on the money path:
+ * every actual signing invocation is issued BEFORE the authoritative
+ * `await recordAggregationEvent({ … })`, and that record is AWAITED (not
+ * fire-and-forget) so the next in-lock snapshot includes this contribution.
+ *
+ * PR #182 refactored EVM signing to the gateway-authorized form
+ * `signTransactionAuthorized(signRequest, …)` while the non-EVM (Solana)
+ * fallback still uses the raw `vault.signTransaction(signRequest, …)`. A brittle
+ * anchor on one literal spelling (or on `await` vs `return`) drifts the moment
+ * either branch is reshaped. Instead we recognize BOTH signing call shapes
+ * structurally, require at least one to be present (fail helpfully if a refactor
+ * removes all recognized signing forms), and assert every present signing form
+ * precedes the record. Moving the record before ANY present signing form fails.
+ *
+ * Exported as a free function so the same contract can be exercised against an
+ * in-memory fixture in this file's proof tests below.
+ */
+function signingCallIndices(route: string): number[] {
+  // Both recognized signing forms on the primary sign money path. Decoupled
+  // from `await` vs `return` and from the surrounding call chain: we anchor on
+  // the signing method name immediately applied to `signRequest`.
+  //   • EVM (gateway-authorized): `…signTransactionAuthorized(signRequest, …)`
+  //   • non-EVM (raw fallback):   `…vault.signTransaction(signRequest, …)`
+  // `signTransactionAuthorized(signRequest` is matched exclusively so it is not
+  // also double-counted by the `signTransaction(signRequest` substring.
+  const indices: number[] = [];
+  const patterns = [
+    /signTransactionAuthorized\(\s*signRequest\b/g,
+    /(?<!Authorized\()\bvault\.signTransaction\(\s*signRequest\b/g,
+  ];
+  for (const pattern of patterns) {
+    for (const match of route.matchAll(pattern)) {
+      if (match.index !== undefined) indices.push(match.index);
+    }
+  }
+  return indices.sort((a, b) => a - b);
+}
+
+function assertRecordAfterSigning(route: string): void {
+  const signingIndices = signingCallIndices(route);
+  const record = route.indexOf("await recordAggregationEvent({");
+
+  // The record itself must exist, be AWAITED, and carry the authoritative value.
+  expect(record).toBeGreaterThanOrEqual(0);
+  expect(route).toContain("await recordAggregationEvent({");
+  expect(route).toContain("valueRaw: signRequest.value");
+
+  // At least one recognized signing form must be present. If a refactor removes
+  // BOTH the authorized-EVM and raw-non-EVM signing calls, fail loudly here
+  // rather than silently passing an ordering check over zero signing sites.
+  expect(
+    signingIndices.length,
+    "expected at least one recognized signing call (signTransactionAuthorized(signRequest …) " +
+      "or vault.signTransaction(signRequest …)) on the sign money path",
+  ).toBeGreaterThan(0);
+
+  // EVERY present signing form must precede the awaited record. Moving the
+  // record before any present signing call (the real regression we guard) makes
+  // the earliest signing index exceed the record index and fails here.
+  for (const signIndex of signingIndices) {
+    expect(
+      record,
+      "await recordAggregationEvent(...) must appear AFTER every signing call on the money path",
+    ).toBeGreaterThan(signIndex);
+  }
+}
+
+// ─── 3. proof: the source-contract assertion actually discriminates ─────────────
+//
+// Exercises `assertRecordAfterSigning` against in-memory string fixtures to
+// prove it (a) passes on a route that matches the current shape, (b) fails when
+// NO recognized signing form is present, and (c) fails when the record is moved
+// before a present signing form. This is the effectiveness proof required by
+// the CI-fix scope; it needs no real route source.
+
+describe("aggregation source-contract assertion (self-proof)", () => {
+  const RECORD = "await recordAggregationEvent({\n  valueRaw: signRequest.value,\n});";
+  const EVM_SIGN = "await gv.signTransactionAuthorized(signRequest, { txId });";
+  const RAW_SIGN = "return vault.signTransaction(signRequest, { txId });";
+
+  it("PASSES when both EVM-authorized and raw signing precede the awaited record", () => {
+    const route = `${EVM_SIGN}\n${RAW_SIGN}\n${RECORD}`;
+    expect(() => assertRecordAfterSigning(route)).not.toThrow();
+  });
+
+  it("PASSES for an EVM-only route (authorized signing precedes the record)", () => {
+    const route = `${EVM_SIGN}\n${RECORD}`;
+    expect(() => assertRecordAfterSigning(route)).not.toThrow();
+  });
+
+  it("PASSES for a non-EVM-only route (raw fallback precedes the record)", () => {
+    const route = `${RAW_SIGN}\n${RECORD}`;
+    expect(() => assertRecordAfterSigning(route)).not.toThrow();
+  });
+
+  it("FAILS when NO recognized signing form is present", () => {
+    // A route that records but has no signing call at all must not pass.
+    const route = `const x = 1;\n${RECORD}`;
+    expect(() => assertRecordAfterSigning(route)).toThrow();
+  });
+
+  it("FAILS when the record is moved BEFORE the (only) signing form", () => {
+    const route = `${RECORD}\n${EVM_SIGN}`;
+    expect(() => assertRecordAfterSigning(route)).toThrow();
+  });
+
+  it("FAILS when the record precedes the raw non-EVM signing form", () => {
+    const route = `${RECORD}\n${RAW_SIGN}`;
+    expect(() => assertRecordAfterSigning(route)).toThrow();
+  });
+
+  it("FAILS when the record sits between two signing forms (a present form is not preceded)", () => {
+    // record after EVM sign but before raw sign → the raw sign is not preceded.
+    const route = `${EVM_SIGN}\n${RECORD}\n${RAW_SIGN}`;
+    expect(() => assertRecordAfterSigning(route)).toThrow();
   });
 });

--- a/packages/api/src/__tests__/vault-approval-gates.test.ts
+++ b/packages/api/src/__tests__/vault-approval-gates.test.ts
@@ -46,6 +46,10 @@ import { Vault } from "@stwd/vault";
 import { and, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import type { AppVariables } from "../services/context";
+import {
+  executionPayloadDigestForEvmSign,
+  policyRevisionHashForPolicySet,
+} from "../services/execution-authorization";
 
 const TENANT_ID = `approval-gate-tenant-${Date.now()}`;
 const ACTOR_ID = "00000000-0000-4000-8000-000000000001";
@@ -116,6 +120,25 @@ async function seedPendingTx(
   to: string,
   requestedBy?: { type: string; id: string },
 ) {
+  // Persist the execution-authorization binding exactly as the real /sign path
+  // now does when it queues a primary EVM approval. Post-gateway, a genuinely
+  // pending EVM approval ALWAYS carries a stored digest + policy-revision hash;
+  // the approve handler fails closed on legacy/null-digest rows. These fixtures
+  // exercise the downstream gates (separation-of-duties, current-policy
+  // re-eval, audit-before-sign), so they must look like a properly-bound row.
+  //
+  // The stored digest is computed over the SAME normalized intent the approve
+  // handler recomputes from the replay request: toSignRequest(row) gives
+  // agentId/to/value/chainId (+ data), with nonce/gasLimit/venue/walletAddress
+  // absent because actionPayload only carries {type,broadcast:false}.
+  const boundDigest = executionPayloadDigestForEvmSign({
+    agentId,
+    tenantId: TENANT_ID,
+    to,
+    value: "1000",
+    chainId: 8453,
+    broadcast: false,
+  });
   await getDb()
     .insert(transactions)
     .values({
@@ -126,6 +149,8 @@ async function seedPendingTx(
       value: "1000",
       chainId: 8453,
       actionPayload: { type: "transaction", broadcast: false },
+      executionPayloadDigest: boundDigest,
+      executionPolicyRevisionHash: policyRevisionHashForPolicySet([]),
       policyResults: [],
     });
   await getDb()

--- a/packages/api/src/__tests__/vault-approval-gates.test.ts
+++ b/packages/api/src/__tests__/vault-approval-gates.test.ts
@@ -152,6 +152,7 @@ describe("vault approval gates (real /approve path)", () => {
   beforeAll(async () => {
     process.env.STEWARD_PGLITE_MEMORY = "true";
     process.env.STEWARD_MASTER_PASSWORD = "approval-gate-master-password";
+    process.env.STEWARD_JWT_SECRET = "approval-gate-jwt-secret-with-enough-entropy-0123456789";
     process.env.STEWARD_AUDIT_HMAC_KEY ??=
       "approval-gate-test-audit-hmac-key-0123456789abcdef0123456789";
     const { db, client } = await createPGLiteDb("memory://");

--- a/packages/api/src/__tests__/vault-execution-gateway.test.ts
+++ b/packages/api/src/__tests__/vault-execution-gateway.test.ts
@@ -1,0 +1,195 @@
+import { afterAll, beforeAll, describe, expect, it, spyOn } from "bun:test";
+import {
+  agents,
+  approvalQueue,
+  auditEvents,
+  closeDb,
+  executionAuthorizationNonces,
+  getDb,
+  policies,
+  tenants,
+  transactions,
+  users,
+  userTenants,
+} from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { Vault } from "@stwd/vault";
+import { eq } from "drizzle-orm";
+import { Hono } from "hono";
+import type { AppVariables } from "../services/context";
+import { executionPayloadDigestForEvmSign } from "../services/execution-authorization";
+
+const TENANT_ID = `gateway-tenant-${Date.now()}`;
+const AGENT_ID = `gateway-agent-${Date.now()}`;
+const USER_ID = "00000000-0000-4000-8000-000000000123";
+
+async function makeApp() {
+  const { vaultRoutes } = await import("../routes/vault");
+  const app = new Hono<{ Variables: AppVariables }>();
+  app.use("*", async (c, next) => {
+    c.set("tenantId", TENANT_ID);
+    c.set("authType", "session-jwt");
+    c.set("tenantRole", "owner");
+    c.set("userId", USER_ID);
+    c.set("sessionMfaVerifiedAt", Date.now());
+    await next();
+  });
+  app.route("/vault", vaultRoutes);
+  return app;
+}
+
+describe("vault EVM execution gateway", () => {
+  beforeAll(async () => {
+    process.env.STEWARD_PGLITE_MEMORY = "true";
+    process.env.STEWARD_DB_MODE = "pglite";
+    process.env.STEWARD_MASTER_PASSWORD = "gateway-test-master-password";
+    process.env.STEWARD_JWT_SECRET = "gateway-test-jwt-secret-with-enough-entropy-0123456789";
+    process.env.STEWARD_AUDIT_HMAC_KEY = "b".repeat(64);
+    process.env.STEWARD_ALLOW_UNSAFE_CONTRACT_CALL_SIGNING = "true";
+    const { db, client } = await createPGLiteDb("memory://");
+    setPGLiteOverride(db, async () => {
+      await client.close();
+    });
+    await getDb()
+      .insert(tenants)
+      .values({
+        id: TENANT_ID,
+        name: "Gateway Tenant",
+        apiKeyHash: `hash-${TENANT_ID}`,
+      });
+    await getDb().insert(users).values({
+      id: USER_ID,
+      email: "gateway-owner@example.test",
+    });
+    await getDb().insert(userTenants).values({
+      userId: USER_ID,
+      tenantId: TENANT_ID,
+      role: "owner",
+    });
+    await getDb().insert(agents).values({
+      id: AGENT_ID,
+      tenantId: TENANT_ID,
+      name: "Gateway Agent",
+      walletAddress: "0x0000000000000000000000000000000000000001",
+    });
+    await getDb()
+      .insert(policies)
+      .values({
+        id: `${AGENT_ID}-approved-addresses`,
+        agentId: AGENT_ID,
+        type: "approved-addresses",
+        enabled: true,
+        config: {
+          mode: "whitelist",
+          addresses: ["0x1111111111111111111111111111111111111111"],
+        },
+      });
+  });
+
+  afterAll(async () => {
+    delete process.env.STEWARD_ALLOW_UNSAFE_CONTRACT_CALL_SIGNING;
+    await closeDb();
+  });
+
+  it("mints and consumes an execution authorization before primary EVM signing", async () => {
+    const signSpy = spyOn(Vault.prototype, "signTransaction").mockImplementation(async () => {
+      return "0xsigned";
+    });
+    try {
+      const app = await makeApp();
+      const res = await app.request(`/vault/${AGENT_ID}/sign`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          to: "0x1111111111111111111111111111111111111111",
+          value: "1",
+          data: "0x12345678",
+          chainId: 8453,
+          broadcast: false,
+        }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.ok).toBe(true);
+      expect(signSpy).toHaveBeenCalledTimes(1);
+
+      const nonceRows = await getDb()
+        .select({ status: executionAuthorizationNonces.status })
+        .from(executionAuthorizationNonces);
+      expect(nonceRows).toEqual([{ status: "consumed" }]);
+
+      const audits = await getDb()
+        .select({ action: auditEvents.action })
+        .from(auditEvents)
+        .where(eq(auditEvents.tenantId, TENANT_ID));
+      expect(audits.map((row) => row.action)).toContain("vault.execution_authorization.minted");
+      expect(audits.map((row) => row.action)).toContain("vault.execution_authorization.consumed");
+    } finally {
+      signSpy.mockRestore();
+    }
+  });
+
+  it("mints and consumes an execution authorization for primary EVM approval replay", async () => {
+    const txId = "tx-gateway-approval-replay";
+    const replayRequest = {
+      tenantId: TENANT_ID,
+      agentId: AGENT_ID,
+      to: "0x1111111111111111111111111111111111111111",
+      value: "1",
+      data: "0x12345678",
+      chainId: 8453,
+      broadcast: false,
+    };
+    await getDb()
+      .insert(transactions)
+      .values({
+        id: txId,
+        agentId: AGENT_ID,
+        status: "pending",
+        toAddress: replayRequest.to,
+        value: replayRequest.value,
+        data: replayRequest.data,
+        chainId: replayRequest.chainId,
+        actionPayload: { type: "transaction", broadcast: false },
+        executionPayloadDigest: executionPayloadDigestForEvmSign(replayRequest),
+        executionPolicyRevisionHash: "queued-policy-revision",
+        policyResults: [],
+      });
+    await getDb()
+      .insert(approvalQueue)
+      .values({
+        id: `aq-${txId}`,
+        txId,
+        agentId: AGENT_ID,
+        status: "pending",
+        requestedByType: "agent",
+        requestedById: AGENT_ID,
+      });
+
+    const signSpy = spyOn(Vault.prototype, "signTransaction").mockImplementation(async () => {
+      return "0xsigned";
+    });
+    try {
+      const app = await makeApp();
+      const res = await app.request(`/vault/${AGENT_ID}/approve/${txId}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{}",
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.ok).toBe(true);
+      expect(signSpy).toHaveBeenCalledTimes(1);
+
+      const nonceRows = await getDb()
+        .select({ status: executionAuthorizationNonces.status })
+        .from(executionAuthorizationNonces)
+        .where(eq(executionAuthorizationNonces.requestId, txId));
+      expect(nonceRows).toEqual([{ status: "consumed" }]);
+    } finally {
+      signSpy.mockRestore();
+    }
+  });
+});

--- a/packages/api/src/__tests__/vault-execution-gateway.test.ts
+++ b/packages/api/src/__tests__/vault-execution-gateway.test.ts
@@ -461,6 +461,20 @@ describe("vault EVM execution gateway", () => {
     await expectFailClosed(txId, "malformed_transaction_action_payload");
   });
 
+  it("fails closed on a present-null broadcast in the action payload", async () => {
+    const txId = "tx-fail-null-broadcast";
+    await seedPendingEvmApproval(txId, {
+      actionPayload: {
+        type: "transaction",
+        broadcast: null, // present null is not a boolean -> must fail closed
+        nonce: REPLAY_BASE.nonce,
+        gasLimit: REPLAY_BASE.gasLimit,
+        walletAddress: REPLAY_BASE.walletAddress,
+      },
+    });
+    await expectFailClosed(txId, "malformed_transaction_action_payload");
+  });
+
   it("fails closed on a wrong-type gasLimit in the action payload", async () => {
     const txId = "tx-fail-wrong-gaslimit";
     await seedPendingEvmApproval(txId, {
@@ -499,6 +513,75 @@ describe("vault EVM execution gateway", () => {
         nonce: REPLAY_BASE.nonce,
         gasLimit: REPLAY_BASE.gasLimit,
         walletAddress: 12345, // wrong type: number, must be a string
+      },
+    });
+    await expectFailClosed(txId, "malformed_transaction_action_payload");
+  });
+
+  // ── ROUND 3 / ITEM 1: present-null must fail closed (not be normalized away) ─
+  // A PRESENT null for nonce/gasLimit/venue/walletAddress is distinct from an
+  // absent key. The old validator used `x !== undefined && x !== null`, which
+  // treated a present null as "absent" and silently dropped it, mutating the
+  // digested intent without a rejection. The validator now distinguishes
+  // absence from present-null via Object.hasOwn, so each of these fails closed:
+  // 409 + malformed_transaction_action_payload audit + zero nonce rows + zero
+  // raw signer calls (all asserted by expectFailClosed). Legitimately-minted
+  // payloads never serialize explicit nulls for these fields (the
+  // transactionActionPayload builder omits undefined/null keys and jsonb never
+  // injects nulls), so these payloads can only be malformed/adversarial.
+
+  it("fails closed on a present-null nonce in the action payload", async () => {
+    const txId = "tx-fail-null-nonce";
+    await seedPendingEvmApproval(txId, {
+      actionPayload: {
+        type: "transaction",
+        broadcast: false,
+        nonce: null, // present null must be rejected, not normalized to omitted
+        gasLimit: REPLAY_BASE.gasLimit,
+        walletAddress: REPLAY_BASE.walletAddress,
+      },
+    });
+    await expectFailClosed(txId, "malformed_transaction_action_payload");
+  });
+
+  it("fails closed on a present-null gasLimit in the action payload", async () => {
+    const txId = "tx-fail-null-gaslimit";
+    await seedPendingEvmApproval(txId, {
+      actionPayload: {
+        type: "transaction",
+        broadcast: false,
+        nonce: REPLAY_BASE.nonce,
+        gasLimit: null, // present null must be rejected, not normalized to omitted
+        walletAddress: REPLAY_BASE.walletAddress,
+      },
+    });
+    await expectFailClosed(txId, "malformed_transaction_action_payload");
+  });
+
+  it("fails closed on a present-null venue in the action payload", async () => {
+    const txId = "tx-fail-null-venue";
+    await seedPendingEvmApproval(txId, {
+      actionPayload: {
+        type: "transaction",
+        broadcast: false,
+        nonce: REPLAY_BASE.nonce,
+        gasLimit: REPLAY_BASE.gasLimit,
+        venue: null, // present null must be rejected, not normalized to omitted
+        walletAddress: REPLAY_BASE.walletAddress,
+      },
+    });
+    await expectFailClosed(txId, "malformed_transaction_action_payload");
+  });
+
+  it("fails closed on a present-null walletAddress in the action payload", async () => {
+    const txId = "tx-fail-null-wallet";
+    await seedPendingEvmApproval(txId, {
+      actionPayload: {
+        type: "transaction",
+        broadcast: false,
+        nonce: REPLAY_BASE.nonce,
+        gasLimit: REPLAY_BASE.gasLimit,
+        walletAddress: null, // present null must be rejected, not normalized to omitted
       },
     });
     await expectFailClosed(txId, "malformed_transaction_action_payload");

--- a/packages/api/src/__tests__/vault-execution-gateway.test.ts
+++ b/packages/api/src/__tests__/vault-execution-gateway.test.ts
@@ -130,6 +130,37 @@ describe("vault EVM execution gateway", () => {
     }
   });
 
+  it("preserves the legacy Solana sign path without minting an EVM authorization", async () => {
+    const beforeRows = await getDb().select().from(executionAuthorizationNonces);
+    const signSpy = spyOn(Vault.prototype, "signTransaction").mockImplementation(async () => {
+      return "solana-signed";
+    });
+    try {
+      const app = await makeApp();
+      const res = await app.request(`/vault/${AGENT_ID}/sign`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          to: "0x1111111111111111111111111111111111111111",
+          value: "1",
+          data: "0x12345678",
+          chainId: 101,
+          broadcast: false,
+        }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.ok).toBe(true);
+      expect(signSpy).toHaveBeenCalledTimes(1);
+
+      const afterRows = await getDb().select().from(executionAuthorizationNonces);
+      expect(afterRows).toHaveLength(beforeRows.length);
+    } finally {
+      signSpy.mockRestore();
+    }
+  });
+
   it("mints and consumes an execution authorization for primary EVM approval replay", async () => {
     const txId = "tx-gateway-approval-replay";
     const replayRequest = {
@@ -139,7 +170,10 @@ describe("vault EVM execution gateway", () => {
       value: "1",
       data: "0x12345678",
       chainId: 8453,
+      nonce: 7,
+      gasLimit: "45000",
       broadcast: false,
+      walletAddress: "0x0000000000000000000000000000000000000001",
     };
     await getDb()
       .insert(transactions)
@@ -151,7 +185,13 @@ describe("vault EVM execution gateway", () => {
         value: replayRequest.value,
         data: replayRequest.data,
         chainId: replayRequest.chainId,
-        actionPayload: { type: "transaction", broadcast: false },
+        actionPayload: {
+          type: "transaction",
+          broadcast: false,
+          nonce: replayRequest.nonce,
+          gasLimit: replayRequest.gasLimit,
+          walletAddress: replayRequest.walletAddress,
+        },
         executionPayloadDigest: executionPayloadDigestForEvmSign(replayRequest),
         executionPolicyRevisionHash: "queued-policy-revision",
         policyResults: [],

--- a/packages/api/src/__tests__/vault-execution-gateway.test.ts
+++ b/packages/api/src/__tests__/vault-execution-gateway.test.ts
@@ -522,14 +522,12 @@ describe("vault EVM execution gateway", () => {
       walletAddress: "0x00000000000000000000000000000000000000ff",
     });
     // Non-local-custody EVM wallet, NO encrypted_chain_keys row => the resolver
-    // returns a non-local-vault backend. The custody discriminator and metadata
-    // key are built from char codes at RUNTIME so their exact bytes match the
-    // vault package's isExternalKeyWalletMetadata literals in this harness.
-    const CUSTODY_KIND = String.fromCharCode(101, 120, 116, 101, 114, 110, 97, 108);
-    const CUSTODY_KEY_FIELD = `${CUSTODY_KIND}Key`;
+    // returns a non-local-vault backend. The custody discriminator "external" and
+    // its metadata key "third-partyKey" matches the vault package,
+    // aligning with isExternalKeyWalletMetadata string literals exactly.
     const custodyMetadata: Record<string, unknown> = {
-      custody: CUSTODY_KIND,
-      [CUSTODY_KEY_FIELD]: {
+      custody: "external",
+      externalKey: {
         providerId: "test-kms",
         keyId: "key-ext-1",
         registeredAt: new Date().toISOString(),

--- a/packages/api/src/__tests__/vault-execution-gateway.test.ts
+++ b/packages/api/src/__tests__/vault-execution-gateway.test.ts
@@ -22,6 +22,8 @@ import { executionPayloadDigestForEvmSign } from "../services/execution-authoriz
 const TENANT_ID = `gateway-tenant-${Date.now()}`;
 const AGENT_ID = `gateway-agent-${Date.now()}`;
 const USER_ID = "00000000-0000-4000-8000-000000000123";
+const ORIGINAL_REDIS_URL = process.env.REDIS_URL;
+const ORIGINAL_REDIS_REQUIRED = process.env.REDIS_REQUIRED;
 
 async function makeApp() {
   const { vaultRoutes } = await import("../routes/vault");
@@ -46,6 +48,8 @@ describe("vault EVM execution gateway", () => {
     process.env.STEWARD_JWT_SECRET = "gateway-test-jwt-secret-with-enough-entropy-0123456789";
     process.env.STEWARD_AUDIT_HMAC_KEY = "b".repeat(64);
     process.env.STEWARD_ALLOW_UNSAFE_CONTRACT_CALL_SIGNING = "true";
+    delete process.env.REDIS_URL;
+    delete process.env.REDIS_REQUIRED;
     const { db, client } = await createPGLiteDb("memory://");
     setPGLiteOverride(db, async () => {
       await client.close();
@@ -88,6 +92,10 @@ describe("vault EVM execution gateway", () => {
 
   afterAll(async () => {
     delete process.env.STEWARD_ALLOW_UNSAFE_CONTRACT_CALL_SIGNING;
+    if (ORIGINAL_REDIS_URL === undefined) delete process.env.REDIS_URL;
+    else process.env.REDIS_URL = ORIGINAL_REDIS_URL;
+    if (ORIGINAL_REDIS_REQUIRED === undefined) delete process.env.REDIS_REQUIRED;
+    else process.env.REDIS_REQUIRED = ORIGINAL_REDIS_REQUIRED;
     await closeDb();
   });
 

--- a/packages/api/src/__tests__/vault-execution-gateway.test.ts
+++ b/packages/api/src/__tests__/vault-execution-gateway.test.ts
@@ -14,11 +14,19 @@ import {
   userTenants,
 } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
-import { Vault } from "@stwd/vault";
+import type {
+  ExternalKeyCustodyProvider,
+  ExternalKeyHandleImportRequest,
+  ExternalKeyHandleRegistration,
+  ExternalKeySignTransactionRequest,
+  ExternalKeySignTransactionResult,
+} from "@stwd/vault";
+import { BackendBindingMismatchError, Vault } from "@stwd/vault";
 import { eq } from "drizzle-orm";
 import { Hono } from "hono";
 import type { AppVariables } from "../services/context";
 import { executionPayloadDigestForEvmSign } from "../services/execution-authorization";
+import { getConfiguredVault } from "../services/vault-factory";
 
 const TENANT_ID = `gateway-tenant-${Date.now()}`;
 const AGENT_ID = `gateway-agent-${Date.now()}`;
@@ -760,6 +768,177 @@ describe("vault EVM execution gateway", () => {
       expect(approval?.status).toBe("pending");
     } finally {
       signSpy.mockRestore();
+    }
+  });
+
+  // ── ROUND 3 / ITEM 3 (PART B): backend-binding TOCTOU — API-level transition —
+  //
+  // The FINDING 4 tests above reject when the wallet ALREADY resolves to a
+  // non-local backend at the gateway precheck (resolveExecutionBackend returns
+  // the non-local backend), so no authorization is ever minted. This test
+  // exercises the harder TOCTOU: the wallet resolves as `local-vault` at MINT
+  // time (precheck passes, an authorization IS minted+consumed and bound to
+  // "local-vault"), then the custody FLIPS to the provider-backed backend
+  // BEFORE the raw signing boundary. The raw Vault.signTransaction re-resolves
+  // the backend from its OWN fresh wallet lookup (independent of the gateway's
+  // resolveExecutionBackend precheck) and, because the authorization is bound to
+  // "local-vault", MUST fail closed with BackendBindingMismatchError BEFORE the
+  // provider is reached.
+  //
+  // We model the flip by making the wallet provider-custody in the DB (the
+  // post-flip state the raw signer sees) while stubbing resolveExecutionBackend
+  // to return "local-vault" (the pre-flip value the gateway precheck read). The
+  // real signTransaction runs (NOT mocked) so the re-resolution + fail-closed
+  // guard actually execute. We register a REAL provider spy on the route's Vault
+  // instance and assert it is NEVER called — proving the guard fires before any
+  // provider routing.
+  //
+  // Required assertions (round-3 PART B):
+  //  (1) the real provider spy is NEVER called,
+  //  (2) the specific BackendBindingMismatchError / backend_binding_mismatch
+  //      code surfaces (HTTP 409 with data.code), and
+  //  (3) the specific PART-A rejection audit
+  //      (vault.execution_authorization.rejected, reason backend_binding_mismatch)
+  //      is written at the API level.
+
+  const TRANSITION_AGENT_ID = `gateway-transition-agent-${Date.now()}`;
+
+  class ProviderSpy implements ExternalKeyCustodyProvider {
+    id = "transition-provider-spy";
+    registerCalls: ExternalKeyHandleImportRequest[] = [];
+    signCalls: ExternalKeySignTransactionRequest[] = [];
+    async registerKeyHandle(
+      request: ExternalKeyHandleImportRequest,
+    ): Promise<ExternalKeyHandleRegistration> {
+      this.registerCalls.push(request);
+      throw new Error("provider registerKeyHandle must not be reached in the transition test");
+    }
+    async signTransaction(
+      request: ExternalKeySignTransactionRequest,
+    ): Promise<ExternalKeySignTransactionResult> {
+      // If this ever runs, the TOCTOU guard failed: a local-vault-bound
+      // authorization reached the provider.
+      this.signCalls.push(request);
+      throw new Error(
+        "provider signTransaction must not be reached for a backend-binding mismatch",
+      );
+    }
+  }
+
+  it("fails closed (backend binding mismatch) on the direct /sign path when a local-vault-bound authorization re-resolves to the provider backend before the provider", async () => {
+    // Seed a wallet that is provider-custody in the DB (the post-flip state the
+    // raw signer's re-resolution will observe), mirroring seedExternalCustodyAgent.
+    await getDb().insert(agents).values({
+      id: TRANSITION_AGENT_ID,
+      tenantId: TENANT_ID,
+      name: "Transition Custody Agent",
+      walletAddress: "0x00000000000000000000000000000000000000ee",
+    });
+    const custodyMetadata: Record<string, unknown> = {
+      custody: "external",
+      externalKey: {
+        providerId: "test-kms",
+        keyId: "key-transition-1",
+        registeredAt: new Date().toISOString(),
+        exportablePrivateKey: false,
+        signingAvailability: "provider-signing",
+      },
+    };
+    await getDb().insert(agentWallets).values({
+      agentId: TRANSITION_AGENT_ID,
+      chainFamily: "evm",
+      address: "0x00000000000000000000000000000000000000ee",
+      metadata: custodyMetadata,
+    });
+    await getDb()
+      .insert(policies)
+      .values({
+        id: `${TRANSITION_AGENT_ID}-approved-addresses`,
+        agentId: TRANSITION_AGENT_ID,
+        type: "approved-addresses",
+        enabled: true,
+        config: {
+          mode: "whitelist",
+          addresses: ["0x1111111111111111111111111111111111111111"],
+        },
+      });
+
+    // Register a REAL provider spy on the route's Vault instance so we can
+    // assert it is NEVER reached. The route resolves its Vault via
+    // getConfiguredVault (the same instance the `vault` proxy in services/context
+    // delegates to), so setting the provider on that instance is what the raw
+    // signer would use if it ever routed to the provider backend.
+    const routeVault = getConfiguredVault({
+      fallbackPassword: process.env.STEWARD_MASTER_PASSWORD,
+    });
+    const providerSpy = new ProviderSpy();
+    const vaultWithProvider = routeVault as unknown as {
+      externalKeyCustodyProvider?: ExternalKeyCustodyProvider;
+    };
+    const priorProvider = vaultWithProvider.externalKeyCustodyProvider;
+    vaultWithProvider.externalKeyCustodyProvider = providerSpy;
+
+    // Stub resolveExecutionBackend to return the PRE-flip value "local-vault"
+    // so the gateway precheck passes and mints+consumes an authorization bound
+    // to local-vault. The raw signTransaction below is NOT mocked, so its own
+    // fresh wallet lookup still observes the provider-custody DB wallet and
+    // fails closed at the signing boundary.
+    const resolveSpy = spyOn(Vault.prototype, "resolveExecutionBackend").mockResolvedValue(
+      "local-vault",
+    );
+
+    try {
+      const app = await makeApp();
+      const res = await app.request(`/vault/${TRANSITION_AGENT_ID}/sign`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "Idempotency-Key": "transition-binding-mismatch-1",
+        },
+        body: JSON.stringify({
+          to: "0x1111111111111111111111111111111111111111",
+          value: "1",
+          chainId: 8453,
+          broadcast: false,
+        }),
+      });
+      const body = await res.json();
+
+      // (2) the specific backend_binding_mismatch surfaces as the fail-closed 409.
+      expect(res.status).toBe(409);
+      expect(body.ok).toBe(false);
+      expect(body.data?.code).toBe("backend_binding_mismatch");
+
+      // (1) the real provider spy was NEVER called.
+      expect(providerSpy.signCalls).toHaveLength(0);
+      expect(providerSpy.registerCalls).toHaveLength(0);
+
+      // Prove the guard genuinely engaged: the mint-time precheck resolver was
+      // consulted, and the mismatch error type is the vault-layer one.
+      expect(resolveSpy).toHaveBeenCalled();
+
+      // (3) the PART-A rejection audit is written with reason backend_binding_mismatch.
+      const audits = await getDb()
+        .select({ action: auditEvents.action, metadata: auditEvents.metadata })
+        .from(auditEvents)
+        .where(eq(auditEvents.resourceId, TRANSITION_AGENT_ID));
+      const rejection = audits.find(
+        (row) => row.action === "vault.execution_authorization.rejected",
+      );
+      expect(rejection, "backend-binding-mismatch rejection audit must exist").toBeDefined();
+      const rejectionMeta = rejection?.metadata as Record<string, unknown> | undefined;
+      expect(rejectionMeta?.reason).toBe("backend_binding_mismatch");
+      expect(rejectionMeta?.expectedBackend).toBe("local-vault");
+      expect(rejectionMeta?.resolvedBackend).toBe("third-party-custody");
+
+      // Sanity: the vault-layer error class is exported and matches the code the
+      // API surfaced, keeping the API contract and the vault guard in lockstep.
+      expect(new BackendBindingMismatchError("local-vault", "third-party-custody").code).toBe(
+        "backend_binding_mismatch",
+      );
+    } finally {
+      resolveSpy.mockRestore();
+      vaultWithProvider.externalKeyCustodyProvider = priorProvider;
     }
   });
 });

--- a/packages/api/src/__tests__/vault-execution-gateway.test.ts
+++ b/packages/api/src/__tests__/vault-execution-gateway.test.ts
@@ -240,4 +240,144 @@ describe("vault EVM execution gateway", () => {
       signSpy.mockRestore();
     }
   });
+
+  // ── Fail-closed negative cases (BLOCKER 1 regression coverage) ──────────────
+  // Every case proves the raw Vault.signTransaction signer is NEVER called for a
+  // legacy/malformed primary-EVM approval row, and the request is rejected.
+
+  const REPLAY_BASE = {
+    tenantId: TENANT_ID,
+    agentId: AGENT_ID,
+    to: "0x1111111111111111111111111111111111111111",
+    value: "1",
+    data: "0x12345678",
+    chainId: 8453,
+    nonce: 7,
+    gasLimit: "45000",
+    broadcast: false,
+    walletAddress: "0x0000000000000000000000000000000000000001",
+  };
+
+  async function seedPendingEvmApproval(
+    txId: string,
+    overrides: {
+      actionPayload?: Record<string, unknown> | null;
+      executionPayloadDigest?: string | null;
+      executionPolicyRevisionHash?: string | null;
+    },
+  ) {
+    await getDb()
+      .insert(transactions)
+      .values({
+        id: txId,
+        agentId: AGENT_ID,
+        status: "pending",
+        toAddress: REPLAY_BASE.to,
+        value: REPLAY_BASE.value,
+        data: REPLAY_BASE.data,
+        chainId: REPLAY_BASE.chainId,
+        actionPayload:
+          overrides.actionPayload === undefined
+            ? {
+                type: "transaction",
+                broadcast: false,
+                nonce: REPLAY_BASE.nonce,
+                gasLimit: REPLAY_BASE.gasLimit,
+                walletAddress: REPLAY_BASE.walletAddress,
+              }
+            : (overrides.actionPayload ?? undefined),
+        executionPayloadDigest:
+          overrides.executionPayloadDigest === undefined
+            ? executionPayloadDigestForEvmSign(REPLAY_BASE)
+            : (overrides.executionPayloadDigest ?? null),
+        executionPolicyRevisionHash:
+          overrides.executionPolicyRevisionHash === undefined
+            ? "queued-policy-revision"
+            : (overrides.executionPolicyRevisionHash ?? null),
+        policyResults: [],
+      });
+    await getDb()
+      .insert(approvalQueue)
+      .values({
+        id: `aq-${txId}`,
+        txId,
+        agentId: AGENT_ID,
+        status: "pending",
+        requestedByType: "agent",
+        requestedById: AGENT_ID,
+      });
+  }
+
+  async function expectFailClosed(txId: string) {
+    const signSpy = spyOn(Vault.prototype, "signTransaction").mockImplementation(async () => {
+      throw new Error("raw signer must not be called for fail-closed approval");
+    });
+    try {
+      const app = await makeApp();
+      const res = await app.request(`/vault/${AGENT_ID}/approve/${txId}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{}",
+      });
+      const body = await res.json();
+      expect(res.status).toBe(409);
+      expect(body.ok).toBe(false);
+      // Raw signer NEVER reached.
+      expect(signSpy).toHaveBeenCalledTimes(0);
+      // No authorization nonce was minted for this fail-closed row.
+      const nonceRows = await getDb()
+        .select({ id: executionAuthorizationNonces.id })
+        .from(executionAuthorizationNonces)
+        .where(eq(executionAuthorizationNonces.requestId, txId));
+      expect(nonceRows).toHaveLength(0);
+      // The pending approval remains pending (not silently approved).
+      const [approval] = await getDb()
+        .select({ status: approvalQueue.status })
+        .from(approvalQueue)
+        .where(eq(approvalQueue.txId, txId));
+      expect(approval?.status).toBe("pending");
+    } finally {
+      signSpy.mockRestore();
+    }
+  }
+
+  it("fails closed when the stored execution payload digest is null (legacy row)", async () => {
+    const txId = "tx-fail-null-digest";
+    await seedPendingEvmApproval(txId, { executionPayloadDigest: null });
+    await expectFailClosed(txId);
+  });
+
+  it("fails closed when the stored policy revision hash is null (legacy row)", async () => {
+    const txId = "tx-fail-null-policy-revision";
+    await seedPendingEvmApproval(txId, { executionPolicyRevisionHash: null });
+    await expectFailClosed(txId);
+  });
+
+  it("fails closed when the transaction action payload is missing/malformed", async () => {
+    const txId = "tx-fail-malformed-action-payload";
+    // action_type null + non-transaction payload => getTransactionActionPayload
+    // returns null => previously flipped isPrimaryEvmApproval=false and raw-signed.
+    await seedPendingEvmApproval(txId, {
+      actionPayload: { type: "not-a-transaction", broadcast: false },
+    });
+    await expectFailClosed(txId);
+  });
+
+  it("fails closed when the stored digest mismatches the replay (payload mutation)", async () => {
+    const txId = "tx-fail-digest-mutation";
+    // Stored digest reflects nonce=7; mutate the queued action payload nonce to 99
+    // so the recomputed replay digest no longer matches the immutable snapshot.
+    await seedPendingEvmApproval(txId, {
+      actionPayload: {
+        type: "transaction",
+        broadcast: false,
+        nonce: 99,
+        gasLimit: REPLAY_BASE.gasLimit,
+        walletAddress: REPLAY_BASE.walletAddress,
+      },
+      // stored digest still bound to nonce=7
+      executionPayloadDigest: executionPayloadDigestForEvmSign(REPLAY_BASE),
+    });
+    await expectFailClosed(txId);
+  });
 });

--- a/packages/api/src/__tests__/vault-execution-gateway.test.ts
+++ b/packages/api/src/__tests__/vault-execution-gateway.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it, spyOn } from "bun:test";
 import {
   agents,
+  agentWallets,
   approvalQueue,
   auditEvents,
   closeDb,
@@ -308,7 +309,7 @@ describe("vault EVM execution gateway", () => {
       });
   }
 
-  async function expectFailClosed(txId: string) {
+  async function expectFailClosed(txId: string, expectedReason?: string) {
     const signSpy = spyOn(Vault.prototype, "signTransaction").mockImplementation(async () => {
       throw new Error("raw signer must not be called for fail-closed approval");
     });
@@ -336,6 +337,21 @@ describe("vault EVM execution gateway", () => {
         .from(approvalQueue)
         .where(eq(approvalQueue.txId, txId));
       expect(approval?.status).toBe("pending");
+      // A specific rejection audit was written with the expected reason. This
+      // proves the audit contract holds (not just that signing was prevented).
+      const rejectionAudits = await getDb()
+        .select({ action: auditEvents.action, metadata: auditEvents.metadata })
+        .from(auditEvents)
+        .where(eq(auditEvents.resourceId, txId));
+      const rejection = rejectionAudits.find(
+        (row) => row.action === "vault.execution_authorization.rejected",
+      );
+      expect(rejection, `a rejection audit must exist for ${txId}`).toBeDefined();
+      if (expectedReason) {
+        expect((rejection?.metadata as Record<string, unknown> | undefined)?.reason).toBe(
+          expectedReason,
+        );
+      }
     } finally {
       signSpy.mockRestore();
     }
@@ -344,13 +360,13 @@ describe("vault EVM execution gateway", () => {
   it("fails closed when the stored execution payload digest is null (legacy row)", async () => {
     const txId = "tx-fail-null-digest";
     await seedPendingEvmApproval(txId, { executionPayloadDigest: null });
-    await expectFailClosed(txId);
+    await expectFailClosed(txId, "missing_stored_execution_payload_digest");
   });
 
   it("fails closed when the stored policy revision hash is null (legacy row)", async () => {
     const txId = "tx-fail-null-policy-revision";
     await seedPendingEvmApproval(txId, { executionPolicyRevisionHash: null });
-    await expectFailClosed(txId);
+    await expectFailClosed(txId, "missing_stored_execution_policy_revision_hash");
   });
 
   it("fails closed when the transaction action payload is missing/malformed", async () => {
@@ -360,7 +376,7 @@ describe("vault EVM execution gateway", () => {
     await seedPendingEvmApproval(txId, {
       actionPayload: { type: "not-a-transaction", broadcast: false },
     });
-    await expectFailClosed(txId);
+    await expectFailClosed(txId, "missing_or_malformed_transaction_action_payload");
   });
 
   it("fails closed when the stored digest mismatches the replay (payload mutation)", async () => {
@@ -378,6 +394,291 @@ describe("vault EVM execution gateway", () => {
       // stored digest still bound to nonce=7
       executionPayloadDigest: executionPayloadDigestForEvmSign(REPLAY_BASE),
     });
-    await expectFailClosed(txId);
+    await expectFailClosed(txId, "stored_digest_mismatch");
+  });
+
+  // ── FINDING 1: strict transaction-action-payload validation ────────────────
+  // Each stored payload is a well-typed `transaction` action with exactly ONE
+  // malformed present field. Previously these were silently coerced/dropped
+  // (mutating the approved intent) or threw deep in the shared normalizer with
+  // no specific rejection audit. Now every one fails closed with the
+  // malformed_transaction_action_payload reason, no nonce row, and zero raw
+  // signer calls.
+
+  it("fails closed on a string nonce in the action payload", async () => {
+    const txId = "tx-fail-string-nonce";
+    await seedPendingEvmApproval(txId, {
+      actionPayload: {
+        type: "transaction",
+        broadcast: false,
+        nonce: "7", // wrong type: string, not a number
+        gasLimit: REPLAY_BASE.gasLimit,
+        walletAddress: REPLAY_BASE.walletAddress,
+      },
+    });
+    await expectFailClosed(txId, "malformed_transaction_action_payload");
+  });
+
+  it("fails closed on an unsafe-integer nonce in the action payload", async () => {
+    const txId = "tx-fail-unsafe-nonce";
+    await seedPendingEvmApproval(txId, {
+      actionPayload: {
+        type: "transaction",
+        broadcast: false,
+        nonce: Number.MAX_SAFE_INTEGER + 1, // passes Number.isInteger, fails isSafeInteger
+        gasLimit: REPLAY_BASE.gasLimit,
+        walletAddress: REPLAY_BASE.walletAddress,
+      },
+    });
+    await expectFailClosed(txId, "malformed_transaction_action_payload");
+  });
+
+  it("fails closed on a negative nonce in the action payload", async () => {
+    const txId = "tx-fail-negative-nonce";
+    await seedPendingEvmApproval(txId, {
+      actionPayload: {
+        type: "transaction",
+        broadcast: false,
+        nonce: -1,
+        gasLimit: REPLAY_BASE.gasLimit,
+        walletAddress: REPLAY_BASE.walletAddress,
+      },
+    });
+    await expectFailClosed(txId, "malformed_transaction_action_payload");
+  });
+
+  it("fails closed on a wrong-type (non-boolean) broadcast in the action payload", async () => {
+    const txId = "tx-fail-wrong-broadcast";
+    await seedPendingEvmApproval(txId, {
+      actionPayload: {
+        type: "transaction",
+        broadcast: "false", // wrong type: string, previously coerced to true
+        nonce: REPLAY_BASE.nonce,
+        gasLimit: REPLAY_BASE.gasLimit,
+        walletAddress: REPLAY_BASE.walletAddress,
+      },
+    });
+    await expectFailClosed(txId, "malformed_transaction_action_payload");
+  });
+
+  it("fails closed on a wrong-type gasLimit in the action payload", async () => {
+    const txId = "tx-fail-wrong-gaslimit";
+    await seedPendingEvmApproval(txId, {
+      actionPayload: {
+        type: "transaction",
+        broadcast: false,
+        nonce: REPLAY_BASE.nonce,
+        gasLimit: 45000, // wrong type: number, must be a decimal uint string
+        walletAddress: REPLAY_BASE.walletAddress,
+      },
+    });
+    await expectFailClosed(txId, "malformed_transaction_action_payload");
+  });
+
+  it("fails closed on a wrong-type venue in the action payload", async () => {
+    const txId = "tx-fail-wrong-venue";
+    await seedPendingEvmApproval(txId, {
+      actionPayload: {
+        type: "transaction",
+        broadcast: false,
+        nonce: REPLAY_BASE.nonce,
+        gasLimit: REPLAY_BASE.gasLimit,
+        venue: { hostile: true }, // wrong type: object, must be a string
+        walletAddress: REPLAY_BASE.walletAddress,
+      },
+    });
+    await expectFailClosed(txId, "malformed_transaction_action_payload");
+  });
+
+  it("fails closed on a wrong-type walletAddress in the action payload", async () => {
+    const txId = "tx-fail-wrong-wallet";
+    await seedPendingEvmApproval(txId, {
+      actionPayload: {
+        type: "transaction",
+        broadcast: false,
+        nonce: REPLAY_BASE.nonce,
+        gasLimit: REPLAY_BASE.gasLimit,
+        walletAddress: 12345, // wrong type: number, must be a string
+      },
+    });
+    await expectFailClosed(txId, "malformed_transaction_action_payload");
+  });
+
+  // ── FINDING 4: third-party-custody backend is not gateway-supported ────────────
+  // The execution authorization is cryptographically bound to backend
+  // "local-vault". An agent whose EVM wallet resolves to EXTERNAL custody (an
+  // agent_wallets row with custody:"third-party" metadata and NO local chain key)
+  // must be rejected BEFORE minting/consuming and BEFORE the third-party custody
+  // provider is ever reached. Otherwise a local-vault-bound authorization could
+  // authorize an third-party-custody execution.
+
+  const EXTERNAL_AGENT_ID = `gateway-ext-agent-${Date.now()}`;
+
+  async function seedExternalCustodyAgent() {
+    await getDb().insert(agents).values({
+      id: EXTERNAL_AGENT_ID,
+      tenantId: TENANT_ID,
+      name: "External Custody Agent",
+      walletAddress: "0x00000000000000000000000000000000000000ff",
+    });
+    // Non-local-custody EVM wallet, NO encrypted_chain_keys row => the resolver
+    // returns a non-local-vault backend. The custody discriminator and metadata
+    // key are built from char codes at RUNTIME so their exact bytes match the
+    // vault package's isExternalKeyWalletMetadata literals in this harness.
+    const CUSTODY_KIND = String.fromCharCode(101, 120, 116, 101, 114, 110, 97, 108);
+    const CUSTODY_KEY_FIELD = `${CUSTODY_KIND}Key`;
+    const custodyMetadata: Record<string, unknown> = {
+      custody: CUSTODY_KIND,
+      [CUSTODY_KEY_FIELD]: {
+        providerId: "test-kms",
+        keyId: "key-ext-1",
+        registeredAt: new Date().toISOString(),
+        exportablePrivateKey: false,
+        signingAvailability: "provider-signing",
+      },
+    };
+    await getDb().insert(agentWallets).values({
+      agentId: EXTERNAL_AGENT_ID,
+      chainFamily: "evm",
+      address: "0x00000000000000000000000000000000000000ff",
+      metadata: custodyMetadata,
+    });
+    await getDb()
+      .insert(policies)
+      .values({
+        id: `${EXTERNAL_AGENT_ID}-approved-addresses`,
+        agentId: EXTERNAL_AGENT_ID,
+        type: "approved-addresses",
+        enabled: true,
+        config: {
+          mode: "whitelist",
+          addresses: ["0x1111111111111111111111111111111111111111"],
+        },
+      });
+  }
+
+  it("fails closed (third-party custody) on the direct /sign path before the provider is reached", async () => {
+    await seedExternalCustodyAgent();
+    // Spy on the raw signer; the third-party custody provider is only ever reached
+    // THROUGH Vault.signTransaction, so proving signTransaction is never called
+    // proves the provider is never reached.
+    const signSpy = spyOn(Vault.prototype, "signTransaction").mockImplementation(async () => {
+      throw new Error(
+        "raw signer / third-party provider must not be reached for third-party custody",
+      );
+    });
+    try {
+      const app = await makeApp();
+      const res = await app.request(`/vault/${EXTERNAL_AGENT_ID}/sign`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "Idempotency-Key": "ext-custody-sign-1",
+        },
+        body: JSON.stringify({
+          to: "0x1111111111111111111111111111111111111111",
+          value: "1",
+          chainId: 8453,
+          broadcast: true,
+        }),
+      });
+      const body = await res.json();
+      expect(res.status).toBe(409);
+      expect(body.ok).toBe(false);
+      expect(signSpy).toHaveBeenCalledTimes(0);
+      // The direct /sign path uses a fresh random txId, so assert on the audit
+      // reason keyed by the agent instead.
+      const audits = await getDb()
+        .select({ action: auditEvents.action, metadata: auditEvents.metadata })
+        .from(auditEvents)
+        .where(eq(auditEvents.resourceId, EXTERNAL_AGENT_ID));
+      const rejection = audits.find(
+        (row) => row.action === "vault.execution_authorization.rejected",
+      );
+      expect(rejection, "third-party-custody rejection audit must exist").toBeDefined();
+      expect((rejection?.metadata as Record<string, unknown> | undefined)?.reason).toBe(
+        "third-party_custody_not_gateway_supported",
+      );
+    } finally {
+      signSpy.mockRestore();
+    }
+  });
+
+  it("fails closed (third-party custody) on the approval replay path before the provider is reached", async () => {
+    const txId = "tx-ext-custody-approval";
+    // Seed a well-formed primary EVM approval row for the EXTERNAL custody agent.
+    const extCustodyReplay = { ...REPLAY_BASE, agentId: EXTERNAL_AGENT_ID };
+    await getDb()
+      .insert(transactions)
+      .values({
+        id: txId,
+        agentId: EXTERNAL_AGENT_ID,
+        status: "pending",
+        toAddress: extCustodyReplay.to,
+        value: extCustodyReplay.value,
+        data: extCustodyReplay.data,
+        chainId: extCustodyReplay.chainId,
+        actionPayload: {
+          type: "transaction",
+          broadcast: false,
+          nonce: extCustodyReplay.nonce,
+          gasLimit: extCustodyReplay.gasLimit,
+          walletAddress: extCustodyReplay.walletAddress,
+        },
+        executionPayloadDigest: executionPayloadDigestForEvmSign(extCustodyReplay),
+        executionPolicyRevisionHash: "queued-policy-revision",
+        policyResults: [],
+      });
+    await getDb()
+      .insert(approvalQueue)
+      .values({
+        id: `aq-${txId}`,
+        txId,
+        agentId: EXTERNAL_AGENT_ID,
+        status: "pending",
+        requestedByType: "agent",
+        requestedById: EXTERNAL_AGENT_ID,
+      });
+
+    const signSpy = spyOn(Vault.prototype, "signTransaction").mockImplementation(async () => {
+      throw new Error(
+        "raw signer / third-party provider must not be reached for third-party custody",
+      );
+    });
+    try {
+      const app = await makeApp();
+      const res = await app.request(`/vault/${EXTERNAL_AGENT_ID}/approve/${txId}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{}",
+      });
+      const body = await res.json();
+      expect(res.status).toBe(409);
+      expect(body.ok).toBe(false);
+      expect(signSpy).toHaveBeenCalledTimes(0);
+      const nonceRows = await getDb()
+        .select({ id: executionAuthorizationNonces.id })
+        .from(executionAuthorizationNonces)
+        .where(eq(executionAuthorizationNonces.requestId, txId));
+      expect(nonceRows).toHaveLength(0);
+      const audits = await getDb()
+        .select({ action: auditEvents.action, metadata: auditEvents.metadata })
+        .from(auditEvents)
+        .where(eq(auditEvents.resourceId, txId));
+      const rejection = audits.find(
+        (row) => row.action === "vault.execution_authorization.rejected",
+      );
+      expect(rejection, "third-party-custody approval rejection audit must exist").toBeDefined();
+      expect((rejection?.metadata as Record<string, unknown> | undefined)?.reason).toBe(
+        "third-party_custody_not_gateway_supported",
+      );
+      const [approval] = await getDb()
+        .select({ status: approvalQueue.status })
+        .from(approvalQueue)
+        .where(eq(approvalQueue.txId, txId));
+      expect(approval?.status).toBe("pending");
+    } finally {
+      signSpy.mockRestore();
+    }
   });
 });

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -2164,7 +2164,7 @@ vaultRoutes.post("/:agentId/sign", async (c) => {
                 });
                 throw error;
               }
-            }).signTransaction(signRequest, {
+            }).signTransactionAuthorized(signRequest, {
               txId,
               policyResults: evaluation.results,
               status: txStatus,
@@ -3722,7 +3722,7 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
               throw error;
             }
           });
-          txHash = await governedVault.signTransaction(approvalSignRequest, {
+          txHash = await governedVault.signTransactionAuthorized(approvalSignRequest, {
             txId,
             policyResults: currentEvaluation.results,
             status: shouldBroadcast ? "broadcast" : "signed",

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -3456,8 +3456,7 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
       // digest match). If any invariant is absent/malformed we reject fail-closed
       // here and NEVER route to raw signing. This closes the legacy/null-digest
       // and malformed-actionPayload replay-fail-open holes.
-      const isRawEvmSigningCandidate =
-        !isSolana && transferPayload === null && !isSendCallsAction;
+      const isRawEvmSigningCandidate = !isSolana && transferPayload === null && !isSendCallsAction;
       const isPrimaryEvmApproval = isRawEvmSigningCandidate && transactionPayload !== null;
       const approvalExecutionPayloadDigest = isPrimaryEvmApproval
         ? executionPayloadDigestForEvmSign(approvalSignRequest)
@@ -3476,8 +3475,7 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
               reason,
               hasTransactionActionPayload: transactionPayload !== null,
               hasStoredPayloadDigest: transactionRow.executionPayloadDigest !== null,
-              hasStoredPolicyRevisionHash:
-                transactionRow.executionPolicyRevisionHash !== null,
+              hasStoredPolicyRevisionHash: transactionRow.executionPolicyRevisionHash !== null,
               storedPayloadDigest: transactionRow.executionPayloadDigest,
               replayPayloadDigest: approvalExecutionPayloadDigest,
             },

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -674,11 +674,22 @@ function sendCallsActionPayload(input: {
   };
 }
 
-function transactionActionPayload(input: { broadcast: boolean; referenceId?: string | null }) {
+function transactionActionPayload(input: {
+  broadcast: boolean;
+  referenceId?: string | null;
+  nonce?: number | null;
+  gasLimit?: string | null;
+  venue?: string | null;
+  walletAddress?: string | null;
+}) {
   return {
     type: "transaction",
     broadcast: input.broadcast,
     ...(input.referenceId ? { referenceId: input.referenceId } : {}),
+    ...(input.nonce !== undefined && input.nonce !== null ? { nonce: input.nonce } : {}),
+    ...(input.gasLimit ? { gasLimit: input.gasLimit } : {}),
+    ...(input.venue ? { venue: input.venue } : {}),
+    ...(input.walletAddress ? { walletAddress: input.walletAddress } : {}),
   };
 }
 
@@ -838,6 +849,10 @@ function getTransactionActionPayload(payload: unknown): {
   type: "transaction";
   broadcast: boolean;
   referenceId?: string;
+  nonce?: number;
+  gasLimit?: string;
+  venue?: string;
+  walletAddress?: string;
 } | null {
   if (!payload || typeof payload !== "object") return null;
   const value = payload as Record<string, unknown>;
@@ -846,6 +861,13 @@ function getTransactionActionPayload(payload: unknown): {
     type: "transaction",
     broadcast: value.broadcast !== false,
     referenceId: actionReferenceId(value) ?? undefined,
+    nonce:
+      typeof value.nonce === "number" && Number.isInteger(value.nonce) && value.nonce >= 0
+        ? value.nonce
+        : undefined,
+    gasLimit: typeof value.gasLimit === "string" ? value.gasLimit : undefined,
+    venue: typeof value.venue === "string" ? value.venue : undefined,
+    walletAddress: typeof value.walletAddress === "string" ? value.walletAddress : undefined,
   };
 }
 
@@ -1894,8 +1916,13 @@ vaultRoutes.post("/:agentId/sign", async (c) => {
 
   const policySet = await getScopedPolicySet(tenantId, agentId, c.get("agentPolicyIds"));
   const conditionSets = await loadConditionSetsForPolicies(tenantId, policySet);
-  const executionPayloadDigest = executionPayloadDigestForEvmSign(signRequest);
-  const executionPolicyRevisionHash = policyRevisionHashForPolicySet(policySet);
+  const isEvmSignRequest = resolvedChainId !== 101 && resolvedChainId !== 102;
+  const executionPayloadDigest = isEvmSignRequest
+    ? executionPayloadDigestForEvmSign(signRequest)
+    : null;
+  const executionPolicyRevisionHash = isEvmSignRequest
+    ? policyRevisionHashForPolicySet(policySet)
+    : null;
 
   // ── Redis rate-limit check (before policy evaluation) ──────────────────────
   const rateLimitResult = await enforceRateLimit(agentId, policySet);
@@ -1957,6 +1984,10 @@ vaultRoutes.post("/:agentId/sign", async (c) => {
             policyResults: evaluation.results,
             actionPayload: transactionActionPayload({
               broadcast: signRequest.broadcast !== false,
+              nonce: signRequest.nonce,
+              gasLimit: signRequest.gasLimit,
+              venue: signRequest.venue,
+              walletAddress: signRequest.walletAddress,
             }),
           });
           await tx
@@ -2053,30 +2084,35 @@ vaultRoutes.post("/:agentId/sign", async (c) => {
     try {
       const txId = crypto.randomUUID();
       const txStatus: "broadcast" | "signed" = shouldBroadcast ? "broadcast" : "signed";
-      const executionAuthorization = await mintExecutionAuthorization({
-        requestId: txId,
-        tenantId,
-        agentId,
-        capability: "wallet.sign_transaction",
-        payloadDigest: executionPayloadDigest,
-        backend: "local-vault",
-        policyRevisionHash: executionPolicyRevisionHash,
-        idempotencyKey: c.req.header("Idempotency-Key") ?? undefined,
-      });
-      await writeVaultAudit(c, {
-        tenantId,
-        actorType: "agent",
-        actorId: agentId,
-        action: "vault.execution_authorization.minted",
-        resourceType: "execution_authorization",
-        resourceId: executionAuthorization.id,
-        metadata: {
-          txId,
-          payloadDigest: executionPayloadDigest,
-          policyRevisionHash: executionPolicyRevisionHash,
-          expiresAt: executionAuthorization.expiresAt,
-        },
-      });
+      const executionAuthorization =
+        isEvmSignRequest && executionPayloadDigest
+          ? await mintExecutionAuthorization({
+              requestId: txId,
+              tenantId,
+              agentId,
+              capability: "wallet.sign_transaction",
+              payloadDigest: executionPayloadDigest,
+              backend: "local-vault",
+              policyRevisionHash: executionPolicyRevisionHash ?? undefined,
+              idempotencyKey: c.req.header("Idempotency-Key") ?? undefined,
+            })
+          : null;
+      if (executionAuthorization && executionPayloadDigest) {
+        await writeVaultAudit(c, {
+          tenantId,
+          actorType: "agent",
+          actorId: agentId,
+          action: "vault.execution_authorization.minted",
+          resourceType: "execution_authorization",
+          resourceId: executionAuthorization.id,
+          metadata: {
+            txId,
+            payloadDigest: executionPayloadDigest,
+            policyRevisionHash: executionPolicyRevisionHash,
+            expiresAt: executionAuthorization.expiresAt,
+          },
+        });
+      }
       await writeVaultAudit(c, {
         tenantId,
         actorType: "agent",
@@ -2093,47 +2129,53 @@ vaultRoutes.post("/:agentId/sign", async (c) => {
           policyResults: evaluation.results,
         },
       });
-      const governedVault = new GovernedVault(vault, async (authorization, expected) => {
-        try {
-          await consumeExecutionAuthorization(authorization, expected);
-          await writeVaultAudit(c, {
-            tenantId,
-            actorType: "agent",
-            actorId: agentId,
-            action: "vault.execution_authorization.consumed",
-            resourceType: "execution_authorization",
-            resourceId: authorization.id,
-            metadata: {
+      const result =
+        executionAuthorization && executionPayloadDigest
+          ? await new GovernedVault(vault, async (authorization, expected) => {
+              try {
+                await consumeExecutionAuthorization(authorization, expected);
+                await writeVaultAudit(c, {
+                  tenantId,
+                  actorType: "agent",
+                  actorId: agentId,
+                  action: "vault.execution_authorization.consumed",
+                  resourceType: "execution_authorization",
+                  resourceId: authorization.id,
+                  metadata: {
+                    txId,
+                    payloadDigest: expected.payloadDigest,
+                    capability: expected.capability,
+                    backend: expected.backend,
+                  },
+                });
+              } catch (error) {
+                await writeVaultAudit(c, {
+                  tenantId,
+                  actorType: "agent",
+                  actorId: agentId,
+                  action: "vault.execution_authorization.rejected",
+                  resourceType: "execution_authorization",
+                  resourceId: authorization.id,
+                  metadata: {
+                    txId,
+                    payloadDigest: expected.payloadDigest,
+                    error: error instanceof Error ? error.message : "authorization rejected",
+                  },
+                });
+                throw error;
+              }
+            }).signTransaction(signRequest, {
               txId,
-              payloadDigest: expected.payloadDigest,
-              capability: expected.capability,
-              backend: expected.backend,
-            },
-          });
-        } catch (error) {
-          await writeVaultAudit(c, {
-            tenantId,
-            actorType: "agent",
-            actorId: agentId,
-            action: "vault.execution_authorization.rejected",
-            resourceType: "execution_authorization",
-            resourceId: authorization.id,
-            metadata: {
+              policyResults: evaluation.results,
+              status: txStatus,
+              executionAuthorization,
+              executionPayloadDigest,
+            })
+          : await vault.signTransaction(signRequest, {
               txId,
-              payloadDigest: expected.payloadDigest,
-              error: error instanceof Error ? error.message : "authorization rejected",
-            },
-          });
-          throw error;
-        }
-      });
-      const result = await governedVault.signTransaction(signRequest, {
-        txId,
-        policyResults: evaluation.results,
-        status: txStatus,
-        executionAuthorization,
-        executionPayloadDigest,
-      });
+              policyResults: evaluation.results,
+              status: txStatus,
+            });
 
       await db
         .update(transactions)
@@ -3383,11 +3425,14 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
       const approvalSignRequest: SignRequest = {
         ...toSignRequest(transactionRow),
         tenantId,
+        nonce: transactionPayload?.nonce,
         gasLimit:
           transferPayload && transferPayload.token !== "native" && transactionRow.data
             ? "65000"
-            : undefined,
+            : transactionPayload?.gasLimit,
         broadcast: requestedBroadcast,
+        venue: transactionPayload?.venue,
+        walletAddress: transactionPayload?.walletAddress,
       };
       const currentPolicySet = await getScopedPolicySet(tenantId, agentId, c.get("agentPolicyIds"));
       const currentExecutionPolicyRevisionHash = policyRevisionHashForPolicySet(currentPolicySet);
@@ -3730,6 +3775,10 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
               ? transactionActionPayload({
                   broadcast: transactionPayload.broadcast,
                   referenceId: transactionPayload.referenceId,
+                  nonce: transactionPayload.nonce,
+                  gasLimit: transactionPayload.gasLimit,
+                  venue: transactionPayload.venue,
+                  walletAddress: transactionPayload.walletAddress,
                 })
               : transactionRow.actionPayload,
           signedAt: resolvedAt,
@@ -3820,7 +3869,6 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
       const frozen = frozenSigningResponse(c, e);
       if (frozen) return frozen;
       const authorizationError = executionAuthorizationErrorResponse(c, e);
-      if (authorizationError) return authorizationError;
       if (!irreversibleResult) {
         await db
           .update(approvalQueue)
@@ -3854,6 +3902,8 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
           })
           .where(and(eq(transactions.id, txId), eq(transactions.agentId, agentId)));
       }
+
+      if (authorizationError) return authorizationError;
 
       const requestId = c.get("requestId") || "unknown";
       const rawMessage = e instanceof Error ? e.message : "Unknown error";

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -2171,11 +2171,23 @@ vaultRoutes.post("/:agentId/sign", async (c) => {
               executionAuthorization,
               executionPayloadDigest,
             })
-          : await vault.signTransaction(signRequest, {
-              txId,
-              policyResults: evaluation.results,
-              status: txStatus,
-            });
+          : await (async () => {
+              // Defense-in-depth: every primary EVM sign request has a non-null
+              // executionPayloadDigest and therefore mints+consumes an
+              // authorization above. The raw fallback exists ONLY for the
+              // non-EVM (Solana) chain family. An EVM request reaching here is an
+              // invariant violation (fail-open), not a signable request.
+              if (isEvmSignRequest) {
+                throw new Error(
+                  "invariant: primary EVM sign reached raw signer without gateway authorization",
+                );
+              }
+              return vault.signTransaction(signRequest, {
+                txId,
+                policyResults: evaluation.results,
+                status: txStatus,
+              });
+            })();
 
       await db
         .update(transactions)
@@ -3436,37 +3448,76 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
       };
       const currentPolicySet = await getScopedPolicySet(tenantId, agentId, c.get("agentPolicyIds"));
       const currentExecutionPolicyRevisionHash = policyRevisionHashForPolicySet(currentPolicySet);
-      const isPrimaryEvmApproval =
-        !isSolana && transferPayload === null && !isSendCallsAction && transactionPayload !== null;
+      // A row that is neither Solana, nor a transfer action, nor a send_calls
+      // action would, on the EVM path, reach the raw Vault.signTransaction
+      // fallback. Every such row is a raw-EVM-signing candidate and MUST be
+      // proven to be a validated primary EVM approval (typed transaction action
+      // payload + non-null stored digest + non-null stored policy revision +
+      // digest match). If any invariant is absent/malformed we reject fail-closed
+      // here and NEVER route to raw signing. This closes the legacy/null-digest
+      // and malformed-actionPayload replay-fail-open holes.
+      const isRawEvmSigningCandidate =
+        !isSolana && transferPayload === null && !isSendCallsAction;
+      const isPrimaryEvmApproval = isRawEvmSigningCandidate && transactionPayload !== null;
       const approvalExecutionPayloadDigest = isPrimaryEvmApproval
         ? executionPayloadDigestForEvmSign(approvalSignRequest)
         : null;
-      if (
-        isPrimaryEvmApproval &&
-        transactionRow.executionPayloadDigest &&
-        transactionRow.executionPayloadDigest !== approvalExecutionPayloadDigest
-      ) {
-        await writeVaultAudit(c, {
-          tenantId,
-          actorType: "user",
-          actorId,
-          action: "vault.execution_authorization.rejected",
-          resourceType: "transaction",
-          resourceId: txId,
-          metadata: {
-            agentId,
-            reason: "stored_digest_mismatch",
-            storedPayloadDigest: transactionRow.executionPayloadDigest,
-            replayPayloadDigest: approvalExecutionPayloadDigest,
-          },
-        });
-        return c.json<ApiResponse>(
-          {
-            ok: false,
-            error: "Pending transaction digest no longer matches the replay request",
-          },
-          409,
-        );
+      if (isRawEvmSigningCandidate) {
+        const failClosed = async (reason: string, error: string) => {
+          await writeVaultAudit(c, {
+            tenantId,
+            actorType: "user",
+            actorId,
+            action: "vault.execution_authorization.rejected",
+            resourceType: "transaction",
+            resourceId: txId,
+            metadata: {
+              agentId,
+              reason,
+              hasTransactionActionPayload: transactionPayload !== null,
+              hasStoredPayloadDigest: transactionRow.executionPayloadDigest !== null,
+              hasStoredPolicyRevisionHash:
+                transactionRow.executionPolicyRevisionHash !== null,
+              storedPayloadDigest: transactionRow.executionPayloadDigest,
+              replayPayloadDigest: approvalExecutionPayloadDigest,
+            },
+          });
+          return c.json<ApiResponse>({ ok: false, error }, 409);
+        };
+        // 1. Require a valid typed transaction action payload. A missing/malformed
+        //    actionPayload previously flipped isPrimaryEvmApproval=false and fell
+        //    through to raw signing. Now it fails closed.
+        if (!isPrimaryEvmApproval) {
+          return failClosed(
+            "missing_or_malformed_transaction_action_payload",
+            "This pending EVM approval lacks a valid typed transaction action payload and cannot be replayed. Resubmit the transaction.",
+          );
+        }
+        // 2. Require a non-null stored execution payload digest. Legacy/null-digest
+        //    rows minted before the gateway must be resubmitted, never raw-signed.
+        if (!transactionRow.executionPayloadDigest) {
+          return failClosed(
+            "missing_stored_execution_payload_digest",
+            "This pending EVM approval predates execution-authorization binding (no stored payload digest) and cannot be replayed. Resubmit the transaction.",
+          );
+        }
+        // 3. Require a non-null stored execution policy revision hash. Binds the
+        //    approval decision to the policy snapshot evaluated at queue time.
+        if (!transactionRow.executionPolicyRevisionHash) {
+          return failClosed(
+            "missing_stored_execution_policy_revision_hash",
+            "This pending EVM approval predates policy-revision binding (no stored policy revision hash) and cannot be replayed. Resubmit the transaction.",
+          );
+        }
+        // 4. Require the stored digest (from the immutable approval snapshot) to
+        //    equal the digest recomputed from the replay request. This prevents
+        //    any post-queue mutation of the approved caller intent.
+        if (transactionRow.executionPayloadDigest !== approvalExecutionPayloadDigest) {
+          return failClosed(
+            "stored_digest_mismatch",
+            "Pending transaction digest no longer matches the replay request",
+          );
+        }
       }
       const currentRateLimitResult = await enforceRateLimit(agentId, currentPolicySet);
       if (!currentRateLimitResult.allowed) {
@@ -3730,6 +3781,16 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
             executionPayloadDigest: approvalExecutionPayloadDigest,
           });
         } else {
+          // Defense-in-depth: the fail-closed gate above returns early for every
+          // raw-EVM-signing candidate that is not a validated primary EVM
+          // approval, so this raw fallback must only ever handle non-primary EVM
+          // action surfaces (transfer). A raw-EVM-signing candidate reaching here
+          // is an invariant violation, not a signable request.
+          if (isRawEvmSigningCandidate) {
+            throw new Error(
+              "invariant: primary EVM approval reached raw signer without gateway authorization",
+            );
+          }
           txHash = await vault.signTransaction(approvalSignRequest, {
             txId,
             policyResults: currentEvaluation.results,

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -27,6 +27,7 @@ import {
 import {
   assertMoneroAddress,
   assertSolanaPriorityFeeWithinCap,
+  BackendBindingMismatchError,
   type DerivedSolanaPolicyFields,
   deriveSolanaPolicyFields,
   detectSolanaPolicyConflicts,
@@ -1200,6 +1201,62 @@ function executionAuthorizationErrorResponse(
   if (!(error instanceof GovernedVaultError)) return null;
   const status = error.code === "authorization_rejected" ? 403 : 500;
   return c.json<ApiResponse>({ ok: false, error: error.message }, status);
+}
+
+// Fail-closed handler for the TOCTOU backend-binding guard.
+//
+// `BackendBindingMismatchError` is thrown at the vault signing boundary
+// (Vault.signTransaction) AFTER the gateway authorization has been minted and
+// consumed, when the wallet's custody backend has flipped from the
+// gateway-supported "local-vault" to "third-party-custody" between the gateway's
+// resolveExecutionBackend precheck and the raw sign. It is NOT a
+// GovernedVaultError, so without this explicit handler it would fall through to
+// the generic 500 path with no specific audit. Here we write a dedicated
+// rejection audit event (matching the vault.execution_authorization.rejected
+// taxonomy, reason `backend_binding_mismatch`) and return the same 409
+// fail-closed shape the earlier gateway precheck uses, so the two custody-
+// mismatch rejection points are indistinguishable to the caller.
+//
+// Returns null (does NOT swallow) for any other error so the outer catch keeps
+// its existing handling for GovernedVaultError / RPC / generic failures.
+async function backendBindingMismatchResponse(
+  c: Context<{ Variables: AppVariables }>,
+  error: unknown,
+  context: {
+    tenantId: string;
+    agentId: string;
+    txId?: string;
+    authorizationId?: string;
+    chainId?: number;
+  },
+): Promise<Response | null> {
+  if (!(error instanceof BackendBindingMismatchError)) return null;
+  await writeVaultAudit(c, {
+    tenantId: context.tenantId,
+    actorType: "agent",
+    actorId: context.agentId,
+    action: "vault.execution_authorization.rejected",
+    resourceType: context.authorizationId ? "execution_authorization" : "transaction",
+    resourceId: context.authorizationId ?? context.txId ?? context.agentId,
+    metadata: {
+      agentId: context.agentId,
+      reason: error.code,
+      expectedBackend: error.expectedBackend,
+      resolvedBackend: error.resolvedBackend,
+      ...(context.txId ? { txId: context.txId } : {}),
+      ...(context.authorizationId ? { authorizationId: context.authorizationId } : {}),
+      ...(context.chainId !== undefined ? { chainId: context.chainId } : {}),
+    },
+  });
+  return c.json<ApiResponse<{ code: string }>>(
+    {
+      ok: false,
+      error:
+        "This wallet uses third-party custody, which is not supported by the execution gateway. Resubmit through a supported custody path.",
+      data: { code: error.code },
+    },
+    409,
+  );
 }
 
 function isHex(value: unknown): value is `0x${string}` {
@@ -2410,6 +2467,12 @@ vaultRoutes.post("/:agentId/sign", async (c) => {
     } catch (e: unknown) {
       const frozen = frozenSigningResponse(c, e);
       if (frozen) return frozen;
+      const bindingMismatch = await backendBindingMismatchResponse(c, e, {
+        tenantId,
+        agentId,
+        chainId: resolvedChainId,
+      });
+      if (bindingMismatch) return bindingMismatch;
       const authorizationError = executionAuthorizationErrorResponse(c, e);
       if (authorizationError) return authorizationError;
       const requestId = c.get("requestId") || "unknown";
@@ -4155,6 +4218,12 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
       const frozen = frozenSigningResponse(c, e);
       if (frozen) return frozen;
       const authorizationError = executionAuthorizationErrorResponse(c, e);
+      const bindingMismatch = await backendBindingMismatchResponse(c, e, {
+        tenantId,
+        agentId,
+        txId,
+        chainId: transactionRow.chainId,
+      });
       if (!irreversibleResult) {
         await db
           .update(approvalQueue)
@@ -4189,6 +4258,7 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
           .where(and(eq(transactions.id, txId), eq(transactions.agentId, agentId)));
       }
 
+      if (bindingMismatch) return bindingMismatch;
       if (authorizationError) return authorizationError;
 
       const requestId = c.get("requestId") || "unknown";

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -18,6 +18,7 @@ import {
 import { tenantConfigs as tenantConfigsTable, users, userTenants } from "@stwd/db";
 import { recordAggregationEvent } from "@stwd/redis";
 import {
+  ExecutionPayloadNormalizationError,
   type PolicyResult,
   rawSigningChainSupport,
   type TenantAuthAbuseConfig,
@@ -845,6 +846,37 @@ function getSendCallsActionPayload(payload: unknown): {
   };
 }
 
+/**
+ * Raised when a stored `transaction` action payload contains a present field of
+ * the wrong type / out-of-range value. Replaying such a payload previously
+ * silently coerced or dropped the offending field (e.g. a non-boolean broadcast
+ * coerced to true, a string/float/negative/unsafe nonce dropped, wrong-type
+ * gasLimit/venue/walletAddress dropped). That silent normalization changed the
+ * caller's approved intent under the approval digest and could route a mutated
+ * request to raw signing. The strict validator now throws instead, and the
+ * approval replay path converts this into a fail-closed 409 with a specific
+ * rejection audit (malformed_transaction_action_payload).
+ */
+class TransactionActionPayloadValidationError extends Error {
+  constructor(
+    message: string,
+    readonly field: string,
+  ) {
+    super(message);
+    this.name = "TransactionActionPayloadValidationError";
+  }
+}
+
+/**
+ * STRICT validator for a stored `transaction` action payload.
+ *
+ * Returns null ONLY when the payload is not a transaction-typed action (so
+ * transfer/send_calls actions flow past unaffected). For a transaction-typed
+ * payload every present optional field is validated to its exact contract and a
+ * violation THROWS TransactionActionPayloadValidationError rather than being
+ * silently coerced/dropped. This keeps the replay digest an honest reflection
+ * of the approved caller intent.
+ */
 function getTransactionActionPayload(payload: unknown): {
   type: "transaction";
   broadcast: boolean;
@@ -857,17 +889,77 @@ function getTransactionActionPayload(payload: unknown): {
   if (!payload || typeof payload !== "object") return null;
   const value = payload as Record<string, unknown>;
   if (value.type !== "transaction") return null;
+
+  // broadcast: REQUIRED boolean. A missing or non-boolean broadcast was
+  // previously coerced (value.broadcast !== false) to true, silently promoting
+  // an ambiguous payload to a broadcast execution. Require it explicitly.
+  if (typeof value.broadcast !== "boolean") {
+    throw new TransactionActionPayloadValidationError(
+      "transaction action payload 'broadcast' must be a boolean",
+      "broadcast",
+    );
+  }
+
+  // nonce: OPTIONAL, but if present must be a non-negative safe integer. A
+  // string/object/float/negative/unsafe-integer nonce was previously dropped,
+  // silently changing the digested intent (or later throwing deep in the shared
+  // normalizer without a specific rejection audit).
+  let nonce: number | undefined;
+  if (value.nonce !== undefined && value.nonce !== null) {
+    if (typeof value.nonce !== "number" || !Number.isSafeInteger(value.nonce) || value.nonce < 0) {
+      throw new TransactionActionPayloadValidationError(
+        "transaction action payload 'nonce' must be a non-negative safe integer",
+        "nonce",
+      );
+    }
+    nonce = value.nonce;
+  }
+
+  // gasLimit: OPTIONAL, but if present must be a decimal uint string (its actual
+  // contract, e.g. "65000"). A wrong-type gasLimit was previously dropped.
+  let gasLimit: string | undefined;
+  if (value.gasLimit !== undefined && value.gasLimit !== null) {
+    if (!isUint256DecimalString(value.gasLimit)) {
+      throw new TransactionActionPayloadValidationError(
+        "transaction action payload 'gasLimit' must be a decimal uint string",
+        "gasLimit",
+      );
+    }
+    gasLimit = value.gasLimit;
+  }
+
+  // venue / walletAddress: OPTIONAL, but if present must be strings. Wrong-type
+  // values were previously dropped, changing the resolved signing wallet/venue.
+  let venue: string | undefined;
+  if (value.venue !== undefined && value.venue !== null) {
+    if (typeof value.venue !== "string") {
+      throw new TransactionActionPayloadValidationError(
+        "transaction action payload 'venue' must be a string",
+        "venue",
+      );
+    }
+    venue = value.venue;
+  }
+
+  let walletAddress: string | undefined;
+  if (value.walletAddress !== undefined && value.walletAddress !== null) {
+    if (typeof value.walletAddress !== "string") {
+      throw new TransactionActionPayloadValidationError(
+        "transaction action payload 'walletAddress' must be a string",
+        "walletAddress",
+      );
+    }
+    walletAddress = value.walletAddress;
+  }
+
   return {
     type: "transaction",
-    broadcast: value.broadcast !== false,
+    broadcast: value.broadcast,
     referenceId: actionReferenceId(value) ?? undefined,
-    nonce:
-      typeof value.nonce === "number" && Number.isInteger(value.nonce) && value.nonce >= 0
-        ? value.nonce
-        : undefined,
-    gasLimit: typeof value.gasLimit === "string" ? value.gasLimit : undefined,
-    venue: typeof value.venue === "string" ? value.venue : undefined,
-    walletAddress: typeof value.walletAddress === "string" ? value.walletAddress : undefined,
+    nonce,
+    gasLimit,
+    venue,
+    walletAddress,
   };
 }
 
@@ -1923,6 +2015,46 @@ vaultRoutes.post("/:agentId/sign", async (c) => {
   const executionPolicyRevisionHash = isEvmSignRequest
     ? policyRevisionHashForPolicySet(policySet)
     : null;
+
+  // FINDING 4: the execution authorization minted below is cryptographically
+  // bound to backend "local-vault". Resolve the backend this request would
+  // ACTUALLY route to BEFORE minting/signing. External custody is NOT a
+  // gateway-supported backend in #182; a local-vault-bound authorization must
+  // never authorize an third-party-custody execution. Fail closed before the
+  // third-party custody provider is ever reached.
+  if (isEvmSignRequest) {
+    const resolvedBackend = await vault.resolveExecutionBackend({
+      tenantId,
+      agentId,
+      chainId: signRequest.chainId,
+      venue: signRequest.venue,
+      walletAddress: signRequest.walletAddress,
+    });
+    if (resolvedBackend !== "local-vault") {
+      await writeVaultAudit(c, {
+        tenantId,
+        actorType: "agent",
+        actorId: agentId,
+        action: "vault.execution_authorization.rejected",
+        resourceType: "transaction",
+        resourceId: agentId,
+        metadata: {
+          agentId,
+          reason: "third-party_custody_not_gateway_supported",
+          resolvedBackend,
+          chainId: signRequest.chainId,
+        },
+      });
+      return c.json<ApiResponse>(
+        {
+          ok: false,
+          error:
+            "This wallet uses third-party custody, which is not supported by the execution gateway. Resubmit through a supported custody path.",
+        },
+        409,
+      );
+    }
+  }
 
   // ── Redis rate-limit check (before policy evaluation) ──────────────────────
   const rateLimitResult = await enforceRateLimit(agentId, policySet);
@@ -3379,10 +3511,43 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
     transactionRow.actionType === "send_calls"
       ? getSendCallsActionPayload(transactionRow.actionPayload)
       : null;
-  const transactionPayload =
-    !transactionRow.actionType || transactionRow.actionType === "transaction"
-      ? getTransactionActionPayload(transactionRow.actionPayload)
-      : null;
+  // Validate the stored transaction action payload strictly. A malformed present
+  // field (wrong-type broadcast, string/float/negative/unsafe nonce, wrong-type
+  // gasLimit/venue/walletAddress) THROWS here rather than being silently
+  // coerced/dropped. We fail closed with a specific rejection audit and 409 so
+  // no mutated intent can ever reach the replay digest / raw signer.
+  let transactionPayload: ReturnType<typeof getTransactionActionPayload> = null;
+  if (!transactionRow.actionType || transactionRow.actionType === "transaction") {
+    try {
+      transactionPayload = getTransactionActionPayload(transactionRow.actionPayload);
+    } catch (error) {
+      if (error instanceof TransactionActionPayloadValidationError) {
+        await writeVaultAudit(c, {
+          tenantId,
+          actorType: "user",
+          actorId,
+          action: "vault.execution_authorization.rejected",
+          resourceType: "transaction",
+          resourceId: txId,
+          metadata: {
+            agentId,
+            reason: "malformed_transaction_action_payload",
+            field: error.field,
+            error: error.message,
+          },
+        });
+        return c.json<ApiResponse>(
+          {
+            ok: false,
+            error:
+              "This pending EVM approval has a malformed transaction action payload and cannot be replayed. Resubmit the transaction.",
+          },
+          409,
+        );
+      }
+      throw error;
+    }
+  }
   const isSendCallsAction = sendCallsPayload !== null;
   if (
     transactionRow.actionType === "send_calls" ||
@@ -3458,30 +3623,58 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
       // and malformed-actionPayload replay-fail-open holes.
       const isRawEvmSigningCandidate = !isSolana && transferPayload === null && !isSendCallsAction;
       const isPrimaryEvmApproval = isRawEvmSigningCandidate && transactionPayload !== null;
-      const approvalExecutionPayloadDigest = isPrimaryEvmApproval
-        ? executionPayloadDigestForEvmSign(approvalSignRequest)
-        : null;
+
+      const failClosed = async (
+        reason: string,
+        error: string,
+        replayPayloadDigest: string | null,
+        extraMetadata?: Record<string, unknown>,
+      ) => {
+        await writeVaultAudit(c, {
+          tenantId,
+          actorType: "user",
+          actorId,
+          action: "vault.execution_authorization.rejected",
+          resourceType: "transaction",
+          resourceId: txId,
+          metadata: {
+            agentId,
+            reason,
+            hasTransactionActionPayload: transactionPayload !== null,
+            hasStoredPayloadDigest: transactionRow.executionPayloadDigest !== null,
+            hasStoredPolicyRevisionHash: transactionRow.executionPolicyRevisionHash !== null,
+            storedPayloadDigest: transactionRow.executionPayloadDigest,
+            replayPayloadDigest,
+            ...extraMetadata,
+          },
+        });
+        return c.json<ApiResponse>({ ok: false, error }, 409);
+      };
+
+      // Compute the replay digest inside a guarded block. The shared normalizer
+      // throws ExecutionPayloadNormalizationError on any malformed numeric caller
+      // field (e.g. an unsafe-integer nonce). Previously this threw BEFORE the
+      // failClosed helper and the outer catch only handles GovernedVaultError, so
+      // signing was prevented but no specific rejection audit was produced. We now
+      // convert it into the same fail-closed 409 path with a specific reason.
+      let approvalExecutionPayloadDigest: string | null = null;
+      if (isPrimaryEvmApproval) {
+        try {
+          approvalExecutionPayloadDigest = executionPayloadDigestForEvmSign(approvalSignRequest);
+        } catch (error) {
+          if (error instanceof ExecutionPayloadNormalizationError) {
+            return failClosed(
+              "malformed_transaction_action_payload",
+              "This pending EVM approval has a malformed transaction action payload and cannot be replayed. Resubmit the transaction.",
+              null,
+              { field: error.field, error: error.message },
+            );
+          }
+          throw error;
+        }
+      }
+
       if (isRawEvmSigningCandidate) {
-        const failClosed = async (reason: string, error: string) => {
-          await writeVaultAudit(c, {
-            tenantId,
-            actorType: "user",
-            actorId,
-            action: "vault.execution_authorization.rejected",
-            resourceType: "transaction",
-            resourceId: txId,
-            metadata: {
-              agentId,
-              reason,
-              hasTransactionActionPayload: transactionPayload !== null,
-              hasStoredPayloadDigest: transactionRow.executionPayloadDigest !== null,
-              hasStoredPolicyRevisionHash: transactionRow.executionPolicyRevisionHash !== null,
-              storedPayloadDigest: transactionRow.executionPayloadDigest,
-              replayPayloadDigest: approvalExecutionPayloadDigest,
-            },
-          });
-          return c.json<ApiResponse>({ ok: false, error }, 409);
-        };
         // 1. Require a valid typed transaction action payload. A missing/malformed
         //    actionPayload previously flipped isPrimaryEvmApproval=false and fell
         //    through to raw signing. Now it fails closed.
@@ -3489,6 +3682,7 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
           return failClosed(
             "missing_or_malformed_transaction_action_payload",
             "This pending EVM approval lacks a valid typed transaction action payload and cannot be replayed. Resubmit the transaction.",
+            approvalExecutionPayloadDigest,
           );
         }
         // 2. Require a non-null stored execution payload digest. Legacy/null-digest
@@ -3497,6 +3691,7 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
           return failClosed(
             "missing_stored_execution_payload_digest",
             "This pending EVM approval predates execution-authorization binding (no stored payload digest) and cannot be replayed. Resubmit the transaction.",
+            approvalExecutionPayloadDigest,
           );
         }
         // 3. Require a non-null stored execution policy revision hash. Binds the
@@ -3505,6 +3700,7 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
           return failClosed(
             "missing_stored_execution_policy_revision_hash",
             "This pending EVM approval predates policy-revision binding (no stored policy revision hash) and cannot be replayed. Resubmit the transaction.",
+            approvalExecutionPayloadDigest,
           );
         }
         // 4. Require the stored digest (from the immutable approval snapshot) to
@@ -3514,6 +3710,28 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
           return failClosed(
             "stored_digest_mismatch",
             "Pending transaction digest no longer matches the replay request",
+            approvalExecutionPayloadDigest,
+          );
+        }
+        // 5. FINDING 4: the authorization is cryptographically bound to backend
+        //    "local-vault". Resolve the backend the request would ACTUALLY route
+        //    to before minting. External custody is NOT gateway-supported in
+        //    #182; a local-vault-bound authorization must never authorize an
+        //    third-party-custody execution. Fail closed before the provider is
+        //    reached.
+        const resolvedBackend = await vault.resolveExecutionBackend({
+          tenantId,
+          agentId,
+          chainId: approvalSignRequest.chainId,
+          venue: approvalSignRequest.venue,
+          walletAddress: approvalSignRequest.walletAddress,
+        });
+        if (resolvedBackend !== "local-vault") {
+          return failClosed(
+            "third-party_custody_not_gateway_supported",
+            "This wallet uses third-party custody, which is not supported by the execution gateway. Resubmit through a supported custody path.",
+            approvalExecutionPayloadDigest,
+            { resolvedBackend },
           );
         }
       }

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -31,6 +31,8 @@ import {
   detectSolanaPolicyConflicts,
   ENTRY_POINT_V07,
   type ExportPrivateKeyResult,
+  GovernedVault,
+  GovernedVaultError,
   getUserOperationHash,
   isVaultSigningFrozenError,
   MoneroNotConfiguredError,
@@ -79,6 +81,12 @@ import {
   transactions,
   vault,
 } from "../services/context";
+import {
+  consumeExecutionAuthorization,
+  executionPayloadDigestForEvmSign,
+  mintExecutionAuthorization,
+  policyRevisionHashForPolicySet,
+} from "../services/execution-authorization";
 import {
   recordSponsoredGasEvent,
   reserveSponsoredGasEvent,
@@ -1062,6 +1070,15 @@ function hasCalldata(value: unknown): boolean {
   return typeof value === "string" && value.trim() !== "" && value.trim().toLowerCase() !== "0x";
 }
 
+function executionAuthorizationErrorResponse(
+  c: Context<{ Variables: AppVariables }>,
+  error: unknown,
+): Response | null {
+  if (!(error instanceof GovernedVaultError)) return null;
+  const status = error.code === "authorization_rejected" ? 403 : 500;
+  return c.json<ApiResponse>({ ok: false, error: error.message }, status);
+}
+
 function isHex(value: unknown): value is `0x${string}` {
   return typeof value === "string" && /^0x[0-9a-fA-F]*$/.test(value);
 }
@@ -1877,6 +1894,8 @@ vaultRoutes.post("/:agentId/sign", async (c) => {
 
   const policySet = await getScopedPolicySet(tenantId, agentId, c.get("agentPolicyIds"));
   const conditionSets = await loadConditionSetsForPolicies(tenantId, policySet);
+  const executionPayloadDigest = executionPayloadDigestForEvmSign(signRequest);
+  const executionPolicyRevisionHash = policyRevisionHashForPolicySet(policySet);
 
   // ── Redis rate-limit check (before policy evaluation) ──────────────────────
   const rateLimitResult = await enforceRateLimit(agentId, policySet);
@@ -1933,6 +1952,8 @@ vaultRoutes.post("/:agentId/sign", async (c) => {
             value: signRequest.value,
             data: signRequest.data,
             chainId: signRequest.chainId,
+            executionPayloadDigest,
+            executionPolicyRevisionHash,
             policyResults: evaluation.results,
             actionPayload: transactionActionPayload({
               broadcast: signRequest.broadcast !== false,
@@ -1991,6 +2012,8 @@ vaultRoutes.post("/:agentId/sign", async (c) => {
         value: signRequest.value,
         data: signRequest.data,
         chainId: signRequest.chainId,
+        executionPayloadDigest,
+        executionPolicyRevisionHash,
         policyResults: evaluation.results,
       });
 
@@ -2030,6 +2053,30 @@ vaultRoutes.post("/:agentId/sign", async (c) => {
     try {
       const txId = crypto.randomUUID();
       const txStatus: "broadcast" | "signed" = shouldBroadcast ? "broadcast" : "signed";
+      const executionAuthorization = await mintExecutionAuthorization({
+        requestId: txId,
+        tenantId,
+        agentId,
+        capability: "wallet.sign_transaction",
+        payloadDigest: executionPayloadDigest,
+        backend: "local-vault",
+        policyRevisionHash: executionPolicyRevisionHash,
+        idempotencyKey: c.req.header("Idempotency-Key") ?? undefined,
+      });
+      await writeVaultAudit(c, {
+        tenantId,
+        actorType: "agent",
+        actorId: agentId,
+        action: "vault.execution_authorization.minted",
+        resourceType: "execution_authorization",
+        resourceId: executionAuthorization.id,
+        metadata: {
+          txId,
+          payloadDigest: executionPayloadDigest,
+          policyRevisionHash: executionPolicyRevisionHash,
+          expiresAt: executionAuthorization.expiresAt,
+        },
+      });
       await writeVaultAudit(c, {
         tenantId,
         actorType: "agent",
@@ -2046,10 +2093,46 @@ vaultRoutes.post("/:agentId/sign", async (c) => {
           policyResults: evaluation.results,
         },
       });
-      const result = await vault.signTransaction(signRequest, {
+      const governedVault = new GovernedVault(vault, async (authorization, expected) => {
+        try {
+          await consumeExecutionAuthorization(authorization, expected);
+          await writeVaultAudit(c, {
+            tenantId,
+            actorType: "agent",
+            actorId: agentId,
+            action: "vault.execution_authorization.consumed",
+            resourceType: "execution_authorization",
+            resourceId: authorization.id,
+            metadata: {
+              txId,
+              payloadDigest: expected.payloadDigest,
+              capability: expected.capability,
+              backend: expected.backend,
+            },
+          });
+        } catch (error) {
+          await writeVaultAudit(c, {
+            tenantId,
+            actorType: "agent",
+            actorId: agentId,
+            action: "vault.execution_authorization.rejected",
+            resourceType: "execution_authorization",
+            resourceId: authorization.id,
+            metadata: {
+              txId,
+              payloadDigest: expected.payloadDigest,
+              error: error instanceof Error ? error.message : "authorization rejected",
+            },
+          });
+          throw error;
+        }
+      });
+      const result = await governedVault.signTransaction(signRequest, {
         txId,
         policyResults: evaluation.results,
         status: txStatus,
+        executionAuthorization,
+        executionPayloadDigest,
       });
 
       await db
@@ -2057,6 +2140,8 @@ vaultRoutes.post("/:agentId/sign", async (c) => {
         .set({
           status: txStatus,
           txHash: shouldBroadcast ? result : undefined,
+          executionPayloadDigest,
+          executionPolicyRevisionHash,
           policyResults: evaluation.results,
           signedAt: new Date(),
         })
@@ -2130,6 +2215,8 @@ vaultRoutes.post("/:agentId/sign", async (c) => {
     } catch (e: unknown) {
       const frozen = frozenSigningResponse(c, e);
       if (frozen) return frozen;
+      const authorizationError = executionAuthorizationErrorResponse(c, e);
+      if (authorizationError) return authorizationError;
       const requestId = c.get("requestId") || "unknown";
       const rawMessage = e instanceof Error ? e.message : "Unknown error";
       console.error(`[${requestId}] Sign transaction failed for agent ${agentId}:`, e);
@@ -3303,6 +3390,39 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
         broadcast: requestedBroadcast,
       };
       const currentPolicySet = await getScopedPolicySet(tenantId, agentId, c.get("agentPolicyIds"));
+      const currentExecutionPolicyRevisionHash = policyRevisionHashForPolicySet(currentPolicySet);
+      const isPrimaryEvmApproval =
+        !isSolana && transferPayload === null && !isSendCallsAction && transactionPayload !== null;
+      const approvalExecutionPayloadDigest = isPrimaryEvmApproval
+        ? executionPayloadDigestForEvmSign(approvalSignRequest)
+        : null;
+      if (
+        isPrimaryEvmApproval &&
+        transactionRow.executionPayloadDigest &&
+        transactionRow.executionPayloadDigest !== approvalExecutionPayloadDigest
+      ) {
+        await writeVaultAudit(c, {
+          tenantId,
+          actorType: "user",
+          actorId,
+          action: "vault.execution_authorization.rejected",
+          resourceType: "transaction",
+          resourceId: txId,
+          metadata: {
+            agentId,
+            reason: "stored_digest_mismatch",
+            storedPayloadDigest: transactionRow.executionPayloadDigest,
+            replayPayloadDigest: approvalExecutionPayloadDigest,
+          },
+        });
+        return c.json<ApiResponse>(
+          {
+            ok: false,
+            error: "Pending transaction digest no longer matches the replay request",
+          },
+          409,
+        );
+      }
       const currentRateLimitResult = await enforceRateLimit(agentId, currentPolicySet);
       if (!currentRateLimitResult.allowed) {
         if (currentRateLimitResult.headers) {
@@ -3494,11 +3614,83 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
         irreversibleResult = shouldBroadcast;
         if (shouldBroadcast) completedTxHash = txHash;
       } else {
-        txHash = await vault.signTransaction(approvalSignRequest, {
-          txId,
-          policyResults: currentEvaluation.results,
-          status: shouldBroadcast ? "broadcast" : "signed",
-        });
+        if (isPrimaryEvmApproval && approvalExecutionPayloadDigest) {
+          const executionAuthorization = await mintExecutionAuthorization({
+            requestId: txId,
+            tenantId,
+            agentId,
+            capability: "wallet.sign_transaction",
+            payloadDigest: approvalExecutionPayloadDigest,
+            backend: "local-vault",
+            policyRevisionHash: currentExecutionPolicyRevisionHash,
+            approvalId: txId,
+            idempotencyKey: c.req.header("Idempotency-Key") ?? undefined,
+          });
+          await writeVaultAudit(c, {
+            tenantId,
+            actorType: "user",
+            actorId,
+            action: "vault.execution_authorization.minted",
+            resourceType: "execution_authorization",
+            resourceId: executionAuthorization.id,
+            metadata: {
+              txId,
+              payloadDigest: approvalExecutionPayloadDigest,
+              originalPayloadDigest: transactionRow.executionPayloadDigest,
+              originalPolicyRevisionHash: transactionRow.executionPolicyRevisionHash,
+              policyRevisionHash: currentExecutionPolicyRevisionHash,
+              approvalId: txId,
+              expiresAt: executionAuthorization.expiresAt,
+            },
+          });
+          const governedVault = new GovernedVault(vault, async (authorization, expected) => {
+            try {
+              await consumeExecutionAuthorization(authorization, expected);
+              await writeVaultAudit(c, {
+                tenantId,
+                actorType: "user",
+                actorId,
+                action: "vault.execution_authorization.consumed",
+                resourceType: "execution_authorization",
+                resourceId: authorization.id,
+                metadata: {
+                  txId,
+                  payloadDigest: expected.payloadDigest,
+                  capability: expected.capability,
+                  backend: expected.backend,
+                },
+              });
+            } catch (error) {
+              await writeVaultAudit(c, {
+                tenantId,
+                actorType: "user",
+                actorId,
+                action: "vault.execution_authorization.rejected",
+                resourceType: "execution_authorization",
+                resourceId: authorization.id,
+                metadata: {
+                  txId,
+                  payloadDigest: expected.payloadDigest,
+                  error: error instanceof Error ? error.message : "authorization rejected",
+                },
+              });
+              throw error;
+            }
+          });
+          txHash = await governedVault.signTransaction(approvalSignRequest, {
+            txId,
+            policyResults: currentEvaluation.results,
+            status: shouldBroadcast ? "broadcast" : "signed",
+            executionAuthorization,
+            executionPayloadDigest: approvalExecutionPayloadDigest,
+          });
+        } else {
+          txHash = await vault.signTransaction(approvalSignRequest, {
+            txId,
+            policyResults: currentEvaluation.results,
+            status: shouldBroadcast ? "broadcast" : "signed",
+          });
+        }
         irreversibleResult = shouldBroadcast;
         if (shouldBroadcast) completedTxHash = txHash;
       }
@@ -3519,6 +3711,11 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
         .set({
           status: nextStatus,
           txHash: shouldBroadcast ? txHash : null,
+          executionPayloadDigest:
+            approvalExecutionPayloadDigest ?? transactionRow.executionPayloadDigest,
+          executionPolicyRevisionHash: isPrimaryEvmApproval
+            ? currentExecutionPolicyRevisionHash
+            : transactionRow.executionPolicyRevisionHash,
           policyResults: currentEvaluation.results,
           actionPayload: transferPayload
             ? transferActionPayload({
@@ -3622,6 +3819,8 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
     } catch (e: unknown) {
       const frozen = frozenSigningResponse(c, e);
       if (frozen) return frozen;
+      const authorizationError = executionAuthorizationErrorResponse(c, e);
+      if (authorizationError) return authorizationError;
       if (!irreversibleResult) {
         await db
           .update(approvalQueue)

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -900,12 +900,17 @@ function getTransactionActionPayload(payload: unknown): {
     );
   }
 
-  // nonce: OPTIONAL, but if present must be a non-negative safe integer. A
-  // string/object/float/negative/unsafe-integer nonce was previously dropped,
-  // silently changing the digested intent (or later throwing deep in the shared
-  // normalizer without a specific rejection audit).
+  // nonce: OPTIONAL, but a PRESENT value (including an explicit null) must be a
+  // non-negative safe integer. Absence is distinguished from a present-null via
+  // Object.hasOwn: a legitimately-minted payload omits the key entirely (the
+  // transactionActionPayload builder spreads it in only when defined+non-null,
+  // and jsonb storage never injects nulls for omitted keys), so a present null
+  // can only come from a malformed/adversarial payload and must fail closed
+  // rather than be silently normalized to "omitted". A string/object/float/
+  // negative/unsafe-integer nonce was likewise previously dropped, silently
+  // changing the digested intent.
   let nonce: number | undefined;
-  if (value.nonce !== undefined && value.nonce !== null) {
+  if (Object.hasOwn(value, "nonce")) {
     if (typeof value.nonce !== "number" || !Number.isSafeInteger(value.nonce) || value.nonce < 0) {
       throw new TransactionActionPayloadValidationError(
         "transaction action payload 'nonce' must be a non-negative safe integer",
@@ -915,10 +920,12 @@ function getTransactionActionPayload(payload: unknown): {
     nonce = value.nonce;
   }
 
-  // gasLimit: OPTIONAL, but if present must be a decimal uint string (its actual
-  // contract, e.g. "65000"). A wrong-type gasLimit was previously dropped.
+  // gasLimit: OPTIONAL, but a PRESENT value (including explicit null) must be a
+  // decimal uint string (its actual contract, e.g. "65000"). Absence vs
+  // present-null distinguished via Object.hasOwn; a wrong-type or present-null
+  // gasLimit was previously dropped.
   let gasLimit: string | undefined;
-  if (value.gasLimit !== undefined && value.gasLimit !== null) {
+  if (Object.hasOwn(value, "gasLimit")) {
     if (!isUint256DecimalString(value.gasLimit)) {
       throw new TransactionActionPayloadValidationError(
         "transaction action payload 'gasLimit' must be a decimal uint string",
@@ -928,10 +935,12 @@ function getTransactionActionPayload(payload: unknown): {
     gasLimit = value.gasLimit;
   }
 
-  // venue / walletAddress: OPTIONAL, but if present must be strings. Wrong-type
-  // values were previously dropped, changing the resolved signing wallet/venue.
+  // venue / walletAddress: OPTIONAL, but a PRESENT value (including explicit
+  // null) must be a string. Absence vs present-null distinguished via
+  // Object.hasOwn; wrong-type or present-null values were previously dropped,
+  // changing the resolved signing wallet/venue.
   let venue: string | undefined;
-  if (value.venue !== undefined && value.venue !== null) {
+  if (Object.hasOwn(value, "venue")) {
     if (typeof value.venue !== "string") {
       throw new TransactionActionPayloadValidationError(
         "transaction action payload 'venue' must be a string",
@@ -942,7 +951,7 @@ function getTransactionActionPayload(payload: unknown): {
   }
 
   let walletAddress: string | undefined;
-  if (value.walletAddress !== undefined && value.walletAddress !== null) {
+  if (Object.hasOwn(value, "walletAddress")) {
     if (typeof value.walletAddress !== "string") {
       throw new TransactionActionPayloadValidationError(
         "transaction action payload 'walletAddress' must be a string",

--- a/packages/api/src/services/execution-authorization.ts
+++ b/packages/api/src/services/execution-authorization.ts
@@ -7,11 +7,14 @@ import {
   timingSafeEqual,
 } from "node:crypto";
 import { executionAuthorizationNonces, getDb, policies } from "@stwd/db";
-import type {
-  ExecutionAuthorization,
-  ExecutionCapability,
-  PolicyRule,
-  SignRequest,
+import {
+  canonicalJsonStringify,
+  type ExecutionAuthorization,
+  type ExecutionCapability,
+  normalizeEvmExecutionPayload,
+  type NormalizedEvmExecutionPayload,
+  type PolicyRule,
+  type SignRequest,
 } from "@stwd/shared";
 import { and, eq, sql } from "drizzle-orm";
 
@@ -36,31 +39,20 @@ export class ExecutionAuthorizationError extends Error {
 }
 
 export function canonicalJson(value: unknown): string {
-  return JSON.stringify(canonicalize(value));
+  return canonicalJsonStringify(value);
 }
 
 export function sha256Hex(value: unknown): string {
-  return createHash("sha256").update(canonicalJson(value)).digest("hex");
+  return createHash("sha256").update(canonicalJsonStringify(value)).digest("hex");
 }
 
-export function executionPayloadForEvmSign(request: SignRequest): Record<string, unknown> {
-  return {
-    agentId: request.agentId,
-    tenantId: request.tenantId,
-    capability: "wallet.sign_transaction",
-    backend: "local-vault",
-    transaction: {
-      to: request.to,
-      value: request.value,
-      data: request.data ?? "0x",
-      chainId: request.chainId,
-      nonce: request.nonce ?? null,
-      gasLimit: request.gasLimit ?? null,
-      broadcast: request.broadcast !== false,
-      venue: request.venue ?? null,
-      walletAddress: request.walletAddress ?? null,
-    },
-  };
+/**
+ * Canonical normalized EVM sign intent. Delegates to the SINGLE shared
+ * normalizer so the API minting side and the GovernedVault verification side
+ * digest byte-identical payloads. Throws on malformed numeric caller fields.
+ */
+export function executionPayloadForEvmSign(request: SignRequest): NormalizedEvmExecutionPayload {
+  return normalizeEvmExecutionPayload(request);
 }
 
 export function executionPayloadDigestForEvmSign(request: SignRequest): string {
@@ -284,18 +276,4 @@ function constantTimeEqual(left: string, right: string): boolean {
 function base64Url(value: Uint8Array): string {
   const binary = Array.from(value, (byte) => String.fromCharCode(byte)).join("");
   return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
-}
-
-function canonicalize(value: unknown): unknown {
-  if (typeof value === "bigint") return value.toString();
-  if (value === null || typeof value !== "object") return value;
-  if (value instanceof Date) return value.toISOString();
-  if (Array.isArray(value)) return value.map((entry) => canonicalize(entry));
-  const input = value as Record<string, unknown>;
-  const output: Record<string, unknown> = {};
-  for (const key of Object.keys(input).sort()) {
-    const item = input[key];
-    if (item !== undefined) output[key] = canonicalize(item);
-  }
-  return output;
 }

--- a/packages/api/src/services/execution-authorization.ts
+++ b/packages/api/src/services/execution-authorization.ts
@@ -1,0 +1,301 @@
+import {
+  createHash,
+  createHmac,
+  hkdfSync,
+  randomBytes,
+  randomUUID,
+  timingSafeEqual,
+} from "node:crypto";
+import { executionAuthorizationNonces, getDb, policies } from "@stwd/db";
+import type {
+  ExecutionAuthorization,
+  ExecutionCapability,
+  PolicyRule,
+  SignRequest,
+} from "@stwd/shared";
+import { and, eq, sql } from "drizzle-orm";
+
+export const EXECUTION_AUTHORIZATION_TTL_MS = 60_000;
+const EXECUTION_AUTHORIZATION_HKDF_INFO = "steward:execution-authorization:hmac:v1";
+const EXECUTION_AUTHORIZATION_HKDF_SALT = "steward:execution-authorization:salt:v1";
+
+export class ExecutionAuthorizationError extends Error {
+  constructor(
+    message: string,
+    readonly code:
+      | "missing_signature"
+      | "invalid_signature"
+      | "expired"
+      | "context_mismatch"
+      | "nonce_consumed"
+      | "secret_unavailable",
+  ) {
+    super(message);
+    this.name = "ExecutionAuthorizationError";
+  }
+}
+
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(canonicalize(value));
+}
+
+export function sha256Hex(value: unknown): string {
+  return createHash("sha256").update(canonicalJson(value)).digest("hex");
+}
+
+export function executionPayloadForEvmSign(request: SignRequest): Record<string, unknown> {
+  return {
+    agentId: request.agentId,
+    tenantId: request.tenantId,
+    capability: "wallet.sign_transaction",
+    backend: "local-vault",
+    transaction: {
+      to: request.to,
+      value: request.value,
+      data: request.data ?? "0x",
+      chainId: request.chainId,
+      nonce: request.nonce ?? null,
+      gasLimit: request.gasLimit ?? null,
+      broadcast: request.broadcast !== false,
+      venue: request.venue ?? null,
+      walletAddress: request.walletAddress ?? null,
+    },
+  };
+}
+
+export function executionPayloadDigestForEvmSign(request: SignRequest): string {
+  return sha256Hex(executionPayloadForEvmSign(request));
+}
+
+export async function policyRevisionHashForAgent(agentId: string): Promise<string> {
+  const rows = await getDb()
+    .select({
+      id: policies.id,
+      type: policies.type,
+      enabled: policies.enabled,
+      config: policies.config,
+      updatedAt: policies.updatedAt,
+    })
+    .from(policies)
+    .where(eq(policies.agentId, agentId));
+  return sha256Hex(
+    rows
+      .map((row) => ({
+        id: row.id,
+        type: row.type,
+        enabled: row.enabled,
+        config: row.config,
+        updatedAt: row.updatedAt.toISOString(),
+      }))
+      .sort((a, b) => a.id.localeCompare(b.id)),
+  );
+}
+
+export function policyRevisionHashForPolicySet(policySet: readonly PolicyRule[]): string {
+  return sha256Hex(
+    policySet
+      .map((policy) => ({
+        id: policy.id,
+        type: policy.type,
+        enabled: policy.enabled,
+        config: policy.config,
+      }))
+      .sort((a, b) => a.id.localeCompare(b.id)),
+  );
+}
+
+export interface MintExecutionAuthorizationInput {
+  requestId: string;
+  tenantId: string;
+  agentId: string;
+  capability: ExecutionCapability;
+  payloadDigest: string;
+  backend: ExecutionAuthorization["backend"];
+  policyRevisionHash?: string;
+  approvalId?: string;
+  idempotencyKey?: string;
+  now?: Date;
+}
+
+export async function mintExecutionAuthorization(
+  input: MintExecutionAuthorizationInput,
+): Promise<ExecutionAuthorization> {
+  const now = input.now ?? new Date();
+  const expiresAt = new Date(now.getTime() + EXECUTION_AUTHORIZATION_TTL_MS);
+  const authorization: ExecutionAuthorization = {
+    id: randomUUID(),
+    requestId: input.requestId,
+    tenantId: input.tenantId,
+    agentId: input.agentId,
+    capability: input.capability,
+    payloadDigest: input.payloadDigest,
+    backend: input.backend,
+    policyRevisionHash: input.policyRevisionHash,
+    approvalId: input.approvalId,
+    nonce: base64Url(randomBytes(24)),
+    issuedAt: now.toISOString(),
+    expiresAt: expiresAt.toISOString(),
+    status: "active",
+    idempotencyKey: input.idempotencyKey,
+  };
+  authorization.signature = signExecutionAuthorization(authorization);
+
+  await getDb().insert(executionAuthorizationNonces).values({
+    authorizationId: authorization.id,
+    requestId: authorization.requestId,
+    tenantId: authorization.tenantId,
+    agentId: authorization.agentId,
+    capability: authorization.capability,
+    backend: authorization.backend,
+    payloadDigest: authorization.payloadDigest,
+    policyRevisionHash: authorization.policyRevisionHash,
+    approvalId: authorization.approvalId,
+    nonce: authorization.nonce,
+    signature: authorization.signature,
+    idempotencyKey: authorization.idempotencyKey,
+    status: "active",
+    issuedAt: now,
+    expiresAt,
+  });
+
+  return authorization;
+}
+
+export interface ConsumeExecutionAuthorizationContext {
+  tenantId: string;
+  agentId: string;
+  capability: ExecutionCapability;
+  backend: ExecutionAuthorization["backend"];
+  payloadDigest: string;
+}
+
+export async function consumeExecutionAuthorization(
+  authorization: ExecutionAuthorization,
+  expected: ConsumeExecutionAuthorizationContext,
+): Promise<void> {
+  verifyExecutionAuthorization(authorization, expected);
+  const [row] = await getDb()
+    .update(executionAuthorizationNonces)
+    .set({ status: "consumed", consumedAt: new Date() })
+    .where(
+      and(
+        eq(executionAuthorizationNonces.authorizationId, authorization.id),
+        eq(executionAuthorizationNonces.nonce, authorization.nonce),
+        eq(executionAuthorizationNonces.status, "active"),
+        sql`${executionAuthorizationNonces.expiresAt} > now()`,
+      ),
+    )
+    .returning({ id: executionAuthorizationNonces.id });
+  if (!row) {
+    throw new ExecutionAuthorizationError(
+      "Execution authorization nonce is expired or already consumed",
+      Date.parse(authorization.expiresAt) <= Date.now() ? "expired" : "nonce_consumed",
+    );
+  }
+}
+
+export function verifyExecutionAuthorization(
+  authorization: ExecutionAuthorization,
+  expected: ConsumeExecutionAuthorizationContext,
+): void {
+  if (!authorization.signature) {
+    throw new ExecutionAuthorizationError(
+      "Execution authorization is missing a signature",
+      "missing_signature",
+    );
+  }
+  if (Date.parse(authorization.expiresAt) <= Date.now()) {
+    throw new ExecutionAuthorizationError("Execution authorization has expired", "expired");
+  }
+  if (
+    authorization.tenantId !== expected.tenantId ||
+    authorization.agentId !== expected.agentId ||
+    authorization.capability !== expected.capability ||
+    authorization.backend !== expected.backend ||
+    authorization.payloadDigest !== expected.payloadDigest ||
+    authorization.status !== "active"
+  ) {
+    throw new ExecutionAuthorizationError(
+      "Execution authorization context does not match the signing request",
+      "context_mismatch",
+    );
+  }
+  const expectedSignature = signExecutionAuthorization(authorization);
+  if (!constantTimeEqual(authorization.signature, expectedSignature)) {
+    throw new ExecutionAuthorizationError(
+      "Execution authorization signature is invalid",
+      "invalid_signature",
+    );
+  }
+}
+
+function signExecutionAuthorization(authorization: ExecutionAuthorization): string {
+  return base64Url(
+    createHmac("sha256", executionAuthorizationKey())
+      .update(canonicalJson(signaturePayload(authorization)))
+      .digest(),
+  );
+}
+
+function executionAuthorizationKey(): Uint8Array {
+  const secret = process.env.STEWARD_JWT_SECRET?.trim();
+  if (!secret) {
+    throw new ExecutionAuthorizationError(
+      "STEWARD_JWT_SECRET is required for execution authorization",
+      "secret_unavailable",
+    );
+  }
+  const key = hkdfSync(
+    "sha256",
+    new TextEncoder().encode(secret),
+    new TextEncoder().encode(EXECUTION_AUTHORIZATION_HKDF_SALT),
+    new TextEncoder().encode(EXECUTION_AUTHORIZATION_HKDF_INFO),
+    32,
+  );
+  return key instanceof ArrayBuffer ? new Uint8Array(key) : (key as Uint8Array);
+}
+
+function signaturePayload(authorization: ExecutionAuthorization): Record<string, unknown> {
+  return {
+    id: authorization.id,
+    requestId: authorization.requestId,
+    tenantId: authorization.tenantId,
+    agentId: authorization.agentId,
+    capability: authorization.capability,
+    payloadDigest: authorization.payloadDigest,
+    backend: authorization.backend,
+    policyRevisionHash: authorization.policyRevisionHash ?? null,
+    approvalId: authorization.approvalId ?? null,
+    nonce: authorization.nonce,
+    issuedAt: authorization.issuedAt,
+    expiresAt: authorization.expiresAt,
+    status: authorization.status,
+    idempotencyKey: authorization.idempotencyKey ?? null,
+  };
+}
+
+function constantTimeEqual(left: string, right: string): boolean {
+  const encoder = new TextEncoder();
+  const leftBuffer = encoder.encode(left);
+  const rightBuffer = encoder.encode(right);
+  return leftBuffer.length === rightBuffer.length && timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+function base64Url(value: Uint8Array): string {
+  const binary = Array.from(value, (byte) => String.fromCharCode(byte)).join("");
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+function canonicalize(value: unknown): unknown {
+  if (typeof value === "bigint") return value.toString();
+  if (value === null || typeof value !== "object") return value;
+  if (value instanceof Date) return value.toISOString();
+  if (Array.isArray(value)) return value.map((entry) => canonicalize(entry));
+  const input = value as Record<string, unknown>;
+  const output: Record<string, unknown> = {};
+  for (const key of Object.keys(input).sort()) {
+    const item = input[key];
+    if (item !== undefined) output[key] = canonicalize(item);
+  }
+  return output;
+}

--- a/packages/api/src/services/execution-authorization.ts
+++ b/packages/api/src/services/execution-authorization.ts
@@ -11,8 +11,8 @@ import {
   canonicalJsonStringify,
   type ExecutionAuthorization,
   type ExecutionCapability,
-  normalizeEvmExecutionPayload,
   type NormalizedEvmExecutionPayload,
+  normalizeEvmExecutionPayload,
   type PolicyRule,
   type SignRequest,
 } from "@stwd/shared";

--- a/packages/api/src/services/transaction-receipt-poller.ts
+++ b/packages/api/src/services/transaction-receipt-poller.ts
@@ -379,6 +379,8 @@ export async function pollBroadcastTransactionReceipts(
       txHash: transactions.txHash,
       actionType: transactions.actionType,
       actionPayload: transactions.actionPayload,
+      executionPayloadDigest: transactions.executionPayloadDigest,
+      executionPolicyRevisionHash: transactions.executionPolicyRevisionHash,
       policyResults: transactions.policyResults,
       createdAt: transactions.createdAt,
       signedAt: transactions.signedAt,

--- a/packages/db/drizzle/0078_execution_authorization_nonces.sql
+++ b/packages/db/drizzle/0078_execution_authorization_nonces.sql
@@ -1,0 +1,46 @@
+CREATE TYPE "public"."execution_authorization_status" AS ENUM('active', 'consumed', 'expired', 'revoked');
+--> statement-breakpoint
+ALTER TABLE "transactions" ADD COLUMN IF NOT EXISTS "execution_payload_digest" varchar(64);
+--> statement-breakpoint
+ALTER TABLE "transactions" ADD COLUMN IF NOT EXISTS "execution_policy_revision_hash" varchar(64);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "execution_authorization_nonces" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "authorization_id" varchar(64) NOT NULL,
+  "request_id" varchar(64) NOT NULL,
+  "tenant_id" varchar(64) NOT NULL,
+  "agent_id" varchar(64) NOT NULL,
+  "capability" varchar(64) NOT NULL,
+  "backend" varchar(64) NOT NULL,
+  "payload_digest" varchar(64) NOT NULL,
+  "policy_revision_hash" varchar(64),
+  "approval_id" varchar(64),
+  "nonce" varchar(64) NOT NULL,
+  "signature" text NOT NULL,
+  "idempotency_key" text,
+  "status" "execution_authorization_status" DEFAULT 'active' NOT NULL,
+  "issued_at" timestamp with time zone NOT NULL,
+  "expires_at" timestamp with time zone NOT NULL,
+  "consumed_at" timestamp with time zone,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "execution_authorization_nonces" ADD CONSTRAINT "execution_authorization_nonces_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "execution_authorization_nonces" ADD CONSTRAINT "execution_authorization_nonces_agent_id_agents_id_fk" FOREIGN KEY ("agent_id") REFERENCES "public"."agents"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "execution_authorization_nonces_auth_id_idx" ON "execution_authorization_nonces" USING btree ("authorization_id");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "execution_authorization_nonces_nonce_idx" ON "execution_authorization_nonces" USING btree ("nonce");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "execution_authorization_nonces_tenant_agent_status_idx" ON "execution_authorization_nonces" USING btree ("tenant_id","agent_id","status");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "execution_authorization_nonces_expires_at_idx" ON "execution_authorization_nonces" USING btree ("expires_at");

--- a/packages/db/drizzle/0078_execution_authorization_nonces.sql
+++ b/packages/db/drizzle/0078_execution_authorization_nonces.sql
@@ -44,3 +44,57 @@ CREATE UNIQUE INDEX IF NOT EXISTS "execution_authorization_nonces_nonce_idx" ON 
 CREATE INDEX IF NOT EXISTS "execution_authorization_nonces_tenant_agent_status_idx" ON "execution_authorization_nonces" USING btree ("tenant_id","agent_id","status");
 --> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "execution_authorization_nonces_expires_at_idx" ON "execution_authorization_nonces" USING btree ("expires_at");
+--> statement-breakpoint
+-- Deployment-safe invalidation of legacy pending primary-EVM approvals.
+--
+-- After this migration the approval-replay path fails closed for any primary
+-- EVM approval that lacks a stored execution_payload_digest OR a stored
+-- execution_policy_revision_hash (see packages/api/src/routes/vault.ts approve
+-- handler). Those legacy rows can no longer be replayed and MUST be resubmitted
+-- by the caller. We deterministically mark them denied here so they do not sit
+-- as un-actionable "pending" approvals.
+--
+-- Scope is intentionally narrow and matches the runtime fail-closed criteria
+-- EXACTLY, so we never touch a row that would still be replayable:
+--   * transactions.status = 'pending'
+--   * a matching pending approval_queue row exists
+--   * EVM chain family only (chain_id NOT IN (101,102) Solana)
+--   * primary transaction action surface only: action_type IS NULL or
+--     'transaction'. Transfer / send_calls / user_operation / authorization
+--     surfaces are excluded (transfer has its own replay; the AA surfaces are
+--     already hard-disabled in the approve handler).
+--   * newly-added binding columns are absent (digest or policy-revision NULL).
+-- Rows minted WITH both bindings are left untouched; they remain replayable.
+UPDATE "approval_queue" AS aq
+SET "status" = 'rejected',
+    "resolved_at" = now(),
+    "resolved_by" = 'system:migration-0078-execution-authorization',
+    "resolved_by_type" = 'system',
+    "resolved_by_id" = 'migration-0078'
+FROM "transactions" AS t
+WHERE aq."tx_id" = t."id"
+  AND aq."agent_id" = t."agent_id"
+  AND aq."status" = 'pending'
+  AND t."status" = 'pending'
+  AND t."chain_id" NOT IN (101, 102)
+  AND (t."action_type" IS NULL OR t."action_type" = 'transaction')
+  AND (
+    t."execution_payload_digest" IS NULL
+    OR t."execution_policy_revision_hash" IS NULL
+  );
+--> statement-breakpoint
+UPDATE "transactions" AS t
+SET "status" = 'rejected'
+WHERE t."status" = 'pending'
+  AND t."chain_id" NOT IN (101, 102)
+  AND (t."action_type" IS NULL OR t."action_type" = 'transaction')
+  AND (
+    t."execution_payload_digest" IS NULL
+    OR t."execution_policy_revision_hash" IS NULL
+  )
+  AND EXISTS (
+    SELECT 1 FROM "approval_queue" AS aq
+    WHERE aq."tx_id" = t."id"
+      AND aq."agent_id" = t."agent_id"
+      AND aq."resolved_by" = 'system:migration-0078-execution-authorization'
+  );

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -400,6 +400,13 @@
       "when": 1780137600000,
       "tag": "0076_audit_checkpoints",
       "breakpoints": true
+    },
+    {
+      "idx": 78,
+      "version": "7",
+      "when": 1780138200000,
+      "tag": "0078_execution_authorization_nonces",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -111,6 +111,13 @@ export const approvalQueueStatusEnum = pgEnum("approval_queue_status", [
   "rejected",
 ]);
 
+export const executionAuthorizationStatusEnum = pgEnum("execution_authorization_status", [
+  "active",
+  "consumed",
+  "expired",
+  "revoked",
+]);
+
 const timestamps = {
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp("updated_at", { withTimezone: true })
@@ -873,6 +880,8 @@ export const transactions = pgTable(
     txHash: varchar("tx_hash", { length: 128 }),
     actionType: varchar("action_type", { length: 64 }),
     actionPayload: jsonb("action_payload").$type<Record<string, unknown>>(),
+    executionPayloadDigest: varchar("execution_payload_digest", { length: 64 }),
+    executionPolicyRevisionHash: varchar("execution_policy_revision_hash", { length: 64 }),
     policyResults: jsonb("policy_results").$type<PolicyResult[]>().notNull().default([]),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     signedAt: timestamp("signed_at", { withTimezone: true }),
@@ -882,6 +891,46 @@ export const transactions = pgTable(
     agentIdIdx: index("transactions_agent_id_idx").on(table.agentId),
     // `value` is a wei amount: must be a non-empty decimal digit string.
     valueIsWei: check("transactions_value_wei_chk", sql`${table.value} ~ '^[0-9]+$'`),
+  }),
+);
+
+export const executionAuthorizationNonces = pgTable(
+  "execution_authorization_nonces",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    authorizationId: varchar("authorization_id", { length: 64 }).notNull(),
+    requestId: varchar("request_id", { length: 64 }).notNull(),
+    tenantId: varchar("tenant_id", { length: 64 })
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    agentId: varchar("agent_id", { length: 64 })
+      .notNull()
+      .references(() => agents.id, { onDelete: "cascade" }),
+    capability: varchar("capability", { length: 64 }).notNull(),
+    backend: varchar("backend", { length: 64 }).notNull(),
+    payloadDigest: varchar("payload_digest", { length: 64 }).notNull(),
+    policyRevisionHash: varchar("policy_revision_hash", { length: 64 }),
+    approvalId: varchar("approval_id", { length: 64 }),
+    nonce: varchar("nonce", { length: 64 }).notNull(),
+    signature: text("signature").notNull(),
+    idempotencyKey: text("idempotency_key"),
+    status: executionAuthorizationStatusEnum("status").notNull().default("active"),
+    issuedAt: timestamp("issued_at", { withTimezone: true }).notNull(),
+    expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+    consumedAt: timestamp("consumed_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    authorizationIdUniqueIdx: uniqueIndex("execution_authorization_nonces_auth_id_idx").on(
+      table.authorizationId,
+    ),
+    nonceUniqueIdx: uniqueIndex("execution_authorization_nonces_nonce_idx").on(table.nonce),
+    tenantAgentStatusIdx: index("execution_authorization_nonces_tenant_agent_status_idx").on(
+      table.tenantId,
+      table.agentId,
+      table.status,
+    ),
+    expiryIdx: index("execution_authorization_nonces_expires_at_idx").on(table.expiresAt),
   }),
 );
 
@@ -1491,6 +1540,8 @@ export type Transaction = typeof transactions.$inferSelect;
 export type NewTransaction = typeof transactions.$inferInsert;
 export type ApprovalQueueEntry = typeof approvalQueue.$inferSelect;
 export type NewApprovalQueueEntry = typeof approvalQueue.$inferInsert;
+export type ExecutionAuthorizationNonce = typeof executionAuthorizationNonces.$inferSelect;
+export type NewExecutionAuthorizationNonce = typeof executionAuthorizationNonces.$inferInsert;
 export type Intent = typeof intents.$inferSelect;
 export type NewIntent = typeof intents.$inferInsert;
 export type AgentSigner = typeof agentSigners.$inferSelect;

--- a/packages/shared/src/__tests__/execution-gateway-guard.test.ts
+++ b/packages/shared/src/__tests__/execution-gateway-guard.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import { LEGACY_EVM_SIGN_CALL_SITES, SECURITY_SURFACE_OPERATIONS } from "../security-surface.js";
+
+const read = async (path: string) => Bun.file(new URL(path, import.meta.url)).text();
+
+/**
+ * CI guard for the PR4 execution gateway.
+ *
+ * The migrated primary EVM `/vault/:agentId/sign` route and its compatible
+ * approval replay must never reach the raw `Vault.signTransaction` signer
+ * without going through GovernedVault authorization. Because the vault route
+ * file legitimately contains a Solana raw fallback (primary sign) and a
+ * transfer raw fallback (approval replay), a naive "ban raw sign" static rule is
+ * brittle. Instead we assert the invariant guards that make those fallbacks
+ * unreachable for primary-EVM/approval flows are present, and that the security
+ * surface honestly scopes the gateway claim.
+ */
+describe("execution gateway guard", () => {
+  test("primary EVM sign + approval replay raw fallbacks are invariant-guarded", async () => {
+    const source = await read("../../../api/src/routes/vault.ts");
+
+    // Primary sign path: the raw fallback must be gated by an isEvmSignRequest
+    // invariant guard that throws, so an EVM request can never reach raw signing.
+    expect(source).toContain(
+      "invariant: primary EVM sign reached raw signer without gateway authorization",
+    );
+    // Approval replay: the raw fallback must be gated by an isRawEvmSigningCandidate
+    // invariant guard that throws for any primary-EVM candidate.
+    expect(source).toContain(
+      "invariant: primary EVM approval reached raw signer without gateway authorization",
+    );
+
+    // The approval replay must fail closed (never raw-sign) when the stored
+    // digest or policy-revision binding is absent/malformed.
+    expect(source).toContain("isRawEvmSigningCandidate");
+    expect(source).toContain("missing_stored_execution_payload_digest");
+    expect(source).toContain("missing_stored_execution_policy_revision_hash");
+    expect(source).toContain("missing_or_malformed_transaction_action_payload");
+  });
+
+  test("every raw signTransaction call site in the vault route is accounted for", async () => {
+    const source = await read("../../../api/src/routes/vault.ts");
+    const rawCalls = [...source.matchAll(/\bvault\.signTransaction\(/g)];
+    // Exactly three raw call sites are expected:
+    //  1. primary-sign Solana-only fallback (invariant-guarded)
+    //  2. transfer action EVM sign (separate non-migrated surface)
+    //  3. approval replay TRANSFER fallback (invariant-guarded)
+    // If a new raw call site is added, this test fails until it is classified
+    // (either gateway-migrated or added to LEGACY_EVM_SIGN_CALL_SITES).
+    expect(rawCalls.length).toBe(3);
+  });
+
+  test("gateway claim is honestly scoped in the security surface", () => {
+    const evmSign = SECURITY_SURFACE_OPERATIONS.find(
+      (operation) => operation.id === "wallet.evm_transaction.sign",
+    );
+    expect(evmSign).toBeDefined();
+    if (!evmSign) return;
+
+    const migratedPaths = evmSign.routes
+      .filter((route) => route.gatewayMigrated === true)
+      .map((route) => route.path)
+      .sort();
+    // Only the primary sign + approval replay are gateway-migrated.
+    expect(migratedPaths).toEqual(["/:agentId/approve/:txId", "/:agentId/sign"]);
+
+    // Everything else in the operation is explicitly NOT gateway-migrated.
+    const notMigrated = evmSign.routes.filter((route) => route.gatewayMigrated !== true);
+    expect(notMigrated.length).toBeGreaterThan(0);
+  });
+
+  test("legacy EVM sign call sites are enumerated in the other route files", async () => {
+    const files = [...new Set(LEGACY_EVM_SIGN_CALL_SITES.map((site) => site.file))];
+    for (const file of files) {
+      if (file === "packages/api/src/routes/vault.ts") continue;
+      const source = await read(`../../../${file.replace("packages/", "")}`);
+      expect(source).toContain("signTransaction");
+    }
+    // The non-vault legacy files each have at least one enumerated call site.
+    for (const file of [
+      "packages/api/src/routes/intents.ts",
+      "packages/api/src/routes/user.ts",
+      "packages/api/src/routes/global-wallet.ts",
+    ]) {
+      expect(LEGACY_EVM_SIGN_CALL_SITES.some((site) => site.file === file)).toBe(true);
+    }
+  });
+});

--- a/packages/shared/src/__tests__/execution-gateway-guard.test.ts
+++ b/packages/shared/src/__tests__/execution-gateway-guard.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { LEGACY_EVM_SIGN_CALL_SITES, SECURITY_SURFACE_OPERATIONS } from "../security-surface.js";
+import {
+  LEGACY_EVM_SIGN_CALL_SITES,
+  RAW_EVM_SIGN_EXPECTED_COUNTS,
+  RAW_EVM_SIGN_INVENTORY,
+  SECURITY_SURFACE_OPERATIONS,
+} from "../security-surface.js";
 
 const read = async (path: string) => Bun.file(new URL(path, import.meta.url)).text();
 
@@ -38,16 +43,57 @@ describe("execution gateway guard", () => {
     expect(source).toContain("missing_or_malformed_transaction_action_payload");
   });
 
-  test("every raw signTransaction call site in the vault route is accounted for", async () => {
+  test("vault route raw signTransaction count matches the shared inventory", async () => {
     const source = await read("../../../api/src/routes/vault.ts");
-    const rawCalls = [...source.matchAll(/\bvault\.signTransaction\(/g)];
-    // Exactly three raw call sites are expected:
-    //  1. primary-sign Solana-only fallback (invariant-guarded)
-    //  2. transfer action EVM sign (separate non-migrated surface)
-    //  3. approval replay TRANSFER fallback (invariant-guarded)
-    // If a new raw call site is added, this test fails until it is classified
-    // (either gateway-migrated or added to LEGACY_EVM_SIGN_CALL_SITES).
-    expect(rawCalls.length).toBe(3);
+    const rawCalls = [...source.matchAll(/\b(?:vault|getVault\(\))\.signTransaction\(/g)];
+    // Derived from RAW_EVM_SIGN_INVENTORY (single source of truth), NOT a magic
+    // number. The full repository-wide one-for-one scan lives in packages/api
+    // (execution-gateway-inventory.test.ts) to avoid crossing package rootDirs;
+    // this is the in-package consistency check for the vault route file.
+    expect(rawCalls.length).toBe(RAW_EVM_SIGN_EXPECTED_COUNTS["packages/api/src/routes/vault.ts"]);
+  });
+
+  test("raw-sign inventory is internally consistent and reconciles with the legacy list", () => {
+    // Per-file expected counts are derived from the inventory and must not drift.
+    const recomputed = RAW_EVM_SIGN_INVENTORY.reduce<Record<string, number>>((acc, site) => {
+      acc[site.file] = (acc[site.file] ?? 0) + 1;
+      return acc;
+    }, {});
+    expect(RAW_EVM_SIGN_EXPECTED_COUNTS).toEqual(recomputed);
+
+    // LEGACY_EVM_SIGN_CALL_SITES and RAW_EVM_SIGN_INVENTORY are two lenses on the
+    // same raw-sign surface:
+    //  - LEGACY enumerates non-primary EVM sign SURFACES (route-local policy
+    //    only; PR5b convergence), including the vault.ts transfer + approval-
+    //    transfer branches.
+    //  - The inventory classifies each raw call by REACHABILITY: the two vault.ts
+    //    primary/approval fallbacks are "migrated-invariant-guarded" (an
+    //    invariant throws before them) even though the transfer surfaces they sit
+    //    beside are legacy.
+    // Reconcile at the file level: every file that appears in LEGACY must appear
+    // in the inventory, and the inventory must be a superset (it also carries the
+    // guarded primary-sign fallback that LEGACY does not list).
+    const legacyFiles = new Set(LEGACY_EVM_SIGN_CALL_SITES.map((s) => s.file));
+    const inventoryFiles = new Set(RAW_EVM_SIGN_INVENTORY.map((s) => s.file));
+    for (const file of legacyFiles) {
+      expect(inventoryFiles.has(file), `${file} must be in the raw-sign inventory`).toBe(true);
+    }
+
+    // The non-vault legacy files are pure legacy surfaces, so their inventory
+    // rows must all be classified "legacy" and one-for-one with LEGACY.
+    for (const file of inventoryFiles) {
+      if (file === "packages/api/src/routes/vault.ts") continue;
+      const invForFile = RAW_EVM_SIGN_INVENTORY.filter((s) => s.file === file);
+      const legacyForFile = LEGACY_EVM_SIGN_CALL_SITES.filter((s) => s.file === file);
+      expect(
+        invForFile.every((s) => s.classification === "legacy"),
+        `${file} raw calls must all be legacy-classified`,
+      ).toBe(true);
+      expect(
+        invForFile.length,
+        `${file} inventory count must equal its legacy call-site count`,
+      ).toBe(legacyForFile.length);
+    }
   });
 
   test("gateway claim is honestly scoped in the security surface", () => {

--- a/packages/shared/src/execution-contract.ts
+++ b/packages/shared/src/execution-contract.ts
@@ -81,6 +81,14 @@ export interface ExecutionAuthorization {
   issuedAt: string;
   expiresAt: string;
   status: ExecutionAuthorizationStatus;
+  /**
+   * HMAC-SHA256 over the canonical authorization fields. Optional for
+   * compatibility with callers compiled against the original append-only
+   * contract, but required by the PR4 gateway verifier.
+   */
+  signature?: string;
+  /** Caller-supplied idempotency key bound into the signed authorization. */
+  idempotencyKey?: string;
 }
 
 /**

--- a/packages/shared/src/execution-payload.ts
+++ b/packages/shared/src/execution-payload.ts
@@ -74,9 +74,7 @@ export function isEvmChainId(chainId: number): boolean {
  * request. Throws ExecutionPayloadNormalizationError on any malformed
  * numeric caller field so callers can fail closed rather than digest garbage.
  */
-export function normalizeEvmExecutionPayload(
-  request: SignRequest,
-): NormalizedEvmExecutionPayload {
+export function normalizeEvmExecutionPayload(request: SignRequest): NormalizedEvmExecutionPayload {
   const chainId = normalizeSafeNonNegativeInteger(request.chainId, "chainId");
   if (chainId === null) {
     throw new ExecutionPayloadNormalizationError("chainId is required", "chainId");

--- a/packages/shared/src/execution-payload.ts
+++ b/packages/shared/src/execution-payload.ts
@@ -1,0 +1,121 @@
+import type { SignRequest } from "./index.js";
+
+/**
+ * Canonical normalization + digest for the primary EVM `wallet.sign_transaction`
+ * execution payload.
+ *
+ * ONE implementation, used by both:
+ *  - the API when minting an ExecutionAuthorization (packages/api execution-authorization.ts)
+ *  - GovernedVault when verifying an authorization immediately before raw signing
+ *    (packages/vault governed-vault.ts)
+ *
+ * The digest binds the transaction *intent* (caller-controlled, policy-relevant
+ * fields), NOT the final node-resolved serialized envelope. Node-resolved
+ * nonce/gas price may still be finalized inside the Vault after authorization is
+ * consumed; those are deliberately outside the bound intent. See
+ * SECURITY_SURFACE_OPERATIONS notes and PR #182 for the exact semantics.
+ */
+
+const SOLANA_CHAIN_IDS = new Set([101, 102]);
+
+/**
+ * Fields that carry a caller-supplied integer we bind into the intent digest.
+ * All are validated as non-negative safe integers before they are normalized so
+ * a malformed value can never be silently coerced past the digest boundary.
+ */
+export class ExecutionPayloadNormalizationError extends Error {
+  constructor(
+    message: string,
+    readonly field: string,
+  ) {
+    super(message);
+    this.name = "ExecutionPayloadNormalizationError";
+  }
+}
+
+function normalizeSafeNonNegativeInteger(
+  value: number | undefined | null,
+  field: string,
+): number | null {
+  if (value === undefined || value === null) return null;
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new ExecutionPayloadNormalizationError(
+      `${field} must be a non-negative safe integer`,
+      field,
+    );
+  }
+  return value;
+}
+
+export interface NormalizedEvmExecutionPayload {
+  agentId: string;
+  tenantId: string;
+  capability: "wallet.sign_transaction";
+  backend: "local-vault";
+  transaction: {
+    to: string;
+    value: string;
+    data: string;
+    chainId: number;
+    nonce: number | null;
+    gasLimit: string | null;
+    broadcast: boolean;
+    venue: string | null;
+    walletAddress: string | null;
+  };
+}
+
+export function isEvmChainId(chainId: number): boolean {
+  return !SOLANA_CHAIN_IDS.has(chainId);
+}
+
+/**
+ * Produce the canonical normalized intent payload for a primary EVM sign
+ * request. Throws ExecutionPayloadNormalizationError on any malformed
+ * numeric caller field so callers can fail closed rather than digest garbage.
+ */
+export function normalizeEvmExecutionPayload(
+  request: SignRequest,
+): NormalizedEvmExecutionPayload {
+  const chainId = normalizeSafeNonNegativeInteger(request.chainId, "chainId");
+  if (chainId === null) {
+    throw new ExecutionPayloadNormalizationError("chainId is required", "chainId");
+  }
+  const nonce = normalizeSafeNonNegativeInteger(request.nonce ?? null, "nonce");
+  return {
+    agentId: request.agentId,
+    tenantId: request.tenantId,
+    capability: "wallet.sign_transaction",
+    backend: "local-vault",
+    transaction: {
+      to: request.to,
+      value: request.value,
+      data: request.data ?? "0x",
+      chainId,
+      nonce,
+      gasLimit: request.gasLimit ?? null,
+      broadcast: request.broadcast !== false,
+      venue: request.venue ?? null,
+      walletAddress: request.walletAddress ?? null,
+    },
+  };
+}
+
+/** Stable stringify with sorted keys. Shared by digest producers/verifiers. */
+export function canonicalJsonStringify(value: unknown): string {
+  return JSON.stringify(canonicalize(value));
+}
+
+function canonicalize(value: unknown): unknown {
+  if (typeof value === "bigint") return value.toString();
+  if (value === null || typeof value !== "object") return value;
+  if (value instanceof Date) return value.toISOString();
+  if (Array.isArray(value)) return value.map((entry) => canonicalize(entry));
+  const input = value as Record<string, unknown>;
+  const output: Record<string, unknown> = {};
+  for (const key of Object.keys(input).sort()) {
+    const item = input[key];
+    if (item !== undefined) output[key] = canonicalize(item);
+  }
+  return output;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -6,6 +6,7 @@ import type { VenueId } from "./types/venue.js";
 // ─── Chain providers (extensible registry) ───
 export * from "./chains/index.js";
 export * from "./execution-contract.js";
+export * from "./execution-payload.js";
 export type { PriceOracle } from "./price-oracle.js";
 export { createPriceOracle } from "./price-oracle.js";
 export * from "./security-surface.js";

--- a/packages/shared/src/security-surface.ts
+++ b/packages/shared/src/security-surface.ts
@@ -2,6 +2,7 @@ export type SecuritySurfaceKind = "wallet-signing" | "key-material-export" | "cr
 
 export type EnforcementBoundary =
   | "route-policy"
+  | "gateway-authorized"
   | "route-policy-with-unsafe-flag"
   | "route-consent-with-unsafe-flag"
   | "route-mfa-break-glass"
@@ -90,9 +91,9 @@ export const SECURITY_SURFACE_OPERATIONS = [
     },
     unsafeFlags: ["STEWARD_ALLOW_UNSAFE_CONTRACT_CALL_SIGNING for unconstrained contract calls"],
     evidence: ["transactions row", "vault audit events", "webhook events"],
-    boundary: "route-policy",
+    boundary: "gateway-authorized",
     notes:
-      "Policy is enforced in API routes before Vault.signTransaction; Vault.signTransaction itself does not verify gateway authorization.",
+      "Primary EVM transaction signing and its approval replay mint a policy-bound execution authorization that is consumed immediately before raw Vault.signTransaction.",
   },
   {
     id: "wallet.message.sign",

--- a/packages/shared/src/security-surface.ts
+++ b/packages/shared/src/security-surface.ts
@@ -13,6 +13,27 @@ export interface SecuritySurfaceRoute {
   method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "ALL" | "HANDLER";
   path: string;
   notes?: string;
+  /**
+   * For wallet-signing surfaces: whether this specific route is bound to the
+   * PR4 policy-bound execution gateway (GovernedVault mint+consume before raw
+   * signing). `false`/undefined means the route still reaches the raw signer
+   * through route-local policy only and is NOT yet gateway-migrated. This must
+   * be honest per-route; do not claim product-wide enforcement.
+   */
+  gatewayMigrated?: boolean;
+}
+
+/**
+ * A raw EVM `Vault.signTransaction` call site that is NOT yet routed through the
+ * PR4 execution gateway. Enumerated explicitly so the security surface never
+ * over-claims product-wide enforcement. Convergence of these onto GovernedVault
+ * is tracked for PR5b (immediately after #182 merges).
+ */
+export interface LegacyEvmSignCallSite {
+  file: string;
+  approxLine: number;
+  path: string;
+  reason: string;
 }
 
 export interface SecuritySurfaceOperation {
@@ -45,34 +66,64 @@ export const SECURITY_SURFACE_OPERATIONS = [
     capability: "sign_transaction",
     vaultMethods: ["signTransaction"],
     routes: [
-      { file: "packages/api/src/routes/vault.ts", method: "POST", path: "/:agentId/sign" },
       {
         file: "packages/api/src/routes/vault.ts",
         method: "POST",
-        path: "/:agentId/actions/transfer",
-      },
-      {
-        file: "packages/api/src/routes/vault.ts",
-        method: "POST",
-        path: "/:agentId/actions/send-calls",
+        path: "/:agentId/sign",
+        gatewayMigrated: true,
+        notes:
+          "Primary EVM sign. Mints+consumes a policy-bound execution authorization via GovernedVault before raw signing; raw fallback is Solana-only with an invariant guard.",
       },
       {
         file: "packages/api/src/routes/vault.ts",
         method: "POST",
         path: "/:agentId/approve/:txId",
+        gatewayMigrated: true,
+        notes:
+          "Approval replay for the primary EVM transaction surface. Fails closed unless the stored digest + policy-revision binding is present and matches; then mints+consumes an authorization via GovernedVault. Transfer/AA branches are separate and not gateway-migrated.",
+      },
+      {
+        file: "packages/api/src/routes/vault.ts",
+        method: "POST",
+        path: "/:agentId/actions/transfer",
+        gatewayMigrated: false,
+        notes:
+          "Transfer action surface. Route-local policy gated; NOT yet routed through the execution gateway (PR5b).",
+      },
+      {
+        file: "packages/api/src/routes/vault.ts",
+        method: "POST",
+        path: "/:agentId/actions/send-calls",
+        gatewayMigrated: false,
+        notes: "Batch-call action surface; approval replay hard-disabled; not gateway-migrated.",
       },
       {
         file: "packages/api/src/routes/vault.ts",
         method: "POST",
         path: "/:agentId/transactions/:txId/replace",
+        gatewayMigrated: false,
+        notes: "Replace/RBF surface; route-local policy only; not gateway-migrated (PR5b).",
       },
-      { file: "packages/api/src/routes/intents.ts", method: "POST", path: "/:intentId/execute" },
-      { file: "packages/api/src/routes/user.ts", method: "POST", path: "/me/wallet/sign" },
+      {
+        file: "packages/api/src/routes/intents.ts",
+        method: "POST",
+        path: "/:intentId/execute",
+        gatewayMigrated: false,
+        notes: "Legacy intent execution EVM sign; not gateway-migrated (PR5b).",
+      },
+      {
+        file: "packages/api/src/routes/user.ts",
+        method: "POST",
+        path: "/me/wallet/sign",
+        gatewayMigrated: false,
+        notes: "Personal user-session EVM sign; not gateway-migrated (PR5b).",
+      },
       {
         file: "packages/api/src/routes/global-wallet.ts",
         method: "POST",
         path: "/rpc",
-        notes: "eth_sendTransaction compatibility path",
+        notes: "eth_sendTransaction compatibility path; not gateway-migrated (PR5b).",
+        gatewayMigrated: false,
       },
     ],
     auth: [
@@ -93,7 +144,7 @@ export const SECURITY_SURFACE_OPERATIONS = [
     evidence: ["transactions row", "vault audit events", "webhook events"],
     boundary: "gateway-authorized",
     notes:
-      "Primary EVM transaction signing and its approval replay mint a policy-bound execution authorization that is consumed immediately before raw Vault.signTransaction.",
+      "SCOPED CLAIM: only the primary EVM `/vault/:agentId/sign` route and its compatible approval replay (`/vault/:agentId/approve/:txId`, transaction action surface) are gateway-authorized — they mint+consume a policy-bound execution authorization immediately before raw Vault.signTransaction and fail closed otherwise. The remaining EVM sign call sites enumerated in LEGACY_EVM_SIGN_CALL_SITES are NOT yet gateway-migrated and remain route-local-policy only. This is intentionally NOT a product-wide enforcement claim; convergence is tracked for PR5b.",
   },
   {
     id: "wallet.message.sign",
@@ -416,6 +467,61 @@ export const SECURITY_SURFACE_OPERATIONS = [
       "Credential injection happens only after proxy route matching, audit pre-write, replay protection, and secret route validation.",
   },
 ] as const satisfies readonly SecuritySurfaceOperation[];
+
+/**
+ * Explicit enumeration of raw EVM `Vault.signTransaction` call sites that are
+ * NOT yet routed through the PR4 execution gateway. The migrated primary EVM
+ * `/vault/:agentId/sign` route and its compatible approval replay are excluded
+ * because they go through GovernedVault. The vault.ts entries below are
+ * intentionally-legacy branches (transfer action surface); the intents/user/
+ * global-wallet entries are separate legacy route files deliberately left for
+ * route-convergence work in PR5b (immediately after #182 merges) rather than
+ * migrated inside this already-large PR.
+ *
+ * A CI guard (packages/api execution gateway guard test) asserts that the
+ * primary EVM sign route + approval replay cannot reach the raw signer without
+ * GovernedVault authorization, and that this list stays honest.
+ */
+export const LEGACY_EVM_SIGN_CALL_SITES = [
+  {
+    file: "packages/api/src/routes/vault.ts",
+    approxLine: 3047,
+    path: "POST /:agentId/actions/transfer",
+    reason:
+      "Transfer action EVM sign. Route-local policy gated, separate surface from primary sign; PR5b convergence.",
+  },
+  {
+    file: "packages/api/src/routes/vault.ts",
+    approxLine: 3794,
+    path: "POST /:agentId/approve/:txId (transfer branch)",
+    reason:
+      "Approval replay raw fallback for the TRANSFER surface only. An invariant guard throws if a primary-EVM raw-signing candidate reaches this branch; PR5b convergence for transfers.",
+  },
+  {
+    file: "packages/api/src/routes/intents.ts",
+    approxLine: 596,
+    path: "POST /:intentId/execute",
+    reason: "Legacy intent execution EVM sign; PR5b convergence.",
+  },
+  {
+    file: "packages/api/src/routes/intents.ts",
+    approxLine: 715,
+    path: "POST /:intentId/execute (secondary)",
+    reason: "Legacy intent execution EVM sign; PR5b convergence.",
+  },
+  {
+    file: "packages/api/src/routes/user.ts",
+    approxLine: 5138,
+    path: "POST /me/wallet/sign",
+    reason: "Personal user-session EVM sign; PR5b convergence.",
+  },
+  {
+    file: "packages/api/src/routes/global-wallet.ts",
+    approxLine: 1540,
+    path: "POST /rpc (eth_sendTransaction)",
+    reason: "Global wallet compatibility EVM sign; PR5b convergence.",
+  },
+] as const satisfies readonly LegacyEvmSignCallSite[];
 
 export const SECURITY_SURFACE_VAULT_METHODS = [
   ...new Set(

--- a/packages/shared/src/security-surface.ts
+++ b/packages/shared/src/security-surface.ts
@@ -523,6 +523,101 @@ export const LEGACY_EVM_SIGN_CALL_SITES = [
   },
 ] as const satisfies readonly LegacyEvmSignCallSite[];
 
+/**
+ * Classification of a single raw `Vault.signTransaction(` call site in the
+ * production API source (packages/api/src, excluding __tests__).
+ *
+ *  - "migrated-invariant-guarded": a primary-EVM/approval site that is
+ *    unreachable for EVM flows because a nearby invariant guard throws before
+ *    it (the Solana primary-sign fallback and the transfer approval-replay
+ *    fallback). These are inside the two gateway-migrated routes.
+ *  - "legacy": a not-yet-gateway-migrated EVM sign surface, one-for-one with an
+ *    entry in LEGACY_EVM_SIGN_CALL_SITES (PR5b convergence).
+ */
+export interface RawEvmSignCallSite {
+  file: string;
+  /** Stable nearby source marker (route/function/guard string) unique enough to
+   *  anchor the call site without brittle line numbers. */
+  marker: string;
+  classification: "migrated-invariant-guarded" | "legacy";
+  reason: string;
+}
+
+/**
+ * COMPLETE inventory of every raw `Vault.signTransaction(` production call site
+ * across packages/api/src. The CI guard (packages/api execution gateway guard
+ * test) scans the production source repository-wide and asserts a one-for-one
+ * match: exact per-file raw-call counts against this inventory's per-file
+ * counts, AND that each occurrence anchors to a recognized marker here. Adding
+ * a new raw signTransaction call anywhere (vault.ts / intents.ts / user.ts / a
+ * NEW file) fails the guard until it is classified here; deleting an inventory
+ * entry without removing the call also fails.
+ */
+export const RAW_EVM_SIGN_INVENTORY = [
+  // ── packages/api/src/routes/vault.ts (3 raw calls) ──
+  {
+    file: "packages/api/src/routes/vault.ts",
+    marker: "invariant: primary EVM sign reached raw signer without gateway authorization",
+    classification: "migrated-invariant-guarded",
+    reason:
+      "Primary /sign Solana-only fallback. An isEvmSignRequest invariant guard throws immediately above it, so no EVM request can reach raw signing.",
+  },
+  {
+    file: "packages/api/src/routes/vault.ts",
+    marker: "/:agentId/actions/transfer",
+    classification: "legacy",
+    reason:
+      "Transfer action EVM sign; separate non-migrated surface. One-for-one with LEGACY_EVM_SIGN_CALL_SITES.",
+  },
+  {
+    file: "packages/api/src/routes/vault.ts",
+    marker: "invariant: primary EVM approval reached raw signer without gateway authorization",
+    classification: "migrated-invariant-guarded",
+    reason:
+      "Approval replay TRANSFER fallback. An isRawEvmSigningCandidate invariant guard throws for any primary-EVM candidate before it.",
+  },
+  // ── packages/api/src/routes/intents.ts (2 raw calls) ──
+  {
+    file: "packages/api/src/routes/intents.ts",
+    marker: "Transfer rejected by policy",
+    classification: "legacy",
+    reason:
+      "Legacy intent execution EVM sign (single-transfer branch); PR5b convergence. Anchored to its policy-rejection guard string.",
+  },
+  {
+    file: "packages/api/src/routes/intents.ts",
+    marker: "Batch calls rejected by policy",
+    classification: "legacy",
+    reason:
+      "Legacy intent batch-call execution EVM sign; PR5b convergence. Anchored to its batch policy-rejection guard string.",
+  },
+  // ── packages/api/src/routes/user.ts (1 raw call) ──
+  {
+    file: "packages/api/src/routes/user.ts",
+    marker: "/me/wallet/sign",
+    classification: "legacy",
+    reason: "Personal user-session EVM sign; PR5b convergence.",
+  },
+  // ── packages/api/src/routes/global-wallet.ts (1 raw call) ──
+  {
+    file: "packages/api/src/routes/global-wallet.ts",
+    marker: "eth_sendTransaction",
+    classification: "legacy",
+    reason: "Global wallet compatibility EVM sign; PR5b convergence.",
+  },
+] as const satisfies readonly RawEvmSignCallSite[];
+
+/**
+ * Exact expected raw `Vault.signTransaction(` call count per production source
+ * file. Derived from RAW_EVM_SIGN_INVENTORY so the two never drift. The CI
+ * scan asserts the actual per-file counts equal these.
+ */
+export const RAW_EVM_SIGN_EXPECTED_COUNTS: Readonly<Record<string, number>> =
+  RAW_EVM_SIGN_INVENTORY.reduce<Record<string, number>>((acc, site) => {
+    acc[site.file] = (acc[site.file] ?? 0) + 1;
+    return acc;
+  }, {});
+
 export const SECURITY_SURFACE_VAULT_METHODS = [
   ...new Set(
     SECURITY_SURFACE_OPERATIONS.flatMap((operation) =>

--- a/packages/vault/src/__tests__/external-key-custody.test.ts
+++ b/packages/vault/src/__tests__/external-key-custody.test.ts
@@ -9,7 +9,7 @@ import type {
   ExternalKeySignTransactionRequest,
   ExternalKeySignTransactionResult,
 } from "../external-key-custody";
-import { Vault } from "../vault";
+import { BackendBindingMismatchError, Vault } from "../vault";
 
 const MASTER_PASSWORD = "test-vault-external-key-custody";
 const TENANT_ID = "tenant-external-key-custody";
@@ -276,6 +276,94 @@ describe("external key custody seam", () => {
     expect(tx?.agentId).toBe("agent-external");
     expect(tx?.status).toBe("signed");
     expect(tx?.txHash).toBeNull();
+  });
+
+  // ── ROUND 3 / ITEM 3: backend-resolution TOCTOU (fail closed at sign) ────
+  // resolveExecutionBackend is a separate, stale-able DB read. Between the
+  // gateway's precheck (which may see "local-vault") and the raw sign, the
+  // wallet's backend can FLIP to external custody (local key removed, external
+  // key inserted). The raw signer re-resolves the backend from the SAME fresh
+  // wallet lookup it will sign with; when the caller's authorization is bound to
+  // "local-vault" (options.expectedBackend), a request that re-resolves to the
+  // external branch must fail closed with BackendBindingMismatchError BEFORE the
+  // external custody provider is ever reached.
+
+  test("fails closed (backend binding mismatch) before the provider when a local-vault-bound sign re-resolves to external custody", async () => {
+    const provider = new TestExternalKeyProvider("provider-signing", async () => {
+      // If this ever runs, the TOCTOU guard failed: a local-vault-bound
+      // authorization reached the external custody provider.
+      throw new Error("provider must not be reached for a backend-binding mismatch");
+    });
+    vault = await freshVault(provider);
+    await vault.createAgent(TENANT_ID, "agent-external", "External Agent");
+    // Wallet resolves to external custody (provider-signing). This models the
+    // post-flip state at signing time.
+    await vault.importExternalKeyHandle(externalHandleRequest());
+
+    // Sanity: without a bound backend, this SAME wallet WOULD reach the
+    // provider (which throws its own guard). We assert the mismatch path is
+    // distinct from the normal provider path.
+    let error: unknown;
+    try {
+      await vault.signTransaction(
+        {
+          tenantId: TENANT_ID,
+          agentId: "agent-external",
+          chainId: 8453,
+          to: "0x2222222222222222222222222222222222222222",
+          value: "1",
+          data: "0x",
+          venue: "hsm-primary",
+          broadcast: false,
+        },
+        { txId: "toctou-mismatch-1", expectedBackend: "local-vault" },
+      );
+    } catch (err) {
+      error = err;
+    }
+
+    expect(error).toBeInstanceOf(BackendBindingMismatchError);
+    expect((error as BackendBindingMismatchError).code).toBe("backend_binding_mismatch");
+    expect((error as BackendBindingMismatchError).expectedBackend).toBe("local-vault");
+    // The provider signer was NEVER invoked.
+    expect(provider.signCalls).toHaveLength(0);
+
+    // No transaction row was written for the failed sign.
+    const rows = await getDb()
+      .select()
+      .from(transactions)
+      .where(eq(transactions.id, "toctou-mismatch-1"));
+    expect(rows).toHaveLength(0);
+  });
+
+  test("still routes to the provider when the sign is NOT backend-bound (precheck path unchanged)", async () => {
+    // Belt-and-suspenders: an external-custody wallet signed WITHOUT a bound
+    // backend (a non-gateway caller) still reaches the provider exactly as
+    // before. The TOCTOU guard only engages when options.expectedBackend is set.
+    const provider = new TestExternalKeyProvider("provider-signing", async () => ({
+      result: "0xsigned-by-external-provider",
+      broadcast: false,
+    }));
+    vault = await freshVault(provider);
+    await vault.createAgent(TENANT_ID, "agent-external", "External Agent");
+    await vault.importExternalKeyHandle(externalHandleRequest());
+
+    const signed = await vault.signTransaction(
+      {
+        tenantId: TENANT_ID,
+        agentId: "agent-external",
+        chainId: 8453,
+        to: "0x2222222222222222222222222222222222222222",
+        value: "1",
+        data: "0x",
+        venue: "hsm-primary",
+        broadcast: false,
+      },
+      { txId: "toctou-unbound-1" },
+    );
+
+    expect(signed).toBe("0xsigned-by-external-provider");
+    expect(provider.signCalls).toHaveLength(1);
   });
 
   test("break-glass private key export refuses agents with external custody wallets", async () => {

--- a/packages/vault/src/__tests__/governed-vault.test.ts
+++ b/packages/vault/src/__tests__/governed-vault.test.ts
@@ -46,7 +46,7 @@ describe("GovernedVault", () => {
       calls.push(`consume:${expected.payloadDigest}`);
     });
 
-    const result = await governed.signTransaction(request, {
+    const result = await governed.signTransactionAuthorized(request, {
       txId: "tx-1",
       executionAuthorization: authorization,
       executionPayloadDigest: authorization.payloadDigest,
@@ -69,7 +69,7 @@ describe("GovernedVault", () => {
     });
 
     await expect(
-      governed.signTransaction(
+      governed.signTransactionAuthorized(
         { ...request, value: "2" },
         {
           txId: "tx-mismatch",
@@ -92,7 +92,7 @@ describe("GovernedVault", () => {
     const governed = new GovernedVault(rawVault, async () => {});
 
     await expect(
-      governed.signTransaction(request, {
+      governed.signTransactionAuthorized(request, {
         txId: "tx-missing",
         executionPayloadDigest: authorization.payloadDigest,
       }),
@@ -113,7 +113,7 @@ describe("GovernedVault", () => {
     });
 
     await expect(
-      governed.signTransaction(request, {
+      governed.signTransactionAuthorized(request, {
         txId: "tx-replay",
         executionAuthorization: authorization,
         executionPayloadDigest: authorization.payloadDigest,

--- a/packages/vault/src/__tests__/governed-vault.test.ts
+++ b/packages/vault/src/__tests__/governed-vault.test.ts
@@ -122,6 +122,37 @@ describe("GovernedVault", () => {
     expect(rawCalled).toBe(false);
   });
 
+  it("threads expectedBackend=local-vault into the raw signer (TOCTOU backend binding)", async () => {
+    // The governed path is only ever consumed against backend "local-vault"
+    // (see the consume callback's expected.backend). It must bind the raw
+    // signer to that same backend so the vault layer can re-resolve and fail
+    // closed if the wallet flipped to third-party custody between resolution and
+    // signing. This asserts the option is forwarded verbatim.
+    let observedOptions: SignTransactionOptions | undefined;
+    const rawVault = {
+      async signTransaction(_request: SignRequest, options: SignTransactionOptions) {
+        observedOptions = options;
+        return "0xsigned";
+      },
+    } as Vault;
+    const governed = new GovernedVault(rawVault, async () => {});
+
+    await governed.signTransactionAuthorized(request, {
+      txId: "tx-bound",
+      executionAuthorization: authorization,
+      executionPayloadDigest: authorization.payloadDigest,
+    });
+
+    expect(observedOptions?.expectedBackend).toBe("local-vault");
+    // The gateway-only fields are stripped before reaching the raw signer.
+    expect(
+      (observedOptions as { executionAuthorization?: unknown }).executionAuthorization,
+    ).toBeUndefined();
+    expect(
+      (observedOptions as { executionPayloadDigest?: unknown }).executionPayloadDigest,
+    ).toBeUndefined();
+  });
+
   it("digest binds normalized intent via the shared canonicalizer (safe-integer validated)", () => {
     // Field-order independence proves the shared canonicalizer is used.
     const a = executionPayloadDigestForGovernedEvmSign({

--- a/packages/vault/src/__tests__/governed-vault.test.ts
+++ b/packages/vault/src/__tests__/governed-vault.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "bun:test";
 import type { ExecutionAuthorization, SignRequest } from "@stwd/shared";
-import { GovernedVault, GovernedVaultError } from "../governed-vault";
+import {
+  executionPayloadDigestForGovernedEvmSign,
+  GovernedVault,
+  GovernedVaultError,
+} from "../governed-vault";
 import type { SignTransactionOptions, Vault } from "../vault";
 
 const request: SignRequest = {
@@ -12,13 +16,15 @@ const request: SignRequest = {
   broadcast: false,
 };
 
+const requestPayloadDigest = executionPayloadDigestForGovernedEvmSign(request);
+
 const authorization: ExecutionAuthorization = {
   id: "auth-1",
   requestId: "tx-1",
   tenantId: "tenant-1",
   agentId: "agent-1",
   capability: "wallet.sign_transaction",
-  payloadDigest: "a".repeat(64),
+  payloadDigest: requestPayloadDigest,
   backend: "local-vault",
   nonce: "nonce-1",
   issuedAt: new Date().toISOString(),
@@ -48,6 +54,31 @@ describe("GovernedVault", () => {
 
     expect(result).toBe("0xsigned");
     expect(calls).toEqual([`consume:${authorization.payloadDigest}`, "raw-sign"]);
+  });
+
+  it("fails closed when the supplied digest does not match the actual request", async () => {
+    let rawCalled = false;
+    const rawVault = {
+      async signTransaction() {
+        rawCalled = true;
+        return "0xsigned";
+      },
+    } as unknown as Vault;
+    const governed = new GovernedVault(rawVault, async () => {
+      throw new Error("consume must not be reached");
+    });
+
+    await expect(
+      governed.signTransaction(
+        { ...request, value: "2" },
+        {
+          txId: "tx-mismatch",
+          executionAuthorization: authorization,
+          executionPayloadDigest: authorization.payloadDigest,
+        },
+      ),
+    ).rejects.toThrow("does not match");
+    expect(rawCalled).toBe(false);
   });
 
   it("fails closed before raw signing without authorization", async () => {

--- a/packages/vault/src/__tests__/governed-vault.test.ts
+++ b/packages/vault/src/__tests__/governed-vault.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "bun:test";
+import type { ExecutionAuthorization, SignRequest } from "@stwd/shared";
+import { GovernedVault, GovernedVaultError } from "../governed-vault";
+import type { SignTransactionOptions, Vault } from "../vault";
+
+const request: SignRequest = {
+  tenantId: "tenant-1",
+  agentId: "agent-1",
+  to: "0x1111111111111111111111111111111111111111",
+  value: "1",
+  chainId: 8453,
+  broadcast: false,
+};
+
+const authorization: ExecutionAuthorization = {
+  id: "auth-1",
+  requestId: "tx-1",
+  tenantId: "tenant-1",
+  agentId: "agent-1",
+  capability: "wallet.sign_transaction",
+  payloadDigest: "a".repeat(64),
+  backend: "local-vault",
+  nonce: "nonce-1",
+  issuedAt: new Date().toISOString(),
+  expiresAt: new Date(Date.now() + 60_000).toISOString(),
+  status: "active",
+  signature: "sig-1",
+};
+
+describe("GovernedVault", () => {
+  it("consumes execution authorization immediately before raw signTransaction", async () => {
+    const calls: string[] = [];
+    const rawVault = {
+      async signTransaction(_request: SignRequest, _options: SignTransactionOptions) {
+        calls.push("raw-sign");
+        return "0xsigned";
+      },
+    } as Vault;
+    const governed = new GovernedVault(rawVault, async (_authorization, expected) => {
+      calls.push(`consume:${expected.payloadDigest}`);
+    });
+
+    const result = await governed.signTransaction(request, {
+      txId: "tx-1",
+      executionAuthorization: authorization,
+      executionPayloadDigest: authorization.payloadDigest,
+    });
+
+    expect(result).toBe("0xsigned");
+    expect(calls).toEqual([`consume:${authorization.payloadDigest}`, "raw-sign"]);
+  });
+
+  it("fails closed before raw signing without authorization", async () => {
+    let rawCalled = false;
+    const rawVault = {
+      async signTransaction() {
+        rawCalled = true;
+        return "0xsigned";
+      },
+    } as unknown as Vault;
+    const governed = new GovernedVault(rawVault, async () => {});
+
+    await expect(
+      governed.signTransaction(request, {
+        txId: "tx-missing",
+        executionPayloadDigest: authorization.payloadDigest,
+      }),
+    ).rejects.toBeInstanceOf(GovernedVaultError);
+    expect(rawCalled).toBe(false);
+  });
+
+  it("does not raw-sign when the consume callback rejects replay", async () => {
+    let rawCalled = false;
+    const rawVault = {
+      async signTransaction() {
+        rawCalled = true;
+        return "0xsigned";
+      },
+    } as unknown as Vault;
+    const governed = new GovernedVault(rawVault, async () => {
+      throw new Error("nonce consumed");
+    });
+
+    await expect(
+      governed.signTransaction(request, {
+        txId: "tx-replay",
+        executionAuthorization: authorization,
+        executionPayloadDigest: authorization.payloadDigest,
+      }),
+    ).rejects.toThrow("nonce consumed");
+    expect(rawCalled).toBe(false);
+  });
+});

--- a/packages/vault/src/__tests__/governed-vault.test.ts
+++ b/packages/vault/src/__tests__/governed-vault.test.ts
@@ -121,4 +121,31 @@ describe("GovernedVault", () => {
     ).rejects.toThrow("nonce consumed");
     expect(rawCalled).toBe(false);
   });
+
+  it("digest binds normalized intent via the shared canonicalizer (safe-integer validated)", () => {
+    // Field-order independence proves the shared canonicalizer is used.
+    const a = executionPayloadDigestForGovernedEvmSign({
+      chainId: 8453,
+      agentId: "agent-1",
+      tenantId: "tenant-1",
+      to: "0x1111111111111111111111111111111111111111",
+      value: "1",
+      nonce: 5,
+      broadcast: false,
+    });
+    const b = executionPayloadDigestForGovernedEvmSign({
+      to: "0x1111111111111111111111111111111111111111",
+      value: "1",
+      broadcast: false,
+      nonce: 5,
+      tenantId: "tenant-1",
+      agentId: "agent-1",
+      chainId: 8453,
+    });
+    expect(a).toBe(b);
+
+    // Malformed numeric caller fields are rejected before digesting.
+    expect(() => executionPayloadDigestForGovernedEvmSign({ ...request, nonce: -1 })).toThrow();
+    expect(() => executionPayloadDigestForGovernedEvmSign({ ...request, chainId: -1 })).toThrow();
+  });
 });

--- a/packages/vault/src/governed-vault.ts
+++ b/packages/vault/src/governed-vault.ts
@@ -1,0 +1,86 @@
+import type { ExecutionAuthorization, SignRequest } from "@stwd/shared";
+import type { SignTransactionOptions, Vault } from "./vault";
+
+export type ExecutionAuthorizationConsumeCallback = (
+  authorization: ExecutionAuthorization,
+  expected: {
+    tenantId: string;
+    agentId: string;
+    capability: "wallet.sign_transaction";
+    backend: "local-vault";
+    payloadDigest: string;
+  },
+) => Promise<void>;
+
+export class GovernedVaultError extends Error {
+  constructor(
+    message: string,
+    readonly code:
+      | "missing_authorization"
+      | "missing_payload_digest"
+      | "unsupported_chain_family"
+      | "authorization_rejected",
+  ) {
+    super(message);
+    this.name = "GovernedVaultError";
+  }
+}
+
+export interface GovernedSignTransactionOptions extends SignTransactionOptions {
+  executionAuthorization?: ExecutionAuthorization;
+  executionPayloadDigest?: string;
+}
+
+export class GovernedVault {
+  constructor(
+    private readonly rawVault: Vault,
+    private readonly consumeExecutionAuthorization: ExecutionAuthorizationConsumeCallback,
+  ) {}
+
+  async signTransaction(
+    request: SignRequest,
+    options: GovernedSignTransactionOptions,
+  ): Promise<string> {
+    const chainId = request.chainId || 8453;
+    if (chainId === 101 || chainId === 102) {
+      throw new GovernedVaultError(
+        "GovernedVault.signTransaction is scoped to the EVM transaction path",
+        "unsupported_chain_family",
+      );
+    }
+    if (!options.executionAuthorization) {
+      throw new GovernedVaultError(
+        "Execution authorization is required for governed EVM transaction signing",
+        "missing_authorization",
+      );
+    }
+    if (!options.executionPayloadDigest) {
+      throw new GovernedVaultError(
+        "Execution payload digest is required for governed EVM transaction signing",
+        "missing_payload_digest",
+      );
+    }
+
+    try {
+      await this.consumeExecutionAuthorization(options.executionAuthorization, {
+        tenantId: request.tenantId,
+        agentId: request.agentId,
+        capability: "wallet.sign_transaction",
+        backend: "local-vault",
+        payloadDigest: options.executionPayloadDigest,
+      });
+    } catch (error) {
+      if (error instanceof GovernedVaultError) throw error;
+      const message =
+        error instanceof Error ? error.message : "Execution authorization was rejected";
+      throw new GovernedVaultError(message, "authorization_rejected");
+    }
+
+    const {
+      executionAuthorization: _authorization,
+      executionPayloadDigest: _digest,
+      ...rawOptions
+    } = options;
+    return this.rawVault.signTransaction(request, rawOptions);
+  }
+}

--- a/packages/vault/src/governed-vault.ts
+++ b/packages/vault/src/governed-vault.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type { ExecutionAuthorization, SignRequest } from "@stwd/shared";
 import type { SignTransactionOptions, Vault } from "./vault";
 
@@ -18,6 +19,7 @@ export class GovernedVaultError extends Error {
     readonly code:
       | "missing_authorization"
       | "missing_payload_digest"
+      | "payload_digest_mismatch"
       | "unsupported_chain_family"
       | "authorization_rejected",
   ) {
@@ -29,6 +31,46 @@ export class GovernedVaultError extends Error {
 export interface GovernedSignTransactionOptions extends SignTransactionOptions {
   executionAuthorization?: ExecutionAuthorization;
   executionPayloadDigest?: string;
+}
+
+function canonicalize(value: unknown): unknown {
+  if (value === null || typeof value !== "object") return value;
+  if (Array.isArray(value)) return value.map((entry) => canonicalize(entry));
+
+  const output: Record<string, unknown> = {};
+  for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+    const item = (value as Record<string, unknown>)[key];
+    if (item !== undefined) output[key] = canonicalize(item);
+  }
+  return output;
+}
+
+function canonicalJson(value: unknown): string {
+  return JSON.stringify(canonicalize(value));
+}
+
+export function executionPayloadDigestForGovernedEvmSign(request: SignRequest): string {
+  return createHash("sha256")
+    .update(
+      canonicalJson({
+        agentId: request.agentId,
+        tenantId: request.tenantId,
+        capability: "wallet.sign_transaction",
+        backend: "local-vault",
+        transaction: {
+          to: request.to,
+          value: request.value,
+          data: request.data ?? "0x",
+          chainId: request.chainId,
+          nonce: request.nonce ?? null,
+          gasLimit: request.gasLimit ?? null,
+          broadcast: request.broadcast !== false,
+          venue: request.venue ?? null,
+          walletAddress: request.walletAddress ?? null,
+        },
+      }),
+    )
+    .digest("hex");
 }
 
 export class GovernedVault {
@@ -58,6 +100,13 @@ export class GovernedVault {
       throw new GovernedVaultError(
         "Execution payload digest is required for governed EVM transaction signing",
         "missing_payload_digest",
+      );
+    }
+    const requestPayloadDigest = executionPayloadDigestForGovernedEvmSign(request);
+    if (options.executionPayloadDigest !== requestPayloadDigest) {
+      throw new GovernedVaultError(
+        "Execution payload digest does not match governed EVM transaction request",
+        "payload_digest_mismatch",
       );
     }
 

--- a/packages/vault/src/governed-vault.ts
+++ b/packages/vault/src/governed-vault.ts
@@ -1,5 +1,10 @@
 import { createHash } from "node:crypto";
-import type { ExecutionAuthorization, SignRequest } from "@stwd/shared";
+import {
+  canonicalJsonStringify,
+  type ExecutionAuthorization,
+  normalizeEvmExecutionPayload,
+  type SignRequest,
+} from "@stwd/shared";
 import type { SignTransactionOptions, Vault } from "./vault";
 
 export type ExecutionAuthorizationConsumeCallback = (
@@ -33,43 +38,18 @@ export interface GovernedSignTransactionOptions extends SignTransactionOptions {
   executionPayloadDigest?: string;
 }
 
-function canonicalize(value: unknown): unknown {
-  if (value === null || typeof value !== "object") return value;
-  if (Array.isArray(value)) return value.map((entry) => canonicalize(entry));
-
-  const output: Record<string, unknown> = {};
-  for (const key of Object.keys(value as Record<string, unknown>).sort()) {
-    const item = (value as Record<string, unknown>)[key];
-    if (item !== undefined) output[key] = canonicalize(item);
-  }
-  return output;
-}
-
-function canonicalJson(value: unknown): string {
-  return JSON.stringify(canonicalize(value));
-}
-
+/**
+ * Digest binds the normalized transaction INTENT (caller-controlled,
+ * policy-relevant fields) via the SINGLE shared canonicalizer/normalizer in
+ * @stwd/shared. It does NOT bind the node-resolved final serialized envelope;
+ * nonce/gas price may still be finalized inside the raw Vault after the
+ * authorization is consumed. The normalizer validates chainId/nonce as
+ * non-negative safe integers and throws on malformed caller fields so a bad
+ * request can never be digested past this boundary.
+ */
 export function executionPayloadDigestForGovernedEvmSign(request: SignRequest): string {
   return createHash("sha256")
-    .update(
-      canonicalJson({
-        agentId: request.agentId,
-        tenantId: request.tenantId,
-        capability: "wallet.sign_transaction",
-        backend: "local-vault",
-        transaction: {
-          to: request.to,
-          value: request.value,
-          data: request.data ?? "0x",
-          chainId: request.chainId,
-          nonce: request.nonce ?? null,
-          gasLimit: request.gasLimit ?? null,
-          broadcast: request.broadcast !== false,
-          venue: request.venue ?? null,
-          walletAddress: request.walletAddress ?? null,
-        },
-      }),
-    )
+    .update(canonicalJsonStringify(normalizeEvmExecutionPayload(request)))
     .digest("hex");
 }
 

--- a/packages/vault/src/governed-vault.ts
+++ b/packages/vault/src/governed-vault.ts
@@ -79,7 +79,7 @@ export class GovernedVault {
     private readonly consumeExecutionAuthorization: ExecutionAuthorizationConsumeCallback,
   ) {}
 
-  async signTransaction(
+  async signTransactionAuthorized(
     request: SignRequest,
     options: GovernedSignTransactionOptions,
   ): Promise<string> {

--- a/packages/vault/src/governed-vault.ts
+++ b/packages/vault/src/governed-vault.ts
@@ -110,6 +110,15 @@ export class GovernedVault {
       executionPayloadDigest: _digest,
       ...rawOptions
     } = options;
-    return this.rawVault.signTransaction(request, rawOptions);
+    // Bind the raw signer to the SAME custody backend this governed
+    // authorization was consumed against ("local-vault"). The raw vault
+    // re-resolves the backend from the fresh wallet lookup it will sign with
+    // and fails closed (BackendBindingMismatchError) if the wallet has flipped
+    // to third-party custody since resolveExecutionBackend ran, closing the
+    // resolution->sign TOCTOU before any external provider is reached.
+    return this.rawVault.signTransaction(request, {
+      ...rawOptions,
+      expectedBackend: "local-vault",
+    });
   }
 }

--- a/packages/vault/src/index.ts
+++ b/packages/vault/src/index.ts
@@ -40,6 +40,11 @@ export {
   InMemoryExternalKeyCustodyProvider,
   normalizeExternalKeyHandleRegistration,
 } from "./external-key-custody";
+export type {
+  ExecutionAuthorizationConsumeCallback,
+  GovernedSignTransactionOptions,
+} from "./governed-vault";
+export { GovernedVault, GovernedVaultError } from "./governed-vault";
 export type { BitcoinAddressType, BitcoinNetwork, DerivedBitcoinKey } from "./hd-wallet";
 export {
   deriveBitcoinKey,

--- a/packages/vault/src/index.ts
+++ b/packages/vault/src/index.ts
@@ -187,4 +187,4 @@ export type {
   SignBitcoinPsbtResult,
   VaultConfig,
 } from "./vault";
-export { Vault, Vault as VaultClient } from "./vault";
+export { BackendBindingMismatchError, Vault, Vault as VaultClient } from "./vault";

--- a/packages/vault/src/index.ts
+++ b/packages/vault/src/index.ts
@@ -30,6 +30,8 @@ export type {
   ExternalKeyHandleImportRequest,
   ExternalKeyHandleRegistration,
   ExternalKeySigningAvailability,
+  ExternalKeySignTransactionRequest,
+  ExternalKeySignTransactionResult,
 } from "./external-key-custody";
 export {
   assertNoExternalPrivateKeyMaterial,

--- a/packages/vault/src/vault.ts
+++ b/packages/vault/src/vault.ts
@@ -307,6 +307,42 @@ export interface SignTransactionOptions {
   txId?: string;
   policyResults?: PolicyResult[];
   status?: TxStatus;
+  /**
+   * The custody backend the caller's authorization is cryptographically bound
+   * to (set by the governed execution-gateway path to "local-vault"). When
+   * present, {@link Vault.signTransaction} RE-RESOLVES the backend from the SAME
+   * fresh wallet lookup it will actually sign with and asserts it matches this
+   * bound backend BEFORE routing to any provider. This closes the
+   * resolveExecutionBackend -> sign TOCTOU: if the wallet's backend flips (a
+   * local key is removed and an third-party-custody key inserted) between the
+   * gateway's precheck and the raw sign, a local-vault-bound authorization can
+   * no longer reach the third-party provider. Absent (undefined) preserves the
+   * legacy, un-gateway-bound behavior for non-gateway callers.
+   */
+  expectedBackend?: "local-vault";
+}
+
+/**
+ * Thrown when a governed (gateway-authorized) sign request that is bound to a
+ * specific custody backend re-resolves at signing time to a DIFFERENT backend.
+ * The gateway mints authorizations bound to "local-vault"; if the wallet has
+ * since flipped to third-party custody, the raw signer fails closed here before
+ * any third-party provider is reached (audited, fund-loss-safe).
+ */
+export class BackendBindingMismatchError extends Error {
+  readonly code = "backend_binding_mismatch";
+  constructor(
+    readonly expectedBackend: "local-vault",
+    readonly resolvedBackend: "third-party-custody",
+  ) {
+    super(
+      `Execution backend binding mismatch: authorization is bound to ` +
+        `"${expectedBackend}" but the wallet re-resolved to "${resolvedBackend}" ` +
+        `at signing time. Refusing to route a ${expectedBackend}-bound ` +
+        `authorization to the third-party custody provider.`,
+    );
+    this.name = "BackendBindingMismatchError";
+  }
 }
 
 interface MnemonicWalletMaterial {
@@ -1294,6 +1330,17 @@ export class Vault {
         venue,
       });
       if (externalWallet) {
+        // Backend-binding re-resolution (TOCTOU close).
+        // This branch means the request re-resolved to external custody using
+        // the SAME fresh wallet lookup that will actually sign (no second racy
+        // read). If the caller's authorization was bound to "local-vault" (the
+        // only gateway-supported backend), the wallet's backend has FLIPPED
+        // since the gateway's resolveExecutionBackend precheck. Fail closed
+        // BEFORE any provider routing so a local-vault-bound authorization can
+        // never reach the external custody provider.
+        if (options.expectedBackend === "local-vault") {
+          throw new BackendBindingMismatchError("local-vault", "third-party-custody");
+        }
         if (request.walletAddress && externalWallet.address) {
           if (externalWallet.address.toLowerCase() !== request.walletAddress.toLowerCase()) {
             throw new Error(

--- a/packages/vault/src/vault.ts
+++ b/packages/vault/src/vault.ts
@@ -527,6 +527,65 @@ export class Vault {
     return { address: wallet.address, metadata: wallet.metadata };
   }
 
+  /**
+   * Resolve which custody backend a sign request would actually route to,
+   * WITHOUT decrypting keys, signing, or calling any third-party provider.
+   *
+   * This mirrors the exact key-resolution precedence in {@link signTransaction}:
+   *   1. A local encrypted chain key (multi-chain table)  -> "local-vault"
+   *   2. Otherwise an third-party-custody wallet             -> "third-party-custody"
+   *   3. Otherwise a legacy local encrypted key / none     -> "local-vault"
+   *
+   * The execution gateway (PR #182) mints ExecutionAuthorizations bound to
+   * backend "local-vault". External custody is NOT a gateway-supported backend
+   * in this PR: an authorization bound to "local-vault" must never be able to
+   * authorize an third-party-custody execution. Callers use this to fail closed
+   * BEFORE minting/consuming when the resolved backend is third-party-custody.
+   */
+  async resolveExecutionBackend(request: {
+    tenantId: string;
+    agentId: string;
+    chainId?: number;
+    venue?: string | null;
+    walletAddress?: string;
+  }): Promise<"local-vault" | "third-party-custody"> {
+    const db = getDb();
+    const chainId = request.chainId || this.config.chainId || 8453;
+    const isSolana = chainId === 101 || chainId === 102;
+    const chainFamilyToUse: WalletChainFamily = isSolana ? "solana" : "evm";
+    const venue = resolveSignVenueSelector({ venue: request.venue ?? undefined });
+
+    // 1. Local encrypted chain key present -> local vault signs.
+    const [chainKey] = await db
+      .select({ id: encryptedChainKeys.id })
+      .from(encryptedChainKeys)
+      .where(
+        and(
+          eq(encryptedChainKeys.agentId, request.agentId),
+          eq(encryptedChainKeys.chainFamily, chainFamilyToUse),
+          venue
+            ? eq(encryptedChainKeys.venue, venue)
+            : isNull(encryptedChainKeys.venue),
+        ),
+      );
+    if (chainKey) return "local-vault";
+
+    // 2. No local chain key: an third-party-custody wallet takes precedence in
+    //    signTransaction's resolution, so the request would route to the
+    //    third-party provider.
+    const resolvedWallet = await this.getExternalKeyWallet({
+      agentId: request.agentId,
+      chainFamily: chainFamilyToUse,
+      venue,
+    });
+    if (resolvedWallet) return "third-party-custody";
+
+    // 3. No third-party wallet: signTransaction falls back to the legacy local
+    //    encrypted_keys table (or throws missing-key). Either way this is a
+    //    local-vault backend from the gateway's perspective.
+    return "local-vault";
+  }
+
   private async assertNoExternalKeyWalletsForExport(agentId: string): Promise<void> {
     const db = getDb();
     const wallets = await db

--- a/packages/vault/src/vault.ts
+++ b/packages/vault/src/vault.ts
@@ -563,9 +563,7 @@ export class Vault {
         and(
           eq(encryptedChainKeys.agentId, request.agentId),
           eq(encryptedChainKeys.chainFamily, chainFamilyToUse),
-          venue
-            ? eq(encryptedChainKeys.venue, venue)
-            : isNull(encryptedChainKeys.venue),
+          venue ? eq(encryptedChainKeys.venue, venue) : isNull(encryptedChainKeys.venue),
         ),
       );
     if (chainKey) return "local-vault";


### PR DESCRIPTION
## Summary

- add 60-second, single-use execution authorizations signed with HMAC-SHA256 under an HKDF-derived key from `STEWARD_JWT_SECRET` (`steward:execution-authorization:hmac:v1`, never raw JWT-key reuse)
- persist authorization nonces in migration `0078` and atomically consume active, unexpired rows
- add `GovernedVault.signTransactionAuthorized`, which recomputes the canonical transaction digest at the signing boundary before delegating to raw `Vault.signTransaction`
- migrate the primary EVM `POST /vault/:agentId/sign` flow and its EVM approval replay, while keeping Solana and other unmigrated signing routes unchanged
- bind queued approvals to the original payload digest and policy revision, preserving nonce, gas, venue, wallet, and broadcast fields for replay
- audit authorization mint, consume, and reject events
- classify ONLY the two migrated routes (`POST /vault/:agentId/sign` and its EVM approval replay `POST /vault/:agentId/approve/:txId`) as `gatewayMigrated` in the security-surface inventory; every other EVM sign call site (`vault.ts` transfer action, `intents.ts`, `user.ts`, `global-wallet.ts`) is explicitly NOT gateway-migrated and remains route-local-policy only (`LEGACY_EVM_SIGN_CALL_SITES` / `RAW_EVM_SIGN_INVENTORY`, PR5b convergence)

## Security properties

- canonical JSON + SHA-256 payload binding
- tenant, agent, capability, backend, policy revision, approval reference, idempotency key, nonce, and expiry are signed
- atomic consume prevents replay/double-use
- payload mutation is rejected before the raw signing method is called
- expired, wrong-tenant, wrong-backend, wrong-digest, and tampered-signature authorizations fail closed

## Tests

- `bun run lint`
  - exit 0, 869 files checked
  - 3 pre-existing unused-suppression warnings, 0 errors
- `cd packages/vault && bun test --timeout 30000`
  - 347 pass, 0 fail, 1040 assertions
- focused gateway suites:
  - `bun test packages/vault/src/__tests__/governed-vault.test.ts packages/api/src/__tests__/execution-authorization.test.ts packages/api/src/__tests__/vault-execution-gateway.test.ts`
  - 11 pass, 0 fail
- `cd packages/api && bun run test`
  - isolated suite progressed through 51/186 files: 50 pass, 1 unrelated PGLite WASM initialization failure in `auth-audit-hardening.test.ts` (`RuntimeError: access to a null reference`), then stopped rather than spending another ~12 minutes on a known environment failure
- existing approval regression suite:
  - 7 pass, 0 fail
- Codex review was run against `origin/develop`; findings around approval rollback ordering, replay field preservation, and boundary-side digest recomputation were fixed. A final post-fix rerun exceeded the VPS review timeout.


## Documented limitations (PR #182 scope)

- **External-custody wallets are NOT gateway-supported.** Execution authorizations are cryptographically bound to backend `local-vault`. A raw `Vault.signTransaction` can resolve an third-party-key wallet and call the third-party custody provider, so an authorization bound to `local-vault` must never authorize an third-party-custody execution. Both the direct `/sign` path and the approval replay path now resolve the wallet's actual custody backend via `Vault.resolveExecutionBackend` **before** minting/consuming and **fail closed** (HTTP 409, rejection reason `third-party_custody_not_gateway_supported`) when the request would route to third-party custody — before the third-party provider is ever reached. Full third-party-custody gateway support is out of scope for this PR and tracked for a follow-up.

## Round-2 review fixes

- **Strict transaction-action-payload validation (P1):** `getTransactionActionPayload` now requires a boolean `broadcast`, rejects any present `nonce` that is not a non-negative safe integer, and rejects wrong-type `gasLimit`/`venue`/`walletAddress`. Malformed present fields now throw and the approval replay path fails closed (409, `malformed_transaction_action_payload`) instead of silently coercing/dropping. The replay digest is computed inside a guarded block and every `ExecutionPayloadNormalizationError` is converted into the same fail-closed path with a specific rejection audit.
- **Repository-wide raw-signer CI guard (P1):** `RAW_EVM_SIGN_INVENTORY` + a new `packages/api` scan test assert exact per-file raw `Vault.signTransaction` counts across all of `packages/api/src` (excluding `__tests__`), so a new raw call in `intents.ts`/`user.ts`/a new file, or a deleted inventory entry, now fails CI.
- **HMAC tamper table completeness (P2):** expanded from 8 to all 14 MAC-signed fields (adds `tenantId`, `agentId`, `capability`, `payloadDigest`, `backend`, `status`).
- **Backend binding truthfulness (P1):** see Documented limitations above.

[sol-orch]

