### PR TITLE
feat(api): add agent-scoped provider-action status

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -8944,6 +8944,338 @@
         }
       }
     },
+    "/v2/provider-actions/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "tags": [
+          "Provider Authority"
+        ],
+        "summary": "Get the authenticated agent's own provider-action status",
+        "description": "Requires an agent JWT. The action is scoped server-side to the verified tenant and agent; absent, malformed, cross-agent, and cross-tenant ids all return the same 404 response. This route does not grant access to the human/MFA-gated approval, case, or evidence surfaces.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "X-Steward-Tenant",
+            "in": "header",
+            "required": false,
+            "description": "Tenant containing the authenticated agent. It is checked against the verified agent principal and never selects a foreign action.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "required": [
+                        "id",
+                        "intent_id",
+                        "intentType",
+                        "intent_type",
+                        "status",
+                        "payload",
+                        "createdAt",
+                        "updatedAt"
+                      ],
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "intent_id": {
+                          "type": "string"
+                        },
+                        "tenantId": {
+                          "type": "string"
+                        },
+                        "agentId": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "wallet_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "intentType": {
+                          "type": "string",
+                          "enum": [
+                            "rpc",
+                            "transfer",
+                            "wallet_update",
+                            "policy_update",
+                            "policy_rule_create",
+                            "policy_rule_delete",
+                            "policy_rule_update",
+                            "quorum_update",
+                            "wallet_action",
+                            "provider-action"
+                          ]
+                        },
+                        "intent_type": {
+                          "type": "string",
+                          "enum": [
+                            "rpc",
+                            "transfer",
+                            "wallet_update",
+                            "policy_update",
+                            "policy_rule_create",
+                            "policy_rule_delete",
+                            "policy_rule_update",
+                            "quorum_update",
+                            "wallet_action",
+                            "provider-action"
+                          ]
+                        },
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "pending",
+                            "authorized",
+                            "executing",
+                            "executed",
+                            "failed",
+                            "rejected",
+                            "canceled",
+                            "expired"
+                          ]
+                        },
+                        "resourceType": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "resourceId": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "resource_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "createdByType": {
+                          "type": "string"
+                        },
+                        "createdById": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "created_by_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "createdByDisplayName": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "created_by_display_name": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "authorizationDetails": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": true
+                          }
+                        },
+                        "authorization_details": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": true
+                          }
+                        },
+                        "payload": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "executionResult": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "additionalProperties": true
+                        },
+                        "execution_result": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "additionalProperties": true
+                        },
+                        "expiresAt": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "format": "date-time"
+                        },
+                        "expires_at": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "authorizedBy": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "authorized_by": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "authorizedAt": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "format": "date-time"
+                        },
+                        "executedAt": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "format": "date-time"
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "created_at": {
+                          "type": "integer"
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/accounts": {
       "get": {
         "tags": [
@@ -33842,7 +34174,8 @@
                 "policy_rule_delete",
                 "policy_rule_update",
                 "quorum_update",
-                "wallet_action"
+                "wallet_action",
+                "provider-action"
               ]
             }
           },
@@ -33861,7 +34194,8 @@
                 "policy_rule_delete",
                 "policy_rule_update",
                 "quorum_update",
-                "wallet_action"
+                "wallet_action",
+                "provider-action"
               ]
             }
           },
@@ -33880,7 +34214,8 @@
                 "policy_rule_delete",
                 "policy_rule_update",
                 "quorum_update",
-                "wallet_action"
+                "wallet_action",
+                "provider-action"
               ]
             }
           },
@@ -33991,7 +34326,8 @@
                                   "policy_rule_delete",
                                   "policy_rule_update",
                                   "quorum_update",
