### PR TITLE
fix(web): client-safe @stwd/shared/client entrypoint unbreaks cf:build

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,6 +9,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./client": {
+      "types": "./dist/client.d.ts",
+      "import": "./dist/client.js"
     }
   },
   "files": [

--- a/packages/shared/src/__tests__/client-entrypoint.test.ts
+++ b/packages/shared/src/__tests__/client-entrypoint.test.ts
@@ -1,0 +1,211 @@
+/**
+ * client-entrypoint.test.ts: contract test for the browser/worker-safe
+ * `@stwd/shared/client` entrypoint (issue #231).
+ *
+ * THE CONTRACT
+ * ------------
+ * `src/client.ts` (and its emitted `dist/client.js`) must have a transitive
+ * import graph that contains:
+ *   - NO `node:*` imports and no bare Node builtin imports;
+ *   - NO server-only modules (`provider-execution-auth`, `provider-action`);
+ *   - NO import of the top-level barrel (`index`), which would transitively
+ *     drag the server-only modules back in.
+ *
+ * If this test fails, someone re-exported a server-only or node-dependent
+ * module from the client entrypoint. That breaks `web` `cf:build` (the
+ * Cloudflare Worker bundle cannot resolve `node:crypto`). Fix the entrypoint,
+ * do NOT weaken this test and do NOT polyfill/stub node builtins in the
+ * Worker build.
+ *
+ * FAIL-CLOSED: a missing dist build or an unresolvable import is a test
+ * FAILURE, never a skip.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { builtinModules } from "node:module";
+import { dirname, join, resolve } from "node:path";
+
+const SHARED_ROOT = resolve(import.meta.dir, "..", "..");
+const SRC_ENTRY = join(SHARED_ROOT, "src", "client.ts");
+const DIST_ENTRY = join(SHARED_ROOT, "dist", "client.js");
+
+/**
+ * Modules that must NEVER be reachable from the client entrypoint, matched
+ * against the resolved module path. `index` is the top-level barrel: reaching
+ * it from client would transitively re-import every server-only module.
+ */
+const SERVER_ONLY_BASENAMES = new Set(["provider-execution-auth", "provider-action", "index"]);
+
+const NODE_BUILTINS = new Set<string>([
+  ...builtinModules,
+  ...builtinModules.map((m) => `node:${m}`),
+]);
+
+/** Extract every static import/export specifier from an ESM source text. */
+function extractSpecifiers(source: string): string[] {
+  const specifiers: string[] = [];
+  // import ... from "x"; export ... from "x"; import "x";
+  const fromRe = /\b(?:import|export)\b[^"'`;]*?\bfrom\s*["']([^"']+)["']/g;
+  const bareImportRe = /\bimport\s*["']([^"']+)["']/g;
+  const dynamicImportRe = /\bimport\s*\(\s*["']([^"']+)["']\s*\)/g;
+  const requireRe = /\brequire\s*\(\s*["']([^"']+)["']\s*\)/g;
+  for (const re of [fromRe, bareImportRe, dynamicImportRe, requireRe]) {
+    let m: RegExpExecArray | null = re.exec(source);
+    while (m !== null) {
+      specifiers.push(m[1]);
+      m = re.exec(source);
+    }
+  }
+  return specifiers;
+}
+
+interface GraphViolation {
+  module: string;
+  specifier: string;
+  kind: "node-builtin" | "server-only" | "unresolvable" | "external";
+}
+
+/**
+ * Resolve a relative specifier from `fromFile` to an on-disk module file.
+ * Handles the NodeNext `.js`-suffix-in-source convention (src) and plain
+ * `.js` (dist). Returns null when nothing exists (caller records a
+ * violation: unresolvable imports fail closed).
+ */
+function resolveRelative(fromFile: string, spec: string): string | null {
+  const base = resolve(dirname(fromFile), spec);
+  const candidates = [
+    base,
+    `${base}.ts`,
+    `${base}.js`,
+    base.replace(/\.js$/, ".ts"),
+    join(base, "index.ts"),
+    join(base, "index.js"),
+  ];
+  for (const c of candidates) {
+    try {
+      if (statSync(c).isFile()) return c;
+    } catch {
+      // keep trying
+    }
+  }
+  return null;
+}
+
+/**
+ * Walk the static import graph from `entry`, collecting every violation of
+ * the client-safety contract. Only relative imports are followed (the shared
+ * package has no runtime dependencies; any bare specifier is either a node
+ * builtin or an unexpected external dependency: both are violations).
+ */
+function walkGraph(entry: string): { visited: Set<string>; violations: GraphViolation[] } {
+  const visited = new Set<string>();
+  const violations: GraphViolation[] = [];
+  const queue: string[] = [entry];
+  while (queue.length > 0) {
+    const file = queue.pop();
+    if (file === undefined || visited.has(file)) continue;
+    visited.add(file);
+    const source = readFileSync(file, "utf8");
+    for (const spec of extractSpecifiers(source)) {
+      if (spec.startsWith(".")) {
+        const target = resolveRelative(file, spec);
+        if (target === null) {
+          violations.push({ module: file, specifier: spec, kind: "unresolvable" });
+          continue;
+        }
+        const basename = target
+          .split("/")
+          .pop()
+          ?.replace(/\.(ts|js)$/, "");
+        // `index` inside chains/ is the chains sub-barrel (client-safe);
+        // only the TOP-LEVEL barrel is server-only.
+        const isTopLevelBarrel =
+          basename === "index" &&
+          (dirname(target) === join(SHARED_ROOT, "src") ||
+            dirname(target) === join(SHARED_ROOT, "dist"));
+        if (
+          (basename !== undefined && basename !== "index" && SERVER_ONLY_BASENAMES.has(basename)) ||
+          isTopLevelBarrel
+        ) {
+          violations.push({ module: file, specifier: spec, kind: "server-only" });
+          continue;
+        }
+        queue.push(target);
+      } else if (NODE_BUILTINS.has(spec)) {
+        violations.push({ module: file, specifier: spec, kind: "node-builtin" });
+      } else {
+        // Bare external specifier: @stwd/shared has zero runtime deps, so
+        // anything here is unexpected in the client graph. Fail closed.
+        violations.push({ module: file, specifier: spec, kind: "external" });
+      }
+    }
+  }
+  return { visited, violations };
+}
+
+function formatViolations(violations: GraphViolation[]): string {
+  return violations
+    .map((v) => `[${v.kind}] ${v.module.replace(`${SHARED_ROOT}/`, "")} -> "${v.specifier}"`)
+    .join("\n");
+}
+
+describe("@stwd/shared/client entrypoint contract (issue #231)", () => {
+  it("source graph of src/client.ts contains no node builtins or server-only modules", () => {
+    const { visited, violations } = walkGraph(SRC_ENTRY);
+    expect(visited.size).toBeGreaterThan(1);
+    expect(formatViolations(violations)).toBe("");
+  });
+
+  it("emitted dist/client.js exists (client entrypoint must ship in the build)", () => {
+    // FAIL-CLOSED: dist must be built before tests (CI builds @stwd/shared
+    // first). A missing dist entry means the exports map points at nothing.
+    expect(statSync(DIST_ENTRY).isFile()).toBe(true);
+  });
+
+  it("emitted dist graph of dist/client.js contains no node builtins or server-only modules", () => {
+    const { visited, violations } = walkGraph(DIST_ENTRY);
+    expect(visited.size).toBeGreaterThan(1);
+    expect(formatViolations(violations)).toBe("");
+  });
+
+  it("package.json exports map exposes ./client with types and import conditions", () => {
+    const pkg = JSON.parse(readFileSync(join(SHARED_ROOT, "package.json"), "utf8")) as {
+      exports?: Record<string, { types?: string; import?: string }>;
+    };
+    expect(pkg.exports?.["./client"]?.import).toBe("./dist/client.js");
+    expect(pkg.exports?.["./client"]?.types).toBe("./dist/client.d.ts");
+  });
+
+  it("client entrypoint still exposes the helpers web depends on", async () => {
+    const client = await import("../client.js");
+    expect(typeof client.getNativeDecimals).toBe("function");
+    expect(typeof client.getNativeSymbol).toBe("function");
+    expect(Array.isArray(client.CHAIN_PROVIDERS)).toBe(true);
+    expect(typeof client.getChainProviderByNumeric).toBe("function");
+    expect(typeof client.describeThrown).toBe("function");
+  });
+
+  it("web client modules do not import the top-level @stwd/shared barrel", () => {
+    // Browser-bundled web code must import @stwd/shared/client, never the
+    // barrel: the barrel drags node:crypto into the Cloudflare Worker bundle
+    // and breaks cf:build. This scans every module under web/src.
+    const webSrc = resolve(SHARED_ROOT, "..", "..", "web", "src");
+    const offenders: string[] = [];
+    const walkDir = (dir: string): void => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) {
+          walkDir(full);
+        } else if (/\.(ts|tsx)$/.test(entry.name) && !/\.(test|spec)\.(ts|tsx)$/.test(entry.name)) {
+          const source = readFileSync(full, "utf8");
+          for (const spec of extractSpecifiers(source)) {
+            if (spec === "@stwd/shared") offenders.push(`${full} -> "${spec}"`);
+          }
+        }
+      }
+    };
+    walkDir(webSrc);
+    expect(offenders.join("\n")).toBe("");
+  });
+});

