### PR TITLE
feat(provider-x): X provider-action adapter + canonical profile (#195 workstream B)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ COPY packages/erc8183/package.json           packages/erc8183/package.json
 COPY packages/plugin-capabilities/package.json packages/plugin-capabilities/package.json
 COPY packages/plugin-trading/package.json     packages/plugin-trading/package.json
 COPY packages/provider-github/package.json    packages/provider-github/package.json
+COPY packages/provider-x/package.json         packages/provider-x/package.json
 COPY packages/proxy-client/package.json       packages/proxy-client/package.json
 COPY packages/policy-engine/package.json     packages/policy-engine/package.json
 COPY packages/proxy/package.json             packages/proxy/package.json
@@ -88,6 +89,7 @@ COPY packages/erc8183/package.json           packages/erc8183/package.json
 COPY packages/plugin-capabilities/package.json packages/plugin-capabilities/package.json
 COPY packages/plugin-trading/package.json     packages/plugin-trading/package.json
 COPY packages/provider-github/package.json    packages/provider-github/package.json
+COPY packages/provider-x/package.json         packages/provider-x/package.json
 COPY packages/proxy-client/package.json       packages/proxy-client/package.json
 COPY packages/policy-engine/package.json     packages/policy-engine/package.json
 COPY packages/proxy/package.json             packages/proxy/package.json
@@ -117,6 +119,7 @@ COPY packages/db          packages/db
 COPY packages/plugin-capabilities packages/plugin-capabilities
 COPY packages/plugin-trading packages/plugin-trading
 COPY packages/provider-github packages/provider-github
+COPY packages/provider-x packages/provider-x
 COPY packages/proxy-client packages/proxy-client
 COPY packages/policy-engine packages/policy-engine
 COPY packages/proxy       packages/proxy
@@ -144,6 +147,7 @@ RUN mkdir -p node_modules/@stwd && \
     ln -sf ../../../packages/plugin-capabilities node_modules/@stwd/plugin-capabilities && \
     ln -sf ../../../packages/plugin-trading    node_modules/@stwd/plugin-trading && \
     ln -sf ../../../packages/provider-github   node_modules/@stwd/provider-github && \
+    ln -sf ../../../packages/provider-x         node_modules/@stwd/provider-x && \
     ln -sf ../../../packages/proxy-client      node_modules/@stwd/proxy-client && \
     ln -sf ../../../packages/trade-sessions    node_modules/@stwd/trade-sessions && \
     ln -sf ../../../packages/venue-hyperliquid node_modules/@stwd/venue-hyperliquid && \
@@ -177,6 +181,7 @@ COPY packages/erc8183/package.json           packages/erc8183/package.json
 COPY packages/plugin-capabilities/package.json packages/plugin-capabilities/package.json
 COPY packages/plugin-trading/package.json     packages/plugin-trading/package.json
 COPY packages/provider-github/package.json    packages/provider-github/package.json
+COPY packages/provider-x/package.json         packages/provider-x/package.json
 COPY packages/proxy-client/package.json       packages/proxy-client/package.json
 COPY packages/policy-engine/package.json     packages/policy-engine/package.json
 COPY packages/proxy/package.json             packages/proxy/package.json
@@ -203,6 +208,7 @@ COPY --from=build /app/packages/db          packages/db
 COPY --from=build /app/packages/plugin-capabilities packages/plugin-capabilities
 COPY --from=build /app/packages/plugin-trading packages/plugin-trading
 COPY --from=build /app/packages/provider-github packages/provider-github
+COPY --from=build /app/packages/provider-x packages/provider-x
 COPY --from=build /app/packages/proxy-client packages/proxy-client
 COPY --from=build /app/packages/policy-engine packages/policy-engine
 COPY --from=build /app/packages/proxy       packages/proxy
@@ -231,6 +237,7 @@ RUN mkdir -p node_modules/@stwd && \
     ln -sf ../../../packages/plugin-capabilities node_modules/@stwd/plugin-capabilities && \
     ln -sf ../../../packages/plugin-trading    node_modules/@stwd/plugin-trading && \
     ln -sf ../../../packages/provider-github   node_modules/@stwd/provider-github && \
+    ln -sf ../../../packages/provider-x         node_modules/@stwd/provider-x && \
     ln -sf ../../../packages/proxy-client      node_modules/@stwd/proxy-client && \
     ln -sf ../../../packages/trade-sessions    node_modules/@stwd/trade-sessions && \
     ln -sf ../../../packages/venue-hyperliquid node_modules/@stwd/venue-hyperliquid && \

--- a/bun.lock
+++ b/bun.lock
@@ -277,6 +277,13 @@
         "@stwd/shared": "workspace:*",
       },
     },
+    "packages/provider-x": {
+      "name": "@stwd/provider-x",
+      "version": "0.1.0",
+      "dependencies": {
+        "@stwd/shared": "workspace:*",
+      },
+    },
     "packages/proxy": {
       "name": "@stwd/proxy",
       "version": "0.4.0",
@@ -1663,6 +1670,8 @@
     "@stwd/policy-engine": ["@stwd/policy-engine@workspace:packages/policy-engine"],
 
     "@stwd/provider-github": ["@stwd/provider-github@workspace:packages/provider-github"],
+
+    "@stwd/provider-x": ["@stwd/provider-x@workspace:packages/provider-x"],
 
     "@stwd/proxy": ["@stwd/proxy@workspace:packages/proxy"],
 

--- a/packages/provider-x/package.json
+++ b/packages/provider-x/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@stwd/provider-x",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "dev": "tsc --watch",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@stwd/shared": "workspace:*"
+  },
+  "description": "X (Twitter) provider-action adapter — operation argument schemas + canonical action construction over the x.provider-action.v1 profile"
+}

