### PR TITLE
feat(authority): exact-request approval binding and safe resume (authority plan PR3)

### DIFF
--- a/packages/api/scripts/pr3-mutation-proofs.sh
+++ b/packages/api/scripts/pr3-mutation-proofs.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# PR3 mutation-strength proofs (spec §14). Each mutation weakens ONE security
+# predicate; a proof is valid iff the named test PASSES clean AND FAILS after the
+# mutation. The file is restored after each proof. Run from packages/api:
+#
+#   bash scripts/pr3-mutation-proofs.sh
+#
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+SVC="src/services/provider-approval.ts"
+NEG="src/__tests__/provider-approval-negative.test.ts"
+CONC="src/__tests__/provider-approval-concurrency.test.ts"
+
+pass_count=0
+fail_count=0
+
+# run_test <file> <filter> -> 0 if all pass (0 fail), 1 otherwise
+run_test() {
+  local out
+  out=$(timeout 90 bun test --timeout 25000 "$1" -t "$2" 2>&1)
+  echo "$out" | grep -qE "^ *0 fail$"
+}
+
+# proof <name> <file> <filter> <target> <sed-expr>
+proof() {
+  local name="$1" file="$2" filter="$3" target="$4" sedexpr="$5"
+  echo "=== PROOF: $name ==="
+  if run_test "$file" "$filter"; then
+    echo "  baseline PASS ✓"
+  else
+    echo "  baseline UNEXPECTED FAIL ✗ (proof invalid)"; fail_count=$((fail_count+1)); return
+  fi
+  cp "$target" "$target.bak"
+  sed -i "$sedexpr" "$target"
+  if run_test "$file" "$filter"; then
+    echo "  post-mutation still PASSES ✗ (mutation did not kill the test)"; fail_count=$((fail_count+1))
+  else
+    echo "  post-mutation FAILS ✓ (predicate killed)"; pass_count=$((pass_count+1))
+  fi
+  mv "$target.bak" "$target"
+}
+
+# M1: loosen MFA window (<=5m -> <=6m) → N12 (5m+1ms) must fail.
+proof "M1 loosen MFA window (N12)" "$NEG" "N12" "$SVC" \
+  's/const MAX_MFA_AGE_MS = 300_000;/const MAX_MFA_AGE_MS = 360_000;/'
+
+# M2: accept ambient role (skip approver-binding requirement) → N04 must fail.
+proof "M2 accept ambient role (N04)" "$NEG" "N04" "$SVC" \
+  's/const eligible = approverRows.some(/const eligible = true || approverRows.some(/'
+
+# M3: skip queue/binding request-hash + digest agreement → N26 must fail.
+proof "M3 skip queue/binding hash agreement (N26)" "$NEG" "N26" "$SVC" \
+  's/if (queue.requestHash !== binding.requestHash || queue.actionDigest !== binding.actionDigest) {/if (false) {/'
+
+# M4: ignore secret version at resume → N39 must fail.
+proof "M4 ignore secret version (N39)" "$NEG" "N39" "$SVC" \
+  's/account.credentialVersion !== c.executionDependencies.secretVersion/false/'
+
+# M5: skip the canonical-byte digest recomputation (accept any stored digest) →
+#     N24 (tampered canonical bytes) must fail. Weaken the digest equality guard.
+proof "M5 skip canonical-byte digest recompute (N24)" "$NEG" "N24" "$SVC" \
+  's/if (recomputedDigest !== binding.actionDigest) {/if (false) {/'
+
+# M6: mint a fresh resumeAttemptId on the idempotent return path → C05 must fail.
+proof "M6 non-idempotent resumeAttemptId (C05)" "$CONC" "C05" "$SVC" \
+  's/resumeAttemptId: binding.resumeAttemptId ?? undefined,/resumeAttemptId: randomUUID(),/'
+
+echo ""
+echo "==================================================="
+echo "MUTATION PROOFS: $pass_count killed, $fail_count invalid"
+echo "==================================================="
+[ "$fail_count" -eq 0 ] && exit 0 || exit 1

--- a/packages/api/src/__tests__/provider-action-service.test.ts
+++ b/packages/api/src/__tests__/provider-action-service.test.ts
@@ -27,6 +27,8 @@ import {
   providerActionBindings,
   providerGrants,
   providerOperations,
+  secretRoutes,
+  secrets,
   tenants,
   users,
   workspaces,
@@ -51,6 +53,8 @@ const OP_A_READ = "40000000-0000-4000-8000-000000000001";
 const OP_A_WRITE = "40000000-0000-4000-8000-000000000002";
 const OP_B_READ = "40000000-0000-4000-8000-000000000003";
 const GRANTOR = "10000000-0000-4000-8000-000000000001";
+const SECRET_A = "50000000-0000-4000-8000-000000000001";
+const ROUTE_A = "60000000-0000-4000-8000-000000000001";
 const FUTURE = new Date(Date.now() + 365 * 24 * 3600_000);
 
 function principal(agentId = AGENT): ProviderPrincipalV1 {
@@ -114,6 +118,32 @@ async function seedCore() {
       createdBy: GRANTOR,
     },
   ]);
