### PR TITLE
fix(test): isolate plugin-trading/plugin-capabilities suites and close CI unit-matrix gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,13 @@ jobs:
           - packages/db
           - packages/shared
           - packages/plugin-wxmr
+          - packages/plugin-trading
+          - packages/plugin-capabilities
+          - packages/trade-sessions
+          # packages/signer-frost is intentionally absent: its test harness
+          # builds the Rust sidecar via `cargo build --release` and this job
+          # has no Rust toolchain (and a release build would strain the
+          # 10-minute timeout). Add it alongside a rust-toolchain step.
 
     steps:
       - name: Checkout
@@ -83,6 +90,11 @@ jobs:
           fi
         env:
           STEWARD_MASTER_PASSWORD: "ci-test-secret"
+          # bunfig.toml [test] preloads only load from bun's cwd, and this job
+          # runs `bun test` from the repo root — so per-package preloads (e.g.
+          # plugin-trading's, which supplies this key) never run. 64-char dummy
+          # matching the preload's "a".repeat(64).
+          STEWARD_AUDIT_HMAC_KEY: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
   unit-redis:
     name: Unit Tests (packages/redis)

--- a/packages/plugin-capabilities/package.json
+++ b/packages/plugin-capabilities/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "tsc --noEmit",
     "dev": "tsc --watch",
-    "test": "bun test --timeout 30000",
+    "test": "bun test --isolate --timeout 30000",
     "typecheck": "tsc --noEmit",
     "lint": "tsc --noEmit"
   },

--- a/packages/plugin-trading/package.json
+++ b/packages/plugin-trading/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "tsc --noEmit",
     "dev": "tsc --watch",
-    "test": "bun test --timeout 30000",
+    "test": "bun test --isolate --timeout 30000",
     "typecheck": "tsc --noEmit",
     "lint": "tsc --noEmit"
   },


### PR DESCRIPTION
## What

Three related test-infrastructure fixes (3 files, +21/−3):

1. **`--isolate` for `plugin-trading` and `plugin-capabilities` test scripts.** Both suites fail under plain `turbo test` from cross-file mock pollution (same class as #59) but pass 100% isolated. Flag placement matches the repo's existing `bun test --isolate` usage in CI.
2. **CI unit-matrix coverage:** `plugin-trading`, `plugin-capabilities`, and `trade-sessions` had **no CI unit job at all** — added to the `unit` matrix. (`signer-frost` deliberately excluded: its harness runs `cargo build` for the Rust sidecar and CI has no Rust toolchain — documented inline.)
3. **`STEWARD_AUDIT_HMAC_KEY` in the unit job env.** Found by adversarial review running the *exact CI invocation*: `bunfig.toml` `[test]` preloads only load from bun's cwd, and CI runs `bun test` from the repo root — so `plugin-trading`'s preload (which supplies this key) never runs in CI, deterministically failing 2 tests. Job-level env var with the preload's exact value shape (64-char dummy), with the root cause documented in the workflow.

Not done deliberately: `--timeout 30000` was **not** added to the shared CI run step (would raise the budget for all 12 matrix packages; the slow files already self-manage via in-code `setDefaultTimeout(30000)`, which survives any invocation cwd). `pr.yml`'s matrix has the same coverage gap (plus missing `plugin-wxmr`) — left as a follow-up to keep this diff reviewable.

## Verification

Baseline repro: `turbo test` filtered to the two plugins → plugin-trading **84 pass / 11 fail** (pollution). After:

- CI-style from repo root (`STEWARD_MASTER_PASSWORD` + `STEWARD_AUDIT_HMAC_KEY`, exact CI command): `plugin-trading` **95/0 ×2** (determinism), `plugin-capabilities` **148/0**, `trade-sessions` **21/0**
- Baseline *without* the new env var reproduces CI's failure (93/2) — proving the var is what fixes it
- `trade-policy-audit.test.ts` (manages/deletes the env var itself) re-verified CI-style: 9/0; `proxy`/`vault` suites confirmed unaffected (hard-assign or exclude the key)
- `turbo test` filtered to both plugins: 2/2 tasks, 0 fail — pollution gone
- YAML parses; matrix = 12 entries; lint 0 errors; no lockfile churn

🤖 Generated with [Claude Code](https://claude.com/claude-code)