### PR TITLE
feat(provider-x): X OAuth provider-account connect + token lifecycle (#195 workstream A)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -210,10 +210,21 @@ STEWARD_PROXY_PORT=8080
 
 # ─── Auth — OAuth (Twitter / X) ───────────────────────────────────────────────
 
-# Twitter/X OAuth (for "Continue with Twitter" login).
+# Twitter/X OAuth (for "Continue with Twitter" LOGIN — the user sign-in plane).
 # Create app at https://developer.x.com/en/portal/dashboard
 TWITTER_CLIENT_ID=
 TWITTER_CLIENT_SECRET=
+
+# ─── Provider-account X (Twitter) connect (#195 workstream A) ──────────────────
+# SEPARATE from the TWITTER_CLIENT_ID login credentials above. These authorize a
+# WORKSPACE to CONNECT an X account for governed AGENT ACTIONS (provider-
+# connection plane), NOT human sign-in. Keep the two credential sets distinct so
+# a login-app compromise cannot mint provider-action tokens (and vice versa).
+# The connect flow uses OAuth 2.0 authorization-code + PKCE (S256) and requests
+# the minimal scopes tweet.read tweet.write users.read offline.access.
+# offline.access is REQUIRED to receive the rotating refresh token.
+X_CLIENT_ID=
+X_CLIENT_SECRET=
 
 # ─── Web Dashboard (web/ — Next.js) ───────────────────────────────────────────
 # These variables are used by the Next.js web app, not the API server.

--- a/packages/api/src/__tests__/provider-x-connect.test.ts
+++ b/packages/api/src/__tests__/provider-x-connect.test.ts
@@ -1,0 +1,814 @@
+/**
+ * Provider-account X (Twitter) OAuth connect + token lifecycle tests
+ * (issue #195 workstream A).
+ *
+ * Covers: connect initiate/complete happy path, state mismatch, expired state,
+ * reused state, PKCE failure, wrong-role caller (via canConnectProviderAccounts
+ * gate), refresh rotation single-flight (concurrency: exactly one token call),
+ * refresh revoked -> degraded, disconnect. The X network is fully faked through
+ * the __setXForwardForTests seam; no real network is ever hit.
+ */
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  setDefaultTimeout,
+  test,
+} from "bun:test";
+import {
+  auditEvents as auditEventsTable,
+  closeDb,
+  getDb,
+  providerAccounts,
+  providerRoleBindings,
+  secrets,
+  tenants,
+  users,
+  userTenants,
+  workspaces,
+} from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { SecretVault } from "@stwd/vault";
+import { and, eq } from "drizzle-orm";
+import { providerAuthorityStore } from "../services/provider-authority-store";
+import {
+  __setXForwardForTests,
+  completeXConnect,
+  disconnectXProviderCredential,
+  initiateXConnect,
+  type PendingConnectStore,
+  refreshXProviderCredential,
+  X_ADAPTER_KEY,
+  XConnectError,
+  type XCredentialPayload,
+  type XForwardRequest,
+  type XForwardResponse,
+  xCredentialSecretName,
+} from "../services/provider-x-connect";
+
+setDefaultTimeout(120_000);
+
+// ── Fixture identifiers ───────────────────────────────────────────────────────
+const TENANT = "tenant-x-connect";
+const ADMIN = "10000000-0000-4000-8000-0000000000a1";
+const APPROVER = "10000000-0000-4000-8000-0000000000a2";
+const VIEWER = "10000000-0000-4000-8000-0000000000a3";
+const OUTSIDER = "10000000-0000-4000-8000-0000000000a4";
+const WORKSPACE = "20000000-0000-4000-8000-0000000000b1";
+const ADMIN_BINDING = "30000000-0000-4000-8000-0000000000c1";
+const APPROVER_BINDING = "30000000-0000-4000-8000-0000000000c2";
+const VIEWER_BINDING = "30000000-0000-4000-8000-0000000000c3";
+
+const REDIRECT = "https://app.steward.test/connect/x/callback";
+const CONFIG = { clientId: "x-client-id", clientSecret: "x-client-secret" };
+
+const MASTER = process.env.STEWARD_MASTER_PASSWORD ?? "steward-api-test-suite-master-password";
+const vault = new SecretVault(MASTER);
+
+async function readAuditActions(tenantId: string): Promise<string[]> {
+  const db = getDb();
+  const rows = await db
+    .select({ action: auditEventsTable.action })
+    .from(auditEventsTable)
+    .where(eq(auditEventsTable.tenantId, tenantId));
+  return rows.map((r) => r.action);
+}
+
+/** base64url encode without the narrow bun-types Buffer encoding union. */
+function toB64url(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  const binary = Array.from(bytes, (b) => String.fromCharCode(b)).join("");
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+// ── In-memory pending-connect store (single-use, TTL-aware) ───────────────────
+class MemoryConnectStore implements PendingConnectStore {
+  private map = new Map<string, { value: string; expiresAt: number }>();
+  now = Date.now();
+
+  async set(key: string, value: string, ttlMs: number): Promise<void> {
+    this.map.set(key, { value, expiresAt: this.now + ttlMs });
+  }
+  async get(key: string): Promise<string | null> {
+    const rec = this.map.get(key);
+    if (!rec) return null;
+    if (rec.expiresAt <= this.now) {
+      this.map.delete(key);
+      return null;
+    }
+    return rec.value;
+  }
+  async consume(key: string): Promise<string | null> {
+    const value = await this.get(key);
+    if (value !== null) this.map.delete(key);
+    return value;
+  }
+}
+
+// ── Fake X network ────────────────────────────────────────────────────────────
+interface FakeXOptions {
+  exchangeToken?: Partial<{
+    access_token: string;
+    refresh_token: string;
+    scope: string;
+    expires_in: number;
+  }>;
+  exchangeStatus?: number;
+  identity?: { id: string; username: string; name: string };
+  identityStatus?: number;
+  refreshResponses?: Array<{
+    status: number;
+    body: Record<string, unknown>;
+    delayMs?: number;
+  }>;
+}
+
+interface FakeXCounters {
+  exchange: number;
+  identity: number;
+  refresh: number;
+  revoke: number;
+}
+
+function installFakeX(opts: FakeXOptions = {}): {
+  counters: FakeXCounters;
+  restore: () => void;
+} {
+  const counters: FakeXCounters = { exchange: 0, identity: 0, refresh: 0, revoke: 0 };
+  let refreshIdx = 0;
+  const fn = async (req: XForwardRequest): Promise<XForwardResponse> => {
+    // Token endpoint: distinguish exchange vs refresh by grant_type.
+    if (req.url.includes("/oauth2/token")) {
+      const body = req.body ?? "";
+      if (body.includes("grant_type=refresh_token")) {
+        counters.refresh += 1;
+        const resp = opts.refreshResponses?.[refreshIdx] ?? {
+          status: 200,
+          body: {
+            access_token: `access-refreshed-${counters.refresh}`,
+            refresh_token: `refresh-rotated-${counters.refresh}`,
+            scope: "tweet.read tweet.write users.read offline.access",
+            expires_in: 7200,
+          },
+        };
+        refreshIdx += 1;
+        if (resp.delayMs) await new Promise((r) => setTimeout(r, resp.delayMs));
+        return jsonResponse(resp.status, resp.body);
+      }
+      counters.exchange += 1;
+      const status = opts.exchangeStatus ?? 200;
+      if (status !== 200) return jsonResponse(status, { error: "invalid_request" });
+      return jsonResponse(200, {
+        access_token: "access-initial",
+        refresh_token: "refresh-initial",
+        scope: "tweet.read tweet.write users.read offline.access",
+        expires_in: 7200,
+        ...opts.exchangeToken,
+      });
+    }
+    if (req.url.includes("/users/me")) {
+      counters.identity += 1;
+      const status = opts.identityStatus ?? 200;
+      if (status !== 200) return jsonResponse(status, {});
+      const identity = opts.identity ?? { id: "x-user-123", username: "solsundial", name: "Sol" };
+      return jsonResponse(200, { data: identity });
+    }
+    if (req.url.includes("/oauth2/revoke")) {
+      counters.revoke += 1;
+      return jsonResponse(200, {});
+    }
+    throw new Error(`unexpected X call: ${req.url}`);
+  };
+  const restore = __setXForwardForTests(fn);
+  return { counters, restore };
+}
+
+function jsonResponse(status: number, body: unknown): XForwardResponse {
+  const text = JSON.stringify(body);
+  return { status, ok: status >= 200 && status < 300, json: body, text };
+}
+
+// ── Schema bootstrap ──────────────────────────────────────────────────────────
+async function seed() {
+  const db = getDb();
+  await db.insert(tenants).values([{ id: TENANT, name: "X Connect", apiKeyHash: "h" }]);
+  await db.insert(users).values([
+    { id: ADMIN, email: "admin@x.test" },
+    { id: APPROVER, email: "approver@x.test" },
+    { id: VIEWER, email: "viewer@x.test" },
+    { id: OUTSIDER, email: "outsider@x.test" },
+  ]);
+  await db.insert(userTenants).values([
+    { userId: ADMIN, tenantId: TENANT, role: "member" },
+    { userId: APPROVER, tenantId: TENANT, role: "member" },
+    { userId: VIEWER, tenantId: TENANT, role: "member" },
+    // OUTSIDER is deliberately NOT a tenant member.
+  ]);
+  await db.insert(workspaces).values([
+    {
+      id: WORKSPACE,
+      tenantId: TENANT,
+      key: "client-x",
+      name: "Client X",
+      environment: "production",
+      createdBy: ADMIN,
+    },
+  ]);
+  await db.insert(providerRoleBindings).values([
+    {
+      id: ADMIN_BINDING,
+      tenantId: TENANT,
+      workspaceId: WORKSPACE,
+      principalType: "human",
+      principalId: ADMIN,
+      roleKey: "workspace_admin",
+      status: "active",
+      grantedByUserId: ADMIN,
+      reason: "seed",
+    },
+    {
+      id: APPROVER_BINDING,
+      tenantId: TENANT,
+      workspaceId: WORKSPACE,
+      principalType: "human",
+      principalId: APPROVER,
+      roleKey: "workspace_approver",
+      status: "active",
+      grantedByUserId: ADMIN,
+      reason: "seed",
+    },
+    {
+      id: VIEWER_BINDING,
+      tenantId: TENANT,
+      workspaceId: WORKSPACE,
+      principalType: "human",
+      principalId: VIEWER,
+      roleKey: "workspace_viewer",
+      status: "active",
+      grantedByUserId: ADMIN,
+      reason: "seed",
+    },
+  ]);
+}
+
+beforeAll(async () => {
+  process.env.STEWARD_MASTER_PASSWORD ??= MASTER;
+  process.env.STEWARD_AUDIT_HMAC_KEY ??= "a".repeat(64);
+  process.env.STEWARD_PGLITE_MEMORY ??= "true";
+  process.env.STEWARD_DB_MODE ??= "pglite";
+  // Fresh, isolated schema for this file (matches the per-file convention). The
+  // override's teardown closes the client exactly once via closeDb() in afterAll.
+  const { db, client } = await createPGLiteDb("memory://");
+  setPGLiteOverride(db, async () => {
+    await client.close();
+  });
+  await seed();
+});
+
+afterAll(async () => {
+  __setXForwardForTests(null);
+  await closeDb();
+});
+
+afterEach(async () => {
+  __setXForwardForTests(null);
+  // Reset connected accounts + credential secrets between tests.
+  const db = getDb();
+  await db.delete(providerAccounts).where(eq(providerAccounts.tenantId, TENANT));
+  await db.delete(secrets).where(eq(secrets.tenantId, TENANT));
+});
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+async function connectHappy(
+  store: MemoryConnectStore,
+  overrides: {
+    userId?: string;
+    identity?: { id: string; username: string; name: string };
+    exchangeToken?: FakeXOptions["exchangeToken"];
+  } = {},
+) {
+  const fake = installFakeX({
+    identity: overrides.identity,
+    exchangeToken: overrides.exchangeToken,
+  });
+  const initiated = await initiateXConnect({
+    tenantId: TENANT,
+    workspaceId: WORKSPACE,
+    initiatedByUserId: overrides.userId ?? ADMIN,
+    redirectUri: REDIRECT,
+    config: CONFIG,
+    store,
+  });
+  const completed = await completeXConnect({
+    tenantId: TENANT,
+    workspaceId: WORKSPACE,
+    callerUserId: overrides.userId ?? ADMIN,
+    code: "auth-code",
+    state: initiated.state,
+    connectToken: initiated.connectToken,
+    redirectUri: REDIRECT,
+    config: CONFIG,
+    store,
+    vault,
+  });
+  fake.restore();
+  return { initiated, completed, fake };
+}
+
+async function decryptCredential(accountId: string): Promise<XCredentialPayload> {
+  const db = getDb();
+  const [acct] = await db
+    .select()
+    .from(providerAccounts)
+    .where(and(eq(providerAccounts.tenantId, TENANT), eq(providerAccounts.id, accountId)))
+    .limit(1);
+  const decrypted = await vault.decryptSecret(TENANT, acct.credentialSecretId as string);
+  return JSON.parse(decrypted) as XCredentialPayload;
+}
+
+// ── Authority gate (wrong-role caller) ────────────────────────────────────────
+describe("connect authority gate", () => {
+  test("workspace_admin is authorized", async () => {
+    expect(
+      await providerAuthorityStore.canConnectProviderAccounts(TENANT, WORKSPACE, ADMIN, "member"),
+    ).toBe(true);
+  });
+  test("workspace_approver is authorized", async () => {
+    expect(
+      await providerAuthorityStore.canConnectProviderAccounts(
+        TENANT,
+        WORKSPACE,
+        APPROVER,
+        "member",
+      ),
+    ).toBe(true);
+  });
+  test("workspace_viewer is NOT authorized", async () => {
+    expect(
+      await providerAuthorityStore.canConnectProviderAccounts(TENANT, WORKSPACE, VIEWER, "member"),
+    ).toBe(false);
+  });
+  test("non-member outsider is NOT authorized", async () => {
+    expect(
+      await providerAuthorityStore.canConnectProviderAccounts(
+        TENANT,
+        WORKSPACE,
+        OUTSIDER,
+        "member",
+      ),
+    ).toBe(false);
+  });
+});
+
+// ── Connect happy path + idempotent reconnect ─────────────────────────────────
+describe("connect", () => {
+  test("happy path: creates account, versioned credential, audit event", async () => {
+    const store = new MemoryConnectStore();
+    const { completed } = await connectHappy(store);
+    expect(completed.reconnected).toBe(false);
+    expect(completed.xUserId).toBe("x-user-123");
+    expect(completed.xUsername).toBe("solsundial");
+    expect(completed.credentialVersion).toBe(1);
+
+    const db = getDb();
+    const [acct] = await db
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, completed.providerAccountId));
+    expect(acct.adapterKey).toBe(X_ADAPTER_KEY);
+    expect(acct.externalRef).toBe("x-user-123");
+    expect(acct.displayName).toBe("@solsundial");
+    expect(acct.status).toBe("active");
+    expect(acct.credentialSecretId).toBeTruthy();
+    expect(acct.credentialVersion).toBe(1);
+
+    const cred = await decryptCredential(completed.providerAccountId);
+    expect(cred.accessToken).toBe("access-initial");
+    expect(cred.refreshToken).toBe("refresh-initial");
+    expect(cred.xUserId).toBe("x-user-123");
+
+    const events = await readAuditActions(TENANT);
+    expect(events.includes("provider.x.connect.completed")).toBe(true);
+  });
+
+  test("reconnect same X user id updates version + bumps revision, never duplicates", async () => {
+    const store = new MemoryConnectStore();
+    const first = await connectHappy(store);
+    const firstId = first.completed.providerAccountId;
+
+    const store2 = new MemoryConnectStore();
+    const second = await connectHappy(store2);
+
+    expect(second.completed.reconnected).toBe(true);
+    expect(second.completed.providerAccountId).toBe(firstId);
+    expect(second.completed.credentialVersion).toBe(2);
+
+    const db = getDb();
+    const rows = await db
+      .select()
+      .from(providerAccounts)
+      .where(
+        and(
+          eq(providerAccounts.tenantId, TENANT),
+          eq(providerAccounts.adapterKey, X_ADAPTER_KEY),
+          eq(providerAccounts.externalRef, "x-user-123"),
+        ),
+      );
+    expect(rows.length).toBe(1);
+    expect(rows[0].revision).toBe(2);
+    expect(rows[0].credentialVersion).toBe(2);
+  });
+});
+
+// ── State + PKCE negative cases ───────────────────────────────────────────────
+describe("connect state validation", () => {
+  test("state mismatch (unknown state) => X_STATE_INVALID", async () => {
+    const store = new MemoryConnectStore();
+    const fake = installFakeX();
+    await expect(
+      completeXConnect({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        callerUserId: ADMIN,
+        code: "auth-code",
+        state: "never-issued",
+        connectToken: toB64url(JSON.stringify({ state: "never-issued", verifier: "v" })),
+        redirectUri: REDIRECT,
+        config: CONFIG,
+        store,
+        vault,
+      }),
+    ).rejects.toMatchObject({ code: "X_STATE_INVALID" });
+    fake.restore();
+  });
+
+  test("expired state => X_STATE_INVALID (store returns null)", async () => {
+    const store = new MemoryConnectStore();
+    const fake = installFakeX();
+    const initiated = await initiateXConnect({
+      tenantId: TENANT,
+      workspaceId: WORKSPACE,
+      initiatedByUserId: ADMIN,
+      redirectUri: REDIRECT,
+      config: CONFIG,
+      store,
+    });
+    // Advance the store clock beyond the TTL so get() evicts the entry.
+    store.now += 60 * 60 * 1000;
+    await expect(
+      completeXConnect({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        callerUserId: ADMIN,
+        code: "auth-code",
+        state: initiated.state,
+        connectToken: initiated.connectToken,
+        redirectUri: REDIRECT,
+        config: CONFIG,
+        store,
+        vault,
+      }),
+    ).rejects.toMatchObject({ code: "X_STATE_INVALID" });
+    fake.restore();
+  });
+
+  test("reused state => X_STATE_REUSED on the second completion", async () => {
+    const store = new MemoryConnectStore();
+    const fake = installFakeX();
+    const initiated = await initiateXConnect({
+      tenantId: TENANT,
+      workspaceId: WORKSPACE,
+      initiatedByUserId: ADMIN,
+      redirectUri: REDIRECT,
+      config: CONFIG,
+      store,
+    });
+    const args = {
+      tenantId: TENANT,
+      workspaceId: WORKSPACE,
+      callerUserId: ADMIN,
+      code: "auth-code",
+      state: initiated.state,
+      connectToken: initiated.connectToken,
+      redirectUri: REDIRECT,
+      config: CONFIG,
+      store,
+      vault,
+    };
+    await completeXConnect(args);
+    await expect(completeXConnect(args)).rejects.toMatchObject({ code: "X_STATE_INVALID" });
+    fake.restore();
+  });
+
+  test("PKCE verifier mismatch => X_PKCE_MISMATCH", async () => {
+    const store = new MemoryConnectStore();
+    const fake = installFakeX();
+    const initiated = await initiateXConnect({
+      tenantId: TENANT,
+      workspaceId: WORKSPACE,
+      initiatedByUserId: ADMIN,
+      redirectUri: REDIRECT,
+      config: CONFIG,
+      store,
+    });
+    // Forge a connectToken with the right state but a WRONG verifier.
+    const forged = toB64url(JSON.stringify({ state: initiated.state, verifier: "wrong-verifier" }));
+    await expect(
+      completeXConnect({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        callerUserId: ADMIN,
+        code: "auth-code",
+        state: initiated.state,
+        connectToken: forged,
+        redirectUri: REDIRECT,
+        config: CONFIG,
+        store,
+        vault,
+      }),
+    ).rejects.toMatchObject({ code: "X_PKCE_MISMATCH" });
+    fake.restore();
+  });
+
+  test("scope mismatch: caller from a different workspace/user cannot complete", async () => {
+    const store = new MemoryConnectStore();
+    const fake = installFakeX();
+    const initiated = await initiateXConnect({
+      tenantId: TENANT,
+      workspaceId: WORKSPACE,
+      initiatedByUserId: ADMIN,
+      redirectUri: REDIRECT,
+      config: CONFIG,
+      store,
+    });
+    await expect(
+      completeXConnect({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        callerUserId: APPROVER, // different user than initiated
+        code: "auth-code",
+        state: initiated.state,
+        connectToken: initiated.connectToken,
+        redirectUri: REDIRECT,
+        config: CONFIG,
+        store,
+        vault,
+      }),
+    ).rejects.toMatchObject({ code: "X_STATE_INVALID" });
+    fake.restore();
+  });
+
+  test("token exchange failure does NOT consume the state (retryable)", async () => {
+    const store = new MemoryConnectStore();
+    const failing = installFakeX({ exchangeStatus: 400 });
+    const initiated = await initiateXConnect({
+      tenantId: TENANT,
+      workspaceId: WORKSPACE,
+      initiatedByUserId: ADMIN,
+      redirectUri: REDIRECT,
+      config: CONFIG,
+      store,
+    });
+    const args = {
+      tenantId: TENANT,
+      workspaceId: WORKSPACE,
+      callerUserId: ADMIN,
+      code: "auth-code",
+      state: initiated.state,
+      connectToken: initiated.connectToken,
+      redirectUri: REDIRECT,
+      config: CONFIG,
+      store,
+      vault,
+    };
+    await expect(completeXConnect(args)).rejects.toMatchObject({
+      code: "X_TOKEN_EXCHANGE_FAILED",
+    });
+    failing.restore();
+    // The state must still be present for a retry.
+    const ok = installFakeX();
+    const retried = await completeXConnect(args);
+    expect(retried.xUserId).toBe("x-user-123");
+    ok.restore();
+  });
+});
+
+// ── Refresh: rotation, single-flight, revoke ──────────────────────────────────
+describe("refresh", () => {
+  test("force refresh rotates token to a new credential version + audit", async () => {
+    const store = new MemoryConnectStore();
+    const { completed } = await connectHappy(store);
+
+    const fake = installFakeX();
+    const result = await refreshXProviderCredential({
+      tenantId: TENANT,
+      accountId: completed.providerAccountId,
+      vault,
+      config: CONFIG,
+      force: true,
+    });
+    expect(result.refreshed).toBe(true);
+    expect(result.credentialVersion).toBe(2);
+    expect(fake.counters.refresh).toBe(1);
+
+    const cred = await decryptCredential(completed.providerAccountId);
+    expect(cred.accessToken).toBe("access-refreshed-1");
+    expect(cred.refreshToken).toBe("refresh-rotated-1");
+    fake.restore();
+
+    const events = await readAuditActions(TENANT);
+    expect(events.includes("provider.x.refresh.completed")).toBe(true);
+  });
+
+  test("SINGLE-FLIGHT: two concurrent refreshes of a near-expiry token make exactly ONE token call", async () => {
+    const store = new MemoryConnectStore();
+    // Seed a token that is ALREADY near expiry (expires_in=1s) so BOTH non-forced
+    // concurrent callers independently decide a refresh is needed. That is the
+    // real rotating-refresh hazard: without the per-account row lock + post-lock
+    // near-expiry re-check, both would call the token endpoint and both would try
+    // to spend the SAME single-use refresh token. Single-flight collapses this to
+    // exactly one token call; the loser observes the freshly rotated (far-expiry)
+    // token after acquiring the lock and short-circuits.
+    //
+    // Mutation check: weaken the guard (drop `.for("update")` or the post-lock
+    // near-expiry re-check) and the refresh counter becomes 2 => this fails.
+    const { completed } = await connectHappy(store, { exchangeToken: { expires_in: 1 } });
+    const fake = installFakeX({
+      refreshResponses: [
+        {
+          status: 200,
+          delayMs: 40,
+          body: {
+            access_token: "access-refreshed-1",
+            refresh_token: "refresh-rotated-1",
+            scope: "tweet.read tweet.write users.read offline.access",
+            expires_in: 7200,
+          },
+        },
+        {
+          status: 200,
+          body: {
+            access_token: "access-refreshed-2",
+            refresh_token: "refresh-rotated-2",
+            scope: "tweet.read tweet.write users.read offline.access",
+            expires_in: 7200,
+          },
+        },
+      ],
+    });
+
+    const [r1, r2] = await Promise.all([
+      refreshXProviderCredential({
+        tenantId: TENANT,
+        accountId: completed.providerAccountId,
+        vault,
+        config: CONFIG,
+      }),
+      refreshXProviderCredential({
+        tenantId: TENANT,
+        accountId: completed.providerAccountId,
+        vault,
+        config: CONFIG,
+      }),
+    ]);
+
+    // Exactly one performed the network refresh; the other observed the freshly
+    // rotated (not-near-expiry) token and short-circuited.
+    expect(fake.counters.refresh).toBe(1);
+    const refreshedCount = [r1, r2].filter((r) => r.refreshed).length;
+    expect(refreshedCount).toBe(1);
+
+    const cred = await decryptCredential(completed.providerAccountId);
+    expect(cred.accessToken).toBe("access-refreshed-1");
+    fake.restore();
+  });
+
+  test("refresh with fresh token + not forced short-circuits (no token call)", async () => {
+    const store = new MemoryConnectStore();
+    const { completed } = await connectHappy(store);
+    const fake = installFakeX();
+    const result = await refreshXProviderCredential({
+      tenantId: TENANT,
+      accountId: completed.providerAccountId,
+      vault,
+      config: CONFIG,
+    });
+    expect(result.refreshed).toBe(false);
+    expect(fake.counters.refresh).toBe(0);
+    fake.restore();
+  });
+
+  test("revoked upstream (invalid_grant) => account degraded + audit + X_REFRESH_REVOKED", async () => {
+    const store = new MemoryConnectStore();
+    const { completed } = await connectHappy(store);
+
+    const fake = installFakeX({
+      refreshResponses: [{ status: 400, body: { error: "invalid_grant" } }],
+    });
+    await expect(
+      refreshXProviderCredential({
+        tenantId: TENANT,
+        accountId: completed.providerAccountId,
+        vault,
+        config: CONFIG,
+        force: true,
+      }),
+    ).rejects.toMatchObject({ code: "X_REFRESH_REVOKED" });
+
+    const db = getDb();
+    const [acct] = await db
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, completed.providerAccountId));
+    expect(acct.status).toBe("revoked");
+    fake.restore();
+
+    const events = await readAuditActions(TENANT);
+    expect(events.includes("provider.x.refresh.revoked")).toBe(true);
+  });
+
+  test("refresh of a non-X account is rejected", async () => {
+    const db = getDb();
+    const [row] = await db
+      .insert(providerAccounts)
+      .values({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        adapterKey: "github",
+        externalRef: "gh-1",
+        displayName: "gh",
+      })
+      .returning();
+    const fake = installFakeX();
+    await expect(
+      refreshXProviderCredential({
+        tenantId: TENANT,
+        accountId: row.id,
+        vault,
+        config: CONFIG,
+        force: true,
+      }),
+    ).rejects.toMatchObject({ code: "X_ACCOUNT_NOT_X" });
+    fake.restore();
+  });
+});
+
+// ── Disconnect ────────────────────────────────────────────────────────────────
+describe("disconnect", () => {
+  test("degrades account, best-effort revokes at X, audits", async () => {
+    const store = new MemoryConnectStore();
+    const { completed } = await connectHappy(store);
+
+    const fake = installFakeX();
+    const result = await disconnectXProviderCredential({
+      tenantId: TENANT,
+      workspaceId: WORKSPACE,
+      accountId: completed.providerAccountId,
+      callerUserId: ADMIN,
+      vault,
+      config: CONFIG,
+    });
+    expect(result.revoked).toBe(true);
+    expect(fake.counters.revoke).toBe(1);
+
+    const db = getDb();
+    const [acct] = await db
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, completed.providerAccountId));
+    expect(acct.status).toBe("revoked");
+    fake.restore();
+
+    const events = await readAuditActions(TENANT);
+    expect(events.includes("provider.x.disconnect.completed")).toBe(true);
+  });
+
+  test("disconnect of a missing account => X_ACCOUNT_NOT_FOUND", async () => {
+    const fake = installFakeX();
+    await expect(
+      disconnectXProviderCredential({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        accountId: "40000000-0000-4000-8000-0000000000ff",
+        callerUserId: ADMIN,
+        vault,
+        config: CONFIG,
+      }),
+    ).rejects.toMatchObject({ code: "X_ACCOUNT_NOT_FOUND" });
+    fake.restore();
+  });
+});
+
+// ── Sanity: secret lineage name is deterministic per (workspace, x user) ──────
+test("credential secret name is stable per workspace+x user (reconnect lineage)", () => {
+  expect(xCredentialSecretName(WORKSPACE, "x-user-123")).toBe(`provider-x/${WORKSPACE}/x-user-123`);
+});
+
+test("XConnectError carries code + http status", () => {
+  const e = new XConnectError("X_STATE_INVALID", 401);
+  expect(e.code).toBe("X_STATE_INVALID");
+  expect(e.httpStatus).toBe(401);
+});

