### PR TITLE
fix(audit): strictly verify and persist RFC3161 proofs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,6 +79,14 @@ AGENT_TOKEN_EXPIRY=24h
 # different trust boundary than the database it audits.
 # Generate with: openssl rand -hex 32
 STEWARD_AUDIT_HMAC_KEY=
+# Optional RFC 3161 anchoring for Ed25519 audit checkpoints. Default `off`
+# performs no network request and does not add fields to evidence bundles.
+# `best-effort` emits an unanchored bundle if the TSA is unavailable;
+# `required` fails evidence generation closed instead.
+# STEWARD_AUDIT_CHECKPOINT_ANCHOR_MODE=off
+# STEWARD_AUDIT_CHECKPOINT_ANCHOR_PROVIDER=rfc3161
+# STEWARD_AUDIT_RFC3161_URL=https://tsa.example.com/timestamp
+# STEWARD_AUDIT_RFC3161_TIMEOUT_MS=10000
 
 # [REQUIRED when creating or verifying retention archives] Stable identity for
 # the active Ed25519 archive signing key. The active private key's public half

--- a/.env.example
+++ b/.env.example
@@ -86,6 +86,16 @@ STEWARD_AUDIT_HMAC_KEY=
 # STEWARD_AUDIT_CHECKPOINT_ANCHOR_MODE=off
 # STEWARD_AUDIT_CHECKPOINT_ANCHOR_PROVIDER=rfc3161
 # STEWARD_AUDIT_RFC3161_URL=https://tsa.example.com/timestamp
+# [REQUIRED when RFC 3161 is enabled] Local PEM trust anchor used to verify the
+# CMS signer/path before Steward accepts or persists a token. Never sourced
+# from the timestamp response.
+# STEWARD_AUDIT_RFC3161_CA_FILE=/etc/steward/tsa-ca.pem
+# STEWARD_AUDIT_RFC3161_UNTRUSTED_FILE=/etc/steward/tsa-intermediates.pem
+# Optional exact signed TSTInfo policy allowlist (single OID).
+# STEWARD_AUDIT_RFC3161_POLICY_OID=1.2.3.4.1
+# Freshness bounds include the TSA's signed accuracy interval.
+# STEWARD_AUDIT_RFC3161_MAX_AGE_SECONDS=300
+# STEWARD_AUDIT_RFC3161_MAX_FUTURE_SKEW_SECONDS=300
 # STEWARD_AUDIT_RFC3161_TIMEOUT_MS=10000
 
 # [REQUIRED when creating or verifying retention archives] Stable identity for

--- a/docs/api-reference/audits.mdx
+++ b/docs/api-reference/audits.mdx
@@ -159,6 +159,19 @@ controls all relevant audit and signing keys could not fabricate a
 self-consistent history. A partial export also does not prove completeness
 outside the exported range.
 
+Deployments can opt into RFC 3161 third-party checkpoint timestamps. Verify an
+included proof with auditor-supplied TSA trust material:
+
+```bash
+node scripts/verify-evidence-bundle.mjs bundle.json \
+  --tsa-ca auditor-trusted-tsa-ca.pem \
+  --require-anchor
+```
+
+The verified timestamp shows that the checkpoint existed no later than the TSA
+time, narrowing the pre-anchor rewrite window. It is not a tamper-proof or
+operator-proof guarantee. See [third-party audit-checkpoint anchoring](/security/audit-checkpoint-anchoring).
+
 ## Common Filters
 
 | Use case | Query |

--- a/docs/concepts/audit-logging.mdx
+++ b/docs/concepts/audit-logging.mdx
@@ -157,6 +157,7 @@ Steward's audit log supports compliance requirements:
 - **Retention**: configurable per tenant
 - **Export**: API endpoints for event export and signed evidence bundles
 - **Trust limit**: an operator controlling all relevant keys can fabricate a self-consistent history
+- **Optional third-party time bound**: RFC 3161 anchoring can prove a checkpoint existed no later than a trusted TSA time, narrowing but not eliminating the pre-anchor rewrite window
 
 ## Related
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -7,7 +7,7 @@ Steward is an open-source, self-hostable governed credential proxy and policy an
 
 Steward runs in your infrastructure. Configured provider calls can receive credentials at the proxy without returning those credentials to the supported agent caller. Governed wallet routes evaluate policy and approval before signing. The primary EVM transaction sign path adds a signed, short-lived, payload-bound, single-use authorization immediately before raw signing.
 
-Steward also maintains a tenant-scoped HMAC audit chain and exports Ed25519-signed evidence bundles. Verify a bundle offline with `scripts/verify-evidence-bundle.mjs <bundle.json>`. The script checks the signature against the public key carried in the bundle. Separately compare that key with an out-of-band trusted Steward signing key or fingerprint. Verification detects changes relative to that trust root. It does not exclude fabrication by an operator controlling all relevant keys.
+Steward also maintains a tenant-scoped HMAC audit chain and exports Ed25519-signed evidence bundles. Verify a bundle offline with `scripts/verify-evidence-bundle.mjs <bundle.json>`. The script checks the signature against the public key carried in the bundle. Separately compare that key with an out-of-band trusted Steward signing key or fingerprint. Optional RFC 3161 anchoring can add an auditor-verifiable third-party time bound. Verification detects changes relative to those trust roots; it does not make the system operator-proof.
 
 <CardGroup cols={2}>
   <Card title="Wallet vault" icon="vault" href="/concepts/wallet-vault">

--- a/docs/security/audit-checkpoint-anchoring.md
+++ b/docs/security/audit-checkpoint-anchoring.md
@@ -20,20 +20,44 @@ and returns the existing v1 bundle shape without an `anchor` field.
 STEWARD_AUDIT_CHECKPOINT_ANCHOR_MODE=best-effort # off | best-effort | required
 STEWARD_AUDIT_CHECKPOINT_ANCHOR_PROVIDER=rfc3161
 STEWARD_AUDIT_RFC3161_URL=https://tsa.example.com/timestamp
+STEWARD_AUDIT_RFC3161_CA_FILE=/etc/steward/tsa-ca.pem
+STEWARD_AUDIT_RFC3161_UNTRUSTED_FILE=/etc/steward/tsa-intermediates.pem # optional
+STEWARD_AUDIT_RFC3161_POLICY_OID=1.2.3.4.1 # optional exact policy
+STEWARD_AUDIT_RFC3161_MAX_AGE_SECONDS=300
+STEWARD_AUDIT_RFC3161_MAX_FUTURE_SKEW_SECONDS=300
 STEWARD_AUDIT_RFC3161_TIMEOUT_MS=10000
 ```
 
 - `best-effort` logs a TSA failure and returns the ordinary signed bundle
   without an anchor proof.
 - `required` returns HTTP 503 and does not emit an evidence bundle when the TSA
-  is missing, rejects the request, times out, or returns a malformed response.
+  is missing, rejects the request, times out, returns a malformed response,
+  fails cryptographic verification, or the verified proof cannot be persisted.
 - production TSA URLs must use HTTPS, may not embed credentials, do not follow
   redirects, and responses are capped at 1 MiB.
 
 The reference sink sends a DER RFC 3161 `TimeStampReq` with a SHA-256
-`MessageImprint` and `certReq=true`. The bundle contains the opaque DER
-`TimeStampResp`, the checkpoint digest, and non-secret algorithm/provider
-metadata. It never contains TSA credentials.
+`MessageImprint`, a new unpredictable 128-bit nonce, and `certReq=true`. Before
+accepting the response, Steward invokes OpenSSL's RFC 3161 verifier against the
+original query and operator-supplied CA. That verifies the CMS `SignedData`,
+signed `TSTInfo`, imprint, nonce, timestamping EKU, signature, and certificate
+path at the signed `genTime` (so a legitimately expired TSA signing certificate
+does not invalidate older evidence). Steward also enforces the signed policy OID
+when configured and checks `genTime` freshness using the TSA's signed accuracy
+interval. The complete uncertainty interval must fit the configured acquisition
+window; an imprecise timestamp cannot pass merely because its interval overlaps
+the window.
+
+The bundle contains the DER `TimeStampResp`, checkpoint digest, nonce, policy,
+time/accuracy, verification time, and acquisition trust-anchor fingerprint. The
+same proof is stored append-only beside the exact signed checkpoint. It never
+contains TSA credentials or a trust root. `best-effort` may still return an
+anchored bundle if later database persistence fails; `required` may not.
+
+Anchoring occurs when an audit bundle or governed evidence case produces a
+checkpoint. Steward does not claim a periodic anchor cadence: operators who
+need hourly/daily bounds must schedule those evidence exports externally and
+monitor for successful persisted proofs.
 
 Self-hosted API compositions can implement `AuditCheckpointAnchorSink` and
 register a named provider with `registerAuditCheckpointAnchorSink` before
@@ -47,13 +71,21 @@ Trust the TSA only through CA material obtained independently from the bundle:
 node scripts/verify-evidence-bundle.mjs bundle.json \
   --expected-key-fingerprint "$STEWARD_EXPECTED_AUDIT_KEY_FP" \
   --tsa-ca auditor-trusted-tsa-ca.pem \
+  --tsa-policy 1.2.3.4.1 \
   --require-anchor
 ```
 
 The verifier reconstructs the exact checkpoint digest, invokes OpenSSL's RFC
-3161 verifier entirely offline, validates the timestamp token's certificate
-chain and message imprint, and reports the TSA time as the "existed no later
-than" bound. An intermediate chain can be supplied with `--tsa-untrusted`.
+3161 verifier entirely offline, validates the CMS/TSTInfo signature, timestamping
+certificate path, message imprint, persisted nonce/policy/time metadata, and
+reports `genTime + accuracy` as the conservative "existed no later than" bound.
+An intermediate chain can be supplied with `--tsa-untrusted`.
+
+Verification is deliberately offline and does not fetch CRLs or OCSP responses.
+For long-term validation, auditors must retain the independently obtained CA and
+intermediate set applicable at `genTime`, plus any time-applicable revocation
+evidence required by their policy. The persisted CA fingerprint and TSA policy
+identify the acquisition trust policy; they are not themselves revocation proof.
 
 To enforce a compliance cutoff:
 

--- a/docs/security/audit-checkpoint-anchoring.md
+++ b/docs/security/audit-checkpoint-anchoring.md
@@ -1,0 +1,69 @@
+# Third-party audit-checkpoint anchoring
+
+Steward can optionally send the SHA-256 digest of each canonical Ed25519 audit
+checkpoint payload to an RFC 3161 timestamp authority (TSA). A verified token
+shows that the checkpoint existed no later than the TSA's signed time. This
+narrows the window in which an operator could rewrite pre-anchor history and
+produce a new checkpoint.
+
+Anchoring is not tamper-proof or operator-proof. It does not prove that the
+export is complete, protect events created after the anchor, prevent TSA and
+operator collusion, or replace the auditor's out-of-band trust in Steward's
+Ed25519 signing-key fingerprint and the TSA certificate authority.
+
+## Configuration
+
+No setting means `off`: Steward constructs no sink, makes no network request,
+and returns the existing v1 bundle shape without an `anchor` field.
+
+```bash
+STEWARD_AUDIT_CHECKPOINT_ANCHOR_MODE=best-effort # off | best-effort | required
+STEWARD_AUDIT_CHECKPOINT_ANCHOR_PROVIDER=rfc3161
+STEWARD_AUDIT_RFC3161_URL=https://tsa.example.com/timestamp
+STEWARD_AUDIT_RFC3161_TIMEOUT_MS=10000
+```
+
+- `best-effort` logs a TSA failure and returns the ordinary signed bundle
+  without an anchor proof.
+- `required` returns HTTP 503 and does not emit an evidence bundle when the TSA
+  is missing, rejects the request, times out, or returns a malformed response.
+- production TSA URLs must use HTTPS, may not embed credentials, do not follow
+  redirects, and responses are capped at 1 MiB.
+
+The reference sink sends a DER RFC 3161 `TimeStampReq` with a SHA-256
+`MessageImprint` and `certReq=true`. The bundle contains the opaque DER
+`TimeStampResp`, the checkpoint digest, and non-secret algorithm/provider
+metadata. It never contains TSA credentials.
+
+Self-hosted API compositions can implement `AuditCheckpointAnchorSink` and
+register a named provider with `registerAuditCheckpointAnchorSink` before
+serving evidence routes. Selecting an unregistered provider fails closed.
+
+## Offline verification
+
+Trust the TSA only through CA material obtained independently from the bundle:
+
+```bash
+node scripts/verify-evidence-bundle.mjs bundle.json \
+  --expected-key-fingerprint "$STEWARD_EXPECTED_AUDIT_KEY_FP" \
+  --tsa-ca auditor-trusted-tsa-ca.pem \
+  --require-anchor
+```
+
+The verifier reconstructs the exact checkpoint digest, invokes OpenSSL's RFC
+3161 verifier entirely offline, validates the timestamp token's certificate
+chain and message imprint, and reports the TSA time as the "existed no later
+than" bound. An intermediate chain can be supplied with `--tsa-untrusted`.
+
+To enforce a compliance cutoff:
+
+```bash
+node scripts/verify-evidence-bundle.mjs bundle.json \
+  --tsa-ca auditor-trusted-tsa-ca.pem \
+  --require-anchor \
+  --anchored-before 2026-12-31T23:59:59Z
+```
+
+Without `--tsa-ca`, an included token is reported as present but untrusted. The
+bundle-carried token and any bundle-carried identity are never treated as their
+own trust root.

--- a/docs/security/audit-checkpoint-anchoring.md
+++ b/docs/security/audit-checkpoint-anchoring.md
@@ -61,7 +61,14 @@ monitor for successful persisted proofs.
 
 Self-hosted API compositions can implement `AuditCheckpointAnchorSink` and
 register a named provider with `registerAuditCheckpointAnchorSink` before
-serving evidence routes. Selecting an unregistered provider fails closed.
+serving evidence routes. A custom registration must include both a sink and a
+proof verifier. Its sink returns a discriminated `type: "custom"` proof with the
+configured provider/sink IDs, exact checkpoint digest, and provider-native JSON
+evidence. Steward validates those bindings and runs the registered verifier
+before persisting or returning the proof; missing or rejected verification fails
+closed in `required` mode. This preserves a custom witness's native proof instead
+of representing it as RFC 3161 evidence. Selecting an unregistered provider fails
+closed.
 
 ## Offline verification
 
@@ -99,3 +106,8 @@ node scripts/verify-evidence-bundle.mjs bundle.json \
 Without `--tsa-ca`, an included token is reported as present but untrusted. The
 bundle-carried token and any bundle-carried identity are never treated as their
 own trust root.
+
+The bundled CLI verifies RFC 3161 proofs only. A `type: "custom"` proof remains
+bound to the signed checkpoint and was verified by the registered application
+verifier at acquisition, but auditors must independently verify its `evidence`
+with the corresponding witness-specific tooling and trust material.

--- a/docs/security/threat-model.mdx
+++ b/docs/security/threat-model.mdx
@@ -394,6 +394,11 @@ adversary defeats the entire architecture.
   Ed25519 checkpoints, and offline verifier detect modification relative to the public key carried in the bundle. Operators must separately
   match that key to an out-of-band trusted signing key or fingerprint. An operator controlling all
   relevant keys can still fabricate a self-consistent history.
+- **Optional checkpoint anchoring narrows, but does not remove, that limit.**
+  An RFC 3161 proof verified against an auditor-supplied TSA CA shows a signed
+  checkpoint existed no later than the TSA time. It does not make Steward
+  tamper-proof or operator-proof, cover post-anchor events, or prove export
+  completeness.
 - **No rate limiting on read endpoints.** Rate limits apply to
   signing and auth; general read traffic is not rate-capped beyond
   whatever the reverse proxy enforces.

--- a/packages/api/src/__tests__/audit-bundle.integration.test.ts
+++ b/packages/api/src/__tests__/audit-bundle.integration.test.ts
@@ -36,6 +36,7 @@ let auditRoutesModule: Awaited<typeof import("../routes/audit")>;
 let tmpDir: string;
 let tsaCaPath: string;
 let tsaConfigPath: string;
