### PR TITLE
feat(policy): per-grant policy engine on the capability invoke path (C1)

### DIFF
--- a/packages/plugin-capabilities/drizzle/0002_grant_policy.sql
+++ b/packages/plugin-capabilities/drizzle/0002_grant_policy.sql
@@ -1,0 +1,29 @@
+-- @stwd/plugin-capabilities migration 0002: per-grant policy + policy-verdict audit (C1).
+--
+-- 1. capability_grants.policy — the per-grant policy document (jsonb) evaluated
+--    at invoke time by @stwd/policy-engine's grant-policy module. EXISTING grants
+--    are backfilled with the EXPLICIT permissive default
+--    ({"version":1,"class":"plain-secret"}) so rollout changes nothing for them:
+--    a plain-secret policy with no constraints allows iff the grant is valid,
+--    which is exactly the pre-policy behavior — but now it is written down
+--    rather than implied. The column stays NULLABLE (with a DEFAULT for new
+--    rows) so strict mode (STEWARD_GRANT_POLICY_STRICT=true) has a real
+--    fail-closed target: a NULL policy denies under strict mode and allows
+--    (explicitly, audited) under compatibility mode.
+--
+-- 2. capability_invocations gains the policy VERDICT columns: which rule fired
+--    (verdict_rule), the human-readable reason (verdict_reason), and the
+--    extracted per-invoke amount in integer micros (amount_micros). amount_micros
+--    on decision IN ('allow','approval','error') rows is the source for the
+--    rolling-window cumulative amount cap (pending approvals and post-
+--    authorization infra errors RESERVE spend so the window can never be
+--    under-counted).
+ALTER TABLE "capability_grants" ADD COLUMN "policy" jsonb DEFAULT '{"version":1,"class":"plain-secret"}'::jsonb;
+--> statement-breakpoint
+UPDATE "capability_grants" SET "policy" = '{"version":1,"class":"plain-secret"}'::jsonb WHERE "policy" IS NULL;
+--> statement-breakpoint
+ALTER TABLE "capability_invocations" ADD COLUMN "verdict_rule" text;
+--> statement-breakpoint
+ALTER TABLE "capability_invocations" ADD COLUMN "verdict_reason" text;
+--> statement-breakpoint
+ALTER TABLE "capability_invocations" ADD COLUMN "amount_micros" bigint;

--- a/packages/plugin-capabilities/drizzle/meta/_journal.json
+++ b/packages/plugin-capabilities/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1782900000000,
       "tag": "0001_capability_invocations",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1783000000000,
+      "tag": "0002_grant_policy",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/plugin-capabilities/src/__tests__/grant-policy-invoke.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/grant-policy-invoke.test.ts
@@ -1,0 +1,451 @@
+/**
+ * grant-policy-invoke.test.ts — the per-GRANT policy layer on the invoke path
+ * (C1), proven at the enforcement point (the mounted invoke route over a real
+ * PGLite with the plugin migrations applied).
+ *
+ * proves BIDIRECTIONALLY (each rule blocks what it should AND allows what it
+ * should) at the HTTP boundary:
+ *   - migration/default: a grant created WITHOUT a policy carries the explicit
+ *     permissive default and behaves exactly as before (allow-through to the
+ *     tenant layer),
+ *   - rate: N-per-window blocks the (N+1)th invoke, allows up to N,
+ *   - amount: per-invoke cap denies; approval threshold => 202 with a pending
+ *     row that RESERVES amountMicros; window cap denies when the rolling sum
+ *     would be exceeded,
+ *   - venue: method allowlist blocks a non-listed method,
+ *   - time: notAfter in the past denies,
+ *   - approval.always: 202 even though the tenant layer allows,
+ *   - malformed policy on the grant: fail-closed 403 (never ignored),
+ *   - strict mode flag: a NULL policy denies iff STEWARD_GRANT_POLICY_STRICT,
+ *   - layering: a grant-policy deny wins over a tenant allow; a tenant deny
+ *     wins over a grant allow (the grant layer can only narrow),
+ *   - audit: every terminal outcome records the verdict rule + reason (+ amount).
+ */
+
+import { afterEach, beforeEach, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { eq } from "@stwd/db";
+import type { AppVariables, PolicyRule } from "@stwd/shared";
+import { Hono } from "hono";
+import type { StewardAppContext } from "../context";
+import { createInvokeRoutes } from "../invoke";
+import { capabilityGrants, capabilityInvocations } from "../schema";
+import { CapabilityStore } from "../store";
+import { ensureAgent, ensureSecret, ensureTenant, type Harness, makeHarness } from "./_harness";
+
+setDefaultTimeout(30000);
+
+let harness: Harness | null = null;
+let tenantId: string;
+let agentId: string;
+let secretId: string;
+let currentPolicySet: PolicyRule[] = [];
+
+/** a tenant-layer capability-intent rule governing github.pr.comment. */
+function capRule(
+  id: string,
+  effect: "allow" | "deny" | "require-approval",
+  capabilities: string[] = ["github.pr.comment"],
+): PolicyRule {
+  return {
+    id,
+    type: "capability-intent" as unknown as PolicyRule["type"],
+    enabled: true,
+    config: { capabilities, effect },
+  };
+}
+
+function buildCtx(db: unknown): StewardAppContext {
+  return {
+    db,
+    vault: {} as never,
+    policyEngine: {} as never,
+    priceOracle: {} as never,
+    async ensureAgentForTenant() {
+      return undefined;
+    },
+    async getPolicySet() {
+      return currentPolicySet;
+    },
+    async safeJsonParse<T>(c: { req: { json(): Promise<unknown> } }): Promise<T | null> {
+      try {
+        return (await c.req.json()) as T;
+      } catch {
+        return null;
+      }
+    },
+    isValidAnyAddress() {
+      return false;
+    },
+    async writeAuditEvent() {},
+    async getAgentTokenStatus() {
+      return null;
+    },
+    getRedisClient() {
+      return null;
+    },
+    async requireAgentJwt() {},
+    async operatorAuth() {},
+    async tenantAuth() {},
+  } as unknown as StewardAppContext;
+}
+
+function buildApp(db: unknown): Hono<{ Variables: AppVariables }> {
+  const app = new Hono<{ Variables: AppVariables }>();
+  app.use("*", async (c, next) => {
+    c.set("tenantId", tenantId);
+    c.set("agentScope", agentId);
+    c.set("authType", "agent-token" as never);
+    await next();
+  });
+  app.route("/capabilities", createInvokeRoutes(buildCtx(db)));
+  return app;
+}
+
+/** create an enabled capability + an active grant (optionally with a policy).
+ *  returns { capId, grantId }. */
+async function seedGrant(
+  policy?: Record<string, unknown>,
+): Promise<{ capId: string; grantId: string }> {
+  const db = harness!.db;
+  const store = new CapabilityStore(db);
+  const cap = await store.createCapability({
+    tenantId,
+    name: "github.pr.comment",
+    spec: {
+      secretId,
+      host: "api.github.com",
+      pathPattern: "/repos/acme/app/issues/1/comments",
+      method: "POST",
+      injectAs: "header",
+      injectKey: "authorization",
+      injectFormat: "Bearer {value}",
+    },
+    constraints: {},
+    enabled: true,
+  });
+  const result = await store.createGrant({
+    tenantId,
+    capabilityId: cap.id,
+    agentId,
+    expiresAt: null,
+    policy,
+  });
+  return { capId: cap.id, grantId: result!.grant.id };
+}
+
+/** write a raw policy value onto the grant, bypassing route validation (models
+ *  a malformed/legacy row: the invoke path must still fail closed). */
+async function setRawGrantPolicy(grantId: string, policy: unknown): Promise<void> {
+  await harness!.db
+    .update(capabilityGrants)
+    .set({ policy })
+    .where(eq(capabilityGrants.id, grantId));
+}
+
+async function invocationRows(capId: string) {
+  const rows = await harness!.db
+    .select()
+    .from(capabilityInvocations)
+    .where(eq(capabilityInvocations.agentId, agentId));
+  return rows.filter((r: { capabilityId: string | null }) => r.capabilityId === capId);
+}
+
+function invoke(app: Hono<{ Variables: AppVariables }>, body?: unknown) {
+  return app.request("/capabilities/github.pr.comment/invoke", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  });
+}
+
+beforeEach(async () => {
+  harness = await makeHarness();
+  tenantId = `tenant-gp-${crypto.randomUUID()}`;
+  agentId = `agent-gp-${crypto.randomUUID()}`;
+  await ensureTenant(harness.db, tenantId);
+  await ensureAgent(harness.db, tenantId, agentId);
+  secretId = await ensureSecret(harness.db, tenantId, "gh-pat");
+  // tenant layer allows by default so the tests isolate the GRANT layer.
+  currentPolicySet = [capRule("tenant-allow", "allow")];
+  delete process.env.STEWARD_PROXY_URL;
+  delete process.env.STEWARD_PROXY_REQUEST_SIGNING_SECRET;
+  delete process.env.STEWARD_PROXY_REQUEST_SIGNING_SECRETS;
+  delete process.env.STEWARD_GRANT_POLICY_STRICT;
+});
+
+afterEach(async () => {
+  await harness?.close();
+  harness = null;
+  delete process.env.STEWARD_PROXY_URL;
+  delete process.env.STEWARD_PROXY_REQUEST_SIGNING_SECRET;
+  delete process.env.STEWARD_PROXY_REQUEST_SIGNING_SECRETS;
+  delete process.env.STEWARD_GRANT_POLICY_STRICT;
+});
+
+// NOTE: proxy env is ABSENT in these tests, so a fully-authorized invoke
+// terminates 503 "capability delegation unavailable" — that status is the
+// proof BOTH policy layers ALLOWED (the decision reached proxy delegation).
+const AUTHORIZED = 503;
+
+describe("grant policy: migration default + compatibility", () => {
+  test("a grant created WITHOUT a policy carries the explicit permissive default", async () => {
+    const { grantId } = await seedGrant();
+    const [row] = await harness!.db
+      .select()
+      .from(capabilityGrants)
+      .where(eq(capabilityGrants.id, grantId));
+    expect(row.policy).toEqual({ version: 1, class: "plain-secret" });
+  });
+
+  test("the default policy allows through to the tenant layer (pre-policy behavior)", async () => {
+    const { capId } = await seedGrant();
+    const app = buildApp(harness!.db);
+    const res = await invoke(app, {});
+    expect(res.status).toBe(AUTHORIZED);
+    const rows = await invocationRows(capId);
+    expect(rows.length).toBe(1);
+    expect(rows[0].decision).toBe("error"); // 503 delegation-unavailable row
+  });
+});
+
+describe("grant policy: rate limit", () => {
+  test("allows up to N then blocks the (N+1)th, auditing the rule", async () => {
+    const { capId } = await seedGrant({
+      version: 1,
+      class: "plain-secret",
+      rate: { maxInvokes: 2, windowSeconds: 3600 },
+    });
+    const app = buildApp(harness!.db);
+    expect((await invoke(app, {})).status).toBe(AUTHORIZED);
+    expect((await invoke(app, {})).status).toBe(AUTHORIZED);
+    const third = await invoke(app, {});
+    expect(third.status).toBe(403);
+    const body = (await third.json()) as { error: string };
+    expect(body.error).toContain("rate limit exceeded");
+    const rows = await invocationRows(capId);
+    const denyRow = rows.find((r: { decision: string }) => r.decision === "deny");
+    expect(denyRow.verdictRule).toBe("grant-policy:rate.limit");
+    expect(denyRow.verdictReason).toContain("rate limit exceeded");
+  });
+});
+
+describe("grant policy: amount limits", () => {
+  const valuePolicy = {
+    version: 1,
+    class: "value-bearing",
+    amount: {
+      argField: "amountMicros",
+      perInvokeMaxMicros: 10_000_000,
+      window: { maxMicros: 15_000_000, windowSeconds: 3600 },
+      approvalOverMicros: 5_000_000,
+    },
+  };
+
+  test("small amount under every bound => authorized, amount audited", async () => {
+    const { capId } = await seedGrant(valuePolicy);
+    const app = buildApp(harness!.db);
+    const res = await invoke(app, { args: { amountMicros: 1_000_000 } });
+    expect(res.status).toBe(AUTHORIZED);
+    const rows = await invocationRows(capId);
+    expect(rows.length).toBe(1);
+    expect(Number(rows[0].amountMicros)).toBe(1_000_000);
+  });
+
+  test("over the per-invoke cap => 403, never softened to approval", async () => {
+    const { capId } = await seedGrant(valuePolicy);
+    const app = buildApp(harness!.db);
+    const res = await invoke(app, { args: { amountMicros: 10_000_001 } });
+    expect(res.status).toBe(403);
+    const rows = await invocationRows(capId);
+    expect(rows[0].decision).toBe("deny");
+    expect(rows[0].verdictRule).toBe("grant-policy:amount.perInvokeMax");
+  });
+
+  test("over the approval threshold (under hard cap) => 202 pending, amount reserved", async () => {
+    const { capId } = await seedGrant(valuePolicy);
+    const app = buildApp(harness!.db);
+    const res = await invoke(app, { args: { amountMicros: 6_000_000 } });
+    expect(res.status).toBe(202);
+    const body = (await res.json()) as {
+      ok: boolean;
+      data: { approvalId: string; status: string };
+    };
+    expect(body.ok).toBe(true);
+    expect(body.data.status).toBe("pending");
+    const rows = await invocationRows(capId);
+    expect(rows.length).toBe(1);
+    expect(rows[0].decision).toBe("approval");
+    expect(rows[0].verdictRule).toBe("grant-policy:amount.approvalOver");
+    expect(Number(rows[0].amountMicros)).toBe(6_000_000);
+  });
+
+  test("rolling window cap: pending approval spend counts, breach denies", async () => {
+    const { capId } = await seedGrant(valuePolicy);
+    const app = buildApp(harness!.db);
+    // 6M -> 202 (reserves 6M in the window). 4M -> authorized (sum 10M). a
+    // further 6M would make 16M > 15M => deny on the window cap.
+    expect((await invoke(app, { args: { amountMicros: 6_000_000 } })).status).toBe(202);
+    expect((await invoke(app, { args: { amountMicros: 4_000_000 } })).status).toBe(AUTHORIZED);
+    const third = await invoke(app, { args: { amountMicros: 6_000_000 } });
+    expect(third.status).toBe(403);
+    const rows = await invocationRows(capId);
+    const denyRow = rows.find((r: { decision: string }) => r.decision === "deny");
+    expect(denyRow.verdictRule).toBe("grant-policy:amount.windowMax");
+  });
+
+  test("missing amount arg on a value-bearing grant => 403 (unreadable value)", async () => {
+    const { capId } = await seedGrant(valuePolicy);
+    const app = buildApp(harness!.db);
+    const res = await invoke(app, {});
+    expect(res.status).toBe(403);
+    const rows = await invocationRows(capId);
+    expect(rows[0].verdictRule).toBe("grant-policy:amount.arg");
+  });
+});
+
+describe("grant policy: venue + time", () => {
+  test("method allowlist blocks the capability's method", async () => {
+    const { capId } = await seedGrant({
+      version: 1,
+      class: "plain-secret",
+      venue: { methods: ["GET"] },
+    });
+    const app = buildApp(harness!.db);
+    const res = await invoke(app, {});
+    expect(res.status).toBe(403);
+    const rows = await invocationRows(capId);
+    expect(rows[0].verdictRule).toBe("grant-policy:venue.method");
+  });
+
+  test("matching venue allowlist passes through", async () => {
+    await seedGrant({
+      version: 1,
+      class: "plain-secret",
+      venue: { hosts: ["api.github.com"], methods: ["POST"], pathPrefixes: ["/repos/acme"] },
+    });
+    const app = buildApp(harness!.db);
+    expect((await invoke(app, {})).status).toBe(AUTHORIZED);
+  });
+
+  test("notAfter in the past denies; in the future allows", async () => {
+    const { capId } = await seedGrant({
+      version: 1,
+      class: "plain-secret",
+      time: { notAfter: "2020-01-01T00:00:00Z" },
+    });
+    const app = buildApp(harness!.db);
+    const res = await invoke(app, {});
+    expect(res.status).toBe(403);
+    const rows = await invocationRows(capId);
+    expect(rows[0].verdictRule).toBe("grant-policy:time.notAfter");
+
+    // future notAfter allows (fresh grant on a new capability name is not
+    // needed: replace the policy in place).
+    const [grantRow] = await harness!.db
+      .select()
+      .from(capabilityGrants)
+      .where(eq(capabilityGrants.capabilityId, capId));
+    await setRawGrantPolicy(grantRow.id, {
+      version: 1,
+      class: "plain-secret",
+      time: { notAfter: "2999-01-01T00:00:00Z" },
+    });
+    expect((await invoke(app, {})).status).toBe(AUTHORIZED);
+  });
+});
+
+describe("grant policy: approval.always + layering", () => {
+  test("approval.always => 202 even though the tenant layer allows", async () => {
+    const { capId } = await seedGrant({
+      version: 1,
+      class: "plain-secret",
+      approval: { always: true },
+    });
+    const app = buildApp(harness!.db);
+    const res = await invoke(app, {});
+    expect(res.status).toBe(202);
+    const rows = await invocationRows(capId);
+    expect(rows[0].decision).toBe("approval");
+    expect(rows[0].verdictRule).toBe("grant-policy:approval.always");
+  });
+
+  test("a tenant-layer DENY wins over a grant-layer allow (grant only narrows)", async () => {
+    const { capId } = await seedGrant(); // permissive default grant policy
+    currentPolicySet = [capRule("tenant-deny", "deny")];
+    const app = buildApp(harness!.db);
+    const res = await invoke(app, {});
+    expect(res.status).toBe(403);
+    const rows = await invocationRows(capId);
+    expect(rows[0].decision).toBe("deny");
+    expect(rows[0].verdictRule).toBe("capability-intent:hard_deny");
+  });
+
+  test("a tenant-layer DENY wins over a grant-layer approval (deny is never softened)", async () => {
+    const { capId } = await seedGrant({
+      version: 1,
+      class: "plain-secret",
+      approval: { always: true },
+    });
+    currentPolicySet = [capRule("tenant-deny", "deny")];
+    const app = buildApp(harness!.db);
+    const res = await invoke(app, {});
+    expect(res.status).toBe(403);
+    const rows = await invocationRows(capId);
+    expect(rows[0].decision).toBe("deny");
+  });
+
+  test("a tenant-layer require-approval still 202s when the grant layer allows", async () => {
+    const { capId } = await seedGrant();
+    currentPolicySet = [capRule("tenant-approve", "require-approval")];
+    const app = buildApp(harness!.db);
+    const res = await invoke(app, {});
+    expect(res.status).toBe(202);
+    const rows = await invocationRows(capId);
+    expect(rows[0].decision).toBe("approval");
+    expect(rows[0].verdictRule).toBe("capability-intent:approval_required");
+  });
+});
+
+describe("grant policy: malformed + strict mode (fail-closed)", () => {
+  test("a malformed policy on the grant => 403, audited, never ignored", async () => {
+    const { capId, grantId } = await seedGrant();
+    await setRawGrantPolicy(grantId, { version: 1, class: "plain-secret", raet: {} });
+    const app = buildApp(harness!.db);
+    const res = await invoke(app, {});
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("unknown key");
+    const rows = await invocationRows(capId);
+    expect(rows[0].decision).toBe("deny");
+    expect(rows[0].verdictRule).toBe("grant-policy:malformed");
+  });
+
+  test("a value-bearing policy whose amount block was stripped => 403", async () => {
+    const { grantId } = await seedGrant();
+    await setRawGrantPolicy(grantId, { version: 1, class: "value-bearing" });
+    const app = buildApp(harness!.db);
+    const res = await invoke(app, {});
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("requires an `amount` block");
+  });
+
+  test("NULL policy: compatibility mode allows (audited), strict mode denies", async () => {
+    const { capId, grantId } = await seedGrant();
+    await setRawGrantPolicy(grantId, null);
+
+    const app = buildApp(harness!.db);
+    // compatibility (flag off): explicit permissive verdict.
+    expect((await invoke(app, {})).status).toBe(AUTHORIZED);
+    let rows = await invocationRows(capId);
+    expect(rows[0].verdictRule).toBe("grant-policy:no-policy.permissive");
+
+    // strict mode: fail closed.
+    process.env.STEWARD_GRANT_POLICY_STRICT = "true";
+    const res = await invoke(app, {});
+    expect(res.status).toBe(403);
+    rows = await invocationRows(capId);
+    const denyRow = rows.find((r: { decision: string }) => r.decision === "deny");
+    expect(denyRow.verdictRule).toBe("grant-policy:no-policy.strict");
+  });
+});

