### PR TITLE
docs(ops): add backup and disaster-recovery runbook

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -158,6 +158,13 @@ Downstream consumers (e.g. an eliza-cloud deployment) run their **own** instance
 this way with their own Railway + variables; they do not deploy from or depend on
 any other operator's instance.
 
+## Backup and disaster recovery
+
+Before storing production credentials or enabling governed provider actions,
+configure and test the [backup, restore, and disaster-recovery runbook](runbooks/backup-restore.md).
+A database dump without its matching root-secret escrow is not a recoverable
+Steward backup.
+
 ## Environment variable reference
 
 | Variable | Purpose | Default | Validation / production rule |

--- a/docs/runbooks/backup-restore.md
+++ b/docs/runbooks/backup-restore.md
@@ -1,0 +1,364 @@
+# Backup, restore, and disaster recovery
+
+This runbook is for self-hosted Steward operators. Test it against the exact
+release and database major version used in production. A backup that has not
+been restored in a drill is not a recovery plan.
+
+> **Critical:** a database dump is not a complete Steward backup. Keep the
+> database, its schema/release metadata, and the out-of-band secrets below as
+> one versioned recovery set. The secrets are not stored in the database. Loss
+> of an encryption root can make otherwise intact ciphertext permanently
+> unrecoverable.
+
+## Recovery set and trust boundaries
+
+### PostgreSQL
+
+Back up the whole database in one consistent `pg_dump`. Do not select only
+"important" tables. The coherent unit includes, among other tables:
+
+- encrypted wallet keys, chain keys, OAuth tokens, credentials, routes, policy,
+  tenant, agent, workspace, provider-account, operation, grant, and binding rows;
+- `approval_queue`, `pending_proxy_requests`, transactions, and intents, which
+  preserve the approval lifecycle and encrypted queued request bodies;
+- `execution_authorization_nonces`, including its consumed state and the v2
+  `dispatch_state` (`none`, `claimed`, `dispatched`, terminal, or
+  `outcome_unknown`);
+- `audit_events`, `audit_chain_heads`, `audit_checkpoints`, provider-action audit
+  rows/outbox, and proxy audit rows.
+
+A table-only dump can sever foreign keys, approval-to-intent bindings, nonce
+replay protection, or audit continuity. Never restore a nonce or approvals table
+from a different point in time than the rest of the database.
+
+Record alongside the dump:
+
+- Steward git commit or image digest and release version;
+- PostgreSQL server major version and `pg_dump --version`;
+- latest applied migration (`packages/db/drizzle/` for PostgreSQL, and
+  `__steward_migrations` for PGLite);
+- backup start/end UTC timestamps and a SHA-256 digest of the encrypted archive;
+- the recovery-set identifier shared with the secret escrow and, if retained,
+  Redis snapshot.
+
+### Out-of-band secrets
+
+Export secrets through the operator's secret store, not by printing `.env` to a
+terminal or copying values into a ticket. Store the export encrypted, separately
+from the database dump, with at least two tested custodians. Files containing
+secrets must be owned by the service account and mode `0600`; parent directories
+must be `0700`.
+
+The current `steward doctor` and Compose production roots are:
+
+| Name | Recovery effect if the value used by the backup is lost |
+| --- | --- |
+| `STEWARD_MASTER_PASSWORD` | **Unrecoverable ciphertext:** encrypted wallet/chain keys, vault credentials, OAuth tokens, and encrypted pending proxy bodies cannot be decrypted. A replacement password does not recover them. |
+| `STEWARD_KDF_SALT` | **Unrecoverable ciphertext when a non-default salt was used:** it is part of master-key derivation. Restore the exact salt with the matching master password. Never fall back to the legacy built-in salt during recovery. |
+| `STEWARD_EXECUTION_AUTH_SECRET` | Existing signed execution authorizations cannot be verified. Preserve the complete comma-separated `keyId:secret` verification list for the longest live authorization window. The first key is active for signing. If lost, fail closed and invalidate/recreate affected work rather than bypass verification. |
+| `STEWARD_AUDIT_HMAC_KEY` | Historical audit-event HMAC chains cannot be recomputed or verified. Database rows and signed checkpoints remain available, but the symmetric chain-integrity check is lost. A new key cannot authenticate old events. |
+| `STEWARD_AUDIT_SIGNING_KEY` | Existing checkpoint rows and exported bundles remain verifiable with their embedded public keys, but the restored instance cannot create continuity checkpoints with the old identity. Loss is not ciphertext loss, but key continuity is unrecoverable. Configure the same PKCS#8 PEM or 64-hex-character Ed25519 seed. |
+| `STEWARD_JWT_SECRET` | Existing user/agent/session JWTs cannot be verified. Restoring a different value forces reauthentication/token reissue; never substitute `STEWARD_MASTER_PASSWORD` in production. |
+| `POSTGRES_PASSWORD` and the credentials represented by `DATABASE_URL` | Required to access the database service. They may be reset by a database administrator without changing encrypted application data, but must be restored consistently to Compose/application configuration. Do not put the password in command history. |
+
+Also escrow every enabled deployment-specific credential that is needed after a
+restore, including `STEWARD_PLATFORM_KEYS`, tenant API keys returned only once,
+proxy request-signing secrets, OAuth client secrets, email credentials, webhook
+key overrides, and optional sidecar credentials. Their loss has the effect of
+that subsystem's documented rotation or re-enrollment path, not database
+decryption. `STEWARD_PLATFORM_KEYS` and raw tenant API keys are not recoverable
+from stored hashes.
+
+The KDF salt is configuration, not a per-row database salt. Row-level IVs,
+authentication tags, and salts are already in the full database dump, but they
+do not replace `STEWARD_MASTER_PASSWORD` plus `STEWARD_KDF_SALT`.
+
+## PostgreSQL backup
+
+Use a `pg_dump` client with the same major version as the server. PostgreSQL
+supports restoring a logical dump into a newer server in many cases, but test
+that path; do not restore with an older `pg_restore` than the `pg_dump` that
+created the archive.
+
+Use a protected passfile instead of embedding a password in the URI or command.
+The placeholders below are non-secret identifiers:
+
+```bash
+install -d -m 0700 /secure/steward-backups
+install -m 0600 /dev/null /secure/steward-backups/pgpass
+# Populate pgpass through the secret store, format:
+# DB_HOST:DB_PORT:DB_NAME:DB_USER:DB_PASSWORD
+export PGPASSFILE=/secure/steward-backups/pgpass
+export PGHOST=DB_HOST PGPORT=5432 PGDATABASE=DB_NAME PGUSER=DB_USER
+umask 077
+pg_dump --format=custom --compress=9 --no-owner \
+  --file=/secure/steward-backups/steward-RECOVERY_SET.dump
+sha256sum /secure/steward-backups/steward-RECOVERY_SET.dump \
+  > /secure/steward-backups/steward-RECOVERY_SET.dump.sha256
+chmod 0600 /secure/steward-backups/steward-RECOVERY_SET.dump*
+```
+
+`pg_dump` is transactionally consistent for PostgreSQL data. For the smallest
+uncertainty window around in-flight external dispatches, stop API and proxy
+writers before the dump. A hot dump is usable, but recovery must still treat any
+captured in-flight dispatch as uncertain.
+
+For the root Compose stack, keep application writers stopped while dumping from
+the bundled PostgreSQL 16 container:
+
+```bash
+docker compose stop steward-api steward-proxy
+umask 077
+docker compose exec -T postgres pg_dump \
+  -U "${POSTGRES_USER:-steward}" -d "${POSTGRES_DB:-steward}" \
+  --format=custom --compress=9 --no-owner \
+  > /secure/steward-backups/steward-RECOVERY_SET.dump
+chmod 0600 /secure/steward-backups/steward-RECOVERY_SET.dump
+# Restart only after the dump and any required Redis snapshot are complete.
+docker compose start steward-api steward-proxy
+```
+
+The password remains inside Compose/container configuration and is not echoed.
+Do not use `docker compose down -v`; `-v` deletes named data volumes.
+
+### Redis
+
+PostgreSQL is the durable source for Steward records. Redis nevertheless holds
+rate-limit, spend-tracking, and challenge/cache state. Losing live spend counters
+can weaken enforcement until their windows expire. During a coordinated backup,
+freeze API/proxy writers and either capture a tested Redis snapshot with the
+same recovery-set identifier or document a conservative cold-start policy that
+keeps the proxy unavailable until affected spend windows expire. Never bring up
+a restored proxy with silently empty counters when a spending-limit policy
+expects prior usage.
+
+## Embedded PGLite backup
+
+PGLite is intended for local/development use and does not use the Compose
+PostgreSQL volume. Its persistent directory is `STEWARD_PGLITE_PATH`, defaulting
+to `~/.steward/data`. `STEWARD_PGLITE_MEMORY=true` has no durable state and
+cannot be backed up after the process exits.
+
+Do not copy a live PGLite directory. Stop the sole API/embedded process, confirm
+no process has the directory open, and archive the entire directory, including
+its migration metadata:
+
+```bash
+umask 077
+# Stop the service/process that runs `bun run start:local` first.
+tar --create --zstd --file /secure/steward-backups/pglite-RECOVERY_SET.tar.zst \
+  --directory /var/lib/steward pglite-data
+chmod 0600 /secure/steward-backups/pglite-RECOVERY_SET.tar.zst
+sha256sum /secure/steward-backups/pglite-RECOVERY_SET.tar.zst \
+  > /secure/steward-backups/pglite-RECOVERY_SET.tar.zst.sha256
+```
+
+Replace `/var/lib/steward/pglite-data` with the configured path. Restore only to
+a stopped instance, preserve ownership/mode, and start the same Steward release
+first. A PGLite directory archive is not a portable `pg_restore` archive.
+
+## Restore order
+
+1. **Declare an incident and freeze writers.** Block inbound traffic at the
+   operator-controlled reverse proxy/firewall, then stop every Steward API,
+   proxy, worker, and embedded process. Stop external schedulers and agents that
+   submit work. Keep them stopped through reconciliation.
+2. **Choose one recovery set.** Verify checksums, timestamps, release/database
+   versions, secret-set identifier, and chain of custody. Never combine a newer
+   database with older nonce/audit tables or a mismatched root-secret set.
+3. **Prepare compatible software.** Restore into the recorded PostgreSQL major
+   version with a `pg_restore` version at least as new as the dump producer.
+   Check out the recorded Steward release. Do not let a newer API migrate the
+   target before the base restore is complete.
+4. **Restore the database while the application is stopped.** Restore into an
+   empty database. For a replacement database owned by the intended role:
+
+   ```bash
+   export PGPASSFILE=/secure/steward-backups/pgpass
+   export PGHOST=DB_HOST PGPORT=5432 PGDATABASE=DB_NAME PGUSER=DB_USER
+   pg_restore --exit-on-error --clean --if-exists --no-owner --no-privileges \
+     --dbname=DB_NAME /secure/steward-backups/steward-RECOVERY_SET.dump
+   ```
+
+   `--clean` is destructive to the selected target. Triple-check `PGHOST` and
+   `PGDATABASE`; never point this command at a healthy production database.
+5. **Restore environment secrets before application startup.** Install the exact
+   `STEWARD_MASTER_PASSWORD`, `STEWARD_KDF_SALT`, audit keys, execution-auth key
+   list, JWT secret, database credentials, and enabled subsystem credentials.
+   Set files to `0600`. Do not print values in logs or shell tracing.
+6. **Resolve migration compatibility.** First run the recorded release against
+   the restored schema. Compare the migration ledger to the checked-out
+   `packages/db/drizzle/` files. Then upgrade one tested release step at a time;
+   normal startup applies forward migrations. Never set `SKIP_MIGRATIONS` unless
+   a separately observed migration job has completed successfully. Never run an
+   older release against a schema already migrated by a newer release.
+7. **Restore or conservatively reset Redis.** Restore the matched snapshot, or
+   enforce the documented cold-start hold for spend windows. Redis recovery must
+   not delay inspection of durable PostgreSQL state.
+8. **Start API only, with dispatch blocked.** Keep the external proxy, agents,
+   workers, and ingress frozen. Confirm `/health` and `/ready`, then run doctor
+   and the database/audit checks below.
+9. **Reconcile approvals and execution state.** Follow the next section. Do not
+   make direct SQL status edits merely to make rows look terminal.
+10. **Resume in stages.** Enable API ingress, then proxy ingress and workers only
+    after a named operator signs off. Monitor denied/replayed authorization,
+    audit-verification, spend-limit, decrypt, and migration errors.
+
+For PGLite, replace step 4 with extraction of the complete archive into an empty
+configured `STEWARD_PGLITE_PATH`, using the original owner and permissions.
+
+## In-flight reconciliation, fail closed
+
+A crash-consistent restore cannot prove what an external provider did after the
+backup boundary. Steward therefore makes **no exactly-once recovery claim**.
+Database single-use and idempotency controls prevent known duplicate dispatches,
+but cannot turn an uncertain external side effect into proof.
+
+While the proxy remains frozen, inventory at least:
+
+```sql
+SELECT id, intent_id, execution_id, status, dispatch_state, issued_at,
+       expires_at, dispatched_at, outcome_recorded_at, provider_idempotency_key
+FROM execution_authorization_nonces
+WHERE version = 2
+  AND (status = 'active'
+       OR dispatch_state IN ('claimed', 'dispatched', 'outcome_unknown'))
+ORDER BY issued_at;
+
+SELECT id, approval_kind, intent_id, status, requested_at, resolved_at,
+       expires_at, consumed_at
+FROM approval_queue
+WHERE status IN ('pending', 'approved')
+ORDER BY requested_at;
+
+SELECT id, status, expires_at, approved_at, executed_at
+FROM pending_proxy_requests
+WHERE status IN ('pending', 'approved', 'executing')
+ORDER BY created_at;
+```
+
+Disposition rules:
+
+- `claimed`, `dispatched`, and `outcome_unknown` executions are **never blindly
+  retried or reset to `none`**. Quarantine them. Check the provider using its
+  operation/request/idempotency identifier and independent records. If a
+  supported reconciliation path can establish the outcome, use that path and
+  retain its audit evidence. The current repository does not expose a generic
+  operator reconciliation command, so do not invent one or update rows by hand.
+  If the outcome cannot be proven, leave it failed closed and create a new human-
+  reviewed intent only after assessing duplicate-side-effect risk.
+- A `claimed` row is not proof that dispatch happened, and a missing terminal
+  event is not proof that it did not. Treat both directions as uncertain.
+- Expired active authorizations must not be extended or replayed. The governed
+  dispatch claim checks database time and fails closed. Recreate approval and
+  authorization through the normal flow when safe.
+- Pending/approved approvals and queued proxy requests may have expired or may
+  bind to policy, routes, secrets, operations, or external facts that changed
+  after the backup. Let normal lifecycle validation expire/reject stale work.
+  Require fresh review for restored approved-but-unconsumed work; do not resume
+  it merely because the restored status says `approved`.
+- Record the incident decision, evidence checked, and replacement intent IDs in
+  the audit/incident record. Preserve the restored database snapshot for
+  forensics.
+
+## Verification before reopening
+
+Run the existing doctor from the restored release. It reports presence/length,
+not secret values:
+
+```bash
+bun packages/cli/src/index.ts doctor --strict --env /secure/steward.env --json
+curl --fail http://127.0.0.1:3200/health
+curl --fail http://127.0.0.1:3200/ready
+```
+
+Doctor checks configuration and health, not decryptability of every ciphertext.
+Using a dedicated test tenant/agent, perform a read/decrypt/sign smoke test that
+does not broadcast value, plus an OAuth/secret decrypt test for each enabled
+backend. Failure means keep ingress closed.
+
+For every tenant, call the existing authenticated `POST /audit/verify` endpoint
+from sequence 1 with `requireHead=true`, paging ranges if needed. It recomputes
+the HMAC chain and checks the in-database high-water mark. Keep authentication in
+a protected curl config or operator client, not command history. A valid result
+must report the expected range and no break. This check requires the original
+`STEWARD_AUDIT_HMAC_KEY`.
+
+Then create and verify a signed evidence bundle with the existing CLI/offline
+verifier. The CLI invokes `scripts/verify-evidence-bundle.mjs` when `--verify` is
+set:
+
+```bash
+umask 077
+bun packages/cli/src/index.ts audit bundle --from 1 --to LAST_SEQUENCE \
+  --out /secure/steward-backups/post-restore-audit.json --verify
+```
+
+This requires tenant authentication configured for the CLI and the restored
+`STEWARD_AUDIT_SIGNING_KEY`. Compare the latest restored checkpoint/public-key
+identity and chain head with a pre-incident bundle held outside the database.
+An offline bundle can validate its embedded signature and content commitment,
+but does not by itself prove that no newer database tail was lost. A mismatch,
+missing expected tail, unknown signer, HMAC failure, or head failure blocks
+reopening.
+
+Also verify row counts/critical inventories against the backup manifest, inspect
+migration status, ensure no service used a development secret fallback, and test
+spend-limit behavior before unfreezing the proxy.
+
+## Tested disaster-recovery drill checklist
+
+Run this at an interval justified by the RPO/RTO target and after material schema,
+key, migration, or deployment changes. Never drill by restoring over production.
+
+- [ ] Assign incident commander, database operator, secret custodian, and
+      independent verifier.
+- [ ] Create a tagged recovery set and record release/image, PostgreSQL and tool
+      versions, migration tip, timestamps, checksums, and escrow identifier.
+- [ ] Provision an isolated target with outbound provider calls blocked.
+- [ ] Restore the full PostgreSQL dump, exact out-of-band secret set, and matched
+      Redis snapshot or documented conservative hold.
+- [ ] Start the recorded Steward release first; capture migration and readiness
+      output. If testing an upgrade, perform it only after base restore succeeds.
+- [ ] Run strict doctor, `/health`, `/ready`, ciphertext smoke tests, authenticated
+      `/audit/verify?fromSeq=1&requireHead=true` for every tenant, and offline
+      evidence-bundle verification.
+- [ ] Compare critical table counts, audit heads/checkpoints, and expected latest
+      transaction/approval/nonce timestamps with the source manifest.
+- [ ] Inject or retain representative pending approval plus `claimed`,
+      `dispatched`, and `outcome_unknown` nonce cases. Confirm the drill procedure
+      quarantines them and sends no provider request.
+- [ ] Confirm expired authorization and stale approval paths fail closed.
+- [ ] Confirm proxy remains blocked with missing execution-auth/audit roots and
+      with unavailable required Redis spend state.
+- [ ] Exercise staged ingress reopening using a non-value test operation, then
+      close ingress again and preserve evidence.
+- [ ] Measure detection, restore, verification, reconciliation, and total recovery
+      times. Record actual recovered timestamp and data loss.
+- [ ] Destroy the isolated copy and secret material under the operator's secure
+      media procedure. File owners and due dates for every failed step.
+
+A drill passes only when all required checks execute and pass. A skipped secret,
+audit, nonce, or approval assertion is a failed drill.
+
+## RPO/RTO worksheet
+
+Fill this per deployment. Do not copy aspirational values into an SLA until a
+drill demonstrates them.
+
+| Item | Target | Last measured | Owner/evidence |
+| --- | --- | --- | --- |
+| Maximum PostgreSQL data loss (RPO) | `___` | `___` | `___` |
+| Secret escrow update lag (must not exceed DB recovery-set lag) | `___` | `___` | `___` |
+| Redis spend/challenge-state loss or conservative hold | `___` | `___` | `___` |
+| Incident detection and writer freeze | `___` | `___` | `___` |
+| Database/PGLite restore | `___` | `___` | `___` |
+| Secret installation and decrypt smoke tests | `___` | `___` | `___` |
+| Audit verification and checkpoint comparison | `___` | `___` | `___` |
+| In-flight approval/dispatch reconciliation | `___` | `___` | `___` |
+| Staged service recovery (RTO) | `___` | `___` | `___` |
+| Backup retention and last successful drill date | `___` | `___` | `___` |
+
+RPO is bounded by the oldest component in a coherent recovery set, not just the
+latest database dump. RTO includes human review of uncertain external dispatches;
+do not hide that time by reopening the proxy before reconciliation.

