### PR TITLE
feat(api): expose least-privilege agent action status

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -8944,6 +8944,196 @@
         }
       }
     },
+    "/v2/provider-actions/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "tags": [
+          "Provider Authority"
+        ],
+        "summary": "Get the authenticated agent's own provider-action status",
+        "description": "Requires an agent JWT. The action is scoped server-side to the verified tenant and agent; absent, malformed, cross-agent, and cross-tenant ids all return the same 404 response. This route does not grant access to the human/MFA-gated approval, case, or evidence surfaces.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "X-Steward-Tenant",
+            "in": "header",
+            "required": false,
+            "description": "Tenant containing the authenticated agent. It is checked against the verified agent principal and never selects a foreign action.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "required": [
+                        "id",
+                        "status",
+                        "version",
+                        "workspaceId",
+                        "providerAccountId",
+                        "operationId",
+                        "operationRevision",
+                        "actionDigest",
+                        "requestHash",
+                        "expiresAt",
+                        "createdAt",
+                        "updatedAt"
+                      ],
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "status": {
+                          "type": "string"
+                        },
+                        "version": {
+                          "type": "integer",
+                          "minimum": 1
+                        },
+                        "workspaceId": {
+                          "type": "string"
+                        },
+                        "providerAccountId": {
+                          "type": "string"
+                        },
+                        "operationId": {
+                          "type": "string"
+                        },
+                        "operationRevision": {
+                          "type": "integer",
+                          "minimum": 1
+                        },
+                        "actionDigest": {
+                          "type": "string"
+                        },
+                        "requestHash": {
+                          "type": "string"
+                        },
+                        "expiresAt": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "format": "date-time"
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/accounts": {
       "get": {
         "tags": [
@@ -33842,7 +34032,8 @@
                 "policy_rule_delete",
                 "policy_rule_update",
                 "quorum_update",
-                "wallet_action"
+                "wallet_action",
+                "provider-action"
               ]
             }
           },
@@ -33861,7 +34052,8 @@
                 "policy_rule_delete",
                 "policy_rule_update",
                 "quorum_update",
-                "wallet_action"
+                "wallet_action",
+                "provider-action"
               ]
             }
           },
@@ -33880,7 +34072,8 @@
                 "policy_rule_delete",
                 "policy_rule_update",
                 "quorum_update",
-                "wallet_action"
+                "wallet_action",
+                "provider-action"
               ]
             }
           },
@@ -33991,7 +34184,8 @@
                                   "policy_rule_delete",
                                   "policy_rule_update",
                                   "quorum_update",
