### PR TITLE
feat(sealed-state): attestation-bound agent state at rest (C2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ COPY packages/adapters/package.json          packages/adapters/package.json
 COPY packages/agent-trader/package.json      packages/agent-trader/package.json
 COPY packages/api/package.json               packages/api/package.json
 COPY packages/attestation/package.json       packages/attestation/package.json
+COPY packages/sealed-state/package.json       packages/sealed-state/package.json
 COPY packages/auth/package.json              packages/auth/package.json
 COPY packages/db/package.json                packages/db/package.json
 COPY packages/eliza-plugin/package.json      packages/eliza-plugin/package.json
@@ -84,6 +85,7 @@ COPY packages/adapters/package.json          packages/adapters/package.json
 COPY packages/agent-trader/package.json      packages/agent-trader/package.json
 COPY packages/api/package.json               packages/api/package.json
 COPY packages/attestation/package.json       packages/attestation/package.json
+COPY packages/sealed-state/package.json       packages/sealed-state/package.json
 COPY packages/auth/package.json              packages/auth/package.json
 COPY packages/db/package.json                packages/db/package.json
 COPY packages/eliza-plugin/package.json      packages/eliza-plugin/package.json
@@ -119,6 +121,7 @@ RUN BUN_FROZEN_LOCKFILE=0 bun install --no-frozen-lockfile --ignore-scripts
 COPY packages/adapters    packages/adapters
 COPY packages/api         packages/api
 COPY packages/attestation packages/attestation
+COPY packages/sealed-state packages/sealed-state
 COPY packages/auth        packages/auth
 COPY packages/db          packages/db
 COPY packages/plugin-capabilities packages/plugin-capabilities
@@ -142,6 +145,7 @@ COPY packages/webhooks    packages/webhooks
 RUN mkdir -p node_modules/@stwd && \
     ln -sf ../../../packages/adapters      node_modules/@stwd/adapters && \
     ln -sf ../../../packages/attestation   node_modules/@stwd/attestation && \
+    ln -sf ../../../packages/sealed-state   node_modules/@stwd/sealed-state && \
     ln -sf ../../../packages/shared        node_modules/@stwd/shared && \
     ln -sf ../../../packages/sdk           node_modules/@stwd/sdk && \
     ln -sf ../../../packages/auth          node_modules/@stwd/auth && \
@@ -182,6 +186,7 @@ COPY packages/adapters/package.json          packages/adapters/package.json
 COPY packages/agent-trader/package.json      packages/agent-trader/package.json
 COPY packages/api/package.json               packages/api/package.json
 COPY packages/attestation/package.json       packages/attestation/package.json
+COPY packages/sealed-state/package.json       packages/sealed-state/package.json
 COPY packages/auth/package.json              packages/auth/package.json
 COPY packages/db/package.json                packages/db/package.json
 COPY packages/eliza-plugin/package.json      packages/eliza-plugin/package.json
@@ -214,6 +219,7 @@ RUN BUN_FROZEN_LOCKFILE=0 bun install --production --no-frozen-lockfile --ignore
 COPY --from=build /app/packages/adapters    packages/adapters
 COPY --from=build /app/packages/api         packages/api
 COPY --from=build /app/packages/attestation packages/attestation
+COPY --from=build /app/packages/sealed-state packages/sealed-state
 COPY --from=build /app/packages/auth        packages/auth
 COPY --from=build /app/packages/db          packages/db
 COPY --from=build /app/packages/plugin-capabilities packages/plugin-capabilities
@@ -237,6 +243,7 @@ COPY --from=build /app/packages/webhooks    packages/webhooks
 RUN mkdir -p node_modules/@stwd && \
     ln -sf ../../../packages/adapters      node_modules/@stwd/adapters && \
     ln -sf ../../../packages/attestation   node_modules/@stwd/attestation && \
+    ln -sf ../../../packages/sealed-state   node_modules/@stwd/sealed-state && \
     ln -sf ../../../packages/shared        node_modules/@stwd/shared && \
     ln -sf ../../../packages/sdk           node_modules/@stwd/sdk && \
     ln -sf ../../../packages/auth          node_modules/@stwd/auth && \

--- a/bun.lock
+++ b/bun.lock
@@ -63,6 +63,7 @@
         "@stwd/provider-github": "workspace:*",
         "@stwd/provider-x": "workspace:*",
         "@stwd/redis": "workspace:*",
+        "@stwd/sealed-state": "workspace:*",
         "@stwd/shared": "workspace:*",
         "@stwd/vault": "workspace:*",
         "@stwd/webhooks": "workspace:*",
@@ -445,6 +446,17 @@
       },
       "devDependencies": {
         "@simplewebauthn/browser": "^13.0.0",
+      },
+    },
+    "packages/sealed-state": {
+      "name": "@stwd/sealed-state",
+      "version": "0.1.0",
+      "dependencies": {
+        "@stwd/attestation": "workspace:*",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "@types/node": "^25.5.0",
       },
     },
     "packages/seed": {
@@ -1740,6 +1752,8 @@
     "@stwd/redis": ["@stwd/redis@workspace:packages/redis"],
 
     "@stwd/sdk": ["@stwd/sdk@workspace:packages/sdk"],
+
+    "@stwd/sealed-state": ["@stwd/sealed-state@workspace:packages/sealed-state"],
 
     "@stwd/seed": ["@stwd/seed@workspace:packages/seed"],
 

--- a/docs/SEALED-STATE.md
+++ b/docs/SEALED-STATE.md
@@ -1,0 +1,38 @@
+# Attestation-bound sealed state
+
+## Package placement audit
+
+Sealed agent state belongs in a new `@stwd/sealed-state`, not `@stwd/vault`. Vault protects signing keys and credentials with tenant policy, database records, and signing/exercise APIs. Agent memory and runtime snapshots are opaque blobs whose release condition is a runtime measurement. Putting them in Vault would conflate operator credential custody with runtime disk encryption. The new package consumes `@stwd/attestation` measurement types while keeping encryption and runtime-key derivation independently replaceable.
+
+## Envelope
+
+`SealedState` generates a random AES-256-GCM data-encryption key (DEK) for every blob. The blob is encrypted with the DEK and the DEK is wrapped with a backend-derived key-encryption key (KEK). Provider id, purpose, image digest, and configuration/compose hash are authenticated as AAD. Any ciphertext, tag, or metadata corruption fails closed.
+
+The production `dstack-tdx` backend calls the dstack Guest Agent `/Info`, requires its current `os_image_hash` and `compose_hash` to equal the requested measurement, then calls `/GetKey` with a measurement- and purpose-separated path. dstack derives that key from the application key held by its KMS. A different measured application cannot derive the same KEK. The application key and wrapping root are not stored by Steward.
+
+`INSECURE-noop-dev` derives a deterministic test KEK from an explicit development secret and simulated measurement. It throws in `NODE_ENV=production`. It exists only for local tests and mismatch proofs.
+
+## Live consumer
+
+`packages/api/src/embedded.ts` is the production entry for `bun run start:local`. With `STEWARD_SEALED_PGLITE_PATH` set, it runs PGLite in memory, unseals a prior database snapshot before startup, and atomically seals a new snapshot during the API shutdown hook. No plaintext PGLite directory is persisted. The default backend is `dstack-tdx`; `STEWARD_SEALED_STATE_BACKEND=noop-dev` requires `STEWARD_SEALED_STATE_DEV_SECRET` and is development-only.
+
+This is an additive, opt-in migration. Existing plaintext PGLite directories are not silently imported because doing that could leave an unnoticed plaintext copy. Operators must deliberately migrate/export and securely retire the old directory.
+
+## Threat model
+
+Protects a copied encrypted snapshot from:
+
+- storage, backup, or volume disclosure;
+- a runtime with a different image or compose/config measurement;
+- accidental ciphertext or authenticated-header modification;
+- database-at-rest inspection by an operator who does not control the dstack application key.
+
+The dstack verifier and measurement registry remain responsible for deciding whether a measurement is approved. Sealing enforces equality and cryptographic custody, not approval policy.
+
+## Explicit non-goals
+
+- **Same-measurement malicious host/runtime:** a runtime that can legitimately obtain the same dstack application key can unseal the state. Rollbacks and cloned authorized instances require deployment policy and KMS revocation controls.
+- **Use-time compromise:** plaintext necessarily exists in enclave memory while PGLite or an agent uses it. RCE inside the measured runtime can read it.
+- Hiding access patterns, blob sizes, or timestamps.
+- Crash-consistent continuous database journaling. The pilot seals on graceful shutdown; abrupt power loss can lose changes since boot, so it is not yet the recommended high-availability database profile.
+- Automatic deletion of legacy plaintext data or operator backups.

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -38,6 +38,7 @@
     "@stwd/provider-github": "workspace:*",
     "@stwd/provider-x": "workspace:*",
     "@stwd/redis": "workspace:*",
+    "@stwd/sealed-state": "workspace:*",
     "@stwd/shared": "workspace:*",
     "@stwd/vault": "workspace:*",
     "@stwd/webhooks": "workspace:*",

--- a/packages/api/src/__tests__/sealed-pglite-snapshot.test.ts
+++ b/packages/api/src/__tests__/sealed-pglite-snapshot.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createPGLiteDb } from "@stwd/db/pglite";
+import { DevMeasurementKeyProvider, SealedState } from "@stwd/sealed-state";
+
+const clients: Array<{ close(): Promise<void> }> = [];
+afterEach(async () => {
+  await Promise.all(clients.splice(0).map((client) => client.close()));
+});
+
+describe("embedded sealed PGLite production path", () => {
+  test("persists and restores state only through an authenticated envelope", async () => {
+    process.env.STEWARD_PGLITE_MEMORY = "true";
+    const first = await createPGLiteDb();
+    clients.push(first.client);
+    await first.client.exec("CREATE TABLE sealed_probe (value text NOT NULL)");
+    await first.client.exec("INSERT INTO sealed_probe VALUES ('private memory')");
+
+    const dump = await first.client.dumpDataDir("gzip");
+    const measurement = { imageDigest: "test-image", configHash: "test-compose" };
+    const sealed = new SealedState(
+      new DevMeasurementKeyProvider("development-secret-only", "test"),
+    );
+    const envelope = await sealed.seal(
+      new Uint8Array(await dump.arrayBuffer()),
+      measurement,
+      "embedded-agent-state",
+    );
+    expect(JSON.stringify(envelope)).not.toContain("private memory");
+
+    const restoredBytes = await sealed.unseal(envelope, measurement);
+    const restored = await createPGLiteDb(
+      undefined,
+      new Blob([
+        restoredBytes.buffer.slice(
+          restoredBytes.byteOffset,
+          restoredBytes.byteOffset + restoredBytes.byteLength,
+        ) as ArrayBuffer,
+      ]),
+    );
+    clients.push(restored.client);
+    const result = await restored.client.query<{ value: string }>("SELECT value FROM sealed_probe");
+    expect(result.rows[0]?.value).toBe("private memory");
+  }, 30_000);
+});

