### PR TITLE
release: promote develop→main — auth rate-limit per-client keying (#268)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -223,6 +223,34 @@ SIWE_ALLOWED_DOMAINS=
 # Example: redis://localhost:6379
 REDIS_URL=
 
+# ─── Client IP trust (auth rate limiting) ─────────────────────────────────────
+
+# Number of trusted reverse proxies that APPEND the observed client IP to
+# x-forwarded-for before requests reach the API. REQUIRED on the Railway
+# deploy: its edge appends exactly one entry, so set 1. Until it is set, auth
+# rate limits fall back to coarse per-host buckets, which are weaker on a
+# directly-exposed (non-Host-locked) service. The entry that many hops from
+# the RIGHT is used as the per-client rate-limit subject. Set it to the EXACT
+# number of appending proxies — overestimating re-opens IP spoofing.
+# Unset/invalid = trust no forwarded headers (coarse per-host fallback; never
+# a single global bucket, never open). Leave unset in un-proxied local dev.
+# STEWARD_TRUSTED_PROXY_HOPS=1
+
+# Set to "true" ONLY when the API origin is locked behind Cloudflare; then
+# cf-connecting-ip is preferred as the client IP. Leave unset otherwise — the
+# header is client-forgeable when Cloudflare is not in front.
+# STEWARD_TRUST_CLOUDFLARE=true
+
+# DEPRECATED: legacy alias honored as STEWARD_TRUSTED_PROXY_HOPS=1 (right-most
+# x-forwarded-for semantics). Prefer STEWARD_TRUSTED_PROXY_HOPS.
+# STEWARD_TRUST_PROXY_HEADERS=true
+
+# When Redis is CONFIGURED but unreachable in production, auth endpoints admit
+# up to this many requests per minute per instance (bounded outage valve)
+# before failing closed. Default 300; set 0 for strict fail-closed. Redis
+# never configured in production always fails closed regardless.
+# STEWARD_AUTH_RATE_LIMIT_OUTAGE_VALVE_MAX=300
+
 # ─── Proxy ─────────────────────────────────────────────────────────────────────
 
 # Port the proxy gateway listens on (default: 8080).

--- a/docs/deploy/railway-lean-full.md
+++ b/docs/deploy/railway-lean-full.md
@@ -69,6 +69,7 @@ service where noted, e.g. each service its own DB).
 | `NODE_ENV=production` | required | flips every dev-secret fallback OFF; without it secrets silently fall back to predictable dev values | `Dockerfile` (already `ENV NODE_ENV=production`); read across `packages/auth/src/jwt.ts`, `packages/api/src/services/audit.ts`, `packages/vault/src/keystore.ts` |
 | `PORT=3200` | required | listen port; `/health` probe targets it | `Dockerfile` (`ENV PORT=3200`), `packages/api/src/index.ts` |
 | `STEWARD_BIND_HOST=0.0.0.0` | required on Railway | default is `127.0.0.1` (loopback only) — Railway's proxy can't reach the container unless it binds `0.0.0.0` | `packages/api/src/index.ts` (`STEWARD_BIND_HOST`) |
+| `STEWARD_TRUSTED_PROXY_HOPS=1` | required on Railway | per-client auth rate limiting: number of trusted proxies APPENDING to `x-forwarded-for` (Railway edge = 1; the entry that many hops from the RIGHT is the client IP). until it is set, auth rate limits fall back to coarse per-host buckets, which are weaker on a directly-exposed (non-Host-locked) service — so it must be `1` on bare Railway. never set higher than the real hop count — that re-opens IP spoofing | `packages/api/src/routes/auth.ts` (`trustedClientIp`) |
 | `DATABASE_URL` | **[boot-fatal in prod]** | Postgres connection. boot runs `runMigrations()` blocking before serving; a bad/missing URL fails migration → `process.exit(1)` | `packages/api/src/index.ts`, `packages/db` (`shouldUsePGLite`) |
 | `STEWARD_JWT_SECRET` | **[boot-fatal in prod]** | canonical JWT signing secret. `validateJwtSecretEnv()` runs at module load in `index.ts`; in prod it THROWS if unset or `< 32` chars | `packages/auth/src/jwt.ts` (`getJwtSecret`), called from `packages/api/src/index.ts` |
 | `STEWARD_MASTER_PASSWORD` | **[boot-fatal / ready-gate]** | derives per-agent vault encryption keys. `/ready` reports `vault: not ok` if unset; vault key derivation throws when used | `packages/api/src/index.ts` (`/ready`), `packages/vault/src/keystore.ts` |
@@ -84,6 +85,8 @@ recommended-but-optional (mode-independent), set if the feature is used:
 | var | why | source |
 |-----|-----|--------|
 | `REDIS_URL` | rate-limit enforcement, proxy spend tracking, tenant policy cache. unset → in-memory rate limit + spend tracking disabled | `packages/api/src/middleware/redis.ts`, `packages/redis` |
+| `STEWARD_TRUST_CLOUDFLARE` | set `true` ONLY if origin ingress is locked behind Cloudflare; then `cf-connecting-ip` is trusted. leave unset on bare Railway (header is client-forgeable) | `packages/api/src/routes/auth.ts` (`trustedClientIp`) |
+| `STEWARD_AUTH_RATE_LIMIT_OUTAGE_VALVE_MAX` | bounded auth admissions per minute per instance while a CONFIGURED Redis is unreachable (default 300; `0` = strict fail-closed). never-configured Redis in prod always fails closed | `packages/api/src/routes/auth.ts` (`authRateLimitOutageAllow`) |
 | `STEWARD_DEFAULT_TENANT_KEY` | default tenant for single-tenant self-host (no `X-Steward-Tenant` header) | `.env.example` |
 | `RESEND_API_KEY` / `EMAIL_FROM` | magic-link email send; unset → tokens logged to console (not viable in prod) | `packages/auth`, `.env.example` |
 | `GOOGLE_/DISCORD_/GITHUB_/TWITTER_CLIENT_ID+SECRET` | the matching OAuth login button only works if its pair is set | `packages/api/src/routes/auth` |

--- a/packages/api/CLOUDFLARE.md
+++ b/packages/api/CLOUDFLARE.md
@@ -92,6 +92,20 @@ directory. Do NOT put them in `wrangler.toml`.
 `SKIP_MIGRATIONS=1`, `DATABASE_DRIVER=neon-http`, and `REDIS_DRIVER=upstash`
 are already in `wrangler.toml` `[vars]` so they ship with every deploy.
 
