### PR TITLE
fix(security): batch 8 — db/redis/shared hardening (SEC-030/031/032/045 + shared cluster)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,11 @@ services:
       STEWARD_PLUGINS: "${STEWARD_PLUGINS:-}"
       WXMR_SOLANA_RPC_URL: "${WXMR_SOLANA_RPC_URL:-}"
       REDIS_URL: "redis://redis:6379"
+      # Cleartext redis:// on the private compose network requires an explicit
+      # opt-out in production (mirrors STEWARD_ALLOW_INSECURE_DB above). No
+      # default is injected here: set STEWARD_ALLOW_INSECURE_REDIS=true in .env
+      # for this stack, or point REDIS_URL at a rediss:// endpoint.
+      STEWARD_ALLOW_INSECURE_REDIS: "${STEWARD_ALLOW_INSECURE_REDIS:-}"
       # API-side invoke paths sign requests to steward-proxy with this shared
       # root. Keep it distinct from JWT/audit secrets; the proxy service below
       # verifies the same value.
@@ -151,6 +156,10 @@ services:
       STEWARD_ALLOW_INSECURE_DB: "${STEWARD_ALLOW_INSECURE_DB:-}"
       STEWARD_PROXY_REQUEST_SIGNING_SECRET: "${STEWARD_PROXY_REQUEST_SIGNING_SECRET:?STEWARD_PROXY_REQUEST_SIGNING_SECRET is required - generate with: openssl rand -hex 32}"
       REDIS_URL: "redis://redis:6379"
+      # Cleartext redis:// on the private compose network requires an explicit
+      # opt-out in production (mirrors STEWARD_ALLOW_INSECURE_DB). Set
+      # STEWARD_ALLOW_INSECURE_REDIS=true in .env for this stack, or use rediss://.
+      STEWARD_ALLOW_INSECURE_REDIS: "${STEWARD_ALLOW_INSECURE_REDIS:-}"
     ports:
       - "127.0.0.1:${STEWARD_PROXY_PORT:-8080}:8080"
     healthcheck:

