### PR TITLE
feat(cli): add operational integrity doctor checks

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -67602,6 +67602,185 @@
         }
       }
     },
+    "/audit/integrity": {
+      "get": {
+        "tags": [
+          "Audits"
+        ],
+        "summary": "Verify audit chain and latest checkpoint at the current head",
+        "description": "Requires an owner/admin browser session with recent MFA. Used by steward doctor to verify the live HMAC chain and the newest persisted Ed25519 checkpoint without returning signing or HMAC key material.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "valid",
+                    "chainValid",
+                    "checkpointPresent",
+                    "checkpointValid",
+                    "checkpointAtHead",
+                    "checkpointSeq",
+                    "chainHeadSeq"
+                  ],
+                  "properties": {
+                    "valid": {
+                      "type": "boolean"
+                    },
+                    "chainValid": {
+                      "type": "boolean"
+                    },
+                    "checkpointPresent": {
+                      "type": "boolean"
+                    },
+                    "checkpointValid": {
+                      "type": "boolean"
+                    },
+                    "checkpointAtHead": {
+                      "type": "boolean"
+                    },
+                    "checkpointSeq": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "chainHeadSeq": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/secrets": {
       "get": {
         "tags": [

--- a/packages/api/src/__tests__/audit-bundle.integration.test.ts
+++ b/packages/api/src/__tests__/audit-bundle.integration.test.ts
@@ -6,11 +6,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { auditCheckpoints, closeDb, getDb, tenants } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { writeAuditEvent } from "../services/audit";
 import { resetCheckpointSignerCache } from "../services/audit-checkpoint";
 import type { AppVariables } from "../services/context";
+import { inspectGovernedRoutes } from "../services/governed-route-inventory";
 
 const TENANT_ID = "audit-bundle-tenant";
 const OTHER_TENANT_ID = "audit-bundle-other-tenant";
@@ -169,6 +170,99 @@ describe("audit evidence bundle endpoint + offline verifier", () => {
     expect(rows.length).toBeGreaterThanOrEqual(1);
     expect(rows[0].signature.length).toBeGreaterThan(0);
     expect(rows[0].publicKey).toContain("BEGIN PUBLIC KEY");
+  });
+
+  it("doctor integrity requires a valid checkpoint at the current chain head", async () => {
+    await fetchBundle();
+    const current = await app().request("/audit/integrity");
+    expect(current.status).toBe(200);
+    expect(await current.json()).toMatchObject({
+      ok: true,
+      data: {
+        valid: true,
+        chainValid: true,
+        checkpointPresent: true,
+        checkpointValid: true,
+        checkpointAtHead: true,
+        checkpointSeq: 4,
+        chainHeadSeq: 4,
+      },
+    });
+
+    await writeAuditEvent({
+      tenantId: TENANT_ID,
+      actorType: "system",
+      action: "doctor.checkpoint.stale",
+      metadata: {},
+    });
+    const stale = await app().request("/audit/integrity");
+    expect(stale.status).toBe(200);
+    expect(await stale.json()).toMatchObject({
+      ok: true,
+      data: {
+        valid: false,
+        chainValid: true,
+        checkpointValid: true,
+        checkpointAtHead: false,
+        checkpointSeq: 4,
+        chainHeadSeq: 5,
+      },
+    });
+
+    // Restore a current checkpoint so the remaining bundle/verifier tests run
+    // against the new five-event head.
+    await fetchBundle();
+  });
+
+  it("shared governed-route inventory detects an enabled legacy bypass", async () => {
+    await getDb().execute(sql`
+      INSERT INTO users (id, email)
+      VALUES ('55555555-5555-4555-8555-555555555555', 'doctor@example.invalid')
+    `);
+    await getDb().execute(sql`
+      INSERT INTO workspaces (id, tenant_id, key, name, environment, created_by)
+      VALUES ('44444444-4444-4444-8444-444444444444', ${TENANT_ID},
+        'doctor', 'Doctor', 'development', '55555555-5555-4555-8555-555555555555')
+    `);
+    await getDb().execute(sql`
+      INSERT INTO provider_accounts
+        (id, tenant_id, workspace_id, adapter_key, external_ref, display_name)
+      VALUES ('66666666-6666-4666-8666-666666666666', ${TENANT_ID},
+        '44444444-4444-4444-8444-444444444444', 'slack', 'doctor', 'Doctor')
+    `);
+    await getDb().execute(sql`
+      INSERT INTO provider_operations
+        (id, tenant_id, workspace_id, provider_account_id, operation_key, risk_class)
+      VALUES ('33333333-3333-4333-8333-333333333333', ${TENANT_ID},
+        '44444444-4444-4444-8444-444444444444',
+        '66666666-6666-4666-8666-666666666666', 'doctor.test', 'read')
+    `);
+    await getDb().execute(sql`
+      INSERT INTO secret_routes
+        (tenant_id, secret_id, host_pattern, path_pattern, method, inject_as, inject_key,
+         enabled, authority_mode, provider_operation_id)
+      VALUES
+        (${TENANT_ID}, '11111111-1111-4111-8111-111111111111', 'slack.com', '/api/*', 'POST',
+         'header', 'Authorization', TRUE, 'legacy', NULL),
+        (${TENANT_ID}, '22222222-2222-4222-8222-222222222222', 'slack.com', '/api/*', 'POST',
+         'header', 'Authorization', TRUE, 'governed_v2',
+         '33333333-3333-4333-8333-333333333333')
+    `);
+    const inventory = await inspectGovernedRoutes();
+    expect(inventory).toMatchObject({
+      governedRoutes: 1,
+      nullOperationRoutes: 0,
+      dualModeRoutes: 1,
+      ok: false,
+    });
+    await getDb().execute(sql`DELETE FROM secret_routes WHERE tenant_id = ${TENANT_ID}`);
+    await getDb().execute(sql`
+      DELETE FROM workspaces
+      WHERE id = '44444444-4444-4444-8444-444444444444'
+    `);
+    await getDb().execute(sql`
+      DELETE FROM users WHERE id = '55555555-5555-4555-8555-555555555555'
+    `);
   });
 
   it("PASSES the standalone offline verifier for a genuine bundle", async () => {

--- a/packages/api/src/__tests__/openapi-contract.test.ts
+++ b/packages/api/src/__tests__/openapi-contract.test.ts
@@ -96,6 +96,7 @@ describe("generated OpenAPI contract", () => {
     expect(spec.paths).toHaveProperty("/audit/export");
     expect(spec.paths).toHaveProperty("/audit/events");
     expect(spec.paths).toHaveProperty("/audit/verify");
+    expect(spec.paths).toHaveProperty("/audit/integrity");
     expect(spec.paths).toHaveProperty("/intents");
     expect(spec.paths).toHaveProperty("/intents/{intentId}/approve");
     expect(spec.paths).toHaveProperty("/v1/intents/{intentId}/approve");

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -13,11 +13,11 @@
  */
 
 import { validateJwtSecretEnv } from "@stwd/auth";
-import { closeDb, getDb, runMigrations } from "@stwd/db";
+import { closeDb, getDb, getMigrationExpectation, runMigrations } from "@stwd/db";
 import { shouldUsePGLite } from "@stwd/db/pglite";
 import { sql } from "drizzle-orm";
 import { composeApp } from "./compose";
-import { initRedis, shutdownRedis } from "./middleware/redis";
+import { getRedisClient, initRedis, shutdownRedis } from "./middleware/redis";
 import { getAuthStoreSources, initAuthStores } from "./routes/auth";
 import {
   API_VERSION,
@@ -26,6 +26,7 @@ import {
   RATE_LIMIT_MAX_REQUESTS,
   RATE_LIMIT_WINDOW_MS,
 } from "./services/context";
+import { inspectGovernedRoutes } from "./services/governed-route-inventory";
 import { startRetentionScheduler } from "./services/retention";
 import { startTransactionReceiptPollingScheduler } from "./services/transaction-receipt-poller";
 import { configuredVaultStartupLogLine, getConfiguredVault } from "./services/vault-factory";
@@ -106,16 +107,88 @@ const requestLogCleanupTimer = setInterval(() => {
 // on the Cloudflare control plane for instance health.
 
 app.get("/ready", async (c) => {
-  const checks: Record<string, { ok: boolean; error?: string; source?: string }> = {};
+  const checks: Record<
+    string,
+    { ok: boolean; required?: boolean; error?: string; source?: string; detail?: unknown }
+  > = {};
 
-  checks.migrations = { ok: migrationsRan };
+  const expectedMigration = getMigrationExpectation();
+  checks.migrations = { ok: false, detail: { expected: expectedMigration.tag } };
 
   try {
     const db = getDb();
-    await db.execute(sql`SELECT 1`);
-    checks.database = { ok: true };
+    const result = await db.execute(sql`
+      SELECT
+        EXTRACT(EPOCH FROM clock_timestamp()) * 1000 AS database_time_ms,
+        (SELECT MAX(created_at) FROM drizzle.__drizzle_migrations) AS migration_created_at
+    `);
+    const rows = Array.isArray(result)
+      ? result
+      : ((result as unknown as { rows?: unknown[] }).rows ?? []);
+    const row = rows[0] as
+      | { database_time_ms?: string | number; migration_created_at?: string | number | null }
+      | undefined;
+    const databaseTimeMs = Number(row?.database_time_ms);
+    const migrationCreatedAt = Number(row?.migration_created_at);
+    const databaseSkewMs = Math.abs(Date.now() - databaseTimeMs);
+    checks.database = {
+      ok: Number.isFinite(databaseTimeMs) && databaseSkewMs <= 30_000,
+      detail: { clockSkewMs: Math.round(databaseSkewMs), serverTime: new Date().toISOString() },
+    };
+    checks.migrations = {
+      ok: migrationsRan && migrationCreatedAt === expectedMigration.createdAt,
+      detail: {
+        expected: expectedMigration.tag,
+        expectedCreatedAt: expectedMigration.createdAt,
+        actualCreatedAt: Number.isFinite(migrationCreatedAt) ? migrationCreatedAt : null,
+      },
+    };
   } catch (err: unknown) {
     checks.database = { ok: false, error: err instanceof Error ? err.message : "unknown" };
+  }
+
+  try {
+    const redis = getRedisClient();
+    checks.redis = redis
+      ? { ok: (await redis.ping()).toUpperCase() === "PONG" }
+      : { ok: false, error: "Redis is not connected" };
+  } catch (err: unknown) {
+    checks.redis = { ok: false, error: err instanceof Error ? err.message : "unknown" };
+  }
+
+  try {
+    const inventory = await inspectGovernedRoutes();
+    checks.governedRoutes = { ok: inventory.ok, detail: inventory };
+  } catch (err: unknown) {
+    checks.governedRoutes = {
+      ok: false,
+      error: err instanceof Error ? err.message : "unknown",
+    };
+  }
+
+  const proxyUrl = process.env.STEWARD_PROXY_URL?.replace(/\/+$/, "");
+  if (!proxyUrl) {
+    checks.proxyClock = {
+      ok: false,
+      required: false,
+      error: "STEWARD_PROXY_URL not configured",
+    };
+  } else {
+    try {
+      const startedAt = Date.now();
+      const response = await fetch(`${proxyUrl}/health`, { signal: AbortSignal.timeout(3_000) });
+      const body = (await response.json()) as { serverTime?: unknown };
+      const endedAt = Date.now();
+      const proxyTime = Date.parse(String(body.serverTime ?? ""));
+      const midpoint = startedAt + (endedAt - startedAt) / 2;
+      const skewMs = Math.abs(proxyTime - midpoint);
+      checks.proxyClock = {
+        ok: response.ok && Number.isFinite(proxyTime) && skewMs <= 30_000,
+        detail: { clockSkewMs: Math.round(skewMs) },
+      };
+    } catch (err: unknown) {
+      checks.proxyClock = { ok: false, error: err instanceof Error ? err.message : "unknown" };
+    }
   }
 
   if (!process.env.STEWARD_MASTER_PASSWORD) {
@@ -136,7 +209,7 @@ app.get("/ready", async (c) => {
       : {}),
   };
 
-  const allOk = Object.values(checks).every((c) => c.ok);
+  const allOk = Object.values(checks).every((check) => check.ok || check.required === false);
   return c.json(
     {
       status: allOk ? "ready" : "not_ready",

--- a/packages/api/src/openapi.ts
+++ b/packages/api/src/openapi.ts
@@ -2943,6 +2943,39 @@ function auditPaths(prefix = ""): Record<string, unknown> {
         },
       },
     },
+    [`${prefix}/audit/integrity`]: {
+      get: {
+        tags: ["Audits"],
+        summary: "Verify audit chain and latest checkpoint at the current head",
+        description:
+          "Requires an owner/admin browser session with recent MFA. Used by steward doctor to verify the live HMAC chain and the newest persisted Ed25519 checkpoint without returning signing or HMAC key material.",
+        security: [{ bearerAuth: [] }],
+        responses: {
+          "200": jsonResponse({
+            type: "object",
+            required: [
+              "valid",
+              "chainValid",
+              "checkpointPresent",
+              "checkpointValid",
+              "checkpointAtHead",
+              "checkpointSeq",
+              "chainHeadSeq",
+            ],
+            properties: {
+              valid: { type: "boolean" },
+              chainValid: { type: "boolean" },
+              checkpointPresent: { type: "boolean" },
+              checkpointValid: { type: "boolean" },
+              checkpointAtHead: { type: "boolean" },
+              checkpointSeq: { type: ["integer", "null"] },
+              chainHeadSeq: { type: ["integer", "null"] },
+            },
+          }),
+          ...errorResponses(),
+        },
+      },
+    },
   };
 }
 

--- a/packages/api/src/routes/audit.ts
+++ b/packages/api/src/routes/audit.ts
@@ -5,7 +5,7 @@
  * Mount: app.route("/audit", auditRoutes)
  */
 
-import { proxyAuditLog } from "@stwd/db";
+import { auditChainHeads, auditCheckpoints, proxyAuditLog } from "@stwd/db";
 import { and, count, desc, eq, gte, inArray, lte, type SQL, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { auditOwnerAdminMfaGate } from "../middleware/audit-gate";
@@ -15,7 +15,12 @@ import {
   signAuditBundle,
   verifyAuditChain,
 } from "../services/audit";
-import { AuditSigningKeyError, isCheckpointSigningConfigured } from "../services/audit-checkpoint";
+import {
+  AuditSigningKeyError,
+  isCheckpointSigningConfigured,
+  type SignedCheckpoint,
+  verifyCheckpoint,
+} from "../services/audit-checkpoint";
 import {
   type ApiResponse,
   type AppVariables,
@@ -799,6 +804,57 @@ auditRoutes.post("/verify", async (c) => {
         fromSeq === 1
           ? undefined
           : "Partial verification is anchored to the stored predecessor hash and is not proof that earlier audit rows are intact.",
+    },
+  });
+});
+
+// ─── GET /audit/integrity ───────────────────────────────────────────────────
+//
+// A bounded operator diagnostic: verify the full live HMAC chain, then verify
+// the newest persisted Ed25519 checkpoint and require it to commit to the
+// current chain head. The normal audit owner/admin + recent-MFA gate above
+// applies; no HMAC key or private signing material is returned.
+auditRoutes.get("/integrity", async (c) => {
+  const tenantId = c.get("tenantId");
+  const chain = await verifyAuditChain(tenantId, { requireHead: true });
+  const [head] = await db
+    .select({ seq: auditChainHeads.expectedSeq, hmac: auditChainHeads.headHmac })
+    .from(auditChainHeads)
+    .where(eq(auditChainHeads.tenantId, tenantId))
+    .limit(1);
+  const [row] = await db
+    .select()
+    .from(auditCheckpoints)
+    .where(eq(auditCheckpoints.tenantId, tenantId))
+    .orderBy(desc(auditCheckpoints.seq), desc(auditCheckpoints.id))
+    .limit(1);
+
+  let checkpointValid = false;
+  let checkpointAtHead = false;
+  if (row && head) {
+    const checkpoint: SignedCheckpoint = {
+      payload: row.payload as unknown as SignedCheckpoint["payload"],
+      signature: row.signature,
+      publicKey: row.publicKey,
+    };
+    checkpointValid = verifyCheckpoint(checkpoint);
+    checkpointAtHead =
+      row.seq === Number(head.seq) &&
+      Buffer.from(row.headHmac).toString("hex") === Buffer.from(head.hmac).toString("hex") &&
+      checkpoint.payload.seq === Number(head.seq) &&
+      checkpoint.payload.headHmac === Buffer.from(head.hmac).toString("hex");
+  }
+
+  return c.json<ApiResponse>({
+    ok: true,
+    data: {
+      valid: chain.valid && checkpointValid && checkpointAtHead,
+      chainValid: chain.valid,
+      checkpointPresent: Boolean(row),
+      checkpointValid,
+      checkpointAtHead,
+      checkpointSeq: row?.seq ?? null,
+      chainHeadSeq: head ? Number(head.seq) : null,
     },
   });
 });

--- a/packages/api/src/services/governed-route-inventory.ts
+++ b/packages/api/src/services/governed-route-inventory.ts
@@ -1,0 +1,65 @@
+import { getDb, sql } from "@stwd/db";
+
+export type GovernedRouteInventory = {
+  governedRoutes: number;
+  nullOperationRoutes: number;
+  dualModeRoutes: number;
+  ok: boolean;
+};
+
+function rowsFromExecute<T>(result: unknown): T[] {
+  if (Array.isArray(result)) return result as T[];
+  if (result && typeof result === "object" && "rows" in result) {
+    const rows = (result as { rows?: unknown }).rows;
+    if (Array.isArray(rows)) return rows as T[];
+  }
+  return [];
+}
+
+/**
+ * Single source for the runtime doctor and PR7's static/runtime route guard.
+ * A dual-mode match is the same tenant/agent/host/path/method credential route
+ * exposed once through legacy authority and once through governed authority.
+ */
+export async function inspectGovernedRoutes(): Promise<GovernedRouteInventory> {
+  const db = getDb();
+  const [row = { governed: 0, null_operations: 0, dual_mode: 0 }] = rowsFromExecute<{
+    governed: number;
+    null_operations: number;
+    dual_mode: number;
+  }>(
+    await db.execute(sql`
+      WITH route_counts AS (
+        SELECT
+          tenant_id,
+          COALESCE(agent_id, '') AS agent_id,
+          host_pattern,
+          COALESCE(path_pattern, '/*') AS path_pattern,
+          COALESCE(method, '*') AS method,
+          BOOL_OR(authority_mode = 'legacy') AS has_legacy,
+          BOOL_OR(authority_mode = 'governed_v2') AS has_governed
+        FROM secret_routes
+        WHERE enabled = TRUE
+        GROUP BY tenant_id, COALESCE(agent_id, ''), host_pattern,
+          COALESCE(path_pattern, '/*'), COALESCE(method, '*')
+      )
+      SELECT
+        (SELECT COUNT(*)::int FROM secret_routes
+          WHERE enabled = TRUE AND authority_mode = 'governed_v2') AS governed,
+        (SELECT COUNT(*)::int FROM secret_routes
+          WHERE enabled = TRUE AND authority_mode = 'governed_v2'
+            AND provider_operation_id IS NULL) AS null_operations,
+        (SELECT COUNT(*)::int FROM route_counts
+          WHERE has_legacy AND has_governed) AS dual_mode
+    `),
+  );
+  const governedRoutes = Number(row.governed);
+  const nullOperationRoutes = Number(row.null_operations);
+  const dualModeRoutes = Number(row.dual_mode);
+  return {
+    governedRoutes,
+    nullOperationRoutes,
+    dualModeRoutes,
+    ok: nullOperationRoutes === 0 && dualModeRoutes === 0,
+  };
+}

--- a/packages/cli/src/__tests__/doctor.test.ts
+++ b/packages/cli/src/__tests__/doctor.test.ts
@@ -12,7 +12,37 @@ import { describeSecret } from "../format";
 function stubApi(): StewardApiClient {
   return {
     baseUrl: "http://stub.local",
-    request: async () => ({ ok: true }),
+    request: async (_method: string, path: string) => {
+      if (path === "/ready") {
+        return {
+          checks: {
+            migrations: { ok: true, detail: { expected: "journal-tip" } },
+            redis: { ok: true },
+            governedRoutes: {
+              ok: true,
+              detail: { governedRoutes: 1, nullOperationRoutes: 0, dualModeRoutes: 0 },
+            },
+            proxyClock: { ok: true, detail: { clockSkewMs: 2 } },
+            database: {
+              ok: true,
+              detail: { clockSkewMs: 1, serverTime: new Date().toISOString() },
+            },
+          },
+        };
+      }
+      if (path === "/audit/integrity") {
+        return {
+          valid: true,
+          chainValid: true,
+          checkpointPresent: true,
+          checkpointValid: true,
+          checkpointAtHead: true,
+          checkpointSeq: 4,
+          chainHeadSeq: 4,
+        };
+      }
+      return { ok: true };
+    },
   } as unknown as StewardApiClient;
 }
 
@@ -162,5 +192,51 @@ describe("PR6 governed-route prerequisites (strict)", () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("operator-integrity diagnostics", () => {
+  test("strict mode fails closed for every unavailable or failed operational check", async () => {
+    const api = {
+      baseUrl: "http://stub.local",
+      request: async (_method: string, path: string) => {
+        if (path === "/ready") {
+          return {
+            checks: {
+              migrations: { ok: false, detail: { expected: "0084", actual: "0083" } },
+              redis: { ok: false, error: "unreachable" },
+              governedRoutes: { ok: false, detail: { nullOperationRoutes: 1 } },
+              proxyClock: { ok: false, detail: { clockSkewMs: 60_000 } },
+              database: {
+                ok: false,
+                detail: { clockSkewMs: 60_000, serverTime: new Date().toISOString() },
+              },
+            },
+          };
+        }
+        if (path === "/audit/integrity") {
+          return {
+            valid: false,
+            chainValid: true,
+            checkpointPresent: true,
+            checkpointValid: true,
+            checkpointAtHead: false,
+          };
+        }
+        return { ok: true };
+      },
+    } as unknown as StewardApiClient;
+    const result = await runDoctor({ strict: true, api });
+    for (const name of [
+      "ops:migration-tip",
+      "ops:redis-reachability",
+      "ops:governed-route-inventory",
+      "ops:proxy-clock-skew",
+      "ops:api-database-clock-skew",
+      "ops:audit-checkpoint-integrity",
+    ]) {
+      expect(result.checks.find((check) => check.name === name)?.ok).toBe(false);
+    }
+    expect(result.ok).toBe(false);
   });
 });

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -15,6 +15,21 @@ export type DoctorOptions = {
   api?: StewardApiClient;
 };
 
+type ReadyCheck = { ok?: unknown; error?: unknown; detail?: unknown };
+type ReadyResponse = {
+  checks?: Record<string, ReadyCheck>;
+};
+
+function operationalDetail(check: ReadyCheck | undefined, fallback: string): string {
+  if (!check) return fallback;
+  if (typeof check.error === "string") return check.error;
+  return check.detail === undefined
+    ? check.ok === true
+      ? "ok"
+      : fallback
+    : JSON.stringify(check.detail);
+}
+
 function parseEnv(path: string): Record<string, string> {
   if (!existsSync(path)) return {};
   const out: Record<string, string> = {};
@@ -90,10 +105,81 @@ export async function runDoctor(
     checks.push({ name: "api:/health", ok: !options.strict, detail: (error as Error).message });
   }
   try {
-    const ready = await api.request("GET", "/ready", undefined, { tenant: false });
+    const requestedAt = Date.now();
+    const ready = await api.request<ReadyResponse>("GET", "/ready", undefined, { tenant: false });
+    const receivedAt = Date.now();
     checks.push({ name: "api:/ready", ok: true, detail: JSON.stringify(ready) });
+    const readyChecks = ready.checks ?? {};
+    for (const [name, source] of [
+      ["ops:migration-tip", readyChecks.migrations],
+      ["ops:redis-reachability", readyChecks.redis],
+      ["ops:governed-route-inventory", readyChecks.governedRoutes],
+      ["ops:proxy-clock-skew", readyChecks.proxyClock],
+    ] as const) {
+      checks.push({
+        name,
+        ok: source?.ok === true || (!options.strict && source?.ok !== false),
+        detail: operationalDetail(source, "diagnostic unavailable"),
+      });
+    }
+    const databaseDetail = readyChecks.database?.detail as
+      | { clockSkewMs?: unknown; serverTime?: unknown }
+      | undefined;
+    const apiTime = Date.parse(String(databaseDetail?.serverTime ?? ""));
+    const midpoint = requestedAt + (receivedAt - requestedAt) / 2;
+    const apiSkewMs = Math.abs(apiTime - midpoint);
+    const dbSkewMs = Number(databaseDetail?.clockSkewMs);
+    const clocksOk =
+      Number.isFinite(apiSkewMs) &&
+      apiSkewMs <= 30_000 &&
+      Number.isFinite(dbSkewMs) &&
+      dbSkewMs <= 30_000;
+    checks.push({
+      name: "ops:api-database-clock-skew",
+      ok: clocksOk || !options.strict,
+      detail: JSON.stringify({ apiSkewMs: Math.round(apiSkewMs), databaseSkewMs: dbSkewMs }),
+    });
   } catch (error) {
     checks.push({ name: "api:/ready", ok: !options.strict, detail: (error as Error).message });
+    for (const name of [
+      "ops:migration-tip",
+      "ops:redis-reachability",
+      "ops:governed-route-inventory",
+      "ops:proxy-clock-skew",
+      "ops:api-database-clock-skew",
+    ]) {
+      checks.push({ name, ok: !options.strict, detail: "unavailable because /ready failed" });
+    }
+  }
+
+  try {
+    const integrity = await api.request<{
+      valid?: unknown;
+      chainValid?: unknown;
+      checkpointPresent?: unknown;
+      checkpointValid?: unknown;
+      checkpointAtHead?: unknown;
+      checkpointSeq?: unknown;
+      chainHeadSeq?: unknown;
+    }>("GET", "/audit/integrity");
+    checks.push({
+      name: "ops:audit-checkpoint-integrity",
+      ok: integrity.valid === true || !options.strict,
+      detail: JSON.stringify({
+        chainValid: integrity.chainValid === true,
+        checkpointPresent: integrity.checkpointPresent === true,
+        checkpointValid: integrity.checkpointValid === true,
+        checkpointAtHead: integrity.checkpointAtHead === true,
+        checkpointSeq: integrity.checkpointSeq ?? null,
+        chainHeadSeq: integrity.chainHeadSeq ?? null,
+      }),
+    });
+  } catch (error) {
+    checks.push({
+      name: "ops:audit-checkpoint-integrity",
+      ok: !options.strict,
+      detail: (error as Error).message,
+    });
   }
 
   return { ok: checks.every((check) => check.ok), checks };

--- a/packages/db/src/__tests__/migration-status.test.ts
+++ b/packages/db/src/__tests__/migration-status.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { getMigrationExpectation } from "../migration-status";
+
+describe("migration expectation", () => {
+  test("is derived from the checked-in journal tip", () => {
+    const journal = JSON.parse(
+      readFileSync(new URL("../../drizzle/meta/_journal.json", import.meta.url), "utf8"),
+    ) as { entries: Array<{ tag: string; when: number }> };
+    const tip = journal.entries.at(-1);
+    expect(tip).toBeDefined();
+    expect(getMigrationExpectation()).toEqual({
+      tag: tip?.tag,
+      createdAt: tip?.when,
+      count: journal.entries.length,
+    });
+  });
+});

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -34,6 +34,7 @@ export {
   setPGLiteOverride,
 } from "./client";
 export { runMigrations } from "./migrate";
+export { getMigrationExpectation, type MigrationExpectation } from "./migration-status";
 export { encryptOAuthAccountPlaintextTokens } from "./oauth-token-encryption";
 export {
   pluginAdvisoryLockKey,

--- a/packages/db/src/migration-status.ts
+++ b/packages/db/src/migration-status.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+
+export type MigrationExpectation = {
+  tag: string;
+  createdAt: number;
+  count: number;
+};
+
+type Journal = { entries?: Array<{ tag?: unknown; when?: unknown }> };
+
+/**
+ * Return the checked-in migration tip. Reading the journal keeps operational
+ * diagnostics aligned with the migrator instead of duplicating a tag that
+ * becomes stale whenever a migration is added.
+ */
+export function getMigrationExpectation(): MigrationExpectation {
+  const path = new URL("../drizzle/meta/_journal.json", import.meta.url);
+  const journal = JSON.parse(readFileSync(path, "utf8")) as Journal;
+  const entries = journal.entries ?? [];
+  const last = entries.at(-1);
+  if (!last || typeof last.tag !== "string" || typeof last.when !== "number") {
+    throw new Error("migration journal has no valid tip");
+  }
+  return { tag: last.tag, createdAt: last.when, count: entries.length };
+}

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -50,6 +50,7 @@ app.get("/health", (c) =>
     ok: true,
     service: "steward-proxy",
     version: "0.3.0",
+    serverTime: new Date().toISOString(),
     aliases: getAliasNames(),
   }),
 );


### PR DESCRIPTION
Closes #211

## Summary
- derive the expected migration tip from the checked-in Drizzle journal and compare it to the live DB journal
- expose Redis, DB/API/proxy clock, and shared governed-route inventory diagnostics through readiness
- add an owner/admin + recent-MFA audit-integrity endpoint that verifies the live HMAC chain and requires a valid Ed25519 checkpoint at the current head
- make `steward doctor --strict` fail closed for every operational diagnostic while retaining non-strict warning behavior
- add the proxy server time and generated OpenAPI contract

## Validation
- API/DB/proxy/CLI filtered build (22/22 tasks after type fixes)
- `bun test packages/cli/src/__tests__/doctor.test.ts` (6/6)
- `bun test packages/db/src/__tests__/migration-status.test.ts` (1/1)
- `bun test packages/api/src/__tests__/audit-bundle.integration.test.ts` (12/12)
- `bun test packages/api/src/__tests__/openapi-contract.test.ts` (8/8)
- focused Biome check and `git diff --check`