### PR TITLE
fix(api): bind policy inputs into replay identity

### DIFF
--- a/packages/api/src/__tests__/provider-x-permissioned-e2e.test.ts
+++ b/packages/api/src/__tests__/provider-x-permissioned-e2e.test.ts
@@ -66,6 +66,7 @@ import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { estimateXPostMicros, X_POST_PRICE_TABLE_V1 } from "@stwd/policy-engine";
 import { buildXAction } from "@stwd/provider-x";
 import {
+  computeProviderPolicyInputDigest,
   computeXActionDigest,
   jcsStringify,
   sha256HexPrefixed,
@@ -365,6 +366,72 @@ describe("Permissioned-X full-chain E2E (authority plane, PGLite)", () => {
     expect(out.kind).toBe("allowed");
     if (out.kind !== "allowed") throw new Error(`got ${out.kind}`);
     expect(out.stub.status).toBe("stub_succeeded");
+  });
+
+  test("policy-input replay identity: exact summoned replay returns the original outcome", async () => {
+    await seed([
+      allowRule("11111111-1111-4111-8111-1111111111b2", { replyPolicy: { mode: "summoned-only" } }),
+    ]);
+    const args = {
+      text: "thanks for the mention!",
+      replyToTweetId: "1750000000000000000",
+      summoned: true,
+    };
+    const first = await propose(args, "summon-idem-exact");
+    expect(first.kind).toBe("allowed");
+    if (first.kind !== "allowed") throw new Error(`got ${first.kind}`);
+
+    const replay = await propose(args, "summon-idem-exact");
+    expect(replay.kind).toBe("allowed");
+    if (replay.kind !== "allowed") throw new Error(`got ${replay.kind}`);
+    expect(replay.intentId).toBe(first.intentId);
+
+    const binding = await bindingRow(first.intentId);
+    const envelope = binding.requestEnvelope as Record<string, unknown>;
+    const build = buildXAction(OP_TWEET as never, args);
+    expect(envelope.policyInputDigest).toBe(computeProviderPolicyInputDigest(build.policyArgs));
+    // Only the digest is persisted in the replay envelope: no policy args or
+    // raw tweet text cross this durability boundary.
+    expect(envelope).not.toHaveProperty("policyArgs");
+    expect(JSON.stringify(envelope)).not.toContain(args.text);
+  });
+
+  test.each([
+    ["denied false -> allowed true", false, true, "summon-idem-danger"],
+    ["allowed true -> denied false", true, false, "summon-idem-benign"],
+  ])("policy-input replay identity conflicts on %s with the same outbound action", async (_case, firstSummoned, replaySummoned, key) => {
+    await seed([
+      allowRule("11111111-1111-4111-8111-1111111111b2", {
+        replyPolicy: { mode: "summoned-only" },
+      }),
+    ]);
+    const base = {
+      text: "thanks for the mention!",
+      replyToTweetId: "1750000000000000000",
+    };
+    const firstBuild = buildXAction(OP_TWEET as never, {
+      ...base,
+      summoned: firstSummoned,
+    });
+    const replayBuild = buildXAction(OP_TWEET as never, {
+      ...base,
+      summoned: replaySummoned,
+    });
+    // `summoned` remains policy-only: outbound canonical bytes/digest are
+    // identical, while the separate replay identity is intentionally not.
+    expect(computeXActionDigest(firstBuild.action)).toBe(computeXActionDigest(replayBuild.action));
+    expect(computeProviderPolicyInputDigest(firstBuild.policyArgs)).not.toBe(
+      computeProviderPolicyInputDigest(replayBuild.policyArgs),
+    );
+
+    const first = await propose({ ...base, summoned: firstSummoned }, key);
+    expect(first.kind).toBe(firstSummoned ? "allowed" : "policy_denied");
+    const replay = await propose({ ...base, summoned: replaySummoned }, key);
+    expect(replay).toEqual({
+      kind: "replay_conflict",
+      code: "REPLAY_IDEMPOTENCY_CONFLICT",
+      httpStatus: 409,
+    });
   });
 
   test("contentPolicy blockedPatterns: a blocked-pattern post is policy_denied via in-memory policyText", async () => {

--- a/packages/api/src/services/provider-action-service.ts
+++ b/packages/api/src/services/provider-action-service.ts
@@ -50,6 +50,7 @@ import {
 import type { GithubActionBuild } from "@stwd/provider-github";
 import type { XActionBuild } from "@stwd/provider-x";
 import {
+  computeProviderPolicyInputDigest,
   type GithubCanonicalActionV1,
   jcsStringify,
   type ProviderRequestEnvelopeV1,
@@ -378,6 +379,12 @@ class ProviderActionService {
     // Compute the canonical action digest + request envelope/hash up-front (they
     // are pure and needed for the binding + idempotency conflict check).
     const actionDigest = sha256HexPrefixed(jcsStringify(this.canonicalActionObject(build.action)));
+    // Idempotency identity includes every adapter-validated policy input, not
+    // only the outbound HTTP action. This is deliberately a separate,
+    // domain-separated digest: policy-only signals such as X `summoned` must
+    // conflict when changed without contaminating the canonical action digest.
+    // `policyText` is a separate in-memory channel and is never included here.
+    const policyInputDigest = computeProviderPolicyInputDigest(build.policyArgs);
     const canonicalBytes = jcsStringify(this.canonicalActionObject(build.action));
 
     // Idempotency replay lookup on the real operation id.
@@ -395,11 +402,20 @@ class ProviderActionService {
       )
       .limit(1);
     if (priorBinding) {
-      // A replay MUST match on the durable action binding. requestedAt/nonce
-      // differ per call, so we compare the ACTION binding (digest + resource),
-      // not the request hash which intentionally varies. Any different
-      // action/resource for the same key => conflict.
-      if (priorBinding.actionDigest !== actionDigest) {
+      // A replay MUST match both the durable outbound action and the validated
+      // policy inputs that authorized it. requestedAt/nonce differ per call, so
+      // requestHash itself is not the replay key. New bindings persist the
+      // policy-input digest inside their immutable, request-hash-bound envelope.
+      // Legacy envelopes have no such member and retain the historical
+      // action-only replay behavior; this is a bounded compatibility path for
+      // pre-rollout rows, never used by a newly-created binding.
+      const persistedPolicyInputDigest = (priorBinding.requestEnvelope as Record<string, unknown>)
+        .policyInputDigest;
+      if (
+        priorBinding.actionDigest !== actionDigest ||
+        (persistedPolicyInputDigest !== undefined &&
+          persistedPolicyInputDigest !== policyInputDigest)
+      ) {
         return {
           kind: "replay_conflict",
           code: "REPLAY_IDEMPOTENCY_CONFLICT",
@@ -473,6 +489,7 @@ class ProviderActionService {
           operationId: txOperation.id,
           operationRevision: txOperation.revision,
           actionDigest,
+          policyInputDigest,
         });
         requestHash = sha256HexPrefixed(jcsStringify(this.envelopeObject(envelope)));
 
@@ -1621,6 +1638,7 @@ class ProviderActionService {
       operationId: string;
       operationRevision: number;
       actionDigest: string;
+      policyInputDigest: string;
     },
   ): ProviderRequestEnvelopeV1 {
     return {
@@ -1632,6 +1650,7 @@ class ProviderActionService {
       operationId: ids.operationId,
       operationRevision: ids.operationRevision,
       actionDigest: ids.actionDigest,
+      policyInputDigest: ids.policyInputDigest,
       idempotencyKeyHash: input.idempotencyKeyHash,
       requestedAt: input.requestedAt,
       expiresAt: input.expiresAt,
@@ -1640,7 +1659,7 @@ class ProviderActionService {
   }
 
   private envelopeObject(e: ProviderRequestEnvelopeV1): Record<string, unknown> {
-    return {
+    const envelope: Record<string, unknown> = {
       schemaVersion: e.schemaVersion,
       tenantId: e.tenantId,
       workspaceId: e.workspaceId,
@@ -1654,6 +1673,8 @@ class ProviderActionService {
       expiresAt: e.expiresAt,
       nonce: e.nonce,
     };
+    if (e.policyInputDigest !== undefined) envelope.policyInputDigest = e.policyInputDigest;
+    return envelope;
   }
 
   /**

--- a/packages/shared/src/__tests__/provider-policy-input.test.ts
+++ b/packages/shared/src/__tests__/provider-policy-input.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "bun:test";
+import {
+  computeProviderPolicyInputDigest,
+  jcsStringify,
+  PROVIDER_POLICY_INPUT_HASH_DOMAIN,
+  PROVIDER_POLICY_INPUT_SCHEMA_VERSION,
+  sha256HexPrefixed,
+} from "../provider-action.js";
+
+describe("provider policy-input replay identity", () => {
+  it("is deterministic under object-key reordering", () => {
+    expect(computeProviderPolicyInputDigest({ summoned: true, isReply: true })).toBe(
+      computeProviderPolicyInputDigest({ isReply: true, summoned: true }),
+    );
+  });
+
+  it("changes when a policy-only boolean changes", () => {
+    expect(computeProviderPolicyInputDigest({ summoned: false })).not.toBe(
+      computeProviderPolicyInputDigest({ summoned: true }),
+    );
+  });
+
+  it("uses an explicit hash domain, not the bare policy document hash", () => {
+    const policyArgs = { summoned: true };
+    const bareBytes = jcsStringify({
+      schemaVersion: PROVIDER_POLICY_INPUT_SCHEMA_VERSION,
+      policyArgs,
+    });
+    const digest = computeProviderPolicyInputDigest(policyArgs);
+    expect(digest).toBe(sha256HexPrefixed(`${PROVIDER_POLICY_INPUT_HASH_DOMAIN}${bareBytes}`));
+    expect(digest).not.toBe(sha256HexPrefixed(bareBytes));
+  });
+
+  it("rejects unsupported values instead of silently dropping identity fields", () => {
+    expect(() => computeProviderPolicyInputDigest({ summoned: undefined })).toThrow();
+    expect(() => computeProviderPolicyInputDigest({ amount: Number.NaN })).toThrow();
+  });
+});

--- a/packages/shared/src/provider-action.ts
+++ b/packages/shared/src/provider-action.ts
@@ -656,6 +656,13 @@ export function sha256HexPrefixed(input: string | Uint8Array): string {
 
 export const GITHUB_PROVIDER_ACTION_PROFILE = "github.provider-action.v1" as const;
 export const PROVIDER_REQUEST_SCHEMA_VERSION = "steward.provider-request.v1" as const;
+export const PROVIDER_POLICY_INPUT_SCHEMA_VERSION = "steward.provider-policy-input.v1" as const;
+/**
+ * Hash-domain prefix for policy-input replay identity. This keeps a policy-input
+ * digest cryptographically distinct from action/request hashes even if a future
+ * document happens to serialize to the same bytes.
+ */
+export const PROVIDER_POLICY_INPUT_HASH_DOMAIN = "steward.provider-policy-input.v1\n" as const;
 export const CANONICAL_ORIGIN = "https://api.github.com" as const;
 
 export type CanonicalMethod = "GET" | "POST" | "PATCH" | "PUT" | "DELETE" | "HEAD";
@@ -687,10 +694,34 @@ export interface ProviderRequestEnvelopeV1 {
   operationId: string;
   operationRevision: number;
   actionDigest: string;
+  /**
+   * Digest of adapter-validated policy inputs. Optional only so request hashes
+   * recorded before this field existed remain reproducible; every newly-created
+   * provider request includes it.
+   */
+  policyInputDigest?: string;
   idempotencyKeyHash: string;
   requestedAt: string;
   expiresAt: string;
   nonce: string;
+}
+
+/**
+ * Compute the replay identity for adapter-validated policy inputs.
+ *
+ * The adapter contract permits only policy-safe JSON values here (never raw
+ * credentials or the X `policyText` channel). JCS rejects undefined, non-finite,
+ * prototype-bearing, or otherwise unsupported runtime values rather than
+ * silently weakening the identity. Only the digest is persisted.
+ */
+export function computeProviderPolicyInputDigest(
+  policyArgs: Readonly<Record<string, unknown>>,
+): string {
+  const bytes = jcsStringify({
+    schemaVersion: PROVIDER_POLICY_INPUT_SCHEMA_VERSION,
+    policyArgs,
+  });
+  return sha256HexPrefixed(`${PROVIDER_POLICY_INPUT_HASH_DOMAIN}${bytes}`);
 }
 
 /**
@@ -721,7 +752,7 @@ export function computeActionDigest(a: GithubCanonicalActionV1): string {
 }
 
 function toEnvelopeObject(e: ProviderRequestEnvelopeV1): Record<string, unknown> {
-  return {
+  const envelope: Record<string, unknown> = {
     schemaVersion: e.schemaVersion,
     tenantId: e.tenantId,
     workspaceId: e.workspaceId,
@@ -735,6 +766,9 @@ function toEnvelopeObject(e: ProviderRequestEnvelopeV1): Record<string, unknown>
     expiresAt: e.expiresAt,
     nonce: e.nonce,
   };
+  // Preserve the byte-for-byte hash of legacy envelopes that predate #229.
+  if (e.policyInputDigest !== undefined) envelope.policyInputDigest = e.policyInputDigest;
+  return envelope;
 }
 
 /** `requestHash` = sha256: hex of the JCS of the request envelope. */


### PR DESCRIPTION
Closes #229.

## What

- adds a generalized, domain-separated digest over every adapter-validated policyArgs object
- persists only that digest inside the immutable request envelope, which also binds it into requestHash and approval commitments
- requires idempotent replay to match both actionDigest and policyInputDigest
- preserves byte-for-byte request hashes and action-only replay behavior for legacy envelopes that predate the optional digest
- keeps raw X policyText, tweet text, credentials, and raw policy arguments out of durable replay state

## Why

The X summoned signal is intentionally policy-only, so flipping it does not change the outbound canonical action. Previously, reusing an idempotency key with the flipped signal returned the prior outcome. New bindings now conflict with REPLAY_IDEMPOTENCY_CONFLICT in both directions while exact replay remains idempotent.

## Verification

- provider-policy-input unit suite: 4 pass
- shared plus provider-x operation suites: 388 pass
- provider-x permissioned E2E plus provider-action service: 25 pass
- provider actions route plus X governed E2E: 16 pass when run with the required STEWARD_EXECUTION_AUTH_SECRET test key
- API dependency graph build: 21 of 21 packages successful
- root lint: clean exit, existing warnings and info only
- git diff --check: clean

## Security properties

- explicit hash-domain prefix and schema version
- JCS deterministic key ordering
- unsupported runtime values fail closed instead of being dropped
- only a digest is persisted; raw policy inputs and text are not stored in the request envelope
- both false-to-true and true-to-false summoned replays are proven to retain the same action digest but return 409 conflict
- legacy golden request hashes remain byte-identical