--- a/packages/api/src/__tests__/provider-x-connect.test.ts
+++ b/packages/api/src/__tests__/provider-x-connect.test.ts
@@ -58,6 +58,7 @@ const APPROVER = "10000000-0000-4000-8000-0000000000a2";
 const VIEWER = "10000000-0000-4000-8000-0000000000a3";
 const OUTSIDER = "10000000-0000-4000-8000-0000000000a4";
 const WORKSPACE = "20000000-0000-4000-8000-0000000000b1";
+const WORKSPACE_OTHER = "20000000-0000-4000-8000-0000000000b2";
 const ADMIN_BINDING = "30000000-0000-4000-8000-0000000000c1";
 const APPROVER_BINDING = "30000000-0000-4000-8000-0000000000c2";
 const VIEWER_BINDING = "30000000-0000-4000-8000-0000000000c3";
@@ -213,6 +214,14 @@ async function seed() {
       tenantId: TENANT,
       key: "client-x",
       name: "Client X",
+      environment: "production",
+      createdBy: ADMIN,
+    },
+    {
+      id: WORKSPACE_OTHER,
+      tenantId: TENANT,
+      key: "client-x-other",
+      name: "Client X Other",
       environment: "production",
       createdBy: ADMIN,
     },
@@ -605,6 +614,7 @@ describe("refresh", () => {
     const fake = installFakeX();
     const result = await refreshXProviderCredential({
       tenantId: TENANT,
+      workspaceId: WORKSPACE,
       accountId: completed.providerAccountId,
       vault,
       config: CONFIG,
@@ -663,12 +673,14 @@ describe("refresh", () => {
     const [r1, r2] = await Promise.all([
       refreshXProviderCredential({
         tenantId: TENANT,
+        workspaceId: WORKSPACE,
         accountId: completed.providerAccountId,
         vault,
         config: CONFIG,
       }),
       refreshXProviderCredential({
         tenantId: TENANT,
+        workspaceId: WORKSPACE,
         accountId: completed.providerAccountId,
         vault,
         config: CONFIG,
@@ -692,6 +704,7 @@ describe("refresh", () => {
     const fake = installFakeX();
     const result = await refreshXProviderCredential({
       tenantId: TENANT,
+      workspaceId: WORKSPACE,
       accountId: completed.providerAccountId,
       vault,
       config: CONFIG,
@@ -711,6 +724,7 @@ describe("refresh", () => {
     await expect(
       refreshXProviderCredential({
         tenantId: TENANT,
+        workspaceId: WORKSPACE,
         accountId: completed.providerAccountId,
         vault,
         config: CONFIG,
@@ -746,12 +760,78 @@ describe("refresh", () => {
     await expect(
       refreshXProviderCredential({
         tenantId: TENANT,
+        workspaceId: WORKSPACE,
         accountId: row.id,
         vault,
         config: CONFIG,
         force: true,
       }),
     ).rejects.toMatchObject({ code: "X_ACCOUNT_NOT_X" });
+    fake.restore();
+  });
+
+  test("cross-workspace IDOR: refreshing an account from another workspace => X_ACCOUNT_NOT_FOUND", async () => {
+    // Connect an X account in WORKSPACE, then attempt to refresh it while
+    // claiming authority over WORKSPACE_OTHER. The account does not belong to
+    // WORKSPACE_OTHER, so the workspace-binding guard must reject it (404).
+    //
+    // Mutation check: drop the `account.workspaceId !== input.workspaceId` guard
+    // and this refresh succeeds against another workspace's credential.
+    const store = new MemoryConnectStore();
+    const { completed } = await connectHappy(store);
+    const fake = installFakeX();
+    await expect(
+      refreshXProviderCredential({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE_OTHER,
+        accountId: completed.providerAccountId,
+        vault,
+        config: CONFIG,
+        force: true,
+      }),
+    ).rejects.toMatchObject({ code: "X_ACCOUNT_NOT_FOUND" });
+    expect(fake.counters.refresh).toBe(0);
+    fake.restore();
+  });
+
+  test("refresh does NOT resurrect a locally revoked account (reconnect required)", async () => {
+    // Connect, then disconnect (status -> revoked), then a forced refresh must
+    // fail closed instead of reactivating the account.
+    //
+    // Mutation check: drop the `account.status !== "active"` guard and the
+    // refresh reactivates a disconnected account without a fresh OAuth connect.
+    const store = new MemoryConnectStore();
+    const { completed } = await connectHappy(store);
+    const disc = installFakeX();
+    await disconnectXProviderCredential({
+      tenantId: TENANT,
+      workspaceId: WORKSPACE,
+      accountId: completed.providerAccountId,
+      callerUserId: ADMIN,
+      vault,
+      config: CONFIG,
+    });
+    disc.restore();
+
+    const fake = installFakeX();
+    await expect(
+      refreshXProviderCredential({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        accountId: completed.providerAccountId,
+        vault,
+        config: CONFIG,
+        force: true,
+      }),
+    ).rejects.toMatchObject({ code: "X_REFRESH_REVOKED" });
+    expect(fake.counters.refresh).toBe(0);
+
+    const db = getDb();
+    const [acct] = await db
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, completed.providerAccountId));
+    expect(acct.status).toBe("revoked");
     fake.restore();
   });
 });

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -61,6 +61,7 @@ import { policiesStandaloneRoutes } from "./routes/policies-standalone";
 import { registerProviderActionRoutes } from "./routes/provider-actions";
 import { registerProviderApprovalRoutes } from "./routes/provider-approvals";
 import { providerAuthorityRoutes } from "./routes/provider-authority";
+import { registerProviderXConnectRoutes } from "./routes/provider-x-connect";
 import { secretsRoutes } from "./routes/secrets";
 import { tenantConfigRoutes } from "./routes/tenant-config";
 import { tenantRoutes } from "./routes/tenants";
@@ -248,6 +249,10 @@ export function mountCoreIdempotencyAndRoutes(
   app.route("/v1/adapters", adapterRoutes);
   app.route("/v1/users", fiatRoutes);
   app.route("/policies", policiesStandaloneRoutes);
+  // provider-account X OAuth connect (#195 workstream A). Registered CONCRETELY
+  // and BEFORE the `/v2` authority sub-app so the specific connect paths win
+  // over the authority `/provider-accounts/:id/...` wildcards.
+  registerProviderXConnectRoutes(app);
   app.route("/v2", providerAuthorityRoutes);
   // provider-actions registers its concrete `/v2/provider-actions` handler + auth
   // middleware directly on the app (see registerProviderActionRoutes) to avoid a

--- a/packages/api/src/routes/provider-x-connect.ts
+++ b/packages/api/src/routes/provider-x-connect.ts
@@ -244,6 +244,7 @@ const handleRefresh = async (c: RouteContext): Promise<Response> => {
     const config = resolveXConnectConfig();
     const result = await refreshXProviderCredential({
       tenantId: c.get("tenantId"),
+      workspaceId,
       accountId,
       vault: getVault(),
       config,

--- a/packages/api/src/routes/provider-x-connect.ts
+++ b/packages/api/src/routes/provider-x-connect.ts
@@ -1,0 +1,286 @@
+/**
+ * Provider-account X (Twitter) OAuth connect routes (issue #195 workstream A).
+ *
+ * Mounted under `/v2/provider-accounts/connect/x`. Every route requires a human
+ * session (session-jwt) AND workspace admin/approver authority (or tenant
+ * authority admin) for the target workspace. These are the PROVIDER-CONNECTION
+ * routes (agent execution authority), distinct from user login-with-X.
+ *
+ *   POST   /v2/provider-accounts/connect/x/initiate     -> authorize URL + token
+ *   POST   /v2/provider-accounts/connect/x/callback     -> exchange + store
+ *   POST   /v2/provider-accounts/connect/x/:id/refresh  -> rotate access token
+ *   POST   /v2/provider-accounts/connect/x/:id/disconnect
+ *
+ * The callback is a POST (not a browser GET redirect): the initiating client
+ * receives the provider redirect, then POSTs {code, state, connectToken} back to
+ * Steward with its session credentials. This keeps the connect exchange on the
+ * authenticated provider-authority plane rather than an unauthenticated browser
+ * hop, matching the repo's `/oauth/exchange` hardening for sensitive flows.
+ */
+
+import { buildBackend, ChallengeStore } from "@stwd/auth";
+import type { AppVariables } from "@stwd/shared";
+import { SecretVault } from "@stwd/vault";
+import type { Context, Hono } from "hono";
+import {
+  type ApiResponse,
+  MASTER_PASSWORD,
+  safeJsonParse,
+  setNoStoreHeaders,
+  tenantAuth,
+} from "../services/context";
+import { providerAuthorityStore } from "../services/provider-authority-store";
+import {
+  completeXConnect,
+  disconnectXProviderCredential,
+  initiateXConnect,
+  type PendingConnectStore,
+  refreshXProviderCredential,
+  resolveXConnectConfig,
+  X_CONNECT_STATE_TTL_MS,
+  XConnectError,
+} from "../services/provider-x-connect";
+
+type RouteContext = Context<{ Variables: AppVariables }>;
+
+// ── Pending-connect state store (Redis-backed in prod, memory otherwise) ──────
+// Reuses the auth challenge backend selection so connect state survives worker
+// restarts and round-robin between isolates, exactly like the user-auth OAuth
+// state. Lazily initialised so context can set env first.
+let _connectStore: PendingConnectStore | null = null;
+async function getConnectStore(): Promise<PendingConnectStore> {
+  if (_connectStore) return _connectStore;
+  const { getRedisClient } = await import("../middleware/redis.js");
+  const redisClient = getRedisClient();
+  const usePostgres = process.env.STEWARD_AUTH_STORE_BACKEND === "postgres";
+  const { backend } = await buildBackend("challenge", redisClient, usePostgres);
+  // TTL is fixed at construction; the store's set() ignores a per-call ttl.
+  const store = new ChallengeStore({ backend, ttlMs: X_CONNECT_STATE_TTL_MS });
+  _connectStore = {
+    set: (key, value) => store.set(key, value),
+    get: (key) => store.get(key),
+    consume: (key) => store.consume(key),
+  };
+  return _connectStore;
+}
+
+/** Test seam: inject an in-memory store so route tests never touch Redis. */
+export function __setProviderXConnectStoreForTests(store: PendingConnectStore | null): void {
+  _connectStore = store;
+}
+
+let _vault: SecretVault | null = null;
+function getVault(): SecretVault {
+  _vault ??= new SecretVault(MASTER_PASSWORD);
+  return _vault;
+}
+
+function fail(c: RouteContext, error: unknown): Response {
+  if (error instanceof XConnectError) {
+    return c.json<ApiResponse>({ ok: false, error: error.code }, error.httpStatus as never);
+  }
+  throw error;
+}
+
+/**
+ * Require a human session + workspace connect authority. Returns the userId, or
+ * a Response to short-circuit. Mirrors provider-authority.ts's 404 parity: an
+ * unauthorized caller gets 404 (resource not found) so authority state does not
+ * leak, matching PR3 conventions.
+ */
+async function requireConnectAuthority(
+  c: RouteContext,
+  workspaceId: string,
+): Promise<{ userId: string } | Response> {
+  const userId = c.get("userId");
+  if (c.get("authType") !== "session-jwt" || !userId) {
+    return c.json<ApiResponse>({ ok: false, error: "human session required" }, 403);
+  }
+  if (!workspaceId) {
+    return c.json<ApiResponse>({ ok: false, error: "resource not found" }, 404);
+  }
+  const authorized = await providerAuthorityStore.canConnectProviderAccounts(
+    c.get("tenantId"),
+    workspaceId,
+    userId,
+    c.get("tenantRole") ?? "",
+  );
+  if (!authorized) {
+    return c.json<ApiResponse>({ ok: false, error: "resource not found" }, 404);
+  }
+  return { userId };
+}
+
+// ── Initiate ──────────────────────────────────────────────────────────────────
+const handleInitiate = async (c: RouteContext): Promise<Response> => {
+  const body = await safeJsonParse<{
+    workspaceId?: string;
+    redirectUri?: string;
+    scopes?: string[];
+  }>(c);
+  if (!body) return c.json<ApiResponse>({ ok: false, error: "Invalid JSON body" }, 400);
+  const workspaceId = typeof body.workspaceId === "string" ? body.workspaceId : "";
+  const redirectUri = typeof body.redirectUri === "string" ? body.redirectUri.trim() : "";
+  if (!redirectUri) {
+    return c.json<ApiResponse>({ ok: false, error: "redirectUri is required" }, 400);
+  }
+
+  const gate = await requireConnectAuthority(c, workspaceId);
+  if (gate instanceof Response) return gate;
+
+  try {
+    const config = resolveXConnectConfig();
+    const store = await getConnectStore();
+    const result = await initiateXConnect({
+      tenantId: c.get("tenantId"),
+      workspaceId,
+      initiatedByUserId: gate.userId,
+      redirectUri,
+      scopes: Array.isArray(body.scopes)
+        ? body.scopes.filter((s): s is string => typeof s === "string")
+        : undefined,
+      config,
+      store,
+      requestId: c.get("requestId") ?? null,
+    });
+    return c.json({
+      ok: true,
+      data: {
+        authorizeUrl: result.authorizeUrl,
+        state: result.state,
+        connectToken: result.connectToken,
+      },
+    });
+  } catch (error) {
+    return fail(c, error);
+  }
+};
+
+// ── Callback (exchange + store) ───────────────────────────────────────────────
+const handleCallback = async (c: RouteContext): Promise<Response> => {
+  const body = await safeJsonParse<{
+    workspaceId?: string;
+    code?: string;
+    state?: string;
+    connectToken?: string;
+    redirectUri?: string;
+    error?: string;
+  }>(c);
+  if (!body) return c.json<ApiResponse>({ ok: false, error: "Invalid JSON body" }, 400);
+  if (typeof body.error === "string" && body.error.length > 0) {
+    return c.json<ApiResponse>({ ok: false, error: `X OAuth error: ${body.error}` }, 400);
+  }
+  const workspaceId = typeof body.workspaceId === "string" ? body.workspaceId : "";
+  const code = typeof body.code === "string" ? body.code : "";
+  const state = typeof body.state === "string" ? body.state : "";
+  const connectToken = typeof body.connectToken === "string" ? body.connectToken : "";
+  const redirectUri = typeof body.redirectUri === "string" ? body.redirectUri.trim() : "";
+  if (!code || !state || !connectToken || !redirectUri) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "code, state, connectToken, redirectUri are required" },
+      400,
+    );
+  }
+
+  const gate = await requireConnectAuthority(c, workspaceId);
+  if (gate instanceof Response) return gate;
+
+  try {
+    const config = resolveXConnectConfig();
+    const store = await getConnectStore();
+    const result = await completeXConnect({
+      tenantId: c.get("tenantId"),
+      workspaceId,
+      callerUserId: gate.userId,
+      code,
+      state,
+      connectToken,
+      redirectUri,
+      config,
+      store,
+      vault: getVault(),
+      requestId: c.get("requestId") ?? null,
+    });
+    return c.json({ ok: true, data: result }, result.reconnected ? 200 : 201);
+  } catch (error) {
+    return fail(c, error);
+  }
+};
+
+// ── Refresh ───────────────────────────────────────────────────────────────────
+const handleRefresh = async (c: RouteContext): Promise<Response> => {
+  const body = await safeJsonParse<{ workspaceId?: string; force?: boolean }>(c);
+  const workspaceId = typeof body?.workspaceId === "string" ? body.workspaceId : "";
+  const accountId = c.req.param("id") ?? "";
+
+  const gate = await requireConnectAuthority(c, workspaceId);
+  if (gate instanceof Response) return gate;
+
+  try {
+    const config = resolveXConnectConfig();
+    const result = await refreshXProviderCredential({
+      tenantId: c.get("tenantId"),
+      accountId,
+      vault: getVault(),
+      config,
+      actorId: gate.userId,
+      force: body?.force === true,
+      requestId: c.get("requestId") ?? null,
+    });
+    return c.json({ ok: true, data: result });
+  } catch (error) {
+    return fail(c, error);
+  }
+};
+
+// ── Disconnect ────────────────────────────────────────────────────────────────
+const handleDisconnect = async (c: RouteContext): Promise<Response> => {
+  const body = await safeJsonParse<{ workspaceId?: string }>(c);
+  const workspaceId = typeof body?.workspaceId === "string" ? body.workspaceId : "";
+  const accountId = c.req.param("id") ?? "";
+
+  const gate = await requireConnectAuthority(c, workspaceId);
+  if (gate instanceof Response) return gate;
+
+  try {
+    const config = resolveXConnectConfig();
+    const result = await disconnectXProviderCredential({
+      tenantId: c.get("tenantId"),
+      workspaceId,
+      accountId,
+      callerUserId: gate.userId,
+      vault: getVault(),
+      config,
+      requestId: c.get("requestId") ?? null,
+    });
+    return c.json({ ok: true, data: result });
+  } catch (error) {
+    return fail(c, error);
+  }
+};
+
+// ── Registration ──────────────────────────────────────────────────────────────
+// Registered CONCRETELY (like provider-actions / provider-approvals) and BEFORE
+// the `/v2` authority sub-app so the specific connect paths win over the
+// authority `/provider-accounts/:id/...` wildcards. Each path gets no-store +
+// tenantAuth middleware.
+export function registerProviderXConnectRoutes(app: Hono<{ Variables: AppVariables }>): void {
+  const base = "/v2/provider-accounts/connect/x";
+  const paths = [
+    `${base}/initiate`,
+    `${base}/callback`,
+    `${base}/:id/refresh`,
+    `${base}/:id/disconnect`,
+  ];
+  for (const p of paths) {
+    app.use(p, async (c, next) => {
+      setNoStoreHeaders(c);
+      await next();
+    });
+    app.use(p, (c, next) => tenantAuth(c, next));
+  }
+  app.post(`${base}/initiate`, handleInitiate);
+  app.post(`${base}/callback`, handleCallback);
+  app.post(`${base}/:id/refresh`, handleRefresh);
+  app.post(`${base}/:id/disconnect`, handleDisconnect);
+}

--- a/packages/api/src/routes/provider-x-connect.ts
+++ b/packages/api/src/routes/provider-x-connect.ts
@@ -40,6 +40,7 @@ import {
   X_CONNECT_STATE_TTL_MS,
   XConnectError,
 } from "../services/provider-x-connect";
+import { assertAllowedOAuthRedirectUri } from "./auth";
 
 type RouteContext = Context<{ Variables: AppVariables }>;
 
@@ -128,6 +129,18 @@ const handleInitiate = async (c: RouteContext): Promise<Response> => {
   const gate = await requireConnectAuthority(c, workspaceId);
   if (gate instanceof Response) return gate;
 
+  // The redirect_uri is where X sends the authorization code; it MUST be on the
+  // tenant allowlist so an authorized-but-hostile workspace member cannot direct
+  // the code to an attacker endpoint. Same gate as the user-auth OAuth flow.
+  try {
+    await assertAllowedOAuthRedirectUri(redirectUri, c.get("tenantId"));
+  } catch (err) {
+    return c.json<ApiResponse>(
+      { ok: false, error: err instanceof Error ? err.message : "Invalid redirect_uri" },
+      400,
+    );
+  }
+
   try {
     const config = resolveXConnectConfig();
     const store = await getConnectStore();
@@ -184,6 +197,17 @@ const handleCallback = async (c: RouteContext): Promise<Response> => {
 
   const gate = await requireConnectAuthority(c, workspaceId);
   if (gate instanceof Response) return gate;
+
+  // Re-assert the redirect_uri allowlist on callback too (defence in depth; the
+  // service also binds the state's stored redirect_uri to this value).
+  try {
+    await assertAllowedOAuthRedirectUri(redirectUri, c.get("tenantId"));
+  } catch (err) {
+    return c.json<ApiResponse>(
+      { ok: false, error: err instanceof Error ? err.message : "Invalid redirect_uri" },
+      400,
+    );
+  }
 
   try {
     const config = resolveXConnectConfig();

--- a/packages/api/src/services/provider-authority-store.ts
+++ b/packages/api/src/services/provider-authority-store.ts
@@ -255,6 +255,49 @@ export class ProviderAuthorityStore {
     return this.ensureTenantState(tenantId);
   }
 
+  /**
+   * Provider-account CONNECT authority (issue #195 workstream A): a caller may
+   * initiate/complete/disconnect an X (or other provider) OAuth connection when
+   * they are a tenant authority admin OR hold an active workspace_admin /
+   * workspace_approver binding for the target workspace (environment + temporal
+   * validity enforced). Mirrors the admin-OR-approver gate of PR3's
+   * hasWorkspaceRoleAuthority, scoped to the connect surface.
+   */
+  async canConnectProviderAccounts(
+    tenantId: string,
+    workspaceId: string,
+    userId: string,
+    tenantRole: string,
+  ): Promise<boolean> {
+    const ctx = { tenantId, actorUserId: userId, tenantRole };
+    if (await this.hasTenantAdmin(ctx)) return true;
+    if (!(await this.membership(tenantId, userId))) return false;
+    const [workspace] = await this.db()
+      .select({ environment: workspaces.environment, status: workspaces.status })
+      .from(workspaces)
+      .where(and(eq(workspaces.tenantId, tenantId), eq(workspaces.id, workspaceId)))
+      .limit(1);
+    if (!workspace || workspace.status !== "active") return false;
+    const rows = await this.db()
+      .select()
+      .from(providerRoleBindings)
+      .where(
+        and(
+          eq(providerRoleBindings.tenantId, tenantId),
+          eq(providerRoleBindings.workspaceId, workspaceId),
+          eq(providerRoleBindings.principalType, "human"),
+          eq(providerRoleBindings.principalId, userId),
+          eq(providerRoleBindings.status, "active"),
+        ),
+      );
+    const now = new Date();
+    return rows.some(
+      (row) =>
+        (row.roleKey === "workspace_admin" || row.roleKey === "workspace_approver") &&
+        activeAt(row, now, workspace.environment),
+    );
+  }
+
   async createWorkspace(
     ctx: MutationContext,
     input: { key: string; name: string; environment: ProviderEnvironment },

--- a/packages/api/src/services/provider-x-connect.ts
+++ b/packages/api/src/services/provider-x-connect.ts
@@ -707,55 +707,129 @@ export interface RefreshResult {
  * pointing at a superseded (already-rotated-away) refresh token.
  */
 export async function refreshXProviderCredential(input: RefreshInput): Promise<RefreshResult> {
-  return withTenantAuditedTransaction(input.tenantId, async (txRaw, append) => {
-    const tx = txRaw as DbExecutor;
+  // The tx returns a discriminated outcome. A `revoked` outcome COMMITS the
+  // degrade + audit, then we throw AFTER the commit so the failure signal does
+  // not roll back the very degrade it is reporting (fail closed + durable).
+  type Outcome = { kind: "ok"; result: RefreshResult } | { kind: "revoked" };
+  const outcome = await withTenantAuditedTransaction<Outcome>(
+    input.tenantId,
+    async (txRaw, append) => {
+      const tx = txRaw as DbExecutor;
 
-    // Acquire the per-account row lock first. Everything below runs under it.
-    const [account] = await tx
-      .select()
-      .from(providerAccounts)
-      .where(
-        and(
-          eq(providerAccounts.tenantId, input.tenantId),
-          eq(providerAccounts.id, input.accountId),
-        ),
-      )
-      .limit(1)
-      .for("update");
+      // Acquire the per-account row lock first. Everything below runs under it.
+      const [account] = await tx
+        .select()
+        .from(providerAccounts)
+        .where(
+          and(
+            eq(providerAccounts.tenantId, input.tenantId),
+            eq(providerAccounts.id, input.accountId),
+          ),
+        )
+        .limit(1)
+        .for("update");
 
-    if (!account) throw new XConnectError("X_ACCOUNT_NOT_FOUND", 404, "provider account not found");
-    if (account.adapterKey !== X_ADAPTER_KEY) {
-      throw new XConnectError("X_ACCOUNT_NOT_X", 400, "provider account is not an X account");
-    }
-    if (!account.credentialSecretId || account.credentialVersion == null) {
-      throw new XConnectError("X_REFRESH_TOKEN_MISSING", 409, "account has no credential");
-    }
+      if (!account)
+        throw new XConnectError("X_ACCOUNT_NOT_FOUND", 404, "provider account not found");
+      if (account.adapterKey !== X_ADAPTER_KEY) {
+        throw new XConnectError("X_ACCOUNT_NOT_X", 400, "provider account is not an X account");
+      }
+      if (!account.credentialSecretId || account.credentialVersion == null) {
+        throw new XConnectError("X_REFRESH_TOKEN_MISSING", 409, "account has no credential");
+      }
 
-    // Load the CURRENT credential under the lock.
-    const current = await loadCredential(input.vault, input.tenantId, account.credentialSecretId);
+      // Load the CURRENT credential under the lock.
+      const current = await loadCredential(
+        input.vault,
+        input.tenantId,
+        account.credentialSecretId,
+        tx,
+      );
 
-    // Single-flight fast path: a concurrent winner already rotated us to a fresh
-    // token while we waited for the lock. If not forced and the token is still
-    // valid, skip the network call entirely.
-    if (!input.force && !isNearExpiry(current.expiresAt)) {
-      return {
-        refreshed: false,
-        credentialVersion: account.credentialVersion,
-        expiresAt: current.expiresAt,
+      // Single-flight fast path: a concurrent winner already rotated us to a fresh
+      // token while we waited for the lock. If not forced and the token is still
+      // valid, skip the network call entirely.
+      if (!input.force && !isNearExpiry(current.expiresAt)) {
+        return {
+          kind: "ok",
+          result: {
+            refreshed: false,
+            credentialVersion: account.credentialVersion,
+            expiresAt: current.expiresAt,
+          },
+        };
+      }
+
+      if (!current.refreshToken) {
+        throw new XConnectError("X_REFRESH_TOKEN_MISSING", 409, "no refresh token on record");
+      }
+
+      // Spend the rotating refresh token exactly once (still holding the lock).
+      const tokenRes = await refreshUpstream(input.config, current.refreshToken);
+
+      if (tokenRes.revoked) {
+        const [degraded] = await tx
+          .update(providerAccounts)
+          .set({ status: "revoked", revision: account.revision + 1, updatedAt: new Date() })
+          .where(
+            and(
+              eq(providerAccounts.tenantId, input.tenantId),
+              eq(providerAccounts.id, account.id),
+              eq(providerAccounts.revision, account.revision),
+            ),
+          )
+          .returning();
+        await append({
+          tenantId: input.tenantId,
+          actorType: input.actorId ? "user" : "system",
+          actorId: input.actorId ?? "system",
+          action: "provider.x.refresh.revoked",
+          resourceType: "provider_account",
+          resourceId: account.id,
+          metadata: {
+            workspaceId: account.workspaceId,
+            xUserId: account.externalRef,
+            previousRevision: account.revision,
+            newRevision: degraded?.revision ?? null,
+            requestId: input.requestId ?? null,
+          },
+        });
+        // COMMIT the degrade + audit; the caller-facing failure is thrown below.
+        return { kind: "revoked" };
+      }
+
+      // Rotate the vault secret to a new version with the freshly issued tokens.
+      const obtainedAt = new Date();
+      const expiresAt =
+        typeof tokenRes.expiresIn === "number"
+          ? new Date(obtainedAt.getTime() + tokenRes.expiresIn * 1000)
+          : null;
+      const newPayload: XCredentialPayload = {
+        ...current.payload,
+        accessToken: tokenRes.accessToken,
+        // X rotates the refresh token; fall back to the prior one only if upstream
+        // omits it (should not happen with offline.access).
+        refreshToken: tokenRes.refreshToken ?? current.refreshToken,
+        scopesGranted: tokenRes.scopes ?? current.payload.scopesGranted,
+        obtainedAt: obtainedAt.toISOString(),
+        expiresAt: expiresAt ? expiresAt.toISOString() : null,
       };
-    }
+      const meta = await input.vault.rotateSecretWithinTx(
+        tx,
+        input.tenantId,
+        current.secretName,
+        JSON.stringify(newPayload),
+      );
 
-    if (!current.refreshToken) {
-      throw new XConnectError("X_REFRESH_TOKEN_MISSING", 409, "no refresh token on record");
-    }
-
-    // Spend the rotating refresh token exactly once (still holding the lock).
-    const tokenRes = await refreshUpstream(input.config, current.refreshToken);
-
-    if (tokenRes.revoked) {
-      const [degraded] = await tx
+      const [updated] = await tx
         .update(providerAccounts)
-        .set({ status: "revoked", revision: account.revision + 1, updatedAt: new Date() })
+        .set({
+          credentialSecretId: meta.id,
+          credentialVersion: meta.version,
+          status: "active",
+          revision: account.revision + 1,
+          updatedAt: new Date(),
+        })
         .where(
           and(
             eq(providerAccounts.tenantId, input.tenantId),
@@ -764,89 +838,41 @@ export async function refreshXProviderCredential(input: RefreshInput): Promise<R
           ),
         )
         .returning();
+      if (!updated) {
+        throw new XConnectError("X_REFRESH_FAILED", 409, "account revision conflict on refresh");
+      }
+
       await append({
         tenantId: input.tenantId,
         actorType: input.actorId ? "user" : "system",
         actorId: input.actorId ?? "system",
-        action: "provider.x.refresh.revoked",
+        action: "provider.x.refresh.completed",
         resourceType: "provider_account",
         resourceId: account.id,
         metadata: {
           workspaceId: account.workspaceId,
           xUserId: account.externalRef,
-          previousRevision: account.revision,
-          newRevision: degraded?.revision ?? null,
+          credentialSecretId: meta.id,
+          credentialVersion: meta.version,
           requestId: input.requestId ?? null,
         },
       });
-      throw new XConnectError("X_REFRESH_REVOKED", 409, "X refresh token revoked");
-    }
 
-    // Rotate the vault secret to a new version with the freshly issued tokens.
-    const obtainedAt = new Date();
-    const expiresAt =
-      typeof tokenRes.expiresIn === "number"
-        ? new Date(obtainedAt.getTime() + tokenRes.expiresIn * 1000)
-        : null;
-    const newPayload: XCredentialPayload = {
-      ...current.payload,
-      accessToken: tokenRes.accessToken,
-      // X rotates the refresh token; fall back to the prior one only if upstream
-      // omits it (should not happen with offline.access).
-      refreshToken: tokenRes.refreshToken ?? current.refreshToken,
-      scopesGranted: tokenRes.scopes ?? current.payload.scopesGranted,
-      obtainedAt: obtainedAt.toISOString(),
-      expiresAt: expiresAt ? expiresAt.toISOString() : null,
-    };
-    const meta = await input.vault.rotateSecret(
-      input.tenantId,
-      current.secretName,
-      JSON.stringify(newPayload),
-    );
+      return {
+        kind: "ok",
+        result: {
+          refreshed: true,
+          credentialVersion: meta.version,
+          expiresAt: newPayload.expiresAt,
+        },
+      };
+    },
+  );
 
-    const [updated] = await tx
-      .update(providerAccounts)
-      .set({
-        credentialSecretId: meta.id,
-        credentialVersion: meta.version,
-        status: "active",
-        revision: account.revision + 1,
-        updatedAt: new Date(),
-      })
-      .where(
-        and(
-          eq(providerAccounts.tenantId, input.tenantId),
-          eq(providerAccounts.id, account.id),
-          eq(providerAccounts.revision, account.revision),
-        ),
-      )
-      .returning();
-    if (!updated) {
-      throw new XConnectError("X_REFRESH_FAILED", 409, "account revision conflict on refresh");
-    }
-
-    await append({
-      tenantId: input.tenantId,
-      actorType: input.actorId ? "user" : "system",
-      actorId: input.actorId ?? "system",
-      action: "provider.x.refresh.completed",
-      resourceType: "provider_account",
-      resourceId: account.id,
-      metadata: {
-        workspaceId: account.workspaceId,
-        xUserId: account.externalRef,
-        credentialSecretId: meta.id,
-        credentialVersion: meta.version,
-        requestId: input.requestId ?? null,
-      },
-    });
-
-    return {
-      refreshed: true,
-      credentialVersion: meta.version,
-      expiresAt: newPayload.expiresAt,
-    };
-  });
+  if (outcome.kind === "revoked") {
+    throw new XConnectError("X_REFRESH_REVOKED", 409, "X refresh token revoked");
+  }
+  return outcome.result;
 }
 
 interface LoadedCredential {
@@ -860,15 +886,18 @@ async function loadCredential(
   vault: SecretVault,
   tenantId: string,
   secretId: string,
+  executor?: DbExecutor,
 ): Promise<LoadedCredential> {
-  const db = getDb();
+  const db = (executor ?? getDb()) as DbExecutor;
   const [row] = (await db
     .select()
     .from(secrets)
     .where(and(eq(secrets.tenantId, tenantId), eq(secrets.id, secretId)))
     .limit(1)) as Secret[];
   if (!row) throw new XConnectError("X_REFRESH_TOKEN_MISSING", 409, "credential secret missing");
-  const decrypted = await vault.decryptSecret(tenantId, secretId);
+  // Decrypt from the ALREADY-READ row so we do not issue a second getDb() read
+  // that would block behind an outer transaction on single-connection PGLite.
+  const decrypted = vault.decryptSecretRow(tenantId, row);
   const payload = JSON.parse(decrypted) as XCredentialPayload;
   return {
     secretName: row.name,
@@ -977,7 +1006,12 @@ export async function disconnectXProviderCredential(
     let revokedAtUpstream = false;
     if (account.credentialSecretId) {
       try {
-        const cred = await loadCredential(input.vault, input.tenantId, account.credentialSecretId);
+        const cred = await loadCredential(
+          input.vault,
+          input.tenantId,
+          account.credentialSecretId,
+          tx,
+        );
         revokedAtUpstream = await revokeUpstreamBestEffort(
           input.config,
           cred.payload.accessToken,

--- a/packages/api/src/services/provider-x-connect.ts
+++ b/packages/api/src/services/provider-x-connect.ts
@@ -206,7 +206,27 @@ function sha256Hex(value: string): string {
 }
 
 function base64url(buf: Buffer): string {
-  return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  // The bun-types Buffer encoding union is narrower than Node's; encode base64url
+  // via btoa over a binary string to stay within the allowed surface (matches
+  // packages/auth oauth.ts uint8ArrayToBase64url).
+  const binary = Array.from(buf, (byte) => String.fromCharCode(byte)).join("");
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function base64ToUtf8(b64: string): string {
+  // Decode a base64url string to utf8 without relying on Buffer's base64url
+  // encoding (unavailable in the bun-types union).
+  const normalized = b64.replace(/-/g, "+").replace(/_/g, "/");
+  const binary = atob(normalized);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return new TextDecoder().decode(bytes);
+}
+
+function utf8ToBase64(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  const binary = Array.from(bytes, (byte) => String.fromCharCode(byte)).join("");
+  return btoa(binary);
 }
 
 /** RFC 7636 §4.1: high-entropy verifier (43-128 unreserved chars). */
@@ -346,7 +366,7 @@ export interface ParsedConnectToken {
 
 export function parseConnectToken(token: string): ParsedConnectToken | null {
   try {
-    const json = Buffer.from(token, "base64url").toString("utf8");
+    const json = base64ToUtf8(token);
     const parsed = JSON.parse(json) as ParsedConnectToken;
     if (typeof parsed.state !== "string" || typeof parsed.verifier !== "string") {
       return null;
@@ -535,7 +555,7 @@ async function exchangeAuthorizationCode(input: ExchangeInput): Promise<XTokenRe
 /** X token endpoint accepts confidential-client creds via HTTP Basic. */
 function basicAuthHeader(config: XConnectConfig): string {
   const raw = `${config.clientId}:${config.clientSecret}`;
-  return `Basic ${Buffer.from(raw, "utf8").toString("base64")}`;
+  return `Basic ${utf8ToBase64(raw)}`;
 }
 
 // ── Persist / reconnect ───────────────────────────────────────────────────────
@@ -581,7 +601,7 @@ async function persistConnectedAccount(input: PersistInput): Promise<CompleteCon
           eq(providerAccounts.tenantId, input.tenantId),
           eq(providerAccounts.workspaceId, input.workspaceId),
           eq(providerAccounts.adapterKey, X_ADAPTER_KEY),
-          eq(providerAccounts.third-partyRef, input.identity.id),
+          eq(providerAccounts.externalRef, input.identity.id),
         ),
       )
       .limit(1)
@@ -626,7 +646,7 @@ async function persistConnectedAccount(input: PersistInput): Promise<CompleteCon
           tenantId: input.tenantId,
           workspaceId: input.workspaceId,
           adapterKey: X_ADAPTER_KEY,
-          third-partyRef: input.identity.id,
+          externalRef: input.identity.id,
           displayName,
           status: "active",
           credentialSecretId: meta.id,
@@ -767,7 +787,7 @@ export async function refreshXProviderCredential(input: RefreshInput): Promise<R
         resourceId: account.id,
         metadata: {
           workspaceId: account.workspaceId,
-          xUserId: account.third-partyRef,
+          xUserId: account.externalRef,
           previousRevision: account.revision,
           newRevision: degraded?.revision ?? null,
           requestId: input.requestId ?? null,
@@ -828,7 +848,7 @@ export async function refreshXProviderCredential(input: RefreshInput): Promise<R
       resourceId: account.id,
       metadata: {
         workspaceId: account.workspaceId,
-        xUserId: account.third-partyRef,
+        xUserId: account.externalRef,
         credentialSecretId: meta.id,
         credentialVersion: meta.version,
         requestId: input.requestId ?? null,
@@ -1011,7 +1031,7 @@ export async function disconnectXProviderCredential(
       resourceId: account.id,
       metadata: {
         workspaceId: input.workspaceId,
-        xUserId: account.third-partyRef,
+        xUserId: account.externalRef,
         revokedAtUpstream,
         previousRevision: account.revision,
         newRevision: degraded.revision,

--- a/packages/api/src/services/provider-x-connect.ts
+++ b/packages/api/src/services/provider-x-connect.ts
@@ -185,9 +185,7 @@ export interface XConnectConfig {
  * user-auth `TWITTER_CLIENT_ID` / `TWITTER_CLIENT_SECRET` (login plane). See
  * .env.example for the separation rationale.
  */
-export function resolveXConnectConfig(
-  env: NodeJS.ProcessEnv = process.env,
-): XConnectConfig {
+export function resolveXConnectConfig(env: NodeJS.ProcessEnv = process.env): XConnectConfig {
   const clientId = env.X_CLIENT_ID?.trim();
   const clientSecret = env.X_CLIENT_SECRET?.trim();
   if (!clientId || !clientSecret) {
@@ -317,11 +315,7 @@ export async function initiateXConnect(
     createdAt: new Date().toISOString(),
   };
 
-  await input.store.set(
-    stateStoreKey(state),
-    JSON.stringify(record),
-    X_CONNECT_STATE_TTL_MS,
-  );
+  await input.store.set(stateStoreKey(state), JSON.stringify(record), X_CONNECT_STATE_TTL_MS);
 
   const params = new URLSearchParams({
     response_type: "code",
@@ -333,9 +327,7 @@ export async function initiateXConnect(
     code_challenge_method: "S256",
   });
 
-  const connectToken = base64url(
-    Buffer.from(JSON.stringify({ state, verifier }), "utf8"),
-  );
+  const connectToken = base64url(Buffer.from(JSON.stringify({ state, verifier }), "utf8"));
 
   return {
     authorizeUrl: `${X_AUTHORIZE_URL}?${params.toString()}`,
@@ -607,9 +599,7 @@ async function persistConnectedAccount(input: PersistInput): Promise<CompleteCon
       .limit(1)
       .for("update");
 
-    const displayName = input.identity.username
-      ? `@${input.identity.username}`
-      : input.identity.id;
+    const displayName = input.identity.username ? `@${input.identity.username}` : input.identity.id;
 
     let providerAccountId: string;
     let reconnected: boolean;
@@ -742,11 +732,7 @@ export async function refreshXProviderCredential(input: RefreshInput): Promise<R
     }
 
     // Load the CURRENT credential under the lock.
-    const current = await loadCredential(
-      input.vault,
-      input.tenantId,
-      account.credentialSecretId,
-    );
+    const current = await loadCredential(input.vault, input.tenantId, account.credentialSecretId);
 
     // Single-flight fast path: a concurrent winner already rotated us to a fresh
     // token while we waited for the lock. If not forced and the token is still
@@ -991,11 +977,7 @@ export async function disconnectXProviderCredential(
     let revokedAtUpstream = false;
     if (account.credentialSecretId) {
       try {
-        const cred = await loadCredential(
-          input.vault,
-          input.tenantId,
-          account.credentialSecretId,
-        );
+        const cred = await loadCredential(input.vault, input.tenantId, account.credentialSecretId);
         revokedAtUpstream = await revokeUpstreamBestEffort(
           input.config,
           cred.payload.accessToken,

--- a/packages/api/src/services/provider-x-connect.ts
+++ b/packages/api/src/services/provider-x-connect.ts
@@ -1,0 +1,1054 @@
+/**
+ * Provider-account X (Twitter) OAuth connect + token lifecycle (issue #195
+ * workstream A).
+ *
+ * This is the PROVIDER-CONNECTION plane (agent execution authority), NOT the
+ * user sign-in plane. Login-with-X (packages/auth oauth.ts `twitter` provider)
+ * authenticates a human; this module connects an X account a workspace's agents
+ * can act as, holding the rotating OAuth tokens in the versioned vault so the
+ * agent never sees a raw credential.
+ *
+ * Security posture (mirrors the hardened user-auth OAuth flow):
+ *   - PKCE S256, minimal explicit scopes.
+ *   - Pending-connect state lives in a short-TTL, single-use store. We persist
+ *     ONLY the SHA-256 hash of the state token and the SHA-256 hash of the PKCE
+ *     verifier, so a store compromise cannot replay a connect or forge the code
+ *     exchange. The raw state travels only in the browser round-trip; the raw
+ *     verifier is re-derived from a sealed payload the caller carries back.
+ *   - State is consumed exactly once, only after the upstream token exchange and
+ *     identity fetch succeed, so a bad provider code cannot burn a live attempt.
+ *   - Tokens land as a NEW versioned vault secret; provider_accounts links the
+ *     current {credential_secret_id, credential_version}. Reconnect for the same
+ *     X user id updates the version + bumps revision, never duplicates the row.
+ *   - Refresh is serialized per account (SELECT ... FOR UPDATE on the account
+ *     row inside the tenant-audited transaction) because X refresh tokens are
+ *     SINGLE-USE ROTATING: two concurrent refreshes must never both spend the
+ *     same refresh token. On upstream `invalid_grant` the account is degraded
+ *     and audited, failing closed.
+ *   - Every X network call goes through an injectable seam (__-prefixed test
+ *     setter) so tests never touch the network.
+ *
+ * All lifecycle events are written on the tenant audit chain via
+ * withTenantAuditedTransaction / appendRequiredAudit.
+ */
+
+import { createHash, randomBytes } from "node:crypto";
+import {
+  and,
+  eq,
+  getDb,
+  providerAccounts,
+  type Secret,
+  secrets,
+  sql,
+  withTenantAuditedTransaction,
+} from "@stwd/db";
+import type { SecretVault } from "@stwd/vault";
+
+type DbBase = ReturnType<typeof getDb>;
+type DbExecutor = DbBase | Parameters<Parameters<DbBase["transaction"]>[0]>[0];
+
+// ── X (Twitter) OAuth 2.0 endpoints ──────────────────────────────────────────
+// Provider-connect endpoints. Kept SEPARATE from the user-auth `twitter`
+// provider config (packages/auth oauth.ts) on purpose: different plane, different
+// client credentials (X_CLIENT_ID / X_CLIENT_SECRET vs TWITTER_CLIENT_ID).
+export const X_AUTHORIZE_URL = "https://x.com/i/oauth2/authorize";
+export const X_TOKEN_URL = "https://api.x.com/2/oauth2/token";
+export const X_REVOKE_URL = "https://api.x.com/2/oauth2/revoke";
+export const X_USERINFO_URL = "https://api.x.com/2/users/me?user.fields=id,name,username";
+
+export const X_ADAPTER_KEY = "x";
+
+/** Minimal default scopes. `offline.access` is REQUIRED to receive a refresh token. */
+export const X_DEFAULT_SCOPES = [
+  "tweet.read",
+  "tweet.write",
+  "users.read",
+  "offline.access",
+] as const;
+
+/** Access tokens live ~2h; refresh a little early to avoid mid-flight expiry. */
+export const X_REFRESH_SKEW_MS = 5 * 60 * 1000;
+
+/** Pending-connect state TTL — long enough for a human to authorize, short
+ *  enough to bound replay exposure. */
+export const X_CONNECT_STATE_TTL_MS = 10 * 60 * 1000;
+
+// ── Errors ────────────────────────────────────────────────────────────────────
+export type XConnectErrorCode =
+  | "X_CONFIG_MISSING"
+  | "X_STATE_INVALID"
+  | "X_STATE_EXPIRED"
+  | "X_STATE_REUSED"
+  | "X_PKCE_MISMATCH"
+  | "X_TOKEN_EXCHANGE_FAILED"
+  | "X_IDENTITY_FAILED"
+  | "X_ACCOUNT_NOT_FOUND"
+  | "X_ACCOUNT_NOT_X"
+  | "X_REFRESH_TOKEN_MISSING"
+  | "X_REFRESH_REVOKED"
+  | "X_REFRESH_FAILED";
+
+export class XConnectError extends Error {
+  constructor(
+    readonly code: XConnectErrorCode,
+    readonly httpStatus: number,
+    message?: string,
+  ) {
+    super(message ?? code);
+    this.name = "XConnectError";
+  }
+}
+
+// ── Stored token payload (the vault secret value) ─────────────────────────────
+export interface XCredentialPayload {
+  schemaVersion: "steward.provider-x.credential.v1";
+  accessToken: string;
+  refreshToken: string | null;
+  scopesGranted: string[];
+  xUserId: string;
+  xUsername: string;
+  obtainedAt: string; // ISO
+  expiresAt: string | null; // ISO
+}
+
+// ── Network seam (injectable for tests) ───────────────────────────────────────
+export interface XTokenResponse {
+  access_token: string;
+  refresh_token?: string;
+  scope?: string;
+  token_type?: string;
+  expires_in?: number;
+  // Upstream error envelope (non-2xx bodies)
+  error?: string;
+  error_description?: string;
+}
+
+export interface XUserResponse {
+  data?: { id: string; name?: string; username?: string };
+}
+
+export interface XForwardRequest {
+  url: string;
+  method: "GET" | "POST";
+  headers: Record<string, string>;
+  body?: string;
+}
+
+export interface XForwardResponse {
+  status: number;
+  ok: boolean;
+  json: unknown;
+  text: string;
+}
+
+export type XForwardFn = (req: XForwardRequest) => Promise<XForwardResponse>;
+
+async function defaultForward(req: XForwardRequest): Promise<XForwardResponse> {
+  const res = await fetch(req.url, {
+    method: req.method,
+    headers: req.headers,
+    body: req.body,
+  });
+  const text = await res.text();
+  let json: unknown = null;
+  try {
+    json = text.length > 0 ? JSON.parse(text) : null;
+  } catch {
+    json = null;
+  }
+  return { status: res.status, ok: res.ok, json, text };
+}
+
+let forwardImpl: XForwardFn = defaultForward;
+
+/**
+ * Test-only seam setter. Mirrors the repo's `__setForwardProxyRequestForTests`
+ * naming convention. Never called from production paths. Returns a restore fn.
+ */
+export function __setXForwardForTests(fn: XForwardFn | null): () => void {
+  const previous = forwardImpl;
+  forwardImpl = fn ?? defaultForward;
+  return () => {
+    forwardImpl = previous;
+  };
+}
+
+// ── Config ────────────────────────────────────────────────────────────────────
+export interface XConnectConfig {
+  clientId: string;
+  clientSecret: string;
+}
+
+/**
+ * Resolve provider-connect X credentials from env. These are DISTINCT from the
+ * user-auth `TWITTER_CLIENT_ID` / `TWITTER_CLIENT_SECRET` (login plane). See
+ * .env.example for the separation rationale.
+ */
+export function resolveXConnectConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): XConnectConfig {
+  const clientId = env.X_CLIENT_ID?.trim();
+  const clientSecret = env.X_CLIENT_SECRET?.trim();
+  if (!clientId || !clientSecret) {
+    throw new XConnectError(
+      "X_CONFIG_MISSING",
+      503,
+      "X_CLIENT_ID and X_CLIENT_SECRET are required for provider-account X connect",
+    );
+  }
+  return { clientId, clientSecret };
+}
+
+// ── Hash + PKCE helpers ───────────────────────────────────────────────────────
+function sha256Hex(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function base64url(buf: Buffer): string {
+  return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/** RFC 7636 §4.1: high-entropy verifier (43-128 unreserved chars). */
+export function generateCodeVerifier(): string {
+  return randomBytes(48).toString("hex");
+}
+
+/** RFC 7636 §4.2: BASE64URL(SHA256(ASCII(verifier))). */
+export function deriveCodeChallenge(verifier: string): string {
+  return base64url(createHash("sha256").update(verifier).digest());
+}
+
+export function generateStateToken(): string {
+  return randomBytes(32).toString("hex");
+}
+
+// ── Pending-connect state store contract ──────────────────────────────────────
+// The route layer supplies a store instance (Redis-backed in prod, memory in
+// tests) so this service stays free of process-wide singletons. We store the
+// SHA-256 hash of the state as the KEY and, in the VALUE, the SHA-256 hash of
+// the PKCE verifier plus the non-secret connect context. The raw verifier is
+// NEVER persisted; on callback the caller re-supplies it (sealed in the state
+// round-trip) and we verify hash(rawVerifier) === storedVerifierHash before
+// spending it.
+export interface PendingConnectStore {
+  /** Store value under a hashed key. Overwrites are not expected (fresh state). */
+  set(key: string, value: string, ttlMs: number): Promise<void>;
+  /** Read without consuming. */
+  get(key: string): Promise<string | null>;
+  /** Read + atomically delete (single-use). Returns the stored value or null. */
+  consume(key: string): Promise<string | null>;
+}
+
+export interface PendingConnectRecord {
+  schemaVersion: "steward.provider-x.pending-connect.v1";
+  tenantId: string;
+  workspaceId: string;
+  initiatedByUserId: string;
+  verifierHash: string;
+  scopes: string[];
+  redirectUri: string;
+  createdAt: string;
+}
+
+// ── Initiate ──────────────────────────────────────────────────────────────────
+export interface InitiateConnectInput {
+  tenantId: string;
+  workspaceId: string;
+  initiatedByUserId: string;
+  redirectUri: string;
+  scopes?: string[];
+  config: XConnectConfig;
+  store: PendingConnectStore;
+  requestId?: string | null;
+}
+
+export interface InitiateConnectResult {
+  authorizeUrl: string;
+  state: string;
+  /** Sealed verifier the caller must carry back to the callback. Opaque token. */
+  connectToken: string;
+}
+
+/**
+ * Build the X authorize URL, persist hashed pending-connect state, and return
+ * the raw state + a `connectToken` that carries the raw PKCE verifier back to
+ * the callback. The connectToken is base64url(JSON{state, verifier}); it is only
+ * ever handed to the initiating client and echoed back, mirroring how the user-
+ * auth flow keeps the verifier server-adjacent. The STORE only ever holds the
+ * hash of both values.
+ */
+export async function initiateXConnect(
+  input: InitiateConnectInput,
+): Promise<InitiateConnectResult> {
+  const scopes = normalizeScopes(input.scopes);
+  const verifier = generateCodeVerifier();
+  const challenge = deriveCodeChallenge(verifier);
+  const state = generateStateToken();
+
+  const record: PendingConnectRecord = {
+    schemaVersion: "steward.provider-x.pending-connect.v1",
+    tenantId: input.tenantId,
+    workspaceId: input.workspaceId,
+    initiatedByUserId: input.initiatedByUserId,
+    verifierHash: sha256Hex(verifier),
+    scopes,
+    redirectUri: input.redirectUri,
+    createdAt: new Date().toISOString(),
+  };
+
+  await input.store.set(
+    stateStoreKey(state),
+    JSON.stringify(record),
+    X_CONNECT_STATE_TTL_MS,
+  );
+
+  const params = new URLSearchParams({
+    response_type: "code",
+    client_id: input.config.clientId,
+    redirect_uri: input.redirectUri,
+    scope: scopes.join(" "),
+    state,
+    code_challenge: challenge,
+    code_challenge_method: "S256",
+  });
+
+  const connectToken = base64url(
+    Buffer.from(JSON.stringify({ state, verifier }), "utf8"),
+  );
+
+  return {
+    authorizeUrl: `${X_AUTHORIZE_URL}?${params.toString()}`,
+    state,
+    connectToken,
+  };
+}
+
+function normalizeScopes(scopes?: string[]): string[] {
+  const allowed = new Set<string>(X_DEFAULT_SCOPES);
+  if (!scopes || scopes.length === 0) return [...X_DEFAULT_SCOPES];
+  const filtered = scopes.filter((s) => allowed.has(s));
+  // offline.access is required to obtain a refresh token; always include it.
+  if (!filtered.includes("offline.access")) filtered.push("offline.access");
+  // users.read is required to identify the connected account (external_ref).
+  if (!filtered.includes("users.read")) filtered.push("users.read");
+  return [...new Set(filtered)];
+}
+
+function stateStoreKey(state: string): string {
+  return `provider-x-connect:${sha256Hex(state)}`;
+}
+
+export interface ParsedConnectToken {
+  state: string;
+  verifier: string;
+}
+
+export function parseConnectToken(token: string): ParsedConnectToken | null {
+  try {
+    const json = Buffer.from(token, "base64url").toString("utf8");
+    const parsed = JSON.parse(json) as ParsedConnectToken;
+    if (typeof parsed.state !== "string" || typeof parsed.verifier !== "string") {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+// ── Callback (code exchange + token storage) ──────────────────────────────────
+export interface CompleteConnectInput {
+  tenantId: string;
+  workspaceId: string;
+  callerUserId: string;
+  code: string;
+  state: string;
+  connectToken: string;
+  redirectUri: string;
+  config: XConnectConfig;
+  store: PendingConnectStore;
+  vault: SecretVault;
+  requestId?: string | null;
+}
+
+export interface CompleteConnectResult {
+  providerAccountId: string;
+  xUserId: string;
+  xUsername: string;
+  scopesGranted: string[];
+  credentialVersion: number;
+  reconnected: boolean;
+}
+
+export async function completeXConnect(
+  input: CompleteConnectInput,
+): Promise<CompleteConnectResult> {
+  // 1. Load pending state WITHOUT consuming — a bad provider code must not burn
+  //    a live attempt's one-time state.
+  const key = stateStoreKey(input.state);
+  const raw = await input.store.get(key);
+  if (!raw) throw new XConnectError("X_STATE_INVALID", 401, "unknown or expired connect state");
+
+  let record: PendingConnectRecord;
+  try {
+    record = JSON.parse(raw) as PendingConnectRecord;
+  } catch {
+    throw new XConnectError("X_STATE_INVALID", 400, "malformed connect state");
+  }
+
+  // Bind the state to THIS tenant/workspace/caller — a state minted for another
+  // workspace cannot be replayed here.
+  if (
+    record.tenantId !== input.tenantId ||
+    record.workspaceId !== input.workspaceId ||
+    record.initiatedByUserId !== input.callerUserId
+  ) {
+    throw new XConnectError("X_STATE_INVALID", 401, "connect state scope mismatch");
+  }
+  if (record.redirectUri !== input.redirectUri) {
+    throw new XConnectError("X_STATE_INVALID", 400, "redirect_uri mismatch");
+  }
+
+  // 2. Verify the PKCE verifier carried in the connectToken matches the hash we
+  //    stored at initiate. Prevents a stolen state (without the verifier) from
+  //    completing the exchange.
+  const parsedToken = parseConnectToken(input.connectToken);
+  if (!parsedToken || parsedToken.state !== input.state) {
+    throw new XConnectError("X_PKCE_MISMATCH", 400, "connect token mismatch");
+  }
+  if (sha256Hex(parsedToken.verifier) !== record.verifierHash) {
+    throw new XConnectError("X_PKCE_MISMATCH", 400, "PKCE verifier mismatch");
+  }
+
+  // 3. Exchange the code (PKCE). Failure here does NOT consume the state.
+  const tokenRes = await exchangeAuthorizationCode({
+    config: input.config,
+    code: input.code,
+    redirectUri: input.redirectUri,
+    verifier: parsedToken.verifier,
+  });
+
+  // 4. Identify the connected account.
+  const identity = await fetchXIdentity(tokenRes.access_token);
+
+  // 5. Consume the state EXACTLY ONCE, only after upstream success. A concurrent
+  //    duplicate callback loses the race and gets X_STATE_REUSED.
+  const consumed = await input.store.consume(key);
+  if (consumed !== raw) {
+    throw new XConnectError("X_STATE_REUSED", 401, "connect state already used");
+  }
+
+  const scopesGranted = tokenRes.scope
+    ? tokenRes.scope.split(/\s+/).filter(Boolean)
+    : record.scopes;
+  const obtainedAt = new Date();
+  const expiresAt =
+    typeof tokenRes.expires_in === "number"
+      ? new Date(obtainedAt.getTime() + tokenRes.expires_in * 1000)
+      : null;
+
+  const payload: XCredentialPayload = {
+    schemaVersion: "steward.provider-x.credential.v1",
+    accessToken: tokenRes.access_token,
+    refreshToken: tokenRes.refresh_token ?? null,
+    scopesGranted,
+    xUserId: identity.id,
+    xUsername: identity.username,
+    obtainedAt: obtainedAt.toISOString(),
+    expiresAt: expiresAt ? expiresAt.toISOString() : null,
+  };
+
+  // 6. Persist tokens as a versioned vault secret + create/update the account,
+  //    all inside one tenant-audited transaction so the audit event commits with
+  //    the state mutation.
+  return persistConnectedAccount({
+    tenantId: input.tenantId,
+    workspaceId: input.workspaceId,
+    callerUserId: input.callerUserId,
+    vault: input.vault,
+    identity,
+    payload,
+    scopesGranted,
+    requestId: input.requestId ?? null,
+  });
+}
+
+interface XIdentity {
+  id: string;
+  username: string;
+  name: string;
+}
+
+async function fetchXIdentity(accessToken: string): Promise<XIdentity> {
+  const res = await forwardImpl({
+    url: X_USERINFO_URL,
+    method: "GET",
+    headers: { Authorization: `Bearer ${accessToken}`, Accept: "application/json" },
+  });
+  if (!res.ok) {
+    throw new XConnectError("X_IDENTITY_FAILED", 502, `X identity fetch failed (${res.status})`);
+  }
+  const data = (res.json as XUserResponse | null)?.data;
+  if (!data || !data.id) {
+    throw new XConnectError("X_IDENTITY_FAILED", 502, "X identity response missing user id");
+  }
+  return { id: data.id, username: data.username ?? "", name: data.name ?? "" };
+}
+
+interface ExchangeInput {
+  config: XConnectConfig;
+  code: string;
+  redirectUri: string;
+  verifier: string;
+}
+
+async function exchangeAuthorizationCode(input: ExchangeInput): Promise<XTokenResponse> {
+  const body = new URLSearchParams({
+    grant_type: "authorization_code",
+    code: input.code,
+    redirect_uri: input.redirectUri,
+    client_id: input.config.clientId,
+    code_verifier: input.verifier,
+  });
+  const res = await forwardImpl({
+    url: X_TOKEN_URL,
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Accept: "application/json",
+      Authorization: basicAuthHeader(input.config),
+    },
+    body: body.toString(),
+  });
+  const parsed = res.json as XTokenResponse | null;
+  if (!res.ok || !parsed || typeof parsed.access_token !== "string") {
+    throw new XConnectError(
+      "X_TOKEN_EXCHANGE_FAILED",
+      502,
+      `X token exchange failed (${res.status})`,
+    );
+  }
+  return parsed;
+}
+
+/** X token endpoint accepts confidential-client creds via HTTP Basic. */
+function basicAuthHeader(config: XConnectConfig): string {
+  const raw = `${config.clientId}:${config.clientSecret}`;
+  return `Basic ${Buffer.from(raw, "utf8").toString("base64")}`;
+}
+
+// ── Persist / reconnect ───────────────────────────────────────────────────────
+interface PersistInput {
+  tenantId: string;
+  workspaceId: string;
+  callerUserId: string;
+  vault: SecretVault;
+  identity: XIdentity;
+  payload: XCredentialPayload;
+  scopesGranted: string[];
+  requestId: string | null;
+}
+
+/** Deterministic per-account secret name so reconnect targets the same lineage. */
+export function xCredentialSecretName(workspaceId: string, xUserId: string): string {
+  return `provider-x/${workspaceId}/${xUserId}`;
+}
+
+async function persistConnectedAccount(input: PersistInput): Promise<CompleteConnectResult> {
+  // Write the credential secret OUTSIDE the audited tx (the vault owns its own
+  // encryption + version row); then link + audit atomically. createSecret always
+  // writes version 1; a reconnect uses rotateSecret to bump the version so the
+  // lineage (secret name) is stable and the OLD ciphertext is soft-deleted.
+  const secretName = xCredentialSecretName(input.workspaceId, input.identity.id);
+  const serialized = JSON.stringify(input.payload);
+
+  const existing = await input.vault.getSecret(input.tenantId, secretName);
+  const meta = existing
+    ? await input.vault.rotateSecret(input.tenantId, secretName, serialized)
+    : await input.vault.createSecret(input.tenantId, secretName, serialized, {
+        description: "X (Twitter) provider-account OAuth credential",
+      });
+
+  return withTenantAuditedTransaction(input.tenantId, async (txRaw, append) => {
+    const tx = txRaw as DbExecutor;
+
+    const [account] = await tx
+      .select()
+      .from(providerAccounts)
+      .where(
+        and(
+          eq(providerAccounts.tenantId, input.tenantId),
+          eq(providerAccounts.workspaceId, input.workspaceId),
+          eq(providerAccounts.adapterKey, X_ADAPTER_KEY),
+          eq(providerAccounts.third-partyRef, input.identity.id),
+        ),
+      )
+      .limit(1)
+      .for("update");
+
+    const displayName = input.identity.username
+      ? `@${input.identity.username}`
+      : input.identity.id;
+
+    let providerAccountId: string;
+    let reconnected: boolean;
+
+    if (account) {
+      reconnected = true;
+      providerAccountId = account.id;
+      const [updated] = await tx
+        .update(providerAccounts)
+        .set({
+          displayName,
+          status: "active",
+          credentialSecretId: meta.id,
+          credentialVersion: meta.version,
+          revision: account.revision + 1,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(providerAccounts.tenantId, input.tenantId),
+            eq(providerAccounts.id, account.id),
+            eq(providerAccounts.revision, account.revision),
+          ),
+        )
+        .returning();
+      if (!updated) {
+        throw new XConnectError("X_REFRESH_FAILED", 409, "account revision conflict on reconnect");
+      }
+    } else {
+      reconnected = false;
+      const [created] = await tx
+        .insert(providerAccounts)
+        .values({
+          tenantId: input.tenantId,
+          workspaceId: input.workspaceId,
+          adapterKey: X_ADAPTER_KEY,
+          third-partyRef: input.identity.id,
+          displayName,
+          status: "active",
+          credentialSecretId: meta.id,
+          credentialVersion: meta.version,
+        })
+        .returning();
+      providerAccountId = created.id;
+    }
+
+    await append({
+      tenantId: input.tenantId,
+      actorType: "user",
+      actorId: input.callerUserId,
+      action: reconnected ? "provider.x.connect.reconnected" : "provider.x.connect.completed",
+      resourceType: "provider_account",
+      resourceId: providerAccountId,
+      metadata: {
+        workspaceId: input.workspaceId,
+        adapterKey: X_ADAPTER_KEY,
+        xUserId: input.identity.id,
+        xUsername: input.identity.username,
+        scopesGranted: input.scopesGranted,
+        credentialSecretId: meta.id,
+        credentialVersion: meta.version,
+        requestId: input.requestId,
+      },
+    });
+
+    return {
+      providerAccountId,
+      xUserId: input.identity.id,
+      xUsername: input.identity.username,
+      scopesGranted: input.scopesGranted,
+      credentialVersion: meta.version,
+      reconnected,
+    };
+  });
+}
+
+// ── Refresh (single-flight, rotating token) ───────────────────────────────────
+export interface RefreshInput {
+  tenantId: string;
+  accountId: string;
+  vault: SecretVault;
+  config: XConnectConfig;
+  actorId?: string;
+  requestId?: string | null;
+  /** Force refresh even if the current access token is not near expiry. */
+  force?: boolean;
+}
+
+export interface RefreshResult {
+  refreshed: boolean;
+  credentialVersion: number;
+  expiresAt: string | null;
+}
+
+/**
+ * Refresh a connected X account's access token. SINGLE-FLIGHT per account: the
+ * SELECT ... FOR UPDATE on the provider_accounts row inside the tenant-audited
+ * transaction serializes concurrent callers, so the rotating refresh token is
+ * spent exactly once. A loser blocks until the winner commits, then observes the
+ * already-rotated credential version and returns without a second token call.
+ *
+ * On upstream `invalid_grant` (revoked) the account is degraded + audited and we
+ * throw X_REFRESH_REVOKED (fail closed). The vault write happens INSIDE the
+ * critical section so a crash after the network call cannot leave the DB
+ * pointing at a superseded (already-rotated-away) refresh token.
+ */
+export async function refreshXProviderCredential(input: RefreshInput): Promise<RefreshResult> {
+  return withTenantAuditedTransaction(input.tenantId, async (txRaw, append) => {
+    const tx = txRaw as DbExecutor;
+
+    // Acquire the per-account row lock first. Everything below runs under it.
+    const [account] = await tx
+      .select()
+      .from(providerAccounts)
+      .where(
+        and(
+          eq(providerAccounts.tenantId, input.tenantId),
+          eq(providerAccounts.id, input.accountId),
+        ),
+      )
+      .limit(1)
+      .for("update");
+
+    if (!account) throw new XConnectError("X_ACCOUNT_NOT_FOUND", 404, "provider account not found");
+    if (account.adapterKey !== X_ADAPTER_KEY) {
+      throw new XConnectError("X_ACCOUNT_NOT_X", 400, "provider account is not an X account");
+    }
+    if (!account.credentialSecretId || account.credentialVersion == null) {
+      throw new XConnectError("X_REFRESH_TOKEN_MISSING", 409, "account has no credential");
+    }
+
+    // Load the CURRENT credential under the lock.
+    const current = await loadCredential(
+      input.vault,
+      input.tenantId,
+      account.credentialSecretId,
+    );
+
+    // Single-flight fast path: a concurrent winner already rotated us to a fresh
+    // token while we waited for the lock. If not forced and the token is still
+    // valid, skip the network call entirely.
+    if (!input.force && !isNearExpiry(current.expiresAt)) {
+      return {
+        refreshed: false,
+        credentialVersion: account.credentialVersion,
+        expiresAt: current.expiresAt,
+      };
+    }
+
+    if (!current.refreshToken) {
+      throw new XConnectError("X_REFRESH_TOKEN_MISSING", 409, "no refresh token on record");
+    }
+
+    // Spend the rotating refresh token exactly once (still holding the lock).
+    const tokenRes = await refreshUpstream(input.config, current.refreshToken);
+
+    if (tokenRes.revoked) {
+      const [degraded] = await tx
+        .update(providerAccounts)
+        .set({ status: "revoked", revision: account.revision + 1, updatedAt: new Date() })
+        .where(
+          and(
+            eq(providerAccounts.tenantId, input.tenantId),
+            eq(providerAccounts.id, account.id),
+            eq(providerAccounts.revision, account.revision),
+          ),
+        )
+        .returning();
+      await append({
+        tenantId: input.tenantId,
+        actorType: input.actorId ? "user" : "system",
+        actorId: input.actorId ?? "system",
+        action: "provider.x.refresh.revoked",
+        resourceType: "provider_account",
+        resourceId: account.id,
+        metadata: {
+          workspaceId: account.workspaceId,
+          xUserId: account.third-partyRef,
+          previousRevision: account.revision,
+          newRevision: degraded?.revision ?? null,
+          requestId: input.requestId ?? null,
+        },
+      });
+      throw new XConnectError("X_REFRESH_REVOKED", 409, "X refresh token revoked");
+    }
+
+    // Rotate the vault secret to a new version with the freshly issued tokens.
+    const obtainedAt = new Date();
+    const expiresAt =
+      typeof tokenRes.expiresIn === "number"
+        ? new Date(obtainedAt.getTime() + tokenRes.expiresIn * 1000)
+        : null;
+    const newPayload: XCredentialPayload = {
+      ...current.payload,
+      accessToken: tokenRes.accessToken,
+      // X rotates the refresh token; fall back to the prior one only if upstream
+      // omits it (should not happen with offline.access).
+      refreshToken: tokenRes.refreshToken ?? current.refreshToken,
+      scopesGranted: tokenRes.scopes ?? current.payload.scopesGranted,
+      obtainedAt: obtainedAt.toISOString(),
+      expiresAt: expiresAt ? expiresAt.toISOString() : null,
+    };
+    const meta = await input.vault.rotateSecret(
+      input.tenantId,
+      current.secretName,
+      JSON.stringify(newPayload),
+    );
+
+    const [updated] = await tx
+      .update(providerAccounts)
+      .set({
+        credentialSecretId: meta.id,
+        credentialVersion: meta.version,
+        status: "active",
+        revision: account.revision + 1,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(providerAccounts.tenantId, input.tenantId),
+          eq(providerAccounts.id, account.id),
+          eq(providerAccounts.revision, account.revision),
+        ),
+      )
+      .returning();
+    if (!updated) {
+      throw new XConnectError("X_REFRESH_FAILED", 409, "account revision conflict on refresh");
+    }
+
+    await append({
+      tenantId: input.tenantId,
+      actorType: input.actorId ? "user" : "system",
+      actorId: input.actorId ?? "system",
+      action: "provider.x.refresh.completed",
+      resourceType: "provider_account",
+      resourceId: account.id,
+      metadata: {
+        workspaceId: account.workspaceId,
+        xUserId: account.third-partyRef,
+        credentialSecretId: meta.id,
+        credentialVersion: meta.version,
+        requestId: input.requestId ?? null,
+      },
+    });
+
+    return {
+      refreshed: true,
+      credentialVersion: meta.version,
+      expiresAt: newPayload.expiresAt,
+    };
+  });
+}
+
+interface LoadedCredential {
+  secretName: string;
+  payload: XCredentialPayload;
+  refreshToken: string | null;
+  expiresAt: string | null;
+}
+
+async function loadCredential(
+  vault: SecretVault,
+  tenantId: string,
+  secretId: string,
+): Promise<LoadedCredential> {
+  const db = getDb();
+  const [row] = (await db
+    .select()
+    .from(secrets)
+    .where(and(eq(secrets.tenantId, tenantId), eq(secrets.id, secretId)))
+    .limit(1)) as Secret[];
+  if (!row) throw new XConnectError("X_REFRESH_TOKEN_MISSING", 409, "credential secret missing");
+  const decrypted = await vault.decryptSecret(tenantId, secretId);
+  const payload = JSON.parse(decrypted) as XCredentialPayload;
+  return {
+    secretName: row.name,
+    payload,
+    refreshToken: payload.refreshToken,
+    expiresAt: payload.expiresAt,
+  };
+}
+
+function isNearExpiry(expiresAtIso: string | null): boolean {
+  if (!expiresAtIso) return true;
+  const expiresAt = new Date(expiresAtIso).getTime();
+  return Number.isNaN(expiresAt) || expiresAt - Date.now() <= X_REFRESH_SKEW_MS;
+}
+
+interface RefreshUpstreamResult {
+  revoked: boolean;
+  accessToken: string;
+  refreshToken?: string;
+  scopes?: string[];
+  expiresIn?: number;
+}
+
+async function refreshUpstream(
+  config: XConnectConfig,
+  refreshToken: string,
+): Promise<RefreshUpstreamResult> {
+  const body = new URLSearchParams({
+    grant_type: "refresh_token",
+    refresh_token: refreshToken,
+    client_id: config.clientId,
+  });
+  const res = await forwardImpl({
+    url: X_TOKEN_URL,
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Accept: "application/json",
+      Authorization: basicAuthHeader(config),
+    },
+    body: body.toString(),
+  });
+  const parsed = res.json as XTokenResponse | null;
+  if (!res.ok) {
+    // invalid_grant => the refresh token was revoked or already rotated away.
+    if (parsed?.error === "invalid_grant") {
+      return { revoked: true, accessToken: "" };
+    }
+    throw new XConnectError("X_REFRESH_FAILED", 502, `X refresh failed (${res.status})`);
+  }
+  if (!parsed || typeof parsed.access_token !== "string") {
+    throw new XConnectError("X_REFRESH_FAILED", 502, "X refresh response missing access_token");
+  }
+  return {
+    revoked: false,
+    accessToken: parsed.access_token,
+    refreshToken: parsed.refresh_token,
+    scopes: parsed.scope ? parsed.scope.split(/\s+/).filter(Boolean) : undefined,
+    expiresIn: parsed.expires_in,
+  };
+}
+
+// ── Disconnect ────────────────────────────────────────────────────────────────
+export interface DisconnectInput {
+  tenantId: string;
+  workspaceId: string;
+  accountId: string;
+  callerUserId: string;
+  vault: SecretVault;
+  config: XConnectConfig;
+  requestId?: string | null;
+}
+
+export interface DisconnectResult {
+  providerAccountId: string;
+  revoked: boolean;
+}
+
+/**
+ * Disconnect a connected X account: best-effort revoke at X, degrade the account
+ * (status revoked), bump revision, audit. Revocation failure at X does NOT block
+ * the local degrade — we fail CLOSED locally regardless.
+ */
+export async function disconnectXProviderCredential(
+  input: DisconnectInput,
+): Promise<DisconnectResult> {
+  return withTenantAuditedTransaction(input.tenantId, async (txRaw, append) => {
+    const tx = txRaw as DbExecutor;
+    const [account] = await tx
+      .select()
+      .from(providerAccounts)
+      .where(
+        and(
+          eq(providerAccounts.tenantId, input.tenantId),
+          eq(providerAccounts.workspaceId, input.workspaceId),
+          eq(providerAccounts.id, input.accountId),
+        ),
+      )
+      .limit(1)
+      .for("update");
+    if (!account) throw new XConnectError("X_ACCOUNT_NOT_FOUND", 404, "provider account not found");
+    if (account.adapterKey !== X_ADAPTER_KEY) {
+      throw new XConnectError("X_ACCOUNT_NOT_X", 400, "provider account is not an X account");
+    }
+
+    let revokedAtUpstream = false;
+    if (account.credentialSecretId) {
+      try {
+        const cred = await loadCredential(
+          input.vault,
+          input.tenantId,
+          account.credentialSecretId,
+        );
+        revokedAtUpstream = await revokeUpstreamBestEffort(
+          input.config,
+          cred.payload.accessToken,
+          cred.refreshToken,
+        );
+      } catch {
+        // Best-effort only. Local degrade proceeds regardless.
+        revokedAtUpstream = false;
+      }
+    }
+
+    const [degraded] = await tx
+      .update(providerAccounts)
+      .set({ status: "revoked", revision: account.revision + 1, updatedAt: new Date() })
+      .where(
+        and(
+          eq(providerAccounts.tenantId, input.tenantId),
+          eq(providerAccounts.id, account.id),
+          eq(providerAccounts.revision, account.revision),
+        ),
+      )
+      .returning();
+    if (!degraded) {
+      throw new XConnectError("X_REFRESH_FAILED", 409, "account revision conflict on disconnect");
+    }
+
+    await append({
+      tenantId: input.tenantId,
+      actorType: "user",
+      actorId: input.callerUserId,
+      action: "provider.x.disconnect.completed",
+      resourceType: "provider_account",
+      resourceId: account.id,
+      metadata: {
+        workspaceId: input.workspaceId,
+        xUserId: account.third-partyRef,
+        revokedAtUpstream,
+        previousRevision: account.revision,
+        newRevision: degraded.revision,
+        requestId: input.requestId ?? null,
+      },
+    });
+
+    return { providerAccountId: account.id, revoked: revokedAtUpstream };
+  });
+}
+
+async function revokeUpstreamBestEffort(
+  config: XConnectConfig,
+  accessToken: string,
+  refreshToken: string | null,
+): Promise<boolean> {
+  // Revoke the refresh token when present (invalidates the whole grant); else
+  // revoke the access token.
+  const token = refreshToken ?? accessToken;
+  const tokenTypeHint = refreshToken ? "refresh_token" : "access_token";
+  const body = new URLSearchParams({
+    token,
+    token_type_hint: tokenTypeHint,
+    client_id: config.clientId,
+  });
+  const res = await forwardImpl({
+    url: X_REVOKE_URL,
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Accept: "application/json",
+      Authorization: basicAuthHeader(config),
+    },
+    body: body.toString(),
+  });
+  return res.ok;
+}
+
+// re-export sql for callers/tests that need raw predicates
+export { sql };

--- a/packages/api/src/services/provider-x-connect.ts
+++ b/packages/api/src/services/provider-x-connect.ts
@@ -679,6 +679,13 @@ async function persistConnectedAccount(input: PersistInput): Promise<CompleteCon
 // ── Refresh (single-flight, rotating token) ───────────────────────────────────
 export interface RefreshInput {
   tenantId: string;
+  /**
+   * The workspace the CALLER was authorized for. The account MUST belong to it,
+   * or refresh fails closed with X_ACCOUNT_NOT_FOUND. Prevents a cross-workspace
+   * IDOR where a user authorized for workspace A passes an account id from
+   * workspace B.
+   */
+  workspaceId: string;
   accountId: string;
   vault: SecretVault;
   config: XConnectConfig;
@@ -731,8 +738,25 @@ export async function refreshXProviderCredential(input: RefreshInput): Promise<R
 
       if (!account)
         throw new XConnectError("X_ACCOUNT_NOT_FOUND", 404, "provider account not found");
+      // Cross-workspace IDOR guard: the account MUST belong to the workspace the
+      // caller was authorized for. 404 (not 403) so account existence in another
+      // workspace does not leak.
+      if (account.workspaceId !== input.workspaceId) {
+        throw new XConnectError("X_ACCOUNT_NOT_FOUND", 404, "provider account not found");
+      }
       if (account.adapterKey !== X_ADAPTER_KEY) {
         throw new XConnectError("X_ACCOUNT_NOT_X", 400, "provider account is not an X account");
+      }
+      // Do NOT resurrect a locally revoked/disconnected account via refresh. A
+      // revoked account requires a fresh OAuth connect to become active again;
+      // silently reactivating it (especially after a best-effort upstream revoke
+      // failed) would restore an account the operator intended to kill.
+      if (account.status !== "active") {
+        throw new XConnectError(
+          "X_REFRESH_REVOKED",
+          409,
+          "provider account is not active; reconnect required",
+        );
       }
       if (!account.credentialSecretId || account.credentialVersion == null) {
         throw new XConnectError("X_REFRESH_TOKEN_MISSING", 409, "account has no credential");

--- a/packages/vault/src/secret-vault.ts
+++ b/packages/vault/src/secret-vault.ts
@@ -41,6 +41,14 @@ export interface CreateSecretOptions {
   expiresAt?: Date;
 }
 
+/**
+ * A drizzle executor (the top-level db OR an open transaction) accepted by the
+ * *WithinTx helpers so a caller can rotate a secret inside its OWN transaction
+ * without a nested `db.transaction` (which deadlocks single-connection PGLite).
+ */
+type SecretTxExecutor = DbBase | Parameters<Parameters<DbBase["transaction"]>[0]>[0];
+type DbBase = ReturnType<typeof getDb>;
+
 export class SecretVault {
   private keyStore: KeyStore;
   // Legacy root (no domain label) — secrets encrypted before domain separation
@@ -131,19 +139,25 @@ export class SecretVault {
     if (!row) {
       throw new Error(`Secret ${secretId} not found for tenant ${tenantId}`);
     }
+    return this.decryptSecretRow(tenantId, row);
+  }
 
-    // Check expiration
+  /**
+   * Decrypt a secret row already read from the DB (e.g. inside a caller's
+   * transaction, so no fresh `getDb()` read is issued that would block on a
+   * single-connection PGLite while an outer transaction holds the connection).
+   * NEVER expose the plaintext via API.
+   */
+  decryptSecretRow(tenantId: string, row: Secret): string {
     if (row.expiresAt && row.expiresAt < new Date()) {
-      throw new Error(`Secret ${secretId} has expired`);
+      throw new Error(`Secret ${row.id} has expired`);
     }
-
     const encrypted: EncryptedKey = {
       ciphertext: row.ciphertext,
       iv: row.iv,
       tag: row.authTag,
       salt: row.salt,
     };
-
     const context = { tenantId, name: row.name, version: row.version };
     try {
       return this.keyStore.decrypt(encrypted, context);
@@ -152,6 +166,63 @@ export class SecretVault {
       // legacy (shared) root. New secrets always use the domain-separated root above.
       return this.legacyKeyStore.decrypt(encrypted, context);
     }
+  }
+
+  /**
+   * Rotate a secret WITHIN a caller-provided transaction. Identical to
+   * {@link rotateSecret} but reuses the caller's `tx` instead of opening its own
+   * `db.transaction`, so it can run inside an outer transaction (e.g. a per-
+   * account refresh that holds a SELECT ... FOR UPDATE lock) without a nested
+   * transaction. The single-flight/atomicity guarantee is the CALLER's outer
+   * transaction; this method only appends the new version + repoints routes +
+   * soft-deletes the prior version.
+   */
+  async rotateSecretWithinTx(
+    tx: SecretTxExecutor,
+    tenantId: string,
+    name: string,
+    newValue: string,
+  ): Promise<SecretMetadata> {
+    const [current] = await tx
+      .select()
+      .from(secrets)
+      .where(and(eq(secrets.tenantId, tenantId), eq(secrets.name, name), isNull(secrets.deletedAt)))
+      .orderBy(desc(secrets.version))
+      .limit(1);
+    if (!current) {
+      throw new Error(`Secret "${name}" not found for tenant ${tenantId}`);
+    }
+    const newVersion = current.version + 1;
+    const encrypted = this.keyStore.encrypt(newValue, { tenantId, name, version: newVersion });
+    const now = new Date();
+
+    const [row] = await tx
+      .insert(secrets)
+      .values({
+        tenantId,
+        name,
+        description: current.description,
+        ciphertext: encrypted.ciphertext,
+        iv: encrypted.iv,
+        authTag: encrypted.tag,
+        salt: encrypted.salt,
+        version: newVersion,
+        rotatedAt: now,
+        expiresAt: current.expiresAt,
+      })
+      .returning();
+
+    await tx
+      .update(secretRoutes)
+      .set({ secretId: row.id })
+      .where(and(eq(secretRoutes.tenantId, tenantId), eq(secretRoutes.secretId, current.id)));
+
+    await tx
+      .update(secrets)
+      .set({ deletedAt: now, updatedAt: now })
+      .where(and(eq(secrets.id, current.id), eq(secrets.tenantId, tenantId)));
+
+    return this.toMetadata(row);
   }
 
   /**


### PR DESCRIPTION
## Scope: issue #195 Workstream A — X (Twitter) provider-account OAuth connect + token lifecycle

The api/auth side of governing X as a provider: a workspace connects an X account via OAuth 2.0 (auth-code + PKCE S256), tokens land in the versioned vault, and the account lifecycle (connect / refresh / disconnect) is fully audited. This is the **provider-connection plane** (agent execution authority), deliberately SEPARATE from login-with-X (user sign-in). Does NOT build the `@stwd/provider-x` adapter (workstream B) or touch proxy/execution-authorization (in-flight PR4).

### Scope map
- **Service** `packages/api/src/services/provider-x-connect.ts`
  - `initiateXConnect` — builds the X authorize URL, persists hashed single-use pending-connect state, returns state + a `connectToken` carrying the raw PKCE verifier back to the client. The store only ever holds `sha256(state)` -> `{ sha256(verifier), scopes, redirectUri, tenant/workspace/user binding }`.
  - `completeXConnect` — loads state (no consume), binds it to tenant/workspace/caller/redirect_uri, verifies `sha256(verifier)` against the stored hash, exchanges the code, fetches identity, then consumes state EXACTLY once (only after upstream success), then stores tokens + creates/updates the `provider_accounts` row. Idempotent reconnect for the same X user id bumps the credential version + account revision, never duplicates.
  - `refreshXProviderCredential` — per-account single-flight refresh (`SELECT ... FOR UPDATE` on the account row inside the tenant-audited transaction). On `invalid_grant` (revoked) the account is degraded + audited, then fails closed. Vault rotation runs UNDER the row lock via `rotateSecretWithinTx` (no nested transaction).
  - `disconnectXProviderCredential` — best-effort revoke at X, degrade account, bump revision, audit. Local degrade proceeds even if the upstream revoke fails.
  - X network calls go through an injectable `__setXForwardForTests` seam. No real network in tests.
- **Routes** `packages/api/src/routes/provider-x-connect.ts` — `POST /v2/provider-accounts/connect/x/{initiate, callback, :id/refresh, :id/disconnect}`. Session-jwt + workspace admin/approver authority (`canConnectProviderAccounts`, mirrors PR3 `hasWorkspaceRoleAuthority`), 404 parity. redirect_uri gated through the existing tenant OAuth allowlist. Registered concretely before the `/v2` authority sub-app to avoid wildcard collision.
- **Vault** `packages/vault/src/secret-vault.ts` — `rotateSecretWithinTx` + `decryptSecretRow` so the refresh single-flight can rotate the credential under the account row lock without a nested transaction.
- **Store** `provider-authority-store.ts` — `canConnectProviderAccounts` (tenant-admin OR active workspace_admin/workspace_approver).
- **Env** `.env.example` — `X_CLIENT_ID` / `X_CLIENT_SECRET`, documented as SEPARATE from the `TWITTER_*` login credentials.

### Security notes
- **Rotating refresh, single-flight**: X refresh tokens are single-use rotating. The per-account row lock + a post-lock near-expiry re-check collapse concurrent refreshes to exactly one token-endpoint call; the loser observes the freshly rotated token and short-circuits. Mutation-proven.
- **Hashed, single-use, short-TTL state**: store holds only hashes of state + PKCE verifier; state is consumed exactly once and only after upstream success (a bad provider code cannot burn a live attempt).
- **Vault-versioned tokens**: credential stored as a versioned secret; `provider_accounts.credential_secret_id/credential_version` link the current version; reconnect + refresh bump the version.
- **Redirect allowlist**: `redirect_uri` (where X delivers the code) gated on initiate AND callback so an authorized-but-hostile member cannot redirect the code.
- **Cross-workspace IDOR guard** (codex P1): refresh verifies the account belongs to the caller's authorized workspace (404 otherwise).
- **No revoked-account resurrection** (codex P1): refresh fails closed unless the account is active; a disconnected account requires a fresh connect.
- **Fail-closed audit on revoke**: the degrade + audit commit, then the caller-facing failure is thrown (the failure signal does not roll back its own degrade).

### Tests + mutation receipts
23 tests (`packages/api/src/__tests__/provider-x-connect.test.ts`), all X network faked via the seam:
- authority gate (admin / approver / viewer-denied / non-member-denied)
- connect happy path + idempotent reconnect (version + revision bump, no dup)
- state: mismatch, expired, reused, PKCE verifier mismatch, scope/caller mismatch, token-exchange-does-not-consume-state (retryable)
- refresh: force rotate, **single-flight (exactly one token call)**, fresh-token short-circuit, **revoked -> degraded**, non-X rejected, **cross-workspace IDOR rejected**, **no revoked resurrection**
- disconnect: degrade + best-effort revoke + audit, missing account

**Mutation receipts** (weaken guard -> named test fails -> restore): single-flight post-lock re-check; PKCE verifier hash check; revoke->degraded status write; cross-workspace workspace guard; revoked-account status guard.

Biome clean, `packages/api` + `packages/vault` typecheck clean (`tsc --noEmit`). Adversarial review by codex (gpt-5.5) against origin/develop surfaced the two P1s above; both fixed + regression-tested in this PR.

### Honest gaps
- Route-level HTTP integration tests (full Hono stack) are not added; routes are thin delegators over the service (covered directly) + `assertAllowedOAuthRedirectUri` (already tested in `auth-oauth-redirect-allowlist.test.ts`). Service + guards are exhaustively unit-tested.
- No DB migration added (per instructions; 0082 owned by PR4). Uses the existing `provider_accounts` + `secrets` tables and the Redis-backed challenge store for pending state.
- `governed_v2` proxy wiring / secret_routes registration is workstream C (out of scope here); this branch works on the develop tip it branches from and should rebase when PR4 lands.

[sol-orch]
