### PR TITLE
feat(policy): enforce first-class agent budgets

### DIFF
--- a/packages/api/src/__tests__/agent-budget-locking.test.ts
+++ b/packages/api/src/__tests__/agent-budget-locking.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const actionSource = readFileSync(
+  new URL("../services/provider-action-service.ts", import.meta.url),
+  "utf8",
+);
+const authoritySource = readFileSync(
+  new URL("../services/provider-authority-store.ts", import.meta.url),
+  "utf8",
+);
+
+describe("provider agent budget namespace serialization", () => {
+  test("locks the agent namespace before execution reads budget children", () => {
+    const method = actionSource.slice(
+      actionSource.indexOf("private async reserveAgentBudgets"),
+      actionSource.indexOf(
+        "// ── Policy evaluation",
+        actionSource.indexOf("private async reserveAgentBudgets"),
+      ),
+    );
+    expect(method.indexOf('.for("share")')).toBeGreaterThan(-1);
+    expect(method.indexOf('.for("share")')).toBeLessThan(
+      method.indexOf(".from(providerAgentBudgets)"),
+    );
+  });
+
+  test("takes the conflicting namespace lock for create and update mutations", () => {
+    for (const [methodName, mutation] of [
+      ["async createAgentBudget", ".insert(providerAgentBudgets)"],
+      ["async updateAgentBudget", ".update(providerAgentBudgets)"],
+    ] as const) {
+      const start = authoritySource.indexOf(methodName);
+      const nextMethod = authoritySource.indexOf("\n  async ", start + methodName.length);
+      const method = authoritySource.slice(start, nextMethod < 0 ? undefined : nextMethod);
+      expect(method, methodName).toContain('.for("update")');
+      expect(method.indexOf('.for("update")'), methodName).toBeLessThan(method.indexOf(mutation));
+    }
+  });
+});