--- a/packages/plugin-capabilities/src/invoke.ts
+++ b/packages/plugin-capabilities/src/invoke.ts
@@ -17,7 +17,12 @@ import {
   CAPABILITY_INTENT_RULE_TYPE,
   composeCapabilityIntentDecision,
   type EvaluatorContext,
+  evaluateGrantPolicy,
+  type GrantPolicyVerdict,
+  grantPolicySignals,
+  noPolicyVerdict,
   PolicyEngine,
+  parseGrantPolicy,
 } from "@stwd/policy-engine";
 import { StewardProxyClient } from "@stwd/proxy-client";
 import type { ApiResponse, AppVariables, PolicyRule, SignRequest } from "@stwd/shared";
@@ -30,6 +35,18 @@ import { CapabilityStore } from "./store";
 const PROXY_SCOPE = "api:proxy";
 /** short-lived: the token only needs to survive the single proxied call. */
 const PROXY_TOKEN_TTL = "2m";
+
+/**
+ * Strict grant-policy mode (C1, flag-gated): when enabled, a grant with NO
+ * policy document (NULL column — only possible for rows written outside the
+ * migrated path) DENIES instead of falling back to the explicit permissive
+ * default. Migration 0002 backfills every existing grant with
+ * `{version:1, class:"plain-secret"}` and new rows get the same DB default, so
+ * flipping this on is safe once the migration has run.
+ */
+function isGrantPolicyStrict(env: NodeJS.ProcessEnv = process.env): boolean {
+  return (env.STEWARD_GRANT_POLICY_STRICT ?? "").trim().toLowerCase() === "true";
+}
 
 interface ProxyEnv {
   proxyUrl: string;
@@ -252,6 +269,12 @@ async function recordAndJson(
     decision: InvocationDecision;
     status: number;
     payload: ApiResponse;
+    /** which policy rule decided this outcome (C1 verdict audit). */
+    verdictRule?: string;
+    /** the verdict's human-readable reason (C1 verdict audit). */
+    verdictReason?: string;
+    /** extracted per-invoke amount (micros) when an amount block evaluated. */
+    amountMicros?: number;
   },
 ): Promise<Response> {
   try {
@@ -260,6 +283,9 @@ async function recordAndJson(
       agentId: args.agentId,
       capabilityId: args.capabilityId,
       decision: args.decision,
+      verdictRule: args.verdictRule,
+      verdictReason: args.verdictReason,
+      amountMicros: args.amountMicros,
     });
   } catch {
     // audit write failed: do NOT block the already fail-closed decision.
@@ -293,9 +319,106 @@ export async function invokeCapabilityThroughProxy(
       decision: "deny",
       status: 403,
       payload: { ok: false, error: "capability not available to agent" } satisfies ApiResponse,
+      verdictRule: "no-usable-grant",
+      verdictReason: "capability not available to agent",
     });
   }
   const cap = match.capability;
+
+  // ── GRANT-POLICY LAYER (C1) ────────────────────────────────────────
+  // The per-grant policy document evaluated BEFORE the tenant capability-intent
+  // set. Precedence across the two layers: a DENY from either layer denies; an
+  // approval from either layer (with no deny) is a 202; only allow+allow
+  // forwards. The grant layer can only NARROW the tenant layer, never widen it.
+  //
+  // Fail-closed rules:
+  //   - a MALFORMED policy document on the grant => deny (never ignored),
+  //   - a NULL policy => strict mode denies; compatibility mode allows with an
+  //     explicit audited "no-policy.permissive" verdict (pre-policy behavior),
+  //   - a required trailing-window counter that cannot be fetched => deny.
+  let grantVerdict: GrantPolicyVerdict;
+  const rawPolicy = match.grant.policy;
+  if (rawPolicy === null || rawPolicy === undefined) {
+    grantVerdict = noPolicyVerdict(isGrantPolicyStrict());
+  } else {
+    const parsedPolicy = parseGrantPolicy(rawPolicy);
+    if (!parsedPolicy.ok) {
+      return recordAndJson(store, {
+        tenantId,
+        agentId,
+        capabilityId: cap.id,
+        decision: "deny",
+        status: 403,
+        payload: { ok: false, error: parsedPolicy.error } satisfies ApiResponse,
+        verdictRule: "grant-policy:malformed",
+        verdictReason: parsedPolicy.error,
+      });
+    }
+    // fetch exactly the trailing-window counters this policy needs. a counter
+    // failure is a missing REQUIRED signal: deny (a cap that cannot be checked
+    // cannot pass).
+    const signals = grantPolicySignals(parsedPolicy.policy);
+    let invokesInWindow: number | undefined;
+    let allowedAmountMicrosInWindow: number | undefined;
+    try {
+      if (signals.rateWindowSeconds !== undefined) {
+        invokesInWindow = await store.countInvocationsInWindow(
+          agentId,
+          cap.id,
+          signals.rateWindowSeconds,
+        );
+      }
+      if (signals.amountWindowSeconds !== undefined) {
+        allowedAmountMicrosInWindow = await store.sumAmountMicrosInWindow(
+          agentId,
+          cap.id,
+          signals.amountWindowSeconds,
+        );
+      }
+    } catch {
+      return recordAndJson(store, {
+        tenantId,
+        agentId,
+        capabilityId: cap.id,
+        decision: "deny",
+        status: 403,
+        payload: { ok: false, error: "policy evaluation unavailable" } satisfies ApiResponse,
+        verdictRule: "grant-policy:signals-unavailable",
+        verdictReason: "trailing-window counters unavailable",
+      });
+    }
+    // evaluateGrantPolicy is non-throwing by contract, but this is a security
+    // gate in front of live credentials: translate ANY escape into a deny.
+    try {
+      grantVerdict = evaluateGrantPolicy(parsedPolicy.policy, {
+        now: new Date(),
+        capability: { name: cap.name, host: cap.host, path: cap.pathPattern, method: cap.method },
+        args: invokeArgs,
+        invokesInWindow,
+        allowedAmountMicrosInWindow,
+      });
+    } catch {
+      grantVerdict = {
+        effect: "deny",
+        rule: "grant-policy:evaluator-error",
+        reason: "grant policy evaluation failed",
+      };
+    }
+  }
+
+  if (grantVerdict.effect === "deny") {
+    return recordAndJson(store, {
+      tenantId,
+      agentId,
+      capabilityId: cap.id,
+      decision: "deny",
+      status: 403,
+      payload: { ok: false, error: grantVerdict.reason } satisfies ApiResponse,
+      verdictRule: `grant-policy:${grantVerdict.rule}`,
+      verdictReason: grantVerdict.reason,
+      amountMicros: grantVerdict.amountMicros,
+    });
+  }
 
   let count1h: number;
   try {
@@ -308,6 +431,8 @@ export async function invokeCapabilityThroughProxy(
       decision: "deny",
       status: 403,
       payload: { ok: false, error: "policy evaluation unavailable" } satisfies ApiResponse,
+      verdictRule: "capability-intent:signals-unavailable",
+      verdictReason: "trailing-hour invoke count unavailable",
     });
   }
 
