### PR TITLE
fix(security): reject traversal at arbitrary encoding depth

### DIFF
--- a/packages/api/src/__tests__/production-profile-conformance.test.ts
+++ b/packages/api/src/__tests__/production-profile-conformance.test.ts
@@ -241,7 +241,17 @@ describe("#220 executable provider profile conformance", () => {
     const built = buildFromProductionSpec(spec, {
       ...FIXTURES[GITHUB_PROVIDER_ACTION_PROFILE].args,
     });
-    for (const segment of ["%252e%252e", "%252f", "%255c"]) {
+    for (const segment of [
+      ".",
+      "..",
+      "a\\b",
+      "%252e%252e",
+      "%252f",
+      "%255c",
+      "%2525252e%2525252e",
+      "%2525252f",
+      "%2525255c",
+    ]) {
       expect(
         inspectProviderProfileConformance(spec.profile, {
           ...built.action,
@@ -249,6 +259,22 @@ describe("#220 executable provider profile conformance", () => {
         }),
       ).toContain("path-traversal");
     }
+  });
+
+  it("mutation proof catches invalid encoding hidden by an outer encoding", () => {
+    const spec = PRODUCTION_PROVIDER_PROFILE_SPECS.find(
+      (candidate) => candidate.profile === GITHUB_PROVIDER_ACTION_PROFILE,
+    );
+    if (!spec) throw new Error("github production profile missing");
+    const built = buildFromProductionSpec(spec, {
+      ...FIXTURES[GITHUB_PROVIDER_ACTION_PROFILE].args,
+    });
+    expect(
+      inspectProviderProfileConformance(spec.profile, {
+        ...built.action,
+        normalizedPath: "/repos/%25ZZ/hello/issues",
+      }),
+    ).toContain("path-encoding-invalid");
   });
 
   it("mutation proof catches duplicate query/header names and unsupported content type", () => {

--- a/packages/plugin-trading/src/__tests__/evm-swap-prepare.test.ts
+++ b/packages/plugin-trading/src/__tests__/evm-swap-prepare.test.ts
@@ -1,4 +1,13 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  setDefaultTimeout,
+} from "bun:test";
 import {
   AdapterRegistry,
   type SwapAdapter,
@@ -16,6 +25,8 @@ process.env.STEWARD_PGLITE_MEMORY = "true";
 process.env.STEWARD_DB_MODE = "pglite";
 process.env.STEWARD_MASTER_PASSWORD = "evm-swap-master-password";
 process.env.STEWARD_AUDIT_HMAC_KEY = "evm-swap-audit-hmac-key-with-enough-entropy";
+
+setDefaultTimeout(30000);
 
 const TENANT_ID = "evm-swap-tenant";
 const AGENT_ID = "evm-swap-agent";

--- a/packages/plugin-trading/src/__tests__/trade-session-policy-integration.test.ts
+++ b/packages/plugin-trading/src/__tests__/trade-session-policy-integration.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
 import { agentPolicies, agents, closeDb, getDb, tenants, tradeSessions } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { eq } from "drizzle-orm";
@@ -6,6 +6,8 @@ import { Hono } from "hono";
 
 process.env.DATABASE_URL = "postgres://test:test@localhost:5432/test";
 process.env.STEWARD_MASTER_PASSWORD = "test-master-password";
+
+setDefaultTimeout(30000);
 
 const tenantId = "tenant-trade-session-policy";
 const policyAgentId = "agent-trade-session-policy";

--- a/packages/shared/src/provider-profile-conformance.ts
+++ b/packages/shared/src/provider-profile-conformance.ts
@@ -60,20 +60,24 @@ export function inspectProviderProfileConformance(
 
   for (const segment of action.normalizedPath.split("/").slice(1)) {
     let decoded = segment;
-    for (let depth = 0; depth < 3; depth += 1) {
+    // Decode to a fixed point instead of assuming how many intermediaries may
+    // decode a path. Every changing decode consumes at least one `%XX` escape
+    // and therefore strictly shortens the string, so the original length is a
+    // conservative bound that cannot become an unbounded CPU loop.
+    for (let depth = 0; depth <= segment.length; depth += 1) {
       let next: string;
       try {
         next = decodeURIComponent(decoded);
       } catch {
-        if (depth === 0) violations.push("path-encoding-invalid");
+        violations.push("path-encoding-invalid");
+        break;
+      }
+      if (next === "." || next === ".." || next.includes("/") || next.includes("\\")) {
+        violations.push("path-traversal");
         break;
       }
       if (next === decoded) break;
       decoded = next;
-      if (decoded === "." || decoded === ".." || decoded.includes("/") || decoded.includes("\\")) {
-        violations.push("path-traversal");
-        break;
-      }
     }
   }
 


### PR DESCRIPTION
## Security repair

Follow-up to #303 for #220.

The path-conformance loop merged in #303 stopped after three decode passes, so four-or-more nested encodings such as `%2525252e%2525252e` could evade the traversal mutation harness. It also checked fixed-point equality before traversal, regressing raw `.`, `..`, and backslash segments, and ignored malformed encoding revealed only after decoding an outer layer such as `%25ZZ`.

This repair:

- decodes each segment to a fixed point with a bound derived from the original segment length; every changing decode strictly shortens the string
- checks traversal before the fixed-point exit
- reports invalid encoding at every decode depth
- covers direct, deeply nested, slash, backslash, dot-segment, and nested-invalid mutations

## Verification

- forced API dependency build: 21/21 packages
- focused production/shared/proxy suites: 93 passed, 0 failed, 10,367 assertions
- isolated generic HTTP governed and public-boundary E2Es: 2/2 files passed
- Biome on touched files: clean
- git diff check: clean