### PR TITLE
feat(vault): add AWS KMS external custody signer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,15 @@ STEWARD_MASTER_PASSWORD=
 # See docs/security/custody-posture.md for the full threat model.
 # STEWARD_ACK_LOCAL_CUSTODY=true
 
+# Optional external signing custody. This is deliberately DISTINCT from
+# STEWARD_KMS_PROVIDER=aws, which is envelope encryption and still decrypts
+# wallet private keys in the Steward process. `aws-kms` stores only an opaque
+# asymmetric key handle in Steward and asks an ECC_SECG_P256K1 SIGN_VERIFY KMS
+# key to sign EVM transaction digests. The private key never enters Steward.
+# See docs/security/external-custody.md.
+# STEWARD_EXTERNAL_CUSTODY_PROVIDER=aws-kms
+# STEWARD_EXTERNAL_CUSTODY_AWS_REGION=us-east-1
+
 # [REQUIRED in production] Canonical JWT signing/verification secret used by
 # the API, proxy, auth routes, user sessions, and agent-scoped tokens. Must be
 # at least 32 characters in production. Existing deployments using

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -60,7 +60,7 @@ Configured provider calls and wallet actions then enter Steward through authenti
 - **Credential proxy:** configured provider requests receive credentials server-side without returning them to the supported agent caller.
 - **Audit evidence:** HMAC chaining, Ed25519 checkpoints, bundle export, and offline verification, with a separate out-of-band check of the bundled public key.
 - **Self-hosting:** Docker with PostgreSQL and Redis, or embedded PGLite for local and desktop use.
-- **Custody choices:** local encrypted storage, AWS KMS envelope wrapping, a PKCS#11 wrapping adapter, and an external custody interface. Steward does not claim MPC or native HSM signing.
+- **Custody choices:** local encrypted storage, AWS KMS envelope wrapping, a PKCS#11 wrapping adapter, a versioned external-custody interface, and an EVM-only AWS KMS asymmetric signing reference provider. Steward does not claim MPC or threshold signing.
 
 ## Direction
 

--- a/docs/security/custody-posture.md
+++ b/docs/security/custody-posture.md
@@ -72,7 +72,8 @@ that.
 | **local** | (default; no `STEWARD_KMS_PROVIDER`) | **Yes**, effectively — key is AES-256-GCM ciphertext, but the unwrap material (`STEWARD_MASTER_PASSWORD` + `STEWARD_KDF_SALT`) is also on the same host/env, so a host compromise recovers keys offline | **Yes** | none | at-rest confidentiality vs. a **stolen DB backup alone** (no env/secrets) | host compromise, memory scrape, malicious dependency, master-password disclosure |
 | **kms-envelope:aws** | `STEWARD_KMS_PROVIDER=aws` + `STEWARD_KMS_KEY_ID`/`STEWARD_AWS_KMS_KEY_ARN` | **No** — each key is wrapped by a per-record data key that only AWS KMS can unwrap; a stolen DB is inert without live KMS access | **Yes** | data-key wrap/unwrap happens in AWS KMS; the KMS master key never leaves KMS | offline DB compromise, offline master-password compromise (data key needs live KMS `Decrypt`), KMS-side audit + revocation | **memory scrape at sign time** (key is AES-decrypted in-process after the data key is unwrapped), a compromised Steward process with live KMS creds |
 | **kms-envelope:pkcs11** | `STEWARD_KMS_PROVIDER=pkcs11` + `STEWARD_PKCS11_MODULE`/`_PIN`/`_KEY_LABEL` (+ operator-supplied `Pkcs11ClientLike`) | **No** — data key is wrapped/unwrapped by the HSM via `C_WrapKey`/`C_UnwrapKey`; stolen DB is inert without the HSM | **Yes** | data-key wrap/unwrap happens inside the HSM; the wrapping key never leaves the HSM | offline DB compromise, offline master-password compromise, HSM-side access control + tamper resistance for the **wrapping** key | **memory scrape at sign time** (private key is AES-decrypted in-process), a compromised Steward process with live HSM session |
-| **external custody** | `VaultConfig.externalKeyCustodyProvider` (code-wired; not a `STEWARD_KMS_PROVIDER` value) | **No** — Steward never holds private key material; it holds an opaque handle (`ExternalKeyHandleDescriptor`) | **No** | signing happens entirely in the external provider; Steward sends the unsigned tx and receives a signed result | plaintext-at-rest **and** plaintext-at-sign-time in the Steward process; key exfiltration via Steward memory | trust in the external provider itself, the provider's own key handling, network/path to the provider |
+| **external custody: AWS KMS** | `STEWARD_EXTERNAL_CUSTODY_PROVIDER=aws-kms` (separate from `STEWARD_KMS_PROVIDER`) | **No** — Steward stores an opaque asymmetric KMS key handle and public address only | **No** | an `ECC_SECG_P256K1` `SIGN_VERIFY` key signs the EVM transaction digest inside AWS KMS | plaintext-at-rest **and** plaintext-at-sign-time in Steward; database-only key recovery | trust in AWS KMS/IAM and the live Steward process's authority to request signatures; EVM transactions only |
+| **external custody: custom v1 provider** | `VaultConfig.externalKeyCustodyProvider` | Provider-defined, but v1 forbids private material in the contract and private-key export | Provider-defined | operator implementation | depends on provider | provider and transport trust; must pass the exported v1 conformance suite |
 
 > **Note on `kms-envelope:pkcs11` in this release:** the built-in PKCS#11 path
 > requires an operator-supplied `Pkcs11ClientLike` adapter for `C_WrapKey` /
@@ -101,9 +102,10 @@ Pick the weakest mode whose residual risk you can accept, then harden.
 - **Your threat model includes a compromised Steward process itself** (memory
   scrape, malicious dependency, hostile co-tenant with code exec), i.e. you
   cannot accept plaintext key bytes in Steward's address space **ever**:
-  → **external custody.** This is the only mode that removes
+  → **external custody.** The reference AWS KMS asymmetric signer is the only
+  built-in mode that removes
   plaintext-at-sign-time. It moves trust to the external signer; evaluate that
-  provider on its own terms.
+  provider on its own terms. See `docs/security/external-custody.md`.
 
 Regardless of mode, always set in production:
 
@@ -173,12 +175,13 @@ local_custody_acknowledged=true capabilities=...`.
 
 ## Honest limitations
 
-- **Every built-in mode exposes plaintext at sign time.** KMS-envelope and
+- **Every built-in keystore mode exposes plaintext at sign time.** KMS-envelope and
   PKCS#11 protect the key **at rest**; they do **not** protect it against a
-  compromised Steward process. Only external custody does.
-- **No MPC, no threshold signing, no native HSM signing** is implemented in
-  this repo. The `KeystoreBackend` interface is a plug for operators to bring
-  their own (`packages/vault/src/keystore-backend.ts`); shipping a threshold
+  compromised Steward process. The AWS KMS asymmetric external-custody provider
+  signs EVM transactions without importing the private key into Steward.
+- **No MPC or threshold signing** is implemented in this repo. The
+  `ExternalKeyCustodyProvider` v1 interface is the plug for operators to bring
+  their own; shipping a threshold
   protocol from inside the monorepo would be theater — the security of MPC comes
   from independent operators, an operational concern outside the codebase.
 - **No operator-proof / tamper-evident custody claim.** Audit logs record
@@ -200,7 +203,9 @@ local_custody_acknowledged=true capabilities=...`.
 | AES-256-GCM at-rest keystore + KDF | `packages/vault/src/keystore.ts` |
 | Pluggable backend contract | `packages/vault/src/keystore-backend.ts` |
 | KMS/PKCS#11 envelope (unwrap + in-process AES decrypt) | `packages/vault/src/keystore-kms.ts` |
-| External custody (no plaintext in-process) | `packages/vault/src/external-key-custody.ts` |
+| External custody v1 contract (no private-material fields) | `packages/vault/src/external-key-custody.ts` |
+| AWS KMS asymmetric EVM reference provider | `packages/vault/src/aws-kms-external-custody.ts` |
+| Reusable provider conformance probe | `packages/vault/src/external-key-custody-conformance.ts` |
 | Signing paths that decrypt to plaintext | `packages/vault/src/vault.ts` (`this.keyStore.decrypt`) |
 | Mode resolution + production ack gate | `packages/api/src/services/vault-factory.ts` |
 | Precedent: adapter mock gate | `packages/adapters/src/registry.ts` |

