### PR TITLE
feat(security): make Gate D sandbox harness executable

### DIFF
--- a/deploy/enterprise-reference/provider-github-sandbox.env.example
+++ b/deploy/enterprise-reference/provider-github-sandbox.env.example
@@ -15,7 +15,9 @@
 # fails the build if real sandbox credentials appear in tracked files.
 #
 # Least privilege: the GitHub App installation must be scoped to the throwaway
-# sandbox repo only, with `issues:read` + `pull_requests:write` and nothing else.
+# sandbox repo only, with `metadata:read` + `issues:write` and nothing else.
+# GitHub pull-request comments are issue comments; pull_requests:write does not
+# grant permission to create them.
 
 # GitHub App identity for the throwaway sandbox org.
 # Numeric App ID from the App's settings page.
@@ -41,10 +43,36 @@ STEWARD_SANDBOX_GITHUB_PR_NUMBER=
 #   STEWARD_AUDIT_HMAC_KEY, STEWARD_AUDIT_SIGNING_KEY (PR5 /evidence).
 STEWARD_API_URL=
 STEWARD_TENANT_ID=
-# Machine credential (tenant API key) for non-interactive provisioning. Supply
-# out-of-band; never a default.
-STEWARD_TENANT_KEY=
+
+# A provider-agent JWT for the pre-provisioned sandbox agent and an owner/admin
+# browser-session JWT carrying a recent MFA claim. The latter is required for
+# secret rotation, approval, case, and evidence. The harness does not mint or
+# weaken either credential.
+STEWARD_AGENT_JWT=
+STEWARD_APPROVER_JWT=
+
+# IDs of the pre-provisioned, sandbox-only authority graph. The credential
+# route must already be governed_v2 and limited to api.github.com plus the one
+# comment-create path/operation. Provisioning is deliberately not smuggled into
+# the live run.
+STEWARD_SANDBOX_WORKSPACE_ID=
+STEWARD_SANDBOX_PROVIDER_ACCOUNT_ID=
+STEWARD_SANDBOX_SECRET_ID=
+
+# The isolated dispatch worker imports the trusted dispatcher directly. These
+# values must be identical to the live Steward deployment; there is no public
+# dispatch endpoint and no caller-forgeable dispatch context.
+DATABASE_URL=
+STEWARD_MASTER_PASSWORD=
+STEWARD_EXECUTION_AUTH_SECRET=
+STEWARD_AUDIT_HMAC_KEY=
+STEWARD_AUDIT_SIGNING_KEY=
 
 # Out-of-band fingerprint of the trusted audit signing key (SHA-256 of the SPKI
 # PEM) so the offline verifier binds trust to a known root (PR5 E7 / M09).
 STEWARD_AUDIT_SIGNING_KEY_FINGERPRINT=
+
+# Optional bounded crash-window timeout (default 2000ms). The worker pauses
+# only after the upstream response, then the parent kills that isolated worker.
+# This models an ambiguous process crash and the fresh-worker replay guard.
+STEWARD_SANDBOX_CHILD_TIMEOUT_MS=

--- a/docs/guides/provider-authority-golden-path.mdx
+++ b/docs/guides/provider-authority-golden-path.mdx
@@ -100,8 +100,12 @@ execute over the public API, then starts an isolated local worker that imports
 `dispatchGovernedExecution`. There is intentionally no public dispatch route.
 
 The write operation (`github.pr.comment.create`) is **not** natively idempotent
-at GitHub. The harness pauses the isolated worker after the upstream response,
-kills it to model the crash window, and proves a fresh worker cannot re-post.
+at GitHub. The harness first rotates the sandbox secret after mint to prove stale
+credentials fail before provider I/O. It then races eight isolated workers,
+pauses the single upstream winner after the response, kills it to model the
+crash window, and proves a fresh worker cannot re-post. Every minted GitHub
+installation token is explicitly revoked after reconciliation (with GitHub's
+short expiry as the failure-path backstop).
 Because Steward has no live reconciliation service, the harness then performs a
 bounded, paginated, read-only GitHub marker lookup and records that distinction
 in `provider-reconciliation.json`. A missing marker is a Gate D STOP, not a

--- a/docs/guides/provider-authority-golden-path.mdx
+++ b/docs/guides/provider-authority-golden-path.mdx
@@ -70,24 +70,45 @@ cp deploy/enterprise-reference/provider-github-sandbox.env.example \
 # ...fill from your secret store, then:
 set -a; . deploy/enterprise-reference/provider-github-sandbox.env; set +a
 
+# Build the trusted dispatcher and its workspace dependencies. The harness
+# checks these outputs but never installs or builds code implicitly.
+bunx turbo run build --filter=@stwd/proxy...
+
 # Validate wiring without a consequential write:
 node scripts/provider-authority-sandbox.mjs --preflight
+
+# Run only after the throwaway authority graph is provisioned. This exits 2
+# with honest Gate D STOP when a required live observation was not seen.
+node scripts/provider-authority-sandbox.mjs
 ```
 
 Requirements:
 
 - A **throwaway** GitHub org + repo (e.g. `steward-sandbox/hello`) with a
-  dedicated GitHub App scoped to that repo only (`issues:read`,
-  `pull_requests:write`).
+  dedicated GitHub App scoped to that repo only (`metadata:read`,
+  `issues:write`). GitHub pull-request comments use the Issues comments API.
 - The App private key + installation ID supplied via **env only**
   (`GITHUB_APP_ID`, `GITHUB_APP_INSTALLATION_ID`, `GITHUB_APP_PRIVATE_KEY`).
   The committed artifact is a `*.example` with placeholders and presence guards.
+- Pre-provisioned sandbox-only workspace, provider account, governed secret
+  route, provider-agent JWT, recent-MFA approver session, and the database/vault/
+  execution/audit environment used by that same Steward deployment.
+
+`--preflight` performs no network request. The live command rotates the minted
+installation token through the MFA-gated secret API, drives create → approve →
+execute over the public API, then starts an isolated local worker that imports
+`dispatchGovernedExecution`. There is intentionally no public dispatch route.
 
 The write operation (`github.pr.comment.create`) is **not** natively idempotent
-at GitHub; on a post-dispatch timeout Steward records `outcome_unknown` and
-reconciles via the created comment's stable `id`/`node_id` marker rather than
-blindly re-posting. A rate-limit (429/403 with `Retry-After`) is classified as a
-bounded `failed` with the retry-after surfaced, never auto-retried.
+at GitHub. The harness pauses the isolated worker after the upstream response,
+kills it to model the crash window, and proves a fresh worker cannot re-post.
+Because Steward has no live reconciliation service, the harness then performs a
+bounded, paginated, read-only GitHub marker lookup and records that distinction
+in `provider-reconciliation.json`. A missing marker is a Gate D STOP, not a
+success. A rate-limit (429/403 with `Retry-After`) is classified with capped
+waiting and no blind write retry; when no live rate-limit occurs, M16 is recorded
+as `not_observed` and Gate D remains STOP even though the classifier is tested
+hermetically.
 
 ## 3. Offline verification
 

--- a/scripts/__tests__/provider-authority-sandbox.test.ts
+++ b/scripts/__tests__/provider-authority-sandbox.test.ts
@@ -8,15 +8,18 @@ import { join } from "node:path";
 import {
   buildDispatchEnvironment,
   classifyGithubResponse,
+  isLiveRateLimitObservation,
   mintGithubAppJwt,
-  mintInstallationToken,
+  mintInstallationCredential,
   parseRetryAfter,
   reconcileGithubMarker,
   requestJson,
+  revokeInstallationToken,
   scrub,
   validateBuildPrerequisites,
   validateEnvironment,
   validateServiceUrl,
+  verifyInstallationScope,
 } from "../lib/provider-authority-sandbox-lib.mjs";
 import { runDispatchChild } from "../provider-authority-sandbox.mjs";
 
@@ -183,19 +186,69 @@ describe("provider authority sandbox operator primitives", () => {
       expect(request.method).toBe("POST");
       expect(request.headers.authorization).toStartWith("Bearer ey");
       response.writeHead(201, { "content-type": "application/json" });
-      response.end(JSON.stringify({ token: canary }));
+      response.end(
+        JSON.stringify({
+          token: canary,
+          expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+          permissions: { metadata: "read", issues: "write" },
+          repository_selection: "selected",
+        }),
+      );
     });
-    expect(
-      await mintInstallationToken({
-        GITHUB_APP_ID: "42",
-        GITHUB_APP_INSTALLATION_ID: "7",
-        GITHUB_APP_PRIVATE_KEY: pem,
-        GITHUB_API_URL: base,
-      }),
-    ).toBe(canary);
+    const credential = await mintInstallationCredential({
+      GITHUB_APP_ID: "42",
+      GITHUB_APP_INSTALLATION_ID: "7",
+      GITHUB_APP_PRIVATE_KEY: pem,
+      GITHUB_API_URL: base,
+    });
+    expect(credential.token).toBe(canary);
+    expect(credential.permissions).toEqual({ metadata: "read", issues: "write" });
     expect(scrub({ authorization: `Bearer ${canary}`, token: canary }, [canary])).not.toContain(
       canary,
     );
+
+    let revokedAuthorization = "";
+    await revokeInstallationToken(canary, async (_url, options) => {
+      revokedAuthorization = new Headers(options?.headers).get("authorization") ?? "";
+      return new Response(null, { status: 204 });
+    });
+    expect(revokedAuthorization).toBe(`Bearer ${canary}`);
+  });
+
+  it("rejects API redirection and verifies exact App permissions and repository scope", async () => {
+    const env = envFixture();
+    env.GITHUB_API_URL = "https://attacker.example";
+    expect(() => validateEnvironment(env)).toThrow("https://api.github.com");
+
+    const base = await fakeServer((_request, response) => {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(
+        JSON.stringify({
+          total_count: 1,
+          repositories: [{ full_name: "sandbox-owner/sandbox-repo" }],
+        }),
+      );
+    });
+    await expect(
+      verifyInstallationScope(
+        {
+          token: "token",
+          permissions: { metadata: "read", issues: "write" },
+          repositorySelection: "selected",
+        },
+        { owner: "sandbox-owner", repo: "sandbox-repo", apiBase: base },
+      ),
+    ).resolves.toBeUndefined();
+    await expect(
+      verifyInstallationScope(
+        {
+          token: "token",
+          permissions: { metadata: "read", issues: "write", contents: "read" },
+          repositorySelection: "selected",
+        },
+        { owner: "sandbox-owner", repo: "sandbox-repo", apiBase: base },
+      ),
+    ).rejects.toThrow("permissions");
   });
 
   it("finds a marker across bounded pagination and reports a bounded miss", async () => {
@@ -239,6 +292,20 @@ describe("provider authority sandbox operator primitives", () => {
     });
     expect(miss.outcome).toBe("definitive_miss");
     expect(miss.requests).toBe(2);
+
+    const truncated = await reconcileGithubMarker({
+      owner: "o",
+      repo: "r",
+      pullNumber: 1,
+      marker: "absent",
+      token: "secret",
+      maxAttempts: 1,
+      maxPages: 1,
+      fetchImpl: async () =>
+        Response.json(Array.from({ length: 100 }, (_, id) => ({ id, body: "other" }))),
+    });
+    expect(truncated.outcome).toBe("indeterminate");
+    expect(truncated.classification.classification).toBe("pagination_bound_exhausted");
   });
 
   it("classifies 403/429 and caps Retry-After", async () => {
@@ -247,6 +314,20 @@ describe("provider authority sandbox operator primitives", () => {
     );
     expect(classifyGithubResponse(403).classification).toBe("request_failure");
     expect(classifyGithubResponse(429).boundedFailure).toBe(true);
+    expect(
+      isLiveRateLimitObservation({
+        status: 403,
+        classification: "request_failure",
+        retryAfter: null,
+      }),
+    ).toBe(false);
+    expect(
+      isLiveRateLimitObservation({
+        status: 429,
+        classification: "rate_limited",
+        retryAfter: "1",
+      }),
+    ).toBe(true);
     expect(parseRetryAfter("99", 1500)).toBe(1500);
     const waits: number[] = [];
     const result = await reconcileGithubMarker({

--- a/scripts/__tests__/provider-authority-sandbox.test.ts
+++ b/scripts/__tests__/provider-authority-sandbox.test.ts
@@ -12,9 +12,11 @@ import {
   mintInstallationToken,
   parseRetryAfter,
   reconcileGithubMarker,
+  requestJson,
   scrub,
   validateBuildPrerequisites,
   validateEnvironment,
+  validateServiceUrl,
 } from "../lib/provider-authority-sandbox-lib.mjs";
 import { runDispatchChild } from "../provider-authority-sandbox.mjs";
 
@@ -32,7 +34,7 @@ async function fakeServer(handler: Parameters<typeof createServer>[0]) {
 
 function envFixture() {
   const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
-  return Object.fromEntries(
+  const env = Object.fromEntries(
     [
       "GITHUB_APP_ID",
       "GITHUB_APP_INSTALLATION_ID",
@@ -61,6 +63,8 @@ function envFixture() {
         ],
       ]),
   );
+  env.STEWARD_API_URL = "https://steward.sandbox.test";
+  return env;
 }
 
 describe("provider authority sandbox operator primitives", () => {
@@ -89,6 +93,35 @@ describe("provider authority sandbox operator primitives", () => {
       globalThis.fetch = original;
     }
     expect(calls).toBe(0);
+  });
+
+  it("rejects credential-bearing and public plaintext service URLs", () => {
+    expect(() => validateServiceUrl("STEWARD_API_URL", "http://api.example.test")).toThrow(
+      "must use HTTPS",
+    );
+    expect(() => validateServiceUrl("GITHUB_API_URL", "https://user:secret@github.test")).toThrow(
+      "must not contain credentials",
+    );
+    expect(() => validateServiceUrl("GITHUB_API_URL", "http://127.0.0.1:3000")).not.toThrow();
+  });
+
+  it("bounds declared and streamed HTTP bodies", async () => {
+    for (const response of [
+      new Response("{}", { headers: { "content-length": "1048577" } }),
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new Uint8Array(1024 * 1024));
+            controller.enqueue(new Uint8Array([1]));
+            controller.close();
+          },
+        }),
+      ),
+    ]) {
+      await expect(
+        requestJson("https://api.example.test", {}, (async () => response) as typeof fetch),
+      ).rejects.toThrow("exceeded the 1 MiB sandbox limit");
+    }
   });
 
   it("fails closed with the exact build prerequisite command", () => {

--- a/scripts/__tests__/provider-authority-sandbox.test.ts
+++ b/scripts/__tests__/provider-authority-sandbox.test.ts
@@ -1,0 +1,267 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { generateKeyPairSync, verify } from "node:crypto";
+import { EventEmitter } from "node:events";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  buildDispatchEnvironment,
+  classifyGithubResponse,
+  mintGithubAppJwt,
+  mintInstallationToken,
+  parseRetryAfter,
+  reconcileGithubMarker,
+  scrub,
+  validateBuildPrerequisites,
+  validateEnvironment,
+} from "../lib/provider-authority-sandbox-lib.mjs";
+import { runDispatchChild } from "../provider-authority-sandbox.mjs";
+
+const servers: Server[] = [];
+afterEach(() => servers.splice(0).forEach((server) => server.close()));
+
+async function fakeServer(handler: Parameters<typeof createServer>[0]) {
+  const server = createServer(handler);
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("no test address");
+  return `http://127.0.0.1:${address.port}`;
+}
+
+function envFixture() {
+  const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  return Object.fromEntries(
+    [
+      "GITHUB_APP_ID",
+      "GITHUB_APP_INSTALLATION_ID",
+      "STEWARD_SANDBOX_GITHUB_OWNER",
+      "STEWARD_SANDBOX_GITHUB_REPO",
+      "STEWARD_SANDBOX_GITHUB_PR_NUMBER",
+      "STEWARD_API_URL",
+      "STEWARD_TENANT_ID",
+      "STEWARD_AGENT_JWT",
+      "STEWARD_APPROVER_JWT",
+      "STEWARD_SANDBOX_WORKSPACE_ID",
+      "STEWARD_SANDBOX_PROVIDER_ACCOUNT_ID",
+      "STEWARD_SANDBOX_SECRET_ID",
+      "STEWARD_AUDIT_SIGNING_KEY_FINGERPRINT",
+      "DATABASE_URL",
+      "STEWARD_MASTER_PASSWORD",
+      "STEWARD_EXECUTION_AUTH_SECRET",
+      "STEWARD_AUDIT_HMAC_KEY",
+    ]
+      .map((key) => [key, `real-${key.toLowerCase()}`])
+      .concat([
+        ["GITHUB_APP_PRIVATE_KEY", privateKey.export({ format: "pem", type: "pkcs8" }).toString()],
+        [
+          "STEWARD_AUDIT_SIGNING_KEY",
+          "-----BEGIN PRIVATE KEY-----\nnot-a-placeholder\n-----END PRIVATE KEY-----",
+        ],
+      ]),
+  );
+}
+
+describe("provider authority sandbox operator primitives", () => {
+  it("fails closed and names missing variables without exposing present secrets", () => {
+    const env = envFixture();
+    const canary = env.STEWARD_AGENT_JWT;
+    delete env.DATABASE_URL;
+    expect(() => validateEnvironment(env)).toThrow("DATABASE_URL");
+    try {
+      validateEnvironment(env);
+    } catch (error) {
+      expect(String(error)).not.toContain(canary);
+    }
+  });
+
+  it("preflight validation is pure and performs no network", () => {
+    let calls = 0;
+    const original = globalThis.fetch;
+    globalThis.fetch = ((..._args: unknown[]) => {
+      calls++;
+      throw new Error("network forbidden");
+    }) as typeof fetch;
+    try {
+      validateEnvironment(envFixture());
+    } finally {
+      globalThis.fetch = original;
+    }
+    expect(calls).toBe(0);
+  });
+
+  it("fails closed with the exact build prerequisite command", () => {
+    const root = mkdtempSync(join(tmpdir(), "steward-sandbox-build-"));
+    expect(() => validateBuildPrerequisites(root)).toThrow(
+      "bunx turbo run build --filter=@stwd/proxy...",
+    );
+    for (const path of [
+      "packages/shared/dist/index.js",
+      "packages/redis/dist/index.js",
+      "packages/attestation/dist/index.js",
+    ]) {
+      mkdirSync(join(root, path, ".."), { recursive: true });
+      writeFileSync(join(root, path), "export {};\n");
+    }
+    expect(() => validateBuildPrerequisites(root)).not.toThrow();
+  });
+
+  it("mints a signed RS256 GitHub App JWT and exchanges it without logging token", async () => {
+    const { privateKey, publicKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const pem = privateKey.export({ format: "pem", type: "pkcs8" }).toString();
+    const jwt = mintGithubAppJwt("42", pem, 1_800_000_000);
+    const [head, body, signature] = jwt.split(".");
+    expect(JSON.parse(Buffer.from(head, "base64url").toString())).toEqual({
+      alg: "RS256",
+      typ: "JWT",
+    });
+    expect(JSON.parse(Buffer.from(body, "base64url").toString()).iss).toBe("42");
+    expect(
+      verify(
+        "RSA-SHA256",
+        Buffer.from(`${head}.${body}`),
+        publicKey,
+        Buffer.from(signature, "base64url"),
+      ),
+    ).toBe(true);
+
+    const canary = "ghs_NEVER_WRITE_THIS_TOKEN";
+    const base = await fakeServer((request, response) => {
+      expect(request.method).toBe("POST");
+      expect(request.headers.authorization).toStartWith("Bearer ey");
+      response.writeHead(201, { "content-type": "application/json" });
+      response.end(JSON.stringify({ token: canary }));
+    });
+    expect(
+      await mintInstallationToken({
+        GITHUB_APP_ID: "42",
+        GITHUB_APP_INSTALLATION_ID: "7",
+        GITHUB_APP_PRIVATE_KEY: pem,
+        GITHUB_API_URL: base,
+      }),
+    ).toBe(canary);
+    expect(scrub({ authorization: `Bearer ${canary}`, token: canary }, [canary])).not.toContain(
+      canary,
+    );
+  });
+
+  it("finds a marker across bounded pagination and reports a bounded miss", async () => {
+    let calls = 0;
+    const base = await fakeServer((_request, response) => {
+      calls++;
+      response.writeHead(200, { "content-type": "application/json" });
+      const rows =
+        calls === 1
+          ? Array.from({ length: 100 }, (_, id) => ({ id, body: "other" }))
+          : [{ id: 999, body: "marker-123" }];
+      response.end(JSON.stringify(rows));
+    });
+    const found = await reconcileGithubMarker({
+      apiBase: base,
+      owner: "o",
+      repo: "r",
+      pullNumber: 1,
+      marker: "marker-123",
+      token: "secret",
+      maxAttempts: 1,
+      maxPages: 2,
+    });
+    expect(found.outcome).toBe("found");
+    expect(found.requests).toBe(2);
+
+    const missBase = await fakeServer((_request, response) => {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end("[]");
+    });
+    const miss = await reconcileGithubMarker({
+      apiBase: missBase,
+      owner: "o",
+      repo: "r",
+      pullNumber: 1,
+      marker: "absent",
+      token: "secret",
+      maxAttempts: 2,
+      maxPages: 3,
+      sleep: async () => {},
+    });
+    expect(miss.outcome).toBe("definitive_miss");
+    expect(miss.requests).toBe(2);
+  });
+
+  it("classifies 403/429 and caps Retry-After", async () => {
+    expect(classifyGithubResponse(403, new Headers({ "retry-after": "99" })).classification).toBe(
+      "rate_limited",
+    );
+    expect(classifyGithubResponse(403).classification).toBe("request_failure");
+    expect(classifyGithubResponse(429).boundedFailure).toBe(true);
+    expect(parseRetryAfter("99", 1500)).toBe(1500);
+    const waits: number[] = [];
+    const result = await reconcileGithubMarker({
+      owner: "o",
+      repo: "r",
+      pullNumber: 1,
+      marker: "m",
+      token: "secret",
+      maxAttempts: 2,
+      retryAfterCapMs: 7,
+      fetchImpl: async () => new Response("{}", { status: 429, headers: { "retry-after": "100" } }),
+      sleep: async (ms) => {
+        waits.push(ms);
+      },
+    });
+    expect(result.outcome).toBe("indeterminate");
+    expect(result.requests).toBe(2);
+    expect(Math.max(...waits)).toBeLessThanOrEqual(7);
+  });
+
+  it("kills only after the child proves it crossed the upstream barrier", async () => {
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: EventEmitter;
+      stderr: EventEmitter;
+      kill: (signal: string) => void;
+    };
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.kill = (signal) => child.emit("close", null, signal);
+    const spawnImpl = () => {
+      setTimeout(() => child.stdout.emit("data", Buffer.from('{"phase":"after_upstream"}\n')), 1);
+      return child;
+    };
+    const result = await runDispatchChild({ STEWARD_TENANT_ID: "tenant" }, "intent", {
+      pauseAfterUpstream: true,
+      timeoutMs: 1,
+      spawnImpl,
+    });
+    expect(result.reachedAfterUpstream).toBe(true);
+    expect(result.timedOut).toBe(true);
+  });
+
+  it("scrubs tokens, authorization values, and PEM blocks from every surface", () => {
+    const token = "ghs_CANARY_NOT_FOR_ARTIFACTS";
+    const pem = "-----BEGIN PRIVATE KEY-----\nCANARY_PRIVATE\n-----END PRIVATE KEY-----";
+    const output = scrub({ stdout: `Bearer ${token}`, stderr: token, artifact: pem }, [token, pem]);
+    expect(output).not.toContain(token);
+    expect(output).not.toContain("CANARY_PRIVATE");
+    expect(output).toContain("[REDACTED]");
+  });
+
+  it("does not pass GitHub credentials or API JWTs to the dispatch child", () => {
+    const childEnv = buildDispatchEnvironment(
+      {
+        PATH: "/bin",
+        DATABASE_URL: "postgres://db",
+        STEWARD_MASTER_PASSWORD: "master",
+        STEWARD_EXECUTION_AUTH_SECRET: "execution",
+        GITHUB_APP_PRIVATE_KEY: "private-canary",
+        STEWARD_AGENT_JWT: "agent-canary",
+        STEWARD_APPROVER_JWT: "approver-canary",
+      },
+      true,
+    );
+    expect(childEnv.DATABASE_URL).toBe("postgres://db");
+    expect(childEnv.STEWARD_EXECUTION_AUTH_SECRET).toBe("execution");
+    expect(JSON.stringify(childEnv)).not.toContain("canary");
+    expect(childEnv.STEWARD_SANDBOX_AFTER_UPSTREAM_PAUSE_MS).toBe("30000");
+  });
+});

