### PR TITLE
fix(policy): approval-required rules cannot be shadowed by allow rules in capability-intent composition

### DIFF
--- a/packages/plugin-capabilities/src/__tests__/invoke-e2e.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/invoke-e2e.test.ts
@@ -334,6 +334,55 @@ describe("invoke e2e: full arc through the real proxy", () => {
     expect(res.headers.get("x-steward-cap-gate")).toBeNull();
   });
 
+  // ROUND-2 P0 (full arc): a GOVERNING capability-intent rule whose evaluation
+  // throws an unprintable value (throwing toString/valueOf/Symbol.toPrimitive)
+  // used to escape the composer's catch as a raw exception => HTTP 500. End to
+  // end it must fail closed: 403, NEVER a 500, and NEVER forward to the proxy
+  // (no credential injection on a gate failure).
+  it("P0: governing rule throws an UNPRINTABLE value => 403 (NOT 500), never forwards", async () => {
+    await seedCapability();
+    const hostile = {
+      toString() {
+        throw new Error("toString throws");
+      },
+      valueOf() {
+        throw new Error("valueOf throws");
+      },
+      [Symbol.toPrimitive]() {
+        throw new Error("toPrimitive throws");
+      },
+    };
+    const hostileConfig: Record<string, unknown> = {
+      capabilities: ["github.pr.comment"],
+      effect: "allow",
+    };
+    Object.defineProperty(hostileConfig, "constraints", {
+      enumerable: true,
+      configurable: true,
+      get() {
+        throw hostile;
+      },
+    });
+    currentPolicySet = [
+      {
+        id: "hostile-throw-e2e",
+        type: "capability-intent" as unknown as PolicyRule["type"],
+        enabled: true,
+        config: hostileConfig as unknown as Record<string, unknown>,
+      },
+    ];
+    const app = buildInvokeApp();
+    const res = await app.request("/capabilities/github.pr.comment/invoke", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(403);
+    expect(res.status).not.toBe(500);
+    // fail-closed: the credential must never have been injected/forwarded.
+    expect(lastForwarded).toBeNull();
+  });
+
   it("ungranted capability => 403", async () => {
     // seed a capability but NO grant for this agent.
     const vault = new SecretVault(MASTER_PASSWORD);

--- a/packages/plugin-capabilities/src/__tests__/invoke.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/invoke.test.ts
@@ -373,6 +373,84 @@ describe("invoke: default-deny + effects", () => {
     expect(res.status).toBe(403);
   });
 
+  test("FINDING 1: config null => 403 (hard deny, NOT 500) even beside a passing allow", async () => {
+    // `rule.config` is opaque jsonb and can be null at runtime. The old
+    // parseConfig did `Object.keys(raw)` unguarded => TypeError => HTTP 500.
+    // It must now fail closed as a 403, never a 500.
+    const nullCfg: PolicyRule = {
+      id: "null-cfg",
+      type: "capability-intent" as unknown as PolicyRule["type"],
+      enabled: true,
+      config: null as unknown as Record<string, unknown>,
+    };
+    await seedCapabilityWithGrant();
+    currentPolicySet = [capRule("allow-rule", "allow", undefined, ["github.*"]), nullCfg];
+    const app = buildApp(harness!.db, { agent: true });
+    const res = await app.request("/capabilities/github.pr.comment/invoke", invokeReq({}));
+    expect(res.status).toBe(403);
+  });
+
+  for (const [label, badConfig] of [
+    ["string", "not-an-object"],
+    ["number", 42],
+    ["array", ["github.*"]],
+  ] as const) {
+    test(`FINDING 1: config ${label} => 403 (hard deny, NOT 500)`, async () => {
+      const badCfg: PolicyRule = {
+        id: `bad-${label}`,
+        type: "capability-intent" as unknown as PolicyRule["type"],
+        enabled: true,
+        config: badConfig as unknown as Record<string, unknown>,
+      };
+      await seedCapabilityWithGrant();
+      currentPolicySet = [badCfg];
+      const app = buildApp(harness!.db, { agent: true });
+      const res = await app.request("/capabilities/github.pr.comment/invoke", invokeReq({}));
+      expect(res.status).toBe(403);
+    });
+  }
+
+  test("FINDING 2: malformed rule SCOPED ELSEWHERE + valid allow => 503 (authorized, NOT bricked to 403)", async () => {
+    // A malformed rule scoped (valid selector) to a DIFFERENT capability must not
+    // brick this invoke. The valid github allow authorizes => proxy-env-absent
+    // 503, proving the decision was ALLOW (not the malformed-elsewhere hard-deny).
+    const malformedElsewhere: PolicyRule = {
+      id: "malformed-elsewhere",
+      type: "capability-intent" as unknown as PolicyRule["type"],
+      enabled: true,
+      config: { capabilities: ["gitlab.*"], effect: "allow", bogus: true } as unknown as Record<
+        string,
+        unknown
+      >,
+    };
+    await seedCapabilityWithGrant();
+    currentPolicySet = [
+      capRule("allow-rule", "allow", undefined, ["github.*"]),
+      malformedElsewhere,
+    ];
+    const app = buildApp(harness!.db, { agent: true });
+    const res = await app.request(
+      "/capabilities/github.pr.comment/invoke",
+      invokeReq({ body: { x: 1 } }),
+    );
+    expect(res.status).toBe(503);
+  });
+
+  test("FINDING 2: malformed rule with UNRECOVERABLE selector + valid allow for another cap => 403 (fail closed on ambiguous scope)", async () => {
+    const unrecoverable: PolicyRule = {
+      id: "unrecoverable",
+      type: "capability-intent" as unknown as PolicyRule["type"],
+      enabled: true,
+      // misspelled `capabilities` => selector unrecoverable => ambiguous scope.
+      config: { capabilties: ["gitlab.*"], effect: "deny" } as unknown as Record<string, unknown>,
+    };
+    await seedCapabilityWithGrant();
+    currentPolicySet = [capRule("allow-rule", "allow", undefined, ["github.*"]), unrecoverable];
+    const app = buildApp(harness!.db, { agent: true });
+    const res = await app.request("/capabilities/github.pr.comment/invoke", invokeReq({}));
+    expect(res.status).toBe(403);
+  });
+
   test("REGRESSION malformed rule that does NOT govern (misspelled `capabilities`) is NOT dropped => 403", async () => {
     // This is the fail-OPEN path codex flagged: a malformed rule whose broken
     // config would make a raw governing-match filter return false (here the

--- a/packages/plugin-capabilities/src/__tests__/invoke.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/invoke.test.ts
@@ -309,6 +309,92 @@ describe("invoke: default-deny + effects", () => {
     expect(rows.length).toBe(1);
     expect(rows[0].decision).toBe("error");
   });
+
+  // CANONICAL PRECEDENCE (master-plan §5.3) end-to-end through the invoke route.
+  // These directly guard the fixed allow-over-approval bug: a matching passing
+  // allow must NEVER shadow an applicable require-approval.
+
+  test("REGRESSION allow + require-approval on same capability => 202 (approval NOT shadowed by allow)", async () => {
+    const capId = await seedCapabilityWithGrant();
+    // an allow rule (would authorize) AND a require-approval rule on the same
+    // capability. old code let the passing allow short-circuit to allow (503).
+    currentPolicySet = [
+      capRule("allow-rule", "allow", undefined, ["github.*"]),
+      capRule("approval-rule", "require-approval"),
+    ];
+    const app = buildApp(harness!.db, { agent: true });
+    const res = await app.request("/capabilities/github.pr.comment/invoke", invokeReq({}));
+    expect(res.status).toBe(202);
+    const rows = await invocationRows(capId);
+    expect(rows.length).toBe(1);
+    expect(rows[0].decision).toBe("approval");
+  });
+
+  test("REGRESSION holds regardless of rule order (approval listed first) => 202", async () => {
+    await seedCapabilityWithGrant();
+    currentPolicySet = [
+      capRule("approval-rule", "require-approval"),
+      capRule("allow-rule", "allow", undefined, ["github.*"]),
+    ];
+    const app = buildApp(harness!.db, { agent: true });
+    const res = await app.request("/capabilities/github.pr.comment/invoke", invokeReq({}));
+    expect(res.status).toBe(202);
+  });
+
+  test("deny + approval on same capability => 403 (deny wins, never softened to approval)", async () => {
+    const capId = await seedCapabilityWithGrant();
+    currentPolicySet = [capRule("approval-rule", "require-approval"), capRule("deny-rule", "deny")];
+    const app = buildApp(harness!.db, { agent: true });
+    const res = await app.request("/capabilities/github.pr.comment/invoke", invokeReq({}));
+    expect(res.status).toBe(403);
+    const rows = await invocationRows(capId);
+    expect(rows[0].decision).toBe("deny");
+  });
+
+  test("deny + allow on same capability => 403 (deny wins over allow)", async () => {
+    await seedCapabilityWithGrant();
+    currentPolicySet = [
+      capRule("allow-rule", "allow", undefined, ["github.*"]),
+      capRule("deny-rule", "deny"),
+    ];
+    const app = buildApp(harness!.db, { agent: true });
+    const res = await app.request("/capabilities/github.pr.comment/invoke", invokeReq({}));
+    expect(res.status).toBe(403);
+  });
+
+  test("malformed rule config alongside a passing allow => 403 (fail closed)", async () => {
+    await seedCapabilityWithGrant();
+    const malformed = capRule("bad-rule", "allow", undefined, ["github.*"]);
+    // inject an unknown config key => parseConfig fails closed => hard deny.
+    (malformed.config as Record<string, unknown>).bogus = true;
+    currentPolicySet = [capRule("allow-rule", "allow", undefined, ["github.*"]), malformed];
+    const app = buildApp(harness!.db, { agent: true });
+    const res = await app.request("/capabilities/github.pr.comment/invoke", invokeReq({}));
+    expect(res.status).toBe(403);
+  });
+
+  test("REGRESSION malformed rule that does NOT govern (misspelled `capabilities`) is NOT dropped => 403", async () => {
+    // This is the fail-OPEN path codex flagged: a malformed rule whose broken
+    // config would make a raw governing-match filter return false (here the
+    // `capabilities` key is misspelled `capabilties`, so there is no valid
+    // capabilities list to match on). The composer must still parse it and
+    // hard-deny — it must NOT be silently filtered out before composition, even
+    // when a sibling allow matches the invoked capability.
+    const malformed: PolicyRule = {
+      id: "typo-rule",
+      type: "capability-intent" as unknown as PolicyRule["type"],
+      enabled: true,
+      // NOTE: `capabilties` (typo) + no valid `capabilities` array => parseConfig
+      // fails closed. A raw `Array.isArray(cfg.capabilities)` governing filter
+      // would drop this rule entirely.
+      config: { capabilties: ["github.*"], effect: "deny" } as unknown as Record<string, unknown>,
+    };
+    await seedCapabilityWithGrant();
+    currentPolicySet = [capRule("allow-rule", "allow", undefined, ["github.*"]), malformed];
+    const app = buildApp(harness!.db, { agent: true });
+    const res = await app.request("/capabilities/github.pr.comment/invoke", invokeReq({}));
+    expect(res.status).toBe(403);
+  });
 });
 
 describe("invoke: body parsing", () => {

--- a/packages/plugin-capabilities/src/__tests__/invoke.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/invoke.test.ts
@@ -473,6 +473,87 @@ describe("invoke: default-deny + effects", () => {
     const res = await app.request("/capabilities/github.pr.comment/invoke", invokeReq({}));
     expect(res.status).toBe(403);
   });
+
+  // ROUND-2 P0: a GOVERNING capability-intent rule whose evaluation throws a
+  // value whose toString/valueOf/Symbol.toPrimitive all throw used to escape the
+  // composer's catch (which did `String(err)`) as a raw exception => HTTP 500 at
+  // this invoke boundary. It must now fail closed as a 403, NEVER a 500, even
+  // beside a passing allow. The `constraints` getter throws the hostile value
+  // during parseConfig, reproducing an evaluator throw on the governing rule.
+  test("P0: governing rule throws an UNPRINTABLE value => 403 (hard deny, NOT 500), even beside a passing allow", async () => {
+    const hostile = {
+      toString() {
+        throw new Error("toString throws");
+      },
+      valueOf() {
+        throw new Error("valueOf throws");
+      },
+      [Symbol.toPrimitive]() {
+        throw new Error("toPrimitive throws");
+      },
+    };
+    const hostileConfig: Record<string, unknown> = {
+      capabilities: ["github.pr.comment"],
+      effect: "allow",
+    };
+    Object.defineProperty(hostileConfig, "constraints", {
+      enumerable: true,
+      configurable: true,
+      get() {
+        throw hostile;
+      },
+    });
+    const hostileRule: PolicyRule = {
+      id: "hostile-throw",
+      type: "capability-intent" as unknown as PolicyRule["type"],
+      enabled: true,
+      config: hostileConfig as unknown as Record<string, unknown>,
+    };
+    await seedCapabilityWithGrant();
+    currentPolicySet = [capRule("allow-rule", "allow", undefined, ["github.*"]), hostileRule];
+    const app = buildApp(harness!.db, { agent: true });
+    const res = await app.request("/capabilities/github.pr.comment/invoke", invokeReq({}));
+    expect(res.status).toBe(403);
+    // Must NOT be a 500 (the pre-fix escape).
+    expect(res.status).not.toBe(500);
+  });
+
+  test("P0: governing rule throws a Proxy(Error) with a throwing `.message` getter => 403, NOT 500", async () => {
+    const hostile = new Proxy(new Error("real"), {
+      get(_t, prop) {
+        if (prop === "message") throw new Error("hostile message getter");
+        if (prop === "toString" || prop === Symbol.toPrimitive || prop === "valueOf") {
+          return () => {
+            throw new Error("hostile coercion");
+          };
+        }
+        return undefined;
+      },
+    });
+    const hostileConfig: Record<string, unknown> = {
+      capabilities: ["github.pr.comment"],
+      effect: "allow",
+    };
+    Object.defineProperty(hostileConfig, "constraints", {
+      enumerable: true,
+      configurable: true,
+      get() {
+        throw hostile;
+      },
+    });
+    const hostileRule: PolicyRule = {
+      id: "hostile-proxy",
+      type: "capability-intent" as unknown as PolicyRule["type"],
+      enabled: true,
+      config: hostileConfig as unknown as Record<string, unknown>,
+    };
+    await seedCapabilityWithGrant();
+    currentPolicySet = [hostileRule];
+    const app = buildApp(harness!.db, { agent: true });
+    const res = await app.request("/capabilities/github.pr.comment/invoke", invokeReq({}));
+    expect(res.status).toBe(403);
+    expect(res.status).not.toBe(500);
+  });
 });
 
 describe("invoke: body parsing", () => {

--- a/packages/plugin-capabilities/src/invoke.ts
+++ b/packages/plugin-capabilities/src/invoke.ts
@@ -249,32 +249,57 @@ export async function invokeCapabilityThroughProxy(
     capabilityInvokeCount1h: count1h,
   };
 
-  await engine.evaluate(capRules, evaluatorCtx);
+  // FAIL-CLOSED OUTER BOUNDARY. Both the generic engine sweep and the canonical
+  // composer are defensively non-throwing by contract (the composer wraps every
+  // per-rule body; the registry describes hostile thrown values with a
+  // non-throwing helper). But this invoke path is a security gate: a throw here
+  // — from either call, a hostile jsonb getter deserializing `r.config`, or any
+  // unforeseen path — must DENY (403), never escape as a raw 500 (which callers
+  // could treat as a transient/retryable failure and which reveals nothing about
+  // the gate). We therefore wrap the entire evaluate+compose region and translate
+  // ANY escape into a fail-closed deny.
+  let decision: ReturnType<typeof composeCapabilityIntentDecision>;
+  try {
+    await engine.evaluate(capRules, evaluatorCtx);
 
-  // CANONICAL PRECEDENCE (master-plan §5.3): the policy-engine helper composes
-  // ALL enabled capability-intent rules in the one true order — hard deny (incl.
-  // malformed config / failed hard constraint) > approval_required > allow >
-  // default-deny. This is the single source of truth: an applicable
-  // require-approval can NEVER be shadowed by a matching allow, and a hard deny
-  // can never be softened into an approval.
-  //
-  // We pass the FULL enabled capability-intent set (not a pre-filtered
-  // "governing" subset): a MALFORMED rule config (e.g. a misspelled
-  // `capabilities` key or an unsupported glob) makes a raw governing-match filter
-  // return false, which would silently DROP the broken gate and fail OPEN if a
-  // sibling allow matched. The composer instead parses every rule and hard-denies
-  // on ANY malformation (fail closed), treats well-formed non-governing rules as
-  // inert, and applies the effective default-deny when no governing allow passes
-  // (covers the previous "no policy authorizes this capability" 403).
-  const decision = composeCapabilityIntentDecision(
-    capRules.map((r) => ({
-      id: r.id,
-      type: r.type as string,
-      enabled: r.enabled,
-      config: r.config,
-    })),
-    evaluatorCtx,
-  );
+    // CANONICAL PRECEDENCE (master-plan §5.3): the policy-engine helper composes
+    // ALL enabled capability-intent rules in the one true order — hard deny
+    // (incl. malformed config / failed hard constraint) > approval_required >
+    // allow > default-deny. This is the single source of truth: an applicable
+    // require-approval can NEVER be shadowed by a matching allow, and a hard deny
+    // can never be softened into an approval.
+    //
+    // We pass the FULL enabled capability-intent set (not a pre-filtered
+    // "governing" subset): a MALFORMED rule config (e.g. a misspelled
+    // `capabilities` key or an unsupported glob) makes a raw governing-match
+    // filter return false, which would silently DROP the broken gate and fail
+    // OPEN if a sibling allow matched. The composer instead parses every rule and
+    // hard-denies on ANY malformation (fail closed), treats well-formed
+    // non-governing rules as inert, and applies the effective default-deny when
+    // no governing allow passes (covers the previous "no policy authorizes this
+    // capability" 403).
+    decision = composeCapabilityIntentDecision(
+      capRules.map((r) => ({
+        id: r.id,
+        type: r.type as string,
+        enabled: r.enabled,
+        config: r.config,
+      })),
+      evaluatorCtx,
+    );
+  } catch {
+    // A throw escaped the (defensively non-throwing) evaluation region. Fail
+    // closed: deny, never 500. The reason is intentionally generic — it must not
+    // leak internals and must not itself risk stringifying a hostile value.
+    return recordAndJson(store, {
+      tenantId,
+      agentId,
+      capabilityId: cap.id,
+      decision: "deny",
+      status: 403,
+      payload: { ok: false, error: "policy evaluation failed" } satisfies ApiResponse,
+    });
+  }
 
   if (decision.effect === "hard_deny") {
     return recordAndJson(store, {

--- a/packages/plugin-capabilities/src/invoke.ts
+++ b/packages/plugin-capabilities/src/invoke.ts
@@ -14,9 +14,8 @@
 import { signAgentToken } from "@stwd/auth";
 import {
   CAPABILITY_INTENT_RULE_TYPE,
-  type CapabilityIntentConfig,
+  composeCapabilityIntentDecision,
   type EvaluatorContext,
-  evaluateCapabilityIntent,
   PolicyEngine,
 } from "@stwd/policy-engine";
 import { StewardProxyClient } from "@stwd/proxy-client";
@@ -145,29 +144,8 @@ function syntheticSignRequest(tenantId: string, agentId: string): SignRequest {
   };
 }
 
-function patternMatches(pattern: string, name: string): boolean {
-  if (typeof pattern !== "string" || pattern.length === 0) return false;
-  if (pattern.endsWith(".*")) return name.startsWith(pattern.slice(0, -1));
-  return pattern === name;
-}
-
 function isCapabilityIntentRule(rule: PolicyRule): boolean {
   return (rule.type as string) === (CAPABILITY_INTENT_RULE_TYPE as string);
-}
-
-function isMatchingAllowRule(rule: PolicyRule, name: string): boolean {
-  if (!isCapabilityIntentRule(rule)) return false;
-  const cfg = rule.config as Partial<CapabilityIntentConfig>;
-  if (cfg.effect !== "allow") return false;
-  if (!Array.isArray(cfg.capabilities)) return false;
-  return cfg.capabilities.some((p) => patternMatches(p, name));
-}
-
-function isGoverningRule(rule: PolicyRule, name: string): boolean {
-  if (!isCapabilityIntentRule(rule)) return false;
-  const cfg = rule.config as Partial<CapabilityIntentConfig>;
-  if (!Array.isArray(cfg.capabilities)) return false;
-  return cfg.capabilities.some((p) => patternMatches(p, name));
 }
 
 async function recordAndJson(
@@ -273,42 +251,46 @@ export async function invokeCapabilityThroughProxy(
 
   await engine.evaluate(capRules, evaluatorCtx);
 
-  const governing = capRules.filter((r) => isGoverningRule(r, cap.name));
-  if (governing.length === 0) {
+  // CANONICAL PRECEDENCE (master-plan §5.3): the policy-engine helper composes
+  // ALL enabled capability-intent rules in the one true order — hard deny (incl.
+  // malformed config / failed hard constraint) > approval_required > allow >
+  // default-deny. This is the single source of truth: an applicable
+  // require-approval can NEVER be shadowed by a matching allow, and a hard deny
+  // can never be softened into an approval.
+  //
+  // We pass the FULL enabled capability-intent set (not a pre-filtered
+  // "governing" subset): a MALFORMED rule config (e.g. a misspelled
+  // `capabilities` key or an unsupported glob) makes a raw governing-match filter
+  // return false, which would silently DROP the broken gate and fail OPEN if a
+  // sibling allow matched. The composer instead parses every rule and hard-denies
+  // on ANY malformation (fail closed), treats well-formed non-governing rules as
+  // inert, and applies the effective default-deny when no governing allow passes
+  // (covers the previous "no policy authorizes this capability" 403).
+  const decision = composeCapabilityIntentDecision(
+    capRules.map((r) => ({
+      id: r.id,
+      type: r.type as string,
+      enabled: r.enabled,
+      config: r.config,
+    })),
+    evaluatorCtx,
+  );
+
+  if (decision.effect === "hard_deny") {
     return recordAndJson(store, {
       tenantId,
       agentId,
       capabilityId: cap.id,
       decision: "deny",
       status: 403,
-      payload: { ok: false, error: "no policy authorizes this capability" } satisfies ApiResponse,
+      payload: {
+        ok: false,
+        error: decision.reason,
+      } satisfies ApiResponse,
     });
   }
 
-  let sawApproval = false;
-  let matchedAllowPassed = false;
-  let sawDeny = false;
-  let denyReason: string | undefined;
-  for (const rule of governing) {
-    const result = evaluateCapabilityIntent(
-      { id: rule.id, type: rule.type as string, enabled: rule.enabled, config: rule.config },
-      evaluatorCtx,
-    );
-    if (result.requiresManualApproval) {
-      sawApproval = true;
-      continue;
-    }
-    if (!result.passed) {
-      sawDeny = true;
-      denyReason = result.reason ?? "denied by policy";
-      continue;
-    }
-    if (isMatchingAllowRule(rule, cap.name)) matchedAllowPassed = true;
-  }
-
-  if (!sawDeny && matchedAllowPassed) {
-    // proceed to proxy delegation.
-  } else if (!sawDeny && sawApproval) {
+  if (decision.effect === "approval_required") {
     let approvalId: string | null = null;
     try {
       approvalId = await store.recordInvocation({
@@ -331,19 +313,9 @@ export async function invokeCapabilityThroughProxy(
       });
     }
     return jsonResponse({ ok: true, data: { approvalId, status: "pending" } }, 202);
-  } else {
-    return recordAndJson(store, {
-      tenantId,
-      agentId,
-      capabilityId: cap.id,
-      decision: "deny",
-      status: 403,
-      payload: {
-        ok: false,
-        error: denyReason ?? "capability invoke denied by policy",
-      } satisfies ApiResponse,
-    });
   }
+
+  // decision.effect === "allow": proceed to proxy delegation.
 
   const proxyEnv = readProxyEnv();
   if (!proxyEnv) {

--- a/packages/policy-engine/src/__tests__/capability-intent.test.ts
+++ b/packages/policy-engine/src/__tests__/capability-intent.test.ts
@@ -18,6 +18,7 @@
 
 import { afterEach, describe, expect, it } from "bun:test";
 import type { ContributedPolicyRule, PolicyRule, SignRequest } from "@stwd/shared";
+import { UNPRINTABLE_THROWN_VALUE } from "@stwd/shared";
 import {
   CAPABILITY_INTENT_RULE_TYPE,
   capabilityIntentContribution,
@@ -1093,5 +1094,126 @@ describe("capability-intent — malformed-input precedence is SCOPED to governin
     expect(composeCapabilityIntentDecision([malformedElsewhere, validAllow], ctx).effect).toBe(
       "allow",
     );
+  });
+});
+
+describe("capability-intent — composer catch is fail-closed against HOSTILE thrown values (P0)", () => {
+  // ROUND-2 P0: the per-rule catch used to build its deny reason with
+  //   `err instanceof Error ? err.message : String(err)`
+  // A thrown value whose toString/valueOf/Symbol.toPrimitive (or a Proxy
+  // `.message` getter) THROWS made that catch block ITSELF throw, unwinding past
+  // the fail-closed `return { effect: "hard_deny" }` and escaping the composer as
+  // a raw exception (=> HTTP 500 at the invoke boundary). These tests assert the
+  // composer NEVER throws and ALWAYS hard-denies for a governing rule whose
+  // evaluation throws an unprintable value.
+  const ctx = makeContext({ capability: cap() });
+
+  // A config that is a GOVERNING match for `github.pr.comment` (valid selector,
+  // so it is not scoped-elsewhere / inert) but whose `constraints` access throws
+  // `thrown` during parseConfig — reproducing an evaluator throw on the governing
+  // rule. `capabilities` and `effect` are plain so recoverSelectorMatch succeeds.
+  function governingConfigThatThrows(thrown: unknown): ContributedPolicyRule {
+    const config: Record<string, unknown> = {
+      capabilities: ["github.pr.comment"],
+      effect: "allow",
+    };
+    Object.defineProperty(config, "constraints", {
+      enumerable: true,
+      configurable: true,
+      get() {
+        throw thrown;
+      },
+    });
+    return { id: "hostile-throw", type: CAPABILITY_INTENT_RULE_TYPE, enabled: true, config };
+  }
+
+  it("thrown value with a throwing toString => hard_deny, NO exception (the exact probe)", () => {
+    const hostile = {
+      toString() {
+        throw new Error("secondary stringify failure");
+      },
+    };
+    let d: ReturnType<typeof composeCapabilityIntentDecision> | undefined;
+    expect(() => {
+      d = composeCapabilityIntentDecision([governingConfigThatThrows(hostile)], ctx);
+    }).not.toThrow();
+    expect(d?.effect).toBe("hard_deny");
+  });
+
+  it("thrown value with throwing toString AND valueOf AND Symbol.toPrimitive => hard_deny, NO exception", () => {
+    const hostile = {
+      toString() {
+        throw new Error("toString throws");
+      },
+      valueOf() {
+        throw new Error("valueOf throws");
+      },
+      [Symbol.toPrimitive]() {
+        throw new Error("toPrimitive throws");
+      },
+    };
+    let d: ReturnType<typeof composeCapabilityIntentDecision> | undefined;
+    expect(() => {
+      d = composeCapabilityIntentDecision([governingConfigThatThrows(hostile)], ctx);
+    }).not.toThrow();
+    expect(d?.effect).toBe("hard_deny");
+    // Reason falls back to the static unprintable message (never leaks / throws).
+    expect(d?.reason).toContain(UNPRINTABLE_THROWN_VALUE);
+  });
+
+  it("thrown Proxy(Error) whose `.message` getter throws => hard_deny, NO exception", () => {
+    // instanceof Error is TRUE for this Proxy, so the old `.message` read would
+    // have invoked the throwing get-trap and escaped.
+    const hostile = new Proxy(new Error("real"), {
+      get(_t, prop) {
+        if (prop === "message") throw new Error("hostile message getter");
+        // Also make string coercion hostile so we exercise the full fallback.
+        if (prop === "toString" || prop === Symbol.toPrimitive || prop === "valueOf") {
+          return () => {
+            throw new Error("hostile coercion");
+          };
+        }
+        return undefined;
+      },
+    });
+    let d: ReturnType<typeof composeCapabilityIntentDecision> | undefined;
+    expect(() => {
+      d = composeCapabilityIntentDecision([governingConfigThatThrows(hostile)], ctx);
+    }).not.toThrow();
+    expect(d?.effect).toBe("hard_deny");
+    expect(d?.reason).toContain(UNPRINTABLE_THROWN_VALUE);
+  });
+
+  it("a hostile throw on a NON-governing (scoped-elsewhere) rule stays inert; sibling allow still wins", () => {
+    // The hostile rule's selector is well-formed and scoped to gitlab.* (NOT this
+    // capability), so the throw is on an inert rule and must not deny.
+    const hostile = {
+      toString() {
+        throw new Error("boom");
+      },
+    };
+    const elsewhereConfig: Record<string, unknown> = {
+      capabilities: ["gitlab.*"],
+      effect: "deny",
+    };
+    Object.defineProperty(elsewhereConfig, "constraints", {
+      enumerable: true,
+      configurable: true,
+      get() {
+        throw hostile;
+      },
+    });
+    const hostileElsewhere: ContributedPolicyRule = {
+      id: "hostile-elsewhere",
+      type: CAPABILITY_INTENT_RULE_TYPE,
+      enabled: true,
+      config: elsewhereConfig,
+    };
+    const validAllow = rule({ capabilities: ["github.*"], effect: "allow" }, "allow-rule");
+    let d: ReturnType<typeof composeCapabilityIntentDecision> | undefined;
+    expect(() => {
+      d = composeCapabilityIntentDecision([hostileElsewhere, validAllow], ctx);
+    }).not.toThrow();
+    expect(d?.effect).toBe("allow");
   });
 });

--- a/packages/policy-engine/src/__tests__/capability-intent.test.ts
+++ b/packages/policy-engine/src/__tests__/capability-intent.test.ts
@@ -880,4 +880,218 @@ describe("capability-intent — composeCapabilityIntentDecision (disabled rules 
     );
     expect(d.effect).toBe("hard_deny");
   });
+
+  it("a rule with enabled:undefined is inert (falsy-enabled, matches the generic engine)", () => {
+    // NIT alignment: the composer skips ANY falsy `enabled`, not only
+    // `enabled === false`. An undefined-enabled deny must not block a valid allow.
+    const d = composeCapabilityIntentDecision(
+      [
+        {
+          id: "undef-enabled-deny",
+          type: CAPABILITY_INTENT_RULE_TYPE,
+          enabled: undefined,
+          config: { capabilities: ["github.pr.comment"], effect: "deny" },
+        } as unknown as ContributedPolicyRule,
+        rule({ capabilities: ["github.*"], effect: "allow" }, "allow-rule"),
+      ],
+      ctx,
+    );
+    expect(d.effect).toBe("allow");
+  });
+});
+
+describe("capability-intent — malformed runtime input never throws (FINDING 1)", () => {
+  // `rule.config` is opaque jsonb: at runtime it can be null / a scalar / an
+  // array (untyped storage, bad migration, hand-edited row). The composer must
+  // turn ANY such malformation into a fail-closed decision, NEVER a thrown
+  // TypeError (which surfaces as an HTTP 500 instead of a deny).
+
+  const ctx = makeContext({ capability: cap() });
+
+  // Build a rule whose config bypasses the compile-time `Record<string,unknown>`
+  // type so we can exercise the true runtime shapes (null / scalar / array).
+  function rawRule(config: unknown, id: string): ContributedPolicyRule {
+    return {
+      id,
+      type: CAPABILITY_INTENT_RULE_TYPE,
+      enabled: true,
+      config,
+    } as ContributedPolicyRule;
+  }
+
+  it("evaluateCapabilityIntent: config null => deny (no throw)", () => {
+    const r = evaluateCapabilityIntent(rawRule(null, "null-cfg"), ctx);
+    expect(r.passed).toBe(false);
+    expect(r.reason).toContain("config must be a non-null object");
+  });
+
+  it("composeCapabilityIntentDecision: config null => hard_deny (no throw), even beside a passing allow", () => {
+    // The null-config rule has an unrecoverable selector => governing-ambiguous
+    // => hard_deny. Critically: it must NOT throw a TypeError.
+    let d: ReturnType<typeof composeCapabilityIntentDecision> | undefined;
+    expect(() => {
+      d = composeCapabilityIntentDecision(
+        [
+          rule({ capabilities: ["github.*"], effect: "allow" }, "allow-rule"),
+          rawRule(null, "null-cfg"),
+        ],
+        ctx,
+      );
+    }).not.toThrow();
+    expect(d?.effect).toBe("hard_deny");
+  });
+
+  for (const [label, badConfig] of [
+    ["string", "not-an-object"],
+    ["number", 42],
+    ["boolean", true],
+    ["array", ["github.*"]],
+  ] as const) {
+    it(`composeCapabilityIntentDecision: config ${label} => hard_deny (no throw)`, () => {
+      let d: ReturnType<typeof composeCapabilityIntentDecision> | undefined;
+      expect(() => {
+        d = composeCapabilityIntentDecision([rawRule(badConfig, `bad-${label}`)], ctx);
+      }).not.toThrow();
+      expect(d?.effect).toBe("hard_deny");
+    });
+  }
+
+  it("composeCapabilityIntentDecision: an evaluator that THROWS => hard_deny (never approval, never 500)", () => {
+    // Inject a throw at the evaluation seam. `constraints.argMatches` is applied
+    // during evaluation; we make Object.entries hit a hostile getter for THIS
+    // rule's constraints object, proving the composer's try/catch converts a
+    // thrown evaluator error into a hard_deny.
+    const hostile: Record<string, unknown> = {};
+    Object.defineProperty(hostile, "boom", {
+      enumerable: true,
+      get() {
+        throw new Error("injected evaluator failure");
+      },
+    });
+    // A well-formed, GOVERNING allow rule whose argMatches constraint iteration
+    // hits the hostile getter and throws inside evaluateConstraints.
+    const throwingRule = rule(
+      { capabilities: ["github.*"], effect: "allow", constraints: { argMatches: hostile } },
+      "throwing-rule",
+    );
+    let d: ReturnType<typeof composeCapabilityIntentDecision> | undefined;
+    expect(() => {
+      d = composeCapabilityIntentDecision([throwingRule], ctx);
+    }).not.toThrow();
+    expect(d?.effect).toBe("hard_deny");
+    expect(d?.reason).toContain("evaluator error");
+  });
+});
+
+describe("capability-intent — malformed-input precedence is SCOPED to governing rules (FINDING 2)", () => {
+  // master-plan §5.3: malformed-input precedence applies to GOVERNING rules. A
+  // malformed rule provably scoped to a DIFFERENT capability must not brick an
+  // unrelated invoke; a malformed rule whose SELECTOR is unrecoverable fails
+  // closed (its scope cannot be determined).
+
+  const ctx = makeContext({ capability: cap() }); // requests github.pr.comment
+
+  function rawRule(config: unknown, id: string): ContributedPolicyRule {
+    return {
+      id,
+      type: CAPABILITY_INTENT_RULE_TYPE,
+      enabled: true,
+      config,
+    } as ContributedPolicyRule;
+  }
+
+  it("malformed rule SCOPED ELSEWHERE (valid selector, other capability) + valid allow => ALLOW (inert, not bricked)", () => {
+    // Selector `gitlab.*` is well-formed and provably does NOT govern
+    // github.pr.comment, so the malformed remainder (bogus key) is irrelevant.
+    const d = composeCapabilityIntentDecision(
+      [
+        rawRule(
+          { capabilities: ["gitlab.*"], effect: "allow", bogus: true },
+          "malformed-elsewhere",
+        ),
+        rule({ capabilities: ["github.*"], effect: "allow" }, "allow-rule"),
+      ],
+      ctx,
+    );
+    expect(d.effect).toBe("allow");
+  });
+
+  it("malformed rule scoped elsewhere with an unknown-constraint typo + valid allow => ALLOW (inert)", () => {
+    const d = composeCapabilityIntentDecision(
+      [
+        rawRule(
+          { capabilities: ["gitlab.*"], effect: "allow", constraints: { maxCallPerHour: 2 } },
+          "malformed-elsewhere-2",
+        ),
+        rule({ capabilities: ["github.*"], effect: "allow" }, "allow-rule"),
+      ],
+      ctx,
+    );
+    expect(d.effect).toBe("allow");
+  });
+
+  it("malformed rule with UNRECOVERABLE selector (misspelled capabilities key) + valid allow for another capability => HARD_DENY (fail closed on ambiguous scope)", () => {
+    // The selector cannot be recovered (`capabilities` is missing), so we cannot
+    // prove this rule is non-governing. Fail closed.
+    const d = composeCapabilityIntentDecision(
+      [
+        rawRule({ capabilties: ["gitlab.*"], effect: "deny" }, "unrecoverable-selector"),
+        rule({ capabilities: ["github.*"], effect: "allow" }, "allow-rule"),
+      ],
+      ctx,
+    );
+    expect(d.effect).toBe("hard_deny");
+  });
+
+  it("malformed rule with null config (unrecoverable selector) + valid allow => HARD_DENY (fail closed)", () => {
+    const d = composeCapabilityIntentDecision(
+      [
+        rawRule(null, "null-selector"),
+        rule({ capabilities: ["github.*"], effect: "allow" }, "allow-rule"),
+      ],
+      ctx,
+    );
+    expect(d.effect).toBe("hard_deny");
+  });
+
+  it("malformed rule with an ILLEGAL glob selector (ambiguous scope) + valid allow => HARD_DENY (fail closed)", () => {
+    // `git*hub.*` is an illegal glob: patternMatches would treat it as an exact
+    // literal that can never match, so we cannot trust it to be non-governing.
+    const d = composeCapabilityIntentDecision(
+      [
+        rawRule({ capabilities: ["git*hub.*"], effect: "deny", bogus: true }, "illegal-glob"),
+        rule({ capabilities: ["github.*"], effect: "allow" }, "allow-rule"),
+      ],
+      ctx,
+    );
+    expect(d.effect).toBe("hard_deny");
+  });
+
+  it("malformed GOVERNING rule (valid selector matches THIS capability, malformed rest) => HARD_DENY (existing semantics preserved)", () => {
+    const d = composeCapabilityIntentDecision(
+      [
+        rawRule(
+          { capabilities: ["github.*"], effect: "allow", bogus: true },
+          "malformed-governing",
+        ),
+        rule({ capabilities: ["github.pr.comment"], effect: "allow" }, "allow-rule"),
+      ],
+      ctx,
+    );
+    expect(d.effect).toBe("hard_deny");
+  });
+
+  it("scoping is order-independent: allow-first vs malformed-elsewhere-first both => ALLOW", () => {
+    const malformedElsewhere = rawRule(
+      { capabilities: ["gitlab.*"], effect: "deny", bogus: true },
+      "malformed-elsewhere",
+    );
+    const validAllow = rule({ capabilities: ["github.*"], effect: "allow" }, "allow-rule");
+    expect(composeCapabilityIntentDecision([validAllow, malformedElsewhere], ctx).effect).toBe(
+      "allow",
+    );
+    expect(composeCapabilityIntentDecision([malformedElsewhere, validAllow], ctx).effect).toBe(
+      "allow",
+    );
+  });
 });

--- a/packages/policy-engine/src/__tests__/capability-intent.test.ts
+++ b/packages/policy-engine/src/__tests__/capability-intent.test.ts
@@ -21,6 +21,7 @@ import type { ContributedPolicyRule, PolicyRule, SignRequest } from "@stwd/share
 import {
   CAPABILITY_INTENT_RULE_TYPE,
   capabilityIntentContribution,
+  composeCapabilityIntentDecision,
   evaluateCapabilityIntent,
 } from "../capability-intent";
 import { PolicyEngine } from "../engine";
@@ -586,5 +587,297 @@ describe("capability-intent — multi-rule composition (all-must-pass)", () => {
     expect(other.passed).toBe(true);
     expect(allow.passed).toBe(true);
     expect(other.passed && allow.passed).toBe(true);
+  });
+});
+
+describe("capability-intent — composeCapabilityIntentDecision (canonical precedence)", () => {
+  // The canonical composition (master-plan §5.3 / PR2 spec §6.3):
+  //   1. malformed/unknown rule config or unavailable input => hard_deny
+  //   2. any matching hard deny (deny effect OR failed hard constraint) => hard_deny
+  //   3. else any matching require-approval => approval_required
+  //   4. else any matching passing allow => allow
+  //   5. else (no governing passing allow) => hard_deny
+  // These tests are the SINGLE SOURCE OF TRUTH for capability-intent precedence
+  // and directly guard the "allow-over-approval" regression.
+
+  const ctx = makeContext({ capability: cap() });
+
+  it("REGRESSION: approval_required is NOT shadowed by a matching passing allow", () => {
+    // This is the exact bug: allow + require-approval on the SAME capability.
+    // The old invoke-layer logic let the passing allow short-circuit to ALLOW.
+    const d = composeCapabilityIntentDecision(
+      [
+        rule({ capabilities: ["github.*"], effect: "allow" }, "allow-rule"),
+        rule({ capabilities: ["github.pr.comment"], effect: "require-approval" }, "approval-rule"),
+      ],
+      ctx,
+    );
+    expect(d.effect).toBe("approval_required");
+  });
+
+  it("REGRESSION holds regardless of rule order (approval listed first)", () => {
+    const d = composeCapabilityIntentDecision(
+      [
+        rule({ capabilities: ["github.pr.comment"], effect: "require-approval" }, "approval-rule"),
+        rule({ capabilities: ["github.*"], effect: "allow" }, "allow-rule"),
+      ],
+      ctx,
+    );
+    expect(d.effect).toBe("approval_required");
+  });
+
+  it("deny + allow => hard_deny (deny wins over allow)", () => {
+    const d = composeCapabilityIntentDecision(
+      [
+        rule({ capabilities: ["github.*"], effect: "allow" }, "allow-rule"),
+        rule({ capabilities: ["github.pr.comment"], effect: "deny" }, "deny-rule"),
+      ],
+      ctx,
+    );
+    expect(d.effect).toBe("hard_deny");
+  });
+
+  it("deny + approval => hard_deny (deny wins over approval, never softened)", () => {
+    const d = composeCapabilityIntentDecision(
+      [
+        rule({ capabilities: ["github.pr.comment"], effect: "require-approval" }, "approval-rule"),
+        rule({ capabilities: ["github.pr.comment"], effect: "deny" }, "deny-rule"),
+      ],
+      ctx,
+    );
+    expect(d.effect).toBe("hard_deny");
+  });
+
+  it("deny + approval + allow => hard_deny (deny is absolute)", () => {
+    const d = composeCapabilityIntentDecision(
+      [
+        rule({ capabilities: ["github.*"], effect: "allow" }, "allow-rule"),
+        rule({ capabilities: ["github.pr.comment"], effect: "require-approval" }, "approval-rule"),
+        rule({ capabilities: ["github.pr.comment"], effect: "deny" }, "deny-rule"),
+      ],
+      ctx,
+    );
+    expect(d.effect).toBe("hard_deny");
+  });
+
+  it("approval + allow => approval_required", () => {
+    const d = composeCapabilityIntentDecision(
+      [
+        rule({ capabilities: ["github.pr.comment"], effect: "require-approval" }, "approval-rule"),
+        rule({ capabilities: ["github.*"], effect: "allow" }, "allow-rule"),
+      ],
+      ctx,
+    );
+    expect(d.effect).toBe("approval_required");
+  });
+
+  it("multiple allows => allow", () => {
+    const d = composeCapabilityIntentDecision(
+      [
+        rule({ capabilities: ["github.*"], effect: "allow" }, "allow-1"),
+        rule({ capabilities: ["github.pr.comment"], effect: "allow" }, "allow-2"),
+      ],
+      ctx,
+    );
+    expect(d.effect).toBe("allow");
+  });
+
+  it("single matching allow => allow", () => {
+    const d = composeCapabilityIntentDecision(
+      [rule({ capabilities: ["github.*"], effect: "allow" }, "allow-rule")],
+      ctx,
+    );
+    expect(d.effect).toBe("allow");
+  });
+
+  it("malformed rule config present => hard_deny (even alongside a passing allow)", () => {
+    const d = composeCapabilityIntentDecision(
+      [
+        rule({ capabilities: ["github.*"], effect: "allow" }, "allow-rule"),
+        // unknown top-level key fails closed in parseConfig
+        rule({ capabilities: ["github.*"], effect: "allow", bogus: true }, "malformed-rule"),
+      ],
+      ctx,
+    );
+    expect(d.effect).toBe("hard_deny");
+  });
+
+  it("malformed rule config => hard_deny, never softened into approval", () => {
+    const d = composeCapabilityIntentDecision(
+      [
+        rule({ capabilities: ["github.pr.comment"], effect: "require-approval" }, "approval-rule"),
+        rule({ capabilities: ["github.*"], effect: "allow", bogus: true }, "malformed-rule"),
+      ],
+      ctx,
+    );
+    expect(d.effect).toBe("hard_deny");
+  });
+
+  it("failed hard constraint on an allow => hard_deny (counts as deny, not approval)", () => {
+    // allow rule whose maxCallsPerHour is exceeded => the allow FAILS a hard
+    // constraint. That is a hard deny and must win over a co-present approval.
+    const overCtx = makeContext({ capability: cap(), capabilityInvokeCount1h: 5 });
+    const d = composeCapabilityIntentDecision(
+      [
+        rule(
+          { capabilities: ["github.*"], effect: "allow", constraints: { maxCallsPerHour: 2 } },
+          "capped-allow",
+        ),
+        rule({ capabilities: ["github.pr.comment"], effect: "require-approval" }, "approval-rule"),
+      ],
+      overCtx,
+    );
+    expect(d.effect).toBe("hard_deny");
+  });
+
+  it("no matching rule (all non-governing) => hard_deny (effective default-deny)", () => {
+    const d = composeCapabilityIntentDecision(
+      [
+        rule({ capabilities: ["gitlab.*"], effect: "allow" }, "other-allow"),
+        rule({ capabilities: ["bitbucket.*"], effect: "deny" }, "other-deny"),
+      ],
+      ctx,
+    );
+    expect(d.effect).toBe("hard_deny");
+  });
+
+  it("empty rule set => hard_deny (no governing allow)", () => {
+    const d = composeCapabilityIntentDecision([], ctx);
+    expect(d.effect).toBe("hard_deny");
+  });
+
+  it("no ctx.capability => hard_deny (fail closed, not a capability invoke)", () => {
+    const d = composeCapabilityIntentDecision(
+      [rule({ capabilities: ["github.*"], effect: "allow" }, "allow-rule")],
+      makeContext(),
+    );
+    expect(d.effect).toBe("hard_deny");
+  });
+
+  it("precedence is stable under 100 shuffles of a deny+approval+allow set", () => {
+    const base = [
+      rule({ capabilities: ["github.*"], effect: "allow" }, "allow-rule"),
+      rule({ capabilities: ["github.pr.comment"], effect: "require-approval" }, "approval-rule"),
+      rule({ capabilities: ["github.pr.comment"], effect: "deny" }, "deny-rule"),
+    ];
+    for (let i = 0; i < 100; i++) {
+      const shuffled = [...base];
+      for (let j = shuffled.length - 1; j > 0; j--) {
+        const k = Math.floor(Math.random() * (j + 1));
+        [shuffled[j], shuffled[k]] = [shuffled[k], shuffled[j]];
+      }
+      expect(composeCapabilityIntentDecision(shuffled, ctx).effect).toBe("hard_deny");
+    }
+  });
+
+  it("approval+allow precedence is stable under 100 shuffles (approval wins)", () => {
+    const base = [
+      rule({ capabilities: ["github.*"], effect: "allow" }, "allow-1"),
+      rule({ capabilities: ["github.pr.comment"], effect: "allow" }, "allow-2"),
+      rule({ capabilities: ["github.pr.comment"], effect: "require-approval" }, "approval-rule"),
+    ];
+    for (let i = 0; i < 100; i++) {
+      const shuffled = [...base];
+      for (let j = shuffled.length - 1; j > 0; j--) {
+        const k = Math.floor(Math.random() * (j + 1));
+        [shuffled[j], shuffled[k]] = [shuffled[k], shuffled[j]];
+      }
+      expect(composeCapabilityIntentDecision(shuffled, ctx).effect).toBe("approval_required");
+    }
+  });
+});
+
+describe("capability-intent — composeCapabilityIntentDecision (malformed rule cannot be dropped)", () => {
+  const ctx = makeContext({ capability: cap() });
+
+  it("a malformed rule with a misspelled `capabilities` key hard-denies even alongside a matching allow", () => {
+    // The rule's `capabilities` is misspelled, so a naive governing-match filter
+    // (Array.isArray(cfg.capabilities)) would treat it as non-governing and DROP
+    // it, failing open. The composer parses every rule first and hard-denies.
+    const d = composeCapabilityIntentDecision(
+      [
+        rule({ capabilities: ["github.*"], effect: "allow" }, "allow-rule"),
+        // @ts-expect-error intentionally malformed config for the fail-closed test
+        {
+          id: "typo",
+          type: CAPABILITY_INTENT_RULE_TYPE,
+          enabled: true,
+          config: { capabilties: ["github.*"], effect: "deny" },
+        },
+      ],
+      ctx,
+    );
+    expect(d.effect).toBe("hard_deny");
+  });
+
+  it("parseConfig runs BEFORE capabilityMatches, so a malformed non-governing-looking rule still hard-denies", () => {
+    const d = composeCapabilityIntentDecision(
+      [
+        // unsupported glob makes parseConfig fail (badPattern) even though it
+        // "looks" like it governs github.* — must hard-deny, not be treated inert.
+        rule({ capabilities: ["git*hub.pr"], effect: "deny" }, "bad-glob"),
+        rule({ capabilities: ["github.*"], effect: "allow" }, "allow-rule"),
+      ],
+      ctx,
+    );
+    expect(d.effect).toBe("hard_deny");
+  });
+});
+
+describe("capability-intent — composeCapabilityIntentDecision (disabled rules are inert)", () => {
+  const ctx = makeContext({ capability: cap() });
+
+  function disabled(config: Record<string, unknown>, id: string): ContributedPolicyRule {
+    return { id, type: CAPABILITY_INTENT_RULE_TYPE, enabled: false, config };
+  }
+
+  it("a DISABLED deny rule does NOT block a matching enabled allow", () => {
+    const d = composeCapabilityIntentDecision(
+      [
+        disabled({ capabilities: ["github.pr.comment"], effect: "deny" }, "disabled-deny"),
+        rule({ capabilities: ["github.*"], effect: "allow" }, "allow-rule"),
+      ],
+      ctx,
+    );
+    expect(d.effect).toBe("allow");
+  });
+
+  it("a DISABLED require-approval rule does NOT queue approval over an enabled allow", () => {
+    const d = composeCapabilityIntentDecision(
+      [
+        disabled(
+          { capabilities: ["github.pr.comment"], effect: "require-approval" },
+          "disabled-approval",
+        ),
+        rule({ capabilities: ["github.*"], effect: "allow" }, "allow-rule"),
+      ],
+      ctx,
+    );
+    expect(d.effect).toBe("allow");
+  });
+
+  it("a DISABLED malformed rule does NOT fail the composition closed", () => {
+    const d = composeCapabilityIntentDecision(
+      [
+        // @ts-expect-error intentionally malformed but DISABLED => must be inert
+        {
+          id: "disabled-bad",
+          type: CAPABILITY_INTENT_RULE_TYPE,
+          enabled: false,
+          config: { capabilties: ["github.*"], effect: "deny" },
+        },
+        rule({ capabilities: ["github.*"], effect: "allow" }, "allow-rule"),
+      ],
+      ctx,
+    );
+    expect(d.effect).toBe("allow");
+  });
+
+  it("only DISABLED rules present => default-deny (no enabled governing allow)", () => {
+    const d = composeCapabilityIntentDecision(
+      [disabled({ capabilities: ["github.*"], effect: "allow" }, "disabled-allow")],
+      ctx,
+    );
+    expect(d.effect).toBe("hard_deny");
   });
 });

--- a/packages/policy-engine/src/__tests__/plugin-policy-rules.test.ts
+++ b/packages/policy-engine/src/__tests__/plugin-policy-rules.test.ts
@@ -16,6 +16,7 @@
 
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import type { ContributedPolicyResult, PolicyRule, SignRequest } from "@stwd/shared";
+import { UNPRINTABLE_THROWN_VALUE } from "@stwd/shared";
 import { type EvaluatorContext, evaluatePolicy } from "../evaluators";
 import {
   CORE_POLICY_RULE_TYPES,
@@ -154,6 +155,94 @@ describe("evaluatePolicy — plugin rule fallthrough (uses the process-wide regi
     const result = await evaluatePolicy(makeRule("throwing-rule"), makeContext());
     expect(result.passed).toBe(false);
     expect(result.reason).toContain("threw");
+  });
+
+  // ROUND-2 P0: the generic engine catch used
+  //   `error instanceof Error ? error.message : String(error)`
+  // to build the deny reason. A thrown value whose toString/valueOf/
+  // Symbol.toPrimitive (or a Proxy `.message` getter) THROWS made the catch
+  // block itself throw, escaping the registry dispatch as a raw exception (500).
+  // These assert the generic dispatch NEVER throws and ALWAYS fails closed for
+  // an evaluator that throws an unprintable value.
+  it("fails CLOSED (deny), NO exception, when an evaluator throws a value with a throwing toString", async () => {
+    policyRuleRegistry.register({
+      type: "hostile-tostring-rule",
+      pluginName: "hostile",
+      evaluate: () => {
+        // intentional hostile throw: a non-Error value whose toString throws
+        const hostile = {
+          toString() {
+            throw new Error("secondary stringify failure");
+          },
+        };
+        throw hostile;
+      },
+    });
+    let result: Awaited<ReturnType<typeof evaluatePolicy>> | undefined;
+    await expect(
+      (async () => {
+        result = await evaluatePolicy(makeRule("hostile-tostring-rule"), makeContext());
+      })(),
+    ).resolves.toBeUndefined();
+    expect(result?.passed).toBe(false);
+    expect(result?.reason).toContain("threw");
+  });
+
+  it("fails CLOSED (deny), NO exception, when toString AND valueOf AND Symbol.toPrimitive all throw", async () => {
+    policyRuleRegistry.register({
+      type: "hostile-all-coercion-rule",
+      pluginName: "hostile",
+      evaluate: () => {
+        throw {
+          toString() {
+            throw new Error("toString throws");
+          },
+          valueOf() {
+            throw new Error("valueOf throws");
+          },
+          [Symbol.toPrimitive]() {
+            throw new Error("toPrimitive throws");
+          },
+        };
+      },
+    });
+    let result: Awaited<ReturnType<typeof evaluatePolicy>> | undefined;
+    await expect(
+      (async () => {
+        result = await evaluatePolicy(makeRule("hostile-all-coercion-rule"), makeContext());
+      })(),
+    ).resolves.toBeUndefined();
+    expect(result?.passed).toBe(false);
+    // Static unprintable fallback is embedded; never leaked / never threw.
+    expect(result?.reason).toContain(UNPRINTABLE_THROWN_VALUE);
+  });
+
+  it("fails CLOSED (deny), NO exception, when the evaluator throws a Proxy(Error) with a throwing `.message` getter", async () => {
+    policyRuleRegistry.register({
+      type: "hostile-proxy-error-rule",
+      pluginName: "hostile",
+      evaluate: () => {
+        throw new Proxy(new Error("real"), {
+          get(_t, prop) {
+            if (prop === "message") throw new Error("hostile message getter");
+            if (prop === "toString" || prop === Symbol.toPrimitive || prop === "valueOf") {
+              return () => {
+                throw new Error("hostile coercion");
+              };
+            }
+            return undefined;
+          },
+        });
+      },
+    });
+    let result: Awaited<ReturnType<typeof evaluatePolicy>> | undefined;
+    await expect(
+      (async () => {
+        result = await evaluatePolicy(makeRule("hostile-proxy-error-rule"), makeContext());
+      })(),
+    ).resolves.toBeUndefined();
+    expect(result?.passed).toBe(false);
+    expect(result?.reason).toContain(UNPRINTABLE_THROWN_VALUE);
   });
 
   it("pins policyId/type to the rule so a plugin can't mislabel the verdict", async () => {

--- a/packages/policy-engine/src/capability-intent.ts
+++ b/packages/policy-engine/src/capability-intent.ts
@@ -59,6 +59,7 @@ import type {
   ContributedPolicyRule,
   PolicyRuleContribution,
 } from "@stwd/shared";
+import { describeThrown } from "@stwd/shared";
 import type { EvaluatorContext } from "./evaluators";
 
 /** the contributed rule-type discriminator. */
@@ -573,11 +574,14 @@ export function composeCapabilityIntentDecision(
         scopedElsewhere = false;
       }
       if (scopedElsewhere) continue;
+      // describeThrown NEVER throws for any hostile value (throwing
+      // toString/valueOf/Symbol.toPrimitive, Proxy message getter, etc.), so
+      // building this fail-closed reason cannot itself unwind past the return.
       return {
         effect: "hard_deny",
-        reason: `capability-intent: evaluator error for capability "${name}" (${
-          err instanceof Error ? err.message : String(err)
-        })`,
+        reason: `capability-intent: evaluator error for capability "${name}" (${describeThrown(
+          err,
+        )})`,
       };
     }
 

--- a/packages/policy-engine/src/capability-intent.ts
+++ b/packages/policy-engine/src/capability-intent.ts
@@ -382,6 +382,117 @@ export function evaluateCapabilityIntent(
 }
 
 /**
+ * The composed decision over a set of `capability-intent` rules that GOVERN a
+ * single invoked capability, in the canonical precedence order.
+ *
+ * CANONICAL COMPOSITION (master-plan §5.3 / PR2 canonicalization spec §6.3):
+ *   1. malformed/unknown rule config, or an unavailable policy input => HARD DENY
+ *   2. any matching hard deny (an `effect: "deny"` match, OR an `effect: "allow"`
+ *      match that FAILS a hard constraint) => HARD DENY
+ *   3. else any matching `require-approval` => APPROVAL REQUIRED
+ *   4. else any matching passing `allow` => ALLOW
+ *   5. else (no governing rule matched/passed) => HARD DENY / no governing allow
+ *
+ * This is the single source of truth for capability-intent precedence. It FIXES
+ * the prior invoke-layer bug where a passing allow could short-circuit an
+ * applicable require-approval (allow-over-approval). A malformed config or a
+ * failed hard constraint can NEVER be softened into an approval.
+ *
+ * The caller supplies ONLY the rules that already govern the invoked capability
+ * (i.e. their `capabilities` list matches the name). Passing non-governing rules
+ * is harmless — they evaluate as "not applicable" (pass) and are ignored — but
+ * the effective default-deny (outcome 5) is defined over the GOVERNING set, so
+ * the caller must not filter out governing rules before composing.
+ */
+export type CapabilityIntentCompositionEffect = "hard_deny" | "approval_required" | "allow";
+
+export interface CapabilityIntentCompositionResult {
+  readonly effect: CapabilityIntentCompositionEffect;
+  readonly reason: string;
+}
+
+export function composeCapabilityIntentDecision(
+  rules: readonly ContributedPolicyRule[],
+  ctx: EvaluatorContext,
+): CapabilityIntentCompositionResult {
+  // Not a capability invoke at all: nothing to compose. Fail closed — the invoke
+  // layer must only call this on an actual capability invoke with ctx.capability.
+  if (!ctx.capability) {
+    return { effect: "hard_deny", reason: "capability-intent: not a capability invoke" };
+  }
+  const { name } = ctx.capability;
+
+  let approvalReason: string | undefined;
+  let allowReason: string | undefined;
+
+  for (const rule of rules) {
+    // A DISABLED rule is inert, matching `evaluatePolicy`/`PolicyEngine`
+    // semantics (`!rule.enabled` => skipped). Disabling a policy must reliably
+    // turn it off for every caller of this exported helper — a disabled
+    // deny/require-approval (or even a disabled malformed) rule must NOT block,
+    // queue, or hard-deny. We skip it BEFORE parsing so a disabled-but-malformed
+    // rule cannot fail the whole composition closed either.
+    if (rule.enabled === false) continue;
+
+    // A malformed/unknown rule config is a HARD DENY and short-circuits the whole
+    // composition — a broken gate must never be silently dropped, and must never
+    // be softened into an approval. parseConfig fails closed on any malformation.
+    const parsed = parseConfig(rule.config);
+    if ("error" in parsed) {
+      return { effect: "hard_deny", reason: parsed.error };
+    }
+
+    // Only rules that govern THIS capability contribute. A non-match is inert.
+    if (!capabilityMatches(parsed, name)) continue;
+
+    const result = evaluateCapabilityIntent(
+      { id: rule.id, type: rule.type, enabled: rule.enabled, config: rule.config },
+      ctx,
+    );
+
+    // A matching require-approval fails without passing and carries the flag.
+    if (result.requiresManualApproval === true && result.passed === false) {
+      // Remember it, but keep scanning: a later hard deny must still win.
+      if (approvalReason === undefined) {
+        approvalReason =
+          result.reason ?? `capability-intent: capability "${name}" requires manual approval`;
+      }
+      continue;
+    }
+
+    // A matching rule that did NOT pass and is NOT an approval is a HARD DENY.
+    // This covers both an `effect: "deny"` match and an `effect: "allow"` match
+    // that failed a hard constraint (arg/regex/rate). Deny wins immediately.
+    if (result.passed === false) {
+      return {
+        effect: "hard_deny",
+        reason: result.reason ?? `capability-intent: capability "${name}" denied by policy`,
+      };
+    }
+
+    // A matching passing allow. Record it, but do NOT return yet: an approval or
+    // a hard deny from another governing rule must be able to override it.
+    if (allowReason === undefined) {
+      allowReason = result.reason ?? `capability-intent: capability "${name}" allowed`;
+    }
+  }
+
+  // No hard deny was seen. Approval outranks allow.
+  if (approvalReason !== undefined) {
+    return { effect: "approval_required", reason: approvalReason };
+  }
+  if (allowReason !== undefined) {
+    return { effect: "allow", reason: allowReason };
+  }
+
+  // No governing rule matched with a passing allow => effective default-deny.
+  return {
+    effect: "hard_deny",
+    reason: `capability-intent: no policy authorizes capability "${name}"`,
+  };
+}
+
+/**
  * The `capability-intent` rule as a {@link PolicyRuleContribution}, ready for the
  * W-1a plugin to register via the plugin host with zero rework. Bound to the
  * policy engine's {@link EvaluatorContext}.

--- a/packages/policy-engine/src/capability-intent.ts
+++ b/packages/policy-engine/src/capability-intent.ts
@@ -124,6 +124,61 @@ function capabilityMatches(config: CapabilityIntentConfig, name: string): boolea
 }
 
 /**
+ * Recover ONLY the capability SELECTOR (the `capabilities` patterns) from an
+ * otherwise-malformed rule config, WITHOUT validating the rest of the config.
+ *
+ * WHY THIS EXISTS (scope isolation, master-plan §5.3 / §"malformed-input
+ * precedence applies to GOVERNING rules"):
+ *   malformed-input precedence must apply to the rules that GOVERN the requested
+ *   capability. A rule whose selector is well-formed and demonstrably scoped to a
+ *   DIFFERENT capability must not brick an unrelated invoke just because some
+ *   OTHER part of its config (effect, constraints) is malformed — it is not a
+ *   governing rule for this request, so it is inert.
+ *
+ * RECOVERABILITY CONTRACT (fail closed on ambiguous scope):
+ *   - `{ recoverable: true, matches }` when the `capabilities` selector is
+ *     unambiguously well-formed: a non-empty array of non-empty strings whose
+ *     glob usage is legal (same rule as `parseConfig`'s `badPattern` check). We
+ *     can then say for certain whether it governs THIS capability (`matches`).
+ *   - `{ recoverable: false }` when the selector itself cannot be trusted to
+ *     determine scope (missing / not an array / empty / a non-string or empty
+ *     entry / an illegal glob). We CANNOT rule out that this rule was meant to
+ *     govern the requested capability, so the caller must treat it as
+ *     potentially governing and hard-deny (never assume it is inert).
+ *
+ * This deliberately mirrors the selector-shaped checks in `parseConfig` so a
+ * selector that would be REJECTED there is also "unrecoverable" here.
+ */
+function recoverSelectorMatch(
+  rawInput: unknown,
+  name: string,
+): { recoverable: true; matches: boolean } | { recoverable: false } {
+  if (typeof rawInput !== "object" || rawInput === null || Array.isArray(rawInput)) {
+    return { recoverable: false };
+  }
+  const capabilities = (rawInput as Record<string, unknown>).capabilities;
+  if (
+    !Array.isArray(capabilities) ||
+    capabilities.length === 0 ||
+    !capabilities.every((c) => typeof c === "string" && c.length > 0)
+  ) {
+    return { recoverable: false };
+  }
+  // An illegal glob makes the selector's intended scope ambiguous (a bad pattern
+  // can never match, so treating it as "non-governing" would be exactly the
+  // silent-drop failure `parseConfig`'s badPattern check guards against). Fail
+  // closed: unrecoverable.
+  const badPattern = (capabilities as string[]).find(
+    (p) => p.includes("*") && !(p.endsWith(".*") && !p.slice(0, -2).includes("*")),
+  );
+  if (badPattern !== undefined) {
+    return { recoverable: false };
+  }
+  const matches = (capabilities as string[]).some((pattern) => patternMatches(pattern, name));
+  return { recoverable: true, matches };
+}
+
+/**
  * Validate the (opaque) rule config into a typed shape, or return an error
  * reason. FAIL CLOSED: anything malformed is rejected (the caller denies).
  */
@@ -134,7 +189,24 @@ const ALLOWED_CONSTRAINT_KEYS: ReadonlySet<string> = new Set([
   "argMatches",
 ]);
 
-function parseConfig(raw: Record<string, unknown>): CapabilityIntentConfig | { error: string } {
+function parseConfig(rawInput: unknown): CapabilityIntentConfig | { error: string } {
+  // FAIL CLOSED on a non-object config. `rule.config` is opaque jsonb and can be
+  // null / a string / a number / an array at runtime (untyped storage, bad
+  // migration, hand-edited row). `Object.keys(null)` (and friends) THROW, which
+  // — before this guard — surfaced as an unhandled TypeError => HTTP 500 instead
+  // of a decision. A 500 is worse than a deny for a money-rail gate: it is
+  // ambiguous and can be retried into a race. Treat any non-plain-object config
+  // as malformed => the caller hard-denies (never throws). Arrays are rejected
+  // too: a JSON array is not a valid rule config shape.
+  if (typeof rawInput !== "object" || rawInput === null || Array.isArray(rawInput)) {
+    return {
+      error: `capability-intent: config must be a non-null object (got ${
+        rawInput === null ? "null" : Array.isArray(rawInput) ? "array" : typeof rawInput
+      })`,
+    };
+  }
+  const raw = rawInput as Record<string, unknown>;
+
   // FAIL CLOSED on unknown top-level keys: a misspelled key (e.g. `capabilties`
   // or `effects`) must never be silently ignored, since that could drop the
   // intended gate and let an action through unconstrained.
@@ -386,17 +458,29 @@ export function evaluateCapabilityIntent(
  * single invoked capability, in the canonical precedence order.
  *
  * CANONICAL COMPOSITION (master-plan §5.3 / PR2 canonicalization spec §6.3):
- *   1. malformed/unknown rule config, or an unavailable policy input => HARD DENY
+ *   1. a malformed/unknown rule config that GOVERNS this capability, or whose
+ *      SELECTOR is unrecoverable (ambiguous scope), or an unavailable policy
+ *      input => HARD DENY
  *   2. any matching hard deny (an `effect: "deny"` match, OR an `effect: "allow"`
- *      match that FAILS a hard constraint) => HARD DENY
+ *      match that FAILS a hard constraint, OR a thrown evaluator error) => HARD
+ *      DENY
  *   3. else any matching `require-approval` => APPROVAL REQUIRED
  *   4. else any matching passing `allow` => ALLOW
  *   5. else (no governing rule matched/passed) => HARD DENY / no governing allow
  *
+ * MALFORMED-INPUT PRECEDENCE IS SCOPED TO GOVERNING RULES (master-plan §5.3).
+ * A malformed rule config does NOT automatically brick every invoke: if the
+ * rule's `capabilities` SELECTOR is well-formed and provably scoped to a
+ * DIFFERENT capability, the rule is not governing this request and stays inert
+ * even though the rest of its config is broken. Only a malformed rule that (a)
+ * governs THIS capability, or (b) has an UNRECOVERABLE selector (so its scope
+ * cannot be determined) => HARD DENY. Ambiguous scope fails closed.
+ *
  * This is the single source of truth for capability-intent precedence. It FIXES
  * the prior invoke-layer bug where a passing allow could short-circuit an
- * applicable require-approval (allow-over-approval). A malformed config or a
- * failed hard constraint can NEVER be softened into an approval.
+ * applicable require-approval (allow-over-approval). A malformed governing
+ * config, a failed hard constraint, or a thrown evaluator error can NEVER be
+ * softened into an approval, and can never surface as a 500.
  *
  * The caller supplies ONLY the rules that already govern the invoked capability
  * (i.e. their `capabilities` list matches the name). Passing non-governing rules
@@ -427,28 +511,78 @@ export function composeCapabilityIntentDecision(
 
   for (const rule of rules) {
     // A DISABLED rule is inert, matching `evaluatePolicy`/`PolicyEngine`
-    // semantics (`!rule.enabled` => skipped). Disabling a policy must reliably
-    // turn it off for every caller of this exported helper — a disabled
-    // deny/require-approval (or even a disabled malformed) rule must NOT block,
-    // queue, or hard-deny. We skip it BEFORE parsing so a disabled-but-malformed
-    // rule cannot fail the whole composition closed either.
-    if (rule.enabled === false) continue;
+    // semantics (any FALSY `enabled` => skipped, mirroring the generic engine's
+    // `!rule.enabled` check — `false`, `undefined`, `null`, `0`, `""` all mean
+    // "off"). Disabling a policy must reliably turn it off for every caller of
+    // this exported helper — a disabled deny/require-approval (or even a disabled
+    // malformed) rule must NOT block, queue, or hard-deny. We skip it BEFORE
+    // parsing so a disabled-but-malformed rule cannot fail the composition closed
+    // either.
+    if (!rule.enabled) continue;
 
-    // A malformed/unknown rule config is a HARD DENY and short-circuits the whole
-    // composition — a broken gate must never be silently dropped, and must never
-    // be softened into an approval. parseConfig fails closed on any malformation.
-    const parsed = parseConfig(rule.config);
-    if ("error" in parsed) {
-      return { effect: "hard_deny", reason: parsed.error };
+    // Evaluate this rule defensively. The whole per-rule body — parse, selector
+    // recovery, and evaluation — is wrapped so that NOTHING it does can throw out
+    // of the helper. A thrown error (a hostile jsonb getter, an evaluator bug,
+    // anything) is treated exactly like a malformed config: fail closed on the
+    // GOVERNING scope, never a 500, never an approval. `result === null` means
+    // the rule was inert (non-governing / provably scoped elsewhere) and
+    // contributes nothing.
+    let result: ContributedPolicyResult | null;
+    try {
+      // Parse the config. A malformed/unknown config CANNOT simply hard-deny
+      // every invoke: malformed-input precedence applies to GOVERNING rules only
+      // (master-plan §5.3). A rule scoped (by a well-formed selector) to a
+      // DIFFERENT capability is not governing this request and must stay inert
+      // even if the rest of its config is broken. But if the selector itself is
+      // unrecoverable, we cannot prove the rule is non-governing, so fail closed.
+      const parsed = parseConfig(rule.config);
+      if ("error" in parsed) {
+        // Separate SELECTOR recovery from full-config validation.
+        const sel = recoverSelectorMatch(rule.config, name);
+        if (sel.recoverable && !sel.matches) {
+          // Well-formed selector, provably scoped elsewhere => inert. The
+          // malformed remainder cannot affect a capability this rule doesn't
+          // govern.
+          continue;
+        }
+        // Either the selector matches THIS capability (malformed governing rule)
+        // or the selector is unrecoverable (ambiguous scope). Both HARD DENY and
+        // short-circuit — a broken governing gate must never be silently dropped
+        // and must never be softened into an approval.
+        return { effect: "hard_deny", reason: parsed.error };
+      }
+
+      // Only rules that govern THIS capability contribute. A non-match is inert.
+      if (!capabilityMatches(parsed, name)) {
+        result = null;
+      } else {
+        result = evaluateCapabilityIntent(
+          { id: rule.id, type: rule.type, enabled: rule.enabled, config: rule.config },
+          ctx,
+        );
+      }
+    } catch (err) {
+      // A throw anywhere in the per-rule body. Scope it: if the selector is
+      // recoverable and demonstrably elsewhere, the throw touched a non-governing
+      // rule and is inert. Otherwise fail closed on the governing/ambiguous rule.
+      let scopedElsewhere = false;
+      try {
+        const sel = recoverSelectorMatch(rule.config, name);
+        scopedElsewhere = sel.recoverable && !sel.matches;
+      } catch {
+        scopedElsewhere = false;
+      }
+      if (scopedElsewhere) continue;
+      return {
+        effect: "hard_deny",
+        reason: `capability-intent: evaluator error for capability "${name}" (${
+          err instanceof Error ? err.message : String(err)
+        })`,
+      };
     }
 
-    // Only rules that govern THIS capability contribute. A non-match is inert.
-    if (!capabilityMatches(parsed, name)) continue;
-
-    const result = evaluateCapabilityIntent(
-      { id: rule.id, type: rule.type, enabled: rule.enabled, config: rule.config },
-      ctx,
-    );
+    // Inert rule (non-governing / scoped elsewhere): contributes nothing.
+    if (result === null) continue;
 
     // A matching require-approval fails without passing and carries the flag.
     if (result.requiresManualApproval === true && result.passed === false) {

--- a/packages/policy-engine/src/index.ts
+++ b/packages/policy-engine/src/index.ts
@@ -1,4 +1,6 @@
 export type {
+  CapabilityIntentCompositionEffect,
+  CapabilityIntentCompositionResult,
   CapabilityIntentConfig,
   CapabilityIntentConstraints,
   CapabilityIntentEffect,
@@ -6,6 +8,7 @@ export type {
 export {
   CAPABILITY_INTENT_RULE_TYPE,
   capabilityIntentContribution,
+  composeCapabilityIntentDecision,
   evaluateCapabilityIntent,
 } from "./capability-intent";
 export type {

--- a/packages/policy-engine/src/policy-rule-registry.ts
+++ b/packages/policy-engine/src/policy-rule-registry.ts
@@ -36,6 +36,7 @@ import type {
   PolicyResult,
   PolicyRule,
 } from "@stwd/shared";
+import { describeThrown } from "@stwd/shared";
 import type { EvaluatorContext } from "./evaluators";
 import type { ManualApprovalSignal } from "./manual-approval";
 
@@ -208,13 +209,13 @@ export async function evaluateRegisteredPolicy(
         : {}),
     };
   } catch (error) {
+    // describeThrown NEVER throws for any hostile thrown value, so this
+    // fail-closed deny reason cannot itself escape as an unhandled exception.
     return {
       policyId: rule.id,
       type: rule.type as PolicyResult["type"],
       passed: false,
-      reason: `Plugin policy evaluator for "${rule.type}" threw: ${
-        error instanceof Error ? error.message : String(error)
-      }`,
+      reason: `Plugin policy evaluator for "${rule.type}" threw: ${describeThrown(error)}`,
     };
   }
 }

--- a/packages/shared/src/__tests__/safe-error.test.ts
+++ b/packages/shared/src/__tests__/safe-error.test.ts
@@ -1,0 +1,123 @@
+/**
+ * safe-error.test.ts — describeThrown MUST never throw for ANY input, and must
+ * preserve useful messages for well-behaved values. This is the unit backstop
+ * for the fail-closed catch boundaries (policy composer + generic engine + invoke
+ * path) that build their deny reason from an arbitrary thrown value.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { describeThrown, UNPRINTABLE_THROWN_VALUE } from "../safe-error.js";
+
+describe("describeThrown — well-behaved values (message preserved)", () => {
+  it("returns the message of a normal Error", () => {
+    expect(describeThrown(new Error("boom"))).toBe("boom");
+  });
+
+  it("returns a non-empty string as-is (trimmed)", () => {
+    expect(describeThrown("  plain string  ")).toBe("plain string");
+  });
+
+  it("coerces primitives via String()", () => {
+    expect(describeThrown(42)).toBe("42");
+    expect(describeThrown(true)).toBe("true");
+    expect(describeThrown(123n)).toBe("123");
+  });
+
+  it("falls back for null/undefined (no useful message)", () => {
+    // String(null) === "null" is honest and non-hostile; keep it.
+    expect(describeThrown(null)).toBe("null");
+    expect(describeThrown(undefined)).toBe("undefined");
+  });
+
+  it("uses a custom (well-behaved) toString", () => {
+    expect(
+      describeThrown({
+        toString() {
+          return "custom description";
+        },
+      }),
+    ).toBe("custom description");
+  });
+});
+
+describe("describeThrown — HOSTILE values (NEVER throws, static fallback)", () => {
+  it("does not throw when toString throws (the exact P0 probe)", () => {
+    const hostile = {
+      toString() {
+        throw new Error("secondary stringify failure");
+      },
+    };
+    let out: string | undefined;
+    expect(() => {
+      out = describeThrown(hostile);
+    }).not.toThrow();
+    expect(out).toBe(UNPRINTABLE_THROWN_VALUE);
+  });
+
+  it("does not throw when toString AND valueOf AND Symbol.toPrimitive all throw", () => {
+    const hostile = {
+      toString() {
+        throw new Error("toString");
+      },
+      valueOf() {
+        throw new Error("valueOf");
+      },
+      [Symbol.toPrimitive]() {
+        throw new Error("toPrimitive");
+      },
+    };
+    expect(describeThrown(hostile)).toBe(UNPRINTABLE_THROWN_VALUE);
+  });
+
+  it("does not throw for a Proxy(Error) whose `.message` getter throws", () => {
+    const hostile = new Proxy(new Error("real"), {
+      get(_t, prop) {
+        if (prop === "message") throw new Error("hostile message getter");
+        if (prop === "toString" || prop === Symbol.toPrimitive || prop === "valueOf") {
+          return () => {
+            throw new Error("hostile coercion");
+          };
+        }
+        return undefined;
+      },
+    });
+    let out: string | undefined;
+    expect(() => {
+      out = describeThrown(hostile);
+    }).not.toThrow();
+    expect(out).toBe(UNPRINTABLE_THROWN_VALUE);
+  });
+
+  it("prefers a SAFE message on a Proxy(Error) even if coercion is hostile", () => {
+    // message getter is safe; only string-coercion is hostile => we should still
+    // recover the useful message and never reach the fallback.
+    const partlyHostile = new Proxy(new Error("safe message"), {
+      get(target, prop) {
+        if (prop === "toString" || prop === Symbol.toPrimitive || prop === "valueOf") {
+          return () => {
+            throw new Error("hostile coercion");
+          };
+        }
+        return Reflect.get(target, prop);
+      },
+    });
+    expect(describeThrown(partlyHostile)).toBe("safe message");
+  });
+
+  it("empty / whitespace-only bare string falls back (no signal)", () => {
+    expect(describeThrown("")).toBe(UNPRINTABLE_THROWN_VALUE);
+    expect(describeThrown("   ")).toBe(UNPRINTABLE_THROWN_VALUE);
+  });
+
+  it("an Error with a whitespace-only message degrades to a safe non-throwing coercion (never throws, never empty)", () => {
+    // `.message` is whitespace => no signal there, but String(error) is still a
+    // safe, honest, non-hostile coercion (e.g. "Error"). The only hard contract
+    // is: never throw, never return an empty string.
+    let out: string | undefined;
+    expect(() => {
+      out = describeThrown(new Error("   "));
+    }).not.toThrow();
+    expect(typeof out).toBe("string");
+    expect((out as string).length).toBeGreaterThan(0);
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -9,6 +9,8 @@ export * from "./execution-contract.js";
 export * from "./execution-payload.js";
 export type { PriceOracle } from "./price-oracle.js";
 export { createPriceOracle } from "./price-oracle.js";
+// ─── Non-throwing description of an arbitrary thrown value (fail-closed catches) ───
+export { describeThrown, UNPRINTABLE_THROWN_VALUE } from "./safe-error.js";
 export * from "./security-surface.js";
 // ─── Token Registry & Price Oracle ───
 export * from "./tokens.js";

--- a/packages/shared/src/safe-error.ts
+++ b/packages/shared/src/safe-error.ts
@@ -1,0 +1,108 @@
+/**
+ * safe-error.ts — a non-throwing description of an ARBITRARY thrown value.
+ *
+ * WHY THIS EXISTS (fail-closed at catch boundaries)
+ * -------------------------------------------------
+ * A `catch (err)` boundary that fails closed (deny) is only actually fail-closed
+ * if BUILDING the deny reason cannot itself throw. The naive idiom
+ *
+ *     err instanceof Error ? err.message : String(err)
+ *
+ * is NOT safe against a hostile or nonstandard thrown value:
+ *
+ *   - `String(err)` invokes `err[Symbol.toPrimitive]` / `err.toString` /
+ *     `err.valueOf`, ANY of which can throw. A probe as small as
+ *     `throw { toString() { throw new Error("boom") } }` makes the catch block
+ *     itself throw, unwinding PAST the fail-closed return and escaping as a raw
+ *     500 — i.e. the exact opposite of fail-closed.
+ *   - `err instanceof Error` is true for a `Proxy(new Error(), handler)` whose
+ *     `get` trap throws, so even reading `err.message` after an `instanceof`
+ *     check can throw.
+ *   - `JSON.stringify(err)` walks getters and can throw / recurse / leak — never
+ *     used here.
+ *
+ * CONTRACT
+ * --------
+ * `describeThrown(value)` ALWAYS returns a string and NEVER throws, for ANY
+ * input. It returns a useful message for well-behaved Errors/strings, and a
+ * static fallback for anything whose coercion misbehaves. Every coercion step is
+ * individually guarded; the outermost guard guarantees the static fallback even
+ * if something we did not anticipate throws.
+ */
+
+/** Last-resort description when every coercion of the thrown value misbehaves. */
+export const UNPRINTABLE_THROWN_VALUE = "policy evaluator threw an unprintable value";
+
+/**
+ * Try to read a hostile-safe `.message` off a value that claims to be an Error.
+ * The property access itself can throw (Proxy get-trap / throwing getter), so it
+ * is wrapped. Returns a non-empty trimmed string, or `undefined` if the message
+ * is absent, non-string, empty, or the access threw.
+ */
+function tryErrorMessage(value: object): string | undefined {
+  try {
+    // Deliberately NOT `value instanceof Error &&` gated: `instanceof` on a
+    // Proxy can invoke a trap, and we already know `value` is an object here.
+    // Read defensively; a throwing getter lands in the catch below.
+    const msg = (value as { message?: unknown }).message;
+    if (typeof msg === "string") {
+      const trimmed = msg.trim();
+      return trimmed.length > 0 ? trimmed : undefined;
+    }
+  } catch {
+    // hostile getter / proxy trap — fall through to undefined.
+  }
+  return undefined;
+}
+
+/**
+ * Try to coerce a value to string via `String(...)`. This invokes
+ * `Symbol.toPrimitive` / `toString` / `valueOf`, any of which can throw or
+ * return a non-string. Returns a non-empty string, or `undefined` if coercion
+ * threw or produced nothing useful.
+ */
+function tryStringCoerce(value: unknown): string | undefined {
+  try {
+    const s = String(value);
+    if (typeof s === "string") {
+      const trimmed = s.trim();
+      // "[object Object]" is technically a string but carries no signal; still
+      // return it rather than the static fallback — it is at least honest about
+      // the shape and cannot itself be hostile.
+      return trimmed.length > 0 ? trimmed : undefined;
+    }
+  } catch {
+    // hostile toString/valueOf/Symbol.toPrimitive — fall through.
+  }
+  return undefined;
+}
+
+/**
+ * Describe an arbitrary thrown value as a string, NEVER throwing.
+ *
+ * Order of preference:
+ *   1. a well-behaved string `.message` (typical Error), else
+ *   2. a `String(...)` coercion (typical primitives, custom stringifiers), else
+ *   3. the static {@link UNPRINTABLE_THROWN_VALUE} fallback.
+ *
+ * The whole body is additionally wrapped so that an unanticipated throw (e.g. a
+ * `typeof` on an exotic proxy) still yields the static fallback.
+ */
+export function describeThrown(value: unknown): string {
+  try {
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      return trimmed.length > 0 ? trimmed : UNPRINTABLE_THROWN_VALUE;
+    }
+    if (value !== null && typeof value === "object") {
+      const fromMessage = tryErrorMessage(value);
+      if (fromMessage !== undefined) return fromMessage;
+    }
+    const coerced = tryStringCoerce(value);
+    if (coerced !== undefined) return coerced;
+    return UNPRINTABLE_THROWN_VALUE;
+  } catch {
+    // Absolute backstop: nothing above is allowed to escape.
+    return UNPRINTABLE_THROWN_VALUE;
+  }
+}


### PR DESCRIPTION
## Summary

Fixes a real composition bug in capability-intent policy evaluation: an **ALLOW result could be selected over an applicable APPROVAL-REQUIRED result**. When multiple capability-intent rules govern the same capability, a matching *passing allow* short-circuited the invoke path to `allow` even when a `require-approval` rule also matched — silently bypassing a human-review gate.

Identified by the PR2 canonicalization spec (§6.3) and MASTER-PLAN §5.3.

### The bug (`plugin-capabilities/src/invoke.ts`, old lines ~309–311)
```ts
if (!sawDeny && matchedAllowPassed) { /* allow */ }        // <-- allow shadows approval
else if (!sawDeny && sawApproval)   { /* approval 202 */ }
else                                { /* deny */ }
```
A passing allow won whenever `!sawDeny`, regardless of a co-present `require-approval`.

## Fix (policy-engine layer, single source of truth)

New exported helper `composeCapabilityIntentDecision(rules, ctx)` in `@stwd/policy-engine` implementing the canonical precedence:

1. malformed / unknown rule config → **hard_deny** (short-circuit)
2. any matching hard deny (deny effect **or** an allow that fails a hard constraint) → **hard_deny**
3. else any matching `require-approval` → **approval_required**
4. else any matching passing allow → **allow**
5. else (no governing passing allow) → **hard_deny** (default-deny)

A hard deny (incl. malformed config / failed constraint) can **never** be softened into an approval; an approval can **never** be shadowed by an allow.

`invoke.ts` now delegates to the helper, passing the **full enabled** capability-intent set (not a pre-filtered "governing" subset — a malformed rule that a raw governing filter drops would otherwise fail *open* alongside a sibling allow). The composer also treats `enabled === false` rules as inert, matching `evaluatePolicy`/`PolicyEngine` semantics.

## Tests

`packages/policy-engine` + `packages/plugin-capabilities`:
- **Precedence matrix:** deny+allow⇒deny, deny+approval⇒deny, approval+allow⇒approval_required, multiple allows⇒allow, malformed⇒deny, no rules⇒deny; order-independence under 100 shuffles.
- **Regression:** allow + require-approval on the same capability ⇒ approval_required (not allow), proven **end-to-end through the invoke route** (HTTP 202, not 503).
- **Malformed non-governing-looking rule is NOT dropped** ⇒ hard_deny (fail closed).
- **Disabled deny/approval/malformed rules are inert.**

**Effectiveness proven:** reverting each fix makes the corresponding regression test fail (composition + malformed-drop), then passes again on restore.

## Verification
- `policy-engine` suite: 307 pass / 0 fail
- `plugin-capabilities` invoke suite: 23 pass / 0 fail; invoke-e2e (standalone): 15 pass / 0 fail
- `api` capabilities-parity: 35 pass / 0 fail
- typecheck (policy-engine + plugin-capabilities + api): green
- biome: clean
- **codex review:** two findings across rounds (P1 malformed-rule drop, P2 disabled-rule handling) both fixed; final pass — "did not identify any discrete regressions in the modified logic."

No version bumps: the CI public-package version-bump check only covers `sdk` / `react` / `eliza-plugin`, none of which changed.

No production semantics were weakened: no existing test or behavior depended on allow-over-approval (that path was the bug).

[sol-orch]
