### PR TITLE
feat(audit): durable per-tenant retention archives

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -343,12 +343,8 @@ STEWARD_AGENT_TOKEN=
 # indefinitely as a ledger record. Default: 365 days.
 # STEWARD_RETENTION_FAILED_TX_DAYS=365
 
-# audit_events — tamper-evident SOC2 audit chain. By default, audit events
-# are NEVER deleted, because SOC2 CC2 / CC7 expect at least one year of
-# retention and most assessors prefer 3+ years. Set this env var to opt in
-# to deletion; a warning will be logged each sweep if the value is below
-# 365 days. For values below 365, also set
-# STEWARD_RETENTION_AUDIT_ARCHIVE_CONFIRMED=true after archiving the audit
-# chain prefix externally.
-# STEWARD_RETENTION_AUDIT_EVENTS_DAYS=
-# STEWARD_RETENTION_AUDIT_ARCHIVE_CONFIRMED=false
+# audit_events — no destructive environment switch exists. Events are never
+# deleted by default. An owner/admin with recent MFA must enable the tenant's
+# retention policy through /audit/retention-policy; Steward then durably seals
+# signed JSONL chunks before a separate transactional floor+delete step. See
+# docs/security/audit-retention-archives.md.

--- a/docs/security/audit-retention-archives.md
+++ b/docs/security/audit-retention-archives.md
@@ -1,0 +1,27 @@
+# Audit retention archives
+
+Steward audit events are retained indefinitely unless an owner or administrator explicitly enables a tenant retention policy. Retention is tenant-scoped, requires a recent-MFA session, and never treats an environment flag as proof of backup.
+
+## Safe workflow
+
+1. Configure `STEWARD_AUDIT_SIGNING_KEY` with an Ed25519 private key and publish the SHA-256 fingerprint of its SPKI public key through an independent channel.
+2. An owner or administrator with recent MFA calls `PUT /audit/retention-policy` with `enabled`, `retentionDays` (30–3650), and `archiveChunkSize` (1–10,000).
+3. `POST /audit/retention/run` selects only the calling tenant's expired contiguous prefix. Steward writes newline-delimited JSON chunks, hashes every exact chunk, signs a versioned manifest, and commits the chunks and sealed receipt before deletion is attempted.
+4. A separate transaction locks the tenant chain, confirms that the sealed receipt begins at the current floor and matches the live ending HMAC, deletes the exact range, advances the floor, and marks the receipt pruned atomically. A crash before this transaction leaves all source events. A rollback leaves neither a partial delete nor an advanced floor. Repeating either operation is idempotent.
+5. Download `GET /audit/archives/:archiveId` and each `GET /audit/archives/:archiveId/chunks/:index`. Store the response `data` as `manifest.json` and chunks under the filenames in `manifest.chunks`.
+6. Verify offline:
+
+```sh
+node scripts/verify-audit-archive.mjs manifest.json . \
+  --expected-key-fingerprint <trusted-spki-sha256>
+```
+
+The verifier checks the trusted signing-key fingerprint, Ed25519 signature, canonical manifest digest, safe chunk names, exact bytes and hashes, tenant/range/count consistency, and chain linkage. A bundle without an independently trusted fingerprint is self-signed evidence and must not be treated as proof of operator identity.
+
+## Durability and limits
+
+The sealed receipt and chunks live in the primary database so pruning cannot be authorized by a transient filesystem write or operator assertion. Operators must still export and back up sealed archives to independently durable storage before destroying or restoring the database. Database replication alone is not an independent archive.
+
+The archive proves that the signed JSONL is byte-for-byte the chain prefix Steward sealed. It does not make an operator who controls both the HMAC and signing keys unable to fabricate history. Key custody, independently published fingerprints, immutable backups, and external checkpoints remain necessary for stronger non-repudiation.
+
+Retention reduces the live personal-data footprint but archived audit records may still contain personal data. Tenant operators remain responsible for lawful retention periods, access control, encryption at rest, backup deletion schedules, legal holds, and data-subject obligations.

