### PR TITLE
feat(approvals): M-of-N quorum approval for provider actions

### DIFF
--- a/DESIGN-QUORUM.md
+++ b/DESIGN-QUORUM.md
@@ -1,10 +1,10 @@
-# M-of-N Quorum Approval (issue #205) — Design
+# M-of-N Quorum Approval (issue #205): Design
 
 ## Goal
 Generalize the single-approver provider-action approval lifecycle to N-of-M quorum,
 while keeping the absent-quorum path byte-for-byte identical to today.
 
-## Config source (NO capability-intent.ts edit — avoids #206 collision)
+## Config source (NO capability-intent.ts edit, avoids #206 collision)
 Quorum config is read from the operation's `request_profile.approvalRequirements.quorum`,
 the SAME place `extractRequesterSeparation` already reads. Shape:
 
@@ -26,7 +26,7 @@ bound into the approval commitment at create time, exactly like requesterSeparat
    - `quorum_threshold integer` (NULL = single-approver)
    - `quorum_eligible_user_ids uuid[] NOT NULL DEFAULT '{}'`
    - `quorum_approvals_count integer NOT NULL DEFAULT 0`
-2. New table `provider_action_approvals` — one row per DISTINCT approver decision.
+2. New table `provider_action_approvals`: one row per DISTINCT approver decision.
    - PK id uuid
    - approval_queue_id FK -> approval_queue.id (cascade)
    - intent_id, tenant_id, workspace_id

--- a/DESIGN-QUORUM.md
+++ b/DESIGN-QUORUM.md
@@ -1,0 +1,85 @@
+# M-of-N Quorum Approval (issue #205) — Design
+
+## Goal
+Generalize the single-approver provider-action approval lifecycle to N-of-M quorum,
+while keeping the absent-quorum path byte-for-byte identical to today.
+
+## Config source (NO capability-intent.ts edit — avoids #206 collision)
+Quorum config is read from the operation's `request_profile.approvalRequirements.quorum`,
+the SAME place `extractRequesterSeparation` already reads. Shape:
+
+```
+approvalRequirements: {
+  requesterSeparation?: boolean,
+  quorum?: { threshold: number, eligibleApproverIds: string[] }  // workspace_approver-scoped user ids
+}
+```
+
+Absent `quorum` => single-approver legacy path (N=1 implicit, unchanged).
+
+The policy engine (`composeProviderActionPolicyDecision`) is unchanged: it still
+emits `approval_required`. The threshold + eligible set are commitment metadata,
+bound into the approval commitment at create time, exactly like requesterSeparation.
+
+## Schema (migration 0083)
+1. `approval_queue` additive columns (nullable, default keeps legacy path):
+   - `quorum_threshold integer` (NULL = single-approver)
+   - `quorum_eligible_user_ids uuid[] NOT NULL DEFAULT '{}'`
+   - `quorum_approvals_count integer NOT NULL DEFAULT 0`
+2. New table `provider_action_approvals` — one row per DISTINCT approver decision.
+   - PK id uuid
+   - approval_queue_id FK -> approval_queue.id (cascade)
+   - intent_id, tenant_id, workspace_id
+   - approver_user_id uuid NOT NULL
+   - decision varchar(16) NOT NULL ('approve'|'deny')
+   - binding_revision_at_decision integer NOT NULL  (STALE binding: which revision this bound)
+   - request_hash, action_digest (I10 exact bind per approval)
+   - approval_commitment_hash (bind the exact commitment)
+   - decision_idempotency_key_hash, decision_request_hash
+   - mfa_verified_at, mfa_age_ms_at_decision
+   - reason_code, reason
+   - created_at
+   - UNIQUE (approval_queue_id, approver_user_id)  -- distinctness: an approver counts once
+   - UNIQUE (tenant_id, approver_user_id, decision_idempotency_key_hash)  -- cross-action idem
+
+## Lifecycle
+- QUORUM path (quorum_threshold NOT NULL):
+  - approve: insert a distinct provider_action_approvals row (approve), increment
+    quorum_approvals_count via guarded CAS. When count reaches threshold => transition
+    queue.status pending->approved, binding pending_approval->approved (Nth winner picks
+    the "approvalActorUserId" = the Nth approver; the full approver set lives in the
+    approvals table + audit trail). N-1 approvals leave status pending (execute unreachable).
+  - deny: DENY WINS IMMEDIATELY. First deny transitions pending->rejected regardless of count.
+  - stale: ANY dependency/payload/integrity change stales the WHOLE set: binding transitions
+    to approval_stale AND all collected provider_action_approvals rows are invalidated
+    (the set is re-bound to binding_revision; a staleness bumps binding_revision, so every
+    prior approval row that recorded an older binding_revision_at_decision is dead). We also
+    hard-delete/ignore prior rows on re-entry after a revision bump: since the queue can only
+    reach `approved` when threshold DISTINCT rows exist AT THE CURRENT binding_revision, a
+    stale (which flips queue to `stale` terminal) makes the set unrecoverable.
+  - distinctness: N DISTINCT user ids (unique index). requester-separation generalized:
+    requester (agent owner) can never count. An approver approving twice: unique index
+    rejects loudly (APPROVAL_DUPLICATE_APPROVER, 409).
+  - eligibility: enforced per-approval at decide time (checkApprover: current membership +
+    role + recent MFA + eligible-set membership). A user who lost eligibility between approvals
+    cannot complete the quorum.
+  - race: two concurrent Nth approvals -> guarded CAS on quorum_approvals_count + the
+    pending->approved transition WHERE status='pending' AND count>=threshold ensures exactly
+    one execute-reachable transition (mirror nonce single-winner).
+
+- SINGLE path (quorum_threshold IS NULL): untouched. Existing decide() code runs verbatim.
+
+## Fail-closed store-time + eval-time validation
+- store (buildApprovalArm): reject threshold that is 0, negative, non-integer, > eligible set
+  size, empty eligible set, eligible set with unknown/duplicate ids, or an eligible set that
+  doesn't include enough non-requester members to ever reach threshold.
+- eval (decide): re-validate threshold + eligible set from the persisted commitment;
+  malformed => deny (APPROVAL_QUORUM_CONFIG_INVALID). Approver must be in eligible set.
+
+## Audit
+- Each distinct decision emits `provider.approval.decided` (existing action) with quorum
+  progress in metadata (threshold, count-after).
+- Terminal quorum-satisfied transition emits the existing `provider.approval.decided`
+  (toStatus approved) carrying threshold/count. No second evidence system.
+
+## Nested quorums: OUT OF SCOPE (flat N-of-M only), stated in PR body.

--- a/packages/api/scripts/quorum-mutation-proofs.sh
+++ b/packages/api/scripts/quorum-mutation-proofs.sh
@@ -19,9 +19,15 @@ export STEWARD_EXECUTION_AUTH_SECRET="${STEWARD_EXECUTION_AUTH_SECRET:-$(printf 
 pass_count=0
 fail_count=0
 
-# run_test <file> <filter> -> 0 if all pass (0 fail), 1 otherwise
+# run_test <file> <filter> -> 0 if all pass (0 fail), 1 otherwise. A single retry
+# absorbs a transient PGLite/WASM contention flake when proofs run back-to-back
+# (observed: the staleness baseline intermittently trips a fresh-instance race).
 run_test() {
   local out
+  out=$(timeout 120 bun test --timeout 30000 "$1" -t "$2" 2>&1)
+  if echo "$out" | grep -qE "^ *0 fail$"; then
+    return 0
+  fi
   out=$(timeout 120 bun test --timeout 30000 "$1" -t "$2" 2>&1)
   echo "$out" | grep -qE "^ *0 fail$"
 }
@@ -79,6 +85,23 @@ proof "M5 drop deny-terminates (deny after partial)" "$Q" "deny after a partial 
 #     ineligible-Nth-approver (not in set) test must fail.
 proof "M6 drop eligible-set membership (ineligible Nth approver)" "$Q" "not in eligible set" "$SVC" \
   '937s/if (!eligible.includes(userId)) {/if (false) {/'
+
+# M7 (GATE-236 NEW): DERIVE EXECUTABLE FROM A DOUBLE-COUNTED TALLY, NOT DISTINCT
+#     APPROVES. Bump the running tally by 2 per approve so the authoritative
+#     quorum_approvals_count diverges from the count of DISTINCT persisted approve
+#     rows. The tally-equals-distinct-approve-rows invariant test must fail
+#     (a single approve would report a tally of 2 while only one approve row
+#     exists — an executable derivation not backed by distinct persisted votes).
+proof "M7 tally double-counts (tally != distinct approve rows)" "$Q" "tally equals distinct APPROVE rows" "$SVC" \
+  '1751s/sql`\${approvalQueue.quorumApprovalsCount} + 1`/sql`\${approvalQueue.quorumApprovalsCount} + 2`/'
+
+# M8 (GATE-236 NEW): DROP THE SATISFYING Nth-TRANSITION THRESHOLD. Satisfy the
+#     quorum at count >= 1 so ANY approve (including N-1) flips the queue to
+#     approved (execute-reachable). The boundary (N-1 NOT execute-reachable) test
+#     must fail. Distinct from M1 (which mutates threshold-1): this proves the
+#     satisfaction predicate is bound to the FULL threshold, not merely >0.
+proof "M8 satisfy at count>=1 (N-1 executable)" "$Q" "boundary: first approval" "$SVC" \
+  '1770s/const quorumSatisfied = countAfter >= threshold;/const quorumSatisfied = countAfter >= 1;/'
 
 echo ""
 echo "==================================================="

--- a/packages/api/scripts/quorum-mutation-proofs.sh
+++ b/packages/api/scripts/quorum-mutation-proofs.sh
@@ -54,13 +54,13 @@ proof "M1 weaken threshold compare (boundary N-1)" "$Q" "boundary: first approva
 # M2: DROP DISTINCTNESS. Skip the same-approver duplicate short-circuit so a
 #     repeated approver would count again. The duplicate-approver test must fail.
 proof "M2 drop distinctness (duplicate approver)" "$Q" "duplicate approver" "$SVC" \
-  's/return fail("APPROVAL_DUPLICATE_APPROVER", 409);/existing.decisionIdempotencyKeyHash === existing.decisionIdempotencyKeyHash;/'
+  '1590s/return fail("APPROVAL_DUPLICATE_APPROVER", 409);/return { ok: true, httpStatus: 200, id: binding.intentId, status: binding.status, version: binding.bindingRevision, requestHash: binding.requestHash, actionDigest: binding.actionDigest };/'
 
 # M3: DROP REQUESTER-SEPARATION. Let the requester (agent owner) count toward the
 #     quorum by neutralizing the owner==approver guard in the quorum branch. The
 #     "requester can never count" test must fail.
 proof "M3 drop requester-separation (requester as approver)" "$Q" "can never count toward the quorum" "$SVC" \
-  '856s/if (agent?.ownerUserId \&\& agent.ownerUserId === userId) {/if (false) {/'
+  '922s/if (agent?.ownerUserId \&\& agent.ownerUserId === userId) {/if (false) {/'
 
 # M4: SKIP STALENESS ON THE SET. Bypass the approve-path dependency staleness so
 #     a mutated committed dependency after the first approval would NOT stale the
@@ -72,13 +72,13 @@ proof "M4 skip staleness on set (stale-after-first)" "$Q" "stale after first app
 #     the immediate-termination branch, so a deny no longer terminates the whole
 #     approval. The deny-after-partial-quorum test must fail.
 proof "M5 drop deny-terminates (deny after partial)" "$Q" "deny after a partial quorum terminates" "$SVC" \
-  '1589s/if (input.decision === "deny") {/if (false) {/'
+  '1657s/if (input.decision === "deny") {/if (false) {/'
 
 # M6: DROP ELIGIBLE-SET MEMBERSHIP. Accept any role-holder as an eligible quorum
 #     approver even if they are not on the frozen eligible set. The
 #     ineligible-Nth-approver (not in set) test must fail.
 proof "M6 drop eligible-set membership (ineligible Nth approver)" "$Q" "not in eligible set" "$SVC" \
-  '871s/if (!eligible.includes(userId)) {/if (false) {/'
+  '937s/if (!eligible.includes(userId)) {/if (false) {/'
 
 echo ""
 echo "==================================================="

--- a/packages/api/scripts/quorum-mutation-proofs.sh
+++ b/packages/api/scripts/quorum-mutation-proofs.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# #205 quorum mutation-strength proofs. Each mutation weakens ONE security
+# predicate of the M-of-N quorum lifecycle; a proof is valid iff the named test
+# PASSES clean AND FAILS after the mutation. The file is restored after each
+# proof (no .bak residue). Run from packages/api:
+#
+#   bash scripts/quorum-mutation-proofs.sh
+#
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+SVC="src/services/provider-approval.ts"
+Q="src/__tests__/provider-approval-quorum.test.ts"
+
+export STEWARD_PGLITE_MEMORY=true
+export STEWARD_AUDIT_HMAC_KEY="${STEWARD_AUDIT_HMAC_KEY:-$(printf '0%.0s' {1..64})}"
+export STEWARD_EXECUTION_AUTH_SECRET="${STEWARD_EXECUTION_AUTH_SECRET:-$(printf '1%.0s' {1..64})}"
+
+pass_count=0
+fail_count=0
+
+# run_test <file> <filter> -> 0 if all pass (0 fail), 1 otherwise
+run_test() {
+  local out
+  out=$(timeout 120 bun test --timeout 30000 "$1" -t "$2" 2>&1)
+  echo "$out" | grep -qE "^ *0 fail$"
+}
+
+# proof <name> <file> <filter> <target> <sed-expr>
+proof() {
+  local name="$1" file="$2" filter="$3" target="$4" sedexpr="$5"
+  echo "=== PROOF: $name ==="
+  if run_test "$file" "$filter"; then
+    echo "  baseline PASS"
+  else
+    echo "  baseline UNEXPECTED FAIL (proof invalid)"; fail_count=$((fail_count+1)); return
+  fi
+  cp "$target" "$target.bak"
+  sed -i "$sedexpr" "$target"
+  if run_test "$file" "$filter"; then
+    echo "  post-mutation still PASSES (mutation did not kill the test)"; fail_count=$((fail_count+1))
+  else
+    echo "  post-mutation FAILS (predicate killed)"; pass_count=$((pass_count+1))
+  fi
+  mv "$target.bak" "$target"
+}
+
+# M1: WEAKEN THRESHOLD COMPARE. Satisfy the quorum at count >= threshold-1, so a
+#     single (N-1) approval would already flip to approved. The boundary test
+#     (N-1 must NOT be execute-reachable) must fail.
+proof "M1 weaken threshold compare (boundary N-1)" "$Q" "boundary: first approval" "$SVC" \
+  's/const quorumSatisfied = countAfter >= threshold;/const quorumSatisfied = countAfter >= threshold - 1;/'
+
+# M2: DROP DISTINCTNESS. Skip the same-approver duplicate short-circuit so a
+#     repeated approver would count again. The duplicate-approver test must fail.
+proof "M2 drop distinctness (duplicate approver)" "$Q" "duplicate approver" "$SVC" \
+  's/return fail("APPROVAL_DUPLICATE_APPROVER", 409);/existing.decisionIdempotencyKeyHash === existing.decisionIdempotencyKeyHash;/'
+
+# M3: DROP REQUESTER-SEPARATION. Let the requester (agent owner) count toward the
+#     quorum by neutralizing the owner==approver guard in the quorum branch. The
+#     "requester can never count" test must fail.
+proof "M3 drop requester-separation (requester as approver)" "$Q" "can never count toward the quorum" "$SVC" \
+  '856s/if (agent?.ownerUserId \&\& agent.ownerUserId === userId) {/if (false) {/'
+
+# M4: SKIP STALENESS ON THE SET. Bypass the approve-path dependency staleness so
+#     a mutated committed dependency after the first approval would NOT stale the
+#     collected set. The stale-after-first-approval test must fail.
+proof "M4 skip staleness on set (stale-after-first)" "$Q" "stale after first approval invalidates the whole set" "$SVC" \
+  's/if (!deps.ok \&\& input.decision === "approve") {/if (false) {/'
+
+# M5: DROP DENY-TERMINATES. Route a deny through the approve tally path instead of
+#     the immediate-termination branch, so a deny no longer terminates the whole
+#     approval. The deny-after-partial-quorum test must fail.
+proof "M5 drop deny-terminates (deny after partial)" "$Q" "deny after a partial quorum terminates" "$SVC" \
+  '1589s/if (input.decision === "deny") {/if (false) {/'
+
+# M6: DROP ELIGIBLE-SET MEMBERSHIP. Accept any role-holder as an eligible quorum
+#     approver even if they are not on the frozen eligible set. The
+#     ineligible-Nth-approver (not in set) test must fail.
+proof "M6 drop eligible-set membership (ineligible Nth approver)" "$Q" "not in eligible set" "$SVC" \
+  '871s/if (!eligible.includes(userId)) {/if (false) {/'
+
+echo ""
+echo "==================================================="
+echo "quorum mutation proofs: killed=$pass_count  survived/invalid=$fail_count"
+[ "$fail_count" -eq 0 ] && echo "ALL MUTATIONS KILLED" || echo "SOME MUTATIONS SURVIVED"
+exit "$fail_count"

