### PR TITLE
feat(mcp): add governed provider action tools

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -190,6 +190,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@stwd/sdk": "workspace:*",
+        "@stwd/shared": "workspace:*",
         "zod": "^4.3.6",
       },
       "devDependencies": {

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -126,6 +126,15 @@ provider credential, URL, or host arguments. Approval, case, and evidence reads
 retain the API's human-session, MFA, role, workspace, and tenant gates. In
 particular, an agent JWT cannot use MCP to impersonate a human approver.
 
+The current API intentionally has split auth modes. Invocation requires an agent
+JWT. The existing status route (`GET /intents/:id`) requires a tenant API key or
+owner/admin session. Approval, case, and evidence reads require eligible human
+sessions and recent MFA, with case and evidence further limited to owner/admin.
+A single agent-JWT MCP process can invoke but receives honest authorization
+errors from those human or tenant-level read routes. No agent-readable v2 status
+route exists on the current API, and this package does not invent one or weaken
+the API gates.
+
 These tools **do not implement MCP OAuth 2.1 resource-server semantics**. That
 separate authorization-layer work is tracked by issue #219.
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -4,12 +4,13 @@ A [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server that
 exposes [Steward](https://steward.fi) agent-wallet and auth operations as tools
 that AI agents and MCP-aware IDEs (Claude Code, Cursor, etc.) can call.
 
-The server is a **thin, authenticated client**. It calls the Steward API through
-the official [`@stwd/sdk`](../sdk) `StewardClient` and never reimplements HTTP,
-holds private keys, or bypasses policy. Every signing or transfer tool is
-evaluated by Steward's policy engine server-side — a request may be signed,
-broadcast, rejected, or queued for human approval, and this server cannot
-override that decision.
+The server is a **thin, authenticated client**. Wallet tools call the Steward API
+through the official [`@stwd/sdk`](../sdk) `StewardClient`. Provider-action tools
+use a narrow internal HTTP transport for the existing v2 routes. Both transports
+use only server configuration. Tool arguments cannot choose a tenant, credential,
+host, or URL. The package holds no provider credentials, private keys, or policy
+authority. Steward evaluates every action server-side, and this server cannot
+override the result.
 
 ## Install
 
@@ -100,6 +101,11 @@ structured content; Steward API errors surface their HTTP status and any policy
 
 | Tool | Kind | SDK method | Description |
 | --- | --- | --- | --- |
+| `provider_action_invoke` | write (destructive) | `POST /v2/provider-actions` | Submit an action for provider authorization and policy evaluation. |
+| `provider_action_status` | read | `GET /intents/:id` | Fetch current action intent status through the API's existing status route. |
+| `provider_action_approval` | read | `GET /v2/provider-actions/:id/approval` | Fetch approval state. The API requires an eligible human session and recent MFA. |
+| `provider_action_case` | read | `GET /v2/provider-actions/:id/case` | Fetch the correlated case manifest. |
+| `provider_action_evidence` | read | `GET /v2/provider-actions/:id/evidence` | Fetch the correlated signed evidence bundle. |
 | `list_wallets` | read | `listAgents` | List all agent wallets visible to the credentials. |
 | `get_wallet` | read | `getAgent` | Fetch a single agent wallet's identity. |
 | `create_wallet` | write | `createWallet` | Provision a new agent wallet (keys stay in Steward). |
@@ -111,6 +117,17 @@ structured content; Steward API errors surface their HTTP status and any policy
 | `get_policy` | read | `getPolicyRule` | A single policy rule by id. |
 | `list_pending_approvals` | read | `listApprovals` | Transactions awaiting human approval. |
 | `get_audit_log` | read | `getAuditLog` | Paginated tenant audit log with filters. |
+
+### Authorization boundary
+
+Provider tools send the same configured Steward credential and optional tenant
+header as the existing MCP client. They do not accept tenant, actor, bearer,
+provider credential, URL, or host arguments. Approval, case, and evidence reads
+retain the API's human-session, MFA, role, workspace, and tenant gates. In
+particular, an agent JWT cannot use MCP to impersonate a human approver.
+
+These tools **do not implement MCP OAuth 2.1 resource-server semantics**. That
+separate authorization-layer work is tracked by issue #219.
 
 ## Development
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -52,6 +52,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@stwd/sdk": "workspace:*",
+    "@stwd/shared": "workspace:*",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/packages/mcp/scripts/provider-action-mutation-proofs.sh
+++ b/packages/mcp/scripts/provider-action-mutation-proofs.sh
@@ -50,4 +50,14 @@ python3 -c 'p="packages/mcp/src/tools.ts";s=open(p).read();start=s.index("const 
 expect_red "rejects malformed action ids"
 restore_green
 
-echo "4/4 provider-action mutation proofs passed"
+# Upstream non-2xx must throw, never render as a success value (5xx-honesty).
+python3 -c 'p="packages/mcp/src/provider-api.ts";s=open(p).read();s=s.replace("if (!response.ok) {", "if (false && !response.ok) {", 1);open(p,"w").write(s)'
+expect_red "throws ProviderApiError"
+restore_green
+
+# Redaction must run on real non-ok error bodies before they surface.
+python3 -c 'p="packages/mcp/src/provider-api.ts";s=open(p).read();s=s.replace("const clean = sanitizeProviderPayload(payload);", "const clean = payload;", 1);open(p,"w").write(s)'
+expect_red "redacts secrets in a real non-ok"
+restore_green
+
+echo "6/6 provider-action mutation proofs passed"

--- a/packages/mcp/scripts/provider-action-mutation-proofs.sh
+++ b/packages/mcp/scripts/provider-action-mutation-proofs.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/../../.."
+TOOLS="packages/mcp/src/tools.ts"
+API="packages/mcp/src/provider-api.ts"
+TOOLS_SAVE="$(mktemp)"
+API_SAVE="$(mktemp)"
+cp "$TOOLS" "$TOOLS_SAVE"
+cp "$API" "$API_SAVE"
+cleanup() {
+  cp "$TOOLS_SAVE" "$TOOLS"
+  cp "$API_SAVE" "$API"
+  rm -f "$TOOLS_SAVE" "$API_SAVE"
+}
+trap cleanup EXIT
+
+expect_red() {
+  local name="$1"
+  if bun test packages/mcp/src/__tests__/provider-tools.test.ts -t "$name" >/tmp/steward-mcp-mutation.log 2>&1; then
+    echo "mutation unexpectedly GREEN: $name" >&2
+    cat /tmp/steward-mcp-mutation.log >&2
+    exit 1
+  fi
+  echo "RED confirmed: $name"
+}
+restore_green() {
+  cp "$TOOLS_SAVE" "$TOOLS"
+  cp "$API_SAVE" "$API"
+  bun test packages/mcp/src/__tests__/provider-tools.test.ts >/dev/null
+  echo "GREEN restored"
+}
+
+# Tenant binding and caller-controlled host fields depend on strict schemas.
+python3 -c 'p="packages/mcp/src/tools.ts";s=open(p).read();s=s.replace("schema: z.object({ actionId: providerCaseId }).strict(),", "schema: z.object({ actionId: providerCaseId }).passthrough(),", 1);open(p,"w").write(s)'
+expect_red "rejects tenant, workspace substitution"
+restore_green
+
+# Credential-bearing keys must be replaced, not traversed.
+python3 -c 'p="packages/mcp/src/provider-api.ts";s=open(p).read();s=s.replace("SENSITIVE_KEY.test(key)\n        ? \"[redacted]\"\n        : sanitizeProviderPayload(nested, depth + 1)", "sanitizeProviderPayload(nested, depth + 1)");open(p,"w").write(s)'
+expect_red "removes credential canaries"
+restore_green
+
+# Pending responses must retain machine-readable policy detail.
+python3 -c 'p="packages/mcp/src/tools.ts";s=open(p).read();s=s.replace("structuredContent: structured,", "structuredContent: {},");open(p,"w").write(s)'
+expect_red "preserves pending approval"
+restore_green
+
+# Invalid action ids must not reach transport.
+python3 -c 'p="packages/mcp/src/tools.ts";s=open(p).read();start=s.index("const providerCaseId = z");end=s.index("const idempotencyKey", start);s=s[:start]+"const providerCaseId = z.string();\n"+s[end:];open(p,"w").write(s)'
+expect_red "rejects malformed action ids"
+restore_green
+
+echo "4/4 provider-action mutation proofs passed"

--- a/packages/mcp/src/__tests__/provider-tools.test.ts
+++ b/packages/mcp/src/__tests__/provider-tools.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, test } from "bun:test";
+import type { StewardClient } from "@stwd/sdk";
+import { type ProviderApi, ProviderApiError, sanitizeProviderPayload } from "../provider-api.js";
+import { buildTools, type StewardTool } from "../tools.js";
+
+const ACTION_ID = `pa_12345678-1234-1234-1234-123456789abc`;
+
+function harness(responses: Record<string, unknown | Error>) {
+  const calls: Array<{ path: string; init?: RequestInit }> = [];
+  const providerApi: ProviderApi = {
+    async request(path, init) {
+      calls.push({ path, init });
+      const response = responses[path];
+      if (response instanceof Error) throw response;
+      return response;
+    },
+  };
+  const tools = buildTools({
+    client: {} as StewardClient,
+    providerApi,
+    config: {},
+  });
+  return { calls, tools: new Map(tools.map((tool: StewardTool) => [tool.name, tool])) };
+}
+
+const validInvoke = {
+  workspaceId: "ws_main",
+  providerAccountId: "pa_github",
+  operationKey: "issue.create",
+  arguments: { repository: "owner/repo", title: "bounded action" },
+  idempotencyKey: "invoke-00000001",
+};
+
+describe("governed provider action tools", () => {
+  test("invokes the fixed v2 route and surfaces an allowed result", async () => {
+    const allowed = { id: ACTION_ID, status: "executed", result: { outcome: "allowed" } };
+    const { tools, calls } = harness({ "/v2/provider-actions": allowed });
+    const result = await tools.get("provider_action_invoke")!.handler(validInvoke);
+    expect(result.structuredContent).toEqual(allowed);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].path).toBe("/v2/provider-actions");
+    expect(JSON.parse(calls[0].init?.body as string)).toEqual(validInvoke);
+  });
+
+  test("preserves pending approval and policy reasons as structured content", async () => {
+    const pending = {
+      id: ACTION_ID,
+      status: "pending_approval",
+      policy: { results: [{ rule: "human_review", reason: "approval threshold" }] },
+    };
+    const { tools } = harness({ "/v2/provider-actions": pending });
+    const result = await tools.get("provider_action_invoke")!.handler(validInvoke);
+    expect(result.isError).toBeUndefined();
+    expect(result.structuredContent).toEqual(pending);
+  });
+
+  test("surfaces denial clearly with the complete sanitized policy payload", async () => {
+    const denied = new ProviderApiError("POLICY_DENIED", 403, {
+      error: "POLICY_DENIED",
+      results: [{ rule: "repository_allowlist", reason: "repository denied" }],
+    });
+    const { tools } = harness({ "/v2/provider-actions": denied });
+    const result = await tools.get("provider_action_invoke")!.handler(validInvoke);
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent).toMatchObject({
+      status: 403,
+      data: { error: "POLICY_DENIED" },
+    });
+    expect(result.content[0].text).toContain("repository denied");
+  });
+
+  test("uses only fixed status, approval, case, and evidence routes", async () => {
+    const routes = {
+      [`/intents/${ACTION_ID}`]: { status: "authorized" },
+      [`/v2/provider-actions/${ACTION_ID}/approval`]: { status: "pending" },
+      [`/v2/provider-actions/${ACTION_ID}/case`]: { kind: "case" },
+      [`/v2/provider-actions/${ACTION_ID}/evidence`]: { kind: "evidence" },
+    };
+    const { tools, calls } = harness(routes);
+    for (const name of ["status", "approval", "case", "evidence"]) {
+      const result = await tools.get(`provider_action_${name}`)!.handler({ actionId: ACTION_ID });
+      expect(result.isError).toBeUndefined();
+    }
+    expect(calls.map((call) => call.path)).toEqual(Object.keys(routes));
+  });
+
+  test("rejects tenant, workspace substitution, host injection, and unknown keys", async () => {
+    const { tools, calls } = harness({});
+    for (const input of [
+      { ...validInvoke, tenantId: "foreign" },
+      { actionId: ACTION_ID, workspaceId: "foreign" },
+      { actionId: ACTION_ID, host: "http://169.254.169.254" },
+    ]) {
+      const tool = "operationKey" in input ? "provider_action_invoke" : "provider_action_status";
+      const result = await tools.get(tool)!.handler(input);
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("Invalid tool input");
+    }
+    expect(calls).toHaveLength(0);
+  });
+
+  test("rejects malformed action ids, operation keys, and idempotency keys", async () => {
+    const { tools, calls } = harness({});
+    expect(
+      (await tools.get("provider_action_status")!.handler({ actionId: "../../secret" })).isError,
+    ).toBe(true);
+    expect(
+      (
+        await tools
+          .get("provider_action_invoke")!
+          .handler({ ...validInvoke, operationKey: "x".repeat(129) })
+      ).isError,
+    ).toBe(true);
+    expect(
+      (
+        await tools
+          .get("provider_action_invoke")!
+          .handler({ ...validInvoke, idempotencyKey: "short" })
+      ).isError,
+    ).toBe(true);
+    expect(calls).toHaveLength(0);
+  });
+
+  test("reports an upstream timeout honestly without claiming an outcome", async () => {
+    const timeout = new ProviderApiError("Provider API request failed: The operation timed out", 0);
+    const { tools } = harness({ "/v2/provider-actions": timeout });
+    const result = await tools.get("provider_action_invoke")!.handler(validInvoke);
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("timed out");
+    expect(result.content[0].text).not.toMatch(/executed|allowed|succeeded/);
+  });
+});
+
+describe("credential redaction", () => {
+  test("removes credential canaries from nested returned and error payloads", () => {
+    const canary = "credential-canary-7e132";
+    const clean = JSON.stringify(
+      sanitizeProviderPayload({
+        authorization: `Bearer ${canary}`,
+        nested: { providerToken: canary, message: `token=${canary}` },
+      }),
+    );
+    expect(clean).not.toContain(canary);
+    expect(clean).toContain("[redacted]");
+  });
+});

