### PR TITLE
feat(provider): add governed Slack actions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,7 @@ COPY packages/plugin-sdk/package.json         packages/plugin-sdk/package.json
 COPY packages/plugin-trading/package.json     packages/plugin-trading/package.json
 COPY packages/plugin-wxmr/package.json        packages/plugin-wxmr/package.json
 COPY packages/provider-github/package.json    packages/provider-github/package.json
+COPY packages/provider-slack/package.json     packages/provider-slack/package.json
 COPY packages/provider-x/package.json         packages/provider-x/package.json
 COPY packages/proxy-client/package.json       packages/proxy-client/package.json
 COPY packages/policy-engine/package.json     packages/policy-engine/package.json
@@ -105,6 +106,7 @@ COPY packages/plugin-sdk/package.json         packages/plugin-sdk/package.json
 COPY packages/plugin-trading/package.json     packages/plugin-trading/package.json
 COPY packages/plugin-wxmr/package.json        packages/plugin-wxmr/package.json
 COPY packages/provider-github/package.json    packages/provider-github/package.json
+COPY packages/provider-slack/package.json     packages/provider-slack/package.json
 COPY packages/provider-x/package.json         packages/provider-x/package.json
 COPY packages/proxy-client/package.json       packages/proxy-client/package.json
 COPY packages/policy-engine/package.json     packages/policy-engine/package.json
@@ -140,6 +142,7 @@ COPY packages/plugin-capabilities packages/plugin-capabilities
 COPY packages/plugin-trading packages/plugin-trading
 COPY packages/plugin-wxmr packages/plugin-wxmr
 COPY packages/provider-github packages/provider-github
+COPY packages/provider-slack packages/provider-slack
 COPY packages/provider-x packages/provider-x
 COPY packages/proxy-client packages/proxy-client
 COPY packages/policy-engine packages/policy-engine
@@ -170,6 +173,7 @@ RUN mkdir -p node_modules/@stwd && \
     ln -sf ../../../packages/plugin-trading    node_modules/@stwd/plugin-trading && \
     ln -sf ../../../packages/plugin-wxmr       node_modules/@stwd/plugin-wxmr && \
     ln -sf ../../../packages/provider-github   node_modules/@stwd/provider-github && \
+    ln -sf ../../../packages/provider-slack    node_modules/@stwd/provider-slack && \
     ln -sf ../../../packages/provider-x         node_modules/@stwd/provider-x && \
     ln -sf ../../../packages/proxy-client      node_modules/@stwd/proxy-client && \
     ln -sf ../../../packages/trade-sessions    node_modules/@stwd/trade-sessions && \
@@ -211,6 +215,7 @@ COPY packages/plugin-sdk/package.json         packages/plugin-sdk/package.json
 COPY packages/plugin-trading/package.json     packages/plugin-trading/package.json
 COPY packages/plugin-wxmr/package.json        packages/plugin-wxmr/package.json
 COPY packages/provider-github/package.json    packages/provider-github/package.json
+COPY packages/provider-slack/package.json     packages/provider-slack/package.json
 COPY packages/provider-x/package.json         packages/provider-x/package.json
 COPY packages/proxy-client/package.json       packages/proxy-client/package.json
 COPY packages/policy-engine/package.json     packages/policy-engine/package.json
@@ -242,6 +247,7 @@ COPY --from=build /app/packages/plugin-capabilities packages/plugin-capabilities
 COPY --from=build /app/packages/plugin-trading packages/plugin-trading
 COPY --from=build /app/packages/plugin-wxmr packages/plugin-wxmr
 COPY --from=build /app/packages/provider-github packages/provider-github
+COPY --from=build /app/packages/provider-slack packages/provider-slack
 COPY --from=build /app/packages/provider-x packages/provider-x
 COPY --from=build /app/packages/proxy-client packages/proxy-client
 COPY --from=build /app/packages/policy-engine packages/policy-engine
@@ -273,6 +279,7 @@ RUN mkdir -p node_modules/@stwd && \
     ln -sf ../../../packages/plugin-trading    node_modules/@stwd/plugin-trading && \
     ln -sf ../../../packages/plugin-wxmr       node_modules/@stwd/plugin-wxmr && \
     ln -sf ../../../packages/provider-github   node_modules/@stwd/provider-github && \
+    ln -sf ../../../packages/provider-slack    node_modules/@stwd/provider-slack && \
     ln -sf ../../../packages/provider-x         node_modules/@stwd/provider-x && \
     ln -sf ../../../packages/proxy-client      node_modules/@stwd/proxy-client && \
     ln -sf ../../../packages/trade-sessions    node_modules/@stwd/trade-sessions && \

