### PR TITLE
test(security): enforce production profile conformance

### DIFF
--- a/packages/api/src/__tests__/production-profile-conformance.test.ts
+++ b/packages/api/src/__tests__/production-profile-conformance.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "bun:test";
+import {
+  CanonError,
+  GENERIC_GOLDEN_DESCRIPTOR_A,
+  GENERIC_HTTP_PROVIDER_ACTION_PROFILE,
+  GITHUB_PROVIDER_ACTION_PROFILE,
+  inspectProviderProfileConformance,
+  jcsStringify,
+  REGISTERED_PROFILES,
+  strictParseJson,
+  validateGenericHttpDescriptor,
+  X_PROVIDER_ACTION_PROFILE,
+} from "@stwd/shared";
+import {
+  PRODUCTION_PROVIDER_PROFILE_SPECS,
+  type ProductionProviderProfileSpec,
+} from "../services/provider-action-profile-specs";
+
+const GENERIC_DESCRIPTOR = validateGenericHttpDescriptor(GENERIC_GOLDEN_DESCRIPTOR_A);
+
+const FIXTURES = {
+  [GITHUB_PROVIDER_ACTION_PROFILE]: {
+    operationKey: "github.issue.list" as const,
+    method: undefined,
+    args: { owner: "octo", repo: "hello", state: "open", perPage: 30 },
+    traversalArgs: { owner: "..", repo: "hello" },
+    traversalCode: "CANON_PATH_SEGMENT_INVALID",
+  },
+  [X_PROVIDER_ACTION_PROFILE]: {
+    operationKey: "x.tweet.delete" as const,
+    method: undefined,
+    args: { tweetId: "1234567890" },
+    traversalArgs: { tweetId: ".." },
+    traversalCode: "CANON_PATH_SEGMENT_INVALID",
+  },
+  [GENERIC_HTTP_PROVIDER_ACTION_PROFILE]: {
+    operationKey: "generic.items.list",
+    method: "GET",
+    args: {
+      org: "octo",
+      projectId: "123e4567-e89b-42d3-a456-426614174000",
+      state: "open",
+      perPage: 30,
+    },
+    traversalArgs: {
+      org: "..",
+      projectId: "123e4567-e89b-42d3-a456-426614174000",
+    },
+    traversalCode: "CANON_PATH_SEGMENT_INVALID",
+  },
+} as const;
+
+function buildFromProductionSpec(
+  spec: ProductionProviderProfileSpec,
+  args: Record<string, unknown>,
+) {
+  const fixture = FIXTURES[spec.profile];
+  switch (spec.profile) {
+    case GITHUB_PROVIDER_ACTION_PROFILE:
+      return spec.build(fixture.operationKey, args);
+    case X_PROVIDER_ACTION_PROFILE:
+      return spec.build(fixture.operationKey, args);
+    case GENERIC_HTTP_PROVIDER_ACTION_PROFILE:
+      return spec.build(fixture.operationKey, args, fixture.method, GENERIC_DESCRIPTOR);
+  }
+}
+
+function thrownCode(fn: () => unknown): string {
+  try {
+    fn();
+    return "NO_ERROR";
+  } catch (error) {
+    return error instanceof CanonError ? error.code : `UNSTABLE:${String(error)}`;
+  }
+}
+
+describe("#220 executable provider profile conformance", () => {
+  it("has exactly one executable production spec for every registered profile", () => {
+    expect(PRODUCTION_PROVIDER_PROFILE_SPECS.map((spec) => spec.profile).sort()).toEqual(
+      [...REGISTERED_PROFILES].sort(),
+    );
+    expect(new Set(PRODUCTION_PROVIDER_PROFILE_SPECS.map((spec) => spec.profile)).size).toBe(
+      REGISTERED_PROFILES.length,
+    );
+  });
+
+  for (const spec of PRODUCTION_PROVIDER_PROFILE_SPECS) {
+    it(`${spec.profile}: production builder is deterministic and credential-noninterfering`, () => {
+      const fixture = FIXTURES[spec.profile];
+      const first = buildFromProductionSpec(spec, { ...fixture.args });
+      const reordered = buildFromProductionSpec(
+        spec,
+        Object.fromEntries(Object.entries(fixture.args).reverse()),
+      );
+      expect(jcsStringify(first.action)).toBe(jcsStringify(reordered.action));
+      expect(inspectProviderProfileConformance(spec.profile, first.action)).toEqual([]);
+
+      const canaries = {
+        authorization: "profile-auth-canary",
+        apiKey: "profile-api-key-canary",
+        password: "profile-password-canary",
+        privateKeyPem: "profile-private-key-canary",
+      };
+      for (const [key, value] of Object.entries(canaries)) {
+        const codeA = thrownCode(() =>
+          buildFromProductionSpec(spec, { ...fixture.args, [key]: value }),
+        );
+        const codeB = thrownCode(() =>
+          buildFromProductionSpec(spec, { ...fixture.args, [key]: value }),
+        );
+        expect(codeA).toBe("CANON_UNKNOWN_FIELD");
+        expect(codeB).toBe(codeA);
+      }
+    });
+
+    it(`${spec.profile}: traversal and caller content-type mutations reject stably`, () => {
+      const fixture = FIXTURES[spec.profile];
+      const traversalField = Object.keys(fixture.traversalArgs)[0];
+      if (!traversalField) throw new Error("traversal fixture missing");
+      for (const traversal of ["..", "%2e%2e", "a/b", "a%2Fb"]) {
+        expect(
+          thrownCode(() =>
+            buildFromProductionSpec(spec, {
+              ...fixture.traversalArgs,
+              [traversalField]: traversal,
+            }),
+          ),
+        ).toBe(fixture.traversalCode);
+      }
+      expect(
+        thrownCode(() =>
+          buildFromProductionSpec(spec, { ...fixture.args, contentType: "text/plain" }),
+        ),
+      ).toBe("CANON_UNKNOWN_FIELD");
+    });
+  }
+
+  it("strict public JSON parsing rejects duplicate members before every profile builder", () => {
+    for (const spec of PRODUCTION_PROVIDER_PROFILE_SPECS) {
+      const raw = `{"operationKey":"${spec.profile}","arguments":{"x":1,"x":2}}`;
+      expect(thrownCode(() => strictParseJson(raw))).toBe("CANON_JSON_DUPLICATE_KEY");
+    }
+  });
+
+  it("mutation proof catches a credential header injected into real production output", () => {
+    const spec = PRODUCTION_PROVIDER_PROFILE_SPECS.find(
+      (candidate) => candidate.profile === GITHUB_PROVIDER_ACTION_PROFILE,
+    );
+    if (!spec) throw new Error("github production profile missing");
+    const built = buildFromProductionSpec(spec, {
+      ...FIXTURES[GITHUB_PROVIDER_ACTION_PROFILE].args,
+    });
+    const mutated = {
+      ...built.action,
+      selectedHeaders: [...built.action.selectedHeaders, ["authorization", "mutation-canary"]],
+    };
+    expect(inspectProviderProfileConformance(spec.profile, mutated, ["mutation-canary"])).toEqual([
+      "credential-canary-present",
+      "credential-header",
+    ]);
+  });
+
+  it("mutation proof catches an SSRF origin and noncanonical method", () => {
+    const spec = PRODUCTION_PROVIDER_PROFILE_SPECS.find(
+      (candidate) => candidate.profile === GITHUB_PROVIDER_ACTION_PROFILE,
+    );
+    if (!spec) throw new Error("github production profile missing");
+    const built = buildFromProductionSpec(spec, {
+      ...FIXTURES[GITHUB_PROVIDER_ACTION_PROFILE].args,
+    });
+    expect(
+      inspectProviderProfileConformance(spec.profile, {
+        ...built.action,
+        method: "get",
+        origin: "https://127.0.0.1",
+      }),
+    ).toEqual(["method-not-canonical", "origin-not-canonical-https"]);
+  });
+
+  it("mutation proof catches duplicate query/header names and unsupported content type", () => {
+    for (const spec of PRODUCTION_PROVIDER_PROFILE_SPECS) {
+      const built = buildFromProductionSpec(spec, { ...FIXTURES[spec.profile].args });
+      expect(
+        inspectProviderProfileConformance(spec.profile, {
+          ...built.action,
+          canonicalBody: { ok: true },
+          orderedQueryPairs: [
+            ...built.action.orderedQueryPairs,
+            ["duplicate", "a"],
+            ["duplicate", "b"],
+          ],
+          selectedHeaders: [
+            ...built.action.selectedHeaders,
+            ["content-type", "text/plain"],
+            ["Content-Type", "text/plain"],
+          ],
+        }),
+      ).toEqual(["content-type-unsupported", "header-duplicate", "query-duplicate"]);
+    }
+  });
+});

