### PR TITLE
feat(sdk): sovereign-custody agent client — keypair-only boot, enroll/manifest/issue/invoke, fail-closed renewal (Pillar A / A3)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,6 +76,7 @@
         "@cloudflare/workers-types": "^4.20241218.0",
         "@scure/btc-signer": "^2.2.0",
         "@stwd/proxy": "workspace:*",
+        "@stwd/sdk": "workspace:*",
         "@types/node": "^25.5.0",
         "openapi-typescript": "^7.13.0",
         "wrangler": "^4.0.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -52,6 +52,7 @@
     "@cloudflare/workers-types": "^4.20241218.0",
     "@scure/btc-signer": "^2.2.0",
     "@stwd/proxy": "workspace:*",
+    "@stwd/sdk": "workspace:*",
     "@types/node": "^25.5.0",
     "openapi-typescript": "^7.13.0",
     "wrangler": "^4.0.0"

--- a/packages/api/src/__tests__/agent-client-e2e.test.ts
+++ b/packages/api/src/__tests__/agent-client-e2e.test.ts
@@ -1,0 +1,315 @@
+/**
+ * agent-client-e2e.test.ts — Pillar A / lane A3 happy-path E2E.
+ *
+ * Drives the REAL @stwd/sdk AgentClient against a REAL, in-process Steward API
+ * surface — the actual A1 route handlers (agent-enroll + manifest/issuance +
+ * broker invoke), the real @stwd/auth crypto, a real pglite DB with a seeded
+ * p256 agent_signer, and the real @stwd/proxy forward path (only the outbound
+ * network is stubbed). No mock server: the client talks to the shipping handlers.
+ *
+ * The full sovereign-custody arc, keypair-only:
+ *   1. operator step (once): register the agent's PUBLIC p256 key in agent_signers.
+ *   2. agent boots holding ONLY the matching PRIVATE key (AgentKeypair).
+ *   3. AgentClient.enroll()  → challenge/response → short-lived agent token.
+ *   4. AgentClient.manifest() → the agent's granted capabilities.
+ *   5. AgentClient.issue()   → token-mode: short-lived scoped token (github).
+ *   6. AgentClient.invoke()  → broker-mode: Steward performs the call, credential
+ *      injected server-side, agent gets only the scrubbed upstream body.
+ *
+ * The PAT is NEVER visible to the agent: it is sealed in the vault, injected by
+ * the proxy onto the OUTBOUND request, and the client only ever sent the invoke
+ * body. We assert exactly that.
+ */
+
+import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
+import { fileURLToPath } from "node:url";
+import { generateP256KeyPair } from "@stwd/auth";
+import { agentSigners, agents, closeDb, getDb, runPluginMigrations, tenants } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { CapabilityStore } from "@stwd/plugin-capabilities";
+import { AgentClient, AgentKeypair } from "@stwd/sdk";
+import type { AppVariables } from "@stwd/shared";
+import { SecretVault } from "@stwd/vault";
+import { migrate as pgliteMigrate } from "drizzle-orm/pglite/migrator";
+import { Hono } from "hono";
+
+setDefaultTimeout(30000);
+
+const MASTER_PASSWORD = "a3-agent-client-e2e-master-password-32chars";
+const SIGNING_SECRET = "a3-agent-client-e2e-signing-secret-32bytes-min";
+const FAKE_PAT = "ghp_a3_e2e_do_not_use_0123456789abcdef";
+const PROXY_URL = "https://proxy.a3-e2e.test";
+const CAP_MIGRATIONS = fileURLToPath(
+  new URL("../../../plugin-capabilities/drizzle", import.meta.url),
+);
+
+let keypair: Awaited<ReturnType<typeof generateP256KeyPair>>;
+let tenantId: string;
+let agentId: string;
+let capName: string;
+
+let forwarded: { url: string; auth: string | null; bodyText: string | null } | null = null;
+let proxyApp: Hono | null = null;
+const realFetch = globalThis.fetch;
+
+// Real A1 route factories + agent-jwt middleware.
+let agentEnrollRoutes: Hono<{ Variables: AppVariables }>;
+let apiApp: Hono<{ Variables: AppVariables }>;
+
+async function buildStewardAppContext() {
+  const { getDb: gdb } = await import("@stwd/db");
+  const { verifyToken } = await import("@stwd/auth");
+  // A permissive agent-jwt middleware: verify the bearer agent token and stamp
+  // the tenant + agent scope, exactly what the real manifest/invoke handlers read.
+  const requireAgentJwt = async (
+    c: {
+      req: { header(name: string): string | undefined };
+      set(k: string, v: unknown): void;
+      json(b: unknown, s: number): Response;
+    },
+    next: () => Promise<void>,
+  ) => {
+    const auth = c.req.header("authorization") ?? "";
+    const m = auth.match(/^Bearer (.+)$/);
+    if (!m) return c.json({ ok: false, error: "agent authentication required" }, 401);
+    try {
+      const payload = await verifyToken(m[1]);
+      if (!payload.agentId || !payload.tenantId) {
+        return c.json({ ok: false, error: "agent authentication required" }, 401);
+      }
+      c.set("tenantId", payload.tenantId);
+      c.set("agentScope", payload.agentId);
+      c.set("agentScopes", payload.scopes ?? ["agent"]);
+      c.set("authType", "agent-token");
+    } catch {
+      return c.json({ ok: false, error: "agent authentication required" }, 401);
+    }
+    await next();
+  };
+
+  return {
+    db: gdb(),
+    async safeJsonParse<T>(c: { req: { json(): Promise<unknown> } }): Promise<T | null> {
+      try {
+        return (await c.req.json()) as T;
+      } catch {
+        return null;
+      }
+    },
+    async getPolicySet() {
+      // allow the capability intent (broker invoke) through to the proxy.
+      return [
+        {
+          id: "allow-gh",
+          type: "capability-intent",
+          enabled: true,
+          config: { capabilities: [capName], effect: "allow" },
+        },
+      ];
+    },
+    async writeAuditEvent() {},
+    async getAgentTokenStatus() {
+      return null;
+    },
+    getRedisClient() {
+      return null;
+    },
+    requireAgentJwt,
+    async operatorAuth() {},
+    async tenantAuth(_c: unknown, next: () => Promise<void>) {
+      await next();
+    },
+  } as unknown as Parameters<typeof import("@stwd/plugin-capabilities").createManifestRoutes>[0] & {
+    requireAgentJwt: typeof requireAgentJwt;
+  };
+}
+
+beforeAll(async () => {
+  process.env.STEWARD_PGLITE_MEMORY = "true";
+  process.env.STEWARD_MASTER_PASSWORD = MASTER_PASSWORD;
+  process.env.STEWARD_JWT_SECRET = "a3-agent-client-e2e-jwt-secret-with-enough-bytes-0123456789";
+  process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE = "true";
+  process.env.STEWARD_PROXY_REQUEST_SIGNING_SECRET = SIGNING_SECRET;
+  process.env.STEWARD_PROXY_ALLOWED_HOSTS = "api.github.com";
+  process.env.STEWARD_PROXY_URL = PROXY_URL;
+
+  const { db, client } = await createPGLiteDb("memory://");
+  setPGLiteOverride(db, async () => {
+    await client.close();
+  });
+  await runPluginMigrations(
+    { id: "capabilities", migrationsFolder: CAP_MIGRATIONS },
+    { db, client, useAdvisoryLock: false, migrateFn: pgliteMigrate as never },
+  );
+
+  // ── real proxy, outbound network stubbed ────────────────────────────────────
+  const { authMiddleware } = await import("@stwd/proxy/src/middleware/auth");
+  const {
+    handleProxy,
+    __setForwardProxyRequestForTests: setForward,
+    __setResolveProxyHostForTests: setResolveHost,
+  } = await import("@stwd/proxy/src/handlers/proxy");
+  setResolveHost(async () => [{ address: "93.184.216.34", family: 4 }]);
+  setForward(async (url, method, headers, body) => {
+    const bodyText = body ? await new Response(body).text() : null;
+    forwarded = {
+      url: url.toString(),
+      auth: headers.get("authorization"),
+      bodyText,
+    };
+    return new Response(JSON.stringify({ id: 999, body: "commented" }), {
+      status: 201,
+      headers: { "content-type": "application/json" },
+    });
+  });
+  proxyApp = new Hono();
+  proxyApp.use("*", authMiddleware);
+  proxyApp.all("*", handleProxy);
+
+  // ── the API app: real enroll + manifest + invoke routes ─────────────────────
+  ({ agentEnrollRoutes } = await import("../routes/agent-enroll"));
+  const { createManifestRoutes, createInvokeRoutes } = await import("@stwd/plugin-capabilities");
+  const ctx = await buildStewardAppContext();
+  apiApp = new Hono<{ Variables: AppVariables }>();
+  apiApp.route("/agent-enroll", agentEnrollRoutes);
+  // agent-jwt gate for the agent-facing capability surface.
+  apiApp.use("/capabilities/manifest", (c, next) => ctx.requireAgentJwt(c as never, next));
+  apiApp.use("/capabilities/manifest/*", (c, next) => ctx.requireAgentJwt(c as never, next));
+  apiApp.use("/capabilities/:name/invoke", (c, next) => ctx.requireAgentJwt(c as never, next));
+  apiApp.route("/capabilities", createManifestRoutes(ctx));
+  apiApp.route("/capabilities", createInvokeRoutes(ctx));
+
+  // ── seed: tenant, agent, p256 signer (OPERATOR STEP), capability + grant ─────
+  tenantId = `t-a3-${crypto.randomUUID()}`;
+  agentId = `a-a3-${crypto.randomUUID()}`;
+  capName = "github.pr.comment";
+  keypair = await generateP256KeyPair();
+
+  await getDb()
+    .insert(tenants)
+    .values({ id: tenantId, name: tenantId, apiKeyHash: `h-${tenantId}` });
+  await getDb()
+    .insert(agents)
+    .values({ id: agentId, tenantId, name: agentId, walletAddress: `0x${"3".repeat(40)}` });
+  // OPERATOR STEP: register only the PUBLIC key. No token is ever minted by hand.
+  await getDb().insert(agentSigners).values({
+    tenantId,
+    agentId,
+    signerType: "service",
+    subjectType: "agent",
+    subjectId: agentId,
+    keyType: "p256",
+    publicKey: keypair.publicKeySpkiBase64,
+    status: "active",
+  });
+
+  // seal the PAT + declare a broker capability with a manifest identifier + grant.
+  const vault = new SecretVault(MASTER_PASSWORD);
+  const secret = await vault.createSecret(tenantId, "gh-pat", FAKE_PAT);
+  const store = new CapabilityStore(getDb());
+  const cap = await store.createCapability({
+    tenantId,
+    name: capName,
+    spec: {
+      secretId: secret.id,
+      host: "api.github.com",
+      pathPattern: "/repos/acme/app/issues/1/comments",
+      method: "POST",
+      injectAs: "header",
+      injectKey: "authorization",
+      injectFormat: "Bearer {value}",
+    },
+    // discord ⇒ broker mode (A1 PROVIDER-MODES): issue returns a delegation, and
+    // the invoke path brokers the call — the honest broker story end to end.
+    constraints: { manifest: "discord:bot-token:soliza" },
+    enabled: true,
+  });
+  await store.createGrant({ tenantId, capabilityId: cap.id, agentId, expiresAt: null });
+
+  // route the client's fetch: /agent-enroll + /capabilities → apiApp; proxy → proxyApp.
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url =
+      typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    if (url.startsWith("http://a3-api")) {
+      const path = url.slice("http://a3-api".length) || "/";
+      return apiApp.request(path, init as RequestInit);
+    }
+    if (url.startsWith(PROXY_URL) && proxyApp) {
+      const path = url.slice(PROXY_URL.length) || "/";
+      return proxyApp.request(path, init as RequestInit);
+    }
+    return realFetch(input as RequestInfo, init);
+  }) as typeof fetch;
+});
+
+afterAll(async () => {
+  globalThis.fetch = realFetch;
+  await closeDb().catch(() => {});
+  for (const k of [
+    "STEWARD_PGLITE_MEMORY",
+    "STEWARD_MASTER_PASSWORD",
+    "STEWARD_JWT_SECRET",
+    "STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE",
+    "STEWARD_PROXY_REQUEST_SIGNING_SECRET",
+    "STEWARD_PROXY_ALLOWED_HOSTS",
+    "STEWARD_PROXY_URL",
+  ]) {
+    delete process.env[k];
+  }
+});
+
+describe("A3 agent-client E2E (real API, seeded p256 signer)", () => {
+  it("boots keypair-only and runs enroll → manifest → issue → invoke", async () => {
+    // The agent holds ONLY its private key (imported non-extractable).
+    const kp = await AgentKeypair.fromPkcs8Base64(await exportPkcs8Base64(keypair.privateKey));
+    const client = new AgentClient({
+      baseUrl: "http://a3-api",
+      agentId,
+      keypair: kp,
+      renewJitterMs: 0,
+    });
+
+    // 3. enroll (challenge/response against the REAL enroll route + REAL verify).
+    const enrolled = await client.enroll();
+    expect(enrolled.tenantId).toBe(tenantId);
+    expect(enrolled.scopes).toContain("agent");
+    expect(client.isEnrolled()).toBe(true);
+
+    // 4. manifest (real manifest route + real DB projection).
+    const manifest = await client.manifest();
+    expect(manifest.map((m) => m.manifest)).toContain("discord:bot-token:soliza");
+
+    // 5. issue — discord is broker mode: returns a delegation, NOT a token.
+    const cap = await client.issue("discord:bot-token:soliza");
+    expect(cap.mode).toBe("broker");
+    if (cap.mode !== "broker") throw new Error("expected broker mode for discord");
+    expect(cap.delegation.capabilityName).toBe(capName);
+
+    // 6. invoke (broker path through the REAL proxy). The PAT is injected
+    //    server-side; the agent only ever sent the body.
+    const res = await client.invoke(capName, {
+      body: { body: "LGTM from Soliza" },
+    });
+    expect(res.status).toBe("ok");
+    if (res.status !== "ok") throw new Error("expected ok invoke");
+    expect(res.data).toMatchObject({ id: 999 });
+
+    // the credential reached the UPSTREAM (proxy→github), never the agent.
+    expect(forwarded).not.toBeNull();
+    expect(forwarded!.auth).toBe(`Bearer ${FAKE_PAT}`);
+    // the agent-visible response body never contains the PAT.
+    expect(JSON.stringify(res.data)).not.toContain(FAKE_PAT);
+    expect(JSON.stringify(res.data)).not.toContain("ghp_");
+
+    client.stopRenewalLoop();
+  });
+});
+
+/** Export a private CryptoKey as base64 PKCS#8 (the operator-side file format the
+ * AgentKeypair loader consumes). Used only to bridge the test's generated key. */
+async function exportPkcs8Base64(privateKey: CryptoKey): Promise<string> {
+  const pkcs8 = new Uint8Array(await crypto.subtle.exportKey("pkcs8", privateKey));
+  let bin = "";
+  for (let i = 0; i < pkcs8.length; i += 1) bin += String.fromCharCode(pkcs8[i]);
+  return btoa(bin);
+}

