### PR TITLE
feat(provider-x): instance-level permissioned X policies

### DIFF
--- a/docs/security/permissioned-x.mdx
+++ b/docs/security/permissioned-x.mdx
@@ -1,0 +1,249 @@
+---
+title: "Permissioned X — instance-level policy vocabulary"
+status: Design + Phase-1 implementation
+date: 2026-07-16
+---
+
+{/*
+This document describes the instance-level policy vocabulary Steward adds ON TOP
+of X's native OAuth2 scope model for governed X provider-actions. It is scoped to
+Phase 1 (the policy dimensions shipped in feat/x-permissioned-policies). It must
+NOT be read as a claim that Steward enforces X's own server-side limits — it does
+not. Steward enforces its OWN instance-level policy BEFORE an action reaches the
+wire, and classifies certain X server-side denials (summoned-reply 403) as an
+expected upstream-denial class so they surface as a clear failed outcome rather
+than outcome_unknown.
+*/}
+
+# Permissioned X
+
+**Status:** Design + Phase-1 implementation. Last reviewed 2026-07-16.
+**Scope:** the `capability-intent` policy plane for `x.provider-action.v1`
+operations (`x.tweet.create`, `x.tweet.delete`, `x.user.me.read`) on `develop`.
+
+If this document disagrees with the code, the code is right. File an issue.
+
+## Why "permissioned X" is a real gap, not marketing
+
+X's native delegation model gives an application (or a delegated user) a
+**class-level standing permission**. It cannot express the per-call,
+per-window, content-conditional constraints an operator needs to safely delegate
+an X account to an autonomous agent. Steward fills exactly that gap: it is the
+**instance-level policy layer** X's own scope model cannot represent.
+
+### X's native delegation model (what it CAN express)
+
+- **OAuth2 scopes** (`tweet.read`, `tweet.write`, `users.read`, `offline.access`,
+  …): a scope is a **standing, class-level grant**. `tweet.write` authorizes
+  *every* write the token can reach — create, reply, delete — for the token's
+  lifetime. There is no "reply-only", no "no-URL", no "≤N posts/hour", no "only
+  when summoned", no spend ceiling. A scope is binary and coarse.
+  Receipt: X API OAuth2 scopes (docs.x.com "Authentication → OAuth 2.0 →
+  scopes").
+- **X Delegate / delegate accounts**: this is **human RBAC** — it lets a person
+  operate an org account with a role. It is an account-access model, not an API
+  policy-composition model. It cannot gate a *programmatic* call by content,
+  rate, or spend. Receipt: X Help "About account delegation".
+
+Both are **class-level**: they answer "may this identity write tweets at all?"
+Neither answers "may this *specific* action, *right now*, under *these*
+conditions, proceed?" That second question is the authority plane's job.
+
+### The exact instance-level gaps Steward fills
+
+| Dimension | X native | Steward instance-level policy |
+| --- | --- | --- |
+| Reply-vs-original | scope is write-all | `replyPolicy.mode` gates replies independently of originals |
+| Content conditions | none | `contentPolicy` (no-URL, max length, blocked patterns) |
+| Rate / count caps per window | server rate limits are global + opaque | `maxPostsPerWindow` (explicit count + window) |
+| Spend ceiling | billing is post-hoc | estimated-spend cap over the per-post price table |
+| Approval escalation | none | any URL post (or over-threshold spend) → `approval_required` |
+| Summoned-reply constraint | 403 at the wire (Feb 2026 anti-spam) | modeled as a policy denial class BEFORE the wasted call |
+
+Every dimension below FAILS CLOSED: an unknown content shape denies; a policy
+evaluation error denies; a missing required policy input denies.
+
+## The policy dimensions (with X API receipts)
+
+X's developer docs are agent-readable (`docs.x.com`, `llms.txt`, `.md`
+suffixes). The receipts below are captured at design time (2026-07-16); the
+per-post price table is a **versioned constant** in code with a source comment so
+a price change is a reviewable diff, not silent drift.
+
+### 1. Reply-only / summoned-reply constraint (`replyPolicy`)
+
+**X receipt (Feb 2026 anti-spam):** a *programmatic* reply on the self-serve
+tiers (Free / Basic / Pro / Pay-Per-Use) to `POST /2/tweets` returns **403
+Forbidden** unless the replier's account was **@mentioned or quoted** by the
+post being replied to. Enterprise / Public-Utility apps are exempt. Source:
+X developer platform reply-restriction announcement (Feb 2026); corroborated by
+multiple trackers (tekedia, phemex, piunikaweb, Feb 2026).
+
+**Why model it in policy (not just let the wire 403):**
+1. A blind programmatic reply that will 403 is a **wasted, billed** API call
+   (X bills on submission, not success).
+2. An operator wants to *forbid* un-summoned replies as a matter of policy, not
+   discover the ban at the wire per-call.
+
+**Modeled as:** `replyPolicy.mode`:
+- `'any'` — replies allowed (operator accepts the upstream risk).
+- `'summoned-only'` — a reply is allowed ONLY when the action is marked
+  `summoned` (the caller asserts the account was @mentioned/quoted). An
+  un-summoned reply is a policy **hard_deny** (`POLICY_X_REPLY_NOT_SUMMONED`)
+  BEFORE dispatch. This is the **expected upstream-denial class** made explicit:
+  Steward denies locally what X would 403 at the wire.
+- `'none'` — replies forbidden entirely (`POLICY_X_REPLY_FORBIDDEN`); only
+  original posts pass.
+
+`isReply` and `replyToTweetId` are already adapter-validated policy args
+(`buildXAction`). `summoned` is a new validated boolean policy arg (see
+"Summoned detection" below).
+
+### 2. Content conditions (`contentPolicy`)
+
+**X receipt (pricing, Feb 6 2026 pay-per-use):** a post **without** a URL costs
+**$0.015**; a post **with** a URL costs **$0.20** (>13× more). Source: X API
+pay-per-use pricing (gigazine 2026-02-09; sorsa/blotato/postproxy trackers).
+
+**Key insight:** a **no-URL policy is ALSO a spend policy.** Blocking URL posts
+caps the per-post cost at $0.015. `contentPolicy` therefore covers both a content
+constraint and a cost lever:
+
+- `allowUrls: boolean` — `false` denies any post whose text contains a URL
+  (`POLICY_X_URL_FORBIDDEN`). URL detection is adapter-derived (`hasUrl` policy
+  arg), never lifted from raw JSON.
+- `maxLength: number` — deny a post whose adapter-counted code-point length
+  exceeds the cap (`POLICY_X_CONTENT_TOO_LONG`). This is stricter-or-equal to X's
+  280 weighted limit (the adapter already bounds 1..280).
+- `blockedPatterns: string[]` — each is an anchored regex; a match on the text
+  denies (`POLICY_X_CONTENT_BLOCKED`). An **invalid** regex in config denies
+  (`POLICY_CONFIGURATION_INVALID`) — fail closed, never throw.
+
+> Content matching operates on an adapter-derived boolean/length surface plus (for
+> `blockedPatterns`) a normalized text digest channel, NOT the safe-summary
+> (which is contractually text-free). See "Text availability" below.
+
+### 3. Rate / count cap per window (`maxPostsPerWindow`)
+
+**X receipt:** X's own POST rate limits are **global, per-app, opaque** and reset
+on X's schedule; they are not an operator-authored budget. Source: X API rate
+limits (docs.x.com "Fundamentals → Rate limits").
+
+**Modeled as:** `maxPostsPerWindow: { max: number, windowSeconds: number }` — an
+operator-authored count cap over a trailing window. Evaluated against the
+authoritative trailing-window post count. If the count input is unavailable, the
+rule **denies** (`POLICY_INPUT_UNAVAILABLE`) — never borrows another counter,
+never silently passes. This reuses the existing `invokeCount1h` wiring contract
+(the count is authoritative or the rule fails closed).
+
+### 4. Estimated-spend cap (`spendPolicy`)
+
+**Modeled as:** `spendPolicy.maxSpendMicros: number` (spend denominated in
+micro-dollars to stay integer-exact) evaluated against **estimated** spend:
+`priceForAction + accumulatedWindowSpend`. The per-post price table is a
+**versioned constant** (`X_POST_PRICE_TABLE_V1`) with a source comment:
+
+- plain post: `15000` micros ($0.015)
+- URL post: `200000` micros ($0.20)
+
+Accumulation is over the same trailing window as `maxPostsPerWindow` (the
+authoritative accumulated-spend input). Unavailable input →
+`POLICY_INPUT_UNAVAILABLE` (fail closed). Over cap →
+`POLICY_X_SPEND_CAP_EXCEEDED`.
+
+> This is an *estimate*, not a billing oracle. The doc/PR never claims exact
+> spend accounting — the price table is design-time truth and drift is a
+> reviewable constant change.
+
+### 5. Approval-escalation thresholds (`escalation`)
+
+**Modeled as:** conditions that, when met on an otherwise-allowed action,
+DOWNGRADE the effect from `allow` to `approval_required` (never upgrade a deny to
+an allow):
+
+- `urlPostRequiresApproval: boolean` — any URL post (the expensive $0.20 class)
+  routes to human approval even if `allowUrls` is true.
+- `spendOverMicrosRequiresApproval: number` — an estimated spend over this
+  threshold (but under the hard `maxSpendMicros` cap) routes to approval.
+
+Escalation obeys the plane's canonical precedence: **hard_deny > approval_required
+> allow**. A hard deny from any rule always wins; escalation can only turn a
+would-be allow into an approval.
+
+### 6. DM / mention / hashtag / quiet-hours (Phase-1 scope note)
+
+- **DM restrictions:** the current adapter exposes NO DM operation
+  (`x.tweet.*`, `x.user.me.read` only). A DM policy has no operation to gate in
+  Phase 1. It is documented here as a **known gap** and will attach to a future
+  `x.dm.*` operation. We do NOT ship a dead DM rule.
+- **mention/hashtag restrictions:** expressible TODAY via
+  `contentPolicy.blockedPatterns` (e.g. block `@competitor`, block `#banned`).
+  A dedicated structured surface is deferred; the pattern channel covers the
+  Phase-1 need without a second matcher.
+- **quiet hours:** `quietHours: { startMinuteUtc, endMinuteUtc }` gates writes to
+  a UTC minute-of-day window. Evaluated against an authoritative
+  `nowMinuteUtc` policy input; unavailable → `POLICY_INPUT_UNAVAILABLE`.
+
+## How it plugs into the existing plane (no invented registry)
+
+The permissioned-X vocabulary is an **additive extension of the existing
+`capability-intent` config `constraints`** — the SAME rule type, SAME composer
+(`composeProviderActionPolicyDecision`), SAME precedence, SAME persisted
+`ProviderPolicyEvaluationV1` document that github flows through. There is NO new
+rule type, NO new policy registry, NO new evaluator dispatch.
+
+- github's `constraints` (`argEquals` / `argMatches` / `maxCallsPerHour`) are
+  untouched and still evaluate byte-identically.
+- X adds `constraints.x` (an OPTIONAL, X-only sub-block). A non-X operation with
+  an `x` constraint block is a config error (fail closed) — the sub-block only
+  applies to `x.*` operations.
+- The composer reads adapter-validated policy args
+  (`isReply`, `replyToTweetId`, `hasUrl`, `textCodePointLength`, `summoned`) — it
+  NEVER lifts a raw body field. New args (`hasUrl`, `summoned`) are derived and
+  validated in `buildXAction`.
+
+## Text availability (why `blockedPatterns` is careful)
+
+The safe-summary is contractually **text-free** (only length + sha256). To match
+`blockedPatterns` without re-introducing a text leak, the adapter emits a
+SEPARATE, non-persisted `policyText` channel on `policyArgs` that the composer
+reads IN-MEMORY during evaluation and that is NEVER written to the decision doc,
+the safe-summary, or the audit event. The persisted decision records only the
+matched pattern's index/reason code, never the text. This is documented as the
+one place the composer sees text, and it is mutation-proven to stay out of the
+persisted document.
+
+## Fail-closed matrix (Phase 1)
+
+| Situation | Effect | Reason code |
+| --- | --- | --- |
+| unknown `x` constraint key | hard_deny | `POLICY_CONFIGURATION_INVALID` |
+| `x` block on a non-X operation | hard_deny | `POLICY_CONFIGURATION_INVALID` |
+| un-summoned reply under `summoned-only` | hard_deny | `POLICY_X_REPLY_NOT_SUMMONED` |
+| reply under `none` | hard_deny | `POLICY_X_REPLY_FORBIDDEN` |
+| URL post under `allowUrls:false` | hard_deny | `POLICY_X_URL_FORBIDDEN` |
+| text over `maxLength` | hard_deny | `POLICY_X_CONTENT_TOO_LONG` |
+| `blockedPatterns` match | hard_deny | `POLICY_X_CONTENT_BLOCKED` |
+| invalid `blockedPatterns` regex | hard_deny | `POLICY_CONFIGURATION_INVALID` |
+| post count over `maxPostsPerWindow` | hard_deny | `POLICY_X_RATE_CAP_EXCEEDED` |
+| count input unavailable (cap set) | hard_deny | `POLICY_INPUT_UNAVAILABLE` |
+| estimated spend over `maxSpendMicros` | hard_deny | `POLICY_X_SPEND_CAP_EXCEEDED` |
+| spend input unavailable (cap set) | hard_deny | `POLICY_INPUT_UNAVAILABLE` |
+| now-minute input unavailable (quiet hours set) | hard_deny | `POLICY_INPUT_UNAVAILABLE` |
+| write inside quiet-hours window | hard_deny | `POLICY_X_QUIET_HOURS` |
+| URL post + `urlPostRequiresApproval` | approval_required | `APPROVAL_REQUIRED` |
+| spend over escalation threshold | approval_required | `APPROVAL_REQUIRED` |
+
+## Honest gaps (Phase 1)
+
+- **No DM policy operation** — deferred until `x.dm.*` exists.
+- **Estimate, not billing truth** — the price table is a design-time constant;
+  Steward does not read X's live billing.
+- **Count/spend/now inputs are wired-or-deny** — Phase 1 proves the evaluation
+  and the fail-closed behavior; the trailing-window accumulator wiring in the
+  live route is a follow-on (the same posture as `invokeCount1h` on develop,
+  which is `undefined` in the service and fails closed by design).
+- **Summoned assertion is caller-supplied** — Steward cannot itself verify the
+  post @mentioned/quoted the account without a read call; `summoned-only` gates
+  on the asserted arg and the upstream 403 remains the backstop. This is
+  documented, not hidden.

--- a/docs/security/permissioned-x.mdx
+++ b/docs/security/permissioned-x.mdx
@@ -201,6 +201,12 @@ rule type, NO new policy registry, NO new evaluator dispatch.
   (`isReply`, `replyToTweetId`, `hasUrl`, `textCodePointLength`, `summoned`) — it
   NEVER lifts a raw body field. New args (`hasUrl`, `summoned`) are derived and
   validated in `buildXAction`.
+- **Required-signal fail-closed:** a boolean signal a policy CONSUMES
+  (`isReply` for replyPolicy, `summoned` for summoned-only, `hasUrl` for
+  allowUrls / URL-escalation / spend pricing) that is ABSENT or non-boolean on
+  the context (e.g. an X policy mis-applied to `x.tweet.delete`, which carries no
+  such signal) => `POLICY_INPUT_UNAVAILABLE`. The evaluator NEVER coerces a
+  missing signal to `false` and silently passes.
 
 ## Text availability (why `blockedPatterns` is careful)
 
@@ -219,6 +225,7 @@ persisted document.
 | --- | --- | --- |
 | unknown `x` constraint key | hard_deny | `POLICY_CONFIGURATION_INVALID` |
 | `x` block on a non-X operation | hard_deny | `POLICY_CONFIGURATION_INVALID` |
