### PR TITLE
fix(ci): close the pr.yml unit-matrix gap left by #260

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -157,6 +157,14 @@ jobs:
           - packages/webhooks
           - packages/db
           - packages/shared
+          - packages/plugin-wxmr
+          - packages/plugin-trading
+          - packages/plugin-capabilities
+          - packages/trade-sessions
+          # packages/signer-frost is intentionally absent: its test harness
+          # builds the Rust sidecar via `cargo build --release` and this job
+          # has no Rust toolchain (and a release build would strain the
+          # 10-minute timeout). Add it alongside a rust-toolchain step.
 
     steps:
       - name: Checkout
@@ -190,6 +198,11 @@ jobs:
           fi
         env:
           STEWARD_MASTER_PASSWORD: "ci-test-secret"
+          # bunfig.toml [test] preloads only load from bun's cwd, and this job
+          # runs `bun test` from the repo root — so per-package preloads (e.g.
+          # plugin-trading's, which supplies this key) never run. 64-char dummy
+          # matching the preload's "a".repeat(64).
+          STEWARD_AUDIT_HMAC_KEY: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
   unit-redis:
     name: Unit Tests (packages/redis)


### PR DESCRIPTION
## What

#260 added `plugin-wxmr`/`plugin-trading`/`plugin-capabilities`/`trade-sessions` (and the `STEWARD_AUDIT_HMAC_KEY` env the repo-root `bun test` needs) to **ci.yml**'s unit matrix, but scoped the change to ci.yml to keep that PR reviewable.

`ci.yml` runs on **push to develop/main** (post-merge), so those four packages' unit tests only ran *after* a merge — a PR could break `plugin-trading` and PR CI wouldn't catch it pre-merge.

This mirrors the exact ci.yml treatment into **pr.yml**: same four matrix entries (`signer-frost` still intentionally absent — needs a Rust toolchain step) + the same `STEWARD_AUDIT_HMAC_KEY` env. `pr.yml` already has the "Build workspace dependencies" step the plugins need, so nothing else changes.

## Verification
YAML parses; unit matrix now 12 packages (was 8). The change is a faithful copy of the already-merged, green ci.yml unit job — this PR's own CI now exercises those four packages, which is the proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)