--- a/packages/provider-x/src/__tests__/operations.test.ts
+++ b/packages/provider-x/src/__tests__/operations.test.ts
@@ -1,0 +1,255 @@
+/**
+ * X adapter operation-schema tests.
+ *
+ * Proves: strict argument validation (unknown/missing/typed/id-regex/length deny
+ * with stable CANON_* codes), dynamic path segments are validated (not
+ * concatenated raw), fixed query canonical order, canonical action construction
+ * is deterministic and matches the shared X canonicalizer, safe_summary never
+ * leaks full tweet text, and risk classes are correct. Re-runs the X golden
+ * corpus as a REQUIRED consumer suite and includes a digest-stability
+ * mutation proof.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  CanonError,
+  computeXActionDigest,
+  X_GOLDEN_VECTORS,
+  type XCanonicalActionV1,
+  xCanonicalActionBytes,
+} from "@stwd/shared";
+import { buildXAction, isXOperationKey, X_OPERATION_RISK } from "../operations.js";
+
+function expectCanon(fn: () => unknown, code: string) {
+  try {
+    fn();
+    throw new Error(`expected CanonError ${code} but none thrown`);
+  } catch (e) {
+    if (!(e instanceof CanonError)) throw e;
+    expect(e.code).toBe(code);
+  }
+}
+
+describe("X golden corpus re-run (adapter consumer suite)", () => {
+  it("has vectors and each reproduces its bytes + digest", () => {
+    expect(X_GOLDEN_VECTORS.length).toBeGreaterThanOrEqual(6);
+    for (const gv of X_GOLDEN_VECTORS) {
+      expect(xCanonicalActionBytes(gv.action)).toBe(gv.canonicalActionBytes);
+      expect(computeXActionDigest(gv.action)).toBe(gv.actionDigest);
+    }
+  });
+
+  it("adapter output equals the golden vectors byte-for-byte", () => {
+    const byId = new Map(X_GOLDEN_VECTORS.map((gv) => [gv.id, gv]));
+    const cases: Array<[string, Parameters<typeof buildXAction>[0], unknown]> = [
+      ["XGV-01", "x.user.me.read", {}],
+      ["XGV-02", "x.tweet.create", { text: "hello world" }],
+      ["XGV-03", "x.tweet.create", { text: "thanks!", replyToTweetId: "1234567890" }],
+      ["XGV-04", "x.tweet.create", { text: "café ☕ 日本" }],
+      ["XGV-05", "x.tweet.create", { text: "  spaced out  " }],
+      ["XGV-06", "x.tweet.delete", { tweetId: "9876543210987654321" }],
+    ];
+    for (const [id, key, args] of cases) {
+      const gv = byId.get(id);
+      if (!gv) throw new Error(`missing golden vector ${id}`);
+      const b = buildXAction(key, args);
+      expect(xCanonicalActionBytes(b.action)).toBe(gv.canonicalActionBytes);
+      expect(computeXActionDigest(b.action)).toBe(gv.actionDigest);
+    }
+  });
+
+  it("MUTATION: reordering canonicalBody keys does not change the digest (JCS sorts)", () => {
+    // Build a reply action with keys deliberately transposed vs the builder's
+    // insertion order; JCS must re-sort so the digest is stable.
+    const base = buildXAction("x.tweet.create", {
+      text: "thanks!",
+      replyToTweetId: "1234567890",
+    }).action;
+    const mutated: XCanonicalActionV1 = {
+      ...base,
+      canonicalBody: { text: "thanks!", reply: { in_reply_to_tweet_id: "1234567890" } },
+    };
+    expect(computeXActionDigest(mutated)).toBe(computeXActionDigest(base));
+  });
+
+  it("MUTATION: changing a body value DOES change the digest (corpus is not vacuous)", () => {
+    const base = buildXAction("x.tweet.create", { text: "hello world" }).action;
+    const mutated: XCanonicalActionV1 = { ...base, canonicalBody: { text: "hello worlds" } };
+    expect(computeXActionDigest(mutated)).not.toBe(computeXActionDigest(base));
+  });
+});
+
+describe("x.tweet.create", () => {
+  it("builds a deterministic POST action with JSON body + injected content-type", () => {
+    const b = buildXAction("x.tweet.create", { text: "gm" });
+    expect(b.method).toBe("POST");
+    expect(b.risk).toBe("write");
+    expect(b.action.normalizedPath).toBe("/2/tweets");
+    expect(b.action.origin).toBe("https://api.x.com");
+    expect(b.action.canonicalBody).toEqual({ text: "gm" });
+    expect(b.action.selectedHeaders).toEqual([["content-type", "application/json"]]);
+    expect(b.action.orderedQueryPairs).toEqual([]);
+  });
+
+  it("nests reply only when replyToTweetId present", () => {
+    const noReply = buildXAction("x.tweet.create", { text: "standalone" });
+    expect(noReply.action.canonicalBody).toEqual({ text: "standalone" });
+
+    const reply = buildXAction("x.tweet.create", { text: "re", replyToTweetId: "42" });
+    expect(reply.action.canonicalBody).toEqual({
+      text: "re",
+      reply: { in_reply_to_tweet_id: "42" },
+    });
+  });
+
+  it("is order-insensitive at the argument level (deterministic digest)", () => {
+    const a = buildXAction("x.tweet.create", { text: "x", replyToTweetId: "7" });
+    const b = buildXAction("x.tweet.create", { replyToTweetId: "7", text: "x" });
+    expect(computeXActionDigest(a.action)).toBe(computeXActionDigest(b.action));
+  });
+
+  it("trims surrounding whitespace before length check and in the body", () => {
+    const b = buildXAction("x.tweet.create", { text: "   hi   " });
+    expect(b.action.canonicalBody).toEqual({ text: "hi" });
+  });
+
+  it("counts length by code points: a 280-astral-char tweet passes, 281 fails", () => {
+    const astral = "😀"; // one code point, two UTF-16 units
+    const ok = astral.repeat(280);
+    expect(() => buildXAction("x.tweet.create", { text: ok })).not.toThrow();
+    const tooLong = astral.repeat(281);
+    expectCanon(
+      () => buildXAction("x.tweet.create", { text: tooLong }),
+      "CANON_FIELD_TYPE_INVALID",
+    );
+  });
+
+  it("safe_summary shows length + sha256 + short preview, never full text", () => {
+    const secret = "this is a secret tweet body that must not leak in full ".repeat(3).trim();
+    const b = buildXAction("x.tweet.create", { text: secret });
+    const s = JSON.stringify(b.safeSummary);
+    expect(s).not.toContain(secret);
+    expect(b.safeSummary.textByteLength).toBe(Buffer.from(secret, "utf8").length);
+    expect(String(b.safeSummary.textSha256)).toMatch(/^sha256:[0-9a-f]{64}$/);
+    // preview is bounded to 32 code points
+    expect([...String(b.safeSummary.textPreview)].length).toBeLessThanOrEqual(32);
+  });
+
+  it("policy args are validated scalars only (no raw text, no raw body)", () => {
+    const b = buildXAction("x.tweet.create", { text: "hello", replyToTweetId: "9" });
+    expect(b.policyArgs).toEqual({
+      isReply: true,
+      textCodePointLength: 5,
+      textByteLength: 5,
+      replyToTweetId: "9",
+    });
+    expect(JSON.stringify(b.policyArgs)).not.toContain("hello");
+  });
+
+  it("rejects empty/whitespace-only, unknown fields, missing required, bad types", () => {
+    expectCanon(() => buildXAction("x.tweet.create", { text: "" }), "CANON_BODY_REQUIRED");
+    expectCanon(() => buildXAction("x.tweet.create", { text: "   " }), "CANON_BODY_REQUIRED");
+    expectCanon(
+      () => buildXAction("x.tweet.create", { text: "hi", nope: 1 }),
+      "CANON_UNKNOWN_FIELD",
+    );
+    expectCanon(() => buildXAction("x.tweet.create", {}), "CANON_REQUIRED_FIELD_MISSING");
+    expectCanon(() => buildXAction("x.tweet.create", { text: 5 }), "CANON_FIELD_TYPE_INVALID");
+  });
+
+  it("rejects a non-numeric or overlong replyToTweetId (id regex enforced)", () => {
+    expectCanon(
+      () => buildXAction("x.tweet.create", { text: "hi", replyToTweetId: "12a" }),
+      "CANON_PATH_SEGMENT_INVALID",
+    );
+    expectCanon(
+      () => buildXAction("x.tweet.create", { text: "hi", replyToTweetId: "1".repeat(26) }),
+      "CANON_PATH_SEGMENT_INVALID",
+    );
+    expectCanon(
+      () => buildXAction("x.tweet.create", { text: "hi", replyToTweetId: 42 }),
+      "CANON_FIELD_TYPE_INVALID",
+    );
+  });
+
+  it("rejects a lone surrogate in text", () => {
+    expectCanon(
+      () => buildXAction("x.tweet.create", { text: `bad\uD800end` }),
+      "CANON_UNICODE_INVALID",
+    );
+  });
+});
+
+describe("x.tweet.delete", () => {
+  it("builds a deterministic DELETE with id path from validated value", () => {
+    const b = buildXAction("x.tweet.delete", { tweetId: "1750000000000000000" });
+    expect(b.method).toBe("DELETE");
+    expect(b.risk).toBe("write");
+    expect(b.action.normalizedPath).toBe("/2/tweets/1750000000000000000");
+    expect(b.action.canonicalBody).toBeNull();
+    expect(b.action.selectedHeaders).toEqual([]);
+    expect(b.safeSummary).toEqual({ operation: "x.tweet.delete", tweetId: "1750000000000000000" });
+    expect(b.policyArgs).toEqual({ tweetId: "1750000000000000000" });
+  });
+
+  it("rejects path-injection via tweetId (validated segment, not raw concat)", () => {
+    expectCanon(
+      () => buildXAction("x.tweet.delete", { tweetId: "1/../2" }),
+      "CANON_PATH_SEGMENT_INVALID",
+    );
+    expectCanon(
+      () => buildXAction("x.tweet.delete", { tweetId: "../evil" }),
+      "CANON_PATH_SEGMENT_INVALID",
+    );
+    expectCanon(
+      () => buildXAction("x.tweet.delete", { tweetId: "12%2F34" }),
+      "CANON_PATH_SEGMENT_INVALID",
+    );
+    expectCanon(
+      () => buildXAction("x.tweet.delete", { tweetId: "" }),
+      "CANON_PATH_SEGMENT_INVALID",
+    );
+  });
+
+  it("rejects unknown fields, missing required, and non-string id", () => {
+    expectCanon(
+      () => buildXAction("x.tweet.delete", { tweetId: "1", extra: 1 }),
+      "CANON_UNKNOWN_FIELD",
+    );
+    expectCanon(() => buildXAction("x.tweet.delete", {}), "CANON_REQUIRED_FIELD_MISSING");
+    expectCanon(() => buildXAction("x.tweet.delete", { tweetId: 1 }), "CANON_FIELD_TYPE_INVALID");
+  });
+});
+
+describe("x.user.me.read", () => {
+  it("builds a deterministic GET with fixed canonical query and no body", () => {
+    const b = buildXAction("x.user.me.read", {});
+    expect(b.method).toBe("GET");
+    expect(b.risk).toBe("read");
+    expect(b.action.normalizedPath).toBe("/2/users/me");
+    expect(b.action.orderedQueryPairs).toEqual([["user.fields", "id,name,username"]]);
+    expect(b.action.canonicalBody).toBeNull();
+    expect(b.action.selectedHeaders).toEqual([]);
+  });
+
+  it("accepts undefined args (no-arg op) but rejects any provided field", () => {
+    expect(() => buildXAction("x.user.me.read", undefined)).not.toThrow();
+    expectCanon(() => buildXAction("x.user.me.read", { foo: 1 }), "CANON_UNKNOWN_FIELD");
+  });
+});
+
+describe("operation-key guard + risk map", () => {
+  it("recognizes only the three workstream-B operations", () => {
+    expect(isXOperationKey("x.tweet.create")).toBe(true);
+    expect(isXOperationKey("x.tweet.delete")).toBe(true);
+    expect(isXOperationKey("x.user.me.read")).toBe(true);
+    expect(isXOperationKey("x.dm.send")).toBe(false);
+    expect(isXOperationKey(42)).toBe(false);
+  });
+
+  it("classifies writes and reads correctly", () => {
+    expect(X_OPERATION_RISK["x.tweet.create"]).toBe("write");
+    expect(X_OPERATION_RISK["x.tweet.delete"]).toBe("write");
+    expect(X_OPERATION_RISK["x.user.me.read"]).toBe("read");
+  });
+});

--- a/packages/provider-x/src/__tests__/operations.test.ts
+++ b/packages/provider-x/src/__tests__/operations.test.ts
@@ -124,15 +124,23 @@ describe("x.tweet.create", () => {
     );
   });
 
-  it("safe_summary shows length + sha256 + short preview, never full text", () => {
+  it("safe_summary shows length + sha256 only, never any slice of the text", () => {
     const secret = "this is a secret tweet body that must not leak in full ".repeat(3).trim();
     const b = buildXAction("x.tweet.create", { text: secret });
     const s = JSON.stringify(b.safeSummary);
     expect(s).not.toContain(secret);
     expect(b.safeSummary.textByteLength).toBe(Buffer.from(secret, "utf8").length);
     expect(String(b.safeSummary.textSha256)).toMatch(/^sha256:[0-9a-f]{64}$/);
-    // preview is bounded to 32 code points
-    expect([...String(b.safeSummary.textPreview)].length).toBeLessThanOrEqual(32);
+    // no preview field exists at all (codex P2 fix): summaries carry no text slice.
+    expect("textPreview" in b.safeSummary).toBe(false);
+  });
+
+  it("safe_summary of a SHORT tweet does not leak the body (codex P2 regression)", () => {
+    // A 2-char tweet must not appear verbatim anywhere in the summary.
+    const b = buildXAction("x.tweet.create", { text: "gm" });
+    const s = JSON.stringify(b.safeSummary);
+    expect(s).not.toContain("gm");
+    expect("textPreview" in b.safeSummary).toBe(false);
   });
 
   it("policy args are validated scalars only (no raw text, no raw body)", () => {

--- a/packages/provider-x/src/index.ts
+++ b/packages/provider-x/src/index.ts
@@ -1,0 +1,19 @@
+/**
+ * @stwd/provider-x — the X (Twitter) provider-action adapter.
+ *
+ * Owns the three workstream-B operation argument schemas (`x.tweet.create`,
+ * `x.tweet.delete`, `x.user.me.read`), their canonical action construction over
+ * the shared `x.provider-action.v1` profile, the non-authoritative safe summary,
+ * and the validated policy-context arguments. It imports the shared X
+ * canonicalizer; it never re-implements JCS, hashing, or normalization.
+ */
+
+export {
+  buildXAction,
+  isXOperationKey,
+  X_OPERATION_KEYS,
+  X_OPERATION_RISK,
+  type XActionBuild,
+  type XOperationKey,
+  type XOperationRisk,
+} from "./operations.js";

