### PR TITLE
fix(policy): make approval reservations crash durable

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -302,6 +302,9 @@ jobs:
           STEWARD_EMAIL_CODE_SECRET: "ci-email-code-secret-must-be-at-least-32-chars-long"
           STEWARD_EXECUTION_AUTH_SECRET: "v2-ci-1:ci-execution-auth-secret-must-be-at-least-32-bytes-long"
           STEWARD_AUDIT_HMAC_KEY: "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+          # Exercise the API's real Redis-backed reservation/crash-recovery E2Es;
+          # this job already provisions a healthy Redis service above.
+          STEWARD_REDIS_TESTS: "1"
           SIWE_ALLOWED_DOMAINS: "steward.fi,localhost,127.0.0.1:3200"
           # The whole api suite drives this one server from a single IP; the
           # default 100-req/60s per-IP gate 429s the sharded test flood.
@@ -345,6 +348,7 @@ jobs:
           STEWARD_EMAIL_CODE_SECRET: "ci-email-code-secret-must-be-at-least-32-chars-long"
           STEWARD_EXECUTION_AUTH_SECRET: "v2-ci-1:ci-execution-auth-secret-must-be-at-least-32-bytes-long"
           STEWARD_AUDIT_HMAC_KEY: "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+          STEWARD_REDIS_TESTS: "1"
           SIWE_ALLOWED_DOMAINS: "steward.fi,localhost,127.0.0.1:3200"
 
       - name: Stop API test server