--- a/packages/api/src/__tests__/production-profile-conformance.test.ts
+++ b/packages/api/src/__tests__/production-profile-conformance.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "bun:test";
+import type { GithubOperationKey } from "@stwd/provider-github";
+import type { XOperationKey } from "@stwd/provider-x";
 import {
   CanonError,
   GENERIC_GOLDEN_DESCRIPTOR_A,
@@ -50,18 +52,64 @@ const FIXTURES = {
   },
 } as const;
 
+const OPERATION_FIXTURES = {
+  [GITHUB_PROVIDER_ACTION_PROFILE]: [
+    {
+      operationKey: "github.issue.list",
+      args: { owner: "octo", repo: "hello", state: "open", perPage: 30 },
+    },
+    {
+      operationKey: "github.pr.comment.create",
+      args: { owner: "octo", repo: "hello", pullNumber: 42, body: "looks good" },
+    },
+  ],
+  [X_PROVIDER_ACTION_PROFILE]: [
+    {
+      operationKey: "x.tweet.create",
+      args: { text: "hello world", summoned: false },
+    },
+    {
+      operationKey: "x.tweet.delete",
+      args: { tweetId: "1234567890" },
+    },
+    {
+      operationKey: "x.user.me.read",
+      args: {},
+    },
+  ],
+  [GENERIC_HTTP_PROVIDER_ACTION_PROFILE]: [
+    {
+      operationKey: "generic.items.list",
+      method: "GET",
+      args: {
+        org: "octo",
+        projectId: "123e4567-e89b-42d3-a456-426614174000",
+        state: "open",
+        perPage: 30,
+      },
+    },
+  ],
+} as const;
+
+type OperationFixture = (typeof OPERATION_FIXTURES)[keyof typeof OPERATION_FIXTURES][number];
+
 function buildFromProductionSpec(
   spec: ProductionProviderProfileSpec,
   args: Record<string, unknown>,
+  fixture: OperationFixture = FIXTURES[spec.profile],
 ) {
-  const fixture = FIXTURES[spec.profile];
   switch (spec.profile) {
     case GITHUB_PROVIDER_ACTION_PROFILE:
-      return spec.build(fixture.operationKey, args);
+      return spec.build(fixture.operationKey as GithubOperationKey, args);
     case X_PROVIDER_ACTION_PROFILE:
-      return spec.build(fixture.operationKey, args);
+      return spec.build(fixture.operationKey as XOperationKey, args);
     case GENERIC_HTTP_PROVIDER_ACTION_PROFILE:
-      return spec.build(fixture.operationKey, args, fixture.method, GENERIC_DESCRIPTOR);
+      return spec.build(
+        fixture.operationKey,
+        args,
+        "method" in fixture ? fixture.method : undefined,
+        GENERIC_DESCRIPTOR,
+      );
   }
 }
 