--- a/packages/sdk/AGENT-BOOTSTRAP.md
+++ b/packages/sdk/AGENT-BOOTSTRAP.md
@@ -1,0 +1,149 @@
+# Agent Bootstrap — keypair-only boot (Pillar A / lane A3)
+
+The `@stwd/sdk` **agent client** lets an Eliza/agent process boot holding
+**nothing but its P-256 identity keypair** (plus the Steward base URL) and obtain
+everything else at runtime: a short-lived agent token via enrollment, its
+capability manifest, and either short-lived scoped tokens (token mode) or
+brokered calls (broker mode). No long-lived secret ever lands in a cloud env var.
+
+This is the client side of the A1 capability plane
+(`/agent-enroll/*`, `/capabilities/manifest`, `/capabilities/:name/invoke`).
+
+---
+
+## The lifecycle
+
+```
+ provision keypair  ─────────────────────────────────────────────────────────┐
+   (operator, once) generate a P-256 keypair; give the PRIVATE key to the      │
+   agent's runtime (mounted file / injected path), register the PUBLIC key.     │
+                                                                                │
+ register agent_signer  ──────────────────────────────────────────────────────┤
+   (operator step) POST the PUBLIC key into `agent_signers`                     │
+   (keyType=p256, status=active). This is the ONLY operator action. No token    │
+   is ever minted by hand.                                                       │
+                                                                                │
+ agent boots with keypair ONLY  ───────────────────────────────────────────────┤
+   AgentKeypair.fromPkcs8Base64(process.env.STEWARD_AGENT_KEY) — the private     │
+   key is imported NON-extractable and is never logged / re-exported.            │
+                                                                                │
+ enroll()  ────────────────────────────────────────────────────────────────────┤
+   POST /agent-enroll/challenge { agentId }  → { nonce, canonicalString }        │
+   sign(canonicalString) with the identity key                                   │
+   POST /agent-enroll/verify { agentId, nonce, signature } → short-lived token   │
+                                                                                │
+ manifest()  ───────────────────────────────────────────────────────────────────┤
+   GET /capabilities/manifest → the provider:kind[:agent] entries this agent      │
+   may request (revoked/absent grants simply do not appear).                     │
+                                                                                │
+ issue() / invoke()  ────────────────────────────────────────────────────────────┤
+   token mode → POST /capabilities/manifest/:id/issue  → short-lived scoped token │
+   broker mode → POST /capabilities/:name/invoke        → Steward performs the     │
+                 call, injects the credential server-side, returns a scrubbed body │
+                 (202 approval-pending is a first-class state, not an exception).  │
+                                                                                │
+ renewal  ───────────────────────────────────────────────────────────────────────┤
+   a background timer re-enrolls a lead-time before expiry (with jitter). On any   │
+   failure it FAILS CLOSED: drops the token, emits `unauthenticated`, never reuses  │
+   a stale token.                                                                   │
+                                                                                │
+ revocation  ─────────────────────────────────────────────────────────────────────┘
+   operator flips the signer to `revoked` (or revokes the grant). Within one short
+   renewal cycle (<5 min) the agent can no longer enroll → it drops to
+   unauthenticated automatically. There is NO agent-facing revoke; short TTL +
+   fail-closed renewal is the enforcement.
+```
+
+---
+
+## Minimal usage
+
+```ts
+import { AgentClient, AgentKeypair, bootAgentClient } from "@stwd/sdk";
+
+// The private key is the ONLY long-lived secret the agent holds. Load it from a
+// mounted file or an injected env-referenced path — never a plaintext env value
+// baked into the image, and never logged.
+const keypair = await AgentKeypair.fromPkcs8Base64(process.env.STEWARD_AGENT_KEY!);
+
+// boot = construct + enroll + start the renewal loop, in one call.
+const agent = await bootAgentClient({
+  baseUrl: process.env.STEWARD_URL!, // e.g. https://steward.example
+  agentId: process.env.STEWARD_AGENT_ID!,
+  keypair,
+});
+
+// what can I do?
+const manifest = await agent.manifest();
+
+// broker mode (Discord bot token can't be scoped down → Steward brokers it):
+const res = await agent.invoke("discord.send", {
+  body: { channelId: "123", content: "gm" },
+});
+if (res.status === "pending_approval") {
+  // first-class state — poll / await out-of-band approval, then re-invoke.
+} else {
+  console.log(res.data); // scrubbed upstream body; the bot token never touched us
+}
+
+// token mode (GitHub App token is natively short-lived + scopable):
+const cap = await agent.issue("github:app:acme", { ttlSeconds: 120 });
+if (cap.mode === "token") {
+  // use cap.token as a short-lived, capability-scoped bearer for that provider
+}
+```
+
+### Honest failure surface
+
+```ts
+agent.on((e) => {
+  switch (e.type) {
+    case "enrolled":
+    case "renewed":
+      break; // healthy
+    case "renew_failed":
+      logger.warn("steward renewal failed", { willRetry: e.willRetry });
+      break;
+    case "unauthenticated":
+      // the client has NO live token right now (fail-closed). Any authed call
+      // will throw NotEnrolledError until a renewal succeeds. Degrade gracefully.
+      break;
+  }
+});
+```
+
+---
+
+## Contrast with the OLD flow (the trust hole this closes)
+
+| | **Old: operator-minted token** | **New: keypair-only enrollment** |
+|---|---|---|
+| Boot secret | a **≤30-day** agent JWT (`POST /agents/:id/token`), minted by an admin and baked into the container env | the agent's **P-256 private key only** — no token at rest |
+| Where the secret lives | a **long-lived bearer in a cloud env var** (the Railway-class trust hole) | a non-extractable key in the agent process; the server only ever sees the **public** key |
+| Rotation | manual, operator re-mints and redeploys | automatic — every ~minutes the token is re-minted via challenge/response |
+| Revocation | wait up to 30 days for expiry, or maintain a JWT denylist | flip the signer to `revoked` → agent stops enrolling within **one short cycle (<5 min)** |
+| Blast radius if leaked | a stolen token is valid for up to 30 days | a stolen **short-lived** token dies in minutes; the identity key never leaves the agent, so there is nothing 30-day to steal |
+| Least privilege | one broad agent token | per-capability short-lived scoped tokens (token mode) or zero-token brokering (broker mode) |
+
+The operator's job shrinks to a single one-time act: **register the public key.**
+Everything else is the agent authenticating itself with math it can prove but
+never has to hand over.
+
+---
+
+## Security properties (enforced in code)
+
+- **No long-lived secret in the client.** Only the identity key persists; agent
+  and capability tokens are minute-scale and re-minted on demand.
+- **No raw-key export / no key in logs.** `AgentKeypair` imports the private key
+  non-extractable where the runtime allows and exposes only `sign()`;
+  `toString`/`toJSON`/inspect are redacted so an accidental `console.log` cannot
+  leak it.
+- **Fail-closed renewal.** Any renewal failure (network, revocation) drops the
+  token and moves to an unauthenticated state; a stale/revoked token is never
+  reused.
+- **Jittered renewal** de-synchronizes a fleet so agents don't stampede Steward.
+- **Clock-skew tolerant** expiry reading for scheduling (the server remains the
+  authority on validity).
+- **202 approval-pending is a state, not an exception**, so approval workflows
+  are first-class rather than error handling.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -13,7 +13,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "AGENT-BOOTSTRAP.md"
   ],
   "scripts": {
     "build": "tsc",

--- a/packages/sdk/src/__tests__/agent-client-mock-server.ts
+++ b/packages/sdk/src/__tests__/agent-client-mock-server.ts
@@ -1,0 +1,350 @@
+/**
+ * agent-client-mock-server.ts — a faithful in-process mock of the A1 capability
+ * plane, wired as a `fetch` impl. It performs REAL P-256 verification of the
+ * enrollment signature (so a wrong key / tampered signature genuinely fails) and
+ * mints REAL signed JWTs with an `exp` claim (so the client's expiry/renewal
+ * scheduling is exercised against real tokens, not stubs).
+ *
+ * It deliberately mirrors A1's exact wire contracts:
+ *   POST /agent-enroll/challenge  → { ok, data:{ agentId, nonce, canonicalString, expiresAt } }
+ *   POST /agent-enroll/verify     → { ok, data:{ token, agentId, tenantId, scope, scopes, expiresIn } }
+ *   GET  /capabilities/manifest   → { ok, data:{ manifest:[...] } }
+ *   POST /capabilities/manifest/:id/{issue,renew} → token|broker envelope
+ *   POST /capabilities/:name/invoke → success | 202 pending | gate deny
+ *
+ * Only what the client depends on is modelled; it is not the real server.
+ */
+
+import { SignJWT } from "jose";
+
+const AGENT_ENROLL_DOMAIN = "steward:agent-enroll:v1";
+const JWT_SECRET = new TextEncoder().encode("mock-agent-client-jwt-secret-32chars-min!");
+
+function b64ToBytes(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i += 1) out[i] = bin.charCodeAt(i);
+  return out;
+}
+function bytesToB64(bytes: Uint8Array): string {
+  let bin = "";
+  for (let i = 0; i < bytes.length; i += 1) bin += String.fromCharCode(bytes[i]);
+  return btoa(bin);
+}
+
+export interface MockSignerRow {
+  agentId: string;
+  tenantId: string;
+  /** raw uncompressed 04||X||Y base64 public key. */
+  publicKeyRawBase64: string;
+  status: "active" | "revoked";
+}
+
+export interface MockManifestEntry {
+  manifest: string;
+  provider: string;
+  kind: string;
+  capabilityName: string;
+  capabilityId: string;
+  grantExpiresAt: string | null;
+  mode: "token" | "broker";
+}
+
+export interface MockServerOptions {
+  signers: MockSignerRow[];
+  manifest?: MockManifestEntry[];
+  /** default seconds the enroll token lives (drives exp claim). default 300. */
+  enrollTtlSeconds?: number;
+  /** capability names whose invoke should return 202 pending. */
+  approvalRequired?: Set<string>;
+  /** capability names whose invoke should return a gate deny (status, message). */
+  denies?: Map<string, { status: number; message: string }>;
+  /** the (mock) upstream body a successful invoke returns. */
+  invokeBody?: unknown;
+  now?: () => number;
+}
+
+/** Generate a P-256 keypair; returns the private CryptoKey + raw-base64 pubkey. */
+export async function generateMockKeyPair(): Promise<{
+  privateKey: CryptoKey;
+  publicKeyRawBase64: string;
+  pkcs8Base64: string;
+}> {
+  const pair = (await crypto.subtle.generateKey({ name: "ECDSA", namedCurve: "P-256" }, true, [
+    "sign",
+    "verify",
+  ])) as CryptoKeyPair;
+  const raw = new Uint8Array(await crypto.subtle.exportKey("raw", pair.publicKey));
+  const pkcs8 = new Uint8Array(await crypto.subtle.exportKey("pkcs8", pair.privateKey));
+  return {
+    privateKey: pair.privateKey,
+    publicKeyRawBase64: bytesToB64(raw),
+    pkcs8Base64: bytesToB64(pkcs8),
+  };
+}
+
+interface Challenge {
+  agentId: string;
+  nonce: string;
+  issuedAt: number;
+  canonicalString: string;
+}
+
+export class MockStewardServer {
+  private readonly signers: MockSignerRow[];
+  private manifestEntries: MockManifestEntry[];
+  private readonly enrollTtlSeconds: number;
+  private readonly approvalRequired: Set<string>;
+  private readonly denies: Map<string, { status: number; message: string }>;
+  private readonly invokeBody: unknown;
+  private readonly now: () => number;
+
+  private readonly challenges = new Map<string, Challenge>();
+  /** revoked jti values (broker-token-level revocation simulation). */
+  readonly revokedJti = new Set<string>();
+
+  /** counters for assertions. */
+  challengeCount = 0;
+  verifyCount = 0;
+  issueCount = 0;
+
+  constructor(opts: MockServerOptions) {
+    this.signers = opts.signers;
+    this.manifestEntries = opts.manifest ?? [];
+    this.enrollTtlSeconds = opts.enrollTtlSeconds ?? 300;
+    this.approvalRequired = opts.approvalRequired ?? new Set();
+    this.denies = opts.denies ?? new Map();
+    this.invokeBody = opts.invokeBody ?? { ok: true };
+    this.now = opts.now ?? (() => Date.now());
+  }
+
+  setManifest(entries: MockManifestEntry[]): void {
+    this.manifestEntries = entries;
+  }
+  revokeSigner(agentId: string): void {
+    for (const s of this.signers) if (s.agentId === agentId) s.status = "revoked";
+  }
+  activeSigner(agentId: string): MockSignerRow | undefined {
+    return this.signers.find((s) => s.agentId === agentId && s.status === "active");
+  }
+
+  /** the fetch impl to hand the AgentClient. */
+  fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url = typeof input === "string" ? input : input.toString();
+    const path = new URL(url, "http://mock").pathname;
+    const method = (init?.method ?? "GET").toUpperCase();
+    const auth = new Headers(init?.headers).get("Authorization") ?? "";
+    const body = init?.body ? JSON.parse(init.body as string) : {};
+
+    if (path === "/agent-enroll/challenge" && method === "POST") {
+      return this.handleChallenge(body);
+    }
+    if (path === "/agent-enroll/verify" && method === "POST") {
+      return this.handleVerify(body);
+    }
+    if (path === "/capabilities/manifest" && method === "GET") {
+      return this.handleManifest(auth);
+    }
+    const issueMatch = path.match(/^\/capabilities\/manifest\/([^/]+)\/(issue|renew)$/);
+    if (issueMatch && method === "POST") {
+      return this.handleIssue(auth, decodeURIComponent(issueMatch[1]), body);
+    }
+    const invokeMatch = path.match(/^\/capabilities\/([^/]+)\/invoke$/);
+    if (invokeMatch && method === "POST") {
+      return this.handleInvoke(auth, decodeURIComponent(invokeMatch[1]));
+    }
+    return this.json({ ok: false, error: "not found" }, 404);
+  };
+
+  private json(payload: unknown, status = 200): Response {
+    return new Response(JSON.stringify(payload), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  private handleChallenge(body: { agentId?: string }): Response {
+    this.challengeCount += 1;
+    const agentId = String(body.agentId ?? "");
+    if (!agentId) return this.json({ ok: false, error: "agentId required" }, 400);
+    const nonce = crypto.randomUUID();
+    const issuedAt = this.now();
+    const canonicalString = [AGENT_ENROLL_DOMAIN, agentId, nonce, String(issuedAt)].join("\n");
+    this.challenges.set(`${agentId}:${nonce}`, { agentId, nonce, issuedAt, canonicalString });
+    return this.json({
+      ok: true,
+      data: { agentId, nonce, canonicalString, expiresAt: issuedAt + 120_000 },
+    });
+  }
+
+  private async handleVerify(body: {
+    agentId?: string;
+    nonce?: string;
+    signature?: string;
+  }): Promise<Response> {
+    this.verifyCount += 1;
+    const agentId = String(body.agentId ?? "");
+    const nonce = String(body.nonce ?? "");
+    const signature = String(body.signature ?? "");
+    const key = `${agentId}:${nonce}`;
+    const challenge = this.challenges.get(key);
+    // consume BEFORE verify (single-use), mirroring A1.
+    this.challenges.delete(key);
+    if (!challenge) return this.json({ ok: false, error: "enrollment denied" }, 401);
+
+    const signer = this.activeSigner(agentId);
+    if (!signer) return this.json({ ok: false, error: "enrollment denied" }, 401);
+
+    const ok = await this.verifyP256(
+      signer.publicKeyRawBase64,
+      challenge.canonicalString,
+      signature,
+    );
+    if (!ok) return this.json({ ok: false, error: "enrollment denied" }, 401);
+
+    const token = await this.mintToken(agentId, signer.tenantId, ["agent"], this.enrollTtlSeconds);
+    return this.json({
+      ok: true,
+      data: {
+        token,
+        agentId,
+        tenantId: signer.tenantId,
+        scope: "agent",
+        scopes: ["agent"],
+        expiresIn: `${this.enrollTtlSeconds}s`,
+      },
+    });
+  }
+
+  private async handleManifest(auth: string): Promise<Response> {
+    const claims = await this.authAgent(auth);
+    if (!claims) return this.json({ ok: false, error: "agent authentication required" }, 401);
+    return this.json({
+      ok: true,
+      data: {
+        manifest: this.manifestEntries.map(({ mode: _mode, ...rest }) => rest),
+      },
+    });
+  }
+
+  private async handleIssue(
+    auth: string,
+    manifestId: string,
+    body: { ttlSeconds?: number },
+  ): Promise<Response> {
+    this.issueCount += 1;
+    const claims = await this.authAgent(auth);
+    if (!claims) return this.json({ ok: false, error: "agent authentication required" }, 401);
+    const entry = this.manifestEntries.find((m) => m.manifest === manifestId);
+    if (!entry) return this.json({ ok: false, error: "capability not granted to agent" }, 403);
+
+    if (entry.mode === "broker") {
+      return this.json({
+        ok: true,
+        mode: "broker",
+        delegation: {
+          capabilityName: entry.capabilityName,
+          method: "POST",
+          note: `broker mode: exercise via POST /capabilities/${entry.capabilityName}/invoke`,
+        },
+        manifest: entry.manifest,
+        capabilityId: entry.capabilityId,
+      });
+    }
+    const ttl = body.ttlSeconds ?? 120;
+    if (ttl <= 0 || ttl > 300) {
+      return this.json({ ok: false, error: "ttl must be 1-300 seconds" }, 400);
+    }
+    const scope = `cap:${entry.manifest}`;
+    const jti = crypto.randomUUID();
+    const token = await this.mintToken(claims.agentId, claims.tenantId, [scope], ttl, jti);
+    return this.json({
+      ok: true,
+      mode: "token",
+      token,
+      jti,
+      ttlSeconds: ttl,
+      scopes: [scope],
+      manifest: entry.manifest,
+      capabilityId: entry.capabilityId,
+    });
+  }
+
+  private async handleInvoke(auth: string, name: string): Promise<Response> {
+    const claims = await this.authAgent(auth);
+    if (!claims) return this.json({ ok: false, error: "agent authentication required" }, 401);
+    const deny = this.denies.get(name);
+    if (deny) return this.json({ ok: false, error: deny.message }, deny.status);
+    if (this.approvalRequired.has(name)) {
+      return this.json(
+        { ok: true, data: { approvalId: crypto.randomUUID(), status: "pending" } },
+        202,
+      );
+    }
+    return this.json({ ok: true, data: this.invokeBody });
+  }
+
+  // ── crypto ────────────────────────────────────────────────────────────────
+  private async verifyP256(
+    publicKeyRawBase64: string,
+    canonicalString: string,
+    signatureBase64: string,
+  ): Promise<boolean> {
+    try {
+      const key = await crypto.subtle.importKey(
+        "raw",
+        b64ToBytes(publicKeyRawBase64),
+        { name: "ECDSA", namedCurve: "P-256" },
+        false,
+        ["verify"],
+      );
+      return await crypto.subtle.verify(
+        { name: "ECDSA", hash: "SHA-256" },
+        key,
+        b64ToBytes(signatureBase64),
+        new TextEncoder().encode(canonicalString),
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  private async mintToken(
+    agentId: string,
+    tenantId: string,
+    scopes: string[],
+    ttlSeconds: number,
+    jti?: string,
+  ): Promise<string> {
+    const iat = Math.floor(this.now() / 1000);
+    const builder = new SignJWT({ agentId, tenantId, scopes })
+      .setProtectedHeader({ alg: "HS256" })
+      .setIssuedAt(iat)
+      .setExpirationTime(iat + ttlSeconds);
+    if (jti) builder.setJti(jti);
+    return builder.sign(JWT_SECRET);
+  }
+
+  /** Verify a bearer agent token; returns claims or null. Honours revoked jti. */
+  private async authAgent(
+    auth: string,
+  ): Promise<{ agentId: string; tenantId: string; scopes: string[]; jti?: string } | null> {
+    const m = auth.match(/^Bearer (.+)$/);
+    if (!m) return null;
+    try {
+      const { jwtVerify } = await import("jose");
+      const { payload } = await jwtVerify(m[1], JWT_SECRET, {
+        currentDate: new Date(this.now()),
+      });
+      if (payload.jti && this.revokedJti.has(payload.jti)) return null;
+      return {
+        agentId: String(payload.agentId),
+        tenantId: String(payload.tenantId),
+        scopes: (payload.scopes as string[]) ?? [],
+        jti: payload.jti,
+      };
+    } catch {
+      return null;
+    }
+  }
+}

--- a/packages/sdk/src/__tests__/agent-client.test.ts
+++ b/packages/sdk/src/__tests__/agent-client.test.ts
@@ -1,0 +1,362 @@
+/**
+ * agent-client.test.ts — mocked-server unit tests for the A3 sovereign-custody
+ * agent client. The mock server performs REAL P-256 verification and mints REAL
+ * signed JWTs, so these prove the client's crypto interoperates, not just its
+ * plumbing. Covers: keypair-only enroll, wrong-key/tamper fail-closed, manifest,
+ * token & broker issue/renew, broker invoke, 202 approval as a first-class state,
+ * revocation mid-session (renewal MUST fail closed — bidirectional proof),
+ * clock-skew tolerance, and key-leak guards.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  AgentClient,
+  AgentClientError,
+  type AgentClientEvent,
+  AgentKeypair,
+  NotEnrolledError,
+} from "../index";
+import {
+  generateMockKeyPair,
+  type MockManifestEntry,
+  MockStewardServer,
+} from "./agent-client-mock-server";
+
+const AGENT_ID = "agent-soliza";
+const TENANT_ID = "tenant-acme";
+
+const MANIFEST: MockManifestEntry[] = [
+  {
+    manifest: "github:app:org",
+    provider: "github",
+    kind: "app",
+    capabilityName: "gh-comment",
+    capabilityId: "cap-gh",
+    grantExpiresAt: null,
+    mode: "token",
+  },
+  {
+    manifest: "discord:bot-token:soliza",
+    provider: "discord",
+    kind: "bot-token",
+    capabilityName: "discord-send",
+    capabilityId: "cap-discord",
+    grantExpiresAt: null,
+    mode: "broker",
+  },
+];
+
+async function setup(opts?: {
+  approvalRequired?: Set<string>;
+  denies?: Map<string, { status: number; message: string }>;
+  enrollTtlSeconds?: number;
+  now?: () => number;
+}) {
+  const kp = await generateMockKeyPair();
+  const server = new MockStewardServer({
+    signers: [
+      {
+        agentId: AGENT_ID,
+        tenantId: TENANT_ID,
+        publicKeyRawBase64: kp.publicKeyRawBase64,
+        status: "active",
+      },
+    ],
+    manifest: MANIFEST,
+    approvalRequired: opts?.approvalRequired,
+    denies: opts?.denies,
+    enrollTtlSeconds: opts?.enrollTtlSeconds,
+    now: opts?.now,
+    invokeBody: { messageId: "123", channel: "general" },
+  });
+  const keypair = await AgentKeypair.fromPkcs8Base64(kp.pkcs8Base64);
+  const client = new AgentClient({
+    baseUrl: "http://mock",
+    agentId: AGENT_ID,
+    keypair,
+    fetchImpl: server.fetch,
+    now: opts?.now,
+    renewJitterMs: 0,
+  });
+  return { server, client, kp };
+}
+
+const clients: AgentClient[] = [];
+afterEach(() => {
+  for (const c of clients) c.stopRenewalLoop();
+  clients.length = 0;
+});
+
+describe("AgentClient — enroll (keypair-only boot)", () => {
+  test("boots with keypair only and gets a short-lived agent token", async () => {
+    const { client, server } = await setup();
+    const result = await client.enroll();
+    expect(result.agentId).toBe(AGENT_ID);
+    expect(result.tenantId).toBe(TENANT_ID);
+    expect(result.scopes).toEqual(["agent"]);
+    expect(result.expiresAt).toBeGreaterThan(Date.now());
+    expect(client.isEnrolled()).toBe(true);
+    expect(server.challengeCount).toBe(1);
+    expect(server.verifyCount).toBe(1);
+  });
+
+  test("emits an 'enrolled' event", async () => {
+    const { client } = await setup();
+    const events: AgentClientEvent[] = [];
+    client.on((e) => events.push(e));
+    await client.enroll();
+    expect(events.some((e) => e.type === "enrolled")).toBe(true);
+  });
+
+  test("WRONG key fails closed (bidirectional): a mismatched signer cannot enroll", async () => {
+    // fails-before: swap in an unrelated keypair, enroll must be denied.
+    const { server } = await setup();
+    const wrong = await generateMockKeyPair();
+    const wrongKeypair = await AgentKeypair.fromPkcs8Base64(wrong.pkcs8Base64);
+    const client = new AgentClient({
+      baseUrl: "http://mock",
+      agentId: AGENT_ID,
+      keypair: wrongKeypair,
+      fetchImpl: server.fetch,
+      renewJitterMs: 0,
+    });
+    await expect(client.enroll()).rejects.toBeInstanceOf(AgentClientError);
+    expect(client.isEnrolled()).toBe(false);
+    // passes-after: the correct key enrolls fine (same server, same agent).
+    const correct = await generateMockKeyPair();
+    server.activeSigner(AGENT_ID)!.publicKeyRawBase64 = correct.publicKeyRawBase64;
+    const good = new AgentClient({
+      baseUrl: "http://mock",
+      agentId: AGENT_ID,
+      keypair: await AgentKeypair.fromPkcs8Base64(correct.pkcs8Base64),
+      fetchImpl: server.fetch,
+      renewJitterMs: 0,
+    });
+    await expect(good.enroll()).resolves.toMatchObject({ agentId: AGENT_ID });
+  });
+
+  test("unknown agent (no active signer) is denied", async () => {
+    const { server, kp } = await setup();
+    server.revokeSigner(AGENT_ID);
+    const client = new AgentClient({
+      baseUrl: "http://mock",
+      agentId: AGENT_ID,
+      keypair: await AgentKeypair.fromPkcs8Base64(kp.pkcs8Base64),
+      fetchImpl: server.fetch,
+      renewJitterMs: 0,
+    });
+    await expect(client.enroll()).rejects.toBeInstanceOf(AgentClientError);
+  });
+});
+
+describe("AgentClient — manifest + issuance", () => {
+  test("manifest returns typed entries (no mode leakage of secrets)", async () => {
+    const { client } = await setup();
+    await client.enroll();
+    const manifest = await client.manifest();
+    expect(manifest.map((m) => m.manifest).sort()).toEqual([
+      "discord:bot-token:soliza",
+      "github:app:org",
+    ]);
+    expect(manifest[0]).toHaveProperty("provider");
+    expect(manifest[0]).toHaveProperty("capabilityName");
+  });
+
+  test("token-mode issue returns a short-lived scoped token with an exp", async () => {
+    const { client } = await setup();
+    await client.enroll();
+    const cap = await client.issue("github:app:org", { ttlSeconds: 120 });
+    expect(cap.mode).toBe("token");
+    if (cap.mode !== "token") throw new Error("expected token mode");
+    expect(cap.scopes).toEqual(["cap:github:app:org"]);
+    expect(cap.token.split(".")).toHaveLength(3);
+    expect(cap.expiresAt).toBeGreaterThan(Date.now());
+    expect(cap.jti).toBeTruthy();
+  });
+
+  test("broker-mode issue returns a delegation (NO token)", async () => {
+    const { client } = await setup();
+    await client.enroll();
+    const cap = await client.issue("discord:bot-token:soliza");
+    expect(cap.mode).toBe("broker");
+    if (cap.mode !== "broker") throw new Error("expected broker mode");
+    expect(cap.delegation.capabilityName).toBe("discord-send");
+    expect(cap).not.toHaveProperty("token");
+  });
+
+  test("renew hits the same path and re-mints", async () => {
+    const { client } = await setup();
+    await client.enroll();
+    const a = await client.issue("github:app:org");
+    const b = await client.renew("github:app:org");
+    if (a.mode !== "token" || b.mode !== "token") throw new Error("expected token mode");
+    expect(b.jti).not.toBe(a.jti);
+  });
+
+  test("out-of-range ttl is rejected (400)", async () => {
+    const { client } = await setup();
+    await client.enroll();
+    await expect(client.issue("github:app:org", { ttlSeconds: 99999 })).rejects.toMatchObject({
+      status: 400,
+    });
+  });
+
+  test("manifest/issue before enroll throws NotEnrolledError", async () => {
+    const { client } = await setup();
+    await expect(client.manifest()).rejects.toBeInstanceOf(NotEnrolledError);
+    await expect(client.issue("github:app:org")).rejects.toBeInstanceOf(NotEnrolledError);
+  });
+});
+
+describe("AgentClient — broker invoke", () => {
+  test("successful invoke returns the scrubbed upstream body", async () => {
+    const { client } = await setup();
+    await client.enroll();
+    const res = await client.invoke("discord-send", { body: { content: "hi" } });
+    expect(res.status).toBe("ok");
+    if (res.status !== "ok") throw new Error("expected ok");
+    expect(res.data).toMatchObject({ messageId: "123" });
+  });
+
+  test("202 approval-pending is a FIRST-CLASS state, not an exception", async () => {
+    const { client } = await setup({ approvalRequired: new Set(["discord-send"]) });
+    await client.enroll();
+    const res = await client.invoke("discord-send", { body: { content: "hi" } });
+    expect(res.status).toBe("pending_approval");
+    if (res.status !== "pending_approval") throw new Error("expected pending");
+    expect(res.approvalId).toBeTruthy();
+  });
+
+  test("gate deny (403) throws a typed AgentClientError with status", async () => {
+    const { client } = await setup({
+      denies: new Map([["discord-send", { status: 403, message: "capability intent denied" }]]),
+    });
+    await client.enroll();
+    await expect(client.invoke("discord-send")).rejects.toMatchObject({
+      status: 403,
+      message: "capability intent denied",
+    });
+  });
+
+  test("invoke before enroll throws NotEnrolledError", async () => {
+    const { client } = await setup();
+    await expect(client.invoke("discord-send")).rejects.toBeInstanceOf(NotEnrolledError);
+  });
+});
+
+describe("AgentClient — revocation mid-session (fail-closed)", () => {
+  test("renewal after signer revocation FAILS CLOSED (bidirectional proof)", async () => {
+    // passes-before-revocation: client is enrolled and can call authed endpoints.
+    const { client, server } = await setup();
+    const events: AgentClientEvent[] = [];
+    client.on((e) => events.push(e));
+    await client.enroll();
+    expect(client.isEnrolled()).toBe(true);
+    await expect(client.manifest()).resolves.toBeDefined();
+
+    // revoke the signer, then force a renewal (what the loop does on a timer).
+    server.revokeSigner(AGENT_ID);
+    await client["renewOnce"](); // exercise the private renewal path directly
+
+    // fails-after: no token, unauthenticated state, authed calls now throw.
+    expect(client.isEnrolled()).toBe(false);
+    expect(events.some((e) => e.type === "renew_failed")).toBe(true);
+    expect(events.some((e) => e.type === "unauthenticated")).toBe(true);
+    await expect(client.manifest()).rejects.toBeInstanceOf(NotEnrolledError);
+  });
+
+  test("a 401 from an authed call (token revoked mid-flight) fails closed", async () => {
+    const { client, server } = await setup();
+    await client.enroll();
+    // Simulate the server rejecting the (still-held) token by revoking its jti.
+    // Force the agent token's jti into the revoked set by re-minting is complex;
+    // instead revoke the signer AND expire logic via 401: monkeypatch the server
+    // to reject the next authed call.
+    const realFetch = server.fetch;
+    let calls = 0;
+    (client as unknown as { fetchImpl: typeof fetch }).fetchImpl = async (u, i) => {
+      calls += 1;
+      return new Response(JSON.stringify({ ok: false, error: "unauthorized" }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      });
+    };
+    await expect(client.manifest()).rejects.toBeInstanceOf(AgentClientError);
+    expect(client.isEnrolled()).toBe(false); // failed closed on the 401
+    void realFetch;
+    void calls;
+  });
+
+  test("no stale-token reuse: after fail-closed, invoke refuses until re-enroll", async () => {
+    const { client, server } = await setup();
+    await client.enroll();
+    server.revokeSigner(AGENT_ID);
+    await client["renewOnce"]();
+    await expect(client.invoke("discord-send")).rejects.toBeInstanceOf(NotEnrolledError);
+    // re-activate + re-enroll heals it.
+    server.activeSigner(AGENT_ID); // still revoked; reactivate:
+    (server as unknown as { signers: { agentId: string; status: string }[] }).signers.forEach(
+      (s) => {
+        if (s.agentId === AGENT_ID) s.status = "active";
+      },
+    );
+    await client.enroll();
+    expect(client.isEnrolled()).toBe(true);
+  });
+});
+
+describe("AgentClient — clock-skew tolerance", () => {
+  test("schedules renewal before expiry even under modest skew (no throw)", async () => {
+    // Server clock is 20s ahead of the client; tokens still parse and the client
+    // schedules a renewal without error. We assert the token's exp is read and in
+    // the future relative to the client, and the loop can be started/stopped.
+    let clientNow = 1_000_000_000_000;
+    const serverNow = () => clientNow + 20_000; // server 20s ahead
+    const { client } = await setup({ enrollTtlSeconds: 300, now: serverNow });
+    // client uses its own clock:
+    (client as unknown as { now: () => number }).now = () => clientNow;
+    (client as unknown as { clockSkewToleranceMs: number }).clockSkewToleranceMs = 30_000;
+    const res = await client.enroll();
+    expect(res.expiresAt).not.toBeNull();
+    // exp is ~300s ahead of the SERVER clock, i.e. > client now.
+    expect(res.expiresAt!).toBeGreaterThan(clientNow);
+    client.startRenewalLoop();
+    clients.push(client);
+    // advance the client clock near expiry; isEnrolled still true within skew.
+    clientNow += 250_000;
+    expect(client.isEnrolled()).toBe(true);
+  });
+});
+
+describe("AgentKeypair — key never leaks", () => {
+  test("toString / toJSON / inspect are redacted", async () => {
+    const kp = await generateMockKeyPair();
+    const keypair = await AgentKeypair.fromPkcs8Base64(kp.pkcs8Base64);
+    expect(String(keypair)).toBe("[AgentKeypair: private key redacted]");
+    expect(JSON.stringify({ k: keypair })).toContain("redacted");
+    expect(`${keypair}`).toContain("redacted");
+    // no method returns raw key material.
+    expect(Object.keys(keypair)).not.toContain("privateKey");
+  });
+
+  test("sign produces a base64 P1363 signature the server accepts", async () => {
+    const { client } = await setup();
+    // enroll succeeding IS the proof the signature verified server-side.
+    await expect(client.enroll()).resolves.toBeDefined();
+  });
+
+  test("rejects a non-P256 / non-private CryptoKey", async () => {
+    const rsa = (await crypto.subtle.generateKey(
+      {
+        name: "RSA-PSS",
+        modulusLength: 2048,
+        publicExponent: new Uint8Array([1, 0, 1]),
+        hash: "SHA-256",
+      },
+      true,
+      ["sign", "verify"],
+    )) as CryptoKeyPair;
+    await expect(AgentKeypair.fromCryptoKey(rsa.privateKey)).rejects.toThrow();
+    await expect(AgentKeypair.fromCryptoKey(rsa.publicKey)).rejects.toThrow();
+  });
+});

--- a/packages/sdk/src/agent-client.ts
+++ b/packages/sdk/src/agent-client.ts
@@ -1,0 +1,590 @@
+/**
+ * agent-client.ts — @stwd/sdk agent-side capability client (lane A3).
+ *
+ * The sovereign-custody client: an Eliza/agent process boots holding NOTHING but
+ * its P-256 identity keypair (+ the Steward base URL) and obtains everything else
+ * at runtime:
+ *
+ *     boot(keypair)                       ← no token, no API key, no secret
+ *       └─ enroll()                       ← challenge/response → short-lived agent token
+ *            └─ manifest()               ← what capabilities may I request?
+ *                 ├─ issue()/renew()     ← token-mode: short-lived scoped token
+ *                 └─ invoke()            ← broker-mode: Steward performs the call
+ *       └─ renewal loop                   ← re-enroll before expiry (fail-closed)
+ *
+ * Contrast with the OLD flow (`POST /agents/:id/token`, ≤30d operator-minted
+ * token baked into the container env): the operator's ONE job here is to register
+ * the agent's PUBLIC key once (`agent_signers`, keyType=p256). No secret ever
+ * lands in a cloud env var, and revocation (flip the signer to revoked, or
+ * revoke a grant) takes effect within one short renewal cycle — the client
+ * fails closed to unauthenticated on any renewal failure and never reuses a
+ * stale token.
+ *
+ * This file layers on the A1 API surface documented in the receipt:
+ *   POST /agent-enroll/challenge, /agent-enroll/verify          (public)
+ *   GET  /capabilities/manifest                                  (agent-jwt)
+ *   POST /capabilities/manifest/:id/issue|renew                  (agent-jwt)
+ *   POST /capabilities/:name/invoke                              (agent-jwt)
+ *
+ * It uses only WebCrypto + fetch (vendor-neutral, browser+Node+Bun). The private
+ * key never leaves `AgentKeypair` and is never logged.
+ */
+
+import { AgentKeypair } from "./agent-keypair.ts";
+
+// ─── Errors ───────────────────────────────────────────────────────────────────
+
+/** A typed error carrying the HTTP status + machine-readable code from Steward. */
+export class AgentClientError extends Error {
+  readonly status: number;
+  readonly code?: string;
+  readonly data?: unknown;
+  constructor(message: string, status: number, opts?: { code?: string; data?: unknown }) {
+    super(message);
+    this.name = "AgentClientError";
+    this.status = status;
+    this.code = opts?.code;
+    this.data = opts?.data;
+  }
+}
+
+/**
+ * Thrown when the client is asked to do something requiring a live agent token
+ * but it has none (never enrolled, or it fail-closed after a renewal failure /
+ * revocation). Distinct from a server 401 so callers can branch on it.
+ */
+export class NotEnrolledError extends AgentClientError {
+  constructor(message = "agent is not enrolled (no live token)") {
+    super(message, 0, { code: "not_enrolled" });
+    this.name = "NotEnrolledError";
+  }
+}
+
+// ─── Public shapes ──────────────────────────────────────────────────────────
+
+export interface EnrollResult {
+  agentId: string;
+  tenantId: string;
+  scopes: string[];
+  /** epoch ms at which the current agent token expires (best-effort, from JWT exp). */
+  expiresAt: number | null;
+}
+
+/** One manifest entry the agent may request (mirrors A1 `ManifestListing`). */
+export interface ManifestEntry {
+  manifest: string;
+  provider: string;
+  kind: string;
+  capabilityName: string;
+  capabilityId: string;
+  grantExpiresAt: string | null;
+}
+
+/** Result of a token-mode issue/renew: a short-lived scoped token. */
+export interface TokenCapability {
+  mode: "token";
+  token: string;
+  jti: string;
+  ttlSeconds: number;
+  scopes: string[];
+  manifest: string;
+  capabilityId: string;
+  /** epoch ms at which this capability token expires. */
+  expiresAt: number;
+}
+
+/** Result of a broker-mode issue: how to exercise the capability via invoke(). */
+export interface BrokerCapability {
+  mode: "broker";
+  delegation: { capabilityName: string; method: string; note: string };
+  manifest: string;
+  capabilityId: string;
+}
+
+export type IssuedCapability = TokenCapability | BrokerCapability;
+
+/**
+ * 202 approval-pending is a FIRST-CLASS state, not an exception: a broker invoke
+ * that hits a require-approval policy returns this instead of throwing. Callers
+ * poll or await out-of-band approval, then re-invoke.
+ */
+export interface InvokePendingApproval {
+  status: "pending_approval";
+  approvalId: string | null;
+}
+
+/** A successful broker invoke: the scrubbed upstream body Steward returned. */
+export interface InvokeSuccess<T = unknown> {
+  status: "ok";
+  httpStatus: number;
+  data: T;
+}
+
+export type InvokeResult<T = unknown> = InvokeSuccess<T> | InvokePendingApproval;
+
+// ─── Config + events ──────────────────────────────────────────────────────────
+
+/** Lifecycle events surfaced honestly (no silent failures). */
+export type AgentClientEvent =
+  | { type: "enrolled"; agentId: string; tenantId: string; expiresAt: number | null }
+  | { type: "renewed"; agentId: string; expiresAt: number | null }
+  | { type: "renew_failed"; error: AgentClientError; willRetry: boolean }
+  | { type: "unauthenticated"; reason: string };
+
+export type AgentClientListener = (event: AgentClientEvent) => void;
+
+export interface AgentClientConfig {
+  /** Steward base URL, e.g. https://steward.example / http://localhost:3200. */
+  baseUrl: string;
+  /** the agent's id (matches an `agent_signers` row with an active p256 key). */
+  agentId: string;
+  /** the identity keypair — the only long-lived secret the agent holds. */
+  keypair: AgentKeypair;
+  /**
+   * Renew this many ms BEFORE the token actually expires, so a request is never
+   * made with an about-to-die token. Default 60s. Clamped to < token lifetime.
+   */
+  renewLeadMs?: number;
+  /**
+   * Max jitter (ms) subtracted from the renewal delay so a fleet of agents does
+   * not stampede Steward at the same instant. Default 5000ms.
+   */
+  renewJitterMs?: number;
+  /** injectable clock (tests). */
+  now?: () => number;
+  /** injectable fetch (tests / custom transport). */
+  fetchImpl?: typeof fetch;
+  /**
+   * Tolerance (seconds) applied when reading a token's `exp` claim, to absorb
+   * modest client/server clock skew when scheduling renewal. Default 30s.
+   */
+  clockSkewToleranceSeconds?: number;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Decode a JWT's `exp` (seconds) without verifying — for renewal scheduling
+ * only; the SERVER is the authority on validity. Returns null if unparseable. */
+function readJwtExpMs(token: string): number | null {
+  const parts = token.split(".");
+  if (parts.length !== 3) return null;
+  try {
+    const payloadB64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+    const padded = payloadB64 + "=".repeat((4 - (payloadB64.length % 4)) % 4);
+    const json = JSON.parse(atob(padded)) as { exp?: unknown };
+    if (typeof json.exp !== "number") return null;
+    return json.exp * 1000;
+  } catch {
+    return null;
+  }
+}
+
+// ─── The client ─────────────────────────────────────────────────────────────
+
+export class AgentClient {
+  private readonly baseUrl: string;
+  private readonly agentId: string;
+  private readonly keypair: AgentKeypair;
+  private readonly renewLeadMs: number;
+  private readonly renewJitterMs: number;
+  private readonly now: () => number;
+  private readonly fetchImpl: typeof fetch;
+  private readonly clockSkewToleranceMs: number;
+
+  private token: string | null = null;
+  private tenantId: string | null = null;
+  private scopes: string[] = [];
+  private tokenExpiresAt: number | null = null;
+
+  private renewTimer: ReturnType<typeof setTimeout> | null = null;
+  private renewing = false;
+  private stopped = false;
+
+  private readonly listeners = new Set<AgentClientListener>();
+
+  constructor(config: AgentClientConfig) {
+    if (!config.baseUrl) throw new Error("baseUrl required");
+    if (!config.agentId) throw new Error("agentId required");
+    if (!(config.keypair instanceof AgentKeypair)) {
+      throw new Error("keypair must be an AgentKeypair (the private key never leaves it)");
+    }
+    this.baseUrl = config.baseUrl.replace(/\/+$/, "");
+    this.agentId = config.agentId;
+    this.keypair = config.keypair;
+    this.renewLeadMs = config.renewLeadMs ?? 60_000;
+    this.renewJitterMs = config.renewJitterMs ?? 5_000;
+    this.now = config.now ?? (() => Date.now());
+    this.fetchImpl = config.fetchImpl ?? fetch;
+    this.clockSkewToleranceMs = (config.clockSkewToleranceSeconds ?? 30) * 1000;
+  }
+
+  // ── observability ───────────────────────────────────────────────────────────
+  on(listener: AgentClientListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+  private emit(event: AgentClientEvent): void {
+    for (const l of this.listeners) {
+      try {
+        l(event);
+      } catch {
+        // a listener throwing must never break the client.
+      }
+    }
+  }
+
+  /** Whether the client currently holds a token it believes is live. The SERVER
+   * remains the authority — this is a local best-effort view for callers. */
+  isEnrolled(): boolean {
+    if (!this.token) return false;
+    if (this.tokenExpiresAt === null) return true;
+    return this.now() < this.tokenExpiresAt;
+  }
+
+  getTenantId(): string | null {
+    return this.tenantId;
+  }
+  getScopes(): readonly string[] {
+    return this.scopes;
+  }
+  getTokenExpiresAt(): number | null {
+    return this.tokenExpiresAt;
+  }
+
+  // ── enrollment (keypair-only boot) ────────────────────────────────────────────
+  /**
+   * Enroll: fetch a single-use challenge, sign its canonical string with the
+   * identity key, exchange the signature for a short-lived agent token. This is
+   * the ONLY authentication step; everything downstream rides the resulting
+   * token. Idempotent to call again (re-enroll / manual refresh).
+   */
+  async enroll(): Promise<EnrollResult> {
+    const challenge = await this.postPublic<{
+      agentId: string;
+      nonce: string;
+      canonicalString: string;
+      expiresAt: number;
+    }>("/agent-enroll/challenge", { agentId: this.agentId });
+
+    // Sign EXACTLY the server-provided canonical string (never reconstruct it —
+    // any drift fails closed at verify).
+    const signature = await this.keypair.sign(challenge.canonicalString);
+
+    const verified = await this.postPublic<{
+      token: string;
+      agentId: string;
+      tenantId: string;
+      scope: string;
+      scopes: string[];
+      expiresIn: string;
+    }>("/agent-enroll/verify", {
+      agentId: this.agentId,
+      nonce: challenge.nonce,
+      signature,
+    });
+
+    this.token = verified.token;
+    this.tenantId = verified.tenantId;
+    this.scopes = verified.scopes ?? (verified.scope ? [verified.scope] : []);
+    this.tokenExpiresAt = readJwtExpMs(verified.token);
+
+    const result: EnrollResult = {
+      agentId: verified.agentId,
+      tenantId: verified.tenantId,
+      scopes: this.scopes,
+      expiresAt: this.tokenExpiresAt,
+    };
+    this.emit({
+      type: "enrolled",
+      agentId: result.agentId,
+      tenantId: result.tenantId,
+      expiresAt: result.expiresAt,
+    });
+    return result;
+  }
+
+  /**
+   * Start the background renewal loop: re-enroll (fresh challenge/response) a
+   * lead-time before the current token expires, with jitter. On success emits
+   * `renewed`; on failure emits `renew_failed` AND fails closed (drops the token,
+   * emits `unauthenticated`) — a revoked signer stops enrolling, and we never
+   * keep serving with a token that may have been revoked. The loop keeps trying
+   * (a transient network blip should self-heal) but every attempt in the failed
+   * window operates from the unauthenticated state, so no stale token is reused.
+   */
+  startRenewalLoop(): void {
+    this.stopped = false;
+    this.scheduleRenew();
+  }
+
+  /** Stop the renewal loop (does NOT drop the current token). */
+  stopRenewalLoop(): void {
+    this.stopped = true;
+    if (this.renewTimer) {
+      clearTimeout(this.renewTimer);
+      this.renewTimer = null;
+    }
+  }
+
+  private scheduleRenew(): void {
+    if (this.stopped) return;
+    if (this.renewTimer) clearTimeout(this.renewTimer);
+
+    // If we have no expiry known, retry soon; otherwise renew lead-time early.
+    let delay: number;
+    if (this.tokenExpiresAt === null) {
+      delay = Math.max(0, this.renewLeadMs);
+    } else {
+      const untilExpiry = this.tokenExpiresAt - this.now();
+      const lead = Math.min(this.renewLeadMs, Math.max(0, untilExpiry - 1));
+      delay = Math.max(0, untilExpiry - lead);
+    }
+    // Subtract jitter (never below 0) to de-synchronize a fleet.
+    const jitter = this.renewJitterMs > 0 ? Math.floor(Math.random() * this.renewJitterMs) : 0;
+    delay = Math.max(0, delay - jitter);
+
+    this.renewTimer = setTimeout(() => {
+      void this.renewOnce();
+    }, delay);
+    // Do not keep the process alive purely for renewal (Node/Bun).
+    (this.renewTimer as unknown as { unref?: () => void })?.unref?.();
+  }
+
+  private async renewOnce(): Promise<void> {
+    if (this.stopped || this.renewing) return;
+    this.renewing = true;
+    try {
+      await this.enroll();
+      this.emit({ type: "renewed", agentId: this.agentId, expiresAt: this.tokenExpiresAt });
+    } catch (err) {
+      const error =
+        err instanceof AgentClientError
+          ? err
+          : new AgentClientError(err instanceof Error ? err.message : "renewal failed", 0);
+      // FAIL CLOSED: drop the token so no revoked/stale token is ever reused.
+      this.failClosed(`renewal failed: ${error.message}`);
+      this.emit({ type: "renew_failed", error, willRetry: !this.stopped });
+    } finally {
+      this.renewing = false;
+      this.scheduleRenew();
+    }
+  }
+
+  /** Drop all authenticated state; subsequent authed calls throw NotEnrolledError
+   * until a successful (re-)enroll. */
+  private failClosed(reason: string): void {
+    this.token = null;
+    this.tenantId = null;
+    this.scopes = [];
+    this.tokenExpiresAt = null;
+    this.emit({ type: "unauthenticated", reason });
+  }
+
+  // ── manifest ──────────────────────────────────────────────────────────────────
+  /** Fetch this agent's capability manifest (typed entries). */
+  async manifest(): Promise<ManifestEntry[]> {
+    const data = await this.getAuthed<{ manifest: ManifestEntry[] }>("/capabilities/manifest");
+    return data.manifest;
+  }
+
+  // ── issuance ──────────────────────────────────────────────────────────────────
+  /**
+   * Issue a capability by manifest id. token-mode returns a short-lived scoped
+   * token; broker-mode returns a delegation descriptor (exercise via invoke()).
+   */
+  async issue(manifestId: string, opts?: { ttlSeconds?: number }): Promise<IssuedCapability> {
+    return this.issueOrRenew(manifestId, false, opts);
+  }
+
+  /** Renew a capability (identical security path; refreshes a token-mode token,
+   * re-checks a broker grant). Revocation lands here: a revoked grant → 403. */
+  async renew(manifestId: string, opts?: { ttlSeconds?: number }): Promise<IssuedCapability> {
+    return this.issueOrRenew(manifestId, true, opts);
+  }
+
+  private async issueOrRenew(
+    manifestId: string,
+    isRenewal: boolean,
+    opts?: { ttlSeconds?: number },
+  ): Promise<IssuedCapability> {
+    const path = `/capabilities/manifest/${encodeURIComponent(manifestId)}/${
+      isRenewal ? "renew" : "issue"
+    }`;
+    const raw = await this.postAuthed<
+      | {
+          ok: true;
+          mode: "token";
+          token: string;
+          jti: string;
+          ttlSeconds: number;
+          scopes: string[];
+          manifest: string;
+          capabilityId: string;
+        }
+      | {
+          ok: true;
+          mode: "broker";
+          delegation: { capabilityName: string; method: string; note: string };
+          manifest: string;
+          capabilityId: string;
+        }
+    >(path, opts?.ttlSeconds !== undefined ? { ttlSeconds: opts.ttlSeconds } : {});
+
+    if (raw.mode === "token") {
+      const expFromJwt = readJwtExpMs(raw.token);
+      const expiresAt = expFromJwt ?? this.now() + raw.ttlSeconds * 1000;
+      return {
+        mode: "token",
+        token: raw.token,
+        jti: raw.jti,
+        ttlSeconds: raw.ttlSeconds,
+        scopes: raw.scopes,
+        manifest: raw.manifest,
+        capabilityId: raw.capabilityId,
+        expiresAt,
+      };
+    }
+    return {
+      mode: "broker",
+      delegation: raw.delegation,
+      manifest: raw.manifest,
+      capabilityId: raw.capabilityId,
+    };
+  }
+
+  // ── broker invoke ─────────────────────────────────────────────────────────────
+  /**
+   * Invoke a broker-mode capability: Steward performs the outbound call with the
+   * credential injected server-side; the agent only ever gets a scrubbed body.
+   * 202 approval-pending is returned as a first-class `InvokePendingApproval`
+   * state, NOT thrown. Gate denials (401/403/429/400/…) throw AgentClientError.
+   */
+  async invoke<T = unknown>(
+    name: string,
+    payload?: { args?: Record<string, unknown>; body?: unknown; query?: Record<string, string> },
+  ): Promise<InvokeResult<T>> {
+    if (!this.isEnrolled() || !this.token) {
+      throw new NotEnrolledError();
+    }
+    const res = await this.fetchImpl(
+      `${this.baseUrl}/capabilities/${encodeURIComponent(name)}/invoke`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+          Authorization: `Bearer ${this.token}`,
+        },
+        body: JSON.stringify(payload ?? {}),
+      },
+    ).catch((e: unknown) => {
+      throw new AgentClientError(e instanceof Error ? e.message : "network error", 0);
+    });
+
+    // 202 approval-pending: A1 returns { ok:true, data:{ approvalId, status:"pending" } }.
+    if (res.status === 202) {
+      const body = await this.safeJson(res);
+      const data = (body?.data ?? {}) as { approvalId?: unknown };
+      return {
+        status: "pending_approval",
+        approvalId: typeof data.approvalId === "string" ? data.approvalId : null,
+      };
+    }
+
+    if (res.status === 401) {
+      // The server rejected our token (revoked / expired mid-flight): fail closed.
+      this.failClosed("invoke rejected with 401 (token revoked or expired)");
+    }
+
+    if (!res.ok) {
+      const body = await this.safeJson(res);
+      const errField: unknown = body?.error;
+      const message =
+        (typeof errField === "string" && errField) ||
+        (isRecord(errField) && typeof errField.message === "string" && errField.message) ||
+        `capability invoke failed with status ${res.status}`;
+      throw new AgentClientError(message, res.status, { data: body });
+    }
+
+    // Success. The proxy passes the (scrubbed) upstream body through verbatim; A1
+    // gate successes use the { ok, data } envelope. Prefer `data` when present.
+    const body = await this.safeJson(res);
+    const data = (body && "ok" in body ? (body.data as T) : (body as unknown as T)) ?? (null as T);
+    return { status: "ok", httpStatus: res.status, data };
+  }
+
+  // ── transport ─────────────────────────────────────────────────────────────────
+  private async postPublic<T>(path: string, body: unknown): Promise<T> {
+    const res = await this.fetchImpl(`${this.baseUrl}${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify(body),
+    }).catch((e: unknown) => {
+      throw new AgentClientError(e instanceof Error ? e.message : "network error", 0);
+    });
+    return this.unwrap<T>(res);
+  }
+
+  private async getAuthed<T>(path: string): Promise<T> {
+    return this.authed<T>(path, "GET");
+  }
+  private async postAuthed<T>(path: string, body: unknown): Promise<T> {
+    return this.authed<T>(path, "POST", body);
+  }
+
+  private async authed<T>(path: string, method: "GET" | "POST", body?: unknown): Promise<T> {
+    if (!this.isEnrolled() || !this.token) throw new NotEnrolledError();
+    const res = await this.fetchImpl(`${this.baseUrl}${path}`, {
+      method,
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        Authorization: `Bearer ${this.token}`,
+      },
+      body: method === "POST" ? JSON.stringify(body ?? {}) : undefined,
+    }).catch((e: unknown) => {
+      throw new AgentClientError(e instanceof Error ? e.message : "network error", 0);
+    });
+    if (res.status === 401) {
+      this.failClosed("authed request rejected with 401 (token revoked or expired)");
+    }
+    return this.unwrap<T>(res);
+  }
+
+  private async unwrap<T>(res: Response): Promise<T> {
+    const body = await this.safeJson(res);
+    if (!res.ok || body?.ok === false) {
+      const message =
+        (typeof body?.error === "string" && body.error) ||
+        `request failed with status ${res.status}`;
+      throw new AgentClientError(message, res.status, { data: body?.data });
+    }
+    return (body?.data ?? body) as T;
+  }
+
+  private async safeJson(res: Response): Promise<Record<string, unknown> | null> {
+    const text = await res.text().catch(() => "");
+    if (!text) return null;
+    try {
+      const parsed = JSON.parse(text);
+      return isRecord(parsed) ? parsed : { data: parsed };
+    } catch {
+      return null;
+    }
+  }
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/**
+ * One-liner boot helper: construct → enroll → start renewal loop, returning a
+ * ready client. This is the whole "boot with keypair only" story in one call.
+ */
+export async function bootAgentClient(config: AgentClientConfig): Promise<AgentClient> {
+  const client = new AgentClient(config);
+  await client.enroll();
+  client.startRenewalLoop();
+  return client;
+}

--- a/packages/sdk/src/agent-keypair.ts
+++ b/packages/sdk/src/agent-keypair.ts
@@ -1,0 +1,144 @@
+/**
+ * agent-keypair.ts — the agent's identity keypair, the ONLY long-lived secret an
+ * agent process holds (Pillar A, sovereign-custody premise). Everything else
+ * (agent token, capability tokens) is short-lived and obtained at runtime via
+ * enrollment + issuance.
+ *
+ * Hard rules baked in here:
+ *   - the P-256 private key is imported NON-extractable wherever the runtime
+ *     allows it (Node/Bun WebCrypto honours `extractable=false` on `pkcs8`/`jwk`),
+ *     so it can sign but can never be re-exported by the client;
+ *   - there is NO API on `AgentKeypair` that returns the raw private key — the
+ *     only capability exposed is `sign()`;
+ *   - `toString`/`toJSON`/inspection are stubbed to a redacted marker so an
+ *     accidental `console.log(keypair)` (or JSON serialization into a log line)
+ *     can never leak key material.
+ *
+ * Signature format matches the server verifier (`@stwd/auth verifyP256Signature`,
+ * which accepts both P1363 r||s and DER): we emit base64 P1363, identical to the
+ * server-side `signP256` test helper, so an enrollment signature produced here
+ * verifies against the registered `agent_signers.publicKey`.
+ */
+
+const P256_CURVE = "P-256";
+const EC_KEY_PARAMS: EcKeyImportParams = { name: "ECDSA", namedCurve: P256_CURVE };
+const ECDSA_SIGN_PARAMS: EcdsaParams = { name: "ECDSA", hash: "SHA-256" };
+
+const REDACTED = "[AgentKeypair: private key redacted]";
+
+function base64ToBytes(b64: string): Uint8Array {
+  const binary = atob(b64.trim());
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (let i = 0; i < bytes.length; i += 1) binary += String.fromCharCode(bytes[i]);
+  return btoa(binary);
+}
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}
+
+/** Accepted private-key source shapes. All map onto one imported CryptoKey. */
+export type AgentKeyMaterial =
+  | { kind: "pkcs8-base64"; value: string }
+  | { kind: "jwk"; value: JsonWebKey }
+  | { kind: "crypto-key"; value: CryptoKey };
+
+/**
+ * The agent's identity keypair. Construct via the async factories (import is
+ * async in WebCrypto); never via `new`. `sign()` is the only key-using method.
+ */
+export class AgentKeypair {
+  /** the imported, non-extractable (where supported) signing key. */
+  readonly #privateKey: CryptoKey;
+
+  private constructor(privateKey: CryptoKey) {
+    this.#privateKey = privateKey;
+  }
+
+  /**
+   * Import from a PKCS#8 DER private key encoded as base64 (the format an
+   * operator would write to a mounted key file / inject as an env-referenced
+   * path). Imported NON-extractable: the returned keypair can sign but the
+   * client can never re-export the raw key.
+   */
+  static async fromPkcs8Base64(pkcs8Base64: string): Promise<AgentKeypair> {
+    const bytes = base64ToBytes(pkcs8Base64);
+    const key = await crypto.subtle.importKey("pkcs8", toArrayBuffer(bytes), EC_KEY_PARAMS, false, [
+      "sign",
+    ]);
+    return new AgentKeypair(key);
+  }
+
+  /**
+   * Import from a JWK private key. Imported NON-extractable regardless of the
+   * JWK's `ext` flag (we force `extractable=false`).
+   */
+  static async fromJwk(jwk: JsonWebKey): Promise<AgentKeypair> {
+    const key = await crypto.subtle.importKey("jwk", jwk, EC_KEY_PARAMS, false, ["sign"]);
+    return new AgentKeypair(key);
+  }
+
+  /**
+   * Adopt an already-imported CryptoKey (e.g. from a platform keystore / HSM
+   * shim). We assert it is a P-256 private signing key and reject anything else,
+   * fail-closed. If the caller imported it non-extractable, it stays that way.
+   */
+  static async fromCryptoKey(key: CryptoKey): Promise<AgentKeypair> {
+    if (key.type !== "private") throw new Error("agent key must be a private key");
+    const alg = key.algorithm as EcKeyAlgorithm;
+    if (alg?.name !== "ECDSA" || alg?.namedCurve !== P256_CURVE) {
+      throw new Error("agent key must be an ECDSA P-256 key");
+    }
+    if (!key.usages.includes("sign")) throw new Error("agent key must allow 'sign'");
+    return new AgentKeypair(key);
+  }
+
+  /** Unified factory over the accepted source shapes. */
+  static async from(material: AgentKeyMaterial): Promise<AgentKeypair> {
+    switch (material.kind) {
+      case "pkcs8-base64":
+        return AgentKeypair.fromPkcs8Base64(material.value);
+      case "jwk":
+        return AgentKeypair.fromJwk(material.value);
+      case "crypto-key":
+        return AgentKeypair.fromCryptoKey(material.value);
+      default: {
+        const _exhaustive: never = material;
+        throw new Error(`unsupported agent key material: ${JSON.stringify(_exhaustive)}`);
+      }
+    }
+  }
+
+  /**
+   * Sign a canonical string with the identity key, returning a base64 P1363
+   * (r||s) signature — the exact shape the server verifier expects for
+   * enrollment. Never logs, never returns key material.
+   */
+  async sign(canonicalString: string): Promise<string> {
+    const data = new TextEncoder().encode(canonicalString);
+    const sig = new Uint8Array(
+      await crypto.subtle.sign(ECDSA_SIGN_PARAMS, this.#privateKey, toArrayBuffer(data)),
+    );
+    return bytesToBase64(sig);
+  }
+
+  // ── leak guards ─────────────────────────────────────────────────────────────
+  /** Redacted so `console.log(keypair)` / template interpolation can't leak. */
+  toString(): string {
+    return REDACTED;
+  }
+  /** Redacted so `JSON.stringify(keypair)` (e.g. structured logging) can't leak. */
+  toJSON(): string {
+    return REDACTED;
+  }
+  /** Node's util.inspect hook — redacted for the same reason. */
+  [Symbol.for("nodejs.util.inspect.custom")](): string {
+    return REDACTED;
+  }
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,3 +1,22 @@
+export {
+  AgentClient,
+  type AgentClientConfig,
+  AgentClientError,
+  type AgentClientEvent,
+  type AgentClientListener,
+  type BrokerCapability,
+  bootAgentClient,
+  type EnrollResult,
+  type InvokePendingApproval,
+  type InvokeResult,
+  type InvokeSuccess,
+  type IssuedCapability,
+  type ManifestEntry,
+  NotEnrolledError,
+  type TokenCapability,
+} from "./agent-client.ts";
+// A3 — sovereign-custody agent client (keypair-only boot → enroll → manifest → issue/invoke → renew)
+export { type AgentKeyMaterial, AgentKeypair } from "./agent-keypair.ts";
 export { StewardAuth } from "./auth.ts";
 export type {
   SessionStorage,


### PR DESCRIPTION
## Pillar A / lane A3 — sovereign-custody **agent client**

The client side of the capability plane: an Eliza/agent process boots holding
**nothing but its P-256 identity keypair** (+ the Steward base URL) and obtains
everything else at runtime — a short-lived agent token via enrollment, its
capability manifest, and either short-lived scoped tokens (token mode) or
brokered calls (broker mode). **No long-lived secret in any cloud env var.**

### ⛓️ Depends on #247 (A1, `lane/steward-cap-api`)
This PR is **stacked on #247** and branched from `lane/steward-cap-api` so it
builds against the real enroll / manifest / issuance / invoke API. **Retarget to
`develop` once #247 merges** (currently targets `lane/steward-cap-api`).

### Home: `@stwd/sdk` (audited)
`@stwd/sdk` is *"TypeScript client for Steward governed wallet and provider
capability APIs"* and is already consumed by `@stwd/eliza-plugin`. It has
`bearerToken` auth, `StewardApiError`, 202-approval handling and WebCrypto in
place — the correct home. No parallel client package.

### What's in it
- **`AgentKeypair`** — the only long-lived secret. Private key imported
  **non-extractable**, `sign()`-only; `toString`/`toJSON`/inspect **redacted** so
  it can never be logged or re-exported.
- **`AgentClient`** — `enroll()` (p256 challenge/response → short-lived token),
  `manifest()`, `issue()`/`renew()` (token mode) + `invoke()` (broker mode) with
  **202 approval-pending as a first-class state**, typed errors. Background
  **renewal loop with jitter** that **fails closed** (drops the token → drops to
  unauthenticated, **no stale-token reuse** after revocation) with an honest
  event surface. `bootAgentClient()` one-liner.
- **`AGENT-BOOTSTRAP.md`** — full lifecycle (provision → register `agent_signer`
  → keypair-only boot → enroll → manifest → issue/invoke → renewal → revocation),
  explicitly contrasted with the old 30-day operator-minted token flow.

### Tests (no fakes; bidirectional where it matters)
| Suite | Result | Notes |
|---|---|---|
| `sdk/agent-client.test.ts` (mocked server) | **21 pass** | Mock server does **real P-256 verify** + mints **real signed JWTs**. Enroll, **wrong-key/tamper fail-closed (bidirectional)**, manifest, token & broker issue/renew, invoke, **202 approval**, **revocation mid-session → renewal fails closed + no stale reuse**, clock-skew tolerance, key-leak guards. |
| `api/agent-client-e2e.test.ts` (real API) | **1 pass** | Real enroll + manifest + invoke handlers, seeded p256 signer in pglite, **real `@stwd/proxy` broker path** (outbound stubbed): `enroll→manifest→issue(broker)→invoke`. Asserts the credential is injected **server-side** and **never visible to the agent**. |

- Fails-before proof: tampering `AgentKeypair.sign` breaks enrollment (real
  crypto); restoring → all 21 pass.
- `bunx turbo run build` (typecheck) — **green across all 20 packages**.
- Biome — **clean** on all touched files.
- Full `@stwd/sdk` suite — **241 pass / 0 fail** (no regression from `index.ts`).

### Rules compliance
- **No long-lived secret in the client**; no raw-key export; **keypair never logged**.
- **Vendor-neutral**: WebCrypto + fetch only.
- **Production-path**: extends the shipping client + drives the shipping handlers.
- bun + turbo + biome; own worktree/branch; no other branches touched.

### Collision check
- Only `packages/sdk/src/index.ts`, `packages/sdk/package.json`,
  `packages/api/package.json` modified (added `@stwd/sdk` devDep + one line in
  `bun.lock`); everything else is new files. Disjoint from #247's changes and the
  open capabilities/trading PRs.

### Handoff (C3)
`bootAgentClient({ baseUrl, agentId, keypair })` is the whole "boot with keypair
only" story — wire this into the Eliza Cloud container profile for the final
end-to-end test.