--- a/docs/runbooks/backup-restore.md
+++ b/docs/runbooks/backup-restore.md
@@ -63,8 +63,8 @@ The current `steward doctor` and Compose production roots are:
 
 Also escrow every enabled deployment-specific credential that is needed after a
 restore, including `STEWARD_PLATFORM_KEYS`, tenant API keys returned only once,
-proxy request-signing secrets, OAuth client secrets, email credentials, webhook
-key overrides, and optional sidecar credentials. Their loss has the effect of
+`STEWARD_PROXY_REQUEST_SIGNING_SECRETS`, OAuth client secrets, email credentials,
+webhook key overrides, and optional sidecar credentials. Their loss has the effect of
 that subsystem's documented rotation or re-enrollment path, not database
 decryption. `STEWARD_PLATFORM_KEYS` and raw tenant API keys are not recoverable
 from stored hashes.
@@ -277,21 +277,34 @@ Using a dedicated test tenant/agent, perform a read/decrypt/sign smoke test that
 does not broadcast value, plus an OAuth/secret decrypt test for each enabled
 backend. Failure means keep ingress closed.
 
-For every tenant, call the existing authenticated `POST /audit/verify` endpoint
-from sequence 1 with `requireHead=true`, paging ranges if needed. It recomputes
-the HMAC chain and checks the in-database high-water mark. Keep authentication in
-a protected curl config or operator client, not command history. A valid result
-must report the expected range and no break. This check requires the original
+For every tenant, read the expected head while writers remain frozen:
+
+```sql
+SELECT tenant_id, expected_seq, expected_count, floor_seq,
+       encode(head_hmac, 'hex') AS head_hmac
+FROM audit_chain_heads
+ORDER BY tenant_id;
+```
+
+Call the existing authenticated `POST /audit/verify` endpoint starting at
+`fromSeq=1`, with `requireHead=true`. The endpoint accepts at most 10,000 rows,
+so use contiguous ranges and set the final `toSeq` to that tenant's exact
+`expected_seq`; do not use a guessed upper bound. It recomputes the HMAC chain
+and checks the in-database high-water mark. Keep authentication in a protected
+curl config or operator client, not command history. Every result must be valid,
+cover the requested range, and report no break. This check requires the original
 `STEWARD_AUDIT_HMAC_KEY`.
 
