### PR TITLE
test(security): enforce provider profile conformance

### DIFF
--- a/packages/shared/src/__tests__/generic-http-provider-action.test.ts
+++ b/packages/shared/src/__tests__/generic-http-provider-action.test.ts
@@ -32,8 +32,11 @@ import {
   GOLDEN_VECTORS,
   genericDescriptorAllowsExactPath,
   genericHttpCanonicalActionBytes,
+  getProfileDescriptor,
   isRegisteredProfile,
+  type ProviderProfileDescriptor,
   REGISTERED_PROFILES,
+  runProfileConformance,
   UnregisteredProfileError,
   validateGenericHttpDescriptor,
   X_GOLDEN_VECTORS,
@@ -169,6 +172,52 @@ describe("profile registry", () => {
   // that admits an unregistered profile at any site would flip one of these.
   it("every registered profile round-trips through assertRegisteredProfile", () => {
     for (const p of REGISTERED_PROFILES) expect(assertRegisteredProfile(p)).toBe(p);
+  });
+
+  it("runs every invariant against every immutable registered profile", () => {
+    for (const profile of REGISTERED_PROFILES) {
+      const descriptor = getProfileDescriptor(profile);
+      expect(descriptor).toBeDefined();
+      expect(Object.isFrozen(descriptor)).toBe(true);
+      expect(Object.isFrozen(descriptor?.conformance)).toBe(true);
+      expect(Object.isFrozen(descriptor?.conformance.rejects)).toBe(true);
+      expect(runProfileConformance(descriptor as ProviderProfileDescriptor)).toEqual([]);
+    }
+  });
+
+  it("the harness catches a deliberately violating profile fixture", () => {
+    const acceptsEverything = () => ({ ok: true });
+    let buildCount = 0;
+    const violating = {
+      profile: "violating.provider-action.v1",
+      kind: "adapter-fixed",
+      label: "Violating",
+      conformance: {
+        build: () => ({
+          bytes: 'authorization:"steward-secret-canary"',
+          digest: String(++buildCount),
+        }),
+        rejects: {
+          "credential-exclusion": acceptsEverything,
+          "duplicate-key": acceptsEverything,
+          "duplicate-query": acceptsEverything,
+          "plain-traversal": acceptsEverything,
+          "encoded-traversal": acceptsEverything,
+          "unsupported-content-type": acceptsEverything,
+        },
+      },
+    } satisfies ProviderProfileDescriptor;
+    expect(runProfileConformance(violating)).toEqual(
+      expect.arrayContaining([
+        "determinism",
+        "credential-exclusion",
+        "duplicate-key",
+        "duplicate-query",
+        "plain-traversal",
+        "encoded-traversal",
+        "unsupported-content-type",
+      ]),
+    );
   });
 });
 

--- a/packages/shared/src/provider-profile-registry.ts
+++ b/packages/shared/src/provider-profile-registry.ts
@@ -21,12 +21,33 @@
  * building the action.
  */
 
-import { GENERIC_HTTP_PROVIDER_ACTION_PROFILE } from "./generic-http-provider-action.js";
-import { GITHUB_PROVIDER_ACTION_PROFILE } from "./provider-action.js";
-import { X_PROVIDER_ACTION_PROFILE } from "./x-provider-action.js";
+import {
+  buildGenericHttpAction,
+  computeGenericHttpActionDigest,
+  GENERIC_GOLDEN_DESCRIPTOR_A,
+  GENERIC_HTTP_PROVIDER_ACTION_PROFILE,
+  genericHttpCanonicalActionBytes,
+  validateGenericHttpDescriptor,
+} from "./generic-http-provider-action.js";
+import {
+  canonicalActionBytes,
+  canonicalizeRawInternalAction,
+  computeActionDigest,
+  GITHUB_PROVIDER_ACTION_PROFILE,
+} from "./provider-action.js";
+import {
+  canonicalizeRawInternalXAction,
+  computeXActionDigest,
+  X_PROVIDER_ACTION_PROFILE,
+  xCanonicalActionBytes,
+} from "./x-provider-action.js";
 
 /** Whether a profile's operation shape is fixed by an adapter or authored by config. */
 export type ProfileKind = "adapter-fixed" | "config-driven";
+export type RegisteredProviderProfile =
+  | typeof GITHUB_PROVIDER_ACTION_PROFILE
+  | typeof X_PROVIDER_ACTION_PROFILE
+  | typeof GENERIC_HTTP_PROVIDER_ACTION_PROFILE;
 
 export interface ProviderProfileDescriptor {
   /** The stable wire profile string (also stamped into every canonical action). */
@@ -34,7 +55,216 @@ export interface ProviderProfileDescriptor {
   kind: ProfileKind;
   /** Human label for logs/UX (never on the digest surface). */
   label: string;
+  conformance: ProviderProfileConformance;
 }
+
+export const PROFILE_CONFORMANCE_INVARIANTS = [
+  "credential-exclusion",
+  "duplicate-key",
+  "duplicate-query",
+  "plain-traversal",
+  "encoded-traversal",
+  "unsupported-content-type",
+] as const;
+
+export type ProfileConformanceInvariant = (typeof PROFILE_CONFORMANCE_INVARIANTS)[number];
+
+export interface ProviderProfileConformance {
+  build(): { bytes: string; digest: string };
+  rejects: Readonly<Record<ProfileConformanceInvariant, () => unknown>>;
+}
+
+function frozenConformance(
+  build: ProviderProfileConformance["build"],
+  rejects: Record<ProfileConformanceInvariant, () => unknown>,
+): ProviderProfileConformance {
+  return Object.freeze({ build, rejects: Object.freeze(rejects) });
+}
+
+const githubConformance = frozenConformance(
+  () => {
+    const action = canonicalizeRawInternalAction({
+      method: "GET",
+      origin: "https://api.github.com",
+      path: "/repos/acme/widgets/issues",
+    });
+    return { bytes: canonicalActionBytes(action), digest: computeActionDigest(action) };
+  },
+  {
+    "credential-exclusion": () =>
+      canonicalizeRawInternalAction({
+        method: "GET",
+        origin: "https://api.github.com",
+        path: "/repos/acme/widgets/issues",
+        headers: [["authorization", "steward-secret-canary"]],
+      }),
+    "duplicate-key": () =>
+      canonicalizeRawInternalAction({
+        method: "GET",
+        origin: "https://api.github.com",
+        path: "/repos/acme/widgets/issues",
+        headers: [
+          ["accept", "a"],
+          ["accept", "b"],
+        ],
+      }),
+    "duplicate-query": () =>
+      canonicalizeRawInternalAction({
+        method: "GET",
+        origin: "https://api.github.com",
+        path: "/repos/acme/widgets/issues",
+        query: [
+          ["state", "open"],
+          ["state", "closed"],
+        ],
+      }),
+    "plain-traversal": () =>
+      canonicalizeRawInternalAction({
+        method: "GET",
+        origin: "https://api.github.com",
+        path: "/repos/../admin",
+      }),
+    "encoded-traversal": () =>
+      canonicalizeRawInternalAction({
+        method: "GET",
+        origin: "https://api.github.com",
+        path: "/repos/%2e%2e/admin",
+      }),
+    "unsupported-content-type": () =>
+      canonicalizeRawInternalAction({
+        method: "POST",
+        origin: "https://api.github.com",
+        path: "/repos/acme/widgets/issues",
+        contentType: "application/xml",
+        body: { title: "x" },
+      }),
+  },
+);
+
+const xConformance = frozenConformance(
+  () => {
+    const action = canonicalizeRawInternalXAction({
+      method: "GET",
+      origin: "https://api.x.com",
+      path: "/2/users/me",
+    });
+    return { bytes: xCanonicalActionBytes(action), digest: computeXActionDigest(action) };
+  },
+  {
+    "credential-exclusion": () =>
+      canonicalizeRawInternalXAction({
+        method: "GET",
+        origin: "https://api.x.com",
+        path: "/2/users/me",
+        headers: [["authorization", "steward-secret-canary"]],
+      }),
+    "duplicate-key": () =>
+      canonicalizeRawInternalXAction({
+        method: "GET",
+        origin: "https://api.x.com",
+        path: "/2/users/me",
+        headers: [
+          ["x-a", "1"],
+          ["x-a", "2"],
+        ],
+      }),
+    "duplicate-query": () =>
+      canonicalizeRawInternalXAction({
+        method: "GET",
+        origin: "https://api.x.com",
+        path: "/2/users/me",
+        query: [
+          ["expansions", "a"],
+          ["expansions", "b"],
+        ],
+      }),
+    "plain-traversal": () =>
+      canonicalizeRawInternalXAction({
+        method: "GET",
+        origin: "https://api.x.com",
+        path: "/2/../admin",
+      }),
+    "encoded-traversal": () =>
+      canonicalizeRawInternalXAction({
+        method: "GET",
+        origin: "https://api.x.com",
+        path: "/2/%2e%2e/admin",
+      }),
+    "unsupported-content-type": () =>
+      canonicalizeRawInternalXAction({
+        method: "POST",
+        origin: "https://api.x.com",
+        path: "/2/tweets",
+        contentType: "application/xml",
+        body: { text: "x" },
+      }),
+  },
+);
+
+function genericBuildArgs() {
+  return {
+    org: "acme-inc",
+    projectId: "11111111-1111-4111-8111-111111111111",
+    state: "open",
+    perPage: 30,
+  };
+}
+
+const genericConformance = frozenConformance(
+  () => {
+    const descriptor = validateGenericHttpDescriptor(GENERIC_GOLDEN_DESCRIPTOR_A);
+    const action = buildGenericHttpAction(
+      "items.list",
+      descriptor,
+      "GET",
+      genericBuildArgs(),
+    ).action;
+    return {
+      bytes: genericHttpCanonicalActionBytes(action),
+      digest: computeGenericHttpActionDigest(action),
+    };
+  },
+  {
+    "credential-exclusion": () =>
+      validateGenericHttpDescriptor({
+        ...GENERIC_GOLDEN_DESCRIPTOR_A,
+        headers: [{ name: "authorization", value: "steward-secret-canary" }],
+      }),
+    "duplicate-key": () =>
+      validateGenericHttpDescriptor({
+        ...GENERIC_GOLDEN_DESCRIPTOR_A,
+        projection: { policyArgs: ["org", "org"], safeSummary: [] },
+      }),
+    "duplicate-query": () =>
+      validateGenericHttpDescriptor({
+        ...GENERIC_GOLDEN_DESCRIPTOR_A,
+        query: [
+          { name: "state", type: "string", pattern: "^(open|closed)$" },
+          { name: "state", type: "string", pattern: "^(open|closed)$" },
+        ],
+      }),
+    "plain-traversal": () => {
+      const descriptor = validateGenericHttpDescriptor(GENERIC_GOLDEN_DESCRIPTOR_A);
+      return buildGenericHttpAction("items.list", descriptor, "GET", {
+        ...genericBuildArgs(),
+        org: "..",
+      });
+    },
+    "encoded-traversal": () => {
+      const descriptor = validateGenericHttpDescriptor(GENERIC_GOLDEN_DESCRIPTOR_A);
+      return buildGenericHttpAction("items.list", descriptor, "GET", {
+        ...genericBuildArgs(),
+        org: "%2e%2e",
+      });
+    },
+    "unsupported-content-type": () =>
+      validateGenericHttpDescriptor({
+        ...GENERIC_GOLDEN_DESCRIPTOR_A,
+        methods: ["POST"],
+        body: { contentType: "application/xml", fields: [] },
+      }),
+  },
+);
 
 /**
  * The registered profiles. FROZEN: this is the single source of truth for which
@@ -48,6 +278,7 @@ const REGISTRY: ReadonlyMap<string, ProviderProfileDescriptor> = new Map([
       profile: GITHUB_PROVIDER_ACTION_PROFILE,
       kind: "adapter-fixed",
       label: "GitHub",
+      conformance: githubConformance,
     }),
   ],
   [
@@ -56,6 +287,7 @@ const REGISTRY: ReadonlyMap<string, ProviderProfileDescriptor> = new Map([
       profile: X_PROVIDER_ACTION_PROFILE,
       kind: "adapter-fixed",
       label: "X",
+      conformance: xConformance,
     }),
   ],
   [
@@ -64,6 +296,7 @@ const REGISTRY: ReadonlyMap<string, ProviderProfileDescriptor> = new Map([
       profile: GENERIC_HTTP_PROVIDER_ACTION_PROFILE,
       kind: "config-driven",
       label: "Generic HTTP",
+      conformance: genericConformance,
     }),
   ],
 ]);
@@ -72,7 +305,7 @@ const REGISTRY: ReadonlyMap<string, ProviderProfileDescriptor> = new Map([
 export const REGISTERED_PROFILES: readonly string[] = Object.freeze([...REGISTRY.keys()]);
 
 /** True iff `profile` is a registered canonical profile string. */
-export function isRegisteredProfile(profile: unknown): profile is string {
+export function isRegisteredProfile(profile: unknown): profile is RegisteredProviderProfile {
   return typeof profile === "string" && REGISTRY.has(profile);
 }
 
@@ -104,7 +337,7 @@ export function isUnregisteredProfileError(e: unknown): e is UnregisteredProfile
  * {@link UnregisteredProfileError} otherwise. Call at EVERY consumption site:
  * store insert, policy eval, dispatch, approval binding, evidence emission.
  */
-export function assertRegisteredProfile(profile: unknown): string {
+export function assertRegisteredProfile(profile: unknown): RegisteredProviderProfile {
   if (!isRegisteredProfile(profile)) throw new UnregisteredProfileError(profile);
   return profile;
 }
@@ -112,4 +345,28 @@ export function assertRegisteredProfile(profile: unknown): string {
 /** True iff the profile is registered AND config-driven (needs a descriptor). */
 export function isConfigDrivenProfile(profile: unknown): boolean {
   return getProfileDescriptor(profile)?.kind === "config-driven";
+}
+
+/** Return invariant names that a descriptor fails; empty means conformant. */
+export function runProfileConformance(descriptor: ProviderProfileDescriptor): string[] {
+  const failures: string[] = [];
+  const first = descriptor.conformance.build();
+  const second = descriptor.conformance.build();
+  if (first.bytes !== second.bytes || first.digest !== second.digest) failures.push("determinism");
+  if (first.bytes.includes("steward-secret-canary")) failures.push("credential-exclusion");
+  for (const invariant of PROFILE_CONFORMANCE_INVARIANTS) {
+    const negative = descriptor.conformance.rejects[invariant];
+    if (typeof negative !== "function") {
+      failures.push(invariant);
+      continue;
+    }
+    let rejected = false;
+    try {
+      negative();
+    } catch {
+      rejected = true;
+    }
+    if (!rejected) failures.push(invariant);
+  }
+  return failures;
 }


### PR DESCRIPTION
Closes #220

Stacked on #287; retarget to `develop` after #287 merges.

## Summary
- attach a deeply immutable conformance fixture/build callback to every registered profile
- enumerate github, X, and generic HTTP through the same determinism and adversarial invariant harness
- require credential exclusion, duplicate-key/query rejection, plain/encoded traversal rejection, and unsupported-content-type rejection for every profile
- add a registered-profile key union and preserve the private fail-closed registry
- prove the harness itself is load-bearing with a deliberately violating fixture that fails every invariant
- retain the existing byte-exact github/X/generic golden corpus and DB/API/proxy boundary checks from #287

## Validation
- shared profile suite: 41/41
- `@stwd/shared` build passes
- focused Biome check and `git diff --check` clean