### PR TITLE
feat(audit): add optional RFC 3161 checkpoint anchoring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,14 @@ AGENT_TOKEN_EXPIRY=24h
 # different trust boundary than the database it audits.
 # Generate with: openssl rand -hex 32
 STEWARD_AUDIT_HMAC_KEY=
+# Optional RFC 3161 anchoring for Ed25519 audit checkpoints. Default `off`
+# performs no network request and does not add fields to evidence bundles.
+# `best-effort` emits an unanchored bundle if the TSA is unavailable;
+# `required` fails evidence generation closed instead.
+# STEWARD_AUDIT_CHECKPOINT_ANCHOR_MODE=off
+# STEWARD_AUDIT_CHECKPOINT_ANCHOR_PROVIDER=rfc3161
+# STEWARD_AUDIT_RFC3161_URL=https://tsa.example.com/timestamp
+# STEWARD_AUDIT_RFC3161_TIMEOUT_MS=10000
 
 # STEWARD_EXECUTION_AUTH_SECRET (PR4): key for provider execution
 # authorization v2. SEPARATE from STEWARD_JWT_SECRET (never a fallback).

--- a/docs/api-reference/audits.mdx
+++ b/docs/api-reference/audits.mdx
@@ -159,6 +159,19 @@ controls all relevant audit and signing keys could not fabricate a
 self-consistent history. A partial export also does not prove completeness
 outside the exported range.
 
+Deployments can opt into RFC 3161 third-party checkpoint timestamps. Verify an
+included proof with auditor-supplied TSA trust material:
+
+```bash
+node scripts/verify-evidence-bundle.mjs bundle.json \
+  --tsa-ca auditor-trusted-tsa-ca.pem \
+  --require-anchor
+```
+
+The verified timestamp shows that the checkpoint existed no later than the TSA
+time, narrowing the pre-anchor rewrite window. It is not a tamper-proof or
+operator-proof guarantee. See [third-party audit-checkpoint anchoring](/security/audit-checkpoint-anchoring).
+
 ## Common Filters
 
 | Use case | Query |

--- a/docs/concepts/audit-logging.mdx
+++ b/docs/concepts/audit-logging.mdx
@@ -157,6 +157,7 @@ Steward's audit log supports compliance requirements:
 - **Retention**: configurable per tenant
 - **Export**: API endpoints for event export and signed evidence bundles
 - **Trust limit**: an operator controlling all relevant keys can fabricate a self-consistent history
+- **Optional third-party time bound**: RFC 3161 anchoring can prove a checkpoint existed no later than a trusted TSA time, narrowing but not eliminating the pre-anchor rewrite window
 
 ## Related
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -7,7 +7,7 @@ Steward is an open-source, self-hostable governed credential proxy and policy an
 
 Steward runs in your infrastructure. Configured provider calls can receive credentials at the proxy without returning those credentials to the supported agent caller. Governed wallet routes evaluate policy and approval before signing. The primary EVM transaction sign path adds a signed, short-lived, payload-bound, single-use authorization immediately before raw signing.
 
-Steward also maintains a tenant-scoped HMAC audit chain and exports Ed25519-signed evidence bundles. Verify a bundle offline with `scripts/verify-evidence-bundle.mjs <bundle.json>`. The script checks the signature against the public key carried in the bundle. Separately compare that key with an out-of-band trusted Steward signing key or fingerprint. Verification detects changes relative to that trust root. It does not exclude fabrication by an operator controlling all relevant keys.
+Steward also maintains a tenant-scoped HMAC audit chain and exports Ed25519-signed evidence bundles. Verify a bundle offline with `scripts/verify-evidence-bundle.mjs <bundle.json>`. The script checks the signature against the public key carried in the bundle. Separately compare that key with an out-of-band trusted Steward signing key or fingerprint. Optional RFC 3161 anchoring can add an auditor-verifiable third-party time bound. Verification detects changes relative to those trust roots; it does not make the system operator-proof.
 
 <CardGroup cols={2}>
   <Card title="Wallet vault" icon="vault" href="/concepts/wallet-vault">

--- a/docs/security/audit-checkpoint-anchoring.md
+++ b/docs/security/audit-checkpoint-anchoring.md
@@ -1,0 +1,69 @@
+# Third-party audit-checkpoint anchoring
+
+Steward can optionally send the SHA-256 digest of each canonical Ed25519 audit
+checkpoint payload to an RFC 3161 timestamp authority (TSA). A verified token
+shows that the checkpoint existed no later than the TSA's signed time. This
+narrows the window in which an operator could rewrite pre-anchor history and
+produce a new checkpoint.
+
+Anchoring is not tamper-proof or operator-proof. It does not prove that the
+export is complete, protect events created after the anchor, prevent TSA and
+operator collusion, or replace the auditor's out-of-band trust in Steward's
+Ed25519 signing-key fingerprint and the TSA certificate authority.
+
+## Configuration
+
+No setting means `off`: Steward constructs no sink, makes no network request,
+and returns the existing v1 bundle shape without an `anchor` field.
+
+```bash
+STEWARD_AUDIT_CHECKPOINT_ANCHOR_MODE=best-effort # off | best-effort | required
+STEWARD_AUDIT_CHECKPOINT_ANCHOR_PROVIDER=rfc3161
+STEWARD_AUDIT_RFC3161_URL=https://tsa.example.com/timestamp
+STEWARD_AUDIT_RFC3161_TIMEOUT_MS=10000
+```
+
+- `best-effort` logs a TSA failure and returns the ordinary signed bundle
+  without an anchor proof.
+- `required` returns HTTP 503 and does not emit an evidence bundle when the TSA
+  is missing, rejects the request, times out, or returns a malformed response.
+- production TSA URLs must use HTTPS, may not embed credentials, do not follow
+  redirects, and responses are capped at 1 MiB.
+
+The reference sink sends a DER RFC 3161 `TimeStampReq` with a SHA-256
+`MessageImprint` and `certReq=true`. The bundle contains the opaque DER
+`TimeStampResp`, the checkpoint digest, and non-secret algorithm/provider
+metadata. It never contains TSA credentials.
+
+Self-hosted API compositions can implement `AuditCheckpointAnchorSink` and
+register a named provider with `registerAuditCheckpointAnchorSink` before
+serving evidence routes. Selecting an unregistered provider fails closed.
+
+## Offline verification
+
+Trust the TSA only through CA material obtained independently from the bundle:
+
+```bash
+node scripts/verify-evidence-bundle.mjs bundle.json \
+  --expected-key-fingerprint "$STEWARD_EXPECTED_AUDIT_KEY_FP" \
+  --tsa-ca auditor-trusted-tsa-ca.pem \
+  --require-anchor
+```
+
+The verifier reconstructs the exact checkpoint digest, invokes OpenSSL's RFC
+3161 verifier entirely offline, validates the timestamp token's certificate
+chain and message imprint, and reports the TSA time as the "existed no later
+than" bound. An intermediate chain can be supplied with `--tsa-untrusted`.
+
+To enforce a compliance cutoff:
+
+```bash
+node scripts/verify-evidence-bundle.mjs bundle.json \
+  --tsa-ca auditor-trusted-tsa-ca.pem \
+  --require-anchor \
+  --anchored-before 2026-12-31T23:59:59Z
+```
+
+Without `--tsa-ca`, an included token is reported as present but untrusted. The
+bundle-carried token and any bundle-carried identity are never treated as their
+own trust root.