--- a/packages/api/src/__tests__/shutdown-hooks.test.ts
+++ b/packages/api/src/__tests__/shutdown-hooks.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import { registerShutdownHook, runShutdownHooks } from "../services/shutdown-hooks";
+
+describe("shutdown durability hooks", () => {
+  test("runs registered persistence work", async () => {
+    let persisted = false;
+    registerShutdownHook(() => {
+      persisted = true;
+    });
+    await runShutdownHooks();
+    expect(persisted).toBe(true);
+  });
+
+  test("fails closed when persistence fails", async () => {
+    registerShutdownHook(() => {
+      throw new Error("seal failed");
+    });
+    await expect(runShutdownHooks()).rejects.toThrow("seal failed");
+  });
+});

--- a/packages/api/src/embedded.ts
+++ b/packages/api/src/embedded.ts
@@ -14,7 +14,15 @@
  *   STEWARD_BIND_HOST     — bind host (default 127.0.0.1)
  */
 
+import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { createPGLiteDb, getDataDir, setPGLiteOverride } from "@stwd/db/pglite";
+import {
+  DevMeasurementKeyProvider,
+  DstackSealedStateKeyProvider,
+  SealedState,
+  type SealedStateEnvelope,
+} from "@stwd/sealed-state";
+import { registerShutdownHook } from "./services/shutdown-hooks";
 
 // Force PGLite/embedded mode
 process.env.STEWARD_DB_MODE = "pglite";