-                                  "wallet_action"
+                                  "wallet_action",
+                                  "provider-action"
                                 ]
                               },
                               "intent_type": {
@@ -34005,7 +34199,8 @@
                                   "policy_rule_delete",
                                   "policy_rule_update",
                                   "quorum_update",
-                                  "wallet_action"
+                                  "wallet_action",
+                                  "provider-action"
                                 ]
                               },
                               "status": {
@@ -34314,7 +34509,8 @@
                       "policy_rule_delete",
                       "policy_rule_update",
                       "quorum_update",
-                      "wallet_action"
+                      "wallet_action",
+                      "provider-action"
                     ]
                   },
                   "intent_type": {
@@ -34328,7 +34524,8 @@
                       "policy_rule_delete",
                       "policy_rule_update",
                       "quorum_update",
-                      "wallet_action"
+                      "wallet_action",
+                      "provider-action"
                     ]
                   },
                   "agentId": {
@@ -34497,7 +34694,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "intent_type": {
@@ -34511,7 +34709,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "status": {
@@ -34959,7 +35158,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "intent_type": {
@@ -34973,7 +35173,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "status": {
@@ -35350,7 +35551,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "intent_type": {
@@ -35364,7 +35566,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "status": {
@@ -35837,7 +36040,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "intent_type": {
@@ -35851,7 +36055,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "status": {
@@ -36323,7 +36528,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "intent_type": {
@@ -36337,7 +36543,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "status": {
@@ -36809,7 +37016,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "intent_type": {
@@ -36823,7 +37031,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "status": {
@@ -37295,7 +37504,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "intent_type": {
@@ -37309,7 +37519,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "status": {
@@ -37781,7 +37992,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "intent_type": {
@@ -37795,7 +38007,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "status": {
@@ -38267,7 +38480,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "intent_type": {
@@ -38281,7 +38495,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "status": {
@@ -38692,7 +38907,8 @@
                 "policy_rule_delete",
                 "policy_rule_update",
                 "quorum_update",
-                "wallet_action"
+                "wallet_action",
+                "provider-action"
               ]
             }
           },
@@ -38711,7 +38927,8 @@
                 "policy_rule_delete",
                 "policy_rule_update",
                 "quorum_update",
-                "wallet_action"
+                "wallet_action",
+                "provider-action"
               ]
             }
           },
@@ -38730,7 +38947,8 @@
                 "policy_rule_delete",
                 "policy_rule_update",
                 "quorum_update",
-                "wallet_action"
+                "wallet_action",
+                "provider-action"
               ]
             }
           },
@@ -38841,7 +39059,8 @@
                                   "policy_rule_delete",
                                   "policy_rule_update",
                                   "quorum_update",
-                                  "wallet_action"
+                                  "wallet_action",
+                                  "provider-action"
                                 ]
                               },
                               "intent_type": {
@@ -38855,7 +39074,8 @@
                                   "policy_rule_delete",
                                   "policy_rule_update",
                                   "quorum_update",
-                                  "wallet_action"
+                                  "wallet_action",
+                                  "provider-action"
                                 ]
                               },
                               "status": {
@@ -39164,7 +39384,8 @@
                       "policy_rule_delete",
                       "policy_rule_update",
                       "quorum_update",
-                      "wallet_action"
+                      "wallet_action",
+                      "provider-action"
                     ]
                   },
                   "intent_type": {
@@ -39178,7 +39399,8 @@
                       "policy_rule_delete",
                       "policy_rule_update",
                       "quorum_update",
-                      "wallet_action"
+                      "wallet_action",
+                      "provider-action"
                     ]
                   },
                   "agentId": {
@@ -39347,7 +39569,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "intent_type": {
@@ -39361,7 +39584,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "status": {
@@ -39714,7 +39938,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "intent_type": {
@@ -39728,7 +39953,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "status": {
@@ -40105,7 +40331,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "intent_type": {
@@ -40119,7 +40346,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "status": {
@@ -40497,7 +40725,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "intent_type": {
@@ -40511,7 +40740,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "status": {
@@ -40888,7 +41118,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "intent_type": {
@@ -40902,7 +41133,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "status": {
@@ -41279,7 +41511,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "intent_type": {
@@ -41293,7 +41526,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "status": {
@@ -41670,7 +41904,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "intent_type": {
@@ -41684,7 +41919,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "status": {
@@ -42061,7 +42297,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "intent_type": {
@@ -42075,7 +42312,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "status": {
@@ -42452,7 +42690,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "intent_type": {
@@ -42466,7 +42705,8 @@
                             "policy_rule_delete",
                             "policy_rule_update",
                             "quorum_update",
-                            "wallet_action"
+                            "wallet_action",
+                            "provider-action"
                           ]
                         },
                         "status": {

--- a/packages/api/src/__tests__/intent-read-hardening.test.ts
+++ b/packages/api/src/__tests__/intent-read-hardening.test.ts
@@ -96,4 +96,14 @@ describe("intent read hardening", () => {
     expect(transferBody).toContain("const txId = row.id");
     expect(transferBody).not.toContain("row.resourceId || row.id");
   });
+
+  it("redacts authorization details before dispatching intent webhooks", () => {
+    const start = routeSource.indexOf("function dispatchIntentWebhook");
+    const end = routeSource.indexOf("function dispatchWalletActionSuccessWebhook", start);
+    const body = routeSource.slice(start, end);
+    expect(body).toContain(
+      "authorization_details: redactIntentResponseValue(row.authorizationDetails)",
+    );
+    expect(body).not.toContain("authorization_details: row.authorizationDetails");
+  });
 });

--- a/packages/api/src/__tests__/intent-read-hardening.test.ts
+++ b/packages/api/src/__tests__/intent-read-hardening.test.ts
@@ -1,25 +1,67 @@
 import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import {
+  redactIntentResponseValue,
+  toProviderActionStatusResponse,
+} from "../services/intent-response";
 
 const routeSource = readFileSync(join(import.meta.dir, "..", "routes", "intents.ts"), "utf8");
 
 describe("intent read hardening", () => {
-  it("redacts signed transaction material from stored intent read responses", () => {
-    const responseStart = routeSource.indexOf("function toIntentResponse");
-    expect(responseStart).toBeGreaterThanOrEqual(0);
-    const responseBody = routeSource.slice(
-      responseStart,
-      routeSource.indexOf("function redactSignedTransactions", responseStart),
+  it("behaviorally redacts adversarial nested and array credential shapes", () => {
+    const canary = "intent-hardening-canary";
+    const redacted = redactIntentResponseValue({
+      tokenAddress: "0xabc",
+      nested: [
+        { password: `${canary}-password`, passphrase: `${canary}-passphrase` },
+        { auth: `Bearer ${canary}-auth`, clientSecretValue: `${canary}-client-secret` },
+        { privateKeyPem: `-----BEGIN PRIVATE KEY-----\n${canary}\n-----END PRIVATE KEY-----` },
+        { cookieHeader: `session=${canary}-cookie` },
+        { endpoint: `https://user:${canary}-userinfo@example.test/path` },
+      ],
+    });
+    const text = JSON.stringify(redacted);
+    expect(text).not.toContain(canary);
+    expect(text).toContain('"tokenAddress":"0xabc"');
+  });
+
+  it("provider-action status DTO is an explicit scalar allowlist", () => {
+    const canary = "provider-status-canary";
+    const hostileInput = {
+      id: "pa_00000000-0000-4000-8000-000000000001",
+      status: "pending_approval",
+      version: 1,
+      workspaceId: "20000000-0000-4000-8000-000000000001",
+      providerAccountId: "30000000-0000-4000-8000-000000000001",
+      operationId: "40000000-0000-4000-8000-000000000001",
+      operationRevision: 1,
+      actionDigest: `sha256:${"a".repeat(64)}`,
+      requestHash: `sha256:${"b".repeat(64)}`,
+      expiresAt: null,
+      createdAt: new Date("2026-08-16T00:00:00.000Z"),
+      updatedAt: new Date("2026-08-16T00:00:01.000Z"),
+      payload: { password: canary },
+      safeSummary: { auth: canary },
+    };
+    const status = toProviderActionStatusResponse(hostileInput);
+    expect(Object.keys(status).sort()).toEqual(
+      [
+        "actionDigest",
+        "createdAt",
+        "expiresAt",
+        "id",
+        "operationId",
+        "operationRevision",
+        "providerAccountId",
+        "requestHash",
+        "status",
+        "updatedAt",
+        "version",
+        "workspaceId",
+      ].sort(),
     );
-    expect(responseBody).toContain(
-      "executionResult: redactSignedTransactions(row.executionResult)",
-    );
-    expect(responseBody).toContain(
-      "execution_result: redactSignedTransactions(row.executionResult)",
-    );
-    expect(responseBody).not.toContain("executionResult: row.executionResult");
-    expect(responseBody).not.toContain("execution_result: row.executionResult");
+    expect(JSON.stringify(status)).not.toContain(canary);
   });
 
   it("attributes intent audits to the actual auth type and writes lifecycle authorization audit first", () => {

--- a/packages/api/src/__tests__/intent-read-hardening.test.ts
+++ b/packages/api/src/__tests__/intent-read-hardening.test.ts
@@ -2,28 +2,72 @@ import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import {
-  redactIntentResponseValue,
+  redactSignedTransactions,
+  toIntentResponse,
   toProviderActionStatusResponse,
 } from "../services/intent-response";
 
 const routeSource = readFileSync(join(import.meta.dir, "..", "routes", "intents.ts"), "utf8");
 
 describe("intent read hardening", () => {
-  it("behaviorally redacts adversarial nested and array credential shapes", () => {
-    const canary = "intent-hardening-canary";
-    const redacted = redactIntentResponseValue({
+  it("preserves benign generic intent data while redacting signed transactions", () => {
+    const value = {
       tokenAddress: "0xabc",
+      prose: [
+        "token price is rising",
+        "authorization required by policy",
+        "secret sauce recipe",
+        "cookie policy accepted",
+      ],
+      cookiePolicy: "accepted",
+      authorizationStatus: "required",
+      privateKeyRequired: false,
       nested: [
-        { password: `${canary}-password`, passphrase: `${canary}-passphrase` },
-        { auth: `Bearer ${canary}-auth`, clientSecretValue: `${canary}-client-secret` },
-        { privateKeyPem: `-----BEGIN PRIVATE KEY-----\n${canary}\n-----END PRIVATE KEY-----` },
-        { cookieHeader: `session=${canary}-cookie` },
-        { endpoint: `https://user:${canary}-userinfo@example.test/path` },
+        { signedTx: "0xsigned", txHash: "0xhash" },
+        { signed_tx: "0xsigned-snake", status: "complete" },
+      ],
+    };
+
+    expect(redactSignedTransactions(value)).toEqual({
+      ...value,
+      nested: [
+        { signedTx: "[redacted]", txHash: "0xhash" },
+        { signed_tx: "[redacted]", status: "complete" },
       ],
     });
-    const text = JSON.stringify(redacted);
-    expect(text).not.toContain(canary);
-    expect(text).toContain('"tokenAddress":"0xabc"');
+  });
+
+  it("keeps generic GET, webhook, and persistence on the signedTx-only contract", () => {
+    const authorizationDetails = { authorizationStatus: "required", cookiePolicy: "accepted" };
+    const payload = { prose: "token price is rising", privateKeyRequired: false };
+    const response = toIntentResponse({
+      id: "intent-1",
+      authorizationDetails,
+      payload,
+      executionResult: { signedTx: "0xsigned", prose: "secret sauce recipe" },
+      createdAt: new Date("2026-08-16T00:00:00.000Z"),
+    } as Parameters<typeof toIntentResponse>[0]);
+
+    expect(response.authorizationDetails).toBe(authorizationDetails);
+    expect(response.payload).toBe(payload);
+    expect(response.executionResult).toEqual({
+      signedTx: "[redacted]",
+      prose: "secret sauce recipe",
+    });
+
+    const webhookStart = routeSource.indexOf("function dispatchIntentWebhook");
+    const webhookEnd = routeSource.indexOf(
+      "function dispatchWalletActionSuccessWebhook",
+      webhookStart,
+    );
+    const webhookBody = routeSource.slice(webhookStart, webhookEnd);
+    expect(webhookBody).toContain("authorization_details: row.authorizationDetails");
+    expect(webhookBody).toContain(
+      "execution_result: redactSignedTransactions(row.executionResult)",
+    );
+    expect(routeSource).toContain(
+      "const storedExecutionResult = redactSignedTransactions(executionResult)",
+    );
   });
 
   it("provider-action status DTO is an explicit scalar allowlist", () => {
@@ -95,15 +139,5 @@ describe("intent read hardening", () => {
     );
     expect(transferBody).toContain("const txId = row.id");
     expect(transferBody).not.toContain("row.resourceId || row.id");
-  });
-
-  it("redacts authorization details before dispatching intent webhooks", () => {
-    const start = routeSource.indexOf("function dispatchIntentWebhook");
-    const end = routeSource.indexOf("function dispatchWalletActionSuccessWebhook", start);
-    const body = routeSource.slice(start, end);
-    expect(body).toContain(
-      "authorization_details: redactIntentResponseValue(row.authorizationDetails)",
-    );
-    expect(body).not.toContain("authorization_details: row.authorizationDetails");
   });
 });

--- a/packages/api/src/__tests__/openapi-contract.test.ts
+++ b/packages/api/src/__tests__/openapi-contract.test.ts
@@ -914,6 +914,34 @@ describe("generated OpenAPI contract", () => {
     expect(paths["/v2/provider-grants"]).toHaveProperty("post");
     expect(paths["/v2/provider-grants/{id}/revoke"]).toHaveProperty("post");
     expect(paths["/v2/provider-access/check"]).toHaveProperty("post");
+    expect(paths["/v2/provider-actions/{id}"]).toHaveProperty("get");
+
+    const status = paths["/v2/provider-actions/{id}"].get;
+    expect(status.security).toEqual([{ bearerAuth: [] }]);
+    expect(status.description).toContain("cross-agent");
+    expect(status.description).toContain("human/MFA-gated");
+    const responseStatus =
+      status.responses["200"].content["application/json"].schema.properties.data;
+    expect(responseStatus.additionalProperties).toBe(false);
+    expect(Object.keys(responseStatus.properties).sort()).toEqual(
+      [
+        "actionDigest",
+        "createdAt",
+        "expiresAt",
+        "id",
+        "operationId",
+        "operationRevision",
+        "providerAccountId",
+        "requestHash",
+        "status",
+        "updatedAt",
+        "version",
+        "workspaceId",
+      ].sort(),
+    );
+    expect(responseStatus.properties).not.toHaveProperty("payload");
+    expect(responseStatus.properties).not.toHaveProperty("executionResult");
+    expect(responseStatus.properties).not.toHaveProperty("safeSummary");
   });
 
   it("serves the generated contract at /openapi.json", async () => {

--- a/packages/api/src/__tests__/provider-actions-route.test.ts
+++ b/packages/api/src/__tests__/provider-actions-route.test.ts
@@ -10,10 +10,12 @@
 
 import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { createServer, type Server } from "node:http";
+import { generateApiKey } from "@stwd/auth";
 import {
   agents,
   closeDb,
   getDb,
+  intents,
   providerAccounts,
   providerGrants,
   providerOperations,
@@ -22,6 +24,7 @@ import {
   workspaces,
 } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { eq } from "drizzle-orm";
 import { type Hono } from "hono";
 import { exportJWK, generateKeyPair, type KeyLike, SignJWT } from "jose";
 import type { AppVariables } from "../services/context";
@@ -29,24 +32,30 @@ import type { AppVariables } from "../services/context";
 setDefaultTimeout(120_000);
 
 const TENANT = "tenant-main";
+const TENANT_OTHER = "tenant-other";
 const AGENT = "agent-x";
+const AGENT_OTHER = "agent-y";
+const AGENT_OTHER_TENANT = "agent-z";
 const WORKSPACE_A = "20000000-0000-4000-8000-000000000001";
 const ACCOUNT_A = "30000000-0000-4000-8000-000000000001";
 const OP_A_READ = "40000000-0000-4000-8000-000000000001";
 const GRANTOR = "10000000-0000-4000-8000-000000000001";
 const FUTURE = new Date(Date.now() + 365 * 24 * 3600_000);
 const KID = "test-kid-1";
+const TENANT_KEY = generateApiKey();
+const CREDENTIAL_CANARY = "credential-canary-issue-233";
 
 let app: Hono<{ Variables: AppVariables }>;
 let jwksServer: Server;
 let privateKey: KeyLike;
+let statusIntentId = "";
 
-async function signAgentToken(scopes: string[]): Promise<string> {
-  return new SignJWT({ agent_id: AGENT, scopes })
+async function signAgentToken(scopes: string[], agentId = AGENT): Promise<string> {
+  return new SignJWT({ agent_id: agentId, scopes })
     .setProtectedHeader({ alg: "RS256", kid: KID })
     .setIssuer("eliza-cloud")
     .setAudience("steward")
-    .setSubject(`agent:${AGENT}`)
+    .setSubject(`agent:${agentId}`)
     .setIssuedAt()
     .setExpirationTime("10m")
     .sign(privateKey);
@@ -54,11 +63,21 @@ async function signAgentToken(scopes: string[]): Promise<string> {
 
 async function seed() {
   const db = getDb();
-  await db.insert(tenants).values([{ id: TENANT, name: "Main", apiKeyHash: "h" }]);
+  await db.insert(tenants).values([
+    { id: TENANT, name: "Main", apiKeyHash: TENANT_KEY.hash },
+    { id: TENANT_OTHER, name: "Other", apiKeyHash: "other-hash" },
+  ]);
   await db.insert(users).values([{ id: GRANTOR, email: "g@t.test" }]);
-  await db
-    .insert(agents)
-    .values([{ id: AGENT, tenantId: TENANT, name: "X", walletAddress: "0x1" }]);
+  await db.insert(agents).values([
+    { id: AGENT, tenantId: TENANT, name: "X", walletAddress: "0x1" },
+    { id: AGENT_OTHER, tenantId: TENANT, name: "Y", walletAddress: "0x2" },
+    {
+      id: AGENT_OTHER_TENANT,
+      tenantId: TENANT_OTHER,
+      name: "Z",
+      walletAddress: "0x3",
+    },
+  ]);
   await db.insert(workspaces).values([
     {
       id: WORKSPACE_A,
@@ -112,13 +131,18 @@ async function seed() {
   });
 }
 
-async function post(token: string, body: string, contentType = "application/json") {
+async function post(
+  token: string,
+  body: string,
+  contentType = "application/json",
+  tenantId = TENANT,
+) {
   return app.request("/v2/provider-actions", {
     method: "POST",
     headers: {
       "content-type": contentType,
       authorization: `Bearer ${token}`,
-      "X-Steward-Tenant": TENANT,
+      "X-Steward-Tenant": tenantId,
     },
     body,
   });
@@ -152,6 +176,52 @@ describe("POST /v2/provider-actions (route)", () => {
     // the Phase-1 middleware-only app, so all `/v2` routes are mounted.
     const mod = await import("../app");
     app = mod.app as Hono<{ Variables: AppVariables }>;
+
+    // Create one real provider action through the mounted HTTP route. The status
+    // tests below then exercise the exact persisted binding + intent rows.
+    const token = await signAgentToken([]);
+    const created = await post(
+      token,
+      JSON.stringify({
+        workspaceId: WORKSPACE_A,
+        providerAccountId: ACCOUNT_A,
+        operationKey: "github.issue.list",
+        arguments: { owner: "octo", repo: "hello" },
+        idempotencyKey: "idem-status-fixture",
+      }),
+    );
+    expect(created.status).toBe(200);
+    statusIntentId = ((await created.json()) as { id: string }).id;
+
+    // Every generic JSON surface is hostile at the agent response boundary.
+    // Populate nested/array variants of common credential shapes; the status
+    // DTO must omit the blobs wholesale, rather than trying to redact them.
+    await getDb()
+      .update(intents)
+      .set({
+        authorizationDetails: [
+          {
+            nested: [
+              { password: `${CREDENTIAL_CANARY}-password` },
+              { passphrase: `${CREDENTIAL_CANARY}-passphrase` },
+              { auth: `Bearer ${CREDENTIAL_CANARY}-auth` },
+            ],
+          },
+        ],
+        payload: {
+          operationKey: "github.issue.list",
+          items: [
+            { clientSecretValue: `${CREDENTIAL_CANARY}-client-secret` },
+            { cookieHeader: `session=${CREDENTIAL_CANARY}-cookie` },
+            { endpoint: `https://user:${CREDENTIAL_CANARY}-userinfo@example.test/path` },
+          ],
+        },
+        executionResult: {
+          privateKeyPem: `-----BEGIN PRIVATE KEY-----\n${CREDENTIAL_CANARY}-pem\n-----END PRIVATE KEY-----`,
+          nested: [{ apiKey: `${CREDENTIAL_CANARY}-api-key` }],
+        },
+      })
+      .where(eq(intents.id, statusIntentId));
   });
 
   afterAll(async () => {
@@ -221,6 +291,120 @@ describe("POST /v2/provider-actions (route)", () => {
       method: "POST",
       headers: { "content-type": "application/json", "X-Steward-Tenant": TENANT },
       body: "{}",
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test("agent reads its own provider action through an explicit scalar-only status DTO", async () => {
+    const token = await signAgentToken(["some:unrelated:scope"]);
+    const own = await app.request(`/v2/provider-actions/${statusIntentId}`, {
+      headers: { authorization: `Bearer ${token}`, "X-Steward-Tenant": TENANT },
+    });
+    expect(own.status).toBe(200);
+    expect(own.headers.get("cache-control")).toBe("no-store, max-age=0");
+    const ownBody = (await own.json()) as { ok: boolean; data: Record<string, unknown> };
+
+    expect(ownBody.ok).toBe(true);
+    expect(Object.keys(ownBody.data).sort()).toEqual(
+      [
+        "actionDigest",
+        "createdAt",
+        "expiresAt",
+        "id",
+        "operationId",
+        "operationRevision",
+        "providerAccountId",
+        "requestHash",
+        "status",
+        "updatedAt",
+        "version",
+        "workspaceId",
+      ].sort(),
+    );
+    expect(ownBody.data).toMatchObject({
+      id: statusIntentId,
+      status: "stub_succeeded",
+      version: 1,
+      workspaceId: WORKSPACE_A,
+      providerAccountId: ACCOUNT_A,
+      operationId: OP_A_READ,
+      operationRevision: 1,
+    });
+  });
+
+  test("omits nested and array credential canaries instead of redacting extensible blobs", async () => {
+    const token = await signAgentToken([]);
+    const res = await app.request(`/v2/provider-actions/${statusIntentId}`, {
+      headers: { authorization: `Bearer ${token}`, "X-Steward-Tenant": TENANT },
+    });
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).not.toContain(CREDENTIAL_CANARY);
+    for (const forbiddenField of [
+      "authorizationDetails",
+      "payload",
+      "executionResult",
+      "safeSummary",
+      "requestEnvelope",
+      "accessDecision",
+      "policyDecision",
+    ]) {
+      expect(text).not.toContain(forbiddenField);
+    }
+  });
+
+  test("returns the same uniform 404 for foreign agent, foreign tenant, absent, and malformed ids", async () => {
+    const cases = [
+      {
+        token: await signAgentToken([], AGENT_OTHER),
+        tenantId: TENANT,
+        id: statusIntentId,
+      },
+      {
+        token: await signAgentToken([], AGENT_OTHER_TENANT),
+        tenantId: TENANT_OTHER,
+        id: statusIntentId,
+      },
+      {
+        token: await signAgentToken([]),
+        tenantId: TENANT,
+        id: "pa_00000000-0000-4000-8000-000000000000",
+      },
+      { token: await signAgentToken([]), tenantId: TENANT, id: "not-an-action" },
+    ];
+
+    const responses: Array<{ status: number; body: unknown }> = [];
+    for (const item of cases) {
+      const res = await app.request(`/v2/provider-actions/${item.id}`, {
+        headers: {
+          authorization: `Bearer ${item.token}`,
+          "X-Steward-Tenant": item.tenantId,
+        },
+      });
+      responses.push({ status: res.status, body: await res.json() });
+    }
+
+    expect(responses).toEqual(
+      cases.map(() => ({
+        status: 404,
+        body: { ok: false, error: "PROVIDER_ACTION_NOT_FOUND" },
+      })),
+    );
+  });
+
+  test("exact status route does not weaken approval/case/evidence human-MFA gates", async () => {
+    const token = await signAgentToken([]);
+    for (const suffix of ["approval", "case", "evidence"]) {
+      const res = await app.request(`/v2/provider-actions/${statusIntentId}/${suffix}`, {
+        headers: { authorization: `Bearer ${token}`, "X-Steward-Tenant": TENANT },
+      });
+      expect(res.status).toBe(403);
+    }
+  });
+
+  test("status route requires an agent JWT", async () => {
+    const res = await app.request(`/v2/provider-actions/${statusIntentId}`, {
+      headers: { "X-Steward-Tenant": TENANT },
     });
     expect(res.status).toBe(401);
   });

--- a/packages/api/src/openapi.ts
+++ b/packages/api/src/openapi.ts
@@ -60,6 +60,7 @@ const intentTypeSchema: JsonSchema = {
     "policy_rule_update",
     "quorum_update",
     "wallet_action",
+    "provider-action",
   ],
 };
 const intentSchema: JsonSchema = {
@@ -104,6 +105,39 @@ const intentSchema: JsonSchema = {
     executedAt: { type: ["string", "null"], format: "date-time" },
     createdAt: dateTimeSchema,
     created_at: { type: "integer" },
+    updatedAt: dateTimeSchema,
+  },
+};
+
+const providerActionStatusSchema: JsonSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: [
+    "id",
+    "status",
+    "version",
+    "workspaceId",
+    "providerAccountId",
+    "operationId",
+    "operationRevision",
+    "actionDigest",
+    "requestHash",
+    "expiresAt",
+    "createdAt",
+    "updatedAt",
+  ],
+  properties: {
+    id: stringSchema,
+    status: stringSchema,
+    version: { type: "integer", minimum: 1 },
+    workspaceId: stringSchema,
+    providerAccountId: stringSchema,
+    operationId: stringSchema,
+    operationRevision: { type: "integer", minimum: 1 },
+    actionDigest: stringSchema,
+    requestHash: stringSchema,
+    expiresAt: { type: ["string", "null"], format: "date-time" },
+    createdAt: dateTimeSchema,
     updatedAt: dateTimeSchema,
   },
 };
@@ -297,6 +331,28 @@ function providerAuthorityPaths(): Record<string, OpenApiPathItem> {
           content: { "application/json": { schema: metadataSchema } },
         },
         responses: { "200": jsonResponse(apiResponse(metadataSchema)), ...errorResponses() },
+      },
+    },
+    "/v2/provider-actions/{id}": {
+      parameters: [parameter("id", "path")],
+      get: {
+        tags: ["Provider Authority"],
+        summary: "Get the authenticated agent's own provider-action status",
+        description:
+          "Requires an agent JWT. The action is scoped server-side to the verified tenant and agent; absent, malformed, cross-agent, and cross-tenant ids all return the same 404 response. This route does not grant access to the human/MFA-gated approval, case, or evidence surfaces.",
+        security: [{ bearerAuth: [] }],
+        parameters: [
+          headerParameter(
+            "X-Steward-Tenant",
+            "Tenant containing the authenticated agent. It is checked against the verified agent principal and never selects a foreign action.",
+          ),
+        ],
+        responses: {
+          "200": jsonResponse(apiResponse(providerActionStatusSchema)),
+          "401": jsonResponse(errorResponse()),
+          "403": jsonResponse(errorResponse()),
+          "404": jsonResponse(errorResponse()),
+        },
       },
     },
   };

--- a/packages/api/src/routes/intents.ts
+++ b/packages/api/src/routes/intents.ts
@@ -31,6 +31,7 @@ import {
   transactions,
   vault,
 } from "../services/context";
+import { redactIntentResponseValue, toIntentResponse } from "../services/intent-response";
 import { getPolicyRulesValidationError } from "../services/policy-validation";
 import { dispatchWebhook } from "../services/webhook-dispatch";
 
@@ -1032,75 +1033,6 @@ async function assertIntentAuthorizationBaselineCurrent(row: typeof intents.$inf
   }
 }
 
-function toIntentResponse(row: typeof intents.$inferSelect) {
-  return {
-    id: row.id,
-    intent_id: row.id,
-    tenantId: row.tenantId,
-    agentId: row.agentId,
-    wallet_id: row.agentId,
-    intentType: row.intentType,
-    intent_type: row.intentType,
-    status: row.status,
-    resourceType: row.resourceType,
-    resource_id: row.resourceId,
-    resourceId: row.resourceId,
-    createdByType: row.createdByType,
-    created_by_id: row.createdById,
-    createdById: row.createdById,
-    created_by_display_name: row.createdByDisplayName,
-    createdByDisplayName: row.createdByDisplayName,
-    authorizationDetails: row.authorizationDetails,
-    authorization_details: row.authorizationDetails,
-    payload: row.payload,
-    executionResult: redactSignedTransactions(row.executionResult),
-    execution_result: redactSignedTransactions(row.executionResult),
-    expiresAt: row.expiresAt,
-    expires_at: row.expiresAt?.getTime() ?? null,
-    authorizedBy: row.authorizedBy,
-    authorized_by: row.authorizedBy,
-    canceledAt: row.canceledAt,
-    canceledBy: row.canceledBy,
-    canceled_by: row.canceledBy,
-    cancellationReason: row.cancellationReason,
-    cancellation_reason: row.cancellationReason,
-    expiredAt: row.expiredAt,
-    expiredBy: row.expiredBy,
-    expired_by: row.expiredBy,
-    rejectedAt: row.rejectedAt,
-    rejectedBy: row.rejectedBy,
-    rejected_by: row.rejectedBy,
-    rejectionReason: row.rejectionReason,
-    rejection_reason: row.rejectionReason,
-    executedBy: row.executedBy,
-    executed_by: row.executedBy,
-    failedAt: row.failedAt,
-    failedBy: row.failedBy,
-    failed_by: row.failedBy,
-    failureReason: row.failureReason,
-    failure_reason: row.failureReason,
-    createdAt: row.createdAt,
-    created_at: row.createdAt.getTime(),
-    updatedAt: row.updatedAt,
-    authorizedAt: row.authorizedAt,
-    executedAt: row.executedAt,
-  };
-}
-
-function redactSignedTransactions(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(redactSignedTransactions);
-  if (!value || typeof value !== "object") return value;
-  const redacted: Record<string, unknown> = {};
-  for (const [key, nested] of Object.entries(value)) {
-    if (key === "signedTx" || key === "signed_tx") {
-      redacted[key] = "[redacted]";
-    } else {
-      redacted[key] = redactSignedTransactions(nested);
-    }
-  }
-  return redacted;
-}
-
 async function writeIntentAudit(
   c: Context<{ Variables: AppVariables }>,
   action: string,
@@ -1142,7 +1074,7 @@ function dispatchIntentWebhook(
     status: row.status,
     resource_id: row.resourceId,
     authorization_details: row.authorizationDetails,
-    execution_result: redactSignedTransactions(row.executionResult),
+    execution_result: redactIntentResponseValue(row.executionResult),
     rejection_reason: row.rejectionReason,
     cancellation_reason: row.cancellationReason,
     failure_reason: row.failureReason,
@@ -1167,7 +1099,7 @@ function dispatchWalletActionSuccessWebhook(
     dispatchWebhook(tenantId, agentId, "wallet_action.send_calls.succeeded", {
       actionId: executionResult.actionId,
       intent_id: executionResult.actionId,
-      signedCalls: redactSignedTransactions(executionResult.signedCalls),
+      signedCalls: redactIntentResponseValue(executionResult.signedCalls),
     });
   }
 }
@@ -1931,7 +1863,7 @@ async function updateIntentStatus(
       return c.json<ApiResponse>({ ok: false, error: failureReason }, 400);
     }
 
-    const storedExecutionResult = redactSignedTransactions(executionResult) as Record<
+    const storedExecutionResult = redactIntentResponseValue(executionResult) as Record<
       string,
       unknown
     >;

--- a/packages/api/src/routes/intents.ts
+++ b/packages/api/src/routes/intents.ts
@@ -1073,7 +1073,7 @@ function dispatchIntentWebhook(
     action_type: row.intentType,
     status: row.status,
     resource_id: row.resourceId,
-    authorization_details: row.authorizationDetails,
+    authorization_details: redactIntentResponseValue(row.authorizationDetails),
     execution_result: redactIntentResponseValue(row.executionResult),
     rejection_reason: row.rejectionReason,
     cancellation_reason: row.cancellationReason,

--- a/packages/api/src/routes/intents.ts
+++ b/packages/api/src/routes/intents.ts
@@ -31,7 +31,7 @@ import {
   transactions,
   vault,
 } from "../services/context";
-import { redactIntentResponseValue, toIntentResponse } from "../services/intent-response";
+import { redactSignedTransactions, toIntentResponse } from "../services/intent-response";
 import { getPolicyRulesValidationError } from "../services/policy-validation";
 import { dispatchWebhook } from "../services/webhook-dispatch";
 
@@ -1073,8 +1073,8 @@ function dispatchIntentWebhook(
     action_type: row.intentType,
     status: row.status,
     resource_id: row.resourceId,
-    authorization_details: redactIntentResponseValue(row.authorizationDetails),
-    execution_result: redactIntentResponseValue(row.executionResult),
+    authorization_details: row.authorizationDetails,
+    execution_result: redactSignedTransactions(row.executionResult),
     rejection_reason: row.rejectionReason,
     cancellation_reason: row.cancellationReason,
     failure_reason: row.failureReason,
@@ -1099,7 +1099,7 @@ function dispatchWalletActionSuccessWebhook(
     dispatchWebhook(tenantId, agentId, "wallet_action.send_calls.succeeded", {
       actionId: executionResult.actionId,
       intent_id: executionResult.actionId,
-      signedCalls: redactIntentResponseValue(executionResult.signedCalls),
+      signedCalls: redactSignedTransactions(executionResult.signedCalls),
     });
   }
 }
@@ -1863,7 +1863,7 @@ async function updateIntentStatus(
       return c.json<ApiResponse>({ ok: false, error: failureReason }, 400);
     }
 
-    const storedExecutionResult = redactIntentResponseValue(executionResult) as Record<
+    const storedExecutionResult = redactSignedTransactions(executionResult) as Record<
       string,
       unknown
     >;

--- a/packages/api/src/routes/provider-actions.ts
+++ b/packages/api/src/routes/provider-actions.ts
@@ -16,14 +16,17 @@
  */
 
 import { createHash, randomBytes } from "node:crypto";
+import { getDb, intents, providerActionBindings } from "@stwd/db";
 import { buildGithubAction, isGithubOperationKey } from "@stwd/provider-github";
 import { buildXAction, isXOperationKey } from "@stwd/provider-x";
 import { CanonError, decodeUtf8Strict, isCanonError, strictParseJson } from "@stwd/shared";
+import { and, eq } from "drizzle-orm";
 import type { Context } from "hono";
 import { Hono } from "hono";
 import { requireProviderAgentJwt } from "../middleware/agent-jwt";
 import { resolveProviderPrincipal } from "../middleware/provider-principal";
 import { type ApiResponse, type AppVariables, setNoStoreHeaders } from "../services/context";
+import { toProviderActionStatusResponse } from "../services/intent-response";
 import {
   type ProviderActionOutcome,
   providerActionService,
@@ -56,6 +59,16 @@ export function registerProviderActionRoutes(app: Hono<{ Variables: AppVariables
   });
   app.use("/v2/provider-actions", requireProviderAgentJwt);
   app.post("/v2/provider-actions", handleCreateProviderAction);
+
+  // #233: a read-only status view for the authenticated agent's own actions.
+  // Keep this path exact (no wildcard suffix) so the sibling approval, execute,
+  // case, and evidence routes retain their distinct human/MFA gates.
+  app.use("/v2/provider-actions/:id", async (c, next) => {
+    setNoStoreHeaders(c);
+    await next();
+  });
+  app.use("/v2/provider-actions/:id", requireProviderAgentJwt);
+  app.get("/v2/provider-actions/:id", handleGetProviderActionStatus);
 }
 
 const MAX_REQUEST_BYTES = 256 * 1024; // 256 KiB bound
@@ -73,6 +86,60 @@ const TOP_LEVEL_KEYS = new Set([
 
 function deny(c: RouteContext, code: string, status: number) {
   return c.json<ApiResponse>({ ok: false, error: code }, status as never);
+}
+
+function providerActionNotFound(c: RouteContext) {
+  return c.json<ApiResponse>({ ok: false, error: "PROVIDER_ACTION_NOT_FOUND" }, 404);
+}
+
+async function handleGetProviderActionStatus(c: RouteContext) {
+  const principal = resolveProviderPrincipal(c);
+  const intentId = c.req.param("id") ?? "";
+
+  // Provider action ids are currently `pa_` + UUID. Treat malformed ids exactly
+  // like absent/foreign ids so this read surface is non-enumerating.
+  if (!/^pa_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(intentId)) {
+    return providerActionNotFound(c);
+  }
+
+  const [owned] = await getDb()
+    .select({ binding: providerActionBindings, intent: intents })
+    .from(providerActionBindings)
+    .innerJoin(
+      intents,
+      and(
+        eq(intents.id, providerActionBindings.intentId),
+        eq(intents.tenantId, providerActionBindings.tenantId),
+      ),
+    )
+    .where(
+      and(
+        eq(providerActionBindings.intentId, intentId),
+        eq(providerActionBindings.tenantId, principal.tenantId),
+        eq(providerActionBindings.actorAgentId, principal.agentId),
+        eq(intents.intentType, "provider-action"),
+      ),
+    )
+    .limit(1);
+
+  if (!owned) return providerActionNotFound(c);
+  return c.json<ApiResponse>({
+    ok: true,
+    data: toProviderActionStatusResponse({
+      id: owned.binding.intentId,
+      status: owned.binding.status,
+      version: owned.binding.bindingRevision,
+      workspaceId: owned.binding.workspaceId,
+      providerAccountId: owned.binding.providerAccountId,
+      operationId: owned.binding.operationId,
+      operationRevision: owned.binding.operationRevision,
+      actionDigest: owned.binding.actionDigest,
+      requestHash: owned.binding.requestHash,
+      expiresAt: owned.intent.expiresAt,
+      createdAt: owned.binding.createdAt,
+      updatedAt: owned.binding.updatedAt,
+    }),
+  });
 }
 
 function outcomeToResponse(c: RouteContext, outcome: ProviderActionOutcome) {
@@ -254,6 +321,7 @@ async function handleCreateProviderAction(c: RouteContext) {
 // Also register on the standalone sub-app so it can be unit-tested in isolation
 // (and remains a valid mount target if the router behavior changes).
 providerActionRoutes.post("/provider-actions", handleCreateProviderAction);
+providerActionRoutes.get("/provider-actions/:id", handleGetProviderActionStatus);
 
 /** RFC 3339 UTC with exactly three fractional digits and trailing Z. */
 function toRfc3339Millis(d: Date): string {

--- a/packages/api/src/services/intent-response.ts
+++ b/packages/api/src/services/intent-response.ts
@@ -1,0 +1,148 @@
+import { intents } from "@stwd/db";
+
+const SENSITIVE_INTENT_KEY_SUFFIX = /(?:token|credential|apikey|signedtx)$/;
+const SECRET_TEXT =
+  /(?:bearer\s+|(?:api[-_]?key|access[-_]?token|refresh[-_]?token|token|secret|credential|password|passphrase|private[-_]?key|cookie|authorization)["'\s:=]+)[^\s,"'}]+/gi;
+const PEM_PRIVATE_KEY = /-----BEGIN(?: [A-Z0-9]+)? PRIVATE KEY-----/i;
+const URL_USERINFO = /\b[a-z][a-z0-9+.-]*:\/\/[^\s/@:]+(?::[^\s/@]*)?@/i;
+
+function isSensitiveIntentKey(key: string): boolean {
+  const normalized = key.replace(/[^a-z0-9]/gi, "").toLowerCase();
+  if (normalized === "auth" || normalized.includes("authorization")) return true;
+  if (normalized.includes("password") || normalized.includes("passphrase")) return true;
+  if (normalized.includes("clientsecret") || normalized.includes("privatekey")) return true;
+  if (normalized.includes("cookie")) return true;
+  if (normalized === "secret" || normalized.includes("credential")) return true;
+  return SENSITIVE_INTENT_KEY_SUFFIX.test(normalized) && normalized !== "tokenaddress";
+}
+
+/**
+ * Recursively remove credential-shaped material from generic intent fields.
+ *
+ * Intent payloads and execution results are intentionally extensible JSON. A
+ * new producer must not be able to accidentally turn GET /intents/:id (or the
+ * agent-scoped provider-action status view) into a credential-read endpoint.
+ * Credential key names (including producer-prefixed names such as
+ * `githubAccessToken`) are redacted while legitimate fields such as
+ * `tokenAddress` remain intact. String values also have common bearer/secret
+ * assignments scrubbed as a defense in depth.
+ */
+export function redactIntentResponseValue(value: unknown, depth = 0): unknown {
+  if (depth > 20) return "[redacted]";
+  if (typeof value === "string") {
+    if (PEM_PRIVATE_KEY.test(value) || URL_USERINFO.test(value)) return "[redacted]";
+    return value.replace(SECRET_TEXT, "[redacted]");
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => redactIntentResponseValue(item, depth + 1));
+  }
+  if (value && typeof value === "object") {
+    const redacted: Record<string, unknown> = {};
+    for (const [key, nested] of Object.entries(value)) {
+      redacted[key] = isSensitiveIntentKey(key)
+        ? "[redacted]"
+        : redactIntentResponseValue(nested, depth + 1);
+    }
+    return redacted;
+  }
+  return value;
+}
+
+export interface ProviderActionStatusResponse {
+  id: string;
+  status: string;
+  version: number;
+  workspaceId: string;
+  providerAccountId: string;
+  operationId: string;
+  operationRevision: number;
+  actionDigest: string;
+  requestHash: string;
+  expiresAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * Least-privilege agent status view for a governed provider action.
+ *
+ * Keep this allowlist scalar-only. In particular, generic intent JSON and the
+ * binding's extensible requestEnvelope/safeSummary/decision documents must
+ * never be added here: this endpoint is reachable with an agent JWT.
+ */
+export function toProviderActionStatusResponse(input: ProviderActionStatusResponse) {
+  return {
+    id: input.id,
+    status: input.status,
+    version: input.version,
+    workspaceId: input.workspaceId,
+    providerAccountId: input.providerAccountId,
+    operationId: input.operationId,
+    operationRevision: input.operationRevision,
+    actionDigest: input.actionDigest,
+    requestHash: input.requestHash,
+    expiresAt: input.expiresAt,
+    createdAt: input.createdAt,
+    updatedAt: input.updatedAt,
+  };
+}
+
+/** The canonical public intent response shared by every intent status route. */
+export function toIntentResponse(row: typeof intents.$inferSelect) {
+  const authorizationDetails = redactIntentResponseValue(row.authorizationDetails);
+  const payload = redactIntentResponseValue(row.payload);
+  const executionResult = redactIntentResponseValue(row.executionResult);
+
+  return {
+    id: row.id,
+    intent_id: row.id,
+    tenantId: row.tenantId,
+    agentId: row.agentId,
+    wallet_id: row.agentId,
+    intentType: row.intentType,
+    intent_type: row.intentType,
+    status: row.status,
+    resourceType: row.resourceType,
+    resource_id: row.resourceId,
+    resourceId: row.resourceId,
+    createdByType: row.createdByType,
+    created_by_id: row.createdById,
+    createdById: row.createdById,
+    created_by_display_name: row.createdByDisplayName,
+    createdByDisplayName: row.createdByDisplayName,
+    authorizationDetails,
+    authorization_details: authorizationDetails,
+    payload,
+    executionResult,
+    execution_result: executionResult,
+    expiresAt: row.expiresAt,
+    expires_at: row.expiresAt?.getTime() ?? null,
+    authorizedBy: row.authorizedBy,
+    authorized_by: row.authorizedBy,
+    canceledAt: row.canceledAt,
+    canceledBy: row.canceledBy,
+    canceled_by: row.canceledBy,
+    cancellationReason: row.cancellationReason,
+    cancellation_reason: row.cancellationReason,
+    expiredAt: row.expiredAt,
+    expiredBy: row.expiredBy,
+    expired_by: row.expiredBy,
+    rejectedAt: row.rejectedAt,
+    rejectedBy: row.rejectedBy,
+    rejected_by: row.rejectedBy,
+    rejectionReason: row.rejectionReason,
+    rejection_reason: row.rejectionReason,
+    executedBy: row.executedBy,
+    executed_by: row.executedBy,
+    failedAt: row.failedAt,
+    failedBy: row.failedBy,
+    failed_by: row.failedBy,
+    failureReason: row.failureReason,
+    failure_reason: row.failureReason,
+    createdAt: row.createdAt,
+    created_at: row.createdAt.getTime(),
+    updatedAt: row.updatedAt,
+    authorizedAt: row.authorizedAt,
+    executedAt: row.executedAt,
+  };
+}

--- a/packages/api/src/services/intent-response.ts
+++ b/packages/api/src/services/intent-response.ts
@@ -1,51 +1,25 @@
 import { intents } from "@stwd/db";
 
-const SENSITIVE_INTENT_KEY_SUFFIX = /(?:token|credential|apikey|signedtx)$/;
-const SECRET_TEXT =
-  /(?:bearer\s+|(?:api[-_]?key|access[-_]?token|refresh[-_]?token|token|secret|credential|password|passphrase|private[-_]?key|cookie|authorization)["'\s:=]+)[^\s,"'}]+/gi;
-const PEM_PRIVATE_KEY = /-----BEGIN(?: [A-Z0-9]+)? PRIVATE KEY-----/i;
-const URL_USERINFO = /\b[a-z][a-z0-9+.-]*:\/\/[^\s/@:]+(?::[^\s/@]*)?@/i;
-
-function isSensitiveIntentKey(key: string): boolean {
-  const normalized = key.replace(/[^a-z0-9]/gi, "").toLowerCase();
-  if (normalized === "auth" || normalized.includes("authorization")) return true;
-  if (normalized.includes("password") || normalized.includes("passphrase")) return true;
-  if (normalized.includes("clientsecret") || normalized.includes("privatekey")) return true;
-  if (normalized.includes("cookie")) return true;
-  if (normalized === "secret" || normalized.includes("credential")) return true;
-  return SENSITIVE_INTENT_KEY_SUFFIX.test(normalized) && normalized !== "tokenaddress";
-}
-
 /**
- * Recursively remove credential-shaped material from generic intent fields.
+ * Recursively remove signed transaction material from intent execution data.
  *
- * Intent payloads and execution results are intentionally extensible JSON. A
- * new producer must not be able to accidentally turn GET /intents/:id (or the
- * agent-scoped provider-action status view) into a credential-read endpoint.
- * Credential key names (including producer-prefixed names such as
- * `githubAccessToken`) are redacted while legitimate fields such as
- * `tokenAddress` remain intact. String values also have common bearer/secret
- * assignments scrubbed as a defense in depth.
+ * This preserves the established generic intent response, webhook, and stored
+ * execution-result contract. The agent-readable provider-action route does not
+ * use these extensible fields at all; its separate scalar DTO below is the
+ * least-privilege security boundary.
  */
-export function redactIntentResponseValue(value: unknown, depth = 0): unknown {
-  if (depth > 20) return "[redacted]";
-  if (typeof value === "string") {
-    if (PEM_PRIVATE_KEY.test(value) || URL_USERINFO.test(value)) return "[redacted]";
-    return value.replace(SECRET_TEXT, "[redacted]");
-  }
-  if (Array.isArray(value)) {
-    return value.map((item) => redactIntentResponseValue(item, depth + 1));
-  }
-  if (value && typeof value === "object") {
-    const redacted: Record<string, unknown> = {};
-    for (const [key, nested] of Object.entries(value)) {
-      redacted[key] = isSensitiveIntentKey(key)
-        ? "[redacted]"
-        : redactIntentResponseValue(nested, depth + 1);
+export function redactSignedTransactions(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(redactSignedTransactions);
+  if (!value || typeof value !== "object") return value;
+  const redacted: Record<string, unknown> = {};
+  for (const [key, nested] of Object.entries(value)) {
+    if (key === "signedTx" || key === "signed_tx") {
+      redacted[key] = "[redacted]";
+    } else {
+      redacted[key] = redactSignedTransactions(nested);
     }
-    return redacted;
   }
-  return value;
+  return redacted;
 }
 
 export interface ProviderActionStatusResponse {
@@ -89,9 +63,7 @@ export function toProviderActionStatusResponse(input: ProviderActionStatusRespon
 
 /** The canonical public intent response shared by every intent status route. */
 export function toIntentResponse(row: typeof intents.$inferSelect) {
-  const authorizationDetails = redactIntentResponseValue(row.authorizationDetails);
-  const payload = redactIntentResponseValue(row.payload);
-  const executionResult = redactIntentResponseValue(row.executionResult);
+  const executionResult = redactSignedTransactions(row.executionResult);
 
   return {
     id: row.id,
@@ -110,9 +82,9 @@ export function toIntentResponse(row: typeof intents.$inferSelect) {
     createdById: row.createdById,
     created_by_display_name: row.createdByDisplayName,
     createdByDisplayName: row.createdByDisplayName,
-    authorizationDetails,
-    authorization_details: authorizationDetails,
-    payload,
+    authorizationDetails: row.authorizationDetails,
+    authorization_details: row.authorizationDetails,
+    payload: row.payload,
     executionResult,
     execution_result: executionResult,
     expiresAt: row.expiresAt,

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -102,7 +102,7 @@ structured content; Steward API errors surface their HTTP status and any policy
 | Tool | Kind | SDK method | Description |
 | --- | --- | --- | --- |
 | `provider_action_invoke` | write (destructive) | `POST /v2/provider-actions` | Submit an action for provider authorization and policy evaluation. |
-| `provider_action_status` | read | `GET /intents/:id` | Fetch current action intent status through the API's existing status route. |
+| `provider_action_status` | read | `GET /v2/provider-actions/:id` | Fetch the authenticated agent's own scalar-only action lifecycle status. Generic intent/request/result blobs are omitted; foreign and absent actions return the same not-found response. |
 | `provider_action_approval` | read | `GET /v2/provider-actions/:id/approval` | Fetch approval state. The API requires an eligible human session and recent MFA. |
 | `provider_action_case` | read | `GET /v2/provider-actions/:id/case` | Fetch the correlated case manifest. |
 | `provider_action_evidence` | read | `GET /v2/provider-actions/:id/evidence` | Fetch the correlated signed evidence bundle. |
@@ -126,14 +126,12 @@ provider credential, URL, or host arguments. Approval, case, and evidence reads
 retain the API's human-session, MFA, role, workspace, and tenant gates. In
 particular, an agent JWT cannot use MCP to impersonate a human approver.
 
-The current API intentionally has split auth modes. Invocation requires an agent
-JWT. The existing status route (`GET /intents/:id`) requires a tenant API key or
-owner/admin session. Approval, case, and evidence reads require eligible human
-sessions and recent MFA, with case and evidence further limited to owner/admin.
-A single agent-JWT MCP process can invoke but receives honest authorization
-errors from those human or tenant-level read routes. No agent-readable v2 status
-route exists on the current API, and this package does not invent one or weaken
-the API gates.
+Invocation and the agent-scoped status route both accept an agent JWT. Status is
+bound server-side to the verified tenant and agent, so a process can poll only
+actions that same agent submitted. Approval, case, and evidence reads continue
+to require eligible human sessions and recent MFA, with case and evidence
+further limited to owner/admin. The agent-readable route does not weaken or
+stand in for any of those human gates.
 
 These tools **do not implement MCP OAuth 2.1 resource-server semantics**. That
 separate authorization-layer work is tracked by issue #219.

--- a/packages/mcp/src/__tests__/provider-tools.test.ts
+++ b/packages/mcp/src/__tests__/provider-tools.test.ts
@@ -76,7 +76,7 @@ describe("governed provider action tools", () => {
 
   test("uses only fixed status, approval, case, and evidence routes", async () => {
     const routes = {
-      [`/intents/${ACTION_ID}`]: { status: "authorized" },
+      [`/v2/provider-actions/${ACTION_ID}`]: { status: "authorized" },
       [`/v2/provider-actions/${ACTION_ID}/approval`]: { status: "pending" },
       [`/v2/provider-actions/${ACTION_ID}/case`]: { kind: "case" },
       [`/v2/provider-actions/${ACTION_ID}/evidence`]: { kind: "evidence" },
@@ -87,6 +87,29 @@ describe("governed provider action tools", () => {
       expect(result.isError).toBeUndefined();
     }
     expect(calls.map((call) => call.path)).toEqual(Object.keys(routes));
+  });
+
+  test("status uses the agent-scoped route and preserves its least-privilege DTO", async () => {
+    const status = {
+      ok: true,
+      data: {
+        id: ACTION_ID,
+        status: "pending_approval",
+        version: 1,
+        workspaceId: "20000000-0000-4000-8000-000000000001",
+        providerAccountId: "30000000-0000-4000-8000-000000000001",
+        operationId: "40000000-0000-4000-8000-000000000001",
+        operationRevision: 1,
+      },
+    };
+    const path = `/v2/provider-actions/${ACTION_ID}`;
+    const { tools, calls } = harness({ [path]: status });
+
+    const result = await tools.get("provider_action_status")!.handler({ actionId: ACTION_ID });
+
+    expect(result.isError).toBeUndefined();
+    expect(result.structuredContent).toEqual(status);
+    expect(calls).toEqual([{ path, init: undefined }]);
   });
 
   test("rejects tenant, workspace substitution, host injection, and unknown keys", async () => {

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -256,11 +256,11 @@ export function buildTools(ctx: ToolContext): StewardTool[] {
     defineTool(ctx, {
       name: "provider_action_status",
       description:
-        "Fetch the current provider-action intent from the existing GET /intents/:intentId route. This real API route requires tenant-level credentials and rejects agent JWTs; MCP preserves that gate.",
+        "Fetch the scalar-only lifecycle status for the authenticated agent's own provider action through GET /v2/provider-actions/:id. The API omits generic intent/request/result blobs and uses a uniform not-found response for foreign actions.",
       schema: z.object({ actionId: providerCaseId }).strict(),
       readOnly: true,
       run: ({ actionId }) =>
-        requireProviderApi(ctx).request(`/intents/${encodeURIComponent(actionId)}`),
+        requireProviderApi(ctx).request(`/v2/provider-actions/${encodeURIComponent(actionId)}`),
     }),
     defineTool(ctx, {
       name: "provider_action_approval",


### PR DESCRIPTION
## Summary

- add exact agent-JWT `GET /v2/provider-actions/:id`, bound in SQL to both tenant and submitting agent
- return a provider-action-specific scalar allowlist derived from persisted binding lifecycle state
- omit every extensible intent/binding blob instead of relying on key-name redaction
- return one uniform 404 for malformed, absent, cross-agent, and cross-tenant ids
- repoint MCP status while preserving human/MFA gates on approval, case, and evidence
- behaviorally preserve hardening on the existing tenant intent response

## Security proof

Adversarial tests persist nested/array password, passphrase, auth, client-secret, private-key PEM, cookie, API-key, and URL-userinfo canaries into authorization details, payload, and execution result. The agent DTO exposes only its exact documented scalar allowlist and none of those blobs or canaries.

This is a replacement for rejected #280; it does not reopen or reuse that unsafe head unchanged.

## Exact-head verification

- API build plus MCP build: 22/22 tasks
- API status/hardening: 14/14
- MCP focused suites: 36/36
- OpenAPI contract: 8/8
- Biome and `git diff --check`: clean

Closes #233