@@ -330,6 +455,8 @@ export async function invokeCapabilityThroughProxy(
       decision: "deny",
       status: 403,
       payload: { ok: false, error: "policy evaluation unavailable" } satisfies ApiResponse,
+      verdictRule: "capability-intent:policy-set-unavailable",
+      verdictReason: "tenant policy set unavailable",
     });
   }
   const capRules = policySet.filter((r) => isCapabilityIntentRule(r) && r.enabled !== false);
@@ -393,6 +520,8 @@ export async function invokeCapabilityThroughProxy(
       decision: "deny",
       status: 403,
       payload: { ok: false, error: "policy evaluation failed" } satisfies ApiResponse,
+      verdictRule: "capability-intent:evaluator-error",
+      verdictReason: "policy evaluation failed",
     });
   }
 
@@ -407,10 +536,24 @@ export async function invokeCapabilityThroughProxy(
         ok: false,
         error: decision.reason,
       } satisfies ApiResponse,
+      verdictRule: "capability-intent:hard_deny",
+      verdictReason: decision.reason,
+      amountMicros: grantVerdict.amountMicros,
     });
   }
 
-  if (decision.effect === "approval_required") {
+  // CROSS-LAYER APPROVAL COMPOSITION: an approval from EITHER layer (grant
+  // policy or tenant capability-intent) routes to the 202 pending flow — but
+  // only now, after BOTH layers have proven no hard deny applies (a deny from
+  // either layer can never be softened into an approval). The approval row
+  // carries the verdict + the reserved amountMicros so parallel pending
+  // approvals count against the rolling amount window.
+  if (grantVerdict.effect === "approval_required" || decision.effect === "approval_required") {
+    const fromGrant = grantVerdict.effect === "approval_required";
+    const verdictRule = fromGrant
+      ? `grant-policy:${grantVerdict.rule}`
+      : "capability-intent:approval_required";
+    const verdictReason = fromGrant ? grantVerdict.reason : decision.reason;
     let approvalId: string | null = null;
     try {
       approvalId = await store.recordInvocation({
@@ -418,6 +561,9 @@ export async function invokeCapabilityThroughProxy(
         agentId,
         capabilityId: cap.id,
         decision: "approval",
+        verdictRule,
+        verdictReason,
+        amountMicros: grantVerdict.amountMicros,
       });
     } catch {
       approvalId = null;
@@ -430,12 +576,14 @@ export async function invokeCapabilityThroughProxy(
         decision: "deny",
         status: 403,
         payload: { ok: false, error: "approval enqueue failed" } satisfies ApiResponse,
+        verdictRule: "approval-enqueue-failed",
+        verdictReason: "approval enqueue failed",
       });
     }
     return jsonResponse({ ok: true, data: { approvalId, status: "pending" } }, 202);
   }
 
-  // decision.effect === "allow": proceed to proxy delegation.
+  // both layers allow: proceed to proxy delegation.
 
   const proxyEnv = readProxyEnv();
   if (!proxyEnv) {
@@ -446,6 +594,14 @@ export async function invokeCapabilityThroughProxy(
       decision: "error",
       status: 503,
       payload: { ok: false, error: "capability delegation unavailable" } satisfies ApiResponse,
+      // decision='error' records the INFRA outcome; the verdict columns record
+      // the POLICY decision that had already authorized the forward. Both policy
+      // layers allowed, so the row carries the grant verdict + reserves the
+      // authorized amount in the rolling window (fail-closed for money — see
+      // sumAmountMicrosInWindow).
+      verdictRule: `grant-policy:${grantVerdict.rule}`,
+      verdictReason: "authorized; capability delegation unavailable",
+      amountMicros: grantVerdict.amountMicros,
     });
   }
 
@@ -469,6 +625,8 @@ export async function invokeCapabilityThroughProxy(
           ok: false,
           error: "GOVERNED_ROUTE_PLUGIN_DENIED",
         } satisfies ApiResponse,
+        verdictRule: "governed-route-plugin-denied",
+        verdictReason: "capability maps to a governed_v2 route",
       });
     }
   } catch {
@@ -483,6 +641,8 @@ export async function invokeCapabilityThroughProxy(
         ok: false,
         error: "GOVERNED_ROUTE_PLUGIN_DENIED",
       } satisfies ApiResponse,
+      verdictRule: "governed-route-plugin-denied",
+      verdictReason: "governed-route check unavailable (fail closed)",
     });
   }
 
@@ -522,11 +682,26 @@ export async function invokeCapabilityThroughProxy(
       decision: "error",
       status: 502,
       payload: { ok: false, error: "capability delegation failed" } satisfies ApiResponse,
+      // a 502 AFTER authorization is ambiguous (the upstream call may have gone
+      // through): record the policy verdict that authorized it and reserve the
+      // amount — over-counting a money window is acceptable, under-counting is
+      // not.
+      verdictRule: `grant-policy:${grantVerdict.rule}`,
+      verdictReason: "authorized; capability delegation failed",
+      amountMicros: grantVerdict.amountMicros,
     });
   }
 
   try {
-    await store.recordInvocation({ tenantId, agentId, capabilityId: cap.id, decision: "allow" });
+    await store.recordInvocation({
+      tenantId,
+      agentId,
+      capabilityId: cap.id,
+      decision: "allow",
+      verdictRule: `grant-policy:${grantVerdict.rule}`,
+      verdictReason: grantVerdict.reason,
+      amountMicros: grantVerdict.amountMicros,
+    });
   } catch {
     // audit write failed: do NOT block the already-authorized upstream response.
   }

--- a/packages/plugin-capabilities/src/routes.ts
+++ b/packages/plugin-capabilities/src/routes.ts
@@ -13,6 +13,7 @@
  * (validate.ts), so a capability can never be broader than a legal route.
  */
 
+import { parseGrantPolicy } from "@stwd/policy-engine";
 import type { ApiResponse, AppVariables } from "@stwd/shared";
 import type { Context } from "hono";
 import { Hono } from "hono";
@@ -52,6 +53,7 @@ function toGrantView(grant: CapabilityGrant) {
     capabilityId: grant.capabilityId,
     agentId: grant.agentId,
     secretRouteId: grant.secretRouteId,
+    policy: grant.policy,
     expiresAt: grant.expiresAt,
     status: grant.status,
     createdAt: grant.createdAt,
@@ -343,10 +345,20 @@ export function createCapabilityRoutes(ctx: StewardAppContext): Hono<{ Variables
         400,
       );
     }
-    const { agentId, expiresAt } = parsed.data;
+    const { agentId, expiresAt, policy } = parsed.data;
     const expires = expiresAt ? new Date(expiresAt) : null;
     if (expires && Number.isFinite(expires.getTime()) && expires.getTime() <= Date.now()) {
       return c.json<ApiResponse>({ ok: false, error: "expiresAt must be in the future" }, 400);
+    }
+
+    // per-grant policy (C1): validate through the SAME fail-closed parser the
+    // invoke path enforces with, so a policy that would deny-as-malformed at
+    // invoke time can never be stored (single source of truth, no drift).
+    if (policy !== undefined) {
+      const parsedPolicy = parseGrantPolicy(policy);
+      if (!parsedPolicy.ok) {
+        return c.json<ApiResponse>({ ok: false, error: parsedPolicy.error }, 400);
+      }
     }
 
     try {
@@ -355,6 +367,7 @@ export function createCapabilityRoutes(ctx: StewardAppContext): Hono<{ Variables
         capabilityId,
         agentId,
         expiresAt: expires,
+        policy,
       });
       if (!result) return c.json<ApiResponse>({ ok: false, error: "capability not found" }, 404);
       await audit(c, {
@@ -380,6 +393,41 @@ export function createCapabilityRoutes(ctx: StewardAppContext): Hono<{ Variables
           409,
         );
       }
+      return errorResponse(c, e);
+    }
+  });
+
+  // ── PUT /grants/:grantId/policy - replace the per-grant policy (C1) ────────
+  // same admin+MFA bar as every other grant mutation (a policy edit changes what
+  // a live credential may do). validated by the SAME fail-closed parser the
+  // invoke path enforces with. takes effect on the next invoke.
+  routes.put("/grants/:grantId/policy", async (c) => {
+    const mfa = requireCapabilityAdmin(c, "Capability grant management");
+    if (mfa) return mfa;
+    const tenantId = c.get("tenantId");
+    const grantId = c.req.param("grantId");
+
+    const body = await ctx.safeJsonParse<Record<string, unknown>>(c);
+    if (!body)
+      return c.json<ApiResponse>({ ok: false, error: "Invalid JSON in request body" }, 400);
+
+    const parsedPolicy = parseGrantPolicy(body);
+    if (!parsedPolicy.ok) {
+      return c.json<ApiResponse>({ ok: false, error: parsedPolicy.error }, 400);
+    }
+
+    try {
+      const updated = await store.updateGrantPolicy(tenantId, grantId, body);
+      if (!updated) return c.json<ApiResponse>({ ok: false, error: "grant not found" }, 404);
+      await audit(c, {
+        tenantId,
+        action: "capability.grant.policy.update",
+        resourceType: "capability_grant",
+        resourceId: grantId,
+        metadata: { policy: body },
+      });
+      return c.json<ApiResponse>({ ok: true, data: toGrantView(updated) });
+    } catch (e) {
       return errorResponse(c, e);
     }
   });