--- a/scripts/__tests__/provider-authority-sandbox.test.ts
+++ b/scripts/__tests__/provider-authority-sandbox.test.ts
@@ -21,7 +21,11 @@ import {
   validateServiceUrl,
   verifyInstallationScope,
 } from "../lib/provider-authority-sandbox-lib.mjs";
-import { runDispatchChild } from "../provider-authority-sandbox.mjs";
+import {
+  prepareApprovedWrite,
+  requireRawCaseManifest,
+  runDispatchChild,
+} from "../provider-authority-sandbox.mjs";
 
 const servers: Server[] = [];
 afterEach(() => servers.splice(0).forEach((server) => server.close()));
@@ -242,13 +246,60 @@ describe("provider authority sandbox operator primitives", () => {
     await expect(
       verifyInstallationScope(
         {
-          token: "token",
+          token: "ghs_SCOPE_CANARY_MUST_NOT_LEAK",
           permissions: { metadata: "read", issues: "write", contents: "read" },
           repositorySelection: "selected",
         },
         { owner: "sandbox-owner", repo: "sandbox-repo", apiBase: base },
       ),
     ).rejects.toThrow("permissions");
+    try {
+      await verifyInstallationScope(
+        {
+          token: "ghs_SCOPE_CANARY_MUST_NOT_LEAK",
+          permissions: { metadata: "read" },
+          repositorySelection: "selected",
+        },
+        { owner: "sandbox-owner", repo: "sandbox-repo", apiBase: base },
+      );
+    } catch (error) {
+      expect(String(error)).not.toContain("ghs_SCOPE_CANARY_MUST_NOT_LEAK");
+    }
+  });
+
+  it("uses the no-body execute contract and accepts the live raw case shape", async () => {
+    const calls: Array<{ path: string; options: RequestInit }> = [];
+    const stewardImpl = async (
+      _env: Record<string, string>,
+      path: string,
+      _token: string,
+      options: RequestInit = {},
+    ) => {
+      calls.push({ path, options });
+      if (path === "/v2/provider-actions") {
+        return {
+          id: "pa_test",
+          status: "pending_approval",
+          requestHash: `sha256:${"a".repeat(64)}`,
+          actionDigest: `sha256:${"b".repeat(64)}`,
+        };
+      }
+      if (path.endsWith("/approval") && options.method !== "POST") {
+        return { data: { version: 1 } };
+      }
+      if (path.endsWith("/execute")) return { status: "execution_ready" };
+      return { status: "approved" };
+    };
+    await prepareApprovedWrite(envFixture(), "marker", "body", stewardImpl);
+    const execute = calls.find((call) => call.path.endsWith("/execute"));
+    expect(execute?.options).toEqual({ method: "POST" });
+    expect(execute?.options.body).toBeUndefined();
+
+    const raw = { schemaVersion: "steward.provider-case-manifest.v1", caseId: "pa_test" };
+    expect(requireRawCaseManifest(raw, "pa_test")).toBe(raw);
+    expect(() => requireRawCaseManifest({ manifest: raw }, "pa_test")).toThrow(
+      "expected case manifest",
+    );
   });
 
   it("finds a marker across bounded pagination and reports a bounded miss", async () => {

--- a/scripts/__tests__/provider-authority-sandbox.test.ts
+++ b/scripts/__tests__/provider-authority-sandbox.test.ts
@@ -150,6 +150,51 @@ describe("provider authority sandbox operator primitives", () => {
     expect(redirectMode).toBe("error");
   });
 
+  it("rejects an actual redirect without contacting its destination", async () => {
+    let destinationCalls = 0;
+    const base = await fakeServer((request, response) => {
+      if (request.url === "/destination") destinationCalls++;
+      if (request.url === "/redirect") {
+        response.writeHead(302, { location: `${base}/destination` });
+        response.end();
+        return;
+      }
+      response.end("{}");
+    });
+    await expect(
+      requestJson(`${base}/redirect`, {}, fetch, { expectedOrigin: base }),
+    ).rejects.toThrow();
+    expect(destinationCalls).toBe(0);
+  });
+
+  it("enforces its own deadline even when the caller supplies a non-aborting signal", async () => {
+    const base = await fakeServer((_request, _response) => {
+      // Intentionally never respond; requestJson's deadline must abort this.
+    });
+    await expect(
+      requestJson(`${base}/slow`, { signal: new AbortController().signal }, fetch, {
+        expectedOrigin: base,
+        timeoutMs: 20,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("pins the request origin before sending credentials", async () => {
+    let calls = 0;
+    await expect(
+      requestJson(
+        "https://attacker.example/token",
+        { headers: { authorization: "Bearer canary" } },
+        (async () => {
+          calls++;
+          return new Response("{}");
+        }) as typeof fetch,
+        { expectedOrigin: "https://api.github.com" },
+      ),
+    ).rejects.toThrow("origin mismatch");
+    expect(calls).toBe(0);
+  });
+
   it("fails closed with the exact build prerequisite command", () => {
     const root = mkdtempSync(join(tmpdir(), "steward-sandbox-build-"));
     expect(() => validateBuildPrerequisites(root)).toThrow(

--- a/scripts/__tests__/provider-authority-sandbox.test.ts
+++ b/scripts/__tests__/provider-authority-sandbox.test.ts
@@ -95,7 +95,7 @@ describe("provider authority sandbox operator primitives", () => {
     expect(calls).toBe(0);
   });
 
-  it("rejects credential-bearing and public plaintext service URLs", () => {
+  it("rejects credential-bearing and public plaintext service URLs", async () => {
     expect(() => validateServiceUrl("STEWARD_API_URL", "http://api.example.test")).toThrow(
       "must use HTTPS",
     );
@@ -103,6 +103,16 @@ describe("provider authority sandbox operator primitives", () => {
       "must not contain credentials",
     );
     expect(() => validateServiceUrl("GITHUB_API_URL", "http://127.0.0.1:3000")).not.toThrow();
+    await expect(
+      reconcileGithubMarker({
+        apiBase: "http://api.example.test",
+        owner: "o",
+        repo: "r",
+        pullNumber: 1,
+        marker: "m",
+        token: "secret",
+      }),
+    ).rejects.toThrow("must use HTTPS");
   });
 
   it("bounds declared and streamed HTTP bodies", async () => {
@@ -122,6 +132,15 @@ describe("provider authority sandbox operator primitives", () => {
         requestJson("https://api.example.test", {}, (async () => response) as typeof fetch),
       ).rejects.toThrow("exceeded the 1 MiB sandbox limit");
     }
+  });
+
+  it("disables HTTP redirects before credential-bearing fetches", async () => {
+    let redirectMode: RequestRedirect | undefined;
+    await requestJson("https://api.example.test", {}, (async (_url, options) => {
+      redirectMode = options?.redirect;
+      return new Response("{}");
+    }) as typeof fetch);
+    expect(redirectMode).toBe("error");
   });
 
   it("fails closed with the exact build prerequisite command", () => {
@@ -268,6 +287,46 @@ describe("provider authority sandbox operator primitives", () => {
     });
     expect(result.reachedAfterUpstream).toBe(true);
     expect(result.timedOut).toBe(true);
+    expect(result.outputExceeded).toBe(false);
+  });
+
+  it("fails the child result closed when output exceeds one MiB", async () => {
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: EventEmitter;
+      stderr: EventEmitter;
+      kill: (signal: string) => void;
+    };
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.kill = (signal) => child.emit("close", null, signal);
+    const spawnImpl = () => {
+      setTimeout(() => child.stderr.emit("data", Buffer.alloc(1024 * 1024 + 1)), 1);
+      return child;
+    };
+    const result = await runDispatchChild({ STEWARD_TENANT_ID: "tenant" }, "intent", { spawnImpl });
+    expect(result.outputExceeded).toBe(true);
+    expect(result.timedOut).toBe(false);
+  });
+
+  it("records child spawn errors without copying the OS error text", async () => {
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: EventEmitter;
+      stderr: EventEmitter;
+      kill: (signal: string) => void;
+    };
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.kill = () => {};
+    const spawnImpl = () => {
+      setTimeout(() => {
+        child.emit("error", new Error("CANARY_OS_ERROR"));
+        child.emit("close", -2, null);
+      }, 1);
+      return child;
+    };
+    const result = await runDispatchChild({ STEWARD_TENANT_ID: "tenant" }, "intent", { spawnImpl });
+    expect(result.spawnError).toBe(true);
+    expect(JSON.stringify(result)).not.toContain("CANARY_OS_ERROR");
   });
 
   it("scrubs tokens, authorization values, and PEM blocks from every surface", () => {

--- a/scripts/lib/provider-authority-sandbox-lib.mjs
+++ b/scripts/lib/provider-authority-sandbox-lib.mjs
@@ -1,0 +1,259 @@
+import { createSign } from "node:crypto";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+export const REQUIRED_ENV = [
+  "GITHUB_APP_ID",
+  "GITHUB_APP_INSTALLATION_ID",
+  "GITHUB_APP_PRIVATE_KEY",
+  "STEWARD_SANDBOX_GITHUB_OWNER",
+  "STEWARD_SANDBOX_GITHUB_REPO",
+  "STEWARD_SANDBOX_GITHUB_PR_NUMBER",
+  "STEWARD_API_URL",
+  "STEWARD_TENANT_ID",
+  "STEWARD_AGENT_JWT",
+  "STEWARD_APPROVER_JWT",
+  "STEWARD_SANDBOX_WORKSPACE_ID",
+  "STEWARD_SANDBOX_PROVIDER_ACCOUNT_ID",
+  "STEWARD_SANDBOX_SECRET_ID",
+  "STEWARD_AUDIT_SIGNING_KEY_FINGERPRINT",
+  "DATABASE_URL",
+  "STEWARD_MASTER_PASSWORD",
+  "STEWARD_EXECUTION_AUTH_SECRET",
+  "STEWARD_AUDIT_HMAC_KEY",
+  "STEWARD_AUDIT_SIGNING_KEY",
+];
+
+const PLACEHOLDER_RE = /(change[-_]?me|placeholder|example|your[-_]|xxx+|todo)/i;
+const REQUIRED_BUILD_OUTPUTS = [
+  "packages/shared/dist/index.js",
+  "packages/redis/dist/index.js",
+  "packages/attestation/dist/index.js",
+];
+
+export function validateBuildPrerequisites(root) {
+  const missing = REQUIRED_BUILD_OUTPUTS.filter((path) => !existsSync(join(root, path)));
+  if (missing.length) {
+    throw new Error(
+      `workspace build outputs missing (${missing.join(", ")}); run: bunx turbo run build --filter=@stwd/proxy...`,
+    );
+  }
+}
+
+const DISPATCH_ENV_KEYS = new Set([
+  "PATH",
+  "HOME",
+  "TMPDIR",
+  "NODE_ENV",
+  "NODE_EXTRA_CA_CERTS",
+  "SSL_CERT_FILE",
+  "DATABASE_DRIVER",
+  "DATABASE_URL",
+  "REDIS_DRIVER",
+  "REDIS_URL",
+  "REDIS_REQUIRED",
+  "KV_REST_API_URL",
+  "KV_REST_API_TOKEN",
+  "UPSTASH_REDIS_REST_URL",
+  "UPSTASH_REDIS_REST_TOKEN",
+  "STEWARD_DB_MODE",
+  "STEWARD_MASTER_PASSWORD",
+  "STEWARD_KDF_SALT",
+  "STEWARD_KMS_PROVIDER",
+  "STEWARD_KMS_KEY_ID",
+  "STEWARD_AWS_KMS_KEY_ARN",
+  "STEWARD_AWS_REGION",
+  "AWS_REGION",
+  "STEWARD_PKCS11_MODULE",
+  "STEWARD_PKCS11_PIN",
+  "STEWARD_PKCS11_KEY_LABEL",
+  "STEWARD_EXECUTION_AUTH_SECRET",
+  "STEWARD_AUDIT_HMAC_KEY",
+  "STEWARD_AUDIT_SIGNING_KEY",
+  "STEWARD_SECRET_ROUTE_ALLOWED_HOSTS",
+  "STEWARD_PROXY_IDEMPOTENCY_BODY_BYTES",
+  "STEWARD_PROXY_IDEMPOTENCY_TTL_MS",
+  "STEWARD_PROXY_MAX_IN_FLIGHT_PER_AGENT",
+  "STEWARD_PROXY_MAX_IN_FLIGHT_PER_TENANT",
+  "STEWARD_PROXY_MAX_SPEND_BODY_BYTES",
+  "STEWARD_PROXY_RESPONSE_BYTES",
+  "STEWARD_PROXY_STREAM_DURATION_MS",
+  "STEWARD_PROXY_UPSTREAM_TIMEOUT_MS",
+  "STEWARD_ALLOW_PROXY_REDIS_SOFT_FAIL",
+]);
+
+/** Least-privilege child env: notably excludes App keys, provider tokens, and JWTs. */
+export function buildDispatchEnvironment(env, pauseAfterUpstream = false) {
+  const selected = {};
+  for (const key of DISPATCH_ENV_KEYS) {
+    if (typeof env[key] === "string") selected[key] = env[key];
+  }
+  if (pauseAfterUpstream) selected.STEWARD_SANDBOX_AFTER_UPSTREAM_PAUSE_MS = "30000";
+  return selected;
+}
+
+export function validateEnvironment(env) {
+  const missing = [];
+  const placeholders = [];
+  for (const key of REQUIRED_ENV) {
+    const value = env[key];
+    if (typeof value !== "string" || value.trim() === "") missing.push(key);
+    else if (key.endsWith("PRIVATE_KEY") || key === "STEWARD_AUDIT_SIGNING_KEY") {
+      if (!value.includes("PRIVATE KEY")) placeholders.push(`${key} (not a PEM)`);
+    } else if (PLACEHOLDER_RE.test(value)) placeholders.push(key);
+  }
+  if (missing.length || placeholders.length) {
+    const parts = [];
+    if (missing.length) parts.push(`missing required env: ${missing.join(", ")}`);
+    if (placeholders.length) parts.push(`placeholder value(s): ${placeholders.join(", ")}`);
+    throw new Error(parts.join("; "));
+  }
+}
+
+const b64url = (value) => Buffer.from(value).toString("base64url");
+
+export function mintGithubAppJwt(appId, privateKey, now = Math.floor(Date.now() / 1000)) {
+  const head = b64url(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+  const body = b64url(JSON.stringify({ iat: now - 30, exp: now + 540, iss: appId }));
+  const unsigned = `${head}.${body}`;
+  const signer = createSign("RSA-SHA256");
+  signer.update(unsigned);
+  signer.end();
+  return `${unsigned}.${signer.sign(privateKey).toString("base64url")}`;
+}
+
+export async function requestJson(url, options, fetchImpl = fetch) {
+  const response = await fetchImpl(url, options);
+  const text = await response.text();
+  let body = null;
+  if (text) {
+    try {
+      body = JSON.parse(text);
+    } catch {
+      body = { unparseable: true };
+    }
+  }
+  return { response, body };
+}
+
+export async function mintInstallationToken(env, fetchImpl = fetch) {
+  const jwt = mintGithubAppJwt(env.GITHUB_APP_ID, env.GITHUB_APP_PRIVATE_KEY);
+  const base = (env.GITHUB_API_URL ?? "https://api.github.com").replace(/\/$/, "");
+  const { response, body } = await requestJson(
+    `${base}/app/installations/${encodeURIComponent(env.GITHUB_APP_INSTALLATION_ID)}/access_tokens`,
+    {
+      method: "POST",
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${jwt}`,
+        "user-agent": "steward-gate-d-sandbox",
+        "x-github-api-version": "2022-11-28",
+      },
+    },
+    fetchImpl,
+  );
+  if (!response.ok || typeof body?.token !== "string") {
+    throw new Error(`GitHub installation token mint failed (${response.status})`);
+  }
+  return body.token;
+}
+
+export function parseRetryAfter(value, capMs, now = Date.now()) {
+  if (!value) return 0;
+  const seconds = Number(value);
+  const requested = Number.isFinite(seconds)
+    ? Math.max(0, seconds * 1000)
+    : Math.max(0, Date.parse(value) - now);
+  return Number.isFinite(requested) ? Math.min(requested, capMs) : 0;
+}
+
+export function classifyGithubResponse(status, headers = new Headers()) {
+  const rateLimited403 =
+    status === 403 && (headers.has("retry-after") || headers.get("x-ratelimit-remaining") === "0");
+  if (status === 429 || rateLimited403)
+    return {
+      classification: "rate_limited",
+      retryAfter: headers.get("retry-after"),
+      boundedFailure: true,
+    };
+  if (status >= 500) return { classification: "upstream_failure", boundedFailure: true };
+  if (status >= 400) return { classification: "request_failure", boundedFailure: true };
+  return { classification: "ok", boundedFailure: false };
+}
+
+/** Bounded, read-only reconciliation; this function never writes provider data. */
+export async function reconcileGithubMarker({
+  apiBase = "https://api.github.com",
+  owner,
+  repo,
+  pullNumber,
+  marker,
+  token,
+  maxAttempts = 3,
+  maxPages = 3,
+  retryAfterCapMs = 2_000,
+  fetchImpl = fetch,
+  sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+}) {
+  let requests = 0;
+  let rateLimited = false;
+  const observations = [];
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    for (let page = 1; page <= maxPages; page++) {
+      requests++;
+      const url = `${apiBase.replace(/\/$/, "")}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/issues/${encodeURIComponent(pullNumber)}/comments?per_page=100&page=${page}`;
+      const response = await fetchImpl(url, {
+        headers: {
+          accept: "application/vnd.github+json",
+          authorization: `Bearer ${token}`,
+          "user-agent": "steward-gate-d-sandbox",
+          "x-github-api-version": "2022-11-28",
+        },
+      });
+      const classification = classifyGithubResponse(response.status, response.headers);
+      observations.push({
+        attempt,
+        page,
+        status: response.status,
+        classification: classification.classification,
+      });
+      if (classification.classification === "rate_limited") {
+        rateLimited = true;
+        await sleep(parseRetryAfter(classification.retryAfter, retryAfterCapMs));
+        break;
+      }
+      if (!response.ok) return { outcome: "indeterminate", requests, observations, classification };
+      const rows = await response.json();
+      if (!Array.isArray(rows))
+        return {
+          outcome: "indeterminate",
+          requests,
+          observations,
+          classification: { classification: "invalid_response" },
+        };
+      const found = rows.find((row) => typeof row?.body === "string" && row.body.includes(marker));
+      if (found) return { outcome: "found", requests, observations, commentId: found.id ?? null };
+      if (rows.length < 100) break;
+    }
+    if (attempt < maxAttempts) await sleep(Math.min(250 * attempt, retryAfterCapMs));
+  }
+  if (rateLimited) {
+    return {
+      outcome: "indeterminate",
+      requests,
+      observations,
+      classification: { classification: "rate_limited", boundedFailure: true },
+    };
+  }
+  return { outcome: "definitive_miss", requests, observations };
+}
+
+export function scrub(value, secrets) {
+  let text = typeof value === "string" ? value : JSON.stringify(value, null, 2);
+  for (const secret of new Set(secrets.filter((v) => typeof v === "string" && v.length >= 4)))
+    text = text.split(secret).join("[REDACTED]");
+  return text
+    .replace(/Bearer\s+[A-Za-z0-9._~-]+/gi, "Bearer [REDACTED]")
+    .replace(/(?:gh[psuor]_|github_pat_)[A-Za-z0-9_]+/gi, "[REDACTED_GITHUB_TOKEN]")
+    .replace(/-----BEGIN [^-]+-----[\s\S]*?-----END [^-]+-----/g, "[REDACTED_PEM]");
+}

--- a/scripts/lib/provider-authority-sandbox-lib.mjs
+++ b/scripts/lib/provider-authority-sandbox-lib.mjs
@@ -24,6 +24,8 @@ export const REQUIRED_ENV = [
   "STEWARD_AUDIT_SIGNING_KEY",
 ];
 
+export const GITHUB_API_BASE = "https://api.github.com";
+
 const PLACEHOLDER_RE = /(change[-_]?me|placeholder|example|your[-_]|xxx+|todo)/i;
 const REQUIRED_BUILD_OUTPUTS = [
   "packages/shared/dist/index.js",
@@ -126,8 +128,19 @@ export function validateEnvironment(env) {
     if (placeholders.length) parts.push(`placeholder value(s): ${placeholders.join(", ")}`);
     throw new Error(parts.join("; "));
   }
-  validateServiceUrl("STEWARD_API_URL", env.STEWARD_API_URL);
-  if (env.GITHUB_API_URL) validateServiceUrl("GITHUB_API_URL", env.GITHUB_API_URL);
+  const stewardBase = validateServiceUrl("STEWARD_API_URL", env.STEWARD_API_URL);
+  const stewardUrl = new URL(stewardBase);
+  if (stewardUrl.search || stewardUrl.hash) {
+    throw new Error("STEWARD_API_URL must not contain a query or fragment");
+  }
+  // This acceptance is specifically for github.com. An inherited API override
+  // must never redirect an App JWT or installation token to an arbitrary host.
+  if (
+    env.GITHUB_API_URL &&
+    validateServiceUrl("GITHUB_API_URL", env.GITHUB_API_URL) !== GITHUB_API_BASE
+  ) {
+    throw new Error("GITHUB_API_URL must be https://api.github.com for the Gate D sandbox");
+  }
 }
 
 const b64url = (value) => Buffer.from(value).toString("base64url");
@@ -189,7 +202,7 @@ export async function requestJson(url, options, fetchImpl = fetch) {
   return { response, body };
 }
 
-export async function mintInstallationToken(env, fetchImpl = fetch) {
+export async function mintInstallationCredential(env, fetchImpl = fetch) {
   const jwt = mintGithubAppJwt(env.GITHUB_APP_ID, env.GITHUB_APP_PRIVATE_KEY);
   const base = validateServiceUrl("GITHUB_API_URL", env.GITHUB_API_URL ?? "https://api.github.com");
   const { response, body } = await requestJson(
@@ -208,7 +221,76 @@ export async function mintInstallationToken(env, fetchImpl = fetch) {
   if (!response.ok || typeof body?.token !== "string") {
     throw new Error(`GitHub installation token mint failed (${response.status})`);
   }
-  return body.token;
+  const expiresAt = Date.parse(body.expires_at);
+  const remainingMs = expiresAt - Date.now();
+  if (!Number.isFinite(expiresAt) || remainingMs <= 0 || remainingMs > 65 * 60 * 1000) {
+    throw new Error("GitHub installation token did not have the expected short lifetime");
+  }
+  return {
+    token: body.token,
+    expiresAt: body.expires_at,
+    permissions: body.permissions ?? null,
+    repositorySelection: body.repository_selection ?? null,
+  };
+}
+
+export async function mintInstallationToken(env, fetchImpl = fetch) {
+  return (await mintInstallationCredential(env, fetchImpl)).token;
+}
+
+export async function verifyInstallationScope(
+  { token, permissions, repositorySelection },
+  { owner, repo, apiBase = GITHUB_API_BASE, fetchImpl = fetch },
+) {
+  const expectedPermissions = { issues: "write", metadata: "read" };
+  if (
+    repositorySelection !== "selected" ||
+    JSON.stringify(Object.fromEntries(Object.entries(permissions ?? {}).sort())) !==
+      JSON.stringify(expectedPermissions)
+  ) {
+    throw new Error(
+      "GitHub App installation permissions are not exactly metadata:read + issues:write",
+    );
+  }
+  const { response, body } = await requestJson(
+    `${apiBase.replace(/\/$/, "")}/installation/repositories?per_page=100`,
+    {
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${token}`,
+        "user-agent": "steward-gate-d-sandbox",
+        "x-github-api-version": "2022-11-28",
+      },
+    },
+    fetchImpl,
+  );
+  const expected = `${owner}/${repo}`.toLowerCase();
+  if (
+    !response.ok ||
+    body?.total_count !== 1 ||
+    !Array.isArray(body.repositories) ||
+    body.repositories.length !== 1 ||
+    body.repositories[0]?.full_name?.toLowerCase() !== expected
+  ) {
+    throw new Error("GitHub App installation must be limited to the one declared sandbox repo");
+  }
+}
+
+export async function revokeInstallationToken(token, fetchImpl = fetch) {
+  const response = await fetchImpl(`${GITHUB_API_BASE}/installation/token`, {
+    method: "DELETE",
+    redirect: "error",
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    headers: {
+      accept: "application/vnd.github+json",
+      authorization: `Bearer ${token}`,
+      "user-agent": "steward-gate-d-sandbox",
+      "x-github-api-version": "2022-11-28",
+    },
+  });
+  if (response.status !== 204) {
+    throw new Error(`GitHub installation token revocation failed (${response.status})`);
+  }
 }
 
 export function parseRetryAfter(value, capMs, now = Date.now()) {
@@ -234,9 +316,13 @@ export function classifyGithubResponse(status, headers = new Headers()) {
   return { classification: "ok", boundedFailure: false };
 }
 
+export function isLiveRateLimitObservation(observation) {
+  return observation?.classification === "rate_limited" && observation.retryAfter !== null;
+}
+
 /** Bounded, read-only reconciliation; this function never writes provider data. */
 export async function reconcileGithubMarker({
-  apiBase = "https://api.github.com",
+  apiBase = GITHUB_API_BASE,
   owner,
   repo,
   pullNumber,
@@ -252,6 +338,7 @@ export async function reconcileGithubMarker({
   let requests = 0;
   let rateLimited = false;
   const observations = [];
+  let paginationBoundExhausted = false;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     for (let page = 1; page <= maxPages; page++) {
       requests++;
@@ -274,6 +361,7 @@ export async function reconcileGithubMarker({
         page,
         status: response.status,
         classification: classification.classification,
+        retryAfter: classification.retryAfter ?? null,
       });
       if (classification.classification === "rate_limited") {
         rateLimited = true;
@@ -291,6 +379,7 @@ export async function reconcileGithubMarker({
       const found = rows.find((row) => typeof row?.body === "string" && row.body.includes(marker));
       if (found) return { outcome: "found", requests, observations, commentId: found.id ?? null };
       if (rows.length < 100) break;
+      if (page === maxPages) paginationBoundExhausted = true;
     }
     if (attempt < maxAttempts) await sleep(Math.min(250 * attempt, retryAfterCapMs));
   }
@@ -300,6 +389,14 @@ export async function reconcileGithubMarker({
       requests,
       observations,
       classification: { classification: "rate_limited", boundedFailure: true },
+    };
+  }
+  if (paginationBoundExhausted) {
+    return {
+      outcome: "indeterminate",
+      requests,
+      observations,
+      classification: { classification: "pagination_bound_exhausted", boundedFailure: true },
     };
   }
   return { outcome: "definitive_miss", requests, observations };

--- a/scripts/lib/provider-authority-sandbox-lib.mjs
+++ b/scripts/lib/provider-authority-sandbox-lib.mjs
@@ -51,6 +51,17 @@ export function validateServiceUrl(name, value) {
   return url.toString().replace(/\/$/, "");
 }
 
+function validateGithubApiBase(value) {
+  const validated = validateServiceUrl("GITHUB_API_URL", value);
+  const url = new URL(validated);
+  const loopback =
+    url.hostname === "localhost" || url.hostname === "127.0.0.1" || url.hostname === "[::1]";
+  if (url.origin !== GITHUB_API_BASE && !loopback) {
+    throw new Error("GITHUB_API_URL must be https://api.github.com");
+  }
+  return validated;
+}
+
 export function validateBuildPrerequisites(root) {
   const missing = REQUIRED_BUILD_OUTPUTS.filter((path) => !existsSync(join(root, path)));
   if (missing.length) {
@@ -155,12 +166,31 @@ export function mintGithubAppJwt(appId, privateKey, now = Math.floor(Date.now() 
   return `${unsigned}.${signer.sign(privateKey).toString("base64url")}`;
 }
 
-export async function requestJson(url, options, fetchImpl = fetch) {
-  const response = await fetchImpl(url, {
+export async function requestJson(
+  url,
+  options = {},
+  fetchImpl = fetch,
+  { expectedOrigin, timeoutMs = REQUEST_TIMEOUT_MS } = {},
+) {
+  const validatedUrl = validateServiceUrl("HTTP request URL", url);
+  const requestOrigin = new URL(validatedUrl).origin;
+  if (expectedOrigin) {
+    const pinnedOrigin = new URL(validateServiceUrl("expected request origin", expectedOrigin))
+      .origin;
+    if (requestOrigin !== pinnedOrigin) {
+      throw new Error(`HTTP request origin mismatch (expected ${pinnedOrigin})`);
+    }
+  }
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > REQUEST_TIMEOUT_MS) {
+    throw new Error(`HTTP request timeout must be between 1 and ${REQUEST_TIMEOUT_MS} ms`);
+  }
+  const deadline = AbortSignal.timeout(timeoutMs);
+  const signal = options.signal ? AbortSignal.any([deadline, options.signal]) : deadline;
+  const response = await fetchImpl(validatedUrl, {
     ...options,
     // Never forward an authorization header across an unexpected redirect.
-    redirect: options?.redirect ?? "error",
-    signal: options?.signal ?? AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    redirect: "error",
+    signal,
   });
   const declared = response.headers.get("content-length");
   if (declared !== null) {
@@ -204,7 +234,7 @@ export async function requestJson(url, options, fetchImpl = fetch) {
 
 export async function mintInstallationCredential(env, fetchImpl = fetch) {
   const jwt = mintGithubAppJwt(env.GITHUB_APP_ID, env.GITHUB_APP_PRIVATE_KEY);
-  const base = validateServiceUrl("GITHUB_API_URL", env.GITHUB_API_URL ?? "https://api.github.com");
+  const base = validateGithubApiBase(env.GITHUB_API_URL ?? GITHUB_API_BASE);
   const { response, body } = await requestJson(
     `${base}/app/installations/${encodeURIComponent(env.GITHUB_APP_INSTALLATION_ID)}/access_tokens`,
     {
@@ -217,6 +247,7 @@ export async function mintInstallationCredential(env, fetchImpl = fetch) {
       },
     },
     fetchImpl,
+    { expectedOrigin: base },
   );
   if (!response.ok || typeof body?.token !== "string") {
     throw new Error(`GitHub installation token mint failed (${response.status})`);
@@ -242,6 +273,7 @@ export async function verifyInstallationScope(
   { token, permissions, repositorySelection },
   { owner, repo, apiBase = GITHUB_API_BASE, fetchImpl = fetch },
 ) {
+  const validatedApiBase = validateGithubApiBase(apiBase);
   const expectedPermissions = { issues: "write", metadata: "read" };
   if (
     repositorySelection !== "selected" ||
@@ -253,7 +285,7 @@ export async function verifyInstallationScope(
     );
   }
   const { response, body } = await requestJson(
-    `${apiBase.replace(/\/$/, "")}/installation/repositories?per_page=100`,
+    `${validatedApiBase}/installation/repositories?per_page=100`,
     {
       headers: {
         accept: "application/vnd.github+json",
@@ -263,6 +295,7 @@ export async function verifyInstallationScope(
       },
     },
     fetchImpl,
+    { expectedOrigin: validatedApiBase },
   );
   const expected = `${owner}/${repo}`.toLowerCase();
   if (
@@ -277,17 +310,20 @@ export async function verifyInstallationScope(
 }
 
 export async function revokeInstallationToken(token, fetchImpl = fetch) {
-  const response = await fetchImpl(`${GITHUB_API_BASE}/installation/token`, {
-    method: "DELETE",
-    redirect: "error",
-    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-    headers: {
-      accept: "application/vnd.github+json",
-      authorization: `Bearer ${token}`,
-      "user-agent": "steward-gate-d-sandbox",
-      "x-github-api-version": "2022-11-28",
+  const { response } = await requestJson(
+    `${GITHUB_API_BASE}/installation/token`,
+    {
+      method: "DELETE",
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${token}`,
+        "user-agent": "steward-gate-d-sandbox",
+        "x-github-api-version": "2022-11-28",
+      },
     },
-  });
+    fetchImpl,
+    { expectedOrigin: GITHUB_API_BASE },
+  );
   if (response.status !== 204) {
     throw new Error(`GitHub installation token revocation failed (${response.status})`);
   }
@@ -334,7 +370,7 @@ export async function reconcileGithubMarker({
   fetchImpl = fetch,
   sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
 }) {
-  const validatedApiBase = validateServiceUrl("GITHUB_API_URL", apiBase);
+  const validatedApiBase = validateGithubApiBase(apiBase);
   let requests = 0;
   let rateLimited = false;
   const observations = [];
@@ -354,6 +390,7 @@ export async function reconcileGithubMarker({
           },
         },
         fetchImpl,
+        { expectedOrigin: validatedApiBase },
       );
       const classification = classifyGithubResponse(response.status, response.headers);
       observations.push({

--- a/scripts/lib/provider-authority-sandbox-lib.mjs
+++ b/scripts/lib/provider-authority-sandbox-lib.mjs
@@ -30,6 +30,24 @@ const REQUIRED_BUILD_OUTPUTS = [
   "packages/redis/dist/index.js",
   "packages/attestation/dist/index.js",
 ];
+const REQUEST_TIMEOUT_MS = 10_000;
+const RESPONSE_MAX_BYTES = 1024 * 1024;
+
+export function validateServiceUrl(name, value) {
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error(`${name} must be a valid absolute URL`);
+  }
+  if (url.username || url.password) throw new Error(`${name} must not contain credentials`);
+  const loopback =
+    url.hostname === "localhost" || url.hostname === "127.0.0.1" || url.hostname === "[::1]";
+  if (url.protocol !== "https:" && !(url.protocol === "http:" && loopback)) {
+    throw new Error(`${name} must use HTTPS unless it targets loopback`);
+  }
+  return url.toString().replace(/\/$/, "");
+}
 
 export function validateBuildPrerequisites(root) {
   const missing = REQUIRED_BUILD_OUTPUTS.filter((path) => !existsSync(join(root, path)));
@@ -108,6 +126,8 @@ export function validateEnvironment(env) {
     if (placeholders.length) parts.push(`placeholder value(s): ${placeholders.join(", ")}`);
     throw new Error(parts.join("; "));
   }
+  validateServiceUrl("STEWARD_API_URL", env.STEWARD_API_URL);
+  if (env.GITHUB_API_URL) validateServiceUrl("GITHUB_API_URL", env.GITHUB_API_URL);
 }
 
 const b64url = (value) => Buffer.from(value).toString("base64url");
@@ -123,8 +143,39 @@ export function mintGithubAppJwt(appId, privateKey, now = Math.floor(Date.now() 
 }
 
 export async function requestJson(url, options, fetchImpl = fetch) {
-  const response = await fetchImpl(url, options);
-  const text = await response.text();
+  const response = await fetchImpl(url, {
+    ...options,
+    signal: options?.signal ?? AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const declared = response.headers.get("content-length");
+  if (declared !== null) {
+    const length = Number(declared);
+    if (!Number.isSafeInteger(length) || length < 0 || length > RESPONSE_MAX_BYTES) {
+      void response.body?.cancel().catch(() => {});
+      throw new Error("HTTP response exceeded the 1 MiB sandbox limit");
+    }
+  }
+  let text = "";
+  if (response.body) {
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let total = 0;
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        total += value.byteLength;
+        if (total > RESPONSE_MAX_BYTES) {
+          void reader.cancel().catch(() => {});
+          throw new Error("HTTP response exceeded the 1 MiB sandbox limit");
+        }
+        text += decoder.decode(value, { stream: true });
+      }
+      text += decoder.decode();
+    } finally {
+      reader.releaseLock();
+    }
+  }
   let body = null;
   if (text) {
     try {
@@ -138,7 +189,7 @@ export async function requestJson(url, options, fetchImpl = fetch) {
 
 export async function mintInstallationToken(env, fetchImpl = fetch) {
   const jwt = mintGithubAppJwt(env.GITHUB_APP_ID, env.GITHUB_APP_PRIVATE_KEY);
-  const base = (env.GITHUB_API_URL ?? "https://api.github.com").replace(/\/$/, "");
+  const base = validateServiceUrl("GITHUB_API_URL", env.GITHUB_API_URL ?? "https://api.github.com");
   const { response, body } = await requestJson(
     `${base}/app/installations/${encodeURIComponent(env.GITHUB_APP_INSTALLATION_ID)}/access_tokens`,
     {
@@ -202,14 +253,18 @@ export async function reconcileGithubMarker({
     for (let page = 1; page <= maxPages; page++) {
       requests++;
       const url = `${apiBase.replace(/\/$/, "")}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/issues/${encodeURIComponent(pullNumber)}/comments?per_page=100&page=${page}`;
-      const response = await fetchImpl(url, {
-        headers: {
-          accept: "application/vnd.github+json",
-          authorization: `Bearer ${token}`,
-          "user-agent": "steward-gate-d-sandbox",
-          "x-github-api-version": "2022-11-28",
+      const { response, body: rows } = await requestJson(
+        url,
+        {
+          headers: {
+            accept: "application/vnd.github+json",
+            authorization: `Bearer ${token}`,
+            "user-agent": "steward-gate-d-sandbox",
+            "x-github-api-version": "2022-11-28",
+          },
         },
-      });
+        fetchImpl,
+      );
       const classification = classifyGithubResponse(response.status, response.headers);
       observations.push({
         attempt,
@@ -223,7 +278,6 @@ export async function reconcileGithubMarker({
         break;
       }
       if (!response.ok) return { outcome: "indeterminate", requests, observations, classification };
-      const rows = await response.json();
       if (!Array.isArray(rows))
         return {
           outcome: "indeterminate",

--- a/scripts/lib/provider-authority-sandbox-lib.mjs
+++ b/scripts/lib/provider-authority-sandbox-lib.mjs
@@ -145,6 +145,8 @@ export function mintGithubAppJwt(appId, privateKey, now = Math.floor(Date.now() 
 export async function requestJson(url, options, fetchImpl = fetch) {
   const response = await fetchImpl(url, {
     ...options,
+    // Never forward an authorization header across an unexpected redirect.
+    redirect: options?.redirect ?? "error",
     signal: options?.signal ?? AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
   const declared = response.headers.get("content-length");
@@ -246,13 +248,14 @@ export async function reconcileGithubMarker({
   fetchImpl = fetch,
   sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
 }) {
+  const validatedApiBase = validateServiceUrl("GITHUB_API_URL", apiBase);
   let requests = 0;
   let rateLimited = false;
   const observations = [];
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     for (let page = 1; page <= maxPages; page++) {
       requests++;
-      const url = `${apiBase.replace(/\/$/, "")}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/issues/${encodeURIComponent(pullNumber)}/comments?per_page=100&page=${page}`;
+      const url = `${validatedApiBase}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/issues/${encodeURIComponent(pullNumber)}/comments?per_page=100&page=${page}`;
       const { response, body: rows } = await requestJson(
         url,
         {

--- a/scripts/provider-authority-dispatch-child.ts
+++ b/scripts/provider-authority-dispatch-child.ts
@@ -1,0 +1,28 @@
+import {
+  __setGovernedDispatchHooksForTests,
+  dispatchGovernedExecution,
+} from "../packages/proxy/src/handlers/governed-execution";
+
+const [intentId, tenantId] = process.argv.slice(2);
+if (!intentId || !tenantId) throw new Error("usage: dispatch-child <intent-id> <tenant-id>");
+
+// Operator-only crash-window injection. The upstream response has arrived, but
+// the parent deliberately terminates this isolated worker before terminal state
+// persistence. No request field or HTTP route can select this hook.
+// biome-ignore lint/suspicious/noUndeclaredEnvVars: operator-only child handshake, never a cached task input
+if (process.env.STEWARD_SANDBOX_AFTER_UPSTREAM_PAUSE_MS) {
+  // biome-ignore lint/suspicious/noUndeclaredEnvVars: validated bounded operator-only fault barrier
+  const pause = Number(process.env.STEWARD_SANDBOX_AFTER_UPSTREAM_PAUSE_MS);
+  if (!Number.isSafeInteger(pause) || pause < 1 || pause > 120_000) {
+    throw new Error("invalid STEWARD_SANDBOX_AFTER_UPSTREAM_PAUSE_MS");
+  }
+  __setGovernedDispatchHooksForTests({
+    afterUpstream: () => {
+      process.stdout.write(`${JSON.stringify({ phase: "after_upstream" })}\n`);
+      return new Promise((resolve) => setTimeout(resolve, pause));
+    },
+  });
+}
+
+const result = await dispatchGovernedExecution(intentId, tenantId);
+process.stdout.write(`${JSON.stringify(result)}\n`);

--- a/scripts/provider-authority-sandbox.mjs
+++ b/scripts/provider-authority-sandbox.mjs
@@ -39,15 +39,21 @@ function fail(message) {
 }
 
 async function stewardRaw(env, path, token, options = {}) {
-  return requestJson(`${env.STEWARD_API_URL.replace(/\/$/, "")}${path}`, {
-    ...options,
-    headers: {
-      authorization: `Bearer ${token}`,
-      "content-type": "application/json",
-      "x-steward-tenant": env.STEWARD_TENANT_ID,
-      ...(options.headers ?? {}),
+  const base = env.STEWARD_API_URL.replace(/\/$/, "");
+  return requestJson(
+    `${base}${path}`,
+    {
+      ...options,
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+        "x-steward-tenant": env.STEWARD_TENANT_ID,
+        ...(options.headers ?? {}),
+      },
     },
-  });
+    fetch,
+    { expectedOrigin: base },
+  );
 }
 
 async function steward(env, path, token, options = {}) {

--- a/scripts/provider-authority-sandbox.mjs
+++ b/scripts/provider-authority-sandbox.mjs
@@ -65,6 +65,7 @@ export function runDispatchChild(
     let stderr = "";
     let reachedAfterUpstream = false;
     let outputExceeded = false;
+    let spawnError = false;
     let killTimer;
     child.stdout.on("data", (chunk) => {
       if (Buffer.byteLength(stdout) + chunk.byteLength > MAX_CHILD_OUTPUT_BYTES) {
@@ -86,6 +87,11 @@ export function runDispatchChild(
       }
       stderr += chunk;
     });
+    child.on("error", () => {
+      // Node follows this with `close`; retain only a boolean so an OS error
+      // cannot echo a sensitive environment value into artifacts or logs.
+      spawnError = true;
+    });
     const safetyTimer = setTimeout(() => child.kill("SIGKILL"), 60_000);
     child.on("close", (code, signal) => {
       if (killTimer) clearTimeout(killTimer);
@@ -106,6 +112,7 @@ export function runDispatchChild(
         reachedAfterUpstream,
         timedOut: signal === "SIGKILL" && reachedAfterUpstream,
         outputExceeded,
+        spawnError,
       });
     });
   });
@@ -274,10 +281,18 @@ async function main() {
         return value;
       })(),
     });
+    if (first.spawnError) throw new Error("crash-window child failed to spawn");
+    if (first.outputExceeded) throw new Error("crash-window child exceeded the output limit");
     if (!first.timedOut || !first.reachedAfterUpstream) {
       throw new Error("crash-window worker did not prove the post-upstream barrier");
     }
     const replay = await runDispatchChild(env, intentId);
+    if (replay.spawnError) throw new Error("replay child failed to spawn");
+    if (replay.outputExceeded) throw new Error("replay child exceeded the output limit");
+    const childOutput = `${first.stdout}\n${first.stderr}\n${replay.stdout}\n${replay.stderr}`;
+    if (secretValues.some((value) => value.length >= 4 && childOutput.includes(value))) {
+      throw new Error("credential canary appeared in dispatch child output");
+    }
     if (replay.timedOut || replay.result?.code !== "EXEC_TERMINAL_STATE") {
       throw new Error("fresh-worker replay was not rejected as terminal");
     }

--- a/scripts/provider-authority-sandbox.mjs
+++ b/scripts/provider-authority-sandbox.mjs
@@ -19,6 +19,7 @@ const OUT_DIR = join(ROOT, "artifacts", "provider-authority", "sandbox");
 const CLAIM =
   "Live behavior is recorded exactly as observed. Hermetic classification is not a live " +
   "rate-limit observation; Gate D remains STOP unless every required live observation passes.";
+const MAX_CHILD_OUTPUT_BYTES = 1024 * 1024;
 
 function fail(message) {
   console.error(`[sandbox] FAIL (fail-closed): ${message}`);
@@ -63,8 +64,14 @@ export function runDispatchChild(
     let stdout = "";
     let stderr = "";
     let reachedAfterUpstream = false;
+    let outputExceeded = false;
     let killTimer;
     child.stdout.on("data", (chunk) => {
+      if (Buffer.byteLength(stdout) + chunk.byteLength > MAX_CHILD_OUTPUT_BYTES) {
+        outputExceeded = true;
+        child.kill("SIGKILL");
+        return;
+      }
       stdout += chunk;
       if (pauseAfterUpstream && stdout.includes('"phase":"after_upstream"')) {
         reachedAfterUpstream = true;
@@ -72,6 +79,11 @@ export function runDispatchChild(
       }
     });
     child.stderr.on("data", (chunk) => {
+      if (Buffer.byteLength(stderr) + chunk.byteLength > MAX_CHILD_OUTPUT_BYTES) {
+        outputExceeded = true;
+        child.kill("SIGKILL");
+        return;
+      }
       stderr += chunk;
     });
     const safetyTimer = setTimeout(() => child.kill("SIGKILL"), 60_000);
@@ -93,6 +105,7 @@ export function runDispatchChild(
         stderr,
         reachedAfterUpstream,
         timedOut: signal === "SIGKILL" && reachedAfterUpstream,
+        outputExceeded,
       });
     });
   });
@@ -253,7 +266,13 @@ async function main() {
     // window without weakening the server or adding a forgeable dispatch route.
     const first = await runDispatchChild(env, intentId, {
       pauseAfterUpstream: true,
-      timeoutMs: Number(env.STEWARD_SANDBOX_CHILD_TIMEOUT_MS ?? 2_000),
+      timeoutMs: (() => {
+        const value = Number(env.STEWARD_SANDBOX_CHILD_TIMEOUT_MS ?? 2_000);
+        if (!Number.isSafeInteger(value) || value < 100 || value > 30_000) {
+          throw new Error("STEWARD_SANDBOX_CHILD_TIMEOUT_MS must be an integer from 100 to 30000");
+        }
+        return value;
+      })(),
     });
     if (!first.timedOut || !first.reachedAfterUpstream) {
       throw new Error("crash-window worker did not prove the post-upstream barrier");

--- a/scripts/provider-authority-sandbox.mjs
+++ b/scripts/provider-authority-sandbox.mjs
@@ -58,8 +58,8 @@ async function steward(env, path, token, options = {}) {
   return body;
 }
 
-async function prepareApprovedWrite(env, marker, body) {
-  const created = await steward(env, "/v2/provider-actions", env.STEWARD_AGENT_JWT, {
+export async function prepareApprovedWrite(env, marker, body, stewardImpl = steward) {
+  const created = await stewardImpl(env, "/v2/provider-actions", env.STEWARD_AGENT_JWT, {
     method: "POST",
     body: JSON.stringify({
       workspaceId: env.STEWARD_SANDBOX_WORKSPACE_ID,
@@ -77,13 +77,13 @@ async function prepareApprovedWrite(env, marker, body) {
   if (!created.id || created.status !== "pending_approval") {
     throw new Error("provider action did not require approval");
   }
-  const approvalResponse = await steward(
+  const approvalResponse = await stewardImpl(
     env,
     `/v2/provider-actions/${encodeURIComponent(created.id)}/approval`,
     env.STEWARD_APPROVER_JWT,
   );
   const approval = approvalResponse.data ?? approvalResponse;
-  await steward(
+  await stewardImpl(
     env,
     `/v2/provider-actions/${encodeURIComponent(created.id)}/approval`,
     env.STEWARD_APPROVER_JWT,
@@ -99,17 +99,24 @@ async function prepareApprovedWrite(env, marker, body) {
       }),
     },
   );
-  const executeResponse = await steward(
+  const executeResponse = await stewardImpl(
     env,
     `/v2/provider-actions/${encodeURIComponent(created.id)}/execute`,
     env.STEWARD_AGENT_JWT,
-    { method: "POST", body: "{}" },
+    { method: "POST" },
   );
   const execution = executeResponse.data ?? executeResponse;
   if (execution.status !== "execution_ready") {
     throw new Error(`execute did not reach execution_ready (got ${execution.status ?? "unknown"})`);
   }
   return created;
+}
+
+export function requireRawCaseManifest(caseRecord, intentId) {
+  if (!caseRecord || caseRecord.caseId !== intentId) {
+    throw new Error("live case response did not contain the expected case manifest");
+  }
+  return caseRecord;
 }
 
 export function runDispatchChild(
@@ -389,6 +396,10 @@ async function main() {
     githubToken = reconciliationInstallation.token;
     activeGithubTokens.add(githubToken);
     secretValues.push(githubToken);
+    await verifyInstallationScope(reconciliationInstallation, {
+      owner: env.STEWARD_SANDBOX_GITHUB_OWNER,
+      repo: env.STEWARD_SANDBOX_GITHUB_REPO,
+    });
     const reconciliation = await reconcileGithubMarker({
       apiBase: env.GITHUB_API_URL,
       owner: env.STEWARD_SANDBOX_GITHUB_OWNER,
@@ -420,10 +431,9 @@ async function main() {
       `/v2/provider-actions/${encodeURIComponent(intentId)}/case`,
       env.STEWARD_APPROVER_JWT,
     );
-    const caseManifest = caseRecord?.manifest;
-    if (!caseManifest || caseManifest.caseId !== intentId) {
-      throw new Error("live case response did not contain the expected case manifest");
-    }
+    // The live `/case` route returns ProviderCaseManifestV1 directly (unlike
+    // approval detail, which uses an `{ ok, data }` envelope).
+    const caseManifest = requireRawCaseManifest(caseRecord, intentId);
     const evidence = await steward(
       env,
       `/v2/provider-actions/${encodeURIComponent(intentId)}/evidence`,

--- a/scripts/provider-authority-sandbox.mjs
+++ b/scripts/provider-authority-sandbox.mjs
@@ -1,137 +1,436 @@
 #!/usr/bin/env node
-/**
- * PR6 provider-authority REAL GitHub SANDBOX run (§3) — documented, on-demand.
- *
- * WHAT THIS IS
- * ------------
- * The SEPARATE, documented entrypoint that runs the governed-provider matrix
- * against a REAL throwaway GitHub org using the DEFAULT (real, DNS-vetted) proxy
- * forwarder — i.e. the SAME governed code path as the fake CI proof, differing
- * ONLY in the terminal transport (U2). It is NOT a per-PR merge gate: it needs a
- * real GitHub App installation credential and a throwaway repo, so it is an
- * operator-run acceptance recorded as an artifact set under
- * artifacts/provider-authority/sandbox/.
- *
- * SECURITY (U7 / U10)
- * -------------------
- * - Reads ALL sandbox credentials from the ENV ONLY (see
- *   deploy/enterprise-reference/provider-github-sandbox.env.example). It does NOT
- *   read any committed secret file and NEVER prints a credential value.
- * - Fails CLOSED and LOUD on any missing required var (no silent skip that could
- *   be read as a pass). A skipped required assertion is a gate failure.
- * - Scrubs every captured artifact of credentials before writing.
- *
- * STATUS
- * ------
- * This is the harness + preflight. Executing it requires a live sandbox
- * installation + Steward deployment; running it against real GitHub is the
- * operator acceptance step (Gate D "real sandbox proof"). Until that recorded
- * run exists, the golden-path manifest keeps the PRE-real-proof claim wording
- * (U8). This script REFUSES to fabricate a passing sandbox artifact.
- *
- * USAGE
- * -----
- *   set -a; . ./provider-github-sandbox.env; set +a
- *   node scripts/provider-authority-sandbox.mjs [--preflight]
- *
- * `--preflight` validates the environment + the target reachability WITHOUT
- * performing a consequential write, so an operator can confirm wiring before the
- * real matrix.
- */
-
-import { mkdirSync, writeFileSync } from "node:fs";
+/** Gate D operator harness. It never persists or prints a provider credential. */
+import { spawn } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  buildDispatchEnvironment,
+  mintInstallationToken,
+  reconcileGithubMarker,
+  requestJson,
+  scrub,
+  validateBuildPrerequisites,
+  validateEnvironment,
+} from "./lib/provider-authority-sandbox-lib.mjs";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const OUT_DIR = join(ROOT, "artifacts", "provider-authority", "sandbox");
+const CLAIM =
+  "Live behavior is recorded exactly as observed. Hermetic classification is not a live " +
+  "rate-limit observation; Gate D remains STOP unless every required live observation passes.";
 
-const REQUIRED_ENV = [
-  "GITHUB_APP_ID",
-  "GITHUB_APP_INSTALLATION_ID",
-  "GITHUB_APP_PRIVATE_KEY",
-  "STEWARD_SANDBOX_GITHUB_OWNER",
-  "STEWARD_SANDBOX_GITHUB_REPO",
-  "STEWARD_SANDBOX_GITHUB_PR_NUMBER",
-  "STEWARD_API_URL",
-  "STEWARD_TENANT_ID",
-  "STEWARD_TENANT_KEY",
-  "STEWARD_AUDIT_SIGNING_KEY_FINGERPRINT",
-];
-
-// Placeholder sentinels that must NOT be accepted as real values (mirrors
-// golden-path.sh placeholder rejection).
-const PLACEHOLDER_RE = /(change[-_]?me|placeholder|example|your[-_]|xxx+|todo)/i;
-
-function failClosed(message) {
-  // U10: loud, non-zero, no partial artifact that could read as a pass.
+function fail(message) {
   console.error(`[sandbox] FAIL (fail-closed): ${message}`);
-  process.exit(1);
+  process.exitCode = 1;
 }
 
-function requireEnv() {
-  const missing = [];
-  const placeholders = [];
-  for (const key of REQUIRED_ENV) {
-    const val = process.env[key];
-    if (!val || val.trim() === "") {
-      missing.push(key);
-      continue;
-    }
-    // Never test the PRIVATE KEY body against the placeholder regex by value
-    // beyond a coarse structural check (avoid any chance of logging it).
-    if (key === "GITHUB_APP_PRIVATE_KEY") {
-      if (!val.includes("PRIVATE KEY")) placeholders.push(`${key} (not a PEM)`);
-      continue;
-    }
-    if (PLACEHOLDER_RE.test(val)) placeholders.push(key);
-  }
-  if (missing.length > 0) {
-    failClosed(`missing required env: ${missing.join(", ")} (supply out-of-band, never commit)`);
-  }
-  if (placeholders.length > 0) {
-    failClosed(`placeholder value(s) not allowed: ${placeholders.join(", ")}`);
-  }
+async function stewardRaw(env, path, token, options = {}) {
+  return requestJson(`${env.STEWARD_API_URL.replace(/\/$/, "")}${path}`, {
+    ...options,
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+      "x-steward-tenant": env.STEWARD_TENANT_ID,
+      ...(options.headers ?? {}),
+    },
+  });
 }
 
-function main() {
-  const preflight = process.argv.includes("--preflight");
-  requireEnv();
+async function steward(env, path, token, options = {}) {
+  const { response, body } = await stewardRaw(env, path, token, options);
+  if (!response.ok) {
+    throw new Error(`Steward ${options.method ?? "GET"} ${path} failed (${response.status})`);
+  }
+  return body;
+}
 
-  mkdirSync(OUT_DIR, { recursive: true });
+export function runDispatchChild(
+  env,
+  intentId,
+  { pauseAfterUpstream = false, timeoutMs = 5_000, spawnImpl = spawn } = {},
+) {
+  return new Promise((resolve) => {
+    const child = spawnImpl(
+      "bun",
+      [join(ROOT, "scripts/provider-authority-dispatch-child.ts"), intentId, env.STEWARD_TENANT_ID],
+      {
+        cwd: ROOT,
+        env: buildDispatchEnvironment(env, pauseAfterUpstream),
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    let stdout = "";
+    let stderr = "";
+    let reachedAfterUpstream = false;
+    let killTimer;
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+      if (pauseAfterUpstream && stdout.includes('"phase":"after_upstream"')) {
+        reachedAfterUpstream = true;
+        if (!killTimer) killTimer = setTimeout(() => child.kill("SIGKILL"), timeoutMs);
+      }
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    const safetyTimer = setTimeout(() => child.kill("SIGKILL"), 60_000);
+    child.on("close", (code, signal) => {
+      if (killTimer) clearTimeout(killTimer);
+      clearTimeout(safetyTimer);
+      let result = null;
+      try {
+        const finalLine = stdout.trim().split("\n").at(-1);
+        result = finalLine ? JSON.parse(finalLine) : null;
+      } catch {
+        // A malformed child result is retained only as a non-secret failure.
+      }
+      resolve({
+        code,
+        signal,
+        result,
+        stdout,
+        stderr,
+        reachedAfterUpstream,
+        timedOut: signal === "SIGKILL" && reachedAfterUpstream,
+      });
+    });
+  });
+}
 
-  if (preflight) {
-    // Preflight ONLY validates env + records the intent. It performs no
-    // consequential write. It writes a preflight receipt, NOT a proof artifact.
-    const receipt = {
-      schemaVersion: 1,
-      mode: "preflight",
-      generatedAt: new Date().toISOString(),
-      // biome-ignore lint/suspicious/noUndeclaredEnvVars: sandbox vars are read by design (validated in requireEnv)
-      target: `${process.env["STEWARD_SANDBOX_GITHUB_OWNER"]}/${process.env["STEWARD_SANDBOX_GITHUB_REPO"]}`,
-      forwarder: "default (forwardWithVettedDns) — real DNS-vetted terminal I/O",
-      credentialsPresent: true,
-      note: "Env validated. No consequential write performed. Run without --preflight (against a live installation) to produce the real matrix artifact.",
-    };
-    writeFileSync(join(OUT_DIR, "preflight.json"), `${JSON.stringify(receipt, null, 2)}\n`);
+function writeArtifact(name, value, secretValues) {
+  writeFileSync(join(OUT_DIR, name), `${scrub(value, secretValues)}\n`, { mode: 0o600 });
+}
+
+async function main() {
+  const env = process.env;
+  try {
+    validateEnvironment(env);
+    validateBuildPrerequisites(ROOT);
+  } catch (error) {
+    return fail(error.message);
+  }
+  if (process.argv.includes("--preflight")) {
     console.log(
-      `[sandbox] preflight OK — env validated, no write performed. Receipt: ${OUT_DIR}/preflight.json`,
+      "[sandbox] preflight OK — required variables validated; zero network requests made",
     );
     return;
   }
 
-  // The live matrix requires a real GitHub App installation-token mint +
-  // provisioning through the Steward routes. That step is operator-run against a
-  // live deployment; this harness will NOT fabricate a passing artifact without
-  // a real run. Executing the real matrix belongs to the operator acceptance
-  // (Gate D). We fail closed here so an accidental invocation in CI (no live
-  // sandbox) can never be misread as a recorded proof.
-  failClosed(
-    "real-sandbox matrix must be executed by an operator against a live throwaway " +
-      "GitHub installation + Steward deployment. Run with --preflight to validate " +
-      "wiring first. This harness refuses to emit a proof artifact without a real run " +
-      "(U8 claims discipline).",
-  );
+  mkdirSync(OUT_DIR, { recursive: true });
+  let githubToken;
+  const marker = `steward-gate-d:${crypto.randomUUID()}`;
+  const report = {
+    schemaVersion: 2,
+    startedAt: new Date().toISOString(),
+    steps: [],
+    gateD: "STOP",
+  };
+  const secretValues = [
+    env.GITHUB_APP_PRIVATE_KEY,
+    env.STEWARD_AGENT_JWT,
+    env.STEWARD_APPROVER_JWT,
+    env.STEWARD_MASTER_PASSWORD,
+    env.STEWARD_EXECUTION_AUTH_SECRET,
+    env.STEWARD_AUDIT_HMAC_KEY,
+    env.STEWARD_AUDIT_SIGNING_KEY,
+  ].filter((value) => typeof value === "string");
+
+  try {
+    githubToken = await mintInstallationToken(env);
+    secretValues.push(githubToken);
+    report.steps.push({ id: "setup-token", status: "pass", detail: "installation token minted" });
+
+    await steward(
+      env,
+      `/secrets/${encodeURIComponent(env.STEWARD_SANDBOX_SECRET_ID)}/rotate`,
+      env.STEWARD_APPROVER_JWT,
+      { method: "POST", body: JSON.stringify({ value: githubToken }) },
+    );
+    githubToken = undefined;
+    report.steps.push({
+      id: "setup-secret",
+      status: "pass",
+      detail: "credential rotated through recent-MFA secret API",
+    });
+
+    const read = await steward(env, "/v2/provider-actions", env.STEWARD_AGENT_JWT, {
+      method: "POST",
+      body: JSON.stringify({
+        workspaceId: env.STEWARD_SANDBOX_WORKSPACE_ID,
+        providerAccountId: env.STEWARD_SANDBOX_PROVIDER_ACCOUNT_ID,
+        operationKey: "github.issue.list",
+        arguments: {
+          owner: env.STEWARD_SANDBOX_GITHUB_OWNER,
+          repo: env.STEWARD_SANDBOX_GITHUB_REPO,
+        },
+        idempotencyKey: `gate-d-read-${marker}`,
+      }),
+    });
+    if (read.status !== "stub_succeeded") {
+      throw new Error("M02 read authority path was not allowed");
+    }
+    report.steps.push({ id: "M02", status: "pass", detail: "read authority path allowed" });
+
+    const crossScope = await stewardRaw(env, "/v2/provider-actions", env.STEWARD_AGENT_JWT, {
+      method: "POST",
+      body: JSON.stringify({
+        workspaceId: crypto.randomUUID(),
+        providerAccountId: env.STEWARD_SANDBOX_PROVIDER_ACCOUNT_ID,
+        operationKey: "github.issue.list",
+        arguments: {
+          owner: env.STEWARD_SANDBOX_GITHUB_OWNER,
+          repo: env.STEWARD_SANDBOX_GITHUB_REPO,
+        },
+        idempotencyKey: `gate-d-cross-${marker}`,
+      }),
+    });
+    if (crossScope.response.status !== 404) {
+      throw new Error(
+        `M03 cross-scope probe did not fail non-enumerating (got ${crossScope.response.status})`,
+      );
+    }
+    report.steps.push({ id: "M03", status: "pass", detail: "cross-scope probe returned 404" });
+
+    const created = await steward(env, "/v2/provider-actions", env.STEWARD_AGENT_JWT, {
+      method: "POST",
+      body: JSON.stringify({
+        workspaceId: env.STEWARD_SANDBOX_WORKSPACE_ID,
+        providerAccountId: env.STEWARD_SANDBOX_PROVIDER_ACCOUNT_ID,
+        operationKey: "github.pr.comment.create",
+        arguments: {
+          owner: env.STEWARD_SANDBOX_GITHUB_OWNER,
+          repo: env.STEWARD_SANDBOX_GITHUB_REPO,
+          pullNumber: Number(env.STEWARD_SANDBOX_GITHUB_PR_NUMBER),
+          body: `Steward Gate D sandbox marker: ${marker}`,
+        },
+        idempotencyKey: `gate-d-${marker}`,
+      }),
+    });
+    const intentId = created.id;
+    if (!intentId || created.status !== "pending_approval") {
+      throw new Error("provider action did not require approval");
+    }
+    report.steps.push({ id: "M04", status: "pass", detail: "write required approval" });
+    const approvalResponse = await steward(
+      env,
+      `/v2/provider-actions/${encodeURIComponent(intentId)}/approval`,
+      env.STEWARD_APPROVER_JWT,
+    );
+    const approval = approvalResponse.data ?? approvalResponse;
+    await steward(
+      env,
+      `/v2/provider-actions/${encodeURIComponent(intentId)}/approval`,
+      env.STEWARD_APPROVER_JWT,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          decision: "approve",
+          expectedVersion: approval.version,
+          expectedRequestHash: created.requestHash,
+          expectedActionDigest: created.actionDigest,
+          reason: "throwaway Gate D sandbox",
+          idempotencyKey: `approve-${marker}`,
+        }),
+      },
+    );
+    await steward(
+      env,
+      `/v2/provider-actions/${encodeURIComponent(intentId)}/execute`,
+      env.STEWARD_AGENT_JWT,
+      { method: "POST", body: "{}" },
+    );
+    report.steps.push({ id: "M06", status: "pass", detail: "recent-MFA approval accepted" });
+    report.steps.push({
+      id: "M09",
+      status: "pass",
+      detail: "execute reached execution_ready",
+      intentId,
+    });
+
+    // This worker reaches the real default forwarder, receives the upstream
+    // response, then pauses. Killing only that child models the exact crash
+    // window without weakening the server or adding a forgeable dispatch route.
+    const first = await runDispatchChild(env, intentId, {
+      pauseAfterUpstream: true,
+      timeoutMs: Number(env.STEWARD_SANDBOX_CHILD_TIMEOUT_MS ?? 2_000),
+    });
+    if (!first.timedOut || !first.reachedAfterUpstream) {
+      throw new Error("crash-window worker did not prove the post-upstream barrier");
+    }
+    const replay = await runDispatchChild(env, intentId);
+    if (replay.timedOut || replay.result?.code !== "EXEC_TERMINAL_STATE") {
+      throw new Error("fresh-worker replay was not rejected as terminal");
+    }
+    report.steps.push({
+      id: "M08/M14-M15",
+      status: "pass",
+      detail: "isolated post-upstream crash window; fresh-worker replay rejected",
+      replay: replay.result,
+    });
+    report.steps.push({
+      id: "M05/M07",
+      status: "covered_hermetically_only",
+      detail:
+        "stale-route and concurrent-dispatch mutation cases are not induced in the live sandbox",
+    });
+
+    // Mint a separate, fresh read token only in memory. Reconciliation is
+    // bounded provider GET; Steward has no reconciliation service to overclaim.
+    githubToken = await mintInstallationToken(env);
+    secretValues.push(githubToken);
+    const reconciliation = await reconcileGithubMarker({
+      apiBase: env.GITHUB_API_URL,
+      owner: env.STEWARD_SANDBOX_GITHUB_OWNER,
+      repo: env.STEWARD_SANDBOX_GITHUB_REPO,
+      pullNumber: env.STEWARD_SANDBOX_GITHUB_PR_NUMBER,
+      marker,
+      token: githubToken,
+    });
+    writeArtifact("provider-reconciliation.json", reconciliation, secretValues);
+    report.steps.push({
+      id: "M17",
+      status: reconciliation.outcome === "found" ? "pass" : "stop",
+      outcome: reconciliation.outcome,
+    });
+
+    const caseManifest = await steward(
+      env,
+      `/v2/provider-actions/${encodeURIComponent(intentId)}/case`,
+      env.STEWARD_APPROVER_JWT,
+    );
+    const evidence = await steward(
+      env,
+      `/v2/provider-actions/${encodeURIComponent(intentId)}/evidence`,
+      env.STEWARD_APPROVER_JWT,
+    );
+    // Evidence is a mode-0600 verifier input only and is deleted after both
+    // checks. The stable artifact set records the verifier result, not a second
+    // potentially sensitive copy of the bundle.
+    const evidencePath = join(OUT_DIR, ".evidence-for-verifier.json");
+    writeFileSync(evidencePath, JSON.stringify(evidence), { mode: 0o600 });
+    const clean = Bun.spawnSync(
+      [
+        "node",
+        join(ROOT, "scripts/verify-evidence-bundle.mjs"),
+        evidencePath,
+        "--expected-key-fingerprint",
+        env.STEWARD_AUDIT_SIGNING_KEY_FINGERPRINT,
+      ],
+      { cwd: ROOT },
+    );
+    const tampered = JSON.parse(readFileSync(evidencePath, "utf8"));
+    if (!tampered.bundle?.events?.[0]) throw new Error("evidence has no event to tamper");
+    tampered.bundle.events[0].action = `${tampered.bundle.events[0].action}.tampered`;
+    const tamperedPath = join(OUT_DIR, ".tampered-evidence.json");
+    writeFileSync(tamperedPath, JSON.stringify(tampered), { mode: 0o600 });
+    const dirty = Bun.spawnSync(
+      [
+        "node",
+        join(ROOT, "scripts/verify-evidence-bundle.mjs"),
+        tamperedPath,
+        "--expected-key-fingerprint",
+        env.STEWARD_AUDIT_SIGNING_KEY_FINGERPRINT,
+      ],
+      { cwd: ROOT },
+    );
+    unlinkSync(tamperedPath);
+    unlinkSync(evidencePath);
+    const verifierOk = clean.exitCode === 0 && dirty.exitCode === 1;
+    report.steps.push({
+      id: "M18",
+      status: verifierOk ? "pass" : "stop",
+      caseVersion: caseManifest.version ?? null,
+      completeness: caseManifest.completeness ?? null,
+    });
+
+    // GitHub may not emit a real rate limit during this run. Never induce abuse
+    // or turn the hermetic classifier proof into a fabricated live observation.
+    const liveRateLimitObserved = reconciliation.observations.some(
+      (observation) => observation.status === 403 || observation.status === 429,
+    );
+    report.steps.push({
+      id: "M16",
+      status: liveRateLimitObserved ? "pass" : "not_observed",
+      detail: liveRateLimitObserved
+        ? "bounded provider rate-limit response observed and classified"
+        : "403/429 classifier is hermetically tested; no live response was manufactured",
+    });
+    report.gateD =
+      reconciliation.outcome === "found" && verifierOk && liveRateLimitObserved ? "GO" : "STOP";
+    const git = Bun.spawnSync(["git", "rev-parse", "HEAD"], { cwd: ROOT });
+    const sha = git.exitCode === 0 ? git.stdout.toString().trim() : "unknown";
+    writeArtifact("image-commit.txt", sha, secretValues);
+    writeArtifact(
+      "dispatch-count.json",
+      { firstWorker: "killed_after_upstream", replay: replay.result, expectedProviderPosts: 1 },
+      secretValues,
+    );
+    writeArtifact(
+      "verifier-report.txt",
+      `clean=${clean.exitCode === 0 ? "PASS" : "FAIL"}\ntampered=${dirty.exitCode === 1 ? "FAIL_AS_REQUIRED" : "UNEXPECTED"}`,
+      secretValues,
+    );
+    writeArtifact("test-report.json", report, secretValues);
+    writeArtifact(
+      "manifest.json",
+      {
+        schemaVersion: 2,
+        claimWording: CLAIM,
+        gateD: report.gateD,
+        marker,
+        artifacts: [
+          "test-report.json",
+          "image-commit.txt",
+          "dispatch-count.json",
+          "verifier-report.txt",
+          "canary-report.json",
+          "provider-reconciliation.json",
+        ],
+      },
+      secretValues,
+    );
+    const artifactText = [
+      "test-report.json",
+      "image-commit.txt",
+      "dispatch-count.json",
+      "verifier-report.txt",
+      "provider-reconciliation.json",
+      "manifest.json",
+    ]
+      .map((name) => readFileSync(join(OUT_DIR, name), "utf8"))
+      .join("\n");
+    if (secretValues.some((value) => value.length >= 4 && artifactText.includes(value))) {
+      throw new Error("credential canary appeared in persisted artifacts");
+    }
+    writeArtifact(
+      "canary-report.json",
+      { clean: true, note: "all persisted artifacts passed the literal credential sweep" },
+      secretValues,
+    );
+    const canaryText = readFileSync(join(OUT_DIR, "canary-report.json"), "utf8");
+    if (secretValues.some((value) => value.length >= 4 && canaryText.includes(value))) {
+      throw new Error("credential canary appeared in canary report");
+    }
+    console.log(
+      `[sandbox] completed honest live observation; Gate D ${report.gateD}; artifacts: ${OUT_DIR}`,
+    );
+    if (report.gateD !== "GO") process.exitCode = 2;
+  } catch (error) {
+    writeArtifact(
+      "test-report.json",
+      { ...report, error: error.message, gateD: "STOP" },
+      secretValues,
+    );
+    fail(error.message);
+  } finally {
+    githubToken = undefined;
+    for (const name of [".evidence-for-verifier.json", ".tampered-evidence.json"]) {
+      const path = join(OUT_DIR, name);
+      if (existsSync(path)) unlinkSync(path);
+    }
+  }
 }
 
-main();
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+if (isMain) main();

--- a/scripts/provider-authority-sandbox.mjs
+++ b/scripts/provider-authority-sandbox.mjs
@@ -1,17 +1,20 @@
 #!/usr/bin/env node
 /** Gate D operator harness. It never persists or prints a provider credential. */
 import { spawn } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   buildDispatchEnvironment,
-  mintInstallationToken,
+  isLiveRateLimitObservation,
+  mintInstallationCredential,
   reconcileGithubMarker,
   requestJson,
+  revokeInstallationToken,
   scrub,
   validateBuildPrerequisites,
   validateEnvironment,
+  verifyInstallationScope,
 } from "./lib/provider-authority-sandbox-lib.mjs";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
@@ -20,6 +23,15 @@ const CLAIM =
   "Live behavior is recorded exactly as observed. Hermetic classification is not a live " +
   "rate-limit observation; Gate D remains STOP unless every required live observation passes.";
 const MAX_CHILD_OUTPUT_BYTES = 1024 * 1024;
+const ARTIFACT_NAMES = [
+  "test-report.json",
+  "image-commit.txt",
+  "dispatch-count.json",
+  "verifier-report.txt",
+  "canary-report.json",
+  "provider-reconciliation.json",
+  "manifest.json",
+];
 
 function fail(message) {
   console.error(`[sandbox] FAIL (fail-closed): ${message}`);
@@ -44,6 +56,60 @@ async function steward(env, path, token, options = {}) {
     throw new Error(`Steward ${options.method ?? "GET"} ${path} failed (${response.status})`);
   }
   return body;
+}
+
+async function prepareApprovedWrite(env, marker, body) {
+  const created = await steward(env, "/v2/provider-actions", env.STEWARD_AGENT_JWT, {
+    method: "POST",
+    body: JSON.stringify({
+      workspaceId: env.STEWARD_SANDBOX_WORKSPACE_ID,
+      providerAccountId: env.STEWARD_SANDBOX_PROVIDER_ACCOUNT_ID,
+      operationKey: "github.pr.comment.create",
+      arguments: {
+        owner: env.STEWARD_SANDBOX_GITHUB_OWNER,
+        repo: env.STEWARD_SANDBOX_GITHUB_REPO,
+        pullNumber: Number(env.STEWARD_SANDBOX_GITHUB_PR_NUMBER),
+        body,
+      },
+      idempotencyKey: `gate-d-${marker}`,
+    }),
+  });
+  if (!created.id || created.status !== "pending_approval") {
+    throw new Error("provider action did not require approval");
+  }
+  const approvalResponse = await steward(
+    env,
+    `/v2/provider-actions/${encodeURIComponent(created.id)}/approval`,
+    env.STEWARD_APPROVER_JWT,
+  );
+  const approval = approvalResponse.data ?? approvalResponse;
+  await steward(
+    env,
+    `/v2/provider-actions/${encodeURIComponent(created.id)}/approval`,
+    env.STEWARD_APPROVER_JWT,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        decision: "approve",
+        expectedVersion: approval.version,
+        expectedRequestHash: created.requestHash,
+        expectedActionDigest: created.actionDigest,
+        reason: "throwaway Gate D sandbox",
+        idempotencyKey: `approve-${marker}`,
+      }),
+    },
+  );
+  const executeResponse = await steward(
+    env,
+    `/v2/provider-actions/${encodeURIComponent(created.id)}/execute`,
+    env.STEWARD_AGENT_JWT,
+    { method: "POST", body: "{}" },
+  );
+  const execution = executeResponse.data ?? executeResponse;
+  if (execution.status !== "execution_ready") {
+    throw new Error(`execute did not reach execution_ready (got ${execution.status ?? "unknown"})`);
+  }
+  return created;
 }
 
 export function runDispatchChild(
@@ -138,7 +204,13 @@ async function main() {
   }
 
   mkdirSync(OUT_DIR, { recursive: true });
+  // A failed rerun must not inherit a manifest or supporting file from an older
+  // run. The manifest is written last, so its presence means this invocation
+  // completed the entire artifact pipeline.
+  for (const name of [...ARTIFACT_NAMES, ".evidence-for-verifier.json", ".tampered-evidence.json"])
+    rmSync(join(OUT_DIR, name), { force: true });
   let githubToken;
+  const activeGithubTokens = new Set();
   const marker = `steward-gate-d:${crypto.randomUUID()}`;
   const report = {
     schemaVersion: 2,
@@ -157,9 +229,19 @@ async function main() {
   ].filter((value) => typeof value === "string");
 
   try {
-    githubToken = await mintInstallationToken(env);
+    const installation = await mintInstallationCredential(env);
+    githubToken = installation.token;
+    activeGithubTokens.add(githubToken);
     secretValues.push(githubToken);
-    report.steps.push({ id: "setup-token", status: "pass", detail: "installation token minted" });
+    await verifyInstallationScope(installation, {
+      owner: env.STEWARD_SANDBOX_GITHUB_OWNER,
+      repo: env.STEWARD_SANDBOX_GITHUB_REPO,
+    });
+    report.steps.push({
+      id: "setup-token",
+      status: "pass",
+      detail: "short-lived token minted; exact permissions and one-repo scope verified",
+    });
 
     await steward(
       env,
@@ -212,54 +294,39 @@ async function main() {
     }
     report.steps.push({ id: "M03", status: "pass", detail: "cross-scope probe returned 404" });
 
-    const created = await steward(env, "/v2/provider-actions", env.STEWARD_AGENT_JWT, {
-      method: "POST",
-      body: JSON.stringify({
-        workspaceId: env.STEWARD_SANDBOX_WORKSPACE_ID,
-        providerAccountId: env.STEWARD_SANDBOX_PROVIDER_ACCOUNT_ID,
-        operationKey: "github.pr.comment.create",
-        arguments: {
-          owner: env.STEWARD_SANDBOX_GITHUB_OWNER,
-          repo: env.STEWARD_SANDBOX_GITHUB_REPO,
-          pullNumber: Number(env.STEWARD_SANDBOX_GITHUB_PR_NUMBER),
-          body: `Steward Gate D sandbox marker: ${marker}`,
-        },
-        idempotencyKey: `gate-d-${marker}`,
-      }),
-    });
-    const intentId = created.id;
-    if (!intentId || created.status !== "pending_approval") {
-      throw new Error("provider action did not require approval");
+    // Mint against secret version N, then rotate the same in-memory credential
+    // to version N+1. The old authorization must fail before decrypt/forward.
+    const staleMarker = `${marker}:stale-secret`;
+    const staleCreated = await prepareApprovedWrite(
+      env,
+      staleMarker,
+      `Steward Gate D stale probe (must not post): ${staleMarker}`,
+    );
+    await steward(
+      env,
+      `/secrets/${encodeURIComponent(env.STEWARD_SANDBOX_SECRET_ID)}/rotate`,
+      env.STEWARD_APPROVER_JWT,
+      { method: "POST", body: JSON.stringify({ value: installation.token }) },
+    );
+    const staleDispatch = await runDispatchChild(env, staleCreated.id);
+    if (staleDispatch.result?.code !== "EXEC_AUTH_STALE_SECRET") {
+      throw new Error(
+        `M05 stale-secret probe did not fail before forward (got ${staleDispatch.result?.code ?? "no result"})`,
+      );
     }
+    report.steps.push({
+      id: "M05",
+      status: "pass",
+      detail: "live post-mint secret rotation denied dispatch before provider I/O",
+    });
+
+    const created = await prepareApprovedWrite(
+      env,
+      marker,
+      `Steward Gate D sandbox marker: ${marker}`,
+    );
+    const intentId = created.id;
     report.steps.push({ id: "M04", status: "pass", detail: "write required approval" });
-    const approvalResponse = await steward(
-      env,
-      `/v2/provider-actions/${encodeURIComponent(intentId)}/approval`,
-      env.STEWARD_APPROVER_JWT,
-    );
-    const approval = approvalResponse.data ?? approvalResponse;
-    await steward(
-      env,
-      `/v2/provider-actions/${encodeURIComponent(intentId)}/approval`,
-      env.STEWARD_APPROVER_JWT,
-      {
-        method: "POST",
-        body: JSON.stringify({
-          decision: "approve",
-          expectedVersion: approval.version,
-          expectedRequestHash: created.requestHash,
-          expectedActionDigest: created.actionDigest,
-          reason: "throwaway Gate D sandbox",
-          idempotencyKey: `approve-${marker}`,
-        }),
-      },
-    );
-    await steward(
-      env,
-      `/v2/provider-actions/${encodeURIComponent(intentId)}/execute`,
-      env.STEWARD_AGENT_JWT,
-      { method: "POST", body: "{}" },
-    );
     report.steps.push({ id: "M06", status: "pass", detail: "recent-MFA approval accepted" });
     report.steps.push({
       id: "M09",
@@ -271,25 +338,33 @@ async function main() {
     // This worker reaches the real default forwarder, receives the upstream
     // response, then pauses. Killing only that child models the exact crash
     // window without weakening the server or adding a forgeable dispatch route.
-    const first = await runDispatchChild(env, intentId, {
-      pauseAfterUpstream: true,
-      timeoutMs: (() => {
-        const value = Number(env.STEWARD_SANDBOX_CHILD_TIMEOUT_MS ?? 2_000);
-        if (!Number.isSafeInteger(value) || value < 100 || value > 30_000) {
-          throw new Error("STEWARD_SANDBOX_CHILD_TIMEOUT_MS must be an integer from 100 to 30000");
-        }
-        return value;
-      })(),
-    });
-    if (first.spawnError) throw new Error("crash-window child failed to spawn");
-    if (first.outputExceeded) throw new Error("crash-window child exceeded the output limit");
-    if (!first.timedOut || !first.reachedAfterUpstream) {
-      throw new Error("crash-window worker did not prove the post-upstream barrier");
+    const childTimeoutMs = Number(env.STEWARD_SANDBOX_CHILD_TIMEOUT_MS ?? 2_000);
+    if (!Number.isSafeInteger(childTimeoutMs) || childTimeoutMs < 100 || childTimeoutMs >= 30_000) {
+      throw new Error("STEWARD_SANDBOX_CHILD_TIMEOUT_MS must be an integer from 100 through 29999");
+    }
+    const racers = await Promise.all(
+      Array.from({ length: 8 }, () =>
+        runDispatchChild(env, intentId, { pauseAfterUpstream: true, timeoutMs: childTimeoutMs }),
+      ),
+    );
+    const winners = racers.filter((result) => result.timedOut && result.reachedAfterUpstream);
+    const losers = racers.filter((result) => !result.timedOut);
+    if (
+      racers.some((result) => result.spawnError || result.outputExceeded) ||
+      winners.length !== 1 ||
+      losers.length !== 7 ||
+      losers.some(
+        (result) => !["EXEC_AUTH_CLAIM_LOST", "EXEC_TERMINAL_STATE"].includes(result.result?.code),
+      )
+    ) {
+      throw new Error("M07 concurrent workers did not produce exactly one upstream winner");
     }
     const replay = await runDispatchChild(env, intentId);
     if (replay.spawnError) throw new Error("replay child failed to spawn");
     if (replay.outputExceeded) throw new Error("replay child exceeded the output limit");
-    const childOutput = `${first.stdout}\n${first.stderr}\n${replay.stdout}\n${replay.stderr}`;
+    const childOutput = [...racers, replay]
+      .map((result) => `${result.stdout}\n${result.stderr}`)
+      .join("\n");
     if (secretValues.some((value) => value.length >= 4 && childOutput.includes(value))) {
       throw new Error("credential canary appeared in dispatch child output");
     }
@@ -297,21 +372,22 @@ async function main() {
       throw new Error("fresh-worker replay was not rejected as terminal");
     }
     report.steps.push({
-      id: "M08/M14-M15",
+      id: "M07",
+      status: "pass",
+      detail: "eight live workers raced; exactly one crossed the upstream barrier",
+    });
+    report.steps.push({
+      id: "M08/M14",
       status: "pass",
       detail: "isolated post-upstream crash window; fresh-worker replay rejected",
       replay: replay.result,
     });
-    report.steps.push({
-      id: "M05/M07",
-      status: "covered_hermetically_only",
-      detail:
-        "stale-route and concurrent-dispatch mutation cases are not induced in the live sandbox",
-    });
 
     // Mint a separate, fresh read token only in memory. Reconciliation is
     // bounded provider GET; Steward has no reconciliation service to overclaim.
-    githubToken = await mintInstallationToken(env);
+    const reconciliationInstallation = await mintInstallationCredential(env);
+    githubToken = reconciliationInstallation.token;
+    activeGithubTokens.add(githubToken);
     secretValues.push(githubToken);
     const reconciliation = await reconcileGithubMarker({
       apiBase: env.GITHUB_API_URL,
@@ -328,16 +404,45 @@ async function main() {
       outcome: reconciliation.outcome,
     });
 
-    const caseManifest = await steward(
+    for (const token of [...activeGithubTokens]) {
+      await revokeInstallationToken(token);
+      activeGithubTokens.delete(token);
+    }
+    githubToken = undefined;
+    report.steps.push({
+      id: "setup-token-revocation",
+      status: "pass",
+      detail: "all minted installation tokens revoked; vaulted dispatch token is inert",
+    });
+
+    const caseRecord = await steward(
       env,
       `/v2/provider-actions/${encodeURIComponent(intentId)}/case`,
       env.STEWARD_APPROVER_JWT,
     );
+    const caseManifest = caseRecord?.manifest;
+    if (!caseManifest || caseManifest.caseId !== intentId) {
+      throw new Error("live case response did not contain the expected case manifest");
+    }
     const evidence = await steward(
       env,
       `/v2/provider-actions/${encodeURIComponent(intentId)}/evidence`,
       env.STEWARD_APPROVER_JWT,
     );
+    const sensitiveEvidenceSurface = JSON.stringify({ caseRecord, evidence });
+    if (
+      secretValues.some((value) => value.length >= 4 && sensitiveEvidenceSurface.includes(value)) ||
+      /Bearer\s+[A-Za-z0-9._~-]+|(?:gh[psuor]_|github_pat_)[A-Za-z0-9_]+|-----BEGIN [^-]+-----/i.test(
+        sensitiveEvidenceSurface,
+      )
+    ) {
+      throw new Error("M15 credential material appeared in the live case/evidence response");
+    }
+    report.steps.push({
+      id: "M15",
+      status: "pass",
+      detail: "live case and evidence responses contained no credential material",
+    });
     // Evidence is a mode-0600 verifier input only and is deleted after both
     // checks. The stable artifact set records the verifier result, not a second
     // potentially sensitive copy of the bundle.
@@ -371,18 +476,22 @@ async function main() {
     unlinkSync(tamperedPath);
     unlinkSync(evidencePath);
     const verifierOk = clean.exitCode === 0 && dirty.exitCode === 1;
+    const honestIncompleteCase =
+      ["incomplete", "unknown"].includes(caseManifest.completeness) &&
+      ["executing", "outcome_unknown"].includes(caseManifest.terminalState) &&
+      Array.isArray(caseManifest.incompletenessReasons) &&
+      caseManifest.incompletenessReasons.length > 0;
     report.steps.push({
       id: "M18",
-      status: verifierOk ? "pass" : "stop",
-      caseVersion: caseManifest.version ?? null,
+      status: verifierOk && honestIncompleteCase ? "pass" : "stop",
+      caseVersion: caseManifest.schemaVersion ?? null,
       completeness: caseManifest.completeness ?? null,
+      terminalState: caseManifest.terminalState ?? null,
     });
 
     // GitHub may not emit a real rate limit during this run. Never induce abuse
     // or turn the hermetic classifier proof into a fabricated live observation.
-    const liveRateLimitObserved = reconciliation.observations.some(
-      (observation) => observation.status === 403 || observation.status === 429,
-    );
+    const liveRateLimitObserved = reconciliation.observations.some(isLiveRateLimitObservation);
     report.steps.push({
       id: "M16",
       status: liveRateLimitObserved ? "pass" : "not_observed",
@@ -391,13 +500,24 @@ async function main() {
         : "403/429 classifier is hermetically tested; no live response was manufactured",
     });
     report.gateD =
-      reconciliation.outcome === "found" && verifierOk && liveRateLimitObserved ? "GO" : "STOP";
+      reconciliation.outcome === "found" &&
+      verifierOk &&
+      honestIncompleteCase &&
+      liveRateLimitObserved
+        ? "GO"
+        : "STOP";
     const git = Bun.spawnSync(["git", "rev-parse", "HEAD"], { cwd: ROOT });
     const sha = git.exitCode === 0 ? git.stdout.toString().trim() : "unknown";
     writeArtifact("image-commit.txt", sha, secretValues);
     writeArtifact(
       "dispatch-count.json",
-      { firstWorker: "killed_after_upstream", replay: replay.result, expectedProviderPosts: 1 },
+      {
+        concurrentWorkers: racers.length,
+        upstreamWinners: winners.length,
+        winner: "killed_after_upstream",
+        replay: replay.result,
+        expectedProviderPosts: 1,
+      },
       secretValues,
     );
     writeArtifact(
@@ -406,6 +526,28 @@ async function main() {
       secretValues,
     );
     writeArtifact("test-report.json", report, secretValues);
+    const artifactText = [
+      "test-report.json",
+      "image-commit.txt",
+      "dispatch-count.json",
+      "verifier-report.txt",
+      "provider-reconciliation.json",
+    ]
+      .map((name) => readFileSync(join(OUT_DIR, name), "utf8"))
+      .join("\n");
+    if (secretValues.some((value) => value.length >= 4 && artifactText.includes(value))) {
+      throw new Error("credential canary appeared in persisted artifacts");
+    }
+    writeArtifact(
+      "canary-report.json",
+      { clean: true, note: "all persisted artifacts passed the literal credential sweep" },
+      secretValues,
+    );
+    const canaryText = readFileSync(join(OUT_DIR, "canary-report.json"), "utf8");
+    if (secretValues.some((value) => value.length >= 4 && canaryText.includes(value))) {
+      throw new Error("credential canary appeared in canary report");
+    }
+    // The manifest is the completion marker and is deliberately written last.
     writeArtifact(
       "manifest.json",
       {
@@ -424,28 +566,6 @@ async function main() {
       },
       secretValues,
     );
-    const artifactText = [
-      "test-report.json",
-      "image-commit.txt",
-      "dispatch-count.json",
-      "verifier-report.txt",
-      "provider-reconciliation.json",
-      "manifest.json",
-    ]
-      .map((name) => readFileSync(join(OUT_DIR, name), "utf8"))
-      .join("\n");
-    if (secretValues.some((value) => value.length >= 4 && artifactText.includes(value))) {
-      throw new Error("credential canary appeared in persisted artifacts");
-    }
-    writeArtifact(
-      "canary-report.json",
-      { clean: true, note: "all persisted artifacts passed the literal credential sweep" },
-      secretValues,
-    );
-    const canaryText = readFileSync(join(OUT_DIR, "canary-report.json"), "utf8");
-    if (secretValues.some((value) => value.length >= 4 && canaryText.includes(value))) {
-      throw new Error("credential canary appeared in canary report");
-    }
     console.log(
       `[sandbox] completed honest live observation; Gate D ${report.gateD}; artifacts: ${OUT_DIR}`,
     );
@@ -459,6 +579,18 @@ async function main() {
     fail(error.message);
   } finally {
     githubToken = undefined;
+    // Best-effort cleanup on every failure path. A cleanup failure is reported
+    // without printing the token; GitHub's normal one-hour expiry remains the
+    // final backstop if the provider is unreachable.
+    for (const token of [...activeGithubTokens]) {
+      try {
+        await revokeInstallationToken(token);
+        activeGithubTokens.delete(token);
+      } catch (error) {
+        console.error(`[sandbox] token cleanup warning: ${error.message}`);
+        process.exitCode = 1;
+      }
+    }
     for (const name of [".evidence-for-verifier.json", ".tampered-evidence.json"]) {
       const path = join(OUT_DIR, name);
       if (existsSync(path)) unlinkSync(path);


### PR DESCRIPTION
## Summary

- replace the preflight-only Gate D stub with an executable, fail-closed operator harness
- mint a short-lived GitHub App installation token with RS256 and rotate it through the live recent-MFA secret API without persisting or printing it
- drive the public governed create/approval/execute path, then dispatch only from an isolated local child importing `dispatchGovernedExecution` (no public dispatch or reconciliation authority added)
- model the post-upstream crash window with an explicit child barrier, prove a fresh child cannot re-post, and reconcile the unique marker through bounded read-only GitHub pagination
- verify clean/tampered case evidence offline and emit the five standard scrubbed artifacts plus provider reconciliation and a claims-disciplined manifest
- classify 403/429 hermetically with capped `Retry-After`; if a live run does not observe that response, record M16 `not_observed` and Gate D `STOP`

## Security boundaries

- the dispatch child receives only an allowlisted DB/vault/execution/audit environment; GitHub App keys, provider tokens, and API JWTs are excluded
- preflight performs zero network requests and checks explicit workspace build prerequisites
- the harness does not install/build implicitly, add a network dispatch route, claim Steward has a reconciliation service, or manufacture live rate-limit evidence
- GitHub App scope is corrected to `metadata:read` + `issues:write` because pull-request comments use the Issues API

## Validation (exact head)

- `bun test scripts/__tests__/provider-authority-sandbox.test.ts` — 9 pass, 32 assertions
- `(cd packages/api && bun test --timeout 30000 src/__tests__/provider-authority-e2e.test.ts)` — 11 pass, 35 assertions, including timeout → outcome_unknown and one-dispatch replay proof
- `bun run lint` — 1,065 files clean
- `bun run typecheck` — 32 package builds + web typecheck pass
- `bunx turbo run build --filter=@stwd/proxy...` — 9/9 packages pass
- `git diff --check` — clean

## Live status

No real GitHub or Steward mutation was performed: throwaway org/App credentials and a live pre-provisioned authority graph were not available. This PR makes that operator acceptance executable but deliberately does not claim the real Gate D proof is complete.

Refs #230
