### PR TITLE
fix(providers): enforce real boundary conformance

### DIFF
--- a/packages/api/src/__tests__/production-profile-boundary-e2e.test.ts
+++ b/packages/api/src/__tests__/production-profile-boundary-e2e.test.ts
@@ -1,0 +1,346 @@
+/**
+ * Registry-wide production boundary proof.
+ *
+ * Each profile enters through the authenticated public agent route, is reloaded
+ * from the database, approved and resumed through the authenticated human
+ * routes, assembled as provider-case evidence, and finally parsed by the exact
+ * governed proxy pre-claim parser.  This deliberately complements the pure
+ * builder conformance tests: no synthetic approval/evidence labels stand in for
+ * a production boundary here.
+ */
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  setDefaultTimeout,
+  test,
+} from "bun:test";
+import { generateKeyPairSync } from "node:crypto";
+import { createServer, type Server } from "node:http";
+import { signAccessToken } from "@stwd/auth";
+import {
+  closeDb,
+  getDb,
+  providerAccounts,
+  providerActionBindings,
+  providerGrants,
+  providerOperations,
+  secretRoutes,
+} from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { parseGovernedCanonicalActionForDispatch } from "@stwd/proxy/src/handlers/governed-execution";
+import {
+  GENERIC_HTTP_PROVIDER_ACTION_PROFILE,
+  GITHUB_PROVIDER_ACTION_PROFILE,
+  jcsStringify,
+  REGISTERED_PROFILES,
+  X_PROVIDER_ACTION_PROFILE,
+} from "@stwd/shared";
+import { and, eq } from "drizzle-orm";
+import type { Hono } from "hono";
+import { exportJWK, generateKeyPair, type KeyLike, SignJWT } from "jose";
+import type { AppVariables } from "../services/context";
+import { getProviderCase, getProviderCaseEvidence } from "../services/provider-case";
+
+const KID = "production-profile-boundary-kid";
+setDefaultTimeout(120_000);
+
+type ApprovalFixture = typeof import("./provider-approval-fixture");
+type CaseFixture = typeof import("./provider-case-fixture");
+let F: ApprovalFixture["F"];
+let seedFixture: ApprovalFixture["seedFixture"];
+let wipeCase: CaseFixture["wipeCase"];
+let app: Hono<{ Variables: AppVariables }>;
+let jwksServer: Server;
+let agentPrivateKey: KeyLike;
+
+const PROFILES = [
+  {
+    profile: GITHUB_PROVIDER_ACTION_PROFILE,
+    adapterKey: "github",
+    operationKey: "github.pr.comment.create",
+    host: "api.github.com",
+    method: "POST",
+    path: "/repos/octo/hello/issues/42/comments",
+    args: { owner: "octo", repo: "hello", pullNumber: 42, body: "boundary proof" },
+    requestProfile: {},
+  },
+  {
+    profile: X_PROVIDER_ACTION_PROFILE,
+    adapterKey: "x",
+    operationKey: "x.tweet.create",
+    host: "api.x.com",
+    method: "POST",
+    path: "/2/tweets",
+    args: { text: "boundary proof", summoned: false },
+    requestProfile: {},
+  },
+  {
+    profile: GENERIC_HTTP_PROVIDER_ACTION_PROFILE,
+    adapterKey: "generic-http",
+    operationKey: "generic.ticket.create",
+    host: "api.example.com",
+    method: "POST",
+    path: "/v1/tickets",
+    args: { title: "boundary proof" },
+    requestProfile: {
+      profile: GENERIC_HTTP_PROVIDER_ACTION_PROFILE,
+      operationDescriptor: {
+        profile: GENERIC_HTTP_PROVIDER_ACTION_PROFILE,
+        origin: "https://api.example.com",
+        methods: ["POST"],
+        pathTemplate: [{ literal: "v1" }, { literal: "tickets" }],
+        body: {
+          contentType: "application/json",
+          fields: [{ name: "title", type: "string", pattern: "^.{1,200}$", maxBytes: 4096 }],
+        },
+        projection: { policyArgs: [], safeSummary: ["title"] },
+      },
+    },
+  },
+] as const;
+
+function approvalRules(operationKey: string) {
+  return [
+    {
+      id: "11111111-1111-4111-8111-111111111111",
+      type: "capability-intent",
+      enabled: true,
+      config: { capabilities: [operationKey], effect: "allow" },
+    },
+    {
+      id: "22222222-2222-4222-8222-222222222222",
+      type: "capability-intent",
+      enabled: true,
+      config: { capabilities: [operationKey], effect: "require-approval" },
+    },
+  ];
+}
+
+async function sessionToken(): Promise<string> {
+  return signAccessToken(
+    {
+      address: "0xprofile",
+      tenantId: F.TENANT,
+      userId: F.APPROVER,
+      mfaVerifiedAt: Date.now(),
+    } as never,
+    "10m",
+  );
+}
+
+async function agentToken(): Promise<string> {
+  return new SignJWT({ agent_id: F.AGENT, scopes: [], tenant_id: F.TENANT })
+    .setProtectedHeader({ alg: "RS256", kid: KID })
+    .setIssuer("eliza-cloud")
+    .setAudience("steward")
+    .setSubject(`agent:${F.AGENT}`)
+    .setIssuedAt()
+    .setExpirationTime("10m")
+    .sign(agentPrivateKey);
+}
+
+beforeAll(async () => {
+  process.env.STEWARD_PGLITE_MEMORY = "true";
+  process.env.STEWARD_AUDIT_HMAC_KEY = "0".repeat(64);
+  process.env.STEWARD_EXECUTION_AUTH_SECRET = "1".repeat(64);
+  process.env.STEWARD_MASTER_PASSWORD = "profile-boundary-master-password";
+  process.env.STEWARD_SECRET_ROUTE_ALLOWED_HOSTS = "api.github.com,api.x.com,api.example.com";
+  process.env.STEWARD_PROXY_ALLOWED_HOSTS = "api.github.com,api.x.com,api.example.com";
+  process.env.STEWARD_JWT_SECRET = "profile-boundary-jwt-secret-0123456789abcdef0123456789";
+  const signingKeys = generateKeyPairSync("ed25519");
+  process.env.STEWARD_AUDIT_SIGNING_KEY = signingKeys.privateKey
+    .export({ format: "pem", type: "pkcs8" })
+    .toString();
+
+  const { db, client } = await createPGLiteDb("memory://");
+  setPGLiteOverride(db, async () => client.close());
+  ({ F, seedFixture } = await import("./provider-approval-fixture"));
+  ({ wipeCase } = await import("./provider-case-fixture"));
+
+  const kp = await generateKeyPair("RS256");
+  agentPrivateKey = kp.privateKey;
+  const jwk = await exportJWK(kp.publicKey);
+  const jwks = JSON.stringify({ keys: [{ ...jwk, kid: KID, alg: "RS256", use: "sig" }] });
+  jwksServer = createServer((_req, res) => {
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(jwks);
+  });
+  await new Promise<void>((resolve) => jwksServer.listen(0, resolve));
+  const address = jwksServer.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+  process.env.ELIZA_CLOUD_JWKS_URL = `http://127.0.0.1:${port}/jwks`;
+  const { clearAgentJwksCacheForTests } = await import("../middleware/agent-jwt");
+  clearAgentJwksCacheForTests();
+  const { resetCheckpointSignerCache } = await import("../services/audit-checkpoint");
+  resetCheckpointSignerCache();
+  app = (await import("../app")).app as Hono<{ Variables: AppVariables }>;
+});
+
+beforeEach(async () => {
+  await seedFixture();
+});
+
+afterEach(async () => {
+  await getDb()
+    .update(secretRoutes)
+    .set({ authorityMode: "legacy", providerOperationId: null })
+    .where(eq(secretRoutes.tenantId, F.TENANT));
+  await wipeCase();
+});
+
+afterAll(async () => {
+  await closeDb();
+  await new Promise<void>((resolve) => jwksServer.close(() => resolve()));
+  for (const key of [
+    "STEWARD_PGLITE_MEMORY",
+    "STEWARD_AUDIT_HMAC_KEY",
+    "STEWARD_EXECUTION_AUTH_SECRET",
+    "STEWARD_MASTER_PASSWORD",
+    "STEWARD_SECRET_ROUTE_ALLOWED_HOSTS",
+    "STEWARD_PROXY_ALLOWED_HOSTS",
+    "STEWARD_JWT_SECRET",
+    "STEWARD_AUDIT_SIGNING_KEY",
+    "ELIZA_CLOUD_JWKS_URL",
+  ]) {
+    delete process.env[key];
+  }
+});
+
+describe("#220 real production profile boundaries", () => {
+  test("the live runner covers exactly every registered profile", () => {
+    expect(PROFILES.map(({ profile }) => profile).sort()).toEqual([...REGISTERED_PROFILES].sort());
+  });
+
+  for (const fixture of PROFILES) {
+    test(`${fixture.profile}: authenticated ingress persists, approval reconstructs, evidence assembles, proxy parses`, async () => {
+      const requestProfile = {
+        ...fixture.requestProfile,
+        policyRules: approvalRules(fixture.operationKey),
+      };
+      const db = getDb();
+      await db
+        .update(providerAccounts)
+        .set({ adapterKey: fixture.adapterKey })
+        .where(and(eq(providerAccounts.tenantId, F.TENANT), eq(providerAccounts.id, F.ACCOUNT)));
+      await db
+        .update(providerOperations)
+        .set({ operationKey: fixture.operationKey, requestProfile })
+        .where(and(eq(providerOperations.tenantId, F.TENANT), eq(providerOperations.id, F.OP)));
+      await db
+        .update(providerGrants)
+        .set({ operationKeys: [fixture.operationKey] })
+        .where(and(eq(providerGrants.tenantId, F.TENANT), eq(providerGrants.id, F.GRANT)));
+      await db
+        .update(secretRoutes)
+        .set({
+          hostPattern: fixture.host,
+          pathPattern: fixture.path,
+          method: fixture.method,
+          agentId: F.AGENT,
+          authorityMode: "governed_v2",
+          providerOperationId: F.OP,
+        })
+        .where(and(eq(secretRoutes.tenantId, F.TENANT), eq(secretRoutes.id, F.ROUTE)));
+
+      const actionResponse = await app.request("/v2/provider-actions", {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${await agentToken()}`,
+          "content-type": "application/json",
+          "x-steward-tenant": F.TENANT,
+        },
+        body: JSON.stringify({
+          workspaceId: F.WORKSPACE,
+          providerAccountId: F.ACCOUNT,
+          operationKey: fixture.operationKey,
+          ...(fixture.profile === GENERIC_HTTP_PROVIDER_ACTION_PROFILE
+            ? { method: fixture.method }
+            : {}),
+          arguments: fixture.args,
+          idempotencyKey: `profile-boundary-${fixture.adapterKey}`,
+        }),
+      });
+      expect(actionResponse.status).toBe(202);
+      const action = (await actionResponse.json()) as {
+        id: string;
+        requestHash: string;
+        actionDigest: string;
+      };
+
+      const [persisted] = await db
+        .select({
+          canonicalProfile: providerActionBindings.canonicalProfile,
+          canonicalActionBytes: providerActionBindings.canonicalActionBytes,
+        })
+        .from(providerActionBindings)
+        .where(
+          and(
+            eq(providerActionBindings.tenantId, F.TENANT),
+            eq(providerActionBindings.intentId, action.id),
+          ),
+        );
+      expect(persisted?.canonicalProfile).toBe(fixture.profile);
+      const operationContext = {
+        operationKey: fixture.operationKey,
+        requestProfile,
+      };
+      const parsed = parseGovernedCanonicalActionForDispatch(
+        new Uint8Array(persisted.canonicalActionBytes),
+        fixture.profile,
+        [`https://${fixture.host}`],
+        operationContext,
+      );
+      expect(parsed).toMatchObject({
+        profile: fixture.profile,
+        origin: `https://${fixture.host}`,
+        method: fixture.method,
+        normalizedPath: fixture.path,
+      });
+
+      const human = await sessionToken();
+      const approvalResponse = await app.request(`/v2/provider-actions/${action.id}/approval`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${human}`,
+          "content-type": "application/json",
+          "x-steward-tenant": F.TENANT,
+        },
+        body: JSON.stringify({
+          decision: "approve",
+          expectedVersion: 1,
+          expectedRequestHash: action.requestHash,
+          expectedActionDigest: action.actionDigest,
+          idempotencyKey: `profile-approve-${fixture.adapterKey}`,
+        }),
+      });
+      expect(approvalResponse.status).toBe(200);
+      const executeResponse = await app.request(`/v2/provider-actions/${action.id}/execute`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${human}`, "x-steward-tenant": F.TENANT },
+      });
+      expect(executeResponse.status).toBe(200);
+      expect(await executeResponse.json()).toMatchObject({ status: "execution_ready" });
+
+      const kase = await getProviderCase(F.TENANT, action.id, [F.WORKSPACE]);
+      expect(kase?.manifest).toMatchObject({
+        caseId: action.id,
+        operation: { key: fixture.operationKey, canonicalProfile: fixture.profile },
+        terminalState: "execution_ready",
+      });
+      const evidence = await getProviderCaseEvidence(F.TENANT, action.id, [F.WORKSPACE]);
+      expect(evidence?.manifest).toMatchObject({
+        caseId: kase?.manifest.caseId,
+        actionDigest: kase?.manifest.actionDigest,
+        requestHash: kase?.manifest.requestHash,
+        operation: kase?.manifest.operation,
+        terminalState: kase?.manifest.terminalState,
+      });
+      expect(evidence?.bundle.events.length).toBeGreaterThan(0);
+      expect(jcsStringify(parsed)).toBe(new TextDecoder().decode(persisted.canonicalActionBytes));
+    });
+  }
+});