@@ -45,9 +53,56 @@ async function main() {
   console.log(`Data directory: ${dataDir}`);
   console.log();
 
-  // Initialize PGLite + run migrations BEFORE the API boots
+  // Initialize PGLite + run migrations BEFORE the API boots. When configured,
+  // the production entry path keeps PGLite in memory and persists only an
+  // attestation-bound encrypted snapshot, never a plaintext data directory.
   console.log("[embedded] Initializing PGLite database...");
-  const { db, client } = await createPGLiteDb();
+  const sealedPath = process.env.STEWARD_SEALED_PGLITE_PATH;
+  let snapshot: Blob | undefined;
+  let sealedState: SealedState | undefined;
+  let measurement: { imageDigest: string; configHash: string } | undefined;
+  if (sealedPath) {
+    // First boot has no snapshot yet, so force memory explicitly as well as on restore.
+    process.env.STEWARD_PGLITE_MEMORY = "true";
+    const backend = process.env.STEWARD_SEALED_STATE_BACKEND ?? "dstack-tdx";
+    if (backend === "dstack-tdx") {
+      const keys = new DstackSealedStateKeyProvider();
+      measurement = await keys.currentMeasurement();
+      sealedState = new SealedState(keys);
+    } else if (backend === "noop-dev") {
+      const secret = process.env.STEWARD_SEALED_STATE_DEV_SECRET;
+      if (!secret)
+        throw new Error("noop-dev sealed state requires STEWARD_SEALED_STATE_DEV_SECRET");
+      measurement = {
+        imageDigest: process.env.STEWARD_DEV_MEASUREMENT_IMAGE ?? "noop-dev",
+        configHash: process.env.STEWARD_DEV_MEASUREMENT_CONFIG ?? "noop-dev",
+      };
+      sealedState = new SealedState(new DevMeasurementKeyProvider(secret));
+      console.warn(
+        "[embedded] INSECURE noop-dev sealed-state backend enabled; never use outside development",
+      );
+    } else {
+      throw new Error(`unknown sealed-state backend: ${backend}`);
+    }
+    if (existsSync(sealedPath)) {
+      const envelope = JSON.parse(readFileSync(sealedPath, "utf8")) as SealedStateEnvelope;
+      const bytes = await sealedState.unseal(envelope, measurement);
+      snapshot = new Blob([
+        bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer,
+      ]);
+    }
+  }
+  const { db, client } = await createPGLiteDb(undefined, snapshot);
+  if (sealedPath && sealedState && measurement) {
+    registerShutdownHook(async () => {
+      const dump = await client.dumpDataDir("gzip");
+      const bytes = new Uint8Array(await dump.arrayBuffer());
+      const envelope = await sealedState.seal(bytes, measurement, "embedded-agent-state");
+      const temporary = `${sealedPath}.tmp`;
+      writeFileSync(temporary, JSON.stringify(envelope), { mode: 0o600 });
+      renameSync(temporary, sealedPath);
+    });
+  }
   console.log("[embedded] Database ready.");
 
   // Register PGLite as the backing database for getDb()/closeDb()

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -258,13 +258,17 @@ const shutdown = async (signal: string) => {
   if (cancelWebhookRetryScheduler) cancelWebhookRetryScheduler();
   requestLog.clear();
 
+  let exitCode = 0;
   try {
+    const { runShutdownHooks } = await import("./services/shutdown-hooks");
+    await runShutdownHooks();
     await Promise.all([closeDb(), shutdownRedis()]);
   } catch (error) {
-    console.error("Failed to close connections cleanly", error);
+    exitCode = 1;
+    console.error("Failed to persist state or close connections cleanly", error);
   }
 
-  process.exit(0);
+  process.exit(exitCode);
 };
 
 process.on("SIGINT", () => void shutdown("SIGINT"));

--- a/packages/api/src/services/shutdown-hooks.ts
+++ b/packages/api/src/services/shutdown-hooks.ts
@@ -1,0 +1,12 @@
+type ShutdownHook = () => void | Promise<void>;
+const hooks: ShutdownHook[] = [];
+
+/** Register durability work that must finish before the API closes its database. */
+export function registerShutdownHook(hook: ShutdownHook): void {
+  hooks.push(hook);
+}
+
+export async function runShutdownHooks(): Promise<void> {
+  const pending = hooks.splice(0);
+  for (const hook of pending) await hook();
+}

--- a/packages/db/src/pglite.ts
+++ b/packages/db/src/pglite.ts
@@ -112,8 +112,11 @@ async function runPGLiteMigrations(client: PGlite): Promise<void> {
  *
  * @param dataDir - directory for persistence, or "memory://" for in-memory
  */
-export async function createPGLiteDb(dataDir?: string): Promise<{ client: PGlite; db: PGLiteDb }> {
-  const useMemory = process.env.STEWARD_PGLITE_MEMORY === "true";
+export async function createPGLiteDb(
+  dataDir?: string,
+  loadDataDir?: Blob,
+): Promise<{ client: PGlite; db: PGLiteDb }> {
+  const useMemory = process.env.STEWARD_PGLITE_MEMORY === "true" || loadDataDir !== undefined;
 
   let connectionTarget: string;
   if (useMemory) {
@@ -129,7 +132,9 @@ export async function createPGLiteDb(dataDir?: string): Promise<{ client: PGlite
   }
 
   console.log(`[pglite] Initializing PGLite at: ${connectionTarget}`);
-  const client = new PGlite(connectionTarget);
+  const client = loadDataDir
+    ? new PGlite({ dataDir: connectionTarget, loadDataDir })
+    : new PGlite(connectionTarget);
 
   // Run migrations
   await runPGLiteMigrations(client);

--- a/packages/sealed-state/package.json
+++ b/packages/sealed-state/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@stwd/sealed-state",
+  "version": "0.1.0",
+  "description": "Attestation-bound envelope encryption for Steward agent state blobs",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "bun test"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "@stwd/attestation": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "@types/node": "^25.5.0"
+  }
+}

--- a/packages/sealed-state/src/__tests__/sealed-state.test.ts
+++ b/packages/sealed-state/src/__tests__/sealed-state.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { DevMeasurementKeyProvider, SealedState } from "..";
+
+const m1 = { imageDigest: "image-a", configHash: "compose-a" };
+const m2 = { imageDigest: "image-a", configHash: "compose-b" };
+const store = new SealedState(new DevMeasurementKeyProvider("development-secret-only", "test"));
+
+describe("sealed state", () => {
+  test("round trips only under the same measurement", async () => {
+    const envelope = await store.seal(new TextEncoder().encode("agent memory"), m1);
+    expect(new TextDecoder().decode(await store.unseal(envelope, m1))).toBe("agent memory");
+    await expect(store.unseal(envelope, m2)).rejects.toThrow(/measurement mismatch/);
+  });
+
+  test("property: every distinct simulated measurement fails closed", async () => {
+    for (let index = 0; index < 64; index += 1) {
+      const source = { imageDigest: `image-${index}`, configHash: `config-${index}` };
+      const other = { ...source, configHash: `config-other-${index}` };
+      const envelope = await store.seal(crypto.getRandomValues(new Uint8Array(32)), source);
+      await expect(store.unseal(envelope, other)).rejects.toThrow(/measurement mismatch/);
+    }
+  });
+
+  test("corrupt ciphertext and authenticated metadata fail closed", async () => {
+    const envelope = await store.seal(new TextEncoder().encode("private state"), m1);
+    const corrupt = { ...envelope, ciphertext: `${envelope.ciphertext.slice(0, -2)}AA` };
+    await expect(store.unseal(corrupt, m1)).rejects.toThrow(/authentication failed/);
+    await expect(store.unseal({ ...envelope, purpose: "other" }, m1)).rejects.toThrow(
+      /authentication failed/,
+    );
+  });
+
+  test("dev provider cannot be enabled in production", () => {
+    expect(() => new DevMeasurementKeyProvider("development-secret-only", "production")).toThrow(
+      /forbidden/,
+    );
+  });
+});

--- a/packages/sealed-state/src/index.ts
+++ b/packages/sealed-state/src/index.ts
@@ -1,0 +1,207 @@
+import { createCipheriv, createDecipheriv, hkdfSync, randomBytes } from "node:crypto";
+import { request as httpRequest } from "node:http";
+import type { AttestationMeasurement } from "@stwd/attestation";
+
+const VERSION = 1 as const;
+const AAD_DOMAIN = "steward.sealed-state.v1";
+
+export interface SealedStateKeyProvider {
+  readonly id: string;
+  deriveKey(measurement: AttestationMeasurement, purpose: string): Promise<Uint8Array>;
+}
+
+export interface SealedStateEnvelope {
+  version: typeof VERSION;
+  provider: string;
+  measurement: AttestationMeasurement;
+  purpose: string;
+  wrappedDek: string;
+  wrapIv: string;
+  wrapTag: string;
+  ciphertext: string;
+  iv: string;
+  tag: string;
+}
+
+function aad(
+  envelope: Pick<SealedStateEnvelope, "version" | "provider" | "measurement" | "purpose">,
+): Buffer {
+  return Buffer.from(
+    JSON.stringify({
+      domain: AAD_DOMAIN,
+      version: envelope.version,
+      provider: envelope.provider,
+      measurement: envelope.measurement,
+      purpose: envelope.purpose,
+    }),
+    "utf8",
+  );
+}
+
+function encrypt(key: Uint8Array, plaintext: Uint8Array, associatedData: Buffer) {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", key, iv);
+  cipher.setAAD(associatedData);
+  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  return {
+    ciphertext: ciphertext.toString("base64"),
+    iv: iv.toString("base64"),
+    tag: cipher.getAuthTag().toString("base64"),
+  };
+}
+
+function decrypt(
+  key: Uint8Array,
+  ciphertext: string,
+  iv: string,
+  tag: string,
+  associatedData: Buffer,
+): Buffer {
+  try {
+    const decipher = createDecipheriv("aes-256-gcm", key, Buffer.from(iv, "base64"));
+    decipher.setAAD(associatedData);
+    decipher.setAuthTag(Buffer.from(tag, "base64"));
+    return Buffer.concat([decipher.update(Buffer.from(ciphertext, "base64")), decipher.final()]);
+  } catch {
+    throw new Error("sealed state authentication failed");
+  }
+}
+
+export class SealedState {
+  constructor(private readonly keys: SealedStateKeyProvider) {}
+
+  async seal(
+    state: Uint8Array,
+    measurement: AttestationMeasurement,
+    purpose = "agent-state",
+  ): Promise<SealedStateEnvelope> {
+    const header = { version: VERSION, provider: this.keys.id, measurement, purpose };
+    const associatedData = aad(header);
+    const kek = await this.keys.deriveKey(measurement, purpose);
+    if (kek.byteLength !== 32) throw new Error("sealed-state key provider must return 32 bytes");
+    const dek = randomBytes(32);
+    const wrapped = encrypt(kek, dek, associatedData);
+    const payload = encrypt(dek, state, associatedData);
+    dek.fill(0);
+    return {
+      ...header,
+      wrappedDek: wrapped.ciphertext,
+      wrapIv: wrapped.iv,
+      wrapTag: wrapped.tag,
+      ciphertext: payload.ciphertext,
+      iv: payload.iv,
+      tag: payload.tag,
+    };
+  }
+
+  async unseal(
+    envelope: SealedStateEnvelope,
+    currentMeasurement: AttestationMeasurement,
+  ): Promise<Uint8Array> {
+    if (envelope.version !== VERSION || envelope.provider !== this.keys.id)
+      throw new Error("unsupported sealed state envelope");
+    if (
+      envelope.measurement.imageDigest !== currentMeasurement.imageDigest ||
+      envelope.measurement.configHash !== currentMeasurement.configHash
+    ) {
+      throw new Error("sealed state measurement mismatch");
+    }
+    const associatedData = aad(envelope);
+    const kek = await this.keys.deriveKey(currentMeasurement, envelope.purpose);
+    const dek = decrypt(
+      kek,
+      envelope.wrappedDek,
+      envelope.wrapIv,
+      envelope.wrapTag,
+      associatedData,
+    );
+    try {
+      return decrypt(dek, envelope.ciphertext, envelope.iv, envelope.tag, associatedData);
+    } finally {
+      dek.fill(0);
+    }
+  }
+}
+
+export class DevMeasurementKeyProvider implements SealedStateKeyProvider {
+  readonly id = "INSECURE-noop-dev";
+  constructor(
+    private readonly secret: string,
+    environment = process.env.NODE_ENV ?? "development",
+  ) {
+    if (environment === "production")
+      throw new Error("INSECURE noop-dev sealed-state backend is forbidden in production");
+    if (secret.length < 16)
+      throw new Error("noop-dev sealed-state secret must be at least 16 characters");
+  }
+  async deriveKey(measurement: AttestationMeasurement, purpose: string): Promise<Uint8Array> {
+    const info = `${measurement.imageDigest}\0${measurement.configHash}\0${purpose}`;
+    return new Uint8Array(hkdfSync("sha256", this.secret, AAD_DOMAIN, info, 32));
+  }
+}
+
+export interface DstackSealedStateKeyProviderOptions {
+  socketPath?: string;
+}
+export class DstackSealedStateKeyProvider implements SealedStateKeyProvider {
+  readonly id = "dstack-tdx";
+  private readonly socketPath: string;
+  constructor(options: DstackSealedStateKeyProviderOptions = {}) {
+    this.socketPath =
+      options.socketPath ?? process.env.DSTACK_SOCKET_PATH ?? "/var/run/dstack.sock";
+  }
+  async currentMeasurement(): Promise<AttestationMeasurement> {
+    const info = await this.call<{ os_image_hash?: string; compose_hash?: string }>("/Info");
+    if (!info.os_image_hash || !info.compose_hash)
+      throw new Error("dstack /Info omitted runtime measurement");
+    return { imageDigest: info.os_image_hash, configHash: info.compose_hash };
+  }
+  async deriveKey(measurement: AttestationMeasurement, purpose: string): Promise<Uint8Array> {
+    const info = await this.call<{ os_image_hash?: string; compose_hash?: string }>("/Info");
+    if (
+      info.os_image_hash !== measurement.imageDigest ||
+      info.compose_hash !== measurement.configHash
+    )
+      throw new Error("dstack runtime measurement does not match sealed-state request");
+    const path = `steward/sealed-state/v1/${measurement.imageDigest}/${measurement.configHash}/${purpose}`;
+    const result = await this.call<{ key?: string }>("/GetKey", {
+      path,
+      purpose: "sealed-state-kek",
+      algorithm: "ed25519",
+    });
+    if (!result.key || !/^[0-9a-fA-F]{64}$/.test(result.key))
+      throw new Error("dstack /GetKey returned invalid key material");
+    return Uint8Array.from(Buffer.from(result.key, "hex"));
+  }
+  private call<T>(path: string, body?: unknown): Promise<T> {
+    return new Promise((resolve, reject) => {
+      const payload = body ? JSON.stringify(body) : undefined;
+      const req = httpRequest(
+        {
+          socketPath: this.socketPath,
+          path,
+          method: payload ? "POST" : "GET",
+          headers: payload
+            ? { "content-type": "application/json", "content-length": Buffer.byteLength(payload) }
+            : undefined,
+        },
+        (res) => {
+          const chunks: Buffer[] = [];
+          res.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+          res.on("end", () => {
+            if ((res.statusCode ?? 500) >= 300)
+              return reject(new Error(`dstack guest agent ${path} failed (${res.statusCode})`));
+            try {
+              resolve(JSON.parse(Buffer.concat(chunks).toString("utf8")) as T);
+            } catch {
+              reject(new Error(`dstack guest agent ${path} returned invalid JSON`));
+            }
+          });
+        },
+      );
+      req.on("error", () => reject(new Error(`dstack guest agent ${path} unavailable`)));
+      if (payload) req.write(payload);
+      req.end();
+    });
+  }
+}

--- a/packages/sealed-state/tsconfig.json
+++ b/packages/sealed-state/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/__tests__", "**/*.test.ts", "**/*.spec.ts"]
+}


### PR DESCRIPTION
## C2: attestation-bound sealed agent state

### Placement audit
This belongs in new `@stwd/sealed-state`, not `@stwd/vault`. Vault is tenant credential/signing custody with database and exercise policy semantics. Agent memory/runtime snapshots are opaque blobs released by runtime measurement. The package consumes measurement types from `@stwd/attestation` without conflating the custody planes.

### What ships
- AES-256-GCM envelope encryption: random DEK per blob, KEK-wrapped DEK, authenticated provider/purpose/image/config metadata.
- `dstack-tdx` backend: `/Info` measurement equality is mandatory, then `/GetKey` derives a measurement/purpose-separated KEK from dstack's application key. No fallback.
- loudly named `INSECURE-noop-dev`, forbidden in production.
- 64-case measurement mismatch property proof; payload/header corruption rejection.
- `docs/SEALED-STATE.md` threat model and explicit non-goals.

### Honest production consumer
Exact live path: `packages/api/src/embedded.ts`, executed by root `bun run start:local` via `scripts/start-local.ts`. With `STEWARD_SEALED_PGLITE_PATH`, PGLite runs only in memory, restores from an authenticated envelope, and seals an atomic 0600 snapshot before database shutdown. First boot is explicitly forced in-memory. Shutdown persistence errors exit non-zero. Existing plaintext directories are not silently migrated or deleted.

This is opt-in because graceful-shutdown snapshots are not yet an HA database profile. It is a real production entry path behind a flag, not a harness.

### Proof
- `bun test packages/sealed-state/src/__tests__/sealed-state.test.ts`: same M passes; 64 distinct M fail; corruption fails; dev backend production enable fails.
- `bun test src/__tests__/sealed-pglite-snapshot.test.ts` from `packages/api`: real PGLite dump -> seal -> restore -> query passes; envelope excludes plaintext.
- shutdown hook success/failure tests pass.
- `bun run typecheck`: 34/34 packages green.
- `bun run lint`: clean for this diff; repo reports only pre-existing warnings.

### Non-goals
Same-measurement authorized clones/hosts, use-time runtime compromise, access-pattern hiding, crash-consistent continuous journaling, automatic legacy plaintext deletion.
