### PR TITLE
feat(provider-x): governed wiring + E2E scaffolding (#195 workstream C)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -58,6 +58,7 @@
         "@stwd/plugin-trading": "workspace:*",
         "@stwd/policy-engine": "workspace:*",
         "@stwd/provider-github": "workspace:*",
+        "@stwd/provider-x": "workspace:*",
         "@stwd/redis": "workspace:*",
         "@stwd/shared": "workspace:*",
         "@stwd/vault": "workspace:*",

--- a/docs/provider-x/WORKSTREAM-C-NOTES.md
+++ b/docs/provider-x/WORKSTREAM-C-NOTES.md
@@ -1,0 +1,92 @@
+# Workstream C working notes (#195) — governed wiring + E2E proof for X
+
+Scratch notes for the implementer. Not shipped copy; kept in-tree so the design
+decisions are reviewable alongside the code. The polished runbook lives in
+`RUNBOOK-real-x-proof.md`.
+
+## Two planes (confirmed by reading the github wiring end to end)
+
+1. **Provider-action authority pipeline** (`packages/api`): propose
+   (`POST /v2/provider-actions`) -> access -> policy
+   (`composeProviderActionPolicyDecision`) -> approval arm (`provider-approval.ts`
+   `buildApprovalArm`) -> human decide/resume (`provider-approvals.ts` +
+   `ProviderApprovalService`) -> in-process **stub** executor
+   (`executeProviderActionStub`). This is the LEGACY (pre-PR4) execution path on
+   `develop`. It NEVER decrypts a credential or hits the wire. It records the
+   binding, the commitment, and the audit chain.
+
+2. **Proxy credential-route injection** (`packages/proxy`): the actual Bearer
+   injection happens here via `secret_routes` (created with
+   `SecretVault.createRoute`). Proven for github by
+   `packages/proxy/src/__tests__/github-credential-route.test.ts` over the
+   `__setForwardProxyRequestForTests` fake-transport seam: the proxy resolves the
+   route -> secret id -> decrypts the CURRENT version -> injects
+   `Authorization: Bearer <token>` upstream, and the agent's own JWT never leaks.
+
+X is wired through BOTH planes exactly as github is: authority pipeline for
+propose/policy/approval, proxy secret-route for the real byte-level injection.
+
+## Drift decision (secret version bump between approval and execution)
+
+**Decision: version drift STALES the action fail-closed. It does NOT silently
+use the new token.** This is already MANDATED and IMPLEMENTED by PR3 — X inherits
+it for free; I only prove it for X and cite it here.
+
+- The approval commitment (`ProviderApprovalCommitmentV1.executionDependencies`)
+  binds `{ routeId, routeRevision, secretId, secretVersion }`. `buildApprovalArm`
+  sets `secretVersion = account.credentialVersion` at propose time
+  (`provider-approval.ts`, service copy).
+- At BOTH approve and safe-resume, `revalidateDependencies` checks:
+  `account.credentialSecretId !== c.executionDependencies.secretId ||
+   account.credentialVersion !== c.executionDependencies.secretVersion`
+  -> returns `APPROVAL_CREDENTIAL_STALE` and `staleTransition(...)` moves the
+  action to `approval_stale` (intent canceled), fail-closed.
+- #197's refresh rotation bumps `provider_accounts.credential_version` (and
+  repoints the secret_route to the new secret row via
+  `rotateSecretWithinTx`). So a refresh landing between approval and execution
+  is exactly a `credential_version` bump on the account row -> surfaces as
+  `APPROVAL_CREDENTIAL_STALE`. The stale token is never used; the human must
+  re-approve against the new version.
+- This matches the task's rule verbatim: "if the commitment binds secretVersion,
+  version drift must surface as the existing drift/stale error, NOT silently use
+  the new version." No new policy invented; existing PR3 binding reused.
+
+Spec citation: PR3 approval spec §5.1 (commitment executionDependencies) + §5.2
+(dependency revalidation, credential staleness) — implemented at
+`packages/api/src/services/provider-approval.ts` `revalidateDependencies`
+(`APPROVAL_CREDENTIAL_STALE`).
+
+## Minimal-touch wiring changes
+
+- `@stwd/shared` `provider-approval.ts`: widen commitment
+  `operation.canonicalProfile` from the github literal to a string union that
+  also admits `x.provider-action.v1`. Pure type widening; JCS hashes whatever
+  string is present, so no digest behavior change for github.
+- `provider-authority-store.ts`: add `x` to `PROVIDER_OPERATION_ALLOWLIST`
+  (`x.tweet.create`=POST, `x.tweet.delete`=DELETE, `x.user.me.read`=GET; widen
+  the method union to include DELETE) + `PROVIDER_HOST_ALLOWLIST` (`x` ->
+  `api.x.com`).
+- `@stwd/vault` `secret-route-validator.ts`: add `api.x.com` to
+  `DEFAULT_SECRET_ROUTE_HOSTS` and a `STRICT_HOSTS` entry (minPathSegments 2,
+  requireExplicitMethod true, disallowPathWildcards true). All three X paths
+  (`/2/tweets`, `/2/tweets/{id}`, `/2/users/me`) have >=2 segments.
+- `proxy/config.ts`: add `x -> api.x.com` alias.
+- `provider-action-service.ts`: accept `GithubActionBuild | XActionBuild`; derive
+  the policy-context `host` from the action origin instead of hardcoding
+  `api.github.com`. `canonicalProfile` on the commitment already flows from the
+  operation profile via the approval arm change.
+- `provider-actions.ts` route: dispatch X operation keys to `buildXAction`.
+
+## NOT touched (PR4 in-flight on feat/execution-authorization-v2)
+
+- No changes to proxy governed-execution v2 files, no migration 0082/0083.
+- X rides the legacy stub authority path + the existing proxy secret-route
+  injection, exactly like github today. `governed_v2` cutover for X happens
+  with/after PR4 (noted in the PR body).
+
+## Dashboard
+
+Checked `apps/` + packages for an existing provider-accounts UI surface to
+extend. If none exists that cheaply admits an X connect button + status + scopes,
+this is filed as a follow-up in the PR rather than built here (avoids a UI
+redesign in a wiring/proof PR).

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -34,6 +34,7 @@
     "@stwd/plugin-trading": "workspace:*",
     "@stwd/policy-engine": "workspace:*",
     "@stwd/provider-github": "workspace:*",
+    "@stwd/provider-x": "workspace:*",
     "@stwd/redis": "workspace:*",
     "@stwd/shared": "workspace:*",
     "@stwd/vault": "workspace:*",

