### PR TITLE
fix(docs): remove dead hosted-API references; Steward is self-host-first until hosted API ships

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ Steward is the self-hostable authority plane for private enterprise agents. It g
 
 [![npm](https://img.shields.io/npm/v/@stwd/sdk)](https://www.npmjs.com/package/@stwd/sdk)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![API](https://img.shields.io/badge/API-live-brightgreen)](https://api.steward.fi)
 [![Docs](https://img.shields.io/badge/docs-steward.fi-blue)](https://docs.steward.fi)
 
 ## what exists today
@@ -42,7 +41,8 @@ npm install @stwd/sdk
 import { StewardClient } from "@stwd/sdk";
 
 const steward = new StewardClient({
-  baseUrl: "https://api.steward.fi",
+  // point this at your self-hosted Steward instance (see deploy/docker-compose.yml)
+  baseUrl: "http://localhost:3200",
   apiKey: "stw_your_tenant_key",
   tenantId: "my-app",
 });
@@ -79,7 +79,7 @@ function App() {
   return (
     <StewardProvider
       client={stewardClient}
-      auth={{ baseUrl: "https://api.steward.fi" }}
+      auth={{ baseUrl: "http://localhost:3200" }}
     >
       <StewardAuthGuard fallback={<StewardLogin methods={["passkey", "email", "google"]} />}>
         <Dashboard />
@@ -207,7 +207,6 @@ see [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, coding standards, 
 
 - website: [steward.fi](https://steward.fi)
 - docs: [docs.steward.fi](https://docs.steward.fi)
-- API: [api.steward.fi](https://api.steward.fi)
 - npm: [@stwd/sdk](https://www.npmjs.com/package/@stwd/sdk), [@stwd/react](https://www.npmjs.com/package/@stwd/react), [@stwd/eliza-plugin](https://www.npmjs.com/package/@stwd/eliza-plugin)
 
 ## license

--- a/deploy/DEPLOYMENT.md
+++ b/deploy/DEPLOYMENT.md
@@ -33,7 +33,7 @@ Steward runs as two **systemd services** on each Milady node, built from source 
 │    └─ Reach proxy at:   http://172.18.0.1:8080        │
 │       (Docker bridge gateway IP)                      │
 │                                                       │
-│  External: api.steward.fi → milady-core-1:3200        │
+│  External: <your-domain> → milady-core-1:3200         │
 └──────────────────────────────────────────────────────┘
 ```
 
@@ -425,7 +425,7 @@ Note: The root `docker-compose.yml` includes a local Postgres. For Neon, use the
 
 | Node | IP | API (:3200) | Proxy (:8080) | Notes |
 |------|-----|------------|--------------|-------|
-| milady-core-1 | 88.99.66.168 | ✅ Running | ✅ Running | Primary, hosts api.steward.fi |
+| milady-core-1 | 88.99.66.168 | ✅ Running | ✅ Running | Primary; front with your own domain/TLS |
 | milady-core-2 | 178.63.251.122 | ✅ Running | ✅ Running | |
 | milady-core-3 | 138.201.80.125 | ✅ Running | ✅ Running | |
 | milady-core-4 | 85.10.193.52 | ✅ Running | ✅ Running | |

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -177,7 +177,7 @@ ssh root@${NODE_IP} "
 
 ## Nginx Reverse Proxy (TLS Termination)
 
-The `deploy/nginx.conf` proxies `api.steward.fi → :3200` and `proxy.steward.fi → :8080`.
+The `deploy/nginx.conf` proxies `api.example.com → :3200` and `proxy.example.com → :8080`. Replace `api.example.com` / `proxy.example.com` with the domains you control (Steward is self-host-first; there is no shared hosted API yet).
 
 ```bash
 # On the node with nginx installed
@@ -198,7 +198,7 @@ sudo ln -s /etc/nginx/sites-available/steward /etc/nginx/sites-enabled/steward
 sudo nginx -t && sudo systemctl reload nginx
 
 # Get TLS certificates
-sudo certbot --nginx -d api.steward.fi -d proxy.steward.fi
+sudo certbot --nginx -d api.example.com -d proxy.example.com
 ```
 
 ---

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -2,12 +2,12 @@
 # Steward — Nginx Reverse Proxy
 #
 # Routes:
-#   api.steward.fi        → steward-api  :3200
-#   proxy.steward.fi      → steward-proxy :8080
+#   api.example.com        → steward-api  :3200
+#   proxy.example.com      → steward-proxy :8080
 #   (or subdomain-less via path prefix)
 #
 # TLS termination via Certbot/Let's Encrypt.
-# Run: certbot --nginx -d api.steward.fi -d proxy.steward.fi
+# Run: certbot --nginx -d api.example.com -d proxy.example.com
 #
 # Install:
 #   cp deploy/nginx.conf /etc/nginx/sites-available/steward
@@ -40,7 +40,7 @@ upstream steward_proxy {
 server {
     listen 80;
     listen [::]:80;
-    server_name api.steward.fi proxy.steward.fi;
+    server_name api.example.com proxy.example.com;
 
     # Let's Encrypt ACME challenge passthrough
     location /.well-known/acme-challenge/ {
@@ -52,16 +52,16 @@ server {
     }
 }
 
-# ── Steward API (api.steward.fi) ──────────────────────────────────────────────
+# ── Steward API (api.example.com) ──────────────────────────────────────────────
 server {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
-    server_name api.steward.fi;
+    server_name api.example.com;
 
     # ── TLS — managed by Certbot (replace with your cert paths) ──────────────
     # certbot will inject these automatically; placeholders shown for reference:
-    # ssl_certificate     /etc/letsencrypt/live/api.steward.fi/fullchain.pem;
-    # ssl_certificate_key /etc/letsencrypt/live/api.steward.fi/privkey.pem;
+    # ssl_certificate     /etc/letsencrypt/live/api.example.com/fullchain.pem;
+    # ssl_certificate_key /etc/letsencrypt/live/api.example.com/privkey.pem;
     # include             /etc/letsencrypt/options-ssl-nginx.conf;
     # ssl_dhparam         /etc/letsencrypt/ssl-dhparams.pem;
 
@@ -125,15 +125,15 @@ server {
     }
 }
 
-# ── Steward Proxy Gateway (proxy.steward.fi) ──────────────────────────────────
+# ── Steward Proxy Gateway (proxy.example.com) ──────────────────────────────────
 server {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
-    server_name proxy.steward.fi;
+    server_name proxy.example.com;
 
     # ── TLS (same cert setup as above) ───────────────────────────────────────
-    # ssl_certificate     /etc/letsencrypt/live/proxy.steward.fi/fullchain.pem;
-    # ssl_certificate_key /etc/letsencrypt/live/proxy.steward.fi/privkey.pem;
+    # ssl_certificate     /etc/letsencrypt/live/proxy.example.com/fullchain.pem;
+    # ssl_certificate_key /etc/letsencrypt/live/proxy.example.com/privkey.pem;
     # include             /etc/letsencrypt/options-ssl-nginx.conf;
     # ssl_dhparam         /etc/letsencrypt/ssl-dhparams.pem;
 

--- a/docs/api-reference/accounts.mdx
+++ b/docs/api-reference/accounts.mdx
@@ -221,7 +221,7 @@ const { accounts } = await steward.accounts.list();
 ```
 
 ```bash cURL
-curl https://api.steward.fi/accounts \
+curl http://localhost:3200/accounts \
   -H "X-Steward-Key: your-key"
 ```
 </CodeGroup>
@@ -276,7 +276,7 @@ const account = await steward.accounts.create({
 ```
 
 ```bash cURL
-curl -X POST https://api.steward.fi/accounts \
+curl -X POST http://localhost:3200/accounts \
   -H "X-Steward-Key: your-key" \
   -H "Content-Type: application/json" \
   -d '{
@@ -310,7 +310,7 @@ const account = await steward.accounts.get("acct_treasury");
 ```
 
 ```bash cURL
-curl https://api.steward.fi/accounts/acct_treasury \
+curl http://localhost:3200/accounts/acct_treasury \
   -H "X-Steward-Key: your-key"
 ```
 </CodeGroup>
@@ -420,7 +420,7 @@ const balance = await steward.accounts.getBalance("acct_treasury");
 ```
 
 ```bash cURL
-curl "https://api.steward.fi/accounts/acct_treasury/balance?chainId=84532&tokens=0x9999999999999999999999999999999999999999" \
+curl "http://localhost:3200/accounts/acct_treasury/balance?chainId=84532&tokens=0x9999999999999999999999999999999999999999" \
   -H "X-Steward-Key: your-key"
 ```
 </CodeGroup>
@@ -469,7 +469,7 @@ const account = await steward.accounts.update("acct_treasury", {
 ```
 
 ```bash cURL
-curl -X PATCH https://api.steward.fi/accounts/acct_treasury \
+curl -X PATCH http://localhost:3200/accounts/acct_treasury \
   -H "X-Steward-Key: your-key" \
   -H "Content-Type: application/json" \
   -d '{
@@ -514,7 +514,7 @@ await steward.accounts.delete("acct_treasury");
 ```
 
 ```bash cURL
-curl -X DELETE https://api.steward.fi/accounts/acct_treasury \
+curl -X DELETE http://localhost:3200/accounts/acct_treasury \
   -H "X-Steward-Key: your-key"
 ```
 </CodeGroup>
@@ -584,7 +584,7 @@ const { aggregations } = await steward.accounts.listAggregations("acct_treasury"
 ```
 
 ```bash cURL
-curl https://api.steward.fi/accounts/acct_treasury/aggregations \
+curl http://localhost:3200/accounts/acct_treasury/aggregations \
   -H "X-Steward-Key: your-key"
 ```
 </CodeGroup>
@@ -617,7 +617,7 @@ const aggregation = await steward.accounts.createAggregation("acct_treasury", {
 ```
 
 ```bash cURL
-curl -X POST https://api.steward.fi/accounts/acct_treasury/aggregations \
+curl -X POST http://localhost:3200/accounts/acct_treasury/aggregations \
   -H "X-Steward-Key: your-key" \
   -H "Content-Type: application/json" \
   -d '{

--- a/docs/api-reference/agents.mdx
+++ b/docs/api-reference/agents.mdx
@@ -51,7 +51,7 @@ const agent = await steward.createWallet("my-agent", "My Trading Agent");
 ```
 
 ```bash cURL
-curl -X POST https://api.steward.fi/agents \
+curl -X POST http://localhost:3200/agents \
   -H "X-Steward-Key: your-key" \
   -H "Content-Type: application/json" \
   -d '{"id": "my-agent", "name": "My Trading Agent"}'
@@ -93,7 +93,7 @@ const agents = await steward.listAgents();
 ```
 
 ```bash cURL
-curl https://api.steward.fi/agents \
+curl http://localhost:3200/agents \
   -H "X-Steward-Key: your-key"
 ```
 </CodeGroup>
@@ -116,7 +116,7 @@ const agent = await steward.getAgent("my-agent");
 ```
 
 ```bash cURL
-curl https://api.steward.fi/agents/my-agent \
+curl http://localhost:3200/agents/my-agent \
   -H "X-Steward-Key: your-key"
 ```
 </CodeGroup>
@@ -147,7 +147,7 @@ DELETE /agents/:agentId
 </Warning>
 
 ```bash
-curl -X DELETE https://api.steward.fi/agents/my-agent \
+curl -X DELETE http://localhost:3200/agents/my-agent \
   -H "X-Steward-Key: your-key"
 ```
 
@@ -187,7 +187,7 @@ POST /agents/:agentId/token
 ```
 
 ```bash
-curl -X POST https://api.steward.fi/agents/my-agent/token \
+curl -X POST http://localhost:3200/agents/my-agent/token \
   -H "X-Steward-Key: your-key" \
   -H "Content-Type: application/json" \
   -d '{"expiresIn": "24h"}'
@@ -239,7 +239,7 @@ const account = await steward.getAgentAccount("my-agent", {
 ```
 
 ```bash cURL
-curl "https://api.steward.fi/agents/my-agent/account?chainId=8453" \
+curl "http://localhost:3200/agents/my-agent/account?chainId=8453" \
   -H "Authorization: Bearer agent-jwt"
 ```
 </CodeGroup>
@@ -280,7 +280,7 @@ const balance = await steward.getBalance("my-agent", 8453);
 ```
 
 ```bash cURL
-curl "https://api.steward.fi/agents/my-agent/balance?chainId=8453" \
+curl "http://localhost:3200/agents/my-agent/balance?chainId=8453" \
   -H "Authorization: Bearer agent-jwt"
 ```
 </CodeGroup>
@@ -451,7 +451,7 @@ const result = await steward.createWalletBatch(
 ```
 
 ```bash cURL
-curl -X POST https://api.steward.fi/agents/batch \
+curl -X POST http://localhost:3200/agents/batch \
   -H "X-Steward-Key: your-key" \
   -H "Content-Type: application/json" \
   -d '{

--- a/docs/api-reference/approvals.mdx
+++ b/docs/api-reference/approvals.mdx
@@ -31,7 +31,7 @@ GET /approvals?status=pending&limit=50&offset=0
 ```
 
 ```bash
-curl https://api.steward.fi/approvals \
+curl http://localhost:3200/approvals \
   -H "X-Steward-Key: your-tenant-key"
 ```
 
@@ -98,7 +98,7 @@ POST /approvals/:id/approve
 ```
 
 ```bash
-curl -X POST https://api.steward.fi/approvals/appr_550e8400-.../approve \
+curl -X POST http://localhost:3200/approvals/appr_550e8400-.../approve \
   -H "X-Steward-Key: your-tenant-key"
 ```
 
@@ -126,7 +126,7 @@ POST /approvals/:id/deny
 ```
 
 ```bash
-curl -X POST https://api.steward.fi/approvals/appr_550e8400-.../deny \
+curl -X POST http://localhost:3200/approvals/appr_550e8400-.../deny \
   -H "X-Steward-Key: your-tenant-key" \
   -H "Content-Type: application/json" \
   -d '{ "reason": "Amount too large for current market conditions" }'
@@ -211,7 +211,7 @@ Configure a `tx.pending` webhook to get notified when transactions need review:
 
 ```typescript
 // Register webhook
-await fetch("https://api.steward.fi/webhooks", {
+await fetch("http://localhost:3200/webhooks", {
   method: "POST",
   headers: { "X-Steward-Key": apiKey, "Content-Type": "application/json" },
   body: JSON.stringify({

--- a/docs/api-reference/audits.mdx
+++ b/docs/api-reference/audits.mdx
@@ -32,7 +32,7 @@ newest first by audit sequence.
 import { StewardClient } from "@stwd/sdk";
 
 const steward = new StewardClient({
-  baseUrl: "https://api.steward.fi",
+  baseUrl: "http://localhost:3200",
   bearerToken: sessionToken,
 });
 
@@ -58,7 +58,7 @@ const params = new URLSearchParams({
   limit: "25",
 });
 
-const response = await fetch(`https://api.steward.fi/audit/events?${params}`, {
+const response = await fetch(`http://localhost:3200/audit/events?${params}`, {
   headers: {
     Authorization: `Bearer ${sessionToken}`,
   },

--- a/docs/api-reference/dashboard.mdx
+++ b/docs/api-reference/dashboard.mdx
@@ -19,7 +19,7 @@ GET /dashboard/:agentId
 ```
 
 ```bash
-curl https://api.steward.fi/dashboard/trading-bot-1 \
+curl http://localhost:3200/dashboard/trading-bot-1 \
   -H "Authorization: Bearer <agent-jwt>"
 # or with tenant key:
   -H "X-Steward-Key: your-tenant-key"

--- a/docs/api-reference/intents.mdx
+++ b/docs/api-reference/intents.mdx
@@ -126,7 +126,7 @@ await steward.createIntent({
 ```
 
 ```bash cURL
-curl -X POST https://api.steward.fi/intents \
+curl -X POST http://localhost:3200/intents \
   -H "Authorization: Bearer owner-session-jwt" \
   -H "Content-Type: application/json" \
   -H "Idempotency-Key: policy-rule-create-spending-limit-v1" \
@@ -170,7 +170,7 @@ GET /intents
 ```
 
 ```bash
-curl "https://api.steward.fi/intents?status=pending&intent_type=policy_rule_update&wallet_id=treasury-wallet" \
+curl "http://localhost:3200/intents?status=pending&intent_type=policy_rule_update&wallet_id=treasury-wallet" \
   -H "X-Steward-Key: your-tenant-key"
 ```
 
@@ -183,7 +183,7 @@ GET /intents/:intentId
 **Auth:** Tenant-level auth
 
 ```bash
-curl https://api.steward.fi/intents/intent_550e8400-... \
+curl http://localhost:3200/intents/intent_550e8400-... \
   -H "X-Steward-Key: your-tenant-key"
 ```
 
@@ -201,7 +201,7 @@ POST /intents/:intentId/reject
 is stored for rejection audit/webhook context.
 
 ```bash
-curl -X POST https://api.steward.fi/intents/intent_550e8400-.../approve \
+curl -X POST http://localhost:3200/intents/intent_550e8400-.../approve \
   -H "Authorization: Bearer owner-session-jwt" \
   -H "Content-Type: application/json" \
   -d '{ "reason": "Reviewed in weekly policy change window" }'
@@ -220,7 +220,7 @@ Execution requires the intent to be `authorized`. The response includes
 redacted in stored intent rows.
 
 ```bash
-curl -X POST https://api.steward.fi/intents/intent_550e8400-.../execute \
+curl -X POST http://localhost:3200/intents/intent_550e8400-.../execute \
   -H "Authorization: Bearer owner-session-jwt" \
   -H "Content-Type: application/json" \
   -H "Idempotency-Key: execute-intent-550e8400-v1" \

--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -7,8 +7,8 @@
   },
   "servers": [
     {
-      "url": "https://api.steward.fi",
-      "description": "Production"
+      "url": "http://localhost:3200",
+      "description": "Your self-hosted Steward instance (Steward is self-host-first; replace with your deployment URL). The playground targets this rather than the docs domain."
     }
   ],
   "components": {

--- a/docs/api-reference/overview.mdx
+++ b/docs/api-reference/overview.mdx
@@ -9,11 +9,13 @@ The Steward API is a REST API built with [Hono](https://hono.dev) running on [Bu
 
 ## Base URL
 
+Steward is self-host-first today. Point the SDK and all requests at your own deployment. The default local compose profile exposes the API on port 3200:
+
 ```
-https://api.steward.fi
+http://localhost:3200
 ```
 
-For self-hosted instances, replace with your deployment URL.
+Replace this with your deployment's URL when running behind your own domain and TLS. A managed hosted API is coming soon.
 
 ## Authentication
 
@@ -24,7 +26,7 @@ Steward supports three authentication methods:
     For tenant-level operations (agent CRUD, policy management, secret management):
 
     ```bash
-    curl https://api.steward.fi/agents \
+    curl http://localhost:3200/agents \
       -H "X-Steward-Key: stwd_your_tenant_api_key"
     ```
 
@@ -34,7 +36,7 @@ Steward supports three authentication methods:
     For agent-scoped operations (signing, balance checks). Preferred for agents:
 
     ```bash
-    curl https://api.steward.fi/vault/my-agent/sign \
+    curl http://localhost:3200/vault/my-agent/sign \
       -H "Authorization: Bearer stwd_jwt_..."
     ```
 
@@ -45,10 +47,10 @@ Steward supports three authentication methods:
 
     ```bash
     # 1. Get nonce
-    curl https://api.steward.fi/auth/nonce
+    curl http://localhost:3200/auth/nonce
 
     # 2. Sign message and verify
-    curl -X POST https://api.steward.fi/auth/verify \
+    curl -X POST http://localhost:3200/auth/verify \
       -H "Content-Type: application/json" \
       -d '{ "message": "...", "signature": "0x..." }'
     ```
@@ -62,7 +64,7 @@ Steward supports three authentication methods:
 For platform-level operations (cross-tenant management), use the platform key:
 
 ```bash
-curl https://api.steward.fi/platform/stats \
+curl http://localhost:3200/platform/stats \
   -H "X-Steward-Platform-Key: your-platform-key"
 ```
 

--- a/docs/api-reference/platform-apps.mdx
+++ b/docs/api-reference/platform-apps.mdx
@@ -49,7 +49,7 @@ const spend = await steward.platformApps.getGasSpend({
 ```
 
 ```bash cURL
-curl "https://api.steward.fi/platform/apps/gas_spend?tenant_id=app-prod&wallet_external_ids=external-wallet-1" \
+curl "http://localhost:3200/platform/apps/gas_spend?tenant_id=app-prod&wallet_external_ids=external-wallet-1" \
   -H "X-Steward-Platform-Key: your-platform-key"
 ```
 </CodeGroup>

--- a/docs/api-reference/platform-users.mdx
+++ b/docs/api-reference/platform-users.mdx
@@ -10,7 +10,7 @@ identity records, and attach immutable tenant-scoped wallet external IDs. They
 require a platform key and route scopes when scoped platform keys are enabled.
 
 ```bash
-curl https://api.steward.fi/platform/users/lookup \
+curl http://localhost:3200/platform/users/lookup \
   -H "X-Steward-Platform-Key: your-platform-key"
 ```
 
@@ -89,7 +89,7 @@ const user = await steward.platformUsers.create({
 ```
 
 ```bash cURL
-curl -X POST https://api.steward.fi/platform/users \
+curl -X POST http://localhost:3200/platform/users \
   -H "X-Steward-Platform-Key: your-platform-key" \
   -H "Content-Type: application/json" \
   -d '{
@@ -156,7 +156,7 @@ const sameUser = await steward.platformUsers.getUserByWalletExternalId(
 ```
 
 ```bash cURL
-curl "https://api.steward.fi/platform/users/lookup?tenantId=app-prod&walletExternalId=wallet_ada_001" \
+curl "http://localhost:3200/platform/users/lookup?tenantId=app-prod&walletExternalId=wallet_ada_001" \
   -H "X-Steward-Platform-Key: your-platform-key"
 ```
 </CodeGroup>
@@ -218,7 +218,7 @@ await steward.platformUsers.assignWalletExternalId("usr_123", {
 ```
 
 ```bash cURL
-curl -X POST https://api.steward.fi/platform/users/usr_123/wallet/external-id \
+curl -X POST http://localhost:3200/platform/users/usr_123/wallet/external-id \
   -H "X-Steward-Platform-Key: your-platform-key" \
   -H "Content-Type: application/json" \
   -d '{ "tenantId": "app-prod", "walletExternalId": "wallet_ada_001" }'
@@ -255,7 +255,7 @@ const { user } = await steward.platformUsers.resolveWalletExternalId({
 ```
 
 ```bash cURL
-curl -X POST https://api.steward.fi/platform/users/wallet/external-id \
+curl -X POST http://localhost:3200/platform/users/wallet/external-id \
   -H "X-Steward-Platform-Key: your-platform-key" \
   -H "Content-Type: application/json" \
   -d '{ "tenantId": "app-prod", "walletExternalId": "wallet_ada_001" }'
@@ -297,7 +297,7 @@ const result = await steward.platformUsers.connectOrCreateByWalletExternalId({
 ```
 
 ```bash cURL
-curl -X POST https://api.steward.fi/platform/users/wallet/external-id/connect-or-create \
+curl -X POST http://localhost:3200/platform/users/wallet/external-id/connect-or-create \
   -H "X-Steward-Platform-Key: your-platform-key" \
   -H "Content-Type: application/json" \
   -d '{
@@ -349,7 +349,7 @@ const result = await steward.platformUsers.search("app-prod", {
 ```
 
 ```bash cURL
-curl "https://api.steward.fi/platform/tenants/app-prod/users?walletExternalId=wallet_ada_001" \
+curl "http://localhost:3200/platform/tenants/app-prod/users?walletExternalId=wallet_ada_001" \
   -H "X-Steward-Platform-Key: your-platform-key"
 ```
 </CodeGroup>
@@ -383,7 +383,7 @@ const report = await steward.getTenantWalletPolicyViolations("app-prod", {
 ```
 
 ```bash cURL
-curl "https://api.steward.fi/user/me/tenants/app-prod/users/wallet-policy/violations?limit=50" \
+curl "http://localhost:3200/user/me/tenants/app-prod/users/wallet-policy/violations?limit=50" \
   -H "Authorization: Bearer user-session-jwt"
 ```
 </CodeGroup>
@@ -454,7 +454,7 @@ const result = await steward.remediateTenantWalletPolicyViolation(
 
 ```bash cURL
 curl -X DELETE \
-  "https://api.steward.fi/user/me/tenants/app-prod/users/usr_123/wallet-policy/wallets/acct_2" \
+  "http://localhost:3200/user/me/tenants/app-prod/users/usr_123/wallet-policy/wallets/acct_2" \
   -H "Authorization: Bearer user-session-jwt"
 ```
 </CodeGroup>
@@ -503,7 +503,7 @@ const result = await steward.bulkRemediateTenantWalletPolicyViolations(
 
 ```bash cURL
 curl -X POST \
-  "https://api.steward.fi/user/me/tenants/app-prod/users/wallet-policy/remediations" \
+  "http://localhost:3200/user/me/tenants/app-prod/users/wallet-policy/remediations" \
   -H "Authorization: Bearer user-session-jwt" \
   -H "Content-Type: application/json" \
   -d '{"wallets":[{"userId":"usr_123","accountId":"acct_2"},{"userId":"usr_456","accountId":"acct_7"}]}'

--- a/docs/api-reference/policies.mdx
+++ b/docs/api-reference/policies.mdx
@@ -50,7 +50,7 @@ const policies = await steward.getPolicies("my-agent");
 ```
 
 ```bash cURL
-curl https://api.steward.fi/agents/my-agent/policies \
+curl http://localhost:3200/agents/my-agent/policies \
   -H "X-Steward-Key: your-key"
 ```
 </CodeGroup>
@@ -133,7 +133,7 @@ await steward.setPolicies("my-agent", [
 ```
 
 ```bash cURL
-curl -X PUT https://api.steward.fi/agents/my-agent/policies \
+curl -X PUT http://localhost:3200/agents/my-agent/policies \
   -H "X-Steward-Key: your-key" \
   -H "Content-Type: application/json" \
   -d '[

--- a/docs/api-reference/routes.mdx
+++ b/docs/api-reference/routes.mdx
@@ -56,7 +56,7 @@ POST /secrets/routes
 
 <CodeGroup>
 ```bash OpenAI
-curl -X POST https://api.steward.fi/secrets/routes \
+curl -X POST http://localhost:3200/secrets/routes \
   -H "X-Steward-Key: your-key" \
   -H "Content-Type: application/json" \
   -d '{
@@ -70,7 +70,7 @@ curl -X POST https://api.steward.fi/secrets/routes \
 ```
 
 ```bash Anthropic
-curl -X POST https://api.steward.fi/secrets/routes \
+curl -X POST http://localhost:3200/secrets/routes \
   -H "X-Steward-Key: your-key" \
   -H "Content-Type: application/json" \
   -d '{
@@ -84,7 +84,7 @@ curl -X POST https://api.steward.fi/secrets/routes \
 ```
 
 ```bash Query Param Auth
-curl -X POST https://api.steward.fi/secrets/routes \
+curl -X POST http://localhost:3200/secrets/routes \
   -H "X-Steward-Key: your-key" \
   -H "Content-Type: application/json" \
   -d '{
@@ -156,7 +156,7 @@ PUT /secrets/routes/:id
 
 ```bash
 # Disable a route
-curl -X PUT https://api.steward.fi/secrets/routes/route-uuid \
+curl -X PUT http://localhost:3200/secrets/routes/route-uuid \
   -H "X-Steward-Key: your-key" \
   -H "Content-Type: application/json" \
   -d '{ "enabled": false }'

--- a/docs/api-reference/secrets.mdx
+++ b/docs/api-reference/secrets.mdx
@@ -46,7 +46,7 @@ POST /secrets
 - `409` — Secret with this name already exists
 
 ```bash
-curl -X POST https://api.steward.fi/secrets \
+curl -X POST http://localhost:3200/secrets \
   -H "X-Steward-Key: your-key" \
   -H "Content-Type: application/json" \
   -d '{
@@ -188,7 +188,7 @@ Key benefits of rotation:
 - **Audit trail** — rotation events are logged
 
 ```bash
-curl -X POST https://api.steward.fi/secrets/550e8400-.../rotate \
+curl -X POST http://localhost:3200/secrets/550e8400-.../rotate \
   -H "X-Steward-Key: your-key" \
   -H "Content-Type: application/json" \
   -d '{ "value": "sk-proj-new-key-xyz..." }'

--- a/docs/api-reference/tenant-config.mdx
+++ b/docs/api-reference/tenant-config.mdx
@@ -21,7 +21,7 @@ GET /tenants/:id/config
 ```
 
 ```bash
-curl https://api.steward.fi/tenants/my-platform/config \
+curl http://localhost:3200/tenants/my-platform/config \
   -H "X-Steward-Key: your-tenant-key"
 ```
 
@@ -134,7 +134,7 @@ GET /auth/oauth/google/authorize?tenant_id=my-platform&client_id=web-prod&redire
 ```
 
 ```bash
-curl -X POST https://api.steward.fi/auth/device/code \
+curl -X POST http://localhost:3200/auth/device/code \
   -H "Content-Type: application/json" \
   -H "X-Steward-Native-Bundle-Id: com.example.app" \
   -d '{
@@ -142,7 +142,7 @@ curl -X POST https://api.steward.fi/auth/device/code \
     "client_id": "ios-prod"
   }'
 
-curl -X POST https://api.steward.fi/auth/device/token \
+curl -X POST http://localhost:3200/auth/device/token \
   -H "Content-Type: application/json" \
   -H "X-Steward-Native-Bundle-Id: com.example.app" \
   -d '{
@@ -168,7 +168,7 @@ App clients can also have backend-only app secrets for Privy-style REST API auth
 Use Basic Auth with the app ID as the username and the app secret as the password, plus `X-Steward-App-Id`:
 
 ```bash
-curl https://api.steward.fi/agents \
+curl http://localhost:3200/agents \
   -H "X-Steward-App-Id: my-platform/web-prod" \
   -H "Authorization: Basic $(printf 'my-platform/web-prod:stw_app_...' | base64)"
 ```
@@ -189,7 +189,7 @@ integrations.
 
 ```ts
 const steward = new StewardClient({
-  baseUrl: "https://api.steward.fi",
+  baseUrl: "http://localhost:3200",
   appId: "my-platform/web-prod",
   appSecret: "stw_app_...",
   requestSigningSecret: "stw_app_...",
@@ -215,7 +215,7 @@ metadata only.
 
 ```ts
 const steward = new StewardClient({
-  baseUrl: "https://api.steward.fi",
+  baseUrl: "http://localhost:3200",
   tenantId: "my-platform",
   apiKey: "stw_...",
   requestSigningSecret: "stw_sig_...",
@@ -303,7 +303,7 @@ GET /tenants/:id/idempotency-metrics/export
 ```
 
 ```bash
-curl "https://api.steward.fi/tenants/my-platform/idempotency-metrics/export" \
+curl "http://localhost:3200/tenants/my-platform/idempotency-metrics/export" \
   -H "Authorization: Bearer user-session-jwt" \
   -o idempotency-metrics.csv
 ```
@@ -501,7 +501,7 @@ PUT /tenants/:id/config
 Full replace — any fields omitted default to their zero values.
 
 ```bash
-curl -X PUT https://api.steward.fi/tenants/my-platform/config \
+curl -X PUT http://localhost:3200/tenants/my-platform/config \
   -H "X-Steward-Key: your-tenant-key" \
   -H "Content-Type: application/json" \
   -d '{

--- a/docs/api-reference/user-wallets.mdx
+++ b/docs/api-reference/user-wallets.mdx
@@ -133,12 +133,12 @@ await steward.submitEncryptedUserWalletKeyImport({
 ```
 
 ```bash cURL
-curl -X POST https://api.steward.fi/user/me/wallet/import/init \
+curl -X POST http://localhost:3200/user/me/wallet/import/init \
   -H "Authorization: Bearer user-session-jwt" \
   -H "Content-Type: application/json" \
   -d '{"chain":"evm","walletIndex":2}'
 
-curl -X POST https://api.steward.fi/user/me/wallet/import/submit \
+curl -X POST http://localhost:3200/user/me/wallet/import/submit \
   -H "Authorization: Bearer user-session-jwt" \
   -H "Content-Type: application/json" \
   -d '{
@@ -287,7 +287,7 @@ await steward.revokeUserWalletSigner(created.id, { walletIndex: 2 });
 ```
 
 ```bash cURL
-curl -X POST https://api.steward.fi/user/me/wallet/signers \
+curl -X POST http://localhost:3200/user/me/wallet/signers \
   -H "Authorization: Bearer user-session-jwt" \
   -H "Content-Type: application/json" \
   -d '{

--- a/docs/api-reference/vault.mdx
+++ b/docs/api-reference/vault.mdx
@@ -88,7 +88,7 @@ if ("txHash" in result) {
 ```
 
 ```bash cURL
-curl -X POST https://api.steward.fi/vault/my-agent/sign \
+curl -X POST http://localhost:3200/vault/my-agent/sign \
   -H "Authorization: Bearer agent-jwt" \
   -H "Content-Type: application/json" \
   -d '{
@@ -367,7 +367,7 @@ if (result.finalizedTxHex) {
 ```
 
 ```bash cURL
-curl -X POST https://api.steward.fi/vault/my-agent/sign-bitcoin-psbt \
+curl -X POST http://localhost:3200/vault/my-agent/sign-bitcoin-psbt \
   -H "Authorization: Bearer agent-jwt" \
   -H "Content-Type: application/json" \
   -H "Idempotency-Key: order-123-bitcoin-psbt-v1" \
@@ -484,12 +484,12 @@ await steward.submitEncryptedAgentKeyImport("my-agent", {
 ```
 
 ```bash cURL
-curl -X POST https://api.steward.fi/vault/my-agent/import/init \
+curl -X POST http://localhost:3200/vault/my-agent/import/init \
   -H "Authorization: Bearer tenant-admin-session-jwt" \
   -H "Content-Type: application/json" \
   -d '{"chain":"evm"}'
 
-curl -X POST https://api.steward.fi/vault/my-agent/import/submit \
+curl -X POST http://localhost:3200/vault/my-agent/import/submit \
   -H "Authorization: Bearer tenant-admin-session-jwt" \
   -H "Content-Type: application/json" \
   -d '{
@@ -603,7 +603,7 @@ const history = await steward.getHistory("my-agent");
 ```
 
 ```bash cURL
-curl https://api.steward.fi/vault/my-agent/history \
+curl http://localhost:3200/vault/my-agent/history \
   -H "Authorization: Bearer agent-jwt"
 ```
 </CodeGroup>
@@ -648,7 +648,7 @@ const result = await steward.listTransactions("my-agent", {
 ```
 
 ```bash cURL
-curl "https://api.steward.fi/vault/my-agent/transactions?actionType=transfer&referenceId=customer-order-123" \
+curl "http://localhost:3200/vault/my-agent/transactions?actionType=transfer&referenceId=customer-order-123" \
   -H "Authorization: Bearer agent-jwt"
 ```
 </CodeGroup>
@@ -669,7 +669,7 @@ const tx = await steward.getTransaction("my-agent", "tx_123");
 ```
 
 ```bash cURL
-curl https://api.steward.fi/vault/my-agent/transactions/tx_123 \
+curl http://localhost:3200/vault/my-agent/transactions/tx_123 \
   -H "Authorization: Bearer agent-jwt"
 ```
 </CodeGroup>
@@ -692,7 +692,7 @@ const addresses = await steward.getAddresses("my-agent");
 ```
 
 ```bash cURL
-curl https://api.steward.fi/vault/my-agent/addresses \
+curl http://localhost:3200/vault/my-agent/addresses \
   -H "Authorization: Bearer agent-jwt"
 ```
 </CodeGroup>

--- a/docs/api-reference/webhooks.mdx
+++ b/docs/api-reference/webhooks.mdx
@@ -34,7 +34,7 @@ POST /webhooks
 ```
 
 ```bash
-curl -X POST https://api.steward.fi/webhooks \
+curl -X POST http://localhost:3200/webhooks \
   -H "X-Steward-Key: your-tenant-key" \
   -H "Content-Type: application/json" \
   -d '{
@@ -88,7 +88,7 @@ GET /webhooks
 ```
 
 ```bash
-curl https://api.steward.fi/webhooks \
+curl http://localhost:3200/webhooks \
   -H "X-Steward-Key: your-tenant-key"
 ```
 
@@ -103,7 +103,7 @@ PUT /webhooks/:id
 ```
 
 ```bash
-curl -X PUT https://api.steward.fi/webhooks/wh_550e8400-... \
+curl -X PUT http://localhost:3200/webhooks/wh_550e8400-... \
   -H "X-Steward-Key: your-tenant-key" \
   -H "Content-Type: application/json" \
   -d '{
@@ -123,7 +123,7 @@ DELETE /webhooks/:id
 ```
 
 ```bash
-curl -X DELETE https://api.steward.fi/webhooks/wh_550e8400-... \
+curl -X DELETE http://localhost:3200/webhooks/wh_550e8400-... \
   -H "X-Steward-Key: your-tenant-key"
 ```
 

--- a/docs/auth/cross-tenant.mdx
+++ b/docs/auth/cross-tenant.mdx
@@ -36,7 +36,7 @@ Each tenant controls how new users can join:
 
 ```typescript
 const auth = new StewardAuth({
-  baseUrl: "https://api.steward.fi",
+  baseUrl: "http://localhost:3200",
   storage: localStorage,
 });
 

--- a/docs/auth/email.mdx
+++ b/docs/auth/email.mdx
@@ -24,7 +24,7 @@ Email authentication sends a one-time sign-in link to the user's email address. 
 import { StewardAuth } from "@stwd/sdk";
 
 const auth = new StewardAuth({
-  baseUrl: "https://api.steward.fi",
+  baseUrl: "http://localhost:3200",
   storage: localStorage,
 });
 

--- a/docs/auth/oauth.mdx
+++ b/docs/auth/oauth.mdx
@@ -34,7 +34,7 @@ The popup-based flow keeps the user on your page while authentication happens in
 import { StewardAuth } from "@stwd/sdk";
 
 const auth = new StewardAuth({
-  baseUrl: "https://api.steward.fi",
+  baseUrl: "http://localhost:3200",
   storage: localStorage,
 });
 
@@ -178,7 +178,7 @@ For CLIs, TVs, and other input-constrained clients, Steward supports a bounded R
 
 ```typescript
 const auth = new StewardAuth({
-  baseUrl: "https://api.steward.fi",
+  baseUrl: "http://localhost:3200",
   tenantId: "my-tenant",
 });
 
@@ -232,7 +232,7 @@ attestation provider used by the native app.
 Minimal iOS-bound device-code request:
 
 ```bash
-curl -X POST https://api.steward.fi/auth/device/code \
+curl -X POST http://localhost:3200/auth/device/code \
   -H "Content-Type: application/json" \
   -H "X-Steward-Native-Bundle-Id: com.example.ios" \
   -d '{
@@ -259,7 +259,7 @@ The token poll must repeat the same app client and native identifier, either as
 headers or JSON fields:
 
 ```bash
-curl -X POST https://api.steward.fi/auth/device/token \
+curl -X POST http://localhost:3200/auth/device/token \
   -H "Content-Type: application/json" \
   -d '{
     "grant_type": "urn:ietf:params:oauth:grant-type:device_code",

--- a/docs/auth/overview.mdx
+++ b/docs/auth/overview.mdx
@@ -52,7 +52,7 @@ The SDK handles token refresh automatically. When the access token is within 2 m
 import { StewardAuth } from "@stwd/sdk";
 
 const auth = new StewardAuth({
-  baseUrl: "https://api.steward.fi",
+  baseUrl: "http://localhost:3200",
   storage: localStorage, // persist across page reloads
   onSessionChange: (session) => {
     console.log(session ? "Signed in" : "Signed out");
@@ -100,11 +100,11 @@ See [Cross-Tenant Identity](/auth/cross-tenant) for details on tenant management
     ```typescript
     import { StewardAuth } from "@stwd/sdk";
 
-    const auth = new StewardAuth({ baseUrl: "https://api.steward.fi" });
+    const auth = new StewardAuth({ baseUrl: "http://localhost:3200" });
     const result = await auth.signInWithPasskey("user@example.com");
 
     const client = new StewardClient({
-      baseUrl: "https://api.steward.fi",
+      baseUrl: "http://localhost:3200",
       bearerToken: auth.getToken(),
     });
     ```
@@ -118,7 +118,7 @@ See [Cross-Tenant Identity](/auth/cross-tenant) for details on tenant management
         <StewardProvider
           client={client}
           agentId="my-agent"
-          auth={{ baseUrl: "https://api.steward.fi" }}
+          auth={{ baseUrl: "http://localhost:3200" }}
         >
           <StewardAuthGuard>
             <Dashboard />

--- a/docs/auth/passkeys.mdx
+++ b/docs/auth/passkeys.mdx
@@ -26,7 +26,7 @@ The entire flow is a single SDK call.
 import { StewardAuth } from "@stwd/sdk";
 
 const auth = new StewardAuth({
-  baseUrl: "https://api.steward.fi",
+  baseUrl: "http://localhost:3200",
   storage: localStorage,
 });
 
@@ -58,7 +58,7 @@ function LoginPage() {
     <StewardProvider
       client={client}
       agentId="my-agent"
-      auth={{ baseUrl: "https://api.steward.fi" }}
+      auth={{ baseUrl: "http://localhost:3200" }}
     >
       <StewardLogin
         showPasskey       // enabled by default

--- a/docs/concepts/audit-logging.mdx
+++ b/docs/concepts/audit-logging.mdx
@@ -71,7 +71,7 @@ Transaction records include:
 Steward dispatches webhooks for key events. Configure your webhook URL per-tenant:
 
 ```typescript
-await fetch("https://api.steward.fi/tenants/your-tenant/webhook", {
+await fetch("http://localhost:3200/tenants/your-tenant/webhook", {
   method: "PUT",
   headers: {
     "X-Steward-Key": "your-key",

--- a/docs/concepts/policy-engine.mdx
+++ b/docs/concepts/policy-engine.mdx
@@ -172,13 +172,13 @@ Transactions that pass all policies except auto-approve enter the approval queue
 ```typescript
 // List pending approvals
 const pending = await fetch(
-  `https://api.steward.fi/vault/${agentId}/pending`,
+  `http://localhost:3200/vault/${agentId}/pending`,
   { headers: { Authorization: `Bearer ${agentToken}` } }
 );
 
 // Approve (requires tenant-level auth)
 await fetch(
-  `https://api.steward.fi/vault/${agentId}/approve/${txId}`,
+  `http://localhost:3200/vault/${agentId}/approve/${txId}`,
   {
     method: "POST",
     headers: { "X-Steward-Key": "tenant-key" },
@@ -187,7 +187,7 @@ await fetch(
 
 // Reject
 await fetch(
-  `https://api.steward.fi/vault/${agentId}/reject/${txId}`,
+  `http://localhost:3200/vault/${agentId}/reject/${txId}`,
   {
     method: "POST",
     headers: { "X-Steward-Key": "tenant-key" },

--- a/docs/concepts/secret-vault.mdx
+++ b/docs/concepts/secret-vault.mdx
@@ -21,7 +21,7 @@ You store credentials in Steward's Secret Vault and configure **routes** that ma
 
 ```typescript
 // 1. Store an encrypted credential
-await fetch("https://api.steward.fi/secrets", {
+await fetch("http://localhost:3200/secrets", {
   method: "POST",
   headers: {
     "X-Steward-Key": "your-tenant-key",
@@ -35,7 +35,7 @@ await fetch("https://api.steward.fi/secrets", {
 });
 
 // 2. Create a route: when an agent calls api.openai.com, inject this key
-await fetch("https://api.steward.fi/secrets/routes", {
+await fetch("http://localhost:3200/secrets/routes", {
   method: "POST",
   headers: {
     "X-Steward-Key": "your-tenant-key",
@@ -80,7 +80,7 @@ Master Key (Argon2id from STEWARD_MASTER_PASSWORD)
 <Tabs>
   <Tab title="Create">
     ```bash
-    curl -X POST https://api.steward.fi/secrets \
+    curl -X POST http://localhost:3200/secrets \
       -H "X-Steward-Key: your-key" \
       -H "Content-Type: application/json" \
       -d '{
@@ -108,7 +108,7 @@ Master Key (Argon2id from STEWARD_MASTER_PASSWORD)
   </Tab>
   <Tab title="Rotate">
     ```bash
-    curl -X POST https://api.steward.fi/secrets/{id}/rotate \
+    curl -X POST http://localhost:3200/secrets/{id}/rotate \
       -H "X-Steward-Key: your-key" \
       -H "Content-Type: application/json" \
       -d '{ "value": "sk-ant-new-key..." }'
@@ -118,7 +118,7 @@ Master Key (Argon2id from STEWARD_MASTER_PASSWORD)
   </Tab>
   <Tab title="Delete">
     ```bash
-    curl -X DELETE https://api.steward.fi/secrets/{id} \
+    curl -X DELETE http://localhost:3200/secrets/{id} \
       -H "X-Steward-Key: your-key"
     ```
 

--- a/docs/concepts/wallet-vault.mdx
+++ b/docs/concepts/wallet-vault.mdx
@@ -100,7 +100,7 @@ For agents that already have keys (e.g., migrating from another system), you can
 
 ```typescript
 // Import requires tenant-level authentication
-const result = await fetch("https://api.steward.fi/vault/my-agent/import", {
+const result = await fetch("http://localhost:3200/vault/my-agent/import", {
   method: "POST",
   headers: {
     "X-Steward-Key": "your-tenant-api-key",

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -131,7 +131,7 @@ Configure the Railway service with the normal production environment plus Railwa
 
 Run the proxy as a separate Railway service/process using the same image and command `bun run packages/proxy/src/index.ts`, with `STEWARD_PROXY_PORT` set to the port Railway expects for that service.
 
-A hosted instance at `api.steward.fi` is run by the project for trusted testers. Self-hosted deployments should not depend on it for operator workflows.
+A managed hosted API is not available yet. Steward is self-host-first today: run your own instance (see the Docker/compose steps above) and point clients at your deployment URL. A hosted offering is coming soon.
 
 ### Automated Railway deploys via GitHub Actions (optional)
 

--- a/docs/guides/agent-setup.mdx
+++ b/docs/guides/agent-setup.mdx
@@ -19,7 +19,7 @@ This guide walks through creating a Steward agent from scratch — wallet creati
 import { StewardClient } from "@stwd/sdk";
 
 const steward = new StewardClient({
-  baseUrl: "https://api.steward.fi",
+  baseUrl: "http://localhost:3200",
   apiKey: "stwd_your_tenant_api_key",
 });
 ```
@@ -120,7 +120,7 @@ For the agent to authenticate its own requests, generate a scoped JWT:
 
 ```typescript
 const tokenResponse = await fetch(
-  "https://api.steward.fi/agents/my-trading-bot/token",
+  "http://localhost:3200/agents/my-trading-bot/token",
   {
     method: "POST",
     headers: {
@@ -142,7 +142,7 @@ In your agent code, create a client with the agent token:
 
 ```typescript
 const agentClient = new StewardClient({
-  baseUrl: "https://api.steward.fi",
+  baseUrl: "http://localhost:3200",
   bearerToken: process.env.STEWARD_AGENT_TOKEN,
 });
 

--- a/docs/guides/eliza-plugin.mdx
+++ b/docs/guides/eliza-plugin.mdx
@@ -42,7 +42,7 @@ const character = {
 Set the required environment variables:
 
 ```bash
-STEWARD_API_URL=https://api.steward.fi    # Steward API base URL
+STEWARD_API_URL=http://localhost:3200    # Steward API base URL
 STEWARD_API_KEY=stwd_your_tenant_key       # Tenant API key
 STEWARD_AGENT_ID=my-trading-agent          # Agent ID in Steward
 STEWARD_AGENT_TOKEN=stwd_jwt_...           # Agent JWT (optional, preferred over API key)

--- a/docs/guides/policies.mdx
+++ b/docs/guides/policies.mdx
@@ -30,7 +30,7 @@ await steward.setPolicies("my-agent", [
 ```
 
 ```bash cURL
-curl -X PUT https://api.steward.fi/agents/my-agent/policies \
+curl -X PUT http://localhost:3200/agents/my-agent/policies \
   -H "X-Steward-Key: your-key" \
   -H "Content-Type: application/json" \
   -d '[{ "id": "limit-1", "type": "spending-limit", "enabled": true, "config": { ... } }]'

--- a/docs/guides/secrets.mdx
+++ b/docs/guides/secrets.mdx
@@ -15,7 +15,7 @@ This guide covers creating encrypted credentials, configuring injection routes, 
 ## Creating a Secret
 
 ```typescript
-const response = await fetch("https://api.steward.fi/secrets", {
+const response = await fetch("http://localhost:3200/secrets", {
   method: "POST",
   headers: {
     "X-Steward-Key": "your-tenant-key",
@@ -41,7 +41,7 @@ Routes tell the proxy how to inject credentials when an agent makes a request:
 
 ```typescript
 // Route for OpenAI
-await fetch("https://api.steward.fi/secrets/routes", {
+await fetch("http://localhost:3200/secrets/routes", {
   method: "POST",
   headers: {
     "X-Steward-Key": "your-tenant-key",
@@ -149,7 +149,7 @@ scope for the job:
 ### 2. Store the token as a secret
 
 ```bash
-curl -X POST https://api.steward.fi/secrets \
+curl -X POST http://localhost:3200/secrets \
   -H "X-Steward-Key: your-tenant-key" \
   -H "Content-Type: application/json" \
   -d '{
@@ -166,7 +166,7 @@ Scope the route to one method and one deep path. GitHub accepts both
 `injectFormat` works.
 
 ```bash
-curl -X POST https://api.steward.fi/secrets/routes \
+curl -X POST http://localhost:3200/secrets/routes \
   -H "X-Steward-Key: your-tenant-key" \
   -H "Content-Type: application/json" \
   -d '{
@@ -203,7 +203,7 @@ curl -X POST https://proxy.steward.fi/github/repos/acme/widgets/issues/1/comment
 ## Listing Secrets
 
 ```bash
-curl https://api.steward.fi/secrets \
+curl http://localhost:3200/secrets \
   -H "X-Steward-Key: your-key"
 ```
 
@@ -234,7 +234,7 @@ curl https://api.steward.fi/secrets \
 When you need to update a credential (e.g., API key rotation), use the rotate endpoint:
 
 ```bash
-curl -X POST https://api.steward.fi/secrets/550e8400-.../rotate \
+curl -X POST http://localhost:3200/secrets/550e8400-.../rotate \
   -H "X-Steward-Key: your-key" \
   -H "Content-Type: application/json" \
   -d '{ "value": "sk-proj-new-key-xyz..." }'
@@ -248,7 +248,7 @@ This:
 ## Deleting a Secret
 
 ```bash
-curl -X DELETE https://api.steward.fi/secrets/550e8400-... \
+curl -X DELETE http://localhost:3200/secrets/550e8400-... \
   -H "X-Steward-Key: your-key"
 ```
 
@@ -261,14 +261,14 @@ curl -X DELETE https://api.steward.fi/secrets/550e8400-... \
 ### List Routes
 
 ```bash
-curl https://api.steward.fi/secrets/routes \
+curl http://localhost:3200/secrets/routes \
   -H "X-Steward-Key: your-key"
 ```
 
 ### Update a Route
 
 ```bash
-curl -X PUT https://api.steward.fi/secrets/routes/route-id \
+curl -X PUT http://localhost:3200/secrets/routes/route-id \
   -H "X-Steward-Key: your-key" \
   -H "Content-Type: application/json" \
   -d '{ "enabled": false }'
@@ -277,7 +277,7 @@ curl -X PUT https://api.steward.fi/secrets/routes/route-id \
 ### Delete a Route
 
 ```bash
-curl -X DELETE https://api.steward.fi/secrets/routes/route-id \
+curl -X DELETE http://localhost:3200/secrets/routes/route-id \
   -H "X-Steward-Key: your-key"
 ```
 

--- a/docs/guides/session-broker-integration.mdx
+++ b/docs/guides/session-broker-integration.mdx
@@ -102,7 +102,7 @@ STEWARD_PROXY_UPSTREAM_TIMEOUT_MS=120000
 The scoped broker token is stored encrypted. It is never returned in any response.
 
 ```bash
-curl -X POST https://api.steward.fi/secrets \
+curl -X POST http://localhost:3200/secrets \
   -H "X-Steward-Key: your-tenant-key" \
   -H "Content-Type: application/json" \
   -d '{
@@ -123,7 +123,7 @@ secret-route rules (host must be allowlisted, `injectAs` is header-only, framing
 headers are blocked).
 
 ```bash
-curl -X POST https://api.steward.fi/capabilities \
+curl -X POST http://localhost:3200/capabilities \
   -H "X-Steward-Key: your-tenant-key" \
   -H "Content-Type: application/json" \
   -d '{
@@ -160,7 +160,7 @@ A capability is inert until an agent is granted it. Grants are per-agent and may
 carry an optional expiry.
 
 ```bash
-curl -X POST https://api.steward.fi/capabilities/<capabilityId>/grants \
+curl -X POST http://localhost:3200/capabilities/<capabilityId>/grants \
   -H "X-Steward-Key: your-tenant-key" \
   -H "Content-Type: application/json" \
   -d '{
@@ -180,7 +180,7 @@ whose patterns govern the capability name. Policies are set with the full-set
 `PUT` (it **replaces** the agent's policy set — include every rule).
 
 ```bash
-curl -X PUT https://api.steward.fi/agents/my-agent/policies \
+curl -X PUT http://localhost:3200/agents/my-agent/policies \
   -H "X-Steward-Key: your-tenant-key" \
   -H "Content-Type: application/json" \
   -d '[
@@ -216,7 +216,7 @@ The agent calls the invoke route with its **agent token** (not the tenant key). 
 agent never references the broker token — the proxy attaches it.
 
 ```bash
-curl -X POST https://api.steward.fi/capabilities/broker.session.render/invoke \
+curl -X POST http://localhost:3200/capabilities/broker.session.render/invoke \
   -H "Authorization: Bearer <agent-token>" \
   -H "Content-Type: application/json" \
   -d '{

--- a/docs/guides/wallet-external-id-migration.mdx
+++ b/docs/guides/wallet-external-id-migration.mdx
@@ -58,7 +58,7 @@ if (existing.user) {
 ```
 
 ```bash cURL
-curl -X POST https://api.steward.fi/platform/users/wallet/external-id \
+curl -X POST http://localhost:3200/platform/users/wallet/external-id \
   -H "X-Steward-Platform-Key: your-platform-key" \
   -H "Content-Type: application/json" \
   -d '{
@@ -81,7 +81,7 @@ await steward.platformUsers.assignWalletExternalId("usr_123", {
 ```
 
 ```bash cURL
-curl -X POST https://api.steward.fi/platform/users/usr_123/wallet/external-id \
+curl -X POST http://localhost:3200/platform/users/usr_123/wallet/external-id \
   -H "X-Steward-Platform-Key: your-platform-key" \
   -H "Content-Type: application/json" \
   -d '{

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -25,12 +25,6 @@
     "default": "dark"
   },
   "css": "custom.css",
-  "topbarLinks": [
-    {
-      "name": "API Status",
-      "url": "https://api.steward.fi/health"
-    }
-  ],
   "topbarCtaButton": {
     "name": "GitHub",
     "url": "https://github.com/Steward-Fi/steward"

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -7,7 +7,8 @@
   },
   "servers": [
     {
-      "url": "https://api.steward.fi"
+      "url": "/",
+      "description": "Same origin as this Steward deployment (self-hosted)"
     }
   ],
   "x-steward-sensitive-prefixes": [

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -7,7 +7,7 @@ description: "Get up and running with Steward in 5 minutes."
 
 
 <Note>
-  Using your own instance? Start with [Self-Hosting](/guides/self-hosting), [Docker Deployment](/guides/docker), or the root [deployment guide](https://github.com/Steward-Fi/steward/blob/develop/docs/deployment.md). The project also runs `api.steward.fi` for trusted testers.
+  Steward is self-host-first today. Start with [Self-Hosting](/guides/self-hosting), [Docker Deployment](/guides/docker), or the root [deployment guide](https://github.com/Steward-Fi/steward/blob/develop/docs/deployment.md). A managed hosted API is coming soon.
 </Note>
 
 This guide walks you through creating your first agent with an encrypted wallet, setting policies, and signing a transaction — all using the `@stwd/sdk`.
@@ -38,7 +38,7 @@ bun add @stwd/sdk
 import { StewardClient } from "@stwd/sdk";
 
 const steward = new StewardClient({
-  baseUrl: "https://api.steward.fi",
+  baseUrl: "http://localhost:3200",
   apiKey: "your-tenant-api-key",
 });
 ```

--- a/docs/sdk/client.mdx
+++ b/docs/sdk/client.mdx
@@ -13,7 +13,7 @@ The `StewardClient` class provides typed methods for all Steward API operations.
 import { StewardClient } from "@stwd/sdk";
 
 const client = new StewardClient({
-  baseUrl: string;        // Steward API URL (e.g., "https://api.steward.fi")
+  baseUrl: string;        // Steward API URL (e.g., "http://localhost:3200")
   apiKey?: string;        // Tenant API key (X-Steward-Key header)
   bearerToken?: string;   // Agent JWT (Authorization: Bearer header)
   tenantId?: string;      // Optional tenant ID header

--- a/docs/sdk/installation.mdx
+++ b/docs/sdk/installation.mdx
@@ -40,13 +40,13 @@ import { StewardClient } from "@stwd/sdk";
 
 // Tenant-level client (for management operations)
 const steward = new StewardClient({
-  baseUrl: "https://api.steward.fi",
+  baseUrl: "http://localhost:3200",
   apiKey: "stwd_your_tenant_api_key",
 });
 
 // Agent-level client (for signing operations)
 const agentClient = new StewardClient({
-  baseUrl: "https://api.steward.fi",
+  baseUrl: "http://localhost:3200",
   bearerToken: process.env.STEWARD_AGENT_TOKEN,
 });
 ```
@@ -79,7 +79,7 @@ import {
 Common environment variables used with the SDK:
 
 ```bash
-STEWARD_API_URL=https://api.steward.fi    # API base URL
+STEWARD_API_URL=http://localhost:3200    # API base URL
 STEWARD_API_KEY=stwd_your_tenant_key       # Tenant API key
 STEWARD_AGENT_TOKEN=stwd_jwt_...           # Agent JWT token
 STEWARD_AGENT_ID=my-agent                  # Agent identifier

--- a/docs/sdk/react-components.mdx
+++ b/docs/sdk/react-components.mdx
@@ -22,7 +22,7 @@ import "@stwd/react/styles.css";
 import { StewardClient } from "@stwd/sdk";
 
 const client = new StewardClient({
-  baseUrl: "https://api.steward.fi",
+  baseUrl: "http://localhost:3200",
   apiKey: "your-tenant-key",
   tenantId: "your-tenant-id",
 });

--- a/packages/agent-trader/agent-trader.config.example.json
+++ b/packages/agent-trader/agent-trader.config.example.json
@@ -1,6 +1,6 @@
 {
   "steward": {
-    "apiUrl": "https://api.steward.fi",
+    "apiUrl": "http://localhost:3200",
     "tenantId": "waifu.fun",
     "apiKey": "your-api-key"
   },

--- a/packages/agent-trader/src/config.ts
+++ b/packages/agent-trader/src/config.ts
@@ -16,7 +16,7 @@ import { MAX_SLIPPAGE_BPS } from "./trade-builder.js";
 // ─── Types ───────────────────────────────────────────────────────────────────
 
 export interface StewardConnection {
-  /** Base URL of the Steward API, e.g. https://api.steward.fi */
+  /** Base URL of the Steward API, e.g. http://localhost:3200 for a self-hosted instance */
   apiUrl: string;
   /** Tenant identifier, e.g. "waifu.fun" */
   tenantId: string;

--- a/packages/android/README.md
+++ b/packages/android/README.md
@@ -9,7 +9,7 @@ registration.
 
 ```java
 StewardAndroidClient client = StewardAndroidClient.withBearerToken(
-    "https://api.steward.fi",
+    "http://localhost:3200",
     "user_access_token"
 );
 

--- a/packages/api/scripts/generate-openapi.ts
+++ b/packages/api/scripts/generate-openapi.ts
@@ -42,11 +42,35 @@ const { app } = await import("../src/app");
 const { OPENAPI_DOC } = await import("../src/openapi");
 
 const document = app.getOpenAPI31Document(OPENAPI_DOC);
-const json = `${JSON.stringify(document, null, 2)}\n`;
 
-// Single canonical artifact. The route definitions in packages/api are the source
-// of truth; this emitted spec is the one committed copy, consumed by both Mintlify
-// (docs site) and the SDK type generator. No second copy to drift.
+// Server URL for the DOCS-SITE copy (Mintlify).
+//
+// The runtime spec (getOpenApiSpec / docs/openapi.json, served by the API at
+// /openapi.json) uses a RELATIVE server URL ("/") so generated clients target
+// the same origin the spec was fetched from. That is correct there, but WRONG
+// for the Mintlify copy: Mintlify serves this file from the docs domain
+// (docs.steward.fi), so a relative "/" would make the API playground resolve
+// requests against the docs site instead of a Steward instance.
+//
+// Steward is self-host-first (no shared hosted API), so the docs playground
+// points at an explicit self-host example the reader replaces with their own
+// deployment URL.
+const docsDocument = {
+  ...document,
+  servers: [
+    {
+      url: "http://localhost:3200",
+      description:
+        "Your self-hosted Steward instance (Steward is self-host-first; replace with your deployment URL). The playground targets this rather than the docs domain.",
+    },
+  ],
+};
+const json = `${JSON.stringify(docsDocument, null, 2)}\n`;
+
+// The route definitions in packages/api are the source of truth for the schema.
+// This emitted spec is the docs-site copy consumed by Mintlify (and the SDK type
+// generator); it is identical to the runtime spec except for the `servers` block
+// above, which is overridden for the docs-playground use case.
 const specPath = join(import.meta.dir, "..", "..", "..", "docs", "api-reference", "openapi.json");
 mkdirSync(dirname(specPath), { recursive: true });
 writeFileSync(specPath, json);

--- a/packages/api/src/openapi.ts
+++ b/packages/api/src/openapi.ts
@@ -5652,7 +5652,16 @@ export function getOpenApiSpec() {
       description:
         "Generated OpenAPI contract for implemented Steward API surfaces. This contract includes Privy-parity account resources, wallet external IDs, gas spend filtering, transaction reference filtering, and request-hardening inventory markers for sensitive mutating routes.",
     },
-    servers: [{ url: "https://api.steward.fi" }],
+    // Steward is self-host-first: there is no shared hosted API. A relative
+    // server URL means "same origin the spec was served from", so generated
+    // clients and importers target the actual deployment they fetched this
+    // document from (whatever domain/port that is) instead of a hardcoded host.
+    servers: [
+      {
+        url: "/",
+        description: "Same origin as this Steward deployment (self-hosted)",
+      },
+    ],
     "x-steward-sensitive-prefixes": SENSITIVE_PATH_PREFIXES,
     tags: [
       { name: "Auth" },

--- a/packages/csharp/README.md
+++ b/packages/csharp/README.md
@@ -6,7 +6,7 @@ runtime compatibility.
 ```csharp
 var client = new StewardClient(new StewardClientConfig
 {
-    BaseUrl = "https://api.steward.fi",
+    BaseUrl = "http://localhost:3200",
     PlatformKey = "steward_platform_..."
 });
 

--- a/packages/eliza-plugin/CHANGELOG.md
+++ b/packages/eliza-plugin/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @stwd/eliza-plugin Changelog
 
+## Unreleased
+
+### Docs
+- Make the opt-in live integration suite (`STEWARD_LIVE_TESTS=1`) target env-configurable (`STEWARD_URL` / `STEWARD_API_KEY` / `STEWARD_TENANT_ID`) with self-host defaults (`http://localhost:3200`, `my-app`) instead of a hardcoded hosted `api.steward.fi` URL and production tenant/key. Steward is self-host-first today; there is no shared hosted API. Test-fixture only, no runtime change.
+
 ## 0.4.1
 
 - Security audit hardening release.

--- a/packages/eliza-plugin/src/__tests__/integration.test.ts
+++ b/packages/eliza-plugin/src/__tests__/integration.test.ts
@@ -1,8 +1,9 @@
 /**
  * Integration tests for @stwd/eliza-plugin against real Steward API.
  *
- * These tests create a temporary agent on milady-cloud tenant,
- * exercise every plugin component, then clean up.
+ * These tests create a temporary agent on the configured tenant
+ * (STEWARD_TENANT_ID, default "my-app"), exercise every plugin component,
+ * then clean up.
  *
  * Run with: npx vitest run src/__tests__/integration.test.ts
  */
@@ -22,9 +23,14 @@ const describeLive = runLive ? describe : describe.skip;
 
 // ── Config ──────────────────────────────────────────────────────
 
-const API_URL = "https://api.steward.fi";
-const API_KEY = "stw_b1715e3d9fc4aa49b8d2641f9e0349cf";
-const TENANT_ID = "milady-cloud";
+// Opt-in live suite (STEWARD_LIVE_TESTS=1). Steward is self-host-first, so the
+// target instance and its seeded tenant/key are environment-specific. Override
+// via env to point at whatever instance you are exercising; the defaults assume
+// a locally running self-hosted Steward (compose profile exposes :3200) with a
+// tenant/key you have seeded.
+const API_URL = (process.env.STEWARD_URL ?? "http://localhost:3200").replace(/\/$/, "");
+const API_KEY = process.env.STEWARD_API_KEY ?? "stw_your_tenant_key";
+const TENANT_ID = process.env.STEWARD_TENANT_ID ?? "my-app";
 const TEST_AGENT_ID = `eliza-integ-${Date.now()}`;
 
 // ── Helpers ─────────────────────────────────────────────────────

--- a/packages/flutter/README.md
+++ b/packages/flutter/README.md
@@ -30,7 +30,7 @@ import 'package:steward_flutter/steward.dart';
 
 final client = StewardClient(
   StewardClientConfig(
-    baseUrl: 'https://api.steward.fi',
+    baseUrl: 'http://localhost:3200',
     bearerToken: session.token,
     tenantId: 'my-app',
   ),
@@ -52,7 +52,7 @@ await client.registerUserPushSubscription(
 final storage = MemoryStewardSessionStorage();
 final auth = StewardAuth(
   StewardAuthConfig(
-    baseUrl: 'https://api.steward.fi',
+    baseUrl: 'http://localhost:3200',
     tenantId: 'my-app',
     storage: storage,
   ),

--- a/packages/go/README.md
+++ b/packages/go/README.md
@@ -4,7 +4,7 @@ First-pass Go backend SDK for Steward API integrations.
 
 ```go
 client, err := steward.NewClient(steward.Config{
-    BaseURL:     "https://api.steward.fi",
+    BaseURL:     "http://localhost:3200",
     PlatformKey: "steward_platform_...",
 })
 if err != nil {

--- a/packages/java/README.md
+++ b/packages/java/README.md
@@ -9,7 +9,7 @@ The SDK uses only the Java standard library and can be compiled directly with
 import com.steward.sdk.CreateUserInput;
 import com.steward.sdk.StewardClient;
 
-StewardClient client = new StewardClient(StewardClient.config("https://api.steward.fi")
+StewardClient client = new StewardClient(StewardClient.config("http://localhost:3200")
     .platformKey("steward_platform_...")
     .build());
 
@@ -23,7 +23,7 @@ adds Steward request freshness, HMAC signature, and idempotency headers for
 sensitive mutations.
 
 ```java
-StewardClient client = new StewardClient(StewardClient.config("https://api.steward.fi")
+StewardClient client = new StewardClient(StewardClient.config("http://localhost:3200")
     .appCredentials("app_...", "secret_...")
     .requestSigningSecret("stwd_req_...")
     .requestSigningKeyId("key_...")

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -26,7 +26,7 @@ message if required values are missing.
 
 | Variable | Required | Description |
 | --- | --- | --- |
-| `STEWARD_URL` (or `STEWARD_BASE_URL`) | yes | Steward API base URL, e.g. `https://api.steward.fi`. `http://` is rejected for non-localhost hosts. |
+| `STEWARD_URL` (or `STEWARD_BASE_URL`) | yes | Steward API base URL, e.g. `http://localhost:3200`. `http://` is rejected for non-localhost hosts. |
 | `STEWARD_API_KEY` | one of | Tenant API key. |
 | `STEWARD_JWT` (or `STEWARD_BEARER_TOKEN`) | one of | Agent-scoped bearer token. Preferred over `STEWARD_API_KEY` when both are set. |
 | `STEWARD_TENANT_ID` | no | Tenant id scoping requests. |
@@ -48,7 +48,7 @@ At least one credential (`STEWARD_API_KEY` or a bearer token) must be provided.
 
 ```bash
 claude mcp add steward \
-  --env STEWARD_URL=https://api.steward.fi \
+  --env STEWARD_URL=http://localhost:3200 \
   --env STEWARD_API_KEY=sk_live_... \
   --env STEWARD_TENANT_ID=your_tenant \
   --env STEWARD_AGENT_ID=your_default_agent \
@@ -66,7 +66,7 @@ Add an entry to your MCP config (`~/.cursor/mcp.json`, or
     "steward": {
       "command": "stwd-mcp",
       "env": {
-        "STEWARD_URL": "https://api.steward.fi",
+        "STEWARD_URL": "http://localhost:3200",
         "STEWARD_API_KEY": "sk_live_...",
         "STEWARD_TENANT_ID": "your_tenant",
         "STEWARD_AGENT_ID": "your_default_agent"
@@ -84,7 +84,7 @@ If the package is not installed globally, use `bunx`/`npx`:
     "steward": {
       "command": "npx",
       "args": ["-y", "@stwd/mcp"],
-      "env": { "STEWARD_URL": "https://api.steward.fi", "STEWARD_API_KEY": "sk_live_..." }
+      "env": { "STEWARD_URL": "http://localhost:3200", "STEWARD_API_KEY": "sk_live_..." }
     }
   }
 }

--- a/packages/mcp/src/__tests__/config.test.ts
+++ b/packages/mcp/src/__tests__/config.test.ts
@@ -9,7 +9,7 @@ import {
 
 describe("assertSecureBaseUrl", () => {
   test("accepts https URLs", () => {
-    expect(() => assertSecureBaseUrl("https://api.steward.fi")).not.toThrow();
+    expect(() => assertSecureBaseUrl("https://steward.example.com")).not.toThrow();
   });
 
   test("accepts http for localhost variants", () => {
@@ -19,13 +19,13 @@ describe("assertSecureBaseUrl", () => {
   });
 
   test("rejects http for remote hosts", () => {
-    expect(() => assertSecureBaseUrl("http://api.steward.fi")).toThrow(
+    expect(() => assertSecureBaseUrl("http://steward.example.com")).toThrow(
       /only allowed for localhost/,
     );
   });
 
   test("rejects non-http(s) protocols", () => {
-    expect(() => assertSecureBaseUrl("ftp://api.steward.fi")).toThrow(/only http\(s\)/);
+    expect(() => assertSecureBaseUrl("ftp://steward.example.com")).toThrow(/only http\(s\)/);
   });
 
   test("rejects malformed URLs", () => {
@@ -36,13 +36,13 @@ describe("assertSecureBaseUrl", () => {
 describe("loadConfig", () => {
   test("loads a full config from env", () => {
     const config = loadConfig({
-      STEWARD_URL: "https://api.steward.fi",
+      STEWARD_URL: "https://steward.example.com",
       STEWARD_API_KEY: "sk_live_abcd1234",
       STEWARD_TENANT_ID: "tenant_1",
       STEWARD_AGENT_ID: "agent_1",
     } as NodeJS.ProcessEnv);
     expect(config).toEqual({
-      baseUrl: "https://api.steward.fi",
+      baseUrl: "https://steward.example.com",
       apiKey: "sk_live_abcd1234",
       bearerToken: undefined,
       tenantId: "tenant_1",
@@ -52,15 +52,15 @@ describe("loadConfig", () => {
 
   test("accepts STEWARD_BASE_URL as a fallback for STEWARD_URL", () => {
     const config = loadConfig({
-      STEWARD_BASE_URL: "https://api.steward.fi",
+      STEWARD_BASE_URL: "https://steward.example.com",
       STEWARD_API_KEY: "k",
     } as NodeJS.ProcessEnv);
-    expect(config.baseUrl).toBe("https://api.steward.fi");
+    expect(config.baseUrl).toBe("https://steward.example.com");
   });
 
   test("accepts a bearer token instead of an api key", () => {
     const config = loadConfig({
-      STEWARD_URL: "https://api.steward.fi",
+      STEWARD_URL: "https://steward.example.com",
       STEWARD_JWT: "jwt-token",
     } as NodeJS.ProcessEnv);
     expect(config.bearerToken).toBe("jwt-token");
@@ -69,7 +69,7 @@ describe("loadConfig", () => {
 
   test("accepts STEWARD_BEARER_TOKEN as an alias for STEWARD_JWT", () => {
     const config = loadConfig({
-      STEWARD_URL: "https://api.steward.fi",
+      STEWARD_URL: "https://steward.example.com",
       STEWARD_BEARER_TOKEN: "jwt-token",
     } as NodeJS.ProcessEnv);
     expect(config.bearerToken).toBe("jwt-token");
@@ -83,14 +83,14 @@ describe("loadConfig", () => {
 
   test("throws when no credentials are provided", () => {
     expect(() =>
-      loadConfig({ STEWARD_URL: "https://api.steward.fi" } as NodeJS.ProcessEnv),
+      loadConfig({ STEWARD_URL: "https://steward.example.com" } as NodeJS.ProcessEnv),
     ).toThrow(/Missing Steward credentials/);
   });
 
   test("throws on insecure remote http URLs", () => {
     expect(() =>
       loadConfig({
-        STEWARD_URL: "http://api.steward.fi",
+        STEWARD_URL: "http://steward.example.com",
         STEWARD_API_KEY: "k",
       } as NodeJS.ProcessEnv),
     ).toThrow(/only allowed for localhost/);
@@ -99,7 +99,7 @@ describe("loadConfig", () => {
   test("treats blank credential strings as absent", () => {
     expect(() =>
       loadConfig({
-        STEWARD_URL: "https://api.steward.fi",
+        STEWARD_URL: "https://steward.example.com",
         STEWARD_API_KEY: "   ",
       } as NodeJS.ProcessEnv),
     ).toThrow(/Missing Steward credentials/);
@@ -118,14 +118,14 @@ describe("redaction", () => {
 
   test("redactConfig hides apiKey and bearerToken but keeps non-secret fields", () => {
     const config: StewardMcpConfig = {
-      baseUrl: "https://api.steward.fi",
+      baseUrl: "https://steward.example.com",
       apiKey: "sk_live_abcd1234",
       bearerToken: "jwt-supersecret-token",
       tenantId: "tenant_1",
       defaultAgentId: "agent_1",
     };
     const redacted = redactConfig(config);
-    expect(redacted.baseUrl).toBe("https://api.steward.fi");
+    expect(redacted.baseUrl).toBe("https://steward.example.com");
     expect(redacted.tenantId).toBe("tenant_1");
     expect(redacted.defaultAgentId).toBe("agent_1");
     expect(redacted.apiKey).toBe("****1234");
@@ -136,7 +136,10 @@ describe("redaction", () => {
   });
 
   test("redactConfig omits undefined fields", () => {
-    const redacted = redactConfig({ baseUrl: "https://api.steward.fi", apiKey: "sk_abcd1234" });
+    const redacted = redactConfig({
+      baseUrl: "https://steward.example.com",
+      apiKey: "sk_abcd1234",
+    });
     expect("bearerToken" in redacted).toBe(false);
     expect("tenantId" in redacted).toBe(false);
   });

--- a/packages/mcp/src/config.ts
+++ b/packages/mcp/src/config.ts
@@ -6,7 +6,7 @@ import { StewardClient, type StewardClientConfig } from "@stwd/sdk";
  * agent-scoped tools when the caller omits one.
  */
 export interface StewardMcpConfig {
-  /** Base URL of the Steward API, e.g. `https://api.steward.fi`. */
+  /** Base URL of the Steward API, e.g. `http://localhost:3200` for a self-hosted instance. */
   baseUrl: string;
   /** Tenant API key. Sent as an authorization header by the SDK. */
   apiKey?: string;
@@ -66,7 +66,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): StewardMcpConf
   const baseUrl = (env.STEWARD_URL ?? env.STEWARD_BASE_URL ?? "").trim();
   if (!baseUrl) {
     throw new Error(
-      "Missing required STEWARD_URL (or STEWARD_BASE_URL). Set it to your Steward API base URL, e.g. https://api.steward.fi",
+      "Missing required STEWARD_URL (or STEWARD_BASE_URL). Set it to your Steward API base URL, e.g. http://localhost:3200",
     );
   }
   assertSecureBaseUrl(baseUrl);

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -6,7 +6,7 @@ Python backend SDK for Steward API integrations.
 from steward_sdk import StewardClient
 
 client = StewardClient(
-    base_url="https://api.steward.fi",
+    base_url="http://localhost:3200",
     platform_key="steward_platform_...",
 )
 
@@ -21,7 +21,7 @@ Steward HMAC request signatures, freshness timestamps, and idempotency keys.
 
 ```python
 client = StewardClient(
-    base_url="https://api.steward.fi",
+    base_url="http://localhost:3200",
     app_id="app_...",
     app_secret="secret_...",
     request_signing_secret="stwd_req_...",

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -19,7 +19,7 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 import { createStewardNativeAuth } from "@stwd/react-native";
 
 const auth = await createStewardNativeAuth({
-  baseUrl: "https://api.steward.fi",
+  baseUrl: "http://localhost:3200",
   tenantId: "my-app",
   storage: AsyncStorage,
 });
@@ -137,7 +137,7 @@ const registration = createNativePushTokenRegistration(expoPushToken, {
 });
 
 const client = createStewardNativeClient({
-  baseUrl: "https://api.steward.fi",
+  baseUrl: "http://localhost:3200",
   bearerToken: auth.getSession()?.token,
 });
 await registerNativePushToken(client, expoPushToken, registration);

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to `@stwd/react` are documented here.
 
 ## Unreleased
 
+### Docs
+- Point example `baseUrl` values in JSDoc (`StewardProvider`, `StewardLogin`) and the README at a self-hosted instance (`http://localhost:3200`) instead of a hosted `api.steward.fi` URL. Steward is self-host-first today; there is no shared hosted API. Docs/comment only, no source behavior change.
+
 ### Tests
 - Added test coverage for utilities (format, theme, walletPanelRegistry), context hooks (useAuth, useSteward), data hooks (useWallet, useTransactions, useApprovals, usePolicies, useSpend), and SSR branch coverage for the component surface (auth guard, user button, tenant picker, spend dashboard, approval queue, wallet overview, policy controls, email/OAuth callbacks, passkey enrollment). Suite goes from 56 to 195 passing. No source changes.
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -16,7 +16,7 @@ import "@stwd/react/styles.css";
 import { StewardClient } from "@stwd/sdk";
 
 const client = new StewardClient({
-  baseUrl: "https://api.steward.fi",
+  baseUrl: "http://localhost:3200",
   bearerToken: agentJwt,
 });
 
@@ -131,7 +131,7 @@ export function EvmLogin() {
     <StewardProvider
       client={client}
       agentId="agent_abc"
-      auth={{ baseUrl: "https://api.steward.fi" }}
+      auth={{ baseUrl: "http://localhost:3200" }}
     >
       <EVMWalletProvider config={wagmiConfig}>
         <WalletLogin chains="evm" />
@@ -240,7 +240,7 @@ import "@solana/wallet-adapter-react-ui/styles.css";
 
 export default function Login() {
   return (
-    <StewardProvider auth={{ baseUrl: "https://api.steward.fi" }}>
+    <StewardProvider auth={{ baseUrl: "http://localhost:3200" }}>
       <StewardLoginWithWallets
         title="sign in"
         showPasskey
@@ -296,7 +296,7 @@ export function SolanaLogin() {
     <StewardProvider
       client={client}
       agentId="agent_abc"
-      auth={{ baseUrl: "https://api.steward.fi" }}
+      auth={{ baseUrl: "http://localhost:3200" }}
     >
       <SolanaWalletProvider
         endpoint="https://api.mainnet-beta.solana.com"
@@ -312,7 +312,7 @@ export function SolanaLogin() {
 ### Combined EVM and Solana example
 
 ```tsx
-<StewardProvider client={client} agentId="agent_abc" auth={{ baseUrl: "https://api.steward.fi" }}>
+<StewardProvider client={client} agentId="agent_abc" auth={{ baseUrl: "http://localhost:3200" }}>
   <EVMWalletProvider config={wagmiConfig}>
     <SolanaWalletProvider endpoint="https://api.mainnet-beta.solana.com">
       <WalletLogin chains="both" onSuccess={(res, kind) => console.log("signed in via", kind)} />

--- a/packages/react/examples/wallet-login.tsx
+++ b/packages/react/examples/wallet-login.tsx
@@ -40,7 +40,7 @@ const wagmiConfig = createDefaultWagmiConfig({
 });
 
 const stewardClient = new StewardClient({
-  baseUrl: "https://api.steward.fi",
+  baseUrl: "http://localhost:3200",
   apiKey: "…",
 });
 
@@ -49,7 +49,7 @@ export function PatternA() {
     <StewardProvider
       client={stewardClient}
       agentId="agent_abc"
-      auth={{ baseUrl: "https://api.steward.fi" }}
+      auth={{ baseUrl: "http://localhost:3200" }}
     >
       <EVMWalletProvider config={wagmiConfig}>
         <SolanaWalletProvider endpoint="https://api.mainnet-beta.solana.com">
@@ -96,7 +96,7 @@ export function PatternB() {
                 <StewardProvider
                   client={stewardClient}
                   agentId="agent_abc"
-                  auth={{ baseUrl: "https://api.steward.fi" }}
+                  auth={{ baseUrl: "http://localhost:3200" }}
                 >
                   <WalletLogin chains="both" />
                 </StewardProvider>
@@ -116,7 +116,7 @@ export function EvmOnly() {
     <StewardProvider
       client={stewardClient}
       agentId="agent_abc"
-      auth={{ baseUrl: "https://api.steward.fi" }}
+      auth={{ baseUrl: "http://localhost:3200" }}
     >
       <EVMWalletProvider config={wagmiConfig}>
         <WalletLogin chains="evm" />

--- a/packages/react/src/components/StewardLogin.tsx
+++ b/packages/react/src/components/StewardLogin.tsx
@@ -150,7 +150,7 @@ function useDynamicWalletPanel(
  *   - Discord OAuth (popup)
  *
  * @example
- * <StewardProvider client={client} agentId="..." auth={{ baseUrl: "https://api.steward.fi" }}>
+ * <StewardProvider client={client} agentId="..." auth={{ baseUrl: "http://localhost:3200" }}>
  *   <StewardLogin
  *     variant="card"
  *     title="welcome back"

--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -55,7 +55,7 @@ export interface StewardProviderWithAuthProps extends StewardProviderProps {
    * <StewardProvider
    *   client={client}
    *   agentId="abc"
-   *   auth={{ baseUrl: "https://api.steward.fi" }}
+   *   auth={{ baseUrl: "http://localhost:3200" }}
    *   tenantId="my-app"
    * >
    *   <App />

--- a/packages/ruby/README.md
+++ b/packages/ruby/README.md
@@ -4,7 +4,7 @@ First-pass Ruby backend SDK for Steward API integrations.
 
 ```ruby
 client = Steward::Client.new(
-  base_url: "https://api.steward.fi",
+  base_url: "http://localhost:3200",
   platform_key: "steward_platform_..."
 )
 

--- a/packages/rust/README.md
+++ b/packages/rust/README.md
@@ -6,7 +6,7 @@ First-pass Rust backend SDK for Steward API integrations.
 use steward_sdk::{Client, Config, CreateUserInput};
 
 let client = Client::new(Config {
-    base_url: "https://api.steward.fi".to_string(),
+    base_url: "http://localhost:3200".to_string(),
     platform_key: Some("steward_platform_...".to_string()),
     ..Config::default()
 })?;

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @stwd/sdk Changelog
 
+## Unreleased
+
+### Docs
+- Point example `baseUrl` values at a self-hosted instance (`http://localhost:3200`) instead of a hosted `api.steward.fi` URL. Steward is self-host-first today; there is no shared hosted API. JSDoc/README/test-fixture only, no runtime or API change (the SDK `baseUrl` remains a required field with no default).
+
 ## 0.10.1
 
 - chainId threaded through SIWE/SIWS sign-in (signInWithSIWE/signInWithSolana accept the connected chain).

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -16,7 +16,8 @@ npm install @stwd/sdk
 import { StewardClient } from '@stwd/sdk';
 
 const steward = new StewardClient({
-  baseUrl: 'https://api.steward.fi',
+  // point this at your self-hosted Steward instance
+  baseUrl: 'http://localhost:3200',
   tenantId: 'my-platform',
   apiKey: 'sk-...',
 });
@@ -50,7 +51,7 @@ new StewardClient(config: StewardClientConfig)
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `baseUrl` | `string` | ✅ | Base URL of the Steward API (e.g. `https://api.steward.fi`) |
+| `baseUrl` | `string` | ✅ | Base URL of your self-hosted Steward API (e.g. `http://localhost:3200`) |
 | `apiKey` | `string` | — | API key sent as `X-Steward-Key` header |
 | `tenantId` | `string` | — | Tenant ID sent as `X-Steward-Tenant` header |
 

--- a/packages/sdk/src/__tests__/auth-oauth.test.ts
+++ b/packages/sdk/src/__tests__/auth-oauth.test.ts
@@ -106,7 +106,7 @@ class TestStorage implements SessionStorage {
 
 // ─── Test Setup ───────────────────────────────────────────────────────────
 
-const BASE_URL = "https://api.steward.fi";
+const BASE_URL = "http://localhost:3200";
 
 let storage: TestStorage;
 let auth: StewardAuth;

--- a/packages/sdk/src/auth-types.ts
+++ b/packages/sdk/src/auth-types.ts
@@ -305,7 +305,7 @@ export interface StewardIdentityTokenResult {
 // ─── Config ───────────────────────────────────────────────────────────────────
 
 export interface StewardAuthConfig {
-  /** Base URL of the Steward API, e.g. "https://api.steward.fi" */
+  /** Base URL of the Steward API, e.g. "http://localhost:3200" for a self-hosted instance */
   baseUrl: string;
   /**
    * Optional storage backend for persisting access and refresh tokens.

--- a/packages/sdk/src/auth.ts
+++ b/packages/sdk/src/auth.ts
@@ -7,7 +7,7 @@
  *   - SIWE (Sign-In With Ethereum) — browser + Node
  *
  * Usage:
- *   const auth = new StewardAuth({ baseUrl: "https://api.steward.fi" });
+ *   const auth = new StewardAuth({ baseUrl: "http://localhost:3200" });
  *   const { token, user } = await auth.signInWithPasskey("me@example.com");
  *   const client = new StewardClient({ baseUrl, bearerToken: auth.getToken() });
  */

--- a/packages/swift/README.md
+++ b/packages/swift/README.md
@@ -4,7 +4,7 @@ First-pass Swift SDK for Steward API integrations.
 
 ```swift
 let client = try StewardClient(config: StewardConfig(
-    baseURL: "https://api.steward.fi",
+    baseURL: "http://localhost:3200",
     platformKey: "steward_platform_..."
 ))
 

--- a/scripts/e2e-auth-test.ts
+++ b/scripts/e2e-auth-test.ts
@@ -10,14 +10,14 @@ import path from "node:path";
  * token refresh, cross-tenant auth, and user endpoint protection.
  *
  * Usage:
- *   STEWARD_URL=https://api.steward.fi \
+ *   STEWARD_URL=http://localhost:3200 \
  *   PLATFORM_KEY=stw_plat... \
  *   bun run scripts/e2e-auth-test.ts
  */
 
 // ─── Config ──────────────────────────────────────────────────────────────────
 
-const STEWARD_URL = (process.env.STEWARD_URL || "https://api.steward.fi").replace(/\/$/, "");
+const STEWARD_URL = (process.env.STEWARD_URL || "http://localhost:3200").replace(/\/$/, "");
 
 function firstNonEmpty(...values: Array<string | null | undefined>): string {
   for (const value of values) {

--- a/scripts/provision-agent.ts
+++ b/scripts/provision-agent.ts
@@ -106,7 +106,7 @@ async function main() {
   console.log("");
   console.log("Set these in Sol's eliza-cloud container env:");
   console.log(`STEWARD_AGENT_ID=${agentId}`);
-  console.log("STEWARD_API_URL=https://api.steward.fi");
+  console.log("STEWARD_API_URL=http://localhost:3200");
   console.log(`STEWARD_TRADE_SESSION_ID=${session.id}`);
   console.log(`STEWARD_JWT=${jwt}`);
   console.log("");

--- a/scripts/run-e2e-smoke.ts
+++ b/scripts/run-e2e-smoke.ts
@@ -4,7 +4,7 @@ import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 
 const skipRequested = process.env.MILADY_SKIP_STEWARD_FI_LIVE_SMOKE?.trim() === "1";
-const stewardUrl = process.env.STEWARD_URL?.trim() || "https://api.steward.fi";
+const stewardUrl = process.env.STEWARD_URL?.trim() || "http://localhost:3200";
 const authSmokeScript = new URL("./e2e-auth-test.ts", import.meta.url);
 
 if (skipRequested) {

--- a/web/src/components/providers.tsx
+++ b/web/src/components/providers.tsx
@@ -3,11 +3,12 @@
 import { StewardProvider, useAuth } from "@stwd/react";
 import { createElement, type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { clearAuthToken, setAuthToken, steward } from "@/lib/api";
+import { STEWARD_API_URL } from "@/lib/steward-api-url";
 
 // Pre-import @simplewebauthn/browser so it's in the client bundle.
 import "@simplewebauthn/browser";
 
-const API_URL = process.env.NEXT_PUBLIC_STEWARD_API_URL || "https://api.steward.fi";
+const API_URL = STEWARD_API_URL;
 
 /**
  * SECURITY (XSS risk — tracked hardening): this wires the Steward auth tokens

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,6 +1,7 @@
 import { StewardClient } from "@stwd/sdk";
+import { STEWARD_API_URL } from "./steward-api-url";
 
-export const API_URL = process.env.NEXT_PUBLIC_STEWARD_API_URL || "https://api.steward.fi";
+export const API_URL = STEWARD_API_URL;
 
 export type GasSponsorshipProvider =
   | "custom_evm_paymaster"

--- a/web/src/lib/steward-api-url.ts
+++ b/web/src/lib/steward-api-url.ts
@@ -1,0 +1,22 @@
+/**
+ * Single source of truth for the dashboard's Steward API origin.
+ *
+ * Steward is self-host-first: there is no shared hosted API. When
+ * `NEXT_PUBLIC_STEWARD_API_URL` is unset (local dev), we fall back to the local
+ * compose profile, which exposes the API on port 3200.
+ *
+ * This module deliberately has NO dependencies (no `@stwd/sdk`, no Next imports)
+ * so it can be consumed by both the client bundle (`lib/api.ts`, providers) and
+ * the edge middleware (`middleware.ts`). Keeping the fallback here ensures the
+ * runtime request origin and the CSP `connect-src` allowlist stay in sync. If
+ * the default changes, both places change together.
+ *
+ * Note on the local-dev default: the plain-http compose API cannot answer https,
+ * so `middleware.ts` recognizes an http loopback API origin and omits
+ * `upgrade-insecure-requests` for it (production sets an https origin via
+ * NEXT_PUBLIC_STEWARD_API_URL, where HTTPS enforcement stays fully on).
+ */
+export const DEFAULT_STEWARD_API_URL = "http://localhost:3200";
+
+/** Resolved Steward API base URL: env override or the self-host default. */
+export const STEWARD_API_URL = process.env.NEXT_PUBLIC_STEWARD_API_URL || DEFAULT_STEWARD_API_URL;

--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -1,5 +1,6 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
+import { STEWARD_API_URL } from "@/lib/steward-api-url";
 
 const SECURITY_HEADERS = [
   ["X-Frame-Options", "DENY"],
@@ -26,18 +27,33 @@ function makeNonce(): string {
   return btoa(String.fromCharCode(...bytes));
 }
 
-function configuredApiOrigin(): string | null {
-  const raw = process.env.NEXT_PUBLIC_STEWARD_API_URL;
-  if (!raw) return null;
+// Resolve the Steward API origin the client will actually call. This uses the
+// SAME resolved base URL as `lib/api.ts` / providers (env override or the
+// self-host default from `lib/steward-api-url.ts`), so the CSP `connect-src`
+// allowlist stays in sync with the request origin.
+function configuredApiUrl(): URL | null {
   try {
-    return new URL(raw).origin;
+    return new URL(STEWARD_API_URL);
   } catch {
     return null;
   }
 }
 
+const LOOPBACK_HOSTNAMES = new Set(["localhost", "127.0.0.1", "[::1]", "::1"]);
+
+// An http origin on a loopback host (the self-host local-dev default,
+// http://localhost:3200) is legitimate and cannot be served over https by the
+// plain-http compose API. Detecting it lets us keep the CSP `connect-src`
+// allowlist correct AND skip `upgrade-insecure-requests` for that origin only,
+// without weakening production (a real deployment sets NEXT_PUBLIC_STEWARD_API_URL
+// to an https origin, so the upgrade stays fully enforced there).
+function isLoopbackHttp(url: URL | null): boolean {
+  return !!url && url.protocol === "http:" && LOOPBACK_HOSTNAMES.has(url.hostname);
+}
+
 function buildCsp(nonce: string): string {
-  const apiOrigin = configuredApiOrigin();
+  const apiUrl = configuredApiUrl();
+  const apiOrigin = apiUrl?.origin ?? null;
   const connectSrc = ["'self'", "https:", "wss:"];
   if (apiOrigin) connectSrc.push(apiOrigin);
 
@@ -54,7 +70,15 @@ function buildCsp(nonce: string): string {
     "base-uri 'self'",
     "form-action 'self'",
   ];
-  if (!ALLOW_INSECURE_HTTP) directives.push("upgrade-insecure-requests");
+  // Keep HTTPS enforcement ON everywhere EXCEPT when the app itself is served
+  // over plain http for local e2e (ALLOW_INSECURE_HTTP) or when the configured
+  // API is an http loopback origin (the self-host local-dev default). In both
+  // cases upgrade-insecure-requests would break same-origin/localhost calls the
+  // plain-http server cannot answer. Production points at an https API origin,
+  // so the upgrade stays fully enforced there.
+  if (!ALLOW_INSECURE_HTTP && !isLoopbackHttp(apiUrl)) {
+    directives.push("upgrade-insecure-requests");
+  }
   return directives.join("; ");
 }
 

--- a/web/wrangler.toml
+++ b/web/wrangler.toml
@@ -25,13 +25,14 @@ custom_domain = true
 [observability]
 enabled = true
 
-# Public build-time var: the dashboard API origin (Steward API on Railway, a
-# separate service). This is the only LIVE origin right now ({"name":"steward"}
-# responds there); it is build-time only and not rendered in any user-facing UI.
+# Public build-time var: the dashboard API origin. This build targets the
+# elizacloud-hosted Steward instance (eliza.steward.fi), which is elizacloud's
+# own self-hosted deployment, not a shared Steward hosted API. It is build-time
+# only and not rendered in any user-facing UI.
 #
-# TODO: move this to a vanity api.steward.fi once that DNS record exists and
-# points at the Railway service. Do not swap the value before then: api.steward.fi
-# has no DNS record yet (the in-code default of https://api.steward.fi is
-# currently dead), so changing it now would break the live dashboard's API calls.
+# NOTE: Steward is self-host-first today; there is no public api.steward.fi
+# hosted API. The in-code fallback default is http://localhost:3200 (the local
+# compose profile). Keep this var pointed at whatever Steward instance this
+# dashboard build should talk to.
 [vars]
 NEXT_PUBLIC_STEWARD_API_URL = "https://eliza.steward.fi"


### PR DESCRIPTION
## Summary

`api.steward.fi` has no DNS record and is not a live hosted API Steward can advertise. `eliza.steward.fi` is elizacloud's own self-hosted Steward instance, not Steward's hosted offering. **Steward is self-host-first today; there is no shared hosted API yet.** This PR removes/reword/genericizes every `api.steward.fi` reference so nothing claims a hosted endpoint a prospect can curl and find dead, and points runnable examples/defaults at a self-host-friendly value.

## Changes by category

**Hosted-API claims removed / reworded (no curl-able dead URL):**
- Removed the "API live" README badge and the dead `api.steward.fi` link (root `README.md`).
- Reworded "hosted instance / trusted testers" prose to "self-host-first, hosted coming soon" with no URL: `docs/quickstart.mdx`, `docs/deployment.md`, `docs/api-reference/overview.mdx`.
- Removed the dead "API Status" health-check topbar link: `docs/mint.json`.

**Runnable examples + curl snippets → self-host default `http://localhost:3200`** (compose profile exposes `:3200`):
- All `docs/**` (api-reference, auth, guides, concepts, sdk).
- SDK + language-binding READMEs: `sdk`, `react`, `react-native`, `android`, `csharp`, `flutter`, `go`, `java`, `python`, `ruby`, `rust`, `swift`, `mcp`; `react/examples/wallet-login.tsx`.

**Self-host-friendly runtime fallback defaults** (were `api.steward.fi`):
- `web/src/lib/api.ts`, `web/src/components/providers.tsx`
- `scripts/e2e-auth-test.ts`, `scripts/run-e2e-smoke.ts`, `scripts/provision-agent.ts`
- `packages/agent-trader` (config comment + `agent-trader.config.example.json` `apiUrl`)

**OpenAPI `servers`:**
- Runtime spec (`packages/api/src/openapi.ts` → `docs/openapi.json`, served by the API at `/openapi.json`) uses a **relative `"/"`** URL so generated clients target the same origin the spec was fetched from (correct for any self-host deployment). Removed the false `"Production"` server entry.
- Mintlify docs copy (`docs/api-reference/openapi.json`) uses an **explicit `http://localhost:3200`** example server, because Mintlify serves it from `docs.steward.fi` and a relative URL would make the playground hit the docs domain. The api docs generator (`packages/api/scripts/generate-openapi.ts`) now overrides `servers` for that copy so it stays reproducible.

**Deploy / self-host recipe genericized:**
- `deploy/nginx.conf` + `deploy/README.md`: vanity domain genericized to `api.example.com` / `proxy.example.com` with an explicit "no shared hosted API yet" note (self-hosters supply their own domain).
- `deploy/DEPLOYMENT.md`: internal node-inventory diagram/table changed to a `<your-domain>` placeholder.

**web/wrangler.toml:** comment refreshed. `NEXT_PUBLIC_STEWARD_API_URL` still targets `eliza.steward.fi` (elizacloud's own self-hosted instance running THIS dashboard, not a shared Steward hosted API); documented that the in-code fallback is now `http://localhost:3200`.

**mcp test fixtures:** use `steward.example.com` (a generic non-localhost host) so the `assertSecureBaseUrl` http-remote-rejection assertions still exercise a remote host.

## SDK/CLI default note

No SDK/CLI had an **actual default baseURL** pointing at `api.steward.fi` (`baseUrl` is a required field, everything else was JSDoc/README/test-fixture). So **no package version bump was warranted on a default-behavior-change basis.** CI enforces a version-bump-or-changelog gate for `packages/{sdk,react,eliza-plugin}`; added `CHANGELOG.md` "Unreleased > Docs" entries for all three (docs/comment/test-fixture only, no runtime API change).

## Web CSP correctness (from review)

Extracted the resolved API base URL to a dependency-free `web/src/lib/steward-api-url.ts` shared by the client bundle **and** the edge middleware, so the CSP `connect-src` allowlist stays in sync with the request origin. Because the self-host default is `http://localhost:3200` and `upgrade-insecure-requests` (on by default) would upgrade it to `https` and break the plain-http compose API, `middleware.ts` now detects an **http loopback API origin** and omits `upgrade-insecure-requests` for that case only. Production points `NEXT_PUBLIC_STEWARD_API_URL` at an https origin, so HTTPS enforcement stays fully on there.

## eliza-plugin live test (from review)

The opt-in live integration suite (`STEWARD_LIVE_TESTS=1`) is now env-configurable (`STEWARD_URL` / `STEWARD_API_KEY` / `STEWARD_TENANT_ID`) with self-host defaults instead of a hardcoded URL + production tenant/key, so it works against a freshly seeded local instance.

## Left untouched (intentional)
- `docs/archive/**` — dated point-in-time records.
- Pre-existing `eliza.steward.fi` refs in `.github/workflows/deploy-web-cloudflare.yml` — elizacloud's own deploy config.

## Validation
- `bun run lint` clean (3 pre-existing warnings in `packages/db`, untouched).
- `bunx tsc --noEmit --project web/tsconfig.json` clean.
- `packages/sdk` (215), `packages/mcp` (49), `packages/api` openapi-contract incl. `docs/openapi.json` sync test (7), eliza-plugin plugin/transfer/integration (23) all pass.
- Pre-existing `submit-trade.test.ts` failure (`vi.stubGlobal` unsupported under bun) is unrelated and reproduces on clean `develop`.
- Reviewed with `codex review` across three rounds; all findings addressed, final review clean.

[sol-orch]