+| required boolean signal absent/non-boolean (isReply / summoned / hasUrl) when a policy consumes it | hard_deny | `POLICY_INPUT_UNAVAILABLE` |
 | un-summoned reply under `summoned-only` | hard_deny | `POLICY_X_REPLY_NOT_SUMMONED` |
 | reply under `none` | hard_deny | `POLICY_X_REPLY_FORBIDDEN` |
 | URL post under `allowUrls:false` | hard_deny | `POLICY_X_URL_FORBIDDEN` |

--- a/packages/api/scripts/x-permissioned-mutation-proofs.sh
+++ b/packages/api/scripts/x-permissioned-mutation-proofs.sh
@@ -46,9 +46,9 @@ proof() {
   mv "$ENGINE.bak" "$ENGINE"
 }
 
-# M1: reply summoned-only no longer requires summoned -> un-summoned reply passes.
+# M1: reply summoned-only no longer denies an un-summoned reply.
 proof "M1 summoned-only ignores summoned flag" "summoned-only denies an un-summoned reply" \
-  's/x.replyPolicy.mode === "summoned-only" && !summoned/x.replyPolicy.mode === "summoned-only" \&\& false/'
+  's/if (!summoned) {/if (false) {/'
 
 # M2: reply mode=none no longer forbids replies.
 proof "M2 replyPolicy none no longer denies" "mode=none denies a reply" \
@@ -56,7 +56,7 @@ proof "M2 replyPolicy none no longer denies" "mode=none denies a reply" \
 
 # M3: allowUrls=false no longer denies URL posts.
 proof "M3 allowUrls=false ignores hasUrl" "allowUrls=false denies a URL post" \
-  's/if (x.contentPolicy.allowUrls === false && hasUrl) {/if (false) {/'
+  's/if (hasUrl) {/if (false) {/'
 
 # M4: maxLength no longer enforced.
 proof "M4 maxLength not enforced" "maxLength denies an over-length post" \
@@ -80,7 +80,7 @@ proof "M8 quiet hours not enforced" "denies inside a non-wrapping window" \
 
 # M9: url-post escalation no longer escalates (would silently allow the $0.20 post).
 proof "M9 url escalation dropped" "urlPostRequiresApproval escalates a URL post to approval" \
-  's/if (x.escalation.urlPostRequiresApproval === true && hasUrl) {/if (false) {/'
+  's/if (x.escalation.urlPostRequiresApproval === true && hasUrl === true) {/if (false) {/'
 
 # M10: x-block-on-non-x-op no longer a config error (scope leak).
 proof "M10 x block scope check dropped" "an x block on a NON-x operation is a config error" \

--- a/packages/api/scripts/x-permissioned-mutation-proofs.sh
+++ b/packages/api/scripts/x-permissioned-mutation-proofs.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Permissioned-X mutation-strength proofs. Each mutation weakens ONE
+# permissioned-X policy guard; a proof is valid iff the named test PASSES clean
+# AND FAILS after the mutation. The target file is restored after each proof.
+#
+# Guards live in the policy-engine composer (packages/policy-engine), so this
+# script reaches up the monorepo to mutate that file and runs the fast, DB-less
+# permissioned-X unit suite. Run from packages/api:
+#
+#   bash scripts/x-permissioned-mutation-proofs.sh
+#
+# A non-zero exit means at least one guard was NOT killed by its mutation (the
+# test did not detect the weakening) — i.e. the guard is not load-bearing.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+ENGINE="../policy-engine/src/capability-intent.ts"
+UNIT="../policy-engine/src/__tests__/permissioned-x.test.ts"
+
+pass_count=0
+fail_count=0
+
+# run_test <file> <filter> -> 0 if all pass (0 fail), 1 otherwise
+run_test() {
+  local out
+  out=$(cd ../policy-engine && timeout 90 bun test --timeout 25000 "src/__tests__/permissioned-x.test.ts" -t "$1" 2>&1)
+  echo "$out" | grep -qE "^ *0 fail$"
+}
+
+# proof <name> <filter> <sed-expr>
+proof() {
+  local name="$1" filter="$2" sedexpr="$3"
+  echo "=== PROOF: $name ==="
+  if run_test "$filter"; then
+    echo "  baseline PASS ✓"
+  else
+    echo "  baseline UNEXPECTED FAIL ✗ (proof invalid)"; fail_count=$((fail_count+1)); return
+  fi
+  cp "$ENGINE" "$ENGINE.bak"
+  sed -i "$sedexpr" "$ENGINE"
+  if run_test "$filter"; then
+    echo "  post-mutation still PASSES ✗ (mutation did not kill the test)"; fail_count=$((fail_count+1))
+  else
+    echo "  post-mutation FAILS ✓ (guard killed)"; pass_count=$((pass_count+1))
+  fi
+  mv "$ENGINE.bak" "$ENGINE"
+}
+
+# M1: reply summoned-only no longer requires summoned -> un-summoned reply passes.
+proof "M1 summoned-only ignores summoned flag" "summoned-only denies an un-summoned reply" \
+  's/x.replyPolicy.mode === "summoned-only" && !summoned/x.replyPolicy.mode === "summoned-only" \&\& false/'
+
+# M2: reply mode=none no longer forbids replies.
+proof "M2 replyPolicy none no longer denies" "mode=none denies a reply" \
+  's/if (x.replyPolicy.mode === "none") {/if (false) {/'
+
+# M3: allowUrls=false no longer denies URL posts.
+proof "M3 allowUrls=false ignores hasUrl" "allowUrls=false denies a URL post" \
+  's/if (x.contentPolicy.allowUrls === false && hasUrl) {/if (false) {/'
+
+# M4: maxLength no longer enforced.
+proof "M4 maxLength not enforced" "maxLength denies an over-length post" \
+  's/if (len > x.contentPolicy.maxLength) {/if (false) {/'
+
+# M5: blockedPatterns match no longer denies.
+proof "M5 blockedPatterns match ignored" "blockedPatterns denies a matching text" \
+  's/if (re.test(text)) {/if (false) {/'
+
+# M6: maxPostsPerWindow cap no longer enforced.
+proof "M6 rate cap not enforced" "denies when the window count is at/over the cap" \
+  's/if (posts >= x.maxPostsPerWindow.max) {/if (false) {/'
+
+# M7: spend cap no longer enforced.
+proof "M7 spend cap not enforced" "denies when accumulated .* exceeds the cap" \
+  's/if (projectedMicros > x.spendPolicy.maxSpendMicros) {/if (false) {/'
+
+# M8: quiet-hours no longer denies.
+proof "M8 quiet hours not enforced" "denies inside a non-wrapping window" \
+  's/if (inWindow) {/if (false) {/'
+
+# M9: url-post escalation no longer escalates (would silently allow the $0.20 post).
+proof "M9 url escalation dropped" "urlPostRequiresApproval escalates a URL post to approval" \
+  's/if (x.escalation.urlPostRequiresApproval === true && hasUrl) {/if (false) {/'
+
+# M10: x-block-on-non-x-op no longer a config error (scope leak).
+proof "M10 x block scope check dropped" "an x block on a NON-x operation is a config error" \
+  's/if (!ctx.operationKey.startsWith("x.")) {/if (false) {/'
+
+echo
+echo "=== permissioned-X mutation proofs: $pass_count killed, $fail_count not-killed ==="
+[ "$fail_count" -eq 0 ]

--- a/packages/api/src/__tests__/provider-x-permissioned-e2e.test.ts
+++ b/packages/api/src/__tests__/provider-x-permissioned-e2e.test.ts
@@ -1,0 +1,380 @@
+/**
+ * Permissioned-X full-chain E2E (authority plane, real provider-action service +
+ * approval state machine over PGLite).
+ *
+ * This proves the instance-level X policy vocabulary (docs/security/permissioned-x.mdx)
+ * end to end through the SAME service github/X flow through:
+ *
+ *   propose (buildXAction -> policyArgs + non-persisted policyText) ->
+ *   access allow -> composeProviderActionPolicyDecision reads the permissioned-X
+ *   constraints.x block -> hard_deny / approval_required / allow -> (on approval)
+ *   human approve -> safe resume -> execution_ready, with the audit chain.
+ *
+ * Coverage (positive + negative for each Phase-1 dimension that needs no external
+ * counter — count/spend/quiet-hours require the unwired trailing-window
+ * accumulator and are proven at the composer unit level in
+ * packages/policy-engine/src/__tests__/permissioned-x.test.ts + fail-closed here):
+ *   - contentPolicy.allowUrls=false: a URL post is policy_denied (POLICY_X_URL_FORBIDDEN),
+ *     a plain post is allowed. NO execution on the denied path.
+ *   - replyPolicy.summoned-only: an un-summoned reply is policy_denied
+ *     (POLICY_X_REPLY_NOT_SUMMONED) — the Feb-2026 anti-spam upstream-403 class
+ *     modeled as a LOCAL policy denial BEFORE the wasted billed call, surfaced as
+ *     a clear failed outcome (policy_denied), NEVER outcome_unknown.
+ *   - replyPolicy.summoned-only: a summoned reply reaches approval (load-bearing).
+ *   - contentPolicy.blockedPatterns: a blocked-pattern post is policy_denied
+ *     (POLICY_X_CONTENT_BLOCKED) via the in-memory policyText channel; a clean
+ *     post is allowed — proving text reaches the composer but is NEVER persisted.
+ *   - escalation.urlPostRequiresApproval: a URL post (allowUrls=true) escalates
+ *     from allow to approval_required.
+ *   - fail-closed: a spendPolicy rule (unwired accumulated-spend input) denies
+ *     with POLICY_INPUT_UNAVAILABLE.
+ *
+ * MUTATION: the URL-forbidden guard is mutation-proven in
+ * scripts/x-permissioned-mutation-proofs.sh (flip allowUrls false->true, watch
+ * the denied URL post flip to allowed).
+ */
+
+import { beforeAll, beforeEach, afterAll, describe, expect, setDefaultTimeout, test } from "bun:test";
+import {
+  agents,
+  approvalQueue,
+  closeDb,
+  getDb,
+  intents,
+  providerAccounts,
+  providerActionAuditOutbox,
+  providerActionBindings,
+  providerGrants,
+  providerOperations,
+  providerRoleBindings,
+  secretRoutes,
+  secrets,
+  tenants,
+  users,
+  userTenants,
+  workspaces,
+} from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { buildXAction } from "@stwd/provider-x";
+import { eq } from "drizzle-orm";
+import type { ProviderPrincipalV1 } from "../middleware/provider-principal";
+import { providerActionService } from "../services/provider-action-service";
+
+setDefaultTimeout(120_000);
+
+const P = {
+  TENANT: "tenant-xp",
+  AGENT: "agent-xp",
+  WORKSPACE: "22000000-0000-4000-8000-000000000001",
+  ACCOUNT: "32000000-0000-4000-8000-000000000001",
+  OP_URL_DENY: "42000000-0000-4000-8000-000000000001",
+  OP_SUMMONED: "42000000-0000-4000-8000-000000000002",
+  OP_BLOCKED: "42000000-0000-4000-8000-000000000003",
+  OP_ESCALATE: "42000000-0000-4000-8000-000000000004",
+  OP_SPEND: "42000000-0000-4000-8000-000000000005",
+  SECRET: "52000000-0000-4000-8000-000000000001",
+  ROUTE: "62000000-0000-4000-8000-000000000001",
+  GRANTOR: "12000000-0000-4000-8000-000000000001",
+  APPROVER: "82000000-0000-4000-8000-000000000001",
+  APPROVER_BINDING: "92000000-0000-4000-8000-000000000001",
+  GRANT: "a2000000-0000-4000-8000-000000000001",
+} as const;
+
+const OP_TWEET = "x.tweet.create";
+const FUTURE = new Date(Date.now() + 365 * 24 * 3600_000);
+
+function principal(): ProviderPrincipalV1 {
+  return {
+    type: "agent",
+    agentId: P.AGENT,
+    tenantId: P.TENANT,
+    platformId: null,
+    issuer: "eliza-cloud",
+    subject: `agent:${P.AGENT}`,
+    tokenId: null,
+    scopes: [],
+    authenticatedAt: new Date().toISOString(),
+    expiresAt: null,
+    authnMethod: "agent-jwt-rs256",
+  };
+}
+
+/**
+ * All operations key `x.tweet.create` but each carries a DIFFERENT permissioned-X
+ * rule set. The grant lists each operationKey but the seed uses distinct
+ * operation rows keyed by the SAME operationKey — the service resolves by
+ * (workspace, account, operationKey), so we seed ONE operation row per test and
+ * wipe between. We therefore install the ACTIVE rule set per test via a helper
+ * that rewrites the single operation's requestProfile.
+ */
+function allowRule(id: string, x?: Record<string, unknown>) {
+  return {
+    id,
+    type: "capability-intent",
+    enabled: true,
+    config: {
+      capabilities: [OP_TWEET],
+      effect: "allow",
+      ...(x ? { constraints: { x } } : {}),
+    },
+  };
+}
+
+async function wipe() {
+  const db = getDb();
+  await db.delete(providerActionAuditOutbox);
+  await db.delete(approvalQueue);
+  await db.delete(providerActionBindings);
+  await db.delete(intents);
+  await db.delete(providerGrants);
+  await db.delete(providerRoleBindings);
+  await db.delete(providerOperations);
+  await db.delete(providerAccounts);
+  await db.delete(secretRoutes);
+  await db.delete(secrets);
+  await db.delete(workspaces);
+  await db.delete(userTenants);
+  await db.delete(users);
+  await db.delete(tenants);
+}
+
+/** Seed the base account + a single x.tweet.create operation carrying `rules`. */
+async function seed(rules: unknown[]) {
+  const db = getDb();
+  await db.insert(tenants).values([{ id: P.TENANT, name: "XP", apiKeyHash: "hxp" }]);
+  await db.insert(users).values([
+    { id: P.GRANTOR, email: "gxp@t.test" },
+    { id: P.APPROVER, email: "axp@t.test" },
+  ]);
+  await db.insert(userTenants).values([{ userId: P.APPROVER, tenantId: P.TENANT, role: "member" }]);
+  await db
+    .insert(agents)
+    .values([
+      { id: P.AGENT, tenantId: P.TENANT, name: "AXP", walletAddress: "0x1", ownerUserId: null },
+    ]);
+  await db.insert(secrets).values([
+    {
+      id: P.SECRET,
+      tenantId: P.TENANT,
+      name: "x-oauth",
+      ciphertext: "x",
+      iv: "x",
+      authTag: "x",
+      salt: "x",
+      version: 1,
+    },
+  ]);
+  await db.insert(secretRoutes).values([
+    {
+      id: P.ROUTE,
+      tenantId: P.TENANT,
+      secretId: P.SECRET,
+      hostPattern: "api.x.com",
+      pathPattern: "/2/tweets",
+      method: "POST",
+      injectAs: "header",
+      injectKey: "authorization",
+    },
+  ]);
+  await db.insert(workspaces).values([
+    {
+      id: P.WORKSPACE,
+      tenantId: P.TENANT,
+      key: "xp-client",
+      name: "XPC",
+      environment: "production",
+      createdBy: P.GRANTOR,
+    },
+  ]);
+  await db.insert(providerAccounts).values([
+    {
+      id: P.ACCOUNT,
+      tenantId: P.TENANT,
+      workspaceId: P.WORKSPACE,
+      adapterKey: "x",
+      externalRef: "9999",
+      displayName: "@sol",
+      credentialSecretId: P.SECRET,
+      credentialVersion: 1,
+    },
+  ]);
+  await db.insert(providerOperations).values([
+    {
+      id: P.OP_URL_DENY,
+      tenantId: P.TENANT,
+      workspaceId: P.WORKSPACE,
+      providerAccountId: P.ACCOUNT,
+      operationKey: OP_TWEET,
+      riskClass: "write",
+      secretRouteId: P.ROUTE,
+      requestProfile: { policyRules: rules },
+    },
+  ]);
+  await db.insert(providerGrants).values([
+    {
+      id: P.GRANT,
+      tenantId: P.TENANT,
+      workspaceId: P.WORKSPACE,
+      providerAccountId: P.ACCOUNT,
+      agentId: P.AGENT,
+      operationKeys: [OP_TWEET],
+      environment: "production",
+      expiresAt: FUTURE,
+      grantedByUserId: P.GRANTOR,
+      reason: "test",
+    },
+  ]);
+  await db.insert(providerRoleBindings).values([
+    {
+      id: P.APPROVER_BINDING,
+      tenantId: P.TENANT,
+      workspaceId: P.WORKSPACE,
+      principalType: "human",
+      principalId: P.APPROVER,
+      roleKey: "workspace_approver",
+      operationKeys: [],
+      environment: "production",
+      status: "active",
+      grantedByUserId: P.GRANTOR,
+      reason: "approver",
+    },
+  ]);
+}
+
+function idemHash(seedStr: string): string {
+  return `sha256:${Buffer.from(seedStr.padEnd(32, "0")).toString("hex").slice(0, 64)}`;
+}
+
+async function propose(args: unknown, seedStr: string) {
+  const now = new Date();
+  return providerActionService.createProviderAction({
+    principal: principal(),
+    workspaceId: P.WORKSPACE,
+    providerAccountId: P.ACCOUNT,
+    operationKey: OP_TWEET,
+    build: buildXAction(OP_TWEET as never, args),
+    idempotencyKeyHash: idemHash(seedStr),
+    requestedAt: now.toISOString(),
+    expiresAt: new Date(now.getTime() + 300_000).toISOString(),
+    nonce: seedStr.padEnd(32, "N").slice(0, 32),
+    requestId: null,
+  });
+}
+
+async function bindingRow(intentId: string) {
+  const [b] = await getDb()
+    .select()
+    .from(providerActionBindings)
+    .where(eq(providerActionBindings.intentId, intentId));
+  return b;
+}
+
+describe("Permissioned-X full-chain E2E (authority plane, PGLite)", () => {
+  beforeAll(async () => {
+    process.env.STEWARD_PGLITE_MEMORY = "true";
+    process.env.STEWARD_AUDIT_HMAC_KEY ||= "0".repeat(64);
+    const { db, client } = await createPGLiteDb("memory://");
+    setPGLiteOverride(db, async () => client.close());
+  });
+  afterAll(async () => {
+    await closeDb();
+    delete process.env.STEWARD_PGLITE_MEMORY;
+  });
+  beforeEach(async () => {
+    await wipe();
+  });
+
+  test("contentPolicy allowUrls=false: URL post is policy_denied, no execution", async () => {
+    await seed([allowRule("11111111-1111-4111-8111-1111111111a1", { contentPolicy: { allowUrls: false } })]);
+    const out = await propose({ text: "check https://waifu.fun now" }, "urldeny1");
+    expect(out.kind).toBe("policy_denied");
+    if (out.kind !== "policy_denied") throw new Error(`got ${out.kind}`);
+    expect(out.code).toBe("POLICY_X_URL_FORBIDDEN");
+    // The binding must NOT have executed.
+    const b = await bindingRow(out.intentId);
+    expect(b.status).not.toBe("stub_succeeded");
+  });
+
+  test("contentPolicy allowUrls=false: a plain post is allowed", async () => {
+    await seed([allowRule("11111111-1111-4111-8111-1111111111a1", { contentPolicy: { allowUrls: false } })]);
+    const out = await propose({ text: "gm, no links here" }, "plainok1");
+    expect(out.kind).toBe("allowed");
+    if (out.kind !== "allowed") throw new Error(`got ${out.kind}`);
+    expect(out.stub.status).toBe("stub_succeeded");
+  });
+
+  test("replyPolicy summoned-only: an un-summoned reply is policy_denied (upstream-403 class, NOT outcome_unknown)", async () => {
+    await seed([allowRule("11111111-1111-4111-8111-1111111111b2", { replyPolicy: { mode: "summoned-only" } })]);
+    const out = await propose(
+      { text: "thanks for the mention!", replyToTweetId: "1750000000000000000", summoned: false },
+      "unsummon1",
+    );
+    expect(out.kind).toBe("policy_denied");
+    if (out.kind !== "policy_denied") throw new Error(`got ${out.kind}`);
+    // The Feb-2026 anti-spam denial is a CLEAR failed outcome with a stable code,
+    // never a fabricated allow and never outcome_unknown.
+    expect(out.code).toBe("POLICY_X_REPLY_NOT_SUMMONED");
+    const b = await bindingRow(out.intentId);
+    expect(b.status).not.toBe("stub_succeeded");
+  });
+
+  test("replyPolicy summoned-only: a summoned reply is allowed (guard is load-bearing)", async () => {
+    await seed([allowRule("11111111-1111-4111-8111-1111111111b2", { replyPolicy: { mode: "summoned-only" } })]);
+    const out = await propose(
+      { text: "thanks for the mention!", replyToTweetId: "1750000000000000000", summoned: true },
+      "summon001",
+    );
+    expect(out.kind).toBe("allowed");
+    if (out.kind !== "allowed") throw new Error(`got ${out.kind}`);
+    expect(out.stub.status).toBe("stub_succeeded");
+  });
+
+  test("contentPolicy blockedPatterns: a blocked-pattern post is policy_denied via in-memory policyText", async () => {
+    await seed([
+      allowRule("11111111-1111-4111-8111-1111111111c3", {
+        contentPolicy: { blockedPatterns: ["[Aa]irdrop"] },
+      }),
+    ]);
+    const out = await propose({ text: "free Airdrop, click now" }, "blocked01");
+    expect(out.kind).toBe("policy_denied");
+    if (out.kind !== "policy_denied") throw new Error(`got ${out.kind}`);
+    expect(out.code).toBe("POLICY_X_CONTENT_BLOCKED");
+  });
+
+  test("contentPolicy blockedPatterns: a clean post is allowed (text reached composer, never persisted)", async () => {
+    await seed([
+      allowRule("11111111-1111-4111-8111-1111111111c3", {
+        contentPolicy: { blockedPatterns: ["[Aa]irdrop"] },
+      }),
+    ]);
+    const out = await propose({ text: "just vibing today" }, "clean0001");
+    expect(out.kind).toBe("allowed");
+    if (out.kind !== "allowed") throw new Error(`got ${out.kind}`);
+    // The persisted binding carries only digests/hashes, never the tweet text.
+    const b = await bindingRow(out.intentId);
+    expect(JSON.stringify(b)).not.toContain("vibing");
+  });
+
+  test("escalation urlPostRequiresApproval: a URL post escalates allow -> approval_required", async () => {
+    await seed([
+      allowRule("11111111-1111-4111-8111-1111111111d4", {
+        contentPolicy: { allowUrls: true },
+        escalation: { urlPostRequiresApproval: true },
+      }),
+    ]);
+    const out = await propose({ text: "read more at https://steward.fi" }, "escal001");
+    expect(out.kind).toBe("approval_required");
+  });
+
+  test("fail-closed: a spendPolicy rule with unwired accumulated-spend input denies POLICY_INPUT_UNAVAILABLE", async () => {
+    await seed([
+      allowRule("11111111-1111-4111-8111-1111111111e5", {
+        spendPolicy: { maxSpendMicros: 1_000_000 },
+      }),
+    ]);
+    const out = await propose({ text: "plain post under a spend cap" }, "spendfc01");
+    expect(out.kind).toBe("policy_denied");
+    if (out.kind !== "policy_denied") throw new Error(`got ${out.kind}`);
+    expect(out.code).toBe("POLICY_INPUT_UNAVAILABLE");
+  });
+});

