### PR TITLE
feat(ops): add opt-in bounded security metrics and alert catalog

### DIFF
--- a/docs/runbooks/security-alerting.md
+++ b/docs/runbooks/security-alerting.md
@@ -1,0 +1,80 @@
+# Self-hosted security metrics and alerting
+
+Steward does not send telemetry or alerts to Steward-Fi. Operators may opt in to a process-local Prometheus endpoint and route durable typed audit events through their own infrastructure.
+
+## Enable the metrics endpoint
+
+The endpoint is disabled by default and returns `404` until explicitly enabled. Set both:
+
+```text
+STEWARD_METRICS_ENABLED=true
+STEWARD_METRICS_TOKEN=<random value of at least 32 characters>
+```
+
+Scrape `GET /metrics` with `Authorization: Bearer <token>`. Missing, short, or incorrect tokens are rejected. Generate a token with a cryptographically secure generator, store it outside source control, and rotate it like any operator credential.
+
+The API and proxy are separate processes and each exposes its own process-local `/metrics` view. Scrape both when deployed separately. Bind their listeners to localhost or a private service network, terminate TLS at the operator-controlled ingress, and do not expose either endpoint directly to the public Internet. The bearer token is defense in depth, not a substitute for network isolation and TLS.
+
+No tenant, user, agent, action, route, provider, resource, error message, raw denial reason, or other unbounded value appears in labels. The only labels are compile-time bounded outcome, reason class, and approval decision enums.
+
+## Metric catalog
+
+- `steward_governed_executions_total{outcome="succeeded|failed|outcome_unknown"}`: terminal governed execution audit events.
+- `steward_security_denials_total{reason_class="..."}`: denials collapsed into a fixed reason class. Investigate durable audit records for exact typed details.
+- `steward_approval_decisions_total{decision="approved|denied"}`: provider approval decisions.
+- `steward_governed_boundary_denials_total`: typed `provider.execution.denied_at_boundary` events. This is a provider-boundary denial signal, not proof that every legacy or bypass path in the product was attempted.
+- `steward_nonce_claim_contentions_total`: execution authorization claims that returned the typed `EXEC_AUTH_CLAIM_LOST` result.
+- `steward_audit_checkpoint_age_seconds`: age of the most recent checkpoint created by the current API process. `-1` means none has been observed since process start.
+
+Counters and the checkpoint-age observation are in memory and reset on process restart. Prometheus can retain scraped samples, but a reset is not durable evidence. The tamper-evident audit chain and signed checkpoint records are the durable investigation source. Metrics are operational hints only and do not establish compliance, completeness, exactly-once processing, or operator-proof execution.
+
+Collection is post-decision or best-effort. Metrics failures cannot authorize, deny, roll back, or otherwise change a governed action.
+
+## Typed audit event alert catalog
+
+Suggested starting points must be tuned to baseline volume and maintenance windows:
+
+- `provider.execution.outcome_unknown`, **critical**: page immediately on any event. Freeze automated retries for that execution until an operator reconciles its upstream state.
+- `provider.execution.denied_at_boundary`, **high**: page on any event outside planned credential, route, or account rotation. Otherwise alert on 3 events in 5 minutes. Review the typed `reasonCode` in the audit record.
+- `provider.execution.failed`, **medium**: alert when 5 events occur in 10 minutes or the failure ratio exceeds the operator's baseline. An upstream failure is not automatically a security incident.
+- `provider.action.denied`, **medium**: alert on a sharp rise over baseline, for example 10 events in 5 minutes. Use the durable audit event to distinguish access and policy causes.
+- `provider.approval.decided` with decision `denied`, **low to medium**: notify or ticket on each denial for high-risk workflows; otherwise alert on 5 in 15 minutes.
+- `provider.approval.expired` or `provider.approval.staled`, **medium**: alert on 3 in 15 minutes. Check approver latency and dependency or policy changes.
+- `provider.execution.claimed`, **informational**: useful for correlation, not normally alert-worthy alone.
+- `provider.execution.succeeded`, **informational**: use as denominator and investigation context.
+
+`EXEC_AUTH_CLAIM_LOST` is currently a typed execution result counted directly by the proxy, not a durable audit event. Treat a rise in `steward_nonce_claim_contentions_total` as **high** at 3 in 5 minutes and correlate with request logs and nearby `provider.execution.claimed` events. A process restart can hide the prior counter value, so absence after restart is not evidence that contention did not occur.
+
+There is no fabricated generic "bypass attempted" audit event. The catalog uses the existing typed `provider.execution.denied_at_boundary` event and states its narrower meaning. Add alert semantics only when a corresponding typed event exists.
+
+## Example Prometheus rules
+
+```yaml
+groups:
+  - name: steward-security
+    rules:
+      - alert: StewardExecutionOutcomeUnknown
+        expr: increase(steward_governed_executions_total{outcome="outcome_unknown"}[5m]) > 0
+        for: 0m
+        labels:
+          severity: critical
+        annotations:
+          summary: Steward governed execution has an unknown outcome
+      - alert: StewardBoundaryDenials
+        expr: increase(steward_governed_boundary_denials_total[5m]) >= 3
+        for: 0m
+        labels:
+          severity: high
+      - alert: StewardNonceClaimContention
+        expr: increase(steward_nonce_claim_contentions_total[5m]) >= 3
+        for: 0m
+        labels:
+          severity: high
+      - alert: StewardCheckpointNotObserved
+        expr: steward_audit_checkpoint_age_seconds < 0 or steward_audit_checkpoint_age_seconds > 86400
+        for: 15m
+        labels:
+          severity: medium
+```
+
+After any alert, preserve and inspect the audit bundle rather than relying on metric labels. Metric labels are deliberately too coarse for forensic conclusions.

