### PR TITLE
fix(security): batch 4a — webhooks + policy-engine (SEC-001/006/035-040/103)

### DIFF
--- a/packages/api/src/__tests__/transaction-stats-chain-scope.test.ts
+++ b/packages/api/src/__tests__/transaction-stats-chain-scope.test.ts
@@ -20,6 +20,8 @@
  * total (display behaviour preserved).
  */
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { agents, closeDb, getDb, tenants, transactions } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 
@@ -112,5 +114,23 @@ describe("getTransactionStats chain scoping (issue #110)", () => {
     expect(stats.spentThisWeek.toString()).toBe(combined);
     // Counts remain agent-wide (chain-agnostic) regardless of chain scoping.
     expect(stats.recentTxCount24h).toBe(2);
+  });
+});
+
+// SEC-039: the chain-scoping argument above is only effective if the
+// policy-enforcement call sites actually pass it. Guard the wiring: every
+// getTransactionStats call in the vault routes (all enforcement paths) must
+// pass a chainId, and the user-wallet sign route must scope its stats helper
+// too. Display-only callers (dashboard/agents) intentionally stay unscoped.
+describe("spend-cap enforcement call sites pass chainId (SEC-039)", () => {
+  const vaultRoutesSource = readFileSync(join(import.meta.dir, "..", "routes", "vault.ts"), "utf8");
+  const userRoutesSource = readFileSync(join(import.meta.dir, "..", "routes", "user.ts"), "utf8");
+
+  it("leaves no unscoped getTransactionStats call in the vault routes", () => {
+    expect(vaultRoutesSource).not.toMatch(/getTransactionStats\(agentId\)/);
+  });
+
+  it("scopes the user-wallet sign stats to the request chain", () => {
+    expect(userRoutesSource).toContain("getUserWalletTransactionStats(userId, chainId)");
   });
 });