-                                  "wallet_action"
+                                  "wallet_action",
+                                  "provider-action"
                                 ]
                               },
                               "intent_type": {
@@ -34005,7 +34341,8 @@
                                   "policy_rule_delete",
                                   "policy_rule_update",
                                   "quorum_update",
-                                  "wallet_action"
+                                  "wallet_action",
+                                  "provider-action"
                                 ]
                               },
                               "status": {
@@ -34314,7 +34651,8 @@
                       "policy_rule_delete",
                       "policy_rule_update",
                       "quorum_update",
-                      "wallet_action"
+                      "wallet_action",
+                      "provider-action"
                     ]
                   },
                   "intent_type": {
@@ -34328,7 +34666,8 @@
                       "policy_rule_delete",
                       "policy_rule_update",
                       "quorum_update",
-                      "wallet_action"
+                      "wallet_action",
+                      "provider-action"
                     ]
                   },
                   "agentId": {
@@ -34497,7 +34836,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "intent_type": {
@@ -34511,7 +34851,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "status": {
@@ -34959,7 +35300,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "intent_type": {
@@ -34973,7 +35315,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "status": {
@@ -35350,7 +35693,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "intent_type": {
@@ -35364,7 +35708,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "status": {
@@ -35837,7 +36182,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "intent_type": {
@@ -35851,7 +36197,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "status": {
@@ -36323,7 +36670,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "intent_type": {
@@ -36337,7 +36685,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "status": {
@@ -36809,7 +37158,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "intent_type": {
@@ -36823,7 +37173,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "status": {
@@ -37295,7 +37646,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "intent_type": {
@@ -37309,7 +37661,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "status": {
@@ -37781,7 +38134,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "intent_type": {
@@ -37795,7 +38149,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "status": {
@@ -38267,7 +38622,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "intent_type": {
@@ -38281,7 +38637,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "status": {
@@ -38692,7 +39049,8 @@
                 "policy_rule_delete",
                 "policy_rule_update",
                 "quorum_update",
-                "wallet_action"
+                "wallet_action",
+                "provider-action"
               ]
             }
           },
@@ -38711,7 +39069,8 @@
                 "policy_rule_delete",
                 "policy_rule_update",
                 "quorum_update",
-                "wallet_action"
+                "wallet_action",
+                "provider-action"
               ]
             }
           },
@@ -38730,7 +39089,8 @@
                 "policy_rule_delete",
                 "policy_rule_update",
                 "quorum_update",
-                "wallet_action"
+                "wallet_action",
+                "provider-action"
               ]
             }
           },
@@ -38841,7 +39201,8 @@
                                   "policy_rule_delete",
                                   "policy_rule_update",
                                   "quorum_update",
-                                  "wallet_action"
+                                  "wallet_action",
+                                  "provider-action"
                                 ]
                               },
                               "intent_type": {
@@ -38855,7 +39216,8 @@
                                   "policy_rule_delete",
                                   "policy_rule_update",
                                   "quorum_update",
-                                  "wallet_action"
+                                  "wallet_action",
+                                  "provider-action"
                                 ]
                               },
                               "status": {
@@ -39164,7 +39526,8 @@
                       "policy_rule_delete",
                       "policy_rule_update",
                       "quorum_update",
-                      "wallet_action"
+                      "wallet_action",
+                      "provider-action"
                     ]
                   },
                   "intent_type": {
@@ -39178,7 +39541,8 @@
                       "policy_rule_delete",
                       "policy_rule_update",
                       "quorum_update",
-                      "wallet_action"
+                      "wallet_action",
+                      "provider-action"
                     ]
                   },
                   "agentId": {
@@ -39347,7 +39711,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "intent_type": {
@@ -39361,7 +39726,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "status": {
@@ -39714,7 +40080,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "intent_type": {
@@ -39728,7 +40095,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "status": {
@@ -40105,7 +40473,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "intent_type": {
@@ -40119,7 +40488,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "status": {
@@ -40497,7 +40867,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "intent_type": {
@@ -40511,7 +40882,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "status": {
@@ -40888,7 +41260,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "intent_type": {
@@ -40902,7 +41275,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "status": {
@@ -41279,7 +41653,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "intent_type": {
@@ -41293,7 +41668,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "status": {
@@ -41670,7 +42046,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "intent_type": {
@@ -41684,7 +42061,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "status": {
@@ -42061,7 +42439,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "intent_type": {
@@ -42075,7 +42454,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "status": {
@@ -42452,7 +42832,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "intent_type": {
@@ -42466,7 +42847,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "status": {

--- a/packages/api/src/__tests__/openapi-contract.test.ts
+++ b/packages/api/src/__tests__/openapi-contract.test.ts
@@ -914,6 +914,15 @@ describe("generated OpenAPI contract", () => {
     expect(paths["/v2/provider-grants"]).toHaveProperty("post");
     expect(paths["/v2/provider-grants/{id}/revoke"]).toHaveProperty("post");
     expect(paths["/v2/provider-access/check"]).toHaveProperty("post");
+    expect(paths["/v2/provider-actions/{id}"]).toHaveProperty("get");
+
+    const status = paths["/v2/provider-actions/{id}"].get;
+    expect(status.security).toEqual([{ bearerAuth: [] }]);
+    expect(status.description).toContain("cross-agent");
+    expect(status.description).toContain("human/MFA-gated");
+    const responseIntent =
+      status.responses["200"].content["application/json"].schema.properties.data;
+    expect(responseIntent.properties.intentType.enum).toContain("provider-action");
   });
 
   it("serves the generated contract at /openapi.json", async () => {

--- a/packages/api/src/__tests__/provider-actions-route.test.ts
+++ b/packages/api/src/__tests__/provider-actions-route.test.ts
@@ -10,10 +10,12 @@
 
 import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { createServer, type Server } from "node:http";
+import { generateApiKey } from "@stwd/auth";
 import {
   agents,
   closeDb,
   getDb,
+  intents,
   providerAccounts,
   providerGrants,
   providerOperations,
@@ -22,6 +24,7 @@ import {
   workspaces,
 } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { eq } from "drizzle-orm";
 import { type Hono } from "hono";
 import { exportJWK, generateKeyPair, type KeyLike, SignJWT } from "jose";
 import type { AppVariables } from "../services/context";
@@ -29,24 +32,30 @@ import type { AppVariables } from "../services/context";
 setDefaultTimeout(120_000);
 
 const TENANT = "tenant-main";
+const TENANT_OTHER = "tenant-other";
 const AGENT = "agent-x";
+const AGENT_OTHER = "agent-y";
+const AGENT_OTHER_TENANT = "agent-z";
 const WORKSPACE_A = "20000000-0000-4000-8000-000000000001";
 const ACCOUNT_A = "30000000-0000-4000-8000-000000000001";
 const OP_A_READ = "40000000-0000-4000-8000-000000000001";
 const GRANTOR = "10000000-0000-4000-8000-000000000001";
 const FUTURE = new Date(Date.now() + 365 * 24 * 3600_000);
 const KID = "test-kid-1";
+const TENANT_KEY = generateApiKey();
+const CREDENTIAL_CANARY = "credential-canary-issue-233-7e132";
 
 let app: Hono<{ Variables: AppVariables }>;
 let jwksServer: Server;
 let privateKey: KeyLike;
+let statusIntentId = "";
 
-async function signAgentToken(scopes: string[]): Promise<string> {
-  return new SignJWT({ agent_id: AGENT, scopes })
+async function signAgentToken(scopes: string[], agentId = AGENT): Promise<string> {
+  return new SignJWT({ agent_id: agentId, scopes })
     .setProtectedHeader({ alg: "RS256", kid: KID })
     .setIssuer("eliza-cloud")
     .setAudience("steward")
-    .setSubject(`agent:${AGENT}`)
+    .setSubject(`agent:${agentId}`)
     .setIssuedAt()
     .setExpirationTime("10m")
     .sign(privateKey);
@@ -54,11 +63,21 @@ async function signAgentToken(scopes: string[]): Promise<string> {
 
 async function seed() {
   const db = getDb();
-  await db.insert(tenants).values([{ id: TENANT, name: "Main", apiKeyHash: "h" }]);
+  await db.insert(tenants).values([
+    { id: TENANT, name: "Main", apiKeyHash: TENANT_KEY.hash },
+    { id: TENANT_OTHER, name: "Other", apiKeyHash: "other-hash" },
+  ]);
   await db.insert(users).values([{ id: GRANTOR, email: "g@t.test" }]);
-  await db
-    .insert(agents)
-    .values([{ id: AGENT, tenantId: TENANT, name: "X", walletAddress: "0x1" }]);
+  await db.insert(agents).values([
+    { id: AGENT, tenantId: TENANT, name: "X", walletAddress: "0x1" },
+    { id: AGENT_OTHER, tenantId: TENANT, name: "Y", walletAddress: "0x2" },
+    {
+      id: AGENT_OTHER_TENANT,
+      tenantId: TENANT_OTHER,
+      name: "Z",
+      walletAddress: "0x3",
+    },
+  ]);
   await db.insert(workspaces).values([
     {
       id: WORKSPACE_A,
@@ -112,13 +131,18 @@ async function seed() {
   });
 }
 
-async function post(token: string, body: string, contentType = "application/json") {
+async function post(
+  token: string,
+  body: string,
+  contentType = "application/json",
+  tenantId = TENANT,
+) {
   return app.request("/v2/provider-actions", {
     method: "POST",
     headers: {
       "content-type": contentType,
       authorization: `Bearer ${token}`,
-      "X-Steward-Tenant": TENANT,
+      "X-Steward-Tenant": tenantId,
     },
     body,
   });
@@ -152,6 +176,44 @@ describe("POST /v2/provider-actions (route)", () => {
     // the Phase-1 middleware-only app, so all `/v2` routes are mounted.
     const mod = await import("../app");
     app = mod.app as Hono<{ Variables: AppVariables }>;
+
+    // Create one real provider action through the mounted HTTP route. The status
+    // tests below then exercise the exact persisted binding + intent rows.
+    const token = await signAgentToken([]);
+    const created = await post(
+      token,
+      JSON.stringify({
+        workspaceId: WORKSPACE_A,
+        providerAccountId: ACCOUNT_A,
+        operationKey: "github.issue.list",
+        arguments: { owner: "octo", repo: "hello" },
+        idempotencyKey: "idem-status-fixture",
+      }),
+    );
+    expect(created.status).toBe(200);
+    statusIntentId = ((await created.json()) as { id: string }).id;
+
+    // Extensible intent JSON must not turn either status route into a secret
+    // read primitive. Include legitimate tokenAddress to prove exact-key
+    // redaction does not erase non-credential fields.
+    await getDb()
+      .update(intents)
+      .set({
+        authorizationDetails: [
+          { authorization: `Bearer ${CREDENTIAL_CANARY}`, tokenAddress: "0xabc" },
+        ],
+        payload: {
+          operationKey: "github.issue.list",
+          refreshToken: CREDENTIAL_CANARY,
+          providerToken: CREDENTIAL_CANARY,
+          tokenAddress: "0xabc",
+        },
+        executionResult: {
+          signedTx: CREDENTIAL_CANARY,
+          nested: { apiKey: CREDENTIAL_CANARY, note: `token=${CREDENTIAL_CANARY}` },
+        },
+      })
+      .where(eq(intents.id, statusIntentId));
   });
 
   afterAll(async () => {
@@ -221,6 +283,94 @@ describe("POST /v2/provider-actions (route)", () => {
       method: "POST",
       headers: { "content-type": "application/json", "X-Steward-Tenant": TENANT },
       body: "{}",
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test("agent reads its own provider action with exact tenant-intent response parity", async () => {
+    const token = await signAgentToken(["some:unrelated:scope"]);
+    const own = await app.request(`/v2/provider-actions/${statusIntentId}`, {
+      headers: { authorization: `Bearer ${token}`, "X-Steward-Tenant": TENANT },
+    });
+    expect(own.status).toBe(200);
+    expect(own.headers.get("cache-control")).toBe("no-store, max-age=0");
+    const ownBody = (await own.json()) as { ok: boolean; data: Record<string, unknown> };
+
+    const tenant = await app.request(`/intents/${statusIntentId}`, {
+      headers: { "X-Steward-Tenant": TENANT, "X-Steward-Key": TENANT_KEY.key },
+    });
+    expect(tenant.status).toBe(200);
+    const tenantBody = (await tenant.json()) as { ok: boolean; data: Record<string, unknown> };
+
+    expect(ownBody).toEqual(tenantBody);
+    expect(ownBody.data.intentType).toBe("provider-action");
+    expect(ownBody.data.agentId).toBe(AGENT);
+  });
+
+  test("redacts credential canaries without redacting legitimate token metadata", async () => {
+    const token = await signAgentToken([]);
+    const res = await app.request(`/v2/provider-actions/${statusIntentId}`, {
+      headers: { authorization: `Bearer ${token}`, "X-Steward-Tenant": TENANT },
+    });
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).not.toContain(CREDENTIAL_CANARY);
+    expect(text).toContain("[redacted]");
+    expect(text).toContain('"tokenAddress":"0xabc"');
+  });
+
+  test("returns the same uniform 404 for foreign agent, foreign tenant, absent, and malformed ids", async () => {
+    const cases = [
+      {
+        token: await signAgentToken([], AGENT_OTHER),
+        tenantId: TENANT,
+        id: statusIntentId,
+      },
+      {
+        token: await signAgentToken([], AGENT_OTHER_TENANT),
+        tenantId: TENANT_OTHER,
+        id: statusIntentId,
+      },
+      {
+        token: await signAgentToken([]),
+        tenantId: TENANT,
+        id: "pa_00000000-0000-4000-8000-000000000000",
+      },
+      { token: await signAgentToken([]), tenantId: TENANT, id: "not-an-action" },
+    ];
+
+    const responses: Array<{ status: number; body: unknown }> = [];
+    for (const item of cases) {
+      const res = await app.request(`/v2/provider-actions/${item.id}`, {
+        headers: {
+          authorization: `Bearer ${item.token}`,
+          "X-Steward-Tenant": item.tenantId,
+        },
+      });
+      responses.push({ status: res.status, body: await res.json() });
+    }
+
+    expect(responses).toEqual(
+      cases.map(() => ({
+        status: 404,
+        body: { ok: false, error: "PROVIDER_ACTION_NOT_FOUND" },
+      })),
+    );
+  });
+
+  test("exact status route does not weaken approval/case/evidence human-MFA gates", async () => {
+    const token = await signAgentToken([]);
+    for (const suffix of ["approval", "case", "evidence"]) {
+      const res = await app.request(`/v2/provider-actions/${statusIntentId}/${suffix}`, {
+        headers: { authorization: `Bearer ${token}`, "X-Steward-Tenant": TENANT },
+      });
+      expect(res.status).toBe(403);
+    }
+  });
+
+  test("status route requires an agent JWT", async () => {
+    const res = await app.request(`/v2/provider-actions/${statusIntentId}`, {
+      headers: { "X-Steward-Tenant": TENANT },
     });
     expect(res.status).toBe(401);
   });

--- a/packages/api/src/openapi.ts
+++ b/packages/api/src/openapi.ts
@@ -60,6 +60,7 @@ const intentTypeSchema: JsonSchema = {
     "policy_rule_update",
     "quorum_update",
     "wallet_action",
+    "provider-action",
   ],
 };
 const intentSchema: JsonSchema = {
@@ -297,6 +298,28 @@ function providerAuthorityPaths(): Record<string, OpenApiPathItem> {
           content: { "application/json": { schema: metadataSchema } },
         },
         responses: { "200": jsonResponse(apiResponse(metadataSchema)), ...errorResponses() },
+      },
+    },
+    "/v2/provider-actions/{id}": {
+      parameters: [parameter("id", "path")],
+      get: {
+        tags: ["Provider Authority"],
+        summary: "Get the authenticated agent's own provider-action status",
+        description:
+          "Requires an agent JWT. The action is scoped server-side to the verified tenant and agent; absent, malformed, cross-agent, and cross-tenant ids all return the same 404 response. This route does not grant access to the human/MFA-gated approval, case, or evidence surfaces.",
+        security: [{ bearerAuth: [] }],
+        parameters: [
+          headerParameter(
+            "X-Steward-Tenant",
+            "Tenant containing the authenticated agent. It is checked against the verified agent principal and never selects a foreign action.",
+          ),
+        ],
+        responses: {
+          "200": jsonResponse(apiResponse(intentSchema)),
+          "401": jsonResponse(errorResponse()),
+          "403": jsonResponse(errorResponse()),
+          "404": jsonResponse(errorResponse()),
+        },
       },
     },
   };

--- a/packages/api/src/routes/intents.ts
+++ b/packages/api/src/routes/intents.ts
@@ -31,6 +31,7 @@ import {
   transactions,
   vault,
 } from "../services/context";
+import { redactIntentResponseValue, toIntentResponse } from "../services/intent-response";
 import { getPolicyRulesValidationError } from "../services/policy-validation";
 import { dispatchWebhook } from "../services/webhook-dispatch";
 
@@ -1032,75 +1033,6 @@ async function assertIntentAuthorizationBaselineCurrent(row: typeof intents.$inf
   }
 }
 
-function toIntentResponse(row: typeof intents.$inferSelect) {
-  return {
-    id: row.id,
-    intent_id: row.id,
-    tenantId: row.tenantId,
-    agentId: row.agentId,
-    wallet_id: row.agentId,
-    intentType: row.intentType,
-    intent_type: row.intentType,
-    status: row.status,
-    resourceType: row.resourceType,
-    resource_id: row.resourceId,
-    resourceId: row.resourceId,
-    createdByType: row.createdByType,
-    created_by_id: row.createdById,
-    createdById: row.createdById,
-    created_by_display_name: row.createdByDisplayName,
-    createdByDisplayName: row.createdByDisplayName,
-    authorizationDetails: row.authorizationDetails,
-    authorization_details: row.authorizationDetails,
-    payload: row.payload,
-    executionResult: redactSignedTransactions(row.executionResult),
-    execution_result: redactSignedTransactions(row.executionResult),
-    expiresAt: row.expiresAt,
-    expires_at: row.expiresAt?.getTime() ?? null,
-    authorizedBy: row.authorizedBy,
-    authorized_by: row.authorizedBy,
-    canceledAt: row.canceledAt,
-    canceledBy: row.canceledBy,
-    canceled_by: row.canceledBy,
-    cancellationReason: row.cancellationReason,
-    cancellation_reason: row.cancellationReason,
-    expiredAt: row.expiredAt,
-    expiredBy: row.expiredBy,
-    expired_by: row.expiredBy,
-    rejectedAt: row.rejectedAt,
-    rejectedBy: row.rejectedBy,
-    rejected_by: row.rejectedBy,
-    rejectionReason: row.rejectionReason,
-    rejection_reason: row.rejectionReason,
-    executedBy: row.executedBy,
-    executed_by: row.executedBy,
-    failedAt: row.failedAt,
-    failedBy: row.failedBy,
-    failed_by: row.failedBy,
-    failureReason: row.failureReason,
-    failure_reason: row.failureReason,
-    createdAt: row.createdAt,
-    created_at: row.createdAt.getTime(),
-    updatedAt: row.updatedAt,
-    authorizedAt: row.authorizedAt,
-    executedAt: row.executedAt,
-  };
-}
-
-function redactSignedTransactions(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(redactSignedTransactions);
-  if (!value || typeof value !== "object") return value;
-  const redacted: Record<string, unknown> = {};
-  for (const [key, nested] of Object.entries(value)) {
-    if (key === "signedTx" || key === "signed_tx") {
-      redacted[key] = "[redacted]";
-    } else {
-      redacted[key] = redactSignedTransactions(nested);
-    }
-  }
-  return redacted;
-}
-
 async function writeIntentAudit(
   c: Context<{ Variables: AppVariables }>,
   action: string,
@@ -1142,7 +1074,7 @@ function dispatchIntentWebhook(
     status: row.status,
     resource_id: row.resourceId,
     authorization_details: row.authorizationDetails,
-    execution_result: redactSignedTransactions(row.executionResult),
+    execution_result: redactIntentResponseValue(row.executionResult),
     rejection_reason: row.rejectionReason,
     cancellation_reason: row.cancellationReason,
     failure_reason: row.failureReason,
@@ -1167,7 +1099,7 @@ function dispatchWalletActionSuccessWebhook(
     dispatchWebhook(tenantId, agentId, "wallet_action.send_calls.succeeded", {
       actionId: executionResult.actionId,
       intent_id: executionResult.actionId,
-      signedCalls: redactSignedTransactions(executionResult.signedCalls),
+      signedCalls: redactIntentResponseValue(executionResult.signedCalls),
     });
   }
 }
@@ -1931,7 +1863,7 @@ async function updateIntentStatus(
       return c.json<ApiResponse>({ ok: false, error: failureReason }, 400);
     }
 
-    const storedExecutionResult = redactSignedTransactions(executionResult) as Record<
+    const storedExecutionResult = redactIntentResponseValue(executionResult) as Record<
       string,
       unknown
     >;

--- a/packages/api/src/routes/provider-actions.ts
+++ b/packages/api/src/routes/provider-actions.ts
@@ -16,14 +16,17 @@
  */
 
 import { createHash, randomBytes } from "node:crypto";
+import { getDb, intents, providerActionBindings } from "@stwd/db";
 import { buildGithubAction, isGithubOperationKey } from "@stwd/provider-github";
 import { buildXAction, isXOperationKey } from "@stwd/provider-x";
 import { CanonError, decodeUtf8Strict, isCanonError, strictParseJson } from "@stwd/shared";
+import { and, eq } from "drizzle-orm";
 import type { Context } from "hono";
 import { Hono } from "hono";
 import { requireProviderAgentJwt } from "../middleware/agent-jwt";
 import { resolveProviderPrincipal } from "../middleware/provider-principal";
 import { type ApiResponse, type AppVariables, setNoStoreHeaders } from "../services/context";
+import { toIntentResponse } from "../services/intent-response";
 import {
   type ProviderActionOutcome,
   providerActionService,
@@ -56,6 +59,16 @@ export function registerProviderActionRoutes(app: Hono<{ Variables: AppVariables
   });
   app.use("/v2/provider-actions", requireProviderAgentJwt);
   app.post("/v2/provider-actions", handleCreateProviderAction);
+
+  // #233: a read-only status view for the authenticated agent's own actions.
+  // Keep this path exact (no wildcard suffix) so the sibling approval, execute,
+  // case, and evidence routes retain their distinct human/MFA gates.
+  app.use("/v2/provider-actions/:id", async (c, next) => {
+    setNoStoreHeaders(c);
+    await next();
+  });
+  app.use("/v2/provider-actions/:id", requireProviderAgentJwt);
+  app.get("/v2/provider-actions/:id", handleGetProviderActionStatus);
 }
 
 const MAX_REQUEST_BYTES = 256 * 1024; // 256 KiB bound
@@ -73,6 +86,44 @@ const TOP_LEVEL_KEYS = new Set([
 
 function deny(c: RouteContext, code: string, status: number) {
   return c.json<ApiResponse>({ ok: false, error: code }, status as never);
+}
+
+function providerActionNotFound(c: RouteContext) {
+  return c.json<ApiResponse>({ ok: false, error: "PROVIDER_ACTION_NOT_FOUND" }, 404);
+}
+
+async function handleGetProviderActionStatus(c: RouteContext) {
+  const principal = resolveProviderPrincipal(c);
+  const intentId = c.req.param("id") ?? "";
+
+  // Provider action ids are currently `pa_` + UUID. Treat malformed ids exactly
+  // like absent/foreign ids so this read surface is non-enumerating.
+  if (!/^pa_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(intentId)) {
+    return providerActionNotFound(c);
+  }
+
+  const [owned] = await getDb()
+    .select({ intent: intents })
+    .from(providerActionBindings)
+    .innerJoin(
+      intents,
+      and(
+        eq(intents.id, providerActionBindings.intentId),
+        eq(intents.tenantId, providerActionBindings.tenantId),
+      ),
+    )
+    .where(
+      and(
+        eq(providerActionBindings.intentId, intentId),
+        eq(providerActionBindings.tenantId, principal.tenantId),
+        eq(providerActionBindings.actorAgentId, principal.agentId),
+        eq(intents.intentType, "provider-action"),
+      ),
+    )
+    .limit(1);
+
+  if (!owned) return providerActionNotFound(c);
+  return c.json<ApiResponse>({ ok: true, data: toIntentResponse(owned.intent) });
 }
 
 function outcomeToResponse(c: RouteContext, outcome: ProviderActionOutcome) {
@@ -254,6 +305,7 @@ async function handleCreateProviderAction(c: RouteContext) {
 // Also register on the standalone sub-app so it can be unit-tested in isolation
 // (and remains a valid mount target if the router behavior changes).
 providerActionRoutes.post("/provider-actions", handleCreateProviderAction);
+providerActionRoutes.get("/provider-actions/:id", handleGetProviderActionStatus);
 
 /** RFC 3339 UTC with exactly three fractional digits and trailing Z. */
 function toRfc3339Millis(d: Date): string {

--- a/packages/api/src/services/intent-response.ts
+++ b/packages/api/src/services/intent-response.ts
@@ -1,0 +1,95 @@
+import { intents } from "@stwd/db";
+
+const SENSITIVE_INTENT_KEY =
+  /(?:authorization|cookie|token|secret|credential|api[-_]?key|private[-_]?key|signed[-_]?tx)$/i;
+const SECRET_TEXT =
+  /(?:bearer\s+|(?:api[-_]?key|access[-_]?token|refresh[-_]?token|token|secret|credential|private[-_]?key)["'\s:=]+)[^\s,"'}]+/gi;
+
+/**
+ * Recursively remove credential-shaped material from generic intent fields.
+ *
+ * Intent payloads and execution results are intentionally extensible JSON. A
+ * new producer must not be able to accidentally turn GET /intents/:id (or the
+ * agent-scoped provider-action status view) into a credential-read endpoint.
+ * Credential key names (including producer-prefixed names such as
+ * `githubAccessToken`) are redacted while legitimate fields such as
+ * `tokenAddress` remain intact. String values also have common bearer/secret
+ * assignments scrubbed as a defense in depth.
+ */
+export function redactIntentResponseValue(value: unknown, depth = 0): unknown {
+  if (depth > 20) return "[redacted]";
+  if (typeof value === "string") return value.replace(SECRET_TEXT, "[redacted]");
+  if (Array.isArray(value)) {
+    return value.map((item) => redactIntentResponseValue(item, depth + 1));
+  }
+  if (value && typeof value === "object") {
+    const redacted: Record<string, unknown> = {};
+    for (const [key, nested] of Object.entries(value)) {
+      redacted[key] = SENSITIVE_INTENT_KEY.test(key)
+        ? "[redacted]"
+        : redactIntentResponseValue(nested, depth + 1);
+    }
+    return redacted;
+  }
+  return value;
+}
+
+/** The canonical public intent response shared by every intent status route. */
+export function toIntentResponse(row: typeof intents.$inferSelect) {
+  const authorizationDetails = redactIntentResponseValue(row.authorizationDetails);
+  const payload = redactIntentResponseValue(row.payload);
+  const executionResult = redactIntentResponseValue(row.executionResult);
+
+  return {
+    id: row.id,
+    intent_id: row.id,
+    tenantId: row.tenantId,
+    agentId: row.agentId,
+    wallet_id: row.agentId,
+    intentType: row.intentType,
+    intent_type: row.intentType,
+    status: row.status,
+    resourceType: row.resourceType,
+    resource_id: row.resourceId,
+    resourceId: row.resourceId,
+    createdByType: row.createdByType,
+    created_by_id: row.createdById,
+    createdById: row.createdById,
+    created_by_display_name: row.createdByDisplayName,
+    createdByDisplayName: row.createdByDisplayName,
+    authorizationDetails,
+    authorization_details: authorizationDetails,
+    payload,
+    executionResult,
+    execution_result: executionResult,
+    expiresAt: row.expiresAt,
+    expires_at: row.expiresAt?.getTime() ?? null,
+    authorizedBy: row.authorizedBy,
+    authorized_by: row.authorizedBy,
+    canceledAt: row.canceledAt,
+    canceledBy: row.canceledBy,
+    canceled_by: row.canceledBy,
+    cancellationReason: row.cancellationReason,
+    cancellation_reason: row.cancellationReason,
+    expiredAt: row.expiredAt,
+    expiredBy: row.expiredBy,
+    expired_by: row.expiredBy,
+    rejectedAt: row.rejectedAt,
+    rejectedBy: row.rejectedBy,
+    rejected_by: row.rejectedBy,
+    rejectionReason: row.rejectionReason,
+    rejection_reason: row.rejectionReason,
+    executedBy: row.executedBy,
+    executed_by: row.executedBy,
+    failedAt: row.failedAt,
+    failedBy: row.failedBy,
+    failed_by: row.failedBy,
+    failureReason: row.failureReason,
+    failure_reason: row.failureReason,
+    createdAt: row.createdAt,
+    created_at: row.createdAt.getTime(),
+    updatedAt: row.updatedAt,
+    authorizedAt: row.authorizedAt,
+    executedAt: row.executedAt,
+  };
+}

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -102,7 +102,7 @@ structured content; Steward API errors surface their HTTP status and any policy
 | Tool | Kind | SDK method | Description |
 | --- | --- | --- | --- |
 | `provider_action_invoke` | write (destructive) | `POST /v2/provider-actions` | Submit an action for provider authorization and policy evaluation. |
-| `provider_action_status` | read | `GET /intents/:id` | Fetch current action intent status through the API's existing status route. |
+| `provider_action_status` | read | `GET /v2/provider-actions/:id` | Fetch the authenticated agent's own action intent status. Foreign and absent actions return the same not-found response. |
 | `provider_action_approval` | read | `GET /v2/provider-actions/:id/approval` | Fetch approval state. The API requires an eligible human session and recent MFA. |
 | `provider_action_case` | read | `GET /v2/provider-actions/:id/case` | Fetch the correlated case manifest. |
 | `provider_action_evidence` | read | `GET /v2/provider-actions/:id/evidence` | Fetch the correlated signed evidence bundle. |
@@ -126,14 +126,12 @@ provider credential, URL, or host arguments. Approval, case, and evidence reads
 retain the API's human-session, MFA, role, workspace, and tenant gates. In
 particular, an agent JWT cannot use MCP to impersonate a human approver.
 
-The current API intentionally has split auth modes. Invocation requires an agent
-JWT. The existing status route (`GET /intents/:id`) requires a tenant API key or
-owner/admin session. Approval, case, and evidence reads require eligible human
-sessions and recent MFA, with case and evidence further limited to owner/admin.
-A single agent-JWT MCP process can invoke but receives honest authorization
-errors from those human or tenant-level read routes. No agent-readable v2 status
-route exists on the current API, and this package does not invent one or weaken
-the API gates.
+Invocation and the agent-scoped status route both accept an agent JWT. Status is
+bound server-side to the verified tenant and agent, so a process can poll only
+actions that same agent submitted. Approval, case, and evidence reads continue
+to require eligible human sessions and recent MFA, with case and evidence
+further limited to owner/admin. The agent-readable route does not weaken or
+stand in for any of those human gates.
 
 These tools **do not implement MCP OAuth 2.1 resource-server semantics**. That
 separate authorization-layer work is tracked by issue #219.

--- a/packages/mcp/src/__tests__/provider-tools.test.ts
+++ b/packages/mcp/src/__tests__/provider-tools.test.ts
@@ -76,7 +76,7 @@ describe("governed provider action tools", () => {
 
   test("uses only fixed status, approval, case, and evidence routes", async () => {
     const routes = {
-      [`/intents/${ACTION_ID}`]: { status: "authorized" },
+      [`/v2/provider-actions/${ACTION_ID}`]: { status: "authorized" },
       [`/v2/provider-actions/${ACTION_ID}/approval`]: { status: "pending" },
       [`/v2/provider-actions/${ACTION_ID}/case`]: { kind: "case" },
       [`/v2/provider-actions/${ACTION_ID}/evidence`]: { kind: "evidence" },
@@ -87,6 +87,26 @@ describe("governed provider action tools", () => {
       expect(result.isError).toBeUndefined();
     }
     expect(calls.map((call) => call.path)).toEqual(Object.keys(routes));
+  });
+
+  test("status uses the agent-scoped route and preserves the redacted intent contract", async () => {
+    const status = {
+      ok: true,
+      data: {
+        id: ACTION_ID,
+        intentType: "provider-action",
+        status: "pending",
+        payload: { operationKey: "github.pr.comment.create" },
+      },
+    };
+    const path = `/v2/provider-actions/${ACTION_ID}`;
+    const { tools, calls } = harness({ [path]: status });
+
+    const result = await tools.get("provider_action_status")!.handler({ actionId: ACTION_ID });
+
+    expect(result.isError).toBeUndefined();
+    expect(result.structuredContent).toEqual(status);
+    expect(calls).toEqual([{ path, init: undefined }]);
   });
 
   test("rejects tenant, workspace substitution, host injection, and unknown keys", async () => {

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -256,11 +256,11 @@ export function buildTools(ctx: ToolContext): StewardTool[] {
     defineTool(ctx, {
       name: "provider_action_status",
       description:
-        "Fetch the current provider-action intent from the existing GET /intents/:intentId route. This real API route requires tenant-level credentials and rejects agent JWTs; MCP preserves that gate.",
+        "Fetch the current provider-action intent through the agent-scoped GET /v2/provider-actions/:id route. The API only returns actions submitted by the authenticated agent and uses a uniform not-found response for foreign actions.",
       schema: z.object({ actionId: providerCaseId }).strict(),
       readOnly: true,
       run: ({ actionId }) =>
-        requireProviderApi(ctx).request(`/intents/${encodeURIComponent(actionId)}`),
+        requireProviderApi(ctx).request(`/v2/provider-actions/${encodeURIComponent(actionId)}`),
     }),
     defineTool(ctx, {
       name: "provider_action_approval",


### PR DESCRIPTION
## Summary

- add exact agent-JWT `GET /v2/provider-actions/:id` status route
- bind reads to the persisted provider-action tenant and submitting agent
- return one uniform 404 for malformed, absent, cross-agent, and cross-tenant ids
- share the canonical redacted intent serializer with `GET /intents/:id`
- repoint MCP status and document the least-privilege boundary
- retain separate human-session and MFA gates on approval, case, and evidence routes

## Security validation

- response parity test against `GET /intents/:id`
- credential canaries across authorization details, payload, and execution result
- legitimate `tokenAddress` metadata remains visible
- mutation-style same-tenant foreign-agent and cross-tenant denial proofs
- exact suffix-route canary proves agent JWT still receives 403 on approval, case, and evidence
- missing agent JWT receives 401

## Verification

- `bunx turbo run build --filter=@stwd/api --filter=@stwd/mcp` (22/22 tasks)
- `bun test packages/api/src/__tests__/provider-actions-route.test.ts` (10 pass)
- `bun test packages/mcp/src/__tests__/provider-tools.test.ts packages/mcp/src/__tests__/tools.test.ts` (36 pass)
- `bun test --timeout 15000 packages/api/src/__tests__/openapi-contract.test.ts` (8 pass)
- Biome check on every touched TypeScript source (clean)
- `git diff --check` (clean)

Closes #233
