### PR TITLE
ci: build @stwd/web on develop so shared-package regressions cannot land unseen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,52 @@ jobs:
       - name: Typecheck
         run: bun run typecheck
 
+  web-build:
+    # Guard for the @stwd/web Worker build. deploy-web-cloudflare.yml only
+    # triggers on main pushes / PRs touching web/**, so a packages/* change
+    # (e.g. the @stwd/shared barrel leaking node:crypto into the client
+    # bundle, issue #231) can break the web build without any check firing.
+    # Build the Worker here — no upload, no secrets — so those regressions
+    # surface immediately. Mirrors build-check in deploy-web-cloudflare.yml.
+    name: Web Build (@stwd/web)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3"
+
+      # OpenNext tooling needs Node; pin to 22 (Node 24 breaks its CLI deps).
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # web imports the @stwd/react|sdk|shared workspace packages via their
+      # dist/ outputs, so they must be built before the Next build can
+      # resolve them.
+      - name: Build workspace dependencies
+        run: bunx turbo run build --filter=@stwd/react --filter=@stwd/sdk --filter=@stwd/shared
+
+      - name: Build Worker (OpenNext)
+        working-directory: web
+        env:
+          NEXT_TELEMETRY_DISABLED: "1"
+          NEXT_PUBLIC_STEWARD_API_URL: "https://eliza.steward.fi"
+        run: bun run cf:build
+
+      - name: Validate Worker bundle (dry-run deploy)
+        working-directory: web
+        run: bunx wrangler deploy --dry-run --outdir /tmp/wrangler-dryrun
+
   unit:
     name: Unit Tests (${{ matrix.package }})
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -94,6 +94,53 @@ jobs:
             exit 1
           fi
 
+  web-build:
+    # Guard for the @stwd/web Worker build. deploy-web-cloudflare.yml only
+    # triggers on main pushes / PRs touching web/**, so a packages/* change
+    # (e.g. the @stwd/shared barrel leaking node:crypto into the client
+    # bundle, issue #231) can break the web build without any check firing.
+    # Build the Worker here — no upload, no secrets — so those regressions
+    # are caught before they land. Mirrors build-check in
+    # deploy-web-cloudflare.yml.
+    name: Web Build (@stwd/web)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3"
+
+      # OpenNext tooling needs Node; pin to 22 (Node 24 breaks its CLI deps).
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # web imports the @stwd/react|sdk|shared workspace packages via their
+      # dist/ outputs, so they must be built before the Next build can
+      # resolve them.
+      - name: Build workspace dependencies
+        run: bunx turbo run build --filter=@stwd/react --filter=@stwd/sdk --filter=@stwd/shared
+
+      - name: Build Worker (OpenNext)
+        working-directory: web
+        env:
+          NEXT_TELEMETRY_DISABLED: "1"
+          NEXT_PUBLIC_STEWARD_API_URL: "https://eliza.steward.fi"
+        run: bun run cf:build
+
+      - name: Validate Worker bundle (dry-run deploy)
+        working-directory: web
+        run: bunx wrangler deploy --dry-run --outdir /tmp/wrangler-dryrun
+
   unit:
     name: Unit Tests (${{ matrix.package }})
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Adds a `web-build` job to **both** `ci.yml` and `pr.yml`, mirroring `deploy-web-cloudflare.yml`'s `build-check` step-for-step (checkout → bun → node 22 → frozen install → turbo build of `@stwd/react`/`sdk`/`shared` → `cf:build` → `wrangler deploy --dry-run`) — **no deploy step, no secrets, no `continue-on-error`**.

Both files need it: `ci.yml` triggers only on *pushes* to develop/main, so a `ci.yml`-only guard fires post-merge; the `pr.yml` copy is what actually blocks a regression from landing.

## Why

The `@stwd/web` build broke on develop (#231) via a `packages/shared` change **without any CI catching it** — `deploy-web-cloudflare.yml` only runs on `main` pushes / PRs touching `web/**`, so shared-package regressions sail through. This closes that exact gap.

## ⚠️ Sequencing: merge #235 first (or together)

This job **will fail on current develop until #235 lands** — that is the guard doing its job, not a defect (`continue-on-error` deliberately not set; a guard that cannot fail is decoration).

**We independently verified #235 is safe to merge** (green CI is not proof, so we built it): control build on develop fails with exactly the #231 `node:crypto UnhandledSchemeError`; treatment build on the PR head exits 0 (OpenNext + wrangler dry-run both pass); the new client entrypoint's full transitive graph (src + dist) has **zero** `node:` imports, env access, or server-only crypto reaching the browser bundle; `packages/shared` tests 354/0 isolated; and a manual mutation (re-exporting `provider-execution-auth` from `client.ts`) is caught by the new contract test — the guard has teeth.

## Verification

- `actionlint` on both workflows: exit 0; YAML parses; job present with 7 steps in each file
- Behavioral proof the guard catches the real regression: ran the job's exact commands locally on develop → turbo build 3/3, then `cf:build` **exit 1** with the #231 error (`Reading from "node:crypto" is not handled by plugins`, import trace through `packages/shared/dist/provider-execution-auth.js`)
- No secrets used; inherits each workflow's existing `permissions: contents: read`
- Known duplication: on PRs touching `web/**`, this overlaps `build-check` (~10 min) — accepted cost; the guard's purpose is the `packages/*` changes that path filter misses

🤖 Generated with [Claude Code](https://claude.com/claude-code)