--- a/packages/api/src/__tests__/user-wallet-signing-hardening.test.ts
+++ b/packages/api/src/__tests__/user-wallet-signing-hardening.test.ts
@@ -67,7 +67,7 @@ describe("user wallet signing hardening", () => {
     const lock = routeBody.indexOf("withAgentSpendLock(");
     const userWalletLock = routeBody.indexOf("`user-wallet-${userId}`", lock);
     const aggregateStats = routeBody.indexOf(
-      "getUserWalletTransactionStats(userId)",
+      "getUserWalletTransactionStats(userId, chainId)",
       userWalletLock,
     );
     const policyEvaluation = routeBody.indexOf("engine.evaluate", aggregateStats);

--- a/packages/api/src/routes/user.ts
+++ b/packages/api/src/routes/user.ts
@@ -1316,7 +1316,7 @@ async function getTransactionStats(agentId: string) {
   };
 }
 
-async function getUserWalletTransactionStats(userId: string) {
+async function getUserWalletTransactionStats(userId: string, chainId?: number) {
   const db = getDb();
   const now = new Date();
   const oneHourAgo = new Date(now.getTime() - 3_600_000);
@@ -1331,6 +1331,12 @@ async function getUserWalletTransactionStats(userId: string) {
     ...Array.from({ length: 255 }, (_, index) => `${baseAgentId}-${index + 1}`),
   ];
 
+  // Same cross-chain unit discipline as getTransactionStats (SEC-039): the
+  // value column holds raw per-chain base units, so spend sums used for
+  // policy enforcement must be scoped to the request's chain.
+  const chainFilter =
+    chainId === undefined ? sql`` : sql` and ${transactions.chainId} = ${chainId}`;
+
   const [stats] = await db
     .select({
       recentTxCount1h: sql<number>`count(*) filter (where ${transactions.createdAt} >= ${oneHourAgoStr}::timestamptz)`,
@@ -1339,14 +1345,14 @@ async function getUserWalletTransactionStats(userId: string) {
         coalesce(
           sum(
             case
-              when ${transactions.createdAt} >= ${oneDayAgoStr}::timestamptz then (${transactions.value})::numeric
+              when ${transactions.createdAt} >= ${oneDayAgoStr}::timestamptz${chainFilter} then (${transactions.value})::numeric
               else 0
             end
           ),
           0
         )::text
       `,
-      spentThisWeek: sql<string>`coalesce(sum((${transactions.value})::numeric), 0)::text`,
+      spentThisWeek: sql<string>`coalesce(sum((${transactions.value})::numeric) filter (where true${chainFilter}), 0)::text`,
     })
     .from(transactions)
     .where(
@@ -5098,7 +5104,7 @@ user.post("/me/wallet/sign", async (c) => {
     const result: UserWalletSignResult = await withAgentSpendLock(
       `user-wallet-${userId}`,
       async () => {
-        const stats = await getUserWalletTransactionStats(userId);
+        const stats = await getUserWalletTransactionStats(userId, chainId);
         const engine = new PolicyEngine();
         const evaluation = await engine.evaluate(policySet, {
           request: signRequest,

--- a/packages/api/src/routes/user.ts
+++ b/packages/api/src/routes/user.ts
@@ -5071,7 +5071,19 @@ user.post("/me/wallet/sign", async (c) => {
       403,
     );
   }
-  const signRequest: SignRequest = { ...signBody, tenantId, agentId, chainId };
+  // Build the SignRequest from its declared fields only (never spread the raw
+  // body): extra body fields must not reach the policy engine or the vault —
+  // e.g. a smuggled `destination` previously shadowed `to` in the
+  // approved-addresses evaluator while the vault signed `to` (SEC-001).
+  const signRequest: SignRequest = {
+    tenantId,
+    agentId,
+    to: signBody.to,
+    value: signBody.value,
+    data: typeof signBody.data === "string" ? signBody.data : undefined,
+    chainId,
+    broadcast: shouldBroadcast,
+  };
 
   // Fetch active policies
   const db = getDb();

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -2118,7 +2118,7 @@ vaultRoutes.post("/:agentId/sign", async (c) => {
   }
 
   return withAgentSpendLock(agentId, async () => {
-    const stats = await getTransactionStats(agentId);
+    const stats = await getTransactionStats(agentId, signRequest.chainId);
 
     // Authoritative cumulative aggregates (Redis-sourced) for any aggregation
     // policies on this agent. Loaded INSIDE the per-agent spend lock so the
@@ -2650,7 +2650,7 @@ vaultRoutes.post("/:agentId/actions/send-calls", async (c) => {
       );
     }
 
-    const stats = await getTransactionStats(agentId);
+    const stats = await getTransactionStats(agentId, parsed.chainId);
     let runningSpentToday = stats.spentToday;
     let runningSpentThisWeek = stats.spentThisWeek;
     const evaluations = [];
@@ -3022,7 +3022,7 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
       });
     }
 
-    const stats = await getTransactionStats(agentId);
+    const stats = await getTransactionStats(agentId, signRequest.chainId);
     const transferPrecheckFailure = isSolanaTokenTransfer
       ? splTransferPolicyPrecheck(policySet, transfer.to, transfer.token)
       : isTokenTransfer
@@ -3820,7 +3820,7 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
         }
       }
       const currentConditionSets = await loadConditionSetsForPolicies(tenantId, currentPolicySet);
-      const stats = await getTransactionStats(agentId);
+      const stats = await getTransactionStats(agentId, approvalSignRequest.chainId);
       const currentTransferPrecheckFailure =
         isSolana &&
         transferPayload !== null &&
@@ -5390,7 +5390,7 @@ vaultRoutes.post("/:agentId/sign-raw-digest", async (c) => {
   if (rateLimitResult.headers) {
     for (const [key, value] of Object.entries(rateLimitResult.headers)) c.header(key, value);
   }
-  const stats = await getTransactionStats(agentId);
+  const stats = await getTransactionStats(agentId, 0);
   const evaluation = await policyEngine.evaluate(policySet, {
     request: {
       agentId,
@@ -5632,8 +5632,8 @@ vaultRoutes.post("/:agentId/sign-bitcoin-psbt", async (c) => {
   const bitcoinSpendSats = (destinationTotalSats + feeSats).toString();
 
   return withAgentSpendLock(agentId, async () => {
-    const stats = await getTransactionStats(agentId);
     const bitcoinChainId = psbtInspection.network === "mainnet" ? 201 : 202;
+    const stats = await getTransactionStats(agentId, bitcoinChainId);
     const policyResults: PolicyResult[] = [];
     for (const output of destinationOutputs) {
       const evaluation = await policyEngine.evaluate(policySet, {
@@ -6138,7 +6138,7 @@ vaultRoutes.post("/:agentId/monero/transfer", async (c) => {
       });
     }
 
-    const stats = await getTransactionStats(agentId);
+    const stats = await getTransactionStats(agentId, moneroChainId);
     const policyResults: PolicyResult[] = [];
     // NOTE: USD-denominated rules fail closed for Monero (the price oracle has
     // no XMR source), so operators must use piconero-denominated limits.
@@ -6525,7 +6525,7 @@ vaultRoutes.post("/:agentId/sign-typed-data", async (c) => {
     return c.json<ApiResponse>({ ok: false, error: rlResult.reason || "Rate limit exceeded" }, 429);
   }
 
-  const stats = await getTransactionStats(agentId);
+  const stats = await getTransactionStats(agentId, resolvedChainId);
 
   const evaluation = await policyEngine.evaluate(policySet, {
     request: signRequest,
@@ -6842,7 +6842,7 @@ vaultRoutes.post("/:agentId/sign-user-operation", async (c) => {
   }
 
   return withAgentSpendLock(agentId, async () => {
-    const stats = await getTransactionStats(agentId);
+    const stats = await getTransactionStats(agentId, signRequest.chainId);
     const evaluation = await policyEngine.evaluate(policySet, {
       request: signRequest,
       recentTxCount1h: stats.recentTxCount1h,
@@ -7218,7 +7218,7 @@ vaultRoutes.post("/:agentId/sign-authorization", async (c) => {
   }
 
   return withAgentSpendLock(agentId, async () => {
-    const stats = await getTransactionStats(agentId);
+    const stats = await getTransactionStats(agentId, signRequest.chainId);
     const evaluation = await policyEngine.evaluate(policySet, {
       request: signRequest,
       recentTxCount1h: stats.recentTxCount1h,
@@ -7456,7 +7456,7 @@ async function signSolanaBlind(
   // Same per-agent advisory spend lock as the parsed path: serialize eval+sign+
   // commit so concurrent blind-sign requests cannot race the spend cap.
   return withAgentSpendLock(agentId, async () => {
-    const stats = await getTransactionStats(agentId);
+    const stats = await getTransactionStats(agentId, signRequest.chainId);
     const evaluation = await policyEngine.evaluate(policySet, {
       request: signRequest,
       recentTxCount1h: stats.recentTxCount1h,
@@ -7853,7 +7853,7 @@ vaultRoutes.post("/:agentId/sign-solana", async (c) => {
   // both sign — overspending the cap. This mirrors the EVM sign/transfer/
   // user-operation/authorization paths, which all wrap eval+sign under the lock.
   return withAgentSpendLock(agentId, async () => {
-    const stats = await getTransactionStats(agentId);
+    const stats = await getTransactionStats(agentId, chainId);
 
     const evaluation = await policyEngine.evaluate(policySet, {
       request: signRequest,

--- a/packages/policy-engine/src/__tests__/evaluators.test.ts
+++ b/packages/policy-engine/src/__tests__/evaluators.test.ts
@@ -1486,6 +1486,34 @@ describe("PolicyEngine.evaluate()", () => {
     expect(result.results).toHaveLength(0);
   });
 
+  it("policies with falsy non-false `enabled` hit the deny-all branch (SEC-103)", async () => {
+    // Hand-authored rules carrying enabled: undefined/null bypass the API
+    // write validator's boolean check. They are "disabled" for pass purposes,
+    // so an all-such set must deny — never auto-approve.
+    const policies = [
+      { id: "p1", type: "spending-limit", enabled: undefined, config: {} },
+      { id: "p2", type: "rate-limit", enabled: null, config: {} },
+    ] as unknown as PolicyRule[];
+
+    const result = await engine.evaluate(policies, makeEngineCtx());
+
+    expect(result.approved).toBe(false);
+  });
+
+  it("a non-boolean `enabled` fails closed instead of evaluating (SEC-103)", async () => {
+    const rule = {
+      id: "p1",
+      type: "spending-limit",
+      enabled: "yes",
+      config: { maxPerTx: "1", maxPerDay: "1", maxPerWeek: "1" },
+    } as unknown as PolicyRule;
+
+    const result = await evaluatePolicy(rule, makeContext());
+
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("enabled");
+  });
+
   it("all hard policies pass → approved", async () => {
     const policies: PolicyRule[] = [
       makeSpendingRule({

--- a/packages/policy-engine/src/__tests__/evaluators.test.ts
+++ b/packages/policy-engine/src/__tests__/evaluators.test.ts
@@ -860,26 +860,30 @@ describe("Approved Addresses Policy", () => {
     expect(result.passed).toBe(true);
   });
 
-  it("passes withdrawal when destination is approved", async () => {
-    const destination = "0xfeed00000000000000000000000000000000beef";
+  it("ignores a smuggled destination field — request.to is authoritative (SEC-001)", async () => {
+    const whitelisted = "0xfeed00000000000000000000000000000000beef";
     const rule = makeAddressRule({
-      addresses: [destination],
+      addresses: [whitelisted],
       mode: "whitelist",
     });
 
+    // { to: <attacker>, destination: <whitelisted> } must NOT pass: the engine
+    // evaluates only the address actually signed (`to`), never envelope shadow
+    // fields.
     const ctx = makeContext({
       request: {
         ...makeContext().request,
         to: "0x0000000000000000000000000000000000000000",
-        destination,
+        destination: whitelisted,
       } as SignRequest & { destination: string },
     });
     const result = await evaluatePolicy(rule, ctx);
 
-    expect(result.passed).toBe(true);
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("not in whitelist");
   });
 
-  it("rejects withdrawal when destination is not approved", async () => {
+  it("passes when request.to is approved even if a shadow destination is not", async () => {
     const destination = "0xfeed00000000000000000000000000000000beef";
     const rule = makeAddressRule({
       addresses: ["0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"],
@@ -889,15 +893,19 @@ describe("Approved Addresses Policy", () => {
     const ctx = makeContext({
       request: {
         ...makeContext().request,
-        to: "0x0000000000000000000000000000000000000000",
+        to: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         destination,
-      } as SignRequest & { destination: string },
+        action: { destination },
+        withdraw: { destination },
+      } as SignRequest & {
+        destination: string;
+        action: { destination: string };
+        withdraw: { destination: string };
+      },
     });
     const result = await evaluatePolicy(rule, ctx);
 
-    expect(result.passed).toBe(false);
-    expect(result.reason).toContain("Destination address");
-    expect(result.reason).toContain("not in whitelist");
+    expect(result.passed).toBe(true);
   });
 });
 

--- a/packages/policy-engine/src/__tests__/evaluators.test.ts
+++ b/packages/policy-engine/src/__tests__/evaluators.test.ts
@@ -448,6 +448,47 @@ describe("Spending Limit Policy", () => {
     expect(result.reason).toContain("daily spending limit");
   });
 
+  // ─── Mixed wei + USD limits are conjunctive (SEC-037) ────────────────────
+
+  const ethPriceOracle = {
+    getNativeUsdPrice: async () => 2000,
+    getTokenUsdPrice: async () => null,
+    weiToUsd: async (wei: string) => (Number(BigInt(wei)) / 1e18) * 2000,
+    usdToWei: async () => null,
+  };
+
+  it("enforces an explicit wei cap even when a USD limit is also configured", async () => {
+    const rule = makeSpendingRule({
+      maxPerTx: "10000000000000000", // 0.01 ETH
+      maxPerDayUsd: 5000, // USD daily cap the tx satisfies ($2000 < $5000)
+    });
+
+    const ctx = makeContext({
+      request: { ...makeContext().request, value: "1000000000000000000" }, // 1 ETH
+      priceOracle: ethPriceOracle,
+    });
+    const result = await evaluatePolicy(rule, ctx);
+
+    // Previously the USD branch returned early and the wei cap never fired.
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("per-tx limit");
+  });
+
+  it("passes a mixed wei+USD config only when both limits hold", async () => {
+    const rule = makeSpendingRule({
+      maxPerTx: "10000000000000000", // 0.01 ETH
+      maxPerDayUsd: 5000,
+    });
+
+    const ctx = makeContext({
+      request: { ...makeContext().request, value: "5000000000000000" }, // 0.005 ETH = $10
+      priceOracle: ethPriceOracle,
+    });
+    const result = await evaluatePolicy(rule, ctx);
+
+    expect(result.passed).toBe(true);
+  });
+
   // ─── Per-tx boundary tests ─────────────────────────────────────────────
 
   it("passes when value is exactly at the per-tx limit (boundary)", async () => {

--- a/packages/policy-engine/src/__tests__/evaluators.test.ts
+++ b/packages/policy-engine/src/__tests__/evaluators.test.ts
@@ -190,6 +190,60 @@ describe("Contract Allowlist Policy", () => {
     expect(result.reason).toContain("exceeds selector maxNativeValueWei 1");
   });
 
+  it("fails closed when a constraint is declared for a selector the engine cannot decode (SEC-038)", async () => {
+    // swapExactTokensForTokens(uint256,uint256,address[],address,uint256) —
+    // allowlisted, but not one of the 8 selectors with a constraint decoder.
+    const swapSelector = "0x38ed1739";
+    const swapRule = makeContractAllowlistRule({
+      contracts: [
+        {
+          address: contract,
+          selectors: [swapSelector],
+          constraints: { [swapSelector]: { maxAmount: "1000" } },
+        },
+      ],
+    });
+    const result = await evaluatePolicy(
+      swapRule,
+      makeContext({
+        request: {
+          ...makeContext().request,
+          to: contract,
+          data: `${swapSelector}${abiUint(500)}${abiUint(1)}`,
+        },
+      }),
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("unrecognized selector");
+  });
+
+  it("still passes an unrecognized selector when only maxNativeValueWei is constrained", async () => {
+    const swapSelector = "0x38ed1739";
+    const swapRule = makeContractAllowlistRule({
+      contracts: [
+        {
+          address: contract,
+          selectors: [swapSelector],
+          constraints: { [swapSelector]: { maxNativeValueWei: "10", recipientAllowlist: [] } },
+        },
+      ],
+    });
+    const result = await evaluatePolicy(
+      swapRule,
+      makeContext({
+        request: {
+          ...makeContext().request,
+          to: contract,
+          value: "10",
+          data: `${swapSelector}00`,
+        },
+      }),
+    );
+
+    expect(result.passed).toBe(true);
+  });
+
   it("fails when selector is not allowed for the contract", async () => {
     const result = await evaluatePolicy(
       rule,

--- a/packages/policy-engine/src/__tests__/reputation-manual-approval.test.ts
+++ b/packages/policy-engine/src/__tests__/reputation-manual-approval.test.ts
@@ -151,12 +151,12 @@ describe("PolicyEngine — reputation-threshold fallbackAction (no score availab
     expect(res.requiresManualApproval).toBe(true);
   });
 
-  it("fallbackAction approve → approved", async () => {
+  it("fallbackAction approve with no score wired → hard deny (fail closed, SEC-040)", async () => {
     const engine = new PolicyEngine();
     const rule = makeReputationRule({ minScore: 50, fallbackAction: "approve" });
     const res = await engine.evaluate([rule], makePolicyContext({}));
 
-    expect(res.approved).toBe(true);
+    expect(res.approved).toBe(false);
     expect(res.requiresManualApproval).toBe(false);
   });
 });

--- a/packages/policy-engine/src/__tests__/reputation.test.ts
+++ b/packages/policy-engine/src/__tests__/reputation.test.ts
@@ -139,12 +139,22 @@ describe("reputation-threshold evaluator", () => {
     expect(result.reason).toContain("fallback");
   });
 
-  it("passes on fallback when fallbackAction is approve", () => {
+  it("fails closed on fallback when fallbackAction is approve and no score is wired (SEC-040)", () => {
     const rule = makeRule("reputation-threshold", {
       ...config,
       fallbackAction: "approve",
     });
     const result = evaluateReputationThreshold(rule, {});
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("fail closed");
+  });
+
+  it("still honors action: approve when a score IS wired but below minimum", () => {
+    const rule = makeRule("reputation-threshold", {
+      ...config,
+      action: "approve",
+    });
+    const result = evaluateReputationThreshold(rule, { reputationScore: 10 });
     expect(result.passed).toBe(true);
   });
 

--- a/packages/policy-engine/src/engine.ts
+++ b/packages/policy-engine/src/engine.ts
@@ -214,7 +214,10 @@ export class PolicyEngine {
       policies.map((policy) => evaluatePolicy(policy, evaluatorCtx)),
     );
 
-    if (policies.every((policy) => policy.enabled === false)) {
+    // Same falsy check as evaluatePolicy: a rule with `enabled: undefined`/
+    // null/0 is disabled for pass purposes, so an all-such policy set hits
+    // this deny-all branch instead of auto-approving everything (SEC-103).
+    if (policies.every((policy) => !policy.enabled)) {
       const evaluationResult = { approved: false, results, requiresManualApproval: false };
       await this.emitAuditEvent(ctx, results, evaluationResult);
       return evaluationResult;

--- a/packages/policy-engine/src/engine.ts
+++ b/packages/policy-engine/src/engine.ts
@@ -39,6 +39,12 @@ export interface PolicyEvaluationContext {
   request: SignRequest;
   recentTxCount24h: number;
   recentTxCount1h: number;
+  /**
+   * Rolling spend sums in the base unit of `request.chainId` ONLY. Callers
+   * MUST scope these counters to the request's chain — a cross-chain sum
+   * mixes incomparable units (wei/lamports/piconero) and corrupts both the
+   * wei caps and the USD-priced caps (SEC-039).
+   */
   spentToday: bigint;
   spentThisWeek: bigint;
   /** Optional price oracle for USD-based policy evaluation */

--- a/packages/policy-engine/src/evaluators.ts
+++ b/packages/policy-engine/src/evaluators.ts
@@ -540,20 +540,12 @@ function evaluateApprovedAddresses(rule: PolicyRule, ctx: EvaluatorContext): Pol
 }
 
 function getApprovedAddressTarget(request: SignRequest): string | undefined {
-  const withdrawalRequest = request as SignRequest & {
-    destination?: unknown;
-    action?: { destination?: unknown };
-    withdraw?: { destination?: unknown };
-  };
-
-  if (typeof withdrawalRequest.destination === "string") return withdrawalRequest.destination;
-  if (typeof withdrawalRequest.action?.destination === "string") {
-    return withdrawalRequest.action.destination;
-  }
-  if (typeof withdrawalRequest.withdraw?.destination === "string") {
-    return withdrawalRequest.withdraw.destination;
-  }
-
+  // ONLY `request.to` is authoritative: it is the address the vault actually
+  // signs for. Envelope shadow fields (`destination`, `action.destination`,
+  // `withdraw.destination`) were once honored for a server-built withdraw flow
+  // that now passes `to` explicitly — keeping them lets a caller smuggle a
+  // whitelisted `destination` past the whitelist while signing to an arbitrary
+  // `to` (SEC-001).
   return request.to;
 }
 

--- a/packages/policy-engine/src/evaluators.ts
+++ b/packages/policy-engine/src/evaluators.ts
@@ -140,6 +140,16 @@ export async function evaluatePolicy(
   rule: PolicyRule,
   ctx: EvaluatorContext,
 ): Promise<PolicyResult & ManualApprovalSignal> {
+  // A non-boolean `enabled` is malformed config, not "disabled": fail closed
+  // rather than let a hand-authored rule silently pass as disabled (SEC-103).
+  if (typeof rule.enabled !== "boolean") {
+    return {
+      policyId: rule.id,
+      type: rule.type,
+      passed: false,
+      reason: "Policy enabled flag must be a boolean",
+    };
+  }
   if (!rule.enabled) {
     return {
       policyId: rule.id,

--- a/packages/policy-engine/src/evaluators.ts
+++ b/packages/policy-engine/src/evaluators.ts
@@ -452,10 +452,21 @@ async function evaluateSpendingLimit(
       }
     }
 
-    return { ...base, passed: true };
+    // USD limits hold. Wei-denominated caps declared in the SAME config are
+    // conjunctive, not alternative: previously any USD field short-circuited
+    // the whole wei section, so an operator's per-tx wei cap silently went
+    // unenforced (SEC-037). Fall through to the wei evaluation — undeclared
+    // wei fields normalize to MAX_UINT256, so only explicit caps bite.
+    if (
+      rule.config.maxPerTx === undefined &&
+      rule.config.maxPerDay === undefined &&
+      rule.config.maxPerWeek === undefined
+    ) {
+      return { ...base, passed: true };
+    }
   }
 
-  // ── Wei-based evaluation (legacy / fallback) ────────────────────────────────
+  // ── Wei-based evaluation (legacy / fallback, and conjunctive with USD) ──────
   // ATOMICITY CONTRACT: this evaluator is pure — it compares the caller-supplied
   // spentToday/spentThisWeek counters and reserves/commits nothing. Concurrency
   // safety for the daily/weekly caps is the CALLER's responsibility: the spend

--- a/packages/policy-engine/src/evaluators.ts
+++ b/packages/policy-engine/src/evaluators.ts
@@ -35,6 +35,13 @@ export interface EvaluatorContext {
   request: SignRequest;
   recentTxCount24h: number;
   recentTxCount1h: number;
+  /**
+   * Rolling spend sums in the base unit of `request.chainId` ONLY (wei for
+   * EVM, lamports for Solana, piconero for Monero...). Callers MUST scope
+   * these counters to the request's chain: a cross-chain sum mixes
+   * incomparable units, and the USD path re-prices it at this request's chain
+   * price — silently under- or over-enforcing the cap (SEC-039).
+   */
   spentToday: bigint;
   spentThisWeek: bigint;
   /** Optional price oracle for USD-based policy evaluation */

--- a/packages/policy-engine/src/evaluators.ts
+++ b/packages/policy-engine/src/evaluators.ts
@@ -1252,8 +1252,26 @@ function evaluateEvmSelectorConstraint(
 
       return { ...base, passed: true };
     }
-    default:
+    default: {
+      // `maxNativeValueWei` is selector-agnostic and was already enforced
+      // above. Any OTHER declared constraint requires decoding calldata for a
+      // selector this engine does not know — fail closed rather than let the
+      // operator believe a recipient/amount/tokenId gate is enforced when it
+      // is a silent no-op (SEC-038). Empty arrays are no-ops, matching the
+      // known-selector arms.
+      const hasUnenforceableConstraint = Object.entries(constraint).some(([key, value]) => {
+        if (key === "maxNativeValueWei" || value === undefined) return false;
+        return !(Array.isArray(value) && value.length === 0);
+      });
+      if (hasUnenforceableConstraint) {
+        return {
+          ...base,
+          passed: false,
+          reason: `Selector constraints cannot be enforced for unrecognized selector ${selector}`,
+        };
+      }
       return { ...base, passed: true };
+    }
   }
 }
 

--- a/packages/policy-engine/src/evaluators/reputation-threshold.ts
+++ b/packages/policy-engine/src/evaluators/reputation-threshold.ts
@@ -7,6 +7,10 @@
  * Each configurable action maps to a distinct engine outcome when the score is
  * below `minScore` (or when no score is available and `fallbackAction` applies):
  *   - `approve`          → `passed: true` (the policy does not block this tx).
+ *                         EXCEPTION: as a `fallbackAction` with NO score wired
+ *                         it fails closed (deny) — otherwise every rule is a
+ *                         hidden default-allow while no score source exists
+ *                         (SEC-040).
  *   - `require-approval` → `passed: false` + `requiresManualApproval: true`
  *                          (the engine routes the tx to the manual-approval
  *                          queue instead of hard-rejecting it).
@@ -66,7 +70,19 @@ export function evaluateReputationThreshold(
   const base = { policyId: rule.id, type: rule.type } as const;
 
   if (ctx.reputationScore === undefined || ctx.reputationScore === null) {
-    // No score available, use fallback action.
+    // No score available. FAIL CLOSED on an `approve` fallback: no caller in
+    // the API wires a reputation score, so honoring `fallbackAction:
+    // "approve"` would make every reputation-threshold rule a silent
+    // default-allow (SEC-040). Manual-review and block fallbacks keep their
+    // semantics.
+    if (config.fallbackAction === "approve") {
+      return {
+        ...base,
+        passed: false,
+        reason:
+          "No reputation score available; fallbackAction \"approve\" is not permitted without a wired score (fail closed)",
+      };
+    }
     return resultForUnmetThreshold(
       base,
       config.fallbackAction,

--- a/packages/policy-engine/src/evaluators/reputation-threshold.ts
+++ b/packages/policy-engine/src/evaluators/reputation-threshold.ts
@@ -80,7 +80,7 @@ export function evaluateReputationThreshold(
         ...base,
         passed: false,
         reason:
-          "No reputation score available; fallbackAction \"approve\" is not permitted without a wired score (fail closed)",
+          'No reputation score available; fallbackAction "approve" is not permitted without a wired score (fail closed)',
       };
     }
     return resultForUnmetThreshold(

--- a/packages/webhooks/src/__tests__/dispatcher-security.test.ts
+++ b/packages/webhooks/src/__tests__/dispatcher-security.test.ts
@@ -237,6 +237,30 @@ describe("WebhookDispatcher HMAC signing", () => {
       await server.close();
     }
   });
+
+  it("treats an empty events array as subscribe-to-all and actually delivers", async () => {
+    const server = await withWebhookServer(() => ({ status: 200 }));
+
+    try {
+      const dispatcher = new WebhookDispatcher({
+        maxRetries: 0,
+        timeoutMs: 1_000,
+        allowPrivateNetwork: true,
+        allowInsecureHttp: true,
+      });
+      const result = await dispatcher.dispatch(makeEvent(), {
+        url: server.url,
+        secret: SECRET,
+        events: [],
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.attempts).toBe(1);
+      expect(server.requests).toHaveLength(1);
+    } finally {
+      await server.close();
+    }
+  });
 });
 
 describe("RetryQueue delivery invariants", () => {

--- a/packages/webhooks/src/__tests__/dispatcher-ssrf-literal.test.ts
+++ b/packages/webhooks/src/__tests__/dispatcher-ssrf-literal.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "bun:test";
+import { createServer, type IncomingMessage } from "node:http";
+import type { AddressInfo } from "node:net";
+import type { WebhookEvent } from "@stwd/shared";
+import { WebhookDispatcher } from "../dispatcher";
+
+const SECRET = "ssrf-literal-test-secret";
+
+const makeEvent = (): WebhookEvent => ({
+  type: "tx_signed",
+  tenantId: "tenant-a",
+  agentId: "agent-a",
+  data: { txHash: "0xabc" },
+  timestamp: new Date("2026-05-30T09:00:00.000Z"),
+});
+
+async function withLoopbackServer() {
+  let hits = 0;
+  const server = createServer((_req: IncomingMessage, res) => {
+    hits += 1;
+    res.writeHead(200, { "Content-Type": "text/plain" });
+    res.end("ok");
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.listen(0, "127.0.0.1", (error?: Error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+  const { port } = server.address() as AddressInfo;
+  return {
+    port,
+    hits: () => hits,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      }),
+  };
+}
+
+describe("WebhookDispatcher SSRF guard for IP-literal URLs", () => {
+  // Node's http client skips options.lookup for IPv4 literals, so the guarded
+  // lookup alone never fired for these forms (SEC-006). The guard must reject
+  // the literal hostname before any socket is opened.
+  it("rejects loopback IPv4 literals in every canonicalized form without connecting", async () => {
+    const server = await withLoopbackServer();
+    const dispatcher = new WebhookDispatcher({
+      maxRetries: 0,
+      retryDelayMs: 1,
+      timeoutMs: 500,
+      allowPrivateNetwork: false,
+      allowInsecureHttp: true,
+    });
+
+    try {
+      for (const url of [
+        `http://127.0.0.1:${server.port}/hook`,
+        `http://2130706433:${server.port}/hook`, // 127.0.0.1 as decimal
+        `http://0x7f000001:${server.port}/hook`, // 127.0.0.1 as hex
+        `http://127.1:${server.port}/hook`, // shorthand
+      ]) {
+        const result = await dispatcher.dispatch(makeEvent(), { url, secret: SECRET });
+        expect(result.success).toBe(false);
+        expect(result.error).toContain("must resolve to a public address");
+      }
+      expect(server.hits()).toBe(0);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("rejects private-range and link-local IPv4 literals", async () => {
+    const dispatcher = new WebhookDispatcher({
+      maxRetries: 0,
+      retryDelayMs: 1,
+      timeoutMs: 500,
+      allowPrivateNetwork: false,
+      allowInsecureHttp: true,
+    });
+
+    for (const url of [
+      "http://169.254.169.254/latest/meta-data",
+      "http://10.0.0.8/hook",
+      "http://192.168.1.1/hook",
+      "http://172.16.0.1/hook",
+      "http://[::1]/hook",
+    ]) {
+      const result = await dispatcher.dispatch(makeEvent(), { url, secret: SECRET });
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("must resolve to a public address");
+    }
+  });
+
+  it("still delivers to loopback when the private-network escape hatch is explicit", async () => {
+    const server = await withLoopbackServer();
+    const dispatcher = new WebhookDispatcher({
+      maxRetries: 0,
+      timeoutMs: 1_000,
+      allowPrivateNetwork: true,
+      allowInsecureHttp: true,
+    });
+
+    try {
+      const result = await dispatcher.dispatch(makeEvent(), {
+        url: `http://127.0.0.1:${server.port}/hook`,
+        secret: SECRET,
+      });
+      expect(result.success).toBe(true);
+      expect(server.hits()).toBe(1);
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/packages/webhooks/src/__tests__/persistent-queue.test.ts
+++ b/packages/webhooks/src/__tests__/persistent-queue.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, mock } from "bun:test";
+import type { WebhookEvent } from "@stwd/shared";
+
+// PersistentQueue talks to the DB through @stwd/db + drizzle-orm; mock both so
+// the queue loop can be exercised without a live database. No other test file
+// in this package imports either module, so the process-wide module mock is
+// contained.
+const webhookConfigRow = { id: "cfg-1", url: "https://receiver.example.com/hook", events: [] };
+const updateSets: Record<string, unknown>[] = [];
+
+const claimedRows = [
+  {
+    id: "delivery-poison",
+    tenantId: "tenant-1",
+    webhookConfigId: "cfg-1",
+    agentId: "agent-1",
+    eventType: "tx_signed",
+    payload: {
+      type: "tx_signed",
+      tenantId: "tenant-1",
+      agentId: "agent-1",
+      data: {},
+      timestamp: new Date("2026-05-30T09:00:00.000Z"),
+    } satisfies WebhookEvent,
+    url: webhookConfigRow.url,
+    // Undecryptable: valid prefix, garbage payload (e.g. post key-rotation row).
+    secret: "stwd_whsec_v1:{not-json",
+    events: null,
+    status: "pending",
+    attempts: 0,
+    maxAttempts: 5,
+    nextRetryAt: new Date(),
+  },
+  {
+    id: "delivery-good",
+    tenantId: "tenant-1",
+    webhookConfigId: "cfg-1",
+    agentId: "agent-1",
+    eventType: "tx_signed",
+    payload: {
+      type: "tx_signed",
+      tenantId: "tenant-1",
+      agentId: "agent-1",
+      data: {},
+      timestamp: new Date("2026-05-30T09:00:00.000Z"),
+    } satisfies WebhookEvent,
+    url: webhookConfigRow.url,
+    secret: "whsec_plaintext",
+    events: null,
+    status: "pending",
+    attempts: 0,
+    maxAttempts: 5,
+    nextRetryAt: new Date(),
+  },
+];
+
+const db = {
+  transaction: async (fn: (tx: { execute: () => Promise<unknown> }) => Promise<unknown>) =>
+    fn({ execute: async () => claimedRows }),
+  select: () => ({
+    from: () => ({
+      where: () => ({
+        limit: () => Promise.resolve([webhookConfigRow]),
+      }),
+    }),
+  }),
+  update: () => ({
+    set: (value: Record<string, unknown>) => {
+      updateSets.push(value);
+      return { where: () => Promise.resolve([{ id: "delivery-1", ...value }]) };
+    },
+  }),
+};
+
+mock.module("@stwd/db", () => ({
+  getDb: () => db,
+  webhookConfigs: { id: "id", tenantId: "tenantId", url: "url", events: "events", enabled: "on" },
+  webhookDeliveries: {
+    id: "id",
+    status: "status",
+    nextRetryAt: "nextRetryAt",
+    tenantId: "tenantId",
+  },
+}));
+mock.module("drizzle-orm", () => ({
+  and: () => true,
+  eq: () => true,
+  sql: () => ({}),
+}));
+
+const dispatchCalls: { url: string; secret: string }[] = [];
+const stubDispatcher = {
+  dispatch: async (_event: WebhookEvent, config: { url: string; secret: string }) => {
+    dispatchCalls.push({ url: config.url, secret: config.secret });
+    return { success: true, attempts: 1, deliveredAt: new Date() };
+  },
+};
+
+const { PersistentQueue } = await import("../persistent-queue");
+const { WebhookDispatcher } = await import("../dispatcher");
+
+describe("PersistentQueue poison-pill isolation", () => {
+  it("dead-letters an undecryptable secret and still processes the rest of the batch", async () => {
+    const queue = new PersistentQueue(
+      stubDispatcher as unknown as InstanceType<typeof WebhookDispatcher>,
+      { batchSize: 10 },
+    );
+
+    // Without per-delivery isolation the decrypt throw rejects processQueue().
+    const results = await queue.processQueue();
+
+    expect(results).toHaveLength(2);
+    const [poison, good] = results;
+    expect(poison).toMatchObject({ success: false, attempts: 1 });
+    expect(poison?.error).toBeDefined();
+    expect(good).toMatchObject({ success: true, attempts: 1 });
+
+    // The poisoned row is dead-lettered with its attempts incremented…
+    const deadUpdate = updateSets.find((set) => set.status === "dead");
+    expect(deadUpdate).toMatchObject({ attempts: 1 });
+    expect(String(deadUpdate?.lastError)).toContain("failed deterministically");
+    // …and a delivered update is recorded for the healthy row.
+    expect(updateSets.some((set) => set.status === "delivered" && set.attempts === 1)).toBe(true);
+
+    // The poisoned row never reaches the dispatcher; the healthy one does.
+    expect(dispatchCalls).toHaveLength(1);
+    expect(dispatchCalls[0]?.secret).toBe("whsec_plaintext");
+  });
+});

--- a/packages/webhooks/src/dispatcher.ts
+++ b/packages/webhooks/src/dispatcher.ts
@@ -393,7 +393,10 @@ export class WebhookDispatcher {
   ): Promise<WebhookDeliveryResult> {
     const config = normalizeWebhook(webhook);
 
-    if (config.events && !config.events.includes(event.type)) {
+    // An empty events array means "subscribe to all" everywhere else
+    // (acceptsConfiguredWebhookEvent, persistent-queue) — a truthy [] must
+    // not silently drop every event while reporting success.
+    if (config.events?.length && !config.events.includes(event.type)) {
       return {
         success: true,
         attempts: 0,

--- a/packages/webhooks/src/dispatcher.ts
+++ b/packages/webhooks/src/dispatcher.ts
@@ -178,6 +178,18 @@ function isNonPublicIpv6(address: string): boolean {
   );
 }
 
+/**
+ * Deterministic, non-transient rejection of a webhook delivery target (bad
+ * scheme, non-public host/address). Distinct from network failures so callers
+ * can classify it as non-retryable.
+ */
+export class WebhookValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WebhookValidationError";
+  }
+}
+
 function assertPublicWebhookHostname(hostname: string): void {
   if (!hostname) throw new Error("Webhook URL must include a host");
   if (
@@ -186,15 +198,15 @@ function assertPublicWebhookHostname(hostname: string): void {
     hostname.endsWith(".local") ||
     hostname.endsWith(".internal")
   ) {
-    throw new Error("Webhook host must resolve to a public address");
+    throw new WebhookValidationError("Webhook host must resolve to a public address");
   }
 
   const literalVersion = isIP(hostname);
   if (literalVersion === 4 && isNonPublicIpv4(hostname)) {
-    throw new Error("Webhook host must resolve to a public address");
+    throw new WebhookValidationError("Webhook host must resolve to a public address");
   }
   if (literalVersion === 6 && isNonPublicIpv6(hostname)) {
-    throw new Error("Webhook host must resolve to a public address");
+    throw new WebhookValidationError("Webhook host must resolve to a public address");
   }
 }
 
@@ -289,6 +301,12 @@ async function postWebhook(
     },
   };
   if (!init.allowPrivateNetwork) {
+    // Node's http/https client skips `options.lookup` entirely when the URL
+    // host is already an IP literal, so the guarded lookup alone never runs
+    // for `http://127.0.0.1/…`-style targets (WHATWG parsing canonicalizes
+    // decimal/hex/shorthand IPv4 forms to dotted-quad first). Check the
+    // literal hostname up front, before any socket is opened.
+    assertPublicWebhookHostname(parsed.hostname.replace(/^\[|\]$/g, "").toLowerCase());
     options.lookup = createPublicLookup(init.lookup);
   } else if (init.lookup) {
     options.lookup = init.lookup;

--- a/packages/webhooks/src/persistent-queue.ts
+++ b/packages/webhooks/src/persistent-queue.ts
@@ -212,12 +212,37 @@ export class PersistentQueue {
         continue;
       }
 
-      const result = await this.dispatcher.dispatch(event, {
-        id: webhook.id,
-        url: delivery.url,
-        secret: decryptWebhookSecret(delivery.secret),
-        events: delivery.events ?? undefined,
-      });
+      // A poisoned row must not reject the whole batch: an undecryptable
+      // secret (e.g. after STEWARD_WEBHOOK_SECRET_ENCRYPTION_KEY rotation, or
+      // a malformed stwd_whsec_v1: payload) throws deterministically, and an
+      // un-wrapped throw would reclaim the row forever and block every later
+      // delivery in the batch. Dead-letter it (attempts incremented) and move
+      // on — the row never becomes deliverable again on its own.
+      let result: WebhookDeliveryResult;
+      try {
+        result = await this.dispatcher.dispatch(event, {
+          id: webhook.id,
+          url: delivery.url,
+          secret: decryptWebhookSecret(delivery.secret),
+          events: delivery.events ?? undefined,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Unknown webhook delivery error";
+        await db
+          .update(webhookDeliveries)
+          .set({
+            status: "dead",
+            attempts: newAttempts,
+            lastError: `Webhook delivery failed deterministically: ${message}`,
+          })
+          .where(eq(webhookDeliveries.id, delivery.id));
+        results.push({
+          success: false,
+          attempts: newAttempts,
+          error: message,
+        });
+        continue;
+      }
 
       // dispatch() mutates `event` with a stable deliveryId + signedAt; persist it
       // so retries reuse the same id/timestamp/signature instead of re-signing fresh.


### PR DESCRIPTION
## Summary

Batch 4a of the wave-2 audit remediation: `packages/webhooks` + `packages/policy-engine` (plus the two minimal API call-site changes those fixes require). Both HIGH and all six MEDIUM findings are fixed with regression tests; one LOW (SEC-103) landed incidentally while in the engine; the remaining LOW/INFO findings are deferred to a follow-up so this PR stays reviewable.

| SEC ID | Severity | Status | Change |
|---|---|---|---|
| SEC-001 | HIGH | FIXED | `approved-addresses` evaluates `request.to` only (shadow `destination`/`action.destination`/`withdraw.destination` precedence removed — its only consumer already passes `to` explicitly); `POST /me/wallet/sign` builds its `SignRequest` from allow-listed fields instead of spreading the raw body. |
| SEC-006 | HIGH | FIXED | `postWebhook` runs the non-public-host check on the parsed (WHATWG-canonicalized) hostname before opening a socket — Node skips `options.lookup` for IP literals, so the guarded lookup never ran for `127.0.0.1`, decimal/hex/shorthand IPv4, or link-local literals. New `WebhookValidationError` classifies these deterministic rejections. |
| SEC-035 | MEDIUM | FIXED | Dispatcher subscription check uses `config.events?.length`, so `events: []` is subscribe-to-all like every other layer instead of silently dropping all events while reporting `delivered`. |
| SEC-036 | MEDIUM | FIXED | Per-delivery try/catch in `PersistentQueue.processQueue`: an undecryptable secret is dead-lettered (attempts incremented) instead of rejecting the whole batch into an infinite reclaim loop. |
| SEC-037 | MEDIUM | FIXED | Spending-limit evaluates explicit wei caps conjunctively with USD caps (undeclared wei fields still normalize to MAX_UINT256, so pure-USD configs are unchanged). |
| SEC-038 | MEDIUM | FIXED | Contract-allowlist fails closed when a constraint other than the selector-agnostic `maxNativeValueWei` is declared for a selector the engine cannot decode. |
| SEC-039 | MEDIUM | FIXED | All `vault.ts` enforcement call sites and the user-wallet sign route pass the request's `chainId` to the spend-stats query (no more wei+lamports+piconero mixed sums priced at the wrong chain); engine context contract documents the chain-scoped-unit requirement. Tx counts stay agent-wide. |
| SEC-040 | MEDIUM | FIXED | `reputation-threshold` with `fallbackAction: "approve"` and no wired score now fails closed (deny) instead of silently passing 100% of traffic. `require-approval`/`block` fallbacks and `action: "approve"` with a wired score are unchanged. |
| SEC-103 | LOW | FIXED | Engine all-disabled guard uses the same falsy check as `evaluatePolicy`; a non-boolean `enabled` now denies as malformed config. |
| SEC-101 | LOW | DEFERRED | Removing the legacy string-URL path means deleting the in-memory tenant-config fan-out in the API (per-tenant persisted configs already duplicate-deliver it) — behavior change needs its own review. |
| SEC-102 | LOW | DEFERRED | Dev-key gating on explicit development NODE_ENV + loud private-network warning; not started. |
| SEC-104 | LOW | DEFERRED | Audit-hook gaps (empty-policy-set deny, evaluator-throw path, swallowed hook failures); not started. |
| SEC-105 | LOW | DEFERRED | Evaluator config-shape guards (time-window/allowed-chains/approved-addresses/reputation-scaling); not started. |
| SEC-106 | LOW | DEFERRED | `Object.hasOwn` for the named-window table; one-line fix, not started. |
| SEC-107 | LOW | DEFERRED | ReDoS length caps for operator-supplied regexes in capability-intent; not started. |
| SEC-177 | INFO | DEFERRED | Receiver-side `verifyWebhookSignature` helper (timingSafeEqual + timestamp tolerance); not started. |
| SEC-178 | INFO | DEFERRED | IPv4-translated `::ffff:0:0/96` + discard/documentation IPv6 ranges; not started. |
| SEC-179 | INFO | DEFERRED | Retry classification: make deterministic validation failures non-retryable. Note: the `WebhookValidationError` class introduced for SEC-006 is the intended hook for this. |
| SEC-180 | INFO | DEFERRED | Fail closed on empty time-window config; not started. |
| SEC-181 | INFO | DEFERRED | Align malformed-rule scoping across the two capability-intent composers + generic path; not started. |
| SEC-182 | INFO | DEFERRED | Move X-constraint signals to typed `ctx.x` fields; not started. |
| SEC-183 | INFO | DEFERRED | Document the contract-allowlist native-transfer seam; not started. |

## Trade-offs / breaking changes

- **SEC-001**: `POST /me/wallet/sign` now drops undeclared body fields (`nonce`, `venue`, `walletAddress`, any extra keys) instead of forwarding them. All were either rejected by the route already or should never have been caller-controlled on a user-wallet sign.
- **SEC-040**: a `reputation-threshold` rule with `fallbackAction: "approve"` now denies whenever no score is wired (today: always, since no API caller wires one). This is the intended fail-closed behavior but will hard-deny such rules until a score source lands — flagged loudly in the result reason.
- **SEC-037**: mixed wei+USD spending-limit rules now enforce both; configs that accidentally relied on the USD field disabling wei caps will see new (correct) denials.

## Testing

- `packages/webhooks`: `bun test` — 33 pass, 0 fail (new regression coverage: SSRF-literal, events-[], poison-pill). Each new regression test was verified to FAIL without its fix (git-stash mutation check).
- `packages/policy-engine`: `bun test` — all pass, 0 fail; new regression cases for SEC-001/037/038/040/103, each mutation-verified against the unfixed code. Two pre-existing tests that encoded the old insecure behavior (destination shadowing; approve-fallback) were updated to the new contract.
- `packages/api`: `tsc --noEmit` clean; targeted `bun test src/__tests__/transaction-stats-chain-scope.test.ts` — 6 pass (includes new SEC-039 call-site wiring assertions). Full API suite not run (per batch instructions; the isolated runner is slow).
- `bunx biome check` on all changed files — clean.
- Pre-existing note: root `bun install` fails building the `pkcs11js` native module on this machine (unrelated HSM dep); `--ignore-scripts` + building `@stwd/shared`/`@stwd/redis`/`@stwd/attestation` dists was needed for local validation.