--- a/packages/api/src/__tests__/execution-authorization-v2-crypto.test.ts
+++ b/packages/api/src/__tests__/execution-authorization-v2-crypto.test.ts
@@ -130,8 +130,8 @@ describe("provider execution authorization v2 crypto", () => {
   it("domain separation: a v2 signature does not validate as a v1 HMAC of the same bytes", () => {
     // Same secret material fed to both, but v1 uses a different HKDF salt/info +
     // no domain prefix, so the digests must differ.
-    process.env.STEWARD_EXECUTION_AUTH_SECRET = "k1:shared-secret-entropy-abcdef";
-    process.env.STEWARD_JWT_SECRET = "shared-secret-entropy-abcdef";
+    process.env.STEWARD_EXECUTION_AUTH_SECRET = "k1:shared-secret-entropy-abcdef-padded32";
+    process.env.STEWARD_JWT_SECRET = "shared-secret-entropy-abcdef-padded32";
     const c = commitment({ keyId: "k1" });
     const v2sig = signProviderExecutionCommitmentV2(c);
     // Re-derive a v1-style HMAC by hand would require the v1 key; instead assert

--- a/packages/api/src/__tests__/execution-authorization-v2-crypto.test.ts
+++ b/packages/api/src/__tests__/execution-authorization-v2-crypto.test.ts
@@ -102,7 +102,7 @@ describe("provider execution authorization v2 crypto", () => {
 
   it("keyId rotation: first key signs, all listed keys verify", () => {
     process.env.STEWARD_EXECUTION_AUTH_SECRET =
-      "k2:new-secret-entropy-abcdef,k1:old-secret-entropy-abcdef";
+      "k2:new-secret-entropy-abcdef-padded32,k1:old-secret-entropy-abcdef-padded32";
     // Active key is k2 (first).
     expect(activeExecutionAuthV2Key().keyId).toBe("k2");
     const c2 = commitment({ keyId: "k2" });
@@ -111,11 +111,11 @@ describe("provider execution authorization v2 crypto", () => {
     // A commitment minted under the retired k1 still verifies (TTL window).
     // Rebuild the key set with k1 active to produce a k1 signature, then verify
     // it under the rotation list where k1 is second.
-    process.env.STEWARD_EXECUTION_AUTH_SECRET = "k1:old-secret-entropy-abcdef";
+    process.env.STEWARD_EXECUTION_AUTH_SECRET = "k1:old-secret-entropy-abcdef-padded32";
     const c1 = commitment({ keyId: "k1" });
     const sig1 = signProviderExecutionCommitmentV2(c1);
     process.env.STEWARD_EXECUTION_AUTH_SECRET =
-      "k2:new-secret-entropy-abcdef,k1:old-secret-entropy-abcdef";
+      "k2:new-secret-entropy-abcdef-padded32,k1:old-secret-entropy-abcdef-padded32";
     expect(verifyProviderExecutionCommitmentV2(c1, sig1)).toBe(true);
   });
 

--- a/packages/db/drizzle/0090_provider_action_approval_evidence_write_once.sql
+++ b/packages/db/drizzle/0090_provider_action_approval_evidence_write_once.sql
@@ -1,0 +1,107 @@
+-- SEC-031: approval evidence on provider_action_bindings is write-once.
+--
+-- The binding guard's `mutable` list includes the approval evidence columns
+-- (approval_actor_user_id, approval_queue_id, approval_commitment_hash,
+-- approved_at) but previously imposed no write-once rule on them (contrast the
+-- execution_policy_* gate added in 0084). A same-status UPDATE could therefore
+-- rewrite WHO approved an action and WHAT request was approved, post-hoc, and
+-- the app-level HMAC audit chain never sees direct DB writes.
+--
+-- Approval evidence may now only transition NULL -> value, and only during the
+-- initial decision transitions out of pending_approval (approved carries the
+-- actor + timestamp; approval_denied carries the deciding actor). After the
+-- decision lands, the evidence is frozen across every later transition —
+-- expire/stale deliberately preserve it (see provider-approval.ts).
+
+CREATE OR REPLACE FUNCTION steward_provider_action_binding_guard() RETURNS trigger LANGUAGE plpgsql AS $fn$
+DECLARE
+  frozen_old jsonb;
+  frozen_new jsonb;
+  mutable text[] := ARRAY[
+    'status','binding_revision','approval_actor_user_id','approval_queue_id',
+    'approval_commitment_hash','approved_at','denied_at','expired_at','stale_at',
+    'stale_reason_code','resume_actor','resume_attempt_id','resume_validated_at','updated_at',
+    'execution_policy_decision_id','execution_policy_revision_hash','execution_policy_decision',
+    'execution_policy_decision_hash','execution_policy_evaluated_at'
+  ];
+  col text;
+  execution_policy_changed boolean;
+  approval_evidence_changed boolean;
+BEGIN
+  frozen_old := to_jsonb(OLD);
+  frozen_new := to_jsonb(NEW);
+  FOREACH col IN ARRAY mutable LOOP
+    frozen_old := frozen_old - col;
+    frozen_new := frozen_new - col;
+  END LOOP;
+  IF frozen_old IS DISTINCT FROM frozen_new THEN
+    RAISE EXCEPTION 'provider_action_bindings frozen column mutated' USING ERRCODE = '23514';
+  END IF;
+
+  execution_policy_changed :=
+    OLD.execution_policy_decision_id IS DISTINCT FROM NEW.execution_policy_decision_id OR
+    OLD.execution_policy_revision_hash IS DISTINCT FROM NEW.execution_policy_revision_hash OR
+    OLD.execution_policy_decision IS DISTINCT FROM NEW.execution_policy_decision OR
+    OLD.execution_policy_decision_hash IS DISTINCT FROM NEW.execution_policy_decision_hash OR
+    OLD.execution_policy_evaluated_at IS DISTINCT FROM NEW.execution_policy_evaluated_at;
+  IF execution_policy_changed AND NOT (
+    OLD.status = 'approved' AND NEW.status = 'execution_ready' AND
+    OLD.execution_policy_decision_id IS NULL AND
+    NEW.execution_policy_decision_id IS NOT NULL AND
+    NEW.execution_policy_revision_hash IS NOT NULL AND
+    NEW.execution_policy_decision IS NOT NULL AND
+    NEW.execution_policy_decision_hash IS NOT NULL AND
+    NEW.execution_policy_evaluated_at IS NOT NULL
+  ) THEN
+    RAISE EXCEPTION 'illegal provider execution policy mutation' USING ERRCODE = '23514';
+  END IF;
+
+  -- Approval evidence is write-once: each changed column may only transition
+  -- NULL -> value, and only during the pending_approval decision transitions
+  -- (approved records actor + approved_at; approval_denied records the actor).
+  -- Same-status or post-decision rewrites of who/what was approved are rejected.
+  approval_evidence_changed :=
+    OLD.approval_actor_user_id IS DISTINCT FROM NEW.approval_actor_user_id OR
+    OLD.approval_queue_id IS DISTINCT FROM NEW.approval_queue_id OR
+    OLD.approval_commitment_hash IS DISTINCT FROM NEW.approval_commitment_hash OR
+    OLD.approved_at IS DISTINCT FROM NEW.approved_at;
+  IF approval_evidence_changed AND NOT (
+    OLD.status = 'pending_approval' AND NEW.status IN ('approved','approval_denied') AND
+    (OLD.approval_actor_user_id IS NOT DISTINCT FROM NEW.approval_actor_user_id OR
+      (OLD.approval_actor_user_id IS NULL AND NEW.approval_actor_user_id IS NOT NULL)) AND
+    (OLD.approval_queue_id IS NOT DISTINCT FROM NEW.approval_queue_id OR
+      (OLD.approval_queue_id IS NULL AND NEW.approval_queue_id IS NOT NULL)) AND
+    (OLD.approval_commitment_hash IS NOT DISTINCT FROM NEW.approval_commitment_hash OR
+      (OLD.approval_commitment_hash IS NULL AND NEW.approval_commitment_hash IS NOT NULL)) AND
+    (OLD.approved_at IS NOT DISTINCT FROM NEW.approved_at OR
+      (OLD.approved_at IS NULL AND NEW.approved_at IS NOT NULL))
+  ) THEN
+    RAISE EXCEPTION 'illegal provider approval evidence mutation' USING ERRCODE = '23514';
+  END IF;
+
+  IF OLD.status IS DISTINCT FROM NEW.status THEN
+    IF OLD.status = 'allowed_stub' AND NEW.status IN ('stub_succeeded','stub_failed') THEN
+      IF NEW.binding_revision IS DISTINCT FROM OLD.binding_revision THEN
+        RAISE EXCEPTION 'provider_action_bindings stub transition must not change binding_revision'
+          USING ERRCODE = '23514';
+      END IF;
+    ELSIF (
+      (OLD.status = 'pending_approval' AND NEW.status IN ('approved','approval_denied','approval_expired','approval_stale')) OR
+      (OLD.status = 'approved' AND NEW.status IN ('execution_ready','approval_expired','approval_stale')) OR
+      (OLD.status = 'execution_ready' AND NEW.status IN ('executing','failed')) OR
+      (OLD.status = 'executing' AND NEW.status IN ('succeeded','failed','outcome_unknown')) OR
+      (OLD.status = 'outcome_unknown' AND NEW.status IN ('succeeded','failed'))
+    ) THEN
+      IF NEW.binding_revision IS DISTINCT FROM OLD.binding_revision + 1 THEN
+        RAISE EXCEPTION 'provider_action_bindings binding_revision must increment by exactly one on transition'
+          USING ERRCODE = '23514';
+      END IF;
+    ELSE
+      RAISE EXCEPTION 'illegal provider_action_bindings status transition' USING ERRCODE = '23514';
+    END IF;
+  ELSIF NEW.binding_revision IS DISTINCT FROM OLD.binding_revision THEN
+    RAISE EXCEPTION 'provider_action_bindings binding_revision changed without a status transition'
+      USING ERRCODE = '23514';
+  END IF;
+  RETURN NEW;
+END $fn$;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -491,6 +491,13 @@
       "when": 1784832000000,
       "tag": "0089_rfc3161_checkpoint_proofs",
       "breakpoints": true
+    },
+    {
+      "idx": 90,
+      "version": "7",
+      "when": 1784918400000,
+      "tag": "0090_provider_action_approval_evidence_write_once",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/__tests__/approval-evidence-write-once-migration.test.ts
+++ b/packages/db/src/__tests__/approval-evidence-write-once-migration.test.ts
@@ -1,0 +1,219 @@
+/**
+ * SEC-031 regression tests for 0090_provider_action_approval_evidence_write_once.
+ *
+ * The binding guard's `mutable` list includes the approval evidence columns
+ * (approval_actor_user_id, approval_queue_id, approval_commitment_hash,
+ * approved_at); before 0090 a same-status UPDATE could rewrite who approved an
+ * action and what request was approved, post-hoc, without the app-level audit
+ * chain ever seeing it. Approval evidence is now write-once: NULL -> value
+ * only, and only on the pending_approval decision transitions.
+ */
+
+import { describe, expect, setDefaultTimeout, test } from "bun:test";
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { PGlite } from "@electric-sql/pglite";
+
+setDefaultTimeout(120_000);
+const migrations = new URL("../../drizzle", import.meta.url).pathname;
+
+async function applyFile(client: PGlite, file: string) {
+  const sql = await readFile(join(migrations, file), "utf8");
+  for (const statement of sql.split("--> statement-breakpoint")) {
+    if (statement.trim()) await client.exec(statement);
+  }
+}
+
+async function applyAll(client: PGlite) {
+  const files = (await readdir(migrations)).filter((f) => f.endsWith(".sql")).sort();
+  for (const file of files) await applyFile(client, file);
+}
+
+const IDS = {
+  wsA: "00000000-0000-4000-8000-000000000101",
+  acctA: "00000000-0000-4000-8000-000000000201",
+  opA: "00000000-0000-4000-8000-000000000301",
+  owner: "00000000-0000-4000-8000-000000000001",
+  accessDecision: "00000000-0000-4000-8000-000000000401",
+  policyDecision: "00000000-0000-4000-8000-000000000402",
+  queue: "00000000-0000-4000-8000-000000000501",
+};
+
+const DIGEST = "sha256:effa84639ed9c9b0b2c01b65bd716342a25a846d9209818b194ab3d151276f3a";
+const REQHASH = "sha256:8c0d3d5761ad6ad8ea017d3d36bd57157a7d2f5767acce8ede417d4556b377e3";
+const IDEMHASH = "sha256:36c27d7668cf64a4354635a421f14d74410e9cd54bf1002bffa82421145c7a57";
+const ACCESSHASH = "sha256:1111111111111111111111111111111111111111111111111111111111111111";
+const COMMITMENT = "sha256:2222222222222222222222222222222222222222222222222222222222222222";
+const REWRITTEN_COMMITMENT =
+  "sha256:3333333333333333333333333333333333333333333333333333333333333333";
+
+async function seed(client: PGlite) {
+  // PGlite's multi-statement exec mis-parses mixed batches once the
+  // dollar-quoted trigger function is installed; run each statement alone.
+  const stmts = [
+    `INSERT INTO tenants(id,name,api_key_hash) VALUES ('ta','A','ha')`,
+    `INSERT INTO users(id,email,created_at,updated_at) VALUES ('${IDS.owner}','owner@example.test',now(),now())`,
+    `INSERT INTO agents(id,tenant_id,name,wallet_address) VALUES ('agent-a','ta','A','0xa')`,
+    `INSERT INTO workspaces(id,tenant_id,key,name,environment,created_by) VALUES ('${IDS.wsA}','ta','client-a','Client A','production','${IDS.owner}')`,
+    `INSERT INTO provider_accounts(id,tenant_id,workspace_id,adapter_key,external_ref,display_name) VALUES ('${IDS.acctA}','ta','${IDS.wsA}','github','a','A')`,
+    `INSERT INTO provider_operations(id,tenant_id,workspace_id,provider_account_id,operation_key,risk_class) VALUES ('${IDS.opA}','ta','${IDS.wsA}','${IDS.acctA}','github.issue.list','read')`,
+    `INSERT INTO intents(id,tenant_id,agent_id,intent_type,status) VALUES ('intent-1','ta','agent-a','provider.action','pending')`,
+  ];
+  for (const s of stmts) await client.exec(`${s};`);
+}
+
+/** Insert an approval_required binding in pending_approval (revision 1). */
+async function insertPendingApprovalBinding(client: PGlite) {
+  await client.exec(`
+    INSERT INTO provider_action_bindings(
+      intent_id, tenant_id, workspace_id, actor_agent_id, provider_account_id,
+      operation_id, operation_revision, canonical_profile, canonical_action_bytes,
+      action_digest, request_envelope, request_hash, idempotency_key_hash, safe_summary,
+      access_decision_id, access_effect, access_reason_code, dependency_revisions,
+      access_decision, access_decision_hash,
+      policy_decision_id, policy_effect, policy_revision_hash, policy_decision, policy_decision_hash,
+      status, binding_revision, approval_queue_id, approval_commitment_hash
+    ) VALUES (
+      'intent-1','ta','${IDS.wsA}','agent-a','${IDS.acctA}',
+      '${IDS.opA}',7,'github.provider-action.v1', decode('7b7d','hex'),
+      '${DIGEST}','{}'::jsonb,'${REQHASH}','${IDEMHASH}','{}'::jsonb,
+      '${IDS.accessDecision}','allow','provider_access_allowed','{}'::jsonb,
+      '{}'::jsonb,'${ACCESSHASH}',
+      '${IDS.policyDecision}','approval_required','${ACCESSHASH}','{}'::jsonb,'${ACCESSHASH}',
+      'pending_approval',1,'${IDS.queue}','${COMMITMENT}'
+    );
+  `);
+}
+
+async function approveBinding(client: PGlite) {
+  await client.exec(`
+    UPDATE provider_action_bindings
+    SET status='approved', binding_revision=2,
+        approval_actor_user_id='${IDS.owner}', approved_at=now(), updated_at=now()
+    WHERE intent_id='intent-1'
+  `);
+}
+
+async function freshApprovedClient(): Promise<PGlite> {
+  const client = new PGlite("memory://");
+  await applyAll(client);
+  await seed(client);
+  await insertPendingApprovalBinding(client);
+  await approveBinding(client);
+  return client;
+}
+
+describe("0090 approval evidence write-once guard (SEC-031)", () => {
+  test("legit approve: pending_approval -> approved may populate actor + approved_at", async () => {
+    const client = new PGlite("memory://");
+    await applyAll(client);
+    await seed(client);
+    await insertPendingApprovalBinding(client);
+    await approveBinding(client);
+    const rows = await client.query<{
+      status: string;
+      approval_actor_user_id: string;
+      approved_at: Date | null;
+    }>(
+      `SELECT status, approval_actor_user_id, approved_at FROM provider_action_bindings WHERE intent_id='intent-1'`,
+    );
+    expect(rows.rows[0].status).toBe("approved");
+    expect(rows.rows[0].approval_actor_user_id).toBe(IDS.owner);
+    expect(rows.rows[0].approved_at).not.toBeNull();
+    await client.close();
+  });
+
+  test("legit deny: pending_approval -> approval_denied may record the deciding actor", async () => {
+    const client = new PGlite("memory://");
+    await applyAll(client);
+    await seed(client);
+    await insertPendingApprovalBinding(client);
+    await client.exec(`
+      UPDATE provider_action_bindings
+      SET status='approval_denied', binding_revision=2,
+          approval_actor_user_id='${IDS.owner}', denied_at=now(), updated_at=now()
+      WHERE intent_id='intent-1'
+    `);
+    const rows = await client.query<{ status: string; approval_actor_user_id: string }>(
+      `SELECT status, approval_actor_user_id FROM provider_action_bindings WHERE intent_id='intent-1'`,
+    );
+    expect(rows.rows[0].status).toBe("approval_denied");
+    expect(rows.rows[0].approval_actor_user_id).toBe(IDS.owner);
+    await client.close();
+  });
+
+  test("same-status rewrite of approval_actor_user_id is rejected", async () => {
+    const client = await freshApprovedClient();
+    await expect(
+      client.exec(`
+        UPDATE provider_action_bindings
+        SET approval_actor_user_id='00000000-0000-4000-8000-000000000666', updated_at=now()
+        WHERE intent_id='intent-1'
+      `),
+    ).rejects.toThrow(/approval evidence/);
+    await client.close();
+  });
+
+  test("post-hoc rewrite of approval_commitment_hash is rejected", async () => {
+    const client = await freshApprovedClient();
+    await expect(
+      client.exec(`
+        UPDATE provider_action_bindings
+        SET approval_commitment_hash='${REWRITTEN_COMMITMENT}', updated_at=now()
+        WHERE intent_id='intent-1'
+      `),
+    ).rejects.toThrow(/approval evidence/);
+    await client.close();
+  });
+
+  test("rewrite during a later transition (approved -> approval_expired) is rejected", async () => {
+    const client = await freshApprovedClient();
+    await expect(
+      client.exec(`
+        UPDATE provider_action_bindings
+        SET status='approval_expired', binding_revision=3, expired_at=now(),
+            approval_actor_user_id='00000000-0000-4000-8000-000000000666', updated_at=now()
+        WHERE intent_id='intent-1'
+      `),
+    ).rejects.toThrow(/approval evidence/);
+    await client.close();
+  });
+
+  test("later transitions succeed while evidence is carried unchanged", async () => {
+    const client = await freshApprovedClient();
+    await client.exec(`
+      UPDATE provider_action_bindings
+      SET status='approval_expired', binding_revision=3, expired_at=now(), updated_at=now()
+      WHERE intent_id='intent-1'
+    `);
+    const rows = await client.query<{ status: string; approval_actor_user_id: string }>(
+      `SELECT status, approval_actor_user_id FROM provider_action_bindings WHERE intent_id='intent-1'`,
+    );
+    expect(rows.rows[0].status).toBe("approval_expired");
+    expect(rows.rows[0].approval_actor_user_id).toBe(IDS.owner);
+    await client.close();
+  });
+
+  test("execution-policy evidence gate still permits approved -> execution_ready", async () => {
+    const client = await freshApprovedClient();
+    await client.exec(`
+      UPDATE provider_action_bindings
+      SET status='execution_ready', binding_revision=3,
+          resume_actor='steward-system',
+          resume_attempt_id='00000000-0000-4000-8000-000000000502',
+          resume_validated_at=now(),
+          execution_policy_decision_id='00000000-0000-4000-8000-000000000503',
+          execution_policy_revision_hash='${ACCESSHASH}',
+          execution_policy_decision='{}'::jsonb,
+          execution_policy_decision_hash='${ACCESSHASH}',
+          execution_policy_evaluated_at=now(),
+          updated_at=now()
+      WHERE intent_id='intent-1'
+    `);
+    const rows = await client.query<{ status: string }>(
+      `SELECT status FROM provider_action_bindings WHERE intent_id='intent-1'`,
+    );
+    expect(rows.rows[0].status).toBe("execution_ready");
+    await client.close();
+  });
+});

--- a/packages/db/src/__tests__/legacy-backfill.test.ts
+++ b/packages/db/src/__tests__/legacy-backfill.test.ts
@@ -1,0 +1,67 @@
+/**
+ * SEC-030 regression tests. The legacy-DB backfill must seed only the journal
+ * entries the psql-era deploy loop provably applied (through 0024), not the
+ * entire current journal — otherwise constraint-only hardening migrations
+ * (e.g. 0046/0047 cross-tenant FKs and CHECK constraints) are silently skipped
+ * on legacy DBs while the app appears healthy.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import {
+  LEGACY_BACKFILL_FINGERPRINT_TABLE,
+  LEGACY_BACKFILL_TIP_TAG,
+  selectLegacyBackfillEntries,
+} from "../migrate";
+
+interface JournalEntry {
+  idx: number;
+  tag: string;
+  when: number;
+}
+
+function readJournal(): { entries: JournalEntry[] } {
+  return JSON.parse(
+    readFileSync(new URL("../../drizzle/meta/_journal.json", import.meta.url), "utf8"),
+  ) as { entries: JournalEntry[] };
+}
+
+describe("legacy DB backfill (SEC-030)", () => {
+  test("seeds only entries through the psql-era tip, never the whole journal", () => {
+    const journal = readJournal();
+    const seeded = selectLegacyBackfillEntries(journal);
+
+    // The backfill must stop at the psql-era tip...
+    expect(seeded.at(-1)?.tag).toBe(LEGACY_BACKFILL_TIP_TAG);
+    expect(seeded.length).toBeLessThan(journal.entries.length);
+
+    // ...and must never seed hardening migrations that landed after the psql
+    // loop was retired — those must be APPLIED by the migrator so their
+    // constraints actually exist.
+    const seededTags = new Set(seeded.map((entry) => entry.tag));
+    expect(seededTags.has("0046_pr79_cross_tenant_fks")).toBe(false);
+    expect(seededTags.has("0047_pr79_security_invariants")).toBe(false);
+    for (const entry of journal.entries) {
+      if (entry.tag > LEGACY_BACKFILL_TIP_TAG) {
+        expect(seededTags.has(entry.tag)).toBe(false);
+      }
+    }
+  });
+
+  test("fingerprints the psql-era tip table, not the 0000-era tenants table", () => {
+    // `tenants` exists on every legacy DB regardless of how far the psql loop
+    // got; the fingerprint must name the newest backfill-era object instead.
+    expect(LEGACY_BACKFILL_FINGERPRINT_TABLE).toBe("public.audit_events");
+    expect(LEGACY_BACKFILL_FINGERPRINT_TABLE).not.toBe("public.tenants");
+  });
+
+  test("refuses to seed when the backfill-era tip is missing from the journal", () => {
+    const truncated = {
+      entries: [
+        { idx: 0, tag: "0000_black_klaw", when: 1 },
+        { idx: 1, tag: "0001_multi_wallet", when: 2 },
+      ],
+    };
+    expect(() => selectLegacyBackfillEntries(truncated)).toThrow(/backfill-era tip/i);
+  });
+});

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -21,6 +21,36 @@ interface Journal {
   entries: JournalEntry[];
 }
 
+/**
+ * The legacy `psql -f` deploy loop was retired when this migrator was
+ * introduced; the journal tip at that moment was 0024_audit_events. A legacy
+ * DB is therefore only provably migrated through that tag — entries past it
+ * must be APPLIED by the migrator, never seeded.
+ */
+export const LEGACY_BACKFILL_TIP_TAG = "0024_audit_events";
+
+/**
+ * Fingerprint proving a legacy DB actually reached the psql-era tip: the
+ * newest table 0024 created. `public.tenants` (0000) alone says nothing about
+ * how far the psql loop got before the DB was frozen.
+ */
+export const LEGACY_BACKFILL_FINGERPRINT_TABLE = "public.audit_events";
+
+/**
+ * Select the journal entries a legacy DB may be seeded with: everything up to
+ * and including the psql-era tip. Throws if the tip is absent from the
+ * journal (should never happen — it is a historical entry).
+ */
+export function selectLegacyBackfillEntries(journal: Journal): JournalEntry[] {
+  const tipIndex = journal.entries.findIndex((entry) => entry.tag === LEGACY_BACKFILL_TIP_TAG);
+  if (tipIndex === -1) {
+    throw new Error(
+      `[migrate] Backfill-era tip ${LEGACY_BACKFILL_TIP_TAG} is missing from the migration journal; refusing to seed a legacy DB`,
+    );
+  }
+  return journal.entries.slice(0, tipIndex + 1);
+}
+
 function readJournal(): Journal {
   const path = `${MIGRATIONS_FOLDER}/meta/_journal.json`;
   return JSON.parse(readFileSync(path, "utf-8")) as Journal;
@@ -42,7 +72,11 @@ function hashMigration(tag: string): string {
  * used to `psql -f` each .sql by hand), we backfill `drizzle.__drizzle_migrations`
  * from the journal so the migrator doesn't try to re-apply non-idempotent DDL.
  * Heuristic: if `__drizzle_migrations` is empty AND `tenants` exists (was
- * created by 0000), assume all journal entries are already applied.
+ * created by 0000), the DB came from the psql loop. We then FINGERPRINT the
+ * psql-era tip (`LEGACY_BACKFILL_FINGERPRINT_TABLE`, created by 0024) and seed
+ * only the entries through that tip — seeding the whole current journal would
+ * silently skip every migration between the DB's true tip and now, including
+ * constraint-only hardening migrations whose absence produces no runtime error.
  */
 export async function runMigrations(): Promise<{ applied: string[] }> {
   const { client, db } = createDb();
@@ -75,10 +109,28 @@ export async function runMigrations(): Promise<{ applied: string[] }> {
 
       // Backfill: legacy DB previously migrated by the psql loop.
       if (existingRows.length === 0 && tenantsExists[0]?.r) {
+        // Fingerprint the psql-era tip before trusting the heuristic: a DB
+        // frozen at an older tip must fail loudly here, not be seeded with
+        // migrations it never applied.
+        const fingerprint = (await client`
+          SELECT to_regclass(${LEGACY_BACKFILL_FINGERPRINT_TABLE}) AS r
+        `) as Array<{ r: string | null }>;
+        if (!fingerprint[0]?.r) {
+          throw new Error(
+            `[migrate] Legacy DB detected (public.tenants exists) but fingerprint table ` +
+              `${LEGACY_BACKFILL_FINGERPRINT_TABLE} is missing — the DB predates migration ` +
+              `${LEGACY_BACKFILL_TIP_TAG}. Refusing to seed __drizzle_migrations: entries past ` +
+              `the DB's true tip would be silently skipped (including security-hardening ` +
+              `migrations). Reconcile the schema manually, then re-run migrations.`,
+          );
+        }
+        const backfillEntries = selectLegacyBackfillEntries(journal);
         console.log(
-          `[migrate] Legacy DB detected — seeding __drizzle_migrations with ${journal.entries.length} historical entries`,
+          `[migrate] Legacy DB detected — seeding __drizzle_migrations with ${backfillEntries.length} ` +
+            `entries through ${LEGACY_BACKFILL_TIP_TAG}; the migrator will apply the remaining ` +
+            `${journal.entries.length - backfillEntries.length} journal entrie(s) normally`,
         );
-        for (const entry of journal.entries) {
+        for (const entry of backfillEntries) {
           const hash = hashMigration(entry.tag);
           await client`
             INSERT INTO drizzle.__drizzle_migrations ("hash", "created_at")

--- a/packages/redis/src/__tests__/client-tls.test.ts
+++ b/packages/redis/src/__tests__/client-tls.test.ts
@@ -1,0 +1,66 @@
+/**
+ * SEC-032 regression tests. Redis carries spend-limit state, rate-limit state,
+ * policy cache, and auth KV (SIWE nonces); in production the client must
+ * refuse cleartext redis:// transport unless the operator explicitly opts out,
+ * matching the assertDatabaseUrlTls() posture in @stwd/db.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { assertRedisUrlTls } from "../client";
+
+const originalNodeEnv = process.env.NODE_ENV;
+const originalOverride = process.env.STEWARD_ALLOW_INSECURE_REDIS;
+
+afterEach(() => {
+  if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+  else process.env.NODE_ENV = originalNodeEnv;
+  if (originalOverride === undefined) delete process.env.STEWARD_ALLOW_INSECURE_REDIS;
+  else process.env.STEWARD_ALLOW_INSECURE_REDIS = originalOverride;
+});
+
+describe("redis transport security (SEC-032)", () => {
+  test("rejects cleartext redis:// to a remote host in production", () => {
+    process.env.NODE_ENV = "production";
+    delete process.env.STEWARD_ALLOW_INSECURE_REDIS;
+    expect(() => assertRedisUrlTls("redis://redis.example.internal:6379")).toThrow("rediss://");
+    expect(() => assertRedisUrlTls("redis://:secret@10.0.0.5:6379/0")).toThrow("rediss://");
+  });
+
+  test("accepts rediss:// in production", () => {
+    process.env.NODE_ENV = "production";
+    delete process.env.STEWARD_ALLOW_INSECURE_REDIS;
+    expect(() => assertRedisUrlTls("rediss://:secret@redis.example.internal:6380")).not.toThrow();
+  });
+
+  test("exempts localhost cleartext even in production", () => {
+    process.env.NODE_ENV = "production";
+    delete process.env.STEWARD_ALLOW_INSECURE_REDIS;
+    expect(() => assertRedisUrlTls("redis://localhost:6379")).not.toThrow();
+    expect(() => assertRedisUrlTls("redis://127.0.0.1:6379")).not.toThrow();
+    expect(() => assertRedisUrlTls("redis://[::1]:6379")).not.toThrow();
+  });
+
+  test("honors the explicit insecure override with a warning", () => {
+    process.env.NODE_ENV = "production";
+    process.env.STEWARD_ALLOW_INSECURE_REDIS = "true";
+    expect(() => assertRedisUrlTls("redis://redis.example.internal:6379")).not.toThrow();
+  });
+
+  test("fails closed when a production URL cannot be parsed", () => {
+    process.env.NODE_ENV = "production";
+    delete process.env.STEWARD_ALLOW_INSECURE_REDIS;
+    expect(() => assertRedisUrlTls("not a url")).toThrow("valid URL");
+  });
+
+  test("rejects non-redis schemes", () => {
+    process.env.NODE_ENV = "production";
+    delete process.env.STEWARD_ALLOW_INSECURE_REDIS;
+    expect(() => assertRedisUrlTls("http://redis.example.internal:6379")).toThrow("scheme");
+  });
+
+  test("does not restrict non-production environments", () => {
+    process.env.NODE_ENV = "development";
+    delete process.env.STEWARD_ALLOW_INSECURE_REDIS;
+    expect(() => assertRedisUrlTls("redis://redis.example.internal:6379")).not.toThrow();
+  });
+});

--- a/packages/redis/src/client.ts
+++ b/packages/redis/src/client.ts
@@ -13,7 +13,9 @@
  *                            auth `RedisLike` consumer rely on.
  *
  * Reading the connection URL:
- *   - ioredis : REDIS_URL (default redis://localhost:6379)
+ *   - ioredis : REDIS_URL (default redis://localhost:6379). In production the
+ *               URL must use rediss:// (TLS) unless it points at localhost or
+ *               STEWARD_ALLOW_INSECURE_REDIS=true is set (assertRedisUrlTls).
  *   - upstash : KV_REST_API_URL + KV_REST_API_TOKEN
  *               (or UPSTASH_REDIS_REST_URL / UPSTASH_REDIS_REST_TOKEN)
  */
@@ -27,6 +29,55 @@ export type RedisDriver = "ioredis" | "upstash";
 let instance: IoredisLike | null = null;
 let shutdownRegistered = false;
 
+/**
+ * Refuse to start in production if REDIS_URL is not using TLS (rediss://).
+ * Redis carries spend-limit state, rate-limit state, policy cache, and auth KV
+ * (SIWE nonces), so a cleartext link lets a network-positioned attacker read
+ * and tamper with enforcement data. Localhost connections are exempt. Set
+ * STEWARD_ALLOW_INSECURE_REDIS=true to override for private-network
+ * deployments (logs a loud warning), matching the STEWARD_ALLOW_INSECURE_DB
+ * posture in @stwd/db.
+ */
+export function assertRedisUrlTls(url: string): void {
+  if (process.env.NODE_ENV !== "production") return;
+
+  const allowInsecure = process.env.STEWARD_ALLOW_INSECURE_REDIS === "true";
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    if (allowInsecure) {
+      console.warn(
+        "[steward:redis] WARNING: STEWARD_ALLOW_INSECURE_REDIS=true — REDIS_URL is not a valid URL, so TLS cannot be verified.",
+      );
+      return;
+    }
+    throw new Error("REDIS_URL must be a valid URL so TLS settings can be verified in production");
+  }
+
+  if (parsed.protocol === "rediss:") return;
+  if (parsed.protocol !== "redis:") {
+    throw new Error("REDIS_URL must use the redis:// or rediss:// scheme");
+  }
+
+  const host = parsed.hostname.toLowerCase();
+  // URL.hostname keeps the brackets on IPv6 literals ([::1]).
+  if (host === "localhost" || host === "127.0.0.1" || host === "::1" || host === "[::1]") return;
+
+  if (allowInsecure) {
+    console.warn(
+      "[steward:redis] WARNING: STEWARD_ALLOW_INSECURE_REDIS=true — REDIS_URL is cleartext redis://. " +
+        "This is only safe on a private network. SOC2 CC6.7 requires encryption in transit.",
+    );
+    return;
+  }
+
+  throw new Error(
+    "REDIS_URL must use rediss:// (TLS) in production. " +
+      "Set STEWARD_ALLOW_INSECURE_REDIS=true to override for private-network deployments.",
+  );
+}
+
 export function getRedisDriver(): RedisDriver {
   const raw = process.env.REDIS_DRIVER?.trim().toLowerCase();
   if (raw === "upstash") return "upstash";
@@ -35,6 +86,7 @@ export function getRedisDriver(): RedisDriver {
 
 function buildIoredis(): Redis {
   const url = process.env.REDIS_URL || "redis://localhost:6379";
+  assertRedisUrlTls(url);
   const client = new Redis(url, {
     maxRetriesPerRequest: 3,
     retryStrategy(times: number) {

--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -9,6 +9,7 @@ export {
   recordAggregationEvent,
 } from "./aggregation-tracker.js";
 export {
+  assertRedisUrlTls,
   disconnectRedis,
   getRedis,
   getRedisDriver,

--- a/packages/shared/src/__tests__/chains.test.ts
+++ b/packages/shared/src/__tests__/chains.test.ts
@@ -294,6 +294,13 @@ describe("chainFromCaip2", () => {
     expect(chainFromCaip2("eip155:123456789")).toBeUndefined();
   });
 
+  it("does not treat Object.prototype members as chains (SEC-116)", () => {
+    expect(chainFromCaip2("constructor")).toBeUndefined();
+    expect(fromCaip2("constructor")).toBeUndefined();
+    expect(getChainProviderByCaip2("constructor")).toBeUndefined();
+    expect(chainFromCaip2("toString")).toBeUndefined();
+  });
+
   it("finds Solana devnet by CAIP-2", () => {
     const chain = chainFromCaip2("solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1");
     expect(chain).toBeDefined();

--- a/packages/shared/src/__tests__/execution-payload.test.ts
+++ b/packages/shared/src/__tests__/execution-payload.test.ts
@@ -1,0 +1,44 @@
+/**
+ * SEC-115 / SEC-193 regression tests for execution-payload helpers.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { canonicalJsonStringify, isEvmChainId } from "../execution-payload";
+
+describe("canonicalJsonStringify", () => {
+  it("sorts keys and stringifies bigints", () => {
+    expect(canonicalJsonStringify({ b: 1n, a: "x" })).toBe('{"a":"x","b":"1"}');
+  });
+
+  it("does not drop own __proto__ keys (SEC-115)", () => {
+    // JSON.parse creates an OWN `__proto__` member; building the canonical
+    // output via plain `{}` assignment would silently drop it, making two
+    // snapshots that differ only in that member digest identically.
+    const withProto = JSON.parse('{"__proto__":{"polluted":true},"a":1}') as Record<
+      string,
+      unknown
+    >;
+    const withoutProto = { a: 1 };
+    const canonical = canonicalJsonStringify(withProto);
+    expect(canonical).toContain('"__proto__"');
+    expect(canonical).not.toBe(canonicalJsonStringify(withoutProto));
+  });
+});
+
+describe("isEvmChainId (SEC-193)", () => {
+  it("returns true for registered EVM chains", () => {
+    expect(isEvmChainId(1)).toBe(true);
+    expect(isEvmChainId(8453)).toBe(true);
+    expect(isEvmChainId(137)).toBe(true);
+  });
+
+  it("returns false for non-EVM families and unknown ids (fail closed)", () => {
+    expect(isEvmChainId(101)).toBe(false); // Solana
+    expect(isEvmChainId(102)).toBe(false); // Solana devnet
+    expect(isEvmChainId(201)).toBe(false); // Bitcoin
+    expect(isEvmChainId(202)).toBe(false); // Bitcoin testnet
+    expect(isEvmChainId(301)).toBe(false); // Monero
+    expect(isEvmChainId(302)).toBe(false); // Monero stagenet
+    expect(isEvmChainId(999_999)).toBe(false); // unknown
+  });
+});

--- a/packages/shared/src/__tests__/price-oracle.test.ts
+++ b/packages/shared/src/__tests__/price-oracle.test.ts
@@ -50,4 +50,77 @@ describe("price oracle", () => {
       oracle.getTokenUsdPrice(8453, "0x1111111111111111111111111111111111111111"),
     ).resolves.toBeNull();
   });
+
+  it("rejects malformed token addresses without fetching (SEC-118)", async () => {
+    let fetchCalls = 0;
+    globalThis.fetch = (async () => {
+      fetchCalls++;
+      return new Response(JSON.stringify({ pairs: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const oracle = createPriceOracle({ cacheTtlMs: 60_000 });
+
+    // Path/query injection attempts must never reach the URL.
+    await expect(oracle.getTokenUsdPrice(8453, "../admin?x=1")).resolves.toBeNull();
+    await expect(oracle.getTokenUsdPrice(8453, "0x1111#frag")).resolves.toBeNull();
+    // Wrong family: a base58-looking mint on an EVM chain.
+    await expect(
+      oracle.getTokenUsdPrice(8453, "So11111111111111111111111111111111111111112"),
+    ).resolves.toBeNull();
+    expect(fetchCalls).toBe(0);
+  });
+
+  it("usdToWei is exact beyond 2^53 and rounds to nearest (SEC-189)", async () => {
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          pairs: [{ chainId: "base", priceUsd: "50", liquidity: { usd: 100 } }],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      )) as typeof fetch;
+
+    const oracle = createPriceOracle({ cacheTtlMs: 0 });
+
+    // 100 USD at $50 = exactly 2e18 wei.
+    await expect(oracle.usdToWei(100, 8453)).resolves.toBe("2000000000000000000");
+    // 1 USD at $3 = 1e18/3 wei. The old double math (`tokenAmount * 10 ** 18`)
+    // collapses to 333333333333333312 (double rounding); exact rational math
+    // rounds to nearest: 333333333333333333.
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          pairs: [{ chainId: "base", priceUsd: "3", liquidity: { usd: 100 } }],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      )) as typeof fetch;
+    await expect(createPriceOracle({ cacheTtlMs: 0 }).usdToWei(1, 8453)).resolves.toBe(
+      "333333333333333333",
+    );
+  });
+
+  it("fails closed for unknown chains/tokens instead of assuming 18 decimals (SEC-190)", async () => {
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          pairs: [{ chainId: "base", priceUsd: "50", liquidity: { usd: 100 } }],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      )) as typeof fetch;
+
+    const oracle = createPriceOracle({ cacheTtlMs: 0 });
+
+    // Unknown native chain id: no DexScreener mapping anyway, but the decimals
+    // path must also fail closed.
+    await expect(oracle.usdToWei(100, 999_999)).resolves.toBeNull();
+    // Unknown ERC-20 on a known chain: decimals unknown -> null, not 18.
+    await expect(
+      oracle.usdToWei(100, 8453, "0x2222222222222222222222222222222222222222"),
+    ).resolves.toBeNull();
+    await expect(
+      oracle.weiToUsd("1000000", 8453, "0x2222222222222222222222222222222222222222"),
+    ).resolves.toBeNull();
+  });
 });

--- a/packages/shared/src/__tests__/provider-action-canon.test.ts
+++ b/packages/shared/src/__tests__/provider-action-canon.test.ts
@@ -350,14 +350,14 @@ describe("strictParseJson", () => {
   // SEC-045: a `__proto__` member must never silently replace the result's
   // prototype (object value) or vanish (primitive value); reject it outright.
   it("rejects __proto__ member with object value", () =>
-    expectCanon(() => strictParseJson('{"__proto__":{"isAdmin":true}}'), "CANON_JSON_FORBIDDEN_KEY"));
+    expectCanon(
+      () => strictParseJson('{"__proto__":{"isAdmin":true}}'),
+      "CANON_JSON_FORBIDDEN_KEY",
+    ));
   it("rejects __proto__ member with primitive value", () =>
     expectCanon(() => strictParseJson('{"__proto__":1,"text":"hi"}'), "CANON_JSON_FORBIDDEN_KEY"));
   it("rejects __proto__ member nested at any depth", () =>
-    expectCanon(
-      () => strictParseJson('{"x":[{"__proto__":null}]}'),
-      "CANON_JSON_FORBIDDEN_KEY",
-    ));
+    expectCanon(() => strictParseJson('{"x":[{"__proto__":null}]}'), "CANON_JSON_FORBIDDEN_KEY"));
   it("rejects constructor/prototype members", () => {
     expectCanon(() => strictParseJson('{"constructor":{}}'), "CANON_JSON_FORBIDDEN_KEY");
     expectCanon(() => strictParseJson('{"prototype":{}}'), "CANON_JSON_FORBIDDEN_KEY");

--- a/packages/shared/src/__tests__/provider-action-canon.test.ts
+++ b/packages/shared/src/__tests__/provider-action-canon.test.ts
@@ -347,6 +347,28 @@ describe("strictParseJson", () => {
     expectCanon(() => strictParseJson('{"x":{"a":1,"a":2}}'), "CANON_JSON_DUPLICATE_KEY"));
   it("rejects duplicate key deep in array", () =>
     expectCanon(() => strictParseJson('{"x":[{"a":1,"a":2}]}'), "CANON_JSON_DUPLICATE_KEY"));
+  // SEC-045: a `__proto__` member must never silently replace the result's
+  // prototype (object value) or vanish (primitive value); reject it outright.
+  it("rejects __proto__ member with object value", () =>
+    expectCanon(() => strictParseJson('{"__proto__":{"isAdmin":true}}'), "CANON_JSON_FORBIDDEN_KEY"));
+  it("rejects __proto__ member with primitive value", () =>
+    expectCanon(() => strictParseJson('{"__proto__":1,"text":"hi"}'), "CANON_JSON_FORBIDDEN_KEY"));
+  it("rejects __proto__ member nested at any depth", () =>
+    expectCanon(
+      () => strictParseJson('{"x":[{"__proto__":null}]}'),
+      "CANON_JSON_FORBIDDEN_KEY",
+    ));
+  it("rejects constructor/prototype members", () => {
+    expectCanon(() => strictParseJson('{"constructor":{}}'), "CANON_JSON_FORBIDDEN_KEY");
+    expectCanon(() => strictParseJson('{"prototype":{}}'), "CANON_JSON_FORBIDDEN_KEY");
+  });
+  it("never returns an object with a replaced prototype", () => {
+    // Defense in depth: whatever the parser returns, property reads must not
+    // observe smuggled members through the prototype chain.
+    const parsed = strictParseJson('{"text":"hi"}') as Record<string, unknown>;
+    expect(Object.getPrototypeOf(parsed)).toBe(Object.prototype);
+    expect((parsed as { isAdmin?: unknown }).isAdmin).toBeUndefined();
+  });
   it("rejects trailing content", () =>
     expectCanon(() => strictParseJson('{"a":1} garbage'), "CANON_JSON_SYNTAX_INVALID"));
   it("rejects trailing comma", () =>

--- a/packages/shared/src/__tests__/provider-execution-auth-rotation.test.ts
+++ b/packages/shared/src/__tests__/provider-execution-auth-rotation.test.ts
@@ -56,11 +56,11 @@ afterEach(() => {
 
 describe("execution authorization v2 key rotation", () => {
   it("keeps the retired key verify-only during overlap", () => {
-    process.env.STEWARD_EXECUTION_AUTH_SECRET = "old:old-secret-material";
+    process.env.STEWARD_EXECUTION_AUTH_SECRET = "old:old-secret-material-padded-to-32ch";
     const oldCommitment = commitment("old");
     const oldSignature = signProviderExecutionCommitmentV2(oldCommitment);
 
-    process.env.STEWARD_EXECUTION_AUTH_SECRET = "new:new-secret-material,old:old-secret-material";
+    process.env.STEWARD_EXECUTION_AUTH_SECRET = "new:new-secret-material-padded-to-32ch,old:old-secret-material-padded-to-32ch";
     expect(verifyProviderExecutionCommitmentV2(oldCommitment, oldSignature)).toBe(true);
     expect(() => signProviderExecutionCommitmentV2(oldCommitment)).toThrow(
       "commitment keyId does not match the active signing key",
@@ -76,11 +76,24 @@ describe("execution authorization v2 key rotation", () => {
   });
 
   it("rejects the retired key after overlap removal", () => {
-    process.env.STEWARD_EXECUTION_AUTH_SECRET = "old:old-secret-material";
+    process.env.STEWARD_EXECUTION_AUTH_SECRET = "old:old-secret-material-padded-to-32ch";
     const oldCommitment = commitment("old");
     const oldSignature = signProviderExecutionCommitmentV2(oldCommitment);
 
-    process.env.STEWARD_EXECUTION_AUTH_SECRET = "new:new-secret-material";
+    process.env.STEWARD_EXECUTION_AUTH_SECRET = "new:new-secret-material-padded-to-32ch";
     expect(verifyProviderExecutionCommitmentV2(oldCommitment, oldSignature)).toBe(false);
+  });
+
+  it("rejects secrets below the 32-char entropy floor (SEC-117)", () => {
+    process.env.STEWARD_EXECUTION_AUTH_SECRET = "a";
+    expect(() => signProviderExecutionCommitmentV2(commitment("v2-default"))).toThrow(/too weak/);
+
+    process.env.STEWARD_EXECUTION_AUTH_SECRET = "k1:short";
+    expect(() => signProviderExecutionCommitmentV2(commitment("k1"))).toThrow(/too weak/);
+
+    // A too-weak entry anywhere in the rotation list fails closed at load.
+    process.env.STEWARD_EXECUTION_AUTH_SECRET =
+      "k1:secret-one-with-enough-entropy-here,k2:tiny";
+    expect(() => signProviderExecutionCommitmentV2(commitment("k1"))).toThrow(/too weak/);
   });
 });

--- a/packages/shared/src/__tests__/provider-execution-auth-rotation.test.ts
+++ b/packages/shared/src/__tests__/provider-execution-auth-rotation.test.ts
@@ -60,7 +60,8 @@ describe("execution authorization v2 key rotation", () => {
     const oldCommitment = commitment("old");
     const oldSignature = signProviderExecutionCommitmentV2(oldCommitment);
 
-    process.env.STEWARD_EXECUTION_AUTH_SECRET = "new:new-secret-material-padded-to-32ch,old:old-secret-material-padded-to-32ch";
+    process.env.STEWARD_EXECUTION_AUTH_SECRET =
+      "new:new-secret-material-padded-to-32ch,old:old-secret-material-padded-to-32ch";
     expect(verifyProviderExecutionCommitmentV2(oldCommitment, oldSignature)).toBe(true);
     expect(() => signProviderExecutionCommitmentV2(oldCommitment)).toThrow(
       "commitment keyId does not match the active signing key",
@@ -92,8 +93,7 @@ describe("execution authorization v2 key rotation", () => {
     expect(() => signProviderExecutionCommitmentV2(commitment("k1"))).toThrow(/too weak/);
 
     // A too-weak entry anywhere in the rotation list fails closed at load.
-    process.env.STEWARD_EXECUTION_AUTH_SECRET =
-      "k1:secret-one-with-enough-entropy-here,k2:tiny";
+    process.env.STEWARD_EXECUTION_AUTH_SECRET = "k1:secret-one-with-enough-entropy-here,k2:tiny";
     expect(() => signProviderExecutionCommitmentV2(commitment("k1"))).toThrow(/too weak/);
   });
 });

--- a/packages/shared/src/__tests__/signing-curves.test.ts
+++ b/packages/shared/src/__tests__/signing-curves.test.ts
@@ -76,6 +76,15 @@ describe("signing-curve capability registry", () => {
     expect(rawSigningChainSupport(undefined)).toBeUndefined();
   });
 
+  it("rawSigningChainSupport does not treat Object.prototype members as chains (SEC-116)", () => {
+    // `"constructor" in RAW_SIGNING_CHAIN_SUPPORT` is true via the prototype
+    // chain; the lookup must restrict to own keys or it returns the Object
+    // constructor as a fake support record.
+    expect(rawSigningChainSupport("constructor")).toBeUndefined();
+    expect(rawSigningChainSupport("toString")).toBeUndefined();
+    expect(rawSigningChainSupport("hasOwnProperty")).toBeUndefined();
+  });
+
   it("isSigningCurve recognises known curves and rejects junk", () => {
     expect(isSigningCurve("secp256k1")).toBe(true);
     expect(isSigningCurve("ed25519")).toBe(true);

--- a/packages/shared/src/__tests__/tokens-venues-price.test.ts
+++ b/packages/shared/src/__tests__/tokens-venues-price.test.ts
@@ -146,8 +146,10 @@ describe("createPriceOracle", () => {
   });
 
   it("keeps case-distinct Solana mint prices isolated in the cache", async () => {
+    const mintUpper = "AbCMint11111111111111111111111111111111111";
+    const mintLower = "abcmint11111111111111111111111111111111111";
     const fetchMock = mock(async (input: RequestInfo | URL) => {
-      const price = String(input).endsWith("/AbCMint") ? "10" : "20";
+      const price = String(input).endsWith(`/${mintUpper}`) ? "10" : "20";
       return new Response(JSON.stringify({ pairs: [{ chainId: "solana", priceUsd: price }] }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
@@ -156,8 +158,8 @@ describe("createPriceOracle", () => {
     globalThis.fetch = fetchMock as unknown as typeof fetch;
     const oracle = createPriceOracle({ cacheTtlMs: 60_000 });
 
-    await expect(oracle.getTokenUsdPrice(101, "AbCMint")).resolves.toBe(10);
-    await expect(oracle.getTokenUsdPrice(101, "abcmint")).resolves.toBe(20);
+    await expect(oracle.getTokenUsdPrice(101, mintUpper)).resolves.toBe(10);
+    await expect(oracle.getTokenUsdPrice(101, mintLower)).resolves.toBe(20);
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 

--- a/packages/shared/src/chains/index.ts
+++ b/packages/shared/src/chains/index.ts
@@ -63,7 +63,11 @@ export const CHAIN_PROVIDERS_BY_NUMERIC: Record<number, ChainProvider> = Object.
 );
 
 export function getChainProviderByCaip2(caip2: string): ChainProvider | undefined {
-  return CHAIN_PROVIDERS_BY_CAIP2[caip2];
+  // Own-key lookup: a bare index would return Object.prototype members (e.g.
+  // "constructor") as if they were known providers (SEC-116).
+  return Object.hasOwn(CHAIN_PROVIDERS_BY_CAIP2, caip2)
+    ? CHAIN_PROVIDERS_BY_CAIP2[caip2]
+    : undefined;
 }
 
 export function getChainProviderByNumeric(numericId: number): ChainProvider | undefined {

--- a/packages/shared/src/chains/signing.ts
+++ b/packages/shared/src/chains/signing.ts
@@ -218,7 +218,9 @@ export function signingCurveSupport(value: unknown): SigningCurveSupport | undef
 }
 
 export function rawSigningChainSupport(value: unknown): RawSigningChainSupport | undefined {
-  return typeof value === "string" && value in RAW_SIGNING_CHAIN_SUPPORT
+  // `in` would also match Object.prototype members ("constructor" etc.) and
+  // return them as support records; restrict to own keys (SEC-116).
+  return typeof value === "string" && Object.hasOwn(RAW_SIGNING_CHAIN_SUPPORT, value)
     ? RAW_SIGNING_CHAIN_SUPPORT[value as RawSigningChain]
     : undefined;
 }

--- a/packages/shared/src/execution-payload.ts
+++ b/packages/shared/src/execution-payload.ts
@@ -1,3 +1,4 @@
+import { CHAIN_PROVIDERS_BY_NUMERIC } from "./chains/index.js";
 import type { SignRequest } from "./index.js";
 
 /**
@@ -15,8 +16,6 @@ import type { SignRequest } from "./index.js";
  * consumed; those are deliberately outside the bound intent. See
  * SECURITY_SURFACE_OPERATIONS notes and PR #182 for the exact semantics.
  */
-
-const SOLANA_CHAIN_IDS = new Set([101, 102]);
 
 /**
  * Fields that carry a caller-supplied integer we bind into the intent digest.
@@ -65,8 +64,14 @@ export interface NormalizedEvmExecutionPayload {
   };
 }
 
+/**
+ * True only for chains registered as EVM-family. Unknown numeric ids and
+ * non-EVM families (Solana/Bitcoin/Monero) return false — fail closed, so a
+ * future caller routing on this never mis-handles a non-EVM id as EVM
+ * (SEC-193).
+ */
 export function isEvmChainId(chainId: number): boolean {
-  return !SOLANA_CHAIN_IDS.has(chainId);
+  return CHAIN_PROVIDERS_BY_NUMERIC[chainId]?.family === "evm";
 }
 
 /**
@@ -110,7 +115,10 @@ function canonicalize(value: unknown): unknown {
   if (value instanceof Date) return value.toISOString();
   if (Array.isArray(value)) return value.map((entry) => canonicalize(entry));
   const input = value as Record<string, unknown>;
-  const output: Record<string, unknown> = {};
+  // Null-prototype output: plain `{}` assignment silently DROPS an own
+  // `__proto__` key (present after JSON.parse/JSONB reads), which would let two
+  // snapshots differing only in that member digest identically (SEC-115).
+  const output: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
   for (const key of Object.keys(input).sort()) {
     const item = input[key];
     if (item !== undefined) output[key] = canonicalize(item);

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -290,7 +290,9 @@ export function chainFromNumeric(id: number): ChainIdentifier | undefined {
 
 /** Look up a chain by its CAIP-2 string (e.g. `"eip155:8453"`). Returns undefined if not found. */
 export function chainFromCaip2(caip2: string): ChainIdentifier | undefined {
-  return CHAINS[caip2];
+  // Own-key lookup: a bare index would return Object.prototype members (e.g.
+  // "constructor") as if they were known chains (SEC-116).
+  return Object.hasOwn(CHAINS, caip2) ? CHAINS[caip2] : undefined;
 }
 
 /**
@@ -306,7 +308,7 @@ export function toCaip2(numericId: number): string | undefined {
  * Returns undefined for unrecognised CAIP-2 strings.
  */
 export function fromCaip2(caip2: string): number | undefined {
-  return CHAINS[caip2]?.numericId;
+  return chainFromCaip2(caip2)?.numericId;
 }
 
 // ─── Policies ───

--- a/packages/shared/src/price-oracle.ts
+++ b/packages/shared/src/price-oracle.ts
@@ -263,7 +263,6 @@ export function createPriceOracle(options?: { cacheTtlMs?: number }): PriceOracl
       // exact. Rounds to nearest (half up) — an explicit rounding policy,
       // replacing the old double-math `Math.floor(tokenAmount * 10**decimals)`
       // which lost precision and always rounded down.
-      const MICROS = 1_000_000n;
       const usdMicros = BigInt(Math.round(usdValue * 1_000_000));
       const priceMicros = BigInt(Math.round(price * 1_000_000));
       if (priceMicros <= 0n) return null;

--- a/packages/shared/src/price-oracle.ts
+++ b/packages/shared/src/price-oracle.ts
@@ -6,7 +6,11 @@
  * - Graceful degradation: returns null on failure so callers can fall back to wei comparison
  */
 
-import { getNativeDecimals, getTokenDecimals, getWrappedNativeAddress } from "./tokens.js";
+import {
+  getNativeDecimalsStrict,
+  getTokenDecimalsStrict,
+  getWrappedNativeAddress,
+} from "./tokens.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -102,6 +106,18 @@ export function createPriceOracle(options?: { cacheTtlMs?: number }): PriceOracl
   }
 
   /**
+   * Reject malformed token addresses before they reach the request URL
+   * (SEC-118). EVM chains expect a 20-byte hex address; Solana a base58 mint.
+   * Anything else (path/query metacharacters, wrong family) fails closed.
+   */
+  function isPlausibleTokenAddress(chainId: number, tokenAddress: string): boolean {
+    if (chainId === 101 || chainId === 102) {
+      return /^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(tokenAddress);
+    }
+    return /^0x[0-9a-fA-F]{40}$/.test(tokenAddress);
+  }
+
+  /**
    * Fetch price from DexScreener for a token address.
    * Picks the pair with highest liquidity for best accuracy.
    */
@@ -112,7 +128,13 @@ export function createPriceOracle(options?: { cacheTtlMs?: number }): PriceOracl
         console.warn(`[price-oracle] No DexScreener chain mapping for chainId ${chainId}`);
         return null;
       }
-      const url = `https://api.dexscreener.com/latest/dex/tokens/${tokenAddress}`;
+      if (!isPlausibleTokenAddress(chainId, tokenAddress)) {
+        console.warn(
+          `[price-oracle] Rejecting malformed token address for chainId ${chainId}: ${tokenAddress.slice(0, 64)}`,
+        );
+        return null;
+      }
+      const url = `https://api.dexscreener.com/latest/dex/tokens/${encodeURIComponent(tokenAddress)}`;
       const res = await fetch(url, {
         headers: { Accept: "application/json" },
         signal: AbortSignal.timeout(5000),
@@ -187,9 +209,17 @@ export function createPriceOracle(options?: { cacheTtlMs?: number }): PriceOracl
 
       if (price === null) return null;
 
+      // Strict decimals (SEC-190): unknown chains/tokens return null and the
+      // conversion fails closed instead of guessing 18 decimals.
       const decimals = isNative
-        ? getNativeDecimals(chainId)
-        : getTokenDecimals(chainId, tokenAddress);
+        ? getNativeDecimalsStrict(chainId)
+        : getTokenDecimalsStrict(chainId, tokenAddress);
+      if (decimals === null) {
+        console.warn(
+          `[price-oracle] Unknown decimals for chainId ${chainId} token ${tokenAddress ?? "native"}; failing closed`,
+        );
+        return null;
+      }
 
       // Convert wei to token units: weiValue / 10^decimals
       // Use BigInt arithmetic to avoid floating point issues with large numbers
@@ -215,14 +245,30 @@ export function createPriceOracle(options?: { cacheTtlMs?: number }): PriceOracl
 
       if (price === null || price === 0) return null;
 
+      // Strict decimals (SEC-190): unknown chains/tokens fail closed.
       const decimals = isNative
-        ? getNativeDecimals(chainId)
-        : getTokenDecimals(chainId, tokenAddress);
+        ? getNativeDecimalsStrict(chainId)
+        : getTokenDecimalsStrict(chainId, tokenAddress);
+      if (decimals === null) {
+        console.warn(
+          `[price-oracle] Unknown decimals for chainId ${chainId} token ${tokenAddress ?? "native"}; failing closed`,
+        );
+        return null;
+      }
 
-      // tokenAmount = usdValue / price
-      // wei = tokenAmount * 10^decimals
-      const tokenAmount = usdValue / price;
-      const wei = BigInt(Math.floor(tokenAmount * 10 ** decimals));
+      if (!Number.isFinite(usdValue) || usdValue < 0) return null;
+
+      // Rational arithmetic (SEC-189): scale the USD input and price to
+      // micro-unit integers and divide in BigInt, so values beyond 2^53 stay
+      // exact. Rounds to nearest (half up) — an explicit rounding policy,
+      // replacing the old double-math `Math.floor(tokenAmount * 10**decimals)`
+      // which lost precision and always rounded down.
+      const MICROS = 1_000_000n;
+      const usdMicros = BigInt(Math.round(usdValue * 1_000_000));
+      const priceMicros = BigInt(Math.round(price * 1_000_000));
+      if (priceMicros <= 0n) return null;
+      const numerator = usdMicros * 10n ** BigInt(decimals);
+      const wei = (numerator * 2n + priceMicros) / (priceMicros * 2n);
       return wei.toString();
     },
   };

--- a/packages/shared/src/provider-action.ts
+++ b/packages/shared/src/provider-action.ts
@@ -41,6 +41,7 @@ export const CANON_ERROR_CODES = [
   "CANON_INVALID_UTF8",
   "CANON_JSON_SYNTAX_INVALID",
   "CANON_JSON_DUPLICATE_KEY",
+  "CANON_JSON_FORBIDDEN_KEY",
   "CANON_JSON_SHAPE_INVALID",
   "CANON_UNKNOWN_FIELD",
   "CANON_REQUIRED_FIELD_MISSING",
@@ -106,6 +107,7 @@ const CANON_ERROR_HTTP: Record<CanonErrorCode, number> = {
   CANON_INVALID_UTF8: 400,
   CANON_JSON_SYNTAX_INVALID: 400,
   CANON_JSON_DUPLICATE_KEY: 400,
+  CANON_JSON_FORBIDDEN_KEY: 400,
   CANON_JSON_SHAPE_INVALID: 400,
   CANON_UNKNOWN_FIELD: 400,
   CANON_REQUIRED_FIELD_MISSING: 400,
@@ -203,6 +205,9 @@ export const MIN_SAFE_JSON_INT = -9007199254740991;
 // duplicate keys (Conflict 10) and accepts numbers we must reject. This is a
 // bespoke recursive-descent parser over a UTF-8 string that:
 //   - rejects duplicate member names at EVERY depth (CANON_JSON_DUPLICATE_KEY);
+//   - rejects `__proto__`/`constructor`/`prototype` member names at EVERY depth
+//     (CANON_JSON_FORBIDDEN_KEY) — plain assignment would replace the result's
+//     prototype or silently drop the member instead of creating an own key;
 //   - rejects the profile-forbidden number lexemes (decimals/exp/leading-zero/-0);
 //   - rejects trailing tokens, comments, trailing commas, BOM;
 //   - rejects lone surrogates in strings (CANON_UNICODE_INVALID);
@@ -266,6 +271,15 @@ class JsonScanner {
       this.ws();
       if (this.s[this.i] !== '"') fail("CANON_JSON_SYNTAX_INVALID", "expected object key string");
       const key = this.string();
+      // Prototype-pollution guard: a member named `__proto__` never becomes an
+      // own property under plain assignment (an object value REPLACES the
+      // result's prototype; a primitive is silently dropped), and
+      // `constructor`/`prototype` reads follow the prototype chain. These keys
+      // are ambiguous across JS consumer patterns, so reject them outright
+      // instead of silently collapsing them.
+      if (key === "__proto__" || key === "constructor" || key === "prototype") {
+        fail("CANON_JSON_FORBIDDEN_KEY", `forbidden object key ${JSON.stringify(key)}`);
+      }
       if (seen.has(key)) fail("CANON_JSON_DUPLICATE_KEY", `duplicate key ${JSON.stringify(key)}`);
       seen.add(key);
       this.ws();

--- a/packages/shared/src/provider-execution-auth.ts
+++ b/packages/shared/src/provider-execution-auth.ts
@@ -20,6 +20,9 @@ import {
 const EXECUTION_AUTH_V2_HKDF_SALT = "steward:execution-authorization:v2:salt";
 const EXECUTION_AUTH_V2_HKDF_INFO = "steward:execution-authorization:v2:hmac";
 
+/** Minimum accepted length for each STEWARD_EXECUTION_AUTH_SECRET entry. */
+const MIN_EXECUTION_AUTH_SECRET_CHARS = 32;
+
 export type ProviderExecutionAuthV2ErrorCode =
   | "secret_unavailable"
   | "unknown_key"
@@ -89,6 +92,17 @@ export function loadExecutionAuthV2Keys(): ProviderExecutionAuthV2KeyEntry[] {
     if (keyId.length === 0 || secret.length === 0) continue;
     if (seen.has(keyId)) continue;
     seen.add(keyId);
+    // Entropy floor (SEC-117): v2 signatures/commitments appear in exportable
+    // evidence bundles, giving an attacker offline verification material — a
+    // short secret reduces HMAC security to its brute-forceability. Require
+    // ~256 bits of secret material (32 chars), matching the audit-HMAC floor.
+    if (secret.length < MIN_EXECUTION_AUTH_SECRET_CHARS) {
+      throw new ProviderExecutionAuthV2Error(
+        `STEWARD_EXECUTION_AUTH_SECRET entry '${keyId}' is too weak: needs >= ${MIN_EXECUTION_AUTH_SECRET_CHARS} characters of entropy. ` +
+          "Generate with `openssl rand -hex 32`.",
+        "secret_unavailable",
+      );
+    }
     const derived = hkdfSync(
       "sha256",
       new TextEncoder().encode(secret),

--- a/packages/shared/src/tokens.ts
+++ b/packages/shared/src/tokens.ts
@@ -92,6 +92,15 @@ export function getNativeDecimals(chainId: number): number {
 }
 
 /**
+ * Strict variant of {@link getNativeDecimals} for money-conversion paths:
+ * returns null for unknown chains instead of guessing 18 decimals, so callers
+ * fail closed rather than misprice by orders of magnitude (SEC-190).
+ */
+export function getNativeDecimalsStrict(chainId: number): number | null {
+  return NATIVE_TOKENS[chainId]?.decimals ?? null;
+}
+
+/**
  * Get the symbol for a chain's native token.
  * Returns "ETH" for unknown chains.
  */
@@ -113,6 +122,21 @@ export function getTokenDecimals(chainId: number, tokenAddress?: string): number
   if (knownToken) return knownToken.decimals;
   const key = `${chainId}:${tokenAddress.toLowerCase()}`;
   return KNOWN_TOKEN_DECIMALS[key] ?? 18;
+}
+
+/**
+ * Strict variant of {@link getTokenDecimals} for money-conversion paths:
+ * returns null for unknown chains/tokens instead of guessing 18 decimals, so
+ * callers fail closed rather than misprice by orders of magnitude (SEC-190).
+ */
+export function getTokenDecimalsStrict(chainId: number, tokenAddress?: string): number | null {
+  if (!tokenAddress || tokenAddress === "native" || tokenAddress === "") {
+    return getNativeDecimalsStrict(chainId);
+  }
+  const knownToken = getKnownToken(chainId, tokenAddress);
+  if (knownToken) return knownToken.decimals;
+  const key = `${chainId}:${tokenAddress.toLowerCase()}`;
+  return KNOWN_TOKEN_DECIMALS[key] ?? null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Wave-2 misc batch (packages/db, redis, shared, proxy, proxy-client). All 4 MEDIUM findings in this batch are fixed with regression tests; the shared-package LOW/INFO cluster is fixed; remaining LOW/INFO items are DEFERRED (time-boxed wrap-up — see table).

## SEC ID status

| SEC ID | Severity | Status | Change |
|---|---|---|---|
| SEC-030 | MEDIUM | FIXED | Legacy-DB backfill now fingerprints the psql-era tip table (`public.audit_events`, created by 0024) and seeds only journal entries through `0024_audit_events` instead of the entire current journal; refuses loudly when the fingerprint is missing. Tip determined from git history (heuristic introduced in ffa82992 when 0024 was the tip). |
| SEC-031 | MEDIUM | FIXED | New migration `0090_provider_action_approval_evidence_write_once.sql` replaces `steward_provider_action_binding_guard()`: approval evidence (`approval_actor_user_id`, `approval_queue_id`, `approval_commitment_hash`, `approved_at`) may only transition NULL→value, and only on `pending_approval→approved`/`approval_denied`. Also allows the deny path, which legitimately records the deciding actor (see trade-offs). |
| SEC-032 | MEDIUM | FIXED | `assertRedisUrlTls()` in `packages/redis/src/client.ts`: production requires `rediss://` (localhost exempt), with explicit `STEWARD_ALLOW_INSECURE_REDIS=true` opt-out + loud warning, mirroring `assertDatabaseUrlTls()`. docker-compose.yml gained the opt-out passthrough (no default injected). |
| SEC-045 | MEDIUM | FIXED | `strictParseJson` rejects `__proto__`/`constructor`/`prototype` member names at every depth with new additive wire code `CANON_JSON_FORBIDDEN_KEY` (was: object value silently replaced the result's prototype, primitive silently dropped). |
| SEC-087 | LOW | DEFERRED | Requiring `verify-full`+`sslrootcert` for prod would break existing managed-DB deployments using `sslmode=require`; needs a product/migration decision beyond a surgical fix. |
| SEC-088 | LOW | ALREADY FIXED upstream | Writes encrypt (webhooks.ts:420, tenants.ts:69); dispatch lazily re-encrypts legacy plaintext and snapshots only the ENCRYPTED secret into delivery rows (webhook-dispatch.ts:201–237); delivery-row `secret` is never read back. Covered by webhook-retry-hardening.test.ts:97–116. Residual: no bulk backfill of pre-hardening rows (needs master key at migration time; lazy migration covers them on next dispatch). |
| SEC-089 | LOW | DEFERRED | Audit-chain undefined-metadata canonicalization/persistence mismatch — not reached in this run; recommended fix in report (normalize via `canonicalJsonValue` before both HMAC and INSERT). |
| SEC-090 | LOW | DEFERRED | PGLite data-dir permissions (mkdir mode 0o700 + chmod existing) — not reached. |
| SEC-097 | LOW | DEFERRED | Proxy alternate client-IP header stripping — not reached. |
| SEC-098 | LOW | DEFERRED | Strip upstream `Set-Cookie` on credential-injected routes — not reached. |
| SEC-099 | LOW | DEFERRED | Strip `x-steward-request-timestamp`/`-expires-at` from outbound headers — not reached. |
| SEC-100 | LOW | DEFERRED | Reject 0/invalid proxy limit env vars at startup — not reached. |
| SEC-115 | LOW | FIXED | `canonicalJsonStringify` builds output on `Object.create(null)` so own `__proto__` keys survive canonicalization (two snapshots differing only in `__proto__` no longer digest identically). |
| SEC-116 | LOW | FIXED | `rawSigningChainSupport`, `chainFromCaip2`, `fromCaip2`, `getChainProviderByCaip2` now use `Object.hasOwn` own-key lookups (`"constructor"` no longer returns a fake record). |
| SEC-117 | LOW | FIXED | `loadExecutionAuthV2Keys()` rejects secret entries < 32 chars, fail-closed at load with rotation instructions. |
| SEC-118 | LOW | FIXED | DexScreener fetch validates token address format per chain family (EVM `0x`+40 hex / Solana base58 32–44) and `encodeURIComponent`s it; malformed addresses return null without fetching. |
| SEC-166 | INFO | DEFERRED | CLOUDFLARE.md advisory-lock doc vs `pg_advisory_xact_lock` — needs a Workers-path verification before reconciling doc vs code. |
| SEC-167 | INFO | DEFERRED | Narrow `isAuditSequenceConflict` to constraint name/SQLSTATE — not reached. |
| SEC-168 | INFO | DEFERRED | `settleReservedSpend` floor-at-zero Lua guard — not reached. |
| SEC-169 | INFO | DEFERRED | Postgres RLS is an architectural change; schema comments mark app-layer isolation as deliberate — needs a product decision. |
| SEC-174 | INFO | DEFERRED | Proxy wildcard CORS + `/health` disclosure — not reached. |
| SEC-175 | INFO | DEFERRED | Proxy fail-open defaults outside production (STEWARD_PROXY_DEV_MODE gate) — not reached. |
| SEC-176 | INFO | DEFERRED | Unknown `injectAs` should 400/500 — not reached. |
| SEC-189 | INFO | FIXED | `usdToWei` uses BigInt rational arithmetic (micro-scaled numerator/denominator), rounds to nearest half-up, rejects non-finite/negative input. |
| SEC-190 | INFO | FIXED | New `getNativeDecimalsStrict`/`getTokenDecimalsStrict` return null for unknown chains/tokens; oracle conversion paths (`weiToUsd`/`usdToWei`) fail closed. Display helpers keep the 18-default. |
| SEC-191 | INFO | DEFERRED | JCS `serializeObject` getter reads vs header doc — doc/code alignment only. |
| SEC-192 | INFO | DEFERRED | `describeContributions()` `__proto__` plugin name — local-only diagnostics. |
| SEC-193 | INFO | FIXED | `isEvmChainId` now checks `CHAIN_PROVIDERS_BY_NUMERIC[id]?.family === "evm"` — fail closed for unknown ids and Bitcoin/Monero (previously everything except 101/102 was "EVM"). No production callers. |
| SEC-194 | INFO | DEFERRED | `normalizeSensitiveKey` non-ASCII evasion — documentation-only fix. |

## Trade-offs / breaking changes

- **SEC-032**: production deployments using cleartext `redis://` to a non-localhost host now fail loudly. Private-network deployments must set `STEWARD_ALLOW_INSECURE_REDIS=true` (mirrors the existing `STEWARD_ALLOW_INSECURE_DB` posture; compose operators get an explicit passthrough, no silent default).
- **SEC-031**: the guard permits NULL→value on `pending_approval→approval_denied` in addition to `→approved`, because the deny flow legitimately records the deciding actor in `approval_actor_user_id` (verified in provider-approval.ts). The report's "approved-only" wording would break the deny path. Evidence remains write-once after either decision.
- **SEC-045**: JSON bodies containing `__proto__`/`constructor`/`prototype` keys are now rejected (400 `CANON_JSON_FORBIDDEN_KEY`, added per the additive-only wire-code contract). No legitimate profile payload uses these keys.
- **SEC-117**: `STEWARD_EXECUTION_AUTH_SECRET` entries shorter than 32 chars now fail closed; weak deployments must rotate (`openssl rand -hex 32`). Test secrets in shared/api suites were padded (signatures are runtime-computed; no golden digests affected).
- **SEC-190**: oracle conversions for unknown tokens/chains return null (fail closed) instead of assuming 18 decimals; display-only helpers are unchanged.
- **SEC-030**: a legacy DB whose schema predates 0024 now fails migration loudly instead of silently skipping hardening migrations; operator must reconcile manually (this is the intended fail-closed behavior).

## How tested

- `packages/shared`: `bun test` — 426 pass / 0 fail (incl. new execution-payload, price-oracle, chains, signing-curves, rotation, canon regression tests)
- `packages/db`: `bun test` — 81 pass / 0 fail (incl. new legacy-backfill + 0090 write-once migration tests)
- `packages/redis`: `bun test` — 30 pass / 50 skipped (live-Redis tests need `STEWARD_REDIS_TESTS`) / 0 fail
- `packages/api`: `execution-authorization-v2-crypto.test.ts` — 8 pass / 0 fail (only api file touched)
- SEC-031 regression proof: the 3 attack tests fail when migration 0090 is removed, pass with it applied.
- `bunx biome check` on all changed files — clean.

Notes: `bun.lock` has local modifications from `bun install` (incidental, not committed). No pre-existing unrelated failures observed in the touched packages.