--- a/bun.lock
+++ b/bun.lock
@@ -267,7 +267,6 @@
       "name": "@stwd/plugin-trading",
       "version": "0.1.0",
       "dependencies": {
-        "@stwd/adapters": "workspace:*",
         "@stwd/db": "workspace:*",
         "@stwd/policy-engine": "workspace:*",
         "@stwd/redis": "workspace:*",
@@ -2193,7 +2192,7 @@
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
-    "camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
+    "camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
     "camelcase-css": ["camelcase-css@2.0.1", "", {}, "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="],
 
@@ -2227,7 +2226,7 @@
 
     "client-only": ["client-only@0.0.1", "", {}, "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="],
 
-    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+    "cliui": ["cliui@9.0.1", "", { "dependencies": { "string-width": "^7.2.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w=="],
 
     "cloudflare": ["cloudflare@4.5.0", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" } }, "sha512-fPcbPKx4zF45jBvQ0z7PCdgejVAPBBCZxwqk1k7krQNfpM07Cfj97/Q6wBzvYqlWXx/zt1S9+m8vnfCe06umbQ=="],
 
@@ -2247,7 +2246,7 @@
 
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
-    "commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
+    "commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
     "comment-json": ["comment-json@4.6.2", "", { "dependencies": { "array-timsort": "^1.0.3", "esprima": "^4.0.1" } }, "sha512-R2rze/hDX30uul4NZoIZ76ImSJLFxn/1/ZxtKC1L77y2X1k+yYu1joKbAtMA2Fg3hZrTOiw0I5mwVMo0cf250w=="],
 
@@ -2387,7 +2386,7 @@
 
     "elliptic": ["elliptic@6.6.1", "", { "dependencies": { "bn.js": "^4.11.9", "brorand": "^1.1.0", "hash.js": "^1.0.0", "hmac-drbg": "^1.0.1", "inherits": "^2.0.4", "minimalistic-assert": "^1.0.1", "minimalistic-crypto-utils": "^1.0.1" } }, "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g=="],
 
-    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "encode-utf8": ["encode-utf8@1.0.3", "", {}, "sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw=="],
 
@@ -3343,7 +3342,7 @@
 
     "strict-uri-encode": ["strict-uri-encode@2.0.0", "", {}, "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ=="],
 
-    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+    "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -3551,7 +3550,7 @@
 
     "wrangler": ["wrangler@4.105.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.28.1", "miniflare": "4.20260625.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260625.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260625.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "cf-wrangler": "bin/cf-wrangler.js", "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-7dXFH6OLj1Fv0y6ZeRPUxFTkp+duWD7/xxVi/1c0vfOeEYwIFKWB7cdqnY05DvY1Ta3BnqAwRkXfLs8PDj538g=="],
 
-    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+    "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
@@ -3583,7 +3582,7 @@
 
     "yaml-ast-parser": ["yaml-ast-parser@0.0.43", "", {}, "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A=="],
 
-    "yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
+    "yargs": ["yargs@18.0.0", "", { "dependencies": { "cliui": "^9.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "string-width": "^7.2.0", "y18n": "^5.0.5", "yargs-parser": "^22.0.0" } }, "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg=="],
 
     "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
@@ -3865,8 +3864,6 @@
 
     "@opennextjs/aws/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
-    "@opennextjs/cloudflare/yargs": ["yargs@18.0.0", "", { "dependencies": { "cliui": "^9.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "string-width": "^7.2.0", "y18n": "^5.0.5", "yargs-parser": "^22.0.0" } }, "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg=="],
-
     "@particle-network/solana-wallet/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
 
     "@polymarket/abstract-signer/ethers": ["ethers@5.7.2", "", { "dependencies": { "@ethersproject/abi": "5.7.0", "@ethersproject/abstract-provider": "5.7.0", "@ethersproject/abstract-signer": "5.7.0", "@ethersproject/address": "5.7.0", "@ethersproject/base64": "5.7.0", "@ethersproject/basex": "5.7.0", "@ethersproject/bignumber": "5.7.0", "@ethersproject/bytes": "5.7.0", "@ethersproject/constants": "5.7.0", "@ethersproject/contracts": "5.7.0", "@ethersproject/hash": "5.7.0", "@ethersproject/hdnode": "5.7.0", "@ethersproject/json-wallets": "5.7.0", "@ethersproject/keccak256": "5.7.0", "@ethersproject/logger": "5.7.0", "@ethersproject/networks": "5.7.1", "@ethersproject/pbkdf2": "5.7.0", "@ethersproject/properties": "5.7.0", "@ethersproject/providers": "5.7.2", "@ethersproject/random": "5.7.0", "@ethersproject/rlp": "5.7.0", "@ethersproject/sha2": "5.7.0", "@ethersproject/signing-key": "5.7.0", "@ethersproject/solidity": "5.7.0", "@ethersproject/strings": "5.7.0", "@ethersproject/transactions": "5.7.0", "@ethersproject/units": "5.7.0", "@ethersproject/wallet": "5.7.0", "@ethersproject/web": "5.7.1", "@ethersproject/wordlists": "5.7.0" } }, "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg=="],
@@ -3884,6 +3881,8 @@
     "@project-serum/sol-wallet-adapter/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
 
     "@project-serum/sol-wallet-adapter/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
+
+    "@react-native/codegen/yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
 
     "@react-native/dev-middleware/serve-static": ["serve-static@1.16.3", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "~0.19.1" } }, "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA=="],
 
@@ -4225,6 +4224,8 @@
 
     "cbw-sdk/preact": ["preact@10.29.3", "", {}, "sha512-D9NL1GAnJZhc3RndVs4gDdxEeU9TcHgywMrhhOsnpdlvFjdbx0gAsLUnH6JEhlJH5giL7Tx5biWPUSEXE/HPzw=="],
 
+    "cliui/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
     "cloudflare/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
 
     "connect/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
@@ -4287,6 +4288,8 @@
 
     "jest-util/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
+    "jest-validate/camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
+
     "jest-validate/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
@@ -4304,6 +4307,8 @@
     "metro/hermes-parser": ["hermes-parser@0.35.0", "", { "dependencies": { "hermes-estree": "0.35.0" } }, "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA=="],
 
     "metro/source-map": ["source-map@0.5.7", "", {}, "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="],
+
+    "metro/yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
 
     "metro-babel-transformer/hermes-parser": ["hermes-parser@0.35.0", "", { "dependencies": { "hermes-estree": "0.35.0" } }, "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA=="],
 
@@ -4337,9 +4342,13 @@
 
     "qrcode.react/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 
+    "react-native/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
+
     "react-native/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 
     "react-native/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "react-native/yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
 
     "react-qr-reader/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 
@@ -4363,9 +4372,11 @@
 
     "stream-browserify/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
-    "string_decoder/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+    "string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
-    "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
+    "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "string_decoder/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "tailwindcss/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
@@ -4395,15 +4406,21 @@
 
     "wif/bs58check": ["bs58check@4.0.0", "", { "dependencies": { "@noble/hashes": "^1.2.0", "bs58": "^6.0.0" } }, "sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g=="],
 
-    "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+    "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "wrap-ansi/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "xml-crypto/xpath": ["xpath@0.0.33", "", {}, "sha512-NNXnzrkDrAzalLhIUc01jO2mOzXGXh1JwPgkihcLLzw98c0WgYDmmjSh1Kl3wzaxSVWMuA+fe0WTWOBDWCBmNA=="],
 
     "xml-encryption/xpath": ["xpath@0.0.32", "", {}, "sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw=="],
 
     "xml2js/xmlbuilder": ["xmlbuilder@11.0.1", "", {}, "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="],
+
+    "yargs/yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
 
     "youch/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
@@ -4731,17 +4748,15 @@
 
     "@metamask/utils/@ethereumjs/tx/@ethereumjs/common": ["@ethereumjs/common@3.2.0", "", { "dependencies": { "@ethereumjs/util": "^8.1.0", "crc-32": "^1.2.0" } }, "sha512-pksvzI0VyLgmuEF2FA/JR/4/y6hcPq8OUail3/AvycBaW1d5VSauOZzqGvJ3RTmR4MU35lWE8KseKOsEhrFRBA=="],
 
-    "@opennextjs/cloudflare/yargs/cliui": ["cliui@9.0.1", "", { "dependencies": { "string-width": "^7.2.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w=="],
-
-    "@opennextjs/cloudflare/yargs/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
-
-    "@opennextjs/cloudflare/yargs/yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
-
     "@particle-network/solana-wallet/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
 
     "@polymarket/builder-signing-sdk/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
     "@project-serum/sol-wallet-adapter/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
+
+    "@react-native/codegen/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "@react-native/codegen/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "@react-native/dev-middleware/serve-static/send": ["send@0.19.2", "", { "dependencies": { "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "fresh": "~0.5.2", "http-errors": "~2.0.1", "mime": "1.6.0", "ms": "2.1.3", "on-finished": "~2.4.1", "range-parser": "~1.2.1", "statuses": "~2.0.2" } }, "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg=="],
 
@@ -5225,6 +5240,8 @@
 
     "bs58check/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
 
+    "cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
     "cloudflare/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
     "connect/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
@@ -5263,21 +5280,37 @@
 
     "metro/hermes-parser/hermes-estree": ["hermes-estree@0.35.0", "", {}, "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg=="],
 
+    "metro/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "metro/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
     "porto/ox/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
 
     "qrcode/yargs/cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
+
+    "qrcode/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "qrcode/yargs/y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
 
     "qrcode/yargs/yargs-parser": ["yargs-parser@18.1.3", "", { "dependencies": { "camelcase": "^5.0.0", "decamelize": "^1.2.0" } }, "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ=="],
 
+    "react-native/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "react-native/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
     "react-qr-reader/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "tailwindcss/chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "tailwindcss/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
     "unstorage/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
+
+    "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "@aws-sdk/client-cloudfront/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-ini/@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.55", "", { "dependencies": { "@aws-sdk/core": "^3.974.23", "@aws-sdk/nested-clients": "^3.997.23", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-hBBkANo3cDn+h2qxxzER4a+J8JCO9o9Z/YYmU7iky6AcaarX5RRdRcHNC6SLdwY0vAXQygn6soUbDqPn3GghaA=="],
 
@@ -5463,13 +5496,9 @@
 
     "@metamask/providers/@metamask/utils/@ethereumjs/tx/@ethereumjs/common": ["@ethereumjs/common@3.2.0", "", { "dependencies": { "@ethereumjs/util": "^8.1.0", "crc-32": "^1.2.0" } }, "sha512-pksvzI0VyLgmuEF2FA/JR/4/y6hcPq8OUail3/AvycBaW1d5VSauOZzqGvJ3RTmR4MU35lWE8KseKOsEhrFRBA=="],
 
-    "@opennextjs/cloudflare/yargs/cliui/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+    "@react-native/codegen/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
-    "@opennextjs/cloudflare/yargs/cliui/wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
-
-    "@opennextjs/cloudflare/yargs/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
-
-    "@opennextjs/cloudflare/yargs/string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+    "@react-native/codegen/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "@react-native/dev-middleware/serve-static/send/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
@@ -5512,6 +5541,8 @@
     "@reown/appkit-pay/@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils": ["@walletconnect/utils@2.21.0", "", { "dependencies": { "@noble/ciphers": "1.2.1", "@noble/curves": "1.8.1", "@noble/hashes": "1.7.1", "@walletconnect/jsonrpc-utils": "1.0.8", "@walletconnect/keyvaluestorage": "1.1.1", "@walletconnect/relay-api": "1.0.11", "@walletconnect/relay-auth": "1.1.0", "@walletconnect/safe-json": "1.0.2", "@walletconnect/time": "1.0.2", "@walletconnect/types": "2.21.0", "@walletconnect/window-getters": "1.0.1", "@walletconnect/window-metadata": "1.0.1", "bs58": "6.0.0", "detect-browser": "5.3.0", "query-string": "7.1.3", "uint8arrays": "3.1.0", "viem": "2.23.2" } }, "sha512-zfHLiUoBrQ8rP57HTPXW7rQMnYxYI4gT9yTACxVW6LhIFROTF6/ytm5SKNoIvi4a5nX5dfXG4D9XwQUCu8Ilig=="],
 
     "@reown/appkit-ui/qrcode/yargs/cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
+
+    "@reown/appkit-ui/qrcode/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "@reown/appkit-ui/qrcode/yargs/y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
 
@@ -6077,9 +6108,17 @@
 
     "eth-block-tracker/@metamask/utils/@ethereumjs/tx/@ethereumjs/common": ["@ethereumjs/common@3.2.0", "", { "dependencies": { "@ethereumjs/util": "^8.1.0", "crc-32": "^1.2.0" } }, "sha512-pksvzI0VyLgmuEF2FA/JR/4/y6hcPq8OUail3/AvycBaW1d5VSauOZzqGvJ3RTmR4MU35lWE8KseKOsEhrFRBA=="],
 
+    "metro/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "metro/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
     "qrcode/yargs/cliui/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
-    "qrcode/yargs/yargs-parser/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
+    "qrcode/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "react-native/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "react-native/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "tailwindcss/chokidar/readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
@@ -6141,11 +6180,7 @@
 
     "@metamask/providers/@metamask/rpc-errors/@metamask/utils/@ethereumjs/tx/@ethereumjs/common": ["@ethereumjs/common@3.2.0", "", { "dependencies": { "@ethereumjs/util": "^8.1.0", "crc-32": "^1.2.0" } }, "sha512-pksvzI0VyLgmuEF2FA/JR/4/y6hcPq8OUail3/AvycBaW1d5VSauOZzqGvJ3RTmR4MU35lWE8KseKOsEhrFRBA=="],
 
-    "@opennextjs/cloudflare/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
-
-    "@opennextjs/cloudflare/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
-
-    "@opennextjs/cloudflare/yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+    "@react-native/codegen/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "@react-native/dev-middleware/serve-static/send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
@@ -6171,6 +6206,8 @@
 
     "@reown/appkit-pay/@reown/appkit-ui/qrcode/yargs/cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
 
+    "@reown/appkit-pay/@reown/appkit-ui/qrcode/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
     "@reown/appkit-pay/@reown/appkit-ui/qrcode/yargs/y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
 
     "@reown/appkit-pay/@reown/appkit-ui/qrcode/yargs/yargs-parser": ["yargs-parser@18.1.3", "", { "dependencies": { "camelcase": "^5.0.0", "decamelize": "^1.2.0" } }, "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ=="],
@@ -6187,7 +6224,7 @@
 
     "@reown/appkit-ui/qrcode/yargs/cliui/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
-    "@reown/appkit-ui/qrcode/yargs/yargs-parser/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
+    "@reown/appkit-ui/qrcode/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils/viem/@scure/bip32": ["@scure/bip32@1.6.2", "", { "dependencies": { "@noble/curves": "~1.8.1", "@noble/hashes": "~1.7.1", "@scure/base": "~1.2.2" } }, "sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw=="],
 
@@ -6317,7 +6354,11 @@
 
     "@walletconnect/utils/viem/ox/@scure/bip39/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 
+    "metro/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
     "qrcode/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "react-native/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "@aws-sdk/client-cloudfront/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-ini/@aws-sdk/nested-clients/@aws-sdk/signature-v4-multi-region/@smithy/signature-v4": ["@smithy/signature-v4@5.5.2", "", { "dependencies": { "@smithy/core": "^3.26.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-7xHpmPY4rt0IOmeAA8EfjgEH8isT+587TCdy9H6a7d4OMi5CQ0oEHhWllunvPu4j4Cq0vTFwdxXN/kABWPjdyA=="],
 
@@ -6377,7 +6418,7 @@
 
     "@reown/appkit-pay/@reown/appkit-ui/qrcode/yargs/cliui/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
-    "@reown/appkit-pay/@reown/appkit-ui/qrcode/yargs/yargs-parser/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
+    "@reown/appkit-pay/@reown/appkit-ui/qrcode/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "@reown/appkit-pay/@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils/viem/@scure/bip32": ["@scure/bip32@1.6.2", "", { "dependencies": { "@noble/curves": "~1.8.1", "@noble/hashes": "~1.7.1", "@scure/base": "~1.2.2" } }, "sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw=="],
 
@@ -6424,6 +6465,8 @@
     "@walletconnect/core/@walletconnect/utils/viem/ox/@scure/bip39/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 
     "@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode/yargs/cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
+
+    "@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode/yargs/y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
 
@@ -6491,7 +6534,7 @@
 
     "@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode/yargs/cliui/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
-    "@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode/yargs/yargs-parser/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
+    "@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "@walletconnect/ethereum-provider/@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils/viem/@scure/bip32/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -64,6 +64,7 @@
         "@stwd/plugin-wxmr": "workspace:*",
         "@stwd/policy-engine": "workspace:*",
         "@stwd/provider-github": "workspace:*",
+        "@stwd/provider-slack": "workspace:*",
         "@stwd/provider-x": "workspace:*",
         "@stwd/redis": "workspace:*",
         "@stwd/shared": "workspace:*",
@@ -266,6 +267,7 @@
       "name": "@stwd/plugin-trading",
       "version": "0.1.0",
       "dependencies": {
+        "@stwd/adapters": "workspace:*",
         "@stwd/db": "workspace:*",
         "@stwd/policy-engine": "workspace:*",
         "@stwd/redis": "workspace:*",
@@ -311,6 +313,13 @@
     },
     "packages/provider-github": {
       "name": "@stwd/provider-github",
+      "version": "0.1.0",
+      "dependencies": {
+        "@stwd/shared": "workspace:*",
+      },
+    },
+    "packages/provider-slack": {
+      "name": "@stwd/provider-slack",
       "version": "0.1.0",
       "dependencies": {
         "@stwd/shared": "workspace:*",
@@ -1754,6 +1763,8 @@
 
     "@stwd/provider-github": ["@stwd/provider-github@workspace:packages/provider-github"],
 
+    "@stwd/provider-slack": ["@stwd/provider-slack@workspace:packages/provider-slack"],
+
     "@stwd/provider-x": ["@stwd/provider-x@workspace:packages/provider-x"],
 
     "@stwd/proxy": ["@stwd/proxy@workspace:packages/proxy"],
@@ -2182,7 +2193,7 @@
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
-    "camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
+    "camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
 
     "camelcase-css": ["camelcase-css@2.0.1", "", {}, "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="],
 
@@ -2216,7 +2227,7 @@
 
     "client-only": ["client-only@0.0.1", "", {}, "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="],
 
-    "cliui": ["cliui@9.0.1", "", { "dependencies": { "string-width": "^7.2.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w=="],
+    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
     "cloudflare": ["cloudflare@4.5.0", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" } }, "sha512-fPcbPKx4zF45jBvQ0z7PCdgejVAPBBCZxwqk1k7krQNfpM07Cfj97/Q6wBzvYqlWXx/zt1S9+m8vnfCe06umbQ=="],
 
@@ -2236,7 +2247,7 @@
 
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
-    "commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
+    "commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
 
     "comment-json": ["comment-json@4.6.2", "", { "dependencies": { "array-timsort": "^1.0.3", "esprima": "^4.0.1" } }, "sha512-R2rze/hDX30uul4NZoIZ76ImSJLFxn/1/ZxtKC1L77y2X1k+yYu1joKbAtMA2Fg3hZrTOiw0I5mwVMo0cf250w=="],
 
@@ -2376,7 +2387,7 @@
 
     "elliptic": ["elliptic@6.6.1", "", { "dependencies": { "bn.js": "^4.11.9", "brorand": "^1.1.0", "hash.js": "^1.0.0", "hmac-drbg": "^1.0.1", "inherits": "^2.0.4", "minimalistic-assert": "^1.0.1", "minimalistic-crypto-utils": "^1.0.1" } }, "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g=="],
 
-    "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "encode-utf8": ["encode-utf8@1.0.3", "", {}, "sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw=="],
 
@@ -3332,7 +3343,7 @@
 
     "strict-uri-encode": ["strict-uri-encode@2.0.0", "", {}, "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ=="],
 
-    "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -3540,7 +3551,7 @@
 
     "wrangler": ["wrangler@4.105.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.28.1", "miniflare": "4.20260625.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260625.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260625.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "cf-wrangler": "bin/cf-wrangler.js", "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-7dXFH6OLj1Fv0y6ZeRPUxFTkp+duWD7/xxVi/1c0vfOeEYwIFKWB7cdqnY05DvY1Ta3BnqAwRkXfLs8PDj538g=="],
 
-    "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
@@ -3572,7 +3583,7 @@
 
     "yaml-ast-parser": ["yaml-ast-parser@0.0.43", "", {}, "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A=="],
 
-    "yargs": ["yargs@18.0.0", "", { "dependencies": { "cliui": "^9.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "string-width": "^7.2.0", "y18n": "^5.0.5", "yargs-parser": "^22.0.0" } }, "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg=="],
+    "yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
 
     "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
@@ -3854,6 +3865,8 @@
 
     "@opennextjs/aws/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
+    "@opennextjs/cloudflare/yargs": ["yargs@18.0.0", "", { "dependencies": { "cliui": "^9.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "string-width": "^7.2.0", "y18n": "^5.0.5", "yargs-parser": "^22.0.0" } }, "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg=="],
+
     "@particle-network/solana-wallet/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
 
     "@polymarket/abstract-signer/ethers": ["ethers@5.7.2", "", { "dependencies": { "@ethersproject/abi": "5.7.0", "@ethersproject/abstract-provider": "5.7.0", "@ethersproject/abstract-signer": "5.7.0", "@ethersproject/address": "5.7.0", "@ethersproject/base64": "5.7.0", "@ethersproject/basex": "5.7.0", "@ethersproject/bignumber": "5.7.0", "@ethersproject/bytes": "5.7.0", "@ethersproject/constants": "5.7.0", "@ethersproject/contracts": "5.7.0", "@ethersproject/hash": "5.7.0", "@ethersproject/hdnode": "5.7.0", "@ethersproject/json-wallets": "5.7.0", "@ethersproject/keccak256": "5.7.0", "@ethersproject/logger": "5.7.0", "@ethersproject/networks": "5.7.1", "@ethersproject/pbkdf2": "5.7.0", "@ethersproject/properties": "5.7.0", "@ethersproject/providers": "5.7.2", "@ethersproject/random": "5.7.0", "@ethersproject/rlp": "5.7.0", "@ethersproject/sha2": "5.7.0", "@ethersproject/signing-key": "5.7.0", "@ethersproject/solidity": "5.7.0", "@ethersproject/strings": "5.7.0", "@ethersproject/transactions": "5.7.0", "@ethersproject/units": "5.7.0", "@ethersproject/wallet": "5.7.0", "@ethersproject/web": "5.7.1", "@ethersproject/wordlists": "5.7.0" } }, "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg=="],
@@ -3871,8 +3884,6 @@
     "@project-serum/sol-wallet-adapter/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
 
     "@project-serum/sol-wallet-adapter/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
-
-    "@react-native/codegen/yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
 
     "@react-native/dev-middleware/serve-static": ["serve-static@1.16.3", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "~0.19.1" } }, "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA=="],
 
@@ -4214,8 +4225,6 @@
 
     "cbw-sdk/preact": ["preact@10.29.3", "", {}, "sha512-D9NL1GAnJZhc3RndVs4gDdxEeU9TcHgywMrhhOsnpdlvFjdbx0gAsLUnH6JEhlJH5giL7Tx5biWPUSEXE/HPzw=="],
 
-    "cliui/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
-
     "cloudflare/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
 
     "connect/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
@@ -4278,8 +4287,6 @@
 
     "jest-util/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
-    "jest-validate/camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
-
     "jest-validate/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
@@ -4297,8 +4304,6 @@
     "metro/hermes-parser": ["hermes-parser@0.35.0", "", { "dependencies": { "hermes-estree": "0.35.0" } }, "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA=="],
 
     "metro/source-map": ["source-map@0.5.7", "", {}, "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="],
-
-    "metro/yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
 
     "metro-babel-transformer/hermes-parser": ["hermes-parser@0.35.0", "", { "dependencies": { "hermes-estree": "0.35.0" } }, "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA=="],
 
@@ -4332,13 +4337,9 @@
 
     "qrcode.react/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 
-    "react-native/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
-
     "react-native/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 
     "react-native/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
-
-    "react-native/yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
 
     "react-qr-reader/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 
@@ -4362,11 +4363,9 @@
 
     "stream-browserify/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
-    "string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
-
-    "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
     "string_decoder/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
+    "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
     "tailwindcss/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
@@ -4396,21 +4395,15 @@
 
     "wif/bs58check": ["bs58check@4.0.0", "", { "dependencies": { "@noble/hashes": "^1.2.0", "bs58": "^6.0.0" } }, "sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g=="],
 
-    "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
-
-    "wrap-ansi/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+    "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
-    "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "xml-crypto/xpath": ["xpath@0.0.33", "", {}, "sha512-NNXnzrkDrAzalLhIUc01jO2mOzXGXh1JwPgkihcLLzw98c0WgYDmmjSh1Kl3wzaxSVWMuA+fe0WTWOBDWCBmNA=="],
 
     "xml-encryption/xpath": ["xpath@0.0.32", "", {}, "sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw=="],
 
     "xml2js/xmlbuilder": ["xmlbuilder@11.0.1", "", {}, "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="],
-
-    "yargs/yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
 
     "youch/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
@@ -4738,15 +4731,17 @@
 
     "@metamask/utils/@ethereumjs/tx/@ethereumjs/common": ["@ethereumjs/common@3.2.0", "", { "dependencies": { "@ethereumjs/util": "^8.1.0", "crc-32": "^1.2.0" } }, "sha512-pksvzI0VyLgmuEF2FA/JR/4/y6hcPq8OUail3/AvycBaW1d5VSauOZzqGvJ3RTmR4MU35lWE8KseKOsEhrFRBA=="],
 
+    "@opennextjs/cloudflare/yargs/cliui": ["cliui@9.0.1", "", { "dependencies": { "string-width": "^7.2.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w=="],
+
+    "@opennextjs/cloudflare/yargs/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "@opennextjs/cloudflare/yargs/yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
+
     "@particle-network/solana-wallet/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
 
     "@polymarket/builder-signing-sdk/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
     "@project-serum/sol-wallet-adapter/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
-
-    "@react-native/codegen/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
-
-    "@react-native/codegen/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "@react-native/dev-middleware/serve-static/send": ["send@0.19.2", "", { "dependencies": { "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "fresh": "~0.5.2", "http-errors": "~2.0.1", "mime": "1.6.0", "ms": "2.1.3", "on-finished": "~2.4.1", "range-parser": "~1.2.1", "statuses": "~2.0.2" } }, "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg=="],
 
@@ -5230,8 +5225,6 @@
 
     "bs58check/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
 
-    "cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
-
     "cloudflare/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
     "connect/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
@@ -5270,37 +5263,21 @@
 
     "metro/hermes-parser/hermes-estree": ["hermes-estree@0.35.0", "", {}, "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg=="],
 
-    "metro/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
-
-    "metro/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
     "porto/ox/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
 
     "qrcode/yargs/cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
-
-    "qrcode/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "qrcode/yargs/y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
 
     "qrcode/yargs/yargs-parser": ["yargs-parser@18.1.3", "", { "dependencies": { "camelcase": "^5.0.0", "decamelize": "^1.2.0" } }, "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ=="],
 
-    "react-native/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
-
-    "react-native/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
     "react-qr-reader/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
-
-    "string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "tailwindcss/chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "tailwindcss/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
     "unstorage/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
-
-    "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "@aws-sdk/client-cloudfront/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-ini/@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.55", "", { "dependencies": { "@aws-sdk/core": "^3.974.23", "@aws-sdk/nested-clients": "^3.997.23", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-hBBkANo3cDn+h2qxxzER4a+J8JCO9o9Z/YYmU7iky6AcaarX5RRdRcHNC6SLdwY0vAXQygn6soUbDqPn3GghaA=="],
 
@@ -5486,9 +5463,13 @@
 
     "@metamask/providers/@metamask/utils/@ethereumjs/tx/@ethereumjs/common": ["@ethereumjs/common@3.2.0", "", { "dependencies": { "@ethereumjs/util": "^8.1.0", "crc-32": "^1.2.0" } }, "sha512-pksvzI0VyLgmuEF2FA/JR/4/y6hcPq8OUail3/AvycBaW1d5VSauOZzqGvJ3RTmR4MU35lWE8KseKOsEhrFRBA=="],
 
-    "@react-native/codegen/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+    "@opennextjs/cloudflare/yargs/cliui/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
-    "@react-native/codegen/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "@opennextjs/cloudflare/yargs/cliui/wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+
+    "@opennextjs/cloudflare/yargs/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "@opennextjs/cloudflare/yargs/string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "@react-native/dev-middleware/serve-static/send/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
@@ -5531,8 +5512,6 @@
     "@reown/appkit-pay/@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils": ["@walletconnect/utils@2.21.0", "", { "dependencies": { "@noble/ciphers": "1.2.1", "@noble/curves": "1.8.1", "@noble/hashes": "1.7.1", "@walletconnect/jsonrpc-utils": "1.0.8", "@walletconnect/keyvaluestorage": "1.1.1", "@walletconnect/relay-api": "1.0.11", "@walletconnect/relay-auth": "1.1.0", "@walletconnect/safe-json": "1.0.2", "@walletconnect/time": "1.0.2", "@walletconnect/types": "2.21.0", "@walletconnect/window-getters": "1.0.1", "@walletconnect/window-metadata": "1.0.1", "bs58": "6.0.0", "detect-browser": "5.3.0", "query-string": "7.1.3", "uint8arrays": "3.1.0", "viem": "2.23.2" } }, "sha512-zfHLiUoBrQ8rP57HTPXW7rQMnYxYI4gT9yTACxVW6LhIFROTF6/ytm5SKNoIvi4a5nX5dfXG4D9XwQUCu8Ilig=="],
 
     "@reown/appkit-ui/qrcode/yargs/cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
-
-    "@reown/appkit-ui/qrcode/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "@reown/appkit-ui/qrcode/yargs/y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
 
@@ -6098,17 +6077,9 @@
 
     "eth-block-tracker/@metamask/utils/@ethereumjs/tx/@ethereumjs/common": ["@ethereumjs/common@3.2.0", "", { "dependencies": { "@ethereumjs/util": "^8.1.0", "crc-32": "^1.2.0" } }, "sha512-pksvzI0VyLgmuEF2FA/JR/4/y6hcPq8OUail3/AvycBaW1d5VSauOZzqGvJ3RTmR4MU35lWE8KseKOsEhrFRBA=="],
 
-    "metro/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
-
-    "metro/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
     "qrcode/yargs/cliui/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
-    "qrcode/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "react-native/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
-
-    "react-native/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "qrcode/yargs/yargs-parser/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
     "tailwindcss/chokidar/readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
@@ -6170,7 +6141,11 @@
 
     "@metamask/providers/@metamask/rpc-errors/@metamask/utils/@ethereumjs/tx/@ethereumjs/common": ["@ethereumjs/common@3.2.0", "", { "dependencies": { "@ethereumjs/util": "^8.1.0", "crc-32": "^1.2.0" } }, "sha512-pksvzI0VyLgmuEF2FA/JR/4/y6hcPq8OUail3/AvycBaW1d5VSauOZzqGvJ3RTmR4MU35lWE8KseKOsEhrFRBA=="],
 
-    "@react-native/codegen/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+    "@opennextjs/cloudflare/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "@opennextjs/cloudflare/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "@opennextjs/cloudflare/yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "@react-native/dev-middleware/serve-static/send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
@@ -6196,8 +6171,6 @@
 
     "@reown/appkit-pay/@reown/appkit-ui/qrcode/yargs/cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
 
-    "@reown/appkit-pay/@reown/appkit-ui/qrcode/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
     "@reown/appkit-pay/@reown/appkit-ui/qrcode/yargs/y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
 
     "@reown/appkit-pay/@reown/appkit-ui/qrcode/yargs/yargs-parser": ["yargs-parser@18.1.3", "", { "dependencies": { "camelcase": "^5.0.0", "decamelize": "^1.2.0" } }, "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ=="],
@@ -6214,7 +6187,7 @@
 
     "@reown/appkit-ui/qrcode/yargs/cliui/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
-    "@reown/appkit-ui/qrcode/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "@reown/appkit-ui/qrcode/yargs/yargs-parser/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
     "@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils/viem/@scure/bip32": ["@scure/bip32@1.6.2", "", { "dependencies": { "@noble/curves": "~1.8.1", "@noble/hashes": "~1.7.1", "@scure/base": "~1.2.2" } }, "sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw=="],
 
@@ -6344,11 +6317,7 @@
 
     "@walletconnect/utils/viem/ox/@scure/bip39/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 
-    "metro/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
     "qrcode/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
-    "react-native/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "@aws-sdk/client-cloudfront/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-ini/@aws-sdk/nested-clients/@aws-sdk/signature-v4-multi-region/@smithy/signature-v4": ["@smithy/signature-v4@5.5.2", "", { "dependencies": { "@smithy/core": "^3.26.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-7xHpmPY4rt0IOmeAA8EfjgEH8isT+587TCdy9H6a7d4OMi5CQ0oEHhWllunvPu4j4Cq0vTFwdxXN/kABWPjdyA=="],
 
@@ -6408,7 +6377,7 @@
 
     "@reown/appkit-pay/@reown/appkit-ui/qrcode/yargs/cliui/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
-    "@reown/appkit-pay/@reown/appkit-ui/qrcode/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "@reown/appkit-pay/@reown/appkit-ui/qrcode/yargs/yargs-parser/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
     "@reown/appkit-pay/@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils/viem/@scure/bip32": ["@scure/bip32@1.6.2", "", { "dependencies": { "@noble/curves": "~1.8.1", "@noble/hashes": "~1.7.1", "@scure/base": "~1.2.2" } }, "sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw=="],
 
@@ -6455,8 +6424,6 @@
     "@walletconnect/core/@walletconnect/utils/viem/ox/@scure/bip39/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 
     "@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode/yargs/cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
-
-    "@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode/yargs/y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
 
@@ -6524,7 +6491,7 @@
 
     "@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode/yargs/cliui/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
-    "@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode/yargs/yargs-parser/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
     "@walletconnect/ethereum-provider/@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils/viem/@scure/bip32/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 

--- a/docs/security/governed-slack.mdx
+++ b/docs/security/governed-slack.mdx
@@ -1,0 +1,38 @@
+---
+title: "Governed Slack actions"
+description: "Slack Web API operations with channel policy scope and server-held bot credentials."
+---
+
+# Governed Slack actions
+
+The `slack.provider-action.v1` profile pins requests to `https://slack.com/api/*`
+and currently supports:
+
+- `slack.chat.postMessage` (write)
+- `slack.conversations.list` (read)
+- `slack.users.info` (read)
+
+Bot tokens remain encrypted in Steward. A narrow secret route injects
+`Authorization: Bearer ...` only for the exact Slack method and path; the agent
+request, action status, safe summary, response, and audit record never contain
+the token.
+
+Channel authorization is a `capability-intent` argument constraint, not a broad
+credential grant:
+
+```json
+{
+  "type": "capability-intent",
+  "enabled": true,
+  "config": {
+    "capabilities": ["slack.chat.postMessage"],
+    "effect": "allow",
+    "constraints": { "argEquals": { "channel": "C12345678" } }
+  }
+}
+```
+
+Slack reports application errors as HTTP 200 with `{ "ok": false }`. Steward
+requires explicit `ok: true`; `ok: false`, malformed JSON, or a missing `ok`
+field is recorded and returned as a failed dispatch. Provider error codes are
+restricted to a safe token format before they enter audit or response data.

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -36,6 +36,7 @@
     "@stwd/plugin-wxmr": "workspace:*",
     "@stwd/policy-engine": "workspace:*",
     "@stwd/provider-github": "workspace:*",
+    "@stwd/provider-slack": "workspace:*",
     "@stwd/provider-x": "workspace:*",
     "@stwd/redis": "workspace:*",
     "@stwd/shared": "workspace:*",

--- a/packages/api/src/__tests__/production-profile-boundary-e2e.test.ts
+++ b/packages/api/src/__tests__/production-profile-boundary-e2e.test.ts
@@ -192,6 +192,7 @@ beforeAll(async () => {
   resetCheckpointSignerCache();
   app = (await import("../app")).app as Hono<{ Variables: AppVariables }>;
   const proxy = await import("@stwd/proxy/src/handlers/proxy");
+  proxy.__resetSecretVaultForTests();
   ({ dispatchGovernedExecution } = await import("@stwd/proxy/src/handlers/governed-execution"));
   proxy.__setResolveProxyHostForTests(async () => [{ address: "93.184.216.34", family: 4 }]);
   // The boundary proof is about canonical provider authority and exact

--- a/packages/api/src/__tests__/production-profile-boundary-e2e.test.ts
+++ b/packages/api/src/__tests__/production-profile-boundary-e2e.test.ts
@@ -36,6 +36,7 @@ import {
   GENERIC_HTTP_PROVIDER_ACTION_PROFILE,
   GITHUB_PROVIDER_ACTION_PROFILE,
   REGISTERED_PROFILES,
+  SLACK_PROVIDER_ACTION_PROFILE,
   X_PROVIDER_ACTION_PROFILE,
 } from "@stwd/shared";
 import { KeyStore } from "@stwd/vault";
@@ -77,6 +78,16 @@ const PROFILES = [
     method: "POST",
     path: "/2/tweets",
     args: { text: "boundary proof", summoned: false },
+    requestProfile: {},
+  },
+  {
+    profile: SLACK_PROVIDER_ACTION_PROFILE,
+    adapterKey: "slack",
+    operationKey: "slack.chat.postMessage",
+    host: "slack.com",
+    method: "POST",
+    path: "/api/chat.postMessage",
+    args: { channel: "C12345678", text: "boundary proof" },
     requestProfile: {},
   },
   {
@@ -149,8 +160,9 @@ beforeAll(async () => {
   process.env.STEWARD_AUDIT_HMAC_KEY = "0".repeat(64);
   process.env.STEWARD_EXECUTION_AUTH_SECRET = "1".repeat(64);
   process.env.STEWARD_MASTER_PASSWORD = "profile-boundary-master-password";
-  process.env.STEWARD_SECRET_ROUTE_ALLOWED_HOSTS = "api.github.com,api.x.com,api.example.com";
-  process.env.STEWARD_PROXY_ALLOWED_HOSTS = "api.github.com,api.x.com,api.example.com";
+  process.env.STEWARD_SECRET_ROUTE_ALLOWED_HOSTS =
+    "api.github.com,api.x.com,slack.com,api.example.com";
+  process.env.STEWARD_PROXY_ALLOWED_HOSTS = "api.github.com,api.x.com,slack.com,api.example.com";
   process.env.STEWARD_JWT_SECRET = "profile-boundary-jwt-secret-0123456789abcdef0123456789";
   const signingKeys = generateKeyPairSync("ed25519");
   process.env.STEWARD_AUDIT_SIGNING_KEY = signingKeys.privateKey

--- a/packages/api/src/__tests__/production-profile-boundary-e2e.test.ts
+++ b/packages/api/src/__tests__/production-profile-boundary-e2e.test.ts
@@ -431,6 +431,11 @@ describe("#220 real production profile boundaries", () => {
   }
 
   test("the identical authenticated runner rejects a malicious registered fixture pre-claim", async () => {
-    await runAuthenticatedBoundary(PROFILES[2], { maliciousOperationDescriptor: true });
+    const genericFixture = PROFILES.find(
+      ({ profile }) => profile === GENERIC_HTTP_PROVIDER_ACTION_PROFILE,
+    );
+    expect(genericFixture).toBeDefined();
+    if (!genericFixture) throw new Error("generic HTTP production fixture is missing");
+    await runAuthenticatedBoundary(genericFixture, { maliciousOperationDescriptor: true });
   });
 });

--- a/packages/api/src/__tests__/production-profile-boundary-e2e.test.ts
+++ b/packages/api/src/__tests__/production-profile-boundary-e2e.test.ts
@@ -194,6 +194,11 @@ beforeAll(async () => {
   const proxy = await import("@stwd/proxy/src/handlers/proxy");
   ({ dispatchGovernedExecution } = await import("@stwd/proxy/src/handlers/governed-execution"));
   proxy.__setResolveProxyHostForTests(async () => [{ address: "93.184.216.34", family: 4 }]);
+  // The boundary proof is about canonical provider authority and exact
+  // credential injection, not Redis availability. Make the rate-limit seam
+  // deterministic so an unrelated process-local fallback cannot turn every
+  // dispatch into a 429 when this file runs in a larger suite.
+  proxy.__setCheckProxyRateLimitForTests(async () => ({ allowed: true, resetMs: 0 }));
   proxy.__setForwardProxyRequestForTests(async () => {
     forwardCount += 1;
     return new Response('{"ok":true}', { status: 201 });
@@ -247,7 +252,11 @@ async function runAuthenticatedBoundary(
     undefined,
     "secret-vault",
   );
-  const encrypted = vault.encrypt("profile-boundary-credential", {
+  const credential =
+    fixture.profile === SLACK_PROVIDER_ACTION_PROFILE
+      ? "xoxb-profile-boundary-credential"
+      : "profile-boundary-credential";
+  const encrypted = vault.encrypt(credential, {
     tenantId: F.TENANT,
     name: "github",
     version: 1,

--- a/packages/api/src/__tests__/production-profile-conformance.test.ts
+++ b/packages/api/src/__tests__/production-profile-conformance.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import type { GithubOperationKey } from "@stwd/provider-github";
+import type { SlackOperationKey } from "@stwd/provider-slack";
 import type { XOperationKey } from "@stwd/provider-x";
 import { parseGovernedCanonicalActionForDispatch } from "@stwd/proxy/src/handlers/governed-execution";
 import {
@@ -11,6 +12,7 @@ import {
   inspectProviderProfileConformance,
   jcsStringify,
   REGISTERED_PROFILES,
+  SLACK_PROVIDER_ACTION_PROFILE,
   strictParseJson,
   validateGenericHttpDescriptor,
   X_PROVIDER_ACTION_PROFILE,
@@ -35,6 +37,13 @@ const FIXTURES = {
     method: undefined,
     args: { tweetId: "1234567890" },
     traversalArgs: { tweetId: ".." },
+    traversalCode: "CANON_PATH_SEGMENT_INVALID",
+  },
+  [SLACK_PROVIDER_ACTION_PROFILE]: {
+    operationKey: "slack.users.info" as const,
+    method: undefined,
+    args: { user: "U12345678" },
+    traversalArgs: { user: ".." },
     traversalCode: "CANON_PATH_SEGMENT_INVALID",
   },
   [GENERIC_HTTP_PROVIDER_ACTION_PROFILE]: {
@@ -79,6 +88,20 @@ const OPERATION_FIXTURES = {
       args: {},
     },
   ],
+  [SLACK_PROVIDER_ACTION_PROFILE]: [
+    {
+      operationKey: "slack.chat.postMessage",
+      args: { channel: "C12345678", text: "hello world" },
+    },
+    {
+      operationKey: "slack.conversations.list",
+      args: {},
+    },
+    {
+      operationKey: "slack.users.info",
+      args: { user: "U12345678" },
+    },
+  ],
   [GENERIC_HTTP_PROVIDER_ACTION_PROFILE]: [
     {
       operationKey: "generic.items.list",
@@ -105,6 +128,8 @@ function buildFromProductionSpec(
       return spec.build(fixture.operationKey as GithubOperationKey, args);
     case X_PROVIDER_ACTION_PROFILE:
       return spec.build(fixture.operationKey as XOperationKey, args);
+    case SLACK_PROVIDER_ACTION_PROFILE:
+      return spec.build(fixture.operationKey as SlackOperationKey, args);
     case GENERIC_HTTP_PROVIDER_ACTION_PROFILE:
       return spec.build(
         fixture.operationKey,

--- a/packages/api/src/__tests__/provider-slack-approval-rebuild.test.ts
+++ b/packages/api/src/__tests__/provider-slack-approval-rebuild.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { buildSlackAction, type SlackOperationKey } from "@stwd/provider-slack";
+import { jcsStringify } from "@stwd/shared";
+import { __rebuildApprovedActionForTests } from "../services/provider-action-service";
+
+describe("Slack approval-time canonical reconstruction", () => {
+  const cases: Array<[SlackOperationKey, Record<string, unknown>]> = [
+    [
+      "slack.chat.postMessage",
+      {
+        channel: "C12345678",
+        text: "approved payload",
+        blocks: [{ type: "section", text: { type: "plain_text", text: "hello" } }],
+        thread_ts: "1234567890.123456",
+      },
+    ],
+    [
+      "slack.conversations.list",
+      { types: ["private_channel", "public_channel"], limit: 25, cursor: "next_page=" },
+    ],
+    ["slack.users.info", { user: "U12345678" }],
+  ];
+
+  for (const [operationKey, args] of cases) {
+    test(`${operationKey} rebuilds the exact approved canonical action`, () => {
+      const original = buildSlackAction(operationKey, args);
+      const rebuilt = __rebuildApprovedActionForTests(
+        operationKey,
+        original.action as unknown as Record<string, unknown>,
+        original.safeSummary,
+      );
+      expect(jcsStringify(rebuilt.action)).toBe(jcsStringify(original.action));
+      expect(rebuilt.policyArgs).toEqual(original.policyArgs);
+      expect(rebuilt.safeSummary).toEqual(original.safeSummary);
+    });
+  }
+});

--- a/packages/api/src/services/provider-action-profile-specs.ts
+++ b/packages/api/src/services/provider-action-profile-specs.ts
@@ -51,6 +51,7 @@ export type ProductionProviderProfileSpec =
       readonly profile: typeof SLACK_PROVIDER_ACTION_PROFILE;
       readonly kind: "adapter-fixed";
       readonly operationKeys: readonly SlackOperationKey[];
+      readonly allowedOrigins: readonly string[];
       build(operationKey: SlackOperationKey, args: unknown): SlackActionBuild;
     }
   | {
@@ -93,6 +94,7 @@ const SLACK_SPEC = Object.freeze({
   profile: SLACK_PROVIDER_ACTION_PROFILE,
   kind: "adapter-fixed" as const,
   operationKeys: Object.freeze([...SLACK_OPERATION_KEYS]),
+  allowedOrigins: fixedProfileOrigins(SLACK_PROVIDER_ACTION_PROFILE),
   build: buildSlackAction,
 });
 

--- a/packages/api/src/services/provider-action-profile-specs.ts
+++ b/packages/api/src/services/provider-action-profile-specs.ts
@@ -5,6 +5,12 @@ import {
   type GithubOperationKey,
 } from "@stwd/provider-github";
 import {
+  buildSlackAction,
+  SLACK_OPERATION_KEYS,
+  type SlackActionBuild,
+  type SlackOperationKey,
+} from "@stwd/provider-slack";
+import {
   buildXAction,
   X_OPERATION_KEYS,
   type XActionBuild,
@@ -19,10 +25,11 @@ import {
   GITHUB_PROVIDER_ACTION_PROFILE,
   getProfileDescriptor,
   REGISTERED_PROFILES,
+  SLACK_PROVIDER_ACTION_PROFILE,
   X_PROVIDER_ACTION_PROFILE,
 } from "@stwd/shared";
 
-export type AdapterFixedActionBuild = GithubActionBuild | XActionBuild;
+export type AdapterFixedActionBuild = GithubActionBuild | SlackActionBuild | XActionBuild;
 
 function fixedProfileOrigins(profile: string): readonly string[] {
   const descriptor = getProfileDescriptor(profile);
@@ -39,6 +46,12 @@ export type ProductionProviderProfileSpec =
       readonly operationKeys: readonly GithubOperationKey[];
       readonly allowedOrigins: readonly string[];
       build(operationKey: GithubOperationKey, args: unknown): GithubActionBuild;
+    }
+  | {
+      readonly profile: typeof SLACK_PROVIDER_ACTION_PROFILE;
+      readonly kind: "adapter-fixed";
+      readonly operationKeys: readonly SlackOperationKey[];
+      build(operationKey: SlackOperationKey, args: unknown): SlackActionBuild;
     }
   | {
       readonly profile: typeof X_PROVIDER_ACTION_PROFILE;
@@ -76,6 +89,13 @@ const X_SPEC = Object.freeze({
   build: buildXAction,
 });
 
+const SLACK_SPEC = Object.freeze({
+  profile: SLACK_PROVIDER_ACTION_PROFILE,
+  kind: "adapter-fixed" as const,
+  operationKeys: Object.freeze([...SLACK_OPERATION_KEYS]),
+  build: buildSlackAction,
+});
+
 const GENERIC_HTTP_SPEC = Object.freeze({
   profile: GENERIC_HTTP_PROVIDER_ACTION_PROFILE,
   kind: "config-driven" as const,
@@ -96,7 +116,7 @@ const GENERIC_HTTP_SPEC = Object.freeze({
  * frozen list rather than exercising handwritten lookalikes.
  */
 export const PRODUCTION_PROVIDER_PROFILE_SPECS: readonly ProductionProviderProfileSpec[] =
-  Object.freeze([GITHUB_SPEC, X_SPEC, GENERIC_HTTP_SPEC]);
+  Object.freeze([GITHUB_SPEC, X_SPEC, SLACK_SPEC, GENERIC_HTTP_SPEC]);
 
 const SPEC_BY_PROFILE: ReadonlyMap<string, ProductionProviderProfileSpec> = new Map(
   PRODUCTION_PROVIDER_PROFILE_SPECS.map((spec) => [spec.profile, spec] as const),
@@ -155,6 +175,11 @@ export function buildAdapterFixedProviderAction(
     if (method !== undefined)
       throw new CanonError("CANON_UNKNOWN_FIELD", "method is adapter-fixed");
     return X_SPEC.build(operationKey as XOperationKey, args);
+  }
+  if ((SLACK_SPEC.operationKeys as readonly string[]).includes(operationKey)) {
+    if (method !== undefined)
+      throw new CanonError("CANON_UNKNOWN_FIELD", "method is adapter-fixed");
+    return SLACK_SPEC.build(operationKey as SlackOperationKey, args);
   }
   return undefined;
 }

--- a/packages/api/src/services/provider-action-service.ts
+++ b/packages/api/src/services/provider-action-service.ts
@@ -597,6 +597,15 @@ function rebuildApprovedAction(
   throw new Error(`unsupported provider operation '${operationKey}'`);
 }
 
+/** Test-only seam for approval-time adapter reconstruction invariants. */
+export function __rebuildApprovedActionForTests(
+  operationKey: string,
+  action: Record<string, unknown>,
+  safeSummary: Record<string, unknown>,
+): ProviderActionBuild {
+  return rebuildApprovedAction(operationKey, action, safeSummary);
+}
+
 // ─── Public result envelope ───────────────────────────────────────────────────
 
 export type ProviderActionOutcome =

--- a/packages/api/src/services/provider-action-service.ts
+++ b/packages/api/src/services/provider-action-service.ts
@@ -56,6 +56,11 @@ import {
   type GithubActionBuild,
   type GithubOperationKey,
 } from "@stwd/provider-github";
+import {
+  buildSlackAction,
+  type SlackActionBuild,
+  type SlackOperationKey,
+} from "@stwd/provider-slack";
 import { buildXAction, type XActionBuild, type XOperationKey } from "@stwd/provider-x";
 import {
   assertRegisteredProfile,
@@ -72,6 +77,7 @@ import {
   isGenericDescriptorError,
   jcsStringify,
   type ProviderRequestEnvelopeV1,
+  type SlackCanonicalActionV1,
   sha256HexPrefixed,
   UnregisteredProfileError,
   validateGenericHttpDescriptor,
@@ -93,7 +99,11 @@ import {
  * pipeline reads (action.profile/method/origin/path/query/headers/body,
  * policyArgs, safeSummary), so the pipeline consumes them uniformly.
  */
-export type ConcreteProviderActionBuild = GithubActionBuild | XActionBuild | GenericHttpActionBuild;
+export type ConcreteProviderActionBuild =
+  | GithubActionBuild
+  | XActionBuild
+  | SlackActionBuild
+  | GenericHttpActionBuild;
 
 /**
  * #201: a DEFERRED build for a config-driven (generic-http) operation. The route
@@ -114,6 +124,7 @@ export type ProviderActionBuild = ConcreteProviderActionBuild | DeferredGenericB
 type AnyCanonicalActionV1 =
   | GithubCanonicalActionV1
   | XCanonicalActionV1
+  | SlackCanonicalActionV1
   | GenericHttpCanonicalActionV1;
 
 function isDeferredGenericBuild(b: ProviderActionBuild): b is DeferredGenericBuild {
@@ -553,6 +564,35 @@ function rebuildApprovedAction(
       pullNumber: Number(match?.[3]),
       body: body?.body,
     });
+  }
+  if (operationKey === "slack.chat.postMessage") {
+    return buildSlackAction(operationKey as SlackOperationKey, {
+      channel: body?.channel,
+      ...(body?.text !== undefined ? { text: body.text } : {}),
+      ...(body?.blocks !== undefined ? { blocks: body.blocks } : {}),
+      ...(body?.thread_ts !== undefined ? { thread_ts: body.thread_ts } : {}),
+    });
+  }
+  if (operationKey === "slack.conversations.list") {
+    const query = Array.isArray(action.orderedQueryPairs) ? action.orderedQueryPairs : [];
+    const q = new Map<string, unknown>();
+    for (const pair of query) {
+      if (Array.isArray(pair) && pair.length === 2 && typeof pair[0] === "string") {
+        q.set(pair[0], pair[1]);
+      }
+    }
+    return buildSlackAction(operationKey as SlackOperationKey, {
+      ...(q.has("types") ? { types: String(q.get("types")).split(",") } : {}),
+      ...(q.has("limit") ? { limit: Number(q.get("limit")) } : {}),
+      ...(q.has("cursor") ? { cursor: q.get("cursor") } : {}),
+    });
+  }
+  if (operationKey === "slack.users.info") {
+    const query = Array.isArray(action.orderedQueryPairs) ? action.orderedQueryPairs : [];
+    const user = query.find(
+      (pair) => Array.isArray(pair) && pair.length === 2 && pair[0] === "user",
+    )?.[1];
+    return buildSlackAction(operationKey as SlackOperationKey, { user });
   }
   throw new Error(`unsupported provider operation '${operationKey}'`);
 }

--- a/packages/api/src/services/provider-action-service.ts
+++ b/packages/api/src/services/provider-action-service.ts
@@ -602,8 +602,9 @@ export function __rebuildApprovedActionForTests(
   operationKey: string,
   action: Record<string, unknown>,
   safeSummary: Record<string, unknown>,
+  requestProfile: Record<string, unknown> = {},
 ): ProviderActionBuild {
-  return rebuildApprovedAction(operationKey, action, safeSummary);
+  return rebuildApprovedAction(operationKey, action, safeSummary, requestProfile);
 }
 
 // ─── Public result envelope ───────────────────────────────────────────────────

--- a/packages/db/drizzle/0096_slack_provider_profile.sql
+++ b/packages/db/drizzle/0096_slack_provider_profile.sql
@@ -1,0 +1,9 @@
+-- #202: adapter-fixed Slack provider profile (slack.provider-action.v1).
+--
+-- The provider-action binding table uses this named CHECK as its storage-layer
+-- backstop. Keep the allowlist cumulative while admitting Slack bindings
+-- produced by the registered production adapter.
+ALTER TABLE "provider_action_bindings" DROP CONSTRAINT "provider_action_bindings_profile_chk";
+--> statement-breakpoint
+ALTER TABLE "provider_action_bindings" ADD CONSTRAINT "provider_action_bindings_profile_chk"
+  CHECK ("canonical_profile" IN ('github.provider-action.v1', 'x.provider-action.v1', 'generic-http.provider-action.v1', 'slack.provider-action.v1'));

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -533,6 +533,13 @@
       "when": 1787020069000,
       "tag": "0095_approval_queue_agent_pagination",
       "breakpoints": true
+    },
+    {
+      "idx": 96,
+      "version": "7",
+      "when": 1787020070000,
+      "tag": "0096_slack_provider_profile",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/policy-engine/src/__tests__/slack-channel-policy.test.ts
+++ b/packages/policy-engine/src/__tests__/slack-channel-policy.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import {
+  composeProviderActionPolicyDecision,
+  type ProviderPolicyContext,
+  type ProviderPolicyRule,
+} from "../capability-intent";
+
+const rule: ProviderPolicyRule = {
+  id: "slack-channel-scope",
+  type: "capability-intent",
+  enabled: true,
+  config: {
+    capabilities: ["slack.chat.postMessage"],
+    effect: "allow",
+    constraints: { argEquals: { channel: "C12345678" } },
+  },
+};
+
+function context(channel: string): ProviderPolicyContext {
+  return {
+    operationKey: "slack.chat.postMessage",
+    args: { channel, hasBlocks: false, textLength: 5 },
+    method: "POST",
+    host: "slack.com",
+    path: "/api/chat.postMessage",
+    invokeCount1h: 0,
+  };
+}
+
+describe("Slack channel policy scope", () => {
+  test("channel belongs to capability-intent args, not the credential grant", () => {
+    expect(composeProviderActionPolicyDecision([rule], context("C12345678")).effect).toBe("allow");
+    expect(composeProviderActionPolicyDecision([rule], context("C99999999")).effect).toBe(
+      "hard_deny",
+    );
+  });
+});

--- a/packages/provider-slack/package.json
+++ b/packages/provider-slack/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@stwd/provider-slack",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@stwd/shared": "workspace:*"
+  },
+  "description": "Slack governed provider-action adapter"
+}

--- a/packages/provider-slack/src/__tests__/operations.test.ts
+++ b/packages/provider-slack/src/__tests__/operations.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { CanonError } from "@stwd/shared";
+import { buildSlackAction } from "../operations";
+
+describe("Slack provider actions", () => {
+  test("builds postMessage with channel as a policy argument and no content leakage", () => {
+    const built = buildSlackAction("slack.chat.postMessage", {
+      channel: "C12345678",
+      text: "quarterly secret",
+      blocks: [{ type: "section", text: { type: "mrkdwn", text: "hello" } }],
+      thread_ts: "1712345678.123456",
+    });
+    expect(built.action).toMatchObject({
+      profile: "slack.provider-action.v1",
+      origin: "https://slack.com",
+      normalizedPath: "/api/chat.postMessage",
+    });
+    expect(built.policyArgs).toEqual({ channel: "C12345678", hasBlocks: true, textLength: 16 });
+    expect(JSON.stringify(built.safeSummary)).not.toContain("quarterly secret");
+  });
+
+  test("builds bounded read operations", () => {
+    expect(
+      buildSlackAction("slack.conversations.list", {
+        types: ["private_channel", "public_channel"],
+        limit: 100,
+      }).action.orderedQueryPairs,
+    ).toEqual([
+      ["limit", "100"],
+      ["types", "private_channel,public_channel"],
+    ]);
+    expect(buildSlackAction("slack.users.info", { user: "U12345678" }).policyArgs).toEqual({
+      user: "U12345678",
+    });
+  });
+
+  test("fails closed on unknown, malformed, and credential-shaped inputs", () => {
+    for (const args of [
+      { channel: "#general", text: "hello" },
+      { channel: "C12345678", text: "hello", token: "xoxb-canary" },
+      { channel: "C12345678", blocks: [{ type: "section", accessToken: "canary" }] },
+    ]) {
+      expect(() => buildSlackAction("slack.chat.postMessage", args)).toThrow(CanonError);
+    }
+  });
+});

--- a/packages/provider-slack/src/index.ts
+++ b/packages/provider-slack/src/index.ts
@@ -1,0 +1,8 @@
+export {
+  buildSlackAction,
+  isSlackOperationKey,
+  SLACK_OPERATION_KEYS,
+  SLACK_OPERATION_RISK,
+  type SlackActionBuild,
+  type SlackOperationKey,
+} from "./operations.js";

--- a/packages/provider-slack/src/operations.ts
+++ b/packages/provider-slack/src/operations.ts
@@ -1,0 +1,211 @@
+import { createHash } from "node:crypto";
+import {
+  CanonError,
+  type CanonicalMethod,
+  canonicalizeRawInternalSlackAction,
+  type JsonValue,
+  SLACK_CANONICAL_ORIGIN,
+  type SlackCanonicalActionV1,
+} from "@stwd/shared";
+
+export const SLACK_OPERATION_KEYS = [
+  "slack.chat.postMessage",
+  "slack.conversations.list",
+  "slack.users.info",
+] as const;
+export type SlackOperationKey = (typeof SLACK_OPERATION_KEYS)[number];
+export const SLACK_OPERATION_RISK: Readonly<Record<SlackOperationKey, "read" | "write">> = {
+  "slack.chat.postMessage": "write",
+  "slack.conversations.list": "read",
+  "slack.users.info": "read",
+};
+export function isSlackOperationKey(value: unknown): value is SlackOperationKey {
+  return typeof value === "string" && (SLACK_OPERATION_KEYS as readonly string[]).includes(value);
+}
+export interface SlackActionBuild {
+  operationKey: SlackOperationKey;
+  method: CanonicalMethod;
+  risk: "read" | "write";
+  action: SlackCanonicalActionV1;
+  safeSummary: Record<string, unknown>;
+  policyArgs: Record<string, unknown>;
+}
+
+const CHANNEL_RE = /^[CGD][A-Z0-9]{8,19}$/;
+const USER_RE = /^[UW][A-Z0-9]{8,19}$/;
+const THREAD_TS_RE = /^[0-9]{10,16}\.[0-9]{6}$/;
+const TYPES = new Set(["public_channel", "private_channel", "mpim", "im"]);
+const CREDENTIAL_KEY =
+  /(?:authorization|cookie|token|secret|credential|api[-_]?key|private[-_]?key)$/i;
+
+function object(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new CanonError("CANON_JSON_SHAPE_INVALID", "arguments must be an object");
+  }
+  return value as Record<string, unknown>;
+}
+function keys(args: Record<string, unknown>, allowed: readonly string[]): void {
+  for (const key of Object.keys(args)) {
+    if (!allowed.includes(key)) throw new CanonError("CANON_UNKNOWN_FIELD", `unknown '${key}'`);
+  }
+}
+function required(args: Record<string, unknown>, key: string): unknown {
+  if (!(key in args)) throw new CanonError("CANON_REQUIRED_FIELD_MISSING", `missing '${key}'`);
+  return args[key];
+}
+function identifier(value: unknown, name: string, re: RegExp): string {
+  if (typeof value !== "string") throw new CanonError("CANON_FIELD_TYPE_INVALID", `${name} string`);
+  if (!re.test(value)) throw new CanonError("CANON_PATH_SEGMENT_INVALID", `invalid ${name}`);
+  return value;
+}
+function text(value: unknown): string {
+  if (typeof value !== "string") throw new CanonError("CANON_FIELD_TYPE_INVALID", "text string");
+  if ([...value].length < 1 || [...value].length > 40000) {
+    throw new CanonError("CANON_FIELD_TYPE_INVALID", "text length out of range");
+  }
+  return value;
+}
+function assertPublicJson(value: unknown, depth = 0): asserts value is JsonValue {
+  if (depth > 12) throw new CanonError("CANON_FIELD_TYPE_INVALID", "blocks too deeply nested");
+  if (value === null || typeof value === "string" || typeof value === "boolean") return;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value) || !Number.isSafeInteger(value)) {
+      throw new CanonError("CANON_NUMBER_UNSAFE", "unsafe blocks number");
+    }
+    return;
+  }
+  if (Array.isArray(value)) {
+    if (value.length > 100)
+      throw new CanonError("CANON_FIELD_TYPE_INVALID", "blocks array too long");
+    for (const item of value) assertPublicJson(item, depth + 1);
+    return;
+  }
+  if (value && typeof value === "object") {
+    for (const [key, nested] of Object.entries(value)) {
+      if (CREDENTIAL_KEY.test(key)) {
+        throw new CanonError("CANON_UNKNOWN_FIELD", "credential-shaped blocks field");
+      }
+      assertPublicJson(nested, depth + 1);
+    }
+    return;
+  }
+  throw new CanonError("CANON_FIELD_TYPE_INVALID", "unsupported blocks value");
+}
+
+function postMessage(raw: unknown): SlackActionBuild {
+  const args = object(raw);
+  keys(args, ["channel", "text", "blocks", "thread_ts"]);
+  const channel = identifier(required(args, "channel"), "channel", CHANNEL_RE);
+  if (!("text" in args) && !("blocks" in args)) {
+    throw new CanonError("CANON_REQUIRED_FIELD_MISSING", "text or blocks required");
+  }
+  const body: Record<string, JsonValue> = { channel };
+  if ("text" in args) body.text = text(args.text);
+  if ("blocks" in args) {
+    if (!Array.isArray(args.blocks) || args.blocks.length < 1 || args.blocks.length > 50) {
+      throw new CanonError("CANON_FIELD_TYPE_INVALID", "blocks must contain 1..50 items");
+    }
+    assertPublicJson(args.blocks);
+    body.blocks = args.blocks;
+  }
+  if ("thread_ts" in args) {
+    body.thread_ts = identifier(args.thread_ts, "thread_ts", THREAD_TS_RE);
+  }
+  const bytes = Buffer.from(JSON.stringify(body), "utf8");
+  if (bytes.length > 200_000) throw new CanonError("CANON_FIELD_TYPE_INVALID", "body too large");
+  const hasBlocks = "blocks" in body;
+  const textLength = typeof body.text === "string" ? [...body.text].length : 0;
+  return {
+    operationKey: "slack.chat.postMessage",
+    method: "POST",
+    risk: "write",
+    action: canonicalizeRawInternalSlackAction({
+      method: "POST",
+      origin: SLACK_CANONICAL_ORIGIN,
+      path: "/api/chat.postMessage",
+      contentType: "application/json",
+      body,
+    }),
+    safeSummary: {
+      operation: "slack.chat.postMessage",
+      channel,
+      hasBlocks,
+      textLength,
+      bodySha256: `sha256:${createHash("sha256").update(bytes).digest("hex")}`,
+    },
+    policyArgs: { channel, hasBlocks, textLength },
+  };
+}
+
+function conversationsList(raw: unknown): SlackActionBuild {
+  const args = object(raw);
+  keys(args, ["types", "limit", "cursor"]);
+  const query: Array<[string, string]> = [];
+  let types: string[] = ["public_channel"];
+  if ("types" in args) {
+    if (
+      !Array.isArray(args.types) ||
+      args.types.length < 1 ||
+      args.types.some((v) => !TYPES.has(String(v)))
+    ) {
+      throw new CanonError("CANON_QUERY_VALUE_OUT_OF_RANGE", "invalid conversation types");
+    }
+    types = [...new Set(args.types as string[])].sort();
+  }
+  query.push(["types", types.join(",")]);
+  const limit = args.limit ?? 100;
+  if (typeof limit !== "number" || !Number.isInteger(limit) || limit < 1 || limit > 200) {
+    throw new CanonError("CANON_QUERY_VALUE_OUT_OF_RANGE", "limit out of range");
+  }
+  query.push(["limit", String(limit)]);
+  if ("cursor" in args) {
+    if (typeof args.cursor !== "string" || !/^[A-Za-z0-9=_-]{1,512}$/.test(args.cursor)) {
+      throw new CanonError("CANON_QUERY_VALUE_OUT_OF_RANGE", "invalid cursor");
+    }
+    query.push(["cursor", args.cursor]);
+  }
+  return {
+    operationKey: "slack.conversations.list",
+    method: "GET",
+    risk: "read",
+    action: canonicalizeRawInternalSlackAction({
+      method: "GET",
+      origin: SLACK_CANONICAL_ORIGIN,
+      path: "/api/conversations.list",
+      query,
+    }),
+    safeSummary: {
+      operation: "slack.conversations.list",
+      types,
+      limit,
+      hasCursor: "cursor" in args,
+    },
+    policyArgs: { types, limit },
+  };
+}
+
+function usersInfo(raw: unknown): SlackActionBuild {
+  const args = object(raw);
+  keys(args, ["user"]);
+  const user = identifier(required(args, "user"), "user", USER_RE);
+  return {
+    operationKey: "slack.users.info",
+    method: "GET",
+    risk: "read",
+    action: canonicalizeRawInternalSlackAction({
+      method: "GET",
+      origin: SLACK_CANONICAL_ORIGIN,
+      path: "/api/users.info",
+      query: [["user", user]],
+    }),
+    safeSummary: { operation: "slack.users.info", user },
+    policyArgs: { user },
+  };
+}
+
+export function buildSlackAction(key: SlackOperationKey, args: unknown): SlackActionBuild {
+  if (key === "slack.chat.postMessage") return postMessage(args);
+  if (key === "slack.conversations.list") return conversationsList(args);
+  if (key === "slack.users.info") return usersInfo(args);
+  throw new CanonError("CANON_PROFILE_UNSUPPORTED", "unknown Slack operation");
+}

--- a/packages/provider-slack/tsconfig.json
+++ b/packages/provider-slack/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": { "rootDir": "src", "noEmit": true },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/proxy/src/__tests__/slack-credential-route.test.ts
+++ b/packages/proxy/src/__tests__/slack-credential-route.test.ts
@@ -130,6 +130,7 @@ describe("Slack narrow credential route", () => {
     ["user token", "xoxp-CANARY-user-token-must-not-forward"],
     ["arbitrary plaintext", "CANARY-not-a-slack-token"],
     ["truncated bot token", "xoxb-short"],
+    ["line-terminated bot token", "xoxb-CANARY-valid-looking\n"],
   ] as const) {
     test(`rejects ${label} at use time without forwarding or leaking it`, async () => {
       const { tenantId, agentId } = await fixture(invalidCredential);

--- a/packages/proxy/src/__tests__/slack-credential-route.test.ts
+++ b/packages/proxy/src/__tests__/slack-credential-route.test.ts
@@ -19,6 +19,10 @@ beforeAll(async () => {
   process.env.STEWARD_PGLITE_MEMORY = "true";
   process.env.STEWARD_MASTER_PASSWORD = MASTER_PASSWORD;
   process.env.STEWARD_JWT_SECRET = "proxy-slack-route-jwt-secret-with-enough-bytes";
+  // The production proxy deliberately requires request signing and Redis. This
+  // integration test exercises the credential seam in the explicit local-test
+  // posture; setting the flag before importing the handler is intentional.
+  process.env.STEWARD_PROXY_DEV_MODE = "true";
   const { db, client } = await createPGLiteDb("memory://");
   setPGLiteOverride(db, async () => client.close());
   ({ authMiddleware } = await import("../middleware/auth"));
@@ -32,9 +36,10 @@ afterAll(async () => {
   delete process.env.STEWARD_PGLITE_MEMORY;
   delete process.env.STEWARD_MASTER_PASSWORD;
   delete process.env.STEWARD_JWT_SECRET;
+  delete process.env.STEWARD_PROXY_DEV_MODE;
 });
 
-async function fixture() {
+async function fixture(secretValue = SLACK_TOKEN) {
   const tenantId = `tenant-slack-${crypto.randomUUID()}`;
   const agentId = `agent-slack-${crypto.randomUUID()}`;
   await getDb()
@@ -44,7 +49,7 @@ async function fixture() {
     .insert(agents)
     .values({ id: agentId, tenantId, name: agentId, walletAddress: `0x${"1".repeat(40)}` });
   const vault = new SecretVault(MASTER_PASSWORD);
-  const secret = await vault.createSecret(tenantId, "slack-bot", SLACK_TOKEN);
+  const secret = await vault.createSecret(tenantId, "slack-bot", secretValue);
   await vault.createRoute(tenantId, secret.id, {
     agentId,
     hostPattern: "slack.com",
@@ -118,4 +123,35 @@ describe("Slack narrow credential route", () => {
     expect(audit.some((row) => row.statusCode === 200)).toBe(false);
     expect(audit.at(-1)?.reason).toBe("slack-api-error:channel_not_found");
   });
+
+  for (const [label, invalidCredential] of [
+    ["user token", "xoxp-CANARY-user-token-must-not-forward"],
+    ["arbitrary plaintext", "CANARY-not-a-slack-token"],
+    ["truncated bot token", "xoxb-short"],
+  ] as const) {
+    test(`rejects ${label} at use time without forwarding or leaking it`, async () => {
+      const { tenantId, agentId } = await fixture(invalidCredential);
+      let forwarded = false;
+      proxyMod.__setForwardProxyRequestForTests(async () => {
+        forwarded = true;
+        return new Response('{"ok":true}', {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      });
+
+      const response = await invoke(tenantId, agentId);
+      const body = await response.text();
+      const audit = await getDb()
+        .select()
+        .from(proxyAuditLog)
+        .where(eq(proxyAuditLog.tenantId, tenantId));
+
+      expect(response.status).toBe(403);
+      expect(forwarded).toBe(false);
+      expect(body).not.toContain(invalidCredential);
+      expect(JSON.stringify(audit)).not.toContain(invalidCredential);
+      expect(audit.at(-1)?.reason).toBe("slack-bot-credential-required");
+    });
+  }
 });

--- a/packages/proxy/src/__tests__/slack-credential-route.test.ts
+++ b/packages/proxy/src/__tests__/slack-credential-route.test.ts
@@ -27,12 +27,14 @@ beforeAll(async () => {
   setPGLiteOverride(db, async () => client.close());
   ({ authMiddleware } = await import("../middleware/auth"));
   proxyMod = await import("../handlers/proxy");
+  proxyMod.__resetSecretVaultForTests();
   ({ handleProxy } = proxyMod);
   proxyMod.__setResolveProxyHostForTests(async () => [{ address: "13.107.42.16", family: 4 }]);
 });
 
 afterAll(async () => {
   await closeDb().catch(() => {});
+  proxyMod.__resetSecretVaultForTests();
   delete process.env.STEWARD_PGLITE_MEMORY;
   delete process.env.STEWARD_MASTER_PASSWORD;
   delete process.env.STEWARD_JWT_SECRET;

--- a/packages/proxy/src/__tests__/slack-credential-route.test.ts
+++ b/packages/proxy/src/__tests__/slack-credential-route.test.ts
@@ -110,5 +110,12 @@ describe("Slack narrow credential route", () => {
     const body = await response.text();
     expect(body).toContain("channel_not_found");
     expect(body).not.toContain(SLACK_TOKEN);
+    const audit = await getDb()
+      .select()
+      .from(proxyAuditLog)
+      .where(eq(proxyAuditLog.tenantId, tenantId));
+    expect(audit.map((row) => row.statusCode)).toEqual([102, 502]);
+    expect(audit.some((row) => row.statusCode === 200)).toBe(false);
+    expect(audit.at(-1)?.reason).toBe("slack-api-error:channel_not_found");
   });
 });

--- a/packages/proxy/src/__tests__/slack-credential-route.test.ts
+++ b/packages/proxy/src/__tests__/slack-credential-route.test.ts
@@ -1,0 +1,114 @@
+import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { signAgentToken } from "@stwd/auth";
+import { agents, closeDb, getDb, proxyAuditLog, tenants } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { SecretVault } from "@stwd/vault";
+import { eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { PROXY_SCOPE } from "../config";
+
+const MASTER_PASSWORD = "proxy-slack-route-master";
+setDefaultTimeout(30_000);
+const SLACK_TOKEN = "xoxb-CANARY-never-agent-audit-log";
+let authMiddleware: typeof import("../middleware/auth")["authMiddleware"];
+let handleProxy: typeof import("../handlers/proxy")["handleProxy"];
+let proxyMod: typeof import("../handlers/proxy");
+let capturedAuthorization = "";
+
+beforeAll(async () => {
+  process.env.STEWARD_PGLITE_MEMORY = "true";
+  process.env.STEWARD_MASTER_PASSWORD = MASTER_PASSWORD;
+  process.env.STEWARD_JWT_SECRET = "proxy-slack-route-jwt-secret-with-enough-bytes";
+  const { db, client } = await createPGLiteDb("memory://");
+  setPGLiteOverride(db, async () => client.close());
+  ({ authMiddleware } = await import("../middleware/auth"));
+  proxyMod = await import("../handlers/proxy");
+  ({ handleProxy } = proxyMod);
+  proxyMod.__setResolveProxyHostForTests(async () => [{ address: "13.107.42.16", family: 4 }]);
+});
+
+afterAll(async () => {
+  await closeDb().catch(() => {});
+  delete process.env.STEWARD_PGLITE_MEMORY;
+  delete process.env.STEWARD_MASTER_PASSWORD;
+  delete process.env.STEWARD_JWT_SECRET;
+});
+
+async function fixture() {
+  const tenantId = `tenant-slack-${crypto.randomUUID()}`;
+  const agentId = `agent-slack-${crypto.randomUUID()}`;
+  await getDb()
+    .insert(tenants)
+    .values({ id: tenantId, name: tenantId, apiKeyHash: `h-${tenantId}` });
+  await getDb()
+    .insert(agents)
+    .values({ id: agentId, tenantId, name: agentId, walletAddress: `0x${"1".repeat(40)}` });
+  const vault = new SecretVault(MASTER_PASSWORD);
+  const secret = await vault.createSecret(tenantId, "slack-bot", SLACK_TOKEN);
+  await vault.createRoute(tenantId, secret.id, {
+    agentId,
+    hostPattern: "slack.com",
+    pathPattern: "/api/chat.postMessage",
+    method: "POST",
+    injectAs: "header",
+    injectKey: "authorization",
+    injectFormat: "Bearer {value}",
+  });
+  return { tenantId, agentId };
+}
+
+async function invoke(tenantId: string, agentId: string) {
+  const token = await signAgentToken({ agentId, tenantId, scopes: ["agent", PROXY_SCOPE] }, "1h");
+  const app = new Hono();
+  app.use("*", authMiddleware);
+  app.all("*", handleProxy);
+  return app.request("/slack/api/chat.postMessage", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+      "idempotency-key": crypto.randomUUID(),
+    },
+    body: JSON.stringify({ channel: "C12345678", text: "hello" }),
+  });
+}
+
+describe("Slack narrow credential route", () => {
+  test("injects bot token only upstream and keeps it out of response and audit", async () => {
+    const { tenantId, agentId } = await fixture();
+    capturedAuthorization = "";
+    proxyMod.__setForwardProxyRequestForTests(async (_url, _method, headers) => {
+      capturedAuthorization = headers.get("authorization") ?? "";
+      return new Response('{"ok":true,"ts":"1712345678.123456"}', {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const response = await invoke(tenantId, agentId);
+    expect(response.status).toBe(200);
+    expect(capturedAuthorization).toBe(`Bearer ${SLACK_TOKEN}`);
+    expect(await response.text()).not.toContain(SLACK_TOKEN);
+    const audit = await getDb()
+      .select()
+      .from(proxyAuditLog)
+      .where(eq(proxyAuditLog.tenantId, tenantId));
+    expect(JSON.stringify(audit)).not.toContain(SLACK_TOKEN);
+  });
+
+  test("maps Slack HTTP 200 ok:false to a failed dispatch without leaking token", async () => {
+    const { tenantId, agentId } = await fixture();
+    proxyMod.__setForwardProxyRequestForTests(async (_url, _method, headers) => {
+      capturedAuthorization = headers.get("authorization") ?? "";
+      return new Response('{"ok":false,"error":"channel_not_found"}', {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const response = await invoke(tenantId, agentId);
+    expect(capturedAuthorization).toBe(`Bearer ${SLACK_TOKEN}`);
+    expect(response.status).toBe(502);
+    const body = await response.text();
+    expect(body).toContain("channel_not_found");
+    expect(body).not.toContain(SLACK_TOKEN);
+  });
+});

--- a/packages/proxy/src/__tests__/slack-response.test.ts
+++ b/packages/proxy/src/__tests__/slack-response.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { classifySlackWebApiPayload } from "../handlers/proxy";
+
+describe("Slack Web API response semantics", () => {
+  test("requires explicit ok:true even when HTTP transport succeeded", () => {
+    expect(classifySlackWebApiPayload('{"ok":true,"ts":"1712345678.123456"}')).toBeNull();
+    expect(classifySlackWebApiPayload('{"ok":false,"error":"channel_not_found"}')).toBe(
+      "channel_not_found",
+    );
+    expect(classifySlackWebApiPayload('{"error":"missing_ok"}')).toBe("missing_ok");
+    expect(classifySlackWebApiPayload("not json")).toBe("invalid_response");
+    expect(classifySlackWebApiPayload('{"ok":false,"error":"token leaked: xoxb-secret"}')).toBe(
+      "invalid_response",
+    );
+  });
+});

--- a/packages/proxy/src/__tests__/slack-response.test.ts
+++ b/packages/proxy/src/__tests__/slack-response.test.ts
@@ -12,5 +12,7 @@ describe("Slack Web API response semantics", () => {
     expect(classifySlackWebApiPayload('{"ok":false,"error":"token leaked: xoxb-secret"}')).toBe(
       "invalid_response",
     );
+    expect(classifySlackWebApiPayload('{"ok":false,"ok":true}')).toBe("invalid_response");
+    expect(classifySlackWebApiPayload('[{"ok":true}]')).toBe("invalid_response");
   });
 });

--- a/packages/proxy/src/config.ts
+++ b/packages/proxy/src/config.ts
@@ -15,6 +15,7 @@ export const DEFAULT_ALIASES: Record<string, string> = {
   helius: "api.helius.xyz",
   github: "api.github.com",
   x: "api.x.com",
+  slack: "slack.com",
 };
 
 /** Parse a bounded integer setting at module load so malformed resource limits fail closed. */

--- a/packages/proxy/src/handlers/proxy.ts
+++ b/packages/proxy/src/handlers/proxy.ts
@@ -1871,6 +1871,26 @@ export async function handleProxy(c: Context): Promise<Response> {
   let responseBody: ReadableStream<Uint8Array> | ArrayBuffer | null = response.body;
   const contentType = response.headers.get("content-type") || "";
   const isJsonResponse = contentType.includes("application/json");
+  let slackSemanticFailure: string | null = null;
+
+  // Slack Web API encodes operation failures as HTTP 200 + {ok:false}. Treat
+  // that envelope as a failed dispatch, while retaining the buffered bytes for
+  // credential-reflection scanning below. A malformed/non-JSON 2xx response is
+  // also fail-closed: it cannot prove that the requested action succeeded.
+  if (target.host === "slack.com" && response.status >= 200 && response.status < 300) {
+    try {
+      const length = Number(response.headers.get("content-length") ?? "0");
+      if (Number.isFinite(length) && length > MAX_PROXY_RESPONSE_BYTES) {
+        throw new Error("Slack response too large");
+      }
+      const buffer = await response.arrayBuffer();
+      if (buffer.byteLength > MAX_PROXY_RESPONSE_BYTES) throw new Error("Slack response too large");
+      responseBody = buffer;
+      slackSemanticFailure = classifySlackWebApiPayload(new TextDecoder().decode(buffer));
+    } catch {
+      slackSemanticFailure = "invalid_response";
+    }
+  }
   const isLLMHost =
     isProxyRedisAvailable() &&
     (target.host === "api.openai.com" || target.host === "api.anthropic.com");
@@ -2069,6 +2089,29 @@ export async function handleProxy(c: Context): Promise<Response> {
       return c.json({ ok: false, error: "Upstream response reflected injected credential" }, 502);
     }
   }
+  if (slackSemanticFailure) {
+    await recordAudit({
+      agentId,
+      tenantId,
+      targetHost: target.host,
+      targetPath: target.path,
+      method,
+      statusCode: 502,
+      latencyMs: Date.now() - startTime,
+      reason: `slack-api-error:${slackSemanticFailure}`,
+    });
+    injectedCredentialValue = null;
+    sensitiveCredentialValues = [];
+    proxySlot.release();
+    return c.json(
+      {
+        ok: false,
+        error: "Slack upstream operation failed",
+        data: { providerError: slackSemanticFailure },
+      },
+      502,
+    );
+  }
   injectedCredentialValue = null;
   sensitiveCredentialValues = [];
 
@@ -2113,6 +2156,19 @@ export async function handleProxy(c: Context): Promise<Response> {
     statusText: response.statusText,
     headers: responseHeaders,
   });
+}
+
+/** Null means Slack explicitly attested success; any string is a safe failure code. */
+export function classifySlackWebApiPayload(bodyText: string): string | null {
+  try {
+    const parsed = JSON.parse(bodyText) as { ok?: unknown; error?: unknown };
+    if (parsed.ok === true) return null;
+    return typeof parsed.error === "string" && /^[a-z0-9_]{1,128}$/i.test(parsed.error)
+      ? parsed.error
+      : "invalid_response";
+  } catch {
+    return "invalid_response";
+  }
 }
 
 // ─── Exports for testing ─────────────────────────────────────────────────────

--- a/packages/proxy/src/handlers/proxy.ts
+++ b/packages/proxy/src/handlers/proxy.ts
@@ -31,6 +31,7 @@ import {
   workspaces,
 } from "@stwd/db";
 import { getRedis, type SpendReservation, settleReservedSpend } from "@stwd/redis";
+import { strictParseJson } from "@stwd/shared";
 import { SecretVault } from "@stwd/vault";
 import type { Context } from "hono";
 import { boundedPositiveIntegerEnv, isProxyDevMode } from "../config";
@@ -2166,7 +2167,10 @@ export async function handleProxy(c: Context): Promise<Response> {
 /** Null means Slack explicitly attested success; any string is a safe failure code. */
 export function classifySlackWebApiPayload(bodyText: string): string | null {
   try {
-    const parsed = JSON.parse(bodyText) as { ok?: unknown; error?: unknown };
+    const parsed = strictParseJson(bodyText) as { ok?: unknown; error?: unknown };
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return "invalid_response";
+    }
     if (parsed.ok === true) return null;
     return typeof parsed.error === "string" && /^[a-z0-9_]{1,128}$/i.test(parsed.error)
       ? parsed.error

--- a/packages/proxy/src/handlers/proxy.ts
+++ b/packages/proxy/src/handlers/proxy.ts
@@ -149,7 +149,9 @@ async function decryptSecret(tenantId: string, secretId: string): Promise<string
  * secret from inheriting the bot grant's authority.
  */
 function isSlackBotTokenCredential(value: string): boolean {
-  return value.length <= 512 && /^xoxb-[A-Za-z0-9-]{10,}$/.test(value);
+  if (!value.startsWith("xoxb-") || value.length > 512) return false;
+  const suffix = value.slice(5);
+  return suffix.length >= 10 && !/[^A-Za-z0-9-]/.test(suffix);
 }
 
 // ─── Credential injection ────────────────────────────────────────────────────

--- a/packages/proxy/src/handlers/proxy.ts
+++ b/packages/proxy/src/handlers/proxy.ts
@@ -1850,18 +1850,7 @@ export async function handleProxy(c: Context): Promise<Response> {
 
   const latencyMs = Date.now() - startTime;
 
-  // 7. Audit log
-  await recordAudit({
-    agentId,
-    tenantId,
-    targetHost: target.host,
-    targetPath: target.path,
-    method,
-    statusCode: response.status,
-    latencyMs,
-  });
-
-  // 7.5. Spend tracking for LLM API responses
+  // 7. Inspect provider-specific response semantics before recording an outcome.
   //
   // For known LLM hosts, we need to read the response body to extract token
   // usage for cost estimation. We buffer the response body, parse it, track
@@ -1891,6 +1880,22 @@ export async function handleProxy(c: Context): Promise<Response> {
       slackSemanticFailure = "invalid_response";
     }
   }
+
+  // Slack can report failure in an HTTP 200 envelope. Do not persist a
+  // contradictory successful audit row before the semantic failure row below.
+  if (!slackSemanticFailure) {
+    await recordAudit({
+      agentId,
+      tenantId,
+      targetHost: target.host,
+      targetPath: target.path,
+      method,
+      statusCode: response.status,
+      latencyMs,
+    });
+  }
+
+  // 7.5. Spend tracking for LLM API responses
   const isLLMHost =
     isProxyRedisAvailable() &&
     (target.host === "api.openai.com" || target.host === "api.anthropic.com");

--- a/packages/proxy/src/handlers/proxy.ts
+++ b/packages/proxy/src/handlers/proxy.ts
@@ -66,6 +66,11 @@ function getSecretVault(): SecretVault {
   return _secretVault;
 }
 
+/** Reset the process-local vault cache between isolated test fixtures. */
+export function __resetSecretVaultForTests(): void {
+  _secretVault = null;
+}
+
 // ─── Route matching ──────────────────────────────────────────────────────────
 
 /**

--- a/packages/proxy/src/handlers/proxy.ts
+++ b/packages/proxy/src/handlers/proxy.ts
@@ -136,6 +136,17 @@ async function decryptSecret(tenantId: string, secretId: string): Promise<string
   return getSecretVault().decryptSecret(tenantId, secretId);
 }
 
+/**
+ * Slack's governed routes are intentionally bot-token only. Secret routes are
+ * otherwise provider-neutral, so enforce the credential kind again at the last
+ * possible boundary: after decrypt and before it can enter an outbound header.
+ * This prevents a mistakenly stored user token (xoxp-) or arbitrary plaintext
+ * secret from inheriting the bot grant's authority.
+ */
+function isSlackBotTokenCredential(value: string): boolean {
+  return value.length <= 512 && /^xoxb-[A-Za-z0-9-]{10,}$/.test(value);
+}
+
 // ─── Credential injection ────────────────────────────────────────────────────
 
 /**
@@ -1733,6 +1744,27 @@ export async function handleProxy(c: Context): Promise<Response> {
     await releaseUnsafeProxyRequest(replayClaim);
     proxySlot.release();
     return c.json({ ok: false, error: "Failed to decrypt credential" }, 500);
+  }
+
+  if (target.host === "slack.com" && !isSlackBotTokenCredential(credential)) {
+    // Do not include the credential (or any derivative of it) in the response,
+    // logs, or audit reason. The agent only learns that the configured grant is
+    // not an eligible Slack bot credential.
+    credential = "";
+    await recordRequiredAudit({
+      agentId,
+      tenantId,
+      targetHost: target.host,
+      targetPath: target.path,
+      method,
+      statusCode: 403,
+      latencyMs: Date.now() - startTime,
+      reason: "slack-bot-credential-required",
+    });
+    await releaseProxySpendReservation(agentId, tenantId, target.host, spendReservation);
+    await releaseUnsafeProxyRequest(replayClaim);
+    proxySlot.release();
+    return c.json({ ok: false, error: "Slack route requires a bot credential" }, 403);
   }
 
   // 4. Build outbound request

--- a/packages/shared/src/__tests__/generic-http-provider-action.test.ts
+++ b/packages/shared/src/__tests__/generic-http-provider-action.test.ts
@@ -34,6 +34,7 @@ import {
   genericHttpCanonicalActionBytes,
   isRegisteredProfile,
   REGISTERED_PROFILES,
+  SLACK_PROVIDER_ACTION_PROFILE,
   UnregisteredProfileError,
   validateGenericHttpDescriptor,
   X_GOLDEN_VECTORS,
@@ -130,11 +131,12 @@ describe("generic-http golden corpus", () => {
 // ─── Registry (fail-closed at every consumption entry) ─────────────────────────
 
 describe("profile registry", () => {
-  it("registers exactly github, x, generic-http", () => {
+  it("registers exactly github, x, Slack, generic-http", () => {
     expect([...REGISTERED_PROFILES].sort()).toEqual(
       [
         GITHUB_PROVIDER_ACTION_PROFILE,
         X_PROVIDER_ACTION_PROFILE,
+        SLACK_PROVIDER_ACTION_PROFILE,
         GENERIC_HTTP_PROVIDER_ACTION_PROFILE,
       ].sort(),
     );
@@ -143,6 +145,7 @@ describe("profile registry", () => {
   it("isRegisteredProfile accepts registered, rejects unknown / non-string", () => {
     expect(isRegisteredProfile(GITHUB_PROVIDER_ACTION_PROFILE)).toBe(true);
     expect(isRegisteredProfile(X_PROVIDER_ACTION_PROFILE)).toBe(true);
+    expect(isRegisteredProfile(SLACK_PROVIDER_ACTION_PROFILE)).toBe(true);
     expect(isRegisteredProfile(GENERIC_HTTP_PROVIDER_ACTION_PROFILE)).toBe(true);
     expect(isRegisteredProfile("evil.provider-action.v1")).toBe(false);
     expect(isRegisteredProfile("")).toBe(false);

--- a/packages/shared/src/__tests__/slack-provider-action.test.ts
+++ b/packages/shared/src/__tests__/slack-provider-action.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import {
+  canonicalizeRawInternalSlackAction,
+  canonicalizeSlackOrigin,
+  jcsStringify,
+  SLACK_GOLDEN_VECTORS,
+  sha256HexPrefixed,
+} from "../index";
+
+describe("slack.provider-action.v1", () => {
+  test("matches the shared golden corpus exactly", () => {
+    for (const vector of SLACK_GOLDEN_VECTORS) {
+      expect(jcsStringify(vector.action)).toBe(vector.canonicalActionBytes);
+      expect(sha256HexPrefixed(vector.canonicalActionBytes)).toBe(vector.actionDigest);
+    }
+  });
+  test("allows only Slack's canonical origin and /api paths", () => {
+    expect(canonicalizeSlackOrigin("HTTPS://SLACK.COM.:443/")).toBe("https://slack.com");
+    expect(() => canonicalizeSlackOrigin("https://hooks.slack.com")).toThrow();
+    expect(() =>
+      canonicalizeRawInternalSlackAction({
+        method: "GET",
+        origin: "https://slack.com",
+        path: "/services/T/B/secret",
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -22,6 +22,7 @@ export { describeThrown, UNPRINTABLE_THROWN_VALUE } from "./safe-error.js";
 export * from "./secret-route-matching.js";
 export * from "./security-surface.js";
 export * from "./sensitive-keys.js";
+export * from "./slack-provider-action.js";
 // ─── Token Registry & Price Oracle ───
 export * from "./tokens.js";
 // ─── Per-request app context shape (shared so plugins can type routes) ───

--- a/packages/shared/src/provider-profile-conformance.ts
+++ b/packages/shared/src/provider-profile-conformance.ts
@@ -15,6 +15,7 @@ import {
 } from "./provider-action.js";
 import { assertRegisteredProfile } from "./provider-profile-registry.js";
 import { containsSensitiveCredentialKey, isSensitiveCredentialKey } from "./sensitive-keys.js";
+import { SLACK_PROVIDER_ACTION_PROFILE } from "./slack-provider-action.js";
 import { X_PROVIDER_ACTION_PROFILE } from "./x-provider-action.js";
 
 export interface ConformanceCanonicalAction {
@@ -121,6 +122,64 @@ function validTweetBody(value: unknown): boolean {
   return true;
 }
 
+const SLACK_CHANNEL_RE = /^[CGD][A-Z0-9]{8,19}$/;
+const SLACK_USER_RE = /^[UW][A-Z0-9]{8,19}$/;
+const SLACK_THREAD_TS_RE = /^[0-9]{10,16}\.[0-9]{6}$/;
+const SLACK_CONVERSATION_TYPES = new Set(["public_channel", "private_channel", "mpim", "im"]);
+
+function validSlackPostMessageBody(value: unknown): boolean {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const body = value as Record<string, unknown>;
+  const keys = Object.keys(body).sort();
+  const allowed = new Set(["blocks", "channel", "text", "thread_ts"]);
+  if (keys.some((key) => !allowed.has(key))) return false;
+  if (!SLACK_CHANNEL_RE.test(typeof body.channel === "string" ? body.channel : "")) return false;
+  if (!("text" in body) && !("blocks" in body)) return false;
+  if ("text" in body) {
+    if (
+      typeof body.text !== "string" ||
+      [...body.text].length < 1 ||
+      [...body.text].length > 40000
+    ) {
+      return false;
+    }
+  }
+  if (
+    "blocks" in body &&
+    (!Array.isArray(body.blocks) || body.blocks.length < 1 || body.blocks.length > 50)
+  ) {
+    return false;
+  }
+  if (
+    "thread_ts" in body &&
+    !SLACK_THREAD_TS_RE.test(typeof body.thread_ts === "string" ? body.thread_ts : "")
+  ) {
+    return false;
+  }
+  return new TextEncoder().encode(JSON.stringify(body)).byteLength <= 200_000;
+}
+
+function validSlackConversationsQuery(pairs: Array<[string, string]>): boolean {
+  const values = new Map(pairs);
+  if (values.size !== pairs.length || !values.has("limit") || !values.has("types")) return false;
+  if ([...values.keys()].some((key) => !["cursor", "limit", "types"].includes(key))) return false;
+  if (!/^(?:[1-9]|[1-9][0-9]|1[0-9]{2}|200)$/.test(values.get("limit") ?? "")) return false;
+  const types = (values.get("types") ?? "").split(",");
+  if (
+    types.length < 1 ||
+    types.some((type) => !SLACK_CONVERSATION_TYPES.has(type)) ||
+    jcsStringify(types) !== jcsStringify([...new Set(types)].sort())
+  ) {
+    return false;
+  }
+  const cursor = values.get("cursor");
+  if (cursor !== undefined && !/^[A-Za-z0-9=_-]{1,512}$/.test(cursor)) return false;
+  return pairsEqual(
+    pairs,
+    [...values.entries()].sort(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
 /** Exact adapter-fixed reconstruction contract for every registered operation. */
 function fixedActionMatchesOperation(
   action: ConformanceCanonicalAction,
@@ -195,6 +254,37 @@ function fixedActionMatchesOperation(
         action.selectedHeaders.length === 0 &&
         action.canonicalBody === null
       );
+    case "slack.chat.postMessage":
+      return (
+        action.profile === SLACK_PROVIDER_ACTION_PROFILE &&
+        action.origin === "https://slack.com" &&
+        action.method === "POST" &&
+        action.normalizedPath === "/api/chat.postMessage" &&
+        action.orderedQueryPairs.length === 0 &&
+        pairsEqual(action.selectedHeaders, [["content-type", "application/json"]]) &&
+        validSlackPostMessageBody(action.canonicalBody)
+      );
+    case "slack.conversations.list":
+      return (
+        action.profile === SLACK_PROVIDER_ACTION_PROFILE &&
+        action.origin === "https://slack.com" &&
+        action.method === "GET" &&
+        action.normalizedPath === "/api/conversations.list" &&
+        validSlackConversationsQuery(action.orderedQueryPairs) &&
+        action.selectedHeaders.length === 0 &&
+        action.canonicalBody === null
+      );
+    case "slack.users.info":
+      return (
+        action.profile === SLACK_PROVIDER_ACTION_PROFILE &&
+        action.origin === "https://slack.com" &&
+        action.method === "GET" &&
+        action.normalizedPath === "/api/users.info" &&
+        pairsEqual(action.orderedQueryPairs, [["user", action.orderedQueryPairs[0]?.[1] ?? ""]]) &&
+        SLACK_USER_RE.test(action.orderedQueryPairs[0]?.[1] ?? "") &&
+        action.selectedHeaders.length === 0 &&
+        action.canonicalBody === null
+      );
     default:
       return false;
   }
@@ -238,6 +328,19 @@ export function inspectProviderOperationTargetConformance(
       exact("https://api.x.com", "DELETE", /^\/2\/tweets\/[0-9]{1,25}$/);
     } else if (context.operationKey === "x.user.me.read") {
       exact("https://api.x.com", "GET", "/2/users/me");
+    } else {
+      violations.push("operation-key-unsupported");
+    }
+    if (!fixedActionMatchesOperation(action, context.operationKey)) {
+      violations.push("operation-action-mismatch");
+    }
+  } else if (action.profile === SLACK_PROVIDER_ACTION_PROFILE) {
+    if (context.operationKey === "slack.chat.postMessage") {
+      exact("https://slack.com", "POST", "/api/chat.postMessage");
+    } else if (context.operationKey === "slack.conversations.list") {
+      exact("https://slack.com", "GET", "/api/conversations.list");
+    } else if (context.operationKey === "slack.users.info") {
+      exact("https://slack.com", "GET", "/api/users.info");
     } else {
       violations.push("operation-key-unsupported");
     }

--- a/packages/shared/src/provider-profile-registry.ts
+++ b/packages/shared/src/provider-profile-registry.ts
@@ -10,13 +10,14 @@
  *
  * Registration is compile-time (a frozen set here), not runtime-mutable, so the
  * registry cannot be widened by an attacker-controlled value. Adding a profile
- * is a one-line code change plus its adapter. github + x + generic-http are the
- * initial members; github/x remain BYTE-IDENTICAL in behavior (their profile
+ * is a code change plus its adapter and matching database constraint migration.
+ * github + x + Slack + generic-http are the registered members; github/x remain
+ * BYTE-IDENTICAL in behavior (their profile
  * string value is unchanged, so the golden digest corpus does not move).
  *
  * A profile descriptor also records whether the profile is "config-driven"
  * (operator authors a per-operation descriptor, e.g. generic-http) or
- * "adapter-fixed" (a hardcoded adapter, e.g. github/x). The service uses this to
+ * "adapter-fixed" (a hardcoded adapter, e.g. github/x/Slack). The service uses this to
  * decide whether to load + validate a stored operation descriptor before
  * building the action.
  */
@@ -48,8 +49,8 @@ export type ProviderProfileDescriptor =
 
 /**
  * The registered profiles. FROZEN: this is the single source of truth for which
- * profile strings are legal anywhere in the provider-action pipeline. github and
- * x are adapter-fixed; generic-http is config-driven.
+ * profile strings are legal anywhere in the provider-action pipeline. github,
+ * x, and Slack are adapter-fixed; generic-http is config-driven.
  */
 const REGISTRY: ReadonlyMap<string, ProviderProfileDescriptor> = new Map([
   [

--- a/packages/shared/src/provider-profile-registry.ts
+++ b/packages/shared/src/provider-profile-registry.ts
@@ -77,6 +77,7 @@ const REGISTRY: ReadonlyMap<string, ProviderProfileDescriptor> = new Map([
       profile: SLACK_PROVIDER_ACTION_PROFILE,
       kind: "adapter-fixed",
       label: "Slack",
+      allowedOrigins: Object.freeze(["https://slack.com"]),
     }),
   ],
   [

--- a/packages/shared/src/provider-profile-registry.ts
+++ b/packages/shared/src/provider-profile-registry.ts
@@ -23,6 +23,7 @@
 
 import { GENERIC_HTTP_PROVIDER_ACTION_PROFILE } from "./generic-http-provider-action.js";
 import { GITHUB_PROVIDER_ACTION_PROFILE } from "./provider-action.js";
+import { SLACK_PROVIDER_ACTION_PROFILE } from "./slack-provider-action.js";
 import { X_PROVIDER_ACTION_PROFILE } from "./x-provider-action.js";
 
 /** Whether a profile's operation shape is fixed by an adapter or authored by config. */
@@ -67,6 +68,14 @@ const REGISTRY: ReadonlyMap<string, ProviderProfileDescriptor> = new Map([
       kind: "adapter-fixed",
       label: "X",
       allowedOrigins: Object.freeze(["https://api.x.com"]),
+    }),
+  ],
+  [
+    SLACK_PROVIDER_ACTION_PROFILE,
+    Object.freeze<ProviderProfileDescriptor>({
+      profile: SLACK_PROVIDER_ACTION_PROFILE,
+      kind: "adapter-fixed",
+      label: "Slack",
     }),
   ],
   [

--- a/packages/shared/src/slack-provider-action.ts
+++ b/packages/shared/src/slack-provider-action.ts
@@ -1,0 +1,144 @@
+/** Canonical profile for Slack Web API provider actions. */
+import {
+  CanonError,
+  type CanonicalMethod,
+  canonicalizeContentType,
+  canonicalizeMethod,
+  canonicalizeQueryPairs,
+  type JsonValue,
+  jcsStringify,
+  normalizePath,
+  type QueryPair,
+} from "./provider-action.js";
+
+export const SLACK_PROVIDER_ACTION_PROFILE = "slack.provider-action.v1" as const;
+export const SLACK_CANONICAL_ORIGIN = "https://slack.com" as const;
+
+export interface SlackCanonicalActionV1 {
+  profile: typeof SLACK_PROVIDER_ACTION_PROFILE;
+  method: CanonicalMethod;
+  origin: string;
+  normalizedPath: string;
+  orderedQueryPairs: Array<[string, string]>;
+  selectedHeaders: Array<[string, string]>;
+  canonicalBody: null | JsonValue;
+}
+
+export interface RawInternalSlackAction {
+  method: string;
+  origin: string;
+  path: string;
+  query?: QueryPair[];
+  contentType?: string;
+  body?: JsonValue;
+}
+
+export function canonicalizeSlackOrigin(raw: string): string {
+  if (typeof raw !== "string" || raw.length === 0 || /[\u0000-\u0020\u007f]/.test(raw)) {
+    throw new CanonError("CANON_ORIGIN_INVALID", "invalid Slack origin");
+  }
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new CanonError("CANON_ORIGIN_INVALID", "invalid Slack origin");
+  }
+  if (url.protocol !== "https:") {
+    throw new CanonError("CANON_ORIGIN_SCHEME_UNSUPPORTED", "Slack origin must use https");
+  }
+  if (
+    url.username ||
+    url.password ||
+    url.search ||
+    url.hash ||
+    (url.pathname !== "" && url.pathname !== "/")
+  ) {
+    throw new CanonError("CANON_ORIGIN_INVALID", "Slack origin must not contain URL components");
+  }
+  if (url.port && url.port !== "443") {
+    throw new CanonError("CANON_ORIGIN_PORT_UNSUPPORTED", "non-default Slack port");
+  }
+  const host = url.hostname.toLowerCase().replace(/\.$/, "");
+  if (host !== "slack.com") {
+    throw new CanonError("CANON_ORIGIN_NOT_ALLOWED", `host '${host}' not allowed`);
+  }
+  return SLACK_CANONICAL_ORIGIN;
+}
+
+export function canonicalizeRawInternalSlackAction(
+  raw: RawInternalSlackAction,
+): SlackCanonicalActionV1 {
+  const method = canonicalizeMethod(raw.method);
+  const origin = canonicalizeSlackOrigin(raw.origin);
+  const normalizedPath = normalizePath(raw.path);
+  if (!normalizedPath.startsWith("/api/")) {
+    throw new CanonError("CANON_PATH_SEGMENT_INVALID", "Slack path must be under /api/");
+  }
+  const orderedQueryPairs = canonicalizeQueryPairs(raw.query ?? []);
+  let canonicalBody: null | JsonValue = null;
+  const selectedHeaders: Array<[string, string]> = [];
+  if (raw.body !== undefined) {
+    if (method === "GET" || method === "HEAD") {
+      throw new CanonError("CANON_BODY_FORBIDDEN", `${method} cannot carry a body`);
+    }
+    if (raw.contentType === undefined) {
+      throw new CanonError("CANON_BODY_CONTENT_TYPE_REQUIRED", "body present without content type");
+    }
+    selectedHeaders.push(["content-type", canonicalizeContentType(raw.contentType)]);
+    // JCS validation is part of the canonicalization boundary.
+    jcsStringify(raw.body);
+    canonicalBody = raw.body;
+  } else if (raw.contentType !== undefined) {
+    throw new CanonError("CANON_BODY_FORBIDDEN", "content type without body");
+  }
+  return {
+    profile: SLACK_PROVIDER_ACTION_PROFILE,
+    method,
+    origin,
+    normalizedPath,
+    orderedQueryPairs,
+    selectedHeaders,
+    canonicalBody,
+  };
+}
+
+export interface SlackGoldenVector {
+  id: string;
+  action: SlackCanonicalActionV1;
+  canonicalActionBytes: string;
+  actionDigest: string;
+}
+
+const postMessage = canonicalizeRawInternalSlackAction({
+  method: "POST",
+  origin: SLACK_CANONICAL_ORIGIN,
+  path: "/api/chat.postMessage",
+  contentType: "application/json",
+  body: { channel: "C12345678", text: "hello" },
+});
+const conversationsList = canonicalizeRawInternalSlackAction({
+  method: "GET",
+  origin: SLACK_CANONICAL_ORIGIN,
+  path: "/api/conversations.list",
+  query: [
+    ["limit", "100"],
+    ["types", "private_channel,public_channel"],
+  ],
+});
+
+export const SLACK_GOLDEN_VECTORS: SlackGoldenVector[] = [
+  {
+    id: "SGV-01",
+    action: postMessage,
+    canonicalActionBytes:
+      '{"canonicalBody":{"channel":"C12345678","text":"hello"},"method":"POST","normalizedPath":"/api/chat.postMessage","orderedQueryPairs":[],"origin":"https://slack.com","profile":"slack.provider-action.v1","selectedHeaders":[["content-type","application/json"]]}',
+    actionDigest: "sha256:cd77cbcce3f9da334c4a47f545237287fdf0074093068ca6af094f466eabc6a1",
+  },
+  {
+    id: "SGV-02",
+    action: conversationsList,
+    canonicalActionBytes:
+      '{"canonicalBody":null,"method":"GET","normalizedPath":"/api/conversations.list","orderedQueryPairs":[["limit","100"],["types","private_channel,public_channel"]],"origin":"https://slack.com","profile":"slack.provider-action.v1","selectedHeaders":[]}',
+    actionDigest: "sha256:8d4a17110eb34906d05c95c7cf812d63af6711ce37de858d306989440b8f2b82",
+  },
+];

--- a/packages/vault/src/__tests__/secret-route-validator.test.ts
+++ b/packages/vault/src/__tests__/secret-route-validator.test.ts
@@ -371,6 +371,36 @@ describe("STRICT_HOSTS — api.github.com narrowness", () => {
   });
 });
 
+describe("STRICT_HOSTS — slack.com narrowness", () => {
+  it("allows only a method-explicit, exact Slack API route", () => {
+    expect(STRICT_HOSTS["slack.com"]).toEqual({
+      minPathSegments: 2,
+      requireExplicitMethod: true,
+      disallowPathWildcards: true,
+    });
+    expect(DEFAULT_SECRET_ROUTE_HOSTS).toContain("slack.com");
+    expect(
+      validateSecretRouteConfig({
+        ...okBase,
+        hostPattern: "slack.com",
+        pathPattern: "/api/chat.postMessage",
+        method: "POST",
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects a wildcard Slack API route", () => {
+    expect(
+      validateSecretRouteConfig({
+        ...okBase,
+        hostPattern: "slack.com",
+        pathPattern: "/api/*",
+        method: "POST",
+      }),
+    ).toContain('exact path (no "*" wildcards)');
+  });
+});
+
 // Parity net: both former call-path surfaces (the vault boundary and the api
 // route) now import the SAME exported validator. Asserting on the shared export
 // is therefore an assertion about both call sites at once. This matrix locks

--- a/packages/vault/src/secret-route-validator.ts
+++ b/packages/vault/src/secret-route-validator.ts
@@ -29,6 +29,7 @@ export const DEFAULT_SECRET_ROUTE_HOSTS = [
   "api.helius.xyz",
   "api.github.com",
   "api.x.com",
+  "slack.com",
 ] as const;
 
 /**
@@ -105,6 +106,11 @@ export const STRICT_HOSTS: Record<
   // and forbids "*" wildcards (a /2/* route would attach the OAuth token to
   // every X endpoint).
   "api.x.com": {
+    minPathSegments: 2,
+    requireExplicitMethod: true,
+    disallowPathWildcards: true,
+  },
+  "slack.com": {
     minPathSegments: 2,
     requireExplicitMethod: true,
     disallowPathWildcards: true,


### PR DESCRIPTION
Closes #202.

## Implementation
- adds `@stwd/provider-slack` with strict `slack.chat.postMessage`, `slack.conversations.list`, and `slack.users.info` argument validation
- adds the shared, origin-pinned `slack.provider-action.v1` canonical profile and two fixed golden vectors consumed by the same API/provider authority path
- registers Slack with the API's adapter-neutral provider-action pipeline
- adds a narrow `slack.com` proxy alias/secret-route host; bot credentials are Bearer-injected only for exact method/path routes
- treats Slack's HTTP 200 `{ok:false}` contract as a failed dispatch (also fails closed on malformed/missing `ok`)
- makes `channel` a validated scalar `policyArgs` field and proves `capability-intent.constraints.argEquals.channel` allows/denies independently of the credential grant
- documents the security/response contract

## Security evidence
- token canary appears only in the captured outbound Authorization header
- canary is absent from agent response and persisted proxy audit rows
- response errors are restricted to a safe token format before audit/response use
- credential-shaped nested block fields, unknown args, non-Slack origins, non-`/api/` paths, wildcard routes, and malformed identifiers fail closed
- safe summary contains channel/length/hash metadata, never message text or blocks

## Validation (exact head `ac9873e25accef4d88dcc269cf1f9719b9b9d043`)
- focused Slack/profile/policy/proxy/vault suite: 58 passed, 0 failed; exact-head semantic-audit delta: 3 passed, 0 failed
- live-shaped in-memory credential route: `ok:true` pass + HTTP 200 `ok:false` => 502, token/audit canaries clean
- build graph for API/proxy/provider and dependencies: 22/22 succeeded
- Biome and `git diff --check`: clean

No real Slack credential or live workspace was used; provider behavior is proven with the exact outbound seam and deterministic fake upstream.