### PR TITLE
fix(proxy): preserve governed request query semantics during upstream forwarding

### DIFF
--- a/packages/proxy/src/__tests__/proxy-query-preservation.test.ts
+++ b/packages/proxy/src/__tests__/proxy-query-preservation.test.ts
@@ -1,0 +1,399 @@
+/**
+ * Governed-request query-preservation integration tests.
+ *
+ * The proxy handler resolves the upstream target from `c.req.path`, which Hono
+ * strips of any query string. Before the fix this meant a governed request such
+ * as `GET /github/search/issues?q=foo&page=2` was forwarded upstream as
+ * `/search/issues` with the query silently dropped — a correctness bug that
+ * breaks paginated / filtered APIs and can change request semantics.
+ *
+ * These tests drive the real `handleProxy` end-to-end (auth middleware + PGLite
+ * DB + vault, network stubbed) and assert that:
+ *   - the exact raw query string is forwarded to the upstream,
+ *   - duplicate keys keep their ordered pair semantics (no Object collapse),
+ *   - blank values, absent query, and percent-encoding are preserved verbatim,
+ *   - a query value that looks like an absolute URL stays inert data and never
+ *     rewrites the pinned scheme/host/port/path,
+ *   - the query cannot influence route matching, and
+ *   - userinfo / fragment cannot ride in through the query.
+ *
+ * Security invariant: preserving the query must not enable authority bypass or
+ * target confusion. scheme/host/port/path remain pinned to the configured
+ * upstream regardless of query contents.
+ */
+
+import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
+import { signAgentToken } from "@stwd/auth";
+import { agents, closeDb, getDb, tenants } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { SecretVault } from "@stwd/vault";
+import { Hono } from "hono";
+import { PROXY_SCOPE } from "../config";
+
+setDefaultTimeout(30000);
+
+const MASTER_PASSWORD = "proxy-query-preservation-master";
+const FINE_GRAINED_PAT = "github_pat_11QUERYCASE_examplefinegrainedtokenvalue";
+
+let authMiddleware: typeof import("../middleware/auth")["authMiddleware"];
+let handleProxy: typeof import("../handlers/proxy")["handleProxy"];
+let proxyMod: typeof import("../handlers/proxy");
+
+// Captures the outbound URL the proxy would have shipped upstream.
+let captured: { url: URL; method: string; path: string } | null = null;
+
+beforeAll(async () => {
+  process.env.STEWARD_PGLITE_MEMORY = "true";
+  process.env.STEWARD_MASTER_PASSWORD = MASTER_PASSWORD;
+  process.env.STEWARD_JWT_SECRET = "proxy-query-preservation-jwt-secret-with-enough-bytes";
+
+  const { db, client } = await createPGLiteDb("memory://");
+  setPGLiteOverride(db, async () => {
+    await client.close();
+  });
+
+  ({ authMiddleware } = await import("../middleware/auth"));
+  proxyMod = await import("../handlers/proxy");
+  ({ handleProxy } = proxyMod);
+
+  // Pin DNS to a public address so the SSRF guard passes without a real lookup.
+  proxyMod.__setResolveProxyHostForTests(async () => [{ address: "140.82.112.6", family: 4 }]);
+  // Stub the final forward so nothing hits the network; capture the target URL.
+  proxyMod.__setForwardProxyRequestForTests(async (url, method) => {
+    captured = {
+      url: new URL(url.toString()),
+      method,
+      path: `${url.pathname}${url.search}`,
+    };
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  });
+});
+
+afterAll(async () => {
+  await closeDb().catch(() => {});
+  delete process.env.STEWARD_PGLITE_MEMORY;
+  delete process.env.STEWARD_MASTER_PASSWORD;
+  delete process.env.STEWARD_JWT_SECRET;
+});
+
+function buildApp() {
+  const app = new Hono();
+  app.use("*", authMiddleware);
+  app.all("*", handleProxy);
+  return app;
+}
+
+async function ensureTenant(tenantId: string) {
+  await getDb()
+    .insert(tenants)
+    .values({ id: tenantId, name: tenantId, apiKeyHash: `hash-${tenantId}` })
+    .onConflictDoNothing();
+}
+
+async function ensureAgent(tenantId: string, agentId: string) {
+  await getDb()
+    .insert(agents)
+    .values({ id: agentId, tenantId, name: agentId, walletAddress: `0x${"1".repeat(40)}` })
+    .onConflictDoNothing();
+}
+
+/**
+ * Provision a fresh tenant/agent/secret/route and return a signed agent token.
+ * The route governs a single exact path on api.github.com for the given method.
+ */
+async function provisionRoute(
+  pathPattern: string,
+  method: string,
+  opts: { requiresApproval?: boolean } = {},
+): Promise<string> {
+  const tenantId = `tenant-q-${crypto.randomUUID()}`;
+  const agentId = `agent-q-${crypto.randomUUID()}`;
+  await ensureTenant(tenantId);
+  await ensureAgent(tenantId, agentId);
+
+  const vault = new SecretVault(MASTER_PASSWORD);
+  const secret = await vault.createSecret(tenantId, `pat-${crypto.randomUUID()}`, FINE_GRAINED_PAT);
+  await vault.createRoute(tenantId, secret.id, {
+    agentId,
+    hostPattern: "api.github.com",
+    pathPattern,
+    method,
+    injectAs: "header",
+    injectKey: "authorization",
+    injectFormat: "Bearer {value}",
+    requiresApproval: opts.requiresApproval ?? false,
+  });
+
+  return signAgentToken({ agentId, tenantId, scopes: ["agent", PROXY_SCOPE] }, "1h");
+}
+
+function proxyHeaders(token: string): Record<string, string> {
+  return {
+    authorization: `Bearer ${token}`,
+    "content-type": "application/json",
+    "idempotency-key": crypto.randomUUID(),
+  };
+}
+
+describe("proxy governed-request query preservation", () => {
+  it("forwards a single query key/value upstream", async () => {
+    captured = null;
+    const token = await provisionRoute("/repos/acme/widgets/issues", "POST");
+    const res = await buildApp().request("/github/repos/acme/widgets/issues?state=open", {
+      method: "POST",
+      headers: proxyHeaders(token),
+      body: JSON.stringify({ hi: 1 }),
+    });
+    expect(res.status).toBe(200);
+    expect(captured?.url.origin).toBe("https://api.github.com");
+    expect(captured?.url.pathname).toBe("/repos/acme/widgets/issues");
+    expect(captured?.url.search).toBe("?state=open");
+  });
+
+  it("preserves ordered duplicate keys without collapsing pairs", async () => {
+    captured = null;
+    const token = await provisionRoute("/repos/acme/widgets/issues", "POST");
+    const res = await buildApp().request(
+      "/github/repos/acme/widgets/issues?label=bug&label=urgent&label=p0",
+      {
+        method: "POST",
+        headers: proxyHeaders(token),
+        body: JSON.stringify({ hi: 1 }),
+      },
+    );
+    expect(res.status).toBe(200);
+    // Exact raw string, in order — a naive Object/fromEntries would drop dupes.
+    expect(captured?.url.search).toBe("?label=bug&label=urgent&label=p0");
+    expect(captured?.url.searchParams.getAll("label")).toEqual(["bug", "urgent", "p0"]);
+  });
+
+  it("preserves a blank query value", async () => {
+    captured = null;
+    const token = await provisionRoute("/repos/acme/widgets/issues", "POST");
+    const res = await buildApp().request("/github/repos/acme/widgets/issues?q=&page=2", {
+      method: "POST",
+      headers: proxyHeaders(token),
+      body: JSON.stringify({ hi: 1 }),
+    });
+    expect(res.status).toBe(200);
+    expect(captured?.url.search).toBe("?q=&page=2");
+  });
+
+  it("does not decode/re-encode a percent-encoded query value", async () => {
+    captured = null;
+    const token = await provisionRoute("/repos/acme/widgets/issues", "POST");
+    // %2F must stay %2F (not become a literal slash), space stays %20.
+    const res = await buildApp().request(
+      "/github/repos/acme/widgets/issues?q=a%2Fb%20c&sig=%2B%3D",
+      {
+        method: "POST",
+        headers: proxyHeaders(token),
+        body: JSON.stringify({ hi: 1 }),
+      },
+    );
+    expect(res.status).toBe(200);
+    expect(captured?.url.search).toBe("?q=a%2Fb%20c&sig=%2B%3D");
+    // The pinned path is unaffected by an encoded slash in the query.
+    expect(captured?.url.pathname).toBe("/repos/acme/widgets/issues");
+  });
+
+  it("forwards no query string when the request has none", async () => {
+    captured = null;
+    const token = await provisionRoute("/repos/acme/widgets/issues", "POST");
+    const res = await buildApp().request("/github/repos/acme/widgets/issues", {
+      method: "POST",
+      headers: proxyHeaders(token),
+      body: JSON.stringify({ hi: 1 }),
+    });
+    expect(res.status).toBe(200);
+    expect(captured?.url.search).toBe("");
+    expect(captured?.path).toBe("/repos/acme/widgets/issues");
+  });
+
+  it("keeps an absolute-URL-looking query value inert (no authority bypass)", async () => {
+    captured = null;
+    const token = await provisionRoute("/repos/acme/widgets/issues", "POST");
+    // A malicious query value that looks like a full URL to another host must
+    // remain data on the pinned upstream, never redirect scheme/host/port/path.
+    const evil = encodeURIComponent("https://evil.example.com/steal");
+    const res = await buildApp().request(`/github/repos/acme/widgets/issues?next=${evil}`, {
+      method: "POST",
+      headers: proxyHeaders(token),
+      body: JSON.stringify({ hi: 1 }),
+    });
+    expect(res.status).toBe(200);
+    expect(captured?.url.protocol).toBe("https:");
+    expect(captured?.url.host).toBe("api.github.com");
+    expect(captured?.url.hostname).toBe("api.github.com");
+    expect(captured?.url.port).toBe("");
+    expect(captured?.url.pathname).toBe("/repos/acme/widgets/issues");
+    expect(captured?.url.username).toBe("");
+    expect(captured?.url.password).toBe("");
+    expect(captured?.url.hash).toBe("");
+    expect(captured?.url.searchParams.get("next")).toBe("https://evil.example.com/steal");
+  });
+
+  it("does not let the query influence route matching", async () => {
+    captured = null;
+    // Route governs ONLY the exact path. A request that adds a query which,
+    // if folded into path matching, might match a broader/other route must
+    // still resolve against the exact configured path.
+    const token = await provisionRoute("/repos/acme/widgets/issues", "POST");
+    const res = await buildApp().request(
+      "/github/repos/acme/widgets/issues?path=/repos/acme/other",
+      {
+        method: "POST",
+        headers: proxyHeaders(token),
+        body: JSON.stringify({ hi: 1 }),
+      },
+    );
+    expect(res.status).toBe(200);
+    expect(captured?.url.pathname).toBe("/repos/acme/widgets/issues");
+    expect(captured?.url.searchParams.get("path")).toBe("/repos/acme/other");
+  });
+
+  it("rejects a query on an approval-gated route (fail closed, not silently dropped)", async () => {
+    captured = null;
+    // The approval hold/replay path cannot yet round-trip the query, so a
+    // query-bearing request on an approval route must be rejected rather than
+    // held-and-later-forwarded with the query stripped.
+    const token = await provisionRoute("/repos/acme/widgets/issues", "POST", {
+      requiresApproval: true,
+    });
+    const res = await buildApp().request("/github/repos/acme/widgets/issues?state=open", {
+      method: "POST",
+      headers: proxyHeaders(token),
+      body: JSON.stringify({ hi: 1 }),
+    });
+    expect(res.status).toBe(400);
+    // Nothing was forwarded upstream.
+    expect(captured).toBeNull();
+    const json = (await res.json()) as { ok: boolean; error: string };
+    expect(json.ok).toBe(false);
+    expect(json.error).toContain("approval");
+  });
+
+  it("still holds an approval-gated request that has no query", async () => {
+    captured = null;
+    const token = await provisionRoute("/repos/acme/widgets/issues", "POST", {
+      requiresApproval: true,
+    });
+    const res = await buildApp().request("/github/repos/acme/widgets/issues", {
+      method: "POST",
+      headers: proxyHeaders(token),
+      body: JSON.stringify({ hi: 1 }),
+    });
+    // Held for approval, not forwarded.
+    expect(res.status).toBe(202);
+    expect(captured).toBeNull();
+    const json = (await res.json()) as { status: string };
+    expect(json.status).toBe("pending_approval");
+  });
+
+  it("treats requests differing only by query as distinct for idempotency", async () => {
+    // Same tenant/agent/route/method/body + same Idempotency-Key but different
+    // query must NOT collide: the query is part of the forwarded request and
+    // therefore part of the replay identity.
+    const tenantId = `tenant-idem-${crypto.randomUUID()}`;
+    const agentId = `agent-idem-${crypto.randomUUID()}`;
+    await ensureTenant(tenantId);
+    await ensureAgent(tenantId, agentId);
+    const vault = new SecretVault(MASTER_PASSWORD);
+    const secret = await vault.createSecret(
+      tenantId,
+      `pat-${crypto.randomUUID()}`,
+      FINE_GRAINED_PAT,
+    );
+    await vault.createRoute(tenantId, secret.id, {
+      agentId,
+      hostPattern: "api.github.com",
+      pathPattern: "/repos/acme/widgets/issues",
+      method: "POST",
+      injectAs: "header",
+      injectKey: "authorization",
+      injectFormat: "Bearer {value}",
+    });
+    const token = await signAgentToken({ agentId, tenantId, scopes: ["agent", PROXY_SCOPE] }, "1h");
+    const body = JSON.stringify({ hi: 1 });
+    const headersWith = (idem: string) => ({
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+      "idempotency-key": idem,
+    });
+
+    // Two distinct operations (different query) with distinct keys both succeed —
+    // the query is faithfully forwarded and neither is mistaken for the other.
+    captured = null;
+    const first = await buildApp().request("/github/repos/acme/widgets/issues?id=1", {
+      method: "POST",
+      headers: headersWith(crypto.randomUUID()),
+      body,
+    });
+    expect(first.status).toBe(200);
+    expect(captured?.url.search).toBe("?id=1");
+
+    captured = null;
+    const second = await buildApp().request("/github/repos/acme/widgets/issues?id=2", {
+      method: "POST",
+      headers: headersWith(crypto.randomUUID()),
+      body,
+    });
+    expect(second.status).toBe(200);
+    expect(captured?.url.search).toBe("?id=2");
+
+    // Reusing ONE key for two different queries must be detected as a DIFFERENT
+    // request (409 "different"), not silently swallowed as a replay of the first.
+    const sharedKey = crypto.randomUUID();
+    const a = await buildApp().request("/github/repos/acme/widgets/issues?id=1", {
+      method: "POST",
+      headers: headersWith(sharedKey),
+      body,
+    });
+    expect(a.status).toBe(200);
+    const b = await buildApp().request("/github/repos/acme/widgets/issues?id=2", {
+      method: "POST",
+      headers: headersWith(sharedKey),
+      body,
+    });
+    expect(b.status).toBe(409);
+    const bJson = (await b.json()) as { error: string };
+    // The fix makes the fingerprint query-aware: same key + different query is a
+    // "different request" conflict, not an "already forwarded" replay hit.
+    expect(bJson.error).toContain("different");
+
+    // Same key + SAME query + SAME body => a genuine replay (409 "forwarded").
+    const replayKey = crypto.randomUUID();
+    const r1 = await buildApp().request("/github/repos/acme/widgets/issues?id=9", {
+      method: "POST",
+      headers: headersWith(replayKey),
+      body,
+    });
+    expect(r1.status).toBe(200);
+    const r2 = await buildApp().request("/github/repos/acme/widgets/issues?id=9", {
+      method: "POST",
+      headers: headersWith(replayKey),
+      body,
+    });
+    expect(r2.status).toBe(409);
+    const r2Json = (await r2.json()) as { error: string };
+    expect(r2Json.error).toContain("forwarded");
+  });
+
+  it("rejects a fragment smuggled in the request target (no fragment forwarded)", async () => {
+    captured = null;
+    const token = await provisionRoute("/repos/acme/widgets/issues", "POST");
+    // A fragment is not part of the request-target sent over the wire; even if a
+    // client encodes one, it must never appear on the outbound URL.
+    const res = await buildApp().request("/github/repos/acme/widgets/issues?a=1#frag", {
+      method: "POST",
+      headers: proxyHeaders(token),
+      body: JSON.stringify({ hi: 1 }),
+    });
+    expect(res.status).toBe(200);
+    expect(captured?.url.hash).toBe("");
+    expect(captured?.url.search).toBe("?a=1");
+  });
+});