--- a/docs/security/external-custody.md
+++ b/docs/security/external-custody.md
@@ -1,0 +1,125 @@
+# External signing custody v1
+
+Steward's external-custody contract governs a signer without importing its
+private key. Steward stores an opaque provider/key handle and a public EVM
+address. At execution time it prepares a bounded transaction, sends only the
+32-byte transaction digest to the signer, normalizes the returned signature,
+and proves that the signature recovers to the registered address before it can
+be returned or broadcast.
+
+This is different from `STEWARD_KMS_PROVIDER=aws`:
+
+| Configuration | AWS KMS use | Private key in Steward memory at sign time |
+|---|---|---|
+| `STEWARD_KMS_PROVIDER=aws` | Wrap/unwrap a per-record AES data key | **Yes** |
+| `STEWARD_EXTERNAL_CUSTODY_PROVIDER=aws-kms` | Asymmetric secp256k1 signing | **No** |
+
+The modes may coexist. External custody applies only to wallets registered with
+an external handle; local/envelope wallets retain their configured posture.
+
+## AWS prerequisites
+
+Create an asymmetric KMS key with:
+
+- key spec `ECC_SECG_P256K1`;
+- key usage `SIGN_VERIFY`;
+- signing algorithm `ECDSA_SHA_256`;
+- an IAM policy granting only `kms:GetPublicKey` and `kms:Sign` for the exact
+  key ARN. The reference adapter never calls `kms:Decrypt`, `kms:ExportKey`, or
+  key-creation APIs.
+
+Configure the deployment:
+
+```bash
+STEWARD_EXTERNAL_CUSTODY_PROVIDER=aws-kms
+STEWARD_EXTERNAL_CUSTODY_AWS_REGION=us-east-1
+```
+
+`STEWARD_MASTER_PASSWORD` and the normal local-custody acknowledgement still
+apply because a deployment can contain both external and server-managed
+wallets. Selecting an external provider does not silently disable or relabel
+the local keystore.
+
+## Registering an EVM handle
+
+Provisioning code registers the public identity once through the existing
+`Vault.registerExternalKeyHandle` seam:
+
+```ts
+import { AwsKmsExternalKeyCustodyProvider, Vault } from "@stwd/vault";
+
+const vault = new Vault({
+  masterPassword: process.env.STEWARD_MASTER_PASSWORD!,
+  externalKeyCustodyProvider: AwsKmsExternalKeyCustodyProvider.fromEnv(),
+});
+
+await vault.registerExternalKeyHandle({
+  tenantId: "tenant-id",
+  agentId: "agent-id",
+  chainFamily: "evm",
+  address: "0xExpectedAddressDerivedFromTheKmsPublicKey",
+  handle: {
+    providerId: "aws-kms",
+    keyId: "arn:aws:kms:us-east-1:111122223333:key/key-id",
+    region: "us-east-1",
+  },
+  venue: "aws-primary",
+  purpose: "evm-signing",
+});
+```
+
+Registration calls `GetPublicKey`, requires the exact key spec/usage/algorithm,
+derives the Ethereum address from the returned SPKI key, and rejects an address
+mismatch. Steward persists no public-key bytes, signature credentials, or
+private material—only the provider handle and verified address. The same
+binding is repeated immediately before every signature to detect a changed
+alias or handle.
+
+The reference provider supports EVM transaction signing only. Solana, Bitcoin,
+messages, typed data, user operations, and arbitrary hashes fail closed rather
+than being routed through an unreviewed translation.
+
+## Signing and broadcast boundary
+
+For an EVM transaction the provider:
+
+1. validates chain, recipient, value, calldata, gas and nonce inputs;
+2. resolves fees/nonce/gas from the operator-configured RPC;
+3. rechecks that the prepared transaction still matches the semantic request;
+4. hashes the canonical unsigned legacy transaction with Keccak-256;
+5. calls KMS `Sign` with `MessageType=DIGEST` and `ECDSA_SHA_256`;
+6. strictly decodes DER, validates scalar ranges, and normalizes high-s output;
+7. derives `yParity` only by recovering the registered address;
+8. broadcasts only after that recovery succeeds.
+
+A malformed response, wrong key, wrong address, unsupported algorithm, mutated
+RPC preparation, missing RPC, or KMS error fails closed before broadcast.
+
+## Writing another provider
+
+Implement `ExternalKeyCustodyProvider` with
+`contractVersion = EXTERNAL_KEY_CUSTODY_CONTRACT_VERSION`. In the provider's
+own test suite, run the framework-neutral conformance probe:
+
+```ts
+import { runExternalKeyCustodyV1Conformance } from "@stwd/vault";
+
+await runExternalKeyCustodyV1Conformance({
+  createProvider: () => new YourProvider(),
+  validRegistrationRequest: testHandle,
+});
+```
+
+The suite verifies contract versioning, identity binding, non-exportability,
+signing declaration consistency, and direct rejection of nested private-key
+material. Passing it does not certify a provider's HSM, IAM, availability, or
+transport. Those remain operator responsibilities.
+
+## Precise posture
+
+The AWS KMS private key never leaves KMS unencrypted and never enters Steward
+memory. This does **not** make signing operator-proof: a compromised Steward
+process with valid `kms:Sign` permission can request signatures within whatever
+IAM and Steward policy boundaries remain. Use narrow key policies, per-tenant or
+per-agent keys where warranted, CloudTrail monitoring, key disable/revocation,
+and the existing Steward policy/approval/audit controls.