+let tsaNoAccuracyConfigPath: string;
 
 interface BundleEvent {
   seq: number;
@@ -84,6 +85,7 @@ function setupTestTsa(): void {
   const extensions = join(tmpDir, "tsa-extensions.cnf");
   const serial = join(tmpDir, "tsa-serial");
   tsaConfigPath = join(tmpDir, "tsa.cnf");
+  tsaNoAccuracyConfigPath = join(tmpDir, "tsa-no-accuracy.cnf");
 
   runOpenSsl([
     "req",
@@ -136,13 +138,13 @@ function setupTestTsa(): void {
     extensions,
   ]);
   writeFileSync(serial, "01\n");
-  writeFileSync(
-    tsaConfigPath,
-    `[ tsa ]\ndefault_tsa = tsa_config1\n[ tsa_config1 ]\ndir = ${tmpDir}\nserial = ${serial}\ncrypto_device = builtin\nsigner_cert = ${tsaCert}\ncerts = ${tsaCaPath}\nsigner_key = ${tsaKey}\nsigner_digest = sha256\ndefault_policy = 1.2.3.4.1\ndigests = sha256\naccuracy = secs:1\nordering = yes\ntsa_name = yes\ness_cert_id_chain = no\n`,
-  );
+  const config = (accuracy: string) =>
+    `[ tsa ]\ndefault_tsa = tsa_config1\n[ tsa_config1 ]\ndir = ${tmpDir}\nserial = ${serial}\ncrypto_device = builtin\nsigner_cert = ${tsaCert}\ncerts = ${tsaCaPath}\nsigner_key = ${tsaKey}\nsigner_digest = sha256\ndefault_policy = 1.2.3.4.1\ndigests = sha256\n${accuracy}ordering = yes\ntsa_name = yes\ness_cert_id_chain = no\n`;
+  writeFileSync(tsaConfigPath, config("accuracy = secs:1\n"));
+  writeFileSync(tsaNoAccuracyConfigPath, config(""));
 }
 
-function attachTestAnchor(bundle: Bundle): void {
+function attachTestAnchor(bundle: Bundle, configPath = tsaConfigPath, accuracyMillis = 1000): void {
   const payload = bundle.checkpoint.payload;
   const ordered = Object.fromEntries(
     Object.keys(payload)
@@ -158,7 +160,7 @@ function attachTestAnchor(bundle: Bundle): void {
     "ts",
     "-reply",
     "-config",
-    tsaConfigPath,
+    configPath,
     "-queryfile",
     queryPath,
     "-out",
@@ -180,7 +182,7 @@ function attachTestAnchor(bundle: Bundle): void {
     nonce: Buffer.from(nonceBytes).toString("hex"),
     policyOid,
     genTime: new Date(timeText).toISOString(),
-    accuracyMillis: 1000,
+    accuracyMillis,
     verifiedAt: new Date().toISOString(),
     trustAnchorSha256: createHash("sha256").update(readFileSync(tsaCaPath)).digest("hex"),
     timestampResponse: readFileSync(responsePath).toString("base64"),
@@ -559,6 +561,51 @@ describe("audit evidence bundle endpoint + offline verifier", () => {
         maxFutureSkewMs: 0,
       }),
     ).toThrow("future");
+  });
+
+  it("rejects a genuine TSA token without signed Accuracy at acquisition and offline verification", async () => {
+    const bundle = await fetchBundle();
+    const digest = auditCheckpointAnchorDigest(bundle.checkpoint as never);
+    const query = createRfc3161TimestampQuery(
+      digest,
+      Uint8Array.from({ length: 16 }, (_, index) => index + 17),
+    );
+    const queryPath = join(tmpDir, `no-accuracy-${Math.random().toString(36).slice(2)}.tsq`);
+    const responsePath = `${queryPath}.tsr`;
+    writeFileSync(queryPath, query);
+    runOpenSsl([
+      "ts",
+      "-reply",
+      "-config",
+      tsaNoAccuracyConfigPath,
+      "-queryfile",
+      queryPath,
+      "-out",
+      responsePath,
+    ]);
+    const response = readFileSync(responsePath);
+    const inspected = spawnSync("openssl", ["ts", "-reply", "-in", responsePath, "-text"], {
+      encoding: "utf8",
+    });
+    expect(inspected.status).toBe(0);
+    expect(inspected.stdout).toMatch(/^Accuracy:\s*unspecified\s*$/m);
+
+    expect(() =>
+      verifyRfc3161TimestampResponse({
+        query,
+        response,
+        caFile: tsaCaPath,
+        requestStartedAt: Date.now() - 1_000,
+        maxPastAgeMs: 300_000,
+        maxFutureSkewMs: 300_000,
+      }),
+    ).toThrow("accuracy is missing");
+
+    const offlineBundle = await fetchBundle();
+    attachTestAnchor(offlineBundle, tsaNoAccuracyConfigPath, 0);
+    const offline = runVerifier(offlineBundle, ["--tsa-ca", tsaCaPath, "--require-anchor"]);
+    expect(offline.code).toBe(1);
+    expect(offline.stderr).toContain("did not contain Accuracy");
   });
 
   it("persists the exact strictly verified proof with the signed checkpoint", async () => {

--- a/packages/api/src/__tests__/audit-bundle.integration.test.ts
+++ b/packages/api/src/__tests__/audit-bundle.integration.test.ts
@@ -10,12 +10,18 @@ import { eq, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { writeAuditEvent } from "../services/audit";
 import { resetCheckpointSignerCache } from "../services/audit-checkpoint";
-import { createRfc3161TimestampQuery } from "../services/audit-checkpoint-anchor";
+import {
+  auditCheckpointAnchorDigest,
+  createRfc3161TimestampQuery,
+  Rfc3161TimestampSink,
+  verifyRfc3161TimestampResponse,
+} from "../services/audit-checkpoint-anchor";
 import type { AppVariables } from "../services/context";
 import { inspectGovernedRoutes } from "../services/governed-route-inventory";
 
 const TENANT_ID = "audit-bundle-tenant";
 const OTHER_TENANT_ID = "audit-bundle-other-tenant";
+const EMPTY_TENANT_ID = "audit-bundle-empty-tenant";
 const VERIFIER = join(
   import.meta.dir,
   "..",
@@ -146,7 +152,8 @@ function attachTestAnchor(bundle: Bundle): void {
   const digest = createHash("sha256").update(JSON.stringify(ordered)).digest("hex");
   const queryPath = join(tmpDir, `query-${Math.random().toString(36).slice(2)}.tsq`);
   const responsePath = `${queryPath}.tsr`;
-  writeFileSync(queryPath, createRfc3161TimestampQuery(digest));
+  const nonceBytes = Uint8Array.from({ length: 16 }, (_, index) => index + 1);
+  writeFileSync(queryPath, createRfc3161TimestampQuery(digest, nonceBytes));
   runOpenSsl([
     "ts",
     "-reply",
@@ -157,12 +164,25 @@ function attachTestAnchor(bundle: Bundle): void {
     "-out",
     responsePath,
   ]);
+  const inspected = spawnSync("openssl", ["ts", "-reply", "-in", responsePath, "-text"], {
+    encoding: "utf8",
+  });
+  if (inspected.status !== 0) throw new Error("failed to inspect test timestamp");
+  const policyOid = inspected.stdout.match(/^Policy OID:\s*([^\s]+)\s*$/m)?.[1];
+  const timeText = inspected.stdout.match(/^Time stamp:\s*(.+)$/m)?.[1];
+  if (!policyOid || !timeText) throw new Error("test timestamp fields missing");
   bundle.checkpoint.anchor = {
     v: 1,
     type: "rfc3161",
     sinkId: "rfc3161",
     hashAlgorithm: "sha256",
     checkpointDigest: digest,
+    nonce: Buffer.from(nonceBytes).toString("hex"),
+    policyOid,
+    genTime: new Date(timeText).toISOString(),
+    accuracyMillis: 1000,
+    verifiedAt: new Date().toISOString(),
+    trustAnchorSha256: createHash("sha256").update(readFileSync(tsaCaPath)).digest("hex"),
     timestampResponse: readFileSync(responsePath).toString("base64"),
   };
 }
@@ -175,6 +195,7 @@ describe("audit evidence bundle endpoint + offline verifier", () => {
     process.env.STEWARD_MASTER_PASSWORD = "audit-bundle-master-password";
     delete process.env.STEWARD_AUDIT_CHECKPOINT_ANCHOR_MODE;
     delete process.env.STEWARD_AUDIT_RFC3161_URL;
+    delete process.env.STEWARD_AUDIT_RFC3161_CA_FILE;
 
     // Deterministic Ed25519 signing key for the run (PKCS#8 PEM path).
     const { privateKey } = generateKeyPairSync("ed25519");
@@ -195,6 +216,7 @@ describe("audit evidence bundle endpoint + offline verifier", () => {
       .values([
         { id: TENANT_ID, name: "Audit Bundle", apiKeyHash: "audit-bundle" },
         { id: OTHER_TENANT_ID, name: "Audit Bundle Other", apiKeyHash: "audit-bundle-other" },
+        { id: EMPTY_TENANT_ID, name: "Audit Bundle Empty", apiKeyHash: "audit-bundle-empty" },
       ]);
 
     for (let i = 1; i <= 4; i++) {
@@ -227,6 +249,7 @@ describe("audit evidence bundle endpoint + offline verifier", () => {
     delete process.env.STEWARD_AUDIT_SIGNING_KEY;
     delete process.env.STEWARD_AUDIT_CHECKPOINT_ANCHOR_MODE;
     delete process.env.STEWARD_AUDIT_RFC3161_URL;
+    delete process.env.STEWARD_AUDIT_RFC3161_CA_FILE;
     resetCheckpointSignerCache();
   });
 
@@ -427,6 +450,209 @@ describe("audit evidence bundle endpoint + offline verifier", () => {
     expect(stdout).toContain("not operator-proof");
   });
 
+  it("accepts a real CMS token only after nonce, freshness, policy, signature, and path checks", async () => {
+    const bundle = await fetchBundle();
+    const digest = auditCheckpointAnchorDigest(bundle.checkpoint as never);
+    const fakeResponse = Uint8Array.from([
+      0x30,
+      0x29,
+      0x30,
+      0x03,
+      0x02,
+      0x01,
+      0x00,
+      0x30,
+      0x22,
+      0x04,
+      0x20,
+      ...Buffer.from(digest, "hex"),
+    ]);
+    const fakeSink = new Rfc3161TimestampSink({
+      url: "https://tsa.example.test/timestamp",
+      caFile: tsaCaPath,
+      fetch: async () =>
+        new Response(fakeResponse, {
+          status: 200,
+          headers: { "content-type": "application/timestamp-reply" },
+        }),
+    });
+    await expect(fakeSink.anchor(bundle.checkpoint as never)).rejects.toThrow(
+      "trust verification failed",
+    );
+    let observedQuery = new Uint8Array();
+    let observedResponse = new Uint8Array();
+    const sink = new Rfc3161TimestampSink({
+      url: "https://tsa.example.test/timestamp",
+      caFile: tsaCaPath,
+      fetch: async (_input, init) => {
+        const queryPath = join(tmpDir, `live-query-${Math.random().toString(36).slice(2)}.tsq`);
+        const responsePath = `${queryPath}.tsr`;
+        observedQuery = init?.body as Uint8Array;
+        writeFileSync(queryPath, observedQuery);
+        runOpenSsl([
+          "ts",
+          "-reply",
+          "-config",
+          tsaConfigPath,
+          "-queryfile",
+          queryPath,
+          "-out",
+          responsePath,
+        ]);
+        observedResponse = readFileSync(responsePath);
+        return new Response(observedResponse, {
+          status: 200,
+          headers: { "content-type": "application/timestamp-reply" },
+        });
+      },
+    });
+    const proof = await sink.anchor(bundle.checkpoint as never);
+    expect(proof.nonce).toMatch(/^[0-9a-f]{32}$/);
+    expect(proof.policyOid.length).toBeGreaterThan(0);
+    expect(proof.accuracyMillis).toBe(1000);
+    expect(proof.trustAnchorSha256).toBe(
+      createHash("sha256").update(readFileSync(tsaCaPath)).digest("hex"),
+    );
+    expect(() =>
+      verifyRfc3161TimestampResponse({
+        query: createRfc3161TimestampQuery(proof.checkpointDigest),
+        response: observedResponse,
+        caFile: tsaCaPath,
+        requestStartedAt: Date.now(),
+        maxPastAgeMs: 300_000,
+        maxFutureSkewMs: 300_000,
+      }),
+    ).toThrow("trust verification failed");
+    expect(() =>
+      verifyRfc3161TimestampResponse({
+        query: observedQuery,
+        response: observedResponse,
+        caFile: tsaCaPath,
+        requestStartedAt: Date.now() + 60 * 60_000,
+        maxPastAgeMs: 0,
+        maxFutureSkewMs: 0,
+      }),
+    ).toThrow("stale");
+    // Accuracy is an uncertainty interval, not slack. Even when bare genTime
+    // overlaps the window, both interval endpoints must fit the freshness
+    // policy.
+    const genTime = Date.parse(proof.genTime);
+    expect(() =>
+      verifyRfc3161TimestampResponse({
+        query: observedQuery,
+        response: observedResponse,
+        caFile: tsaCaPath,
+        requestStartedAt: genTime + 500,
+        verifiedAt: genTime + 5_000,
+        maxPastAgeMs: 0,
+        maxFutureSkewMs: 0,
+      }),
+    ).toThrow("stale");
+    expect(() =>
+      verifyRfc3161TimestampResponse({
+        query: observedQuery,
+        response: observedResponse,
+        caFile: tsaCaPath,
+        requestStartedAt: genTime - 5_000,
+        verifiedAt: genTime - 500,
+        maxPastAgeMs: 10_000,
+        maxFutureSkewMs: 0,
+      }),
+    ).toThrow("future");
+  });
+
+  it("persists the exact strictly verified proof with the signed checkpoint", async () => {
+    const originalFetch = globalThis.fetch;
+    process.env.STEWARD_AUDIT_CHECKPOINT_ANCHOR_MODE = "required";
+    process.env.STEWARD_AUDIT_RFC3161_URL = "https://tsa.example.test/timestamp";
+    process.env.STEWARD_AUDIT_RFC3161_CA_FILE = tsaCaPath;
+    globalThis.fetch = async (_input, init) => {
+      const queryPath = join(tmpDir, `persist-query-${Math.random().toString(36).slice(2)}.tsq`);
+      const responsePath = `${queryPath}.tsr`;
+      writeFileSync(queryPath, init?.body as Uint8Array);
+      runOpenSsl([
+        "ts",
+        "-reply",
+        "-config",
+        tsaConfigPath,
+        "-queryfile",
+        queryPath,
+        "-out",
+        responsePath,
+      ]);
+      return new Response(readFileSync(responsePath), {
+        status: 200,
+        headers: { "content-type": "application/timestamp-reply" },
+      });
+    };
+    try {
+      const bundle = await fetchBundle();
+      expect(bundle.checkpoint.anchor).toBeDefined();
+      const rows = await getDb()
+        .select()
+        .from(auditCheckpoints)
+        .where(eq(auditCheckpoints.tenantId, TENANT_ID));
+      const persisted = rows.find(
+        (row) => row.anchorProof?.checkpointDigest === bundle.checkpoint.anchor?.checkpointDigest,
+      );
+      expect(persisted?.anchorProof).toEqual(bundle.checkpoint.anchor);
+      expect(persisted?.anchorVerifiedAt).toBeInstanceOf(Date);
+      await expect(
+        (async () =>
+          getDb().execute(
+            sql`UPDATE audit_checkpoints SET anchor_proof = NULL WHERE id = ${persisted?.id}`,
+          ))(),
+      ).rejects.toThrow("Failed query");
+    } finally {
+      globalThis.fetch = originalFetch;
+      delete process.env.STEWARD_AUDIT_CHECKPOINT_ANCHOR_MODE;
+      delete process.env.STEWARD_AUDIT_RFC3161_URL;
+      delete process.env.STEWARD_AUDIT_RFC3161_CA_FILE;
+    }
+  });
+
+  it("persists a required proof even for an empty signed checkpoint", async () => {
+    const originalFetch = globalThis.fetch;
+    process.env.STEWARD_AUDIT_CHECKPOINT_ANCHOR_MODE = "required";
+    process.env.STEWARD_AUDIT_RFC3161_URL = "https://tsa.example.test/timestamp";
+    process.env.STEWARD_AUDIT_RFC3161_CA_FILE = tsaCaPath;
+    globalThis.fetch = async (_input, init) => {
+      const queryPath = join(tmpDir, `empty-query-${Math.random().toString(36).slice(2)}.tsq`);
+      const responsePath = `${queryPath}.tsr`;
+      writeFileSync(queryPath, init?.body as Uint8Array);
+      runOpenSsl([
+        "ts",
+        "-reply",
+        "-config",
+        tsaConfigPath,
+        "-queryfile",
+        queryPath,
+        "-out",
+        responsePath,
+      ]);
+      return new Response(readFileSync(responsePath), {
+        status: 200,
+        headers: { "content-type": "application/timestamp-reply" },
+      });
+    };
+    try {
+      const bundle = await fetchBundle("", EMPTY_TENANT_ID);
+      expect(bundle.events).toHaveLength(0);
+      expect(bundle.checkpoint.anchor).toBeDefined();
+      const rows = await getDb()
+        .select()
+        .from(auditCheckpoints)
+        .where(eq(auditCheckpoints.tenantId, EMPTY_TENANT_ID));
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.anchorProof).toEqual(bundle.checkpoint.anchor);
+    } finally {
+      globalThis.fetch = originalFetch;
+      delete process.env.STEWARD_AUDIT_CHECKPOINT_ANCHOR_MODE;
+      delete process.env.STEWARD_AUDIT_RFC3161_URL;
+      delete process.env.STEWARD_AUDIT_RFC3161_CA_FILE;
+    }
+  });
+
   it("fails offline anchor verification for a missing proof or wrong imprint", async () => {
     const unanchored = await fetchBundle();
     const missing = runVerifier(unanchored, ["--tsa-ca", tsaCaPath, "--require-anchor"]);
@@ -441,6 +667,27 @@ describe("audit evidence bundle endpoint + offline verifier", () => {
     const invalid = runVerifier(wrongImprint, ["--tsa-ca", tsaCaPath, "--require-anchor"]);
     expect(invalid.code).toBe(1);
     expect(invalid.stderr).toContain("digest does not match");
+
+    const wrongNonce = await fetchBundle();
+    attachTestAnchor(wrongNonce);
+    if (wrongNonce.checkpoint.anchor) wrongNonce.checkpoint.anchor.nonce = "ff".repeat(16);
+    const nonceFailure = runVerifier(wrongNonce, ["--tsa-ca", tsaCaPath, "--require-anchor"]);
+    expect(nonceFailure.code).toBe(1);
+    expect(nonceFailure.stderr).toContain("nonce does not match");
+
+    const inaccurateCutoff = await fetchBundle();
+    attachTestAnchor(inaccurateCutoff);
+    const anchor = inaccurateCutoff.checkpoint.anchor;
+    const cutoff = new Date(Date.parse(String(anchor?.genTime)) + 500).toISOString();
+    const cutoffFailure = runVerifier(inaccurateCutoff, [
+      "--tsa-ca",
+      tsaCaPath,
+      "--require-anchor",
+      "--anchored-before",
+      cutoff,
+    ]);
+    expect(cutoffFailure.code).toBe(1);
+    expect(cutoffFailure.stderr).toContain("latest accuracy bound");
   });
 
   it("FAILS the verifier at the right seq when an event byte is flipped", async () => {

--- a/packages/api/src/__tests__/audit-bundle.integration.test.ts
+++ b/packages/api/src/__tests__/audit-bundle.integration.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { generateKeyPairSync } from "node:crypto";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createHash, generateKeyPairSync } from "node:crypto";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { auditCheckpoints, closeDb, getDb, tenants } from "@stwd/db";
@@ -10,6 +10,7 @@ import { eq, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { writeAuditEvent } from "../services/audit";
 import { resetCheckpointSignerCache } from "../services/audit-checkpoint";
+import { createRfc3161TimestampQuery } from "../services/audit-checkpoint-anchor";
 import type { AppVariables } from "../services/context";
 import { inspectGovernedRoutes } from "../services/governed-route-inventory";
 
@@ -27,6 +28,8 @@ const VERIFIER = join(
 
 let auditRoutesModule: Awaited<typeof import("../routes/audit")>;
 let tmpDir: string;
+let tsaCaPath: string;
+let tsaConfigPath: string;
 
 interface BundleEvent {
   seq: number;
@@ -40,15 +43,128 @@ interface Bundle {
   range: { from: number; to: number; includesHead: boolean };
   canonicalizationSpec: string;
   events: BundleEvent[];
-  checkpoint: { payload: Record<string, unknown>; signature: string; publicKey: string };
+  checkpoint: {
+    payload: Record<string, unknown>;
+    signature: string;
+    publicKey: string;
+    anchor?: Record<string, unknown>;
+  };
   generatedAt: string;
 }
 
-function runVerifier(bundle: unknown): { code: number; stdout: string; stderr: string } {
+function runVerifier(
+  bundle: unknown,
+  args: string[] = [],
+): { code: number; stdout: string; stderr: string } {
   const file = join(tmpDir, `bundle-${Math.random().toString(36).slice(2)}.json`);
   writeFileSync(file, JSON.stringify(bundle));
-  const res = spawnSync("node", [VERIFIER, file], { encoding: "utf8" });
+  const res = spawnSync("node", [VERIFIER, file, ...args], { encoding: "utf8" });
   return { code: res.status ?? -1, stdout: res.stdout ?? "", stderr: res.stderr ?? "" };
+}
+
+function runOpenSsl(args: string[]): void {
+  const result = spawnSync("openssl", args, { encoding: "utf8" });
+  if (result.status !== 0) {
+    throw new Error(`openssl ${args.join(" ")} failed: ${result.stderr || result.stdout}`);
+  }
+}
+
+function setupTestTsa(): void {
+  tsaCaPath = join(tmpDir, "tsa-ca.pem");
+  const caKey = join(tmpDir, "tsa-ca-key.pem");
+  const tsaKey = join(tmpDir, "tsa-key.pem");
+  const tsaCsr = join(tmpDir, "tsa.csr");
+  const tsaCert = join(tmpDir, "tsa.pem");
+  const extensions = join(tmpDir, "tsa-extensions.cnf");
+  const serial = join(tmpDir, "tsa-serial");
+  tsaConfigPath = join(tmpDir, "tsa.cnf");
+
+  runOpenSsl([
+    "req",
+    "-x509",
+    "-newkey",
+    "rsa:2048",
+    "-nodes",
+    "-keyout",
+    caKey,
+    "-out",
+    tsaCaPath,
+    "-days",
+    "1",
+    "-subj",
+    "/CN=Steward Test TSA CA",
+  ]);
+  runOpenSsl([
+    "req",
+    "-new",
+    "-newkey",
+    "rsa:2048",
+    "-nodes",
+    "-keyout",
+    tsaKey,
+    "-out",
+    tsaCsr,
+    "-subj",
+    "/CN=Steward Test TSA",
+  ]);
+  writeFileSync(
+    extensions,
+    "basicConstraints=critical,CA:FALSE\nkeyUsage=critical,digitalSignature,nonRepudiation\nextendedKeyUsage=critical,timeStamping\nsubjectKeyIdentifier=hash\nauthorityKeyIdentifier=keyid,issuer\n",
+  );
+  runOpenSsl([
+    "x509",
+    "-req",
+    "-in",
+    tsaCsr,
+    "-CA",
+    tsaCaPath,
+    "-CAkey",
+    caKey,
+    "-CAcreateserial",
+    "-out",
+    tsaCert,
+    "-days",
+    "1",
+    "-sha256",
+    "-extfile",
+    extensions,
+  ]);
+  writeFileSync(serial, "01\n");
+  writeFileSync(
+    tsaConfigPath,
+    `[ tsa ]\ndefault_tsa = tsa_config1\n[ tsa_config1 ]\ndir = ${tmpDir}\nserial = ${serial}\ncrypto_device = builtin\nsigner_cert = ${tsaCert}\ncerts = ${tsaCaPath}\nsigner_key = ${tsaKey}\nsigner_digest = sha256\ndefault_policy = 1.2.3.4.1\ndigests = sha256\naccuracy = secs:1\nordering = yes\ntsa_name = yes\ness_cert_id_chain = no\n`,
+  );
+}
+
+function attachTestAnchor(bundle: Bundle): void {
+  const payload = bundle.checkpoint.payload;
+  const ordered = Object.fromEntries(
+    Object.keys(payload)
+      .sort()
+      .map((key) => [key, payload[key]]),
+  );
+  const digest = createHash("sha256").update(JSON.stringify(ordered)).digest("hex");
+  const queryPath = join(tmpDir, `query-${Math.random().toString(36).slice(2)}.tsq`);
+  const responsePath = `${queryPath}.tsr`;
+  writeFileSync(queryPath, createRfc3161TimestampQuery(digest));
+  runOpenSsl([
+    "ts",
+    "-reply",
+    "-config",
+    tsaConfigPath,
+    "-queryfile",
+    queryPath,
+    "-out",
+    responsePath,
+  ]);
+  bundle.checkpoint.anchor = {
+    v: 1,
+    type: "rfc3161",
+    sinkId: "rfc3161",
+    hashAlgorithm: "sha256",
+    checkpointDigest: digest,
+    timestampResponse: readFileSync(responsePath).toString("base64"),
+  };
 }
 
 describe("audit evidence bundle endpoint + offline verifier", () => {
@@ -57,6 +173,8 @@ describe("audit evidence bundle endpoint + offline verifier", () => {
     process.env.STEWARD_PGLITE_MEMORY = "true";
     process.env.STEWARD_AUDIT_HMAC_KEY = "audit-bundle-hmac-key-0123456789abcdef0123";
     process.env.STEWARD_MASTER_PASSWORD = "audit-bundle-master-password";
+    delete process.env.STEWARD_AUDIT_CHECKPOINT_ANCHOR_MODE;
+    delete process.env.STEWARD_AUDIT_RFC3161_URL;
 
     // Deterministic Ed25519 signing key for the run (PKCS#8 PEM path).
     const { privateKey } = generateKeyPairSync("ed25519");
@@ -70,6 +188,7 @@ describe("audit evidence bundle endpoint + offline verifier", () => {
       await client.close();
     });
     auditRoutesModule = await import("../routes/audit");
+    setupTestTsa();
 
     await getDb()
       .insert(tenants)
@@ -106,6 +225,8 @@ describe("audit evidence bundle endpoint + offline verifier", () => {
     delete process.env.STEWARD_AUDIT_HMAC_KEY;
     delete process.env.STEWARD_MASTER_PASSWORD;
     delete process.env.STEWARD_AUDIT_SIGNING_KEY;
+    delete process.env.STEWARD_AUDIT_CHECKPOINT_ANCHOR_MODE;
+    delete process.env.STEWARD_AUDIT_RFC3161_URL;
     resetCheckpointSignerCache();
   });
 
@@ -137,6 +258,9 @@ describe("audit evidence bundle endpoint + offline verifier", () => {
     expect(bundle.range.includesHead).toBe(true);
     expect(bundle.canonicalizationSpec).toContain("HMAC-SHA256");
     expect(bundle.checkpoint.publicKey).toContain("BEGIN PUBLIC KEY");
+    // No anchor configuration preserves the v1 checkpoint envelope exactly;
+    // there is no placeholder field and therefore no hidden network behavior.
+    expect(Object.keys(bundle.checkpoint).sort()).toEqual(["payload", "publicKey", "signature"]);
     expect(bundle.checkpoint.payload.tenantId).toBe(TENANT_ID);
     expect(bundle.checkpoint.payload.seq).toBe(4);
     // Head binding: last event hmac equals signed headHmac.
@@ -270,6 +394,53 @@ describe("audit evidence bundle endpoint + offline verifier", () => {
     const { code, stdout } = runVerifier(bundle);
     expect(stdout).toContain("PASS");
     expect(code).toBe(0);
+  });
+
+  it("fails evidence generation closed when required anchoring is misconfigured", async () => {
+    process.env.STEWARD_AUDIT_CHECKPOINT_ANCHOR_MODE = "required";
+    delete process.env.STEWARD_AUDIT_RFC3161_URL;
+    try {
+      const response = await app().request("/audit/bundle");
+      expect(response.status).toBe(503);
+      expect(await response.json()).toEqual({
+        ok: false,
+        error: "Required checkpoint anchoring failed",
+      });
+    } finally {
+      delete process.env.STEWARD_AUDIT_CHECKPOINT_ANCHOR_MODE;
+    }
+  });
+
+  it("verifies an RFC 3161 token fully offline and reports the anchored-before bound", async () => {
+    const bundle = await fetchBundle();
+    attachTestAnchor(bundle);
+    const { code, stdout } = runVerifier(bundle, [
+      "--tsa-ca",
+      tsaCaPath,
+      "--require-anchor",
+      "--anchored-before",
+      "2100-01-01T00:00:00.000Z",
+    ]);
+    expect(code).toBe(0);
+    expect(stdout).toContain("RFC 3161 verified");
+    expect(stdout).toContain("existed no later than");
+    expect(stdout).toContain("not operator-proof");
+  });
+
+  it("fails offline anchor verification for a missing proof or wrong imprint", async () => {
+    const unanchored = await fetchBundle();
+    const missing = runVerifier(unanchored, ["--tsa-ca", tsaCaPath, "--require-anchor"]);
+    expect(missing.code).toBe(1);
+    expect(missing.stderr).toContain("anchor is missing");
+
+    const wrongImprint = await fetchBundle();
+    attachTestAnchor(wrongImprint);
+    if (wrongImprint.checkpoint.anchor) {
+      wrongImprint.checkpoint.anchor.checkpointDigest = "00".repeat(32);
+    }
+    const invalid = runVerifier(wrongImprint, ["--tsa-ca", tsaCaPath, "--require-anchor"]);
+    expect(invalid.code).toBe(1);
+    expect(invalid.stderr).toContain("digest does not match");
   });
 
   it("FAILS the verifier at the right seq when an event byte is flipped", async () => {

--- a/packages/api/src/__tests__/audit-checkpoint-anchor.test.ts
+++ b/packages/api/src/__tests__/audit-checkpoint-anchor.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { generateKeyPairSync } from "node:crypto";
+import { type CheckpointPayload, createCheckpointSigner } from "../services/audit-checkpoint";
+import {
+  AuditCheckpointAnchorError,
+  assertGrantedRfc3161Response,
+  auditCheckpointAnchorDigest,
+  configuredAuditCheckpointAnchor,
+  createRfc3161TimestampQuery,
+  maybeAnchorAuditCheckpoint,
+  Rfc3161TimestampSink,
+  registerAuditCheckpointAnchorSink,
+} from "../services/audit-checkpoint-anchor";
+
+const ENV_KEYS = [
+  "NODE_ENV",
+  "STEWARD_AUDIT_CHECKPOINT_ANCHOR_MODE",
+  "STEWARD_AUDIT_CHECKPOINT_ANCHOR_PROVIDER",
+  "STEWARD_AUDIT_RFC3161_URL",
+  "STEWARD_AUDIT_RFC3161_TIMEOUT_MS",
+] as const;
+const originalEnv = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
+
+const payload: CheckpointPayload = {
+  v: 1,
+  tenantId: "tenant-anchor",
+  seq: 7,
+  headHmac: "ab".repeat(32),
+  expectedCount: 7,
+  floorSeq: 0,
+  timestamp: "2026-08-16T00:00:00.000Z",
+  softwareVersion: "test",
+  eventsDigest: "cd".repeat(32),
+  eventsFromSeq: 1,
+  eventsToSeq: 7,
+};
+
+function checkpoint() {
+  const { privateKey } = generateKeyPairSync("ed25519");
+  const pem = privateKey.export({ format: "pem", type: "pkcs8" }).toString();
+  return createCheckpointSigner(pem).sign(payload);
+}
+
+// Minimal structurally granted TimeStampResp carrying the requested imprint.
+// Full CMS signature trust is the offline verifier's job with an
+// auditor-supplied CA.
+function grantedResponse(digest: string): Uint8Array {
+  const imprint = Buffer.from(digest, "hex");
+  return Uint8Array.from([
+    0x30,
+    0x29,
+    0x30,
+    0x03,
+    0x02,
+    0x01,
+    0x00,
+    0x30,
+    0x22,
+    0x04,
+    0x20,
+    ...imprint,
+  ]);
+}
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    const value = originalEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe("audit checkpoint anchoring", () => {
+  it("is byte-shape neutral and makes no network call when unconfigured", async () => {
+    delete process.env.STEWARD_AUDIT_CHECKPOINT_ANCHOR_MODE;
+    delete process.env.STEWARD_AUDIT_RFC3161_URL;
+    let calls = 0;
+    const result = await maybeAnchorAuditCheckpoint(checkpoint(), {
+      mode: "off",
+      sink: {
+        id: "must-not-run",
+        async anchor() {
+          calls++;
+          throw new Error("network must remain unreachable");
+        },
+      },
+    });
+    expect(result).toBeUndefined();
+    expect(calls).toBe(0);
+    expect(configuredAuditCheckpointAnchor()).toEqual({ mode: "off" });
+  });
+
+  it("builds the exact SHA-256 RFC 3161 query and attaches only opaque public proof", async () => {
+    const signed = checkpoint();
+    const responseBytes = grantedResponse(auditCheckpointAnchorDigest(signed));
+    let observedUrl = "";
+    let observedInit: RequestInit | undefined;
+    const sink = new Rfc3161TimestampSink({
+      url: "https://tsa.example.test/v1",
+      fetch: async (input, init) => {
+        observedUrl = String(input);
+        observedInit = init;
+        return new Response(responseBytes, {
+          status: 200,
+          headers: { "content-type": "application/timestamp-reply" },
+        });
+      },
+    });
+    const proof = await sink.anchor(signed);
+    expect(observedUrl).toBe("https://tsa.example.test/v1");
+    expect(observedInit?.method).toBe("POST");
+    expect(observedInit?.redirect).toBe("error");
+    expect(new Headers(observedInit?.headers).get("content-type")).toBe(
+      "application/timestamp-query",
+    );
+    const expectedQuery = createRfc3161TimestampQuery(auditCheckpointAnchorDigest(signed));
+    expect(Buffer.from(observedInit?.body as Uint8Array)).toEqual(Buffer.from(expectedQuery));
+    expect(proof).toEqual({
+      v: 1,
+      type: "rfc3161",
+      sinkId: "rfc3161",
+      hashAlgorithm: "sha256",
+      checkpointDigest: auditCheckpointAnchorDigest(signed),
+      timestampResponse: Buffer.from(responseBytes).toString("base64"),
+    });
+    expect(JSON.stringify(proof).toLowerCase()).not.toContain("private");
+  });
+
+  it("rejects malformed, denied, oversized and token-less responses", () => {
+    expect(() => assertGrantedRfc3161Response(new Uint8Array([1, 2, 3]))).toThrow();
+    expect(() =>
+      assertGrantedRfc3161Response(
+        Uint8Array.from([0x30, 0x08, 0x30, 0x03, 0x02, 0x01, 0x02, 0x30, 0x01, 0x00]),
+      ),
+    ).toThrow("rejected");
+    expect(() =>
+      assertGrantedRfc3161Response(Uint8Array.from([0x30, 0x05, 0x30, 0x03, 0x02, 0x01, 0x00])),
+    ).toThrow("did not include");
+    expect(() => assertGrantedRfc3161Response(new Uint8Array(1024 * 1024 + 1))).toThrow("size");
+  });
+
+  it("fails closed in required mode and degrades only when explicitly best-effort", async () => {
+    const failingSink = {
+      id: "failure",
+      async anchor(): Promise<never> {
+        throw new AuditCheckpointAnchorError("tsa unavailable");
+      },
+    };
+    await expect(
+      maybeAnchorAuditCheckpoint(checkpoint(), { mode: "required", sink: failingSink }),
+    ).rejects.toThrow("tsa unavailable");
+    expect(
+      await maybeAnchorAuditCheckpoint(checkpoint(), { mode: "best-effort", sink: failingSink }),
+    ).toBeUndefined();
+  });
+
+  it("rejects incomplete required configuration and insecure production transport", () => {
+    process.env.STEWARD_AUDIT_CHECKPOINT_ANCHOR_MODE = "required";
+    delete process.env.STEWARD_AUDIT_RFC3161_URL;
+    expect(() => configuredAuditCheckpointAnchor()).toThrow("URL is required");
+
+    process.env.NODE_ENV = "production";
+    process.env.STEWARD_AUDIT_RFC3161_URL = "http://tsa.example.test";
+    expect(() => configuredAuditCheckpointAnchor()).toThrow("HTTPS");
+  });
+
+  it("routes an explicitly registered custom witness through the pluggable interface", () => {
+    const sink = {
+      id: "customer-log",
+      async anchor(): Promise<never> {
+        throw new Error("not invoked by configuration discovery");
+      },
+    };
+    const unregister = registerAuditCheckpointAnchorSink("customer-log", () => sink);
+    try {
+      process.env.STEWARD_AUDIT_CHECKPOINT_ANCHOR_MODE = "required";
+      process.env.STEWARD_AUDIT_CHECKPOINT_ANCHOR_PROVIDER = "customer-log";
+      expect(configuredAuditCheckpointAnchor()).toEqual({ mode: "required", sink });
+    } finally {
+      unregister();
+    }
+  });
+});

--- a/packages/api/src/__tests__/audit-checkpoint-anchor.test.ts
+++ b/packages/api/src/__tests__/audit-checkpoint-anchor.test.ts
@@ -122,6 +122,46 @@ describe("audit checkpoint anchoring", () => {
     expect(() => assertGrantedRfc3161Response(new Uint8Array(1024 * 1024 + 1))).toThrow("size");
   });
 
+  it("applies the deadline to a transport that never returns headers", async () => {
+    let signal: AbortSignal | undefined;
+    const sink = new Rfc3161TimestampSink({
+      url: "https://tsa.example.test/v1",
+      caFile: "/unused-before-response.pem",
+      timeoutMs: 100,
+      fetch: (_url, init) => {
+        signal = init?.signal as AbortSignal;
+        return new Promise(() => {});
+      },
+    });
+    await expect(sink.anchor(checkpoint())).rejects.toThrow("timestamp request timed out");
+    expect(signal?.aborted).toBe(true);
+  });
+
+  it("applies the deadline after headers and cancels a stalled body", async () => {
+    let cancelled = false;
+    const body = new ReadableStream<Uint8Array>({
+      pull() {
+        return new Promise(() => {});
+      },
+      cancel() {
+        cancelled = true;
+        return Promise.reject(new Error("provider-controlled secret"));
+      },
+    });
+    const sink = new Rfc3161TimestampSink({
+      url: "https://tsa.example.test/v1",
+      caFile: "/unused-before-response.pem",
+      timeoutMs: 100,
+      fetch: async () =>
+        new Response(body, {
+          status: 200,
+          headers: { "content-type": "application/timestamp-reply" },
+        }),
+    });
+    await expect(sink.anchor(checkpoint())).rejects.toThrow("timestamp request timed out");
+    expect(cancelled).toBe(true);
+  });
+
   it("fails closed in required mode and degrades only when explicitly best-effort", async () => {
     const failingSink = {
       id: "failure",

--- a/packages/api/src/__tests__/audit-checkpoint-anchor.test.ts
+++ b/packages/api/src/__tests__/audit-checkpoint-anchor.test.ts
@@ -148,20 +148,92 @@ describe("audit checkpoint anchoring", () => {
     expect(() => configuredAuditCheckpointAnchor()).toThrow("HTTPS");
   });
 
-  it("routes an explicitly registered custom witness through the pluggable interface", () => {
+  it("routes and verifies a provider-native custom witness proof", async () => {
+    const signed = checkpoint();
+    let verified = 0;
     const sink = {
       id: "customer-log",
-      async anchor(): Promise<never> {
-        throw new Error("not invoked by configuration discovery");
+      async anchor() {
+        return {
+          v: 1 as const,
+          type: "custom" as const,
+          provider: "customer-log",
+          sinkId: "customer-log",
+          hashAlgorithm: "sha256" as const,
+          checkpointDigest: auditCheckpointAnchorDigest(signed),
+          verifiedAt: "2026-08-16T00:00:00.000Z",
+          evidence: { logIndex: 42, inclusionProof: ["aa", "bb"] },
+        };
       },
     };
-    const unregister = registerAuditCheckpointAnchorSink("customer-log", () => sink);
+    const verifier = (_checkpoint: unknown, proof: { evidence: Record<string, unknown> }) => {
+      expect(proof.evidence.logIndex).toBe(42);
+      verified++;
+    };
+    const unregister = registerAuditCheckpointAnchorSink("customer-log", () => sink, verifier);
     try {
       process.env.STEWARD_AUDIT_CHECKPOINT_ANCHOR_MODE = "required";
       process.env.STEWARD_AUDIT_CHECKPOINT_ANCHOR_PROVIDER = "customer-log";
-      expect(configuredAuditCheckpointAnchor()).toEqual({ mode: "required", sink });
+      const configured = configuredAuditCheckpointAnchor();
+      expect(configured).toEqual({
+        mode: "required",
+        provider: "customer-log",
+        sink,
+        verify: verifier,
+      });
+      const proof = await maybeAnchorAuditCheckpoint(signed, configured);
+      expect(proof).toMatchObject({
+        type: "custom",
+        provider: "customer-log",
+        checkpointDigest: auditCheckpointAnchorDigest(signed),
+      });
+      expect(verified).toBe(1);
     } finally {
       unregister();
     }
+  });
+
+  it("rejects unverified or incorrectly bound custom witness evidence", async () => {
+    const signed = checkpoint();
+    const customSink = (checkpointDigest: string) => ({
+      id: "customer-log",
+      async anchor() {
+        return {
+          v: 1 as const,
+          type: "custom" as const,
+          provider: "customer-log",
+          sinkId: "customer-log",
+          hashAlgorithm: "sha256" as const,
+          checkpointDigest,
+          verifiedAt: "2026-08-16T00:00:00.000Z",
+          evidence: { treeHead: "signed-head" },
+        };
+      },
+    });
+    await expect(
+      maybeAnchorAuditCheckpoint(signed, {
+        mode: "required",
+        provider: "customer-log",
+        sink: customSink(auditCheckpointAnchorDigest(signed)),
+      }),
+    ).rejects.toThrow("requires a proof verifier");
+    await expect(
+      maybeAnchorAuditCheckpoint(signed, {
+        mode: "required",
+        provider: "customer-log",
+        sink: customSink("00".repeat(32)),
+        verify: () => undefined,
+      }),
+    ).rejects.toThrow("does not bind");
+    await expect(
+      maybeAnchorAuditCheckpoint(signed, {
+        mode: "required",
+        provider: "customer-log",
+        sink: customSink(auditCheckpointAnchorDigest(signed)),
+        verify: () => {
+          throw new AuditCheckpointAnchorError("inclusion proof rejected");
+        },
+      }),
+    ).rejects.toThrow("inclusion proof rejected");
   });
 });

--- a/packages/api/src/__tests__/audit-checkpoint-anchor.test.ts
+++ b/packages/api/src/__tests__/audit-checkpoint-anchor.test.ts
@@ -17,6 +17,7 @@ const ENV_KEYS = [
   "STEWARD_AUDIT_CHECKPOINT_ANCHOR_MODE",
   "STEWARD_AUDIT_CHECKPOINT_ANCHOR_PROVIDER",
   "STEWARD_AUDIT_RFC3161_URL",
+  "STEWARD_AUDIT_RFC3161_CA_FILE",
   "STEWARD_AUDIT_RFC3161_TIMEOUT_MS",
 ] as const;
 const originalEnv = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
@@ -41,9 +42,8 @@ function checkpoint() {
   return createCheckpointSigner(pem).sign(payload);
 }
 
-// Minimal structurally granted TimeStampResp carrying the requested imprint.
-// Full CMS signature trust is the offline verifier's job with an
-// auditor-supplied CA.
+// Deliberately fake non-CMS response used to prove acquisition never accepts a
+// byte scan or a shallow ASN.1 wrapper as a timestamp token.
 function grantedResponse(digest: string): Uint8Array {
   const imprint = Buffer.from(digest, "hex");
   return Uint8Array.from([
@@ -90,40 +90,23 @@ describe("audit checkpoint anchoring", () => {
     expect(configuredAuditCheckpointAnchor()).toEqual({ mode: "off" });
   });
 
-  it("builds the exact SHA-256 RFC 3161 query and attaches only opaque public proof", async () => {
+  it("uses a fresh nonce and rejects a fabricated non-CMS response in required acquisition", async () => {
     const signed = checkpoint();
     const responseBytes = grantedResponse(auditCheckpointAnchorDigest(signed));
-    let observedUrl = "";
-    let observedInit: RequestInit | undefined;
+    const first = createRfc3161TimestampQuery(auditCheckpointAnchorDigest(signed));
+    const second = createRfc3161TimestampQuery(auditCheckpointAnchorDigest(signed));
+    expect(first).not.toEqual(second);
     const sink = new Rfc3161TimestampSink({
       url: "https://tsa.example.test/v1",
-      fetch: async (input, init) => {
-        observedUrl = String(input);
-        observedInit = init;
+      caFile: "/definitely-not-a-trust-anchor.pem",
+      fetch: async () => {
         return new Response(responseBytes, {
           status: 200,
           headers: { "content-type": "application/timestamp-reply" },
         });
       },
     });
-    const proof = await sink.anchor(signed);
-    expect(observedUrl).toBe("https://tsa.example.test/v1");
-    expect(observedInit?.method).toBe("POST");
-    expect(observedInit?.redirect).toBe("error");
-    expect(new Headers(observedInit?.headers).get("content-type")).toBe(
-      "application/timestamp-query",
-    );
-    const expectedQuery = createRfc3161TimestampQuery(auditCheckpointAnchorDigest(signed));
-    expect(Buffer.from(observedInit?.body as Uint8Array)).toEqual(Buffer.from(expectedQuery));
-    expect(proof).toEqual({
-      v: 1,
-      type: "rfc3161",
-      sinkId: "rfc3161",
-      hashAlgorithm: "sha256",
-      checkpointDigest: auditCheckpointAnchorDigest(signed),
-      timestampResponse: Buffer.from(responseBytes).toString("base64"),
-    });
-    expect(JSON.stringify(proof).toLowerCase()).not.toContain("private");
+    await expect(sink.anchor(signed)).rejects.toThrow();
   });
 
   it("rejects malformed, denied, oversized and token-less responses", () => {
@@ -160,6 +143,7 @@ describe("audit checkpoint anchoring", () => {
     expect(() => configuredAuditCheckpointAnchor()).toThrow("URL is required");
 
     process.env.NODE_ENV = "production";
+    process.env.STEWARD_AUDIT_RFC3161_CA_FILE = "/tmp/tsa-ca.pem";
     process.env.STEWARD_AUDIT_RFC3161_URL = "http://tsa.example.test";
     expect(() => configuredAuditCheckpointAnchor()).toThrow("HTTPS");
   });

--- a/packages/api/src/__tests__/provider-case-fixture.ts
+++ b/packages/api/src/__tests__/provider-case-fixture.ts
@@ -102,7 +102,10 @@ export async function wipeCase(): Promise<void> {
   await db.delete(tenants);
   await db.execute(sql`DELETE FROM audit_events`);
   await db.execute(sql`DELETE FROM audit_chain_heads`);
-  await db.execute(sql`DELETE FROM audit_checkpoints`);
+  // Checkpoints are append-only in production. TRUNCATE is deliberately used
+  // only by this isolated PGLite fixture to reset the shared test database
+  // without weakening the row-level UPDATE/DELETE guard.
+  await db.execute(sql`TRUNCATE TABLE audit_checkpoints RESTART IDENTITY`);
 }
 
 function idem(seed: string): string {

--- a/packages/api/src/lib.ts
+++ b/packages/api/src/lib.ts
@@ -38,4 +38,5 @@ export {
   type Rfc3161CheckpointAnchorProof,
   Rfc3161TimestampSink,
   registerAuditCheckpointAnchorSink,
+  verifyRfc3161TimestampResponse,
 } from "./services/audit-checkpoint-anchor";

--- a/packages/api/src/lib.ts
+++ b/packages/api/src/lib.ts
@@ -30,3 +30,12 @@ export {
   type StewardApp,
   type StewardAppContext,
 } from "./plugin";
+export {
+  AuditCheckpointAnchorError,
+  type AuditCheckpointAnchorMode,
+  type AuditCheckpointAnchorSink,
+  type AuditCheckpointAnchorSinkFactory,
+  type Rfc3161CheckpointAnchorProof,
+  Rfc3161TimestampSink,
+  registerAuditCheckpointAnchorSink,
+} from "./services/audit-checkpoint-anchor";

--- a/packages/api/src/lib.ts
+++ b/packages/api/src/lib.ts
@@ -33,8 +33,11 @@ export {
 export {
   AuditCheckpointAnchorError,
   type AuditCheckpointAnchorMode,
+  type AuditCheckpointAnchorProof,
+  type AuditCheckpointAnchorProofVerifier,
   type AuditCheckpointAnchorSink,
   type AuditCheckpointAnchorSinkFactory,
+  type CustomCheckpointAnchorProof,
   type Rfc3161CheckpointAnchorProof,
   Rfc3161TimestampSink,
   registerAuditCheckpointAnchorSink,

--- a/packages/api/src/routes/audit.ts
+++ b/packages/api/src/routes/audit.ts
@@ -39,6 +39,7 @@ import {
   type SignedCheckpoint,
   verifyCheckpoint,
 } from "../services/audit-checkpoint";
+import { AuditCheckpointAnchorError } from "../services/audit-checkpoint-anchor";
 import {
   type ApiResponse,
   type AppVariables,
@@ -1264,6 +1265,9 @@ auditRoutes.get("/bundle", async (c) => {
   } catch (err) {
     if (err instanceof AuditSigningKeyError) {
       return c.json<ApiResponse>({ ok: false, error: err.message }, 503);
+    }
+    if (err instanceof AuditCheckpointAnchorError) {
+      return c.json<ApiResponse>({ ok: false, error: "Required checkpoint anchoring failed" }, 503);
     }
     console.error(`[audit] checkpoint signing failed for tenant ${tenantId}:`, err);
     return c.json<ApiResponse>({ ok: false, error: "Failed to sign checkpoint" }, 500);

--- a/packages/api/src/routes/provider-case.ts
+++ b/packages/api/src/routes/provider-case.ts
@@ -25,6 +25,7 @@ import { eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { auditOwnerAdminMfaGate } from "../middleware/audit-gate";
 import { AuditSigningKeyError, isCheckpointSigningConfigured } from "../services/audit-checkpoint";
+import { AuditCheckpointAnchorError } from "../services/audit-checkpoint-anchor";
 import {
   type ApiResponse,
   type AppVariables,
@@ -107,6 +108,9 @@ providerCaseRoutes.get("/provider-actions/:id/evidence", async (c) => {
   } catch (err) {
     if (err instanceof AuditSigningKeyError) {
       return c.json<ApiResponse>({ ok: false, error: "CASE_EVIDENCE_SIGNING_DISABLED" }, 503);
+    }
+    if (err instanceof AuditCheckpointAnchorError) {
+      return c.json<ApiResponse>({ ok: false, error: "CASE_EVIDENCE_ANCHOR_UNAVAILABLE" }, 503);
     }
     if (err instanceof CaseRangeTooLargeError) {
       // Pathological same-tenant interleave (KC15): the case segment is too

--- a/packages/api/src/services/audit-checkpoint-anchor.ts
+++ b/packages/api/src/services/audit-checkpoint-anchor.ts
@@ -7,7 +7,11 @@
  * assembly.
  */
 
-import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import { createHash, randomBytes } from "node:crypto";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { canonicalCheckpointBytes, type SignedCheckpoint } from "./audit-checkpoint";
 
 export type AuditCheckpointAnchorMode = "off" | "best-effort" | "required";
@@ -19,6 +23,14 @@ export interface Rfc3161CheckpointAnchorProof {
   hashAlgorithm: "sha256";
   /** SHA-256 of canonicalCheckpointBytes(checkpoint.payload). */
   checkpointDigest: string;
+  /** Request nonce, verified inside the signed TSTInfo by OpenSSL. */
+  nonce: string;
+  policyOid: string;
+  genTime: string;
+  accuracyMillis: number;
+  verifiedAt: string;
+  /** SHA-256 of the operator-configured acquisition trust-anchor PEM bytes. */
+  trustAnchorSha256: string;
   /** Base64 DER TimeStampResp, including the TSA certificate when supplied. */
   timestampResponse: string;
 }
@@ -55,6 +67,12 @@ export interface Rfc3161TimestampSinkOptions {
   url: string;
   timeoutMs?: number;
   fetch?: typeof globalThis.fetch;
+  caFile: string;
+  untrustedFile?: string;
+  expectedPolicyOid?: string;
+  maxPastAgeMs?: number;
+  maxFutureSkewMs?: number;
+  opensslPath?: string;
 }
 
 export class AuditCheckpointAnchorError extends Error {
@@ -70,6 +88,10 @@ function bytesToBase64(bytes: Uint8Array): string {
   let binary = "";
   for (const byte of bytes) binary += String.fromCharCode(byte);
   return btoa(binary);
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
 }
 
 function hexToBytes(hex: string): Uint8Array {
@@ -90,16 +112,31 @@ function concatBytes(...chunks: Uint8Array[]): Uint8Array {
   return out;
 }
 
+function derLength(length: number): Uint8Array {
+  if (length < 128) return Uint8Array.of(length);
+  const bytes: number[] = [];
+  for (let value = length; value > 0; value >>>= 8) bytes.unshift(value & 0xff);
+  return Uint8Array.of(0x80 | bytes.length, ...bytes);
+}
+
+function der(tag: number, content: Uint8Array): Uint8Array {
+  return concatBytes(Uint8Array.of(tag), derLength(content.length), content);
+}
+
 /** Digest anchored by the TSA. The Ed25519 signature authenticates these bytes separately. */
 export function auditCheckpointAnchorDigest(checkpoint: SignedCheckpoint): string {
   return createHash("sha256").update(canonicalCheckpointBytes(checkpoint.payload)).digest("hex");
 }
 
 /**
- * DER TimeStampReq v1 with SHA-256 MessageImprint and certReq=true.
- * The fixed-size SHA-256 request uses only short-form DER lengths.
+ * DER TimeStampReq v1 with SHA-256 MessageImprint, an unpredictable 128-bit
+ * nonce, and certReq=true. The nonce is mandatory: it prevents a previously
+ * issued token from satisfying a new required-mode acquisition.
  */
-export function createRfc3161TimestampQuery(checkpointDigest: string): Uint8Array {
+export function createRfc3161TimestampQuery(
+  checkpointDigest: string,
+  nonceBytes: Uint8Array = randomBytes(16),
+): Uint8Array {
   if (!/^[0-9a-f]{64}$/.test(checkpointDigest)) {
     throw new AuditCheckpointAnchorError(
       "RFC 3161 checkpoint digest must be 32-byte lowercase hex",
@@ -108,16 +145,24 @@ export function createRfc3161TimestampQuery(checkpointDigest: string): Uint8Arra
   const sha256AlgorithmIdentifier = Uint8Array.from([
     0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x01, 0x05, 0x00,
   ]);
-  const imprint = concatBytes(
-    Uint8Array.from([0x30, 0x31]),
-    sha256AlgorithmIdentifier,
-    Uint8Array.from([0x04, 0x20]),
-    hexToBytes(checkpointDigest),
+  if (nonceBytes.length !== 16 || nonceBytes.every((byte) => byte === 0)) {
+    throw new AuditCheckpointAnchorError("RFC 3161 nonce must be a non-zero 128-bit value");
+  }
+  const imprint = der(
+    0x30,
+    concatBytes(sha256AlgorithmIdentifier, der(0x04, hexToBytes(checkpointDigest))),
   );
-  return concatBytes(
-    Uint8Array.from([0x30, 0x39, 0x02, 0x01, 0x01]),
-    imprint,
-    Uint8Array.from([0x01, 0x01, 0xff]),
+  let integer = nonceBytes;
+  while (integer.length > 1 && integer[0] === 0) integer = integer.slice(1);
+  if ((integer[0] & 0x80) !== 0) integer = concatBytes(Uint8Array.of(0), integer);
+  return der(
+    0x30,
+    concatBytes(
+      der(0x02, Uint8Array.of(1)),
+      imprint,
+      der(0x02, integer),
+      der(0x01, Uint8Array.of(0xff)),
+    ),
   );
 }
 
@@ -191,17 +236,122 @@ export function assertGrantedRfc3161Response(bytes: Uint8Array): void {
   }
 }
 
-function assertRfc3161ResponseContainsImprint(bytes: Uint8Array, digest: string): void {
-  const expected = concatBytes(Uint8Array.from([0x04, 0x20]), hexToBytes(digest));
-  outer: for (let offset = 0; offset <= bytes.length - expected.length; offset++) {
-    for (let i = 0; i < expected.length; i++) {
-      if (bytes[offset + i] !== expected[i]) continue outer;
+export interface VerifiedRfc3161Token {
+  policyOid: string;
+  genTime: string;
+  accuracyMillis: number;
+  trustAnchorSha256: string;
+}
+
+function parseAccuracyMillis(text: string): number {
+  const line = text.match(/^Accuracy:\s*(.+)$/m)?.[1];
+  if (!line) return 0;
+  const number = (name: string) => {
+    const value = line.match(new RegExp(`(?:0x([0-9a-f]+)|([0-9]+))\\s+${name}`, "i"));
+    return value ? Number.parseInt(value[1] ?? value[2], value[1] ? 16 : 10) : 0;
+  };
+  return number("seconds") * 1000 + number("millis") + number("micros") / 1000;
+}
+
+/**
+ * Strict acquisition verification. `openssl ts -verify -queryfile` validates
+ * the TimeStampResp/CMS SignedData/TSTInfo structure, signed message imprint,
+ * signed nonce, signer EKU/signature, and certificate path to `caFile`.
+ */
+export function verifyRfc3161TimestampResponse(input: {
+  query: Uint8Array;
+  response: Uint8Array;
+  caFile: string;
+  untrustedFile?: string;
+  expectedPolicyOid?: string;
+  opensslPath?: string;
+  requestStartedAt: number;
+  verifiedAt?: number;
+  maxPastAgeMs: number;
+  maxFutureSkewMs: number;
+}): VerifiedRfc3161Token {
+  const directory = mkdtempSync(join(tmpdir(), "steward-tsa-acquire-"));
+  const queryPath = join(directory, "request.tsq");
+  const responsePath = join(directory, "response.tsr");
+  const caPath = join(directory, "trusted-ca.pem");
+  const untrustedPath = join(directory, "untrusted.pem");
+  const openssl = input.opensslPath ?? "openssl";
+  try {
+    const caBytes = readFileSync(input.caFile);
+    writeFileSync(queryPath, input.query, { mode: 0o600 });
+    writeFileSync(responsePath, input.response, { mode: 0o600 });
+    writeFileSync(caPath, caBytes, { mode: 0o600 });
+    if (input.untrustedFile) {
+      writeFileSync(untrustedPath, readFileSync(input.untrustedFile), { mode: 0o600 });
     }
-    return;
+    const inspected = spawnSync(openssl, ["ts", "-reply", "-in", responsePath, "-text"], {
+      encoding: "utf8",
+      timeout: 30_000,
+    });
+    if (inspected.error || inspected.status !== 0) {
+      throw new AuditCheckpointAnchorError("RFC 3161 CMS/TSTInfo trust verification failed");
+    }
+    const text = inspected.stdout;
+    const policyOid = text.match(/^Policy OID:\s*([^\s]+)\s*$/m)?.[1];
+    const timeText = text.match(/^Time stamp:\s*(.+)$/m)?.[1];
+    const nonce = text.match(/^Nonce:\s*(0x[0-9a-f]+|[0-9]+)\s*$/im)?.[1];
+    if (!policyOid || !timeText || !nonce || !/^Hash Algorithm:\s*sha256\s*$/im.test(text)) {
+      throw new AuditCheckpointAnchorError("RFC 3161 TSTInfo is missing required signed fields");
+    }
+    if (input.expectedPolicyOid && policyOid !== input.expectedPolicyOid) {
+      throw new AuditCheckpointAnchorError("RFC 3161 TSA policy OID is not allowed");
+    }
+    const genTimeMs = Date.parse(timeText);
+    if (!Number.isFinite(genTimeMs)) {
+      throw new AuditCheckpointAnchorError("RFC 3161 genTime is not parseable");
+    }
+    // RFC 3161 tokens are long-lived evidence. Validate the TSA certificate
+    // path at the signed generation time, rather than at the later acquisition
+    // or audit time when the signing certificate may legitimately be expired.
+    // The inspected time is not trusted until this verification succeeds.
+    const args = [
+      "ts",
+      "-verify",
+      "-queryfile",
+      queryPath,
+      "-in",
+      responsePath,
+      "-CAfile",
+      caPath,
+      "-attime",
+      String(Math.floor(genTimeMs / 1000)),
+    ];
+    if (input.untrustedFile) args.push("-untrusted", untrustedPath);
+    const verified = spawnSync(openssl, args, { encoding: "utf8", timeout: 30_000 });
+    if (verified.error || verified.status !== 0) {
+      throw new AuditCheckpointAnchorError("RFC 3161 CMS/TSTInfo trust verification failed", {
+        cause: verified.error,
+      });
+    }
+    const accuracyMillis = parseAccuracyMillis(text);
+    if (!Number.isFinite(accuracyMillis) || accuracyMillis < 0) {
+      throw new AuditCheckpointAnchorError("RFC 3161 accuracy is invalid");
+    }
+    const verifiedAt = input.verifiedAt ?? Date.now();
+    // The signed time can be anywhere inside [genTime-accuracy,
+    // genTime+accuracy]. Require the entire interval to fit the configured
+    // acquisition window; mere overlap would let an imprecise TSA bypass the
+    // freshness bound.
+    if (genTimeMs - accuracyMillis < input.requestStartedAt - input.maxPastAgeMs) {
+      throw new AuditCheckpointAnchorError("RFC 3161 genTime is stale for this acquisition");
+    }
+    if (genTimeMs + accuracyMillis > verifiedAt + input.maxFutureSkewMs) {
+      throw new AuditCheckpointAnchorError("RFC 3161 genTime is implausibly in the future");
+    }
+    return {
+      policyOid,
+      genTime: new Date(genTimeMs).toISOString(),
+      accuracyMillis,
+      trustAnchorSha256: createHash("sha256").update(caBytes).digest("hex"),
+    };
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
   }
-  throw new AuditCheckpointAnchorError(
-    "RFC 3161 response does not contain the requested SHA-256 message imprint",
-  );
 }
 
 async function readTimestampResponse(response: Response): Promise<Uint8Array> {
@@ -257,6 +407,7 @@ export class Rfc3161TimestampSink implements AuditCheckpointAnchorSink {
   private readonly url: URL;
   private readonly timeoutMs: number;
   private readonly fetchImpl: typeof globalThis.fetch;
+  private readonly options: Rfc3161TimestampSinkOptions;
 
   constructor(options: Rfc3161TimestampSinkOptions) {
     this.url = validateTimestampUrl(options.url);
@@ -265,11 +416,18 @@ export class Rfc3161TimestampSink implements AuditCheckpointAnchorSink {
       throw new AuditCheckpointAnchorError("RFC 3161 timeout must be between 100 and 60000ms");
     }
     this.fetchImpl = options.fetch ?? globalThis.fetch;
+    if (!options.caFile?.trim()) {
+      throw new AuditCheckpointAnchorError("RFC 3161 trusted CA file is required");
+    }
+    this.options = options;
   }
 
   async anchor(checkpoint: SignedCheckpoint): Promise<Rfc3161CheckpointAnchorProof> {
     const checkpointDigest = auditCheckpointAnchorDigest(checkpoint);
-    const query = createRfc3161TimestampQuery(checkpointDigest);
+    const nonceBytes = randomBytes(16);
+    const nonce = bytesToHex(nonceBytes);
+    const query = createRfc3161TimestampQuery(checkpointDigest, nonceBytes);
+    const requestStartedAt = Date.now();
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), this.timeoutMs);
     try {
@@ -289,19 +447,47 @@ export class Rfc3161TimestampSink implements AuditCheckpointAnchorSink {
       if (!response.ok) {
         throw new AuditCheckpointAnchorError(`RFC 3161 TSA returned HTTP ${response.status}`);
       }
+      if (
+        (response.headers.get("content-type") ?? "").split(";", 1)[0].trim().toLowerCase() !==
+        "application/timestamp-reply"
+      ) {
+        throw new AuditCheckpointAnchorError("RFC 3161 TSA returned an invalid content type");
+      }
       const declaredLength = Number(response.headers.get("content-length") ?? "0");
-      if (declaredLength > MAX_TIMESTAMP_RESPONSE_BYTES) {
+      if (
+        !Number.isFinite(declaredLength) ||
+        declaredLength < 0 ||
+        declaredLength > MAX_TIMESTAMP_RESPONSE_BYTES
+      ) {
         throw new AuditCheckpointAnchorError("RFC 3161 response exceeds 1 MiB");
       }
       const bytes = await readTimestampResponse(response);
       assertGrantedRfc3161Response(bytes);
-      assertRfc3161ResponseContainsImprint(bytes, checkpointDigest);
+      const verifiedAt = Date.now();
+      const verified = verifyRfc3161TimestampResponse({
+        query,
+        response: bytes,
+        caFile: this.options.caFile,
+        untrustedFile: this.options.untrustedFile,
+        expectedPolicyOid: this.options.expectedPolicyOid,
+        opensslPath: this.options.opensslPath,
+        requestStartedAt,
+        verifiedAt,
+        maxPastAgeMs: this.options.maxPastAgeMs ?? 5 * 60_000,
+        maxFutureSkewMs: this.options.maxFutureSkewMs ?? 5 * 60_000,
+      });
       return {
         v: 1,
         type: "rfc3161",
         sinkId: this.id,
         hashAlgorithm: "sha256",
         checkpointDigest,
+        nonce,
+        policyOid: verified.policyOid,
+        genTime: verified.genTime,
+        accuracyMillis: verified.accuracyMillis,
+        verifiedAt: new Date(verifiedAt).toISOString(),
+        trustAnchorSha256: verified.trustAnchorSha256,
         timestampResponse: bytesToBase64(bytes),
       };
     } catch (error) {
@@ -347,7 +533,32 @@ export function configuredAuditCheckpointAnchor(): {
   }
   const rawTimeout = process.env.STEWARD_AUDIT_RFC3161_TIMEOUT_MS?.trim();
   const timeoutMs = rawTimeout ? Number(rawTimeout) : undefined;
-  return { mode, sink: new Rfc3161TimestampSink({ url, timeoutMs }) };
+  const caFile = process.env.STEWARD_AUDIT_RFC3161_CA_FILE?.trim();
+  if (!caFile) {
+    throw new AuditCheckpointAnchorError(
+      "STEWARD_AUDIT_RFC3161_CA_FILE is required when RFC 3161 anchoring is enabled",
+    );
+  }
+  const seconds = (name: string, fallback: number) => {
+    const raw = process.env[name]?.trim();
+    const value = raw ? Number(raw) : fallback;
+    if (!Number.isSafeInteger(value) || value < 0 || value > 3600) {
+      throw new AuditCheckpointAnchorError(`${name} must be an integer from 0 to 3600 seconds`);
+    }
+    return value * 1000;
+  };
+  return {
+    mode,
+    sink: new Rfc3161TimestampSink({
+      url,
+      timeoutMs,
+      caFile,
+      untrustedFile: process.env.STEWARD_AUDIT_RFC3161_UNTRUSTED_FILE?.trim(),
+      expectedPolicyOid: process.env.STEWARD_AUDIT_RFC3161_POLICY_OID?.trim(),
+      maxPastAgeMs: seconds("STEWARD_AUDIT_RFC3161_MAX_AGE_SECONDS", 300),
+      maxFutureSkewMs: seconds("STEWARD_AUDIT_RFC3161_MAX_FUTURE_SKEW_SECONDS", 300),
+    }),
+  };
 }
 
 /** Anchor according to environment policy; required mode never degrades silently. */

--- a/packages/api/src/services/audit-checkpoint-anchor.ts
+++ b/packages/api/src/services/audit-checkpoint-anchor.ts
@@ -279,14 +279,17 @@ export interface VerifiedRfc3161Token {
   trustAnchorSha256: string;
 }
 
-function parseAccuracyMillis(text: string): number {
+function parseAccuracyMillis(text: string): number | null {
   const line = text.match(/^Accuracy:\s*(.+)$/m)?.[1];
-  if (!line) return 0;
+  if (!line || /^\s*unspecified\s*$/i.test(line)) return null;
+  let foundComponent = false;
   const number = (name: string) => {
     const value = line.match(new RegExp(`(?:0x([0-9a-f]+)|([0-9]+))\\s+${name}`, "i"));
+    if (value) foundComponent = true;
     return value ? Number.parseInt(value[1] ?? value[2], value[1] ? 16 : 10) : 0;
   };
-  return number("seconds") * 1000 + number("millis") + number("micros") / 1000;
+  const accuracyMillis = number("seconds") * 1000 + number("millis") + number("micros") / 1000;
+  return foundComponent ? accuracyMillis : Number.NaN;
 }
 
 /**
@@ -365,6 +368,9 @@ export function verifyRfc3161TimestampResponse(input: {
       });
     }
     const accuracyMillis = parseAccuracyMillis(text);
+    if (accuracyMillis === null) {
+      throw new AuditCheckpointAnchorError("RFC 3161 accuracy is missing");
+    }
     if (!Number.isFinite(accuracyMillis) || accuracyMillis < 0) {
       throw new AuditCheckpointAnchorError("RFC 3161 accuracy is invalid");
     }

--- a/packages/api/src/services/audit-checkpoint-anchor.ts
+++ b/packages/api/src/services/audit-checkpoint-anchor.ts
@@ -35,31 +35,67 @@ export interface Rfc3161CheckpointAnchorProof {
   timestampResponse: string;
 }
 
+/** Provider-native evidence from an operator-registered append-only witness. */
+export interface CustomCheckpointAnchorProof {
+  v: 1;
+  type: "custom";
+  /** Must equal the provider name used at registration/configuration. */
+  provider: string;
+  sinkId: string;
+  hashAlgorithm: "sha256";
+  /** SHA-256 of canonicalCheckpointBytes(checkpoint.payload). */
+  checkpointDigest: string;
+  /** Time at which the registered verifier accepted this exact proof. */
+  verifiedAt: string;
+  /** Opaque, JSON-serializable provider proof retained append-only in the bundle/DB. */
+  evidence: Record<string, unknown>;
+}
+
+export type AuditCheckpointAnchorProof = Rfc3161CheckpointAnchorProof | CustomCheckpointAnchorProof;
+
 export interface AuditCheckpointAnchorSink {
   readonly id: string;
-  anchor(checkpoint: SignedCheckpoint): Promise<Rfc3161CheckpointAnchorProof>;
+  anchor(checkpoint: SignedCheckpoint): Promise<AuditCheckpointAnchorProof>;
 }
 
 export type AuditCheckpointAnchorSinkFactory = () => AuditCheckpointAnchorSink;
+export type AuditCheckpointAnchorProofVerifier = (
+  checkpoint: SignedCheckpoint,
+  proof: CustomCheckpointAnchorProof,
+) => Promise<void> | void;
 
-const registeredSinkFactories = new Map<string, AuditCheckpointAnchorSinkFactory>();
+interface RegisteredAnchorProvider {
+  factory: AuditCheckpointAnchorSinkFactory;
+  verify: AuditCheckpointAnchorProofVerifier;
+}
+
+const registeredSinkProviders = new Map<string, RegisteredAnchorProvider>();
 
 /** Register an operator-supplied append-only witness implementation. */
 export function registerAuditCheckpointAnchorSink(
   provider: string,
   factory: AuditCheckpointAnchorSinkFactory,
+  verify: AuditCheckpointAnchorProofVerifier,
 ): () => void {
   if (!/^[a-z0-9][a-z0-9-]{0,63}$/.test(provider) || provider === "rfc3161") {
     throw new AuditCheckpointAnchorError("Custom checkpoint anchor provider name is invalid");
   }
-  if (registeredSinkFactories.has(provider)) {
+  if (typeof verify !== "function") {
+    throw new AuditCheckpointAnchorError(
+      "Custom checkpoint anchor provider requires a proof verifier",
+    );
+  }
+  if (registeredSinkProviders.has(provider)) {
     throw new AuditCheckpointAnchorError(
       `Checkpoint anchor provider ${provider} is already registered`,
     );
   }
-  registeredSinkFactories.set(provider, factory);
+  const registration = { factory, verify };
+  registeredSinkProviders.set(provider, registration);
   return () => {
-    if (registeredSinkFactories.get(provider) === factory) registeredSinkFactories.delete(provider);
+    if (registeredSinkProviders.get(provider) === registration) {
+      registeredSinkProviders.delete(provider);
+    }
   };
 }
 
@@ -512,18 +548,25 @@ function configuredMode(): AuditCheckpointAnchorMode {
 export function configuredAuditCheckpointAnchor(): {
   mode: AuditCheckpointAnchorMode;
   sink?: AuditCheckpointAnchorSink;
+  provider?: string;
+  verify?: AuditCheckpointAnchorProofVerifier;
 } {
   const mode = configuredMode();
   if (mode === "off") return { mode };
   const provider = process.env.STEWARD_AUDIT_CHECKPOINT_ANCHOR_PROVIDER?.trim() || "rfc3161";
   if (provider !== "rfc3161") {
-    const factory = registeredSinkFactories.get(provider);
-    if (!factory) {
+    const registration = registeredSinkProviders.get(provider);
+    if (!registration) {
       throw new AuditCheckpointAnchorError(
         `Checkpoint anchor provider ${provider} is not registered`,
       );
     }
-    return { mode, sink: factory() };
+    return {
+      mode,
+      provider,
+      sink: registration.factory(),
+      verify: registration.verify,
+    };
   }
   const url = process.env.STEWARD_AUDIT_RFC3161_URL?.trim();
   if (!url) {
@@ -549,6 +592,7 @@ export function configuredAuditCheckpointAnchor(): {
   };
   return {
     mode,
+    provider: "rfc3161",
     sink: new Rfc3161TimestampSink({
       url,
       timeoutMs,
@@ -561,17 +605,84 @@ export function configuredAuditCheckpointAnchor(): {
   };
 }
 
+function assertCustomAnchorProofShape(
+  checkpoint: SignedCheckpoint,
+  sink: AuditCheckpointAnchorSink,
+  provider: string,
+  proof: AuditCheckpointAnchorProof,
+): asserts proof is CustomCheckpointAnchorProof {
+  if (proof.type !== "custom") {
+    throw new AuditCheckpointAnchorError(
+      "Custom checkpoint anchor sink returned a non-custom proof",
+    );
+  }
+  if (
+    proof.v !== 1 ||
+    proof.provider !== provider ||
+    proof.sinkId !== sink.id ||
+    proof.hashAlgorithm !== "sha256" ||
+    proof.checkpointDigest !== auditCheckpointAnchorDigest(checkpoint) ||
+    !Number.isFinite(Date.parse(proof.verifiedAt)) ||
+    !proof.evidence ||
+    typeof proof.evidence !== "object" ||
+    Array.isArray(proof.evidence)
+  ) {
+    throw new AuditCheckpointAnchorError(
+      "Custom checkpoint anchor proof does not bind the configured provider, sink, and checkpoint",
+    );
+  }
+  let encoded: string;
+  try {
+    encoded = JSON.stringify(proof.evidence);
+  } catch {
+    throw new AuditCheckpointAnchorError(
+      "Custom checkpoint anchor evidence must be JSON serializable",
+    );
+  }
+  if (!encoded || new TextEncoder().encode(encoded).length > 1024 * 1024) {
+    throw new AuditCheckpointAnchorError(
+      "Custom checkpoint anchor evidence must be non-empty and at most 1 MiB",
+    );
+  }
+}
+
 /** Anchor according to environment policy; required mode never degrades silently. */
 export async function maybeAnchorAuditCheckpoint(
   checkpoint: SignedCheckpoint,
-  configured = configuredAuditCheckpointAnchor(),
-): Promise<Rfc3161CheckpointAnchorProof | undefined> {
+  configured: {
+    mode: AuditCheckpointAnchorMode;
+    sink?: AuditCheckpointAnchorSink;
+    provider?: string;
+    verify?: AuditCheckpointAnchorProofVerifier;
+  } = configuredAuditCheckpointAnchor(),
+): Promise<AuditCheckpointAnchorProof | undefined> {
   if (configured.mode === "off") return undefined;
   if (!configured.sink) {
     throw new AuditCheckpointAnchorError("Checkpoint anchor sink is not configured");
   }
   try {
-    return await configured.sink.anchor(checkpoint);
+    const proof = await configured.sink.anchor(checkpoint);
+    const provider = configured.provider ?? proof.type;
+    if (provider === "rfc3161") {
+      if (
+        proof.type !== "rfc3161" ||
+        proof.sinkId !== configured.sink.id ||
+        proof.checkpointDigest !== auditCheckpointAnchorDigest(checkpoint)
+      ) {
+        throw new AuditCheckpointAnchorError(
+          "RFC 3161 checkpoint proof does not bind the configured sink and checkpoint",
+        );
+      }
+      return proof;
+    }
+    if (!configured.verify) {
+      throw new AuditCheckpointAnchorError(
+        "Custom checkpoint anchor provider requires a proof verifier",
+      );
+    }
+    assertCustomAnchorProofShape(checkpoint, configured.sink, provider, proof);
+    await configured.verify(checkpoint, proof);
+    return { ...proof, verifiedAt: new Date().toISOString() };
   } catch (error) {
     if (configured.mode === "required") {
       throw error instanceof AuditCheckpointAnchorError

--- a/packages/api/src/services/audit-checkpoint-anchor.ts
+++ b/packages/api/src/services/audit-checkpoint-anchor.ts
@@ -1,0 +1,373 @@
+/**
+ * Optional third-party anchoring for signed audit checkpoints.
+ *
+ * Disabled means exactly disabled: no sink is constructed and no network call
+ * is made. RFC 3161 is the reference implementation; the interface is public
+ * so another append-only witness can be supplied without changing bundle
+ * assembly.
+ */
+
+import { createHash } from "node:crypto";
+import { canonicalCheckpointBytes, type SignedCheckpoint } from "./audit-checkpoint";
+
+export type AuditCheckpointAnchorMode = "off" | "best-effort" | "required";
+
+export interface Rfc3161CheckpointAnchorProof {
+  v: 1;
+  type: "rfc3161";
+  sinkId: string;
+  hashAlgorithm: "sha256";
+  /** SHA-256 of canonicalCheckpointBytes(checkpoint.payload). */
+  checkpointDigest: string;
+  /** Base64 DER TimeStampResp, including the TSA certificate when supplied. */
+  timestampResponse: string;
+}
+
+export interface AuditCheckpointAnchorSink {
+  readonly id: string;
+  anchor(checkpoint: SignedCheckpoint): Promise<Rfc3161CheckpointAnchorProof>;
+}
+
+export type AuditCheckpointAnchorSinkFactory = () => AuditCheckpointAnchorSink;
+
+const registeredSinkFactories = new Map<string, AuditCheckpointAnchorSinkFactory>();
+
+/** Register an operator-supplied append-only witness implementation. */
+export function registerAuditCheckpointAnchorSink(
+  provider: string,
+  factory: AuditCheckpointAnchorSinkFactory,
+): () => void {
+  if (!/^[a-z0-9][a-z0-9-]{0,63}$/.test(provider) || provider === "rfc3161") {
+    throw new AuditCheckpointAnchorError("Custom checkpoint anchor provider name is invalid");
+  }
+  if (registeredSinkFactories.has(provider)) {
+    throw new AuditCheckpointAnchorError(
+      `Checkpoint anchor provider ${provider} is already registered`,
+    );
+  }
+  registeredSinkFactories.set(provider, factory);
+  return () => {
+    if (registeredSinkFactories.get(provider) === factory) registeredSinkFactories.delete(provider);
+  };
+}
+
+export interface Rfc3161TimestampSinkOptions {
+  url: string;
+  timeoutMs?: number;
+  fetch?: typeof globalThis.fetch;
+}
+
+export class AuditCheckpointAnchorError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "AuditCheckpointAnchorError";
+  }
+}
+
+const MAX_TIMESTAMP_RESPONSE_BYTES = 1024 * 1024;
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+function concatBytes(...chunks: Uint8Array[]): Uint8Array {
+  const out = new Uint8Array(chunks.reduce((length, chunk) => length + chunk.length, 0));
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return out;
+}
+
+/** Digest anchored by the TSA. The Ed25519 signature authenticates these bytes separately. */
+export function auditCheckpointAnchorDigest(checkpoint: SignedCheckpoint): string {
+  return createHash("sha256").update(canonicalCheckpointBytes(checkpoint.payload)).digest("hex");
+}
+
+/**
+ * DER TimeStampReq v1 with SHA-256 MessageImprint and certReq=true.
+ * The fixed-size SHA-256 request uses only short-form DER lengths.
+ */
+export function createRfc3161TimestampQuery(checkpointDigest: string): Uint8Array {
+  if (!/^[0-9a-f]{64}$/.test(checkpointDigest)) {
+    throw new AuditCheckpointAnchorError(
+      "RFC 3161 checkpoint digest must be 32-byte lowercase hex",
+    );
+  }
+  const sha256AlgorithmIdentifier = Uint8Array.from([
+    0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x01, 0x05, 0x00,
+  ]);
+  const imprint = concatBytes(
+    Uint8Array.from([0x30, 0x31]),
+    sha256AlgorithmIdentifier,
+    Uint8Array.from([0x04, 0x20]),
+    hexToBytes(checkpointDigest),
+  );
+  return concatBytes(
+    Uint8Array.from([0x30, 0x39, 0x02, 0x01, 0x01]),
+    imprint,
+    Uint8Array.from([0x01, 0x01, 0xff]),
+  );
+}
+
+interface DerElement {
+  tag: number;
+  start: number;
+  contentStart: number;
+  end: number;
+}
+
+function readDerElement(bytes: Uint8Array, offset: number): DerElement {
+  const tag = bytes[offset];
+  const firstLength = bytes[offset + 1];
+  if (tag === undefined || firstLength === undefined) {
+    throw new AuditCheckpointAnchorError("RFC 3161 response is truncated");
+  }
+  let length = 0;
+  let contentStart = offset + 2;
+  if ((firstLength & 0x80) === 0) {
+    length = firstLength;
+  } else {
+    const lengthBytes = firstLength & 0x7f;
+    if (lengthBytes < 1 || lengthBytes > 3 || contentStart + lengthBytes > bytes.length) {
+      throw new AuditCheckpointAnchorError("RFC 3161 response has an invalid DER length");
+    }
+    if (bytes[contentStart] === 0) {
+      throw new AuditCheckpointAnchorError("RFC 3161 response has a non-canonical DER length");
+    }
+    for (let i = 0; i < lengthBytes; i++) length = length * 256 + bytes[contentStart + i];
+    if (length < 128) {
+      throw new AuditCheckpointAnchorError("RFC 3161 response has a non-canonical DER length");
+    }
+    contentStart += lengthBytes;
+  }
+  const end = contentStart + length;
+  if (end > bytes.length) throw new AuditCheckpointAnchorError("RFC 3161 response is truncated");
+  return { tag, start: offset, contentStart, end };
+}
+
+/** Reject malformed, denied, or token-less TSA responses before attaching them. */
+export function assertGrantedRfc3161Response(bytes: Uint8Array): void {
+  if (bytes.length < 7 || bytes.length > MAX_TIMESTAMP_RESPONSE_BYTES) {
+    throw new AuditCheckpointAnchorError("RFC 3161 response size is invalid");
+  }
+  const outer = readDerElement(bytes, 0);
+  if (outer.tag !== 0x30 || outer.end !== bytes.length) {
+    throw new AuditCheckpointAnchorError("RFC 3161 response is not one canonical DER sequence");
+  }
+  const statusInfo = readDerElement(bytes, outer.contentStart);
+  if (statusInfo.tag !== 0x30) {
+    throw new AuditCheckpointAnchorError("RFC 3161 response is missing PKIStatusInfo");
+  }
+  const status = readDerElement(bytes, statusInfo.contentStart);
+  if (status.tag !== 0x02 || status.end - status.contentStart !== 1) {
+    throw new AuditCheckpointAnchorError("RFC 3161 response has an invalid PKIStatus");
+  }
+  const statusValue = bytes[status.contentStart];
+  if (statusValue !== 0 && statusValue !== 1) {
+    throw new AuditCheckpointAnchorError(
+      `RFC 3161 TSA rejected the request (status ${statusValue})`,
+    );
+  }
+  if (statusInfo.end >= outer.end) {
+    throw new AuditCheckpointAnchorError(
+      "RFC 3161 granted response did not include a timestamp token",
+    );
+  }
+  const token = readDerElement(bytes, statusInfo.end);
+  if (token.tag !== 0x30 || token.end !== outer.end) {
+    throw new AuditCheckpointAnchorError("RFC 3161 response contains an invalid timestamp token");
+  }
+}
+
+function assertRfc3161ResponseContainsImprint(bytes: Uint8Array, digest: string): void {
+  const expected = concatBytes(Uint8Array.from([0x04, 0x20]), hexToBytes(digest));
+  outer: for (let offset = 0; offset <= bytes.length - expected.length; offset++) {
+    for (let i = 0; i < expected.length; i++) {
+      if (bytes[offset + i] !== expected[i]) continue outer;
+    }
+    return;
+  }
+  throw new AuditCheckpointAnchorError(
+    "RFC 3161 response does not contain the requested SHA-256 message imprint",
+  );
+}
+
+async function readTimestampResponse(response: Response): Promise<Uint8Array> {
+  if (!response.body) {
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    if (bytes.length > MAX_TIMESTAMP_RESPONSE_BYTES) {
+      throw new AuditCheckpointAnchorError("RFC 3161 response exceeds 1 MiB");
+    }
+    return bytes;
+  }
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      const chunk = value instanceof Uint8Array ? value : new Uint8Array(value);
+      total += chunk.length;
+      if (total > MAX_TIMESTAMP_RESPONSE_BYTES) {
+        await reader.cancel();
+        throw new AuditCheckpointAnchorError("RFC 3161 response exceeds 1 MiB");
+      }
+      chunks.push(chunk);
+    }
+    return concatBytes(...chunks);
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function validateTimestampUrl(raw: string): URL {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new AuditCheckpointAnchorError("STEWARD_AUDIT_RFC3161_URL must be a valid URL");
+  }
+  if (url.username || url.password) {
+    throw new AuditCheckpointAnchorError("RFC 3161 URL must not contain credentials");
+  }
+  if (url.protocol !== "https:" && process.env.NODE_ENV === "production") {
+    throw new AuditCheckpointAnchorError("RFC 3161 URL must use HTTPS in production");
+  }
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    throw new AuditCheckpointAnchorError("RFC 3161 URL must use HTTP or HTTPS");
+  }
+  return url;
+}
+
+export class Rfc3161TimestampSink implements AuditCheckpointAnchorSink {
+  readonly id = "rfc3161";
+  private readonly url: URL;
+  private readonly timeoutMs: number;
+  private readonly fetchImpl: typeof globalThis.fetch;
+
+  constructor(options: Rfc3161TimestampSinkOptions) {
+    this.url = validateTimestampUrl(options.url);
+    this.timeoutMs = options.timeoutMs ?? 10_000;
+    if (!Number.isSafeInteger(this.timeoutMs) || this.timeoutMs < 100 || this.timeoutMs > 60_000) {
+      throw new AuditCheckpointAnchorError("RFC 3161 timeout must be between 100 and 60000ms");
+    }
+    this.fetchImpl = options.fetch ?? globalThis.fetch;
+  }
+
+  async anchor(checkpoint: SignedCheckpoint): Promise<Rfc3161CheckpointAnchorProof> {
+    const checkpointDigest = auditCheckpointAnchorDigest(checkpoint);
+    const query = createRfc3161TimestampQuery(checkpointDigest);
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const response = await this.fetchImpl(this.url, {
+        method: "POST",
+        headers: {
+          Accept: "application/timestamp-reply",
+          "Content-Type": "application/timestamp-query",
+        },
+        // Both Node/Bun and Workers accept Uint8Array bodies. workers-types in
+        // this package narrows BodyInit incompatibly, so preserve the runtime
+        // value while widening only the compile-time view.
+        body: query as unknown as string,
+        redirect: "error",
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        throw new AuditCheckpointAnchorError(`RFC 3161 TSA returned HTTP ${response.status}`);
+      }
+      const declaredLength = Number(response.headers.get("content-length") ?? "0");
+      if (declaredLength > MAX_TIMESTAMP_RESPONSE_BYTES) {
+        throw new AuditCheckpointAnchorError("RFC 3161 response exceeds 1 MiB");
+      }
+      const bytes = await readTimestampResponse(response);
+      assertGrantedRfc3161Response(bytes);
+      assertRfc3161ResponseContainsImprint(bytes, checkpointDigest);
+      return {
+        v: 1,
+        type: "rfc3161",
+        sinkId: this.id,
+        hashAlgorithm: "sha256",
+        checkpointDigest,
+        timestampResponse: bytesToBase64(bytes),
+      };
+    } catch (error) {
+      if (error instanceof AuditCheckpointAnchorError) throw error;
+      throw new AuditCheckpointAnchorError("RFC 3161 timestamp request failed", {
+        cause: error,
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}
+
+function configuredMode(): AuditCheckpointAnchorMode {
+  const value = process.env.STEWARD_AUDIT_CHECKPOINT_ANCHOR_MODE?.trim() || "off";
+  if (value === "off" || value === "best-effort" || value === "required") return value;
+  throw new AuditCheckpointAnchorError(
+    "STEWARD_AUDIT_CHECKPOINT_ANCHOR_MODE must be off, best-effort, or required",
+  );
+}
+
+export function configuredAuditCheckpointAnchor(): {
+  mode: AuditCheckpointAnchorMode;
+  sink?: AuditCheckpointAnchorSink;
+} {
+  const mode = configuredMode();
+  if (mode === "off") return { mode };
+  const provider = process.env.STEWARD_AUDIT_CHECKPOINT_ANCHOR_PROVIDER?.trim() || "rfc3161";
+  if (provider !== "rfc3161") {
+    const factory = registeredSinkFactories.get(provider);
+    if (!factory) {
+      throw new AuditCheckpointAnchorError(
+        `Checkpoint anchor provider ${provider} is not registered`,
+      );
+    }
+    return { mode, sink: factory() };
+  }
+  const url = process.env.STEWARD_AUDIT_RFC3161_URL?.trim();
+  if (!url) {
+    throw new AuditCheckpointAnchorError(
+      "STEWARD_AUDIT_RFC3161_URL is required when checkpoint anchoring is enabled",
+    );
+  }
+  const rawTimeout = process.env.STEWARD_AUDIT_RFC3161_TIMEOUT_MS?.trim();
+  const timeoutMs = rawTimeout ? Number(rawTimeout) : undefined;
+  return { mode, sink: new Rfc3161TimestampSink({ url, timeoutMs }) };
+}
+
+/** Anchor according to environment policy; required mode never degrades silently. */
+export async function maybeAnchorAuditCheckpoint(
+  checkpoint: SignedCheckpoint,
+  configured = configuredAuditCheckpointAnchor(),
+): Promise<Rfc3161CheckpointAnchorProof | undefined> {
+  if (configured.mode === "off") return undefined;
+  if (!configured.sink) {
+    throw new AuditCheckpointAnchorError("Checkpoint anchor sink is not configured");
+  }
+  try {
+    return await configured.sink.anchor(checkpoint);
+  } catch (error) {
+    if (configured.mode === "required") {
+      throw error instanceof AuditCheckpointAnchorError
+        ? error
+        : new AuditCheckpointAnchorError("Required checkpoint anchoring failed", { cause: error });
+    }
+    console.error("[audit] best-effort checkpoint anchoring failed; returning unanchored bundle");
+    return undefined;
+  }
+}

--- a/packages/api/src/services/audit-checkpoint-anchor.ts
+++ b/packages/api/src/services/audit-checkpoint-anchor.ts
@@ -390,9 +390,13 @@ export function verifyRfc3161TimestampResponse(input: {
   }
 }
 
-async function readTimestampResponse(response: Response): Promise<Uint8Array> {
+async function readTimestampResponse(
+  response: Response,
+  signal: AbortSignal,
+  deadline: Promise<never>,
+): Promise<Uint8Array> {
   if (!response.body) {
-    const bytes = new Uint8Array(await response.arrayBuffer());
+    const bytes = new Uint8Array(await Promise.race([response.arrayBuffer(), deadline]));
     if (bytes.length > MAX_TIMESTAMP_RESPONSE_BYTES) {
       throw new AuditCheckpointAnchorError("RFC 3161 response exceeds 1 MiB");
     }
@@ -401,21 +405,31 @@ async function readTimestampResponse(response: Response): Promise<Uint8Array> {
   const reader = response.body.getReader();
   const chunks: Uint8Array[] = [];
   let total = 0;
+  const cancel = () => {
+    void Promise.resolve(reader.cancel()).catch(() => undefined);
+  };
+  signal.addEventListener("abort", cancel, { once: true });
   try {
     while (true) {
-      const { done, value } = await reader.read();
+      const { done, value } = await Promise.race([reader.read(), deadline]);
       if (done) break;
       const chunk = value instanceof Uint8Array ? value : new Uint8Array(value);
       total += chunk.length;
       if (total > MAX_TIMESTAMP_RESPONSE_BYTES) {
-        await reader.cancel();
+        cancel();
         throw new AuditCheckpointAnchorError("RFC 3161 response exceeds 1 MiB");
       }
       chunks.push(chunk);
     }
     return concatBytes(...chunks);
   } finally {
-    reader.releaseLock();
+    signal.removeEventListener("abort", cancel);
+    try {
+      reader.releaseLock();
+    } catch {
+      // A hostile or already-cancelled stream must not replace the sanitized
+      // transport error or extend the acquisition deadline.
+    }
   }
 }
 
@@ -465,21 +479,30 @@ export class Rfc3161TimestampSink implements AuditCheckpointAnchorSink {
     const query = createRfc3161TimestampQuery(checkpointDigest, nonceBytes);
     const requestStartedAt = Date.now();
     const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const deadline = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => {
+        reject(new AuditCheckpointAnchorError("RFC 3161 timestamp request timed out"));
+        controller.abort();
+      }, this.timeoutMs);
+    });
     try {
-      const response = await this.fetchImpl(this.url, {
-        method: "POST",
-        headers: {
-          Accept: "application/timestamp-reply",
-          "Content-Type": "application/timestamp-query",
-        },
-        // Both Node/Bun and Workers accept Uint8Array bodies. workers-types in
-        // this package narrows BodyInit incompatibly, so preserve the runtime
-        // value while widening only the compile-time view.
-        body: query as unknown as string,
-        redirect: "error",
-        signal: controller.signal,
-      });
+      const response = await Promise.race([
+        this.fetchImpl(this.url, {
+          method: "POST",
+          headers: {
+            Accept: "application/timestamp-reply",
+            "Content-Type": "application/timestamp-query",
+          },
+          // Both Node/Bun and Workers accept Uint8Array bodies. workers-types in
+          // this package narrows BodyInit incompatibly, so preserve the runtime
+          // value while widening only the compile-time view.
+          body: query as unknown as string,
+          redirect: "error",
+          signal: controller.signal,
+        }),
+        deadline,
+      ]);
       if (!response.ok) {
         throw new AuditCheckpointAnchorError(`RFC 3161 TSA returned HTTP ${response.status}`);
       }
@@ -497,7 +520,7 @@ export class Rfc3161TimestampSink implements AuditCheckpointAnchorSink {
       ) {
         throw new AuditCheckpointAnchorError("RFC 3161 response exceeds 1 MiB");
       }
-      const bytes = await readTimestampResponse(response);
+      const bytes = await readTimestampResponse(response, controller.signal, deadline);
       assertGrantedRfc3161Response(bytes);
       const verifiedAt = Date.now();
       const verified = verifyRfc3161TimestampResponse({
@@ -532,7 +555,7 @@ export class Rfc3161TimestampSink implements AuditCheckpointAnchorSink {
         cause: error,
       });
     } finally {
-      clearTimeout(timer);
+      if (timer) clearTimeout(timer);
     }
   }
 }

--- a/packages/api/src/services/audit-checkpoint.ts
+++ b/packages/api/src/services/audit-checkpoint.ts
@@ -23,8 +23,10 @@
  * BOTH the HMAC key and the signing key from constructing a self-consistent but
  * fabricated history and then signing it. The Ed25519 signature raises the bar
  * from "trust the operator's secret HMAC" to "trust the operator's published,
- * append-only, third-partyly-witnessable checkpoints"; anchoring beyond that
- * (third-party timestamping / transparency log) is explicitly out of scope for v1.
+ * append-only, third-party-witnessable checkpoints"; anchoring beyond that
+ * (third-party timestamping / transparency log) requires a separately trusted
+ * witness. The optional RFC 3161 hook anchors the canonical payload digest and
+ * keeps that narrower claim explicit.
  *
  * Zero new dependencies: uses node:crypto Ed25519 primitives.
  */

--- a/packages/api/src/services/audit.ts
+++ b/packages/api/src/services/audit.ts
@@ -36,6 +36,8 @@ import {
   getCheckpointSigner,
 } from "./audit-checkpoint";
 import {
+  AuditCheckpointAnchorError,
+  configuredAuditCheckpointAnchor,
   maybeAnchorAuditCheckpoint,
   type Rfc3161CheckpointAnchorProof,
 } from "./audit-checkpoint-anchor";
@@ -631,7 +633,8 @@ export async function signAuditBundle(
   // Default/off mode returns synchronously without constructing a sink or
   // touching the network. Required mode throws instead of emitting an
   // unanchored bundle; best-effort mode logs and preserves the v1 envelope.
-  const anchor = await maybeAnchorAuditCheckpoint(signed);
+  const anchorConfiguration = configuredAuditCheckpointAnchor();
+  const anchor = await maybeAnchorAuditCheckpoint(signed, anchorConfiguration);
   // Process-local operational gauge only. Durable checkpoint evidence is the
   // signed payload/table below and remains authoritative across restarts.
   try {
@@ -642,7 +645,11 @@ export async function signAuditBundle(
 
   // Persist the checkpoint (append-only provenance). Best-effort: a persistence
   // failure must not deny the auditor their signed bundle (self-contained).
-  if (head) {
+  // Unanchored empty exports retain the historical no-row behavior. Once a
+  // third-party proof exists, however, persist it even for the signed empty
+  // checkpoint: required mode must never return a proof that has no durable
+  // checkpoint binding.
+  if (head || anchor) {
     try {
       await getDb()
         .insert(auditCheckpoints)
@@ -653,8 +660,16 @@ export async function signAuditBundle(
           payload: checkpointPayload as unknown as Record<string, unknown>,
           signature: signed.signature,
           publicKey: signed.publicKey,
+          anchorProof: anchor as unknown as Record<string, unknown> | undefined,
+          anchorVerifiedAt: anchor ? new Date(anchor.verifiedAt) : undefined,
         });
     } catch (err) {
+      if (anchor && anchorConfiguration.mode === "required") {
+        throw new AuditCheckpointAnchorError(
+          "Required RFC 3161 checkpoint proof could not be persisted atomically",
+          { cause: err },
+        );
+      }
       console.error(`[audit] checkpoint persistence failed for tenant ${tenantId}:`, err);
     }
   }

--- a/packages/api/src/services/audit.ts
+++ b/packages/api/src/services/audit.ts
@@ -35,6 +35,10 @@ import {
   eventsContentDigest,
   getCheckpointSigner,
 } from "./audit-checkpoint";
+import {
+  maybeAnchorAuditCheckpoint,
+  type Rfc3161CheckpointAnchorProof,
+} from "./audit-checkpoint-anchor";
 import { API_VERSION } from "./version";
 
 /**
@@ -565,6 +569,7 @@ export interface SignedAuditBundle {
     payload: CheckpointPayload;
     signature: string;
     publicKey: string;
+    anchor?: Rfc3161CheckpointAnchorProof;
   };
   generatedAt: string;
 }
@@ -623,6 +628,10 @@ export async function signAuditBundle(
     eventsToSeq: events.length > 0 ? events[events.length - 1].seq : 0,
   };
   const signed = signer.sign(checkpointPayload);
+  // Default/off mode returns synchronously without constructing a sink or
+  // touching the network. Required mode throws instead of emitting an
+  // unanchored bundle; best-effort mode logs and preserves the v1 envelope.
+  const anchor = await maybeAnchorAuditCheckpoint(signed);
   // Process-local operational gauge only. Durable checkpoint evidence is the
   // signed payload/table below and remains authoritative across restarts.
   try {
@@ -665,6 +674,7 @@ export async function signAuditBundle(
       payload: signed.payload,
       signature: signed.signature,
       publicKey: signed.publicKey,
+      ...(anchor ? { anchor } : {}),
     },
     generatedAt: new Date().toISOString(),
   };

--- a/packages/api/src/services/audit.ts
+++ b/packages/api/src/services/audit.ts
@@ -37,9 +37,9 @@ import {
 } from "./audit-checkpoint";
 import {
   AuditCheckpointAnchorError,
+  type AuditCheckpointAnchorProof,
   configuredAuditCheckpointAnchor,
   maybeAnchorAuditCheckpoint,
-  type Rfc3161CheckpointAnchorProof,
 } from "./audit-checkpoint-anchor";
 import { API_VERSION } from "./version";
 
@@ -571,7 +571,7 @@ export interface SignedAuditBundle {
     payload: CheckpointPayload;
     signature: string;
     publicKey: string;
-    anchor?: Rfc3161CheckpointAnchorProof;
+    anchor?: AuditCheckpointAnchorProof;
   };
   generatedAt: string;
 }

--- a/packages/db/drizzle/0089_rfc3161_checkpoint_proofs.sql
+++ b/packages/db/drizzle/0089_rfc3161_checkpoint_proofs.sql
@@ -1,0 +1,26 @@
+-- Persist the exact independently verified RFC 3161 proof beside the signed
+-- checkpoint it timestamps. Rows are append-only evidence.
+
+ALTER TABLE "audit_checkpoints"
+  ADD COLUMN IF NOT EXISTS "anchor_proof" jsonb,
+  ADD COLUMN IF NOT EXISTS "anchor_verified_at" timestamptz;
+
+ALTER TABLE "audit_checkpoints"
+  DROP CONSTRAINT IF EXISTS "audit_checkpoints_anchor_complete";
+ALTER TABLE "audit_checkpoints"
+  ADD CONSTRAINT "audit_checkpoints_anchor_complete" CHECK (
+    ("anchor_proof" IS NULL AND "anchor_verified_at" IS NULL) OR
+    ("anchor_proof" IS NOT NULL AND "anchor_verified_at" IS NOT NULL)
+  );
+
+CREATE OR REPLACE FUNCTION steward_guard_audit_checkpoint_immutability()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  RAISE EXCEPTION 'audit checkpoints are append-only evidence';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS audit_checkpoints_immutability_guard ON audit_checkpoints;
+CREATE TRIGGER audit_checkpoints_immutability_guard
+BEFORE UPDATE OR DELETE ON audit_checkpoints
+FOR EACH ROW EXECUTE FUNCTION steward_guard_audit_checkpoint_immutability();

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -484,6 +484,13 @@
       "when": 1784745600000,
       "tag": "0088_provider_agent_budgets",
       "breakpoints": true
+    },
+    {
+      "idx": 89,
+      "version": "7",
+      "when": 1784832000000,
+      "tag": "0089_rfc3161_checkpoint_proofs",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -2643,6 +2643,8 @@ export const auditCheckpoints = pgTable(
     payload: jsonb("payload").$type<Record<string, unknown>>().notNull(),
     signature: text("signature").notNull(),
     publicKey: text("public_key").notNull(),
+    anchorProof: jsonb("anchor_proof").$type<Record<string, unknown>>(),
+    anchorVerifiedAt: timestamp("anchor_verified_at", { withTimezone: true }),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({

--- a/scripts/verify-evidence-bundle.mjs
+++ b/scripts/verify-evidence-bundle.mjs
@@ -244,13 +244,21 @@ function verifyRfc3161Anchor(anchor, payload, options) {
     if (policyOid !== anchor.policyOid || (options.tsaPolicy && policyOid !== options.tsaPolicy)) {
       fail("verified RFC 3161 policy OID is not allowed");
     }
-    const accuracyLine = inspected.stdout.match(/^Accuracy:\s*(.+)$/m)?.[1] ?? "";
+    const accuracyLine = inspected.stdout.match(/^Accuracy:\s*(.+)$/m)?.[1];
+    if (!accuracyLine || /^\s*unspecified\s*$/i.test(accuracyLine)) {
+      fail("verified RFC 3161 TSTInfo did not contain Accuracy");
+    }
+    let foundAccuracyComponent = false;
     const accuracyPart = (name, scale) => {
       const found = accuracyLine.match(new RegExp(`(?:0x([0-9a-f]+)|([0-9]+))\\s+${name}`, "i"));
+      if (found) foundAccuracyComponent = true;
       return found ? Number.parseInt(found[1] ?? found[2], found[1] ? 16 : 10) * scale : 0;
     };
     const accuracyMillis =
       accuracyPart("seconds", 1000) + accuracyPart("millis", 1) + accuracyPart("micros", 0.001);
+    if (!foundAccuracyComponent || !Number.isFinite(accuracyMillis) || accuracyMillis < 0) {
+      fail("verified RFC 3161 TSTInfo contained invalid Accuracy");
+    }
     if (accuracyMillis !== anchor.accuracyMillis || time.toISOString() !== anchor.genTime) {
       fail("RFC 3161 proof metadata does not match the signed TSTInfo");
     }

--- a/scripts/verify-evidence-bundle.mjs
+++ b/scripts/verify-evidence-bundle.mjs
@@ -3,7 +3,8 @@
 /**
  * Standalone offline verifier for a Steward audit evidence bundle.
  *
- * ZERO project imports, ZERO third-party dependencies — only Node builtins.
+ * ZERO project imports and ZERO package dependencies. Base bundle checks use
+ * only Node builtins; optional RFC 3161 trust verification invokes OpenSSL.
  * An auditor can run this on any machine with Node, holding nothing but the
  * bundle JSON (which carries its own Ed25519 public key). No Steward access, no
  * secret HMAC key.
@@ -43,11 +44,16 @@
  *     is present is internally consistent, its contents are authentic, and (when
  *     it reaches the head) it matches the signed head. A gap BELOW the first
  *     exported seq is expected for partial exports.
- *   • It does not timestamp-anchor the checkpoint externally (out of scope v1).
+ *   • RFC 3161 verification is optional and trusts only an auditor-supplied
+ *     TSA CA. Anchoring narrows the pre-anchor rewrite window; it does not make
+ *     the system tamper-proof or operator-proof.
  */
 
+import { spawnSync } from "node:child_process";
 import { createHash, createPublicKey, verify as edVerify } from "node:crypto";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 function fail(msg, seq) {
   const at = seq === undefined ? "" : ` (seq ${seq})`;
@@ -58,7 +64,7 @@ function fail(msg, seq) {
 function usage(msg) {
   console.error(`usage error: ${msg}`);
   console.error(
-    "  node scripts/verify-evidence-bundle.mjs <bundle.json> [--expected-key-fingerprint <hex>]",
+    "  node scripts/verify-evidence-bundle.mjs <bundle.json> [--expected-key-fingerprint <hex>] [--tsa-ca <pem>]",
   );
   console.error("  cat bundle.json | node scripts/verify-evidence-bundle.mjs [--fp <hex>]");
   console.error("");
@@ -67,6 +73,12 @@ function usage(msg) {
   console.error("       STEWARD_EXPECTED_AUDIT_KEY_FP (comma-separated). If absent, the verifier");
   console.error("       prints the observed fingerprint and states trust-root matching is the");
   console.error("       auditor responsibility.");
+  console.error(
+    "  --tsa-ca <pem>  Verify an included RFC 3161 token against this auditor-supplied CA.",
+  );
+  console.error("  --tsa-untrusted <pem>  Optional intermediate TSA certificate chain.");
+  console.error("  --require-anchor  Fail unless an RFC 3161 proof is present and verifies.");
+  console.error("  --anchored-before <ISO-8601>  Require verified TSA time at/before this bound.");
   process.exit(2);
 }
 
@@ -75,6 +87,10 @@ function parseArgs() {
   const argv = process.argv.slice(2);
   let bundleArg;
   const expectedFps = [];
+  let tsaCa;
+  let tsaUntrusted;
+  let requireAnchor = false;
+  let anchoredBefore;
   const clean = (s) => s.toLowerCase().replace(/[^0-9a-f]/g, "");
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
@@ -85,8 +101,21 @@ function parseArgs() {
       i++;
     } else if (a.startsWith("--expected-key-fingerprint=") || a.startsWith("--fp=")) {
       expectedFps.push(clean(a.slice(a.indexOf("=") + 1)));
+    } else if (a === "--tsa-ca" || a === "--tsa-untrusted" || a === "--anchored-before") {
+      const v = argv[i + 1];
+      if (!v) usage(`${a} requires a value`);
+      if (a === "--tsa-ca") tsaCa = v;
+      if (a === "--tsa-untrusted") tsaUntrusted = v;
+      if (a === "--anchored-before") anchoredBefore = v;
+      i++;
+    } else if (a === "--require-anchor") {
+      requireAnchor = true;
+    } else if (a.startsWith("--")) {
+      usage(`unknown option ${a}`);
     } else if (!bundleArg) {
       bundleArg = a;
+    } else {
+      usage(`unexpected positional argument ${a}`);
     }
   }
   const envFp = process.env.STEWARD_EXPECTED_AUDIT_KEY_FP;
@@ -96,7 +125,98 @@ function parseArgs() {
       if (c) expectedFps.push(c);
     }
   }
-  return { bundleArg, expectedFps };
+  if (anchoredBefore && !Number.isFinite(new Date(anchoredBefore).getTime())) {
+    usage("--anchored-before must be a valid ISO-8601 timestamp");
+  }
+  if (tsaUntrusted && !tsaCa) usage("--tsa-untrusted requires --tsa-ca");
+  if ((requireAnchor || anchoredBefore) && !tsaCa) {
+    usage("--require-anchor/--anchored-before require an auditor-supplied --tsa-ca");
+  }
+  return { bundleArg, expectedFps, tsaCa, tsaUntrusted, requireAnchor, anchoredBefore };
+}
+
+function checkpointAnchorDigest(payload) {
+  return createHash("sha256").update(canonicalCheckpointBytes(payload)).digest("hex");
+}
+
+function strictBase64(value, name) {
+  if (typeof value !== "string" || !/^[A-Za-z0-9+/]+={0,2}$/.test(value)) {
+    fail(`${name} is not canonical base64`);
+  }
+  const decoded = Buffer.from(value, "base64");
+  if (decoded.length === 0 || decoded.toString("base64") !== value) {
+    fail(`${name} is not canonical base64`);
+  }
+  return decoded;
+}
+
+function verifyRfc3161Anchor(anchor, payload, options) {
+  if (!anchor) {
+    if (options.requireAnchor || options.tsaCa || options.anchoredBefore) {
+      fail("required RFC 3161 checkpoint anchor is missing");
+    }
+    return { present: false, verified: false, time: null };
+  }
+  if (
+    anchor.v !== 1 ||
+    anchor.type !== "rfc3161" ||
+    anchor.hashAlgorithm !== "sha256" ||
+    typeof anchor.sinkId !== "string" ||
+    !/^[0-9a-f]{64}$/.test(anchor.checkpointDigest)
+  ) {
+    fail("checkpoint RFC 3161 anchor schema is invalid");
+  }
+  const digest = checkpointAnchorDigest(payload);
+  if (anchor.checkpointDigest !== digest) {
+    fail("RFC 3161 anchor digest does not match the signed checkpoint payload");
+  }
+  const response = strictBase64(anchor.timestampResponse, "RFC 3161 timestampResponse");
+  if (response.length > 1024 * 1024) fail("RFC 3161 timestampResponse exceeds 1 MiB");
+  if (!options.tsaCa) return { present: true, verified: false, time: null };
+
+  const dir = mkdtempSync(join(tmpdir(), "steward-rfc3161-"));
+  const responsePath = join(dir, "response.tsr");
+  try {
+    writeFileSync(responsePath, response, { mode: 0o600 });
+    const verifyArgs = [
+      "ts",
+      "-verify",
+      "-digest",
+      digest,
+      "-in",
+      responsePath,
+      "-CAfile",
+      options.tsaCa,
+    ];
+    if (options.tsaUntrusted) verifyArgs.push("-untrusted", options.tsaUntrusted);
+    const verified = spawnSync("openssl", verifyArgs, {
+      encoding: "utf8",
+      timeout: 30_000,
+    });
+    if (verified.error) fail(`could not run OpenSSL RFC 3161 verifier: ${verified.error.message}`);
+    if (verified.status !== 0) {
+      fail(`RFC 3161 token verification failed: ${(verified.stderr || verified.stdout).trim()}`);
+    }
+    const inspected = spawnSync("openssl", ["ts", "-reply", "-in", responsePath, "-text"], {
+      encoding: "utf8",
+      timeout: 30_000,
+    });
+    if (inspected.error || inspected.status !== 0) {
+      fail("verified RFC 3161 token could not be inspected for its timestamp");
+    }
+    const match = inspected.stdout.match(/^Time stamp:\s*(.+)$/m);
+    if (!match) fail("verified RFC 3161 token did not contain a timestamp");
+    const time = new Date(match[1]);
+    if (!Number.isFinite(time.getTime())) fail("RFC 3161 token timestamp is not parseable");
+    if (options.anchoredBefore && time > new Date(options.anchoredBefore)) {
+      fail(
+        `RFC 3161 anchor time ${time.toISOString()} is after required bound ${options.anchoredBefore}`,
+      );
+    }
+    return { present: true, verified: true, time: time.toISOString() };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 }
 
 // SHA-256 fingerprint of a signing key SPKI DER (spec §7.1/§7.2, C6).
@@ -191,7 +311,8 @@ function eventsContentDigest(events, tenantId) {
 }
 
 function main() {
-  const { bundleArg, expectedFps } = parseArgs();
+  const options = parseArgs();
+  const { bundleArg, expectedFps } = options;
   const input = loadBundle(bundleArg);
 
   if (!input || typeof input !== "object") fail("bundle is not an object");
@@ -240,6 +361,10 @@ function main() {
   }
   const sigOk = edVerify(null, canonicalCheckpointBytes(payload), pubKeyObj, sigBytes);
   if (!sigOk) fail("Ed25519 checkpoint signature does not verify");
+
+  // Optional third-party time proof. Its message imprint MUST bind the exact
+  // canonical checkpoint payload. Trust comes only from an auditor-supplied CA.
+  const anchorResult = verifyRfc3161Anchor(checkpoint.anchor, payload, options);
 
   // ── Trust-root fingerprint match (spec §7.1/§7.2, C6) ────────────────────
   // The bundle is self-describing (it carries its own public key); an auditor
@@ -359,6 +484,15 @@ function main() {
   console.log(`  signature:     Ed25519 OK`);
   console.log(`  content:       SHA-256 events digest OK`);
   console.log(`  linkage:       OK`);
+  console.log(
+    `  anchor:        ${
+      anchorResult.verified
+        ? `RFC 3161 verified; checkpoint existed no later than ${anchorResult.time}`
+        : anchorResult.present
+          ? "RFC 3161 proof present but NOT trusted; supply --tsa-ca"
+          : "not present (optional)"
+    }`,
+  );
   if (manifest)
     console.log(`  manifest:      cross-check OK (every fact backed by a signed event)`);
   console.log(`  head:          ${headNote}`);
@@ -378,6 +512,9 @@ function main() {
       (trustRootChecked
         ? "the signing key matches an auditor-supplied trusted fingerprint; "
         : "") +
+      (anchorResult.verified
+        ? `a trusted TSA proves the checkpoint existed no later than ${anchorResult.time}; `
+        : "") +
       "the checkpoint is authentically Ed25519-signed and unaltered.",
   );
   console.log(
@@ -385,7 +522,9 @@ function main() {
       "operator holding BOTH the HMAC key AND the signing key could fabricate a " +
       "self-consistent history; that the export is the complete history; " +
       (trustRootChecked ? "" : "trust-root binding (no expected fingerprint supplied); ") +
-      "out-of-band time anchoring.",
+      (anchorResult.verified
+        ? "events after the anchor or TSA/operator collusion. Anchoring narrows the pre-anchor rewrite window; it is not operator-proof."
+        : "out-of-band time anchoring."),
   );
   process.exit(0);
 }

--- a/scripts/verify-evidence-bundle.mjs
+++ b/scripts/verify-evidence-bundle.mjs
@@ -77,6 +77,7 @@ function usage(msg) {
     "  --tsa-ca <pem>  Verify an included RFC 3161 token against this auditor-supplied CA.",
   );
   console.error("  --tsa-untrusted <pem>  Optional intermediate TSA certificate chain.");
+  console.error("  --tsa-policy <oid>  Require the signed TSTInfo policy OID.");
   console.error("  --require-anchor  Fail unless an RFC 3161 proof is present and verifies.");
   console.error("  --anchored-before <ISO-8601>  Require verified TSA time at/before this bound.");
   process.exit(2);
@@ -91,6 +92,7 @@ function parseArgs() {
   let tsaUntrusted;
   let requireAnchor = false;
   let anchoredBefore;
+  let tsaPolicy;
   const clean = (s) => s.toLowerCase().replace(/[^0-9a-f]/g, "");
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
@@ -101,12 +103,18 @@ function parseArgs() {
       i++;
     } else if (a.startsWith("--expected-key-fingerprint=") || a.startsWith("--fp=")) {
       expectedFps.push(clean(a.slice(a.indexOf("=") + 1)));
-    } else if (a === "--tsa-ca" || a === "--tsa-untrusted" || a === "--anchored-before") {
+    } else if (
+      a === "--tsa-ca" ||
+      a === "--tsa-untrusted" ||
+      a === "--anchored-before" ||
+      a === "--tsa-policy"
+    ) {
       const v = argv[i + 1];
       if (!v) usage(`${a} requires a value`);
       if (a === "--tsa-ca") tsaCa = v;
       if (a === "--tsa-untrusted") tsaUntrusted = v;
       if (a === "--anchored-before") anchoredBefore = v;
+      if (a === "--tsa-policy") tsaPolicy = v;
       i++;
     } else if (a === "--require-anchor") {
       requireAnchor = true;
@@ -132,7 +140,15 @@ function parseArgs() {
   if ((requireAnchor || anchoredBefore) && !tsaCa) {
     usage("--require-anchor/--anchored-before require an auditor-supplied --tsa-ca");
   }
-  return { bundleArg, expectedFps, tsaCa, tsaUntrusted, requireAnchor, anchoredBefore };
+  return {
+    bundleArg,
+    expectedFps,
+    tsaCa,
+    tsaUntrusted,
+    tsaPolicy,
+    requireAnchor,
+    anchoredBefore,
+  };
 }
 
 function checkpointAnchorDigest(payload) {
@@ -162,7 +178,16 @@ function verifyRfc3161Anchor(anchor, payload, options) {
     anchor.type !== "rfc3161" ||
     anchor.hashAlgorithm !== "sha256" ||
     typeof anchor.sinkId !== "string" ||
-    !/^[0-9a-f]{64}$/.test(anchor.checkpointDigest)
+    !/^[0-9a-f]{64}$/.test(anchor.checkpointDigest) ||
+    !/^[0-9a-f]{32}$/.test(anchor.nonce) ||
+    typeof anchor.policyOid !== "string" ||
+    typeof anchor.genTime !== "string" ||
+    !Number.isFinite(Date.parse(anchor.genTime)) ||
+    !Number.isFinite(anchor.accuracyMillis) ||
+    anchor.accuracyMillis < 0 ||
+    typeof anchor.verifiedAt !== "string" ||
+    !Number.isFinite(Date.parse(anchor.verifiedAt)) ||
+    !/^[0-9a-f]{64}$/.test(anchor.trustAnchorSha256)
   ) {
     fail("checkpoint RFC 3161 anchor schema is invalid");
   }
@@ -178,6 +203,17 @@ function verifyRfc3161Anchor(anchor, payload, options) {
   const responsePath = join(dir, "response.tsr");
   try {
     writeFileSync(responsePath, response, { mode: 0o600 });
+    const inspected = spawnSync("openssl", ["ts", "-reply", "-in", responsePath, "-text"], {
+      encoding: "utf8",
+      timeout: 30_000,
+    });
+    if (inspected.error || inspected.status !== 0) {
+      fail("RFC 3161 token could not be inspected for its timestamp");
+    }
+    const match = inspected.stdout.match(/^Time stamp:\s*(.+)$/m);
+    if (!match) fail("RFC 3161 token did not contain a timestamp");
+    const time = new Date(match[1]);
+    if (!Number.isFinite(time.getTime())) fail("RFC 3161 token timestamp is not parseable");
     const verifyArgs = [
       "ts",
       "-verify",
@@ -187,6 +223,8 @@ function verifyRfc3161Anchor(anchor, payload, options) {
       responsePath,
       "-CAfile",
       options.tsaCa,
+      "-attime",
+      String(Math.floor(time.getTime() / 1000)),
     ];
     if (options.tsaUntrusted) verifyArgs.push("-untrusted", options.tsaUntrusted);
     const verified = spawnSync("openssl", verifyArgs, {
@@ -197,23 +235,37 @@ function verifyRfc3161Anchor(anchor, payload, options) {
     if (verified.status !== 0) {
       fail(`RFC 3161 token verification failed: ${(verified.stderr || verified.stdout).trim()}`);
     }
-    const inspected = spawnSync("openssl", ["ts", "-reply", "-in", responsePath, "-text"], {
-      encoding: "utf8",
-      timeout: 30_000,
-    });
-    if (inspected.error || inspected.status !== 0) {
-      fail("verified RFC 3161 token could not be inspected for its timestamp");
+    const policyOid = inspected.stdout.match(/^Policy OID:\s*([^\s]+)\s*$/m)?.[1];
+    const nonceText = inspected.stdout.match(/^Nonce:\s*(0x[0-9a-f]+|[0-9]+)\s*$/im)?.[1];
+    if (!policyOid || !nonceText) fail("verified RFC 3161 TSTInfo is missing policy or nonce");
+    const tokenNonce = BigInt(nonceText).toString(16).padStart(32, "0");
+    if (tokenNonce !== anchor.nonce)
+      fail("verified RFC 3161 nonce does not match the proof binding");
+    if (policyOid !== anchor.policyOid || (options.tsaPolicy && policyOid !== options.tsaPolicy)) {
+      fail("verified RFC 3161 policy OID is not allowed");
     }
-    const match = inspected.stdout.match(/^Time stamp:\s*(.+)$/m);
-    if (!match) fail("verified RFC 3161 token did not contain a timestamp");
-    const time = new Date(match[1]);
-    if (!Number.isFinite(time.getTime())) fail("RFC 3161 token timestamp is not parseable");
-    if (options.anchoredBefore && time > new Date(options.anchoredBefore)) {
+    const accuracyLine = inspected.stdout.match(/^Accuracy:\s*(.+)$/m)?.[1] ?? "";
+    const accuracyPart = (name, scale) => {
+      const found = accuracyLine.match(new RegExp(`(?:0x([0-9a-f]+)|([0-9]+))\\s+${name}`, "i"));
+      return found ? Number.parseInt(found[1] ?? found[2], found[1] ? 16 : 10) * scale : 0;
+    };
+    const accuracyMillis =
+      accuracyPart("seconds", 1000) + accuracyPart("millis", 1) + accuracyPart("micros", 0.001);
+    if (accuracyMillis !== anchor.accuracyMillis || time.toISOString() !== anchor.genTime) {
+      fail("RFC 3161 proof metadata does not match the signed TSTInfo");
+    }
+    const latestTime = new Date(time.getTime() + accuracyMillis);
+    if (options.anchoredBefore && latestTime > new Date(options.anchoredBefore)) {
       fail(
-        `RFC 3161 anchor time ${time.toISOString()} is after required bound ${options.anchoredBefore}`,
+        `RFC 3161 latest accuracy bound ${latestTime.toISOString()} is after required bound ${options.anchoredBefore}`,
       );
     }
-    return { present: true, verified: true, time: time.toISOString() };
+    return {
+      present: true,
+      verified: true,
+      time: time.toISOString(),
+      latestTime: latestTime.toISOString(),
+    };
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
Closes #215.

Replacement for #286 after deep security review.

## What changed
- replaces the shallow DER byte scan with strict OpenSSL RFC3161 verification of the TimeStampResp CMS SignedData/TSTInfo, original SHA-256 imprint, signed nonce, timestamping EKU/signature, and configured CA path
- generates a fresh unpredictable 128-bit nonce for every request and binds it into the persisted proof
- enforces optional exact TSA policy OID plus accuracy-aware past-age and future-skew bounds
- validates the TSA certificate path at signed `genTime` for long-term verification semantics; documents offline CRL/OCSP and evidence-retention boundaries
- copies trust material before verification and fingerprints the exact copied CA bytes, removing trust-file TOCTOU
- persists the exact verified token, nonce, policy, time/accuracy, verification time, and trust-anchor fingerprint atomically with the signed checkpoint
- makes checkpoint rows append-only at the database layer; required mode fails closed if durable proof persistence fails
- upgrades the offline verifier to validate CMS/path/imprint, nonce, policy and persisted metadata, with accuracy-aware `--anchored-before`
- preserves the pluggable optional sink interface and default-off behavior, without claiming a periodic schedule or operator-proof guarantee

## Validation (exact head)
- `bunx biome check ...` (all modified TS/JS): pass
- focused anchoring/checkpoint/provider/evidence suites: 49 pass, 0 fail, 140 assertions
- real OpenSSL CA + timeStamping certificate E2E: pass, including fake-CMS, wrong-nonce, stale-token, wrong-imprint, metadata-tamper, cutoff, and append-only persistence failures
- PGLite migration chain applies 0088 then 0089: pass
- `bun run --cwd packages/db build`: pass
- `bun run --cwd packages/api build`: pass

Migration: 0089, stacked on #304 / 0088 exact head `7a4d0200c3673a1701111905fabf0d62e3315e34`.