--- a/packages/provider-x/src/operations.ts
+++ b/packages/provider-x/src/operations.ts
@@ -1,0 +1,276 @@
+/**
+ * operations.ts — X provider-action operation schemas + canonical action
+ * construction (issue #195 workstream B).
+ *
+ * This adapter owns method, origin, path construction, header selection, and
+ * body shape for the three workstream-B operations. It validates operation
+ * ARGUMENTS strictly (fail closed with stable CANON_* codes), builds a raw
+ * internal HTTP representation, and runs it through the ONE shared X
+ * canonicalizer (`canonicalizeRawInternalXAction`) so the action digest matches
+ * the golden corpus byte-for-byte. Dynamic id segments are encoded from
+ * VALIDATED values, never concatenated from a raw path.
+ *
+ * It also derives the non-authoritative `safeSummary` (display only) and the
+ * validated policy-context arguments the provider policy composer reads. The
+ * policy layer never lifts arbitrary scalar fields from raw JSON: policyArgs is
+ * validated scalars only, never a raw body.
+ *
+ * TEXT LENGTH SIMPLIFICATION. X enforces a "weighted" tweet length: URLs count
+ * as a fixed 23 regardless of their real length, CJK ideographs count as 2, and
+ * some ranges count as 1. Reproducing that weighting requires X's tco URL model
+ * and the published character-count ranges, which drift. This adapter instead
+ * counts by Unicode code points (`[...text].length`) after trimming leading and
+ * trailing ASCII/Unicode whitespace, bounding 1..280. This is STRICTER-or-equal
+ * to X for pure text (code points >= weighted length for non-URL text is not
+ * guaranteed, so an occasional server-side rejection is possible for exotic
+ * inputs), and it is fully deterministic and re-derivable by the proxy and the
+ * offline verifier. The simplification is documented here and in the PR body.
+ */
+
+import { createHash } from "node:crypto";
+import {
+  CanonError,
+  type CanonicalMethod,
+  canonicalizeRawInternalXAction,
+  type JsonValue,
+  type XCanonicalActionV1,
+} from "@stwd/shared";
+
+export const X_OPERATION_KEYS = ["x.tweet.create", "x.tweet.delete", "x.user.me.read"] as const;
+export type XOperationKey = (typeof X_OPERATION_KEYS)[number];
+
+export function isXOperationKey(v: unknown): v is XOperationKey {
+  return typeof v === "string" && (X_OPERATION_KEYS as readonly string[]).includes(v);
+}
+
+/** Risk class per operation (write = approval-worthy, read = low risk). */
+export type XOperationRisk = "read" | "write";
+export const X_OPERATION_RISK: Readonly<Record<XOperationKey, XOperationRisk>> = {
+  "x.tweet.create": "write",
+  "x.tweet.delete": "write",
+  "x.user.me.read": "read",
+};
+
+/** The result of validating + canonicalizing an operation's arguments. */
+export interface XActionBuild {
+  operationKey: XOperationKey;
+  method: CanonicalMethod;
+  risk: XOperationRisk;
+  action: XCanonicalActionV1;
+  /** Non-authoritative, adapter-derived display summary. */
+  safeSummary: Record<string, unknown>;
+  /** Validated arguments a provider policy may read. Never raw JSON. */
+  policyArgs: Record<string, unknown>;
+}
+
+const JSON_CONTENT_TYPE = "application/json";
+
+/** X object ids (tweet id, user id) are decimal snowflakes: 1..25 digits. */
+const ID_RE = /^[0-9]{1,25}$/;
+
+const TWEET_TEXT_MIN = 1;
+const TWEET_TEXT_MAX = 280;
+
+// ─── shared field helpers (stable CANON_* codes) ──────────────────────────────
+
+function fieldError(message: string): never {
+  throw new CanonError("CANON_FIELD_TYPE_INVALID", message);
+}
+
+function unknownField(name: string): never {
+  throw new CanonError("CANON_UNKNOWN_FIELD", `unknown argument '${name}'`);
+}
+
+function requiredMissing(name: string): never {
+  throw new CanonError("CANON_REQUIRED_FIELD_MISSING", `missing required argument '${name}'`);
+}
+
+function rejectUnknownKeys(args: Record<string, unknown>, allowed: ReadonlySet<string>): void {
+  for (const key of Object.keys(args)) {
+    if (!allowed.has(key)) unknownField(key);
+  }
+}
+
+function asObject(args: unknown): Record<string, unknown> {
+  if (typeof args !== "object" || args === null || Array.isArray(args))
+    throw new CanonError("CANON_JSON_SHAPE_INVALID", "arguments must be a JSON object");
+  return args as Record<string, unknown>;
+}
+
+/** Validate a decimal X id string against {@link ID_RE}; return it verbatim. */
+function validateId(v: unknown, name: string): string {
+  if (typeof v !== "string") fieldError(`${name} must be a string`);
+  if (!ID_RE.test(v))
+    throw new CanonError("CANON_PATH_SEGMENT_INVALID", `invalid ${name} '${String(v)}'`);
+  return v;
+}
+
+/** Reject lone UTF-16 surrogates in a caller-supplied string. */
+function assertNoLoneSurrogate(v: string, label: string): void {
+  for (let i = 0; i < v.length; i++) {
+    const c = v.charCodeAt(i);
+    if (c >= 0xd800 && c <= 0xdbff) {
+      const next = v.charCodeAt(i + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff))
+        throw new CanonError("CANON_UNICODE_INVALID", `lone surrogate in ${label}`);
+      i++;
+    } else if (c >= 0xdc00 && c <= 0xdfff) {
+      throw new CanonError("CANON_UNICODE_INVALID", `lone surrogate in ${label}`);
+    }
+  }
+}
+
+/**
+ * Trim leading/trailing whitespace then validate the tweet text length by
+ * Unicode code points (see the module-level simplification note). Returns the
+ * TRIMMED text (the trimmed value is authoritative: it is what goes in the body).
+ */
+function validateTweetText(v: unknown): string {
+  if (typeof v !== "string") fieldError("text must be a string");
+  assertNoLoneSurrogate(v, "tweet text");
+  const trimmed = v.trim();
+  // Code-point count (not UTF-16 length): astral chars count once.
+  const codePoints = [...trimmed].length;
+  if (codePoints < TWEET_TEXT_MIN)
+    throw new CanonError("CANON_BODY_REQUIRED", "tweet text is empty after trim");
+  if (codePoints > TWEET_TEXT_MAX)
+    fieldError(`tweet text exceeds ${TWEET_TEXT_MAX} code points (got ${codePoints})`);
+  return trimmed;
+}
+
+// ─── x.tweet.create ───────────────────────────────────────────────────────────
+
+const TWEET_CREATE_KEYS = new Set(["text", "replyToTweetId"]);
+
+function buildTweetCreate(rawArgs: unknown): XActionBuild {
+  const args = asObject(rawArgs);
+  rejectUnknownKeys(args, TWEET_CREATE_KEYS);
+  if (!("text" in args)) requiredMissing("text");
+  const text = validateTweetText(args.text);
+
+  let replyToTweetId: string | undefined;
+  if ("replyToTweetId" in args && args.replyToTweetId !== undefined) {
+    replyToTweetId = validateId(args.replyToTweetId, "replyToTweetId");
+  }
+
+  // Body: {text} plus a nested reply object only when replying. The shared JCS
+  // sorts object keys, so insertion order here is irrelevant to the digest.
+  const jsonBody: { [k: string]: JsonValue } = { text };
+  if (replyToTweetId !== undefined) {
+    jsonBody.reply = { in_reply_to_tweet_id: replyToTweetId };
+  }
+
+  const action = canonicalizeRawInternalXAction({
+    method: "POST",
+    origin: "https://api.x.com",
+    path: "/2/tweets",
+    contentType: JSON_CONTENT_TYPE,
+    body: jsonBody,
+  });
+
+  const byteLength = Buffer.from(text, "utf8").length;
+  const codePointLength = [...text].length;
+  const textSha256 = `sha256:${createHash("sha256").update(Buffer.from(text, "utf8")).digest("hex")}`;
+  // Non-authoritative preview: first 32 code points, never the full text.
+  const preview = [...text].slice(0, 32).join("");
+
+  const safeSummary: Record<string, unknown> = {
+    operation: "x.tweet.create",
+    isReply: replyToTweetId !== undefined,
+    textCodePointLength: codePointLength,
+    textByteLength: byteLength,
+    textSha256,
+    textPreview: preview,
+  };
+  if (replyToTweetId !== undefined) safeSummary.replyToTweetId = replyToTweetId;
+
+  const policyArgs: Record<string, unknown> = {
+    isReply: replyToTweetId !== undefined,
+    textCodePointLength: codePointLength,
+    textByteLength: byteLength,
+  };
+  if (replyToTweetId !== undefined) policyArgs.replyToTweetId = replyToTweetId;
+
+  return {
+    operationKey: "x.tweet.create",
+    method: "POST",
+    risk: "write",
+    action,
+    safeSummary,
+    policyArgs,
+  };
+}
+
+// ─── x.tweet.delete ───────────────────────────────────────────────────────────
+
+const TWEET_DELETE_KEYS = new Set(["tweetId"]);
+
+function buildTweetDelete(rawArgs: unknown): XActionBuild {
+  const args = asObject(rawArgs);
+  rejectUnknownKeys(args, TWEET_DELETE_KEYS);
+  if (!("tweetId" in args)) requiredMissing("tweetId");
+  const tweetId = validateId(args.tweetId, "tweetId");
+
+  const action = canonicalizeRawInternalXAction({
+    method: "DELETE",
+    origin: "https://api.x.com",
+    // Path built from the VALIDATED id (ID_RE guarantees [0-9]{1,25}: no
+    // percent-encoding needed, no traversal possible).
+    path: `/2/tweets/${tweetId}`,
+  });
+
+  return {
+    operationKey: "x.tweet.delete",
+    method: "DELETE",
+    risk: "write",
+    action,
+    safeSummary: { operation: "x.tweet.delete", tweetId },
+    policyArgs: { tweetId },
+  };
+}
+
+// ─── x.user.me.read ───────────────────────────────────────────────────────────
+
+const USER_ME_KEYS = new Set<string>([]);
+
+function buildUserMeRead(rawArgs: unknown): XActionBuild {
+  // Accept a missing/empty args object; any field is unknown.
+  const args = rawArgs === undefined ? {} : asObject(rawArgs);
+  rejectUnknownKeys(args, USER_ME_KEYS);
+
+  const action = canonicalizeRawInternalXAction({
+    method: "GET",
+    origin: "https://api.x.com",
+    path: "/2/users/me",
+    // Fixed query, single pair. The shared canonicalizer sorts + validates it.
+    query: [["user.fields", "id,name,username"]],
+  });
+
+  return {
+    operationKey: "x.user.me.read",
+    method: "GET",
+    risk: "read",
+    action,
+    safeSummary: { operation: "x.user.me.read" },
+    policyArgs: {},
+  };
+}
+
+/**
+ * Validate + canonicalize the arguments for an X operation. Throws
+ * {@link CanonError} (never a 500) on any argument or canonicalization ambiguity.
+ */
+export function buildXAction(operationKey: XOperationKey, args: unknown): XActionBuild {
+  switch (operationKey) {
+    case "x.tweet.create":
+      return buildTweetCreate(args);
+    case "x.tweet.delete":
+      return buildTweetDelete(args);
+    case "x.user.me.read":
+      return buildUserMeRead(args);
+    default: {
+      const _never: never = operationKey;
+      throw new CanonError("CANON_PROFILE_UNSUPPORTED", `unknown operation '${String(_never)}'`);
+    }
+  }
+}