-Then create and verify a signed evidence bundle with the existing CLI/offline
+Then create and verify signed evidence bundles with the existing CLI/offline
 verifier. The CLI invokes `scripts/verify-evidence-bundle.mjs` when `--verify` is
-set:
+set. Export contiguous ranges of at most 10,000 events, ending the final range at
+the exact head sequence:
 
 ```bash
 umask 077
-bun packages/cli/src/index.ts audit bundle --from 1 --to LAST_SEQUENCE \
-  --out /secure/steward-backups/post-restore-audit.json --verify
+bun packages/cli/src/index.ts audit bundle \
+  --from FIRST_SEQUENCE --to LAST_SEQUENCE_IN_RANGE \
+  --out /secure/steward-backups/post-restore-audit-RANGE.json --verify
 ```
 
 This requires tenant authentication configured for the CLI and the restored

--- a/packages/cli/scripts/backup-runbook-mutation-proof.sh
+++ b/packages/cli/scripts/backup-runbook-mutation-proof.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+RUNBOOK="$ROOT/docs/runbooks/backup-restore.md"
+TEST="$ROOT/packages/cli/src/__tests__/backup-restore-docs.test.ts"
+BACKUP="$(mktemp)"
+
+restore() {
+  cp "$BACKUP" "$RUNBOOK"
+  rm -f "$BACKUP"
+}
+trap restore EXIT
+cp "$RUNBOOK" "$BACKUP"
+
+cd "$ROOT"
+bun test "$TEST"
+
+# Remove one doctor-required root name everywhere. The completeness contract
+# must fail rather than silently accepting incomplete escrow guidance.
+perl -pi -e 's/STEWARD_AUDIT_SIGNING_KEY/STEWARD_AUDIT_SIGNING_KEI/g' "$RUNBOOK"
+if bun test "$TEST" > /tmp/steward-backup-runbook-mutation.log 2>&1; then
+  cat /tmp/steward-backup-runbook-mutation.log
+  echo "mutation survived: missing root-secret guidance was not detected" >&2
+  exit 1
+fi
+grep -q "STEWARD_AUDIT_SIGNING_KEY must be included" \
+  /tmp/steward-backup-runbook-mutation.log
+
+restore
+trap - EXIT
+rm -f /tmp/steward-backup-runbook-mutation.log
+bun test "$TEST"
+echo "mutation killed: out-of-band secret completeness guard failed closed"

