### PR TITLE
feat(policy): enforce capability business hours

### DIFF
--- a/packages/api/src/__tests__/provider-action-service.test.ts
+++ b/packages/api/src/__tests__/provider-action-service.test.ts
@@ -233,6 +233,13 @@ async function auditCount(): Promise<number> {
   return Number((arr[0] as { n: number }).n);
 }
 
+function hhmm(minute: number): string {
+  const normalized = ((minute % 1440) + 1440) % 1440;
+  return `${String(Math.floor(normalized / 60)).padStart(2, "0")}:${String(normalized % 60).padStart(2, "0")}`;
+}
+
+const ALL_DAYS = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"];
+
 describe("provider-action service pipeline", () => {
   beforeAll(async () => {
     process.env.STEWARD_PGLITE_MEMORY = "true";
@@ -271,6 +278,40 @@ describe("provider-action service pipeline", () => {
     expect(bindings.length).toBe(0);
     // Required denial audit DID write.
     expect(await auditCount()).toBe(before + 1);
+  });
+
+  test("#207 server-time business window is enforced end to end and is load-bearing", async () => {
+    await grantAgent(AGENT, WORKSPACE_A, ACCOUNT_A, ["github.issue.list"]);
+    const now = new Date();
+    const minute = now.getUTCHours() * 60 + now.getUTCMinutes();
+    const rules = (from: string, to: string) => [
+      {
+        id: "20700000-0000-4000-8000-000000000001",
+        type: "capability-intent",
+        enabled: true,
+        config: {
+          capabilities: ["github.issue.list"],
+          effect: "allow",
+          constraints: { timeWindow: { timezone: "UTC", allow: [{ days: ALL_DAYS, from, to }] } },
+        },
+      },
+    ];
+
+    // A narrow window containing the current server minute allows.
+    await setOpPolicyRules(OP_A_READ, rules(hhmm(minute - 1), hhmm(minute + 2)));
+    const allowed = await providerActionService.createProviderAction(input());
+    expect(allowed.kind).toBe("allowed");
+
+    await getDb().delete(providerActionAuditOutbox);
+    await getDb().delete(providerActionBindings);
+    await getDb().delete(intents);
+
+    // Mutation proof: moving the same window just ahead of server time denies.
+    await setOpPolicyRules(OP_A_READ, rules(hhmm(minute + 2), hhmm(minute + 4)));
+    const denied = await providerActionService.createProviderAction(
+      input({ idempotencyKeyHash: `sha256:${"b".repeat(64)}` }),
+    );
+    expect(denied.kind).toBe("policy_denied");
   });
 
   test("metrics observer failure cannot change a real governed denial decision", async () => {

--- a/packages/api/src/services/provider-action-service.ts
+++ b/packages/api/src/services/provider-action-service.ts
@@ -1395,6 +1395,7 @@ class ProviderActionService {
       // github actions report api.github.com, never a hardcoded provider.
       host: hostFromOrigin(build.action.origin),
       path: build.action.normalizedPath,
+      evaluatedAt: decidedAt,
       // Trailing-hour count is not wired in PR2; rules that require it will
       // fail closed (POLICY_INPUT_UNAVAILABLE) exactly as specified.
       invokeCount1h: undefined,

--- a/packages/plugin-capabilities/src/invoke.ts
+++ b/packages/plugin-capabilities/src/invoke.ts
@@ -311,12 +311,14 @@ export async function invokeCapabilityThroughProxy(
     });
   }
 
+  const evaluatedAt = new Date().toISOString();
   const capabilityCtx: NonNullable<EvaluatorContext["capability"]> = {
     name: cap.name,
     args: invokeArgs,
     host: cap.host,
     path: cap.pathPattern,
     method: cap.method,
+    evaluatedAt,
   };
 
   let policySet: PolicyRule[];

--- a/packages/policy-engine/src/__tests__/provider-policy-composition.test.ts
+++ b/packages/policy-engine/src/__tests__/provider-policy-composition.test.ts
@@ -151,4 +151,119 @@ describe("composeProviderActionPolicyDecision precedence", () => {
       composeProviderActionPolicyDecision([capRule], { ...ctx, invokeCount1h: 4 }).effect,
     ).toBe("allow");
   });
+
+  it("enforces IANA business hours from the server-supplied instant", () => {
+    const businessHours = rule("hours", "allow", {
+      constraints: {
+        timeWindow: {
+          timezone: "America/Los_Angeles",
+          allow: [{ days: ["mon", "tue", "wed", "thu", "fri"], from: "09:00", to: "17:00" }],
+        },
+      },
+    });
+    expect(
+      composeProviderActionPolicyDecision([businessHours], {
+        ...ctx,
+        evaluatedAt: "2026-08-17T19:00:00.000Z", // Monday noon PDT
+      }).effect,
+    ).toBe("allow");
+    expect(
+      composeProviderActionPolicyDecision([businessHours], {
+        ...ctx,
+        evaluatedAt: "2026-08-17T23:59:00.000Z", // Monday 16:59 PDT
+      }).effect,
+    ).toBe("allow");
+    expect(
+      composeProviderActionPolicyDecision([businessHours], {
+        ...ctx,
+        evaluatedAt: "2026-08-18T00:00:00.000Z", // Monday 17:00 PDT, exclusive
+      }).effect,
+    ).toBe("hard_deny");
+  });
+
+  it("handles overnight windows against the opening weekday", () => {
+    const overnight = rule("overnight", "allow", {
+      constraints: {
+        timeWindow: {
+          timezone: "America/Los_Angeles",
+          allow: [{ days: ["mon"], from: "22:00", to: "02:00" }],
+        },
+      },
+    });
+    expect(
+      composeProviderActionPolicyDecision([overnight], {
+        ...ctx,
+        evaluatedAt: "2026-08-18T08:00:00.000Z", // Tuesday 01:00 PDT
+      }).effect,
+    ).toBe("allow");
+    expect(
+      composeProviderActionPolicyDecision([overnight], {
+        ...ctx,
+        evaluatedAt: "2026-08-18T09:00:00.000Z", // Tuesday 02:00 PDT
+      }).effect,
+    ).toBe("hard_deny");
+  });
+
+  it("is deterministic across DST gaps and repeated local times", () => {
+    const dstWindow = rule("dst", "allow", {
+      constraints: {
+        timeWindow: {
+          timezone: "America/New_York",
+          allow: [{ days: ["sun"], from: "01:00", to: "03:00" }],
+        },
+      },
+    });
+    // Spring-forward: 01:30 exists; the next sampled instant is 03:30 and denied.
+    expect(
+      composeProviderActionPolicyDecision([dstWindow], {
+        ...ctx,
+        evaluatedAt: "2026-03-08T06:30:00.000Z",
+      }).effect,
+    ).toBe("allow");
+    expect(
+      composeProviderActionPolicyDecision([dstWindow], {
+        ...ctx,
+        evaluatedAt: "2026-03-08T07:30:00.000Z",
+      }).effect,
+    ).toBe("hard_deny");
+    // Fall-back: both distinct instants mapping to 01:30 are treated alike.
+    for (const evaluatedAt of ["2026-11-01T05:30:00.000Z", "2026-11-01T06:30:00.000Z"]) {
+      expect(composeProviderActionPolicyDecision([dstWindow], { ...ctx, evaluatedAt }).effect).toBe(
+        "allow",
+      );
+    }
+  });
+
+  it("fails closed on absent time, invalid timezone, unknown keys, and empty windows", () => {
+    const valid = rule("hours", "allow", {
+      constraints: {
+        timeWindow: {
+          timezone: "UTC",
+          allow: [{ days: ["mon"], from: "09:00", to: "17:00" }],
+        },
+      },
+    });
+    const missing = composeProviderActionPolicyDecision([valid], {
+      ...ctx,
+      evaluatedAt: undefined,
+    });
+    expect(missing.effect).toBe("hard_deny");
+    expect(missing.reasonCodes).toContain(PROVIDER_POLICY_REASON.INPUT_UNAVAILABLE);
+
+    for (const timeWindow of [
+      { timezone: "Not/A_Zone", allow: [{ days: ["mon"], from: "09:00", to: "17:00" }] },
+      { timezone: "UTC", allow: [] },
+      { timezone: "UTC", allow: [{ days: ["MON"], from: "09:00", to: "17:00" }] },
+      { timezone: "UTC", allow: [{ days: ["mon"], from: "09:00", to: "09:00" }] },
+      { timezone: "UTC", allow: [{ days: ["mon"], from: "09:00", to: "17:00", extra: true }] },
+    ]) {
+      const malformed = rule("bad-hours", "allow", { constraints: { timeWindow } });
+      const decision = composeProviderActionPolicyDecision([malformed], {
+        ...ctx,
+        evaluatedAt: "2026-08-17T12:00:00.000Z",
+      });
+      expect(decision.effect).toBe("hard_deny");
+      expect(decision.reasonCodes).toContain(PROVIDER_POLICY_REASON.CONFIGURATION_INVALID);
+    }
+  });
 });

--- a/packages/policy-engine/src/capability-intent.ts
+++ b/packages/policy-engine/src/capability-intent.ts
@@ -201,6 +201,8 @@ export interface XConstraints {
 
 /** Constraints evaluated ONLY on an `effect: "allow"` match. */
 export interface CapabilityIntentConstraints {
+  /** Local business-hours allow windows evaluated from a server-supplied instant. */
+  readonly timeWindow?: CapabilityTimeWindow;
   /**
    * Max capability INVOKES per trailing hour. Evaluated against
    * `ctx.capabilityInvokeCount1h` (NOT the tx counter). If this is set but the
@@ -252,6 +254,21 @@ export interface CapabilityIntentConstraints {
    * See {@link XConstraints} + docs/security/permissioned-x.mdx.
    */
   readonly x?: XConstraints;
+}
+
+export type CapabilityWeekday = "mon" | "tue" | "wed" | "thu" | "fri" | "sat" | "sun";
+
+export interface CapabilityTimeWindowEntry {
+  readonly days: CapabilityWeekday[];
+  /** Inclusive local wall-clock start, HH:MM. */
+  readonly from: string;
+  /** Exclusive local wall-clock end, HH:MM. Overnight windows are supported. */
+  readonly to: string;
+}
+
+export interface CapabilityTimeWindow {
+  readonly timezone: string;
+  readonly allow: CapabilityTimeWindowEntry[];
 }
 
 /** The jsonb config of a `capability-intent` rule. */
@@ -354,6 +371,7 @@ const ALLOWED_CONSTRAINT_KEYS: ReadonlySet<string> = new Set([
   "cumulativeSpend",
   "argEquals",
   "argMatches",
+  "timeWindow",
   "x",
 ]);
 const ALLOWED_CUMULATIVE_SPEND_KEYS: ReadonlySet<string> = new Set([
@@ -363,6 +381,109 @@ const ALLOWED_CUMULATIVE_SPEND_KEYS: ReadonlySet<string> = new Set([
   "aggregateOver",
 ]);
 const CUMULATIVE_SPEND_SCOPES: ReadonlySet<string> = new Set(["operation", "agent", "grant"]);
+const WEEKDAYS: readonly CapabilityWeekday[] = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"];
+const WEEKDAY_SET: ReadonlySet<string> = new Set(WEEKDAYS);
+const HH_MM = /^([01][0-9]|2[0-3]):([0-5][0-9])$/;
+
+function minuteOfDay(value: string): number | null {
+  const match = HH_MM.exec(value);
+  return match ? Number(match[1]) * 60 + Number(match[2]) : null;
+}
+
+function parseTimeWindow(raw: unknown): CapabilityTimeWindow | { error: string } {
+  if (!isPlainObject(raw))
+    return { error: "capability-intent: `constraints.timeWindow` must be an object" };
+  const unknown = Object.keys(raw).filter((key) => key !== "timezone" && key !== "allow");
+  if (unknown.length)
+    return {
+      error: `capability-intent: unknown constraints.timeWindow key(s): ${unknown.join(", ")}`,
+    };
+  if (typeof raw.timezone !== "string" || !raw.timezone || raw.timezone.length > 128) {
+    return { error: "capability-intent: `timeWindow.timezone` must be an IANA timezone" };
+  }
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: raw.timezone }).format(new Date(0));
+  } catch {
+    return { error: "capability-intent: `timeWindow.timezone` must be an IANA timezone" };
+  }
+  if (!Array.isArray(raw.allow) || raw.allow.length === 0 || raw.allow.length > 64) {
+    return { error: "capability-intent: `timeWindow.allow` must contain 1..64 windows" };
+  }
+  const allow: CapabilityTimeWindowEntry[] = [];
+  for (const candidate of raw.allow) {
+    if (!isPlainObject(candidate))
+      return { error: "capability-intent: each time window must be an object" };
+    const extra = Object.keys(candidate).filter(
+      (key) => key !== "days" && key !== "from" && key !== "to",
+    );
+    if (extra.length)
+      return { error: `capability-intent: unknown time window key(s): ${extra.join(", ")}` };
+    if (
+      !Array.isArray(candidate.days) ||
+      candidate.days.length === 0 ||
+      candidate.days.some((day) => typeof day !== "string" || !WEEKDAY_SET.has(day))
+    ) {
+      return { error: "capability-intent: time window days must be non-empty lowercase weekdays" };
+    }
+    if (new Set(candidate.days).size !== candidate.days.length) {
+      return { error: "capability-intent: time window days must not contain duplicates" };
+    }
+    if (
+      typeof candidate.from !== "string" ||
+      typeof candidate.to !== "string" ||
+      minuteOfDay(candidate.from) === null ||
+      minuteOfDay(candidate.to) === null ||
+      candidate.from === candidate.to
+    ) {
+      return { error: "capability-intent: time window from/to must be distinct HH:MM values" };
+    }
+    allow.push({
+      days: candidate.days as CapabilityWeekday[],
+      from: candidate.from,
+      to: candidate.to,
+    });
+  }
+  return { timezone: raw.timezone, allow };
+}
+
+function timeWindowAllows(
+  window: CapabilityTimeWindow,
+  evaluatedAt: string | undefined,
+): "allow" | "deny" | "unavailable" {
+  if (typeof evaluatedAt !== "string") return "unavailable";
+  const instant = new Date(evaluatedAt);
+  if (!Number.isFinite(instant.getTime())) return "unavailable";
+  let parts: Intl.DateTimeFormatPart[];
+  try {
+    parts = new Intl.DateTimeFormat("en-US", {
+      timeZone: window.timezone,
+      weekday: "short",
+      hour: "2-digit",
+      minute: "2-digit",
+      hourCycle: "h23",
+    }).formatToParts(instant);
+  } catch {
+    return "unavailable";
+  }
+  const byType = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+  const day = byType.weekday?.slice(0, 3).toLowerCase() as CapabilityWeekday | undefined;
+  const minute = Number(byType.hour) * 60 + Number(byType.minute);
+  if (!day || !WEEKDAY_SET.has(day) || !Number.isInteger(minute)) return "unavailable";
+  const dayIndex = WEEKDAYS.indexOf(day);
+  const previousDay = WEEKDAYS[(dayIndex + 6) % 7];
+  for (const entry of window.allow) {
+    const from = minuteOfDay(entry.from) as number;
+    const to = minuteOfDay(entry.to) as number;
+    if (from < to && entry.days.includes(day) && minute >= from && minute < to) return "allow";
+    if (
+      from > to &&
+      ((entry.days.includes(day) && minute >= from) ||
+        (entry.days.includes(previousDay) && minute < to))
+    )
+      return "allow";
+  }
+  return "deny";
+}
 
 /**
  * Parse a restricted ISO-8601 duration into a positive integer number of
@@ -785,6 +906,13 @@ function parseConfig(rawInput: unknown): CapabilityIntentConfig | { error: strin
       return { error: "capability-intent: `constraints.argMatches` must be Record<string,string>" };
     }
 
+    let timeWindow: CapabilityTimeWindow | undefined;
+    if (c.timeWindow !== undefined) {
+      const parsedTimeWindow = parseTimeWindow(c.timeWindow);
+      if ("error" in parsedTimeWindow) return parsedTimeWindow;
+      timeWindow = parsedTimeWindow;
+    }
+
     let xConstraints: XConstraints | undefined;
     if (c.x !== undefined) {
       const parsedX = parseXConstraints(c.x);
@@ -809,6 +937,7 @@ function parseConfig(rawInput: unknown): CapabilityIntentConfig | { error: strin
         : {}),
       ...(c.argEquals !== undefined ? { argEquals: c.argEquals as Record<string, string> } : {}),
       ...(c.argMatches !== undefined ? { argMatches: c.argMatches as Record<string, string> } : {}),
+      ...(timeWindow !== undefined ? { timeWindow } : {}),
       ...(xConstraints !== undefined ? { x: xConstraints } : {}),
     };
   }
@@ -901,6 +1030,19 @@ function evaluateConstraints(
           reason: `capability-intent: arg "${key}" does not match required pattern`,
         };
       }
+    }
+  }
+  if (constraints.timeWindow) {
+    const result = timeWindowAllows(constraints.timeWindow, capability.evaluatedAt);
+    if (result !== "allow") {
+      return {
+        ...base,
+        passed: false,
+        reason:
+          result === "unavailable"
+            ? "capability-intent: timeWindow set but server evaluation time is unavailable"
+            : "capability-intent: invoke is outside the configured business-hours window",
+      };
     }
   }
 
@@ -1257,6 +1399,8 @@ export interface ProviderPolicyContext {
   readonly method: string;
   readonly host: string;
   readonly path: string;
+  /** Immutable server-supplied evaluation instant. Never accepted from action args. */
+  readonly evaluatedAt?: string;
   /** Authoritative trailing-hour invoke count. `undefined` => input
    *  unavailable => fail closed (hard_deny, POLICY_INPUT_UNAVAILABLE). */
   readonly invokeCount1h?: number;
@@ -1567,6 +1711,11 @@ function evaluateProviderConstraints(
       const value = args[key];
       if (typeof value !== "string" || !re.test(value)) return PROVIDER_POLICY_REASON.HARD_DENY;
     }
+  }
+  if (constraints.timeWindow) {
+    const result = timeWindowAllows(constraints.timeWindow, ctx.evaluatedAt);
+    if (result === "unavailable") return PROVIDER_POLICY_REASON.INPUT_UNAVAILABLE;
+    if (result === "deny") return PROVIDER_POLICY_REASON.HARD_DENY;
   }
   if (constraints.maxCallsPerHour !== undefined) {
     const count = ctx.invokeCount1h;

--- a/packages/policy-engine/src/evaluators.ts
+++ b/packages/policy-engine/src/evaluators.ts
@@ -95,6 +95,8 @@ export interface EvaluatorContext {
     host: string;
     path: string;
     method: string;
+    /** Immutable server-supplied instant for time-window constraints. */
+    evaluatedAt?: string;
   };
   /**
    * Rolling count of capability INVOKES in the trailing hour (distinct from


### PR DESCRIPTION
Closes #207

## Summary
- add a strict IANA-timezone business-hours constraint with weekday and overnight-window support
- evaluate against a server-supplied immutable instant in both provider-action and capability paths
- fail closed for missing time, malformed configuration, ambiguous windows, and out-of-window requests
- cover DST transitions, overnight semantics, validation, composition, and the governed provider-action runtime path

## Validation
- `bun run turbo run build --filter=@stwd/policy-engine --filter=@stwd/api --filter=@stwd/plugin-capabilities` (21/21 tasks)
- `bun test packages/api/src/__tests__/provider-action-service.test.ts` (11/11)
- `bun test packages/policy-engine/src/__tests__/provider-policy-composition.test.ts`
- Biome focused check and `git diff --check`