--- a/docs/security/threat-model.mdx
+++ b/docs/security/threat-model.mdx
@@ -394,6 +394,11 @@ adversary defeats the entire architecture.
   Ed25519 checkpoints, and offline verifier detect modification relative to the public key carried in the bundle. Operators must separately
   match that key to an out-of-band trusted signing key or fingerprint. An operator controlling all
   relevant keys can still fabricate a self-consistent history.
+- **Optional checkpoint anchoring narrows, but does not remove, that limit.**
+  An RFC 3161 proof verified against an auditor-supplied TSA CA shows a signed
+  checkpoint existed no later than the TSA time. It does not make Steward
+  tamper-proof or operator-proof, cover post-anchor events, or prove export
+  completeness.
 - **No rate limiting on read endpoints.** Rate limits apply to
   signing and auth; general read traffic is not rate-capped beyond
   whatever the reverse proxy enforces.

--- a/packages/api/src/__tests__/audit-bundle.integration.test.ts
+++ b/packages/api/src/__tests__/audit-bundle.integration.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { generateKeyPairSync } from "node:crypto";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createHash, generateKeyPairSync } from "node:crypto";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { auditCheckpoints, closeDb, getDb, tenants } from "@stwd/db";
@@ -10,6 +10,7 @@ import { eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { writeAuditEvent } from "../services/audit";
 import { resetCheckpointSignerCache } from "../services/audit-checkpoint";
+import { createRfc3161TimestampQuery } from "../services/audit-checkpoint-anchor";
 import type { AppVariables } from "../services/context";
 
 const TENANT_ID = "audit-bundle-tenant";
@@ -26,6 +27,8 @@ const VERIFIER = join(
 
 let auditRoutesModule: Awaited<typeof import("../routes/audit")>;
 let tmpDir: string;
+let tsaCaPath: string;
+let tsaConfigPath: string;
 
 interface BundleEvent {
   seq: number;
@@ -39,15 +42,128 @@ interface Bundle {
   range: { from: number; to: number; includesHead: boolean };
   canonicalizationSpec: string;
   events: BundleEvent[];
-  checkpoint: { payload: Record<string, unknown>; signature: string; publicKey: string };
+  checkpoint: {
+    payload: Record<string, unknown>;
+    signature: string;
+    publicKey: string;
+    anchor?: Record<string, unknown>;
+  };
   generatedAt: string;
 }
 
-function runVerifier(bundle: unknown): { code: number; stdout: string; stderr: string } {
+function runVerifier(
+  bundle: unknown,
+  args: string[] = [],
+): { code: number; stdout: string; stderr: string } {
   const file = join(tmpDir, `bundle-${Math.random().toString(36).slice(2)}.json`);
   writeFileSync(file, JSON.stringify(bundle));
-  const res = spawnSync("node", [VERIFIER, file], { encoding: "utf8" });
+  const res = spawnSync("node", [VERIFIER, file, ...args], { encoding: "utf8" });
   return { code: res.status ?? -1, stdout: res.stdout ?? "", stderr: res.stderr ?? "" };
+}
+
+function runOpenSsl(args: string[]): void {
+  const result = spawnSync("openssl", args, { encoding: "utf8" });
+  if (result.status !== 0) {
+    throw new Error(`openssl ${args.join(" ")} failed: ${result.stderr || result.stdout}`);
+  }
+}
+
+function setupTestTsa(): void {
+  tsaCaPath = join(tmpDir, "tsa-ca.pem");
+  const caKey = join(tmpDir, "tsa-ca-key.pem");
+  const tsaKey = join(tmpDir, "tsa-key.pem");
+  const tsaCsr = join(tmpDir, "tsa.csr");
+  const tsaCert = join(tmpDir, "tsa.pem");
+  const extensions = join(tmpDir, "tsa-extensions.cnf");
+  const serial = join(tmpDir, "tsa-serial");
+  tsaConfigPath = join(tmpDir, "tsa.cnf");
+
+  runOpenSsl([
+    "req",
+    "-x509",
+    "-newkey",
+    "rsa:2048",
+    "-nodes",
+    "-keyout",
+    caKey,
+    "-out",
+    tsaCaPath,
+    "-days",
+    "1",
+    "-subj",
+    "/CN=Steward Test TSA CA",
+  ]);
+  runOpenSsl([
+    "req",
+    "-new",
+    "-newkey",
+    "rsa:2048",
+    "-nodes",
+    "-keyout",
+    tsaKey,
+    "-out",
+    tsaCsr,
+    "-subj",
+    "/CN=Steward Test TSA",
+  ]);
+  writeFileSync(
+    extensions,
+    "basicConstraints=critical,CA:FALSE\nkeyUsage=critical,digitalSignature,nonRepudiation\nextendedKeyUsage=critical,timeStamping\nsubjectKeyIdentifier=hash\nauthorityKeyIdentifier=keyid,issuer\n",
+  );
+  runOpenSsl([
+    "x509",
+    "-req",
+    "-in",
+    tsaCsr,
+    "-CA",
+    tsaCaPath,
+    "-CAkey",
+    caKey,
+    "-CAcreateserial",
+    "-out",
+    tsaCert,
+    "-days",
+    "1",
+    "-sha256",
+    "-extfile",
+    extensions,
+  ]);
+  writeFileSync(serial, "01\n");
+  writeFileSync(
+    tsaConfigPath,
+    `[ tsa ]\ndefault_tsa = tsa_config1\n[ tsa_config1 ]\ndir = ${tmpDir}\nserial = ${serial}\ncrypto_device = builtin\nsigner_cert = ${tsaCert}\ncerts = ${tsaCaPath}\nsigner_key = ${tsaKey}\nsigner_digest = sha256\ndefault_policy = 1.2.3.4.1\ndigests = sha256\naccuracy = secs:1\nordering = yes\ntsa_name = yes\ness_cert_id_chain = no\n`,
+  );
+}
+
+function attachTestAnchor(bundle: Bundle): void {
+  const payload = bundle.checkpoint.payload;
+  const ordered = Object.fromEntries(
+    Object.keys(payload)
+      .sort()
+      .map((key) => [key, payload[key]]),
+  );
+  const digest = createHash("sha256").update(JSON.stringify(ordered)).digest("hex");
+  const queryPath = join(tmpDir, `query-${Math.random().toString(36).slice(2)}.tsq`);
+  const responsePath = `${queryPath}.tsr`;
+  writeFileSync(queryPath, createRfc3161TimestampQuery(digest));
+  runOpenSsl([
+    "ts",
+    "-reply",
+    "-config",
+    tsaConfigPath,
+    "-queryfile",
+    queryPath,
+    "-out",
+    responsePath,
+  ]);
+  bundle.checkpoint.anchor = {
+    v: 1,
+    type: "rfc3161",
+    sinkId: "rfc3161",
+    hashAlgorithm: "sha256",
+    checkpointDigest: digest,
+    timestampResponse: readFileSync(responsePath).toString("base64"),
+  };
 }
 
 describe("audit evidence bundle endpoint + offline verifier", () => {
@@ -56,6 +172,8 @@ describe("audit evidence bundle endpoint + offline verifier", () => {
     process.env.STEWARD_PGLITE_MEMORY = "true";
     process.env.STEWARD_AUDIT_HMAC_KEY = "audit-bundle-hmac-key-0123456789abcdef0123";
     process.env.STEWARD_MASTER_PASSWORD = "audit-bundle-master-password";
+    delete process.env.STEWARD_AUDIT_CHECKPOINT_ANCHOR_MODE;
+    delete process.env.STEWARD_AUDIT_RFC3161_URL;
 
     // Deterministic Ed25519 signing key for the run (PKCS#8 PEM path).
     const { privateKey } = generateKeyPairSync("ed25519");
@@ -69,6 +187,7 @@ describe("audit evidence bundle endpoint + offline verifier", () => {
       await client.close();
     });
     auditRoutesModule = await import("../routes/audit");
+    setupTestTsa();
 
     await getDb()
       .insert(tenants)
@@ -105,6 +224,8 @@ describe("audit evidence bundle endpoint + offline verifier", () => {
     delete process.env.STEWARD_AUDIT_HMAC_KEY;
     delete process.env.STEWARD_MASTER_PASSWORD;
     delete process.env.STEWARD_AUDIT_SIGNING_KEY;
+    delete process.env.STEWARD_AUDIT_CHECKPOINT_ANCHOR_MODE;
+    delete process.env.STEWARD_AUDIT_RFC3161_URL;
     resetCheckpointSignerCache();
   });
 
@@ -136,6 +257,9 @@ describe("audit evidence bundle endpoint + offline verifier", () => {
     expect(bundle.range.includesHead).toBe(true);
     expect(bundle.canonicalizationSpec).toContain("HMAC-SHA256");
     expect(bundle.checkpoint.publicKey).toContain("BEGIN PUBLIC KEY");
+    // No anchor configuration preserves the v1 checkpoint envelope exactly;
+    // there is no placeholder field and therefore no hidden network behavior.
+    expect(Object.keys(bundle.checkpoint).sort()).toEqual(["payload", "publicKey", "signature"]);
     expect(bundle.checkpoint.payload.tenantId).toBe(TENANT_ID);
     expect(bundle.checkpoint.payload.seq).toBe(4);
     // Head binding: last event hmac equals signed headHmac.
@@ -176,6 +300,53 @@ describe("audit evidence bundle endpoint + offline verifier", () => {
     const { code, stdout } = runVerifier(bundle);
     expect(stdout).toContain("PASS");
     expect(code).toBe(0);
+  });
+
+  it("fails evidence generation closed when required anchoring is misconfigured", async () => {
+    process.env.STEWARD_AUDIT_CHECKPOINT_ANCHOR_MODE = "required";
+    delete process.env.STEWARD_AUDIT_RFC3161_URL;
+    try {
+      const response = await app().request("/audit/bundle");
+      expect(response.status).toBe(503);
+      expect(await response.json()).toEqual({
+        ok: false,
+        error: "Required checkpoint anchoring failed",
+      });
+    } finally {
+      delete process.env.STEWARD_AUDIT_CHECKPOINT_ANCHOR_MODE;
+    }
+  });
+
+  it("verifies an RFC 3161 token fully offline and reports the anchored-before bound", async () => {
+    const bundle = await fetchBundle();
+    attachTestAnchor(bundle);
+    const { code, stdout } = runVerifier(bundle, [
+      "--tsa-ca",
+      tsaCaPath,
+      "--require-anchor",
+      "--anchored-before",
+      "2100-01-01T00:00:00.000Z",
+    ]);
+    expect(code).toBe(0);
+    expect(stdout).toContain("RFC 3161 verified");
+    expect(stdout).toContain("existed no later than");
+    expect(stdout).toContain("not operator-proof");
+  });
+
+  it("fails offline anchor verification for a missing proof or wrong imprint", async () => {
+    const unanchored = await fetchBundle();
+    const missing = runVerifier(unanchored, ["--tsa-ca", tsaCaPath, "--require-anchor"]);
+    expect(missing.code).toBe(1);
+    expect(missing.stderr).toContain("anchor is missing");
+
+    const wrongImprint = await fetchBundle();
+    attachTestAnchor(wrongImprint);
+    if (wrongImprint.checkpoint.anchor) {
+      wrongImprint.checkpoint.anchor.checkpointDigest = "00".repeat(32);
+    }
+    const invalid = runVerifier(wrongImprint, ["--tsa-ca", tsaCaPath, "--require-anchor"]);
+    expect(invalid.code).toBe(1);
+    expect(invalid.stderr).toContain("digest does not match");
   });
 
   it("FAILS the verifier at the right seq when an event byte is flipped", async () => {

--- a/packages/api/src/__tests__/audit-checkpoint-anchor.test.ts
+++ b/packages/api/src/__tests__/audit-checkpoint-anchor.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { generateKeyPairSync } from "node:crypto";
+import { type CheckpointPayload, createCheckpointSigner } from "../services/audit-checkpoint";
+import {
+  AuditCheckpointAnchorError,
+  assertGrantedRfc3161Response,
+  auditCheckpointAnchorDigest,
+  configuredAuditCheckpointAnchor,
+  createRfc3161TimestampQuery,
+  maybeAnchorAuditCheckpoint,
+  Rfc3161TimestampSink,
+  registerAuditCheckpointAnchorSink,
+} from "../services/audit-checkpoint-anchor";
+
+const ENV_KEYS = [
+  "NODE_ENV",
+  "STEWARD_AUDIT_CHECKPOINT_ANCHOR_MODE",
+  "STEWARD_AUDIT_CHECKPOINT_ANCHOR_PROVIDER",
+  "STEWARD_AUDIT_RFC3161_URL",
+  "STEWARD_AUDIT_RFC3161_TIMEOUT_MS",
+] as const;
+const originalEnv = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
+
+const payload: CheckpointPayload = {
+  v: 1,
+  tenantId: "tenant-anchor",
+  seq: 7,
+  headHmac: "ab".repeat(32),
+  expectedCount: 7,
+  floorSeq: 0,
+  timestamp: "2026-08-16T00:00:00.000Z",
+  softwareVersion: "test",
+  eventsDigest: "cd".repeat(32),
+  eventsFromSeq: 1,
+  eventsToSeq: 7,
+};
+
+function checkpoint() {
+  const { privateKey } = generateKeyPairSync("ed25519");
+  const pem = privateKey.export({ format: "pem", type: "pkcs8" }).toString();
+  return createCheckpointSigner(pem).sign(payload);
+}
+
+// Minimal structurally granted TimeStampResp carrying the requested imprint.
+// Full CMS signature trust is the offline verifier's job with an
+// auditor-supplied CA.
+function grantedResponse(digest: string): Uint8Array {
+  const imprint = Buffer.from(digest, "hex");
+  return Uint8Array.from([
+    0x30,
+    0x29,
+    0x30,
+    0x03,
+    0x02,
+    0x01,
+    0x00,
+    0x30,
+    0x22,
+    0x04,
+    0x20,
+    ...imprint,
+  ]);
+}
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    const value = originalEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe("audit checkpoint anchoring", () => {
+  it("is byte-shape neutral and makes no network call when unconfigured", async () => {
+    delete process.env.STEWARD_AUDIT_CHECKPOINT_ANCHOR_MODE;
+    delete process.env.STEWARD_AUDIT_RFC3161_URL;
+    let calls = 0;
+    const result = await maybeAnchorAuditCheckpoint(checkpoint(), {
+      mode: "off",
+      sink: {
+        id: "must-not-run",
+        async anchor() {
+          calls++;
+          throw new Error("network must remain unreachable");
+        },
+      },
+    });
+    expect(result).toBeUndefined();
+    expect(calls).toBe(0);
+    expect(configuredAuditCheckpointAnchor()).toEqual({ mode: "off" });
+  });
+
+  it("builds the exact SHA-256 RFC 3161 query and attaches only opaque public proof", async () => {
+    const signed = checkpoint();
+    const responseBytes = grantedResponse(auditCheckpointAnchorDigest(signed));
+    let observedUrl = "";
+    let observedInit: RequestInit | undefined;
+    const sink = new Rfc3161TimestampSink({
+      url: "https://tsa.example.test/v1",
+      fetch: async (input, init) => {
+        observedUrl = String(input);
+        observedInit = init;
+        return new Response(responseBytes, {
+          status: 200,
+          headers: { "content-type": "application/timestamp-reply" },
+        });
+      },
+    });
+    const proof = await sink.anchor(signed);
+    expect(observedUrl).toBe("https://tsa.example.test/v1");
+    expect(observedInit?.method).toBe("POST");
+    expect(observedInit?.redirect).toBe("error");
+    expect(new Headers(observedInit?.headers).get("content-type")).toBe(
+      "application/timestamp-query",
+    );
+    const expectedQuery = createRfc3161TimestampQuery(auditCheckpointAnchorDigest(signed));
+    expect(Buffer.from(observedInit?.body as Uint8Array)).toEqual(Buffer.from(expectedQuery));
+    expect(proof).toEqual({
+      v: 1,
+      type: "rfc3161",
+      sinkId: "rfc3161",
+      hashAlgorithm: "sha256",
+      checkpointDigest: auditCheckpointAnchorDigest(signed),
+      timestampResponse: Buffer.from(responseBytes).toString("base64"),
+    });
+    expect(JSON.stringify(proof).toLowerCase()).not.toContain("private");
+  });
+
+  it("rejects malformed, denied, oversized and token-less responses", () => {
+    expect(() => assertGrantedRfc3161Response(new Uint8Array([1, 2, 3]))).toThrow();
+    expect(() =>
+      assertGrantedRfc3161Response(
+        Uint8Array.from([0x30, 0x08, 0x30, 0x03, 0x02, 0x01, 0x02, 0x30, 0x01, 0x00]),
+      ),
+    ).toThrow("rejected");
+    expect(() =>
+      assertGrantedRfc3161Response(Uint8Array.from([0x30, 0x05, 0x30, 0x03, 0x02, 0x01, 0x00])),
+    ).toThrow("did not include");
+    expect(() => assertGrantedRfc3161Response(new Uint8Array(1024 * 1024 + 1))).toThrow("size");
+  });
+
+  it("fails closed in required mode and degrades only when explicitly best-effort", async () => {
+    const failingSink = {
+      id: "failure",
+      async anchor(): Promise<never> {
+        throw new AuditCheckpointAnchorError("tsa unavailable");
+      },
+    };
+    await expect(
+      maybeAnchorAuditCheckpoint(checkpoint(), { mode: "required", sink: failingSink }),
+    ).rejects.toThrow("tsa unavailable");
+    expect(
+      await maybeAnchorAuditCheckpoint(checkpoint(), { mode: "best-effort", sink: failingSink }),
+    ).toBeUndefined();
+  });
+
+  it("rejects incomplete required configuration and insecure production transport", () => {
+    process.env.STEWARD_AUDIT_CHECKPOINT_ANCHOR_MODE = "required";
+    delete process.env.STEWARD_AUDIT_RFC3161_URL;
+    expect(() => configuredAuditCheckpointAnchor()).toThrow("URL is required");
+
+    process.env.NODE_ENV = "production";
+    process.env.STEWARD_AUDIT_RFC3161_URL = "http://tsa.example.test";
+    expect(() => configuredAuditCheckpointAnchor()).toThrow("HTTPS");
+  });
+
+  it("routes an explicitly registered custom witness through the pluggable interface", () => {
+    const sink = {
+      id: "customer-log",
+      async anchor(): Promise<never> {
+        throw new Error("not invoked by configuration discovery");
+      },
+    };
+    const unregister = registerAuditCheckpointAnchorSink("customer-log", () => sink);
+    try {
+      process.env.STEWARD_AUDIT_CHECKPOINT_ANCHOR_MODE = "required";
+      process.env.STEWARD_AUDIT_CHECKPOINT_ANCHOR_PROVIDER = "customer-log";
+      expect(configuredAuditCheckpointAnchor()).toEqual({ mode: "required", sink });
+    } finally {
+      unregister();
+    }
+  });
+});

--- a/packages/api/src/lib.ts
+++ b/packages/api/src/lib.ts
@@ -30,3 +30,12 @@ export {
   type StewardApp,
   type StewardAppContext,
 } from "./plugin";
+export {
+  AuditCheckpointAnchorError,
+  type AuditCheckpointAnchorMode,
+  type AuditCheckpointAnchorSink,
+  type AuditCheckpointAnchorSinkFactory,
+  type Rfc3161CheckpointAnchorProof,
+  Rfc3161TimestampSink,
+  registerAuditCheckpointAnchorSink,
+} from "./services/audit-checkpoint-anchor";

--- a/packages/api/src/routes/audit.ts
+++ b/packages/api/src/routes/audit.ts
@@ -16,6 +16,7 @@ import {
   verifyAuditChain,
 } from "../services/audit";
 import { AuditSigningKeyError, isCheckpointSigningConfigured } from "../services/audit-checkpoint";
+import { AuditCheckpointAnchorError } from "../services/audit-checkpoint-anchor";
 import {
   type ApiResponse,
   type AppVariables,
@@ -888,6 +889,9 @@ auditRoutes.get("/bundle", async (c) => {
   } catch (err) {
     if (err instanceof AuditSigningKeyError) {
       return c.json<ApiResponse>({ ok: false, error: err.message }, 503);
+    }
+    if (err instanceof AuditCheckpointAnchorError) {
+      return c.json<ApiResponse>({ ok: false, error: "Required checkpoint anchoring failed" }, 503);
     }
     console.error(`[audit] checkpoint signing failed for tenant ${tenantId}:`, err);
     return c.json<ApiResponse>({ ok: false, error: "Failed to sign checkpoint" }, 500);

--- a/packages/api/src/routes/provider-case.ts
+++ b/packages/api/src/routes/provider-case.ts
@@ -25,6 +25,7 @@ import { eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { auditOwnerAdminMfaGate } from "../middleware/audit-gate";
 import { AuditSigningKeyError, isCheckpointSigningConfigured } from "../services/audit-checkpoint";
+import { AuditCheckpointAnchorError } from "../services/audit-checkpoint-anchor";
 import {
   type ApiResponse,
   type AppVariables,
@@ -107,6 +108,9 @@ providerCaseRoutes.get("/provider-actions/:id/evidence", async (c) => {
   } catch (err) {
     if (err instanceof AuditSigningKeyError) {
       return c.json<ApiResponse>({ ok: false, error: "CASE_EVIDENCE_SIGNING_DISABLED" }, 503);
+    }
+    if (err instanceof AuditCheckpointAnchorError) {
+      return c.json<ApiResponse>({ ok: false, error: "CASE_EVIDENCE_ANCHOR_UNAVAILABLE" }, 503);
     }
     if (err instanceof CaseRangeTooLargeError) {
       // Pathological same-tenant interleave (KC15): the case segment is too

--- a/packages/api/src/services/audit-checkpoint-anchor.ts
+++ b/packages/api/src/services/audit-checkpoint-anchor.ts
@@ -1,0 +1,373 @@
+/**
+ * Optional third-party anchoring for signed audit checkpoints.
+ *
+ * Disabled means exactly disabled: no sink is constructed and no network call
+ * is made. RFC 3161 is the reference implementation; the interface is public
+ * so another append-only witness can be supplied without changing bundle
+ * assembly.
+ */
+
+import { createHash } from "node:crypto";
+import { canonicalCheckpointBytes, type SignedCheckpoint } from "./audit-checkpoint";
+
+export type AuditCheckpointAnchorMode = "off" | "best-effort" | "required";
+
+export interface Rfc3161CheckpointAnchorProof {
+  v: 1;
+  type: "rfc3161";
+  sinkId: string;
+  hashAlgorithm: "sha256";
+  /** SHA-256 of canonicalCheckpointBytes(checkpoint.payload). */
+  checkpointDigest: string;
+  /** Base64 DER TimeStampResp, including the TSA certificate when supplied. */
+  timestampResponse: string;
+}
+
+export interface AuditCheckpointAnchorSink {
+  readonly id: string;
+  anchor(checkpoint: SignedCheckpoint): Promise<Rfc3161CheckpointAnchorProof>;
+}
+
+export type AuditCheckpointAnchorSinkFactory = () => AuditCheckpointAnchorSink;
+
+const registeredSinkFactories = new Map<string, AuditCheckpointAnchorSinkFactory>();
+
+/** Register an operator-supplied append-only witness implementation. */
+export function registerAuditCheckpointAnchorSink(
+  provider: string,
+  factory: AuditCheckpointAnchorSinkFactory,
+): () => void {
+  if (!/^[a-z0-9][a-z0-9-]{0,63}$/.test(provider) || provider === "rfc3161") {
+    throw new AuditCheckpointAnchorError("Custom checkpoint anchor provider name is invalid");
+  }
+  if (registeredSinkFactories.has(provider)) {
+    throw new AuditCheckpointAnchorError(
+      `Checkpoint anchor provider ${provider} is already registered`,
+    );
+  }
+  registeredSinkFactories.set(provider, factory);
+  return () => {
+    if (registeredSinkFactories.get(provider) === factory) registeredSinkFactories.delete(provider);
+  };
+}
+
+export interface Rfc3161TimestampSinkOptions {
+  url: string;
+  timeoutMs?: number;
+  fetch?: typeof globalThis.fetch;
+}
+
+export class AuditCheckpointAnchorError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "AuditCheckpointAnchorError";
+  }
+}
+
+const MAX_TIMESTAMP_RESPONSE_BYTES = 1024 * 1024;
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+function concatBytes(...chunks: Uint8Array[]): Uint8Array {
+  const out = new Uint8Array(chunks.reduce((length, chunk) => length + chunk.length, 0));
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return out;
+}
+
+/** Digest anchored by the TSA. The Ed25519 signature authenticates these bytes separately. */
+export function auditCheckpointAnchorDigest(checkpoint: SignedCheckpoint): string {
+  return createHash("sha256").update(canonicalCheckpointBytes(checkpoint.payload)).digest("hex");
+}
+
+/**
+ * DER TimeStampReq v1 with SHA-256 MessageImprint and certReq=true.
+ * The fixed-size SHA-256 request uses only short-form DER lengths.
+ */
+export function createRfc3161TimestampQuery(checkpointDigest: string): Uint8Array {
+  if (!/^[0-9a-f]{64}$/.test(checkpointDigest)) {
+    throw new AuditCheckpointAnchorError(
+      "RFC 3161 checkpoint digest must be 32-byte lowercase hex",
+    );
+  }
+  const sha256AlgorithmIdentifier = Uint8Array.from([
+    0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x01, 0x05, 0x00,
+  ]);
+  const imprint = concatBytes(
+    Uint8Array.from([0x30, 0x31]),
+    sha256AlgorithmIdentifier,
+    Uint8Array.from([0x04, 0x20]),
+    hexToBytes(checkpointDigest),
+  );
+  return concatBytes(
+    Uint8Array.from([0x30, 0x39, 0x02, 0x01, 0x01]),
+    imprint,
+    Uint8Array.from([0x01, 0x01, 0xff]),
+  );
+}
+
+interface DerElement {
+  tag: number;
+  start: number;
+  contentStart: number;
+  end: number;
+}
+
+function readDerElement(bytes: Uint8Array, offset: number): DerElement {
+  const tag = bytes[offset];
+  const firstLength = bytes[offset + 1];
+  if (tag === undefined || firstLength === undefined) {
+    throw new AuditCheckpointAnchorError("RFC 3161 response is truncated");
+  }
+  let length = 0;
+  let contentStart = offset + 2;
+  if ((firstLength & 0x80) === 0) {
+    length = firstLength;
+  } else {
+    const lengthBytes = firstLength & 0x7f;
+    if (lengthBytes < 1 || lengthBytes > 3 || contentStart + lengthBytes > bytes.length) {
+      throw new AuditCheckpointAnchorError("RFC 3161 response has an invalid DER length");
+    }
+    if (bytes[contentStart] === 0) {
+      throw new AuditCheckpointAnchorError("RFC 3161 response has a non-canonical DER length");
+    }
+    for (let i = 0; i < lengthBytes; i++) length = length * 256 + bytes[contentStart + i];
+    if (length < 128) {
+      throw new AuditCheckpointAnchorError("RFC 3161 response has a non-canonical DER length");
+    }
+    contentStart += lengthBytes;
+  }
+  const end = contentStart + length;
+  if (end > bytes.length) throw new AuditCheckpointAnchorError("RFC 3161 response is truncated");
+  return { tag, start: offset, contentStart, end };
+}
+
+/** Reject malformed, denied, or token-less TSA responses before attaching them. */
+export function assertGrantedRfc3161Response(bytes: Uint8Array): void {
+  if (bytes.length < 7 || bytes.length > MAX_TIMESTAMP_RESPONSE_BYTES) {
+    throw new AuditCheckpointAnchorError("RFC 3161 response size is invalid");
+  }
+  const outer = readDerElement(bytes, 0);
+  if (outer.tag !== 0x30 || outer.end !== bytes.length) {
+    throw new AuditCheckpointAnchorError("RFC 3161 response is not one canonical DER sequence");
+  }
+  const statusInfo = readDerElement(bytes, outer.contentStart);
+  if (statusInfo.tag !== 0x30) {
+    throw new AuditCheckpointAnchorError("RFC 3161 response is missing PKIStatusInfo");
+  }
+  const status = readDerElement(bytes, statusInfo.contentStart);
+  if (status.tag !== 0x02 || status.end - status.contentStart !== 1) {
+    throw new AuditCheckpointAnchorError("RFC 3161 response has an invalid PKIStatus");
+  }
+  const statusValue = bytes[status.contentStart];
+  if (statusValue !== 0 && statusValue !== 1) {
+    throw new AuditCheckpointAnchorError(
+      `RFC 3161 TSA rejected the request (status ${statusValue})`,
+    );
+  }
+  if (statusInfo.end >= outer.end) {
+    throw new AuditCheckpointAnchorError(
+      "RFC 3161 granted response did not include a timestamp token",
+    );
+  }
+  const token = readDerElement(bytes, statusInfo.end);
+  if (token.tag !== 0x30 || token.end !== outer.end) {
+    throw new AuditCheckpointAnchorError("RFC 3161 response contains an invalid timestamp token");
+  }
+}
+
+function assertRfc3161ResponseContainsImprint(bytes: Uint8Array, digest: string): void {
+  const expected = concatBytes(Uint8Array.from([0x04, 0x20]), hexToBytes(digest));
+  outer: for (let offset = 0; offset <= bytes.length - expected.length; offset++) {
+    for (let i = 0; i < expected.length; i++) {
+      if (bytes[offset + i] !== expected[i]) continue outer;
+    }
+    return;
+  }
+  throw new AuditCheckpointAnchorError(
+    "RFC 3161 response does not contain the requested SHA-256 message imprint",
+  );
+}
+
+async function readTimestampResponse(response: Response): Promise<Uint8Array> {
+  if (!response.body) {
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    if (bytes.length > MAX_TIMESTAMP_RESPONSE_BYTES) {
+      throw new AuditCheckpointAnchorError("RFC 3161 response exceeds 1 MiB");
+    }
+    return bytes;
+  }
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      const chunk = value instanceof Uint8Array ? value : new Uint8Array(value);
+      total += chunk.length;
+      if (total > MAX_TIMESTAMP_RESPONSE_BYTES) {
+        await reader.cancel();
+        throw new AuditCheckpointAnchorError("RFC 3161 response exceeds 1 MiB");
+      }
+      chunks.push(chunk);
+    }
+    return concatBytes(...chunks);
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function validateTimestampUrl(raw: string): URL {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new AuditCheckpointAnchorError("STEWARD_AUDIT_RFC3161_URL must be a valid URL");
+  }
+  if (url.username || url.password) {
+    throw new AuditCheckpointAnchorError("RFC 3161 URL must not contain credentials");
+  }
+  if (url.protocol !== "https:" && process.env.NODE_ENV === "production") {
+    throw new AuditCheckpointAnchorError("RFC 3161 URL must use HTTPS in production");
+  }
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    throw new AuditCheckpointAnchorError("RFC 3161 URL must use HTTP or HTTPS");
+  }
+  return url;
+}
+
+export class Rfc3161TimestampSink implements AuditCheckpointAnchorSink {
+  readonly id = "rfc3161";
+  private readonly url: URL;
+  private readonly timeoutMs: number;
+  private readonly fetchImpl: typeof globalThis.fetch;
+
+  constructor(options: Rfc3161TimestampSinkOptions) {
+    this.url = validateTimestampUrl(options.url);
+    this.timeoutMs = options.timeoutMs ?? 10_000;
+    if (!Number.isSafeInteger(this.timeoutMs) || this.timeoutMs < 100 || this.timeoutMs > 60_000) {
+      throw new AuditCheckpointAnchorError("RFC 3161 timeout must be between 100 and 60000ms");
+    }
+    this.fetchImpl = options.fetch ?? globalThis.fetch;
+  }
+
+  async anchor(checkpoint: SignedCheckpoint): Promise<Rfc3161CheckpointAnchorProof> {
+    const checkpointDigest = auditCheckpointAnchorDigest(checkpoint);
+    const query = createRfc3161TimestampQuery(checkpointDigest);
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const response = await this.fetchImpl(this.url, {
+        method: "POST",
+        headers: {
+          Accept: "application/timestamp-reply",
+          "Content-Type": "application/timestamp-query",
+        },
+        // Both Node/Bun and Workers accept Uint8Array bodies. workers-types in
+        // this package narrows BodyInit incompatibly, so preserve the runtime
+        // value while widening only the compile-time view.
+        body: query as unknown as string,
+        redirect: "error",
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        throw new AuditCheckpointAnchorError(`RFC 3161 TSA returned HTTP ${response.status}`);
+      }
+      const declaredLength = Number(response.headers.get("content-length") ?? "0");
+      if (declaredLength > MAX_TIMESTAMP_RESPONSE_BYTES) {
+        throw new AuditCheckpointAnchorError("RFC 3161 response exceeds 1 MiB");
+      }
+      const bytes = await readTimestampResponse(response);
+      assertGrantedRfc3161Response(bytes);
+      assertRfc3161ResponseContainsImprint(bytes, checkpointDigest);
+      return {
+        v: 1,
+        type: "rfc3161",
+        sinkId: this.id,
+        hashAlgorithm: "sha256",
+        checkpointDigest,
+        timestampResponse: bytesToBase64(bytes),
+      };
+    } catch (error) {
+      if (error instanceof AuditCheckpointAnchorError) throw error;
+      throw new AuditCheckpointAnchorError("RFC 3161 timestamp request failed", {
+        cause: error,
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}
+
+function configuredMode(): AuditCheckpointAnchorMode {
+  const value = process.env.STEWARD_AUDIT_CHECKPOINT_ANCHOR_MODE?.trim() || "off";
+  if (value === "off" || value === "best-effort" || value === "required") return value;
+  throw new AuditCheckpointAnchorError(
+    "STEWARD_AUDIT_CHECKPOINT_ANCHOR_MODE must be off, best-effort, or required",
+  );
+}
+
+export function configuredAuditCheckpointAnchor(): {
+  mode: AuditCheckpointAnchorMode;
+  sink?: AuditCheckpointAnchorSink;
+} {
+  const mode = configuredMode();
+  if (mode === "off") return { mode };
+  const provider = process.env.STEWARD_AUDIT_CHECKPOINT_ANCHOR_PROVIDER?.trim() || "rfc3161";
+  if (provider !== "rfc3161") {
+    const factory = registeredSinkFactories.get(provider);
+    if (!factory) {
+      throw new AuditCheckpointAnchorError(
+        `Checkpoint anchor provider ${provider} is not registered`,
+      );
+    }
+    return { mode, sink: factory() };
+  }
+  const url = process.env.STEWARD_AUDIT_RFC3161_URL?.trim();
+  if (!url) {
+    throw new AuditCheckpointAnchorError(
+      "STEWARD_AUDIT_RFC3161_URL is required when checkpoint anchoring is enabled",
+    );
+  }
+  const rawTimeout = process.env.STEWARD_AUDIT_RFC3161_TIMEOUT_MS?.trim();
+  const timeoutMs = rawTimeout ? Number(rawTimeout) : undefined;
+  return { mode, sink: new Rfc3161TimestampSink({ url, timeoutMs }) };
+}
+
+/** Anchor according to environment policy; required mode never degrades silently. */
+export async function maybeAnchorAuditCheckpoint(
+  checkpoint: SignedCheckpoint,
+  configured = configuredAuditCheckpointAnchor(),
+): Promise<Rfc3161CheckpointAnchorProof | undefined> {
+  if (configured.mode === "off") return undefined;
+  if (!configured.sink) {
+    throw new AuditCheckpointAnchorError("Checkpoint anchor sink is not configured");
+  }
+  try {
+    return await configured.sink.anchor(checkpoint);
+  } catch (error) {
+    if (configured.mode === "required") {
+      throw error instanceof AuditCheckpointAnchorError
+        ? error
+        : new AuditCheckpointAnchorError("Required checkpoint anchoring failed", { cause: error });
+    }
+    console.error("[audit] best-effort checkpoint anchoring failed; returning unanchored bundle");
+    return undefined;
+  }
+}

--- a/packages/api/src/services/audit-checkpoint.ts
+++ b/packages/api/src/services/audit-checkpoint.ts
@@ -23,8 +23,10 @@
  * BOTH the HMAC key and the signing key from constructing a self-consistent but
  * fabricated history and then signing it. The Ed25519 signature raises the bar
  * from "trust the operator's secret HMAC" to "trust the operator's published,
- * append-only, third-partyly-witnessable checkpoints"; anchoring beyond that
- * (third-party timestamping / transparency log) is explicitly out of scope for v1.
+ * append-only, third-party-witnessable checkpoints"; anchoring beyond that
+ * (third-party timestamping / transparency log) requires a separately trusted
+ * witness. The optional RFC 3161 hook anchors the canonical payload digest and
+ * keeps that narrower claim explicit.
  *
  * Zero new dependencies: uses node:crypto Ed25519 primitives.
  */

--- a/packages/api/src/services/audit.ts
+++ b/packages/api/src/services/audit.ts
@@ -35,6 +35,10 @@ import {
   eventsContentDigest,
   getCheckpointSigner,
 } from "./audit-checkpoint";
+import {
+  maybeAnchorAuditCheckpoint,
+  type Rfc3161CheckpointAnchorProof,
+} from "./audit-checkpoint-anchor";
 import { API_VERSION } from "./version";
 
 /**
@@ -532,6 +536,7 @@ export interface SignedAuditBundle {
     payload: CheckpointPayload;
     signature: string;
     publicKey: string;
+    anchor?: Rfc3161CheckpointAnchorProof;
   };
   generatedAt: string;
 }
@@ -590,6 +595,10 @@ export async function signAuditBundle(
     eventsToSeq: events.length > 0 ? events[events.length - 1].seq : 0,
   };
   const signed = signer.sign(checkpointPayload);
+  // Default/off mode returns synchronously without constructing a sink or
+  // touching the network. Required mode throws instead of emitting an
+  // unanchored bundle; best-effort mode logs and preserves the v1 envelope.
+  const anchor = await maybeAnchorAuditCheckpoint(signed);
   // Process-local operational gauge only. Durable checkpoint evidence is the
   // signed payload/table below and remains authoritative across restarts.
   try {
@@ -632,6 +641,7 @@ export async function signAuditBundle(
       payload: signed.payload,
       signature: signed.signature,
       publicKey: signed.publicKey,
+      ...(anchor ? { anchor } : {}),
     },
     generatedAt: new Date().toISOString(),
   };

--- a/scripts/verify-evidence-bundle.mjs
+++ b/scripts/verify-evidence-bundle.mjs
@@ -3,7 +3,8 @@
 /**
  * Standalone offline verifier for a Steward audit evidence bundle.
  *
- * ZERO project imports, ZERO third-party dependencies — only Node builtins.
+ * ZERO project imports and ZERO package dependencies. Base bundle checks use
+ * only Node builtins; optional RFC 3161 trust verification invokes OpenSSL.
  * An auditor can run this on any machine with Node, holding nothing but the
  * bundle JSON (which carries its own Ed25519 public key). No Steward access, no
  * secret HMAC key.
@@ -43,11 +44,16 @@
  *     is present is internally consistent, its contents are authentic, and (when
  *     it reaches the head) it matches the signed head. A gap BELOW the first
  *     exported seq is expected for partial exports.
- *   • It does not timestamp-anchor the checkpoint externally (out of scope v1).
+ *   • RFC 3161 verification is optional and trusts only an auditor-supplied
+ *     TSA CA. Anchoring narrows the pre-anchor rewrite window; it does not make
+ *     the system tamper-proof or operator-proof.
  */
 
+import { spawnSync } from "node:child_process";
 import { createHash, createPublicKey, verify as edVerify } from "node:crypto";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 function fail(msg, seq) {
   const at = seq === undefined ? "" : ` (seq ${seq})`;
@@ -58,7 +64,7 @@ function fail(msg, seq) {
 function usage(msg) {
   console.error(`usage error: ${msg}`);
   console.error(
-    "  node scripts/verify-evidence-bundle.mjs <bundle.json> [--expected-key-fingerprint <hex>]",
+    "  node scripts/verify-evidence-bundle.mjs <bundle.json> [--expected-key-fingerprint <hex>] [--tsa-ca <pem>]",
   );
   console.error("  cat bundle.json | node scripts/verify-evidence-bundle.mjs [--fp <hex>]");
   console.error("");
@@ -67,6 +73,12 @@ function usage(msg) {
   console.error("       STEWARD_EXPECTED_AUDIT_KEY_FP (comma-separated). If absent, the verifier");
   console.error("       prints the observed fingerprint and states trust-root matching is the");
   console.error("       auditor responsibility.");
+  console.error(
+    "  --tsa-ca <pem>  Verify an included RFC 3161 token against this auditor-supplied CA.",
+  );
+  console.error("  --tsa-untrusted <pem>  Optional intermediate TSA certificate chain.");
+  console.error("  --require-anchor  Fail unless an RFC 3161 proof is present and verifies.");
+  console.error("  --anchored-before <ISO-8601>  Require verified TSA time at/before this bound.");
   process.exit(2);
 }
 
@@ -75,6 +87,10 @@ function parseArgs() {
   const argv = process.argv.slice(2);
   let bundleArg;
   const expectedFps = [];
+  let tsaCa;
+  let tsaUntrusted;
+  let requireAnchor = false;
+  let anchoredBefore;
   const clean = (s) => s.toLowerCase().replace(/[^0-9a-f]/g, "");
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
@@ -85,8 +101,21 @@ function parseArgs() {
       i++;
     } else if (a.startsWith("--expected-key-fingerprint=") || a.startsWith("--fp=")) {
       expectedFps.push(clean(a.slice(a.indexOf("=") + 1)));
+    } else if (a === "--tsa-ca" || a === "--tsa-untrusted" || a === "--anchored-before") {
+      const v = argv[i + 1];
+      if (!v) usage(`${a} requires a value`);
+      if (a === "--tsa-ca") tsaCa = v;
+      if (a === "--tsa-untrusted") tsaUntrusted = v;
+      if (a === "--anchored-before") anchoredBefore = v;
+      i++;
+    } else if (a === "--require-anchor") {
+      requireAnchor = true;
+    } else if (a.startsWith("--")) {
+      usage(`unknown option ${a}`);
     } else if (!bundleArg) {
       bundleArg = a;
+    } else {
+      usage(`unexpected positional argument ${a}`);
     }
   }
   const envFp = process.env.STEWARD_EXPECTED_AUDIT_KEY_FP;
@@ -96,7 +125,98 @@ function parseArgs() {
       if (c) expectedFps.push(c);
     }
   }
-  return { bundleArg, expectedFps };
+  if (anchoredBefore && !Number.isFinite(new Date(anchoredBefore).getTime())) {
+    usage("--anchored-before must be a valid ISO-8601 timestamp");
+  }
+  if (tsaUntrusted && !tsaCa) usage("--tsa-untrusted requires --tsa-ca");
+  if ((requireAnchor || anchoredBefore) && !tsaCa) {
+    usage("--require-anchor/--anchored-before require an auditor-supplied --tsa-ca");
+  }
+  return { bundleArg, expectedFps, tsaCa, tsaUntrusted, requireAnchor, anchoredBefore };
+}
+
+function checkpointAnchorDigest(payload) {
+  return createHash("sha256").update(canonicalCheckpointBytes(payload)).digest("hex");
+}
+
+function strictBase64(value, name) {
+  if (typeof value !== "string" || !/^[A-Za-z0-9+/]+={0,2}$/.test(value)) {
+    fail(`${name} is not canonical base64`);
+  }
+  const decoded = Buffer.from(value, "base64");
+  if (decoded.length === 0 || decoded.toString("base64") !== value) {
+    fail(`${name} is not canonical base64`);
+  }
+  return decoded;
+}
+
+function verifyRfc3161Anchor(anchor, payload, options) {
+  if (!anchor) {
+    if (options.requireAnchor || options.tsaCa || options.anchoredBefore) {
+      fail("required RFC 3161 checkpoint anchor is missing");
+    }
+    return { present: false, verified: false, time: null };
+  }
+  if (
+    anchor.v !== 1 ||
+    anchor.type !== "rfc3161" ||
+    anchor.hashAlgorithm !== "sha256" ||
+    typeof anchor.sinkId !== "string" ||
+    !/^[0-9a-f]{64}$/.test(anchor.checkpointDigest)
+  ) {
+    fail("checkpoint RFC 3161 anchor schema is invalid");
+  }
+  const digest = checkpointAnchorDigest(payload);
+  if (anchor.checkpointDigest !== digest) {
+    fail("RFC 3161 anchor digest does not match the signed checkpoint payload");
+  }
+  const response = strictBase64(anchor.timestampResponse, "RFC 3161 timestampResponse");
+  if (response.length > 1024 * 1024) fail("RFC 3161 timestampResponse exceeds 1 MiB");
+  if (!options.tsaCa) return { present: true, verified: false, time: null };
+
+  const dir = mkdtempSync(join(tmpdir(), "steward-rfc3161-"));
+  const responsePath = join(dir, "response.tsr");
+  try {
+    writeFileSync(responsePath, response, { mode: 0o600 });
+    const verifyArgs = [
+      "ts",
+      "-verify",
+      "-digest",
+      digest,
+      "-in",
+      responsePath,
+      "-CAfile",
+      options.tsaCa,
+    ];
+    if (options.tsaUntrusted) verifyArgs.push("-untrusted", options.tsaUntrusted);
+    const verified = spawnSync("openssl", verifyArgs, {
+      encoding: "utf8",
+      timeout: 30_000,
+    });
+    if (verified.error) fail(`could not run OpenSSL RFC 3161 verifier: ${verified.error.message}`);
+    if (verified.status !== 0) {
+      fail(`RFC 3161 token verification failed: ${(verified.stderr || verified.stdout).trim()}`);
+    }
+    const inspected = spawnSync("openssl", ["ts", "-reply", "-in", responsePath, "-text"], {
+      encoding: "utf8",
+      timeout: 30_000,
+    });
+    if (inspected.error || inspected.status !== 0) {
+      fail("verified RFC 3161 token could not be inspected for its timestamp");
+    }
+    const match = inspected.stdout.match(/^Time stamp:\s*(.+)$/m);
+    if (!match) fail("verified RFC 3161 token did not contain a timestamp");
+    const time = new Date(match[1]);
+    if (!Number.isFinite(time.getTime())) fail("RFC 3161 token timestamp is not parseable");
+    if (options.anchoredBefore && time > new Date(options.anchoredBefore)) {
+      fail(
+        `RFC 3161 anchor time ${time.toISOString()} is after required bound ${options.anchoredBefore}`,
+      );
+    }
+    return { present: true, verified: true, time: time.toISOString() };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 }
 
 // SHA-256 fingerprint of a signing key SPKI DER (spec §7.1/§7.2, C6).
@@ -191,7 +311,8 @@ function eventsContentDigest(events, tenantId) {
 }
 
 function main() {
-  const { bundleArg, expectedFps } = parseArgs();
+  const options = parseArgs();
+  const { bundleArg, expectedFps } = options;
   const input = loadBundle(bundleArg);
 
   if (!input || typeof input !== "object") fail("bundle is not an object");
@@ -240,6 +361,10 @@ function main() {
   }
   const sigOk = edVerify(null, canonicalCheckpointBytes(payload), pubKeyObj, sigBytes);
   if (!sigOk) fail("Ed25519 checkpoint signature does not verify");
+
+  // Optional third-party time proof. Its message imprint MUST bind the exact
+  // canonical checkpoint payload. Trust comes only from an auditor-supplied CA.
+  const anchorResult = verifyRfc3161Anchor(checkpoint.anchor, payload, options);
 
   // ── Trust-root fingerprint match (spec §7.1/§7.2, C6) ────────────────────
   // The bundle is self-describing (it carries its own public key); an auditor
@@ -359,6 +484,15 @@ function main() {
   console.log(`  signature:     Ed25519 OK`);
   console.log(`  content:       SHA-256 events digest OK`);
   console.log(`  linkage:       OK`);
+  console.log(
+    `  anchor:        ${
+      anchorResult.verified
+        ? `RFC 3161 verified; checkpoint existed no later than ${anchorResult.time}`
+        : anchorResult.present
+          ? "RFC 3161 proof present but NOT trusted; supply --tsa-ca"
+          : "not present (optional)"
+    }`,
+  );
   if (manifest)
     console.log(`  manifest:      cross-check OK (every fact backed by a signed event)`);
   console.log(`  head:          ${headNote}`);
@@ -378,6 +512,9 @@ function main() {
       (trustRootChecked
         ? "the signing key matches an auditor-supplied trusted fingerprint; "
         : "") +
+      (anchorResult.verified
+        ? `a trusted TSA proves the checkpoint existed no later than ${anchorResult.time}; `
+        : "") +
       "the checkpoint is authentically Ed25519-signed and unaltered.",
   );
   console.log(
@@ -385,7 +522,9 @@ function main() {
       "operator holding BOTH the HMAC key AND the signing key could fabricate a " +
       "self-consistent history; that the export is the complete history; " +
       (trustRootChecked ? "" : "trust-root binding (no expected fingerprint supplied); ") +
-      "out-of-band time anchoring.",
+      (anchorResult.verified
+        ? "events after the anchor or TSA/operator collusion. Anchoring narrows the pre-anchor rewrite window; it is not operator-proof."
+        : "out-of-band time anchoring."),
   );
   process.exit(0);
 }


### PR DESCRIPTION
## Summary

- add a pluggable `AuditCheckpointAnchorSink` registry with an RFC 3161 reference sink
- anchor the SHA-256 digest of canonical Ed25519 checkpoint payloads and attach the opaque DER proof only when configured
- preserve the existing v1 checkpoint envelope exactly when unconfigured: no `anchor` key, no sink construction, and no network call
- provide explicit `off`, `best-effort`, and `required` modes; required mode returns 503 rather than emitting unanchored evidence
- extend the standalone verifier with auditor-supplied TSA CA/intermediate trust, required-anchor enforcement, and anchored-before cutoff checks
- document the precise claim: a trusted timestamp narrows the pre-anchor rewrite window; it is never described as tamper-proof or operator-proof

## Security boundaries

Production RFC 3161 URLs require HTTPS, embedded URL credentials and redirects are rejected, requests time out, and responses are streamed with a 1 MiB cap. Granted status, token presence, DER framing, and the requested SHA-256 message imprint are checked before attachment. Full certificate-chain, CMS signature, and message-imprint verification happens offline with OpenSSL and an auditor-supplied CA; bundle-carried identity is never its own trust root.

## Exact-head validation

Validated on `51422a4658f25923e57fa775c77df9134a2d7a4e`:

- `bun test packages/api/src/__tests__/audit-checkpoint-anchor.test.ts packages/api/src/__tests__/audit-checkpoint.test.ts packages/api/src/__tests__/provider-case-verifier.test.ts packages/api/src/__tests__/audit-bundle.integration.test.ts` — 47 pass, 0 fail, 126 assertions
- the integration suite generates a local CA + time-stamping certificate, produces a real DER RFC 3161 response, then verifies it fully offline; missing proofs and wrong imprints fail
- `bunx turbo run build --filter=@stwd/api` — 21/21 tasks successful
- `git diff --check` — clean

No external TSA, network credential, or hosted dependency is needed by the tests.

Closes #215