--- a/packages/api/src/__tests__/vault-execution-gateway.test.ts
+++ b/packages/api/src/__tests__/vault-execution-gateway.test.ts
@@ -805,6 +805,7 @@ describe("vault EVM execution gateway", () => {
 
   class ProviderSpy implements ExternalKeyCustodyProvider {
     id = "transition-provider-spy";
+    readonly contractVersion = 1 as const;
     registerCalls: ExternalKeyHandleImportRequest[] = [];
     signCalls: ExternalKeySignTransactionRequest[] = [];
     async registerKeyHandle(

--- a/packages/api/src/__tests__/vault-factory.test.ts
+++ b/packages/api/src/__tests__/vault-factory.test.ts
@@ -22,6 +22,8 @@ const ENV_KEYS = [
   "STEWARD_ALLOW_DEV_SECRET",
   "STEWARD_MASTER_PASSWORD",
   "STEWARD_KMS_PROVIDER",
+  "STEWARD_EXTERNAL_CUSTODY_PROVIDER",
+  "STEWARD_EXTERNAL_CUSTODY_AWS_REGION",
   "STEWARD_KMS_KEY_ID",
   "STEWARD_AWS_KMS_KEY_ARN",
   "STEWARD_AWS_REGION",
@@ -143,6 +145,25 @@ describe("vault factory", () => {
     for (const capability of VAULT_SIGNING_CAPABILITIES) {
       expect(line).toContain(capability);
     }
+  });
+
+  it("wires AWS asymmetric external custody separately from KMS envelope mode", () => {
+    process.env.STEWARD_MASTER_PASSWORD = "factory-master";
+    delete process.env.STEWARD_KMS_PROVIDER;
+    process.env.STEWARD_EXTERNAL_CUSTODY_PROVIDER = "aws-kms";
+    process.env.STEWARD_EXTERNAL_CUSTODY_AWS_REGION = "us-east-1";
+
+    expect(() => createConfiguredVault()).not.toThrow();
+    const line = configuredVaultStartupLogLine();
+    expect(line).toContain("mode=local");
+    expect(line).toContain("external_custody=aws-kms");
+    expect(line).not.toContain("us-east-1");
+  });
+
+  it("fails closed for an unknown external custody provider", () => {
+    process.env.STEWARD_MASTER_PASSWORD = "factory-master";
+    process.env.STEWARD_EXTERNAL_CUSTODY_PROVIDER = "not-a-provider";
+    expect(() => createConfiguredVault()).toThrow("Unsupported STEWARD_EXTERNAL_CUSTODY_PROVIDER");
   });
 
   it("marks every signing operation supported for local and KMS envelope modes", () => {

--- a/packages/api/src/services/vault-factory.ts
+++ b/packages/api/src/services/vault-factory.ts
@@ -1,10 +1,11 @@
 import { createRequire } from "node:module";
 import { isDevSecretAllowed } from "@stwd/auth";
-import { KmsEnvelopeKeystore, Vault } from "@stwd/vault";
+import { AwsKmsExternalKeyCustodyProvider, KmsEnvelopeKeystore, Vault } from "@stwd/vault";
 
 const require = createRequire(import.meta.url);
 
 export type VaultMode = "local" | "kms-envelope:aws" | "kms-envelope:pkcs11";
+export type ExternalCustodyProviderName = "aws-kms";
 
 /**
  * Explicit acknowledgement that this deployment runs the weakest custody
@@ -76,6 +77,29 @@ function configuredKmsProvider(): "aws" | "pkcs11" | undefined {
   if (!value) return undefined;
   if (value === "aws" || value === "pkcs11") return value;
   throw new Error(`Unsupported STEWARD_KMS_PROVIDER: ${value}`);
+}
+
+function configuredExternalCustodyProvider(): ExternalCustodyProviderName | undefined {
+  const value = process.env.STEWARD_EXTERNAL_CUSTODY_PROVIDER?.trim();
+  if (!value) return undefined;
+  if (value === "aws-kms") return value;
+  throw new Error(`Unsupported STEWARD_EXTERNAL_CUSTODY_PROVIDER: ${value}`);
+}
+
+function createExternalCustodyProvider() {
+  const provider = configuredExternalCustodyProvider();
+  if (!provider) return undefined;
+  // External signing uses the same optional AWS SDK package as envelope mode,
+  // but it is deliberately selected by a separate configuration key and never
+  // changes the keystore backend.
+  try {
+    require.resolve("@aws-sdk/client-kms");
+  } catch {
+    throw new Error(
+      "@aws-sdk/client-kms is required when STEWARD_EXTERNAL_CUSTODY_PROVIDER=aws-kms",
+    );
+  }
+  return AwsKmsExternalKeyCustodyProvider.fromEnv();
 }
 
 function requireKmsConfiguration(provider: "aws" | "pkcs11"): void {
@@ -197,13 +221,17 @@ export function createConfiguredVault(options: ConfiguredVaultOptions = {}): Vau
     rpcUrl: process.env.RPC_URL || "https://sepolia.base.org",
     chainId: parseInt(process.env.CHAIN_ID || "84532", 10),
     ...(mode === "local" ? {} : { keystoreBackend: KmsEnvelopeKeystore.fromEnv() }),
+    ...(configuredExternalCustodyProvider()
+      ? { externalKeyCustodyProvider: createExternalCustodyProvider() }
+      : {}),
   });
 }
 
 export function getConfiguredVault(options: ConfiguredVaultOptions = {}): Vault {
   const mode = configuredMode();
+  const externalCustody = configuredExternalCustodyProvider() ?? "none";
   const masterPassword = resolveMasterPassword(options);
-  const key = `${mode}:${masterPassword}`;
+  const key = `${mode}:${externalCustody}:${masterPassword}`;
   let vault = vaultsByKey.get(key);
   if (!vault) {
     vault = createConfiguredVault({ ...options, fallbackPassword: masterPassword });
@@ -216,6 +244,7 @@ export function configuredVaultStartupLogLine(): string {
   const provider = configuredKmsProvider();
   const mode: VaultMode = provider ? `kms-envelope:${provider}` : "local";
   const plaintextAtSignTime = modeExposesPlaintextAtSignTime(mode);
+  const externalCustody = configuredExternalCustodyProvider() ?? "none";
   // In production, local mode only reaches this point when the operator has
   // explicitly acknowledged the weak posture (see assertProductionCustodyAcknowledged).
   // Surface that acknowledgement in the boot log so it is auditable. Never emit
@@ -225,7 +254,8 @@ export function configuredVaultStartupLogLine(): string {
       ? ` local_custody_acknowledged=${localCustodyAcknowledged()}`
       : "";
   return (
-    `[steward] vault mode=${mode} plaintext_at_sign_time=${plaintextAtSignTime}${ack} ` +
+    `[steward] vault mode=${mode} external_custody=${externalCustody} ` +
+    `plaintext_at_sign_time=${plaintextAtSignTime}${ack} ` +
     `capabilities=${VAULT_SIGNING_CAPABILITIES.join(",")}`
   );
 }

--- a/packages/vault/src/__tests__/aws-kms-external-custody.test.ts
+++ b/packages/vault/src/__tests__/aws-kms-external-custody.test.ts
@@ -1,0 +1,351 @@
+import { describe, expect, test } from "bun:test";
+import { secp256k1 } from "@noble/curves/secp256k1";
+import {
+  getAddress,
+  type Hex,
+  parseTransaction,
+  recoverTransactionAddress,
+  type TransactionSerializableLegacy,
+  toHex,
+} from "viem";
+import { publicKeyToAddress } from "viem/accounts";
+import {
+  type AwsKmsEvmRpc,
+  AwsKmsExternalKeyCustodyProvider,
+  type AwsKmsSigningClientLike,
+  decodeAwsKmsEcdsaSignature,
+} from "../aws-kms-external-custody";
+import type {
+  ExternalKeyHandleImportRequest,
+  ExternalKeySignTransactionRequest,
+} from "../external-key-custody";
+import { runExternalKeyCustodyV1Conformance } from "../external-key-custody-conformance";
+
+const CURVE_ORDER = BigInt("0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141");
+
+function hexBytes(value: string): Uint8Array {
+  const clean = value.startsWith("0x") ? value.slice(2) : value;
+  return Uint8Array.from({ length: clean.length / 2 }, (_, index) =>
+    Number.parseInt(clean.slice(index * 2, index * 2 + 2), 16),
+  );
+}
+
+function concatBytes(...values: Uint8Array[]): Uint8Array {
+  const output = new Uint8Array(values.reduce((sum, value) => sum + value.length, 0));
+  let offset = 0;
+  for (const value of values) {
+    output.set(value, offset);
+    offset += value.length;
+  }
+  return output;
+}
+
+function spkiForPrivateKey(privateKey: Uint8Array): Uint8Array {
+  const publicKey = secp256k1.getPublicKey(privateKey, false);
+  // SubjectPublicKeyInfo(ecPublicKey, secp256k1, uncompressed point).
+  return concatBytes(hexBytes("3056301006072a8648ce3d020106052b8104000a034200"), publicKey);
+}
+
+function addressForPrivateKey(privateKey: Uint8Array) {
+  return getAddress(publicKeyToAddress(toHex(secp256k1.getPublicKey(privateKey, false))));
+}
+
+type SignatureMode = "normal" | "high-s" | "malformed";
+
+class MockKms implements AwsKmsSigningClientLike {
+  readonly commands: Array<{ commandName: string; input: Record<string, unknown> }> = [];
+
+  constructor(
+    private readonly privateKey: Uint8Array,
+    private readonly signatureMode: SignatureMode = "normal",
+    private readonly keySpec = "ECC_SECG_P256K1",
+  ) {}
+
+  async send(command: unknown): Promise<unknown> {
+    const parsed = command as { commandName: string; input: Record<string, unknown> };
+    this.commands.push(parsed);
+    if (parsed.commandName === "GetPublicKeyCommand") {
+      return {
+        KeyId: "arn:aws:kms:us-east-1:111122223333:key/test",
+        PublicKey: spkiForPrivateKey(this.privateKey),
+        KeySpec: this.keySpec,
+        KeyUsage: "SIGN_VERIFY",
+        SigningAlgorithms: ["ECDSA_SHA_256"],
+      };
+    }
+    if (parsed.commandName === "SignCommand") {
+      const digest = parsed.input.Message as Uint8Array;
+      if (this.signatureMode === "malformed") {
+        return { Signature: new Uint8Array([0x30, 0x01, 0x00]) };
+      }
+      const signature = secp256k1.sign(digest, this.privateKey, { lowS: true });
+      const encoded =
+        this.signatureMode === "high-s"
+          ? new secp256k1.Signature(signature.r, CURVE_ORDER - signature.s).toBytes("der")
+          : signature.toBytes("der");
+      return { Signature: encoded, SigningAlgorithm: "ECDSA_SHA_256" };
+    }
+    throw new Error(`unexpected mock command ${parsed.commandName}`);
+  }
+}
+
+class MockRpc implements AwsKmsEvmRpc {
+  readonly broadcasts: Hex[] = [];
+  transaction: TransactionSerializableLegacy = {
+    type: "legacy",
+    chainId: 8453,
+    nonce: 7,
+    gas: 21_000n,
+    gasPrice: 1_000_000_000n,
+    to: "0x2222222222222222222222222222222222222222",
+    value: 123n,
+    data: "0x",
+  };
+
+  async prepareTransaction(): Promise<TransactionSerializableLegacy> {
+    return this.transaction;
+  }
+
+  async broadcast(serializedTransaction: Hex): Promise<Hex> {
+    this.broadcasts.push(serializedTransaction);
+    return "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+  }
+}
+
+function registrationRequest(
+  privateKey: Uint8Array,
+  overrides: Partial<ExternalKeyHandleImportRequest> = {},
+): ExternalKeyHandleImportRequest {
+  return {
+    tenantId: "tenant-1",
+    agentId: "agent-1",
+    chainFamily: "evm",
+    address: addressForPrivateKey(privateKey),
+    handle: { providerId: "aws-kms", keyId: "alias/steward-agent-1", region: "us-east-1" },
+    venue: "aws-primary",
+    purpose: "evm-signing",
+    metadata: { owner: "security" },
+    ...overrides,
+  };
+}
+
+function signRequest(
+  privateKey: Uint8Array,
+  overrides: Partial<ExternalKeySignTransactionRequest> = {},
+): ExternalKeySignTransactionRequest {
+  return {
+    tenantId: "tenant-1",
+    agentId: "agent-1",
+    chainFamily: "evm",
+    address: addressForPrivateKey(privateKey),
+    handle: { providerId: "aws-kms", keyId: "alias/steward-agent-1", region: "us-east-1" },
+    chainId: 8453,
+    to: "0x2222222222222222222222222222222222222222",
+    value: "123",
+    data: "0x",
+    gasLimit: "21000",
+    nonce: 7,
+    broadcast: false,
+    rpcUrl: "https://rpc.example.test",
+    ...overrides,
+  };
+}
+
+function providerFor(kms: MockKms, rpc: MockRpc): AwsKmsExternalKeyCustodyProvider {
+  return new AwsKmsExternalKeyCustodyProvider({
+    client: kms,
+    region: "us-east-1",
+    rpcFactory: () => rpc,
+  });
+}
+
+describe("AWS KMS asymmetric external custody", () => {
+  test("passes the reusable external custody v1 conformance contract", async () => {
+    const privateKey = secp256k1.utils.randomPrivateKey();
+    const result = await runExternalKeyCustodyV1Conformance({
+      createProvider: () => providerFor(new MockKms(privateKey), new MockRpc()),
+      validRegistrationRequest: registrationRequest(privateKey),
+    });
+    expect(result).toEqual({
+      contractVersion: 1,
+      providerId: "external-custody:aws-kms",
+      signingAvailability: "provider-signing",
+    });
+  });
+
+  test("registers only an address-bound secp256k1 SIGN_VERIFY handle", async () => {
+    const privateKey = secp256k1.utils.randomPrivateKey();
+    const kms = new MockKms(privateKey);
+    const registration = await providerFor(kms, new MockRpc()).registerKeyHandle(
+      registrationRequest(privateKey),
+    );
+
+    expect(registration).toMatchObject({
+      custody: "external",
+      chainFamily: "evm",
+      address: addressForPrivateKey(privateKey),
+      exportablePrivateKey: false,
+      signingAvailability: "provider-signing",
+      handle: { providerId: "aws-kms", keyId: "alias/steward-agent-1" },
+    });
+    const serializedRegistration = JSON.stringify(registration).toLowerCase();
+    expect(serializedRegistration).not.toContain("secretkey");
+    expect(serializedRegistration).not.toContain("mnemonic");
+    expect(serializedRegistration).not.toContain("ciphertext");
+    expect(kms.commands[0]).toEqual({
+      commandName: "GetPublicKeyCommand",
+      input: { KeyId: "alias/steward-agent-1" },
+    });
+  });
+
+  test("rejects an address mismatch and unsupported AWS key modes", async () => {
+    const privateKey = secp256k1.utils.randomPrivateKey();
+    await expect(
+      providerFor(new MockKms(privateKey), new MockRpc()).registerKeyHandle(
+        registrationRequest(privateKey, {
+          address: "0x1111111111111111111111111111111111111111",
+        }),
+      ),
+    ).rejects.toThrow("does not match");
+
+    await expect(
+      providerFor(
+        new MockKms(privateKey, "normal", "ECC_NIST_P256"),
+        new MockRpc(),
+      ).registerKeyHandle(registrationRequest(privateKey)),
+    ).rejects.toThrow("ECC_SECG_P256K1");
+
+    await expect(
+      providerFor(new MockKms(privateKey), new MockRpc()).registerKeyHandle(
+        registrationRequest(privateKey, { chainFamily: "solana" }),
+      ),
+    ).rejects.toThrow("EVM key handles only");
+
+    await expect(
+      new AwsKmsExternalKeyCustodyProvider({
+        client: new MockKms(privateKey),
+        region: "us-west-2",
+        rpcFactory: () => new MockRpc(),
+      }).registerKeyHandle(registrationRequest(privateKey)),
+    ).rejects.toThrow("handle region must match");
+  });
+
+  test("signs a prepared legacy transaction digest and recovers the registered address", async () => {
+    const privateKey = secp256k1.utils.randomPrivateKey();
+    const kms = new MockKms(privateKey);
+    const result = await providerFor(kms, new MockRpc()).signTransaction(signRequest(privateKey));
+
+    expect(result.broadcast).toBe(false);
+    const raw = result.result as Hex;
+    expect(await recoverTransactionAddress({ serializedTransaction: raw })).toBe(
+      addressForPrivateKey(privateKey),
+    );
+    const parsed = parseTransaction(raw);
+    expect(parsed.chainId).toBe(8453);
+    expect(parsed.to).toBe("0x2222222222222222222222222222222222222222");
+    expect(parsed.value).toBe(123n);
+    expect(parsed.s && BigInt(parsed.s)).toBeLessThanOrEqual(CURVE_ORDER / 2n);
+
+    const signCommand = kms.commands.find((command) => command.commandName === "SignCommand");
+    expect(signCommand?.input).toMatchObject({
+      KeyId: "alias/steward-agent-1",
+      MessageType: "DIGEST",
+      SigningAlgorithm: "ECDSA_SHA_256",
+    });
+    expect(signCommand?.input.Message).toBeInstanceOf(Uint8Array);
+    expect((signCommand?.input.Message as Uint8Array).length).toBe(32);
+  });
+
+  test("normalizes high-s KMS output before serialization", async () => {
+    const privateKey = secp256k1.utils.randomPrivateKey();
+    const result = await providerFor(
+      new MockKms(privateKey, "high-s"),
+      new MockRpc(),
+    ).signTransaction(signRequest(privateKey));
+    const parsed = parseTransaction(result.result as Hex);
+    expect(parsed.s && BigInt(parsed.s)).toBeLessThanOrEqual(CURVE_ORDER / 2n);
+    expect(await recoverTransactionAddress({ serializedTransaction: result.result as Hex })).toBe(
+      addressForPrivateKey(privateKey),
+    );
+  });
+
+  test("rejects malformed or wrong-key signatures before broadcast", async () => {
+    const privateKey = secp256k1.utils.randomPrivateKey();
+    const malformedRpc = new MockRpc();
+    await expect(
+      providerFor(new MockKms(privateKey, "malformed"), malformedRpc).signTransaction(
+        signRequest(privateKey, { broadcast: true }),
+      ),
+    ).rejects.toThrow("malformed ECDSA signature");
+    expect(malformedRpc.broadcasts).toHaveLength(0);
+
+    const otherKey = secp256k1.utils.randomPrivateKey();
+    const wrongKeyRpc = new MockRpc();
+    // GetPublicKey must still describe the registered key, while Sign is made to
+    // return a signature from another key.
+    const kms = new MockKms(privateKey);
+    const originalSend = kms.send.bind(kms);
+    kms.send = async (command: unknown) => {
+      const parsed = command as { commandName: string; input: { Message: Uint8Array } };
+      if (parsed.commandName === "SignCommand") {
+        return { Signature: secp256k1.sign(parsed.input.Message, otherKey).toBytes("der") };
+      }
+      return originalSend(command);
+    };
+    await expect(
+      providerFor(kms, wrongKeyRpc).signTransaction(signRequest(privateKey, { broadcast: true })),
+    ).rejects.toThrow("does not recover");
+    expect(wrongKeyRpc.broadcasts).toHaveLength(0);
+  });
+
+  test("rebinds semantic transaction fields before requesting a signature", async () => {
+    const privateKey = secp256k1.utils.randomPrivateKey();
+    const kms = new MockKms(privateKey);
+    const rpc = new MockRpc();
+    rpc.transaction = { ...rpc.transaction, value: 124n };
+    await expect(providerFor(kms, rpc).signTransaction(signRequest(privateKey))).rejects.toThrow(
+      "wrong value",
+    );
+    expect(kms.commands.some((command) => command.commandName === "SignCommand")).toBe(false);
+
+    rpc.transaction = { ...new MockRpc().transaction, nonce: 8 };
+    await expect(providerFor(kms, rpc).signTransaction(signRequest(privateKey))).rejects.toThrow(
+      "wrong nonce",
+    );
+    expect(kms.commands.some((command) => command.commandName === "SignCommand")).toBe(false);
+
+    rpc.transaction = { ...new MockRpc().transaction, gas: 21_001n };
+    await expect(providerFor(kms, rpc).signTransaction(signRequest(privateKey))).rejects.toThrow(
+      "wrong gas limit",
+    );
+    expect(kms.commands.some((command) => command.commandName === "SignCommand")).toBe(false);
+  });
+
+  test("broadcasts only the address-verified serialized transaction", async () => {
+    const privateKey = secp256k1.utils.randomPrivateKey();
+    const rpc = new MockRpc();
+    const result = await providerFor(new MockKms(privateKey), rpc).signTransaction(
+      signRequest(privateKey, { broadcast: true }),
+    );
+    expect(result).toEqual({
+      result: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      broadcast: true,
+    });
+    expect(rpc.broadcasts).toHaveLength(1);
+    expect(await recoverTransactionAddress({ serializedTransaction: rpc.broadcasts[0] })).toBe(
+      addressForPrivateKey(privateKey),
+    );
+  });
+
+  test("strict DER parser rejects ambiguity, trailing bytes, zero and out-of-range scalars", () => {
+    for (const malformed of [
+      hexBytes("300102"),
+      hexBytes("300602010102010100"),
+      hexBytes("3006020100020101"),
+      hexBytes("300702020001020101"),
+      hexBytes("3006020180020101"),
+    ]) {
+      expect(() => decodeAwsKmsEcdsaSignature(malformed)).toThrow();
+    }
+  });
+});

--- a/packages/vault/src/__tests__/external-key-custody-contract.test.ts
+++ b/packages/vault/src/__tests__/external-key-custody-contract.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import {
+  assertExternalKeyCustodyProviderV1,
   assertNoExternalPrivateKeyMaterial,
+  EXTERNAL_KEY_CUSTODY_CONTRACT_VERSION,
   type ExternalKeyHandleImportRequest,
   type ExternalKeyHandleRegistration,
   externalKeyPrivateExportUnavailableError,
@@ -40,6 +42,28 @@ function registration(
 }
 
 describe("external key custody contract", () => {
+  test("publishes and enforces the v1 compatibility marker", () => {
+    expect(EXTERNAL_KEY_CUSTODY_CONTRACT_VERSION).toBe(1);
+    expect(() =>
+      assertExternalKeyCustodyProviderV1({
+        id: "provider-v1",
+        contractVersion: 1,
+        async registerKeyHandle(input) {
+          return normalizeExternalKeyHandleRegistration(input, registration());
+        },
+      }),
+    ).not.toThrow();
+    expect(() =>
+      assertExternalKeyCustodyProviderV1({
+        id: "future-provider",
+        contractVersion: 2 as 1,
+        async registerKeyHandle(input) {
+          return normalizeExternalKeyHandleRegistration(input, registration());
+        },
+      }),
+    ).toThrow("Unsupported external key custody contract version");
+  });
+
   test("normalizes provider-signing registrations without private-key exportability", () => {
     const normalized = normalizeExternalKeyHandleRegistration(request, registration());
 
@@ -58,6 +82,12 @@ describe("external key custody contract", () => {
         handle: { providerId: "hsm", keyId: "key-1" },
         metadata: { nested: { secretKey: "not-allowed" } },
       }),
+    ).toThrow("must not contain private key material");
+    expect(() =>
+      assertNoExternalPrivateKeyMaterial({ metadata: { nested: { private_key: "0xsecret" } } }),
+    ).toThrow("must not contain private key material");
+    expect(() =>
+      assertNoExternalPrivateKeyMaterial({ metadata: { nested: { seedPhrase: "words" } } }),
     ).toThrow("must not contain private key material");
   });
 

--- a/packages/vault/src/__tests__/external-key-custody.test.ts
+++ b/packages/vault/src/__tests__/external-key-custody.test.ts
@@ -20,6 +20,7 @@ const openClients: Array<{ close: () => Promise<void> }> = [];
 
 class TestExternalKeyProvider implements ExternalKeyCustodyProvider {
   id = "test-external-key-provider";
+  readonly contractVersion = 1 as const;
   registerCalls: ExternalKeyHandleImportRequest[] = [];
   signCalls: ExternalKeySignTransactionRequest[] = [];
 
@@ -181,6 +182,7 @@ describe("external key custody seam", () => {
   test("external-only wallets refuse signing when provider signing is unavailable", async () => {
     const provider = {
       id: "unsupported-signing-provider",
+      contractVersion: 1 as const,
       async registerKeyHandle(
         request: ExternalKeyHandleImportRequest,
       ): Promise<ExternalKeyHandleRegistration> {

--- a/packages/vault/src/aws-kms-external-custody.ts
+++ b/packages/vault/src/aws-kms-external-custody.ts
@@ -1,0 +1,444 @@
+import { secp256k1 } from "@noble/curves/secp256k1";
+import {
+  type Address,
+  createPublicClient,
+  getAddress,
+  type Hex,
+  http,
+  isAddress,
+  isHex,
+  keccak256,
+  recoverAddress,
+  serializeTransaction,
+  type TransactionSerializableLegacy,
+} from "viem";
+import { publicKeyToAddress } from "viem/accounts";
+import type {
+  ExternalKeyCustodyProvider,
+  ExternalKeyHandleImportRequest,
+  ExternalKeyHandleRegistration,
+  ExternalKeySignTransactionRequest,
+  ExternalKeySignTransactionResult,
+} from "./external-key-custody";
+import {
+  assertNoExternalPrivateKeyMaterial,
+  EXTERNAL_KEY_CUSTODY_CONTRACT_VERSION,
+} from "./external-key-custody";
+
+const AWS_PROVIDER_ID = "aws-kms";
+const SECP256K1_ORDER = BigInt(
+  "0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+);
+const SECP256K1_HALF_ORDER = SECP256K1_ORDER / 2n;
+// DER SubjectPublicKeyInfo prefix for ecPublicKey + secp256k1 followed by a
+// 65-byte uncompressed SEC1 point. AWS KMS GetPublicKey uses this encoding.
+const SECP256K1_SPKI_PREFIX = Uint8Array.from([
+  0x30, 0x56, 0x30, 0x10, 0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01, 0x06, 0x05, 0x2b,
+  0x81, 0x04, 0x00, 0x0a, 0x03, 0x42, 0x00,
+]);
+
+interface AwsGetPublicKeyInput {
+  KeyId: string;
+}
+
+interface AwsSignInput {
+  KeyId: string;
+  Message: Uint8Array;
+  MessageType: "DIGEST";
+  SigningAlgorithm: "ECDSA_SHA_256";
+}
+
+interface AwsGetPublicKeyOutput {
+  KeyId?: string;
+  PublicKey?: Uint8Array;
+  KeySpec?: string;
+  KeyUsage?: string;
+  SigningAlgorithms?: string[];
+}
+
+interface AwsSignOutput {
+  KeyId?: string;
+  Signature?: Uint8Array;
+  SigningAlgorithm?: string;
+}
+
+export interface AwsKmsSigningClientLike {
+  send(command: unknown): Promise<unknown>;
+}
+
+export interface AwsKmsEvmRpc {
+  prepareTransaction(
+    request: ExternalKeySignTransactionRequest,
+    address: Address,
+  ): Promise<TransactionSerializableLegacy>;
+  broadcast(serializedTransaction: Hex): Promise<Hex>;
+}
+
+export interface AwsKmsExternalKeyCustodyOptions {
+  client?: AwsKmsSigningClientLike;
+  region?: string;
+  rpcFactory?: (rpcUrl: string) => AwsKmsEvmRpc;
+}
+
+function bytesToHex(bytes: Uint8Array): Hex {
+  return `0x${Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("")}`;
+}
+
+function hexToBytes(value: Hex): Uint8Array {
+  const out = new Uint8Array((value.length - 2) / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = Number.parseInt(value.slice(2 + i * 2, 4 + i * 2), 16);
+  }
+  return out;
+}
+
+function unsignedBigIntToHex(value: bigint): Hex {
+  return `0x${value.toString(16).padStart(64, "0")}`;
+}
+
+function readDerLength(bytes: Uint8Array, offset: number): { length: number; next: number } {
+  const first = bytes[offset];
+  if (first === undefined) throw new Error("AWS KMS returned a truncated ECDSA signature");
+  if ((first & 0x80) === 0) return { length: first, next: offset + 1 };
+  // KMS secp256k1 signatures are tiny. Reject non-minimal/oversized DER rather
+  // than accepting an ambiguous ASN.1 encoding.
+  const lengthBytes = first & 0x7f;
+  if (lengthBytes !== 1 || bytes[offset + 1] === undefined || bytes[offset + 1] < 0x80) {
+    throw new Error("AWS KMS returned a non-canonical ECDSA signature length");
+  }
+  return { length: bytes[offset + 1], next: offset + 2 };
+}
+
+function readDerInteger(bytes: Uint8Array, offset: number): { value: bigint; next: number } {
+  if (bytes[offset] !== 0x02) throw new Error("AWS KMS returned malformed ECDSA DER integers");
+  const { length, next } = readDerLength(bytes, offset + 1);
+  if (length < 1 || length > 33 || next + length > bytes.length) {
+    throw new Error("AWS KMS returned an invalid ECDSA integer length");
+  }
+  const encoded = bytes.slice(next, next + length);
+  if ((encoded[0] & 0x80) !== 0) throw new Error("AWS KMS returned a negative ECDSA integer");
+  if (encoded.length > 1 && encoded[0] === 0 && (encoded[1] & 0x80) === 0) {
+    throw new Error("AWS KMS returned a non-canonical ECDSA integer");
+  }
+  const magnitude = encoded[0] === 0 ? encoded.slice(1) : encoded;
+  const hex = Array.from(magnitude, (byte) => byte.toString(16).padStart(2, "0")).join("");
+  return { value: hex.length === 0 ? 0n : BigInt(`0x${hex}`), next: next + length };
+}
+
+/** Strictly decode the ASN.1 DER ECDSA signature returned by AWS KMS. */
+export function decodeAwsKmsEcdsaSignature(signature: Uint8Array): { r: bigint; s: bigint } {
+  if (signature.length < 8 || signature.length > 72 || signature[0] !== 0x30) {
+    throw new Error("AWS KMS returned a malformed ECDSA signature");
+  }
+  const sequence = readDerLength(signature, 1);
+  if (sequence.next + sequence.length !== signature.length) {
+    throw new Error("AWS KMS returned an ECDSA signature with trailing or truncated bytes");
+  }
+  const r = readDerInteger(signature, sequence.next);
+  const s = readDerInteger(signature, r.next);
+  if (s.next !== signature.length) {
+    throw new Error("AWS KMS returned an ECDSA signature with trailing bytes");
+  }
+  for (const [name, value] of [
+    ["r", r.value],
+    ["s", s.value],
+  ] as const) {
+    if (value <= 0n || value >= SECP256K1_ORDER) {
+      throw new Error(`AWS KMS returned ECDSA ${name} outside the secp256k1 scalar range`);
+    }
+  }
+  return { r: r.value, s: s.value };
+}
+
+function evmAddressFromSpki(publicKey: Uint8Array): Address {
+  if (publicKey.length !== SECP256K1_SPKI_PREFIX.length + 65) {
+    throw new Error("AWS KMS returned an invalid secp256k1 SPKI public key length");
+  }
+  if (!SECP256K1_SPKI_PREFIX.every((byte, index) => publicKey[index] === byte)) {
+    throw new Error("AWS KMS returned an SPKI key with an unexpected algorithm or encoding");
+  }
+  const encodedPoint = publicKey.slice(SECP256K1_SPKI_PREFIX.length);
+  let canonicalPoint: Uint8Array;
+  try {
+    canonicalPoint = secp256k1.ProjectivePoint.fromHex(encodedPoint).toRawBytes(false);
+  } catch {
+    throw new Error("AWS KMS returned a public key point outside secp256k1");
+  }
+  return getAddress(publicKeyToAddress(bytesToHex(canonicalPoint)));
+}
+
+function assertAwsSigningKey(output: AwsGetPublicKeyOutput): Uint8Array {
+  if (!output.PublicKey) throw new Error("AWS KMS GetPublicKey did not return PublicKey");
+  if (output.KeySpec !== "ECC_SECG_P256K1") {
+    throw new Error("AWS KMS external custody requires KeySpec ECC_SECG_P256K1");
+  }
+  if (output.KeyUsage !== "SIGN_VERIFY") {
+    throw new Error("AWS KMS external custody requires KeyUsage SIGN_VERIFY");
+  }
+  if (!output.SigningAlgorithms?.includes("ECDSA_SHA_256")) {
+    throw new Error("AWS KMS external custody requires ECDSA_SHA_256 signing support");
+  }
+  return output.PublicKey;
+}
+
+function assertEvmRequest(request: ExternalKeySignTransactionRequest): void {
+  if (request.chainFamily !== "evm") {
+    throw new Error("AWS KMS reference custody supports EVM transaction signing only");
+  }
+  if (request.handle.providerId !== AWS_PROVIDER_ID) {
+    throw new Error(`AWS KMS external custody handle providerId must be ${AWS_PROVIDER_ID}`);
+  }
+  if (!request.handle.keyId.trim()) throw new Error("AWS KMS external custody requires keyId");
+  if (!isAddress(request.address) || !isAddress(request.to)) {
+    throw new Error("AWS KMS external custody requires valid EVM addresses");
+  }
+  if (!Number.isSafeInteger(request.chainId) || request.chainId <= 0) {
+    throw new Error("AWS KMS external custody requires a positive EVM chainId");
+  }
+  if (BigInt(request.value) < 0n)
+    throw new Error("AWS KMS external custody value cannot be negative");
+  if (request.gasLimit !== undefined && BigInt(request.gasLimit) <= 0n) {
+    throw new Error("AWS KMS external custody gasLimit must be positive");
+  }
+  if (request.nonce !== undefined && (!Number.isSafeInteger(request.nonce) || request.nonce < 0)) {
+    throw new Error("AWS KMS external custody nonce must be a non-negative safe integer");
+  }
+  if (request.data !== undefined && !isHex(request.data)) {
+    throw new Error("AWS KMS external custody data must be hex encoded");
+  }
+  if (!request.rpcUrl?.trim()) throw new Error("AWS KMS external custody requires an EVM RPC URL");
+}
+
+function assertHandleRegion(
+  handleRegion: string | undefined,
+  configuredRegion: string | undefined,
+): void {
+  if (handleRegion !== undefined && handleRegion !== configuredRegion) {
+    throw new Error(
+      "AWS KMS external custody handle region must match STEWARD_EXTERNAL_CUSTODY_AWS_REGION",
+    );
+  }
+}
+
+function defaultRpcFactory(rpcUrl: string): AwsKmsEvmRpc {
+  const client = createPublicClient({ transport: http(rpcUrl) });
+  return {
+    async prepareTransaction(request, address) {
+      const to = getAddress(request.to);
+      const value = BigInt(request.value);
+      const data = (request.data ?? "0x") as Hex;
+      const nonce =
+        request.nonce ?? (await client.getTransactionCount({ address, blockTag: "pending" }));
+      const gas = request.gasLimit
+        ? BigInt(request.gasLimit)
+        : await client.estimateGas({ account: address, to, value, data });
+      const gasPrice = await client.getGasPrice();
+      return {
+        type: "legacy",
+        chainId: request.chainId,
+        to,
+        value,
+        data,
+        nonce,
+        gas,
+        gasPrice,
+      };
+    },
+    broadcast(serializedTransaction) {
+      return client.sendRawTransaction({ serializedTransaction });
+    },
+  };
+}
+
+export class AwsKmsExternalKeyCustodyProvider implements ExternalKeyCustodyProvider {
+  readonly id = "external-custody:aws-kms";
+  readonly contractVersion = EXTERNAL_KEY_CUSTODY_CONTRACT_VERSION;
+
+  private readonly clientIsInjected: boolean;
+  private client?: AwsKmsSigningClientLike;
+  private readonly region?: string;
+  private readonly rpcFactory: (rpcUrl: string) => AwsKmsEvmRpc;
+
+  constructor(options: AwsKmsExternalKeyCustodyOptions = {}) {
+    this.client = options.client;
+    this.clientIsInjected = Boolean(options.client);
+    this.region = options.region;
+    this.rpcFactory = options.rpcFactory ?? defaultRpcFactory;
+  }
+
+  static fromEnv(): AwsKmsExternalKeyCustodyProvider {
+    return new AwsKmsExternalKeyCustodyProvider({
+      region:
+        process.env.STEWARD_EXTERNAL_CUSTODY_AWS_REGION ??
+        process.env.STEWARD_AWS_REGION ??
+        process.env.AWS_REGION,
+    });
+  }
+
+  async registerKeyHandle(
+    request: ExternalKeyHandleImportRequest,
+  ): Promise<ExternalKeyHandleRegistration> {
+    assertNoExternalPrivateKeyMaterial(request);
+    assertHandleRegion(request.handle.region, this.region);
+    if (request.chainFamily !== "evm") {
+      throw new Error("AWS KMS reference custody supports EVM key handles only");
+    }
+    if (request.handle.providerId !== AWS_PROVIDER_ID || !request.handle.keyId.trim()) {
+      throw new Error(
+        `AWS KMS external custody handle requires providerId=${AWS_PROVIDER_ID} and keyId`,
+      );
+    }
+    if (!isAddress(request.address)) {
+      throw new Error("AWS KMS external custody registration requires a valid EVM address");
+    }
+    const resolved = await this.resolveSigningAddress(request.handle.keyId);
+    if (resolved !== getAddress(request.address)) {
+      throw new Error("AWS KMS public key does not match the requested external wallet address");
+    }
+    return {
+      custody: "external",
+      tenantId: request.tenantId,
+      agentId: request.agentId,
+      chainFamily: "evm",
+      address: resolved,
+      handle: {
+        providerId: AWS_PROVIDER_ID,
+        keyId: request.handle.keyId,
+        version: request.handle.version,
+        region: this.region,
+      },
+      venue: request.venue ?? null,
+      purpose: request.purpose ?? null,
+      metadata: request.metadata ?? {},
+      registeredAt: new Date(),
+      exportablePrivateKey: false,
+      signingAvailability: "provider-signing",
+    };
+  }
+
+  async exportKeyHandle(): Promise<never> {
+    throw new Error("AWS KMS external custody key handles are not exportable through Steward");
+  }
+
+  async signTransaction(
+    request: ExternalKeySignTransactionRequest,
+  ): Promise<ExternalKeySignTransactionResult> {
+    assertNoExternalPrivateKeyMaterial(request);
+    assertEvmRequest(request);
+    assertHandleRegion(request.handle.region, this.region);
+    const expectedAddress = getAddress(request.address);
+    const resolvedAddress = await this.resolveSigningAddress(request.handle.keyId);
+    if (resolvedAddress !== expectedAddress) {
+      throw new Error(
+        "AWS KMS public key no longer matches the registered external wallet address",
+      );
+    }
+
+    const rpc = this.rpcFactory(request.rpcUrl!);
+    const transaction = await rpc.prepareTransaction(request, expectedAddress);
+    if (transaction.type !== undefined && transaction.type !== "legacy") {
+      throw new Error("AWS KMS reference custody supports legacy EIP-155 transactions only");
+    }
+    if (transaction.chainId !== request.chainId) {
+      throw new Error("AWS KMS RPC prepared a transaction for the wrong chainId");
+    }
+    if (transaction.to && getAddress(transaction.to) !== getAddress(request.to)) {
+      throw new Error("AWS KMS RPC prepared a transaction for the wrong recipient");
+    }
+    if ((transaction.value ?? 0n) !== BigInt(request.value)) {
+      throw new Error("AWS KMS RPC prepared a transaction with the wrong value");
+    }
+    if ((transaction.data ?? "0x").toLowerCase() !== (request.data ?? "0x").toLowerCase()) {
+      throw new Error("AWS KMS RPC prepared a transaction with the wrong calldata");
+    }
+    if (request.nonce !== undefined && transaction.nonce !== request.nonce) {
+      throw new Error("AWS KMS RPC prepared a transaction with the wrong nonce");
+    }
+    if (request.gasLimit !== undefined && transaction.gas !== BigInt(request.gasLimit)) {
+      throw new Error("AWS KMS RPC prepared a transaction with the wrong gas limit");
+    }
+
+    const unsigned = serializeTransaction(transaction);
+    const digest = keccak256(unsigned);
+    const response = (await (
+      await this.getClient()
+    ).send(
+      await this.createSignCommand({
+        KeyId: request.handle.keyId,
+        Message: hexToBytes(digest),
+        MessageType: "DIGEST",
+        SigningAlgorithm: "ECDSA_SHA_256",
+      }),
+    )) as AwsSignOutput;
+    if (!response.Signature) throw new Error("AWS KMS Sign did not return Signature");
+    if (response.SigningAlgorithm && response.SigningAlgorithm !== "ECDSA_SHA_256") {
+      throw new Error("AWS KMS Sign returned an unexpected signing algorithm");
+    }
+
+    const decoded = decodeAwsKmsEcdsaSignature(response.Signature);
+    const normalizedS = decoded.s > SECP256K1_HALF_ORDER ? SECP256K1_ORDER - decoded.s : decoded.s;
+    const r = unsignedBigIntToHex(decoded.r);
+    const s = unsignedBigIntToHex(normalizedS);
+    let yParity: 0 | 1 | undefined;
+    for (const candidate of [0, 1] as const) {
+      const recovered = getAddress(
+        await recoverAddress({ hash: digest, signature: { r, s, yParity: candidate } }),
+      );
+      if (recovered === expectedAddress) {
+        yParity = candidate;
+        break;
+      }
+    }
+    if (yParity === undefined) {
+      throw new Error(
+        "AWS KMS signature does not recover to the registered external wallet address",
+      );
+    }
+    const serialized = serializeTransaction(transaction, {
+      r,
+      s,
+      // Legacy EIP-155 serialization consumes v (27/28) and derives the
+      // chain-bound value itself. yParity above remains the recovery proof.
+      v: yParity === 0 ? 27n : 28n,
+    });
+    const result = request.broadcast ? await rpc.broadcast(serialized) : serialized;
+    return { result, broadcast: request.broadcast };
+  }
+
+  private async resolveSigningAddress(keyId: string): Promise<Address> {
+    const response = (await (
+      await this.getClient()
+    ).send(await this.createGetPublicKeyCommand({ KeyId: keyId }))) as AwsGetPublicKeyOutput;
+    return evmAddressFromSpki(assertAwsSigningKey(response));
+  }
+
+  private async getClient(): Promise<AwsKmsSigningClientLike> {
+    if (this.client) return this.client;
+    const moduleName = "@aws-sdk/client-kms";
+    const aws = (await import(moduleName)) as {
+      KMSClient: new (options: { region?: string }) => AwsKmsSigningClientLike;
+    };
+    this.client = new aws.KMSClient({ region: this.region });
+    return this.client;
+  }
+
+  private async createGetPublicKeyCommand(input: AwsGetPublicKeyInput): Promise<unknown> {
+    if (this.clientIsInjected) return { commandName: "GetPublicKeyCommand", input };
+    const moduleName = "@aws-sdk/client-kms";
+    const aws = (await import(moduleName)) as {
+      GetPublicKeyCommand: new (input: AwsGetPublicKeyInput) => unknown;
+    };
+    return new aws.GetPublicKeyCommand(input);
+  }
+
+  private async createSignCommand(input: AwsSignInput): Promise<unknown> {
+    if (this.clientIsInjected) return { commandName: "SignCommand", input };
+    const moduleName = "@aws-sdk/client-kms";
+    const aws = (await import(moduleName)) as {
+      SignCommand: new (input: AwsSignInput) => unknown;
+    };
+    return new aws.SignCommand(input);
+  }
+}
+
+export { AWS_PROVIDER_ID as AWS_KMS_EXTERNAL_CUSTODY_PROVIDER_ID };

--- a/packages/vault/src/external-key-custody-conformance.ts
+++ b/packages/vault/src/external-key-custody-conformance.ts
@@ -1,0 +1,84 @@
+import {
+  assertExternalKeyCustodyProviderV1,
+  assertNoExternalPrivateKeyMaterial,
+  type ExternalKeyCustodyProvider,
+  type ExternalKeyHandleImportRequest,
+  normalizeExternalKeyHandleRegistration,
+} from "./external-key-custody";
+
+export interface ExternalKeyCustodyV1ConformanceSubject {
+  /** Return a fresh provider so the negative private-material probe is isolated. */
+  createProvider(): ExternalKeyCustodyProvider;
+  /** A real/public test handle that the provider can resolve without secret material. */
+  validRegistrationRequest: ExternalKeyHandleImportRequest;
+}
+
+export interface ExternalKeyCustodyV1ConformanceResult {
+  contractVersion: 1;
+  providerId: string;
+  signingAvailability: "not-supported" | "provider-signing";
+}
+
+/**
+ * Reusable v1 provider conformance probe for operator-supplied custody adapters.
+ *
+ * This is intentionally framework-neutral: call it from Bun/Jest/Vitest and
+ * expect it to resolve. It verifies the stable identity binding, no-export
+ * invariant, registration normalization, provider-signing declaration, and
+ * direct-provider rejection of nested private material.
+ */
+export async function runExternalKeyCustodyV1Conformance(
+  subject: ExternalKeyCustodyV1ConformanceSubject,
+): Promise<ExternalKeyCustodyV1ConformanceResult> {
+  assertNoExternalPrivateKeyMaterial(subject.validRegistrationRequest);
+  const provider = subject.createProvider();
+  assertExternalKeyCustodyProviderV1(provider);
+
+  const raw = await provider.registerKeyHandle(subject.validRegistrationRequest);
+  if (
+    raw.tenantId !== subject.validRegistrationRequest.tenantId ||
+    raw.agentId !== subject.validRegistrationRequest.agentId ||
+    raw.chainFamily !== subject.validRegistrationRequest.chainFamily ||
+    raw.address.toLowerCase() !== subject.validRegistrationRequest.address.toLowerCase() ||
+    raw.handle.providerId !== subject.validRegistrationRequest.handle.providerId ||
+    raw.handle.keyId !== subject.validRegistrationRequest.handle.keyId
+  ) {
+    throw new Error("External custody v1 provider did not preserve the requested identity binding");
+  }
+  const registration = normalizeExternalKeyHandleRegistration(
+    subject.validRegistrationRequest,
+    raw,
+  );
+  if (registration.exportablePrivateKey !== false) {
+    throw new Error("External custody v1 providers must never export private keys");
+  }
+  if (
+    registration.signingAvailability === "provider-signing" &&
+    typeof provider.signTransaction !== "function"
+  ) {
+    throw new Error("External custody v1 provider declares signing without signTransaction");
+  }
+  const negativeProvider = subject.createProvider();
+  const contaminated: ExternalKeyHandleImportRequest = {
+    ...subject.validRegistrationRequest,
+    metadata: {
+      ...(subject.validRegistrationRequest.metadata ?? {}),
+      nested: { privateKey: "conformance-probe-must-never-reach-provider" },
+    },
+  };
+  let rejected = false;
+  try {
+    await negativeProvider.registerKeyHandle(contaminated);
+  } catch {
+    rejected = true;
+  }
+  if (!rejected) {
+    throw new Error("External custody v1 provider accepted nested private key material");
+  }
+
+  return {
+    contractVersion: 1,
+    providerId: provider.id,
+    signingAvailability: registration.signingAvailability,
+  };
+}

--- a/packages/vault/src/external-key-custody.ts
+++ b/packages/vault/src/external-key-custody.ts
@@ -2,6 +2,9 @@ import type { ChainFamily } from "@stwd/shared";
 
 export type ExternalKeySigningAvailability = "not-supported" | "provider-signing";
 
+/** Public compatibility marker for operator-supplied custody providers. */
+export const EXTERNAL_KEY_CUSTODY_CONTRACT_VERSION = 1 as const;
+
 export interface ExternalKeyHandleDescriptor {
   providerId: string;
   keyId: string;
@@ -67,6 +70,7 @@ export interface ExternalKeyHandleRegistration {
 
 export interface ExternalKeyCustodyProvider {
   id: string;
+  readonly contractVersion: typeof EXTERNAL_KEY_CUSTODY_CONTRACT_VERSION;
   registerKeyHandle(
     request: ExternalKeyHandleImportRequest,
   ): Promise<ExternalKeyHandleRegistration>;
@@ -76,6 +80,19 @@ export interface ExternalKeyCustodyProvider {
   ): Promise<ExternalKeySignTransactionResult>;
 }
 
+export function assertExternalKeyCustodyProviderV1(provider: ExternalKeyCustodyProvider): void {
+  if (provider.contractVersion !== EXTERNAL_KEY_CUSTODY_CONTRACT_VERSION) {
+    throw new Error(
+      `Unsupported external key custody contract version: ${String(provider.contractVersion)}`,
+    );
+  }
+  if (!provider.id?.trim() || typeof provider.registerKeyHandle !== "function") {
+    throw new Error(
+      "External key custody provider does not implement the v1 registration contract",
+    );
+  }
+}
+
 const PRIVATE_MATERIAL_FIELD_NAMES = new Set([
   "privatekey",
   "secretkey",
@@ -83,6 +100,7 @@ const PRIVATE_MATERIAL_FIELD_NAMES = new Set([
   "plaintextkey",
   "mnemonic",
   "seed",
+  "seedphrase",
 ]);
 
 export function externalKeyCustodyUnavailableError(): Error {
@@ -110,7 +128,10 @@ export function assertNoExternalPrivateKeyMaterial(value: unknown, path = "reque
   if (typeof value !== "object") return;
 
   for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
-    if (PRIVATE_MATERIAL_FIELD_NAMES.has(key.toLowerCase())) {
+    // Normalize separators/casing so aliases such as private_key, private-key,
+    // seedPhrase and KEY_MATERIAL cannot bypass the provider boundary.
+    const normalizedKey = key.toLowerCase().replace(/[^a-z0-9]/g, "");
+    if (PRIVATE_MATERIAL_FIELD_NAMES.has(normalizedKey)) {
       throw new Error(`External key custody ${path}.${key} must not contain private key material`);
     }
     assertNoExternalPrivateKeyMaterial(nested, `${path}.${key}`);
@@ -147,6 +168,7 @@ export function normalizeExternalKeyHandleRegistration(
 
 export class FailClosedExternalKeyCustodyProvider implements ExternalKeyCustodyProvider {
   id = "external-key-custody-disabled";
+  readonly contractVersion = EXTERNAL_KEY_CUSTODY_CONTRACT_VERSION;
 
   async registerKeyHandle(): Promise<ExternalKeyHandleRegistration> {
     throw externalKeyCustodyUnavailableError();
@@ -159,6 +181,7 @@ export class FailClosedExternalKeyCustodyProvider implements ExternalKeyCustodyP
 
 export class InMemoryExternalKeyCustodyProvider implements ExternalKeyCustodyProvider {
   id: string;
+  readonly contractVersion = EXTERNAL_KEY_CUSTODY_CONTRACT_VERSION;
   private registrations = new Map<string, ExternalKeyHandleRegistration>();
 
   constructor(id = "in-memory-external-key-custody") {

--- a/packages/vault/src/index.ts
+++ b/packages/vault/src/index.ts
@@ -1,3 +1,13 @@
+export type {
+  AwsKmsEvmRpc,
+  AwsKmsExternalKeyCustodyOptions,
+  AwsKmsSigningClientLike,
+} from "./aws-kms-external-custody";
+export {
+  AWS_KMS_EXTERNAL_CUSTODY_PROVIDER_ID,
+  AwsKmsExternalKeyCustodyProvider,
+  decodeAwsKmsEcdsaSignature,
+} from "./aws-kms-external-custody";
 export type { BitcoinPsbtOutput, SignBitcoinPsbtOptions } from "./bitcoin-psbt";
 export {
   extractBitcoinPsbtOutputs,
@@ -34,7 +44,9 @@ export type {
   ExternalKeySignTransactionResult,
 } from "./external-key-custody";
 export {
+  assertExternalKeyCustodyProviderV1,
   assertNoExternalPrivateKeyMaterial,
+  EXTERNAL_KEY_CUSTODY_CONTRACT_VERSION,
   externalKeyCustodyUnavailableError,
   externalKeyPrivateExportUnavailableError,
   externalKeySigningUnavailableError,
@@ -42,6 +54,11 @@ export {
   InMemoryExternalKeyCustodyProvider,
   normalizeExternalKeyHandleRegistration,
 } from "./external-key-custody";
+export type {
+  ExternalKeyCustodyV1ConformanceResult,
+  ExternalKeyCustodyV1ConformanceSubject,
+} from "./external-key-custody-conformance";
+export { runExternalKeyCustodyV1Conformance } from "./external-key-custody-conformance";
 export type {
   ExecutionAuthorizationConsumeCallback,
   GovernedSignTransactionOptions,

--- a/packages/vault/src/vault.ts
+++ b/packages/vault/src/vault.ts
@@ -54,6 +54,7 @@ import {
 } from "./bitcoin-psbt";
 import { allocateEvmNonce, confirmEvmNonce, markEvmNonceDropped } from "./evm-nonce-manager";
 import {
+  assertExternalKeyCustodyProviderV1,
   assertNoExternalPrivateKeyMaterial,
   type ExternalKeyCustodyProvider,
   type ExternalKeyHandleImportRequest,
@@ -441,6 +442,9 @@ export class Vault {
   private moneroBackend?: MoneroWalletBackend;
 
   constructor(config: VaultConfig) {
+    if (config.externalKeyCustodyProvider) {
+      assertExternalKeyCustodyProviderV1(config.externalKeyCustodyProvider);
+    }
     this.config = config;
     this.externalKeyCustodyProvider = config.externalKeyCustodyProvider;
     this.moneroBackend = config.moneroBackend;
@@ -1847,9 +1851,8 @@ export class Vault {
   /**
    * Register an external hardware/HSM key handle for an agent.
    *
-   * This is intentionally a custody seam only. It accepts provider-neutral
-   * handle metadata and returns the registered public identity, but signing
-   * through external handles is not wired into Vault signing paths yet and
+   * It accepts provider-neutral handle metadata and returns the registered
+   * public identity. A v1 provider may also opt into transaction signing, but
    * plaintext private key export is never available for external custody.
    */
   async importExternalKeyHandle(


### PR DESCRIPTION
## Summary

- add a versioned external-custody v1 contract and reusable provider conformance probe
- add an EVM-only AWS KMS asymmetric signer using `ECC_SECG_P256K1`, `SIGN_VERIFY`, `ECDSA_SHA_256`, and `MessageType=DIGEST`
- bind every registration and signature to the KMS-derived Ethereum address and configured region
- strictly decode DER, validate scalar ranges, normalize low-s, derive recovery parity, and verify the registered address before return/broadcast
- wire external custody through a separate `STEWARD_EXTERNAL_CUSTODY_PROVIDER=aws-kms` registry path without changing envelope-KMS semantics
- document setup, IAM boundary, unsupported modes, and the precise custody posture

No private key, mnemonic, seed phrase, plaintext key, or key material is accepted by the external-custody boundary. Steward stores only an opaque KMS handle and verified public address.

## Security behavior

The adapter fails closed on unsupported chain/key modes, region/address mismatch, malformed/non-canonical/out-of-range signatures, wrong-key recovery, high-s output (normalized), semantic RPC mutation, missing RPC/KMS responses, and broadcast-before-verification. Solana, Bitcoin, messages, typed data, user operations, and arbitrary hash signing are not exposed by this reference provider.

## Exact-head validation

Validated on `e44793809a63b89c23f55b175cb6f90222af3990`:

- `bun test packages/vault/src/__tests__/aws-kms-external-custody.test.ts packages/vault/src/__tests__/external-key-custody-contract.test.ts packages/api/src/__tests__/vault-factory.test.ts` — 29 pass, 0 fail, 153 assertions
- `bun test packages/vault/src/__tests__/external-key-custody.test.ts -t "delegates transaction signing|backend binding mismatch|still routes to the provider"` — 3 pass, 0 fail, 15 assertions
- `bunx turbo run build --filter=@stwd/vault --filter=@stwd/api` — 21/21 tasks successful
- `git diff --check` — clean

AWS interactions are hermetically exercised through a mock SDK client; live AWS credentials and key creation are intentionally not required by this test suite.

Closes #214