### PR TITLE
fix(auth): Envoy client-IP derivation on Railway + generous per-IP limits (#268 follow-up)

### DIFF
--- a/packages/api/src/__tests__/auth-client-ip.test.ts
+++ b/packages/api/src/__tests__/auth-client-ip.test.ts
@@ -187,6 +187,70 @@ describe("trustedClientIp", () => {
     expect(await probeIp({ "x-real-ip": "203.0.113.5" })).toBeNull();
   });
 
+  it("x-envoy-external-address is honored when a trusted edge is configured, with :port stripped", async () => {
+    process.env.STEWARD_TRUSTED_PROXY_HOPS = "1";
+    expect(await probeIp({ "x-envoy-external-address": "203.0.113.9" })).toBe("203.0.113.9");
+    // Railway's Envoy edge may append the observed source port.
+    expect(await probeIp({ "x-envoy-external-address": "203.0.113.9:41234" })).toBe("203.0.113.9");
+    expect(await probeIp({ "x-envoy-external-address": "[2001:db8::9]:443" })).toBe("2001:db8::9");
+    // Envoy's single trusted value wins over the XFF fallback at hops=1.
+    expect(
+      await probeIp({
+        "x-envoy-external-address": "203.0.113.9",
+        "x-forwarded-for": "198.51.100.7",
+      }),
+    ).toBe("203.0.113.9");
+    // Garbage still falls through to the XFF path, never becomes a key.
+    expect(
+      await probeIp({
+        "x-envoy-external-address": "not-an-ip:80",
+        "x-forwarded-for": "198.51.100.7",
+      }),
+    ).toBe("198.51.100.7");
+  });
+
+  it("x-envoy-external-address is NEVER trusted with zero trusted hops (client-forgeable)", async () => {
+    delete process.env.STEWARD_TRUSTED_PROXY_HOPS;
+    delete process.env.STEWARD_TRUST_PROXY_HEADERS;
+    delete process.env.STEWARD_TRUST_CLOUDFLARE;
+    expect(await probeIp({ "x-envoy-external-address": "203.0.113.9" })).toBeNull();
+  });
+
+  it("with hops >= 2 the positional XFF read stays authoritative over x-envoy-external-address", async () => {
+    process.env.STEWARD_TRUSTED_PROXY_HOPS = "2";
+    // Envoy names the intermediate proxy here, not the client — XFF wins.
+    expect(
+      await probeIp({
+        "x-envoy-external-address": "10.0.0.9",
+        "x-forwarded-for": "203.0.113.5, 198.51.100.7, 10.0.0.9",
+      }),
+    ).toBe("198.51.100.7");
+    // ...but Envoy still rescues when the positional read cannot parse.
+    expect(
+      await probeIp({
+        "x-envoy-external-address": "10.0.0.9",
+        "x-forwarded-for": "203.0.113.5",
+      }),
+    ).toBe("10.0.0.9");
+  });
+
+  it("parses ip:port and [ipv6]:port in the trusted XFF position; bare IPv6 is never mangled", async () => {
+    process.env.STEWARD_TRUSTED_PROXY_HOPS = "1";
+    // Envoy-style ip:port right-most entry (the Railway prod shape).
+    expect(await probeIp({ "x-forwarded-for": "203.0.113.5, 198.51.100.7:52801" })).toBe(
+      "198.51.100.7",
+    );
+    expect(await probeIp({ "x-forwarded-for": "203.0.113.5, [2001:db8::7]:443" })).toBe(
+      "2001:db8::7",
+    );
+    expect(await probeIp({ "x-forwarded-for": "203.0.113.5, [2001:db8::7]" })).toBe("2001:db8::7");
+    // Bare IPv6 has >= 2 colons and must not be truncated at its last group.
+    expect(await probeIp({ "x-forwarded-for": "203.0.113.5, 2001:db8::7" })).toBe("2001:db8::7");
+    expect(await probeIp({ "x-forwarded-for": "::1" })).toBe("::1");
+    // ip:garbage-port is not silently repaired into an IP.
+    expect(await probeIp({ "x-forwarded-for": "198.51.100.7:notaport" })).toBeNull();
+  });
+
   it("cf-connecting-ip is honored only behind STEWARD_TRUST_CLOUDFLARE=true", async () => {
     process.env.STEWARD_TRUSTED_PROXY_HOPS = "1";
     delete process.env.STEWARD_TRUST_CLOUDFLARE;
@@ -288,7 +352,12 @@ describe("auth rate-limit keying (route harness)", () => {
     forceDenyAll = true;
 
     const res = await authRoutes.request("/nonce", {
-      headers: { host: "api.steward.example", "x-forwarded-for": "203.0.113.5" },
+      headers: {
+        host: "api.steward.example",
+        "x-forwarded-for": "203.0.113.5",
+        // Forged Envoy header without a trusted edge must not mint an ip: bucket.
+        "x-envoy-external-address": "203.0.113.5",
+      },
     });
     expect(res.status).toBe(429);
     // Base 30/min widened x5 for the shared coarse bucket.
@@ -336,7 +405,7 @@ describe("auth rate-limit keying (route harness)", () => {
     );
   });
 
-  it("enforces launch-sized per-endpoint budgets (email-send 10/min, sms-send 5/min per IP)", async () => {
+  it("enforces launch-sized per-endpoint budgets (email-send 30/min, sms-send 5/min per IP)", async () => {
     await connectMockRedis();
     process.env.STEWARD_TRUSTED_PROXY_HOPS = "1";
     const headers = {
@@ -344,9 +413,11 @@ describe("auth rate-limit keying (route harness)", () => {
       "x-forwarded-for": "198.51.100.30",
     };
 
-    // email-send: 10 allowed, 11th denied. Unique destination emails keep the
-    // per-email limiter out of the way; the per-IP budget is what trips.
-    for (let i = 0; i < 10; i++) {
+    // email-send: 30 allowed (generous per-IP burst for shared NATs — the
+    // per-destination limiter is the anti-abuse backstop), 31st denied.
+    // Unique destination emails keep the per-email limiter out of the way;
+    // the per-IP budget is what trips.
+    for (let i = 0; i < 30; i++) {
       const res = await authRoutes.request("/email/send", {
         method: "POST",
         headers,
@@ -357,10 +428,10 @@ describe("auth rate-limit keying (route harness)", () => {
     const emailDenied = await authRoutes.request("/email/send", {
       method: "POST",
       headers,
-      body: JSON.stringify({ email: "person-10@example.com" }),
+      body: JSON.stringify({ email: "person-30@example.com" }),
     });
     expect(emailDenied.status).toBe(429);
-    expect(emailDenied.headers.get("ratelimit-policy")).toBe("10;w=60");
+    expect(emailDenied.headers.get("ratelimit-policy")).toBe("30;w=60");
 
     // sms-send: 5 allowed (invalid body → 400 AFTER the limiter), 6th denied.
     for (let i = 0; i < 5; i++) {

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -213,35 +213,99 @@ function trustedProxyHops(): number {
 }
 
 /**
+ * Normalize one forwarded-address candidate to a bare IP, or undefined.
+ * Proxies (Railway's Envoy edge included) sometimes forward `ip:port` or
+ * `[ipv6]:port`, both of which node's isIP rejects, so the port is stripped
+ * first — but only where it is unambiguous: brackets always delimit an IPv6
+ * address, and a single colon can only be IPv4:port (bare IPv6 always
+ * contains at least two colons and is never truncated).
+ */
+function normalizeIpCandidate(value: string | undefined): string | undefined {
+  let candidate = value?.trim();
+  if (!candidate) return undefined;
+  const bracketed = /^\[([^\]]+)\](?::\d{1,5})?$/.exec(candidate);
+  if (bracketed?.[1]) {
+    candidate = bracketed[1];
+  } else {
+    const ipv4Port = /^([^:]+):\d{1,5}$/.exec(candidate);
+    if (ipv4Port?.[1]) candidate = ipv4Port[1];
+  }
+  return isIP(candidate) ? candidate : undefined;
+}
+
+let clientIpDiagLoggedAt = 0;
+
+/**
+ * TEMPORARY diagnostics — remove once Railway's forwarded-header shape is
+ * confirmed in production logs. Fires (throttled) only when trust IS
+ * configured yet no candidate validated, dumping the raw header values so a
+ * still-failing parse can be fixed precisely instead of guessed at.
+ * JSON.stringify keeps attacker-controlled header bytes on one escaped line.
+ */
+function logNoTrustedClientIpDiag(c: Context, hops: number): void {
+  const now = Date.now();
+  if (now - clientIpDiagLoggedAt < 60_000) return;
+  clientIpDiagLoggedAt = now;
+  console.warn(
+    "[AuthRateLimit][diag] trust configured but no client IP derived; falling back to coarse subject",
+    JSON.stringify({
+      hops,
+      "x-forwarded-for": c.req.header("x-forwarded-for") ?? null,
+      "x-real-ip": c.req.header("x-real-ip") ?? null,
+      "x-envoy-external-address": c.req.header("x-envoy-external-address") ?? null,
+      "cf-connecting-ip": c.req.header("cf-connecting-ip") ?? null,
+    }),
+  );
+}
+
+/**
  * Best-effort trustworthy client IP, or undefined when none can be derived.
  *
  * - cf-connecting-ip is honored only when STEWARD_TRUST_CLOUDFLARE=true AND
  *   origin ingress is locked to Cloudflare. This service is served directly
  *   by Railway today (no cf-ray), so the flag stays unset and the header is
  *   ignored as client-forgeable.
+ * - x-envoy-external-address: Railway's Envoy edge sets this to the single
+ *   external client address it observed (possibly with a :port). It is only
+ *   consulted once the operator has opted into a trusted edge (hops > 0 or
+ *   Cloudflare trust) — on a bare deployment a client could set it — and it
+ *   identifies the CLIENT only when that edge is the outermost trusted hop,
+ *   so with hops >= 2 the positional x-forwarded-for read stays authoritative
+ *   and Envoy's value is only a rescue when that read fails.
  * - x-forwarded-for: each trusted proxy APPENDS the peer it observed, so with
  *   N trusted hops the trustworthy entry is the N-th from the RIGHT. The
  *   left-most entry is client-supplied and is never read.
  * - x-real-ip is deliberately not consulted: no proxy in this topology sets
  *   it authoritatively, so a client-set value would pass through verbatim.
  *
- * Every candidate is validated with isIP so header garbage can never become a
- * rate-limit key or a captcha remoteip. Callers seeing undefined must degrade
- * to a partitioned coarse subject — never a shared "global" bucket, never open.
+ * Every candidate is validated with isIP (after unambiguous :port stripping)
+ * so header garbage can never become a rate-limit key or a captcha remoteip.
+ * Callers seeing undefined must degrade to a partitioned coarse subject —
+ * never a shared "global" bucket, never open.
  */
 export function trustedClientIp(c: Context): string | undefined {
-  if (process.env.STEWARD_TRUST_CLOUDFLARE === "true") {
+  const trustCloudflare = process.env.STEWARD_TRUST_CLOUDFLARE === "true";
+  if (trustCloudflare) {
     const cf = c.req.header("cf-connecting-ip")?.trim();
     if (cf && isIP(cf)) return cf;
   }
   const hops = trustedProxyHops();
-  if (hops === 0) return undefined;
-  const entries = (c.req.header("x-forwarded-for") ?? "")
-    .split(",")
-    .map((entry) => entry.trim())
-    .filter((entry) => entry.length > 0);
-  const candidate = entries[entries.length - hops];
-  return candidate && isIP(candidate) ? candidate : undefined;
+  if (hops === 0 && !trustCloudflare) return undefined;
+
+  const fromEnvoy = () => normalizeIpCandidate(c.req.header("x-envoy-external-address"));
+  const fromForwardedFor = () => {
+    if (hops === 0) return undefined;
+    const entries = (c.req.header("x-forwarded-for") ?? "")
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0);
+    return normalizeIpCandidate(entries[entries.length - hops]);
+  };
+
+  const ip = hops >= 2 ? (fromForwardedFor() ?? fromEnvoy()) : (fromEnvoy() ?? fromForwardedFor());
+  if (ip) return ip;
+  logNoTrustedClientIpDiag(c, hops);
+  return undefined;
 }
 
 /**
@@ -8119,7 +8183,10 @@ auth.post("/passkey/login/verify", async (c) => {
  * Sends a magic link email, returns expiry time.
  */
 auth.post("/email/send", async (c) => {
-  const rl = await checkAuthRateLimit(c, "email-send", 60_000, 10);
+  // Tiered limits: the per-IP burst is generous (30/min) because one IP is
+  // often an office/NAT/dev box full of legit users; the tight anti-abuse
+  // backstop is email-send-destination (5 per 10min per address) below.
+  const rl = await checkAuthRateLimit(c, "email-send", 60_000, 30);
   if (!rl.allowed) {
     return c.json<ApiResponse>(
       { ok: false, error: "Too many requests. Please try again later." },
@@ -8473,7 +8540,10 @@ auth.post("/email/status", async (c) => {
 //                                unverified registration (pre-hijack) closed.
 
 auth.post("/email/otp/send", async (c) => {
-  const rl = await checkAuthRateLimit(c, "email-otp-send", 60_000, 10);
+  // Tiered limits: generous per-IP burst (30/min — shared NATs must not
+  // block); email-otp-send-destination (5 per 10min per address) below is the
+  // tight anti-abuse backstop.
+  const rl = await checkAuthRateLimit(c, "email-otp-send", 60_000, 30);
   if (!rl.allowed) {
     return c.json<ApiResponse>(
       { ok: false, error: "Too many requests. Please try again later." },


### PR DESCRIPTION
Follow-up to #269. On Railway the #268 keying fell to the coarse per-host fallback — `STEWARD_TRUSTED_PROXY_HOPS=1` was live but the right-most `X-Forwarded-For` entry didn't validate (Railway's Envoy edge attaches a port / exposes the client via `x-envoy-external-address`). Adds Envoy-header derivation + port-tolerant XFF parsing + a throttled `[diag]` log that self-reveals Railway's header shape if anything's still exotic. Also raises per-IP `email-send`/`email-otp-send` 10→30 (per operator: never block a legit NAT/office/dev) while keeping the per-destination 5/10min backstop and SMS limits tight. 25/25 focused tests pass.