+  // A secret + route so the PR3 approval commitment can bind route/credential
+  // revisions (spec §5.2: missing route/credential fails approval creation).
+  await db.insert(secrets).values([
+    {
+      id: SECRET_A,
+      tenantId: TENANT,
+      name: "github-a",
+      ciphertext: "x",
+      iv: "x",
+      authTag: "x",
+      salt: "x",
+      version: 1,
+    },
+  ]);
+  await db.insert(secretRoutes).values([
+    {
+      id: ROUTE_A,
+      tenantId: TENANT,
+      secretId: SECRET_A,
+      hostPattern: "api.github.com",
+      pathPattern: "/*",
+      method: "*",
+      injectAs: "header",
+      injectKey: "authorization",
+    },
+  ]);
   await db.insert(providerAccounts).values([
     {
       id: ACCOUNT_A,
@@ -122,6 +152,8 @@ async function seedCore() {
       adapterKey: "github",
       externalRef: "a",
       displayName: "A",
+      credentialSecretId: SECRET_A,
+      credentialVersion: 1,
     },
     {
       id: ACCOUNT_B,
@@ -140,6 +172,7 @@ async function seedCore() {
       providerAccountId: ACCOUNT_A,
       operationKey: "github.issue.list",
       riskClass: "read",
+      secretRouteId: ROUTE_A,
     },
     {
       id: OP_A_WRITE,
@@ -148,6 +181,7 @@ async function seedCore() {
       providerAccountId: ACCOUNT_A,
       operationKey: "github.pr.comment.create",
       riskClass: "consequential",
+      secretRouteId: ROUTE_A,
     },
     {
       id: OP_B_READ,

--- a/packages/api/src/__tests__/provider-approval-boundary.test.ts
+++ b/packages/api/src/__tests__/provider-approval-boundary.test.ts
@@ -11,10 +11,7 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
-const raw = readFileSync(
-  join(import.meta.dir, "..", "services", "provider-approval.ts"),
-  "utf8",
-);
+const raw = readFileSync(join(import.meta.dir, "..", "services", "provider-approval.ts"), "utf8");
 
 // Strip line + block comments so the guard matches CODE, not prose describing
 // the boundary (the file legitimately DOCUMENTS that it never decrypts/proxies).
@@ -28,7 +25,10 @@ describe("PR3 boundary (I15): no decrypt / proxy / mint / nonce / network in the
   const forbidden: Array<[string, RegExp]> = [
     ["credential decryption", /decrypt|getSecretPlaintext|decryptSecret/i],
     ["proxy dispatch", /\bproxy\b|forwardRequest|dispatchProxy|handleProxy/i],
-    ["execution-authorization mint", /mintExecutionAuthorization|execution-authorization|executionAuthorization/i],
+    [
+      "execution-authorization mint",
+      /mintExecutionAuthorization|execution-authorization|executionAuthorization/i,
+    ],
     ["nonce claim", /executionAuthorizationNonces|claimNonce|nonceClaim/i],
     ["network I/O", /\bfetch\(|axios|node:https?|undici/],
     ["legacy pending_proxy_requests fallback", /pendingProxyRequests|pending_proxy_requests/],
@@ -42,7 +42,9 @@ describe("PR3 boundary (I15): no decrypt / proxy / mint / nonce / network in the
 
   test("imports only DB + shared + drizzle (no vault/proxy/secret packages)", () => {
     // Guard the forbidden package specifiers anywhere in the source.
-    expect(svc).not.toMatch(/from "@stwd\/proxy|from "@stwd\/vault|from "@stwd\/secrets|proxy-client/);
+    expect(svc).not.toMatch(
+      /from "@stwd\/proxy|from "@stwd\/vault|from "@stwd\/secrets|proxy-client/,
+    );
     // The transition owner pulls from @stwd/db + @stwd/shared + drizzle-orm.
     expect(svc).toMatch(/from "@stwd\/db"/);
     expect(svc).toMatch(/from "@stwd\/shared"/);

--- a/packages/api/src/__tests__/provider-approval-boundary.test.ts
+++ b/packages/api/src/__tests__/provider-approval-boundary.test.ts
@@ -1,0 +1,50 @@
+/**
+ * PR3 static boundary test (I15 / spec §14 static import guard). Proves the
+ * provider-approval service source has ZERO references to credential decryption,
+ * the proxy, execution-authorization minting, nonce claims, network I/O, or the
+ * legacy PR #181 pending_proxy_requests fallback. This is a source-introspection
+ * test: a future edit that pulls any of those into the PR3 transition owner
+ * fails CI, not a runtime spy.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const raw = readFileSync(
+  join(import.meta.dir, "..", "services", "provider-approval.ts"),
+  "utf8",
+);
+
+// Strip line + block comments so the guard matches CODE, not prose describing
+// the boundary (the file legitimately DOCUMENTS that it never decrypts/proxies).
+const svc = raw
+  .replace(/\/\*[\s\S]*?\*\//g, "")
+  .split("\n")
+  .map((l) => l.replace(/\/\/.*$/, ""))
+  .join("\n");
+
+describe("PR3 boundary (I15): no decrypt / proxy / mint / nonce / network in the transition owner", () => {
+  const forbidden: Array<[string, RegExp]> = [
+    ["credential decryption", /decrypt|getSecretPlaintext|decryptSecret/i],
+    ["proxy dispatch", /\bproxy\b|forwardRequest|dispatchProxy|handleProxy/i],
+    ["execution-authorization mint", /mintExecutionAuthorization|execution-authorization|executionAuthorization/i],
+    ["nonce claim", /executionAuthorizationNonces|claimNonce|nonceClaim/i],
+    ["network I/O", /\bfetch\(|axios|node:https?|undici/],
+    ["legacy pending_proxy_requests fallback", /pendingProxyRequests|pending_proxy_requests/],
+  ];
+
+  for (const [label, re] of forbidden) {
+    test(`does not reference ${label}`, () => {
+      expect(re.test(svc)).toBe(false);
+    });
+  }
+
+  test("imports only DB + shared + drizzle (no vault/proxy/secret packages)", () => {
+    // Guard the forbidden package specifiers anywhere in the source.
+    expect(svc).not.toMatch(/from "@stwd\/proxy|from "@stwd\/vault|from "@stwd\/secrets|proxy-client/);
+    // The transition owner pulls from @stwd/db + @stwd/shared + drizzle-orm.
+    expect(svc).toMatch(/from "@stwd\/db"/);
+    expect(svc).toMatch(/from "@stwd\/shared"/);
+  });
+});

--- a/packages/api/src/__tests__/provider-approval-concurrency.test.ts
+++ b/packages/api/src/__tests__/provider-approval-concurrency.test.ts
@@ -233,6 +233,29 @@ describe("PR3 concurrency + fault matrix", () => {
     expect((await bindingRow(intentId)).status).toBe("approval_stale");
   });
 
+  test("C13 (codex P2): concurrent stale attempts emit exactly one staled event, no double audit", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    await providerApprovalService.decide(decideBody(intentId, requestHash, actionDigest));
+    // Revoke a matched grant so both concurrent resume attempts detect a stale
+    // condition; the guarded CAS must let only ONE win + emit one staled event.
+    await getDb()
+      .update(providerGrants)
+      .set({ status: "revoked" })
+      .where(eq(providerGrants.id, F.GRANT));
+    const results = await Promise.all([
+      providerApprovalService.resume({ intentId, tenantId: F.TENANT }),
+      providerApprovalService.resume({ intentId, tenantId: F.TENANT }),
+      providerApprovalService.resume({ intentId, tenantId: F.TENANT }),
+    ]);
+    // All fail (stale); the binding is stale exactly once.
+    expect(results.every((r) => !r.ok)).toBe(true);
+    expect((await bindingRow(intentId)).status).toBe("approval_stale");
+    const staled = (await correlatedAudit(intentId)).filter(
+      (e) => e.action === "provider.approval.staled",
+    );
+    expect(staled.length).toBe(1);
+  });
+
   test("C09/C10/N49: audit append fault rolls back the WHOLE tuple (evidence before visibility)", async () => {
     const { intentId, requestHash, actionDigest } = await createApprovalRequired();
     const auditsBefore = await auditCount();

--- a/packages/api/src/__tests__/provider-approval-concurrency.test.ts
+++ b/packages/api/src/__tests__/provider-approval-concurrency.test.ts
@@ -29,8 +29,8 @@ import {
   secretRoutes,
   secrets,
   tenants,
-  userTenants,
   users,
+  userTenants,
   workspaces,
 } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
@@ -177,12 +177,12 @@ describe("PR3 concurrency + fault matrix", () => {
     const { intentId, requestHash, actionDigest } = await createApprovalRequired();
     await providerApprovalService.decide(decideBody(intentId, requestHash, actionDigest));
     const results = await Promise.all(
-      Array.from({ length: 25 }, () => providerApprovalService.resume({ intentId, tenantId: F.TENANT })),
+      Array.from({ length: 25 }, () =>
+        providerApprovalService.resume({ intentId, tenantId: F.TENANT }),
+      ),
     );
     const readyIds = new Set(
-      results
-        .filter((r) => r.ok)
-        .map((r) => (r as { resumeAttemptId?: string }).resumeAttemptId),
+      results.filter((r) => r.ok).map((r) => (r as { resumeAttemptId?: string }).resumeAttemptId),
     );
     expect(readyIds.size).toBe(1);
     const b = await bindingRow(intentId);
@@ -242,7 +242,9 @@ describe("PR3 concurrency + fault matrix", () => {
         throw new AuditUnavailableError("audit unavailable");
       },
     };
-    const res = await providerApprovalService.decide(decideBody(intentId, requestHash, actionDigest));
+    const res = await providerApprovalService.decide(
+      decideBody(intentId, requestHash, actionDigest),
+    );
     expect(res.ok).toBe(false);
     if (res.ok) throw new Error();
     expect(res.code).toBe("EVIDENCE_REQUIRED_AUDIT_UNAVAILABLE");

--- a/packages/api/src/__tests__/provider-approval-concurrency.test.ts
+++ b/packages/api/src/__tests__/provider-approval-concurrency.test.ts
@@ -1,0 +1,308 @@
+/**
+ * PR3 concurrency + fault-injection matrix (spec §13) + C2 crash recovery.
+ * Uses real Promise.all races and the service's named fault hooks (production
+ * no-ops; not settable from runtime input). Under PGLite the per-tenant audit
+ * queue + unique/revision constraints yield exactly one transition (C14).
+ */
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  setDefaultTimeout,
+  test,
+} from "bun:test";
+import {
+  approvalQueue,
+  closeDb,
+  getDb,
+  intents,
+  providerAccounts,
+  providerActionAuditOutbox,
+  providerActionBindings,
+  providerGrants,
+  providerOperations,
+  providerRoleBindings,
+  secretRoutes,
+  secrets,
+  tenants,
+  userTenants,
+  users,
+  workspaces,
+} from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { eq, sql } from "drizzle-orm";
+import { providerActionService } from "../services/provider-action-service";
+import { AuditUnavailableError, providerApprovalService } from "../services/provider-approval";
+import {
+  auditCount,
+  bindingRow,
+  correlatedAudit,
+  createApprovalRequired,
+  F,
+  freshMfa,
+  queueRow,
+  seedFixture,
+} from "./provider-approval-fixture";
+
+setDefaultTimeout(120_000);
+
+async function wipe() {
+  const db = getDb();
+  for (const t of [
+    providerActionAuditOutbox,
+    approvalQueue,
+    providerActionBindings,
+    intents,
+    providerGrants,
+    providerRoleBindings,
+    providerOperations,
+    providerAccounts,
+    secretRoutes,
+    secrets,
+    workspaces,
+    userTenants,
+    users,
+    tenants,
+  ]) {
+    await db.delete(t);
+  }
+}
+
+function decideBody(
+  intentId: string,
+  requestHash: string,
+  actionDigest: string,
+  overrides: Partial<Parameters<typeof providerApprovalService.decide>[0]> = {},
+) {
+  return {
+    intentId,
+    tenantId: F.TENANT,
+    authenticatedUserId: F.APPROVER,
+    sessionMfaVerifiedAt: freshMfa(),
+    decision: "approve" as const,
+    expectedVersion: 1,
+    expectedRequestHash: requestHash,
+    expectedActionDigest: actionDigest,
+    reasonCode: null,
+    reason: null,
+    idempotencyKey: "conc-key",
+    ...overrides,
+  };
+}
+
+describe("PR3 concurrency + fault matrix", () => {
+  beforeAll(async () => {
+    process.env.STEWARD_PGLITE_MEMORY = "true";
+    process.env.STEWARD_AUDIT_HMAC_KEY ||= "0".repeat(64);
+    const { db, client } = await createPGLiteDb("memory://");
+    setPGLiteOverride(db, async () => client.close());
+  });
+  afterAll(async () => {
+    await closeDb();
+    delete process.env.STEWARD_PGLITE_MEMORY;
+  });
+  beforeEach(async () => {
+    await wipe();
+    await seedFixture();
+  });
+  afterEach(() => {
+    providerApprovalService.faultHooks = {};
+  });
+
+  test("C01: two humans approve the same pending action concurrently => exactly one transition + one decided event", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    // APPROVER_2 already exists (fixture) as an admin member; add a second
+    // eligible workspace_approver binding for the race.
+    await getDb().insert(providerRoleBindings).values({
+      tenantId: F.TENANT,
+      workspaceId: F.WORKSPACE,
+      principalType: "human",
+      principalId: F.APPROVER_2,
+      roleKey: "workspace_approver",
+      operationKeys: [],
+      environment: "production",
+      status: "active",
+      grantedByUserId: F.GRANTOR,
+      reason: "second approver",
+    });
+    const [r1, r2] = await Promise.all([
+      providerApprovalService.decide(
+        decideBody(intentId, requestHash, actionDigest, { idempotencyKey: "c01-a" }),
+      ),
+      providerApprovalService.decide(
+        decideBody(intentId, requestHash, actionDigest, {
+          authenticatedUserId: F.APPROVER_2,
+          idempotencyKey: "c01-b",
+        }),
+      ),
+    ]);
+    const oks = [r1, r2].filter((r) => r.ok).length;
+    expect(oks).toBe(1);
+    const b = await bindingRow(intentId);
+    expect(b.status).toBe("approved");
+    expect(b.bindingRevision).toBe(2);
+    // exactly one decided event.
+    const decided = (await correlatedAudit(intentId)).filter(
+      (e) => e.action === "provider.approval.decided",
+    );
+    expect(decided.length).toBe(1);
+  });
+
+  test("C02: approve and deny race => exactly one immutable decision wins, tuple is wholly one or the other", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    const [r1, r2] = await Promise.all([
+      providerApprovalService.decide(
+        decideBody(intentId, requestHash, actionDigest, { idempotencyKey: "c02-approve" }),
+      ),
+      providerApprovalService.decide(
+        decideBody(intentId, requestHash, actionDigest, {
+          decision: "deny",
+          reasonCode: "approver_manual_deny",
+          idempotencyKey: "c02-deny",
+        }),
+      ),
+    ]);
+    expect([r1, r2].filter((r) => r.ok).length).toBe(1);
+    const b = await bindingRow(intentId);
+    expect(["approved", "approval_denied"]).toContain(b.status);
+    const q = await queueRow(intentId);
+    expect(b.status === "approved" ? q.status === "approved" : q.status === "rejected").toBe(true);
+  });
+
+  test("C05: many concurrent execute calls => one approved->ready update, one resumeAttemptId, one ready event", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    await providerApprovalService.decide(decideBody(intentId, requestHash, actionDigest));
+    const results = await Promise.all(
+      Array.from({ length: 25 }, () => providerApprovalService.resume({ intentId, tenantId: F.TENANT })),
+    );
+    const readyIds = new Set(
+      results
+        .filter((r) => r.ok)
+        .map((r) => (r as { resumeAttemptId?: string }).resumeAttemptId),
+    );
+    expect(readyIds.size).toBe(1);
+    const b = await bindingRow(intentId);
+    expect(b.status).toBe("execution_ready");
+    expect(b.bindingRevision).toBe(3);
+    const ready = (await correlatedAudit(intentId)).filter(
+      (e) => e.action === "provider.resume.ready",
+    );
+    expect(ready.length).toBe(1);
+  });
+
+  // C06/C07/C08: a dependency change that commits before the guarded resume claim
+  // is seen by the in-tx revalidation (which reads current state at claim time)
+  // and stales the action; no ready state is produced. (PGLite is single-writer,
+  // so a genuinely-concurrent mid-transaction commit cannot be injected without
+  // deadlock; committing the change immediately before resume is the equivalent
+  // deterministic oracle for the revalidation-at-claim predicate.)
+  test("C06: grant revoked before the resume claim => stale, no ready state", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    await providerApprovalService.decide(decideBody(intentId, requestHash, actionDigest));
+    await getDb()
+      .update(providerGrants)
+      .set({ status: "revoked" })
+      .where(eq(providerGrants.id, F.GRANT));
+    const res = await providerApprovalService.resume({ intentId, tenantId: F.TENANT });
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error();
+    expect(res.code).toBe("APPROVAL_GRANT_STALE");
+    expect((await bindingRow(intentId)).status).toBe("approval_stale");
+    // No ready audit event was produced.
+    const ready = (await correlatedAudit(intentId)).filter(
+      (e) => e.action === "provider.resume.ready",
+    );
+    expect(ready.length).toBe(0);
+  });
+
+  test("C08: credential rotated before the resume claim => stale credential, no ready state", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    await providerApprovalService.decide(decideBody(intentId, requestHash, actionDigest));
+    await getDb()
+      .update(providerAccounts)
+      .set({ credentialVersion: 2 })
+      .where(eq(providerAccounts.id, F.ACCOUNT));
+    const res = await providerApprovalService.resume({ intentId, tenantId: F.TENANT });
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error();
+    expect(res.code).toBe("APPROVAL_CREDENTIAL_STALE");
+    expect((await bindingRow(intentId)).status).toBe("approval_stale");
+  });
+
+  test("C09/C10/N49: audit append fault rolls back the WHOLE tuple (evidence before visibility)", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    const auditsBefore = await auditCount();
+    // Inject an audit failure at the append boundary.
+    providerApprovalService.faultHooks = {
+      beforeAudit: () => {
+        throw new AuditUnavailableError("audit unavailable");
+      },
+    };
+    const res = await providerApprovalService.decide(decideBody(intentId, requestHash, actionDigest));
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error();
+    expect(res.code).toBe("EVIDENCE_REQUIRED_AUDIT_UNAVAILABLE");
+    expect(res.httpStatus).toBe(503);
+    // Lifecycle tuple fully rolled back: still pending, no new audit rows.
+    const b = await bindingRow(intentId);
+    expect(b.status).toBe("pending_approval");
+    expect(b.bindingRevision).toBe(1);
+    const q = await queueRow(intentId);
+    expect(q.status).toBe("pending");
+    const i = await getDb().select().from(intents).where(eq(intents.id, intentId));
+    expect(i[0].status).toBe("pending");
+    expect(await auditCount()).toBe(auditsBefore);
+  });
+
+  test("C2 crash recovery: a crash between commit and drain leaves an undelivered outbox row; the sweeper signs it exactly once", async () => {
+    // Create an approval-required action but SIMULATE a crash before the drain by
+    // marking the just-created outbox row undelivered again (createApprovalRequired
+    // already drains). Instead: create a fresh action and null delivered_at to
+    // emulate a crash between commit and drain.
+    const { intentId } = await createApprovalRequired();
+    await getDb()
+      .update(providerActionAuditOutbox)
+      .set({ deliveredAt: null })
+      .where(eq(providerActionAuditOutbox.intentId, intentId));
+    // Delete any signed event that was produced so we can prove the sweeper
+    // produces exactly one.
+    await getDb().execute(
+      sql`DELETE FROM audit_events WHERE tenant_id = ${F.TENANT} AND resource_id = ${intentId}`,
+    );
+    // First sweep signs it; second sweep is a no-op (exactly once).
+    const first = await providerActionService.recoverUnsignedIntents(F.TENANT, intentId);
+    const second = await providerActionService.recoverUnsignedIntents(F.TENANT, intentId);
+    expect(first).toBe(1);
+    expect(second).toBe(0);
+    const events = await correlatedAudit(intentId);
+    expect(events.filter((e) => e.action === "provider.action.approval_required").length).toBe(1);
+    // The outbox row is delivered.
+    const [row] = await getDb()
+      .select()
+      .from(providerActionAuditOutbox)
+      .where(eq(providerActionAuditOutbox.intentId, intentId));
+    expect(row.deliveredAt).not.toBeNull();
+  });
+
+  test("C2 recovery is idempotent under concurrency: two parallel sweeps sign exactly once", async () => {
+    const { intentId } = await createApprovalRequired();
+    await getDb()
+      .update(providerActionAuditOutbox)
+      .set({ deliveredAt: null })
+      .where(eq(providerActionAuditOutbox.intentId, intentId));
+    await getDb().execute(
+      sql`DELETE FROM audit_events WHERE tenant_id = ${F.TENANT} AND resource_id = ${intentId}`,
+    );
+    const [a, b] = await Promise.all([
+      providerActionService.recoverUnsignedIntents(F.TENANT, intentId),
+      providerActionService.recoverUnsignedIntents(F.TENANT, intentId),
+    ]);
+    expect(a + b).toBe(1);
+    const events = await correlatedAudit(intentId);
+    expect(events.length).toBe(1);
+  });
+});

--- a/packages/api/src/__tests__/provider-approval-fixture.ts
+++ b/packages/api/src/__tests__/provider-approval-fixture.ts
@@ -11,7 +11,6 @@ import {
   getDb,
   intents,
   providerAccounts,
-  providerActionAuditOutbox,
   providerActionBindings,
   providerGrants,
   providerOperations,
@@ -19,8 +18,8 @@ import {
   secretRoutes,
   secrets,
   tenants,
-  userTenants,
   users,
+  userTenants,
   workspaces,
 } from "@stwd/db";
 import { buildGithubAction } from "@stwd/provider-github";
@@ -235,7 +234,9 @@ export async function createApprovalRequired(idem = "aaaaaaaa"): Promise<{
     requestId: null,
   });
   if (out.kind !== "approval_required") {
-    throw new Error(`expected approval_required, got ${out.kind} (${(out as { code?: string }).code})`);
+    throw new Error(
+      `expected approval_required, got ${out.kind} (${(out as { code?: string }).code})`,
+    );
   }
   return { intentId: out.intentId, requestHash: out.requestHash, actionDigest: out.actionDigest };
 }
@@ -275,7 +276,9 @@ export async function auditCount(tenantId = F.TENANT, action?: string): Promise<
 export async function correlatedAudit(
   intentId: string,
   tenantId = F.TENANT,
-): Promise<Array<{ action: string; resource_type: string; resource_id: string; intent_meta: string }>> {
+): Promise<
+  Array<{ action: string; resource_type: string; resource_id: string; intent_meta: string }>
+> {
   const rows = await getDb().execute(
     sql`SELECT action, resource_type, resource_id, (metadata->>'intentId') AS intent_meta
         FROM audit_events
@@ -283,7 +286,12 @@ export async function correlatedAudit(
         ORDER BY seq ASC`,
   );
   const arr = Array.isArray(rows) ? rows : ((rows as { rows?: unknown[] }).rows ?? []);
-  return arr as Array<{ action: string; resource_type: string; resource_id: string; intent_meta: string }>;
+  return arr as Array<{
+    action: string;
+    resource_type: string;
+    resource_id: string;
+    intent_meta: string;
+  }>;
 }
 
 export function freshMfa(): number {

--- a/packages/api/src/__tests__/provider-approval-fixture.ts
+++ b/packages/api/src/__tests__/provider-approval-fixture.ts
@@ -1,0 +1,291 @@
+/**
+ * Shared PGLite fixture for the PR3 provider-approval test suite. Seeds a full
+ * tenant with a workspace, provider account (+credential), a governed operation
+ * (+route), an active agent grant, and an eligible human workspace_approver so
+ * an approval-required provider action can be created and decided end-to-end.
+ */
+
+import {
+  agents,
+  approvalQueue,
+  getDb,
+  intents,
+  providerAccounts,
+  providerActionAuditOutbox,
+  providerActionBindings,
+  providerGrants,
+  providerOperations,
+  providerRoleBindings,
+  secretRoutes,
+  secrets,
+  tenants,
+  userTenants,
+  users,
+  workspaces,
+} from "@stwd/db";
+import { buildGithubAction } from "@stwd/provider-github";
+import { eq, sql } from "drizzle-orm";
+import type { ProviderPrincipalV1 } from "../middleware/provider-principal";
+import { providerActionService } from "../services/provider-action-service";
+
+export const F = {
+  TENANT: "tenant-appr",
+  TENANT_B: "tenant-b",
+  AGENT: "agent-a",
+  AGENT_OWNER: "70000000-0000-4000-8000-000000000001",
+  WORKSPACE: "20000000-0000-4000-8000-000000000001",
+  WORKSPACE_2: "20000000-0000-4000-8000-000000000002",
+  ACCOUNT: "30000000-0000-4000-8000-000000000001",
+  OP: "40000000-0000-4000-8000-000000000001",
+  OP_KEY: "github.pr.comment.create",
+  SECRET: "50000000-0000-4000-8000-000000000001",
+  ROUTE: "60000000-0000-4000-8000-000000000001",
+  GRANTOR: "10000000-0000-4000-8000-000000000001",
+  APPROVER: "80000000-0000-4000-8000-000000000001",
+  APPROVER_2: "80000000-0000-4000-8000-000000000002",
+  APPROVER_BINDING: "90000000-0000-4000-8000-000000000001",
+  GRANT: "a0000000-0000-4000-8000-000000000001",
+};
+
+const FUTURE = new Date(Date.now() + 365 * 24 * 3600_000);
+
+export function principal(agentId = F.AGENT, tenantId = F.TENANT): ProviderPrincipalV1 {
+  return {
+    type: "agent",
+    agentId,
+    tenantId,
+    platformId: null,
+    issuer: "eliza-cloud",
+    subject: `agent:${agentId}`,
+    tokenId: null,
+    scopes: [],
+    authenticatedAt: new Date().toISOString(),
+    expiresAt: null,
+    authnMethod: "agent-jwt-rs256",
+  };
+}
+
+/** A require-approval policy rule for the op (allow + require-approval => approval). */
+export const APPROVAL_RULES = [
+  {
+    id: "11111111-1111-4111-8111-111111111111",
+    type: "capability-intent",
+    enabled: true,
+    config: { capabilities: [F.OP_KEY], effect: "allow" },
+  },
+  {
+    id: "22222222-2222-4222-8222-222222222222",
+    type: "capability-intent",
+    enabled: true,
+    config: { capabilities: [F.OP_KEY], effect: "require-approval" },
+  },
+];
+
+export async function seedFixture(opts: { requesterSeparation?: boolean } = {}) {
+  const db = getDb();
+  await db.insert(tenants).values([
+    { id: F.TENANT, name: "Appr", apiKeyHash: "h" },
+    { id: F.TENANT_B, name: "B", apiKeyHash: "h2" },
+  ]);
+  await db.insert(users).values([
+    { id: F.GRANTOR, email: "g@t.test" },
+    { id: F.APPROVER, email: "approver@t.test" },
+    { id: F.APPROVER_2, email: "approver2@t.test" },
+    { id: F.AGENT_OWNER, email: "owner@t.test" },
+  ]);
+  await db.insert(userTenants).values([
+    { userId: F.APPROVER, tenantId: F.TENANT, role: "member" },
+    { userId: F.APPROVER_2, tenantId: F.TENANT, role: "admin" },
+    { userId: F.AGENT_OWNER, tenantId: F.TENANT, role: "member" },
+  ]);
+  await db.insert(agents).values([
+    {
+      id: F.AGENT,
+      tenantId: F.TENANT,
+      name: "A",
+      walletAddress: "0x1",
+      ownerUserId: opts.requesterSeparation ? F.AGENT_OWNER : null,
+    },
+  ]);
+  await db.insert(secrets).values([
+    {
+      id: F.SECRET,
+      tenantId: F.TENANT,
+      name: "github",
+      ciphertext: "x",
+      iv: "x",
+      authTag: "x",
+      salt: "x",
+      version: 1,
+    },
+  ]);
+  await db.insert(secretRoutes).values([
+    {
+      id: F.ROUTE,
+      tenantId: F.TENANT,
+      secretId: F.SECRET,
+      hostPattern: "api.github.com",
+      pathPattern: "/*",
+      method: "*",
+      injectAs: "header",
+      injectKey: "authorization",
+    },
+  ]);
+  await db.insert(workspaces).values([
+    {
+      id: F.WORKSPACE,
+      tenantId: F.TENANT,
+      key: "client-a",
+      name: "A",
+      environment: "production",
+      createdBy: F.GRANTOR,
+    },
+    {
+      id: F.WORKSPACE_2,
+      tenantId: F.TENANT,
+      key: "client-2",
+      name: "2",
+      environment: "production",
+      createdBy: F.GRANTOR,
+    },
+  ]);
+  await db.insert(providerAccounts).values([
+    {
+      id: F.ACCOUNT,
+      tenantId: F.TENANT,
+      workspaceId: F.WORKSPACE,
+      adapterKey: "github",
+      externalRef: "a",
+      displayName: "A",
+      credentialSecretId: F.SECRET,
+      credentialVersion: 1,
+    },
+  ]);
+  await db.insert(providerOperations).values([
+    {
+      id: F.OP,
+      tenantId: F.TENANT,
+      workspaceId: F.WORKSPACE,
+      providerAccountId: F.ACCOUNT,
+      operationKey: F.OP_KEY,
+      riskClass: "consequential",
+      secretRouteId: F.ROUTE,
+      requestProfile: {
+        policyRules: APPROVAL_RULES,
+        ...(opts.requesterSeparation
+          ? { approvalRequirements: { requesterSeparation: true } }
+          : {}),
+      },
+    },
+  ]);
+  await db.insert(providerGrants).values([
+    {
+      id: F.GRANT,
+      tenantId: F.TENANT,
+      workspaceId: F.WORKSPACE,
+      providerAccountId: F.ACCOUNT,
+      agentId: F.AGENT,
+      operationKeys: [F.OP_KEY],
+      environment: "production",
+      expiresAt: FUTURE,
+      grantedByUserId: F.GRANTOR,
+      reason: "test",
+    },
+  ]);
+  // Eligible human workspace_approver for the exact workspace.
+  await db.insert(providerRoleBindings).values([
+    {
+      id: F.APPROVER_BINDING,
+      tenantId: F.TENANT,
+      workspaceId: F.WORKSPACE,
+      principalType: "human",
+      principalId: F.APPROVER,
+      roleKey: "workspace_approver",
+      operationKeys: [],
+      environment: "production",
+      status: "active",
+      grantedByUserId: F.GRANTOR,
+      reason: "approver",
+    },
+  ]);
+}
+
+/** Create an approval-required provider action and return its intentId. */
+export async function createApprovalRequired(idem = "aaaaaaaa"): Promise<{
+  intentId: string;
+  requestHash: string;
+  actionDigest: string;
+}> {
+  const now = new Date();
+  const out = await providerActionService.createProviderAction({
+    principal: principal(),
+    workspaceId: F.WORKSPACE,
+    providerAccountId: F.ACCOUNT,
+    operationKey: F.OP_KEY,
+    build: buildGithubAction(F.OP_KEY, {
+      owner: "octo",
+      repo: "hello",
+      pullNumber: 1,
+      body: "hi",
+    }),
+    idempotencyKeyHash: `sha256:${Buffer.from(idem.padEnd(32, "0")).toString("hex").slice(0, 64)}`,
+    requestedAt: now.toISOString(),
+    expiresAt: new Date(now.getTime() + 300_000).toISOString(),
+    nonce: idem.padEnd(32, "N").slice(0, 32),
+    requestId: null,
+  });
+  if (out.kind !== "approval_required") {
+    throw new Error(`expected approval_required, got ${out.kind} (${(out as { code?: string }).code})`);
+  }
+  return { intentId: out.intentId, requestHash: out.requestHash, actionDigest: out.actionDigest };
+}
+
+export async function bindingRow(intentId: string) {
+  const [b] = await getDb()
+    .select()
+    .from(providerActionBindings)
+    .where(eq(providerActionBindings.intentId, intentId));
+  return b;
+}
+
+export async function queueRow(intentId: string) {
+  const [q] = await getDb()
+    .select()
+    .from(approvalQueue)
+    .where(eq(approvalQueue.intentId, intentId));
+  return q;
+}
+
+export async function intentRow(intentId: string) {
+  const [i] = await getDb().select().from(intents).where(eq(intents.id, intentId));
+  return i;
+}
+
+export async function auditCount(tenantId = F.TENANT, action?: string): Promise<number> {
+  const rows = await getDb().execute(
+    action
+      ? sql`SELECT count(*)::int AS n FROM audit_events WHERE tenant_id = ${tenantId} AND action = ${action}`
+      : sql`SELECT count(*)::int AS n FROM audit_events WHERE tenant_id = ${tenantId}`,
+  );
+  const arr = Array.isArray(rows) ? rows : ((rows as { rows?: unknown[] }).rows ?? []);
+  return Number((arr[0] as { n: number }).n);
+}
+
+/** Distinct audit rows correlated to a case by top-level resource_id (PR5 C1). */
+export async function correlatedAudit(
+  intentId: string,
+  tenantId = F.TENANT,
+): Promise<Array<{ action: string; resource_type: string; resource_id: string; intent_meta: string }>> {
+  const rows = await getDb().execute(
+    sql`SELECT action, resource_type, resource_id, (metadata->>'intentId') AS intent_meta
+        FROM audit_events
+        WHERE tenant_id = ${tenantId} AND resource_type = 'provider_action' AND resource_id = ${intentId}
+        ORDER BY seq ASC`,
+  );
+  const arr = Array.isArray(rows) ? rows : ((rows as { rows?: unknown[] }).rows ?? []);
+  return arr as Array<{ action: string; resource_type: string; resource_id: string; intent_meta: string }>;
+}
+
+export function freshMfa(): number {
+  return Date.now() - 1000;
+}

--- a/packages/api/src/__tests__/provider-approval-lifecycle.test.ts
+++ b/packages/api/src/__tests__/provider-approval-lifecycle.test.ts
@@ -195,7 +195,7 @@ describe("PR3 approval lifecycle", () => {
     expect(q.status).toBe("consumed");
     expect(q.consumedBy).toBe("steward-system");
     const i = await intentRow(intentId);
-    // execution_ready must NOT set executed/executed_at (no third-party execution).
+    // execution_ready must NOT set executed/executed_at (no external execution).
     expect(i.status).toBe("authorized");
     expect(i.executedAt).toBeNull();
     expect(i.executedBy).toBe("steward-system");

--- a/packages/api/src/__tests__/provider-approval-lifecycle.test.ts
+++ b/packages/api/src/__tests__/provider-approval-lifecycle.test.ts
@@ -1,0 +1,263 @@
+/**
+ * PR3 approval lifecycle (state machine) integration tests against PGLite.
+ * Covers creation, approve, deny, expiry, staleness, and safe resume through the
+ * real provider-approval service + the exact atomic state machine (spec §6).
+ */
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  setDefaultTimeout,
+  test,
+} from "bun:test";
+import {
+  approvalQueue,
+  closeDb,
+  getDb,
+  intents,
+  providerAccounts,
+  providerActionAuditOutbox,
+  providerActionBindings,
+  providerGrants,
+  providerOperations,
+  providerRoleBindings,
+  secretRoutes,
+  secrets,
+  tenants,
+  userTenants,
+  users,
+  workspaces,
+} from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { eq } from "drizzle-orm";
+import { providerApprovalService } from "../services/provider-approval";
+import {
+  bindingRow,
+  correlatedAudit,
+  createApprovalRequired,
+  F,
+  freshMfa,
+  intentRow,
+  queueRow,
+  seedFixture,
+} from "./provider-approval-fixture";
+
+setDefaultTimeout(120_000);
+
+async function wipe() {
+  const db = getDb();
+  await db.delete(providerActionAuditOutbox);
+  await db.delete(approvalQueue);
+  await db.delete(providerActionBindings);
+  await db.delete(intents);
+  await db.delete(providerGrants);
+  await db.delete(providerRoleBindings);
+  await db.delete(providerOperations);
+  await db.delete(providerAccounts);
+  await db.delete(secretRoutes);
+  await db.delete(secrets);
+  await db.delete(workspaces);
+  await db.delete(userTenants);
+  await db.delete(users);
+  await db.delete(tenants);
+}
+
+function decideInput(
+  intentId: string,
+  requestHash: string,
+  actionDigest: string,
+  overrides: Partial<Parameters<typeof providerApprovalService.decide>[0]> = {},
+) {
+  return {
+    intentId,
+    tenantId: F.TENANT,
+    authenticatedUserId: F.APPROVER,
+    sessionMfaVerifiedAt: freshMfa(),
+    decision: "approve" as const,
+    expectedVersion: 1,
+    expectedRequestHash: requestHash,
+    expectedActionDigest: actionDigest,
+    reasonCode: null,
+    reason: null,
+    idempotencyKey: "decide-key-0001",
+    ...overrides,
+  };
+}
+
+describe("PR3 approval lifecycle", () => {
+  beforeAll(async () => {
+    process.env.STEWARD_PGLITE_MEMORY = "true";
+    process.env.STEWARD_AUDIT_HMAC_KEY ||= "0".repeat(64);
+    const { db, client } = await createPGLiteDb("memory://");
+    setPGLiteOverride(db, async () => client.close());
+  });
+  afterAll(async () => {
+    await closeDb();
+    delete process.env.STEWARD_PGLITE_MEMORY;
+  });
+  beforeEach(async () => {
+    await wipe();
+    await seedFixture();
+  });
+
+  test("creation: one intent + one binding + one queue row + one requested audit event", async () => {
+    const { intentId } = await createApprovalRequired();
+    const b = await bindingRow(intentId);
+    const q = await queueRow(intentId);
+    const i = await intentRow(intentId);
+    expect(b.status).toBe("pending_approval");
+    expect(b.bindingRevision).toBe(1);
+    expect(b.approvalQueueId).toBe(q.id);
+    expect(b.approvalCommitmentHash).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(q.approvalKind).toBe("provider_action");
+    expect(q.status).toBe("pending");
+    expect(q.expectedBindingRevision).toBe(1);
+    expect(q.approvalCommitmentHash).toBe(b.approvalCommitmentHash);
+    expect(i.status).toBe("pending");
+    // exactly one requested correlated audit event with C1 fields.
+    const events = await correlatedAudit(intentId);
+    expect(events.length).toBe(1);
+    expect(events[0].action).toBe("provider.action.approval_required");
+    expect(events[0].resource_type).toBe("provider_action");
+    expect(events[0].resource_id).toBe(intentId);
+    expect(events[0].intent_meta).toBe(intentId);
+  });
+
+  test("approve: pending_approval -> approved, intent authorized, decided audit", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    const res = await providerApprovalService.decide(
+      decideInput(intentId, requestHash, actionDigest),
+    );
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error("approve failed");
+    expect(res.status).toBe("approved");
+    expect(res.version).toBe(2);
+    const b = await bindingRow(intentId);
+    expect(b.status).toBe("approved");
+    expect(b.bindingRevision).toBe(2);
+    expect(b.approvalActorUserId).toBe(F.APPROVER);
+    expect(b.approvedAt).not.toBeNull();
+    const q = await queueRow(intentId);
+    expect(q.status).toBe("approved");
+    expect(q.resolvedById).toBe(F.APPROVER);
+    const i = await intentRow(intentId);
+    expect(i.status).toBe("authorized");
+    expect(i.authorizedBy).toBe(`user:${F.APPROVER}`);
+    const events = await correlatedAudit(intentId);
+    expect(events.map((e) => e.action)).toEqual([
+      "provider.action.approval_required",
+      "provider.approval.decided",
+    ]);
+  });
+
+  test("deny: pending_approval -> approval_denied, reason required", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    // no reason code => 400
+    const missing = await providerApprovalService.decide(
+      decideInput(intentId, requestHash, actionDigest, { decision: "deny", idempotencyKey: "d1" }),
+    );
+    expect(missing.ok).toBe(false);
+    if (missing.ok) throw new Error("unexpected");
+    expect(missing.code).toBe("APPROVAL_REASON_REQUIRED");
+
+    const res = await providerApprovalService.decide(
+      decideInput(intentId, requestHash, actionDigest, {
+        decision: "deny",
+        reasonCode: "approver_manual_deny",
+        idempotencyKey: "d2",
+      }),
+    );
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error("deny failed");
+    expect(res.status).toBe("approval_denied");
+    const b = await bindingRow(intentId);
+    expect(b.status).toBe("approval_denied");
+    const i = await intentRow(intentId);
+    expect(i.status).toBe("rejected");
+  });
+
+  test("safe resume: approved -> execution_ready, consumes approval once, no execution", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    await providerApprovalService.decide(decideInput(intentId, requestHash, actionDigest));
+    const res = await providerApprovalService.resume({ intentId, tenantId: F.TENANT });
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error("resume failed");
+    expect(res.status).toBe("execution_ready");
+    expect(res.resumeAttemptId).toBeTruthy();
+    const b = await bindingRow(intentId);
+    expect(b.status).toBe("execution_ready");
+    expect(b.resumeActor).toBe("steward-system");
+    expect(b.bindingRevision).toBe(3);
+    const q = await queueRow(intentId);
+    expect(q.status).toBe("consumed");
+    expect(q.consumedBy).toBe("steward-system");
+    const i = await intentRow(intentId);
+    // execution_ready must NOT set executed/executed_at (no third-party execution).
+    expect(i.status).toBe("authorized");
+    expect(i.executedAt).toBeNull();
+    expect(i.executedBy).toBe("steward-system");
+    // resume idempotent: same resumeAttemptId, no new event.
+    const events1 = (await correlatedAudit(intentId)).length;
+    const res2 = await providerApprovalService.resume({ intentId, tenantId: F.TENANT });
+    expect(res2.ok).toBe(true);
+    if (!res2.ok) throw new Error();
+    expect(res2.resumeAttemptId).toBe(res.resumeAttemptId);
+    const events2 = (await correlatedAudit(intentId)).length;
+    expect(events2).toBe(events1);
+  });
+
+  test("resume of a non-approved (pending) action => RESUME_NOT_APPROVED", async () => {
+    const { intentId } = await createApprovalRequired();
+    const res = await providerApprovalService.resume({ intentId, tenantId: F.TENANT });
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error();
+    expect(res.code).toBe("RESUME_NOT_APPROVED");
+  });
+
+  test("expiry: an expired pending action denies with APPROVAL_EXPIRED and persists expired tuple", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    // Force the deadline into the past.
+    await getDb()
+      .update(approvalQueue)
+      .set({ expiresAt: new Date(Date.now() - 1000) })
+      .where(eq(approvalQueue.intentId, intentId));
+    const res = await providerApprovalService.decide(
+      decideInput(intentId, requestHash, actionDigest),
+    );
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error();
+    expect(res.code).toBe("APPROVAL_EXPIRED");
+    const b = await bindingRow(intentId);
+    expect(b.status).toBe("approval_expired");
+    const i = await intentRow(intentId);
+    expect(i.status).toBe("expired");
+  });
+
+  test("terminal: a denied action cannot be re-approved (APPROVAL_ALREADY_DECIDED / TERMINAL)", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    await providerApprovalService.decide(
+      decideInput(intentId, requestHash, actionDigest, {
+        decision: "deny",
+        reasonCode: "approver_manual_deny",
+        idempotencyKey: "deny-terminal",
+      }),
+    );
+    const res = await providerApprovalService.decide(
+      decideInput(intentId, requestHash, actionDigest, {
+        decision: "approve",
+        expectedVersion: 2,
+        idempotencyKey: "approve-after-deny",
+      }),
+    );
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error();
+    expect(res.code).toBe("APPROVAL_ALREADY_DECIDED");
+    // original decision unchanged
+    const b = await bindingRow(intentId);
+    expect(b.status).toBe("approval_denied");
+    expect(b.approvalActorUserId).toBe(F.APPROVER);
+  });
+});

--- a/packages/api/src/__tests__/provider-approval-lifecycle.test.ts
+++ b/packages/api/src/__tests__/provider-approval-lifecycle.test.ts
@@ -27,8 +27,8 @@ import {
   secretRoutes,
   secrets,
   tenants,
-  userTenants,
   users,
+  userTenants,
   workspaces,
 } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";

--- a/packages/api/src/__tests__/provider-approval-negative.test.ts
+++ b/packages/api/src/__tests__/provider-approval-negative.test.ts
@@ -161,6 +161,18 @@ describe("PR3 negative matrix", () => {
     await expectFail(approve(intentId, requestHash, actionDigest), "APPROVAL_ROLE_REQUIRED");
   });
 
+  test("codex P1: an approver binding scoped to a DIFFERENT environment (staging) cannot approve a production action => APPROVAL_ROLE_REQUIRED", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    // The seeded action's workspace is production. Re-scope the approver binding
+    // to staging — it must no longer be eligible.
+    await getDb()
+      .update(providerRoleBindings)
+      .set({ environment: "staging" })
+      .where(eq(providerRoleBindings.id, F.APPROVER_BINDING));
+    await expectFail(approve(intentId, requestHash, actionDigest), "APPROVAL_ROLE_REQUIRED");
+    expect((await bindingRow(intentId)).status).toBe("pending_approval");
+  });
+
   // ── Requester separation (N09, N10) ──
   test("N09/N10: known agent owner attempts decision with separation => APPROVAL_REQUESTER_SEPARATION_REQUIRED", async () => {
     await wipe();

--- a/packages/api/src/__tests__/provider-approval-negative.test.ts
+++ b/packages/api/src/__tests__/provider-approval-negative.test.ts
@@ -15,7 +15,6 @@ import {
   test,
 } from "bun:test";
 import {
-  agents,
   approvalQueue,
   closeDb,
   getDb,
@@ -29,8 +28,8 @@ import {
   secretRoutes,
   secrets,
   tenants,
-  userTenants,
   users,
+  userTenants,
   workspaces,
 } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
@@ -308,10 +307,7 @@ describe("PR3 negative matrix", () => {
 
   test("N31: matched grant revision changes => APPROVAL_GRANT_STALE", async () => {
     const { intentId, requestHash, actionDigest } = await createApprovalRequired();
-    await getDb()
-      .update(providerGrants)
-      .set({ revision: 2 })
-      .where(eq(providerGrants.id, F.GRANT));
+    await getDb().update(providerGrants).set({ revision: 2 }).where(eq(providerGrants.id, F.GRANT));
     await expectFail(approve(intentId, requestHash, actionDigest), "APPROVAL_GRANT_STALE");
   });
 
@@ -383,7 +379,10 @@ describe("PR3 negative matrix", () => {
   test("N44: denial omits reason code => APPROVAL_REASON_REQUIRED", async () => {
     const { intentId, requestHash, actionDigest } = await createApprovalRequired();
     await expectFail(
-      approve(intentId, requestHash, actionDigest, { decision: "deny", idempotencyKey: "no-reason" }),
+      approve(intentId, requestHash, actionDigest, {
+        decision: "deny",
+        idempotencyKey: "no-reason",
+      }),
       "APPROVAL_REASON_REQUIRED",
     );
   });

--- a/packages/api/src/__tests__/provider-approval-negative.test.ts
+++ b/packages/api/src/__tests__/provider-approval-negative.test.ts
@@ -423,6 +423,45 @@ describe("PR3 negative matrix", () => {
     );
   });
 
+  test("codex P2a: exact retry with a decided key AFTER the action transitioned to expired => APPROVAL_EXPIRED, not a stale replay", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    // Approve with key K (records the idem hash + decision on the queue row).
+    await approve(intentId, requestHash, actionDigest, { idempotencyKey: "expiry-replay-K" });
+    // Push the (approved) row past its deadline, then drive the resume path once
+    // so the service TRANSITIONS it to expired (clearing queue.decision but
+    // retaining the idem hash) — this is exactly the state codex flagged.
+    await getDb()
+      .update(approvalQueue)
+      .set({ expiresAt: new Date(Date.now() - 1000) })
+      .where(eq(approvalQueue.intentId, intentId));
+    const exp = await providerApprovalService.resume({ intentId, tenantId: F.TENANT });
+    expect(exp.ok).toBe(false);
+    expect((await bindingRow(intentId)).status).toBe("approval_expired");
+    // Now an EXACT retry of the ORIGINAL decision body + key must surface the
+    // terminal expiry, NOT a stale "approved" replay.
+    await expectFail(
+      approve(intentId, requestHash, actionDigest, { idempotencyKey: "expiry-replay-K" }),
+      "APPROVAL_EXPIRED",
+    );
+  });
+
+  test("codex P2b: same approver reuses a decision key on a DIFFERENT intent => APPROVAL_IDEMPOTENCY_CONFLICT (not 503)", async () => {
+    const a = await createApprovalRequired("aaaaaaaa");
+    const b = await createApprovalRequired("bbbbbbbb");
+    // Approve action A with key K.
+    await approve(a.intentId, a.requestHash, a.actionDigest, { idempotencyKey: "cross-key-K" });
+    // Reuse key K by the SAME approver on action B => precise 409, not a 503.
+    const res = await approve(b.intentId, b.requestHash, b.actionDigest, {
+      idempotencyKey: "cross-key-K",
+    });
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error();
+    expect(res.code).toBe("APPROVAL_IDEMPOTENCY_CONFLICT");
+    expect((res as { httpStatus: number }).httpStatus).toBe(409);
+    // B is untouched.
+    expect((await bindingRow(b.intentId)).status).toBe("pending_approval");
+  });
+
   test("N43: action expired exactly at decision DB time => APPROVAL_EXPIRED, expired tuple", async () => {
     const { intentId, requestHash, actionDigest } = await createApprovalRequired();
     await getDb()

--- a/packages/api/src/__tests__/provider-approval-negative.test.ts
+++ b/packages/api/src/__tests__/provider-approval-negative.test.ts
@@ -1,0 +1,497 @@
+/**
+ * PR3 negative matrix (spec §12, N01-N50) — the cases that map to shipped code
+ * paths, exercised through the real provider-approval service against PGLite.
+ * Each asserts the exact stable code + persisted tuple + zero forbidden side
+ * effects (no secret decrypt / proxy / mint — the service imports none).
+ */
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  setDefaultTimeout,
+  test,
+} from "bun:test";
+import {
+  agents,
+  approvalQueue,
+  closeDb,
+  getDb,
+  intents,
+  providerAccounts,
+  providerActionAuditOutbox,
+  providerActionBindings,
+  providerGrants,
+  providerOperations,
+  providerRoleBindings,
+  secretRoutes,
+  secrets,
+  tenants,
+  userTenants,
+  users,
+  workspaces,
+} from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { eq, sql } from "drizzle-orm";
+import { providerApprovalService } from "../services/provider-approval";
+import {
+  bindingRow,
+  createApprovalRequired,
+  F,
+  freshMfa,
+  queueRow,
+  seedFixture,
+} from "./provider-approval-fixture";
+
+setDefaultTimeout(120_000);
+
+async function wipe() {
+  const db = getDb();
+  for (const t of [
+    providerActionAuditOutbox,
+    approvalQueue,
+    providerActionBindings,
+    intents,
+    providerGrants,
+    providerRoleBindings,
+    providerOperations,
+    providerAccounts,
+    secretRoutes,
+    secrets,
+    workspaces,
+    userTenants,
+    users,
+    tenants,
+  ]) {
+    await db.delete(t);
+  }
+}
+
+function approve(
+  intentId: string,
+  requestHash: string,
+  actionDigest: string,
+  overrides: Partial<Parameters<typeof providerApprovalService.decide>[0]> = {},
+) {
+  return providerApprovalService.decide({
+    intentId,
+    tenantId: F.TENANT,
+    authenticatedUserId: F.APPROVER,
+    sessionMfaVerifiedAt: freshMfa(),
+    decision: "approve",
+    expectedVersion: 1,
+    expectedRequestHash: requestHash,
+    expectedActionDigest: actionDigest,
+    reasonCode: null,
+    reason: null,
+    idempotencyKey: "neg-key-0001",
+    ...overrides,
+  });
+}
+
+async function expectFail(p: Promise<{ ok: boolean } & Record<string, unknown>>, code: string) {
+  const r = await p;
+  expect(r.ok).toBe(false);
+  expect((r as { code: string }).code).toBe(code);
+  return r;
+}
+
+describe("PR3 negative matrix", () => {
+  beforeAll(async () => {
+    process.env.STEWARD_PGLITE_MEMORY = "true";
+    process.env.STEWARD_AUDIT_HMAC_KEY ||= "0".repeat(64);
+    const { db, client } = await createPGLiteDb("memory://");
+    setPGLiteOverride(db, async () => client.close());
+  });
+  afterAll(async () => {
+    await closeDb();
+    delete process.env.STEWARD_PGLITE_MEMORY;
+  });
+  beforeEach(async () => {
+    await wipe();
+    await seedFixture();
+  });
+
+  // ── Approver eligibility (N04, N05, N08) ──
+  test("N04: user with tenant membership but no workspace_approver binding => APPROVAL_ROLE_REQUIRED", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    // APPROVER_2 is an admin member but has NO workspace_approver binding.
+    await expectFail(
+      approve(intentId, requestHash, actionDigest, { authenticatedUserId: F.APPROVER_2 }),
+      "APPROVAL_ROLE_REQUIRED",
+    );
+    const b = await bindingRow(intentId);
+    expect(b.status).toBe("pending_approval");
+  });
+
+  test("N05: workspace_admin-only (no approver binding) => APPROVAL_ROLE_REQUIRED", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    // Give APPROVER_2 a workspace_admin binding — still insufficient.
+    await getDb().insert(providerRoleBindings).values({
+      tenantId: F.TENANT,
+      workspaceId: F.WORKSPACE,
+      principalType: "human",
+      principalId: F.APPROVER_2,
+      roleKey: "workspace_admin",
+      operationKeys: [],
+      environment: "production",
+      status: "active",
+      grantedByUserId: F.GRANTOR,
+      reason: "admin",
+    });
+    await expectFail(
+      approve(intentId, requestHash, actionDigest, { authenticatedUserId: F.APPROVER_2 }),
+      "APPROVAL_ROLE_REQUIRED",
+    );
+  });
+
+  test("N08: membership deleted after session mint => APPROVAL_MEMBERSHIP_INACTIVE", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    await getDb().delete(userTenants).where(eq(userTenants.userId, F.APPROVER));
+    await expectFail(approve(intentId, requestHash, actionDigest), "APPROVAL_MEMBERSHIP_INACTIVE");
+  });
+
+  test("N07: approver binding expired one ms earlier => APPROVAL_ROLE_REQUIRED", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    await getDb()
+      .update(providerRoleBindings)
+      .set({ expiresAt: new Date(Date.now() - 1) })
+      .where(eq(providerRoleBindings.id, F.APPROVER_BINDING));
+    await expectFail(approve(intentId, requestHash, actionDigest), "APPROVAL_ROLE_REQUIRED");
+  });
+
+  // ── Requester separation (N09, N10) ──
+  test("N09/N10: known agent owner attempts decision with separation => APPROVAL_REQUESTER_SEPARATION_REQUIRED", async () => {
+    await wipe();
+    await seedFixture({ requesterSeparation: true });
+    // Give the agent owner an approver binding so only separation blocks them.
+    await getDb().insert(providerRoleBindings).values({
+      tenantId: F.TENANT,
+      workspaceId: F.WORKSPACE,
+      principalType: "human",
+      principalId: F.AGENT_OWNER,
+      roleKey: "workspace_approver",
+      operationKeys: [],
+      environment: "production",
+      status: "active",
+      grantedByUserId: F.GRANTOR,
+      reason: "approver-owner",
+    });
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    await expectFail(
+      approve(intentId, requestHash, actionDigest, { authenticatedUserId: F.AGENT_OWNER }),
+      "APPROVAL_REQUESTER_SEPARATION_REQUIRED",
+    );
+    await expectFail(
+      approve(intentId, requestHash, actionDigest, {
+        authenticatedUserId: F.AGENT_OWNER,
+        decision: "deny",
+        reasonCode: "approver_manual_deny",
+        idempotencyKey: "sep-deny",
+      }),
+      "APPROVAL_REQUESTER_SEPARATION_REQUIRED",
+    );
+  });
+
+  // ── Recent MFA (N11, N12, N13) ──
+  test("N11: MFA absent => APPROVAL_MFA_REQUIRED", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    await expectFail(
+      approve(intentId, requestHash, actionDigest, { sessionMfaVerifiedAt: undefined }),
+      "APPROVAL_MFA_REQUIRED",
+    );
+  });
+
+  test("N12: MFA 5m+1ms old => APPROVAL_MFA_STALE", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    await expectFail(
+      approve(intentId, requestHash, actionDigest, {
+        sessionMfaVerifiedAt: Date.now() - (300_000 + 1),
+      }),
+      "APPROVAL_MFA_STALE",
+    );
+  });
+
+  test("N13: MFA >30s in the future => APPROVAL_MFA_TIMESTAMP_INVALID", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    await expectFail(
+      approve(intentId, requestHash, actionDigest, {
+        sessionMfaVerifiedAt: Date.now() + 120_000,
+      }),
+      "APPROVAL_MFA_TIMESTAMP_INVALID",
+    );
+  });
+
+  // ── Scope / non-enumeration (N17) ──
+  test("N17: foreign/absent action id => SCOPE_RESOURCE_NOT_FOUND", async () => {
+    await expectFail(
+      approve("pa_does-not-exist", `sha256:${"0".repeat(64)}`, `sha256:${"0".repeat(64)}`),
+      "SCOPE_RESOURCE_NOT_FOUND",
+    );
+  });
+
+  // ── Optimistic-lock echoes (N21, N22, N23) ──
+  test("N21: wrong expected binding revision => APPROVAL_EXPECTED_VERSION_MISMATCH", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    await expectFail(
+      approve(intentId, requestHash, actionDigest, { expectedVersion: 99 }),
+      "APPROVAL_EXPECTED_VERSION_MISMATCH",
+    );
+    expect((await bindingRow(intentId)).status).toBe("pending_approval");
+  });
+
+  test("N22: wrong echoed request hash => APPROVAL_REQUEST_HASH_MISMATCH, unchanged", async () => {
+    const { intentId, actionDigest } = await createApprovalRequired();
+    await expectFail(
+      approve(intentId, `sha256:${"b".repeat(64)}`, actionDigest),
+      "APPROVAL_REQUEST_HASH_MISMATCH",
+    );
+    expect((await bindingRow(intentId)).status).toBe("pending_approval");
+  });
+
+  test("N23: wrong echoed action digest => APPROVAL_ACTION_DIGEST_MISMATCH", async () => {
+    const { intentId, requestHash } = await createApprovalRequired();
+    await expectFail(
+      approve(intentId, requestHash, `sha256:${"c".repeat(64)}`),
+      "APPROVAL_ACTION_DIGEST_MISMATCH",
+    );
+  });
+
+  // ── Integrity tampering (N24, N26) ──
+  test("N24: persisted canonical bytes changed after request => stale COMMITMENT_INTEGRITY_MISMATCH", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    // Tamper the stored canonical bytes as an attacker with RAW DB write would.
+    // The PR3 immutability trigger normally freezes this column; disable it for
+    // the tamper so we exercise the SERVICE integrity recomputation (the trigger
+    // is defense-in-depth, the recompute is the authority check).
+    await getDb().execute(
+      sql`ALTER TABLE provider_action_bindings DISABLE TRIGGER provider_action_bindings_immutable`,
+    );
+    await getDb().execute(
+      sql`UPDATE provider_action_bindings SET canonical_action_bytes = '\x7b7d'::bytea WHERE intent_id = ${intentId}`,
+    );
+    await getDb().execute(
+      sql`ALTER TABLE provider_action_bindings ENABLE TRIGGER provider_action_bindings_immutable`,
+    );
+    await expectFail(
+      approve(intentId, requestHash, actionDigest),
+      "APPROVAL_COMMITMENT_INTEGRITY_MISMATCH",
+    );
+    expect((await bindingRow(intentId)).status).toBe("approval_stale");
+  });
+
+  test("N26: queue request hash differs from binding => stale integrity mismatch", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    await getDb()
+      .update(approvalQueue)
+      .set({ requestHash: `sha256:${"d".repeat(64)}` })
+      .where(eq(approvalQueue.intentId, intentId));
+    await expectFail(
+      approve(intentId, requestHash, actionDigest),
+      "APPROVAL_COMMITMENT_INTEGRITY_MISMATCH",
+    );
+    expect((await bindingRow(intentId)).status).toBe("approval_stale");
+  });
+
+  // ── Dependency staleness (N30, N32, N34, N35, N39, N40) ──
+  test("N30: matched grant revoked before approval => APPROVAL_GRANT_STALE", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    await getDb()
+      .update(providerGrants)
+      .set({ status: "revoked" })
+      .where(eq(providerGrants.id, F.GRANT));
+    await expectFail(approve(intentId, requestHash, actionDigest), "APPROVAL_GRANT_STALE");
+    expect((await bindingRow(intentId)).status).toBe("approval_stale");
+  });
+
+  test("N31: matched grant revision changes => APPROVAL_GRANT_STALE", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    await getDb()
+      .update(providerGrants)
+      .set({ revision: 2 })
+      .where(eq(providerGrants.id, F.GRANT));
+    await expectFail(approve(intentId, requestHash, actionDigest), "APPROVAL_GRANT_STALE");
+  });
+
+  test("N34: operation revision changes => APPROVAL_OPERATION_STALE", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    await getDb()
+      .update(providerOperations)
+      .set({ revision: 2 })
+      .where(eq(providerOperations.id, F.OP));
+    await expectFail(approve(intentId, requestHash, actionDigest), "APPROVAL_OPERATION_STALE");
+  });
+
+  test("N35: provider account disabled => APPROVAL_PROVIDER_ACCOUNT_STALE", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    await getDb()
+      .update(providerAccounts)
+      .set({ status: "disabled" })
+      .where(eq(providerAccounts.id, F.ACCOUNT));
+    await expectFail(
+      approve(intentId, requestHash, actionDigest),
+      "APPROVAL_PROVIDER_ACCOUNT_STALE",
+    );
+  });
+
+  test("N39: secret rotates before resume => APPROVAL_CREDENTIAL_STALE at resume", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    await approve(intentId, requestHash, actionDigest);
+    // Rotate the account credential version after approval.
+    await getDb()
+      .update(providerAccounts)
+      .set({ credentialVersion: 2 })
+      .where(eq(providerAccounts.id, F.ACCOUNT));
+    await expectFail(
+      providerApprovalService.resume({ intentId, tenantId: F.TENANT }),
+      "APPROVAL_CREDENTIAL_STALE",
+    );
+    expect((await bindingRow(intentId)).status).toBe("approval_stale");
+  });
+
+  test("N40: route revision changes before resume => APPROVAL_ROUTE_STALE at resume", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    await approve(intentId, requestHash, actionDigest);
+    // A route mutation bumps authority_revision via the 0081 trigger.
+    await getDb()
+      .update(secretRoutes)
+      .set({ pathPattern: "/changed" })
+      .where(eq(secretRoutes.id, F.ROUTE));
+    await expectFail(
+      providerApprovalService.resume({ intentId, tenantId: F.TENANT }),
+      "APPROVAL_ROUTE_STALE",
+    );
+  });
+
+  test("N41/N42: approver loses role after approval => APPROVAL_APPROVER_STALE at resume", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    await approve(intentId, requestHash, actionDigest);
+    await getDb()
+      .update(providerRoleBindings)
+      .set({ status: "revoked" })
+      .where(eq(providerRoleBindings.id, F.APPROVER_BINDING));
+    await expectFail(
+      providerApprovalService.resume({ intentId, tenantId: F.TENANT }),
+      "APPROVAL_APPROVER_STALE",
+    );
+    expect((await bindingRow(intentId)).status).toBe("approval_stale");
+  });
+
+  // ── Decision terminal / idempotency (N44, N45, N46, N47) ──
+  test("N44: denial omits reason code => APPROVAL_REASON_REQUIRED", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    await expectFail(
+      approve(intentId, requestHash, actionDigest, { decision: "deny", idempotencyKey: "no-reason" }),
+      "APPROVAL_REASON_REQUIRED",
+    );
+  });
+
+  test("N45: opposite decision after approved => APPROVAL_ALREADY_DECIDED; original unchanged", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    await approve(intentId, requestHash, actionDigest, { idempotencyKey: "first-approve" });
+    await expectFail(
+      approve(intentId, requestHash, actionDigest, {
+        decision: "deny",
+        reasonCode: "approver_manual_deny",
+        expectedVersion: 2,
+        idempotencyKey: "second-deny",
+      }),
+      "APPROVAL_ALREADY_DECIDED",
+    );
+    const b = await bindingRow(intentId);
+    expect(b.status).toBe("approved");
+    expect(b.approvalActorUserId).toBe(F.APPROVER);
+  });
+
+  test("N47: reuse decision idempotency key with changed decision => APPROVAL_IDEMPOTENCY_CONFLICT", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    // First decision denies with key K.
+    await approve(intentId, requestHash, actionDigest, {
+      decision: "deny",
+      reasonCode: "approver_manual_deny",
+      idempotencyKey: "shared-key-K",
+    });
+    // Reuse key K by the same user with a DIFFERENT decision body.
+    await expectFail(
+      approve(intentId, requestHash, actionDigest, {
+        decision: "approve",
+        expectedVersion: 2,
+        idempotencyKey: "shared-key-K",
+      }),
+      "APPROVAL_IDEMPOTENCY_CONFLICT",
+    );
+  });
+
+  test("N43: action expired exactly at decision DB time => APPROVAL_EXPIRED, expired tuple", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    await getDb()
+      .update(approvalQueue)
+      .set({ expiresAt: new Date(Date.now() - 5) })
+      .where(eq(approvalQueue.intentId, intentId));
+    await expectFail(approve(intentId, requestHash, actionDigest), "APPROVAL_EXPIRED");
+    expect((await bindingRow(intentId)).status).toBe("approval_expired");
+  });
+
+  test("N20-equivalent: approving an allow (non-approval) action => APPROVAL_NOT_REQUIRED", async () => {
+    // Reconfigure the op to allow-only, create an allow action, then attempt to
+    // approve it through the approval endpoint.
+    await getDb()
+      .update(providerOperations)
+      .set({
+        requestProfile: {
+          policyRules: [
+            {
+              id: "11111111-1111-4111-8111-111111111111",
+              type: "capability-intent",
+              enabled: true,
+              config: { capabilities: [F.OP_KEY], effect: "allow" },
+            },
+          ],
+        },
+      })
+      .where(eq(providerOperations.id, F.OP));
+    const { providerActionService } = await import("../services/provider-action-service");
+    const { buildGithubAction } = await import("@stwd/provider-github");
+    const now = new Date();
+    const out = await providerActionService.createProviderAction({
+      principal: (await import("./provider-approval-fixture")).principal(),
+      workspaceId: F.WORKSPACE,
+      providerAccountId: F.ACCOUNT,
+      operationKey: F.OP_KEY,
+      build: buildGithubAction(F.OP_KEY, { owner: "o", repo: "r", pullNumber: 1, body: "x" }),
+      idempotencyKeyHash: `sha256:${"e".repeat(64)}`,
+      requestedAt: now.toISOString(),
+      expiresAt: new Date(now.getTime() + 300_000).toISOString(),
+      nonce: "Z".repeat(32),
+      requestId: null,
+    });
+    expect(out.kind).toBe("allowed");
+    if (out.kind !== "allowed") throw new Error();
+    await expectFail(
+      approve(out.intentId, out.requestHash, out.actionDigest),
+      "APPROVAL_NOT_REQUIRED",
+    );
+  });
+
+  // ── Positive isolation: Client B change does NOT stale Client A (I6) ──
+  test("isolation: an unrelated workspace-2 grant/op change does NOT stale the action", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    // Add an unrelated account+op+grant in WORKSPACE_2 and mutate it.
+    const acc2 = "31000000-0000-4000-8000-000000000009";
+    await getDb().insert(providerAccounts).values({
+      id: acc2,
+      tenantId: F.TENANT,
+      workspaceId: F.WORKSPACE_2,
+      adapterKey: "github",
+      externalRef: "w2",
+      displayName: "W2",
+    });
+    // Approve A — unrelated B mutations must not stale it.
+    const r = await approve(intentId, requestHash, actionDigest);
+    expect(r.ok).toBe(true);
+    expect((await bindingRow(intentId)).status).toBe("approved");
+    void queueRow;
+  });
+});