--- a/packages/api/src/__tests__/provider-approval-fixture.ts
+++ b/packages/api/src/__tests__/provider-approval-fixture.ts
@@ -279,6 +279,23 @@ export async function approvalRowCount(intentId: string): Promise<number> {
   return Number((arr[0] as { n: number }).n);
 }
 
+/**
+ * Count of DISTINCT persisted APPROVE decision rows for an intent. The
+ * authoritative executable-derivation invariant is that this equals the queue's
+ * quorum_approvals_count (the tally can never diverge from the distinct approve
+ * votes actually committed). Deny rows are excluded, so a mixed approve/deny
+ * corpus can prove the tally counts approvals only.
+ */
+export async function approveRowCount(intentId: string): Promise<number> {
+  const rows = await getDb().execute(
+    sql`SELECT count(*)::int AS n FROM provider_action_approvals paa
+        JOIN approval_queue aq ON aq.id = paa.approval_queue_id
+        WHERE aq.intent_id = ${intentId} AND paa.decision = 'approve'`,
+  );
+  const arr = Array.isArray(rows) ? rows : ((rows as { rows?: unknown[] }).rows ?? []);
+  return Number((arr[0] as { n: number }).n);
+}
+
 /** Create an approval-required provider action and return its intentId. */
 export async function createApprovalRequired(idem = "aaaaaaaa"): Promise<{
   intentId: string;

--- a/packages/api/src/__tests__/provider-approval-fixture.ts
+++ b/packages/api/src/__tests__/provider-approval-fixture.ts
@@ -42,7 +42,10 @@ export const F = {
   GRANTOR: "10000000-0000-4000-8000-000000000001",
   APPROVER: "80000000-0000-4000-8000-000000000001",
   APPROVER_2: "80000000-0000-4000-8000-000000000002",
+  APPROVER_3: "80000000-0000-4000-8000-000000000003",
   APPROVER_BINDING: "90000000-0000-4000-8000-000000000001",
+  APPROVER_BINDING_2: "90000000-0000-4000-8000-000000000002",
+  APPROVER_BINDING_3: "90000000-0000-4000-8000-000000000003",
   GRANT: "a0000000-0000-4000-8000-000000000001",
 };
 
@@ -80,7 +83,21 @@ export const APPROVAL_RULES = [
   },
 ];
 
-export async function seedFixture(opts: { requesterSeparation?: boolean } = {}) {
+export interface QuorumFixtureConfig {
+  threshold: number;
+  eligibleApproverUserIds: string[];
+}
+
+export async function seedFixture(
+  opts: {
+    requesterSeparation?: boolean;
+    quorum?: QuorumFixtureConfig;
+    /** Set the agent owner (defaults to AGENT_OWNER when requesterSeparation is
+     *  on). Use this to make the requester an eligible-listed approver so the
+     *  requester-as-approver quorum guard can be exercised. */
+    agentOwnerUserId?: string;
+  } = {},
+) {
   const db = getDb();
   await db.insert(tenants).values([
     { id: F.TENANT, name: "Appr", apiKeyHash: "h" },
@@ -90,11 +107,13 @@ export async function seedFixture(opts: { requesterSeparation?: boolean } = {}) 
     { id: F.GRANTOR, email: "g@t.test" },
     { id: F.APPROVER, email: "approver@t.test" },
     { id: F.APPROVER_2, email: "approver2@t.test" },
+    { id: F.APPROVER_3, email: "approver3@t.test" },
     { id: F.AGENT_OWNER, email: "owner@t.test" },
   ]);
   await db.insert(userTenants).values([
     { userId: F.APPROVER, tenantId: F.TENANT, role: "member" },
     { userId: F.APPROVER_2, tenantId: F.TENANT, role: "admin" },
+    { userId: F.APPROVER_3, tenantId: F.TENANT, role: "member" },
     { userId: F.AGENT_OWNER, tenantId: F.TENANT, role: "member" },
   ]);
   await db.insert(agents).values([
@@ -103,7 +122,8 @@ export async function seedFixture(opts: { requesterSeparation?: boolean } = {}) 
       tenantId: F.TENANT,
       name: "A",
       walletAddress: "0x1",
-      ownerUserId: opts.requesterSeparation ? F.AGENT_OWNER : null,
+      ownerUserId:
+        opts.agentOwnerUserId ?? (opts.requesterSeparation ? F.AGENT_OWNER : null),
     },
   ]);
   await db.insert(secrets).values([
@@ -171,8 +191,15 @@ export async function seedFixture(opts: { requesterSeparation?: boolean } = {}) 
       secretRouteId: F.ROUTE,
       requestProfile: {
         policyRules: APPROVAL_RULES,
-        ...(opts.requesterSeparation
-          ? { approvalRequirements: { requesterSeparation: true } }
+        ...(opts.requesterSeparation || opts.quorum
+          ? {
+              approvalRequirements: {
+                ...(opts.requesterSeparation ? { requesterSeparation: true } : {}),
+                // Pass the quorum config through VERBATIM (including any extra
+                // keys) so malformed-config store-time rejection can be tested.
+                ...(opts.quorum ? { quorum: opts.quorum } : {}),
+              },
+            }
           : {}),
       },
     },
@@ -191,8 +218,11 @@ export async function seedFixture(opts: { requesterSeparation?: boolean } = {}) 
       reason: "test",
     },
   ]);
-  // Eligible human workspace_approver for the exact workspace.
-  await db.insert(providerRoleBindings).values([
+  // Eligible human workspace_approver for the exact workspace. The single
+  // APPROVER is always bound. APPROVER_2 / APPROVER_3 get workspace_approver
+  // bindings ONLY for quorum fixtures, so the single-approver negative matrix
+  // (which relies on APPROVER_2 having NO approver binding) is unaffected.
+  const bindings: Array<typeof providerRoleBindings.$inferInsert> = [
     {
       id: F.APPROVER_BINDING,
       tenantId: F.TENANT,
@@ -206,7 +236,48 @@ export async function seedFixture(opts: { requesterSeparation?: boolean } = {}) 
       grantedByUserId: F.GRANTOR,
       reason: "approver",
     },
-  ]);
+  ];
+  if (opts.quorum) {
+    bindings.push(
+      {
+        id: F.APPROVER_BINDING_2,
+        tenantId: F.TENANT,
+        workspaceId: F.WORKSPACE,
+        principalType: "human",
+        principalId: F.APPROVER_2,
+        roleKey: "workspace_approver",
+        operationKeys: [],
+        environment: "production",
+        status: "active",
+        grantedByUserId: F.GRANTOR,
+        reason: "approver-2",
+      },
+      {
+        id: F.APPROVER_BINDING_3,
+        tenantId: F.TENANT,
+        workspaceId: F.WORKSPACE,
+        principalType: "human",
+        principalId: F.APPROVER_3,
+        roleKey: "workspace_approver",
+        operationKeys: [],
+        environment: "production",
+        status: "active",
+        grantedByUserId: F.GRANTOR,
+        reason: "approver-3",
+      },
+    );
+  }
+  await db.insert(providerRoleBindings).values(bindings);
+}
+
+export async function approvalRowCount(intentId: string): Promise<number> {
+  const rows = await getDb().execute(
+    sql`SELECT count(*)::int AS n FROM provider_action_approvals paa
+        JOIN approval_queue aq ON aq.id = paa.approval_queue_id
+        WHERE aq.intent_id = ${intentId}`,
+  );
+  const arr = Array.isArray(rows) ? rows : ((rows as { rows?: unknown[] }).rows ?? []);
+  return Number((arr[0] as { n: number }).n);
 }
 
 /** Create an approval-required provider action and return its intentId. */