--- a/packages/api/src/__tests__/audit-retention-archive.test.ts
+++ b/packages/api/src/__tests__/audit-retention-archive.test.ts
@@ -1,0 +1,182 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { createHash, createPublicKey } from "node:crypto";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { closeDb, getDb, tenants } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { eq, sql } from "drizzle-orm";
+import { verifyAuditChain, writeAuditEvent } from "../services/audit";
+import {
+  createAuditArchive,
+  getAuditArchiveChunk,
+  getAuditArchiveManifest,
+  pruneSealedAuditArchive,
+  setAuditRetentionPolicy,
+} from "../services/audit-archive";
+
+const TENANT = `audit-archive-${Date.now()}`;
+const OTHER = `${TENANT}-other`;
+
+function rows<T>(result: unknown): T[] {
+  if (Array.isArray(result)) return result as T[];
+  return ((result as { rows?: T[] }).rows ?? []) as T[];
+}
+
+describe("durable audit retention archives", () => {
+  beforeAll(async () => {
+    process.env.STEWARD_PGLITE_MEMORY = "true";
+    process.env.STEWARD_AUDIT_HMAC_KEY = "audit-archive-test-hmac-key-0123456789abcdef";
+    process.env.STEWARD_AUDIT_SIGNING_KEY = "11".repeat(32);
+    const { db, client } = await createPGLiteDb("memory://");
+    setPGLiteOverride(db, async () => client.close());
+    await getDb()
+      .insert(tenants)
+      .values([
+        { id: TENANT, name: "Archive Tenant", apiKeyHash: "archive-hash" },
+        { id: OTHER, name: "Other Tenant", apiKeyHash: "other-hash" },
+      ]);
+    for (let i = 1; i <= 5; i++) {
+      await writeAuditEvent({
+        tenantId: TENANT,
+        actorType: "system",
+        action: "archive.fixture",
+        metadata: { i },
+      });
+    }
+  }, 120_000);
+
+  afterAll(async () => {
+    await getDb().execute(sql`DELETE FROM audit_archives WHERE tenant_id = ${TENANT}`);
+    await getDb().delete(tenants).where(eq(tenants.id, TENANT));
+    await getDb().delete(tenants).where(eq(tenants.id, OTHER));
+    await closeDb();
+    delete process.env.STEWARD_PGLITE_MEMORY;
+    delete process.env.STEWARD_AUDIT_HMAC_KEY;
+    delete process.env.STEWARD_AUDIT_SIGNING_KEY;
+  });
+
+  it("keeps tenant policy isolated and validates configured bounds", async () => {
+    const policy = await setAuditRetentionPolicy({
+      tenantId: TENANT,
+      enabled: true,
+      retentionDays: 90,
+      archiveChunkSize: 2,
+      updatedBy: "owner",
+    });
+    expect(policy).toMatchObject({ tenantId: TENANT, enabled: true, retentionDays: 90 });
+    const other = await getDb().execute(
+      sql`SELECT count(*)::int AS count FROM audit_retention_policies WHERE tenant_id = ${OTHER}`,
+    );
+    expect(Number(rows<{ count: number }>(other)[0].count)).toBe(0);
+    expect(
+      setAuditRetentionPolicy({
+        tenantId: TENANT,
+        enabled: true,
+        retentionDays: 29,
+        archiveChunkSize: 2,
+        updatedBy: "owner",
+      }),
+    ).rejects.toThrow("retentionDays");
+  });
+
+  it("seals all chunks before pruning, resumes idempotently, and preserves the live chain", async () => {
+    const sealed = await createAuditArchive({
+      tenantId: TENANT,
+      fromSeq: 1,
+      toSeq: 3,
+      chunkSize: 2,
+    });
+    expect(sealed).toMatchObject({ reused: false, status: "sealed" });
+    expect(sealed.manifest.chunks).toHaveLength(2);
+
+    const before = await getDb().execute(
+      sql`SELECT count(*)::int AS count FROM audit_events WHERE tenant_id = ${TENANT}`,
+    );
+    expect(Number(rows<{ count: number }>(before)[0].count)).toBe(5);
+    expect(await getAuditArchiveManifest(OTHER, sealed.archiveId)).toBeNull();
+    expect(await getAuditArchiveChunk(OTHER, sealed.archiveId, 0)).toBeNull();
+
+    const directory = mkdtempSync(join(tmpdir(), "steward-audit-archive-"));
+    try {
+      writeFileSync(join(directory, "manifest.json"), JSON.stringify(sealed));
+      for (const chunk of sealed.manifest.chunks) {
+        const stored = await getAuditArchiveChunk(TENANT, sealed.archiveId, chunk.index);
+        writeFileSync(join(directory, chunk.file), stored?.jsonl ?? "");
+      }
+      const fingerprint = createHash("sha256")
+        .update(createPublicKey(sealed.publicKey).export({ format: "der", type: "spki" }))
+        .digest("hex");
+      const verifier = spawnSync(
+        "node",
+        [
+          "scripts/verify-audit-archive.mjs",
+          join(directory, "manifest.json"),
+          directory,
+          "--expected-key-fingerprint",
+          fingerprint,
+        ],
+        { cwd: join(import.meta.dir, "../../../.."), encoding: "utf8" },
+      );
+      expect(verifier.status).toBe(0);
+      writeFileSync(join(directory, sealed.manifest.chunks[0].file), "tampered\n");
+      const tampered = spawnSync(
+        "node",
+        ["scripts/verify-audit-archive.mjs", join(directory, "manifest.json"), directory],
+        { cwd: join(import.meta.dir, "../../../.."), encoding: "utf8" },
+      );
+      expect(tampered.status).toBe(1);
+      expect(tampered.stderr).toContain("does not match");
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+
+    const resumed = await createAuditArchive({
+      tenantId: TENANT,
+      fromSeq: 1,
+      toSeq: 3,
+      chunkSize: 2,
+    });
+    expect(resumed).toMatchObject({ archiveId: sealed.archiveId, reused: true });
+
+    const pruned = await pruneSealedAuditArchive(TENANT, sealed.archiveId);
+    expect(pruned).toMatchObject({ deleted: 3, floorSeq: 3, reused: false });
+    expect(await pruneSealedAuditArchive(TENANT, sealed.archiveId)).toMatchObject({
+      deleted: 0,
+      floorSeq: 3,
+      reused: true,
+    });
+    expect(await getAuditArchiveChunk(TENANT, sealed.archiveId, 0)).not.toBeNull();
+    expect(await verifyAuditChain(TENANT, { requireHead: true })).toMatchObject({
+      valid: true,
+      count: 2,
+    });
+  });
+
+  it("refuses deletion without a sealed receipt or across a non-contiguous floor", async () => {
+    expect(pruneSealedAuditArchive(TENANT, "00000000-0000-4000-8000-000000000000")).rejects.toThrow(
+      "sealed",
+    );
+    const later = await createAuditArchive({
+      tenantId: TENANT,
+      fromSeq: 5,
+      toSeq: 5,
+      chunkSize: 1,
+    });
+    await getDb().execute(
+      sql`UPDATE audit_archives SET signature = ${"A".repeat(86)} || '==' WHERE id = ${later.archiveId}::uuid`,
+    );
+    expect(pruneSealedAuditArchive(TENANT, later.archiveId)).rejects.toThrow("signature");
+    await getDb().execute(
+      sql`UPDATE audit_archives SET signature = ${later.signature} WHERE id = ${later.archiveId}::uuid`,
+    );
+    expect(pruneSealedAuditArchive(TENANT, later.archiveId)).rejects.toThrow(
+      "live retention floor 4",
+    );
+    const remaining = await getDb().execute(
+      sql`SELECT seq FROM audit_events WHERE tenant_id = ${TENANT} ORDER BY seq`,
+    );
+    expect(rows<{ seq: number | string }>(remaining).map((row) => Number(row.seq))).toEqual([4, 5]);
+  });
+});

--- a/packages/api/src/routes/audit.ts
+++ b/packages/api/src/routes/audit.ts
@@ -14,7 +14,20 @@ import {
   readAuditBundleData,
   signAuditBundle,
   verifyAuditChain,
+  writeAuditEvent,
 } from "../services/audit";
+import {
+  createAuditArchive,
+  getAuditArchiveChunk,
+  getAuditArchiveManifest,
+  getAuditRetentionPolicy,
+  MAX_ARCHIVE_CHUNK_SIZE,
+  MAX_AUDIT_RETENTION_DAYS,
+  MIN_ARCHIVE_CHUNK_SIZE,
+  MIN_AUDIT_RETENTION_DAYS,
+  runTenantAuditRetention,
+  setAuditRetentionPolicy,
+} from "../services/audit-archive";
 import { AuditSigningKeyError, isCheckpointSigningConfigured } from "../services/audit-checkpoint";
 import {
   type ApiResponse,
@@ -22,6 +35,7 @@ import {
   agents,
   approvalQueue,
   db,
+  safeJsonParse,
   transactions,
 } from "../services/context";
 
@@ -44,6 +58,8 @@ const MAX_AUDIT_METADATA_VALUE_LENGTH = 256;
 // Owner/admin + recent-MFA gate, shared with the PR5 case/evidence routes so
 // both surfaces enforce an IDENTICAL posture (spec §6.3).
 auditRoutes.use("*", auditOwnerAdminMfaGate);
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -801,6 +817,160 @@ auditRoutes.post("/verify", async (c) => {
           : "Partial verification is anchored to the stored predecessor hash and is not proof that earlier audit rows are intact.",
     },
   });
+});
+
+// ─── Tenant retention + durable archive control plane ─────────────────────
+
+auditRoutes.get("/retention-policy", async (c) => {
+  const policy = await getAuditRetentionPolicy(c.get("tenantId"));
+  return c.json({ ok: true, data: policy });
+});
+
+auditRoutes.put("/retention-policy", async (c) => {
+  const body = await safeJsonParse<Record<string, unknown>>(c);
+  if (!body) return c.json<ApiResponse>({ ok: false, error: "Invalid JSON body" }, 400);
+  const allowed = new Set(["enabled", "retentionDays", "archiveChunkSize"]);
+  if (Object.keys(body).some((key) => !allowed.has(key))) {
+    return c.json<ApiResponse>({ ok: false, error: "Unsupported retention policy field" }, 400);
+  }
+  if (
+    typeof body.enabled !== "boolean" ||
+    !Number.isSafeInteger(body.retentionDays) ||
+    !Number.isSafeInteger(body.archiveChunkSize)
+  ) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "enabled, retentionDays, and archiveChunkSize are required" },
+      400,
+    );
+  }
+  const retentionDays = body.retentionDays as number;
+  const archiveChunkSize = body.archiveChunkSize as number;
+  if (retentionDays < MIN_AUDIT_RETENTION_DAYS || retentionDays > MAX_AUDIT_RETENTION_DAYS) {
+    return c.json<ApiResponse>(
+      {
+        ok: false,
+        error: `retentionDays must be ${MIN_AUDIT_RETENTION_DAYS}-${MAX_AUDIT_RETENTION_DAYS}`,
+      },
+      400,
+    );
+  }
+  if (archiveChunkSize < MIN_ARCHIVE_CHUNK_SIZE || archiveChunkSize > MAX_ARCHIVE_CHUNK_SIZE) {
+    return c.json<ApiResponse>(
+      {
+        ok: false,
+        error: `archiveChunkSize must be ${MIN_ARCHIVE_CHUNK_SIZE}-${MAX_ARCHIVE_CHUNK_SIZE}`,
+      },
+      400,
+    );
+  }
+  const tenantId = c.get("tenantId");
+  const policy = await setAuditRetentionPolicy({
+    tenantId,
+    enabled: body.enabled,
+    retentionDays,
+    archiveChunkSize,
+    updatedBy: c.get("userId") ?? null,
+  });
+  await writeAuditEvent({
+    tenantId,
+    actorType: "user",
+    actorId: c.get("userId") ?? null,
+    action: "audit.retention_policy.updated",
+    resourceType: "audit_retention_policy",
+    resourceId: tenantId,
+    metadata: { enabled: policy.enabled, retentionDays, archiveChunkSize },
+    requestId: c.get("requestId") ?? null,
+  });
+  return c.json({ ok: true, data: policy });
+});
+
+auditRoutes.post("/archives", async (c) => {
+  if (!isCheckpointSigningConfigured()) {
+    return c.json<ApiResponse>({ ok: false, error: "Audit signing key is required" }, 503);
+  }
+  const body = await safeJsonParse<Record<string, unknown>>(c);
+  const allowed = new Set(["fromSeq", "toSeq", "chunkSize"]);
+  if (
+    !body ||
+    Object.keys(body).some((key) => !allowed.has(key)) ||
+    !Number.isSafeInteger(body.fromSeq) ||
+    !Number.isSafeInteger(body.toSeq) ||
+    (body.chunkSize !== undefined && !Number.isSafeInteger(body.chunkSize))
+  ) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "fromSeq and toSeq are required safe integers" },
+      400,
+    );
+  }
+  try {
+    const policy = await getAuditRetentionPolicy(c.get("tenantId"));
+    const archive = await createAuditArchive({
+      tenantId: c.get("tenantId"),
+      fromSeq: body.fromSeq as number,
+      toSeq: body.toSeq as number,
+      chunkSize: (body.chunkSize as number | undefined) ?? policy.archiveChunkSize,
+    });
+    return c.json({ ok: true, data: archive }, archive.reused ? 200 : 201);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Audit archive failed";
+    return c.json<ApiResponse>({ ok: false, error: message }, 409);
+  }
+});
+
+auditRoutes.get("/archives/:archiveId", async (c) => {
+  const archiveId = c.req.param("archiveId");
+  if (!UUID_PATTERN.test(archiveId)) {
+    return c.json<ApiResponse>({ ok: false, error: "Archive not found" }, 404);
+  }
+  const manifest = await getAuditArchiveManifest(c.get("tenantId"), archiveId);
+  if (!manifest) return c.json<ApiResponse>({ ok: false, error: "Archive not found" }, 404);
+  return c.json({ ok: true, data: manifest });
+});
+
+auditRoutes.get("/archives/:archiveId/chunks/:index", async (c) => {
+  const archiveId = c.req.param("archiveId");
+  const indexRaw = c.req.param("index");
+  if (!UUID_PATTERN.test(archiveId) || !/^\d{1,6}$/.test(indexRaw)) {
+    return c.json<ApiResponse>({ ok: false, error: "Archive chunk not found" }, 404);
+  }
+  const chunk = await getAuditArchiveChunk(c.get("tenantId"), archiveId, Number(indexRaw));
+  if (!chunk) return c.json<ApiResponse>({ ok: false, error: "Archive chunk not found" }, 404);
+  return new Response(chunk.jsonl, {
+    headers: {
+      "Cache-Control": "no-store",
+      "Content-Type": "application/x-ndjson; charset=utf-8",
+      "X-Content-SHA256": chunk.sha256,
+      "X-Content-Type-Options": "nosniff",
+    },
+  });
+});
+
+auditRoutes.post("/retention/run", async (c) => {
+  if (!isCheckpointSigningConfigured()) {
+    return c.json<ApiResponse>({ ok: false, error: "Audit signing key is required" }, 503);
+  }
+  const tenantId = c.get("tenantId");
+  try {
+    const result = await runTenantAuditRetention(tenantId);
+    const verification = await verifyAuditChain(tenantId, { requireHead: true });
+    if (!verification.valid) {
+      throw new Error(`Post-retention audit verification failed at seq ${verification.brokenAt}`);
+    }
+    await writeAuditEvent({
+      tenantId,
+      actorType: "user",
+      actorId: c.get("userId") ?? null,
+      action: "audit.retention.completed",
+      resourceType: "audit_archive",
+      resourceId: result.archiveId,
+      metadata: result,
+      requestId: c.get("requestId") ?? null,
+    });
+    return c.json({ ok: true, data: result });
+  } catch (error) {
+    console.error(`[audit] retention run failed for tenant ${tenantId}:`, error);
+    return c.json<ApiResponse>({ ok: false, error: "Audit retention failed" }, 500);
+  }
 });
 
 // ─── GET /audit/bundle ────────────────────────────────────────────────────