--- a/packages/api/src/__tests__/production-profile-conformance.test.ts
+++ b/packages/api/src/__tests__/production-profile-conformance.test.ts
@@ -4,14 +4,11 @@ import type { XOperationKey } from "@stwd/provider-x";
 import { parseGovernedCanonicalActionForDispatch } from "@stwd/proxy/src/handlers/governed-execution";
 import {
   CanonError,
-  canonicalApprovalCommitmentObject,
-  computeApprovalCommitmentHash,
   GENERIC_GOLDEN_DESCRIPTOR_A,
   GENERIC_HTTP_PROVIDER_ACTION_PROFILE,
   GITHUB_PROVIDER_ACTION_PROFILE,
   inspectProviderProfileConformance,
   jcsStringify,
-  type ProviderApprovalCommitmentV1,
   REGISTERED_PROFILES,
   strictParseJson,
   validateGenericHttpDescriptor,
@@ -123,6 +120,19 @@ function allowedOriginsFromProductionSpec(spec: ProductionProviderProfileSpec): 
     : spec.allowedOrigins;
 }
 
+function operationContext(spec: ProductionProviderProfileSpec) {
+  return {
+    operationKey: FIXTURES[spec.profile].operationKey,
+    requestProfile:
+      spec.profile === GENERIC_HTTP_PROVIDER_ACTION_PROFILE
+        ? {
+            profile: GENERIC_HTTP_PROVIDER_ACTION_PROFILE,
+            operationDescriptor: GENERIC_DESCRIPTOR,
+          }
+        : { profile: spec.profile },
+  };
+}
+
 function thrownCode(fn: () => unknown): string {
   try {
     fn();
@@ -132,14 +142,12 @@ function thrownCode(fn: () => unknown): string {
   }
 }
 
-const HASH = `sha256:${"1".repeat(64)}`;
-
 /**
- * One runner for every registered production profile and for mutation proof.
- * Every stage consumes the prior stage's serialized output, so a friendly
- * handwritten snapshot cannot hide drift at a later deserialization boundary.
+ * Pure canonicalization runner for every registered production profile and for
+ * mutation proof.  The separate production-profile-boundary-e2e suite covers
+ * authenticated ingress, durable reload, approval/resume, and case evidence.
  */
-function runFullBoundaryConformance(
+function runCanonicalBoundaryConformance(
   spec: ProductionProviderProfileSpec,
   mutate?: (
     action: ReturnType<typeof buildFromProductionSpec>["action"],
@@ -163,96 +171,20 @@ function runFullBoundaryConformance(
     new TextEncoder().encode(wireText),
     spec.profile,
     allowedOrigins,
+    operationContext(spec),
   );
   expect(jcsStringify(proxyAction)).toBe(wireText);
 
-  // Approval reconstruction binds the registered profile and action digest.
-  const approval: ProviderApprovalCommitmentV1 = {
-    schemaVersion: "steward.provider-approval-commitment.v1",
-    intentId: "intent-conformance",
-    tenantId: "tenant-conformance",
-    workspaceId: "00000000-0000-4000-8000-000000000001",
-    requestActor: { type: "agent", id: "agent-conformance", revision: 1 },
-    providerAccount: {
-      id: "00000000-0000-4000-8000-000000000002",
-      revision: 1,
-      status: "active",
-    },
-    operation: {
-      id: "00000000-0000-4000-8000-000000000003",
-      key: FIXTURES[spec.profile].operationKey,
-      revision: 1,
-      riskClass: "write",
-      canonicalProfile: proxyAction.profile,
-    },
-    requestHash: HASH,
-    actionDigest: HASH,
-    accessDecision: {
-      id: "00000000-0000-4000-8000-000000000004",
-      hash: HASH,
-      effect: "allow",
-      matchedBindings: [],
-      matchedGrants: [],
-    },
-    policyDecision: {
-      id: "00000000-0000-4000-8000-000000000005",
-      hash: HASH,
-      effect: "approval_required",
-      policyRevisionHash: HASH,
-      approvalPolicyRevisionHash: HASH,
-      evaluatorVersion: "conformance-v1",
-    },
-    executionDependencies: {
-      routeId: "00000000-0000-4000-8000-000000000006",
-      routeRevision: 1,
-      secretId: "00000000-0000-4000-8000-000000000007",
-      secretVersion: 1,
-    },
-    approvalRequirements: {
-      role: "workspace_approver",
-      requesterSeparation: true,
-      maxMfaAgeSeconds: 300,
-      requiredMfaAssurance: "current-session-mfa",
-    },
-    requestedAt: "2026-01-01T00:00:00.000Z",
-    expiresAt: "2026-01-01T00:05:00.000Z",
-  };
-  const approvalText = jcsStringify(canonicalApprovalCommitmentObject(approval));
-  const reloadedApproval = strictParseJson(approvalText) as ProviderApprovalCommitmentV1;
-  expect(reloadedApproval.operation.canonicalProfile).toBe(spec.profile);
-  expect(computeApprovalCommitmentHash(reloadedApproval)).toBe(
-    computeApprovalCommitmentHash(approval),
-  );
-
-  // Evidence reconstruction consumes only the persisted wire snapshot/profile.
-  const evidenceText = jcsStringify({
-    operation: { canonicalProfile: reloadedApproval.operation.canonicalProfile },
-    canonicalAction: proxyAction,
-  });
-  const evidence = strictParseJson(evidenceText) as {
-    operation: { canonicalProfile: string };
-    canonicalAction: typeof apiAction;
-  };
-  expect(evidence.operation.canonicalProfile).toBe(spec.profile);
-  expect(
-    inspectProviderProfileConformance(spec.profile, allowedOrigins, evidence.canonicalAction),
-  ).toEqual([]);
-  return ["api", "wire", "proxy", "approval", "evidence"];
+  return ["builder", "wire", "proxy"];
 }
 
 describe("#220 executable provider profile conformance", () => {
-  it("runs every registered profile through every production boundary", () => {
+  it("runs every registered profile through canonical builder and proxy parsing", () => {
     expect(PRODUCTION_PROVIDER_PROFILE_SPECS.map((spec) => spec.profile).sort()).toEqual(
       [...REGISTERED_PROFILES].sort(),
     );
     for (const spec of PRODUCTION_PROVIDER_PROFILE_SPECS) {
-      expect(runFullBoundaryConformance(spec)).toEqual([
-        "api",
-        "wire",
-        "proxy",
-        "approval",
-        "evidence",
-      ]);
+      expect(runCanonicalBoundaryConformance(spec)).toEqual(["builder", "wire", "proxy"]);
     }
   });
 
@@ -343,7 +275,7 @@ describe("#220 executable provider profile conformance", () => {
     );
     if (!spec) throw new Error("github production profile missing");
     expect(() =>
-      runFullBoundaryConformance(spec, (action) => ({
+      runCanonicalBoundaryConformance(spec, (action) => ({
         ...action,
         selectedHeaders: [
           ...action.selectedHeaders,
@@ -366,6 +298,7 @@ describe("#220 executable provider profile conformance", () => {
         new TextEncoder().encode(jcsStringify(malicious)),
         spec.profile,
         allowedOriginsFromProductionSpec(spec),
+        operationContext(spec),
       ),
     ).toThrow("canonical action conformance failed");
   });
@@ -381,6 +314,7 @@ describe("#220 executable provider profile conformance", () => {
         new TextEncoder().encode(jcsStringify(action)),
         spec.profile,
         allowedOriginsFromProductionSpec(spec),
+        operationContext(spec),
       );
 
     expect(() => parse({ ...built.action, origin: "https://attacker.example" })).toThrow(

--- a/packages/api/src/__tests__/production-profile-conformance.test.ts
+++ b/packages/api/src/__tests__/production-profile-conformance.test.ts
@@ -3,6 +3,7 @@ import type { GithubOperationKey } from "@stwd/provider-github";
 import type { XOperationKey } from "@stwd/provider-x";
 import { parseGovernedCanonicalActionForDispatch } from "@stwd/proxy/src/handlers/governed-execution";
 import {
+  buildGenericHttpAction,
   CanonError,
   GENERIC_GOLDEN_DESCRIPTOR_A,
   GENERIC_HTTP_PROVIDER_ACTION_PROFILE,
@@ -195,6 +196,109 @@ describe("#220 executable provider profile conformance", () => {
     expect(new Set(PRODUCTION_PROVIDER_PROFILE_SPECS.map((spec) => spec.profile)).size).toBe(
       REGISTERED_PROFILES.length,
     );
+  });
+
+  it("the proxy parser reconstructs every fixed operation and rejects widened fields", () => {
+    for (const spec of PRODUCTION_PROVIDER_PROFILE_SPECS) {
+      if (spec.kind !== "adapter-fixed") continue;
+      for (const fixture of OPERATION_FIXTURES[spec.profile]) {
+        const built = buildFromProductionSpec(spec, { ...fixture.args }, fixture);
+        const parse = (action: typeof built.action) =>
+          parseGovernedCanonicalActionForDispatch(
+            new TextEncoder().encode(jcsStringify(action)),
+            spec.profile,
+            spec.allowedOrigins,
+            { operationKey: fixture.operationKey, requestProfile: { profile: spec.profile } },
+          );
+
+        expect(jcsStringify(parse(built.action))).toBe(jcsStringify(built.action));
+        expect(() =>
+          parse({
+            ...built.action,
+            orderedQueryPairs: [...built.action.orderedQueryPairs, ["x-extra", "1"]],
+          }),
+        ).toThrow("operation-action-mismatch");
+        expect(() =>
+          parse({
+            ...built.action,
+            selectedHeaders: [...built.action.selectedHeaders, ["x-extra", "ok"]],
+          }),
+        ).toThrow("operation-action-mismatch");
+      }
+    }
+  });
+
+  it("the proxy parser rejects widened or type-confused fixed bodies", () => {
+    const github = PRODUCTION_PROVIDER_PROFILE_SPECS.find(
+      (candidate) => candidate.profile === GITHUB_PROVIDER_ACTION_PROFILE,
+    );
+    const x = PRODUCTION_PROVIDER_PROFILE_SPECS.find(
+      (candidate) => candidate.profile === X_PROVIDER_ACTION_PROFILE,
+    );
+    if (!github || github.kind !== "adapter-fixed" || !x || x.kind !== "adapter-fixed") {
+      throw new Error("fixed production profiles missing");
+    }
+
+    const commentFixture = OPERATION_FIXTURES[GITHUB_PROVIDER_ACTION_PROFILE][1];
+    const comment = buildFromProductionSpec(github, { ...commentFixture.args }, commentFixture);
+    expect(() =>
+      parseGovernedCanonicalActionForDispatch(
+        new TextEncoder().encode(
+          jcsStringify({ ...comment.action, canonicalBody: { body: "looks good", extra: true } }),
+        ),
+        github.profile,
+        github.allowedOrigins,
+        { operationKey: commentFixture.operationKey, requestProfile: { profile: github.profile } },
+      ),
+    ).toThrow("operation-action-mismatch");
+
+    const tweetFixture = OPERATION_FIXTURES[X_PROVIDER_ACTION_PROFILE][0];
+    const tweet = buildFromProductionSpec(x, { ...tweetFixture.args }, tweetFixture);
+    expect(() =>
+      parseGovernedCanonicalActionForDispatch(
+        new TextEncoder().encode(jcsStringify({ ...tweet.action, canonicalBody: null })),
+        x.profile,
+        x.allowedOrigins,
+        { operationKey: tweetFixture.operationKey, requestProfile: { profile: x.profile } },
+      ),
+    ).toThrow("operation-action-mismatch");
+    expect(() =>
+      parseGovernedCanonicalActionForDispatch(
+        new TextEncoder().encode(
+          jcsStringify({
+            ...tweet.action,
+            canonicalBody: { text: "hello world", reply: { in_reply_to_tweet_id: 123 } },
+          }),
+        ),
+        x.profile,
+        x.allowedOrigins,
+        { operationKey: tweetFixture.operationKey, requestProfile: { profile: x.profile } },
+      ),
+    ).toThrow("operation-action-mismatch");
+  });
+
+  it("accepts a descriptor-backed generic HEAD action at the proxy boundary", () => {
+    const descriptor = validateGenericHttpDescriptor({
+      profile: GENERIC_HTTP_PROVIDER_ACTION_PROFILE,
+      origin: "https://api.example.com",
+      methods: ["HEAD"],
+      pathTemplate: [{ literal: "v1" }, { literal: "health" }],
+      projection: { policyArgs: [], safeSummary: [] },
+    });
+    const built = buildGenericHttpAction("generic.health.head", descriptor, "HEAD", {});
+    const parsed = parseGovernedCanonicalActionForDispatch(
+      new TextEncoder().encode(jcsStringify(built.action)),
+      GENERIC_HTTP_PROVIDER_ACTION_PROFILE,
+      [descriptor.origin],
+      {
+        operationKey: "generic.health.head",
+        requestProfile: {
+          profile: GENERIC_HTTP_PROVIDER_ACTION_PROFILE,
+          operationDescriptor: descriptor,
+        },
+      },
+    );
+    expect(jcsStringify(parsed)).toBe(jcsStringify(built.action));
   });
 
   for (const spec of PRODUCTION_PROVIDER_PROFILE_SPECS) {

--- a/packages/proxy/src/__tests__/governed-execution.test.ts
+++ b/packages/proxy/src/__tests__/governed-execution.test.ts
@@ -136,7 +136,10 @@ const ACTION: GithubCanonicalActionV1 = {
     ["per_page", "30"],
     ["state", "open"],
   ],
-  selectedHeaders: [["accept", "application/vnd.github+json"]],
+  selectedHeaders: [
+    ["accept", "application/vnd.github+json"],
+    ["x-github-api-version", "2022-11-28"],
+  ],
   canonicalBody: null,
 };
 

--- a/packages/proxy/src/__tests__/governed-execution.test.ts
+++ b/packages/proxy/src/__tests__/governed-execution.test.ts
@@ -199,7 +199,7 @@ async function seedBase() {
     workspaceId: IDS.workspace,
     providerAccountId: IDS.account,
     secretRouteId: IDS.route,
-    operationKey: "issues.list",
+    operationKey: "github.issue.list",
     riskClass: "read",
     revision: 1,
   });
@@ -239,6 +239,47 @@ async function seedExecutionReady(opts: SeedNonceOpts = {}) {
   const secretVersion = opts.secretVersion ?? 1;
   const action = opts.action ?? ACTION;
   const generic = action.profile === "generic-http.provider-action.v1";
+  if (generic) {
+    await db
+      .update(providerOperations)
+      .set({
+        requestProfile: {
+          profile: "generic-http.provider-action.v1",
+          operationDescriptor: {
+            profile: "generic-http.provider-action.v1",
+            origin: "https://api.customer.example",
+            methods: ["POST"],
+            pathTemplate: [{ literal: "v1" }, { literal: "items" }],
+            query: [
+              {
+                name: "mode",
+                type: "string",
+                required: true,
+                pattern: "^safe$",
+              },
+            ],
+            headers: [{ name: "accept", value: "application/json" }],
+            body: {
+              contentType: "application/json",
+              fields: [
+                {
+                  name: "name",
+                  type: "string",
+                  required: true,
+                  pattern: "^[a-z]{1,64}$",
+                  maxBytes: 64,
+                },
+                { name: "alpha", type: "int" },
+                { name: "zeta", type: "int" },
+              ],
+            },
+            projection: { policyArgs: [], safeSummary: [] },
+          },
+        },
+      })
+      .where(eq(providerOperations.id, IDS.operation));
+    await db.execute(sql`UPDATE provider_operations SET revision = 1 WHERE id = ${IDS.operation}`);
+  }
   const actionDigest = generic
     ? computeGenericHttpActionDigest(action as GenericHttpCanonicalActionV1)
     : computeActionDigest(action as GithubCanonicalActionV1);
@@ -259,7 +300,7 @@ async function seedExecutionReady(opts: SeedNonceOpts = {}) {
     providerAccount: { id: IDS.account, revision: 1, status: "active" },
     operation: {
       id: IDS.operation,
-      key: "issues.list",
+      key: "github.issue.list",
       revision: 1,
       riskClass: "read",
       canonicalProfile: action.profile,
@@ -304,7 +345,7 @@ async function seedExecutionReady(opts: SeedNonceOpts = {}) {
     requestHash,
     actionDigest,
     operationId: IDS.operation,
-    operationKey: "issues.list",
+    operationKey: "github.issue.list",
     effect: "approval_required",
     reasonCodes: ["APPROVAL_REQUIRED"],
     policyResults: [],
@@ -355,7 +396,7 @@ async function seedExecutionReady(opts: SeedNonceOpts = {}) {
     actionDigest,
     requestEnvelope: { schemaVersion: "steward.provider-request.v1" },
     requestHash,
-    idempotencyKeyHash: sha256HexPrefixed("idem:1"),
+    idempotencyKeyHash: sha256HexPrefixed(`idem:${intentId}`),
     safeSummary: {},
     accessDecisionId: randomUUID(),
     accessEffect: "allow",
@@ -861,26 +902,80 @@ describe("PR4 dispatchGovernedExecution claim + dispatch", () => {
     }
   });
 
-  it("denies a credential carrier in persisted canonical bytes before claim or forward", async () => {
-    const poisoned = {
-      ...ACTION,
-      selectedHeaders: [["authorization", "registered-malicious-canary"]] as Array<
-        [string, string]
-      >,
+  it("denies malformed and operation-widening canonical bytes before claim or forward", async () => {
+    const mutations: GithubCanonicalActionV1[] = [
+      {
+        ...ACTION,
+        selectedHeaders: [["authorization", "registered-malicious-canary"]],
+      },
+      { ...ACTION, origin: "https://attacker.example" },
+      { ...ACTION, method: "POST" },
+      { ...ACTION, normalizedPath: "/repos/acme/widgets/hooks" },
+      { ...ACTION, canonicalBody: { client_secret: "registered-malicious-canary" } },
+      { ...ACTION, canonicalBody: { harmless: true } },
+      {
+        ...ACTION,
+        selectedHeaders: [["content-type", "text/plain"]],
+        canonicalBody: { harmless: true },
+      },
+    ];
+    for (const poisoned of mutations) {
+      const { intentId, authorizationId } = await seedExecutionReady({ action: poisoned });
+      const result = await dispatchGovernedExecution(intentId, IDS.tenant);
+      expect(result).toMatchObject({
+        ok: false,
+        code: "EXEC_AUTH_STALE_DEPENDENCY",
+        httpStatus: 409,
+      });
+      const [nonce] = await getDb()
+        .select({ status: executionAuthorizationNonces.status })
+        .from(executionAuthorizationNonces)
+        .where(eq(executionAuthorizationNonces.authorizationId, authorizationId));
+      expect(nonce.status).toBe("active");
+      expect(captured).toBeNull();
+    }
+
+    await getDb()
+      .update(secretRoutes)
+      .set({ hostPattern: "api.customer.example", pathPattern: "/v1/items", method: "POST" })
+      .where(eq(secretRoutes.id, IDS.route));
+    await getDb().execute(
+      sql`UPDATE secret_routes SET authority_revision = 1 WHERE id = ${IDS.route}`,
+    );
+    const generic: GenericHttpCanonicalActionV1 = {
+      profile: "generic-http.provider-action.v1",
+      method: "POST",
+      origin: "https://api.customer.example",
+      normalizedPath: "/v1/items",
+      orderedQueryPairs: [["mode", "safe"]],
+      selectedHeaders: [
+        ["accept", "application/json"],
+        ["content-type", "application/json"],
+      ],
+      canonicalBody: { name: "safe" },
     };
-    const { intentId, authorizationId } = await seedExecutionReady({ action: poisoned });
-    const result = await dispatchGovernedExecution(intentId, IDS.tenant);
-    expect(result).toMatchObject({
-      ok: false,
-      code: "EXEC_AUTH_STALE_DEPENDENCY",
-      httpStatus: 409,
-    });
-    const [nonce] = await getDb()
-      .select({ status: executionAuthorizationNonces.status })
-      .from(executionAuthorizationNonces)
-      .where(eq(executionAuthorizationNonces.authorizationId, authorizationId));
-    expect(nonce.status).toBe("active");
-    expect(captured).toBeNull();
+    for (const poisoned of [
+      { ...generic, orderedQueryPairs: [["mode", "unsafe"]] as Array<[string, string]> },
+      { ...generic, canonicalBody: { name: "ATTACKER" } },
+      {
+        ...generic,
+        selectedHeaders: [["content-type", "application/json"]] as Array<[string, string]>,
+      },
+    ]) {
+      const { intentId, authorizationId } = await seedExecutionReady({ action: poisoned });
+      const result = await dispatchGovernedExecution(intentId, IDS.tenant);
+      expect(result).toMatchObject({
+        ok: false,
+        code: "EXEC_AUTH_STALE_DEPENDENCY",
+        httpStatus: 409,
+      });
+      const [nonce] = await getDb()
+        .select({ status: executionAuthorizationNonces.status })
+        .from(executionAuthorizationNonces)
+        .where(eq(executionAuthorizationNonces.authorizationId, authorizationId));
+      expect(nonce.status).toBe("active");
+      expect(captured).toBeNull();
+    }
   });
 
   it("denies an action-controlled origin before claim or forward", async () => {
@@ -1331,12 +1426,27 @@ describe("PR4 dispatchGovernedExecution claim + dispatch", () => {
     // idempotency guard would fire for a legacy request. A governed dispatch must
     // bypass that guard (it carries its own single-use nonce), so the forward is
     // reached instead of a local 400 for a missing Idempotency-Key.
-    const savedMethod = ACTION.method;
-    const savedBody = ACTION.canonicalBody;
-    (ACTION as { method: string }).method = "POST";
-    (ACTION as { canonicalBody: unknown }).canonicalBody = { title: "bug" };
-    try {
-      const { intentId, authorizationId } = await seedExecutionReady();
+    const action: GenericHttpCanonicalActionV1 = {
+      profile: "generic-http.provider-action.v1",
+      method: "POST",
+      origin: "https://api.customer.example",
+      normalizedPath: "/v1/items",
+      orderedQueryPairs: [["mode", "safe"]],
+      selectedHeaders: [
+        ["accept", "application/json"],
+        ["content-type", "application/json"],
+      ],
+      canonicalBody: { name: "bug" },
+    };
+    await getDb()
+      .update(secretRoutes)
+      .set({ hostPattern: "api.customer.example", pathPattern: "/v1/items", method: "POST" })
+      .where(eq(secretRoutes.id, IDS.route));
+    await getDb().execute(
+      sql`UPDATE secret_routes SET authority_revision = 1 WHERE id = ${IDS.route}`,
+    );
+    {
+      const { intentId, authorizationId } = await seedExecutionReady({ action });
       const res = await dispatchGovernedExecution(intentId, IDS.tenant);
       // The forward was reached (no 400 idempotency short-circuit) and the method
       // is the mutating one.
@@ -1353,9 +1463,6 @@ describe("PR4 dispatchGovernedExecution claim + dispatch", () => {
       expect(n.status).toBe("consumed");
       expect(n.ds).not.toBe("none");
       void res;
-    } finally {
-      (ACTION as { method: string }).method = savedMethod;
-      (ACTION as { canonicalBody: unknown }).canonicalBody = savedBody;
     }
   });
 
@@ -1484,15 +1591,30 @@ describe("PR4 dispatchGovernedExecution claim + dispatch", () => {
   });
 
   it("P35: the forwarded body is JCS-serialized (byte-identical to the committed canonical action), NOT JSON.stringify insertion order (codex P2)", async () => {
-    const savedMethod = ACTION.method;
-    const savedBody = ACTION.canonicalBody;
-    // Keys deliberately in NON-lexicographic insertion order + an integer-like key
-    // so JSON.stringify (insertion order) and JCS (sorted) produce DIFFERENT bytes.
-    const body = { zeta: 1, alpha: 2, "10": 3, "2": 4 } as Record<string, unknown>;
-    (ACTION as { method: string }).method = "POST";
-    (ACTION as { canonicalBody: unknown }).canonicalBody = body;
-    try {
-      const { intentId } = await seedExecutionReady();
+    // Keys deliberately in NON-lexicographic insertion order so JSON.stringify
+    // (insertion order) and JCS (sorted) produce DIFFERENT bytes.
+    const body = { zeta: 1, name: "safe", alpha: 2 } as Record<string, unknown>;
+    const action: GenericHttpCanonicalActionV1 = {
+      profile: "generic-http.provider-action.v1",
+      method: "POST",
+      origin: "https://api.customer.example",
+      normalizedPath: "/v1/items",
+      orderedQueryPairs: [["mode", "safe"]],
+      selectedHeaders: [
+        ["accept", "application/json"],
+        ["content-type", "application/json"],
+      ],
+      canonicalBody: body,
+    };
+    await getDb()
+      .update(secretRoutes)
+      .set({ hostPattern: "api.customer.example", pathPattern: "/v1/items", method: "POST" })
+      .where(eq(secretRoutes.id, IDS.route));
+    await getDb().execute(
+      sql`UPDATE secret_routes SET authority_revision = 1 WHERE id = ${IDS.route}`,
+    );
+    {
+      const { intentId } = await seedExecutionReady({ action });
       await dispatchGovernedExecution(intentId, IDS.tenant);
       expect(captured).not.toBeNull();
       // The forwarded bytes must equal the JCS serialization, and must NOT equal
@@ -1501,9 +1623,6 @@ describe("PR4 dispatchGovernedExecution claim + dispatch", () => {
       const insertion = JSON.stringify(body);
       expect(capturedBody).toBe(jcs);
       expect(jcs).not.toBe(insertion); // guard: the fixture actually differentiates
-    } finally {
-      (ACTION as { method: string }).method = savedMethod;
-      (ACTION as { canonicalBody: unknown }).canonicalBody = savedBody;
     }
   });
 

--- a/packages/proxy/src/handlers/governed-execution.ts
+++ b/packages/proxy/src/handlers/governed-execution.ts
@@ -215,6 +215,7 @@ async function loadGovernedExecution(
   // descriptor from the exact operation revision bound to this execution.
   const operationRows = await db
     .select({
+      operationKey: providerOperations.operationKey,
       requestProfile: providerOperations.requestProfile,
       revision: providerOperations.revision,
     })
@@ -252,6 +253,7 @@ async function loadGovernedExecution(
     new Uint8Array(binding.canonicalActionBytes as Uint8Array),
     profile,
     allowedOrigins,
+    operation,
   );
 
   return {
@@ -298,11 +300,13 @@ export function parseGovernedCanonicalActionForDispatch(
   bytes: Uint8Array,
   expectedProfile: string,
   allowedOrigins: readonly string[],
+  operation: { operationKey: string; requestProfile: Record<string, unknown> },
 ): GithubCanonicalActionV1 {
   return parseCanonicalProviderActionBytes(
     bytes,
     expectedProfile,
     allowedOrigins,
+    operation,
   ) as GithubCanonicalActionV1;
 }
 

--- a/packages/shared/src/provider-profile-conformance.ts
+++ b/packages/shared/src/provider-profile-conformance.ts
@@ -1,6 +1,21 @@
-import { CanonError, decodeUtf8Strict, jcsStringify, strictParseJson } from "./provider-action.js";
+import {
+  buildGenericHttpAction,
+  GENERIC_HTTP_PROVIDER_ACTION_PROFILE,
+  type GenericHttpOperationDescriptorV1,
+  type GenericSegmentType,
+  genericDescriptorAllowsExactPath,
+  validateGenericHttpDescriptor,
+} from "./generic-http-provider-action.js";
+import {
+  CanonError,
+  decodeUtf8Strict,
+  GITHUB_PROVIDER_ACTION_PROFILE,
+  jcsStringify,
+  strictParseJson,
+} from "./provider-action.js";
 import { assertRegisteredProfile } from "./provider-profile-registry.js";
 import { containsSensitiveCredentialKey, isSensitiveCredentialKey } from "./sensitive-keys.js";
+import { X_PROVIDER_ACTION_PROFILE } from "./x-provider-action.js";
 
 export interface ConformanceCanonicalAction {
   profile: string;
@@ -10,6 +25,119 @@ export interface ConformanceCanonicalAction {
   orderedQueryPairs: Array<[string, string]>;
   selectedHeaders: Array<[string, string]>;
   canonicalBody: unknown;
+}
+
+export interface ProviderOperationTargetContext {
+  operationKey: string;
+  requestProfile: Record<string, unknown>;
+}
+
+function recoveredGenericScalar(value: string, type: GenericSegmentType): unknown {
+  if (type !== "int") return value;
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) throw new Error("generic integer is not safe");
+  return parsed;
+}
+
+/** Rebuild config-driven bytes from the persisted descriptor, not caller labels. */
+function genericActionMatchesDescriptor(
+  action: ConformanceCanonicalAction,
+  operationKey: string,
+  descriptor: GenericHttpOperationDescriptorV1,
+): boolean {
+  try {
+    const pathParts = action.normalizedPath.split("/").slice(1);
+    if (pathParts.length !== descriptor.pathTemplate.length) return false;
+    const args: Record<string, unknown> = {};
+    for (let i = 0; i < descriptor.pathTemplate.length; i++) {
+      const param = descriptor.pathTemplate[i].param;
+      if (!param) continue;
+      args[param.name] = recoveredGenericScalar(decodeURIComponent(pathParts[i]), param.type);
+    }
+    const query = new Map((descriptor.query ?? []).map((item) => [item.name, item]));
+    for (const [name, value] of action.orderedQueryPairs) {
+      const spec = query.get(name);
+      if (!spec || name in args) return false;
+      args[name] = recoveredGenericScalar(value, spec.type);
+    }
+    if (action.canonicalBody !== null) {
+      if (typeof action.canonicalBody !== "object" || Array.isArray(action.canonicalBody)) {
+        return false;
+      }
+      for (const [name, value] of Object.entries(action.canonicalBody)) {
+        if (name in args) return false;
+        args[name] = value;
+      }
+    }
+    const rebuilt = buildGenericHttpAction(operationKey, descriptor, action.method, args);
+    return jcsStringify(rebuilt.action) === jcsStringify(action);
+  } catch {
+    return false;
+  }
+}
+
+/** Enforce the adapter operation's exact target at the last pre-claim boundary. */
+export function inspectProviderOperationTargetConformance(
+  action: ConformanceCanonicalAction,
+  context: ProviderOperationTargetContext,
+): string[] {
+  const violations: string[] = [];
+  const exact = (origin: string, method: string, path: string | RegExp) => {
+    if (action.origin !== origin) violations.push("operation-origin-mismatch");
+    if (action.method !== method) violations.push("operation-method-mismatch");
+    if (
+      typeof path === "string" ? action.normalizedPath !== path : !path.test(action.normalizedPath)
+    ) {
+      violations.push("operation-path-mismatch");
+    }
+  };
+
+  if (action.profile === GITHUB_PROVIDER_ACTION_PROFILE) {
+    if (context.operationKey === "github.issue.list") {
+      exact("https://api.github.com", "GET", /^\/repos\/[^/]+\/[^/]+\/issues$/);
+    } else if (context.operationKey === "github.pr.comment.create") {
+      exact(
+        "https://api.github.com",
+        "POST",
+        /^\/repos\/[^/]+\/[^/]+\/issues\/[1-9][0-9]*\/comments$/,
+      );
+    } else {
+      violations.push("operation-key-unsupported");
+    }
+  } else if (action.profile === X_PROVIDER_ACTION_PROFILE) {
+    if (context.operationKey === "x.tweet.create") {
+      exact("https://api.x.com", "POST", "/2/tweets");
+    } else if (context.operationKey === "x.tweet.delete") {
+      exact("https://api.x.com", "DELETE", /^\/2\/tweets\/[0-9]{1,25}$/);
+    } else if (context.operationKey === "x.user.me.read") {
+      exact("https://api.x.com", "GET", "/2/users/me");
+    } else {
+      violations.push("operation-key-unsupported");
+    }
+  } else if (action.profile === GENERIC_HTTP_PROVIDER_ACTION_PROFILE) {
+    let descriptor: GenericHttpOperationDescriptorV1;
+    try {
+      if (context.requestProfile.profile !== GENERIC_HTTP_PROVIDER_ACTION_PROFILE) {
+        throw new Error("profile mismatch");
+      }
+      descriptor = validateGenericHttpDescriptor(context.requestProfile.operationDescriptor);
+    } catch {
+      return ["operation-descriptor-invalid"];
+    }
+    if (action.origin !== descriptor.origin) violations.push("operation-origin-mismatch");
+    if (!descriptor.methods.includes(action.method as never)) {
+      violations.push("operation-method-mismatch");
+    }
+    if (!genericDescriptorAllowsExactPath(descriptor, action.normalizedPath)) {
+      violations.push("operation-path-mismatch");
+    }
+    if (!genericActionMatchesDescriptor(action, context.operationKey, descriptor)) {
+      violations.push("operation-descriptor-mismatch");
+    }
+  } else {
+    violations.push("operation-profile-unsupported");
+  }
+  return [...new Set(violations)].sort();
 }
 
 const CANONICAL_ACTION_KEYS = Object.freeze([
@@ -49,6 +177,7 @@ export function parseCanonicalProviderActionBytes(
   bytes: Uint8Array,
   expectedProfile: string,
   allowedOrigins: readonly string[],
+  operation: ProviderOperationTargetContext,
 ): ConformanceCanonicalAction {
   const text = decodeUtf8Strict(bytes);
   const parsed = strictParseJson(text);
@@ -73,22 +202,10 @@ export function parseCanonicalProviderActionBytes(
   assertRegisteredProfile(expectedProfile);
   assertRegisteredProfile(record.profile);
   const action = record as unknown as ConformanceCanonicalAction;
-  // Profile builders may deliberately allow provider-specific JSON media types
-  // (for example GitHub vendor JSON), so this shared parser enforces every
-  // profile-independent invariant and leaves the exact media allowlist to the
-  // registered API builder.
-  const violations = inspectProviderProfileConformance(
-    expectedProfile,
-    allowedOrigins,
-    action,
-  ).filter(
-    (violation) =>
-      violation !== "content-type-unsupported" &&
-      // Existing digest-tamper probes deliberately produce this state and must
-      // reach the signed digest comparison. The API builder remains the owner
-      // of body/media coupling for newly created actions.
-      violation !== "body-content-type-missing",
-  );
+  const violations = [
+    ...inspectProviderProfileConformance(expectedProfile, allowedOrigins, action),
+    ...inspectProviderOperationTargetConformance(action, operation),
+  ];
   if (violations.length > 0) {
     throw new CanonError(
       violations.includes("credential-header")

--- a/packages/shared/src/provider-profile-conformance.ts
+++ b/packages/shared/src/provider-profile-conformance.ts
@@ -76,6 +76,130 @@ function genericActionMatchesDescriptor(
   }
 }
 
+function pairsEqual(actual: Array<[string, string]>, expected: Array<[string, string]>): boolean {
+  return jcsStringify(actual) === jcsStringify(expected);
+}
+
+function exactObject(value: unknown, keys: readonly string[]): value is Record<string, unknown> {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    jcsStringify(Object.keys(value).sort()) === jcsStringify([...keys].sort())
+  );
+}
+
+function validGithubIssueQuery(pairs: Array<[string, string]>): boolean {
+  const allowed = new Map<string, (value: string) => boolean>([
+    ["direction", (value) => value === "asc" || value === "desc"],
+    ["page", (value) => /^[1-9][0-9]{0,9}$/.test(value) && Number(value) <= 2147483647],
+    ["per_page", (value) => /^(?:[1-9]|[1-9][0-9]|100)$/.test(value)],
+    ["sort", (value) => ["created", "updated", "comments"].includes(value)],
+    ["state", (value) => ["open", "closed", "all"].includes(value)],
+  ]);
+  let previous = "";
+  for (const [name, value] of pairs) {
+    const validator = allowed.get(name);
+    if (!validator || name <= previous || !validator(value)) return false;
+    previous = name;
+  }
+  return true;
+}
+
+function validTweetBody(value: unknown): boolean {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  if (!exactObject(value, Object.hasOwn(value, "reply") ? ["reply", "text"] : ["text"])) {
+    return false;
+  }
+  if (typeof value.text !== "string" || value.text !== value.text.trim()) return false;
+  if ([...value.text].length < 1 || [...value.text].length > 280) return false;
+  if ("reply" in value) {
+    if (!exactObject(value.reply, ["in_reply_to_tweet_id"])) return false;
+    if (typeof value.reply.in_reply_to_tweet_id !== "string") return false;
+    if (!/^[0-9]{1,25}$/.test(value.reply.in_reply_to_tweet_id)) return false;
+  }
+  return true;
+}
+
+/** Exact adapter-fixed reconstruction contract for every registered operation. */
+function fixedActionMatchesOperation(
+  action: ConformanceCanonicalAction,
+  operationKey: string,
+): boolean {
+  const githubHeaders: Array<[string, string]> = [
+    ["accept", "application/vnd.github+json"],
+    ["x-github-api-version", "2022-11-28"],
+  ];
+  switch (operationKey) {
+    case "github.issue.list":
+      return (
+        action.profile === GITHUB_PROVIDER_ACTION_PROFILE &&
+        action.origin === "https://api.github.com" &&
+        action.method === "GET" &&
+        /^\/repos\/[A-Za-z0-9][A-Za-z0-9-]{0,38}\/(?!\.{1,2}(?:\/|$))[A-Za-z0-9._-]{1,100}\/issues$/.test(
+          action.normalizedPath,
+        ) &&
+        validGithubIssueQuery(action.orderedQueryPairs) &&
+        pairsEqual(action.selectedHeaders, githubHeaders) &&
+        action.canonicalBody === null
+      );
+    case "github.pr.comment.create": {
+      if (!exactObject(action.canonicalBody, ["body"])) return false;
+      const body = action.canonicalBody.body;
+      return (
+        action.profile === GITHUB_PROVIDER_ACTION_PROFILE &&
+        action.origin === "https://api.github.com" &&
+        action.method === "POST" &&
+        /^\/repos\/[A-Za-z0-9][A-Za-z0-9-]{0,38}\/(?!\.{1,2}(?:\/|$))[A-Za-z0-9._-]{1,100}\/issues\/[1-9][0-9]{0,9}\/comments$/.test(
+          action.normalizedPath,
+        ) &&
+        Number(action.normalizedPath.split("/").at(-2)) <= 2147483647 &&
+        action.orderedQueryPairs.length === 0 &&
+        pairsEqual(action.selectedHeaders, [
+          ["accept", "application/vnd.github+json"],
+          ["content-type", "application/json"],
+          ["x-github-api-version", "2022-11-28"],
+        ]) &&
+        typeof body === "string" &&
+        body.length > 0 &&
+        new TextEncoder().encode(body).byteLength <= 65536
+      );
+    }
+    case "x.tweet.create":
+      return (
+        action.profile === X_PROVIDER_ACTION_PROFILE &&
+        action.origin === "https://api.x.com" &&
+        action.method === "POST" &&
+        action.normalizedPath === "/2/tweets" &&
+        action.orderedQueryPairs.length === 0 &&
+        pairsEqual(action.selectedHeaders, [["content-type", "application/json"]]) &&
+        validTweetBody(action.canonicalBody)
+      );
+    case "x.tweet.delete":
+      return (
+        action.profile === X_PROVIDER_ACTION_PROFILE &&
+        action.origin === "https://api.x.com" &&
+        action.method === "DELETE" &&
+        /^\/2\/tweets\/[0-9]{1,25}$/.test(action.normalizedPath) &&
+        action.orderedQueryPairs.length === 0 &&
+        action.selectedHeaders.length === 0 &&
+        action.canonicalBody === null
+      );
+    case "x.user.me.read":
+      return (
+        action.profile === X_PROVIDER_ACTION_PROFILE &&
+        action.origin === "https://api.x.com" &&
+        action.method === "GET" &&
+        action.normalizedPath === "/2/users/me" &&
+        pairsEqual(action.orderedQueryPairs, [["user.fields", "id,name,username"]]) &&
+        action.selectedHeaders.length === 0 &&
+        action.canonicalBody === null
+      );
+    default:
+      return false;
+  }
+}
+
 /** Enforce the adapter operation's exact target at the last pre-claim boundary. */
 export function inspectProviderOperationTargetConformance(
   action: ConformanceCanonicalAction,
@@ -104,6 +228,9 @@ export function inspectProviderOperationTargetConformance(
     } else {
       violations.push("operation-key-unsupported");
     }
+    if (!fixedActionMatchesOperation(action, context.operationKey)) {
+      violations.push("operation-action-mismatch");
+    }
   } else if (action.profile === X_PROVIDER_ACTION_PROFILE) {
     if (context.operationKey === "x.tweet.create") {
       exact("https://api.x.com", "POST", "/2/tweets");
@@ -113,6 +240,9 @@ export function inspectProviderOperationTargetConformance(
       exact("https://api.x.com", "GET", "/2/users/me");
     } else {
       violations.push("operation-key-unsupported");
+    }
+    if (!fixedActionMatchesOperation(action, context.operationKey)) {
+      violations.push("operation-action-mismatch");
     }
   } else if (action.profile === GENERIC_HTTP_PROVIDER_ACTION_PROFILE) {
     let descriptor: GenericHttpOperationDescriptorV1;
@@ -263,7 +393,7 @@ export function inspectProviderProfileConformance(
   }
   if (allowedOrigins.length === 0) violations.push("origin-policy-missing");
   if (!allowedOrigins.includes(action.origin)) violations.push("origin-not-allowed");
-  if (!/^(?:GET|POST|PUT|PATCH|DELETE)$/.test(action.method)) {
+  if (!/^(?:GET|POST|PUT|PATCH|DELETE|HEAD)$/.test(action.method)) {
     violations.push("method-not-canonical");
   }
   if (!action.normalizedPath.startsWith("/")) violations.push("path-not-absolute");


### PR DESCRIPTION
Closes #220.

Corrects the remaining security gaps after merged PR #312:

- replaces synthetic approval/evidence labels with a real registry-wide boundary runner: authenticated RS256 agent ingress, durable binding/profile/bytes reload, MFA human approval, execute-time resume reconstruction, provider-case plus signed evidence assembly, and the exact governed proxy parser
- binds pre-claim parsing to the independently derived registered profile/origin policy and exact persisted operation revision
- enforces operation-aware fixed adapter origin/method/path contracts
- reconstructs generic HTTP actions through the persisted descriptor, rejecting undeclared/malformed query, headers, body, method, origin, and path
- rejects credential carriers and wrong/missing content types before nonce claim or forwarding
- adds deterministic malicious origin/method/path/query/header/body/content-type tests proving the nonce remains active and forwarding stays at zero

Validation on exact head `b336c7ace06640240ad644cd40bd27e737ea4276` / base `c3e82465190fc49eb0909d0dfcc0bfdc59d0c44c`:
- focused production boundary + conformance + governed proxy: 62/62 tests, 321 assertions
- Biome and `git diff --check`: clean

Broad validation on the patch-identical predecessor before the final current-develop replay/test-timeout annotation:
- dependency/API/proxy TypeScript builds: 21/21
- API isolated suite: 234/234 files
- proxy isolated suite: 19/19 files
- shared + profile migration: 414/414 tests, 11,163 assertions

The current-develop replay only added merged #295/0087 beneath this commit; exact-head CI is authoritative for the final branch.