### PR TITLE
fix(policy): make provider reservations crash-durable

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -302,6 +302,9 @@ jobs:
           STEWARD_EMAIL_CODE_SECRET: "ci-email-code-secret-must-be-at-least-32-chars-long"
           STEWARD_EXECUTION_AUTH_SECRET: "v2-ci-1:ci-execution-auth-secret-must-be-at-least-32-bytes-long"
           STEWARD_AUDIT_HMAC_KEY: "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+          # Exercise the API's real Redis-backed reservation/crash-recovery E2Es;
+          # this job already provisions a healthy Redis service above.
+          STEWARD_REDIS_TESTS: "1"
           SIWE_ALLOWED_DOMAINS: "steward.fi,localhost"
           # The whole api suite drives this one server from a single IP; the
           # default 100-req/60s per-IP gate 429s the sharded test flood.
@@ -345,6 +348,7 @@ jobs:
           STEWARD_EMAIL_CODE_SECRET: "ci-email-code-secret-must-be-at-least-32-chars-long"
           STEWARD_EXECUTION_AUTH_SECRET: "v2-ci-1:ci-execution-auth-secret-must-be-at-least-32-bytes-long"
           STEWARD_AUDIT_HMAC_KEY: "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+          STEWARD_REDIS_TESTS: "1"
           SIWE_ALLOWED_DOMAINS: "steward.fi,localhost"
 
       - name: Stop API test server