--- a/packages/api/src/__tests__/cumulative-spend-cap-e2e.test.ts
+++ b/packages/api/src/__tests__/cumulative-spend-cap-e2e.test.ts
@@ -45,6 +45,7 @@ import {
   providerActionAuditOutbox,
   providerActionBindings,
   providerActionReservationGenerations,
+  providerAgentBudgets,
   providerGrants,
   providerOperations,
   providerRoleBindings,
@@ -53,6 +54,7 @@ import {
   tenants,
   users,
   userTenants,
+  vaultSigningFreezes,
   workspaces,
 } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
@@ -188,10 +190,12 @@ async function cleanupRedis() {
 async function wipe() {
   const db = getDb();
   await db.delete(providerActionAuditOutbox);
+  await db.delete(vaultSigningFreezes);
   await db.delete(approvalQueue);
   await db.delete(providerActionBindings);
   await db.delete(intents);
   await db.delete(providerGrants);
+  await db.delete(providerAgentBudgets);
   await db.delete(providerRoleBindings);
   await db.delete(providerOperations);
   await db.delete(providerAccounts);
@@ -493,6 +497,143 @@ describeRedis("#206 cumulativeSpend cap - full-chain E2E (real service + real Re
     if (t.kind === "policy_denied") {
       expect(t.code).toBe(PROVIDER_POLICY_REASON.CUMULATIVE_SPEND_CAP_EXCEEDED);
     }
+  });
+
+  test("#208 concurrent actions cannot cross a first-class count budget", async () => {
+    await seed({ maxBytes: 1_000_000 });
+    await getDb().insert(providerAgentBudgets).values({
+      tenantId: CS.TENANT,
+      agentId: CS.AGENT,
+      dimension: "count",
+      windowSeconds: 86_400,
+      max: 3,
+      autoFreeze: true,
+    });
+
+    // This assertion is deliberately load-bearing mutation proof: bypassing the
+    // budget reservation admits all ten actions and changes the exact 3/7 split.
+    const outcomes = await Promise.all(
+      Array.from({ length: 10 }, (_, index) =>
+        proposeTweet(`budget-${index}`, `cs-208-race-${index}`),
+      ),
+    );
+    expect(outcomes.filter((outcome) => outcome.kind === "allowed")).toHaveLength(3);
+    const denied = outcomes.filter((outcome) => outcome.kind === "policy_denied");
+    expect(denied).toHaveLength(7);
+    expect(denied.every((outcome) => outcome.code === "PROVIDER_AGENT_BUDGET_EXHAUSTED")).toBe(
+      true,
+    );
+
+    const exhaustionEvents = await getDb()
+      .select()
+      .from(providerActionAuditOutbox)
+      .where(eq(providerActionAuditOutbox.action, "provider.budget.exhausted"));
+    expect(exhaustionEvents).toHaveLength(7);
+    expect(
+      exhaustionEvents.every(
+        (event) =>
+          event.resourceType === "provider_action" &&
+          typeof event.resourceId === "string" &&
+          event.resourceId.length > 0,
+      ),
+    ).toBe(true);
+    const freezes = await getDb()
+      .select()
+      .from(vaultSigningFreezes)
+      .where(eq(vaultSigningFreezes.agentId, CS.AGENT));
+    expect(freezes).toHaveLength(1);
+    expect(freezes[0]?.liftedAt).toBeNull();
+  });
+
+  test("#208 notional budgets debit the declared amount and denied reservations do not leak", async () => {
+    await seed({ maxBytes: 1_000_000 });
+    await getDb().insert(providerAgentBudgets).values({
+      tenantId: CS.TENANT,
+      workspaceId: CS.WORKSPACE,
+      agentId: CS.AGENT,
+      dimension: "notional",
+      windowSeconds: 604_800,
+      max: 10,
+      currency: "BYTES",
+    });
+
+    expect((await proposeTweet("123456", "cs-208-notional-a")).kind).toBe("allowed");
+    const crossing = await proposeTweet("12345", "cs-208-notional-b");
+    expect(crossing.kind).toBe("policy_denied");
+    if (crossing.kind === "policy_denied") {
+      expect(crossing.code).toBe("PROVIDER_AGENT_BUDGET_EXHAUSTED");
+    }
+    // The rejected 5-byte reservation is removed atomically, leaving room for
+    // the exact remaining four bytes.
+    expect((await proposeTweet("1234", "cs-208-notional-c")).kind).toBe("allowed");
+  });
+
+  test("#208 approval resume re-debits the current budget before consumption", async () => {
+    process.env.STEWARD_EXECUTION_AUTH_SECRET =
+      "k1:issue-208-real-redis-test-secret-with-enough-entropy";
+    await seed({ maxBytes: 1_000_000, requireApproval: true });
+    await getDb().insert(providerAgentBudgets).values({
+      tenantId: CS.TENANT,
+      agentId: CS.AGENT,
+      dimension: "count",
+      windowSeconds: 86_400,
+      max: 1,
+    });
+    const queued = await proposeTweet("queued-budget", "cs-208-queued");
+    expect(queued.kind).toBe("approval_required");
+    if (queued.kind !== "approval_required") throw new Error("expected approval");
+    expect(
+      (
+        await providerApprovalService.decide({
+          intentId: queued.intentId,
+          tenantId: CS.TENANT,
+          authenticatedUserId: CS.GRANTOR,
+          sessionMfaVerifiedAt: Date.now(),
+          decision: "approve",
+          expectedVersion: 1,
+          expectedRequestHash: queued.requestHash,
+          expectedActionDigest: queued.actionDigest,
+          reasonCode: null,
+          reason: null,
+          idempotencyKey: "cs-208-approve",
+        })
+      ).ok,
+    ).toBe(true);
+
+    // A different governed operation for this agent consumed the sole global
+    // count slot while this action waited for its human approval.
+    expect(
+      await reserveCumulativeSpend({
+        stream: {
+          agentId: CS.AGENT,
+          scope: "agent",
+          scopeKey: "budget:global:count",
+          currency: "__agent_budget_count__",
+        },
+        caps: [{ windowSeconds: 86_400, max: 1 }],
+        amount: 1,
+        reservationId: `concurrent-budget-${RUN}`,
+      }),
+    ).toMatchObject({ ok: true });
+
+    expect(
+      await providerApprovalService.resume({ intentId: queued.intentId, tenantId: CS.TENANT }),
+    ).toEqual({
+      ok: false,
+      code: "PROVIDER_AGENT_BUDGET_EXHAUSTED",
+      httpStatus: 403,
+    });
+    const [binding] = await getDb()
+      .select()
+      .from(providerActionBindings)
+      .where(eq(providerActionBindings.intentId, queued.intentId));
+    expect(binding.status).toBe("approved");
+    expect(binding.executionPolicyDecision).toBeNull();
+    const events = await getDb()
+      .select()
+      .from(providerActionAuditOutbox)
+      .where(eq(providerActionAuditOutbox.intentId, queued.intentId));
+    expect(events.some((event) => event.action === "provider.budget.exhausted")).toBe(true);
   });
 
   test("#240 crash after terminal commit: C2 settles persisted handles exactly once under a worker race", async () => {

--- a/packages/api/src/__tests__/cumulative-spend-cap-e2e.test.ts
+++ b/packages/api/src/__tests__/cumulative-spend-cap-e2e.test.ts
@@ -38,6 +38,7 @@ import {
 import {
   agents,
   approvalQueue,
+  auditEvents,
   closeDb,
   getDb,
   intents,
@@ -66,7 +67,7 @@ import {
   getRedis,
   reserveCumulativeSpend,
 } from "@stwd/redis";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import type { ProviderPrincipalV1 } from "../middleware/provider-principal";
 import {
   __setReservationReconciliationFaultForTests,
@@ -629,11 +630,24 @@ describeRedis("#206 cumulativeSpend cap - full-chain E2E (real service + real Re
       .where(eq(providerActionBindings.intentId, queued.intentId));
     expect(binding.status).toBe("approved");
     expect(binding.executionPolicyDecision).toBeNull();
+    // Resume denials are written by withTenantAuditedTransaction directly to
+    // the canonical HMAC-chained audit log. The provider-action outbox is used
+    // by the initial decision path and is not the resume audit sink.
     const events = await getDb()
       .select()
-      .from(providerActionAuditOutbox)
-      .where(eq(providerActionAuditOutbox.intentId, queued.intentId));
-    expect(events.some((event) => event.action === "provider.budget.exhausted")).toBe(true);
+      .from(auditEvents)
+      .where(
+        and(
+          eq(auditEvents.tenantId, CS.TENANT),
+          eq(auditEvents.resourceId, queued.intentId),
+          eq(auditEvents.action, "provider.budget.exhausted"),
+        ),
+      );
+    expect(events).toHaveLength(1);
+    expect(events[0]?.metadata).toMatchObject({
+      intentId: queued.intentId,
+      reasonCode: "PROVIDER_AGENT_BUDGET_EXHAUSTED",
+    });
   });
 
   test("#240 crash after terminal commit: C2 settles persisted handles exactly once under a worker race", async () => {

--- a/packages/api/src/__tests__/cumulative-spend-cap-e2e.test.ts
+++ b/packages/api/src/__tests__/cumulative-spend-cap-e2e.test.ts
@@ -182,7 +182,9 @@ async function cleanupRedis() {
   const redis = getRedis();
   let cursor = "0";
   do {
-    const [next, keys] = await redis.scan(cursor, "MATCH", `cumspend:${CS.AGENT}*`, "COUNT", 100);
+    // Agent-budget streams use a Redis Cluster hash tag around the agent id;
+    // match both the legacy untagged policy streams and tagged budget streams.
+    const [next, keys] = await redis.scan(cursor, "MATCH", `cumspend:*${CS.AGENT}*`, "COUNT", 100);
     cursor = next;
     if (keys.length > 0) await redis.del(...keys);
   } while (cursor !== "0");

--- a/packages/api/src/__tests__/provider-authority.test.ts
+++ b/packages/api/src/__tests__/provider-authority.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
 import {
   agents,
+  auditEvents as persistedAuditEvents,
   closeDb,
   getDb,
   providerAccounts,
@@ -14,10 +15,12 @@ import {
   workspaces,
 } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { type AuthorityAudit, ProviderAuthorityStore } from "../services/provider-authority-store";
 
 setDefaultTimeout(120_000);
+process.env.STEWARD_AUDIT_HMAC_KEY ??=
+  "provider-authority-test-audit-hmac-key-with-adequate-entropy";
 
 const OWNER = "10000000-0000-4000-8000-000000000001";
 const ADMIN = "10000000-0000-4000-8000-000000000002";
@@ -79,7 +82,12 @@ async function seedCore() {
   await db.insert(agents).values([
     { id: "agent-x", tenantId: "tenant-main", name: "X", walletAddress: "0x1" },
     { id: "agent-y", tenantId: "tenant-main", name: "Y", walletAddress: "0x2" },
-    { id: "foreign-agent", tenantId: "tenant-foreign", name: "F", walletAddress: "0x3" },
+    {
+      id: "foreign-agent",
+      tenantId: "tenant-foreign",
+      name: "F",
+      walletAddress: "0x3",
+    },
   ]);
   await db.insert(workspaces).values([
     {
@@ -174,14 +182,22 @@ describe("provider authority foundation", () => {
       }),
     ).rejects.toMatchObject({ code: "forbidden" });
     const created = await store.createWorkspace(
-      mutation({ actorUserId: ADMIN, tenantRole: "admin", expectedRevision: 1 }),
+      mutation({
+        actorUserId: ADMIN,
+        tenantRole: "admin",
+        expectedRevision: 1,
+      }),
       { key: "explicit-admin", name: "Allowed", environment: "production" },
     );
     expect(created.key).toBe("explicit-admin");
   });
 
   test("every mutation requires authority, recent MFA, idempotency, revision, and successful pre-commit audit", async () => {
-    const base = mutation({ actorUserId: ADMIN, tenantRole: "admin", expectedRevision: 2 });
+    const base = mutation({
+      actorUserId: ADMIN,
+      tenantRole: "admin",
+      expectedRevision: 2,
+    });
     await expect(
       store.createWorkspace(base, {
         key: 123 as unknown as string,
@@ -256,7 +272,11 @@ describe("provider authority foundation", () => {
       ]);
     await expect(
       store.createProviderAccount(
-        mutation({ actorUserId: OTHER, tenantRole: "member", expectedRevision: 1 }),
+        mutation({
+          actorUserId: OTHER,
+          tenantRole: "member",
+          expectedRevision: 1,
+        }),
         {
           workspaceId: WORKSPACE_B,
           adapterKey: "github",
@@ -267,7 +287,11 @@ describe("provider authority foundation", () => {
     ).rejects.toMatchObject({ code: "not_found", status: 404 });
     await expect(
       store.createProviderAccount(
-        mutation({ actorUserId: OWNER, tenantRole: "owner", expectedRevision: 1 }),
+        mutation({
+          actorUserId: OWNER,
+          tenantRole: "owner",
+          expectedRevision: 1,
+        }),
         {
           workspaceId: WORKSPACE_B,
           adapterKey: "github",
@@ -294,7 +318,11 @@ describe("provider authority foundation", () => {
     ).rejects.toMatchObject({ code: "not_found", status: 404 });
     await expect(
       store.issueRoleBinding(
-        mutation({ actorUserId: ADMIN, tenantRole: "admin", expectedRevision: 1 }),
+        mutation({
+          actorUserId: ADMIN,
+          tenantRole: "admin",
+          expectedRevision: 1,
+        }),
         {
           workspaceId: WORKSPACE_B,
           principalType: "human",
@@ -350,7 +378,11 @@ describe("provider authority foundation", () => {
       ),
     ).rejects.toMatchObject({ code: "forbidden" });
     const grant = await store.issueGrant(
-      mutation({ actorUserId: OTHER, tenantRole: "member", expectedRevision: workspace.revision }),
+      mutation({
+        actorUserId: OTHER,
+        tenantRole: "member",
+        expectedRevision: workspace.revision,
+      }),
       {
         workspaceId: WORKSPACE_A,
         providerAccountId: ACCOUNT_A,
@@ -375,7 +407,12 @@ describe("provider authority foundation", () => {
       environment: "production" as const,
     };
     expect(
-      (await store.checkAccess({ ...common, evaluatedAt: new Date().toISOString() })).effect,
+      (
+        await store.checkAccess({
+          ...common,
+          evaluatedAt: new Date().toISOString(),
+        })
+      ).effect,
     ).toBe("allow");
     await getDb()
       .insert(providerGrants)
@@ -479,7 +516,11 @@ describe("provider authority foundation", () => {
       .where(eq(providerRoleBindings.id, adminBinding.id));
     await expect(
       store.createWorkspace(
-        mutation({ actorUserId: ADMIN, tenantRole: "admin", expectedRevision: 2 }),
+        mutation({
+          actorUserId: ADMIN,
+          tenantRole: "admin",
+          expectedRevision: 2,
+        }),
         { key: "expired-admin", name: "Denied", environment: "production" },
       ),
     ).rejects.toMatchObject({ code: "forbidden" });
@@ -503,7 +544,11 @@ describe("provider authority foundation", () => {
       .update(providerRoleBindings)
       .set({ expiresAt: null })
       .where(eq(providerRoleBindings.roleKey, "tenant_authority_admin"));
-    const admin = mutation({ actorUserId: ADMIN, tenantRole: "admin", expectedRevision: 0 });
+    const admin = mutation({
+      actorUserId: ADMIN,
+      tenantRole: "admin",
+      expectedRevision: 0,
+    });
     const count = await store.createAgentBudget(admin, {
       agentId: "agent-x",
       dimension: "count",
@@ -519,7 +564,11 @@ describe("provider authority foundation", () => {
       revision: 1,
     });
     const notional = await store.createAgentBudget(
-      mutation({ actorUserId: ADMIN, tenantRole: "admin", expectedRevision: 0 }),
+      mutation({
+        actorUserId: ADMIN,
+        tenantRole: "admin",
+        expectedRevision: 0,
+      }),
       {
         agentId: "agent-x",
         workspaceId: WORKSPACE_A,
@@ -532,7 +581,11 @@ describe("provider authority foundation", () => {
     expect(await store.listAgentBudgets("tenant-main", "agent-x")).toHaveLength(2);
 
     const disabled = await store.updateAgentBudget(
-      mutation({ actorUserId: ADMIN, tenantRole: "admin", expectedRevision: notional.revision }),
+      mutation({
+        actorUserId: ADMIN,
+        tenantRole: "admin",
+        expectedRevision: notional.revision,
+      }),
       notional.id,
       {
         dimension: "notional",
@@ -545,7 +598,11 @@ describe("provider authority foundation", () => {
     expect(disabled).toMatchObject({ max: 9_000, enabled: false, revision: 2 });
     await expect(
       store.updateAgentBudget(
-        mutation({ actorUserId: ADMIN, tenantRole: "admin", expectedRevision: 1 }),
+        mutation({
+          actorUserId: ADMIN,
+          tenantRole: "admin",
+          expectedRevision: 1,
+        }),
         notional.id,
         {
           dimension: "notional",
@@ -563,7 +620,102 @@ describe("provider authority foundation", () => {
           .where(eq(providerAgentBudgets.id, count.id))
       )[0]?.autoFreeze,
     ).toBe(true);
-    expect(auditEvents.some((event) => event.action === "provider.agent_budget.create")).toBe(true);
-    expect(auditEvents.some((event) => event.action === "provider.agent_budget.update")).toBe(true);
+    const budgetAuditRows = await getDb()
+      .select({
+        action: persistedAuditEvents.action,
+        resourceId: persistedAuditEvents.resourceId,
+      })
+      .from(persistedAuditEvents);
+    expect(
+      budgetAuditRows.some(
+        (event) => event.action === "provider.agent_budget.create" && event.resourceId === count.id,
+      ),
+    ).toBe(true);
+    expect(
+      budgetAuditRows.some(
+        (event) =>
+          event.action === "provider.agent_budget.update" && event.resourceId === notional.id,
+      ),
+    ).toBe(true);
+  });
+
+  test("budget insert failure rolls back its required audit event", async () => {
+    const context = mutation({
+      actorUserId: ADMIN,
+      tenantRole: "admin",
+      expectedRevision: 0,
+    });
+    const definition = {
+      agentId: "agent-x",
+      dimension: "count" as const,
+      windowSeconds: 3_600,
+      max: 10,
+    };
+    await store.createAgentBudget(context, definition);
+    const before = await getDb()
+      .select({ id: persistedAuditEvents.id })
+      .from(persistedAuditEvents)
+      .where(eq(persistedAuditEvents.action, "provider.agent_budget.create"));
+
+    await expect(
+      store.createAgentBudget(
+        mutation({
+          actorUserId: ADMIN,
+          tenantRole: "admin",
+          expectedRevision: 0,
+        }),
+        definition,
+      ),
+    ).rejects.toThrow();
+
+    const after = await getDb()
+      .select({ id: persistedAuditEvents.id })
+      .from(persistedAuditEvents)
+      .where(eq(persistedAuditEvents.action, "provider.agent_budget.create"));
+    expect(after).toHaveLength(before.length);
+  });
+
+  test("a concurrent budget revision race commits exactly one mutation and one audit", async () => {
+    const created = await store.createAgentBudget(
+      mutation({
+        actorUserId: ADMIN,
+        tenantRole: "admin",
+        expectedRevision: 0,
+      }),
+      {
+        agentId: "agent-y",
+        dimension: "count",
+        windowSeconds: 7_200,
+        max: 20,
+      },
+    );
+    const update = (max: number) =>
+      store.updateAgentBudget(
+        mutation({
+          actorUserId: ADMIN,
+          tenantRole: "admin",
+          expectedRevision: created.revision,
+        }),
+        created.id,
+        {
+          dimension: "count",
+          windowSeconds: 7_200,
+          max,
+        },
+      );
+
+    const outcomes = await Promise.allSettled([update(21), update(22)]);
+    expect(outcomes.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    expect(outcomes.filter((result) => result.status === "rejected")).toHaveLength(1);
+    const rows = await getDb()
+      .select({ id: persistedAuditEvents.id })
+      .from(persistedAuditEvents)
+      .where(
+        and(
+          eq(persistedAuditEvents.action, "provider.agent_budget.update"),
+          eq(persistedAuditEvents.resourceId, created.id),
+        ),
+      );
+    expect(rows).toHaveLength(1);
   });
 });

--- a/packages/api/src/__tests__/provider-authority.test.ts
+++ b/packages/api/src/__tests__/provider-authority.test.ts
@@ -4,6 +4,7 @@ import {
   closeDb,
   getDb,
   providerAccounts,
+  providerAgentBudgets,
   providerGrants,
   providerOperations,
   providerRoleBindings,
@@ -495,5 +496,74 @@ describe("provider authority foundation", () => {
     expect(auditEvents.some((event) => event.action === "provider.role_binding.issue")).toBe(true);
     expect(auditEvents.some((event) => event.action === "provider.workspace.create")).toBe(true);
     expect(auditEvents.some((event) => event.action === "provider.grant.issue")).toBe(true);
+  });
+
+  test("operators can create, list, revise, and disable first-class agent budgets", async () => {
+    await getDb()
+      .update(providerRoleBindings)
+      .set({ expiresAt: null })
+      .where(eq(providerRoleBindings.roleKey, "tenant_authority_admin"));
+    const admin = mutation({ actorUserId: ADMIN, tenantRole: "admin", expectedRevision: 0 });
+    const count = await store.createAgentBudget(admin, {
+      agentId: "agent-x",
+      dimension: "count",
+      windowSeconds: 86_400,
+      max: 500,
+      autoFreeze: true,
+    });
+    expect(count).toMatchObject({
+      agentId: "agent-x",
+      workspaceId: null,
+      dimension: "count",
+      max: 500,
+      revision: 1,
+    });
+    const notional = await store.createAgentBudget(
+      mutation({ actorUserId: ADMIN, tenantRole: "admin", expectedRevision: 0 }),
+      {
+        agentId: "agent-x",
+        workspaceId: WORKSPACE_A,
+        dimension: "notional",
+        windowSeconds: 604_800,
+        max: 10_000,
+        currency: "USD",
+      },
+    );
+    expect(await store.listAgentBudgets("tenant-main", "agent-x")).toHaveLength(2);
+
+    const disabled = await store.updateAgentBudget(
+      mutation({ actorUserId: ADMIN, tenantRole: "admin", expectedRevision: notional.revision }),
+      notional.id,
+      {
+        dimension: "notional",
+        windowSeconds: 604_800,
+        max: 9_000,
+        currency: "USD",
+        enabled: false,
+      },
+    );
+    expect(disabled).toMatchObject({ max: 9_000, enabled: false, revision: 2 });
+    await expect(
+      store.updateAgentBudget(
+        mutation({ actorUserId: ADMIN, tenantRole: "admin", expectedRevision: 1 }),
+        notional.id,
+        {
+          dimension: "notional",
+          windowSeconds: 604_800,
+          max: 8_000,
+          currency: "USD",
+        },
+      ),
+    ).rejects.toMatchObject({ code: "revision_conflict" });
+    expect(
+      (
+        await getDb()
+          .select()
+          .from(providerAgentBudgets)
+          .where(eq(providerAgentBudgets.id, count.id))
+      )[0]?.autoFreeze,
+    ).toBe(true);
+    expect(auditEvents.some((event) => event.action === "provider.agent_budget.create")).toBe(true);
+    expect(auditEvents.some((event) => event.action === "provider.agent_budget.update")).toBe(true);
   });
 });

--- a/packages/api/src/__tests__/provider-authority.test.ts
+++ b/packages/api/src/__tests__/provider-authority.test.ts
@@ -1,9 +1,9 @@
 import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
 import {
   agents,
-  auditEvents as persistedAuditEvents,
   closeDb,
   getDb,
+  auditEvents as persistedAuditEvents,
   providerAccounts,
   providerAgentBudgets,
   providerGrants,

--- a/packages/api/src/routes/provider-authority.ts
+++ b/packages/api/src/routes/provider-authority.ts
@@ -355,6 +355,73 @@ providerAuthorityRoutes.post("/provider-grants/:id/revoke", async (c) => {
   }
 });
 
+providerAuthorityRoutes.get("/provider-agent-budgets", async (c) => {
+  const agentId = c.req.query("agentId") ?? "";
+  const workspaceId = c.req.query("workspaceId");
+  if (!agentId) return c.json<ApiResponse>({ ok: false, error: "agentId is required" }, 400);
+  try {
+    await requireReadAdmin(c, workspaceId);
+    return c.json({
+      ok: true,
+      data: await providerAuthorityStore.listAgentBudgets(c.get("tenantId"), agentId, workspaceId),
+    });
+  } catch (error) {
+    return fail(c, error);
+  }
+});
+
+providerAuthorityRoutes.post("/provider-agent-budgets", async (c) => {
+  const body = await safeJsonParse<{
+    agentId: string;
+    workspaceId?: string | null;
+    dimension: "count" | "notional";
+    windowSeconds: number;
+    max: number;
+    currency?: string | null;
+    autoFreeze?: boolean;
+    expectedRevision: number;
+    reason: string;
+  }>(c);
+  if (!body) return c.json<ApiResponse>({ ok: false, error: "Invalid JSON body" }, 400);
+  try {
+    return c.json(
+      {
+        ok: true,
+        data: await providerAuthorityStore.createAgentBudget(mutationContext(c, body), body),
+      },
+      201,
+    );
+  } catch (error) {
+    return fail(c, error);
+  }
+});
+
+providerAuthorityRoutes.put("/provider-agent-budgets/:id", async (c) => {
+  const body = await safeJsonParse<{
+    dimension: "count" | "notional";
+    windowSeconds: number;
+    max: number;
+    currency?: string | null;
+    autoFreeze?: boolean;
+    enabled?: boolean;
+    expectedRevision: number;
+    reason: string;
+  }>(c);
+  if (!body) return c.json<ApiResponse>({ ok: false, error: "Invalid JSON body" }, 400);
+  try {
+    return c.json({
+      ok: true,
+      data: await providerAuthorityStore.updateAgentBudget(
+        mutationContext(c, body),
+        c.req.param("id"),
+        body,
+      ),
+    });
+  } catch (error) {
+    return fail(c, error);
+  }
+});
+
 providerAuthorityRoutes.post("/provider-access/check", async (c) => {
   const body = await safeJsonParse<
     Omit<ProviderAccessRequestV1, "tenantId" | "actor" | "evaluatedAt"> & {

--- a/packages/api/src/services/provider-action-service.ts
+++ b/packages/api/src/services/provider-action-service.ts
@@ -2425,10 +2425,11 @@ class ProviderActionService {
           "execution",
         ),
       );
+      const code = primaryPolicyDenialReason(policy.doc);
       return {
         ok: false,
-        code: policy.doc.reasonCodes[0] ?? "POLICY_HARD_DENY",
-        httpStatus: policy.doc.reasonCodes[0] === AGENT_BUDGET_UNAVAILABLE ? 503 : 403,
+        code,
+        httpStatus: code === AGENT_BUDGET_UNAVAILABLE ? 503 : 403,
         decision: policy.doc,
         decisionHash: sha256HexPrefixed(jcsStringify(policy.doc)),
         exhaustedBudgets: policy.exhaustedBudgets,

--- a/packages/api/src/services/provider-action-service.ts
+++ b/packages/api/src/services/provider-action-service.ts
@@ -124,6 +124,7 @@ import {
   releaseCumulativeSpend,
   releaseWindowedInvoke,
   reserveCumulativeSpend,
+  reserveCumulativeSpendBatch,
   reserveWindowedInvoke,
   settleCumulativeSpend,
 } from "@stwd/redis";
@@ -1851,18 +1852,17 @@ class ProviderActionService {
     autoFreeze: boolean;
     snapshots: Array<Record<string, unknown>>;
   }> {
-    // Lock the parent namespace before reading child budget rows. Existing-row
-    // locks alone cannot serialize against insertion of a brand-new budget (a
-    // phantom), which could otherwise commit while this execution still admits
-    // against an empty/stale budget set. Mutations take the conflicting UPDATE
-    // lock on the same agent row; executions share this lock with each other.
-    const [budgetNamespace] = await input.db
+    // Lock the durable parent row before reading the child configuration. Budget
+    // create/update takes the conflicting parent lock. Unlike locking the
+    // current budget result set, this also closes the empty-set INSERT race: an
+    // action that observed no budget cannot overlap a newly-created max=0 cap.
+    const [agent] = await input.db
       .select({ id: agents.id })
       .from(agents)
       .where(and(eq(agents.tenantId, input.tenantId), eq(agents.id, input.agentId)))
       .limit(1)
       .for("share");
-    if (!budgetNamespace) {
+    if (!agent) {
       return {
         reservations: [],
         results: [],
@@ -1975,10 +1975,14 @@ class ProviderActionService {
     const results: AgentBudgetResult[] = [];
     const exhausted: AgentBudgetResult[] = [];
     let unavailable = false;
-    for (const [groupKey, group] of groups) {
-      let reserved: Awaited<ReturnType<typeof reserveCumulativeSpend>>;
-      try {
-        reserved = await reserveCumulativeSpend({
+    const grouped = [...groups.entries()];
+    if (grouped.length === 0) {
+      return { reservations, results, exhausted, unavailable, autoFreeze: false, snapshots };
+    }
+    let reserved: Awaited<ReturnType<typeof reserveCumulativeSpendBatch>>;
+    try {
+      reserved = await reserveCumulativeSpendBatch(
+        grouped.map(([groupKey, group]) => ({
           stream: group.stream,
           caps: group.budgets.map((budget) => ({
             windowSeconds: budget.windowSeconds,
@@ -1993,9 +1997,11 @@ class ProviderActionService {
               groupKey,
             }),
           ),
-        });
-      } catch {
-        unavailable = true;
+        })),
+      );
+    } catch {
+      unavailable = true;
+      for (const [, group] of grouped) {
         for (const budget of group.budgets) {
           results.push({
             budgetId: budget.id,
@@ -2010,10 +2016,20 @@ class ProviderActionService {
             prior: null,
           });
         }
-        break;
       }
+      return {
+        reservations,
+        results,
+        exhausted,
+        unavailable,
+        autoFreeze: false,
+        snapshots,
+      };
+    }
+    grouped.forEach(([, group], groupIndex) => {
+      const groupPriors = reserved.priorSums[groupIndex] ?? [];
       group.budgets.forEach((budget, index) => {
-        const prior = reserved.priorSums[index];
+        const prior = groupPriors[index];
         const breached =
           !reserved.ok && (typeof prior !== "number" || prior + group.amount > budget.max);
         const result: AgentBudgetResult = {
@@ -2031,26 +2047,14 @@ class ProviderActionService {
         results.push(result);
         if (breached) exhausted.push(result);
       });
-      if (!reserved.ok) break;
-      reservations.push({
-        stream: group.stream,
-        reservationId: reserved.reservationId as string,
-        amount: group.amount,
-      });
-    }
-
-    if ((unavailable || exhausted.length > 0) && reservations.length > 0) {
-      await Promise.all(
-        reservations.map((reservation) =>
-          releaseCumulativeSpend({
-            stream: reservation.stream,
-            reservationId: reservation.reservationId,
-            amount: reservation.amount,
-          }),
-        ),
-      );
-      reservations.length = 0;
-    }
+      if (reserved.ok) {
+        reservations.push({
+          stream: group.stream,
+          reservationId: reserved.reservationIds?.[groupIndex] as string,
+          amount: group.amount,
+        });
+      }
+    });
     const exhaustedIds = new Set(exhausted.map((result) => result.budgetId));
     return {
       reservations,
@@ -2127,204 +2131,224 @@ class ProviderActionService {
       spendDeclaration,
       policyArgs: build.policyArgs,
     });
-    if (agentBudgets.autoFreeze) {
-      await (args.db ?? this.db())
-        .insert(vaultSigningFreezes)
-        .values({
-          tenantId: args.tenantId,
-          scopeType: "agent",
-          agentId: args.actorAgentId,
-          reason: "provider agent budget exhausted",
-          createdByType: "system",
-          createdById: "provider-budget-enforcer",
-        })
-        .onConflictDoNothing();
-    }
-    const cumulative = await this.reserveCumulativeSpendForInvoke({
-      rules,
-      intentId: args.intentId,
-      operationKey: operation.operationKey,
-      agentId: args.actorAgentId,
-      grantId: args.grantId ?? null,
-      spendDeclaration,
-      policyArgs: build.policyArgs,
-      reservationGeneration: args.reservationGeneration ?? 1,
-    });
-
-    // #206 configurable count cap (maxCalls + callWindow): ATOMICALLY reserve one
-    // invoke slot against the trailing-window count so concurrent invokes cannot
-    // collectively exceed maxCalls (single-winner, like the spend path; codex P2).
-    // The reserved priorCount is fed to the composer so its check agrees; a
-    // REJECTED reservation feeds a count AT the cap so the composer denies. Absent
-    // reservation (no governing maxCalls rule, or a Redis failure) leaves
-    // windowedInvokeCount undefined => a maxCalls rule fails closed
-    // (POLICY_INPUT_UNAVAILABLE). The slot is settled (kept) on a known-success
-    // allow and released on any deny/failure below.
-    // #206 configurable count caps: ATOMICALLY reserve ONE invoke slot against
-    // ALL count windows at once (a single invoke is counted ONCE across an hourly
-    // AND a daily cap; codex P2). Each window's count is fed to the composer keyed
-    // by its own bucket. A rejection on ANY window denies (no slot taken); a
-    // Redis failure feeds every cap AT its max so the composer fails closed.
-    const govMaxCalls = extractGoverningMaxCalls(rules, operation.operationKey);
-    let windowedInvokeCounts: Record<string, number> | undefined;
+    let cumulative:
+      | {
+          contextSums: Record<string, number> | undefined;
+          reservations: CumulativeSpendReservationHandle[];
+        }
+      | undefined;
     let windowedInvokeReservation: WindowedInvokeReservationHandle | undefined;
-    if (govMaxCalls.length > 0) {
-      const counts: Record<string, number> = {};
-      windowedInvokeCounts = counts;
-      const wr = await reserveWindowedInvoke({
-        agentId: args.actorAgentId,
-        operationKey: operation.operationKey,
-        caps: govMaxCalls.map((c) => ({ windowSeconds: c.windowSeconds, max: c.max })),
-        reservationId: sha256HexPrefixed(
-          jcsStringify({
-            domain: "steward.provider-reservation.v1",
-            intentId: args.intentId,
-            generation: args.reservationGeneration ?? 1,
-            kind: "windowedInvoke",
+    try {
+      if (agentBudgets.autoFreeze) {
+        await (args.db ?? this.db())
+          .insert(vaultSigningFreezes)
+          .values({
+            tenantId: args.tenantId,
+            scopeType: "agent",
             agentId: args.actorAgentId,
-            operationKey: operation.operationKey,
-          }),
-        ),
+            reason: "provider agent budget exhausted",
+            createdByType: "system",
+            createdById: "provider-budget-enforcer",
+          })
+          .onConflictDoNothing();
+      }
+      cumulative = await this.reserveCumulativeSpendForInvoke({
+        rules,
+        intentId: args.intentId,
+        operationKey: operation.operationKey,
+        agentId: args.actorAgentId,
+        grantId: args.grantId ?? null,
+        spendDeclaration,
+        policyArgs: build.policyArgs,
+        reservationGeneration: args.reservationGeneration ?? 1,
       });
-      govMaxCalls.forEach((cap, i) => {
-        const bucketKey = windowedInvokeBucketKey({
-          windowSeconds: cap.windowSeconds,
-          max: cap.max,
-        });
-        // On success feed the real prior count; on rejection/absence feed AT the
-        // cap so the composer denies (count >= maxCalls) for the breaching cap.
-        const prior = wr.priorCounts[i];
-        counts[bucketKey] = wr.ok && typeof prior === "number" ? prior : (prior ?? cap.max);
-      });
-      if (wr.ok && wr.reservationId !== undefined) {
-        windowedInvokeReservation = {
+
+      // #206 configurable count cap (maxCalls + callWindow): ATOMICALLY reserve one
+      // invoke slot against the trailing-window count so concurrent invokes cannot
+      // collectively exceed maxCalls (single-winner, like the spend path; codex P2).
+      // The reserved priorCount is fed to the composer so its check agrees; a
+      // REJECTED reservation feeds a count AT the cap so the composer denies. Absent
+      // reservation (no governing maxCalls rule, or a Redis failure) leaves
+      // windowedInvokeCount undefined => a maxCalls rule fails closed
+      // (POLICY_INPUT_UNAVAILABLE). The slot is settled (kept) on a known-success
+      // allow and released on any deny/failure below.
+      // #206 configurable count caps: ATOMICALLY reserve ONE invoke slot against
+      // ALL count windows at once (a single invoke is counted ONCE across an hourly
+      // AND a daily cap; codex P2). Each window's count is fed to the composer keyed
+      // by its own bucket. A rejection on ANY window denies (no slot taken); a
+      // Redis failure feeds every cap AT its max so the composer fails closed.
+      const govMaxCalls = extractGoverningMaxCalls(rules, operation.operationKey);
+      let windowedInvokeCounts: Record<string, number> | undefined;
+      if (govMaxCalls.length > 0) {
+        const counts: Record<string, number> = {};
+        windowedInvokeCounts = counts;
+        const wr = await reserveWindowedInvoke({
           agentId: args.actorAgentId,
           operationKey: operation.operationKey,
-          reservationId: wr.reservationId,
-        };
-      }
-      // A rejected multi-cap reserve takes NO slot, so there is nothing to
-      // release here; the composer will deny from the fed counts.
-    }
-
-    const context: ProviderPolicyContext = {
-      operationKey: operation.operationKey,
-      args: build.policyArgs,
-      method: build.method,
-      // Host is carried context only (the composer never gates on it); derive it
-      // from the adapter's canonical origin so X actions report api.x.com and
-      // github actions report api.github.com, never a hardcoded provider.
-      host: hostFromOrigin(build.action.origin),
-      path: build.action.normalizedPath,
-      evaluatedAt: decidedAt,
-      // Trailing-hour count is not wired in PR2; rules that require it will
-      // fail closed (POLICY_INPUT_UNAVAILABLE) exactly as specified.
-      invokeCount1h: undefined,
-      // #206 configurable count caps: per-cap trailing-window counts (undefined
-      // when unwired => a maxCalls rule fails closed).
-      ...(windowedInvokeCounts !== undefined ? { windowedInvokeCounts } : {}),
-      ...(policyText !== undefined ? { policyText } : {}),
-      // #206 cumulative-spend aggregate + declaration. spendDeclaration absent =>
-      // a cumulativeSpend rule fails closed (NO_SPEND_FIELD). cumulativeSpend
-      // carries the reserved priorSum per scope; absent scope => fail closed
-      // (INPUT_UNAVAILABLE). See reserveCumulativeSpendForInvoke.
-      ...(spendDeclaration !== undefined ? { spendDeclaration } : {}),
-      ...(cumulative.contextSums !== undefined ? { cumulativeSpend: cumulative.contextSums } : {}),
-      // Permissioned-X authoritative inputs (post count / accumulated spend /
-      // now-minute) are NOT wired into the service in Phase 1 — exactly the same
-      // posture as invokeCount1h above. A permissioned-X rule that REQUIRES one
-      // of these inputs (maxPostsPerWindow / spendPolicy / quietHours) therefore
-      // fails closed (POLICY_INPUT_UNAVAILABLE) until the trailing-window
-      // accumulator lands. Content/reply/URL rules need no external input and are
-      // fully live now.
-      x: undefined,
-    };
-
-    const ruleEvaluation = composeProviderActionPolicyDecision(rules, context);
-    const budgetReason = agentBudgets.unavailable
-      ? AGENT_BUDGET_UNAVAILABLE
-      : agentBudgets.exhausted.length > 0
-        ? AGENT_BUDGET_EXHAUSTED
-        : null;
-    const evaluation: ProviderPolicyEvaluationV1 = budgetReason
-      ? {
-          ...ruleEvaluation,
-          effect: "hard_deny",
-          reasonCodes: [budgetReason, ...ruleEvaluation.reasonCodes],
+          caps: govMaxCalls.map((c) => ({ windowSeconds: c.windowSeconds, max: c.max })),
+          reservationId: sha256HexPrefixed(
+            jcsStringify({
+              domain: "steward.provider-reservation.v1",
+              intentId: args.intentId,
+              generation: args.reservationGeneration ?? 1,
+              kind: "windowedInvoke",
+              agentId: args.actorAgentId,
+              operationKey: operation.operationKey,
+            }),
+          ),
+        });
+        govMaxCalls.forEach((cap, i) => {
+          const bucketKey = windowedInvokeBucketKey({
+            windowSeconds: cap.windowSeconds,
+            max: cap.max,
+          });
+          // On success feed the real prior count; on rejection/absence feed AT the
+          // cap so the composer denies (count >= maxCalls) for the breaching cap.
+          const prior = wr.priorCounts[i];
+          counts[bucketKey] = wr.ok && typeof prior === "number" ? prior : (prior ?? cap.max);
+        });
+        if (wr.ok && wr.reservationId !== undefined) {
+          windowedInvokeReservation = {
+            agentId: args.actorAgentId,
+            operationKey: operation.operationKey,
+            reservationId: wr.reservationId,
+          };
         }
-      : ruleEvaluation;
+        // A rejected multi-cap reserve takes NO slot, so there is nothing to
+        // release here; the composer will deny from the fed counts.
+      }
 
-    // Per-rule revision hashes and the composite policy revision hash.
-    const enabledGoverning = rules.filter(
-      (r) => r.enabled && capabilitySelectorMatches(r.config, operation.operationKey),
-    );
-    const ruleSnapshots = enabledGoverning
-      .map((r) => ({
-        id: r.id,
-        type: r.type,
-        enabled: r.enabled,
-        config: r.config,
-        hash: ruleRevisionHash(r),
-      }))
-      .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : a.hash < b.hash ? -1 : 1));
+      const context: ProviderPolicyContext = {
+        operationKey: operation.operationKey,
+        args: build.policyArgs,
+        method: build.method,
+        // Host is carried context only (the composer never gates on it); derive it
+        // from the adapter's canonical origin so X actions report api.x.com and
+        // github actions report api.github.com, never a hardcoded provider.
+        host: hostFromOrigin(build.action.origin),
+        path: build.action.normalizedPath,
+        evaluatedAt: decidedAt,
+        // Trailing-hour count is not wired in PR2; rules that require it will
+        // fail closed (POLICY_INPUT_UNAVAILABLE) exactly as specified.
+        invokeCount1h: undefined,
+        // #206 configurable count caps: per-cap trailing-window counts (undefined
+        // when unwired => a maxCalls rule fails closed).
+        ...(windowedInvokeCounts !== undefined ? { windowedInvokeCounts } : {}),
+        ...(policyText !== undefined ? { policyText } : {}),
+        // #206 cumulative-spend aggregate + declaration. spendDeclaration absent =>
+        // a cumulativeSpend rule fails closed (NO_SPEND_FIELD). cumulativeSpend
+        // carries the reserved priorSum per scope; absent scope => fail closed
+        // (INPUT_UNAVAILABLE). See reserveCumulativeSpendForInvoke.
+        ...(spendDeclaration !== undefined ? { spendDeclaration } : {}),
+        ...(cumulative.contextSums !== undefined
+          ? { cumulativeSpend: cumulative.contextSums }
+          : {}),
+        // Permissioned-X authoritative inputs (post count / accumulated spend /
+        // now-minute) are NOT wired into the service in Phase 1 — exactly the same
+        // posture as invokeCount1h above. A permissioned-X rule that REQUIRES one
+        // of these inputs (maxPostsPerWindow / spendPolicy / quietHours) therefore
+        // fails closed (POLICY_INPUT_UNAVAILABLE) until the trailing-window
+        // accumulator lands. Content/reply/URL rules need no external input and are
+        // fully live now.
+        x: undefined,
+      };
 
-    const policyRevisionHash = sha256HexPrefixed(
-      jcsStringify({
-        operationId: operation.id,
-        operationRevision: operation.revision,
-        actorAgentId: args.actorAgentId,
-        evaluatorVersion: EVALUATOR_VERSION,
-        rules: ruleSnapshots.map((r) => ({ id: r.id, hash: r.hash })),
-        agentBudgets: agentBudgets.snapshots,
-      }),
-    );
+      const ruleEvaluation = composeProviderActionPolicyDecision(rules, context);
+      const budgetReason = agentBudgets.unavailable
+        ? AGENT_BUDGET_UNAVAILABLE
+        : agentBudgets.exhausted.length > 0
+          ? AGENT_BUDGET_EXHAUSTED
+          : null;
+      const evaluation: ProviderPolicyEvaluationV1 = budgetReason
+        ? {
+            ...ruleEvaluation,
+            effect: "hard_deny",
+            reasonCodes: [budgetReason, ...ruleEvaluation.reasonCodes],
+          }
+        : ruleEvaluation;
 
-    const hashById = new Map(ruleSnapshots.map((r) => [r.id, r.hash]));
-    const policyResults: PersistedPolicyDecisionV1["policyResults"] = evaluation.results
-      .map((res) => ({
-        policyId: res.policyId,
-        policyType: POLICY_TYPE,
-        applicable: true as const,
-        configuredEffect: res.configuredEffect,
-        outcome: res.outcome,
-        reasonCode: res.reasonCode,
-        ruleRevisionHash: hashById.get(res.policyId) ?? "",
-      }))
-      .sort((a, b) =>
-        a.policyId < b.policyId
-          ? -1
-          : a.policyId > b.policyId
-            ? 1
-            : a.ruleRevisionHash < b.ruleRevisionHash
-              ? -1
-              : 1,
+      // Per-rule revision hashes and the composite policy revision hash.
+      const enabledGoverning = rules.filter(
+        (r) => r.enabled && capabilitySelectorMatches(r.config, operation.operationKey),
+      );
+      const ruleSnapshots = enabledGoverning
+        .map((r) => ({
+          id: r.id,
+          type: r.type,
+          enabled: r.enabled,
+          config: r.config,
+          hash: ruleRevisionHash(r),
+        }))
+        .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : a.hash < b.hash ? -1 : 1));
+
+      const policyRevisionHash = sha256HexPrefixed(
+        jcsStringify({
+          operationId: operation.id,
+          operationRevision: operation.revision,
+          actorAgentId: args.actorAgentId,
+          evaluatorVersion: EVALUATOR_VERSION,
+          rules: ruleSnapshots.map((r) => ({ id: r.id, hash: r.hash })),
+          agentBudgets: agentBudgets.snapshots,
+        }),
       );
 
-    const doc: PersistedPolicyDecisionV1 = {
-      schemaVersion: "steward.provider-policy-decision.v1",
-      decisionId,
-      intentId: args.intentId,
-      requestHash: args.requestHash,
-      actionDigest: args.actionDigest,
-      operationId: operation.id,
-      operationKey: operation.operationKey,
-      effect: evaluation.effect,
-      reasonCodes: evaluation.reasonCodes,
-      policyResults,
-      agentBudgetResults: agentBudgets.results,
-      policyRevisionHash,
-      evaluatorVersion: EVALUATOR_VERSION,
-      decidedAt,
-    };
-    return {
-      doc,
-      evaluation,
-      decisionId,
-      cumulativeSpendReservations: [...cumulative.reservations, ...agentBudgets.reservations],
-      ...(windowedInvokeReservation !== undefined ? { windowedInvokeReservation } : {}),
-      exhaustedBudgets: agentBudgets.exhausted,
-      autoFreeze: agentBudgets.autoFreeze,
-    };
+      const hashById = new Map(ruleSnapshots.map((r) => [r.id, r.hash]));
+      const policyResults: PersistedPolicyDecisionV1["policyResults"] = evaluation.results
+        .map((res) => ({
+          policyId: res.policyId,
+          policyType: POLICY_TYPE,
+          applicable: true as const,
+          configuredEffect: res.configuredEffect,
+          outcome: res.outcome,
+          reasonCode: res.reasonCode,
+          ruleRevisionHash: hashById.get(res.policyId) ?? "",
+        }))
+        .sort((a, b) =>
+          a.policyId < b.policyId
+            ? -1
+            : a.policyId > b.policyId
+              ? 1
+              : a.ruleRevisionHash < b.ruleRevisionHash
+                ? -1
+                : 1,
+        );
+
+      const doc: PersistedPolicyDecisionV1 = {
+        schemaVersion: "steward.provider-policy-decision.v1",
+        decisionId,
+        intentId: args.intentId,
+        requestHash: args.requestHash,
+        actionDigest: args.actionDigest,
+        operationId: operation.id,
+        operationKey: operation.operationKey,
+        effect: evaluation.effect,
+        reasonCodes: evaluation.reasonCodes,
+        policyResults,
+        agentBudgetResults: agentBudgets.results,
+        policyRevisionHash,
+        evaluatorVersion: EVALUATOR_VERSION,
+        decidedAt,
+      };
+      return {
+        doc,
+        evaluation,
+        decisionId,
+        cumulativeSpendReservations: [...cumulative.reservations, ...agentBudgets.reservations],
+        ...(windowedInvokeReservation !== undefined ? { windowedInvokeReservation } : {}),
+        exhaustedBudgets: agentBudgets.exhausted,
+        autoFreeze: agentBudgets.autoFreeze,
+      };
+    } catch (error) {
+      // Redis admission precedes the durable decision transaction. If any later
+      // reservation/evaluation step throws, the caller cannot persist handles it
+      // never received, so compensate every handle accumulated in this frame.
+      await this.finalizeCumulativeSpend(
+        [...(cumulative?.reservations ?? []), ...agentBudgets.reservations],
+        "failure",
+      );
+      await this.finalizeWindowedInvoke(windowedInvokeReservation, "failure");
+      throw error;
+    }
   }
 
   /**
@@ -2356,8 +2380,6 @@ class ProviderActionService {
         ok: false;
         code: string;
         httpStatus: number;
-        decision?: PersistedPolicyDecisionV1;
-        decisionHash?: string;
         exhaustedBudgets?: AgentBudgetResult[];
         autoFreeze?: boolean;
       }
@@ -2403,10 +2425,8 @@ class ProviderActionService {
       );
       return {
         ok: false,
-        code: primaryPolicyDenialReason(policy.doc),
+        code: policy.doc.reasonCodes[0] ?? "POLICY_HARD_DENY",
         httpStatus: policy.doc.reasonCodes[0] === AGENT_BUDGET_UNAVAILABLE ? 503 : 403,
-        decision: policy.doc,
-        decisionHash: sha256HexPrefixed(jcsStringify(policy.doc)),
         exhaustedBudgets: policy.exhaustedBudgets,
         autoFreeze: policy.autoFreeze,
       };

--- a/packages/api/src/services/provider-action-service.ts
+++ b/packages/api/src/services/provider-action-service.ts
@@ -2380,6 +2380,8 @@ class ProviderActionService {
         ok: false;
         code: string;
         httpStatus: number;
+        decision?: PersistedPolicyDecisionV1;
+        decisionHash?: string;
         exhaustedBudgets?: AgentBudgetResult[];
         autoFreeze?: boolean;
       }
@@ -2427,6 +2429,8 @@ class ProviderActionService {
         ok: false,
         code: policy.doc.reasonCodes[0] ?? "POLICY_HARD_DENY",
         httpStatus: policy.doc.reasonCodes[0] === AGENT_BUDGET_UNAVAILABLE ? 503 : 403,
+        decision: policy.doc,
+        decisionHash: sha256HexPrefixed(jcsStringify(policy.doc)),
         exhaustedBudgets: policy.exhaustedBudgets,
         autoFreeze: policy.autoFreeze,
       };

--- a/packages/api/src/services/provider-action-service.ts
+++ b/packages/api/src/services/provider-action-service.ts
@@ -1851,6 +1851,27 @@ class ProviderActionService {
     autoFreeze: boolean;
     snapshots: Array<Record<string, unknown>>;
   }> {
+    // Lock the parent namespace before reading child budget rows. Existing-row
+    // locks alone cannot serialize against insertion of a brand-new budget (a
+    // phantom), which could otherwise commit while this execution still admits
+    // against an empty/stale budget set. Mutations take the conflicting UPDATE
+    // lock on the same agent row; executions share this lock with each other.
+    const [budgetNamespace] = await input.db
+      .select({ id: agents.id })
+      .from(agents)
+      .where(and(eq(agents.tenantId, input.tenantId), eq(agents.id, input.agentId)))
+      .limit(1)
+      .for("share");
+    if (!budgetNamespace) {
+      return {
+        reservations: [],
+        results: [],
+        exhausted: [],
+        unavailable: true,
+        autoFreeze: false,
+        snapshots: [],
+      };
+    }
     const rows = await input.db
       .select()
       .from(providerAgentBudgets)

--- a/packages/api/src/services/provider-action-service.ts
+++ b/packages/api/src/services/provider-action-service.ts
@@ -34,10 +34,12 @@ import {
   providerActionAuditOutbox,
   providerActionBindings,
   providerActionReservationGenerations,
+  providerAgentBudgets,
   providerGrants,
   providerOperations,
   providerRoleBindings,
   secretRoutes,
+  vaultSigningFreezes,
   workspaces,
 } from "@stwd/db";
 import {
@@ -125,7 +127,7 @@ import {
   reserveWindowedInvoke,
   settleCumulativeSpend,
 } from "@stwd/redis";
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, isNull, or, sql } from "drizzle-orm";
 import type { ProviderPrincipalV1 } from "../middleware/provider-principal";
 import { appendAuditEvent, withTenantAuditQueue, writeAuditEvent } from "./audit";
 import { getGenericHttpProductionSpec } from "./provider-action-profile-specs";
@@ -613,10 +615,27 @@ interface PersistedPolicyDecisionV1 {
     reasonCode: string;
     ruleRevisionHash: string;
   }>;
+  agentBudgetResults: AgentBudgetResult[];
   policyRevisionHash: string;
   evaluatorVersion: string;
   decidedAt: string;
 }
+
+interface AgentBudgetResult {
+  budgetId: string;
+  revision: number;
+  dimension: "count" | "notional";
+  workspaceId: string | null;
+  windowSeconds: number;
+  max: number;
+  currency: string | null;
+  amount: number;
+  outcome: "pass" | "exhausted" | "unavailable";
+  prior: number | null;
+}
+
+const AGENT_BUDGET_EXHAUSTED = "PROVIDER_AGENT_BUDGET_EXHAUSTED";
+const AGENT_BUDGET_UNAVAILABLE = "PROVIDER_AGENT_BUDGET_UNAVAILABLE";
 
 function byUuidBytes(a: string, b: string): number {
   return a < b ? -1 : a > b ? 1 : 0;
@@ -643,6 +662,8 @@ const POLICY_DENY_HTTP: Record<string, number> = {
   POLICY_CONFIGURATION_INVALID: 403,
   POLICY_INPUT_UNAVAILABLE: 503,
   POLICY_EVALUATOR_ERROR: 503,
+  [AGENT_BUDGET_EXHAUSTED]: 403,
+  [AGENT_BUDGET_UNAVAILABLE]: 503,
 };
 
 // ─── Service ──────────────────────────────────────────────────────────────────
@@ -666,6 +687,8 @@ type PolicyResult = {
   decisionId: string;
   cumulativeSpendReservations: CumulativeSpendReservationHandle[];
   windowedInvokeReservation?: WindowedInvokeReservationHandle;
+  exhaustedBudgets: AgentBudgetResult[];
+  autoFreeze: boolean;
 };
 
 class ProviderActionService {
@@ -892,6 +915,7 @@ class ProviderActionService {
         policy =
           access.effect === "allow"
             ? await this.evaluatePolicy({
+                db: tx,
                 tenantId,
                 workspaceId: input.workspaceId,
                 actorAgentId,
@@ -1065,10 +1089,31 @@ class ProviderActionService {
             policyDecisionHash,
             policyEffect: effects.policy,
             policyReasonCodes: policy?.doc.reasonCodes ?? [],
+            agentBudgetResults: policy?.doc.agentBudgetResults ?? [],
             status: effects.status,
             requestId: input.requestId ?? null,
           },
         });
+        if (policy && policy.exhaustedBudgets.length > 0) {
+          await tx.insert(providerActionAuditOutbox).values({
+            tenantId,
+            intentId,
+            action: "provider.budget.exhausted",
+            resourceType: "provider_action",
+            resourceId: intentId,
+            metadata: {
+              schemaVersion: "steward.provider-agent-budget-exhausted.v1",
+              intentId,
+              actorAgentId,
+              workspaceId: input.workspaceId,
+              operationKey: input.operationKey,
+              requestHash,
+              actionDigest,
+              budgetResults: policy.exhaustedBudgets,
+              autoFreeze: policy.autoFreeze,
+            },
+          });
+        }
       });
     } catch (e) {
       // #206: the decision transaction failed to persist, so the action WILL NOT
@@ -1785,8 +1830,220 @@ class ProviderActionService {
     }).catch(() => undefined);
   }
 
+  /** Atomically debit every applicable first-class agent budget. Global and
+   * workspace budgets use distinct streams; all caps on one stream are checked
+   * in one Lua call, so concurrent executions have a single winner at the
+   * boundary. The returned handles join the normal crash-durable generation. */
+  private async reserveAgentBudgets(input: {
+    db: DbExecutor;
+    tenantId: string;
+    workspaceId: string;
+    agentId: string;
+    intentId: string;
+    generation: number;
+    spendDeclaration?: { field: string; currency: string };
+    policyArgs: Record<string, unknown>;
+  }): Promise<{
+    reservations: CumulativeSpendReservationHandle[];
+    results: AgentBudgetResult[];
+    exhausted: AgentBudgetResult[];
+    unavailable: boolean;
+    autoFreeze: boolean;
+    snapshots: Array<Record<string, unknown>>;
+  }> {
+    const rows = await input.db
+      .select()
+      .from(providerAgentBudgets)
+      .where(
+        and(
+          eq(providerAgentBudgets.tenantId, input.tenantId),
+          eq(providerAgentBudgets.agentId, input.agentId),
+          eq(providerAgentBudgets.enabled, true),
+          or(
+            isNull(providerAgentBudgets.workspaceId),
+            eq(providerAgentBudgets.workspaceId, input.workspaceId),
+          ),
+        ),
+      )
+      .orderBy(providerAgentBudgets.id)
+      // Concurrent executions may share the snapshot, while an operator budget
+      // mutation must wait until this execution decision commits. This prevents
+      // a newly tightened budget from racing an admission based on stale config.
+      .for("share");
+
+    const snapshots = rows.map((row) => ({
+      id: row.id,
+      revision: row.revision,
+      workspaceId: row.workspaceId,
+      dimension: row.dimension,
+      windowSeconds: row.windowSeconds,
+      max: row.max,
+      currency: row.currency,
+      autoFreeze: row.autoFreeze,
+    }));
+    const groups = new Map<
+      string,
+      {
+        stream: CumulativeSpendReservationHandle["stream"];
+        amount: number;
+        budgets: typeof rows;
+      }
+    >();
+    for (const row of rows) {
+      if (
+        (row.dimension !== "count" && row.dimension !== "notional") ||
+        !Number.isSafeInteger(row.windowSeconds) ||
+        row.windowSeconds <= 0 ||
+        !Number.isSafeInteger(row.max) ||
+        row.max < 0
+      ) {
+        return {
+          reservations: [],
+          results: [],
+          exhausted: [],
+          unavailable: true,
+          autoFreeze: false,
+          snapshots,
+        };
+      }
+      let amount: number;
+      let currency: string;
+      if (row.dimension === "count") {
+        amount = 1;
+        currency = "__agent_budget_count__";
+      } else {
+        const declaration = input.spendDeclaration;
+        // A currency-specific notional budget is applicable only to operations
+        // explicitly declaring that currency. Count budgets still cover every
+        // governed action, including operations with no notional declaration.
+        if (!declaration || row.currency !== declaration.currency) continue;
+        const raw = input.policyArgs[declaration.field];
+        if (!Number.isSafeInteger(raw) || (raw as number) < 0) {
+          return {
+            reservations: [],
+            results: [],
+            exhausted: [],
+            unavailable: true,
+            autoFreeze: false,
+            snapshots,
+          };
+        }
+        amount = raw as number;
+        currency = row.currency as string;
+      }
+      const scope = row.workspaceId ? `workspace:${row.workspaceId}` : "global";
+      const groupKey = `${scope}|${row.dimension}|${currency}`;
+      let group = groups.get(groupKey);
+      if (!group) {
+        group = {
+          stream: {
+            agentId: input.agentId,
+            scope: "agent",
+            scopeKey: `budget:${scope}:${row.dimension}`,
+            currency,
+          },
+          amount,
+          budgets: [],
+        };
+        groups.set(groupKey, group);
+      }
+      group.budgets.push(row);
+    }
+
+    const reservations: CumulativeSpendReservationHandle[] = [];
+    const results: AgentBudgetResult[] = [];
+    const exhausted: AgentBudgetResult[] = [];
+    let unavailable = false;
+    for (const [groupKey, group] of groups) {
+      let reserved: Awaited<ReturnType<typeof reserveCumulativeSpend>>;
+      try {
+        reserved = await reserveCumulativeSpend({
+          stream: group.stream,
+          caps: group.budgets.map((budget) => ({
+            windowSeconds: budget.windowSeconds,
+            max: budget.max,
+          })),
+          amount: group.amount,
+          reservationId: sha256HexPrefixed(
+            jcsStringify({
+              domain: "steward.provider-agent-budget.v1",
+              intentId: input.intentId,
+              generation: input.generation,
+              groupKey,
+            }),
+          ),
+        });
+      } catch {
+        unavailable = true;
+        for (const budget of group.budgets) {
+          results.push({
+            budgetId: budget.id,
+            revision: budget.revision,
+            dimension: budget.dimension as "count" | "notional",
+            workspaceId: budget.workspaceId,
+            windowSeconds: budget.windowSeconds,
+            max: budget.max,
+            currency: budget.currency,
+            amount: group.amount,
+            outcome: "unavailable",
+            prior: null,
+          });
+        }
+        break;
+      }
+      group.budgets.forEach((budget, index) => {
+        const prior = reserved.priorSums[index];
+        const breached =
+          !reserved.ok && (typeof prior !== "number" || prior + group.amount > budget.max);
+        const result: AgentBudgetResult = {
+          budgetId: budget.id,
+          revision: budget.revision,
+          dimension: budget.dimension as "count" | "notional",
+          workspaceId: budget.workspaceId,
+          windowSeconds: budget.windowSeconds,
+          max: budget.max,
+          currency: budget.currency,
+          amount: group.amount,
+          outcome: breached ? "exhausted" : "pass",
+          prior: typeof prior === "number" ? prior : null,
+        };
+        results.push(result);
+        if (breached) exhausted.push(result);
+      });
+      if (!reserved.ok) break;
+      reservations.push({
+        stream: group.stream,
+        reservationId: reserved.reservationId as string,
+        amount: group.amount,
+      });
+    }
+
+    if ((unavailable || exhausted.length > 0) && reservations.length > 0) {
+      await Promise.all(
+        reservations.map((reservation) =>
+          releaseCumulativeSpend({
+            stream: reservation.stream,
+            reservationId: reservation.reservationId,
+            amount: reservation.amount,
+          }),
+        ),
+      );
+      reservations.length = 0;
+    }
+    const exhaustedIds = new Set(exhausted.map((result) => result.budgetId));
+    return {
+      reservations,
+      results,
+      exhausted,
+      unavailable,
+      autoFreeze: rows.some((row) => row.autoFreeze && exhaustedIds.has(row.id)),
+      snapshots,
+    };
+  }
+
   // ── Policy evaluation (spec §6.2 / §6.3) ──
   private async evaluatePolicy(args: {
+    db?: DbExecutor;
     tenantId: string;
     workspaceId: string;
     actorAgentId: string;
@@ -1810,6 +2067,8 @@ class ProviderActionService {
      *  covering ALL count windows). Settle (keep) on known-success, release on
      *  deny/failure, leave on outcome_unknown. */
     windowedInvokeReservation?: WindowedInvokeReservationHandle;
+    exhaustedBudgets: AgentBudgetResult[];
+    autoFreeze: boolean;
   }> {
     const decidedAt = (providerPolicyClockForTests?.() ?? new Date()).toISOString();
     const decisionId = randomUUID();
@@ -1837,6 +2096,29 @@ class ProviderActionService {
     // missing declaration / absent aggregate is left to the composer to fail
     // closed exactly as specified.
     const spendDeclaration = extractSpendDeclaration(operation.requestProfile);
+    const agentBudgets = await this.reserveAgentBudgets({
+      db: args.db ?? this.db(),
+      tenantId: args.tenantId,
+      workspaceId: args.workspaceId,
+      agentId: args.actorAgentId,
+      intentId: args.intentId,
+      generation: args.reservationGeneration ?? 1,
+      spendDeclaration,
+      policyArgs: build.policyArgs,
+    });
+    if (agentBudgets.autoFreeze) {
+      await (args.db ?? this.db())
+        .insert(vaultSigningFreezes)
+        .values({
+          tenantId: args.tenantId,
+          scopeType: "agent",
+          agentId: args.actorAgentId,
+          reason: "provider agent budget exhausted",
+          createdByType: "system",
+          createdById: "provider-budget-enforcer",
+        })
+        .onConflictDoNothing();
+    }
     const cumulative = await this.reserveCumulativeSpendForInvoke({
       rules,
       intentId: args.intentId,
@@ -1937,7 +2219,19 @@ class ProviderActionService {
       x: undefined,
     };
 
-    const evaluation = composeProviderActionPolicyDecision(rules, context);
+    const ruleEvaluation = composeProviderActionPolicyDecision(rules, context);
+    const budgetReason = agentBudgets.unavailable
+      ? AGENT_BUDGET_UNAVAILABLE
+      : agentBudgets.exhausted.length > 0
+        ? AGENT_BUDGET_EXHAUSTED
+        : null;
+    const evaluation: ProviderPolicyEvaluationV1 = budgetReason
+      ? {
+          ...ruleEvaluation,
+          effect: "hard_deny",
+          reasonCodes: [budgetReason, ...ruleEvaluation.reasonCodes],
+        }
+      : ruleEvaluation;
 
     // Per-rule revision hashes and the composite policy revision hash.
     const enabledGoverning = rules.filter(
@@ -1960,6 +2254,7 @@ class ProviderActionService {
         actorAgentId: args.actorAgentId,
         evaluatorVersion: EVALUATOR_VERSION,
         rules: ruleSnapshots.map((r) => ({ id: r.id, hash: r.hash })),
+        agentBudgets: agentBudgets.snapshots,
       }),
     );
 
@@ -1995,6 +2290,7 @@ class ProviderActionService {
       effect: evaluation.effect,
       reasonCodes: evaluation.reasonCodes,
       policyResults,
+      agentBudgetResults: agentBudgets.results,
       policyRevisionHash,
       evaluatorVersion: EVALUATOR_VERSION,
       decidedAt,
@@ -2003,8 +2299,10 @@ class ProviderActionService {
       doc,
       evaluation,
       decisionId,
-      cumulativeSpendReservations: cumulative.reservations,
+      cumulativeSpendReservations: [...cumulative.reservations, ...agentBudgets.reservations],
       ...(windowedInvokeReservation !== undefined ? { windowedInvokeReservation } : {}),
+      exhaustedBudgets: agentBudgets.exhausted,
+      autoFreeze: agentBudgets.autoFreeze,
     };
   }
 
@@ -2014,6 +2312,7 @@ class ProviderActionService {
    * text exists only in this stack frame and is never returned or persisted.
    */
   async evaluateApprovedExecution(args: {
+    db?: DbExecutor;
     tenantId: string;
     workspaceId: string;
     actorAgentId: string;
@@ -2038,6 +2337,8 @@ class ProviderActionService {
         httpStatus: number;
         decision?: PersistedPolicyDecisionV1;
         decisionHash?: string;
+        exhaustedBudgets?: AgentBudgetResult[];
+        autoFreeze?: boolean;
       }
   > {
     const generation = args.priorGeneration + 1;
@@ -2058,6 +2359,7 @@ class ProviderActionService {
     }
 
     const policy = await this.evaluatePolicy({
+      db: args.db,
       tenantId: args.tenantId,
       workspaceId: args.workspaceId,
       actorAgentId: args.actorAgentId,
@@ -2081,9 +2383,11 @@ class ProviderActionService {
       return {
         ok: false,
         code: primaryPolicyDenialReason(policy.doc),
-        httpStatus: 403,
+        httpStatus: policy.doc.reasonCodes[0] === AGENT_BUDGET_UNAVAILABLE ? 503 : 403,
         decision: policy.doc,
         decisionHash: sha256HexPrefixed(jcsStringify(policy.doc)),
+        exhaustedBudgets: policy.exhaustedBudgets,
+        autoFreeze: policy.autoFreeze,
       };
     }
 

--- a/packages/api/src/services/provider-approval.ts
+++ b/packages/api/src/services/provider-approval.ts
@@ -2093,6 +2093,7 @@ class ProviderApprovalService {
 
           const { providerActionService } = await import("./provider-action-service.js");
           const executionPolicy = await providerActionService.evaluateApprovedExecution({
+            db: tx,
             tenantId: binding.tenantId,
             workspaceId: binding.workspaceId,
             actorAgentId: binding.actorAgentId,
@@ -2110,7 +2111,10 @@ class ProviderApprovalService {
               tenantId: binding.tenantId,
               actorType: "system",
               actorId: RESUME_ACTOR,
-              action: "provider.resume.policy_denied",
+              action:
+                executionPolicy.code === "PROVIDER_AGENT_BUDGET_EXHAUSTED"
+                  ? "provider.budget.exhausted"
+                  : "provider.resume.policy_denied",
               resourceType: "provider_action",
               resourceId: binding.intentId,
               metadata: {
@@ -2122,6 +2126,8 @@ class ProviderApprovalService {
                 executionPolicyDecisionId: executionPolicy.decision?.decisionId ?? null,
                 executionPolicyDecisionHash: executionPolicy.decisionHash ?? null,
                 executionPolicyRevisionHash: executionPolicy.decision?.policyRevisionHash ?? null,
+                budgetResults: executionPolicy.exhaustedBudgets ?? [],
+                autoFreeze: executionPolicy.autoFreeze ?? false,
               },
               ipAddress: input.ipAddress ?? null,
               userAgent: input.userAgent ?? null,

--- a/packages/api/src/services/provider-authority-store.ts
+++ b/packages/api/src/services/provider-authority-store.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import {
+  type AppendRequiredAudit,
   agents,
   getDb,
   providerAccounts,
@@ -72,6 +73,9 @@ const RISK_CLASSES = new Set(["read", "write", "consequential"]);
 const BUDGET_DIMENSIONS = new Set(["count", "notional"]);
 const MAX_BUDGET_WINDOW_SECONDS = 30 * 24 * 60 * 60;
 
+type DbBase = ReturnType<typeof getDb>;
+type DbExecutor = DbBase | Parameters<Parameters<DbBase["transaction"]>[0]>[0];
+
 export class ProviderAuthorityError extends Error {
   constructor(
     message: string,
@@ -95,9 +99,28 @@ export type AuthorityAudit = (event: {
   metadata: Record<string, unknown>;
 }) => Promise<void>;
 
-type MutationContext = ProviderAuthorityMutationContext & { audit: AuthorityAudit };
+type MutationContext = ProviderAuthorityMutationContext & {
+  audit: AuthorityAudit;
+};
 type BindingInsert = typeof providerRoleBindings.$inferInsert;
 type GrantInsert = typeof providerGrants.$inferInsert;
+
+async function appendAuthorityMutationAudit(
+  ctx: MutationContext,
+  append: AppendRequiredAudit,
+  event: Parameters<AuthorityAudit>[0],
+): Promise<void> {
+  await append({
+    tenantId: ctx.tenantId,
+    actorType: "user",
+    actorId: ctx.actorUserId,
+    action: event.action,
+    resourceType: event.resourceType,
+    resourceId: event.resourceId,
+    metadata: event.metadata,
+    requestId: ctx.requestId ?? null,
+  });
+}
 
 function assertText(value: unknown, field: string, max = 512): string {
   const normalized = typeof value === "string" ? value.trim() : "";
@@ -260,7 +283,9 @@ export class ProviderAuthorityStore {
       return true;
     await this.ensureTenantState(ctx.tenantId);
     const [state] = await this.db()
-      .select({ bootstrapCompleted: providerAuthorityTenantState.bootstrapCompleted })
+      .select({
+        bootstrapCompleted: providerAuthorityTenantState.bootstrapCompleted,
+      })
       .from(providerAuthorityTenantState)
       .where(eq(providerAuthorityTenantState.tenantId, ctx.tenantId))
       .limit(1);
@@ -354,7 +379,10 @@ export class ProviderAuthorityStore {
     if (await this.hasTenantAdmin(ctx)) return true;
     if (!(await this.membership(tenantId, userId))) return false;
     const [workspace] = await this.db()
-      .select({ environment: workspaces.environment, status: workspaces.status })
+      .select({
+        environment: workspaces.environment,
+        status: workspaces.status,
+      })
       .from(workspaces)
       .where(and(eq(workspaces.tenantId, tenantId), eq(workspaces.id, workspaceId)))
       .limit(1);
@@ -453,7 +481,11 @@ export class ProviderAuthorityStore {
     });
     const [updated] = await this.db()
       .update(workspaces)
-      .set({ status: "disabled", revision: row.revision + 1, updatedAt: new Date() })
+      .set({
+        status: "disabled",
+        revision: row.revision + 1,
+        updatedAt: new Date(),
+      })
       .where(
         and(
           eq(workspaces.id, id),
@@ -606,7 +638,11 @@ export class ProviderAuthorityStore {
     });
     const [updated] = await this.db()
       .update(providerAccounts)
-      .set({ status: "disabled", revision: row.revision + 1, updatedAt: new Date() })
+      .set({
+        status: "disabled",
+        revision: row.revision + 1,
+        updatedAt: new Date(),
+      })
       .where(
         and(
           eq(providerAccounts.id, id),
@@ -915,7 +951,9 @@ export class ProviderAuthorityStore {
             authorityMode: "governed_v2",
             providerOperationId: row.id,
             ...(genericDescriptor
-              ? { pathPattern: genericDescriptorGovernedRoutePattern(genericDescriptor) }
+              ? {
+                  pathPattern: genericDescriptorGovernedRoutePattern(genericDescriptor),
+                }
               : {}),
           })
           .where(
@@ -1051,7 +1089,11 @@ export class ProviderAuthorityStore {
       return this.db().transaction(async (tx) => {
         const [cas] = await tx
           .update(providerAuthorityTenantState)
-          .set({ revision: revision + 1, bootstrapCompleted: true, updatedAt: new Date() })
+          .set({
+            revision: revision + 1,
+            bootstrapCompleted: true,
+            updatedAt: new Date(),
+          })
           .where(
             and(
               eq(providerAuthorityTenantState.tenantId, ctx.tenantId),
@@ -1118,7 +1160,10 @@ export class ProviderAuthorityStore {
     }
     if (requestedOperationKeys.length > 0) {
       const scopedOperations = await this.db()
-        .select({ key: providerOperations.operationKey, riskClass: providerOperations.riskClass })
+        .select({
+          key: providerOperations.operationKey,
+          riskClass: providerOperations.riskClass,
+        })
         .from(providerOperations)
         .where(
           and(
@@ -1255,7 +1300,11 @@ export class ProviderAuthorityStore {
     });
     const [updated] = await this.db()
       .update(providerRoleBindings)
-      .set({ status: "revoked", revision: binding.revision + 1, updatedAt: new Date() })
+      .set({
+        status: "revoked",
+        revision: binding.revision + 1,
+        updatedAt: new Date(),
+      })
       .where(
         and(
           eq(providerRoleBindings.id, id),
@@ -1473,32 +1522,35 @@ export class ProviderAuthorityStore {
     }
     const normalized = normalizeBudgetInput(input);
     const id = randomUUID();
-    await ctx.audit({
-      action: "provider.agent_budget.create",
-      resourceType: "provider_agent_budget",
-      resourceId: id,
-      metadata: {
-        agentId: input.agentId,
-        workspaceId,
-        dimension: normalized.dimension,
-        windowSeconds: normalized.windowSeconds,
-        max: normalized.max,
-        currency: normalized.currency,
-        autoFreeze: normalized.autoFreeze,
-        reason: ctx.reason,
-      },
+    return withTenantAuditedTransaction(ctx.tenantId, async (txRaw, append) => {
+      const tx = txRaw as DbExecutor;
+      const [row] = await tx
+        .insert(providerAgentBudgets)
+        .values({
+          id,
+          tenantId: ctx.tenantId,
+          workspaceId,
+          agentId: input.agentId,
+          ...normalized,
+        })
+        .returning();
+      await appendAuthorityMutationAudit(ctx, append, {
+        action: "provider.agent_budget.create",
+        resourceType: "provider_agent_budget",
+        resourceId: id,
+        metadata: {
+          agentId: input.agentId,
+          workspaceId,
+          dimension: normalized.dimension,
+          windowSeconds: normalized.windowSeconds,
+          max: normalized.max,
+          currency: normalized.currency,
+          autoFreeze: normalized.autoFreeze,
+          reason: ctx.reason,
+        },
+      });
+      return row;
     });
-    const [row] = await this.db()
-      .insert(providerAgentBudgets)
-      .values({
-        id,
-        tenantId: ctx.tenantId,
-        workspaceId,
-        agentId: input.agentId,
-        ...normalized,
-      })
-      .returning();
-    return row;
   }
 
   async updateAgentBudget(
@@ -1528,38 +1580,41 @@ export class ProviderAuthorityStore {
       throw new ProviderAuthorityError("budget revision conflict", "revision_conflict", 409);
     }
     const normalized = normalizeBudgetInput(input);
-    await ctx.audit({
-      action: "provider.agent_budget.update",
-      resourceType: "provider_agent_budget",
-      resourceId: id,
-      metadata: {
-        agentId: current.agentId,
-        workspaceId: current.workspaceId,
-        expectedRevision: current.revision,
-        dimension: normalized.dimension,
-        windowSeconds: normalized.windowSeconds,
-        max: normalized.max,
-        currency: normalized.currency,
-        autoFreeze: normalized.autoFreeze,
-        enabled: normalized.enabled,
-        reason: ctx.reason,
-      },
+    return withTenantAuditedTransaction(ctx.tenantId, async (txRaw, append) => {
+      const tx = txRaw as DbExecutor;
+      const [updated] = await tx
+        .update(providerAgentBudgets)
+        .set(normalized)
+        .where(
+          and(
+            eq(providerAgentBudgets.tenantId, ctx.tenantId),
+            eq(providerAgentBudgets.id, id),
+            eq(providerAgentBudgets.revision, current.revision),
+          ),
+        )
+        .returning();
+      if (!updated) {
+        throw new ProviderAuthorityError("budget revision conflict", "revision_conflict", 409);
+      }
+      await appendAuthorityMutationAudit(ctx, append, {
+        action: "provider.agent_budget.update",
+        resourceType: "provider_agent_budget",
+        resourceId: id,
+        metadata: {
+          agentId: current.agentId,
+          workspaceId: current.workspaceId,
+          expectedRevision: current.revision,
+          dimension: normalized.dimension,
+          windowSeconds: normalized.windowSeconds,
+          max: normalized.max,
+          currency: normalized.currency,
+          autoFreeze: normalized.autoFreeze,
+          enabled: normalized.enabled,
+          reason: ctx.reason,
+        },
+      });
+      return updated;
     });
-    const [updated] = await this.db()
-      .update(providerAgentBudgets)
-      .set(normalized)
-      .where(
-        and(
-          eq(providerAgentBudgets.tenantId, ctx.tenantId),
-          eq(providerAgentBudgets.id, id),
-          eq(providerAgentBudgets.revision, current.revision),
-        ),
-      )
-      .returning();
-    if (!updated) {
-      throw new ProviderAuthorityError("budget revision conflict", "revision_conflict", 409);
-    }
-    return updated;
   }
 
   async revokeGrant(ctx: MutationContext, id: string) {

--- a/packages/api/src/services/provider-authority-store.ts
+++ b/packages/api/src/services/provider-authority-store.ts
@@ -1524,6 +1524,15 @@ export class ProviderAuthorityStore {
     const id = randomUUID();
     return withTenantAuditedTransaction(ctx.tenantId, async (txRaw, append) => {
       const tx = txRaw as DbExecutor;
+      const [lockedAgent] = await tx
+        .select({ id: agents.id })
+        .from(agents)
+        .where(and(eq(agents.tenantId, ctx.tenantId), eq(agents.id, input.agentId)))
+        .limit(1)
+        .for("update");
+      if (!lockedAgent) {
+        throw new ProviderAuthorityError("resource not found", "not_found", 404);
+      }
       const [row] = await tx
         .insert(providerAgentBudgets)
         .values({
@@ -1582,6 +1591,15 @@ export class ProviderAuthorityStore {
     const normalized = normalizeBudgetInput(input);
     return withTenantAuditedTransaction(ctx.tenantId, async (txRaw, append) => {
       const tx = txRaw as DbExecutor;
+      const [lockedAgent] = await tx
+        .select({ id: agents.id })
+        .from(agents)
+        .where(and(eq(agents.tenantId, ctx.tenantId), eq(agents.id, current.agentId)))
+        .limit(1)
+        .for("update");
+      if (!lockedAgent) {
+        throw new ProviderAuthorityError("resource not found", "not_found", 404);
+      }
       const [updated] = await tx
         .update(providerAgentBudgets)
         .set(normalized)

--- a/packages/api/src/services/provider-authority-store.ts
+++ b/packages/api/src/services/provider-authority-store.ts
@@ -3,6 +3,7 @@ import {
   agents,
   getDb,
   providerAccounts,
+  providerAgentBudgets,
   providerAuthorityTenantState,
   providerGrants,
   providerOperations,
@@ -68,6 +69,8 @@ const ROLES = new Set([
   "workspace_approver",
 ]);
 const RISK_CLASSES = new Set(["read", "write", "consequential"]);
+const BUDGET_DIMENSIONS = new Set(["count", "notional"]);
+const MAX_BUDGET_WINDOW_SECONDS = 30 * 24 * 60 * 60;
 
 export class ProviderAuthorityError extends Error {
   constructor(
@@ -106,6 +109,57 @@ function assertText(value: unknown, field: string, max = 512): string {
     );
   }
   return normalized;
+}
+
+function normalizeBudgetInput(input: {
+  dimension: unknown;
+  windowSeconds: unknown;
+  max: unknown;
+  currency?: unknown;
+  autoFreeze?: unknown;
+  enabled?: unknown;
+}) {
+  if (typeof input.dimension !== "string" || !BUDGET_DIMENSIONS.has(input.dimension)) {
+    throw new ProviderAuthorityError("invalid budget dimension", "bad_request", 400);
+  }
+  if (
+    !Number.isSafeInteger(input.windowSeconds) ||
+    (input.windowSeconds as number) < 1 ||
+    (input.windowSeconds as number) > MAX_BUDGET_WINDOW_SECONDS
+  ) {
+    throw new ProviderAuthorityError("invalid budget windowSeconds", "bad_request", 400);
+  }
+  if (!Number.isSafeInteger(input.max) || (input.max as number) < 0) {
+    throw new ProviderAuthorityError("invalid budget max", "bad_request", 400);
+  }
+  const currency =
+    input.currency === undefined || input.currency === null
+      ? null
+      : assertText(input.currency, "currency", 64);
+  if (
+    (input.dimension === "count" && currency !== null) ||
+    (input.dimension === "notional" && currency === null)
+  ) {
+    throw new ProviderAuthorityError(
+      "count budgets omit currency; notional budgets require currency",
+      "bad_request",
+      400,
+    );
+  }
+  if (input.autoFreeze !== undefined && typeof input.autoFreeze !== "boolean") {
+    throw new ProviderAuthorityError("invalid budget autoFreeze", "bad_request", 400);
+  }
+  if (input.enabled !== undefined && typeof input.enabled !== "boolean") {
+    throw new ProviderAuthorityError("invalid budget enabled", "bad_request", 400);
+  }
+  return {
+    dimension: input.dimension as "count" | "notional",
+    windowSeconds: input.windowSeconds as number,
+    max: input.max as number,
+    currency,
+    autoFreeze: input.autoFreeze ?? false,
+    enabled: input.enabled ?? true,
+  };
 }
 
 function assertMutationContext(ctx: MutationContext): void {
@@ -1351,6 +1405,161 @@ export class ProviderAuthorityStore {
       .where(
         and(eq(providerGrants.tenantId, tenantId), eq(providerGrants.workspaceId, workspaceId)),
       );
+  }
+
+  async listAgentBudgets(tenantId: string, agentId: string, workspaceId?: string) {
+    const [agent] = await this.db()
+      .select({ id: agents.id })
+      .from(agents)
+      .where(and(eq(agents.tenantId, tenantId), eq(agents.id, agentId)))
+      .limit(1);
+    if (!agent) throw new ProviderAuthorityError("resource not found", "not_found", 404);
+    const conditions = [
+      eq(providerAgentBudgets.tenantId, tenantId),
+      eq(providerAgentBudgets.agentId, agentId),
+    ];
+    if (workspaceId) conditions.push(eq(providerAgentBudgets.workspaceId, workspaceId));
+    return this.db()
+      .select()
+      .from(providerAgentBudgets)
+      .where(and(...conditions))
+      .orderBy(providerAgentBudgets.createdAt, providerAgentBudgets.id);
+  }
+
+  async createAgentBudget(
+    ctx: MutationContext,
+    input: {
+      agentId: string;
+      workspaceId?: string | null;
+      dimension: unknown;
+      windowSeconds: unknown;
+      max: unknown;
+      currency?: unknown;
+      autoFreeze?: unknown;
+    },
+  ) {
+    assertMutationContext(ctx);
+    if (ctx.expectedRevision !== 0) {
+      throw new ProviderAuthorityError(
+        "new budget expectedRevision must be 0",
+        "revision_conflict",
+        409,
+      );
+    }
+    const workspaceId = input.workspaceId ?? null;
+    if (workspaceId) await this.requireWorkspaceAdmin(ctx, workspaceId, true);
+    else if (!(await this.hasTenantAdmin(ctx))) {
+      throw new ProviderAuthorityError("tenant authority required", "forbidden", 403);
+    }
+    const [agent] = await this.db()
+      .select({ id: agents.id })
+      .from(agents)
+      .where(and(eq(agents.tenantId, ctx.tenantId), eq(agents.id, input.agentId)))
+      .limit(1);
+    if (!agent) throw new ProviderAuthorityError("resource not found", "not_found", 404);
+    if (workspaceId) {
+      const [workspace] = await this.db()
+        .select({ id: workspaces.id })
+        .from(workspaces)
+        .where(
+          and(
+            eq(workspaces.tenantId, ctx.tenantId),
+            eq(workspaces.id, workspaceId),
+            eq(workspaces.status, "active"),
+          ),
+        )
+        .limit(1);
+      if (!workspace) throw new ProviderAuthorityError("resource not found", "not_found", 404);
+    }
+    const normalized = normalizeBudgetInput(input);
+    const id = randomUUID();
+    await ctx.audit({
+      action: "provider.agent_budget.create",
+      resourceType: "provider_agent_budget",
+      resourceId: id,
+      metadata: {
+        agentId: input.agentId,
+        workspaceId,
+        dimension: normalized.dimension,
+        windowSeconds: normalized.windowSeconds,
+        max: normalized.max,
+        currency: normalized.currency,
+        autoFreeze: normalized.autoFreeze,
+        reason: ctx.reason,
+      },
+    });
+    const [row] = await this.db()
+      .insert(providerAgentBudgets)
+      .values({
+        id,
+        tenantId: ctx.tenantId,
+        workspaceId,
+        agentId: input.agentId,
+        ...normalized,
+      })
+      .returning();
+    return row;
+  }
+
+  async updateAgentBudget(
+    ctx: MutationContext,
+    id: string,
+    input: {
+      dimension: unknown;
+      windowSeconds: unknown;
+      max: unknown;
+      currency?: unknown;
+      autoFreeze?: unknown;
+      enabled?: unknown;
+    },
+  ) {
+    assertMutationContext(ctx);
+    const [current] = await this.db()
+      .select()
+      .from(providerAgentBudgets)
+      .where(and(eq(providerAgentBudgets.tenantId, ctx.tenantId), eq(providerAgentBudgets.id, id)))
+      .limit(1);
+    if (!current) throw new ProviderAuthorityError("resource not found", "not_found", 404);
+    if (current.workspaceId) await this.requireWorkspaceAdmin(ctx, current.workspaceId, true);
+    else if (!(await this.hasTenantAdmin(ctx))) {
+      throw new ProviderAuthorityError("tenant authority required", "forbidden", 403);
+    }
+    if (current.revision !== ctx.expectedRevision) {
+      throw new ProviderAuthorityError("budget revision conflict", "revision_conflict", 409);
+    }
+    const normalized = normalizeBudgetInput(input);
+    await ctx.audit({
+      action: "provider.agent_budget.update",
+      resourceType: "provider_agent_budget",
+      resourceId: id,
+      metadata: {
+        agentId: current.agentId,
+        workspaceId: current.workspaceId,
+        expectedRevision: current.revision,
+        dimension: normalized.dimension,
+        windowSeconds: normalized.windowSeconds,
+        max: normalized.max,
+        currency: normalized.currency,
+        autoFreeze: normalized.autoFreeze,
+        enabled: normalized.enabled,
+        reason: ctx.reason,
+      },
+    });
+    const [updated] = await this.db()
+      .update(providerAgentBudgets)
+      .set(normalized)
+      .where(
+        and(
+          eq(providerAgentBudgets.tenantId, ctx.tenantId),
+          eq(providerAgentBudgets.id, id),
+          eq(providerAgentBudgets.revision, current.revision),
+        ),
+      )
+      .returning();
+    if (!updated) {
+      throw new ProviderAuthorityError("budget revision conflict", "revision_conflict", 409);
+    }
+    return updated;
   }
 
   async revokeGrant(ctx: MutationContext, id: string) {

--- a/packages/db/drizzle/0088_provider_agent_budgets.sql
+++ b/packages/db/drizzle/0088_provider_agent_budgets.sql
@@ -1,0 +1,63 @@
+-- #208: first-class per-agent budgets spanning providers and operations.
+CREATE TABLE "provider_agent_budgets" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "tenant_id" varchar(64) NOT NULL,
+  "workspace_id" uuid,
+  "agent_id" varchar(64) NOT NULL,
+  "dimension" varchar(16) NOT NULL,
+  "window_seconds" integer NOT NULL,
+  "max" bigint NOT NULL,
+  "currency" varchar(64),
+  "auto_freeze" boolean NOT NULL DEFAULT false,
+  "enabled" boolean NOT NULL DEFAULT true,
+  "revision" integer NOT NULL DEFAULT 1,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT "provider_agent_budgets_agent_fk"
+    FOREIGN KEY ("tenant_id","agent_id") REFERENCES "agents"("tenant_id","id") ON DELETE CASCADE,
+  CONSTRAINT "provider_agent_budgets_workspace_fk"
+    FOREIGN KEY ("tenant_id","workspace_id") REFERENCES "workspaces"("tenant_id","id") ON DELETE CASCADE,
+  CONSTRAINT "provider_agent_budgets_shape_chk" CHECK (
+    "dimension" IN ('count','notional') AND
+    "window_seconds" BETWEEN 1 AND 2592000 AND
+    "max" BETWEEN 0 AND 9007199254740991 AND
+    "revision" > 0 AND
+    (("dimension" = 'count' AND "currency" IS NULL) OR
+     ("dimension" = 'notional' AND "currency" IS NOT NULL AND length("currency") BETWEEN 1 AND 64))
+  )
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "provider_agent_budgets_identity_idx"
+  ON "provider_agent_budgets" (
+    "tenant_id", COALESCE("workspace_id"::text, ''), "agent_id", "dimension",
+    COALESCE("currency", ''), "window_seconds"
+  );
+--> statement-breakpoint
+CREATE INDEX "provider_agent_budgets_lookup_idx"
+  ON "provider_agent_budgets" ("tenant_id","agent_id","enabled","workspace_id");
+--> statement-breakpoint
+CREATE OR REPLACE FUNCTION steward_bump_provider_agent_budget_revision()
+RETURNS trigger LANGUAGE plpgsql AS $fn$
+BEGIN
+  IF OLD.tenant_id IS DISTINCT FROM NEW.tenant_id OR
+     OLD.workspace_id IS DISTINCT FROM NEW.workspace_id OR
+     OLD.agent_id IS DISTINCT FROM NEW.agent_id OR
+     OLD.dimension IS DISTINCT FROM NEW.dimension OR
+     OLD.window_seconds IS DISTINCT FROM NEW.window_seconds OR
+     OLD.max IS DISTINCT FROM NEW.max OR
+     OLD.currency IS DISTINCT FROM NEW.currency OR
+     OLD.auto_freeze IS DISTINCT FROM NEW.auto_freeze OR
+     OLD.enabled IS DISTINCT FROM NEW.enabled THEN
+    NEW.revision := OLD.revision + 1;
+    NEW.updated_at := now();
+  ELSIF NEW.revision IS DISTINCT FROM OLD.revision THEN
+    RAISE EXCEPTION 'provider budget revision changed without configuration mutation'
+      USING ERRCODE = '23514';
+  END IF;
+  RETURN NEW;
+END $fn$;
+--> statement-breakpoint
+CREATE TRIGGER "provider_agent_budgets_bump_revision"
+BEFORE UPDATE ON "provider_agent_budgets"
+FOR EACH ROW EXECUTE FUNCTION steward_bump_provider_agent_budget_revision();
+--> statement-breakpoint

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -477,6 +477,13 @@
       "when": 1784659200000,
       "tag": "0087_external_custody_execution_binding",
       "breakpoints": true
+    },
+    {
+      "idx": 88,
+      "version": "7",
+      "when": 1784745600000,
+      "tag": "0088_provider_agent_budgets",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/__tests__/provider-agent-budgets-migration.test.ts
+++ b/packages/db/src/__tests__/provider-agent-budgets-migration.test.ts
@@ -1,0 +1,92 @@
+import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { PGlite } from "@electric-sql/pglite";
+import { createPGLiteDb } from "../pglite";
+
+setDefaultTimeout(120_000);
+
+let client: PGlite;
+
+const IDS = {
+  owner: "00000000-0000-4000-8000-000000000001",
+  workspaceA: "00000000-0000-4000-8000-000000000101",
+  workspaceB: "00000000-0000-4000-8000-000000000102",
+  countBudget: "00000000-0000-4000-8000-000000000201",
+} as const;
+
+describe("provider agent budgets migration (0088)", () => {
+  beforeAll(async () => {
+    ({ client } = await createPGLiteDb("memory://"));
+    await client.exec(`
+      INSERT INTO tenants(id,name,api_key_hash) VALUES ('ta','A','ha'),('tb','B','hb');
+      INSERT INTO users(id,email,created_at,updated_at) VALUES
+        ('${IDS.owner}','owner@example.test',now(),now());
+      INSERT INTO agents(id,tenant_id,name,wallet_address) VALUES
+        ('agent-a','ta','A','0xa'),('agent-b','tb','B','0xb');
+      INSERT INTO workspaces(id,tenant_id,key,name,environment,created_by) VALUES
+        ('${IDS.workspaceA}','ta','a','A','production','${IDS.owner}'),
+        ('${IDS.workspaceB}','tb','b','B','production','${IDS.owner}');
+    `);
+  });
+
+  afterAll(async () => {
+    await client.close();
+  });
+
+  test("creates count and notional budget objects with bounded windows", async () => {
+    await client.exec(`
+      INSERT INTO provider_agent_budgets
+        (id,tenant_id,agent_id,dimension,window_seconds,max,auto_freeze)
+      VALUES ('${IDS.countBudget}','ta','agent-a','count',86400,500,true);
+      INSERT INTO provider_agent_budgets
+        (tenant_id,workspace_id,agent_id,dimension,window_seconds,max,currency)
+      VALUES ('ta','${IDS.workspaceA}','agent-a','notional',604800,10000,'USD');
+    `);
+    const rows = await client.query<{ dimension: string; currency: string | null }>(
+      `SELECT dimension,currency FROM provider_agent_budgets ORDER BY dimension`,
+    );
+    expect(rows.rows).toEqual([
+      { dimension: "count", currency: null },
+      { dimension: "notional", currency: "USD" },
+    ]);
+    await expect(
+      client.exec(
+        `INSERT INTO provider_agent_budgets (tenant_id,agent_id,dimension,window_seconds,max,currency) VALUES ('ta','agent-a','count',0,1,NULL)`,
+      ),
+    ).rejects.toThrow();
+    await expect(
+      client.exec(
+        `INSERT INTO provider_agent_budgets (tenant_id,agent_id,dimension,window_seconds,max,currency) VALUES ('ta','agent-a','notional',60,1,NULL)`,
+      ),
+    ).rejects.toThrow();
+  });
+
+  test("enforces tenant ownership and one budget per scope/dimension/window", async () => {
+    await expect(
+      client.exec(
+        `INSERT INTO provider_agent_budgets (tenant_id,workspace_id,agent_id,dimension,window_seconds,max) VALUES ('ta','${IDS.workspaceB}','agent-a','count',60,1)`,
+      ),
+    ).rejects.toThrow();
+    await expect(
+      client.exec(
+        `INSERT INTO provider_agent_budgets (tenant_id,agent_id,dimension,window_seconds,max) VALUES ('ta','agent-b','count',60,1)`,
+      ),
+    ).rejects.toThrow();
+    await expect(
+      client.exec(
+        `INSERT INTO provider_agent_budgets (tenant_id,agent_id,dimension,window_seconds,max) VALUES ('ta','agent-a','count',86400,999)`,
+      ),
+    ).rejects.toThrow();
+  });
+
+  test("configuration changes atomically bump revision and reject naked revisions", async () => {
+    await client.exec(`UPDATE provider_agent_budgets SET max=501 WHERE id='${IDS.countBudget}'`);
+    const changed = await client.query<{ max: bigint; revision: number }>(
+      `SELECT max,revision FROM provider_agent_budgets WHERE id='${IDS.countBudget}'`,
+    );
+    expect(Number(changed.rows[0]?.max)).toBe(501);
+    expect(changed.rows[0]?.revision).toBe(2);
+    await expect(
+      client.exec(`UPDATE provider_agent_budgets SET revision=99 WHERE id='${IDS.countBudget}'`),
+    ).rejects.toThrow(/revision changed/);
+  });
+});

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -2266,6 +2266,48 @@ export const providerActionBindings = pgTable(
 
 export type ProviderActionBinding = typeof providerActionBindings.$inferSelect;
 
+/** First-class aggregate limits spanning every provider operation for an agent.
+ * Enforcement is an atomic Redis reservation; this row is the durable,
+ * revisioned operator configuration bound into each provider policy decision. */
+export const providerAgentBudgets = pgTable(
+  "provider_agent_budgets",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    tenantId: varchar("tenant_id", { length: 64 }).notNull(),
+    workspaceId: uuid("workspace_id"),
+    agentId: varchar("agent_id", { length: 64 }).notNull(),
+    dimension: varchar("dimension", { length: 16 }).notNull(),
+    windowSeconds: integer("window_seconds").notNull(),
+    max: bigint("max", { mode: "number" }).notNull(),
+    currency: varchar("currency", { length: 64 }),
+    autoFreeze: boolean("auto_freeze").notNull().default(false),
+    enabled: boolean("enabled").notNull().default(true),
+    revision: integer("revision").notNull().default(1),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    agentFk: foreignKey({
+      columns: [table.tenantId, table.agentId],
+      foreignColumns: [agents.tenantId, agents.id],
+      name: "provider_agent_budgets_agent_fk",
+    }).onDelete("cascade"),
+    workspaceFk: foreignKey({
+      columns: [table.tenantId, table.workspaceId],
+      foreignColumns: [workspaces.tenantId, workspaces.id],
+      name: "provider_agent_budgets_workspace_fk",
+    }).onDelete("cascade"),
+    lookupIdx: index("provider_agent_budgets_lookup_idx").on(
+      table.tenantId,
+      table.agentId,
+      table.enabled,
+      table.workspaceId,
+    ),
+  }),
+);
+
+export type ProviderAgentBudget = typeof providerAgentBudgets.$inferSelect;
+
 /** Append-only reservation identities. Mutable reconciliation metadata is
  * isolated from the immutable generation payload and claimed with SKIP LOCKED. */
 export const providerActionReservationGenerations = pgTable(

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -2297,6 +2297,14 @@ export const providerAgentBudgets = pgTable(
       foreignColumns: [workspaces.tenantId, workspaces.id],
       name: "provider_agent_budgets_workspace_fk",
     }).onDelete("cascade"),
+    identityIdx: uniqueIndex("provider_agent_budgets_identity_idx").on(
+      table.tenantId,
+      sql`COALESCE(${table.workspaceId}::text, '')`,
+      table.agentId,
+      table.dimension,
+      sql`COALESCE(${table.currency}, '')`,
+      table.windowSeconds,
+    ),
     lookupIdx: index("provider_agent_budgets_lookup_idx").on(
       table.tenantId,
       table.agentId,

--- a/packages/redis/src/__tests__/cumulative-spend-tracker.test.ts
+++ b/packages/redis/src/__tests__/cumulative-spend-tracker.test.ts
@@ -113,6 +113,13 @@ describeRedis("reserveCumulativeSpendBatch - cross-stream atomicity", () => {
     currency: "__agent_budget_count__",
   };
 
+  test("every agent-budget stream shares the agent Redis Cluster hash slot", () => {
+    const globalKey = cumulativeSpendStreamKeyForTest(global);
+    const workspaceKey = cumulativeSpendStreamKeyForTest(workspace);
+    expect(globalKey).toContain(`{${encodeURIComponent(AGENT)}}`);
+    expect(workspaceKey).toContain(`{${encodeURIComponent(AGENT)}}`);
+  });
+
   test("a breach on one stream appends no member to any stream", async () => {
     await reserveCumulativeSpend({
       stream: workspace,

--- a/packages/redis/src/__tests__/cumulative-spend-tracker.test.ts
+++ b/packages/redis/src/__tests__/cumulative-spend-tracker.test.ts
@@ -26,6 +26,7 @@ import {
   releaseCumulativeSpend,
   releaseWindowedInvoke,
   reserveCumulativeSpend,
+  reserveCumulativeSpendBatch,
   reserveWindowedInvoke,
   settleCumulativeSpend,
 } from "../cumulative-spend-tracker.js";
@@ -40,7 +41,7 @@ async function cleanup() {
   const redis = getRedis();
   let cursor = "0";
   do {
-    const [next, keys] = await redis.scan(cursor, "MATCH", `cumspend:${AGENT}*`, "COUNT", 100);
+    const [next, keys] = await redis.scan(cursor, "MATCH", `cumspend:*${AGENT}*`, "COUNT", 100);
     cursor = next;
     if (keys.length > 0) await redis.del(...keys);
   } while (cursor !== "0");
@@ -95,6 +96,70 @@ describeRedis("reserveCumulativeSpend - REAL concurrency single-winner", () => {
     expect(results.filter((r) => r.ok).length).toBe(10);
     const snap = await getCumulativeSpendSum({ ...STREAM, windowSeconds: 3600 });
     expect(snap?.sum).toBe(1_000_000);
+  });
+});
+
+describeRedis("reserveCumulativeSpendBatch - cross-stream atomicity", () => {
+  const global = {
+    agentId: AGENT,
+    scope: "agent" as const,
+    scopeKey: "budget:global:count",
+    currency: "__agent_budget_count__",
+  };
+  const workspace = {
+    agentId: AGENT,
+    scope: "agent" as const,
+    scopeKey: "budget:workspace:w1:count",
+    currency: "__agent_budget_count__",
+  };
+
+  test("a breach on one stream appends no member to any stream", async () => {
+    await reserveCumulativeSpend({
+      stream: workspace,
+      caps: [{ windowSeconds: 3600, max: 1 }],
+      amount: 1,
+    });
+    const denied = await reserveCumulativeSpendBatch([
+      {
+        stream: global,
+        caps: [{ windowSeconds: 3600, max: 10 }],
+        amount: 1,
+        reservationId: "batch-global-denied",
+      },
+      {
+        stream: workspace,
+        caps: [{ windowSeconds: 3600, max: 1 }],
+        amount: 1,
+        reservationId: "batch-workspace-denied",
+      },
+    ]);
+    expect(denied.ok).toBe(false);
+    expect(await getCumulativeSpendSum({ ...global, windowSeconds: 3600 })).toEqual({ sum: 0 });
+    expect(await getCumulativeSpendSum({ ...workspace, windowSeconds: 3600 })).toEqual({ sum: 1 });
+  });
+
+  test("parallel batches admit the same exact winners on every stream", async () => {
+    const outcomes = await Promise.all(
+      Array.from({ length: 10 }, (_, index) =>
+        reserveCumulativeSpendBatch([
+          {
+            stream: global,
+            caps: [{ windowSeconds: 3600, max: 3 }],
+            amount: 1,
+            reservationId: `batch-global-${index}`,
+          },
+          {
+            stream: workspace,
+            caps: [{ windowSeconds: 3600, max: 3 }],
+            amount: 1,
+            reservationId: `batch-workspace-${index}`,
+          },
+        ]),
+      ),
+    );
+    expect(outcomes.filter((outcome) => outcome.ok)).toHaveLength(3);
+    expect(await getCumulativeSpendSum({ ...global, windowSeconds: 3600 })).toEqual({ sum: 3 });
+    expect(await getCumulativeSpendSum({ ...workspace, windowSeconds: 3600 })).toEqual({ sum: 3 });
   });
 });
 

--- a/packages/redis/src/cumulative-spend-tracker.ts
+++ b/packages/redis/src/cumulative-spend-tracker.ts
@@ -118,6 +118,18 @@ export interface ReserveCumulativeSpendResult {
   reservationId?: string;
 }
 
+/** One independently-keyed stream participating in an all-or-nothing reserve. */
+export interface CumulativeSpendBatchEntry extends ReserveCumulativeSpendInput {}
+
+export interface ReserveCumulativeSpendBatchResult {
+  /** true only when every cap on every stream admits the reservation. */
+  ok: boolean;
+  /** Per-entry prior sums, in the same entry/cap order supplied by the caller. */
+  priorSums: number[][];
+  /** Stable reservation ids, present only when the whole batch is admitted. */
+  reservationIds?: string[];
+}
+
 /** Read-only trailing-window sum snapshot (advisory; enforcement is reserve). */
 export interface CumulativeSpendSnapshot {
   /** committed+reserved sum over the trailing window, integer minor units. */
@@ -129,6 +141,12 @@ function streamKey(s: CumulativeSpendStream): string {
   // delimiter-safe. Deliberately NO window/max in the key (codex P1): the stream
   // identity is the spend history, not the current cap threshold.
   const enc = (v: string) => encodeURIComponent(v);
+  // First-class agent budgets reserve several scope/dimension streams in one
+  // Lua call. Keep those keys in one Redis Cluster hash slot while preserving
+  // the established key shape (and history) for every pre-existing stream.
+  if (s.scope === "agent" && s.scopeKey.startsWith("budget:")) {
+    return `cumspend:{${enc(s.agentId)}}:${s.scope}:${enc(s.scopeKey)}:${enc(s.currency)}`;
+  }
   return `cumspend:${enc(s.agentId)}:${s.scope}:${enc(s.scopeKey)}:${enc(s.currency)}`;
 }
 
@@ -188,6 +206,73 @@ elseif out[1] == 0 and existingScore then
   -- A current-policy retry no longer admits this previously orphaned member.
   -- Remove it atomically with the denial so it cannot pin phantom budget.
   redis.call('ZREM', KEYS[1], member)
+end
+return out
+`;
+
+// ATOMIC all-or-nothing reserve over several independently-keyed streams.
+// Every stream is inspected before any member is added, so a rejection never
+// needs compensating writes and concurrent callers cannot observe a partial
+// multi-dimensional budget reservation.
+//
+// KEYS = one key per entry
+// ARGV[1]=now ARGV[2]=retentionCutoff ARGV[3]=ttlMs ARGV[4]=nEntries
+// then, for each entry: amount, member, nCaps, nCaps*(windowStart,max)
+const RESERVE_BATCH_LUA = `
+local now = tonumber(ARGV[1])
+local retentionCutoff = tonumber(ARGV[2])
+local ttl = tonumber(ARGV[3])
+local nEntries = tonumber(ARGV[4])
+local cursor = 5
+local admitted = 1
+local out = {1}
+local members = {}
+
+for e = 1, nEntries do
+  local amount = tonumber(ARGV[cursor])
+  local member = ARGV[cursor + 1]
+  local nCaps = tonumber(ARGV[cursor + 2])
+  cursor = cursor + 3
+  members[e] = member
+  redis.call('ZREMRANGEBYSCORE', KEYS[e], 0, retentionCutoff)
+  for c = 1, nCaps do
+    local windowStart = tonumber(ARGV[cursor])
+    local maxv = tonumber(ARGV[cursor + 1])
+    cursor = cursor + 2
+    local live = redis.call('ZRANGEBYSCORE', KEYS[e], '(' .. windowStart, now)
+    local sum = 0
+    for i = 1, #live do
+      local m = live[i]
+      if m ~= member then
+        local firstBar = string.find(m, '|', 1, true)
+        if not firstBar then return {-1} end
+        local rest = string.sub(m, firstBar + 1)
+        local secondBar = string.find(rest, '|', 1, true)
+        local amtStr = secondBar and string.sub(rest, 1, secondBar - 1) or rest
+        local amt = tonumber(amtStr)
+        if amt == nil then return {-1} end
+        sum = sum + amt
+      end
+    end
+    out[#out + 1] = sum
+    if (sum + amount) > maxv then admitted = 0 end
+  end
+end
+
+out[1] = admitted
+cursor = 5
+for e = 1, nEntries do
+  local amount = tonumber(ARGV[cursor])
+  local member = ARGV[cursor + 1]
+  local nCaps = tonumber(ARGV[cursor + 2])
+  cursor = cursor + 3 + nCaps * 2
+  local existing = redis.call('ZSCORE', KEYS[e], member)
+  if admitted == 1 and not existing then
+    redis.call('ZADD', KEYS[e], now, member)
+    redis.call('PEXPIRE', KEYS[e], ttl)
+  elseif admitted == 0 and existing then
+    redis.call('ZREM', KEYS[e], member)
+  end
 end
 return out
 `;
@@ -309,6 +394,84 @@ export async function reserveCumulativeSpend(
   if (res[0] === 1) {
     return { ok: true, priorSums, reservationId };
   }
+  return { ok: false, priorSums };
+}
+
+/**
+ * Atomically reserve several distinct cumulative-spend streams. Redis executes
+ * the Lua script as one operation: either every entry is appended or none is.
+ * This is intended for one logical policy gate spanning several scopes or
+ * dimensions. Callers must supply keys in one Redis Cluster hash slot (agent
+ * budget keys do so automatically); duplicate stream keys are rejected because
+ * caps for one stream belong in one entry.
+ */
+export async function reserveCumulativeSpendBatch(
+  entries: CumulativeSpendBatchEntry[],
+): Promise<ReserveCumulativeSpendBatchResult> {
+  if (!Array.isArray(entries) || entries.length === 0) {
+    throw new Error("cumulative spend batch requires at least one entry");
+  }
+  const now = entries[0]?.now ?? Date.now();
+  const keys: string[] = [];
+  const args: string[] = [
+    String(now),
+    String(now - RETENTION_MS),
+    String(RETENTION_MS),
+    String(entries.length),
+  ];
+  const reservationIds: string[] = [];
+  const seenKeys = new Set<string>();
+  for (const entry of entries) {
+    if (entry.now !== undefined && entry.now !== now) {
+      throw new Error("cumulative spend batch entries must share one evaluation time");
+    }
+    if (!isNonNegInt(entry.amount)) {
+      throw new Error(`invalid cumulative spend amount: ${entry.amount}`);
+    }
+    if (!Array.isArray(entry.caps) || entry.caps.length === 0) {
+      throw new Error("cumulative spend reserve requires at least one cap");
+    }
+    for (const cap of entry.caps) {
+      if (!isNonNegInt(cap.max)) throw new Error(`invalid cumulative spend max: ${cap.max}`);
+      if (!isValidWindow(cap.windowSeconds)) {
+        throw new Error(`invalid cumulative spend window: ${cap.windowSeconds}`);
+      }
+    }
+    if (typeof entry.stream.agentId !== "string" || entry.stream.agentId.length === 0) {
+      throw new Error("cumulative spend reserve requires agentId");
+    }
+    if (typeof entry.stream.currency !== "string" || entry.stream.currency.length === 0) {
+      throw new Error("cumulative spend reserve requires currency");
+    }
+    const key = streamKey(entry.stream);
+    if (seenKeys.has(key)) throw new Error("cumulative spend batch contains a duplicate stream");
+    seenKeys.add(key);
+    keys.push(key);
+    const reservationId = entry.reservationId ?? `${now}:${nextSeq()}`;
+    if (reservationId.length === 0 || reservationId.length > 200 || reservationId.includes("|")) {
+      throw new Error("invalid cumulative spend reservationId");
+    }
+    reservationIds.push(reservationId);
+    args.push(
+      String(entry.amount),
+      `${reservationId}|${entry.amount}|reserved`,
+      String(entry.caps.length),
+    );
+    for (const cap of entry.caps) {
+      args.push(String(now - cap.windowSeconds * 1000), String(cap.max));
+    }
+  }
+
+  const redis = getRedis();
+  const raw = (await redis.eval(RESERVE_BATCH_LUA, keys.length, ...keys, ...args)) as number[];
+  if (raw[0] === -1) throw new Error("cumulative spend stream contained a corrupt member");
+  let offset = 1;
+  const priorSums = entries.map((entry) => {
+    const sums = raw.slice(offset, offset + entry.caps.length);
+    offset += entry.caps.length;
+    return sums;
+  });
+  if (raw[0] === 1) return { ok: true, priorSums, reservationIds };
   return { ok: false, priorSums };
 }
 

--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -21,6 +21,7 @@ export {
   isKnownHost,
 } from "./cost-estimator.js";
 export {
+  type CumulativeSpendBatchEntry,
   type CumulativeSpendCap,
   type CumulativeSpendScope,
   type CumulativeSpendSnapshot,
@@ -32,6 +33,7 @@ export {
   releaseCumulativeSpend,
   releaseWindowedInvoke,
   reserveCumulativeSpend,
+  reserveCumulativeSpendBatch,
   reserveWindowedInvoke,
   settleCumulativeSpend,
 } from "./cumulative-spend-tracker.js";


### PR DESCRIPTION
Closes #208.

## What changed

- adds migration `0088_provider_agent_budgets` after the contiguous 0084–0087 stack
- adds tenant-global and workspace-scoped per-agent budget objects for count and currency-denominated notional dimensions, with bounded configurable rolling windows
- adds audited, admin/MFA/revision-gated control-plane list/create/update-disable operations
- evaluates and atomically reserves every applicable budget in Redis at governed execution time using provider/operation-independent agent streams
- binds budget revisions/results into the persisted policy decision and #240 crash-durable reservation generation
- re-evaluates and re-debits budgets immediately before approved execution is consumed
- fails closed on budget store unavailability, denies exhausted budgets with `PROVIDER_AGENT_BUDGET_EXHAUSTED`, and emits durable `provider.budget.exhausted` audit evidence
- optionally creates the existing active agent signing freeze in the same database transaction as the denied decision
- locks budget snapshots against concurrent configuration mutation while an execution decision is in flight

## Validation

Exact head: `7a4d0200c3673a1701111905fabf0d62e3315e34`
Exact base: `abf551729dbb80cf868226a95714565cc8fe8bba`

- `bunx turbo run build --filter=@stwd/api` — 21/21 build tasks green
- focused PGLite/API integration matrix — 83/83 tests, 331 assertions green
  - 0088 schema/constraint/revision migration tests
  - provider authority control-plane tests
  - provider action and approval concurrency/lifecycle/negative suites
  - generic HTTP governed E2E suite
- Biome on every touched TS file — green
- `git diff --check` — green
- real Redis tests are enabled in PR CI by `STEWARD_REDIS_TESTS=1`; the added cases prove an exact 3/7 admission split under a ten-way race, notional rejection rollback, durable exhaustion audit + one active freeze, and approval-time budget consumption followed by execute-time denial. The exact split is mutation proof: bypassing the budget gate admits all ten.

## Stack

This is intentionally based on #214 so the journal remains contiguous:
#296 / 0084 → #299 / 0085 → #301 / 0086 → #214 / 0087 → this PR / 0088.