--- a/packages/plugin-capabilities/src/schema.ts
+++ b/packages/plugin-capabilities/src/schema.ts
@@ -20,6 +20,7 @@
 
 import { relations, sql } from "drizzle-orm";
 import {
+  bigint,
   boolean,
   check,
   index,
@@ -73,6 +74,14 @@ export const capabilityGrants = pgTable(
     // grant is being torn down / for a route that failed to materialize (never
     // left as an orphaned enabled route - see the lifecycle in store.ts + tests).
     secretRouteId: uuid("secret_route_id"),
+    // the per-grant POLICY document (C1): constraints evaluated at invoke time
+    // by @stwd/policy-engine's grant-policy module (rate / amount / venue / time
+    // / approval). New rows default to the EXPLICIT permissive plain-secret
+    // policy (exactly pre-policy behavior, but written down); migration 0002
+    // backfills existing rows the same way. Kept NULLABLE so strict mode
+    // (STEWARD_GRANT_POLICY_STRICT=true) has a fail-closed target for rows
+    // written outside the migrated path: NULL denies under strict mode.
+    policy: jsonb("policy").default(sql`'{"version":1,"class":"plain-secret"}'::jsonb`),
     expiresAt: timestamp("expires_at", { withTimezone: true }),
     status: text("status").notNull().default("active"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
@@ -119,6 +128,18 @@ export const capabilityInvocations = pgTable(
     // capability's id.
     capabilityId: uuid("capability_id"),
     decision: text("decision").notNull(),
+    // policy VERDICT audit (C1): which rule decided this invoke (e.g.
+    // "grant-policy:amount.perInvokeMax", "capability-intent:allow",
+    // "no-usable-grant") + the human-readable reason. nullable: rows predating
+    // the policy engine carry no verdict.
+    verdictRule: text("verdict_rule"),
+    verdictReason: text("verdict_reason"),
+    // the extracted per-invoke amount (integer micros) for value-bearing
+    // invokes. summed over decision IN ('allow','approval','error') rows as the
+    // rolling-window cumulative amount source (pending approvals and post-
+    // authorization infra errors RESERVE spend so the window can never be
+    // under-counted).
+    amountMicros: bigint("amount_micros", { mode: "number" }),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({

--- a/packages/plugin-capabilities/src/store.ts
+++ b/packages/plugin-capabilities/src/store.ts
@@ -378,6 +378,13 @@ export class CapabilityStore {
     agentId: string;
     capabilityId: string | null;
     decision: InvocationDecision;
+    /** which policy rule decided this invoke (C1 verdict audit). */
+    verdictRule?: string;
+    /** the human-readable verdict reason (C1 verdict audit). */
+    verdictReason?: string;
+    /** extracted per-invoke amount (integer micros) for value-bearing invokes;
+     *  summed by {@link sumAmountMicrosInWindow} for the rolling window cap. */
+    amountMicros?: number;
     now?: Date;
   }): Promise<string> {
     const values: Record<string, unknown> = {
@@ -386,6 +393,9 @@ export class CapabilityStore {
       capabilityId: input.capabilityId,
       decision: input.decision,
     };
+    if (input.verdictRule !== undefined) values.verdictRule = input.verdictRule;
+    if (input.verdictReason !== undefined) values.verdictReason = input.verdictReason;
+    if (input.amountMicros !== undefined) values.amountMicros = input.amountMicros;
     if (input.now) values.createdAt = input.now;
     const [row] = await this.db.insert(capabilityInvocations).values(values).returning();
     return row.id as string;
@@ -420,6 +430,60 @@ export class CapabilityStore {
     return Number(row?.n ?? 0);
   }
 
+  /**
+   * Count this agent's invocations of a capability in an ARBITRARY trailing
+   * window (seconds) — the source for the grant-policy `rate` limit (C1). Same
+   * fail-closed semantics as {@link countInvocations1h}: ALL recorded attempts
+   * consume rate (a denied probe is not free).
+   */
+  async countInvocationsInWindow(
+    agentId: string,
+    capabilityId: string,
+    windowSeconds: number,
+    now: Date = new Date(),
+  ): Promise<number> {
+    return this.countInvocations1h(agentId, capabilityId, now, windowSeconds * 1000);
+  }
+
+  /**
+   * Sum the recorded per-invoke amounts (integer micros) for this agent+
+   * capability over a trailing window — the source for the grant-policy rolling
+   * amount cap (C1). Sums decision IN ('allow','approval','error') rows:
+   *   - an APPROVAL row RESERVES its amount while pending, so parallel
+   *     over-threshold invokes cannot collectively overshoot the window cap;
+   *   - an ERROR row was AUTHORIZED before the infra failure (and for a 502 the
+   *     upstream call may actually have gone through), so it reserves too.
+   * DENY rows never count — no value moved. Over-counting a money cap is
+   * acceptable; under-counting is not (fail closed).
+   */
+  async sumAmountMicrosInWindow(
+    agentId: string,
+    capabilityId: string,
+    windowSeconds: number,
+    now: Date = new Date(),
+  ): Promise<number> {
+    const since = new Date(now.getTime() - windowSeconds * 1000);
+    const [row] = await this.db
+      .select({ total: sql<string>`coalesce(sum(${capabilityInvocations.amountMicros}), 0)::text` })
+      .from(capabilityInvocations)
+      .where(
+        and(
+          eq(capabilityInvocations.agentId, agentId),
+          eq(capabilityInvocations.capabilityId, capabilityId),
+          gte(capabilityInvocations.createdAt, since),
+          sql`${capabilityInvocations.decision} IN ('allow','approval','error')`,
+          sql`${capabilityInvocations.amountMicros} IS NOT NULL`,
+        ),
+      );
+    const total = Number(row?.total ?? 0);
+    if (!Number.isSafeInteger(total)) {
+      // a sum beyond safe-integer range cannot be compared exactly; the invoke
+      // layer treats a thrown counter as policy-unavailable (deny). fail closed.
+      throw new Error("amount window sum exceeds safe integer range");
+    }
+    return total;
+  }
+
   // ── grant create (materializes the paired route) ────────────────────────────
 
   /**
@@ -433,6 +497,11 @@ export class CapabilityStore {
     capabilityId: string;
     agentId: string;
     expiresAt: Date | null;
+    /** the per-grant policy document (C1). when ABSENT the DB default applies
+     *  (the explicit permissive plain-secret policy). the ROUTE layer validates
+     *  it via the policy-engine's fail-closed parseGrantPolicy before it gets
+     *  here — the store persists what it is given. */
+    policy?: Record<string, unknown>;
     now?: Date;
   }): Promise<{ grant: CapabilityGrant; route: SecretRoute | null } | null> {
     const now = input.now ?? new Date();
@@ -477,20 +546,39 @@ export class CapabilityStore {
         .values(routeValuesFor(input.tenantId, input.agentId, cap, routeEnabled))
         .returning();
 
-      const [grant] = await tx
-        .insert(capabilityGrants)
-        .values({
-          tenantId: input.tenantId,
-          agentId: input.agentId,
-          capabilityId: input.capabilityId,
-          secretRouteId: route.id,
-          expiresAt: input.expiresAt,
-          status: "active",
-        })
-        .returning();
+      const grantValues: Record<string, unknown> = {
+        tenantId: input.tenantId,
+        agentId: input.agentId,
+        capabilityId: input.capabilityId,
+        secretRouteId: route.id,
+        expiresAt: input.expiresAt,
+        status: "active",
+      };
+      if (input.policy !== undefined) grantValues.policy = input.policy;
+      const [grant] = await tx.insert(capabilityGrants).values(grantValues).returning();
 
       return { grant, route };
     });
+  }
+
+  /**
+   * Replace a grant's policy document (C1). The ROUTE layer validates the new
+   * policy via the policy-engine's fail-closed parseGrantPolicy before calling
+   * this. Takes effect on the NEXT invoke (the invoke path re-reads the grant
+   * row every time). Returns the updated grant, or null when the grant does not
+   * exist for the tenant.
+   */
+  async updateGrantPolicy(
+    tenantId: string,
+    grantId: string,
+    policy: Record<string, unknown>,
+  ): Promise<CapabilityGrant | null> {
+    const [updated] = await this.db
+      .update(capabilityGrants)
+      .set({ policy })
+      .where(and(eq(capabilityGrants.id, grantId), eq(capabilityGrants.tenantId, tenantId)))
+      .returning();
+    return updated ?? null;
   }
 
   // ── grant revoke (tears down the paired route) ──────────────────────────────

--- a/packages/plugin-capabilities/src/validate.ts
+++ b/packages/plugin-capabilities/src/validate.ts
@@ -73,10 +73,14 @@ export const updateCapabilitySchema = z
 
 export type UpdateCapabilityBody = z.infer<typeof updateCapabilitySchema>;
 
-/** grant body: which agent, optional expiry. */
+/** grant body: which agent, optional expiry, optional per-grant policy (C1).
+ * the policy value is validated by the policy-engine's fail-closed
+ * `parseGrantPolicy` at the route layer (a zod passthrough here would duplicate
+ * that source of truth); this schema only asserts it is an object when present. */
 export const createGrantSchema = z.object({
   agentId: z.string().min(1).max(64),
   expiresAt: z.string().datetime().optional(),
+  policy: z.record(z.string(), z.unknown()).optional(),
 });
 
 export type CreateGrantBody = z.infer<typeof createGrantSchema>;

--- a/packages/policy-engine/src/__tests__/grant-policy.test.ts
+++ b/packages/policy-engine/src/__tests__/grant-policy.test.ts
@@ -1,0 +1,446 @@
+/**
+ * grant-policy.test.ts — bidirectional coverage for the per-grant policy module
+ * (C1): every rule must BLOCK what it should AND ALLOW what it should, malformed
+ * policy must fail closed at parse, and every verdict must name the rule that
+ * fired (the audit contract).
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  evaluateGrantPolicy,
+  GRANT_POLICY_VERSION,
+  type GrantPolicyInput,
+  type GrantPolicyV1,
+  grantPolicySignals,
+  LEGACY_DEFAULT_GRANT_POLICY,
+  MAX_AGGREGATE_WINDOW_SECONDS,
+  noPolicyVerdict,
+  parseGrantPolicy,
+} from "../index";
+
+const CAP = {
+  name: "github.pr.comment",
+  host: "api.github.com",
+  path: "/repos/acme/app/issues/1/comments",
+  method: "POST",
+};
+
+function input(overrides: Partial<GrantPolicyInput> = {}): GrantPolicyInput {
+  return {
+    now: new Date("2026-07-30T12:00:00Z"),
+    capability: CAP,
+    args: {},
+    ...overrides,
+  };
+}
+
+function policy(overrides: Partial<GrantPolicyV1> = {}): GrantPolicyV1 {
+  return { version: GRANT_POLICY_VERSION, class: "plain-secret", ...overrides };
+}
+
+// ─── parse: fail-closed ──────────────────────────────────────────────────────
+
+describe("parseGrantPolicy (fail-closed)", () => {
+  test("accepts the explicit permissive default", () => {
+    const r = parseGrantPolicy({ version: 1, class: "plain-secret" });
+    expect(r.ok).toBe(true);
+  });
+
+  test("accepts the frozen LEGACY_DEFAULT_GRANT_POLICY constant", () => {
+    const r = parseGrantPolicy(LEGACY_DEFAULT_GRANT_POLICY);
+    expect(r.ok).toBe(true);
+  });
+
+  test.each([
+    ["non-object", "nope"],
+    ["null", null],
+    ["array", [1]],
+    ["missing version", { class: "plain-secret" }],
+    ["wrong version", { version: 2, class: "plain-secret" }],
+    ["missing class", { version: 1 }],
+    ["bad class", { version: 1, class: "root" }],
+    ["unknown top-level key", { version: 1, class: "plain-secret", raet: {} }],
+  ])("rejects %s", (_label, raw) => {
+    const r = parseGrantPolicy(raw);
+    expect(r.ok).toBe(false);
+  });
+
+  test("value-bearing WITHOUT an amount block is a config error", () => {
+    const r = parseGrantPolicy({ version: 1, class: "value-bearing" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("requires an `amount` block");
+  });
+
+  test("value-bearing WITH an amount bound parses", () => {
+    const r = parseGrantPolicy({
+      version: 1,
+      class: "value-bearing",
+      amount: { argField: "amountMicros", perInvokeMaxMicros: 5_000_000 },
+    });
+    expect(r.ok).toBe(true);
+  });
+
+  test.each([
+    ["rate missing maxInvokes", { rate: { windowSeconds: 60 } }],
+    ["rate zero maxInvokes", { rate: { maxInvokes: 0, windowSeconds: 60 } }],
+    ["rate float maxInvokes", { rate: { maxInvokes: 1.5, windowSeconds: 60 } }],
+    ["rate zero window", { rate: { maxInvokes: 5, windowSeconds: 0 } }],
+    [
+      "rate over-retention window (silent under-enforcement)",
+      { rate: { maxInvokes: 5, windowSeconds: MAX_AGGREGATE_WINDOW_SECONDS + 1 } },
+    ],
+    ["rate unknown key", { rate: { maxInvokes: 5, windowSeconds: 60, burst: 2 } }],
+    ["amount empty (no bound)", { amount: { argField: "v" } }],
+    ["amount missing argField", { amount: { perInvokeMaxMicros: 1 } }],
+    ["amount float cap", { amount: { argField: "v", perInvokeMaxMicros: 1.5 } }],
+    ["amount negative cap", { amount: { argField: "v", perInvokeMaxMicros: -1 } }],
+    [
+      "amount window missing maxMicros",
+      { amount: { argField: "v", window: { windowSeconds: 60 } } },
+    ],
+    [
+      "amount window over retention",
+      {
+        amount: {
+          argField: "v",
+          window: { maxMicros: 10, windowSeconds: MAX_AGGREGATE_WINDOW_SECONDS + 1 },
+        },
+      },
+    ],
+    ["venue empty object", { venue: {} }],
+    ["venue empty hosts array", { venue: { hosts: [] } }],
+    ["venue non-string host", { venue: { hosts: [3] } }],
+    ["venue path prefix without leading slash", { venue: { pathPrefixes: ["repos"] } }],
+    ["venue unknown key", { venue: { hosts: ["a.com"], ports: [443] } }],
+    ["time empty object", { time: {} }],
+    ["time bad notBefore", { time: { notBefore: "not-a-date" } }],
+    [
+      "time notBefore >= notAfter",
+      { time: { notBefore: "2026-02-01T00:00:00Z", notAfter: "2026-01-01T00:00:00Z" } },
+    ],
+    [
+      "time window start === end (ambiguous)",
+      { time: { allowedWindowUtc: { startMinuteUtc: 100, endMinuteUtc: 100 } } },
+    ],
+    [
+      "time window minute out of range",
+      { time: { allowedWindowUtc: { startMinuteUtc: 0, endMinuteUtc: 1440 } } },
+    ],
+    ["approval non-boolean always", { approval: { always: "yes" } }],
+    ["approval unknown key", { approval: { quorum: 2 } }],
+  ])("rejects %s", (_label, partial) => {
+    const r = parseGrantPolicy({ version: 1, class: "plain-secret", ...partial });
+    expect(r.ok).toBe(false);
+  });
+
+  test("normalizes venue hosts to lowercase and methods to uppercase", () => {
+    const r = parseGrantPolicy({
+      version: 1,
+      class: "plain-secret",
+      venue: { hosts: ["API.GitHub.com"], methods: ["post"] },
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.policy.venue?.hosts).toEqual(["api.github.com"]);
+      expect(r.policy.venue?.methods).toEqual(["POST"]);
+    }
+  });
+
+  test("never throws on hostile config (throwing getters)", () => {
+    const hostile = new Proxy(
+      {},
+      {
+        ownKeys: () => {
+          throw new Error("boom");
+        },
+        get: () => {
+          throw new Error("boom");
+        },
+      },
+    );
+    // a throw inside parse would escape as an exception; assert it does not.
+    let r: ReturnType<typeof parseGrantPolicy>;
+    try {
+      r = parseGrantPolicy(hostile);
+    } catch {
+      // acceptable ONLY if the invoke layer catches it — but our contract is
+      // stronger: parse must not throw. Fail the test.
+      throw new Error("parseGrantPolicy threw on hostile input");
+    }
+    expect(r.ok).toBe(false);
+  });
+});
+
+// ─── signals ─────────────────────────────────────────────────────────────────
+
+describe("grantPolicySignals", () => {
+  test("names exactly the windows the policy needs", () => {
+    const p = policy({
+      rate: { maxInvokes: 5, windowSeconds: 300 },
+      amount: { argField: "v", window: { maxMicros: 100, windowSeconds: 86400 } },
+      class: "value-bearing",
+    });
+    expect(grantPolicySignals(p)).toEqual({
+      rateWindowSeconds: 300,
+      amountWindowSeconds: 86400,
+    });
+  });
+
+  test("empty for the permissive default", () => {
+    expect(grantPolicySignals(LEGACY_DEFAULT_GRANT_POLICY)).toEqual({
+      rateWindowSeconds: undefined,
+      amountWindowSeconds: undefined,
+    });
+  });
+});
+
+// ─── evaluate: each rule blocks AND allows ───────────────────────────────────
+
+describe("evaluateGrantPolicy — rate", () => {
+  const p = policy({ rate: { maxInvokes: 3, windowSeconds: 600 } });
+
+  test("allows under the cap", () => {
+    const v = evaluateGrantPolicy(p, input({ invokesInWindow: 2 }));
+    expect(v.effect).toBe("allow");
+    expect(v.rule).toBe("allow");
+  });
+
+  test("denies at the cap, naming the rule", () => {
+    const v = evaluateGrantPolicy(p, input({ invokesInWindow: 3 }));
+    expect(v.effect).toBe("deny");
+    expect(v.rule).toBe("rate.limit");
+  });
+
+  test("denies when the count signal is missing (fail closed)", () => {
+    const v = evaluateGrantPolicy(p, input({}));
+    expect(v.effect).toBe("deny");
+    expect(v.rule).toBe("rate.signal-missing");
+  });
+});
+
+describe("evaluateGrantPolicy — amount", () => {
+  const p = policy({
+    class: "value-bearing",
+    amount: {
+      argField: "amountMicros",
+      perInvokeMaxMicros: 10_000_000,
+      window: { maxMicros: 25_000_000, windowSeconds: 86400 },
+      approvalOverMicros: 5_000_000,
+    },
+  });
+
+  test("allows a small amount under every bound, carrying amountMicros", () => {
+    const v = evaluateGrantPolicy(
+      p,
+      input({ args: { amountMicros: 1_000_000 }, allowedAmountMicrosInWindow: 0 }),
+    );
+    expect(v.effect).toBe("allow");
+    expect(v.amountMicros).toBe(1_000_000);
+  });
+
+  test("routes over-threshold (but under hard cap) to approval", () => {
+    const v = evaluateGrantPolicy(
+      p,
+      input({ args: { amountMicros: 6_000_000 }, allowedAmountMicrosInWindow: 0 }),
+    );
+    expect(v.effect).toBe("approval_required");
+    expect(v.rule).toBe("amount.approvalOver");
+    expect(v.amountMicros).toBe(6_000_000);
+  });
+
+  test("denies over the per-invoke hard cap (never softened to approval)", () => {
+    const v = evaluateGrantPolicy(
+      p,
+      input({ args: { amountMicros: 10_000_001 }, allowedAmountMicrosInWindow: 0 }),
+    );
+    expect(v.effect).toBe("deny");
+    expect(v.rule).toBe("amount.perInvokeMax");
+  });
+
+  test("denies when the rolling window would be exceeded", () => {
+    const v = evaluateGrantPolicy(
+      p,
+      input({ args: { amountMicros: 2_000_000 }, allowedAmountMicrosInWindow: 24_000_000 }),
+    );
+    expect(v.effect).toBe("deny");
+    expect(v.rule).toBe("amount.windowMax");
+  });
+
+  test("allows exactly at the rolling window boundary", () => {
+    const v = evaluateGrantPolicy(
+      p,
+      input({ args: { amountMicros: 1_000_000 }, allowedAmountMicrosInWindow: 24_000_000 }),
+    );
+    // 24M + 1M = 25M, not > 25M => within cap. 1M is under approval threshold.
+    expect(v.effect).toBe("allow");
+  });
+
+  test("denies when the window sum signal is missing (fail closed)", () => {
+    const v = evaluateGrantPolicy(p, input({ args: { amountMicros: 1_000_000 } }));
+    expect(v.effect).toBe("deny");
+    expect(v.rule).toBe("amount.signal-missing");
+  });
+
+  test.each([
+    ["missing arg", {}],
+    ["string arg", { amountMicros: "100" }],
+    ["float arg", { amountMicros: 1.5 }],
+    ["negative arg", { amountMicros: -1 }],
+    ["NaN arg", { amountMicros: Number.NaN }],
+    ["unsafe integer arg", { amountMicros: Number.MAX_SAFE_INTEGER + 2 }],
+  ])("denies an unreadable amount arg: %s", (_label, args) => {
+    const v = evaluateGrantPolicy(
+      p,
+      input({ args: args as Record<string, unknown>, allowedAmountMicrosInWindow: 0 }),
+    );
+    expect(v.effect).toBe("deny");
+    expect(v.rule).toBe("amount.arg");
+  });
+});
+
+describe("evaluateGrantPolicy — venue", () => {
+  test("host allowlist blocks a non-matching host and allows a matching one", () => {
+    const p = policy({ venue: { hosts: ["api.github.com"] } });
+    expect(evaluateGrantPolicy(p, input()).effect).toBe("allow");
+    const v = evaluateGrantPolicy(p, input({ capability: { ...CAP, host: "api.evil.com" } }));
+    expect(v.effect).toBe("deny");
+    expect(v.rule).toBe("venue.host");
+  });
+
+  test("wildcard host entry matches subdomains but never the bare apex", () => {
+    const p = policy({ venue: { hosts: ["*.github.com"] } });
+    expect(
+      evaluateGrantPolicy(p, input({ capability: { ...CAP, host: "api.github.com" } })).effect,
+    ).toBe("allow");
+    expect(
+      evaluateGrantPolicy(p, input({ capability: { ...CAP, host: "github.com" } })).effect,
+    ).toBe("deny");
+    expect(
+      evaluateGrantPolicy(p, input({ capability: { ...CAP, host: "evilgithub.com" } })).effect,
+    ).toBe("deny");
+  });
+
+  test("method allowlist blocks and allows", () => {
+    const p = policy({ venue: { methods: ["GET", "POST"] } });
+    expect(evaluateGrantPolicy(p, input()).effect).toBe("allow");
+    const v = evaluateGrantPolicy(p, input({ capability: { ...CAP, method: "DELETE" } }));
+    expect(v.effect).toBe("deny");
+    expect(v.rule).toBe("venue.method");
+  });
+
+  test("path prefix matches on segment boundaries only", () => {
+    const p = policy({ venue: { pathPrefixes: ["/repos/acme"] } });
+    expect(evaluateGrantPolicy(p, input()).effect).toBe("allow");
+    // /repos/acmeX must NOT match the /repos/acme prefix.
+    const v = evaluateGrantPolicy(
+      p,
+      input({ capability: { ...CAP, path: "/repos/acmeX/issues" } }),
+    );
+    expect(v.effect).toBe("deny");
+    expect(v.rule).toBe("venue.path");
+  });
+});
+
+describe("evaluateGrantPolicy — time", () => {
+  test("notBefore blocks early use and allows after", () => {
+    const p = policy({ time: { notBefore: "2026-07-30T13:00:00Z" } });
+    const early = evaluateGrantPolicy(p, input({ now: new Date("2026-07-30T12:59:59Z") }));
+    expect(early.effect).toBe("deny");
+    expect(early.rule).toBe("time.notBefore");
+    expect(evaluateGrantPolicy(p, input({ now: new Date("2026-07-30T13:00:00Z") })).effect).toBe(
+      "allow",
+    );
+  });
+
+  test("notAfter allows before and blocks after", () => {
+    const p = policy({ time: { notAfter: "2026-07-30T13:00:00Z" } });
+    expect(evaluateGrantPolicy(p, input({ now: new Date("2026-07-30T12:00:00Z") })).effect).toBe(
+      "allow",
+    );
+    const late = evaluateGrantPolicy(p, input({ now: new Date("2026-07-30T13:00:01Z") }));
+    expect(late.effect).toBe("deny");
+    expect(late.rule).toBe("time.notAfter");
+  });
+
+  test("minute-of-day window blocks outside and allows inside", () => {
+    // allowed 09:00-17:00 UTC.
+    const p = policy({ time: { allowedWindowUtc: { startMinuteUtc: 540, endMinuteUtc: 1020 } } });
+    expect(evaluateGrantPolicy(p, input({ now: new Date("2026-07-30T12:00:00Z") })).effect).toBe(
+      "allow",
+    );
+    const night = evaluateGrantPolicy(p, input({ now: new Date("2026-07-30T03:00:00Z") }));
+    expect(night.effect).toBe("deny");
+    expect(night.rule).toBe("time.window");
+  });
+
+  test("wrapped window spans midnight", () => {
+    // allowed 22:00-02:00 UTC.
+    const p = policy({ time: { allowedWindowUtc: { startMinuteUtc: 1320, endMinuteUtc: 120 } } });
+    expect(evaluateGrantPolicy(p, input({ now: new Date("2026-07-30T23:30:00Z") })).effect).toBe(
+      "allow",
+    );
+    expect(evaluateGrantPolicy(p, input({ now: new Date("2026-07-30T01:30:00Z") })).effect).toBe(
+      "allow",
+    );
+    expect(evaluateGrantPolicy(p, input({ now: new Date("2026-07-30T12:00:00Z") })).effect).toBe(
+      "deny",
+    );
+  });
+});
+
+describe("evaluateGrantPolicy — approval + precedence", () => {
+  test("approval.always routes every invoke to approval", () => {
+    const p = policy({ approval: { always: true } });
+    const v = evaluateGrantPolicy(p, input());
+    expect(v.effect).toBe("approval_required");
+    expect(v.rule).toBe("approval.always");
+  });
+
+  test("a hard deny is NEVER softened into an approval (deny-first)", () => {
+    const p = policy({
+      approval: { always: true },
+      venue: { hosts: ["other.example.com"] },
+    });
+    const v = evaluateGrantPolicy(p, input());
+    expect(v.effect).toBe("deny");
+    expect(v.rule).toBe("venue.host");
+  });
+
+  test("rate exhaustion beats amount approval threshold", () => {
+    const p = policy({
+      class: "value-bearing",
+      rate: { maxInvokes: 1, windowSeconds: 60 },
+      amount: { argField: "amountMicros", approvalOverMicros: 0 },
+    });
+    const v = evaluateGrantPolicy(p, input({ invokesInWindow: 1, args: { amountMicros: 5 } }));
+    expect(v.effect).toBe("deny");
+    expect(v.rule).toBe("rate.limit");
+  });
+
+  test("the permissive default allows with the audit-visible allow rule", () => {
+    const v = evaluateGrantPolicy(LEGACY_DEFAULT_GRANT_POLICY, input());
+    expect(v.effect).toBe("allow");
+    expect(v.rule).toBe("allow");
+  });
+
+  test("determinism: identical inputs produce identical verdicts", () => {
+    const p = policy({ rate: { maxInvokes: 2, windowSeconds: 60 } });
+    const a = evaluateGrantPolicy(p, input({ invokesInWindow: 1 }));
+    const b = evaluateGrantPolicy(p, input({ invokesInWindow: 1 }));
+    expect(a).toEqual(b);
+  });
+});
+
+describe("noPolicyVerdict (strict-mode flag)", () => {
+  test("strict mode denies a policy-less grant", () => {
+    const v = noPolicyVerdict(true);
+    expect(v.effect).toBe("deny");
+    expect(v.rule).toBe("no-policy.strict");
+  });
+
+  test("compatibility mode allows with an explicit audited rule", () => {
+    const v = noPolicyVerdict(false);
+    expect(v.effect).toBe("allow");
+    expect(v.rule).toBe("no-policy.permissive");
+  });
+});

--- a/packages/policy-engine/src/grant-policy.ts
+++ b/packages/policy-engine/src/grant-policy.ts
@@ -1,0 +1,724 @@
+/**
+ * grant-policy.ts — per-GRANT invoke-time policy (Sovereign Custody, lane C1).
+ *
+ * WHAT THIS GATES
+ * ---------------
+ * Today a capability grant is BINARY: "agent X may use capability Y until
+ * expiresAt". Steward's pitch is authorization ABOVE execution — which agent,
+ * how much, which venue/method, what approval threshold. A `GrantPolicy` is the
+ * per-grant constraint document evaluated at INVOKE time, layered UNDER the
+ * tenant-level `capability-intent` policy set:
+ *
+ *   grant resolution (fail-closed)          — existing
+ *   -> GRANT POLICY (this module)           — per-grant constraints
+ *   -> capability-intent composition        — existing tenant policy set
+ *   -> proxy delegation                     — existing
+ *
+ * BOTH layers must allow; a deny from EITHER is a deny; an approval from either
+ * (with no deny) is a 202. The grant policy can only NARROW what the tenant
+ * policy set would allow, never widen it.
+ *
+ * RULE VOCABULARY (v1)
+ * --------------------
+ *   - `rate`    — N invokes per trailing window (windowSeconds, counted from the
+ *                 append-only capability_invocations audit rows).
+ *   - `amount`  — value-bearing caps: a declared invoke-arg field carrying
+ *                 INTEGER micros (no floats), a per-invoke cap, a rolling-window
+ *                 cumulative cap, and an approval threshold (over X -> 202).
+ *   - `venue`   — allowlist of upstream hosts / methods / path prefixes the
+ *                 grant may exercise (can only narrow the capability's already
+ *                 narrow route surface).
+ *   - `time`    — notBefore / notAfter instants + a UTC minute-of-day allowed
+ *                 window (wrap across midnight supported).
+ *   - `approval`— `always: true` routes EVERY invoke to human approval.
+ *
+ * CLASSES + FAIL-CLOSED DEFAULTS
+ * ------------------------------
+ * Every policy declares a capability `class`:
+ *   - `"value-bearing"` — moves money/value. MUST carry an `amount` block with
+ *     at least one bound; a value-bearing policy without amount limits is a
+ *     config error (deny). A missing/malformed policy on the grant is a DENY for
+ *     this class (the invoke layer enforces via strict mode / parse failure).
+ *   - `"plain-secret"`  — exercises a non-value credential (e.g. read API). A
+ *     bare `{version:1, class:"plain-secret"}` allows iff the grant is valid —
+ *     this is the EXPLICIT permissive default existing grants are migrated to,
+ *     so nothing breaks at rollout.
+ *
+ * DETERMINISM + FAIL-CLOSED EVERYWHERE
+ * ------------------------------------
+ * `evaluateGrantPolicy` is a PURE function of (policy, input): the caller
+ * supplies `now` and the trailing-window counters (fetched per
+ * `grantPolicySignals`), so the same inputs always produce the same verdict.
+ * Any ambiguity denies: unknown keys, a bad window, a missing counter the
+ * policy needs, a missing/non-integer amount arg, an invalid time bound. The
+ * module NEVER throws on hostile config — parse failures are values.
+ *
+ * Every verdict names the RULE that fired (`verdict.rule`) so the audit row can
+ * record exactly why an invoke was allowed, denied, or queued.
+ */
+
+import { MAX_AGGREGATE_WINDOW_SECONDS } from "./capability-intent";
+
+/** Grant policy schema version this module understands. */
+export const GRANT_POLICY_VERSION = 1 as const;
+
+/** The capability class a grant policy declares. Fail-closed: value-bearing
+ *  requires amount limits; a missing policy denies value-bearing exercise. */
+export type GrantCapabilityClass = "value-bearing" | "plain-secret";
+
+/** N invokes per trailing window. Counted from the append-only invocation rows
+ *  (ALL attempts consume rate — a denied probe is not free). */
+export interface GrantRateLimit {
+  readonly maxInvokes: number;
+  readonly windowSeconds: number;
+}
+
+/** Rolling cumulative amount cap over a trailing window (integer micros). */
+export interface GrantAmountWindowCap {
+  readonly maxMicros: number;
+  readonly windowSeconds: number;
+}
+
+/** Amount limits for a value-bearing capability. `argField` names the invoke
+ *  arg that carries the operation's value as a NON-NEGATIVE SAFE INTEGER in
+ *  micros (minor units). A missing/non-integer arg DENIES — an operation whose
+ *  value cannot be read can never pass an amount-constrained policy. */
+export interface GrantAmountPolicy {
+  readonly argField: string;
+  /** per-invoke hard cap: amount > perInvokeMaxMicros => deny. */
+  readonly perInvokeMaxMicros?: number;
+  /** rolling-window cumulative cap: windowSum + amount > maxMicros => deny. */
+  readonly window?: GrantAmountWindowCap;
+  /** approval threshold: amount > approvalOverMicros (and under the hard caps)
+   *  => 202 pending human approval. */
+  readonly approvalOverMicros?: number;
+}
+
+/** Venue/method allowlists. Each list, when present, is a non-empty allowlist
+ *  the resolved capability surface must match. Hosts support a leading `*.`
+ *  wildcard (mirrors the proxy's host matching); path prefixes match on segment
+ *  boundaries. */
+export interface GrantVenuePolicy {
+  readonly hosts?: readonly string[];
+  readonly methods?: readonly string[];
+  readonly pathPrefixes?: readonly string[];
+}
+
+/** UTC minute-of-day window in which invokes are ALLOWED (outside => deny).
+ *  start > end wraps across midnight. start === end is a config error. */
+export interface GrantAllowedWindowUtc {
+  readonly startMinuteUtc: number;
+  readonly endMinuteUtc: number;
+}
+
+/** Time bounds: absolute instants + an allowed minute-of-day window. */
+export interface GrantTimePolicy {
+  readonly notBefore?: string;
+  readonly notAfter?: string;
+  readonly allowedWindowUtc?: GrantAllowedWindowUtc;
+}
+
+/** Approval quorum block. v1: `always` routes every invoke to human approval. */
+export interface GrantApprovalPolicy {
+  readonly always?: boolean;
+}
+
+/** The v1 grant policy document (the `policy` jsonb on capability_grants). */
+export interface GrantPolicyV1 {
+  readonly version: typeof GRANT_POLICY_VERSION;
+  readonly class: GrantCapabilityClass;
+  readonly rate?: GrantRateLimit;
+  readonly amount?: GrantAmountPolicy;
+  readonly venue?: GrantVenuePolicy;
+  readonly time?: GrantTimePolicy;
+  readonly approval?: GrantApprovalPolicy;
+}
+
+/**
+ * The EXPLICIT permissive default existing grants are migrated to (and new
+ * grants receive when created without a policy): plain-secret exercise, no
+ * constraints — exactly the pre-policy behavior, but written down so every
+ * grant's authorization is explicit rather than implied by a NULL.
+ */
+export const LEGACY_DEFAULT_GRANT_POLICY: GrantPolicyV1 = Object.freeze({
+  version: GRANT_POLICY_VERSION,
+  class: "plain-secret",
+});
+
+/** The verdict effects. `approval_required` reuses the existing 202 flow. */
+export type GrantPolicyEffect = "allow" | "deny" | "approval_required";
+
+/** Verdict + WHICH rule fired (audited verbatim). `amountMicros` carries the
+ *  extracted per-invoke amount (when an amount block evaluated) so the invoke
+ *  layer can record it for future rolling-window sums. */
+export interface GrantPolicyVerdict {
+  readonly effect: GrantPolicyEffect;
+  readonly rule: string;
+  readonly reason: string;
+  readonly amountMicros?: number;
+}
+
+/** The trailing-window signals a parsed policy needs the caller to fetch
+ *  before evaluation. Absent-but-required signals DENY at evaluation. */
+export interface GrantPolicySignals {
+  /** rate.windowSeconds, when a rate block is present. */
+  readonly rateWindowSeconds?: number;
+  /** amount.window.windowSeconds, when an amount window cap is present. */
+  readonly amountWindowSeconds?: number;
+}
+
+/** The pure evaluation input. `now` is supplied (never read from the clock)
+ *  so the verdict is a deterministic function of its inputs. */
+export interface GrantPolicyInput {
+  readonly now: Date;
+  readonly capability: {
+    readonly name: string;
+    readonly host: string;
+    readonly path: string;
+    readonly method: string;
+  };
+  readonly args: Record<string, unknown>;
+  /** count of this agent+capability's invocation rows in the rate window. */
+  readonly invokesInWindow?: number;
+  /** sum of recorded allow-row amountMicros in the amount window. */
+  readonly allowedAmountMicrosInWindow?: number;
+}
+
+// ─── parse (fail-closed) ─────────────────────────────────────────────────────
+
+const ALLOWED_POLICY_KEYS: ReadonlySet<string> = new Set([
+  "version",
+  "class",
+  "rate",
+  "amount",
+  "venue",
+  "time",
+  "approval",
+]);
+const ALLOWED_RATE_KEYS: ReadonlySet<string> = new Set(["maxInvokes", "windowSeconds"]);
+const ALLOWED_AMOUNT_KEYS: ReadonlySet<string> = new Set([
+  "argField",
+  "perInvokeMaxMicros",
+  "window",
+  "approvalOverMicros",
+]);
+const ALLOWED_AMOUNT_WINDOW_KEYS: ReadonlySet<string> = new Set(["maxMicros", "windowSeconds"]);
+const ALLOWED_VENUE_KEYS: ReadonlySet<string> = new Set(["hosts", "methods", "pathPrefixes"]);
+const ALLOWED_TIME_KEYS: ReadonlySet<string> = new Set([
+  "notBefore",
+  "notAfter",
+  "allowedWindowUtc",
+]);
+const ALLOWED_WINDOW_UTC_KEYS: ReadonlySet<string> = new Set(["startMinuteUtc", "endMinuteUtc"]);
+const ALLOWED_APPROVAL_KEYS: ReadonlySet<string> = new Set(["always"]);
+const GRANT_CLASSES: ReadonlySet<string> = new Set(["value-bearing", "plain-secret"]);
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+function isPosInt(v: unknown): v is number {
+  return typeof v === "number" && Number.isSafeInteger(v) && v > 0;
+}
+function isNonNegInt(v: unknown): v is number {
+  return typeof v === "number" && Number.isSafeInteger(v) && v >= 0;
+}
+function isMinuteOfDay(v: unknown): v is number {
+  return typeof v === "number" && Number.isInteger(v) && v >= 0 && v <= 1439;
+}
+function isNonEmptyStringArray(v: unknown): v is string[] {
+  return Array.isArray(v) && v.length > 0 && v.every((s) => typeof s === "string" && s.length > 0);
+}
+
+function unknownKeys(obj: Record<string, unknown>, allowed: ReadonlySet<string>): string[] {
+  return Object.keys(obj).filter((k) => !allowed.has(k));
+}
+
+/** A window must be a positive integer of seconds within aggregate-store
+ *  retention (an over-retention window would silently under-enforce). */
+function isValidWindowSeconds(v: unknown): v is number {
+  return isPosInt(v) && v <= MAX_AGGREGATE_WINDOW_SECONDS;
+}
+
+export type GrantPolicyParseResult =
+  | { readonly ok: true; readonly policy: GrantPolicyV1 }
+  | { readonly ok: false; readonly error: string };
+
+/**
+ * Validate an untrusted jsonb value into a typed {@link GrantPolicyV1}, or
+ * return an error string (the caller DENIES on error — a malformed policy on a
+ * grant can never be silently ignored). Never throws.
+ */
+export function parseGrantPolicy(raw: unknown): GrantPolicyParseResult {
+  // Hostile values (throwing Proxy traps / getters, e.g. a hostile jsonb
+  // deserializer) must not unwind past this function: a throw from a POLICY
+  // gate would surface as a raw 500 upstream instead of a fail-closed deny.
+  // The inner body does the actual validation; ANY escape is a parse error.
+  try {
+    return parseGrantPolicyInner(raw);
+  } catch {
+    return { ok: false, error: "grant-policy: policy is unreadable (hostile or invalid value)" };
+  }
+}
+
+function parseGrantPolicyInner(raw: unknown): GrantPolicyParseResult {
+  if (!isPlainObject(raw)) return { ok: false, error: "grant-policy: policy must be an object" };
+  const unknown = unknownKeys(raw, ALLOWED_POLICY_KEYS);
+  if (unknown.length > 0) {
+    return { ok: false, error: `grant-policy: unknown key(s): ${unknown.join(", ")}` };
+  }
+  if (raw.version !== GRANT_POLICY_VERSION) {
+    return { ok: false, error: "grant-policy: `version` must be 1" };
+  }
+  if (typeof raw.class !== "string" || !GRANT_CLASSES.has(raw.class)) {
+    return { ok: false, error: 'grant-policy: `class` must be "value-bearing"|"plain-secret"' };
+  }
+  const cls = raw.class as GrantCapabilityClass;
+
+  // rate
+  let rate: GrantRateLimit | undefined;
+  if (raw.rate !== undefined) {
+    if (!isPlainObject(raw.rate))
+      return { ok: false, error: "grant-policy: `rate` must be an object" };
+    const u = unknownKeys(raw.rate, ALLOWED_RATE_KEYS);
+    if (u.length > 0)
+      return { ok: false, error: `grant-policy: unknown rate key(s): ${u.join(", ")}` };
+    if (!isPosInt(raw.rate.maxInvokes)) {
+      return { ok: false, error: "grant-policy: `rate.maxInvokes` must be a positive integer" };
+    }
+    if (!isValidWindowSeconds(raw.rate.windowSeconds)) {
+      return {
+        ok: false,
+        error: `grant-policy: \`rate.windowSeconds\` must be a positive integer <= ${MAX_AGGREGATE_WINDOW_SECONDS}`,
+      };
+    }
+    rate = { maxInvokes: raw.rate.maxInvokes, windowSeconds: raw.rate.windowSeconds };
+  }
+
+  // amount
+  let amount: GrantAmountPolicy | undefined;
+  if (raw.amount !== undefined) {
+    if (!isPlainObject(raw.amount)) {
+      return { ok: false, error: "grant-policy: `amount` must be an object" };
+    }
+    const u = unknownKeys(raw.amount, ALLOWED_AMOUNT_KEYS);
+    if (u.length > 0) {
+      return { ok: false, error: `grant-policy: unknown amount key(s): ${u.join(", ")}` };
+    }
+    if (typeof raw.amount.argField !== "string" || raw.amount.argField.length === 0) {
+      return { ok: false, error: "grant-policy: `amount.argField` must be a non-empty string" };
+    }
+    let perInvokeMaxMicros: number | undefined;
+    if (raw.amount.perInvokeMaxMicros !== undefined) {
+      if (!isNonNegInt(raw.amount.perInvokeMaxMicros)) {
+        return {
+          ok: false,
+          error: "grant-policy: `amount.perInvokeMaxMicros` must be a non-negative integer",
+        };
+      }
+      perInvokeMaxMicros = raw.amount.perInvokeMaxMicros;
+    }
+    let window: GrantAmountWindowCap | undefined;
+    if (raw.amount.window !== undefined) {
+      if (!isPlainObject(raw.amount.window)) {
+        return { ok: false, error: "grant-policy: `amount.window` must be an object" };
+      }
+      const wu = unknownKeys(raw.amount.window, ALLOWED_AMOUNT_WINDOW_KEYS);
+      if (wu.length > 0) {
+        return { ok: false, error: `grant-policy: unknown amount.window key(s): ${wu.join(", ")}` };
+      }
+      if (!isNonNegInt(raw.amount.window.maxMicros)) {
+        return {
+          ok: false,
+          error: "grant-policy: `amount.window.maxMicros` must be a non-negative integer",
+        };
+      }
+      if (!isValidWindowSeconds(raw.amount.window.windowSeconds)) {
+        return {
+          ok: false,
+          error: `grant-policy: \`amount.window.windowSeconds\` must be a positive integer <= ${MAX_AGGREGATE_WINDOW_SECONDS}`,
+        };
+      }
+      window = {
+        maxMicros: raw.amount.window.maxMicros,
+        windowSeconds: raw.amount.window.windowSeconds,
+      };
+    }
+    let approvalOverMicros: number | undefined;
+    if (raw.amount.approvalOverMicros !== undefined) {
+      if (!isNonNegInt(raw.amount.approvalOverMicros)) {
+        return {
+          ok: false,
+          error: "grant-policy: `amount.approvalOverMicros` must be a non-negative integer",
+        };
+      }
+      approvalOverMicros = raw.amount.approvalOverMicros;
+    }
+    if (
+      perInvokeMaxMicros === undefined &&
+      window === undefined &&
+      approvalOverMicros === undefined
+    ) {
+      return {
+        ok: false,
+        error:
+          "grant-policy: `amount` must declare at least one bound (perInvokeMaxMicros, window, approvalOverMicros)",
+      };
+    }
+    amount = { argField: raw.amount.argField, perInvokeMaxMicros, window, approvalOverMicros };
+  }
+
+  // A value-bearing capability class without amount limits is unauthorized by
+  // construction: the whole point of the class is that value movement is bounded.
+  if (cls === "value-bearing" && amount === undefined) {
+    return {
+      ok: false,
+      error: 'grant-policy: class "value-bearing" requires an `amount` block',
+    };
+  }
+
+  // venue
+  let venue: GrantVenuePolicy | undefined;
+  if (raw.venue !== undefined) {
+    if (!isPlainObject(raw.venue)) {
+      return { ok: false, error: "grant-policy: `venue` must be an object" };
+    }
+    const u = unknownKeys(raw.venue, ALLOWED_VENUE_KEYS);
+    if (u.length > 0) {
+      return { ok: false, error: `grant-policy: unknown venue key(s): ${u.join(", ")}` };
+    }
+    const venueOut: { hosts?: string[]; methods?: string[]; pathPrefixes?: string[] } = {};
+    if (raw.venue.hosts !== undefined) {
+      if (!isNonEmptyStringArray(raw.venue.hosts)) {
+        return {
+          ok: false,
+          error: "grant-policy: `venue.hosts` must be a non-empty array of non-empty strings",
+        };
+      }
+      venueOut.hosts = raw.venue.hosts.map((h) => h.toLowerCase());
+    }
+    if (raw.venue.methods !== undefined) {
+      if (!isNonEmptyStringArray(raw.venue.methods)) {
+        return {
+          ok: false,
+          error: "grant-policy: `venue.methods` must be a non-empty array of non-empty strings",
+        };
+      }
+      venueOut.methods = raw.venue.methods.map((m) => m.toUpperCase());
+    }
+    if (raw.venue.pathPrefixes !== undefined) {
+      if (!isNonEmptyStringArray(raw.venue.pathPrefixes)) {
+        return {
+          ok: false,
+          error:
+            "grant-policy: `venue.pathPrefixes` must be a non-empty array of non-empty strings",
+        };
+      }
+      const bad = raw.venue.pathPrefixes.find((p) => !p.startsWith("/"));
+      if (bad !== undefined) {
+        return {
+          ok: false,
+          error: "grant-policy: every `venue.pathPrefixes` entry must start with /",
+        };
+      }
+      venueOut.pathPrefixes = [...raw.venue.pathPrefixes];
+    }
+    if (
+      venueOut.hosts === undefined &&
+      venueOut.methods === undefined &&
+      venueOut.pathPrefixes === undefined
+    ) {
+      return { ok: false, error: "grant-policy: `venue` must declare at least one allowlist" };
+    }
+    venue = venueOut;
+  }
+
+  // time
+  let time: GrantTimePolicy | undefined;
+  if (raw.time !== undefined) {
+    if (!isPlainObject(raw.time)) {
+      return { ok: false, error: "grant-policy: `time` must be an object" };
+    }
+    const u = unknownKeys(raw.time, ALLOWED_TIME_KEYS);
+    if (u.length > 0) {
+      return { ok: false, error: `grant-policy: unknown time key(s): ${u.join(", ")}` };
+    }
+    const timeOut: {
+      notBefore?: string;
+      notAfter?: string;
+      allowedWindowUtc?: GrantAllowedWindowUtc;
+    } = {};
+    let notBeforeMs: number | undefined;
+    let notAfterMs: number | undefined;
+    if (raw.time.notBefore !== undefined) {
+      if (
+        typeof raw.time.notBefore !== "string" ||
+        !Number.isFinite(Date.parse(raw.time.notBefore))
+      ) {
+        return { ok: false, error: "grant-policy: `time.notBefore` must be an ISO-8601 instant" };
+      }
+      timeOut.notBefore = raw.time.notBefore;
+      notBeforeMs = Date.parse(raw.time.notBefore);
+    }
+    if (raw.time.notAfter !== undefined) {
+      if (
+        typeof raw.time.notAfter !== "string" ||
+        !Number.isFinite(Date.parse(raw.time.notAfter))
+      ) {
+        return { ok: false, error: "grant-policy: `time.notAfter` must be an ISO-8601 instant" };
+      }
+      timeOut.notAfter = raw.time.notAfter;
+      notAfterMs = Date.parse(raw.time.notAfter);
+    }
+    if (notBeforeMs !== undefined && notAfterMs !== undefined && notBeforeMs >= notAfterMs) {
+      return { ok: false, error: "grant-policy: `time.notBefore` must be before `time.notAfter`" };
+    }
+    if (raw.time.allowedWindowUtc !== undefined) {
+      const w = raw.time.allowedWindowUtc;
+      if (!isPlainObject(w)) {
+        return { ok: false, error: "grant-policy: `time.allowedWindowUtc` must be an object" };
+      }
+      const wu = unknownKeys(w, ALLOWED_WINDOW_UTC_KEYS);
+      if (wu.length > 0) {
+        return {
+          ok: false,
+          error: `grant-policy: unknown time.allowedWindowUtc key(s): ${wu.join(", ")}`,
+        };
+      }
+      if (!isMinuteOfDay(w.startMinuteUtc) || !isMinuteOfDay(w.endMinuteUtc)) {
+        return {
+          ok: false,
+          error: "grant-policy: `time.allowedWindowUtc` minutes must be integers in 0..1439",
+        };
+      }
+      if (w.startMinuteUtc === w.endMinuteUtc) {
+        return {
+          ok: false,
+          error:
+            "grant-policy: `time.allowedWindowUtc` start and end must differ (an empty/full window is ambiguous)",
+        };
+      }
+      timeOut.allowedWindowUtc = { startMinuteUtc: w.startMinuteUtc, endMinuteUtc: w.endMinuteUtc };
+    }
+    if (
+      timeOut.notBefore === undefined &&
+      timeOut.notAfter === undefined &&
+      timeOut.allowedWindowUtc === undefined
+    ) {
+      return { ok: false, error: "grant-policy: `time` must declare at least one bound" };
+    }
+    time = timeOut;
+  }
+
+  // approval
+  let approval: GrantApprovalPolicy | undefined;
+  if (raw.approval !== undefined) {
+    if (!isPlainObject(raw.approval)) {
+      return { ok: false, error: "grant-policy: `approval` must be an object" };
+    }
+    const u = unknownKeys(raw.approval, ALLOWED_APPROVAL_KEYS);
+    if (u.length > 0) {
+      return { ok: false, error: `grant-policy: unknown approval key(s): ${u.join(", ")}` };
+    }
+    if (raw.approval.always !== undefined && typeof raw.approval.always !== "boolean") {
+      return { ok: false, error: "grant-policy: `approval.always` must be a boolean" };
+    }
+    approval = { always: raw.approval.always };
+  }
+
+  return {
+    ok: true,
+    policy: { version: GRANT_POLICY_VERSION, class: cls, rate, amount, venue, time, approval },
+  };
+}
+
+/** The trailing-window counters a parsed policy requires the caller to fetch. */
+export function grantPolicySignals(policy: GrantPolicyV1): GrantPolicySignals {
+  return {
+    rateWindowSeconds: policy.rate?.windowSeconds,
+    amountWindowSeconds: policy.amount?.window?.windowSeconds,
+  };
+}
+
+// ─── evaluate (pure, deterministic, deny-first) ──────────────────────────────
+
+/** host allowlist entry match: exact, or `*.suffix` subdomain wildcard
+ *  (mirrors the proxy's host matching; a bare `*.x` never matches `x` itself). */
+function hostEntryMatches(entry: string, host: string): boolean {
+  if (entry === host) return true;
+  if (entry.startsWith("*.")) {
+    const suffix = entry.slice(1); // ".example.com"
+    return host.endsWith(suffix) && host.length > suffix.length;
+  }
+  return false;
+}
+
+/** path prefix match on segment boundaries: `/a/b` matches `/a/b` and
+ *  `/a/b/c`, never `/a/bc`. */
+function pathPrefixMatches(prefix: string, path: string): boolean {
+  if (prefix === path) return true;
+  const p = prefix.endsWith("/") ? prefix : `${prefix}/`;
+  return path.startsWith(p);
+}
+
+function deny(rule: string, reason: string, amountMicros?: number): GrantPolicyVerdict {
+  return { effect: "deny", rule, reason, amountMicros };
+}
+
+/**
+ * Evaluate a PARSED grant policy against a single invoke. Pure + deterministic:
+ * no clock reads, no I/O, never throws. Deny-first precedence:
+ *
+ *   venue -> time -> rate -> amount hard caps -> approval routing -> allow
+ *
+ * A deny can never be softened into an approval; approvals are only reachable
+ * once every hard constraint has passed.
+ */
+export function evaluateGrantPolicy(
+  policy: GrantPolicyV1,
+  input: GrantPolicyInput,
+): GrantPolicyVerdict {
+  const cap = input.capability;
+
+  // venue allowlists (narrowing only: the capability surface must be inside).
+  if (policy.venue) {
+    const host = cap.host.toLowerCase();
+    if (policy.venue.hosts && !policy.venue.hosts.some((h) => hostEntryMatches(h, host))) {
+      return deny("venue.host", `grant-policy: host "${host}" not in grant venue allowlist`);
+    }
+    const method = cap.method.toUpperCase();
+    if (policy.venue.methods && !policy.venue.methods.includes(method)) {
+      return deny("venue.method", `grant-policy: method "${method}" not in grant venue allowlist`);
+    }
+    if (
+      policy.venue.pathPrefixes &&
+      !policy.venue.pathPrefixes.some((p) => pathPrefixMatches(p, cap.path))
+    ) {
+      return deny("venue.path", "grant-policy: capability path not in grant venue allowlist");
+    }
+  }
+
+  // time bounds.
+  if (policy.time) {
+    const nowMs = input.now.getTime();
+    if (policy.time.notBefore !== undefined && nowMs < Date.parse(policy.time.notBefore)) {
+      return deny("time.notBefore", "grant-policy: grant not usable yet (before notBefore)");
+    }
+    if (policy.time.notAfter !== undefined && nowMs > Date.parse(policy.time.notAfter)) {
+      return deny("time.notAfter", "grant-policy: grant usage window has ended (after notAfter)");
+    }
+    if (policy.time.allowedWindowUtc) {
+      const { startMinuteUtc, endMinuteUtc } = policy.time.allowedWindowUtc;
+      const minute = input.now.getUTCHours() * 60 + input.now.getUTCMinutes();
+      const inside =
+        startMinuteUtc < endMinuteUtc
+          ? minute >= startMinuteUtc && minute < endMinuteUtc
+          : minute >= startMinuteUtc || minute < endMinuteUtc;
+      if (!inside) {
+        return deny("time.window", "grant-policy: outside the allowed time-of-day window");
+      }
+    }
+  }
+
+  // rate limit. A missing counter is a missing REQUIRED signal: deny (the
+  // invoke layer must wire the count; a cap that cannot be checked cannot pass).
+  if (policy.rate) {
+    if (typeof input.invokesInWindow !== "number" || !Number.isFinite(input.invokesInWindow)) {
+      return deny("rate.signal-missing", "grant-policy: invoke count unavailable for rate window");
+    }
+    if (input.invokesInWindow >= policy.rate.maxInvokes) {
+      return deny(
+        "rate.limit",
+        `grant-policy: rate limit exceeded (${policy.rate.maxInvokes} per ${policy.rate.windowSeconds}s)`,
+      );
+    }
+  }
+
+  // amount limits. The declared arg must be a non-negative safe integer
+  // (micros); anything else denies — value that cannot be read cannot be bounded.
+  let amountMicros: number | undefined;
+  if (policy.amount) {
+    const rawAmount = input.args[policy.amount.argField];
+    if (typeof rawAmount !== "number" || !Number.isSafeInteger(rawAmount) || rawAmount < 0) {
+      return deny(
+        "amount.arg",
+        `grant-policy: invoke arg "${policy.amount.argField}" must be a non-negative integer (micros)`,
+      );
+    }
+    amountMicros = rawAmount;
+    if (
+      policy.amount.perInvokeMaxMicros !== undefined &&
+      amountMicros > policy.amount.perInvokeMaxMicros
+    ) {
+      return deny(
+        "amount.perInvokeMax",
+        `grant-policy: amount ${amountMicros} exceeds per-invoke cap ${policy.amount.perInvokeMaxMicros}`,
+        amountMicros,
+      );
+    }
+    if (policy.amount.window) {
+      const sum = input.allowedAmountMicrosInWindow;
+      if (typeof sum !== "number" || !Number.isFinite(sum)) {
+        return deny(
+          "amount.signal-missing",
+          "grant-policy: rolling amount sum unavailable for window cap",
+          amountMicros,
+        );
+      }
+      if (sum + amountMicros > policy.amount.window.maxMicros) {
+        return deny(
+          "amount.windowMax",
+          `grant-policy: rolling window cap exceeded (${sum} + ${amountMicros} > ${policy.amount.window.maxMicros})`,
+          amountMicros,
+        );
+      }
+    }
+  }
+
+  // approval routing (only reachable after every hard constraint passed).
+  if (policy.approval?.always === true) {
+    return {
+      effect: "approval_required",
+      rule: "approval.always",
+      reason: "grant-policy: this grant requires human approval for every invoke",
+      amountMicros,
+    };
+  }
+  if (
+    policy.amount?.approvalOverMicros !== undefined &&
+    amountMicros !== undefined &&
+    amountMicros > policy.amount.approvalOverMicros
+  ) {
+    return {
+      effect: "approval_required",
+      rule: "amount.approvalOver",
+      reason: `grant-policy: amount ${amountMicros} over approval threshold ${policy.amount.approvalOverMicros}`,
+      amountMicros,
+    };
+  }
+
+  return {
+    effect: "allow",
+    rule: "allow",
+    reason: "grant-policy: all grant constraints passed",
+    amountMicros,
+  };
+}
+
+/**
+ * The verdict for a grant that carries NO policy document (NULL column — only
+ * possible for rows written outside the migrated path). Strict mode fails
+ * closed (deny); compatibility mode preserves pre-policy behavior explicitly.
+ */
+export function noPolicyVerdict(strict: boolean): GrantPolicyVerdict {
+  return strict
+    ? {
+        effect: "deny",
+        rule: "no-policy.strict",
+        reason: "grant-policy: grant has no policy and strict mode is enabled",
+      }
+    : {
+        effect: "allow",
+        rule: "no-policy.permissive",
+        reason: "grant-policy: grant has no policy (permissive compatibility mode)",
+      };
+}

--- a/packages/policy-engine/src/index.ts
+++ b/packages/policy-engine/src/index.ts
@@ -76,6 +76,30 @@ export type { ReputationThresholdConfig } from "./evaluators/reputation-threshol
 export { evaluateReputationThreshold } from "./evaluators/reputation-threshold";
 export type { VenueAllowlistContext } from "./evaluators/venue-allowlist";
 export { evaluateVenueAllowlist } from "./evaluators/venue-allowlist";
+export type {
+  GrantAllowedWindowUtc,
+  GrantAmountPolicy,
+  GrantAmountWindowCap,
+  GrantApprovalPolicy,
+  GrantCapabilityClass,
+  GrantPolicyEffect,
+  GrantPolicyInput,
+  GrantPolicyParseResult,
+  GrantPolicySignals,
+  GrantPolicyV1,
+  GrantPolicyVerdict,
+  GrantRateLimit,
+  GrantTimePolicy,
+  GrantVenuePolicy,
+} from "./grant-policy";
+export {
+  evaluateGrantPolicy,
+  GRANT_POLICY_VERSION,
+  grantPolicySignals,
+  LEGACY_DEFAULT_GRANT_POLICY,
+  noPolicyVerdict,
+  parseGrantPolicy,
+} from "./grant-policy";
 export type { ManualApprovalSignal } from "./manual-approval";
 export { resultRequiresManualApproval } from "./manual-approval";
 export type { RegisteredPolicyEvaluator } from "./policy-rule-registry";


### PR DESCRIPTION
## What

Pillar C / lane C1 of the Sovereign Custody plan: a real **policy engine on the capability invoke path**. Today a grant is binary (agent may use capability until `expiresAt`). This PR adds per-grant, invoke-time constraints — which agent, how much, which venue, what approval threshold — enforced server-side, layered UNDER the existing tenant `capability-intent` policy set.

## Design

**Two-layer composition** on `POST /capabilities/:name/invoke` (and the OpenAI-compat adapter, which shares the same core):

```
grant resolution (fail-closed, existing)
  -> GRANT POLICY (new, per-grant jsonb)      deny -> 403
  -> capability-intent composition (existing) deny -> 403
  -> approval from either layer (no deny)     -> 202 (existing pending flow)
  -> allow + allow                            -> proxy delegation (existing)
```

A deny from either layer wins; the grant layer can only **narrow** the tenant layer, never widen it. The agent SDK surface is unchanged: allow / deny / 202.

**Rule vocabulary (v1)** — `@stwd/policy-engine` `grant-policy.ts`, pure/deterministic/non-throwing:
- `rate`: N invokes per trailing window (counted from the append-only `capability_invocations` rows; denied probes consume rate)
- `amount` (value-bearing): declared integer-micros arg field, per-invoke hard cap, rolling-window cumulative cap, and `approvalOverMicros` (over X → 202 human approval)
- `venue`: allowlists of hosts (`*.` wildcard, mirrors proxy matching), methods, segment-boundary path prefixes
- `time`: `notBefore`/`notAfter` + UTC minute-of-day allowed window (wraps across midnight)
- `approval.always`: every invoke → human approval

**Capability classes, fail-closed:**
- `value-bearing` **must** carry amount bounds — a value-bearing policy without them is a config error (deny)
- `plain-secret` with no constraints allows iff the grant is valid — this is the **explicit permissive default** existing grants are migrated to

**Fail-closed everywhere:** unknown keys, malformed/over-retention windows, missing trailing-window counters, unreadable amount args, hostile jsonb values — all deny. A deny is never softened into an approval (deny-first precedence, same discipline as `composeCapabilityIntentDecision`).

**Audit:** every terminal outcome records `verdict_rule` + `verdict_reason` (+ `amount_micros`) on its invocation row — you can always answer *which rule fired*. The rolling amount window sums `allow`+`approval`+`error` rows: pending approvals and post-authorization infra errors **reserve** spend, so parallel invokes cannot overshoot a money cap (over-counting acceptable; under-counting never).

## Migration / rollout (nothing breaks)

- `capability_grants.policy` jsonb: migration 0002 backfills existing rows and defaults new rows to `{"version":1,"class":"plain-secret"}` — exactly pre-policy behavior, but written down instead of implied by NULL
- **Flag-gated strict mode**: `STEWARD_GRANT_POLICY_STRICT=true` makes a NULL policy (rows written outside the migrated path) deny; compatibility mode allows with an audited `no-policy.permissive` verdict
- Grant create accepts an optional `policy` (validated by the **same** fail-closed parser the invoke path enforces with — single source of truth, no drift); new `PUT /capabilities/grants/:grantId/policy` (tenant-admin + recent MFA, the same bar as every other grant mutation) edits it, effective next invoke

## Tests (bidirectional)

- **70 engine tests**: every rule blocks what it should AND allows what it should; malformed-config parse matrix (25+ rejection cases incl. hostile Proxy values); precedence (hard deny beats approval); determinism
- **18 enforcement tests** at the mounted invoke route over real PGLite + plugin migrations: rate arc (N pass, N+1 blocked, rule audited), amount per-invoke cap / approval threshold 202 with reserved spend / rolling window breach incl. pending-approval reservation, venue block+pass, time bounds block+pass, tenant-deny-beats-grant-allow and tenant-deny-beats-grant-approval layering, malformed + stripped policy rows deny, strict-mode flag both ways, verdict audit on every row
- Full plugin suite: 161 pass / 5 fail — the 5 failures (`invoke-e2e` proxy-forward AES decrypt error) **pre-exist on the base commit with a clean tree** (verified via `git stash`: same 5 fail without this diff; an env-dependent keystore issue unrelated to this change)

## Scope notes

- Enforcement is entirely server-side in `plugin-capabilities` invoke (the single shared core used by both the envelope route and the OpenAI adapter). The `packages/proxy` redis rate/spend enforcement is untouched — it remains the per-host transport-layer backstop; this PR is the authorization layer above it.
- Approval quorum >1 and provider-verified amount extraction are follow-ups; the 202 path reuses the existing approval state machine.

Part of SOVEREIGN-CUSTODY-PILLARS-2026-07-30.md (Pillar C, lane C1).