--- a/packages/proxy/src/__tests__/query-forwarding.test.ts
+++ b/packages/proxy/src/__tests__/query-forwarding.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Unit tests for the governed query-forwarding chokepoint.
+ *
+ * These exercise `extractRawQuery` and `applyGovernedQuery` directly, covering
+ * the encoding/duplicate-key preservation contract and the fail-closed security
+ * rejections (base query on the target, userinfo, fragment, altered authority)
+ * that are awkward to reach through the full proxy integration path.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { applyGovernedQuery, extractRawQuery } from "../handlers/query-forwarding";
+
+describe("extractRawQuery", () => {
+  test("returns empty string when there is no query", () => {
+    expect(extractRawQuery("http://localhost/github/x")).toBe("");
+  });
+
+  test("normalizes a bare '?' to empty", () => {
+    expect(extractRawQuery("http://localhost/github/x?")).toBe("");
+  });
+
+  test("preserves ordered duplicate keys and strips the fragment", () => {
+    expect(extractRawQuery("http://localhost/github/x?a=1&a=2&b=3#frag")).toBe("?a=1&a=2&b=3");
+  });
+
+  test("preserves percent-encoding verbatim", () => {
+    expect(extractRawQuery("http://localhost/github/x?q=a%2Fb%20c&sig=%2B%3D")).toBe(
+      "?q=a%2Fb%20c&sig=%2B%3D",
+    );
+  });
+
+  test("fails closed to empty on an unparseable url", () => {
+    expect(extractRawQuery("::::not a url::::")).toBe("");
+  });
+});
+
+describe("applyGovernedQuery", () => {
+  const target = () => new URL("https://api.github.com/repos/acme/widgets/issues");
+
+  test("applies a simple query and pins the authority/path", () => {
+    const result = applyGovernedQuery(target(), "?state=open");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.url.protocol).toBe("https:");
+    expect(result.url.host).toBe("api.github.com");
+    expect(result.url.pathname).toBe("/repos/acme/widgets/issues");
+    expect(result.url.search).toBe("?state=open");
+  });
+
+  test("does not mutate the input target", () => {
+    const t = target();
+    applyGovernedQuery(t, "?state=open");
+    expect(t.search).toBe("");
+  });
+
+  test("preserves ordered duplicate keys without collapsing", () => {
+    const result = applyGovernedQuery(target(), "?label=bug&label=urgent&label=p0");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.url.search).toBe("?label=bug&label=urgent&label=p0");
+    expect(result.url.searchParams.getAll("label")).toEqual(["bug", "urgent", "p0"]);
+  });
+
+  test("preserves a blank value", () => {
+    const result = applyGovernedQuery(target(), "?q=&page=2");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.url.search).toBe("?q=&page=2");
+  });
+
+  test("does not decode/re-encode percent-encoded values", () => {
+    const result = applyGovernedQuery(target(), "?q=a%2Fb%20c&sig=%2B%3D");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.url.search).toBe("?q=a%2Fb%20c&sig=%2B%3D");
+    expect(result.url.pathname).toBe("/repos/acme/widgets/issues");
+  });
+
+  test("accepts a raw query string without a leading '?'", () => {
+    const result = applyGovernedQuery(target(), "a=1&a=2");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.url.search).toBe("?a=1&a=2");
+  });
+
+  test("empty query yields no search", () => {
+    const result = applyGovernedQuery(target(), "");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.url.search).toBe("");
+  });
+
+  test("a URL-looking query value stays inert data", () => {
+    const result = applyGovernedQuery(
+      target(),
+      `?next=${encodeURIComponent("https://evil.example.com/steal")}`,
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.url.host).toBe("api.github.com");
+    expect(result.url.pathname).toBe("/repos/acme/widgets/issues");
+    expect(result.url.searchParams.get("next")).toBe("https://evil.example.com/steal");
+  });
+
+  test("rejects fail-closed when the target already carries a base query", () => {
+    const withQuery = new URL("https://api.github.com/repos/acme/widgets/issues?base=1");
+    const result = applyGovernedQuery(withQuery, "?state=open");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("target-carries-base-query");
+  });
+
+  test("rejects fail-closed when the target carries userinfo", () => {
+    const withUser = new URL("https://user:pass@api.github.com/repos/acme/widgets/issues");
+    const result = applyGovernedQuery(withUser, "?state=open");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("target-carries-userinfo");
+  });
+
+  test("rejects fail-closed when the target carries a fragment", () => {
+    const withHash = new URL("https://api.github.com/repos/acme/widgets/issues#frag");
+    const result = applyGovernedQuery(withHash, "?state=open");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("target-carries-fragment");
+  });
+
+  test("does not fold a fragment in the query onto the outbound url", () => {
+    // `.search` treats "#" as literal query data, never a real fragment.
+    const result = applyGovernedQuery(target(), "?a=1%23notfrag");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.url.hash).toBe("");
+    expect(result.url.search).toBe("?a=1%23notfrag");
+  });
+});

