### PR TITLE
fix(security): capability-token scope enforcement, capability authz/rate-limit, durable adapter guard (batch 4c)

### DIFF
--- a/packages/adapters/src/registry.ts
+++ b/packages/adapters/src/registry.ts
@@ -145,6 +145,16 @@ export class AdapterRegistry {
     this.resolved.delete(category);
   }
 
+  /**
+   * True when an adapter is already registered under `(category, providerName)`.
+   * Read-only introspection for callers (e.g. the plugin host) that must refuse
+   * to SILENTLY overwrite a live adapter: `register` itself is a plain
+   * `Map.set`, so the collision check has to happen before calling it.
+   */
+  has(category: AdapterCategory, providerName: string): boolean {
+    return this.registered.get(category)?.has(providerName) ?? false;
+  }
+
   private resolve<C extends AdapterCategory>(category: C): CategoryToAdapter[C] {
     const cached = this.resolved.get(category);
     if (cached) return cached as CategoryToAdapter[C];

--- a/packages/api/src/__tests__/agent-jwt-hardening.test.ts
+++ b/packages/api/src/__tests__/agent-jwt-hardening.test.ts
@@ -42,11 +42,29 @@ describe("external agent JWT hardening", () => {
   it("does not treat api:proxy as implicit broad agent metadata scope", () => {
     expect(contextSource).not.toContain("new Set([AGENT_SCOPE])");
     expect(contextSource).toContain("if (!scopes || scopes.length === 0) return [AGENT_SCOPE]");
-    expect(contextSource).toContain(
-      'c.set("agentScopes", normalizeAgentTokenScopes(payload.scopes))',
-    );
+    expect(contextSource).toContain("c.set(\"agentScopes\", agentTokenScopes)");
     expect(contextSource).toContain(
       'agentScope === c.req.param("agentId") && hasAgentTokenScope(c.get("agentScopes"))',
     );
+  });
+
+  it("refuses capability-scoped (cap:) tokens on the general tenant surface", () => {
+    // SEC-033: a token-mode capability token authorizes EXACTLY one capability.
+    // The tenant gate must reject any agent token carrying a `cap:` scope —
+    // even one that also stamps the broad `agent` scope — so it can never act
+    // as a general agent credential.
+    expect(contextSource).toContain('CAPABILITY_TOKEN_SCOPE_PREFIX = "cap:"');
+    expect(contextSource).toContain(
+      "agentTokenScopes.some((scope) => scope.startsWith(CAPABILITY_TOKEN_SCOPE_PREFIX))",
+    );
+    // The refusal happens BEFORE any agent lookup/context install (fail fast).
+    const refusal = contextSource.indexOf(
+      "agentTokenScopes.some((scope) => scope.startsWith(CAPABILITY_TOKEN_SCOPE_PREFIX))",
+    );
+    const agentLookup = contextSource.indexOf(
+      "const agent = await ensureAgentForTenant(payload.tenantId, payload.agentId as string);",
+    );
+    expect(refusal).toBeGreaterThanOrEqual(0);
+    expect(agentLookup).toBeGreaterThan(refusal);
   });
 });

--- a/packages/api/src/__tests__/agent-jwt-hardening.test.ts
+++ b/packages/api/src/__tests__/agent-jwt-hardening.test.ts
@@ -42,7 +42,7 @@ describe("external agent JWT hardening", () => {
   it("does not treat api:proxy as implicit broad agent metadata scope", () => {
     expect(contextSource).not.toContain("new Set([AGENT_SCOPE])");
     expect(contextSource).toContain("if (!scopes || scopes.length === 0) return [AGENT_SCOPE]");
-    expect(contextSource).toContain("c.set(\"agentScopes\", agentTokenScopes)");
+    expect(contextSource).toContain('c.set("agentScopes", agentTokenScopes)');
     expect(contextSource).toContain(
       'agentScope === c.req.param("agentId") && hasAgentTokenScope(c.get("agentScopes"))',
     );

--- a/packages/api/src/__tests__/capability-agent-jwt.test.ts
+++ b/packages/api/src/__tests__/capability-agent-jwt.test.ts
@@ -50,9 +50,7 @@ beforeAll(async () => {
   process.env.STEWARD_MASTER_PASSWORD ||= "capability-gate-test-master-password";
   const { db, client } = await createPGLiteDb("memory://");
   setPGLiteOverride(db, async () => client.close());
-  await getDb()
-    .insert(tenants)
-    .values({ id: TENANT, name: "Cap Gate Tenant", apiKeyHash: "hash" });
+  await getDb().insert(tenants).values({ id: TENANT, name: "Cap Gate Tenant", apiKeyHash: "hash" });
   await getDb()
     .insert(agents)
     .values({ id: AGENT, tenantId: TENANT, name: AGENT, walletAddress: "0x4" });
@@ -70,8 +68,9 @@ beforeAll(async () => {
   const port = typeof address === "object" && address ? address.port : 0;
   process.env.ELIZA_CLOUD_JWKS_URL = `http://127.0.0.1:${port}/jwks`;
 
-  const { clearAgentJwksCacheForTests, requireAgentJwt, requireCapabilityAgentJwt } =
-    await import("../middleware/agent-jwt");
+  const { clearAgentJwksCacheForTests, requireAgentJwt, requireCapabilityAgentJwt } = await import(
+    "../middleware/agent-jwt"
+  );
   clearAgentJwksCacheForTests();
 
   app = new Hono<{ Variables: AppVariables }>();

--- a/packages/api/src/__tests__/capability-agent-jwt.test.ts
+++ b/packages/api/src/__tests__/capability-agent-jwt.test.ts
@@ -1,0 +1,121 @@
+/**
+ * SEC-092 regression: the agent-facing capability surface must not be gated by
+ * the TRADING scope. Before the fix, capability invoke/manifest/issuance routes
+ * mounted the legacy `requireAgentJwt`, which hard-requires `trade:order` — so
+ * capability-only agents were locked out and every trading agent implicitly
+ * carried capability access (scope conflation). The dedicated
+ * `requireCapabilityAgentJwt` authenticates the same JWT but leaves
+ * authorization to the capability grant + capability-intent policy
+ * (default-deny) in the invoke path.
+ *
+ * Behavioral proof over a real RS256 agent JWT (local JWKS fixture + PGLite):
+ *   - a token WITHOUT `trade:order` passes requireCapabilityAgentJwt
+ *   - the same token is still rejected by requireAgentJwt (control: the
+ *     trading gate itself is untouched)
+ *   - an unverifiable token is still a 401 (authentication is unchanged)
+ */
+
+import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { createServer, type Server } from "node:http";
+import { agents, closeDb, getDb, tenants } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { Hono } from "hono";
+import { exportJWK, generateKeyPair, type KeyLike, SignJWT } from "jose";
+import type { AppVariables } from "../services/context";
+
+setDefaultTimeout(30000);
+
+const TENANT = `cap-gate-tenant-${Date.now()}`;
+const AGENT = `cap-gate-agent-${Date.now()}`;
+const KID = "cap-gate-kid-1";
+
+let jwksServer: Server;
+let privateKey: KeyLike;
+let app: Hono<{ Variables: AppVariables }>;
+
+async function signToken(scopes: string[]): Promise<string> {
+  return new SignJWT({ agent_id: AGENT, scopes })
+    .setProtectedHeader({ alg: "RS256", kid: KID })
+    .setIssuer("eliza-cloud")
+    .setAudience("steward")
+    .setSubject(`agent:${AGENT}`)
+    .setIssuedAt()
+    .setExpirationTime("10m")
+    .sign(privateKey);
+}
+
+beforeAll(async () => {
+  process.env.STEWARD_PGLITE_MEMORY = "true";
+  process.env.STEWARD_AUDIT_HMAC_KEY ||= "1".repeat(64);
+  process.env.STEWARD_MASTER_PASSWORD ||= "capability-gate-test-master-password";
+  const { db, client } = await createPGLiteDb("memory://");
+  setPGLiteOverride(db, async () => client.close());
+  await getDb()
+    .insert(tenants)
+    .values({ id: TENANT, name: "Cap Gate Tenant", apiKeyHash: "hash" });
+  await getDb()
+    .insert(agents)
+    .values({ id: AGENT, tenantId: TENANT, name: AGENT, walletAddress: "0x4" });
+
+  const kp = await generateKeyPair("RS256");
+  privateKey = kp.privateKey;
+  const jwk = await exportJWK(kp.publicKey);
+  const jwks = JSON.stringify({ keys: [{ ...jwk, kid: KID, alg: "RS256", use: "sig" }] });
+  jwksServer = createServer((_req, res) => {
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(jwks);
+  });
+  await new Promise<void>((resolve) => jwksServer.listen(0, resolve));
+  const address = jwksServer.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+  process.env.ELIZA_CLOUD_JWKS_URL = `http://127.0.0.1:${port}/jwks`;
+
+  const { clearAgentJwksCacheForTests, requireAgentJwt, requireCapabilityAgentJwt } =
+    await import("../middleware/agent-jwt");
+  clearAgentJwksCacheForTests();
+
+  app = new Hono<{ Variables: AppVariables }>();
+  app.use("/cap/*", (c, next) => requireCapabilityAgentJwt(c, next));
+  app.get("/cap/probe", (c) => c.json({ ok: true, agentId: c.get("agentScope") }));
+  app.use("/trade/*", (c, next) => requireAgentJwt(c, next));
+  app.get("/trade/probe", (c) => c.json({ ok: true, agentId: c.get("agentScope") }));
+});
+
+afterAll(async () => {
+  await closeDb();
+  await new Promise<void>((resolve) => jwksServer.close(() => resolve()));
+  delete process.env.ELIZA_CLOUD_JWKS_URL;
+});
+
+async function probe(path: string, token: string): Promise<Response> {
+  return app.request(path, {
+    headers: { authorization: `Bearer ${token}`, "X-Steward-Tenant": TENANT },
+  });
+}
+
+describe("requireCapabilityAgentJwt (SEC-092)", () => {
+  test("admits a capability-only agent JWT with no trade:order scope", async () => {
+    const res = await probe("/cap/probe", await signToken(["cap:github:app:org"]));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; agentId: string };
+    expect(body.ok).toBe(true);
+    expect(body.agentId).toBe(AGENT);
+  });
+
+  test("admits a scope-less agent JWT (authz is the grant + policy, not the scope)", async () => {
+    const res = await probe("/cap/probe", await signToken([]));
+    expect(res.status).toBe(200);
+  });
+
+  test("control: requireAgentJwt still hard-requires trade:order", async () => {
+    const res = await probe("/trade/probe", await signToken(["cap:github:app:org"]));
+    expect(res.status).toBe(403);
+    const scoped = await probe("/trade/probe", await signToken(["trade:order"]));
+    expect(scoped.status).toBe(200);
+  });
+
+  test("still rejects an unverifiable token (authentication unchanged)", async () => {
+    const res = await probe("/cap/probe", "not-a-jwt");
+    expect(res.status).toBe(401);
+  });
+});

--- a/packages/api/src/__tests__/capability-token-scope.test.ts
+++ b/packages/api/src/__tests__/capability-token-scope.test.ts
@@ -1,0 +1,98 @@
+/**
+ * SEC-033 regression: a token-mode capability token (scopes `["cap:<manifest>"]`)
+ * must NOT authenticate as a general agent credential on the tenant surface.
+ *
+ * The capability issuance layer (packages/plugin-capabilities) mints short-lived
+ * tokens documented as "authorizes EXACTLY this capability and nothing else".
+ * Before the fix they also carried the broad `agent` scope, and tenantAuth
+ * accepted any HS256 `scope === "agent"` bearer — so the "least-privilege"
+ * token worked on every agent-token endpoint (trade-session self-management,
+ * token-status reads, policy reads, ...). These tests exercise the REAL app +
+ * tenantAuth against an in-memory PGLite db and assert both halves of the fix:
+ *
+ *   1. tenantAuth refuses any agent token carrying a `cap:` scope (even one
+ *      that also stamps the broad `agent` scope — defense in depth).
+ *   2. a plain `agent`-scoped token still passes the gate (control).
+ */
+
+import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
+import { signAgentToken } from "@stwd/auth";
+import { agents, closeDb, getDb, tenants } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import type { Hono } from "hono";
+import type { AppVariables } from "../services/context";
+
+setDefaultTimeout(30000);
+
+const TENANT_ID = `cap-scope-tenant-${Date.now()}`;
+const AGENT_ID = `cap-scope-agent-${Date.now()}`;
+
+let app: Hono<{ Variables: AppVariables }>;
+
+beforeAll(async () => {
+  process.env.STEWARD_PGLITE_MEMORY = "true";
+  process.env.STEWARD_MASTER_PASSWORD ??= "cap-scope-test-master-password";
+  process.env.STEWARD_JWT_SECRET ??= "cap-scope-test-jwt-secret-with-enough-entropy-0123456789";
+  process.env.STEWARD_AUDIT_HMAC_KEY ??= "c".repeat(64);
+
+  const { db, client } = await createPGLiteDb("memory://");
+  setPGLiteOverride(db, async () => {
+    await client.close();
+  });
+
+  const { app: realApp } = await import("../app");
+  app = realApp;
+
+  await getDb()
+    .insert(tenants)
+    .values({ id: TENANT_ID, name: "Cap Scope Tenant", apiKeyHash: "hash" })
+    .onConflictDoNothing();
+  await getDb()
+    .insert(agents)
+    .values({
+      id: AGENT_ID,
+      tenantId: TENANT_ID,
+      name: AGENT_ID,
+      walletAddress: "0x0000000000000000000000000000000000000c0c",
+    })
+    .onConflictDoNothing();
+});
+
+afterAll(async () => {
+  await closeDb();
+});
+
+/** Probe an agent-token-gated route (GET /agents/:agentId/policy). */
+async function probeAsAgent(token: string): Promise<number> {
+  const res = await app.request(`/agents/${AGENT_ID}/policy`, {
+    headers: { authorization: `Bearer ${token}`, "X-Steward-Tenant": TENANT_ID },
+  });
+  return res.status;
+}
+
+describe("capability-scoped (cap:) tokens are not general agent credentials", () => {
+  it("rejects a token carrying ONLY a cap: scope", async () => {
+    const token = await signAgentToken(
+      { agentId: AGENT_ID, tenantId: TENANT_ID, scopes: ["cap:github:app:org"] },
+      "5m",
+    );
+    expect(await probeAsAgent(token)).toBe(403);
+  });
+
+  it("rejects a token carrying cap: alongside the broad agent scope", async () => {
+    const token = await signAgentToken(
+      { agentId: AGENT_ID, tenantId: TENANT_ID, scopes: ["agent", "cap:github:app:org"] },
+      "5m",
+    );
+    expect(await probeAsAgent(token)).toBe(403);
+  });
+
+  it("still accepts a plain agent-scoped token (control)", async () => {
+    const token = await signAgentToken(
+      { agentId: AGENT_ID, tenantId: TENANT_ID, scopes: ["agent"] },
+      "5m",
+    );
+    // 404 (no policy row) — the point is the tenant auth gate did NOT 403.
+    expect(await probeAsAgent(token)).toBe(404);
+  });
+});

--- a/packages/api/src/__tests__/plugin-host-adapters.test.ts
+++ b/packages/api/src/__tests__/plugin-host-adapters.test.ts
@@ -122,6 +122,44 @@ describe("PluginHost — adapter contributions (Phase 2d)", () => {
     await expect(host.register(app, ctx, plugin)).rejects.toThrow(PluginHostError);
   });
 
+  it("FAILS CLOSED on a collision across SEPARATE register() passes on one host", async () => {
+    // SEC-093: the guard must be durable — a plugin registered in a LATER host
+    // pass must not silently overwrite a pair an earlier pass registered (the
+    // registry's own register() is a silent Map.set-overwrite).
+    const registry = new AdapterRegistry({ env: {} });
+    const ctx = ctxWith(registry);
+
+    const a = adapterPlugin("plugin-a", [
+      { category: "swap", provider: "dup", adapter: fakeSwapAdapter("a") },
+    ]);
+    const b = adapterPlugin("plugin-b", [
+      { category: "swap", provider: "dup", adapter: fakeSwapAdapter("b") },
+    ]);
+
+    const host = new PluginHost<typeof ctx>();
+    await host.register(app, ctx, a);
+    await expect(host.register(app, ctx, b)).rejects.toThrow(PluginHostError);
+    // and the original adapter is still the registered one (no clobber).
+    expect(registry.swap().provider).toBe("a");
+  });
+
+  it("FAILS CLOSED on a collision with an adapter registered OUTSIDE the host", async () => {
+    // SEC-093: core code (or a previous host) may have registered the pair
+    // directly on the shared registry — a plugin contribution for the same
+    // (category, provider) must refuse to overwrite it.
+    const registry = new AdapterRegistry({ env: {} });
+    registry.register("swap", "core-swap", fakeSwapAdapter("core-swap"));
+    const ctx = ctxWith(registry);
+
+    const plugin = adapterPlugin("trading", [
+      { category: "swap", provider: "core-swap", adapter: fakeSwapAdapter("plugin") },
+    ]);
+
+    const host = new PluginHost<typeof ctx>();
+    await expect(host.register(app, ctx, plugin)).rejects.toThrow(PluginHostError);
+    expect(registry.swap().provider).toBe("core-swap");
+  });
+
   it("FAILS CLOSED on an unknown adapter category", async () => {
     const registry = new AdapterRegistry({ env: {} });
     const ctx = ctxWith(registry);

--- a/packages/api/src/middleware/agent-jwt.ts
+++ b/packages/api/src/middleware/agent-jwt.ts
@@ -392,6 +392,37 @@ export async function requireAgentJwt(c: Context<{ Variables: AppVariables }>, n
 }
 
 /**
+ * CAPABILITY middleware. Authenticates the agent JWT and installs context with
+ * NO `trade:order` requirement. The agent-facing capability surface (invoke /
+ * manifest / issuance) is authorized per-call by the capability grant +
+ * capability-intent policy (default-deny), never by the trading scope — so
+ * requiring `trade:order` here both locked out capability-only agents and
+ * handed every trading agent implicit capability access (scope conflation).
+ * Wire behavior matches the legacy gate this replaces on that surface.
+ */
+export async function requireCapabilityAgentJwt(
+  c: Context<{ Variables: AppVariables }>,
+  next: Next,
+) {
+  const auth = await authenticateAgentJwt(c);
+  if (isAgentJwtFailure(auth)) {
+    if (auth.kind === "tenant-not-found") {
+      return c.json<ApiResponse>({ ok: false, error: "Tenant not found" }, 404);
+    }
+    if (auth.kind === "agent-not-registered") {
+      return c.json<ApiResponse>(
+        { ok: false, error: "Forbidden: agent is not registered for tenant" },
+        403,
+      );
+    }
+    return invalid(c, auth.reason, 401);
+  }
+
+  await installAgentJwtContext(c, auth);
+  return next();
+}
+
+/**
  * PROVIDER-ACTION middleware. Authenticates the agent JWT and installs context
  * with NO trading or proxy scope check — provider authority is decided later by
  * bindings/grants, never by token scope. ONLY provider-action routes use this.

--- a/packages/api/src/plugin.ts
+++ b/packages/api/src/plugin.ts
@@ -396,6 +396,14 @@ export class PluginHost<Ctx> {
    */
   private readonly adapterContributions = new Map<string, string[]>();
   /**
+   * EVERY `(category, provider)` pair this host has registered, durable across
+   * `register()` calls. The collision guard must outlive a single host pass:
+   * the registry's own `register` silently `Map.set`-overwrites, so a plugin
+   * registered in a LATER pass (or core code registering directly) would
+   * otherwise clobber a live money-route adapter without an error.
+   */
+  private readonly registeredAdapterKeys = new Set<string>();
+  /**
    * declared plugin migration sources, in dependency (registration) order. The
    * host does NOT run these during `register` (route registration must not block
    * on a schema migration); instead {@link runMigrations} applies them, called by
@@ -491,12 +499,13 @@ export class PluginHost<Ctx> {
     // `register` would silently OVERWRITE by (category, provider); to prevent a
     // plugin (or two plugins) from silently clobbering a real money-route
     // adapter, the host tracks every (category, provider) it has registered
-    // across the plugin loop and throws PluginHostError BEFORE calling
-    // `registry.register` on a duplicate. Each contribution is also validated
-    // fail-closed: a known category, a non-empty provider, and a present adapter.
+    // DURABLY (across `register()` passes, not just within one) AND consults the
+    // registry itself, so a pair already registered outside this host (core
+    // code, or a previous host sharing the registry) also fails closed. Each
+    // contribution is also validated fail-closed: a known category, a non-empty
+    // provider, and a present adapter.
     {
       const hostRegistry = ctxAdapterRegistry(ctx);
-      const seenAdapters = new Set<string>();
       for (const plugin of ordered) {
         if (!plugin.adapters || plugin.adapters.length === 0) continue;
         if (!hostRegistry) {
@@ -527,7 +536,7 @@ export class PluginHost<Ctx> {
             );
           }
           const key = `${category}::${provider}`;
-          if (seenAdapters.has(key)) {
+          if (this.registeredAdapterKeys.has(key)) {
             throw new PluginHostError(
               `duplicate adapter contribution for (category="${category}", ` +
                 `provider="${provider}") — plugin "${plugin.name}" collides with an ` +
@@ -535,7 +544,15 @@ export class PluginHost<Ctx> {
                 "adapter.",
             );
           }
-          seenAdapters.add(key);
+          if (hostRegistry.has(category, provider)) {
+            throw new PluginHostError(
+              `adapter contribution for (category="${category}", ` +
+                `provider="${provider}") from plugin "${plugin.name}" collides with ` +
+                "an adapter already registered outside the plugin host; refusing " +
+                "to overwrite a live adapter.",
+            );
+          }
+          this.registeredAdapterKeys.add(key);
           // category is narrowed to AdapterCategory; adapter is `unknown` at the
           // shared boundary — cast to the registry's per-category type here, at
           // the api boundary where @stwd/adapters is a legitimate dependency. The

--- a/packages/api/src/plugin.ts
+++ b/packages/api/src/plugin.ts
@@ -56,7 +56,11 @@ import {
 import type { PluginMigrationSource, StewardPlugin } from "@stwd/shared";
 import { WebhookEventRegistry } from "@stwd/shared";
 import type { Hono } from "hono";
-import { requireAgentJwt, requireProviderAgentJwt } from "./middleware/agent-jwt";
+import {
+  requireAgentJwt,
+  requireCapabilityAgentJwt,
+  requireProviderAgentJwt,
+} from "./middleware/agent-jwt";
 import { operatorAuth } from "./middleware/operator-auth";
 import { getRedisClient } from "./middleware/redis";
 import { getAgentTokenStatus } from "./services/agent-token-status";
@@ -166,6 +170,14 @@ export interface StewardAppContext {
   getRedisClient: typeof getRedisClient;
   requireAgentJwt: typeof requireAgentJwt;
   /**
+   * Capability-surface authenticator: verifies the agent JWT and installs the
+   * context WITHOUT the legacy `trade:order` scope gate. Capability invoke /
+   * manifest / issuance routes use this — their authorization is the
+   * capability grant + capability-intent policy (default-deny), not the
+   * trading scope. It is a NEW field and does NOT replace `requireAgentJwt`.
+   */
+  requireCapabilityAgentJwt: typeof requireCapabilityAgentJwt;
+  /**
    * PR2 provider-action authenticator: verifies the agent JWT and installs the
    * runtime-neutral principal WITHOUT a trading/proxy scope check. Provider-action
    * routes use this; it is a NEW field and does NOT replace `requireAgentJwt`.
@@ -214,6 +226,7 @@ export function buildPluginContext(): StewardAppContext {
     getAgentTokenStatus,
     getRedisClient,
     requireAgentJwt,
+    requireCapabilityAgentJwt,
     requireProviderAgentJwt,
     operatorAuth,
     tenantAuth,

--- a/packages/api/src/services/context.ts
+++ b/packages/api/src/services/context.ts
@@ -93,6 +93,12 @@ export const isWorkersRuntime =
 export const JWT_EXPIRY = ACCESS_TOKEN_EXPIRY;
 export const AGENT_SCOPE = "agent";
 export const PROXY_SCOPE = "api:proxy";
+/** Scope prefix on tokens minted by the capability issuance layer
+ * (`cap:<manifest>`, see @stwd/plugin-capabilities — the core never imports
+ * plugin packages, so the prefix is mirrored here). These are least-privilege
+ * credentials for the capability surface ONLY; the tenant gate below refuses
+ * them so they can never act as general agent credentials. */
+export const CAPABILITY_TOKEN_SCOPE_PREFIX = "cap:";
 
 export function normalizeAgentTokenScopes(scopes?: string[]): string[] {
   if (!scopes || scopes.length === 0) return [AGENT_SCOPE];
@@ -704,7 +710,15 @@ export async function tenantAuth(
         }
 
         const isAgentToken = payload.scope === "agent" && typeof payload.agentId === "string";
+        const agentTokenScopes = normalizeAgentTokenScopes(payload.scopes);
         if (isAgentToken) {
+          // Fail closed: a capability-scoped token (`cap:<manifest>`) is a
+          // least-privilege credential for the capability surface only. Refuse
+          // it on the general tenant surface even if a minter stamped the
+          // broad `agent` scope alongside it.
+          if (agentTokenScopes.some((scope) => scope.startsWith(CAPABILITY_TOKEN_SCOPE_PREFIX))) {
+            return c.json<ApiResponse>({ ok: false, error: "Forbidden" }, 403);
+          }
           const agent = await ensureAgentForTenant(payload.tenantId, payload.agentId as string);
           if (!agent) {
             return c.json<ApiResponse>({ ok: false, error: "Agent not found" }, 403);
@@ -793,7 +807,7 @@ export async function tenantAuth(
             "agentSubject",
             typeof tokenSubject === "string" ? tokenSubject : `agent:${payload.agentId}`,
           );
-          c.set("agentScopes", normalizeAgentTokenScopes(payload.scopes));
+          c.set("agentScopes", agentTokenScopes);
           c.set("authType", "agent-token");
         } else {
           if (typeof payload.mfaVerifiedAt === "number") {

--- a/packages/plugin-capabilities/PROVIDER-MODES.md
+++ b/packages/plugin-capabilities/PROVIDER-MODES.md
@@ -30,10 +30,12 @@ for a provider we have not deliberately classified as token-safe).
 ```
 POST /capabilities/manifest/github:app:org/issue   { "ttlSeconds": 120 }
 → { "mode": "token", "token": "<short-lived JWT>", "ttlSeconds": 120,
-    "scopes": ["agent", "cap:github:app:org"] }
+    "scopes": ["cap:github:app:org"] }
 ```
 The token is a minute-scale agent JWT scoped to exactly this capability
-(`cap:<manifest-id>`). The agent renews before expiry (`.../renew`).
+(`cap:<manifest-id>`) — it carries ONLY the `cap:` scope (never the broad
+`agent` scope) and the tenant surface refuses `cap:`-scoped tokens, so it is
+not a general agent credential. The agent renews before expiry (`.../renew`).
 
 ### broker mode
 ```

--- a/packages/plugin-capabilities/src/__tests__/invoke-e2e.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/invoke-e2e.test.ts
@@ -231,6 +231,7 @@ function buildCtx(): StewardAppContext {
       return null;
     },
     async requireAgentJwt() {},
+    async requireCapabilityAgentJwt() {},
     async operatorAuth() {},
     async tenantAuth() {},
   } as unknown as StewardAppContext;

--- a/packages/plugin-capabilities/src/__tests__/invoke.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/invoke.test.ts
@@ -96,6 +96,7 @@ function buildCtx(db: unknown): StewardAppContext {
       return null;
     },
     async requireAgentJwt() {},
+    async requireCapabilityAgentJwt() {},
     async operatorAuth() {},
     async tenantAuth() {},
   } as unknown as StewardAppContext;

--- a/packages/plugin-capabilities/src/__tests__/issuance.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/issuance.test.ts
@@ -130,8 +130,11 @@ describe("issueCapability", () => {
     expect(res.token).toBe("tok.ttl=60");
     expect(res.ttlSeconds).toBe(60);
     expect(res.jti).toBe("jti-123");
-    expect(res.scopes).toContain("agent");
-    expect(res.scopes).toContain(capabilityTokenScope("github:app:org"));
+    // Least privilege (SEC-033): the token carries ONLY the capability scope.
+    // Stamping the broad `agent` scope would make it a general agent credential
+    // for the whole tenant surface.
+    expect(res.scopes).toEqual([capabilityTokenScope("github:app:org")]);
+    expect(res.scopes).not.toContain("agent");
     expect(events[0]).toMatchObject({
       action: "capability.issue",
       mode: "token",

--- a/packages/plugin-capabilities/src/__tests__/manifest-routes.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/manifest-routes.test.ts
@@ -41,6 +41,7 @@ const GH_SPEC = {
 function buildCtx(db: unknown): StewardAppContext {
   return {
     db,
+    getRedisClient: () => null,
     async writeAuditEvent(ev: Record<string, unknown>) {
       // Reconstruct the structured event from the core-audit shape for assertion.
       const md = (ev.metadata ?? {}) as Record<string, unknown>;

--- a/packages/plugin-capabilities/src/__tests__/manifest-routes.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/manifest-routes.test.ts
@@ -142,10 +142,13 @@ describe("manifest routes", () => {
     expect(body.data.mode).toBe("token");
     expect(body.data.ttlSeconds).toBe(90);
     expect(body.data.scopes).toContain("cap:github:app:org");
+    // SEC-033: never the broad `agent` scope on a capability token.
+    expect(body.data.scopes).not.toContain("agent");
 
     const payload = await verifyToken(body.data.token);
     expect(payload.agentId).toBe(agentId);
     expect((payload.scopes as string[]) ?? []).toContain("cap:github:app:org");
+    expect((payload.scopes as string[]) ?? []).not.toContain("agent");
 
     // audit: exactly one issue/allow/token event.
     expect(

--- a/packages/plugin-capabilities/src/__tests__/rate-limit.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/rate-limit.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Tests for the per-agent capability rate limiter (SEC-094).
+ *
+ * Before the fix the invoke / OpenAI-adapter / manifest-issuance routes had no
+ * throttle at all (the only limit was an optional operator-configured
+ * `maxCallsPerHour` policy rule), so an agent could spam invocations — a DB
+ * write per attempt plus upstream calls with credential injection. These tests
+ * pin the limiter's contract: the (max+1)-th request in a window is denied,
+ * buckets are per-agent and per-surface, an expired window resets, and a
+ * Redis-path error fails CLOSED (deny).
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  CAPABILITY_INVOKE_RATE_LIMIT,
+  CAPABILITY_ISSUE_RATE_LIMIT,
+  enforceCapabilityRateLimit,
+} from "../rate-limit";
+
+const noRedis = { getRedisClient: () => null };
+
+describe("enforceCapabilityRateLimit (memory path)", () => {
+  test("admits up to maxRequests then denies with a positive resetMs", async () => {
+    const agent = `agent-cap-rl-${crypto.randomUUID()}`;
+    for (let i = 0; i < CAPABILITY_INVOKE_RATE_LIMIT.maxRequests; i++) {
+      const r = await enforceCapabilityRateLimit(noRedis, "invoke", agent);
+      expect(r.allowed).toBe(true);
+    }
+    const denied = await enforceCapabilityRateLimit(noRedis, "invoke", agent);
+    expect(denied.allowed).toBe(false);
+    expect(denied.resetMs).toBeGreaterThan(0);
+    expect(denied.resetMs).toBeLessThanOrEqual(CAPABILITY_INVOKE_RATE_LIMIT.windowMs);
+  });
+
+  test("buckets are per-agent and per-surface", async () => {
+    const flooded = `agent-cap-rl-${crypto.randomUUID()}`;
+    const other = `agent-cap-rl-${crypto.randomUUID()}`;
+    for (let i = 0; i < CAPABILITY_ISSUE_RATE_LIMIT.maxRequests; i++) {
+      await enforceCapabilityRateLimit(noRedis, "issue", flooded);
+    }
+    expect((await enforceCapabilityRateLimit(noRedis, "issue", flooded)).allowed).toBe(false);
+    // a different agent is unaffected
+    expect((await enforceCapabilityRateLimit(noRedis, "issue", other)).allowed).toBe(true);
+    // and the flooded agent's invoke bucket is separate from its issue bucket
+    expect((await enforceCapabilityRateLimit(noRedis, "invoke", flooded)).allowed).toBe(true);
+  });
+
+  test("fails CLOSED when the Redis path errors", async () => {
+    const brokenRedis = {
+      getRedisClient: () => ({}) as never, // non-null → takes the Redis path
+    };
+    // checkRateLimit will throw against the fake client (no .eval) — the limiter
+    // must deny, never fall open.
+    const r = await enforceCapabilityRateLimit(brokenRedis, "invoke", "agent-any");
+    expect(r.allowed).toBe(false);
+  });
+});

--- a/packages/plugin-capabilities/src/__tests__/routes.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/routes.test.ts
@@ -91,6 +91,7 @@ function buildCtx(db: TestDb): StewardAppContext {
       return null;
     },
     async requireAgentJwt() {},
+    async requireCapabilityAgentJwt() {},
     async operatorAuth() {},
     async tenantAuth() {},
     // note (any is intentional): the test ctx satisfies the used subset.

--- a/packages/plugin-capabilities/src/__tests__/session-broker-e2e.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/session-broker-e2e.test.ts
@@ -236,6 +236,7 @@ function buildCtx(): StewardAppContext {
       return null;
     },
     async requireAgentJwt() {},
+    async requireCapabilityAgentJwt() {},
     async operatorAuth() {},
     async tenantAuth() {},
   } as unknown as StewardAppContext;

--- a/packages/plugin-capabilities/src/context.ts
+++ b/packages/plugin-capabilities/src/context.ts
@@ -84,6 +84,10 @@ export interface StewardAppContext {
 
   // ── auth middleware the plugin installs on its own routes ─────────────────
   requireAgentJwt: StewardMiddleware;
+  /** capability-surface agent authenticator: verifies the agent JWT WITHOUT the
+   * legacy `trade:order` scope gate — capability authz is the grant +
+   * capability-intent policy (default-deny), not the trading scope. */
+  requireCapabilityAgentJwt: StewardMiddleware;
   operatorAuth: StewardMiddleware;
   tenantAuth: (
     c: Context<{ Variables: AppVariables }>,

--- a/packages/plugin-capabilities/src/index.ts
+++ b/packages/plugin-capabilities/src/index.ts
@@ -148,7 +148,7 @@ export const capabilitiesPlugin: StewardApiPlugin = {
     migrationsFolder: MIGRATIONS_FOLDER,
   },
   register(app, ctx) {
-    const { tenantAuth, requireAgentJwt } = ctx;
+    const { tenantAuth, requireCapabilityAgentJwt } = ctx;
 
     // ── auth gates ────────────────────────────────────────────────────────────
     // the agent-facing invoke path (`/capabilities/:name/invoke`) is agent-token-
@@ -159,16 +159,20 @@ export const capabilitiesPlugin: StewardApiPlugin = {
     // gate is applied via a wrapper that SKIPS the invoke subpath — the invoke
     // route's own agent-jwt middleware is the only auth on that path. fail-closed:
     // anything that is not exactly the invoke subpath falls through to tenantAuth.
-    app.use("/capabilities/:name/invoke", (c, next) => requireAgentJwt(c, next));
-    app.use("/v1/capabilities/:name/invoke", (c, next) => requireAgentJwt(c, next));
-    app.use("/capabilities/:name/openai/v1/*", (c, next) => requireAgentJwt(c, next));
-    app.use("/v1/capabilities/:name/openai/v1/*", (c, next) => requireAgentJwt(c, next));
+    //
+    // the agent-facing gates use the CAPABILITY authenticator (no `trade:order`
+    // scope requirement): capability authz is the per-call grant + capability-
+    // intent policy (default-deny), never the trading scope (SEC-092).
+    app.use("/capabilities/:name/invoke", (c, next) => requireCapabilityAgentJwt(c, next));
+    app.use("/v1/capabilities/:name/invoke", (c, next) => requireCapabilityAgentJwt(c, next));
+    app.use("/capabilities/:name/openai/v1/*", (c, next) => requireCapabilityAgentJwt(c, next));
+    app.use("/v1/capabilities/:name/openai/v1/*", (c, next) => requireCapabilityAgentJwt(c, next));
     // the agent-facing manifest + issuance/renewal surface is agent-token authed
     // (like invoke), NOT tenant-gated.
-    app.use("/capabilities/manifest", (c, next) => requireAgentJwt(c, next));
-    app.use("/capabilities/manifest/*", (c, next) => requireAgentJwt(c, next));
-    app.use("/v1/capabilities/manifest", (c, next) => requireAgentJwt(c, next));
-    app.use("/v1/capabilities/manifest/*", (c, next) => requireAgentJwt(c, next));
+    app.use("/capabilities/manifest", (c, next) => requireCapabilityAgentJwt(c, next));
+    app.use("/capabilities/manifest/*", (c, next) => requireCapabilityAgentJwt(c, next));
+    app.use("/v1/capabilities/manifest", (c, next) => requireCapabilityAgentJwt(c, next));
+    app.use("/v1/capabilities/manifest/*", (c, next) => requireCapabilityAgentJwt(c, next));
     app.use("/capabilities", (c, next) => tenantAuth(c, next));
     app.use("/capabilities/*", (c, next) => tenantGateSkippingInvoke(c, next, tenantAuth));
     app.use("/v1/capabilities", (c, next) => tenantAuth(c, next));

--- a/packages/plugin-capabilities/src/invoke.ts
+++ b/packages/plugin-capabilities/src/invoke.ts
@@ -23,6 +23,7 @@ import { StewardProxyClient } from "@stwd/proxy-client";
 import type { ApiResponse, AppVariables, PolicyRule, SignRequest } from "@stwd/shared";
 import { Hono } from "hono";
 import type { StewardAppContext } from "./context";
+import { enforceCapabilityRateLimit } from "./rate-limit";
 import type { Capability, InvocationDecision } from "./schema";
 import { CapabilityStore } from "./store";
 
@@ -568,6 +569,15 @@ export function createInvokeRoutes(ctx: StewardAppContext): Hono<{ Variables: Ap
       );
     }
 
+    // Per-agent throttle BEFORE any DB/upstream work (SEC-094); the 429 path
+    // deliberately writes no invocation row (that write is the vector throttled).
+    const rate = await enforceCapabilityRateLimit(ctx, "invoke", agentId);
+    if (!rate.allowed) {
+      const res = jsonResponse({ ok: false, error: "capability invoke rate limit exceeded" }, 429);
+      res.headers.set("Retry-After", String(Math.ceil(rate.resetMs / 1000)));
+      return stripGateMarker(res);
+    }
+
     type InvokeEnvelope = {
       args?: Record<string, unknown>;
       body?: unknown;
@@ -630,6 +640,14 @@ export function createInvokeRoutes(ctx: StewardAppContext): Hono<{ Variables: Ap
     const agentId = c.get("agentScope");
     if (!tenantId || !agentId) {
       return openAIError("agent authentication required", 401);
+    }
+
+    // Same per-agent throttle as the envelope invoke route (SEC-094).
+    const rate = await enforceCapabilityRateLimit(ctx, "invoke", agentId);
+    if (!rate.allowed) {
+      const res = openAIError("capability invoke rate limit exceeded", 429);
+      res.headers.set("Retry-After", String(Math.ceil(rate.resetMs / 1000)));
+      return res;
     }
 
     let body: unknown;

--- a/packages/plugin-capabilities/src/issuance.ts
+++ b/packages/plugin-capabilities/src/issuance.ts
@@ -143,7 +143,10 @@ export function clampTtlSeconds(requested: number | undefined): number | null {
 
 /** The scope string a token-mode capability token carries. Namespaced by the
  * manifest identifier so a minted token authorizes EXACTLY this capability and
- * nothing else (least privilege). */
+ * nothing else (least privilege). A capability token carries ONLY this scope —
+ * never the broad `agent` scope, which the tenant surface would accept as a
+ * general agent credential (the tenant gate also refuses any token carrying a
+ * `cap:` scope, so the two halves fail closed together). */
 export function capabilityTokenScope(manifest: string): string {
   return `cap:${manifest}`;
 }
@@ -238,7 +241,10 @@ export async function issueCapability(args: {
     };
   }
 
-  const scopes = ["agent", capabilityTokenScope(args.manifest)];
+  // Least privilege: ONLY the capability scope. Adding the broad `agent`
+  // scope here would make the token a general agent credential for up to its
+  // TTL (trade-session self-management, token-status reads, ...).
+  const scopes = [capabilityTokenScope(args.manifest)];
   let minted: { token: string; jti: string };
   try {
     minted = await args.mintToken({

--- a/packages/plugin-capabilities/src/manifest-routes.ts
+++ b/packages/plugin-capabilities/src/manifest-routes.ts
@@ -34,6 +34,7 @@ import {
   type ShortLivedTokenMinter,
 } from "./issuance";
 import { listAgentManifest, resolveManifestEntry } from "./manifest";
+import { enforceCapabilityRateLimit } from "./rate-limit";
 import { CapabilityStore } from "./store";
 
 /** Mint a short-lived agent token carrying the given scopes; pre-generate the jti
@@ -119,6 +120,17 @@ export function createManifestRoutes(ctx: StewardAppContext): Hono<{ Variables: 
         return c.json<ApiResponse>({ ok: false, error: "agent authentication required" }, 401);
       }
       const manifestId = c.req.param("id") ?? "";
+
+      // Per-agent throttle on issuance/renewal (SEC-094): each attempt mints a
+      // token and writes an audit row, so it must be bounded like invoke.
+      const rate = await enforceCapabilityRateLimit(ctx, "issue", agentId);
+      if (!rate.allowed) {
+        c.header("Retry-After", String(Math.ceil(rate.resetMs / 1000)));
+        return c.json<ApiResponse>(
+          { ok: false, error: "capability issuance rate limit exceeded" },
+          429,
+        );
+      }
 
       let body: unknown = {};
       const raw = await c.req.text().catch(() => "");

--- a/packages/plugin-capabilities/src/manifest-routes.ts
+++ b/packages/plugin-capabilities/src/manifest-routes.ts
@@ -1,9 +1,10 @@
 /**
  * manifest-routes.ts — agent-facing manifest + issuance/renewal surface (A1).
  *
- * These routes are AGENT-token authed (the same requireAgentJwt gate the invoke
- * path uses); agent identity comes from the token (c.get("agentScope")), never
- * the body. They layer on the existing capability store + the issuance core:
+ * These routes are AGENT-token authed (the same capability agent-jwt gate the
+ * invoke path uses — no `trade:order` scope requirement); agent identity comes
+ * from the token (c.get("agentScope")), never the body. They layer on the
+ * existing capability store + the issuance core:
  *
  *   GET  /capabilities/manifest
  *        → list THIS agent's manifest (provider:kind entries it may request).

--- a/packages/plugin-capabilities/src/rate-limit.ts
+++ b/packages/plugin-capabilities/src/rate-limit.ts
@@ -1,0 +1,70 @@
+/**
+ * rate-limit.ts — per-agent rate limiting for the agent-facing capability
+ * surface (invoke / OpenAI adapter / manifest issuance). Trade orders have
+ * `enforceOrderRateLimit`; the capability routes had NO throttle beyond the
+ * optional operator-configured `maxCallsPerHour` policy rule, so an agent
+ * could spam invocations (a DB write per attempt + upstream calls with
+ * credential injection). This mirrors the trade-order limiter's shape: a
+ * Redis sliding window when the core reports Redis available, a per-process
+ * memory bucket otherwise (the documented local-dev posture), and FAIL CLOSED
+ * (deny) when the configured Redis path errors.
+ */
+
+import { checkRateLimit } from "@stwd/redis";
+import type { StewardAppContext } from "./context";
+
+/** invoke + OpenAI-adapter calls: 60 per agent per minute. */
+export const CAPABILITY_INVOKE_RATE_LIMIT = { windowMs: 60_000, maxRequests: 60 } as const;
+/** manifest issue/renew: 30 per agent per minute (renewal is minute-scale by design). */
+export const CAPABILITY_ISSUE_RATE_LIMIT = { windowMs: 60_000, maxRequests: 30 } as const;
+
+const RATE_LIMITS = {
+  invoke: CAPABILITY_INVOKE_RATE_LIMIT,
+  issue: CAPABILITY_ISSUE_RATE_LIMIT,
+} as const;
+
+export type CapabilityRateSurface = keyof typeof RATE_LIMITS;
+
+/** Process-local fallback buckets (mirrors the trade route's memory limiter). */
+const memoryBuckets = new Map<string, { count: number; resetAt: number }>();
+
+export interface CapabilityRateResult {
+  allowed: boolean;
+  resetMs: number;
+}
+
+/**
+ * Check-and-increment the per-agent limit for a capability surface. Call BEFORE
+ * any DB/upstream work so a flooded agent is turned away cheaply (and the 429
+ * path does NOT write an invocation row — that write is the very vector being
+ * throttled).
+ */
+export async function enforceCapabilityRateLimit(
+  ctx: Pick<StewardAppContext, "getRedisClient">,
+  surface: CapabilityRateSurface,
+  agentId: string,
+): Promise<CapabilityRateResult> {
+  const { windowMs, maxRequests } = RATE_LIMITS[surface];
+  const key = `ratelimit:capability:${surface}:${agentId}:${windowMs}`;
+
+  if (ctx.getRedisClient()) {
+    try {
+      const result = await checkRateLimit(key, windowMs, maxRequests);
+      return { allowed: result.allowed, resetMs: result.resetMs };
+    } catch {
+      // Fail CLOSED: Redis was configured but errored — deny rather than let a
+      // flood through unthrottled.
+      return { allowed: false, resetMs: windowMs };
+    }
+  }
+
+  const now = Date.now();
+  const current = memoryBuckets.get(key);
+  if (!current || current.resetAt <= now) {
+    memoryBuckets.set(key, { count: 1, resetAt: now + windowMs });
+    return { allowed: true, resetMs: windowMs };
+  }
+  if (current.count >= maxRequests) return { allowed: false, resetMs: current.resetAt - now };
+  current.count += 1;
+  return { allowed: true, resetMs: current.resetAt - now };
+}


### PR DESCRIPTION
Batch 4c of the wave-2 audit remediation (plugin framework + misc). All findings verified against 0027e106 before fixing.

## SEC-ID status

| SEC ID | Severity | Status | Change |
|---|---|---|---|
| SEC-033 | MEDIUM | FIXED | Token-mode capability tokens are minted with ONLY the `cap:<manifest>` scope (no broad `agent` scope), and `tenantAuth` refuses any agent token carrying a `cap:` scope on the general tenant surface — the "least-privilege" token can no longer act as a general agent credential. |
| SEC-092 | LOW | FIXED | New `requireCapabilityAgentJwt` (same RS256 authN, no `trade:order` gate) now guards capability invoke/manifest/issuance; authz stays with the grant + capability-intent policy (default-deny). `requireAgentJwt` untouched for trading. |
| SEC-093 | LOW | FIXED | Plugin adapter-collision guard is durable: `PluginHost` tracks registered `(category, provider)` pairs across `register()` passes and also consults the registry itself (new read-only `AdapterRegistry.has`), so later-pass or out-of-band registrations can no longer silently overwrite a live adapter. |
| SEC-094 | LOW | FIXED | Per-agent rate limit on capability invoke/OpenAI-adapter (60/min) and manifest issuance (30/min), mirroring the trade-order limiter (Redis sliding window, memory fallback, fail-closed on Redis error, `Retry-After` on 429, no invocation-row write on the throttled path). |
| SEC-095 | LOW | DEFERRED | eliza-plugin `STEWARD_API_URL` https guard — not started within this run's time box; follow-up. |
| SEC-096 | LOW | DEFERRED | Capability audit `ipAddress` XFF trust — not started; follow-up. |
| SEC-109 | LOW | DEFERRED | `decodeJobCreatedId` emitter check — not started; follow-up. |
| SEC-112 | LOW | DEFERRED | erc8004/erc8183 single-RPC trust — not started; follow-up. |
| SEC-170 | INFO | DEFERRED | Plugin trust-bar documentation — not started; follow-up. |
| SEC-171 | INFO | DEFERRED | eliza-plugin HMAC signing enforcement — not started; follow-up. |
| SEC-172 | INFO | DEFERRED | MCP `sanitizeProviderPayload` broadening — not started; follow-up. |
| SEC-173 | INFO | DEFERRED | Example plugin unauthenticated `/example/ping` — not started; follow-up. |

## Trade-offs / breaking-change notes

- **SEC-033:** `cap:`-scoped tokens are now refused by every tenant-surface endpoint. Any client that (incorrectly) presented a capability token to general agent endpoints (policy reads, trade-session self-management, token-status) will get 403 — that was the vulnerability. The capability surface itself authenticates via the RS256 `requireCapabilityAgentJwt` and is unaffected. Already-minted tokens carry ≤5-min TTLs, so the transition window is bounded.
- **SEC-092:** capability routes no longer require `trade:order`. Capability-only agents (no trading scope) can now reach invoke/manifest — access is still default-deny without an explicit grant + allowing capability-intent policy. Trading agents lose nothing they were meant to have.
- **SEC-094:** very chatty agents may now see 429s on invoke (>60/min) or issuance (>30/min); both are per-agent and match the trade-order limiter's posture (fail closed when Redis is configured but errors; per-process memory buckets when Redis is not configured).

## Testing

- New regression tests, each verified to FAIL without its fix (stash-check) and pass with it:
  - `packages/api/src/__tests__/capability-token-scope.test.ts` — PGLite + real app: `cap:`-only and `["agent","cap:…"]` tokens → 403 on an agent-gated route; plain `agent` token still passes (SEC-033).
  - `packages/api/src/__tests__/capability-agent-jwt.test.ts` — real RS256 JWT via local JWKS fixture: no-`trade:order` token passes the capability gate, still 403 on the trading gate, garbage token still 401 (SEC-092).
  - `packages/api/src/__tests__/plugin-host-adapters.test.ts` — 2 new cases: collision across separate `register()` passes and collision with an out-of-band registration both throw `PluginHostError` and leave the original adapter in place (SEC-093).
  - `packages/plugin-capabilities/src/__tests__/rate-limit.test.ts` — (max+1)-th request denied, per-agent/per-surface buckets, Redis-error fail-closed (SEC-094).
  - Minted-scope shape assertions updated in `issuance.test.ts` / `manifest-routes.test.ts`; source anchors updated in `agent-jwt-hardening.test.ts`.
- Suites run: `@stwd/plugin-capabilities` full suite 151 pass / 2 fail — the 2 `session-broker-e2e` failures are PRE-EXISTING on clean origin/develop (verified by stashing; test-isolation issue, the file passes standalone); `@stwd/adapters` 97 pass; targeted `@stwd/api` test files all pass; `tsc --noEmit` clean for api + plugin-capabilities; `bunx biome check` clean on every changed file.