+Non-secret client-IP trust config (auth rate limiting) can go in `[vars]`:
+`STEWARD_TRUST_CLOUDFLARE=true` (Workers always sit behind Cloudflare, so
+`cf-connecting-ip` is authoritative here), or `STEWARD_TRUSTED_PROXY_HOPS=<n>`
+when a different appending proxy chain fronts the worker. Optional
+`STEWARD_AUTH_RATE_LIMIT_OUTAGE_VALVE_MAX` bounds auth admissions per minute
+per isolate while a configured Upstash is unreachable (default 300, `0` =
+strict fail-closed). See `packages/api/src/routes/auth.ts`
+(`trustedClientIp`).
+
+On the Railway deploy (no Cloudflare in front), `STEWARD_TRUSTED_PROXY_HOPS=1`
+is REQUIRED, not optional: until it is set, auth rate limits fall back to
+coarse per-host buckets, which are weaker on a directly-exposed
+(non-Host-locked) service. See `docs/deploy/railway-lean-full.md`.
+
 ## Migrations
 
 ```bash

--- a/packages/api/src/__tests__/auth-client-ip.test.ts
+++ b/packages/api/src/__tests__/auth-client-ip.test.ts
@@ -1,0 +1,428 @@
+/**
+ * Per-client auth rate limiting (#268): trusted-client-IP derivation, IPv6
+ * bucketing, spoof resistance, hashed Redis subjects, per-endpoint budgets,
+ * the coarse per-host fallback, and the bounded Redis-outage valve.
+ *
+ * Harness notes:
+ *   - "@stwd/redis" is mocked with an in-memory counting checkRateLimit so
+ *     budget exhaustion is real and every Redis key is captured for
+ *     inspection (pattern: redis-rate-limit-fail-closed.test.ts).
+ *   - Route-level requests go through authRoutes.request(...) with crafted
+ *     headers (pattern: auth-abuse-controls.test.ts).
+ *   - Env is saved/restored around every test (pattern:
+ *     auth-rate-limit-headers.test.ts).
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it, mock } from "bun:test";
+import { hashSha256Hex } from "@stwd/auth";
+import { closeDb } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { Hono } from "hono";
+
+// ─── @stwd/redis counting mock ───────────────────────────────────────────────
+
+const rateLimitCalls: Array<{ key: string; windowMs: number; max: number }> = [];
+const rateLimitCounts = new Map<string, number>();
+let forceDenyAll = false;
+
+const checkRateLimitMock = mock(async (key: string, windowMs: number, max: number) => {
+  rateLimitCalls.push({ key, windowMs, max });
+  if (forceDenyAll) return { allowed: false, remaining: 0, resetMs: windowMs };
+  const count = (rateLimitCounts.get(key) ?? 0) + 1;
+  rateLimitCounts.set(key, count);
+  return { allowed: count <= max, remaining: Math.max(max - count, 0), resetMs: windowMs };
+});
+const pingMock = mock(async () => "PONG");
+
+mock.module("@stwd/redis", () => ({
+  checkRateLimit: checkRateLimitMock,
+  checkSpendLimit: async () => ({ allowed: true, spent: 0, remaining: 1 }),
+  createUpstashIoredisAdapter: () => ({ ping: pingMock }),
+  disconnectRedis: async () => undefined,
+  estimateCost: () => 0,
+  getAggregationSnapshot: async () => null,
+  getCachedPolicies: async () => null,
+  getPricingTable: () => ({}),
+  getRedis: () => ({ ping: pingMock }),
+  getRedisDriver: () => "ioredis",
+  getSpend: async () => 0,
+  getSpendByHost: async () => ({}),
+  invalidateCache: async () => undefined,
+  invalidateTenantCache: async () => undefined,
+  isKnownHost: () => false,
+  recordAggregationEvent: async () => undefined,
+  recordSpend: async () => undefined,
+  reserveSpend: async () => ({ allowed: true, reservationId: "reservation-test" }),
+  setCachedPolicies: async () => undefined,
+  settleReservedSpend: async () => undefined,
+}));
+
+// ─── Env save/restore ────────────────────────────────────────────────────────
+
+const ORIGINAL_ENV = {
+  NODE_ENV: process.env.NODE_ENV,
+  STEWARD_TRUSTED_PROXY_HOPS: process.env.STEWARD_TRUSTED_PROXY_HOPS,
+  STEWARD_TRUST_PROXY_HEADERS: process.env.STEWARD_TRUST_PROXY_HEADERS,
+  STEWARD_TRUST_CLOUDFLARE: process.env.STEWARD_TRUST_CLOUDFLARE,
+  STEWARD_AUTH_RATE_LIMIT_OUTAGE_VALVE_MAX: process.env.STEWARD_AUTH_RATE_LIMIT_OUTAGE_VALVE_MAX,
+  STEWARD_ALLOW_AUTH_RATE_LIMIT_SOFT_FAIL: process.env.STEWARD_ALLOW_AUTH_RATE_LIMIT_SOFT_FAIL,
+  REDIS_URL: process.env.REDIS_URL,
+  REDIS_DRIVER: process.env.REDIS_DRIVER,
+} as const;
+
+function restoreEnv(key: keyof typeof ORIGINAL_ENV) {
+  const value = ORIGINAL_ENV[key];
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+}
+
+function restoreAllEnv() {
+  for (const key of Object.keys(ORIGINAL_ENV) as Array<keyof typeof ORIGINAL_ENV>) {
+    restoreEnv(key);
+  }
+}
+
+// ─── Module handles (loaded once in beforeAll) ───────────────────────────────
+
+let authRoutes: Awaited<typeof import("../routes/auth")>["authRoutes"];
+let trustedClientIp: Awaited<typeof import("../routes/auth")>["trustedClientIp"];
+let clientIpBucket: Awaited<typeof import("../routes/auth")>["clientIpBucket"];
+let redisMiddleware: Awaited<typeof import("../middleware/redis")>;
+
+/** Tiny probe app so trustedClientIp can be exercised with crafted headers. */
+let probe: Hono;
+
+beforeAll(async () => {
+  process.env.STEWARD_PGLITE_MEMORY = "true";
+  process.env.STEWARD_MASTER_PASSWORD ??= "auth-client-ip-master-password";
+  process.env.STEWARD_JWT_SECRET ??= "auth-client-ip-jwt-secret-with-enough-entropy-0123";
+  const { db, client } = await createPGLiteDb("memory://");
+  setPGLiteOverride(db, async () => {
+    await client.close();
+  });
+  ({ authRoutes, trustedClientIp, clientIpBucket } = await import("../routes/auth"));
+  redisMiddleware = await import("../middleware/redis");
+
+  probe = new Hono();
+  probe.get("/ip", (c) => c.json({ ip: trustedClientIp(c) ?? null }));
+});
+
+afterAll(async () => {
+  await closeDb();
+  restoreAllEnv();
+  delete process.env.STEWARD_PGLITE_MEMORY;
+});
+
+afterEach(() => {
+  restoreAllEnv();
+  forceDenyAll = false;
+  rateLimitCalls.length = 0;
+  rateLimitCounts.clear();
+});
+
+async function probeIp(headers: Record<string, string>): Promise<string | null> {
+  const res = await probe.request("/ip", { headers });
+  return ((await res.json()) as { ip: string | null }).ip;
+}
+
+/** Make Redis "available" via the mocked client so checkRateLimit is reached. */
+async function connectMockRedis(): Promise<void> {
+  process.env.REDIS_DRIVER = "ioredis";
+  process.env.REDIS_URL = "redis://auth-client-ip.test:6379";
+  expect(await redisMiddleware.initRedis()).toBe(true);
+}
+
+function capturedKeys(endpoint: string): string[] {
+  return rateLimitCalls
+    .filter((call) => call.key.startsWith(`ratelimit:auth:${endpoint}:`))
+    .map((call) => call.key);
+}
+
+describe("trustedClientIp", () => {
+  it("trusts no forwarded header when no hops are configured (safe default)", async () => {
+    delete process.env.STEWARD_TRUSTED_PROXY_HOPS;
+    delete process.env.STEWARD_TRUST_PROXY_HEADERS;
+    expect(
+      await probeIp({ "x-forwarded-for": "203.0.113.5", "x-real-ip": "203.0.113.5" }),
+    ).toBeNull();
+  });
+
+  it("hops=1 reads the RIGHT-most x-forwarded-for entry; prepended spoofs are ignored", async () => {
+    process.env.STEWARD_TRUSTED_PROXY_HOPS = "1";
+    expect(await probeIp({ "x-forwarded-for": "203.0.113.5, 198.51.100.7" })).toBe("198.51.100.7");
+    // Attacker prepends garbage and extra fake IPs — right-most still wins.
+    expect(await probeIp({ "x-forwarded-for": "1.1.1.1, 2.2.2.2, evil, 198.51.100.7" })).toBe(
+      "198.51.100.7",
+    );
+  });
+
+  it("hops=2 selects the 2nd entry from the right; too-short lists yield undefined", async () => {
+    process.env.STEWARD_TRUSTED_PROXY_HOPS = "2";
+    expect(await probeIp({ "x-forwarded-for": "203.0.113.5, 198.51.100.7, 10.0.0.9" })).toBe(
+      "198.51.100.7",
+    );
+    // Only one entry with two trusted hops: never fall back to the left-most.
+    expect(await probeIp({ "x-forwarded-for": "203.0.113.5" })).toBeNull();
+  });
+
+  it("rejects non-IP garbage in the trusted position", async () => {
+    process.env.STEWARD_TRUSTED_PROXY_HOPS = "1";
+    expect(await probeIp({ "x-forwarded-for": "203.0.113.5, not-an-ip" })).toBeNull();
+  });
+
+  it("invalid hop counts disable trust instead of widening it", async () => {
+    for (const bad of ["abc", "-1", "0", "99", "1.5"]) {
+      process.env.STEWARD_TRUSTED_PROXY_HOPS = bad;
+      expect(await probeIp({ "x-forwarded-for": "203.0.113.5, 198.51.100.7" })).toBeNull();
+    }
+  });
+
+  it("legacy STEWARD_TRUST_PROXY_HEADERS=true maps to hops=1 with RIGHT-most semantics", async () => {
+    delete process.env.STEWARD_TRUSTED_PROXY_HOPS;
+    process.env.STEWARD_TRUST_PROXY_HEADERS = "true";
+    expect(await probeIp({ "x-forwarded-for": "6.6.6.6, 198.51.100.7" })).toBe("198.51.100.7");
+  });
+
+  it("x-real-ip is never consulted", async () => {
+    process.env.STEWARD_TRUSTED_PROXY_HOPS = "1";
+    expect(await probeIp({ "x-real-ip": "203.0.113.5" })).toBeNull();
+  });
+
+  it("cf-connecting-ip is honored only behind STEWARD_TRUST_CLOUDFLARE=true", async () => {
+    process.env.STEWARD_TRUSTED_PROXY_HOPS = "1";
+    delete process.env.STEWARD_TRUST_CLOUDFLARE;
+    // Flag unset: forged CF header is ignored; XFF path is used instead.
+    expect(
+      await probeIp({ "cf-connecting-ip": "9.9.9.9", "x-forwarded-for": "198.51.100.7" }),
+    ).toBe("198.51.100.7");
+
+    process.env.STEWARD_TRUST_CLOUDFLARE = "true";
+    expect(
+      await probeIp({ "cf-connecting-ip": "9.9.9.9", "x-forwarded-for": "198.51.100.7" }),
+    ).toBe("9.9.9.9");
+    // Flag on + invalid CF value falls through to the XFF path.
+    expect(await probeIp({ "cf-connecting-ip": "junk", "x-forwarded-for": "198.51.100.7" })).toBe(
+      "198.51.100.7",
+    );
+  });
+});
+
+describe("clientIpBucket", () => {
+  it("keys IPv4 as itself", () => {
+    expect(clientIpBucket("198.51.100.7")).toBe("198.51.100.7");
+  });
+
+  it("unwraps IPv4-mapped IPv6 to the embedded IPv4", () => {
+    expect(clientIpBucket("::ffff:1.2.3.4")).toBe("1.2.3.4");
+  });
+
+  it("unwraps the hex spelling of IPv4-mapped IPv6 to the same bucket as the dotted form", () => {
+    expect(clientIpBucket("::ffff:0102:0304")).toBe("1.2.3.4");
+    // Leading zeros stripped and full form: still the same mapped address.
+    expect(clientIpBucket("::ffff:102:304")).toBe("1.2.3.4");
+    expect(clientIpBucket("0:0:0:0:0:ffff:0102:0304")).toBe("1.2.3.4");
+    expect(clientIpBucket("::ffff:0102:0304")).toBe(clientIpBucket("::ffff:1.2.3.4"));
+  });
+
+  it("buckets native IPv6 by /64 so one host cannot mint 2^64 budgets", () => {
+    expect(clientIpBucket("2001:db8:abcd:12:1::1")).toBe("2001:db8:abcd:12::/64");
+    expect(clientIpBucket("2001:db8:abcd:12:ffff:ffff:ffff:2")).toBe("2001:db8:abcd:12::/64");
+    // Different /64 → different bucket.
+    expect(clientIpBucket("2001:db8:abcd:13::1")).not.toBe(clientIpBucket("2001:db8:abcd:12::1"));
+  });
+
+  it("normalizes full-form and ::-compressed spellings to the same bucket", () => {
+    expect(clientIpBucket("2001:0db8:0000:0000:0000:0000:0000:0001")).toBe(
+      clientIpBucket("2001:db8::1"),
+    );
+  });
+});
+
+describe("auth rate-limit keying (route harness)", () => {
+  it("keys per trusted client IP: spoofed prefixes share a bucket, real clients get independent budgets", async () => {
+    await connectMockRedis();
+    process.env.STEWARD_TRUSTED_PROXY_HOPS = "1";
+
+    // siwe-nonce budget is 30/min. Rotating attacker-prepended entries with a
+    // fixed right-most IP must all land in ONE bucket and exhaust it.
+    let denied: Response | null = null;
+    for (let i = 0; i < 31; i++) {
+      const res = await authRoutes.request("/nonce", {
+        headers: { "x-forwarded-for": `10.66.${i}.1, 198.51.100.7` },
+      });
+      if (res.status === 429) denied = res;
+    }
+    const nonceKeys = capturedKeys("siwe-nonce");
+    const expectedKey = `ratelimit:auth:siwe-nonce:${hashSha256Hex("ip:198.51.100.7")}:60000`;
+    expect(new Set(nonceKeys)).toEqual(new Set([expectedKey]));
+    expect(denied).not.toBeNull();
+    expect(denied?.headers.get("retry-after")).toBe("60");
+
+    // A different (unspoofed) client is unaffected by the exhausted bucket.
+    // (400 = admitted past the limiter but no allowed Origin header; the
+    // limiter outcome is all this test cares about.)
+    const other = await authRoutes.request("/nonce", {
+      headers: { "x-forwarded-for": "203.0.113.99" },
+    });
+    expect(other.status).toBe(400);
+    expect(capturedKeys("siwe-nonce")).toContain(
+      `ratelimit:auth:siwe-nonce:${hashSha256Hex("ip:203.0.113.99")}:60000`,
+    );
+  });
+
+  it("multi-hop depth keys on the Nth-from-right entry", async () => {
+    await connectMockRedis();
+    process.env.STEWARD_TRUSTED_PROXY_HOPS = "2";
+    const res = await authRoutes.request("/nonce", {
+      headers: { "x-forwarded-for": "203.0.113.5, 198.51.100.7, 10.0.0.9" },
+    });
+    expect(res.status).not.toBe(429);
+    expect(capturedKeys("siwe-nonce")).toContain(
+      `ratelimit:auth:siwe-nonce:${hashSha256Hex("ip:198.51.100.7")}:60000`,
+    );
+  });
+
+  it("without a trusted IP, falls back to coarse per-host subjects (distinct per Host, never the old global) with x5 headroom", async () => {
+    await connectMockRedis();
+    delete process.env.STEWARD_TRUSTED_PROXY_HOPS;
+    delete process.env.STEWARD_TRUST_PROXY_HEADERS;
+    forceDenyAll = true;
+
+    const res = await authRoutes.request("/nonce", {
+      headers: { host: "api.steward.example", "x-forwarded-for": "203.0.113.5" },
+    });
+    expect(res.status).toBe(429);
+    // Base 30/min widened x5 for the shared coarse bucket.
+    expect(res.headers.get("ratelimit-limit")).toBe("150");
+    expect(res.headers.get("ratelimit-policy")).toBe("150;w=60");
+    await authRoutes.request("/nonce", {
+      headers: { host: "staging.steward.example", "x-forwarded-for": "203.0.113.5" },
+    });
+
+    const calls = rateLimitCalls.filter((entry) => entry.key.includes("siwe-nonce"));
+    expect(calls.map((entry) => entry.max)).toEqual([150, 150]);
+    // The subject is exactly `host:<lowercased Host>` hashed — so each served
+    // Host gets its own bucket, and no request ever lands in the legacy
+    // "global" chokepoint or puts raw client-controlled bytes in the key.
+    expect(calls.map((entry) => entry.key)).toEqual([
+      `ratelimit:auth:siwe-nonce:${hashSha256Hex("host:api.steward.example")}:60000`,
+      `ratelimit:auth:siwe-nonce:${hashSha256Hex("host:staging.steward.example")}:60000`,
+    ]);
+    expect(calls[0]?.key).not.toBe(calls[1]?.key);
+    for (const call of calls) {
+      expect(call.key).not.toContain(hashSha256Hex("global"));
+      expect(call.key).not.toContain("global");
+    }
+  });
+
+  it("hashes subjectOverride subjects: destination emails never reach Redis raw", async () => {
+    await connectMockRedis();
+    process.env.STEWARD_TRUSTED_PROXY_HOPS = "1";
+    const email = "pii-probe@example.com";
+    await authRoutes.request("/email/send", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-forwarded-for": "198.51.100.20",
+      },
+      body: JSON.stringify({ email }),
+    });
+    expect(rateLimitCalls.length).toBeGreaterThan(0);
+    for (const call of rateLimitCalls) {
+      expect(call.key).not.toContain(email);
+    }
+    // The destination limiter still keys deterministically on the email.
+    expect(capturedKeys("email-send-destination")).toContain(
+      `ratelimit:auth:email-send-destination:${hashSha256Hex(email)}:600000`,
+    );
+  });
+
+  it("enforces launch-sized per-endpoint budgets (email-send 10/min, sms-send 5/min per IP)", async () => {
+    await connectMockRedis();
+    process.env.STEWARD_TRUSTED_PROXY_HOPS = "1";
+    const headers = {
+      "content-type": "application/json",
+      "x-forwarded-for": "198.51.100.30",
+    };
+
+    // email-send: 10 allowed, 11th denied. Unique destination emails keep the
+    // per-email limiter out of the way; the per-IP budget is what trips.
+    for (let i = 0; i < 10; i++) {
+      const res = await authRoutes.request("/email/send", {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ email: `person-${i}@example.com` }),
+      });
+      expect(res.status).not.toBe(429);
+    }
+    const emailDenied = await authRoutes.request("/email/send", {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ email: "person-10@example.com" }),
+    });
+    expect(emailDenied.status).toBe(429);
+    expect(emailDenied.headers.get("ratelimit-policy")).toBe("10;w=60");
+
+    // sms-send: 5 allowed (invalid body → 400 AFTER the limiter), 6th denied.
+    for (let i = 0; i < 5; i++) {
+      const res = await authRoutes.request("/sms/send", {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ phone: "not-a-phone" }),
+      });
+      expect(res.status).toBe(400);
+    }
+    const smsDenied = await authRoutes.request("/sms/send", {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ phone: "not-a-phone" }),
+    });
+    expect(smsDenied.status).toBe(429);
+    expect(smsDenied.headers.get("ratelimit-policy")).toBe("5;w=60");
+  });
+
+  it("bounded outage valve: configured-but-down Redis admits a small budget, then denies; 0 restores strict fail-closed", async () => {
+    process.env.NODE_ENV = "production";
+    delete process.env.STEWARD_ALLOW_AUTH_RATE_LIMIT_SOFT_FAIL;
+    process.env.REDIS_DRIVER = "ioredis";
+    process.env.REDIS_URL = "redis://auth-client-ip.test:6379"; // configured...
+    await redisMiddleware.shutdownRedis(); // ...but unavailable
+    process.env.STEWARD_AUTH_RATE_LIMIT_OUTAGE_VALVE_MAX = "3";
+
+    const statuses: number[] = [];
+    for (let i = 0; i < 4; i++) {
+      const res = await authRoutes.request("/nonce", {
+        headers: { "x-forwarded-for": "198.51.100.40" },
+      });
+      statuses.push(res.status);
+    }
+    // Admitted requests reach the handler (400: no allowed Origin header);
+    // once the valve budget is spent, the limiter itself denies with 429.
+    expect(statuses.slice(0, 3)).toEqual([400, 400, 400]);
+    expect(statuses[3]).toBe(429);
+    // The Redis-backed limiter was never reached during the outage.
+    expect(rateLimitCalls.length).toBe(0);
+
+    // Valve max 0 → strict fail-closed.
+    process.env.STEWARD_AUTH_RATE_LIMIT_OUTAGE_VALVE_MAX = "0";
+    const strict = await authRoutes.request("/nonce", {
+      headers: { "x-forwarded-for": "198.51.100.40" },
+    });
+    expect(strict.status).toBe(429);
+    expect(strict.headers.get("retry-after")).toBe("60");
+  });
+
+  it("never-configured Redis in production stays hard fail-closed (valve does not apply)", async () => {
+    process.env.NODE_ENV = "production";
+    delete process.env.STEWARD_ALLOW_AUTH_RATE_LIMIT_SOFT_FAIL;
+    delete process.env.REDIS_URL;
+    delete process.env.REDIS_DRIVER;
+    await redisMiddleware.shutdownRedis();
+
+    const res = await authRoutes.request("/nonce", {
+      headers: { "x-forwarded-for": "198.51.100.50" },
+    });
+    expect(res.status).toBe(429);
+    expect(res.headers.get("retry-after")).toBe("60");
+    expect(rateLimitCalls.length).toBe(0);
+  });
+});

--- a/packages/api/src/__tests__/auth-rate-limit-headers.test.ts
+++ b/packages/api/src/__tests__/auth-rate-limit-headers.test.ts
@@ -50,11 +50,14 @@ describe("auth rate-limit headers", () => {
 
     expect(response.status).toBe(429);
     expect(response.headers.get("retry-after")).toBe("60");
-    expect(response.headers.get("ratelimit-limit")).toBe("30");
+    // No trusted proxy hops are configured here, so the subject is the coarse
+    // per-host fallback and the advertised limit is the base 30 widened by the
+    // ×5 coarse-fallback headroom (many clients share each coarse bucket).
+    expect(response.headers.get("ratelimit-limit")).toBe("150");
     expect(response.headers.get("ratelimit-remaining")).toBe("0");
     expect(response.headers.get("ratelimit-reset")).toBe("60");
-    expect(response.headers.get("ratelimit-policy")).toBe("30;w=60");
-    expect(response.headers.get("x-ratelimit-limit")).toBe("30");
+    expect(response.headers.get("ratelimit-policy")).toBe("150;w=60");
+    expect(response.headers.get("x-ratelimit-limit")).toBe("150");
     expect(response.headers.get("x-ratelimit-remaining")).toBe("0");
     expect(response.headers.get("x-ratelimit-reset")).toBe("60");
 

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -187,32 +187,129 @@ function normalizeEmailDomain(value: unknown): string | null {
   return domain;
 }
 
-// ─── IP-based auth rate limiting ─────────────────────────────────────────────
+// ─── Trusted client IP + auth rate limiting ──────────────────────────────────
 
 /**
- * Check a client rate limit for auth endpoints, backed by the Redis sliding
- * window. In production, Redis must be available for endpoint-specific auth
- * throttles unless STEWARD_ALLOW_AUTH_RATE_LIMIT_SOFT_FAIL=true is explicitly
- * configured. Forwarded IP headers
- * are used only when STEWARD_TRUST_PROXY_HEADERS=true; otherwise a single
- * global bucket is safer than letting clients pick arbitrary rate-limit keys.
- * We deliberately do not
- * keep an in-memory fallback Map: it is incorrect across multiple instances
- * and impossible on Cloudflare Workers (no shared state across isolates).
- *
- * @param c        - Hono context (used to read client IP headers)
- * @param endpoint - Short name used as part of the Redis key
- * @param windowMs - Window length in milliseconds
- * @param max      - Maximum allowed requests in the window
+ * Number of trusted reverse proxies that APPEND to x-forwarded-for before
+ * requests reach this process. Railway's edge appends the peer IP it observed
+ * as the RIGHT-most entry, so STEWARD_TRUSTED_PROXY_HOPS=1 makes the last
+ * entry authoritative and everything a client prepends is ignored. Set it to
+ * the EXACT number of appending proxies (1 for bare Railway); overestimating
+ * re-opens spoofing. Unset, empty, or invalid values mean no forwarded header
+ * is trusted (safe default — a typo can never widen trust). The deprecated
+ * STEWARD_TRUST_PROXY_HEADERS=true is honored as hops=1 with right-most
+ * semantics; the old left-most read was client-spoofable and is deliberately
+ * not preserved.
  */
-function authRateLimitSubject(c: Context): string {
-  if (process.env.STEWARD_TRUST_PROXY_HEADERS !== "true") return "global";
-  return (
-    c.req.header("cf-connecting-ip")?.trim() ||
-    c.req.header("x-real-ip")?.trim() ||
-    c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ||
-    "global"
+function trustedProxyHops(): number {
+  const raw = process.env.STEWARD_TRUSTED_PROXY_HOPS?.trim();
+  if (raw === undefined || raw === "") {
+    return process.env.STEWARD_TRUST_PROXY_HEADERS === "true" ? 1 : 0;
+  }
+  // Canonical non-negative integer only: "1.5" must not truncate into trust.
+  if (!/^\d+$/.test(raw)) return 0;
+  const parsed = Number.parseInt(raw, 10);
+  return parsed > 0 && parsed <= 10 ? parsed : 0;
+}
+
+/**
+ * Best-effort trustworthy client IP, or undefined when none can be derived.
+ *
+ * - cf-connecting-ip is honored only when STEWARD_TRUST_CLOUDFLARE=true AND
+ *   origin ingress is locked to Cloudflare. This service is served directly
+ *   by Railway today (no cf-ray), so the flag stays unset and the header is
+ *   ignored as client-forgeable.
+ * - x-forwarded-for: each trusted proxy APPENDS the peer it observed, so with
+ *   N trusted hops the trustworthy entry is the N-th from the RIGHT. The
+ *   left-most entry is client-supplied and is never read.
+ * - x-real-ip is deliberately not consulted: no proxy in this topology sets
+ *   it authoritatively, so a client-set value would pass through verbatim.
+ *
+ * Every candidate is validated with isIP so header garbage can never become a
+ * rate-limit key or a captcha remoteip. Callers seeing undefined must degrade
+ * to a partitioned coarse subject — never a shared "global" bucket, never open.
+ */
+export function trustedClientIp(c: Context): string | undefined {
+  if (process.env.STEWARD_TRUST_CLOUDFLARE === "true") {
+    const cf = c.req.header("cf-connecting-ip")?.trim();
+    if (cf && isIP(cf)) return cf;
+  }
+  const hops = trustedProxyHops();
+  if (hops === 0) return undefined;
+  const entries = (c.req.header("x-forwarded-for") ?? "")
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+  const candidate = entries[entries.length - hops];
+  return candidate && isIP(candidate) ? candidate : undefined;
+}
+
+/**
+ * Coarsen an IP for rate-limit keying. IPv4 keys as itself; IPv4-mapped IPv6
+ * unwraps to the embedded IPv4 in BOTH spellings (::ffff:a.b.c.d and the hex
+ * form ::ffff:aabb:ccdd) so mapped clients share one bucket instead of all
+ * collapsing into 0::/64 or splitting across spellings; native IPv6 keys by
+ * /64 — providers delegate whole /64s, so full-address buckets would let one
+ * host mint 2^64 independent budgets while distinct subscribers almost never
+ * share a /64.
+ */
+export function clientIpBucket(ip: string): string {
+  const lower = ip.toLowerCase();
+  if (lower.startsWith("::ffff:") && isIP(lower.slice(7)) === 4) {
+    return lower.slice(7);
+  }
+  if (isIP(lower) !== 6) return lower;
+  const [head = "", tail = ""] = lower.split("::");
+  const headParts = head ? head.split(":") : [];
+  const tailParts = tail ? tail.split(":") : [];
+  const missing = Math.max(8 - headParts.length - tailParts.length, 0);
+  // Parse each hextet numerically so full-form and ::-compressed spellings of
+  // the same address always land in the same bucket.
+  const full = [...headParts, ...Array(missing).fill("0"), ...tailParts].map((part) =>
+    Number.parseInt(part || "0", 16),
   );
+  // IPv4-mapped spelled in hex (::ffff:0102:0304): unwrap to the embedded
+  // IPv4 so it shares the dotted-quad spelling's bucket.
+  if (full.length === 8 && full.slice(0, 5).every((part) => part === 0) && full[5] === 0xffff) {
+    const hi = full[6] ?? 0;
+    const lo = full[7] ?? 0;
+    return `${hi >> 8}.${hi & 0xff}.${lo >> 8}.${lo & 0xff}`;
+  }
+  return `${full
+    .slice(0, 4)
+    .map((part) => part.toString(16))
+    .join(":")}::/64`;
+}
+
+/** Coarse fallback buckets are shared by many clients; widen their budget. */
+const AUTH_RATE_LIMIT_FALLBACK_HEADROOM = 5;
+
+let coarseSubjectWarnedAt = 0;
+
+/**
+ * Rate-limit subject for auth endpoints. With a trusted client IP every
+ * client gets an independent budget (IPv6 at /64). Without one, requests
+ * shard per Host — the edge only routes configured domains here, so Host
+ * cannot be rotated to mint unbounded buckets the way client-controlled
+ * headers or user-agents can — and checkAuthRateLimit widens the budget by
+ * AUTH_RATE_LIMIT_FALLBACK_HEADROOM because many clients share each bucket.
+ * No configuration yields the old literal "global" chokepoint (#268), and no
+ * client-controlled free text ever reaches Redis unhashed.
+ */
+function authRateLimitSubject(c: Context): { subject: string; coarse: boolean } {
+  const ip = trustedClientIp(c);
+  if (ip) return { subject: `ip:${clientIpBucket(ip)}`, coarse: false };
+  const now = Date.now();
+  if (process.env.NODE_ENV === "production" && now - coarseSubjectWarnedAt >= 60_000) {
+    coarseSubjectWarnedAt = now;
+    console.warn(
+      "[AuthRateLimit] No trusted client IP (set STEWARD_TRUSTED_PROXY_HOPS=1 on Railway); auth rate limits fall back to coarse per-host buckets instead of per-client budgets",
+    );
+  }
+  return {
+    subject: `host:${c.req.header("host")?.toLowerCase().trim() || "unknown"}`,
+    coarse: true,
+  };
 }
 
 function allowAuthRateLimitSoftFail(): boolean {
@@ -222,6 +319,68 @@ function allowAuthRateLimitSoftFail(): boolean {
   );
 }
 
+/**
+ * Bounded, observable fallback for the window where Redis is CONFIGURED but
+ * unreachable (blip, restart, failover): admit up to
+ * STEWARD_AUTH_RATE_LIMIT_OUTAGE_VALVE_MAX requests per minute per instance
+ * across all auth endpoints, then deny. 0 restores strict fail-closed.
+ * Redis NEVER configured in production remains a hard deny — misconfiguration
+ * must stay loud. This is not a per-client limiter and does not violate the
+ * no-in-memory-fallback-Map rule in checkAuthRateLimit's doc: it is a single
+ * O(1) circuit-breaker counter bounding blast radius per instance (per
+ * isolate on Workers, which only tightens it).
+ */
+function authRateLimitOutageValveMax(): number {
+  const raw = process.env.STEWARD_AUTH_RATE_LIMIT_OUTAGE_VALVE_MAX;
+  if (raw === undefined || raw === "") return 300;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : 300;
+}
+
+let outageValveWindowStartMs = 0;
+let outageValveCount = 0;
+let outageValveLoggedAt = 0;
+
+function authRateLimitOutageAllow(endpoint: string, err?: unknown): boolean {
+  const valveMax = authRateLimitOutageValveMax();
+  if (valveMax === 0) return false;
+  const now = Date.now();
+  if (now - outageValveWindowStartMs >= 60_000) {
+    outageValveWindowStartMs = now;
+    outageValveCount = 0;
+  }
+  if (now - outageValveLoggedAt >= 30_000) {
+    outageValveLoggedAt = now;
+    console.error(
+      `[AuthRateLimit] Redis unavailable; bounded per-instance outage valve engaged (endpoint "${endpoint}", max ${valveMax}/min)`,
+      err ?? "",
+    );
+  }
+  outageValveCount += 1;
+  return outageValveCount <= valveMax;
+}
+
+/**
+ * Check a client rate limit for auth endpoints, backed by the Redis sliding
+ * window. Subjects come from authRateLimitSubject (trusted client IP, or a
+ * coarse per-host fallback whose budget is widened by
+ * AUTH_RATE_LIMIT_FALLBACK_HEADROOM) unless subjectOverride is given. The
+ * subject is always hashed into the Redis key, so neither PII (destination
+ * emails/phones) nor header-controlled bytes ever reach Redis. In production,
+ * Redis must be available unless STEWARD_ALLOW_AUTH_RATE_LIMIT_SOFT_FAIL=true
+ * (full soft-fail, break-glass only) or the bounded outage valve admits the
+ * request (Redis configured but unreachable only). We deliberately do not
+ * keep an in-memory fallback Map as a limiter: it is incorrect across
+ * multiple instances and impossible on Cloudflare Workers (no shared state
+ * across isolates); the outage valve is a single bounded counter, not a
+ * per-client map.
+ *
+ * @param c        - Hono context (used to derive the client subject)
+ * @param endpoint - Short name used as part of the Redis key
+ * @param windowMs - Window length in milliseconds
+ * @param max      - Max requests in the window (×5 for coarse fallback subjects)
+ * @param subjectOverride - Per-target subject (e.g. destination email); hashed at key build
+ */
 async function checkAuthRateLimit(
   c: Context,
   endpoint: string,
@@ -229,17 +388,21 @@ async function checkAuthRateLimit(
   max: number,
   subjectOverride?: string,
 ): Promise<{ allowed: boolean; retryAfterSecs?: number }> {
-  const subject = subjectOverride ?? authRateLimitSubject(c);
-  const key = `ratelimit:auth:${endpoint}:${subject}:${windowMs}`;
+  const resolved =
+    subjectOverride !== undefined
+      ? { subject: subjectOverride, coarse: false }
+      : authRateLimitSubject(c);
+  const effectiveMax = resolved.coarse ? max * AUTH_RATE_LIMIT_FALLBACK_HEADROOM : max;
+  const key = `ratelimit:auth:${endpoint}:${hashSha256Hex(resolved.subject)}:${windowMs}`;
 
   const deny = (retryAfterSecs: number) => {
     const headers = formatRateLimitHeaders({
-      limit: max,
+      limit: effectiveMax,
       remaining: 0,
       resetMs: retryAfterSecs * 1000,
       retryAfterMs: retryAfterSecs * 1000,
     });
-    headers["RateLimit-Policy"] = `${max};w=${Math.ceil(windowMs / 1000)}`;
+    headers["RateLimit-Policy"] = `${effectiveMax};w=${Math.ceil(windowMs / 1000)}`;
     for (const [name, value] of Object.entries(headers)) c.header(name, value);
     return { allowed: false, retryAfterSecs };
   };
@@ -248,17 +411,26 @@ async function checkAuthRateLimit(
     const redisMw = await import("../middleware/redis.js");
     if (!redisMw.isRedisAvailable()) {
       if (allowAuthRateLimitSoftFail()) return { allowed: true };
+      if (redisMw.isRedisConfigured() && authRateLimitOutageAllow(endpoint)) {
+        return { allowed: true };
+      }
       return deny(60);
     }
 
     const { checkRateLimit } = await import("@stwd/redis");
-    const result = await checkRateLimit(key, windowMs, max);
+    const result = await checkRateLimit(key, windowMs, effectiveMax);
     if (!result.allowed) {
       return deny(Math.ceil(result.resetMs / 1000));
     }
     return { allowed: true };
-  } catch {
+  } catch (err) {
     if (allowAuthRateLimitSoftFail()) return { allowed: true };
+    // Any step above can throw — the dynamic imports, the availability probe,
+    // or checkRateLimit itself — so a throw is NOT proof Redis was seen
+    // available. Treat it as an outage and let the bounded valve decide; the
+    // deliberate hard deny for never-configured Redis in production is the
+    // non-throwing isRedisAvailable() branch above, which returns instead.
+    if (authRateLimitOutageAllow(endpoint, err)) return { allowed: true };
     return deny(60);
   }
 }
@@ -473,16 +645,6 @@ async function validateExplicitAuthTenantHint(
   if (!explicitHint) return null;
   if (!(await tenantExists(tenantId))) return `Tenant '${tenantId}' not found`;
   return null;
-}
-
-function trustedRemoteIp(c: Context): string | undefined {
-  if (process.env.STEWARD_TRUST_PROXY_HEADERS !== "true") return undefined;
-  return (
-    c.req.header("cf-connecting-ip")?.trim() ||
-    c.req.header("x-real-ip")?.trim() ||
-    c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ||
-    undefined
-  );
 }
 
 function authTenantHint(c: Context, bodyTenantId?: string): string {
@@ -5011,7 +5173,7 @@ auth.post("/test/token", async (c) => {
 // ── SMS OTP ─────────────────────────────────────────────────────────────────
 
 auth.post("/sms/send", async (c) => {
-  const rl = await checkAuthRateLimit(c, "sms-send", 60_000, 3);
+  const rl = await checkAuthRateLimit(c, "sms-send", 60_000, 5);
   if (!rl.allowed) {
     return c.json<ApiResponse>(
       { ok: false, error: "Too many requests. Please try again later." },
@@ -5044,7 +5206,7 @@ auth.post("/sms/send", async (c) => {
     authAbuseConfig,
     "sms_otp",
     body.captchaToken,
-    trustedRemoteIp(c),
+    trustedClientIp(c),
   );
   if (!captcha.ok) {
     return c.json<ApiResponse>(
@@ -5169,7 +5331,7 @@ auth.post("/whatsapp/send", async (c) => {
     return c.json<ApiResponse>({ ok: false, error: "WhatsApp OTP is not configured" }, 503);
   }
 
-  const rl = await checkAuthRateLimit(c, "whatsapp-send", 60_000, 3);
+  const rl = await checkAuthRateLimit(c, "whatsapp-send", 60_000, 5);
   if (!rl.allowed) {
     return c.json<ApiResponse>(
       { ok: false, error: "Too many requests. Please try again later." },
@@ -5202,7 +5364,7 @@ auth.post("/whatsapp/send", async (c) => {
     authAbuseConfig,
     "sms_otp",
     body.captchaToken,
-    trustedRemoteIp(c),
+    trustedClientIp(c),
   );
   if (!captcha.ok) {
     return c.json<ApiResponse>(
@@ -7299,7 +7461,7 @@ auth.post("/logout", async (c) => {
  * Supports silent re-auth without user interaction when the access token nears expiry.
  */
 auth.post("/refresh", async (c) => {
-  const rl = await checkAuthRateLimit(c, "refresh", 60_000, 30);
+  const rl = await checkAuthRateLimit(c, "refresh", 60_000, 60);
   if (!rl.allowed) {
     return c.json<ApiResponse>(
       { ok: false, error: "Too many requests. Please try again later." },
@@ -7602,7 +7764,9 @@ auth.post("/passkey/register/options", async (c) => {
  * Verifies registration, stores credential, provisions wallet, returns JWT.
  */
 auth.post("/passkey/register/verify", async (c) => {
-  const rl = await checkAuthRateLimit(c, "passkey-verify", 60_000, 10);
+  // Distinct endpoint key from login's "passkey-verify" so registration and
+  // login verification do not share one bucket.
+  const rl = await checkAuthRateLimit(c, "passkey-register-verify", 60_000, 10);
   if (!rl.allowed) {
     return c.json<ApiResponse>(
       { ok: false, error: "Too many requests. Please try again later." },
@@ -7955,7 +8119,7 @@ auth.post("/passkey/login/verify", async (c) => {
  * Sends a magic link email, returns expiry time.
  */
 auth.post("/email/send", async (c) => {
-  const rl = await checkAuthRateLimit(c, "email-send", 60_000, 3);
+  const rl = await checkAuthRateLimit(c, "email-send", 60_000, 10);
   if (!rl.allowed) {
     return c.json<ApiResponse>(
       { ok: false, error: "Too many requests. Please try again later." },
@@ -7996,7 +8160,7 @@ auth.post("/email/send", async (c) => {
     authAbuseConfig,
     "email_otp",
     body.captchaToken,
-    trustedRemoteIp(c),
+    trustedClientIp(c),
   );
   if (!captcha.ok) {
     return c.json<ApiResponse>(
@@ -8262,7 +8426,7 @@ auth.post("/email/code/verify", async (c) => {
 });
 
 auth.post("/email/status", async (c) => {
-  const rl = await checkAuthRateLimit(c, "email-status", 60_000, 60);
+  const rl = await checkAuthRateLimit(c, "email-status", 60_000, 120);
   if (!rl.allowed) {
     return c.json<ApiResponse>(
       { ok: false, error: "Too many requests. Please try again later." },
@@ -8309,7 +8473,7 @@ auth.post("/email/status", async (c) => {
 //                                unverified registration (pre-hijack) closed.
 
 auth.post("/email/otp/send", async (c) => {
-  const rl = await checkAuthRateLimit(c, "email-otp-send", 60_000, 3);
+  const rl = await checkAuthRateLimit(c, "email-otp-send", 60_000, 10);
   if (!rl.allowed) {
     return c.json<ApiResponse>(
       { ok: false, error: "Too many requests. Please try again later." },
@@ -8350,7 +8514,7 @@ auth.post("/email/otp/send", async (c) => {
     authAbuseConfig,
     "email_otp",
     body.captchaToken,
-    trustedRemoteIp(c),
+    trustedClientIp(c),
   );
   if (!captcha.ok) {
     return c.json<ApiResponse>(

--- a/packages/api/src/worker.ts
+++ b/packages/api/src/worker.ts
@@ -25,6 +25,14 @@
  *   - RESEND_API_KEY                Magic-link email provider
  *   - GOOGLE/DISCORD/GITHUB/TWITTER OAuth client IDs + secrets
  *   - PASSKEY_RP_ID, PASSKEY_ORIGIN, PASSKEY_RP_NAME
+ *
+ * Optional client-IP trust bindings (auth rate limiting):
+ *   - STEWARD_TRUSTED_PROXY_HOPS    Trusted proxies appending to x-forwarded-for
+ *   - STEWARD_TRUST_CLOUDFLARE      "true" only when ingress is locked to
+ *                                   Cloudflare; trusts cf-connecting-ip
+ *   - STEWARD_AUTH_RATE_LIMIT_OUTAGE_VALVE_MAX
+ *                                   Bounded auth admissions/min/isolate while a
+ *                                   configured Redis is unreachable
  */
 
 import { initRedis } from "./middleware/redis";
@@ -53,6 +61,9 @@ export interface Env {
   PASSKEY_RP_ID?: string;
   PASSKEY_ORIGIN?: string;
   PASSKEY_RP_NAME?: string;
+  STEWARD_TRUSTED_PROXY_HOPS?: string;
+  STEWARD_TRUST_CLOUDFLARE?: string;
+  STEWARD_AUTH_RATE_LIMIT_OUTAGE_VALVE_MAX?: string;
   [key: string]: unknown;
 }
 

--- a/packages/api/wrangler.toml
+++ b/packages/api/wrangler.toml
@@ -44,6 +44,18 @@ REDIS_DRIVER = "upstash"
 # Passkeys (WebAuthn)
 #   PASSKEY_RP_ID, PASSKEY_ORIGIN, PASSKEY_RP_NAME
 #   PASSKEY_ALLOWED_ORIGINS          comma-separated list of accepted origins
+#
+# Client IP trust (auth rate limiting) — non-secret, can live in [vars]
+#   STEWARD_TRUSTED_PROXY_HOPS       trusted proxies APPENDING to x-forwarded-for
+#                                    (right-most-Nth entry = client IP; unset =
+#                                    coarse per-host rate-limit fallback)
+#   STEWARD_TRUST_CLOUDFLARE         "true" only when origin ingress is locked to
+#                                    Cloudflare; then cf-connecting-ip is trusted
+#                                    (natural fit for this Workers adapter)
+#   STEWARD_AUTH_RATE_LIMIT_OUTAGE_VALVE_MAX
+#                                    bounded auth admissions/min/isolate while a
+#                                    configured Redis is unreachable (default 300,
+#                                    0 = strict fail-closed)
 
 [env.staging]
 name = "steward-api-staging"


### PR DESCRIPTION
Promotes #269 (fixes #268: per-client spoof-resistant auth rate-limit keying) to production. Only commit ahead of main. **Deploy requires `STEWARD_TRUSTED_PROXY_HOPS=1` on steward-api staging+prod** (set as part of this deploy). Rollback = redeploy prior deployment + unset the var.