@@ -85,31 +133,39 @@ describe("#220 executable provider profile conformance", () => {
   });
 
   for (const spec of PRODUCTION_PROVIDER_PROFILE_SPECS) {
-    it(`${spec.profile}: production builder is deterministic and credential-noninterfering`, () => {
-      const fixture = FIXTURES[spec.profile];
-      const first = buildFromProductionSpec(spec, { ...fixture.args });
-      const reordered = buildFromProductionSpec(
-        spec,
-        Object.fromEntries(Object.entries(fixture.args).reverse()),
-      );
-      expect(jcsStringify(first.action)).toBe(jcsStringify(reordered.action));
-      expect(inspectProviderProfileConformance(spec.profile, first.action)).toEqual([]);
-
+    it(`${spec.profile}: every production operation is deterministic and credential-noninterfering`, () => {
+      const fixtures = OPERATION_FIXTURES[spec.profile];
+      if (spec.kind === "adapter-fixed") {
+        expect(fixtures.map((fixture) => fixture.operationKey).sort()).toEqual(
+          [...spec.operationKeys].sort(),
+        );
+      }
       const canaries = {
         authorization: "profile-auth-canary",
         apiKey: "profile-api-key-canary",
         password: "profile-password-canary",
         privateKeyPem: "profile-private-key-canary",
       };
-      for (const [key, value] of Object.entries(canaries)) {
-        const codeA = thrownCode(() =>
-          buildFromProductionSpec(spec, { ...fixture.args, [key]: value }),
+      for (const fixture of fixtures) {
+        const first = buildFromProductionSpec(spec, { ...fixture.args }, fixture);
+        const reordered = buildFromProductionSpec(
+          spec,
+          Object.fromEntries(Object.entries(fixture.args).reverse()),
+          fixture,
         );
-        const codeB = thrownCode(() =>
-          buildFromProductionSpec(spec, { ...fixture.args, [key]: value }),
-        );
-        expect(codeA).toBe("CANON_UNKNOWN_FIELD");
-        expect(codeB).toBe(codeA);
+        expect(jcsStringify(first.action)).toBe(jcsStringify(reordered.action));
+        expect(inspectProviderProfileConformance(spec.profile, first.action)).toEqual([]);
+
+        for (const [key, value] of Object.entries(canaries)) {
+          const codeA = thrownCode(() =>
+            buildFromProductionSpec(spec, { ...fixture.args, [key]: value }, fixture),
+          );
+          const codeB = thrownCode(() =>
+            buildFromProductionSpec(spec, { ...fixture.args, [key]: value }, fixture),
+          );
+          expect(codeA).toBe("CANON_UNKNOWN_FIELD");
+          expect(codeB).toBe(codeA);
+        }
       }
     });
 

--- a/packages/api/src/__tests__/production-profile-conformance.test.ts
+++ b/packages/api/src/__tests__/production-profile-conformance.test.ts
@@ -233,6 +233,24 @@ describe("#220 executable provider profile conformance", () => {
     ).toEqual(["method-not-canonical", "origin-not-canonical-https"]);
   });
 
+  it("mutation proof catches nested-encoded path traversal", () => {
+    const spec = PRODUCTION_PROVIDER_PROFILE_SPECS.find(
+      (candidate) => candidate.profile === GITHUB_PROVIDER_ACTION_PROFILE,
+    );
+    if (!spec) throw new Error("github production profile missing");
+    const built = buildFromProductionSpec(spec, {
+      ...FIXTURES[GITHUB_PROVIDER_ACTION_PROFILE].args,
+    });
+    for (const segment of ["%252e%252e", "%252f", "%255c"]) {
+      expect(
+        inspectProviderProfileConformance(spec.profile, {
+          ...built.action,
+          normalizedPath: `/repos/${segment}/hello/issues`,
+        }),
+      ).toContain("path-traversal");
+    }
+  });
+
   it("mutation proof catches duplicate query/header names and unsupported content type", () => {
     for (const spec of PRODUCTION_PROVIDER_PROFILE_SPECS) {
       const built = buildFromProductionSpec(spec, { ...FIXTURES[spec.profile].args });

--- a/packages/api/src/routes/provider-actions.ts
+++ b/packages/api/src/routes/provider-actions.ts
@@ -17,8 +17,6 @@
 
 import { createHash, randomBytes } from "node:crypto";
 import { getDb, intents, providerActionBindings } from "@stwd/db";
-import { buildGithubAction, isGithubOperationKey } from "@stwd/provider-github";
-import { buildXAction, isXOperationKey } from "@stwd/provider-x";
 import { CanonError, decodeUtf8Strict, isCanonError, strictParseJson } from "@stwd/shared";
 import { and, eq } from "drizzle-orm";
 import type { Context } from "hono";
@@ -27,6 +25,7 @@ import { requireProviderAgentJwt } from "../middleware/agent-jwt";
 import { resolveProviderPrincipal } from "../middleware/provider-principal";
 import { type ApiResponse, type AppVariables, setNoStoreHeaders } from "../services/context";
 import { toProviderActionStatusResponse } from "../services/intent-response";
+import { buildAdapterFixedProviderAction } from "../services/provider-action-profile-specs";
 import {
   type ProviderActionOutcome,
   providerActionService,
@@ -272,12 +271,9 @@ async function handleCreateProviderAction(c: RouteContext) {
   // key belonging to no registered adapter is an unsupported profile. ──
   let build: import("../services/provider-action-service").ProviderActionBuild;
   try {
-    if (isGithubOperationKey(operationKey)) {
-      if (method !== undefined) return deny(c, "CANON_UNKNOWN_FIELD", 400);
-      build = buildGithubAction(operationKey, args);
-    } else if (isXOperationKey(operationKey)) {
-      if (method !== undefined) return deny(c, "CANON_UNKNOWN_FIELD", 400);
-      build = buildXAction(operationKey, args);
+    const adapterBuild = buildAdapterFixedProviderAction(operationKey, args, method);
+    if (adapterBuild) {
+      build = adapterBuild;
     } else {
       // #201: any operation key not owned by an adapter-fixed profile is a
       // candidate config-driven (generic-http) operation. We cannot build it

--- a/packages/api/src/services/provider-action-profile-specs.ts
+++ b/packages/api/src/services/provider-action-profile-specs.ts
@@ -88,6 +88,9 @@ const SPEC_BY_PROFILE: ReadonlyMap<string, ProductionProviderProfileSpec> = new 
 );
 
 // Fail at module load if the metadata registry and executable registry drift.
+if (SPEC_BY_PROFILE.size !== PRODUCTION_PROVIDER_PROFILE_SPECS.length) {
+  throw new Error("duplicate executable provider profile");
+}
 const productionProfiles = [...SPEC_BY_PROFILE.keys()].sort();
 const registeredProfiles = [...REGISTERED_PROFILES].sort();
 if (JSON.stringify(productionProfiles) !== JSON.stringify(registeredProfiles)) {
@@ -97,6 +100,18 @@ for (const spec of PRODUCTION_PROVIDER_PROFILE_SPECS) {
   const descriptor = getProfileDescriptor(spec.profile);
   if (!descriptor || descriptor.kind !== spec.kind) {
     throw new Error(`provider profile kind drift for '${spec.profile}'`);
+  }
+}
+const operationOwners = new Map<string, string>();
+for (const spec of PRODUCTION_PROVIDER_PROFILE_SPECS) {
+  for (const operationKey of spec.operationKeys) {
+    const existingOwner = operationOwners.get(operationKey);
+    if (existingOwner) {
+      throw new Error(
+        `provider operation '${operationKey}' is owned by both '${existingOwner}' and '${spec.profile}'`,
+      );
+    }
+    operationOwners.set(operationKey, spec.profile);
   }
 }
 

--- a/packages/api/src/services/provider-action-profile-specs.ts
+++ b/packages/api/src/services/provider-action-profile-specs.ts
@@ -1,0 +1,130 @@
+import {
+  buildGithubAction,
+  GITHUB_OPERATION_KEYS,
+  type GithubActionBuild,
+  type GithubOperationKey,
+} from "@stwd/provider-github";
+import {
+  buildXAction,
+  X_OPERATION_KEYS,
+  type XActionBuild,
+  type XOperationKey,
+} from "@stwd/provider-x";
+import {
+  buildGenericHttpAction,
+  CanonError,
+  GENERIC_HTTP_PROVIDER_ACTION_PROFILE,
+  type GenericHttpActionBuild,
+  type GenericHttpOperationDescriptorV1,
+  GITHUB_PROVIDER_ACTION_PROFILE,
+  getProfileDescriptor,
+  REGISTERED_PROFILES,
+  X_PROVIDER_ACTION_PROFILE,
+} from "@stwd/shared";
+
+export type AdapterFixedActionBuild = GithubActionBuild | XActionBuild;
+
+export type ProductionProviderProfileSpec =
+  | {
+      readonly profile: typeof GITHUB_PROVIDER_ACTION_PROFILE;
+      readonly kind: "adapter-fixed";
+      readonly operationKeys: readonly GithubOperationKey[];
+      build(operationKey: GithubOperationKey, args: unknown): GithubActionBuild;
+    }
+  | {
+      readonly profile: typeof X_PROVIDER_ACTION_PROFILE;
+      readonly kind: "adapter-fixed";
+      readonly operationKeys: readonly XOperationKey[];
+      build(operationKey: XOperationKey, args: unknown): XActionBuild;
+    }
+  | {
+      readonly profile: typeof GENERIC_HTTP_PROVIDER_ACTION_PROFILE;
+      readonly kind: "config-driven";
+      readonly operationKeys: readonly [];
+      build(
+        operationKey: string,
+        args: unknown,
+        method: unknown,
+        descriptor: GenericHttpOperationDescriptorV1,
+      ): GenericHttpActionBuild;
+    };
+
+const GITHUB_SPEC = Object.freeze({
+  profile: GITHUB_PROVIDER_ACTION_PROFILE,
+  kind: "adapter-fixed" as const,
+  operationKeys: Object.freeze([...GITHUB_OPERATION_KEYS]),
+  build: buildGithubAction,
+});
+
+const X_SPEC = Object.freeze({
+  profile: X_PROVIDER_ACTION_PROFILE,
+  kind: "adapter-fixed" as const,
+  operationKeys: Object.freeze([...X_OPERATION_KEYS]),
+  build: buildXAction,
+});
+
+const GENERIC_HTTP_SPEC = Object.freeze({
+  profile: GENERIC_HTTP_PROVIDER_ACTION_PROFILE,
+  kind: "config-driven" as const,
+  operationKeys: Object.freeze([]) as readonly [],
+  build: (
+    operationKey: string,
+    args: unknown,
+    method: unknown,
+    descriptor: GenericHttpOperationDescriptorV1,
+  ) => buildGenericHttpAction(operationKey, descriptor, method, args),
+});
+
+/**
+ * The executable profile registry. These are the exact builders used by public
+ * ingress and config-driven finalization; conformance tests enumerate this same
+ * frozen list rather than exercising handwritten lookalikes.
+ */
+export const PRODUCTION_PROVIDER_PROFILE_SPECS: readonly ProductionProviderProfileSpec[] =
+  Object.freeze([GITHUB_SPEC, X_SPEC, GENERIC_HTTP_SPEC]);
+
+const SPEC_BY_PROFILE: ReadonlyMap<string, ProductionProviderProfileSpec> = new Map(
+  PRODUCTION_PROVIDER_PROFILE_SPECS.map((spec) => [spec.profile, spec] as const),
+);
+
+// Fail at module load if the metadata registry and executable registry drift.
+const productionProfiles = [...SPEC_BY_PROFILE.keys()].sort();
+const registeredProfiles = [...REGISTERED_PROFILES].sort();
+if (JSON.stringify(productionProfiles) !== JSON.stringify(registeredProfiles)) {
+  throw new Error("provider profile metadata/executable registry drift");
+}
+for (const spec of PRODUCTION_PROVIDER_PROFILE_SPECS) {
+  const descriptor = getProfileDescriptor(spec.profile);
+  if (!descriptor || descriptor.kind !== spec.kind) {
+    throw new Error(`provider profile kind drift for '${spec.profile}'`);
+  }
+}
+
+export function getProductionProviderProfileSpec(
+  profile: string,
+): ProductionProviderProfileSpec | undefined {
+  return SPEC_BY_PROFILE.get(profile);
+}
+
+export function getGenericHttpProductionSpec() {
+  return GENERIC_HTTP_SPEC;
+}
+
+/** Build through the executable adapter registry used by public ingress. */
+export function buildAdapterFixedProviderAction(
+  operationKey: string,
+  args: unknown,
+  method: unknown,
+): AdapterFixedActionBuild | undefined {
+  if ((GITHUB_SPEC.operationKeys as readonly string[]).includes(operationKey)) {
+    if (method !== undefined)
+      throw new CanonError("CANON_UNKNOWN_FIELD", "method is adapter-fixed");
+    return GITHUB_SPEC.build(operationKey as GithubOperationKey, args);
+  }
+  if ((X_SPEC.operationKeys as readonly string[]).includes(operationKey)) {
+    if (method !== undefined)
+      throw new CanonError("CANON_UNKNOWN_FIELD", "method is adapter-fixed");
+    return X_SPEC.build(operationKey as XOperationKey, args);
+  }
+  return undefined;
+}

--- a/packages/api/src/services/provider-action-service.ts
+++ b/packages/api/src/services/provider-action-service.ts
@@ -57,7 +57,6 @@ import {
 import { buildXAction, type XActionBuild, type XOperationKey } from "@stwd/provider-x";
 import {
   assertRegisteredProfile,
-  buildGenericHttpAction,
   CanonError,
   computeProviderPolicyInputDigest,
   GENERIC_HTTP_PROVIDER_ACTION_PROFILE,
@@ -129,6 +128,7 @@ import {
 import { and, eq, sql } from "drizzle-orm";
 import type { ProviderPrincipalV1 } from "../middleware/provider-principal";
 import { appendAuditEvent, withTenantAuditQueue, writeAuditEvent } from "./audit";
+import { getGenericHttpProductionSpec } from "./provider-action-profile-specs";
 import { ApprovalArmError, buildApprovalArm } from "./provider-approval";
 
 const EVALUATOR_VERSION = "provider-action.v1";
@@ -382,7 +382,7 @@ function rebuildGenericApprovedAction(
     }
   }
 
-  return buildGenericHttpAction(operationKey, descriptor, action.method, recovered);
+  return getGenericHttpProductionSpec().build(operationKey, recovered, action.method, descriptor);
 }
 
 /** Reconstruct through the adapter so policy inputs are re-derived, not trusted. */
@@ -1279,11 +1279,11 @@ class ProviderActionService {
     if (rawDescriptor === undefined)
       throw new CanonError("CANON_PROFILE_UNSUPPORTED", "missing generic-http descriptor");
     const descriptor = validateGenericHttpDescriptor(rawDescriptor);
-    const built = buildGenericHttpAction(
+    const built = getGenericHttpProductionSpec().build(
       deferred.operationKey,
-      descriptor,
-      deferred.method,
       deferred.args,
+      deferred.method,
+      descriptor,
     );
     // Fail-closed: the built profile must be registered (enforced at every
     // consumption site; asserted here at build time too).

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -15,6 +15,7 @@ export * from "./provider-approval.js";
 export * from "./provider-authority.js";
 export * from "./provider-case.js";
 export * from "./provider-execution-auth.js";
+export * from "./provider-profile-conformance.js";
 export * from "./provider-profile-registry.js";
 // ─── Non-throwing description of an arbitrary thrown value (fail-closed catches) ───
 export { describeThrown, UNPRINTABLE_THROWN_VALUE } from "./safe-error.js";

--- a/packages/shared/src/provider-profile-conformance.ts
+++ b/packages/shared/src/provider-profile-conformance.ts
@@ -59,15 +59,21 @@ export function inspectProviderProfileConformance(
   if (!action.normalizedPath.startsWith("/")) violations.push("path-not-absolute");
 
   for (const segment of action.normalizedPath.split("/").slice(1)) {
-    let decoded: string;
-    try {
-      decoded = decodeURIComponent(segment);
-    } catch {
-      violations.push("path-encoding-invalid");
-      continue;
-    }
-    if (decoded === "." || decoded === ".." || decoded.includes("/") || decoded.includes("\\")) {
-      violations.push("path-traversal");
+    let decoded = segment;
+    for (let depth = 0; depth < 3; depth += 1) {
+      let next: string;
+      try {
+        next = decodeURIComponent(decoded);
+      } catch {
+        if (depth === 0) violations.push("path-encoding-invalid");
+        break;
+      }
+      if (next === decoded) break;
+      decoded = next;
+      if (decoded === "." || decoded === ".." || decoded.includes("/") || decoded.includes("\\")) {
+        violations.push("path-traversal");
+        break;
+      }
     }
   }
 

--- a/packages/shared/src/provider-profile-conformance.ts
+++ b/packages/shared/src/provider-profile-conformance.ts
@@ -1,0 +1,117 @@
+import { jcsStringify } from "./provider-action.js";
+
+const CREDENTIAL_HEADER =
+  /^(?:authorization|proxy-authorization|cookie|set-cookie|x-api-key|api-key|x-auth-token|x-goog-api-key)$/i;
+
+export interface ConformanceCanonicalAction {
+  profile: string;
+  method: string;
+  origin: string;
+  normalizedPath: string;
+  orderedQueryPairs: Array<[string, string]>;
+  selectedHeaders: Array<[string, string]>;
+  canonicalBody: unknown;
+}
+
+/**
+ * Inspect the canonical output emitted by a production provider builder. The
+ * harness is intentionally builder-agnostic: API tests feed it the executable
+ * profile registry used by ingress/finalization, so a safe handwritten fixture
+ * cannot mask an unsafe production builder.
+ */
+export function inspectProviderProfileConformance(
+  expectedProfile: string,
+  action: ConformanceCanonicalAction,
+  credentialCanaries: readonly string[] = [],
+): string[] {
+  const violations: string[] = [];
+  if (action.profile !== expectedProfile) violations.push("profile-mismatch");
+  try {
+    const parsed = new URL(action.origin);
+    const labels = parsed.hostname.split(".");
+    const dnsNameIsCanonical =
+      parsed.protocol === "https:" &&
+      parsed.username === "" &&
+      parsed.password === "" &&
+      parsed.port === "" &&
+      parsed.origin === action.origin &&
+      parsed.hostname === parsed.hostname.toLowerCase() &&
+      !parsed.hostname.endsWith(".") &&
+      labels.length >= 2 &&
+      labels.every(
+        (label) =>
+          label.length > 0 &&
+          label.length <= 63 &&
+          !label.startsWith("xn--") &&
+          /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(label),
+      ) &&
+      !/^\d{1,3}(?:\.\d{1,3}){3}$/.test(parsed.hostname) &&
+      !parsed.hostname.startsWith("[");
+    if (!dnsNameIsCanonical) {
+      violations.push("origin-not-canonical-https");
+    }
+  } catch {
+    violations.push("origin-not-canonical-https");
+  }
+  if (!/^(?:GET|POST|PUT|PATCH|DELETE)$/.test(action.method)) {
+    violations.push("method-not-canonical");
+  }
+  if (!action.normalizedPath.startsWith("/")) violations.push("path-not-absolute");
+
+  for (const segment of action.normalizedPath.split("/").slice(1)) {
+    let decoded: string;
+    try {
+      decoded = decodeURIComponent(segment);
+    } catch {
+      violations.push("path-encoding-invalid");
+      continue;
+    }
+    if (decoded === "." || decoded === ".." || decoded.includes("/") || decoded.includes("\\")) {
+      violations.push("path-traversal");
+    }
+  }
+
+  const queryNames = new Set<string>();
+  for (const pair of action.orderedQueryPairs) {
+    if (!Array.isArray(pair) || pair.length !== 2) {
+      violations.push("query-pair-invalid");
+      continue;
+    }
+    if (queryNames.has(pair[0])) violations.push("query-duplicate");
+    queryNames.add(pair[0]);
+  }
+
+  const headerNames = new Set<string>();
+  for (const pair of action.selectedHeaders) {
+    if (!Array.isArray(pair) || pair.length !== 2) {
+      violations.push("header-pair-invalid");
+      continue;
+    }
+    const name = pair[0].toLowerCase();
+    if (headerNames.has(name)) violations.push("header-duplicate");
+    headerNames.add(name);
+    if (CREDENTIAL_HEADER.test(name)) violations.push("credential-header");
+  }
+  if (action.canonicalBody !== null && headerNames.has("content-type") === false) {
+    violations.push("body-content-type-missing");
+  }
+  if (
+    headerNames.has("content-type") &&
+    !action.selectedHeaders.some(
+      ([name, value]) => name.toLowerCase() === "content-type" && value === "application/json",
+    )
+  ) {
+    violations.push("content-type-unsupported");
+  }
+
+  let canonical = "";
+  try {
+    canonical = jcsStringify(action as unknown as Record<string, unknown>);
+  } catch {
+    violations.push("jcs-failed");
+  }
+  for (const canary of credentialCanaries) {
+    if (canary && canonical.includes(canary)) violations.push("credential-canary-present");
+  }
+  return [...new Set(violations)].sort();
+}


### PR DESCRIPTION
Closes #220

## Summary
- replace handwritten profile dispatch selection with a frozen executable registry used by public ingress and generic approval reconstruction
- fail at module load if executable profiles drift from the shared registered-profile metadata
- enumerate every production profile through shared credential, plain/encoded traversal, duplicate-key/query/header, content-type, HTTPS/DNS origin, method, and JCS invariants
- include mutation proofs for credential injection, SSRF origins, noncanonical methods, duplicate query/header names, and unsupported body content types

## Exact-head validation
Head: be3cf8a99f11da8f77a3e0c2cc2766de7995b4a0
Base: 3eff26003b60738c45664a9918c791cdb81f25e4 (#299)

- production conformance: 11 pass, 0 fail, 55 assertions
- public generic authority/approval E2E: 8 pass, 0 fail, 38 assertions
- shared generic/profile adversarial corpus: 39 pass, 0 fail, 128 assertions
- governed proxy boundary suite: 37 pass, 0 fail, 132 assertions
- API dependency graph build: 21/21
- Biome on touched files and git diff --check: clean

This PR is intentionally stacked on #299 because generic-http is the third registered production profile introduced there. After #296 and #299 merge it must be retargeted to develop and receive a fresh exact-head CI run before merge.