--- a/packages/api/src/__tests__/provider-x-governed-e2e.test.ts
+++ b/packages/api/src/__tests__/provider-x-governed-e2e.test.ts
@@ -1,0 +1,797 @@
+/**
+ * X governed provider-action E2E (#195 workstream C, authority plane).
+ *
+ * ── State of this suite (READ THIS) ─────────────────────────────────────────
+ * This file has THREE kinds of coverage:
+ *
+ *   1. ACTIVE full-chain-up-to-persist proof (`describe("X governed wiring …")`):
+ *      proposes a real `x.tweet.create` through the real provider-action service
+ *      against a fully-migrated PGLite. It proves the ENTIRE governed chain runs
+ *      for X — access allow, policy composing an approval_required decision on the
+ *      X profile, and the PR3 approval arm building — and that the ONLY thing that
+ *      stops it is the persist of the `provider_action_bindings` row. It then
+ *      isolates that persist failure to the EXACT database blocker
+ *      (`provider_action_bindings_profile_chk`), proving it is the migration CHECK
+ *      and not a wiring bug.
+ *
+ *   2. ACTIVE pure policy-composition unit (`describe("X policy composition …")`):
+ *      no DB. Proves the X operation's capability-intent rules compose to
+ *      `approval_required` (write) / `allow` (read) via the same
+ *      `composeProviderActionPolicyDecision` the service calls, with mutation
+ *      proof that dropping the require-approval rule flips the write path to
+ *      `allow` (i.e. the approval is genuinely load-bearing, not incidental).
+ *
+ *   3. SKIPPED full-chain E2E (`describe.skip("X governed provider-action E2E …")`):
+ *      the five end-to-end tests that require a `provider_action_bindings` row to
+ *      PERSIST with `canonical_profile = 'x.provider-action.v1'`.
+ *
+ * ── Why the five E2E tests are skipped (the blocker) ────────────────────────
+ * `packages/db/drizzle/0080_provider_action_bindings.sql` line 69:
+ *
+ *     CONSTRAINT "provider_action_bindings_profile_chk"
+ *       CHECK ("canonical_profile" = 'github.provider-action.v1')
+ *
+ * The CHECK hardcodes the github profile literal, so NO X binding
+ * (`canonical_profile = 'x.provider-action.v1'`) can be persisted yet. The
+ * provider-action service builds the correct X binding and fails closed at the
+ * INSERT (surfaced to the caller as `EVIDENCE_DECISION_PERSIST_FAILED`). This is
+ * proven precisely by the ACTIVE suite below.
+ *
+ * The migration that widens this CHECK to admit `'x.provider-action.v1'` is NOT
+ * taken in this PR: the next free migration journal slot is owned by the in-flight
+ * PR4 (feat/execution-authorization-v2, migration 0082). Taking a competing
+ * migration here would collide the journal. The follow-up is: AFTER PR4 lands,
+ * the next free slot (0083+) widens the profile CHECK, and these five tests get
+ * un-skipped in that same follow-up PR (no code change to the tests is needed —
+ * they already assert the full X chain end to end).
+ *
+ * ── What the five (skipped) tests prove once unblocked ──────────────────────
+ * The FULL X governed chain over the real provider-action service + approval
+ * state machine against PGLite, exactly as the github wiring is proven:
+ *
+ *   connect (seed X vault secret + provider_accounts row directly — we do NOT
+ *   re-test #197's OAuth dance) -> agent proposes x.tweet.create via the service
+ *   -> access allows -> policy composes to approval_required -> human approves
+ *   (binding) -> safe resume -> execution_ready, with a full audit chain.
+ *
+ * Read-path: x.user.me.read defaults to allow (no approval) and reaches the
+ * in-process stub (the legacy pre-PR4 executor; the real byte-level Bearer
+ * injection is proven separately on the proxy plane in
+ * packages/proxy/src/__tests__/x-credential-route.test.ts).
+ *
+ * Negatives (fail-closed):
+ *   - tampered canonical action bytes after approval => digest mismatch, stales.
+ *   - expired approval => APPROVAL_EXPIRED, no execution.
+ *   - credential VERSION DRIFT: a refresh bumps provider_accounts.credential_version
+ *     between approval and resume => APPROVAL_CREDENTIAL_STALE (fail-closed). The
+ *     stale token is NEVER silently used. This is the documented drift behavior;
+ *     it reuses the PR3 commitment executionDependencies.secretVersion binding
+ *     (packages/api/src/services/provider-approval.ts revalidateDependencies).
+ */
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  setDefaultTimeout,
+  test,
+} from "bun:test";
+import {
+  agents,
+  approvalQueue,
+  closeDb,
+  getDb,
+  intents,
+  providerAccounts,
+  providerActionAuditOutbox,
+  providerActionBindings,
+  providerGrants,
+  providerOperations,
+  providerRoleBindings,
+  secretRoutes,
+  secrets,
+  tenants,
+  users,
+  userTenants,
+  workspaces,
+} from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import {
+  composeProviderActionPolicyDecision,
+  PROVIDER_POLICY_REASON,
+  type ProviderPolicyContext,
+  type ProviderPolicyRule,
+} from "@stwd/policy-engine";
+import { buildXAction } from "@stwd/provider-x";
+import { X_PROVIDER_ACTION_PROFILE } from "@stwd/shared";
+import { eq } from "drizzle-orm";
+import type { ProviderPrincipalV1 } from "../middleware/provider-principal";
+import { providerActionService } from "../services/provider-action-service";
+import { providerApprovalService } from "../services/provider-approval";
+
+setDefaultTimeout(120_000);
+
+// ─── Fixture ids (X provider account) ─────────────────────────────────────────
+
+const X = {
+  TENANT: "tenant-x",
+  AGENT: "agent-x",
+  WORKSPACE: "21000000-0000-4000-8000-000000000001",
+  ACCOUNT: "31000000-0000-4000-8000-000000000001",
+  OP_TWEET: "41000000-0000-4000-8000-000000000001",
+  OP_READ: "41000000-0000-4000-8000-000000000002",
+  OP_DELETE: "41000000-0000-4000-8000-000000000003",
+  SECRET: "51000000-0000-4000-8000-000000000001",
+  ROUTE_TWEET: "61000000-0000-4000-8000-000000000001",
+  ROUTE_READ: "61000000-0000-4000-8000-000000000002",
+  ROUTE_DELETE: "61000000-0000-4000-8000-000000000003",
+  GRANTOR: "11000000-0000-4000-8000-000000000001",
+  APPROVER: "81000000-0000-4000-8000-000000000001",
+  APPROVER_BINDING: "91000000-0000-4000-8000-000000000001",
+  GRANT: "a1000000-0000-4000-8000-000000000001",
+} as const;
+
+const OP_TWEET_KEY = "x.tweet.create";
+const OP_READ_KEY = "x.user.me.read";
+const OP_DELETE_KEY = "x.tweet.delete";
+const FUTURE = new Date(Date.now() + 365 * 24 * 3600_000);
+
+function principal(agentId = X.AGENT, tenantId = X.TENANT): ProviderPrincipalV1 {
+  return {
+    type: "agent",
+    agentId,
+    tenantId,
+    platformId: null,
+    issuer: "eliza-cloud",
+    subject: `agent:${agentId}`,
+    tokenId: null,
+    scopes: [],
+    authenticatedAt: new Date().toISOString(),
+    expiresAt: null,
+    authnMethod: "agent-jwt-rs256",
+  };
+}
+
+/** allow + require-approval => approval_required (write path). */
+function approvalRules(opKey: string) {
+  return [
+    {
+      id: "11111111-1111-4111-8111-1111111111f1",
+      type: "capability-intent",
+      enabled: true,
+      config: { capabilities: [opKey], effect: "allow" },
+    },
+    {
+      id: "22222222-2222-4222-8222-2222222222f2",
+      type: "capability-intent",
+      enabled: true,
+      config: { capabilities: [opKey], effect: "require-approval" },
+    },
+  ];
+}
+
+/** allow-only => no approval (read path). */
+function allowRules(opKey: string) {
+  return [
+    {
+      id: "33333333-3333-4333-8333-3333333333f3",
+      type: "capability-intent",
+      enabled: true,
+      config: { capabilities: [opKey], effect: "allow" },
+    },
+  ];
+}
+
+async function wipe() {
+  const db = getDb();
+  await db.delete(providerActionAuditOutbox);
+  await db.delete(approvalQueue);
+  await db.delete(providerActionBindings);
+  await db.delete(intents);
+  await db.delete(providerGrants);
+  await db.delete(providerRoleBindings);
+  await db.delete(providerOperations);
+  await db.delete(providerAccounts);
+  await db.delete(secretRoutes);
+  await db.delete(secrets);
+  await db.delete(workspaces);
+  await db.delete(userTenants);
+  await db.delete(users);
+  await db.delete(tenants);
+}
+
+/**
+ * Seed an X provider account connected (as #197's connect would leave it):
+ * a versioned vault secret holding the OAuth tokens (payload contents are
+ * opaque here — we only assert version binding), a provider_accounts row with
+ * credential_secret_id/credential_version, three governed operations with their
+ * strict secret_routes, an agent grant, and a human workspace_approver.
+ */
+async function seedX() {
+  const db = getDb();
+  await db.insert(tenants).values([{ id: X.TENANT, name: "X", apiKeyHash: "hx" }]);
+  await db.insert(users).values([
+    { id: X.GRANTOR, email: "gx@t.test" },
+    { id: X.APPROVER, email: "approverx@t.test" },
+  ]);
+  await db.insert(userTenants).values([{ userId: X.APPROVER, tenantId: X.TENANT, role: "member" }]);
+  await db
+    .insert(agents)
+    .values([
+      { id: X.AGENT, tenantId: X.TENANT, name: "AX", walletAddress: "0x1", ownerUserId: null },
+    ]);
+  // Versioned vault secret (v1). The connect flow stores the serialized OAuth
+  // token payload here; the E2E cares only that credential_version binds it.
+  await db.insert(secrets).values([
+    {
+      id: X.SECRET,
+      tenantId: X.TENANT,
+      name: "x-oauth",
+      ciphertext: "x",
+      iv: "x",
+      authTag: "x",
+      salt: "x",
+      version: 1,
+    },
+  ]);
+  await db.insert(secretRoutes).values([
+    {
+      id: X.ROUTE_TWEET,
+      tenantId: X.TENANT,
+      secretId: X.SECRET,
+      hostPattern: "api.x.com",
+      pathPattern: "/2/tweets",
+      method: "POST",
+      injectAs: "header",
+      injectKey: "authorization",
+    },
+    {
+      id: X.ROUTE_READ,
+      tenantId: X.TENANT,
+      secretId: X.SECRET,
+      hostPattern: "api.x.com",
+      pathPattern: "/2/users/me",
+      method: "GET",
+      injectAs: "header",
+      injectKey: "authorization",
+    },
+    {
+      id: X.ROUTE_DELETE,
+      tenantId: X.TENANT,
+      secretId: X.SECRET,
+      hostPattern: "api.x.com",
+      pathPattern: "/2/tweets/1234567890",
+      method: "DELETE",
+      injectAs: "header",
+      injectKey: "authorization",
+    },
+  ]);
+  await db.insert(workspaces).values([
+    {
+      id: X.WORKSPACE,
+      tenantId: X.TENANT,
+      key: "x-client",
+      name: "XC",
+      environment: "production",
+      createdBy: X.GRANTOR,
+    },
+  ]);
+  await db.insert(providerAccounts).values([
+    {
+      id: X.ACCOUNT,
+      tenantId: X.TENANT,
+      workspaceId: X.WORKSPACE,
+      adapterKey: "x",
+      externalRef: "9999",
+      displayName: "@sol",
+      credentialSecretId: X.SECRET,
+      credentialVersion: 1,
+    },
+  ]);
+  await db.insert(providerOperations).values([
+    {
+      id: X.OP_TWEET,
+      tenantId: X.TENANT,
+      workspaceId: X.WORKSPACE,
+      providerAccountId: X.ACCOUNT,
+      operationKey: OP_TWEET_KEY,
+      riskClass: "write",
+      secretRouteId: X.ROUTE_TWEET,
+      requestProfile: { policyRules: approvalRules(OP_TWEET_KEY) },
+    },
+    {
+      id: X.OP_READ,
+      tenantId: X.TENANT,
+      workspaceId: X.WORKSPACE,
+      providerAccountId: X.ACCOUNT,
+      operationKey: OP_READ_KEY,
+      riskClass: "read",
+      secretRouteId: X.ROUTE_READ,
+      requestProfile: { policyRules: allowRules(OP_READ_KEY) },
+    },
+    {
+      id: X.OP_DELETE,
+      tenantId: X.TENANT,
+      workspaceId: X.WORKSPACE,
+      providerAccountId: X.ACCOUNT,
+      operationKey: OP_DELETE_KEY,
+      riskClass: "write",
+      secretRouteId: X.ROUTE_DELETE,
+      requestProfile: { policyRules: approvalRules(OP_DELETE_KEY) },
+    },
+  ]);
+  await db.insert(providerGrants).values([
+    {
+      id: X.GRANT,
+      tenantId: X.TENANT,
+      workspaceId: X.WORKSPACE,
+      providerAccountId: X.ACCOUNT,
+      agentId: X.AGENT,
+      operationKeys: [OP_TWEET_KEY, OP_READ_KEY, OP_DELETE_KEY],
+      environment: "production",
+      expiresAt: FUTURE,
+      grantedByUserId: X.GRANTOR,
+      reason: "test",
+    },
+  ]);
+  await db.insert(providerRoleBindings).values([
+    {
+      id: X.APPROVER_BINDING,
+      tenantId: X.TENANT,
+      workspaceId: X.WORKSPACE,
+      principalType: "human",
+      principalId: X.APPROVER,
+      roleKey: "workspace_approver",
+      operationKeys: [],
+      environment: "production",
+      status: "active",
+      grantedByUserId: X.GRANTOR,
+      reason: "approver",
+    },
+  ]);
+}
+
+function idemHash(seed: string): string {
+  return `sha256:${Buffer.from(seed.padEnd(32, "0")).toString("hex").slice(0, 64)}`;
+}
+
+async function propose(opKey: string, args: unknown, seed: string) {
+  const now = new Date();
+  return providerActionService.createProviderAction({
+    principal: principal(),
+    workspaceId: X.WORKSPACE,
+    providerAccountId: X.ACCOUNT,
+    operationKey: opKey,
+    build: buildXAction(opKey as never, args),
+    idempotencyKeyHash: idemHash(seed),
+    requestedAt: now.toISOString(),
+    expiresAt: new Date(now.getTime() + 300_000).toISOString(),
+    nonce: seed.padEnd(32, "N").slice(0, 32),
+    requestId: null,
+  });
+}
+
+function freshMfa(): number {
+  return Date.now() - 1000;
+}
+
+function decideInput(intentId: string, requestHash: string, actionDigest: string) {
+  return {
+    intentId,
+    tenantId: X.TENANT,
+    authenticatedUserId: X.APPROVER,
+    sessionMfaVerifiedAt: freshMfa(),
+    decision: "approve" as const,
+    expectedVersion: 1,
+    expectedRequestHash: requestHash,
+    expectedActionDigest: actionDigest,
+    reasonCode: null,
+    reason: null,
+    idempotencyKey: "x-decide-key-0001",
+  };
+}
+
+async function bindingRow(intentId: string) {
+  const [b] = await getDb()
+    .select()
+    .from(providerActionBindings)
+    .where(eq(providerActionBindings.intentId, intentId));
+  return b;
+}
+
+async function queueRow(intentId: string) {
+  const [q] = await getDb()
+    .select()
+    .from(approvalQueue)
+    .where(eq(approvalQueue.intentId, intentId));
+  return q;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ACTIVE — pure policy composition (no DB). Proves the X operation policy rules
+// genuinely compose to approval_required / allow via the SAME composer the
+// service invokes, and that the require-approval rule is load-bearing.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Minimal X-shaped policy context the composer reads (host is carried-only). */
+function xPolicyContext(
+  opKey: string,
+  overrides: Partial<ProviderPolicyContext> = {},
+): ProviderPolicyContext {
+  const build = buildXAction(
+    opKey as never,
+    opKey === OP_TWEET_KEY
+      ? { text: "gm from a governed agent" }
+      : opKey === OP_DELETE_KEY
+        ? { tweetId: "1234567890" }
+        : {},
+  );
+  return {
+    operationKey: opKey,
+    args: build.policyArgs,
+    method: build.method,
+    host: "api.x.com",
+    path: build.action.normalizedPath,
+    invokeCount1h: 0,
+    ...overrides,
+  };
+}
+
+describe("X policy composition (authority plane, no DB)", () => {
+  test("x.tweet.create: allow + require-approval composes to approval_required", () => {
+    const rules = approvalRules(OP_TWEET_KEY) as unknown as ProviderPolicyRule[];
+    const out = composeProviderActionPolicyDecision(rules, xPolicyContext(OP_TWEET_KEY));
+    expect(out.effect).toBe("approval_required");
+    expect(out.reasonCodes).toContain(PROVIDER_POLICY_REASON.APPROVAL_REQUIRED);
+  });
+
+  test("MUTATION: dropping the require-approval rule flips x.tweet.create to allow (approval is load-bearing)", () => {
+    const rules = allowRules(OP_TWEET_KEY) as unknown as ProviderPolicyRule[];
+    const out = composeProviderActionPolicyDecision(rules, xPolicyContext(OP_TWEET_KEY));
+    // With ONLY the allow rule, the composed effect is a passing allow — proving
+    // the approval_required in the write path above is produced by the
+    // require-approval rule, not incidental to the X wiring.
+    expect(out.effect).toBe("allow");
+    expect(out.reasonCodes).not.toContain(PROVIDER_POLICY_REASON.APPROVAL_REQUIRED);
+  });
+
+  test("x.user.me.read: allow-only composes to allow (no approval on the read path)", () => {
+    const rules = allowRules(OP_READ_KEY) as unknown as ProviderPolicyRule[];
+    const out = composeProviderActionPolicyDecision(rules, xPolicyContext(OP_READ_KEY));
+    expect(out.effect).toBe("allow");
+    expect(out.reasonCodes).not.toContain(PROVIDER_POLICY_REASON.APPROVAL_REQUIRED);
+  });
+
+  test("empty governing rule set fails closed (default-deny), never approval or allow", () => {
+    const out = composeProviderActionPolicyDecision([], xPolicyContext(OP_TWEET_KEY));
+    expect(out.effect).toBe("hard_deny");
+    expect(out.reasonCodes).toContain(PROVIDER_POLICY_REASON.NO_GOVERNING_ALLOW);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ACTIVE — full governed chain UP TO the constrained persist. Proves the entire
+// X governed pipeline runs against a fully-migrated PGLite, and that the ONLY
+// thing stopping it is the 0080 profile CHECK on provider_action_bindings — not a
+// wiring bug. Runs the real provider-action service (access + policy + approval
+// arm) and then isolates the persist failure to the exact DB constraint.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("X governed wiring up to the 0080 profile-CHECK blocker", () => {
+  beforeAll(async () => {
+    process.env.STEWARD_PGLITE_MEMORY = "true";
+    process.env.STEWARD_AUDIT_HMAC_KEY ||= "0".repeat(64);
+    const { db, client } = await createPGLiteDb("memory://");
+    setPGLiteOverride(db, async () => client.close());
+  });
+  afterAll(async () => {
+    await closeDb();
+    delete process.env.STEWARD_PGLITE_MEMORY;
+  });
+  beforeEach(async () => {
+    await wipe();
+    await seedX();
+  });
+
+  test("x.tweet.create runs the whole chain and fails CLOSED only at the binding persist", async () => {
+    // The whole governed pipeline runs: access allows (grant present), policy
+    // composes approval_required (write rules), and the PR3 approval arm builds
+    // — all BEFORE the provider_action_bindings insert. The insert carries
+    // canonical_profile = 'x.provider-action.v1', which violates the 0080 CHECK,
+    // so the create transaction rolls back and the service returns a fail-closed
+    // evidence failure. No partial binding, no approval queue row, no stub call.
+    const out = await propose(OP_TWEET_KEY, { text: "gm from a governed agent" }, "twcreate1");
+    expect(out.kind).toBe("evidence_failure");
+    if (out.kind !== "evidence_failure") throw new Error("unreachable");
+    expect(out.code).toBe("EVIDENCE_DECISION_PERSIST_FAILED");
+
+    // Transaction rolled back cleanly: nothing persisted for this intent.
+    const bindings = await getDb().select().from(providerActionBindings);
+    expect(bindings.length).toBe(0);
+    const queue = await getDb().select().from(approvalQueue);
+    expect(queue.length).toBe(0);
+  });
+
+  test("BLOCKER ISOLATION: the persist failure is PRECISELY the 0080 profile CHECK, not a wiring bug", async () => {
+    // Prove the exact database constraint that blocks X. Attempt the minimal
+    // provider_action_bindings insert that differs from a github binding ONLY in
+    // the profile literal, against the fully-migrated schema. The X profile is
+    // rejected by name; the github profile inserts fine. This pins the blocker to
+    // provider_action_bindings_profile_chk (0080 line 69) and nothing else.
+    const db = getDb();
+
+    // A minimal, fully-valid DENIED binding shape (access deny -> policy
+    // not_evaluated -> status denied). This satisfies every OTHER 0080 CHECK
+    // (state-machine, policy-shape, digest regexes, byte-size) with NO approval
+    // columns required, so the profile literal is the ONLY variable under test.
+    // Each attempt seeds its own intents row (the binding's intent_fk parent).
+    async function bindingValues(profile: string) {
+      const h = "sha256:" + "a".repeat(64);
+      const idem = `sha256:${crypto.randomUUID().replace(/-/g, "").padEnd(64, "0").slice(0, 64)}`;
+      const intentId = crypto.randomUUID();
+      await db.insert(intents).values({
+        id: intentId,
+        tenantId: X.TENANT,
+        agentId: X.AGENT,
+        intentType: "provider-action",
+        status: "rejected",
+      });
+      return {
+        intentId,
+        tenantId: X.TENANT,
+        workspaceId: X.WORKSPACE,
+        actorAgentId: X.AGENT,
+        providerAccountId: X.ACCOUNT,
+        operationId: X.OP_TWEET,
+        operationRevision: 1,
+        canonicalProfile: profile,
+        canonicalActionBytes: Buffer.from("{}", "utf8"),
+        actionDigest: h,
+        requestEnvelope: {} as Record<string, unknown>,
+        requestHash: idem,
+        idempotencyKeyHash: idem,
+        safeSummary: {} as Record<string, unknown>,
+        accessDecisionId: crypto.randomUUID(),
+        accessEffect: "deny" as const,
+        accessReasonCode: "ACCESS_DENIED",
+        matchedBindingIds: [] as string[],
+        matchedGrantIds: [] as string[],
+        dependencyRevisions: {} as Record<string, unknown>,
+        accessDecision: {} as Record<string, unknown>,
+        accessDecisionHash: h,
+        policyDecisionId: null,
+        policyEffect: "not_evaluated" as const,
+        policyReasonCodes: [] as string[],
+        policyResults: [] as Array<Record<string, unknown>>,
+        policyRevisionHash: null,
+        policyDecision: null,
+        policyDecisionHash: null,
+        status: "denied",
+      };
+    }
+
+    // CONTROL FIRST: the SAME row shape with the github profile literal persists
+    // cleanly. This proves the row satisfies EVERY other binding constraint
+    // (all NOT NULLs, every format/state CHECK, all FKs) — so the row is complete
+    // and valid in every dimension except the profile literal.
+    await db
+      .insert(providerActionBindings)
+      .values(await bindingValues("github.provider-action.v1"));
+    const control = await db.select().from(providerActionBindings);
+    expect(control.length).toBe(1);
+    expect(control[0]?.canonicalProfile).toBe("github.provider-action.v1");
+
+    // Now the X row: byte-identical shape, ONLY canonical_profile swapped to
+    // 'x.provider-action.v1'. Since the control proved the shape is otherwise
+    // valid, the sole thing that can reject it is the profile CHECK
+    // (provider_action_bindings_profile_chk, 0080 line 69). Assert it throws a
+    // check_violation (SQLSTATE 23514) — not a null/FK/format error, and not a
+    // wiring defect.
+    let caught: unknown;
+    try {
+      await db
+        .insert(providerActionBindings)
+        .values(await bindingValues(X_PROVIDER_ACTION_PROFILE));
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeDefined();
+    const code =
+      (caught as { code?: string })?.code ?? (caught as { cause?: { code?: string } })?.cause?.code;
+    expect(code).toBe("23514");
+    // The underlying PG error names the exact constraint: this pins the blocker
+    // to 0080's profile CHECK by NAME, not merely to "some check failed".
+    const constraintName =
+      (caught as { constraint?: string })?.constraint ??
+      (caught as { cause?: { constraint?: string } })?.cause?.constraint;
+    expect(constraintName).toBe("provider_action_bindings_profile_chk");
+
+    // And the X row did NOT persist: the table still holds only the github control.
+    const after = await db.select().from(providerActionBindings);
+    expect(after.length).toBe(1);
+    expect(after[0]?.canonicalProfile).toBe("github.provider-action.v1");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SKIPPED — full X governed E2E. Blocked by 0080 provider_action_bindings_profile_chk
+// (see the file header). Un-skip in the post-PR4 follow-up PR that widens the
+// CHECK to admit 'x.provider-action.v1'. No test change is needed at that point —
+// these assert the full chain end to end and will pass once the binding persists.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe.skip("X governed provider-action E2E (unblock after 0080 CHECK widened, post-PR4)", () => {
+  beforeAll(async () => {
+    process.env.STEWARD_PGLITE_MEMORY = "true";
+    process.env.STEWARD_AUDIT_HMAC_KEY ||= "0".repeat(64);
+    const { db, client } = await createPGLiteDb("memory://");
+    setPGLiteOverride(db, async () => client.close());
+  });
+  afterAll(async () => {
+    await closeDb();
+    delete process.env.STEWARD_PGLITE_MEMORY;
+  });
+  beforeEach(async () => {
+    await wipe();
+    await seedX();
+  });
+
+  test("x.tweet.create: propose -> policy -> approval_required -> approve -> resume", async () => {
+    const out = await propose(OP_TWEET_KEY, { text: "gm from a governed agent" }, "twcreate1");
+    expect(out.kind).toBe("approval_required");
+    if (out.kind !== "approval_required") throw new Error("unreachable");
+
+    // Binding committed the X profile + a real approval commitment.
+    const b = await bindingRow(out.intentId);
+    expect(b.status).toBe("pending_approval");
+    expect(b.canonicalProfile).toBe(X_PROVIDER_ACTION_PROFILE);
+    expect(b.approvalCommitmentHash).toMatch(/^sha256:[0-9a-f]{64}$/);
+    const q = await queueRow(out.intentId);
+    // The commitment binds the X profile + the credential VERSION (drift guard).
+    const commitment = q.approvalCommitment as {
+      operation: { canonicalProfile: string };
+      executionDependencies: { secretId: string; secretVersion: number };
+    };
+    expect(commitment.operation.canonicalProfile).toBe(X_PROVIDER_ACTION_PROFILE);
+    expect(commitment.executionDependencies.secretId).toBe(X.SECRET);
+    expect(commitment.executionDependencies.secretVersion).toBe(1);
+
+    // Human approves.
+    const dec = await providerApprovalService.decide(
+      decideInput(out.intentId, out.requestHash, out.actionDigest),
+    );
+    expect(dec.ok).toBe(true);
+    if (!dec.ok) throw new Error("unreachable");
+    expect(dec.status).toBe("approved");
+
+    // Safe resume -> execution_ready (no execution, no credential decrypt here).
+    const res = await providerApprovalService.resume({
+      intentId: out.intentId,
+      tenantId: X.TENANT,
+      caller: { agentId: X.AGENT },
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error("unreachable");
+    expect(res.status).toBe("execution_ready");
+    expect(res.resumeAttemptId).toBeTruthy();
+
+    const bFinal = await bindingRow(out.intentId);
+    expect(bFinal.status).toBe("execution_ready");
+  });
+
+  test("x.user.me.read: allow read path reaches the stub with no approval", async () => {
+    const out = await propose(OP_READ_KEY, {}, "read0001");
+    expect(out.kind).toBe("allowed");
+    if (out.kind !== "allowed") throw new Error(`got ${out.kind}`);
+    expect(out.stub.status).toBe("stub_succeeded");
+    const b = await bindingRow(out.intentId);
+    expect(b.canonicalProfile).toBe(X_PROVIDER_ACTION_PROFILE);
+    expect(b.status).toBe("stub_succeeded");
+  });
+
+  test("NEGATIVE: tampered canonical action bytes after approval => digest mismatch, stales", async () => {
+    const out = await propose(OP_TWEET_KEY, { text: "original text" }, "tamper01");
+    if (out.kind !== "approval_required") throw new Error(`got ${out.kind}`);
+    const dec = await providerApprovalService.decide(
+      decideInput(out.intentId, out.requestHash, out.actionDigest),
+    );
+    expect(dec.ok).toBe(true);
+
+    // Tamper the stored canonical action bytes AFTER approval (attacker swaps the
+    // body between approval and execution). Integrity re-hash at resume must
+    // catch it and fail closed (stale), never resume.
+    const b = await bindingRow(out.intentId);
+    const tampered = Buffer.from(
+      (b.canonicalActionBytes as Uint8Array as Buffer)
+        .toString("utf8")
+        .replace("original text", "attacker text"),
+      "utf8",
+    );
+    await getDb()
+      .update(providerActionBindings)
+      .set({ canonicalActionBytes: tampered })
+      .where(eq(providerActionBindings.intentId, out.intentId));
+
+    const res = await providerApprovalService.resume({
+      intentId: out.intentId,
+      tenantId: X.TENANT,
+      caller: { agentId: X.AGENT },
+    });
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error("unreachable");
+    expect(res.code).toBe("APPROVAL_COMMITMENT_INTEGRITY_MISMATCH");
+    const bFinal = await bindingRow(out.intentId);
+    expect(bFinal.status).toBe("approval_stale");
+  });
+
+  test("NEGATIVE: expired approval => APPROVAL_EXPIRED, no execution", async () => {
+    const out = await propose(OP_TWEET_KEY, { text: "will expire" }, "expire01");
+    if (out.kind !== "approval_required") throw new Error(`got ${out.kind}`);
+    const dec = await providerApprovalService.decide(
+      decideInput(out.intentId, out.requestHash, out.actionDigest),
+    );
+    expect(dec.ok).toBe(true);
+
+    // Force the queue row past its expiry, then resume: expiry wins fail-closed.
+    await getDb()
+      .update(approvalQueue)
+      .set({ expiresAt: new Date(Date.now() - 1000) })
+      .where(eq(approvalQueue.intentId, out.intentId));
+
+    const res = await providerApprovalService.resume({
+      intentId: out.intentId,
+      tenantId: X.TENANT,
+      caller: { agentId: X.AGENT },
+    });
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error("unreachable");
+    expect(res.code).toBe("APPROVAL_EXPIRED");
+    const bFinal = await bindingRow(out.intentId);
+    expect(bFinal.status).toBe("approval_expired");
+  });
+
+  test("NEGATIVE: credential version drift between approval and resume => APPROVAL_CREDENTIAL_STALE", async () => {
+    const out = await propose(OP_TWEET_KEY, { text: "drift me" }, "drift001");
+    if (out.kind !== "approval_required") throw new Error(`got ${out.kind}`);
+    const dec = await providerApprovalService.decide(
+      decideInput(out.intentId, out.requestHash, out.actionDigest),
+    );
+    expect(dec.ok).toBe(true);
+
+    // Simulate #197's token refresh landing BETWEEN approval and execution: a
+    // new secret version is written and provider_accounts.credential_version is
+    // bumped to point at it. The commitment bound version 1; the drift must
+    // surface as APPROVAL_CREDENTIAL_STALE and the action must NOT resume with
+    // the new (unapproved) token.
+    const db = getDb();
+    await db.insert(secrets).values([
+      {
+        id: "52000000-0000-4000-8000-000000000002",
+        tenantId: X.TENANT,
+        name: "x-oauth",
+        ciphertext: "y",
+        iv: "y",
+        authTag: "y",
+        salt: "y",
+        version: 2,
+      },
+    ]);
+    await db
+      .update(providerAccounts)
+      .set({ credentialSecretId: "52000000-0000-4000-8000-000000000002", credentialVersion: 2 })
+      .where(eq(providerAccounts.id, X.ACCOUNT));
+
+    const res = await providerApprovalService.resume({
+      intentId: out.intentId,
+      tenantId: X.TENANT,
+      caller: { agentId: X.AGENT },
+    });
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error("unreachable");
+    expect(res.code).toBe("APPROVAL_CREDENTIAL_STALE");
+    const bFinal = await bindingRow(out.intentId);
+    expect(bFinal.status).toBe("approval_stale");
+  });
+});

--- a/packages/api/src/routes/provider-actions.ts
+++ b/packages/api/src/routes/provider-actions.ts
@@ -17,6 +17,7 @@
 
 import { createHash, randomBytes } from "node:crypto";
 import { buildGithubAction, isGithubOperationKey } from "@stwd/provider-github";
+import { buildXAction, isXOperationKey } from "@stwd/provider-x";
 import { CanonError, decodeUtf8Strict, isCanonError, strictParseJson } from "@stwd/shared";
 import type { Context } from "hono";
 import { Hono } from "hono";
@@ -192,14 +193,19 @@ async function handleCreateProviderAction(c: RouteContext) {
   if (!IDEM_KEY_RE.test(idempotencyKey)) {
     return deny(c, "CANON_FIELD_TYPE_INVALID", 400);
   }
-  if (!isGithubOperationKey(operationKey)) {
-    return deny(c, "CANON_PROFILE_UNSUPPORTED", 400);
-  }
-
-  // ── Adapter: validate + canonicalize the operation arguments. ──
-  let build: ReturnType<typeof buildGithubAction>;
+  // ── Adapter dispatch: resolve the operation to its owning provider adapter
+  // and validate + canonicalize the arguments. Both adapters emit a
+  // structurally-compatible build the pipeline accepts uniformly. An operation
+  // key belonging to no registered adapter is an unsupported profile. ──
+  let build: import("../services/provider-action-service").ProviderActionBuild;
   try {
-    build = buildGithubAction(operationKey, args);
+    if (isGithubOperationKey(operationKey)) {
+      build = buildGithubAction(operationKey, args);
+    } else if (isXOperationKey(operationKey)) {
+      build = buildXAction(operationKey, args);
+    } else {
+      return deny(c, "CANON_PROFILE_UNSUPPORTED", 400);
+    }
   } catch (e) {
     if (isCanonError(e)) return deny(c, e.code, e.httpStatus);
     // Never surface an arbitrary thrown value as a 500.

--- a/packages/api/src/services/provider-action-service.ts
+++ b/packages/api/src/services/provider-action-service.ts
@@ -65,6 +65,7 @@ import {
 export type ProviderActionBuild = GithubActionBuild | XActionBuild;
 /** The structurally-shared canonical action shape both adapters emit. */
 type AnyCanonicalActionV1 = GithubCanonicalActionV1 | XCanonicalActionV1;
+
 import { and, eq, sql } from "drizzle-orm";
 import type { ProviderPrincipalV1 } from "../middleware/provider-principal";
 import { appendAuditEvent, withTenantAuditQueue, writeAuditEvent } from "./audit";

--- a/packages/api/src/services/provider-action-service.ts
+++ b/packages/api/src/services/provider-action-service.ts
@@ -45,12 +45,26 @@ import {
   type ProviderPolicyRule,
 } from "@stwd/policy-engine";
 import type { GithubActionBuild } from "@stwd/provider-github";
+import type { XActionBuild } from "@stwd/provider-x";
 import {
   type GithubCanonicalActionV1,
   jcsStringify,
   type ProviderRequestEnvelopeV1,
   sha256HexPrefixed,
+  type XCanonicalActionV1,
 } from "@stwd/shared";
+
+/**
+ * The provider-action pipeline is adapter-agnostic: it reads only the generic
+ * canonical-action fields (profile/method/origin/normalizedPath/query/headers/
+ * body), the validated `policyArgs`, and the `safeSummary`. github and X builds
+ * are structurally compatible on all of those, so the pipeline accepts either.
+ * Adding a new adapter is a matter of extending this union, never forking the
+ * pipeline.
+ */
+export type ProviderActionBuild = GithubActionBuild | XActionBuild;
+/** The structurally-shared canonical action shape both adapters emit. */
+type AnyCanonicalActionV1 = GithubCanonicalActionV1 | XCanonicalActionV1;
 import { and, eq, sql } from "drizzle-orm";
 import type { ProviderPrincipalV1 } from "../middleware/provider-principal";
 import { appendAuditEvent, withTenantAuditQueue, writeAuditEvent } from "./audit";
@@ -127,7 +141,7 @@ export interface CreateProviderActionInput {
   workspaceId: string;
   providerAccountId: string;
   operationKey: string;
-  build: GithubActionBuild;
+  build: ProviderActionBuild;
   idempotencyKeyHash: string;
   requestedAt: string;
   expiresAt: string;
@@ -501,6 +515,9 @@ class ProviderActionService {
             requesterSeparation: extractRequesterSeparation(txOperation.requestProfile),
             requestedAt: input.requestedAt,
             expiresAt: input.expiresAt,
+            // Bind the adapter profile from the validated build, never a
+            // hardcoded provider (so X actions commit x.provider-action.v1).
+            canonicalProfile: build.action.profile,
           });
           approvalQueueId = arm.queueId;
           approvalCommitmentHash = arm.commitmentHash;
@@ -892,7 +909,7 @@ class ProviderActionService {
     workspaceId: string;
     actorAgentId: string;
     operation: typeof providerOperations.$inferSelect;
-    build: GithubActionBuild;
+    build: ProviderActionBuild;
     intentId: string;
     requestHash: string;
     actionDigest: string;
@@ -915,7 +932,10 @@ class ProviderActionService {
       operationKey: operation.operationKey,
       args: build.policyArgs,
       method: build.method,
-      host: "api.github.com",
+      // Host is carried context only (the composer never gates on it); derive it
+      // from the adapter's canonical origin so X actions report api.x.com and
+      // github actions report api.github.com, never a hardcoded provider.
+      host: hostFromOrigin(build.action.origin),
       path: build.action.normalizedPath,
       // Trailing-hour count is not wired in PR2; rules that require it will
       // fail closed (POLICY_INPUT_UNAVAILABLE) exactly as specified.
@@ -1098,7 +1118,7 @@ class ProviderActionService {
   }
 
   // ── helpers ──
-  private canonicalActionObject(a: GithubCanonicalActionV1): Record<string, unknown> {
+  private canonicalActionObject(a: AnyCanonicalActionV1): Record<string, unknown> {
     return {
       profile: a.profile,
       method: a.method,
@@ -1269,6 +1289,19 @@ class ProviderActionService {
 }
 
 // ── module-scope helpers ──
+
+/**
+ * Extract the host from a canonical origin like `https://api.x.com`. The origin
+ * is already canonicalized by the adapter (scheme https, no port, no path), so a
+ * simple prefix strip is sufficient and total; a malformed origin (never emitted
+ * by the adapters) falls back to the raw value rather than throwing, since this
+ * value is non-authoritative policy context only.
+ */
+function hostFromOrigin(origin: string): string {
+  const withoutScheme = origin.replace(/^https:\/\//, "");
+  const slash = withoutScheme.indexOf("/");
+  return slash === -1 ? withoutScheme : withoutScheme.slice(0, slash);
+}
 
 function activeAtRow(
   row: {

--- a/packages/api/src/services/provider-approval.ts
+++ b/packages/api/src/services/provider-approval.ts
@@ -144,6 +144,13 @@ export async function buildApprovalArm(args: {
   requesterSeparation: boolean;
   requestedAt: string;
   expiresAt: string;
+  /**
+   * The adapter canonical profile of the action being committed (e.g.
+   * `github.provider-action.v1` or `x.provider-action.v1`). Bound into the
+   * commitment so a resume recomputes the same document; sourced from the
+   * validated action build, never hardcoded per provider.
+   */
+  canonicalProfile: ProviderApprovalCommitmentV1["operation"]["canonicalProfile"];
 }): Promise<{ queueId: string; commitmentHash: string; commitment: ProviderApprovalCommitmentV1 }> {
   const tx = args.tx;
 
@@ -179,7 +186,7 @@ export async function buildApprovalArm(args: {
       key: args.operation.operationKey,
       revision: args.operation.revision,
       riskClass: args.operation.riskClass,
-      canonicalProfile: "github.provider-action.v1",
+      canonicalProfile: args.canonicalProfile,
     },
     requestHash: args.requestHash,
     actionDigest: args.actionDigest,

--- a/packages/api/src/services/provider-authority-store.ts
+++ b/packages/api/src/services/provider-authority-store.ts
@@ -27,14 +27,22 @@ const RECENT_MFA_MS = 5 * 60_000;
 const OPERATION_KEY = /^[a-z][a-z0-9]*(?:\.[a-z][a-z0-9_]*)+$/;
 const KEY = /^[a-z][a-z0-9_-]{0,127}$/;
 const PROVIDER_OPERATION_ALLOWLIST: Readonly<
-  Record<string, Readonly<Record<string, "GET" | "POST">>>
+  Record<string, Readonly<Record<string, "GET" | "POST" | "DELETE">>>
 > = {
   github: {
     "github.issue.list": "GET",
     "github.pr.comment.create": "POST",
   },
+  x: {
+    "x.tweet.create": "POST",
+    "x.tweet.delete": "DELETE",
+    "x.user.me.read": "GET",
+  },
 };
-const PROVIDER_HOST_ALLOWLIST: Readonly<Record<string, string>> = { github: "api.github.com" };
+const PROVIDER_HOST_ALLOWLIST: Readonly<Record<string, string>> = {
+  github: "api.github.com",
+  x: "api.x.com",
+};
 const ENVIRONMENTS = new Set(["development", "staging", "production"]);
 const PRINCIPAL_TYPES = new Set(["human", "agent"]);
 const ROLES = new Set([

--- a/packages/proxy/src/__tests__/x-credential-route.test.ts
+++ b/packages/proxy/src/__tests__/x-credential-route.test.ts
@@ -1,0 +1,261 @@
+/**
+ * X narrow credential-route integration test (#195 workstream C, proxy plane).
+ *
+ * Full flow, no real network: an X OAuth access token is stored in the vault, a
+ * narrow secret_route is created for a single X API endpoint, and a proxied
+ * agent request is verified to carry the token upstream as `Authorization:
+ * Bearer <token>` while the agent's own JWT never contained it. Byte-level proof
+ * that the governed X `x.tweet.create` request reaches the wire as the exact
+ * canonical bytes (method POST, path /2/tweets, JSON body). Mirrors the github
+ * credential-route test posture exactly (same seam, same allowlist model).
+ *
+ * This proves the CURRENT-version credential resolution at execution: the proxy
+ * resolves the route -> its secret id -> decrypts the current version. The
+ * authority-plane version-DRIFT guard (a refresh between approval and execution
+ * bumping credential_version => APPROVAL_CREDENTIAL_STALE) lives in the api
+ * package and is proven in provider-x-governed-e2e.test.ts.
+ */
+
+import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
+import { signAgentToken } from "@stwd/auth";
+import { agents, closeDb, getDb, tenants } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { SecretVault } from "@stwd/vault";
+import { Hono } from "hono";
+import { PROXY_SCOPE } from "../config";
+
+setDefaultTimeout(30000);
+
+const MASTER_PASSWORD = "proxy-x-route-master";
+// A recognizable X OAuth2 access token shape; asserted never to leak back.
+const X_ACCESS_TOKEN = "x-oauth2-access-EXAMPLEtokenVALUEdeadbeef1234567890";
+
+let authMiddleware: typeof import("../middleware/auth")["authMiddleware"];
+let handleProxy: typeof import("../handlers/proxy")["handleProxy"];
+let proxyMod: typeof import("../handlers/proxy");
+
+// Captures the outbound request the proxy would have sent upstream.
+let captured: {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: string | null;
+} | null = null;
+
+beforeAll(async () => {
+  process.env.STEWARD_PGLITE_MEMORY = "true";
+  process.env.STEWARD_MASTER_PASSWORD = MASTER_PASSWORD;
+  process.env.STEWARD_JWT_SECRET = "proxy-x-route-jwt-secret-with-enough-bytes-here-ok";
+  // api.x.com ships in the default allowlists (secret-route + proxy alias) as of
+  // workstream C, so no STEWARD_*_ALLOWED_HOSTS env is needed for the happy path.
+
+  const { db, client } = await createPGLiteDb("memory://");
+  setPGLiteOverride(db, async () => {
+    await client.close();
+  });
+
+  ({ authMiddleware } = await import("../middleware/auth"));
+  proxyMod = await import("../handlers/proxy");
+  ({ handleProxy } = proxyMod);
+
+  // Pin DNS to a public address so the SSRF guard passes without a real lookup.
+  proxyMod.__setResolveProxyHostForTests(async () => [{ address: "104.244.42.65", family: 4 }]);
+  // Stub the final forward so nothing hits the network; capture what would ship.
+  proxyMod.__setForwardProxyRequestForTests(async (url, method, headers, body) => {
+    const headerObj: Record<string, string> = {};
+    headers.forEach((v, k) => {
+      headerObj[k.toLowerCase()] = v;
+    });
+    // body is the outbound ReadableStream<Uint8Array> | null; drain it so the
+    // test can byte-match the canonical request bytes that reach the wire.
+    let bodyText: string | null = null;
+    if (body) {
+      const chunks: Uint8Array[] = [];
+      const reader = body.getReader();
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (value) chunks.push(value);
+      }
+      bodyText = Buffer.concat(chunks.map((c) => Buffer.from(c))).toString("utf8");
+    }
+    captured = { url: url.toString(), method, headers: headerObj, body: bodyText };
+    return new Response(JSON.stringify({ data: { id: "1799999999", text: "ok" } }), {
+      status: 201,
+      headers: { "content-type": "application/json" },
+    });
+  });
+});
+
+afterAll(async () => {
+  await closeDb().catch(() => {});
+  delete process.env.STEWARD_PGLITE_MEMORY;
+  delete process.env.STEWARD_MASTER_PASSWORD;
+  delete process.env.STEWARD_JWT_SECRET;
+});
+
+function buildApp() {
+  const app = new Hono();
+  app.use("*", authMiddleware);
+  app.all("*", handleProxy);
+  return app;
+}
+
+async function ensureTenant(tenantId: string) {
+  await getDb()
+    .insert(tenants)
+    .values({ id: tenantId, name: tenantId, apiKeyHash: `hash-${tenantId}` })
+    .onConflictDoNothing();
+}
+
+async function ensureAgent(tenantId: string, agentId: string) {
+  await getDb()
+    .insert(agents)
+    .values({ id: agentId, tenantId, name: agentId, walletAddress: `0x${"1".repeat(40)}` })
+    .onConflictDoNothing();
+}
+
+describe("x narrow credential route (integration)", () => {
+  it("injects the X access token upstream on POST /2/tweets; agent request never carries it", async () => {
+    captured = null;
+    const tenantId = `tenant-x-${crypto.randomUUID()}`;
+    const agentId = `agent-x-${crypto.randomUUID()}`;
+    await ensureTenant(tenantId);
+    await ensureAgent(tenantId, agentId);
+
+    const vault = new SecretVault(MASTER_PASSWORD);
+    const secret = await vault.createSecret(tenantId, "x-oauth", X_ACCESS_TOKEN);
+    await vault.createRoute(tenantId, secret.id, {
+      agentId,
+      hostPattern: "api.x.com",
+      pathPattern: "/2/tweets",
+      method: "POST",
+      injectAs: "header",
+      injectKey: "authorization",
+      injectFormat: "Bearer {value}",
+    });
+
+    const token = await signAgentToken({ agentId, tenantId, scopes: ["agent", PROXY_SCOPE] }, "1h");
+
+    // The exact canonical body the X adapter would emit for x.tweet.create.
+    const canonicalBody = JSON.stringify({ text: "gm from a governed agent" });
+    const res = await buildApp().request("/x/2/tweets", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+        "idempotency-key": crypto.randomUUID(),
+      },
+      body: canonicalBody,
+    });
+
+    expect(res.status).toBe(201);
+    expect(captured).not.toBeNull();
+    // The proxy resolved the /x alias to api.x.com.
+    expect(captured?.url).toBe("https://api.x.com/2/tweets");
+    expect(captured?.method).toBe("POST");
+    // Exact canonical bytes reach the wire, unmodified.
+    expect(captured?.body).toBe(canonicalBody);
+    // The X token was injected upstream as a Bearer credential.
+    expect(captured?.headers.authorization).toBe(`Bearer ${X_ACCESS_TOKEN}`);
+    // The agent's own JWT is replaced — the token is never something the agent
+    // supplied, and the agent's JWT never leaks upstream.
+    expect(captured?.headers.authorization).not.toContain(token);
+    // The raw token is never returned to the agent in the response body.
+    const text = await res.text();
+    expect(text).not.toContain(X_ACCESS_TOKEN);
+  });
+
+  it("MUTATION: a route/endpoint mismatch fails closed; the Bearer is NEVER injected or leaked", async () => {
+    // A route for /2/users/me must NOT inject on a POST /2/tweets request: the
+    // credential is pinned to one exact endpoint+verb. With only that route
+    // configured, the non-matching /2/tweets call has no credential route and the
+    // proxy fails CLOSED (403) rather than forwarding an un-credentialed call.
+    // Either way the X token must never be injected or leak into the outbound
+    // request or the response.
+    captured = null;
+    const tenantId = `tenant-x-mm-${crypto.randomUUID()}`;
+    const agentId = `agent-x-mm-${crypto.randomUUID()}`;
+    await ensureTenant(tenantId);
+    await ensureAgent(tenantId, agentId);
+
+    const vault = new SecretVault(MASTER_PASSWORD);
+    const secret = await vault.createSecret(tenantId, "x-oauth-2", X_ACCESS_TOKEN);
+    // Route bound to the READ endpoint only.
+    await vault.createRoute(tenantId, secret.id, {
+      agentId,
+      hostPattern: "api.x.com",
+      pathPattern: "/2/users/me",
+      method: "GET",
+      injectAs: "header",
+      injectKey: "authorization",
+      injectFormat: "Bearer {value}",
+    });
+
+    const token = await signAgentToken({ agentId, tenantId, scopes: ["agent", PROXY_SCOPE] }, "1h");
+    const res = await buildApp().request("/x/2/tweets", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+        "idempotency-key": crypto.randomUUID(),
+      },
+      body: JSON.stringify({ text: "should not carry the X token" }),
+    });
+
+    // Fail-closed: no credential route matches this exact endpoint+verb, so the
+    // proxy denies rather than forwarding an un-credentialed call.
+    expect(res.status).toBe(403);
+    // The X token was never injected into any outbound request...
+    if (captured) {
+      expect(captured.headers.authorization).not.toBe(`Bearer ${X_ACCESS_TOKEN}`);
+      expect(captured.headers.authorization ?? "").not.toContain(X_ACCESS_TOKEN);
+      expect(captured.body ?? "").not.toContain(X_ACCESS_TOKEN);
+    }
+    // ...and never leaks into the response body.
+    const text = await res.text();
+    expect(text).not.toContain(X_ACCESS_TOKEN);
+  });
+
+  it("rejects a single-segment X route (POST /) at create time", async () => {
+    const tenantId = `tenant-x-bad-${crypto.randomUUID()}`;
+    const agentId = `agent-${crypto.randomUUID()}`;
+    await ensureTenant(tenantId);
+    await ensureAgent(tenantId, agentId);
+    const vault = new SecretVault(MASTER_PASSWORD);
+    const secret = await vault.createSecret(tenantId, "x-oauth-3", X_ACCESS_TOKEN);
+
+    await expect(
+      vault.createRoute(tenantId, secret.id, {
+        agentId,
+        hostPattern: "api.x.com",
+        pathPattern: "/",
+        method: "POST",
+        injectAs: "header",
+        injectKey: "authorization",
+        injectFormat: "Bearer {value}",
+      }),
+    ).rejects.toThrow(/at least 2 segments/);
+  });
+
+  it("rejects a wildcard X path (/2/*) at create time", async () => {
+    const tenantId = `tenant-x-wild-${crypto.randomUUID()}`;
+    const agentId = `agent-${crypto.randomUUID()}`;
+    await ensureTenant(tenantId);
+    await ensureAgent(tenantId, agentId);
+    const vault = new SecretVault(MASTER_PASSWORD);
+    const secret = await vault.createSecret(tenantId, "x-oauth-wild", X_ACCESS_TOKEN);
+
+    await expect(
+      vault.createRoute(tenantId, secret.id, {
+        agentId,
+        hostPattern: "api.x.com",
+        pathPattern: "/2/*",
+        method: "POST",
+        injectAs: "header",
+        injectKey: "authorization",
+        injectFormat: "Bearer {value}",
+      }),
+    ).rejects.toThrow(/exact path \(no "\*" wildcards\)/);
+  });
+});

--- a/packages/proxy/src/config.ts
+++ b/packages/proxy/src/config.ts
@@ -14,6 +14,7 @@ export const DEFAULT_ALIASES: Record<string, string> = {
   coingecko: "api.coingecko.com",
   helius: "api.helius.xyz",
   github: "api.github.com",
+  x: "api.x.com",
 };
 
 /** Default port for the proxy server */

--- a/packages/shared/src/provider-approval.ts
+++ b/packages/shared/src/provider-approval.ts
@@ -32,7 +32,11 @@ export interface ProviderApprovalCommitmentV1 {
     key: string;
     revision: number;
     riskClass: string;
-    canonicalProfile: "github.provider-action.v1";
+    // Adapter canonical profile. Widened from the github literal so the same
+    // commitment schema binds X (`x.provider-action.v1`) and future adapters.
+    // JCS hashes whatever string is present, so this is behavior-neutral for the
+    // existing github digest corpus (the string value is unchanged there).
+    canonicalProfile: "github.provider-action.v1" | "x.provider-action.v1";
   };
   requestHash: string;
   actionDigest: string;

--- a/packages/vault/src/secret-route-validator.ts
+++ b/packages/vault/src/secret-route-validator.ts
@@ -28,6 +28,7 @@ export const DEFAULT_SECRET_ROUTE_HOSTS = [
   "api.coingecko.com",
   "api.helius.xyz",
   "api.github.com",
+  "api.x.com",
 ] as const;
 
 /**
@@ -94,6 +95,16 @@ export const STRICT_HOSTS: Record<
   { minPathSegments: number; requireExplicitMethod: boolean; disallowPathWildcards: boolean }
 > = {
   "api.github.com": {
+    minPathSegments: 2,
+    requireExplicitMethod: true,
+    disallowPathWildcards: true,
+  },
+  // X provider-action endpoints: POST /2/tweets, DELETE /2/tweets/{id},
+  // GET /2/users/me. Every governed X path has >=2 segments, so the same
+  // strict narrowness as github pins each route to one exact endpoint + verb
+  // and forbids "*" wildcards (a /2/* route would attach the OAuth token to
+  // every X endpoint).
+  "api.x.com": {
     minPathSegments: 2,
     requireExplicitMethod: true,
     disallowPathWildcards: true,


### PR DESCRIPTION
## feat(provider-x): governed wiring + E2E scaffolding (#195 workstream C)

Wires X (Twitter) operations through the same governed provider-action pipeline that GitHub uses, and adds the E2E + proxy-plane test scaffolding that proves it. [sol-orch]

### Wiring map (both planes, mirroring GitHub)

**Authority plane (`packages/api`)** — propose → access → policy → approval → resume:
- `provider-authority-store.ts`: X operation allowlist (`x.tweet.create`=POST, `x.tweet.delete`=DELETE, `x.user.me.read`=GET) + host allowlist (`x` → `api.x.com`).
- `provider-action-service.ts`: accepts `GithubActionBuild | XActionBuild`; derives the policy-context `host` from the action origin instead of a hardcoded `api.github.com`.
- `provider-approval.ts`: binds the adapter `canonicalProfile` from the validated build, not a hardcoded github literal (so X commitments carry `x.provider-action.v1`).
- `provider-actions.ts` route: dispatches `x.*` operation keys to `buildXAction`.
- `@stwd/shared` `provider-approval.ts`: widens the commitment `operation.canonicalProfile` type to admit `x.provider-action.v1` (pure type widening; JCS hashes whatever string is present, so no digest change for github).

**Proxy plane (`packages/proxy`)** — byte-level Bearer injection:
- `config.ts`: `x → api.x.com` alias.
- `@stwd/vault` `secret-route-validator.ts`: `api.x.com` in the default host set + a STRICT_HOSTS entry (minPathSegments 2, requireExplicitMethod, disallowPathWildcards). All three X paths (`/2/tweets`, `/2/tweets/{id}`, `/2/users/me`) have ≥2 segments.

### Drift-behavior decision (secret version bump between approval and execution)

**Decision: version drift STALES the action fail-closed. It does NOT silently use the new token.** This is already mandated + implemented by the authority plan PR3 — X inherits it for free; this PR only proves it for X and cites it.

- The approval commitment (`ProviderApprovalCommitmentV1.executionDependencies`) binds `{ routeId, routeRevision, secretId, secretVersion }`. `buildApprovalArm` sets `secretVersion = account.credentialVersion` at propose time.
- At BOTH approve and safe-resume, `revalidateDependencies` compares the live `provider_accounts.credential_version` against the bound `executionDependencies.secretVersion`; a mismatch returns `APPROVAL_CREDENTIAL_STALE` and `staleTransition(...)` moves the action to `approval_stale` (intent canceled), fail-closed.
- #197's token refresh bumps `provider_accounts.credential_version`, so a refresh landing between approval and execution surfaces as `APPROVAL_CREDENTIAL_STALE`; the stale token is never used, the human must re-approve against the new version.

**Spec citation:** authority plan PR3 approval spec §5.1 (commitment `executionDependencies`) + §5.2 (dependency revalidation / credential staleness) — implemented at `packages/api/src/services/provider-approval.ts` `revalidateDependencies` (`APPROVAL_CREDENTIAL_STALE`). No new policy invented; the existing PR3 binding is reused.

### ⚠️ KNOWN BLOCKER: migration 0080 profile CHECK (NOT taken in this PR)

`packages/db/drizzle/0080_provider_action_bindings.sql` **line 69**:

```sql
CONSTRAINT "provider_action_bindings_profile_chk"
  CHECK ("canonical_profile" = 'github.provider-action.v1')
```

The CHECK hardcodes the github profile literal, so **no X binding (`canonical_profile = 'x.provider-action.v1'`) can persist yet.** The service builds the correct X binding and fails closed at the INSERT — surfaced to the caller as `EVIDENCE_DECISION_PERSIST_FAILED` (503). This is the same finding codex raised (P2, `provider-actions.ts:204-205`); it is a deliberate, documented decision, not a defect.

**Why no migration here:** the next free migration journal slot (0082) is owned by the in-flight PR4 (`feat/execution-authorization-v2`). Taking a competing migration in this PR would collide the journal.

**Follow-up (post-PR4):** the next free slot after PR4's 0082 (i.e. 0083+) widens the profile CHECK to admit `'x.provider-action.v1'`, and the five `describe.skip` E2E tests get un-skipped in that same follow-up PR. No test change is needed at that point — they already assert the full X chain end to end and will pass once the binding persists.

### Tests (honest active vs skipped counts)

**ACTIVE — 10 tests, all passing:**

`packages/proxy/src/__tests__/x-credential-route.test.ts` (4 active) — does NOT touch `provider_action_bindings`, fully unblocked:
- Byte-level proof: X OAuth token injected upstream as `Authorization: Bearer` on `POST /2/tweets`; exact canonical bytes reach the wire; agent JWT never leaks.
- MUTATION: endpoint/verb mismatch fails closed (403) — Bearer never injected or leaked.
- Strict-route create-time rejections: single-segment path, wildcard path.

`packages/api/src/__tests__/provider-x-governed-e2e.test.ts` (6 active):
- Policy composition (4, no DB): X write rules compose to `approval_required`, read rules to `allow`, a MUTATION dropping the require-approval rule flips the write path to `allow` (proving the approval is load-bearing), and empty governing rules fail closed (default-deny).
- Wiring-up-to-persist (2, PGLite): a real `x.tweet.create` runs the whole governed chain (access allow → policy `approval_required` → PR3 approval arm) and fails CLOSED only at the binding persist; then isolates that persist failure PRECISELY to `provider_action_bindings_profile_chk` (SQLSTATE 23514, constraint named), with a github-profile control proving the row is valid in every other dimension.

**SKIPPED — 5 tests (`describe.skip`), blocked by 0080:**
- `x.tweet.create`: propose → policy → approval_required → approve → resume → execution_ready.
- `x.user.me.read`: allow read path reaches the stub with no approval.
- NEGATIVE: tampered canonical action bytes after approval → integrity mismatch → stales.
- NEGATIVE: expired approval → `APPROVAL_EXPIRED`, no execution.
- NEGATIVE: credential version drift between approval and resume → `APPROVAL_CREDENTIAL_STALE`.

### Verification
- Touched suites green: proxy x-credential-route (4/4), api provider-x-governed-e2e (6 active pass / 5 skip), plus adjacent shared x-provider-action (13/13), provider-x (22/22), db bindings-migration (10/10).
- `tsc --noEmit` clean on `@stwd/api` and `@stwd/proxy`.
- Biome clean on both new files.
- codex `review --base origin/develop`: one finding, the known 0080 blocker above (documented, deliberate).

### Honest gaps
- The five full-chain E2E tests are skipped, not passing — they cannot pass until the 0080 CHECK is widened post-PR4.
- No dashboard/UI surface for X connect is added here (a wiring/proof PR, not a UI PR); filed as follow-up per the design notes.
- The version-drift guard is proven by the SKIPPED api E2E (blocked); the ACTIVE proxy test proves current-version resolution only. The drift guard's live proof lands with the un-skip.

Design notes: `docs/provider-x/WORKSTREAM-C-NOTES.md` (committed in d2306e0).

Co-authored-by: wakesync <shadow@shad0w.xyz>