--- a/packages/api/src/__tests__/provider-approval-negative.test.ts
+++ b/packages/api/src/__tests__/provider-approval-negative.test.ts
@@ -332,6 +332,15 @@ describe("PR3 negative matrix", () => {
     await expectFail(approve(intentId, requestHash, actionDigest), "APPROVAL_OPERATION_STALE");
   });
 
+  test("codex P1: workspace authority revision bumped (still active) => APPROVAL_DEPENDENCY_STALE", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    // Bump the workspace revision while it stays active; the committed access
+    // decision recorded the original revision, so this must stale the action.
+    await getDb().update(workspaces).set({ revision: 99 }).where(eq(workspaces.id, F.WORKSPACE));
+    await expectFail(approve(intentId, requestHash, actionDigest), "APPROVAL_DEPENDENCY_STALE");
+    expect((await bindingRow(intentId)).status).toBe("approval_stale");
+  });
+
   test("N35: provider account disabled => APPROVAL_PROVIDER_ACCOUNT_STALE", async () => {
     const { intentId, requestHash, actionDigest } = await createApprovalRequired();
     await getDb()
@@ -523,6 +532,37 @@ describe("PR3 negative matrix", () => {
       approve(out.intentId, out.requestHash, out.actionDigest),
       "APPROVAL_NOT_REQUIRED",
     );
+  });
+
+  test("codex P1: create-replay of a governed action AFTER it was approved reports 202 APPROVAL_REQUIRED, never POLICY_ALLOW", async () => {
+    const { providerActionService } = await import("../services/provider-action-service");
+    const { buildGithubAction } = await import("@stwd/provider-github");
+    const { principal } = await import("./provider-approval-fixture");
+    const now = new Date();
+    const createInput = {
+      principal: principal(),
+      workspaceId: F.WORKSPACE,
+      providerAccountId: F.ACCOUNT,
+      operationKey: F.OP_KEY,
+      build: buildGithubAction(F.OP_KEY, { owner: "o", repo: "r", pullNumber: 1, body: "x" }),
+      idempotencyKeyHash: `sha256:${"9".repeat(64)}`,
+      requestedAt: now.toISOString(),
+      expiresAt: new Date(now.getTime() + 300_000).toISOString(),
+      nonce: "Y".repeat(32),
+      requestId: null,
+    };
+    const first = await providerActionService.createProviderAction(createInput);
+    expect(first.kind).toBe("approval_required");
+    if (first.kind !== "approval_required") throw new Error();
+    // Approve it out-of-band.
+    await approve(first.intentId, first.requestHash, first.actionDigest, {
+      idempotencyKey: "replay-approve-key",
+    });
+    expect((await bindingRow(first.intentId)).status).toBe("approved");
+    // A create-replay with the same idem key must still report 202, NOT allow.
+    const replay = await providerActionService.createProviderAction(createInput);
+    expect(replay.kind).toBe("approval_required");
+    expect((replay as { code: string }).code).toBe("APPROVAL_REQUIRED");
   });
 
   // ── Positive isolation: Client B change does NOT stale Client A (I6) ──

--- a/packages/api/src/__tests__/provider-approval-route.test.ts
+++ b/packages/api/src/__tests__/provider-approval-route.test.ts
@@ -1,0 +1,212 @@
+/**
+ * PR3 approval + execute HTTP route tests (PGLite + fully composed app).
+ * Proves the §9 route contract: human-session gating, MFA gating, unknown-field
+ * + resume-actor-substitution rejection, and the exact happy-path status codes.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { closeDb } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { signAccessToken } from "@stwd/auth";
+import type { Hono } from "hono";
+import type { AppVariables } from "../services/context";
+import {
+  bindingRow,
+  createApprovalRequired,
+  F,
+  freshMfa,
+  seedFixture,
+} from "./provider-approval-fixture";
+
+setDefaultTimeout(120_000);
+
+let app: Hono<{ Variables: AppVariables }>;
+
+async function wipeAndSeed() {
+  const {
+    getDb,
+    approvalQueue,
+    intents,
+    providerAccounts,
+    providerActionAuditOutbox,
+    providerActionBindings,
+    providerGrants,
+    providerOperations,
+    providerRoleBindings,
+    secretRoutes,
+    secrets,
+    tenants,
+    userTenants,
+    users,
+    workspaces,
+  } = await import("@stwd/db");
+  const db = getDb();
+  for (const t of [
+    providerActionAuditOutbox,
+    approvalQueue,
+    providerActionBindings,
+    intents,
+    providerGrants,
+    providerRoleBindings,
+    providerOperations,
+    providerAccounts,
+    secretRoutes,
+    secrets,
+    workspaces,
+    userTenants,
+    users,
+    tenants,
+  ]) {
+    await db.delete(t);
+  }
+  await seedFixture();
+}
+
+async function humanToken(userId: string, mfaVerifiedAt: number | null = freshMfa()) {
+  const payload: Record<string, unknown> = {
+    address: `0xuser-${userId.slice(0, 6)}`,
+    tenantId: F.TENANT,
+    userId,
+  };
+  if (mfaVerifiedAt !== null) payload.mfaVerifiedAt = mfaVerifiedAt;
+  return signAccessToken(payload as never, "10m");
+}
+
+async function agentToken() {
+  const { signAgentToken } = await import("@stwd/auth");
+  return signAgentToken({ agentId: F.AGENT, tenantId: F.TENANT, scopes: [] }, "10m");
+}
+
+function decideReq(intentId: string, token: string, body: unknown) {
+  return app.request(`/v2/provider-actions/${intentId}/approval`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+      "x-steward-tenant": F.TENANT,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("PR3 approval + execute routes", () => {
+  beforeAll(async () => {
+    process.env.STEWARD_PGLITE_MEMORY = "true";
+    process.env.STEWARD_AUDIT_HMAC_KEY ||= "0".repeat(64);
+    const { db, client } = await createPGLiteDb("memory://");
+    setPGLiteOverride(db, async () => client.close());
+    const mod = await import("../app");
+    app = mod.app as Hono<{ Variables: AppVariables }>;
+  });
+  afterAll(async () => {
+    await closeDb();
+    delete process.env.STEWARD_PGLITE_MEMORY;
+  });
+  beforeEach(async () => {
+    await wipeAndSeed();
+  });
+
+  test("N01: agent token calls approval decision => 403 APPROVAL_HUMAN_SESSION_REQUIRED, pending unchanged", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    const res = await decideReq(intentId, await agentToken(), {
+      decision: "approve",
+      expectedVersion: 1,
+      expectedRequestHash: requestHash,
+      expectedActionDigest: actionDigest,
+      idempotencyKey: "route-agent-key",
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("APPROVAL_HUMAN_SESSION_REQUIRED");
+    expect((await bindingRow(intentId)).status).toBe("pending_approval");
+  });
+
+  test("N15: body supplies an unknown field => 400 APPROVAL_UNKNOWN_FIELD, caller value never stored", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    const res = await decideReq(intentId, await humanToken(F.APPROVER), {
+      decision: "approve",
+      expectedVersion: 1,
+      expectedRequestHash: requestHash,
+      expectedActionDigest: actionDigest,
+      idempotencyKey: "route-unknown-key",
+      approvedBy: "attacker",
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("APPROVAL_UNKNOWN_FIELD");
+    expect((await bindingRow(intentId)).status).toBe("pending_approval");
+  });
+
+  test("N16: execute body supplies an actor/action field => 400 RESUME_ACTOR_SUBSTITUTION_FORBIDDEN", async () => {
+    const { intentId } = await createApprovalRequired();
+    const res = await app.request(`/v2/provider-actions/${intentId}/execute`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${await humanToken(F.APPROVER)}`,
+        "content-type": "application/json",
+        "x-steward-tenant": F.TENANT,
+      },
+      body: JSON.stringify({ resumeActor: "attacker", account: "x" }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("RESUME_ACTOR_SUBSTITUTION_FORBIDDEN");
+  });
+
+  test("happy path: human approver approves (200), then execute resumes (200 execution_ready)", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    const token = await humanToken(F.APPROVER);
+    const approveRes = await decideReq(intentId, token, {
+      decision: "approve",
+      expectedVersion: 1,
+      expectedRequestHash: requestHash,
+      expectedActionDigest: actionDigest,
+      idempotencyKey: "route-happy-approve",
+    });
+    expect(approveRes.status).toBe(200);
+    const approveBody = (await approveRes.json()) as { status: string; version: number };
+    expect(approveBody.status).toBe("approved");
+    expect(approveBody.version).toBe(2);
+
+    const execRes = await app.request(`/v2/provider-actions/${intentId}/execute`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "x-steward-tenant": F.TENANT,
+      },
+    });
+    expect(execRes.status).toBe(200);
+    const execBody = (await execRes.json()) as { status: string; resumeAttemptId: string };
+    expect(execBody.status).toBe("execution_ready");
+    expect(execBody.resumeAttemptId).toBeTruthy();
+  });
+
+  test("GET approval requires recent MFA => 403 APPROVAL_MFA_REQUIRED when MFA missing", async () => {
+    const { intentId } = await createApprovalRequired();
+    const res = await app.request(`/v2/provider-actions/${intentId}/approval`, {
+      method: "GET",
+      headers: {
+        authorization: `Bearer ${await humanToken(F.APPROVER, null)}`,
+        "x-steward-tenant": F.TENANT,
+      },
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("APPROVAL_MFA_REQUIRED");
+  });
+
+  test("GET approval returns safe summary to an eligible approver", async () => {
+    const { intentId } = await createApprovalRequired();
+    const res = await app.request(`/v2/provider-actions/${intentId}/approval`, {
+      method: "GET",
+      headers: {
+        authorization: `Bearer ${await humanToken(F.APPROVER)}`,
+        "x-steward-tenant": F.TENANT,
+      },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { status: string; safeSummary: unknown } };
+    expect(body.data.status).toBe("pending_approval");
+    expect(body.data.safeSummary).toBeDefined();
+  });
+});

--- a/packages/api/src/__tests__/provider-approval-route.test.ts
+++ b/packages/api/src/__tests__/provider-approval-route.test.ts
@@ -4,10 +4,18 @@
  * + resume-actor-substitution rejection, and the exact happy-path status codes.
  */
 
-import { afterAll, beforeAll, beforeEach, describe, expect, setDefaultTimeout, test } from "bun:test";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  setDefaultTimeout,
+  test,
+} from "bun:test";
+import { signAccessToken } from "@stwd/auth";
 import { closeDb } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
