### PR TITLE
fix(cli): enforce bounded operational integrity checks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,10 +124,12 @@ services:
     image: steward:${STEWARD_IMAGE_TAG:-0.4.2}
     container_name: steward-proxy
     restart: unless-stopped
-    # Proxy only needs the API to be healthy (for JWT verification + DB access)
+    # The API's deep /ready check verifies proxy clock health, so waiting for API
+    # health here would deadlock both services. The proxy health endpoint does
+    # not require the API and can start as soon as the API container is running.
     depends_on:
       steward-api:
-        condition: service_healthy
+        condition: service_started
     command: ["bun", "run", "packages/proxy/src/index.ts"]
     environment:
       STEWARD_PROXY_PORT: "${STEWARD_PROXY_PORT:-8080}"

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -67842,6 +67842,185 @@
         }
       }
     },
+    "/audit/integrity": {
+      "get": {
+        "tags": [
+          "Audits"
+        ],
+        "summary": "Verify audit chain and latest checkpoint at the current head",
+        "description": "Requires an owner/admin browser session with recent MFA. Used by steward doctor to verify the live HMAC chain and the newest persisted Ed25519 checkpoint without returning signing or HMAC key material.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "valid",
+                    "chainValid",
+                    "checkpointPresent",
+                    "checkpointValid",
+                    "checkpointAtHead",
+                    "checkpointSeq",
+                    "chainHeadSeq"
+                  ],
+                  "properties": {
+                    "valid": {
+                      "type": "boolean"
+                    },
+                    "chainValid": {
+                      "type": "boolean"
+                    },
+                    "checkpointPresent": {
+                      "type": "boolean"
+                    },
+                    "checkpointValid": {
+                      "type": "boolean"
+                    },
+                    "checkpointAtHead": {
+                      "type": "boolean"
+                    },
+                    "checkpointSeq": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "chainHeadSeq": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/secrets": {
       "get": {
         "tags": [

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -67868,7 +67868,8 @@
                     "checkpointValid",
                     "checkpointAtHead",
                     "checkpointSeq",
-                    "chainHeadSeq"
+                    "chainHeadSeq",
+                    "governedRoutes"
                   ],
                   "properties": {
                     "valid": {
@@ -67897,6 +67898,29 @@
                         "integer",
                         "null"
                       ]
+                    },
+                    "governedRoutes": {
+                      "type": "object",
+                      "required": [
+                        "governedRoutes",
+                        "nullOperationRoutes",
+                        "dualModeRoutes",
+                        "ok"
+                      ],
+                      "properties": {
+                        "governedRoutes": {
+                          "type": "integer"
+                        },
+                        "nullOperationRoutes": {
+                          "type": "integer"
+                        },
+                        "dualModeRoutes": {
+                          "type": "integer"
+                        },
+                        "ok": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
                 }

--- a/packages/api/src/__tests__/audit-bundle.integration.test.ts
+++ b/packages/api/src/__tests__/audit-bundle.integration.test.ts
@@ -6,11 +6,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { auditCheckpoints, closeDb, getDb, tenants } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { writeAuditEvent } from "../services/audit";
 import { resetCheckpointSignerCache } from "../services/audit-checkpoint";
 import type { AppVariables } from "../services/context";
+import { inspectGovernedRoutes } from "../services/governed-route-inventory";
 
 const TENANT_ID = "audit-bundle-tenant";
 const OTHER_TENANT_ID = "audit-bundle-other-tenant";
@@ -169,6 +170,99 @@ describe("audit evidence bundle endpoint + offline verifier", () => {
     expect(rows.length).toBeGreaterThanOrEqual(1);
     expect(rows[0].signature.length).toBeGreaterThan(0);
     expect(rows[0].publicKey).toContain("BEGIN PUBLIC KEY");
+  });
+
+  it("doctor integrity requires a valid checkpoint at the current chain head", async () => {
+    await fetchBundle();
+    const current = await app().request("/audit/integrity");
+    expect(current.status).toBe(200);
+    expect(await current.json()).toMatchObject({
+      ok: true,
+      data: {
+        valid: true,
+        chainValid: true,
+        checkpointPresent: true,
+        checkpointValid: true,
+        checkpointAtHead: true,
+        checkpointSeq: 4,
+        chainHeadSeq: 4,
+      },
+    });
+
+    await writeAuditEvent({
+      tenantId: TENANT_ID,
+      actorType: "system",
+      action: "doctor.checkpoint.stale",
+      metadata: {},
+    });
+    const stale = await app().request("/audit/integrity");
+    expect(stale.status).toBe(200);
+    expect(await stale.json()).toMatchObject({
+      ok: true,
+      data: {
+        valid: false,
+        chainValid: true,
+        checkpointValid: true,
+        checkpointAtHead: false,
+        checkpointSeq: 4,
+        chainHeadSeq: 5,
+      },
+    });
+
+    // Restore a current checkpoint so the remaining bundle/verifier tests run
+    // against the new five-event head.
+    await fetchBundle();
+  });
+
+  it("shared governed-route inventory detects an enabled legacy bypass", async () => {
+    await getDb().execute(sql`
+      INSERT INTO users (id, email)
+      VALUES ('55555555-5555-4555-8555-555555555555', 'doctor@example.invalid')
+    `);
+    await getDb().execute(sql`
+      INSERT INTO workspaces (id, tenant_id, key, name, environment, created_by)
+      VALUES ('44444444-4444-4444-8444-444444444444', ${TENANT_ID},
+        'doctor', 'Doctor', 'development', '55555555-5555-4555-8555-555555555555')
+    `);
+    await getDb().execute(sql`
+      INSERT INTO provider_accounts
+        (id, tenant_id, workspace_id, adapter_key, external_ref, display_name)
+      VALUES ('66666666-6666-4666-8666-666666666666', ${TENANT_ID},
+        '44444444-4444-4444-8444-444444444444', 'slack', 'doctor', 'Doctor')
+    `);
+    await getDb().execute(sql`
+      INSERT INTO provider_operations
+        (id, tenant_id, workspace_id, provider_account_id, operation_key, risk_class)
+      VALUES ('33333333-3333-4333-8333-333333333333', ${TENANT_ID},
+        '44444444-4444-4444-8444-444444444444',
+        '66666666-6666-4666-8666-666666666666', 'doctor.test', 'read')
+    `);
+    await getDb().execute(sql`
+      INSERT INTO secret_routes
+        (tenant_id, secret_id, host_pattern, path_pattern, method, inject_as, inject_key,
+         enabled, authority_mode, provider_operation_id)
+      VALUES
+        (${TENANT_ID}, '11111111-1111-4111-8111-111111111111', 'slack.com', '/api/*', 'POST',
+         'header', 'Authorization', TRUE, 'legacy', NULL),
+        (${TENANT_ID}, '22222222-2222-4222-8222-222222222222', 'slack.com', '/api/*', 'POST',
+         'header', 'Authorization', TRUE, 'governed_v2',
+         '33333333-3333-4333-8333-333333333333')
+    `);
+    const inventory = await inspectGovernedRoutes();
+    expect(inventory).toMatchObject({
+      governedRoutes: 1,
+      nullOperationRoutes: 0,
+      dualModeRoutes: 1,
+      ok: false,
+    });
+    await getDb().execute(sql`DELETE FROM secret_routes WHERE tenant_id = ${TENANT_ID}`);
+    await getDb().execute(sql`
+      DELETE FROM workspaces
+      WHERE id = '44444444-4444-4444-8444-444444444444'
+    `);
+    await getDb().execute(sql`
+      DELETE FROM users WHERE id = '55555555-5555-4555-8555-555555555555'
+    `);
   });
 
   it("PASSES the standalone offline verifier for a genuine bundle", async () => {

--- a/packages/api/src/__tests__/audit-bundle.integration.test.ts
+++ b/packages/api/src/__tests__/audit-bundle.integration.test.ts
@@ -248,7 +248,7 @@ describe("audit evidence bundle endpoint + offline verifier", () => {
          'header', 'Authorization', TRUE, 'governed_v2',
          '33333333-3333-4333-8333-333333333333')
     `);
-    const inventory = await inspectGovernedRoutes();
+    const inventory = await inspectGovernedRoutes(TENANT_ID);
     expect(inventory).toMatchObject({
       governedRoutes: 1,
       nullOperationRoutes: 0,

--- a/packages/api/src/__tests__/audit-chain.test.ts
+++ b/packages/api/src/__tests__/audit-chain.test.ts
@@ -20,6 +20,7 @@ const TENANT_TRUNCATE = `audit-test-truncate-${Date.now()}`;
 const TENANT_TAIL = `audit-test-tail-${Date.now()}`;
 const TENANT_WIPE = `audit-test-wipe-${Date.now()}`;
 const TENANT_EMPTY = `audit-test-empty-${Date.now()}`;
+const TENANT_BOUNDED = `audit-test-bounded-${Date.now()}`;
 
 const ALL_TENANTS = [
   TENANT_OK,
@@ -28,6 +29,7 @@ const ALL_TENANTS = [
   TENANT_TAIL,
   TENANT_WIPE,
   TENANT_EMPTY,
+  TENANT_BOUNDED,
 ];
 
 async function cleanup(): Promise<void> {
@@ -163,6 +165,22 @@ describe.skipIf(SKIP)("audit chain", () => {
     const result = await verifyAuditChain(TENANT_EMPTY);
     expect(result.valid).toBe(true);
     if (result.valid) expect(result.count).toBe(0);
+  });
+
+  it("enforces maxRows in SQL even when the stored head count is understated", async () => {
+    for (let i = 0; i < 5; i++) {
+      await writeAuditEvent({
+        tenantId: TENANT_BOUNDED,
+        actorType: "system",
+        action: "test.bounded",
+        metadata: { i },
+      });
+    }
+    await getDb().execute(
+      sql`UPDATE audit_chain_heads SET expected_count = 1 WHERE tenant_id = ${TENANT_BOUNDED}`,
+    );
+    const result = await verifyAuditChain(TENANT_BOUNDED, { requireHead: true, maxRows: 2 });
+    expect(result).toEqual({ valid: false, brokenAt: 3, limitExceeded: true });
   });
 
   it("trackAuditEvent does not throw on success", () => {

--- a/packages/api/src/__tests__/doctor-bounds.test.ts
+++ b/packages/api/src/__tests__/doctor-bounds.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { PgDialect } from "drizzle-orm/pg-core";
+import { auditRowAggregateQuery } from "../services/audit";
+
+describe("doctor operational bounds", () => {
+  test("caps the audit high-water aggregate before COUNT and MAX", () => {
+    const query = new PgDialect().sqlToQuery(auditRowAggregateQuery("tenant-a", 7, 100));
+    expect(query.sql).toContain("FROM (\n            SELECT seq FROM audit_events");
+    expect(query.sql).toContain("LIMIT $3");
+    expect(query.params).toEqual(["tenant-a", 7, 101]);
+  });
+
+  test("keeps tenant route inventory off the public readiness probe", () => {
+    const readinessSource = readFileSync(new URL("../index.ts", import.meta.url), "utf8");
+    const auditSource = readFileSync(new URL("../routes/audit.ts", import.meta.url), "utf8");
+    expect(readinessSource).not.toContain("inspectGovernedRoutes");
+    expect(auditSource).toContain("inspectGovernedRoutes(tenantId, tx)");
+  });
+});

--- a/packages/api/src/__tests__/governed-route-inventory.test.ts
+++ b/packages/api/src/__tests__/governed-route-inventory.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import {
+  secretRouteHostPatternsOverlap,
+  secretRouteMethodPatternsOverlap,
+  secretRoutePathPatternsOverlap,
+} from "@stwd/shared";
+
+describe("governed route overlap semantics", () => {
+  test("detects broad and narrow host overlap without matching sibling domains", () => {
+    expect(secretRouteHostPatternsOverlap("*.example.com", "api.example.com")).toBe(true);
+    expect(secretRouteHostPatternsOverlap("*.example.com", "*.sub.example.com")).toBe(true);
+    expect(secretRouteHostPatternsOverlap("*.example.com", "example.com")).toBe(false);
+    expect(secretRouteHostPatternsOverlap("*.example.com", "api.example.net")).toBe(false);
+  });
+
+  test("detects wildcard path and method intersections", () => {
+    expect(secretRoutePathPatternsOverlap("/v1/*", "/v1/secrets")).toBe(true);
+    expect(secretRoutePathPatternsOverlap("/v1/*", "/v2/*")).toBe(false);
+    expect(secretRoutePathPatternsOverlap("/*", "/anything")).toBe(true);
+    expect(secretRouteMethodPatternsOverlap("*", "POST")).toBe(true);
+    expect(secretRouteMethodPatternsOverlap("GET", "post")).toBe(false);
+  });
+});

--- a/packages/api/src/__tests__/openapi-contract.test.ts
+++ b/packages/api/src/__tests__/openapi-contract.test.ts
@@ -96,6 +96,7 @@ describe("generated OpenAPI contract", () => {
     expect(spec.paths).toHaveProperty("/audit/export");
     expect(spec.paths).toHaveProperty("/audit/events");
     expect(spec.paths).toHaveProperty("/audit/verify");
+    expect(spec.paths).toHaveProperty("/audit/integrity");
     expect(spec.paths).toHaveProperty("/intents");
     expect(spec.paths).toHaveProperty("/intents/{intentId}/approve");
     expect(spec.paths).toHaveProperty("/v1/intents/{intentId}/approve");

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -17,7 +17,7 @@ import { closeDb, getDb, getMigrationExpectation, runMigrations } from "@stwd/db
 import { shouldUsePGLite } from "@stwd/db/pglite";
 import { sql } from "drizzle-orm";
 import { composeApp } from "./compose";
-import { getRedisClient, initRedis, shutdownRedis } from "./middleware/redis";
+import { getRedisClient, initRedis, isRedisConfigured, shutdownRedis } from "./middleware/redis";
 import { assertAuthStoresAreSafe, getAuthStoreSources, initAuthStores } from "./routes/auth";
 import {
   API_VERSION,
@@ -117,11 +117,20 @@ app.get("/ready", async (c) => {
 
   try {
     const db = getDb();
-    const result = await db.execute(sql`
-      SELECT
-        EXTRACT(EPOCH FROM clock_timestamp()) * 1000 AS database_time_ms,
-        (SELECT MAX(created_at) FROM drizzle.__drizzle_migrations) AS migration_created_at
-    `);
+    const pglite = shouldUsePGLite();
+    const result = pglite
+      ? await db.execute(sql`
+          SELECT
+            EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) * 1000 AS database_time_ms,
+            EXISTS(
+              SELECT 1 FROM __steward_migrations WHERE tag = ${expectedMigration.tag}
+            ) AS expected_migration_applied
+        `)
+      : await db.execute(sql`
+          SELECT
+            EXTRACT(EPOCH FROM clock_timestamp()) * 1000 AS database_time_ms,
+            (SELECT MAX(created_at) FROM drizzle.__drizzle_migrations) AS migration_created_at
+        `);
     const rows = Array.isArray(result)
       ? result
       : ((result as unknown as { rows?: unknown[] }).rows ?? []);
@@ -130,17 +139,24 @@ app.get("/ready", async (c) => {
       | undefined;
     const databaseTimeMs = Number(row?.database_time_ms);
     const migrationCreatedAt = Number(row?.migration_created_at);
+    const expectedMigrationApplied =
+      (row as { expected_migration_applied?: unknown } | undefined)?.expected_migration_applied ===
+      true;
     const databaseSkewMs = Math.abs(Date.now() - databaseTimeMs);
     checks.database = {
       ok: Number.isFinite(databaseTimeMs) && databaseSkewMs <= 30_000,
       detail: { clockSkewMs: Math.round(databaseSkewMs), serverTime: new Date().toISOString() },
     };
     checks.migrations = {
-      ok: migrationsRan && migrationCreatedAt === expectedMigration.createdAt,
+      ok:
+        migrationsRan &&
+        (pglite ? expectedMigrationApplied : migrationCreatedAt === expectedMigration.createdAt),
       detail: {
         expected: expectedMigration.tag,
         expectedCreatedAt: expectedMigration.createdAt,
-        actualCreatedAt: Number.isFinite(migrationCreatedAt) ? migrationCreatedAt : null,
+        ...(pglite
+          ? { expectedMigrationApplied }
+          : { actualCreatedAt: Number.isFinite(migrationCreatedAt) ? migrationCreatedAt : null }),
       },
     };
   } catch (err: unknown) {
@@ -151,7 +167,9 @@ app.get("/ready", async (c) => {
     const redis = getRedisClient();
     checks.redis = redis
       ? { ok: (await redis.ping()).toUpperCase() === "PONG" }
-      : { ok: false, error: "Redis is not connected" };
+      : isRedisConfigured()
+        ? { ok: false, error: "Redis is configured but not connected" }
+        : { ok: false, required: false, error: "Redis is not configured (optional mode)" };
   } catch (err: unknown) {
     checks.redis = { ok: false, error: err instanceof Error ? err.message : "unknown" };
   }

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -13,11 +13,11 @@
  */
 
 import { validateJwtSecretEnv } from "@stwd/auth";
-import { closeDb, getDb, runMigrations } from "@stwd/db";
+import { closeDb, getDb, getMigrationExpectation, runMigrations } from "@stwd/db";
 import { shouldUsePGLite } from "@stwd/db/pglite";
 import { sql } from "drizzle-orm";
 import { composeApp } from "./compose";
-import { initRedis, shutdownRedis } from "./middleware/redis";
+import { getRedisClient, initRedis, shutdownRedis } from "./middleware/redis";
 import { assertAuthStoresAreSafe, getAuthStoreSources, initAuthStores } from "./routes/auth";
 import {
   API_VERSION,
@@ -26,6 +26,7 @@ import {
   RATE_LIMIT_MAX_REQUESTS,
   RATE_LIMIT_WINDOW_MS,
 } from "./services/context";
+import { inspectGovernedRoutes } from "./services/governed-route-inventory";
 import { startRetentionScheduler } from "./services/retention";
 import { startTransactionReceiptPollingScheduler } from "./services/transaction-receipt-poller";
 import { configuredVaultStartupLogLine, getConfiguredVault } from "./services/vault-factory";
@@ -106,16 +107,88 @@ const requestLogCleanupTimer = setInterval(() => {
 // on the Cloudflare control plane for instance health.
 
 app.get("/ready", async (c) => {
-  const checks: Record<string, { ok: boolean; error?: string; source?: string }> = {};
+  const checks: Record<
+    string,
+    { ok: boolean; required?: boolean; error?: string; source?: string; detail?: unknown }
+  > = {};
 
-  checks.migrations = { ok: migrationsRan };
+  const expectedMigration = getMigrationExpectation();
+  checks.migrations = { ok: false, detail: { expected: expectedMigration.tag } };
 
   try {
     const db = getDb();
-    await db.execute(sql`SELECT 1`);
-    checks.database = { ok: true };
+    const result = await db.execute(sql`
+      SELECT
+        EXTRACT(EPOCH FROM clock_timestamp()) * 1000 AS database_time_ms,
+        (SELECT MAX(created_at) FROM drizzle.__drizzle_migrations) AS migration_created_at
+    `);
+    const rows = Array.isArray(result)
+      ? result
+      : ((result as unknown as { rows?: unknown[] }).rows ?? []);
+    const row = rows[0] as
+      | { database_time_ms?: string | number; migration_created_at?: string | number | null }
+      | undefined;
+    const databaseTimeMs = Number(row?.database_time_ms);
+    const migrationCreatedAt = Number(row?.migration_created_at);
+    const databaseSkewMs = Math.abs(Date.now() - databaseTimeMs);
+    checks.database = {
+      ok: Number.isFinite(databaseTimeMs) && databaseSkewMs <= 30_000,
+      detail: { clockSkewMs: Math.round(databaseSkewMs), serverTime: new Date().toISOString() },
+    };
+    checks.migrations = {
+      ok: migrationsRan && migrationCreatedAt === expectedMigration.createdAt,
+      detail: {
+        expected: expectedMigration.tag,
+        expectedCreatedAt: expectedMigration.createdAt,
+        actualCreatedAt: Number.isFinite(migrationCreatedAt) ? migrationCreatedAt : null,
+      },
+    };
   } catch (err: unknown) {
     checks.database = { ok: false, error: err instanceof Error ? err.message : "unknown" };
+  }
+
+  try {
+    const redis = getRedisClient();
+    checks.redis = redis
+      ? { ok: (await redis.ping()).toUpperCase() === "PONG" }
+      : { ok: false, error: "Redis is not connected" };
+  } catch (err: unknown) {
+    checks.redis = { ok: false, error: err instanceof Error ? err.message : "unknown" };
+  }
+
+  try {
+    const inventory = await inspectGovernedRoutes();
+    checks.governedRoutes = { ok: inventory.ok, detail: inventory };
+  } catch (err: unknown) {
+    checks.governedRoutes = {
+      ok: false,
+      error: err instanceof Error ? err.message : "unknown",
+    };
+  }
+
+  const proxyUrl = process.env.STEWARD_PROXY_URL?.replace(/\/+$/, "");
+  if (!proxyUrl) {
+    checks.proxyClock = {
+      ok: false,
+      required: false,
+      error: "STEWARD_PROXY_URL not configured",
+    };
+  } else {
+    try {
+      const startedAt = Date.now();
+      const response = await fetch(`${proxyUrl}/health`, { signal: AbortSignal.timeout(3_000) });
+      const body = (await response.json()) as { serverTime?: unknown };
+      const endedAt = Date.now();
+      const proxyTime = Date.parse(String(body.serverTime ?? ""));
+      const midpoint = startedAt + (endedAt - startedAt) / 2;
+      const skewMs = Math.abs(proxyTime - midpoint);
+      checks.proxyClock = {
+        ok: response.ok && Number.isFinite(proxyTime) && skewMs <= 30_000,
+        detail: { clockSkewMs: Math.round(skewMs) },
+      };
+    } catch (err: unknown) {
+      checks.proxyClock = { ok: false, error: err instanceof Error ? err.message : "unknown" };
+    }
   }
 
   if (!process.env.STEWARD_MASTER_PASSWORD) {
@@ -141,7 +214,7 @@ app.get("/ready", async (c) => {
       : {}),
   };
 
-  const allOk = Object.values(checks).every((c) => c.ok);
+  const allOk = Object.values(checks).every((check) => check.ok || check.required === false);
   return c.json(
     {
       status: allOk ? "ready" : "not_ready",

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -26,7 +26,6 @@ import {
   RATE_LIMIT_MAX_REQUESTS,
   RATE_LIMIT_WINDOW_MS,
 } from "./services/context";
-import { inspectGovernedRoutes } from "./services/governed-route-inventory";
 import { startRetentionScheduler } from "./services/retention";
 import { startTransactionReceiptPollingScheduler } from "./services/transaction-receipt-poller";
 import { configuredVaultStartupLogLine, getConfiguredVault } from "./services/vault-factory";
@@ -172,16 +171,6 @@ app.get("/ready", async (c) => {
         : { ok: false, required: false, error: "Redis is not configured (optional mode)" };
   } catch (err: unknown) {
     checks.redis = { ok: false, error: err instanceof Error ? err.message : "unknown" };
-  }
-
-  try {
-    const inventory = await inspectGovernedRoutes();
-    checks.governedRoutes = { ok: inventory.ok, detail: inventory };
-  } catch (err: unknown) {
-    checks.governedRoutes = {
-      ok: false,
-      error: err instanceof Error ? err.message : "unknown",
-    };
   }
 
   const proxyUrl = process.env.STEWARD_PROXY_URL?.replace(/\/+$/, "");

--- a/packages/api/src/openapi.ts
+++ b/packages/api/src/openapi.ts
@@ -3017,6 +3017,7 @@ function auditPaths(prefix = ""): Record<string, unknown> {
               "checkpointAtHead",
               "checkpointSeq",
               "chainHeadSeq",
+              "governedRoutes",
             ],
             properties: {
               valid: { type: "boolean" },
@@ -3026,6 +3027,16 @@ function auditPaths(prefix = ""): Record<string, unknown> {
               checkpointAtHead: { type: "boolean" },
               checkpointSeq: { type: ["integer", "null"] },
               chainHeadSeq: { type: ["integer", "null"] },
+              governedRoutes: {
+                type: "object",
+                required: ["governedRoutes", "nullOperationRoutes", "dualModeRoutes", "ok"],
+                properties: {
+                  governedRoutes: { type: "integer" },
+                  nullOperationRoutes: { type: "integer" },
+                  dualModeRoutes: { type: "integer" },
+                  ok: { type: "boolean" },
+                },
+              },
             },
           }),
           ...errorResponses(),

--- a/packages/api/src/openapi.ts
+++ b/packages/api/src/openapi.ts
@@ -2999,6 +2999,39 @@ function auditPaths(prefix = ""): Record<string, unknown> {
         },
       },
     },
+    [`${prefix}/audit/integrity`]: {
+      get: {
+        tags: ["Audits"],
+        summary: "Verify audit chain and latest checkpoint at the current head",
+        description:
+          "Requires an owner/admin browser session with recent MFA. Used by steward doctor to verify the live HMAC chain and the newest persisted Ed25519 checkpoint without returning signing or HMAC key material.",
+        security: [{ bearerAuth: [] }],
+        responses: {
+          "200": jsonResponse({
+            type: "object",
+            required: [
+              "valid",
+              "chainValid",
+              "checkpointPresent",
+              "checkpointValid",
+              "checkpointAtHead",
+              "checkpointSeq",
+              "chainHeadSeq",
+            ],
+            properties: {
+              valid: { type: "boolean" },
+              chainValid: { type: "boolean" },
+              checkpointPresent: { type: "boolean" },
+              checkpointValid: { type: "boolean" },
+              checkpointAtHead: { type: "boolean" },
+              checkpointSeq: { type: ["integer", "null"] },
+              chainHeadSeq: { type: ["integer", "null"] },
+            },
+          }),
+          ...errorResponses(),
+        },
+      },
+    },
   };
 }
 

--- a/packages/api/src/routes/audit.ts
+++ b/packages/api/src/routes/audit.ts
@@ -5,7 +5,7 @@
  * Mount: app.route("/audit", auditRoutes)
  */
 
-import { proxyAuditLog } from "@stwd/db";
+import { auditChainHeads, auditCheckpoints, proxyAuditLog } from "@stwd/db";
 import { and, count, desc, eq, gte, inArray, lte, type SQL, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { auditOwnerAdminMfaGate } from "../middleware/audit-gate";
@@ -15,7 +15,12 @@ import {
   signAuditBundle,
   verifyAuditChain,
 } from "../services/audit";
-import { AuditSigningKeyError, isCheckpointSigningConfigured } from "../services/audit-checkpoint";
+import {
+  AuditSigningKeyError,
+  isCheckpointSigningConfigured,
+  type SignedCheckpoint,
+  verifyCheckpoint,
+} from "../services/audit-checkpoint";
 import {
   type ApiResponse,
   type AppVariables,
@@ -799,6 +804,57 @@ auditRoutes.post("/verify", async (c) => {
         fromSeq === 1
           ? undefined
           : "Partial verification is anchored to the stored predecessor hash and is not proof that earlier audit rows are intact.",
+    },
+  });
+});
+
+// ─── GET /audit/integrity ───────────────────────────────────────────────────
+//
+// A bounded operator diagnostic: verify the full live HMAC chain, then verify
+// the newest persisted Ed25519 checkpoint and require it to commit to the
+// current chain head. The normal audit owner/admin + recent-MFA gate above
+// applies; no HMAC key or private signing material is returned.
+auditRoutes.get("/integrity", async (c) => {
+  const tenantId = c.get("tenantId");
+  const chain = await verifyAuditChain(tenantId, { requireHead: true });
+  const [head] = await db
+    .select({ seq: auditChainHeads.expectedSeq, hmac: auditChainHeads.headHmac })
+    .from(auditChainHeads)
+    .where(eq(auditChainHeads.tenantId, tenantId))
+    .limit(1);
+  const [row] = await db
+    .select()
+    .from(auditCheckpoints)
+    .where(eq(auditCheckpoints.tenantId, tenantId))
+    .orderBy(desc(auditCheckpoints.seq), desc(auditCheckpoints.id))
+    .limit(1);
+
+  let checkpointValid = false;
+  let checkpointAtHead = false;
+  if (row && head) {
+    const checkpoint: SignedCheckpoint = {
+      payload: row.payload as unknown as SignedCheckpoint["payload"],
+      signature: row.signature,
+      publicKey: row.publicKey,
+    };
+    checkpointValid = verifyCheckpoint(checkpoint);
+    checkpointAtHead =
+      row.seq === Number(head.seq) &&
+      Buffer.from(row.headHmac).toString("hex") === Buffer.from(head.hmac).toString("hex") &&
+      checkpoint.payload.seq === Number(head.seq) &&
+      checkpoint.payload.headHmac === Buffer.from(head.hmac).toString("hex");
+  }
+
+  return c.json<ApiResponse>({
+    ok: true,
+    data: {
+      valid: chain.valid && checkpointValid && checkpointAtHead,
+      chainValid: chain.valid,
+      checkpointPresent: Boolean(row),
+      checkpointValid,
+      checkpointAtHead,
+      checkpointSeq: row?.seq ?? null,
+      chainHeadSeq: head ? Number(head.seq) : null,
     },
   });
 });

--- a/packages/api/src/routes/audit.ts
+++ b/packages/api/src/routes/audit.ts
@@ -30,6 +30,7 @@ import {
   db,
   transactions,
 } from "../services/context";
+import { inspectGovernedRoutes } from "../services/governed-route-inventory";
 
 export const auditRoutes = new Hono<{ Variables: AppVariables }>();
 
@@ -840,6 +841,7 @@ auditRoutes.get("/integrity", async (c) => {
       .where(eq(auditCheckpoints.tenantId, tenantId))
       .orderBy(desc(auditCheckpoints.seq), desc(auditCheckpoints.id))
       .limit(1);
+    const governedRoutes = await inspectGovernedRoutes(tenantId, tx);
 
     let checkpointValid = false;
     let checkpointAtHead = false;
@@ -868,6 +870,7 @@ auditRoutes.get("/integrity", async (c) => {
       bounded: true,
       eventsInspected: chain.valid ? chain.count : maxEvents,
       maxEvents,
+      governedRoutes,
       ...(limitExceeded
         ? {
             error:

--- a/packages/api/src/routes/audit.ts
+++ b/packages/api/src/routes/audit.ts
@@ -6,6 +6,7 @@
  */
 
 import { auditChainHeads, auditCheckpoints, proxyAuditLog } from "@stwd/db";
+import { shouldUsePGLite } from "@stwd/db/pglite";
 import { and, count, desc, eq, gte, inArray, lte, type SQL, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { auditOwnerAdminMfaGate } from "../middleware/audit-gate";
@@ -816,38 +817,47 @@ auditRoutes.post("/verify", async (c) => {
 // applies; no HMAC key or private signing material is returned.
 auditRoutes.get("/integrity", async (c) => {
   const tenantId = c.get("tenantId");
-  const chain = await verifyAuditChain(tenantId, { requireHead: true });
-  const [head] = await db
-    .select({ seq: auditChainHeads.expectedSeq, hmac: auditChainHeads.headHmac })
-    .from(auditChainHeads)
-    .where(eq(auditChainHeads.tenantId, tenantId))
-    .limit(1);
-  const [row] = await db
-    .select()
-    .from(auditCheckpoints)
-    .where(eq(auditCheckpoints.tenantId, tenantId))
-    .orderBy(desc(auditCheckpoints.seq), desc(auditCheckpoints.id))
-    .limit(1);
+  const configuredLimit = Number(process.env.STEWARD_DOCTOR_AUDIT_MAX_EVENTS ?? "100000");
+  const maxEvents =
+    Number.isSafeInteger(configuredLimit) && configuredLimit > 0 ? configuredLimit : 100_000;
+  const data = await db.transaction(async (tx) => {
+    if (!shouldUsePGLite()) {
+      await tx.execute(sql`SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY`);
+    }
+    const [head] = await tx
+      .select({ seq: auditChainHeads.expectedSeq, hmac: auditChainHeads.headHmac })
+      .from(auditChainHeads)
+      .where(eq(auditChainHeads.tenantId, tenantId))
+      .limit(1);
+    const chain = await verifyAuditChain(tenantId, {
+      requireHead: true,
+      maxRows: maxEvents,
+      executor: tx,
+    });
+    const [row] = await tx
+      .select()
+      .from(auditCheckpoints)
+      .where(eq(auditCheckpoints.tenantId, tenantId))
+      .orderBy(desc(auditCheckpoints.seq), desc(auditCheckpoints.id))
+      .limit(1);
 
-  let checkpointValid = false;
-  let checkpointAtHead = false;
-  if (row && head) {
-    const checkpoint: SignedCheckpoint = {
-      payload: row.payload as unknown as SignedCheckpoint["payload"],
-      signature: row.signature,
-      publicKey: row.publicKey,
-    };
-    checkpointValid = verifyCheckpoint(checkpoint);
-    checkpointAtHead =
-      row.seq === Number(head.seq) &&
-      Buffer.from(row.headHmac).toString("hex") === Buffer.from(head.hmac).toString("hex") &&
-      checkpoint.payload.seq === Number(head.seq) &&
-      checkpoint.payload.headHmac === Buffer.from(head.hmac).toString("hex");
-  }
-
-  return c.json<ApiResponse>({
-    ok: true,
-    data: {
+    let checkpointValid = false;
+    let checkpointAtHead = false;
+    if (row && head && !("limitExceeded" in chain && chain.limitExceeded)) {
+      const checkpoint: SignedCheckpoint = {
+        payload: row.payload as unknown as SignedCheckpoint["payload"],
+        signature: row.signature,
+        publicKey: row.publicKey,
+      };
+      checkpointValid = verifyCheckpoint(checkpoint);
+      checkpointAtHead =
+        row.seq === Number(head.seq) &&
+        Buffer.from(row.headHmac).toString("hex") === Buffer.from(head.hmac).toString("hex") &&
+        checkpoint.payload.seq === Number(head.seq) &&
+        checkpoint.payload.headHmac === Buffer.from(head.hmac).toString("hex");
+    }
+    const limitExceeded = "limitExceeded" in chain && chain.limitExceeded === true;
+    return {
       valid: chain.valid && checkpointValid && checkpointAtHead,
       chainValid: chain.valid,
       checkpointPresent: Boolean(row),
@@ -855,7 +865,21 @@ auditRoutes.get("/integrity", async (c) => {
       checkpointAtHead,
       checkpointSeq: row?.seq ?? null,
       chainHeadSeq: head ? Number(head.seq) : null,
-    },
+      bounded: true,
+      eventsInspected: chain.valid ? chain.count : maxEvents,
+      maxEvents,
+      ...(limitExceeded
+        ? {
+            error:
+              "audit chain exceeds the bounded doctor verification limit; use an offline export",
+          }
+        : {}),
+    };
+  });
+
+  return c.json<ApiResponse>({
+    ok: true,
+    data,
   });
 });
 

--- a/packages/api/src/services/audit.ts
+++ b/packages/api/src/services/audit.ts
@@ -61,6 +61,19 @@ export type { AuditActorType as ActorType } from "@stwd/db";
  * their existing typing when an executor is supplied.
  */
 export type AuditReadExecutor = Pick<ReturnType<typeof getDb>, "execute">;
+
+/** Build the high-water aggregate read, bounded when doctor supplies maxRows. */
+export function auditRowAggregateQuery(tenantId: string, genesisSeq: number, maxRows?: number) {
+  return maxRows === undefined
+    ? sql`SELECT MAX(seq) AS max_seq, COUNT(*) AS cnt FROM audit_events WHERE tenant_id = ${tenantId} AND seq >= ${genesisSeq}`
+    : sql`SELECT MAX(seq) AS max_seq, COUNT(*) AS cnt
+          FROM (
+            SELECT seq FROM audit_events
+            WHERE tenant_id = ${tenantId} AND seq >= ${genesisSeq}
+            ORDER BY seq ASC
+            LIMIT ${maxRows + 1}
+          ) AS bounded_audit_events`;
+}
 // The tamper-evident audit-chain WRITE core (append/transaction primitives, the
 // HMAC key handling, and metadata redaction) now lives in `@stwd/db` so the
 // proxy package can extend the chain atomically without importing `@stwd/api`
@@ -277,13 +290,14 @@ export async function verifyAuditChain(
     const expectedSeqHwm = Number(head.expected_seq);
     const expectedCount = Number(head.expected_count);
     const aggRows = rowsFromExecute<{ max_seq: number | string | null; cnt: number | string }>(
-      await db.execute(
-        sql`SELECT MAX(seq) AS max_seq, COUNT(*) AS cnt FROM audit_events WHERE tenant_id = ${tenantId} AND seq >= ${genesisSeq}`,
-      ),
+      await db.execute(auditRowAggregateQuery(tenantId, genesisSeq, maxRows)),
     );
     const actualMaxSeq = aggRows[0]?.max_seq != null ? Number(aggRows[0].max_seq) : 0;
     const actualCount = aggRows[0]?.cnt != null ? Number(aggRows[0].cnt) : 0;
     const expectedLiveCount = expectedCount - (genesisSeq - 1);
+    if (maxRows !== undefined && actualCount > maxRows) {
+      return { valid: false, brokenAt: genesisSeq + maxRows, limitExceeded: true };
+    }
     // Missing newest rows (tail truncation) or whole-chain deletion: the stored
     // head outranks / outcounts what survives on disk. Point brokenAt at the
     // first missing seq.

--- a/packages/api/src/services/audit.ts
+++ b/packages/api/src/services/audit.ts
@@ -217,6 +217,8 @@ export async function verifyAuditChain(
     fromSeq?: number;
     toSeq?: number;
     requireHead?: boolean;
+    /** Hard cap enforced by the SQL read itself (LIMIT maxRows + 1). */
+    maxRows?: number;
     /**
      * Optional read executor (a snapshot transaction) so callers can verify a
      * chain segment WITHIN a single coherent snapshot alongside other reads
@@ -225,11 +227,20 @@ export async function verifyAuditChain(
      */
     executor?: AuditReadExecutor;
   } = {},
-): Promise<{ valid: true; count: number } | { valid: false; brokenAt: number }> {
+): Promise<
+  { valid: true; count: number } | { valid: false; brokenAt: number; limitExceeded?: boolean }
+> {
   const key = getHmacKey();
   const db = opts.executor ?? getDb();
   const requestedFromSeq = opts.fromSeq ?? 1;
   const toSeq = opts.toSeq;
+  const maxRows = opts.maxRows;
+  if (
+    maxRows !== undefined &&
+    (!Number.isSafeInteger(maxRows) || maxRows <= 0 || maxRows > 1_000_000)
+  ) {
+    throw new Error("maxRows must be a positive safe integer no greater than 1000000");
+  }
 
   // Out-of-band high-water-mark: persisted atomically with each append. Lets us
   // detect tail-truncation / whole-chain deletion that walking the surviving
@@ -320,10 +331,18 @@ export async function verifyAuditChain(
   }>(
     await db.execute(
       toSeq !== undefined
-        ? sql`SELECT * FROM audit_events WHERE tenant_id = ${tenantId} AND seq BETWEEN ${effectiveFromSeq} AND ${toSeq} ORDER BY seq ASC`
-        : sql`SELECT * FROM audit_events WHERE tenant_id = ${tenantId} AND seq >= ${effectiveFromSeq} ORDER BY seq ASC`,
+        ? maxRows !== undefined
+          ? sql`SELECT * FROM audit_events WHERE tenant_id = ${tenantId} AND seq BETWEEN ${effectiveFromSeq} AND ${toSeq} ORDER BY seq ASC LIMIT ${maxRows + 1}`
+          : sql`SELECT * FROM audit_events WHERE tenant_id = ${tenantId} AND seq BETWEEN ${effectiveFromSeq} AND ${toSeq} ORDER BY seq ASC`
+        : maxRows !== undefined
+          ? sql`SELECT * FROM audit_events WHERE tenant_id = ${tenantId} AND seq >= ${effectiveFromSeq} ORDER BY seq ASC LIMIT ${maxRows + 1}`
+          : sql`SELECT * FROM audit_events WHERE tenant_id = ${tenantId} AND seq >= ${effectiveFromSeq} ORDER BY seq ASC`,
     ),
   );
+
+  if (maxRows !== undefined && rows.length > maxRows) {
+    return { valid: false, brokenAt: effectiveFromSeq + maxRows, limitExceeded: true };
+  }
 
   let count = 0;
   let expectedSeq = effectiveFromSeq;

--- a/packages/api/src/services/governed-route-inventory.ts
+++ b/packages/api/src/services/governed-route-inventory.ts
@@ -12,6 +12,8 @@ export type GovernedRouteInventory = {
   ok: boolean;
 };
 
+type RouteReadExecutor = Pick<ReturnType<typeof getDb>, "execute">;
+
 type InventoryRoute = {
   tenant_id: string;
   agent_id: string | null;
@@ -42,12 +44,15 @@ function authorityRoutesOverlap(a: InventoryRoute, b: InventoryRoute): boolean {
 }
 
 /** Runtime doctor using the same wildcard semantics as proxy matching. */
-export async function inspectGovernedRoutes(): Promise<GovernedRouteInventory> {
+export async function inspectGovernedRoutes(
+  tenantId: string,
+  executor: RouteReadExecutor = getDb(),
+): Promise<GovernedRouteInventory> {
   const routes = rowsFromExecute<InventoryRoute>(
-    await getDb().execute(sql`
+    await executor.execute(sql`
       SELECT tenant_id, agent_id, authority_mode, provider_operation_id,
              host_pattern, path_pattern, method
-      FROM secret_routes WHERE enabled = TRUE
+      FROM secret_routes WHERE enabled = TRUE AND tenant_id = ${tenantId}
     `),
   );
   const governed = routes.filter((route) => route.authority_mode === "governed_v2");

--- a/packages/api/src/services/governed-route-inventory.ts
+++ b/packages/api/src/services/governed-route-inventory.ts
@@ -1,10 +1,25 @@
 import { getDb, sql } from "@stwd/db";
+import {
+  secretRouteHostPatternsOverlap,
+  secretRouteMethodPatternsOverlap,
+  secretRoutePathPatternsOverlap,
+} from "@stwd/shared";
 
 export type GovernedRouteInventory = {
   governedRoutes: number;
   nullOperationRoutes: number;
   dualModeRoutes: number;
   ok: boolean;
+};
+
+type InventoryRoute = {
+  tenant_id: string;
+  agent_id: string | null;
+  authority_mode: string;
+  provider_operation_id: string | null;
+  host_pattern: string;
+  path_pattern: string | null;
+  method: string | null;
 };
 
 function rowsFromExecute<T>(result: unknown): T[] {
@@ -16,46 +31,33 @@ function rowsFromExecute<T>(result: unknown): T[] {
   return [];
 }
 
-/**
- * Single source for the runtime doctor and PR7's static/runtime route guard.
- * A dual-mode match is the same tenant/agent/host/path/method credential route
- * exposed once through legacy authority and once through governed authority.
- */
+function authorityRoutesOverlap(a: InventoryRoute, b: InventoryRoute): boolean {
+  return (
+    a.tenant_id === b.tenant_id &&
+    a.agent_id === b.agent_id &&
+    secretRouteHostPatternsOverlap(a.host_pattern, b.host_pattern) &&
+    secretRoutePathPatternsOverlap(a.path_pattern ?? "/*", b.path_pattern ?? "/*") &&
+    secretRouteMethodPatternsOverlap(a.method, b.method)
+  );
+}
+
+/** Runtime doctor using the same wildcard semantics as proxy matching. */
 export async function inspectGovernedRoutes(): Promise<GovernedRouteInventory> {
-  const db = getDb();
-  const [row = { governed: 0, null_operations: 0, dual_mode: 0 }] = rowsFromExecute<{
-    governed: number;
-    null_operations: number;
-    dual_mode: number;
-  }>(
-    await db.execute(sql`
-      WITH route_counts AS (
-        SELECT
-          tenant_id,
-          COALESCE(agent_id, '') AS agent_id,
-          host_pattern,
-          COALESCE(path_pattern, '/*') AS path_pattern,
-          COALESCE(method, '*') AS method,
-          BOOL_OR(authority_mode = 'legacy') AS has_legacy,
-          BOOL_OR(authority_mode = 'governed_v2') AS has_governed
-        FROM secret_routes
-        WHERE enabled = TRUE
-        GROUP BY tenant_id, COALESCE(agent_id, ''), host_pattern,
-          COALESCE(path_pattern, '/*'), COALESCE(method, '*')
-      )
-      SELECT
-        (SELECT COUNT(*)::int FROM secret_routes
-          WHERE enabled = TRUE AND authority_mode = 'governed_v2') AS governed,
-        (SELECT COUNT(*)::int FROM secret_routes
-          WHERE enabled = TRUE AND authority_mode = 'governed_v2'
-            AND provider_operation_id IS NULL) AS null_operations,
-        (SELECT COUNT(*)::int FROM route_counts
-          WHERE has_legacy AND has_governed) AS dual_mode
+  const routes = rowsFromExecute<InventoryRoute>(
+    await getDb().execute(sql`
+      SELECT tenant_id, agent_id, authority_mode, provider_operation_id,
+             host_pattern, path_pattern, method
+      FROM secret_routes WHERE enabled = TRUE
     `),
   );
-  const governedRoutes = Number(row.governed);
-  const nullOperationRoutes = Number(row.null_operations);
-  const dualModeRoutes = Number(row.dual_mode);
+  const governed = routes.filter((route) => route.authority_mode === "governed_v2");
+  const legacy = routes.filter((route) => route.authority_mode === "legacy");
+  let dualModeRoutes = 0;
+  for (const route of governed) {
+    if (legacy.some((candidate) => authorityRoutesOverlap(route, candidate))) dualModeRoutes++;
+  }
+  const governedRoutes = governed.length;
+  const nullOperationRoutes = governed.filter((route) => !route.provider_operation_id).length;
   return {
     governedRoutes,
     nullOperationRoutes,

--- a/packages/api/src/services/governed-route-inventory.ts
+++ b/packages/api/src/services/governed-route-inventory.ts
@@ -1,0 +1,65 @@
+import { getDb, sql } from "@stwd/db";
+
+export type GovernedRouteInventory = {
+  governedRoutes: number;
+  nullOperationRoutes: number;
+  dualModeRoutes: number;
+  ok: boolean;
+};
+
+function rowsFromExecute<T>(result: unknown): T[] {
+  if (Array.isArray(result)) return result as T[];
+  if (result && typeof result === "object" && "rows" in result) {
+    const rows = (result as { rows?: unknown }).rows;
+    if (Array.isArray(rows)) return rows as T[];
+  }
+  return [];
+}
+
+/**
+ * Single source for the runtime doctor and PR7's static/runtime route guard.
+ * A dual-mode match is the same tenant/agent/host/path/method credential route
+ * exposed once through legacy authority and once through governed authority.
+ */
+export async function inspectGovernedRoutes(): Promise<GovernedRouteInventory> {
+  const db = getDb();
+  const [row = { governed: 0, null_operations: 0, dual_mode: 0 }] = rowsFromExecute<{
+    governed: number;
+    null_operations: number;
+    dual_mode: number;
+  }>(
+    await db.execute(sql`
+      WITH route_counts AS (
+        SELECT
+          tenant_id,
+          COALESCE(agent_id, '') AS agent_id,
+          host_pattern,
+          COALESCE(path_pattern, '/*') AS path_pattern,
+          COALESCE(method, '*') AS method,
+          BOOL_OR(authority_mode = 'legacy') AS has_legacy,
+          BOOL_OR(authority_mode = 'governed_v2') AS has_governed
+        FROM secret_routes
+        WHERE enabled = TRUE
+        GROUP BY tenant_id, COALESCE(agent_id, ''), host_pattern,
+          COALESCE(path_pattern, '/*'), COALESCE(method, '*')
+      )
+      SELECT
+        (SELECT COUNT(*)::int FROM secret_routes
+          WHERE enabled = TRUE AND authority_mode = 'governed_v2') AS governed,
+        (SELECT COUNT(*)::int FROM secret_routes
+          WHERE enabled = TRUE AND authority_mode = 'governed_v2'
+            AND provider_operation_id IS NULL) AS null_operations,
+        (SELECT COUNT(*)::int FROM route_counts
+          WHERE has_legacy AND has_governed) AS dual_mode
+    `),
+  );
+  const governedRoutes = Number(row.governed);
+  const nullOperationRoutes = Number(row.null_operations);
+  const dualModeRoutes = Number(row.dual_mode);
+  return {
+    governedRoutes,
+    nullOperationRoutes,
+    dualModeRoutes,
+    ok: nullOperationRoutes === 0 && dualModeRoutes === 0,
+  };
+}

--- a/packages/cli/src/__tests__/api.test.ts
+++ b/packages/cli/src/__tests__/api.test.ts
@@ -94,15 +94,18 @@ describe("StewardApiClient", () => {
 
   test("applies a request deadline to every API call", async () => {
     let signal: AbortSignal | undefined;
+    let redirect: RequestRedirect | undefined;
     const client = new StewardApiClient({
       baseUrl: "https://api.example.test",
       fetchImpl: (async (_url, init) => {
         signal = init?.signal as AbortSignal;
+        redirect = init?.redirect;
         return Response.json({ ok: true, data: {} });
       }) as typeof fetch,
     });
     await client.request("GET", "/health");
     expect(signal).toBeInstanceOf(AbortSignal);
+    expect(redirect).toBe("error");
   });
 
   test("rejects credential-bearing and public plaintext API URLs", () => {

--- a/packages/cli/src/__tests__/api.test.ts
+++ b/packages/cli/src/__tests__/api.test.ts
@@ -70,4 +70,38 @@ describe("StewardApiClient", () => {
     await expect(client.request("GET", "/agents")).rejects.toThrow(ApiError);
     await expect(client.request("GET", "/agents")).rejects.toThrow("nope");
   });
+
+  test("bounds declared and streamed API response bodies", async () => {
+    for (const response of [
+      new Response("small", { headers: { "content-length": "1048577" } }),
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new Uint8Array(1024 * 1024));
+            controller.enqueue(new Uint8Array([1]));
+            controller.close();
+          },
+        }),
+      ),
+    ]) {
+      const client = new StewardApiClient({
+        baseUrl: "https://api.example.test",
+        fetchImpl: (async () => response) as typeof fetch,
+      });
+      await expect(client.request("GET", "/health")).rejects.toThrow("exceeded the 1 MiB limit");
+    }
+  });
+
+  test("applies a request deadline to every API call", async () => {
+    let signal: AbortSignal | undefined;
+    const client = new StewardApiClient({
+      baseUrl: "https://api.example.test",
+      fetchImpl: (async (_url, init) => {
+        signal = init?.signal as AbortSignal;
+        return Response.json({ ok: true, data: {} });
+      }) as typeof fetch,
+    });
+    await client.request("GET", "/health");
+    expect(signal).toBeInstanceOf(AbortSignal);
+  });
 });

--- a/packages/cli/src/__tests__/api.test.ts
+++ b/packages/cli/src/__tests__/api.test.ts
@@ -5,7 +5,7 @@ describe("StewardApiClient", () => {
   test("sends platform key for platform requests and unwraps ApiResponse data", async () => {
     const seen: Record<string, string> = {};
     const client = new StewardApiClient({
-      baseUrl: "http://steward.test/",
+      baseUrl: "https://steward.test/",
       platformKey: "platform-secret",
       fetchImpl: (async (_url, init) => {
         Object.assign(seen, init?.headers);
@@ -26,7 +26,7 @@ describe("StewardApiClient", () => {
   test("falls back to tenant API key (X-Steward-Key) when no bearer token is set", async () => {
     const seen: Record<string, string> = {};
     const client = new StewardApiClient({
-      baseUrl: "http://steward.test",
+      baseUrl: "https://steward.test",
       tenantId: "acme",
       tenantKey: "stw_tenant_secret",
       fetchImpl: (async (_url, init) => {
@@ -44,7 +44,7 @@ describe("StewardApiClient", () => {
   test("prefers bearer token over tenant API key when both are set", async () => {
     const seen: Record<string, string> = {};
     const client = new StewardApiClient({
-      baseUrl: "http://steward.test",
+      baseUrl: "https://steward.test",
       token: "bearer-token",
       tenantKey: "stw_tenant_secret",
       fetchImpl: (async (_url, init) => {
@@ -60,7 +60,7 @@ describe("StewardApiClient", () => {
 
   test("raises API errors with response status and message", async () => {
     const client = new StewardApiClient({
-      baseUrl: "http://steward.test",
+      baseUrl: "https://steward.test",
       fetchImpl: (async () =>
         new Response(JSON.stringify({ ok: false, error: "nope" }), {
           status: 403,
@@ -103,5 +103,15 @@ describe("StewardApiClient", () => {
     });
     await client.request("GET", "/health");
     expect(signal).toBeInstanceOf(AbortSignal);
+  });
+
+  test("rejects credential-bearing and public plaintext API URLs", () => {
+    expect(() => new StewardApiClient({ baseUrl: "http://api.example.test" })).toThrow(
+      "must use HTTPS",
+    );
+    expect(() => new StewardApiClient({ baseUrl: "https://user:secret@api.example.test" })).toThrow(
+      "must not contain embedded credentials",
+    );
+    expect(() => new StewardApiClient({ baseUrl: "http://127.0.0.1:3200" })).not.toThrow();
   });
 });

--- a/packages/cli/src/__tests__/api.test.ts
+++ b/packages/cli/src/__tests__/api.test.ts
@@ -86,7 +86,7 @@ describe("StewardApiClient", () => {
     ]) {
       const client = new StewardApiClient({
         baseUrl: "https://api.example.test",
-        fetchImpl: (async () => response) as typeof fetch,
+        fetchImpl: (async () => response) as unknown as typeof fetch,
       });
       await expect(client.request("GET", "/health")).rejects.toThrow("exceeded the 1 MiB limit");
     }

--- a/packages/cli/src/__tests__/doctor.test.ts
+++ b/packages/cli/src/__tests__/doctor.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
-import type { StewardApiClient } from "../api";
+import { join, resolve } from "node:path";
+import { ApiError, type StewardApiClient } from "../api";
 import { runDoctor } from "../doctor";
 import { describeSecret } from "../format";
 
@@ -46,8 +47,8 @@ function stubApi(): StewardApiClient {
   } as unknown as StewardApiClient;
 }
 
-/** All contiguous substrings of length >= 4 of `value`. */
-function substringsOf(value: string, min = 4): string[] {
+/** Long contiguous fragments whose accidental appearance in static output is negligible. */
+function substringsOf(value: string, min = 12): string[] {
   const out: string[] = [];
   for (let len = min; len <= value.length; len++) {
     for (let i = 0; i + len <= value.length; i++) out.push(value.slice(i, i + len));
@@ -70,7 +71,7 @@ describe("describeSecret", () => {
 });
 
 describe("steward doctor secret redaction", () => {
-  test("no >=4-char substring of any secret appears in pretty or JSON output", async () => {
+  test("no long fragment of any secret appears in pretty or JSON output", async () => {
     const dir = mkdtempSync(join(tmpdir(), "steward-doctor-"));
     try {
       // Realistic high-entropy secrets (random hex), so accidental overlaps with
@@ -196,6 +197,73 @@ describe("PR6 governed-route prerequisites (strict)", () => {
 });
 
 describe("operator-integrity diagnostics", () => {
+  test("preserves structured readiness diagnostics from an HTTP 503", async () => {
+    const api = {
+      baseUrl: "http://stub.local",
+      request: async (_method: string, path: string) => {
+        if (path === "/health") return { ok: true };
+        if (path === "/ready") {
+          throw new ApiError("not ready", 503, {
+            status: "not_ready",
+            checks: {
+              migrations: { ok: false, detail: { expected: "0085", actual: "0084" } },
+              redis: { ok: false, required: false },
+              governedRoutes: { ok: true },
+              proxyClock: { ok: false, required: false },
+              database: {
+                ok: true,
+                detail: { clockSkewMs: 0, serverTime: new Date().toISOString() },
+              },
+            },
+          });
+        }
+        return { valid: true };
+      },
+    } as unknown as StewardApiClient;
+    const result = await runDoctor({ strict: true, api });
+    expect(result.checks.find((check) => check.name === "ops:migration-tip")?.ok).toBe(false);
+    expect(result.checks.find((check) => check.name === "ops:redis-reachability")?.ok).toBe(true);
+    expect(result.checks.find((check) => check.name === "ops:proxy-clock-skew")?.ok).toBe(true);
+  });
+
+  test("strict mode reports that tenant-key auth cannot satisfy the audit MFA gate", async () => {
+    const api = {
+      baseUrl: "http://stub.local",
+      request: async (_method: string, path: string) => {
+        if (path === "/health") return { ok: true };
+        if (path === "/ready") return stubApi().request("GET", path);
+        throw new ApiError("Owner/admin session with recent MFA required", 403, {
+          error: "Owner/admin session with recent MFA required",
+        });
+      },
+    } as unknown as StewardApiClient;
+    const result = await runDoctor({ strict: true, api });
+    const check = result.checks.find((entry) => entry.name === "ops:audit-checkpoint-integrity");
+    expect(check?.ok).toBe(false);
+    expect(check?.detail).toContain("recent MFA");
+  });
+
+  test("the real --strict CLI exits nonzero when any gate fails", () => {
+    const result = spawnSync(
+      process.execPath,
+      ["packages/cli/src/index.ts", "doctor", "--strict", "--json", "--env", "/dev/null"],
+      {
+        cwd: resolve(import.meta.dir, "../../../.."),
+        env: {
+          ...process.env,
+          STEWARD_API_URL: "http://127.0.0.1:1",
+          STEWARD_API_TOKEN: "",
+          STEWARD_TOKEN: "",
+          STEWARD_TENANT_KEY: "",
+        },
+        encoding: "utf8",
+        timeout: 10_000,
+      },
+    );
+    expect(result.status).toBe(1);
+    expect(JSON.parse(result.stdout).ok).toBe(false);
+  });
+
   test("strict mode fails closed for every unavailable or failed operational check", async () => {
     const api = {
       baseUrl: "http://stub.local",

--- a/packages/cli/src/__tests__/doctor.test.ts
+++ b/packages/cli/src/__tests__/doctor.test.ts
@@ -12,7 +12,37 @@ import { describeSecret } from "../format";
 function stubApi(): StewardApiClient {
   return {
     baseUrl: "http://stub.local",
-    request: async () => ({ ok: true }),
+    request: async (_method: string, path: string) => {
+      if (path === "/ready") {
+        return {
+          checks: {
+            migrations: { ok: true, detail: { expected: "journal-tip" } },
+            redis: { ok: true },
+            governedRoutes: {
+              ok: true,
+              detail: { governedRoutes: 1, nullOperationRoutes: 0, dualModeRoutes: 0 },
+            },
+            proxyClock: { ok: true, detail: { clockSkewMs: 2 } },
+            database: {
+              ok: true,
+              detail: { clockSkewMs: 1, serverTime: new Date().toISOString() },
+            },
+          },
+        };
+      }
+      if (path === "/audit/integrity") {
+        return {
+          valid: true,
+          chainValid: true,
+          checkpointPresent: true,
+          checkpointValid: true,
+          checkpointAtHead: true,
+          checkpointSeq: 4,
+          chainHeadSeq: 4,
+        };
+      }
+      return { ok: true };
+    },
   } as unknown as StewardApiClient;
 }
 
@@ -162,5 +192,51 @@ describe("PR6 governed-route prerequisites (strict)", () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("operator-integrity diagnostics", () => {
+  test("strict mode fails closed for every unavailable or failed operational check", async () => {
+    const api = {
+      baseUrl: "http://stub.local",
+      request: async (_method: string, path: string) => {
+        if (path === "/ready") {
+          return {
+            checks: {
+              migrations: { ok: false, detail: { expected: "0084", actual: "0083" } },
+              redis: { ok: false, error: "unreachable" },
+              governedRoutes: { ok: false, detail: { nullOperationRoutes: 1 } },
+              proxyClock: { ok: false, detail: { clockSkewMs: 60_000 } },
+              database: {
+                ok: false,
+                detail: { clockSkewMs: 60_000, serverTime: new Date().toISOString() },
+              },
+            },
+          };
+        }
+        if (path === "/audit/integrity") {
+          return {
+            valid: false,
+            chainValid: true,
+            checkpointPresent: true,
+            checkpointValid: true,
+            checkpointAtHead: false,
+          };
+        }
+        return { ok: true };
+      },
+    } as unknown as StewardApiClient;
+    const result = await runDoctor({ strict: true, api });
+    for (const name of [
+      "ops:migration-tip",
+      "ops:redis-reachability",
+      "ops:governed-route-inventory",
+      "ops:proxy-clock-skew",
+      "ops:api-database-clock-skew",
+      "ops:audit-checkpoint-integrity",
+    ]) {
+      expect(result.checks.find((check) => check.name === name)?.ok).toBe(false);
+    }
+    expect(result.ok).toBe(false);
   });
 });

--- a/packages/cli/src/__tests__/doctor.test.ts
+++ b/packages/cli/src/__tests__/doctor.test.ts
@@ -19,10 +19,6 @@ function stubApi(): StewardApiClient {
           checks: {
             migrations: { ok: true, detail: { expected: "journal-tip" } },
             redis: { ok: true },
-            governedRoutes: {
-              ok: true,
-              detail: { governedRoutes: 1, nullOperationRoutes: 0, dualModeRoutes: 0 },
-            },
             proxyClock: { ok: true, detail: { clockSkewMs: 2 } },
             database: {
               ok: true,
@@ -40,6 +36,10 @@ function stubApi(): StewardApiClient {
           checkpointAtHead: true,
           checkpointSeq: 4,
           chainHeadSeq: 4,
+          governedRoutes: {
+            ok: true,
+            detail: { governedRoutes: 1, nullOperationRoutes: 0, dualModeRoutes: 0 },
+          },
         };
       }
       return { ok: true };
@@ -208,7 +208,6 @@ describe("operator-integrity diagnostics", () => {
             checks: {
               migrations: { ok: false, detail: { expected: "0085", actual: "0084" } },
               redis: { ok: false, required: false },
-              governedRoutes: { ok: true },
               proxyClock: { ok: false, required: false },
               database: {
                 ok: true,
@@ -217,7 +216,7 @@ describe("operator-integrity diagnostics", () => {
             },
           });
         }
-        return { valid: true };
+        return { valid: true, governedRoutes: { ok: true } };
       },
     } as unknown as StewardApiClient;
     const result = await runDoctor({ strict: true, api });
@@ -273,7 +272,6 @@ describe("operator-integrity diagnostics", () => {
             checks: {
               migrations: { ok: false, detail: { expected: "0084", actual: "0083" } },
               redis: { ok: false, error: "unreachable" },
-              governedRoutes: { ok: false, detail: { nullOperationRoutes: 1 } },
               proxyClock: { ok: false, detail: { clockSkewMs: 60_000 } },
               database: {
                 ok: false,
@@ -289,6 +287,7 @@ describe("operator-integrity diagnostics", () => {
             checkpointPresent: true,
             checkpointValid: true,
             checkpointAtHead: false,
+            governedRoutes: { ok: false, detail: { nullOperationRoutes: 1 } },
           };
         }
         return { ok: true };

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -65,7 +65,22 @@ async function readBoundedResponse(res: Response): Promise<string> {
 }
 
 function normalizeBaseUrl(value: string | undefined): string {
-  return (value || process.env.STEWARD_API_URL || "http://127.0.0.1:3200").replace(/\/+$/, "");
+  const raw = (value || process.env.STEWARD_API_URL || "http://127.0.0.1:3200").replace(/\/+$/, "");
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new Error("STEWARD_API_URL must be a valid absolute URL");
+  }
+  if (url.username || url.password) {
+    throw new Error("STEWARD_API_URL must not contain embedded credentials");
+  }
+  const loopback =
+    url.hostname === "localhost" || url.hostname === "127.0.0.1" || url.hostname === "[::1]";
+  if (url.protocol !== "https:" && !(url.protocol === "http:" && loopback)) {
+    throw new Error("STEWARD_API_URL must use HTTPS unless it targets loopback");
+  }
+  return raw;
 }
 
 export class StewardApiClient {

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -25,6 +25,45 @@ export class ApiError extends Error {
   }
 }
 
+const API_REQUEST_TIMEOUT_MS = 10_000;
+const API_RESPONSE_MAX_BYTES = 1024 * 1024;
+
+async function readBoundedResponse(res: Response): Promise<string> {
+  const declared = res.headers.get("content-length");
+  if (declared !== null) {
+    const length = Number(declared);
+    if (!Number.isSafeInteger(length) || length < 0 || length > API_RESPONSE_MAX_BYTES) {
+      void res.body?.cancel().catch(() => {});
+      throw new Error("Steward API response exceeded the 1 MiB limit");
+    }
+  }
+  if (!res.body) return "";
+  const reader = res.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > API_RESPONSE_MAX_BYTES) {
+        void reader.cancel().catch(() => {});
+        throw new Error("Steward API response exceeded the 1 MiB limit");
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(bytes);
+}
+
 function normalizeBaseUrl(value: string | undefined): string {
   return (value || process.env.STEWARD_API_URL || "http://127.0.0.1:3200").replace(/\/+$/, "");
 }
@@ -69,8 +108,9 @@ export class StewardApiClient {
       method,
       headers,
       body: body === undefined ? undefined : JSON.stringify(body),
+      signal: AbortSignal.timeout(API_REQUEST_TIMEOUT_MS),
     });
-    const text = await res.text();
+    const text = await readBoundedResponse(res);
     const parsed = text ? safeJson(text) : null;
     if (!res.ok) {
       const message =

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -124,6 +124,10 @@ export class StewardApiClient {
       headers,
       body: body === undefined ? undefined : JSON.stringify(body),
       signal: AbortSignal.timeout(API_REQUEST_TIMEOUT_MS),
+      // The client attaches bearer, platform, or tenant credentials. Never let
+      // fetch replay those headers to a Location selected by an intermediary or
+      // compromised endpoint; operators must configure the canonical API URL.
+      redirect: "error",
     });
     const text = await readBoundedResponse(res);
     const parsed = text ? safeJson(text) : null;

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { StewardApiClient } from "./api";
+import { ApiError, StewardApiClient } from "./api";
 import { describeSecret } from "./format";
 
 export type DoctorCheck = {
@@ -15,10 +15,24 @@ export type DoctorOptions = {
   api?: StewardApiClient;
 };
 
-type ReadyCheck = { ok?: unknown; error?: unknown; detail?: unknown };
+type ReadyCheck = { ok?: unknown; required?: unknown; error?: unknown; detail?: unknown };
 type ReadyResponse = {
   checks?: Record<string, ReadyCheck>;
 };
+
+function readyResponseFromError(error: unknown): ReadyResponse | null {
+  if (!(error instanceof ApiError) || !error.body || typeof error.body !== "object") return null;
+  const body = error.body as { checks?: unknown; data?: unknown };
+  const candidate =
+    body.checks !== undefined
+      ? body
+      : body.data && typeof body.data === "object"
+        ? (body.data as { checks?: unknown })
+        : null;
+  return candidate && candidate.checks && typeof candidate.checks === "object"
+    ? (candidate as ReadyResponse)
+    : null;
+}
 
 function operationalDetail(check: ReadyCheck | undefined, fallback: string): string {
   if (!check) return fallback;
@@ -104,43 +118,36 @@ export async function runDoctor(
   } catch (error) {
     checks.push({ name: "api:/health", ok: !options.strict, detail: (error as Error).message });
   }
+  let readyResponse: ReadyResponse | null = null;
+  let readyError: unknown;
   try {
     const requestedAt = Date.now();
     const ready = await api.request<ReadyResponse>("GET", "/ready", undefined, { tenant: false });
     const receivedAt = Date.now();
-    checks.push({ name: "api:/ready", ok: true, detail: JSON.stringify(ready) });
+    readyResponse = ready;
     const readyChecks = ready.checks ?? {};
-    for (const [name, source] of [
-      ["ops:migration-tip", readyChecks.migrations],
-      ["ops:redis-reachability", readyChecks.redis],
-      ["ops:governed-route-inventory", readyChecks.governedRoutes],
-      ["ops:proxy-clock-skew", readyChecks.proxyClock],
-    ] as const) {
-      checks.push({
-        name,
-        ok: source?.ok === true || (!options.strict && source?.ok !== false),
-        detail: operationalDetail(source, "diagnostic unavailable"),
-      });
-    }
-    const databaseDetail = readyChecks.database?.detail as
-      | { clockSkewMs?: unknown; serverTime?: unknown }
-      | undefined;
-    const apiTime = Date.parse(String(databaseDetail?.serverTime ?? ""));
-    const midpoint = requestedAt + (receivedAt - requestedAt) / 2;
-    const apiSkewMs = Math.abs(apiTime - midpoint);
-    const dbSkewMs = Number(databaseDetail?.clockSkewMs);
-    const clocksOk =
-      Number.isFinite(apiSkewMs) &&
-      apiSkewMs <= 30_000 &&
-      Number.isFinite(dbSkewMs) &&
-      dbSkewMs <= 30_000;
-    checks.push({
-      name: "ops:api-database-clock-skew",
-      ok: clocksOk || !options.strict,
-      detail: JSON.stringify({ apiSkewMs: Math.round(apiSkewMs), databaseSkewMs: dbSkewMs }),
-    });
+    checks.push({ name: "api:/ready", ok: true, detail: JSON.stringify(ready) });
+    appendReadyChecks(checks, readyChecks, options.strict === true, requestedAt, receivedAt);
   } catch (error) {
-    checks.push({ name: "api:/ready", ok: !options.strict, detail: (error as Error).message });
+    readyError = error;
+    readyResponse = readyResponseFromError(error);
+    if (readyResponse) {
+      const now = Date.now();
+      checks.push({
+        name: "api:/ready",
+        ok: !options.strict,
+        detail: JSON.stringify(readyResponse),
+      });
+      appendReadyChecks(checks, readyResponse.checks ?? {}, options.strict === true, now, now);
+    }
+  }
+  if (!readyResponse) {
+    const error = readyError;
+    checks.push({
+      name: "api:/ready",
+      ok: !options.strict,
+      detail: error instanceof Error ? error.message : "readiness response unavailable",
+    });
     for (const name of [
       "ops:migration-tip",
       "ops:redis-reachability",
@@ -183,4 +190,42 @@ export async function runDoctor(
   }
 
   return { ok: checks.every((check) => check.ok), checks };
+}
+
+function appendReadyChecks(
+  checks: DoctorCheck[],
+  readyChecks: Record<string, ReadyCheck>,
+  strict: boolean,
+  requestedAt: number,
+  receivedAt: number,
+): void {
+  for (const [name, source] of [
+    ["ops:migration-tip", readyChecks.migrations],
+    ["ops:redis-reachability", readyChecks.redis],
+    ["ops:governed-route-inventory", readyChecks.governedRoutes],
+    ["ops:proxy-clock-skew", readyChecks.proxyClock],
+  ] as const) {
+    checks.push({
+      name,
+      ok: source?.ok === true || source?.required === false || (!strict && source?.ok !== false),
+      detail: operationalDetail(source, "diagnostic unavailable"),
+    });
+  }
+  const databaseDetail = readyChecks.database?.detail as
+    | { clockSkewMs?: unknown; serverTime?: unknown }
+    | undefined;
+  const apiTime = Date.parse(String(databaseDetail?.serverTime ?? ""));
+  const midpoint = requestedAt + (receivedAt - requestedAt) / 2;
+  const apiSkewMs = Math.abs(apiTime - midpoint);
+  const dbSkewMs = Number(databaseDetail?.clockSkewMs);
+  const clocksOk =
+    Number.isFinite(apiSkewMs) &&
+    apiSkewMs <= 30_000 &&
+    Number.isFinite(dbSkewMs) &&
+    dbSkewMs <= 30_000;
+  checks.push({
+    name: "ops:api-database-clock-skew",
+    ok: clocksOk || !strict,
+    detail: JSON.stringify({ apiSkewMs: Math.round(apiSkewMs), databaseSkewMs: dbSkewMs }),
+  });
 }

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -151,7 +151,6 @@ export async function runDoctor(
     for (const name of [
       "ops:migration-tip",
       "ops:redis-reachability",
-      "ops:governed-route-inventory",
       "ops:proxy-clock-skew",
       "ops:api-database-clock-skew",
     ]) {
@@ -168,7 +167,15 @@ export async function runDoctor(
       checkpointAtHead?: unknown;
       checkpointSeq?: unknown;
       chainHeadSeq?: unknown;
+      governedRoutes?: ReadyCheck;
     }>("GET", "/audit/integrity");
+    checks.push({
+      name: "ops:governed-route-inventory",
+      ok:
+        integrity.governedRoutes?.ok === true ||
+        (!options.strict && integrity.governedRoutes?.ok !== false),
+      detail: operationalDetail(integrity.governedRoutes, "diagnostic unavailable"),
+    });
     checks.push({
       name: "ops:audit-checkpoint-integrity",
       ok: integrity.valid === true || !options.strict,
@@ -182,6 +189,11 @@ export async function runDoctor(
       }),
     });
   } catch (error) {
+    checks.push({
+      name: "ops:governed-route-inventory",
+      ok: !options.strict,
+      detail: (error as Error).message,
+    });
     checks.push({
       name: "ops:audit-checkpoint-integrity",
       ok: !options.strict,
@@ -202,7 +214,6 @@ function appendReadyChecks(
   for (const [name, source] of [
     ["ops:migration-tip", readyChecks.migrations],
     ["ops:redis-reachability", readyChecks.redis],
-    ["ops:governed-route-inventory", readyChecks.governedRoutes],
     ["ops:proxy-clock-skew", readyChecks.proxyClock],
   ] as const) {
     checks.push({

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -15,6 +15,21 @@ export type DoctorOptions = {
   api?: StewardApiClient;
 };
 
+type ReadyCheck = { ok?: unknown; error?: unknown; detail?: unknown };
+type ReadyResponse = {
+  checks?: Record<string, ReadyCheck>;
+};
+
+function operationalDetail(check: ReadyCheck | undefined, fallback: string): string {
+  if (!check) return fallback;
+  if (typeof check.error === "string") return check.error;
+  return check.detail === undefined
+    ? check.ok === true
+      ? "ok"
+      : fallback
+    : JSON.stringify(check.detail);
+}
+
 function parseEnv(path: string): Record<string, string> {
   if (!existsSync(path)) return {};
   const out: Record<string, string> = {};
@@ -90,10 +105,81 @@ export async function runDoctor(
     checks.push({ name: "api:/health", ok: !options.strict, detail: (error as Error).message });
   }
   try {
-    const ready = await api.request("GET", "/ready", undefined, { tenant: false });
+    const requestedAt = Date.now();
+    const ready = await api.request<ReadyResponse>("GET", "/ready", undefined, { tenant: false });
+    const receivedAt = Date.now();
     checks.push({ name: "api:/ready", ok: true, detail: JSON.stringify(ready) });
+    const readyChecks = ready.checks ?? {};
+    for (const [name, source] of [
+      ["ops:migration-tip", readyChecks.migrations],
+      ["ops:redis-reachability", readyChecks.redis],
+      ["ops:governed-route-inventory", readyChecks.governedRoutes],
+      ["ops:proxy-clock-skew", readyChecks.proxyClock],
+    ] as const) {
+      checks.push({
+        name,
+        ok: source?.ok === true || (!options.strict && source?.ok !== false),
+        detail: operationalDetail(source, "diagnostic unavailable"),
+      });
+    }
+    const databaseDetail = readyChecks.database?.detail as
+      | { clockSkewMs?: unknown; serverTime?: unknown }
+      | undefined;
+    const apiTime = Date.parse(String(databaseDetail?.serverTime ?? ""));
+    const midpoint = requestedAt + (receivedAt - requestedAt) / 2;
+    const apiSkewMs = Math.abs(apiTime - midpoint);
+    const dbSkewMs = Number(databaseDetail?.clockSkewMs);
+    const clocksOk =
+      Number.isFinite(apiSkewMs) &&
+      apiSkewMs <= 30_000 &&
+      Number.isFinite(dbSkewMs) &&
+      dbSkewMs <= 30_000;
+    checks.push({
+      name: "ops:api-database-clock-skew",
+      ok: clocksOk || !options.strict,
+      detail: JSON.stringify({ apiSkewMs: Math.round(apiSkewMs), databaseSkewMs: dbSkewMs }),
+    });
   } catch (error) {
     checks.push({ name: "api:/ready", ok: !options.strict, detail: (error as Error).message });
+    for (const name of [
+      "ops:migration-tip",
+      "ops:redis-reachability",
+      "ops:governed-route-inventory",
+      "ops:proxy-clock-skew",
+      "ops:api-database-clock-skew",
+    ]) {
+      checks.push({ name, ok: !options.strict, detail: "unavailable because /ready failed" });
+    }
+  }
+
+  try {
+    const integrity = await api.request<{
+      valid?: unknown;
+      chainValid?: unknown;
+      checkpointPresent?: unknown;
+      checkpointValid?: unknown;
+      checkpointAtHead?: unknown;
+      checkpointSeq?: unknown;
+      chainHeadSeq?: unknown;
+    }>("GET", "/audit/integrity");
+    checks.push({
+      name: "ops:audit-checkpoint-integrity",
+      ok: integrity.valid === true || !options.strict,
+      detail: JSON.stringify({
+        chainValid: integrity.chainValid === true,
+        checkpointPresent: integrity.checkpointPresent === true,
+        checkpointValid: integrity.checkpointValid === true,
+        checkpointAtHead: integrity.checkpointAtHead === true,
+        checkpointSeq: integrity.checkpointSeq ?? null,
+        chainHeadSeq: integrity.chainHeadSeq ?? null,
+      }),
+    });
+  } catch (error) {
+    checks.push({
+      name: "ops:audit-checkpoint-integrity",
+      ok: !options.strict,
+      detail: (error as Error).message,
+    });
   }
 
   return { ok: checks.every((check) => check.ok), checks };

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -47,6 +47,9 @@ Auth:
   back to the tenant API key (--tenant-key -> X-Steward-Key), which the API
   treats as an api-key machine credential. This is the non-interactive path the
   golden-path script uses (api-key auth bypasses the human-session MFA step-up).
+  doctor --strict additionally verifies /audit/integrity and therefore requires
+  an owner/admin Bearer session with recent MFA; tenant keys and agent tokens
+  intentionally fail that check.
 `;
 
 function createContext(flags: Record<string, string | boolean>): CommandContext {
@@ -363,13 +366,14 @@ async function main(argv: string[]) {
     return;
   }
   if (command === "doctor") {
-    printResult(
-      await runDoctor({
-        strict: boolFlag(parsed.flags, "strict"),
-        envPath: stringFlag(parsed.flags, "env"),
-      }),
-      ctx.format,
-    );
+    const strict = boolFlag(parsed.flags, "strict");
+    const result = await runDoctor({
+      strict,
+      envPath: stringFlag(parsed.flags, "env"),
+      api: ctx.api,
+    });
+    printResult(result, ctx.format);
+    if (strict && !result.ok) process.exitCode = 1;
     return;
   }
 

--- a/packages/db/src/__tests__/migration-status.test.ts
+++ b/packages/db/src/__tests__/migration-status.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { getMigrationExpectation } from "../migration-status";
+
+describe("migration expectation", () => {
+  test("is derived from the checked-in journal tip", () => {
+    const journal = JSON.parse(
+      readFileSync(new URL("../../drizzle/meta/_journal.json", import.meta.url), "utf8"),
+    ) as { entries: Array<{ tag: string; when: number }> };
+    const tip = journal.entries.at(-1);
+    expect(tip).toBeDefined();
+    expect(getMigrationExpectation()).toEqual({
+      tag: tip?.tag,
+      createdAt: tip?.when,
+      count: journal.entries.length,
+    });
+  });
+});

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -34,6 +34,7 @@ export {
   setPGLiteOverride,
 } from "./client";
 export { runMigrations } from "./migrate";
+export { getMigrationExpectation, type MigrationExpectation } from "./migration-status";
 export { encryptOAuthAccountPlaintextTokens } from "./oauth-token-encryption";
 export {
   pluginAdvisoryLockKey,

--- a/packages/db/src/migration-status.ts
+++ b/packages/db/src/migration-status.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+
+export type MigrationExpectation = {
+  tag: string;
+  createdAt: number;
+  count: number;
+};
+
+type Journal = { entries?: Array<{ tag?: unknown; when?: unknown }> };
+
+/**
+ * Return the checked-in migration tip. Reading the journal keeps operational
+ * diagnostics aligned with the migrator instead of duplicating a tag that
+ * becomes stale whenever a migration is added.
+ */
+export function getMigrationExpectation(): MigrationExpectation {
+  const path = new URL("../drizzle/meta/_journal.json", import.meta.url);
+  const journal = JSON.parse(readFileSync(path, "utf8")) as Journal;
+  const entries = journal.entries ?? [];
+  const last = entries.at(-1);
+  if (!last || typeof last.tag !== "string" || typeof last.when !== "number") {
+    throw new Error("migration journal has no valid tip");
+  }
+  return { tag: last.tag, createdAt: last.when, count: entries.length };
+}

--- a/packages/proxy/src/handlers/matching.ts
+++ b/packages/proxy/src/handlers/matching.ts
@@ -4,33 +4,10 @@
  * Extracted from proxy.ts so they can be unit-tested without DB dependencies.
  */
 
-/**
- * Match a host pattern against a hostname.
- * Supports exact match and wildcard prefix: *.example.com
- */
-export function matchHost(pattern: string, host: string): boolean {
-  if (pattern === host) return true;
-  if (pattern.startsWith("*.")) {
-    const suffix = pattern.slice(1); // ".example.com"
-    return host.endsWith(suffix) && host.length > suffix.length;
-  }
-  return false;
-}
-
-/**
- * Match a path pattern against a request path.
- * Supports exact match and wildcard suffix: /v1/*
- * The pattern "/*" matches everything.
- */
-export function matchPath(pattern: string, path: string): boolean {
-  if (pattern === "/*" || pattern === "*") return true;
-  if (pattern === path) return true;
-  if (pattern.endsWith("/*")) {
-    const prefix = pattern.slice(0, -1); // "/v1/"
-    return path.startsWith(prefix);
-  }
-  return false;
-}
+export {
+  matchSecretRouteHost as matchHost,
+  matchSecretRoutePath as matchPath,
+} from "@stwd/shared";
 
 export interface RouteMatchPattern {
   hostPattern: string;

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -50,6 +50,7 @@ app.get("/health", (c) =>
     ok: true,
     service: "steward-proxy",
     version: "0.3.0",
+    serverTime: new Date().toISOString(),
     aliases: getAliasNames(),
   }),
 );

--- a/packages/shared/src/__tests__/secret-route-matching.test.ts
+++ b/packages/shared/src/__tests__/secret-route-matching.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import {
+  matchSecretRouteHost,
+  matchSecretRoutePath,
+  secretRouteHostPatternsOverlap,
+  secretRoutePathPatternsOverlap,
+} from "../secret-route-matching";
+
+describe("shared secret-route matching", () => {
+  test("host intersection agrees with runtime matching over exact and nested wildcard witnesses", () => {
+    const patterns = [
+      "api.example.com",
+      "other.example.com",
+      "*.example.com",
+      "*.sub.example.com",
+      "example.com",
+      "api.example.net",
+    ];
+    const hosts = [
+      "api.example.com",
+      "other.example.com",
+      "x.sub.example.com",
+      "deep.sub.example.com",
+      "example.com",
+      "api.example.net",
+    ];
+    for (const left of patterns) {
+      for (const right of patterns) {
+        const hasWitness = hosts.some(
+          (host) => matchSecretRouteHost(left, host) && matchSecretRouteHost(right, host),
+        );
+        expect(secretRouteHostPatternsOverlap(left, right)).toBe(hasWitness);
+      }
+    }
+  });
+
+  test("path intersection agrees with runtime matching over broad/narrow witnesses", () => {
+    const patterns = ["/*", "*", "/v1/*", "/v1/read/*", "/v1/read", "/v2/*", "/v2/x"];
+    const paths = ["/", "/x", "/v1/x", "/v1/read", "/v1/read/x", "/v2/x", "/v2/y"];
+    for (const left of patterns) {
+      for (const right of patterns) {
+        const hasWitness = paths.some(
+          (path) => matchSecretRoutePath(left, path) && matchSecretRoutePath(right, path),
+        );
+        expect(secretRoutePathPatternsOverlap(left, right)).toBe(hasWitness);
+      }
+    }
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -16,6 +16,7 @@ export * from "./provider-case.js";
 export * from "./provider-execution-auth.js";
 // ─── Non-throwing description of an arbitrary thrown value (fail-closed catches) ───
 export { describeThrown, UNPRINTABLE_THROWN_VALUE } from "./safe-error.js";
+export * from "./secret-route-matching.js";
 export * from "./security-surface.js";
 // ─── Token Registry & Price Oracle ───
 export * from "./tokens.js";

--- a/packages/shared/src/secret-route-matching.ts
+++ b/packages/shared/src/secret-route-matching.ts
@@ -1,0 +1,48 @@
+/** Shared credential-route matching and intersection semantics. */
+export function matchSecretRouteHost(pattern: string, host: string): boolean {
+  if (pattern === host) return true;
+  if (pattern.startsWith("*.")) {
+    const suffix = pattern.slice(1);
+    return host.endsWith(suffix) && host.length > suffix.length;
+  }
+  return false;
+}
+
+export function matchSecretRoutePath(pattern: string, path: string): boolean {
+  if (pattern === "/*" || pattern === "*") return true;
+  if (pattern === path) return true;
+  if (pattern.endsWith("/*")) return path.startsWith(pattern.slice(0, -1));
+  return false;
+}
+
+export function secretRouteHostPatternsOverlap(a: string, b: string): boolean {
+  if (a === b) return true;
+  if (a.startsWith("*.")) {
+    const witness = b.startsWith("*.") ? `x${b.slice(1)}` : b;
+    if (matchSecretRouteHost(a, witness)) return true;
+  }
+  if (b.startsWith("*.")) {
+    const witness = a.startsWith("*.") ? `x${a.slice(1)}` : a;
+    if (matchSecretRouteHost(b, witness)) return true;
+  }
+  return false;
+}
+
+export function secretRoutePathPatternsOverlap(a: string, b: string): boolean {
+  if (a === b) return true;
+  const witness = (pattern: string) => {
+    if (pattern === "*" || pattern === "/*") return "/__steward_overlap_witness__";
+    if (pattern.endsWith("/*")) return `${pattern.slice(0, -1)}__steward_overlap_witness__`;
+    return pattern;
+  };
+  return matchSecretRoutePath(a, witness(b)) || matchSecretRoutePath(b, witness(a));
+}
+
+export function secretRouteMethodPatternsOverlap(
+  a: string | null | undefined,
+  b: string | null | undefined,
+): boolean {
+  const left = (a ?? "*").toUpperCase();
+  const right = (b ?? "*").toUpperCase();
+  return left === "*" || right === "*" || left === right;
+}


### PR DESCRIPTION
Closes #211

## Summary

- make `steward doctor` a bounded, fail-closed operational integrity gate
- verify the checked-in migration-journal tip instead of hardcoding a stale migration number
- run audit verification inside a repeatable-read integrity snapshot with an explicit SQL row limit
- reuse the production route matcher and report strict auth/MFA limitations honestly
- preserve structured readiness diagnostics without leaking secret material
- remove the Compose readiness deadlock structurally while preserving strict proxy-clock readiness
- reject redirects for every credential-bearing CLI API request

## Exact-head validation

Head: `f14a52968be51d95e3327aa35964fc49d720baf8`
Base: `19dff0eb85906e3776b11d0c9a13e6dfe7636f91`

- CLI API + doctor: 16 pass, 20,382 assertions
- CLI dependency build: 5/5
- changed-file Biome and `git diff --check`: clean
- GitHub exact-head PR Checks: all 18 substantive jobs passed, including Postgres, embedded smoke, Compose, lint/typecheck, web, and every package matrix

The credential redirect regression asserts `redirect: "error"`; platform, tenant, and bearer credentials are never replayed to a `Location` selected by an intermediary or endpoint.