--- a/packages/api/src/__tests__/metrics-endpoint.test.ts
+++ b/packages/api/src/__tests__/metrics-endpoint.test.ts
@@ -29,7 +29,9 @@ describe("GET /metrics exposure guard", () => {
     process.env.STEWARD_METRICS_ENABLED = "true";
     process.env.STEWARD_METRICS_TOKEN = token;
     expect((await app.request("/metrics")).status).toBe(401);
-    expect((await app.request("/metrics", { headers: { Authorization: "Bearer wrong" } })).status).toBe(401);
+    expect(
+      (await app.request("/metrics", { headers: { Authorization: "Bearer wrong" } })).status,
+    ).toBe(401);
   });
 
   test("returns Prometheus text without audit metadata", async () => {

--- a/packages/api/src/__tests__/metrics-endpoint.test.ts
+++ b/packages/api/src/__tests__/metrics-endpoint.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { __resetSecurityMetricsForTests, observeSecurityAuditEvent } from "@stwd/shared";
+import app from "../app";
+
+const savedEnabled = process.env.STEWARD_METRICS_ENABLED;
+const savedToken = process.env.STEWARD_METRICS_TOKEN;
+const token = "operator-metrics-token-32-characters-minimum";
+
+afterEach(() => {
+  if (savedEnabled === undefined) delete process.env.STEWARD_METRICS_ENABLED;
+  else process.env.STEWARD_METRICS_ENABLED = savedEnabled;
+  if (savedToken === undefined) delete process.env.STEWARD_METRICS_TOKEN;
+  else process.env.STEWARD_METRICS_TOKEN = savedToken;
+  __resetSecurityMetricsForTests();
+});
+
+beforeEach(() => {
+  delete process.env.STEWARD_METRICS_ENABLED;
+  delete process.env.STEWARD_METRICS_TOKEN;
+});
+
+describe("GET /metrics exposure guard", () => {
+  test("is a 404 while disabled", async () => {
+    const response = await app.request("/metrics");
+    expect(response.status).toBe(404);
+  });
+
+  test("rejects missing and wrong operator tokens", async () => {
+    process.env.STEWARD_METRICS_ENABLED = "true";
+    process.env.STEWARD_METRICS_TOKEN = token;
+    expect((await app.request("/metrics")).status).toBe(401);
+    expect((await app.request("/metrics", { headers: { Authorization: "Bearer wrong" } })).status).toBe(401);
+  });
+
+  test("returns Prometheus text without audit metadata", async () => {
+    process.env.STEWARD_METRICS_ENABLED = "true";
+    process.env.STEWARD_METRICS_TOKEN = token;
+    observeSecurityAuditEvent("provider.execution.outcome_unknown", {
+      token: "sk_live_NEVER_RENDER",
+      email: "private@example.com",
+    });
+    const response = await app.request("/metrics", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/plain");
+    const body = await response.text();
+    expect(body).toContain('outcome="outcome_unknown"} 1');
+    expect(body).not.toContain("sk_live_NEVER_RENDER");
+    expect(body).not.toContain("private@example.com");
+  });
+});

--- a/packages/api/src/__tests__/provider-action-service.test.ts
+++ b/packages/api/src/__tests__/provider-action-service.test.ts
@@ -35,7 +35,12 @@ import {
 } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { buildGithubAction } from "@stwd/provider-github";
-import { computeActionDigest } from "@stwd/shared";
+import {
+  __resetSecurityMetricsForTests,
+  __setSecurityMetricsObserverFailureForTests,
+  computeActionDigest,
+  renderSecurityMetrics,
+} from "@stwd/shared";
 import { eq, sql } from "drizzle-orm";
 import type { ProviderPrincipalV1 } from "../middleware/provider-principal";
 import { providerActionService } from "../services/provider-action-service";
@@ -243,6 +248,7 @@ describe("provider-action service pipeline", () => {
   });
 
   beforeEach(async () => {
+    __resetSecurityMetricsForTests();
     const db = getDb();
     await db.delete(providerActionAuditOutbox);
     await db.delete(providerActionBindings);
@@ -267,6 +273,19 @@ describe("provider-action service pipeline", () => {
     expect(await auditCount()).toBe(before + 1);
   });
 
+  test("metrics observer failure cannot change a real governed denial decision", async () => {
+    __setSecurityMetricsObserverFailureForTests(true);
+    const before = await auditCount();
+    const out = await providerActionService.createProviderAction(
+      input({
+        operationKey: "github.issue.list",
+        providerAccountId: "30000000-0000-4000-8000-0000000000ff",
+      }),
+    );
+    expect(out.kind).toBe("scope_not_found");
+    expect(await auditCount()).toBe(before + 1);
+  });
+
   test("access deny (no grant): creates intent + binding with policy not_evaluated", async () => {
     const out = await providerActionService.createProviderAction(input());
     expect(out.kind).toBe("access_denied");
@@ -283,6 +302,12 @@ describe("provider-action service pipeline", () => {
     // access + policy decision documents are DISTINCT: policy is null here.
     expect(b.policyDecision).toBeNull();
     expect(b.accessDecisionHash).toMatch(/^sha256:[0-9a-f]{64}$/);
+    // The real composed service -> outbox -> durable audit path feeds only the
+    // bounded reason class, never the raw grant reason or principal metadata.
+    const metrics = renderSecurityMetrics();
+    expect(metrics).toContain('reason_class="access"} 1');
+    expect(metrics).not.toContain("GRANT_ABSENT");
+    expect(metrics).not.toContain(AGENT);
   });
 
   test("allow: grant present, no governing policy denies (default deny) unless allow rule present", async () => {

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -56,6 +56,7 @@ import { identityDiscoveryRoutes } from "./routes/discovery";
 import { discoveryRoutes, erc8004Routes } from "./routes/erc8004";
 import { globalWalletRoutes } from "./routes/global-wallet";
 import { intentRoutes } from "./routes/intents";
+import { metricsRoutes } from "./routes/metrics";
 import { platformRoutes } from "./routes/platform";
 import { policiesStandaloneRoutes } from "./routes/policies-standalone";
 import { registerProviderActionRoutes } from "./routes/provider-actions";
@@ -221,6 +222,7 @@ export function mountCoreIdempotencyAndRoutes(
       uptime: Math.floor((Date.now() - startTime) / 1000),
     }),
   );
+  app.route("/metrics", metricsRoutes);
 
   // ─── Route modules ──────────────────────────────────────────────────────────
 

--- a/packages/api/src/routes/metrics.ts
+++ b/packages/api/src/routes/metrics.ts
@@ -1,0 +1,30 @@
+import { metricsTokenIsValid, renderSecurityMetrics, securityMetricsEnabled } from "@stwd/shared";
+import { Hono } from "hono";
+
+export const metricsRoutes = new Hono();
+
+metricsRoutes.get("/", (c) => {
+  // Deliberately indistinguishable from an absent route unless explicitly
+  // enabled. This guard is the primary endpoint exposure boundary.
+  if (!securityMetricsEnabled()) {
+    return c.json({ ok: false, error: "Not found: GET /metrics" }, 404);
+  }
+
+  const authorization = c.req.header("Authorization");
+  const candidate = authorization?.startsWith("Bearer ") ? authorization.slice(7) : undefined;
+  if (!metricsTokenIsValid(candidate)) {
+    return c.json({ ok: false, error: "Metrics authentication required" }, 401, {
+      "WWW-Authenticate": 'Bearer realm="steward-metrics"',
+    });
+  }
+
+  try {
+    return c.text(renderSecurityMetrics(), 200, {
+      "Content-Type": "text/plain; version=0.0.4; charset=utf-8",
+      "Cache-Control": "no-store",
+    });
+  } catch {
+    // Export failure is isolated from all governed action paths.
+    return c.json({ ok: false, error: "Metrics unavailable" }, 503);
+  }
+});

--- a/packages/api/src/services/audit.ts
+++ b/packages/api/src/services/audit.ts
@@ -27,6 +27,7 @@ import {
   withTenantAuditQueue,
   writeAuditEvent,
 } from "@stwd/db";
+import { observeAuditCheckpoint } from "@stwd/shared";
 import { sql } from "drizzle-orm";
 import {
   type CheckpointEventContent,
@@ -589,6 +590,13 @@ export async function signAuditBundle(
     eventsToSeq: events.length > 0 ? events[events.length - 1].seq : 0,
   };
   const signed = signer.sign(checkpointPayload);
+  // Process-local operational gauge only. Durable checkpoint evidence is the
+  // signed payload/table below and remains authoritative across restarts.
+  try {
+    observeAuditCheckpoint(Date.parse(checkpointPayload.timestamp));
+  } catch {
+    // Monitoring is best-effort and cannot affect evidence generation.
+  }
 
   // Persist the checkpoint (append-only provenance). Best-effort: a persistence
   // failure must not deny the auditor their signed bundle (self-contained).

--- a/packages/db/src/audit-chain.ts
+++ b/packages/db/src/audit-chain.ts
@@ -23,6 +23,7 @@
  */
 
 import { createHmac } from "node:crypto";
+import { observeSecurityAuditEvent } from "@stwd/shared";
 import { sql } from "drizzle-orm";
 import { getDb } from "./client";
 
@@ -379,6 +380,13 @@ export async function appendAuditEvent(ev: AuditEventInput): Promise<void> {
         // we can safely skip in embedded mode.
         await appendAuditEventWithinTx(tx as AuditTxLike, ev);
       });
+      // Metrics are deliberately post-commit and best-effort. They cannot roll
+      // back or otherwise affect the audited authority transition.
+      try {
+        observeSecurityAuditEvent(ev.action, ev.metadata);
+      } catch {
+        // Monitoring must never become part of the security decision path.
+      }
       return;
     } catch (err) {
       if (attempt < 4 && isAuditSequenceConflict(err)) {
@@ -437,7 +445,8 @@ export async function withTenantAuditedTransaction<T>(
   return withTenantAuditQueue(tenantId, async () => {
     for (let attempt = 0; attempt < 5; attempt++) {
       try {
-        return await db.transaction(async (tx) => {
+        const committedEvents: AuditEventInput[] = [];
+        const result = await db.transaction(async (tx) => {
           if (!isPGLiteRuntime()) {
             await tx.execute(
               sql`SELECT pg_advisory_xact_lock(hashtextextended(${`steward_audit_${tenantId}`}, 0))`,
@@ -450,9 +459,18 @@ export async function withTenantAuditedTransaction<T>(
               );
             }
             await appendAuditEventWithinTx(tx as AuditTxLike, event);
+            committedEvents.push(event);
           };
           return await fn(tx, appendRequiredAudit);
         });
+        for (const event of committedEvents) {
+          try {
+            observeSecurityAuditEvent(event.action, event.metadata);
+          } catch {
+            // Monitoring must never become part of the security decision path.
+          }
+        }
+        return result;
       } catch (err) {
         if (attempt < 4 && isAuditSequenceConflict(err)) {
           await new Promise((resolve) => setTimeout(resolve, 5 * (attempt + 1)));

--- a/packages/proxy/src/__tests__/governed-execution.test.ts
+++ b/packages/proxy/src/__tests__/governed-execution.test.ts
@@ -46,6 +46,8 @@ import {
 } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import {
+  __resetSecurityMetricsForTests,
+  __setSecurityMetricsObserverFailureForTests,
   buildProviderExecutionCommitmentV2,
   canonicalActionBytes,
   computeActionDigest,
@@ -539,6 +541,7 @@ beforeEach(async () => {
 afterEach(() => {
   // Reset any fault-injection hooks so a race test cannot leak into the next.
   dispatchMod.__resetGovernedDispatchHooksForTests();
+  __resetSecurityMetricsForTests();
 });
 
 // Build a minimal Hono-like context for handleProxy with an optional forged
@@ -1278,5 +1281,40 @@ describe("PR4 dispatchGovernedExecution claim + dispatch", () => {
     // The governed claim consumed exactly once; the direct hit never touched it.
     expect(n.status).toBe("consumed");
     void gov;
+  });
+
+  it("a THROWING metrics observer never changes the governed dispatch outcome (post-commit isolation, all proxy hook sites)", async () => {
+    // observeSecurityAuditEvent is invoked from the post-commit loop of EVERY
+    // withTenantAuditedTransaction the proxy dispatch path runs: the claim, the
+    // claimed->dispatched transition, and the terminal outcome. Force that
+    // observer to throw for the WHOLE dispatch and prove:
+    //   1. the dispatch still succeeds (ok:true, EXEC_DISPATCH_SUCCEEDED),
+    //   2. the nonce is consumed and reaches the terminal succeeded state,
+    //   3. exactly one upstream forward happened (no blind retry, X8),
+    // i.e. a metrics failure can never block, delay, or reorder the atomic
+    // claimed->dispatched transition or the authority decision.
+    __setSecurityMetricsObserverFailureForTests(true);
+    try {
+      const { intentId, authorizationId } = await seedExecutionReady();
+      forwarderMode = "ok";
+      const res = await dispatchGovernedExecution(intentId, IDS.tenant);
+      expect(res.ok).toBe(true);
+      expect(res.code).toBe("EXEC_DISPATCH_SUCCEEDED");
+      expect(res.dispatchState).toBe("succeeded");
+      // Exactly one forward reached the upstream.
+      expect(captured).not.toBeNull();
+      const db = getDb();
+      const [n] = await db
+        .select({
+          status: executionAuthorizationNonces.status,
+          dispatchState: executionAuthorizationNonces.dispatchState,
+        })
+        .from(executionAuthorizationNonces)
+        .where(eq(executionAuthorizationNonces.authorizationId, authorizationId));
+      expect(n.status).toBe("consumed");
+      expect(n.dispatchState).toBe("succeeded");
+    } finally {
+      __setSecurityMetricsObserverFailureForTests(false);
+    }
   });
 });

--- a/packages/proxy/src/__tests__/metrics-exposure.test.ts
+++ b/packages/proxy/src/__tests__/metrics-exposure.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Proxy /metrics exposure guard.
+ *
+ * The opt-in operator metrics endpoint must be disabled by default AND, while
+ * disabled, be INDISTINGUISHABLE from any other unrouted path. The proxy runs
+ * authMiddleware as its catch-all, so every unauthenticated request to an
+ * unknown path returns a 401. If disabled /metrics emitted its own 404 instead,
+ * an unauthenticated attacker could fingerprint the endpoint's existence by the
+ * anomalous status/body. This test locks the no-fingerprint property (the
+ * disabled handler falls through via next()), and that a valid operator token
+ * still scrapes metrics once enabled.
+ */
+import { beforeEach, describe, expect, test } from "bun:test";
+
+// Bootstrap the entrypoint's boot-time env BEFORE any dynamic import of
+// `../index.ts`. index.ts runs `validateJwtSecretEnv()` and requires a database
+// URL at module load (it `process.exit(1)`s otherwise), so a bare
+// `bun test metrics-exposure.test.ts` under the normal isolated runner (which
+// inherits the ambient env and injects nothing) must supply these itself. Using
+// the in-memory PGLite posture keeps the test fully self-contained with no
+// third-party Postgres/JWT config, matching the other proxy suites' isolation.
+process.env.STEWARD_ALLOW_DEV_SECRETS = "true";
+process.env.STEWARD_JWT_SECRET ||= "test-proxy-metrics-jwt-secret-32-characters-min";
+process.env.STEWARD_PGLITE_MEMORY = "true";
+process.env.DATABASE_URL ||= "postgres://steward:steward@127.0.0.1:5432/steward_test";
+
+const TOKEN = "operator-metrics-token-32-characters-minimum";
+
+beforeEach(() => {
+  delete process.env.STEWARD_METRICS_ENABLED;
+  delete process.env.STEWARD_METRICS_TOKEN;
+});
+
+describe("proxy /metrics exposure guard", () => {
+  test("disabled /metrics is byte-identical to an unknown path (no fingerprint)", async () => {
+    const mod = await import("../index.ts");
+    const app = mod.default as { fetch: (r: Request) => Promise<Response> };
+
+    const metrics = await app.fetch(new Request("http://proxy.local/metrics"));
+    const unknown = await app.fetch(new Request("http://proxy.local/definitely-not-a-route"));
+
+    const metricsBody = await metrics.text();
+    const unknownBody = await unknown.text();
+
+    // Same status AND same body: the disabled endpoint reveals nothing.
+    expect(metrics.status).toBe(unknown.status);
+    expect(metricsBody).toBe(unknownBody);
+    // Sanity: the shared behavior is the auth catch-all (401), never a 404 that
+    // would betray the route's existence.
+    expect(metrics.status).toBe(401);
+  });
+
+  test("enabled + valid operator token renders metrics; missing token is rejected", async () => {
+    process.env.STEWARD_METRICS_ENABLED = "true";
+    process.env.STEWARD_METRICS_TOKEN = TOKEN;
+    const mod = await import("../index.ts");
+    const app = mod.default as { fetch: (r: Request) => Promise<Response> };
+
+    const authed = await app.fetch(
+      new Request("http://proxy.local/metrics", {
+        headers: { Authorization: `Bearer ${TOKEN}` },
+      }),
+    );
+    expect(authed.status).toBe(200);
+    expect(authed.headers.get("content-type")).toContain("text/plain");
+    const body = await authed.text();
+    expect(body).toContain("steward_governed_executions_total");
+
+    const noToken = await app.fetch(new Request("http://proxy.local/metrics"));
+    expect(noToken.status).toBe(401);
+
+    const wrongToken = await app.fetch(
+      new Request("http://proxy.local/metrics", {
+        headers: { Authorization: "Bearer wrong" },
+      }),
+    );
+    expect(wrongToken.status).toBe(401);
+  });
+});

--- a/packages/proxy/src/handlers/governed-execution.ts
+++ b/packages/proxy/src/handlers/governed-execution.ts
@@ -53,6 +53,7 @@ import {
   serializeCanonicalOutboundQuery,
   strictParseJson,
   verifyProviderExecutionCommitmentV2,
+  observeNonceClaimContention,
 } from "@stwd/shared";
 import { and, eq, sql } from "drizzle-orm";
 import type { Context } from "hono";
@@ -246,6 +247,13 @@ function deny(
   intentId: string,
   extra?: Partial<GovernedDispatchResult>,
 ): GovernedDispatchResult {
+  if (code === "EXEC_AUTH_CLAIM_LOST") {
+    try {
+      observeNonceClaimContention();
+    } catch {
+      // Metrics are never allowed to affect the claim decision.
+    }
+  }
   return { ok: false, code, httpStatus, intentId, ...extra };
 }
 

--- a/packages/proxy/src/handlers/governed-execution.ts
+++ b/packages/proxy/src/handlers/governed-execution.ts
@@ -49,11 +49,11 @@ import {
   type GithubCanonicalActionV1,
   isExecutionAuthV2SecretConfigured,
   jcsStringify,
+  observeNonceClaimContention,
   type ProviderApprovalCommitmentV1,
   serializeCanonicalOutboundQuery,
   strictParseJson,
   verifyProviderExecutionCommitmentV2,
-  observeNonceClaimContention,
 } from "@stwd/shared";
 import { and, eq, sql } from "drizzle-orm";
 import type { Context } from "hono";

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -56,8 +56,16 @@ app.get("/health", (c) =>
 
 // ─── Opt-in operator metrics (separate token, disabled by default) ────────────
 
-app.get("/metrics", (c) => {
-  if (!securityMetricsEnabled()) return c.json({ ok: false, error: "Not found" }, 404);
+app.get("/metrics", (c, next) => {
+  // Disabled is the default. Fall THROUGH to the normal auth + proxy pipeline
+  // (return next()) rather than emitting a distinctive 404 here, so a disabled
+  // /metrics is byte-identical to any other unrouted path (the proxy's catch-all
+  // runs authMiddleware first, so an unauthenticated probe of /metrics gets the
+  // exact same 401 as an unauthenticated probe of any random path). Emitting a
+  // 404 only from here would fingerprint the endpoint's existence to an
+  // unauthenticated attacker, since every other path returns 401. This mirrors
+  // the API side, where the disabled 404 is identical to the generic notFound.
+  if (!securityMetricsEnabled()) return next();
   const authorization = c.req.header("Authorization");
   const token = authorization?.startsWith("Bearer ") ? authorization.slice(7) : undefined;
   if (!metricsTokenIsValid(token)) {

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -13,6 +13,7 @@
  */
 
 import { validateJwtSecretEnv } from "@stwd/auth";
+import { metricsTokenIsValid, renderSecurityMetrics, securityMetricsEnabled } from "@stwd/shared";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { PROXY_PORT } from "./config";
@@ -52,6 +53,25 @@ app.get("/health", (c) =>
     aliases: getAliasNames(),
   }),
 );
+
+// ─── Opt-in operator metrics (separate token, disabled by default) ────────────
+
+app.get("/metrics", (c) => {
+  if (!securityMetricsEnabled()) return c.json({ ok: false, error: "Not found" }, 404);
+  const authorization = c.req.header("Authorization");
+  const token = authorization?.startsWith("Bearer ") ? authorization.slice(7) : undefined;
+  if (!metricsTokenIsValid(token)) {
+    return c.json({ ok: false, error: "Metrics authentication required" }, 401);
+  }
+  try {
+    return c.text(renderSecurityMetrics(), 200, {
+      "Content-Type": "text/plain; version=0.0.4; charset=utf-8",
+      "Cache-Control": "no-store",
+    });
+  } catch {
+    return c.json({ ok: false, error: "Metrics unavailable" }, 503);
+  }
+});
 
 // ─── All other routes go through auth + proxy ────────────────────────────────
 

--- a/packages/shared/src/__tests__/security-metrics.test.ts
+++ b/packages/shared/src/__tests__/security-metrics.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  __resetSecurityMetricsForTests,
+  metricsTokenIsValid,
+  observeSecurityAuditEvent,
+  renderSecurityMetrics,
+  securityMetricsEnabled,
+} from "../security-metrics";
+
+describe("bounded security metrics", () => {
+  beforeEach(() => __resetSecurityMetricsForTests());
+  afterEach(() => __resetSecurityMetricsForTests());
+
+  test("real typed audit events increment only bounded labels", () => {
+    observeSecurityAuditEvent("provider.execution.succeeded", {});
+    observeSecurityAuditEvent("provider.execution.outcome_unknown", {});
+    observeSecurityAuditEvent("provider.action.denied", { reasonCode: "POLICY_HARD_DENY" });
+    observeSecurityAuditEvent("provider.approval.decided", { decision: "denied" });
+    const rendered = renderSecurityMetrics(1000);
+    expect(rendered).toContain('outcome="succeeded"} 1');
+    expect(rendered).toContain('outcome="outcome_unknown"} 1');
+    expect(rendered).toContain('reason_class="policy"} 1');
+    expect(rendered).toContain('decision="denied"} 1');
+  });
+
+  test("rejects arbitrary labels and never renders secret or PII canaries", () => {
+    const canaries = ["sk_live_SUPERSECRET", "person@example.com", "tenant-123", "raw-custom-reason"];
+    observeSecurityAuditEvent("provider.action.denied", {
+      reasonCode: canaries[3],
+      token: canaries[0],
+      email: canaries[1],
+      tenantId: canaries[2],
+    });
+    observeSecurityAuditEvent("provider.execution.attacker_label", { outcome: canaries[0] });
+    const rendered = renderSecurityMetrics();
+    for (const canary of canaries) expect(rendered).not.toContain(canary);
+    expect(rendered).toContain('reason_class="other"} 1');
+  });
+
+  test("enablement is exact and token requires 32 characters", () => {
+    expect(securityMetricsEnabled({ STEWARD_METRICS_ENABLED: "TRUE" })).toBe(false);
+    expect(securityMetricsEnabled({ STEWARD_METRICS_ENABLED: "true" })).toBe(true);
+    expect(metricsTokenIsValid("short", { STEWARD_METRICS_TOKEN: "short" })).toBe(false);
+    const token = "a".repeat(32);
+    expect(metricsTokenIsValid(token, { STEWARD_METRICS_TOKEN: token })).toBe(true);
+    expect(metricsTokenIsValid(`${token}x`, { STEWARD_METRICS_TOKEN: token })).toBe(false);
+  });
+});

--- a/packages/shared/src/__tests__/security-metrics.test.ts
+++ b/packages/shared/src/__tests__/security-metrics.test.ts
@@ -15,7 +15,7 @@ describe("bounded security metrics", () => {
     observeSecurityAuditEvent("provider.execution.succeeded", {});
     observeSecurityAuditEvent("provider.execution.outcome_unknown", {});
     observeSecurityAuditEvent("provider.action.denied", { reasonCode: "POLICY_HARD_DENY" });
-    observeSecurityAuditEvent("provider.approval.decided", { decision: "denied" });
+    observeSecurityAuditEvent("provider.approval.decided", { toStatus: "approval_denied" });
     const rendered = renderSecurityMetrics(1000);
     expect(rendered).toContain('outcome="succeeded"} 1');
     expect(rendered).toContain('outcome="outcome_unknown"} 1');
@@ -24,7 +24,12 @@ describe("bounded security metrics", () => {
   });
 
   test("rejects arbitrary labels and never renders secret or PII canaries", () => {
-    const canaries = ["sk_live_SUPERSECRET", "person@example.com", "tenant-123", "raw-custom-reason"];
+    const canaries = [
+      "sk_live_SUPERSECRET",
+      "person@example.com",
+      "tenant-123",
+      "raw-custom-reason",
+    ];
     observeSecurityAuditEvent("provider.action.denied", {
       reasonCode: canaries[3],
       token: canaries[0],

--- a/packages/shared/src/__tests__/security-metrics.test.ts
+++ b/packages/shared/src/__tests__/security-metrics.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   __resetSecurityMetricsForTests,
+  __setSecurityMetricsObserverFailureForTests,
+  classifyDenialReason,
+  DENIAL_REASON_CLASSES,
   metricsTokenIsValid,
   observeSecurityAuditEvent,
   renderSecurityMetrics,
@@ -42,6 +45,78 @@ describe("bounded security metrics", () => {
     expect(rendered).toContain('reason_class="other"} 1');
   });
 
+  test("hostile values in reasons, provider names, and error strings never mint a label", () => {
+    // Canaries injected through EVERY field the denial classifier reads, plus a
+    // wholly-unknown reason code, must all collapse to the bounded "other" class
+    // and never surface verbatim in the scrape output.
+    const canaries = [
+      "DROP TABLE audit_events",
+      "sk_live_LEAK",
+      "attacker.example.com",
+      'reason_class="injected"} 999',
+      "\n# HELP forged_metric injected\nforged_metric 1",
+    ];
+    observeSecurityAuditEvent("provider.action.denied", {
+      reasonCode: canaries[0],
+      accessReasonCode: canaries[1],
+      policyReasonCodes: [canaries[2]],
+      provider: canaries[3],
+    });
+    observeSecurityAuditEvent("provider.execution.denied_at_boundary", {
+      reasonCode: canaries[4],
+      error: canaries[1],
+    });
+    // A hostile approval decision string must not mint a decision label either.
+    observeSecurityAuditEvent("provider.approval.decided", { decision: canaries[3] });
+    const rendered = renderSecurityMetrics();
+    for (const canary of canaries) expect(rendered).not.toContain(canary);
+    // No injected metric line, no forged label — the render is a fixed catalog.
+    expect(rendered).not.toContain("forged_metric");
+    expect(rendered).not.toContain('reason_class="injected"');
+    // Every rendered reason_class label is a member of the compile-time set.
+    const reasonLabels = [...rendered.matchAll(/reason_class="([^"]*)"/g)].map((m) => m[1]);
+    for (const label of reasonLabels)
+      expect((DENIAL_REASON_CLASSES as readonly string[]).includes(label)).toBe(true);
+  });
+
+  test("classifyDenialReason always returns a bounded class for any input", () => {
+    const inputs: unknown[] = [
+      undefined,
+      null,
+      42,
+      {},
+      [],
+      "",
+      "totally-unknown-reason",
+      "POLICY_HARD_DENY",
+      "SCOPE_MISSING",
+      "EXEC_AUTH_STALE_ROUTE",
+    ];
+    for (const input of inputs)
+      expect(
+        (DENIAL_REASON_CLASSES as readonly string[]).includes(classifyDenialReason(input)),
+      ).toBe(true);
+  });
+
+  test("a throwing observer never propagates through the isolated call site", () => {
+    // The db/proxy post-commit hooks wrap observeSecurityAuditEvent in try/catch.
+    // Prove the throw is real (so the isolation wrap is load-bearing) and that a
+    // caller who wraps it, like the real hook sites do, is unaffected.
+    __setSecurityMetricsObserverFailureForTests(true);
+    expect(() => observeSecurityAuditEvent("provider.execution.succeeded", {})).toThrow();
+    let survived = false;
+    try {
+      observeSecurityAuditEvent("provider.execution.succeeded", {});
+    } catch {
+      survived = true;
+    }
+    expect(survived).toBe(true);
+    __setSecurityMetricsObserverFailureForTests(false);
+    // After clearing the fault, the counter path works again and stays bounded.
+    observeSecurityAuditEvent("provider.execution.succeeded", {});
+    expect(renderSecurityMetrics()).toContain('outcome="succeeded"} 1');
+  });
+
   test("enablement is exact and token requires 32 characters", () => {
     expect(securityMetricsEnabled({ STEWARD_METRICS_ENABLED: "TRUE" })).toBe(false);
     expect(securityMetricsEnabled({ STEWARD_METRICS_ENABLED: "true" })).toBe(true);
@@ -49,5 +124,11 @@ describe("bounded security metrics", () => {
     const token = "a".repeat(32);
     expect(metricsTokenIsValid(token, { STEWARD_METRICS_TOKEN: token })).toBe(true);
     expect(metricsTokenIsValid(`${token}x`, { STEWARD_METRICS_TOKEN: token })).toBe(false);
+    // Configured-but-short token fails closed even when the candidate matches it.
+    expect(metricsTokenIsValid("a".repeat(31), { STEWARD_METRICS_TOKEN: "a".repeat(31) })).toBe(
+      false,
+    );
+    // No configured token => always closed.
+    expect(metricsTokenIsValid(token, {})).toBe(false);
   });
 });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1295,6 +1295,8 @@ export function getChainMeta(chainId: number): ChainMeta | undefined {
   return CHAIN_META[chainId];
 }
 
+export * from "./security-metrics.js";
+
 export function getExplorerTxLink(chainId: number, txHash: string): string | undefined {
   const meta = CHAIN_META[chainId];
   return meta ? `${meta.explorerTxUrl}${txHash}` : undefined;

--- a/packages/shared/src/security-metrics.ts
+++ b/packages/shared/src/security-metrics.ts
@@ -1,5 +1,3 @@
-import { timingSafeEqual } from "node:crypto";
-
 /**
  * Process-local, bounded security metrics. This module intentionally has no I/O:
  * metrics can never participate in an authority decision or make it fail.
@@ -198,7 +196,12 @@ export function metricsTokenIsValid(
   if (!configured || configured.length < 32 || !candidate) return false;
   const expected = new TextEncoder().encode(configured);
   const actual = new TextEncoder().encode(candidate);
-  return expected.length === actual.length && timingSafeEqual(expected, actual);
+  if (expected.length !== actual.length) return false;
+  let difference = 0;
+  for (let index = 0; index < expected.length; index += 1) {
+    difference |= expected[index] ^ actual[index];
+  }
+  return difference === 0;
 }
 
 export function __setSecurityMetricsObserverFailureForTests(enabled: boolean): void {

--- a/packages/shared/src/security-metrics.ts
+++ b/packages/shared/src/security-metrics.ts
@@ -1,0 +1,142 @@
+import { timingSafeEqual } from "node:crypto";
+
+/**
+ * Process-local, bounded security metrics. This module intentionally has no I/O:
+ * metrics can never participate in an authority decision or make it fail.
+ */
+export const GOVERNED_EXECUTION_OUTCOMES = ["succeeded", "failed", "outcome_unknown"] as const;
+export const DENIAL_REASON_CLASSES = [
+  "access",
+  "policy",
+  "authorization",
+  "stale_dependency",
+  "account_disabled",
+  "audit_unavailable",
+  "terminal_state",
+  "other",
+] as const;
+export const APPROVAL_DECISIONS = ["approved", "denied"] as const;
+
+export type GovernedExecutionOutcome = (typeof GOVERNED_EXECUTION_OUTCOMES)[number];
+export type DenialReasonClass = (typeof DENIAL_REASON_CLASSES)[number];
+export type ApprovalDecision = (typeof APPROVAL_DECISIONS)[number];
+
+const executions = new Map<GovernedExecutionOutcome, number>(
+  GOVERNED_EXECUTION_OUTCOMES.map((value) => [value, 0]),
+);
+const denials = new Map<DenialReasonClass, number>(DENIAL_REASON_CLASSES.map((value) => [value, 0]));
+const approvals = new Map<ApprovalDecision, number>(APPROVAL_DECISIONS.map((value) => [value, 0]));
+let bypassDenials = 0;
+let nonceContentions = 0;
+let lastCheckpointAtMs: number | null = null;
+
+function incrementBounded<T extends string>(map: Map<T, number>, value: string, allowed: readonly T[]): void {
+  if (!allowed.includes(value as T)) return;
+  map.set(value as T, (map.get(value as T) ?? 0) + 1);
+}
+
+export function classifyDenialReason(reasonCode: unknown): DenialReasonClass {
+  if (typeof reasonCode !== "string") return "other";
+  if (reasonCode.startsWith("SCOPE_") || reasonCode.startsWith("ACCESS_")) return "access";
+  if (reasonCode.startsWith("POLICY_")) return "policy";
+  if (reasonCode.includes("STALE_") || reasonCode.includes("DEPENDENCY")) return "stale_dependency";
+  if (reasonCode.includes("ACCOUNT_DISABLED")) return "account_disabled";
+  if (reasonCode.includes("AUDIT_UNAVAILABLE")) return "audit_unavailable";
+  if (reasonCode.includes("TERMINAL_STATE")) return "terminal_state";
+  if (reasonCode.startsWith("EXEC_AUTH_") || reasonCode.startsWith("AUTH_")) return "authorization";
+  return "other";
+}
+
+export function observeGovernedExecution(outcome: string): void {
+  incrementBounded(executions, outcome, GOVERNED_EXECUTION_OUTCOMES);
+}
+export function observeDenial(reasonCode: unknown): void {
+  incrementBounded(denials, classifyDenialReason(reasonCode), DENIAL_REASON_CLASSES);
+}
+export function observeApprovalDecision(decision: string): void {
+  incrementBounded(approvals, decision, APPROVAL_DECISIONS);
+}
+export function observeBypassDenial(): void {
+  bypassDenials += 1;
+}
+export function observeNonceClaimContention(): void {
+  nonceContentions += 1;
+}
+export function observeAuditCheckpoint(createdAtMs = Date.now()): void {
+  lastCheckpointAtMs = createdAtMs;
+}
+
+/** Observe only established typed audit events. Unknown actions are ignored. */
+export function observeSecurityAuditEvent(action: string, metadata: Record<string, unknown> = {}): void {
+  if (action === "provider.execution.succeeded") observeGovernedExecution("succeeded");
+  else if (action === "provider.execution.failed") observeGovernedExecution("failed");
+  else if (action === "provider.execution.outcome_unknown") observeGovernedExecution("outcome_unknown");
+  else if (action === "provider.action.denied") observeDenial(metadata.reasonCode ?? metadata.accessReasonCode);
+  else if (action === "provider.execution.denied_at_boundary") {
+    observeDenial(metadata.reasonCode);
+    observeBypassDenial();
+  } else if (action === "provider.approval.decided") {
+    observeApprovalDecision(typeof metadata.decision === "string" ? metadata.decision : "");
+  }
+}
+
+function metricLine(name: string, labels: string, value: number): string {
+  return `${name}${labels.length > 0 ? `{${labels}}` : ""} ${value}`;
+}
+
+export function renderSecurityMetrics(nowMs = Date.now()): string {
+  const lines = [
+    "# HELP steward_governed_executions_total Governed executions completed by bounded outcome.",
+    "# TYPE steward_governed_executions_total counter",
+  ];
+  for (const outcome of GOVERNED_EXECUTION_OUTCOMES) {
+    lines.push(metricLine("steward_governed_executions_total", `outcome=\"${outcome}\"`, executions.get(outcome) ?? 0));
+  }
+  lines.push(
+    "# HELP steward_security_denials_total Security denials by bounded reason class.",
+    "# TYPE steward_security_denials_total counter",
+  );
+  for (const reasonClass of DENIAL_REASON_CLASSES) {
+    lines.push(metricLine("steward_security_denials_total", `reason_class=\"${reasonClass}\"`, denials.get(reasonClass) ?? 0));
+  }
+  lines.push(
+    "# HELP steward_approval_decisions_total Provider approval decisions by bounded decision.",
+    "# TYPE steward_approval_decisions_total counter",
+  );
+  for (const decision of APPROVAL_DECISIONS) {
+    lines.push(metricLine("steward_approval_decisions_total", `decision=\"${decision}\"`, approvals.get(decision) ?? 0));
+  }
+  lines.push(
+    "# HELP steward_governed_boundary_denials_total Governed execution attempts denied at the provider boundary.",
+    "# TYPE steward_governed_boundary_denials_total counter",
+    metricLine("steward_governed_boundary_denials_total", "", bypassDenials),
+    "# HELP steward_nonce_claim_contentions_total Governed execution nonce claims lost to contention.",
+    "# TYPE steward_nonce_claim_contentions_total counter",
+    metricLine("steward_nonce_claim_contentions_total", "", nonceContentions),
+    "# HELP steward_audit_checkpoint_age_seconds Seconds since this process last created an audit checkpoint; -1 means none observed since start.",
+    "# TYPE steward_audit_checkpoint_age_seconds gauge",
+    metricLine("steward_audit_checkpoint_age_seconds", "", lastCheckpointAtMs === null ? -1 : Math.max(0, (nowMs - lastCheckpointAtMs) / 1000)),
+  );
+  return `${lines.join("\n")}\n`;
+}
+
+export function securityMetricsEnabled(env: Record<string, string | undefined> = process.env): boolean {
+  return env.STEWARD_METRICS_ENABLED === "true";
+}
+
+export function metricsTokenIsValid(candidate: string | undefined, env: Record<string, string | undefined> = process.env): boolean {
+  const configured = env.STEWARD_METRICS_TOKEN;
+  if (!configured || configured.length < 32 || !candidate) return false;
+  const expected = new TextEncoder().encode(configured);
+  const actual = new TextEncoder().encode(candidate);
+  return expected.length === actual.length && timingSafeEqual(expected, actual);
+}
+
+export function __resetSecurityMetricsForTests(): void {
+  for (const key of GOVERNED_EXECUTION_OUTCOMES) executions.set(key, 0);
+  for (const key of DENIAL_REASON_CLASSES) denials.set(key, 0);
+  for (const key of APPROVAL_DECISIONS) approvals.set(key, 0);
+  bypassDenials = 0;
+  nonceContentions = 0;
+  lastCheckpointAtMs = null;
+}

--- a/packages/shared/src/security-metrics.ts
+++ b/packages/shared/src/security-metrics.ts
@@ -24,26 +24,40 @@ export type ApprovalDecision = (typeof APPROVAL_DECISIONS)[number];
 const executions = new Map<GovernedExecutionOutcome, number>(
   GOVERNED_EXECUTION_OUTCOMES.map((value) => [value, 0]),
 );
-const denials = new Map<DenialReasonClass, number>(DENIAL_REASON_CLASSES.map((value) => [value, 0]));
+const denials = new Map<DenialReasonClass, number>(
+  DENIAL_REASON_CLASSES.map((value) => [value, 0]),
+);
 const approvals = new Map<ApprovalDecision, number>(APPROVAL_DECISIONS.map((value) => [value, 0]));
 let bypassDenials = 0;
 let nonceContentions = 0;
 let lastCheckpointAtMs: number | null = null;
+let failObserverForTests = false;
 
-function incrementBounded<T extends string>(map: Map<T, number>, value: string, allowed: readonly T[]): void {
+function incrementBounded<T extends string>(
+  map: Map<T, number>,
+  value: string,
+  allowed: readonly T[],
+): void {
   if (!allowed.includes(value as T)) return;
   map.set(value as T, (map.get(value as T) ?? 0) + 1);
 }
 
 export function classifyDenialReason(reasonCode: unknown): DenialReasonClass {
   if (typeof reasonCode !== "string") return "other";
-  if (reasonCode.startsWith("SCOPE_") || reasonCode.startsWith("ACCESS_")) return "access";
-  if (reasonCode.startsWith("POLICY_")) return "policy";
-  if (reasonCode.includes("STALE_") || reasonCode.includes("DEPENDENCY")) return "stale_dependency";
-  if (reasonCode.includes("ACCOUNT_DISABLED")) return "account_disabled";
-  if (reasonCode.includes("AUDIT_UNAVAILABLE")) return "audit_unavailable";
-  if (reasonCode.includes("TERMINAL_STATE")) return "terminal_state";
-  if (reasonCode.startsWith("EXEC_AUTH_") || reasonCode.startsWith("AUTH_")) return "authorization";
+  const normalized = reasonCode.toUpperCase();
+  if (
+    normalized.startsWith("SCOPE_") ||
+    normalized.startsWith("ACCESS_") ||
+    normalized.startsWith("GRANT_") ||
+    normalized.includes("GRANT")
+  )
+    return "access";
+  if (normalized.startsWith("POLICY_")) return "policy";
+  if (normalized.includes("STALE_") || normalized.includes("DEPENDENCY")) return "stale_dependency";
+  if (normalized.includes("ACCOUNT_DISABLED")) return "account_disabled";
+  if (normalized.includes("AUDIT_UNAVAILABLE")) return "audit_unavailable";
+  if (normalized.includes("TERMINAL_STATE")) return "terminal_state";
+  if (normalized.startsWith("EXEC_AUTH_") || normalized.startsWith("AUTH_")) return "authorization";
   return "other";
 }
 
@@ -67,16 +81,44 @@ export function observeAuditCheckpoint(createdAtMs = Date.now()): void {
 }
 
 /** Observe only established typed audit events. Unknown actions are ignored. */
-export function observeSecurityAuditEvent(action: string, metadata: Record<string, unknown> = {}): void {
+export function observeSecurityAuditEvent(action: string, metadata: unknown = {}): void {
+  if (failObserverForTests) throw new Error("injected security metrics observer failure");
+  let fields: Record<string, unknown> = {};
+  if (metadata && typeof metadata === "object" && !Array.isArray(metadata)) {
+    fields = metadata as Record<string, unknown>;
+  } else if (typeof metadata === "string") {
+    try {
+      const parsed = JSON.parse(metadata);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        fields = parsed as Record<string, unknown>;
+      }
+    } catch {
+      // Malformed metadata is untrusted detail, never a metric label.
+    }
+  }
   if (action === "provider.execution.succeeded") observeGovernedExecution("succeeded");
   else if (action === "provider.execution.failed") observeGovernedExecution("failed");
-  else if (action === "provider.execution.outcome_unknown") observeGovernedExecution("outcome_unknown");
-  else if (action === "provider.action.denied") observeDenial(metadata.reasonCode ?? metadata.accessReasonCode);
-  else if (action === "provider.execution.denied_at_boundary") {
-    observeDenial(metadata.reasonCode);
+  else if (action === "provider.execution.outcome_unknown")
+    observeGovernedExecution("outcome_unknown");
+  else if (action === "provider.action.denied") {
+    const policyReasons = fields.policyReasonCodes;
+    const reason =
+      fields.policyEffect === "hard_deny"
+        ? "POLICY_HARD_DENY"
+        : fields.policyEffect === "not_evaluated"
+          ? "ACCESS_DENIED"
+          : Array.isArray(policyReasons) && policyReasons.length > 0
+            ? policyReasons[0]
+            : (fields.reasonCode ?? fields.accessReasonCode);
+    observeDenial(reason);
+  } else if (action === "provider.execution.denied_at_boundary") {
+    observeDenial(fields.reasonCode);
     observeBypassDenial();
   } else if (action === "provider.approval.decided") {
-    observeApprovalDecision(typeof metadata.decision === "string" ? metadata.decision : "");
+    const decision = fields.decision ?? fields.toStatus;
+    observeApprovalDecision(
+      decision === "approved" ? "approved" : decision === "approval_denied" ? "denied" : "",
+    );
   }
 }
 
@@ -90,21 +132,39 @@ export function renderSecurityMetrics(nowMs = Date.now()): string {
     "# TYPE steward_governed_executions_total counter",
   ];
   for (const outcome of GOVERNED_EXECUTION_OUTCOMES) {
-    lines.push(metricLine("steward_governed_executions_total", `outcome=\"${outcome}\"`, executions.get(outcome) ?? 0));
+    lines.push(
+      metricLine(
+        "steward_governed_executions_total",
+        `outcome="${outcome}"`,
+        executions.get(outcome) ?? 0,
+      ),
+    );
   }
   lines.push(
     "# HELP steward_security_denials_total Security denials by bounded reason class.",
     "# TYPE steward_security_denials_total counter",
   );
   for (const reasonClass of DENIAL_REASON_CLASSES) {
-    lines.push(metricLine("steward_security_denials_total", `reason_class=\"${reasonClass}\"`, denials.get(reasonClass) ?? 0));
+    lines.push(
+      metricLine(
+        "steward_security_denials_total",
+        `reason_class="${reasonClass}"`,
+        denials.get(reasonClass) ?? 0,
+      ),
+    );
   }
   lines.push(
     "# HELP steward_approval_decisions_total Provider approval decisions by bounded decision.",
     "# TYPE steward_approval_decisions_total counter",
   );
   for (const decision of APPROVAL_DECISIONS) {
-    lines.push(metricLine("steward_approval_decisions_total", `decision=\"${decision}\"`, approvals.get(decision) ?? 0));
+    lines.push(
+      metricLine(
+        "steward_approval_decisions_total",
+        `decision="${decision}"`,
+        approvals.get(decision) ?? 0,
+      ),
+    );
   }
   lines.push(
     "# HELP steward_governed_boundary_denials_total Governed execution attempts denied at the provider boundary.",
@@ -115,21 +175,34 @@ export function renderSecurityMetrics(nowMs = Date.now()): string {
     metricLine("steward_nonce_claim_contentions_total", "", nonceContentions),
     "# HELP steward_audit_checkpoint_age_seconds Seconds since this process last created an audit checkpoint; -1 means none observed since start.",
     "# TYPE steward_audit_checkpoint_age_seconds gauge",
-    metricLine("steward_audit_checkpoint_age_seconds", "", lastCheckpointAtMs === null ? -1 : Math.max(0, (nowMs - lastCheckpointAtMs) / 1000)),
+    metricLine(
+      "steward_audit_checkpoint_age_seconds",
+      "",
+      lastCheckpointAtMs === null ? -1 : Math.max(0, (nowMs - lastCheckpointAtMs) / 1000),
+    ),
   );
   return `${lines.join("\n")}\n`;
 }
 
-export function securityMetricsEnabled(env: Record<string, string | undefined> = process.env): boolean {
+export function securityMetricsEnabled(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
   return env.STEWARD_METRICS_ENABLED === "true";
 }
 
-export function metricsTokenIsValid(candidate: string | undefined, env: Record<string, string | undefined> = process.env): boolean {
+export function metricsTokenIsValid(
+  candidate: string | undefined,
+  env: Record<string, string | undefined> = process.env,
+): boolean {
   const configured = env.STEWARD_METRICS_TOKEN;
   if (!configured || configured.length < 32 || !candidate) return false;
   const expected = new TextEncoder().encode(configured);
   const actual = new TextEncoder().encode(candidate);
   return expected.length === actual.length && timingSafeEqual(expected, actual);
+}
+
+export function __setSecurityMetricsObserverFailureForTests(enabled: boolean): void {
+  failObserverForTests = enabled;
 }
 
 export function __resetSecurityMetricsForTests(): void {
@@ -139,4 +212,5 @@ export function __resetSecurityMetricsForTests(): void {
   bypassDenials = 0;
   nonceContentions = 0;
   lastCheckpointAtMs = null;
+  failObserverForTests = false;
 }

--- a/scripts/security-metrics-mutation-proofs.sh
+++ b/scripts/security-metrics-mutation-proofs.sh
@@ -4,15 +4,18 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 API="$ROOT/packages/api/src/routes/metrics.ts"
 SHARED="$ROOT/packages/shared/src/security-metrics.ts"
+PROXY="$ROOT/packages/proxy/src/index.ts"
 TMP="$(mktemp -d)"
 cleanup() {
   cp "$TMP/metrics-route.ts" "$API"
   cp "$TMP/security-metrics.ts" "$SHARED"
+  cp "$TMP/proxy-index.ts" "$PROXY"
   rm -rf "$TMP"
 }
 trap cleanup EXIT
 cp "$API" "$TMP/metrics-route.ts"
 cp "$SHARED" "$TMP/security-metrics.ts"
+cp "$PROXY" "$TMP/proxy-index.ts"
 
 python3 - "$API" <<'PY'
 import sys
@@ -49,3 +52,23 @@ if (cd "$ROOT/packages/shared" && bun test --timeout 30000 src/__tests__/securit
   exit 1
 fi
 echo "PASS: bounded label allowlist mutation was killed"
+cp "$TMP/security-metrics.ts" "$SHARED"
+
+# Mutation 3 (proxy exposure fingerprint): revert the disabled-path fall-through
+# to a distinctive 404. The disabled /metrics must be indistinguishable from any
+# other unrouted path (both hit the auth catch-all => 401). A 404 here would
+# fingerprint the endpoint's existence to an unauthenticated attacker.
+python3 - "$PROXY" <<'PY'
+import sys
+p=sys.argv[1]
+s=open(p).read()
+old='if (!securityMetricsEnabled()) return next();'
+assert s.count(old) == 1
+s=s.replace(old, 'if (!securityMetricsEnabled()) return c.json({ ok: false, error: "Not found" }, 404);')
+open(p,'w').write(s)
+PY
+if (cd "$ROOT/packages/proxy" && STEWARD_JWT_SECRET="$(printf 'x%.0s' {1..48})" STEWARD_ALLOW_DEV_SECRETS=true STEWARD_PGLITE_MEMORY=true DATABASE_URL="postgres://u:p@localhost:5432/x" bun test --timeout 30000 src/__tests__/metrics-exposure.test.ts >/dev/null 2>&1); then
+  echo "FAIL: proxy metrics exposure fingerprint mutation survived" >&2
+  exit 1
+fi
+echo "PASS: proxy metrics exposure fingerprint mutation was killed"

--- a/scripts/security-metrics-mutation-proofs.sh
+++ b/scripts/security-metrics-mutation-proofs.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+API="$ROOT/packages/api/src/routes/metrics.ts"
+SHARED="$ROOT/packages/shared/src/security-metrics.ts"
+TMP="$(mktemp -d)"
+cleanup() {
+  cp "$TMP/metrics-route.ts" "$API"
+  cp "$TMP/security-metrics.ts" "$SHARED"
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+cp "$API" "$TMP/metrics-route.ts"
+cp "$SHARED" "$TMP/security-metrics.ts"
+
+python3 - "$API" <<'PY'
+import sys
+p=sys.argv[1]
+s=open(p).read()
+old='if (!securityMetricsEnabled()) {'
+assert s.count(old) == 1
+open(p,'w').write(s.replace(old, 'if (false) {'))
+PY
+if (cd "$ROOT/packages/api" && bun test --timeout 30000 src/__tests__/metrics-endpoint.test.ts >/dev/null 2>&1); then
+  echo "FAIL: disabled endpoint exposure mutation survived" >&2
+  exit 1
+fi
+cp "$TMP/metrics-route.ts" "$API"
+echo "PASS: endpoint exposure guard mutation was killed"
+
+python3 - "$SHARED" <<'PY'
+import sys
+p=sys.argv[1]
+s=open(p).read()
+old_guard='if (!allowed.includes(value as T)) return;'
+old_observe='incrementBounded(denials, classifyDenialReason(reasonCode), DENIAL_REASON_CLASSES);'
+old_render='for (const reasonClass of DENIAL_REASON_CLASSES) {'
+assert s.count(old_guard) == 1
+assert s.count(old_observe) == 1
+assert s.count(old_render) == 1
+s=s.replace(old_guard, 'if (false) return;')
+s=s.replace(old_observe, 'incrementBounded(denials, String(reasonCode), DENIAL_REASON_CLASSES);')
+s=s.replace(old_render, 'for (const reasonClass of denials.keys()) {')
+open(p,'w').write(s)
+PY
+if (cd "$ROOT/packages/shared" && bun test --timeout 30000 src/__tests__/security-metrics.test.ts >/dev/null 2>&1); then
+  echo "FAIL: bounded label allowlist mutation survived" >&2
+  exit 1
+fi
+echo "PASS: bounded label allowlist mutation was killed"


### PR DESCRIPTION
## Summary

- add an opt-in Prometheus-compatible `/metrics` endpoint to the API and proxy, disabled by default and protected by a dedicated constant-time-compared operator bearer token
- collect process-local bounded counters/gauges from committed typed audit events and the real nonce-claim contention path without adding authority dependencies
- statically constrain all labels to outcome, denial-class, and approval-decision allowlists; never render tenant/user/agent/action/route/provider IDs, raw reasons, arbitrary errors, secrets, or PII
- document self-hosted exposure, reset semantics, durable-audit distinction, event severity, and conservative starter alerts
- add endpoint, canary, real governed service path, collection-failure isolation, and mutation proof coverage

## Security posture

- default: disabled, `/metrics` returns 404
- enabled: requires `STEWARD_METRICS_ENABLED=true` plus a `STEWARD_METRICS_TOKEN` of at least 32 characters
- zero phone-home, in-memory only, counters reset on process restart
- metrics are post-commit/best-effort and cannot authorize, deny, or roll back a governed action
- `provider.execution.denied_at_boundary` is reported narrowly as a boundary denial; this PR does not invent a generic bypass event

## Validation

- `bun run --cwd packages/shared build`
- `bun run --cwd packages/db build`
- `bun run --cwd packages/redis build`
- `bun run --cwd packages/api build`
- `bun run --cwd packages/proxy build`
- API isolated: metrics endpoint, provider action service, approvals, cases, audit bundles, provider-X governed E2E
- proxy isolated: governed execution suite
- shared bounded/canary suite
- Biome on all changed TS files
- `scripts/security-metrics-mutation-proofs.sh` kills endpoint-exposure and label-allowlist mutants
- Codex review against `origin/develop`: no findings

## Honest gaps

- metrics are process-local, so API and proxy must both be scraped and process restarts reset counters
- nonce contention is a typed proxy result but is not currently a durable audit event; the runbook calls this out explicitly
- the all-plugin single-process test command showed known shared-state failures and was stopped; the governed API/proxy regression floor and package builds passed

Closes #212

[sol-orch]
