### PR TITLE
feat(authority): workspace-scoped RBAC and provider authority foundation (authority plan PR1)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -39,7 +39,11 @@
     "/condition-sets",
     "/v1/condition-sets",
     "/condition_sets",
-    "/v1/condition_sets"
+    "/v1/condition_sets",
+    "/v2/workspaces",
+    "/v2/provider-accounts",
+    "/v2/provider-role-bindings",
+    "/v2/provider-grants"
   ],
   "tags": [
     {
@@ -104,6 +108,9 @@
     },
     {
       "name": "Tenant Config"
+    },
+    {
+      "name": "Provider Authority"
     }
   ],
   "components": {
@@ -5220,6 +5227,3710 @@
             "header": "Idempotency-Key",
             "requiredForSignedRequests": true,
             "replayStorage": "enabled when callers provide a key in a replay-safe authenticated context"
+          }
+        }
+      }
+    },
+    "/v2/workspaces": {
+      "get": {
+        "tags": [
+          "Provider Authority"
+        ],
+        "summary": "List workspaces",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": true
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Provider Authority"
+        ],
+        "summary": "Create workspace",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "description": "Required for signed sensitive requests and recommended for all sensitive mutating requests. Replays are scoped to authenticated or explicitly signed contexts.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Request-Timestamp",
+            "in": "header",
+            "required": false,
+            "description": "Unix seconds, Unix milliseconds, or HTTP/ISO timestamp. Sensitive mutating routes require this or X-Steward-Request-Expires-At when request-expiry or request signatures are enforced.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Request-Expires-At",
+            "in": "header",
+            "required": false,
+            "description": "Unix seconds, Unix milliseconds, or HTTP/ISO expiry time. Sensitive mutating routes require this or X-Steward-Request-Timestamp when request-expiry or request signatures are enforced.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Signature",
+            "in": "header",
+            "required": false,
+            "description": "Authorization signature for sensitive mutating routes when STEWARD_REQUIRE_AUTH_SIGNATURE=true or production enforcement is enabled. Use v1=<hmac-sha256> or p256=<signature>.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Signing-Key-Id",
+            "in": "header",
+            "required": false,
+            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "expectedRevision",
+                  "reason"
+                ],
+                "properties": {
+                  "expectedRevision": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "reason": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "408": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-steward-hardening": {
+          "sensitive": true,
+          "sensitivePrefix": "/v2/workspaces",
+          "requestExpiry": {
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "acceptedHeaders": [
+              "X-Steward-Request-Timestamp",
+              "X-Steward-Request-Expires-At"
+            ]
+          },
+          "authorizationSignature": {
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "header": "X-Steward-Signature",
+            "schemes": [
+              "v1=hmac-sha256",
+              "p256=ecdsa-secp256r1"
+            ],
+            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+          },
+          "idempotency": {
+            "header": "Idempotency-Key",
+            "requiredForSignedRequests": true,
+            "replayStorage": "enabled when callers provide a key in a replay-safe authenticated context"
+          }
+        }
+      }
+    },
+    "/v2/workspaces/{id}/disable": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "post": {
+        "tags": [
+          "Provider Authority"
+        ],
+        "summary": "Disable workspace",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "description": "Required for signed sensitive requests and recommended for all sensitive mutating requests. Replays are scoped to authenticated or explicitly signed contexts.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Request-Timestamp",
+            "in": "header",
+            "required": false,
+            "description": "Unix seconds, Unix milliseconds, or HTTP/ISO timestamp. Sensitive mutating routes require this or X-Steward-Request-Expires-At when request-expiry or request signatures are enforced.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Request-Expires-At",
+            "in": "header",
+            "required": false,
+            "description": "Unix seconds, Unix milliseconds, or HTTP/ISO expiry time. Sensitive mutating routes require this or X-Steward-Request-Timestamp when request-expiry or request signatures are enforced.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Signature",
+            "in": "header",
+            "required": false,
+            "description": "Authorization signature for sensitive mutating routes when STEWARD_REQUIRE_AUTH_SIGNATURE=true or production enforcement is enabled. Use v1=<hmac-sha256> or p256=<signature>.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Signing-Key-Id",
+            "in": "header",
+            "required": false,
+            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "expectedRevision",
+                  "reason"
+                ],
+                "properties": {
+                  "expectedRevision": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "reason": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "408": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-steward-hardening": {
+          "sensitive": true,
+          "sensitivePrefix": "/v2/workspaces",
+          "requestExpiry": {
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "acceptedHeaders": [
+              "X-Steward-Request-Timestamp",
+              "X-Steward-Request-Expires-At"
+            ]
+          },
+          "authorizationSignature": {
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "header": "X-Steward-Signature",
+            "schemes": [
+              "v1=hmac-sha256",
+              "p256=ecdsa-secp256r1"
+            ],
+            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+          },
+          "idempotency": {
+            "header": "Idempotency-Key",
+            "requiredForSignedRequests": true,
+            "replayStorage": "enabled when callers provide a key in a replay-safe authenticated context"
+          }
+        }
+      }
+    },
+    "/v2/provider-accounts": {
+      "get": {
+        "tags": [
+          "Provider Authority"
+        ],
+        "summary": "List provider accounts",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "workspaceId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": true
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Provider Authority"
+        ],
+        "summary": "Create provider account",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "description": "Required for signed sensitive requests and recommended for all sensitive mutating requests. Replays are scoped to authenticated or explicitly signed contexts.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Request-Timestamp",
+            "in": "header",
+            "required": false,
+            "description": "Unix seconds, Unix milliseconds, or HTTP/ISO timestamp. Sensitive mutating routes require this or X-Steward-Request-Expires-At when request-expiry or request signatures are enforced.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Request-Expires-At",
+            "in": "header",
+            "required": false,
+            "description": "Unix seconds, Unix milliseconds, or HTTP/ISO expiry time. Sensitive mutating routes require this or X-Steward-Request-Timestamp when request-expiry or request signatures are enforced.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Signature",
+            "in": "header",
+            "required": false,
+            "description": "Authorization signature for sensitive mutating routes when STEWARD_REQUIRE_AUTH_SIGNATURE=true or production enforcement is enabled. Use v1=<hmac-sha256> or p256=<signature>.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Signing-Key-Id",
+            "in": "header",
+            "required": false,
+            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "expectedRevision",
+                  "reason"
+                ],
+                "properties": {
+                  "expectedRevision": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "reason": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "408": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-steward-hardening": {
+          "sensitive": true,
+          "sensitivePrefix": "/v2/provider-accounts",
+          "requestExpiry": {
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "acceptedHeaders": [
+              "X-Steward-Request-Timestamp",
+              "X-Steward-Request-Expires-At"
+            ]
+          },
+          "authorizationSignature": {
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "header": "X-Steward-Signature",
+            "schemes": [
+              "v1=hmac-sha256",
+              "p256=ecdsa-secp256r1"
+            ],
+            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+          },
+          "idempotency": {
+            "header": "Idempotency-Key",
+            "requiredForSignedRequests": true,
+            "replayStorage": "enabled when callers provide a key in a replay-safe authenticated context"
+          }
+        }
+      }
+    },
+    "/v2/provider-accounts/{id}/disable": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "post": {
+        "tags": [
+          "Provider Authority"
+        ],
+        "summary": "Disable provider account",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "description": "Required for signed sensitive requests and recommended for all sensitive mutating requests. Replays are scoped to authenticated or explicitly signed contexts.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Request-Timestamp",
+            "in": "header",
+            "required": false,
+            "description": "Unix seconds, Unix milliseconds, or HTTP/ISO timestamp. Sensitive mutating routes require this or X-Steward-Request-Expires-At when request-expiry or request signatures are enforced.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Request-Expires-At",
+            "in": "header",
+            "required": false,
+            "description": "Unix seconds, Unix milliseconds, or HTTP/ISO expiry time. Sensitive mutating routes require this or X-Steward-Request-Timestamp when request-expiry or request signatures are enforced.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Signature",
+            "in": "header",
+            "required": false,
+            "description": "Authorization signature for sensitive mutating routes when STEWARD_REQUIRE_AUTH_SIGNATURE=true or production enforcement is enabled. Use v1=<hmac-sha256> or p256=<signature>.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Signing-Key-Id",
+            "in": "header",
+            "required": false,
+            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "expectedRevision",
+                  "reason"
+                ],
+                "properties": {
+                  "expectedRevision": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "reason": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "408": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-steward-hardening": {
+          "sensitive": true,
+          "sensitivePrefix": "/v2/provider-accounts",
+          "requestExpiry": {
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "acceptedHeaders": [
+              "X-Steward-Request-Timestamp",
+              "X-Steward-Request-Expires-At"
+            ]
+          },
+          "authorizationSignature": {
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "header": "X-Steward-Signature",
+            "schemes": [
+              "v1=hmac-sha256",
+              "p256=ecdsa-secp256r1"
+            ],
+            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+          },
+          "idempotency": {
+            "header": "Idempotency-Key",
+            "requiredForSignedRequests": true,
+            "replayStorage": "enabled when callers provide a key in a replay-safe authenticated context"
+          }
+        }
+      }
+    },
+    "/v2/provider-accounts/{id}/operations": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "tags": [
+          "Provider Authority"
+        ],
+        "summary": "List provider operations",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "workspaceId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": true
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Provider Authority"
+        ],
+        "summary": "Register provider operation",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "description": "Required for signed sensitive requests and recommended for all sensitive mutating requests. Replays are scoped to authenticated or explicitly signed contexts.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Request-Timestamp",
+            "in": "header",
+            "required": false,
+            "description": "Unix seconds, Unix milliseconds, or HTTP/ISO timestamp. Sensitive mutating routes require this or X-Steward-Request-Expires-At when request-expiry or request signatures are enforced.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Request-Expires-At",
+            "in": "header",
+            "required": false,
+            "description": "Unix seconds, Unix milliseconds, or HTTP/ISO expiry time. Sensitive mutating routes require this or X-Steward-Request-Timestamp when request-expiry or request signatures are enforced.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Signature",
+            "in": "header",
+            "required": false,
+            "description": "Authorization signature for sensitive mutating routes when STEWARD_REQUIRE_AUTH_SIGNATURE=true or production enforcement is enabled. Use v1=<hmac-sha256> or p256=<signature>.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Signing-Key-Id",
+            "in": "header",
+            "required": false,
+            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "expectedRevision",
+                  "reason"
+                ],
+                "properties": {
+                  "expectedRevision": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "reason": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "408": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-steward-hardening": {
+          "sensitive": true,
+          "sensitivePrefix": "/v2/provider-accounts",
+          "requestExpiry": {
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "acceptedHeaders": [
+              "X-Steward-Request-Timestamp",
+              "X-Steward-Request-Expires-At"
+            ]
+          },
+          "authorizationSignature": {
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "header": "X-Steward-Signature",
+            "schemes": [
+              "v1=hmac-sha256",
+              "p256=ecdsa-secp256r1"
+            ],
+            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+          },
+          "idempotency": {
+            "header": "Idempotency-Key",
+            "requiredForSignedRequests": true,
+            "replayStorage": "enabled when callers provide a key in a replay-safe authenticated context"
+          }
+        }
+      }
+    },
+    "/v2/provider-role-bindings": {
+      "get": {
+        "tags": [
+          "Provider Authority"
+        ],
+        "summary": "List provider role bindings",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "workspaceId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": true
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Provider Authority"
+        ],
+        "summary": "Issue provider role binding",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "description": "Required for signed sensitive requests and recommended for all sensitive mutating requests. Replays are scoped to authenticated or explicitly signed contexts.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Request-Timestamp",
+            "in": "header",
+            "required": false,
+            "description": "Unix seconds, Unix milliseconds, or HTTP/ISO timestamp. Sensitive mutating routes require this or X-Steward-Request-Expires-At when request-expiry or request signatures are enforced.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Request-Expires-At",
+            "in": "header",
+            "required": false,
+            "description": "Unix seconds, Unix milliseconds, or HTTP/ISO expiry time. Sensitive mutating routes require this or X-Steward-Request-Timestamp when request-expiry or request signatures are enforced.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Signature",
+            "in": "header",
+            "required": false,
+            "description": "Authorization signature for sensitive mutating routes when STEWARD_REQUIRE_AUTH_SIGNATURE=true or production enforcement is enabled. Use v1=<hmac-sha256> or p256=<signature>.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Signing-Key-Id",
+            "in": "header",
+            "required": false,
+            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "expectedRevision",
+                  "reason"
+                ],
+                "properties": {
+                  "expectedRevision": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "reason": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "408": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-steward-hardening": {
+          "sensitive": true,
+          "sensitivePrefix": "/v2/provider-role-bindings",
+          "requestExpiry": {
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "acceptedHeaders": [
+              "X-Steward-Request-Timestamp",
+              "X-Steward-Request-Expires-At"
+            ]
+          },
+          "authorizationSignature": {
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "header": "X-Steward-Signature",
+            "schemes": [
+              "v1=hmac-sha256",
+              "p256=ecdsa-secp256r1"
+            ],
+            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+          },
+          "idempotency": {
+            "header": "Idempotency-Key",
+            "requiredForSignedRequests": true,
+            "replayStorage": "enabled when callers provide a key in a replay-safe authenticated context"
+          }
+        }
+      }
+    },
+    "/v2/provider-role-bindings/{id}/revoke": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "post": {
+        "tags": [
+          "Provider Authority"
+        ],
+        "summary": "Revoke provider role binding",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "description": "Required for signed sensitive requests and recommended for all sensitive mutating requests. Replays are scoped to authenticated or explicitly signed contexts.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Request-Timestamp",
+            "in": "header",
+            "required": false,
+            "description": "Unix seconds, Unix milliseconds, or HTTP/ISO timestamp. Sensitive mutating routes require this or X-Steward-Request-Expires-At when request-expiry or request signatures are enforced.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Request-Expires-At",
+            "in": "header",
+            "required": false,
+            "description": "Unix seconds, Unix milliseconds, or HTTP/ISO expiry time. Sensitive mutating routes require this or X-Steward-Request-Timestamp when request-expiry or request signatures are enforced.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Signature",
+            "in": "header",
+            "required": false,
+            "description": "Authorization signature for sensitive mutating routes when STEWARD_REQUIRE_AUTH_SIGNATURE=true or production enforcement is enabled. Use v1=<hmac-sha256> or p256=<signature>.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Signing-Key-Id",
+            "in": "header",
+            "required": false,
+            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "expectedRevision",
+                  "reason"
+                ],
+                "properties": {
+                  "expectedRevision": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "reason": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "408": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-steward-hardening": {
+          "sensitive": true,
+          "sensitivePrefix": "/v2/provider-role-bindings",
+          "requestExpiry": {
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "acceptedHeaders": [
+              "X-Steward-Request-Timestamp",
+              "X-Steward-Request-Expires-At"
+            ]
+          },
+          "authorizationSignature": {
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "header": "X-Steward-Signature",
+            "schemes": [
+              "v1=hmac-sha256",
+              "p256=ecdsa-secp256r1"
+            ],
+            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+          },
+          "idempotency": {
+            "header": "Idempotency-Key",
+            "requiredForSignedRequests": true,
+            "replayStorage": "enabled when callers provide a key in a replay-safe authenticated context"
+          }
+        }
+      }
+    },
+    "/v2/provider-grants": {
+      "get": {
+        "tags": [
+          "Provider Authority"
+        ],
+        "summary": "List direct provider grants",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "workspaceId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": true
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Provider Authority"
+        ],
+        "summary": "Issue non-delegable provider grant",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "description": "Required for signed sensitive requests and recommended for all sensitive mutating requests. Replays are scoped to authenticated or explicitly signed contexts.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Request-Timestamp",
+            "in": "header",
+            "required": false,
+            "description": "Unix seconds, Unix milliseconds, or HTTP/ISO timestamp. Sensitive mutating routes require this or X-Steward-Request-Expires-At when request-expiry or request signatures are enforced.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Request-Expires-At",
+            "in": "header",
+            "required": false,
+            "description": "Unix seconds, Unix milliseconds, or HTTP/ISO expiry time. Sensitive mutating routes require this or X-Steward-Request-Timestamp when request-expiry or request signatures are enforced.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Signature",
+            "in": "header",
+            "required": false,
+            "description": "Authorization signature for sensitive mutating routes when STEWARD_REQUIRE_AUTH_SIGNATURE=true or production enforcement is enabled. Use v1=<hmac-sha256> or p256=<signature>.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Signing-Key-Id",
+            "in": "header",
+            "required": false,
+            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "expectedRevision",
+                  "reason"
+                ],
+                "properties": {
+                  "expectedRevision": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "reason": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "408": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-steward-hardening": {
+          "sensitive": true,
+          "sensitivePrefix": "/v2/provider-grants",
+          "requestExpiry": {
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "acceptedHeaders": [
+              "X-Steward-Request-Timestamp",
+              "X-Steward-Request-Expires-At"
+            ]
+          },
+          "authorizationSignature": {
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "header": "X-Steward-Signature",
+            "schemes": [
+              "v1=hmac-sha256",
+              "p256=ecdsa-secp256r1"
+            ],
+            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+          },
+          "idempotency": {
+            "header": "Idempotency-Key",
+            "requiredForSignedRequests": true,
+            "replayStorage": "enabled when callers provide a key in a replay-safe authenticated context"
+          }
+        }
+      }
+    },
+    "/v2/provider-grants/{id}/revoke": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "post": {
+        "tags": [
+          "Provider Authority"
+        ],
+        "summary": "Revoke provider grant",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "description": "Required for signed sensitive requests and recommended for all sensitive mutating requests. Replays are scoped to authenticated or explicitly signed contexts.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Request-Timestamp",
+            "in": "header",
+            "required": false,
+            "description": "Unix seconds, Unix milliseconds, or HTTP/ISO timestamp. Sensitive mutating routes require this or X-Steward-Request-Expires-At when request-expiry or request signatures are enforced.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Request-Expires-At",
+            "in": "header",
+            "required": false,
+            "description": "Unix seconds, Unix milliseconds, or HTTP/ISO expiry time. Sensitive mutating routes require this or X-Steward-Request-Timestamp when request-expiry or request signatures are enforced.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Signature",
+            "in": "header",
+            "required": false,
+            "description": "Authorization signature for sensitive mutating routes when STEWARD_REQUIRE_AUTH_SIGNATURE=true or production enforcement is enabled. Use v1=<hmac-sha256> or p256=<signature>.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Signing-Key-Id",
+            "in": "header",
+            "required": false,
+            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "expectedRevision",
+                  "reason"
+                ],
+                "properties": {
+                  "expectedRevision": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "reason": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "408": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-steward-hardening": {
+          "sensitive": true,
+          "sensitivePrefix": "/v2/provider-grants",
+          "requestExpiry": {
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "acceptedHeaders": [
+              "X-Steward-Request-Timestamp",
+              "X-Steward-Request-Expires-At"
+            ]
+          },
+          "authorizationSignature": {
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "header": "X-Steward-Signature",
+            "schemes": [
+              "v1=hmac-sha256",
+              "p256=ecdsa-secp256r1"
+            ],
+            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+          },
+          "idempotency": {
+            "header": "Idempotency-Key",
+            "requiredForSignedRequests": true,
+            "replayStorage": "enabled when callers provide a key in a replay-safe authenticated context"
+          }
+        }
+      }
+    },
+    "/v2/provider-access/check": {
+      "post": {
+        "tags": [
+          "Provider Authority"
+        ],
+        "summary": "Evaluate structural provider access without execution policy",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -5458,7 +5458,8 @@
                 "properties": {
                   "expectedRevision": {
                     "type": "integer",
-                    "minimum": 0
+                    "minimum": 0,
+                    "description": "Compare-and-set token: MUST equal the current tenant authority revision (provider_authority_tenant_state.revision). Read it from the authorityRevision field returned by GET /v2/workspaces (the only listing that surfaces it). Mismatch returns 409 revision_conflict."
                   },
                   "reason": {
                     "type": "string"
@@ -5765,7 +5766,8 @@
                 "properties": {
                   "expectedRevision": {
                     "type": "integer",
-                    "minimum": 0
+                    "minimum": 0,
+                    "description": "Compare-and-set token: MUST equal this object's own current revision. Mismatch returns 409 revision_conflict."
                   },
                   "reason": {
                     "type": "string"
@@ -6227,7 +6229,8 @@
                 "properties": {
                   "expectedRevision": {
                     "type": "integer",
-                    "minimum": 0
+                    "minimum": 0,
+                    "description": "Compare-and-set token: MUST equal the parent workspace's current revision. Mismatch returns 409 revision_conflict."
                   },
                   "reason": {
                     "type": "string"
@@ -6534,7 +6537,8 @@
                 "properties": {
                   "expectedRevision": {
                     "type": "integer",
-                    "minimum": 0
+                    "minimum": 0,
+                    "description": "Compare-and-set token: MUST equal this object's own current revision. Mismatch returns 409 revision_conflict."
                   },
                   "reason": {
                     "type": "string"
@@ -7006,7 +7010,8 @@
                 "properties": {
                   "expectedRevision": {
                     "type": "integer",
-                    "minimum": 0
+                    "minimum": 0,
+                    "description": "Compare-and-set token: MUST equal the parent provider account's current revision. Mismatch returns 409 revision_conflict."
                   },
                   "reason": {
                     "type": "string"
@@ -7468,7 +7473,8 @@
                 "properties": {
                   "expectedRevision": {
                     "type": "integer",
-                    "minimum": 0
+                    "minimum": 0,
+                    "description": "Compare-and-set token whose binding target depends on role_key: for role_key='tenant_authority_admin' it MUST equal the tenant authority revision (provider_authority_tenant_state.revision, from the authorityRevision field of GET /v2/workspaces); for every workspace-scoped role (workspace_admin/operator/viewer/approver) it MUST equal the target workspace's current revision. Mismatch returns 409 revision_conflict."
                   },
                   "reason": {
                     "type": "string"
@@ -7775,7 +7781,8 @@
                 "properties": {
                   "expectedRevision": {
                     "type": "integer",
-                    "minimum": 0
+                    "minimum": 0,
+                    "description": "Compare-and-set token: MUST equal this object's own current revision. Mismatch returns 409 revision_conflict."
                   },
                   "reason": {
                     "type": "string"
@@ -8237,7 +8244,8 @@
                 "properties": {
                   "expectedRevision": {
                     "type": "integer",
-                    "minimum": 0
+                    "minimum": 0,
+                    "description": "Compare-and-set token: MUST equal the parent workspace's current revision. Mismatch returns 409 revision_conflict."
                   },
                   "reason": {
                     "type": "string"
@@ -8544,7 +8552,8 @@
                 "properties": {
                   "expectedRevision": {
                     "type": "integer",
-                    "minimum": 0
+                    "minimum": 0,
+                    "description": "Compare-and-set token: MUST equal this object's own current revision. Mismatch returns 409 revision_conflict."
                   },
                   "reason": {
                     "type": "string"

--- a/packages/api/src/__tests__/openapi-contract.test.ts
+++ b/packages/api/src/__tests__/openapi-contract.test.ts
@@ -905,6 +905,17 @@ describe("generated OpenAPI contract", () => {
     expect(simulateBody.properties).toHaveProperty("request");
   });
 
+  it("registers workspace-scoped provider authority v2 surfaces", () => {
+    const paths = getOpenApiSpec().paths;
+    expect(paths["/v2/workspaces"]).toHaveProperty("post");
+    expect(paths["/v2/provider-accounts"]).toHaveProperty("post");
+    expect(paths["/v2/provider-accounts/{id}/operations"]).toHaveProperty("post");
+    expect(paths["/v2/provider-role-bindings"]).toHaveProperty("post");
+    expect(paths["/v2/provider-grants"]).toHaveProperty("post");
+    expect(paths["/v2/provider-grants/{id}/revoke"]).toHaveProperty("post");
+    expect(paths["/v2/provider-access/check"]).toHaveProperty("post");
+  });
+
   it("serves the generated contract at /openapi.json", async () => {
     process.env.DATABASE_URL ??= "postgres://openapi-contract.invalid/steward";
     process.env.STEWARD_MASTER_PASSWORD ??= "openapi-contract-master-password";

--- a/packages/api/src/__tests__/provider-authority.test.ts
+++ b/packages/api/src/__tests__/provider-authority.test.ts
@@ -447,6 +447,30 @@ describe("provider authority foundation", () => {
     expect(mixed.matchedGrantIds).toEqual([]);
   });
 
+  test("expired tenant-admin authority does not act or reopen owner bootstrap", async () => {
+    const [adminBinding] = await getDb()
+      .select()
+      .from(providerRoleBindings)
+      .where(eq(providerRoleBindings.roleKey, "tenant_authority_admin"));
+    await getDb()
+      .update(providerRoleBindings)
+      .set({ expiresAt: new Date(Date.now() - 1_000) })
+      .where(eq(providerRoleBindings.id, adminBinding.id));
+    await expect(
+      store.createWorkspace(
+        mutation({ actorUserId: ADMIN, tenantRole: "admin", expectedRevision: 2 }),
+        { key: "expired-admin", name: "Denied", environment: "production" },
+      ),
+    ).rejects.toMatchObject({ code: "forbidden" });
+    await expect(
+      store.createWorkspace(mutation({ expectedRevision: 2 }), {
+        key: "bootstrap-cannot-reopen",
+        name: "Denied",
+        environment: "production",
+      }),
+    ).rejects.toMatchObject({ code: "forbidden" });
+  });
+
   test("mandatory audit runs before each successful mutation", () => {
     expect(auditEvents.some((event) => event.action === "provider.role_binding.issue")).toBe(true);
     expect(auditEvents.some((event) => event.action === "provider.workspace.create")).toBe(true);

--- a/packages/api/src/__tests__/provider-authority.test.ts
+++ b/packages/api/src/__tests__/provider-authority.test.ts
@@ -223,16 +223,29 @@ describe("provider authority foundation", () => {
   test("enforces matrix scope and non-enumerating cross-workspace/tenant behavior", async () => {
     await getDb()
       .insert(providerRoleBindings)
-      .values({
-        tenantId: "tenant-main",
-        workspaceId: WORKSPACE_A,
-        principalType: "human",
-        principalId: OTHER,
-        roleKey: "workspace_admin",
-        operationKeys: ["github.issue.list"],
-        grantedByUserId: ADMIN,
-        reason: "scoped",
-      });
+      .values([
+        {
+          tenantId: "tenant-main",
+          workspaceId: WORKSPACE_A,
+          principalType: "human",
+          principalId: OTHER,
+          roleKey: "workspace_admin",
+          operationKeys: ["github.issue.list"],
+          grantedByUserId: ADMIN,
+          reason: "scoped",
+        },
+        {
+          tenantId: "tenant-main",
+          workspaceId: WORKSPACE_B,
+          principalType: "human",
+          principalId: OWNER,
+          roleKey: "workspace_admin",
+          operationKeys: ["github.issue.list"],
+          environment: "staging",
+          grantedByUserId: ADMIN,
+          reason: "wrong environment",
+        },
+      ]);
     await expect(
       store.createProviderAccount(
         mutation({ actorUserId: OTHER, tenantRole: "member", expectedRevision: 1 }),
@@ -241,6 +254,17 @@ describe("provider authority foundation", () => {
           adapterKey: "github",
           externalRef: "forbidden",
           displayName: "Forbidden",
+        },
+      ),
+    ).rejects.toMatchObject({ code: "not_found", status: 404 });
+    await expect(
+      store.createProviderAccount(
+        mutation({ actorUserId: OWNER, tenantRole: "owner", expectedRevision: 1 }),
+        {
+          workspaceId: WORKSPACE_B,
+          adapterKey: "github",
+          externalRef: "wrong-environment",
+          displayName: "Wrong Environment",
         },
       ),
     ).rejects.toMatchObject({ code: "not_found", status: 404 });

--- a/packages/api/src/__tests__/provider-authority.test.ts
+++ b/packages/api/src/__tests__/provider-authority.test.ts
@@ -1,0 +1,431 @@
+import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
+import {
+  agents,
+  closeDb,
+  getDb,
+  providerAccounts,
+  providerGrants,
+  providerOperations,
+  providerRoleBindings,
+  tenants,
+  users,
+  userTenants,
+  workspaces,
+} from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { eq } from "drizzle-orm";
+import { type AuthorityAudit, ProviderAuthorityStore } from "../services/provider-authority-store";
+
+setDefaultTimeout(120_000);
+
+const OWNER = "10000000-0000-4000-8000-000000000001";
+const ADMIN = "10000000-0000-4000-8000-000000000002";
+const OTHER = "10000000-0000-4000-8000-000000000003";
+const WORKSPACE_A = "20000000-0000-4000-8000-000000000001";
+const WORKSPACE_B = "20000000-0000-4000-8000-000000000002";
+const ACCOUNT_A = "30000000-0000-4000-8000-000000000001";
+const ACCOUNT_B = "30000000-0000-4000-8000-000000000002";
+const OP_A_READ = "40000000-0000-4000-8000-000000000001";
+const OP_A_WRITE = "40000000-0000-4000-8000-000000000002";
+const OP_B_READ = "40000000-0000-4000-8000-000000000003";
+const store = new ProviderAuthorityStore();
+const auditEvents: Array<{ action: string; resourceType: string }> = [];
+const audit: AuthorityAudit = async (event) => {
+  auditEvents.push(event);
+};
+
+function mutation(
+  overrides: Partial<{
+    tenantId: string;
+    actorUserId: string;
+    tenantRole: string;
+    mfaVerifiedAt: number;
+    idempotencyKey: string;
+    expectedRevision: number;
+    reason: string;
+    audit: AuthorityAudit;
+  }> = {},
+) {
+  return {
+    tenantId: "tenant-main",
+    actorUserId: OWNER,
+    tenantRole: "owner",
+    mfaVerifiedAt: Date.now(),
+    idempotencyKey: `idem-${crypto.randomUUID()}`,
+    expectedRevision: 0,
+    reason: "authority test",
+    audit,
+    ...overrides,
+  };
+}
+
+async function seedCore() {
+  const db = getDb();
+  await db.insert(tenants).values([
+    { id: "tenant-main", name: "Main", apiKeyHash: "main-hash" },
+    { id: "tenant-foreign", name: "Foreign", apiKeyHash: "foreign-hash" },
+  ]);
+  await db.insert(users).values([
+    { id: OWNER, email: "owner@authority.test" },
+    { id: ADMIN, email: "admin@authority.test" },
+    { id: OTHER, email: "other@authority.test" },
+  ]);
+  await db.insert(userTenants).values([
+    { userId: OWNER, tenantId: "tenant-main", role: "owner" },
+    { userId: ADMIN, tenantId: "tenant-main", role: "admin" },
+    { userId: OTHER, tenantId: "tenant-main", role: "member" },
+  ]);
+  await db.insert(agents).values([
+    { id: "agent-x", tenantId: "tenant-main", name: "X", walletAddress: "0x1" },
+    { id: "agent-y", tenantId: "tenant-main", name: "Y", walletAddress: "0x2" },
+    { id: "foreign-agent", tenantId: "tenant-foreign", name: "F", walletAddress: "0x3" },
+  ]);
+  await db.insert(workspaces).values([
+    {
+      id: WORKSPACE_A,
+      tenantId: "tenant-main",
+      key: "client-a",
+      name: "Client A",
+      environment: "production",
+      createdBy: OWNER,
+    },
+    {
+      id: WORKSPACE_B,
+      tenantId: "tenant-main",
+      key: "client-b",
+      name: "Client B",
+      environment: "production",
+      createdBy: OWNER,
+    },
+  ]);
+  await db.insert(providerAccounts).values([
+    {
+      id: ACCOUNT_A,
+      tenantId: "tenant-main",
+      workspaceId: WORKSPACE_A,
+      adapterKey: "github",
+      externalRef: "a",
+      displayName: "A",
+    },
+    {
+      id: ACCOUNT_B,
+      tenantId: "tenant-main",
+      workspaceId: WORKSPACE_B,
+      adapterKey: "github",
+      externalRef: "b",
+      displayName: "B",
+    },
+  ]);
+  await db.insert(providerOperations).values([
+    {
+      id: OP_A_READ,
+      tenantId: "tenant-main",
+      workspaceId: WORKSPACE_A,
+      providerAccountId: ACCOUNT_A,
+      operationKey: "github.issue.list",
+      riskClass: "read",
+    },
+    {
+      id: OP_A_WRITE,
+      tenantId: "tenant-main",
+      workspaceId: WORKSPACE_A,
+      providerAccountId: ACCOUNT_A,
+      operationKey: "github.pr.comment.create",
+      riskClass: "consequential",
+    },
+    {
+      id: OP_B_READ,
+      tenantId: "tenant-main",
+      workspaceId: WORKSPACE_B,
+      providerAccountId: ACCOUNT_B,
+      operationKey: "github.issue.list",
+      riskClass: "read",
+    },
+  ]);
+}
+
+describe("provider authority foundation", () => {
+  beforeAll(async () => {
+    process.env.STEWARD_PGLITE_MEMORY = "true";
+    const { db, client } = await createPGLiteDb("memory://");
+    setPGLiteOverride(db, async () => client.close());
+    await seedCore();
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    delete process.env.STEWARD_PGLITE_MEMORY;
+  });
+
+  test("owner bootstrap transitions one way to explicit tenant authority", async () => {
+    const binding = await store.issueRoleBinding(mutation(), {
+      principalType: "human",
+      principalId: ADMIN,
+      roleKey: "tenant_authority_admin",
+      operationKeys: [],
+    });
+    expect(binding.roleKey).toBe("tenant_authority_admin");
+    await expect(
+      store.createWorkspace(mutation({ expectedRevision: 1 }), {
+        key: "owner-after-bootstrap",
+        name: "Denied",
+        environment: "production",
+      }),
+    ).rejects.toMatchObject({ code: "forbidden" });
+    const created = await store.createWorkspace(
+      mutation({ actorUserId: ADMIN, tenantRole: "admin", expectedRevision: 1 }),
+      { key: "explicit-admin", name: "Allowed", environment: "production" },
+    );
+    expect(created.key).toBe("explicit-admin");
+  });
+
+  test("every mutation requires authority, recent MFA, idempotency, revision, and successful pre-commit audit", async () => {
+    const base = mutation({ actorUserId: ADMIN, tenantRole: "admin", expectedRevision: 2 });
+    await expect(
+      store.createWorkspace(
+        { ...base, actorUserId: OTHER, tenantRole: "member" },
+        { key: "noauth", name: "No", environment: "production" },
+      ),
+    ).rejects.toMatchObject({ code: "forbidden" });
+    await expect(
+      store.createWorkspace(
+        { ...base, mfaVerifiedAt: Date.now() - 600_000 },
+        { key: "nomfa", name: "No", environment: "production" },
+      ),
+    ).rejects.toMatchObject({ code: "forbidden" });
+    await expect(
+      store.createWorkspace(
+        { ...base, idempotencyKey: "" },
+        { key: "noidem", name: "No", environment: "production" },
+      ),
+    ).rejects.toMatchObject({ code: "bad_request" });
+    await expect(
+      store.createWorkspace(
+        { ...base, expectedRevision: 999 },
+        { key: "stale", name: "No", environment: "production" },
+      ),
+    ).rejects.toMatchObject({ code: "revision_conflict" });
+    const before = (await getDb().select().from(workspaces)).length;
+    await expect(
+      store.createWorkspace(
+        {
+          ...base,
+          audit: async () => {
+            throw new Error("audit unavailable");
+          },
+        },
+        { key: "noaudit", name: "No", environment: "production" },
+      ),
+    ).rejects.toThrow("audit unavailable");
+    expect((await getDb().select().from(workspaces)).length).toBe(before);
+  });
+
+  test("enforces matrix scope and non-enumerating cross-workspace/tenant behavior", async () => {
+    await getDb()
+      .insert(providerRoleBindings)
+      .values({
+        tenantId: "tenant-main",
+        workspaceId: WORKSPACE_A,
+        principalType: "human",
+        principalId: OTHER,
+        roleKey: "workspace_admin",
+        operationKeys: ["github.issue.list"],
+        grantedByUserId: ADMIN,
+        reason: "scoped",
+      });
+    await expect(
+      store.createProviderAccount(
+        mutation({ actorUserId: OTHER, tenantRole: "member", expectedRevision: 1 }),
+        {
+          workspaceId: WORKSPACE_B,
+          adapterKey: "github",
+          externalRef: "forbidden",
+          displayName: "Forbidden",
+        },
+      ),
+    ).rejects.toMatchObject({ code: "not_found", status: 404 });
+    await expect(
+      store.createProviderAccount(
+        mutation({
+          actorUserId: ADMIN,
+          tenantRole: "admin",
+          tenantId: "tenant-main",
+          expectedRevision: 1,
+        }),
+        {
+          workspaceId: "90000000-0000-4000-8000-000000000001",
+          adapterKey: "github",
+          externalRef: "guessed",
+          displayName: "Guessed",
+        },
+      ),
+    ).rejects.toMatchObject({ code: "not_found", status: 404 });
+    expect(await store.listProviderAccounts("tenant-main", WORKSPACE_B)).toHaveLength(1);
+    expect(
+      await store.listProviderAccounts("tenant-main", "90000000-0000-4000-8000-000000000001"),
+    ).toEqual([]);
+  });
+
+  test("protects the last tenant authority admin", async () => {
+    const [adminBinding] = await getDb()
+      .select()
+      .from(providerRoleBindings)
+      .where(eq(providerRoleBindings.roleKey, "tenant_authority_admin"));
+    await expect(
+      store.revokeRoleBinding(
+        mutation({
+          actorUserId: ADMIN,
+          tenantRole: "admin",
+          expectedRevision: adminBinding.revision,
+        }),
+        adminBinding.id,
+      ),
+    ).rejects.toMatchObject({ code: "last_admin" });
+  });
+
+  test("grant operation sets attenuate the administrator mandate and grants are non-delegable", async () => {
+    const [workspace] = await getDb()
+      .select()
+      .from(workspaces)
+      .where(eq(workspaces.id, WORKSPACE_A));
+    await expect(
+      store.issueGrant(
+        mutation({
+          actorUserId: OTHER,
+          tenantRole: "member",
+          expectedRevision: workspace.revision,
+        }),
+        {
+          workspaceId: WORKSPACE_A,
+          providerAccountId: ACCOUNT_A,
+          agentId: "agent-x",
+          operationKeys: ["github.pr.comment.create"],
+          expiresAt: new Date(Date.now() + 60_000),
+        },
+      ),
+    ).rejects.toMatchObject({ code: "forbidden" });
+    const grant = await store.issueGrant(
+      mutation({ actorUserId: OTHER, tenantRole: "member", expectedRevision: workspace.revision }),
+      {
+        workspaceId: WORKSPACE_A,
+        providerAccountId: ACCOUNT_A,
+        agentId: "agent-x",
+        operationKeys: ["github.issue.list"],
+        expiresAt: new Date(Date.now() + 60_000),
+        environment: "production",
+      },
+    );
+    expect(grant.operationKeys).toEqual(["github.issue.list"]);
+    expect("parentGrantId" in grant).toBe(false);
+    expect("delegateGrant" in store).toBe(false);
+  });
+
+  test("access checks enforce time bounds, environment, lifecycle, and no implicit admin invoke", async () => {
+    const common = {
+      tenantId: "tenant-main",
+      workspaceId: WORKSPACE_A,
+      actor: { type: "agent" as const, id: "agent-x" },
+      providerAccountId: ACCOUNT_A,
+      operationKey: "github.issue.list",
+      environment: "production" as const,
+    };
+    expect(
+      (await store.checkAccess({ ...common, evaluatedAt: new Date().toISOString() })).effect,
+    ).toBe("allow");
+    await getDb()
+      .insert(providerGrants)
+      .values([
+        {
+          tenantId: "tenant-main",
+          workspaceId: WORKSPACE_A,
+          providerAccountId: ACCOUNT_A,
+          agentId: "agent-y",
+          operationKeys: ["github.issue.list"],
+          environment: "staging",
+          expiresAt: new Date(Date.now() + 60_000),
+          grantedByUserId: ADMIN,
+          reason: "wrong env",
+        },
+        {
+          tenantId: "tenant-main",
+          workspaceId: WORKSPACE_A,
+          providerAccountId: ACCOUNT_A,
+          agentId: "agent-y",
+          operationKeys: ["github.issue.list"],
+          notBefore: new Date(Date.now() + 60_000),
+          expiresAt: new Date(Date.now() + 120_000),
+          grantedByUserId: ADMIN,
+          reason: "future",
+        },
+        {
+          tenantId: "tenant-main",
+          workspaceId: WORKSPACE_A,
+          providerAccountId: ACCOUNT_A,
+          agentId: "agent-y",
+          operationKeys: ["github.issue.list"],
+          expiresAt: new Date(Date.now() - 1_000),
+          grantedByUserId: ADMIN,
+          reason: "expired",
+        },
+      ]);
+    expect(
+      (
+        await store.checkAccess({
+          ...common,
+          actor: { type: "agent", id: "agent-y" },
+          evaluatedAt: new Date().toISOString(),
+        })
+      ).reasonCode,
+    ).toBe("no_matching_authority");
+    expect(
+      (
+        await store.checkAccess({
+          ...common,
+          actor: { type: "human", id: ADMIN },
+          evaluatedAt: new Date().toISOString(),
+        })
+      ).effect,
+    ).toBe("deny");
+  });
+
+  test("Client A allow cannot be replayed against Client B or mixed identifiers", async () => {
+    const base = {
+      tenantId: "tenant-main",
+      actor: { type: "agent" as const, id: "agent-x" },
+      operationKey: "github.issue.list",
+      environment: "production" as const,
+      evaluatedAt: new Date().toISOString(),
+    };
+    const allow = await store.checkAccess({
+      ...base,
+      workspaceId: WORKSPACE_A,
+      providerAccountId: ACCOUNT_A,
+    });
+    const sibling = await store.checkAccess({
+      ...base,
+      workspaceId: WORKSPACE_B,
+      providerAccountId: ACCOUNT_B,
+    });
+    const mixed = await store.checkAccess({
+      ...base,
+      workspaceId: WORKSPACE_A,
+      providerAccountId: ACCOUNT_B,
+    });
+    const copied = await store.checkAccess({
+      ...base,
+      workspaceId: WORKSPACE_B,
+      providerAccountId: ACCOUNT_A,
+    });
+    expect(allow.effect).toBe("allow");
+    expect(sibling.effect).toBe("deny");
+    expect(mixed.reasonCode).toBe("resource_not_found");
+    expect(copied.reasonCode).toBe("resource_not_found");
+    expect(mixed.matchedGrantIds).toEqual([]);
+  });
+
+  test("mandatory audit runs before each successful mutation", () => {
+    expect(auditEvents.some((event) => event.action === "provider.role_binding.issue")).toBe(true);
+    expect(auditEvents.some((event) => event.action === "provider.workspace.create")).toBe(true);
+    expect(auditEvents.some((event) => event.action === "provider.grant.issue")).toBe(true);
+  });
+});

--- a/packages/api/src/__tests__/provider-authority.test.ts
+++ b/packages/api/src/__tests__/provider-authority.test.ts
@@ -182,6 +182,13 @@ describe("provider authority foundation", () => {
   test("every mutation requires authority, recent MFA, idempotency, revision, and successful pre-commit audit", async () => {
     const base = mutation({ actorUserId: ADMIN, tenantRole: "admin", expectedRevision: 2 });
     await expect(
+      store.createWorkspace(base, {
+        key: 123 as unknown as string,
+        name: "Malformed",
+        environment: "production",
+      }),
+    ).rejects.toMatchObject({ code: "bad_request" });
+    await expect(
       store.createWorkspace(
         { ...base, actorUserId: OTHER, tenantRole: "member" },
         { key: "noauth", name: "No", environment: "production" },
@@ -284,6 +291,19 @@ describe("provider authority foundation", () => {
         },
       ),
     ).rejects.toMatchObject({ code: "not_found", status: 404 });
+    await expect(
+      store.issueRoleBinding(
+        mutation({ actorUserId: ADMIN, tenantRole: "admin", expectedRevision: 1 }),
+        {
+          workspaceId: WORKSPACE_B,
+          principalType: "human",
+          principalId: OTHER,
+          roleKey: "workspace_approver",
+          operationKeys: [],
+          notBefore: new Date("invalid"),
+        },
+      ),
+    ).rejects.toMatchObject({ code: "bad_request" });
     expect(await store.listProviderAccounts("tenant-main", WORKSPACE_B)).toHaveLength(1);
     expect(
       await store.listProviderAccounts("tenant-main", "90000000-0000-4000-8000-000000000001"),

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -58,6 +58,7 @@ import { globalWalletRoutes } from "./routes/global-wallet";
 import { intentRoutes } from "./routes/intents";
 import { platformRoutes } from "./routes/platform";
 import { policiesStandaloneRoutes } from "./routes/policies-standalone";
+import { providerAuthorityRoutes } from "./routes/provider-authority";
 import { secretsRoutes } from "./routes/secrets";
 import { tenantConfigRoutes } from "./routes/tenant-config";
 import { tenantRoutes } from "./routes/tenants";
@@ -179,6 +180,15 @@ export function createApp(): Hono<{ Variables: AppVariables }> {
   app.use("/condition_sets/*", (c, next) => tenantAuth(c, next));
   app.use("/v1/condition_sets", (c, next) => tenantAuth(c, next));
   app.use("/v1/condition_sets/*", (c, next) => tenantAuth(c, next));
+  app.use("/v2/workspaces", (c, next) => tenantAuth(c, next));
+  app.use("/v2/workspaces/*", (c, next) => tenantAuth(c, next));
+  app.use("/v2/provider-accounts", (c, next) => tenantAuth(c, next));
+  app.use("/v2/provider-accounts/*", (c, next) => tenantAuth(c, next));
+  app.use("/v2/provider-role-bindings", (c, next) => tenantAuth(c, next));
+  app.use("/v2/provider-role-bindings/*", (c, next) => tenantAuth(c, next));
+  app.use("/v2/provider-grants", (c, next) => tenantAuth(c, next));
+  app.use("/v2/provider-grants/*", (c, next) => tenantAuth(c, next));
+  app.use("/v2/provider-access/check", (c, next) => tenantAuth(c, next));
 
   return app;
 }
@@ -236,6 +246,7 @@ export function mountCoreIdempotencyAndRoutes(
   app.route("/v1/adapters", adapterRoutes);
   app.route("/v1/users", fiatRoutes);
   app.route("/policies", policiesStandaloneRoutes);
+  app.route("/v2", providerAuthorityRoutes);
   app.route("/condition-sets", conditionSetRoutes);
   app.route("/condition_sets", conditionSetRoutes);
   app.route("/v1/condition_sets", conditionSetRoutes);

--- a/packages/api/src/middleware/sensitive-paths.ts
+++ b/packages/api/src/middleware/sensitive-paths.ts
@@ -47,6 +47,10 @@ export const SENSITIVE_PATH_PREFIXES: readonly string[] = [
   "/v1/condition-sets",
   "/condition_sets",
   "/v1/condition_sets",
+  "/v2/workspaces",
+  "/v2/provider-accounts",
+  "/v2/provider-role-bindings",
+  "/v2/provider-grants",
 ];
 
 /**

--- a/packages/api/src/openapi.ts
+++ b/packages/api/src/openapi.ts
@@ -179,6 +179,89 @@ function errorResponses(): JsonSchema {
   };
 }
 
+function providerAuthorityPaths(): Record<string, OpenApiPathItem> {
+  const security = [{ bearerAuth: [] }];
+  const mutation = (summary: string, schema: JsonSchema): OpenApiOperation => ({
+    tags: ["Provider Authority"],
+    summary,
+    security,
+    parameters: [idempotencyKeyHeader],
+    requestBody: { required: true, content: { "application/json": { schema } } },
+    responses: {
+      "200": jsonResponse(apiResponse(metadataSchema)),
+      "201": jsonResponse(apiResponse(metadataSchema)),
+      ...errorResponses(),
+    },
+  });
+  const listing = (summary: string, workspace = false): OpenApiOperation => ({
+    tags: ["Provider Authority"],
+    summary,
+    security,
+    parameters: workspace ? [parameter("workspaceId", "query")] : [],
+    responses: {
+      "200": jsonResponse(apiResponse({ type: "array", items: metadataSchema })),
+      ...errorResponses(),
+    },
+  });
+  const revisionReason: JsonSchema = {
+    type: "object",
+    required: ["expectedRevision", "reason"],
+    properties: { expectedRevision: { type: "integer", minimum: 0 }, reason: stringSchema },
+    additionalProperties: true,
+  };
+  return {
+    "/v2/workspaces": {
+      get: listing("List workspaces"),
+      post: mutation("Create workspace", revisionReason),
+    },
+    "/v2/workspaces/{id}/disable": {
+      parameters: [parameter("id", "path")],
+      post: mutation("Disable workspace", revisionReason),
+    },
+    "/v2/provider-accounts": {
+      get: listing("List provider accounts", true),
+      post: mutation("Create provider account", revisionReason),
+    },
+    "/v2/provider-accounts/{id}/disable": {
+      parameters: [parameter("id", "path")],
+      post: mutation("Disable provider account", revisionReason),
+    },
+    "/v2/provider-accounts/{id}/operations": {
+      parameters: [parameter("id", "path")],
+      get: listing("List provider operations", true),
+      post: mutation("Register provider operation", revisionReason),
+    },
+    "/v2/provider-role-bindings": {
+      get: listing("List provider role bindings", true),
+      post: mutation("Issue provider role binding", revisionReason),
+    },
+    "/v2/provider-role-bindings/{id}/revoke": {
+      parameters: [parameter("id", "path")],
+      post: mutation("Revoke provider role binding", revisionReason),
+    },
+    "/v2/provider-grants": {
+      get: listing("List direct provider grants", true),
+      post: mutation("Issue non-delegable provider grant", revisionReason),
+    },
+    "/v2/provider-grants/{id}/revoke": {
+      parameters: [parameter("id", "path")],
+      post: mutation("Revoke provider grant", revisionReason),
+    },
+    "/v2/provider-access/check": {
+      post: {
+        tags: ["Provider Authority"],
+        summary: "Evaluate structural provider access without execution policy",
+        security,
+        requestBody: {
+          required: true,
+          content: { "application/json": { schema: metadataSchema } },
+        },
+        responses: { "200": jsonResponse(apiResponse(metadataSchema)), ...errorResponses() },
+      },
+    },
+  };
+}
+
 function parameter(name: string, location: "path" | "query", schema: JsonSchema = stringSchema) {
   return {
     name,
@@ -5685,6 +5768,7 @@ export function getOpenApiSpec() {
       { name: "Global Wallet" },
       { name: "Trading" },
       { name: "Tenant Config" },
+      { name: "Provider Authority" },
     ],
     components: {
       securitySchemes: {
@@ -5708,6 +5792,7 @@ export function getOpenApiSpec() {
     },
     paths: {
       ...authPaths(),
+      ...providerAuthorityPaths(),
       ...accountPaths(),
       ...accountPaths("/v1"),
       ...policyPaths(),

--- a/packages/api/src/openapi.ts
+++ b/packages/api/src/openapi.ts
@@ -203,49 +203,89 @@ function providerAuthorityPaths(): Record<string, OpenApiPathItem> {
       ...errorResponses(),
     },
   });
-  const revisionReason: JsonSchema = {
+  // `expectedRevision` is an optimistic-concurrency (compare-and-set) token, but
+  // WHICH object's revision it binds to differs per endpoint:
+  //   - tenant    -> the tenant-level authority watermark
+  //                  (provider_authority_tenant_state.revision)
+  //   - workspace -> the parent workspace's revision
+  //   - account   -> the parent provider account's revision
+  //   - self      -> the target object's own current revision
+  // `revisionReason(target)` documents that binding inline so clients read the
+  // right revision before mutating; a mismatch yields 409 revision_conflict.
+  const revisionBindingDescription: Record<string, string> = {
+    tenant:
+      "Compare-and-set token: MUST equal the current tenant authority revision (provider_authority_tenant_state.revision). Read it from the authorityRevision field returned by GET /v2/workspaces (the only listing that surfaces it). Mismatch returns 409 revision_conflict.",
+    workspace:
+      "Compare-and-set token: MUST equal the parent workspace's current revision. Mismatch returns 409 revision_conflict.",
+    account:
+      "Compare-and-set token: MUST equal the parent provider account's current revision. Mismatch returns 409 revision_conflict.",
+    self: "Compare-and-set token: MUST equal this object's own current revision. Mismatch returns 409 revision_conflict.",
+    roleBinding:
+      "Compare-and-set token whose binding target depends on role_key: for role_key='tenant_authority_admin' it MUST equal the tenant authority revision (provider_authority_tenant_state.revision, from the authorityRevision field of GET /v2/workspaces); for every workspace-scoped role (workspace_admin/operator/viewer/approver) it MUST equal the target workspace's current revision. Mismatch returns 409 revision_conflict.",
+  };
+  const revisionReason = (
+    target: "tenant" | "workspace" | "account" | "self" | "roleBinding",
+  ): JsonSchema => ({
     type: "object",
     required: ["expectedRevision", "reason"],
-    properties: { expectedRevision: { type: "integer", minimum: 0 }, reason: stringSchema },
+    properties: {
+      expectedRevision: {
+        type: "integer",
+        minimum: 0,
+        description: revisionBindingDescription[target],
+      },
+      reason: stringSchema,
+    },
     additionalProperties: true,
-  };
+  });
   return {
     "/v2/workspaces": {
       get: listing("List workspaces"),
-      post: mutation("Create workspace", revisionReason),
+      // create workspace -> binds to the tenant authority revision
+      post: mutation("Create workspace", revisionReason("tenant")),
     },
     "/v2/workspaces/{id}/disable": {
       parameters: [parameter("id", "path")],
-      post: mutation("Disable workspace", revisionReason),
+      // binds to the workspace's own revision
+      post: mutation("Disable workspace", revisionReason("self")),
     },
     "/v2/provider-accounts": {
       get: listing("List provider accounts", true),
-      post: mutation("Create provider account", revisionReason),
+      // create account -> binds to the parent workspace revision
+      post: mutation("Create provider account", revisionReason("workspace")),
     },
     "/v2/provider-accounts/{id}/disable": {
       parameters: [parameter("id", "path")],
-      post: mutation("Disable provider account", revisionReason),
+      // binds to the account's own revision
+      post: mutation("Disable provider account", revisionReason("self")),
     },
     "/v2/provider-accounts/{id}/operations": {
       parameters: [parameter("id", "path")],
       get: listing("List provider operations", true),
-      post: mutation("Register provider operation", revisionReason),
+      // register operation -> binds to the parent provider account revision
+      post: mutation("Register provider operation", revisionReason("account")),
     },
     "/v2/provider-role-bindings": {
       get: listing("List provider role bindings", true),
-      post: mutation("Issue provider role binding", revisionReason),
+      // issue role binding -> CONDITIONAL: tenant_authority_admin binds to the
+      // tenant authority revision; every workspace-scoped role binds to the
+      // target workspace's revision (see providerAuthorityStore.issueRoleBinding).
+      post: mutation("Issue provider role binding", revisionReason("roleBinding")),
     },
     "/v2/provider-role-bindings/{id}/revoke": {
       parameters: [parameter("id", "path")],
-      post: mutation("Revoke provider role binding", revisionReason),
+      // binds to the role binding's own revision
+      post: mutation("Revoke provider role binding", revisionReason("self")),
     },
     "/v2/provider-grants": {
       get: listing("List direct provider grants", true),
-      post: mutation("Issue non-delegable provider grant", revisionReason),
+      // issue grant -> binds to the parent workspace revision
+      post: mutation("Issue non-delegable provider grant", revisionReason("workspace")),
     },
     "/v2/provider-grants/{id}/revoke": {
       parameters: [parameter("id", "path")],
-      post: mutation("Revoke provider grant", revisionReason),
+      // binds to the grant's own revision
+      post: mutation("Revoke provider grant", revisionReason("self")),
     },
     "/v2/provider-access/check": {
       post: {

--- a/packages/api/src/routes/provider-authority.ts
+++ b/packages/api/src/routes/provider-authority.ts
@@ -1,0 +1,389 @@
+import type {
+  ProviderAccessRequestV1,
+  ProviderEnvironment,
+  ProviderPrincipalType,
+  ProviderRiskClass,
+  ProviderRole,
+} from "@stwd/shared";
+import type { Context } from "hono";
+import { Hono } from "hono";
+import { writeAuditEvent } from "../services/audit";
+import {
+  type ApiResponse,
+  type AppVariables,
+  safeJsonParse,
+  setNoStoreHeaders,
+} from "../services/context";
+import {
+  type AuthorityAudit,
+  ProviderAuthorityError,
+  providerAuthorityStore,
+} from "../services/provider-authority-store";
+
+export const providerAuthorityRoutes = new Hono<{ Variables: AppVariables }>();
+
+providerAuthorityRoutes.use("*", async (c, next) => {
+  setNoStoreHeaders(c);
+  await next();
+});
+
+type RouteContext = Context<{ Variables: AppVariables }>;
+
+function fail(c: RouteContext, error: unknown) {
+  if (error instanceof ProviderAuthorityError) {
+    return c.json<ApiResponse>({ ok: false, error: error.message }, error.status);
+  }
+  throw error;
+}
+
+function userSession(c: RouteContext): { userId: string; tenantRole: string } {
+  const userId = c.get("userId");
+  const tenantRole = c.get("tenantRole") ?? "";
+  if (c.get("authType") !== "session-jwt" || !userId) {
+    throw new ProviderAuthorityError("human session required", "forbidden", 403);
+  }
+  return { userId, tenantRole };
+}
+
+function auditFor(c: RouteContext, userId: string): AuthorityAudit {
+  return async (event) => {
+    await writeAuditEvent({
+      tenantId: c.get("tenantId"),
+      actorType: "user",
+      actorId: userId,
+      action: event.action,
+      resourceType: event.resourceType,
+      resourceId: event.resourceId,
+      metadata: event.metadata,
+      ipAddress: c.req.header("x-forwarded-for") ?? null,
+      userAgent: c.req.header("user-agent") ?? null,
+      requestId: c.get("requestId") ?? null,
+    });
+  };
+}
+
+function mutationContext(c: RouteContext, body: { expectedRevision?: unknown; reason?: unknown }) {
+  const { userId, tenantRole } = userSession(c);
+  return {
+    tenantId: c.get("tenantId"),
+    actorUserId: userId,
+    tenantRole,
+    mfaVerifiedAt: c.get("sessionMfaVerifiedAt") ?? Number.NaN,
+    idempotencyKey: c.req.header("Idempotency-Key") ?? "",
+    expectedRevision: typeof body.expectedRevision === "number" ? body.expectedRevision : -1,
+    reason: typeof body.reason === "string" ? body.reason : "",
+    requestId: c.get("requestId"),
+    audit: auditFor(c, userId),
+  };
+}
+
+async function requireReadAdmin(c: RouteContext, workspaceId?: string) {
+  const { userId, tenantRole } = userSession(c);
+  if (
+    !(await providerAuthorityStore.canAdminister(
+      c.get("tenantId"),
+      workspaceId,
+      userId,
+      tenantRole,
+    ))
+  ) {
+    throw new ProviderAuthorityError("resource not found", "not_found", 404);
+  }
+}
+
+providerAuthorityRoutes.get("/workspaces", async (c) => {
+  try {
+    await requireReadAdmin(c);
+    const data = await providerAuthorityStore.listWorkspaces(c.get("tenantId"));
+    return c.json({
+      ok: true,
+      data,
+      authorityRevision: await providerAuthorityStore.getTenantRevision(c.get("tenantId")),
+    });
+  } catch (error) {
+    return fail(c, error);
+  }
+});
+
+providerAuthorityRoutes.post("/workspaces", async (c) => {
+  const body = await safeJsonParse<{
+    key: string;
+    name: string;
+    environment: ProviderEnvironment;
+    expectedRevision: number;
+    reason: string;
+  }>(c);
+  if (!body) return c.json<ApiResponse>({ ok: false, error: "Invalid JSON body" }, 400);
+  try {
+    const data = await providerAuthorityStore.createWorkspace(mutationContext(c, body), body);
+    return c.json({ ok: true, data }, 201);
+  } catch (error) {
+    return fail(c, error);
+  }
+});
+
+providerAuthorityRoutes.post("/workspaces/:id/disable", async (c) => {
+  const body = await safeJsonParse<{ expectedRevision: number; reason: string }>(c);
+  if (!body) return c.json<ApiResponse>({ ok: false, error: "Invalid JSON body" }, 400);
+  try {
+    return c.json({
+      ok: true,
+      data: await providerAuthorityStore.disableWorkspace(
+        mutationContext(c, body),
+        c.req.param("id"),
+      ),
+    });
+  } catch (error) {
+    return fail(c, error);
+  }
+});
+
+providerAuthorityRoutes.get("/provider-accounts", async (c) => {
+  const workspaceId = c.req.query("workspaceId");
+  try {
+    await requireReadAdmin(c, workspaceId);
+    return c.json({
+      ok: true,
+      data: await providerAuthorityStore.listProviderAccounts(c.get("tenantId"), workspaceId),
+    });
+  } catch (error) {
+    return fail(c, error);
+  }
+});
+
+providerAuthorityRoutes.post("/provider-accounts", async (c) => {
+  const body = await safeJsonParse<{
+    workspaceId: string;
+    adapterKey: string;
+    externalRef: string;
+    displayName: string;
+    credentialSecretId?: string;
+    credentialVersion?: number;
+    expectedRevision: number;
+    reason: string;
+  }>(c);
+  if (!body) return c.json<ApiResponse>({ ok: false, error: "Invalid JSON body" }, 400);
+  try {
+    return c.json(
+      {
+        ok: true,
+        data: await providerAuthorityStore.createProviderAccount(mutationContext(c, body), body),
+      },
+      201,
+    );
+  } catch (error) {
+    return fail(c, error);
+  }
+});
+
+providerAuthorityRoutes.post("/provider-accounts/:id/disable", async (c) => {
+  const body = await safeJsonParse<{ expectedRevision: number; reason: string }>(c);
+  if (!body) return c.json<ApiResponse>({ ok: false, error: "Invalid JSON body" }, 400);
+  try {
+    return c.json({
+      ok: true,
+      data: await providerAuthorityStore.disableProviderAccount(
+        mutationContext(c, body),
+        c.req.param("id"),
+      ),
+    });
+  } catch (error) {
+    return fail(c, error);
+  }
+});
+
+providerAuthorityRoutes.get("/provider-accounts/:id/operations", async (c) => {
+  const workspaceId = c.req.query("workspaceId");
+  try {
+    await requireReadAdmin(c, workspaceId);
+    return c.json({
+      ok: true,
+      data: await providerAuthorityStore.listOperations(
+        c.get("tenantId"),
+        workspaceId,
+        c.req.param("id"),
+      ),
+    });
+  } catch (error) {
+    return fail(c, error);
+  }
+});
+
+providerAuthorityRoutes.post("/provider-accounts/:id/operations", async (c) => {
+  const body = await safeJsonParse<{
+    operationKey: string;
+    riskClass: ProviderRiskClass;
+    capabilityId?: string;
+    secretRouteId?: string;
+    requestProfile?: Record<string, unknown>;
+    responseProfile?: Record<string, unknown>;
+    expectedRevision: number;
+    reason: string;
+  }>(c);
+  if (!body) return c.json<ApiResponse>({ ok: false, error: "Invalid JSON body" }, 400);
+  try {
+    return c.json(
+      {
+        ok: true,
+        data: await providerAuthorityStore.registerOperation(
+          mutationContext(c, body),
+          c.req.param("id"),
+          body,
+        ),
+      },
+      201,
+    );
+  } catch (error) {
+    return fail(c, error);
+  }
+});
+
+providerAuthorityRoutes.get("/provider-role-bindings", async (c) => {
+  const workspaceId = c.req.query("workspaceId");
+  try {
+    await requireReadAdmin(c, workspaceId);
+    return c.json({
+      ok: true,
+      data: await providerAuthorityStore.listRoleBindings(c.get("tenantId"), workspaceId),
+    });
+  } catch (error) {
+    return fail(c, error);
+  }
+});
+
+providerAuthorityRoutes.post("/provider-role-bindings", async (c) => {
+  const body = await safeJsonParse<{
+    workspaceId?: string;
+    providerAccountId?: string;
+    principalType: ProviderPrincipalType;
+    principalId: string;
+    roleKey: ProviderRole;
+    operationKeys?: string[];
+    environment?: ProviderEnvironment;
+    notBefore?: string;
+    expiresAt?: string;
+    expectedRevision: number;
+    reason: string;
+  }>(c);
+  if (!body) return c.json<ApiResponse>({ ok: false, error: "Invalid JSON body" }, 400);
+  try {
+    const data = await providerAuthorityStore.issueRoleBinding(mutationContext(c, body), {
+      workspaceId: body.workspaceId,
+      providerAccountId: body.providerAccountId,
+      principalType: body.principalType,
+      principalId: body.principalId,
+      roleKey: body.roleKey,
+      operationKeys: body.operationKeys ?? [],
+      environment: body.environment,
+      notBefore: body.notBefore ? new Date(body.notBefore) : undefined,
+      expiresAt: body.expiresAt ? new Date(body.expiresAt) : undefined,
+    });
+    return c.json({ ok: true, data }, 201);
+  } catch (error) {
+    return fail(c, error);
+  }
+});
+
+providerAuthorityRoutes.post("/provider-role-bindings/:id/revoke", async (c) => {
+  const body = await safeJsonParse<{ expectedRevision: number; reason: string }>(c);
+  if (!body) return c.json<ApiResponse>({ ok: false, error: "Invalid JSON body" }, 400);
+  try {
+    return c.json({
+      ok: true,
+      data: await providerAuthorityStore.revokeRoleBinding(
+        mutationContext(c, body),
+        c.req.param("id"),
+      ),
+    });
+  } catch (error) {
+    return fail(c, error);
+  }
+});
+
+providerAuthorityRoutes.get("/provider-grants", async (c) => {
+  const workspaceId = c.req.query("workspaceId");
+  try {
+    await requireReadAdmin(c, workspaceId);
+    return c.json({
+      ok: true,
+      data: await providerAuthorityStore.listGrants(c.get("tenantId"), workspaceId),
+    });
+  } catch (error) {
+    return fail(c, error);
+  }
+});
+
+providerAuthorityRoutes.post("/provider-grants", async (c) => {
+  const body = await safeJsonParse<{
+    workspaceId: string;
+    providerAccountId: string;
+    agentId: string;
+    operationKeys: string[];
+    environment?: ProviderEnvironment;
+    notBefore?: string;
+    expiresAt: string;
+    expectedRevision: number;
+    reason: string;
+  }>(c);
+  if (!body) return c.json<ApiResponse>({ ok: false, error: "Invalid JSON body" }, 400);
+  try {
+    const data = await providerAuthorityStore.issueGrant(mutationContext(c, body), {
+      workspaceId: body.workspaceId,
+      providerAccountId: body.providerAccountId,
+      agentId: body.agentId,
+      operationKeys: body.operationKeys,
+      environment: body.environment,
+      notBefore: body.notBefore ? new Date(body.notBefore) : undefined,
+      expiresAt: new Date(body.expiresAt),
+    });
+    return c.json({ ok: true, data }, 201);
+  } catch (error) {
+    return fail(c, error);
+  }
+});
+
+providerAuthorityRoutes.post("/provider-grants/:id/revoke", async (c) => {
+  const body = await safeJsonParse<{ expectedRevision: number; reason: string }>(c);
+  if (!body) return c.json<ApiResponse>({ ok: false, error: "Invalid JSON body" }, 400);
+  try {
+    return c.json({
+      ok: true,
+      data: await providerAuthorityStore.revokeGrant(mutationContext(c, body), c.req.param("id")),
+    });
+  } catch (error) {
+    return fail(c, error);
+  }
+});
+
+providerAuthorityRoutes.post("/provider-access/check", async (c) => {
+  const body = await safeJsonParse<
+    Omit<ProviderAccessRequestV1, "tenantId" | "actor" | "evaluatedAt"> & {
+      actor?: ProviderAccessRequestV1["actor"];
+      evaluatedAt?: string;
+    }
+  >(c);
+  if (!body) return c.json<ApiResponse>({ ok: false, error: "Invalid JSON body" }, 400);
+  const authType = c.get("authType");
+  const actor =
+    authType === "agent-token"
+      ? { type: "agent" as const, id: c.get("agentScope") ?? "" }
+      : authType === "session-jwt" && c.get("userId")
+        ? { type: "human" as const, id: c.get("userId") as string }
+        : null;
+  if (!actor?.id)
+    return c.json<ApiResponse>(
+      { ok: false, error: "authenticated human or agent principal required" },
+      403,
+    );
+  try {
+    const data = await providerAuthorityStore.checkAccess({
+      ...body,
+      tenantId: c.get("tenantId"),
+      actor,
+      evaluatedAt: body.evaluatedAt ?? new Date().toISOString(),
+    });
+    return c.json({ ok: true, data });
+  } catch (error) {
+    return fail(c, error);
+  }
+});

--- a/packages/api/src/services/provider-authority-store.ts
+++ b/packages/api/src/services/provider-authority-store.ts
@@ -167,31 +167,18 @@ export class ProviderAuthorityStore {
     return explicit.length === 0 && membership.role === "owner" && ctx.tenantRole === "owner";
   }
 
-  private async tenantAdminIsExplicit(
-    ctx: Pick<MutationContext, "tenantId" | "actorUserId">,
-  ): Promise<boolean> {
-    const [row] = await this.db()
-      .select({ id: providerRoleBindings.id })
-      .from(providerRoleBindings)
-      .where(
-        and(
-          eq(providerRoleBindings.tenantId, ctx.tenantId),
-          eq(providerRoleBindings.roleKey, "tenant_authority_admin"),
-          eq(providerRoleBindings.principalType, "human"),
-          eq(providerRoleBindings.principalId, ctx.actorUserId),
-          eq(providerRoleBindings.status, "active"),
-        ),
-      )
-      .limit(1);
-    return Boolean(row);
-  }
-
   private async workspaceAdminMandate(
     tenantId: string,
     workspaceId: string,
     userId: string,
     at = new Date(),
   ) {
+    const [workspace] = await this.db()
+      .select({ environment: workspaces.environment })
+      .from(workspaces)
+      .where(and(eq(workspaces.tenantId, tenantId), eq(workspaces.id, workspaceId)))
+      .limit(1);
+    if (!workspace) return undefined;
     const rows = await this.db()
       .select()
       .from(providerRoleBindings)
@@ -205,7 +192,7 @@ export class ProviderAuthorityStore {
           eq(providerRoleBindings.status, "active"),
         ),
       );
-    return rows.find((row) => activeAt(row, at, row.environment ?? "production"));
+    return rows.find((row) => activeAt(row, at, workspace.environment));
   }
 
   private async requireWorkspaceAdmin(

--- a/packages/api/src/services/provider-authority-store.ts
+++ b/packages/api/src/services/provider-authority-store.ts
@@ -140,8 +140,8 @@ export class ProviderAuthorityStore {
     return row;
   }
 
-  private async activeTenantAdmins(tenantId: string) {
-    return this.db()
+  private async activeTenantAdmins(tenantId: string, at = new Date()) {
+    const rows = await this.db()
       .select()
       .from(providerRoleBindings)
       .where(
@@ -151,6 +151,9 @@ export class ProviderAuthorityStore {
           eq(providerRoleBindings.status, "active"),
         ),
       );
+    return rows.filter(
+      (row) => (!row.notBefore || row.notBefore <= at) && (!row.expiresAt || row.expiresAt > at),
+    );
   }
 
   /** Owner compatibility is bootstrap-only. Creating the first explicit tenant admin closes it permanently. */
@@ -164,7 +167,13 @@ export class ProviderAuthorityStore {
       explicit.some((row) => row.principalType === "human" && row.principalId === ctx.actorUserId)
     )
       return true;
-    return explicit.length === 0 && membership.role === "owner" && ctx.tenantRole === "owner";
+    await this.ensureTenantState(ctx.tenantId);
+    const [state] = await this.db()
+      .select({ bootstrapCompleted: providerAuthorityTenantState.bootstrapCompleted })
+      .from(providerAuthorityTenantState)
+      .where(eq(providerAuthorityTenantState.tenantId, ctx.tenantId))
+      .limit(1);
+    return !state?.bootstrapCompleted && membership.role === "owner" && ctx.tenantRole === "owner";
   }
 
   private async workspaceAdminMandate(
@@ -651,9 +660,14 @@ export class ProviderAuthorityStore {
       const revision = await this.ensureTenantState(ctx.tenantId);
       if (revision !== ctx.expectedRevision)
         throw new ProviderAuthorityError("authority revision conflict", "revision_conflict", 409);
-      if (input.principalType !== "human" || input.workspaceId || input.providerAccountId)
+      if (
+        input.principalType !== "human" ||
+        input.workspaceId ||
+        input.providerAccountId ||
+        input.environment
+      )
         throw new ProviderAuthorityError(
-          "tenant authority admin must be a tenant-scoped human",
+          "tenant authority admin must be a tenant-scoped human without an environment scope",
           "bad_request",
           400,
         );
@@ -672,7 +686,7 @@ export class ProviderAuthorityStore {
       return this.db().transaction(async (tx) => {
         const [cas] = await tx
           .update(providerAuthorityTenantState)
-          .set({ revision: revision + 1, updatedAt: new Date() })
+          .set({ revision: revision + 1, bootstrapCompleted: true, updatedAt: new Date() })
           .where(
             and(
               eq(providerAuthorityTenantState.tenantId, ctx.tenantId),

--- a/packages/api/src/services/provider-authority-store.ts
+++ b/packages/api/src/services/provider-authority-store.ts
@@ -1,0 +1,1241 @@
+import { randomUUID } from "node:crypto";
+import {
+  agents,
+  getDb,
+  providerAccounts,
+  providerAuthorityTenantState,
+  providerGrants,
+  providerOperations,
+  providerRoleBindings,
+  secretRoutes,
+  secrets,
+  userTenants,
+  workspaces,
+} from "@stwd/db";
+import {
+  PROVIDER_ACCESS_REASON,
+  type ProviderAccessDecisionV1,
+  type ProviderAccessRequestV1,
+  type ProviderAuthorityMutationContext,
+  type ProviderEnvironment,
+  type ProviderPrincipalType,
+  type ProviderRiskClass,
+} from "@stwd/shared";
+import { and, eq, inArray, sql } from "drizzle-orm";
+
+const RECENT_MFA_MS = 5 * 60_000;
+const OPERATION_KEY = /^[a-z][a-z0-9]*(?:\.[a-z][a-z0-9_]*)+$/;
+const KEY = /^[a-z][a-z0-9_-]{0,127}$/;
+const PROVIDER_OPERATION_ALLOWLIST: Readonly<
+  Record<string, Readonly<Record<string, "GET" | "POST">>>
+> = {
+  github: {
+    "github.issue.list": "GET",
+    "github.pr.comment.create": "POST",
+  },
+};
+const PROVIDER_HOST_ALLOWLIST: Readonly<Record<string, string>> = { github: "api.github.com" };
+
+export class ProviderAuthorityError extends Error {
+  constructor(
+    message: string,
+    readonly code:
+      | "bad_request"
+      | "forbidden"
+      | "not_found"
+      | "revision_conflict"
+      | "last_admin"
+      | "audit_required",
+    readonly status: 400 | 403 | 404 | 409 | 428,
+  ) {
+    super(message);
+  }
+}
+
+export type AuthorityAudit = (event: {
+  action: string;
+  resourceType: string;
+  resourceId?: string;
+  metadata: Record<string, unknown>;
+}) => Promise<void>;
+
+type MutationContext = ProviderAuthorityMutationContext & { audit: AuthorityAudit };
+type BindingInsert = typeof providerRoleBindings.$inferInsert;
+type GrantInsert = typeof providerGrants.$inferInsert;
+
+function assertText(value: string, field: string, max = 512): string {
+  const normalized = value?.trim();
+  if (!normalized || normalized.length > max) {
+    throw new ProviderAuthorityError(
+      `${field} is required and must be at most ${max} characters`,
+      "bad_request",
+      400,
+    );
+  }
+  return normalized;
+}
+
+function assertMutationContext(ctx: MutationContext): void {
+  assertText(ctx.reason, "reason", 2_000);
+  if (!ctx.idempotencyKey || ctx.idempotencyKey.length < 8) {
+    throw new ProviderAuthorityError("Idempotency-Key is required", "bad_request", 400);
+  }
+  if (!Number.isInteger(ctx.expectedRevision) || ctx.expectedRevision < 0) {
+    throw new ProviderAuthorityError(
+      "expectedRevision must be a non-negative integer",
+      "bad_request",
+      400,
+    );
+  }
+  if (
+    !Number.isFinite(ctx.mfaVerifiedAt) ||
+    Date.now() - ctx.mfaVerifiedAt > RECENT_MFA_MS ||
+    ctx.mfaVerifiedAt > Date.now() + 30_000
+  ) {
+    throw new ProviderAuthorityError("recent MFA verification is required", "forbidden", 403);
+  }
+  if (typeof ctx.audit !== "function") {
+    throw new ProviderAuthorityError("mandatory audit writer is required", "audit_required", 428);
+  }
+}
+
+function activeAt(
+  row: {
+    status: string;
+    notBefore?: Date | null;
+    expiresAt?: Date | null;
+    environment?: string | null;
+  },
+  now: Date,
+  environment: string,
+): boolean {
+  return (
+    row.status === "active" &&
+    (!row.notBefore || row.notBefore <= now) &&
+    (!row.expiresAt || row.expiresAt > now) &&
+    (!row.environment || row.environment === environment)
+  );
+}
+
+function operationIncluded(keys: string[], operationKey: string): boolean {
+  return keys.includes(operationKey);
+}
+
+function subset(candidate: string[], allowed: string[]): boolean {
+  const set = new Set(allowed);
+  return candidate.every((key) => set.has(key));
+}
+
+export class ProviderAuthorityStore {
+  private db() {
+    return getDb();
+  }
+
+  private async membership(tenantId: string, userId: string) {
+    const [row] = await this.db()
+      .select()
+      .from(userTenants)
+      .where(and(eq(userTenants.tenantId, tenantId), eq(userTenants.userId, userId)))
+      .limit(1);
+    return row;
+  }
+
+  private async activeTenantAdmins(tenantId: string) {
+    return this.db()
+      .select()
+      .from(providerRoleBindings)
+      .where(
+        and(
+          eq(providerRoleBindings.tenantId, tenantId),
+          eq(providerRoleBindings.roleKey, "tenant_authority_admin"),
+          eq(providerRoleBindings.status, "active"),
+        ),
+      );
+  }
+
+  /** Owner compatibility is bootstrap-only. Creating the first explicit tenant admin closes it permanently. */
+  private async hasTenantAdmin(
+    ctx: Pick<MutationContext, "tenantId" | "actorUserId" | "tenantRole">,
+  ): Promise<boolean> {
+    const membership = await this.membership(ctx.tenantId, ctx.actorUserId);
+    if (!membership) return false;
+    const explicit = await this.activeTenantAdmins(ctx.tenantId);
+    if (
+      explicit.some((row) => row.principalType === "human" && row.principalId === ctx.actorUserId)
+    )
+      return true;
+    return explicit.length === 0 && membership.role === "owner" && ctx.tenantRole === "owner";
+  }
+
+  private async tenantAdminIsExplicit(
+    ctx: Pick<MutationContext, "tenantId" | "actorUserId">,
+  ): Promise<boolean> {
+    const [row] = await this.db()
+      .select({ id: providerRoleBindings.id })
+      .from(providerRoleBindings)
+      .where(
+        and(
+          eq(providerRoleBindings.tenantId, ctx.tenantId),
+          eq(providerRoleBindings.roleKey, "tenant_authority_admin"),
+          eq(providerRoleBindings.principalType, "human"),
+          eq(providerRoleBindings.principalId, ctx.actorUserId),
+          eq(providerRoleBindings.status, "active"),
+        ),
+      )
+      .limit(1);
+    return Boolean(row);
+  }
+
+  private async workspaceAdminMandate(
+    tenantId: string,
+    workspaceId: string,
+    userId: string,
+    at = new Date(),
+  ) {
+    const rows = await this.db()
+      .select()
+      .from(providerRoleBindings)
+      .where(
+        and(
+          eq(providerRoleBindings.tenantId, tenantId),
+          eq(providerRoleBindings.workspaceId, workspaceId),
+          eq(providerRoleBindings.principalType, "human"),
+          eq(providerRoleBindings.principalId, userId),
+          eq(providerRoleBindings.roleKey, "workspace_admin"),
+          eq(providerRoleBindings.status, "active"),
+        ),
+      );
+    return rows.find((row) => activeAt(row, at, row.environment ?? "production"));
+  }
+
+  private async requireWorkspaceAdmin(
+    ctx: MutationContext,
+    workspaceId: string,
+    allowTenantAdmin: boolean,
+  ) {
+    if (allowTenantAdmin && (await this.hasTenantAdmin(ctx)))
+      return { type: "tenant" as const, operationKeys: [] as string[] };
+    const binding = await this.workspaceAdminMandate(ctx.tenantId, workspaceId, ctx.actorUserId);
+    if (!binding) throw new ProviderAuthorityError("resource not found", "not_found", 404);
+    return { type: "workspace" as const, operationKeys: binding.operationKeys };
+  }
+
+  private async ensureTenantState(tenantId: string): Promise<number> {
+    await this.db()
+      .insert(providerAuthorityTenantState)
+      .values({ tenantId, revision: 0 })
+      .onConflictDoNothing();
+    const [row] = await this.db()
+      .select()
+      .from(providerAuthorityTenantState)
+      .where(eq(providerAuthorityTenantState.tenantId, tenantId));
+    return row?.revision ?? 0;
+  }
+
+  async canAdminister(
+    tenantId: string,
+    workspaceId: string | undefined,
+    userId: string,
+    tenantRole: string,
+  ): Promise<boolean> {
+    const ctx = { tenantId, actorUserId: userId, tenantRole };
+    if (await this.hasTenantAdmin(ctx)) return true;
+    return Boolean(
+      workspaceId && (await this.workspaceAdminMandate(tenantId, workspaceId, userId)),
+    );
+  }
+
+  async getTenantRevision(tenantId: string): Promise<number> {
+    return this.ensureTenantState(tenantId);
+  }
+
+  async createWorkspace(
+    ctx: MutationContext,
+    input: { key: string; name: string; environment: ProviderEnvironment },
+  ) {
+    assertMutationContext(ctx);
+    if (!(await this.hasTenantAdmin(ctx)))
+      throw new ProviderAuthorityError("tenant authority required", "forbidden", 403);
+    const key = assertText(input.key, "key", 128);
+    if (!KEY.test(key))
+      throw new ProviderAuthorityError("invalid workspace key", "bad_request", 400);
+    const current = await this.ensureTenantState(ctx.tenantId);
+    if (current !== ctx.expectedRevision)
+      throw new ProviderAuthorityError("authority revision conflict", "revision_conflict", 409);
+    const id = randomUUID();
+    await ctx.audit({
+      action: "provider.workspace.create",
+      resourceType: "workspace",
+      resourceId: id,
+      metadata: { expectedRevision: current, key, reason: ctx.reason },
+    });
+    return this.db().transaction(async (tx) => {
+      const [cas] = await tx
+        .update(providerAuthorityTenantState)
+        .set({ revision: current + 1, updatedAt: new Date() })
+        .where(
+          and(
+            eq(providerAuthorityTenantState.tenantId, ctx.tenantId),
+            eq(providerAuthorityTenantState.revision, current),
+          ),
+        )
+        .returning();
+      if (!cas)
+        throw new ProviderAuthorityError("authority revision conflict", "revision_conflict", 409);
+      const [row] = await tx
+        .insert(workspaces)
+        .values({
+          id,
+          tenantId: ctx.tenantId,
+          key,
+          name: assertText(input.name, "name", 255),
+          environment: input.environment,
+          createdBy: ctx.actorUserId,
+        })
+        .returning();
+      return row;
+    });
+  }
+
+  async listWorkspaces(tenantId: string) {
+    return this.db().select().from(workspaces).where(eq(workspaces.tenantId, tenantId));
+  }
+
+  async disableWorkspace(ctx: MutationContext, id: string) {
+    assertMutationContext(ctx);
+    if (!(await this.hasTenantAdmin(ctx)))
+      throw new ProviderAuthorityError("tenant authority required", "forbidden", 403);
+    const [row] = await this.db()
+      .select()
+      .from(workspaces)
+      .where(and(eq(workspaces.id, id), eq(workspaces.tenantId, ctx.tenantId)))
+      .limit(1);
+    if (!row) throw new ProviderAuthorityError("resource not found", "not_found", 404);
+    if (row.revision !== ctx.expectedRevision)
+      throw new ProviderAuthorityError("workspace revision conflict", "revision_conflict", 409);
+    await ctx.audit({
+      action: "provider.workspace.disable",
+      resourceType: "workspace",
+      resourceId: id,
+      metadata: { expectedRevision: row.revision, reason: ctx.reason },
+    });
+    const [updated] = await this.db()
+      .update(workspaces)
+      .set({ status: "disabled", revision: row.revision + 1, updatedAt: new Date() })
+      .where(
+        and(
+          eq(workspaces.id, id),
+          eq(workspaces.tenantId, ctx.tenantId),
+          eq(workspaces.revision, row.revision),
+        ),
+      )
+      .returning();
+    if (!updated)
+      throw new ProviderAuthorityError("workspace revision conflict", "revision_conflict", 409);
+    return updated;
+  }
+
+  async createProviderAccount(
+    ctx: MutationContext,
+    input: {
+      workspaceId: string;
+      adapterKey: string;
+      externalRef: string;
+      displayName: string;
+      credentialSecretId?: string;
+      credentialVersion?: number;
+    },
+  ) {
+    assertMutationContext(ctx);
+    await this.requireWorkspaceAdmin(ctx, input.workspaceId, true);
+    const [workspace] = await this.db()
+      .select()
+      .from(workspaces)
+      .where(
+        and(
+          eq(workspaces.id, input.workspaceId),
+          eq(workspaces.tenantId, ctx.tenantId),
+          eq(workspaces.status, "active"),
+        ),
+      )
+      .limit(1);
+    if (!workspace) throw new ProviderAuthorityError("resource not found", "not_found", 404);
+    if (workspace.revision !== ctx.expectedRevision)
+      throw new ProviderAuthorityError("workspace revision conflict", "revision_conflict", 409);
+    if (Boolean(input.credentialSecretId) !== Boolean(input.credentialVersion))
+      throw new ProviderAuthorityError(
+        "credentialSecretId and credentialVersion must be supplied together",
+        "bad_request",
+        400,
+      );
+    if (input.credentialSecretId) {
+      if (ctx.tenantRole !== "owner" && ctx.tenantRole !== "admin") {
+        throw new ProviderAuthorityError(
+          "credential binding also requires the existing secret-management gate",
+          "forbidden",
+          403,
+        );
+      }
+      const [secret] = await this.db()
+        .select()
+        .from(secrets)
+        .where(
+          and(
+            eq(secrets.tenantId, ctx.tenantId),
+            eq(secrets.id, input.credentialSecretId),
+            eq(secrets.version, input.credentialVersion as number),
+            sql`${secrets.deletedAt} IS NULL`,
+          ),
+        )
+        .limit(1);
+      if (!secret || (secret.expiresAt && secret.expiresAt <= new Date()))
+        throw new ProviderAuthorityError("resource not found", "not_found", 404);
+    }
+    const id = randomUUID();
+    await ctx.audit({
+      action: "provider.account.create",
+      resourceType: "provider_account",
+      resourceId: id,
+      metadata: {
+        workspaceId: workspace.id,
+        expectedRevision: workspace.revision,
+        reason: ctx.reason,
+      },
+    });
+    return this.db().transaction(async (tx) => {
+      const [cas] = await tx
+        .update(workspaces)
+        .set({ revision: workspace.revision + 1, updatedAt: new Date() })
+        .where(
+          and(
+            eq(workspaces.id, workspace.id),
+            eq(workspaces.tenantId, ctx.tenantId),
+            eq(workspaces.revision, workspace.revision),
+          ),
+        )
+        .returning();
+      if (!cas)
+        throw new ProviderAuthorityError("workspace revision conflict", "revision_conflict", 409);
+      const [row] = await tx
+        .insert(providerAccounts)
+        .values({
+          id,
+          tenantId: ctx.tenantId,
+          workspaceId: workspace.id,
+          adapterKey: assertText(input.adapterKey, "adapterKey", 128),
+          externalRef: assertText(input.externalRef, "externalRef", 512),
+          displayName: assertText(input.displayName, "displayName", 255),
+          credentialSecretId: input.credentialSecretId,
+          credentialVersion: input.credentialVersion,
+        })
+        .returning();
+      return row;
+    });
+  }
+
+  async listProviderAccounts(tenantId: string, workspaceId?: string) {
+    if (!workspaceId) return [];
+    return this.db()
+      .select()
+      .from(providerAccounts)
+      .where(
+        and(eq(providerAccounts.tenantId, tenantId), eq(providerAccounts.workspaceId, workspaceId)),
+      );
+  }
+
+  async disableProviderAccount(ctx: MutationContext, id: string) {
+    assertMutationContext(ctx);
+    const [row] = await this.db()
+      .select()
+      .from(providerAccounts)
+      .where(and(eq(providerAccounts.id, id), eq(providerAccounts.tenantId, ctx.tenantId)))
+      .limit(1);
+    if (!row) throw new ProviderAuthorityError("resource not found", "not_found", 404);
+    await this.requireWorkspaceAdmin(ctx, row.workspaceId, true);
+    if (row.revision !== ctx.expectedRevision)
+      throw new ProviderAuthorityError(
+        "provider account revision conflict",
+        "revision_conflict",
+        409,
+      );
+    await ctx.audit({
+      action: "provider.account.disable",
+      resourceType: "provider_account",
+      resourceId: id,
+      metadata: {
+        workspaceId: row.workspaceId,
+        expectedRevision: row.revision,
+        reason: ctx.reason,
+      },
+    });
+    const [updated] = await this.db()
+      .update(providerAccounts)
+      .set({ status: "disabled", revision: row.revision + 1, updatedAt: new Date() })
+      .where(
+        and(
+          eq(providerAccounts.id, id),
+          eq(providerAccounts.tenantId, ctx.tenantId),
+          eq(providerAccounts.workspaceId, row.workspaceId),
+          eq(providerAccounts.revision, row.revision),
+        ),
+      )
+      .returning();
+    if (!updated)
+      throw new ProviderAuthorityError(
+        "provider account revision conflict",
+        "revision_conflict",
+        409,
+      );
+    return updated;
+  }
+
+  async registerOperation(
+    ctx: MutationContext,
+    accountId: string,
+    input: {
+      operationKey: string;
+      riskClass: ProviderRiskClass;
+      capabilityId?: string;
+      secretRouteId?: string;
+      requestProfile?: Record<string, unknown>;
+      responseProfile?: Record<string, unknown>;
+    },
+  ) {
+    assertMutationContext(ctx);
+    const [account] = await this.db()
+      .select()
+      .from(providerAccounts)
+      .where(
+        and(
+          eq(providerAccounts.id, accountId),
+          eq(providerAccounts.tenantId, ctx.tenantId),
+          eq(providerAccounts.status, "active"),
+        ),
+      )
+      .limit(1);
+    if (!account) throw new ProviderAuthorityError("resource not found", "not_found", 404);
+    await this.requireWorkspaceAdmin(ctx, account.workspaceId, false);
+    if (account.revision !== ctx.expectedRevision)
+      throw new ProviderAuthorityError(
+        "provider account revision conflict",
+        "revision_conflict",
+        409,
+      );
+    const operationKey = assertText(input.operationKey, "operationKey", 128);
+    if (!OPERATION_KEY.test(operationKey))
+      throw new ProviderAuthorityError("invalid operationKey", "bad_request", 400);
+    const allowedMethod = PROVIDER_OPERATION_ALLOWLIST[account.adapterKey]?.[operationKey];
+    if (!allowedMethod)
+      throw new ProviderAuthorityError(
+        "operation is not in the adapter allowlist",
+        "forbidden",
+        403,
+      );
+    if (input.secretRouteId) {
+      const [route] = await this.db()
+        .select()
+        .from(secretRoutes)
+        .where(
+          and(
+            eq(secretRoutes.tenantId, ctx.tenantId),
+            eq(secretRoutes.id, input.secretRouteId),
+            eq(secretRoutes.enabled, true),
+          ),
+        )
+        .limit(1);
+      const expectedHost = PROVIDER_HOST_ALLOWLIST[account.adapterKey];
+      if (
+        !route ||
+        route.hostPattern !== expectedHost ||
+        route.method !== allowedMethod ||
+        !route.pathPattern ||
+        route.pathPattern.includes("*")
+      ) {
+        throw new ProviderAuthorityError(
+          "route target would widen the adapter operation",
+          "forbidden",
+          403,
+        );
+      }
+    }
+    const id = randomUUID();
+    await ctx.audit({
+      action: "provider.operation.register",
+      resourceType: "provider_operation",
+      resourceId: id,
+      metadata: {
+        workspaceId: account.workspaceId,
+        providerAccountId: account.id,
+        operationKey,
+        expectedRevision: account.revision,
+        reason: ctx.reason,
+      },
+    });
+    return this.db().transaction(async (tx) => {
+      const [cas] = await tx
+        .update(providerAccounts)
+        .set({ revision: account.revision + 1, updatedAt: new Date() })
+        .where(
+          and(
+            eq(providerAccounts.id, account.id),
+            eq(providerAccounts.tenantId, ctx.tenantId),
+            eq(providerAccounts.workspaceId, account.workspaceId),
+            eq(providerAccounts.revision, account.revision),
+          ),
+        )
+        .returning();
+      if (!cas)
+        throw new ProviderAuthorityError(
+          "provider account revision conflict",
+          "revision_conflict",
+          409,
+        );
+      const [row] = await tx
+        .insert(providerOperations)
+        .values({
+          id,
+          tenantId: ctx.tenantId,
+          workspaceId: account.workspaceId,
+          providerAccountId: account.id,
+          operationKey,
+          riskClass: input.riskClass,
+          capabilityId: input.capabilityId,
+          secretRouteId: input.secretRouteId,
+          requestProfile: input.requestProfile ?? {},
+          responseProfile: input.responseProfile ?? {},
+        })
+        .returning();
+      return row;
+    });
+  }
+
+  async listOperations(tenantId: string, workspaceId: string | undefined, accountId: string) {
+    if (!workspaceId) return [];
+    return this.db()
+      .select()
+      .from(providerOperations)
+      .where(
+        and(
+          eq(providerOperations.tenantId, tenantId),
+          eq(providerOperations.workspaceId, workspaceId),
+          eq(providerOperations.providerAccountId, accountId),
+        ),
+      );
+  }
+
+  private async validatePrincipal(
+    tenantId: string,
+    type: ProviderPrincipalType,
+    id: string,
+  ): Promise<void> {
+    if (type === "agent") {
+      const [agent] = await this.db()
+        .select({ id: agents.id })
+        .from(agents)
+        .where(and(eq(agents.tenantId, tenantId), eq(agents.id, id)))
+        .limit(1);
+      if (!agent) throw new ProviderAuthorityError("resource not found", "not_found", 404);
+    } else {
+      const membership = await this.membership(tenantId, id);
+      if (!membership) throw new ProviderAuthorityError("resource not found", "not_found", 404);
+    }
+  }
+
+  async issueRoleBinding(
+    ctx: MutationContext,
+    input: Omit<
+      BindingInsert,
+      | "id"
+      | "tenantId"
+      | "status"
+      | "revision"
+      | "grantedByUserId"
+      | "reason"
+      | "createdAt"
+      | "updatedAt"
+    >,
+  ) {
+    assertMutationContext(ctx);
+    await this.validatePrincipal(ctx.tenantId, input.principalType, input.principalId);
+    const tenantRole = input.roleKey === "tenant_authority_admin";
+    if (tenantRole) {
+      if (!(await this.hasTenantAdmin(ctx)))
+        throw new ProviderAuthorityError("tenant authority required", "forbidden", 403);
+      const revision = await this.ensureTenantState(ctx.tenantId);
+      if (revision !== ctx.expectedRevision)
+        throw new ProviderAuthorityError("authority revision conflict", "revision_conflict", 409);
+      if (input.principalType !== "human" || input.workspaceId || input.providerAccountId)
+        throw new ProviderAuthorityError(
+          "tenant authority admin must be a tenant-scoped human",
+          "bad_request",
+          400,
+        );
+      const id = randomUUID();
+      await ctx.audit({
+        action: "provider.role_binding.issue",
+        resourceType: "provider_role_binding",
+        resourceId: id,
+        metadata: {
+          roleKey: input.roleKey,
+          principalId: input.principalId,
+          expectedRevision: revision,
+          reason: ctx.reason,
+        },
+      });
+      return this.db().transaction(async (tx) => {
+        const [cas] = await tx
+          .update(providerAuthorityTenantState)
+          .set({ revision: revision + 1, updatedAt: new Date() })
+          .where(
+            and(
+              eq(providerAuthorityTenantState.tenantId, ctx.tenantId),
+              eq(providerAuthorityTenantState.revision, revision),
+            ),
+          )
+          .returning();
+        if (!cas)
+          throw new ProviderAuthorityError("authority revision conflict", "revision_conflict", 409);
+        const [row] = await tx
+          .insert(providerRoleBindings)
+          .values({
+            ...input,
+            id,
+            tenantId: ctx.tenantId,
+            grantedByUserId: ctx.actorUserId,
+            reason: ctx.reason,
+          })
+          .returning();
+        return row;
+      });
+    }
+    if (!input.workspaceId)
+      throw new ProviderAuthorityError("workspaceId is required", "bad_request", 400);
+    const mandate = await this.requireWorkspaceAdmin(ctx, input.workspaceId, true);
+    if (input.roleKey === "workspace_admin" && mandate.type !== "tenant")
+      throw new ProviderAuthorityError(
+        "tenant authority required to assign workspace_admin",
+        "forbidden",
+        403,
+      );
+    if (input.providerAccountId) {
+      const [account] = await this.db()
+        .select()
+        .from(providerAccounts)
+        .where(
+          and(
+            eq(providerAccounts.tenantId, ctx.tenantId),
+            eq(providerAccounts.workspaceId, input.workspaceId),
+            eq(providerAccounts.id, input.providerAccountId),
+          ),
+        )
+        .limit(1);
+      if (!account) throw new ProviderAuthorityError("resource not found", "not_found", 404);
+    }
+    const [workspace] = await this.db()
+      .select()
+      .from(workspaces)
+      .where(and(eq(workspaces.tenantId, ctx.tenantId), eq(workspaces.id, input.workspaceId)))
+      .limit(1);
+    if (!workspace) throw new ProviderAuthorityError("resource not found", "not_found", 404);
+    if (workspace.revision !== ctx.expectedRevision)
+      throw new ProviderAuthorityError("workspace revision conflict", "revision_conflict", 409);
+    const requestedOperationKeys = input.operationKeys ?? [];
+    if (
+      (input.roleKey === "workspace_operator" || input.roleKey === "workspace_viewer") &&
+      requestedOperationKeys.length === 0
+    ) {
+      throw new ProviderAuthorityError(
+        "operationKeys are required for operator and viewer bindings",
+        "bad_request",
+        400,
+      );
+    }
+    if (requestedOperationKeys.length > 0) {
+      const scopedOperations = await this.db()
+        .select({ key: providerOperations.operationKey, riskClass: providerOperations.riskClass })
+        .from(providerOperations)
+        .where(
+          and(
+            eq(providerOperations.tenantId, ctx.tenantId),
+            eq(providerOperations.workspaceId, input.workspaceId),
+            input.providerAccountId
+              ? eq(providerOperations.providerAccountId, input.providerAccountId)
+              : sql`true`,
+            eq(providerOperations.status, "active"),
+            inArray(providerOperations.operationKey, requestedOperationKeys),
+          ),
+        );
+      if (scopedOperations.length !== new Set(requestedOperationKeys).size)
+        throw new ProviderAuthorityError("operation set exceeds binding scope", "forbidden", 403);
+      if (
+        input.roleKey === "workspace_viewer" &&
+        scopedOperations.some((operation) => operation.riskClass !== "read")
+      )
+        throw new ProviderAuthorityError(
+          "workspace_viewer may include only read-class operations",
+          "forbidden",
+          403,
+        );
+    }
+    if (mandate.operationKeys.length && !subset(requestedOperationKeys, mandate.operationKeys))
+      throw new ProviderAuthorityError(
+        "operation set exceeds administrator mandate",
+        "forbidden",
+        403,
+      );
+    const id = randomUUID();
+    await ctx.audit({
+      action: "provider.role_binding.issue",
+      resourceType: "provider_role_binding",
+      resourceId: id,
+      metadata: {
+        workspaceId: input.workspaceId,
+        roleKey: input.roleKey,
+        principalId: input.principalId,
+        expectedRevision: workspace.revision,
+        reason: ctx.reason,
+      },
+    });
+    return this.db().transaction(async (tx) => {
+      const [cas] = await tx
+        .update(workspaces)
+        .set({ revision: workspace.revision + 1, updatedAt: new Date() })
+        .where(
+          and(
+            eq(workspaces.id, workspace.id),
+            eq(workspaces.tenantId, ctx.tenantId),
+            eq(workspaces.revision, workspace.revision),
+          ),
+        )
+        .returning();
+      if (!cas)
+        throw new ProviderAuthorityError("workspace revision conflict", "revision_conflict", 409);
+      const [row] = await tx
+        .insert(providerRoleBindings)
+        .values({
+          ...input,
+          id,
+          tenantId: ctx.tenantId,
+          grantedByUserId: ctx.actorUserId,
+          reason: ctx.reason,
+        })
+        .returning();
+      return row;
+    });
+  }
+
+  async listRoleBindings(tenantId: string, workspaceId?: string) {
+    if (!workspaceId)
+      return this.db()
+        .select()
+        .from(providerRoleBindings)
+        .where(
+          and(
+            eq(providerRoleBindings.tenantId, tenantId),
+            sql`${providerRoleBindings.workspaceId} IS NULL`,
+          ),
+        );
+    return this.db()
+      .select()
+      .from(providerRoleBindings)
+      .where(
+        and(
+          eq(providerRoleBindings.tenantId, tenantId),
+          eq(providerRoleBindings.workspaceId, workspaceId),
+        ),
+      );
+  }
+
+  async revokeRoleBinding(ctx: MutationContext, id: string) {
+    assertMutationContext(ctx);
+    const [binding] = await this.db()
+      .select()
+      .from(providerRoleBindings)
+      .where(and(eq(providerRoleBindings.id, id), eq(providerRoleBindings.tenantId, ctx.tenantId)))
+      .limit(1);
+    if (!binding) throw new ProviderAuthorityError("resource not found", "not_found", 404);
+    if (binding.revision !== ctx.expectedRevision)
+      throw new ProviderAuthorityError("binding revision conflict", "revision_conflict", 409);
+    if (binding.roleKey === "tenant_authority_admin") {
+      if (!(await this.hasTenantAdmin(ctx)))
+        throw new ProviderAuthorityError("tenant authority required", "forbidden", 403);
+      const admins = await this.activeTenantAdmins(ctx.tenantId);
+      if (admins.length <= 1)
+        throw new ProviderAuthorityError(
+          "cannot revoke the last active tenant authority admin",
+          "last_admin",
+          409,
+        );
+    } else {
+      if (!binding.workspaceId)
+        throw new ProviderAuthorityError("resource not found", "not_found", 404);
+      const isOriginalGrantor =
+        binding.grantedByUserId === ctx.actorUserId &&
+        Boolean(
+          await this.workspaceAdminMandate(ctx.tenantId, binding.workspaceId, ctx.actorUserId),
+        );
+      if (!isOriginalGrantor) await this.requireWorkspaceAdmin(ctx, binding.workspaceId, true);
+    }
+    await ctx.audit({
+      action: "provider.role_binding.revoke",
+      resourceType: "provider_role_binding",
+      resourceId: id,
+      metadata: {
+        workspaceId: binding.workspaceId,
+        roleKey: binding.roleKey,
+        expectedRevision: binding.revision,
+        reason: ctx.reason,
+      },
+    });
+    const [updated] = await this.db()
+      .update(providerRoleBindings)
+      .set({ status: "revoked", revision: binding.revision + 1, updatedAt: new Date() })
+      .where(
+        and(
+          eq(providerRoleBindings.id, id),
+          eq(providerRoleBindings.tenantId, ctx.tenantId),
+          eq(providerRoleBindings.revision, binding.revision),
+          eq(providerRoleBindings.status, "active"),
+        ),
+      )
+      .returning();
+    if (!updated)
+      throw new ProviderAuthorityError("binding revision conflict", "revision_conflict", 409);
+    return updated;
+  }
+
+  async issueGrant(
+    ctx: MutationContext,
+    input: Pick<
+      GrantInsert,
+      | "workspaceId"
+      | "providerAccountId"
+      | "agentId"
+      | "operationKeys"
+      | "environment"
+      | "notBefore"
+      | "expiresAt"
+    >,
+  ) {
+    assertMutationContext(ctx);
+    const mandate = await this.requireWorkspaceAdmin(ctx, input.workspaceId, true);
+    await this.validatePrincipal(ctx.tenantId, "agent", input.agentId);
+    const [workspace] = await this.db()
+      .select()
+      .from(workspaces)
+      .where(
+        and(
+          eq(workspaces.tenantId, ctx.tenantId),
+          eq(workspaces.id, input.workspaceId),
+          eq(workspaces.status, "active"),
+        ),
+      )
+      .limit(1);
+    const [account] = await this.db()
+      .select()
+      .from(providerAccounts)
+      .where(
+        and(
+          eq(providerAccounts.tenantId, ctx.tenantId),
+          eq(providerAccounts.workspaceId, input.workspaceId),
+          eq(providerAccounts.id, input.providerAccountId),
+          eq(providerAccounts.status, "active"),
+        ),
+      )
+      .limit(1);
+    if (!workspace || !account)
+      throw new ProviderAuthorityError("resource not found", "not_found", 404);
+    if (workspace.revision !== ctx.expectedRevision)
+      throw new ProviderAuthorityError("workspace revision conflict", "revision_conflict", 409);
+    const keys = [...new Set(input.operationKeys.map((key) => key.trim()).filter(Boolean))];
+    if (!keys.length)
+      throw new ProviderAuthorityError("operationKeys must not be empty", "bad_request", 400);
+    const operations = await this.db()
+      .select({ key: providerOperations.operationKey })
+      .from(providerOperations)
+      .where(
+        and(
+          eq(providerOperations.tenantId, ctx.tenantId),
+          eq(providerOperations.workspaceId, input.workspaceId),
+          eq(providerOperations.providerAccountId, input.providerAccountId),
+          eq(providerOperations.status, "active"),
+          inArray(providerOperations.operationKey, keys),
+        ),
+      );
+    if (operations.length !== keys.length)
+      throw new ProviderAuthorityError(
+        "operation set exceeds provider account operations",
+        "forbidden",
+        403,
+      );
+    if (mandate.operationKeys.length && !subset(keys, mandate.operationKeys))
+      throw new ProviderAuthorityError(
+        "operation set exceeds administrator mandate",
+        "forbidden",
+        403,
+      );
+    const expiresAt =
+      input.expiresAt instanceof Date
+        ? input.expiresAt
+        : new Date(input.expiresAt as unknown as string);
+    if (!Number.isFinite(expiresAt.getTime()) || expiresAt <= new Date())
+      throw new ProviderAuthorityError("expiresAt must be in the future", "bad_request", 400);
+    if (input.notBefore && expiresAt <= input.notBefore)
+      throw new ProviderAuthorityError("expiresAt must be after notBefore", "bad_request", 400);
+    const id = randomUUID();
+    await ctx.audit({
+      action: "provider.grant.issue",
+      resourceType: "provider_grant",
+      resourceId: id,
+      metadata: {
+        workspaceId: input.workspaceId,
+        providerAccountId: input.providerAccountId,
+        agentId: input.agentId,
+        operationKeys: keys,
+        nonDelegable: true,
+        expectedRevision: workspace.revision,
+        reason: ctx.reason,
+      },
+    });
+    return this.db().transaction(async (tx) => {
+      const [cas] = await tx
+        .update(workspaces)
+        .set({ revision: workspace.revision + 1, updatedAt: new Date() })
+        .where(
+          and(
+            eq(workspaces.id, workspace.id),
+            eq(workspaces.tenantId, ctx.tenantId),
+            eq(workspaces.revision, workspace.revision),
+          ),
+        )
+        .returning();
+      if (!cas)
+        throw new ProviderAuthorityError("workspace revision conflict", "revision_conflict", 409);
+      const [row] = await tx
+        .insert(providerGrants)
+        .values({
+          ...input,
+          id,
+          tenantId: ctx.tenantId,
+          operationKeys: keys,
+          expiresAt,
+          grantedByUserId: ctx.actorUserId,
+          reason: ctx.reason,
+        })
+        .returning();
+      return row;
+    });
+  }
+
+  async listGrants(tenantId: string, workspaceId?: string) {
+    if (!workspaceId) return [];
+    return this.db()
+      .select()
+      .from(providerGrants)
+      .where(
+        and(eq(providerGrants.tenantId, tenantId), eq(providerGrants.workspaceId, workspaceId)),
+      );
+  }
+
+  async revokeGrant(ctx: MutationContext, id: string) {
+    assertMutationContext(ctx);
+    const [grant] = await this.db()
+      .select()
+      .from(providerGrants)
+      .where(and(eq(providerGrants.id, id), eq(providerGrants.tenantId, ctx.tenantId)))
+      .limit(1);
+    if (!grant) throw new ProviderAuthorityError("resource not found", "not_found", 404);
+    if (grant.revision !== ctx.expectedRevision)
+      throw new ProviderAuthorityError("grant revision conflict", "revision_conflict", 409);
+    const originalGrantor =
+      grant.grantedByUserId === ctx.actorUserId &&
+      Boolean(await this.workspaceAdminMandate(ctx.tenantId, grant.workspaceId, ctx.actorUserId));
+    if (!originalGrantor) await this.requireWorkspaceAdmin(ctx, grant.workspaceId, true);
+    await ctx.audit({
+      action: "provider.grant.revoke",
+      resourceType: "provider_grant",
+      resourceId: id,
+      metadata: {
+        workspaceId: grant.workspaceId,
+        agentId: grant.agentId,
+        expectedRevision: grant.revision,
+        reason: ctx.reason,
+      },
+    });
+    const [updated] = await this.db()
+      .update(providerGrants)
+      .set({
+        status: "revoked",
+        revision: grant.revision + 1,
+        revokedAt: new Date(),
+        revokedByUserId: ctx.actorUserId,
+        revocationReason: ctx.reason,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(providerGrants.id, id),
+          eq(providerGrants.tenantId, ctx.tenantId),
+          eq(providerGrants.workspaceId, grant.workspaceId),
+          eq(providerGrants.revision, grant.revision),
+          eq(providerGrants.status, "active"),
+        ),
+      )
+      .returning();
+    if (!updated)
+      throw new ProviderAuthorityError("grant revision conflict", "revision_conflict", 409);
+    return updated;
+  }
+
+  /** Direct grants are terminal authority objects. There is intentionally no delegate method. */
+  async checkAccess(request: ProviderAccessRequestV1): Promise<ProviderAccessDecisionV1> {
+    const decisionId = randomUUID();
+    const evaluatedAt = new Date(request.evaluatedAt);
+    const decidedAt = new Date().toISOString();
+    const deny = (
+      reasonCode: string,
+      revisions: ProviderAccessDecisionV1["dependencyRevisions"] = {
+        actor: 0,
+        workspace: 0,
+        providerAccount: 0,
+        operation: 0,
+        bindings: [],
+        grants: [],
+      },
+    ): ProviderAccessDecisionV1 => ({
+      decisionId,
+      effect: "deny",
+      reasonCode,
+      matchedBindingIds: [],
+      matchedGrantIds: [],
+      dependencyRevisions: revisions,
+      decidedAt,
+    });
+    if (
+      !Number.isFinite(evaluatedAt.getTime()) ||
+      Math.abs(Date.now() - evaluatedAt.getTime()) > 5 * 60_000
+    )
+      return deny(PROVIDER_ACCESS_REASON.RESOURCE_NOT_FOUND);
+    const actorActive =
+      request.actor.type === "agent"
+        ? Boolean(
+            (
+              await this.db()
+                .select({ id: agents.id })
+                .from(agents)
+                .where(and(eq(agents.tenantId, request.tenantId), eq(agents.id, request.actor.id)))
+                .limit(1)
+            )[0],
+          )
+        : Boolean(await this.membership(request.tenantId, request.actor.id));
+    if (!actorActive) return deny(PROVIDER_ACCESS_REASON.ACTOR_INACTIVE);
+    const [workspace] = await this.db()
+      .select()
+      .from(workspaces)
+      .where(and(eq(workspaces.tenantId, request.tenantId), eq(workspaces.id, request.workspaceId)))
+      .limit(1);
+    const [account] = await this.db()
+      .select()
+      .from(providerAccounts)
+      .where(
+        and(
+          eq(providerAccounts.tenantId, request.tenantId),
+          eq(providerAccounts.workspaceId, request.workspaceId),
+          eq(providerAccounts.id, request.providerAccountId),
+        ),
+      )
+      .limit(1);
+    const [operation] = await this.db()
+      .select()
+      .from(providerOperations)
+      .where(
+        and(
+          eq(providerOperations.tenantId, request.tenantId),
+          eq(providerOperations.workspaceId, request.workspaceId),
+          eq(providerOperations.providerAccountId, request.providerAccountId),
+          eq(providerOperations.operationKey, request.operationKey),
+        ),
+      )
+      .limit(1);
+    if (!workspace || !account || !operation)
+      return deny(PROVIDER_ACCESS_REASON.RESOURCE_NOT_FOUND);
+    const baseRevisions = {
+      actor: 1,
+      workspace: workspace.revision,
+      providerAccount: account.revision,
+      operation: operation.revision,
+      bindings: [] as Array<{ id: string; revision: number }>,
+      grants: [] as Array<{ id: string; revision: number }>,
+    };
+    if (
+      workspace.status !== "active" ||
+      account.status !== "active" ||
+      operation.status !== "active" ||
+      workspace.environment !== request.environment
+    )
+      return deny(PROVIDER_ACCESS_REASON.RESOURCE_INACTIVE, baseRevisions);
+    const bindingRows = await this.db()
+      .select()
+      .from(providerRoleBindings)
+      .where(
+        and(
+          eq(providerRoleBindings.tenantId, request.tenantId),
+          eq(providerRoleBindings.workspaceId, request.workspaceId),
+          eq(providerRoleBindings.principalType, request.actor.type),
+          eq(providerRoleBindings.principalId, request.actor.id),
+          eq(providerRoleBindings.status, "active"),
+        ),
+      );
+    const matchedBindings = bindingRows.filter((binding) => {
+      if (!activeAt(binding, evaluatedAt, request.environment)) return false;
+      if (binding.providerAccountId && binding.providerAccountId !== request.providerAccountId)
+        return false;
+      if (binding.roleKey === "workspace_operator")
+        return operationIncluded(binding.operationKeys, request.operationKey);
+      if (binding.roleKey === "workspace_viewer")
+        return (
+          operation.riskClass === "read" &&
+          operationIncluded(binding.operationKeys, request.operationKey)
+        );
+      return false;
+    });
+    const grantRows =
+      request.actor.type === "agent"
+        ? await this.db()
+            .select()
+            .from(providerGrants)
+            .where(
+              and(
+                eq(providerGrants.tenantId, request.tenantId),
+                eq(providerGrants.workspaceId, request.workspaceId),
+                eq(providerGrants.providerAccountId, request.providerAccountId),
+                eq(providerGrants.agentId, request.actor.id),
+                eq(providerGrants.status, "active"),
+              ),
+            )
+        : [];
+    const matchedGrants = grantRows.filter(
+      (grant) =>
+        activeAt(grant, evaluatedAt, request.environment) &&
+        operationIncluded(grant.operationKeys, request.operationKey),
+    );
+    const revisions = {
+      ...baseRevisions,
+      bindings: matchedBindings.map(({ id, revision }) => ({ id, revision })),
+      grants: matchedGrants.map(({ id, revision }) => ({ id, revision })),
+    };
+    if (!matchedBindings.length && !matchedGrants.length)
+      return deny(PROVIDER_ACCESS_REASON.NO_MATCHING_AUTHORITY, revisions);
+    return {
+      decisionId,
+      effect: "allow",
+      reasonCode: PROVIDER_ACCESS_REASON.ALLOWED,
+      matchedBindingIds: matchedBindings.map((row) => row.id),
+      matchedGrantIds: matchedGrants.map((row) => row.id),
+      dependencyRevisions: revisions,
+      decidedAt,
+    };
+  }
+}
+
+export const providerAuthorityStore = new ProviderAuthorityStore();

--- a/packages/api/src/services/provider-authority-store.ts
+++ b/packages/api/src/services/provider-authority-store.ts
@@ -35,6 +35,16 @@ const PROVIDER_OPERATION_ALLOWLIST: Readonly<
   },
 };
 const PROVIDER_HOST_ALLOWLIST: Readonly<Record<string, string>> = { github: "api.github.com" };
+const ENVIRONMENTS = new Set(["development", "staging", "production"]);
+const PRINCIPAL_TYPES = new Set(["human", "agent"]);
+const ROLES = new Set([
+  "tenant_authority_admin",
+  "workspace_admin",
+  "workspace_operator",
+  "workspace_viewer",
+  "workspace_approver",
+]);
+const RISK_CLASSES = new Set(["read", "write", "consequential"]);
 
 export class ProviderAuthorityError extends Error {
   constructor(
@@ -63,8 +73,8 @@ type MutationContext = ProviderAuthorityMutationContext & { audit: AuthorityAudi
 type BindingInsert = typeof providerRoleBindings.$inferInsert;
 type GrantInsert = typeof providerGrants.$inferInsert;
 
-function assertText(value: string, field: string, max = 512): string {
-  const normalized = value?.trim();
+function assertText(value: unknown, field: string, max = 512): string {
+  const normalized = typeof value === "string" ? value.trim() : "";
   if (!normalized || normalized.length > max) {
     throw new ProviderAuthorityError(
       `${field} is required and must be at most ${max} characters`,
@@ -250,6 +260,8 @@ export class ProviderAuthorityStore {
     input: { key: string; name: string; environment: ProviderEnvironment },
   ) {
     assertMutationContext(ctx);
+    if (!ENVIRONMENTS.has(input.environment))
+      throw new ProviderAuthorityError("invalid environment", "bad_request", 400);
     if (!(await this.hasTenantAdmin(ctx)))
       throw new ProviderAuthorityError("tenant authority required", "forbidden", 403);
     const key = assertText(input.key, "key", 128);
@@ -518,6 +530,8 @@ export class ProviderAuthorityStore {
         409,
       );
     const operationKey = assertText(input.operationKey, "operationKey", 128);
+    if (!RISK_CLASSES.has(input.riskClass))
+      throw new ProviderAuthorityError("invalid riskClass", "bad_request", 400);
     if (!OPERATION_KEY.test(operationKey))
       throw new ProviderAuthorityError("invalid operationKey", "bad_request", 400);
     const allowedMethod = PROVIDER_OPERATION_ALLOWLIST[account.adapterKey]?.[operationKey];
@@ -652,6 +666,20 @@ export class ProviderAuthorityStore {
     >,
   ) {
     assertMutationContext(ctx);
+    if (
+      !PRINCIPAL_TYPES.has(input.principalType) ||
+      !ROLES.has(input.roleKey) ||
+      (input.environment && !ENVIRONMENTS.has(input.environment))
+    ) {
+      throw new ProviderAuthorityError("invalid role binding vocabulary", "bad_request", 400);
+    }
+    if (
+      (input.notBefore && !Number.isFinite(input.notBefore.getTime())) ||
+      (input.expiresAt && !Number.isFinite(input.expiresAt.getTime())) ||
+      (input.notBefore && input.expiresAt && input.expiresAt <= input.notBefore)
+    ) {
+      throw new ProviderAuthorityError("invalid role binding lifetime", "bad_request", 400);
+    }
     await this.validatePrincipal(ctx.tenantId, input.principalType, input.principalId);
     const tenantRole = input.roleKey === "tenant_authority_admin";
     if (tenantRole) {
@@ -919,6 +947,10 @@ export class ProviderAuthorityStore {
     >,
   ) {
     assertMutationContext(ctx);
+    if (input.environment && !ENVIRONMENTS.has(input.environment))
+      throw new ProviderAuthorityError("invalid environment", "bad_request", 400);
+    if (input.notBefore && !Number.isFinite(input.notBefore.getTime()))
+      throw new ProviderAuthorityError("invalid notBefore", "bad_request", 400);
     const mandate = await this.requireWorkspaceAdmin(ctx, input.workspaceId, true);
     await this.validatePrincipal(ctx.tenantId, "agent", input.agentId);
     const [workspace] = await this.db()

--- a/packages/db/drizzle/0079_workspace_provider_authority.sql
+++ b/packages/db/drizzle/0079_workspace_provider_authority.sql
@@ -10,6 +10,7 @@ CREATE UNIQUE INDEX "secret_routes_tenant_id_unique_idx" ON "secret_routes" ("te
 CREATE TABLE "provider_authority_tenant_state" (
   "tenant_id" varchar(64) PRIMARY KEY REFERENCES "tenants"("id") ON DELETE CASCADE,
   "revision" integer NOT NULL DEFAULT 0,
+  "bootstrap_completed" boolean NOT NULL DEFAULT false,
   "created_at" timestamptz NOT NULL DEFAULT now(),
   "updated_at" timestamptz NOT NULL DEFAULT now()
 );

--- a/packages/db/drizzle/0079_workspace_provider_authority.sql
+++ b/packages/db/drizzle/0079_workspace_provider_authority.sql
@@ -1,0 +1,142 @@
+CREATE TYPE "provider_environment" AS ENUM ('development', 'staging', 'production');
+CREATE TYPE "provider_authority_status" AS ENUM ('active', 'disabled', 'revoked');
+CREATE TYPE "provider_principal_type" AS ENUM ('human', 'agent');
+CREATE TYPE "provider_role" AS ENUM ('tenant_authority_admin', 'workspace_admin', 'workspace_operator', 'workspace_viewer', 'workspace_approver');
+CREATE TYPE "provider_risk_class" AS ENUM ('read', 'write', 'consequential');
+--> statement-breakpoint
+CREATE UNIQUE INDEX "secrets_tenant_id_unique_idx" ON "secrets" ("tenant_id", "id");
+CREATE UNIQUE INDEX "secret_routes_tenant_id_unique_idx" ON "secret_routes" ("tenant_id", "id");
+--> statement-breakpoint
+CREATE TABLE "provider_authority_tenant_state" (
+  "tenant_id" varchar(64) PRIMARY KEY REFERENCES "tenants"("id") ON DELETE CASCADE,
+  "revision" integer NOT NULL DEFAULT 0,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now()
+);
+CREATE TABLE "workspaces" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "tenant_id" varchar(64) NOT NULL REFERENCES "tenants"("id") ON DELETE CASCADE,
+  "key" varchar(128) NOT NULL,
+  "name" varchar(255) NOT NULL,
+  "environment" provider_environment NOT NULL,
+  "status" provider_authority_status NOT NULL DEFAULT 'active',
+  "revision" integer NOT NULL DEFAULT 1 CHECK (revision > 0),
+  "created_by" uuid NOT NULL REFERENCES "users"("id") ON DELETE RESTRICT,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now(),
+  UNIQUE ("tenant_id", "id"),
+  UNIQUE ("tenant_id", "key")
+);
+CREATE INDEX "workspaces_tenant_status_idx" ON "workspaces" ("tenant_id", "status");
+--> statement-breakpoint
+CREATE TABLE "provider_accounts" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "tenant_id" varchar(64) NOT NULL,
+  "workspace_id" uuid NOT NULL,
+  "adapter_key" varchar(128) NOT NULL,
+  "external_ref" varchar(512) NOT NULL,
+  "display_name" varchar(255) NOT NULL,
+  "status" provider_authority_status NOT NULL DEFAULT 'active',
+  "credential_secret_id" uuid,
+  "credential_version" integer,
+  "revision" integer NOT NULL DEFAULT 1 CHECK (revision > 0),
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT "provider_accounts_tenant_workspace_fk" FOREIGN KEY ("tenant_id", "workspace_id") REFERENCES "workspaces"("tenant_id", "id") ON DELETE CASCADE,
+  CONSTRAINT "provider_accounts_tenant_credential_fk" FOREIGN KEY ("tenant_id", "credential_secret_id") REFERENCES "secrets"("tenant_id", "id") ON DELETE RESTRICT,
+  CONSTRAINT "provider_accounts_credential_pair_check" CHECK ((credential_secret_id IS NULL) = (credential_version IS NULL)),
+  UNIQUE ("tenant_id", "workspace_id", "id"),
+  UNIQUE ("tenant_id", "workspace_id", "adapter_key", "external_ref")
+);
+--> statement-breakpoint
+CREATE TABLE "provider_operations" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "tenant_id" varchar(64) NOT NULL,
+  "workspace_id" uuid NOT NULL,
+  "provider_account_id" uuid NOT NULL,
+  "operation_key" varchar(128) NOT NULL,
+  "risk_class" provider_risk_class NOT NULL,
+  "capability_id" uuid,
+  "secret_route_id" uuid,
+  "request_profile" jsonb NOT NULL DEFAULT '{}',
+  "response_profile" jsonb NOT NULL DEFAULT '{}',
+  "status" provider_authority_status NOT NULL DEFAULT 'active',
+  "revision" integer NOT NULL DEFAULT 1 CHECK (revision > 0),
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT "provider_operations_tenant_workspace_account_fk" FOREIGN KEY ("tenant_id", "workspace_id", "provider_account_id") REFERENCES "provider_accounts"("tenant_id", "workspace_id", "id") ON DELETE CASCADE,
+  CONSTRAINT "provider_operations_tenant_route_fk" FOREIGN KEY ("tenant_id", "secret_route_id") REFERENCES "secret_routes"("tenant_id", "id") ON DELETE RESTRICT,
+  UNIQUE ("tenant_id", "workspace_id", "provider_account_id", "operation_key"),
+  UNIQUE ("tenant_id", "workspace_id", "provider_account_id", "id")
+);
+--> statement-breakpoint
+CREATE TABLE "provider_role_bindings" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "tenant_id" varchar(64) NOT NULL REFERENCES "tenants"("id") ON DELETE CASCADE,
+  "workspace_id" uuid,
+  "provider_account_id" uuid,
+  "principal_type" provider_principal_type NOT NULL,
+  "principal_id" varchar(64) NOT NULL,
+  "role_key" provider_role NOT NULL,
+  "operation_keys" text[] NOT NULL DEFAULT '{}',
+  "environment" provider_environment,
+  "not_before" timestamptz,
+  "expires_at" timestamptz,
+  "status" provider_authority_status NOT NULL DEFAULT 'active',
+  "revision" integer NOT NULL DEFAULT 1 CHECK (revision > 0),
+  "granted_by_user_id" uuid NOT NULL REFERENCES "users"("id") ON DELETE RESTRICT,
+  "reason" text NOT NULL CHECK (length(trim(reason)) > 0),
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT "provider_role_bindings_tenant_workspace_fk" FOREIGN KEY ("tenant_id", "workspace_id") REFERENCES "workspaces"("tenant_id", "id") ON DELETE CASCADE,
+  CONSTRAINT "provider_role_bindings_tenant_workspace_account_fk" FOREIGN KEY ("tenant_id", "workspace_id", "provider_account_id") REFERENCES "provider_accounts"("tenant_id", "workspace_id", "id") ON DELETE CASCADE,
+  CONSTRAINT "provider_role_bindings_scope_check" CHECK ((role_key = 'tenant_authority_admin' AND workspace_id IS NULL AND provider_account_id IS NULL) OR (role_key <> 'tenant_authority_admin' AND workspace_id IS NOT NULL)),
+  CONSTRAINT "provider_role_bindings_account_workspace_check" CHECK (provider_account_id IS NULL OR workspace_id IS NOT NULL),
+  CONSTRAINT "provider_role_bindings_lifetime_check" CHECK (not_before IS NULL OR expires_at IS NULL OR expires_at > not_before)
+);
+CREATE INDEX "provider_role_bindings_principal_idx" ON "provider_role_bindings" ("tenant_id", "principal_type", "principal_id", "status");
+--> statement-breakpoint
+CREATE TABLE "provider_grants" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "tenant_id" varchar(64) NOT NULL,
+  "workspace_id" uuid NOT NULL,
+  "provider_account_id" uuid NOT NULL,
+  "agent_id" varchar(64) NOT NULL,
+  "operation_keys" text[] NOT NULL,
+  "environment" provider_environment,
+  "not_before" timestamptz,
+  "expires_at" timestamptz NOT NULL,
+  "status" provider_authority_status NOT NULL DEFAULT 'active',
+  "revision" integer NOT NULL DEFAULT 1 CHECK (revision > 0),
+  "granted_by_user_id" uuid NOT NULL REFERENCES "users"("id") ON DELETE RESTRICT,
+  "reason" text NOT NULL CHECK (length(trim(reason)) > 0),
+  "revoked_at" timestamptz,
+  "revoked_by_user_id" uuid REFERENCES "users"("id") ON DELETE RESTRICT,
+  "revocation_reason" text,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT "provider_grants_tenant_workspace_account_fk" FOREIGN KEY ("tenant_id", "workspace_id", "provider_account_id") REFERENCES "provider_accounts"("tenant_id", "workspace_id", "id") ON DELETE CASCADE,
+  CONSTRAINT "provider_grants_tenant_agent_fk" FOREIGN KEY ("tenant_id", "agent_id") REFERENCES "agents"("tenant_id", "id") ON DELETE CASCADE,
+  CONSTRAINT "provider_grants_operations_nonempty_check" CHECK (cardinality(operation_keys) > 0),
+  CONSTRAINT "provider_grants_lifetime_check" CHECK (not_before IS NULL OR expires_at > not_before)
+);
+CREATE INDEX "provider_grants_agent_scope_idx" ON "provider_grants" ("tenant_id", "workspace_id", "agent_id", "status");
+--> statement-breakpoint
+CREATE OR REPLACE FUNCTION steward_reject_provider_scope_move() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF OLD.tenant_id IS DISTINCT FROM NEW.tenant_id THEN
+    RAISE EXCEPTION 'provider authority tenant ownership is immutable' USING ERRCODE = '23514';
+  END IF;
+  IF (to_jsonb(OLD)->>'workspace_id') IS DISTINCT FROM (to_jsonb(NEW)->>'workspace_id') THEN
+    RAISE EXCEPTION 'provider authority workspace ownership is immutable' USING ERRCODE = '23514';
+  END IF;
+  IF (to_jsonb(OLD)->>'provider_account_id') IS DISTINCT FROM (to_jsonb(NEW)->>'provider_account_id') THEN
+    RAISE EXCEPTION 'provider account ownership is immutable' USING ERRCODE = '23514';
+  END IF;
+  RETURN NEW;
+END $$;
+CREATE TRIGGER workspaces_immutable_owner BEFORE UPDATE ON workspaces FOR EACH ROW EXECUTE FUNCTION steward_reject_provider_scope_move();
+CREATE TRIGGER provider_accounts_immutable_owner BEFORE UPDATE ON provider_accounts FOR EACH ROW EXECUTE FUNCTION steward_reject_provider_scope_move();
+CREATE TRIGGER provider_operations_immutable_owner BEFORE UPDATE ON provider_operations FOR EACH ROW EXECUTE FUNCTION steward_reject_provider_scope_move();
+CREATE TRIGGER provider_role_bindings_immutable_owner BEFORE UPDATE ON provider_role_bindings FOR EACH ROW EXECUTE FUNCTION steward_reject_provider_scope_move();
+CREATE TRIGGER provider_grants_immutable_owner BEFORE UPDATE ON provider_grants FOR EACH ROW EXECUTE FUNCTION steward_reject_provider_scope_move();

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -414,6 +414,13 @@
       "when": 1780138200000,
       "tag": "0078_execution_authorization_nonces",
       "breakpoints": true
+    },
+    {
+      "idx": 79,
+      "version": "7",
+      "when": 1784050800000,
+      "tag": "0079_workspace_provider_authority",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/__tests__/provider-authority-migration.test.ts
+++ b/packages/db/src/__tests__/provider-authority-migration.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, setDefaultTimeout, test } from "bun:test";
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { PGlite } from "@electric-sql/pglite";
+import { createPGLiteDb } from "../pglite";
+
+setDefaultTimeout(120_000);
+const migrations = new URL("../../drizzle", import.meta.url).pathname;
+
+async function applyFile(client: PGlite, file: string) {
+  const sql = await readFile(join(migrations, file), "utf8");
+  for (const statement of sql.split("--> statement-breakpoint")) {
+    if (statement.trim()) await client.exec(statement);
+  }
+}
+
+async function applyThroughCurrentSchema(client: PGlite) {
+  const files = (await readdir(migrations))
+    .filter((file) => file.endsWith(".sql") && file !== "0079_workspace_provider_authority.sql")
+    .sort();
+  for (const file of files) await applyFile(client, file);
+}
+
+async function seedAuthority(client: PGlite) {
+  await client.exec(`
+    INSERT INTO tenants(id,name,api_key_hash) VALUES ('ta','A','ha'),('tb','B','hb');
+    INSERT INTO users(id,email,created_at,updated_at) VALUES
+      ('00000000-0000-4000-8000-000000000001','owner@example.test',now(),now());
+    INSERT INTO user_tenants(id,user_id,tenant_id,role) VALUES
+      ('00000000-0000-4000-8000-000000000011','00000000-0000-4000-8000-000000000001','ta','owner');
+    INSERT INTO agents(id,tenant_id,name,wallet_address) VALUES ('agent-a','ta','A','0xa'),('agent-b','tb','B','0xb');
+    INSERT INTO workspaces(id,tenant_id,key,name,environment,created_by) VALUES
+      ('00000000-0000-4000-8000-000000000101','ta','client-a','Client A','production','00000000-0000-4000-8000-000000000001'),
+      ('00000000-0000-4000-8000-000000000102','tb','client-b','Client B','production','00000000-0000-4000-8000-000000000001');
+    INSERT INTO provider_accounts(id,tenant_id,workspace_id,adapter_key,external_ref,display_name) VALUES
+      ('00000000-0000-4000-8000-000000000201','ta','00000000-0000-4000-8000-000000000101','github','a','A');
+  `);
+}
+
+describe("provider authority migration", () => {
+  test("migrates an empty database and creates the authority tables", async () => {
+    const { client } = await createPGLiteDb("memory://");
+    const result = await client.query<{ table_name: string }>(
+      `SELECT table_name FROM information_schema.tables WHERE table_schema='public' AND table_name IN ('workspaces','provider_accounts','provider_operations','provider_role_bindings','provider_grants') ORDER BY table_name`,
+    );
+    expect(result.rows.map((row) => row.table_name)).toEqual([
+      "provider_accounts",
+      "provider_grants",
+      "provider_operations",
+      "provider_role_bindings",
+      "workspaces",
+    ]);
+    await client.close();
+  });
+
+  test("upgrades the current schema without changing existing rows", async () => {
+    const client = new PGlite("memory://");
+    await applyThroughCurrentSchema(client);
+    await client.exec(
+      `INSERT INTO tenants(id,name,api_key_hash) VALUES ('existing','Existing','existing-hash')`,
+    );
+    await applyFile(client, "0079_workspace_provider_authority.sql");
+    const tenant = await client.query<{ name: string }>(
+      "SELECT name FROM tenants WHERE id='existing'",
+    );
+    const table = await client.query<{ r: string | null }>(
+      "SELECT to_regclass('public.provider_grants')::text AS r",
+    );
+    expect(tenant.rows[0]?.name).toBe("Existing");
+    expect(table.rows[0]?.r).toBe("provider_grants");
+    await client.close();
+  });
+
+  test("rejects cross-tenant/workspace references and ownership moves", async () => {
+    const { client } = await createPGLiteDb("memory://");
+    await seedAuthority(client);
+    await expect(
+      client.exec(
+        `INSERT INTO provider_accounts(id,tenant_id,workspace_id,adapter_key,external_ref,display_name) VALUES ('00000000-0000-4000-8000-000000000202','tb','00000000-0000-4000-8000-000000000101','github','bad','bad')`,
+      ),
+    ).rejects.toThrow();
+    await expect(
+      client.exec(
+        `INSERT INTO provider_grants(id,tenant_id,workspace_id,provider_account_id,agent_id,operation_keys,expires_at,granted_by_user_id,reason) VALUES ('00000000-0000-4000-8000-000000000301','ta','00000000-0000-4000-8000-000000000101','00000000-0000-4000-8000-000000000201','agent-b',ARRAY['github.issue.list'],now()+interval '1 hour','00000000-0000-4000-8000-000000000001','bad')`,
+      ),
+    ).rejects.toThrow();
+    await expect(
+      client.exec(
+        `UPDATE provider_accounts SET workspace_id='00000000-0000-4000-8000-000000000102' WHERE id='00000000-0000-4000-8000-000000000201'`,
+      ),
+    ).rejects.toThrow(/immutable/);
+    await client.close();
+  });
+});

--- a/packages/db/src/__tests__/provider-authority-migration.test.ts
+++ b/packages/db/src/__tests__/provider-authority-migration.test.ts
@@ -71,6 +71,87 @@ describe("provider authority migration", () => {
     await client.close();
   });
 
+  test("keeps raw-SQL-only invariants present after migration (P1-1)", async () => {
+    // These are the invariants that live ONLY in 0079 raw SQL and are invisible
+    // to drizzle-kit (see the RAW-SQL-ONLY banner in schema.ts). Asserting they
+    // exist post-migration means an accidental drop (e.g. someone regenerating
+    // from schema.ts) fails CI instead of silently removing fund-safety guards.
+    const { client } = await createPGLiteDb("memory://");
+
+    // 1. All five *_immutable_owner triggers exist.
+    const triggers = await client.query<{ tgname: string }>(
+      `SELECT tgname FROM pg_trigger WHERE NOT tgisinternal AND tgname LIKE '%_immutable_owner' ORDER BY tgname`,
+    );
+    expect(triggers.rows.map((row) => row.tgname)).toEqual([
+      "provider_accounts_immutable_owner",
+      "provider_grants_immutable_owner",
+      "provider_operations_immutable_owner",
+      "provider_role_bindings_immutable_owner",
+      "workspaces_immutable_owner",
+    ]);
+
+    // The shared trigger function backing them exists.
+    const fn = await client.query<{ proname: string }>(
+      `SELECT proname FROM pg_proc WHERE proname='steward_reject_provider_scope_move'`,
+    );
+    expect(fn.rows.map((row) => row.proname)).toEqual(["steward_reject_provider_scope_move"]);
+
+    // 2. The role-binding lifetime CHECK (raw-SQL-only counterpart to the
+    //    in-schema provider_grants lifetime check) exists.
+    const lifetimeCheck = await client.query<{ conname: string }>(
+      `SELECT conname FROM pg_constraint WHERE contype='c' AND conname='provider_role_bindings_lifetime_check'`,
+    );
+    expect(lifetimeCheck.rows.map((row) => row.conname)).toEqual([
+      "provider_role_bindings_lifetime_check",
+    ]);
+
+    await client.close();
+  });
+
+  test("enforces the role-binding lifetime CHECK at write time (P1-1)", async () => {
+    const { client } = await createPGLiteDb("memory://");
+    await seedAuthority(client);
+    // expires_at <= not_before must be rejected by the lifetime CHECK.
+    await expect(
+      client.exec(
+        `INSERT INTO provider_role_bindings(id,tenant_id,workspace_id,principal_type,principal_id,role_key,granted_by_user_id,reason,not_before,expires_at) VALUES ('00000000-0000-4000-8000-000000000401','ta','00000000-0000-4000-8000-000000000101','human','user-a','workspace_admin','00000000-0000-4000-8000-000000000001','bad lifetime',now()+interval '2 hour',now()+interval '1 hour')`,
+      ),
+    ).rejects.toThrow(/lifetime/);
+    // A valid ordering (or a NULL bound) is accepted.
+    await client.exec(
+      `INSERT INTO provider_role_bindings(id,tenant_id,workspace_id,principal_type,principal_id,role_key,granted_by_user_id,reason,not_before,expires_at) VALUES ('00000000-0000-4000-8000-000000000402','ta','00000000-0000-4000-8000-000000000101','human','user-a','workspace_admin','00000000-0000-4000-8000-000000000001','ok lifetime',now(),now()+interval '1 hour')`,
+    );
+    const ok = await client.query<{ id: string }>(
+      `SELECT id FROM provider_role_bindings WHERE id='00000000-0000-4000-8000-000000000402'`,
+    );
+    expect(ok.rows).toHaveLength(1);
+    await client.close();
+  });
+
+  test("provider_accounts immutability trigger allows same-table mutation but blocks owner move (P1-2)", async () => {
+    const { client } = await createPGLiteDb("memory://");
+    await seedAuthority(client);
+
+    // Positive: mutating status + revision on the same row passes the trigger.
+    await client.exec(
+      `UPDATE provider_accounts SET status='disabled', revision=revision+1 WHERE id='00000000-0000-4000-8000-000000000201'`,
+    );
+    const updated = await client.query<{ status: string; revision: number }>(
+      `SELECT status, revision FROM provider_accounts WHERE id='00000000-0000-4000-8000-000000000201'`,
+    );
+    expect(updated.rows[0]?.status).toBe("disabled");
+    expect(updated.rows[0]?.revision).toBe(2);
+
+    // Negative: moving workspace_id on the same row is rejected as immutable.
+    await expect(
+      client.exec(
+        `UPDATE provider_accounts SET workspace_id='00000000-0000-4000-8000-000000000102' WHERE id='00000000-0000-4000-8000-000000000201'`,
+      ),
+    ).rejects.toThrow(/immutable/);
+
+    await client.close();
+  });
+
   test("rejects cross-tenant/workspace references and ownership moves", async () => {
     const { client } = await createPGLiteDb("memory://");
     await seedAuthority(client);

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1631,6 +1631,37 @@ export const secretRoutes = pgTable(
 );
 
 // ─── Workspace-scoped provider authority (governed-provider plan PR1) ─────────
+//
+// ⚠️ RAW-SQL-ONLY INVARIANTS (drift risk — NOT expressible in Drizzle, see
+//    drizzle/0079_workspace_provider_authority.sql):
+//
+//    1. Ownership immutability. A BEFORE UPDATE trigger
+//       `steward_reject_provider_scope_move()` is attached to FIVE tables via
+//       these triggers, and rejects any UPDATE that changes tenant_id /
+//       workspace_id / provider_account_id (RAISE EXCEPTION ... 'immutable',
+//       ERRCODE 23514):
+//         - workspaces_immutable_owner            (ON workspaces)
+//         - provider_accounts_immutable_owner     (ON provider_accounts)
+//         - provider_operations_immutable_owner   (ON provider_operations)
+//         - provider_role_bindings_immutable_owner(ON provider_role_bindings)
+//         - provider_grants_immutable_owner       (ON provider_grants)
+//       Drizzle has no trigger DSL, so these live only in raw SQL. Do NOT
+//       assume a `drizzle-kit generate` reflects them — it will not, and
+//       regenerating without re-adding them silently drops fund-safety guards.
+//
+//    2. provider_role_bindings_lifetime_check CHECK
+//       (not_before IS NULL OR expires_at IS NULL OR expires_at > not_before)
+//       is defined in 0079 raw SQL only and is intentionally absent from the
+//       providerRoleBindings table below (both bounds are nullable there, so
+//       the tri-state predicate is awkward to keep in sync via the Drizzle
+//       `check()` helper). It is the counterpart to providerGrants'
+//       lifetimeCheck (which IS declared in-schema because expires_at is NOT
+//       NULL on grants).
+//
+//    The regression test `packages/db/src/__tests__/provider-authority-migration.test.ts`
+//    ("schema-only invariants ..." cases) asserts all five triggers, the trigger
+//    function, and the lifetime CHECK exist after migration so accidental
+//    removal fails CI.
 
 export const providerEnvironmentEnum = pgEnum("provider_environment", [
   "development",
@@ -1666,6 +1697,8 @@ export const providerAuthorityTenantState = pgTable("provider_authority_tenant_s
   ...timestamps,
 });
 
+// NOTE: owner immutability enforced by `workspaces_immutable_owner` trigger in
+// 0079 raw SQL (tenant_id cannot change). Not visible to drizzle-kit.
 export const workspaces = pgTable(
   "workspaces",
   {
@@ -1688,6 +1721,9 @@ export const workspaces = pgTable(
   }),
 );
 
+// NOTE: owner immutability (tenant_id + workspace_id) enforced by
+// `provider_accounts_immutable_owner` trigger in 0079 raw SQL. Not visible to
+// drizzle-kit.
 export const providerAccounts = pgTable(
   "provider_accounts",
   {
@@ -1732,6 +1768,8 @@ export const providerAccounts = pgTable(
   }),
 );
 
+// NOTE: owner immutability enforced by `provider_operations_immutable_owner`
+// trigger in 0079 raw SQL. Not visible to drizzle-kit.
 export const providerOperations = pgTable(
   "provider_operations",
   {
@@ -1779,6 +1817,10 @@ export const providerOperations = pgTable(
   }),
 );
 
+// NOTE: owner immutability enforced by `provider_role_bindings_immutable_owner`
+// trigger, and the tri-state lifetime rule by
+// `provider_role_bindings_lifetime_check` CHECK — BOTH in 0079 raw SQL only
+// (see the section banner above). Not visible to drizzle-kit.
 export const providerRoleBindings = pgTable(
   "provider_role_bindings",
   {
@@ -1833,6 +1875,9 @@ export const providerRoleBindings = pgTable(
   }),
 );
 
+// NOTE: owner immutability enforced by `provider_grants_immutable_owner`
+// trigger in 0079 raw SQL (lifetimeCheck IS declared in-schema below since
+// expires_at is NOT NULL here). Not visible to drizzle-kit.
 export const providerGrants = pgTable(
   "provider_grants",
   {

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1598,6 +1598,7 @@ export const secrets = pgTable(
       table.version,
     ),
     tenantIdx: index("secrets_tenant_idx").on(table.tenantId),
+    tenantIdUnique: uniqueIndex("secrets_tenant_id_unique_idx").on(table.tenantId, table.id),
   }),
 );
 
@@ -1625,8 +1626,270 @@ export const secretRoutes = pgTable(
     agentIdx: index("secret_routes_agent_idx").on(table.agentId),
     secretIdx: index("secret_routes_secret_idx").on(table.secretId),
     hostIdx: index("secret_routes_host_idx").on(table.hostPattern),
+    tenantIdUnique: uniqueIndex("secret_routes_tenant_id_unique_idx").on(table.tenantId, table.id),
   }),
 );
+
+// ─── Workspace-scoped provider authority (governed-provider plan PR1) ─────────
+
+export const providerEnvironmentEnum = pgEnum("provider_environment", [
+  "development",
+  "staging",
+  "production",
+]);
+export const providerAuthorityStatusEnum = pgEnum("provider_authority_status", [
+  "active",
+  "disabled",
+  "revoked",
+]);
+export const providerPrincipalTypeEnum = pgEnum("provider_principal_type", ["human", "agent"]);
+export const providerRoleEnum = pgEnum("provider_role", [
+  "tenant_authority_admin",
+  "workspace_admin",
+  "workspace_operator",
+  "workspace_viewer",
+  "workspace_approver",
+]);
+export const providerRiskClassEnum = pgEnum("provider_risk_class", [
+  "read",
+  "write",
+  "consequential",
+]);
+
+/** Tenant-level CAS watermark for authority mutations. It is not an access dependency. */
+export const providerAuthorityTenantState = pgTable("provider_authority_tenant_state", {
+  tenantId: varchar("tenant_id", { length: 64 })
+    .primaryKey()
+    .references(() => tenants.id, { onDelete: "cascade" }),
+  revision: integer("revision").notNull().default(0),
+  ...timestamps,
+});
+
+export const workspaces = pgTable(
+  "workspaces",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    tenantId: varchar("tenant_id", { length: 64 })
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    key: varchar("key", { length: 128 }).notNull(),
+    name: varchar("name", { length: 255 }).notNull(),
+    environment: providerEnvironmentEnum("environment").notNull(),
+    status: providerAuthorityStatusEnum("status").notNull().default("active"),
+    revision: integer("revision").notNull().default(1),
+    createdBy: uuid("created_by").notNull(),
+    ...timestamps,
+  },
+  (table) => ({
+    tenantIdUnique: uniqueIndex("workspaces_tenant_id_id_idx").on(table.tenantId, table.id),
+    tenantKeyUnique: uniqueIndex("workspaces_tenant_key_idx").on(table.tenantId, table.key),
+    tenantStatusIdx: index("workspaces_tenant_status_idx").on(table.tenantId, table.status),
+  }),
+);
+
+export const providerAccounts = pgTable(
+  "provider_accounts",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    tenantId: varchar("tenant_id", { length: 64 }).notNull(),
+    workspaceId: uuid("workspace_id").notNull(),
+    adapterKey: varchar("adapter_key", { length: 128 }).notNull(),
+    externalRef: varchar("external_ref", { length: 512 }).notNull(),
+    displayName: varchar("display_name", { length: 255 }).notNull(),
+    status: providerAuthorityStatusEnum("status").notNull().default("active"),
+    credentialSecretId: uuid("credential_secret_id"),
+    credentialVersion: integer("credential_version"),
+    revision: integer("revision").notNull().default(1),
+    ...timestamps,
+  },
+  (table) => ({
+    workspaceFk: foreignKey({
+      columns: [table.tenantId, table.workspaceId],
+      foreignColumns: [workspaces.tenantId, workspaces.id],
+      name: "provider_accounts_tenant_workspace_fk",
+    }).onDelete("cascade"),
+    credentialFk: foreignKey({
+      columns: [table.tenantId, table.credentialSecretId],
+      foreignColumns: [secrets.tenantId, secrets.id],
+      name: "provider_accounts_tenant_credential_fk",
+    }).onDelete("restrict"),
+    tenantWorkspaceIdUnique: uniqueIndex("provider_accounts_tenant_workspace_id_idx").on(
+      table.tenantId,
+      table.workspaceId,
+      table.id,
+    ),
+    externalRefUnique: uniqueIndex("provider_accounts_workspace_external_ref_idx").on(
+      table.tenantId,
+      table.workspaceId,
+      table.adapterKey,
+      table.externalRef,
+    ),
+    credentialPairCheck: check(
+      "provider_accounts_credential_pair_check",
+      sql`(${table.credentialSecretId} IS NULL) = (${table.credentialVersion} IS NULL)`,
+    ),
+  }),
+);
+
+export const providerOperations = pgTable(
+  "provider_operations",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    tenantId: varchar("tenant_id", { length: 64 }).notNull(),
+    workspaceId: uuid("workspace_id").notNull(),
+    providerAccountId: uuid("provider_account_id").notNull(),
+    operationKey: varchar("operation_key", { length: 128 }).notNull(),
+    riskClass: providerRiskClassEnum("risk_class").notNull(),
+    capabilityId: uuid("capability_id"),
+    secretRouteId: uuid("secret_route_id"),
+    requestProfile: jsonb("request_profile").$type<Record<string, unknown>>().notNull().default({}),
+    responseProfile: jsonb("response_profile")
+      .$type<Record<string, unknown>>()
+      .notNull()
+      .default({}),
+    status: providerAuthorityStatusEnum("status").notNull().default("active"),
+    revision: integer("revision").notNull().default(1),
+    ...timestamps,
+  },
+  (table) => ({
+    accountFk: foreignKey({
+      columns: [table.tenantId, table.workspaceId, table.providerAccountId],
+      foreignColumns: [
+        providerAccounts.tenantId,
+        providerAccounts.workspaceId,
+        providerAccounts.id,
+      ],
+      name: "provider_operations_tenant_workspace_account_fk",
+    }).onDelete("cascade"),
+    routeFk: foreignKey({
+      columns: [table.tenantId, table.secretRouteId],
+      foreignColumns: [secretRoutes.tenantId, secretRoutes.id],
+      name: "provider_operations_tenant_route_fk",
+    }).onDelete("restrict"),
+    operationUnique: uniqueIndex("provider_operations_account_key_idx").on(
+      table.tenantId,
+      table.workspaceId,
+      table.providerAccountId,
+      table.operationKey,
+    ),
+    tenantWorkspaceAccountIdUnique: uniqueIndex(
+      "provider_operations_tenant_workspace_account_id_idx",
+    ).on(table.tenantId, table.workspaceId, table.providerAccountId, table.id),
+  }),
+);
+
+export const providerRoleBindings = pgTable(
+  "provider_role_bindings",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    tenantId: varchar("tenant_id", { length: 64 })
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    workspaceId: uuid("workspace_id"),
+    providerAccountId: uuid("provider_account_id"),
+    principalType: providerPrincipalTypeEnum("principal_type").notNull(),
+    principalId: varchar("principal_id", { length: 64 }).notNull(),
+    roleKey: providerRoleEnum("role_key").notNull(),
+    operationKeys: text("operation_keys").array().notNull().default([]),
+    environment: providerEnvironmentEnum("environment"),
+    notBefore: timestamp("not_before", { withTimezone: true }),
+    expiresAt: timestamp("expires_at", { withTimezone: true }),
+    status: providerAuthorityStatusEnum("status").notNull().default("active"),
+    revision: integer("revision").notNull().default(1),
+    grantedByUserId: uuid("granted_by_user_id").notNull(),
+    reason: text("reason").notNull(),
+    ...timestamps,
+  },
+  (table) => ({
+    workspaceFk: foreignKey({
+      columns: [table.tenantId, table.workspaceId],
+      foreignColumns: [workspaces.tenantId, workspaces.id],
+      name: "provider_role_bindings_tenant_workspace_fk",
+    }).onDelete("cascade"),
+    accountFk: foreignKey({
+      columns: [table.tenantId, table.workspaceId, table.providerAccountId],
+      foreignColumns: [
+        providerAccounts.tenantId,
+        providerAccounts.workspaceId,
+        providerAccounts.id,
+      ],
+      name: "provider_role_bindings_tenant_workspace_account_fk",
+    }).onDelete("cascade"),
+    principalIdx: index("provider_role_bindings_principal_idx").on(
+      table.tenantId,
+      table.principalType,
+      table.principalId,
+      table.status,
+    ),
+    scopeCheck: check(
+      "provider_role_bindings_scope_check",
+      sql`(${table.roleKey} = 'tenant_authority_admin' AND ${table.workspaceId} IS NULL AND ${table.providerAccountId} IS NULL) OR (${table.roleKey} <> 'tenant_authority_admin' AND ${table.workspaceId} IS NOT NULL)`,
+    ),
+    accountNeedsWorkspaceCheck: check(
+      "provider_role_bindings_account_workspace_check",
+      sql`${table.providerAccountId} IS NULL OR ${table.workspaceId} IS NOT NULL`,
+    ),
+  }),
+);
+
+export const providerGrants = pgTable(
+  "provider_grants",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    tenantId: varchar("tenant_id", { length: 64 }).notNull(),
+    workspaceId: uuid("workspace_id").notNull(),
+    providerAccountId: uuid("provider_account_id").notNull(),
+    agentId: varchar("agent_id", { length: 64 }).notNull(),
+    operationKeys: text("operation_keys").array().notNull(),
+    environment: providerEnvironmentEnum("environment"),
+    notBefore: timestamp("not_before", { withTimezone: true }),
+    expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+    status: providerAuthorityStatusEnum("status").notNull().default("active"),
+    revision: integer("revision").notNull().default(1),
+    grantedByUserId: uuid("granted_by_user_id").notNull(),
+    reason: text("reason").notNull(),
+    revokedAt: timestamp("revoked_at", { withTimezone: true }),
+    revokedByUserId: uuid("revoked_by_user_id"),
+    revocationReason: text("revocation_reason"),
+    ...timestamps,
+  },
+  (table) => ({
+    accountFk: foreignKey({
+      columns: [table.tenantId, table.workspaceId, table.providerAccountId],
+      foreignColumns: [
+        providerAccounts.tenantId,
+        providerAccounts.workspaceId,
+        providerAccounts.id,
+      ],
+      name: "provider_grants_tenant_workspace_account_fk",
+    }).onDelete("cascade"),
+    agentFk: foreignKey({
+      columns: [table.tenantId, table.agentId],
+      foreignColumns: [agents.tenantId, agents.id],
+      name: "provider_grants_tenant_agent_fk",
+    }).onDelete("cascade"),
+    agentScopeIdx: index("provider_grants_agent_scope_idx").on(
+      table.tenantId,
+      table.workspaceId,
+      table.agentId,
+      table.status,
+    ),
+    operationsNonempty: check(
+      "provider_grants_operations_nonempty_check",
+      sql`cardinality(${table.operationKeys}) > 0`,
+    ),
+    lifetimeCheck: check(
+      "provider_grants_lifetime_check",
+      sql`${table.notBefore} IS NULL OR ${table.expiresAt} > ${table.notBefore}`,
+    ),
+  }),
+);
+
+export type Workspace = typeof workspaces.$inferSelect;
+export type ProviderAccount = typeof providerAccounts.$inferSelect;
+export type ProviderOperation = typeof providerOperations.$inferSelect;
+export type ProviderRoleBinding = typeof providerRoleBindings.$inferSelect;
+export type ProviderGrant = typeof providerGrants.$inferSelect;
 
 export const pendingProxyRequestStatusEnum = pgEnum("pending_proxy_request_status", [
   "pending",

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1662,6 +1662,7 @@ export const providerAuthorityTenantState = pgTable("provider_authority_tenant_s
     .primaryKey()
     .references(() => tenants.id, { onDelete: "cascade" }),
   revision: integer("revision").notNull().default(0),
+  bootstrapCompleted: boolean("bootstrap_completed").notNull().default(false),
   ...timestamps,
 });
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -9,6 +9,7 @@ export * from "./execution-contract.js";
 export * from "./execution-payload.js";
 export type { PriceOracle } from "./price-oracle.js";
 export { createPriceOracle } from "./price-oracle.js";
+export * from "./provider-authority.js";
 export * from "./security-surface.js";
 // ─── Token Registry & Price Oracle ───
 export * from "./tokens.js";

--- a/packages/shared/src/provider-authority.ts
+++ b/packages/shared/src/provider-authority.ts
@@ -1,0 +1,72 @@
+export const PROVIDER_ENVIRONMENTS = ["development", "staging", "production"] as const;
+export type ProviderEnvironment = (typeof PROVIDER_ENVIRONMENTS)[number];
+
+export const PROVIDER_AUTHORITY_STATUSES = ["active", "disabled", "revoked"] as const;
+export type ProviderAuthorityStatus = (typeof PROVIDER_AUTHORITY_STATUSES)[number];
+
+export const PROVIDER_ROLES = [
+  "tenant_authority_admin",
+  "workspace_admin",
+  "workspace_operator",
+  "workspace_viewer",
+  "workspace_approver",
+] as const;
+export type ProviderRole = (typeof PROVIDER_ROLES)[number];
+
+export const PROVIDER_PRINCIPAL_TYPES = ["human", "agent"] as const;
+export type ProviderPrincipalType = (typeof PROVIDER_PRINCIPAL_TYPES)[number];
+
+export const PROVIDER_RISK_CLASSES = ["read", "write", "consequential"] as const;
+export type ProviderRiskClass = (typeof PROVIDER_RISK_CLASSES)[number];
+
+/** Every repository lookup carries this scope. organizationId is tenantId in v1. */
+export interface TenantWorkspaceScope {
+  tenantId: string;
+  workspaceId: string;
+}
+
+export interface ProviderAccessRequestV1 {
+  tenantId: string;
+  workspaceId: string;
+  actor: { type: ProviderPrincipalType; id: string };
+  providerAccountId: string;
+  operationKey: string;
+  environment: ProviderEnvironment;
+  evaluatedAt: string;
+}
+
+export interface ProviderAccessDecisionV1 {
+  decisionId: string;
+  effect: "allow" | "deny";
+  reasonCode: string;
+  matchedBindingIds: string[];
+  matchedGrantIds: string[];
+  dependencyRevisions: {
+    actor: number;
+    workspace: number;
+    providerAccount: number;
+    operation: number;
+    bindings: Array<{ id: string; revision: number }>;
+    grants: Array<{ id: string; revision: number }>;
+  };
+  decidedAt: string;
+}
+
+export const PROVIDER_ACCESS_REASON = {
+  ALLOWED: "provider_access_allowed",
+  ACTOR_INACTIVE: "actor_inactive",
+  RESOURCE_NOT_FOUND: "resource_not_found",
+  RESOURCE_INACTIVE: "resource_inactive",
+  NO_MATCHING_AUTHORITY: "no_matching_authority",
+} as const;
+
+export interface ProviderAuthorityMutationContext {
+  tenantId: string;
+  actorUserId: string;
+  tenantRole: string;
+  mfaVerifiedAt: number;
+  idempotencyKey: string;
+  expectedRevision: number;
+  reason: string;
+  requestId?: string;
+}


### PR DESCRIPTION
## Summary

Implements PR1 of the governed-provider authority plan: workspace-scoped RBAC and the provider authority foundation.

### Plan phase mapping

- [PR1 schema foundation](https://github.com/Steward-Fi/steward/blob/feat/workspace-authority/packages/db/drizzle/0079_workspace_provider_authority.sql): tenant-owned workspaces, provider accounts, provider operations, role bindings, direct grants, composite scope constraints, immutable ownership, and a tenant bootstrap/CAS state.
- [PR1 shared contract](https://github.com/Steward-Fi/steward/blob/feat/workspace-authority/packages/shared/src/provider-authority.ts): canonical vocabulary and the structural provider-access decision contract.
- [PR1 authority service](https://github.com/Steward-Fi/steward/blob/feat/workspace-authority/packages/api/src/services/provider-authority-store.ts): default deny, explicit role composition, one-way owner bootstrap, time/environment scoping, last-admin protection, grant attenuation, non-delegability, recent MFA, expected revisions, and mandatory pre-commit audit callbacks.
- [PR1 management and check surfaces](https://github.com/Steward-Fi/steward/blob/feat/workspace-authority/packages/api/src/routes/provider-authority.ts): `/v2` management routes plus `/v2/provider-access/check`, authenticated principal derivation, and non-enumerating scoped lookups.
- [PR1 OpenAPI registration](https://github.com/Steward-Fi/steward/blob/feat/workspace-authority/packages/api/src/openapi.ts): registered provider-authority endpoints and regenerated `docs/openapi.json`.

`org_id` remains identical to `tenant_id`; this adds no separate organization concept.

## Security behavior

- Cross-tenant and cross-workspace ownership is rejected by composite foreign keys and service predicates.
- Workspace/account/provider identifiers are immutable via database triggers.
- Existing tenant owners may create the first explicit tenant authority administrator only. A persisted bootstrap-completed bit prevents owner compatibility from reopening after expiration or revocation.
- Administrative bindings honor `not_before`, `expires_at`, and environment scope.
- Mutations require human session authority, recent MFA, `Idempotency-Key`, expected revision, reason, and a successful mandatory audit write before the state change.
- Last active tenant authority admin cannot be revoked.
- Grant operation sets must be a subset of active provider operations and any narrowed workspace-admin mandate.
- Direct agent grants are terminal and non-delegable.
- Operation enrollment is restricted to a code-defined adapter/operation/host/method allowlist.
- `/v2/provider-access/check` returns the full structural decision contract with matched authority IDs and dependency revisions.

## Test evidence

- `bun test --timeout 120000 packages/db/src/__tests__/provider-authority-migration.test.ts`
  - 3 pass, 0 fail
  - empty migration, upgrade from current schema, cross-tenant FK rejection, immutable ownership
- `bun test --timeout 120000 packages/api/src/__tests__/provider-authority.test.ts packages/api/src/__tests__/openapi-contract.test.ts`
  - 27 pass, 0 fail
  - owner bootstrap transition, mutation gates, scope matrix, last-admin protection, grant subsets, expiry/not-before/environment, non-delegability, workspace isolation, access allow/deny matrix, OpenAPI surfaces
- Isolation mutation proof:
  - removed the grant workspace/account guards locally
  - focused suite failed with `Expected: "deny" / Received: "allow"`
  - restored the guards and reran: 9 pass, 0 fail
- Typechecks/builds passed for `@stwd/shared`, `@stwd/db`, `@stwd/redis`, `@stwd/api`, and `@stwd/sdk`.
- Biome passed on all touched source/test files.
- Codex review completed. Fixed findings for environment-scoped admins, tenant-admin lifetime/bootstrap handling, malformed scalar validation, and invalid date validation.

## Explicit non-goals

- No execution-path integration.
- No proxy changes.
- No capability-plugin changes.
- No trading-route changes.
- No credential injection or outbound provider calls.
- No auto-merge or merge requested.

[sol-orch]