--- a/packages/provider-x/src/operations.ts
+++ b/packages/provider-x/src/operations.ts
@@ -171,16 +171,17 @@ function buildTweetCreate(rawArgs: unknown): XActionBuild {
   const byteLength = Buffer.from(text, "utf8").length;
   const codePointLength = [...text].length;
   const textSha256 = `sha256:${createHash("sha256").update(Buffer.from(text, "utf8")).digest("hex")}`;
-  // Non-authoritative preview: first 32 code points, never the full text.
-  const preview = [...text].slice(0, 32).join("");
 
+  // Safe summary mirrors the GitHub adapter: length + sha256 only, never any
+  // slice of the text. A preview was intentionally REMOVED (codex P2, #195
+  // workstream B): for short tweets a prefix preview equals the full body, which
+  // would leak user content the summary is contractually forbidden to contain.
   const safeSummary: Record<string, unknown> = {
     operation: "x.tweet.create",
     isReply: replyToTweetId !== undefined,
     textCodePointLength: codePointLength,
     textByteLength: byteLength,
     textSha256,
-    textPreview: preview,
   };
   if (replyToTweetId !== undefined) safeSummary.replyToTweetId = replyToTweetId;
 

--- a/packages/provider-x/tsconfig.json
+++ b/packages/provider-x/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/__tests__"]
+}