--- a/packages/cli/src/__tests__/backup-restore-docs.test.ts
+++ b/packages/cli/src/__tests__/backup-restore-docs.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, normalize } from "node:path";
+
+const ROOT = join(import.meta.dir, "../../../..");
+
+function read(path: string): string {
+  return readFileSync(join(ROOT, path), "utf8");
+}
+
+function doctorRequiredNames(source: string): string[] {
+  const block = source.match(/const required = \[([\s\S]*?)\];/)?.[1];
+  if (!block) throw new Error("doctor required-secret list was not found");
+  return [...block.matchAll(/"([A-Z][A-Z0-9_]*)"/g)].map((match) => match[1]);
+}
+
+function composeRequiredNames(source: string): string[] {
+  return [...source.matchAll(/\$\{([A-Z][A-Z0-9_]*):\?/g)].map((match) => match[1]);
+}
+
+describe("backup/restore documentation contract", () => {
+  const runbookPath = "docs/runbooks/backup-restore.md";
+  const runbook = read(runbookPath);
+
+  test("mentions every root configuration value required by doctor or Compose", () => {
+    const names = new Set([
+      ...doctorRequiredNames(read("packages/cli/src/doctor.ts")),
+      ...composeRequiredNames(read("docker-compose.yml")),
+    ]);
+
+    expect(names.size).toBeGreaterThan(0);
+    for (const name of names) {
+      expect(runbook, `${name} must be included in out-of-band recovery guidance`).toContain(name);
+    }
+  });
+
+  test("carries fail-closed recovery warnings for uncertain dispatch and secret loss", () => {
+    expect(runbook).toContain("database dump is not a complete Steward backup");
+    expect(runbook).toContain("The secrets are not stored in the database");
+    expect(runbook).toContain("never blindly\n  retried or reset to `none`");
+    expect(runbook).toContain("no exactly-once recovery claim");
+    expect(runbook).toContain("A skipped secret,\naudit, nonce, or approval assertion is a failed drill");
+  });
+
+  test("is linked from deployment docs and local Markdown links resolve", () => {
+    const deployment = read("docs/deployment.md");
+    expect(deployment).toContain("[backup, restore, and disaster-recovery runbook](runbooks/backup-restore.md)");
+
+    for (const match of runbook.matchAll(/\[[^\]]+\]\(([^)]+)\)/g)) {
+      const target = match[1];
+      if (/^(?:https?:|mailto:|#)/.test(target)) continue;
+      const path = target.split("#", 1)[0];
+      expect(
+        existsSync(normalize(join(ROOT, dirname(runbookPath), path))),
+        `broken local link in ${runbookPath}: ${target}`,
+      ).toBe(true);
+    }
+  });
+});

--- a/packages/cli/src/__tests__/backup-restore-docs.test.ts
+++ b/packages/cli/src/__tests__/backup-restore-docs.test.ts
@@ -14,6 +14,14 @@ function doctorRequiredNames(source: string): string[] {
   return [...block.matchAll(/"([A-Z][A-Z0-9_]*)"/g)].map((match) => match[1]);
 }
 
+function doctorSecretNames(source: string): string[] {
+  const required = doctorRequiredNames(source);
+  const strictSecrets = [
+    ...source.matchAll(/env\.(STEWARD_[A-Z0-9_]*(?:SECRET|SECRETS|KEY|KEYS))/g),
+  ].map((match) => match[1]);
+  return [...required, ...strictSecrets];
+}
+
 function composeRequiredNames(source: string): string[] {
   return [...source.matchAll(/\$\{([A-Z][A-Z0-9_]*):\?/g)].map((match) => match[1]);
 }
@@ -24,8 +32,9 @@ describe("backup/restore documentation contract", () => {
 
   test("mentions every root configuration value required by doctor or Compose", () => {
     const names = new Set([
-      ...doctorRequiredNames(read("packages/cli/src/doctor.ts")),
+      ...doctorSecretNames(read("packages/cli/src/doctor.ts")),
       ...composeRequiredNames(read("docker-compose.yml")),
+      ...composeRequiredNames(read("deploy/docker-compose.yml")),
     ]);
 
     expect(names.size).toBeGreaterThan(0);

--- a/packages/cli/src/__tests__/backup-restore-docs.test.ts
+++ b/packages/cli/src/__tests__/backup-restore-docs.test.ts
@@ -39,12 +39,16 @@ describe("backup/restore documentation contract", () => {
     expect(runbook).toContain("The secrets are not stored in the database");
     expect(runbook).toContain("never blindly\n  retried or reset to `none`");
     expect(runbook).toContain("no exactly-once recovery claim");
-    expect(runbook).toContain("A skipped secret,\naudit, nonce, or approval assertion is a failed drill");
+    expect(runbook).toContain(
+      "A skipped secret,\naudit, nonce, or approval assertion is a failed drill",
+    );
   });
 
   test("is linked from deployment docs and local Markdown links resolve", () => {
     const deployment = read("docs/deployment.md");
-    expect(deployment).toContain("[backup, restore, and disaster-recovery runbook](runbooks/backup-restore.md)");
+    expect(deployment).toContain(
+      "[backup, restore, and disaster-recovery runbook](runbooks/backup-restore.md)",
+    );
 
     for (const match of runbook.matchAll(/\[[^\]]+\]\(([^)]+)\)/g)) {
       const target = match[1];


### PR DESCRIPTION
Closes #209.

## Summary

- Adds `docs/runbooks/backup-restore.md` with a concrete self-hosted PostgreSQL/Compose and embedded-PGLite backup/restore procedure.
- Defines the coherent recovery unit across approvals, pending proxy requests, execution authorization nonce/dispatch state, and audit events/heads/checkpoints.
- Documents exact out-of-band root handling for `STEWARD_MASTER_PASSWORD`, `STEWARD_KDF_SALT`, `STEWARD_EXECUTION_AUTH_SECRET`, `STEWARD_AUDIT_HMAC_KEY`, `STEWARD_AUDIT_SIGNING_KEY`, `STEWARD_JWT_SECRET`, database credentials, strict proxy request signing, and one-time operator/tenant credentials.
- Adds protected-passfile `pg_dump`/`pg_restore` examples, file permissions, version constraints, migration ordering, Redis spend-state cautions, staged restart, and audit verification with only commands/endpoints that exist in this repository.
- Explicitly makes no exactly-once recovery claim. Claimed/dispatched/outcome-unknown executions remain quarantined and fail closed rather than being reset or retried.
- Adds a DR drill checklist and RPO/RTO worksheet, and links the runbook from `docs/deployment.md`.

## Contract and mutation proof

`packages/cli/src/__tests__/backup-restore-docs.test.ts` derives required names from current doctor logic plus both Compose manifests, then asserts the runbook names every root, retains critical fail-closed warnings, and has a valid deployment-doc link/local links.

`packages/cli/scripts/backup-runbook-mutation-proof.sh` replaces every `STEWARD_AUDIT_SIGNING_KEY` mention with a misspelling. The completeness test fails with `STEWARD_AUDIT_SIGNING_KEY must be included`; the script restores the file and reruns green. No backup residue remains.

## Verification

- `bun test packages/cli/src/__tests__`: 25 passed, 0 failed across 6 files (27,180 expectations)
- Docs contract alone: 3 passed, 0 failed (18 expectations)
- `bun run --cwd packages/cli typecheck`: passed
- Biome on the new TypeScript contract test: passed
- markdownlint-cli2 on the runbook and deployment doc with MD013 disabled to match the pre-existing deployment-doc line-length style: 0 errors
- `git diff --check`: passed
- Mutation proof: killed, restored, baseline green
- Codex `review --base origin/develop`: final review found no discrete introduced issue. An initial full review process was OOM-killed; two subsequent low-reasoning full-base reviews completed cleanly.

## Honest gaps / drift

- This change validates documentation contracts and command/runtime semantics from source. It does not claim a real production-size `pg_dump`/`pg_restore` or PGLite filesystem drill was executed in this lane. The runbook deliberately requires operators to record such a drill before treating RPO/RTO as demonstrated.
- There is no generic operator reconciliation command in the current repository, so the runbook does not invent one and requires uncertain external dispatches to remain fail closed.
- PR #194 merged during gate review. This branch was rebased onto that merge and retains both the WXMR deployment content and the backup-runbook link.

[sol-orch]