-import { signAccessToken } from "@stwd/auth";
 import type { Hono } from "hono";
 import type { AppVariables } from "../services/context";
 import {

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -59,6 +59,7 @@ import { intentRoutes } from "./routes/intents";
 import { platformRoutes } from "./routes/platform";
 import { policiesStandaloneRoutes } from "./routes/policies-standalone";
 import { registerProviderActionRoutes } from "./routes/provider-actions";
+import { registerProviderApprovalRoutes } from "./routes/provider-approvals";
 import { providerAuthorityRoutes } from "./routes/provider-authority";
 import { secretsRoutes } from "./routes/secrets";
 import { tenantConfigRoutes } from "./routes/tenant-config";
@@ -252,6 +253,9 @@ export function mountCoreIdempotencyAndRoutes(
   // middleware directly on the app (see registerProviderActionRoutes) to avoid a
   // second `/v2` sub-app mount colliding with the authority wildcard.
   registerProviderActionRoutes(app);
+  // PR3 approval + safe-resume routes (also registered directly to avoid the
+  // /v2 authority-wildcard collision).
+  registerProviderApprovalRoutes(app);
 
   app.route("/condition-sets", conditionSetRoutes);
   app.route("/condition_sets", conditionSetRoutes);

--- a/packages/api/src/routes/intents.ts
+++ b/packages/api/src/routes/intents.ts
@@ -1661,6 +1661,22 @@ async function updateIntentStatus(
     .where(and(eq(intents.id, intentId), eq(intents.tenantId, tenantId)));
   if (!existing) return c.json<ApiResponse>({ ok: false, error: "Intent not found" }, 404);
 
+  // PR3 (N50, I1/I4/I12): a governed provider-action intent's lifecycle is owned
+  // exclusively by the provider approval service + its companion binding/queue.
+  // The generic intent status endpoint MUST NOT set authorized/executed/etc on a
+  // provider action (that would bypass the exact approval + safe-resume state
+  // machine). Reject before any status change.
+  if (existing.intentType === "provider-action") {
+    return c.json<ApiResponse>(
+      {
+        ok: false,
+        error:
+          "Provider-action intents transition only through /v2/provider-actions approval + execute",
+      },
+      409,
+    );
+  }
+
   if (
     status === "authorized" ||
     status === "rejected" ||

--- a/packages/api/src/routes/provider-approvals.ts
+++ b/packages/api/src/routes/provider-approvals.ts
@@ -14,13 +14,8 @@
  * with the provider-authority wildcard.
  */
 
-import {
-  decodeUtf8Strict,
-  isApprovalReasonCode,
-  strictParseJson,
-} from "@stwd/shared";
-import type { Context } from "hono";
-import type { Hono } from "hono";
+import { decodeUtf8Strict, isApprovalReasonCode, strictParseJson } from "@stwd/shared";
+import type { Context, Hono } from "hono";
 import { type AppVariables, setNoStoreHeaders, tenantAuth } from "../services/context";
 import { providerApprovalService } from "../services/provider-approval";
 
@@ -265,10 +260,7 @@ async function handlePostExecute(c: RouteContext) {
  * requirement where the spec demands it.
  */
 export function registerProviderApprovalRoutes(app: Hono<{ Variables: AppVariables }>): void {
-  const paths = [
-    "/v2/provider-actions/:id/approval",
-    "/v2/provider-actions/:id/execute",
-  ];
+  const paths = ["/v2/provider-actions/:id/approval", "/v2/provider-actions/:id/execute"];
   for (const p of paths) {
     app.use(p, async (c, next) => {
       setNoStoreHeaders(c);

--- a/packages/api/src/routes/provider-approvals.ts
+++ b/packages/api/src/routes/provider-approvals.ts
@@ -1,0 +1,285 @@
+/**
+ * provider-approvals.ts — PR3 human approval + safe-resume HTTP surface (spec §9).
+ *
+ *   GET  /v2/provider-actions/:id/approval  — eligible workspace approver + MFA
+ *   POST /v2/provider-actions/:id/approval  — approve/deny decision
+ *   POST /v2/provider-actions/:id/execute   — request typed system resume
+ *
+ * Authority comes ONLY from persisted state + the service's current-authority
+ * revalidation. The route never supplies actor/action/resource fields to the
+ * service; the resume actor is always the in-process `steward-system` identity.
+ *
+ * These handlers are registered directly on the composed app (like
+ * registerProviderActionRoutes) to avoid a second `/v2` sub-app mount colliding
+ * with the provider-authority wildcard.
+ */
+
+import {
+  decodeUtf8Strict,
+  isApprovalReasonCode,
+  strictParseJson,
+} from "@stwd/shared";
+import type { Context } from "hono";
+import type { Hono } from "hono";
+import { type AppVariables, setNoStoreHeaders, tenantAuth } from "../services/context";
+import { providerApprovalService } from "../services/provider-approval";
+
+type RouteContext = Context<{ Variables: AppVariables }>;
+
+const MAX_REQUEST_BYTES = 64 * 1024;
+const ALLOWED_MEDIA = new Set(["application/json", "application/json; charset=utf-8"]);
+const IDEM_KEY_RE = /^[\x21-\x7e]{8,255}$/;
+const MAX_REASON_LEN = 1000;
+
+const DECIDE_KEYS = new Set([
+  "decision",
+  "expectedVersion",
+  "expectedRequestHash",
+  "expectedActionDigest",
+  "reasonCode",
+  "reason",
+  "idempotencyKey",
+]);
+
+function err(c: RouteContext, code: string, status: number) {
+  // Spec §9 structured error body. `ApiResponse.error` is a string, so we return a
+  // bespoke shape here (never echo dependency IDs on scope failures).
+  return c.json(
+    {
+      ok: false as const,
+      error: { code, message: safeMessage(code), requestId: c.get("requestId") ?? null },
+    },
+    status as never,
+  );
+}
+
+function safeMessage(code: string): string {
+  // Safe, non-enumerating messages. Never echo dependency IDs.
+  switch (code) {
+    case "SCOPE_RESOURCE_NOT_FOUND":
+      return "resource not found";
+    case "APPROVAL_HUMAN_SESSION_REQUIRED":
+      return "a verified human session is required";
+    default:
+      return code.toLowerCase().replace(/_/g, " ");
+  }
+}
+
+/** Human-session gate (spec §3.2 items 1-3). Agent tokens/API keys are rejected. */
+function requireHumanSession(
+  c: RouteContext,
+): { ok: true; userId: string; tenantId: string } | { ok: false } {
+  const authType = c.get("authType");
+  const userId = c.get("userId");
+  const tenantId = c.get("tenantId");
+  if (
+    (authType === "session-jwt" || authType === "dashboard-jwt") &&
+    typeof userId === "string" &&
+    userId.length > 0 &&
+    typeof tenantId === "string" &&
+    tenantId.length > 0
+  ) {
+    return { ok: true, userId, tenantId };
+  }
+  return { ok: false };
+}
+
+// ─── Handlers ─────────────────────────────────────────────────────────────────
+
+async function handleGetApproval(c: RouteContext) {
+  const human = requireHumanSession(c);
+  if (!human.ok) return err(c, "APPROVAL_HUMAN_SESSION_REQUIRED", 403);
+  const intentId = c.req.param("id");
+  if (!intentId) return err(c, "SCOPE_RESOURCE_NOT_FOUND", 404);
+
+  // MFA gate — even safe summaries are sensitive (spec §9.1).
+  const mfa = c.get("sessionMfaVerifiedAt");
+  if (typeof mfa !== "number" || !Number.isFinite(mfa)) {
+    return err(c, "APPROVAL_MFA_REQUIRED", 403);
+  }
+  if (Date.now() - mfa > 300_000) return err(c, "APPROVAL_MFA_STALE", 403);
+
+  // Eligibility (exact workspace approver) is enforced by the service via a
+  // detail-load that first checks the caller is an eligible approver. For the
+  // GET we require the same eligibility as a decision would, so reuse the
+  // service's approver check by attempting a no-op eligibility probe.
+  const eligible = await providerApprovalService.getApprovalDetailForApprover(
+    human.tenantId,
+    intentId,
+    human.userId,
+    mfa,
+  );
+  if (!eligible.ok) return err(c, eligible.code, eligible.httpStatus);
+  return c.json({ ok: true, data: eligible.data }, 200);
+}
+
+async function handlePostApproval(c: RouteContext) {
+  const human = requireHumanSession(c);
+  if (!human.ok) return err(c, "APPROVAL_HUMAN_SESSION_REQUIRED", 403);
+  const intentId = c.req.param("id");
+  if (!intentId) return err(c, "SCOPE_RESOURCE_NOT_FOUND", 404);
+
+  const contentType = (c.req.header("content-type") ?? "").trim().toLowerCase();
+  if (!ALLOWED_MEDIA.has(contentType)) return err(c, "APPROVAL_FIELD_INVALID", 400);
+
+  let bytes: Uint8Array;
+  try {
+    const buf = await c.req.raw.clone().arrayBuffer();
+    if (buf.byteLength > MAX_REQUEST_BYTES) return err(c, "APPROVAL_FIELD_INVALID", 400);
+    bytes = new Uint8Array(buf);
+  } catch {
+    return err(c, "APPROVAL_FIELD_INVALID", 400);
+  }
+  let parsed: unknown;
+  try {
+    parsed = strictParseJson(decodeUtf8Strict(bytes));
+  } catch {
+    return err(c, "APPROVAL_FIELD_INVALID", 400);
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return err(c, "APPROVAL_FIELD_INVALID", 400);
+  }
+  const body = parsed as Record<string, unknown>;
+  for (const key of Object.keys(body)) {
+    if (!DECIDE_KEYS.has(key)) return err(c, "APPROVAL_UNKNOWN_FIELD", 400);
+  }
+
+  const decision = body.decision;
+  if (decision !== "approve" && decision !== "deny") return err(c, "APPROVAL_FIELD_INVALID", 400);
+  const expectedVersion = body.expectedVersion;
+  if (typeof expectedVersion !== "number" || !Number.isInteger(expectedVersion)) {
+    return err(c, "APPROVAL_FIELD_INVALID", 400);
+  }
+  const expectedRequestHash = body.expectedRequestHash;
+  const expectedActionDigest = body.expectedActionDigest;
+  if (
+    typeof expectedRequestHash !== "string" ||
+    !/^sha256:[0-9a-f]{64}$/.test(expectedRequestHash) ||
+    typeof expectedActionDigest !== "string" ||
+    !/^sha256:[0-9a-f]{64}$/.test(expectedActionDigest)
+  ) {
+    return err(c, "APPROVAL_FIELD_INVALID", 400);
+  }
+  const idempotencyKey = body.idempotencyKey;
+  if (typeof idempotencyKey !== "string" || !IDEM_KEY_RE.test(idempotencyKey)) {
+    return err(c, "APPROVAL_FIELD_INVALID", 400);
+  }
+  let reasonCode: string | null = null;
+  if (body.reasonCode !== undefined) {
+    if (!isApprovalReasonCode(body.reasonCode)) return err(c, "APPROVAL_FIELD_INVALID", 400);
+    reasonCode = body.reasonCode;
+  }
+  let reason: string | null = null;
+  if (body.reason !== undefined) {
+    if (typeof body.reason !== "string" || [...body.reason].length > MAX_REASON_LEN) {
+      return err(c, "APPROVAL_FIELD_INVALID", 400);
+    }
+    reason = body.reason;
+  }
+
+  const result = await providerApprovalService.decide({
+    intentId,
+    tenantId: human.tenantId,
+    authenticatedUserId: human.userId,
+    sessionMfaVerifiedAt: c.get("sessionMfaVerifiedAt"),
+    decision,
+    expectedVersion,
+    expectedRequestHash,
+    expectedActionDigest,
+    reasonCode,
+    reason,
+    idempotencyKey,
+    ipAddress: c.req.header("x-forwarded-for") ?? null,
+    userAgent: c.req.header("user-agent") ?? null,
+    requestId: c.get("requestId") ?? null,
+  });
+
+  if (!result.ok) return err(c, result.code, result.httpStatus);
+  return c.json(
+    {
+      id: result.id,
+      status: result.status,
+      version: result.version,
+      requestHash: result.requestHash,
+      actionDigest: result.actionDigest,
+      ...(result.replayed ? { replayed: true } : {}),
+    },
+    result.httpStatus,
+  );
+}
+
+async function handlePostExecute(c: RouteContext) {
+  const tenantId = c.get("tenantId");
+  if (typeof tenantId !== "string" || tenantId.length === 0) {
+    return err(c, "APPROVAL_HUMAN_SESSION_REQUIRED", 403);
+  }
+  const intentId = c.req.param("id");
+  if (!intentId) return err(c, "SCOPE_RESOURCE_NOT_FOUND", 404);
+
+  // Reject any body that supplies actor/action fields (I4 / RESUME_ACTOR_SUBSTITUTION).
+  const contentType = (c.req.header("content-type") ?? "").trim().toLowerCase();
+  if (contentType && ALLOWED_MEDIA.has(contentType)) {
+    try {
+      const buf = await c.req.raw.clone().arrayBuffer();
+      if (buf.byteLength > 0) {
+        const parsed = strictParseJson(decodeUtf8Strict(new Uint8Array(buf)));
+        if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+          for (const key of Object.keys(parsed as Record<string, unknown>)) {
+            if (key !== "idempotencyKey") {
+              return err(c, "RESUME_ACTOR_SUBSTITUTION_FORBIDDEN", 400);
+            }
+          }
+        }
+      }
+    } catch {
+      return err(c, "RESUME_ACTOR_SUBSTITUTION_FORBIDDEN", 400);
+    }
+  }
+
+  const result = await providerApprovalService.resume({
+    intentId,
+    tenantId,
+    ipAddress: c.req.header("x-forwarded-for") ?? null,
+    userAgent: c.req.header("user-agent") ?? null,
+    requestId: c.get("requestId") ?? null,
+  });
+
+  if (!result.ok) return err(c, result.code, result.httpStatus);
+  return c.json(
+    {
+      id: result.id,
+      status: result.status,
+      version: result.version,
+      requestHash: result.requestHash,
+      actionDigest: result.actionDigest,
+      ...(result.resumeAttemptId ? { resumeAttemptId: result.resumeAttemptId } : {}),
+    },
+    result.httpStatus,
+  );
+}
+
+/**
+ * Register the PR3 approval + execute routes directly on the composed app.
+ * `tenantAuth` populates authType/userId/tenantId/sessionMfaVerifiedAt for both
+ * human sessions and agent tokens; the handlers enforce the human-session
+ * requirement where the spec demands it.
+ */
+export function registerProviderApprovalRoutes(app: Hono<{ Variables: AppVariables }>): void {
+  const paths = [
+    "/v2/provider-actions/:id/approval",
+    "/v2/provider-actions/:id/execute",
+  ];
+  for (const p of paths) {
+    app.use(p, async (c, next) => {
+      setNoStoreHeaders(c);
+      await next();
+    });
+    app.use(p, (c, next) => tenantAuth(c, next));
+  }
+  app.get("/v2/provider-actions/:id/approval", handleGetApproval);
+  app.post("/v2/provider-actions/:id/approval", handlePostApproval);
+  app.post("/v2/provider-actions/:id/execute", handlePostExecute);
+}
+
+// Test/mount surface: a standalone sub-app for isolated unit tests.
+export const providerApprovalRoutes = { registerProviderApprovalRoutes };

--- a/packages/api/src/services/provider-action-service.ts
+++ b/packages/api/src/services/provider-action-service.ts
@@ -53,7 +53,7 @@ import {
 } from "@stwd/shared";
 import { and, eq, sql } from "drizzle-orm";
 import type { ProviderPrincipalV1 } from "../middleware/provider-principal";
-import { writeAuditEvent } from "./audit";
+import { appendAuditEvent, withTenantAuditQueue, writeAuditEvent } from "./audit";
 import { ApprovalArmError, buildApprovalArm } from "./provider-approval";
 
 const EVALUATOR_VERSION = "provider-action.v1";
@@ -1018,11 +1018,42 @@ class ProviderActionService {
       );
     let delivered = 0;
     for (const row of rows) {
-      // Guarded claim: only deliver rows still undelivered. A concurrent sweeper
-      // that already delivered this row leaves delivered_at set; the signed
-      // append below is only reached after a successful CAS on delivered_at, so
-      // no row is signed twice.
-      const claimed = await this.db()
+      // Crash-safe exactly-once (codex P1). The SOURCE OF TRUTH for "is this
+      // event signed?" is the audit chain itself, keyed by the deterministic
+      // correlation (tenant, resource_id=intentId, action). `delivered_at` is
+      // only an optimization. We serialize the whole check+sign+mark per tenant
+      // (same queue writeAuditEvent uses) so two in-process sweeps cannot both
+      // sign, and if a prior sweep crashed AFTER signing but BEFORE marking, this
+      // sweep observes the existing signed event and just marks the row — never
+      // a duplicate, never a permanently-unsigned intent.
+      const signedNow = await withTenantAuditQueue(row.tenantId, async () => {
+        const existing = await this.db().execute(
+          sql`SELECT 1 FROM audit_events
+              WHERE tenant_id = ${row.tenantId}
+                AND resource_type = ${row.resourceType}
+                AND resource_id = ${row.resourceId}
+                AND action = ${row.action}
+              LIMIT 1`,
+        );
+        const existingRows = Array.isArray(existing)
+          ? existing
+          : ((existing as { rows?: unknown[] }).rows ?? []);
+        if (existingRows.length === 0) {
+          await appendAuditEvent({
+            tenantId: row.tenantId,
+            actorType: "agent",
+            actorId: (row.metadata as { actorAgentId?: string }).actorAgentId ?? null,
+            action: row.action,
+            resourceType: row.resourceType,
+            resourceId: row.resourceId,
+            metadata: row.metadata as Record<string, unknown>,
+          });
+          return true;
+        }
+        return false;
+      });
+      // Mark delivered whether we just signed it or found it already signed.
+      const marked = await this.db()
         .update(providerActionAuditOutbox)
         .set({ deliveredAt: new Date() })
         .where(
@@ -1032,27 +1063,7 @@ class ProviderActionService {
           ),
         )
         .returning({ id: providerActionAuditOutbox.id });
-      if (claimed.length === 0) continue; // another pass won the row
-      try {
-        await writeAuditEvent({
-          tenantId: row.tenantId,
-          actorType: "agent",
-          actorId: (row.metadata as { actorAgentId?: string }).actorAgentId ?? null,
-          action: row.action,
-          resourceType: row.resourceType,
-          resourceId: row.resourceId,
-          metadata: row.metadata as Record<string, unknown>,
-        });
-        delivered += 1;
-      } catch (err) {
-        // Signing failed AFTER we claimed the row: release the claim so a later
-        // pass retries (the event must never be silently dropped).
-        await this.db()
-          .update(providerActionAuditOutbox)
-          .set({ deliveredAt: null })
-          .where(eq(providerActionAuditOutbox.id, row.id));
-        throw err;
-      }
+      if (marked.length > 0 && signedNow) delivered += 1;
     }
     return delivered;
   }

--- a/packages/api/src/services/provider-action-service.ts
+++ b/packages/api/src/services/provider-action-service.ts
@@ -54,6 +54,7 @@ import {
 import { and, eq, sql } from "drizzle-orm";
 import type { ProviderPrincipalV1 } from "../middleware/provider-principal";
 import { writeAuditEvent } from "./audit";
+import { ApprovalArmError, buildApprovalArm } from "./provider-approval";
 
 const EVALUATOR_VERSION = "provider-action.v1";
 const POLICY_TYPE = "capability-intent" as const;
@@ -471,7 +472,43 @@ class ProviderActionService {
           expiresAt: new Date(input.expiresAt),
         });
 
+        // PR3 (§6.3): for the approval-required arm, build the exact approval
+        // commitment + queue row inside THIS create transaction (AFTER the intent
+        // insert the queue FK references). A missing PR1 execution dependency
+        // (route/credential) throws ApprovalArmError => creation fails closed.
+        let approvalQueueId: string | null = null;
+        let approvalCommitmentHash: string | null = null;
+        if (effects.status === "pending_approval") {
+          const arm = await buildApprovalArm({
+            tx,
+            tenantId,
+            workspaceId: input.workspaceId,
+            intentId,
+            actorAgentId,
+            actorRevision: access.doc.dependencyRevisions.actor,
+            account: txAccount,
+            operation: txOperation,
+            requestHash,
+            actionDigest,
+            accessDecisionId,
+            accessDecisionHash,
+            matchedBindings: access.doc.dependencyRevisions.bindings,
+            matchedGrants: access.doc.dependencyRevisions.grants,
+            policyDecisionId: (policy as PolicyResult).decisionId,
+            policyDecisionHash: policyDecisionHash as string,
+            policyRevisionHash: (policy as PolicyResult).doc.policyRevisionHash,
+            evaluatorVersion: EVALUATOR_VERSION,
+            requesterSeparation: extractRequesterSeparation(txOperation.requestProfile),
+            requestedAt: input.requestedAt,
+            expiresAt: input.expiresAt,
+          });
+          approvalQueueId = arm.queueId;
+          approvalCommitmentHash = arm.commitmentHash;
+        }
+
         await tx.insert(providerActionBindings).values({
+          approvalQueueId,
+          approvalCommitmentHash,
           intentId,
           tenantId,
           workspaceId: input.workspaceId,
@@ -507,6 +544,9 @@ class ProviderActionService {
         });
 
         // Required audit intent -> transactional outbox (drained post-commit).
+        // PR5 C1: correlated lifecycle events set resource_type='provider_action'
+        // and resource_id=intents.id (not the operation id) so PR5 can correlate
+        // online by the lifecycle root.
         await tx.insert(providerActionAuditOutbox).values({
           tenantId,
           intentId,
@@ -516,9 +556,12 @@ class ProviderActionService {
               : effects.status === "pending_approval"
                 ? "provider.action.approval_required"
                 : "provider.action.allowed",
-          resourceType: "provider-action",
-          resourceId: operation.id,
+          resourceType: "provider_action",
+          resourceId: intentId,
           metadata: {
+            // PR5 C1: metadata.intentId is the offline-authoritative correlation
+            // key (inside the signed eventsDigest).
+            intentId,
             actorAgentId,
             operationKey: input.operationKey,
             actionDigest,
@@ -933,33 +976,82 @@ class ProviderActionService {
     return { doc, evaluation, decisionId };
   }
 
-  // ── Required-audit outbox drain (post-commit, pre-stub) ──
-  private async drainAuditOutbox(tenantId: string, intentId: string): Promise<boolean> {
+  /**
+   * C2 crash-recovery sweeper (spec §7.3). The required-audit outbox row commits
+   * IN-TX with the intent/binding, but its drain into the signed chain happens
+   * post-commit. A crash between commit and drain leaves an intent with an
+   * UNDELIVERED outbox row and therefore ZERO signed correlated events — which
+   * would break the C2 invariant (every persisted intent has >=1 signed event).
+   *
+   * This sweeper drains every undelivered outbox row for the tenant (optionally
+   * scoped to one intent). It is safe to run repeatedly and concurrently: the
+   * drain marks `delivered_at` per row after the signed append, and
+   * `writeAuditEvent` is itself per-tenant serialized, so a signed event is
+   * produced EXACTLY ONCE per outbox row. Call it opportunistically (any read
+   * path) and/or from a periodic job; a killed drain is always recoverable.
+   *
+   * Returns the number of rows delivered in this pass.
+   */
+  async recoverUnsignedIntents(tenantId: string, intentId?: string): Promise<number> {
     const rows = await this.db()
       .select()
       .from(providerActionAuditOutbox)
       .where(
         and(
           eq(providerActionAuditOutbox.tenantId, tenantId),
-          eq(providerActionAuditOutbox.intentId, intentId),
+          intentId
+            ? eq(providerActionAuditOutbox.intentId, intentId)
+            : (sql`true` as unknown as ReturnType<typeof eq>),
           sql`${providerActionAuditOutbox.deliveredAt} IS NULL`,
         ),
       );
+    let delivered = 0;
     for (const row of rows) {
-      await writeAuditEvent({
-        tenantId: row.tenantId,
-        actorType: "agent",
-        actorId: (row.metadata as { actorAgentId?: string }).actorAgentId ?? null,
-        action: row.action,
-        resourceType: row.resourceType,
-        resourceId: row.resourceId,
-        metadata: row.metadata as Record<string, unknown>,
-      });
-      await this.db()
+      // Guarded claim: only deliver rows still undelivered. A concurrent sweeper
+      // that already delivered this row leaves delivered_at set; the signed
+      // append below is only reached after a successful CAS on delivered_at, so
+      // no row is signed twice.
+      const claimed = await this.db()
         .update(providerActionAuditOutbox)
         .set({ deliveredAt: new Date() })
-        .where(eq(providerActionAuditOutbox.id, row.id));
+        .where(
+          and(
+            eq(providerActionAuditOutbox.id, row.id),
+            sql`${providerActionAuditOutbox.deliveredAt} IS NULL`,
+          ),
+        )
+        .returning({ id: providerActionAuditOutbox.id });
+      if (claimed.length === 0) continue; // another pass won the row
+      try {
+        await writeAuditEvent({
+          tenantId: row.tenantId,
+          actorType: "agent",
+          actorId: (row.metadata as { actorAgentId?: string }).actorAgentId ?? null,
+          action: row.action,
+          resourceType: row.resourceType,
+          resourceId: row.resourceId,
+          metadata: row.metadata as Record<string, unknown>,
+        });
+        delivered += 1;
+      } catch (err) {
+        // Signing failed AFTER we claimed the row: release the claim so a later
+        // pass retries (the event must never be silently dropped).
+        await this.db()
+          .update(providerActionAuditOutbox)
+          .set({ deliveredAt: null })
+          .where(eq(providerActionAuditOutbox.id, row.id));
+        throw err;
+      }
     }
+    return delivered;
+  }
+
+  // ── Required-audit outbox drain (post-commit, pre-stub) ──
+  private async drainAuditOutbox(tenantId: string, intentId: string): Promise<boolean> {
+    // Delegate to the CAS-guarded recovery path so the inline drain and the
+    // crash-recovery sweeper share exactly-once semantics (spec §7.3). Any signer
+    // failure propagates (caller maps it to EVIDENCE_REQUIRED_AUDIT_UNAVAILABLE).
+    await this.recoverUnsignedIntents(tenantId, intentId);
     return true;
   }
 
@@ -1187,6 +1279,20 @@ function extractCapabilityIntentRules(
     });
   }
   return rules;
+}
+
+/**
+ * Extract the operation's requester-separation requirement (spec I10). PR1 does
+ * not yet ship a structured approval-requirements field, so PR3 reads it from
+ * `request_profile.approvalRequirements.requesterSeparation` when present
+ * (forward-compatible) and defaults to false. Documented deviation: when PR1
+ * lands a first-class approval-requirements field the commitment builder should
+ * read that instead.
+ */
+export function extractRequesterSeparation(requestProfile: Record<string, unknown>): boolean {
+  const reqs = (requestProfile as { approvalRequirements?: unknown }).approvalRequirements;
+  if (typeof reqs !== "object" || reqs === null) return false;
+  return (reqs as { requesterSeparation?: unknown }).requesterSeparation === true;
 }
 
 function capabilitySelectorMatches(config: Record<string, unknown>, operationKey: string): boolean {

--- a/packages/api/src/services/provider-action-service.ts
+++ b/packages/api/src/services/provider-action-service.ts
@@ -579,8 +579,19 @@ class ProviderActionService {
           },
         });
       });
-    } catch {
-      // Any evaluation or persistence failure denies; the stub is never called.
+    } catch (e) {
+      // A missing PR1 execution dependency (route/credential) fails approval
+      // creation CLOSED (spec §5.2) — surfaced as an evidence failure so no
+      // partial approval arm is ever visible.
+      if (e instanceof ApprovalArmError) {
+        return {
+          kind: "evidence_failure",
+          code: "EVIDENCE_DECISION_PERSIST_FAILED",
+          httpStatus: 503,
+        };
+      }
+      // Any other evaluation or persistence failure denies; the stub is never
+      // called.
       return {
         kind: "evidence_failure",
         code: "EVIDENCE_DECISION_PERSIST_FAILED",

--- a/packages/api/src/services/provider-action-service.ts
+++ b/packages/api/src/services/provider-action-service.ts
@@ -1177,7 +1177,21 @@ class ProviderActionService {
         actionDigest: b.actionDigest,
       };
     }
-    if (b.status === "pending_approval")
+    // Approval-required lineage (PR3). A create-replay of a governed provider
+    // action must NEVER report POLICY_ALLOW/stub_succeeded (that would fabricate
+    // an allow for an action that requires a human decision). The agent's create
+    // contract is 202 APPROVAL_REQUIRED regardless of where the out-of-band
+    // approval lifecycle currently sits (pending/approved/denied/expired/stale/
+    // execution_ready); the human decision + safe resume happen through the
+    // /v2/provider-actions approval + execute routes, not this create path.
+    if (
+      b.status === "pending_approval" ||
+      b.status === "approved" ||
+      b.status === "execution_ready" ||
+      b.status === "approval_denied" ||
+      b.status === "approval_expired" ||
+      b.status === "approval_stale"
+    )
       return {
         kind: "approval_required",
         code: "APPROVAL_REQUIRED",

--- a/packages/api/src/services/provider-approval.ts
+++ b/packages/api/src/services/provider-approval.ts
@@ -1,0 +1,1422 @@
+/**
+ * provider-approval.ts — PR3 sole transition owner for approval-required
+ * provider actions (spec §6). It:
+ *
+ *   - builds the exact approval commitment at PR2 creation (createApprovalArm),
+ *   - decides (approve/deny) with current-authority + recent-MFA + exact-request
+ *     integrity checks,
+ *   - expires and stales through the exact atomic state machine,
+ *   - safely resumes an approved action to `execution_ready` WITHOUT executing
+ *     anything, consuming the queue approval exactly once.
+ *
+ * Every state transition and its REQUIRED audit event commit atomically through
+ * `withTenantAuditedTransaction` (I14). The service NEVER decrypts a credential,
+ * calls the proxy, mints execution authorization, claims a nonce, or performs
+ * network I/O (I15) — that is PR4.
+ *
+ * Correlation contract (PR5 C1): every lifecycle audit event sets top-level
+ * `resource_type='provider_action'` and `resource_id=intents.id` in addition to
+ * the signed `metadata.intentId`.
+ */
+
+import { randomUUID } from "node:crypto";
+import {
+  agents,
+  approvalQueue,
+  getDb,
+  intents,
+  providerAccounts,
+  providerActionBindings,
+  providerGrants,
+  providerOperations,
+  providerRoleBindings,
+  secretRoutes,
+  userTenants,
+  withTenantAuditedTransaction,
+  workspaces,
+} from "@stwd/db";
+import {
+  type ProviderApprovalAuditPayloadV1,
+  type ProviderApprovalCommitmentV1,
+  computeApprovalCommitmentHash,
+  computeDecisionRequestHash,
+  jcsStringify,
+  PROVIDER_APPROVAL_AUDIT_SCHEMA,
+  sha256HexPrefixed,
+} from "@stwd/shared";
+import { and, eq, sql } from "drizzle-orm";
+
+const RESUME_ACTOR = "steward-system" as const;
+const MAX_MFA_AGE_MS = 300_000; // 5 minutes (spec §3.3, not tenant-configurable up)
+const MFA_FUTURE_SKEW_MS = 30_000; // 30s upper tolerance
+
+// ─── Result envelope ──────────────────────────────────────────────────────────
+
+export interface ApprovalSuccess {
+  ok: true;
+  httpStatus: 200;
+  id: string;
+  status: string;
+  version: number;
+  requestHash: string;
+  actionDigest: string;
+  replayed?: boolean;
+  resumeAttemptId?: string;
+}
+
+export interface ApprovalFailure {
+  ok: false;
+  code: string;
+  httpStatus: number;
+}
+
+export type ApprovalResult = ApprovalSuccess | ApprovalFailure;
+
+function fail(code: string, httpStatus: number): ApprovalFailure {
+  return { ok: false, code, httpStatus };
+}
+
+// ─── Decision input (already validated by the route) ──────────────────────────
+
+export interface DecideInput {
+  intentId: string;
+  tenantId: string;
+  authenticatedUserId: string;
+  sessionMfaVerifiedAt: number | undefined;
+  requiredMfaAssurance?: string; // reserved; PR1 does not yet supply assurance
+  decision: "approve" | "deny";
+  expectedVersion: number;
+  expectedRequestHash: string;
+  expectedActionDigest: string;
+  reasonCode: string | null;
+  reason: string | null;
+  idempotencyKey: string;
+  ipAddress?: string | null;
+  userAgent?: string | null;
+  requestId?: string | null;
+}
+
+// ─── Row shapes ───────────────────────────────────────────────────────────────
+
+type BindingRow = typeof providerActionBindings.$inferSelect;
+type QueueRow = typeof approvalQueue.$inferSelect;
+
+interface LoadedCase {
+  intent: typeof intents.$inferSelect;
+  binding: BindingRow;
+  queue: QueueRow;
+}
+
+// ─── Commitment creation (called from the PR2 create tx, spec §6.3) ───────────
+
+type DbBase = ReturnType<typeof getDb>;
+type DbExecutor = DbBase | Parameters<Parameters<DbBase["transaction"]>[0]>[0];
+
+/**
+ * Build the exact approval commitment + queue row inside the PR2 create
+ * transaction (spec §6.3 steps 3-5). Returns the commitment hash + queue id so
+ * the caller can set them on the binding. THROWS if a required PR1 execution
+ * dependency (route/credential) is missing — creation must fail closed (§5.2).
+ *
+ * The caller (provider-action-service) has already inserted the intent and is
+ * inside the same transaction; it sets binding.approval_queue_id +
+ * approval_commitment_hash on the binding insert with these return values.
+ */
+export async function buildApprovalArm(args: {
+  tx: DbExecutor;
+  tenantId: string;
+  workspaceId: string;
+  intentId: string;
+  actorAgentId: string;
+  actorRevision: number;
+  account: typeof providerAccounts.$inferSelect;
+  operation: typeof providerOperations.$inferSelect;
+  requestHash: string;
+  actionDigest: string;
+  accessDecisionId: string;
+  accessDecisionHash: string;
+  matchedBindings: Array<{ id: string; revision: number }>;
+  matchedGrants: Array<{ id: string; revision: number }>;
+  policyDecisionId: string;
+  policyDecisionHash: string;
+  policyRevisionHash: string;
+  evaluatorVersion: string;
+  requesterSeparation: boolean;
+  requestedAt: string;
+  expiresAt: string;
+}): Promise<{ queueId: string; commitmentHash: string; commitment: ProviderApprovalCommitmentV1 }> {
+  const tx = args.tx;
+
+  // Route + credential dependencies MUST exist (spec §5.2). Missing => throw so
+  // creation fails closed.
+  const routeId = args.operation.secretRouteId;
+  if (!routeId) {
+    throw new ApprovalArmError("APPROVAL_ROUTE_UNAVAILABLE");
+  }
+  const [route] = await tx
+    .select({ id: secretRoutes.id, authorityRevision: secretRoutes.authorityRevision })
+    .from(secretRoutes)
+    .where(and(eq(secretRoutes.tenantId, args.tenantId), eq(secretRoutes.id, routeId)))
+    .limit(1);
+  if (!route) {
+    throw new ApprovalArmError("APPROVAL_ROUTE_UNAVAILABLE");
+  }
+  const secretId = args.account.credentialSecretId;
+  const secretVersion = args.account.credentialVersion;
+  if (!secretId || secretVersion == null) {
+    throw new ApprovalArmError("APPROVAL_CREDENTIAL_UNAVAILABLE");
+  }
+
+  const commitment: ProviderApprovalCommitmentV1 = {
+    schemaVersion: "steward.provider-approval-commitment.v1",
+    intentId: args.intentId,
+    tenantId: args.tenantId,
+    workspaceId: args.workspaceId,
+    requestActor: { type: "agent", id: args.actorAgentId, revision: args.actorRevision },
+    providerAccount: { id: args.account.id, revision: args.account.revision, status: "active" },
+    operation: {
+      id: args.operation.id,
+      key: args.operation.operationKey,
+      revision: args.operation.revision,
+      riskClass: args.operation.riskClass,
+      canonicalProfile: "github.provider-action.v1",
+    },
+    requestHash: args.requestHash,
+    actionDigest: args.actionDigest,
+    accessDecision: {
+      id: args.accessDecisionId,
+      hash: args.accessDecisionHash,
+      effect: "allow",
+      matchedBindings: args.matchedBindings,
+      matchedGrants: args.matchedGrants,
+    },
+    policyDecision: {
+      id: args.policyDecisionId,
+      hash: args.policyDecisionHash,
+      effect: "approval_required",
+      policyRevisionHash: args.policyRevisionHash,
+      approvalPolicyRevisionHash: args.policyRevisionHash,
+      evaluatorVersion: args.evaluatorVersion,
+    },
+    executionDependencies: {
+      routeId: route.id,
+      routeRevision: route.authorityRevision,
+      secretId,
+      secretVersion,
+    },
+    approvalRequirements: {
+      role: "workspace_approver",
+      requesterSeparation: args.requesterSeparation,
+      maxMfaAgeSeconds: 300,
+      requiredMfaAssurance: "current-session-mfa",
+    },
+    requestedAt: args.requestedAt,
+    expiresAt: args.expiresAt,
+  };
+
+  const commitmentHash = computeApprovalCommitmentHash(commitment);
+  const queueId = `aq_${randomUUID()}`;
+
+  await tx.insert(approvalQueue).values({
+    id: queueId,
+    txId: null,
+    agentId: args.actorAgentId,
+    approvalKind: "provider_action",
+    intentId: args.intentId,
+    tenantId: args.tenantId,
+    workspaceId: args.workspaceId,
+    status: "pending",
+    requestedByType: "agent",
+    requestedById: args.actorAgentId,
+    requestHash: args.requestHash,
+    actionDigest: args.actionDigest,
+    approvalCommitment: commitment as unknown as Record<string, unknown>,
+    approvalCommitmentHash: commitmentHash,
+    expectedBindingRevision: 1,
+    expiresAt: new Date(args.expiresAt),
+  });
+
+  return { queueId, commitmentHash, commitment };
+}
+
+export class ApprovalArmError extends Error {
+  constructor(public code: string) {
+    super(code);
+    this.name = "ApprovalArmError";
+  }
+}
+
+// ─── Audit payload helper (C1 fields) ─────────────────────────────────────────
+
+function buildAuditPayload(
+  binding: BindingRow,
+  queue: QueueRow,
+  args: {
+    approvalActorUserId: string | null;
+    resumeActor: "steward-system" | null;
+    bindingRevisionBefore: number | null;
+    bindingRevisionAfter: number;
+    fromStatus: string | null;
+    toStatus: string;
+    reasonCode: string;
+    resumeAttemptId: string | null;
+  },
+): ProviderApprovalAuditPayloadV1 {
+  return {
+    schemaVersion: PROVIDER_APPROVAL_AUDIT_SCHEMA,
+    intentId: binding.intentId,
+    approvalQueueId: queue.id,
+    tenantId: binding.tenantId,
+    workspaceId: binding.workspaceId,
+    requestActorAgentId: binding.actorAgentId,
+    approvalActorUserId: args.approvalActorUserId,
+    resumeActor: args.resumeActor,
+    providerAccountId: binding.providerAccountId,
+    operationId: binding.operationId,
+    requestHash: binding.requestHash,
+    actionDigest: binding.actionDigest,
+    accessDecisionId: binding.accessDecisionId,
+    accessDecisionHash: binding.accessDecisionHash,
+    policyDecisionId: binding.policyDecisionId ?? "",
+    policyDecisionHash: binding.policyDecisionHash ?? "",
+    policyRevisionHash: binding.policyRevisionHash ?? "",
+    approvalCommitmentHash: queue.approvalCommitmentHash ?? "",
+    bindingRevisionBefore: args.bindingRevisionBefore,
+    bindingRevisionAfter: args.bindingRevisionAfter,
+    fromStatus: args.fromStatus,
+    toStatus: args.toStatus,
+    reasonCode: args.reasonCode,
+    resumeAttemptId: args.resumeAttemptId,
+    occurredAt: new Date().toISOString(),
+  };
+}
+
+function auditActor(actorType: "agent" | "user" | "system", actorId: string | null) {
+  return { actorType, actorId };
+}
+
+// ─── The service ──────────────────────────────────────────────────────────────
+
+class ProviderApprovalService {
+  private db() {
+    return getDb();
+  }
+
+  // Test-only fault-injection hooks (production defaults are no-ops; not settable
+  // from runtime input). Named per spec §13.
+  faultHooks: Partial<Record<
+    | "afterScopeLoad"
+    | "afterIntegrity"
+    | "afterAuthority"
+    | "afterMfa"
+    | "beforeAudit"
+    | "afterAudit"
+    | "beforeCommit",
+    () => void | Promise<void>
+  >> = {};
+
+  private async hook(name: keyof ProviderApprovalService["faultHooks"]): Promise<void> {
+    const h = this.faultHooks[name];
+    if (h) await h();
+  }
+
+  /** Load the intent/binding/queue tuple for a provider approval-required action. */
+  private async loadCase(
+    tx: DbExecutor,
+    tenantId: string,
+    intentId: string,
+    lock: boolean,
+  ): Promise<LoadedCase | { notFound: true } | { notApproval: true }> {
+    const [binding] = await tx
+      .select()
+      .from(providerActionBindings)
+      .where(
+        and(
+          eq(providerActionBindings.tenantId, tenantId),
+          eq(providerActionBindings.intentId, intentId),
+        ),
+      )
+      .limit(1);
+    if (!binding) return { notFound: true };
+    // Only approval-required lineage is governed here.
+    if (binding.policyEffect !== "approval_required") return { notApproval: true };
+
+    const [intent] = await tx
+      .select()
+      .from(intents)
+      .where(and(eq(intents.tenantId, tenantId), eq(intents.id, intentId)))
+      .limit(1);
+    if (!intent) return { notFound: true };
+
+    const [queue] = await tx
+      .select()
+      .from(approvalQueue)
+      .where(
+        and(
+          eq(approvalQueue.approvalKind, "provider_action"),
+          eq(approvalQueue.tenantId, tenantId),
+          eq(approvalQueue.intentId, intentId),
+        ),
+      )
+      .limit(1);
+    if (!queue) return { notFound: true };
+
+    // Stable lock order: intents, binding, queue (spec §13). The rows are already
+    // read; re-select FOR UPDATE in order when a mutating transition needs them.
+    if (lock) {
+      await tx.execute(
+        sql`SELECT id FROM intents WHERE tenant_id = ${tenantId} AND id = ${intentId} FOR UPDATE`,
+      );
+      await tx.execute(
+        sql`SELECT intent_id FROM provider_action_bindings WHERE tenant_id = ${tenantId} AND intent_id = ${intentId} FOR UPDATE`,
+      );
+      await tx.execute(
+        sql`SELECT id FROM approval_queue WHERE approval_kind = 'provider_action' AND tenant_id = ${tenantId} AND intent_id = ${intentId} FOR UPDATE`,
+      );
+    }
+    return { intent, binding, queue };
+  }
+
+  // ── Integrity verification (spec §5.3) ──
+  private verifyIntegrity(
+    binding: BindingRow,
+    queue: QueueRow,
+  ): { ok: true } | { ok: false; code: string } {
+    // 2/3. Re-hash the persisted canonical action bytes → action_digest. The
+    // bytes are the UTF-8 of the JCS canonical action (PR2 stores
+    // `jcsStringify(action)` as bytea and digests `sha256HexPrefixed(jcs)`); a
+    // raw-byte sha256 is byte-identical to the string form.
+    const rawBytes = new Uint8Array(binding.canonicalActionBytes as Uint8Array);
+    const recomputedDigest = sha256HexPrefixed(rawBytes);
+    if (recomputedDigest !== binding.actionDigest) {
+      return { ok: false, code: "APPROVAL_COMMITMENT_INTEGRITY_MISMATCH" };
+    }
+    // 5. Re-JCS + hash the persisted envelope → request_hash.
+    const recomputedReqHash = sha256HexPrefixed(
+      jcsStringify(binding.requestEnvelope as Record<string, unknown>),
+    );
+    if (recomputedReqHash !== binding.requestHash) {
+      return { ok: false, code: "APPROVAL_COMMITMENT_INTEGRITY_MISMATCH" };
+    }
+    // 6. Re-JCS + hash access decision + policy decision documents.
+    const recomputedAccessHash = sha256HexPrefixed(
+      jcsStringify(binding.accessDecision as Record<string, unknown>),
+    );
+    if (recomputedAccessHash !== binding.accessDecisionHash) {
+      return { ok: false, code: "APPROVAL_COMMITMENT_INTEGRITY_MISMATCH" };
+    }
+    if (binding.policyDecision && binding.policyDecisionHash) {
+      const recomputedPolicyHash = sha256HexPrefixed(
+        jcsStringify(binding.policyDecision as Record<string, unknown>),
+      );
+      if (recomputedPolicyHash !== binding.policyDecisionHash) {
+        return { ok: false, code: "APPROVAL_COMMITMENT_INTEGRITY_MISMATCH" };
+      }
+    }
+    // Re-hash the persisted commitment document → commitment hash.
+    if (queue.approvalCommitment && queue.approvalCommitmentHash) {
+      const recomputedCommitmentHash = computeApprovalCommitmentHash(
+        queue.approvalCommitment as unknown as ProviderApprovalCommitmentV1,
+      );
+      if (recomputedCommitmentHash !== queue.approvalCommitmentHash) {
+        return { ok: false, code: "APPROVAL_COMMITMENT_INTEGRITY_MISMATCH" };
+      }
+    } else {
+      return { ok: false, code: "APPROVAL_COMMITMENT_INTEGRITY_MISMATCH" };
+    }
+    // 7. Cross-table agreement: queue request_hash/action_digest == binding.
+    if (queue.requestHash !== binding.requestHash || queue.actionDigest !== binding.actionDigest) {
+      return { ok: false, code: "APPROVAL_COMMITMENT_INTEGRITY_MISMATCH" };
+    }
+    // Commitment doc identity fields must equal binding columns.
+    const c = queue.approvalCommitment as unknown as ProviderApprovalCommitmentV1;
+    if (
+      c.intentId !== binding.intentId ||
+      c.tenantId !== binding.tenantId ||
+      c.workspaceId !== binding.workspaceId ||
+      c.requestActor.id !== binding.actorAgentId ||
+      c.requestHash !== binding.requestHash ||
+      c.actionDigest !== binding.actionDigest ||
+      c.accessDecision.id !== binding.accessDecisionId ||
+      c.accessDecision.hash !== binding.accessDecisionHash ||
+      c.policyDecision.id !== (binding.policyDecisionId ?? "") ||
+      c.policyDecision.hash !== (binding.policyDecisionHash ?? "")
+    ) {
+      return { ok: false, code: "APPROVAL_COMMITMENT_INTEGRITY_MISMATCH" };
+    }
+    return { ok: true };
+  }
+
+  // ── Dependency re-evaluation against current authoritative state (§5.2) ──
+  // Returns { ok } if every committed dependency still matches, else a specific
+  // stale code. `requireApprovalRequired` gates policy: at approve/resume the
+  // current policy must still be approval_required; at deny we tolerate a stale
+  // NON-identity dependency so an approver can still deny (§6.5).
+  private async revalidateDependencies(
+    tx: DbExecutor,
+    binding: BindingRow,
+    queue: QueueRow,
+  ): Promise<{ ok: true } | { ok: false; code: string }> {
+    const c = queue.approvalCommitment as unknown as ProviderApprovalCommitmentV1;
+    const now = new Date();
+
+    // Actor still an active agent.
+    const [agent] = await tx
+      .select({ id: agents.id, ownerUserId: agents.ownerUserId })
+      .from(agents)
+      .where(and(eq(agents.tenantId, binding.tenantId), eq(agents.id, binding.actorAgentId)))
+      .limit(1);
+    if (!agent) return { ok: false, code: "APPROVAL_DEPENDENCY_STALE" };
+
+    // Workspace current + revision.
+    const [workspace] = await tx
+      .select()
+      .from(workspaces)
+      .where(and(eq(workspaces.tenantId, binding.tenantId), eq(workspaces.id, binding.workspaceId)))
+      .limit(1);
+    if (!workspace || workspace.status !== "active") {
+      return { ok: false, code: "APPROVAL_DEPENDENCY_STALE" };
+    }
+
+    // Provider account: exact revision + active status.
+    const [account] = await tx
+      .select()
+      .from(providerAccounts)
+      .where(
+        and(
+          eq(providerAccounts.tenantId, binding.tenantId),
+          eq(providerAccounts.workspaceId, binding.workspaceId),
+          eq(providerAccounts.id, binding.providerAccountId),
+        ),
+      )
+      .limit(1);
+    if (
+      !account ||
+      account.status !== "active" ||
+      account.revision !== c.providerAccount.revision
+    ) {
+      return { ok: false, code: "APPROVAL_PROVIDER_ACCOUNT_STALE" };
+    }
+
+    // Operation: exact revision + active status.
+    const [operation] = await tx
+      .select()
+      .from(providerOperations)
+      .where(
+        and(
+          eq(providerOperations.tenantId, binding.tenantId),
+          eq(providerOperations.workspaceId, binding.workspaceId),
+          eq(providerOperations.providerAccountId, binding.providerAccountId),
+          eq(providerOperations.id, binding.operationId),
+        ),
+      )
+      .limit(1);
+    if (!operation || operation.status !== "active" || operation.revision !== c.operation.revision) {
+      return { ok: false, code: "APPROVAL_OPERATION_STALE" };
+    }
+
+    // Route + credential commitments.
+    if (!operation.secretRouteId || operation.secretRouteId !== c.executionDependencies.routeId) {
+      return { ok: false, code: "APPROVAL_ROUTE_STALE" };
+    }
+    const [route] = await tx
+      .select({ id: secretRoutes.id, authorityRevision: secretRoutes.authorityRevision })
+      .from(secretRoutes)
+      .where(
+        and(eq(secretRoutes.tenantId, binding.tenantId), eq(secretRoutes.id, operation.secretRouteId)),
+      )
+      .limit(1);
+    if (!route || route.authorityRevision !== c.executionDependencies.routeRevision) {
+      return { ok: false, code: "APPROVAL_ROUTE_STALE" };
+    }
+    if (
+      account.credentialSecretId !== c.executionDependencies.secretId ||
+      account.credentialVersion !== c.executionDependencies.secretVersion
+    ) {
+      return { ok: false, code: "APPROVAL_CREDENTIAL_STALE" };
+    }
+
+    // Matched grants/bindings: EVERY committed source must still exist, be
+    // active, in-window, and retain the exact revision. Any committed source
+    // that changed/vanished stales, even if another allow remains (I6/N32).
+    for (const g of c.accessDecision.matchedGrants) {
+      const [row] = await tx
+        .select({ revision: providerGrants.revision, status: providerGrants.status, notBefore: providerGrants.notBefore, expiresAt: providerGrants.expiresAt, environment: providerGrants.environment })
+        .from(providerGrants)
+        .where(and(eq(providerGrants.tenantId, binding.tenantId), eq(providerGrants.id, g.id)))
+        .limit(1);
+      if (!row || row.status !== "active" || row.revision !== g.revision) {
+        return { ok: false, code: "APPROVAL_GRANT_STALE" };
+      }
+      if ((row.notBefore && row.notBefore > now) || (row.expiresAt && row.expiresAt <= now)) {
+        return { ok: false, code: "APPROVAL_GRANT_STALE" };
+      }
+    }
+    for (const b of c.accessDecision.matchedBindings) {
+      const [row] = await tx
+        .select({ revision: providerRoleBindings.revision, status: providerRoleBindings.status, notBefore: providerRoleBindings.notBefore, expiresAt: providerRoleBindings.expiresAt })
+        .from(providerRoleBindings)
+        .where(and(eq(providerRoleBindings.tenantId, binding.tenantId), eq(providerRoleBindings.id, b.id)))
+        .limit(1);
+      if (!row || row.status !== "active" || row.revision !== b.revision) {
+        return { ok: false, code: "APPROVAL_GRANT_STALE" };
+      }
+      if ((row.notBefore && row.notBefore > now) || (row.expiresAt && row.expiresAt <= now)) {
+        return { ok: false, code: "APPROVAL_GRANT_STALE" };
+      }
+    }
+
+    // Access decision: exact stored hash must still verify against the persisted
+    // document AND the current effective committed set must equal the recorded
+    // one (no new broader allow silently repurposed — N33). We recompute the
+    // current matched grant/binding id-set for this actor/operation and require
+    // it equals the committed id-set.
+    const currentAccess = await this.currentMatchedSources(tx, binding, operation, workspace);
+    const committedGrantIds = new Set(c.accessDecision.matchedGrants.map((g) => g.id));
+    const committedBindingIds = new Set(c.accessDecision.matchedBindings.map((b) => b.id));
+    if (
+      !setsEqual(committedGrantIds, currentAccess.grantIds) ||
+      !setsEqual(committedBindingIds, currentAccess.bindingIds)
+    ) {
+      return { ok: false, code: "APPROVAL_ACCESS_DECISION_STALE" };
+    }
+
+    return { ok: true };
+  }
+
+  /** Recompute the current matched grant/binding id-sets for the committed actor/operation. */
+  private async currentMatchedSources(
+    tx: DbExecutor,
+    binding: BindingRow,
+    operation: typeof providerOperations.$inferSelect,
+    workspace: typeof workspaces.$inferSelect,
+  ): Promise<{ grantIds: Set<string>; bindingIds: Set<string> }> {
+    const now = new Date();
+    const env = workspace.environment;
+    const grantRows = await tx
+      .select()
+      .from(providerGrants)
+      .where(
+        and(
+          eq(providerGrants.tenantId, binding.tenantId),
+          eq(providerGrants.workspaceId, binding.workspaceId),
+          eq(providerGrants.providerAccountId, binding.providerAccountId),
+          eq(providerGrants.agentId, binding.actorAgentId),
+          eq(providerGrants.status, "active"),
+        ),
+      );
+    const grantIds = new Set(
+      grantRows
+        .filter(
+          (g) =>
+            (!g.notBefore || g.notBefore <= now) &&
+            (!g.expiresAt || g.expiresAt > now) &&
+            (!g.environment || g.environment === env) &&
+            g.operationKeys.includes(operation.operationKey),
+        )
+        .map((g) => g.id),
+    );
+    const bindingRows = await tx
+      .select()
+      .from(providerRoleBindings)
+      .where(
+        and(
+          eq(providerRoleBindings.tenantId, binding.tenantId),
+          eq(providerRoleBindings.workspaceId, binding.workspaceId),
+          eq(providerRoleBindings.principalType, "agent"),
+          eq(providerRoleBindings.principalId, binding.actorAgentId),
+          eq(providerRoleBindings.status, "active"),
+        ),
+      );
+    const bindingIds = new Set(
+      bindingRows
+        .filter((b) => {
+          if (b.notBefore && b.notBefore > now) return false;
+          if (b.expiresAt && b.expiresAt <= now) return false;
+          if (b.environment && b.environment !== env) return false;
+          if (b.providerAccountId && b.providerAccountId !== binding.providerAccountId) return false;
+          if (b.roleKey === "workspace_operator")
+            return b.operationKeys.includes(operation.operationKey);
+          if (b.roleKey === "workspace_viewer")
+            return (
+              operation.riskClass === "read" && b.operationKeys.includes(operation.operationKey)
+            );
+          return false;
+        })
+        .map((b) => b.id),
+    );
+    return { grantIds, bindingIds };
+  }
+
+  // ── Current-policy re-evaluation is a commitment-hash equality check for PR3.
+  // The persisted policy document's revision hash must still match the operation
+  // (operation revision equality above already covers rule-set drift because the
+  // policy revision hash binds operationRevision). A current hard deny is
+  // surfaced by the operation/policy revision changing → APPROVAL_OPERATION_STALE
+  // or APPROVAL_POLICY_STALE. PR3 does not re-run the evaluator here; operation
+  // revision + policy revision hash equality is the exact-binding rule.
+
+  // ── Approver eligibility (spec §3.2, §3.3) ──
+  private async checkApprover(
+    tx: DbExecutor,
+    binding: BindingRow,
+    queue: QueueRow,
+    userId: string,
+    tenantId: string,
+    sessionMfaVerifiedAt: number | undefined,
+    atResume: boolean,
+  ): Promise<{ ok: true } | { ok: false; code: string; httpStatus: number }> {
+    // Current tenant membership row must exist.
+    const [membership] = await tx
+      .select({ id: userTenants.id })
+      .from(userTenants)
+      .where(and(eq(userTenants.userId, userId), eq(userTenants.tenantId, tenantId)))
+      .limit(1);
+    if (!membership) {
+      return atResume
+        ? { ok: false, code: "APPROVAL_APPROVER_STALE", httpStatus: 409 }
+        : { ok: false, code: "APPROVAL_MEMBERSHIP_INACTIVE", httpStatus: 403 };
+    }
+
+    // Active, in-window workspace_approver binding for THIS exact workspace.
+    const now = new Date();
+    const env = (queue.approvalCommitment as unknown as ProviderApprovalCommitmentV1 | null)
+      ?.operation
+      ? undefined
+      : undefined;
+    void env;
+    const approverRows = await tx
+      .select()
+      .from(providerRoleBindings)
+      .where(
+        and(
+          eq(providerRoleBindings.tenantId, tenantId),
+          eq(providerRoleBindings.workspaceId, binding.workspaceId),
+          eq(providerRoleBindings.principalType, "human"),
+          eq(providerRoleBindings.principalId, userId),
+          eq(providerRoleBindings.roleKey, "workspace_approver"),
+          eq(providerRoleBindings.status, "active"),
+        ),
+      );
+    const eligible = approverRows.some(
+      (b) => (!b.notBefore || b.notBefore <= now) && (!b.expiresAt || b.expiresAt > now),
+    );
+    if (!eligible) {
+      return atResume
+        ? { ok: false, code: "APPROVAL_APPROVER_STALE", httpStatus: 409 }
+        : { ok: false, code: "APPROVAL_ROLE_REQUIRED", httpStatus: 403 };
+    }
+
+    // Requester separation (I10): if enabled and the approver is a known
+    // controller of the requesting agent, ineligible.
+    const c = queue.approvalCommitment as unknown as ProviderApprovalCommitmentV1;
+    if (c.approvalRequirements.requesterSeparation) {
+      const [agent] = await tx
+        .select({ ownerUserId: agents.ownerUserId })
+        .from(agents)
+        .where(and(eq(agents.tenantId, tenantId), eq(agents.id, binding.actorAgentId)))
+        .limit(1);
+      if (agent?.ownerUserId && agent.ownerUserId === userId) {
+        return { ok: false, code: "APPROVAL_REQUESTER_SEPARATION_REQUIRED", httpStatus: 403 };
+      }
+    }
+
+    // Recent MFA (only enforced at decision time, not resume — §9). At resume we
+    // only require the approver still be eligible (checked above).
+    if (!atResume) {
+      const mfa = this.checkMfa(sessionMfaVerifiedAt);
+      if (!mfa.ok) return mfa;
+    }
+
+    return { ok: true };
+  }
+
+  private checkMfa(
+    verifiedAt: number | undefined,
+  ): { ok: true } | { ok: false; code: string; httpStatus: number } {
+    if (verifiedAt == null || !Number.isFinite(verifiedAt)) {
+      return { ok: false, code: "APPROVAL_MFA_REQUIRED", httpStatus: 403 };
+    }
+    const nowMs = Date.now();
+    if (verifiedAt > nowMs + MFA_FUTURE_SKEW_MS) {
+      return { ok: false, code: "APPROVAL_MFA_TIMESTAMP_INVALID", httpStatus: 403 };
+    }
+    if (nowMs - verifiedAt > MAX_MFA_AGE_MS) {
+      return { ok: false, code: "APPROVAL_MFA_STALE", httpStatus: 403 };
+    }
+    return { ok: true };
+  }
+
+  // ── Expiry helper: guarded atomic expiry (spec §6.6). Returns true if it
+  // transitioned pending/approved → expired in this tx. ──
+  private async expireIfDue(
+    tx: DbExecutor,
+    append: (ev: { tenantId: string } & Record<string, unknown>) => Promise<void>,
+    loaded: LoadedCase,
+  ): Promise<boolean> {
+    const { binding, queue } = loaded;
+    // DB time.
+    const [{ due }] = (await tx.execute(
+      sql`SELECT (${queue.expiresAt} <= now()) AS due`,
+    )) as unknown as Array<{ due: boolean }>;
+    if (!due) return false;
+    if (!(queue.status === "pending" || queue.status === "approved")) return false;
+
+    const before = binding.bindingRevision;
+    const after = before + 1;
+    await tx
+      .update(approvalQueue)
+      .set({ status: "expired" })
+      .where(
+        and(
+          eq(approvalQueue.id, queue.id),
+          sql`${approvalQueue.status} IN ('pending','approved')`,
+        ),
+      );
+    await tx
+      .update(providerActionBindings)
+      .set({ status: "approval_expired", bindingRevision: after, expiredAt: new Date(), updatedAt: new Date() })
+      .where(
+        and(
+          eq(providerActionBindings.intentId, binding.intentId),
+          sql`${providerActionBindings.status} IN ('pending_approval','approved')`,
+        ),
+      );
+    await tx
+      .update(intents)
+      .set({ status: "expired", expiredBy: RESUME_ACTOR, expiredAt: new Date(), updatedAt: new Date() })
+      .where(eq(intents.id, binding.intentId));
+
+    const payload = buildAuditPayload(binding, queue, {
+      approvalActorUserId: null,
+      resumeActor: RESUME_ACTOR,
+      bindingRevisionBefore: before,
+      bindingRevisionAfter: after,
+      fromStatus: binding.status,
+      toStatus: "approval_expired",
+      reasonCode: "APPROVAL_EXPIRED",
+      resumeAttemptId: null,
+    });
+    await append({
+      tenantId: binding.tenantId,
+      actorType: "system",
+      actorId: RESUME_ACTOR,
+      action: "provider.approval.expired",
+      resourceType: "provider_action",
+      resourceId: binding.intentId,
+      metadata: payload as unknown as Record<string, unknown>,
+    });
+    return true;
+  }
+
+  // ── Stale transition (spec §6.7). One tx moves pending/approved → stale. ──
+  private async staleTransition(
+    tx: DbExecutor,
+    append: (ev: { tenantId: string } & Record<string, unknown>) => Promise<void>,
+    binding: BindingRow,
+    queue: QueueRow,
+    reasonCode: string,
+  ): Promise<void> {
+    const before = binding.bindingRevision;
+    const after = before + 1;
+    await tx
+      .update(approvalQueue)
+      .set({ status: "stale" })
+      .where(
+        and(eq(approvalQueue.id, queue.id), sql`${approvalQueue.status} IN ('pending','approved')`),
+      );
+    await tx
+      .update(providerActionBindings)
+      .set({
+        status: "approval_stale",
+        bindingRevision: after,
+        staleAt: new Date(),
+        staleReasonCode: reasonCode,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(providerActionBindings.intentId, binding.intentId),
+          sql`${providerActionBindings.status} IN ('pending_approval','approved')`,
+        ),
+      );
+    await tx
+      .update(intents)
+      .set({
+        status: "canceled",
+        canceledBy: RESUME_ACTOR,
+        canceledAt: new Date(),
+        cancellationReason: reasonCode,
+        updatedAt: new Date(),
+      })
+      .where(eq(intents.id, binding.intentId));
+    const payload = buildAuditPayload(binding, queue, {
+      approvalActorUserId: null,
+      resumeActor: RESUME_ACTOR,
+      bindingRevisionBefore: before,
+      bindingRevisionAfter: after,
+      fromStatus: binding.status,
+      toStatus: "approval_stale",
+      reasonCode,
+      resumeAttemptId: null,
+    });
+    await append({
+      tenantId: binding.tenantId,
+      actorType: "system",
+      actorId: RESUME_ACTOR,
+      action: "provider.approval.staled",
+      resourceType: "provider_action",
+      resourceId: binding.intentId,
+      metadata: payload as unknown as Record<string, unknown>,
+    });
+  }
+
+  // ── Terminal-state → outcome mapping for a loaded (non-transitioning) case. ──
+  private terminalOutcome(binding: BindingRow, queue: QueueRow): ApprovalResult {
+    const base = {
+      id: binding.intentId,
+      version: binding.bindingRevision,
+      requestHash: binding.requestHash,
+      actionDigest: binding.actionDigest,
+    };
+    switch (binding.status) {
+      case "approval_denied":
+        return fail("APPROVAL_TERMINAL", 409);
+      case "approval_expired":
+        return fail("APPROVAL_EXPIRED", 410);
+      case "approval_stale":
+        return fail("APPROVAL_TERMINAL", 409);
+      case "execution_ready":
+        return {
+          ok: true,
+          httpStatus: 200,
+          status: "execution_ready",
+          resumeAttemptId: binding.resumeAttemptId ?? undefined,
+          ...base,
+        };
+      default:
+        void queue;
+        return fail("APPROVAL_STATE_CONFLICT", 409);
+    }
+  }
+
+  // ── DECIDE (approve/deny), spec §6.4 / §6.5 ──
+  async decide(input: DecideInput): Promise<ApprovalResult> {
+    try {
+      return await withTenantAuditedTransaction(input.tenantId, async (txRaw, appendRaw) => {
+        const tx = txRaw as DbExecutor;
+        const append = appendRaw as unknown as (
+          ev: { tenantId: string } & Record<string, unknown>,
+        ) => Promise<void>;
+
+        const loaded = await this.loadCase(tx, input.tenantId, input.intentId, true);
+        await this.hook("afterScopeLoad");
+        if ("notFound" in loaded) return fail("SCOPE_RESOURCE_NOT_FOUND", 404);
+        if ("notApproval" in loaded) return fail("APPROVAL_NOT_REQUIRED", 409);
+        const { binding, queue } = loaded;
+
+        // Decision idempotency: exact retry by same user+key returns existing.
+        const idemHash = sha256HexPrefixed(input.idempotencyKey);
+        const decisionReqHash = computeDecisionRequestHash({
+          schemaVersion: "steward.provider-approval-decision.v1",
+          tenantId: input.tenantId,
+          workspaceId: binding.workspaceId,
+          intentId: input.intentId,
+          authenticatedUserId: input.authenticatedUserId,
+          decision: input.decision,
+          expectedVersion: input.expectedVersion,
+          expectedRequestHash: input.expectedRequestHash,
+          expectedActionDigest: input.expectedActionDigest,
+          reasonCode: input.reasonCode,
+          reason: input.reason,
+        });
+
+        if (queue.decisionIdempotencyKeyHash) {
+          if (
+            queue.resolvedById === input.authenticatedUserId &&
+            queue.decisionIdempotencyKeyHash === idemHash
+          ) {
+            if (queue.decisionRequestHash === decisionReqHash) {
+              // Exact retry → return existing decision.
+              return this.decisionReplay(binding, queue);
+            }
+            return fail("APPROVAL_IDEMPOTENCY_CONFLICT", 409);
+          }
+        }
+
+        // Expire first (DB time). Expiry wins over decision.
+        if (queue.status === "pending" || queue.status === "approved") {
+          const expired = await this.expireIfDue(tx, append, loaded);
+          if (expired) return fail("APPROVAL_EXPIRED", 410);
+        }
+
+        // Terminal / non-pending state handling.
+        if (binding.status !== "pending_approval") {
+          // Different-key decision after resolution: allow same-user same-decision
+          // replay=true, else conflict (§8.2).
+          if (binding.status === "approved" || binding.status === "approval_denied") {
+            if (
+              queue.resolvedById === input.authenticatedUserId &&
+              queue.decision === input.decision
+            ) {
+              return this.decisionReplay(binding, queue, true);
+            }
+            return fail("APPROVAL_ALREADY_DECIDED", 409);
+          }
+          return this.terminalOutcome(binding, queue);
+        }
+
+        // Optimistic-lock echoes (§6.4 step 4). These are echo values only.
+        if (input.expectedVersion !== binding.bindingRevision) {
+          return fail("APPROVAL_EXPECTED_VERSION_MISMATCH", 409);
+        }
+        if (input.expectedRequestHash !== binding.requestHash) {
+          return fail("APPROVAL_REQUEST_HASH_MISMATCH", 409);
+        }
+        if (input.expectedActionDigest !== binding.actionDigest) {
+          return fail("APPROVAL_ACTION_DIGEST_MISMATCH", 409);
+        }
+
+        // Integrity (§5.3). A persisted-integrity failure stales.
+        const integ = this.verifyIntegrity(binding, queue);
+        await this.hook("afterIntegrity");
+        if (!integ.ok) {
+          await this.staleTransition(tx, append, binding, queue, integ.code);
+          return fail(integ.code, 409);
+        }
+
+        // Dependency re-eval. For approve, ANY committed dependency mismatch
+        // stales. For deny, we still require integrity + scope but tolerate a
+        // stale NON-identity dependency (approver may deny an unsafe request).
+        const deps = await this.revalidateDependencies(tx, binding, queue);
+        await this.hook("afterAuthority");
+        if (!deps.ok && input.decision === "approve") {
+          await this.staleTransition(tx, append, binding, queue, deps.code);
+          return fail(deps.code, 409);
+        }
+
+        // Approver eligibility + MFA.
+        const approver = await this.checkApprover(
+          tx,
+          binding,
+          queue,
+          input.authenticatedUserId,
+          input.tenantId,
+          input.sessionMfaVerifiedAt,
+          false,
+        );
+        await this.hook("afterMfa");
+        if (!approver.ok) return fail(approver.code, approver.httpStatus);
+
+        // Denial reason required.
+        if (input.decision === "deny" && !input.reasonCode) {
+          return fail("APPROVAL_REASON_REQUIRED", 400);
+        }
+
+        const before = binding.bindingRevision;
+        const after = before + 1;
+        const nowTs = new Date();
+        const mfaVerifiedAt = new Date(input.sessionMfaVerifiedAt as number);
+        const mfaAgeMs = Date.now() - (input.sessionMfaVerifiedAt as number);
+
+        if (input.decision === "approve") {
+          const upd = await tx
+            .update(approvalQueue)
+            .set({
+              status: "approved",
+              decision: "approve",
+              resolvedAt: nowTs,
+              resolvedByType: "user",
+              resolvedById: input.authenticatedUserId,
+              resolvedBy: input.authenticatedUserId,
+              mfaVerifiedAt,
+              mfaAgeMsAtDecision: mfaAgeMs,
+              reasonCode: input.reasonCode ?? null,
+              reason: input.reason ?? null,
+              decisionIdempotencyKeyHash: idemHash,
+              decisionRequestHash: decisionReqHash,
+            })
+            .where(and(eq(approvalQueue.id, queue.id), eq(approvalQueue.status, "pending")))
+            .returning({ id: approvalQueue.id });
+          if (upd.length === 0) return fail("APPROVAL_STATE_CONFLICT", 409);
+
+          await tx
+            .update(providerActionBindings)
+            .set({
+              status: "approved",
+              bindingRevision: after,
+              approvalActorUserId: input.authenticatedUserId,
+              approvedAt: nowTs,
+              updatedAt: nowTs,
+            })
+            .where(
+              and(
+                eq(providerActionBindings.intentId, binding.intentId),
+                eq(providerActionBindings.status, "pending_approval"),
+                eq(providerActionBindings.bindingRevision, before),
+              ),
+            );
+          await tx
+            .update(intents)
+            .set({
+              status: "authorized",
+              authorizedBy: `user:${input.authenticatedUserId}`,
+              authorizedAt: nowTs,
+              updatedAt: nowTs,
+            })
+            .where(eq(intents.id, binding.intentId));
+
+          const payload = buildAuditPayload(binding, queue, {
+            approvalActorUserId: input.authenticatedUserId,
+            resumeActor: null,
+            bindingRevisionBefore: before,
+            bindingRevisionAfter: after,
+            fromStatus: "pending_approval",
+            toStatus: "approved",
+            reasonCode: input.reasonCode ?? "approver_manual_approve",
+            resumeAttemptId: null,
+          });
+          await this.hook("beforeAudit");
+          await append({
+            tenantId: binding.tenantId,
+            actorType: "user",
+            actorId: input.authenticatedUserId,
+            action: "provider.approval.decided",
+            resourceType: "provider_action",
+            resourceId: binding.intentId,
+            metadata: payload as unknown as Record<string, unknown>,
+            ipAddress: input.ipAddress ?? null,
+            userAgent: input.userAgent ?? null,
+            requestId: input.requestId ?? null,
+          });
+          await this.hook("afterAudit");
+
+          return {
+            ok: true,
+            httpStatus: 200,
+            id: binding.intentId,
+            status: "approved",
+            version: after,
+            requestHash: binding.requestHash,
+            actionDigest: binding.actionDigest,
+          };
+        }
+
+        // DENY.
+        const upd = await tx
+          .update(approvalQueue)
+          .set({
+            status: "rejected",
+            decision: "deny",
+            resolvedAt: nowTs,
+            resolvedByType: "user",
+            resolvedById: input.authenticatedUserId,
+            resolvedBy: input.authenticatedUserId,
+            mfaVerifiedAt,
+            mfaAgeMsAtDecision: mfaAgeMs,
+            reasonCode: input.reasonCode ?? null,
+            reason: input.reason ?? null,
+            decisionIdempotencyKeyHash: idemHash,
+            decisionRequestHash: decisionReqHash,
+          })
+          .where(and(eq(approvalQueue.id, queue.id), eq(approvalQueue.status, "pending")))
+          .returning({ id: approvalQueue.id });
+        if (upd.length === 0) return fail("APPROVAL_STATE_CONFLICT", 409);
+
+        await tx
+          .update(providerActionBindings)
+          .set({
+            status: "approval_denied",
+            bindingRevision: after,
+            approvalActorUserId: input.authenticatedUserId,
+            deniedAt: nowTs,
+            updatedAt: nowTs,
+          })
+          .where(
+            and(
+              eq(providerActionBindings.intentId, binding.intentId),
+              eq(providerActionBindings.status, "pending_approval"),
+              eq(providerActionBindings.bindingRevision, before),
+            ),
+          );
+        await tx
+          .update(intents)
+          .set({
+            status: "rejected",
+            rejectedBy: `user:${input.authenticatedUserId}`,
+            rejectedAt: nowTs,
+            rejectionReason: input.reasonCode ?? null,
+            updatedAt: nowTs,
+          })
+          .where(eq(intents.id, binding.intentId));
+
+        const payload = buildAuditPayload(binding, queue, {
+          approvalActorUserId: input.authenticatedUserId,
+          resumeActor: null,
+          bindingRevisionBefore: before,
+          bindingRevisionAfter: after,
+          fromStatus: "pending_approval",
+          toStatus: "approval_denied",
+          reasonCode: input.reasonCode ?? "approver_manual_deny",
+          resumeAttemptId: null,
+        });
+        await this.hook("beforeAudit");
+        await append({
+          tenantId: binding.tenantId,
+          actorType: "user",
+          actorId: input.authenticatedUserId,
+          action: "provider.approval.decided",
+          resourceType: "provider_action",
+          resourceId: binding.intentId,
+          metadata: payload as unknown as Record<string, unknown>,
+          ipAddress: input.ipAddress ?? null,
+          userAgent: input.userAgent ?? null,
+          requestId: input.requestId ?? null,
+        });
+        await this.hook("afterAudit");
+
+        return {
+          ok: true,
+          httpStatus: 200,
+          id: binding.intentId,
+          status: "approval_denied",
+          version: after,
+          requestHash: binding.requestHash,
+          actionDigest: binding.actionDigest,
+        };
+      });
+    } catch (e) {
+      if (e instanceof AuditUnavailableError) return fail("EVIDENCE_REQUIRED_AUDIT_UNAVAILABLE", 503);
+      return fail("APPROVAL_PERSISTENCE_FAILED", 503);
+    }
+  }
+
+  private decisionReplay(binding: BindingRow, queue: QueueRow, replayed = false): ApprovalResult {
+    const status =
+      queue.decision === "approve"
+        ? binding.status === "execution_ready"
+          ? "execution_ready"
+          : "approved"
+        : "approval_denied";
+    return {
+      ok: true,
+      httpStatus: 200,
+      id: binding.intentId,
+      status,
+      version: binding.bindingRevision,
+      requestHash: binding.requestHash,
+      actionDigest: binding.actionDigest,
+      replayed: replayed || undefined,
+    };
+  }
+
+  // ── SAFE RESUME (approved → execution_ready), spec §6.8 ──
+  async resume(input: {
+    intentId: string;
+    tenantId: string;
+    ipAddress?: string | null;
+    userAgent?: string | null;
+    requestId?: string | null;
+  }): Promise<ApprovalResult> {
+    try {
+      return await withTenantAuditedTransaction(input.tenantId, async (txRaw, appendRaw) => {
+        const tx = txRaw as DbExecutor;
+        const append = appendRaw as unknown as (
+          ev: { tenantId: string } & Record<string, unknown>,
+        ) => Promise<void>;
+
+        const loaded = await this.loadCase(tx, input.tenantId, input.intentId, true);
+        await this.hook("afterScopeLoad");
+        if ("notFound" in loaded) return fail("SCOPE_RESOURCE_NOT_FOUND", 404);
+        if ("notApproval" in loaded) return fail("APPROVAL_NOT_REQUIRED", 409);
+        const { binding, queue } = loaded;
+
+        // Idempotent: already execution_ready returns same state.
+        if (binding.status === "execution_ready") {
+          return {
+            ok: true,
+            httpStatus: 200,
+            id: binding.intentId,
+            status: "execution_ready",
+            version: binding.bindingRevision,
+            requestHash: binding.requestHash,
+            actionDigest: binding.actionDigest,
+            resumeAttemptId: binding.resumeAttemptId ?? undefined,
+          };
+        }
+
+        // Expire first.
+        if (queue.status === "pending" || queue.status === "approved") {
+          const expired = await this.expireIfDue(tx, append, loaded);
+          if (expired) return fail("APPROVAL_EXPIRED", 410);
+        }
+
+        if (binding.status !== "approved") {
+          if (binding.status === "pending_approval") return fail("RESUME_NOT_APPROVED", 409);
+          if (binding.status === "approval_denied") return fail("RESUME_NOT_APPROVED", 409);
+          return this.terminalOutcome(binding, queue);
+        }
+
+        // Integrity + full dependency revalidation (§6.8 step 6-8).
+        const integ = this.verifyIntegrity(binding, queue);
+        await this.hook("afterIntegrity");
+        if (!integ.ok) {
+          await this.staleTransition(tx, append, binding, queue, integ.code);
+          return fail(integ.code, 409);
+        }
+        const deps = await this.revalidateDependencies(tx, binding, queue);
+        await this.hook("afterAuthority");
+        if (!deps.ok) {
+          await this.staleTransition(tx, append, binding, queue, deps.code);
+          return fail(deps.code, 409);
+        }
+
+        // Approver still eligible at resume (I7). No MFA-age recheck (§9).
+        const approverUserId = binding.approvalActorUserId as string;
+        const approver = await this.checkApprover(
+          tx,
+          binding,
+          queue,
+          approverUserId,
+          input.tenantId,
+          undefined,
+          true,
+        );
+        if (!approver.ok) {
+          await this.staleTransition(tx, append, binding, queue, approver.code);
+          return fail(approver.code, approver.httpStatus === 403 ? 409 : approver.httpStatus);
+        }
+
+        const before = binding.bindingRevision;
+        const after = before + 1;
+        const nowTs = new Date();
+        const resumeAttemptId = randomUUID();
+
+        const upd = await tx
+          .update(approvalQueue)
+          .set({ status: "consumed", consumedAt: nowTs, consumedBy: RESUME_ACTOR })
+          .where(and(eq(approvalQueue.id, queue.id), eq(approvalQueue.status, "approved")))
+          .returning({ id: approvalQueue.id });
+        if (upd.length === 0) return fail("APPROVAL_STATE_CONFLICT", 409);
+
+        await tx
+          .update(providerActionBindings)
+          .set({
+            status: "execution_ready",
+            bindingRevision: after,
+            resumeActor: RESUME_ACTOR,
+            resumeAttemptId,
+            resumeValidatedAt: nowTs,
+            updatedAt: nowTs,
+          })
+          .where(
+            and(
+              eq(providerActionBindings.intentId, binding.intentId),
+              eq(providerActionBindings.status, "approved"),
+              eq(providerActionBindings.bindingRevision, before),
+            ),
+          );
+        await tx
+          .update(intents)
+          .set({ executedBy: RESUME_ACTOR, updatedAt: nowTs })
+          .where(eq(intents.id, binding.intentId));
+
+        const payload = buildAuditPayload(binding, queue, {
+          approvalActorUserId: approverUserId,
+          resumeActor: RESUME_ACTOR,
+          bindingRevisionBefore: before,
+          bindingRevisionAfter: after,
+          fromStatus: "approved",
+          toStatus: "execution_ready",
+          reasonCode: "provider_resume_ready",
+          resumeAttemptId,
+        });
+        await this.hook("beforeAudit");
+        await append({
+          tenantId: binding.tenantId,
+          actorType: "system",
+          actorId: RESUME_ACTOR,
+          action: "provider.resume.ready",
+          resourceType: "provider_action",
+          resourceId: binding.intentId,
+          metadata: payload as unknown as Record<string, unknown>,
+          ipAddress: input.ipAddress ?? null,
+          userAgent: input.userAgent ?? null,
+          requestId: input.requestId ?? null,
+        });
+        await this.hook("afterAudit");
+
+        return {
+          ok: true,
+          httpStatus: 200,
+          id: binding.intentId,
+          status: "execution_ready",
+          version: after,
+          requestHash: binding.requestHash,
+          actionDigest: binding.actionDigest,
+          resumeAttemptId,
+        };
+      });
+    } catch (e) {
+      if (e instanceof AuditUnavailableError) return fail("EVIDENCE_REQUIRED_AUDIT_UNAVAILABLE", 503);
+      return fail("RESUME_PREPARATION_FAILED", 503);
+    }
+  }
+
+  // ── GET approval detail for an eligible approver (safe summary + labels), §9.1 ──
+  // The GET endpoint requires an eligible workspace approver with recent MFA
+  // (even safe summaries are sensitive). Non-enumerating: any ineligibility on a
+  // foreign/absent action returns the same 404 shape as absent.
+  async getApprovalDetailForApprover(
+    tenantId: string,
+    intentId: string,
+    userId: string,
+    sessionMfaVerifiedAt: number,
+  ): Promise<
+    | { ok: true; data: Record<string, unknown> }
+    | { ok: false; code: string; httpStatus: number }
+  > {
+    const loaded = await this.loadCase(this.db(), tenantId, intentId, false);
+    if ("notFound" in loaded) return { ok: false, code: "SCOPE_RESOURCE_NOT_FOUND", httpStatus: 404 };
+    if ("notApproval" in loaded) return { ok: false, code: "APPROVAL_NOT_REQUIRED", httpStatus: 409 };
+    const { binding, queue } = loaded;
+    const approver = await this.checkApprover(
+      this.db(),
+      binding,
+      queue,
+      userId,
+      tenantId,
+      sessionMfaVerifiedAt,
+      false,
+    );
+    if (!approver.ok) return { ok: false, code: approver.code, httpStatus: approver.httpStatus };
+    return {
+      ok: true,
+      data: {
+        id: binding.intentId,
+        status: binding.status,
+        version: binding.bindingRevision,
+        requestHash: binding.requestHash,
+        actionDigest: binding.actionDigest,
+        expiresAt: queue.expiresAt?.toISOString() ?? null,
+        safeSummary: binding.safeSummary,
+        operationId: binding.operationId,
+        providerAccountId: binding.providerAccountId,
+        workspaceId: binding.workspaceId,
+      },
+    };
+  }
+}
+
+// ── module helpers ──
+
+class AuditUnavailableError extends Error {}
+
+function setsEqual(a: Set<string>, b: Set<string>): boolean {
+  if (a.size !== b.size) return false;
+  for (const x of a) if (!b.has(x)) return false;
+  return true;
+}
+
+export const providerApprovalService = new ProviderApprovalService();
+export { ProviderApprovalService, AuditUnavailableError };

--- a/packages/api/src/services/provider-approval.ts
+++ b/packages/api/src/services/provider-approval.ts
@@ -986,15 +986,47 @@ class ProviderApprovalService {
           reason: input.reason,
         });
 
-        if (queue.decisionIdempotencyKeyHash) {
-          if (
-            queue.resolvedById === input.authenticatedUserId &&
-            queue.decisionIdempotencyKeyHash === idemHash
-          ) {
-            if (queue.decisionRequestHash === decisionReqHash) {
-              // Exact retry → return existing decision.
-              return this.decisionReplay(binding, queue);
-            }
+        // Decision idempotency replay. Only replay when THIS queue row is still
+        // in a DECIDED state (approved/rejected/consumed). If the row later
+        // expired/staled (which clears `decision` to NULL but retains the idem
+        // hash), an exact retry must NOT report a stale success — it falls through
+        // to the expiry/terminal handling below (codex P2).
+        if (
+          queue.decisionIdempotencyKeyHash &&
+          queue.resolvedById === input.authenticatedUserId &&
+          queue.decisionIdempotencyKeyHash === idemHash &&
+          queue.decision != null &&
+          (queue.status === "approved" ||
+            queue.status === "rejected" ||
+            queue.status === "consumed")
+        ) {
+          if (queue.decisionRequestHash === decisionReqHash) {
+            // Exact retry → return existing decision.
+            return this.decisionReplay(binding, queue);
+          }
+          return fail("APPROVAL_IDEMPOTENCY_CONFLICT", 409);
+        }
+
+        // Cross-action idempotency conflict (codex P2): the same approver reusing
+        // this decision key on a DIFFERENT intent would violate the partial
+        // unique index (tenant_id, resolved_by_id, decision_idempotency_key_hash)
+        // and surface as an opaque 503. Detect it here and return the precise
+        // 409 instead. Only relevant when we are about to WRITE the key (i.e. the
+        // current row has not already recorded it).
+        if (queue.decisionIdempotencyKeyHash !== idemHash) {
+          const [conflict] = await tx
+            .select({ id: approvalQueue.id })
+            .from(approvalQueue)
+            .where(
+              and(
+                eq(approvalQueue.approvalKind, "provider_action"),
+                eq(approvalQueue.tenantId, input.tenantId),
+                eq(approvalQueue.resolvedById, input.authenticatedUserId),
+                eq(approvalQueue.decisionIdempotencyKeyHash, idemHash),
+              ),
+            )
+            .limit(1);
+          if (conflict && conflict.id !== queue.id) {
             return fail("APPROVAL_IDEMPOTENCY_CONFLICT", 409);
           }
         }

--- a/packages/api/src/services/provider-approval.ts
+++ b/packages/api/src/services/provider-approval.ts
@@ -755,18 +755,34 @@ class ProviderApprovalService {
     loaded: LoadedCase,
   ): Promise<boolean> {
     const { binding, queue } = loaded;
-    // DB time.
-    const [{ due }] = (await tx.execute(
-      sql`SELECT (${queue.expiresAt} <= now()) AS due`,
-    )) as unknown as Array<{ due: boolean }>;
+    // DB time. drizzle's tx.execute returns either an array (postgres-js) or a
+    // { rows } object (pglite/neon), so normalize.
+    const dueRes = await tx.execute(sql`SELECT (${queue.expiresAt} <= now()) AS due`);
+    const dueRows = (
+      Array.isArray(dueRes) ? dueRes : ((dueRes as { rows?: unknown[] }).rows ?? [])
+    ) as Array<{ due: boolean }>;
+    const due = dueRows[0]?.due === true;
     if (!due) return false;
     if (!(queue.status === "pending" || queue.status === "approved")) return false;
 
     const before = binding.bindingRevision;
     const after = before + 1;
+    // The decision-shape CHECK requires expired/stale rows to carry decision
+    // IS NULL / consumed_at IS NULL. An approved-then-expired row must clear its
+    // queue decision fields; the immutable decision evidence is preserved on the
+    // binding (approval_actor_user_id/approved_at) and in the signed
+    // provider.approval.decided audit event (I3 evidence, I14).
     await tx
       .update(approvalQueue)
-      .set({ status: "expired" })
+      .set({
+        status: "expired",
+        decision: null,
+        resolvedAt: null,
+        resolvedByType: null,
+        resolvedById: null,
+        resolvedBy: null,
+        mfaVerifiedAt: null,
+      })
       .where(
         and(
           eq(approvalQueue.id, queue.id),
@@ -819,9 +835,19 @@ class ProviderApprovalService {
   ): Promise<void> {
     const before = binding.bindingRevision;
     const after = before + 1;
+    // See expireIfDue: stale rows must carry decision IS NULL per the shape CHECK;
+    // the immutable decision evidence lives on the binding + audit chain.
     await tx
       .update(approvalQueue)
-      .set({ status: "stale" })
+      .set({
+        status: "stale",
+        decision: null,
+        resolvedAt: null,
+        resolvedByType: null,
+        resolvedById: null,
+        resolvedBy: null,
+        mfaVerifiedAt: null,
+      })
       .where(
         and(eq(approvalQueue.id, queue.id), sql`${approvalQueue.status} IN ('pending','approved')`),
       );

--- a/packages/api/src/services/provider-approval.ts
+++ b/packages/api/src/services/provider-approval.ts
@@ -1447,7 +1447,22 @@ class ProviderApprovalService {
       sessionMfaVerifiedAt,
       false,
     );
-    if (!approver.ok) return { ok: false, code: approver.code, httpStatus: approver.httpStatus };
+    if (!approver.ok) {
+      // Non-enumeration (I16, codex P2): an ineligible tenant member must NOT be
+      // able to distinguish an existing approval action from an absent one on
+      // this READ path. Membership/role/separation eligibility failures collapse
+      // to the same 404 as an absent id. MFA failures are surfaced (they are not
+      // enumeration signals: the caller already proved tenant membership and the
+      // MFA gate is enforced at the route before this call).
+      if (
+        approver.code === "APPROVAL_MFA_REQUIRED" ||
+        approver.code === "APPROVAL_MFA_STALE" ||
+        approver.code === "APPROVAL_MFA_TIMESTAMP_INVALID"
+      ) {
+        return { ok: false, code: approver.code, httpStatus: approver.httpStatus };
+      }
+      return { ok: false, code: "SCOPE_RESOURCE_NOT_FOUND", httpStatus: 404 };
+    }
     return {
       ok: true,
       data: {

--- a/packages/api/src/services/provider-approval.ts
+++ b/packages/api/src/services/provider-approval.ts
@@ -36,12 +36,12 @@ import {
   workspaces,
 } from "@stwd/db";
 import {
-  type ProviderApprovalAuditPayloadV1,
-  type ProviderApprovalCommitmentV1,
   computeApprovalCommitmentHash,
   computeDecisionRequestHash,
   jcsStringify,
   PROVIDER_APPROVAL_AUDIT_SCHEMA,
+  type ProviderApprovalAuditPayloadV1,
+  type ProviderApprovalCommitmentV1,
   sha256HexPrefixed,
 } from "@stwd/shared";
 import { and, eq, sql } from "drizzle-orm";
@@ -291,10 +291,6 @@ function buildAuditPayload(
   };
 }
 
-function auditActor(actorType: "agent" | "user" | "system", actorId: string | null) {
-  return { actorType, actorId };
-}
-
 // ─── The service ──────────────────────────────────────────────────────────────
 
 class ProviderApprovalService {
@@ -304,16 +300,18 @@ class ProviderApprovalService {
 
   // Test-only fault-injection hooks (production defaults are no-ops; not settable
   // from runtime input). Named per spec §13.
-  faultHooks: Partial<Record<
-    | "afterScopeLoad"
-    | "afterIntegrity"
-    | "afterAuthority"
-    | "afterMfa"
-    | "beforeAudit"
-    | "afterAudit"
-    | "beforeCommit",
-    () => void | Promise<void>
-  >> = {};
+  faultHooks: Partial<
+    Record<
+      | "afterScopeLoad"
+      | "afterIntegrity"
+      | "afterAuthority"
+      | "afterMfa"
+      | "beforeAudit"
+      | "afterAudit"
+      | "beforeCommit",
+      () => void | Promise<void>
+    >
+  > = {};
 
   private async hook(name: keyof ProviderApprovalService["faultHooks"]): Promise<void> {
     const h = this.faultHooks[name];
@@ -511,7 +509,11 @@ class ProviderApprovalService {
         ),
       )
       .limit(1);
-    if (!operation || operation.status !== "active" || operation.revision !== c.operation.revision) {
+    if (
+      !operation ||
+      operation.status !== "active" ||
+      operation.revision !== c.operation.revision
+    ) {
       return { ok: false, code: "APPROVAL_OPERATION_STALE" };
     }
 
@@ -523,7 +525,10 @@ class ProviderApprovalService {
       .select({ id: secretRoutes.id, authorityRevision: secretRoutes.authorityRevision })
       .from(secretRoutes)
       .where(
-        and(eq(secretRoutes.tenantId, binding.tenantId), eq(secretRoutes.id, operation.secretRouteId)),
+        and(
+          eq(secretRoutes.tenantId, binding.tenantId),
+          eq(secretRoutes.id, operation.secretRouteId),
+        ),
       )
       .limit(1);
     if (!route || route.authorityRevision !== c.executionDependencies.routeRevision) {
@@ -541,7 +546,13 @@ class ProviderApprovalService {
     // that changed/vanished stales, even if another allow remains (I6/N32).
     for (const g of c.accessDecision.matchedGrants) {
       const [row] = await tx
-        .select({ revision: providerGrants.revision, status: providerGrants.status, notBefore: providerGrants.notBefore, expiresAt: providerGrants.expiresAt, environment: providerGrants.environment })
+        .select({
+          revision: providerGrants.revision,
+          status: providerGrants.status,
+          notBefore: providerGrants.notBefore,
+          expiresAt: providerGrants.expiresAt,
+          environment: providerGrants.environment,
+        })
         .from(providerGrants)
         .where(and(eq(providerGrants.tenantId, binding.tenantId), eq(providerGrants.id, g.id)))
         .limit(1);
@@ -554,9 +565,19 @@ class ProviderApprovalService {
     }
     for (const b of c.accessDecision.matchedBindings) {
       const [row] = await tx
-        .select({ revision: providerRoleBindings.revision, status: providerRoleBindings.status, notBefore: providerRoleBindings.notBefore, expiresAt: providerRoleBindings.expiresAt })
+        .select({
+          revision: providerRoleBindings.revision,
+          status: providerRoleBindings.status,
+          notBefore: providerRoleBindings.notBefore,
+          expiresAt: providerRoleBindings.expiresAt,
+        })
         .from(providerRoleBindings)
-        .where(and(eq(providerRoleBindings.tenantId, binding.tenantId), eq(providerRoleBindings.id, b.id)))
+        .where(
+          and(
+            eq(providerRoleBindings.tenantId, binding.tenantId),
+            eq(providerRoleBindings.id, b.id),
+          ),
+        )
         .limit(1);
       if (!row || row.status !== "active" || row.revision !== b.revision) {
         return { ok: false, code: "APPROVAL_GRANT_STALE" };
@@ -634,7 +655,8 @@ class ProviderApprovalService {
           if (b.notBefore && b.notBefore > now) return false;
           if (b.expiresAt && b.expiresAt <= now) return false;
           if (b.environment && b.environment !== env) return false;
-          if (b.providerAccountId && b.providerAccountId !== binding.providerAccountId) return false;
+          if (b.providerAccountId && b.providerAccountId !== binding.providerAccountId)
+            return false;
           if (b.roleKey === "workspace_operator")
             return b.operationKeys.includes(operation.operationKey);
           if (b.roleKey === "workspace_viewer")
@@ -784,14 +806,16 @@ class ProviderApprovalService {
         mfaVerifiedAt: null,
       })
       .where(
-        and(
-          eq(approvalQueue.id, queue.id),
-          sql`${approvalQueue.status} IN ('pending','approved')`,
-        ),
+        and(eq(approvalQueue.id, queue.id), sql`${approvalQueue.status} IN ('pending','approved')`),
       );
     await tx
       .update(providerActionBindings)
-      .set({ status: "approval_expired", bindingRevision: after, expiredAt: new Date(), updatedAt: new Date() })
+      .set({
+        status: "approval_expired",
+        bindingRevision: after,
+        expiredAt: new Date(),
+        updatedAt: new Date(),
+      })
       .where(
         and(
           eq(providerActionBindings.intentId, binding.intentId),
@@ -800,7 +824,12 @@ class ProviderApprovalService {
       );
     await tx
       .update(intents)
-      .set({ status: "expired", expiredBy: RESUME_ACTOR, expiredAt: new Date(), updatedAt: new Date() })
+      .set({
+        status: "expired",
+        expiredBy: RESUME_ACTOR,
+        expiredAt: new Date(),
+        updatedAt: new Date(),
+      })
       .where(eq(intents.id, binding.intentId));
 
     const payload = buildAuditPayload(binding, queue, {
@@ -1212,7 +1241,8 @@ class ProviderApprovalService {
         };
       });
     } catch (e) {
-      if (e instanceof AuditUnavailableError) return fail("EVIDENCE_REQUIRED_AUDIT_UNAVAILABLE", 503);
+      if (e instanceof AuditUnavailableError)
+        return fail("EVIDENCE_REQUIRED_AUDIT_UNAVAILABLE", 503);
       return fail("APPROVAL_PERSISTENCE_FAILED", 503);
     }
   }
@@ -1384,7 +1414,8 @@ class ProviderApprovalService {
         };
       });
     } catch (e) {
-      if (e instanceof AuditUnavailableError) return fail("EVIDENCE_REQUIRED_AUDIT_UNAVAILABLE", 503);
+      if (e instanceof AuditUnavailableError)
+        return fail("EVIDENCE_REQUIRED_AUDIT_UNAVAILABLE", 503);
       return fail("RESUME_PREPARATION_FAILED", 503);
     }
   }
@@ -1399,12 +1430,13 @@ class ProviderApprovalService {
     userId: string,
     sessionMfaVerifiedAt: number,
   ): Promise<
-    | { ok: true; data: Record<string, unknown> }
-    | { ok: false; code: string; httpStatus: number }
+    { ok: true; data: Record<string, unknown> } | { ok: false; code: string; httpStatus: number }
   > {
     const loaded = await this.loadCase(this.db(), tenantId, intentId, false);
-    if ("notFound" in loaded) return { ok: false, code: "SCOPE_RESOURCE_NOT_FOUND", httpStatus: 404 };
-    if ("notApproval" in loaded) return { ok: false, code: "APPROVAL_NOT_REQUIRED", httpStatus: 409 };
+    if ("notFound" in loaded)
+      return { ok: false, code: "SCOPE_RESOURCE_NOT_FOUND", httpStatus: 404 };
+    if ("notApproval" in loaded)
+      return { ok: false, code: "APPROVAL_NOT_REQUIRED", httpStatus: 409 };
     const { binding, queue } = loaded;
     const approver = await this.checkApprover(
       this.db(),
@@ -1445,4 +1477,4 @@ function setsEqual(a: Set<string>, b: Set<string>): boolean {
 }
 
 export const providerApprovalService = new ProviderApprovalService();
-export { ProviderApprovalService, AuditUnavailableError };
+export { AuditUnavailableError, ProviderApprovalService };

--- a/packages/api/src/services/provider-approval.ts
+++ b/packages/api/src/services/provider-approval.ts
@@ -466,13 +466,25 @@ class ProviderApprovalService {
       .limit(1);
     if (!agent) return { ok: false, code: "APPROVAL_DEPENDENCY_STALE" };
 
-    // Workspace current + revision.
+    // Workspace current + EXACT committed revision. The committed value lives in
+    // the persisted PR2 access decision (dependencyRevisions.workspace); a
+    // workspace-authority revision bump while the workspace stays active must
+    // stale the action (exact dependency binding, codex P1).
     const [workspace] = await tx
       .select()
       .from(workspaces)
       .where(and(eq(workspaces.tenantId, binding.tenantId), eq(workspaces.id, binding.workspaceId)))
       .limit(1);
     if (!workspace || workspace.status !== "active") {
+      return { ok: false, code: "APPROVAL_DEPENDENCY_STALE" };
+    }
+    const committedWorkspaceRevision = (
+      binding.dependencyRevisions as { workspace?: number } | null
+    )?.workspace;
+    if (
+      typeof committedWorkspaceRevision === "number" &&
+      workspace.revision !== committedWorkspaceRevision
+    ) {
       return { ok: false, code: "APPROVAL_DEPENDENCY_STALE" };
     }
 

--- a/packages/api/src/services/provider-approval.ts
+++ b/packages/api/src/services/provider-approval.ts
@@ -700,13 +700,20 @@ class ProviderApprovalService {
         : { ok: false, code: "APPROVAL_MEMBERSHIP_INACTIVE", httpStatus: 403 };
     }
 
-    // Active, in-window workspace_approver binding for THIS exact workspace.
+    // The action's environment is the committed workspace environment. An
+    // environment-scoped approver binding must match it (a NULL binding env =
+    // all environments). This mirrors the actor access checks which gate on
+    // workspace.environment (codex P1).
+    const [workspace] = await tx
+      .select({ environment: workspaces.environment })
+      .from(workspaces)
+      .where(and(eq(workspaces.tenantId, tenantId), eq(workspaces.id, binding.workspaceId)))
+      .limit(1);
+    const actionEnv = workspace?.environment;
+
+    // Active, in-window, in-environment workspace_approver binding for THIS exact
+    // workspace.
     const now = new Date();
-    const env = (queue.approvalCommitment as unknown as ProviderApprovalCommitmentV1 | null)
-      ?.operation
-      ? undefined
-      : undefined;
-    void env;
     const approverRows = await tx
       .select()
       .from(providerRoleBindings)
@@ -721,7 +728,10 @@ class ProviderApprovalService {
         ),
       );
     const eligible = approverRows.some(
-      (b) => (!b.notBefore || b.notBefore <= now) && (!b.expiresAt || b.expiresAt > now),
+      (b) =>
+        (!b.notBefore || b.notBefore <= now) &&
+        (!b.expiresAt || b.expiresAt > now) &&
+        (!b.environment || b.environment === actionEnv),
     );
     if (!eligible) {
       return atResume
@@ -794,7 +804,7 @@ class ProviderApprovalService {
     // queue decision fields; the immutable decision evidence is preserved on the
     // binding (approval_actor_user_id/approved_at) and in the signed
     // provider.approval.decided audit event (I3 evidence, I14).
-    await tx
+    const won = await tx
       .update(approvalQueue)
       .set({
         status: "expired",
@@ -807,7 +817,11 @@ class ProviderApprovalService {
       })
       .where(
         and(eq(approvalQueue.id, queue.id), sql`${approvalQueue.status} IN ('pending','approved')`),
-      );
+      )
+      .returning({ id: approvalQueue.id });
+    // Guarded CAS: if a concurrent winner already transitioned the row, do NOT
+    // update the intent or append a duplicate expired event (codex P2).
+    if (won.length === 0) return false;
     await tx
       .update(providerActionBindings)
       .set({
@@ -854,19 +868,21 @@ class ProviderApprovalService {
     return true;
   }
 
-  // ── Stale transition (spec §6.7). One tx moves pending/approved → stale. ──
+  // ── Stale transition (spec §6.7). One tx moves pending/approved → stale.
+  // Returns false if a concurrent winner already moved the row (guarded CAS lost)
+  // so the caller does NOT emit a duplicate transition or audit event (codex P2). ──
   private async staleTransition(
     tx: DbExecutor,
     append: (ev: { tenantId: string } & Record<string, unknown>) => Promise<void>,
     binding: BindingRow,
     queue: QueueRow,
     reasonCode: string,
-  ): Promise<void> {
+  ): Promise<boolean> {
     const before = binding.bindingRevision;
     const after = before + 1;
     // See expireIfDue: stale rows must carry decision IS NULL per the shape CHECK;
     // the immutable decision evidence lives on the binding + audit chain.
-    await tx
+    const won = await tx
       .update(approvalQueue)
       .set({
         status: "stale",
@@ -879,7 +895,10 @@ class ProviderApprovalService {
       })
       .where(
         and(eq(approvalQueue.id, queue.id), sql`${approvalQueue.status} IN ('pending','approved')`),
-      );
+      )
+      .returning({ id: approvalQueue.id });
+    // Loser: another attempt already transitioned the row. Emit nothing.
+    if (won.length === 0) return false;
     await tx
       .update(providerActionBindings)
       .set({
@@ -924,6 +943,7 @@ class ProviderApprovalService {
       resourceId: binding.intentId,
       metadata: payload as unknown as Record<string, unknown>,
     });
+    return true;
   }
 
   // ── Terminal-state → outcome mapping for a loaded (non-transitioning) case. ──

--- a/packages/db/drizzle/0081_exact_approval_binding.sql
+++ b/packages/db/drizzle/0081_exact_approval_binding.sql
@@ -244,6 +244,47 @@ ALTER TABLE "provider_action_bindings" ADD CONSTRAINT "provider_action_bindings_
 );
 --> statement-breakpoint
 
+-- Drop the PR2 immutability trigger BEFORE the legacy backfill so the backfill
+-- UPDATE (pending_approval -> approval_stale on pre-existing rows) is not
+-- rejected by the PR2 transition allowlist / frozen-column guard. The PR3
+-- transition trigger is (re)created at the end of this migration.
+DROP TRIGGER IF EXISTS provider_action_bindings_immutable ON "provider_action_bindings";
+--> statement-breakpoint
+DROP FUNCTION IF EXISTS steward_provider_action_binding_guard();
+--> statement-breakpoint
+
+-- Backfill legacy PR2 `pending_approval` rows BEFORE adding the shape CHECK. On
+-- a database that already carries approval-required actions created under PR2
+-- (before this migration), the new approval columns are NULL, and the pending
+-- branch of the shape CHECK requires approval_queue_id + approval_commitment_hash
+-- to be NOT NULL. Rather than fabricate an unverifiable commitment for a legacy
+-- row, transition any pre-existing pending_approval binding (and its intent) to
+-- the terminal `approval_stale` classification with a stable migration reason so
+-- the requester must re-request under the exact-binding regime. This keeps the
+-- migration forward-safe on deployments with outstanding approvals.
+UPDATE "provider_action_bindings"
+  SET "status" = 'approval_stale',
+      "stale_at" = now(),
+      "stale_reason_code" = 'APPROVAL_MIGRATED_PR3',
+      -- approval_queue_id is required by the stale branch of the shape CHECK; a
+      -- legacy pending row has none, so synthesize a stable placeholder id that
+      -- references no queue row (the stale branch only requires NOT NULL).
+      "approval_queue_id" = 'aq_migrated_' || "intent_id",
+      "updated_at" = now()
+  WHERE "status" = 'pending_approval';
+--> statement-breakpoint
+UPDATE "intents" i
+  SET "status" = 'canceled',
+      "canceled_by" = 'steward-system',
+      "canceled_at" = now(),
+      "cancellation_reason" = 'APPROVAL_MIGRATED_PR3',
+      "updated_at" = now()
+  FROM "provider_action_bindings" b
+  WHERE b."intent_id" = i."id"
+    AND b."stale_reason_code" = 'APPROVAL_MIGRATED_PR3'
+    AND i."status" = 'pending';
+--> statement-breakpoint
+
 -- Per-state field-shape CHECK (spec §4.2): which lifecycle columns must be set
 -- for each approval status. Non-approval statuses (PR2 lineage) carry none.
 ALTER TABLE "provider_action_bindings" ADD CONSTRAINT "provider_action_bindings_approval_shape_chk" CHECK (

--- a/packages/db/drizzle/0081_exact_approval_binding.sql
+++ b/packages/db/drizzle/0081_exact_approval_binding.sql
@@ -1,0 +1,351 @@
+-- PR3: exact-request approval binding and safe resume (authority plan PR3).
+--
+-- This migration turns the PR2 `approval_required` provider action into a
+-- recent-human, exact-request approval and a safe `steward-system` resume. It:
+--
+--   1. Adds `secret_routes.authority_revision` + a BEFORE UPDATE bump trigger
+--      (G1 orchestrator adjudication: PR3's approval commitment binds a route
+--      revision, so the column must exist in PR3's migration, not PR4's 0082).
+--   2. Turns `approval_queue` into a discriminated union of the legacy
+--      transaction approval and the new provider-intent approval (spec §4.1).
+--      NO `provider_action_approvals` table is created (spec §1).
+--   3. Extends `provider_action_bindings` with the approval lifecycle columns
+--      and REPLACES the PR2 immutability trigger with the PR3 transition trigger
+--      (spec §4.2).
+--
+-- `intents` remains the sole lifecycle root (adjudication conflict 16). There is
+-- no second approval, decision, or execution ledger.
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 1. secret_routes.authority_revision + bump trigger (G1)
+-- ─────────────────────────────────────────────────────────────────────────────
+-- The bump trigger mirrors PR1's 0079 trigger pattern. It stales an unconsumed
+-- v2 authorization on route rotation (PR4 X5), and — more relevantly for PR3 —
+-- it makes the route revision PR3 binds move whenever the route is mutated, so
+-- resume can detect a rotated route (N40 APPROVAL_ROUTE_STALE). PR4's 0082 adds
+-- `authority_mode`, `provider_operation_id`, and the governed-mode CHECK; those
+-- are intentionally NOT here.
+ALTER TABLE "secret_routes"
+  ADD COLUMN "authority_revision" integer NOT NULL DEFAULT 1 CHECK ("authority_revision" > 0);
+--> statement-breakpoint
+
+CREATE OR REPLACE FUNCTION steward_bump_secret_route_authority_revision() RETURNS trigger LANGUAGE plpgsql AS $fn$
+BEGIN
+  -- Increment authority_revision by exactly 1 whenever any bound route field
+  -- changes. Mirror PR4 §1.2: host_pattern, path_pattern, method, inject_as,
+  -- inject_key, inject_format, secret_id, enabled changing all bump the
+  -- revision. (authority_mode / provider_operation_id land in PR4's 0082; when
+  -- that migration adds them it will extend this function's predicate.)
+  IF (
+    OLD."host_pattern"  IS DISTINCT FROM NEW."host_pattern"  OR
+    OLD."path_pattern"  IS DISTINCT FROM NEW."path_pattern"  OR
+    OLD."method"        IS DISTINCT FROM NEW."method"        OR
+    OLD."inject_as"     IS DISTINCT FROM NEW."inject_as"     OR
+    OLD."inject_key"    IS DISTINCT FROM NEW."inject_key"    OR
+    OLD."inject_format" IS DISTINCT FROM NEW."inject_format" OR
+    OLD."secret_id"     IS DISTINCT FROM NEW."secret_id"     OR
+    OLD."enabled"       IS DISTINCT FROM NEW."enabled"
+  ) THEN
+    NEW."authority_revision" := OLD."authority_revision" + 1;
+  END IF;
+  RETURN NEW;
+END $fn$;
+--> statement-breakpoint
+CREATE TRIGGER secret_routes_bump_authority_revision
+  BEFORE UPDATE ON "secret_routes"
+  FOR EACH ROW EXECUTE FUNCTION steward_bump_secret_route_authority_revision();
+--> statement-breakpoint
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 2. approval_queue: discriminated union (transaction | provider_action)
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Legacy transaction approvals keep tx_id NOT NULL semantics via the arm CHECK.
+ALTER TABLE "approval_queue" ALTER COLUMN "tx_id" DROP NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "approval_queue" ADD COLUMN "intent_id" varchar(64);
+--> statement-breakpoint
+ALTER TABLE "approval_queue" ADD COLUMN "approval_kind" varchar(32) NOT NULL DEFAULT 'transaction';
+--> statement-breakpoint
+ALTER TABLE "approval_queue" ADD COLUMN "tenant_id" varchar(64);
+--> statement-breakpoint
+ALTER TABLE "approval_queue" ADD COLUMN "workspace_id" uuid;
+--> statement-breakpoint
+ALTER TABLE "approval_queue" ADD COLUMN "request_hash" varchar(71);
+--> statement-breakpoint
+ALTER TABLE "approval_queue" ADD COLUMN "action_digest" varchar(71);
+--> statement-breakpoint
+ALTER TABLE "approval_queue" ADD COLUMN "approval_commitment" jsonb;
+--> statement-breakpoint
+ALTER TABLE "approval_queue" ADD COLUMN "approval_commitment_hash" varchar(71);
+--> statement-breakpoint
+ALTER TABLE "approval_queue" ADD COLUMN "expected_binding_revision" integer;
+--> statement-breakpoint
+ALTER TABLE "approval_queue" ADD COLUMN "expires_at" timestamptz;
+--> statement-breakpoint
+ALTER TABLE "approval_queue" ADD COLUMN "decision" varchar(16);
+--> statement-breakpoint
+ALTER TABLE "approval_queue" ADD COLUMN "reason_code" varchar(96);
+--> statement-breakpoint
+ALTER TABLE "approval_queue" ADD COLUMN "reason" text;
+--> statement-breakpoint
+ALTER TABLE "approval_queue" ADD COLUMN "mfa_verified_at" timestamptz;
+--> statement-breakpoint
+ALTER TABLE "approval_queue" ADD COLUMN "mfa_age_ms_at_decision" integer;
+--> statement-breakpoint
+ALTER TABLE "approval_queue" ADD COLUMN "decision_idempotency_key_hash" varchar(71);
+--> statement-breakpoint
+ALTER TABLE "approval_queue" ADD COLUMN "decision_request_hash" varchar(71);
+--> statement-breakpoint
+ALTER TABLE "approval_queue" ADD COLUMN "consumed_at" timestamptz;
+--> statement-breakpoint
+ALTER TABLE "approval_queue" ADD COLUMN "consumed_by" varchar(64);
+--> statement-breakpoint
+
+-- New provider lifecycle statuses. The enum already carries pending/approved/
+-- rejected (transaction arm reuses those).
+ALTER TYPE "approval_queue_status" ADD VALUE IF NOT EXISTS 'expired';
+--> statement-breakpoint
+ALTER TYPE "approval_queue_status" ADD VALUE IF NOT EXISTS 'stale';
+--> statement-breakpoint
+ALTER TYPE "approval_queue_status" ADD VALUE IF NOT EXISTS 'consumed';
+--> statement-breakpoint
+
+-- Backfill legacy rows explicitly (the DEFAULT already set 'transaction', this
+-- is belt-and-suspenders for any row inserted before the DEFAULT existed).
+UPDATE "approval_queue" SET "approval_kind" = 'transaction' WHERE "approval_kind" IS NULL;
+--> statement-breakpoint
+
+-- Composite FK: a provider row's (tenant_id, intent_id) must reference a real
+-- intent. Legacy rows carry NULL tenant_id/intent_id and are exempt (the FK is
+-- NULL-permissive on either column).
+ALTER TABLE "approval_queue"
+  ADD CONSTRAINT "approval_queue_intent_fk"
+  FOREIGN KEY ("tenant_id", "intent_id")
+  REFERENCES "intents" ("tenant_id", "id") ON DELETE CASCADE;
+--> statement-breakpoint
+
+-- Arm discriminator: transaction rows keep tx_id and carry no provider fields;
+-- provider rows carry the full exact-binding tuple and no tx_id.
+ALTER TABLE "approval_queue" ADD CONSTRAINT "approval_queue_arm_chk" CHECK (
+  ("approval_kind" = 'transaction'
+    AND "tx_id" IS NOT NULL AND "intent_id" IS NULL
+    AND "workspace_id" IS NULL AND "request_hash" IS NULL
+    AND "action_digest" IS NULL AND "approval_commitment" IS NULL
+    AND "approval_commitment_hash" IS NULL)
+  OR
+  ("approval_kind" = 'provider_action'
+    AND "tx_id" IS NULL AND "intent_id" IS NOT NULL
+    AND "tenant_id" IS NOT NULL AND "workspace_id" IS NOT NULL
+    AND "request_hash" ~ '^sha256:[0-9a-f]{64}$'
+    AND "action_digest" ~ '^sha256:[0-9a-f]{64}$'
+    AND "approval_commitment" IS NOT NULL
+    AND "approval_commitment_hash" ~ '^sha256:[0-9a-f]{64}$'
+    AND "expected_binding_revision" > 0
+    AND "expires_at" IS NOT NULL)
+);
+--> statement-breakpoint
+
+-- Decision shape: pin the (status, decision, resolution, mfa, consumption)
+-- tuple for every provider lifecycle state. Legacy transaction rows are exempt.
+ALTER TABLE "approval_queue" ADD CONSTRAINT "approval_queue_decision_shape_chk" CHECK (
+  ("approval_kind" = 'transaction') OR
+  ("status" = 'pending' AND "decision" IS NULL AND "resolved_at" IS NULL
+    AND "resolved_by_type" IS NULL AND "resolved_by_id" IS NULL
+    AND "mfa_verified_at" IS NULL AND "consumed_at" IS NULL)
+  OR
+  ("status" = 'approved' AND "decision" = 'approve' AND "resolved_at" IS NOT NULL
+    AND "resolved_by_type" = 'user' AND "resolved_by_id" IS NOT NULL
+    AND "mfa_verified_at" IS NOT NULL AND "consumed_at" IS NULL)
+  OR
+  ("status" = 'rejected' AND "decision" = 'deny' AND "resolved_at" IS NOT NULL
+    AND "resolved_by_type" = 'user' AND "resolved_by_id" IS NOT NULL
+    AND "mfa_verified_at" IS NOT NULL AND "consumed_at" IS NULL)
+  OR
+  ("status" IN ('expired','stale') AND "decision" IS NULL AND "consumed_at" IS NULL)
+  OR
+  ("status" = 'consumed' AND "decision" = 'approve' AND "resolved_at" IS NOT NULL
+    AND "resolved_by_type" = 'user' AND "resolved_by_id" IS NOT NULL
+    AND "mfa_verified_at" IS NOT NULL AND "consumed_at" IS NOT NULL
+    AND "consumed_by" = 'steward-system')
+);
+--> statement-breakpoint
+
+-- One approval row per intent (partial unique on the provider arm).
+CREATE UNIQUE INDEX "approval_queue_intent_id_idx"
+  ON "approval_queue" ("intent_id") WHERE "intent_id" IS NOT NULL;
+--> statement-breakpoint
+CREATE INDEX "approval_queue_provider_scope_status_idx"
+  ON "approval_queue" ("tenant_id", "workspace_id", "status", "requested_at" DESC)
+  WHERE "approval_kind" = 'provider_action';
+--> statement-breakpoint
+-- Decision idempotency is scoped to (tenant, approver, key-hash) on the
+-- provider arm; the key is only ever stored hashed.
+CREATE UNIQUE INDEX "approval_queue_provider_decision_idem_idx"
+  ON "approval_queue" ("tenant_id", "resolved_by_id", "decision_idempotency_key_hash")
+  WHERE "approval_kind" = 'provider_action'
+    AND "decision_idempotency_key_hash" IS NOT NULL;
+--> statement-breakpoint
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 3. provider_action_bindings: approval lifecycle columns + PR3 transition trigger
+-- ─────────────────────────────────────────────────────────────────────────────
+ALTER TABLE "provider_action_bindings"
+  ADD COLUMN "binding_revision" integer NOT NULL DEFAULT 1,
+  ADD COLUMN "approval_queue_id" varchar(64),
+  ADD COLUMN "approval_actor_user_id" uuid,
+  ADD COLUMN "approval_commitment_hash" varchar(71),
+  ADD COLUMN "approved_at" timestamptz,
+  ADD COLUMN "denied_at" timestamptz,
+  ADD COLUMN "expired_at" timestamptz,
+  ADD COLUMN "stale_at" timestamptz,
+  ADD COLUMN "stale_reason_code" varchar(96),
+  ADD COLUMN "resume_actor" varchar(64),
+  ADD COLUMN "resume_attempt_id" uuid,
+  ADD COLUMN "resume_validated_at" timestamptz;
+--> statement-breakpoint
+
+ALTER TABLE "provider_action_bindings"
+  ADD CONSTRAINT "provider_action_bindings_binding_revision_chk"
+    CHECK ("binding_revision" > 0);
+--> statement-breakpoint
+
+-- One binding per approval-queue row (partial unique; NULL until a queue exists).
+CREATE UNIQUE INDEX "provider_action_bindings_approval_queue_id_uniq"
+  ON "provider_action_bindings" ("approval_queue_id")
+  WHERE "approval_queue_id" IS NOT NULL;
+--> statement-breakpoint
+
+-- Extend the status allowlist to the PR3 approval lifecycle. Drop the PR2 CHECK
+-- and re-add it with the full set. PR4 later adds executing/succeeded/failed/
+-- outcome_unknown.
+ALTER TABLE "provider_action_bindings" DROP CONSTRAINT "provider_action_bindings_status_chk";
+--> statement-breakpoint
+ALTER TABLE "provider_action_bindings" ADD CONSTRAINT "provider_action_bindings_status_chk"
+  CHECK ("status" IN (
+    'denied','pending_approval','allowed_stub','stub_succeeded','stub_failed',
+    'approved','execution_ready','approval_denied','approval_expired','approval_stale'
+  ));
+--> statement-breakpoint
+
+-- The PR2 `_state_chk` pins (access_effect, policy_effect, status). Approval
+-- lifecycle transitions move `status` away from 'pending_approval' while the
+-- decision effects stay fixed, so the old equality must be relaxed to allow all
+-- of the approval-required lineage statuses.
+ALTER TABLE "provider_action_bindings" DROP CONSTRAINT "provider_action_bindings_state_chk";
+--> statement-breakpoint
+ALTER TABLE "provider_action_bindings" ADD CONSTRAINT "provider_action_bindings_state_chk" CHECK (
+  ("access_effect" = 'deny' AND "policy_effect" = 'not_evaluated' AND "status" = 'denied') OR
+  ("access_effect" = 'allow' AND "policy_effect" = 'hard_deny' AND "status" = 'denied') OR
+  ("access_effect" = 'allow' AND "policy_effect" = 'approval_required'
+    AND "status" IN ('pending_approval','approved','execution_ready',
+                     'approval_denied','approval_expired','approval_stale')) OR
+  ("access_effect" = 'allow' AND "policy_effect" = 'allow'
+    AND "status" IN ('allowed_stub','stub_succeeded','stub_failed'))
+);
+--> statement-breakpoint
+
+-- Per-state field-shape CHECK (spec §4.2): which lifecycle columns must be set
+-- for each approval status. Non-approval statuses (PR2 lineage) carry none.
+ALTER TABLE "provider_action_bindings" ADD CONSTRAINT "provider_action_bindings_approval_shape_chk" CHECK (
+  ("status" NOT IN ('pending_approval','approved','execution_ready','approval_denied','approval_expired','approval_stale')
+    AND "approval_actor_user_id" IS NULL AND "approved_at" IS NULL AND "denied_at" IS NULL
+    AND "expired_at" IS NULL AND "stale_at" IS NULL
+    AND "resume_actor" IS NULL AND "resume_attempt_id" IS NULL AND "resume_validated_at" IS NULL)
+  OR
+  ("status" = 'pending_approval'
+    AND "approval_queue_id" IS NOT NULL AND "approval_commitment_hash" IS NOT NULL
+    AND "approval_actor_user_id" IS NULL AND "approved_at" IS NULL AND "denied_at" IS NULL
+    AND "expired_at" IS NULL AND "stale_at" IS NULL
+    AND "resume_actor" IS NULL AND "resume_attempt_id" IS NULL AND "resume_validated_at" IS NULL)
+  OR
+  ("status" = 'approved'
+    AND "approval_queue_id" IS NOT NULL AND "approval_commitment_hash" IS NOT NULL
+    AND "approval_actor_user_id" IS NOT NULL AND "approved_at" IS NOT NULL
+    AND "denied_at" IS NULL AND "expired_at" IS NULL AND "stale_at" IS NULL
+    AND "resume_actor" IS NULL AND "resume_attempt_id" IS NULL AND "resume_validated_at" IS NULL)
+  OR
+  ("status" = 'execution_ready'
+    AND "approval_queue_id" IS NOT NULL AND "approval_commitment_hash" IS NOT NULL
+    AND "approval_actor_user_id" IS NOT NULL AND "approved_at" IS NOT NULL
+    AND "resume_actor" = 'steward-system' AND "resume_attempt_id" IS NOT NULL
+    AND "resume_validated_at" IS NOT NULL)
+  OR
+  ("status" = 'approval_denied'
+    AND "approval_queue_id" IS NOT NULL AND "approval_actor_user_id" IS NOT NULL
+    AND "denied_at" IS NOT NULL
+    AND "approved_at" IS NULL AND "expired_at" IS NULL AND "stale_at" IS NULL
+    AND "resume_actor" IS NULL)
+  OR
+  ("status" = 'approval_expired'
+    AND "approval_queue_id" IS NOT NULL AND "expired_at" IS NOT NULL
+    AND "denied_at" IS NULL AND "stale_at" IS NULL AND "resume_actor" IS NULL)
+  OR
+  ("status" = 'approval_stale'
+    AND "approval_queue_id" IS NOT NULL AND "stale_at" IS NOT NULL
+    AND "stale_reason_code" IS NOT NULL
+    AND "denied_at" IS NULL AND "expired_at" IS NULL AND "resume_actor" IS NULL)
+);
+--> statement-breakpoint
+
+-- Replace the PR2 immutability trigger with the PR3 transition trigger. PR3
+-- freezes the immutable PR2 columns, permits only the lifecycle columns to
+-- change, enforces the legal transition graph, and requires binding_revision to
+-- increment by exactly one on every state-changing transition (spec §4.2).
+DROP TRIGGER IF EXISTS provider_action_bindings_immutable ON "provider_action_bindings";
+--> statement-breakpoint
+DROP FUNCTION IF EXISTS steward_provider_action_binding_guard();
+--> statement-breakpoint
+CREATE OR REPLACE FUNCTION steward_provider_action_binding_guard() RETURNS trigger LANGUAGE plpgsql AS $fn$
+DECLARE
+  frozen_old jsonb;
+  frozen_new jsonb;
+  mutable text[] := ARRAY[
+    'status','binding_revision','approval_actor_user_id','approval_queue_id',
+    'approval_commitment_hash','approved_at','denied_at','expired_at','stale_at',
+    'stale_reason_code','resume_actor','resume_attempt_id','resume_validated_at','updated_at'
+  ];
+  col text;
+BEGIN
+  -- Freeze every PR2 immutable column. Strip the mutable lifecycle columns from
+  -- both projections; any residual difference is a frozen-column mutation.
+  frozen_old := to_jsonb(OLD);
+  frozen_new := to_jsonb(NEW);
+  FOREACH col IN ARRAY mutable LOOP
+    frozen_old := frozen_old - col;
+    frozen_new := frozen_new - col;
+  END LOOP;
+  IF frozen_old IS DISTINCT FROM frozen_new THEN
+    RAISE EXCEPTION 'provider_action_bindings frozen column mutated' USING ERRCODE = '23514';
+  END IF;
+
+  -- Transition allowlist.
+  IF OLD.status IS DISTINCT FROM NEW.status THEN
+    IF NOT (
+      -- PR2 stub lineage (unchanged).
+      (OLD.status = 'allowed_stub' AND NEW.status IN ('stub_succeeded','stub_failed')) OR
+      -- PR3 approval lifecycle.
+      (OLD.status = 'pending_approval' AND NEW.status IN ('approved','approval_denied','approval_expired','approval_stale')) OR
+      (OLD.status = 'approved'         AND NEW.status IN ('execution_ready','approval_expired','approval_stale'))
+    ) THEN
+      RAISE EXCEPTION 'illegal provider_action_bindings status transition'
+        USING ERRCODE = '23514';
+    END IF;
+    -- Every state-changing transition increments binding_revision by exactly 1.
+    IF NEW.binding_revision IS DISTINCT FROM OLD.binding_revision + 1 THEN
+      RAISE EXCEPTION 'provider_action_bindings binding_revision must increment by exactly one on transition'
+        USING ERRCODE = '23514';
+    END IF;
+  ELSE
+    -- No status change: binding_revision must not move (the only writer of the
+    -- lifecycle is the transition path; a no-op update cannot bump it).
+    IF NEW.binding_revision IS DISTINCT FROM OLD.binding_revision THEN
+      RAISE EXCEPTION 'provider_action_bindings binding_revision changed without a status transition'
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+  RETURN NEW;
+END $fn$;
+--> statement-breakpoint
+CREATE TRIGGER provider_action_bindings_immutable
+  BEFORE UPDATE ON "provider_action_bindings"
+  FOR EACH ROW EXECUTE FUNCTION steward_provider_action_binding_guard();

--- a/packages/db/drizzle/0081_exact_approval_binding.sql
+++ b/packages/db/drizzle/0081_exact_approval_binding.sql
@@ -320,19 +320,25 @@ BEGIN
 
   -- Transition allowlist.
   IF OLD.status IS DISTINCT FROM NEW.status THEN
-    IF NOT (
-      -- PR2 stub lineage (unchanged).
-      (OLD.status = 'allowed_stub' AND NEW.status IN ('stub_succeeded','stub_failed')) OR
+    IF (OLD.status = 'allowed_stub' AND NEW.status IN ('stub_succeeded','stub_failed')) THEN
+      -- PR2 stub lineage: does NOT participate in the binding_revision optimistic
+      -- lock (PR2 sets only status/updated_at). Leave binding_revision unchanged.
+      IF NEW.binding_revision IS DISTINCT FROM OLD.binding_revision THEN
+        RAISE EXCEPTION 'provider_action_bindings stub transition must not change binding_revision'
+          USING ERRCODE = '23514';
+      END IF;
+    ELSIF (
       -- PR3 approval lifecycle.
       (OLD.status = 'pending_approval' AND NEW.status IN ('approved','approval_denied','approval_expired','approval_stale')) OR
       (OLD.status = 'approved'         AND NEW.status IN ('execution_ready','approval_expired','approval_stale'))
     ) THEN
+      -- Every PR3 lifecycle transition increments binding_revision by exactly 1.
+      IF NEW.binding_revision IS DISTINCT FROM OLD.binding_revision + 1 THEN
+        RAISE EXCEPTION 'provider_action_bindings binding_revision must increment by exactly one on transition'
+          USING ERRCODE = '23514';
+      END IF;
+    ELSE
       RAISE EXCEPTION 'illegal provider_action_bindings status transition'
-        USING ERRCODE = '23514';
-    END IF;
-    -- Every state-changing transition increments binding_revision by exactly 1.
-    IF NEW.binding_revision IS DISTINCT FROM OLD.binding_revision + 1 THEN
-      RAISE EXCEPTION 'provider_action_bindings binding_revision must increment by exactly one on transition'
         USING ERRCODE = '23514';
     END IF;
   ELSE

--- a/packages/db/drizzle/0081_exact_approval_binding.sql
+++ b/packages/db/drizzle/0081_exact_approval_binding.sql
@@ -147,23 +147,31 @@ ALTER TABLE "approval_queue" ADD CONSTRAINT "approval_queue_arm_chk" CHECK (
 
 -- Decision shape: pin the (status, decision, resolution, mfa, consumption)
 -- tuple for every provider lifecycle state. Legacy transaction rows are exempt.
+--
+-- NOTE: `status` is compared via `::text` because this CHECK references the
+-- enum values ('expired','stale','consumed') that are ADDed to
+-- approval_queue_status EARLIER in THIS migration. Postgres forbids using a
+-- newly-added enum value in the same transaction it was added ("unsafe use of
+-- new value"), and drizzle-orm's migrator wraps a migration file in one
+-- transaction. Casting the enum column to text sidesteps the enum-literal bind
+-- at constraint-creation time and is semantically identical.
 ALTER TABLE "approval_queue" ADD CONSTRAINT "approval_queue_decision_shape_chk" CHECK (
   ("approval_kind" = 'transaction') OR
-  ("status" = 'pending' AND "decision" IS NULL AND "resolved_at" IS NULL
+  ("status"::text = 'pending' AND "decision" IS NULL AND "resolved_at" IS NULL
     AND "resolved_by_type" IS NULL AND "resolved_by_id" IS NULL
     AND "mfa_verified_at" IS NULL AND "consumed_at" IS NULL)
   OR
-  ("status" = 'approved' AND "decision" = 'approve' AND "resolved_at" IS NOT NULL
+  ("status"::text = 'approved' AND "decision" = 'approve' AND "resolved_at" IS NOT NULL
     AND "resolved_by_type" = 'user' AND "resolved_by_id" IS NOT NULL
     AND "mfa_verified_at" IS NOT NULL AND "consumed_at" IS NULL)
   OR
-  ("status" = 'rejected' AND "decision" = 'deny' AND "resolved_at" IS NOT NULL
+  ("status"::text = 'rejected' AND "decision" = 'deny' AND "resolved_at" IS NOT NULL
     AND "resolved_by_type" = 'user' AND "resolved_by_id" IS NOT NULL
     AND "mfa_verified_at" IS NOT NULL AND "consumed_at" IS NULL)
   OR
-  ("status" IN ('expired','stale') AND "decision" IS NULL AND "consumed_at" IS NULL)
+  ("status"::text IN ('expired','stale') AND "decision" IS NULL AND "consumed_at" IS NULL)
   OR
-  ("status" = 'consumed' AND "decision" = 'approve' AND "resolved_at" IS NOT NULL
+  ("status"::text = 'consumed' AND "decision" = 'approve' AND "resolved_at" IS NOT NULL
     AND "resolved_by_type" = 'user' AND "resolved_by_id" IS NOT NULL
     AND "mfa_verified_at" IS NOT NULL AND "consumed_at" IS NOT NULL
     AND "consumed_by" = 'steward-system')

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -428,6 +428,13 @@
       "when": 1784054400000,
       "tag": "0080_provider_action_bindings",
       "breakpoints": true
+    },
+    {
+      "idx": 81,
+      "version": "7",
+      "when": 1784140800000,
+      "tag": "0081_exact_approval_binding",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/__tests__/exact-approval-migration.test.ts
+++ b/packages/db/src/__tests__/exact-approval-migration.test.ts
@@ -15,12 +15,31 @@
  */
 
 import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
-import type { PGlite } from "@electric-sql/pglite";
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { PGlite } from "@electric-sql/pglite";
 import { createPGLiteDb } from "../pglite";
 
 setDefaultTimeout(120_000);
 
 let client: PGlite;
+
+const migrationsDir = new URL("../../drizzle", import.meta.url).pathname;
+const MIG_0081 = "0081_exact_approval_binding.sql";
+
+async function applyFile(c: PGlite, file: string) {
+  const sql = await readFile(join(migrationsDir, file), "utf8");
+  for (const stmt of sql.split("--> statement-breakpoint")) {
+    if (stmt.trim()) await c.exec(stmt);
+  }
+}
+
+async function applyThrough(c: PGlite, upToExclusive: string) {
+  const files = (await readdir(migrationsDir))
+    .filter((f) => f.endsWith(".sql") && f < upToExclusive)
+    .sort();
+  for (const f of files) await applyFile(c, f);
+}
 
 describe("PR3 exact-approval migration (0081)", () => {
   beforeAll(async () => {
@@ -115,6 +134,49 @@ describe("PR3 exact-approval migration (0081)", () => {
        WHERE table_name='approval_queue' AND column_name='tx_id'`,
     );
     expect(txcol.rows[0].is_nullable).toBe("YES");
+  });
+
+  test("backfill: a legacy PR2 pending_approval binding migrates to approval_stale without failing the shape CHECK (P1 codex)", async () => {
+    // Build the pre-0081 schema, insert a pending_approval binding (as PR2 would
+    // leave it), THEN apply 0081 and assert the migration succeeds + reclassifies.
+    const c = new PGlite("memory://");
+    await applyThrough(c, MIG_0081);
+    await c.exec(`
+      INSERT INTO tenants(id,name,api_key_hash) VALUES ('t','T','h');
+      INSERT INTO users(id,email,created_at,updated_at) VALUES
+        ('00000000-0000-4000-8000-000000000001','o@e.test',now(),now());
+      INSERT INTO agents(id,tenant_id,name,wallet_address) VALUES ('ag','t','A','0x1');
+      INSERT INTO workspaces(id,tenant_id,key,name,environment,created_by) VALUES
+        ('00000000-0000-4000-8000-000000000101','t','w','W','production','00000000-0000-4000-8000-000000000001');
+      INSERT INTO provider_accounts(id,tenant_id,workspace_id,adapter_key,external_ref,display_name) VALUES
+        ('00000000-0000-4000-8000-000000000201','t','00000000-0000-4000-8000-000000000101','github','a','A');
+      INSERT INTO provider_operations(id,tenant_id,workspace_id,provider_account_id,operation_key,risk_class) VALUES
+        ('00000000-0000-4000-8000-000000000301','t','00000000-0000-4000-8000-000000000101','00000000-0000-4000-8000-000000000201','github.pr.comment.create','consequential');
+      INSERT INTO intents(id,tenant_id,agent_id,intent_type,status,resource_type,resource_id,created_by_type,created_by_id)
+        VALUES ('pa_legacy','t','ag','provider-action','pending','provider-action','x','agent','ag');
+      INSERT INTO provider_action_bindings(
+        intent_id,tenant_id,workspace_id,actor_agent_id,provider_account_id,operation_id,operation_revision,
+        canonical_profile,canonical_action_bytes,action_digest,request_envelope,request_hash,idempotency_key_hash,
+        safe_summary,access_decision_id,access_effect,access_reason_code,dependency_revisions,access_decision,
+        access_decision_hash,policy_decision_id,policy_effect,policy_revision_hash,policy_decision,policy_decision_hash,status)
+      VALUES (
+        'pa_legacy','t','00000000-0000-4000-8000-000000000101','ag','00000000-0000-4000-8000-000000000201',
+        '00000000-0000-4000-8000-000000000301',1,'github.provider-action.v1',decode('7b7d','hex'),
+        'sha256:${"a".repeat(64)}','{}'::jsonb,'sha256:${"b".repeat(64)}','sha256:${"c".repeat(64)}','{}'::jsonb,
+        '00000000-0000-4000-8000-000000000401','allow','ok','{}'::jsonb,'{}'::jsonb,'sha256:${"d".repeat(64)}',
+        '00000000-0000-4000-8000-000000000501','approval_required','sha256:${"e".repeat(64)}','{}'::jsonb,
+        'sha256:${"f".repeat(64)}','pending_approval');
+    `);
+    // Apply 0081 — must NOT fail on the shape CHECK.
+    await applyFile(c, MIG_0081);
+    const b = await c.query<{ status: string; stale_reason_code: string | null }>(
+      `SELECT status, stale_reason_code FROM provider_action_bindings WHERE intent_id='pa_legacy'`,
+    );
+    expect(b.rows[0].status).toBe("approval_stale");
+    expect(b.rows[0].stale_reason_code).toBe("APPROVAL_MIGRATED_PR3");
+    const i = await c.query<{ status: string }>(`SELECT status FROM intents WHERE id='pa_legacy'`);
+    expect(i.rows[0].status).toBe("canceled");
+    await c.close();
   });
 
   test("the enum carries the PR3 provider lifecycle statuses", async () => {

--- a/packages/db/src/__tests__/exact-approval-migration.test.ts
+++ b/packages/db/src/__tests__/exact-approval-migration.test.ts
@@ -1,0 +1,131 @@
+/**
+ * PR3 migration 0081 schema-invariant tests. Mirrors
+ * provider-authority-migration.test.ts: asserts the raw-SQL-only invariants that
+ * drizzle-kit cannot express survive migration, so accidental removal fails CI.
+ *
+ *   - secret_routes.authority_revision column + bump trigger (G1 adjudication)
+ *   - the PR3 provider_action_bindings transition trigger (replaces the PR2
+ *     immutability trigger)
+ *   - the approval_queue provider-action arm CHECK + decision-shape CHECK
+ *
+ * A single migrated PGLite instance is shared across the cases (fresh WASM
+ * instances per case race the pglite WASM runtime under bun's parallel test
+ * execution). The schema is read-only for all but the trigger-behavior case,
+ * which uses disposable rows.
+ */
+
+import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
+import type { PGlite } from "@electric-sql/pglite";
+import { createPGLiteDb } from "../pglite";
+
+setDefaultTimeout(120_000);
+
+let client: PGlite;
+
+describe("PR3 exact-approval migration (0081)", () => {
+  beforeAll(async () => {
+    ({ client } = await createPGLiteDb("memory://"));
+  });
+  afterAll(async () => {
+    await client.close();
+  });
+
+  test("secret_routes.authority_revision exists with the bump trigger (G1)", async () => {
+    const col = await client.query<{ column_name: string; is_nullable: string }>(
+      `SELECT column_name, is_nullable FROM information_schema.columns
+       WHERE table_name='secret_routes' AND column_name='authority_revision'`,
+    );
+    expect(col.rows.length).toBe(1);
+    expect(col.rows[0].is_nullable).toBe("NO");
+
+    const trg = await client.query<{ tgname: string }>(
+      `SELECT tgname FROM pg_trigger WHERE NOT tgisinternal
+       AND tgname='secret_routes_bump_authority_revision'`,
+    );
+    expect(trg.rows.map((r) => r.tgname)).toEqual(["secret_routes_bump_authority_revision"]);
+
+    const fn = await client.query<{ p: string | null }>(
+      `SELECT to_regprocedure('steward_bump_secret_route_authority_revision()')::text AS p`,
+    );
+    expect(fn.rows[0].p).toBe("steward_bump_secret_route_authority_revision()");
+  });
+
+  test("the authority_revision bump trigger increments on a bound-field change", async () => {
+    await client.exec(`
+      INSERT INTO tenants(id,name,api_key_hash) VALUES ('t','T','h');
+      INSERT INTO secrets(id,tenant_id,name,ciphertext,iv,auth_tag,salt,version)
+        VALUES ('00000000-0000-4000-8000-0000000000a1','t','s','x','x','x','x',1);
+      INSERT INTO secret_routes(id,tenant_id,secret_id,host_pattern,inject_as,inject_key)
+        VALUES ('00000000-0000-4000-8000-0000000000b1','t','00000000-0000-4000-8000-0000000000a1','api.github.com','header','authorization');
+    `);
+    await client.exec(
+      `UPDATE secret_routes SET path_pattern='/changed' WHERE id='00000000-0000-4000-8000-0000000000b1'`,
+    );
+    let rev = await client.query<{ authority_revision: number }>(
+      `SELECT authority_revision FROM secret_routes WHERE id='00000000-0000-4000-8000-0000000000b1'`,
+    );
+    expect(Number(rev.rows[0].authority_revision)).toBe(2);
+    // A non-bound field change (priority) does NOT bump.
+    await client.exec(
+      `UPDATE secret_routes SET priority=5 WHERE id='00000000-0000-4000-8000-0000000000b1'`,
+    );
+    rev = await client.query<{ authority_revision: number }>(
+      `SELECT authority_revision FROM secret_routes WHERE id='00000000-0000-4000-8000-0000000000b1'`,
+    );
+    expect(Number(rev.rows[0].authority_revision)).toBe(2);
+  });
+
+  test("the PR3 provider_action_bindings transition trigger replaces the PR2 one", async () => {
+    const trg = await client.query<{ tgname: string }>(
+      `SELECT tgname FROM pg_trigger WHERE NOT tgisinternal
+       AND tgname='provider_action_bindings_immutable'`,
+    );
+    expect(trg.rows.map((r) => r.tgname)).toEqual(["provider_action_bindings_immutable"]);
+    const fn = await client.query<{ p: string | null }>(
+      `SELECT to_regprocedure('steward_provider_action_binding_guard()')::text AS p`,
+    );
+    expect(fn.rows[0].p).toBe("steward_provider_action_binding_guard()");
+  });
+
+  test("approval_queue carries the provider-action arm columns + constraints", async () => {
+    const cols = await client.query<{ column_name: string }>(
+      `SELECT column_name FROM information_schema.columns
+       WHERE table_name='approval_queue'
+       AND column_name IN ('approval_kind','intent_id','approval_commitment_hash','expected_binding_revision','consumed_by')
+       ORDER BY 1`,
+    );
+    expect(cols.rows.map((r) => r.column_name)).toEqual([
+      "approval_commitment_hash",
+      "approval_kind",
+      "consumed_by",
+      "expected_binding_revision",
+      "intent_id",
+    ]);
+    const chk = await client.query<{ conname: string }>(
+      `SELECT conname FROM pg_constraint
+       WHERE conname IN ('approval_queue_arm_chk','approval_queue_decision_shape_chk')
+       ORDER BY 1`,
+    );
+    expect(chk.rows.map((r) => r.conname)).toEqual([
+      "approval_queue_arm_chk",
+      "approval_queue_decision_shape_chk",
+    ]);
+    const txcol = await client.query<{ is_nullable: string }>(
+      `SELECT is_nullable FROM information_schema.columns
+       WHERE table_name='approval_queue' AND column_name='tx_id'`,
+    );
+    expect(txcol.rows[0].is_nullable).toBe("YES");
+  });
+
+  test("the enum carries the PR3 provider lifecycle statuses", async () => {
+    const vals = await client.query<{ enumlabel: string }>(
+      `SELECT enumlabel FROM pg_enum e
+       JOIN pg_type t ON t.oid = e.enumtypid
+       WHERE t.typname = 'approval_queue_status' ORDER BY enumlabel`,
+    );
+    const labels = vals.rows.map((r) => r.enumlabel);
+    for (const s of ["expired", "stale", "consumed"]) {
+      expect(labels).toContain(s);
+    }
+  });
+});

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -109,6 +109,11 @@ export const approvalQueueStatusEnum = pgEnum("approval_queue_status", [
   "pending",
   "approved",
   "rejected",
+  // PR3 provider-action arm lifecycle statuses (0081). The legacy transaction
+  // arm only ever uses pending/approved/rejected.
+  "expired",
+  "stale",
+  "consumed",
 ]);
 
 export const executionAuthorizationStatusEnum = pgEnum("execution_authorization_status", [
@@ -986,13 +991,19 @@ export const sponsoredGasEvents = pgTable(
   }),
 );
 
+// PR3 (0081): approval_queue is a discriminated union. The legacy transaction
+// arm (approval_kind='transaction') keeps tx_id + the original columns; the new
+// provider_action arm carries the exact-binding tuple. `tx_id` is now nullable
+// (arm CHECK re-requires it for transaction rows). Several PR3 invariants (the
+// arm CHECK, the decision-shape CHECK, and the partial unique indexes) live in
+// 0081 raw SQL and are NOT visible to drizzle-kit.
 export const approvalQueue = pgTable(
   "approval_queue",
   {
     id: varchar("id", { length: 64 }).primaryKey(),
-    txId: varchar("tx_id", { length: 64 })
-      .notNull()
-      .references(() => transactions.id, { onDelete: "cascade" }),
+    txId: varchar("tx_id", { length: 64 }).references(() => transactions.id, {
+      onDelete: "cascade",
+    }),
     agentId: varchar("agent_id", { length: 64 })
       .notNull()
       .references(() => agents.id, { onDelete: "cascade" }),
@@ -1004,6 +1015,26 @@ export const approvalQueue = pgTable(
     resolvedBy: varchar("resolved_by", { length: 255 }),
     resolvedByType: varchar("resolved_by_type", { length: 32 }),
     resolvedById: varchar("resolved_by_id", { length: 255 }),
+    // ── PR3 provider-action arm (0081) ──
+    approvalKind: varchar("approval_kind", { length: 32 }).notNull().default("transaction"),
+    intentId: varchar("intent_id", { length: 64 }),
+    tenantId: varchar("tenant_id", { length: 64 }),
+    workspaceId: uuid("workspace_id"),
+    requestHash: varchar("request_hash", { length: 71 }),
+    actionDigest: varchar("action_digest", { length: 71 }),
+    approvalCommitment: jsonb("approval_commitment").$type<Record<string, unknown>>(),
+    approvalCommitmentHash: varchar("approval_commitment_hash", { length: 71 }),
+    expectedBindingRevision: integer("expected_binding_revision"),
+    expiresAt: timestamp("expires_at", { withTimezone: true }),
+    decision: varchar("decision", { length: 16 }),
+    reasonCode: varchar("reason_code", { length: 96 }),
+    reason: text("reason"),
+    mfaVerifiedAt: timestamp("mfa_verified_at", { withTimezone: true }),
+    mfaAgeMsAtDecision: integer("mfa_age_ms_at_decision"),
+    decisionIdempotencyKeyHash: varchar("decision_idempotency_key_hash", { length: 71 }),
+    decisionRequestHash: varchar("decision_request_hash", { length: 71 }),
+    consumedAt: timestamp("consumed_at", { withTimezone: true }),
+    consumedBy: varchar("consumed_by", { length: 64 }),
   },
   (table) => ({
     txIdUniqueIdx: uniqueIndex("approval_queue_tx_id_idx").on(table.txId),
@@ -1619,6 +1650,12 @@ export const secretRoutes = pgTable(
     enabled: boolean("enabled").notNull().default(true),
     requiresApproval: boolean("requires_approval").notNull().default(false),
     approvalConfig: jsonb("approval_config").$type<Record<string, unknown>>().notNull().default({}),
+    // PR3 (0081, G1 adjudication): a route revision that a route/secret rotation
+    // increments. Bound by PR3's approval commitment so resume can detect route
+    // rotation. Maintained by the `secret_routes_bump_authority_revision`
+    // BEFORE UPDATE trigger (raw SQL only, not visible to drizzle-kit). PR4's
+    // 0082 adds authority_mode + provider_operation_id and extends the trigger.
+    authorityRevision: integer("authority_revision").notNull().default(1),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({
@@ -1989,6 +2026,23 @@ export const providerActionBindings = pgTable(
     policyDecisionHash: varchar("policy_decision_hash", { length: 71 }),
 
     status: varchar("status", { length: 32 }).notNull(),
+    // ── PR3 approval lifecycle columns (0081) ──
+    // Mutable only via the PR3 transition trigger; binding_revision increments by
+    // exactly one per state-changing transition. Several invariants (transition
+    // graph, per-state field-shape CHECK, frozen-column freeze) live in 0081 raw
+    // SQL and are not visible to drizzle-kit.
+    bindingRevision: integer("binding_revision").notNull().default(1),
+    approvalQueueId: varchar("approval_queue_id", { length: 64 }),
+    approvalActorUserId: uuid("approval_actor_user_id"),
+    approvalCommitmentHash: varchar("approval_commitment_hash", { length: 71 }),
+    approvedAt: timestamp("approved_at", { withTimezone: true }),
+    deniedAt: timestamp("denied_at", { withTimezone: true }),
+    expiredAt: timestamp("expired_at", { withTimezone: true }),
+    staleAt: timestamp("stale_at", { withTimezone: true }),
+    staleReasonCode: varchar("stale_reason_code", { length: 96 }),
+    resumeActor: varchar("resume_actor", { length: 64 }),
+    resumeAttemptId: uuid("resume_attempt_id"),
+    resumeValidatedAt: timestamp("resume_validated_at", { withTimezone: true }),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -10,6 +10,7 @@ export * from "./execution-payload.js";
 export type { PriceOracle } from "./price-oracle.js";
 export { createPriceOracle } from "./price-oracle.js";
 export * from "./provider-action.js";
+export * from "./provider-approval.js";
 export * from "./provider-authority.js";
 // ─── Non-throwing description of an arbitrary thrown value (fail-closed catches) ───
 export { describeThrown, UNPRINTABLE_THROWN_VALUE } from "./safe-error.js";

--- a/packages/shared/src/provider-approval.ts
+++ b/packages/shared/src/provider-approval.ts
@@ -85,7 +85,11 @@ export function canonicalApprovalCommitmentObject(
     intentId: c.intentId,
     tenantId: c.tenantId,
     workspaceId: c.workspaceId,
-    requestActor: { type: c.requestActor.type, id: c.requestActor.id, revision: c.requestActor.revision },
+    requestActor: {
+      type: c.requestActor.type,
+      id: c.requestActor.id,
+      revision: c.requestActor.revision,
+    },
     providerAccount: {
       id: c.providerAccount.id,
       revision: c.providerAccount.revision,
@@ -143,8 +147,7 @@ export function computeApprovalCommitmentHash(c: ProviderApprovalCommitmentV1): 
 
 // ─── Human decision document (spec §8.2) ──────────────────────────────────────
 
-export const PROVIDER_APPROVAL_DECISION_SCHEMA =
-  "steward.provider-approval-decision.v1" as const;
+export const PROVIDER_APPROVAL_DECISION_SCHEMA = "steward.provider-approval-decision.v1" as const;
 
 export interface ProviderApprovalDecisionCommitmentV1 {
   schemaVersion: typeof PROVIDER_APPROVAL_DECISION_SCHEMA;

--- a/packages/shared/src/provider-approval.ts
+++ b/packages/shared/src/provider-approval.ts
@@ -1,0 +1,239 @@
+/**
+ * provider-approval.ts — PR3 exact-request approval commitment, decision, and
+ * audit document schemas + their canonical hashes (spec §5, §7.2, §8.2).
+ *
+ * SECURITY POSTURE. Every builder here is on the evidence surface. The
+ * commitment document is what an approval binds to and what safe resume
+ * independently recomputes and compares byte-for-byte. It MUST be built ONLY
+ * from persisted/authoritative fields and hashed with the SAME strict RFC 8785
+ * JCS implementation PR2 owns (`jcsStringify`), never a bespoke serializer.
+ *
+ * This module is pure (no DB, no crypto beyond sha256HexPrefixed) so it can be
+ * reused by the API service AND by an offline verifier (PR5) without pulling in
+ * server dependencies.
+ */
+
+import { jcsStringify, sha256HexPrefixed } from "./provider-action.js";
+
+// ─── Commitment document (spec §5.1) ──────────────────────────────────────────
+
+export const PROVIDER_APPROVAL_COMMITMENT_SCHEMA =
+  "steward.provider-approval-commitment.v1" as const;
+
+export interface ProviderApprovalCommitmentV1 {
+  schemaVersion: typeof PROVIDER_APPROVAL_COMMITMENT_SCHEMA;
+  intentId: string;
+  tenantId: string;
+  workspaceId: string;
+  requestActor: { type: "agent"; id: string; revision: number };
+  providerAccount: { id: string; revision: number; status: "active" };
+  operation: {
+    id: string;
+    key: string;
+    revision: number;
+    riskClass: string;
+    canonicalProfile: "github.provider-action.v1";
+  };
+  requestHash: string;
+  actionDigest: string;
+  accessDecision: {
+    id: string;
+    hash: string;
+    effect: "allow";
+    matchedBindings: Array<{ id: string; revision: number }>;
+    matchedGrants: Array<{ id: string; revision: number }>;
+  };
+  policyDecision: {
+    id: string;
+    hash: string;
+    effect: "approval_required";
+    policyRevisionHash: string;
+    approvalPolicyRevisionHash: string;
+    evaluatorVersion: string;
+  };
+  executionDependencies: {
+    routeId: string;
+    routeRevision: number;
+    secretId: string;
+    secretVersion: number;
+  };
+  approvalRequirements: {
+    role: "workspace_approver";
+    requesterSeparation: boolean;
+    maxMfaAgeSeconds: 300;
+    requiredMfaAssurance: "current-session-mfa" | "phishing-resistant";
+  };
+  requestedAt: string;
+  expiresAt: string;
+}
+
+/** UUID-byte (lexicographic on the canonical string form) comparator. */
+function byUuidBytes(a: { id: string }, b: { id: string }): number {
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+}
+
+/**
+ * Produce the canonical object of the commitment with arrays sorted by UUID
+ * bytes, exactly as §5.1 requires. Property order is irrelevant (JCS re-sorts),
+ * but arrays must be pre-sorted because JCS preserves array order.
+ */
+export function canonicalApprovalCommitmentObject(
+  c: ProviderApprovalCommitmentV1,
+): Record<string, unknown> {
+  return {
+    schemaVersion: c.schemaVersion,
+    intentId: c.intentId,
+    tenantId: c.tenantId,
+    workspaceId: c.workspaceId,
+    requestActor: { type: c.requestActor.type, id: c.requestActor.id, revision: c.requestActor.revision },
+    providerAccount: {
+      id: c.providerAccount.id,
+      revision: c.providerAccount.revision,
+      status: c.providerAccount.status,
+    },
+    operation: {
+      id: c.operation.id,
+      key: c.operation.key,
+      revision: c.operation.revision,
+      riskClass: c.operation.riskClass,
+      canonicalProfile: c.operation.canonicalProfile,
+    },
+    requestHash: c.requestHash,
+    actionDigest: c.actionDigest,
+    accessDecision: {
+      id: c.accessDecision.id,
+      hash: c.accessDecision.hash,
+      effect: c.accessDecision.effect,
+      matchedBindings: [...c.accessDecision.matchedBindings]
+        .sort(byUuidBytes)
+        .map((b) => ({ id: b.id, revision: b.revision })),
+      matchedGrants: [...c.accessDecision.matchedGrants]
+        .sort(byUuidBytes)
+        .map((g) => ({ id: g.id, revision: g.revision })),
+    },
+    policyDecision: {
+      id: c.policyDecision.id,
+      hash: c.policyDecision.hash,
+      effect: c.policyDecision.effect,
+      policyRevisionHash: c.policyDecision.policyRevisionHash,
+      approvalPolicyRevisionHash: c.policyDecision.approvalPolicyRevisionHash,
+      evaluatorVersion: c.policyDecision.evaluatorVersion,
+    },
+    executionDependencies: {
+      routeId: c.executionDependencies.routeId,
+      routeRevision: c.executionDependencies.routeRevision,
+      secretId: c.executionDependencies.secretId,
+      secretVersion: c.executionDependencies.secretVersion,
+    },
+    approvalRequirements: {
+      role: c.approvalRequirements.role,
+      requesterSeparation: c.approvalRequirements.requesterSeparation,
+      maxMfaAgeSeconds: c.approvalRequirements.maxMfaAgeSeconds,
+      requiredMfaAssurance: c.approvalRequirements.requiredMfaAssurance,
+    },
+    requestedAt: c.requestedAt,
+    expiresAt: c.expiresAt,
+  };
+}
+
+/** `approvalCommitmentHash` = sha256: hex of the JCS of the canonical commitment. */
+export function computeApprovalCommitmentHash(c: ProviderApprovalCommitmentV1): string {
+  return sha256HexPrefixed(jcsStringify(canonicalApprovalCommitmentObject(c)));
+}
+
+// ─── Human decision document (spec §8.2) ──────────────────────────────────────
+
+export const PROVIDER_APPROVAL_DECISION_SCHEMA =
+  "steward.provider-approval-decision.v1" as const;
+
+export interface ProviderApprovalDecisionCommitmentV1 {
+  schemaVersion: typeof PROVIDER_APPROVAL_DECISION_SCHEMA;
+  tenantId: string;
+  workspaceId: string;
+  intentId: string;
+  authenticatedUserId: string;
+  decision: "approve" | "deny";
+  expectedVersion: number;
+  expectedRequestHash: string;
+  expectedActionDigest: string;
+  reasonCode: string | null;
+  reason: string | null;
+}
+
+export function computeDecisionRequestHash(d: ProviderApprovalDecisionCommitmentV1): string {
+  return sha256HexPrefixed(
+    jcsStringify({
+      schemaVersion: d.schemaVersion,
+      tenantId: d.tenantId,
+      workspaceId: d.workspaceId,
+      intentId: d.intentId,
+      authenticatedUserId: d.authenticatedUserId,
+      decision: d.decision,
+      expectedVersion: d.expectedVersion,
+      expectedRequestHash: d.expectedRequestHash,
+      expectedActionDigest: d.expectedActionDigest,
+      reasonCode: d.reasonCode ?? null,
+      reason: d.reason ?? null,
+    }),
+  );
+}
+
+// ─── Audit event payload (spec §7.2) ──────────────────────────────────────────
+
+export const PROVIDER_APPROVAL_AUDIT_SCHEMA = "steward.provider-approval-audit.v1" as const;
+
+export interface ProviderApprovalAuditPayloadV1 {
+  schemaVersion: typeof PROVIDER_APPROVAL_AUDIT_SCHEMA;
+  intentId: string;
+  approvalQueueId: string;
+  tenantId: string;
+  workspaceId: string;
+  requestActorAgentId: string;
+  approvalActorUserId: string | null;
+  resumeActor: "steward-system" | null;
+  providerAccountId: string;
+  operationId: string;
+  requestHash: string;
+  actionDigest: string;
+  accessDecisionId: string;
+  accessDecisionHash: string;
+  policyDecisionId: string;
+  policyDecisionHash: string;
+  policyRevisionHash: string;
+  approvalCommitmentHash: string;
+  bindingRevisionBefore: number | null;
+  bindingRevisionAfter: number;
+  fromStatus: string | null;
+  toStatus: string;
+  reasonCode: string;
+  resumeAttemptId: string | null;
+  occurredAt: string;
+}
+
+// ─── Decision request body (public API shape, spec §8.2) ──────────────────────
+
+export interface DecideProviderActionV1 {
+  decision: "approve" | "deny";
+  expectedVersion: number;
+  expectedRequestHash: string;
+  expectedActionDigest: string;
+  reasonCode?: string;
+  reason?: string;
+  idempotencyKey: string;
+}
+
+/** The fixed reason-code list (spec §4.1: reason_code from a fixed list). */
+export const APPROVAL_REASON_CODES = [
+  "approver_manual_approve",
+  "approver_manual_deny",
+  "approver_risk_deny",
+  "approver_scope_deny",
+  "approver_duplicate_deny",
+  "approver_other",
+] as const;
+
+export type ApprovalReasonCode = (typeof APPROVAL_REASON_CODES)[number];
+
+export function isApprovalReasonCode(v: unknown): v is ApprovalReasonCode {
+  return typeof v === "string" && (APPROVAL_REASON_CODES as readonly string[]).includes(v);
+}


### PR DESCRIPTION
## Summary

PR3 turns the PR2 `approval_required` provider action into a **recent-human, exact-request approval** and a **safe `steward-system` resume**, rooted in the existing `intents` + `approval_queue` + `provider_action_bindings` (no `provider_action_approvals` table — spec §1). It does **not** decrypt credentials, call the proxy, mint execution authorization, claim a nonce, or dispatch (I15) — that is PR4.

Base: `develop` @ `a1dcd75` (PR2 #191). Migration `0081` (journal max verified = 0080 before, 0081 after).

## Spec mapping

- **§4 schema / migration 0081**: `approval_queue` discriminated union (transaction | provider_action arm) with arm CHECK + decision-shape CHECK + partial unique indexes; `provider_action_bindings` lifecycle columns + the PR3 transition trigger (transition graph, per-state field-shape CHECK, `binding_revision` increment-by-one) replacing the PR2 immutability trigger; enum `expired`/`stale`/`consumed`.
- **§5 exact commitment**: `packages/shared/src/provider-approval.ts` builds `ProviderApprovalCommitmentV1` + hash with the strict RFC 8785 JCS PR2 owns; binds request/action hashes, access + policy decisions, **all** matched grants/bindings + revisions, operation/account revisions, route+credential (incl. `authority_revision`), actor/workspace, approval-policy revision. §5.3 integrity recompute (canonical bytes → digest, envelope → request hash, access/policy/commitment docs → hashes, cross-table agreement).
- **§6 state machine**: `none→pending_approval→approved/denied/expired/stale→execution_ready`, exclusive guarded CAS transitions, DB-time expiry (`<= now()`), staleness, safe resume (approved→execution_ready, consumes approval once, no execution).
- **§7 audit**: every transition + required event commit atomically via `withTenantAuditedTransaction` (#189). Taxonomy per §7.2 + **C1** top-level `resource_type='provider_action'`, `resource_id=intents.id`.
- **§8 idempotency**: decision replay (exact retry returns existing; changed body → conflict; cross-action reuse → 409), resume single-winner.
- **§9 HTTP**: `GET/POST /v2/provider-actions/:id/approval`, `POST /v2/provider-actions/:id/execute`, exact codes, structured error bodies, non-enumerating 404s, resume-actor-substitution rejection.
- **G1 (PR4 adjudication)**: `secret_routes.authority_revision` (int NOT NULL DEFAULT 1 CHECK > 0) + `steward_bump_secret_route_authority_revision()` BEFORE UPDATE trigger folded into **0081** (not PR4's 0082); commitment binds `authority_revision` directly; trigger-existence CI test added.
- **C1 (PR5 adjudication)**: all provider-action lifecycle audit events (PR3's + the PR2 service writes touched) set top-level `resource_type='provider_action'`, `resource_id=intents.id`.
- **C2 (PR5 adjudication)**: crash-recovery sweeper `recoverUnsignedIntents` closes the "commit-then-drain" gap. Exactly-once, crash-safe (keys on the audit chain itself under the per-tenant audit queue), with a regression test (kill drain → recover → signed event exists exactly once, idempotent under concurrent sweeps).

## Tests

- **Lifecycle** (7): create/approve/deny/expire/stale/resume/terminal.
- **Negative matrix** (29): N04/05/07/08/09/10/11/12/13/17/20/21/22/23/24/26/30/31/34/35/39/40/41/42/43/44/45/47 + Client-B isolation + both codex P2 idempotency regressions.
- **Concurrency/fault** (8): C01 (two approves), C02 (approve+deny race), C05 (25 concurrent execute → one resumeAttemptId + one ready event), C06/C08 (dependency change before claim stales), C09/C10/N49 (audit fault rolls back the whole tuple), C2 crash-recovery (exactly-once + idempotent).
- **Route HTTP** (6): N01/N15/N16, happy approve→execute, GET MFA gating + safe-summary.
- **Migration invariants** (6): authority_revision + bump trigger (G1), PR3 binding trigger, approval_queue arm/shape CHECKs, enum labels, legacy-pending backfill.
- **Static boundary** (7): I15 import guard (no decrypt/proxy/mint/nonce/network/legacy fallback).
- **Mutation proofs** (`scripts/pr3-mutation-proofs.sh`): **6/6 killed** — M1 MFA window (N12), M2 ambient role (N04), M3 queue/binding hash agreement (N26), M4 secret version (N39), M5 canonical digest recompute (N24), M6 non-idempotent resumeAttemptId (C05). Each: baseline pass → mutation → named test fails → restore.

Existing approvals/intents/audit/provider-authority/vault suites remain green (regression-checked, 35+ files).

## Codex review

Two full passes; all findings addressed:
- [P1] migration backfill of legacy pending rows before the shape CHECK — fixed + tested.
- [P1] crash-between-commit-and-drain evidence loss — fixed (crash-safe exactly-once sweeper).
- [P1] same-tx new-enum-value use (`ALTER TYPE ADD VALUE` + CHECK referencing it) — fixed via `status::text` in the decision-shape CHECK.
- [P2] non-enumeration on GET approval detail — ineligible → 404.
- [P2] stale idempotent replay after expiry/stale — replay only when decided.
- [P2] cross-action idempotency-key reuse → 409 not 503.

## Deviations

- **requester separation source**: PR1 does not yet ship a structured operation approval-requirements field, so PR3 reads `request_profile.approvalRequirements.requesterSeparation` (default false), documented in `extractRequesterSeparation`. Swap to the first-class field when PR1 lands it.
- **G1 option (a)**: `secret_routes.authority_revision` + trigger live in 0081 per the orchestrator ruling (PR4's 0082 keeps `authority_mode`/`provider_operation_id`).
- **approved→expired/stale queue rows** clear `decision`/resolution fields to satisfy the decision-shape CHECK; the immutable decision evidence is preserved on the binding (`approval_actor_user_id`/`approved_at`) + the signed `provider.approval.decided` audit event.

## Spec contradictions surfaced (not silently resolved)

None blocking. The G1/C1/C2/C3 cross-PR contracts were already adjudicated in the PR4/PR5 spec appends and implemented accordingly. The decision-shape CHECK requiring `decision IS NULL` for expired/stale is in tension with I3's "decision never changes"; resolved by treating the binding + audit chain as the immutable decision record and the queue decision fields as clearable on terminal transition (flagged here for the orchestrator).

Do NOT merge — orchestrator gate.

[sol-orch]
