### PR TITLE
docs: align public claims with shipped capabilities (claims ladder sweep)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,40 @@
 # Steward
 
-Steward is the self-hostable authority plane for private enterprise agents. It gives agents scoped wallet and API capabilities without exposing secrets, routes sensitive actions through policy and human approval, and records execution evidence. Bring your own agent runtime, cloud, and custodian.
+Steward is an open-source, self-hostable governed credential proxy and policy and approval layer for agent provider actions and wallets. It ships scoped grants, exact-request approval, policy-bound execution authorization on the primary EVM sign path, and signed audit evidence verifiable offline. Bring your own agent runtime, cloud, identity provider, and custodian.
 
 [![npm](https://img.shields.io/npm/v/@stwd/sdk)](https://www.npmjs.com/package/@stwd/sdk)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Docs](https://img.shields.io/badge/docs-steward.fi-blue)](https://docs.steward.fi)
 
-## what exists today
+## What exists today
 
-Steward provides encrypted wallet and credential storage, authenticated multi-tenant APIs, policy evaluation and approval workflows, a credential-injecting proxy, operator freeze controls, and an HMAC-chained execution record. Wallet and API capabilities are the core. Trading venue packages are optional extensions.
+Steward provides encrypted wallet and credential storage, authenticated tenant-scoped APIs, policy evaluation and approval workflows, a credential-injecting proxy, operator freeze controls, and signed audit evidence. Wallet and configured provider capabilities are the core. Trading venue packages are optional extensions.
 
 | Area | Current implementation |
 |---|---|
-| **Custody** | Wallet keys are encrypted at rest under an operator-held root. An optional KMS envelope is available, with an adapter seam for third-party custody providers. |
-| **Policy boundary** | Policy is evaluated in API route handlers before governed routes call signing operations. The vault primitive does not independently enforce policy. |
-| **Approvals** | Sensitive actions can be held for human review, then approved or denied through API and UI workflows. |
-| **Execution record** | Steward writes a machine-readable, HMAC-chained audit record. Offline, independently verifiable Ed25519 evidence bundles are roadmap work. |
-| **Deployment** | Self-hosted Docker and embedded PGLite modes are available. Operators bring their own runtime, cloud, and custody configuration. |
+| **Custody** | Wallet keys and credentials are encrypted at rest under an operator-held root. Optional AWS KMS envelope wrapping is available, along with an operator-supplied PKCS#11 wrapping adapter and an external custody interface. Local and KMS envelope modes expose plaintext key material to the application at sign time. |
+| **Scoped grants** | Named provider capabilities can bind an agent grant to a configured host, path, method, credential route, expiry, and revocation state. Grants are tenant-scoped today, not first-class client-workspace grants. |
+| **Policy and approval** | Governed routes evaluate policy before calling signing or proxy operations. Wallet workflows support human approval, and provider capabilities support an exact-request approval and resume flow. |
+| **Execution authorization** | The primary EVM transaction sign path and compatible approval replay require a signed, payload-bound, backend-bound, single-use authorization immediately before raw signing. This boundary does not cover every signing or proxy surface. |
+| **Audit evidence** | Steward writes a tenant-scoped HMAC audit chain and exports Ed25519-signed evidence bundles through `/audit/bundle`. Bundles can be checked offline with `scripts/verify-evidence-bundle.mjs`. The verifier checks the signature against the public key carried in the bundle, so operators must separately compare that key with an out-of-band trusted signing key or fingerprint. An operator controlling all relevant keys can fabricate a self-consistent history. |
+| **Deployment** | Self-hosted Docker and embedded PGLite modes are available. Operators bring their own runtime, cloud, identity, and custody configuration. |
 
-## architecture
+## Architecture
 
 ```text
-agent runtime              Steward authority plane             target systems
+agent runtime           Steward governed paths               target systems
 ┌─────────────┐      ┌────────────────────────────┐      ┌──────────────────┐
-│ scoped token│─────>│ auth + route policy checks │─────>│ chains and APIs  │
-│ no raw keys │      │ approvals                  │      │ custody provider │
-│ no API keys │      │ encrypted wallet/secrets   │      └──────────────────┘
+│ scoped token│─────>│ auth + route policy checks │─────>│ configured APIs  │
+│ no raw keys │      │ exact-request approvals    │      │ chains/custodian │
+│ no API keys │      │ wallet + secret storage    │      └──────────────────┘
 └─────────────┘      │ credential proxy           │
-                     │ HMAC-chained audit record  │
+                     │ signed audit evidence      │
                      └────────────────────────────┘
 ```
 
-## quick start
+Steward's long-term direction is an open authority plane across supported agent execution surfaces. Today, enforcement is surface-specific. Consult the security surface inventory and documentation before treating any path as governed.
+
+## Quick start
 
 ```bash
 npm install @stwd/sdk
@@ -41,31 +44,27 @@ npm install @stwd/sdk
 import { StewardClient } from "@stwd/sdk";
 
 const steward = new StewardClient({
-  // point this at your self-hosted Steward instance (see deploy/docker-compose.yml)
+  // Point this at your self-hosted Steward instance.
   baseUrl: "http://localhost:3200",
   apiKey: "stw_your_tenant_key",
   tenantId: "my-app",
 });
 
-// create an agent with EVM + Solana wallets
-const agent = await steward.createWallet("trading-bot", "Trading Bot");
-console.log(agent.walletAddresses); // { evm: "0x...", solana: "..." }
+const agent = await steward.createWallet("operations-bot", "Operations Bot");
+console.log(agent.walletAddresses);
 
-// request signing through a policy-evaluating API route
-const result = await steward.signTransaction("trading-bot", {
+const result = await steward.signTransaction("operations-bot", {
   to: "0xRecipient",
-  value: "10000000000000000", // 0.01 ETH
-  chainId: 8453, // Base
+  value: "10000000000000000",
+  chainId: 8453,
 });
 ```
 
-see the full [quickstart guide](docs/quickstart.mdx) for auth setup and policies. see the [deployment guide](docs/deployment.md) for self-hosting.
+See the full [quickstart guide](docs/quickstart.mdx) for authentication setup and policies. See the [deployment guide](docs/deployment.md) for self-hosting.
 
----
+## Auth widget
 
-## auth widget
-
-drop-in React components for login and wallet management:
+Install React components for login and wallet management:
 
 ```bash
 npm install @stwd/react @stwd/sdk
@@ -89,126 +88,99 @@ function App() {
 }
 ```
 
-components: `StewardLogin`, `StewardAuthGuard`, `StewardUserButton`, `StewardTenantPicker`, `WalletOverview`, `PolicyControls`, `ApprovalQueue`, `SpendDashboard`, `TransactionHistory`.
+Components include `StewardLogin`, `StewardAuthGuard`, `StewardUserButton`, `StewardTenantPicker`, `WalletOverview`, `PolicyControls`, `ApprovalQueue`, `SpendDashboard`, and `TransactionHistory`.
 
----
+## Packages
 
-## packages
+| Package | Description |
+|---|---|
+| [`@stwd/sdk`](https://www.npmjs.com/package/@stwd/sdk) | TypeScript client for Steward's governed wallet and provider capability APIs. |
+| [`@stwd/react`](https://www.npmjs.com/package/@stwd/react) | React components for Steward authentication, wallets, policies, and approvals. |
+| [`@stwd/eliza-plugin`](https://www.npmjs.com/package/@stwd/eliza-plugin) | ElizaOS integration for Steward-scoped wallet and provider capabilities. |
+| [`@stwd/mcp`](https://www.npmjs.com/package/@stwd/mcp) | MCP tools for invoking Steward-authorized wallet and provider capabilities. |
+| `@stwd/api` | Steward authorization, approval, execution, and evidence API. |
+| `@stwd/vault` | Local and pluggable wallet-key storage and signing primitives. Policy enforcement is provided by governed execution paths. |
+| `@stwd/policy-engine` | Composable policy decisions for scoped provider capabilities and wallet actions. |
+| `@stwd/proxy` | Credential-injecting proxy for configured routes. |
 
-| package | version | description |
-|---|---|---|
-| [`@stwd/sdk`](https://www.npmjs.com/package/@stwd/sdk) | ![npm](https://img.shields.io/npm/v/@stwd/sdk) | TypeScript client for browser + Node. zero deps. |
-| [`@stwd/react`](https://www.npmjs.com/package/@stwd/react) | ![npm](https://img.shields.io/npm/v/@stwd/react) | drop-in React components: login, wallet, policies, approvals. |
-| [`@stwd/eliza-plugin`](https://www.npmjs.com/package/@stwd/eliza-plugin) | ![npm](https://img.shields.io/npm/v/@stwd/eliza-plugin) | ELIZA OS integration: sign, transfer, balance, approval evaluator. |
-| `@stwd/api` | internal | Hono REST API. 30+ endpoints, multi-tenant, dual auth. |
-| `@stwd/vault` | internal | wallet + secret encryption. AES-256-GCM, EVM + Solana. |
-| `@stwd/policy-engine` | internal | composable policy evaluation. 6 rule types, 1000+ lines of tests. |
-| `@stwd/proxy` | internal | API proxy with credential injection, alias system, audit trail. |
-| `@stwd/auth` | internal | passkeys (WebAuthn), email magic links, SIWE, OAuth. |
-| `@stwd/webhooks` | internal | HMAC-signed event delivery with retries. |
-| `@stwd/db` | internal | Drizzle ORM schema, migrations, PGLite adapter. |
-| `@stwd/shared` | internal | types, chain metadata, constants. |
+## Self-hosting
 
----
-
-## self-hosting
-
-Steward runs anywhere. two options:
-
-**docker (recommended for production):**
+### Docker
 
 ```bash
 git clone https://github.com/Steward-Fi/steward.git && cd steward
 cp .env.example .env
-# set STEWARD_MASTER_PASSWORD, POSTGRES_PASSWORD, STEWARD_PLATFORM_KEYS,
-# STEWARD_SESSION_SECRET, and STEWARD_JWT_SECRET in .env
+# Set STEWARD_MASTER_PASSWORD, POSTGRES_PASSWORD, STEWARD_PLATFORM_KEYS,
+# STEWARD_SESSION_SECRET, and STEWARD_JWT_SECRET in .env.
 docker compose up -d
 curl http://127.0.0.1:3200/ready
 ```
 
-starts the API (`:3200`), proxy (`:8080`), Postgres, and Redis. API migrations run automatically on startup unless `SKIP_MIGRATIONS` is set.
+This starts the API on port 3200, the proxy on port 8080, PostgreSQL, and Redis. API migrations run automatically on startup unless `SKIP_MIGRATIONS` is set.
 
-**embedded mode (no third-party dependencies):**
+### Embedded mode
 
 ```bash
 bun run start:local
 ```
 
-uses PGLite (in-process Postgres via WASM). data persists to `~/.steward/data/`. good for local development, CLI agents, and desktop apps.
+Embedded mode uses PGLite, an in-process PostgreSQL-compatible database through WASM. Data persists to `~/.steward/data/`. It is intended for local development, CLI agents, and desktop apps.
 
-**required env vars:**
+### Required environment variables
 
-| variable | description |
+| Variable | Description |
 |---|---|
-| `STEWARD_MASTER_PASSWORD` | derives all vault encryption keys. **no recovery if lost.** |
-| `DATABASE_URL` | Postgres connection string (not needed in embedded mode) |
-| `STEWARD_SESSION_SECRET` | JWT signing secret (defaults to master password) |
-| `REDIS_URL` | Redis for rate limiting + token store (optional) |
-| `RESEND_API_KEY` | for email magic link auth (optional) |
-| `PASSKEY_RP_ID` | WebAuthn relying party domain (optional) |
-| `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | Google OAuth (optional) |
-| `DISCORD_CLIENT_ID` / `DISCORD_CLIENT_SECRET` | Discord OAuth (optional) |
+| `STEWARD_MASTER_PASSWORD` | Derives vault encryption keys. There is no recovery if it is lost. |
+| `DATABASE_URL` | PostgreSQL connection string, not needed in embedded mode. |
+| `STEWARD_SESSION_SECRET` | JWT signing secret, defaults to the master password. |
+| `REDIS_URL` | Redis for rate limiting and the token store, optional. |
+| `RESEND_API_KEY` | Email magic-link authentication, optional. |
+| `PASSKEY_RP_ID` | WebAuthn relying-party domain, optional. |
+| `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | Google OAuth, optional. |
+| `DISCORD_CLIENT_ID` / `DISCORD_CLIENT_SECRET` | Discord OAuth, optional. |
 
-full list in [`.env.example`](.env.example). see [deployment guide](docs/deployment.md) for production setup.
+See [`.env.example`](.env.example) for the full list.
 
----
+## Shipped capabilities
 
-## features
+- **Credential proxy:** configured routes inject provider credentials server-side without returning them to the supported agent caller.
+- **Scoped grants:** named capabilities support per-agent grants, expiry, revocation, argument constraints, and rate constraints.
+- **Wallet policy and approval:** supported wallet routes evaluate policy and can hold an exact request for human review.
+- **Primary EVM execution authorization:** the primary EVM transaction sign path uses a signed, short-lived, single-use execution authorization immediately before raw signing.
+- **Signed audit evidence:** tenant-scoped HMAC chaining, Ed25519 checkpoints, bundle export, and an offline verifier.
+- **Encrypted custody:** local AES encryption, optional AWS KMS envelope wrapping, a PKCS#11 wrapping adapter, and an external-custody interface.
+- **Authentication:** passkeys, email magic links, SIWE, Google OAuth, and Discord OAuth.
+- **SDKs and integrations:** TypeScript SDK, React components, ElizaOS plugin, and MCP server.
+- **Self-hosting:** Docker with PostgreSQL and Redis, plus embedded PGLite mode.
 
-- [x] **vault**: AES-256-GCM encrypted wallets, EVM (7 chains) + Solana
-- [x] **policy engine**: 6 composable types (spending-limit, approved-addresses, rate-limit, time-window, auto-approve-threshold, allowed-chains)
-- [x] **auth**: passkeys (WebAuthn), email magic links, SIWE, Google OAuth, Discord OAuth
-- [x] **JWT sessions**: access + refresh token rotation, revoke single/all sessions
-- [x] **cross-tenant identity**: one user, one wallet, multiple apps
-- [x] **multi-tenant API**: full tenant isolation at middleware + DB level
-- [x] **proxy gateway**: credential injection, alias system, spend tracking, audit trail
-- [x] **React components**: login widget, wallet overview, policy controls, approval queue
-- [x] **TypeScript SDK**: typed client, browser + Node, all wallet/policy/auth ops
-- [x] **ELIZA OS plugin**: sign, transfer, balance, approval evaluator
-- [x] **embedded mode**: PGLite, zero third-party dependencies, same API surface
-- [x] **docker**: multi-stage Dockerfile, docker-compose with Postgres + Redis
-- [x] **webhooks**: HMAC-signed events (tx.signed, tx.pending, policy.violation, etc.)
-- [x] **per-tenant CORS**: configurable allowed origins per tenant
+## Scope and trust limits
 
----
+- Steward governs configured routes and supported signing paths. It does not govern arbitrary agent network egress or every action in the product.
+- The primary EVM sign path has the shipped execution authorization boundary. Other wallet and proxy paths have their own documented boundaries.
+- Steward does not claim MPC custody, native HSM signing, non-custodial operation, or that keys never enter application memory.
+- Evidence bundles are tamper-evident after the bundled public key is separately matched to a trusted signing key or fingerprint. They are not operator-proof when the operator controls the audit and signing keys.
+- Steward does not prove that a policy-allowed action is semantically legitimate or safe from prompt injection.
 
-## what Steward offers
+## Supported wallet networks
 
-- **open source.** MIT licensed, full source available.
-- **self-hostable.** docker, embedded PGLite, or hosted.
-- **full auth surface.** passkey / email / SIWE / OAuth.
-- **policy evaluation in governed API routes.** 6 composable rule types are evaluated before those routes call the vault. The vault primitive is not an independent policy boundary.
-- **agent-native.** built from day one for autonomous operation: approval queues, audit log, kill-switch.
-- **credential proxy.** inject keys for any third-party API. agents never see raw secrets.
+Wallet primitives support Ethereum, Base, Polygon, Arbitrum, BSC, Gnosis, Base Sepolia, BSC Testnet, Solana, Bitcoin, and Monero. Support differs by route, operation, custody backend, and deployment. This list is not a claim that every network shares the primary EVM execution authorization boundary.
 
----
+## Integrations
 
-## supported chains
+- [ElizaOS](https://elizaos.ai) through [`@stwd/eliza-plugin`](https://www.npmjs.com/package/@stwd/eliza-plugin)
+- wagmi v2 and v3, with a MetaMask Connect EVM connector
+- Model Context Protocol server for AI agents and IDEs
 
-Ethereum, Base, Polygon, Arbitrum, BSC, Gnosis, Base Sepolia, BSC Testnet, Solana, Bitcoin,
-Monero (self-hosted deployments; official `monero-wallet-rpc` sidecar against remote public
-nodes: keys never leave your host, policy evaluated by the relay route)
+## Contributing
 
----
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, coding standards, and pull-request guidelines.
 
-## integrations
+## Links
 
-- [ElizaOS](https://elizaos.ai) (via [`@stwd/eliza-plugin`](https://www.npmjs.com/package/@stwd/eliza-plugin))
-- wagmi v2 and v3, with a first-class MetaMask Connect (EVM) connector
-- Model Context Protocol (MCP) server for AI agents and IDEs
-
----
-
-## contributing
-
-see [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, coding standards, and PR guidelines.
-
-## links
-
-- website: [steward.fi](https://steward.fi)
-- docs: [docs.steward.fi](https://docs.steward.fi)
+- Website: [steward.fi](https://steward.fi)
+- Docs: [docs.steward.fi](https://docs.steward.fi)
 - npm: [@stwd/sdk](https://www.npmjs.com/package/@stwd/sdk), [@stwd/react](https://www.npmjs.com/package/@stwd/react), [@stwd/eliza-plugin](https://www.npmjs.com/package/@stwd/eliza-plugin)
 
-## license
+## License
 
 [MIT](LICENSE)

--- a/VISION.md
+++ b/VISION.md
@@ -1,101 +1,88 @@
 # Steward Vision
 
-Steward is the self-hostable authority plane for private enterprise agents. It gives agents scoped wallet and API capabilities without exposing secrets, routes sensitive actions through policy and human approval, and records execution evidence. Bring your own agent runtime, cloud, and custodian.
+Steward is an open-source, self-hostable governed credential proxy and policy and approval layer for agent provider actions and wallets. It ships scoped grants, exact-request approval, policy-bound execution authorization on the primary EVM sign path, and signed audit evidence verifiable offline.
 
 ## Mission
 
-Every agent deserves scoped authority without direct access to the underlying secrets.
+Agents should receive narrowly scoped authority without receiving the underlying provider credential or wallet key.
 
-AI agents are managing real money, signing real transactions, calling paid APIs. The infrastructure securing those operations is a `.env` file with plaintext keys. One prompt injection, one leaked log, one compromised dependency, and everything is gone.
+Agents increasingly sign transactions and call private APIs. Giving an agent a standing secret expands the blast radius of prompt injection, compromised dependencies, and leaked logs. Steward reduces that exposure through configured credential routes, scoped capability grants, wallet policy and approval workflows, and evidence that operators can export and verify outside the running service.
 
-Steward reduces exposure by combining encrypted vaults, policy evaluation in API route handlers before signing, and credential isolation at the proxy layer. Agents operate within constraints their operators define. A signer-level authorization boundary is on the roadmap.
+Steward's direction is an open authority plane for agent execution. That is an architectural goal, not a claim that every action or execution surface is governed today.
 
----
+## Current product boundary
 
-## Architecture
+Steward currently provides these distinct boundaries:
 
-Four pillars. Each solves a distinct problem. Together they form a complete security and auth layer for any agent platform.
+### Credential proxy
 
-### Vault
-AES-256-GCM encrypted key storage. Per-agent encryption keys derived from master password + agent ID via PBKDF2. Private keys are decrypted ephemerally for signing and never returned to callers. Supports EVM (7 chains) and Solana (Ed25519).
+Configured provider calls can receive a stored credential at the proxy instead of in the supported agent process. Capability definitions bind host, path, method, injection settings, and a per-agent grant with expiry and revocation. The proxy does not govern arbitrary network egress.
 
-### Policy Engine
-Composable rules evaluated synchronously by Steward API routes before they call the vault for governed signing operations. Six types: spending limits (per-tx, daily, weekly), approved address lists, rate limits, time windows, auto-approve thresholds, and allowed chains. Hard policies reject. Soft policies (auto-approve-threshold) queue for human review. A failed policy evaluation stops the governed API request before signing. The engine is stateless; spend and rate context are pre-fetched and injected.
+### Wallet vault
 
-### Auth
-User authentication with passkeys (WebAuthn), email magic links, Sign-In With Ethereum, and OAuth (Google, Discord). JWT sessions with refresh token rotation. Users are global identities that can belong to multiple tenants. On first login, users get an auto-provisioned embedded wallet.
+Local wallet keys are encrypted with AES-256-GCM. Optional AWS KMS envelope wrapping, an operator-supplied PKCS#11 wrapping adapter, and an external-custody interface are available. Local and KMS envelope modes expose plaintext key material to the application at sign time. Steward does not claim MPC custody or native HSM signing.
 
-### Proxy Gateway
-Sits between agents and any third-party API (OpenAI, exchanges, RPC providers). Agents send requests to the proxy. Steward authenticates the agent, decrypts the right credential from the vault, injects it into the outbound request, and streams the response back. The agent never touches the raw key. Full audit trail, rate limiting, and spend tracking on every call.
+### Policy and approval
 
----
+Governed API routes evaluate policy before calling their signing or proxy operation. Wallet workflows support approval queues, generic intents, recent-MFA controls, and stale-state checks. Provider capabilities support exact-request approval and resume. Coverage is route-specific and must not be inferred for an unlisted surface.
+
+### Primary EVM execution authorization
+
+The primary EVM transaction sign path and compatible approval replay require a signed, payload-bound, backend-bound, short-lived, single-use authorization immediately before raw signing. This is an earned enforcement claim for that path, not a product-wide signing claim.
+
+### Audit evidence
+
+Steward maintains a tenant-scoped HMAC audit chain and can export Ed25519-signed checkpoints and event bundles. The standalone verifier checks bundles offline against the public key carried in the bundle. Operators must separately match that key to an out-of-band trusted Steward signing key or fingerprint. This detects modification relative to that trust root, but it cannot exclude fabrication by an operator controlling all relevant keys.
+
+## Product direction
+
+The long-term authority plane should answer:
+
+> May this principal perform this exact action, against this scoped resource, using this credential or wallet, under the applicable policy and approval, right now?
+
+Reaching that direction requires explicit enrollment and tests for each claimed execution surface. A broad authority-plane claim is earned only when materially different adapters share a governed boundary, alternate paths are closed for the claimed surfaces, and a real deployment proves the operating model.
+
+Near-term work should deepen the current open and self-hosted product:
+
+- make scoped provider grants and exact-request approvals easier to configure;
+- extend execution authorization only through explicit, tested surface enrollment;
+- keep the credential, policy, approval, execution, and evidence contracts inspectable;
+- publish precise support matrices and trust limits;
+- improve self-hosted deployment, backup, restore, rotation, and monitoring guidance;
+- integrate external identity, secrets, and custody systems without replacing them.
 
 ## Positioning
 
-The agent wallet market has fragmented into closed platforms and low-level primitives. Nobody occupies the quadrant Steward targets:
+Steward is not trying to replace an enterprise directory, a generic authorization engine, a secrets manager, or a specialist custody vendor.
 
-**High abstraction + open source + self-hostable.**
+- Identity systems establish who the human or agent is.
+- Authorization engines can contribute allow or deny decisions.
+- Secrets managers and custody systems protect secret or key material.
+- Steward connects scoped agent authority, policy, approval, governed execution paths, and exportable evidence for its supported surfaces.
 
-Six capabilities define the space. Most platforms cover two or three:
+The open-source and self-hostable ethos is part of the security model. Operators can inspect the enforcement code, run the full stack in their own infrastructure, export their data and evidence, and choose their runtime, cloud, identity provider, secrets system, and custodian.
 
-| Capability | What it means |
-|---|---|
-| **Open source** | Audit the code. Fork it. No black boxes. |
-| **Self-hostable** | Run it on your infra. No vendor dependency. No token required. |
-| **Auth** | User login (passkeys, email, OAuth, SIWE). Not just API keys. |
-| **Policy evaluation** | Rules evaluated in Steward API signing routes before the vault is called. |
-| **Agent-native** | Built for autonomous operation, not retrofitted from consumer auth. |
-| **Credential proxy** | Manages all sensitive credentials, not just wallet keys. |
+## Deployment
 
-Steward checks all six. Existing platforms each miss critical boxes: most are closed and hosted-only, depend on an external MPC network, lack auth or policy enforcement, or expose only low-level signing primitives without auth, policies, or a credential proxy.
+Steward ships two self-hosted modes:
 
----
+- **Docker:** API, proxy, PostgreSQL, and Redis for a networked deployment.
+- **Embedded:** PGLite for local development, CLI agents, and desktop applications.
 
-## Two Deployment Modes
-
-**Hosted** (steward.fi / your cloud): Multi-tenant, production-grade. Drop-in replacement for closed embedded-wallet platforms. Your app is a tenant. Zero infra overhead.
-
-**Embedded** (PGLite): Local-first, runs in-process. Same vault, same policies, same SDK. For desktop apps, CLI agents, self-hosted deployments. No third-party database, no network dependency.
-
-Same API surface. Same guarantees. Write the integration once.
-
----
-
-## Roadmap
-
-### Shipped
-- Vault with AES-256-GCM encryption, EVM + Solana
-- Policy engine with 6 composable rule types
-- Multi-tenant API with full tenant isolation
-- Auth: passkeys, email magic links, SIWE, Google OAuth, Discord OAuth
-- JWT sessions with refresh token rotation
-- Cross-tenant user identity
-- TypeScript SDK (`@stwd/sdk`)
-- React components (`@stwd/react`): login, wallet, policies, approvals
-- ElizaOS plugin (`@stwd/eliza-plugin`)
-- Proxy gateway with credential injection
-- Embedded mode (PGLite)
-- Production Docker setup (API + proxy + Postgres + Redis)
-- Webhook system with HMAC-signed delivery
-
-### Next
-- Milady Cloud integration as auth + wallet layer
-- Dashboard self-service (tenant creation, policy configuration, API key management)
-- Production hardening (security audit, token store persistence, monitoring)
-- Babylon integration
-- Pluggable key storage backends (AWS KMS, Hashicorp Vault)
-- Strata Reserve deployment
-
----
+The modes share much of the API surface, but their operating and security properties differ. Operators should select and test a deployment profile appropriate to their threat model.
 
 ## Values
 
-**Open source.** MIT license. The code is the documentation. If you don't trust it, read it.
+**Open source.** Steward is MIT licensed. Trust-critical contracts and the offline verifier remain inspectable.
 
-**Developer-first.** `npm install @stwd/sdk` and you're building. No sales calls, no onboarding decks, no "contact us for pricing."
+**Self-hostable.** Steward runs in operator-controlled infrastructure. Public documentation does not depend on a managed control plane.
 
-**No vendor lock-in.** Self-host the entire stack. Export your data. Switch providers. Your keys, your infra, your choice.
+**Scoped by default.** Provider capabilities and wallet operations should be bounded to the smallest practical route, action, lifetime, and principal.
 
-**No token required.** Steward is infrastructure, not a protocol. No governance token, no staking requirement, no on-chain dependency for basic operations.
+**Approval binds the request.** Human review should authorize an exact immutable request, not a reusable blanket permission.
 
-**Policy is first-class.** Steward API signing routes evaluate policies before calling the vault, and a failed evaluation stops that request before key decryption. Moving authorization into a signer-level boundary is a roadmap item.
+**Enforcement claims are surface-specific.** A governed path may claim only the boundary implemented and tested on that path.
+
+**Evidence is portable.** Operators can export signed evidence, verify it offline, and separately match the bundled public key to a trusted signing key or fingerprint.
+
+**Trust limits are explicit.** Steward does not imply MPC, native HSM signing, operator-proof logs, prompt-injection immunity, or universal action coverage where those properties are not implemented.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Steward
 
-**Steward is a governance layer for autonomous AI agents.** It provides encrypted wallet management, route-level policy gates, secret storage, credential injection, and embeddable React UI, so agents can transact on-chain and call external APIs without ever touching raw private keys or credentials.
+**Steward is an open-source, self-hostable governed credential proxy and policy and approval layer for agent provider actions and wallets.** Supported integrations use scoped grants and configured routes instead of receiving provider credentials directly. The primary EVM transaction sign path adds a signed, single-use execution authorization before raw signing.
 
 ## What It Does
 
@@ -34,9 +34,9 @@ Supported transactions and API calls flow through Steward routes, where they are
 
 | Primitive | What it does |
 |-----------|-------------|
-| **Wallet Vault** | AES-256-GCM encrypted key storage. Creates EVM + Solana keypairs per agent. Agents request signatures; private keys never leave the vault. |
+| **Wallet Vault** | AES-256-GCM encrypted key storage for EVM and Solana keypairs. Governed API routes request signatures without returning private keys to the caller. |
 | **Policy Engine** | Declarative rules evaluated by supported signing routes before Vault calls: spending limits, address whitelists, rate limits, time windows, chain filters, auto-approve thresholds. |
-| **Secret Vault** | Encrypted credential storage. The proxy injects secrets at request time; agents never see the raw values. |
+| **Secret Vault** | Encrypted credential storage. Configured proxy routes inject secrets server-side instead of returning them to the supported agent caller. |
 | **API Proxy** | Routes agent HTTP calls through Steward for credential injection, cost tracking, and audit logging. |
 | **Approval Queue** | Large or unusual transactions queue for human review before execution. |
 | **Webhooks** | Push notifications on `tx.pending`, `tx.signed`, `tx.approved`, `tx.denied`, `policy.violation`, `spend.threshold`. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,7 +49,7 @@ Supported transactions and API calls flow through Steward routes, where they are
 bun run start:local
 ```
 
-**Hosted** — Backed by PostgreSQL, optional Redis for rate limiting and spend tracking. For production multi-tenant deployments.
+**PostgreSQL** — Backed by PostgreSQL, optional Redis for rate limiting and spend tracking. For self-hosted production deployments that need a durable third-party database.
 
 ```bash
 docker compose up -d

--- a/docs/adrs/0002-runtime-choice.mdx
+++ b/docs/adrs/0002-runtime-choice.mdx
@@ -71,7 +71,7 @@ All routes in `packages/api/src/routes/*.ts` are Hono handlers. The proxy
 - **Edge-ready.** Hono's core is a small request/response router that
   compiles to Bun, Node, Cloudflare Workers, Deno, and Vercel Edge without
   code changes. We do not currently deploy to edge targets, but a future
-  hosted tier might (e.g. per-region proxy shards). Hono keeps that door
+  large self-hosted deployment might, such as per-region proxy shards. Hono keeps that door
   open. Express would not.
 - **Small footprint.** No dep tree. Install size under 100 KB. The whole
   framework is ~2000 lines of readable TypeScript.

--- a/docs/adrs/0003-deployment-model.mdx
+++ b/docs/adrs/0003-deployment-model.mdx
@@ -152,9 +152,6 @@ them into an init container.
 - **Future:**
   - **Helm chart / k8s manifests** for users who have already made the
     k8s bet.
-  - **Managed hosted tier** (`steward.fi`) — multi-tenant, Steward runs
-    the infra. Same packages, same Compose-shaped topology under the
-    hood, just operated for you.
 
 ## Related
 

--- a/docs/adrs/0004-policy-enforcement-model.mdx
+++ b/docs/adrs/0004-policy-enforcement-model.mdx
@@ -58,8 +58,11 @@ operations in production:
    API from within the monorepo. It is not published with an interface
    that encourages direct calls from outside the API.
 
-Combined, that means a **non-compromised API process enforces every
-policy on every signing call**, and this is the boundary we claim.
+This describes the original route-level boundary. The current primary EVM
+transaction sign path and compatible approval replay also require a signed,
+payload-bound, backend-bound, single-use execution authorization before raw
+signing. Other signing and proxy surfaces retain their documented,
+route-specific boundaries.
 
 ### What this does NOT protect against
 
@@ -94,8 +97,8 @@ Be explicit:
   typos and wrong chains.
 
 These are real wins. The overclaim is not "policies work" — they do —
-it's "policies are cryptographically impossible to bypass," which is
-not true of the v1 architecture.
+it's an unqualified product-wide enforcement claim. The stronger execution
+authorization boundary is earned only for the enrolled primary EVM sign path.
 
 ## Decision (future direction, sketched)
 

--- a/docs/api-reference/audits.mdx
+++ b/docs/api-reference/audits.mdx
@@ -137,6 +137,28 @@ Responses include page/limit pagination metadata:
 Use `page` and `limit` for incremental review. Large exports should use the
 bounded audit export endpoint instead of walking unbounded event pages.
 
+## Signed evidence bundles
+
+```bash
+GET /audit/bundle
+```
+
+When `STEWARD_AUDIT_SIGNING_KEY` is configured, this endpoint exports a bounded
+event range with an Ed25519-signed checkpoint over the tenant audit-chain head.
+The repository includes an offline verifier:
+
+```bash
+node scripts/verify-evidence-bundle.mjs bundle.json
+```
+
+The verifier checks the signature against the public key carried in the bundle.
+Separately compare that key with an out-of-band trusted Steward signing key or
+fingerprint. After that trust-root check, a valid bundle shows that its exported
+content matches the signed checkpoint. It does not prove that an operator who
+controls all relevant audit and signing keys could not fabricate a
+self-consistent history. A partial export also does not prove completeness
+outside the exported range.
+
 ## Common Filters
 
 | Use case | Query |

--- a/docs/api-reference/overview.mdx
+++ b/docs/api-reference/overview.mdx
@@ -9,13 +9,13 @@ The Steward API is a REST API built with [Hono](https://hono.dev) running on [Bu
 
 ## Base URL
 
-Steward is self-host-first today. Point the SDK and all requests at your own deployment. The default local compose profile exposes the API on port 3200:
+Steward is self-hosted. Point the SDK and all requests at your own deployment. The default local Compose profile exposes the API on port 3200:
 
 ```
 http://localhost:3200
 ```
 
-Replace this with your deployment's URL when running behind your own domain and TLS. A managed hosted API is coming soon.
+Replace this with your deployment's URL when running behind your own domain and TLS.
 
 ## Authentication
 

--- a/docs/concepts/architecture.mdx
+++ b/docs/concepts/architecture.mdx
@@ -5,19 +5,19 @@ description: "How Steward's three pillars work together to secure autonomous age
 
 # Architecture
 
-Steward is the single chokepoint between an AI agent and the outside world. Every API call, every transaction, every secret access flows through Steward, gets policy-checked, gets logged, gets metered.
+Steward provides governed paths for configured agent provider calls and wallet operations. Only requests routed through supported Steward integrations receive these checks and audit events. Arbitrary agent network egress remains outside the boundary.
 
 ## Three Pillars
 
 <CardGroup cols={3}>
   <Card title="Wallet Vault" icon="vault">
-    Encrypted key storage with policy-enforced signing. Agents never see private keys.
+    Encrypted key storage for supported signing paths. Governed routes apply policy before signing.
   </Card>
   <Card title="Secret Vault" icon="key">
-    Encrypted credential storage with an API proxy. Agents never see API keys.
+    Encrypted credential storage with injection on configured proxy routes.
   </Card>
   <Card title="Policy Engine" icon="shield-check">
-    Declarative policy evaluation on every action. Default deny.
+    Declarative policy evaluation on enrolled, governed actions. Default deny.
   </Card>
 </CardGroup>
 

--- a/docs/concepts/architecture.mdx
+++ b/docs/concepts/architecture.mdx
@@ -115,7 +115,7 @@ sequenceDiagram
 
 Steward currently supports two database modes:
 
-- **Hosted/PostgreSQL mode** — API and proxy processes connect to PostgreSQL using `DATABASE_URL`. This is what Docker Compose and production-style deployments use.
+- **PostgreSQL mode** — API and proxy processes connect to PostgreSQL using `DATABASE_URL`. This is what Docker Compose and durable self-hosted deployments use.
 - **Embedded/PGLite mode** — `bun run start:local` runs the API against PGLite, persisted at `~/.steward/data` unless `STEWARD_PGLITE_MEMORY=true` is set. This is intended for local development, desktop sidecars, and tests.
 
 ## Deployment Topology
@@ -173,7 +173,7 @@ flowchart LR
     TK2 --> W2
 ```
 
-- **Tenants** are isolated at the database level — each tenant's agents, secrets, and policies are scoped
+- **Tenants** are isolated at the service layer: every tenant-scoped query filters on `tenantId` and rows carry a composite foreign key to their tenant. This is not database row-level security (RLS is not implemented).
 - **Agents** authenticate with JWTs scoped to their tenant and agent ID
 - **Secrets** are encrypted with per-tenant encryption keys (key hierarchy: master → tenant → secret)
 - **Policies** are evaluated per-agent within their tenant context

--- a/docs/concepts/audit-logging.mdx
+++ b/docs/concepts/audit-logging.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Audit Logging"
-description: "Immutable audit trail for every agent action — compliance, debugging, and cost tracking."
+description: "Tamper-evident audit records and signed evidence exports for instrumented Steward actions."
 ---
 
-# Audit Logging
+# Audit logging
 
-Every action in Steward is logged: every signing request, every API proxy call, every policy decision, every credential access. The audit log is append-only, queryable, and exportable.
+Instrumented Steward routes emit queryable and exportable audit events for signing, proxy, policy, credential, and approval activity. Coverage is route-specific. The tenant-scoped HMAC chain and Ed25519 checkpoints make exported evidence tamper-evident after the bundled public key is separately matched to a trusted signing key or fingerprint.
 
 ## What's Logged
 
@@ -153,10 +153,10 @@ Webhook events:
 
 Steward's audit log supports compliance requirements:
 
-- **Immutability** — Append-only log; entries cannot be modified or deleted
-- **Retention** — Configurable per-tenant (default: 90 days hot storage)
-- **Export** — API endpoint for bulk export (CSV/JSON)
-- **Partitioning** — Monthly partitioned tables for query performance at scale
+- **Tamper evidence**: HMAC-linked events and Ed25519-signed checkpoints expose modification after the bundled public key is separately matched to a trusted signing key or fingerprint
+- **Retention**: configurable per tenant
+- **Export**: API endpoints for event export and signed evidence bundles
+- **Trust limit**: an operator controlling all relevant keys can fabricate a self-consistent history
 
 ## Related
 

--- a/docs/concepts/policy-engine.mdx
+++ b/docs/concepts/policy-engine.mdx
@@ -1,18 +1,18 @@
 ---
 title: "Policy Engine"
-description: "Declarative policy evaluation on every agent action — default deny, composable rules."
+description: "Declarative policy evaluation for governed wallet routes and named provider capabilities."
 ---
 
 # Policy Engine
 
-The Policy Engine evaluates declarative policies before every agent action. It enforces **default deny** — if no policy explicitly allows an action, it's rejected.
+The Policy Engine evaluates declarative policies on governed wallet routes and named provider capability invocations. Those paths use default deny when no applicable policy allows the request. Policy coverage is route-specific.
 
 ## Design Principles
 
 - **Default deny** — new agents can't do anything until policies are assigned
 - **Declarative** — JSON-based policy definitions, no custom DSL to learn
 - **Composable** — multiple policies evaluated in order; ALL must pass
-- **Fast** — < 5ms evaluation, cached in Redis
+- **Cache-aware**: policy context can be cached in Redis
 
 ## Policy Types
 

--- a/docs/concepts/proxy-gateway.mdx
+++ b/docs/concepts/proxy-gateway.mdx
@@ -62,7 +62,7 @@ The proxy supports two routing modes:
     → https://api.custom-service.com/v2/endpoint
     ```
 
-    Any API with a configured [credential route](/api-reference/routes) can be proxied this way.
+    An API operation with a compatible configured [credential route](/api-reference/routes) can be proxied this way. Steward does not govern arbitrary agent network egress.
   </Tab>
 </Tabs>
 

--- a/docs/concepts/secret-vault.mdx
+++ b/docs/concepts/secret-vault.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Secret Vault"
-description: "Encrypted credential storage with automatic injection — agents never see API keys."
+description: "Encrypted credential storage with server-side injection on configured proxy routes."
 ---
 
 # Secret Vault
 
-The Secret Vault stores encrypted API credentials and injects them into outbound requests through the [Proxy Gateway](/concepts/proxy-gateway). Agents never see real API keys.
+The Secret Vault stores encrypted API credentials and injects them into configured outbound requests through the [Proxy Gateway](/concepts/proxy-gateway). Supported agent callers receive the provider response, not the stored credential. Steward does not restrict arbitrary egress outside configured routes.
 
 ## How It Works
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -131,7 +131,7 @@ Configure the Railway service with the normal production environment plus Railwa
 
 Run the proxy as a separate Railway service/process using the same image and command `bun run packages/proxy/src/index.ts`, with `STEWARD_PROXY_PORT` set to the port Railway expects for that service.
 
-A managed hosted API is not available yet. Steward is self-host-first today: run your own instance (see the Docker/compose steps above) and point clients at your deployment URL. A hosted offering is coming soon.
+Steward is self-hosted. Run your own instance with the Docker and Compose steps above, then point clients at that deployment URL.
 
 ### Automated Railway deploys via GitHub Actions (optional)
 

--- a/docs/erc8004-integration.md
+++ b/docs/erc8004-integration.md
@@ -13,7 +13,7 @@ ERC-8004 uses CREATE2 deterministic deployment — the same contract address exi
 - **Primary registry:** Base (cheap gas, sub-cent per registration)
 - **Mirror registries:** Ethereum + BSC + Arbitrum (for platforms on those chains)
 - **Cross-chain attestation:** When an agent registers on Base, steward can optionally mirror the registration to other chains via a batch relay
-- **Reputation aggregation:** Reputation signals from ALL chains feed into a unified score
+- **Reputation aggregation:** Configured reputation signals feed into a unified score
 
 | Chain | Registry Address | Gas Cost | Use Case |
 |-------|-----------------|----------|----------|

--- a/docs/guides/cloud-deployment.mdx
+++ b/docs/guides/cloud-deployment.mdx
@@ -1,15 +1,15 @@
 ---
 title: "Cloud Deployment Integration"
-description: "How Steward powers wallet management for hosted AI agents across a node fleet."
+description: "How to self-host Steward for wallet management across an operator-controlled node fleet."
 ---
 
 # Cloud Deployment Integration
 
-A hosted cloud deployment can use Steward as the governance layer between its agent containers and the outside world. This guide describes a production topology managing dozens of AI agents across a node fleet with on-chain transactions on Base mainnet.
+An operator-controlled cloud deployment can place Steward governed routes between its agent containers and configured provider or wallet operations. This guide describes a reference topology for a node fleet with on-chain transactions on Base mainnet.
 
 ## Architecture
 
-Each node runs Steward as the governance layer in front of its agent containers:
+Each node runs self-hosted Steward in front of supported agent actions:
 
 ```
 ┌─────────────────────────────────────────┐

--- a/docs/guides/secrets.mdx
+++ b/docs/guides/secrets.mdx
@@ -185,10 +185,10 @@ curl -X POST http://localhost:3200/secrets/routes \
 
 The agent calls the `github` alias with its own agent token. The proxy matches
 the route, injects the PAT as the `Authorization` header, and forwards the
-request. The agent never sees the token.
+request. The supported agent caller receives the provider response, not the stored token.
 
 ```bash
-curl -X POST https://proxy.steward.fi/github/repos/acme/widgets/issues/1/comments \
+curl -X POST https://steward-proxy.internal/github/repos/acme/widgets/issues/1/comments \
   -H "Authorization: Bearer <agent-token>" \
   -H "Idempotency-Key: $(uuidgen)" \
   -H "Content-Type: application/json" \

--- a/docs/guides/session-broker-integration.mdx
+++ b/docs/guides/session-broker-integration.mdx
@@ -9,16 +9,16 @@ A **session broker** is an third-party service that turns a stored session (a co
 jar, an OAuth session, a headless-browser session) into a small, scoped HTTP API:
 the agent asks the broker to `list`, `fetch`, or `render` something on a site that
 only has an unofficial web API, and the broker replies with structured JSON. The
-broker holds the live session; the agent never does.
+broker holds the live session; the supported agent integration does not receive that session.
 
-Steward is the governance layer in front of that broker. This guide wires an agent
+Steward can provide a configured credential and policy boundary in front of that broker. This guide wires an agent
 to a session broker **config-only** — no product-code changes — so that:
 
 - the broker's scoped token is stored as an encrypted Steward **secret** and
-  injected on the outbound request by the **proxy** (the agent never sees it),
+  injected on the outbound request by the **proxy** instead of returned to the supported agent caller,
 - a **capability** + **grant** + an **allow policy** decide, per agent, whether a
   given broker call is permitted (deny-by-default),
-- every attempt writes one durable **audit** row (allow / deny / approval / error).
+- instrumented attempts write an **audit** row for allow, deny, approval, or error outcomes.
 
 The moving parts mirror the reference implementation in
 [teleport-computer/oauth3-server](https://github.com/teleport-computer/oauth3-server):

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -1,93 +1,90 @@
 ---
-title: "what is Steward?"
-description: "a self-hostable authority plane for private enterprise agents, with scoped wallet and API capabilities, policy, approvals, and execution records."
+title: "What is Steward?"
+description: "An open-source, self-hostable governed credential proxy and policy and approval layer for configured agent provider actions and wallets."
 ---
 
-Steward is the self-hostable authority plane for private enterprise agents. It gives agents scoped wallet and API capabilities without exposing secrets, routes sensitive actions through policy and human approval, and produces an HMAC-chained execution record. Bring your own agent runtime, cloud, and custodian.
+Steward is an open-source, self-hostable governed credential proxy and policy and approval layer for agent provider actions and wallets. It ships scoped grants, exact-request approval, policy-bound execution authorization on the primary EVM sign path, and signed audit evidence verifiable offline.
 
-Today, keys are stored encrypted under an operator-held root, with an optional KMS envelope and a seam for third-party custody providers. Policy is evaluated in API route handlers before governed signing operations call the vault. Steward records requests, decisions, and effects in an HMAC-chained audit log. Offline independently verifiable evidence bundles are roadmap work.
+Steward runs in your infrastructure. Configured provider calls can receive credentials at the proxy without returning those credentials to the supported agent caller. Governed wallet routes evaluate policy and approval before signing. The primary EVM transaction sign path adds a signed, short-lived, payload-bound, single-use authorization immediately before raw signing.
+
+Steward also maintains a tenant-scoped HMAC audit chain and exports Ed25519-signed evidence bundles. Verify a bundle offline with `scripts/verify-evidence-bundle.mjs <bundle.json>`. The script checks the signature against the public key carried in the bundle. Separately compare that key with an out-of-band trusted Steward signing key or fingerprint. Verification detects changes relative to that trust root. It does not exclude fabrication by an operator controlling all relevant keys.
 
 <CardGroup cols={2}>
-  <Card title="wallet vault" icon="vault" href="/concepts/wallet-vault">
-    AES-256-GCM encrypted key storage with multi-chain signing (EVM + Solana). agents request signatures, they never see private keys.
+  <Card title="Wallet vault" icon="vault" href="/concepts/wallet-vault">
+    Encrypted wallet-key storage and signing primitives for supported EVM and Solana routes. Policy enforcement is provided by governed execution paths, not by every vault primitive.
   </Card>
-  <Card title="secret vault" icon="key" href="/concepts/secret-vault">
-    encrypted credential storage with automatic injection. agents never see API keys. Steward's proxy injects them at request time.
+  <Card title="Secret vault" icon="key" href="/concepts/secret-vault">
+    Encrypted credential storage for configured proxy routes. The proxy injects credentials server-side instead of returning them to the supported agent caller.
   </Card>
-  <Card title="policy engine" icon="shield-check" href="/concepts/policy-engine">
-    declarative policies evaluated before every action. spending limits, rate limits, address whitelists, time windows, all configurable per agent.
+  <Card title="Policy engine" icon="shield-check" href="/concepts/policy-engine">
+    Declarative policy decisions for supported wallet routes and named provider capabilities, including argument and rate constraints.
   </Card>
   <Card title="API proxy" icon="shuffle" href="/concepts/proxy-gateway">
-    configured third-party API calls flow through Steward. credentials are injected at the proxy, with cost tracking and audit events.
+    Configured provider calls flow through strict route matching, server-side credential injection, and audit events.
   </Card>
 </CardGroup>
 
-## the problem
+## The problem
 
-today, most agent platforms inject plaintext credentials directly into agent containers:
+Agent processes are often given standing provider credentials and wallet keys through environment variables:
 
 ```bash
-# what agent containers look like today
 OPENAI_API_KEY=sk-proj-abc123...
 ANTHROPIC_API_KEY=sk-ant-def456...
 EVM_PRIVATE_KEY=0xdeadbeef...
 DATABASE_URL=postgres://user:pass@host/db
 ```
 
-any code operating from the container, including code triggered by prompt injection, can read these credentials, exfiltrate them, or drain wallets. there is no spending control, no audit trail, and rotating a credential means redeploying every container that uses it.
+Code running in that process may be able to read and misuse those credentials. Rotation also requires updating every process that received the secret.
 
-## the solution
+## The Steward model
 
-with Steward, agent containers only receive two environment variables:
+A supported agent integration can receive a Steward URL and scoped token instead:
 
 ```bash
-# what agent containers look like with Steward
 STEWARD_PROXY_URL=http://steward-proxy:8080
 STEWARD_AGENT_TOKEN=stwd_jwt_...
 ```
 
-configured API calls and wallet actions enter Steward through authenticated routes. governed routes evaluate policy and approvals before calling signing or proxy operations, then record the result.
+Configured provider calls and wallet actions then enter Steward through authenticated routes. Depending on the route, Steward checks grants, evaluates policy, requests exact-action approval, signs or injects a credential, and records evidence.
 
-## who uses Steward?
+<Warning>
+  Coverage is route-specific. Steward does not govern arbitrary agent network egress, every wallet operation, or every action in the product. The shipped execution authorization boundary applies to the primary EVM transaction sign path and compatible approval replay.
+</Warning>
 
-- **private enterprise agents.** agents using scoped wallet or API capabilities for treasury operations, vendor payments, internal systems, and other sensitive workflows.
-- **constrained trading agents.** optional venue packages support bounded financial workflows without making trading the core platform.
-- **production multi-agent deployments.** platforms managing dozens of agents across a node fleet with on-chain transactions on Base mainnet.
-- **agent developers** building autonomous agents that need wallet access or API credential management.
-- **platform operators** running multi-tenant agent hosting who need security, cost control, and compliance.
-- **desktop apps**. local mode with PGLite means Steward can run as an embedded sidecar with no third-party dependencies.
+## Current capabilities
 
-## what's new
+- **Scoped provider grants:** named capabilities support per-agent grants, expiry, revocation, strict host, path, and method matching, argument constraints, and rate constraints.
+- **Exact-request approval:** wallet workflows and provider capabilities can hold a consequential request for human approval and resume the approved request.
+- **Primary EVM execution authorization:** the primary EVM transaction sign path requires a signed, short-lived, payload-bound, backend-bound, single-use authorization before raw signing.
+- **Credential proxy:** configured provider requests receive credentials server-side without returning them to the supported agent caller.
+- **Audit evidence:** HMAC chaining, Ed25519 checkpoints, bundle export, and offline verification, with a separate out-of-band check of the bundled public key.
+- **Self-hosting:** Docker with PostgreSQL and Redis, or embedded PGLite for local and desktop use.
+- **Custody choices:** local encrypted storage, AWS KMS envelope wrapping, a PKCS#11 wrapping adapter, and an external custody interface. Steward does not claim MPC or native HSM signing.
 
-Current authority-plane capabilities include:
+## Direction
 
-- **API proxy.** route any HTTP API call through Steward for credential injection, cost tracking, and audit logging.
-- **webhook events.** get notified on `tx.pending`, `tx.signed`, `spend.threshold`, `policy.violation`, and more.
-- **approval workflow.** large transactions queue for human review. approve or deny via API or the `<ApprovalQueue>` component.
-- **control plane config.** per-tenant configuration of policy exposure, UI feature flags, themes, and approval rules.
-- **embeddable React UI.** drop `@stwd/react` into any app for wallet overview, transaction history, policy controls, and approval queues.
-- **local mode.** run Steward without any third-party database using the built-in PGLite (Postgres-in-WASM) backend.
-- **aggregated dashboard.** single API call returns agent balances, spend stats, recent transactions, policy summary, and pending approvals.
+Steward's direction is an open authority plane across explicitly supported agent execution surfaces. "Authority plane" is shorthand for that direction, not a claim of universal enforcement today.
 
-## quick links
+## Quick links
 
 <CardGroup cols={2}>
-  <Card title="quickstart" icon="rocket" href="/quickstart">
-    get up and running with Steward in 5 minutes.
+  <Card title="Quickstart" icon="rocket" href="/quickstart">
+    Run Steward in your infrastructure and create a governed wallet flow.
   </Card>
-  <Card title="architecture" icon="sitemap" href="/concepts/architecture">
-    understand how the four pillars work together.
+  <Card title="Architecture" icon="sitemap" href="/concepts/architecture">
+    Understand the current execution boundaries.
   </Card>
   <Card title="React components" icon="react" href="/sdk/react-components">
-    drop-in UI for wallet management and policy controls.
+    Add wallet, policy, and approval UI to your application.
   </Card>
-  <Card title="local mode" icon="computer" href="/guides/local-mode">
-    run Steward locally with PGLite, no database required.
+  <Card title="Local mode" icon="computer" href="/guides/local-mode">
+    Run Steward locally with PGLite.
   </Card>
   <Card title="SDK reference" icon="code" href="/sdk/installation">
-    install the TypeScript SDK and start building.
+    Install the TypeScript SDK.
   </Card>
   <Card title="API reference" icon="server" href="/api-reference/overview">
-    explore the full REST API.
+    Explore the self-hosted REST API.
   </Card>
 </CardGroup>

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -7,7 +7,7 @@ description: "Get up and running with Steward in 5 minutes."
 
 
 <Note>
-  Steward is self-host-first today. Start with [Self-Hosting](/guides/self-hosting), [Docker Deployment](/guides/docker), or the root [deployment guide](https://github.com/Steward-Fi/steward/blob/develop/docs/deployment.md). A managed hosted API is coming soon.
+  Steward is self-hosted. Start with [Self-Hosting](/guides/self-hosting), [Docker Deployment](/guides/docker), or the root [deployment guide](https://github.com/Steward-Fi/steward/blob/develop/docs/deployment.md).
 </Note>
 
 This guide walks you through creating your first agent with an encrypted wallet, setting policies, and signing a transaction — all using the `@stwd/sdk`.

--- a/docs/security/threat-model.mdx
+++ b/docs/security/threat-model.mdx
@@ -59,11 +59,15 @@ If any of these fails, the threat model below does not hold.
    provides limited defense.
 6. **Tenant operators are trusted with their own tenant.** A tenant
    admin can read the policies, approvals, and audit log for their
-   tenant. They cannot read another tenant's data (isolation is
-   row-level + enforced by the API). In self-hosted mode this is
-   trivially true (there's one tenant). In hosted multi-tenant mode,
-   the hosting operator trusts the tenant owner with their own tenant
-   scope.
+   tenant. They cannot read another tenant's data. Isolation is
+   enforced at the service layer: every tenant-scoped query filters
+   on `tenantId` and rows carry a composite foreign key to their
+   tenant. It is NOT database row-level security (RLS is not
+   implemented). Steward ships self-hosted only, and the expected
+   topology is one tenant per deployment, where this is trivially
+   true. An operator who chooses to run multiple tenants in a single
+   self-hosted deployment relies on that service-layer scoping and
+   trusts each tenant owner with their own scope.
 7. **TLS is terminated in front of Steward.** The Compose file binds
    the API to `127.0.0.1`; the expected topology has Caddy / nginx /
    Traefik handling TLS. Steward does not itself terminate TLS in the
@@ -160,11 +164,13 @@ including the Steward API credentials the operator provisioned.
 
 ---
 
-### 3. Malicious co-tenant in hosted deploy
+### 3. Malicious co-tenant in a multi-tenant self-hosted deploy
 
-**Capability.** On the hosted `steward.fi` tier, another tenant on the
-same infrastructure is adversarial. They try to read, modify, or
-exhaust resources belonging to another tenant.
+**Capability.** There is no hosted `steward.fi` service; Steward ships
+self-hosted only. This adversary applies when an operator chooses to
+run multiple tenants in a single self-hosted deployment. Another
+tenant on the same infrastructure is adversarial and tries to read,
+modify, or exhaust resources belonging to another tenant.
 
 **What Steward defends:**
 

--- a/docs/security/threat-model.mdx
+++ b/docs/security/threat-model.mdx
@@ -5,42 +5,8 @@ date: 2026-04-24
 ---
 
 {/*
-VISION.md lines that are directly contradicted by this threat model and
-should be toned down in a follow-up PR (NOT this PR):
-
-  • Line 5:  "Every agent deserves a bank account it can't be robbed of."
-             → aspirational; overclaims absolute security. Suggest:
-               "Every agent deserves strong, policy-bounded custody."
-
-  • Line 9:  "Steward exists to make that impossible. Not through trust,
-             through architecture: … policy enforcement at the signing
-             layer …"
-             → "impossible" is wrong. Policies are enforced in the API
-               process, not the signing layer. See ADR-0004. Suggest:
-               "Steward reduces the blast radius of prompt injection and
-               credential leakage by enforcing operator-defined policies
-               before every signing operation, and by isolating
-               credentials behind a proxy."
-
-  • Line 44: "Policy enforcement | Rules enforced at the vault, not the
-             application layer."
-             → Factually inaccurate today. Rules are enforced at the API
-               layer, which then calls the vault. See ADR-0004.
-               Suggest: "Rules enforced in the API signing path, not in
-               user application code."
-
-  • Line 99: "Policy is architecture, not advice. Rules are enforced at
-             the cryptographic signing layer. Not in middleware. Not in
-             application code. Not as suggestions. If the policy says
-             no, the vault won't sign it."
-             → Overstated. Policies are in-process middleware, not a
-               cryptographic layer. The vault itself will sign anything
-               the API asks it to. Suggest:
-               "Policy is first-class. Every signing API in Steward
-               evaluates policies before calling the vault, and a
-               failed policy stops the request before any key is
-               decrypted. Future versions will move this enforcement
-               into a separate signer process (see ADR-0004)."
+This document describes route-specific boundaries. It must not be read as a
+claim that every signing, proxy, or plugin execution path is governed.
 */}
 
 # Steward Threat Model
@@ -62,7 +28,7 @@ right and this document is wrong. Please file an issue.
   that Steward holds keys for.
 - **Tenant:** an organizational boundary in Steward. A tenant owns
   agents, policies, secrets, and API keys. In a self-hosted deploy,
-  typically one tenant. In the hosted tier, many tenants share
+  typically one tenant. In a multi-tenant self-hosted deployment, many tenants share
   infrastructure.
 - **Operator:** the human/team running Steward. Owns
   `STEWARD_MASTER_PASSWORD`, `STEWARD_SESSION_SECRET`,
@@ -120,9 +86,8 @@ problem is semantic, not authentication.
 
 **What Steward defends:**
 
-- Policy engine evaluates every signing call
-  (`packages/api/src/routes/vault.ts` lines ~115, ~597, ~808) and
-  rejects anything outside `spending-limit`, `approved-addresses`,
+- Governed wallet routes evaluate policy before their signing calls and
+  reject requests outside `spending-limit`, `approved-addresses`,
   `rate-limit`, `time-window`, `auto-approve-threshold`, and
   `allowed-chains` rules.
 - Auto-approve thresholds queue high-value transactions for human
@@ -175,8 +140,8 @@ including the Steward API credentials the operator provisioned.
   The agent sees responses but not the API key the proxy used. So
   malware in the agent cannot exfiltrate, e.g., the OpenAI key
   directly — it can only cause the proxy to use it.
-- Audit logs record every signing call and every proxy call, tagged
-  with the agent identity. Exfiltration leaves a trail.
+- Instrumented signing and proxy routes emit audit events tagged with the
+  agent identity. Coverage remains route-specific.
 
 **What Steward does NOT defend:**
 
@@ -225,9 +190,9 @@ exhaust resources belonging to another tenant.
 **Mitigation (for self-hosters):** run one tenant per deploy. The
 isolation claim is stronger when there's no multi-tenancy to test.
 
-**Mitigation (for hosted tier operator — us, eventually):**
-per-tenant rate limits, per-tenant DB connection pool caps,
-workload-isolation plans.
+**Mitigation for multi-tenant self-hosters:** use per-tenant rate limits,
+per-tenant database connection-pool caps, and deployment-level workload
+isolation appropriate to the operator's threat model.
 
 ---
 
@@ -342,10 +307,10 @@ turns malicious, or has their session token stolen.
 
 **What Steward defends:**
 
-- Audit log records admin actions: policy changes, API key
-  creation, approval decisions. Not tamper-evident (admin can
-  likely also delete audit rows via DB access), but useful for
-  detection.
+- Instrumented admin actions enter the tenant-scoped HMAC chain and signed
+  evidence exports. Verification detects modification relative to the public key carried in the bundle. Operators must separately
+  match that key to an out-of-band trusted signing key or fingerprint. An operator controlling all relevant keys
+  can still fabricate a self-consistent history.
 - API key creation requires authenticated admin.
 - Every signed transaction has a policy-evaluation record
   attached (`transactions.policyResults`).
@@ -411,14 +376,18 @@ adversary defeats the entire architecture.
   / JSC heap until garbage collection. We do not hold it longer than
   needed (`vault.ts` line ~324 comment) but we cannot guarantee
   erasure. This affects any attacker with a memory-dump primitive.
-- **No HSM / KMS integration in v1.** Planned (VISION.md roadmap).
+- **Custody backends have distinct trust limits.** AWS KMS envelope wrapping
+  and an operator-supplied PKCS#11 wrapping adapter are available, but the
+  application still sees plaintext key material at sign time in local and KMS
+  envelope modes. Steward does not claim native HSM signing.
 - **Default `STEWARD_KDF_SALT` is weak** if the operator doesn't
   override it. Loud warning; should be an error in v2.
 - **Migrations run at startup with no leader lock.** Not safe for
   multi-replica rolling deploys.
-- **No tamper-evident audit log.** An attacker with DB write can
-  rewrite the audit trail. Options under consideration: HMAC chain,
-  third-party write-only log (e.g., Loki / Vector → S3 WORM).
+- **Audit evidence is not operator-proof.** The tenant-scoped HMAC chain,
+  Ed25519 checkpoints, and offline verifier detect modification relative to the public key carried in the bundle. Operators must separately
+  match that key to an out-of-band trusted signing key or fingerprint. An operator controlling all
+  relevant keys can still fabricate a self-consistent history.
 - **No rate limiting on read endpoints.** Rate limits apply to
   signing and auth; general read traffic is not rate-capped beyond
   whatever the reverse proxy enforces.

--- a/packages/eliza-plugin/package.json
+++ b/packages/eliza-plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stwd/eliza-plugin",
   "version": "0.4.2",
-  "description": "Steward wallet management plugin for ElizaOS agents",
+  "description": "ElizaOS integration for Steward-scoped wallet and provider capabilities",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/erc8183/package.json
+++ b/packages/erc8183/package.json
@@ -31,5 +31,6 @@
   "devDependencies": {
     "@types/bun": "latest",
     "typescript": "^5.0.0"
-  }
+  },
+  "description": "ERC-8183 primitives for Steward wallet workflows"
 }

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stwd/mcp",
   "version": "0.1.0",
-  "description": "Model Context Protocol (MCP) server exposing Steward agent-wallet and auth operations as tools for AI agents and IDEs",
+  "description": "MCP tools for invoking Steward-authorized wallet and provider capabilities",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stwd/react-native",
   "version": "0.1.0",
-  "description": "React Native and Expo helpers for Steward authentication and API clients",
+  "description": "React Native and Expo helpers for Steward authentication and governed API clients",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "build": "tsc && cp src/styles.css dist/styles.css",
     "dev": "tsc --watch",
-    "test": "for f in src/__tests__/*.test.*; do echo \"\\n\u25b6 $f\"; bun test \"$f\" || exit 1; done"
+    "test": "for f in src/__tests__/*.test.*; do echo \"\\n▶ $f\"; bun test \"$f\" || exit 1; done"
   },
   "dependencies": {
     "@stwd/sdk": "^0.10.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stwd/react",
   "version": "0.10.0",
-  "description": "Embeddable React components for Steward agent wallet management",
+  "description": "React components for Steward authentication, wallets, policies, and approvals",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -40,7 +40,7 @@
   "scripts": {
     "build": "tsc && cp src/styles.css dist/styles.css",
     "dev": "tsc --watch",
-    "test": "for f in src/__tests__/*.test.*; do echo \"\\n▶ $f\"; bun test \"$f\" || exit 1; done"
+    "test": "for f in src/__tests__/*.test.*; do echo \"\\n\u25b6 $f\"; bun test \"$f\" || exit 1; done"
   },
   "dependencies": {
     "@stwd/sdk": "^0.10.0"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stwd/sdk",
   "version": "0.10.3",
-  "description": "TypeScript SDK for Steward, agent wallet infrastructure with policy enforcement",
+  "description": "TypeScript client for Steward governed wallet and provider capability APIs",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stwd/shared",
   "version": "0.2.0",
-  "description": "Shared domain types, interfaces, and constants for the Steward monorepo",
+  "description": "Shared domain types, execution contracts, and constants for Steward",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -44,9 +44,9 @@ const metadataBase = (() => {
 
 export const metadata: Metadata = {
   metadataBase,
-  title: "Steward: self-hostable authority plane for enterprise agents",
+  title: "Steward: governed credentials and wallet actions for agents",
   description:
-    "Steward gives private enterprise agents scoped wallet and API capabilities without exposing secrets, routes sensitive actions through policy and human approval, and records execution evidence. Bring your own runtime, cloud, and custodian.",
+    "Open-source, self-hostable governed credential proxy and policy and approval layer for configured agent provider actions and wallets.",
   icons: {
     icon: [
       { url: "/favicon.ico", sizes: "32x32" },
@@ -57,9 +57,9 @@ export const metadata: Metadata = {
   },
   manifest: "/site.webmanifest",
   openGraph: {
-    title: "Steward: self-hostable authority plane for enterprise agents",
+    title: "Steward: governed credentials and wallet actions for agents",
     description:
-      "A self-hostable authority plane for private enterprise agents. Bring your own agent runtime, cloud, and custodian.",
+      "Scoped grants, exact-request approval, a governed primary EVM sign path, and signed evidence verifiable offline.",
     type: "website",
     images: [
       {

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -48,18 +48,18 @@ function Hero() {
               className="hero-rise font-display text-hero-landing font-extrabold leading-[0.94] tracking-[-0.035em] text-balance"
               style={{ animationDelay: "0.15s" }}
             >
-              Give agents power.
+              Give agents scope.
               <br />
-              <span className={accent}>Never the keys.</span>
+              <span className={accent}>Keep keys behind the boundary.</span>
             </h1>
 
             <p
               className="hero-rise mt-6 text-lg text-text-secondary max-w-lg leading-relaxed text-pretty"
               style={{ animationDelay: "0.3s" }}
             >
-              The self-hostable authority plane for private enterprise agents. Give agents scoped
-              wallet and API capabilities without exposing secrets, with policy checks, human
-              approval, and an HMAC-chained execution record.
+              Open-source, self-hostable control for configured agent API calls and wallets. Scoped
+              grants, exact-request approval, a governed primary EVM sign path, and signed evidence
+              you can verify offline.
             </p>
 
             <div
@@ -72,7 +72,7 @@ function Hero() {
               <span className="text-border">/</span>
               <span>Your custodian</span>
               <span className="text-border">/</span>
-              <span className={accent}>Your authority plane</span>
+              <span className={accent}>Your governed boundary</span>
             </div>
 
             <div
@@ -158,16 +158,16 @@ function SecretSprawlSection() {
               The problem
             </p>
             <h2 className="font-display text-hero-sm font-extrabold tracking-[-0.02em] leading-[1.02] text-balance">
-              One Steward credential.
+              One scoped credential.
               <br />
-              <span className={accent}>Zero raw secrets.</span>
+              <span className={accent}>Provider keys stay server-side.</span>
             </h2>
           </Reveal>
           <Reveal delay={0.1}>
             <p className="mt-6 text-text-secondary leading-relaxed max-w-md text-pretty">
-              Handing an agent an API key or a signing key is not security. It is a secret with no
-              boundary, no revocation, and no record. Steward gives the agent one scoped credential
-              and keeps the real authority behind a policy plane.
+              Standing API keys and signing keys widen the blast radius. Steward gives supported
+              agent integrations a scoped credential while configured provider keys stay behind the
+              proxy and governed wallet routes apply policy and approval.
             </p>
           </Reveal>
         </div>
@@ -205,13 +205,13 @@ function PipelineSection() {
     {
       idx: "00",
       label: "Agent intent",
-      body: "The model asks for a privileged action. It never holds the underlying authority.",
+      body: "The model asks for a privileged action through a supported Steward integration.",
       decision: false,
     },
     {
       idx: "01",
       label: "Identity + capability",
-      body: "Steward resolves who is asking and which scoped capabilities they hold.",
+      body: "Steward resolves the authenticated agent and its active capability grants.",
       decision: true,
     },
     {
@@ -223,13 +223,13 @@ function PipelineSection() {
     {
       idx: "03",
       label: "Simulation + execution",
-      body: "Where supported, the action is simulated, then signed and executed across the target rail.",
+      body: "Supported wallet routes sign or execute after their route-specific checks pass.",
       decision: true,
     },
     {
       idx: "04",
       label: "Audit + reconciliation",
-      body: "Requests, decisions, and effects land in an HMAC-chained, machine-readable record.",
+      body: "Instrumented routes emit HMAC-chained events and signed evidence exports.",
       decision: false,
     },
   ];
@@ -334,7 +334,7 @@ function ExecutionSection() {
     {
       tag: "proxy.inject",
       title: "Credential proxy",
-      body: "Outbound API calls get their credentials injected at the edge with zero key exposure to the agent, stripped from logs.",
+      body: "Configured provider calls receive credentials server-side instead of returning them to the supported agent caller.",
     },
     {
       tag: "grant.scope",
@@ -348,8 +348,8 @@ function ExecutionSection() {
     },
     {
       tag: "audit.log",
-      title: "Append-only audit",
-      body: "An HMAC-chained record of every request, decision, and effect. Tamper-evident and machine-readable end to end.",
+      title: "Signed audit evidence",
+      body: "Instrumented actions emit HMAC-chained events and Ed25519-signed bundles verifiable offline against a trusted key fingerprint.",
     },
   ];
 
@@ -367,9 +367,9 @@ function ExecutionSection() {
           </Reveal>
           <Reveal delay={0.1}>
             <p className="mt-6 text-text-secondary leading-relaxed max-w-sm text-pretty">
-              Today Steward provides wallet signing, credential proxying, capability grants,
-              approval workflows, and an HMAC-chained audit record. Trading packages are optional
-              extensions.
+              Steward ships wallet signing, configured credential proxying, scoped grants, exact
+              approval workflows, and signed audit exports. Enforcement coverage remains
+              surface-specific.
             </p>
           </Reveal>
         </div>
@@ -495,7 +495,7 @@ function AgentsSection() {
   const traits = [
     {
       t: "Autonomous execution",
-      d: "Actions fire at machine speed without a human in the loop, until policy says otherwise.",
+      d: "Supported actions can proceed automatically when their route-specific policy allows them.",
     },
     {
       t: "Persistent delegated authority",
@@ -507,7 +507,7 @@ function AgentsSection() {
     },
     {
       t: "Ambiguous-outcome recovery",
-      d: "Durable intents reconcile a dropped call so nothing is lost or executed twice.",
+      d: "Durable intents preserve state for reconciliation when an outcome is ambiguous.",
     },
     {
       t: "Machine-readable audit",
@@ -515,7 +515,7 @@ function AgentsSection() {
     },
     {
       t: "Emergency operator control",
-      d: "A human can freeze everything instantly, without shipping new code to the agent.",
+      d: "An operator can freeze supported signing paths without redeploying the agent.",
     },
   ];
 
@@ -566,7 +566,7 @@ function SpecsSection() {
     { value: "AES-256-GCM", label: "Encryption at rest" },
     { value: "Default deny", label: "Policy model" },
     { value: "7 EVM + Solana", label: "Chains supported" },
-    { value: "< 50ms", label: "Proxy overhead" },
+    { value: "Ed25519", label: "Signed checkpoints" },
   ];
 
   return (
@@ -603,7 +603,7 @@ function SpecsSection() {
 function ComparisonSection() {
   const rows = [
     { feature: "Source", steward: "Open source, MIT", vendor: "Closed, proprietary" },
-    { feature: "Hosting", steward: "Self-host or managed", vendor: "Hosted only" },
+    { feature: "Deployment", steward: "Self-hosted", vendor: "Vendor-defined" },
     {
       feature: "Custody",
       steward: "Operator-held root, optional KMS envelope",
@@ -616,9 +616,9 @@ function ComparisonSection() {
     },
     { feature: "Agent runtime", steward: "Bring your own", vendor: "Vendor-dependent" },
     {
-      feature: "Pricing",
-      steward: "No per-transaction toll",
-      vendor: "Per-seat + per-transaction",
+      feature: "Evidence",
+      steward: "Offline-verifiable signed bundles",
+      vendor: "Vendor-defined",
     },
   ];
 
@@ -717,7 +717,7 @@ function ComparisonSection() {
 
 // --- Open by design / CTA (the one centered moment) ---
 function OpenSourceSection() {
-  const pillars = ["MIT licensed", "Self-hostable", "Vendor-neutral", "No per-transaction toll"];
+  const pillars = ["MIT licensed", "Self-hostable", "Vendor-neutral", "Offline verification"];
 
   return (
     <section className="relative px-6 md:px-10 py-32 md:py-44 border-t border-border-subtle overflow-hidden">
@@ -735,9 +735,9 @@ function OpenSourceSection() {
         </Reveal>
         <Reveal delay={0.1}>
           <p className="mt-7 text-lg text-text-secondary leading-relaxed max-w-xl mx-auto text-pretty">
-            MIT-licensed, self-hostable, and vendor-neutral, with no per-transaction toll. Choose
-            your runtime, cloud, and custodian while keeping policy, approvals, and execution
-            records under operator control.
+            MIT-licensed, self-hostable, and vendor-neutral. Choose your runtime, cloud, identity
+            provider, and custodian while keeping policy, approvals, and signed evidence under
+            operator control.
           </p>
         </Reveal>
         <Reveal delay={0.16}>
@@ -791,7 +791,7 @@ function Footer() {
             <span className="font-display text-base font-bold tracking-tight">steward</span>
           </div>
           <p className="text-xs text-text-tertiary mt-1.5">
-            The self-hostable authority plane for private enterprise agents.
+            Open-source, self-hostable control for configured agent actions.
           </p>
         </div>
         <div className="flex items-center gap-6 text-sm text-text-secondary">


### PR DESCRIPTION
## Summary

Aligns Steward's public positioning with the EARNED-NOW claims rung and Shadow's open-source, self-hosted direction.

## Claim changes, before and after

- **Category**
  - Before: "the self-hostable authority plane for private enterprise agents"
  - After: "an open-source, self-hostable governed credential proxy and policy and approval layer for agent provider actions and wallets"
- **Authority plane**
  - Before: presented as the current product category and universal boundary
  - After: retained only as clearly labeled long-term architectural direction, with current enforcement described as surface-specific
- **Provider and wallet scope**
  - Before: broad references to any API, every action, every API call, and a single chokepoint
  - After: configured provider routes, named capabilities, supported wallet routes, and explicit exclusion of arbitrary agent network egress
- **Scoped grants**
  - Before: generic scoped wallet and API capabilities
  - After: shipped per-agent grants bound to configured host, path, method, credential route, expiry, revocation, argument constraints, and rate constraints, with the current tenant-scoped limitation stated
- **Approval**
  - Before: generic human approval language and wallet-first approval examples
  - After: exact-request approval and resume for shipped wallet and provider-capability workflows
- **Execution enforcement**
  - Before: route policy checks only, signer-level authorization described as roadmap, or unqualified policy enforcement across signing
  - After: signed, payload-bound, backend-bound, short-lived, single-use execution authorization on the primary EVM transaction sign path and compatible approval replay, explicitly not product-wide
- **Evidence status**
  - Before: offline independently verifiable Ed25519 evidence bundles described as roadmap work
  - After: HMAC chain, Ed25519 checkpoint, `/audit/bundle`, and `scripts/verify-evidence-bundle.mjs` documented as shipped
- **Evidence trust root**
  - Before: HMAC record without the shipped checkpoint and verifier, plus immutable or append-only language in older docs
  - After: offline verification against the public key carried in the bundle, a separate required comparison with an out-of-band trusted key or fingerprint, partial-range limits, and the operator-key fabrication limit
- **Custody**
  - Before: language that could imply keys never leave a vault, stronger custody equivalence, or dependency on external MPC networks
  - After: local AES encryption, optional AWS KMS envelope wrapping, operator-supplied PKCS#11 wrapping adapter, external custody interface, and explicit plaintext-at-sign-time limits for local and KMS envelope modes
- **MPC and HSM**
  - Before: competitive framing around external MPC and stale "no HSM/KMS" roadmap copy
  - After: no Steward MPC or native HSM signing claim, with current KMS and PKCS#11 wrapping support described precisely
- **Audit coverage**
  - Before: every action, every signing call, and every proxy call logged
  - After: instrumented and governed routes emit audit events, with route-specific coverage
- **Tamper resistance**
  - Before: immutable and append-only audit wording
  - After: tamper-evident signed exports relative to a separately established trust root, not operator-proof history
- **Tenant isolation**
  - Before: full tenant isolation at middleware and database level
  - After: tenant-scoped APIs and evidence without an unearned database-level isolation claim
- **Deployment**
  - Before: hosted, managed, coming-soon hosted API, hosted tier, production-grade, drop-in replacement, and same-guarantees language
  - After: Docker and embedded PGLite as self-hosted modes, with deployment-specific operating and security properties
- **Commercial packaging**
  - Before: hosted or managed comparisons and per-transaction pricing positioning
  - After: no paid, managed, SLA, enterprise-pricing, or hosted-product packaging language
- **Competitive comparison**
  - Before: closed custody vendors characterized broadly as hosted-only and weaker on policy
  - After: vendor-neutral self-hosting and integration boundaries without implying custody vendors lack their own policy or enforcement
- **Chain support**
  - Before: chain counts and broad cross-chain language could imply shared guarantees
  - After: wallet primitive support is listed separately from route, operation, backend, and execution-authorization coverage
- **Site hero**
  - Before: "Give agents power. Never the keys." and "zero raw secrets"
  - After: scoped, configured actions with provider keys kept server-side for supported integrations and explicit primary EVM enforcement scope
- **Site evidence and metrics**
  - Before: HMAC-only execution record, append-only audit, and an unqualified proxy latency number
  - After: signed offline-verifiable evidence, surface-specific audit language, and Ed25519 checkpoint proof instead of an unsupported latency claim
- **Public package descriptions**
  - Before: fragmented wallet-infrastructure, wallet-management, auth-operation, or generic component categories
  - After: one Steward family centered on governed wallet and provider capabilities, policy, approvals, and execution contracts
- **Brand naming**
  - Before: inconsistent ELIZA OS wording in public package copy
  - After: ElizaOS

## Validation

- `bunx @biomejs/biome check web/src/app/page.tsx web/src/app/layout.tsx packages/eliza-plugin/package.json packages/erc8183/package.json packages/mcp/package.json packages/react-native/package.json packages/react/package.json packages/sdk/package.json packages/shared/package.json`
- `bunx turbo run build --filter='./packages/*' && bunx tsc --noEmit --project web/tsconfig.json`
- `git diff --check`
- Codex review: clean after correcting the evidence-verifier invocation and clarifying the separate out-of-band trust-root check

No code, tests, OpenAPI runtime specifications, or changelog history entries were changed.

[sol-orch]
