### PR TITLE
fix(deploy): serialize and pin staging images

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -36,13 +36,24 @@ permissions:
   contents: read
   deployments: write
 
+# Railway deploys mutate one shared staging service. Serialize manual and
+# automatic requests so two close develop pushes cannot race each other.
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: false
+
 jobs:
   deploy-staging:
     runs-on: ubuntu-latest
-    # On workflow_run, only proceed if the upstream Docker build succeeded.
+    # On workflow_run, deploy only a successful Docker build for the commit
+    # that is still at the tip of develop. GITHUB_SHA for workflow_run is the
+    # default-branch tip when this downstream run is created; without this
+    # equality check, a slower Docker run for an older push can deploy after a
+    # newer commit has already landed.
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+      (github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_sha == github.sha)
 
     steps:
       - name: Checkout
@@ -52,9 +63,16 @@ jobs:
         id: resolve
         env:
           DISPATCH_TAG: ${{ inputs.image_tag }}
+          EVENT_NAME: ${{ github.event_name }}
+          UPSTREAM_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          # Manual dispatch may override the tag; auto runs always use `develop`.
-          TAG="${DISPATCH_TAG:-develop}"
+          # Automatic runs deploy the immutable tag built by the exact upstream
+          # Docker run. Manual dispatches retain the operator-selected tag.
+          if [[ "$EVENT_NAME" == "workflow_run" ]]; then
+            TAG="sha-${UPSTREAM_SHA}"
+          else
+            TAG="${DISPATCH_TAG:-develop}"
+          fi
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "Staging image tag: ${TAG}"
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,6 +19,12 @@ on:
       - "packages/**/package.json"
       - ".github/workflows/docker.yml"
 
+# A branch tag is mutable. Do not let a slower build for an older push finish
+# after a newer build and overwrite `:develop` / `:main` with stale bytes.
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
@@ -63,6 +69,8 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            # Immutable tag consumed by the staging workflow.
+            type=sha,format=long
 
       # Build pull requests to validate the Dockerfile; publish images for pushes
       # to develop and version tags so deploys can pull the expected tags.


### PR DESCRIPTION
## Summary
- cancel superseded Docker builds for the same ref so stale builds cannot overwrite mutable branch tags
- publish a full immutable `sha-<commit>` image tag from every Docker build
- skip staging deploys for Docker workflow completions that are no longer the `develop` tip
- serialize staging mutations and deploy the exact upstream SHA tag
- upgrade `actions/checkout` and `actions/setup-node` to their official Node 24 majors across all workflows

## Failure/race evidence
Consecutive develop Docker runs `31975671184` and `31975679428` spawned overlapping staging runs `31976043328` and `31976050487` against the same mutable `develop` tag. Both happened to succeed, but they mutated the same Railway service concurrently and did not prove which commit was deployed. Exact-head PR checks also emitted GitHub deprecation warnings for every Node-20 `actions/checkout@v4` / `actions/setup-node@v4` invocation.

## Local validation
- `actionlint .github/workflows/*.yml`
- `bun run lint`
- `git diff --check`
- verified official v7 action manifests use `node24`