--- a/packages/shared/src/__tests__/x-provider-action.test.ts
+++ b/packages/shared/src/__tests__/x-provider-action.test.ts
@@ -1,0 +1,224 @@
+/**
+ * x.provider-action.v1 shared-profile tests.
+ *
+ * Proves the X canonicalizer reuses the ONE shared JCS/hash/normalize surface
+ * (byte-identical framing to the GitHub profile, differing only in the profile
+ * and origin string VALUES), enforces the X origin allowlist, the header-free
+ * rule, and the body/content-type matrix. Includes the X golden corpus and a
+ * digest-stability mutation proof (weaken key-sort, watch the digest collapse,
+ * restore).
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  CanonError,
+  canonicalizeRawInternalXAction,
+  canonicalizeXOrigin,
+  computeXActionDigest,
+  X_CANONICAL_ORIGIN,
+  X_GOLDEN_VECTORS,
+  X_PROVIDER_ACTION_PROFILE,
+  xCanonicalActionBytes,
+} from "../index.js";
+
+function denies(fn: () => unknown): boolean {
+  try {
+    fn();
+    return false;
+  } catch (e) {
+    return e instanceof CanonError;
+  }
+}
+
+function expectCanon(fn: () => unknown, code: string) {
+  try {
+    fn();
+    throw new Error(`expected CanonError ${code} but none thrown`);
+  } catch (e) {
+    if (!(e instanceof CanonError)) throw e;
+    expect(e.code).toBe(code);
+  }
+}
+
+describe("X golden corpus (shared)", () => {
+  it("each vector reproduces its bytes + digest", () => {
+    expect(X_GOLDEN_VECTORS.length).toBeGreaterThanOrEqual(6);
+    for (const gv of X_GOLDEN_VECTORS) {
+      expect(xCanonicalActionBytes(gv.action)).toBe(gv.canonicalActionBytes);
+      expect(computeXActionDigest(gv.action)).toBe(gv.actionDigest);
+    }
+  });
+
+  it("stamps the X profile and origin (not github)", () => {
+    for (const gv of X_GOLDEN_VECTORS) {
+      expect(gv.action.profile).toBe(X_PROVIDER_ACTION_PROFILE);
+      expect(gv.action.origin).toBe(X_CANONICAL_ORIGIN);
+      expect(gv.canonicalActionBytes).toContain('"profile":"x.provider-action.v1"');
+      expect(gv.canonicalActionBytes).toContain('"origin":"https://api.x.com"');
+    }
+  });
+});
+
+describe("X origin canonicalization", () => {
+  it("normalizes case + default port + terminal dot to the canonical origin", () => {
+    expect(canonicalizeXOrigin("https://API.X.com")).toBe(X_CANONICAL_ORIGIN);
+    expect(canonicalizeXOrigin("https://api.x.com:443")).toBe(X_CANONICAL_ORIGIN);
+    expect(canonicalizeXOrigin("https://api.x.com./")).toBe(X_CANONICAL_ORIGIN);
+  });
+
+  it("denies non-https, wrong host, github host, userinfo, non-default port", () => {
+    expectCanon(() => canonicalizeXOrigin("http://api.x.com"), "CANON_ORIGIN_SCHEME_UNSUPPORTED");
+    expectCanon(() => canonicalizeXOrigin("https://api.twitter.com"), "CANON_ORIGIN_NOT_ALLOWED");
+    expectCanon(() => canonicalizeXOrigin("https://api.github.com"), "CANON_ORIGIN_NOT_ALLOWED");
+    expectCanon(() => canonicalizeXOrigin("https://evil.x.com"), "CANON_ORIGIN_NOT_ALLOWED");
+    expectCanon(() => canonicalizeXOrigin("https://u@api.x.com"), "CANON_ORIGIN_INVALID");
+    expectCanon(
+      () => canonicalizeXOrigin("https://api.x.com:8443"),
+      "CANON_ORIGIN_PORT_UNSUPPORTED",
+    );
+  });
+});
+
+describe("X body / content-type matrix", () => {
+  it("POST requires a JSON body + content-type and injects the header", () => {
+    const a = canonicalizeRawInternalXAction({
+      method: "POST",
+      origin: "https://api.x.com",
+      path: "/2/tweets",
+      contentType: "application/json",
+      body: { text: "hi" },
+    });
+    expect(a.selectedHeaders).toEqual([["content-type", "application/json"]]);
+    expect(a.canonicalBody).toEqual({ text: "hi" });
+  });
+
+  it("POST with a body but no content-type denies", () => {
+    expectCanon(
+      () =>
+        canonicalizeRawInternalXAction({
+          method: "POST",
+          origin: "https://api.x.com",
+          path: "/2/tweets",
+          body: { text: "hi" },
+        }),
+      "CANON_BODY_CONTENT_TYPE_REQUIRED",
+    );
+  });
+
+  it("POST rejects the github vendor media type (X is application/json only)", () => {
+    expectCanon(
+      () =>
+        canonicalizeRawInternalXAction({
+          method: "POST",
+          origin: "https://api.x.com",
+          path: "/2/tweets",
+          contentType: "application/vnd.github+json",
+          body: { text: "hi" },
+        }),
+      "CANON_BODY_CONTENT_TYPE_UNSUPPORTED",
+    );
+  });
+
+  it("GET / DELETE deny any body or content-type", () => {
+    expectCanon(
+      () =>
+        canonicalizeRawInternalXAction({
+          method: "GET",
+          origin: "https://api.x.com",
+          path: "/2/users/me",
+          body: { x: 1 },
+          contentType: "application/json",
+        }),
+      "CANON_BODY_FORBIDDEN",
+    );
+    expectCanon(
+      () =>
+        canonicalizeRawInternalXAction({
+          method: "DELETE",
+          origin: "https://api.x.com",
+          path: "/2/tweets/1",
+          body: { x: 1 },
+          contentType: "application/json",
+        }),
+      "CANON_BODY_FORBIDDEN",
+    );
+  });
+
+  it("rejects any caller-supplied header (X carries none)", () => {
+    expectCanon(
+      () =>
+        canonicalizeRawInternalXAction({
+          method: "GET",
+          origin: "https://api.x.com",
+          path: "/2/users/me",
+          headers: [["accept", "application/json"]],
+        }),
+      "CANON_HEADER_UNSUPPORTED",
+    );
+  });
+});
+
+describe("mutation proof: X digest depends on JCS key-sorting", () => {
+  const reply = {
+    reply: { in_reply_to_tweet_id: "1234567890" },
+    text: "thanks!",
+  };
+
+  it("shipped digest is order-independent (JCS sorts keys)", () => {
+    const a = canonicalizeRawInternalXAction({
+      method: "POST",
+      origin: "https://api.x.com",
+      path: "/2/tweets",
+      contentType: "application/json",
+      body: reply,
+    });
+    const b = canonicalizeRawInternalXAction({
+      method: "POST",
+      origin: "https://api.x.com",
+      path: "/2/tweets",
+      contentType: "application/json",
+      body: { text: "thanks!", reply: { in_reply_to_tweet_id: "1234567890" } },
+    });
+    expect(computeXActionDigest(a)).toBe(computeXActionDigest(b));
+  });
+
+  it("a naive un-sorted serializer would produce DIFFERENT bytes for the two orders", () => {
+    // Demonstrate the guard's value: plain JSON.stringify (insertion order) is
+    // NOT canonical, so the two logically-identical bodies serialize differently.
+    const s1 = JSON.stringify({ reply: { in_reply_to_tweet_id: "1234567890" }, text: "thanks!" });
+    const s2 = JSON.stringify({ text: "thanks!", reply: { in_reply_to_tweet_id: "1234567890" } });
+    expect(s1).not.toBe(s2);
+  });
+
+  it("shipped canonical bytes are identical for both orders (guard still holds)", () => {
+    const a = canonicalizeRawInternalXAction({
+      method: "POST",
+      origin: "https://api.x.com",
+      path: "/2/tweets",
+      contentType: "application/json",
+      body: reply,
+    });
+    const b = canonicalizeRawInternalXAction({
+      method: "POST",
+      origin: "https://api.x.com",
+      path: "/2/tweets",
+      contentType: "application/json",
+      body: { text: "thanks!", reply: { in_reply_to_tweet_id: "1234567890" } },
+    });
+    expect(xCanonicalActionBytes(a)).toBe(xCanonicalActionBytes(b));
+  });
+});
+
+describe("X denies path traversal / non-ASCII in the raw path", () => {
+  it("literal dot segment denies", () => {
+    expect(
+      denies(() =>
+        canonicalizeRawInternalXAction({
+          method: "DELETE",
+          origin: "https://api.x.com",
+          path: "/2/tweets/../secrets",
+        }),
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -11,7 +11,6 @@ export type { PriceOracle } from "./price-oracle.js";
 export { createPriceOracle } from "./price-oracle.js";
 export * from "./provider-action.js";
 export * from "./provider-approval.js";
-export * from "./x-provider-action.js";
 export * from "./provider-authority.js";
 // ─── Non-throwing description of an arbitrary thrown value (fail-closed catches) ───
 export { describeThrown, UNPRINTABLE_THROWN_VALUE } from "./safe-error.js";
@@ -33,6 +32,7 @@ export type {
 export * from "./types/venue.js";
 // ─── Runtime-extensible webhook event registry (core ∪ plugin-declared) ───
 export { WebhookEventRegistry } from "./webhook-event-registry.js";
+export * from "./x-provider-action.js";
 
 // ─── Tenancy ───
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -11,6 +11,7 @@ export type { PriceOracle } from "./price-oracle.js";
 export { createPriceOracle } from "./price-oracle.js";
 export * from "./provider-action.js";
 export * from "./provider-approval.js";
+export * from "./x-provider-action.js";
 export * from "./provider-authority.js";
 // ─── Non-throwing description of an arbitrary thrown value (fail-closed catches) ───
 export { describeThrown, UNPRINTABLE_THROWN_VALUE } from "./safe-error.js";

--- a/packages/shared/src/x-provider-action.ts
+++ b/packages/shared/src/x-provider-action.ts
@@ -1,0 +1,375 @@
+/**
+ * x-provider-action.ts — the `x.provider-action.v1` canonicalization profile.
+ *
+ * This module is the X (Twitter) sibling of the `github.provider-action.v1`
+ * profile in provider-action.ts. It defines, for the governed-provider-authority
+ * plan (issue #195 workstream B):
+ *   - the X canonical origin (`https://api.x.com`) + host allowlist;
+ *   - the X canonical action type (`XCanonicalActionV1`) and profile string;
+ *   - the X origin canonicalizer + the thin body/content-type orchestration that
+ *     produces a canonical action from a raw internal HTTP representation.
+ *
+ * SECURITY POSTURE. This module deliberately does NOT re-implement JCS, hashing,
+ * path normalization, query canonicalization, method canonicalization, or the
+ * content-type matrix. It imports the ONE shared canonicalizer surface from
+ * provider-action.ts and composes those primitives. The only X-specific logic
+ * here is: which origin/host is allowed, which profile string is stamped, and
+ * which request headers are allowlisted (X ops carry no caller-supplied headers;
+ * the sole header is the `content-type` injected by the body matrix). Every
+ * ambiguity fails closed with a stable CANON_* code, never a 500, never a coerce.
+ *
+ * Because `XCanonicalActionV1` is structurally identical to
+ * `GithubCanonicalActionV1` (same field set and shapes, differing only in the
+ * `profile` and `origin` string VALUES), the shared JCS serializer produces
+ * byte-identical framing and the action digest is computed by the exact same
+ * `sha256HexPrefixed(jcsStringify(...))` path the GitHub profile uses.
+ */
+
+import {
+  canonicalizeContentType,
+  canonicalizeMethod,
+  canonicalizeQueryPairs,
+  CanonError,
+  type CanonicalMethod,
+  jcsStringify,
+  type JsonValue,
+  normalizePath,
+  type QueryPair,
+  sha256HexPrefixed,
+} from "./provider-action.js";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Profile constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const X_PROVIDER_ACTION_PROFILE = "x.provider-action.v1" as const;
+
+/**
+ * The X canonical origin. Equivalent to GitHub's `CANONICAL_ORIGIN`. Only this
+ * exact host reaches an X action; every other origin denies. Chosen to match X's
+ * v2 REST base host (`api.x.com`); the legacy `api.twitter.com` alias is NOT
+ * accepted so a single canonical bytes representation exists per action.
+ */
+export const X_CANONICAL_ORIGIN = "https://api.x.com" as const;
+
+const X_ALLOWED_HOST = "api.x.com" as const;
+
+const X_JSON_CONTENT_TYPE = "application/json" as const;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Canonical action type
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The fully-canonical X provider action. Structurally identical to
+ * {@link GithubCanonicalActionV1}: the shared JCS framing depends only on the
+ * field set (which is the same), so digests are computed on the same path.
+ */
+export interface XCanonicalActionV1 {
+  profile: typeof X_PROVIDER_ACTION_PROFILE;
+  method: CanonicalMethod;
+  origin: string;
+  normalizedPath: string;
+  orderedQueryPairs: Array<[string, string]>;
+  selectedHeaders: Array<[string, string]>;
+  canonicalBody: null | JsonValue;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Origin canonicalization (X)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Normalize a raw origin string to the canonical `https://api.x.com`, or deny.
+ * Mirrors the GitHub origin canonicalizer's posture EXACTLY (scheme/host ASCII
+ * lowercasing, one terminal DNS-dot removal, explicit :443 omission, empty-or-`/`
+ * path, no IDNA, no IP literals, DNS-label validation) with the sole difference
+ * that the accepted host is `api.x.com`. Kept as a small self-contained function
+ * rather than parameterizing the GitHub canonicalizer so the GitHub profile's
+ * golden bytes remain provably untouched.
+ */
+export function canonicalizeXOrigin(raw: string): string {
+  if (typeof raw !== "string" || raw.length === 0)
+    throw new CanonError("CANON_ORIGIN_INVALID", "origin must be a non-empty string");
+  if (/[\u0000-\u0020\u007f]/.test(raw))
+    throw new CanonError("CANON_ORIGIN_INVALID", "control/space in origin");
+
+  const schemeMatch = /^([A-Za-z][A-Za-z0-9+.-]*):\/\//.exec(raw);
+  if (!schemeMatch) throw new CanonError("CANON_ORIGIN_INVALID", "origin missing scheme://");
+  const scheme = schemeMatch[1].toLowerCase();
+  if (scheme !== "https")
+    throw new CanonError("CANON_ORIGIN_SCHEME_UNSUPPORTED", `scheme '${scheme}' not https`);
+
+  const rest = raw.slice(schemeMatch[0].length);
+  if (rest.includes("@")) throw new CanonError("CANON_ORIGIN_INVALID", "userinfo not allowed");
+  if (rest.includes("?"))
+    throw new CanonError("CANON_ORIGIN_INVALID", "query not allowed in origin");
+  if (rest.includes("#"))
+    throw new CanonError("CANON_ORIGIN_INVALID", "fragment not allowed in origin");
+
+  const slash = rest.indexOf("/");
+  const authority = slash === -1 ? rest : rest.slice(0, slash);
+  const path = slash === -1 ? "" : rest.slice(slash);
+  if (path !== "" && path !== "/")
+    throw new CanonError("CANON_ORIGIN_INVALID", "origin path must be empty or '/'");
+
+  if (authority.includes("[") || authority.includes("]"))
+    throw new CanonError("CANON_ORIGIN_HOST_INVALID", "IP literal host");
+
+  let host = authority;
+  const colon = authority.lastIndexOf(":");
+  if (colon !== -1) {
+    const portStr = authority.slice(colon + 1);
+    host = authority.slice(0, colon);
+    if (!/^[0-9]+$/.test(portStr))
+      throw new CanonError("CANON_ORIGIN_PORT_UNSUPPORTED", "invalid port");
+    if (portStr !== "443")
+      throw new CanonError("CANON_ORIGIN_PORT_UNSUPPORTED", `nondefault port ${portStr}`);
+  }
+
+  if (/%/.test(host)) throw new CanonError("CANON_ORIGIN_HOST_INVALID", "percent escape in host");
+  if (/[^\x00-\x7f]/.test(host))
+    throw new CanonError("CANON_ORIGIN_HOST_INVALID", "non-ASCII host");
+  let h = host.toLowerCase();
+  if (h.endsWith(".."))
+    throw new CanonError("CANON_ORIGIN_HOST_INVALID", "multiple terminal dots");
+  if (h.endsWith(".")) h = h.slice(0, -1);
+  if (h.startsWith("[")) throw new CanonError("CANON_ORIGIN_HOST_INVALID", "IP literal host");
+  if (/^[0-9]+(\.[0-9]+)*$/.test(h))
+    throw new CanonError("CANON_ORIGIN_HOST_INVALID", "numeric/IPv4 host");
+  for (const label of h.split(".")) {
+    if (!/^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/.test(label))
+      throw new CanonError("CANON_ORIGIN_HOST_INVALID", `invalid DNS label '${label}'`);
+  }
+  if (h !== X_ALLOWED_HOST)
+    throw new CanonError("CANON_ORIGIN_NOT_ALLOWED", `host '${h}' not allowed`);
+  return X_CANONICAL_ORIGIN;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Raw internal HTTP representation → canonical X action (body/content-type matrix)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * A raw, INTERNAL HTTP representation of an X provider action. Mirrors
+ * {@link RawInternalAction} for GitHub. Fields are raw/pre-canonical; the X
+ * adapter constructs these from validated operation arguments and the PR-C proxy
+ * recomputation / offline verifier feed the same shape in, so there is exactly
+ * ONE X canonicalization path and the golden corpus proves it byte-for-byte.
+ *
+ * X operations carry NO caller-supplied headers: the only header that can appear
+ * on a canonical X action is the `content-type` injected by the body matrix for
+ * a body-bearing mutation. A non-empty `headers` array therefore denies.
+ */
+export interface RawInternalXAction {
+  method: string;
+  origin: string;
+  path: string;
+  query?: ReadonlyArray<QueryPair>;
+  /** X ops declare no caller headers; a non-empty list denies. */
+  headers?: ReadonlyArray<[string, string]>;
+  /** Raw content-type header value when a body is present; omit for no body. */
+  contentType?: string;
+  /** Already-parsed JSON body value, or absent/undefined for no body. */
+  body?: JsonValue;
+}
+
+const X_BODYLESS_METHODS: ReadonlySet<CanonicalMethod> = new Set(["GET", "HEAD"]);
+const X_BODY_METHODS: ReadonlySet<CanonicalMethod> = new Set(["POST", "PUT", "PATCH"]);
+
+/**
+ * Canonicalize a raw internal X HTTP representation into the fully-canonical
+ * {@link XCanonicalActionV1}, applying the body/content-type matrix. Throws
+ * {@link CanonError} on any ambiguity (never a 500).
+ *
+ * Reuses the shared method/path/query/content-type canonicalizers verbatim; the
+ * only X-specific steps are the origin allowlist and the profile stamp. The
+ * content-type header is validated and injected HERE (X ops pass no headers
+ * otherwise) so the body and its media type are canonicalized together.
+ */
+export function canonicalizeRawInternalXAction(raw: RawInternalXAction): XCanonicalActionV1 {
+  const method = canonicalizeMethod(raw.method);
+  const origin = canonicalizeXOrigin(raw.origin);
+  const normalizedPath = normalizePath(raw.path);
+  const orderedQueryPairs = canonicalizeQueryPairs(raw.query ?? []);
+
+  // X operations supply no caller headers. Reject any provided rather than
+  // silently dropping them (fail closed, no coercion).
+  if (raw.headers !== undefined && raw.headers.length > 0)
+    throw new CanonError("CANON_HEADER_UNSUPPORTED", "X actions carry no caller headers");
+
+  const selectedHeaders: Array<[string, string]> = [];
+  const hasBody = raw.body !== undefined;
+  const hasContentType = raw.contentType !== undefined;
+
+  let canonicalBody: JsonValue | null = null;
+
+  if (X_BODYLESS_METHODS.has(method)) {
+    if (hasBody || hasContentType)
+      throw new CanonError("CANON_BODY_FORBIDDEN", `${method} must not carry a body`);
+  } else if (X_BODY_METHODS.has(method)) {
+    if (!hasBody) throw new CanonError("CANON_BODY_REQUIRED", `${method} requires a body`);
+    if (!hasContentType)
+      throw new CanonError("CANON_BODY_CONTENT_TYPE_REQUIRED", "body present without content-type");
+    const media = canonicalizeContentType(raw.contentType as string);
+    // X v2 accepts JSON only in this profile; the shared content-type matrix also
+    // admits the GitHub vendor media type, so pin JSON explicitly here.
+    if (media !== X_JSON_CONTENT_TYPE)
+      throw new CanonError(
+        "CANON_BODY_CONTENT_TYPE_UNSUPPORTED",
+        `X body content-type must be application/json, got '${media}'`,
+      );
+    selectedHeaders.push(["content-type", media]);
+    if (raw.body === null || typeof raw.body !== "object" || Array.isArray(raw.body))
+      throw new CanonError("CANON_JSON_SHAPE_INVALID", "body must be a JSON object");
+    canonicalBody = raw.body;
+  } else {
+    // DELETE: bodyless only in this profile.
+    if (hasBody || hasContentType)
+      throw new CanonError("CANON_BODY_FORBIDDEN", `${method} must not carry a body`);
+  }
+
+  return {
+    profile: X_PROVIDER_ACTION_PROFILE,
+    method,
+    origin,
+    normalizedPath,
+    orderedQueryPairs,
+    selectedHeaders,
+    canonicalBody,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Canonical action bytes + digest (X)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Build the JCS-serializable canonical action object. Property order here is
+ * irrelevant (JCS re-sorts); we build a plain object so the serializer never
+ * sees a class instance. Field set is identical to the GitHub action object.
+ */
+function toXCanonicalActionObject(a: XCanonicalActionV1): Record<string, unknown> {
+  return {
+    profile: a.profile,
+    method: a.method,
+    origin: a.origin,
+    normalizedPath: a.normalizedPath,
+    orderedQueryPairs: a.orderedQueryPairs.map(([n, v]) => [n, v]),
+    selectedHeaders: a.selectedHeaders.map(([n, v]) => [n, v]),
+    canonicalBody: a.canonicalBody,
+  };
+}
+
+/** `canonicalActionBytes` for an X action as a UTF-8 string (no newline). */
+export function xCanonicalActionBytes(a: XCanonicalActionV1): string {
+  return jcsStringify(toXCanonicalActionObject(a));
+}
+
+/** `actionDigest` = sha256: hex of the X canonical action bytes. */
+export function computeXActionDigest(a: XCanonicalActionV1): string {
+  return sha256HexPrefixed(xCanonicalActionBytes(a));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Golden vectors — the authoritative X corpus, imported by every suite.
+//
+// Byte-exact canonical action bytes + digests for one representative case of
+// each operation plus the reply / unicode / trim / query-order edge cases. Tests
+// assert both that OUR serializer reproduces `canonicalActionBytes` and that the
+// recorded digests match, so a byte corruption in either direction fails.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface XGoldenVector {
+  id: string;
+  description: string;
+  action: XCanonicalActionV1;
+  canonicalActionBytes: string;
+  actionDigest: string;
+}
+
+function xa(
+  method: CanonicalMethod,
+  normalizedPath: string,
+  orderedQueryPairs: Array<[string, string]>,
+  selectedHeaders: Array<[string, string]>,
+  canonicalBody: null | JsonValue,
+): XCanonicalActionV1 {
+  return {
+    profile: X_PROVIDER_ACTION_PROFILE,
+    method,
+    origin: X_CANONICAL_ORIGIN,
+    normalizedPath,
+    orderedQueryPairs,
+    selectedHeaders,
+    canonicalBody,
+  };
+}
+
+export const X_GOLDEN_VECTORS: XGoldenVector[] = [
+  {
+    id: "XGV-01",
+    description: "user.me.read fixed query, canonical order",
+    action: xa("GET", "/2/users/me", [["user.fields", "id,name,username"]], [], null),
+    canonicalActionBytes:
+      '{"canonicalBody":null,"method":"GET","normalizedPath":"/2/users/me","orderedQueryPairs":[["user.fields","id,name,username"]],"origin":"https://api.x.com","profile":"x.provider-action.v1","selectedHeaders":[]}',
+    actionDigest: "sha256:1f9294f2c964103e13fdec37e08442e7a8e2480f24937a475fff992ec8c281f2",
+  },
+  {
+    id: "XGV-02",
+    description: "tweet.create basic text body",
+    action: xa(
+      "POST",
+      "/2/tweets",
+      [],
+      [["content-type", "application/json"]],
+      { text: "hello world" },
+    ),
+    canonicalActionBytes:
+      '{"canonicalBody":{"text":"hello world"},"method":"POST","normalizedPath":"/2/tweets","orderedQueryPairs":[],"origin":"https://api.x.com","profile":"x.provider-action.v1","selectedHeaders":[["content-type","application/json"]]}',
+    actionDigest: "sha256:7a37b4b65790940602d89529ec31198810046eaaaeea5a14a83740595cabd1f6",
+  },
+  {
+    id: "XGV-03",
+    description: "tweet.create reply (nested reply object, JCS key-sorted)",
+    action: xa("POST", "/2/tweets", [], [["content-type", "application/json"]], {
+      reply: { in_reply_to_tweet_id: "1234567890" },
+      text: "thanks!",
+    }),
+    canonicalActionBytes:
+      '{"canonicalBody":{"reply":{"in_reply_to_tweet_id":"1234567890"},"text":"thanks!"},"method":"POST","normalizedPath":"/2/tweets","orderedQueryPairs":[],"origin":"https://api.x.com","profile":"x.provider-action.v1","selectedHeaders":[["content-type","application/json"]]}',
+    actionDigest: "sha256:a9f340cac72bcfde034729f925c05782b5776ab8b2c8a16b27519de4c29a0e6a",
+  },
+  {
+    id: "XGV-04",
+    description: "tweet.create unicode text preserved (no normalization)",
+    action: xa("POST", "/2/tweets", [], [["content-type", "application/json"]], {
+      text: "café ☕ 日本",
+    }),
+    canonicalActionBytes:
+      '{"canonicalBody":{"text":"café ☕ 日本"},"method":"POST","normalizedPath":"/2/tweets","orderedQueryPairs":[],"origin":"https://api.x.com","profile":"x.provider-action.v1","selectedHeaders":[["content-type","application/json"]]}',
+    actionDigest: "sha256:7cd23ae2ea1e37f58917f39fd2023e3f3f3bf4a5f9f64c443d7baeb9f49726dc",
+  },
+  {
+    id: "XGV-05",
+    description: "tweet.create trims surrounding whitespace to authoritative body",
+    action: xa(
+      "POST",
+      "/2/tweets",
+      [],
+      [["content-type", "application/json"]],
+      { text: "spaced out" },
+    ),
+    canonicalActionBytes:
+      '{"canonicalBody":{"text":"spaced out"},"method":"POST","normalizedPath":"/2/tweets","orderedQueryPairs":[],"origin":"https://api.x.com","profile":"x.provider-action.v1","selectedHeaders":[["content-type","application/json"]]}',
+    actionDigest: "sha256:13cb864da52a15a468bf3945de99d00a36c09479a3b4678acdf0ae2d86852397",
+  },
+  {
+    id: "XGV-06",
+    description: "tweet.delete path segment from validated id",
+    action: xa("DELETE", "/2/tweets/9876543210987654321", [], [], null),
+    canonicalActionBytes:
+      '{"canonicalBody":null,"method":"DELETE","normalizedPath":"/2/tweets/9876543210987654321","orderedQueryPairs":[],"origin":"https://api.x.com","profile":"x.provider-action.v1","selectedHeaders":[]}',
+    actionDigest: "sha256:dc0f5eb1befcb5e92bffb9b6f6cae628f947343a9c50552c35ff7c6cdfdf33a5",
+  },
+];

--- a/packages/shared/src/x-provider-action.ts
+++ b/packages/shared/src/x-provider-action.ts
@@ -26,13 +26,13 @@
  */
 
 import {
+  CanonError,
+  type CanonicalMethod,
   canonicalizeContentType,
   canonicalizeMethod,
   canonicalizeQueryPairs,
-  CanonError,
-  type CanonicalMethod,
-  jcsStringify,
   type JsonValue,
+  jcsStringify,
   normalizePath,
   type QueryPair,
   sha256HexPrefixed,
@@ -131,8 +131,7 @@ export function canonicalizeXOrigin(raw: string): string {
   if (/[^\x00-\x7f]/.test(host))
     throw new CanonError("CANON_ORIGIN_HOST_INVALID", "non-ASCII host");
   let h = host.toLowerCase();
-  if (h.endsWith(".."))
-    throw new CanonError("CANON_ORIGIN_HOST_INVALID", "multiple terminal dots");
+  if (h.endsWith("..")) throw new CanonError("CANON_ORIGIN_HOST_INVALID", "multiple terminal dots");
   if (h.endsWith(".")) h = h.slice(0, -1);
   if (h.startsWith("[")) throw new CanonError("CANON_ORIGIN_HOST_INVALID", "IP literal host");
   if (/^[0-9]+(\.[0-9]+)*$/.test(h))
@@ -318,13 +317,9 @@ export const X_GOLDEN_VECTORS: XGoldenVector[] = [
   {
     id: "XGV-02",
     description: "tweet.create basic text body",
-    action: xa(
-      "POST",
-      "/2/tweets",
-      [],
-      [["content-type", "application/json"]],
-      { text: "hello world" },
-    ),
+    action: xa("POST", "/2/tweets", [], [["content-type", "application/json"]], {
+      text: "hello world",
+    }),
     canonicalActionBytes:
       '{"canonicalBody":{"text":"hello world"},"method":"POST","normalizedPath":"/2/tweets","orderedQueryPairs":[],"origin":"https://api.x.com","profile":"x.provider-action.v1","selectedHeaders":[["content-type","application/json"]]}',
     actionDigest: "sha256:7a37b4b65790940602d89529ec31198810046eaaaeea5a14a83740595cabd1f6",
@@ -353,13 +348,9 @@ export const X_GOLDEN_VECTORS: XGoldenVector[] = [
   {
     id: "XGV-05",
     description: "tweet.create trims surrounding whitespace to authoritative body",
-    action: xa(
-      "POST",
-      "/2/tweets",
-      [],
-      [["content-type", "application/json"]],
-      { text: "spaced out" },
-    ),
+    action: xa("POST", "/2/tweets", [], [["content-type", "application/json"]], {
+      text: "spaced out",
+    }),
     canonicalActionBytes:
       '{"canonicalBody":{"text":"spaced out"},"method":"POST","normalizedPath":"/2/tweets","orderedQueryPairs":[],"origin":"https://api.x.com","profile":"x.provider-action.v1","selectedHeaders":[["content-type","application/json"]]}',
     actionDigest: "sha256:13cb864da52a15a468bf3945de99d00a36c09479a3b4678acdf0ae2d86852397",


### PR DESCRIPTION
## Summary

Workstream B of #195: the pure `@stwd/provider-x` adapter + the shared `x.provider-action.v1` canonical profile. No DB, no routes, no OAuth flow, no proxy changes (workstreams A and C own those).

The adapter owns operation argument schemas, canonical action construction, safe summaries, and validated policy args. It imports the ONE shared canonicalizer surface and **never re-implements JCS, hashing, path/query/method normalization, or the content-type matrix**. The X canonical action is structurally identical to the GitHub one (same field set), so the shared JCS serializer produces byte-identical framing and the action digest is computed on the exact same `sha256HexPrefixed(jcsStringify(...))` path.

## Operations

| operation | method | path | body | risk |
|---|---|---|---|---|
| `x.tweet.create` | POST | `/2/tweets` | `{text}` + `{reply:{in_reply_to_tweet_id}}` when replying | write (approval-worthy) |
| `x.tweet.delete` | DELETE | `/2/tweets/{id}` | none | write (approval-worthy) |
| `x.user.me.read` | GET | `/2/users/me?user.fields=id,name,username` | none | read |

### Argument schemas (fail-closed, stable CANON_* codes)
- `x.tweet.create`: `{text: string, replyToTweetId?: string}`. `text` trimmed then bounded 1..280 **code points**; `replyToTweetId` must match `/^[0-9]{1,25}$/`. The `reply` body key appears only when `replyToTweetId` is present.
- `x.tweet.delete`: `{tweetId: string}`, `/^[0-9]{1,25}$/`. The path segment is built from the VALIDATED id (no raw concatenation, no percent-encoding needed, traversal impossible).
- `x.user.me.read`: no args (accepts absent/empty object); any field is `CANON_UNKNOWN_FIELD`. Fixed single-pair query in canonical order.
- Unknown fields -> `CANON_UNKNOWN_FIELD`; type errors -> `CANON_FIELD_TYPE_INVALID`; bad ids -> `CANON_PATH_SEGMENT_INVALID`; empty-after-trim text -> `CANON_BODY_REQUIRED`; over-length text -> `CANON_FIELD_TYPE_INVALID`; lone surrogate -> `CANON_UNICODE_INVALID`.

## Shared profile changes (minimal + additive)
- New file `packages/shared/src/x-provider-action.ts`, re-exported from the shared index. Adds `X_PROVIDER_ACTION_PROFILE` (`x.provider-action.v1`), `X_CANONICAL_ORIGIN` (`https://api.x.com`), `XCanonicalActionV1`, `canonicalizeXOrigin`, `canonicalizeRawInternalXAction`, `xCanonicalActionBytes`, `computeXActionDigest`, and `X_GOLDEN_VECTORS`.
- **Zero edits to `provider-action.ts`** beyond the single index re-export line: the GitHub profile's golden bytes are provably untouched (all 331 shared tests + 8 provider-github tests still green). The X origin canonicalizer mirrors GitHub's posture exactly (scheme/host lowercasing, one terminal dot, :443 omission, DNS-label validation, no IDNA, no IP literals) with the sole difference that the accepted host is `api.x.com`.

## Canonicalization notes
- **X carries NO caller headers.** The only header that can appear on a canonical X action is the `content-type: application/json` injected by the body matrix for a POST. A non-empty `headers` input denies (`CANON_HEADER_UNSUPPORTED`).
- **JSON only.** POST bodies pin `application/json`; the GitHub vendor media type is rejected (`CANON_BODY_CONTENT_TYPE_UNSUPPORTED`).
- **Text length simplification (documented in-code + here):** X's real limit is a *weighted* length (URLs count 23, CJK count 2, etc.), which depends on X's tco model and drifting published ranges. This adapter counts by Unicode **code points** (`[...text].length`) after trim, bounded 1..280. Deterministic and re-derivable by the proxy/offline verifier; an occasional server-side rejection is possible for exotic inputs, which is acceptable for a fail-closed adapter.
- **Reply body key ordering:** builder inserts `{text, reply}` but JCS re-sorts to `{reply, text}`; digest is order-independent (proven below).

## Safe summaries + policy args
- `x.tweet.create` safe summary: `{operation, isReply, textCodePointLength, textByteLength, textSha256}` — **no text slice** (see codex P2 fix below), mirroring the GitHub adapter's length+sha256 pattern.
- policy args are **validated scalars only** (`isReply`, lengths, `replyToTweetId`/`tweetId`) — never raw JSON, never the text.

## Golden vector receipts (byte-exact, in shared)
`X_GOLDEN_VECTORS` (6): XGV-01 user.me.read fixed query; XGV-02 basic tweet; XGV-03 reply (nested, JCS-sorted); XGV-04 unicode (`café ☕ 日本`, no normalization); XGV-05 whitespace-trim; XGV-06 delete id path. Both suites assert our serializer reproduces `canonicalActionBytes` AND the recorded `actionDigest`, and that the adapter output equals the vectors byte-for-byte.

## Mutation receipts
- **Digest depends on JCS key-sort:** reply body in two key orders -> identical bytes + identical digest (shipped); plain `JSON.stringify` of the two orders differs (demonstrates the guard has teeth). `packages/shared/.../x-provider-action.test.ts`.
- **Corpus is not vacuous:** mutating a body value changes the digest; mutating key order does not.
- **id regex has teeth:** `12a`, 26 digits, `1/../2`, `../evil`, `12%2F34`, `` all deny `CANON_PATH_SEGMENT_INVALID`.
- **length bound has teeth:** 280 astral code points pass, 281 deny.
- **codex P2 regression:** short tweet (`gm`) never appears in the summary; no `textPreview` field exists.

## Plumbing
- `packages/provider-x` package.json/tsconfig mirror provider-github. Workspace picks it up via the existing `packages/*` glob.
- **Dockerfile:** provider-x COPY + symlink entries added mirroring provider-github in **all 3 stages** (deps, build, runtime) — the PR2 lesson that new workspace packages need root Dockerfile COPY in every stage.
- `bun.lock`: additive registration of `@stwd/provider-x` only.

## Verification
- `@stwd/shared`: 331 pass / 0 fail (github golden vectors byte-stable). `@stwd/provider-github`: 8 pass (regression). `@stwd/provider-x`: 22 pass. tsc + biome clean on all changed files.
- codex `review --base origin/develop`: one P2 (short-tweet preview leak) — **fixed** in ae6f311 by removing the preview entirely.

## Honest gaps / out of scope
- No DB registration, routes, OAuth connect, refresh, or proxy Bearer injection (workstreams A/C).
- Code-point length is stricter-or-equal to X's weighted length for pure text, not identical; documented tradeoff.
- No media/attachments in v1 (matches the issue).

[sol-orch]

Tip: $TIP