--- a/packages/api/src/__tests__/cumulative-spend-cap-e2e.test.ts
+++ b/packages/api/src/__tests__/cumulative-spend-cap-e2e.test.ts
@@ -368,7 +368,7 @@ async function seed(opts: {
         id: "71000000-0000-4000-8000-0000000000c1",
         tenantId: CS.TENANT,
         workspaceId: CS.WORKSPACE,
-        principalType: "user",
+        principalType: "human",
         principalId: CS.GRANTOR,
         roleKey: "workspace_approver",
         operationKeys: [OP_TWEET_KEY],

--- a/packages/api/src/__tests__/cumulative-spend-cap-e2e.test.ts
+++ b/packages/api/src/__tests__/cumulative-spend-cap-e2e.test.ts
@@ -44,6 +44,7 @@ import {
   providerAccounts,
   providerActionAuditOutbox,
   providerActionBindings,
+  providerActionReservationGenerations,
   providerGrants,
   providerOperations,
   providerRoleBindings,
@@ -64,6 +65,7 @@ import {
   __setReservationReconciliationFaultForTests,
   providerActionService,
 } from "../services/provider-action-service";
+import { providerApprovalService } from "../services/provider-approval";
 
 setDefaultTimeout(120_000);
 
@@ -211,6 +213,7 @@ async function seed(opts: {
   grantScoped?: boolean;
   accessViaRoleBindingNoGrant?: boolean;
   extraDenyRule?: boolean;
+  requireApproval?: boolean;
 }) {
   const db = getDb();
   await db.insert(tenants).values([{ id: CS.TENANT, name: "CS", apiKeyHash: "hcs" }]);
@@ -288,6 +291,14 @@ async function seed(opts: {
       config: { capabilities: [OP_TWEET_KEY], effect: "deny" },
     });
   }
+  if (opts.requireApproval) {
+    (requestProfile.policyRules as Array<Record<string, unknown>>).push({
+      id: "c5555555-5555-4555-8555-5555555555f5",
+      type: "capability-intent",
+      enabled: true,
+      config: { capabilities: [OP_TWEET_KEY], effect: "require-approval" },
+    });
+  }
   if (
     (opts.countCapMaxCalls === undefined || opts.combineCountAndSpend) &&
     opts.declareSpendField !== false
@@ -340,6 +351,26 @@ async function seed(opts: {
         expiresAt: FUTURE,
         grantedByUserId: CS.GRANTOR,
         reason: "test",
+      },
+    ]);
+  }
+  if (opts.requireApproval) {
+    await db
+      .insert(userTenants)
+      .values([{ userId: CS.GRANTOR, tenantId: CS.TENANT, role: "admin" }]);
+    await db.insert(providerRoleBindings).values([
+      {
+        id: "71000000-0000-4000-8000-0000000000c1",
+        tenantId: CS.TENANT,
+        workspaceId: CS.WORKSPACE,
+        principalType: "user",
+        principalId: CS.GRANTOR,
+        roleKey: "workspace_approver",
+        operationKeys: [OP_TWEET_KEY],
+        environment: "production",
+        status: "active",
+        grantedByUserId: CS.GRANTOR,
+        reason: "approval test",
       },
     ]);
   }
@@ -464,22 +495,26 @@ describeRedis("#206 cumulativeSpend cap - full-chain E2E (real service + real Re
     const out = await proposeTweet("settled-spend", "cs-240-settle");
     expect(out.kind).toBe("allowed");
     if (out.kind !== "allowed") throw new Error("expected allowed");
-    const [crashed] = await getDb()
+    const [binding] = await getDb()
       .select()
       .from(providerActionBindings)
       .where(eq(providerActionBindings.intentId, out.intentId));
-    expect(crashed.status).toBe("stub_succeeded");
-    expect(crashed.reservationReconciliationState).toBe("pending");
-    expect(crashed.reservationReconciliationAttempts).toBe(1);
-    expect(crashed.reservationReconciliationLastError).toContain("injected crash");
-    expect(crashed.reservationReconciliationNextRetryAt).not.toBeNull();
-    expect(crashed.policyReservationHandles).toMatchObject({
+    expect(binding.status).toBe("stub_succeeded");
+    const [crashed] = await getDb()
+      .select()
+      .from(providerActionReservationGenerations)
+      .where(eq(providerActionReservationGenerations.intentId, out.intentId));
+    expect(crashed.state).toBe("pending");
+    expect(crashed.attempts).toBe(1);
+    expect(crashed.lastError).toContain("injected crash");
+    expect(crashed.nextRetryAt).not.toBeNull();
+    expect(crashed.handles).toMatchObject({
       schemaVersion: "steward.provider-policy-reservations.v1",
       generation: 1,
       phase: "decision",
       cumulativeSpend: [{ amount: 13 }],
     });
-    expect(JSON.stringify(crashed.policyReservationHandles)).not.toContain("settled-spend");
+    expect(JSON.stringify(crashed.handles)).not.toContain("settled-spend");
 
     __setReservationReconciliationFaultForTests(null);
     const [a, b] = await Promise.all([
@@ -489,10 +524,10 @@ describeRedis("#206 cumulativeSpend cap - full-chain E2E (real service + real Re
     expect(a + b).toBe(1);
     const [done] = await getDb()
       .select()
-      .from(providerActionBindings)
-      .where(eq(providerActionBindings.intentId, out.intentId));
-    expect(done.reservationReconciliationState).toBe("settled");
-    expect(done.reservationReconciledAt).not.toBeNull();
+      .from(providerActionReservationGenerations)
+      .where(eq(providerActionReservationGenerations.intentId, out.intentId));
+    expect(done.state).toBe("settled");
+    expect(done.reconciledAt).not.toBeNull();
   });
 
   test("#240 crash before release: C2 reclaims failed spend and maxCalls reservations", async () => {
@@ -508,11 +543,11 @@ describeRedis("#206 cumulativeSpend cap - full-chain E2E (real service + real Re
     if (out.kind !== "policy_denied") throw new Error("expected denial");
     const [crashed] = await getDb()
       .select()
-      .from(providerActionBindings)
-      .where(eq(providerActionBindings.intentId, out.intentId));
-    expect(crashed.reservationReconciliationState).toBe("pending");
-    expect(crashed.reservationReconciliationAttempts).toBe(1);
-    expect(crashed.policyReservationHandles).toMatchObject({
+      .from(providerActionReservationGenerations)
+      .where(eq(providerActionReservationGenerations.intentId, out.intentId));
+    expect(crashed.state).toBe("pending");
+    expect(crashed.attempts).toBe(1);
+    expect(crashed.handles).toMatchObject({
       cumulativeSpend: [{ amount: 13 }],
       windowedInvoke: { agentId: CS.AGENT, operationKey: OP_TWEET_KEY },
     });
@@ -539,9 +574,9 @@ describeRedis("#206 cumulativeSpend cap - full-chain E2E (real service + real Re
     ).toEqual({ sum: 0 });
     const [done] = await getDb()
       .select()
-      .from(providerActionBindings)
-      .where(eq(providerActionBindings.intentId, out.intentId));
-    expect(done.reservationReconciliationState).toBe("released");
+      .from(providerActionReservationGenerations)
+      .where(eq(providerActionReservationGenerations.intentId, out.intentId));
+    expect(done.state).toBe("released");
   });
 
   test("#240 crash after Redis release but before CAS is idempotently recovered", async () => {
@@ -552,9 +587,9 @@ describeRedis("#206 cumulativeSpend cap - full-chain E2E (real service + real Re
     if (out.kind !== "policy_denied") throw new Error("expected denial");
     const [crashed] = await getDb()
       .select()
-      .from(providerActionBindings)
-      .where(eq(providerActionBindings.intentId, out.intentId));
-    expect(crashed.reservationReconciliationState).toBe("pending");
+      .from(providerActionReservationGenerations)
+      .where(eq(providerActionReservationGenerations.intentId, out.intentId));
+    expect(crashed.state).toBe("pending");
     expect(
       await getCumulativeSpendSum({
         agentId: CS.AGENT,
@@ -569,12 +604,70 @@ describeRedis("#206 cumulativeSpend cap - full-chain E2E (real service + real Re
     // The unscoped entry point is what the autonomous startup/periodic worker
     // invokes. Make the retry due, then prove it recovers across all tenants.
     await getDb()
-      .update(providerActionBindings)
-      .set({ reservationReconciliationNextRetryAt: new Date(0) })
-      .where(eq(providerActionBindings.intentId, out.intentId));
+      .update(providerActionReservationGenerations)
+      .set({ nextRetryAt: new Date(0) })
+      .where(eq(providerActionReservationGenerations.intentId, out.intentId));
     expect(await providerActionService.reconcilePolicyReservations()).toBe(1);
     expect(await providerActionService.reconcilePolicyReservations(CS.TENANT, out.intentId)).toBe(
       0,
     );
+  });
+
+  test("#239 execute-time cap crossing denies without consuming the approval", async () => {
+    process.env.STEWARD_EXECUTION_AUTH_SECRET =
+      "k1:issue-239-real-redis-test-secret-with-enough-entropy";
+    await seed({ maxBytes: 100, requireApproval: true });
+    const queued = await proposeTweet("q".repeat(60), "cs-239-queued");
+    expect(queued.kind).toBe("approval_required");
+    if (queued.kind !== "approval_required") throw new Error("expected approval");
+    const approved = await providerApprovalService.decide({
+      intentId: queued.intentId,
+      tenantId: CS.TENANT,
+      authenticatedUserId: CS.GRANTOR,
+      sessionMfaVerifiedAt: Date.now(),
+      decision: "approve",
+      expectedVersion: 1,
+      expectedRequestHash: queued.requestHash,
+      expectedActionDigest: queued.actionDigest,
+      reasonCode: null,
+      reason: null,
+      idempotencyKey: "cs-239-approve",
+    });
+    expect(approved.ok).toBe(true);
+
+    // Current policy no longer requires approval. A later immediate action uses
+    // 80/100 bytes while the queued action waits; its original decision-time
+    // reservation was released by #240.
+    await getDb()
+      .update(providerOperations)
+      .set({
+        requestProfile: {
+          policyRules: spendCapRules(OP_TWEET_KEY, 100),
+          spendDeclaration: { field: "textByteLength", currency: "BYTES" },
+        },
+      })
+      .where(eq(providerOperations.id, CS.OP_TWEET));
+    expect((await proposeTweet("x".repeat(80), "cs-239-later")).kind).toBe("allowed");
+
+    const denied = await providerApprovalService.resume({
+      intentId: queued.intentId,
+      tenantId: CS.TENANT,
+    });
+    expect(denied).toEqual({
+      ok: false,
+      code: PROVIDER_POLICY_REASON.CUMULATIVE_SPEND_CAP_EXCEEDED,
+      httpStatus: 403,
+    });
+    const [binding] = await getDb()
+      .select()
+      .from(providerActionBindings)
+      .where(eq(providerActionBindings.intentId, queued.intentId));
+    expect(binding.status).toBe("approved");
+    expect(binding.executionPolicyDecision).toBeNull();
+    const [queue] = await getDb()
+      .select()
+      .from(approvalQueue)
+      .where(eq(approvalQueue.intentId, queued.intentId));
+    expect(queue.status).toBe("approved");
   });
 });

--- a/packages/api/src/__tests__/cumulative-spend-cap-e2e.test.ts
+++ b/packages/api/src/__tests__/cumulative-spend-cap-e2e.test.ts
@@ -57,9 +57,13 @@ import {
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { PROVIDER_POLICY_REASON } from "@stwd/policy-engine";
 import { buildXAction } from "@stwd/provider-x";
-import { disconnectRedis, getRedis } from "@stwd/redis";
+import { disconnectRedis, getCumulativeSpendSum, getRedis } from "@stwd/redis";
+import { eq } from "drizzle-orm";
 import type { ProviderPrincipalV1 } from "../middleware/provider-principal";
-import { providerActionService } from "../services/provider-action-service";
+import {
+  __setReservationReconciliationFaultForTests,
+  providerActionService,
+} from "../services/provider-action-service";
 
 setDefaultTimeout(120_000);
 
@@ -203,8 +207,10 @@ async function seed(opts: {
   declaredCurrency?: string;
   declareSpendField?: boolean;
   countCapMaxCalls?: number;
+  combineCountAndSpend?: boolean;
   grantScoped?: boolean;
   accessViaRoleBindingNoGrant?: boolean;
+  extraDenyRule?: boolean;
 }) {
   const db = getDb();
   await db.insert(tenants).values([{ id: CS.TENANT, name: "CS", apiKeyHash: "hcs" }]);
@@ -263,13 +269,29 @@ async function seed(opts: {
   ]);
   const requestProfile: Record<string, unknown> = {
     policyRules:
-      opts.countCapMaxCalls !== undefined
+      opts.countCapMaxCalls !== undefined && !opts.combineCountAndSpend
         ? countCapRules(OP_TWEET_KEY, opts.countCapMaxCalls)
         : opts.grantScoped
           ? grantScopedSpendRules(OP_TWEET_KEY, opts.maxBytes)
           : spendCapRules(OP_TWEET_KEY, opts.maxBytes, opts.capCurrency ?? "BYTES"),
   };
-  if (opts.countCapMaxCalls === undefined && opts.declareSpendField !== false) {
+  if (opts.combineCountAndSpend && opts.countCapMaxCalls !== undefined) {
+    (requestProfile.policyRules as Array<Record<string, unknown>>).push(
+      ...countCapRules(OP_TWEET_KEY, opts.countCapMaxCalls),
+    );
+  }
+  if (opts.extraDenyRule) {
+    (requestProfile.policyRules as Array<Record<string, unknown>>).push({
+      id: "c4444444-4444-4444-8444-4444444444f4",
+      type: "capability-intent",
+      enabled: true,
+      config: { capabilities: [OP_TWEET_KEY], effect: "deny" },
+    });
+  }
+  if (
+    (opts.countCapMaxCalls === undefined || opts.combineCountAndSpend) &&
+    opts.declareSpendField !== false
+  ) {
     requestProfile.spendDeclaration = {
       field: "textByteLength",
       currency: opts.declaredCurrency ?? "BYTES",
@@ -359,6 +381,7 @@ describeRedis("#206 cumulativeSpend cap - full-chain E2E (real service + real Re
     delete process.env.STEWARD_PGLITE_MEMORY;
   });
   beforeEach(async () => {
+    __setReservationReconciliationFaultForTests(null);
     await wipe();
     await cleanupRedis();
   });
@@ -433,5 +456,125 @@ describeRedis("#206 cumulativeSpend cap - full-chain E2E (real service + real Re
     if (t.kind === "policy_denied") {
       expect(t.code).toBe(PROVIDER_POLICY_REASON.CUMULATIVE_SPEND_CAP_EXCEEDED);
     }
+  });
+
+  test("#240 crash after terminal commit: C2 settles persisted handles exactly once under a worker race", async () => {
+    await seed({ maxBytes: 250 });
+    __setReservationReconciliationFaultForTests("before_apply");
+    const out = await proposeTweet("settled-spend", "cs-240-settle");
+    expect(out.kind).toBe("allowed");
+    if (out.kind !== "allowed") throw new Error("expected allowed");
+    const [crashed] = await getDb()
+      .select()
+      .from(providerActionBindings)
+      .where(eq(providerActionBindings.intentId, out.intentId));
+    expect(crashed.status).toBe("stub_succeeded");
+    expect(crashed.reservationReconciliationState).toBe("pending");
+    expect(crashed.reservationReconciliationAttempts).toBe(1);
+    expect(crashed.reservationReconciliationLastError).toContain("injected crash");
+    expect(crashed.reservationReconciliationNextRetryAt).not.toBeNull();
+    expect(crashed.policyReservationHandles).toMatchObject({
+      schemaVersion: "steward.provider-policy-reservations.v1",
+      generation: 1,
+      phase: "decision",
+      cumulativeSpend: [{ amount: 13 }],
+    });
+    expect(JSON.stringify(crashed.policyReservationHandles)).not.toContain("settled-spend");
+
+    __setReservationReconciliationFaultForTests(null);
+    const [a, b] = await Promise.all([
+      providerActionService.reconcilePolicyReservations(CS.TENANT, out.intentId),
+      providerActionService.reconcilePolicyReservations(CS.TENANT, out.intentId),
+    ]);
+    expect(a + b).toBe(1);
+    const [done] = await getDb()
+      .select()
+      .from(providerActionBindings)
+      .where(eq(providerActionBindings.intentId, out.intentId));
+    expect(done.reservationReconciliationState).toBe("settled");
+    expect(done.reservationReconciledAt).not.toBeNull();
+  });
+
+  test("#240 crash before release: C2 reclaims failed spend and maxCalls reservations", async () => {
+    await seed({
+      maxBytes: 250,
+      extraDenyRule: true,
+      countCapMaxCalls: 5,
+      combineCountAndSpend: true,
+    });
+    __setReservationReconciliationFaultForTests("before_apply");
+    const out = await proposeTweet("known-failure", "cs-240-release");
+    expect(out.kind).toBe("policy_denied");
+    if (out.kind !== "policy_denied") throw new Error("expected denial");
+    const [crashed] = await getDb()
+      .select()
+      .from(providerActionBindings)
+      .where(eq(providerActionBindings.intentId, out.intentId));
+    expect(crashed.reservationReconciliationState).toBe("pending");
+    expect(crashed.reservationReconciliationAttempts).toBe(1);
+    expect(crashed.policyReservationHandles).toMatchObject({
+      cumulativeSpend: [{ amount: 13 }],
+      windowedInvoke: { agentId: CS.AGENT, operationKey: OP_TWEET_KEY },
+    });
+    expect(
+      await getCumulativeSpendSum({
+        agentId: CS.AGENT,
+        scope: "agent",
+        scopeKey: "",
+        currency: "BYTES",
+        windowSeconds: 86_400,
+      }),
+    ).toEqual({ sum: 13 });
+
+    __setReservationReconciliationFaultForTests(null);
+    expect(await providerActionService.recoverUnsignedIntents(CS.TENANT, out.intentId)).toBe(0);
+    expect(
+      await getCumulativeSpendSum({
+        agentId: CS.AGENT,
+        scope: "agent",
+        scopeKey: "",
+        currency: "BYTES",
+        windowSeconds: 86_400,
+      }),
+    ).toEqual({ sum: 0 });
+    const [done] = await getDb()
+      .select()
+      .from(providerActionBindings)
+      .where(eq(providerActionBindings.intentId, out.intentId));
+    expect(done.reservationReconciliationState).toBe("released");
+  });
+
+  test("#240 crash after Redis release but before CAS is idempotently recovered", async () => {
+    await seed({ maxBytes: 250, extraDenyRule: true });
+    __setReservationReconciliationFaultForTests("after_apply");
+    const out = await proposeTweet("released-once", "cs-240-after-redis");
+    expect(out.kind).toBe("policy_denied");
+    if (out.kind !== "policy_denied") throw new Error("expected denial");
+    const [crashed] = await getDb()
+      .select()
+      .from(providerActionBindings)
+      .where(eq(providerActionBindings.intentId, out.intentId));
+    expect(crashed.reservationReconciliationState).toBe("pending");
+    expect(
+      await getCumulativeSpendSum({
+        agentId: CS.AGENT,
+        scope: "agent",
+        scopeKey: "",
+        currency: "BYTES",
+        windowSeconds: 86_400,
+      }),
+    ).toEqual({ sum: 0 });
+
+    __setReservationReconciliationFaultForTests(null);
+    // The unscoped entry point is what the autonomous startup/periodic worker
+    // invokes. Make the retry due, then prove it recovers across all tenants.
+    await getDb()
+      .update(providerActionBindings)
+      .set({ reservationReconciliationNextRetryAt: new Date(0) })
+      .where(eq(providerActionBindings.intentId, out.intentId));
+    expect(await providerActionService.reconcilePolicyReservations()).toBe(1);
+    expect(await providerActionService.reconcilePolicyReservations(CS.TENANT, out.intentId)).toBe(
+      0,
+    );
   });
 });

--- a/packages/api/src/__tests__/cumulative-spend-cap-e2e.test.ts
+++ b/packages/api/src/__tests__/cumulative-spend-cap-e2e.test.ts
@@ -506,20 +506,10 @@ describeRedis("#206 cumulativeSpend cap - full-chain E2E (real service + real Re
       .from(providerActionBindings)
       .where(eq(providerActionBindings.intentId, out.intentId));
     expect(binding.status).toBe("stub_succeeded");
-    let [crashed] = await getDb()
+    const [crashed] = await getDb()
       .select()
       .from(providerActionReservationGenerations)
       .where(eq(providerActionReservationGenerations.intentId, out.intentId));
-    // A concurrent C2 sweep may claim this row between the terminal binding
-    // update and the scoped reconciliation above. Wait for that in-flight
-    // worker to persist the injected failure before asserting its retry state.
-    for (let poll = 0; crashed?.attempts === 0 && poll < 50; poll += 1) {
-      await Bun.sleep(20);
-      [crashed] = await getDb()
-        .select()
-        .from(providerActionReservationGenerations)
-        .where(eq(providerActionReservationGenerations.intentId, out.intentId));
-    }
     expect(crashed.state).toBe("pending");
     expect(crashed.attempts).toBe(1);
     expect(crashed.lastError).toContain("injected crash");

--- a/packages/api/src/__tests__/cumulative-spend-cap-e2e.test.ts
+++ b/packages/api/src/__tests__/cumulative-spend-cap-e2e.test.ts
@@ -58,7 +58,12 @@ import {
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { PROVIDER_POLICY_REASON } from "@stwd/policy-engine";
 import { buildXAction } from "@stwd/provider-x";
-import { disconnectRedis, getCumulativeSpendSum, getRedis } from "@stwd/redis";
+import {
+  disconnectRedis,
+  getCumulativeSpendSum,
+  getRedis,
+  reserveCumulativeSpend,
+} from "@stwd/redis";
 import { eq } from "drizzle-orm";
 import type { ProviderPrincipalV1 } from "../middleware/provider-principal";
 import {
@@ -413,6 +418,7 @@ describeRedis("#206 cumulativeSpend cap - full-chain E2E (real service + real Re
   });
   beforeEach(async () => {
     __setReservationReconciliationFaultForTests(null);
+    providerApprovalService.faultHooks = {};
     await wipe();
     await cleanupRedis();
   });
@@ -517,6 +523,12 @@ describeRedis("#206 cumulativeSpend cap - full-chain E2E (real service + real Re
     expect(JSON.stringify(crashed.handles)).not.toContain("settled-spend");
 
     __setReservationReconciliationFaultForTests(null);
+    // A scoped replay must honor persisted exponential backoff too. Make the
+    // crash row due before racing two workers; exactly one SKIP LOCKED claim wins.
+    await getDb()
+      .update(providerActionReservationGenerations)
+      .set({ nextRetryAt: new Date(0) })
+      .where(eq(providerActionReservationGenerations.intentId, out.intentId));
     const [a, b] = await Promise.all([
       providerActionService.reconcilePolicyReservations(CS.TENANT, out.intentId),
       providerActionService.reconcilePolicyReservations(CS.TENANT, out.intentId),
@@ -562,6 +574,10 @@ describeRedis("#206 cumulativeSpend cap - full-chain E2E (real service + real Re
     ).toEqual({ sum: 13 });
 
     __setReservationReconciliationFaultForTests(null);
+    await getDb()
+      .update(providerActionReservationGenerations)
+      .set({ nextRetryAt: new Date(0) })
+      .where(eq(providerActionReservationGenerations.intentId, out.intentId));
     expect(await providerActionService.recoverUnsignedIntents(CS.TENANT, out.intentId)).toBe(0);
     expect(
       await getCumulativeSpendSum({
@@ -635,19 +651,18 @@ describeRedis("#206 cumulativeSpend cap - full-chain E2E (real service + real Re
     });
     expect(approved.ok).toBe(true);
 
-    // Current policy no longer requires approval. A later immediate action uses
-    // 80/100 bytes while the queued action waits; its original decision-time
-    // reservation was released by #240.
-    await getDb()
-      .update(providerOperations)
-      .set({
-        requestProfile: {
-          policyRules: spendCapRules(OP_TWEET_KEY, 100),
-          spendDeclaration: { field: "textByteLength", currency: "BYTES" },
-        },
-      })
-      .where(eq(providerOperations.id, CS.OP_TWEET));
-    expect((await proposeTweet("x".repeat(80), "cs-239-later")).kind).toBe("allowed");
+    // Another operation for this agent consumes 80/100 from the same global
+    // agent stream while the queued action waits. Keep the approved operation's
+    // revision unchanged so dependency revalidation succeeds and the test reaches
+    // the execute-time cap gate rather than merely testing stale approval.
+    expect(
+      await reserveCumulativeSpend({
+        stream: { agentId: CS.AGENT, scope: "agent", scopeKey: "", currency: "BYTES" },
+        caps: [{ windowSeconds: 86_400, max: 100 }],
+        amount: 80,
+        reservationId: `concurrent-${RUN}`,
+      }),
+    ).toMatchObject({ ok: true });
 
     const denied = await providerApprovalService.resume({
       intentId: queued.intentId,
@@ -669,5 +684,89 @@ describeRedis("#206 cumulativeSpend cap - full-chain E2E (real service + real Re
       .from(approvalQueue)
       .where(eq(approvalQueue.intentId, queued.intentId));
     expect(queue.status).toBe("approved");
+  });
+
+  test("#239 execute reservation rollback is reclaimed and concurrent resumes create one generation", async () => {
+    process.env.STEWARD_EXECUTION_AUTH_SECRET =
+      "k1:issue-239-real-redis-test-secret-with-enough-entropy";
+    await seed({
+      maxBytes: 100,
+      requireApproval: true,
+      countCapMaxCalls: 2,
+      combineCountAndSpend: true,
+    });
+    const queued = await proposeTweet("approved", "cs-239-race");
+    expect(queued.kind).toBe("approval_required");
+    if (queued.kind !== "approval_required") throw new Error("expected approval");
+    expect(
+      (
+        await providerApprovalService.decide({
+          intentId: queued.intentId,
+          tenantId: CS.TENANT,
+          authenticatedUserId: CS.GRANTOR,
+          sessionMfaVerifiedAt: Date.now(),
+          decision: "approve",
+          expectedVersion: 1,
+          expectedRequestHash: queued.requestHash,
+          expectedActionDigest: queued.actionDigest,
+          reasonCode: null,
+          reason: null,
+          idempotencyKey: "cs-239-race-approve",
+        })
+      ).ok,
+    ).toBe(true);
+
+    // Throw after Redis admission but before the audited PG transaction commits.
+    // The outer compensation releases both spend and count handles, and no
+    // append-only execution generation may leak from the rolled-back tx.
+    providerApprovalService.faultHooks.afterPolicyReserve = () => {
+      throw new Error("injected crash after execute reserve");
+    };
+    expect(
+      await providerApprovalService.resume({ intentId: queued.intentId, tenantId: CS.TENANT }),
+    ).toEqual({ ok: false, code: "RESUME_PREPARATION_FAILED", httpStatus: 503 });
+    providerApprovalService.faultHooks = {};
+    expect(
+      await getCumulativeSpendSum({
+        agentId: CS.AGENT,
+        scope: "agent",
+        scopeKey: "",
+        currency: "BYTES",
+        windowSeconds: 86_400,
+      }),
+    ).toEqual({ sum: 0 });
+    expect(
+      (
+        await getDb()
+          .select()
+          .from(providerActionReservationGenerations)
+          .where(eq(providerActionReservationGenerations.intentId, queued.intentId))
+      ).map((row) => row.generation),
+    ).toEqual([1]);
+
+    const [first, second] = await Promise.all([
+      providerApprovalService.resume({ intentId: queued.intentId, tenantId: CS.TENANT }),
+      providerApprovalService.resume({ intentId: queued.intentId, tenantId: CS.TENANT }),
+    ]);
+    expect(first.ok).toBe(true);
+    expect(second.ok).toBe(true);
+    const generations = await getDb()
+      .select()
+      .from(providerActionReservationGenerations)
+      .where(eq(providerActionReservationGenerations.intentId, queued.intentId));
+    expect(generations.map((row) => [row.generation, row.phase])).toEqual([
+      [1, "decision"],
+      [2, "execution"],
+    ]);
+    expect(generations[1]?.state).toBe("pending");
+    expect(
+      await getCumulativeSpendSum({
+        agentId: CS.AGENT,
+        scope: "agent",
+        scopeKey: "",
+        currency: "BYTES",
+        windowSeconds: 86_400,
+      }),
+    ).toEqual({ sum: 8 });
   });
 });

--- a/packages/api/src/__tests__/cumulative-spend-cap-e2e.test.ts
+++ b/packages/api/src/__tests__/cumulative-spend-cap-e2e.test.ts
@@ -506,10 +506,20 @@ describeRedis("#206 cumulativeSpend cap - full-chain E2E (real service + real Re
       .from(providerActionBindings)
       .where(eq(providerActionBindings.intentId, out.intentId));
     expect(binding.status).toBe("stub_succeeded");
-    const [crashed] = await getDb()
+    let [crashed] = await getDb()
       .select()
       .from(providerActionReservationGenerations)
       .where(eq(providerActionReservationGenerations.intentId, out.intentId));
+    // A concurrent C2 sweep may claim this row between the terminal binding
+    // update and the scoped reconciliation above. Wait for that in-flight
+    // worker to persist the injected failure before asserting its retry state.
+    for (let poll = 0; crashed?.attempts === 0 && poll < 50; poll += 1) {
+      await Bun.sleep(20);
+      [crashed] = await getDb()
+        .select()
+        .from(providerActionReservationGenerations)
+        .where(eq(providerActionReservationGenerations.intentId, out.intentId));
+    }
     expect(crashed.state).toBe("pending");
     expect(crashed.attempts).toBe(1);
     expect(crashed.lastError).toContain("injected crash");

--- a/packages/api/src/__tests__/provider-approval-concurrency.test.ts
+++ b/packages/api/src/__tests__/provider-approval-concurrency.test.ts
@@ -109,15 +109,19 @@ function decideBody(
 }
 
 describe("PR3 concurrency + fault matrix", () => {
+  const priorExecutionAuthSecret = process.env.STEWARD_EXECUTION_AUTH_SECRET;
   beforeAll(async () => {
     process.env.STEWARD_PGLITE_MEMORY = "true";
     process.env.STEWARD_AUDIT_HMAC_KEY ||= "0".repeat(64);
+    process.env.STEWARD_EXECUTION_AUTH_SECRET = "1".repeat(64);
     const { db, client } = await createPGLiteDb("memory://");
     setPGLiteOverride(db, async () => client.close());
   });
   afterAll(async () => {
     await closeDb();
     delete process.env.STEWARD_PGLITE_MEMORY;
+    if (priorExecutionAuthSecret === undefined) delete process.env.STEWARD_EXECUTION_AUTH_SECRET;
+    else process.env.STEWARD_EXECUTION_AUTH_SECRET = priorExecutionAuthSecret;
   });
   beforeEach(async () => {
     await wipe();

--- a/packages/api/src/__tests__/provider-approval-lifecycle.test.ts
+++ b/packages/api/src/__tests__/provider-approval-lifecycle.test.ts
@@ -48,6 +48,8 @@ import {
 
 setDefaultTimeout(120_000);
 
+let priorExecutionAuthSecret: string | undefined;
+
 async function wipe() {
   const db = getDb();
   await db.delete(providerActionAuditOutbox);
@@ -92,12 +94,19 @@ describe("PR3 approval lifecycle", () => {
   beforeAll(async () => {
     process.env.STEWARD_PGLITE_MEMORY = "true";
     process.env.STEWARD_AUDIT_HMAC_KEY ||= "0".repeat(64);
+    priorExecutionAuthSecret = process.env.STEWARD_EXECUTION_AUTH_SECRET;
+    process.env.STEWARD_EXECUTION_AUTH_SECRET = "1".repeat(64);
     const { db, client } = await createPGLiteDb("memory://");
     setPGLiteOverride(db, async () => client.close());
   });
   afterAll(async () => {
     await closeDb();
     delete process.env.STEWARD_PGLITE_MEMORY;
+    if (priorExecutionAuthSecret === undefined) {
+      delete process.env.STEWARD_EXECUTION_AUTH_SECRET;
+    } else {
+      process.env.STEWARD_EXECUTION_AUTH_SECRET = priorExecutionAuthSecret;
+    }
   });
   beforeEach(async () => {
     await wipe();

--- a/packages/api/src/__tests__/provider-approval-lifecycle.test.ts
+++ b/packages/api/src/__tests__/provider-approval-lifecycle.test.ts
@@ -33,7 +33,7 @@ import {
   workspaces,
 } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { providerApprovalService } from "../services/provider-approval";
 import {
   bindingRow,
@@ -210,7 +210,7 @@ describe("PR3 approval lifecycle", () => {
     expect(events2).toBe(events1);
   });
 
-  test("resume idempotent path re-ensures the v2 authorization for an execution_ready row that has none (codex P2 pre-rollout repair)", async () => {
+  test("resume idempotent path re-ensures v2 authorization only for an evidence-bound execution_ready row", async () => {
     const { intentId, requestHash, actionDigest } = await createApprovalRequired();
     await providerApprovalService.decide(decideInput(intentId, requestHash, actionDigest));
     const first = await providerApprovalService.resume({ intentId, tenantId: F.TENANT });
@@ -221,9 +221,8 @@ describe("PR3 approval lifecycle", () => {
       .from(executionAuthorizationNonces)
       .where(eq(executionAuthorizationNonces.intentId, intentId));
     expect(before.length).toBe(1);
-    // Simulate a pre-rollout execution_ready row: delete its authorization so the
-    // binding is execution_ready with NO v2 nonce (the governed dispatcher would
-    // be unable to dispatch it).
+    // Simulate loss of the authorization while retaining the immutable 0084
+    // execution-policy evidence.
     await getDb()
       .delete(executionAuthorizationNonces)
       .where(eq(executionAuthorizationNonces.intentId, intentId));
@@ -242,6 +241,54 @@ describe("PR3 approval lifecycle", () => {
       .from(executionAuthorizationNonces)
       .where(eq(executionAuthorizationNonces.intentId, intentId));
     expect(after.length).toBe(1);
+  });
+
+  test("#239 rollout: resume never mints for a legacy execution_ready row without policy evidence", async () => {
+    const { intentId, requestHash, actionDigest } = await createApprovalRequired();
+    await providerApprovalService.decide(decideInput(intentId, requestHash, actionDigest));
+    expect((await providerApprovalService.resume({ intentId, tenantId: F.TENANT })).ok).toBe(true);
+    const db = getDb();
+    await db
+      .delete(executionAuthorizationNonces)
+      .where(eq(executionAuthorizationNonces.intentId, intentId));
+    await db.execute(
+      sql`ALTER TABLE provider_action_bindings DROP CONSTRAINT provider_action_bindings_execution_policy_ready_chk`,
+    );
+    await db.execute(
+      sql`DROP TRIGGER provider_action_bindings_immutable ON provider_action_bindings`,
+    );
+    await db
+      .update(providerActionBindings)
+      .set({
+        executionPolicyDecisionId: null,
+        executionPolicyRevisionHash: null,
+        executionPolicyDecision: null,
+        executionPolicyDecisionHash: null,
+        executionPolicyEvaluatedAt: null,
+      })
+      .where(eq(providerActionBindings.intentId, intentId));
+    await db.execute(sql`
+      CREATE TRIGGER provider_action_bindings_immutable
+      BEFORE UPDATE ON provider_action_bindings
+      FOR EACH ROW EXECUTE FUNCTION steward_provider_action_binding_guard()
+    `);
+    await db.execute(sql`
+      ALTER TABLE provider_action_bindings
+      ADD CONSTRAINT provider_action_bindings_execution_policy_ready_chk CHECK (
+        status NOT IN ('execution_ready','executing') OR execution_policy_decision_id IS NOT NULL
+      ) NOT VALID
+    `);
+
+    expect(await providerApprovalService.resume({ intentId, tenantId: F.TENANT })).toEqual({
+      ok: false,
+      code: "EXECUTION_POLICY_EVIDENCE_MISSING",
+      httpStatus: 409,
+    });
+    const nonce = await db
+      .select({ id: executionAuthorizationNonces.id })
+      .from(executionAuthorizationNonces)
+      .where(eq(executionAuthorizationNonces.intentId, intentId));
+    expect(nonce).toHaveLength(0);
   });
 
   test("resume of a non-approved (pending) action => RESUME_NOT_APPROVED", async () => {

--- a/packages/api/src/__tests__/provider-approval-lifecycle.test.ts
+++ b/packages/api/src/__tests__/provider-approval-lifecycle.test.ts
@@ -241,6 +241,35 @@ describe("PR3 approval lifecycle", () => {
       .from(executionAuthorizationNonces)
       .where(eq(executionAuthorizationNonces.intentId, intentId));
     expect(after.length).toBe(1);
+
+    // Presence is insufficient: corrupting the frozen decision hash must stop
+    // the idempotent path before it can mint another durable authorization.
+    await getDb()
+      .delete(executionAuthorizationNonces)
+      .where(eq(executionAuthorizationNonces.intentId, intentId));
+    await getDb().execute(
+      sql`DROP TRIGGER provider_action_bindings_immutable ON provider_action_bindings`,
+    );
+    await getDb()
+      .update(providerActionBindings)
+      .set({ executionPolicyDecisionHash: `sha256:${"0".repeat(64)}` })
+      .where(eq(providerActionBindings.intentId, intentId));
+    await getDb().execute(sql`
+      CREATE TRIGGER provider_action_bindings_immutable
+      BEFORE UPDATE ON provider_action_bindings
+      FOR EACH ROW EXECUTE FUNCTION steward_provider_action_binding_guard()
+    `);
+    expect(await providerApprovalService.resume({ intentId, tenantId: F.TENANT })).toEqual({
+      ok: false,
+      code: "EXECUTION_POLICY_EVIDENCE_MISSING",
+      httpStatus: 409,
+    });
+    expect(
+      await getDb()
+        .select({ id: executionAuthorizationNonces.authorizationId })
+        .from(executionAuthorizationNonces)
+        .where(eq(executionAuthorizationNonces.intentId, intentId)),
+    ).toHaveLength(0);
   });
 
   test("#239 rollout: resume never mints for a legacy execution_ready row without policy evidence", async () => {

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -26,6 +26,7 @@ import {
   RATE_LIMIT_MAX_REQUESTS,
   RATE_LIMIT_WINDOW_MS,
 } from "./services/context";
+import { startProviderReservationReconciliationScheduler } from "./services/provider-reservation-reconciliation-scheduler";
 import { startRetentionScheduler } from "./services/retention";
 import { startTransactionReceiptPollingScheduler } from "./services/transaction-receipt-poller";
 import { configuredVaultStartupLogLine, getConfiguredVault } from "./services/vault-factory";
@@ -56,6 +57,7 @@ const app = await composeApp();
 const requestLog = new Map<string, { count: number; resetAt: number }>();
 let isShuttingDown = false;
 let cancelRetention: (() => void) | undefined;
+let cancelProviderReservationReconciliation: (() => void) | undefined;
 let cancelTransactionReceiptPolling: (() => void) | undefined;
 let cancelWebhookRetryScheduler: (() => void) | undefined;
 
@@ -303,6 +305,9 @@ assertAuthStoresAreSafe();
 
 if (migrationsRan) {
   cancelRetention = startRetentionScheduler();
+  if (redisOk) {
+    cancelProviderReservationReconciliation = startProviderReservationReconciliationScheduler();
+  }
   cancelTransactionReceiptPolling = startTransactionReceiptPollingScheduler();
   cancelWebhookRetryScheduler = startWebhookRetryScheduler();
 }
@@ -334,6 +339,7 @@ const shutdown = async (signal: string) => {
   clearInterval(requestLogCleanupTimer);
   if (nonceCleanupTimer) clearInterval(nonceCleanupTimer);
   if (cancelRetention) cancelRetention();
+  if (cancelProviderReservationReconciliation) cancelProviderReservationReconciliation();
   if (cancelTransactionReceiptPolling) cancelTransactionReceiptPolling();
   if (cancelWebhookRetryScheduler) cancelWebhookRetryScheduler();
   requestLog.clear();

--- a/packages/api/src/services/provider-action-service.ts
+++ b/packages/api/src/services/provider-action-service.ts
@@ -33,6 +33,7 @@ import {
   providerAccounts,
   providerActionAuditOutbox,
   providerActionBindings,
+  providerActionReservationGenerations,
   providerGrants,
   providerOperations,
   providerRoleBindings,
@@ -47,8 +48,12 @@ import {
   type ProviderPolicyRule,
   windowedInvokeBucketKey,
 } from "@stwd/policy-engine";
-import type { GithubActionBuild } from "@stwd/provider-github";
-import type { XActionBuild } from "@stwd/provider-x";
+import {
+  buildGithubAction,
+  type GithubActionBuild,
+  type GithubOperationKey,
+} from "@stwd/provider-github";
+import { buildXAction, type XActionBuild, type XOperationKey } from "@stwd/provider-x";
 import {
   computeProviderPolicyInputDigest,
   type GithubCanonicalActionV1,
@@ -134,12 +139,14 @@ export function __setReservationReconciliationFaultForTests(
 function persistedReservationHandles(
   cumulativeSpend: CumulativeSpendReservationHandle[],
   windowedInvoke: WindowedInvokeReservationHandle | undefined,
+  generation = 1,
+  phase: PersistedPolicyReservationHandlesV1["phase"] = "decision",
 ): PersistedPolicyReservationHandlesV1 | null {
   if (cumulativeSpend.length === 0 && windowedInvoke === undefined) return null;
   return {
     schemaVersion: "steward.provider-policy-reservations.v1",
-    generation: 1,
-    phase: "decision",
+    generation,
+    phase,
     cumulativeSpend,
     windowedInvoke: windowedInvoke ?? null,
   };
@@ -235,6 +242,70 @@ function reconciliationTargetForStatus(
   // allowed_stub / approved / execution_ready / executing / outcome_unknown:
   // never free maybe-consumed budget before the action has a known outcome.
   return null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("canonical provider action must be an object");
+  }
+  return value as Record<string, unknown>;
+}
+
+/** Reconstruct through the adapter so policy inputs are re-derived, not trusted. */
+function rebuildApprovedAction(
+  operationKey: string,
+  action: Record<string, unknown>,
+  safeSummary: Record<string, unknown>,
+): ProviderActionBuild {
+  const body = action.canonicalBody === null ? undefined : asRecord(action.canonicalBody);
+  if (operationKey === "x.tweet.create") {
+    const reply = body?.reply === undefined ? undefined : asRecord(body.reply);
+    return buildXAction(operationKey as XOperationKey, {
+      text: body?.text,
+      ...(reply?.in_reply_to_tweet_id !== undefined
+        ? { replyToTweetId: reply.in_reply_to_tweet_id }
+        : {}),
+      summoned: safeSummary.summoned === true,
+    });
+  }
+  if (operationKey === "x.tweet.delete") {
+    const match = /^\/2\/tweets\/([0-9]{1,25})$/.exec(String(action.normalizedPath));
+    return buildXAction(operationKey as XOperationKey, { tweetId: match?.[1] });
+  }
+  if (operationKey === "x.user.me.read") {
+    return buildXAction(operationKey as XOperationKey, {});
+  }
+  if (operationKey === "github.issue.list") {
+    const match = /^\/repos\/([^/]+)\/([^/]+)\/issues$/.exec(String(action.normalizedPath));
+    const query = Array.isArray(action.orderedQueryPairs) ? action.orderedQueryPairs : [];
+    const q = new Map<string, unknown>();
+    for (const pair of query) {
+      if (Array.isArray(pair) && pair.length === 2 && typeof pair[0] === "string") {
+        q.set(pair[0], pair[1]);
+      }
+    }
+    return buildGithubAction(operationKey as GithubOperationKey, {
+      owner: match?.[1],
+      repo: match?.[2],
+      ...(q.has("state") ? { state: q.get("state") } : {}),
+      ...(q.has("sort") ? { sort: q.get("sort") } : {}),
+      ...(q.has("direction") ? { direction: q.get("direction") } : {}),
+      ...(q.has("per_page") ? { perPage: Number(q.get("per_page")) } : {}),
+      ...(q.has("page") ? { page: Number(q.get("page")) } : {}),
+    });
+  }
+  if (operationKey === "github.pr.comment.create") {
+    const match = /^\/repos\/([^/]+)\/([^/]+)\/issues\/([0-9]+)\/comments$/.exec(
+      String(action.normalizedPath),
+    );
+    return buildGithubAction(operationKey as GithubOperationKey, {
+      owner: match?.[1],
+      repo: match?.[2],
+      pullNumber: Number(match?.[3]),
+      body: body?.body,
+    });
+  }
+  throw new Error(`unsupported provider operation '${operationKey}'`);
 }
 
 // ─── Public result envelope ───────────────────────────────────────────────────
@@ -757,16 +828,22 @@ class ProviderActionService {
           policyRevisionHash: policy ? policy.doc.policyRevisionHash : null,
           policyDecision: policy ? (policy.doc as unknown as Record<string, unknown>) : null,
           policyDecisionHash,
-          policyReservationHandles: persistedReservationHandles(
-            cumulativeSpendReservations,
-            windowedInvokeReservation,
-          ),
-          reservationReconciliationState:
-            cumulativeSpendReservations.length > 0 || windowedInvokeReservation !== undefined
-              ? "pending"
-              : "not_required",
           status: effects.status,
         });
+
+        const decisionHandles = persistedReservationHandles(
+          cumulativeSpendReservations,
+          windowedInvokeReservation,
+        );
+        if (decisionHandles) {
+          await tx.insert(providerActionReservationGenerations).values({
+            intentId,
+            tenantId,
+            generation: decisionHandles.generation,
+            phase: decisionHandles.phase,
+            handles: decisionHandles as unknown as Record<string, unknown>,
+          });
+        }
 
         // Required audit intent -> transactional outbox (drained post-commit).
         // PR5 C1: correlated lifecycle events set resource_type='provider_action'
@@ -1622,6 +1699,91 @@ class ProviderActionService {
   }
 
   /**
+   * Rebuild the immutable canonical action and authoritatively evaluate the
+   * operation's CURRENT policy immediately before approval consumption. Raw
+   * text exists only in this stack frame and is never returned or persisted.
+   */
+  async evaluateApprovedExecution(args: {
+    tenantId: string;
+    workspaceId: string;
+    actorAgentId: string;
+    operation: typeof providerOperations.$inferSelect;
+    intentId: string;
+    requestHash: string;
+    actionDigest: string;
+    canonicalActionBytes: Uint8Array;
+    safeSummary: Record<string, unknown>;
+    matchedGrantIds: string[];
+    priorGeneration: number;
+  }): Promise<
+    | {
+        ok: true;
+        decision: PersistedPolicyDecisionV1;
+        decisionHash: string;
+        handles: PersistedPolicyReservationHandlesV1 | null;
+      }
+    | { ok: false; code: string; httpStatus: number }
+  > {
+    const canonicalText = Buffer.from(args.canonicalActionBytes).toString("utf8");
+    const action = JSON.parse(canonicalText) as Record<string, unknown>;
+    const build = rebuildApprovedAction(args.operation.operationKey, action, args.safeSummary);
+    if (jcsStringify(build.action) !== canonicalText) {
+      return { ok: false, code: "APPROVAL_ACTION_INTEGRITY_FAILED", httpStatus: 409 };
+    }
+    const digest = sha256HexPrefixed(canonicalText);
+    if (digest !== args.actionDigest) {
+      return { ok: false, code: "APPROVAL_ACTION_INTEGRITY_FAILED", httpStatus: 409 };
+    }
+
+    const policy = await this.evaluatePolicy({
+      tenantId: args.tenantId,
+      workspaceId: args.workspaceId,
+      actorAgentId: args.actorAgentId,
+      operation: args.operation,
+      build,
+      intentId: args.intentId,
+      requestHash: args.requestHash,
+      actionDigest: args.actionDigest,
+      grantId: args.matchedGrantIds[0] ?? null,
+    });
+    if (policy.doc.effect === "hard_deny") {
+      await this.releasePolicyReservationHandles(
+        persistedReservationHandles(
+          policy.cumulativeSpendReservations,
+          policy.windowedInvokeReservation,
+          1,
+          "execution",
+        ),
+      );
+      return {
+        ok: false,
+        code: policy.doc.reasonCodes[0] ?? "POLICY_HARD_DENY",
+        httpStatus: 403,
+      };
+    }
+
+    const generation = args.priorGeneration + 1;
+    return {
+      ok: true,
+      decision: policy.doc,
+      decisionHash: sha256HexPrefixed(jcsStringify(policy.doc)),
+      handles: persistedReservationHandles(
+        policy.cumulativeSpendReservations,
+        policy.windowedInvokeReservation,
+        generation,
+        "execution",
+      ),
+    };
+  }
+
+  async releasePolicyReservationHandles(handles: unknown): Promise<void> {
+    if (handles === null) return;
+    const parsed = parsePersistedReservationHandles(handles);
+    if (!parsed) throw new Error("invalid persisted policy reservation handles");
+    await this.applyPersistedReservationHandles(parsed, "released");
+  }
+
+  /**
    * C2 crash-recovery sweeper (spec §7.3). The required-audit outbox row commits
    * IN-TX with the intent/binding, but its drain into the signed chain happens
    * post-commit. A crash between commit and drain leaves an intent with an
@@ -1714,32 +1876,77 @@ class ProviderActionService {
    * safely retried; unknown outcomes remain pending and are never released.
    */
   async reconcilePolicyReservations(tenantId?: string, intentId?: string): Promise<number> {
-    const rows = await this.db()
+    const candidates = await this.db()
       .select()
-      .from(providerActionBindings)
+      .from(providerActionReservationGenerations)
       .where(
         and(
           tenantId
-            ? eq(providerActionBindings.tenantId, tenantId)
+            ? eq(providerActionReservationGenerations.tenantId, tenantId)
             : (sql`true` as unknown as ReturnType<typeof eq>),
-          sql`${providerActionBindings.reservationReconciliationState} IN ('pending','needs_attention')`,
+          sql`${providerActionReservationGenerations.state} IN ('pending','needs_attention')`,
+          sql`(${providerActionReservationGenerations.nextRetryAt} IS NULL OR ${providerActionReservationGenerations.nextRetryAt} <= now())`,
+          sql`(${providerActionReservationGenerations.claimedAt} IS NULL OR ${providerActionReservationGenerations.claimedAt} < now() - interval '60 seconds')`,
           intentId
-            ? (sql`true` as unknown as ReturnType<typeof eq>)
-            : (sql`(${providerActionBindings.reservationReconciliationNextRetryAt} IS NULL OR ${providerActionBindings.reservationReconciliationNextRetryAt} <= now())` as unknown as ReturnType<
-                typeof eq
-              >),
-          intentId
-            ? eq(providerActionBindings.intentId, intentId)
+            ? eq(providerActionReservationGenerations.intentId, intentId)
             : (sql`true` as unknown as ReturnType<typeof eq>),
         ),
-      );
+      )
+      .orderBy(
+        providerActionReservationGenerations.nextRetryAt,
+        providerActionReservationGenerations.createdAt,
+      )
+      .limit(50);
     let reconciled = 0;
-    for (const row of rows) {
-      const handles = parsePersistedReservationHandles(row.policyReservationHandles);
-      // Corrupt/unrecognized persisted handles fail closed and remain pending.
-      if (!handles) continue;
-      const target = reconciliationTargetForStatus(row.status, handles.phase);
-      if (!target) continue;
+    for (const candidate of candidates) {
+      const claimId = randomUUID();
+      const [row] = await this.db()
+        .update(providerActionReservationGenerations)
+        .set({ claimedBy: claimId, claimedAt: new Date() })
+        .where(
+          and(
+            eq(providerActionReservationGenerations.id, candidate.id),
+            eq(providerActionReservationGenerations.state, candidate.state),
+            eq(providerActionReservationGenerations.attempts, candidate.attempts),
+            sql`(${providerActionReservationGenerations.claimedAt} IS NULL OR ${providerActionReservationGenerations.claimedAt} < now() - interval '60 seconds')`,
+          ),
+        )
+        .returning();
+      if (!row) continue;
+      const [binding] = await this.db()
+        .select({ status: providerActionBindings.status })
+        .from(providerActionBindings)
+        .where(eq(providerActionBindings.intentId, row.intentId))
+        .limit(1);
+      const handles = parsePersistedReservationHandles(row.handles);
+      if (!handles || handles.generation !== row.generation || handles.phase !== row.phase) {
+        const message = "malformed immutable reservation generation";
+        await this.recordReservationFailure(row, claimId, message, true);
+        await writeAuditEvent({
+          tenantId: row.tenantId,
+          actorType: "system",
+          action: "provider.reservation.needs_attention",
+          resourceType: "provider_action",
+          resourceId: row.intentId,
+          metadata: { generation: row.generation, reasonCode: "RESERVATION_GENERATION_MALFORMED" },
+        }).catch((error) =>
+          console.error("[provider-reservations] malformed-generation audit failed:", error),
+        );
+        continue;
+      }
+      const target = binding ? reconciliationTargetForStatus(binding.status, handles.phase) : null;
+      if (!target) {
+        await this.db()
+          .update(providerActionReservationGenerations)
+          .set({ claimedAt: null, claimedBy: null, nextRetryAt: new Date(Date.now() + 15_000) })
+          .where(
+            and(
+              eq(providerActionReservationGenerations.id, row.id),
+              eq(providerActionReservationGenerations.claimedBy, claimId),
+            ),
+          );
+        continue;
+      }
       try {
         if (reservationReconciliationFaultForTests === "before_apply")
           throw new Error("injected crash before reservation reconciliation");
@@ -1748,69 +1955,63 @@ class ProviderActionService {
           throw new Error("injected crash after reservation reconciliation");
       } catch (error) {
         const message = (error instanceof Error ? error.message : String(error)).slice(0, 1000);
-        const attempts = row.reservationReconciliationAttempts + 1;
-        const delaySeconds = Math.min(3600, 2 ** Math.min(attempts, 12));
-        await this.db()
-          .update(providerActionBindings)
-          .set({
-            reservationReconciliationState: attempts >= 20 ? "needs_attention" : "pending",
-            reservationReconciliationAttempts: attempts,
-            reservationReconciliationLastError: message,
-            reservationReconciliationNextRetryAt: new Date(Date.now() + delaySeconds * 1000),
-            updatedAt: new Date(),
-          })
-          .where(
-            and(
-              eq(providerActionBindings.intentId, row.intentId),
-              eq(providerActionBindings.status, row.status),
-              eq(
-                providerActionBindings.reservationReconciliationState,
-                row.reservationReconciliationState,
-              ),
-              eq(
-                providerActionBindings.reservationReconciliationAttempts,
-                row.reservationReconciliationAttempts,
-              ),
-              sql`${providerActionBindings.policyReservationHandles} = ${JSON.stringify(
-                row.policyReservationHandles,
-              )}::jsonb`,
-            ),
-          );
+        await this.recordReservationFailure(row, claimId, message, false);
         console.error(
-          `[provider-reservations] reconciliation failed intent=${row.intentId} generation=${handles.generation} attempts=${attempts}: ${message}`,
+          `[provider-reservations] reconciliation failed intent=${row.intentId} generation=${handles.generation}: ${message}`,
         );
         continue;
       }
       const updated = await this.db()
-        .update(providerActionBindings)
+        .update(providerActionReservationGenerations)
         .set({
-          reservationReconciliationState: target,
-          reservationReconciledAt: new Date(),
-          reservationReconciliationNextRetryAt: null,
-          reservationReconciliationLastError: null,
-          updatedAt: new Date(),
+          state: target,
+          reconciledAt: new Date(),
+          nextRetryAt: null,
+          lastError: null,
+          claimedAt: null,
+          claimedBy: null,
         })
         .where(
           and(
-            eq(providerActionBindings.intentId, row.intentId),
-            eq(providerActionBindings.status, row.status),
-            eq(
-              providerActionBindings.reservationReconciliationState,
-              row.reservationReconciliationState,
-            ),
-            eq(
-              providerActionBindings.reservationReconciliationAttempts,
-              row.reservationReconciliationAttempts,
-            ),
-            sql`${providerActionBindings.policyReservationHandles} = ${JSON.stringify(
-              row.policyReservationHandles,
-            )}::jsonb`,
+            eq(providerActionReservationGenerations.id, row.id),
+            eq(providerActionReservationGenerations.generation, row.generation),
+            eq(providerActionReservationGenerations.state, row.state),
+            eq(providerActionReservationGenerations.attempts, row.attempts),
+            eq(providerActionReservationGenerations.claimedBy, claimId),
           ),
         )
-        .returning({ intentId: providerActionBindings.intentId });
+        .returning({ intentId: providerActionReservationGenerations.intentId });
       if (updated.length > 0) reconciled += 1;
     }
     return reconciled;
+  }
+
+  private async recordReservationFailure(
+    row: typeof providerActionReservationGenerations.$inferSelect,
+    claimId: string,
+    message: string,
+    malformed: boolean,
+  ): Promise<void> {
+    const attempts = row.attempts + 1;
+    const delaySeconds = Math.min(3600, 2 ** Math.min(attempts, 12));
+    await this.db()
+      .update(providerActionReservationGenerations)
+      .set({
+        state: malformed || attempts >= 20 ? "needs_attention" : "pending",
+        attempts,
+        lastError: message.slice(0, 1000),
+        nextRetryAt: new Date(Date.now() + delaySeconds * 1000),
+        claimedAt: null,
+        claimedBy: null,
+      })
+      .where(
+        and(
+          eq(providerActionReservationGenerations.id, row.id),
+          eq(providerActionReservationGenerations.state, row.state),
+          eq(providerActionReservationGenerations.attempts, row.attempts),
+          eq(providerActionReservationGenerations.claimedBy, claimId),
+        ),
+      );
   }
 
   private async applyPersistedReservationHandles(

--- a/packages/api/src/services/provider-action-service.ts
+++ b/packages/api/src/services/provider-action-service.ts
@@ -1025,15 +1025,33 @@ class ProviderActionService {
       };
     }
     // Record the narrow allowed_stub -> stub_succeeded|stub_failed transition.
-    await this.db()
-      .update(providerActionBindings)
-      .set({ status: stub.status, updatedAt: new Date() })
-      .where(
-        and(
-          eq(providerActionBindings.intentId, intentId),
-          eq(providerActionBindings.status, "allowed_stub"),
-        ),
-      );
+    // A pre-terminal C2 sweep can defer this reservation for 15 seconds because
+    // allowed_stub has no safe settle/release target. Make an unclaimed pending
+    // generation immediately due in the same transaction as the terminal state
+    // change so this request's scoped reconciliation cannot miss it.
+    await this.db().transaction(async (tx) => {
+      const transitioned = await tx
+        .update(providerActionBindings)
+        .set({ status: stub.status, updatedAt: new Date() })
+        .where(
+          and(
+            eq(providerActionBindings.intentId, intentId),
+            eq(providerActionBindings.status, "allowed_stub"),
+          ),
+        )
+        .returning({ intentId: providerActionBindings.intentId });
+      if (transitioned.length === 0) return;
+      await tx
+        .update(providerActionReservationGenerations)
+        .set({ nextRetryAt: null })
+        .where(
+          and(
+            eq(providerActionReservationGenerations.intentId, intentId),
+            eq(providerActionReservationGenerations.state, "pending"),
+            sql`${providerActionReservationGenerations.claimedBy} IS NULL`,
+          ),
+        );
+    });
     // #240: status is the durable outcome source. Reconcile only AFTER the
     // terminal transition so a crash at any instruction boundary is retryable.
     await this.reconcilePolicyReservations(tenantId, intentId);

--- a/packages/api/src/services/provider-action-service.ts
+++ b/packages/api/src/services/provider-action-service.ts
@@ -1279,11 +1279,13 @@ class ProviderActionService {
    */
   private async reserveCumulativeSpendForInvoke(input: {
     rules: ProviderPolicyRule[];
+    intentId: string;
     operationKey: string;
     agentId: string;
     grantId: string | null;
     spendDeclaration: { field: string; currency: string } | undefined;
     policyArgs: Record<string, unknown>;
+    reservationGeneration: number;
   }): Promise<{
     contextSums: Record<string, number> | undefined;
     reservations: CumulativeSpendReservationHandle[];
@@ -1401,6 +1403,15 @@ class ProviderActionService {
           stream,
           caps: caps.map((c) => ({ windowSeconds: c.windowSeconds, max: c.max })),
           amount: thisSpend,
+          reservationId: sha256HexPrefixed(
+            jcsStringify({
+              domain: "steward.provider-reservation.v1",
+              intentId: input.intentId,
+              generation: input.reservationGeneration,
+              kind: "cumulativeSpend",
+              stream,
+            }),
+          ),
         });
       } catch {
         // Redis/parse failure => deny for every cap on this stream (missing
@@ -1502,6 +1513,9 @@ class ProviderActionService {
     requestHash: string;
     actionDigest: string;
     grantId?: string | null;
+    /** Append-only reservation generation. Stable identities derived from this
+     * make an approval retry idempotent across the Redis-before-PG crash gap. */
+    reservationGeneration?: number;
   }): Promise<{
     doc: PersistedPolicyDecisionV1;
     evaluation: ProviderPolicyEvaluationV1;
@@ -1542,11 +1556,13 @@ class ProviderActionService {
     const spendDeclaration = extractSpendDeclaration(operation.requestProfile);
     const cumulative = await this.reserveCumulativeSpendForInvoke({
       rules,
+      intentId: args.intentId,
       operationKey: operation.operationKey,
       agentId: args.actorAgentId,
       grantId: args.grantId ?? null,
       spendDeclaration,
       policyArgs: build.policyArgs,
+      reservationGeneration: args.reservationGeneration ?? 1,
     });
 
     // #206 configurable count cap (maxCalls + callWindow): ATOMICALLY reserve one
@@ -1573,6 +1589,16 @@ class ProviderActionService {
         agentId: args.actorAgentId,
         operationKey: operation.operationKey,
         caps: govMaxCalls.map((c) => ({ windowSeconds: c.windowSeconds, max: c.max })),
+        reservationId: sha256HexPrefixed(
+          jcsStringify({
+            domain: "steward.provider-reservation.v1",
+            intentId: args.intentId,
+            generation: args.reservationGeneration ?? 1,
+            kind: "windowedInvoke",
+            agentId: args.actorAgentId,
+            operationKey: operation.operationKey,
+          }),
+        ),
       });
       govMaxCalls.forEach((cap, i) => {
         const bucketKey = windowedInvokeBucketKey({
@@ -1724,6 +1750,7 @@ class ProviderActionService {
       }
     | { ok: false; code: string; httpStatus: number }
   > {
+    const generation = args.priorGeneration + 1;
     const canonicalText = Buffer.from(args.canonicalActionBytes).toString("utf8");
     const action = JSON.parse(canonicalText) as Record<string, unknown>;
     const build = rebuildApprovedAction(args.operation.operationKey, action, args.safeSummary);
@@ -1745,13 +1772,14 @@ class ProviderActionService {
       requestHash: args.requestHash,
       actionDigest: args.actionDigest,
       grantId: args.matchedGrantIds[0] ?? null,
+      reservationGeneration: generation,
     });
     if (policy.doc.effect === "hard_deny") {
       await this.releasePolicyReservationHandles(
         persistedReservationHandles(
           policy.cumulativeSpendReservations,
           policy.windowedInvokeReservation,
-          1,
+          generation,
           "execution",
         ),
       );
@@ -1762,7 +1790,6 @@ class ProviderActionService {
       };
     }
 
-    const generation = args.priorGeneration + 1;
     return {
       ok: true,
       decision: policy.doc,
@@ -1876,43 +1903,42 @@ class ProviderActionService {
    * safely retried; unknown outcomes remain pending and are never released.
    */
   async reconcilePolicyReservations(tenantId?: string, intentId?: string): Promise<number> {
-    const candidates = await this.db()
-      .select()
-      .from(providerActionReservationGenerations)
-      .where(
-        and(
-          tenantId
-            ? eq(providerActionReservationGenerations.tenantId, tenantId)
-            : (sql`true` as unknown as ReturnType<typeof eq>),
-          sql`${providerActionReservationGenerations.state} IN ('pending','needs_attention')`,
-          sql`(${providerActionReservationGenerations.nextRetryAt} IS NULL OR ${providerActionReservationGenerations.nextRetryAt} <= now())`,
-          sql`(${providerActionReservationGenerations.claimedAt} IS NULL OR ${providerActionReservationGenerations.claimedAt} < now() - interval '60 seconds')`,
-          intentId
-            ? eq(providerActionReservationGenerations.intentId, intentId)
-            : (sql`true` as unknown as ReturnType<typeof eq>),
-        ),
-      )
-      .orderBy(
-        providerActionReservationGenerations.nextRetryAt,
-        providerActionReservationGenerations.createdAt,
-      )
-      .limit(50);
-    let reconciled = 0;
-    for (const candidate of candidates) {
-      const claimId = randomUUID();
-      const [row] = await this.db()
-        .update(providerActionReservationGenerations)
-        .set({ claimedBy: claimId, claimedAt: new Date() })
-        .where(
-          and(
-            eq(providerActionReservationGenerations.id, candidate.id),
-            eq(providerActionReservationGenerations.state, candidate.state),
-            eq(providerActionReservationGenerations.attempts, candidate.attempts),
-            sql`(${providerActionReservationGenerations.claimedAt} IS NULL OR ${providerActionReservationGenerations.claimedAt} < now() - interval '60 seconds')`,
-          ),
+    // Claim a bounded batch in one short transaction. SKIP LOCKED lets every
+    // replica make progress on a disjoint batch instead of selecting the same
+    // hot rows and losing N-1 follow-up CAS updates. A stale claim is a lease,
+    // not ownership: all Redis operations below are idempotent by reservation
+    // identity, so a worker death is safe to reclaim after 60 seconds.
+    const claimId = randomUUID();
+    const candidates = await this.db().transaction(async (tx) => {
+      const tenantFilter = tenantId ? sql`AND tenant_id = ${tenantId}` : sql``;
+      const intentFilter = intentId ? sql`AND intent_id = ${intentId}` : sql``;
+      await tx.execute(sql`
+        WITH due AS (
+          SELECT id
+          FROM provider_action_reservation_generations
+          WHERE (
+              (state = 'pending' AND (next_retry_at IS NULL OR next_retry_at <= now()))
+              OR (state = 'needs_attention' AND next_retry_at IS NOT NULL AND next_retry_at <= now())
+            )
+            AND (claimed_at IS NULL OR claimed_at < now() - interval '60 seconds')
+            ${tenantFilter}
+            ${intentFilter}
+          ORDER BY COALESCE(next_retry_at, '-infinity'::timestamptz), created_at, id
+          LIMIT 50
+          FOR UPDATE SKIP LOCKED
         )
-        .returning();
-      if (!row) continue;
+        UPDATE provider_action_reservation_generations AS generation
+        SET claimed_by = ${claimId}::uuid, claimed_at = now()
+        FROM due
+        WHERE generation.id = due.id
+      `);
+      return tx
+        .select()
+        .from(providerActionReservationGenerations)
+        .where(eq(providerActionReservationGenerations.claimedBy, claimId));
+    });
+    let reconciled = 0;
+    for (const row of candidates) {
       const [binding] = await this.db()
         .select({ status: providerActionBindings.status })
         .from(providerActionBindings)
@@ -1922,15 +1948,11 @@ class ProviderActionService {
       if (!handles || handles.generation !== row.generation || handles.phase !== row.phase) {
         const message = "malformed immutable reservation generation";
         await this.recordReservationFailure(row, claimId, message, true);
-        await writeAuditEvent({
-          tenantId: row.tenantId,
-          actorType: "system",
-          action: "provider.reservation.needs_attention",
-          resourceType: "provider_action",
-          resourceId: row.intentId,
-          metadata: { generation: row.generation, reasonCode: "RESERVATION_GENERATION_MALFORMED" },
-        }).catch((error) =>
-          console.error("[provider-reservations] malformed-generation audit failed:", error),
+        // recordReservationFailure transactionally enqueues REQUIRED evidence.
+        // Draining is best effort here; a signer outage cannot erase the durable
+        // attention row or outbox event and normal C2 recovery will retry it.
+        await this.recoverUnsignedIntents(row.tenantId, row.intentId).catch((error) =>
+          console.error("[provider-reservations] malformed-generation audit drain failed:", error),
         );
         continue;
       }
@@ -1994,24 +2016,49 @@ class ProviderActionService {
   ): Promise<void> {
     const attempts = row.attempts + 1;
     const delaySeconds = Math.min(3600, 2 ** Math.min(attempts, 12));
-    await this.db()
-      .update(providerActionReservationGenerations)
-      .set({
-        state: malformed || attempts >= 20 ? "needs_attention" : "pending",
-        attempts,
-        lastError: message.slice(0, 1000),
-        nextRetryAt: new Date(Date.now() + delaySeconds * 1000),
-        claimedAt: null,
-        claimedBy: null,
-      })
-      .where(
-        and(
-          eq(providerActionReservationGenerations.id, row.id),
-          eq(providerActionReservationGenerations.state, row.state),
-          eq(providerActionReservationGenerations.attempts, row.attempts),
-          eq(providerActionReservationGenerations.claimedBy, claimId),
-        ),
-      );
+    const terminalAttention = malformed || attempts >= 20;
+    await this.db().transaction(async (tx) => {
+      const updated = await tx
+        .update(providerActionReservationGenerations)
+        .set({
+          state: terminalAttention ? "needs_attention" : "pending",
+          attempts,
+          lastError: message.slice(0, 1000),
+          // NULL on durable attention deliberately removes the immutable-bad or
+          // exhausted row from the hot sweep. An operator must explicitly reset
+          // it after remediation; normal transient failures use exponential
+          // backoff and remain eligible.
+          nextRetryAt: terminalAttention ? null : new Date(Date.now() + delaySeconds * 1000),
+          claimedAt: null,
+          claimedBy: null,
+        })
+        .where(
+          and(
+            eq(providerActionReservationGenerations.id, row.id),
+            eq(providerActionReservationGenerations.state, row.state),
+            eq(providerActionReservationGenerations.attempts, row.attempts),
+            eq(providerActionReservationGenerations.claimedBy, claimId),
+          ),
+        )
+        .returning({ id: providerActionReservationGenerations.id });
+      if (updated.length === 0 || !terminalAttention) return;
+      await tx.insert(providerActionAuditOutbox).values({
+        tenantId: row.tenantId,
+        intentId: row.intentId,
+        action: "provider.reservation.needs_attention",
+        resourceType: "provider_action",
+        resourceId: row.intentId,
+        metadata: {
+          schemaVersion: "steward.provider-reservation-attention.v1",
+          intentId: row.intentId,
+          generation: row.generation,
+          reasonCode: malformed
+            ? "RESERVATION_GENERATION_MALFORMED"
+            : "RESERVATION_RECONCILIATION_RETRIES_EXHAUSTED",
+          attempts,
+        },
+      });
+    });
   }
 
   private async applyPersistedReservationHandles(

--- a/packages/api/src/services/provider-action-service.ts
+++ b/packages/api/src/services/provider-action-service.ts
@@ -87,11 +87,10 @@ const EVALUATOR_VERSION = "provider-action.v1";
 const POLICY_TYPE = "capability-intent" as const;
 
 /**
- * A handle to an atomic cumulative-spend reservation (#206) so the pipeline can
- * SETTLE it (known-success) or RELEASE it (known-failure/deny). On
- * outcome_unknown the pipeline deliberately does NEITHER - the reservation ages
- * out at the window edge (fail closed for a money cap: never free budget that
- * may have really spent).
+ * A handle to an atomic cumulative-spend reservation (#206). #240 persists this
+ * exact identity on the binding so a known outcome can be reconciled after a
+ * process crash. On outcome_unknown the sweeper deliberately does NEITHER - the
+ * reservation ages out at the window edge (fail closed for a money cap).
  */
 export interface CumulativeSpendReservationHandle {
   /** the spend-STREAM identity (scope+scopeKey+currency); NOT the cap threshold
@@ -111,6 +110,131 @@ export interface WindowedInvokeReservationHandle {
   agentId: string;
   operationKey: string;
   reservationId: string;
+}
+
+export interface PersistedPolicyReservationHandlesV1 {
+  schemaVersion: "steward.provider-policy-reservations.v1";
+  generation: number;
+  phase: "decision" | "execution";
+  cumulativeSpend: CumulativeSpendReservationHandle[];
+  windowedInvoke: WindowedInvokeReservationHandle | null;
+}
+
+type ReservationReconciliationTarget = "settled" | "released";
+
+let reservationReconciliationFaultForTests: "before_apply" | "after_apply" | null = null;
+
+/** Test-only crash injection at the external-effect / DB-CAS boundary. */
+export function __setReservationReconciliationFaultForTests(
+  fault: "before_apply" | "after_apply" | null,
+): void {
+  reservationReconciliationFaultForTests = fault;
+}
+
+function persistedReservationHandles(
+  cumulativeSpend: CumulativeSpendReservationHandle[],
+  windowedInvoke: WindowedInvokeReservationHandle | undefined,
+): PersistedPolicyReservationHandlesV1 | null {
+  if (cumulativeSpend.length === 0 && windowedInvoke === undefined) return null;
+  return {
+    schemaVersion: "steward.provider-policy-reservations.v1",
+    generation: 1,
+    phase: "decision",
+    cumulativeSpend,
+    windowedInvoke: windowedInvoke ?? null,
+  };
+}
+
+function parsePersistedReservationHandles(
+  value: unknown,
+): PersistedPolicyReservationHandlesV1 | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const v = value as Record<string, unknown>;
+  if (v.schemaVersion !== "steward.provider-policy-reservations.v1") return null;
+  if (!Number.isSafeInteger(v.generation) || (v.generation as number) <= 0) return null;
+  if (v.phase !== "decision" && v.phase !== "execution") return null;
+  if (!Array.isArray(v.cumulativeSpend)) return null;
+  const cumulativeSpend: CumulativeSpendReservationHandle[] = [];
+  for (const raw of v.cumulativeSpend) {
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+    const r = raw as Record<string, unknown>;
+    if (!r.stream || typeof r.stream !== "object" || Array.isArray(r.stream)) return null;
+    const stream = r.stream as Record<string, unknown>;
+    if (
+      typeof stream.agentId !== "string" ||
+      !["operation", "agent", "grant"].includes(String(stream.scope)) ||
+      typeof stream.scopeKey !== "string" ||
+      typeof stream.currency !== "string" ||
+      typeof r.reservationId !== "string" ||
+      !Number.isSafeInteger(r.amount) ||
+      (r.amount as number) < 0
+    )
+      return null;
+    cumulativeSpend.push({
+      stream: {
+        agentId: stream.agentId,
+        scope: stream.scope as CumulativeSpendScope,
+        scopeKey: stream.scopeKey,
+        currency: stream.currency,
+      },
+      reservationId: r.reservationId,
+      amount: r.amount as number,
+    });
+  }
+  let windowedInvoke: WindowedInvokeReservationHandle | null = null;
+  if (v.windowedInvoke !== null) {
+    if (
+      !v.windowedInvoke ||
+      typeof v.windowedInvoke !== "object" ||
+      Array.isArray(v.windowedInvoke)
+    )
+      return null;
+    const r = v.windowedInvoke as Record<string, unknown>;
+    if (
+      typeof r.agentId !== "string" ||
+      typeof r.operationKey !== "string" ||
+      typeof r.reservationId !== "string"
+    )
+      return null;
+    windowedInvoke = {
+      agentId: r.agentId,
+      operationKey: r.operationKey,
+      reservationId: r.reservationId,
+    };
+  }
+  if (cumulativeSpend.length === 0 && windowedInvoke === null) return null;
+  return {
+    schemaVersion: "steward.provider-policy-reservations.v1",
+    generation: v.generation as number,
+    phase: v.phase,
+    cumulativeSpend,
+    windowedInvoke,
+  };
+}
+
+function reconciliationTargetForStatus(
+  status: string,
+  phase: PersistedPolicyReservationHandlesV1["phase"],
+): ReservationReconciliationTarget | null {
+  if (status === "stub_succeeded" || status === "succeeded") return "settled";
+  // Decision-time reservations for approval-gated actions are never carried
+  // across the human lifecycle; execution takes a fresh authoritative reserve.
+  if (
+    phase === "decision" &&
+    [
+      "pending_approval",
+      "approved",
+      "execution_ready",
+      "approval_denied",
+      "approval_expired",
+      "approval_stale",
+    ].includes(status)
+  )
+    return "released";
+  if (status === "denied" || status === "stub_failed" || status === "failed") return "released";
+  // allowed_stub / approved / execution_ready / executing / outcome_unknown:
+  // never free maybe-consumed budget before the action has a known outcome.
+  return null;
 }
 
 // ─── Public result envelope ───────────────────────────────────────────────────
@@ -633,6 +757,14 @@ class ProviderActionService {
           policyRevisionHash: policy ? policy.doc.policyRevisionHash : null,
           policyDecision: policy ? (policy.doc as unknown as Record<string, unknown>) : null,
           policyDecisionHash,
+          policyReservationHandles: persistedReservationHandles(
+            cumulativeSpendReservations,
+            windowedInvokeReservation,
+          ),
+          reservationReconciliationState:
+            cumulativeSpendReservations.length > 0 || windowedInvokeReservation !== undefined
+              ? "pending"
+              : "not_required",
           status: effects.status,
         });
 
@@ -725,8 +857,7 @@ class ProviderActionService {
       // never run on replay, so we DO reclaim. `effects.status === "allowed_stub"`
       // is exactly the replayable-execute case.
       if (effects.status !== "allowed_stub") {
-        await this.finalizeCumulativeSpend(cumulativeSpendReservations, "failure");
-        await this.finalizeWindowedInvoke(windowedInvokeReservation, "failure");
+        await this.reconcilePolicyReservations(tenantId, intentId);
       }
       return {
         kind: "evidence_failure",
@@ -740,8 +871,7 @@ class ProviderActionService {
     if (effects.access === "deny") {
       // Access denied => policy never ran => no reservations to release, but be
       // defensive in case a future path reserves before access resolves.
-      await this.finalizeCumulativeSpend(cumulativeSpendReservations, "failure");
-      await this.finalizeWindowedInvoke(windowedInvokeReservation, "failure");
+      await this.reconcilePolicyReservations(tenantId, intentId);
       return {
         kind: "access_denied",
         code: access.doc.reasonCode,
@@ -756,11 +886,7 @@ class ProviderActionService {
       // spend-cap breach already released its own reservations during eval; this
       // covers a deny for a DIFFERENT reason where a cumulativeSpend rule had
       // passed and reserved - the action will not execute, so free its budget.
-      await this.finalizeCumulativeSpend(
-        (policy as PolicyResult | null)?.cumulativeSpendReservations ?? [],
-        "failure",
-      );
-      await this.finalizeWindowedInvoke(windowedInvokeReservation, "failure");
+      await this.reconcilePolicyReservations(tenantId, intentId);
       const code = (policy as PolicyResult | null)?.doc.reasonCodes[0] ?? "POLICY_HARD_DENY";
       return {
         kind: "policy_denied",
@@ -791,11 +917,7 @@ class ProviderActionService {
       // Correct enforcement requires the approval-execute path to re-reserve at
       // EXECUTION time; that is a documented follow-up filed against the approval
       // plane (provider-approval.ts). See the PR honest-gaps section.
-      await this.finalizeCumulativeSpend(
-        (policy as PolicyResult | null)?.cumulativeSpendReservations ?? [],
-        "failure",
-      );
-      await this.finalizeWindowedInvoke(windowedInvokeReservation, "failure");
+      await this.reconcilePolicyReservations(tenantId, intentId);
       return {
         kind: "approval_required",
         code: "APPROVAL_REQUIRED",
@@ -807,7 +929,6 @@ class ProviderActionService {
     }
 
     // ── Step 4: allow — call the in-process stub, then record the transition. ──
-    const csReservations = (policy as PolicyResult | null)?.cumulativeSpendReservations ?? [];
     let stub: ProviderActionStubResult;
     try {
       stub = await executeProviderActionStub(intentId);
@@ -826,15 +947,6 @@ class ProviderActionService {
         actionDigest,
       };
     }
-    // #206: known outcome. stub_succeeded => settle (keep counted); stub_failed
-    // => release (reclaim spend budget + the maxCalls slot, the action did not
-    // consume one).
-    const outcome = stub.ok ? "success" : "failure";
-    await this.finalizeCumulativeSpend(csReservations, outcome);
-    await this.finalizeWindowedInvoke(
-      (policy as PolicyResult | null)?.windowedInvokeReservation,
-      outcome,
-    );
     // Record the narrow allowed_stub -> stub_succeeded|stub_failed transition.
     await this.db()
       .update(providerActionBindings)
@@ -845,6 +957,9 @@ class ProviderActionService {
           eq(providerActionBindings.status, "allowed_stub"),
         ),
       );
+    // #240: status is the durable outcome source. Reconcile only AFTER the
+    // terminal transition so a crash at any instruction boundary is retryable.
+    await this.reconcilePolicyReservations(tenantId, intentId);
 
     return {
       kind: "allowed",
@@ -1114,7 +1229,7 @@ class ProviderActionService {
     const spendValid =
       decl !== undefined &&
       typeof rawSpend === "number" &&
-      Number.isInteger(rawSpend) &&
+      Number.isSafeInteger(rawSpend) &&
       rawSpend >= 0;
     const thisSpend = spendValid ? (rawSpend as number) : undefined;
 
@@ -1584,7 +1699,138 @@ class ProviderActionService {
         .returning({ id: providerActionAuditOutbox.id });
       if (marked.length > 0 && signedNow) delivered += 1;
     }
+    // #240 extends the same C2 pass to durable policy reservations. Audit and
+    // reservation recovery are independently idempotent; a Redis outage leaves
+    // the reservation pending and fail-closed for the next sweep.
+    await this.reconcilePolicyReservations(tenantId, intentId);
     return delivered;
+  }
+
+  /**
+   * Reconcile terminal provider bindings with their immutable Redis reservation
+   * handles. Redis settle/release operations are idempotent, so workers may race:
+   * they perform the external operation first, then exactly one worker wins the
+   * DB CAS from pending to settled/released. A crash before or after Redis is
+   * safely retried; unknown outcomes remain pending and are never released.
+   */
+  async reconcilePolicyReservations(tenantId?: string, intentId?: string): Promise<number> {
+    const rows = await this.db()
+      .select()
+      .from(providerActionBindings)
+      .where(
+        and(
+          tenantId
+            ? eq(providerActionBindings.tenantId, tenantId)
+            : (sql`true` as unknown as ReturnType<typeof eq>),
+          sql`${providerActionBindings.reservationReconciliationState} IN ('pending','needs_attention')`,
+          intentId
+            ? (sql`true` as unknown as ReturnType<typeof eq>)
+            : (sql`(${providerActionBindings.reservationReconciliationNextRetryAt} IS NULL OR ${providerActionBindings.reservationReconciliationNextRetryAt} <= now())` as unknown as ReturnType<
+                typeof eq
+              >),
+          intentId
+            ? eq(providerActionBindings.intentId, intentId)
+            : (sql`true` as unknown as ReturnType<typeof eq>),
+        ),
+      );
+    let reconciled = 0;
+    for (const row of rows) {
+      const handles = parsePersistedReservationHandles(row.policyReservationHandles);
+      // Corrupt/unrecognized persisted handles fail closed and remain pending.
+      if (!handles) continue;
+      const target = reconciliationTargetForStatus(row.status, handles.phase);
+      if (!target) continue;
+      try {
+        if (reservationReconciliationFaultForTests === "before_apply")
+          throw new Error("injected crash before reservation reconciliation");
+        await this.applyPersistedReservationHandles(handles, target);
+        if (reservationReconciliationFaultForTests === "after_apply")
+          throw new Error("injected crash after reservation reconciliation");
+      } catch (error) {
+        const message = (error instanceof Error ? error.message : String(error)).slice(0, 1000);
+        const attempts = row.reservationReconciliationAttempts + 1;
+        const delaySeconds = Math.min(3600, 2 ** Math.min(attempts, 12));
+        await this.db()
+          .update(providerActionBindings)
+          .set({
+            reservationReconciliationState: attempts >= 20 ? "needs_attention" : "pending",
+            reservationReconciliationAttempts: attempts,
+            reservationReconciliationLastError: message,
+            reservationReconciliationNextRetryAt: new Date(Date.now() + delaySeconds * 1000),
+            updatedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(providerActionBindings.intentId, row.intentId),
+              eq(providerActionBindings.status, row.status),
+              eq(
+                providerActionBindings.reservationReconciliationState,
+                row.reservationReconciliationState,
+              ),
+              eq(
+                providerActionBindings.reservationReconciliationAttempts,
+                row.reservationReconciliationAttempts,
+              ),
+              sql`${providerActionBindings.policyReservationHandles} = ${JSON.stringify(
+                row.policyReservationHandles,
+              )}::jsonb`,
+            ),
+          );
+        console.error(
+          `[provider-reservations] reconciliation failed intent=${row.intentId} generation=${handles.generation} attempts=${attempts}: ${message}`,
+        );
+        continue;
+      }
+      const updated = await this.db()
+        .update(providerActionBindings)
+        .set({
+          reservationReconciliationState: target,
+          reservationReconciledAt: new Date(),
+          reservationReconciliationNextRetryAt: null,
+          reservationReconciliationLastError: null,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(providerActionBindings.intentId, row.intentId),
+            eq(providerActionBindings.status, row.status),
+            eq(
+              providerActionBindings.reservationReconciliationState,
+              row.reservationReconciliationState,
+            ),
+            eq(
+              providerActionBindings.reservationReconciliationAttempts,
+              row.reservationReconciliationAttempts,
+            ),
+            sql`${providerActionBindings.policyReservationHandles} = ${JSON.stringify(
+              row.policyReservationHandles,
+            )}::jsonb`,
+          ),
+        )
+        .returning({ intentId: providerActionBindings.intentId });
+      if (updated.length > 0) reconciled += 1;
+    }
+    return reconciled;
+  }
+
+  private async applyPersistedReservationHandles(
+    handles: PersistedPolicyReservationHandlesV1,
+    target: ReservationReconciliationTarget,
+  ): Promise<void> {
+    await Promise.all(
+      handles.cumulativeSpend.map((r) =>
+        target === "settled"
+          ? settleCumulativeSpend({ stream: r.stream, reservationId: r.reservationId })
+          : releaseCumulativeSpend({
+              stream: r.stream,
+              reservationId: r.reservationId,
+              amount: r.amount,
+            }),
+      ),
+    );
+    if (target === "released" && handles.windowedInvoke) {
+      await releaseWindowedInvoke(handles.windowedInvoke);
+    }
   }
 
   // ── Required-audit outbox drain (post-commit, pre-stub) ──
@@ -1677,26 +1923,12 @@ class ProviderActionService {
     return envelope;
   }
 
-  /**
-   * Idempotent replay path: reconstruct the outcome from an existing binding.
-   *
-   * #206 RESERVATION REPLAY CAVEAT (codex P2, honest gap): cumulative-spend
-   * reservation handles are in-memory to the ORIGINAL create call and are NOT
-   * persisted on the binding. A replay here (or a crash between the binding
-   * commit and the original finalize) therefore has no handle to settle/release.
-   * This is deliberately FAIL-CLOSED, not a silent leak: on the original call a
-   * crash after commit leaves the reservation as `outcome_unknown` (documented:
-   * it ages out at the window edge, never freeing maybe-spent budget). A replay
-   * that resolves to stub_succeeded is a real spend and SHOULD stay counted, so
-   * not releasing is correct. A replay that resolves to stub_failed is the only
-   * case where budget could be transiently over-counted for one window; that is
-   * a bounded DENY-side error (safe), never an allow-side one. Crash-durable
-   * reservation handles (persisted per binding + reconciled by the C2 sweeper)
-   * are the follow-up; this lane does not add a migration for it.
-   */
+  /** Idempotent replay path: reconstruct the outcome from an existing binding. */
   private async outcomeFromBinding(
     b: typeof providerActionBindings.$inferSelect,
   ): Promise<ProviderActionOutcome> {
+    // Opportunistically finish any terminal reservation left pending by a crash.
+    await this.reconcilePolicyReservations(b.tenantId, b.intentId);
     if (b.status === "denied") {
       if (b.accessEffect === "deny")
         return {
@@ -1780,6 +2012,7 @@ class ProviderActionService {
             eq(providerActionBindings.status, "allowed_stub"),
           ),
         );
+      await this.reconcilePolicyReservations(b.tenantId, b.intentId);
       return {
         kind: "allowed",
         code: "POLICY_ALLOW",

--- a/packages/api/src/services/provider-approval.ts
+++ b/packages/api/src/services/provider-approval.ts
@@ -1902,6 +1902,13 @@ class ProviderApprovalService {
     userAgent?: string | null;
     requestId?: string | null;
   }): Promise<ApprovalResult> {
+    // Cross-store pre-commit semantics are deliberately fail-closed. A normal PG
+    // rollback/exception is compensated below by releasing these Redis handles.
+    // If the process is killed after Redis admission but before PG commit, no
+    // execution authorization exists, so dispatch is impossible; a retry derives
+    // the same (intent,generation,stream) reservation identities and therefore
+    // does not double-debit. With no retry, Redis's bounded 30-day retention ages
+    // the orphan out. This can transiently deny, never permit an overspend.
     let executionHandlesToRelease: unknown = null;
     try {
       const result = await withTenantAuditedTransaction(
@@ -2100,9 +2107,9 @@ class ProviderApprovalService {
             .set({ status: "consumed", consumedAt: nowTs, consumedBy: RESUME_ACTOR })
             .where(and(eq(approvalQueue.id, queue.id), eq(approvalQueue.status, "approved")))
             .returning({ id: approvalQueue.id });
-          if (upd.length === 0) return fail("APPROVAL_STATE_CONFLICT", 409);
+          if (upd.length === 0) throw new ApprovalResumeStateConflictError();
 
-          await tx
+          const bindingUpdate = await tx
             .update(providerActionBindings)
             .set({
               status: "execution_ready",
@@ -2126,7 +2133,9 @@ class ProviderApprovalService {
                 eq(providerActionBindings.status, "approved"),
                 eq(providerActionBindings.bindingRevision, before),
               ),
-            );
+            )
+            .returning({ intentId: providerActionBindings.intentId });
+          if (bindingUpdate.length === 0) throw new ApprovalResumeStateConflictError();
           await tx
             .update(intents)
             .set({ executedBy: RESUME_ACTOR, updatedAt: nowTs })
@@ -2226,6 +2235,8 @@ class ProviderApprovalService {
       }
       if (e instanceof AuditUnavailableError)
         return fail("EVIDENCE_REQUIRED_AUDIT_UNAVAILABLE", 503);
+      if (e instanceof ApprovalResumeStateConflictError)
+        return fail("APPROVAL_STATE_CONFLICT", 409);
       // v2 mint fail-closed: absent HMAC key rolls back the whole resume tx so
       // no execution_ready lands without a mintable authorization (X7, P49/F06).
       if (e instanceof ProviderExecutionMintError) {
@@ -2337,6 +2348,11 @@ class ProviderApprovalService {
 // ── module helpers ──
 
 class AuditUnavailableError extends Error {}
+
+/** Throwing (instead of returning) is required after Redis admission so the
+ * approval consumption, generation insert, evidence, and mint all roll back as
+ * one unit; the outer compensation then releases the pre-commit reservation. */
+class ApprovalResumeStateConflictError extends Error {}
 
 /**
  * #205: thrown from the quorum decide path AFTER the provider_action_approvals

--- a/packages/api/src/services/provider-approval.ts
+++ b/packages/api/src/services/provider-approval.ts
@@ -45,6 +45,7 @@ import {
   type ProviderApprovalAuditPayloadV1,
   type ProviderApprovalCommitmentV1,
   sha256HexPrefixed,
+  verifyProviderExecutionPolicyEvidence,
 } from "@stwd/shared";
 import { and, eq, sql } from "drizzle-orm";
 import {
@@ -1943,6 +1944,22 @@ class ProviderApprovalService {
               !binding.executionPolicyDecision ||
               !binding.executionPolicyDecisionHash ||
               !binding.executionPolicyEvaluatedAt
+            ) {
+              return fail("EXECUTION_POLICY_EVIDENCE_MISSING", 409);
+            }
+            if (
+              !verifyProviderExecutionPolicyEvidence(
+                binding.executionPolicyDecision,
+                binding.executionPolicyDecisionHash,
+                {
+                  decisionId: binding.executionPolicyDecisionId,
+                  intentId: binding.intentId,
+                  requestHash: binding.requestHash,
+                  actionDigest: binding.actionDigest,
+                  operationId: binding.operationId,
+                  policyRevisionHash: binding.executionPolicyRevisionHash,
+                },
+              )
             ) {
               return fail("EXECUTION_POLICY_EVIDENCE_MISSING", 409);
             }

--- a/packages/api/src/services/provider-approval.ts
+++ b/packages/api/src/services/provider-approval.ts
@@ -1934,6 +1934,18 @@ class ProviderApprovalService {
           // exec_auth_nonces_intent_uniq (K22/F01): a repeat resume that already has
           // a nonce is a no-op insert. Fails closed if the secret is absent (X7).
           if (binding.status === "execution_ready") {
+            // 0084 terminalizes pre-rollout rows, but retain a second application
+            // boundary for partially applied/manual schemas: never mint an
+            // authorization for a row that did not pass execute-time policy.
+            if (
+              !binding.executionPolicyDecisionId ||
+              !binding.executionPolicyRevisionHash ||
+              !binding.executionPolicyDecision ||
+              !binding.executionPolicyDecisionHash ||
+              !binding.executionPolicyEvaluatedAt
+            ) {
+              return fail("EXECUTION_POLICY_EVIDENCE_MISSING", 409);
+            }
             await this.hook("beforeMint");
             await mintProviderExecutionAuthorizationWithinTx(
               tx as unknown as Parameters<typeof mintProviderExecutionAuthorizationWithinTx>[0],

--- a/packages/api/src/services/provider-approval.ts
+++ b/packages/api/src/services/provider-approval.ts
@@ -28,6 +28,7 @@ import {
   providerAccounts,
   providerActionApprovals,
   providerActionBindings,
+  providerActionReservationGenerations,
   providerGrants,
   providerOperations,
   providerRoleBindings,
@@ -428,6 +429,7 @@ class ProviderApprovalService {
       | "afterScopeLoad"
       | "afterIntegrity"
       | "afterAuthority"
+      | "afterPolicyReserve"
       | "afterMfa"
       | "beforeAudit"
       | "afterAudit"
@@ -1900,28 +1902,268 @@ class ProviderApprovalService {
     userAgent?: string | null;
     requestId?: string | null;
   }): Promise<ApprovalResult> {
+    let executionHandlesToRelease: unknown = null;
     try {
-      return await withTenantAuditedTransaction(input.tenantId, async (txRaw, appendRaw) => {
-        const tx = txRaw as DbExecutor;
-        const append = mapRequiredAuditFailure(appendRaw as unknown as ApprovalAuditAppend);
+      const result = await withTenantAuditedTransaction(
+        input.tenantId,
+        async (txRaw, appendRaw): Promise<ApprovalResult> => {
+          const tx = txRaw as DbExecutor;
+          const append = mapRequiredAuditFailure(appendRaw as unknown as ApprovalAuditAppend);
 
-        const loaded = await this.loadCase(tx, input.tenantId, input.intentId, true);
-        await this.hook("afterScopeLoad");
-        if ("notFound" in loaded) return fail("SCOPE_RESOURCE_NOT_FOUND", 404);
-        if ("notApproval" in loaded) return fail("APPROVAL_NOT_REQUIRED", 409);
-        const { binding, queue } = loaded;
-        if (input.caller && !(await this.isExecuteCallerAuthorized(tx, binding, input.caller))) {
-          return fail("SCOPE_RESOURCE_NOT_FOUND", 404);
-        }
+          const loaded = await this.loadCase(tx, input.tenantId, input.intentId, true);
+          await this.hook("afterScopeLoad");
+          if ("notFound" in loaded) return fail("SCOPE_RESOURCE_NOT_FOUND", 404);
+          if ("notApproval" in loaded) return fail("APPROVAL_NOT_REQUIRED", 409);
+          const { binding, queue } = loaded;
+          if (input.caller && !(await this.isExecuteCallerAuthorized(tx, binding, input.caller))) {
+            return fail("SCOPE_RESOURCE_NOT_FOUND", 404);
+          }
 
-        // Idempotent: already execution_ready returns same state. BUT a row that
-        // reached execution_ready BEFORE this rollout (or via any path that did
-        // not mint) has no v2 authorization, and the governed dispatcher REQUIRES
-        // one (codex P2). So the idempotent path ALSO ensures the v2 nonce exists,
-        // minting it in this same audited tx if absent. The mint is idempotent via
-        // exec_auth_nonces_intent_uniq (K22/F01): a repeat resume that already has
-        // a nonce is a no-op insert. Fails closed if the secret is absent (X7).
-        if (binding.status === "execution_ready") {
+          // Idempotent: already execution_ready returns same state. BUT a row that
+          // reached execution_ready BEFORE this rollout (or via any path that did
+          // not mint) has no v2 authorization, and the governed dispatcher REQUIRES
+          // one (codex P2). So the idempotent path ALSO ensures the v2 nonce exists,
+          // minting it in this same audited tx if absent. The mint is idempotent via
+          // exec_auth_nonces_intent_uniq (K22/F01): a repeat resume that already has
+          // a nonce is a no-op insert. Fails closed if the secret is absent (X7).
+          if (binding.status === "execution_ready") {
+            await this.hook("beforeMint");
+            await mintProviderExecutionAuthorizationWithinTx(
+              tx as unknown as Parameters<typeof mintProviderExecutionAuthorizationWithinTx>[0],
+              append as unknown as Parameters<typeof mintProviderExecutionAuthorizationWithinTx>[1],
+              {
+                intentId: binding.intentId,
+                tenantId: binding.tenantId,
+                workspaceId: binding.workspaceId,
+                actorAgentId: binding.actorAgentId,
+                providerAccountId: binding.providerAccountId,
+                operationId: binding.operationId,
+                operationRevision: binding.operationRevision,
+                requestHash: binding.requestHash,
+                actionDigest: binding.actionDigest,
+                approvalId: queue.id,
+                approvalCommitmentHash: queue.approvalCommitmentHash ?? "",
+                approvalCommitment:
+                  queue.approvalCommitment as unknown as ProviderApprovalCommitmentV1,
+                canonicalActionBytes: new Uint8Array(binding.canonicalActionBytes as Uint8Array),
+                requestId: input.requestId ?? null,
+              },
+              {
+                now: new Date(),
+                ipAddress: input.ipAddress ?? null,
+                userAgent: input.userAgent ?? null,
+                requestId: input.requestId ?? null,
+                hooks: {
+                  beforeInsert: () => this.hook("beforeMintInsert"),
+                  beforeAudit: () => this.hook("beforeMintAudit"),
+                },
+              },
+            );
+            await this.hook("afterMint");
+            return {
+              ok: true,
+              httpStatus: 200,
+              id: binding.intentId,
+              status: "execution_ready",
+              version: binding.bindingRevision,
+              requestHash: binding.requestHash,
+              actionDigest: binding.actionDigest,
+              resumeAttemptId: binding.resumeAttemptId ?? undefined,
+            };
+          }
+
+          // Expire first.
+          if (queue.status === "pending" || queue.status === "approved") {
+            const expired = await this.expireIfDue(tx, append, loaded);
+            if (expired) return fail("APPROVAL_EXPIRED", 410);
+          }
+
+          if (binding.status !== "approved") {
+            if (binding.status === "pending_approval") return fail("RESUME_NOT_APPROVED", 409);
+            if (binding.status === "approval_denied") return fail("RESUME_NOT_APPROVED", 409);
+            return this.terminalOutcome(binding, queue);
+          }
+
+          // Integrity + full dependency revalidation (§6.8 step 6-8).
+          const integ = this.verifyIntegrity(binding, queue);
+          await this.hook("afterIntegrity");
+          if (!integ.ok) {
+            await this.staleTransition(tx, append, binding, queue, integ.code);
+            return fail(integ.code, 409);
+          }
+          const deps = await this.revalidateDependencies(tx, binding, queue);
+          await this.hook("afterAuthority");
+          if (!deps.ok) {
+            await this.staleTransition(tx, append, binding, queue, deps.code);
+            return fail(deps.code, 409);
+          }
+
+          // The approval-time reservation generation must be fully released before
+          // execution can reserve a new generation. This prevents a late release
+          // worker from ever touching execution budget.
+          const priorGenerations = await tx
+            .select()
+            .from(providerActionReservationGenerations)
+            .where(eq(providerActionReservationGenerations.intentId, binding.intentId))
+            .orderBy(sql`${providerActionReservationGenerations.generation} DESC`)
+            .limit(1);
+          const priorGeneration = priorGenerations[0];
+          if (priorGeneration && priorGeneration.state !== "released") {
+            return fail("APPROVAL_RESERVATION_RECONCILIATION_PENDING", 503);
+          }
+
+          // Approver still eligible at resume (I7). No MFA-age recheck (§9).
+          const approverUserId = binding.approvalActorUserId as string;
+          const approver = await this.checkApprover(
+            tx,
+            binding,
+            queue,
+            approverUserId,
+            input.tenantId,
+            undefined,
+            true,
+          );
+          if (!approver.ok) {
+            await this.staleTransition(tx, append, binding, queue, approver.code);
+            return fail(approver.code, approver.httpStatus === 403 ? 409 : approver.httpStatus);
+          }
+
+          const [currentOperation] = await tx
+            .select()
+            .from(providerOperations)
+            .where(
+              and(
+                eq(providerOperations.id, binding.operationId),
+                eq(providerOperations.tenantId, binding.tenantId),
+                eq(providerOperations.workspaceId, binding.workspaceId),
+                eq(providerOperations.providerAccountId, binding.providerAccountId),
+              ),
+            )
+            .limit(1);
+          if (!currentOperation) return fail("APPROVAL_DEPENDENCY_STALE", 409);
+
+          const { providerActionService } = await import("./provider-action-service.js");
+          const executionPolicy = await providerActionService.evaluateApprovedExecution({
+            tenantId: binding.tenantId,
+            workspaceId: binding.workspaceId,
+            actorAgentId: binding.actorAgentId,
+            operation: currentOperation,
+            intentId: binding.intentId,
+            requestHash: binding.requestHash,
+            actionDigest: binding.actionDigest,
+            canonicalActionBytes: new Uint8Array(binding.canonicalActionBytes as Uint8Array),
+            safeSummary: binding.safeSummary,
+            matchedGrantIds: binding.matchedGrantIds,
+            priorGeneration: priorGeneration?.generation ?? 0,
+          });
+          if (!executionPolicy.ok) {
+            await append({
+              tenantId: binding.tenantId,
+              actorType: "system",
+              actorId: RESUME_ACTOR,
+              action: "provider.resume.policy_denied",
+              resourceType: "provider_action",
+              resourceId: binding.intentId,
+              metadata: {
+                schemaVersion: "steward.provider-resume-policy-denial.v1",
+                intentId: binding.intentId,
+                requestHash: binding.requestHash,
+                actionDigest: binding.actionDigest,
+                reasonCode: executionPolicy.code,
+              },
+              ipAddress: input.ipAddress ?? null,
+              userAgent: input.userAgent ?? null,
+              requestId: input.requestId ?? null,
+            });
+            return fail(executionPolicy.code, executionPolicy.httpStatus);
+          }
+          executionHandlesToRelease = executionPolicy.handles;
+          await this.hook("afterPolicyReserve");
+
+          if (executionPolicy.handles) {
+            await tx.insert(providerActionReservationGenerations).values({
+              intentId: binding.intentId,
+              tenantId: binding.tenantId,
+              generation: executionPolicy.handles.generation,
+              phase: executionPolicy.handles.phase,
+              handles: executionPolicy.handles as unknown as Record<string, unknown>,
+            });
+          }
+
+          const before = binding.bindingRevision;
+          const after = before + 1;
+          const nowTs = new Date();
+          const resumeAttemptId = randomUUID();
+
+          const upd = await tx
+            .update(approvalQueue)
+            .set({ status: "consumed", consumedAt: nowTs, consumedBy: RESUME_ACTOR })
+            .where(and(eq(approvalQueue.id, queue.id), eq(approvalQueue.status, "approved")))
+            .returning({ id: approvalQueue.id });
+          if (upd.length === 0) return fail("APPROVAL_STATE_CONFLICT", 409);
+
+          await tx
+            .update(providerActionBindings)
+            .set({
+              status: "execution_ready",
+              bindingRevision: after,
+              resumeActor: RESUME_ACTOR,
+              resumeAttemptId,
+              resumeValidatedAt: nowTs,
+              executionPolicyDecisionId: executionPolicy.decision.decisionId,
+              executionPolicyRevisionHash: executionPolicy.decision.policyRevisionHash,
+              executionPolicyDecision: executionPolicy.decision as unknown as Record<
+                string,
+                unknown
+              >,
+              executionPolicyDecisionHash: executionPolicy.decisionHash,
+              executionPolicyEvaluatedAt: new Date(executionPolicy.decision.decidedAt),
+              updatedAt: nowTs,
+            })
+            .where(
+              and(
+                eq(providerActionBindings.intentId, binding.intentId),
+                eq(providerActionBindings.status, "approved"),
+                eq(providerActionBindings.bindingRevision, before),
+              ),
+            );
+          await tx
+            .update(intents)
+            .set({ executedBy: RESUME_ACTOR, updatedAt: nowTs })
+            .where(eq(intents.id, binding.intentId));
+
+          const payload = buildAuditPayload(binding, queue, {
+            approvalActorUserId: approverUserId,
+            resumeActor: RESUME_ACTOR,
+            bindingRevisionBefore: before,
+            bindingRevisionAfter: after,
+            fromStatus: "approved",
+            toStatus: "execution_ready",
+            reasonCode: "provider_resume_ready",
+            resumeAttemptId,
+          });
+          await this.hook("beforeAudit");
+          await append({
+            tenantId: binding.tenantId,
+            actorType: "system",
+            actorId: RESUME_ACTOR,
+            action: "provider.resume.ready",
+            resourceType: "provider_action",
+            resourceId: binding.intentId,
+            metadata: payload as unknown as Record<string, unknown>,
+            ipAddress: input.ipAddress ?? null,
+            userAgent: input.userAgent ?? null,
+            requestId: input.requestId ?? null,
+          });
+          await this.hook("afterAudit");
+
+          // PR4 mint-within-tx (spec §2.3): mint the v2 execution authorization in
+          // the SAME audited transaction as the resume, so approved→execution_ready
+          // →authorization-minted is one atomic step (removes an extra crash window,
+          // F01). Idempotent by exec_auth_nonces_intent_uniq (K22). Fails closed if
+          // STEWARD_EXECUTION_AUTH_SECRET is absent (X7, P49). The whole resume tx
+          // rolls back on mint failure, so a resume never lands execution_ready
+          // without a mintable authorization.
           await this.hook("beforeMint");
           await mintProviderExecutionAuthorizationWithinTx(
             tx as unknown as Parameters<typeof mintProviderExecutionAuthorizationWithinTx>[0],
@@ -1944,7 +2186,7 @@ class ProviderApprovalService {
               requestId: input.requestId ?? null,
             },
             {
-              now: new Date(),
+              now: nowTs,
               ipAddress: input.ipAddress ?? null,
               userAgent: input.userAgent ?? null,
               requestId: input.requestId ?? null,
@@ -1955,171 +2197,33 @@ class ProviderApprovalService {
             },
           );
           await this.hook("afterMint");
+
           return {
             ok: true,
             httpStatus: 200,
             id: binding.intentId,
             status: "execution_ready",
-            version: binding.bindingRevision,
+            version: after,
             requestHash: binding.requestHash,
             actionDigest: binding.actionDigest,
-            resumeAttemptId: binding.resumeAttemptId ?? undefined,
-          };
-        }
-
-        // Expire first.
-        if (queue.status === "pending" || queue.status === "approved") {
-          const expired = await this.expireIfDue(tx, append, loaded);
-          if (expired) return fail("APPROVAL_EXPIRED", 410);
-        }
-
-        if (binding.status !== "approved") {
-          if (binding.status === "pending_approval") return fail("RESUME_NOT_APPROVED", 409);
-          if (binding.status === "approval_denied") return fail("RESUME_NOT_APPROVED", 409);
-          return this.terminalOutcome(binding, queue);
-        }
-
-        // Integrity + full dependency revalidation (§6.8 step 6-8).
-        const integ = this.verifyIntegrity(binding, queue);
-        await this.hook("afterIntegrity");
-        if (!integ.ok) {
-          await this.staleTransition(tx, append, binding, queue, integ.code);
-          return fail(integ.code, 409);
-        }
-        const deps = await this.revalidateDependencies(tx, binding, queue);
-        await this.hook("afterAuthority");
-        if (!deps.ok) {
-          await this.staleTransition(tx, append, binding, queue, deps.code);
-          return fail(deps.code, 409);
-        }
-
-        // Approver still eligible at resume (I7). No MFA-age recheck (§9).
-        const approverUserId = binding.approvalActorUserId as string;
-        const approver = await this.checkApprover(
-          tx,
-          binding,
-          queue,
-          approverUserId,
-          input.tenantId,
-          undefined,
-          true,
-        );
-        if (!approver.ok) {
-          await this.staleTransition(tx, append, binding, queue, approver.code);
-          return fail(approver.code, approver.httpStatus === 403 ? 409 : approver.httpStatus);
-        }
-
-        const before = binding.bindingRevision;
-        const after = before + 1;
-        const nowTs = new Date();
-        const resumeAttemptId = randomUUID();
-
-        const upd = await tx
-          .update(approvalQueue)
-          .set({ status: "consumed", consumedAt: nowTs, consumedBy: RESUME_ACTOR })
-          .where(and(eq(approvalQueue.id, queue.id), eq(approvalQueue.status, "approved")))
-          .returning({ id: approvalQueue.id });
-        if (upd.length === 0) return fail("APPROVAL_STATE_CONFLICT", 409);
-
-        await tx
-          .update(providerActionBindings)
-          .set({
-            status: "execution_ready",
-            bindingRevision: after,
-            resumeActor: RESUME_ACTOR,
             resumeAttemptId,
-            resumeValidatedAt: nowTs,
-            updatedAt: nowTs,
-          })
-          .where(
-            and(
-              eq(providerActionBindings.intentId, binding.intentId),
-              eq(providerActionBindings.status, "approved"),
-              eq(providerActionBindings.bindingRevision, before),
+          };
+        },
+      );
+      executionHandlesToRelease = null;
+      return result;
+    } catch (e) {
+      if (executionHandlesToRelease !== null) {
+        const { providerActionService } = await import("./provider-action-service.js");
+        await providerActionService
+          .releasePolicyReservationHandles(executionHandlesToRelease)
+          .catch((releaseError) =>
+            console.error(
+              "[provider-approval] failed to release rolled-back reservation:",
+              releaseError,
             ),
           );
-        await tx
-          .update(intents)
-          .set({ executedBy: RESUME_ACTOR, updatedAt: nowTs })
-          .where(eq(intents.id, binding.intentId));
-
-        const payload = buildAuditPayload(binding, queue, {
-          approvalActorUserId: approverUserId,
-          resumeActor: RESUME_ACTOR,
-          bindingRevisionBefore: before,
-          bindingRevisionAfter: after,
-          fromStatus: "approved",
-          toStatus: "execution_ready",
-          reasonCode: "provider_resume_ready",
-          resumeAttemptId,
-        });
-        await this.hook("beforeAudit");
-        await append({
-          tenantId: binding.tenantId,
-          actorType: "system",
-          actorId: RESUME_ACTOR,
-          action: "provider.resume.ready",
-          resourceType: "provider_action",
-          resourceId: binding.intentId,
-          metadata: payload as unknown as Record<string, unknown>,
-          ipAddress: input.ipAddress ?? null,
-          userAgent: input.userAgent ?? null,
-          requestId: input.requestId ?? null,
-        });
-        await this.hook("afterAudit");
-
-        // PR4 mint-within-tx (spec §2.3): mint the v2 execution authorization in
-        // the SAME audited transaction as the resume, so approved→execution_ready
-        // →authorization-minted is one atomic step (removes an extra crash window,
-        // F01). Idempotent by exec_auth_nonces_intent_uniq (K22). Fails closed if
-        // STEWARD_EXECUTION_AUTH_SECRET is absent (X7, P49). The whole resume tx
-        // rolls back on mint failure, so a resume never lands execution_ready
-        // without a mintable authorization.
-        await this.hook("beforeMint");
-        await mintProviderExecutionAuthorizationWithinTx(
-          tx as unknown as Parameters<typeof mintProviderExecutionAuthorizationWithinTx>[0],
-          append as unknown as Parameters<typeof mintProviderExecutionAuthorizationWithinTx>[1],
-          {
-            intentId: binding.intentId,
-            tenantId: binding.tenantId,
-            workspaceId: binding.workspaceId,
-            actorAgentId: binding.actorAgentId,
-            providerAccountId: binding.providerAccountId,
-            operationId: binding.operationId,
-            operationRevision: binding.operationRevision,
-            requestHash: binding.requestHash,
-            actionDigest: binding.actionDigest,
-            approvalId: queue.id,
-            approvalCommitmentHash: queue.approvalCommitmentHash ?? "",
-            approvalCommitment: queue.approvalCommitment as unknown as ProviderApprovalCommitmentV1,
-            canonicalActionBytes: new Uint8Array(binding.canonicalActionBytes as Uint8Array),
-            requestId: input.requestId ?? null,
-          },
-          {
-            now: nowTs,
-            ipAddress: input.ipAddress ?? null,
-            userAgent: input.userAgent ?? null,
-            requestId: input.requestId ?? null,
-            hooks: {
-              beforeInsert: () => this.hook("beforeMintInsert"),
-              beforeAudit: () => this.hook("beforeMintAudit"),
-            },
-          },
-        );
-        await this.hook("afterMint");
-
-        return {
-          ok: true,
-          httpStatus: 200,
-          id: binding.intentId,
-          status: "execution_ready",
-          version: after,
-          requestHash: binding.requestHash,
-          actionDigest: binding.actionDigest,
-          resumeAttemptId,
-        };
-      });
-    } catch (e) {
+      }
       if (e instanceof AuditUnavailableError)
         return fail("EVIDENCE_REQUIRED_AUDIT_UNAVAILABLE", 503);
       // v2 mint fail-closed: absent HMAC key rolls back the whole resume tx so
@@ -2128,6 +2232,7 @@ class ProviderApprovalService {
         if (e.code === "EXEC_AUTH_KEY_UNAVAILABLE") return fail("EXEC_AUTH_KEY_UNAVAILABLE", 503);
         return fail("RESUME_PREPARATION_FAILED", 503);
       }
+      console.error("[provider-approval] resume preparation failed:", e);
       return fail("RESUME_PREPARATION_FAILED", 503);
     }
   }

--- a/packages/api/src/services/provider-approval.ts
+++ b/packages/api/src/services/provider-approval.ts
@@ -1957,7 +1957,11 @@ class ProviderApprovalService {
                   requestHash: binding.requestHash,
                   actionDigest: binding.actionDigest,
                   operationId: binding.operationId,
+                  operationKey: (
+                    queue.approvalCommitment as unknown as ProviderApprovalCommitmentV1
+                  ).operation.key,
                   policyRevisionHash: binding.executionPolicyRevisionHash,
+                  decidedAt: binding.executionPolicyEvaluatedAt.toISOString(),
                 },
               )
             ) {

--- a/packages/api/src/services/provider-reservation-reconciliation-scheduler.ts
+++ b/packages/api/src/services/provider-reservation-reconciliation-scheduler.ts
@@ -1,0 +1,37 @@
+import { providerActionService } from "./provider-action-service";
+
+const DEFAULT_INTERVAL_MS = 15_000;
+
+function configuredInterval(): number {
+  const parsed = Number(process.env.STEWARD_PROVIDER_RESERVATION_SWEEP_INTERVAL_MS);
+  return Number.isSafeInteger(parsed) && parsed >= 1_000 ? parsed : DEFAULT_INTERVAL_MS;
+}
+
+/**
+ * Starts the autonomous C2 reservation reconciler. The immediate startup pass
+ * closes the crash-before-drain gap; later passes retry transient Redis/DB
+ * failures. The service records attempts, backoff, the last error and a
+ * needs_attention state after sustained failure, so recovery never disappears
+ * into an unobservable catch.
+ */
+export function startProviderReservationReconciliationScheduler(): () => void {
+  if (process.env.STEWARD_PROVIDER_RESERVATION_SWEEPER === "false") return () => {};
+  let running = false;
+  const tick = () => {
+    if (running) return;
+    running = true;
+    void providerActionService
+      .reconcilePolicyReservations()
+      .then((count) => {
+        if (count > 0) console.log(`[provider-reservations] reconciled ${count} reservation(s)`);
+      })
+      .catch((error) => console.error("[provider-reservations] sweep failed:", error))
+      .finally(() => {
+        running = false;
+      });
+  };
+  const timer = setInterval(tick, configuredInterval());
+  timer.unref?.();
+  tick();
+  return () => clearInterval(timer);
+}

--- a/packages/db/drizzle/0084_provider_action_reservation_reconciliation.sql
+++ b/packages/db/drizzle/0084_provider_action_reservation_reconciliation.sql
@@ -1,0 +1,149 @@
+-- #240: crash-durable policy reservation handles and reconciliation state.
+--
+-- Handles are persisted in the same transaction as the provider binding. They
+-- are frozen thereafter. The C2 sweeper may only CAS `pending` to a terminal
+-- reconciliation state after the idempotent Redis settle/release succeeds.
+
+ALTER TABLE "provider_action_bindings"
+  ADD COLUMN "policy_reservation_handles" jsonb,
+  ADD COLUMN "reservation_reconciliation_state" varchar(24) NOT NULL DEFAULT 'not_required',
+  ADD COLUMN "reservation_reconciled_at" timestamptz,
+  ADD COLUMN "reservation_reconciliation_attempts" integer NOT NULL DEFAULT 0,
+  ADD COLUMN "reservation_reconciliation_next_retry_at" timestamptz,
+  ADD COLUMN "reservation_reconciliation_last_error" text;
+--> statement-breakpoint
+
+ALTER TABLE "provider_action_bindings"
+  ADD CONSTRAINT "provider_action_bindings_reservation_state_chk" CHECK (
+    (
+      "reservation_reconciliation_state" = 'not_required'
+      AND "policy_reservation_handles" IS NULL
+      AND "reservation_reconciled_at" IS NULL
+      AND "reservation_reconciliation_attempts" = 0
+      AND "reservation_reconciliation_next_retry_at" IS NULL
+      AND "reservation_reconciliation_last_error" IS NULL
+    ) OR (
+      "reservation_reconciliation_state" IN ('pending','needs_attention')
+      AND "policy_reservation_handles" IS NOT NULL
+      AND "reservation_reconciled_at" IS NULL
+      AND "reservation_reconciliation_attempts" >= 0
+    ) OR (
+      "reservation_reconciliation_state" IN ('settled','released')
+      AND "policy_reservation_handles" IS NOT NULL
+      AND "reservation_reconciled_at" IS NOT NULL
+    )
+  );
+--> statement-breakpoint
+
+ALTER TABLE "provider_action_bindings"
+  ADD CONSTRAINT "provider_action_bindings_reservation_handles_chk" CHECK (
+    "policy_reservation_handles" IS NULL OR (
+      jsonb_typeof("policy_reservation_handles") = 'object'
+      AND "policy_reservation_handles"->>'schemaVersion' = 'steward.provider-policy-reservations.v1'
+      AND ("policy_reservation_handles"->>'generation')::integer > 0
+      AND "policy_reservation_handles"->>'phase' IN ('decision','execution')
+      AND jsonb_typeof("policy_reservation_handles"->'cumulativeSpend') = 'array'
+      AND (
+        jsonb_array_length("policy_reservation_handles"->'cumulativeSpend') > 0
+        OR (
+          "policy_reservation_handles" ? 'windowedInvoke'
+          AND "policy_reservation_handles"->'windowedInvoke' <> 'null'::jsonb
+        )
+      )
+    )
+  );
+--> statement-breakpoint
+
+CREATE INDEX "provider_action_bindings_reservation_pending_idx"
+  ON "provider_action_bindings" ("tenant_id", "created_at")
+  WHERE "reservation_reconciliation_state" IN ('pending','needs_attention');
+--> statement-breakpoint
+
+-- Replace the latest (0082) guard body. The handle document deliberately stays
+-- in the frozen projection. Only the state/timestamp are mutable, and only the
+-- one-way pending -> settled|released transition is legal.
+CREATE OR REPLACE FUNCTION steward_provider_action_binding_guard() RETURNS trigger LANGUAGE plpgsql AS $fn$
+DECLARE
+  frozen_old jsonb;
+  frozen_new jsonb;
+  mutable text[] := ARRAY[
+    'status','binding_revision','approval_actor_user_id','approval_queue_id',
+    'approval_commitment_hash','approved_at','denied_at','expired_at','stale_at',
+    'stale_reason_code','resume_actor','resume_attempt_id','resume_validated_at','updated_at',
+    'reservation_reconciliation_state','reservation_reconciled_at',
+    'reservation_reconciliation_attempts','reservation_reconciliation_next_retry_at',
+    'reservation_reconciliation_last_error'
+  ];
+  col text;
+BEGIN
+  frozen_old := to_jsonb(OLD);
+  frozen_new := to_jsonb(NEW);
+  FOREACH col IN ARRAY mutable LOOP
+    frozen_old := frozen_old - col;
+    frozen_new := frozen_new - col;
+  END LOOP;
+  IF frozen_old IS DISTINCT FROM frozen_new THEN
+    RAISE EXCEPTION 'provider_action_bindings frozen column mutated' USING ERRCODE = '23514';
+  END IF;
+
+  IF OLD.reservation_reconciliation_state IS DISTINCT FROM NEW.reservation_reconciliation_state THEN
+    IF NOT (
+      (
+        OLD.reservation_reconciliation_state IN ('pending','needs_attention')
+        AND NEW.reservation_reconciliation_state IN ('settled','released')
+        AND OLD.reservation_reconciled_at IS NULL
+        AND NEW.reservation_reconciled_at IS NOT NULL
+        AND NEW.reservation_reconciliation_attempts = OLD.reservation_reconciliation_attempts
+      ) OR (
+        OLD.reservation_reconciliation_state = 'pending'
+        AND NEW.reservation_reconciliation_state = 'needs_attention'
+        AND OLD.reservation_reconciled_at IS NULL
+        AND NEW.reservation_reconciled_at IS NULL
+        AND NEW.reservation_reconciliation_attempts = OLD.reservation_reconciliation_attempts + 1
+      )
+    ) THEN
+      RAISE EXCEPTION 'illegal provider_action_bindings reservation reconciliation transition'
+        USING ERRCODE = '23514';
+    END IF;
+  ELSIF OLD.reservation_reconciled_at IS DISTINCT FROM NEW.reservation_reconciled_at THEN
+    RAISE EXCEPTION 'provider_action_bindings reservation timestamp changed without reconciliation'
+      USING ERRCODE = '23514';
+  END IF;
+
+  IF NEW.reservation_reconciliation_attempts < OLD.reservation_reconciliation_attempts OR
+     NEW.reservation_reconciliation_attempts > OLD.reservation_reconciliation_attempts + 1 THEN
+    RAISE EXCEPTION 'illegal provider_action_bindings reservation retry counter transition'
+      USING ERRCODE = '23514';
+  END IF;
+
+  IF OLD.status IS DISTINCT FROM NEW.status THEN
+    IF (OLD.status = 'allowed_stub' AND NEW.status IN ('stub_succeeded','stub_failed')) THEN
+      IF NEW.binding_revision IS DISTINCT FROM OLD.binding_revision THEN
+        RAISE EXCEPTION 'provider_action_bindings stub transition must not change binding_revision'
+          USING ERRCODE = '23514';
+      END IF;
+    ELSIF (
+      (OLD.status = 'pending_approval' AND NEW.status IN ('approved','approval_denied','approval_expired','approval_stale')) OR
+      (OLD.status = 'approved'         AND NEW.status IN ('execution_ready','approval_expired','approval_stale')) OR
+      (OLD.status = 'execution_ready'  AND NEW.status = 'executing') OR
+      (OLD.status = 'execution_ready'  AND NEW.status = 'failed') OR
+      (OLD.status = 'executing'        AND NEW.status IN ('succeeded','failed','outcome_unknown')) OR
+      (OLD.status = 'outcome_unknown'  AND NEW.status IN ('succeeded','failed'))
+    ) THEN
+      IF NEW.binding_revision IS DISTINCT FROM OLD.binding_revision + 1 THEN
+        RAISE EXCEPTION 'provider_action_bindings binding_revision must increment by exactly one on transition'
+          USING ERRCODE = '23514';
+      END IF;
+    ELSE
+      RAISE EXCEPTION 'illegal provider_action_bindings status transition'
+        USING ERRCODE = '23514';
+    END IF;
+  ELSE
+    IF NEW.binding_revision IS DISTINCT FROM OLD.binding_revision THEN
+      RAISE EXCEPTION 'provider_action_bindings binding_revision changed without a status transition'
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+  RETURN NEW;
+END $fn$;
+--> statement-breakpoint

--- a/packages/db/drizzle/0084_provider_action_reservation_reconciliation.sql
+++ b/packages/db/drizzle/0084_provider_action_reservation_reconciliation.sql
@@ -32,8 +32,14 @@ CREATE TABLE "provider_action_reservation_generations" (
 );
 --> statement-breakpoint
 CREATE INDEX "provider_action_reservation_generations_due_idx"
-  ON "provider_action_reservation_generations" ("state","next_retry_at","created_at")
-  WHERE "state" IN ('pending','needs_attention');
+  ON "provider_action_reservation_generations"
+    (COALESCE("next_retry_at", '-infinity'::timestamptz), "created_at", "id")
+  WHERE "state" = 'pending' OR ("state" = 'needs_attention' AND "next_retry_at" IS NOT NULL);
+--> statement-breakpoint
+CREATE INDEX "provider_action_reservation_generations_tenant_due_idx"
+  ON "provider_action_reservation_generations"
+    ("tenant_id", COALESCE("next_retry_at", '-infinity'::timestamptz), "created_at", "id")
+  WHERE "state" = 'pending' OR ("state" = 'needs_attention' AND "next_retry_at" IS NOT NULL);
 --> statement-breakpoint
 CREATE OR REPLACE FUNCTION steward_provider_reservation_generation_guard()
 RETURNS trigger LANGUAGE plpgsql AS $fn$
@@ -55,4 +61,96 @@ END $fn$;
 CREATE TRIGGER "provider_action_reservation_generation_guard"
 BEFORE UPDATE ON "provider_action_reservation_generations"
 FOR EACH ROW EXECUTE FUNCTION steward_provider_reservation_generation_guard();
+--> statement-breakpoint
+
+-- #239: the current execute-time policy decision is immutable evidence written
+-- in the same transaction that consumes approval and mints authorization.
+ALTER TABLE "provider_action_bindings"
+  ADD COLUMN "execution_policy_decision_id" uuid,
+  ADD COLUMN "execution_policy_revision_hash" varchar(71),
+  ADD COLUMN "execution_policy_decision" jsonb,
+  ADD COLUMN "execution_policy_decision_hash" varchar(71),
+  ADD COLUMN "execution_policy_evaluated_at" timestamptz;
+--> statement-breakpoint
+ALTER TABLE "provider_action_bindings" ADD CONSTRAINT "provider_action_bindings_execution_policy_shape_chk" CHECK (
+  ("execution_policy_decision_id" IS NULL AND "execution_policy_revision_hash" IS NULL AND
+   "execution_policy_decision" IS NULL AND "execution_policy_decision_hash" IS NULL AND
+   "execution_policy_evaluated_at" IS NULL) OR
+  ("execution_policy_decision_id" IS NOT NULL AND "execution_policy_revision_hash" ~ '^sha256:[0-9a-f]{64}$' AND
+   "execution_policy_decision" IS NOT NULL AND "execution_policy_decision_hash" ~ '^sha256:[0-9a-f]{64}$' AND
+   "execution_policy_evaluated_at" IS NOT NULL)
+);
+--> statement-breakpoint
+
+-- Extend the existing frozen projection narrowly: execution-policy evidence may
+-- be populated exactly once, only on approved -> execution_ready. It remains
+-- frozen across every later dispatch/outcome transition.
+CREATE OR REPLACE FUNCTION steward_provider_action_binding_guard() RETURNS trigger LANGUAGE plpgsql AS $fn$
+DECLARE
+  frozen_old jsonb;
+  frozen_new jsonb;
+  mutable text[] := ARRAY[
+    'status','binding_revision','approval_actor_user_id','approval_queue_id',
+    'approval_commitment_hash','approved_at','denied_at','expired_at','stale_at',
+    'stale_reason_code','resume_actor','resume_attempt_id','resume_validated_at','updated_at',
+    'execution_policy_decision_id','execution_policy_revision_hash','execution_policy_decision',
+    'execution_policy_decision_hash','execution_policy_evaluated_at'
+  ];
+  col text;
+  execution_policy_changed boolean;
+BEGIN
+  frozen_old := to_jsonb(OLD);
+  frozen_new := to_jsonb(NEW);
+  FOREACH col IN ARRAY mutable LOOP
+    frozen_old := frozen_old - col;
+    frozen_new := frozen_new - col;
+  END LOOP;
+  IF frozen_old IS DISTINCT FROM frozen_new THEN
+    RAISE EXCEPTION 'provider_action_bindings frozen column mutated' USING ERRCODE = '23514';
+  END IF;
+
+  execution_policy_changed :=
+    OLD.execution_policy_decision_id IS DISTINCT FROM NEW.execution_policy_decision_id OR
+    OLD.execution_policy_revision_hash IS DISTINCT FROM NEW.execution_policy_revision_hash OR
+    OLD.execution_policy_decision IS DISTINCT FROM NEW.execution_policy_decision OR
+    OLD.execution_policy_decision_hash IS DISTINCT FROM NEW.execution_policy_decision_hash OR
+    OLD.execution_policy_evaluated_at IS DISTINCT FROM NEW.execution_policy_evaluated_at;
+  IF execution_policy_changed AND NOT (
+    OLD.status = 'approved' AND NEW.status = 'execution_ready' AND
+    OLD.execution_policy_decision_id IS NULL AND
+    NEW.execution_policy_decision_id IS NOT NULL AND
+    NEW.execution_policy_revision_hash IS NOT NULL AND
+    NEW.execution_policy_decision IS NOT NULL AND
+    NEW.execution_policy_decision_hash IS NOT NULL AND
+    NEW.execution_policy_evaluated_at IS NOT NULL
+  ) THEN
+    RAISE EXCEPTION 'illegal provider execution policy mutation' USING ERRCODE = '23514';
+  END IF;
+
+  IF OLD.status IS DISTINCT FROM NEW.status THEN
+    IF OLD.status = 'allowed_stub' AND NEW.status IN ('stub_succeeded','stub_failed') THEN
+      IF NEW.binding_revision IS DISTINCT FROM OLD.binding_revision THEN
+        RAISE EXCEPTION 'provider_action_bindings stub transition must not change binding_revision'
+          USING ERRCODE = '23514';
+      END IF;
+    ELSIF (
+      (OLD.status = 'pending_approval' AND NEW.status IN ('approved','approval_denied','approval_expired','approval_stale')) OR
+      (OLD.status = 'approved' AND NEW.status IN ('execution_ready','approval_expired','approval_stale')) OR
+      (OLD.status = 'execution_ready' AND NEW.status IN ('executing','failed')) OR
+      (OLD.status = 'executing' AND NEW.status IN ('succeeded','failed','outcome_unknown')) OR
+      (OLD.status = 'outcome_unknown' AND NEW.status IN ('succeeded','failed'))
+    ) THEN
+      IF NEW.binding_revision IS DISTINCT FROM OLD.binding_revision + 1 THEN
+        RAISE EXCEPTION 'provider_action_bindings binding_revision must increment by exactly one on transition'
+          USING ERRCODE = '23514';
+      END IF;
+    ELSE
+      RAISE EXCEPTION 'illegal provider_action_bindings status transition' USING ERRCODE = '23514';
+    END IF;
+  ELSIF NEW.binding_revision IS DISTINCT FROM OLD.binding_revision THEN
+    RAISE EXCEPTION 'provider_action_bindings binding_revision changed without a status transition'
+      USING ERRCODE = '23514';
+  END IF;
+  RETURN NEW;
+END $fn$;
 --> statement-breakpoint

--- a/packages/db/drizzle/0084_provider_action_reservation_reconciliation.sql
+++ b/packages/db/drizzle/0084_provider_action_reservation_reconciliation.sql
@@ -1,149 +1,58 @@
--- #240: crash-durable policy reservation handles and reconciliation state.
---
--- Handles are persisted in the same transaction as the provider binding. They
--- are frozen thereafter. The C2 sweeper may only CAS `pending` to a terminal
--- reconciliation state after the idempotent Redis settle/release succeeds.
-
-ALTER TABLE "provider_action_bindings"
-  ADD COLUMN "policy_reservation_handles" jsonb,
-  ADD COLUMN "reservation_reconciliation_state" varchar(24) NOT NULL DEFAULT 'not_required',
-  ADD COLUMN "reservation_reconciled_at" timestamptz,
-  ADD COLUMN "reservation_reconciliation_attempts" integer NOT NULL DEFAULT 0,
-  ADD COLUMN "reservation_reconciliation_next_retry_at" timestamptz,
-  ADD COLUMN "reservation_reconciliation_last_error" text;
+-- #240: append-only, generation-specific provider policy reservations.
+CREATE TABLE "provider_action_reservation_generations" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "intent_id" varchar(64) NOT NULL,
+  "tenant_id" varchar(64) NOT NULL,
+  "generation" integer NOT NULL,
+  "phase" varchar(16) NOT NULL,
+  "handles" jsonb NOT NULL,
+  "state" varchar(24) NOT NULL DEFAULT 'pending',
+  "attempts" integer NOT NULL DEFAULT 0,
+  "next_retry_at" timestamptz,
+  "last_error" text,
+  "claimed_at" timestamptz,
+  "claimed_by" uuid,
+  "reconciled_at" timestamptz,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT "provider_action_reservation_generations_intent_fk"
+    FOREIGN KEY ("tenant_id","intent_id") REFERENCES "intents"("tenant_id","id") ON DELETE CASCADE,
+  CONSTRAINT "provider_action_reservation_generations_intent_gen_uniq" UNIQUE ("intent_id","generation"),
+  CONSTRAINT "provider_action_reservation_generations_shape_chk" CHECK (
+    "generation" > 0 AND "phase" IN ('decision','execution')
+    AND "state" IN ('pending','needs_attention','settled','released') AND "attempts" >= 0
+    AND jsonb_typeof("handles") = 'object'
+    AND "handles"->>'schemaVersion' = 'steward.provider-policy-reservations.v1'
+    AND ("handles"->>'generation')::integer = "generation" AND "handles"->>'phase' = "phase"
+    AND jsonb_typeof("handles"->'cumulativeSpend') = 'array'
+    AND (jsonb_array_length("handles"->'cumulativeSpend') > 0 OR
+      ("handles" ? 'windowedInvoke' AND "handles"->'windowedInvoke' <> 'null'::jsonb))
+    AND (("state" IN ('pending','needs_attention') AND "reconciled_at" IS NULL) OR
+      ("state" IN ('settled','released') AND "reconciled_at" IS NOT NULL))
+  )
+);
 --> statement-breakpoint
-
-ALTER TABLE "provider_action_bindings"
-  ADD CONSTRAINT "provider_action_bindings_reservation_state_chk" CHECK (
-    (
-      "reservation_reconciliation_state" = 'not_required'
-      AND "policy_reservation_handles" IS NULL
-      AND "reservation_reconciled_at" IS NULL
-      AND "reservation_reconciliation_attempts" = 0
-      AND "reservation_reconciliation_next_retry_at" IS NULL
-      AND "reservation_reconciliation_last_error" IS NULL
-    ) OR (
-      "reservation_reconciliation_state" IN ('pending','needs_attention')
-      AND "policy_reservation_handles" IS NOT NULL
-      AND "reservation_reconciled_at" IS NULL
-      AND "reservation_reconciliation_attempts" >= 0
-    ) OR (
-      "reservation_reconciliation_state" IN ('settled','released')
-      AND "policy_reservation_handles" IS NOT NULL
-      AND "reservation_reconciled_at" IS NOT NULL
-    )
-  );
+CREATE INDEX "provider_action_reservation_generations_due_idx"
+  ON "provider_action_reservation_generations" ("state","next_retry_at","created_at")
+  WHERE "state" IN ('pending','needs_attention');
 --> statement-breakpoint
-
-ALTER TABLE "provider_action_bindings"
-  ADD CONSTRAINT "provider_action_bindings_reservation_handles_chk" CHECK (
-    "policy_reservation_handles" IS NULL OR (
-      jsonb_typeof("policy_reservation_handles") = 'object'
-      AND "policy_reservation_handles"->>'schemaVersion' = 'steward.provider-policy-reservations.v1'
-      AND ("policy_reservation_handles"->>'generation')::integer > 0
-      AND "policy_reservation_handles"->>'phase' IN ('decision','execution')
-      AND jsonb_typeof("policy_reservation_handles"->'cumulativeSpend') = 'array'
-      AND (
-        jsonb_array_length("policy_reservation_handles"->'cumulativeSpend') > 0
-        OR (
-          "policy_reservation_handles" ? 'windowedInvoke'
-          AND "policy_reservation_handles"->'windowedInvoke' <> 'null'::jsonb
-        )
-      )
-    )
-  );
---> statement-breakpoint
-
-CREATE INDEX "provider_action_bindings_reservation_pending_idx"
-  ON "provider_action_bindings" ("tenant_id", "created_at")
-  WHERE "reservation_reconciliation_state" IN ('pending','needs_attention');
---> statement-breakpoint
-
--- Replace the latest (0082) guard body. The handle document deliberately stays
--- in the frozen projection. Only the state/timestamp are mutable, and only the
--- one-way pending -> settled|released transition is legal.
-CREATE OR REPLACE FUNCTION steward_provider_action_binding_guard() RETURNS trigger LANGUAGE plpgsql AS $fn$
-DECLARE
-  frozen_old jsonb;
-  frozen_new jsonb;
-  mutable text[] := ARRAY[
-    'status','binding_revision','approval_actor_user_id','approval_queue_id',
-    'approval_commitment_hash','approved_at','denied_at','expired_at','stale_at',
-    'stale_reason_code','resume_actor','resume_attempt_id','resume_validated_at','updated_at',
-    'reservation_reconciliation_state','reservation_reconciled_at',
-    'reservation_reconciliation_attempts','reservation_reconciliation_next_retry_at',
-    'reservation_reconciliation_last_error'
-  ];
-  col text;
+CREATE OR REPLACE FUNCTION steward_provider_reservation_generation_guard()
+RETURNS trigger LANGUAGE plpgsql AS $fn$
 BEGIN
-  frozen_old := to_jsonb(OLD);
-  frozen_new := to_jsonb(NEW);
-  FOREACH col IN ARRAY mutable LOOP
-    frozen_old := frozen_old - col;
-    frozen_new := frozen_new - col;
-  END LOOP;
-  IF frozen_old IS DISTINCT FROM frozen_new THEN
-    RAISE EXCEPTION 'provider_action_bindings frozen column mutated' USING ERRCODE = '23514';
+  IF OLD.intent_id IS DISTINCT FROM NEW.intent_id OR OLD.tenant_id IS DISTINCT FROM NEW.tenant_id OR
+     OLD.generation IS DISTINCT FROM NEW.generation OR OLD.phase IS DISTINCT FROM NEW.phase OR
+     OLD.handles IS DISTINCT FROM NEW.handles OR OLD.created_at IS DISTINCT FROM NEW.created_at THEN
+    RAISE EXCEPTION 'provider reservation generation identity mutated' USING ERRCODE='23514';
   END IF;
-
-  IF OLD.reservation_reconciliation_state IS DISTINCT FROM NEW.reservation_reconciliation_state THEN
-    IF NOT (
-      (
-        OLD.reservation_reconciliation_state IN ('pending','needs_attention')
-        AND NEW.reservation_reconciliation_state IN ('settled','released')
-        AND OLD.reservation_reconciled_at IS NULL
-        AND NEW.reservation_reconciled_at IS NOT NULL
-        AND NEW.reservation_reconciliation_attempts = OLD.reservation_reconciliation_attempts
-      ) OR (
-        OLD.reservation_reconciliation_state = 'pending'
-        AND NEW.reservation_reconciliation_state = 'needs_attention'
-        AND OLD.reservation_reconciled_at IS NULL
-        AND NEW.reservation_reconciled_at IS NULL
-        AND NEW.reservation_reconciliation_attempts = OLD.reservation_reconciliation_attempts + 1
-      )
-    ) THEN
-      RAISE EXCEPTION 'illegal provider_action_bindings reservation reconciliation transition'
-        USING ERRCODE = '23514';
-    END IF;
-  ELSIF OLD.reservation_reconciled_at IS DISTINCT FROM NEW.reservation_reconciled_at THEN
-    RAISE EXCEPTION 'provider_action_bindings reservation timestamp changed without reconciliation'
-      USING ERRCODE = '23514';
+  IF OLD.state IN ('settled','released') THEN
+    RAISE EXCEPTION 'terminal provider reservation generation mutated' USING ERRCODE='23514';
   END IF;
-
-  IF NEW.reservation_reconciliation_attempts < OLD.reservation_reconciliation_attempts OR
-     NEW.reservation_reconciliation_attempts > OLD.reservation_reconciliation_attempts + 1 THEN
-    RAISE EXCEPTION 'illegal provider_action_bindings reservation retry counter transition'
-      USING ERRCODE = '23514';
-  END IF;
-
-  IF OLD.status IS DISTINCT FROM NEW.status THEN
-    IF (OLD.status = 'allowed_stub' AND NEW.status IN ('stub_succeeded','stub_failed')) THEN
-      IF NEW.binding_revision IS DISTINCT FROM OLD.binding_revision THEN
-        RAISE EXCEPTION 'provider_action_bindings stub transition must not change binding_revision'
-          USING ERRCODE = '23514';
-      END IF;
-    ELSIF (
-      (OLD.status = 'pending_approval' AND NEW.status IN ('approved','approval_denied','approval_expired','approval_stale')) OR
-      (OLD.status = 'approved'         AND NEW.status IN ('execution_ready','approval_expired','approval_stale')) OR
-      (OLD.status = 'execution_ready'  AND NEW.status = 'executing') OR
-      (OLD.status = 'execution_ready'  AND NEW.status = 'failed') OR
-      (OLD.status = 'executing'        AND NEW.status IN ('succeeded','failed','outcome_unknown')) OR
-      (OLD.status = 'outcome_unknown'  AND NEW.status IN ('succeeded','failed'))
-    ) THEN
-      IF NEW.binding_revision IS DISTINCT FROM OLD.binding_revision + 1 THEN
-        RAISE EXCEPTION 'provider_action_bindings binding_revision must increment by exactly one on transition'
-          USING ERRCODE = '23514';
-      END IF;
-    ELSE
-      RAISE EXCEPTION 'illegal provider_action_bindings status transition'
-        USING ERRCODE = '23514';
-    END IF;
-  ELSE
-    IF NEW.binding_revision IS DISTINCT FROM OLD.binding_revision THEN
-      RAISE EXCEPTION 'provider_action_bindings binding_revision changed without a status transition'
-        USING ERRCODE = '23514';
-    END IF;
+  IF NEW.attempts < OLD.attempts OR NEW.attempts > OLD.attempts + 1 THEN
+    RAISE EXCEPTION 'illegal provider reservation attempt transition' USING ERRCODE='23514';
   END IF;
   RETURN NEW;
 END $fn$;
+--> statement-breakpoint
+CREATE TRIGGER "provider_action_reservation_generation_guard"
+BEFORE UPDATE ON "provider_action_reservation_generations"
+FOR EACH ROW EXECUTE FUNCTION steward_provider_reservation_generation_guard();
 --> statement-breakpoint

--- a/packages/db/drizzle/0084_provider_action_reservation_reconciliation.sql
+++ b/packages/db/drizzle/0084_provider_action_reservation_reconciliation.sql
@@ -82,6 +82,58 @@ ALTER TABLE "provider_action_bindings" ADD CONSTRAINT "provider_action_bindings_
 );
 --> statement-breakpoint
 
+-- Rollout fence for #239. 0084 introduces execute-time policy evidence, so an
+-- older API binary must not be allowed to create a fresh execution_ready row
+-- without it while a rolling deployment is in progress. NOT VALID deliberately
+-- avoids rejecting historical executing/terminal rows whose provider outcome
+-- may already be unknown, while PostgreSQL still enforces the check for every
+-- new insert/update immediately.
+ALTER TABLE "provider_action_bindings" ADD CONSTRAINT "provider_action_bindings_execution_policy_ready_chk" CHECK (
+  "status" NOT IN ('execution_ready','executing') OR "execution_policy_decision_id" IS NOT NULL
+) NOT VALID;
+--> statement-breakpoint
+
+-- Existing execution_ready rows were authorized before execute-time cap
+-- reservation existed. Never bless them retroactively: revoke an unclaimed v2
+-- nonce, terminalize the binding/intent, and enqueue durable recovery evidence.
+-- A data-modifying CTE keeps the rollout disposition atomic. Already executing
+-- rows are intentionally left alone because an external effect may have begun;
+-- the NOT VALID fence above prevents any new evidence-less execution arm.
+WITH legacy AS MATERIALIZED (
+  SELECT "tenant_id", "intent_id"
+  FROM "provider_action_bindings"
+  WHERE "status" = 'execution_ready' AND "execution_policy_decision_id" IS NULL
+), revoked AS (
+  UPDATE "execution_authorization_nonces" n
+  SET "status" = 'revoked'
+  FROM legacy l
+  WHERE n."tenant_id" = l."tenant_id" AND n."intent_id" = l."intent_id"
+    AND n."version" = 2 AND n."status" = 'active' AND n."dispatch_state" = 'none'
+), transitioned AS (
+  UPDATE "provider_action_bindings" b
+  SET "status" = 'failed', "binding_revision" = b."binding_revision" + 1, "updated_at" = now()
+  FROM legacy l
+  WHERE b."tenant_id" = l."tenant_id" AND b."intent_id" = l."intent_id"
+    AND b."status" = 'execution_ready' AND b."execution_policy_decision_id" IS NULL
+  RETURNING b."tenant_id", b."intent_id"
+), failed_intents AS (
+  UPDATE "intents" i
+  SET "status" = 'failed', "failed_by" = 'steward-system', "failed_at" = now(), "updated_at" = now()
+  FROM transitioned t
+  WHERE i."tenant_id" = t."tenant_id" AND i."id" = t."intent_id"
+)
+INSERT INTO "provider_action_audit_outbox"
+  ("tenant_id", "intent_id", "action", "resource_type", "resource_id", "metadata")
+SELECT t."tenant_id", t."intent_id", 'provider.execution.legacy_policy_evidence_rejected',
+       'provider_action', t."intent_id",
+       jsonb_build_object(
+         'schemaVersion', 'steward.provider-execution-rollout.v1',
+         'intentId', t."intent_id",
+         'reasonCode', 'EXECUTION_POLICY_EVIDENCE_MISSING'
+       )
+FROM transitioned t;
+--> statement-breakpoint
+
 -- Extend the existing frozen projection narrowly: execution-policy evidence may
 -- be populated exactly once, only on approved -> execution_ready. It remains
 -- frozen across every later dispatch/outcome transition.

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -449,6 +449,13 @@
       "when": 1784313600000,
       "tag": "0083_provider_approval_quorum",
       "breakpoints": true
+    },
+    {
+      "idx": 84,
+      "version": "7",
+      "when": 1784399999000,
+      "tag": "0084_provider_action_reservation_reconciliation",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/__tests__/provider-action-bindings-migration.test.ts
+++ b/packages/db/src/__tests__/provider-action-bindings-migration.test.ts
@@ -68,6 +68,9 @@ function bindingInsert(overrides: Partial<Record<string, string>> = {}): string 
     policyRevHash: `'${ACCESSHASH}'`,
     policyDecision: `'{}'::jsonb`,
     policyDecisionHash: `'${ACCESSHASH}'`,
+    reservationHandles: "NULL",
+    reservationState: "'not_required'",
+    reservationReconciledAt: "NULL",
     ...overrides,
   } as Record<string, string>;
   return `
@@ -78,6 +81,7 @@ function bindingInsert(overrides: Partial<Record<string, string>> = {}): string 
       access_decision_id, access_effect, access_reason_code, dependency_revisions,
       access_decision, access_decision_hash,
       policy_decision_id, policy_effect, policy_revision_hash, policy_decision, policy_decision_hash,
+      policy_reservation_handles, reservation_reconciliation_state, reservation_reconciled_at,
       status
     ) VALUES (
       '${v.intentId}','ta','${IDS.wsA}','agent-a','${IDS.acctA}',
@@ -86,6 +90,7 @@ function bindingInsert(overrides: Partial<Record<string, string>> = {}): string 
       '${IDS.accessDecision}','${v.accessEffect}','provider_access_allowed','{}'::jsonb,
       '{}'::jsonb,'${ACCESSHASH}',
       ${v.policyId},'${v.policyEffect}',${v.policyRevHash},${v.policyDecision},${v.policyDecisionHash},
+      ${v.reservationHandles},${v.reservationState},${v.reservationReconciledAt},
       '${v.status}'
     );
   `;
@@ -217,6 +222,56 @@ describe("0080 provider_action_bindings migration", () => {
       threw = true;
     }
     expect(threw).toBe(true);
+    await client.close();
+  });
+
+  test("0084 freezes handles and permits only pending -> terminal reconciliation CAS", async () => {
+    const client = new PGlite("memory://");
+    await applyAll(client);
+    await seed(client);
+    const handles = `'{"schemaVersion":"steward.provider-policy-reservations.v1","generation":1,"phase":"decision","cumulativeSpend":[{"stream":{"agentId":"agent-a","scope":"agent","scopeKey":"","currency":"USD"},"reservationId":"r1","amount":7}],"windowedInvoke":null}'::jsonb`;
+    await client.exec(
+      bindingInsert({ reservationHandles: handles, reservationState: "'pending'" }),
+    );
+
+    await expect(
+      client.exec(
+        `UPDATE provider_action_bindings
+         SET policy_reservation_handles = jsonb_set(policy_reservation_handles, '{cumulativeSpend,0,amount}', '8')
+         WHERE intent_id='intent-1'`,
+      ),
+    ).rejects.toBeDefined();
+    await client.exec(
+      `UPDATE provider_action_bindings
+       SET reservation_reconciliation_state='settled', reservation_reconciled_at=now()
+       WHERE intent_id='intent-1' AND reservation_reconciliation_state='pending'`,
+    );
+    const row = await client.query<{
+      reservation_reconciliation_state: string;
+      reservation_reconciled_at: Date | null;
+    }>(
+      `SELECT reservation_reconciliation_state,reservation_reconciled_at
+       FROM provider_action_bindings WHERE intent_id='intent-1'`,
+    );
+    expect(row.rows[0].reservation_reconciliation_state).toBe("settled");
+    expect(row.rows[0].reservation_reconciled_at).not.toBeNull();
+    await expect(
+      client.exec(
+        `UPDATE provider_action_bindings SET reservation_reconciliation_state='released'
+         WHERE intent_id='intent-1'`,
+      ),
+    ).rejects.toBeDefined();
+    await client.close();
+  });
+
+  test("0084 rejects terminal reconciliation without a timestamp", async () => {
+    const client = new PGlite("memory://");
+    await applyAll(client);
+    await seed(client);
+    const handles = `'{"schemaVersion":"steward.provider-policy-reservations.v1","generation":2,"phase":"execution","cumulativeSpend":[],"windowedInvoke":{"agentId":"agent-a","operationKey":"github.issue.list","reservationId":"r2"}}'::jsonb`;
+    await expect(
+      client.exec(bindingInsert({ reservationHandles: handles, reservationState: "'released'" })),
+    ).rejects.toBeDefined();
     await client.close();
   });
 

--- a/packages/db/src/__tests__/provider-action-bindings-migration.test.ts
+++ b/packages/db/src/__tests__/provider-action-bindings-migration.test.ts
@@ -68,9 +68,6 @@ function bindingInsert(overrides: Partial<Record<string, string>> = {}): string 
     policyRevHash: `'${ACCESSHASH}'`,
     policyDecision: `'{}'::jsonb`,
     policyDecisionHash: `'${ACCESSHASH}'`,
-    reservationHandles: "NULL",
-    reservationState: "'not_required'",
-    reservationReconciledAt: "NULL",
     ...overrides,
   } as Record<string, string>;
   return `
@@ -80,18 +77,14 @@ function bindingInsert(overrides: Partial<Record<string, string>> = {}): string 
       action_digest, request_envelope, request_hash, idempotency_key_hash, safe_summary,
       access_decision_id, access_effect, access_reason_code, dependency_revisions,
       access_decision, access_decision_hash,
-      policy_decision_id, policy_effect, policy_revision_hash, policy_decision, policy_decision_hash,
-      policy_reservation_handles, reservation_reconciliation_state, reservation_reconciled_at,
-      status
+      policy_decision_id, policy_effect, policy_revision_hash, policy_decision, policy_decision_hash, status
     ) VALUES (
       '${v.intentId}','ta','${IDS.wsA}','agent-a','${IDS.acctA}',
       '${IDS.opA}',7,'github.provider-action.v1', decode('7b7d','hex'),
       '${DIGEST}','{}'::jsonb,'${REQHASH}','${IDEMHASH}','{}'::jsonb,
       '${IDS.accessDecision}','${v.accessEffect}','provider_access_allowed','{}'::jsonb,
       '{}'::jsonb,'${ACCESSHASH}',
-      ${v.policyId},'${v.policyEffect}',${v.policyRevHash},${v.policyDecision},${v.policyDecisionHash},
-      ${v.reservationHandles},${v.reservationState},${v.reservationReconciledAt},
-      '${v.status}'
+      ${v.policyId},'${v.policyEffect}',${v.policyRevHash},${v.policyDecision},${v.policyDecisionHash},'${v.status}'
     );
   `;
 }
@@ -225,40 +218,36 @@ describe("0080 provider_action_bindings migration", () => {
     await client.close();
   });
 
-  test("0084 freezes handles and permits only pending -> terminal reconciliation CAS", async () => {
+  test("0084 uses append-only generations and permits only pending -> terminal reconciliation CAS", async () => {
     const client = new PGlite("memory://");
     await applyAll(client);
     await seed(client);
     const handles = `'{"schemaVersion":"steward.provider-policy-reservations.v1","generation":1,"phase":"decision","cumulativeSpend":[{"stream":{"agentId":"agent-a","scope":"agent","scopeKey":"","currency":"USD"},"reservationId":"r1","amount":7}],"windowedInvoke":null}'::jsonb`;
-    await client.exec(
-      bindingInsert({ reservationHandles: handles, reservationState: "'pending'" }),
-    );
+    await client.exec(bindingInsert());
+    await client.exec(`INSERT INTO provider_action_reservation_generations
+      (intent_id,tenant_id,generation,phase,handles) VALUES ('intent-1','ta',1,'decision',${handles})`);
 
     await expect(
       client.exec(
-        `UPDATE provider_action_bindings
-         SET policy_reservation_handles = jsonb_set(policy_reservation_handles, '{cumulativeSpend,0,amount}', '8')
-         WHERE intent_id='intent-1'`,
+        `UPDATE provider_action_reservation_generations
+         SET handles = jsonb_set(handles, '{cumulativeSpend,0,amount}', '8') WHERE intent_id='intent-1'`,
       ),
     ).rejects.toBeDefined();
     await client.exec(
-      `UPDATE provider_action_bindings
-       SET reservation_reconciliation_state='settled', reservation_reconciled_at=now()
-       WHERE intent_id='intent-1' AND reservation_reconciliation_state='pending'`,
+      `UPDATE provider_action_reservation_generations SET state='settled', reconciled_at=now()
+       WHERE intent_id='intent-1' AND state='pending'`,
     );
     const row = await client.query<{
-      reservation_reconciliation_state: string;
-      reservation_reconciled_at: Date | null;
+      state: string;
+      reconciled_at: Date | null;
     }>(
-      `SELECT reservation_reconciliation_state,reservation_reconciled_at
-       FROM provider_action_bindings WHERE intent_id='intent-1'`,
+      `SELECT state,reconciled_at FROM provider_action_reservation_generations WHERE intent_id='intent-1'`,
     );
-    expect(row.rows[0].reservation_reconciliation_state).toBe("settled");
-    expect(row.rows[0].reservation_reconciled_at).not.toBeNull();
+    expect(row.rows[0].state).toBe("settled");
+    expect(row.rows[0].reconciled_at).not.toBeNull();
     await expect(
       client.exec(
-        `UPDATE provider_action_bindings SET reservation_reconciliation_state='released'
-         WHERE intent_id='intent-1'`,
+        `UPDATE provider_action_reservation_generations SET state='released' WHERE intent_id='intent-1'`,
       ),
     ).rejects.toBeDefined();
     await client.close();
@@ -269,8 +258,11 @@ describe("0080 provider_action_bindings migration", () => {
     await applyAll(client);
     await seed(client);
     const handles = `'{"schemaVersion":"steward.provider-policy-reservations.v1","generation":2,"phase":"execution","cumulativeSpend":[],"windowedInvoke":{"agentId":"agent-a","operationKey":"github.issue.list","reservationId":"r2"}}'::jsonb`;
+    await client.exec(bindingInsert());
     await expect(
-      client.exec(bindingInsert({ reservationHandles: handles, reservationState: "'released'" })),
+      client.exec(`INSERT INTO provider_action_reservation_generations
+      (intent_id,tenant_id,generation,phase,handles,state)
+      VALUES ('intent-1','ta',2,'execution',${handles},'released')`),
     ).rejects.toBeDefined();
     await client.close();
   });

--- a/packages/db/src/__tests__/provider-action-bindings-migration.test.ts
+++ b/packages/db/src/__tests__/provider-action-bindings-migration.test.ts
@@ -27,6 +27,11 @@ async function applyAll(client: PGlite) {
   for (const file of files) await applyFile(client, file);
 }
 
+async function applyThrough(client: PGlite, last: string) {
+  const files = (await readdir(migrations)).filter((f) => f.endsWith(".sql") && f <= last).sort();
+  for (const file of files) await applyFile(client, file);
+}
+
 const IDS = {
   wsA: "00000000-0000-4000-8000-000000000101",
   wsB: "00000000-0000-4000-8000-000000000102",
@@ -264,6 +269,93 @@ describe("0080 provider_action_bindings migration", () => {
       (intent_id,tenant_id,generation,phase,handles,state)
       VALUES ('intent-1','ta',2,'execution',${handles},'released')`),
     ).rejects.toBeDefined();
+    await client.close();
+  });
+
+  test("0084 fail-closes a legacy execution_ready row and enqueues rollout evidence", async () => {
+    const client = new PGlite("memory://");
+    await applyThrough(client, "0083_provider_approval_quorum.sql");
+    await seed(client);
+    for (const statement of [
+      `INSERT INTO secrets(id,tenant_id,name,ciphertext,iv,auth_tag,salt,version)
+       VALUES ('00000000-0000-4000-8000-000000000601','ta','legacy','x','x','x','x',1)`,
+      `INSERT INTO secret_routes(id,tenant_id,secret_id,host_pattern,inject_as,inject_key)
+       VALUES ('00000000-0000-4000-8000-000000000602','ta',
+       '00000000-0000-4000-8000-000000000601','api.github.com','header','authorization')`,
+      `UPDATE provider_accounts SET credential_secret_id='00000000-0000-4000-8000-000000000601',
+       credential_version=1 WHERE id='${IDS.acctA}'`,
+      `UPDATE provider_operations SET secret_route_id='00000000-0000-4000-8000-000000000602'
+       WHERE id='${IDS.opA}'`,
+      `UPDATE secret_routes SET authority_mode='governed_v2', provider_operation_id='${IDS.opA}'
+       WHERE id='00000000-0000-4000-8000-000000000602'`,
+    ]) {
+      await client.exec(statement);
+    }
+    await client.exec(`UPDATE intents SET status='authorized' WHERE id='intent-1'`);
+    await client.exec(`
+      INSERT INTO provider_action_bindings(
+        intent_id,tenant_id,workspace_id,actor_agent_id,provider_account_id,
+        operation_id,operation_revision,canonical_profile,canonical_action_bytes,
+        action_digest,request_envelope,request_hash,idempotency_key_hash,safe_summary,
+        access_decision_id,access_effect,access_reason_code,dependency_revisions,
+        access_decision,access_decision_hash,policy_decision_id,policy_effect,
+        policy_revision_hash,policy_decision,policy_decision_hash,status,binding_revision,
+        approval_queue_id,approval_commitment_hash,approval_actor_user_id,approved_at,
+        resume_actor,resume_attempt_id,resume_validated_at
+      ) VALUES (
+        'intent-1','ta','${IDS.wsA}','agent-a','${IDS.acctA}','${IDS.opA}',1,
+        'github.provider-action.v1',decode('7b7d','hex'),'${DIGEST}','{}'::jsonb,
+        '${REQHASH}','${IDEMHASH}','{}'::jsonb,'${IDS.accessDecision}','allow',
+        'provider_access_allowed','{}'::jsonb,'{}'::jsonb,'${ACCESSHASH}',
+        '${IDS.policyDecision}','approval_required','${ACCESSHASH}','{}'::jsonb,
+        '${ACCESSHASH}','execution_ready',2,'00000000-0000-4000-8000-000000000501',
+        '${ACCESSHASH}','${IDS.owner}',now(),'steward-system',
+        '00000000-0000-4000-8000-000000000502',now()
+      )
+    `);
+    await client.exec(`
+      INSERT INTO execution_authorization_nonces(
+        authorization_id,request_id,tenant_id,agent_id,capability,backend,payload_digest,
+        policy_revision_hash,approval_id,nonce,signature,idempotency_key,status,issued_at,
+        expires_at,version,execution_id,intent_id,workspace_id,provider_account_id,
+        operation_id,operation_revision,request_hash,action_digest,grant_dependency_hash,
+        route_id,route_revision,secret_id,secret_version,provider_idempotency_key,
+        commitment_hash,key_id,dispatch_state
+      ) VALUES (
+        'legacy-auth','intent-1','ta','agent-a','credential.inject_http','credential-proxy',
+        '${DIGEST.slice(7)}','${ACCESSHASH.slice(7)}','00000000-0000-4000-8000-000000000501',
+        'legacy-nonce','legacy-signature','legacy-provider-idem','active',now(),now()+interval '5 minutes',
+        2,'legacy-execution','intent-1','${IDS.wsA}','${IDS.acctA}','${IDS.opA}',1,
+        '${REQHASH}','${DIGEST}','${ACCESSHASH}','00000000-0000-4000-8000-000000000602',
+        2,'00000000-0000-4000-8000-000000000601',1,'legacy-provider-idem',
+        '${ACCESSHASH}','v2-1','none'
+      )
+    `);
+    await applyFile(client, "0084_provider_action_reservation_reconciliation.sql");
+
+    const binding = await client.query<{ status: string; binding_revision: number }>(
+      `SELECT status,binding_revision FROM provider_action_bindings WHERE intent_id='intent-1'`,
+    );
+    expect(binding.rows[0]).toMatchObject({ status: "failed", binding_revision: 3 });
+    const intent = await client.query<{ status: string }>(
+      `SELECT status FROM intents WHERE id='intent-1'`,
+    );
+    expect(intent.rows[0].status).toBe("failed");
+    const nonce = await client.query<{ status: string }>(
+      `SELECT status FROM execution_authorization_nonces WHERE intent_id='intent-1'`,
+    );
+    expect(nonce.rows[0].status).toBe("revoked");
+    const evidence = await client.query<{ action: string }>(
+      `SELECT action FROM provider_action_audit_outbox WHERE intent_id='intent-1'`,
+    );
+    expect(evidence.rows.map((row) => row.action)).toContain(
+      "provider.execution.legacy_policy_evidence_rejected",
+    );
+    const fence = await client.query<{ convalidated: boolean }>(
+      `SELECT convalidated FROM pg_constraint
+       WHERE conname='provider_action_bindings_execution_policy_ready_chk'`,
+    );
+    expect(fence.rows).toEqual([{ convalidated: false }]);
     await client.close();
   });
 

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -2288,9 +2288,15 @@ export const providerActionReservationGenerations = pgTable(
       table.generation,
     ),
     dueIdx: index("provider_action_reservation_generations_due_idx").on(
-      table.state,
       table.nextRetryAt,
       table.createdAt,
+      table.id,
+    ),
+    tenantDueIdx: index("provider_action_reservation_generations_tenant_due_idx").on(
+      table.tenantId,
+      table.nextRetryAt,
+      table.createdAt,
+      table.id,
     ),
   }),
 );

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -2163,6 +2163,41 @@ export const providerActionBindings = pgTable(
     policyDecision: jsonb("policy_decision").$type<Record<string, unknown>>(),
     policyDecisionHash: varchar("policy_decision_hash", { length: 71 }),
 
+    // #240: immutable Redis reservation identities captured in the same commit
+    // as the authority decision. Only the reconciliation state/timestamp below
+    // may advance after insert; the raw handles remain frozen by migration 0084.
+    policyReservationHandles: jsonb("policy_reservation_handles").$type<{
+      schemaVersion: "steward.provider-policy-reservations.v1";
+      generation: number;
+      phase: "decision" | "execution";
+      cumulativeSpend: Array<{
+        stream: {
+          agentId: string;
+          scope: "operation" | "agent" | "grant";
+          scopeKey: string;
+          currency: string;
+        };
+        reservationId: string;
+        amount: number;
+      }>;
+      windowedInvoke: {
+        agentId: string;
+        operationKey: string;
+        reservationId: string;
+      } | null;
+    }>(),
+    reservationReconciliationState: varchar("reservation_reconciliation_state", { length: 24 })
+      .notNull()
+      .default("not_required"),
+    reservationReconciledAt: timestamp("reservation_reconciled_at", { withTimezone: true }),
+    reservationReconciliationAttempts: integer("reservation_reconciliation_attempts")
+      .notNull()
+      .default(0),
+    reservationReconciliationNextRetryAt: timestamp("reservation_reconciliation_next_retry_at", {
+      withTimezone: true,
+    }),
+    reservationReconciliationLastError: text("reservation_reconciliation_last_error"),
+
     status: varchar("status", { length: 32 }).notNull(),
     // ── PR3 approval lifecycle columns (0081) ──
     // Mutable only via the PR3 transition trigger; binding_revision increments by

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -2171,6 +2171,11 @@ export const providerActionBindings = pgTable(
     executionPolicyDecision: jsonb("execution_policy_decision").$type<Record<string, unknown>>(),
     executionPolicyDecisionHash: varchar("execution_policy_decision_hash", { length: 71 }),
     executionPolicyEvaluatedAt: timestamp("execution_policy_evaluated_at", { withTimezone: true }),
+    // 0084 also installs the raw-SQL NOT VALID rollout fence
+    // provider_action_bindings_execution_policy_ready_chk. It is intentionally
+    // not modeled here because Drizzle cannot express NOT VALID: PostgreSQL
+    // enforces it for every new execution_ready/executing row while tolerating
+    // historical in-flight executions whose outcome may already be unknown.
 
     status: varchar("status", { length: 32 }).notNull(),
     // ── PR3 approval lifecycle columns (0081) ──

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -2163,40 +2163,14 @@ export const providerActionBindings = pgTable(
     policyDecision: jsonb("policy_decision").$type<Record<string, unknown>>(),
     policyDecisionHash: varchar("policy_decision_hash", { length: 71 }),
 
-    // #240: immutable Redis reservation identities captured in the same commit
-    // as the authority decision. Only the reconciliation state/timestamp below
-    // may advance after insert; the raw handles remain frozen by migration 0084.
-    policyReservationHandles: jsonb("policy_reservation_handles").$type<{
-      schemaVersion: "steward.provider-policy-reservations.v1";
-      generation: number;
-      phase: "decision" | "execution";
-      cumulativeSpend: Array<{
-        stream: {
-          agentId: string;
-          scope: "operation" | "agent" | "grant";
-          scopeKey: string;
-          currency: string;
-        };
-        reservationId: string;
-        amount: number;
-      }>;
-      windowedInvoke: {
-        agentId: string;
-        operationKey: string;
-        reservationId: string;
-      } | null;
-    }>(),
-    reservationReconciliationState: varchar("reservation_reconciliation_state", { length: 24 })
-      .notNull()
-      .default("not_required"),
-    reservationReconciledAt: timestamp("reservation_reconciled_at", { withTimezone: true }),
-    reservationReconciliationAttempts: integer("reservation_reconciliation_attempts")
-      .notNull()
-      .default(0),
-    reservationReconciliationNextRetryAt: timestamp("reservation_reconciliation_next_retry_at", {
-      withTimezone: true,
-    }),
-    reservationReconciliationLastError: text("reservation_reconciliation_last_error"),
+    // #239: authoritative execute-time policy evidence. Unlike the approval-time
+    // decision above, this snapshot is derived from current rules immediately
+    // before approval consumption and authorization mint.
+    executionPolicyDecisionId: uuid("execution_policy_decision_id"),
+    executionPolicyRevisionHash: varchar("execution_policy_revision_hash", { length: 71 }),
+    executionPolicyDecision: jsonb("execution_policy_decision").$type<Record<string, unknown>>(),
+    executionPolicyDecisionHash: varchar("execution_policy_decision_hash", { length: 71 }),
+    executionPolicyEvaluatedAt: timestamp("execution_policy_evaluated_at", { withTimezone: true }),
 
     status: varchar("status", { length: 32 }).notNull(),
     // ── PR3 approval lifecycle columns (0081) ──
@@ -2282,6 +2256,44 @@ export const providerActionBindings = pgTable(
 );
 
 export type ProviderActionBinding = typeof providerActionBindings.$inferSelect;
+
+/** Append-only reservation identities. Mutable reconciliation metadata is
+ * isolated from the immutable generation payload and claimed with SKIP LOCKED. */
+export const providerActionReservationGenerations = pgTable(
+  "provider_action_reservation_generations",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    intentId: varchar("intent_id", { length: 64 }).notNull(),
+    tenantId: varchar("tenant_id", { length: 64 }).notNull(),
+    generation: integer("generation").notNull(),
+    phase: varchar("phase", { length: 16 }).notNull(),
+    handles: jsonb("handles").$type<Record<string, unknown>>().notNull(),
+    state: varchar("state", { length: 24 }).notNull().default("pending"),
+    attempts: integer("attempts").notNull().default(0),
+    nextRetryAt: timestamp("next_retry_at", { withTimezone: true }),
+    lastError: text("last_error"),
+    claimedAt: timestamp("claimed_at", { withTimezone: true }),
+    claimedBy: uuid("claimed_by"),
+    reconciledAt: timestamp("reconciled_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    intentFk: foreignKey({
+      columns: [table.tenantId, table.intentId],
+      foreignColumns: [intents.tenantId, intents.id],
+      name: "provider_action_reservation_generations_intent_fk",
+    }).onDelete("cascade"),
+    generationUnique: uniqueIndex("provider_action_reservation_generations_intent_gen_uniq").on(
+      table.intentId,
+      table.generation,
+    ),
+    dueIdx: index("provider_action_reservation_generations_due_idx").on(
+      table.state,
+      table.nextRetryAt,
+      table.createdAt,
+    ),
+  }),
+);
 
 // Transactional required-audit outbox (spec §6.4). A provider-action decision
 // inserts its REQUIRED audit intent here in the SAME transaction as the binding;

--- a/packages/proxy/src/__tests__/governed-execution.test.ts
+++ b/packages/proxy/src/__tests__/governed-execution.test.ts
@@ -284,6 +284,22 @@ async function seedExecutionReady(opts: SeedNonceOpts = {}) {
     expiresAt: expiresAt.toISOString(),
   };
   const approvalCommitmentHash = computeApprovalCommitmentHash(approvalCommitment);
+  const executionPolicyDecision = {
+    schemaVersion: "steward.provider-policy-decision.v1",
+    decisionId: randomUUID(),
+    intentId,
+    requestHash,
+    actionDigest,
+    operationId: IDS.operation,
+    operationKey: "issues.list",
+    effect: "approval_required",
+    reasonCodes: ["APPROVAL_REQUIRED"],
+    policyResults: [],
+    policyRevisionHash,
+    evaluatorVersion: "provider-action.v1",
+    decidedAt: now.toISOString(),
+  };
+  const executionPolicyDecisionHash = sha256HexPrefixed(jcsStringify(executionPolicyDecision));
 
   const commitment = buildProviderExecutionCommitmentV2({
     approval: approvalCommitment,
@@ -350,6 +366,11 @@ async function seedExecutionReady(opts: SeedNonceOpts = {}) {
     resumeActor: "steward-system",
     resumeAttemptId: randomUUID(),
     resumeValidatedAt: now,
+    executionPolicyDecisionId: executionPolicyDecision.decisionId,
+    executionPolicyRevisionHash: policyRevisionHash,
+    executionPolicyDecision,
+    executionPolicyDecisionHash,
+    executionPolicyEvaluatedAt: now,
   });
   await db.insert(approvalQueue).values({
     id: approvalId,
@@ -650,6 +671,53 @@ describe("PR4 dispatchGovernedExecution claim + dispatch", () => {
     expect(res.ok).toBe(false);
     expect(res.code).toBe("EXEC_AUTH_NOT_READY");
     expect(res.httpStatus).toBe(409);
+  });
+
+  it("#239 rollout: a signed legacy nonce cannot dispatch without execute-time policy evidence", async () => {
+    const { intentId, authorizationId } = await seedExecutionReady();
+    const db = getDb();
+    // Simulate a pre-0084 row. The live schema prevents creating this shape, so
+    // temporarily remove only the two rollout guards, mutate it, then restore
+    // both before calling the production boundary.
+    await db.execute(
+      sql`ALTER TABLE provider_action_bindings DROP CONSTRAINT provider_action_bindings_execution_policy_ready_chk`,
+    );
+    await db.execute(
+      sql`DROP TRIGGER provider_action_bindings_immutable ON provider_action_bindings`,
+    );
+    await db
+      .update(providerActionBindings)
+      .set({
+        executionPolicyDecisionId: null,
+        executionPolicyRevisionHash: null,
+        executionPolicyDecision: null,
+        executionPolicyDecisionHash: null,
+        executionPolicyEvaluatedAt: null,
+      })
+      .where(eq(providerActionBindings.intentId, intentId));
+    await db.execute(sql`
+      CREATE TRIGGER provider_action_bindings_immutable
+      BEFORE UPDATE ON provider_action_bindings
+      FOR EACH ROW EXECUTE FUNCTION steward_provider_action_binding_guard()
+    `);
+    await db.execute(sql`
+      ALTER TABLE provider_action_bindings
+      ADD CONSTRAINT provider_action_bindings_execution_policy_ready_chk CHECK (
+        status NOT IN ('execution_ready','executing') OR execution_policy_decision_id IS NOT NULL
+      ) NOT VALID
+    `);
+
+    const res = await dispatchGovernedExecution(intentId, IDS.tenant);
+    expect(res).toMatchObject({
+      ok: false,
+      code: "EXEC_AUTH_POLICY_EVIDENCE_MISSING",
+      httpStatus: 409,
+    });
+    const [nonce] = await db
+      .select({ status: executionAuthorizationNonces.status })
+      .from(executionAuthorizationNonces)
+      .where(eq(executionAuthorizationNonces.authorizationId, authorizationId));
+    expect(nonce.status).toBe("active");
   });
 
   it("happy path: gate permits, claim consumes exactly once, one dispatch", async () => {

--- a/packages/proxy/src/__tests__/governed-execution.test.ts
+++ b/packages/proxy/src/__tests__/governed-execution.test.ts
@@ -720,6 +720,35 @@ describe("PR4 dispatchGovernedExecution claim + dispatch", () => {
     expect(nonce.status).toBe("active");
   });
 
+  it("#239 rollout: corrupt execute-time policy evidence never claims or dispatches", async () => {
+    const { intentId, authorizationId } = await seedExecutionReady();
+    const db = getDb();
+    await db.execute(
+      sql`DROP TRIGGER provider_action_bindings_immutable ON provider_action_bindings`,
+    );
+    await db
+      .update(providerActionBindings)
+      .set({ executionPolicyDecisionHash: `sha256:${"0".repeat(64)}` })
+      .where(eq(providerActionBindings.intentId, intentId));
+    await db.execute(sql`
+      CREATE TRIGGER provider_action_bindings_immutable
+      BEFORE UPDATE ON provider_action_bindings
+      FOR EACH ROW EXECUTE FUNCTION steward_provider_action_binding_guard()
+    `);
+
+    expect(await dispatchGovernedExecution(intentId, IDS.tenant)).toMatchObject({
+      ok: false,
+      code: "EXEC_AUTH_POLICY_EVIDENCE_MISSING",
+      httpStatus: 409,
+    });
+    const [nonce] = await db
+      .select({ status: executionAuthorizationNonces.status })
+      .from(executionAuthorizationNonces)
+      .where(eq(executionAuthorizationNonces.authorizationId, authorizationId));
+    expect(nonce.status).toBe("active");
+    expect(captured).toBeNull();
+  });
+
   it("happy path: gate permits, claim consumes exactly once, one dispatch", async () => {
     const { intentId, authorizationId } = await seedExecutionReady();
     const res = await dispatchGovernedExecution(intentId, IDS.tenant);

--- a/packages/proxy/src/handlers/governed-execution.ts
+++ b/packages/proxy/src/handlers/governed-execution.ts
@@ -52,6 +52,7 @@ import {
   observeNonceClaimContention,
   type ProviderApprovalCommitmentV1,
   serializeCanonicalOutboundQuery,
+  sha256HexPrefixed,
   strictParseJson,
   verifyProviderExecutionCommitmentV2,
 } from "@stwd/shared";
@@ -71,6 +72,7 @@ export type GovernedDispatchCode =
   | "EXEC_AUTH_ACCOUNT_DISABLED"
   | "EXEC_AUTH_KEY_UNAVAILABLE"
   | "EXEC_AUTH_SIGNATURE_INVALID"
+  | "EXEC_AUTH_POLICY_EVIDENCE_MISSING"
   | "EXEC_DISPATCH_OUTCOME_UNKNOWN"
   | "EXEC_DISPATCH_UPSTREAM_ERROR"
   | "EXEC_AUDIT_UNAVAILABLE"
@@ -146,6 +148,11 @@ interface LoadedGovernedExecution {
   dispatchState: string;
   authStatus: string;
   bindingStatus: string;
+  executionPolicyDecisionId: string | null;
+  executionPolicyRevisionHash: string | null;
+  executionPolicyDecision: Record<string, unknown> | null;
+  executionPolicyDecisionHash: string | null;
+  executionPolicyEvaluatedAt: string | null;
   issuedAt: string;
   expiresAt: string;
 }
@@ -232,6 +239,11 @@ async function loadGovernedExecution(
     dispatchState: (nonce.dispatchState as string) ?? "none",
     authStatus: nonce.status,
     bindingStatus: binding.status,
+    executionPolicyDecisionId: binding.executionPolicyDecisionId,
+    executionPolicyRevisionHash: binding.executionPolicyRevisionHash,
+    executionPolicyDecision: binding.executionPolicyDecision,
+    executionPolicyDecisionHash: binding.executionPolicyDecisionHash,
+    executionPolicyEvaluatedAt: binding.executionPolicyEvaluatedAt?.toISOString() ?? null,
     issuedAt: (nonce.issuedAt as Date).toISOString(),
     expiresAt: (nonce.expiresAt as Date).toISOString(),
   };
@@ -290,6 +302,28 @@ export async function dispatchGovernedExecution(
     return deny("EXEC_TERMINAL_STATE", 409, intentId, {
       executionId: loaded.executionId,
       dispatchState: loaded.dispatchState,
+    });
+  }
+
+  // #239 rollout boundary: a pre-0084 execution_ready row may carry a validly
+  // signed legacy nonce but never have reserved the current cumulative cap.
+  // Require and verify the execute-time decision before the claim/decrypt edge.
+  const executionPolicy = loaded.executionPolicyDecision;
+  if (
+    !loaded.executionPolicyDecisionId ||
+    !loaded.executionPolicyRevisionHash ||
+    !executionPolicy ||
+    !loaded.executionPolicyDecisionHash ||
+    !loaded.executionPolicyEvaluatedAt ||
+    executionPolicy.decisionId !== loaded.executionPolicyDecisionId ||
+    executionPolicy.intentId !== loaded.intentId ||
+    executionPolicy.requestHash !== loaded.requestHash ||
+    executionPolicy.actionDigest !== loaded.actionDigest ||
+    executionPolicy.policyRevisionHash !== loaded.executionPolicyRevisionHash ||
+    sha256HexPrefixed(jcsStringify(executionPolicy)) !== loaded.executionPolicyDecisionHash
+  ) {
+    return deny("EXEC_AUTH_POLICY_EVIDENCE_MISSING", 409, intentId, {
+      executionId: loaded.executionId,
     });
   }
 
@@ -496,6 +530,10 @@ export async function dispatchGovernedExecution(
             eq(providerActionBindings.tenantId, tenantId),
             eq(providerActionBindings.intentId, loaded.intentId),
             eq(providerActionBindings.status, "execution_ready"),
+            eq(
+              providerActionBindings.executionPolicyDecisionHash,
+              loaded.executionPolicyDecisionHash as string,
+            ),
           ),
         )
         .returning({ intentId: providerActionBindings.intentId });

--- a/packages/proxy/src/handlers/governed-execution.ts
+++ b/packages/proxy/src/handlers/governed-execution.ts
@@ -52,9 +52,9 @@ import {
   observeNonceClaimContention,
   type ProviderApprovalCommitmentV1,
   serializeCanonicalOutboundQuery,
-  sha256HexPrefixed,
   strictParseJson,
   verifyProviderExecutionCommitmentV2,
+  verifyProviderExecutionPolicyEvidence,
 } from "@stwd/shared";
 import { and, eq, sql } from "drizzle-orm";
 import type { Context } from "hono";
@@ -315,12 +315,14 @@ export async function dispatchGovernedExecution(
     !executionPolicy ||
     !loaded.executionPolicyDecisionHash ||
     !loaded.executionPolicyEvaluatedAt ||
-    executionPolicy.decisionId !== loaded.executionPolicyDecisionId ||
-    executionPolicy.intentId !== loaded.intentId ||
-    executionPolicy.requestHash !== loaded.requestHash ||
-    executionPolicy.actionDigest !== loaded.actionDigest ||
-    executionPolicy.policyRevisionHash !== loaded.executionPolicyRevisionHash ||
-    sha256HexPrefixed(jcsStringify(executionPolicy)) !== loaded.executionPolicyDecisionHash
+    !verifyProviderExecutionPolicyEvidence(executionPolicy, loaded.executionPolicyDecisionHash, {
+      decisionId: loaded.executionPolicyDecisionId,
+      intentId: loaded.intentId,
+      requestHash: loaded.requestHash,
+      actionDigest: loaded.actionDigest,
+      operationId: loaded.operationId,
+      policyRevisionHash: loaded.executionPolicyRevisionHash,
+    })
   ) {
     return deny("EXEC_AUTH_POLICY_EVIDENCE_MISSING", 409, intentId, {
       executionId: loaded.executionId,

--- a/packages/proxy/src/handlers/governed-execution.ts
+++ b/packages/proxy/src/handlers/governed-execution.ts
@@ -321,7 +321,9 @@ export async function dispatchGovernedExecution(
       requestHash: loaded.requestHash,
       actionDigest: loaded.actionDigest,
       operationId: loaded.operationId,
+      operationKey: loaded.approvalCommitment.operation.key,
       policyRevisionHash: loaded.executionPolicyRevisionHash,
+      decidedAt: loaded.executionPolicyEvaluatedAt,
     })
   ) {
     return deny("EXEC_AUTH_POLICY_EVIDENCE_MISSING", 409, intentId, {

--- a/packages/redis/src/__tests__/cumulative-spend-tracker.test.ts
+++ b/packages/redis/src/__tests__/cumulative-spend-tracker.test.ts
@@ -98,6 +98,34 @@ describeRedis("reserveCumulativeSpend - REAL concurrency single-winner", () => {
   });
 });
 
+describeRedis("stable reservation identity - crash retry semantics", () => {
+  test("parallel retries debit once and a now-denied orphan is atomically reclaimed", async () => {
+    const stable = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const input = {
+      stream: STREAM,
+      caps: [{ windowSeconds: 3600, max: 10 }],
+      amount: 4,
+      reservationId: stable,
+    };
+    const [a, b] = await Promise.all([
+      reserveCumulativeSpend(input),
+      reserveCumulativeSpend(input),
+    ]);
+    expect(a).toMatchObject({ ok: true, priorSums: [0], reservationId: stable });
+    expect(b).toMatchObject({ ok: true, priorSums: [0], reservationId: stable });
+    expect(await getCumulativeSpendSum({ ...STREAM, windowSeconds: 3600 })).toEqual({ sum: 4 });
+
+    // If current authoritative policy no longer admits the pre-commit orphan,
+    // retry denies and removes that exact member in the same Lua operation.
+    const denied = await reserveCumulativeSpend({
+      ...input,
+      caps: [{ windowSeconds: 3600, max: 3 }],
+    });
+    expect(denied).toMatchObject({ ok: false, priorSums: [0] });
+    expect(await getCumulativeSpendSum({ ...STREAM, windowSeconds: 3600 })).toEqual({ sum: 0 });
+  });
+});
+
 describeRedis("multi-cap on one stream (codex P2: counted once, any breach rejects)", () => {
   test("an invoke governed by a 1h AND 24h cap is counted once; a 1h breach rejects", async () => {
     // Fill the 1h window to 90 while the 24h window has plenty of room.

--- a/packages/redis/src/__tests__/cumulative-spend-tracker.test.ts
+++ b/packages/redis/src/__tests__/cumulative-spend-tracker.test.ts
@@ -232,6 +232,9 @@ describeRedis("fail closed", () => {
     const caps = [{ windowSeconds: 3600, max: 5_000_000 }];
     await expect(reserveCumulativeSpend({ stream: STREAM, caps, amount: -1 })).rejects.toThrow();
     await expect(reserveCumulativeSpend({ stream: STREAM, caps, amount: 1.5 })).rejects.toThrow();
+    await expect(
+      reserveCumulativeSpend({ stream: STREAM, caps, amount: Number.MAX_SAFE_INTEGER + 1 }),
+    ).rejects.toThrow();
     await expect(reserveCumulativeSpend({ stream: STREAM, caps: [], amount: 1 })).rejects.toThrow();
     await expect(
       reserveCumulativeSpend({

--- a/packages/redis/src/cumulative-spend-tracker.ts
+++ b/packages/redis/src/cumulative-spend-tracker.ts
@@ -102,6 +102,10 @@ export interface ReserveCumulativeSpendInput {
   amount: number;
   /** evaluation time in ms; injectable for tests. */
   now?: number;
+  /** Optional caller-stable identity. This makes a durable workflow retry the
+   * same reservation instead of double-debiting after a process death between
+   * Redis admission and its database commit. Must be opaque and delimiter-safe. */
+  reservationId?: string;
 }
 
 export interface ReserveCumulativeSpendResult {
@@ -143,6 +147,7 @@ local ttl = tonumber(ARGV[4])
 local member = ARGV[5]
 local nCaps = tonumber(ARGV[6])
 redis.call('ZREMRANGEBYSCORE', KEYS[1], 0, retentionCutoff)
+local existingScore = redis.call('ZSCORE', KEYS[1], member)
 local out = {1}
 local base = 6
 for c = 1, nCaps do
@@ -152,6 +157,12 @@ for c = 1, nCaps do
   local sum = 0
   for i = 1, #members do
     local m = members[i]
+    -- A retry with a stable reservation identity evaluates the projected total
+    -- exactly once: exclude its already-present member from the prior sum, then
+    -- add the requested amount below just like the first attempt.
+    if m == member then
+      -- no-op
+    else
     local firstBar = string.find(m, '|', 1, true)
     if firstBar then
       local rest = string.sub(m, firstBar + 1)
@@ -163,15 +174,20 @@ for c = 1, nCaps do
     else
       return {-1}
     end
+    end
   end
   out[c + 1] = sum
   if (sum + amount) > maxv then
     out[1] = 0
   end
 end
-if out[1] == 1 then
+if out[1] == 1 and not existingScore then
   redis.call('ZADD', KEYS[1], now, member)
   redis.call('PEXPIRE', KEYS[1], ttl)
+elseif out[1] == 0 and existingScore then
+  -- A current-policy retry no longer admits this previously orphaned member.
+  -- Remove it atomically with the denial so it cannot pin phantom budget.
+  redis.call('ZREM', KEYS[1], member)
 end
 return out
 `;
@@ -254,7 +270,15 @@ export async function reserveCumulativeSpend(
 
   const now = input.now ?? Date.now();
   const retentionCutoff = now - RETENTION_MS;
-  const reservationId = `${now}:${nextSeq()}`;
+  if (
+    input.reservationId !== undefined &&
+    (input.reservationId.length === 0 ||
+      input.reservationId.length > 200 ||
+      input.reservationId.includes("|"))
+  ) {
+    throw new Error("invalid cumulative spend reservationId");
+  }
+  const reservationId = input.reservationId ?? `${now}:${nextSeq()}`;
   const member = `${reservationId}|${input.amount}|reserved`;
   const key = streamKey(stream);
 
@@ -366,6 +390,7 @@ export async function reserveWindowedInvoke(input: {
   operationKey: string;
   caps: CumulativeSpendCap[];
   now?: number;
+  reservationId?: string;
 }): Promise<{ ok: boolean; priorCounts: number[]; reservationId?: string }> {
   if (
     !Array.isArray(input.caps) ||
@@ -385,6 +410,7 @@ export async function reserveWindowedInvoke(input: {
       caps: input.caps,
       amount: 1,
       now: input.now,
+      reservationId: input.reservationId,
     });
     return {
       ok: res.ok,

--- a/packages/redis/src/cumulative-spend-tracker.ts
+++ b/packages/redis/src/cumulative-spend-tracker.ts
@@ -202,7 +202,11 @@ return {sum}
 `;
 
 function isNonNegInt(v: number): boolean {
-  return typeof v === "number" && Number.isFinite(v) && Number.isInteger(v) && v >= 0;
+  // Redis Lua numbers are IEEE-754 doubles. Values above MAX_SAFE_INTEGER may
+  // stringify/round differently between JS and Lua, which would make a durable
+  // reservation impossible to identify and release exactly. Reject them before
+  // touching Redis.
+  return typeof v === "number" && Number.isSafeInteger(v) && v >= 0;
 }
 
 function isValidWindow(w: number): boolean {
@@ -409,7 +413,7 @@ export async function releaseWindowedInvoke(input: {
     },
     reservationId: input.reservationId,
     amount: 1,
-  }).catch(() => undefined);
+  });
 }
 
 /**

--- a/packages/shared/src/__tests__/provider-execution-commitment.test.ts
+++ b/packages/shared/src/__tests__/provider-execution-commitment.test.ts
@@ -4,9 +4,12 @@ import {
   computeGrantDependencyHash,
   computeProviderExecutionCommitmentHash,
   type GithubCanonicalActionV1,
+  jcsStringify,
   type ProviderExecutionCommitmentBuildInput,
   providerExecutionCommitmentBytes,
   serializeCanonicalOutboundQuery,
+  sha256HexPrefixed,
+  verifyProviderExecutionPolicyEvidence,
 } from "../provider-action.js";
 
 // A minimal, valid canonical action (pinned github origin) reused across cases.
@@ -177,5 +180,69 @@ describe("provider execution v2 commitment builder", () => {
     expect(
       computeProviderExecutionCommitmentHash(buildProviderExecutionCommitmentV2(drift)),
     ).not.toBe(baseHash);
+  });
+});
+
+describe("execute-time policy evidence verifier", () => {
+  const decidedAt = "2026-07-14T20:00:00.000Z";
+  const expected = {
+    decisionId: "55555555-5555-4555-8555-555555555555",
+    intentId: "intent-1",
+    requestHash: `sha256:${"a".repeat(64)}`,
+    actionDigest: `sha256:${"b".repeat(64)}`,
+    operationId: "44444444-4444-4444-8444-444444444444",
+    operationKey: "github.issue.create",
+    policyRevisionHash: `sha256:${"d".repeat(64)}`,
+    decidedAt,
+  };
+  const decision = {
+    schemaVersion: "steward.provider-policy-decision.v1",
+    ...expected,
+    effect: "approval_required",
+    reasonCodes: ["APPROVAL_REQUIRED"],
+    policyResults: [],
+    evaluatorVersion: "provider-action.v1",
+  };
+
+  test("accepts a complete decision bound to every denormalized identity field", () => {
+    expect(
+      verifyProviderExecutionPolicyEvidence(
+        decision,
+        sha256HexPrefixed(jcsStringify(decision)),
+        expected,
+      ),
+    ).toBe(true);
+  });
+
+  test("rejects recomputed evidence with a substituted operation key or evaluated time", () => {
+    for (const changed of [
+      { ...decision, operationKey: "github.issue.delete" },
+      { ...decision, decidedAt: "2026-07-14T20:01:00.000Z" },
+    ]) {
+      expect(
+        verifyProviderExecutionPolicyEvidence(
+          changed,
+          sha256HexPrefixed(jcsStringify(changed)),
+          expected,
+        ),
+      ).toBe(false);
+    }
+  });
+
+  test("rejects incomplete or denying policy documents even when their hash matches", () => {
+    for (const changed of [
+      { ...decision, evaluatorVersion: "" },
+      { ...decision, reasonCodes: null },
+      { ...decision, policyResults: null },
+      { ...decision, effect: "hard_deny" },
+    ]) {
+      expect(
+        verifyProviderExecutionPolicyEvidence(
+          changed,
+          sha256HexPrefixed(jcsStringify(changed)),
+          expected,
+        ),
+      ).toBe(false);
+    }
   });
 });

--- a/packages/shared/src/provider-action.ts
+++ b/packages/shared/src/provider-action.ts
@@ -848,7 +848,9 @@ export interface ProviderExecutionPolicyEvidenceExpectation {
   requestHash: string;
   actionDigest: string;
   operationId: string;
+  operationKey: string;
   policyRevisionHash: string;
+  decidedAt: string;
 }
 
 /**
@@ -872,7 +874,14 @@ export function verifyProviderExecutionPolicyEvidence(
     doc.requestHash !== expected.requestHash ||
     doc.actionDigest !== expected.actionDigest ||
     doc.operationId !== expected.operationId ||
+    doc.operationKey !== expected.operationKey ||
     doc.policyRevisionHash !== expected.policyRevisionHash ||
+    doc.decidedAt !== expected.decidedAt ||
+    typeof doc.evaluatorVersion !== "string" ||
+    doc.evaluatorVersion.length === 0 ||
+    !Array.isArray(doc.reasonCodes) ||
+    doc.reasonCodes.some((code) => typeof code !== "string") ||
+    !Array.isArray(doc.policyResults) ||
     (doc.effect !== "allow" && doc.effect !== "approval_required")
   ) {
     return false;

--- a/packages/shared/src/provider-action.ts
+++ b/packages/shared/src/provider-action.ts
@@ -842,6 +842,48 @@ export interface ProviderExecutionCommitmentV2 {
   keyId: string;
 }
 
+export interface ProviderExecutionPolicyEvidenceExpectation {
+  decisionId: string;
+  intentId: string;
+  requestHash: string;
+  actionDigest: string;
+  operationId: string;
+  policyRevisionHash: string;
+}
+
+/**
+ * Verify the complete execute-time policy evidence before an authorization is
+ * minted or claimed. Keeping this check shared prevents the API and proxy
+ * boundaries from accepting different evidence shapes during rollout.
+ */
+export function verifyProviderExecutionPolicyEvidence(
+  decision: unknown,
+  decisionHash: string | null | undefined,
+  expected: ProviderExecutionPolicyEvidenceExpectation,
+): boolean {
+  if (!decision || typeof decision !== "object" || Array.isArray(decision) || !decisionHash) {
+    return false;
+  }
+  const doc = decision as Record<string, unknown>;
+  if (
+    doc.schemaVersion !== "steward.provider-policy-decision.v1" ||
+    doc.decisionId !== expected.decisionId ||
+    doc.intentId !== expected.intentId ||
+    doc.requestHash !== expected.requestHash ||
+    doc.actionDigest !== expected.actionDigest ||
+    doc.operationId !== expected.operationId ||
+    doc.policyRevisionHash !== expected.policyRevisionHash ||
+    (doc.effect !== "allow" && doc.effect !== "approval_required")
+  ) {
+    return false;
+  }
+  try {
+    return sha256HexPrefixed(jcsStringify(doc)) === decisionHash;
+  } catch {
+    return false;
+  }
+}
+
 function toExecutionCommitmentObject(c: ProviderExecutionCommitmentV2): Record<string, unknown> {
   // Build a plain object graph (no class instances) so the JCS serializer never
   // sees a Date/Map/etc. Property order here is irrelevant (JCS re-sorts).


### PR DESCRIPTION
Closes #240
Closes #239

Replaces closed #285 and #289 after incorporating both exact-head rejection audits.

## Correctness model

- stores immutable reservation identities in append-only `(intent,generation)` rows; decision and approval-execution generations cannot overwrite or release one another
- re-evaluates current policy and atomically reserves cumulative-spend/maxCalls immediately before approval consumption, then persists execution policy evidence + generation + approval consumption + execution authorization in one audited PG transaction
- derives stable generation-specific Redis reservation identities, making a retry after Redis-before-PG process death idempotent instead of double-debiting
- explicitly compensates ordinary PG rollback; a hard process death leaves no dispatch authorization and at worst a bounded fail-closed Redis orphan that retry reuses or the 30-day maximum window ages out
- reconciles the exact generation to settled/released based on durable binding outcome
- claims bounded 50-row batches with `FOR UPDATE SKIP LOCKED`, a due-time partial index, a 60-second lease, exponential backoff, and no hot-replay bypass
- transitions malformed/exhausted generations to durable `needs_attention` and transactionally enqueues required audit evidence
- starts an immediate + periodic autonomous recovery worker only after both PG migrations and Redis are ready
- preserves the production auth-store startup hardening now on `develop`

## Verification

Exact head: `e7c1d609fed1b26db8117a028bf60757d863914e`

- `STEWARD_EXECUTION_AUTH_SECRET=... bun test provider-approval-lifecycle provider-approval-concurrency provider-approval-negative provider-action-service`: 62 pass, 0 fail
- migration applied repeatedly by the above four PGLite suites
- focused migration test: 12 pass, 0 fail
- Redis tracker TypeScript build: pass
- API TypeScript: no errors in touched reservation/approval code (current develop has unrelated plugin-trading/policy-engine errors when built without generated workspace artifacts)
- Biome on all touched TS files: pass
- `git diff --check`: pass

CI enables `STEWARD_REDIS_TESTS=1` against the workflow's real Redis service. Added mutation-oriented cases cover: before/after external-effect crash, retry backoff, two-worker claim race, stable-ID parallel retry, approval rollback compensation, cap crossing at execute time, and concurrent approval resumes producing exactly one execution generation.
