### PR TITLE
test(providers): exercise every registered profile boundary

### DIFF
--- a/packages/api/src/__tests__/production-profile-conformance.test.ts
+++ b/packages/api/src/__tests__/production-profile-conformance.test.ts
@@ -1,13 +1,17 @@
 import { describe, expect, it } from "bun:test";
 import type { GithubOperationKey } from "@stwd/provider-github";
 import type { XOperationKey } from "@stwd/provider-x";
+import { parseGovernedCanonicalActionForDispatch } from "@stwd/proxy/src/handlers/governed-execution";
 import {
   CanonError,
+  canonicalApprovalCommitmentObject,
+  computeApprovalCommitmentHash,
   GENERIC_GOLDEN_DESCRIPTOR_A,
   GENERIC_HTTP_PROVIDER_ACTION_PROFILE,
   GITHUB_PROVIDER_ACTION_PROFILE,
   inspectProviderProfileConformance,
   jcsStringify,
+  type ProviderApprovalCommitmentV1,
   REGISTERED_PROFILES,
   strictParseJson,
   validateGenericHttpDescriptor,
@@ -113,6 +117,12 @@ function buildFromProductionSpec(
   }
 }
 
+function allowedOriginsFromProductionSpec(spec: ProductionProviderProfileSpec): readonly string[] {
+  return spec.kind === "config-driven"
+    ? spec.allowedOrigins(GENERIC_DESCRIPTOR)
+    : spec.allowedOrigins;
+}
+
 function thrownCode(fn: () => unknown): string {
   try {
     fn();
@@ -122,7 +132,126 @@ function thrownCode(fn: () => unknown): string {
   }
 }
 
+const HASH = `sha256:${"1".repeat(64)}`;
+
+/**
+ * One runner for every registered production profile and for mutation proof.
+ * Every stage consumes the prior stage's serialized output, so a friendly
+ * handwritten snapshot cannot hide drift at a later deserialization boundary.
+ */
+function runFullBoundaryConformance(
+  spec: ProductionProviderProfileSpec,
+  mutate?: (
+    action: ReturnType<typeof buildFromProductionSpec>["action"],
+  ) => ReturnType<typeof buildFromProductionSpec>["action"],
+): string[] {
+  const built = buildFromProductionSpec(spec, { ...FIXTURES[spec.profile].args });
+  const apiAction = mutate ? mutate(built.action) : built.action;
+  const allowedOrigins = allowedOriginsFromProductionSpec(spec);
+  const apiViolations = inspectProviderProfileConformance(spec.profile, allowedOrigins, apiAction, [
+    "registered-malicious-canary",
+  ]);
+  if (apiViolations.length > 0) throw new Error(`api:${apiViolations.join(",")}`);
+
+  // Public wire snapshot: strict parser and exact JCS bytes used for persistence.
+  const wireText = jcsStringify(apiAction);
+  const wireAction = strictParseJson(wireText) as typeof apiAction;
+  expect(jcsStringify(wireAction)).toBe(wireText);
+
+  // Exact parser used by the governed proxy dispatch boundary.
+  const proxyAction = parseGovernedCanonicalActionForDispatch(new TextEncoder().encode(wireText));
+  expect(jcsStringify(proxyAction)).toBe(wireText);
+
+  // Approval reconstruction binds the registered profile and action digest.
+  const approval: ProviderApprovalCommitmentV1 = {
+    schemaVersion: "steward.provider-approval-commitment.v1",
+    intentId: "intent-conformance",
+    tenantId: "tenant-conformance",
+    workspaceId: "00000000-0000-4000-8000-000000000001",
+    requestActor: { type: "agent", id: "agent-conformance", revision: 1 },
+    providerAccount: {
+      id: "00000000-0000-4000-8000-000000000002",
+      revision: 1,
+      status: "active",
+    },
+    operation: {
+      id: "00000000-0000-4000-8000-000000000003",
+      key: FIXTURES[spec.profile].operationKey,
+      revision: 1,
+      riskClass: "write",
+      canonicalProfile: proxyAction.profile,
+    },
+    requestHash: HASH,
+    actionDigest: HASH,
+    accessDecision: {
+      id: "00000000-0000-4000-8000-000000000004",
+      hash: HASH,
+      effect: "allow",
+      matchedBindings: [],
+      matchedGrants: [],
+    },
+    policyDecision: {
+      id: "00000000-0000-4000-8000-000000000005",
+      hash: HASH,
+      effect: "approval_required",
+      policyRevisionHash: HASH,
+      approvalPolicyRevisionHash: HASH,
+      evaluatorVersion: "conformance-v1",
+    },
+    executionDependencies: {
+      routeId: "00000000-0000-4000-8000-000000000006",
+      routeRevision: 1,
+      secretId: "00000000-0000-4000-8000-000000000007",
+      secretVersion: 1,
+    },
+    approvalRequirements: {
+      role: "workspace_approver",
+      requesterSeparation: true,
+      maxMfaAgeSeconds: 300,
+      requiredMfaAssurance: "current-session-mfa",
+    },
+    requestedAt: "2026-01-01T00:00:00.000Z",
+    expiresAt: "2026-01-01T00:05:00.000Z",
+  };
+  const approvalText = jcsStringify(canonicalApprovalCommitmentObject(approval));
+  const reloadedApproval = strictParseJson(approvalText) as ProviderApprovalCommitmentV1;
+  expect(reloadedApproval.operation.canonicalProfile).toBe(spec.profile);
+  expect(computeApprovalCommitmentHash(reloadedApproval)).toBe(
+    computeApprovalCommitmentHash(approval),
+  );
+
+  // Evidence reconstruction consumes only the persisted wire snapshot/profile.
+  const evidenceText = jcsStringify({
+    operation: { canonicalProfile: reloadedApproval.operation.canonicalProfile },
+    canonicalAction: proxyAction,
+  });
+  const evidence = strictParseJson(evidenceText) as {
+    operation: { canonicalProfile: string };
+    canonicalAction: typeof apiAction;
+  };
+  expect(evidence.operation.canonicalProfile).toBe(spec.profile);
+  expect(
+    inspectProviderProfileConformance(spec.profile, allowedOrigins, evidence.canonicalAction),
+  ).toEqual([]);
+  return ["api", "wire", "proxy", "approval", "evidence"];
+}
+
 describe("#220 executable provider profile conformance", () => {
+  it("runs every registered profile through every production boundary", () => {
+    expect(PRODUCTION_PROVIDER_PROFILE_SPECS.map((spec) => spec.profile).sort()).toEqual(
+      [...REGISTERED_PROFILES].sort(),
+    );
+    for (const spec of PRODUCTION_PROVIDER_PROFILE_SPECS) {
+      expect(runFullBoundaryConformance(spec)).toEqual([
+        "api",
+        "wire",
+        "proxy",
+        "approval",
+        "evidence",
+      ]);
+    }
+  });
+
   it("has exactly one executable production spec for every registered profile", () => {
     expect(PRODUCTION_PROVIDER_PROFILE_SPECS.map((spec) => spec.profile).sort()).toEqual(
       [...REGISTERED_PROFILES].sort(),
@@ -154,7 +283,13 @@ describe("#220 executable provider profile conformance", () => {
           fixture,
         );
         expect(jcsStringify(first.action)).toBe(jcsStringify(reordered.action));
-        expect(inspectProviderProfileConformance(spec.profile, first.action)).toEqual([]);
+        expect(
+          inspectProviderProfileConformance(
+            spec.profile,
+            allowedOriginsFromProductionSpec(spec),
+            first.action,
+          ),
+        ).toEqual([]);
 
         for (const [key, value] of Object.entries(canaries)) {
           const codeA = thrownCode(() =>
@@ -198,22 +333,33 @@ describe("#220 executable provider profile conformance", () => {
     }
   });
 
-  it("mutation proof catches a credential header injected into real production output", () => {
+  it("a malicious registered fixture makes the identical full runner fail", () => {
     const spec = PRODUCTION_PROVIDER_PROFILE_SPECS.find(
       (candidate) => candidate.profile === GITHUB_PROVIDER_ACTION_PROFILE,
     );
     if (!spec) throw new Error("github production profile missing");
-    const built = buildFromProductionSpec(spec, {
-      ...FIXTURES[GITHUB_PROVIDER_ACTION_PROFILE].args,
-    });
-    const mutated = {
+    expect(() =>
+      runFullBoundaryConformance(spec, (action) => ({
+        ...action,
+        selectedHeaders: [
+          ...action.selectedHeaders,
+          ["authorization", "registered-malicious-canary"],
+        ],
+      })),
+    ).toThrow("api:credential-canary-present,credential-header");
+
+    // Defense in depth: even bypassing API/storage, the exact production proxy
+    // parser independently denies the same malicious registered snapshot.
+    const built = buildFromProductionSpec(spec, FIXTURES[GITHUB_PROVIDER_ACTION_PROFILE].args);
+    const malicious = {
       ...built.action,
-      selectedHeaders: [...built.action.selectedHeaders, ["authorization", "mutation-canary"]],
+      selectedHeaders: [["authorization", "registered-malicious-canary"]] as Array<
+        [string, string]
+      >,
     };
-    expect(inspectProviderProfileConformance(spec.profile, mutated, ["mutation-canary"])).toEqual([
-      "credential-canary-present",
-      "credential-header",
-    ]);
+    expect(() =>
+      parseGovernedCanonicalActionForDispatch(new TextEncoder().encode(jcsStringify(malicious))),
+    ).toThrow("canonical action conformance failed");
   });
 
   it("mutation proof catches an SSRF origin and noncanonical method", () => {
@@ -225,12 +371,18 @@ describe("#220 executable provider profile conformance", () => {
       ...FIXTURES[GITHUB_PROVIDER_ACTION_PROFILE].args,
     });
     expect(
-      inspectProviderProfileConformance(spec.profile, {
+      inspectProviderProfileConformance(spec.profile, allowedOriginsFromProductionSpec(spec), {
+        ...built.action,
+        origin: "https://attacker.example",
+      }),
+    ).toEqual(["origin-not-allowed"]);
+    expect(
+      inspectProviderProfileConformance(spec.profile, allowedOriginsFromProductionSpec(spec), {
         ...built.action,
         method: "get",
         origin: "https://127.0.0.1",
       }),
-    ).toEqual(["method-not-canonical", "origin-not-canonical-https"]);
+    ).toEqual(["method-not-canonical", "origin-not-allowed", "origin-not-canonical-https"]);
   });
 
   it("mutation proof catches nested-encoded path traversal", () => {
@@ -253,7 +405,7 @@ describe("#220 executable provider profile conformance", () => {
       "%2525255c",
     ]) {
       expect(
-        inspectProviderProfileConformance(spec.profile, {
+        inspectProviderProfileConformance(spec.profile, allowedOriginsFromProductionSpec(spec), {
           ...built.action,
           normalizedPath: `/repos/${segment}/hello/issues`,
         }),
@@ -281,7 +433,7 @@ describe("#220 executable provider profile conformance", () => {
     for (const spec of PRODUCTION_PROVIDER_PROFILE_SPECS) {
       const built = buildFromProductionSpec(spec, { ...FIXTURES[spec.profile].args });
       expect(
-        inspectProviderProfileConformance(spec.profile, {
+        inspectProviderProfileConformance(spec.profile, allowedOriginsFromProductionSpec(spec), {
           ...built.action,
           canonicalBody: { ok: true },
           orderedQueryPairs: [
@@ -297,5 +449,23 @@ describe("#220 executable provider profile conformance", () => {
         }),
       ).toEqual(["content-type-unsupported", "header-duplicate", "query-duplicate"]);
     }
+  });
+
+  it("mutation proof catches credential-shaped query and nested body fields", () => {
+    const spec = PRODUCTION_PROVIDER_PROFILE_SPECS.find(
+      (candidate) => candidate.profile === GITHUB_PROVIDER_ACTION_PROFILE,
+    );
+    if (!spec) throw new Error("github production profile missing");
+    const built = buildFromProductionSpec(spec, {
+      ...FIXTURES[GITHUB_PROVIDER_ACTION_PROFILE].args,
+    });
+    expect(
+      inspectProviderProfileConformance(spec.profile, allowedOriginsFromProductionSpec(spec), {
+        ...built.action,
+        orderedQueryPairs: [...built.action.orderedQueryPairs, ["access_token", "mutation"]],
+        canonicalBody: { nested: { client_secret: "mutation" } },
+        selectedHeaders: [["content-type", "application/json"]],
+      }),
+    ).toEqual(["credential-body-field", "credential-query"]);
   });
 });

--- a/packages/api/src/__tests__/production-profile-conformance.test.ts
+++ b/packages/api/src/__tests__/production-profile-conformance.test.ts
@@ -159,7 +159,11 @@ function runFullBoundaryConformance(
   expect(jcsStringify(wireAction)).toBe(wireText);
 
   // Exact parser used by the governed proxy dispatch boundary.
-  const proxyAction = parseGovernedCanonicalActionForDispatch(new TextEncoder().encode(wireText));
+  const proxyAction = parseGovernedCanonicalActionForDispatch(
+    new TextEncoder().encode(wireText),
+    spec.profile,
+    allowedOrigins,
+  );
   expect(jcsStringify(proxyAction)).toBe(wireText);
 
   // Approval reconstruction binds the registered profile and action digest.
@@ -358,8 +362,43 @@ describe("#220 executable provider profile conformance", () => {
       >,
     };
     expect(() =>
-      parseGovernedCanonicalActionForDispatch(new TextEncoder().encode(jcsStringify(malicious))),
+      parseGovernedCanonicalActionForDispatch(
+        new TextEncoder().encode(jcsStringify(malicious)),
+        spec.profile,
+        allowedOriginsFromProductionSpec(spec),
+      ),
     ).toThrow("canonical action conformance failed");
+  });
+
+  it("proxy parsing binds profile, origin, and the shared credential vocabulary externally", () => {
+    const spec = PRODUCTION_PROVIDER_PROFILE_SPECS.find(
+      (candidate) => candidate.profile === GITHUB_PROVIDER_ACTION_PROFILE,
+    );
+    if (!spec) throw new Error("github production profile missing");
+    const built = buildFromProductionSpec(spec, FIXTURES[GITHUB_PROVIDER_ACTION_PROFILE].args);
+    const parse = (action: typeof built.action) =>
+      parseGovernedCanonicalActionForDispatch(
+        new TextEncoder().encode(jcsStringify(action)),
+        spec.profile,
+        allowedOriginsFromProductionSpec(spec),
+      );
+
+    expect(() => parse({ ...built.action, origin: "https://attacker.example" })).toThrow(
+      "origin-not-allowed",
+    );
+    expect(() => parse({ ...built.action, profile: X_PROVIDER_ACTION_PROFILE })).toThrow(
+      "profile-mismatch",
+    );
+
+    for (const key of ["auth", "passphrase", "clientSecretValue", "cookieHeader"]) {
+      expect(() =>
+        parse({
+          ...built.action,
+          canonicalBody: { nested: { [key]: "registered-malicious-canary" } },
+          selectedHeaders: [["content-type", "application/json"]],
+        }),
+      ).toThrow("credential-body-field");
+    }
   });
 
   it("mutation proof catches an SSRF origin and noncanonical method", () => {
@@ -422,7 +461,7 @@ describe("#220 executable provider profile conformance", () => {
       ...FIXTURES[GITHUB_PROVIDER_ACTION_PROFILE].args,
     });
     expect(
-      inspectProviderProfileConformance(spec.profile, {
+      inspectProviderProfileConformance(spec.profile, allowedOriginsFromProductionSpec(spec), {
         ...built.action,
         normalizedPath: "/repos/%25ZZ/hello/issues",
       }),

--- a/packages/api/src/services/provider-action-profile-specs.ts
+++ b/packages/api/src/services/provider-action-profile-specs.ts
@@ -29,18 +29,21 @@ export type ProductionProviderProfileSpec =
       readonly profile: typeof GITHUB_PROVIDER_ACTION_PROFILE;
       readonly kind: "adapter-fixed";
       readonly operationKeys: readonly GithubOperationKey[];
+      readonly allowedOrigins: readonly string[];
       build(operationKey: GithubOperationKey, args: unknown): GithubActionBuild;
     }
   | {
       readonly profile: typeof X_PROVIDER_ACTION_PROFILE;
       readonly kind: "adapter-fixed";
       readonly operationKeys: readonly XOperationKey[];
+      readonly allowedOrigins: readonly string[];
       build(operationKey: XOperationKey, args: unknown): XActionBuild;
     }
   | {
       readonly profile: typeof GENERIC_HTTP_PROVIDER_ACTION_PROFILE;
       readonly kind: "config-driven";
       readonly operationKeys: readonly [];
+      allowedOrigins(descriptor: GenericHttpOperationDescriptorV1): readonly string[];
       build(
         operationKey: string,
         args: unknown,
@@ -53,6 +56,7 @@ const GITHUB_SPEC = Object.freeze({
   profile: GITHUB_PROVIDER_ACTION_PROFILE,
   kind: "adapter-fixed" as const,
   operationKeys: Object.freeze([...GITHUB_OPERATION_KEYS]),
+  allowedOrigins: Object.freeze(["https://api.github.com"]),
   build: buildGithubAction,
 });
 
@@ -60,6 +64,7 @@ const X_SPEC = Object.freeze({
   profile: X_PROVIDER_ACTION_PROFILE,
   kind: "adapter-fixed" as const,
   operationKeys: Object.freeze([...X_OPERATION_KEYS]),
+  allowedOrigins: Object.freeze(["https://api.x.com"]),
   build: buildXAction,
 });
 
@@ -67,6 +72,8 @@ const GENERIC_HTTP_SPEC = Object.freeze({
   profile: GENERIC_HTTP_PROVIDER_ACTION_PROFILE,
   kind: "config-driven" as const,
   operationKeys: Object.freeze([]) as readonly [],
+  allowedOrigins: (descriptor: GenericHttpOperationDescriptorV1) =>
+    Object.freeze([descriptor.origin]),
   build: (
     operationKey: string,
     args: unknown,

--- a/packages/api/src/services/provider-action-profile-specs.ts
+++ b/packages/api/src/services/provider-action-profile-specs.ts
@@ -24,6 +24,14 @@ import {
 
 export type AdapterFixedActionBuild = GithubActionBuild | XActionBuild;
 
+function fixedProfileOrigins(profile: string): readonly string[] {
+  const descriptor = getProfileDescriptor(profile);
+  if (!descriptor || descriptor.kind !== "adapter-fixed") {
+    throw new Error(`adapter-fixed profile metadata missing for '${profile}'`);
+  }
+  return descriptor.allowedOrigins;
+}
+
 export type ProductionProviderProfileSpec =
   | {
       readonly profile: typeof GITHUB_PROVIDER_ACTION_PROFILE;
@@ -56,7 +64,7 @@ const GITHUB_SPEC = Object.freeze({
   profile: GITHUB_PROVIDER_ACTION_PROFILE,
   kind: "adapter-fixed" as const,
   operationKeys: Object.freeze([...GITHUB_OPERATION_KEYS]),
-  allowedOrigins: Object.freeze(["https://api.github.com"]),
+  allowedOrigins: fixedProfileOrigins(GITHUB_PROVIDER_ACTION_PROFILE),
   build: buildGithubAction,
 });
 
@@ -64,7 +72,7 @@ const X_SPEC = Object.freeze({
   profile: X_PROVIDER_ACTION_PROFILE,
   kind: "adapter-fixed" as const,
   operationKeys: Object.freeze([...X_OPERATION_KEYS]),
-  allowedOrigins: Object.freeze(["https://api.x.com"]),
+  allowedOrigins: fixedProfileOrigins(X_PROVIDER_ACTION_PROFILE),
   build: buildXAction,
 });
 

--- a/packages/api/src/services/provider-case.ts
+++ b/packages/api/src/services/provider-case.ts
@@ -29,6 +29,7 @@ import {
   redactWebhookSecrets,
 } from "@stwd/db";
 import {
+  assertRegisteredProfile,
   chainSegmentBrokenReason,
   describeThrown,
   missingRoleReason,
@@ -567,7 +568,7 @@ function buildManifest(args: BuildManifestArgs): ProviderCaseAssembly {
       id: binding.operationId,
       key: operation?.operationKey ?? "",
       revision: binding.operationRevision,
-      canonicalProfile: binding.canonicalProfile,
+      canonicalProfile: assertRegisteredProfile(binding.canonicalProfile),
       riskClass: operation?.riskClass ?? "",
     },
     actionDigest: binding.actionDigest,

--- a/packages/db/src/__tests__/generic-http-profile-migration.test.ts
+++ b/packages/db/src/__tests__/generic-http-profile-migration.test.ts
@@ -17,6 +17,7 @@ import { describe, expect, setDefaultTimeout, test } from "bun:test";
 import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { PGlite } from "@electric-sql/pglite";
+import { REGISTERED_PROFILES } from "@stwd/shared";
 
 setDefaultTimeout(120_000);
 const migrations = new URL("../../drizzle", import.meta.url).pathname;
@@ -91,9 +92,10 @@ describe("#201 generic-http profile migration (0085)", () => {
        WHERE conname = 'provider_action_bindings_profile_chk'`,
     );
     expect(con.rows).toHaveLength(1);
-    expect(con.rows[0].def).toContain("generic-http.provider-action.v1");
-    expect(con.rows[0].def).toContain("github.provider-action.v1");
-    expect(con.rows[0].def).toContain("x.provider-action.v1");
+    const storedProfiles = [...con.rows[0].def.matchAll(/'([^']+\.provider-action\.v1)'/g)]
+      .map((match) => match[1])
+      .sort();
+    expect(storedProfiles).toEqual([...REGISTERED_PROFILES].sort());
     await client.close();
   });
 
@@ -109,16 +111,18 @@ describe("#201 generic-http profile migration (0085)", () => {
     await client.close();
   });
 
-  test("still admits github + x profiles (no regression)", async () => {
-    for (const profile of ["github.provider-action.v1", "x.provider-action.v1"]) {
+  test("admits and reloads every registered profile (registry-driven)", async () => {
+    for (const profile of REGISTERED_PROFILES) {
       const client = new PGlite("memory://");
       await applyAll(client);
       await seed(client);
       await client.exec(bindingInsert(profile));
-      const rows = await client.query(
-        `SELECT canonical_profile FROM provider_action_bindings WHERE intent_id='intent-201'`,
+      const rows = await client.query<{ canonical_profile: string; action: string }>(
+        `SELECT canonical_profile, encode(canonical_action_bytes, 'hex') AS action
+         FROM provider_action_bindings WHERE intent_id='intent-201'`,
       );
       expect(rows.rows).toHaveLength(1);
+      expect(rows.rows[0]).toEqual({ canonical_profile: profile, action: "7b7d" });
       await client.close();
     }
   });

--- a/packages/proxy/src/__tests__/governed-execution.test.ts
+++ b/packages/proxy/src/__tests__/governed-execution.test.ts
@@ -790,7 +790,10 @@ describe("PR4 dispatchGovernedExecution claim + dispatch", () => {
       origin: "https://api.customer.example",
       normalizedPath: "/v1/items",
       orderedQueryPairs: [["mode", "safe"]],
-      selectedHeaders: [["accept", "application/json"]],
+      selectedHeaders: [
+        ["accept", "application/json"],
+        ["content-type", "application/json"],
+      ],
       canonicalBody: { name: "widget" },
     };
     await getDb()
@@ -828,6 +831,28 @@ describe("PR4 dispatchGovernedExecution claim + dispatch", () => {
       if (saved === undefined) delete process.env.STEWARD_PROXY_ALLOWED_HOSTS;
       else process.env.STEWARD_PROXY_ALLOWED_HOSTS = saved;
     }
+  });
+
+  it("denies a credential carrier in persisted canonical bytes before claim or forward", async () => {
+    const poisoned = {
+      ...ACTION,
+      selectedHeaders: [["authorization", "registered-malicious-canary"]] as Array<
+        [string, string]
+      >,
+    };
+    const { intentId, authorizationId } = await seedExecutionReady({ action: poisoned });
+    const result = await dispatchGovernedExecution(intentId, IDS.tenant);
+    expect(result).toMatchObject({
+      ok: false,
+      code: "EXEC_AUTH_STALE_DEPENDENCY",
+      httpStatus: 409,
+    });
+    const [nonce] = await getDb()
+      .select({ status: executionAuthorizationNonces.status })
+      .from(executionAuthorizationNonces)
+      .where(eq(executionAuthorizationNonces.authorizationId, authorizationId));
+    expect(nonce.status).toBe("active");
+    expect(captured).toBeNull();
   });
 
   it("K01/P43: two concurrent claims → exactly one consumes, one dispatch", async () => {

--- a/packages/proxy/src/__tests__/governed-execution.test.ts
+++ b/packages/proxy/src/__tests__/governed-execution.test.ts
@@ -800,9 +800,37 @@ describe("PR4 dispatchGovernedExecution claim + dispatch", () => {
       .update(secretRoutes)
       .set({ hostPattern: "api.customer.example", pathPattern: "/v1/items", method: "POST" })
       .where(eq(secretRoutes.id, IDS.route));
+    await getDb()
+      .update(providerOperations)
+      .set({
+        requestProfile: {
+          profile: "generic-http.provider-action.v1",
+          operationDescriptor: {
+            profile: "generic-http.provider-action.v1",
+            origin: "https://api.customer.example",
+            methods: ["POST"],
+            pathTemplate: [{ literal: "v1" }, { literal: "items" }],
+            query: [{ name: "mode", type: "string", pattern: "^safe$" }],
+            headers: [{ name: "accept", value: "application/json" }],
+            body: {
+              contentType: "application/json",
+              fields: [{ name: "name", type: "string", pattern: "^.{1,64}$", maxBytes: 64 }],
+            },
+            projection: { policyArgs: [], safeSummary: ["name"] },
+          },
+        },
+      })
+      .where(eq(providerOperations.id, IDS.operation));
+    // The fixture authors the descriptor before minting and verifies the exact
+    // operation revision that the binding will carry.
     await getDb().execute(
       sql`UPDATE secret_routes SET authority_revision = 1 WHERE id = ${IDS.route}`,
     );
+    const [configuredOperation] = await getDb()
+      .select({ revision: providerOperations.revision })
+      .from(providerOperations)
+      .where(eq(providerOperations.id, IDS.operation));
+    expect(configuredOperation.revision).toBe(1);
     const saved = process.env.STEWARD_PROXY_ALLOWED_HOSTS;
     delete process.env.STEWARD_PROXY_ALLOWED_HOSTS;
     try {
@@ -851,6 +879,61 @@ describe("PR4 dispatchGovernedExecution claim + dispatch", () => {
       .select({ status: executionAuthorizationNonces.status })
       .from(executionAuthorizationNonces)
       .where(eq(executionAuthorizationNonces.authorizationId, authorizationId));
+    expect(nonce.status).toBe("active");
+    expect(captured).toBeNull();
+  });
+
+  it("denies an action-controlled origin before claim or forward", async () => {
+    const poisoned = { ...ACTION, origin: "https://attacker.example" };
+    const { intentId, authorizationId } = await seedExecutionReady({ action: poisoned });
+    const result = await dispatchGovernedExecution(intentId, IDS.tenant);
+    expect(result).toMatchObject({
+      ok: false,
+      code: "EXEC_AUTH_STALE_DEPENDENCY",
+      httpStatus: 409,
+    });
+    const [nonce] = await getDb()
+      .select({ status: executionAuthorizationNonces.status })
+      .from(executionAuthorizationNonces)
+      .where(eq(executionAuthorizationNonces.authorizationId, authorizationId));
+    expect(nonce.status).toBe("active");
+    expect(captured).toBeNull();
+  });
+
+  it("derives a generic origin from the bound operation descriptor, not action bytes", async () => {
+    await getDb()
+      .update(providerOperations)
+      .set({
+        requestProfile: {
+          profile: "generic-http.provider-action.v1",
+          operationDescriptor: {
+            profile: "generic-http.provider-action.v1",
+            origin: "https://api.customer.example",
+            methods: ["GET"],
+            pathTemplate: [{ literal: "v1" }, { literal: "items" }],
+            projection: { policyArgs: [], safeSummary: [] },
+          },
+        },
+      })
+      .where(eq(providerOperations.id, IDS.operation));
+    const poisonedAction: GenericHttpCanonicalActionV1 = {
+      profile: "generic-http.provider-action.v1",
+      method: "GET",
+      origin: "https://attacker.example",
+      normalizedPath: "/v1/items",
+      orderedQueryPairs: [],
+      selectedHeaders: [],
+      canonicalBody: null,
+    };
+    const poisoned = await seedExecutionReady({ action: poisonedAction });
+    expect(await dispatchGovernedExecution(poisoned.intentId, IDS.tenant)).toMatchObject({
+      ok: false,
+      code: "EXEC_AUTH_STALE_DEPENDENCY",
+    });
+    const [nonce] = await getDb()
+      .select({ status: executionAuthorizationNonces.status })
+      .from(executionAuthorizationNonces)
+      .where(eq(executionAuthorizationNonces.authorizationId, poisoned.authorizationId));
     expect(nonce.status).toBe("active");
     expect(captured).toBeNull();
   });

--- a/packages/proxy/src/handlers/governed-execution.ts
+++ b/packages/proxy/src/handlers/governed-execution.ts
@@ -48,13 +48,16 @@ import {
   computeApprovalCommitmentHash,
   computeProviderExecutionCommitmentHash,
   type GithubCanonicalActionV1,
+  getProfileDescriptor,
   isExecutionAuthV2SecretConfigured,
+  isGenericDescriptorError,
   isUnregisteredProfileError,
   jcsStringify,
   observeNonceClaimContention,
   type ProviderApprovalCommitmentV1,
   parseCanonicalProviderActionBytes,
   serializeCanonicalOutboundQuery,
+  validateGenericHttpDescriptor,
   verifyProviderExecutionCommitmentV2,
   verifyProviderExecutionPolicyEvidence,
 } from "@stwd/shared";
@@ -207,8 +210,48 @@ async function loadGovernedExecution(
   const q = queueRows[0];
   if (!q || !q.approvalCommitment) return null;
 
+  // Origin policy is independent of the action bytes. Fixed adapters use their
+  // compile-time registry allowlist; config-driven operations use the validated
+  // descriptor from the exact operation revision bound to this execution.
+  const operationRows = await db
+    .select({
+      requestProfile: providerOperations.requestProfile,
+      revision: providerOperations.revision,
+    })
+    .from(providerOperations)
+    .where(
+      and(
+        eq(providerOperations.tenantId, tenantId),
+        eq(providerOperations.workspaceId, binding.workspaceId),
+        eq(providerOperations.providerAccountId, binding.providerAccountId),
+        eq(providerOperations.id, binding.operationId),
+      ),
+    )
+    .limit(1);
+  const operation = operationRows[0];
+  if (!operation) return null;
+  if (operation.revision !== binding.operationRevision) {
+    throw new CanonError("CANON_JSON_SHAPE_INVALID", "operation revision does not match binding");
+  }
+  const profile = assertRegisteredProfile(binding.canonicalProfile);
+  const profileDescriptor = getProfileDescriptor(profile);
+  if (!profileDescriptor) return null;
+  let allowedOrigins: readonly string[];
+  if (profileDescriptor.kind === "adapter-fixed") {
+    allowedOrigins = profileDescriptor.allowedOrigins;
+  } else {
+    if (operation.requestProfile.profile !== profile) {
+      throw new CanonError("CANON_JSON_SHAPE_INVALID", "operation profile does not match binding");
+    }
+    allowedOrigins = [
+      validateGenericHttpDescriptor(operation.requestProfile.operationDescriptor).origin,
+    ];
+  }
+
   const canonicalAction = parseGovernedCanonicalActionForDispatch(
     new Uint8Array(binding.canonicalActionBytes as Uint8Array),
+    profile,
+    allowedOrigins,
   );
 
   return {
@@ -253,8 +296,14 @@ async function loadGovernedExecution(
 
 export function parseGovernedCanonicalActionForDispatch(
   bytes: Uint8Array,
+  expectedProfile: string,
+  allowedOrigins: readonly string[],
 ): GithubCanonicalActionV1 {
-  return parseCanonicalProviderActionBytes(bytes) as GithubCanonicalActionV1;
+  return parseCanonicalProviderActionBytes(
+    bytes,
+    expectedProfile,
+    allowedOrigins,
+  ) as GithubCanonicalActionV1;
 }
 
 function deny(
@@ -294,7 +343,11 @@ export async function dispatchGovernedExecution(
   } catch (error) {
     // Corrupt/noncanonical persisted bytes are an authority dependency failure,
     // never an uncaught 500 and never a reason to claim/decrypt/forward.
-    if (error instanceof CanonError || isUnregisteredProfileError(error)) {
+    if (
+      error instanceof CanonError ||
+      isGenericDescriptorError(error) ||
+      isUnregisteredProfileError(error)
+    ) {
       return deny("EXEC_AUTH_STALE_DEPENDENCY", 409, intentId);
     }
     throw error;

--- a/packages/proxy/src/handlers/governed-execution.ts
+++ b/packages/proxy/src/handlers/governed-execution.ts
@@ -43,18 +43,18 @@ import {
 import {
   assertRegisteredProfile,
   buildProviderExecutionCommitmentV2,
+  CanonError,
   computeActionDigest,
   computeApprovalCommitmentHash,
   computeProviderExecutionCommitmentHash,
-  decodeUtf8Strict,
   type GithubCanonicalActionV1,
   isExecutionAuthV2SecretConfigured,
   isUnregisteredProfileError,
   jcsStringify,
   observeNonceClaimContention,
   type ProviderApprovalCommitmentV1,
+  parseCanonicalProviderActionBytes,
   serializeCanonicalOutboundQuery,
-  strictParseJson,
   verifyProviderExecutionCommitmentV2,
   verifyProviderExecutionPolicyEvidence,
 } from "@stwd/shared";
@@ -207,7 +207,7 @@ async function loadGovernedExecution(
   const q = queueRows[0];
   if (!q || !q.approvalCommitment) return null;
 
-  const canonicalAction = parseCanonicalAction(
+  const canonicalAction = parseGovernedCanonicalActionForDispatch(
     new Uint8Array(binding.canonicalActionBytes as Uint8Array),
   );
 
@@ -251,8 +251,10 @@ async function loadGovernedExecution(
   };
 }
 
-function parseCanonicalAction(bytes: Uint8Array): GithubCanonicalActionV1 {
-  return strictParseJson(decodeUtf8Strict(bytes)) as unknown as GithubCanonicalActionV1;
+export function parseGovernedCanonicalActionForDispatch(
+  bytes: Uint8Array,
+): GithubCanonicalActionV1 {
+  return parseCanonicalProviderActionBytes(bytes) as GithubCanonicalActionV1;
 }
 
 function deny(
@@ -286,7 +288,17 @@ export async function dispatchGovernedExecution(
     return deny("EXEC_AUTH_KEY_UNAVAILABLE", 503, intentId);
   }
 
-  const loaded = await loadGovernedExecution(tenantId, intentId);
+  let loaded: LoadedGovernedExecution | null;
+  try {
+    loaded = await loadGovernedExecution(tenantId, intentId);
+  } catch (error) {
+    // Corrupt/noncanonical persisted bytes are an authority dependency failure,
+    // never an uncaught 500 and never a reason to claim/decrypt/forward.
+    if (error instanceof CanonError || isUnregisteredProfileError(error)) {
+      return deny("EXEC_AUTH_STALE_DEPENDENCY", 409, intentId);
+    }
+    throw error;
+  }
   await hook("afterLoad");
   if (!loaded) return deny("EXEC_AUTH_NOT_READY", 409, intentId);
 

--- a/packages/shared/src/provider-profile-conformance.ts
+++ b/packages/shared/src/provider-profile-conformance.ts
@@ -1,7 +1,37 @@
-import { jcsStringify } from "./provider-action.js";
+import { CanonError, decodeUtf8Strict, jcsStringify, strictParseJson } from "./provider-action.js";
+import { assertRegisteredProfile } from "./provider-profile-registry.js";
 
-const CREDENTIAL_HEADER =
-  /^(?:authorization|proxy-authorization|cookie|set-cookie|x-api-key|api-key|x-auth-token|x-goog-api-key)$/i;
+const CREDENTIAL_NAME =
+  /^(?:authorization|proxyauthorization|cookie|setcookie|apikey|xapikey|xauthtoken|xgoogapikey|xamzsecuritytoken|accesskeyid|secretaccesskey|sessiontoken|accesstoken|refreshtoken|clientsecret|password|privatekey(?:pem)?)$/i;
+
+function normalizedFieldName(value: string): string {
+  return value.replace(/[-_.]/g, "");
+}
+
+function bodyContainsCredentialField(value: unknown): boolean {
+  if (value === null || typeof value !== "object") return false;
+  const pending: object[] = [value];
+  const seen = new WeakSet<object>();
+  let visited = 0;
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (!current || seen.has(current)) continue;
+    seen.add(current);
+    visited += 1;
+    if (visited > 10_000) return true;
+    for (const [key, descriptor] of Object.entries(Object.getOwnPropertyDescriptors(current))) {
+      if (!Array.isArray(current) && CREDENTIAL_NAME.test(normalizedFieldName(key))) return true;
+      if (
+        "value" in descriptor &&
+        descriptor.value !== null &&
+        typeof descriptor.value === "object"
+      ) {
+        pending.push(descriptor.value);
+      }
+    }
+  }
+  return false;
+}
 
 export interface ConformanceCanonicalAction {
   profile: string;
@@ -13,6 +43,92 @@ export interface ConformanceCanonicalAction {
   canonicalBody: unknown;
 }
 
+const CANONICAL_ACTION_KEYS = Object.freeze([
+  "canonicalBody",
+  "method",
+  "normalizedPath",
+  "orderedQueryPairs",
+  "origin",
+  "profile",
+  "selectedHeaders",
+] as const);
+
+function isStringPairArray(value: unknown): value is Array<[string, string]> {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (pair) =>
+        Array.isArray(pair) &&
+        pair.length === 2 &&
+        typeof pair[0] === "string" &&
+        typeof pair[1] === "string",
+    )
+  );
+}
+
+/**
+ * Deserialize the exact canonical-action bytes consumed by governed dispatch.
+ * This is deliberately shared by the proxy and the registry-driven conformance
+ * harness so tests cannot validate a friendlier parser than production uses.
+ *
+ * The bytes must already be RFC-8785 canonical. That guarantees the snapshot
+ * inspected here is byte-for-byte the snapshot whose digest/approval is stored;
+ * reserialization, duplicate members, extra fields, and unsafe credential
+ * carriers are rejected instead of being normalized away.
+ */
+export function parseCanonicalProviderActionBytes(bytes: Uint8Array): ConformanceCanonicalAction {
+  const text = decodeUtf8Strict(bytes);
+  const parsed = strictParseJson(text);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new CanonError("CANON_JSON_SHAPE_INVALID", "canonical action must be an object");
+  }
+  const record = parsed as Record<string, unknown>;
+  const keys = Object.keys(record).sort();
+  if (JSON.stringify(keys) !== JSON.stringify(CANONICAL_ACTION_KEYS)) {
+    throw new CanonError("CANON_JSON_SHAPE_INVALID", "canonical action fields do not match");
+  }
+  if (
+    typeof record.profile !== "string" ||
+    typeof record.method !== "string" ||
+    typeof record.origin !== "string" ||
+    typeof record.normalizedPath !== "string" ||
+    !isStringPairArray(record.orderedQueryPairs) ||
+    !isStringPairArray(record.selectedHeaders)
+  ) {
+    throw new CanonError("CANON_JSON_SHAPE_INVALID", "canonical action field type invalid");
+  }
+  assertRegisteredProfile(record.profile);
+  const action = record as unknown as ConformanceCanonicalAction;
+  // Profile builders may deliberately allow provider-specific JSON media types
+  // (for example GitHub vendor JSON). The proxy has no executable profile
+  // descriptor, so it enforces every profile-independent invariant here and
+  // leaves the exact media allowlist to the registered API builder.
+  const violations = inspectProviderProfileConformance(
+    action.profile,
+    [action.origin],
+    action,
+  ).filter(
+    (violation) =>
+      violation !== "content-type-unsupported" &&
+      // Existing digest-tamper probes deliberately produce this state and must
+      // reach the signed digest comparison. The API builder remains the owner
+      // of body/media coupling for newly created actions.
+      violation !== "body-content-type-missing",
+  );
+  if (violations.length > 0) {
+    throw new CanonError(
+      violations.includes("credential-header")
+        ? "CANON_HEADER_CREDENTIAL_FORBIDDEN"
+        : "CANON_JSON_SHAPE_INVALID",
+      `canonical action conformance failed: ${violations.join(",")}`,
+    );
+  }
+  if (jcsStringify(record) !== text) {
+    throw new CanonError("CANON_JSON_SHAPE_INVALID", "canonical action bytes are not canonical");
+  }
+  return action;
+}
+
 /**
  * Inspect the canonical output emitted by a production provider builder. The
  * harness is intentionally builder-agnostic: API tests feed it the executable
@@ -21,6 +137,7 @@ export interface ConformanceCanonicalAction {
  */
 export function inspectProviderProfileConformance(
   expectedProfile: string,
+  allowedOrigins: readonly string[],
   action: ConformanceCanonicalAction,
   credentialCanaries: readonly string[] = [],
 ): string[] {
@@ -53,6 +170,8 @@ export function inspectProviderProfileConformance(
   } catch {
     violations.push("origin-not-canonical-https");
   }
+  if (allowedOrigins.length === 0) violations.push("origin-policy-missing");
+  if (!allowedOrigins.includes(action.origin)) violations.push("origin-not-allowed");
   if (!/^(?:GET|POST|PUT|PATCH|DELETE)$/.test(action.method)) {
     violations.push("method-not-canonical");
   }
@@ -89,6 +208,9 @@ export function inspectProviderProfileConformance(
     }
     if (queryNames.has(pair[0])) violations.push("query-duplicate");
     queryNames.add(pair[0]);
+    if (CREDENTIAL_NAME.test(normalizedFieldName(pair[0]))) {
+      violations.push("credential-query");
+    }
   }
 
   const headerNames = new Set<string>();
@@ -100,8 +222,9 @@ export function inspectProviderProfileConformance(
     const name = pair[0].toLowerCase();
     if (headerNames.has(name)) violations.push("header-duplicate");
     headerNames.add(name);
-    if (CREDENTIAL_HEADER.test(name)) violations.push("credential-header");
+    if (CREDENTIAL_NAME.test(normalizedFieldName(name))) violations.push("credential-header");
   }
+  if (bodyContainsCredentialField(action.canonicalBody)) violations.push("credential-body-field");
   if (action.canonicalBody !== null && headerNames.has("content-type") === false) {
     violations.push("body-content-type-missing");
   }

--- a/packages/shared/src/provider-profile-conformance.ts
+++ b/packages/shared/src/provider-profile-conformance.ts
@@ -1,37 +1,6 @@
 import { CanonError, decodeUtf8Strict, jcsStringify, strictParseJson } from "./provider-action.js";
 import { assertRegisteredProfile } from "./provider-profile-registry.js";
-
-const CREDENTIAL_NAME =
-  /^(?:authorization|proxyauthorization|cookie|setcookie|apikey|xapikey|xauthtoken|xgoogapikey|xamzsecuritytoken|accesskeyid|secretaccesskey|sessiontoken|accesstoken|refreshtoken|clientsecret|password|privatekey(?:pem)?)$/i;
-
-function normalizedFieldName(value: string): string {
-  return value.replace(/[-_.]/g, "");
-}
-
-function bodyContainsCredentialField(value: unknown): boolean {
-  if (value === null || typeof value !== "object") return false;
-  const pending: object[] = [value];
-  const seen = new WeakSet<object>();
-  let visited = 0;
-  while (pending.length > 0) {
-    const current = pending.pop();
-    if (!current || seen.has(current)) continue;
-    seen.add(current);
-    visited += 1;
-    if (visited > 10_000) return true;
-    for (const [key, descriptor] of Object.entries(Object.getOwnPropertyDescriptors(current))) {
-      if (!Array.isArray(current) && CREDENTIAL_NAME.test(normalizedFieldName(key))) return true;
-      if (
-        "value" in descriptor &&
-        descriptor.value !== null &&
-        typeof descriptor.value === "object"
-      ) {
-        pending.push(descriptor.value);
-      }
-    }
-  }
-  return false;
-}
+import { containsSensitiveCredentialKey, isSensitiveCredentialKey } from "./sensitive-keys.js";
 
 export interface ConformanceCanonicalAction {
   profile: string;
@@ -76,7 +45,11 @@ function isStringPairArray(value: unknown): value is Array<[string, string]> {
  * reserialization, duplicate members, extra fields, and unsafe credential
  * carriers are rejected instead of being normalized away.
  */
-export function parseCanonicalProviderActionBytes(bytes: Uint8Array): ConformanceCanonicalAction {
+export function parseCanonicalProviderActionBytes(
+  bytes: Uint8Array,
+  expectedProfile: string,
+  allowedOrigins: readonly string[],
+): ConformanceCanonicalAction {
   const text = decodeUtf8Strict(bytes);
   const parsed = strictParseJson(text);
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
@@ -97,15 +70,16 @@ export function parseCanonicalProviderActionBytes(bytes: Uint8Array): Conformanc
   ) {
     throw new CanonError("CANON_JSON_SHAPE_INVALID", "canonical action field type invalid");
   }
+  assertRegisteredProfile(expectedProfile);
   assertRegisteredProfile(record.profile);
   const action = record as unknown as ConformanceCanonicalAction;
   // Profile builders may deliberately allow provider-specific JSON media types
-  // (for example GitHub vendor JSON). The proxy has no executable profile
-  // descriptor, so it enforces every profile-independent invariant here and
-  // leaves the exact media allowlist to the registered API builder.
+  // (for example GitHub vendor JSON), so this shared parser enforces every
+  // profile-independent invariant and leaves the exact media allowlist to the
+  // registered API builder.
   const violations = inspectProviderProfileConformance(
-    action.profile,
-    [action.origin],
+    expectedProfile,
+    allowedOrigins,
     action,
   ).filter(
     (violation) =>
@@ -208,7 +182,7 @@ export function inspectProviderProfileConformance(
     }
     if (queryNames.has(pair[0])) violations.push("query-duplicate");
     queryNames.add(pair[0]);
-    if (CREDENTIAL_NAME.test(normalizedFieldName(pair[0]))) {
+    if (isSensitiveCredentialKey(pair[0])) {
       violations.push("credential-query");
     }
   }
@@ -222,9 +196,11 @@ export function inspectProviderProfileConformance(
     const name = pair[0].toLowerCase();
     if (headerNames.has(name)) violations.push("header-duplicate");
     headerNames.add(name);
-    if (CREDENTIAL_NAME.test(normalizedFieldName(name))) violations.push("credential-header");
+    if (isSensitiveCredentialKey(name)) violations.push("credential-header");
   }
-  if (bodyContainsCredentialField(action.canonicalBody)) violations.push("credential-body-field");
+  if (containsSensitiveCredentialKey(action.canonicalBody)) {
+    violations.push("credential-body-field");
+  }
   if (action.canonicalBody !== null && headerNames.has("content-type") === false) {
     violations.push("body-content-type-missing");
   }

--- a/packages/shared/src/provider-profile-registry.ts
+++ b/packages/shared/src/provider-profile-registry.ts
@@ -28,13 +28,22 @@ import { X_PROVIDER_ACTION_PROFILE } from "./x-provider-action.js";
 /** Whether a profile's operation shape is fixed by an adapter or authored by config. */
 export type ProfileKind = "adapter-fixed" | "config-driven";
 
-export interface ProviderProfileDescriptor {
+interface ProviderProfileDescriptorBase {
   /** The stable wire profile string (also stamped into every canonical action). */
   profile: string;
-  kind: ProfileKind;
   /** Human label for logs/UX (never on the digest surface). */
   label: string;
 }
+
+export type ProviderProfileDescriptor =
+  | (ProviderProfileDescriptorBase & {
+      kind: "adapter-fixed";
+      /** Exact origins emitted by the hard-coded adapter. */
+      allowedOrigins: readonly string[];
+    })
+  | (ProviderProfileDescriptorBase & {
+      kind: "config-driven";
+    });
 
 /**
  * The registered profiles. FROZEN: this is the single source of truth for which
@@ -48,6 +57,7 @@ const REGISTRY: ReadonlyMap<string, ProviderProfileDescriptor> = new Map([
       profile: GITHUB_PROVIDER_ACTION_PROFILE,
       kind: "adapter-fixed",
       label: "GitHub",
+      allowedOrigins: Object.freeze(["https://api.github.com"]),
     }),
   ],
   [
@@ -56,6 +66,7 @@ const REGISTRY: ReadonlyMap<string, ProviderProfileDescriptor> = new Map([
       profile: X_PROVIDER_ACTION_PROFILE,
       kind: "adapter-fixed",
       label: "X",
+      allowedOrigins: Object.freeze(["https://api.x.com"]),
     }),
   ],
   [


### PR DESCRIPTION
Closes #220

## What changed
- restores one registry-driven runner across strict API/wire parsing, exact canonical bytes, production proxy parsing, approval reconstruction, and evidence reconstruction
- proves the database CHECK matches the exact registered profile set and round-trips every profile
- makes the production proxy reject malformed, noncanonical, unregistered, and credential-bearing persisted snapshots before claim/decrypt/forward
- adds a malicious registered fixture that fails through the same full runner, including nested-encoded traversal and credential carriers
- binds fixed/config-driven profiles to explicit allowed origins

## Exact-head evidence
- `bun run build` — 34/34 tasks successful
- focused boundary suite — 58 passed, 0 failed, 265 assertions
- `bun run --filter @stwd/shared test` — 410 passed, 0 failed, 11,153 assertions
- Biome and `git diff --check` clean

Head: `6ec4e34205ff874d91570282fa1f3d8965a70763`