### PR TITLE
fix(ci): stabilize workflow validation and integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,10 +261,11 @@ jobs:
         # size) and each process frees its WASM heap on exit. Reproduced in a
         # 6GB-capped Linux container: the single `--isolate` process is killed
         # at exit 137; a 6-way --shard split still OOMs (25 files/shard is too
-        # much); this runner at TEST_JOBS=2 finishes the full suite with zero
-        # OOM in ~2.3min. TEST_TIMEOUT=30000 absorbs per-file PGLite migration
-        # latency.
-        run: TEST_JOBS=2 TEST_TIMEOUT=30000 bun packages/api/scripts/run-tests-isolated.ts
+        # much). Keep this serial: even two PGLite processes can starve an API
+        # request long enough to hit Bun's per-test timeout. The runner's
+        # 120-second default leaves headroom for migration-heavy files while
+        # the 25-minute job timeout still bounds the complete suite.
+        run: TEST_JOBS=1 TEST_TIMEOUT=120000 bun packages/api/scripts/run-tests-isolated.ts
         env:
           DATABASE_URL: "postgres://steward:steward_ci@localhost:5432/steward_test"
           PORT: "3299"

--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -110,12 +110,12 @@ jobs:
           RESOLVED_TAG: ${{ steps.resolve.outputs.tag }}
           DRY_RUN: ${{ steps.flags.outputs.dry_run }}
         run: |
-          ARGS="$RESOLVED_TAG"
+          ARGS=("$RESOLVED_TAG")
           if [[ "$DRY_RUN" == "true" ]]; then
-            ARGS="${ARGS} --dry-run"
+            ARGS+=("--dry-run")
           fi
           chmod +x scripts/railway-deploy.sh
-          ./scripts/railway-deploy.sh $ARGS
+          ./scripts/railway-deploy.sh "${ARGS[@]}"
 
       # Update deployment status on success
       - name: Update deployment status (success)

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -61,7 +61,10 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
         run: |
           set -euo pipefail
-          git fetch --no-tags --depth=1 origin "${BASE_REF}"
+          # Checkout above is intentionally unshallow. Keep it that way: a
+          # depth-1 fetch can rewrite origin/${BASE_REF} as a shallow tip and
+          # remove the merge base needed by the three-dot diff below.
+          git fetch --no-tags origin "${BASE_REF}"
           changed_files=$(git diff --name-only "origin/${BASE_REF}...HEAD")
 
           status=0


### PR DESCRIPTION
## Summary
- preserve full PR checkout history so public-package three-dot diffs always have a merge base
- run the PGLite-heavy API suite serially with the runner's 120-second per-test headroom
- pass Railway deploy arguments through a quoted Bash array

## Failure evidence fixed
- develop CI run 31650394306: `agent-auth.test.ts` timed out at 30 seconds under two-worker load
- PR runs 31650399615 / 31650379902: `origin/develop...HEAD: no merge base` after a depth-1 refetch
- local `actionlint`: SC2086 in `deploy-railway.yml`

## Local validation
- `actionlint .github/workflows/*.yml`
- `bun run lint`
- `bun run typecheck`
- Railway deploy script dry run with dummy identifiers/token