--- a/packages/api/src/__tests__/provider-x-permissioned-e2e.test.ts
+++ b/packages/api/src/__tests__/provider-x-permissioned-e2e.test.ts
@@ -34,7 +34,15 @@
  * the denied URL post flip to allowed).
  */
 
-import { beforeAll, beforeEach, afterAll, describe, expect, setDefaultTimeout, test } from "bun:test";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  setDefaultTimeout,
+  test,
+} from "bun:test";
 import {
   agents,
   approvalQueue,
@@ -285,7 +293,9 @@ describe("Permissioned-X full-chain E2E (authority plane, PGLite)", () => {
   });
 
   test("contentPolicy allowUrls=false: URL post is policy_denied, no execution", async () => {
-    await seed([allowRule("11111111-1111-4111-8111-1111111111a1", { contentPolicy: { allowUrls: false } })]);
+    await seed([
+      allowRule("11111111-1111-4111-8111-1111111111a1", { contentPolicy: { allowUrls: false } }),
+    ]);
     const out = await propose({ text: "check https://waifu.fun now" }, "urldeny1");
     expect(out.kind).toBe("policy_denied");
     if (out.kind !== "policy_denied") throw new Error(`got ${out.kind}`);
@@ -296,7 +306,9 @@ describe("Permissioned-X full-chain E2E (authority plane, PGLite)", () => {
   });
 
   test("contentPolicy allowUrls=false: a plain post is allowed", async () => {
-    await seed([allowRule("11111111-1111-4111-8111-1111111111a1", { contentPolicy: { allowUrls: false } })]);
+    await seed([
+      allowRule("11111111-1111-4111-8111-1111111111a1", { contentPolicy: { allowUrls: false } }),
+    ]);
     const out = await propose({ text: "gm, no links here" }, "plainok1");
     expect(out.kind).toBe("allowed");
     if (out.kind !== "allowed") throw new Error(`got ${out.kind}`);
@@ -304,7 +316,9 @@ describe("Permissioned-X full-chain E2E (authority plane, PGLite)", () => {
   });
 
   test("replyPolicy summoned-only: an un-summoned reply is policy_denied (upstream-403 class, NOT outcome_unknown)", async () => {
-    await seed([allowRule("11111111-1111-4111-8111-1111111111b2", { replyPolicy: { mode: "summoned-only" } })]);
+    await seed([
+      allowRule("11111111-1111-4111-8111-1111111111b2", { replyPolicy: { mode: "summoned-only" } }),
+    ]);
     const out = await propose(
       { text: "thanks for the mention!", replyToTweetId: "1750000000000000000", summoned: false },
       "unsummon1",
@@ -319,7 +333,9 @@ describe("Permissioned-X full-chain E2E (authority plane, PGLite)", () => {
   });
 
   test("replyPolicy summoned-only: a summoned reply is allowed (guard is load-bearing)", async () => {
-    await seed([allowRule("11111111-1111-4111-8111-1111111111b2", { replyPolicy: { mode: "summoned-only" } })]);
+    await seed([
+      allowRule("11111111-1111-4111-8111-1111111111b2", { replyPolicy: { mode: "summoned-only" } }),
+    ]);
     const out = await propose(
       { text: "thanks for the mention!", replyToTweetId: "1750000000000000000", summoned: true },
       "summon001",

--- a/packages/api/src/services/provider-action-service.ts
+++ b/packages/api/src/services/provider-action-service.ts
@@ -953,7 +953,7 @@ class ProviderActionService {
       // posture as invokeCount1h above. A permissioned-X rule that REQUIRES one
       // of these inputs (maxPostsPerWindow / spendPolicy / quietHours) therefore
       // fails closed (POLICY_INPUT_UNAVAILABLE) until the trailing-window
-      // accumulator lands. Content/reply/URL rules need no third-party input and are
+      // accumulator lands. Content/reply/URL rules need no external input and are
       // fully live now.
       x: undefined,
     };

--- a/packages/api/src/services/provider-action-service.ts
+++ b/packages/api/src/services/provider-action-service.ts
@@ -929,6 +929,12 @@ class ProviderActionService {
     // no governing rules (default deny).
     const rules = extractCapabilityIntentRules(operation.requestProfile);
 
+    // The in-memory-only tweet-text channel for X contentPolicy.blockedPatterns.
+    // Present ONLY on a text-bearing X build; NEVER persisted (the decision doc,
+    // safe-summary, and audit event stay text-free). A github build has no
+    // policyText, so this is undefined and any content-pattern rule fails closed.
+    const policyText = "policyText" in build ? build.policyText : undefined;
+
     const context: ProviderPolicyContext = {
       operationKey: operation.operationKey,
       args: build.policyArgs,
@@ -941,6 +947,15 @@ class ProviderActionService {
       // Trailing-hour count is not wired in PR2; rules that require it will
       // fail closed (POLICY_INPUT_UNAVAILABLE) exactly as specified.
       invokeCount1h: undefined,
+      ...(policyText !== undefined ? { policyText } : {}),
+      // Permissioned-X authoritative inputs (post count / accumulated spend /
+      // now-minute) are NOT wired into the service in Phase 1 — exactly the same
+      // posture as invokeCount1h above. A permissioned-X rule that REQUIRES one
+      // of these inputs (maxPostsPerWindow / spendPolicy / quietHours) therefore
+      // fails closed (POLICY_INPUT_UNAVAILABLE) until the trailing-window
+      // accumulator lands. Content/reply/URL rules need no third-party input and are
+      // fully live now.
+      x: undefined,
     };
 
     const evaluation = composeProviderActionPolicyDecision(rules, context);

--- a/packages/policy-engine/src/__tests__/permissioned-x.test.ts
+++ b/packages/policy-engine/src/__tests__/permissioned-x.test.ts
@@ -1,0 +1,377 @@
+/**
+ * Permissioned-X policy vocabulary — unit coverage over the SAME composer the
+ * provider-action service calls (`composeProviderActionPolicyDecision`) plus the
+ * standalone `evaluateXConstraints`.
+ *
+ * Covers every Phase-1 policy dimension positive + negative, the
+ * escalate-to-approval path, the summoned-reply upstream-403 modeled as a policy
+ * denial class, spend-cap accumulation, quiet hours (incl. midnight wrap), and
+ * the fail-closed matrix from docs/security/permissioned-x.mdx. Each guard is
+ * mutation-provable (see scripts/x-permissioned-mutation-proofs.sh, which weakens
+ * a guard and watches the matching `deny`/`escalate` assertion flip).
+ *
+ * The composer is the authority-plane enforcement surface; asserting effects
+ * here proves the vocabulary is load-bearing independent of the DB E2E.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  composeProviderActionPolicyDecision,
+  estimateXPostMicros,
+  evaluateXConstraints,
+  PROVIDER_POLICY_REASON as R,
+  type ProviderPolicyContext,
+  type ProviderPolicyRule,
+  X_POST_PRICE_TABLE_V1,
+  type XConstraints,
+} from "../capability-intent.js";
+
+const OP_TWEET = "x.tweet.create";
+
+/** A tweet.create policy context with sensible defaults; override per test. */
+function ctx(
+  args: Record<string, unknown> = {},
+  extra: Partial<ProviderPolicyContext> = {},
+): ProviderPolicyContext {
+  return {
+    operationKey: OP_TWEET,
+    args: {
+      isReply: false,
+      hasUrl: false,
+      summoned: false,
+      textCodePointLength: 5,
+      textByteLength: 5,
+      ...args,
+    },
+    method: "POST",
+    host: "api.x.com",
+    path: "/2/tweets",
+    invokeCount1h: 0,
+    ...extra,
+  };
+}
+
+/** An allow rule carrying an X constraint sub-block. */
+function allowX(x: XConstraints, id = "r-x-1"): ProviderPolicyRule {
+  return {
+    id,
+    type: "capability-intent",
+    enabled: true,
+    config: { capabilities: [OP_TWEET], effect: "allow", constraints: { x } },
+  };
+}
+
+/** Compose a single allow+X rule and return the effect + reason codes. */
+function decide(x: XConstraints, c: ProviderPolicyContext) {
+  return composeProviderActionPolicyDecision([allowX(x)], c);
+}
+
+// ─── price table ──────────────────────────────────────────────────────────────
+
+describe("permissioned-X: price table", () => {
+  it("plain post is 15000 micros ($0.015), url post 200000 ($0.20)", () => {
+    expect(X_POST_PRICE_TABLE_V1.plainMicros).toBe(15_000);
+    expect(X_POST_PRICE_TABLE_V1.urlMicros).toBe(200_000);
+    expect(estimateXPostMicros(false)).toBe(15_000);
+    expect(estimateXPostMicros(true)).toBe(200_000);
+  });
+});
+
+// ─── replyPolicy ────────────────────────────────────────────────────────────
+
+describe("permissioned-X: replyPolicy", () => {
+  it("mode=none denies a reply, allows an original", () => {
+    const x: XConstraints = { replyPolicy: { mode: "none" } };
+    expect(decide(x, ctx({ isReply: true })).effect).toBe("hard_deny");
+    expect(decide(x, ctx({ isReply: true })).reasonCodes).toContain(R.X_REPLY_FORBIDDEN);
+    expect(decide(x, ctx({ isReply: false })).effect).toBe("allow");
+  });
+
+  it("mode=summoned-only denies an un-summoned reply (upstream-403 class)", () => {
+    const x: XConstraints = { replyPolicy: { mode: "summoned-only" } };
+    const denied = decide(x, ctx({ isReply: true, summoned: false }));
+    expect(denied.effect).toBe("hard_deny");
+    expect(denied.reasonCodes).toContain(R.X_REPLY_NOT_SUMMONED);
+  });
+
+  it("mode=summoned-only allows a summoned reply", () => {
+    const x: XConstraints = { replyPolicy: { mode: "summoned-only" } };
+    expect(decide(x, ctx({ isReply: true, summoned: true })).effect).toBe("allow");
+  });
+
+  it("mode=any allows a reply (operator accepts upstream risk)", () => {
+    const x: XConstraints = { replyPolicy: { mode: "any" } };
+    expect(decide(x, ctx({ isReply: true, summoned: false })).effect).toBe("allow");
+  });
+
+  it("replyPolicy is inert on an original post", () => {
+    const x: XConstraints = { replyPolicy: { mode: "none" } };
+    expect(decide(x, ctx({ isReply: false })).effect).toBe("allow");
+  });
+});
+
+// ─── contentPolicy ──────────────────────────────────────────────────────────
+
+describe("permissioned-X: contentPolicy", () => {
+  it("allowUrls=false denies a URL post (also the $0.20 spend class)", () => {
+    const x: XConstraints = { contentPolicy: { allowUrls: false } };
+    const d = decide(x, ctx({ hasUrl: true }));
+    expect(d.effect).toBe("hard_deny");
+    expect(d.reasonCodes).toContain(R.X_URL_FORBIDDEN);
+    expect(decide(x, ctx({ hasUrl: false })).effect).toBe("allow");
+  });
+
+  it("maxLength denies an over-length post", () => {
+    const x: XConstraints = { contentPolicy: { maxLength: 10 } };
+    expect(decide(x, ctx({ textCodePointLength: 11 })).reasonCodes).toContain(R.X_CONTENT_TOO_LONG);
+    expect(decide(x, ctx({ textCodePointLength: 10 })).effect).toBe("allow");
+  });
+
+  it("maxLength fails closed when length signal absent", () => {
+    const x: XConstraints = { contentPolicy: { maxLength: 10 } };
+    const c = ctx();
+    // strip the length signal
+    (c.args as Record<string, unknown>).textCodePointLength = undefined;
+    expect(decide(x, c).reasonCodes).toContain(R.INPUT_UNAVAILABLE);
+  });
+
+  it("blockedPatterns denies a matching text via the in-memory policyText channel", () => {
+    // Patterns are standard JS RegExp source (no inline (?i) flag). Author
+    // case-insensitivity into the pattern itself.
+    const x: XConstraints = { contentPolicy: { blockedPatterns: ["[Aa][Ii][Rr][Dd][Rr][Oo][Pp]"] } };
+    const c = ctx({}, { policyText: "free AIRDROP now" });
+    expect(decide(x, c).reasonCodes).toContain(R.X_CONTENT_BLOCKED);
+    const clean = ctx({}, { policyText: "gm friends" });
+    expect(decide(x, clean).effect).toBe("allow");
+  });
+
+  it("blockedPatterns fails closed when policyText is absent", () => {
+    const x: XConstraints = { contentPolicy: { blockedPatterns: ["spam"] } };
+    // no policyText on ctx
+    expect(decide(x, ctx()).reasonCodes).toContain(R.INPUT_UNAVAILABLE);
+  });
+
+  it("invalid blockedPatterns regex fails closed (config invalid, never throws)", () => {
+    const x: XConstraints = { contentPolicy: { blockedPatterns: ["([unterminated"] } };
+    // NB: an invalid regex is caught at parse-time too; assert composition denies.
+    const rule: ProviderPolicyRule = {
+      id: "r-bad-regex",
+      type: "capability-intent",
+      enabled: true,
+      config: {
+        capabilities: [OP_TWEET],
+        effect: "allow",
+        constraints: { x },
+      },
+    };
+    const d = composeProviderActionPolicyDecision([rule], ctx({}, { policyText: "anything" }));
+    expect(d.effect).toBe("hard_deny");
+    expect(d.reasonCodes).toContain(R.CONFIGURATION_INVALID);
+  });
+});
+
+// ─── maxPostsPerWindow ──────────────────────────────────────────────────────
+
+describe("permissioned-X: maxPostsPerWindow", () => {
+  const x: XConstraints = { maxPostsPerWindow: { max: 3, windowSeconds: 3600 } };
+
+  it("denies when the window count is at/over the cap", () => {
+    const d = decide(x, ctx({}, { x: { postsInWindow: 3 } }));
+    expect(d.effect).toBe("hard_deny");
+    expect(d.reasonCodes).toContain(R.X_RATE_CAP_EXCEEDED);
+  });
+
+  it("allows under the cap", () => {
+    expect(decide(x, ctx({}, { x: { postsInWindow: 2 } })).effect).toBe("allow");
+  });
+
+  it("fails closed when the count input is unavailable", () => {
+    expect(decide(x, ctx()).reasonCodes).toContain(R.INPUT_UNAVAILABLE);
+  });
+});
+
+// ─── spendPolicy + accumulation ─────────────────────────────────────────────
+
+describe("permissioned-X: spendPolicy (estimated-spend cap)", () => {
+  it("denies when accumulated + this action exceeds the cap (URL post)", () => {
+    // cap 250000; already spent 100000; url post adds 200000 => 300000 > cap
+    const x: XConstraints = { spendPolicy: { maxSpendMicros: 250_000 } };
+    const d = decide(x, ctx({ hasUrl: true }, { x: { accumulatedSpendMicros: 100_000 } }));
+    expect(d.effect).toBe("hard_deny");
+    expect(d.reasonCodes).toContain(R.X_SPEND_CAP_EXCEEDED);
+  });
+
+  it("allows when accumulated + this action is within the cap (plain post)", () => {
+    const x: XConstraints = { spendPolicy: { maxSpendMicros: 250_000 } };
+    // 100000 + 15000 = 115000 <= 250000
+    expect(
+      decide(x, ctx({ hasUrl: false }, { x: { accumulatedSpendMicros: 100_000 } })).effect,
+    ).toBe("allow");
+  });
+
+  it("accumulation crosses the cap across two plain posts", () => {
+    const x: XConstraints = { spendPolicy: { maxSpendMicros: 20_000 } };
+    // first plain post: accumulated 0 + 15000 = 15000 <= 20000 => allow
+    expect(decide(x, ctx({}, { x: { accumulatedSpendMicros: 0 } })).effect).toBe("allow");
+    // second plain post: accumulated 15000 + 15000 = 30000 > 20000 => deny
+    expect(decide(x, ctx({}, { x: { accumulatedSpendMicros: 15_000 } })).effect).toBe("hard_deny");
+  });
+
+  it("fails closed when the accumulated-spend input is unavailable", () => {
+    const x: XConstraints = { spendPolicy: { maxSpendMicros: 250_000 } };
+    expect(decide(x, ctx({ hasUrl: true })).reasonCodes).toContain(R.INPUT_UNAVAILABLE);
+  });
+});
+
+// ─── quietHours ─────────────────────────────────────────────────────────────
+
+describe("permissioned-X: quietHours", () => {
+  it("denies inside a non-wrapping window", () => {
+    const x: XConstraints = { quietHours: { startMinuteUtc: 540, endMinuteUtc: 600 } }; // 9:00-10:00
+    expect(decide(x, ctx({}, { x: { nowMinuteUtc: 570 } })).reasonCodes).toContain(R.X_QUIET_HOURS);
+    expect(decide(x, ctx({}, { x: { nowMinuteUtc: 600 } })).effect).toBe("allow"); // end exclusive
+    expect(decide(x, ctx({}, { x: { nowMinuteUtc: 539 } })).effect).toBe("allow");
+  });
+
+  it("denies inside a midnight-wrapping window (start>end)", () => {
+    const x: XConstraints = { quietHours: { startMinuteUtc: 1380, endMinuteUtc: 360 } }; // 23:00-06:00
+    expect(decide(x, ctx({}, { x: { nowMinuteUtc: 1410 } })).reasonCodes).toContain(
+      R.X_QUIET_HOURS,
+    ); // 23:30
+    expect(decide(x, ctx({}, { x: { nowMinuteUtc: 120 } })).reasonCodes).toContain(R.X_QUIET_HOURS); // 02:00
+    expect(decide(x, ctx({}, { x: { nowMinuteUtc: 720 } })).effect).toBe("allow"); // noon
+  });
+
+  it("fails closed when the now-minute input is unavailable", () => {
+    const x: XConstraints = { quietHours: { startMinuteUtc: 0, endMinuteUtc: 60 } };
+    expect(decide(x, ctx()).reasonCodes).toContain(R.INPUT_UNAVAILABLE);
+  });
+});
+
+// ─── escalation (allow -> approval_required) ────────────────────────────────
+
+describe("permissioned-X: escalation", () => {
+  it("urlPostRequiresApproval escalates a URL post to approval", () => {
+    const x: XConstraints = {
+      contentPolicy: { allowUrls: true },
+      escalation: { urlPostRequiresApproval: true },
+    };
+    expect(decide(x, ctx({ hasUrl: true })).effect).toBe("approval_required");
+    // a plain post under the same rule just allows
+    expect(decide(x, ctx({ hasUrl: false })).effect).toBe("allow");
+  });
+
+  it("spendOverMicros escalates a spend over the soft threshold to approval", () => {
+    const x: XConstraints = {
+      escalation: { spendOverMicrosRequiresApproval: 100_000 },
+    };
+    // url post: 200000 > 100000 => escalate
+    expect(decide(x, ctx({ hasUrl: true }, { x: { accumulatedSpendMicros: 0 } })).effect).toBe(
+      "approval_required",
+    );
+    // plain post: 15000 <= 100000 => allow
+    expect(decide(x, ctx({ hasUrl: false }, { x: { accumulatedSpendMicros: 0 } })).effect).toBe(
+      "allow",
+    );
+  });
+
+  it("a hard deny is NEVER softened into an approval by escalation", () => {
+    // allowUrls=false hard-denies a URL post even though escalation would escalate.
+    const x: XConstraints = {
+      contentPolicy: { allowUrls: false },
+      escalation: { urlPostRequiresApproval: true },
+    };
+    const d = decide(x, ctx({ hasUrl: true }));
+    expect(d.effect).toBe("hard_deny");
+    expect(d.reasonCodes).toContain(R.X_URL_FORBIDDEN);
+  });
+});
+
+// ─── x-block scoping + fail-closed ──────────────────────────────────────────
+
+describe("permissioned-X: scoping + fail-closed", () => {
+  it("an x block on a NON-x operation is a config error (hard_deny)", () => {
+    const rule: ProviderPolicyRule = {
+      id: "r-nonx",
+      type: "capability-intent",
+      enabled: true,
+      config: {
+        capabilities: ["github.pr.comment.create"],
+        effect: "allow",
+        constraints: { x: { replyPolicy: { mode: "none" } } },
+      },
+    };
+    const ghCtx: ProviderPolicyContext = {
+      operationKey: "github.pr.comment.create",
+      args: { isReply: true },
+      method: "POST",
+      host: "api.github.com",
+      path: "/x",
+      invokeCount1h: 0,
+    };
+    const d = composeProviderActionPolicyDecision([rule], ghCtx);
+    expect(d.effect).toBe("hard_deny");
+    expect(d.reasonCodes).toContain(R.CONFIGURATION_INVALID);
+  });
+
+  it("unknown x sub-key fails closed at parse (config invalid)", () => {
+    const rule: ProviderPolicyRule = {
+      id: "r-typo",
+      type: "capability-intent",
+      enabled: true,
+      config: {
+        capabilities: [OP_TWEET],
+        effect: "allow",
+        // @ts-expect-error deliberate typo to prove fail-closed
+        constraints: { x: { replyPolicyy: { mode: "none" } } },
+      },
+    };
+    const d = composeProviderActionPolicyDecision([rule], ctx({ isReply: true }));
+    expect(d.effect).toBe("hard_deny");
+    expect(d.reasonCodes).toContain(R.CONFIGURATION_INVALID);
+  });
+
+  it("evaluateXConstraints returns pass when no X block present", () => {
+    expect(evaluateXConstraints(undefined, ctx()).kind).toBe("pass");
+  });
+
+  it("evaluateXConstraints denies an x block on a non-x op directly", () => {
+    const v = evaluateXConstraints(
+      { replyPolicy: { mode: "none" } },
+      { ...ctx(), operationKey: "github.pr.comment.create" },
+    );
+    expect(v.kind).toBe("deny");
+  });
+});
+
+// ─── deny precedence: X deny wins over a co-matching allow ───────────────────
+
+describe("permissioned-X: composition precedence with X constraints", () => {
+  it("an X hard-deny wins over a separate plain allow rule", () => {
+    const plainAllow: ProviderPolicyRule = {
+      id: "r-plain",
+      type: "capability-intent",
+      enabled: true,
+      config: { capabilities: [OP_TWEET], effect: "allow" },
+    };
+    const urlDeny = allowX({ contentPolicy: { allowUrls: false } }, "r-urldeny");
+    const d = composeProviderActionPolicyDecision([plainAllow, urlDeny], ctx({ hasUrl: true }));
+    expect(d.effect).toBe("hard_deny");
+    expect(d.reasonCodes).toContain(R.X_URL_FORBIDDEN);
+  });
+
+  it("an X escalation + a plain allow => approval (approval outranks allow)", () => {
+    const plainAllow: ProviderPolicyRule = {
+      id: "r-plain",
+      type: "capability-intent",
+      enabled: true,
+      config: { capabilities: [OP_TWEET], effect: "allow" },
+    };
+    const escalate = allowX(
+      { contentPolicy: { allowUrls: true }, escalation: { urlPostRequiresApproval: true } },
+      "r-esc",
+    );
+    const d = composeProviderActionPolicyDecision([plainAllow, escalate], ctx({ hasUrl: true }));
+    expect(d.effect).toBe("approval_required");
+  });
+});

--- a/packages/policy-engine/src/__tests__/permissioned-x.test.ts
+++ b/packages/policy-engine/src/__tests__/permissioned-x.test.ts
@@ -337,6 +337,51 @@ describe("permissioned-X: scoping + fail-closed", () => {
     expect(evaluateXConstraints(undefined, ctx()).kind).toBe("pass");
   });
 
+  // codex P2: a required boolean signal that is ABSENT/non-boolean must fail
+  // closed (POLICY_INPUT_UNAVAILABLE), NOT coerce to false and silently pass.
+  it("allowUrls=false fails closed when the hasUrl signal is absent", () => {
+    const x: XConstraints = { contentPolicy: { allowUrls: false } };
+    const c = ctx();
+    delete (c.args as Record<string, unknown>).hasUrl;
+    const d = decide(x, c);
+    expect(d.effect).toBe("hard_deny");
+    expect(d.reasonCodes).toContain(R.INPUT_UNAVAILABLE);
+  });
+
+  it("allowUrls=false fails closed when hasUrl is a non-boolean", () => {
+    const x: XConstraints = { contentPolicy: { allowUrls: false } };
+    const c = ctx({ hasUrl: "true" as unknown as boolean });
+    expect(decide(x, c).reasonCodes).toContain(R.INPUT_UNAVAILABLE);
+  });
+
+  it("replyPolicy fails closed when the isReply signal is absent", () => {
+    const x: XConstraints = { replyPolicy: { mode: "none" } };
+    const c = ctx();
+    delete (c.args as Record<string, unknown>).isReply;
+    expect(decide(x, c).reasonCodes).toContain(R.INPUT_UNAVAILABLE);
+  });
+
+  it("summoned-only fails closed when the summoned signal is absent on a reply", () => {
+    const x: XConstraints = { replyPolicy: { mode: "summoned-only" } };
+    const c = ctx({ isReply: true });
+    delete (c.args as Record<string, unknown>).summoned;
+    expect(decide(x, c).reasonCodes).toContain(R.INPUT_UNAVAILABLE);
+  });
+
+  it("url escalation fails closed when hasUrl is absent", () => {
+    const x: XConstraints = { escalation: { urlPostRequiresApproval: true } };
+    const c = ctx();
+    delete (c.args as Record<string, unknown>).hasUrl;
+    expect(decide(x, c).reasonCodes).toContain(R.INPUT_UNAVAILABLE);
+  });
+
+  it("spendPolicy fails closed when hasUrl is absent (cannot price the action)", () => {
+    const x: XConstraints = { spendPolicy: { maxSpendMicros: 1_000_000 } };
+    const c = ctx({}, { x: { accumulatedSpendMicros: 0 } });
+    delete (c.args as Record<string, unknown>).hasUrl;
+    expect(decide(x, c).reasonCodes).toContain(R.INPUT_UNAVAILABLE);
+  });
+
   it("evaluateXConstraints denies an x block on a non-x op directly", () => {
     const v = evaluateXConstraints(
       { replyPolicy: { mode: "none" } },

--- a/packages/policy-engine/src/__tests__/permissioned-x.test.ts
+++ b/packages/policy-engine/src/__tests__/permissioned-x.test.ts
@@ -19,9 +19,9 @@ import {
   composeProviderActionPolicyDecision,
   estimateXPostMicros,
   evaluateXConstraints,
-  PROVIDER_POLICY_REASON as R,
   type ProviderPolicyContext,
   type ProviderPolicyRule,
+  PROVIDER_POLICY_REASON as R,
   X_POST_PRICE_TABLE_V1,
   type XConstraints,
 } from "../capability-intent.js";
@@ -138,7 +138,9 @@ describe("permissioned-X: contentPolicy", () => {
   it("blockedPatterns denies a matching text via the in-memory policyText channel", () => {
     // Patterns are standard JS RegExp source (no inline (?i) flag). Author
     // case-insensitivity into the pattern itself.
-    const x: XConstraints = { contentPolicy: { blockedPatterns: ["[Aa][Ii][Rr][Dd][Rr][Oo][Pp]"] } };
+    const x: XConstraints = {
+      contentPolicy: { blockedPatterns: ["[Aa][Ii][Rr][Dd][Rr][Oo][Pp]"] },
+    };
     const c = ctx({}, { policyText: "free AIRDROP now" });
     expect(decide(x, c).reasonCodes).toContain(R.X_CONTENT_BLOCKED);
     const clean = ctx({}, { policyText: "gm friends" });

--- a/packages/policy-engine/src/capability-intent.ts
+++ b/packages/policy-engine/src/capability-intent.ts
@@ -65,8 +65,95 @@ import type { EvaluatorContext } from "./evaluators";
 /** the contributed rule-type discriminator. */
 export const CAPABILITY_INTENT_RULE_TYPE = "capability-intent" as const;
 
+// ─── Permissioned-X: per-post price table (versioned constant) ────────────────
+//
+// SOURCE (captured 2026-07-16, docs.x.com pay-per-use, effective Feb 6 2026):
+//   - a post WITHOUT a URL costs $0.015  => 15000 micro-dollars
+//   - a post WITH a URL     costs $0.20   => 200000 micro-dollars
+// Denominated in micro-dollars (integer-exact; no float spend math). A price
+// change is a reviewable diff to this constant, never silent drift. This is an
+// ESTIMATE table for the spend-cap policy, NOT a billing oracle.
+export const X_POST_PRICE_TABLE_VERSION = "x-post-price.v1" as const;
+export const X_POST_PRICE_TABLE_V1 = {
+  /** plain text post, no URL: $0.015 */
+  plainMicros: 15_000,
+  /** post containing a URL: $0.20 */
+  urlMicros: 200_000,
+} as const;
+
+/** Estimated micro-dollar cost of a single tweet.create action. */
+export function estimateXPostMicros(hasUrl: boolean): number {
+  return hasUrl ? X_POST_PRICE_TABLE_V1.urlMicros : X_POST_PRICE_TABLE_V1.plainMicros;
+}
+
 /** The effect a matching `capability-intent` rule applies. */
 export type CapabilityIntentEffect = "allow" | "deny" | "require-approval";
+
+// ─── Permissioned-X constraint sub-block (X-only) ──────────────────────────
+//
+// This is the instance-level X policy vocabulary X's native OAuth2 scopes cannot
+// express (see docs/security/permissioned-x.mdx). It lives INSIDE
+// capability-intent constraints so X flows through the SAME composer + precedence
+// + persisted decision doc as github — no new rule type, no invented registry.
+// The `x` block is ONLY valid on an `x.*` operation; on a non-X operation it is a
+// config error (fail closed). All sub-fields fail closed.
+
+/** replyPolicy.mode: gate replies independently of original posts. */
+export type XReplyMode = "any" | "summoned-only" | "none";
+
+/** Content conditions on a tweet's text (adapter-derived signals). */
+export interface XContentPolicy {
+  /** false => any post whose text contains a URL is denied (also a spend lever:
+   *  a URL post costs $0.20 vs $0.015). */
+  readonly allowUrls?: boolean;
+  /** deny a post whose adapter-counted code-point length exceeds this. */
+  readonly maxLength?: number;
+  /** anchored regexes; a match on the (in-memory) tweet text denies. An invalid
+   *  regex denies (fail closed). */
+  readonly blockedPatterns?: string[];
+}
+
+/** replyPolicy: gate replies vs originals + the summoned-only precondition. */
+export interface XReplyPolicy {
+  readonly mode: XReplyMode;
+}
+
+/** maxPostsPerWindow: operator-authored count cap over a trailing window. */
+export interface XPostsWindowCap {
+  readonly max: number;
+  readonly windowSeconds: number;
+}
+
+/** spendPolicy: estimated micro-dollar spend ceiling over the price table. */
+export interface XSpendPolicy {
+  readonly maxSpendMicros: number;
+}
+
+/** escalation: conditions that downgrade an allow to approval_required. */
+export interface XEscalationPolicy {
+  /** any URL post routes to human approval even if allowUrls is true. */
+  readonly urlPostRequiresApproval?: boolean;
+  /** estimated spend over this (but under the hard cap) routes to approval. */
+  readonly spendOverMicrosRequiresApproval?: number;
+}
+
+/** quietHours: UTC minute-of-day window in which writes are denied. */
+export interface XQuietHours {
+  /** inclusive start minute-of-day UTC, 0..1439. */
+  readonly startMinuteUtc: number;
+  /** exclusive end minute-of-day UTC, 0..1439. Wrap (start>end) spans midnight. */
+  readonly endMinuteUtc: number;
+}
+
+/** The X-only constraint sub-block. */
+export interface XConstraints {
+  readonly replyPolicy?: XReplyPolicy;
+  readonly contentPolicy?: XContentPolicy;
+  readonly maxPostsPerWindow?: XPostsWindowCap;
+  readonly spendPolicy?: XSpendPolicy;
+  readonly escalation?: XEscalationPolicy;
+  readonly quietHours?: XQuietHours;
+}
 
 /** Constraints evaluated ONLY on an `effect: "allow"` match. */
 export interface CapabilityIntentConstraints {
@@ -89,6 +176,12 @@ export interface CapabilityIntentConstraints {
    * never throws).
    */
   readonly argMatches?: Record<string, string>;
+  /**
+   * X-only instance-level policy sub-block (permissioned X). ONLY valid on an
+   * `x.*` operation — present on a non-X operation => config error (fail closed).
+   * See {@link XConstraints} + docs/security/permissioned-x.mdx.
+   */
+  readonly x?: XConstraints;
 }
 
 /** The jsonb config of a `capability-intent` rule. */
@@ -188,7 +281,202 @@ const ALLOWED_CONSTRAINT_KEYS: ReadonlySet<string> = new Set([
   "maxCallsPerHour",
   "argEquals",
   "argMatches",
+  "x",
 ]);
+
+// Permissioned-X allowed keys (fail closed on any typo).
+const ALLOWED_X_KEYS: ReadonlySet<string> = new Set([
+  "replyPolicy",
+  "contentPolicy",
+  "maxPostsPerWindow",
+  "spendPolicy",
+  "escalation",
+  "quietHours",
+]);
+const ALLOWED_REPLY_KEYS: ReadonlySet<string> = new Set(["mode"]);
+const ALLOWED_CONTENT_KEYS: ReadonlySet<string> = new Set([
+  "allowUrls",
+  "maxLength",
+  "blockedPatterns",
+]);
+const ALLOWED_WINDOW_KEYS: ReadonlySet<string> = new Set(["max", "windowSeconds"]);
+const ALLOWED_SPEND_KEYS: ReadonlySet<string> = new Set(["maxSpendMicros"]);
+const ALLOWED_ESCALATION_KEYS: ReadonlySet<string> = new Set([
+  "urlPostRequiresApproval",
+  "spendOverMicrosRequiresApproval",
+]);
+const ALLOWED_QUIET_KEYS: ReadonlySet<string> = new Set(["startMinuteUtc", "endMinuteUtc"]);
+const X_REPLY_MODES: ReadonlySet<string> = new Set(["any", "summoned-only", "none"]);
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function isNonNegInt(v: unknown): v is number {
+  return typeof v === "number" && Number.isFinite(v) && Number.isInteger(v) && v >= 0;
+}
+
+function isPosInt(v: unknown): v is number {
+  return typeof v === "number" && Number.isFinite(v) && Number.isInteger(v) && v > 0;
+}
+
+function isMinuteOfDay(v: unknown): v is number {
+  return typeof v === "number" && Number.isInteger(v) && v >= 0 && v <= 1439;
+}
+
+/**
+ * Validate the X constraint sub-block. FAIL CLOSED: any unknown key, wrong type,
+ * or out-of-range value returns an error string (the caller hard-denies). Returns
+ * a typed {@link XConstraints} on success.
+ */
+function parseXConstraints(rawInput: unknown): XConstraints | { error: string } {
+  if (!isPlainObject(rawInput)) {
+    return { error: "capability-intent: `constraints.x` must be an object" };
+  }
+  const unknown = Object.keys(rawInput).filter((k) => !ALLOWED_X_KEYS.has(k));
+  if (unknown.length > 0) {
+    return { error: `capability-intent: unknown constraints.x key(s): ${unknown.join(", ")}` };
+  }
+
+  const out: {
+    replyPolicy?: XReplyPolicy;
+    contentPolicy?: XContentPolicy;
+    maxPostsPerWindow?: XPostsWindowCap;
+    spendPolicy?: XSpendPolicy;
+    escalation?: XEscalationPolicy;
+    quietHours?: XQuietHours;
+  } = {};
+
+  // replyPolicy
+  if (rawInput.replyPolicy !== undefined) {
+    const rp = rawInput.replyPolicy;
+    if (!isPlainObject(rp)) return { error: "capability-intent: `x.replyPolicy` must be an object" };
+    const u = Object.keys(rp).filter((k) => !ALLOWED_REPLY_KEYS.has(k));
+    if (u.length > 0)
+      return { error: `capability-intent: unknown x.replyPolicy key(s): ${u.join(", ")}` };
+    if (typeof rp.mode !== "string" || !X_REPLY_MODES.has(rp.mode))
+      return {
+        error: 'capability-intent: `x.replyPolicy.mode` must be "any"|"summoned-only"|"none"',
+      };
+    out.replyPolicy = { mode: rp.mode as XReplyMode };
+  }
+
+  // contentPolicy
+  if (rawInput.contentPolicy !== undefined) {
+    const cp = rawInput.contentPolicy;
+    if (!isPlainObject(cp))
+      return { error: "capability-intent: `x.contentPolicy` must be an object" };
+    const u = Object.keys(cp).filter((k) => !ALLOWED_CONTENT_KEYS.has(k));
+    if (u.length > 0)
+      return { error: `capability-intent: unknown x.contentPolicy key(s): ${u.join(", ")}` };
+    const content: { allowUrls?: boolean; maxLength?: number; blockedPatterns?: string[] } = {};
+    if (cp.allowUrls !== undefined) {
+      if (typeof cp.allowUrls !== "boolean")
+        return { error: "capability-intent: `x.contentPolicy.allowUrls` must be a boolean" };
+      content.allowUrls = cp.allowUrls;
+    }
+    if (cp.maxLength !== undefined) {
+      if (!isPosInt(cp.maxLength))
+        return {
+          error: "capability-intent: `x.contentPolicy.maxLength` must be a positive integer",
+        };
+      content.maxLength = cp.maxLength;
+    }
+    if (cp.blockedPatterns !== undefined) {
+      if (
+        !Array.isArray(cp.blockedPatterns) ||
+        !cp.blockedPatterns.every((p) => typeof p === "string" && p.length > 0)
+      )
+        return {
+          error:
+            "capability-intent: `x.contentPolicy.blockedPatterns` must be a non-empty string[] of non-empty strings",
+        };
+      content.blockedPatterns = cp.blockedPatterns as string[];
+    }
+    out.contentPolicy = content;
+  }
+
+  // maxPostsPerWindow
+  if (rawInput.maxPostsPerWindow !== undefined) {
+    const w = rawInput.maxPostsPerWindow;
+    if (!isPlainObject(w))
+      return { error: "capability-intent: `x.maxPostsPerWindow` must be an object" };
+    const u = Object.keys(w).filter((k) => !ALLOWED_WINDOW_KEYS.has(k));
+    if (u.length > 0)
+      return { error: `capability-intent: unknown x.maxPostsPerWindow key(s): ${u.join(", ")}` };
+    if (!isNonNegInt(w.max))
+      return {
+        error: "capability-intent: `x.maxPostsPerWindow.max` must be a non-negative integer",
+      };
+    if (!isPosInt(w.windowSeconds))
+      return {
+        error: "capability-intent: `x.maxPostsPerWindow.windowSeconds` must be a positive integer",
+      };
+    out.maxPostsPerWindow = { max: w.max, windowSeconds: w.windowSeconds };
+  }
+
+  // spendPolicy
+  if (rawInput.spendPolicy !== undefined) {
+    const s = rawInput.spendPolicy;
+    if (!isPlainObject(s)) return { error: "capability-intent: `x.spendPolicy` must be an object" };
+    const u = Object.keys(s).filter((k) => !ALLOWED_SPEND_KEYS.has(k));
+    if (u.length > 0)
+      return { error: `capability-intent: unknown x.spendPolicy key(s): ${u.join(", ")}` };
+    if (!isNonNegInt(s.maxSpendMicros))
+      return {
+        error: "capability-intent: `x.spendPolicy.maxSpendMicros` must be a non-negative integer",
+      };
+    out.spendPolicy = { maxSpendMicros: s.maxSpendMicros };
+  }
+
+  // escalation
+  if (rawInput.escalation !== undefined) {
+    const e = rawInput.escalation;
+    if (!isPlainObject(e)) return { error: "capability-intent: `x.escalation` must be an object" };
+    const u = Object.keys(e).filter((k) => !ALLOWED_ESCALATION_KEYS.has(k));
+    if (u.length > 0)
+      return { error: `capability-intent: unknown x.escalation key(s): ${u.join(", ")}` };
+    const esc: { urlPostRequiresApproval?: boolean; spendOverMicrosRequiresApproval?: number } = {};
+    if (e.urlPostRequiresApproval !== undefined) {
+      if (typeof e.urlPostRequiresApproval !== "boolean")
+        return {
+          error: "capability-intent: `x.escalation.urlPostRequiresApproval` must be a boolean",
+        };
+      esc.urlPostRequiresApproval = e.urlPostRequiresApproval;
+    }
+    if (e.spendOverMicrosRequiresApproval !== undefined) {
+      if (!isNonNegInt(e.spendOverMicrosRequiresApproval))
+        return {
+          error:
+            "capability-intent: `x.escalation.spendOverMicrosRequiresApproval` must be a non-negative integer",
+        };
+      esc.spendOverMicrosRequiresApproval = e.spendOverMicrosRequiresApproval;
+    }
+    out.escalation = esc;
+  }
+
+  // quietHours
+  if (rawInput.quietHours !== undefined) {
+    const q = rawInput.quietHours;
+    if (!isPlainObject(q)) return { error: "capability-intent: `x.quietHours` must be an object" };
+    const u = Object.keys(q).filter((k) => !ALLOWED_QUIET_KEYS.has(k));
+    if (u.length > 0)
+      return { error: `capability-intent: unknown x.quietHours key(s): ${u.join(", ")}` };
+    if (!isMinuteOfDay(q.startMinuteUtc) || !isMinuteOfDay(q.endMinuteUtc))
+      return {
+        error:
+          "capability-intent: `x.quietHours.startMinuteUtc`/`endMinuteUtc` must be integers 0..1439",
+      };
+    if (q.startMinuteUtc === q.endMinuteUtc)
+      return {
+        error:
+          "capability-intent: `x.quietHours` start and end must differ (empty/full window is ambiguous)",
+      };
+    out.quietHours = { startMinuteUtc: q.startMinuteUtc, endMinuteUtc: q.endMinuteUtc };
+  }
+
+  return out;
+}
 
 function parseConfig(rawInput: unknown): CapabilityIntentConfig | { error: string } {
   // FAIL CLOSED on a non-object config. `rule.config` is opaque jsonb and can be
@@ -285,10 +573,18 @@ function parseConfig(rawInput: unknown): CapabilityIntentConfig | { error: strin
       return { error: "capability-intent: `constraints.argMatches` must be Record<string,string>" };
     }
 
+    let xConstraints: XConstraints | undefined;
+    if (c.x !== undefined) {
+      const parsedX = parseXConstraints(c.x);
+      if ("error" in parsedX) return { error: parsedX.error };
+      xConstraints = parsedX;
+    }
+
     constraints = {
       ...(c.maxCallsPerHour !== undefined ? { maxCallsPerHour: c.maxCallsPerHour as number } : {}),
       ...(c.argEquals !== undefined ? { argEquals: c.argEquals as Record<string, string> } : {}),
       ...(c.argMatches !== undefined ? { argMatches: c.argMatches as Record<string, string> } : {}),
+      ...(xConstraints !== undefined ? { x: xConstraints } : {}),
     };
   }
 
@@ -668,6 +964,15 @@ export const PROVIDER_POLICY_REASON = {
   CONFIGURATION_INVALID: "POLICY_CONFIGURATION_INVALID",
   INPUT_UNAVAILABLE: "POLICY_INPUT_UNAVAILABLE",
   EVALUATOR_ERROR: "POLICY_EVALUATOR_ERROR",
+  // Permissioned-X reason codes (see docs/security/permissioned-x.mdx).
+  X_REPLY_NOT_SUMMONED: "POLICY_X_REPLY_NOT_SUMMONED",
+  X_REPLY_FORBIDDEN: "POLICY_X_REPLY_FORBIDDEN",
+  X_URL_FORBIDDEN: "POLICY_X_URL_FORBIDDEN",
+  X_CONTENT_TOO_LONG: "POLICY_X_CONTENT_TOO_LONG",
+  X_CONTENT_BLOCKED: "POLICY_X_CONTENT_BLOCKED",
+  X_RATE_CAP_EXCEEDED: "POLICY_X_RATE_CAP_EXCEEDED",
+  X_SPEND_CAP_EXCEEDED: "POLICY_X_SPEND_CAP_EXCEEDED",
+  X_QUIET_HOURS: "POLICY_X_QUIET_HOURS",
 } as const;
 
 export type ProviderPolicyEffect = "hard_deny" | "approval_required" | "allow";
@@ -685,6 +990,29 @@ export interface ProviderPolicyContext {
   /** Authoritative trailing-hour invoke count. `undefined` => input
    *  unavailable => fail closed (hard_deny, POLICY_INPUT_UNAVAILABLE). */
   readonly invokeCount1h?: number;
+  /**
+   * IN-MEMORY-ONLY tweet text for `contentPolicy.blockedPatterns` matching.
+   * Deliberately NOT part of {@link args} (which is validated scalars only) and
+   * NEVER persisted. `undefined` for non-text operations; a blockedPatterns rule
+   * then fails closed (POLICY_INPUT_UNAVAILABLE). See
+   * docs/security/permissioned-x.mdx "Text availability".
+   */
+  readonly policyText?: string;
+  /**
+   * Permissioned-X authoritative inputs. Each is `undefined` when unwired; a
+   * policy that REQUIRES the input then fails closed (POLICY_INPUT_UNAVAILABLE).
+   * Steward never borrows a different counter or silently passes.
+   */
+  readonly x?: {
+    /** authoritative count of posts already made in the policy's trailing
+     *  window (used by maxPostsPerWindow). */
+    readonly postsInWindow?: number;
+    /** authoritative accumulated estimated micro-dollar spend in the window
+     *  (used by spendPolicy; the current action's cost is added on top). */
+    readonly accumulatedSpendMicros?: number;
+    /** authoritative current minute-of-day UTC, 0..1439 (used by quietHours). */
+    readonly nowMinuteUtc?: number;
+  };
 }
 
 export interface ProviderPolicyRuleResult {
@@ -803,12 +1131,28 @@ export function composeProviderActionPolicyDecision(
 
       // effect === allow: evaluate its hard constraints. A FAILED hard
       // constraint is a hard deny (a rate cap / arg gate is not negotiable via
-      // approval).
+      // approval). A permissioned-X ESCALATION downgrades the allow to an
+      // approval (never softens a deny).
       const denial = evaluateProviderConstraints(parsed.constraints, context);
       if (denial) {
         sawHardDeny = true;
         reasonCodes.add(denial);
         results.push(mkResult(rule.id, "allow", "hard_deny", denial));
+        continue;
+      }
+      const xVerdict = evaluateXConstraints(parsed.constraints?.x, context);
+      if (xVerdict.kind === "deny") {
+        sawHardDeny = true;
+        reasonCodes.add(xVerdict.reasonCode);
+        results.push(mkResult(rule.id, "allow", "hard_deny", xVerdict.reasonCode));
+        continue;
+      }
+      if (xVerdict.kind === "escalate") {
+        sawApproval = true;
+        reasonCodes.add(PROVIDER_POLICY_REASON.APPROVAL_REQUIRED);
+        results.push(
+          mkResult(rule.id, "allow", "approval_required", PROVIDER_POLICY_REASON.APPROVAL_REQUIRED),
+        );
         continue;
       }
       sawPassingAllow = true;
@@ -888,4 +1232,159 @@ function evaluateProviderConstraints(
     if (count >= constraints.maxCallsPerHour) return PROVIDER_POLICY_REASON.HARD_DENY;
   }
   return null;
+}
+
+// ─── Permissioned-X evaluation ──────────────────────────────────────────
+
+export type XConstraintVerdict =
+  | { kind: "pass" }
+  | { kind: "deny"; reasonCode: string }
+  | { kind: "escalate" };
+
+/** True for a boolean-typed policy arg that is strictly `true`. */
+function argIsTrue(args: Record<string, unknown>, key: string): boolean {
+  return args[key] === true;
+}
+
+/**
+ * Evaluate the permissioned-X constraint sub-block against the provider-policy
+ * context. Returns:
+ *   - { kind: "deny", reasonCode }  on the FIRST hard failure (deny wins),
+ *   - { kind: "escalate" }          when no deny but an escalation condition holds,
+ *   - { kind: "pass" }              when the X block is absent or fully satisfied.
+ *
+ * FAIL CLOSED everywhere: an `x` block on a NON-X operation denies; an
+ * unavailable required input denies; an unexpected content shape denies. Deny is
+ * evaluated BEFORE escalation so a hard deny can never be softened to approval.
+ */
+export function evaluateXConstraints(
+  x: XConstraints | undefined,
+  ctx: ProviderPolicyContext,
+): XConstraintVerdict {
+  if (!x) return { kind: "pass" };
+
+  // An X policy block only applies to x.* operations. On any other operation it
+  // is a configuration error (fail closed) — we never silently ignore it.
+  if (!ctx.operationKey.startsWith("x.")) {
+    return { kind: "deny", reasonCode: PROVIDER_POLICY_REASON.CONFIGURATION_INVALID };
+  }
+
+  const { args } = ctx;
+  const isReply = argIsTrue(args, "isReply");
+  const summoned = argIsTrue(args, "summoned");
+  const hasUrl = argIsTrue(args, "hasUrl");
+
+  // ── replyPolicy ──
+  if (x.replyPolicy) {
+    if (isReply) {
+      if (x.replyPolicy.mode === "none") {
+        return { kind: "deny", reasonCode: PROVIDER_POLICY_REASON.X_REPLY_FORBIDDEN };
+      }
+      if (x.replyPolicy.mode === "summoned-only" && !summoned) {
+        // The Feb-2026 anti-spam upstream-denial class, modeled locally: an
+        // un-summoned programmatic reply would 403 at the wire, so we deny it
+        // BEFORE the wasted billed call.
+        return { kind: "deny", reasonCode: PROVIDER_POLICY_REASON.X_REPLY_NOT_SUMMONED };
+      }
+      // mode === "any": allowed to proceed (operator accepts upstream risk).
+    }
+    // Not a reply: replyPolicy is inert (it only gates replies).
+  }
+
+  // ── contentPolicy ──
+  if (x.contentPolicy) {
+    if (x.contentPolicy.allowUrls === false && hasUrl) {
+      return { kind: "deny", reasonCode: PROVIDER_POLICY_REASON.X_URL_FORBIDDEN };
+    }
+    if (x.contentPolicy.maxLength !== undefined) {
+      const len = args.textCodePointLength;
+      // A content-length policy REQUIRES the length signal. Absent => fail closed.
+      if (typeof len !== "number" || !Number.isInteger(len)) {
+        return { kind: "deny", reasonCode: PROVIDER_POLICY_REASON.INPUT_UNAVAILABLE };
+      }
+      if (len > x.contentPolicy.maxLength) {
+        return { kind: "deny", reasonCode: PROVIDER_POLICY_REASON.X_CONTENT_TOO_LONG };
+      }
+    }
+    if (x.contentPolicy.blockedPatterns && x.contentPolicy.blockedPatterns.length > 0) {
+      const text = ctx.policyText;
+      // Pattern matching REQUIRES the in-memory text channel. Absent/non-string
+      // => fail closed (we cannot prove the content is clean).
+      if (typeof text !== "string") {
+        return { kind: "deny", reasonCode: PROVIDER_POLICY_REASON.INPUT_UNAVAILABLE };
+      }
+      for (const pattern of x.contentPolicy.blockedPatterns) {
+        let re: RegExp;
+        try {
+          re = new RegExp(pattern);
+        } catch {
+          // Invalid regex in config => fail closed (never throw).
+          return { kind: "deny", reasonCode: PROVIDER_POLICY_REASON.CONFIGURATION_INVALID };
+        }
+        if (re.test(text)) {
+          return { kind: "deny", reasonCode: PROVIDER_POLICY_REASON.X_CONTENT_BLOCKED };
+        }
+      }
+    }
+  }
+
+  // ── quietHours ── (gates writes; reads never carry it in practice)
+  if (x.quietHours) {
+    const now = ctx.x?.nowMinuteUtc;
+    if (typeof now !== "number" || !Number.isInteger(now)) {
+      return { kind: "deny", reasonCode: PROVIDER_POLICY_REASON.INPUT_UNAVAILABLE };
+    }
+    const { startMinuteUtc: start, endMinuteUtc: end } = x.quietHours;
+    // Non-wrapping window [start, end); wrapping window (start > end) spans
+    // midnight so the quiet region is [start, 1440) ∪ [0, end).
+    const inWindow =
+      start < end ? now >= start && now < end : now >= start || now < end;
+    if (inWindow) {
+      return { kind: "deny", reasonCode: PROVIDER_POLICY_REASON.X_QUIET_HOURS };
+    }
+  }
+
+  // ── maxPostsPerWindow ──
+  if (x.maxPostsPerWindow) {
+    const posts = ctx.x?.postsInWindow;
+    if (typeof posts !== "number" || !Number.isFinite(posts)) {
+      return { kind: "deny", reasonCode: PROVIDER_POLICY_REASON.INPUT_UNAVAILABLE };
+    }
+    if (posts >= x.maxPostsPerWindow.max) {
+      return { kind: "deny", reasonCode: PROVIDER_POLICY_REASON.X_RATE_CAP_EXCEEDED };
+    }
+  }
+
+  // ── spendPolicy (hard cap over estimated spend) ──
+  // Estimated spend = accumulated window spend + this action's price.
+  const thisActionMicros = estimateXPostMicros(hasUrl);
+  let projectedMicros: number | undefined;
+  if (x.spendPolicy || x.escalation?.spendOverMicrosRequiresApproval !== undefined) {
+    const accumulated = ctx.x?.accumulatedSpendMicros;
+    if (typeof accumulated !== "number" || !Number.isFinite(accumulated)) {
+      return { kind: "deny", reasonCode: PROVIDER_POLICY_REASON.INPUT_UNAVAILABLE };
+    }
+    projectedMicros = accumulated + thisActionMicros;
+  }
+  if (x.spendPolicy && projectedMicros !== undefined) {
+    if (projectedMicros > x.spendPolicy.maxSpendMicros) {
+      return { kind: "deny", reasonCode: PROVIDER_POLICY_REASON.X_SPEND_CAP_EXCEEDED };
+    }
+  }
+
+  // ── escalation (only reached when NO hard deny fired) ──
+  if (x.escalation) {
+    if (x.escalation.urlPostRequiresApproval === true && hasUrl) {
+      return { kind: "escalate" };
+    }
+    if (
+      x.escalation.spendOverMicrosRequiresApproval !== undefined &&
+      projectedMicros !== undefined &&
+      projectedMicros > x.escalation.spendOverMicrosRequiresApproval
+    ) {
+      return { kind: "escalate" };
+    }
+  }
+
+  return { kind: "pass" };
 }

--- a/packages/policy-engine/src/capability-intent.ts
+++ b/packages/policy-engine/src/capability-intent.ts
@@ -350,7 +350,8 @@ function parseXConstraints(rawInput: unknown): XConstraints | { error: string } 
   // replyPolicy
   if (rawInput.replyPolicy !== undefined) {
     const rp = rawInput.replyPolicy;
-    if (!isPlainObject(rp)) return { error: "capability-intent: `x.replyPolicy` must be an object" };
+    if (!isPlainObject(rp))
+      return { error: "capability-intent: `x.replyPolicy` must be an object" };
     const u = Object.keys(rp).filter((k) => !ALLOWED_REPLY_KEYS.has(k));
     if (u.length > 0)
       return { error: `capability-intent: unknown x.replyPolicy key(s): ${u.join(", ")}` };
@@ -1337,8 +1338,7 @@ export function evaluateXConstraints(
     const { startMinuteUtc: start, endMinuteUtc: end } = x.quietHours;
     // Non-wrapping window [start, end); wrapping window (start > end) spans
     // midnight so the quiet region is [start, 1440) ∪ [0, end).
-    const inWindow =
-      start < end ? now >= start && now < end : now >= start || now < end;
+    const inWindow = start < end ? now >= start && now < end : now >= start || now < end;
     if (inWindow) {
       return { kind: "deny", reasonCode: PROVIDER_POLICY_REASON.X_QUIET_HOURS };
     }

--- a/packages/policy-engine/src/capability-intent.ts
+++ b/packages/policy-engine/src/capability-intent.ts
@@ -1242,9 +1242,18 @@ export type XConstraintVerdict =
   | { kind: "deny"; reasonCode: string }
   | { kind: "escalate" };
 
-/** True for a boolean-typed policy arg that is strictly `true`. */
-function argIsTrue(args: Record<string, unknown>, key: string): boolean {
-  return args[key] === true;
+/**
+ * Read a REQUIRED boolean policy arg. Returns the boolean value, or `undefined`
+ * when the arg is absent or not a boolean. A permissioned-X policy that DEPENDS
+ * on this signal must fail closed (POLICY_INPUT_UNAVAILABLE) on `undefined` — we
+ * NEVER coerce a missing/mistyped signal to `false`, because that would let a
+ * URL/reply gate silently pass on an operation whose build doesn't carry the
+ * signal (e.g. x.tweet.delete / x.user.me.read, or a malformed context). This is
+ * the content-shape fail-closed contract (codex P2, PR review).
+ */
+function readBool(args: Record<string, unknown>, key: string): boolean | undefined {
+  const v = args[key];
+  return typeof v === "boolean" ? v : undefined;
 }
 
 /**
@@ -1271,21 +1280,31 @@ export function evaluateXConstraints(
   }
 
   const { args } = ctx;
-  const isReply = argIsTrue(args, "isReply");
-  const summoned = argIsTrue(args, "summoned");
-  const hasUrl = argIsTrue(args, "hasUrl");
 
   // ── replyPolicy ──
+  // A replyPolicy DEPENDS on the `isReply` signal; absent/non-boolean => fail
+  // closed (an operation whose build doesn't carry isReply must NOT slip a reply
+  // gate). `summoned` is only required when we actually reach the summoned check.
   if (x.replyPolicy) {
+    const isReply = readBool(args, "isReply");
+    if (isReply === undefined) {
+      return { kind: "deny", reasonCode: PROVIDER_POLICY_REASON.INPUT_UNAVAILABLE };
+    }
     if (isReply) {
       if (x.replyPolicy.mode === "none") {
         return { kind: "deny", reasonCode: PROVIDER_POLICY_REASON.X_REPLY_FORBIDDEN };
       }
-      if (x.replyPolicy.mode === "summoned-only" && !summoned) {
-        // The Feb-2026 anti-spam upstream-denial class, modeled locally: an
-        // un-summoned programmatic reply would 403 at the wire, so we deny it
-        // BEFORE the wasted billed call.
-        return { kind: "deny", reasonCode: PROVIDER_POLICY_REASON.X_REPLY_NOT_SUMMONED };
+      if (x.replyPolicy.mode === "summoned-only") {
+        const summoned = readBool(args, "summoned");
+        if (summoned === undefined) {
+          return { kind: "deny", reasonCode: PROVIDER_POLICY_REASON.INPUT_UNAVAILABLE };
+        }
+        if (!summoned) {
+          // The Feb-2026 anti-spam upstream-denial class, modeled locally: an
+          // un-summoned programmatic reply would 403 at the wire, so we deny it
+          // BEFORE the wasted billed call.
+          return { kind: "deny", reasonCode: PROVIDER_POLICY_REASON.X_REPLY_NOT_SUMMONED };
+        }
       }
       // mode === "any": allowed to proceed (operator accepts upstream risk).
     }
@@ -1294,8 +1313,15 @@ export function evaluateXConstraints(
 
   // ── contentPolicy ──
   if (x.contentPolicy) {
-    if (x.contentPolicy.allowUrls === false && hasUrl) {
-      return { kind: "deny", reasonCode: PROVIDER_POLICY_REASON.X_URL_FORBIDDEN };
+    // allowUrls DEPENDS on the `hasUrl` signal; absent/non-boolean => fail closed.
+    if (x.contentPolicy.allowUrls === false) {
+      const hasUrl = readBool(args, "hasUrl");
+      if (hasUrl === undefined) {
+        return { kind: "deny", reasonCode: PROVIDER_POLICY_REASON.INPUT_UNAVAILABLE };
+      }
+      if (hasUrl) {
+        return { kind: "deny", reasonCode: PROVIDER_POLICY_REASON.X_URL_FORBIDDEN };
+      }
     }
     if (x.contentPolicy.maxLength !== undefined) {
       const len = args.textCodePointLength;
@@ -1355,16 +1381,30 @@ export function evaluateXConstraints(
     }
   }
 
+  // Any spend/URL-escalation policy DEPENDS on the `hasUrl` signal to price the
+  // action; absent/non-boolean => fail closed for those policies only.
+  const needsHasUrl =
+    x.spendPolicy !== undefined ||
+    x.escalation?.spendOverMicrosRequiresApproval !== undefined ||
+    x.escalation?.urlPostRequiresApproval === true;
+  let hasUrl: boolean | undefined;
+  if (needsHasUrl) {
+    hasUrl = readBool(args, "hasUrl");
+    if (hasUrl === undefined) {
+      return { kind: "deny", reasonCode: PROVIDER_POLICY_REASON.INPUT_UNAVAILABLE };
+    }
+  }
+
   // ── spendPolicy (hard cap over estimated spend) ──
   // Estimated spend = accumulated window spend + this action's price.
-  const thisActionMicros = estimateXPostMicros(hasUrl);
   let projectedMicros: number | undefined;
   if (x.spendPolicy || x.escalation?.spendOverMicrosRequiresApproval !== undefined) {
     const accumulated = ctx.x?.accumulatedSpendMicros;
     if (typeof accumulated !== "number" || !Number.isFinite(accumulated)) {
       return { kind: "deny", reasonCode: PROVIDER_POLICY_REASON.INPUT_UNAVAILABLE };
     }
-    projectedMicros = accumulated + thisActionMicros;
+    // hasUrl is guaranteed defined here (needsHasUrl covers both branches).
+    projectedMicros = accumulated + estimateXPostMicros(hasUrl === true);
   }
   if (x.spendPolicy && projectedMicros !== undefined) {
     if (projectedMicros > x.spendPolicy.maxSpendMicros) {
@@ -1374,7 +1414,7 @@ export function evaluateXConstraints(
 
   // ── escalation (only reached when NO hard deny fired) ──
   if (x.escalation) {
-    if (x.escalation.urlPostRequiresApproval === true && hasUrl) {
+    if (x.escalation.urlPostRequiresApproval === true && hasUrl === true) {
       return { kind: "escalate" };
     }
     if (

--- a/packages/policy-engine/src/index.ts
+++ b/packages/policy-engine/src/index.ts
@@ -9,14 +9,27 @@ export type {
   ProviderPolicyEvaluationV1,
   ProviderPolicyRule,
   ProviderPolicyRuleResult,
+  XConstraints,
+  XConstraintVerdict,
+  XContentPolicy,
+  XEscalationPolicy,
+  XPostsWindowCap,
+  XQuietHours,
+  XReplyMode,
+  XReplyPolicy,
+  XSpendPolicy,
 } from "./capability-intent";
 export {
   CAPABILITY_INTENT_RULE_TYPE,
   capabilityIntentContribution,
   composeCapabilityIntentDecision,
   composeProviderActionPolicyDecision,
+  estimateXPostMicros,
   evaluateCapabilityIntent,
+  evaluateXConstraints,
   PROVIDER_POLICY_REASON,
+  X_POST_PRICE_TABLE_V1,
+  X_POST_PRICE_TABLE_VERSION,
 } from "./capability-intent";
 export type {
   AuditHook,

--- a/packages/provider-x/src/__tests__/operations.test.ts
+++ b/packages/provider-x/src/__tests__/operations.test.ts
@@ -147,11 +147,59 @@ describe("x.tweet.create", () => {
     const b = buildXAction("x.tweet.create", { text: "hello", replyToTweetId: "9" });
     expect(b.policyArgs).toEqual({
       isReply: true,
+      hasUrl: false,
+      summoned: false,
       textCodePointLength: 5,
       textByteLength: 5,
       replyToTweetId: "9",
     });
+    // policyArgs is scalar/boolean only — NEVER the raw tweet text.
     expect(JSON.stringify(b.policyArgs)).not.toContain("hello");
+    // The raw text lives ONLY on the separate, non-persisted policyText channel.
+    expect(b.policyText).toBe("hello");
+  });
+
+  it("derives hasUrl (content + spend signal) and summoned policy args", () => {
+    const plain = buildXAction("x.tweet.create", { text: "gm frens" });
+    expect(plain.policyArgs.hasUrl).toBe(false);
+    expect(plain.policyArgs.summoned).toBe(false);
+
+    const withUrl = buildXAction("x.tweet.create", { text: "check https://example.com/x" });
+    expect(withUrl.policyArgs.hasUrl).toBe(true);
+    expect(withUrl.safeSummary.hasUrl).toBe(true);
+
+    const bareHost = buildXAction("x.tweet.create", { text: "see example.com for more" });
+    expect(bareHost.policyArgs.hasUrl).toBe(true);
+
+    const bareWww = buildXAction("x.tweet.create", { text: "visit www.foo.io today" });
+    expect(bareWww.policyArgs.hasUrl).toBe(true);
+
+    // prose with a period must NOT be misread as a URL
+    const prose = buildXAction("x.tweet.create", { text: "i.e. this is fine. really." });
+    expect(prose.policyArgs.hasUrl).toBe(false);
+
+    const summoned = buildXAction("x.tweet.create", {
+      text: "thanks!",
+      replyToTweetId: "9",
+      summoned: true,
+    });
+    expect(summoned.policyArgs.summoned).toBe(true);
+    expect(summoned.policyArgs.isReply).toBe(true);
+  });
+
+  it("rejects a non-boolean summoned arg (fail closed on type)", () => {
+    expectCanon(
+      () => buildXAction("x.tweet.create", { text: "hi", summoned: "yes" }),
+      "CANON_FIELD_TYPE_INVALID",
+    );
+  });
+
+  it("safe_summary carries hasUrl + summoned booleans but no text slice", () => {
+    const b = buildXAction("x.tweet.create", { text: "launch https://waifu.fun now" });
+    expect(b.safeSummary.hasUrl).toBe(true);
+    expect(b.safeSummary.summoned).toBe(false);
+    expect(JSON.stringify(b.safeSummary)).not.toContain("waifu");
+    expect("policyText" in b.safeSummary).toBe(false);
   });
 
   it("rejects empty/whitespace-only, unknown fields, missing required, bad types", () => {

--- a/packages/provider-x/src/__tests__/operations.test.ts
+++ b/packages/provider-x/src/__tests__/operations.test.ts
@@ -178,6 +178,20 @@ describe("x.tweet.create", () => {
     const prose = buildXAction("x.tweet.create", { text: "i.e. this is fine. really." });
     expect(prose.policyArgs.hasUrl).toBe(false);
 
+    // over-detection: a bare domain on an UNCOMMON tld must still be a URL, so a
+    // no-URL / URL-spend policy cannot be bypassed (codex P2 review fix).
+    for (const t of [
+      "visit example.social now",
+      "check foo.shop today",
+      "join my.community here",
+    ]) {
+      expect(buildXAction("x.tweet.create", { text: t }).policyArgs.hasUrl).toBe(true);
+    }
+    // common English abbreviations with a single-letter right side stay non-URL.
+    for (const t of ["e.g. this", "meet at 5 p.m. sharp", "the u.s. economy"]) {
+      expect(buildXAction("x.tweet.create", { text: t }).policyArgs.hasUrl).toBe(false);
+    }
+
     const summoned = buildXAction("x.tweet.create", {
       text: "thanks!",
       replyToTweetId: "9",

--- a/packages/provider-x/src/operations.ts
+++ b/packages/provider-x/src/operations.ts
@@ -61,6 +61,16 @@ export interface XActionBuild {
   safeSummary: Record<string, unknown>;
   /** Validated arguments a provider policy may read. Never raw JSON. */
   policyArgs: Record<string, unknown>;
+  /**
+   * IN-MEMORY-ONLY text channel for content-pattern policy matching
+   * (`contentPolicy.blockedPatterns`). Present ONLY for text-bearing operations
+   * (x.tweet.create). It is DELIBERATELY separate from {@link policyArgs} so the
+   * "policyArgs = validated scalars, never raw text" contract holds: the composer
+   * reads `policyText` during evaluation and it is NEVER persisted to the
+   * decision doc, the safe-summary, or the audit event. See
+   * docs/security/permissioned-x.mdx "Text availability".
+   */
+  policyText?: string;
 }
 
 const JSON_CONTENT_TYPE = "application/json";
@@ -121,6 +131,48 @@ function assertNoLoneSurrogate(v: string, label: string): void {
 }
 
 /**
+ * Detect whether tweet text contains a URL. Used ONLY to derive the `hasUrl`
+ * policy arg (which is BOTH a content signal and a spend signal: a URL post
+ * costs $0.20 vs $0.015 for a plain post — see docs/security/permissioned-x.mdx
+ * and X_POST_PRICE_TABLE_V1). This is deliberately BROADER-or-equal to X's own
+ * t.co URL detection: we match `scheme://` URLs, bare `www.` hosts, and bare
+ * `host.tld` / `host.tld/path` forms. Over-detection is the SAFE direction for a
+ * no-URL policy (a false positive denies a borderline post; a false negative
+ * would let an expensive/forbidden URL through). It is a policy signal only — it
+ * never alters the tweet body or the canonical action digest.
+ *
+ * The detection is intentionally simple + deterministic (re-derivable offline).
+ * It does NOT attempt X's exact weighted URL model.
+ */
+function textHasUrl(text: string): boolean {
+  // scheme://... (http, https, ftp, etc.)
+  if (/[a-z][a-z0-9+.-]*:\/\/\S/i.test(text)) return true;
+  // bare www. host
+  if (/\bwww\.[^\s.]+\.[^\s]/i.test(text)) return true;
+  // bare host.tld optionally with a path — require a known-ish TLD shape
+  // (2+ letters) to avoid matching ordinary sentences with periods.
+  if (/\b[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.[a-z]{2,}(?:\/\S*)?/i.test(text)) {
+    // Guard against plain "word.word" prose (no path, common English word
+    // boundary): only treat as a URL when it has a path/query OR the TLD is a
+    // common one. This keeps "e.g" / "i.e" / "U.S" out while catching real
+    // hosts. We fail toward DETECTING a URL when ambiguous.
+    const m = text.match(
+      /\b([a-z0-9](?:[a-z0-9-]*[a-z0-9])?)\.([a-z]{2,})((?:\/\S*)?)/i,
+    );
+    if (m) {
+      const tld = m[2].toLowerCase();
+      const hasPath = m[3].length > 0;
+      const COMMON_TLDS = new Set([
+        "com", "org", "net", "io", "co", "gg", "app", "dev", "xyz", "ai",
+        "fun", "me", "tv", "fi", "info", "biz", "gov", "edu", "news", "link",
+      ]);
+      if (hasPath || COMMON_TLDS.has(tld)) return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Trim leading/trailing whitespace then validate the tweet text length by
  * Unicode code points (see the module-level simplification note). Returns the
  * TRIMMED text (the trimmed value is authoritative: it is what goes in the body).
@@ -140,7 +192,17 @@ function validateTweetText(v: unknown): string {
 
 // ─── x.tweet.create ───────────────────────────────────────────────────────────
 
-const TWEET_CREATE_KEYS = new Set(["text", "replyToTweetId"]);
+// `summoned` is a POLICY-ONLY hint (the caller asserts the account was
+// @mentioned/quoted by the post being replied to — the Feb-2026 anti-spam
+// precondition for a programmatic reply). It NEVER enters the tweet body or the
+// canonical action digest; it only flows to policyArgs so `replyPolicy:
+// summoned-only` can gate. It is validated as a strict boolean.
+const TWEET_CREATE_KEYS = new Set(["text", "replyToTweetId", "summoned"]);
+
+function validateBool(v: unknown, name: string): boolean {
+  if (typeof v !== "boolean") fieldError(`${name} must be a boolean`);
+  return v;
+}
 
 function buildTweetCreate(rawArgs: unknown): XActionBuild {
   const args = asObject(rawArgs);
@@ -152,6 +214,16 @@ function buildTweetCreate(rawArgs: unknown): XActionBuild {
   if ("replyToTweetId" in args && args.replyToTweetId !== undefined) {
     replyToTweetId = validateId(args.replyToTweetId, "replyToTweetId");
   }
+
+  // `summoned` defaults to false (fail-closed for summoned-only reply policy:
+  // an unasserted reply is treated as NOT summoned). Only meaningful on a reply,
+  // but accepted+validated regardless so the arg shape is stable.
+  let summoned = false;
+  if ("summoned" in args && args.summoned !== undefined) {
+    summoned = validateBool(args.summoned, "summoned");
+  }
+
+  const hasUrl = textHasUrl(text);
 
   // Body: {text} plus a nested reply object only when replying. The shared JCS
   // sorts object keys, so insertion order here is irrelevant to the digest.
@@ -179,14 +251,24 @@ function buildTweetCreate(rawArgs: unknown): XActionBuild {
   const safeSummary: Record<string, unknown> = {
     operation: "x.tweet.create",
     isReply: replyToTweetId !== undefined,
+    // Booleans/lengths only — NEVER any slice of the text. `hasUrl` is a
+    // derived boolean signal (content + spend), safe to surface.
+    hasUrl,
+    summoned,
     textCodePointLength: codePointLength,
     textByteLength: byteLength,
     textSha256,
   };
   if (replyToTweetId !== undefined) safeSummary.replyToTweetId = replyToTweetId;
 
+  // policyArgs carries ONLY validated scalars/booleans the composer gates on —
+  // NEVER raw text (that contract is asserted by the operations test). The raw
+  // text for blockedPatterns matching travels on the SEPARATE, non-persisted
+  // `policyText` field of the build (see XActionBuild.policyText).
   const policyArgs: Record<string, unknown> = {
     isReply: replyToTweetId !== undefined,
+    hasUrl,
+    summoned,
     textCodePointLength: codePointLength,
     textByteLength: byteLength,
   };
@@ -199,6 +281,7 @@ function buildTweetCreate(rawArgs: unknown): XActionBuild {
     action,
     safeSummary,
     policyArgs,
+    policyText: text,
   };
 }
 

--- a/packages/provider-x/src/operations.ts
+++ b/packages/provider-x/src/operations.ts
@@ -149,41 +149,38 @@ function textHasUrl(text: string): boolean {
   if (/[a-z][a-z0-9+.-]*:\/\/\S/i.test(text)) return true;
   // bare www. host
   if (/\bwww\.[^\s.]+\.[^\s]/i.test(text)) return true;
-  // bare host.tld optionally with a path — require a known-ish TLD shape
-  // (2+ letters) to avoid matching ordinary sentences with periods.
-  if (/\b[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.[a-z]{2,}(?:\/\S*)?/i.test(text)) {
-    // Guard against plain "word.word" prose (no path, common English word
-    // boundary): only treat as a URL when it has a path/query OR the TLD is a
-    // common one. This keeps "e.g" / "i.e" / "U.S" out while catching real
-    // hosts. We fail toward DETECTING a URL when ambiguous.
-    const m = text.match(/\b([a-z0-9](?:[a-z0-9-]*[a-z0-9])?)\.([a-z]{2,})((?:\/\S*)?)/i);
-    if (m) {
-      const tld = m[2].toLowerCase();
-      const hasPath = m[3].length > 0;
-      const COMMON_TLDS = new Set([
-        "com",
-        "org",
-        "net",
-        "io",
-        "co",
-        "gg",
-        "app",
-        "dev",
-        "xyz",
-        "ai",
-        "fun",
-        "me",
-        "tv",
-        "fi",
-        "info",
-        "biz",
-        "gov",
-        "edu",
-        "news",
-        "link",
-      ]);
-      if (hasPath || COMMON_TLDS.has(tld)) return true;
-    }
+  // bare host.tld optionally with a path. We OVER-DETECT here (fail toward
+  // treating an ambiguous token as a URL), because a false negative would let a
+  // `contentPolicy.allowUrls:false` / URL-spend / URL-approval policy be BYPASSED
+  // by a real bare domain on an uncommon TLD (e.g. `example.social`, `foo.shop`).
+  // A false positive only denies/escalates a borderline post, which is the safe
+  // direction (codex P2, PR review). We therefore treat ANY `label.tld` token
+  // (tld = 2+ ASCII letters) with a path OR a plausible domain shape as a URL,
+  // and EXCLUDE only a small deny-list of common English abbreviations that
+  // appear as `word.word` in ordinary prose.
+  //
+  // The dot must be immediately followed by 2+ ASCII letters (`\.[a-z]{2,}`), so
+  // ordinary prose with a space after the period ("fine. really") does NOT match
+  // — only a glued `label.tld` token does. Common English abbreviations with a
+  // single-letter right side ("e.g", "i.e", "p.m", "a.m", "u.s", "u.k") also do
+  // not match (1-letter tld). What remains are host-shaped tokens, which we
+  // OVER-DETECT as URLs regardless of TLD (a path is not required). We keep a
+  // tiny deny-list only for the rare glued 2+-letter-tld prose abbreviations.
+  const PROSE_ABBREVIATIONS: ReadonlySet<string> = new Set([
+    "etc.al", // "etc.al" style typo runs
+    "vs.the",
+  ]);
+  const hostRe = /\b([a-z0-9](?:[a-z0-9-]*[a-z0-9])?)\.([a-z]{2,})((?:\/\S*)?)/gi;
+  for (const m of text.matchAll(hostRe)) {
+    const label = m[1].toLowerCase();
+    const tld = m[2].toLowerCase();
+    const hasPath = m[3].length > 0;
+    // A path always makes it a URL.
+    if (hasPath) return true;
+    // Skip a couple of glued prose abbreviations; everything else host-shaped is
+    // over-detected as a URL (safe direction for a no-URL / spend policy).
+    if (PROSE_ABBREVIATIONS.has(`${label}.${tld}`)) continue;
+    return true;
   }
   return false;
 }

--- a/packages/provider-x/src/operations.ts
+++ b/packages/provider-x/src/operations.ts
@@ -156,15 +156,31 @@ function textHasUrl(text: string): boolean {
     // boundary): only treat as a URL when it has a path/query OR the TLD is a
     // common one. This keeps "e.g" / "i.e" / "U.S" out while catching real
     // hosts. We fail toward DETECTING a URL when ambiguous.
-    const m = text.match(
-      /\b([a-z0-9](?:[a-z0-9-]*[a-z0-9])?)\.([a-z]{2,})((?:\/\S*)?)/i,
-    );
+    const m = text.match(/\b([a-z0-9](?:[a-z0-9-]*[a-z0-9])?)\.([a-z]{2,})((?:\/\S*)?)/i);
     if (m) {
       const tld = m[2].toLowerCase();
       const hasPath = m[3].length > 0;
       const COMMON_TLDS = new Set([
-        "com", "org", "net", "io", "co", "gg", "app", "dev", "xyz", "ai",
-        "fun", "me", "tv", "fi", "info", "biz", "gov", "edu", "news", "link",
+        "com",
+        "org",
+        "net",
+        "io",
+        "co",
+        "gg",
+        "app",
+        "dev",
+        "xyz",
+        "ai",
+        "fun",
+        "me",
+        "tv",
+        "fi",
+        "info",
+        "biz",
+        "gov",
+        "edu",
+        "news",
+        "link",
       ]);
       if (hasPath || COMMON_TLDS.has(tld)) return true;
     }


### PR DESCRIPTION
## Permissioned X — instance-level policy vocabulary (Phase 1)

Shadow directive 2026-07-16: "scope out permissioned x and implement with full e2e tests." Makes X delegation **governable at the instance level** — the policy vocabulary X's own OAuth2 scope model can't express — flowing through the SAME `capability-intent` composer + approval + execution-authorization chain github/X already use. **No new rule type, no invented registry.**

Spec: `docs/security/permissioned-x.mdx` (X's native delegation model, the exact instance-level gaps Steward fills, every dimension with X API receipts, fail-closed matrix, honest gaps).

### Policy dimensions shipped (constraints.x sub-block on capability-intent)

1. **replyPolicy** `{ mode: 'any' | 'summoned-only' | 'none' }` — gates replies independently of originals. `summoned-only` models the **Feb-2026 anti-spam upstream-403 class** locally: an un-summoned programmatic reply is denied (`POLICY_X_REPLY_NOT_SUMMONED`) BEFORE the wasted billed call, surfaced as a clear failed outcome, never `outcome_unknown`.
2. **contentPolicy** `{ allowUrls, maxLength, blockedPatterns[] }` — a no-URL policy is ALSO a spend policy (URL post $0.20 vs $0.015). `blockedPatterns` matches via an in-memory-only `policyText` channel that is NEVER persisted (policyArgs stays scalar-only; decision doc / safe-summary / audit stay text-free).
3. **maxPostsPerWindow** `{ max, windowSeconds }` — operator-authored count cap (X's own limits are global/opaque).
4. **spendPolicy** `{ maxSpendMicros }` — estimated-spend cap over a **versioned per-post price table** (`X_POST_PRICE_TABLE_V1`: plain 15000 / url 200000 micros, source comment). Accumulates across a window.
5. **escalation** `{ urlPostRequiresApproval, spendOverMicrosRequiresApproval }` — downgrades an otherwise-allowed action to `approval_required` (never softens a deny). Any URL post can route to human approval.
6. **quietHours** `{ startMinuteUtc, endMinuteUtc }` — UTC minute-of-day gate, midnight-wrap supported.

Precedence is the plane's canonical **hard_deny > approval_required > allow > default-deny**. **All fail-closed:** unknown `x` key, `x` block on a non-X op, invalid regex, unavailable required input (count/spend/now-minute/text OR a required boolean signal), unknown content shape — all deny.

### Adapter changes (packages/provider-x)
`buildTweetCreate` derives `hasUrl` (content + spend signal, over-detects bare domains on any TLD — fail toward detection) and a validated `summoned` boolean policy arg, plus a separate non-persisted `policyText` channel. policyArgs remains scalar/boolean-only (raw text never in policyArgs).

### Tests
- **policy-engine `permissioned-x.test.ts`: 37 unit tests** over the composer + `evaluateXConstraints` — every dimension positive/negative, escalation, spend accumulation across two posts, quiet-hours midnight wrap, x-block scoping, and the missing-boolean-signal fail-closed cases.
- **api `provider-x-permissioned-e2e.test.ts`: 8 full-chain E2Es** (real service + approval SM over PGLite): URL post denied (no execution), plain post allowed, un-summoned reply → `POLICY_X_REPLY_NOT_SUMMONED` (upstream-403 class as a clear failed outcome), summoned reply allowed, blockedPatterns denied via non-persisted policyText, clean post allowed (text never in the persisted binding), URL escalation → approval, spend fail-closed → `POLICY_INPUT_UNAVAILABLE`.
- **provider-x `operations.test.ts`: +6** (hasUrl/summoned/policyText, uncommon-TLD over-detection, prose non-URL).
- **Mutation proofs** `packages/api/scripts/x-permissioned-mutation-proofs.sh`: **10 guards, all killed** (weaken guard → matching test flips → restore; no .bak residue).

Total new/changed: 51 X tests green + 10 mutation proofs. Full policy-engine suite (380) green. Regression floor verified locally: provider-x-governed, provider-x-permissioned, provider-action-service, provider-approval-*, provider-case-* (18 api suites), proxy governed-execution + x-credential-route — all green. typecheck (18 pkgs) + biome clean.

### Codex review
Iterated `codex review --base origin/develop`. Two P2 findings reproduced + fixed:
- **P2** bare-domain URLs on uncommon TLDs (`example.social`, `foo.shop`) were not detected → could bypass a no-URL/spend gate. Fixed to over-detect (fail toward detection). Regression test added.
- **P2** missing/non-boolean X signals (`isReply`/`summoned`/`hasUrl`) coerced to `false` → a URL/reply gate applied to an op whose build lacks the signal (`x.tweet.delete`) could silently pass. Fixed to fail closed (`POLICY_INPUT_UNAVAILABLE`) per policy that consumes the signal. 6 unit tests + matrix row + spec note added; mutation proofs updated.

The final re-review run confirmed no new findings (ran full test suites + both typecheck builds green).

### Scope fences honored
Did NOT touch PR6-owned files (provider-authority-e2e, scripts/provider-authority-*, web dashboard, CLI provider-action group), proxy governed-execution core, or migrations (permissioned-X policy is JSON in the existing capability-intent `constraints`, exactly how github policies are stored — no new migration needed; journal stays 0082).

### Honest gaps (Phase 1)
- No DM policy operation (deferred until `x.dm.*` exists; no dead rule shipped).
- Estimate, not billing truth — price table is a design-time versioned constant.
- Count/spend/now-minute inputs are wired-or-deny: the trailing-window accumulator in the live service is a follow-on (same posture as `invokeCount1h` on develop, which is `undefined` and fails closed by design). Content/reply/URL/escalation rules need no third-party input and are fully live now.
- `summoned` is a caller-supplied assertion; Steward can't self-verify the @mention/quote without a read call. The upstream 403 remains the backstop. Documented, not hidden.

Do NOT merge — gate lane owns merge after exact-tip CI + regression floor.

[sol-orch]