--- a/packages/shared/src/__tests__/client-entrypoint.test.ts
+++ b/packages/shared/src/__tests__/client-entrypoint.test.ts
@@ -21,8 +21,9 @@
  * FAILURE, never a skip.
  */
 
-import { describe, expect, it } from "bun:test";
-import { readdirSync, readFileSync, statSync } from "node:fs";
+import { beforeAll, describe, expect, it } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { builtinModules } from "node:module";
 import { dirname, join, resolve } from "node:path";
 
@@ -151,6 +152,18 @@ function formatViolations(violations: GraphViolation[]): string {
 }
 
 describe("@stwd/shared/client entrypoint contract (issue #231)", () => {
+  beforeAll(() => {
+    // On a clean checkout dist/ is untracked; build it so the emitted-graph
+    // assertions can run. FAIL-CLOSED: a failed build fails the suite, the
+    // dist checks are never skipped.
+    if (!existsSync(DIST_ENTRY)) {
+      const result = spawnSync("bunx", ["tsc"], { cwd: SHARED_ROOT, stdio: "inherit" });
+      if (result.status !== 0) {
+        throw new Error(`building @stwd/shared dist failed (exit ${String(result.status)})`);
+      }
+    }
+  });
+
   it("source graph of src/client.ts contains no node builtins or server-only modules", () => {
     const { visited, violations } = walkGraph(SRC_ENTRY);
     expect(visited.size).toBeGreaterThan(1);

--- a/packages/shared/src/client.ts
+++ b/packages/shared/src/client.ts
@@ -1,0 +1,36 @@
+/**
+ * client.ts: the browser/worker-safe entrypoint for `@stwd/shared`.
+ *
+ * WHY THIS EXISTS (issue #231)
+ * ----------------------------
+ * The top-level barrel (`index.ts`) re-exports server-only modules that import
+ * `node:crypto` (`provider-execution-auth.ts`, `provider-action.ts`). Any web
+ * bundle that imports the barrel, even for a pure helper like
+ * `getNativeDecimals`, drags `node:crypto` into the Cloudflare Worker bundle,
+ * which webpack/OpenNext cannot resolve, breaking `cf:build`.
+ *
+ * This entrypoint (`@stwd/shared/client`) exposes ONLY modules whose entire
+ * transitive import graph is free of node builtins and free of server-only
+ * crypto. Browser and Worker code MUST import from here, never from the
+ * top-level barrel.
+ *
+ * RULES FOR ADDING EXPORTS
+ * ------------------------
+ *   1. Re-export a module here only if its transitive graph contains no
+ *      `node:*` (or bare node builtin) imports and no server-only modules.
+ *   2. NEVER re-export `provider-execution-auth.js` or `provider-action.js`
+ *      from here; server crypto stays on the server entrypoint (`.`).
+ *   3. The contract test `__tests__/client-entrypoint.test.ts` walks this
+ *      module graph (source AND emitted dist) and fails the build if a node
+ *      builtin or a server-only module leaks in. Keep it passing.
+ */
+
+// Chain provider registry: CAIP-2 metadata, explorer URLs, signing-curve
+// support tables. Pure data + lookups, no node imports.
+export * from "./chains/index.js";
+
+// Non-throwing description of an arbitrary thrown value (fail-closed catches).
+export { describeThrown, UNPRINTABLE_THROWN_VALUE } from "./safe-error.js";
+
+// Token registry: native/known token decimals, symbols, metadata. Pure data.
+export * from "./tokens.js";

--- a/scripts/client-entrypoint-mutation-proofs.sh
+++ b/scripts/client-entrypoint-mutation-proofs.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# client-entrypoint-mutation-proofs.sh
+#
+# Mutation proofs for the @stwd/shared/client contract test (issue #231).
+# Each mutation weakens the client-safety guarantee, asserts the contract
+# test FAILS, then restores the original and asserts it PASSES again.
+#
+#   Mutation 1: re-export the server-only provider-execution-auth module
+#               from the client entrypoint (drags node:crypto into the
+#               client graph).
+#   Mutation 2: point a migrated web import back at the top-level
+#               @stwd/shared barrel (the exact pre-fix cf:build failure).
+#
+# Run from the repo root:  bash scripts/client-entrypoint-mutation-proofs.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SHARED="$ROOT/packages/shared"
+CLIENT_TS="$SHARED/src/client.ts"
+UTILS_TS="$ROOT/web/src/lib/utils.ts"
+TEST_FILE="src/__tests__/client-entrypoint.test.ts"
+
+run_contract_test() {
+  (cd "$SHARED" && bunx tsc && bun test --isolate "$TEST_FILE") >/dev/null 2>&1
+}
+
+fail() {
+  echo "MUTATION PROOF FAILED: $1" >&2
+  exit 1
+}
+
+echo "== baseline: contract test must PASS on pristine tree"
+run_contract_test || fail "baseline contract test did not pass"
+echo "   PASS"
+
+echo "== mutation 1: re-export provider-execution-auth from client entrypoint"
+cp "$CLIENT_TS" "$CLIENT_TS.mutbak"
+printf '\nexport * from "./provider-execution-auth.js";\n' >>"$CLIENT_TS"
+if run_contract_test; then
+  mv "$CLIENT_TS.mutbak" "$CLIENT_TS"
+  fail "mutation 1 was NOT detected (test passed with server-only re-export)"
+fi
+mv "$CLIENT_TS.mutbak" "$CLIENT_TS"
+echo "   KILLED (test failed as required)"
+
+echo "== mutation 2: web utils.ts imports the top-level barrel again"
+cp "$UTILS_TS" "$UTILS_TS.mutbak"
+sed -i 's|from "@stwd/shared/client";|from "@stwd/shared";|' "$UTILS_TS"
+if run_contract_test; then
+  mv "$UTILS_TS.mutbak" "$UTILS_TS"
+  fail "mutation 2 was NOT detected (test passed with barrel import in web)"
+fi
+mv "$UTILS_TS.mutbak" "$UTILS_TS"
+echo "   KILLED (test failed as required)"
+
+echo "== restore check: contract test must PASS again"
+run_contract_test || fail "restore check failed, tree left dirty"
+echo "   PASS"
+
+echo "ALL MUTATION PROOFS GREEN"

--- a/web/src/lib/chains.ts
+++ b/web/src/lib/chains.ts
@@ -5,7 +5,7 @@
  * `CHAIN_PROVIDERS` registry. To add a new chain, add it once in
  * `packages/shared/src/chains/` and it shows up here automatically.
  */
-import { CHAIN_PROVIDERS, getChainProviderByNumeric } from "@stwd/shared";
+import { CHAIN_PROVIDERS, getChainProviderByNumeric } from "@stwd/shared/client";
 
 export interface ChainMeta {
   id: number;

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -1,4 +1,4 @@
-import { getNativeDecimals, getNativeSymbol } from "@stwd/shared";
+import { getNativeDecimals, getNativeSymbol } from "@stwd/shared/client";
 
 export function shortenAddress(addr: string, chars = 4): string {
   if (!addr) return "";


### PR DESCRIPTION
## Summary

Closes #231.

`bun run cf:build` (OpenNext/Cloudflare Worker build) failed on every web-touching PR because `web/src/lib/utils.ts` imported the top-level `@stwd/shared` barrel for two pure helpers, and the barrel re-exports `provider-execution-auth.js` (PR4 #199) which imports `node:crypto`. webpack/OpenNext cannot resolve `node:crypto` in the Worker bundle:

```
Module build failed: UnhandledSchemeError: Reading from "node:crypto" is not handled by plugins.
  node:crypto
  ../packages/shared/dist/provider-execution-auth.js
  ../packages/shared/dist/index.js
  ./src/lib/utils.ts
  ./src/app/dashboard/page.tsx
```

Repro receipt preserved at commit base 24ae042 before any change (log kept by the lane, tail matches the issue trace exactly, exit 1).

## Fix (issue option 1, preferred)

- **New client-safe entrypoint `@stwd/shared/client`** (`packages/shared/src/client.ts` + `./client` in the exports map). It exposes ONLY modules whose full transitive graph is free of node builtins and server-only code: the chains registry, the token registry, and `describeThrown`/`UNPRINTABLE_THROWN_VALUE`.
- **Web import audit + migration.** Every `@stwd/shared` import under `web/src` was audited; exactly two modules import it (`web/src/lib/utils.ts`, `web/src/lib/chains.ts`) and both import only client-safe symbols (`getNativeDecimals`, `getNativeSymbol`, `CHAIN_PROVIDERS`, `getChainProviderByNumeric`). Both migrated to `@stwd/shared/client`.
- **No polyfills, no stubs, no webpack fallback.** `node:crypto` and `provider-execution-auth` remain fully available from the server entrypoint (`.`), which is untouched. API/server imports unchanged.
- **No Dockerfile change needed**: the new entrypoint lives inside the existing `packages/shared` workspace path and ships in `dist/` from the same `tsc` build.

## Contract test (fail-closed)

`packages/shared/src/__tests__/client-entrypoint.test.ts`:

- Walks the static import graph of `src/client.ts` AND the emitted `dist/client.js`; FAILS on any `node:*`/bare node builtin, any server-only module (`provider-execution-auth`, `provider-action`), any import of the top-level barrel, any unresolvable import, and any unexpected external dependency (shared has zero runtime deps). Every ambiguity is a failure, never a skip.
- Verifies the `./client` exports-map entry, that the emitted entrypoint exists (building dist itself on a clean checkout, failing closed if the build fails), and that the client entrypoint exposes the helpers web depends on (ESM consumer check via real `import()`).
- Scans all of `web/src` and fails if any non-test module imports the top-level `@stwd/shared` barrel, preventing regression to the exact pre-fix failure mode.

## Mutation proofs (2/2 killed, scripted)

`scripts/client-entrypoint-mutation-proofs.sh` (run green end-to-end):

1. Re-export `provider-execution-auth.js` from `client.ts` -> contract test FAILS (source-graph and dist-graph assertions both trip). Restored -> passes.
2. Revert `web/src/lib/utils.ts` to import the top-level barrel -> contract test FAILS (web-scan assertion trips). Restored -> passes.

## Receipts

- **Before patch**: `cf:build` exit 1 with the issue's exact `node:crypto` import trace.
- **After patch**: clean `cf:build` (fresh `.next`/`.open-next`) exit 0, `Worker saved in .open-next/worker.js`. `wrangler deploy --dry-run` passes.
- **Bundle scans**: zero hits for `node:crypto` / `provider-execution-auth` / `hkdfSync` / `timingSafeEqual` in `.open-next/**` (worker output) and `.next/static/chunks/**` (client chunks).
- **shared suite**: 354 pass / 0 fail (14 files, includes the new contract test).
- **web unit tests**: 15 pass / 0 fail.
- **api isolated suite (real PG, CI-parity env)**: 212/213 files green on first run; the one failure (`user-wallet-signers.test.ts`, exit 133 crash, not an assertion failure) passed clean on isolated re-run: 6 pass / 0 fail. Regression floor all green: execution-authorization + v2-crypto, provider-x-governed-e2e, provider-approval suites, provider-case/evidence suites, audit-bundle suites, vault-execution-gateway.
- **root typecheck** (`bun run typecheck`): green. **biome lint**: no new findings (4 pre-existing warnings elsewhere). **byte scan**: 0 corruption, 0 em-dashes across all changed files.
- **codex review** (`--base origin/develop`, iterated): first pass found 1 finding (contract test required untracked dist on clean checkouts), reproduced and fixed in commit 2; final pass: "I did not find any discrete correctness issues introduced by this patch."

## Honest gaps / notes

- The dry-run repro + post-fix build were run locally (CI's Build check only triggers on PRs touching `web/**`; this PR touches `web/**` so the check will run here and prove it on CI).
- `bun.lock` untouched (no dependency changes; the exports-map addition needs no lock update).
- `provider-action.ts` also imports `node:crypto` and stays server-only; it was never needed by web.

[sol-orch]
