### PR TITLE
fix(authority): PR3 review nits — audit-unavailable error fidelity and execute-route authz

### DIFF
--- a/packages/api/src/__tests__/provider-approval-concurrency.test.ts
+++ b/packages/api/src/__tests__/provider-approval-concurrency.test.ts
@@ -16,6 +16,7 @@ import {
   test,
 } from "bun:test";
 import {
+  __resetAuditHmacKeyCacheForTests,
   approvalQueue,
   closeDb,
   getDb,
@@ -69,6 +70,19 @@ async function wipe() {
     tenants,
   ]) {
     await db.delete(t);
+  }
+}
+
+async function withRealAuditFailure<T>(run: () => Promise<T>): Promise<T> {
+  const previous = process.env.STEWARD_AUDIT_HMAC_KEY;
+  process.env.STEWARD_AUDIT_HMAC_KEY = "too-weak";
+  __resetAuditHmacKeyCacheForTests();
+  try {
+    return await run();
+  } finally {
+    if (previous === undefined) delete process.env.STEWARD_AUDIT_HMAC_KEY;
+    else process.env.STEWARD_AUDIT_HMAC_KEY = previous;
+    __resetAuditHmacKeyCacheForTests();
   }
 }
 
@@ -200,6 +214,27 @@ describe("PR3 concurrency + fault matrix", () => {
   // so a genuinely-concurrent mid-transaction commit cannot be injected without
   // deadlock; committing the change immediately before resume is the equivalent
   // deterministic oracle for the revalidation-at-claim predicate.)
+  test("P2-2: resume transaction rechecks the execute caller and rejects unrelated principals", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    const approved = await providerApprovalService.decide(
+      decideBody(intentId, requestHash, actionDigest),
+    );
+    expect(approved.ok).toBe(true);
+
+    const result = await providerApprovalService.resume({
+      intentId,
+      tenantId: F.TENANT,
+      caller: { userId: F.APPROVER_2 },
+    });
+    expect(result).toEqual({
+      ok: false,
+      code: "SCOPE_RESOURCE_NOT_FOUND",
+      httpStatus: 404,
+    });
+    expect((await bindingRow(intentId)).status).toBe("approved");
+    expect((await queueRow(intentId)).status).toBe("approved");
+  });
+
   test("C06: grant revoked before the resume claim => stale, no ready state", async () => {
     const { intentId, requestHash, actionDigest } = await createApprovalRequired();
     await providerApprovalService.decide(decideBody(intentId, requestHash, actionDigest));
@@ -280,6 +315,54 @@ describe("PR3 concurrency + fault matrix", () => {
     expect(q.status).toBe("pending");
     const i = await getDb().select().from(intents).where(eq(intents.id, intentId));
     expect(i[0].status).toBe("pending");
+    expect(await auditCount()).toBe(auditsBefore);
+  });
+
+  test("P2-1 decide: real audit persistence failure returns exact audit-unavailable code and rolls back", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    const auditsBefore = await auditCount();
+    const res = await withRealAuditFailure(() =>
+      providerApprovalService.decide(decideBody(intentId, requestHash, actionDigest)),
+    );
+
+    expect(res).toEqual({
+      ok: false,
+      code: "EVIDENCE_REQUIRED_AUDIT_UNAVAILABLE",
+      httpStatus: 503,
+    });
+    const binding = await bindingRow(intentId);
+    expect(binding.status).toBe("pending_approval");
+    expect(binding.bindingRevision).toBe(1);
+    expect((await queueRow(intentId)).status).toBe("pending");
+    const [intent] = await getDb().select().from(intents).where(eq(intents.id, intentId));
+    expect(intent.status).toBe("pending");
+    expect(await auditCount()).toBe(auditsBefore);
+  });
+
+  test("P2-1 resume: real audit persistence failure returns exact audit-unavailable code and rolls back", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    const approved = await providerApprovalService.decide(
+      decideBody(intentId, requestHash, actionDigest),
+    );
+    expect(approved.ok).toBe(true);
+    const auditsBefore = await auditCount();
+
+    const res = await withRealAuditFailure(() =>
+      providerApprovalService.resume({ intentId, tenantId: F.TENANT }),
+    );
+
+    expect(res).toEqual({
+      ok: false,
+      code: "EVIDENCE_REQUIRED_AUDIT_UNAVAILABLE",
+      httpStatus: 503,
+    });
+    const binding = await bindingRow(intentId);
+    expect(binding.status).toBe("approved");
+    expect(binding.bindingRevision).toBe(2);
+    expect(binding.resumeAttemptId).toBeNull();
+    expect((await queueRow(intentId)).status).toBe("approved");
+    const [intent] = await getDb().select().from(intents).where(eq(intents.id, intentId));
+    expect(intent.executedBy).toBeNull();
     expect(await auditCount()).toBe(auditsBefore);
   });
 

--- a/packages/api/src/__tests__/provider-approval-route.test.ts
+++ b/packages/api/src/__tests__/provider-approval-route.test.ts
@@ -14,7 +14,7 @@ import {
   test,
 } from "bun:test";
 import { signAccessToken } from "@stwd/auth";
-import { closeDb } from "@stwd/db";
+import { agents, closeDb, getDb, providerRoleBindings, userTenants } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import type { Hono } from "hono";
 import type { AppVariables } from "../services/context";
@@ -70,19 +70,38 @@ async function wipeAndSeed() {
   await seedFixture();
 }
 
-async function humanToken(userId: string, mfaVerifiedAt: number | null = freshMfa()) {
+async function humanToken(
+  userId: string,
+  mfaVerifiedAt: number | null = freshMfa(),
+  tenantId = F.TENANT,
+) {
   const payload: Record<string, unknown> = {
     address: `0xuser-${userId.slice(0, 6)}`,
-    tenantId: F.TENANT,
+    tenantId,
     userId,
   };
   if (mfaVerifiedAt !== null) payload.mfaVerifiedAt = mfaVerifiedAt;
   return signAccessToken(payload as never, "10m");
 }
 
-async function agentToken() {
+async function agentToken(agentId = F.AGENT, tenantId = F.TENANT, userId?: string) {
   const { signAgentToken } = await import("@stwd/auth");
-  return signAgentToken({ agentId: F.AGENT, tenantId: F.TENANT, scopes: [] }, "10m");
+  return signAgentToken({ agentId, tenantId, scopes: [], ...(userId ? { userId } : {}) }, "10m");
+}
+
+async function expectExecuteErrorShapeMatchesGet(executeResponse: Response, getResponse: Response) {
+  expect(executeResponse.status).toBe(getResponse.status);
+  const executeBody = (await executeResponse.json()) as {
+    ok: false;
+    error: { code: string; message: string; requestId: unknown };
+  };
+  const getBody = (await getResponse.json()) as typeof executeBody;
+  expect(Object.keys(executeBody).sort()).toEqual(Object.keys(getBody).sort());
+  expect(Object.keys(executeBody.error).sort()).toEqual(Object.keys(getBody.error).sort());
+  expect(executeBody.error.code).toBe(getBody.error.code);
+  expect(executeBody.error.message).toBe(getBody.error.message);
+  expect(typeof executeBody.error.requestId).toBe(typeof getBody.error.requestId);
+  return executeBody;
 }
 
 function decideReq(intentId: string, token: string, body: unknown) {
@@ -187,6 +206,139 @@ describe("PR3 approval + execute routes", () => {
     const execBody = (await execRes.json()) as { status: string; resumeAttemptId: string };
     expect(execBody.status).toBe("execution_ready");
     expect(execBody.resumeAttemptId).toBeTruthy();
+  });
+
+  test("execute permits the original requesting agent", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    const approveRes = await decideReq(intentId, await humanToken(F.APPROVER), {
+      decision: "approve",
+      expectedVersion: 1,
+      expectedRequestHash: requestHash,
+      expectedActionDigest: actionDigest,
+      idempotencyKey: "route-agent-execute",
+    });
+    expect(approveRes.status).toBe(200);
+
+    const execRes = await app.request(`/v2/provider-actions/${intentId}/execute`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${await agentToken()}`,
+        "x-steward-tenant": F.TENANT,
+      },
+    });
+    expect(execRes.status).toBe(200);
+    expect((await execRes.json()) as { status: string }).toMatchObject({
+      status: "execution_ready",
+    });
+  });
+
+  test("execute does not let an agent token borrow an embedded human approver claim", async () => {
+    const unrelatedAgentId = "agent-unrelated";
+    await getDb().insert(agents).values({
+      id: unrelatedAgentId,
+      tenantId: F.TENANT,
+      name: "Unrelated",
+      walletAddress: "0x2",
+    });
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    const approveRes = await decideReq(intentId, await humanToken(F.APPROVER), {
+      decision: "approve",
+      expectedVersion: 1,
+      expectedRequestHash: requestHash,
+      expectedActionDigest: actionDigest,
+      idempotencyKey: "route-mixed-identity-execute",
+    });
+    expect(approveRes.status).toBe(200);
+
+    const execRes = await app.request(`/v2/provider-actions/${intentId}/execute`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${await agentToken(unrelatedAgentId, F.TENANT, F.APPROVER)}`,
+        "x-steward-tenant": F.TENANT,
+      },
+    });
+    expect(execRes.status).toBe(404);
+    expect(((await execRes.json()) as { error: { code: string } }).error.code).toBe(
+      "SCOPE_RESOURCE_NOT_FOUND",
+    );
+    expect((await bindingRow(intentId)).status).toBe("approved");
+  });
+
+  test("execute permits a current workspace admin with matching environment scope", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    const approveRes = await decideReq(intentId, await humanToken(F.APPROVER), {
+      decision: "approve",
+      expectedVersion: 1,
+      expectedRequestHash: requestHash,
+      expectedActionDigest: actionDigest,
+      idempotencyKey: "route-admin-execute",
+    });
+    expect(approveRes.status).toBe(200);
+    await getDb().insert(providerRoleBindings).values({
+      tenantId: F.TENANT,
+      workspaceId: F.WORKSPACE,
+      principalType: "human",
+      principalId: F.APPROVER_2,
+      roleKey: "workspace_admin",
+      operationKeys: [],
+      environment: "production",
+      status: "active",
+      grantedByUserId: F.GRANTOR,
+      reason: "route-admin",
+    });
+
+    const execRes = await app.request(`/v2/provider-actions/${intentId}/execute`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${await humanToken(F.APPROVER_2)}`,
+        "x-steward-tenant": F.TENANT,
+      },
+    });
+    expect(execRes.status).toBe(200);
+    expect((await execRes.json()) as { status: string }).toMatchObject({
+      status: "execution_ready",
+    });
+  });
+
+  test("execute hides an existing action from an unrelated tenant principal with GET-shape parity", async () => {
+    const { intentId } = await createApprovalRequired();
+    const token = await humanToken(F.APPROVER_2);
+    const executeResponse = await app.request(`/v2/provider-actions/${intentId}/execute`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}`, "x-steward-tenant": F.TENANT },
+    });
+    const getResponse = await app.request(`/v2/provider-actions/${intentId}/approval`, {
+      method: "GET",
+      headers: { authorization: `Bearer ${token}`, "x-steward-tenant": F.TENANT },
+    });
+
+    const body = await expectExecuteErrorShapeMatchesGet(executeResponse, getResponse);
+    expect(executeResponse.status).toBe(404);
+    expect(body.error.code).toBe("SCOPE_RESOURCE_NOT_FOUND");
+    expect((await bindingRow(intentId)).status).toBe("pending_approval");
+  });
+
+  test("execute hides a cross-tenant action with GET-shape parity", async () => {
+    const { intentId } = await createApprovalRequired();
+    await getDb().insert(userTenants).values({
+      userId: F.APPROVER_2,
+      tenantId: F.TENANT_B,
+      role: "member",
+    });
+    const token = await humanToken(F.APPROVER_2, freshMfa(), F.TENANT_B);
+    const executeResponse = await app.request(`/v2/provider-actions/${intentId}/execute`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}`, "x-steward-tenant": F.TENANT_B },
+    });
+    const getResponse = await app.request(`/v2/provider-actions/${intentId}/approval`, {
+      method: "GET",
+      headers: { authorization: `Bearer ${token}`, "x-steward-tenant": F.TENANT_B },
+    });
+
+    const body = await expectExecuteErrorShapeMatchesGet(executeResponse, getResponse);
+    expect(executeResponse.status).toBe(404);
+    expect(body.error.code).toBe("SCOPE_RESOURCE_NOT_FOUND");
+    expect((await bindingRow(intentId)).status).toBe("pending_approval");
   });
 
   test("GET approval requires recent MFA => 403 APPROVAL_MFA_REQUIRED when MFA missing", async () => {

--- a/packages/api/src/routes/provider-approvals.ts
+++ b/packages/api/src/routes/provider-approvals.ts
@@ -211,6 +211,22 @@ async function handlePostExecute(c: RouteContext) {
   const intentId = c.req.param("id");
   if (!intentId) return err(c, "SCOPE_RESOURCE_NOT_FOUND", 404);
 
+  const authType = c.get("authType");
+  const executeCaller =
+    authType === "agent-token"
+      ? { agentId: c.get("agentScope") }
+      : authType === "session-jwt"
+        ? { userId: c.get("userId") }
+        : {};
+  const callerAuthorization = await providerApprovalService.authorizeExecuteCaller(
+    tenantId,
+    intentId,
+    executeCaller,
+  );
+  if (!callerAuthorization.ok) {
+    return err(c, callerAuthorization.code, callerAuthorization.httpStatus);
+  }
+
   // Reject any body that supplies actor/action fields (I4 / RESUME_ACTOR_SUBSTITUTION).
   const contentType = (c.req.header("content-type") ?? "").trim().toLowerCase();
   if (contentType && ALLOWED_MEDIA.has(contentType)) {
@@ -234,6 +250,7 @@ async function handlePostExecute(c: RouteContext) {
   const result = await providerApprovalService.resume({
     intentId,
     tenantId,
+    caller: executeCaller,
     ipAddress: c.req.header("x-forwarded-for") ?? null,
     userAgent: c.req.header("user-agent") ?? null,
     requestId: c.get("requestId") ?? null,

--- a/packages/api/src/services/provider-approval.ts
+++ b/packages/api/src/services/provider-approval.ts
@@ -690,6 +690,59 @@ class ProviderApprovalService {
   // or APPROVAL_POLICY_STALE. PR3 does not re-run the evaluator here; operation
   // revision + policy revision hash equality is the exact-binding rule.
 
+  /**
+   * Current human workspace authority, shared by approval decisions and the
+   * execute-route caller gate. This is the PR3 authority predicate: current
+   * tenant membership plus an active, in-window role binding for the exact
+   * workspace and its current environment.
+   */
+  private async hasWorkspaceRoleAuthority(
+    tx: DbExecutor,
+    binding: BindingRow,
+    userId: string,
+    tenantId: string,
+    roleKeys: ReadonlySet<"workspace_approver" | "workspace_admin">,
+  ): Promise<{ ok: true } | { ok: false; reason: "membership" | "role" }> {
+    const [membership] = await tx
+      .select({ id: userTenants.id })
+      .from(userTenants)
+      .where(and(eq(userTenants.userId, userId), eq(userTenants.tenantId, tenantId)))
+      .limit(1)
+      .for("update");
+    if (!membership) return { ok: false, reason: "membership" };
+
+    const [workspace] = await tx
+      .select({ environment: workspaces.environment })
+      .from(workspaces)
+      .where(and(eq(workspaces.tenantId, tenantId), eq(workspaces.id, binding.workspaceId)))
+      .limit(1)
+      .for("update");
+    if (!workspace) return { ok: false, reason: "role" };
+
+    const now = new Date();
+    const authorityRows = await tx
+      .select()
+      .from(providerRoleBindings)
+      .where(
+        and(
+          eq(providerRoleBindings.tenantId, tenantId),
+          eq(providerRoleBindings.workspaceId, binding.workspaceId),
+          eq(providerRoleBindings.principalType, "human"),
+          eq(providerRoleBindings.principalId, userId),
+          eq(providerRoleBindings.status, "active"),
+        ),
+      )
+      .for("update");
+    const eligible = authorityRows.some(
+      (row) =>
+        roleKeys.has(row.roleKey as "workspace_approver" | "workspace_admin") &&
+        (!row.notBefore || row.notBefore <= now) &&
+        (!row.expiresAt || row.expiresAt > now) &&
+        (!row.environment || row.environment === workspace.environment),
+    );
+    return eligible ? { ok: true } : { ok: false, reason: "role" };
+  }
+
   // ── Approver eligibility (spec §3.2, §3.3) ──
   private async checkApprover(
     tx: DbExecutor,
@@ -700,54 +753,17 @@ class ProviderApprovalService {
     sessionMfaVerifiedAt: number | undefined,
     atResume: boolean,
   ): Promise<{ ok: true } | { ok: false; code: string; httpStatus: number }> {
-    // Current tenant membership row must exist.
-    const [membership] = await tx
-      .select({ id: userTenants.id })
-      .from(userTenants)
-      .where(and(eq(userTenants.userId, userId), eq(userTenants.tenantId, tenantId)))
-      .limit(1);
-    if (!membership) {
-      return atResume
-        ? { ok: false, code: "APPROVAL_APPROVER_STALE", httpStatus: 409 }
-        : { ok: false, code: "APPROVAL_MEMBERSHIP_INACTIVE", httpStatus: 403 };
-    }
-
-    // The action's environment is the committed workspace environment. An
-    // environment-scoped approver binding must match it (a NULL binding env =
-    // all environments). This mirrors the actor access checks which gate on
-    // workspace.environment (codex P1).
-    const [workspace] = await tx
-      .select({ environment: workspaces.environment })
-      .from(workspaces)
-      .where(and(eq(workspaces.tenantId, tenantId), eq(workspaces.id, binding.workspaceId)))
-      .limit(1);
-    const actionEnv = workspace?.environment;
-
-    // Active, in-window, in-environment workspace_approver binding for THIS exact
-    // workspace.
-    const now = new Date();
-    const approverRows = await tx
-      .select()
-      .from(providerRoleBindings)
-      .where(
-        and(
-          eq(providerRoleBindings.tenantId, tenantId),
-          eq(providerRoleBindings.workspaceId, binding.workspaceId),
-          eq(providerRoleBindings.principalType, "human"),
-          eq(providerRoleBindings.principalId, userId),
-          eq(providerRoleBindings.roleKey, "workspace_approver"),
-          eq(providerRoleBindings.status, "active"),
-        ),
-      );
-    const eligible = approverRows.some(
-      (b) =>
-        (!b.notBefore || b.notBefore <= now) &&
-        (!b.expiresAt || b.expiresAt > now) &&
-        (!b.environment || b.environment === actionEnv),
+    const authority = await this.hasWorkspaceRoleAuthority(
+      tx,
+      binding,
+      userId,
+      tenantId,
+      new Set(["workspace_approver"]),
     );
-    if (!eligible) {
-      return atResume
-        ? { ok: false, code: "APPROVAL_APPROVER_STALE", httpStatus: 409 }
+    if (!authority.ok) {
+      if (atResume) return { ok: false, code: "APPROVAL_APPROVER_STALE", httpStatus: 409 };
+      return authority.reason === "membership"
+        ? { ok: false, code: "APPROVAL_MEMBERSHIP_INACTIVE", httpStatus: 403 }
         : { ok: false, code: "APPROVAL_ROLE_REQUIRED", httpStatus: 403 };
     }
 
@@ -992,9 +1008,7 @@ class ProviderApprovalService {
     try {
       return await withTenantAuditedTransaction(input.tenantId, async (txRaw, appendRaw) => {
         const tx = txRaw as DbExecutor;
-        const append = appendRaw as unknown as (
-          ev: { tenantId: string } & Record<string, unknown>,
-        ) => Promise<void>;
+        const append = mapRequiredAuditFailure(appendRaw as unknown as ApprovalAuditAppend);
 
         const loaded = await this.loadCase(tx, input.tenantId, input.intentId, true);
         await this.hook("afterScopeLoad");
@@ -1334,6 +1348,7 @@ class ProviderApprovalService {
   async resume(input: {
     intentId: string;
     tenantId: string;
+    caller?: { agentId?: string; userId?: string };
     ipAddress?: string | null;
     userAgent?: string | null;
     requestId?: string | null;
@@ -1341,15 +1356,16 @@ class ProviderApprovalService {
     try {
       return await withTenantAuditedTransaction(input.tenantId, async (txRaw, appendRaw) => {
         const tx = txRaw as DbExecutor;
-        const append = appendRaw as unknown as (
-          ev: { tenantId: string } & Record<string, unknown>,
-        ) => Promise<void>;
+        const append = mapRequiredAuditFailure(appendRaw as unknown as ApprovalAuditAppend);
 
         const loaded = await this.loadCase(tx, input.tenantId, input.intentId, true);
         await this.hook("afterScopeLoad");
         if ("notFound" in loaded) return fail("SCOPE_RESOURCE_NOT_FOUND", 404);
         if ("notApproval" in loaded) return fail("APPROVAL_NOT_REQUIRED", 409);
         const { binding, queue } = loaded;
+        if (input.caller && !(await this.isExecuteCallerAuthorized(tx, binding, input.caller))) {
+          return fail("SCOPE_RESOURCE_NOT_FOUND", 404);
+        }
 
         // Idempotent: already execution_ready returns same state.
         if (binding.status === "execution_ready") {
@@ -1484,6 +1500,42 @@ class ProviderApprovalService {
     }
   }
 
+  private async isExecuteCallerAuthorized(
+    tx: DbExecutor,
+    binding: BindingRow,
+    caller: { agentId?: string; userId?: string },
+  ): Promise<boolean> {
+    if (caller.agentId && caller.agentId === binding.actorAgentId) return true;
+    return Boolean(
+      caller.userId &&
+        (
+          await this.hasWorkspaceRoleAuthority(
+            tx,
+            binding,
+            caller.userId,
+            binding.tenantId,
+            new Set(["workspace_approver", "workspace_admin"]),
+          )
+        ).ok,
+    );
+  }
+
+  // ── Execute-route caller authority, §9.1 ──
+  async authorizeExecuteCaller(
+    tenantId: string,
+    intentId: string,
+    caller: { agentId?: string; userId?: string },
+  ): Promise<{ ok: true } | { ok: false; code: "SCOPE_RESOURCE_NOT_FOUND"; httpStatus: 404 }> {
+    const loaded = await this.loadCase(this.db(), tenantId, intentId, false);
+    if ("notFound" in loaded || "notApproval" in loaded) {
+      return { ok: false, code: "SCOPE_RESOURCE_NOT_FOUND", httpStatus: 404 };
+    }
+    if (await this.isExecuteCallerAuthorized(this.db(), loaded.binding, caller)) {
+      return { ok: true };
+    }
+    return { ok: false, code: "SCOPE_RESOURCE_NOT_FOUND", httpStatus: 404 };
+  }
+
   // ── GET approval detail for an eligible approver (safe summary + labels), §9.1 ──
   // The GET endpoint requires an eligible workspace approver with recent MFA
   // (even safe summaries are sensitive). Non-enumerating: any ineligibility on a
@@ -1548,6 +1600,26 @@ class ProviderApprovalService {
 // ── module helpers ──
 
 class AuditUnavailableError extends Error {}
+
+type ApprovalAuditAppend = (event: { tenantId: string } & Record<string, unknown>) => Promise<void>;
+
+function mapRequiredAuditFailure(append: ApprovalAuditAppend): ApprovalAuditAppend {
+  return async (event) => {
+    try {
+      await append(event);
+    } catch (cause) {
+      const causeMessage = cause instanceof Error ? cause.message : String(cause);
+      const error = new AuditUnavailableError(
+        `required approval audit persistence failed: ${causeMessage}`,
+      );
+      error.cause = cause;
+      if (cause && typeof cause === "object" && "code" in cause) {
+        Object.assign(error, { code: (cause as { code?: unknown }).code });
+      }
+      throw error;
+    }
+  };
+}
 
 function setsEqual(a: Set<string>, b: Set<string>): boolean {
   if (a.size !== b.size) return false;


### PR DESCRIPTION
## Summary

Closes the post-merge PR3 review nits from #192 without adding PR4 behavior.

### P2-1: audit-unavailable error fidelity

- Maps real required-audit append failures on both approval decision and resume to `EVIDENCE_REQUIRED_AUDIT_UNAVAILABLE`.
- Preserves HTTP 503, fail-closed behavior, and full transaction rollback.
- Preserves audit sequence-conflict retry classification by forwarding the underlying database code/message through the typed audit error.
- Adds real HMAC/audit-persistence failure regression tests for decision and resume, including exact code and rollback assertions.
- The existing create-path coverage remains green in `provider-action-service.test.ts`.

### P2-2 and P3: execute-route caller authority and non-enumeration

- Restricts `POST /v2/provider-actions/:id/execute` to the original requesting agent or a current human `workspace_approver` / `workspace_admin` for the exact workspace and environment.
- Reuses the PR3 workspace-role authority predicate and locks membership/workspace/role rows while rechecking authority inside the resume transaction.
- Keeps agent-token and human-session identities disjoint, so an agent token cannot borrow an embedded human claim.
- Returns the GET route's `404 SCOPE_RESOURCE_NOT_FOUND` non-enumeration shape for unrelated and cross-tenant callers.
- Adds coverage for original agent, workspace approver, workspace admin, unrelated tenant principal, cross-tenant principal, GET/execute shape parity, mixed agent/human claims, and the transactional recheck.

## Mutation proof

- Audit mapping weakened to rethrow the raw persistence error: `P2-1 decide: real audit persistence failure returns exact audit-unavailable code and rolls back` and `P2-1 resume: real audit persistence failure returns exact audit-unavailable code and rolls back` both failed with `APPROVAL_PERSISTENCE_FAILED`; mapping restored and both pass.
- Execute authority weakened to accept any human caller: `P2-2: resume transaction rechecks the execute caller and rejects unrelated principals` failed by transitioning to `execution_ready`; guard restored and the test passes.

## Verification

- PR3 focused isolated API runner: 7/7 files passed
  - `provider-action-service.test.ts`
  - `provider-approval-boundary.test.ts`
  - `provider-approval-concurrency.test.ts`
  - `provider-approval-lifecycle.test.ts`
  - `provider-approval-negative.test.ts`
  - `provider-approval-route.test.ts`
  - `provider-authority.test.ts`
- Exact approval migration suite: 6 passed, 0 failed
- Dependency-aware build/typecheck: 17/17 packages successful via `turbo run build --filter=@stwd/api...`
- Biome on all four touched files: clean
- `git diff --check`: clean
- `codex review --base origin/develop`: final review clean. Earlier review findings on audit retry classification, transactional authority recheck, and mixed agent/human identity were fixed and re-reviewed.

[sol-orch]