--- a/packages/proxy/src/handlers/proxy.ts
+++ b/packages/proxy/src/handlers/proxy.ts
@@ -33,6 +33,7 @@ import {
 import { resolveTarget } from "./alias";
 import { holdProxyApprovalRequest } from "./approvals";
 import { compareRouteMatchSpecificity, matchHost, matchPath } from "./matching";
+import { applyGovernedQuery, extractRawQuery } from "./query-forwarding";
 
 // ─── Secret Vault singleton ──────────────────────────────────────────────────
 
@@ -528,6 +529,7 @@ async function claimUnsafeProxyRequest(
   agentId: string,
   target: { host: string; path: string },
   method: string,
+  rawQuery: string,
 ): Promise<ProxyReplayClaimResult> {
   const signedRequest = Boolean(requestHeader(c, "x-steward-signature"));
   if (SAFE_PROXY_METHODS.has(method.toUpperCase()) && !signedRequest) {
@@ -553,8 +555,14 @@ async function claimUnsafeProxyRequest(
     };
   }
 
+  // The query is part of the request we forward upstream, so it must be part of
+  // the replay/idempotency identity: two requests that differ only by their
+  // query (e.g. ?id=1 vs ?id=2) are distinct operations and must not collide on
+  // the same Idempotency-Key. `rawQuery` preserves exact bytes + ordering.
   const fingerprint = await sha256Hex(
-    [tenantId, agentId, method.toUpperCase(), target.host, target.path, bodyHash].join("\n"),
+    [tenantId, agentId, method.toUpperCase(), target.host, target.path, rawQuery, bodyHash].join(
+      "\n",
+    ),
   );
   const storageKey = `proxy:idempotency:${await sha256Hex([tenantId, agentId, key].join("\n"))}`;
   const claim: ProxyReplayClaim = {
@@ -577,7 +585,7 @@ async function claimUnsafeProxyRequest(
     const existing = rawExisting ? safeJsonParseString<ProxyReplayClaim>(rawExisting) : null;
     if (!existing || existing.expiresAt <= Date.now()) {
       await redis.del(storageKey);
-      return claimUnsafeProxyRequest(c, tenantId, agentId, target, method);
+      return claimUnsafeProxyRequest(c, tenantId, agentId, target, method, rawQuery);
     }
     if (existing.fingerprint !== fingerprint) {
       return {
@@ -1070,6 +1078,14 @@ export async function handleProxy(c: Context): Promise<Response> {
     );
   }
 
+  // Extract the client's raw query string once (encoding + ordered duplicate
+  // keys preserved, fragment stripped). Target resolution and route matching
+  // above intentionally used the path only, so the query never influences which
+  // route/host we select; it is only forwarded onto the pinned upstream below,
+  // and mixed into the replay/idempotency fingerprint so that two otherwise
+  // identical requests with different queries are treated as distinct.
+  const rawQuery = extractRawQuery(c.req.raw.url);
+
   // 2. Find matching secret route
   const route = await findMatchingRoute(tenantId, agentId, target.host, target.path, method);
   if (!route) {
@@ -1130,6 +1146,32 @@ export async function handleProxy(c: Context): Promise<Response> {
     return c.json({ ok: false, error: "Approved proxy route no longer matches" }, 409);
   }
   if (route.requiresApproval && !approvalReleaseId) {
+    // Fail closed on approval-gated routes that carry a query. The approval
+    // hold/replay path reconstructs the request from the stored path only and
+    // cannot yet round-trip the query, so executing it later would forward a
+    // semantically different (query-stripped) request than the one the agent
+    // submitted and the human approved. Rejecting here is safer than silently
+    // changing the approved request. (Direct, non-approval routes preserve the
+    // query via applyGovernedQuery below.)
+    if (rawQuery !== "") {
+      await recordAudit({
+        agentId,
+        tenantId,
+        targetHost: target.host,
+        targetPath: target.path,
+        method,
+        statusCode: 400,
+        latencyMs: Date.now() - startTime,
+        reason: "proxy-approval-query-unsupported",
+      });
+      return c.json(
+        {
+          ok: false,
+          error: "Query strings are not supported on approval-gated proxy routes",
+        },
+        400,
+      );
+    }
     try {
       const held = await holdProxyApprovalRequest({
         tenantId,
@@ -1352,7 +1394,7 @@ export async function handleProxy(c: Context): Promise<Response> {
 
   const replayClaim = approvalReleaseId
     ? ({ ok: true, storageKey: "", storage: "memory" } as const)
-    : await claimUnsafeProxyRequest(c, tenantId, agentId, target, method);
+    : await claimUnsafeProxyRequest(c, tenantId, agentId, target, method, rawQuery);
   if (!replayClaim.ok) {
     await releaseProxySpendReservation(agentId, tenantId, target.host, spendReservation);
     await recordAudit({
@@ -1429,7 +1471,32 @@ export async function handleProxy(c: Context): Promise<Response> {
   }
 
   // 4. Build outbound request
-  const outboundUrl = new URL(target.url);
+  //
+  // Compose the client's query string onto the pinned upstream target. Target
+  // resolution above (and route matching) intentionally used the path only, so
+  // the query cannot influence which route/host we selected. Here we forward the
+  // client's exact query bytes (encoding + ordered duplicate keys preserved)
+  // while re-validating that the query did not alter the pinned
+  // scheme/host/port/path or introduce userinfo/fragment.
+  const governedQuery = applyGovernedQuery(new URL(target.url), rawQuery);
+  if (!governedQuery.ok) {
+    credential = "";
+    await recordAudit({
+      agentId,
+      tenantId,
+      targetHost: target.host,
+      targetPath: target.path,
+      method,
+      statusCode: 400,
+      latencyMs: Date.now() - startTime,
+      reason: `query-forwarding-rejected:${governedQuery.reason}`,
+    });
+    await releaseProxySpendReservation(agentId, tenantId, target.host, spendReservation);
+    await releaseUnsafeProxyRequest(replayClaim);
+    proxySlot.release();
+    return c.json({ ok: false, error: "Invalid proxy request target" }, 400);
+  }
+  const outboundUrl = governedQuery.url;
   const outboundHeaders = new Headers();
 
   const skipHeaders = stripHopByHopHeaders(c.req.raw.headers);

--- a/packages/proxy/src/handlers/query-forwarding.ts
+++ b/packages/proxy/src/handlers/query-forwarding.ts
@@ -1,0 +1,113 @@
+/**
+ * Governed query-string forwarding.
+ *
+ * The proxy resolves the upstream target from the request *path* only (route
+ * matching must never be influenced by the query — see `applyGovernedQuery`
+ * invariants below). This module is the single, audited chokepoint that
+ * composes the client's query string onto the already-pinned upstream URL.
+ *
+ * Security invariants (all enforced or asserted here):
+ *   - The outbound scheme, host, port, and path are pinned by target
+ *     resolution and MUST be identical before and after applying the query.
+ *     If applying the query changes any of them, we fail closed.
+ *   - The query is applied via `URL.search`, which preserves the exact
+ *     percent-encoding and the ordered, possibly-duplicated key/value pairs of
+ *     the original request-target. We never round-trip through
+ *     `URLSearchParams` entries / `Object.fromEntries`, which would collapse
+ *     duplicate keys and normalize encoding.
+ *   - userinfo (username/password) and fragment must be empty on the final URL.
+ *   - The configured upstream target must not itself already carry a query. The
+ *     current contract builds targets as bare `https://host/path` with no base
+ *     query, so a pre-existing query is unexpected; we reject fail-closed rather
+ *     than guess a merge semantics that could enable parameter smuggling.
+ */
+
+export interface GovernedQueryResult {
+  ok: true;
+  url: URL;
+}
+
+export interface GovernedQueryError {
+  ok: false;
+  reason: string;
+}
+
+/**
+ * Extract the raw query string (including the leading "?", or "" when absent)
+ * from an incoming request URL, using WHATWG URL parsing so that any fragment
+ * is stripped and the exact percent-encoding / ordered duplicate pairs of the
+ * request-target are preserved.
+ *
+ * Returns "" for a missing or empty ("?") query.
+ */
+export function extractRawQuery(requestUrl: string): string {
+  try {
+    return new URL(requestUrl).search;
+  } catch {
+    // A request URL Hono handed us should always parse; fail closed to "no
+    // query" rather than throwing, so a parse hiccup can never smuggle data.
+    return "";
+  }
+}
+
+/**
+ * Compose the governed client query onto the pinned upstream target URL.
+ *
+ * `targetUrl` is the fully-resolved, host/scheme/path-pinned upstream URL built
+ * from the request path (no query). `rawQuery` is the value returned by
+ * `extractRawQuery` for the same request. The returned URL is a fresh clone with
+ * the query applied; the input is not mutated.
+ *
+ * Fails closed (returns `{ ok: false }`) if applying the query would alter the
+ * pinned authority/path, if the target already carried a query, or if the
+ * result exposes userinfo or a fragment.
+ */
+export function applyGovernedQuery(
+  targetUrl: URL,
+  rawQuery: string,
+): GovernedQueryResult | GovernedQueryError {
+  // The pinned target must never itself carry a query, userinfo, or fragment.
+  if (targetUrl.search !== "") {
+    return { ok: false, reason: "target-carries-base-query" };
+  }
+  if (targetUrl.username !== "" || targetUrl.password !== "") {
+    return { ok: false, reason: "target-carries-userinfo" };
+  }
+  if (targetUrl.hash !== "") {
+    return { ok: false, reason: "target-carries-fragment" };
+  }
+
+  // Snapshot the pinned authority + path so we can prove they are unchanged.
+  const pinned = {
+    protocol: targetUrl.protocol,
+    hostname: targetUrl.hostname,
+    port: targetUrl.port,
+    pathname: targetUrl.pathname,
+  };
+
+  const composed = new URL(targetUrl.toString());
+  // Setting `.search` preserves the exact bytes of the query (encoding + order
+  // + duplicate keys). Normalize a bare "?" (empty query) to no query at all.
+  const normalizedQuery =
+    rawQuery === "" || rawQuery === "?" ? "" : rawQuery.startsWith("?") ? rawQuery : `?${rawQuery}`;
+  composed.search = normalizedQuery;
+
+  // Re-validate: the query must not have influenced the pinned authority/path,
+  // and must not have introduced userinfo or a fragment. WHATWG URL parsing
+  // treats `.search` content as opaque query data, so this should always hold —
+  // the assertion exists so any future regression fails closed instead of
+  // silently forwarding a confused target.
+  if (
+    composed.protocol !== pinned.protocol ||
+    composed.hostname !== pinned.hostname ||
+    composed.port !== pinned.port ||
+    composed.pathname !== pinned.pathname ||
+    composed.username !== "" ||
+    composed.password !== "" ||
+    composed.hash !== ""
+  ) {
+    return { ok: false, reason: "query-altered-pinned-target" };
+  }
+
+  return { ok: true, url: composed };
+}


### PR DESCRIPTION
## Problem

The proxy handler resolved the upstream target from `c.req.path`, which Hono strips of any query string. Governed requests like `GET /github/search/issues?q=foo&page=2` were therefore forwarded upstream as `/search/issues` with the **query silently dropped**. This breaks filtered/paginated upstream APIs and can change request semantics without any signal to the caller.

Flagged by the PR2 canonicalization audit. Verified on `develop` first with a failing end-to-end test (query arrives empty at the stubbed upstream) before touching production code.

## Fix

Contained to the proxy handler plus a new pure URL-builder helper (`handlers/query-forwarding.ts`):

- **Extract** the client's raw query once via WHATWG URL parsing (`new URL(c.req.raw.url).search`) — exact percent-encoding and ordered duplicate pairs preserved, fragment stripped. Never round-trips through `URLSearchParams` entries / `Object.fromEntries` (which would collapse duplicate keys and normalize encoding).
- **Compose** the query onto the pinned upstream URL in `applyGovernedQuery`, then **re-validate** that scheme/host/port/path are unchanged and that no userinfo or fragment leaked in. Fails closed if the target already carried a base query.
- The query **never influences route/target resolution** (matching still uses the path only), so preservation cannot enable authority bypass or target confusion.

## Correctness follow-through (from code review)

- **Idempotency fingerprint** now includes the raw query, so two requests differing only by query (`?id=1` vs `?id=2`) under one `Idempotency-Key` are detected as distinct ("different request" 409) rather than swallowed as a replay ("already forwarded").
- **Approval-gated routes** fail closed on query-bearing requests. The approval hold/replay path reconstructs the request from the stored path only and cannot yet round-trip the query, so a query-bearing approved request would otherwise execute a semantically different (query-stripped) request than the one approved. A full query-preserving approval replay is a follow-up.

## Security invariants (tested)

scheme/host/port pinned to the configured upstream; userinfo/fragment rejected; query cannot influence route matching; duplicate keys keep ordered pair semantics; percent-encoding not decoded/re-encoded; empty query, blank values, repeated keys, and a malicious absolute-URL-looking query value all covered.

## Tests

- `query-forwarding.test.ts` — unit coverage of the URL builder (one key, repeated keys, blank value, percent-encoded value, absent query, URL-looking value stays inert data, base-query / userinfo / fragment rejection, input not mutated).
- `proxy-query-preservation.test.ts` — end-to-end proxy integration (real auth + PGLite + vault, network stubbed): forwarding, dup keys, blank, encoding, no host/scheme/path bypass, no route-matching influence, idempotency distinctness (different query vs genuine replay), approval-route rejection + no-query hold still works.

**Effectiveness proven** by reverting each production change independently and observing the corresponding cases fail (query preservation cases → empty search; idempotency fingerprint → "already forwarded" instead of "different request").

`bun test` (both new files 28/28 standalone), `tsc --noEmit`, and biome all clean. `codex review --uncommitted` returned no findings after the follow-through fixes.

Do not merge.

[sol-orch]

Co-authored-by: wakesync <shadow@shad0w.xyz>