--- a/packages/mcp/src/__tests__/provider-tools.test.ts
+++ b/packages/mcp/src/__tests__/provider-tools.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import type { StewardClient } from "@stwd/sdk";
-import { type ProviderApi, ProviderApiError, sanitizeProviderPayload } from "../provider-api.js";
+import {
+  createProviderApi,
+  type ProviderApi,
+  ProviderApiError,
+  sanitizeProviderPayload,
+} from "../provider-api.js";
 import { buildTools, type StewardTool } from "../tools.js";
 
 const ACTION_ID = `pa_12345678-1234-1234-1234-123456789abc`;
@@ -128,6 +133,78 @@ describe("governed provider action tools", () => {
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain("timed out");
     expect(result.content[0].text).not.toMatch(/executed|allowed|succeeded/);
+  });
+});
+
+describe("createProviderApi HTTP transport", () => {
+  const realFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  function stubFetch(
+    status: number,
+    body: unknown,
+  ): { seen: Array<{ url: string; init?: RequestInit }> } {
+    const seen: Array<{ url: string; init?: RequestInit }> = [];
+    globalThis.fetch = (async (url: string, init?: RequestInit) => {
+      seen.push({ url: String(url), init });
+      return new Response(JSON.stringify(body), {
+        status,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+    return { seen };
+  }
+
+  test("throws ProviderApiError (never a success value) on an upstream 5xx", async () => {
+    stubFetch(503, { error: "UPSTREAM_UNAVAILABLE" });
+    const api = createProviderApi({
+      baseUrl: "https://steward.example",
+      bearerToken: "agent-jwt",
+    });
+    let thrown: unknown;
+    try {
+      await api.request("/v2/provider-actions", { method: "POST", body: "{}" });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(ProviderApiError);
+    expect((thrown as ProviderApiError).status).toBe(503);
+    expect((thrown as ProviderApiError).message).toBe("UPSTREAM_UNAVAILABLE");
+  });
+
+  test("builds auth + tenant headers from config only, never from the path", async () => {
+    const { seen } = stubFetch(200, { ok: true });
+    const api = createProviderApi({
+      baseUrl: "https://steward.example/",
+      bearerToken: "agent-jwt",
+      tenantId: "tenant-a",
+    });
+    await api.request("/v2/provider-actions", { method: "POST", body: "{}" });
+    expect(seen).toHaveLength(1);
+    expect(seen[0].url).toBe("https://steward.example/v2/provider-actions");
+    const headers = new Headers(seen[0].init?.headers);
+    expect(headers.get("authorization")).toBe("Bearer agent-jwt");
+    expect(headers.get("x-steward-tenant")).toBe("tenant-a");
+  });
+
+  test("redacts secrets in a real non-ok error body before throwing", async () => {
+    const canary = "canary-http-5xx-9a1";
+    stubFetch(403, {
+      error: "POLICY_DENIED",
+      authorization: `Bearer ${canary}`,
+      detail: `token=${canary}`,
+    });
+    const api = createProviderApi({ baseUrl: "https://steward.example", bearerToken: "agent-jwt" });
+    let thrown: unknown;
+    try {
+      await api.request("/v2/provider-actions", { method: "POST", body: "{}" });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(ProviderApiError);
+    expect(JSON.stringify((thrown as ProviderApiError).data)).not.toContain(canary);
   });
 });
 

--- a/packages/mcp/src/__tests__/tools.test.ts
+++ b/packages/mcp/src/__tests__/tools.test.ts
@@ -55,6 +55,11 @@ function toolMap(tools: StewardTool[]): Map<string, StewardTool> {
 }
 
 const EXPECTED_TOOLS = [
+  "provider_action_invoke",
+  "provider_action_status",
+  "provider_action_approval",
+  "provider_action_case",
+  "provider_action_evidence",
   "list_wallets",
   "get_wallet",
   "create_wallet",
@@ -88,6 +93,8 @@ describe("tool registration", () => {
   test("only state-changing tools are marked destructive; reads are readOnly", () => {
     const { ctx } = makeContext();
     const map = toolMap(buildTools(ctx));
+    expect(map.get("provider_action_invoke")?.annotations.destructiveHint).toBe(true);
+    expect(map.get("provider_action_status")?.annotations.readOnlyHint).toBe(true);
     expect(map.get("sign_transaction")?.annotations.destructiveHint).toBe(true);
     expect(map.get("create_transfer")?.annotations.destructiveHint).toBe(true);
     expect(map.get("create_wallet")?.annotations.readOnlyHint).toBe(false);

--- a/packages/mcp/src/cli.ts
+++ b/packages/mcp/src/cli.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { describeThrown } from "@stwd/shared";
 import { createStewardClient, loadConfig, redactConfig } from "./config.js";
 import { createStewardMcpServer } from "./server.js";
 
@@ -16,7 +17,7 @@ async function main(): Promise<void> {
   try {
     config = loadConfig(process.env);
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+    const message = describeThrown(err);
     process.stderr.write(`[stwd-mcp] Configuration error: ${message}\n`);
     process.exit(1);
     return;
@@ -25,7 +26,7 @@ async function main(): Promise<void> {
   const client = createStewardClient(config);
   const { server, tools } = createStewardMcpServer({
     client,
-    config: { defaultAgentId: config.defaultAgentId },
+    config,
   });
 
   process.stderr.write(
@@ -48,7 +49,7 @@ async function main(): Promise<void> {
 }
 
 main().catch((err) => {
-  const message = err instanceof Error ? err.message : String(err);
+  const message = describeThrown(err);
   process.stderr.write(`[stwd-mcp] Fatal error: ${message}\n`);
   process.exit(1);
 });

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -14,6 +14,12 @@ export {
   SERVER_VERSION,
 } from "./server.js";
 export {
+  createProviderApi,
+  ProviderApiError,
+  sanitizeProviderPayload,
+  type ProviderApi,
+} from "./provider-api.js";
+export {
   buildTools,
   type StewardTool,
   type ToolContext,

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -7,18 +7,18 @@ export {
   type StewardMcpConfig,
 } from "./config.js";
 export {
+  createProviderApi,
+  type ProviderApi,
+  ProviderApiError,
+  sanitizeProviderPayload,
+} from "./provider-api.js";
+export {
   type CreateServerOptions,
   type CreateServerResult,
   createStewardMcpServer,
   SERVER_NAME,
   SERVER_VERSION,
 } from "./server.js";
-export {
-  createProviderApi,
-  ProviderApiError,
-  sanitizeProviderPayload,
-  type ProviderApi,
-} from "./provider-api.js";
 export {
   buildTools,
   type StewardTool,

--- a/packages/mcp/src/provider-api.ts
+++ b/packages/mcp/src/provider-api.ts
@@ -15,7 +15,9 @@ export function sanitizeProviderPayload(value: unknown, depth = 0): unknown {
   if (value && typeof value === "object") {
     const clean: Record<string, unknown> = {};
     for (const [key, nested] of Object.entries(value)) {
-      clean[key] = SENSITIVE_KEY.test(key) ? "[redacted]" : sanitizeProviderPayload(nested, depth + 1);
+      clean[key] = SENSITIVE_KEY.test(key)
+        ? "[redacted]"
+        : sanitizeProviderPayload(nested, depth + 1);
     }
     return clean;
   }
@@ -63,7 +65,9 @@ export function createProviderApi(config: StewardMcpConfig): ProviderApi {
       const clean = sanitizeProviderPayload(payload);
       if (!response.ok) {
         const message =
-          clean && typeof clean === "object" && typeof (clean as Record<string, unknown>).error === "string"
+          clean &&
+          typeof clean === "object" &&
+          typeof (clean as Record<string, unknown>).error === "string"
             ? ((clean as Record<string, unknown>).error as string)
             : `Provider API request failed with HTTP ${response.status}`;
         throw new ProviderApiError(message, response.status, clean);

--- a/packages/mcp/src/provider-api.ts
+++ b/packages/mcp/src/provider-api.ts
@@ -1,0 +1,74 @@
+import { describeThrown } from "@stwd/shared";
+import type { StewardMcpConfig } from "./config.js";
+
+export interface ProviderApi {
+  request(path: string, init?: RequestInit): Promise<unknown>;
+}
+
+const SENSITIVE_KEY = /authorization|bearer|token|secret|credential|api[-_]?key|cookie/i;
+const SECRET_TEXT = /(?:bearer\s+|(?:api[-_]?key|token|secret|credential)["'\s:=]+)[^\s,"'}]+/gi;
+
+export function sanitizeProviderPayload(value: unknown, depth = 0): unknown {
+  if (depth > 20) return "[redacted]";
+  if (typeof value === "string") return value.replace(SECRET_TEXT, "[redacted]");
+  if (Array.isArray(value)) return value.map((item) => sanitizeProviderPayload(item, depth + 1));
+  if (value && typeof value === "object") {
+    const clean: Record<string, unknown> = {};
+    for (const [key, nested] of Object.entries(value)) {
+      clean[key] = SENSITIVE_KEY.test(key) ? "[redacted]" : sanitizeProviderPayload(nested, depth + 1);
+    }
+    return clean;
+  }
+  return value;
+}
+
+export class ProviderApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly data?: unknown,
+  ) {
+    super(message);
+    this.name = "ProviderApiError";
+  }
+}
+
+export function createProviderApi(config: StewardMcpConfig): ProviderApi {
+  const baseUrl = config.baseUrl.replace(/\/+$/, "");
+  return {
+    async request(path, init = {}) {
+      const headers = new Headers(init.headers);
+      headers.set("Accept", "application/json");
+      if (init.body !== undefined) headers.set("Content-Type", "application/json");
+      if (config.bearerToken) headers.set("Authorization", `Bearer ${config.bearerToken}`);
+      else if (config.apiKey) headers.set("X-Steward-Key", config.apiKey);
+      if (config.tenantId) headers.set("X-Steward-Tenant", config.tenantId);
+
+      let response: Response;
+      try {
+        response = await fetch(`${baseUrl}${path}`, {
+          ...init,
+          headers,
+          signal: init.signal ?? AbortSignal.timeout(15_000),
+        });
+      } catch (err) {
+        throw new ProviderApiError(`Provider API request failed: ${describeThrown(err)}`, 0);
+      }
+      let payload: unknown;
+      try {
+        payload = await response.json();
+      } catch {
+        payload = { error: "UPSTREAM_RESPONSE_INVALID" };
+      }
+      const clean = sanitizeProviderPayload(payload);
+      if (!response.ok) {
+        const message =
+          clean && typeof clean === "object" && typeof (clean as Record<string, unknown>).error === "string"
+            ? ((clean as Record<string, unknown>).error as string)
+            : `Provider API request failed with HTTP ${response.status}`;
+        throw new ProviderApiError(message, response.status, clean);
+      }
+      return clean;
+    },
+  };
+}

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -34,7 +34,8 @@ export function createStewardMcpServer(options: CreateServerOptions): CreateServ
   });
 
   const providerApi =
-    options.providerApi ?? (options.config.baseUrl ? createProviderApi(options.config as StewardMcpConfig) : undefined);
+    options.providerApi ??
+    (options.config.baseUrl ? createProviderApi(options.config as StewardMcpConfig) : undefined);
   const tools = buildTools({ client: options.client, providerApi, config: options.config });
 
   for (const tool of tools) {

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,6 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { StewardClient } from "@stwd/sdk";
 import type { StewardMcpConfig } from "./config.js";
+import { createProviderApi, type ProviderApi } from "./provider-api.js";
 import { buildTools, type StewardTool } from "./tools.js";
 
 /** Package identity advertised to MCP clients during initialization. */
@@ -9,7 +10,8 @@ export const SERVER_VERSION = "0.1.0";
 
 export interface CreateServerOptions {
   client: StewardClient;
-  config: Pick<StewardMcpConfig, "defaultAgentId">;
+  config: Pick<StewardMcpConfig, "defaultAgentId"> & Partial<StewardMcpConfig>;
+  providerApi?: ProviderApi;
   name?: string;
   version?: string;
 }
@@ -31,7 +33,9 @@ export function createStewardMcpServer(options: CreateServerOptions): CreateServ
     version: options.version ?? SERVER_VERSION,
   });
 
-  const tools = buildTools({ client: options.client, config: options.config });
+  const providerApi =
+    options.providerApi ?? (options.config.baseUrl ? createProviderApi(options.config as StewardMcpConfig) : undefined);
+  const tools = buildTools({ client: options.client, providerApi, config: options.config });
 
   for (const tool of tools) {
     server.registerTool(

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1,6 +1,8 @@
 import { StewardApiError, type StewardClient } from "@stwd/sdk";
+import { describeThrown } from "@stwd/shared";
 import { z } from "zod";
 import type { StewardMcpConfig } from "./config.js";
+import { ProviderApiError, sanitizeProviderPayload, type ProviderApi } from "./provider-api.js";
 
 /**
  * Minimal shape of an MCP tool result. Matches the `content` + `isError`
@@ -42,6 +44,7 @@ export interface StewardTool {
 /** Context shared by all tool factories. */
 export interface ToolContext {
   client: StewardClient;
+  providerApi?: ProviderApi;
   config: Pick<StewardMcpConfig, "defaultAgentId">;
 }
 
@@ -71,20 +74,27 @@ function errorResult(message: string): ToolResult {
  * pending approval) without leaking transport internals.
  */
 export function toErrorResult(err: unknown): ToolResult {
+  if (err instanceof ProviderApiError) {
+    const detail = sanitizeProviderPayload({ error: err.message, status: err.status, data: err.data });
+    return {
+      content: [{ type: "text", text: `Steward provider API error: ${jsonText(detail)}` }],
+      structuredContent: detail as Record<string, unknown>,
+      isError: true,
+    };
+  }
   if (err instanceof StewardApiError) {
-    const detail: Record<string, unknown> = { error: err.message, status: err.status };
-    if (err.data && typeof err.data === "object") {
-      const data = err.data as { results?: unknown };
-      if (data.results !== undefined) detail.policyResults = data.results;
-    }
-    return errorResult(`Steward API error (HTTP ${err.status}): ${jsonText(detail)}`);
+    const detail = sanitizeProviderPayload({ error: err.message, status: err.status, data: err.data });
+    return {
+      content: [{ type: "text", text: `Steward API error: ${jsonText(detail)}` }],
+      structuredContent: detail as Record<string, unknown>,
+      isError: true,
+    };
   }
   if (err instanceof z.ZodError) {
     const issues = err.issues.map((i) => `${i.path.join(".") || "(root)"}: ${i.message}`);
     return errorResult(`Invalid tool input: ${issues.join("; ")}`);
   }
-  if (err instanceof Error) return errorResult(err.message);
-  return errorResult(String(err));
+  return errorResult(sanitizeProviderPayload(describeThrown(err)) as string);
 }
 
 /**
@@ -149,6 +159,11 @@ function defineTool<S extends z.ZodObject<z.ZodRawShape>>(
   };
 }
 
+function requireProviderApi(ctx: ToolContext): ProviderApi {
+  if (!ctx.providerApi) throw new Error("Provider API transport is not configured");
+  return ctx.providerApi;
+}
+
 function titleCase(name: string): string {
   return name
     .split("_")
@@ -173,6 +188,13 @@ const hexData = z.string().regex(/^0x[0-9a-fA-F]*$/, "must be 0x-prefixed hex");
 const decimalString = z.string().regex(/^\d+$/, "must be a base-10 integer string");
 
 const positiveInt = z.number().int().positive();
+const boundedId = z.string().min(1).max(128).regex(/^[A-Za-z0-9_.:-]+$/, "contains unsupported characters");
+const providerCaseId = z.string().max(128).regex(/^pa_[0-9a-fA-F-]{36}$/, "must be a provider action id");
+const idempotencyKey = z.string().min(8).max(255).regex(/^[\x21-\x7e]+$/, "must contain visible ASCII only");
+const providerArguments = z.record(z.string(), z.unknown()).refine(
+  (value) => JSON.stringify(value).length <= 256 * 1024,
+  "arguments exceed 256 KiB",
+);
 
 /**
  * Build the full set of Steward MCP tools bound to a client + config.
@@ -183,6 +205,62 @@ const positiveInt = z.number().int().positive();
  */
 export function buildTools(ctx: ToolContext): StewardTool[] {
   return [
+    defineTool(ctx, {
+      name: "provider_action_invoke",
+      description:
+        "Submit a governed provider action to POST /v2/provider-actions. Steward derives tenant and actor from the configured agent JWT and evaluates policy server-side. Pending and denied results remain structured.",
+      schema: z
+        .object({
+          workspaceId: boundedId.describe("Workspace id within the authenticated tenant."),
+          providerAccountId: boundedId.describe("Provider account id within that workspace."),
+          operationKey: boundedId.describe("Registered provider operation key."),
+          arguments: providerArguments.describe("Operation arguments validated by the provider adapter."),
+          idempotencyKey: idempotencyKey.describe("Caller idempotency key, validated again by Steward."),
+        })
+        .strict(),
+      readOnly: false,
+      destructive: true,
+      run: (input) =>
+        requireProviderApi(ctx).request("/v2/provider-actions", {
+          method: "POST",
+          body: JSON.stringify(input),
+        }),
+    }),
+    defineTool(ctx, {
+      name: "provider_action_status",
+      description:
+        "Fetch the current provider-action intent from the existing GET /intents/:intentId route. Tenant visibility is determined only by the configured Steward credentials.",
+      schema: z.object({ actionId: providerCaseId }).strict(),
+      readOnly: true,
+      run: ({ actionId }) => requireProviderApi(ctx).request(`/intents/${encodeURIComponent(actionId)}`),
+    }),
+    defineTool(ctx, {
+      name: "provider_action_approval",
+      description:
+        "Fetch approval state from GET /v2/provider-actions/:id/approval. The real API requires an eligible human session and recent MFA, so an agent-token MCP server receives the API's honest authorization error rather than bypassing that gate.",
+      schema: z.object({ actionId: providerCaseId }).strict(),
+      readOnly: true,
+      run: ({ actionId }) =>
+        requireProviderApi(ctx).request(`/v2/provider-actions/${encodeURIComponent(actionId)}/approval`),
+    }),
+    defineTool(ctx, {
+      name: "provider_action_case",
+      description:
+        "Fetch the correlated case manifest from GET /v2/provider-actions/:id/case. The API enforces owner/admin, recent-MFA, and tenant scope.",
+      schema: z.object({ actionId: providerCaseId }).strict(),
+      readOnly: true,
+      run: ({ actionId }) =>
+        requireProviderApi(ctx).request(`/v2/provider-actions/${encodeURIComponent(actionId)}/case`),
+    }),
+    defineTool(ctx, {
+      name: "provider_action_evidence",
+      description:
+        "Fetch the correlated signed evidence bundle from GET /v2/provider-actions/:id/evidence. The API enforces owner/admin, recent-MFA, and tenant scope.",
+      schema: z.object({ actionId: providerCaseId }).strict(),
+      readOnly: true,
+      run: ({ actionId }) =>
+        requireProviderApi(ctx).request(`/v2/provider-actions/${encodeURIComponent(actionId)}/evidence`),
+    }),
     defineTool(ctx, {
       name: "list_wallets",
       description:

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -2,7 +2,7 @@ import { StewardApiError, type StewardClient } from "@stwd/sdk";
 import { describeThrown } from "@stwd/shared";
 import { z } from "zod";
 import type { StewardMcpConfig } from "./config.js";
-import { ProviderApiError, sanitizeProviderPayload, type ProviderApi } from "./provider-api.js";
+import { type ProviderApi, ProviderApiError, sanitizeProviderPayload } from "./provider-api.js";
 
 /**
  * Minimal shape of an MCP tool result. Matches the `content` + `isError`
@@ -75,7 +75,11 @@ function errorResult(message: string): ToolResult {
  */
 export function toErrorResult(err: unknown): ToolResult {
   if (err instanceof ProviderApiError) {
-    const detail = sanitizeProviderPayload({ error: err.message, status: err.status, data: err.data });
+    const detail = sanitizeProviderPayload({
+      error: err.message,
+      status: err.status,
+      data: err.data,
+    });
     return {
       content: [{ type: "text", text: `Steward provider API error: ${jsonText(detail)}` }],
       structuredContent: detail as Record<string, unknown>,
@@ -83,9 +87,18 @@ export function toErrorResult(err: unknown): ToolResult {
     };
   }
   if (err instanceof StewardApiError) {
-    const detail = sanitizeProviderPayload({ error: err.message, status: err.status, data: err.data });
+    const rawData =
+      err.data && typeof err.data === "object" ? (err.data as { results?: unknown }) : undefined;
+    const detail = sanitizeProviderPayload({
+      error: err.message,
+      status: err.status,
+      data: err.data,
+      ...(rawData?.results !== undefined ? { policyResults: rawData.results } : {}),
+    });
     return {
-      content: [{ type: "text", text: `Steward API error: ${jsonText(detail)}` }],
+      content: [
+        { type: "text", text: `Steward API error (HTTP ${err.status}): ${jsonText(detail)}` },
+      ],
       structuredContent: detail as Record<string, unknown>,
       isError: true,
     };
@@ -188,13 +201,23 @@ const hexData = z.string().regex(/^0x[0-9a-fA-F]*$/, "must be 0x-prefixed hex");
 const decimalString = z.string().regex(/^\d+$/, "must be a base-10 integer string");
 
 const positiveInt = z.number().int().positive();
-const boundedId = z.string().min(1).max(128).regex(/^[A-Za-z0-9_.:-]+$/, "contains unsupported characters");
-const providerCaseId = z.string().max(128).regex(/^pa_[0-9a-fA-F-]{36}$/, "must be a provider action id");
-const idempotencyKey = z.string().min(8).max(255).regex(/^[\x21-\x7e]+$/, "must contain visible ASCII only");
-const providerArguments = z.record(z.string(), z.unknown()).refine(
-  (value) => JSON.stringify(value).length <= 256 * 1024,
-  "arguments exceed 256 KiB",
-);
+const boundedId = z
+  .string()
+  .min(1)
+  .max(128)
+  .regex(/^[A-Za-z0-9_.:-]+$/, "contains unsupported characters");
+const providerCaseId = z
+  .string()
+  .max(128)
+  .regex(/^pa_[0-9a-fA-F-]{36}$/, "must be a provider action id");
+const idempotencyKey = z
+  .string()
+  .min(8)
+  .max(255)
+  .regex(/^[\x21-\x7e]+$/, "must contain visible ASCII only");
+const providerArguments = z
+  .record(z.string(), z.unknown())
+  .refine((value) => JSON.stringify(value).length <= 256 * 1024, "arguments exceed 256 KiB");
 
 /**
  * Build the full set of Steward MCP tools bound to a client + config.
@@ -214,8 +237,12 @@ export function buildTools(ctx: ToolContext): StewardTool[] {
           workspaceId: boundedId.describe("Workspace id within the authenticated tenant."),
           providerAccountId: boundedId.describe("Provider account id within that workspace."),
           operationKey: boundedId.describe("Registered provider operation key."),
-          arguments: providerArguments.describe("Operation arguments validated by the provider adapter."),
-          idempotencyKey: idempotencyKey.describe("Caller idempotency key, validated again by Steward."),
+          arguments: providerArguments.describe(
+            "Operation arguments validated by the provider adapter.",
+          ),
+          idempotencyKey: idempotencyKey.describe(
+            "Caller idempotency key, validated again by Steward.",
+          ),
         })
         .strict(),
       readOnly: false,
@@ -232,7 +259,8 @@ export function buildTools(ctx: ToolContext): StewardTool[] {
         "Fetch the current provider-action intent from the existing GET /intents/:intentId route. Tenant visibility is determined only by the configured Steward credentials.",
       schema: z.object({ actionId: providerCaseId }).strict(),
       readOnly: true,
-      run: ({ actionId }) => requireProviderApi(ctx).request(`/intents/${encodeURIComponent(actionId)}`),
+      run: ({ actionId }) =>
+        requireProviderApi(ctx).request(`/intents/${encodeURIComponent(actionId)}`),
     }),
     defineTool(ctx, {
       name: "provider_action_approval",
@@ -241,7 +269,9 @@ export function buildTools(ctx: ToolContext): StewardTool[] {
       schema: z.object({ actionId: providerCaseId }).strict(),
       readOnly: true,
       run: ({ actionId }) =>
-        requireProviderApi(ctx).request(`/v2/provider-actions/${encodeURIComponent(actionId)}/approval`),
+        requireProviderApi(ctx).request(
+          `/v2/provider-actions/${encodeURIComponent(actionId)}/approval`,
+        ),
     }),
     defineTool(ctx, {
       name: "provider_action_case",
@@ -250,7 +280,9 @@ export function buildTools(ctx: ToolContext): StewardTool[] {
       schema: z.object({ actionId: providerCaseId }).strict(),
       readOnly: true,
       run: ({ actionId }) =>
-        requireProviderApi(ctx).request(`/v2/provider-actions/${encodeURIComponent(actionId)}/case`),
+        requireProviderApi(ctx).request(
+          `/v2/provider-actions/${encodeURIComponent(actionId)}/case`,
+        ),
     }),
     defineTool(ctx, {
       name: "provider_action_evidence",
@@ -259,7 +291,9 @@ export function buildTools(ctx: ToolContext): StewardTool[] {
       schema: z.object({ actionId: providerCaseId }).strict(),
       readOnly: true,
       run: ({ actionId }) =>
-        requireProviderApi(ctx).request(`/v2/provider-actions/${encodeURIComponent(actionId)}/evidence`),
+        requireProviderApi(ctx).request(
+          `/v2/provider-actions/${encodeURIComponent(actionId)}/evidence`,
+        ),
     }),
     defineTool(ctx, {
       name: "list_wallets",

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -256,7 +256,7 @@ export function buildTools(ctx: ToolContext): StewardTool[] {
     defineTool(ctx, {
       name: "provider_action_status",
       description:
-        "Fetch the current provider-action intent from the existing GET /intents/:intentId route. Tenant visibility is determined only by the configured Steward credentials.",
+        "Fetch the current provider-action intent from the existing GET /intents/:intentId route. This real API route requires tenant-level credentials and rejects agent JWTs; MCP preserves that gate.",
       schema: z.object({ actionId: providerCaseId }).strict(),
       readOnly: true,
       run: ({ actionId }) =>


### PR DESCRIPTION
## Summary

- add stable snake_case MCP tools for governed provider action invoke, status, approval, case, and evidence
- use a narrow fixed-route API transport with the same configured Steward auth and tenant headers as the MCP server
- reject unknown keys, caller-selected tenants, hosts, URLs, bearer tokens, and provider credentials
- preserve structured pending, denial, policy, approval, case, and evidence payloads while recursively redacting credential-shaped fields
- document the MCP authorization boundary and the separate OAuth 2.1 resource-server work in #219

Closes #217.

## Exact API route anchors

- invoke: `POST /v2/provider-actions`, `packages/api/src/routes/provider-actions.ts:64-69`
- status: `GET /intents/:intentId`, `packages/api/src/routes/intents.ts:1633`
- approval: `GET /v2/provider-actions/:id/approval`, `packages/api/src/routes/provider-approvals.ts:288`
- case: `GET /v2/provider-actions/:id/case`, `packages/api/src/routes/provider-case.ts:67`
- evidence: `GET /v2/provider-actions/:id/evidence`, `packages/api/src/routes/provider-case.ts:91`

## Threat posture

- tool schemas are strict and expose no tenant, actor, host, URL, credential, or bearer fields
- invocation sends only the API's five accepted fields, including server-validated `idempotencyKey`
- route paths are constants plus a bounded provider-action id encoded as one path segment
- the MCP process holds no provider credential and cannot mint authority or bypass policy
- API error payloads remain structured, but credential-bearing keys and bearer/token patterns are redacted before MCP output
- timeouts are surfaced as errors with no success or execution claim

## Tests and mutation receipts

- MCP suite: 57 tests passed, 193 assertions
- provider action, approval, and case regression: 15/15 isolated files passed
- provider X governed E2E: passed
- audit bundle signing and integration: 2/2 isolated files passed
- plugin-capabilities regression: 110 tests passed across 6 isolated files
- package typecheck: passed
- root typecheck/build across 29 packages plus web: passed
- Biome: passed
- byte/control corruption scan across all 11 touched files: passed
- mutation proof script: 4/4 RED, restore, GREEN cycles passed with no backup residue
  - strict tenant/no-caller-host binding
  - credential redaction
  - pending structured payload preservation
  - invalid action id rejection

## Honest gaps and route-auth contradiction

The current API intentionally splits auth modes. Invocation requires an agent JWT. The only current status route, `GET /intents/:id`, rejects agent tokens and requires tenant-level credentials. Approval, case, and evidence require human sessions and recent MFA, with case/evidence also requiring owner/admin. Therefore one agent-JWT MCP process can invoke but cannot poll these protected read routes. This PR maps the real routes and preserves their authorization failures rather than inventing an endpoint or weakening API policy. Codex correctly flagged this as a P2 workflow limitation. Resolving it requires an API auth/route decision outside the `packages/mcp/**` collision fence.

These tools do not implement MCP OAuth 2.1 resource-server semantics. That remains tracked by #219.

[sol-orch]