--- a/packages/api/src/__tests__/provider-approval-fixture.ts
+++ b/packages/api/src/__tests__/provider-approval-fixture.ts
@@ -122,8 +122,7 @@ export async function seedFixture(
       tenantId: F.TENANT,
       name: "A",
       walletAddress: "0x1",
-      ownerUserId:
-        opts.agentOwnerUserId ?? (opts.requesterSeparation ? F.AGENT_OWNER : null),
+      ownerUserId: opts.agentOwnerUserId ?? (opts.requesterSeparation ? F.AGENT_OWNER : null),
     },
   ]);
   await db.insert(secrets).values([

--- a/packages/api/src/__tests__/provider-approval-quorum-race.test.ts
+++ b/packages/api/src/__tests__/provider-approval-quorum-race.test.ts
@@ -13,7 +13,15 @@
  * pool the preload left in place when DATABASE_URL is set.
  */
 
-import { afterAll, beforeAll, beforeEach, describe, expect, setDefaultTimeout, test } from "bun:test";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  setDefaultTimeout,
+  test,
+} from "bun:test";
 import {
   approvalQueue,
   getDb,

--- a/packages/api/src/__tests__/provider-approval-quorum-race.test.ts
+++ b/packages/api/src/__tests__/provider-approval-quorum-race.test.ts
@@ -43,6 +43,7 @@ import {
 import { providerApprovalService } from "../services/provider-approval";
 import {
   approvalRowCount,
+  approveRowCount,
   bindingRow,
   correlatedAudit,
   createApprovalRequired,
@@ -180,6 +181,87 @@ describe.skipIf(SKIP)("#205 quorum Nth-approval race (real PG)", () => {
     expect(await approvalRowCount(intentId)).toBe(3);
     const b = await bindingRow(intentId);
     expect(b.status).toBe("approved");
+  });
+
+  // GATE-236 adversarial interleaving: at N-1, a concurrent approve (which would
+  // satisfy the quorum) races a deny (which must terminate). The terminal state
+  // must be UNAMBIGUOUS and fail-closed: EITHER approved OR denied, never a torn
+  // state where the queue is denied but the binding approved (or vice-versa),
+  // and NEVER an orphan approve tally left on a denied queue. Deny-wins is the
+  // desired posture, but the hard invariant the gate enforces is single-terminal
+  // consistency: the queue, binding, and intent agree, and no execute-reachable
+  // transition coexists with a deny.
+  test("concurrent approve+deny at N-1 => single consistent terminal, no torn state", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    // Bring the tally to N-1 = 1 (2-of-3).
+    await decide(intentId, requestHash, actionDigest, F.APPROVER, "ad-a1");
+
+    // APPROVER_2 approves (would satisfy) and APPROVER_3 denies, concurrently on
+    // separate pooled connections.
+    const [approveRes, denyRes] = await Promise.all([
+      decide(intentId, requestHash, actionDigest, F.APPROVER_2, "ad-a2"),
+      providerApprovalService.decide({
+        intentId,
+        tenantId: F.TENANT,
+        authenticatedUserId: F.APPROVER_3,
+        sessionMfaVerifiedAt: freshMfa(),
+        decision: "deny" as const,
+        expectedVersion: 1,
+        expectedRequestHash: requestHash,
+        expectedActionDigest: actionDigest,
+        reasonCode: "approver_manual_deny",
+        reason: null,
+        idempotencyKey: "ad-deny",
+      }),
+    ]);
+
+    // At most one of the two racers may report a fresh terminal success; the
+    // loser rolls back with a state conflict (never two committed terminals).
+    const terminalOks = [approveRes, denyRes].filter(
+      (r) =>
+        r.ok &&
+        ((r as { status?: string }).status === "approved" ||
+          (r as { status?: string }).status === "approval_denied"),
+    );
+    expect(terminalOks.length).toBe(1);
+
+    const b = await bindingRow(intentId);
+    const q = await queueRow(intentId);
+    const decided = (await correlatedAudit(intentId)).filter(
+      (e) => e.action === "provider.approval.decided",
+    );
+
+    // Single consistent terminal: the binding + queue + intent agree on ONE
+    // outcome. Exactly one of the two racers won the terminal transition; the
+    // loser rolled back (its non-counted evidence row is never committed).
+    if (b.status === "approval_denied") {
+      // Deny won (or deny raced in after the approve): queue rejected, no orphan
+      // approve tally left dangling above what actually counted, and NO
+      // execute-reachable transition was fabricated.
+      expect(q.status).toBe("rejected");
+      // The winning terminal decision emitted exactly one decided event for it.
+      // The approve loser, if it lost the pending->approved CAS, rolled back and
+      // recorded no vote (QuorumStateConflictError).
+      expect(b.status).not.toBe("approved");
+    } else {
+      // Approve won the race and satisfied the quorum: the deny then lost against
+      // the already-approved queue (terminated approve lineage). The binding is
+      // approved and the deny did not tear it back to denied.
+      expect(b.status).toBe("approved");
+      expect(q.status).toBe("approved");
+      // The approve tally equals the distinct persisted approve rows (never torn
+      // by the racing deny).
+      expect(q.quorumApprovalsCount).toBe(await approveRowCount(intentId));
+    }
+
+    // No matter who won: at most one terminal decided event (the winner). The
+    // loser's row rolled back, so it produced no committed decided event.
+    const terminalDecided = decided.filter((e) => e.action === "provider.approval.decided");
+    // a1 (partial approve) + exactly one terminal (approve-satisfy or deny).
+    expect(terminalDecided.length).toBe(2);
+    // The approve tally never exceeds the distinct approve rows regardless of
+    // the winner (no request-count-based inflation under the race).
+    expect(q.quorumApprovalsCount).toBe(await approveRowCount(intentId));
   });
 
   test("concurrent same-approver double-submit counts exactly once (distinctness under race)", async () => {

--- a/packages/api/src/__tests__/provider-approval-quorum-race.test.ts
+++ b/packages/api/src/__tests__/provider-approval-quorum-race.test.ts
@@ -1,0 +1,193 @@
+/**
+ * #205 concurrent-Nth-approval race against REAL Postgres (C-DRIFT-2 /
+ * requirement 9). Gated on DATABASE_URL: only runs against a genuine PG pool so
+ * two concurrent Nth approvals execute on SEPARATE connections in parallel
+ * (PGLite is single-connection and serializes, so this is the only place the
+ * single-winner discipline is proven under true concurrency).
+ *
+ * The guarded CAS on quorum_approvals_count + the pending->approved transition
+ * (WHERE status='pending' AND count>=threshold) must yield EXACTLY ONE
+ * execute-reachable transition even when both Nth approvals commit concurrently.
+ *
+ * This file does NOT install a PGLite override, so getDb() resolves the real
+ * pool the preload left in place when DATABASE_URL is set.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, setDefaultTimeout, test } from "bun:test";
+import {
+  approvalQueue,
+  getDb,
+  intents,
+  providerAccounts,
+  providerActionApprovals,
+  providerActionAuditOutbox,
+  providerActionBindings,
+  providerGrants,
+  providerOperations,
+  providerRoleBindings,
+  secretRoutes,
+  secrets,
+  tenants,
+  users,
+  userTenants,
+  workspaces,
+} from "@stwd/db";
+import { providerApprovalService } from "../services/provider-approval";
+import {
+  approvalRowCount,
+  bindingRow,
+  correlatedAudit,
+  createApprovalRequired,
+  F,
+  freshMfa,
+  queueRow,
+  seedFixture,
+} from "./provider-approval-fixture";
+
+setDefaultTimeout(120_000);
+
+const SKIP = !process.env.DATABASE_URL;
+
+async function wipe() {
+  const db = getDb();
+  await db.delete(providerActionApprovals);
+  await db.delete(providerActionAuditOutbox);
+  await db.delete(approvalQueue);
+  await db.delete(providerActionBindings);
+  await db.delete(intents);
+  await db.delete(providerGrants);
+  await db.delete(providerRoleBindings);
+  await db.delete(providerOperations);
+  await db.delete(providerAccounts);
+  await db.delete(secretRoutes);
+  await db.delete(secrets);
+  await db.delete(workspaces);
+  await db.delete(userTenants);
+  await db.delete(users);
+  await db.delete(tenants);
+}
+
+function decide(
+  intentId: string,
+  requestHash: string,
+  actionDigest: string,
+  userId: string,
+  idempotencyKey: string,
+) {
+  return providerApprovalService.decide({
+    intentId,
+    tenantId: F.TENANT,
+    authenticatedUserId: userId,
+    sessionMfaVerifiedAt: freshMfa(),
+    decision: "approve" as const,
+    expectedVersion: 1,
+    expectedRequestHash: requestHash,
+    expectedActionDigest: actionDigest,
+    reasonCode: null,
+    reason: null,
+    idempotencyKey,
+  });
+}
+
+const TWO_OF_THREE = {
+  threshold: 2,
+  eligibleApproverUserIds: [F.APPROVER, F.APPROVER_2, F.APPROVER_3],
+};
+
+describe.skipIf(SKIP)("#205 quorum Nth-approval race (real PG)", () => {
+  beforeAll(() => {
+    process.env.STEWARD_AUDIT_HMAC_KEY ||= "0".repeat(64);
+    process.env.STEWARD_EXECUTION_AUTH_SECRET ||= "1".repeat(64);
+  });
+  afterAll(async () => {
+    if (!SKIP) await wipe();
+  });
+  beforeEach(async () => {
+    await wipe();
+    await seedFixture({ quorum: TWO_OF_THREE });
+  });
+
+  test("two concurrent Nth approvals => exactly one execute-reachable transition", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    // First approval brings the tally to N-1.
+    await decide(intentId, requestHash, actionDigest, F.APPROVER, "race-a1");
+
+    // APPROVER_2 and APPROVER_3 both satisfy the 2/3 threshold; fire them truly
+    // concurrently on separate pooled connections.
+    const [r2, r3] = await Promise.all([
+      decide(intentId, requestHash, actionDigest, F.APPROVER_2, "race-a2"),
+      decide(intentId, requestHash, actionDigest, F.APPROVER_3, "race-a3"),
+    ]);
+
+    // Exactly ONE drives the binding to approved; the other lands after the
+    // quorum is already satisfied and is rejected loudly (never a second
+    // execute-reachable transition). Whether the loser sees ALREADY_DECIDED or a
+    // STATE_CONFLICT, it is NOT ok+approved.
+    const approvedTransitions = [r2, r3].filter(
+      (r) => r.ok && (r as { status?: string }).status === "approved",
+    );
+    expect(approvedTransitions.length).toBe(1);
+    const loser = [r2, r3].find((r) => !r.ok || (r as { status?: string }).status !== "approved");
+    expect(loser).toBeDefined();
+    expect(loser?.ok).toBe(false);
+
+    const b = await bindingRow(intentId);
+    expect(b.status).toBe("approved");
+    // Single-winner: exactly one binding-revision bump for the satisfying flip.
+    expect(b.bindingRevision).toBe(2);
+
+    const q = await queueRow(intentId);
+    expect(q.status).toBe("approved");
+    // Tally capped at threshold: the guarded CAS never exceeds it even with a
+    // concurrent double increment.
+    expect(q.quorumApprovalsCount).toBe(2);
+
+    // Exactly the satisfying set of distinct votes was recorded (a1 + the
+    // winning Nth). The loser landed after satisfaction and recorded no vote.
+    expect(await approvalRowCount(intentId)).toBe(2);
+    const decided = (await correlatedAudit(intentId)).filter(
+      (e) => e.action === "provider.approval.decided",
+    );
+    expect(decided.length).toBe(2);
+  });
+
+  test("many concurrent approvals from distinct eligible approvers => tally never exceeds threshold", async () => {
+    // Re-seed a 3-of-3 so all three race for the final slots.
+    await wipe();
+    await seedFixture({
+      quorum: { threshold: 3, eligibleApproverUserIds: [F.APPROVER, F.APPROVER_2, F.APPROVER_3] },
+    });
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    const results = await Promise.all([
+      decide(intentId, requestHash, actionDigest, F.APPROVER, "m-a1"),
+      decide(intentId, requestHash, actionDigest, F.APPROVER_2, "m-a2"),
+      decide(intentId, requestHash, actionDigest, F.APPROVER_3, "m-a3"),
+    ]);
+    // All three are distinct valid votes.
+    const oks = results.filter((r) => r.ok).length;
+    expect(oks).toBe(3);
+    const q = await queueRow(intentId);
+    expect(q.status).toBe("approved");
+    expect(q.quorumApprovalsCount).toBe(3);
+    expect(await approvalRowCount(intentId)).toBe(3);
+    const b = await bindingRow(intentId);
+    expect(b.status).toBe("approved");
+  });
+
+  test("concurrent same-approver double-submit counts exactly once (distinctness under race)", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    // Same approver fires the same vote twice concurrently: distinctness index
+    // must keep exactly one row; the loser is a loud duplicate/conflict.
+    const [a, b] = await Promise.all([
+      decide(intentId, requestHash, actionDigest, F.APPROVER, "dup-a"),
+      decide(intentId, requestHash, actionDigest, F.APPROVER, "dup-b"),
+    ]);
+    const oks = [a, b].filter((r) => r.ok).length;
+    // At most one succeeds as a fresh vote (the other is a duplicate-approver
+    // conflict); never two counted votes.
+    expect(oks).toBeLessThanOrEqual(1);
+    expect(await approvalRowCount(intentId)).toBe(1);
+    const q = await queueRow(intentId);
+    expect(q.quorumApprovalsCount).toBe(1);
+  });
+});

--- a/packages/api/src/__tests__/provider-approval-quorum.test.ts
+++ b/packages/api/src/__tests__/provider-approval-quorum.test.ts
@@ -103,7 +103,10 @@ function decide(
   });
 }
 
-const TWO_OF_THREE = { threshold: 2, eligibleApproverUserIds: [F.APPROVER, F.APPROVER_2, F.APPROVER_3] };
+const TWO_OF_THREE = {
+  threshold: 2,
+  eligibleApproverUserIds: [F.APPROVER, F.APPROVER_2, F.APPROVER_3],
+};
 
 describe("#205 M-of-N quorum approval", () => {
   beforeAll(async () => {
@@ -363,7 +366,10 @@ describe("#205 M-of-N quorum approval", () => {
   describe("malformed config fails closed at store time", () => {
     const cases: Array<{ name: string; quorum: unknown }> = [
       { name: "threshold 0", quorum: { threshold: 0, eligibleApproverUserIds: [F.APPROVER] } },
-      { name: "threshold negative", quorum: { threshold: -1, eligibleApproverUserIds: [F.APPROVER] } },
+      {
+        name: "threshold negative",
+        quorum: { threshold: -1, eligibleApproverUserIds: [F.APPROVER] },
+      },
       {
         name: "threshold non-integer",
         quorum: { threshold: 1.5, eligibleApproverUserIds: [F.APPROVER, F.APPROVER_2] },

--- a/packages/api/src/__tests__/provider-approval-quorum.test.ts
+++ b/packages/api/src/__tests__/provider-approval-quorum.test.ts
@@ -410,6 +410,47 @@ describe("#205 M-of-N quorum approval", () => {
     }
   });
 
+  // ── unreachable quorum fails closed at store time (codex P2) ─────────────
+  test("unreachable quorum (eligible ids that cannot vote) fails closed at store time", async () => {
+    await wipe();
+    // threshold 2 but the eligible set is [real approver, unknown UUID]: the
+    // unknown id has no workspace_approver role, so only 1 can ever vote < 2.
+    await seedFixture({
+      quorum: {
+        threshold: 2,
+        eligibleApproverUserIds: [F.APPROVER, "cccccccc-0000-4000-8000-000000000099"],
+      },
+    });
+    let threw = false;
+    try {
+      await createApprovalRequired();
+    } catch (e) {
+      threw = true;
+      expect(String((e as Error).message)).toContain("APPROVAL_QUORUM_CONFIG_INVALID");
+    }
+    expect(threw).toBe(true);
+    const rows = await getDb().select().from(approvalQueue);
+    expect(rows.length).toBe(0);
+  });
+
+  test("unreachable quorum where the only extra eligible member is the requester fails closed", async () => {
+    await wipe();
+    // threshold 2, eligible = [APPROVER, APPROVER_2] but APPROVER_2 is the agent
+    // owner (requester) => only 1 can vote (< 2) => reject at store time.
+    await seedFixture({
+      quorum: { threshold: 2, eligibleApproverUserIds: [F.APPROVER, F.APPROVER_2] },
+      agentOwnerUserId: F.APPROVER_2,
+    });
+    let threw = false;
+    try {
+      await createApprovalRequired();
+    } catch (e) {
+      threw = true;
+      expect(String((e as Error).message)).toContain("APPROVAL_QUORUM_CONFIG_INVALID");
+    }
+    expect(threw).toBe(true);
+  });
+
   // ── single-approver regression floor stays untouched ─────────────────────
   test("absent quorum: single-approver approve path is byte-for-byte unchanged", async () => {
     await wipe();

--- a/packages/api/src/__tests__/provider-approval-quorum.test.ts
+++ b/packages/api/src/__tests__/provider-approval-quorum.test.ts
@@ -1,0 +1,425 @@
+/**
+ * #205 M-of-N quorum approval integration tests against PGLite, through the REAL
+ * provider-approval + provider-action services (spec-binding adversarial cases):
+ *
+ *   - threshold boundary: N-1 approvals are NOT executable, the Nth is
+ *   - deny-after-partial-quorum terminates the whole approval (deny wins)
+ *   - stale-after-first-approval invalidates the collected set
+ *   - duplicate approver rejected loudly (counts once)
+ *   - requester-as-approver can never count
+ *   - ineligible Nth approver cannot complete the quorum
+ *   - malformed configs fail closed at BOTH store time and eval time
+ *   - single-approver regression (absent quorum) untouched
+ *
+ * The concurrent-Nth-approval race lives in provider-approval-quorum-race.test.ts
+ * (real Postgres, DATABASE_URL required).
+ */
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  setDefaultTimeout,
+  test,
+} from "bun:test";
+import {
+  approvalQueue,
+  closeDb,
+  getDb,
+  intents,
+  providerAccounts,
+  providerActionApprovals,
+  providerActionAuditOutbox,
+  providerActionBindings,
+  providerGrants,
+  providerOperations,
+  providerRoleBindings,
+  secretRoutes,
+  secrets,
+  tenants,
+  users,
+  userTenants,
+  workspaces,
+} from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { eq } from "drizzle-orm";
+import { providerApprovalService } from "../services/provider-approval";
+import {
+  approvalRowCount,
+  bindingRow,
+  correlatedAudit,
+  createApprovalRequired,
+  F,
+  freshMfa,
+  intentRow,
+  queueRow,
+  seedFixture,
+} from "./provider-approval-fixture";
+
+setDefaultTimeout(120_000);
+
+async function wipe() {
+  const db = getDb();
+  await db.delete(providerActionApprovals);
+  await db.delete(providerActionAuditOutbox);
+  await db.delete(approvalQueue);
+  await db.delete(providerActionBindings);
+  await db.delete(intents);
+  await db.delete(providerGrants);
+  await db.delete(providerRoleBindings);
+  await db.delete(providerOperations);
+  await db.delete(providerAccounts);
+  await db.delete(secretRoutes);
+  await db.delete(secrets);
+  await db.delete(workspaces);
+  await db.delete(userTenants);
+  await db.delete(users);
+  await db.delete(tenants);
+}
+
+function decide(
+  intentId: string,
+  requestHash: string,
+  actionDigest: string,
+  userId: string,
+  idempotencyKey: string,
+  overrides: Partial<Parameters<typeof providerApprovalService.decide>[0]> = {},
+) {
+  return providerApprovalService.decide({
+    intentId,
+    tenantId: F.TENANT,
+    authenticatedUserId: userId,
+    sessionMfaVerifiedAt: freshMfa(),
+    decision: "approve" as const,
+    expectedVersion: 1,
+    expectedRequestHash: requestHash,
+    expectedActionDigest: actionDigest,
+    reasonCode: null,
+    reason: null,
+    idempotencyKey,
+    ...overrides,
+  });
+}
+
+const TWO_OF_THREE = { threshold: 2, eligibleApproverUserIds: [F.APPROVER, F.APPROVER_2, F.APPROVER_3] };
+
+describe("#205 M-of-N quorum approval", () => {
+  beforeAll(async () => {
+    process.env.STEWARD_PGLITE_MEMORY = "true";
+    process.env.STEWARD_AUDIT_HMAC_KEY ||= "0".repeat(64);
+    process.env.STEWARD_EXECUTION_AUTH_SECRET ||= "1".repeat(64);
+    const { db, client } = await createPGLiteDb("memory://");
+    setPGLiteOverride(db, async () => client.close());
+  });
+  afterAll(async () => {
+    await closeDb();
+    delete process.env.STEWARD_PGLITE_MEMORY;
+  });
+
+  // ── happy path + boundary ────────────────────────────────────────────────
+  describe("2-of-3 lifecycle", () => {
+    beforeEach(async () => {
+      await wipe();
+      await seedFixture({ quorum: TWO_OF_THREE });
+    });
+
+    test("creation persists quorum config on the queue row + commitment", async () => {
+      const { intentId } = await createApprovalRequired();
+      const q = await queueRow(intentId);
+      expect(q.quorumThreshold).toBe(2);
+      expect([...(q.quorumEligibleUserIds ?? [])].sort()).toEqual(
+        [F.APPROVER, F.APPROVER_2, F.APPROVER_3].sort(),
+      );
+      expect(q.quorumApprovalsCount).toBe(0);
+      const commitment = q.approvalCommitment as { approvalRequirements?: { quorum?: unknown } };
+      expect(commitment.approvalRequirements?.quorum).toEqual({
+        threshold: 2,
+        eligibleApproverUserIds: [F.APPROVER, F.APPROVER_2, F.APPROVER_3].sort(),
+      } as never);
+    });
+
+    test("boundary: first approval (N-1) leaves pending, NOT execute-reachable", async () => {
+      const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+      const r1 = await decide(intentId, requestHash, actionDigest, F.APPROVER, "q-a1");
+      expect(r1.ok).toBe(true);
+      if (!r1.ok) throw new Error("a1 failed");
+      expect(r1.status).toBe("pending_approval");
+
+      const b = await bindingRow(intentId);
+      expect(b.status).toBe("pending_approval");
+      const q = await queueRow(intentId);
+      expect(q.status).toBe("pending");
+      expect(q.quorumApprovalsCount).toBe(1);
+      const i = await intentRow(intentId);
+      expect(i.status).toBe("pending");
+      expect(await approvalRowCount(intentId)).toBe(1);
+
+      // Resume must be unreachable while pending (N-1).
+      const resume = await providerApprovalService.resume({ intentId, tenantId: F.TENANT });
+      expect(resume.ok).toBe(false);
+      if (resume.ok) throw new Error("resume should be unreachable at N-1");
+      expect(resume.code).toBe("RESUME_NOT_APPROVED");
+    });
+
+    test("Nth distinct approval satisfies the quorum -> approved + authorized + resumable", async () => {
+      const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+      await decide(intentId, requestHash, actionDigest, F.APPROVER, "q-a1");
+      const r2 = await decide(intentId, requestHash, actionDigest, F.APPROVER_2, "q-a2");
+      expect(r2.ok).toBe(true);
+      if (!r2.ok) throw new Error("a2 failed");
+      expect(r2.status).toBe("approved");
+
+      const b = await bindingRow(intentId);
+      expect(b.status).toBe("approved");
+      const q = await queueRow(intentId);
+      expect(q.status).toBe("approved");
+      expect(q.quorumApprovalsCount).toBe(2);
+      const i = await intentRow(intentId);
+      expect(i.status).toBe("authorized");
+      expect(await approvalRowCount(intentId)).toBe(2);
+
+      // Now resume is reachable.
+      const resume = await providerApprovalService.resume({ intentId, tenantId: F.TENANT });
+      expect(resume.ok).toBe(true);
+      if (!resume.ok) throw new Error("resume failed");
+      expect(resume.status).toBe("execution_ready");
+
+      // Audit trail: two decided events with quorum progress + resume ready.
+      const events = await correlatedAudit(intentId);
+      const decided = events.filter((e) => e.action === "provider.approval.decided");
+      expect(decided.length).toBe(2);
+    });
+
+    test("duplicate approver: same user approving twice is rejected loudly, counts once", async () => {
+      const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+      await decide(intentId, requestHash, actionDigest, F.APPROVER, "q-a1");
+      const dup = await decide(intentId, requestHash, actionDigest, F.APPROVER, "q-a1-dup");
+      expect(dup.ok).toBe(false);
+      if (dup.ok) throw new Error("duplicate should fail");
+      expect(dup.code).toBe("APPROVAL_DUPLICATE_APPROVER");
+      const q = await queueRow(intentId);
+      expect(q.quorumApprovalsCount).toBe(1);
+      expect(await approvalRowCount(intentId)).toBe(1);
+    });
+
+    test("exact retry of the same approver vote replays (idempotent), counts once", async () => {
+      const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+      const r1 = await decide(intentId, requestHash, actionDigest, F.APPROVER, "q-retry");
+      expect(r1.ok).toBe(true);
+      const r1b = await decide(intentId, requestHash, actionDigest, F.APPROVER, "q-retry");
+      expect(r1b.ok).toBe(true);
+      if (!r1b.ok) throw new Error("retry failed");
+      expect(r1b.replayed).toBe(true);
+      const q = await queueRow(intentId);
+      expect(q.quorumApprovalsCount).toBe(1);
+      expect(await approvalRowCount(intentId)).toBe(1);
+    });
+
+    test("concurrent Nth approvals => exactly one execute-reachable transition", async () => {
+      const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+      // Pre-collect one approval so the next two are both "the Nth".
+      await decide(intentId, requestHash, actionDigest, F.APPROVER, "q-race-a1");
+      // Fire APPROVER_2 and APPROVER_3 concurrently: both would satisfy the 2/3
+      // threshold. Exactly one must flip the queue to approved.
+      const [r2, r3] = await Promise.all([
+        decide(intentId, requestHash, actionDigest, F.APPROVER_2, "q-race-a2"),
+        decide(intentId, requestHash, actionDigest, F.APPROVER_3, "q-race-a3"),
+      ]);
+      // Both approvals are recorded as distinct decision rows (both are valid
+      // votes), but only ONE drives the pending->approved transition; the other
+      // sees the queue already approved and reports a state conflict.
+      const approvedResults = [r2, r3].filter(
+        (r) => r.ok && (r as { status?: string }).status === "approved",
+      );
+      expect(approvedResults.length).toBe(1);
+      const b = await bindingRow(intentId);
+      expect(b.status).toBe("approved");
+      expect(b.bindingRevision).toBe(2);
+      const q = await queueRow(intentId);
+      expect(q.status).toBe("approved");
+      // The tally is capped at the threshold: the guarded CAS increment never
+      // pushes count above threshold.
+      expect(q.quorumApprovalsCount).toBe(2);
+      // Exactly the satisfying transition is a single approved decided event
+      // whose toStatus is approved.
+      const decided = (await correlatedAudit(intentId)).filter(
+        (e) => e.action === "provider.approval.decided",
+      );
+      // three votes attempted; the two winners that actually recorded (a1 + one
+      // of a2/a3) produce decided events. Under PGLite serialization the loser
+      // that hit the count cap does not emit a satisfying transition.
+      expect(decided.length).toBeGreaterThanOrEqual(2);
+    });
+
+    test("deny after a partial quorum terminates the whole approval (deny wins)", async () => {
+      const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+      await decide(intentId, requestHash, actionDigest, F.APPROVER, "q-a1");
+      const deny = await decide(intentId, requestHash, actionDigest, F.APPROVER_2, "q-deny", {
+        decision: "deny",
+        reasonCode: "approver_manual_deny",
+      });
+      expect(deny.ok).toBe(true);
+      if (!deny.ok) throw new Error("deny failed");
+      expect(deny.status).toBe("approval_denied");
+      const b = await bindingRow(intentId);
+      expect(b.status).toBe("approval_denied");
+      const q = await queueRow(intentId);
+      expect(q.status).toBe("rejected");
+      const i = await intentRow(intentId);
+      expect(i.status).toBe("rejected");
+
+      // A third approver can no longer complete the quorum (terminated).
+      const late = await decide(intentId, requestHash, actionDigest, F.APPROVER_3, "q-a3-late");
+      expect(late.ok).toBe(false);
+    });
+
+    test("ineligible Nth approver (not in eligible set) cannot complete the quorum", async () => {
+      // APPROVER + APPROVER_2 are in the set; drop APPROVER_2 from the set so
+      // only APPROVER + APPROVER_3 are eligible, but role-bind APPROVER_2 anyway.
+      // Re-seed with a 2-of-2 set of APPROVER + APPROVER_3.
+      await wipe();
+      await seedFixture({
+        quorum: { threshold: 2, eligibleApproverUserIds: [F.APPROVER, F.APPROVER_3] },
+      });
+      const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+      await decide(intentId, requestHash, actionDigest, F.APPROVER, "q-a1");
+      // APPROVER_2 has the role but is NOT in the eligible set.
+      const bad = await decide(intentId, requestHash, actionDigest, F.APPROVER_2, "q-bad");
+      expect(bad.ok).toBe(false);
+      if (bad.ok) throw new Error("ineligible approver should fail");
+      expect(bad.code).toBe("APPROVAL_NOT_ELIGIBLE_APPROVER");
+      const q = await queueRow(intentId);
+      expect(q.quorumApprovalsCount).toBe(1);
+    });
+
+    test("ineligible-by-lost-role Nth approver cannot complete the quorum", async () => {
+      const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+      await decide(intentId, requestHash, actionDigest, F.APPROVER, "q-a1");
+      // Revoke APPROVER_2's workspace_approver role after the first approval.
+      await getDb()
+        .update(providerRoleBindings)
+        .set({ status: "revoked" })
+        .where(eq(providerRoleBindings.id, F.APPROVER_BINDING_2));
+      const bad = await decide(intentId, requestHash, actionDigest, F.APPROVER_2, "q-lostrole");
+      expect(bad.ok).toBe(false);
+      if (bad.ok) throw new Error("lost-role approver should fail");
+      expect(bad.code).toBe("APPROVAL_ROLE_REQUIRED");
+      // APPROVER_3 (still eligible) CAN complete it.
+      const ok = await decide(intentId, requestHash, actionDigest, F.APPROVER_3, "q-a3");
+      expect(ok.ok).toBe(true);
+    });
+  });
+
+  // ── requester separation generalized ─────────────────────────────────────
+  test("requester (agent owner) can never count toward the quorum", async () => {
+    await wipe();
+    // Make APPROVER the agent owner AND list them as eligible: the requester
+    // guard must still reject them.
+    await seedFixture({
+      quorum: { threshold: 2, eligibleApproverUserIds: [F.APPROVER, F.APPROVER_2, F.APPROVER_3] },
+      agentOwnerUserId: F.APPROVER,
+    });
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    const bad = await decide(intentId, requestHash, actionDigest, F.APPROVER, "q-owner");
+    expect(bad.ok).toBe(false);
+    if (bad.ok) throw new Error("requester should never vote");
+    expect(bad.code).toBe("APPROVAL_REQUESTER_SEPARATION_REQUIRED");
+    // Two OTHER distinct approvers still satisfy it.
+    await decide(intentId, requestHash, actionDigest, F.APPROVER_2, "q-a2");
+    const done = await decide(intentId, requestHash, actionDigest, F.APPROVER_3, "q-a3");
+    expect(done.ok).toBe(true);
+    if (!done.ok) throw new Error("quorum should complete without requester");
+    expect(done.status).toBe("approved");
+  });
+
+  // ── staleness invalidates the collected set ──────────────────────────────
+  test("stale after first approval invalidates the whole set", async () => {
+    await wipe();
+    await seedFixture({ quorum: TWO_OF_THREE });
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    await decide(intentId, requestHash, actionDigest, F.APPROVER, "q-a1");
+    // Mutate a committed dependency: bump the provider account revision so the
+    // exact-revision re-eval stales the whole action on the next decide.
+    await getDb()
+      .update(providerAccounts)
+      .set({ revision: 99 })
+      .where(eq(providerAccounts.id, F.ACCOUNT));
+    const second = await decide(intentId, requestHash, actionDigest, F.APPROVER_2, "q-a2");
+    expect(second.ok).toBe(false);
+    if (second.ok) throw new Error("expected stale");
+    expect(second.code).toBe("APPROVAL_PROVIDER_ACCOUNT_STALE");
+    const b = await bindingRow(intentId);
+    expect(b.status).toBe("approval_stale");
+    const q = await queueRow(intentId);
+    expect(q.status).toBe("stale");
+    // The whole set is dead: even a fresh eligible approver cannot revive it.
+    const revive = await decide(intentId, requestHash, actionDigest, F.APPROVER_3, "q-a3");
+    expect(revive.ok).toBe(false);
+  });
+
+  // ── malformed config fails closed at store time ──────────────────────────
+  describe("malformed config fails closed at store time", () => {
+    const cases: Array<{ name: string; quorum: unknown }> = [
+      { name: "threshold 0", quorum: { threshold: 0, eligibleApproverUserIds: [F.APPROVER] } },
+      { name: "threshold negative", quorum: { threshold: -1, eligibleApproverUserIds: [F.APPROVER] } },
+      {
+        name: "threshold non-integer",
+        quorum: { threshold: 1.5, eligibleApproverUserIds: [F.APPROVER, F.APPROVER_2] },
+      },
+      {
+        name: "threshold > eligible set size",
+        quorum: { threshold: 3, eligibleApproverUserIds: [F.APPROVER, F.APPROVER_2] },
+      },
+      { name: "empty eligible set", quorum: { threshold: 1, eligibleApproverUserIds: [] } },
+      {
+        name: "duplicate eligible ids",
+        quorum: { threshold: 2, eligibleApproverUserIds: [F.APPROVER, F.APPROVER] },
+      },
+      {
+        name: "unknown key",
+        quorum: { threshold: 1, eligibleApproverUserIds: [F.APPROVER], nested: true },
+      },
+    ];
+
+    for (const c of cases) {
+      test(`rejects: ${c.name}`, async () => {
+        await wipe();
+        await seedFixture({ quorum: c.quorum as never });
+        // createApprovalRequired throws when the outcome is not approval_required;
+        // a malformed quorum fails creation closed (APPROVAL_QUORUM_CONFIG_INVALID).
+        let threw = false;
+        try {
+          await createApprovalRequired();
+        } catch (e) {
+          threw = true;
+          expect(String((e as Error).message)).toContain("APPROVAL_QUORUM_CONFIG_INVALID");
+        }
+        expect(threw).toBe(true);
+        // No queue / binding / approval row leaked.
+        const rows = await getDb().select().from(approvalQueue);
+        expect(rows.length).toBe(0);
+      });
+    }
+  });
+
+  // ── single-approver regression floor stays untouched ─────────────────────
+  test("absent quorum: single-approver approve path is byte-for-byte unchanged", async () => {
+    await wipe();
+    await seedFixture(); // no quorum
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    const res = await decide(intentId, requestHash, actionDigest, F.APPROVER, "single-1");
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error("single approve failed");
+    expect(res.status).toBe("approved");
+    expect(res.version).toBe(2);
+    const q = await queueRow(intentId);
+    expect(q.quorumThreshold).toBeNull();
+    expect(q.quorumApprovalsCount).toBe(0);
+    // No provider_action_approvals rows for the single-approver path.
+    expect(await approvalRowCount(intentId)).toBe(0);
+    const i = await intentRow(intentId);
+    expect(i.status).toBe("authorized");
+  });
+});

--- a/packages/api/src/__tests__/provider-approval-quorum.test.ts
+++ b/packages/api/src/__tests__/provider-approval-quorum.test.ts
@@ -48,6 +48,7 @@ import { eq } from "drizzle-orm";
 import { providerApprovalService } from "../services/provider-approval";
 import {
   approvalRowCount,
+  approveRowCount,
   bindingRow,
   correlatedAudit,
   createApprovalRequired,
@@ -295,6 +296,61 @@ describe("#205 M-of-N quorum approval", () => {
       expect(bad.code).toBe("APPROVAL_NOT_ELIGIBLE_APPROVER");
       const q = await queueRow(intentId);
       expect(q.quorumApprovalsCount).toBe(1);
+    });
+
+    // GATE-236 adversarial add: the executable tally must be derived from the
+    // DISTINCT APPROVE decision rows in the DB, never inflated by a deny row or
+    // by the raw decision-request count. A deny at N-1 terminates AND leaves the
+    // approve tally == the count of persisted approve rows (1), never 2.
+    test("tally equals distinct APPROVE rows; a deny never inflates the count", async () => {
+      const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+      await decide(intentId, requestHash, actionDigest, F.APPROVER, "inv-a1");
+      // A deny row is inserted but must NOT bump the approve tally (deny wins,
+      // terminates). The approve tally stays 1; the distinct approve-row count
+      // stays 1; the deny added exactly one non-approve row.
+      const deny = await decide(intentId, requestHash, actionDigest, F.APPROVER_2, "inv-deny", {
+        decision: "deny",
+        reasonCode: "approver_manual_deny",
+      });
+      expect(deny.ok).toBe(true);
+      const q = await queueRow(intentId);
+      // The authoritative tally never counted the deny.
+      expect(q.quorumApprovalsCount).toBe(1);
+      // The tally equals the number of DISTINCT persisted APPROVE rows.
+      expect(await approveRowCount(intentId)).toBe(q.quorumApprovalsCount);
+      // Total decision rows = 1 approve + 1 deny.
+      expect(await approvalRowCount(intentId)).toBe(2);
+      // Terminal denied: no execute-reachable transition was fabricated.
+      const b = await bindingRow(intentId);
+      expect(b.status).toBe("approval_denied");
+    });
+
+    // GATE-236 adversarial add: at exactly N-1 collected approvals, a deny by a
+    // DIFFERENT eligible approver must terminate the whole approval (deny wins
+    // even when a single further approve would have satisfied the quorum). A
+    // subsequent approve by the last eligible approver cannot resurrect it.
+    test("deny at N-1 terminates even though one more approve would satisfy quorum", async () => {
+      const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+      // Collect N-1 = 1 approval (2-of-3).
+      await decide(intentId, requestHash, actionDigest, F.APPROVER, "nm-a1");
+      const qBefore = await queueRow(intentId);
+      expect(qBefore.quorumApprovalsCount).toBe(1);
+      // A deny from a second distinct eligible approver terminates.
+      const deny = await decide(intentId, requestHash, actionDigest, F.APPROVER_2, "nm-deny", {
+        decision: "deny",
+        reasonCode: "approver_manual_deny",
+      });
+      expect(deny.ok).toBe(true);
+      if (!deny.ok) throw new Error("deny failed");
+      expect(deny.status).toBe("approval_denied");
+      // The last eligible approver's approve cannot revive the terminated action
+      // (it would otherwise have been the satisfying Nth approve).
+      const late = await decide(intentId, requestHash, actionDigest, F.APPROVER_3, "nm-a3");
+      expect(late.ok).toBe(false);
+      const b = await bindingRow(intentId);
+      expect(b.status).toBe("approval_denied");
+      const i = await intentRow(intentId);
+      expect(i.status).toBe("rejected");
     });
 
     test("ineligible-by-lost-role Nth approver cannot complete the quorum", async () => {

--- a/packages/api/src/services/provider-action-service.ts
+++ b/packages/api/src/services/provider-action-service.ts
@@ -1408,7 +1408,7 @@ export function extractRequesterSeparation(requestProfile: Record<string, unknow
  * THROWS {@link ApprovalArmError}("APPROVAL_QUORUM_CONFIG_INVALID") when a quorum
  * key is present but malformed (non-integer / <1 / > eligible-set size / empty
  * or duplicate or non-string eligible set / unknown members). Creation then
- * fails closed — a malformed quorum is NEVER stored (spec §7).
+ * fails closed. A malformed quorum is NEVER stored (spec §7).
  *
  * NOTE: membership-of-eligible-users-in-the-workspace_approver-role is NOT
  * verified here (the request profile does not carry role state); it is enforced

--- a/packages/api/src/services/provider-action-service.ts
+++ b/packages/api/src/services/provider-action-service.ts
@@ -118,8 +118,11 @@ export type ProviderActionOutcome =
     }
   | {
       kind: "evidence_failure";
-      code: "EVIDENCE_DECISION_PERSIST_FAILED" | "EVIDENCE_REQUIRED_AUDIT_UNAVAILABLE";
-      httpStatus: 503;
+      code:
+        | "EVIDENCE_DECISION_PERSIST_FAILED"
+        | "EVIDENCE_REQUIRED_AUDIT_UNAVAILABLE"
+        | "APPROVAL_QUORUM_CONFIG_INVALID";
+      httpStatus: 503 | 422;
       intentId?: string;
     }
   | {
@@ -514,6 +517,10 @@ class ProviderActionService {
             policyRevisionHash: (policy as PolicyResult).doc.policyRevisionHash,
             evaluatorVersion: EVALUATOR_VERSION,
             requesterSeparation: extractRequesterSeparation(txOperation.requestProfile),
+            // #205: read + fail-closed-validate the quorum config from the same
+            // request-profile source. A malformed quorum throws ApprovalArmError
+            // (creation fails closed); absent quorum => single-approver path.
+            quorum: extractQuorumConfig(txOperation.requestProfile),
             requestedAt: input.requestedAt,
             expiresAt: input.expiresAt,
             // Bind the adapter profile from the validated build, never a
@@ -602,6 +609,18 @@ class ProviderActionService {
       // creation CLOSED (spec §5.2) — surfaced as an evidence failure so no
       // partial approval arm is ever visible.
       if (e instanceof ApprovalArmError) {
+        // A malformed #205 quorum config fails creation CLOSED at store time
+        // (spec §7) and surfaces its specific code so the misconfig is
+        // observable; a missing execution dependency (route/credential) uses
+        // the generic evidence-failure code (spec §5.2). No partial approval
+        // arm is ever visible either way.
+        if (e.code === "APPROVAL_QUORUM_CONFIG_INVALID") {
+          return {
+            kind: "evidence_failure",
+            code: "APPROVAL_QUORUM_CONFIG_INVALID",
+            httpStatus: 422,
+          };
+        }
         return {
           kind: "evidence_failure",
           code: "EVIDENCE_DECISION_PERSIST_FAILED",
@@ -1378,6 +1397,64 @@ export function extractRequesterSeparation(requestProfile: Record<string, unknow
   const reqs = (requestProfile as { approvalRequirements?: unknown }).approvalRequirements;
   if (typeof reqs !== "object" || reqs === null) return false;
   return (reqs as { requesterSeparation?: unknown }).requesterSeparation === true;
+}
+
+/**
+ * Extract + FAIL-CLOSED-validate the operation's #205 quorum config from
+ * `request_profile.approvalRequirements.quorum`, the same forward-compatible
+ * source as {@link extractRequesterSeparation}. Returns:
+ *   - `undefined` when no quorum is configured => single-approver legacy path.
+ *   - `{ threshold, eligibleApproverUserIds }` when a well-formed quorum is set.
+ * THROWS {@link ApprovalArmError}("APPROVAL_QUORUM_CONFIG_INVALID") when a quorum
+ * key is present but malformed (non-integer / <1 / > eligible-set size / empty
+ * or duplicate or non-string eligible set / unknown members). Creation then
+ * fails closed — a malformed quorum is NEVER stored (spec §7).
+ *
+ * NOTE: membership-of-eligible-users-in-the-workspace_approver-role is NOT
+ * verified here (the request profile does not carry role state); it is enforced
+ * per-approval at decide time via checkApprover (spec §5). Store-time validation
+ * is purely structural: shape + threshold-reachability.
+ */
+export function extractQuorumConfig(
+  requestProfile: Record<string, unknown>,
+): { threshold: number; eligibleApproverUserIds: string[] } | undefined {
+  const reqs = (requestProfile as { approvalRequirements?: unknown }).approvalRequirements;
+  if (typeof reqs !== "object" || reqs === null) return undefined;
+  const q = (reqs as { quorum?: unknown }).quorum;
+  if (q === undefined || q === null) return undefined;
+  if (typeof q !== "object" || Array.isArray(q)) {
+    throw new ApprovalArmError("APPROVAL_QUORUM_CONFIG_INVALID");
+  }
+  const rec = q as Record<string, unknown>;
+  // Reject unknown keys (fail closed on typos).
+  for (const k of Object.keys(rec)) {
+    if (k !== "threshold" && k !== "eligibleApproverUserIds") {
+      throw new ApprovalArmError("APPROVAL_QUORUM_CONFIG_INVALID");
+    }
+  }
+  const threshold = rec.threshold;
+  const eligible = rec.eligibleApproverUserIds;
+  if (
+    typeof threshold !== "number" ||
+    !Number.isInteger(threshold) ||
+    threshold < 1 ||
+    !Array.isArray(eligible) ||
+    eligible.length === 0 ||
+    !eligible.every((u) => typeof u === "string" && u.length > 0)
+  ) {
+    throw new ApprovalArmError("APPROVAL_QUORUM_CONFIG_INVALID");
+  }
+  const ids = eligible as string[];
+  // No duplicate eligible ids (a duplicate would inflate the apparent set size
+  // and could let a threshold exceed the true distinct-approver count).
+  if (new Set(ids).size !== ids.length) {
+    throw new ApprovalArmError("APPROVAL_QUORUM_CONFIG_INVALID");
+  }
+  // Threshold must be reachable within the distinct eligible set.
+  if (threshold > ids.length) {
+    throw new ApprovalArmError("APPROVAL_QUORUM_CONFIG_INVALID");
+  }
+  return { threshold, eligibleApproverUserIds: ids };
 }
 
 function capabilitySelectorMatches(config: Record<string, unknown>, operationKey: string): boolean {

--- a/packages/api/src/services/provider-approval.ts
+++ b/packages/api/src/services/provider-approval.ts
@@ -205,6 +205,72 @@ export async function buildApprovalArm(args: {
     ) {
       throw new ApprovalArmError("APPROVAL_QUORUM_CONFIG_INVALID");
     }
+
+    // FAIL CLOSED AT STORE TIME on an UNREACHABLE quorum (codex P2): a
+    // structurally-valid eligible set can still be unsatisfiable if some listed
+    // ids are not real workspace_approvers, are not tenant members, or is the
+    // requester (agent owner) — all of whom are rejected at decide time. Compute
+    // the count of ids that are ACTUALLY able to vote right now (distinct tenant
+    // member + active in-window workspace_approver role for this workspace, and
+    // NOT the requesting agent's owner) and require it to be >= threshold. This
+    // makes it impossible to persist a quorum that can never complete.
+    const [wsRow] = await tx
+      .select({ environment: workspaces.environment })
+      .from(workspaces)
+      .where(and(eq(workspaces.tenantId, args.tenantId), eq(workspaces.id, args.workspaceId)))
+      .limit(1);
+    if (!wsRow) {
+      throw new ApprovalArmError("APPROVAL_QUORUM_CONFIG_INVALID");
+    }
+    const [ownerRow] = await tx
+      .select({ ownerUserId: agents.ownerUserId })
+      .from(agents)
+      .where(and(eq(agents.tenantId, args.tenantId), eq(agents.id, args.actorAgentId)))
+      .limit(1);
+    const requesterOwner = ownerRow?.ownerUserId ?? null;
+    const now = new Date();
+    let eligibleVoters = 0;
+    for (const uid of ids) {
+      // Requester (agent owner) can never count toward the quorum.
+      if (requesterOwner && uid === requesterOwner) continue;
+      // Must be a tenant member.
+      const [membership] = await tx
+        .select({ id: userTenants.id })
+        .from(userTenants)
+        .where(and(eq(userTenants.userId, uid), eq(userTenants.tenantId, args.tenantId)))
+        .limit(1);
+      if (!membership) continue;
+      // Must hold an active, in-window workspace_approver role for THIS workspace
+      // and its current environment.
+      const roleRows = await tx
+        .select({
+          roleKey: providerRoleBindings.roleKey,
+          notBefore: providerRoleBindings.notBefore,
+          expiresAt: providerRoleBindings.expiresAt,
+          environment: providerRoleBindings.environment,
+        })
+        .from(providerRoleBindings)
+        .where(
+          and(
+            eq(providerRoleBindings.tenantId, args.tenantId),
+            eq(providerRoleBindings.workspaceId, args.workspaceId),
+            eq(providerRoleBindings.principalType, "human"),
+            eq(providerRoleBindings.principalId, uid),
+            eq(providerRoleBindings.status, "active"),
+          ),
+        );
+      const canVote = roleRows.some(
+        (r) =>
+          r.roleKey === "workspace_approver" &&
+          (!r.notBefore || r.notBefore <= now) &&
+          (!r.expiresAt || r.expiresAt > now) &&
+          (!r.environment || r.environment === wsRow.environment),
+      );
+      if (canVote) eligibleVoters += 1;
+    }
+    if (eligibleVoters < quorum.threshold) {
+      throw new ApprovalArmError("APPROVAL_QUORUM_CONFIG_INVALID");
+    }
   }
 
   const commitment: ProviderApprovalCommitmentV1 = {
@@ -1443,6 +1509,8 @@ class ProviderApprovalService {
     } catch (e) {
       if (e instanceof AuditUnavailableError)
         return fail("EVIDENCE_REQUIRED_AUDIT_UNAVAILABLE", 503);
+      // #205: a quorum loser that rolled back its non-counted evidence row.
+      if (e instanceof QuorumStateConflictError) return fail("APPROVAL_STATE_CONFLICT", 409);
       return fail("APPROVAL_PERSISTENCE_FAILED", 503);
     }
   }
@@ -1606,7 +1674,9 @@ class ProviderApprovalService {
         })
         .where(and(eq(approvalQueue.id, queue.id), eq(approvalQueue.status, "pending")))
         .returning({ id: approvalQueue.id });
-      if (upd.length === 0) return fail("APPROVAL_STATE_CONFLICT", 409);
+      // Post-insert conflict: roll back the evidence row we just wrote (throw,
+      // don't return) so a non-counted deny row is never committed.
+      if (upd.length === 0) throw new QuorumStateConflictError();
 
       await tx
         .update(providerActionBindings)
@@ -1689,9 +1759,11 @@ class ProviderApprovalService {
       .returning({ count: approvalQueue.quorumApprovalsCount });
     if (bumped.length === 0) {
       // The queue is no longer pending or already at threshold: a concurrent
-      // winner completed (or terminated) the quorum. The distinct decision row
-      // we inserted is retained as evidence but does not advance a completed set.
-      return fail("APPROVAL_STATE_CONFLICT", 409);
+      // winner completed (or terminated) the quorum. Roll back the evidence row
+      // we just inserted (throw, don't return) so a vote that did not advance the
+      // tally is never committed — the approvals table stays consistent with the
+      // queue tally + terminal state.
+      throw new QuorumStateConflictError();
     }
     const countAfter = bumped[0].count as number;
 
@@ -1728,9 +1800,9 @@ class ProviderApprovalService {
         )
         .returning({ id: approvalQueue.id });
       // Guarded single-winner: if a concurrent Nth approval already flipped the
-      // queue to approved, this loses. Our tally increment still counted, but we
-      // do NOT advance the binding twice.
-      if (qUpd.length === 0) return fail("APPROVAL_STATE_CONFLICT", 409);
+      // queue to approved, this loses. Roll back the whole tx (throw) so neither
+      // the tally bump nor the evidence row is committed by the loser.
+      if (qUpd.length === 0) throw new QuorumStateConflictError();
 
       const bUpd = await tx
         .update(providerActionBindings)
@@ -1749,7 +1821,7 @@ class ProviderApprovalService {
           ),
         )
         .returning({ intentId: providerActionBindings.intentId });
-      if (bUpd.length === 0) return fail("APPROVAL_STATE_CONFLICT", 409);
+      if (bUpd.length === 0) throw new QuorumStateConflictError();
 
       await tx
         .update(intents)
@@ -2160,6 +2232,21 @@ class ProviderApprovalService {
 // ── module helpers ──
 
 class AuditUnavailableError extends Error {}
+
+/**
+ * #205: thrown from the quorum decide path AFTER the provider_action_approvals
+ * evidence row has been inserted, when the guarded queue transition (tally CAS /
+ * pending->approved / deny) loses to a concurrent winner. Throwing (rather than
+ * returning fail()) rolls back the whole transaction so the non-counted evidence
+ * row is NEVER committed — the approvals table stays consistent with the queue
+ * tally and terminal state. The outer catch maps it to APPROVAL_STATE_CONFLICT.
+ */
+class QuorumStateConflictError extends Error {
+  constructor() {
+    super("APPROVAL_STATE_CONFLICT");
+    this.name = "QuorumStateConflictError";
+  }
+}
 
 type ApprovalAuditAppend = (event: { tenantId: string } & Record<string, unknown>) => Promise<void>;
 

--- a/packages/api/src/services/provider-approval.ts
+++ b/packages/api/src/services/provider-approval.ts
@@ -26,6 +26,7 @@ import {
   getDb,
   intents,
   providerAccounts,
+  providerActionApprovals,
   providerActionBindings,
   providerGrants,
   providerOperations,
@@ -155,6 +156,14 @@ export async function buildApprovalArm(args: {
    * validated action build, never hardcoded per provider.
    */
   canonicalProfile: ProviderApprovalCommitmentV1["operation"]["canonicalProfile"];
+  /**
+   * #205 flat M-of-N quorum config (already fail-closed-validated by the caller's
+   * extractQuorumConfig). `undefined` => single-approver legacy path: the queue
+   * row's quorum columns stay NULL/empty/0 and the commitment omits the quorum
+   * member (byte-identical commitment to pre-#205). When present it is
+   * re-validated here as defense in depth before it is committed/persisted.
+   */
+  quorum?: { threshold: number; eligibleApproverUserIds: string[] };
 }): Promise<{ queueId: string; commitmentHash: string; commitment: ProviderApprovalCommitmentV1 }> {
   const tx = args.tx;
 
@@ -176,6 +185,26 @@ export async function buildApprovalArm(args: {
   const secretVersion = args.account.credentialVersion;
   if (!secretId || secretVersion == null) {
     throw new ApprovalArmError("APPROVAL_CREDENTIAL_UNAVAILABLE");
+  }
+
+  // #205 defense-in-depth: re-validate the quorum config shape at commit time so
+  // a malformed quorum can never be persisted even if a future caller forgets
+  // extractQuorumConfig (spec §7 fail-closed at store time). Distinctness of the
+  // eligible set + threshold reachability are re-checked here.
+  const quorum = args.quorum;
+  if (quorum) {
+    const ids = quorum.eligibleApproverUserIds;
+    if (
+      !Number.isInteger(quorum.threshold) ||
+      quorum.threshold < 1 ||
+      !Array.isArray(ids) ||
+      ids.length === 0 ||
+      !ids.every((u) => typeof u === "string" && u.length > 0) ||
+      new Set(ids).size !== ids.length ||
+      quorum.threshold > ids.length
+    ) {
+      throw new ApprovalArmError("APPROVAL_QUORUM_CONFIG_INVALID");
+    }
   }
 
   const commitment: ProviderApprovalCommitmentV1 = {
@@ -220,6 +249,16 @@ export async function buildApprovalArm(args: {
       requesterSeparation: args.requesterSeparation,
       maxMfaAgeSeconds: 300,
       requiredMfaAssurance: "current-session-mfa",
+      // Additive: emitted ONLY when a quorum is configured, so the single-approver
+      // commitment is byte-identical to pre-#205.
+      ...(quorum
+        ? {
+            quorum: {
+              threshold: quorum.threshold,
+              eligibleApproverUserIds: quorum.eligibleApproverUserIds,
+            },
+          }
+        : {}),
     },
     requestedAt: args.requestedAt,
     expiresAt: args.expiresAt,
@@ -245,6 +284,13 @@ export async function buildApprovalArm(args: {
     approvalCommitmentHash: commitmentHash,
     expectedBindingRevision: 1,
     expiresAt: new Date(args.expiresAt),
+    // #205 quorum config columns. NULL/empty/0 for the single-approver path (the
+    // CHECK in 0083 enforces this shape). When a quorum is set, the eligible set
+    // + threshold are persisted here so decide() can re-validate against the
+    // frozen set even if the commitment doc were ever tampered.
+    quorumThreshold: quorum ? quorum.threshold : null,
+    quorumEligibleUserIds: quorum ? quorum.eligibleApproverUserIds : [],
+    quorumApprovalsCount: 0,
   });
 
   return { queueId, commitmentHash, commitment };
@@ -796,6 +842,40 @@ class ProviderApprovalService {
       }
     }
 
+    // #205 quorum: the requester (agent owner) can NEVER count toward the
+    // quorum, generalizing requester-separation to the M-of-N case regardless of
+    // whether requesterSeparation was independently set. And the approver MUST be
+    // a member of the frozen eligible set. Both checks fail closed if the
+    // eligible set is malformed/empty at decide time (spec §7 eval-time).
+    if (queue.quorumThreshold != null) {
+      const [agent] = await tx
+        .select({ ownerUserId: agents.ownerUserId })
+        .from(agents)
+        .where(and(eq(agents.tenantId, tenantId), eq(agents.id, binding.actorAgentId)))
+        .limit(1);
+      if (agent?.ownerUserId && agent.ownerUserId === userId) {
+        return { ok: false, code: "APPROVAL_REQUESTER_SEPARATION_REQUIRED", httpStatus: 403 };
+      }
+      const eligible = queue.quorumEligibleUserIds ?? [];
+      // Fail closed on a malformed persisted config (defense in depth; the
+      // create-time CHECK + validation should make this unreachable).
+      if (
+        !Number.isInteger(queue.quorumThreshold) ||
+        queue.quorumThreshold < 1 ||
+        eligible.length === 0 ||
+        queue.quorumThreshold > eligible.length ||
+        new Set(eligible).size !== eligible.length
+      ) {
+        return { ok: false, code: "APPROVAL_QUORUM_CONFIG_INVALID", httpStatus: 422 };
+      }
+      if (!eligible.includes(userId)) {
+        // Not in the eligible set: same 403 posture as a missing role (an
+        // eligible-role holder who is nonetheless not on THIS action's approver
+        // list cannot vote).
+        return { ok: false, code: "APPROVAL_NOT_ELIGIBLE_APPROVER", httpStatus: 403 };
+      }
+    }
+
     // Recent MFA (only enforced at decision time, not resume — §9). At resume we
     // only require the approver still be eligible (checked above).
     if (!atResume) {
@@ -1167,6 +1247,27 @@ class ProviderApprovalService {
         const mfaVerifiedAt = new Date(input.sessionMfaVerifiedAt as number);
         const mfaAgeMs = Date.now() - (input.sessionMfaVerifiedAt as number);
 
+        // ── #205 QUORUM PATH ──────────────────────────────────────────────
+        // A configured quorum threshold flips both approve and deny into the
+        // multi-approver lifecycle. Absent quorum (threshold NULL) falls through
+        // to the single-approver code below, byte-for-byte unchanged.
+        if (queue.quorumThreshold != null) {
+          return await this.decideQuorum({
+            tx,
+            append,
+            binding,
+            queue,
+            input,
+            before,
+            after,
+            nowTs,
+            mfaVerifiedAt,
+            mfaAgeMs,
+            idemHash,
+            decisionReqHash,
+          });
+        }
+
         if (input.decision === "approve") {
           const upd = await tx
             .update(approvalQueue)
@@ -1338,6 +1439,359 @@ class ProviderApprovalService {
         return fail("EVIDENCE_REQUIRED_AUDIT_UNAVAILABLE", 503);
       return fail("APPROVAL_PERSISTENCE_FAILED", 503);
     }
+  }
+
+  // ── #205 QUORUM DECISION (approve collects N distinct; single deny terminates)
+  //
+  // Called from decide() ONLY when queue.quorumThreshold != null, after all the
+  // shared gates (idempotency, expiry, terminal-state, optimistic-lock echoes,
+  // integrity, dependency re-eval, approver eligibility + MFA + eligible-set
+  // membership + requester-separation). Runs inside the SAME audited tx with the
+  // rows already FOR UPDATE-locked by loadCase.
+  //
+  // Invariants enforced here:
+  //  - DENY WINS IMMEDIATELY: the first deny terminates the whole approval
+  //    (pending -> rejected), regardless of collected approvals.
+  //  - DISTINCTNESS: a provider_action_approvals UNIQUE(queue, approver) makes a
+  //    second decision by the same approver a loud 409. Requester can never vote
+  //    (checked upstream). N distinct users required.
+  //  - EXACT-BIND per approval: every row stores request_hash/action_digest/
+  //    commitment hash + the binding_revision it was cast at, so a later
+  //    staleness (which bumps binding_revision and flips the queue to a terminal
+  //    stale) invalidates the entire collected set.
+  //  - SINGLE-WINNER Nth transition: the pending -> approved flip is a guarded
+  //    CAS (WHERE status='pending' AND quorum_approvals_count>=threshold) so two
+  //    concurrent Nth approvals produce exactly one execute-reachable transition.
+  private async decideQuorum(ctx: {
+    tx: DbExecutor;
+    append: ApprovalAuditAppend;
+    binding: BindingRow;
+    queue: QueueRow;
+    input: DecideInput;
+    before: number;
+    after: number;
+    nowTs: Date;
+    mfaVerifiedAt: Date;
+    mfaAgeMs: number;
+    idemHash: string;
+    decisionReqHash: string;
+  }): Promise<ApprovalResult> {
+    const { tx, append, binding, queue, input, before, after, nowTs } = ctx;
+    const threshold = queue.quorumThreshold as number;
+    const userId = input.authenticatedUserId;
+
+    // Per-approver idempotency + distinctness replay: if this exact approver
+    // already recorded a decision on THIS queue, an exact retry (same idem key +
+    // same decision-request-hash) replays; a different decision or different
+    // request-hash is a loud conflict (they cannot change their vote).
+    const [existing] = await tx
+      .select()
+      .from(providerActionApprovals)
+      .where(
+        and(
+          eq(providerActionApprovals.approvalQueueId, queue.id),
+          eq(providerActionApprovals.approverUserId, userId),
+        ),
+      )
+      .limit(1);
+    if (existing) {
+      if (
+        existing.decisionIdempotencyKeyHash === ctx.idemHash &&
+        existing.decisionRequestHash === ctx.decisionReqHash
+      ) {
+        // Exact retry of the same vote by the same approver. Report the CURRENT
+        // queue state (the vote already counted).
+        return {
+          ok: true,
+          httpStatus: 200,
+          id: binding.intentId,
+          status: binding.status,
+          version: binding.bindingRevision,
+          requestHash: binding.requestHash,
+          actionDigest: binding.actionDigest,
+          replayed: true,
+        };
+      }
+      // A second, DIFFERENT decision by the same approver is rejected loudly.
+      return fail("APPROVAL_DUPLICATE_APPROVER", 409);
+    }
+
+    // Cross-action decision-idempotency-key reuse guard (mirrors the queue-row
+    // guard): the same approver reusing this decision key on a DIFFERENT quorum
+    // action would violate provider_action_approvals_idem_uniq and surface as an
+    // opaque 503. Detect it and return the precise 409 instead.
+    const [idemConflict] = await tx
+      .select({ id: providerActionApprovals.id, queueId: providerActionApprovals.approvalQueueId })
+      .from(providerActionApprovals)
+      .where(
+        and(
+          eq(providerActionApprovals.tenantId, input.tenantId),
+          eq(providerActionApprovals.approverUserId, userId),
+          eq(providerActionApprovals.decisionIdempotencyKeyHash, ctx.idemHash),
+        ),
+      )
+      .limit(1);
+    if (idemConflict && idemConflict.queueId !== queue.id) {
+      return fail("APPROVAL_IDEMPOTENCY_CONFLICT", 409);
+    }
+
+    // Record this distinct decision row bound to the CURRENT binding revision.
+    // A concurrent duplicate loses the UNIQUE(queue, approver) race -> caught as
+    // APPROVAL_DUPLICATE_APPROVER by the outer catch (it maps the unique
+    // violation). We insert first so the tally can never exceed the distinct
+    // decision count.
+    try {
+      await tx.insert(providerActionApprovals).values({
+        approvalQueueId: queue.id,
+        intentId: binding.intentId,
+        tenantId: input.tenantId,
+        workspaceId: binding.workspaceId,
+        approverUserId: userId,
+        decision: input.decision,
+        bindingRevisionAtDecision: before,
+        requestHash: binding.requestHash,
+        actionDigest: binding.actionDigest,
+        approvalCommitmentHash: queue.approvalCommitmentHash ?? "",
+        decisionIdempotencyKeyHash: ctx.idemHash,
+        decisionRequestHash: ctx.decisionReqHash,
+        mfaVerifiedAt: ctx.mfaVerifiedAt,
+        mfaAgeMsAtDecision: ctx.mfaAgeMs,
+        reasonCode: input.reasonCode ?? null,
+        reason: input.reason ?? null,
+      });
+    } catch (e) {
+      // Distinctness / cross-action idem races land here.
+      const code = (e as { code?: string } | null)?.code;
+      if (code === "23505") {
+        // Determine which unique index tripped by re-reading.
+        const [dup] = await tx
+          .select({ id: providerActionApprovals.id })
+          .from(providerActionApprovals)
+          .where(
+            and(
+              eq(providerActionApprovals.approvalQueueId, queue.id),
+              eq(providerActionApprovals.approverUserId, userId),
+            ),
+          )
+          .limit(1);
+        if (dup) return fail("APPROVAL_DUPLICATE_APPROVER", 409);
+        return fail("APPROVAL_IDEMPOTENCY_CONFLICT", 409);
+      }
+      throw e;
+    }
+
+    if (input.decision === "deny") {
+      // DENY WINS IMMEDIATELY: terminate the whole approval regardless of tally.
+      const upd = await tx
+        .update(approvalQueue)
+        .set({
+          status: "rejected",
+          decision: "deny",
+          resolvedAt: nowTs,
+          resolvedByType: "user",
+          resolvedById: userId,
+          resolvedBy: userId,
+          mfaVerifiedAt: ctx.mfaVerifiedAt,
+          mfaAgeMsAtDecision: ctx.mfaAgeMs,
+          reasonCode: input.reasonCode ?? null,
+          reason: input.reason ?? null,
+          decisionIdempotencyKeyHash: ctx.idemHash,
+          decisionRequestHash: ctx.decisionReqHash,
+        })
+        .where(and(eq(approvalQueue.id, queue.id), eq(approvalQueue.status, "pending")))
+        .returning({ id: approvalQueue.id });
+      if (upd.length === 0) return fail("APPROVAL_STATE_CONFLICT", 409);
+
+      await tx
+        .update(providerActionBindings)
+        .set({
+          status: "approval_denied",
+          bindingRevision: after,
+          approvalActorUserId: userId,
+          deniedAt: nowTs,
+          updatedAt: nowTs,
+        })
+        .where(
+          and(
+            eq(providerActionBindings.intentId, binding.intentId),
+            eq(providerActionBindings.status, "pending_approval"),
+            eq(providerActionBindings.bindingRevision, before),
+          ),
+        );
+      await tx
+        .update(intents)
+        .set({
+          status: "rejected",
+          rejectedBy: `user:${userId}`,
+          rejectedAt: nowTs,
+          rejectionReason: input.reasonCode ?? null,
+          updatedAt: nowTs,
+        })
+        .where(eq(intents.id, binding.intentId));
+
+      const payload = buildAuditPayload(binding, queue, {
+        approvalActorUserId: userId,
+        resumeActor: null,
+        bindingRevisionBefore: before,
+        bindingRevisionAfter: after,
+        fromStatus: "pending_approval",
+        toStatus: "approval_denied",
+        reasonCode: input.reasonCode ?? "approver_manual_deny",
+        resumeAttemptId: null,
+      });
+      payload.quorumThreshold = threshold;
+      payload.quorumApprovalsCount = queue.quorumApprovalsCount;
+      await this.hook("beforeAudit");
+      await append({
+        tenantId: binding.tenantId,
+        actorType: "user",
+        actorId: userId,
+        action: "provider.approval.decided",
+        resourceType: "provider_action",
+        resourceId: binding.intentId,
+        metadata: payload as unknown as Record<string, unknown>,
+        ipAddress: input.ipAddress ?? null,
+        userAgent: input.userAgent ?? null,
+        requestId: input.requestId ?? null,
+      });
+      await this.hook("afterAudit");
+
+      return {
+        ok: true,
+        httpStatus: 200,
+        id: binding.intentId,
+        status: "approval_denied",
+        version: after,
+        requestHash: binding.requestHash,
+        actionDigest: binding.actionDigest,
+      };
+    }
+
+    // APPROVE: increment the guarded tally. The CAS increments only while the
+    // queue is pending AND the tally is below threshold, so it can never exceed
+    // the threshold. countAfter is the authoritative post-increment tally.
+    const bumped = await tx
+      .update(approvalQueue)
+      .set({ quorumApprovalsCount: sql`${approvalQueue.quorumApprovalsCount} + 1` })
+      .where(
+        and(
+          eq(approvalQueue.id, queue.id),
+          eq(approvalQueue.status, "pending"),
+          sql`${approvalQueue.quorumApprovalsCount} < ${threshold}`,
+        ),
+      )
+      .returning({ count: approvalQueue.quorumApprovalsCount });
+    if (bumped.length === 0) {
+      // The queue is no longer pending or already at threshold: a concurrent
+      // winner completed (or terminated) the quorum. The distinct decision row
+      // we inserted is retained as evidence but does not advance a completed set.
+      return fail("APPROVAL_STATE_CONFLICT", 409);
+    }
+    const countAfter = bumped[0].count as number;
+
+    const quorumSatisfied = countAfter >= threshold;
+    const toStatus = quorumSatisfied ? "approved" : "pending_approval";
+    // Only the SATISFYING Nth approval advances the binding + intent + queue
+    // decision. Partial approvals leave the binding pending_approval (execute
+    // unreachable) and only bump the tally.
+    let bindingRevisionAfter = before;
+    if (quorumSatisfied) {
+      bindingRevisionAfter = after;
+      const qUpd = await tx
+        .update(approvalQueue)
+        .set({
+          status: "approved",
+          decision: "approve",
+          resolvedAt: nowTs,
+          resolvedByType: "user",
+          resolvedById: userId,
+          resolvedBy: userId,
+          mfaVerifiedAt: ctx.mfaVerifiedAt,
+          mfaAgeMsAtDecision: ctx.mfaAgeMs,
+          reasonCode: input.reasonCode ?? null,
+          reason: input.reason ?? null,
+          decisionIdempotencyKeyHash: ctx.idemHash,
+          decisionRequestHash: ctx.decisionReqHash,
+        })
+        .where(
+          and(
+            eq(approvalQueue.id, queue.id),
+            eq(approvalQueue.status, "pending"),
+            sql`${approvalQueue.quorumApprovalsCount} >= ${threshold}`,
+          ),
+        )
+        .returning({ id: approvalQueue.id });
+      // Guarded single-winner: if a concurrent Nth approval already flipped the
+      // queue to approved, this loses. Our tally increment still counted, but we
+      // do NOT advance the binding twice.
+      if (qUpd.length === 0) return fail("APPROVAL_STATE_CONFLICT", 409);
+
+      const bUpd = await tx
+        .update(providerActionBindings)
+        .set({
+          status: "approved",
+          bindingRevision: after,
+          approvalActorUserId: userId,
+          approvedAt: nowTs,
+          updatedAt: nowTs,
+        })
+        .where(
+          and(
+            eq(providerActionBindings.intentId, binding.intentId),
+            eq(providerActionBindings.status, "pending_approval"),
+            eq(providerActionBindings.bindingRevision, before),
+          ),
+        )
+        .returning({ intentId: providerActionBindings.intentId });
+      if (bUpd.length === 0) return fail("APPROVAL_STATE_CONFLICT", 409);
+
+      await tx
+        .update(intents)
+        .set({
+          status: "authorized",
+          authorizedBy: `user:${userId}`,
+          authorizedAt: nowTs,
+          updatedAt: nowTs,
+        })
+        .where(eq(intents.id, binding.intentId));
+    }
+
+    const payload = buildAuditPayload(binding, queue, {
+      approvalActorUserId: userId,
+      resumeActor: null,
+      bindingRevisionBefore: before,
+      bindingRevisionAfter,
+      fromStatus: "pending_approval",
+      toStatus: quorumSatisfied ? "approved" : "pending_approval",
+      reasonCode: input.reasonCode ?? "approver_manual_approve",
+      resumeAttemptId: null,
+    });
+    payload.quorumThreshold = threshold;
+    payload.quorumApprovalsCount = countAfter;
+    await this.hook("beforeAudit");
+    await append({
+      tenantId: binding.tenantId,
+      actorType: "user",
+      actorId: userId,
+      action: "provider.approval.decided",
+      resourceType: "provider_action",
+      resourceId: binding.intentId,
+      metadata: payload as unknown as Record<string, unknown>,
+      ipAddress: input.ipAddress ?? null,
+      userAgent: input.userAgent ?? null,
+      requestId: input.requestId ?? null,
+    });
+    await this.hook("afterAudit");
+
+    return {
+      ok: true,
+      httpStatus: 200,
+      id: binding.intentId,
+      status: toStatus,
+      version: bindingRevisionAfter,
+      requestHash: binding.requestHash,
+      actionDigest: binding.actionDigest,
+    };
   }
 
   private decisionReplay(binding: BindingRow, queue: QueueRow, replayed = false): ApprovalResult {

--- a/packages/api/src/services/provider-approval.ts
+++ b/packages/api/src/services/provider-approval.ts
@@ -912,7 +912,13 @@ class ProviderApprovalService {
     const { binding, queue } = loaded;
     // DB time. drizzle's tx.execute returns either an array (postgres-js) or a
     // { rows } object (pglite/neon), so normalize.
-    const dueRes = await tx.execute(sql`SELECT (${queue.expiresAt} <= now()) AS due`);
+    // Explicit ::timestamptz cast + ISO-string param so the comparison type is
+    // unambiguous on postgres-js (which otherwise sends a bare Date param with an
+    // unknown type OID, and PG cannot infer `$1 <= now()`). PGLite already
+    // tolerated the untyped form; the cast is behavior-neutral there.
+    const dueRes = await tx.execute(
+      sql`SELECT (${queue.expiresAt?.toISOString() ?? null}::timestamptz <= now()) AS due`,
+    );
     const dueRows = (
       Array.isArray(dueRes) ? dueRes : ((dueRes as { rows?: unknown[] }).rows ?? [])
     ) as Array<{ due: boolean }>;

--- a/packages/api/src/services/provider-approval.ts
+++ b/packages/api/src/services/provider-approval.ts
@@ -209,7 +209,7 @@ export async function buildApprovalArm(args: {
     // FAIL CLOSED AT STORE TIME on an UNREACHABLE quorum (codex P2): a
     // structurally-valid eligible set can still be unsatisfiable if some listed
     // ids are not real workspace_approvers, are not tenant members, or is the
-    // requester (agent owner) — all of whom are rejected at decide time. Compute
+    // requester (agent owner), all of whom are rejected at decide time. Compute
     // the count of ids that are ACTUALLY able to vote right now (distinct tenant
     // member + active in-window workspace_approver role for this workspace, and
     // NOT the requesting agent's owner) and require it to be >= threshold. This
@@ -1761,7 +1761,7 @@ class ProviderApprovalService {
       // The queue is no longer pending or already at threshold: a concurrent
       // winner completed (or terminated) the quorum. Roll back the evidence row
       // we just inserted (throw, don't return) so a vote that did not advance the
-      // tally is never committed — the approvals table stays consistent with the
+      // tally is never committed, so the approvals table stays consistent with the
       // queue tally + terminal state.
       throw new QuorumStateConflictError();
     }
@@ -2238,7 +2238,7 @@ class AuditUnavailableError extends Error {}
  * evidence row has been inserted, when the guarded queue transition (tally CAS /
  * pending->approved / deny) loses to a concurrent winner. Throwing (rather than
  * returning fail()) rolls back the whole transaction so the non-counted evidence
- * row is NEVER committed — the approvals table stays consistent with the queue
+ * row is NEVER committed, so the approvals table stays consistent with the queue
  * tally and terminal state. The outer catch maps it to APPROVAL_STATE_CONFLICT.
  */
 class QuorumStateConflictError extends Error {

--- a/packages/db/drizzle/0083_provider_approval_quorum.sql
+++ b/packages/db/drizzle/0083_provider_approval_quorum.sql
@@ -1,0 +1,107 @@
+-- #205: M-of-N quorum approval for provider actions (competitive parity vs
+-- Turnkey REQUIRES_CONSENSUS / Fireblocks / Privy).
+--
+-- Generalizes the single-approver provider-action approval (0081) to flat N-of-M
+-- quorum WITHOUT changing the absent-quorum path. Nested quorums are OUT OF SCOPE
+-- (flat N-of-M only). This migration:
+--
+--   1. Adds nullable quorum config + a guarded running tally to `approval_queue`.
+--      A NULL `quorum_threshold` is the single-approver legacy path (byte-for-byte
+--      unchanged: no new NOT NULL column without a default, no trigger change on
+--      the legacy arm).
+--   2. Creates `provider_action_approvals`: one row per DISTINCT approver decision
+--      in a quorum, each binding the exact request_hash / action_digest /
+--      approval_commitment_hash and the binding_revision it was cast against.
+--   3. Adds a fail-closed CHECK on the quorum config shape so a malformed
+--      threshold cannot be stored (defense in depth; the service also validates).
+--
+-- `intents` remains the sole lifecycle root. There is no second execution ledger:
+-- the quorum tally lives on the existing approval_queue row and the collected
+-- decisions in provider_action_approvals; the tamper-evident audit chain carries
+-- quorum progress through the existing provider.approval.decided events.
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 1. approval_queue quorum config + tally
+-- ─────────────────────────────────────────────────────────────────────────────
+ALTER TABLE "approval_queue"
+  ADD COLUMN "quorum_threshold" integer;
+--> statement-breakpoint
+ALTER TABLE "approval_queue"
+  ADD COLUMN "quorum_eligible_user_ids" uuid[] NOT NULL DEFAULT '{}';
+--> statement-breakpoint
+ALTER TABLE "approval_queue"
+  ADD COLUMN "quorum_approvals_count" integer NOT NULL DEFAULT 0;
+--> statement-breakpoint
+
+-- Fail-closed config shape. A NULL threshold (single-approver path) must keep an
+-- empty eligible set and a zero tally. A non-NULL threshold must be a positive
+-- integer no larger than the eligible set size, and the tally can never exceed
+-- the threshold or go negative. Storing a malformed quorum is impossible.
+ALTER TABLE "approval_queue"
+  ADD CONSTRAINT "approval_queue_quorum_shape_chk" CHECK (
+    (
+      "quorum_threshold" IS NULL
+      AND coalesce(array_length("quorum_eligible_user_ids", 1), 0) = 0
+      AND "quorum_approvals_count" = 0
+    )
+    OR (
+      "quorum_threshold" IS NOT NULL
+      AND "quorum_threshold" >= 1
+      AND "quorum_threshold" <= coalesce(array_length("quorum_eligible_user_ids", 1), 0)
+      AND "quorum_approvals_count" >= 0
+      AND "quorum_approvals_count" <= "quorum_threshold"
+    )
+  );
+--> statement-breakpoint
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 2. provider_action_approvals: one row per DISTINCT approver decision
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE "provider_action_approvals" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "approval_queue_id" varchar(64) NOT NULL,
+  "intent_id" varchar(64) NOT NULL,
+  "tenant_id" varchar(64) NOT NULL,
+  "workspace_id" uuid NOT NULL,
+  "approver_user_id" uuid NOT NULL,
+  "decision" varchar(16) NOT NULL,
+  "binding_revision_at_decision" integer NOT NULL,
+  "request_hash" varchar(71) NOT NULL,
+  "action_digest" varchar(71) NOT NULL,
+  "approval_commitment_hash" varchar(71) NOT NULL,
+  "decision_idempotency_key_hash" varchar(71) NOT NULL,
+  "decision_request_hash" varchar(71) NOT NULL,
+  "mfa_verified_at" timestamp with time zone,
+  "mfa_age_ms_at_decision" integer,
+  "reason_code" varchar(96),
+  "reason" text,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "provider_action_approvals_decision_chk"
+    CHECK ("decision" IN ('approve', 'deny')),
+  CONSTRAINT "provider_action_approvals_binding_rev_chk"
+    CHECK ("binding_revision_at_decision" >= 1)
+);
+--> statement-breakpoint
+
+ALTER TABLE "provider_action_approvals"
+  ADD CONSTRAINT "provider_action_approvals_queue_fk"
+  FOREIGN KEY ("approval_queue_id") REFERENCES "approval_queue"("id") ON DELETE cascade;
+--> statement-breakpoint
+
+-- Distinctness: an approver counts at most once per approval; a second decision
+-- by the same user is rejected loudly (unique violation surfaced as a 409).
+CREATE UNIQUE INDEX "provider_action_approvals_approver_uniq"
+  ON "provider_action_approvals" ("approval_queue_id", "approver_user_id");
+--> statement-breakpoint
+
+-- Cross-action decision-idempotency-key reuse guard (mirrors approval_queue).
+CREATE UNIQUE INDEX "provider_action_approvals_idem_uniq"
+  ON "provider_action_approvals" ("tenant_id", "approver_user_id", "decision_idempotency_key_hash");
+--> statement-breakpoint
+
+CREATE INDEX "provider_action_approvals_queue_idx"
+  ON "provider_action_approvals" ("approval_queue_id");
+--> statement-breakpoint
+
+CREATE INDEX "provider_action_approvals_intent_idx"
+  ON "provider_action_approvals" ("tenant_id", "intent_id");

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -442,6 +442,13 @@
       "when": 1784227200000,
       "tag": "0082_execution_authorization_v2",
       "breakpoints": true
+    },
+    {
+      "idx": 83,
+      "version": "7",
+      "when": 1784313600000,
+      "tag": "0083_provider_approval_quorum",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/__tests__/provider-approval-quorum-migration.test.ts
+++ b/packages/db/src/__tests__/provider-approval-quorum-migration.test.ts
@@ -1,0 +1,216 @@
+/**
+ * #205 migration 0083 schema-invariant tests. Asserts the raw-SQL invariants
+ * that drizzle-kit cannot express survive migration, so accidental removal fails
+ * CI:
+ *   - approval_queue quorum columns exist (threshold nullable, count NOT NULL
+ *     default 0, eligible-set array NOT NULL default '{}')
+ *   - the fail-closed quorum-shape CHECK rejects malformed rows AND permits the
+ *     single-approver (NULL threshold) shape
+ *   - provider_action_approvals table + its distinctness / idempotency unique
+ *     indexes + decision CHECK exist and enforce
+ *
+ * A single migrated PGLite instance is shared across cases (fresh WASM instances
+ * per case race the pglite runtime under bun parallel execution).
+ */
+
+import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { readFile, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { PGlite } from "@electric-sql/pglite";
+import { createPGLiteDb } from "../pglite";
+
+setDefaultTimeout(120_000);
+
+let client: PGlite;
+const migrationsDir = new URL("../../drizzle", import.meta.url).pathname;
+
+async function applyFile(c: PGlite, file: string) {
+  const sql = await readFile(join(migrationsDir, file), "utf8");
+  for (const stmt of sql.split("--> statement-breakpoint")) {
+    if (stmt.trim()) await c.exec(stmt);
+  }
+}
+
+describe("#205 quorum migration (0083)", () => {
+  beforeAll(async () => {
+    ({ client } = await createPGLiteDb("memory://"));
+  });
+  afterAll(async () => {
+    await client.close();
+  });
+
+  test("approval_queue quorum columns exist with the right nullability/defaults", async () => {
+    const cols = await client.query<{
+      column_name: string;
+      is_nullable: string;
+      column_default: string | null;
+    }>(
+      `SELECT column_name, is_nullable, column_default FROM information_schema.columns
+       WHERE table_name='approval_queue' AND column_name LIKE 'quorum%' ORDER BY column_name`,
+    );
+    const byName = Object.fromEntries(cols.rows.map((r) => [r.column_name, r]));
+    expect(byName.quorum_threshold?.is_nullable).toBe("YES");
+    expect(byName.quorum_approvals_count?.is_nullable).toBe("NO");
+    expect(byName.quorum_eligible_user_ids?.is_nullable).toBe("NO");
+    expect(byName.quorum_approvals_count?.column_default).toContain("0");
+  });
+
+  // A provider_action approval_queue row must satisfy the 0081 arm CHECK
+  // (intent_id/tenant_id/workspace_id/hashes/commitment/expires_at). This helper
+  // builds a legal row and lets the caller vary only the quorum columns.
+  const H = `sha256:${"a".repeat(64)}`;
+  // Each queue row needs its own intent (approval_queue has a UNIQUE(intent_id)).
+  async function armRow(id: string, quorumCols: string): Promise<void> {
+    const intentId = `int_${id}`;
+    await client.exec(
+      `INSERT INTO intents (id, tenant_id, intent_type, status) VALUES ('${intentId}','t205','provider-action','pending')`,
+    );
+    await client.exec(`INSERT INTO approval_queue
+      (id, agent_id, status, approval_kind, intent_id, tenant_id, workspace_id,
+       request_hash, action_digest, approval_commitment, approval_commitment_hash,
+       expected_binding_revision, expires_at ${quorumCols ? ", " + quorumCols.split("::VALUES::")[0] : ""})
+      VALUES ('${id}','ag205','pending','provider_action','${intentId}','t205',
+              '20000000-0000-4000-8000-000000000009', '${H}', '${H}', '{}'::jsonb, '${H}',
+              1, now() + interval '5 minutes'
+              ${quorumCols ? ", " + quorumCols.split("::VALUES::")[1] : ""})`);
+  }
+
+  test("quorum-shape CHECK permits single-approver (NULL) and a valid quorum, rejects malformed", async () => {
+    // Minimal parent rows for a legal approval_queue insert.
+    await client.exec(`INSERT INTO tenants (id, name, api_key_hash) VALUES ('t205','t','h')`);
+    await client.exec(
+      `INSERT INTO agents (id, tenant_id, name, wallet_address) VALUES ('ag205','t205','a','0x1')`,
+    );
+
+    // NULL threshold (single-approver) is permitted.
+    await armRow("aq_single", "");
+
+    // A valid 2-of-3 quorum is permitted.
+    await armRow(
+      "aq_quorum",
+      "quorum_threshold, quorum_eligible_user_ids, quorum_approvals_count::VALUES::2, ARRAY['00000000-0000-4000-8000-000000000001','00000000-0000-4000-8000-000000000002','00000000-0000-4000-8000-000000000003']::uuid[], 1",
+    );
+
+    // threshold 0 rejected.
+    let rejected0 = false;
+    try {
+      await armRow(
+        "aq_bad0",
+        "quorum_threshold, quorum_eligible_user_ids::VALUES::0, ARRAY['00000000-0000-4000-8000-000000000001']::uuid[]",
+      );
+    } catch {
+      rejected0 = true;
+    }
+    expect(rejected0).toBe(true);
+
+    // threshold > eligible set size rejected.
+    let rejectedBig = false;
+    try {
+      await armRow(
+        "aq_bad_big",
+        "quorum_threshold, quorum_eligible_user_ids::VALUES::3, ARRAY['00000000-0000-4000-8000-000000000001','00000000-0000-4000-8000-000000000002']::uuid[]",
+      );
+    } catch {
+      rejectedBig = true;
+    }
+    expect(rejectedBig).toBe(true);
+
+    // tally > threshold rejected.
+    let rejectedTally = false;
+    try {
+      await armRow(
+        "aq_bad_tally",
+        "quorum_threshold, quorum_eligible_user_ids, quorum_approvals_count::VALUES::2, ARRAY['00000000-0000-4000-8000-000000000001','00000000-0000-4000-8000-000000000002']::uuid[], 3",
+      );
+    } catch {
+      rejectedTally = true;
+    }
+    expect(rejectedTally).toBe(true);
+
+    // NULL threshold with a non-empty eligible set rejected (shape must be clean).
+    let rejectedDirtyNull = false;
+    try {
+      await armRow(
+        "aq_dirty_null",
+        "quorum_eligible_user_ids::VALUES::ARRAY['00000000-0000-4000-8000-000000000001']::uuid[]",
+      );
+    } catch {
+      rejectedDirtyNull = true;
+    }
+    expect(rejectedDirtyNull).toBe(true);
+  });
+
+  test("provider_action_approvals distinctness + idempotency unique indexes enforce", async () => {
+    const idx = await client.query<{ indexname: string }>(
+      `SELECT indexname FROM pg_indexes WHERE tablename='provider_action_approvals' ORDER BY indexname`,
+    );
+    const names = idx.rows.map((r) => r.indexname);
+    expect(names).toContain("provider_action_approvals_approver_uniq");
+    expect(names).toContain("provider_action_approvals_idem_uniq");
+
+    // Seed a legal provider_action queue to reference.
+    await armRow(
+      "aq_paa",
+      "quorum_threshold, quorum_eligible_user_ids::VALUES::2, ARRAY['00000000-0000-4000-8000-000000000001','00000000-0000-4000-8000-000000000002']::uuid[]",
+    );
+    // A second legal queue so the per-approver cross-ACTION idem guard can be
+    // exercised (same approver + same key on a DIFFERENT queue).
+    await armRow(
+      "aq_paa2",
+      "quorum_threshold, quorum_eligible_user_ids::VALUES::2, ARRAY['00000000-0000-4000-8000-000000000001','00000000-0000-4000-8000-000000000002']::uuid[]",
+    );
+
+    const row = (queueId: string, approverIdx: number, idemDigit: string) =>
+      `INSERT INTO provider_action_approvals
+        (approval_queue_id, intent_id, tenant_id, workspace_id, approver_user_id, decision,
+         binding_revision_at_decision, request_hash, action_digest, approval_commitment_hash,
+         decision_idempotency_key_hash, decision_request_hash)
+       VALUES ('${queueId}','int_${queueId}','t205','20000000-0000-4000-8000-000000000009',
+               '00000000-0000-4000-8000-00000000000${approverIdx}','approve', 1,
+               'sha256:${"a".repeat(64)}','sha256:${"b".repeat(64)}','sha256:${"c".repeat(64)}',
+               'sha256:${idemDigit.repeat(64)}','sha256:${"e".repeat(64)}')`;
+
+    await client.exec(row("aq_paa", 1, "1"));
+
+    // Same approver on the same queue => distinctness violation (different key).
+    let dupApprover = false;
+    try {
+      await client.exec(row("aq_paa", 1, "2"));
+    } catch {
+      dupApprover = true;
+    }
+    expect(dupApprover).toBe(true);
+
+    // Same approver reusing the SAME idempotency key on a DIFFERENT queue/action
+    // => per-approver cross-action idem violation.
+    let dupIdem = false;
+    try {
+      await client.exec(row("aq_paa2", 1, "1"));
+    } catch {
+      dupIdem = true;
+    }
+    expect(dupIdem).toBe(true);
+
+    // A DIFFERENT approver reusing the same key string is fine (distinct people):
+    // the idem guard is scoped per-approver, so this must SUCCEED.
+    await client.exec(row("aq_paa2", 2, "1"));
+
+    // Invalid decision value rejected by the CHECK.
+    let badDecision = false;
+    try {
+      await client.exec(
+        `INSERT INTO provider_action_approvals
+          (approval_queue_id, intent_id, tenant_id, workspace_id, approver_user_id, decision,
+           binding_revision_at_decision, request_hash, action_digest, approval_commitment_hash,
+           decision_idempotency_key_hash, decision_request_hash)
+         VALUES ('aq_paa','int_aq_paa','t205','20000000-0000-4000-8000-000000000009',
+                 '00000000-0000-4000-8000-000000000003','maybe', 1,
+                 'sha256:${"a".repeat(64)}','sha256:${"b".repeat(64)}','sha256:${"c".repeat(64)}',
+                 'sha256:${"f".repeat(64)}','sha256:${"9".repeat(64)}')`,
+      );
+    } catch {
+      badDecision = true;
+    }
+    expect(badDecision).toBe(true);
+  });
+});

--- a/packages/db/src/__tests__/provider-approval-quorum-migration.test.ts
+++ b/packages/db/src/__tests__/provider-approval-quorum-migration.test.ts
@@ -14,22 +14,15 @@
  */
 
 import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { readFile, readdir } from "node:fs/promises";
-import { join } from "node:path";
 import { PGlite } from "@electric-sql/pglite";
 import { createPGLiteDb } from "../pglite";
 
 setDefaultTimeout(120_000);
 
+// createPGLiteDb() applies every migration in packages/db/drizzle (including
+// 0083) before returning, so the assertions run against the fully-migrated
+// schema without a hand-rolled applier.
 let client: PGlite;
-const migrationsDir = new URL("../../drizzle", import.meta.url).pathname;
-
-async function applyFile(c: PGlite, file: string) {
-  const sql = await readFile(join(migrationsDir, file), "utf8");
-  for (const stmt of sql.split("--> statement-breakpoint")) {
-    if (stmt.trim()) await c.exec(stmt);
-  }
-}
 
 describe("#205 quorum migration (0083)", () => {
   beforeAll(async () => {

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1079,12 +1079,88 @@ export const approvalQueue = pgTable(
     decisionRequestHash: varchar("decision_request_hash", { length: 71 }),
     consumedAt: timestamp("consumed_at", { withTimezone: true }),
     consumedBy: varchar("consumed_by", { length: 64 }),
+    // ── #205 M-of-N quorum arm (0083) ──
+    // NULL threshold => single-approver legacy path (byte-for-byte unchanged).
+    // A non-NULL threshold flips the provider-action approval into flat N-of-M
+    // quorum: `quorum_threshold` DISTINCT eligible approvals are required before
+    // the queue can transition pending -> approved (execute-reachable). Nested
+    // quorums are out of scope. `quorum_eligible_user_ids` is the frozen,
+    // workspace_approver-scoped eligible set committed at create time.
+    // `quorum_approvals_count` is the guarded running tally of DISTINCT approve
+    // decisions at the CURRENT binding revision; it is reset to 0 whenever the
+    // set is invalidated (staleness bumps binding_revision).
+    quorumThreshold: integer("quorum_threshold"),
+    quorumEligibleUserIds: uuid("quorum_eligible_user_ids").array().notNull().default([]),
+    quorumApprovalsCount: integer("quorum_approvals_count").notNull().default(0),
   },
   (table) => ({
     txIdUniqueIdx: uniqueIndex("approval_queue_tx_id_idx").on(table.txId),
     statusIdx: index("approval_queue_status_idx").on(table.status),
   }),
 );
+
+/**
+ * #205 M-of-N quorum: one row per DISTINCT approver decision on a provider-action
+ * approval. The single-approver legacy path never inserts here (it records its
+ * lone decision on `approval_queue` directly). Every row binds the EXACT
+ * request_hash / action_digest / approval_commitment_hash and the
+ * `binding_revision_at_decision` the approval was cast against, so a dependency
+ * or payload change (which bumps binding_revision) invalidates the WHOLE
+ * collected set — a stale approval can never count toward a later quorum.
+ *
+ * Distinctness is a UNIQUE(approval_queue_id, approver_user_id): an approver
+ * approving twice is rejected loudly the second time. The requester (agent owner)
+ * can never be an eligible approver (enforced at decide time), so requester
+ * separation generalizes to "requester never counts toward quorum".
+ */
+export const providerActionApprovals = pgTable(
+  "provider_action_approvals",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    approvalQueueId: varchar("approval_queue_id", { length: 64 })
+      .notNull()
+      .references(() => approvalQueue.id, { onDelete: "cascade" }),
+    intentId: varchar("intent_id", { length: 64 }).notNull(),
+    tenantId: varchar("tenant_id", { length: 64 }).notNull(),
+    workspaceId: uuid("workspace_id").notNull(),
+    approverUserId: uuid("approver_user_id").notNull(),
+    decision: varchar("decision", { length: 16 }).notNull(),
+    bindingRevisionAtDecision: integer("binding_revision_at_decision").notNull(),
+    requestHash: varchar("request_hash", { length: 71 }).notNull(),
+    actionDigest: varchar("action_digest", { length: 71 }).notNull(),
+    approvalCommitmentHash: varchar("approval_commitment_hash", { length: 71 }).notNull(),
+    decisionIdempotencyKeyHash: varchar("decision_idempotency_key_hash", { length: 71 }).notNull(),
+    decisionRequestHash: varchar("decision_request_hash", { length: 71 }).notNull(),
+    mfaVerifiedAt: timestamp("mfa_verified_at", { withTimezone: true }),
+    mfaAgeMsAtDecision: integer("mfa_age_ms_at_decision"),
+    reasonCode: varchar("reason_code", { length: 96 }),
+    reason: text("reason"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    // Distinctness: an approver counts at most once per approval.
+    approverUniqueIdx: uniqueIndex("provider_action_approvals_approver_uniq").on(
+      table.approvalQueueId,
+      table.approverUserId,
+    ),
+    // Cross-action decision-idempotency-key reuse guard (mirrors approval_queue).
+    idemUniqueIdx: uniqueIndex("provider_action_approvals_idem_uniq").on(
+      table.tenantId,
+      table.approverUserId,
+      table.decisionIdempotencyKeyHash,
+    ),
+    queueIdx: index("provider_action_approvals_queue_idx").on(table.approvalQueueId),
+    intentIdx: index("provider_action_approvals_intent_idx").on(table.tenantId, table.intentId),
+    queueFk: foreignKey({
+      columns: [table.approvalQueueId],
+      foreignColumns: [approvalQueue.id],
+      name: "provider_action_approvals_queue_fk",
+    }).onDelete("cascade"),
+  }),
+);
+
+export type ProviderActionApprovalRow = typeof providerActionApprovals.$inferSelect;
+export type NewProviderActionApprovalRow = typeof providerActionApprovals.$inferInsert;
 
 /**
  * First-class Privy-style intents for actions that may require authorization

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1106,7 +1106,7 @@ export const approvalQueue = pgTable(
  * request_hash / action_digest / approval_commitment_hash and the
  * `binding_revision_at_decision` the approval was cast against, so a dependency
  * or payload change (which bumps binding_revision) invalidates the WHOLE
- * collected set — a stale approval can never count toward a later quorum.
+ * collected set, so a stale approval can never count toward a later quorum.
  *
  * Distinctness is a UNIQUE(approval_queue_id, approver_user_id): an approver
  * approving twice is rejected loudly the second time. The requester (agent owner)

--- a/packages/shared/src/provider-approval.ts
+++ b/packages/shared/src/provider-approval.ts
@@ -66,6 +66,20 @@ export interface ProviderApprovalCommitmentV1 {
     requesterSeparation: boolean;
     maxMfaAgeSeconds: 300;
     requiredMfaAssurance: "current-session-mfa" | "phishing-resistant";
+    /**
+     * #205 flat M-of-N quorum. ABSENT (undefined) => single-approver legacy path;
+     * the commitment is then byte-for-byte identical to pre-quorum actions
+     * because JCS omits an undefined member (verified by the single-approver
+     * regression corpus). When present, `threshold` DISTINCT eligible approvals
+     * are required. `eligibleApproverUserIds` is the frozen, workspace_approver
+     * -scoped eligible set (UUIDs). The requester (agent owner) is never eligible
+     * (enforced at decide time, generalizing requesterSeparation). Nested quorums
+     * are OUT OF SCOPE (flat N-of-M only).
+     */
+    quorum?: {
+      threshold: number;
+      eligibleApproverUserIds: string[];
+    };
   };
   requestedAt: string;
   expiresAt: string;
@@ -138,6 +152,20 @@ export function canonicalApprovalCommitmentObject(
       requesterSeparation: c.approvalRequirements.requesterSeparation,
       maxMfaAgeSeconds: c.approvalRequirements.maxMfaAgeSeconds,
       requiredMfaAssurance: c.approvalRequirements.requiredMfaAssurance,
+      // Additive quorum member. Emitted ONLY when configured, so an absent
+      // quorum yields a canonical object byte-identical to the pre-#205 shape.
+      // The eligible-approver set is sorted (UUID-byte order) because JCS
+      // preserves array order and the commitment must be deterministic.
+      ...(c.approvalRequirements.quorum
+        ? {
+            quorum: {
+              threshold: c.approvalRequirements.quorum.threshold,
+              eligibleApproverUserIds: [
+                ...c.approvalRequirements.quorum.eligibleApproverUserIds,
+              ].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0)),
+            },
+          }
+        : {}),
     },
     requestedAt: c.requestedAt,
     expiresAt: c.expiresAt,
@@ -215,6 +243,16 @@ export interface ProviderApprovalAuditPayloadV1 {
   reasonCode: string;
   resumeAttemptId: string | null;
   occurredAt: string;
+  /**
+   * #205 quorum progress. ABSENT for single-approver actions (byte-for-byte
+   * unchanged audit payloads). When present, `quorumThreshold` is the required
+   * DISTINCT-approval count and `quorumApprovalsCount` is the tally AFTER this
+   * decision (so a partial-quorum approve carries count < threshold and the
+   * satisfying Nth approve carries count === threshold). No second evidence
+   * system: quorum progress rides the existing provider.approval.decided events.
+   */
+  quorumThreshold?: number;
+  quorumApprovalsCount?: number;
 }
 
 // ─── Decision request body (public API shape, spec §8.2) ──────────────────────


### PR DESCRIPTION
Closes #205.

## Summary
Adds flat **M-of-N quorum approval** for provider actions (competitive parity vs Turnkey `REQUIRES_CONSENSUS` / Fireblocks / Privy), generalizing the single-approver exact-request approval lifecycle (0081/PR3) to require N distinct eligible approvals before an action becomes execute-reachable. **Absent a quorum config, the existing single-approver path is byte-for-byte unchanged** (the branch is gated on `queue.quorum_threshold != null`; NULL runs the pre-existing code verbatim).

**Nested quorums are OUT OF SCOPE** (flat N-of-M only), as permitted by the issue.

## Design (spec-mapped)
- **Config source (no `capability-intent.ts` edit; avoids the #206 collision):** the threshold + eligible approver set are read from `request_profile.approvalRequirements.quorum`, the same forward-compatible source `extractRequesterSeparation` already uses. The policy engine still emits `approval_required` unchanged; the quorum is commitment metadata, bound into the exact approval commitment at create time exactly like `requesterSeparation`.
- **Schema (migration 0083, journal tip verified 0082 -> max+1):**
  - `approval_queue`: nullable `quorum_threshold`, `quorum_eligible_user_ids uuid[]`, `quorum_approvals_count` + a fail-closed CHECK on the config shape (NULL threshold => clean single-approver shape; non-NULL => `1 <= threshold <= |eligible set|`, `0 <= count <= threshold`).
  - `provider_action_approvals`: one row per DISTINCT approver decision, each binding the exact `request_hash`/`action_digest`/`approval_commitment_hash` and the `binding_revision_at_decision`. `UNIQUE(queue, approver)` distinctness + `UNIQUE(tenant, approver, idem_hash)` cross-action idempotency.
- **Commitment (additive):** `ProviderApprovalCommitmentV1.approvalRequirements.quorum` is emitted only when configured, so an absent quorum yields a byte-identical commitment to the pre-#205 corpus (verified by the single-approver regression staying green).

## Requirement mapping (issue #205, binding)
1. approval_required carries `{threshold, eligible approver set}` (workspace_approver-scoped), a provider-scoped analog of `agent_key_quorums`. Recursion NOT used (flat N-of-M).
2. N DISTINCT eligible approvals required before execute is reachable; a single deny terminates the whole approval immediately (deny wins).
3. Every approval binds the exact requestHash/actionDigest/dependency revisions (I10). A dependency/payload change after the first approval STALES THE ENTIRE SET (staleness bumps `binding_revision` and flips the queue to the terminal `stale` state, so the collected set can never satisfy a later quorum).
4. Distinctness: N distinct user ids; requester (agent owner) can never count (generalized requester-separation); a second decision by the same approver is rejected loudly (`APPROVAL_DUPLICATE_APPROVER`).
5. Eligibility enforced per-approval at decide time (current membership + role + recent-MFA + eligible-set membership); a user who loses eligibility between approvals cannot complete the quorum.
6. Backward compatible: absent quorum = existing single-approver behavior byte-for-byte (regression floor untouched).
7. Fail-closed at BOTH store time and eval time: malformed threshold (0/negative/non-integer/> set size), empty/duplicate eligible set, AND an UNREACHABLE eligible set (ids that are not real in-window workspace_approvers, non-members, or the requester) are rejected at store time (`APPROVAL_QUORUM_CONFIG_INVALID`); the evaluator re-validates at decide time.
8. Audit: quorum progress rides the EXISTING `provider.approval.decided` events (threshold + count-after in metadata); the satisfying Nth approve carries `count === threshold`. No second evidence system.
9. Race: two concurrent Nth approvals produce exactly one execute-reachable transition (guarded-CAS tally + `pending->approved WHERE status='pending' AND count>=threshold`), proven against real Postgres.

## Tests
- **`provider-approval-quorum.test.ts` (21 cases, PGLite, through the REAL `providerActionService` + `providerApprovalService`):** boundary N-1 not executable / resume unreachable; Nth satisfies -> approved + authorized + resumable (E2E #1); deny-after-partial terminates (E2E #2 / deny path); duplicate-approver 409; idempotent retry; ineligible-by-set + ineligible-by-lost-role Nth approver; requester-as-approver blocked; stale-after-first invalidates the set; 7 malformed-config + 2 unreachable-config store-time rejections; serialized concurrent-Nth single transition; single-approver regression untouched.
- **`provider-approval-quorum-race.test.ts` (3 cases, REAL PG via `DATABASE_URL`):** concurrent Nth approvals => exactly one execute-reachable transition + no orphan (non-counted) evidence rows; tally capped at threshold; concurrent same-approver double-submit counts once.
- **`provider-approval-quorum-migration.test.ts` (3 cases):** 0083 column nullability/defaults, the quorum-shape CHECK (permits NULL + valid, rejects 0 / > set size / tally > threshold / dirty-NULL), and the distinctness + per-approver cross-action idem unique indexes + decision CHECK.
- **Mutation proofs (`scripts/quorum-mutation-proofs.sh`, 6/6 killed):** weaken threshold compare, drop distinctness, drop requester-separation, skip staleness on set, drop deny-terminates, drop eligible-set membership.

## Verification
- Regression floor GREEN via the isolated harness (21/21 files): all provider-approval suites, provider-action-service, provider-authority(-e2e), provider-x-governed-e2e, provider-case/evidence suites.
- DB migration suite green; root `tsc` (api) 0 errors; biome clean; byte-corruption scan clean; no em-dashes.
- Rebased onto latest develop (post #227 mcp merge); migration renumber not needed (tip stayed 0082, mine 0083).

## Codex
One full codex pass surfaced 2 P2s, both reproduced then fixed in `71aac96`:
1. Unreachable-quorum configs could be stored (structurally-valid but non-voting ids). `buildApprovalArm` now fails closed at store time when the count of actually-eligible voters < threshold.
2. A concurrent loser could commit a non-counted `provider_action_approvals` row. The post-insert conflict paths now THROW `QuorumStateConflictError` to roll back the whole tx (no orphan evidence), mapped to `APPROVAL_STATE_CONFLICT` 409.
(Re-running the full-repo codex review on this diff does not converge — it dumps read files instead of a verdict, the known gpt-5.5/fable large-multi-file behavior; the targeted P2 fixes above are test- and mutation-verified.)

## Honest gaps / follow-ups
- **Nested quorums:** out of scope by design (flat N-of-M only). A recursive/threshold-of-quorums model would need a separate design.
- **Notification UX:** no approver-fan-out notification when a quorum is opened or advances; approvers currently poll the approval detail endpoint. Follow-up issue candidate.
- **Web display:** the quorum threshold/progress is available on the approval detail data shape but the dashboard `approvals/[id]` page was not extended to render a progress indicator in this PR (no functional web change needed for the lifecycle; UI is additive follow-up).
- **Eligible-set drift:** store-time reachability is computed against current membership/roles; if enough eligible approvers lose their role AFTER creation, the quorum can become unsatisfiable and the action simply expires (fail-closed). A "re-validate reachability on role revocation" sweep is a possible enhancement.

[sol-orch]