--- a/packages/api/src/__tests__/cumulative-spend-cap-e2e.test.ts
+++ b/packages/api/src/__tests__/cumulative-spend-cap-e2e.test.ts
@@ -57,9 +57,13 @@ import {
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { PROVIDER_POLICY_REASON } from "@stwd/policy-engine";
 import { buildXAction } from "@stwd/provider-x";
-import { disconnectRedis, getRedis } from "@stwd/redis";
+import { disconnectRedis, getCumulativeSpendSum, getRedis } from "@stwd/redis";
+import { eq } from "drizzle-orm";
 import type { ProviderPrincipalV1 } from "../middleware/provider-principal";
-import { providerActionService } from "../services/provider-action-service";
+import {
+  __setReservationReconciliationFaultForTests,
+  providerActionService,
+} from "../services/provider-action-service";
 
 setDefaultTimeout(120_000);
 
@@ -203,8 +207,10 @@ async function seed(opts: {
   declaredCurrency?: string;
   declareSpendField?: boolean;
   countCapMaxCalls?: number;
+  combineCountAndSpend?: boolean;
   grantScoped?: boolean;
   accessViaRoleBindingNoGrant?: boolean;
+  extraDenyRule?: boolean;
 }) {
   const db = getDb();
   await db.insert(tenants).values([{ id: CS.TENANT, name: "CS", apiKeyHash: "hcs" }]);
@@ -263,13 +269,29 @@ async function seed(opts: {
   ]);
   const requestProfile: Record<string, unknown> = {
     policyRules:
-      opts.countCapMaxCalls !== undefined
+      opts.countCapMaxCalls !== undefined && !opts.combineCountAndSpend
         ? countCapRules(OP_TWEET_KEY, opts.countCapMaxCalls)
         : opts.grantScoped
           ? grantScopedSpendRules(OP_TWEET_KEY, opts.maxBytes)
           : spendCapRules(OP_TWEET_KEY, opts.maxBytes, opts.capCurrency ?? "BYTES"),
   };
-  if (opts.countCapMaxCalls === undefined && opts.declareSpendField !== false) {
+  if (opts.combineCountAndSpend && opts.countCapMaxCalls !== undefined) {
+    (requestProfile.policyRules as Array<Record<string, unknown>>).push(
+      ...countCapRules(OP_TWEET_KEY, opts.countCapMaxCalls),
+    );
+  }
+  if (opts.extraDenyRule) {
+    (requestProfile.policyRules as Array<Record<string, unknown>>).push({
+      id: "c4444444-4444-4444-8444-4444444444f4",
+      type: "capability-intent",
+      enabled: true,
+      config: { capabilities: [OP_TWEET_KEY], effect: "deny" },
+    });
+  }
+  if (
+    (opts.countCapMaxCalls === undefined || opts.combineCountAndSpend) &&
+    opts.declareSpendField !== false
+  ) {
     requestProfile.spendDeclaration = {
       field: "textByteLength",
       currency: opts.declaredCurrency ?? "BYTES",
@@ -359,6 +381,7 @@ describeRedis("#206 cumulativeSpend cap - full-chain E2E (real service + real Re
     delete process.env.STEWARD_PGLITE_MEMORY;
   });
   beforeEach(async () => {
+    __setReservationReconciliationFaultForTests(null);
     await wipe();
     await cleanupRedis();
   });
@@ -433,5 +456,125 @@ describeRedis("#206 cumulativeSpend cap - full-chain E2E (real service + real Re
     if (t.kind === "policy_denied") {
       expect(t.code).toBe(PROVIDER_POLICY_REASON.CUMULATIVE_SPEND_CAP_EXCEEDED);
     }
+  });
+
+  test("#240 crash after terminal commit: C2 settles persisted handles exactly once under a worker race", async () => {
+    await seed({ maxBytes: 250 });
+    __setReservationReconciliationFaultForTests("before_apply");
+    const out = await proposeTweet("settled-spend", "cs-240-settle");
+    expect(out.kind).toBe("allowed");
+    if (out.kind !== "allowed") throw new Error("expected allowed");
+    const [crashed] = await getDb()
+      .select()
+      .from(providerActionBindings)
+      .where(eq(providerActionBindings.intentId, out.intentId));
+    expect(crashed.status).toBe("stub_succeeded");
+    expect(crashed.reservationReconciliationState).toBe("pending");
+    expect(crashed.reservationReconciliationAttempts).toBe(1);
+    expect(crashed.reservationReconciliationLastError).toContain("injected crash");
+    expect(crashed.reservationReconciliationNextRetryAt).not.toBeNull();
+    expect(crashed.policyReservationHandles).toMatchObject({
+      schemaVersion: "steward.provider-policy-reservations.v1",
+      generation: 1,
+      phase: "decision",
+      cumulativeSpend: [{ amount: 13 }],
+    });
+    expect(JSON.stringify(crashed.policyReservationHandles)).not.toContain("settled-spend");
+
+    __setReservationReconciliationFaultForTests(null);
+    const [a, b] = await Promise.all([
+      providerActionService.reconcilePolicyReservations(CS.TENANT, out.intentId),
+      providerActionService.reconcilePolicyReservations(CS.TENANT, out.intentId),
+    ]);
+    expect(a + b).toBe(1);
+    const [done] = await getDb()
+      .select()
+      .from(providerActionBindings)
+      .where(eq(providerActionBindings.intentId, out.intentId));
+    expect(done.reservationReconciliationState).toBe("settled");
+    expect(done.reservationReconciledAt).not.toBeNull();
+  });
+
+  test("#240 crash before release: C2 reclaims failed spend and maxCalls reservations", async () => {
+    await seed({
+      maxBytes: 250,
+      extraDenyRule: true,
+      countCapMaxCalls: 5,
+      combineCountAndSpend: true,
+    });
+    __setReservationReconciliationFaultForTests("before_apply");
+    const out = await proposeTweet("known-failure", "cs-240-release");
+    expect(out.kind).toBe("policy_denied");
+    if (out.kind !== "policy_denied") throw new Error("expected denial");
+    const [crashed] = await getDb()
+      .select()
+      .from(providerActionBindings)
+      .where(eq(providerActionBindings.intentId, out.intentId));
+    expect(crashed.reservationReconciliationState).toBe("pending");
+    expect(crashed.reservationReconciliationAttempts).toBe(1);
+    expect(crashed.policyReservationHandles).toMatchObject({
+      cumulativeSpend: [{ amount: 13 }],
+      windowedInvoke: { agentId: CS.AGENT, operationKey: OP_TWEET_KEY },
+    });
+    expect(
+      await getCumulativeSpendSum({
+        agentId: CS.AGENT,
+        scope: "agent",
+        scopeKey: "",
+        currency: "BYTES",
+        windowSeconds: 86_400,
+      }),
+    ).toEqual({ sum: 13 });
+
+    __setReservationReconciliationFaultForTests(null);
+    expect(await providerActionService.recoverUnsignedIntents(CS.TENANT, out.intentId)).toBe(0);
+    expect(
+      await getCumulativeSpendSum({
+        agentId: CS.AGENT,
+        scope: "agent",
+        scopeKey: "",
+        currency: "BYTES",
+        windowSeconds: 86_400,
+      }),
+    ).toEqual({ sum: 0 });
+    const [done] = await getDb()
+      .select()
+      .from(providerActionBindings)
+      .where(eq(providerActionBindings.intentId, out.intentId));
+    expect(done.reservationReconciliationState).toBe("released");
+  });
+
+  test("#240 crash after Redis release but before CAS is idempotently recovered", async () => {
+    await seed({ maxBytes: 250, extraDenyRule: true });
+    __setReservationReconciliationFaultForTests("after_apply");
+    const out = await proposeTweet("released-once", "cs-240-after-redis");
+    expect(out.kind).toBe("policy_denied");
+    if (out.kind !== "policy_denied") throw new Error("expected denial");
+    const [crashed] = await getDb()
+      .select()
+      .from(providerActionBindings)
+      .where(eq(providerActionBindings.intentId, out.intentId));
+    expect(crashed.reservationReconciliationState).toBe("pending");
+    expect(
+      await getCumulativeSpendSum({
+        agentId: CS.AGENT,
+        scope: "agent",
+        scopeKey: "",
+        currency: "BYTES",
+        windowSeconds: 86_400,
+      }),
+    ).toEqual({ sum: 0 });
+
+    __setReservationReconciliationFaultForTests(null);
+    // The unscoped entry point is what the autonomous startup/periodic worker
+    // invokes. Make the retry due, then prove it recovers across all tenants.
+    await getDb()
+      .update(providerActionBindings)
+      .set({ reservationReconciliationNextRetryAt: new Date(0) })
+      .where(eq(providerActionBindings.intentId, out.intentId));
+    expect(await providerActionService.reconcilePolicyReservations()).toBe(1);
+    expect(await providerActionService.reconcilePolicyReservations(CS.TENANT, out.intentId)).toBe(
+      0,
+    );
   });
 });

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -26,6 +26,7 @@ import {
   RATE_LIMIT_MAX_REQUESTS,
   RATE_LIMIT_WINDOW_MS,
 } from "./services/context";
+import { startProviderReservationReconciliationScheduler } from "./services/provider-reservation-reconciliation-scheduler";
 import { startRetentionScheduler } from "./services/retention";
 import { startTransactionReceiptPollingScheduler } from "./services/transaction-receipt-poller";
 import { configuredVaultStartupLogLine, getConfiguredVault } from "./services/vault-factory";
@@ -56,6 +57,7 @@ const app = await composeApp();
 const requestLog = new Map<string, { count: number; resetAt: number }>();
 let isShuttingDown = false;
 let cancelRetention: (() => void) | undefined;
+let cancelProviderReservationReconciliation: (() => void) | undefined;
 let cancelTransactionReceiptPolling: (() => void) | undefined;
 let cancelWebhookRetryScheduler: (() => void) | undefined;
 
@@ -216,6 +218,7 @@ console.log(configuredVaultStartupLogLine());
 
 initRedis()
   .then((redisOk) => {
+    cancelProviderReservationReconciliation = startProviderReservationReconciliationScheduler();
     // usePostgres=true when migrations have run, so auth_kv_store table exists.
     const usePostgres = migrationsRan && !redisOk;
     return initAuthStores(usePostgres).then(() => {
@@ -254,6 +257,7 @@ const shutdown = async (signal: string) => {
   clearInterval(requestLogCleanupTimer);
   if (nonceCleanupTimer) clearInterval(nonceCleanupTimer);
   if (cancelRetention) cancelRetention();
+  if (cancelProviderReservationReconciliation) cancelProviderReservationReconciliation();
   if (cancelTransactionReceiptPolling) cancelTransactionReceiptPolling();
   if (cancelWebhookRetryScheduler) cancelWebhookRetryScheduler();
   requestLog.clear();

--- a/packages/api/src/services/provider-action-service.ts
+++ b/packages/api/src/services/provider-action-service.ts
@@ -87,11 +87,10 @@ const EVALUATOR_VERSION = "provider-action.v1";
 const POLICY_TYPE = "capability-intent" as const;
 
 /**
- * A handle to an atomic cumulative-spend reservation (#206) so the pipeline can
- * SETTLE it (known-success) or RELEASE it (known-failure/deny). On
- * outcome_unknown the pipeline deliberately does NEITHER - the reservation ages
- * out at the window edge (fail closed for a money cap: never free budget that
- * may have really spent).
+ * A handle to an atomic cumulative-spend reservation (#206). #240 persists this
+ * exact identity on the binding so a known outcome can be reconciled after a
+ * process crash. On outcome_unknown the sweeper deliberately does NEITHER - the
+ * reservation ages out at the window edge (fail closed for a money cap).
  */
 export interface CumulativeSpendReservationHandle {
   /** the spend-STREAM identity (scope+scopeKey+currency); NOT the cap threshold
@@ -111,6 +110,131 @@ export interface WindowedInvokeReservationHandle {
   agentId: string;
   operationKey: string;
   reservationId: string;
+}
+
+export interface PersistedPolicyReservationHandlesV1 {
+  schemaVersion: "steward.provider-policy-reservations.v1";
+  generation: number;
+  phase: "decision" | "execution";
+  cumulativeSpend: CumulativeSpendReservationHandle[];
+  windowedInvoke: WindowedInvokeReservationHandle | null;
+}
+
+type ReservationReconciliationTarget = "settled" | "released";
+
+let reservationReconciliationFaultForTests: "before_apply" | "after_apply" | null = null;
+
+/** Test-only crash injection at the external-effect / DB-CAS boundary. */
+export function __setReservationReconciliationFaultForTests(
+  fault: "before_apply" | "after_apply" | null,
+): void {
+  reservationReconciliationFaultForTests = fault;
+}
+
+function persistedReservationHandles(
+  cumulativeSpend: CumulativeSpendReservationHandle[],
+  windowedInvoke: WindowedInvokeReservationHandle | undefined,
+): PersistedPolicyReservationHandlesV1 | null {
+  if (cumulativeSpend.length === 0 && windowedInvoke === undefined) return null;
+  return {
+    schemaVersion: "steward.provider-policy-reservations.v1",
+    generation: 1,
+    phase: "decision",
+    cumulativeSpend,
+    windowedInvoke: windowedInvoke ?? null,
+  };
+}
+
+function parsePersistedReservationHandles(
+  value: unknown,
+): PersistedPolicyReservationHandlesV1 | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const v = value as Record<string, unknown>;
+  if (v.schemaVersion !== "steward.provider-policy-reservations.v1") return null;
+  if (!Number.isSafeInteger(v.generation) || (v.generation as number) <= 0) return null;
+  if (v.phase !== "decision" && v.phase !== "execution") return null;
+  if (!Array.isArray(v.cumulativeSpend)) return null;
+  const cumulativeSpend: CumulativeSpendReservationHandle[] = [];
+  for (const raw of v.cumulativeSpend) {
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+    const r = raw as Record<string, unknown>;
+    if (!r.stream || typeof r.stream !== "object" || Array.isArray(r.stream)) return null;
+    const stream = r.stream as Record<string, unknown>;
+    if (
+      typeof stream.agentId !== "string" ||
+      !["operation", "agent", "grant"].includes(String(stream.scope)) ||
+      typeof stream.scopeKey !== "string" ||
+      typeof stream.currency !== "string" ||
+      typeof r.reservationId !== "string" ||
+      !Number.isSafeInteger(r.amount) ||
+      (r.amount as number) < 0
+    )
+      return null;
+    cumulativeSpend.push({
+      stream: {
+        agentId: stream.agentId,
+        scope: stream.scope as CumulativeSpendScope,
+        scopeKey: stream.scopeKey,
+        currency: stream.currency,
+      },
+      reservationId: r.reservationId,
+      amount: r.amount as number,
+    });
+  }
+  let windowedInvoke: WindowedInvokeReservationHandle | null = null;
+  if (v.windowedInvoke !== null) {
+    if (
+      !v.windowedInvoke ||
+      typeof v.windowedInvoke !== "object" ||
+      Array.isArray(v.windowedInvoke)
+    )
+      return null;
+    const r = v.windowedInvoke as Record<string, unknown>;
+    if (
+      typeof r.agentId !== "string" ||
+      typeof r.operationKey !== "string" ||
+      typeof r.reservationId !== "string"
+    )
+      return null;
+    windowedInvoke = {
+      agentId: r.agentId,
+      operationKey: r.operationKey,
+      reservationId: r.reservationId,
+    };
+  }
+  if (cumulativeSpend.length === 0 && windowedInvoke === null) return null;
+  return {
+    schemaVersion: "steward.provider-policy-reservations.v1",
+    generation: v.generation as number,
+    phase: v.phase,
+    cumulativeSpend,
+    windowedInvoke,
+  };
+}
+
+function reconciliationTargetForStatus(
+  status: string,
+  phase: PersistedPolicyReservationHandlesV1["phase"],
+): ReservationReconciliationTarget | null {
+  if (status === "stub_succeeded" || status === "succeeded") return "settled";
+  // Decision-time reservations for approval-gated actions are never carried
+  // across the human lifecycle; execution takes a fresh authoritative reserve.
+  if (
+    phase === "decision" &&
+    [
+      "pending_approval",
+      "approved",
+      "execution_ready",
+      "approval_denied",
+      "approval_expired",
+      "approval_stale",
+    ].includes(status)
+  )
+    return "released";
+  if (status === "denied" || status === "stub_failed" || status === "failed") return "released";
+  // allowed_stub / approved / execution_ready / executing / outcome_unknown:
+  // never free maybe-consumed budget before the action has a known outcome.
+  return null;
 }
 
 // ─── Public result envelope ───────────────────────────────────────────────────
@@ -633,6 +757,14 @@ class ProviderActionService {
           policyRevisionHash: policy ? policy.doc.policyRevisionHash : null,
           policyDecision: policy ? (policy.doc as unknown as Record<string, unknown>) : null,
           policyDecisionHash,
+          policyReservationHandles: persistedReservationHandles(
+            cumulativeSpendReservations,
+            windowedInvokeReservation,
+          ),
+          reservationReconciliationState:
+            cumulativeSpendReservations.length > 0 || windowedInvokeReservation !== undefined
+              ? "pending"
+              : "not_required",
           status: effects.status,
         });
 
@@ -725,8 +857,7 @@ class ProviderActionService {
       // never run on replay, so we DO reclaim. `effects.status === "allowed_stub"`
       // is exactly the replayable-execute case.
       if (effects.status !== "allowed_stub") {
-        await this.finalizeCumulativeSpend(cumulativeSpendReservations, "failure");
-        await this.finalizeWindowedInvoke(windowedInvokeReservation, "failure");
+        await this.reconcilePolicyReservations(tenantId, intentId);
       }
       return {
         kind: "evidence_failure",
@@ -740,8 +871,7 @@ class ProviderActionService {
     if (effects.access === "deny") {
       // Access denied => policy never ran => no reservations to release, but be
       // defensive in case a future path reserves before access resolves.
-      await this.finalizeCumulativeSpend(cumulativeSpendReservations, "failure");
-      await this.finalizeWindowedInvoke(windowedInvokeReservation, "failure");
+      await this.reconcilePolicyReservations(tenantId, intentId);
       return {
         kind: "access_denied",
         code: access.doc.reasonCode,
@@ -756,11 +886,7 @@ class ProviderActionService {
       // spend-cap breach already released its own reservations during eval; this
       // covers a deny for a DIFFERENT reason where a cumulativeSpend rule had
       // passed and reserved - the action will not execute, so free its budget.
-      await this.finalizeCumulativeSpend(
-        (policy as PolicyResult | null)?.cumulativeSpendReservations ?? [],
-        "failure",
-      );
-      await this.finalizeWindowedInvoke(windowedInvokeReservation, "failure");
+      await this.reconcilePolicyReservations(tenantId, intentId);
       const code = (policy as PolicyResult | null)?.doc.reasonCodes[0] ?? "POLICY_HARD_DENY";
       return {
         kind: "policy_denied",
@@ -791,11 +917,7 @@ class ProviderActionService {
       // Correct enforcement requires the approval-execute path to re-reserve at
       // EXECUTION time; that is a documented follow-up filed against the approval
       // plane (provider-approval.ts). See the PR honest-gaps section.
-      await this.finalizeCumulativeSpend(
-        (policy as PolicyResult | null)?.cumulativeSpendReservations ?? [],
-        "failure",
-      );
-      await this.finalizeWindowedInvoke(windowedInvokeReservation, "failure");
+      await this.reconcilePolicyReservations(tenantId, intentId);
       return {
         kind: "approval_required",
         code: "APPROVAL_REQUIRED",
@@ -807,7 +929,6 @@ class ProviderActionService {
     }
 
     // ── Step 4: allow — call the in-process stub, then record the transition. ──
-    const csReservations = (policy as PolicyResult | null)?.cumulativeSpendReservations ?? [];
     let stub: ProviderActionStubResult;
     try {
       stub = await executeProviderActionStub(intentId);
@@ -826,15 +947,6 @@ class ProviderActionService {
         actionDigest,
       };
     }
-    // #206: known outcome. stub_succeeded => settle (keep counted); stub_failed
-    // => release (reclaim spend budget + the maxCalls slot, the action did not
-    // consume one).
-    const outcome = stub.ok ? "success" : "failure";
-    await this.finalizeCumulativeSpend(csReservations, outcome);
-    await this.finalizeWindowedInvoke(
-      (policy as PolicyResult | null)?.windowedInvokeReservation,
-      outcome,
-    );
     // Record the narrow allowed_stub -> stub_succeeded|stub_failed transition.
     await this.db()
       .update(providerActionBindings)
@@ -845,6 +957,9 @@ class ProviderActionService {
           eq(providerActionBindings.status, "allowed_stub"),
         ),
       );
+    // #240: status is the durable outcome source. Reconcile only AFTER the
+    // terminal transition so a crash at any instruction boundary is retryable.
+    await this.reconcilePolicyReservations(tenantId, intentId);
 
     return {
       kind: "allowed",
@@ -1114,7 +1229,7 @@ class ProviderActionService {
     const spendValid =
       decl !== undefined &&
       typeof rawSpend === "number" &&
-      Number.isInteger(rawSpend) &&
+      Number.isSafeInteger(rawSpend) &&
       rawSpend >= 0;
     const thisSpend = spendValid ? (rawSpend as number) : undefined;
 
@@ -1584,7 +1699,138 @@ class ProviderActionService {
         .returning({ id: providerActionAuditOutbox.id });
       if (marked.length > 0 && signedNow) delivered += 1;
     }
+    // #240 extends the same C2 pass to durable policy reservations. Audit and
+    // reservation recovery are independently idempotent; a Redis outage leaves
+    // the reservation pending and fail-closed for the next sweep.
+    await this.reconcilePolicyReservations(tenantId, intentId);
     return delivered;
+  }
+
+  /**
+   * Reconcile terminal provider bindings with their immutable Redis reservation
+   * handles. Redis settle/release operations are idempotent, so workers may race:
+   * they perform the external operation first, then exactly one worker wins the
+   * DB CAS from pending to settled/released. A crash before or after Redis is
+   * safely retried; unknown outcomes remain pending and are never released.
+   */
+  async reconcilePolicyReservations(tenantId?: string, intentId?: string): Promise<number> {
+    const rows = await this.db()
+      .select()
+      .from(providerActionBindings)
+      .where(
+        and(
+          tenantId
+            ? eq(providerActionBindings.tenantId, tenantId)
+            : (sql`true` as unknown as ReturnType<typeof eq>),
+          sql`${providerActionBindings.reservationReconciliationState} IN ('pending','needs_attention')`,
+          intentId
+            ? (sql`true` as unknown as ReturnType<typeof eq>)
+            : (sql`(${providerActionBindings.reservationReconciliationNextRetryAt} IS NULL OR ${providerActionBindings.reservationReconciliationNextRetryAt} <= now())` as unknown as ReturnType<
+                typeof eq
+              >),
+          intentId
+            ? eq(providerActionBindings.intentId, intentId)
+            : (sql`true` as unknown as ReturnType<typeof eq>),
+        ),
+      );
+    let reconciled = 0;
+    for (const row of rows) {
+      const handles = parsePersistedReservationHandles(row.policyReservationHandles);
+      // Corrupt/unrecognized persisted handles fail closed and remain pending.
+      if (!handles) continue;
+      const target = reconciliationTargetForStatus(row.status, handles.phase);
+      if (!target) continue;
+      try {
+        if (reservationReconciliationFaultForTests === "before_apply")
+          throw new Error("injected crash before reservation reconciliation");
+        await this.applyPersistedReservationHandles(handles, target);
+        if (reservationReconciliationFaultForTests === "after_apply")
+          throw new Error("injected crash after reservation reconciliation");
+      } catch (error) {
+        const message = (error instanceof Error ? error.message : String(error)).slice(0, 1000);
+        const attempts = row.reservationReconciliationAttempts + 1;
+        const delaySeconds = Math.min(3600, 2 ** Math.min(attempts, 12));
+        await this.db()
+          .update(providerActionBindings)
+          .set({
+            reservationReconciliationState: attempts >= 20 ? "needs_attention" : "pending",
+            reservationReconciliationAttempts: attempts,
+            reservationReconciliationLastError: message,
+            reservationReconciliationNextRetryAt: new Date(Date.now() + delaySeconds * 1000),
+            updatedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(providerActionBindings.intentId, row.intentId),
+              eq(providerActionBindings.status, row.status),
+              eq(
+                providerActionBindings.reservationReconciliationState,
+                row.reservationReconciliationState,
+              ),
+              eq(
+                providerActionBindings.reservationReconciliationAttempts,
+                row.reservationReconciliationAttempts,
+              ),
+              sql`${providerActionBindings.policyReservationHandles} = ${JSON.stringify(
+                row.policyReservationHandles,
+              )}::jsonb`,
+            ),
+          );
+        console.error(
+          `[provider-reservations] reconciliation failed intent=${row.intentId} generation=${handles.generation} attempts=${attempts}: ${message}`,
+        );
+        continue;
+      }
+      const updated = await this.db()
+        .update(providerActionBindings)
+        .set({
+          reservationReconciliationState: target,
+          reservationReconciledAt: new Date(),
+          reservationReconciliationNextRetryAt: null,
+          reservationReconciliationLastError: null,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(providerActionBindings.intentId, row.intentId),
+            eq(providerActionBindings.status, row.status),
+            eq(
+              providerActionBindings.reservationReconciliationState,
+              row.reservationReconciliationState,
+            ),
+            eq(
+              providerActionBindings.reservationReconciliationAttempts,
+              row.reservationReconciliationAttempts,
+            ),
+            sql`${providerActionBindings.policyReservationHandles} = ${JSON.stringify(
+              row.policyReservationHandles,
+            )}::jsonb`,
+          ),
+        )
+        .returning({ intentId: providerActionBindings.intentId });
+      if (updated.length > 0) reconciled += 1;
+    }
+    return reconciled;
+  }
+
+  private async applyPersistedReservationHandles(
+    handles: PersistedPolicyReservationHandlesV1,
+    target: ReservationReconciliationTarget,
+  ): Promise<void> {
+    await Promise.all(
+      handles.cumulativeSpend.map((r) =>
+        target === "settled"
+          ? settleCumulativeSpend({ stream: r.stream, reservationId: r.reservationId })
+          : releaseCumulativeSpend({
+              stream: r.stream,
+              reservationId: r.reservationId,
+              amount: r.amount,
+            }),
+      ),
+    );
+    if (target === "released" && handles.windowedInvoke) {
+      await releaseWindowedInvoke(handles.windowedInvoke);
+    }
   }
 
   // ── Required-audit outbox drain (post-commit, pre-stub) ──
@@ -1677,26 +1923,12 @@ class ProviderActionService {
     return envelope;
   }
 
-  /**
-   * Idempotent replay path: reconstruct the outcome from an existing binding.
-   *
-   * #206 RESERVATION REPLAY CAVEAT (codex P2, honest gap): cumulative-spend
-   * reservation handles are in-memory to the ORIGINAL create call and are NOT
-   * persisted on the binding. A replay here (or a crash between the binding
-   * commit and the original finalize) therefore has no handle to settle/release.
-   * This is deliberately FAIL-CLOSED, not a silent leak: on the original call a
-   * crash after commit leaves the reservation as `outcome_unknown` (documented:
-   * it ages out at the window edge, never freeing maybe-spent budget). A replay
-   * that resolves to stub_succeeded is a real spend and SHOULD stay counted, so
-   * not releasing is correct. A replay that resolves to stub_failed is the only
-   * case where budget could be transiently over-counted for one window; that is
-   * a bounded DENY-side error (safe), never an allow-side one. Crash-durable
-   * reservation handles (persisted per binding + reconciled by the C2 sweeper)
-   * are the follow-up; this lane does not add a migration for it.
-   */
+  /** Idempotent replay path: reconstruct the outcome from an existing binding. */
   private async outcomeFromBinding(
     b: typeof providerActionBindings.$inferSelect,
   ): Promise<ProviderActionOutcome> {
+    // Opportunistically finish any terminal reservation left pending by a crash.
+    await this.reconcilePolicyReservations(b.tenantId, b.intentId);
     if (b.status === "denied") {
       if (b.accessEffect === "deny")
         return {
@@ -1780,6 +2012,7 @@ class ProviderActionService {
             eq(providerActionBindings.status, "allowed_stub"),
           ),
         );
+      await this.reconcilePolicyReservations(b.tenantId, b.intentId);
       return {
         kind: "allowed",
         code: "POLICY_ALLOW",

--- a/packages/api/src/services/provider-reservation-reconciliation-scheduler.ts
+++ b/packages/api/src/services/provider-reservation-reconciliation-scheduler.ts
@@ -1,0 +1,37 @@
+import { providerActionService } from "./provider-action-service";
+
+const DEFAULT_INTERVAL_MS = 15_000;
+
+function configuredInterval(): number {
+  const parsed = Number(process.env.STEWARD_PROVIDER_RESERVATION_SWEEP_INTERVAL_MS);
+  return Number.isSafeInteger(parsed) && parsed >= 1_000 ? parsed : DEFAULT_INTERVAL_MS;
+}
+
+/**
+ * Starts the autonomous C2 reservation reconciler. The immediate startup pass
+ * closes the crash-before-drain gap; later passes retry transient Redis/DB
+ * failures. The service records attempts, backoff, the last error and a
+ * needs_attention state after sustained failure, so recovery never disappears
+ * into an unobservable catch.
+ */
+export function startProviderReservationReconciliationScheduler(): () => void {
+  if (process.env.STEWARD_PROVIDER_RESERVATION_SWEEPER === "false") return () => {};
+  let running = false;
+  const tick = () => {
+    if (running) return;
+    running = true;
+    void providerActionService
+      .reconcilePolicyReservations()
+      .then((count) => {
+        if (count > 0) console.log(`[provider-reservations] reconciled ${count} reservation(s)`);
+      })
+      .catch((error) => console.error("[provider-reservations] sweep failed:", error))
+      .finally(() => {
+        running = false;
+      });
+  };
+  const timer = setInterval(tick, configuredInterval());
+  timer.unref?.();
+  tick();
+  return () => clearInterval(timer);
+}

--- a/packages/db/drizzle/0084_provider_action_reservation_reconciliation.sql
+++ b/packages/db/drizzle/0084_provider_action_reservation_reconciliation.sql
@@ -1,0 +1,149 @@
+-- #240: crash-durable policy reservation handles and reconciliation state.
+--
+-- Handles are persisted in the same transaction as the provider binding. They
+-- are frozen thereafter. The C2 sweeper may only CAS `pending` to a terminal
+-- reconciliation state after the idempotent Redis settle/release succeeds.
+
+ALTER TABLE "provider_action_bindings"
+  ADD COLUMN "policy_reservation_handles" jsonb,
+  ADD COLUMN "reservation_reconciliation_state" varchar(24) NOT NULL DEFAULT 'not_required',
+  ADD COLUMN "reservation_reconciled_at" timestamptz,
+  ADD COLUMN "reservation_reconciliation_attempts" integer NOT NULL DEFAULT 0,
+  ADD COLUMN "reservation_reconciliation_next_retry_at" timestamptz,
+  ADD COLUMN "reservation_reconciliation_last_error" text;
+--> statement-breakpoint
+
+ALTER TABLE "provider_action_bindings"
+  ADD CONSTRAINT "provider_action_bindings_reservation_state_chk" CHECK (
+    (
+      "reservation_reconciliation_state" = 'not_required'
+      AND "policy_reservation_handles" IS NULL
+      AND "reservation_reconciled_at" IS NULL
+      AND "reservation_reconciliation_attempts" = 0
+      AND "reservation_reconciliation_next_retry_at" IS NULL
+      AND "reservation_reconciliation_last_error" IS NULL
+    ) OR (
+      "reservation_reconciliation_state" IN ('pending','needs_attention')
+      AND "policy_reservation_handles" IS NOT NULL
+      AND "reservation_reconciled_at" IS NULL
+      AND "reservation_reconciliation_attempts" >= 0
+    ) OR (
+      "reservation_reconciliation_state" IN ('settled','released')
+      AND "policy_reservation_handles" IS NOT NULL
+      AND "reservation_reconciled_at" IS NOT NULL
+    )
+  );
+--> statement-breakpoint
+
+ALTER TABLE "provider_action_bindings"
+  ADD CONSTRAINT "provider_action_bindings_reservation_handles_chk" CHECK (
+    "policy_reservation_handles" IS NULL OR (
+      jsonb_typeof("policy_reservation_handles") = 'object'
+      AND "policy_reservation_handles"->>'schemaVersion' = 'steward.provider-policy-reservations.v1'
+      AND ("policy_reservation_handles"->>'generation')::integer > 0
+      AND "policy_reservation_handles"->>'phase' IN ('decision','execution')
+      AND jsonb_typeof("policy_reservation_handles"->'cumulativeSpend') = 'array'
+      AND (
+        jsonb_array_length("policy_reservation_handles"->'cumulativeSpend') > 0
+        OR (
+          "policy_reservation_handles" ? 'windowedInvoke'
+          AND "policy_reservation_handles"->'windowedInvoke' <> 'null'::jsonb
+        )
+      )
+    )
+  );
+--> statement-breakpoint
+
+CREATE INDEX "provider_action_bindings_reservation_pending_idx"
+  ON "provider_action_bindings" ("tenant_id", "created_at")
+  WHERE "reservation_reconciliation_state" IN ('pending','needs_attention');
+--> statement-breakpoint
+
+-- Replace the latest (0082) guard body. The handle document deliberately stays
+-- in the frozen projection. Only the state/timestamp are mutable, and only the
+-- one-way pending -> settled|released transition is legal.
+CREATE OR REPLACE FUNCTION steward_provider_action_binding_guard() RETURNS trigger LANGUAGE plpgsql AS $fn$
+DECLARE
+  frozen_old jsonb;
+  frozen_new jsonb;
+  mutable text[] := ARRAY[
+    'status','binding_revision','approval_actor_user_id','approval_queue_id',
+    'approval_commitment_hash','approved_at','denied_at','expired_at','stale_at',
+    'stale_reason_code','resume_actor','resume_attempt_id','resume_validated_at','updated_at',
+    'reservation_reconciliation_state','reservation_reconciled_at',
+    'reservation_reconciliation_attempts','reservation_reconciliation_next_retry_at',
+    'reservation_reconciliation_last_error'
+  ];
+  col text;
+BEGIN
+  frozen_old := to_jsonb(OLD);
+  frozen_new := to_jsonb(NEW);
+  FOREACH col IN ARRAY mutable LOOP
+    frozen_old := frozen_old - col;
+    frozen_new := frozen_new - col;
+  END LOOP;
+  IF frozen_old IS DISTINCT FROM frozen_new THEN
+    RAISE EXCEPTION 'provider_action_bindings frozen column mutated' USING ERRCODE = '23514';
+  END IF;
+
+  IF OLD.reservation_reconciliation_state IS DISTINCT FROM NEW.reservation_reconciliation_state THEN
+    IF NOT (
+      (
+        OLD.reservation_reconciliation_state IN ('pending','needs_attention')
+        AND NEW.reservation_reconciliation_state IN ('settled','released')
+        AND OLD.reservation_reconciled_at IS NULL
+        AND NEW.reservation_reconciled_at IS NOT NULL
+        AND NEW.reservation_reconciliation_attempts = OLD.reservation_reconciliation_attempts
+      ) OR (
+        OLD.reservation_reconciliation_state = 'pending'
+        AND NEW.reservation_reconciliation_state = 'needs_attention'
+        AND OLD.reservation_reconciled_at IS NULL
+        AND NEW.reservation_reconciled_at IS NULL
+        AND NEW.reservation_reconciliation_attempts = OLD.reservation_reconciliation_attempts + 1
+      )
+    ) THEN
+      RAISE EXCEPTION 'illegal provider_action_bindings reservation reconciliation transition'
+        USING ERRCODE = '23514';
+    END IF;
+  ELSIF OLD.reservation_reconciled_at IS DISTINCT FROM NEW.reservation_reconciled_at THEN
+    RAISE EXCEPTION 'provider_action_bindings reservation timestamp changed without reconciliation'
+      USING ERRCODE = '23514';
+  END IF;
+
+  IF NEW.reservation_reconciliation_attempts < OLD.reservation_reconciliation_attempts OR
+     NEW.reservation_reconciliation_attempts > OLD.reservation_reconciliation_attempts + 1 THEN
+    RAISE EXCEPTION 'illegal provider_action_bindings reservation retry counter transition'
+      USING ERRCODE = '23514';
+  END IF;
+
+  IF OLD.status IS DISTINCT FROM NEW.status THEN
+    IF (OLD.status = 'allowed_stub' AND NEW.status IN ('stub_succeeded','stub_failed')) THEN
+      IF NEW.binding_revision IS DISTINCT FROM OLD.binding_revision THEN
+        RAISE EXCEPTION 'provider_action_bindings stub transition must not change binding_revision'
+          USING ERRCODE = '23514';
+      END IF;
+    ELSIF (
+      (OLD.status = 'pending_approval' AND NEW.status IN ('approved','approval_denied','approval_expired','approval_stale')) OR
+      (OLD.status = 'approved'         AND NEW.status IN ('execution_ready','approval_expired','approval_stale')) OR
+      (OLD.status = 'execution_ready'  AND NEW.status = 'executing') OR
+      (OLD.status = 'execution_ready'  AND NEW.status = 'failed') OR
+      (OLD.status = 'executing'        AND NEW.status IN ('succeeded','failed','outcome_unknown')) OR
+      (OLD.status = 'outcome_unknown'  AND NEW.status IN ('succeeded','failed'))
+    ) THEN
+      IF NEW.binding_revision IS DISTINCT FROM OLD.binding_revision + 1 THEN
+        RAISE EXCEPTION 'provider_action_bindings binding_revision must increment by exactly one on transition'
+          USING ERRCODE = '23514';
+      END IF;
+    ELSE
+      RAISE EXCEPTION 'illegal provider_action_bindings status transition'
+        USING ERRCODE = '23514';
+    END IF;
+  ELSE
+    IF NEW.binding_revision IS DISTINCT FROM OLD.binding_revision THEN
+      RAISE EXCEPTION 'provider_action_bindings binding_revision changed without a status transition'
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+  RETURN NEW;
+END $fn$;
+--> statement-breakpoint

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -449,6 +449,13 @@
       "when": 1784313600000,
       "tag": "0083_provider_approval_quorum",
       "breakpoints": true
+    },
+    {
+      "idx": 84,
+      "version": "7",
+      "when": 1784399999000,
+      "tag": "0084_provider_action_reservation_reconciliation",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/__tests__/provider-action-bindings-migration.test.ts
+++ b/packages/db/src/__tests__/provider-action-bindings-migration.test.ts
@@ -68,6 +68,9 @@ function bindingInsert(overrides: Partial<Record<string, string>> = {}): string 
     policyRevHash: `'${ACCESSHASH}'`,
     policyDecision: `'{}'::jsonb`,
     policyDecisionHash: `'${ACCESSHASH}'`,
+    reservationHandles: "NULL",
+    reservationState: "'not_required'",
+    reservationReconciledAt: "NULL",
     ...overrides,
   } as Record<string, string>;
   return `
@@ -78,6 +81,7 @@ function bindingInsert(overrides: Partial<Record<string, string>> = {}): string 
       access_decision_id, access_effect, access_reason_code, dependency_revisions,
       access_decision, access_decision_hash,
       policy_decision_id, policy_effect, policy_revision_hash, policy_decision, policy_decision_hash,
+      policy_reservation_handles, reservation_reconciliation_state, reservation_reconciled_at,
       status
     ) VALUES (
       '${v.intentId}','ta','${IDS.wsA}','agent-a','${IDS.acctA}',
@@ -86,6 +90,7 @@ function bindingInsert(overrides: Partial<Record<string, string>> = {}): string 
       '${IDS.accessDecision}','${v.accessEffect}','provider_access_allowed','{}'::jsonb,
       '{}'::jsonb,'${ACCESSHASH}',
       ${v.policyId},'${v.policyEffect}',${v.policyRevHash},${v.policyDecision},${v.policyDecisionHash},
+      ${v.reservationHandles},${v.reservationState},${v.reservationReconciledAt},
       '${v.status}'
     );
   `;
@@ -217,6 +222,56 @@ describe("0080 provider_action_bindings migration", () => {
       threw = true;
     }
     expect(threw).toBe(true);
+    await client.close();
+  });
+
+  test("0084 freezes handles and permits only pending -> terminal reconciliation CAS", async () => {
+    const client = new PGlite("memory://");
+    await applyAll(client);
+    await seed(client);
+    const handles = `'{"schemaVersion":"steward.provider-policy-reservations.v1","generation":1,"phase":"decision","cumulativeSpend":[{"stream":{"agentId":"agent-a","scope":"agent","scopeKey":"","currency":"USD"},"reservationId":"r1","amount":7}],"windowedInvoke":null}'::jsonb`;
+    await client.exec(
+      bindingInsert({ reservationHandles: handles, reservationState: "'pending'" }),
+    );
+
+    await expect(
+      client.exec(
+        `UPDATE provider_action_bindings
+         SET policy_reservation_handles = jsonb_set(policy_reservation_handles, '{cumulativeSpend,0,amount}', '8')
+         WHERE intent_id='intent-1'`,
+      ),
+    ).rejects.toBeDefined();
+    await client.exec(
+      `UPDATE provider_action_bindings
+       SET reservation_reconciliation_state='settled', reservation_reconciled_at=now()
+       WHERE intent_id='intent-1' AND reservation_reconciliation_state='pending'`,
+    );
+    const row = await client.query<{
+      reservation_reconciliation_state: string;
+      reservation_reconciled_at: Date | null;
+    }>(
+      `SELECT reservation_reconciliation_state,reservation_reconciled_at
+       FROM provider_action_bindings WHERE intent_id='intent-1'`,
+    );
+    expect(row.rows[0].reservation_reconciliation_state).toBe("settled");
+    expect(row.rows[0].reservation_reconciled_at).not.toBeNull();
+    await expect(
+      client.exec(
+        `UPDATE provider_action_bindings SET reservation_reconciliation_state='released'
+         WHERE intent_id='intent-1'`,
+      ),
+    ).rejects.toBeDefined();
+    await client.close();
+  });
+
+  test("0084 rejects terminal reconciliation without a timestamp", async () => {
+    const client = new PGlite("memory://");
+    await applyAll(client);
+    await seed(client);
+    const handles = `'{"schemaVersion":"steward.provider-policy-reservations.v1","generation":2,"phase":"execution","cumulativeSpend":[],"windowedInvoke":{"agentId":"agent-a","operationKey":"github.issue.list","reservationId":"r2"}}'::jsonb`;
+    await expect(
+      client.exec(bindingInsert({ reservationHandles: handles, reservationState: "'released'" })),
+    ).rejects.toBeDefined();
     await client.close();
   });
 

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -2163,6 +2163,41 @@ export const providerActionBindings = pgTable(
     policyDecision: jsonb("policy_decision").$type<Record<string, unknown>>(),
     policyDecisionHash: varchar("policy_decision_hash", { length: 71 }),
 
+    // #240: immutable Redis reservation identities captured in the same commit
+    // as the authority decision. Only the reconciliation state/timestamp below
+    // may advance after insert; the raw handles remain frozen by migration 0084.
+    policyReservationHandles: jsonb("policy_reservation_handles").$type<{
+      schemaVersion: "steward.provider-policy-reservations.v1";
+      generation: number;
+      phase: "decision" | "execution";
+      cumulativeSpend: Array<{
+        stream: {
+          agentId: string;
+          scope: "operation" | "agent" | "grant";
+          scopeKey: string;
+          currency: string;
+        };
+        reservationId: string;
+        amount: number;
+      }>;
+      windowedInvoke: {
+        agentId: string;
+        operationKey: string;
+        reservationId: string;
+      } | null;
+    }>(),
+    reservationReconciliationState: varchar("reservation_reconciliation_state", { length: 24 })
+      .notNull()
+      .default("not_required"),
+    reservationReconciledAt: timestamp("reservation_reconciled_at", { withTimezone: true }),
+    reservationReconciliationAttempts: integer("reservation_reconciliation_attempts")
+      .notNull()
+      .default(0),
+    reservationReconciliationNextRetryAt: timestamp("reservation_reconciliation_next_retry_at", {
+      withTimezone: true,
+    }),
+    reservationReconciliationLastError: text("reservation_reconciliation_last_error"),
+
     status: varchar("status", { length: 32 }).notNull(),
     // ── PR3 approval lifecycle columns (0081) ──
     // Mutable only via the PR3 transition trigger; binding_revision increments by

--- a/packages/redis/src/__tests__/cumulative-spend-tracker.test.ts
+++ b/packages/redis/src/__tests__/cumulative-spend-tracker.test.ts
@@ -232,6 +232,9 @@ describeRedis("fail closed", () => {
     const caps = [{ windowSeconds: 3600, max: 5_000_000 }];
     await expect(reserveCumulativeSpend({ stream: STREAM, caps, amount: -1 })).rejects.toThrow();
     await expect(reserveCumulativeSpend({ stream: STREAM, caps, amount: 1.5 })).rejects.toThrow();
+    await expect(
+      reserveCumulativeSpend({ stream: STREAM, caps, amount: Number.MAX_SAFE_INTEGER + 1 }),
+    ).rejects.toThrow();
     await expect(reserveCumulativeSpend({ stream: STREAM, caps: [], amount: 1 })).rejects.toThrow();
     await expect(
       reserveCumulativeSpend({

--- a/packages/redis/src/cumulative-spend-tracker.ts
+++ b/packages/redis/src/cumulative-spend-tracker.ts
@@ -201,7 +201,11 @@ return {sum}
 `;
 
 function isNonNegInt(v: number): boolean {
-  return typeof v === "number" && Number.isFinite(v) && Number.isInteger(v) && v >= 0;
+  // Redis Lua numbers are IEEE-754 doubles. Values above MAX_SAFE_INTEGER may
+  // stringify/round differently between JS and Lua, which would make a durable
+  // reservation impossible to identify and release exactly. Reject them before
+  // touching Redis.
+  return typeof v === "number" && Number.isSafeInteger(v) && v >= 0;
 }
 
 function isValidWindow(w: number): boolean {
@@ -407,7 +411,7 @@ export async function releaseWindowedInvoke(input: {
     },
     reservationId: input.reservationId,
     amount: 1,
-  }).catch(() => undefined);
+  });
 }
 
 /**


### PR DESCRIPTION
Closes #240.

Supersedes closed #285 and addresses its exact-head review findings:

- persists versioned, immutable, generation-bound spend/count reservation handles in the authority commit
- distinguishes decision and execution phases so approval lifecycle releases cannot settle a future execution generation
- starts an autonomous all-tenant reconciliation pass after Redis initialization and repeats it periodically
- uses idempotent Redis apply followed by a status/state/attempt/handle-generation DB CAS for multi-worker and crash safety
- records retry count, exponential backoff, bounded last error, and promotes sustained failures to observable `needs_attention` while continuing fail-closed retries
- rejects unsafe integers before Redis/Lua and validates persisted amounts/generation
- never persists policy text or secrets
- enables real Redis coverage in the Postgres integration CI job

Validation on exact head:

- `bun test packages/db/src/__tests__/provider-action-bindings-migration.test.ts` (12 pass)
- `STEWARD_EXECUTION_AUTH_SECRET=... bun test packages/api/src/__tests__/provider-approval-concurrency.test.ts packages/api/src/__tests__/provider-action-service.test.ts` (22 pass)
- API, DB, and Redis TypeScript checks pass
- `bun run lint` passes with only 4 pre-existing warnings and 1 pre-existing info diagnostic
- real Redis crash-before-apply, crash-after-apply-before-CAS, release, settle, and multi-worker race tests run in the repository's Postgres integration CI job (`STEWARD_REDIS_TESTS=1`)