--- a/packages/api/src/services/audit-archive.ts
+++ b/packages/api/src/services/audit-archive.ts
@@ -1,0 +1,599 @@
+/** Durable, tenant-scoped signed JSONL audit archives and chain-safe pruning. */
+
+import { createHash, createPublicKey, randomUUID, sign, verify } from "node:crypto";
+import { getDb } from "@stwd/db";
+import { sql } from "drizzle-orm";
+import { verifyAuditChain } from "./audit";
+import { parseSigningKey, publicKeyPem } from "./audit-checkpoint";
+
+export const MIN_AUDIT_RETENTION_DAYS = 30;
+export const MAX_AUDIT_RETENTION_DAYS = 3650;
+export const MIN_ARCHIVE_CHUNK_SIZE = 1;
+export const MAX_ARCHIVE_CHUNK_SIZE = 10_000;
+export const MAX_ARCHIVE_EVENTS_PER_RUN = 50_000;
+
+export interface AuditRetentionPolicyValue {
+  tenantId: string;
+  enabled: boolean;
+  retentionDays: number;
+  archiveChunkSize: number;
+  updatedBy: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AuditArchiveChunkManifest {
+  index: number;
+  fromSeq: number;
+  toSeq: number;
+  eventCount: number;
+  sha256: string;
+  byteLength: number;
+  file: string;
+}
+
+export interface AuditArchiveManifestPayload {
+  schemaVersion: "steward.audit-archive.v1";
+  archiveId: string;
+  tenantId: string;
+  createdAt: string;
+  fromSeq: number;
+  toSeq: number;
+  eventCount: number;
+  startPrevHash: string;
+  endHmac: string;
+  format: "application/x-ndjson";
+  chunks: AuditArchiveChunkManifest[];
+}
+
+export interface SignedAuditArchiveManifest {
+  manifest: AuditArchiveManifestPayload;
+  manifestSha256: string;
+  signature: string;
+  publicKey: string;
+  status: "sealed" | "pruned";
+  sealedAt: string;
+  prunedAt: string | null;
+}
+
+export interface AuditArchiveResult extends SignedAuditArchiveManifest {
+  archiveId: string;
+  reused: boolean;
+}
+
+interface AuditEventRow {
+  tenant_id: string;
+  seq: number | string;
+  prev_hash: unknown;
+  hmac: unknown;
+  actor_type: string;
+  actor_id: string | null;
+  action: string;
+  resource_type: string | null;
+  resource_id: string | null;
+  metadata: Record<string, unknown> | null;
+  ip_address: string | null;
+  user_agent: string | null;
+  request_id: string | null;
+  created_at: Date | string;
+}
+
+function rowsFromExecute<T>(result: unknown): T[] {
+  if (Array.isArray(result)) return result as T[];
+  if (result && typeof result === "object" && Array.isArray((result as { rows?: unknown }).rows)) {
+    return (result as { rows: T[] }).rows;
+  }
+  return [];
+}
+
+function canonicalJsonValue(value: unknown): unknown {
+  if (value === undefined || value === null) return null;
+  if (Array.isArray(value)) return value.map(canonicalJsonValue);
+  if (typeof value === "object") {
+    return Object.fromEntries(
+      Object.keys(value as Record<string, unknown>)
+        .sort()
+        .map((key) => [key, canonicalJsonValue((value as Record<string, unknown>)[key])]),
+    );
+  }
+  return value;
+}
+
+function canonicalBytes(value: unknown): Uint8Array {
+  return new TextEncoder().encode(JSON.stringify(canonicalJsonValue(value)));
+}
+
+function sha256Hex(value: string | Uint8Array): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function bytesToHex(value: unknown): string {
+  const bytes =
+    value instanceof Uint8Array
+      ? value
+      : ArrayBuffer.isView(value)
+        ? new Uint8Array(value.buffer, value.byteOffset, value.byteLength)
+        : new Uint8Array(value as ArrayBuffer);
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+function base64ToBytes(value: string): Uint8Array {
+  if (!/^[A-Za-z0-9+/]{86}==$/.test(value)) {
+    throw new Error("Audit archive receipt signature is not canonical base64");
+  }
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  if (bytes.length !== 64) throw new Error("Audit archive receipt signature has invalid length");
+  return bytes;
+}
+
+function asIso(value: Date | string): string {
+  return (value instanceof Date ? value : new Date(value)).toISOString();
+}
+
+function validateInteger(name: string, value: number, min: number, max: number): void {
+  if (!Number.isSafeInteger(value) || value < min || value > max) {
+    throw new Error(`${name} must be an integer between ${min} and ${max}`);
+  }
+}
+
+function archiveLine(row: AuditEventRow): string {
+  return JSON.stringify(
+    canonicalJsonValue({
+      v: 1,
+      tenantId: row.tenant_id,
+      seq: Number(row.seq),
+      prevHash: bytesToHex(row.prev_hash),
+      hmac: bytesToHex(row.hmac),
+      actorType: row.actor_type,
+      actorId: row.actor_id,
+      action: row.action,
+      resourceType: row.resource_type,
+      resourceId: row.resource_id,
+      metadata: row.metadata ?? {},
+      ipAddress: row.ip_address,
+      userAgent: row.user_agent,
+      requestId: row.request_id,
+      createdAt: asIso(row.created_at),
+    }),
+  );
+}
+
+async function lockTenantAuditWriter(
+  tx: { execute(query: ReturnType<typeof sql>): Promise<unknown> },
+  tenantId: string,
+) {
+  if (process.env.STEWARD_DB_MODE !== "pglite" && process.env.STEWARD_PGLITE_MEMORY !== "true") {
+    await tx.execute(
+      sql`SELECT pg_advisory_xact_lock(hashtextextended(${`steward_audit_${tenantId}`}, 0))`,
+    );
+  }
+}
+
+function parseStoredManifest(row: Record<string, unknown>): SignedAuditArchiveManifest {
+  if (
+    !row.manifest ||
+    !row.signature ||
+    !row.public_key ||
+    !row.manifest_sha256 ||
+    !row.sealed_at
+  ) {
+    throw new Error("Audit archive receipt is not durably sealed");
+  }
+  const manifest = row.manifest as unknown as AuditArchiveManifestPayload;
+  const manifestBytes = canonicalBytes(manifest);
+  if (sha256Hex(manifestBytes) !== String(row.manifest_sha256)) {
+    throw new Error("Audit archive receipt manifest digest does not match");
+  }
+  let publicKey;
+  try {
+    publicKey = createPublicKey(String(row.public_key));
+  } catch {
+    throw new Error("Audit archive receipt public key is invalid");
+  }
+  if (
+    publicKey.asymmetricKeyType !== "ed25519" ||
+    !verify(null, manifestBytes, publicKey, base64ToBytes(String(row.signature)))
+  ) {
+    throw new Error("Audit archive receipt signature does not verify");
+  }
+  if (
+    manifest.archiveId !== String(row.id) ||
+    manifest.tenantId !== String(row.tenant_id) ||
+    manifest.fromSeq !== Number(row.from_seq) ||
+    manifest.toSeq !== Number(row.to_seq) ||
+    manifest.eventCount !== Number(row.event_count)
+  ) {
+    throw new Error("Audit archive receipt identity does not match its manifest");
+  }
+  return {
+    manifest,
+    manifestSha256: String(row.manifest_sha256),
+    signature: String(row.signature),
+    publicKey: String(row.public_key),
+    status: row.status === "pruned" ? "pruned" : "sealed",
+    sealedAt: asIso(row.sealed_at as Date | string),
+    prunedAt: row.pruned_at ? asIso(row.pruned_at as Date | string) : null,
+  };
+}
+
+export async function getAuditRetentionPolicy(
+  tenantId: string,
+): Promise<AuditRetentionPolicyValue> {
+  const rows = rowsFromExecute<Record<string, unknown>>(
+    await getDb().execute(sql`
+      SELECT tenant_id, enabled, retention_days, archive_chunk_size, updated_by, created_at, updated_at
+      FROM audit_retention_policies WHERE tenant_id = ${tenantId} LIMIT 1
+    `),
+  );
+  const row = rows[0];
+  if (!row) {
+    return {
+      tenantId,
+      enabled: false,
+      retentionDays: 365,
+      archiveChunkSize: 1000,
+      updatedBy: null,
+      createdAt: "",
+      updatedAt: "",
+    };
+  }
+  return {
+    tenantId: String(row.tenant_id),
+    enabled: Boolean(row.enabled),
+    retentionDays: Number(row.retention_days),
+    archiveChunkSize: Number(row.archive_chunk_size),
+    updatedBy: row.updated_by == null ? null : String(row.updated_by),
+    createdAt: asIso(row.created_at as Date | string),
+    updatedAt: asIso(row.updated_at as Date | string),
+  };
+}
+
+export async function setAuditRetentionPolicy(input: {
+  tenantId: string;
+  enabled: boolean;
+  retentionDays: number;
+  archiveChunkSize: number;
+  updatedBy: string | null;
+}): Promise<AuditRetentionPolicyValue> {
+  validateInteger(
+    "retentionDays",
+    input.retentionDays,
+    MIN_AUDIT_RETENTION_DAYS,
+    MAX_AUDIT_RETENTION_DAYS,
+  );
+  validateInteger(
+    "archiveChunkSize",
+    input.archiveChunkSize,
+    MIN_ARCHIVE_CHUNK_SIZE,
+    MAX_ARCHIVE_CHUNK_SIZE,
+  );
+  await getDb().execute(sql`
+    INSERT INTO audit_retention_policies
+      (tenant_id, enabled, retention_days, archive_chunk_size, updated_by, created_at, updated_at)
+    VALUES
+      (${input.tenantId}, ${input.enabled}, ${input.retentionDays}, ${input.archiveChunkSize},
+       ${input.updatedBy}, now(), now())
+    ON CONFLICT (tenant_id) DO UPDATE
+      SET enabled = EXCLUDED.enabled,
+          retention_days = EXCLUDED.retention_days,
+          archive_chunk_size = EXCLUDED.archive_chunk_size,
+          updated_by = EXCLUDED.updated_by,
+          updated_at = now()
+  `);
+  return getAuditRetentionPolicy(input.tenantId);
+}
+
+export async function createAuditArchive(input: {
+  tenantId: string;
+  fromSeq: number;
+  toSeq: number;
+  chunkSize: number;
+}): Promise<AuditArchiveResult> {
+  validateInteger("fromSeq", input.fromSeq, 1, Number.MAX_SAFE_INTEGER);
+  validateInteger("toSeq", input.toSeq, input.fromSeq, Number.MAX_SAFE_INTEGER);
+  validateInteger("chunkSize", input.chunkSize, MIN_ARCHIVE_CHUNK_SIZE, MAX_ARCHIVE_CHUNK_SIZE);
+  const eventCount = input.toSeq - input.fromSeq + 1;
+  if (eventCount > MAX_ARCHIVE_EVENTS_PER_RUN) {
+    throw new Error(`Archive range cannot exceed ${MAX_ARCHIVE_EVENTS_PER_RUN} events per run`);
+  }
+  const sourceVerification = await verifyAuditChain(input.tenantId, {
+    fromSeq: input.fromSeq,
+    toSeq: input.toSeq,
+    requireHead: true,
+  });
+  if (!sourceVerification.valid || sourceVerification.count !== eventCount) {
+    const brokenAt = sourceVerification.valid
+      ? input.fromSeq + sourceVerification.count
+      : sourceVerification.brokenAt;
+    throw new Error(`Audit archive source failed HMAC verification at seq ${brokenAt}`);
+  }
+
+  return getDb().transaction(async (tx) => {
+    await lockTenantAuditWriter(tx, input.tenantId);
+    const existing = rowsFromExecute<Record<string, unknown>>(
+      await tx.execute(sql`
+        SELECT * FROM audit_archives
+        WHERE tenant_id = ${input.tenantId} AND from_seq = ${input.fromSeq} AND to_seq = ${input.toSeq}
+        LIMIT 1 FOR UPDATE
+      `),
+    )[0];
+    if (existing && (existing.status === "sealed" || existing.status === "pruned")) {
+      return {
+        archiveId: String(existing.id),
+        reused: true,
+        ...parseStoredManifest(existing),
+      };
+    }
+
+    const archiveId = existing ? String(existing.id) : randomUUID();
+    if (!existing) {
+      await tx.execute(sql`
+        INSERT INTO audit_archives
+          (id, tenant_id, from_seq, to_seq, event_count, status, created_at, updated_at)
+        VALUES
+          (${archiveId}::uuid, ${input.tenantId}, ${input.fromSeq}, ${input.toSeq}, ${eventCount},
+           'building', now(), now())
+      `);
+    } else {
+      await tx.execute(sql`DELETE FROM audit_archive_chunks WHERE archive_id = ${archiveId}::uuid`);
+    }
+
+    const chunks: AuditArchiveChunkManifest[] = [];
+    let firstRow: AuditEventRow | undefined;
+    let lastRow: AuditEventRow | undefined;
+    let observedCount = 0;
+    for (let cursor = input.fromSeq, index = 0; cursor <= input.toSeq; index++) {
+      const chunkTo = Math.min(input.toSeq, cursor + input.chunkSize - 1);
+      const rows = rowsFromExecute<AuditEventRow>(
+        await tx.execute(sql`
+          SELECT tenant_id, seq, prev_hash, hmac, actor_type, actor_id, action,
+                 resource_type, resource_id, metadata, ip_address, user_agent, request_id, created_at
+          FROM audit_events
+          WHERE tenant_id = ${input.tenantId} AND seq BETWEEN ${cursor} AND ${chunkTo}
+          ORDER BY seq ASC
+        `),
+      );
+      if (rows.length !== chunkTo - cursor + 1 || Number(rows[0]?.seq) !== cursor) {
+        throw new Error(`Audit archive source is not contiguous at seq ${cursor}`);
+      }
+      for (let i = 1; i < rows.length; i++) {
+        if (Number(rows[i].seq) !== Number(rows[i - 1].seq) + 1) {
+          throw new Error(
+            `Audit archive source is not contiguous at seq ${Number(rows[i - 1].seq) + 1}`,
+          );
+        }
+        if (bytesToHex(rows[i].prev_hash) !== bytesToHex(rows[i - 1].hmac)) {
+          throw new Error(`Audit archive source chain is broken at seq ${Number(rows[i].seq)}`);
+        }
+      }
+      if (lastRow && bytesToHex(rows[0].prev_hash) !== bytesToHex(lastRow.hmac)) {
+        throw new Error(`Audit archive source chain is broken at seq ${cursor}`);
+      }
+      firstRow ??= rows[0];
+      lastRow = rows[rows.length - 1];
+      observedCount += rows.length;
+      const jsonl = `${rows.map(archiveLine).join("\n")}\n`;
+      const chunk = {
+        index,
+        fromSeq: cursor,
+        toSeq: chunkTo,
+        eventCount: rows.length,
+        sha256: sha256Hex(jsonl),
+        byteLength: new TextEncoder().encode(jsonl).length,
+        file: `chunk-${String(index).padStart(6, "0")}.jsonl`,
+      };
+      await tx.execute(sql`
+        INSERT INTO audit_archive_chunks
+          (archive_id, chunk_index, from_seq, to_seq, event_count, sha256, byte_length, jsonl)
+        VALUES
+          (${archiveId}::uuid, ${index}, ${cursor}, ${chunkTo}, ${rows.length}, ${chunk.sha256},
+           ${chunk.byteLength}, ${jsonl})
+      `);
+      chunks.push(chunk);
+      cursor = chunkTo + 1;
+    }
+    if (!firstRow || !lastRow || observedCount !== eventCount) {
+      throw new Error("Audit archive event count changed while sealing");
+    }
+
+    const createdAt = new Date().toISOString();
+    const manifest: AuditArchiveManifestPayload = {
+      schemaVersion: "steward.audit-archive.v1",
+      archiveId,
+      tenantId: input.tenantId,
+      createdAt,
+      fromSeq: input.fromSeq,
+      toSeq: input.toSeq,
+      eventCount,
+      startPrevHash: bytesToHex(firstRow.prev_hash),
+      endHmac: bytesToHex(lastRow.hmac),
+      format: "application/x-ndjson",
+      chunks,
+    };
+    const manifestBytes = canonicalBytes(manifest);
+    const manifestSha256 = sha256Hex(manifestBytes);
+    const signingKey = parseSigningKey(process.env.STEWARD_AUDIT_SIGNING_KEY ?? "");
+    const signature = bytesToBase64(sign(null, manifestBytes, signingKey));
+    const publicKey = publicKeyPem(signingKey);
+    await tx.execute(sql`
+      UPDATE audit_archives
+      SET status = 'sealed', manifest = ${JSON.stringify(manifest)}::jsonb,
+          manifest_sha256 = ${manifestSha256}, signature = ${signature}, public_key = ${publicKey},
+          sealed_at = now(), updated_at = now()
+      WHERE id = ${archiveId}::uuid AND tenant_id = ${input.tenantId}
+    `);
+    const sealed = rowsFromExecute<Record<string, unknown>>(
+      await tx.execute(sql`
+        SELECT * FROM audit_archives WHERE id = ${archiveId}::uuid AND tenant_id = ${input.tenantId}
+      `),
+    )[0];
+    if (!sealed) throw new Error("Audit archive receipt failed to persist");
+    return { archiveId, reused: false, ...parseStoredManifest(sealed) };
+  });
+}
+
+export async function pruneSealedAuditArchive(
+  tenantId: string,
+  archiveId: string,
+): Promise<{ archiveId: string; deleted: number; floorSeq: number; reused: boolean }> {
+  return getDb().transaction(async (tx) => {
+    await lockTenantAuditWriter(tx, tenantId);
+    const receipt = rowsFromExecute<Record<string, unknown>>(
+      await tx.execute(sql`
+        SELECT * FROM audit_archives WHERE id = ${archiveId}::uuid AND tenant_id = ${tenantId}
+        LIMIT 1 FOR UPDATE
+      `),
+    )[0];
+    if (!receipt || (receipt.status !== "sealed" && receipt.status !== "pruned")) {
+      throw new Error("A durably sealed tenant archive receipt is required before pruning");
+    }
+    parseStoredManifest(receipt);
+    const toSeq = Number(receipt.to_seq);
+    const fromSeq = Number(receipt.from_seq);
+    const head = rowsFromExecute<{ floor_seq: number | string; floor_hmac: unknown }>(
+      await tx.execute(sql`
+        SELECT floor_seq, floor_hmac FROM audit_chain_heads
+        WHERE tenant_id = ${tenantId} LIMIT 1 FOR UPDATE
+      `),
+    )[0];
+    if (!head) throw new Error("Audit chain head is missing; refusing to prune");
+    const currentFloor = Number(head.floor_seq);
+    if (receipt.status === "pruned" || currentFloor >= toSeq) {
+      return { archiveId, deleted: 0, floorSeq: currentFloor, reused: true };
+    }
+    if (fromSeq !== currentFloor + 1) {
+      throw new Error(`Archive must begin at the live retention floor ${currentFloor + 1}`);
+    }
+    const anchor = rowsFromExecute<{ seq: number | string; hmac: unknown }>(
+      await tx.execute(sql`
+        SELECT seq, hmac FROM audit_events
+        WHERE tenant_id = ${tenantId} AND seq = ${toSeq} LIMIT 1
+      `),
+    )[0];
+    if (!anchor) throw new Error("Archive floor anchor event is missing; refusing to prune");
+    const manifest = receipt.manifest as unknown as AuditArchiveManifestPayload;
+    if (bytesToHex(anchor.hmac) !== manifest.endHmac) {
+      throw new Error("Archive receipt does not match the live floor anchor HMAC");
+    }
+    const removed = rowsFromExecute<{ seq: number | string }>(
+      await tx.execute(sql`
+        DELETE FROM audit_events
+        WHERE tenant_id = ${tenantId} AND seq BETWEEN ${fromSeq} AND ${toSeq}
+        RETURNING seq
+      `),
+    );
+    if (removed.length !== toSeq - fromSeq + 1) {
+      throw new Error("Prune source changed after archive sealing; transaction rolled back");
+    }
+    await tx.execute(sql`
+      UPDATE audit_chain_heads
+      SET floor_seq = ${toSeq}, floor_hmac = ${anchor.hmac as Uint8Array}, updated_at = now()
+      WHERE tenant_id = ${tenantId}
+    `);
+    await tx.execute(sql`
+      UPDATE audit_archives
+      SET status = 'pruned', pruned_at = now(), updated_at = now()
+      WHERE id = ${archiveId}::uuid AND tenant_id = ${tenantId} AND status = 'sealed'
+    `);
+    return { archiveId, deleted: removed.length, floorSeq: toSeq, reused: false };
+  });
+}
+
+export async function runTenantAuditRetention(tenantId: string): Promise<{
+  tenantId: string;
+  archiveId: string | null;
+  archived: number;
+  deleted: number;
+  floorSeq: number;
+  reused: boolean;
+}> {
+  const policy = await getAuditRetentionPolicy(tenantId);
+  if (!policy.enabled) {
+    return { tenantId, archiveId: null, archived: 0, deleted: 0, floorSeq: 0, reused: false };
+  }
+  const db = getDb();
+  const head = rowsFromExecute<{ floor_seq: number | string; expected_seq: number | string }>(
+    await db.execute(sql`
+      SELECT floor_seq, expected_seq FROM audit_chain_heads WHERE tenant_id = ${tenantId} LIMIT 1
+    `),
+  )[0];
+  if (!head) {
+    return { tenantId, archiveId: null, archived: 0, deleted: 0, floorSeq: 0, reused: false };
+  }
+  const floorSeq = Number(head.floor_seq);
+  const firstFresh = rowsFromExecute<{ seq: number | string }>(
+    await db.execute(sql`
+      SELECT seq FROM audit_events
+      WHERE tenant_id = ${tenantId} AND seq > ${floorSeq}
+        AND created_at >= now() - make_interval(days => ${policy.retentionDays})
+      ORDER BY seq ASC LIMIT 1
+    `),
+  )[0];
+  const last = rowsFromExecute<{ seq: number | string }>(
+    await db.execute(sql`
+      SELECT seq FROM audit_events WHERE tenant_id = ${tenantId} AND seq > ${floorSeq}
+      ORDER BY seq DESC LIMIT 1
+    `),
+  )[0];
+  if (!last) {
+    return { tenantId, archiveId: null, archived: 0, deleted: 0, floorSeq, reused: false };
+  }
+  const eligibleTo = firstFresh ? Number(firstFresh.seq) - 1 : Number(last.seq);
+  if (eligibleTo <= floorSeq) {
+    return { tenantId, archiveId: null, archived: 0, deleted: 0, floorSeq, reused: false };
+  }
+  const toSeq = Math.min(eligibleTo, floorSeq + MAX_ARCHIVE_EVENTS_PER_RUN);
+  const archive = await createAuditArchive({
+    tenantId,
+    fromSeq: floorSeq + 1,
+    toSeq,
+    chunkSize: policy.archiveChunkSize,
+  });
+  const pruned = await pruneSealedAuditArchive(tenantId, archive.archiveId);
+  return {
+    tenantId,
+    archiveId: archive.archiveId,
+    archived: toSeq - floorSeq,
+    deleted: pruned.deleted,
+    floorSeq: pruned.floorSeq,
+    reused: archive.reused || pruned.reused,
+  };
+}
+
+export async function getAuditArchiveManifest(
+  tenantId: string,
+  archiveId: string,
+): Promise<SignedAuditArchiveManifest | null> {
+  const row = rowsFromExecute<Record<string, unknown>>(
+    await getDb().execute(sql`
+      SELECT * FROM audit_archives WHERE id = ${archiveId}::uuid AND tenant_id = ${tenantId} LIMIT 1
+    `),
+  )[0];
+  return row ? parseStoredManifest(row) : null;
+}
+
+export async function getAuditArchiveChunk(
+  tenantId: string,
+  archiveId: string,
+  index: number,
+): Promise<{ jsonl: string; sha256: string; byteLength: number } | null> {
+  const row = rowsFromExecute<{ jsonl: string; sha256: string; byte_length: number | string }>(
+    await getDb().execute(sql`
+      SELECT c.jsonl, c.sha256, c.byte_length
+      FROM audit_archive_chunks c
+      JOIN audit_archives a ON a.id = c.archive_id
+      WHERE c.archive_id = ${archiveId}::uuid AND c.chunk_index = ${index}
+        AND a.tenant_id = ${tenantId} AND a.status IN ('sealed', 'pruned')
+      LIMIT 1
+    `),
+  )[0];
+  return row ? { jsonl: row.jsonl, sha256: row.sha256, byteLength: Number(row.byte_length) } : null;
+}

--- a/packages/api/src/services/retention.ts
+++ b/packages/api/src/services/retention.ts
@@ -4,10 +4,9 @@
  * Deletes rows past their per-table TTL from high-volume operational tables.
  * Defaults are conservative; each table is independently overridable via env.
  *
- * SOC2 note on `audit_events`: tamper-evident audit log entries support
- * incident-response and compliance review. We do NOT delete them by default,
- * and we emit a warning every sweep when an explicit override drops retention
- * below one year. Operators must opt in deliberately.
+ * Audit-event retention is tenant-scoped and disabled by default. Enabled
+ * policies always archive a signed JSONL prefix and durably seal its receipt
+ * before a separate transaction advances the floor and removes source rows.
  *
  * All deletes use parameterized intervals (`make_interval(days := $n)`) so
  * untrusted env values can never be interpolated into SQL text.
@@ -16,6 +15,7 @@
 import { getDb } from "@stwd/db";
 import { sql } from "drizzle-orm";
 import { writeAuditEvent } from "./audit";
+import { runTenantAuditRetention } from "./audit-archive";
 
 const SYSTEM_TENANT_ID = "system";
 
@@ -23,7 +23,6 @@ const SYSTEM_TENANT_ID = "system";
 const DEFAULT_PROXY_AUDIT_DAYS = 90;
 const DEFAULT_REFRESH_TOKEN_GRACE_DAYS = 7;
 const DEFAULT_FAILED_TX_DAYS = 365;
-const DEFAULT_AUDIT_EVENTS_DAYS = 365;
 const MIN_DEACTIVATED_USERS_DAYS = 30;
 
 const SWEEP_INTERVAL_MS = 24 * 60 * 60 * 1000;
@@ -156,79 +155,22 @@ async function sweepFailedTransactions(ctx: RetentionSweepContext): Promise<Swee
 }
 
 async function sweepAuditEvents(ctx: RetentionSweepContext): Promise<SweepResult | null> {
-  const override = readPositiveInt("STEWARD_RETENTION_AUDIT_EVENTS_DAYS");
-  if (override === undefined) {
-    // Default: audit events are immutable — never deleted.
-    return null;
-  }
-  // Sub-floor retention is a hard error, not a warning: silently keeping less
-  // than the SOC2 floor would erode the compliance guarantee unnoticed.
-  if (override < DEFAULT_AUDIT_EVENTS_DAYS) {
-    throw new Error(
-      `[retention] STEWARD_RETENTION_AUDIT_EVENTS_DAYS=${override} is below the ` +
-        `${DEFAULT_AUDIT_EVENTS_DAYS}-day SOC2 floor; refusing to delete audit events. ` +
-        "Set the retention >= 365 days (and STEWARD_RETENTION_AUDIT_ARCHIVE_CONFIRMED=true) to proceed.",
-    );
-  }
-  // Audit rows are part of a tamper-evident chain: a plain DELETE of the prefix
-  // would orphan the survivors from ZERO_HASH and make verification impossible.
-  // Require an explicit operator attestation that rows were archived first.
-  if (process.env.STEWARD_RETENTION_AUDIT_ARCHIVE_CONFIRMED !== "true") {
-    throw new Error(
-      "[retention] Deleting audit_events requires archiving first. Set " +
-        "STEWARD_RETENTION_AUDIT_ARCHIVE_CONFIRMED=true only after the chain prefix " +
-        "has been exported to durable storage; the sweep will then advance the " +
-        "verified floor anchor so post-sweep verification still succeeds.",
-    );
-  }
+  // Retention is now tenant-owned and disabled by default. A boolean env
+  // attestation is never sufficient authority to delete a chain prefix: each
+  // enabled tenant is first copied into signed, durable JSONL archive rows and
+  // only a sealed receipt can authorize the transactional floor+delete step.
+  const policies = rowsFromExecute<{ tenant_id: string }>(
+    await getDb().execute(sql`
+      SELECT tenant_id FROM audit_retention_policies WHERE enabled = true ORDER BY tenant_id
+    `),
+  );
+  if (policies.length === 0) return null;
   await writeRetentionAuthorization("audit_events", ctx);
-
-  const db = getDb();
   let deleted = 0;
-  // Per tenant: archive+drop the eligible prefix and advance the floor anchor
-  // (floor_seq + floor_hmac = the newest surviving-prefix row) so verifyAuditChain
-  // restarts the chain from the anchor instead of the public ZERO_HASH.
-  await db.transaction(async (tx) => {
-    const tenantRows = rowsFromExecute<{ tenant_id: string }>(
-      await tx.execute(sql`
-        SELECT DISTINCT tenant_id FROM audit_events
-        WHERE created_at < now() - make_interval(days => ${override})
-      `),
-    );
-    for (const { tenant_id } of tenantRows) {
-      // New floor = highest seq among rows being dropped for this tenant.
-      const anchorRows = rowsFromExecute<{ seq: number | string; hmac: unknown }>(
-        await tx.execute(sql`
-          SELECT seq, hmac FROM audit_events
-          WHERE tenant_id = ${tenant_id}
-            AND created_at < now() - make_interval(days => ${override})
-          ORDER BY seq DESC LIMIT 1
-        `),
-      );
-      const anchor = anchorRows[0];
-      if (!anchor) continue;
-      const floorSeq = Number(anchor.seq);
-      const floorHmac = anchor.hmac as Uint8Array;
-
-      const removed = await deleteRows(sql`
-        DELETE FROM audit_events
-        WHERE tenant_id = ${tenant_id}
-          AND created_at < now() - make_interval(days => ${override})
-      `);
-      deleted += removed;
-
-      // Persist the new verified floor. The head row already exists from append;
-      // if not (legacy data) we still record the floor so verify can anchor.
-      await tx.execute(sql`
-        INSERT INTO audit_chain_heads (tenant_id, expected_seq, expected_count, head_hmac, floor_seq, floor_hmac, updated_at)
-        VALUES (${tenant_id}, ${floorSeq}, 0, ${floorHmac}, ${floorSeq}, ${floorHmac}, now())
-        ON CONFLICT (tenant_id) DO UPDATE
-          SET floor_seq = ${floorSeq},
-              floor_hmac = ${floorHmac},
-              updated_at = now()
-      `);
-    }
-  });
+  for (const policy of policies) {
+    const result = await runTenantAuditRetention(policy.tenant_id);
+    deleted += result.deleted;
+  }
   return { table: "audit_events", deleted };
 }
 
@@ -308,7 +250,7 @@ function ttlForTable(table: string): number | undefined {
     case "transactions":
       return readPositiveInt("STEWARD_RETENTION_FAILED_TX_DAYS") ?? DEFAULT_FAILED_TX_DAYS;
     case "audit_events":
-      return readPositiveInt("STEWARD_RETENTION_AUDIT_EVENTS_DAYS");
+      return undefined; // per-tenant policy; no global destructive default
     case "auth_kv_store":
       return undefined; // per-row expiry
     case "users.deactivated":

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -84,6 +84,17 @@ export class StewardApiClient {
     }
     return parsed as T;
   }
+
+  async requestText(path: string): Promise<string> {
+    const headers: Record<string, string> = { Accept: "application/x-ndjson" };
+    if (this.token) headers.Authorization = `Bearer ${this.token}`;
+    else if (this.tenantKey) headers["X-Steward-Key"] = this.tenantKey;
+    if (this.tenantId) headers["X-Steward-Tenant"] = this.tenantId;
+    const res = await this.fetchImpl(`${this.baseUrl}${path}`, { method: "GET", headers });
+    const text = await res.text();
+    if (!res.ok) throw new ApiError(`GET ${path} failed with HTTP ${res.status}`, res.status, text);
+    return text;
+  }
 }
 
 function safeJson(text: string): unknown {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env bun
 
 import { spawnSync } from "node:child_process";
-import { readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { StewardApiClient } from "./api";
 import { boolFlag, intFlag, parseArgs, parseJsonFlag, required, stringFlag } from "./args";
 import { runDoctor } from "./doctor";
@@ -28,6 +29,7 @@ Usage:
   steward policy set --name NAME --rules '[...]' [--description TEXT] [--agent-id ID]
   steward approvals list|stats|approve|deny ...
   steward audit bundle [--from 1] [--to N] [--out bundle.json] [--verify]
+  steward audit export --from N --to N --out DIR [--chunk-size N] [--verify] [--fp HEX]
   steward provider-action create --workspace-id ID --account-id ID --operation KEY --arguments '{...}' --idempotency-key KEY
   steward provider-action get|approval|case --id ID
   steward provider-action approve|deny --id ID --reason TEXT [--idempotency-key KEY]
@@ -223,7 +225,44 @@ async function approvalsCommand(action: string | undefined, ctx: CommandContext)
 }
 
 async function auditCommand(action: string | undefined, ctx: CommandContext) {
-  if (action !== "bundle") throw new Error("Supported audit command: audit bundle");
+  if (action === "export") {
+    const fromSeq = intFlag(ctx.flags, "from");
+    const toSeq = intFlag(ctx.flags, "to");
+    if (fromSeq === undefined) throw new Error("--from is required");
+    if (toSeq === undefined) throw new Error("--to is required");
+    const out = required(stringFlag(ctx.flags, "out"), "out");
+    const chunkSize = intFlag(ctx.flags, "chunk-size");
+    const archive = await ctx.api.request<{
+      archiveId: string;
+      manifest: { chunks: Array<{ index: number; file: string }> };
+      manifestSha256: string;
+      signature: string;
+      publicKey: string;
+      status: string;
+      sealedAt: string;
+      prunedAt: string | null;
+    }>("POST", "/audit/archives", { fromSeq, toSeq, chunkSize });
+    mkdirSync(out, { recursive: true, mode: 0o700 });
+    const manifestPath = join(out, "manifest.json");
+    writeFileSync(manifestPath, `${JSON.stringify(archive, null, 2)}\n`, { mode: 0o600 });
+    for (const chunk of archive.manifest.chunks) {
+      const jsonl = await ctx.api.requestText(
+        `/audit/archives/${encodeURIComponent(archive.archiveId)}/chunks/${chunk.index}`,
+      );
+      writeFileSync(join(out, chunk.file), jsonl, { mode: 0o600, flag: "wx" });
+    }
+    if (boolFlag(ctx.flags, "verify")) {
+      const args = ["scripts/verify-audit-archive.mjs", manifestPath, out];
+      const fingerprint = stringFlag(ctx.flags, "fp");
+      if (fingerprint) args.push("--expected-key-fingerprint", fingerprint);
+      const result = spawnSync("node", args, { cwd: process.cwd(), stdio: "inherit" });
+      if (result.status !== 0) throw new Error("Offline audit archive verification failed");
+    }
+    return { archiveId: archive.archiveId, wrote: out, chunks: archive.manifest.chunks.length };
+  }
+  if (action !== "bundle") {
+    throw new Error("Supported audit commands: audit bundle|export");
+  }
   const params = new URLSearchParams();
   params.set("from", String(intFlag(ctx.flags, "from") ?? 1));
   const to = intFlag(ctx.flags, "to");

--- a/packages/db/drizzle/0086_audit_retention_archives.sql
+++ b/packages/db/drizzle/0086_audit_retention_archives.sql
@@ -1,0 +1,66 @@
+-- Per-tenant audit retention plus durable, resumable signed archive receipts.
+-- 0084 is reserved by PR #285; 0085 is reserved by the #201 repair lane.
+
+CREATE TABLE IF NOT EXISTS "audit_retention_policies" (
+  "tenant_id" varchar(64) PRIMARY KEY NOT NULL,
+  "enabled" boolean DEFAULT false NOT NULL,
+  "retention_days" integer DEFAULT 365 NOT NULL,
+  "archive_chunk_size" integer DEFAULT 1000 NOT NULL,
+  "updated_by" varchar(255),
+  "created_at" timestamptz DEFAULT now() NOT NULL,
+  "updated_at" timestamptz DEFAULT now() NOT NULL,
+  CONSTRAINT "audit_retention_policies_tenant_fk"
+    FOREIGN KEY ("tenant_id") REFERENCES "tenants"("id") ON DELETE CASCADE,
+  CONSTRAINT "audit_retention_days_bounds"
+    CHECK ("retention_days" BETWEEN 30 AND 3650),
+  CONSTRAINT "audit_retention_chunk_bounds"
+    CHECK ("archive_chunk_size" BETWEEN 1 AND 10000)
+);
+
+CREATE TABLE IF NOT EXISTS "audit_archives" (
+  "id" uuid PRIMARY KEY NOT NULL,
+  "tenant_id" varchar(64) NOT NULL,
+  "from_seq" bigint NOT NULL,
+  "to_seq" bigint NOT NULL,
+  "event_count" bigint NOT NULL,
+  "status" varchar(16) DEFAULT 'building' NOT NULL,
+  "manifest" jsonb,
+  "manifest_sha256" varchar(64),
+  "signature" text,
+  "public_key" text,
+  "sealed_at" timestamptz,
+  "pruned_at" timestamptz,
+  "created_at" timestamptz DEFAULT now() NOT NULL,
+  "updated_at" timestamptz DEFAULT now() NOT NULL,
+  CONSTRAINT "audit_archives_tenant_fk"
+    FOREIGN KEY ("tenant_id") REFERENCES "tenants"("id") ON DELETE RESTRICT,
+  CONSTRAINT "audit_archives_range_valid" CHECK ("from_seq" > 0 AND "to_seq" >= "from_seq"),
+  CONSTRAINT "audit_archives_count_valid" CHECK ("event_count" = "to_seq" - "from_seq" + 1),
+  CONSTRAINT "audit_archives_status_valid" CHECK ("status" IN ('building', 'sealed', 'pruned')),
+  CONSTRAINT "audit_archives_tenant_range_unique" UNIQUE ("tenant_id", "from_seq", "to_seq")
+);
+
+CREATE INDEX IF NOT EXISTS "audit_archives_tenant_created_idx"
+  ON "audit_archives" ("tenant_id", "created_at");
+CREATE INDEX IF NOT EXISTS "audit_archives_resumable_idx"
+  ON "audit_archives" ("tenant_id", "status", "from_seq", "to_seq");
+
+CREATE TABLE IF NOT EXISTS "audit_archive_chunks" (
+  "archive_id" uuid NOT NULL,
+  "chunk_index" integer NOT NULL,
+  "from_seq" bigint NOT NULL,
+  "to_seq" bigint NOT NULL,
+  "event_count" integer NOT NULL,
+  "sha256" varchar(64) NOT NULL,
+  "byte_length" integer NOT NULL,
+  "jsonl" text NOT NULL,
+  "created_at" timestamptz DEFAULT now() NOT NULL,
+  CONSTRAINT "audit_archive_chunks_pk" PRIMARY KEY ("archive_id", "chunk_index"),
+  CONSTRAINT "audit_archive_chunks_archive_fk"
+    FOREIGN KEY ("archive_id") REFERENCES "audit_archives"("id") ON DELETE CASCADE,
+  CONSTRAINT "audit_archive_chunks_range_valid"
+    CHECK ("chunk_index" >= 0 AND "from_seq" > 0 AND "to_seq" >= "from_seq"),
+  CONSTRAINT "audit_archive_chunks_count_valid"
+    CHECK ("event_count" = "to_seq" - "from_seq" + 1 AND "event_count" BETWEEN 1 AND 10000),
+  CONSTRAINT "audit_archive_chunks_bytes_valid" CHECK ("byte_length" > 0)
+);

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -449,6 +449,13 @@
       "when": 1784313600000,
       "tag": "0083_provider_approval_quorum",
       "breakpoints": true
+    },
+    {
+      "idx": 86,
+      "version": "7",
+      "when": 1784403600000,
+      "tag": "0086_audit_retention_archives",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -26,6 +26,7 @@ import {
   numeric,
   pgEnum,
   pgTable,
+  primaryKey,
   serial,
   text,
   timestamp,
@@ -2544,3 +2545,94 @@ export const auditCheckpoints = pgTable(
 
 export type AuditCheckpointRow = typeof auditCheckpoints.$inferSelect;
 export type NewAuditCheckpointRow = typeof auditCheckpoints.$inferInsert;
+
+export const auditRetentionPolicies = pgTable(
+  "audit_retention_policies",
+  {
+    tenantId: varchar("tenant_id", { length: 64 })
+      .primaryKey()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    enabled: boolean("enabled").notNull().default(false),
+    retentionDays: integer("retention_days").notNull().default(365),
+    archiveChunkSize: integer("archive_chunk_size").notNull().default(1000),
+    updatedBy: varchar("updated_by", { length: 255 }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    retentionBounds: check(
+      "audit_retention_days_bounds",
+      sql`${table.retentionDays} BETWEEN 30 AND 3650`,
+    ),
+    chunkBounds: check(
+      "audit_retention_chunk_bounds",
+      sql`${table.archiveChunkSize} BETWEEN 1 AND 10000`,
+    ),
+  }),
+);
+
+export const auditArchives = pgTable(
+  "audit_archives",
+  {
+    id: uuid("id").primaryKey(),
+    tenantId: varchar("tenant_id", { length: 64 })
+      .notNull()
+      .references(() => tenants.id, { onDelete: "restrict" }),
+    fromSeq: bigint("from_seq", { mode: "number" }).notNull(),
+    toSeq: bigint("to_seq", { mode: "number" }).notNull(),
+    eventCount: bigint("event_count", { mode: "number" }).notNull(),
+    status: varchar("status", { length: 16 }).notNull().default("building"),
+    manifest: jsonb("manifest").$type<Record<string, unknown>>(),
+    manifestSha256: varchar("manifest_sha256", { length: 64 }),
+    signature: text("signature"),
+    publicKey: text("public_key"),
+    sealedAt: timestamp("sealed_at", { withTimezone: true }),
+    prunedAt: timestamp("pruned_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    tenantRangeUnique: uniqueIndex("audit_archives_tenant_range_unique").on(
+      table.tenantId,
+      table.fromSeq,
+      table.toSeq,
+    ),
+    tenantCreatedIdx: index("audit_archives_tenant_created_idx").on(
+      table.tenantId,
+      table.createdAt,
+    ),
+    resumableIdx: index("audit_archives_resumable_idx").on(
+      table.tenantId,
+      table.status,
+      table.fromSeq,
+      table.toSeq,
+    ),
+  }),
+);
+
+export const auditArchiveChunks = pgTable(
+  "audit_archive_chunks",
+  {
+    archiveId: uuid("archive_id")
+      .notNull()
+      .references(() => auditArchives.id, { onDelete: "cascade" }),
+    chunkIndex: integer("chunk_index").notNull(),
+    fromSeq: bigint("from_seq", { mode: "number" }).notNull(),
+    toSeq: bigint("to_seq", { mode: "number" }).notNull(),
+    eventCount: integer("event_count").notNull(),
+    sha256: varchar("sha256", { length: 64 }).notNull(),
+    byteLength: integer("byte_length").notNull(),
+    jsonl: text("jsonl").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    primaryKey: primaryKey({
+      name: "audit_archive_chunks_pk",
+      columns: [table.archiveId, table.chunkIndex],
+    }),
+  }),
+);
+
+export type AuditRetentionPolicy = typeof auditRetentionPolicies.$inferSelect;
+export type AuditArchive = typeof auditArchives.$inferSelect;
+export type AuditArchiveChunk = typeof auditArchiveChunks.$inferSelect;

--- a/scripts/verify-audit-archive.mjs
+++ b/scripts/verify-audit-archive.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+
+/** Offline verifier for a Steward signed JSONL audit archive directory. */
+
+import { createHash, createPublicKey, verify } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+function fail(message) {
+  console.error(`FAIL: ${message}`);
+  process.exit(1);
+}
+
+function canonical(value) {
+  if (value === undefined || value === null) return null;
+  if (Array.isArray(value)) return value.map(canonical);
+  if (typeof value === "object") {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map((key) => [key, canonical(value[key])]),
+    );
+  }
+  return value;
+}
+
+function canonicalBytes(value) {
+  return Buffer.from(JSON.stringify(canonical(value)), "utf8");
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+const manifestPath = process.argv[2];
+if (!manifestPath) {
+  console.error(
+    "usage: node scripts/verify-audit-archive.mjs <manifest.json> [archive-directory] [--expected-key-fingerprint <sha256>]",
+  );
+  process.exit(2);
+}
+const archiveDir = process.argv[3] || dirname(manifestPath);
+const fingerprintFlag = process.argv.indexOf("--expected-key-fingerprint");
+const expectedFingerprint = fingerprintFlag >= 0 ? process.argv[fingerprintFlag + 1] : undefined;
+if (fingerprintFlag >= 0 && !/^[0-9a-f]{64}$/i.test(expectedFingerprint ?? "")) {
+  fail("expected key fingerprint must be exactly 64 hexadecimal characters");
+}
+let envelope;
+try {
+  envelope = JSON.parse(readFileSync(manifestPath, "utf8"));
+} catch (error) {
+  fail(`manifest cannot be read: ${error.message}`);
+}
+const { manifest, manifestSha256, signature, publicKey } = envelope;
+if (!manifest || manifest.schemaVersion !== "steward.audit-archive.v1") {
+  fail("unsupported or missing archive manifest");
+}
+if (!Array.isArray(manifest.chunks) || manifest.chunks.length === 0) {
+  fail("manifest chunks are missing");
+}
+const bytes = canonicalBytes(manifest);
+if (sha256(bytes) !== manifestSha256) fail("manifest SHA-256 does not match");
+let key;
+try {
+  key = createPublicKey({ key: publicKey, format: "pem" });
+} catch (error) {
+  fail(`archive public key is invalid: ${error.message}`);
+}
+if (key.asymmetricKeyType !== "ed25519") fail("archive signing key is not Ed25519");
+const signatureBytes = Buffer.from(signature, "base64");
+if (signatureBytes.length !== 64 || signatureBytes.toString("base64") !== signature) {
+  fail("archive signature is not canonical Ed25519 base64");
+}
+const actualFingerprint = sha256(key.export({ format: "der", type: "spki" }));
+if (expectedFingerprint && actualFingerprint !== expectedFingerprint.toLowerCase()) {
+  fail("archive signing key fingerprint does not match the trusted key");
+}
+if (!verify(null, bytes, key, signatureBytes)) {
+  fail("archive manifest signature does not verify");
+}
+
+let expectedSeq = manifest.fromSeq;
+let previousHmac = manifest.startPrevHash;
+let observed = 0;
+for (let index = 0; index < manifest.chunks.length; index++) {
+  const chunk = manifest.chunks[index];
+  if (chunk.index !== index || chunk.fromSeq !== expectedSeq) {
+    fail(`chunk ${index} range is not contiguous`);
+  }
+  if (!/^chunk-\d{6}\.jsonl$/.test(chunk.file)) fail(`chunk ${index} filename is unsafe`);
+  const path = join(archiveDir, chunk.file);
+  let raw;
+  try {
+    raw = readFileSync(path);
+  } catch (error) {
+    fail(`chunk ${index} cannot be read: ${error.message}`);
+  }
+  if (raw.length !== chunk.byteLength) fail(`chunk ${index} byte length does not match`);
+  if (sha256(raw) !== chunk.sha256) fail(`chunk ${index} SHA-256 does not match`);
+  const text = raw.toString("utf8");
+  if (!text.endsWith("\n")) fail(`chunk ${index} is not newline-terminated JSONL`);
+  const lines = text.slice(0, -1).split("\n");
+  if (lines.length !== chunk.eventCount) fail(`chunk ${index} event count does not match`);
+  for (const line of lines) {
+    let event;
+    try {
+      event = JSON.parse(line);
+    } catch {
+      fail(`chunk ${index} contains invalid JSONL`);
+    }
+    if (event.tenantId !== manifest.tenantId) fail(`event ${expectedSeq} tenant mismatch`);
+    if (event.seq !== expectedSeq) fail(`expected event seq ${expectedSeq}, got ${event.seq}`);
+    if (!/^[0-9a-f]{64}$/.test(event.prevHash) || !/^[0-9a-f]{64}$/.test(event.hmac)) {
+      fail(`event ${event.seq} contains a malformed chain hash`);
+    }
+    if (event.prevHash !== previousHmac) fail(`event ${event.seq} chain linkage mismatch`);
+    previousHmac = event.hmac;
+    expectedSeq++;
+    observed++;
+  }
+  if (chunk.toSeq !== expectedSeq - 1) fail(`chunk ${index} toSeq does not match content`);
+}
+if (observed !== manifest.eventCount || expectedSeq - 1 !== manifest.toSeq) {
+  fail("archive manifest event range/count does not match JSONL content");
+}
+if (previousHmac !== manifest.endHmac) fail("archive end HMAC does not match manifest");
+
+console.log("PASS");
+console.log(`  archive: ${manifest.archiveId}`);
+console.log(`  tenant:  ${manifest.tenantId}`);
+console.log(`  events:  ${manifest.eventCount} (seq ${manifest.fromSeq}..${manifest.toSeq})`);
+console.log(`  chunks:  ${manifest.chunks.length}`);
+console.log("  manifest signature: Ed25519 OK");
+console.log("  JSONL hashes/linkage: OK");


### PR DESCRIPTION
Closes #216

## Summary
- replace the global destructive audit-retention env switch with explicit per-tenant policy (disabled by default) behind the existing owner/admin + recent-MFA audit gate
- durably seal versioned Ed25519-signed JSONL chunks and a manifest receipt before any source deletion
- verify the live HMAC source, receipt digest/signature/identity, contiguous floor, exact ending HMAC, and exact delete count; atomically advance floor + delete + mark pruned
- make archive and prune resumable/idempotent, tenant-isolated, and bounded (50k events/run, 10k/chunk)
- add CLI export plus offline verifier with independently trusted signing-key fingerprint support
- document durability, trust, backup, privacy, and non-repudiation limits
- use migration 0086 (0084 is active in PR #289; 0085 is reserved by the coordinated #201 repair lane)

## Exact-head verification
Head: `8ace53989f63de4d5a57f6498cf23c58d600e6ca`

- `bun test --timeout 120000 packages/api/src/__tests__/audit-retention-archive.test.ts` — 3 pass, 0 fail, 20 assertions; includes migration application, policy isolation/bounds, archive-before-delete, signed offline verification, tampered JSONL rejection, idempotent resume/prune, receipt signature corruption rejection, contiguous-floor refusal, and post-prune chain verification
- `bun test --timeout 120000 packages/api/src/__tests__/audit-chain-strict.test.ts packages/api/src/__tests__/audit-retention-archive.test.ts packages/api/src/__tests__/retention.test.ts` — 5 pass, 5 DATABASE_URL-only skips, 0 fail, 24 assertions
- `bun test packages/api/src/__tests__/auth-audit-hardening.test.ts packages/api/src/__tests__/secret-bearing-cache-control.test.ts` — 20 pass, 0 fail, 228 assertions (owner/admin session, recent MFA, and no-store audit gates)
- `bunx turbo run build --filter=@stwd/api --filter=@stwd/cli` — 22/22 tasks successful
- Biome on all changed TS/JS files and `git diff --check` — clean

## Security properties
There is no boolean/environment attestation that permits audit deletion. A sealed status alone is insufficient: prune re-hashes the canonical manifest, verifies Ed25519 and archive/tenant/range identity, matches the live ending HMAC, deletes the exact range, and advances the chain floor in one transaction. A crash before prune leaves source rows; a prune failure rolls back deletion and floor movement together.