### PR TITLE
test(api): bound archive stress test timeout

### DIFF
--- a/packages/api/src/__tests__/audit-retention-archive.test.ts
+++ b/packages/api/src/__tests__/audit-retention-archive.test.ts
@@ -507,5 +507,5 @@ describe("durable audit retention archives", () => {
         chunkSize: 1,
       }),
     ).rejects.toThrow(`more than ${MAX_ARCHIVE_CHUNKS} chunks`);
-  });
+  }, 30_000);
 });


### PR DESCRIPTION
Summary:
- allow the intentionally maximum-size audit archive test up to 30 seconds under loaded CI runners
- keep the timeout bounded and scoped to this test file

Validation:
- audit retention archive test: 8 pass
- Biome check passed
- git diff check passed