### PR TITLE
fix(security): wave 2 api batch — remount request guards, tighten-only trade policies, SSRF/rate-limit/logging hardening

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -43,7 +43,12 @@
     "/v2/workspaces",
     "/v2/provider-accounts",
     "/v2/provider-role-bindings",
-    "/v2/provider-grants"
+    "/v2/provider-grants",
+    "/v1/kms",
+    "/v2/provider-actions",
+    "/dashboard",
+    "/agent-enroll",
+    "/v1/agent-enroll"
   ],
   "tags": [
     {
@@ -417,14 +422,14 @@
           "sensitive": true,
           "sensitivePrefix": "/auth",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -722,14 +727,14 @@
           "sensitive": true,
           "sensitivePrefix": "/auth",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -1040,14 +1045,14 @@
           "sensitive": true,
           "sensitivePrefix": "/auth",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -1356,14 +1361,14 @@
           "sensitive": true,
           "sensitivePrefix": "/auth",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -1658,14 +1663,14 @@
           "sensitive": true,
           "sensitivePrefix": "/auth",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -1981,14 +1986,14 @@
           "sensitive": true,
           "sensitivePrefix": "/auth",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -2281,14 +2286,14 @@
           "sensitive": true,
           "sensitivePrefix": "/auth",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -2585,14 +2590,14 @@
           "sensitive": true,
           "sensitivePrefix": "/auth",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -2889,14 +2894,14 @@
           "sensitive": true,
           "sensitivePrefix": "/auth",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -3193,14 +3198,14 @@
           "sensitive": true,
           "sensitivePrefix": "/auth",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -3490,14 +3495,14 @@
           "sensitive": true,
           "sensitivePrefix": "/auth",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -3758,14 +3763,14 @@
           "sensitive": true,
           "sensitivePrefix": "/auth",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -4069,14 +4074,14 @@
           "sensitive": true,
           "sensitivePrefix": "/auth",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -4380,14 +4385,14 @@
           "sensitive": true,
           "sensitivePrefix": "/auth",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -4645,14 +4650,14 @@
           "sensitive": true,
           "sensitivePrefix": "/auth",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -4944,14 +4949,14 @@
           "sensitive": true,
           "sensitivePrefix": "/auth",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -5208,14 +5213,14 @@
           "sensitive": true,
           "sensitivePrefix": "/auth",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -5503,6 +5508,29 @@
               }
             }
           },
+          "408": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
           "409": {
             "description": "JSON response",
             "content": {
@@ -5525,6 +5553,78 @@
                 }
               }
             }
+          }
+        },
+        "parameters": [
+          {
+            "name": "X-Steward-Request-Timestamp",
+            "in": "header",
+            "required": false,
+            "description": "Unix seconds, Unix milliseconds, or HTTP/ISO timestamp. Sensitive mutating routes require this or X-Steward-Request-Expires-At when request-expiry or request signatures are enforced.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Request-Expires-At",
+            "in": "header",
+            "required": false,
+            "description": "Unix seconds, Unix milliseconds, or HTTP/ISO expiry time. Sensitive mutating routes require this or X-Steward-Request-Timestamp when request-expiry or request signatures are enforced.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Signature",
+            "in": "header",
+            "required": false,
+            "description": "Authorization signature for sensitive mutating routes when STEWARD_REQUIRE_AUTH_SIGNATURE=true or production enforcement is enabled. Use v1=<hmac-sha256> or p256=<signature>.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Signing-Key-Id",
+            "in": "header",
+            "required": false,
+            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "description": "Required for signed sensitive requests and recommended for all sensitive mutating requests. Replays are scoped to authenticated or explicitly signed contexts.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "x-steward-hardening": {
+          "sensitive": true,
+          "sensitivePrefix": "/v2/provider-actions",
+          "requestExpiry": {
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
+            "acceptedHeaders": [
+              "X-Steward-Request-Timestamp",
+              "X-Steward-Request-Expires-At"
+            ]
+          },
+          "authorizationSignature": {
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
+            "header": "X-Steward-Signature",
+            "schemes": [
+              "v1=hmac-sha256",
+              "p256=ecdsa-secp256r1"
+            ],
+            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+          },
+          "idempotency": {
+            "header": "Idempotency-Key",
+            "requiredForSignedRequests": true,
+            "replayStorage": "enabled when callers provide a key in a replay-safe authenticated context"
           }
         }
       }
@@ -5960,14 +6060,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v2/workspaces",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -6268,14 +6368,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v2/workspaces",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -6731,14 +6831,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v2/provider-accounts",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -7039,14 +7139,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v2/provider-accounts",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -7512,14 +7612,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v2/provider-accounts",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -7975,14 +8075,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v2/provider-role-bindings",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -8283,14 +8383,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v2/provider-role-bindings",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -8746,14 +8846,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v2/provider-grants",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -9054,14 +9154,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v2/provider-grants",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -9895,6 +9995,29 @@
               }
             }
           },
+          "408": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
           "409": {
             "description": "JSON response",
             "content": {
@@ -9917,6 +10040,78 @@
                 }
               }
             }
+          }
+        },
+        "parameters": [
+          {
+            "name": "X-Steward-Request-Timestamp",
+            "in": "header",
+            "required": false,
+            "description": "Unix seconds, Unix milliseconds, or HTTP/ISO timestamp. Sensitive mutating routes require this or X-Steward-Request-Expires-At when request-expiry or request signatures are enforced.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Request-Expires-At",
+            "in": "header",
+            "required": false,
+            "description": "Unix seconds, Unix milliseconds, or HTTP/ISO expiry time. Sensitive mutating routes require this or X-Steward-Request-Timestamp when request-expiry or request signatures are enforced.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Signature",
+            "in": "header",
+            "required": false,
+            "description": "Authorization signature for sensitive mutating routes when STEWARD_REQUIRE_AUTH_SIGNATURE=true or production enforcement is enabled. Use v1=<hmac-sha256> or p256=<signature>.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Signing-Key-Id",
+            "in": "header",
+            "required": false,
+            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "description": "Required for signed sensitive requests and recommended for all sensitive mutating requests. Replays are scoped to authenticated or explicitly signed contexts.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "x-steward-hardening": {
+          "sensitive": true,
+          "sensitivePrefix": "/v2/provider-actions",
+          "requestExpiry": {
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
+            "acceptedHeaders": [
+              "X-Steward-Request-Timestamp",
+              "X-Steward-Request-Expires-At"
+            ]
+          },
+          "authorizationSignature": {
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
+            "header": "X-Steward-Signature",
+            "schemes": [
+              "v1=hmac-sha256",
+              "p256=ecdsa-secp256r1"
+            ],
+            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+          },
+          "idempotency": {
+            "header": "Idempotency-Key",
+            "requiredForSignedRequests": true,
+            "replayStorage": "enabled when callers provide a key in a replay-safe authenticated context"
           }
         }
       }
@@ -10092,6 +10287,29 @@
               }
             }
           },
+          "408": {
+            "description": "JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
           "409": {
             "description": "JSON response",
             "content": {
@@ -10114,6 +10332,78 @@
                 }
               }
             }
+          }
+        },
+        "parameters": [
+          {
+            "name": "X-Steward-Request-Timestamp",
+            "in": "header",
+            "required": false,
+            "description": "Unix seconds, Unix milliseconds, or HTTP/ISO timestamp. Sensitive mutating routes require this or X-Steward-Request-Expires-At when request-expiry or request signatures are enforced.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Request-Expires-At",
+            "in": "header",
+            "required": false,
+            "description": "Unix seconds, Unix milliseconds, or HTTP/ISO expiry time. Sensitive mutating routes require this or X-Steward-Request-Timestamp when request-expiry or request signatures are enforced.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Signature",
+            "in": "header",
+            "required": false,
+            "description": "Authorization signature for sensitive mutating routes when STEWARD_REQUIRE_AUTH_SIGNATURE=true or production enforcement is enabled. Use v1=<hmac-sha256> or p256=<signature>.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Steward-Signing-Key-Id",
+            "in": "header",
+            "required": false,
+            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "description": "Required for signed sensitive requests and recommended for all sensitive mutating requests. Replays are scoped to authenticated or explicitly signed contexts.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "x-steward-hardening": {
+          "sensitive": true,
+          "sensitivePrefix": "/v2/provider-actions",
+          "requestExpiry": {
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
+            "acceptedHeaders": [
+              "X-Steward-Request-Timestamp",
+              "X-Steward-Request-Expires-At"
+            ]
+          },
+          "authorizationSignature": {
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
+            "header": "X-Steward-Signature",
+            "schemes": [
+              "v1=hmac-sha256",
+              "p256=ecdsa-secp256r1"
+            ],
+            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+          },
+          "idempotency": {
+            "header": "Idempotency-Key",
+            "requiredForSignedRequests": true,
+            "replayStorage": "enabled when callers provide a key in a replay-safe authenticated context"
           }
         }
       }
@@ -12212,14 +12502,14 @@
           "sensitive": true,
           "sensitivePrefix": "/accounts",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -13385,14 +13675,14 @@
           "sensitive": true,
           "sensitivePrefix": "/accounts",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -13639,14 +13929,14 @@
           "sensitive": true,
           "sensitivePrefix": "/accounts",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -14806,14 +15096,14 @@
           "sensitive": true,
           "sensitivePrefix": "/accounts",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -15320,14 +15610,14 @@
           "sensitive": true,
           "sensitivePrefix": "/accounts",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -16491,14 +16781,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/accounts",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -17664,14 +17954,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/accounts",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -17918,14 +18208,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/accounts",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -19085,14 +19375,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/accounts",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -19599,14 +19889,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/accounts",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -20145,14 +20435,14 @@
           "sensitive": true,
           "sensitivePrefix": "/policies",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -20543,14 +20833,14 @@
           "sensitive": true,
           "sensitivePrefix": "/policies",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -21070,14 +21360,14 @@
           "sensitive": true,
           "sensitivePrefix": "/policies",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -21321,14 +21611,14 @@
           "sensitive": true,
           "sensitivePrefix": "/policies",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -21621,14 +21911,14 @@
           "sensitive": true,
           "sensitivePrefix": "/policies",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -22167,14 +22457,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/policies",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -22565,14 +22855,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/policies",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -23092,14 +23382,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/policies",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -23343,14 +23633,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/policies",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -23643,14 +23933,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/policies",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -24204,14 +24494,14 @@
           "sensitive": true,
           "sensitivePrefix": "/condition-sets",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -24731,14 +25021,14 @@
           "sensitive": true,
           "sensitivePrefix": "/condition-sets",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -24978,14 +25268,14 @@
           "sensitive": true,
           "sensitivePrefix": "/condition-sets",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -25539,14 +25829,14 @@
           "sensitive": true,
           "sensitivePrefix": "/condition-sets",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -25869,14 +26159,14 @@
           "sensitive": true,
           "sensitivePrefix": "/condition-sets",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -26395,14 +26685,14 @@
           "sensitive": true,
           "sensitivePrefix": "/condition-sets",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -26642,14 +26932,14 @@
           "sensitive": true,
           "sensitivePrefix": "/condition-sets",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -27203,14 +27493,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/condition-sets",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -27730,14 +28020,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/condition-sets",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -27977,14 +28267,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/condition-sets",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -28538,14 +28828,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/condition-sets",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -28868,14 +29158,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/condition-sets",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -29394,14 +29684,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/condition-sets",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -29641,14 +29931,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/condition-sets",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -30562,14 +30852,14 @@
           "sensitive": true,
           "sensitivePrefix": "/agents",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -31049,14 +31339,14 @@
           "sensitive": true,
           "sensitivePrefix": "/agents",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -31419,14 +31709,14 @@
           "sensitive": true,
           "sensitivePrefix": "/agents",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -32053,14 +32343,14 @@
           "sensitive": true,
           "sensitivePrefix": "/agents",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -32444,14 +32734,14 @@
           "sensitive": true,
           "sensitivePrefix": "/agents",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -32766,14 +33056,14 @@
           "sensitive": true,
           "sensitivePrefix": "/agents",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -33687,14 +33977,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/agents",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -34174,14 +34464,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/agents",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -34544,14 +34834,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/agents",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -35178,14 +35468,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/agents",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -35569,14 +35859,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/agents",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -35891,14 +36181,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/agents",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -36980,14 +37270,14 @@
           "sensitive": true,
           "sensitivePrefix": "/intents",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -37837,14 +38127,14 @@
           "sensitive": true,
           "sensitivePrefix": "/intents",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -38326,14 +38616,14 @@
           "sensitive": true,
           "sensitivePrefix": "/intents",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -38814,14 +39104,14 @@
           "sensitive": true,
           "sensitivePrefix": "/intents",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -39302,14 +39592,14 @@
           "sensitive": true,
           "sensitivePrefix": "/intents",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -39790,14 +40080,14 @@
           "sensitive": true,
           "sensitivePrefix": "/intents",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -40278,14 +40568,14 @@
           "sensitive": true,
           "sensitivePrefix": "/intents",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -40766,14 +41056,14 @@
           "sensitive": true,
           "sensitivePrefix": "/intents",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -45229,14 +45519,14 @@
           "sensitive": true,
           "sensitivePrefix": "/user",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -45557,14 +45847,14 @@
           "sensitive": true,
           "sensitivePrefix": "/user",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -46323,14 +46613,14 @@
           "sensitive": true,
           "sensitivePrefix": "/user",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -46726,14 +47016,14 @@
           "sensitive": true,
           "sensitivePrefix": "/user",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -48571,14 +48861,14 @@
           "sensitive": true,
           "sensitivePrefix": "/wallets/batch",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -48949,14 +49239,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/wallets/batch",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -49530,14 +49820,14 @@
           "sensitive": true,
           "sensitivePrefix": "/adapters",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -49944,14 +50234,14 @@
           "sensitive": true,
           "sensitivePrefix": "/adapters",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -50715,14 +51005,14 @@
           "sensitive": true,
           "sensitivePrefix": "/adapters",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -51049,14 +51339,14 @@
           "sensitive": true,
           "sensitivePrefix": "/adapters",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -51518,14 +51808,14 @@
           "sensitive": true,
           "sensitivePrefix": "/adapters",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -52089,14 +52379,14 @@
           "sensitive": true,
           "sensitivePrefix": "/adapters",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -52553,14 +52843,14 @@
           "sensitive": true,
           "sensitivePrefix": "/adapters",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -53111,14 +53401,14 @@
           "sensitive": true,
           "sensitivePrefix": "/adapters",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -53877,14 +54167,14 @@
           "sensitive": true,
           "sensitivePrefix": "/adapters",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -54211,14 +54501,14 @@
           "sensitive": true,
           "sensitivePrefix": "/adapters",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -54542,14 +54832,14 @@
           "sensitive": true,
           "sensitivePrefix": "/adapters",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -55095,14 +55385,14 @@
           "sensitive": true,
           "sensitivePrefix": "/adapters",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -55436,14 +55726,14 @@
           "sensitive": true,
           "sensitivePrefix": "/adapters",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -55781,14 +56071,14 @@
           "sensitive": true,
           "sensitivePrefix": "/adapters",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -56060,14 +56350,14 @@
           "sensitive": true,
           "sensitivePrefix": "/adapters",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -56396,14 +56686,14 @@
           "sensitive": true,
           "sensitivePrefix": "/adapters",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -57099,14 +57389,14 @@
           "sensitive": true,
           "sensitivePrefix": "/adapters",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -57680,14 +57970,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/adapters",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -58094,14 +58384,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/adapters",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -58865,14 +59155,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/adapters",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -59199,14 +59489,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/adapters",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -59668,14 +59958,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/adapters",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -60239,14 +60529,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/adapters",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -60703,14 +60993,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/adapters",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -61261,14 +61551,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/adapters",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -62027,14 +62317,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/adapters",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -62361,14 +62651,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/adapters",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -62692,14 +62982,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/adapters",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -63245,14 +63535,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/adapters",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -63586,14 +63876,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/adapters",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -63931,14 +64221,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/adapters",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -64210,14 +64500,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/adapters",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -64546,14 +64836,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/adapters",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -65249,14 +65539,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/adapters",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -65885,14 +66175,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/users",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -66233,14 +66523,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/users",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -66798,14 +67088,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/users",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -67131,14 +67421,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/users",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -67486,14 +67776,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/users",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -68071,14 +68361,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/users",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -69749,14 +70039,14 @@
           "sensitive": true,
           "sensitivePrefix": "/audit",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -70474,14 +70764,14 @@
           "sensitive": true,
           "sensitivePrefix": "/secrets",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -71095,14 +71385,14 @@
           "sensitive": true,
           "sensitivePrefix": "/secrets",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -71479,14 +71769,14 @@
           "sensitive": true,
           "sensitivePrefix": "/secrets",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -71731,14 +72021,14 @@
           "sensitive": true,
           "sensitivePrefix": "/secrets",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -72249,14 +72539,14 @@
           "sensitive": true,
           "sensitivePrefix": "/secrets",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -72501,14 +72791,14 @@
           "sensitive": true,
           "sensitivePrefix": "/secrets",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -72823,14 +73113,14 @@
           "sensitive": true,
           "sensitivePrefix": "/secrets",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -73451,14 +73741,14 @@
           "sensitive": true,
           "sensitivePrefix": "/webhooks",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -73848,14 +74138,14 @@
           "sensitive": true,
           "sensitivePrefix": "/webhooks",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -74104,14 +74394,14 @@
           "sensitive": true,
           "sensitivePrefix": "/webhooks",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -74377,14 +74667,14 @@
           "sensitive": true,
           "sensitivePrefix": "/webhooks",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -75274,14 +75564,14 @@
           "sensitive": true,
           "sensitivePrefix": "/webhooks",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -75594,14 +75884,14 @@
           "sensitive": true,
           "sensitivePrefix": "/webhooks",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -76402,14 +76692,14 @@
           "sensitive": true,
           "sensitivePrefix": "/approvals",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -76761,14 +77051,14 @@
           "sensitive": true,
           "sensitivePrefix": "/approvals",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -77354,14 +77644,14 @@
           "sensitive": true,
           "sensitivePrefix": "/approvals",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -78225,14 +78515,14 @@
           "sensitive": true,
           "sensitivePrefix": "/global-wallet",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -78865,14 +79155,14 @@
           "sensitive": true,
           "sensitivePrefix": "/global-wallet",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -79213,14 +79503,14 @@
           "sensitive": true,
           "sensitivePrefix": "/global-wallet",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -79631,14 +79921,14 @@
           "sensitive": true,
           "sensitivePrefix": "/global-wallet",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -79947,14 +80237,14 @@
           "sensitive": true,
           "sensitivePrefix": "/global-wallet",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -80464,14 +80754,14 @@
           "sensitive": true,
           "sensitivePrefix": "/trade",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -81007,14 +81297,14 @@
           "sensitive": true,
           "sensitivePrefix": "/trade",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -81438,14 +81728,14 @@
           "sensitive": true,
           "sensitivePrefix": "/trade",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -81782,14 +82072,14 @@
           "sensitive": true,
           "sensitivePrefix": "/trade",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -82110,14 +82400,14 @@
           "sensitive": true,
           "sensitivePrefix": "/trade",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -82508,14 +82798,14 @@
           "sensitive": true,
           "sensitivePrefix": "/trade",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -82843,14 +83133,14 @@
           "sensitive": true,
           "sensitivePrefix": "/trade",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -83180,14 +83470,14 @@
           "sensitive": true,
           "sensitivePrefix": "/trade",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -83532,14 +83822,14 @@
           "sensitive": true,
           "sensitivePrefix": "/trade",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -84049,14 +84339,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/trade",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -84592,14 +84882,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/trade",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -85023,14 +85313,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/trade",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -85367,14 +85657,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/trade",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -85695,14 +85985,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/trade",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -86093,14 +86383,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/trade",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -86428,14 +86718,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/trade",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -86765,14 +87055,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/trade",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -87117,14 +87407,14 @@
           "sensitive": true,
           "sensitivePrefix": "/v1/trade",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -88043,14 +88333,14 @@
           "sensitive": true,
           "sensitivePrefix": "/tenants",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -88532,14 +88822,14 @@
           "sensitive": true,
           "sensitivePrefix": "/tenants",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -88980,14 +89270,14 @@
           "sensitive": true,
           "sensitivePrefix": "/tenants",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -90088,14 +90378,14 @@
           "sensitive": true,
           "sensitivePrefix": "/tenants",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -90416,14 +90706,14 @@
           "sensitive": true,
           "sensitivePrefix": "/tenants",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -90966,14 +91256,14 @@
           "sensitive": true,
           "sensitivePrefix": "/platform",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -91277,14 +91567,14 @@
           "sensitive": true,
           "sensitivePrefix": "/platform",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -91524,14 +91814,14 @@
           "sensitive": true,
           "sensitivePrefix": "/platform",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -92204,14 +92494,14 @@
           "sensitive": true,
           "sensitivePrefix": "/platform",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -92471,14 +92761,14 @@
           "sensitive": true,
           "sensitivePrefix": "/platform",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -92808,14 +93098,14 @@
           "sensitive": true,
           "sensitivePrefix": "/platform",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -93506,14 +93796,14 @@
           "sensitive": true,
           "sensitivePrefix": "/platform",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -93815,14 +94105,14 @@
           "sensitive": true,
           "sensitivePrefix": "/platform",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -94206,14 +94496,14 @@
           "sensitive": true,
           "sensitivePrefix": "/platform",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -94765,14 +95055,14 @@
           "sensitive": true,
           "sensitivePrefix": "/platform",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -95571,14 +95861,14 @@
           "sensitive": true,
           "sensitivePrefix": "/user",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -96107,14 +96397,14 @@
           "sensitive": true,
           "sensitivePrefix": "/vault",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -96424,14 +96714,14 @@
           "sensitive": true,
           "sensitivePrefix": "/vault",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -96935,14 +97225,14 @@
           "sensitive": true,
           "sensitivePrefix": "/vault",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -97564,14 +97854,14 @@
           "sensitive": true,
           "sensitivePrefix": "/vault",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -98070,14 +98360,14 @@
           "sensitive": true,
           "sensitivePrefix": "/vault",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -98678,14 +98968,14 @@
           "sensitive": true,
           "sensitivePrefix": "/vault",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",
@@ -99249,14 +99539,14 @@
           "sensitive": true,
           "sensitivePrefix": "/vault",
           "requestExpiry": {
-            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+            "requiredWhen": "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
             "acceptedHeaders": [
               "X-Steward-Request-Timestamp",
               "X-Steward-Request-Expires-At"
             ]
           },
           "authorizationSignature": {
-            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+            "requiredWhen": "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
             "header": "X-Steward-Signature",
             "schemes": [
               "v1=hmac-sha256",

--- a/packages/api/src/__tests__/agent-admin-mutations-mfa.test.ts
+++ b/packages/api/src/__tests__/agent-admin-mutations-mfa.test.ts
@@ -1,0 +1,141 @@
+import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
+import { agents, closeDb, getDb, tenants } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { Hono } from "hono";
+import type { AppVariables } from "../services/context";
+
+/**
+ * SEC-209 regression: minting agent tokens, replacing an agent's vault policy
+ * set, and deleting agents are root-equivalent mutations. A bare tenant API
+ * key is no longer sufficient by default — they require a human owner/admin
+ * session with recent MFA. STEWARD_ALLOW_API_KEY_ADMIN_MUTATIONS=true is the
+ * explicit operator opt-in that restores the legacy api-key path.
+ */
+
+const TENANT_ID = `agent-admin-mutations-${Date.now()}`;
+const AGENT_ID = `agent-admin-mutations-agent-${Date.now()}`;
+
+setDefaultTimeout(30000);
+
+type AuthMode = "admin" | "admin-no-mfa" | "member" | "api-key";
+
+async function makeApp(authMode: AuthMode) {
+  const { agentRoutes } = await import("../routes/agents");
+  const app = new Hono<{ Variables: AppVariables }>();
+  app.use("*", async (c, next) => {
+    c.set("tenantId", TENANT_ID);
+    if (authMode === "api-key") {
+      c.set("authType", "api-key");
+    } else {
+      c.set("authType", "session-jwt");
+      c.set("tenantRole", authMode === "member" ? "member" : "owner");
+      c.set("userId", "admin-mutations-admin");
+      if (authMode === "admin") c.set("sessionMfaVerifiedAt", Date.now());
+    }
+    await next();
+  });
+  app.route("/agents", agentRoutes);
+  return app;
+}
+
+describe("agent admin mutations require human session + MFA (SEC-209)", () => {
+  beforeAll(async () => {
+    process.env.STEWARD_PGLITE_MEMORY = "true";
+    process.env.STEWARD_MASTER_PASSWORD = "agent-admin-mutations-master-password";
+    process.env.STEWARD_JWT_SECRET = "agent-admin-mutations-jwt-secret-with-enough-entropy";
+    process.env.STEWARD_AUDIT_HMAC_KEY = "agent-admin-mutations-audit-hmac-key-entropy";
+    const { db, client } = await createPGLiteDb("memory://");
+    setPGLiteOverride(db, async () => {
+      await client.close();
+    });
+    await getDb().insert(tenants).values({
+      id: TENANT_ID,
+      name: "Admin Mutations Tenant",
+      apiKeyHash: "hash",
+    });
+    await getDb().insert(agents).values({
+      id: AGENT_ID,
+      tenantId: TENANT_ID,
+      name: "Admin Mutations Agent",
+      walletAddress: "0x1234567890123456789012345678901234567890",
+    });
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    delete process.env.STEWARD_PGLITE_MEMORY;
+    delete process.env.STEWARD_MASTER_PASSWORD;
+    delete process.env.STEWARD_JWT_SECRET;
+    delete process.env.STEWARD_AUDIT_HMAC_KEY;
+    delete process.env.STEWARD_ALLOW_API_KEY_ADMIN_MUTATIONS;
+  });
+
+  it("rejects a bare tenant API key on all three root-equivalent mutations", async () => {
+    const app = await makeApp("api-key");
+
+    const tokenRes = await app.request(`/agents/${AGENT_ID}/token`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ expiresIn: "1h" }),
+    });
+    expect(tokenRes.status).toBe(403);
+
+    const policiesRes = await app.request(`/agents/${AGENT_ID}/policies`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify([]),
+    });
+    expect(policiesRes.status).toBe(403);
+
+    const deleteRes = await app.request(`/agents/${AGENT_ID}`, { method: "DELETE" });
+    expect(deleteRes.status).toBe(403);
+  });
+
+  it("rejects admin sessions without recent MFA", async () => {
+    const app = await makeApp("admin-no-mfa");
+    const res = await app.request(`/agents/${AGENT_ID}/token`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ expiresIn: "1h" }),
+    });
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toMatchObject({
+      ok: false,
+      error: "Agent token creation requires recent MFA verification",
+    });
+  });
+
+  it("rejects non-admin sessions", async () => {
+    const app = await makeApp("member");
+    const res = await app.request(`/agents/${AGENT_ID}`, { method: "DELETE" });
+    expect(res.status).toBe(403);
+  });
+
+  it("allows the explicit api-key opt-in (documented fully-root escape hatch)", async () => {
+    process.env.STEWARD_ALLOW_API_KEY_ADMIN_MUTATIONS = "true";
+    try {
+      const app = await makeApp("api-key");
+      const res = await app.request(`/agents/${AGENT_ID}/policies`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify([]),
+      });
+      expect(res.status).toBe(200);
+    } finally {
+      delete process.env.STEWARD_ALLOW_API_KEY_ADMIN_MUTATIONS;
+    }
+  });
+
+  it("allows an owner/admin session with recent MFA", async () => {
+    const app = await makeApp("admin");
+    const tokenRes = await app.request(`/agents/${AGENT_ID}/token`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ expiresIn: "1h" }),
+    });
+    expect(tokenRes.status).toBe(200);
+
+    const deleteRes = await app.request(`/agents/${AGENT_ID}`, { method: "DELETE" });
+    expect(deleteRes.status).toBe(200);
+  });
+});

--- a/packages/api/src/__tests__/agent-policy.test.ts
+++ b/packages/api/src/__tests__/agent-policy.test.ts
@@ -140,7 +140,9 @@ describe("agent trade policy", () => {
     expect(res.status).toBe(403);
     const body = (await res.json()) as { ok: boolean; error: string };
     expect(body.ok).toBe(false);
-    expect(body.error).toContain("Agent policy updates require agent JWT authentication");
+    expect(body.error).toContain(
+      "Agent policy updates require an agent token or an owner/admin session",
+    );
   });
 
   it("GET returns an existing policy row", async () => {
@@ -206,18 +208,68 @@ describe("agent trade policy", () => {
     expect(((await rejected.json()) as { error: string }).error).toContain(
       "allowBuilderPerps=true",
     );
+  });
 
-    const accepted = await putPolicy({
+  it("SEC-208: an agent token cannot widen allowedAssets or enable builder perps", async () => {
+    const widen = await putPolicy({
       allowedAssets: ["BTC", "xyz:SPCX"],
       allowBuilderPerps: true,
       reason: "explicitly allow Trade.xyz SPCX builder perp",
     });
-    expect(accepted.status).toBe(200);
-    const body = (await accepted.json()) as {
-      data: { policy: { allowedAssets: string[]; allowBuilderPerps: boolean } };
-    };
-    expect(body.data.policy.allowedAssets).toEqual(["BTC", "xyz:SPCX"]);
-    expect(body.data.policy.allowBuilderPerps).toBe(true);
+    expect(widen.status).toBe(403);
+    expect(((await widen.json()) as { error: string }).error).toContain(
+      "allowedAssets cannot be widened with an agent token",
+    );
+  });
+
+  it("SEC-208: an agent token cannot raise its own caps", async () => {
+    const raiseDaily = await putPolicy({ dailyCap: 10_000, reason: "raise my own daily cap" });
+    expect(raiseDaily.status).toBe(403);
+    expect(((await raiseDaily.json()) as { error: string }).error).toContain(
+      "dailyCap cannot be raised",
+    );
+
+    const raiseLeverage = await putPolicy({ leverageCap: 50, reason: "raise my own leverage" });
+    expect(raiseLeverage.status).toBe(403);
+    expect(((await raiseLeverage.json()) as { error: string }).error).toContain(
+      "leverageCap cannot be raised",
+    );
+
+    const enableBuilder = await putPolicy({
+      allowBuilderPerps: true,
+      reason: "flip builder perps on",
+    });
+    expect(enableBuilder.status).toBe(403);
+    expect(((await enableBuilder.json()) as { error: string }).error).toContain(
+      "allowBuilderPerps cannot be enabled with an agent token",
+    );
+  });
+
+  it("SEC-208: an agent token cannot create an initial policy looser than the defaults", async () => {
+    const res = await app.request(`/v1/agents/${missingAgentId}/policy`, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${await signAgentToken({ agentId: missingAgentId, tenantId, sub: `agent:${missingAgentId}` } as never, "1h")}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ dailyCap: 100_000, reason: "maximal initial policy" }),
+    });
+    // 10_000 exceeds the Layer-1 platform ceiling AND the defaults; the
+    // platform-ceiling 400 fires before the tighten-only 403.
+    expect(res.status).toBe(400);
+
+    const justAboveDefaults = await app.request(`/v1/agents/${missingAgentId}/policy`, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${await signAgentToken({ agentId: missingAgentId, tenantId, sub: `agent:${missingAgentId}` } as never, "1h")}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ dailyCap: 1_001, reason: "just above default" }),
+    });
+    expect(justAboveDefaults.status).toBe(403);
+    expect(((await justAboveDefaults.json()) as { error: string }).error).toContain(
+      "dailyCap cannot be raised above 1000",
+    );
   });
 
   it("emits an agent.policy.updated audit event with diff", async () => {
@@ -231,7 +283,7 @@ describe("agent trade policy", () => {
     expect(latest).toMatchObject({ tenantId, actorId: `agent:${agentId}`, resourceId: agentId });
     expect(latest?.metadata).toMatchObject({
       agentId,
-      reason: "explicitly allow Trade.xyz SPCX builder perp",
+      reason: "tighten risk",
     });
   });
 });

--- a/packages/api/src/__tests__/agent-route-scope.test.ts
+++ b/packages/api/src/__tests__/agent-route-scope.test.ts
@@ -244,41 +244,55 @@ describeWithDatabase("agent route scope enforcement", () => {
     expect(ids).toContain(AGENT_B);
   });
 
-  it("lets the tenant root API key mint an agent token without session MFA", async () => {
-    const res = await app.request(`/agents/${AGENT_A}/token`, {
-      method: "POST",
-      headers: {
-        "X-Steward-Tenant": TENANT_ID,
-        "X-Steward-Key": apiKey,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({}),
-    });
+  it("rejects a bare tenant API key for agent-token minting unless explicitly opted in (SEC-209)", async () => {
+    const mintWithApiKey = () =>
+      app.request(`/agents/${AGENT_A}/token`, {
+        method: "POST",
+        headers: {
+          "X-Steward-Tenant": TENANT_ID,
+          "X-Steward-Key": apiKey,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({}),
+      });
 
-    expect(res.status).toBe(200);
-    const body = (await res.json()) as {
-      ok: boolean;
-      data: { token: string; agentId: string; tenantId: string; scope: string; scopes: string[] };
-    };
-    expect(body.ok).toBe(true);
-    expect(body.data.token).toBeDefined();
-    expect(body.data.agentId).toBe(AGENT_A);
-    expect(body.data.tenantId).toBe(TENANT_ID);
-    expect(body.data.scope).toBe("agent");
-    expect(body.data.scopes).toEqual(["agent"]);
+    // SEC-209: minting agent tokens is root-equivalent — a bare tenant API key
+    // is no longer sufficient by default (human admin session + recent MFA).
+    const rejected = await mintWithApiKey();
+    expect(rejected.status).toBe(403);
 
-    const [audit] = await getDb()
-      .select({ actorType: auditEvents.actorType, actorId: auditEvents.actorId })
-      .from(auditEvents)
-      .where(
-        and(
-          eq(auditEvents.tenantId, TENANT_ID),
-          eq(auditEvents.resourceId, AGENT_A),
-          eq(auditEvents.action, "agent.token.create.authorized"),
-        ),
-      )
-      .orderBy(desc(auditEvents.seq));
-    expect(audit).toEqual({ actorType: "api-key", actorId: TENANT_ID });
+    // The explicit STEWARD_ALLOW_API_KEY_ADMIN_MUTATIONS=true opt-in restores
+    // the legacy machine path (documented as fully-root).
+    process.env.STEWARD_ALLOW_API_KEY_ADMIN_MUTATIONS = "true";
+    try {
+      const res = await mintWithApiKey();
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        ok: boolean;
+        data: { token: string; agentId: string; tenantId: string; scope: string; scopes: string[] };
+      };
+      expect(body.ok).toBe(true);
+      expect(body.data.token).toBeDefined();
+      expect(body.data.agentId).toBe(AGENT_A);
+      expect(body.data.tenantId).toBe(TENANT_ID);
+      expect(body.data.scope).toBe("agent");
+      expect(body.data.scopes).toEqual(["agent"]);
+
+      const [audit] = await getDb()
+        .select({ actorType: auditEvents.actorType, actorId: auditEvents.actorId })
+        .from(auditEvents)
+        .where(
+          and(
+            eq(auditEvents.tenantId, TENANT_ID),
+            eq(auditEvents.resourceId, AGENT_A),
+            eq(auditEvents.action, "agent.token.create.authorized"),
+          ),
+        )
+        .orderBy(desc(auditEvents.seq));
+      expect(audit).toEqual({ actorType: "api-key", actorId: TENANT_ID });
+    } finally {
+      delete process.env.STEWARD_ALLOW_API_KEY_ADMIN_MUTATIONS;
+    }
   });
 
   it("keeps owner and admin sessions authorized to mint agent tokens", async () => {

--- a/packages/api/src/__tests__/agent-trade-policy-admin.test.ts
+++ b/packages/api/src/__tests__/agent-trade-policy-admin.test.ts
@@ -1,0 +1,141 @@
+import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
+import { agentPolicies, agents, closeDb, getDb, tenants } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { eq } from "drizzle-orm";
+import { Hono } from "hono";
+import type { AppVariables } from "../services/context";
+
+/**
+ * SEC-208 regression: PUT /agents/:agentId/policy is the only writer of the
+ * trade-session ceiling table. The human-ceiling model requires an
+ * owner/admin session with recent MFA for unrestricted writes; agent tokens
+ * are tighten-only (covered in agent-policy.test.ts).
+ */
+
+const TENANT_ID = `agent-trade-policy-admin-${Date.now()}`;
+const AGENT_ID = `agent-trade-policy-admin-agent-${Date.now()}`;
+
+setDefaultTimeout(30000);
+
+type AuthMode = "admin" | "admin-no-mfa" | "member" | "api-key";
+
+async function makeApp(authMode: AuthMode = "admin") {
+  const { agentRoutes } = await import("../routes/agents");
+  const app = new Hono<{ Variables: AppVariables }>();
+  app.use("*", async (c, next) => {
+    c.set("tenantId", TENANT_ID);
+    if (authMode === "api-key") {
+      c.set("authType", "api-key");
+    } else {
+      c.set("authType", "session-jwt");
+      c.set("tenantRole", authMode === "member" ? "member" : "owner");
+      c.set("userId", "trade-policy-admin");
+      if (authMode === "admin") c.set("sessionMfaVerifiedAt", Date.now());
+    }
+    await next();
+  });
+  app.route("/agents", agentRoutes);
+  return app;
+}
+
+function putPolicy(app: Awaited<ReturnType<typeof makeApp>>, body: Record<string, unknown>) {
+  return app.request(`/agents/${AGENT_ID}/policy`, {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("agent trade policy admin path (SEC-208)", () => {
+  beforeAll(async () => {
+    process.env.STEWARD_PGLITE_MEMORY = "true";
+    process.env.STEWARD_MASTER_PASSWORD = "agent-trade-policy-admin-master-password";
+    process.env.STEWARD_AUDIT_HMAC_KEY = "agent-trade-policy-admin-audit-hmac-key-entropy";
+    const { db, client } = await createPGLiteDb("memory://");
+    setPGLiteOverride(db, async () => {
+      await client.close();
+    });
+    await getDb().insert(tenants).values({
+      id: TENANT_ID,
+      name: "Trade Policy Admin Tenant",
+      apiKeyHash: "hash",
+    });
+    await getDb().insert(agents).values({
+      id: AGENT_ID,
+      tenantId: TENANT_ID,
+      name: "Trade Policy Admin Agent",
+      walletAddress: "0x1234567890123456789012345678901234567890",
+    });
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    delete process.env.STEWARD_PGLITE_MEMORY;
+    delete process.env.STEWARD_MASTER_PASSWORD;
+    delete process.env.STEWARD_AUDIT_HMAC_KEY;
+  });
+
+  it("rejects a tenant API key with 403 (no machine self-escalation)", async () => {
+    const app = await makeApp("api-key");
+    const res = await putPolicy(app, { dailyCap: 5000, reason: "api-key raise" });
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects a non-admin session with 403", async () => {
+    const app = await makeApp("member");
+    const res = await putPolicy(app, { dailyCap: 5000, reason: "member raise" });
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects an admin session without recent MFA with 403", async () => {
+    const app = await makeApp("admin-no-mfa");
+    const res = await putPolicy(app, { dailyCap: 5000, reason: "no-mfa raise" });
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toMatchObject({
+      ok: false,
+      error: "Agent policy updates requires recent MFA verification",
+    });
+  });
+
+  it("allows an owner/admin session with recent MFA to loosen limits", async () => {
+    const app = await makeApp("admin");
+    const res = await putPolicy(app, {
+      dailyCap: 5000,
+      perOrderCap: 1000,
+      leverageCap: 20,
+      allowedAssets: ["BTC", "ETH", "SOL"],
+      allowedVenues: ["hyperliquid"],
+      allowBuilderPerps: true,
+      reason: "human-approved ceiling raise",
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      ok: boolean;
+      data: {
+        policy: {
+          dailyCap: number;
+          perOrderCap: number;
+          leverageCap: number;
+          allowedAssets: string[];
+          allowBuilderPerps: boolean;
+          updatedBy: string;
+        };
+      };
+    };
+    expect(body.ok).toBe(true);
+    expect(body.data.policy).toMatchObject({
+      dailyCap: 5000,
+      perOrderCap: 1000,
+      leverageCap: 20,
+      allowBuilderPerps: true,
+      updatedBy: "trade-policy-admin",
+    });
+    expect(body.data.policy.allowedAssets).toEqual(["BTC", "ETH", "SOL"]);
+
+    const [row] = await getDb()
+      .select()
+      .from(agentPolicies)
+      .where(eq(agentPolicies.agentId, AGENT_ID));
+    expect(row?.updatedBy).toBe("trade-policy-admin");
+  });
+});

--- a/packages/api/src/__tests__/discovery-routes.test.ts
+++ b/packages/api/src/__tests__/discovery-routes.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it, mock } from "bun:test";
 import {
   agentRegistrations,
   agents,
@@ -11,6 +11,15 @@ import {
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { eq } from "drizzle-orm";
 import { Hono } from "hono";
+
+// SEC-017: registration-time agent-card URL validation now resolves DNS and
+// fails closed on unresolvable hosts. The tests below intentionally use
+// `.invalid` hostnames as *syntactically* valid public-looking URLs, so mock
+// the resolver to a public answer — the string-level rejections in
+// "rejects unsafe ERC-8004 agent card URLs" never reach DNS.
+mock.module("node:dns/promises", () => ({
+  lookup: async () => [{ address: "93.184.216.34", family: 4 }],
+}));
 
 describe("public discovery routes", () => {
   let discoveryRoutes: typeof import("../routes/erc8004").discoveryRoutes;

--- a/packages/api/src/__tests__/middleware-security-hardening.test.ts
+++ b/packages/api/src/__tests__/middleware-security-hardening.test.ts
@@ -59,9 +59,11 @@ describe("middleware security hardening", () => {
   });
 
   it("applies Bun runtime gates before Hono route dispatch", () => {
-    expect(indexSource).toContain("function runtimeGate(request: Request)");
     expect(indexSource).toContain(
-      "fetch: (request: Request) => runtimeGate(request) ?? app.fetch(request)",
+      "function runtimeGate(request: Request, peerAddress: string | null)",
+    );
+    expect(indexSource).toContain(
+      "runtimeGate(request, server.requestIP(request)?.address ?? null) ?? app.fetch(request)",
     );
     expect(indexSource).not.toContain('app.use("*", async (c, next) => {');
   });

--- a/packages/api/src/__tests__/redis-rate-limit-fail-closed.test.ts
+++ b/packages/api/src/__tests__/redis-rate-limit-fail-closed.test.ts
@@ -105,4 +105,35 @@ describe("Redis rate-limit wrappers", () => {
     expect(result.remaining).toBe(Infinity);
     expect(checkRateLimitMock).not.toHaveBeenCalled();
   });
+
+  it("SEC-016: fails closed when Redis is configured but unavailable at boot", async () => {
+    // REDIS_URL set (production posture) but the connection fails: the helpers
+    // must NOT silently disable rate limiting.
+    pingMock.mockImplementation(async () => {
+      throw new Error("connect ECONNREFUSED");
+    });
+    expect(await redisMiddleware.initRedis()).toBe(false);
+
+    const proxyResult = await redisMiddleware.checkProxyRateLimit(
+      "agent-proxy",
+      "api.example.test",
+      60_000,
+      10,
+    );
+    expect(proxyResult).toEqual({ allowed: false, remaining: 0, resetMs: 60_000 });
+
+    const agentResult = await redisMiddleware.checkAgentRateLimit("agent-vault", 60_000, 10);
+    expect(agentResult).toEqual({ allowed: false, remaining: 0, resetMs: 60_000 });
+    expect(checkRateLimitMock).not.toHaveBeenCalled();
+  });
+
+  it("SEC-016: keeps the unconfigured local-development agent path permissive", async () => {
+    delete process.env.REDIS_URL;
+    await redisMiddleware.shutdownRedis();
+
+    const result = await redisMiddleware.checkAgentRateLimit("agent-vault", 60_000, 10);
+
+    expect(result.allowed).toBe(true);
+    expect(result.remaining).toBe(Infinity);
+  });
 });

--- a/packages/api/src/__tests__/request-guards-mounted.test.ts
+++ b/packages/api/src/__tests__/request-guards-mounted.test.ts
@@ -1,0 +1,101 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { closeDb } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+
+/**
+ * SEC-010 / SEC-150 regression: the request-expiry + authorization-signature
+ * guards must be MOUNTED on the real app (they were unmounted dead code while
+ * /openapi.json and the tenant security checklist claimed enforcement), and
+ * the sensitive-path prefix list must cover the key-material / money-movement
+ * surfaces that were missing.
+ *
+ * Default posture is verify-when-present: requests WITHOUT guard headers flow
+ * through to route auth, but a request carrying stale freshness or an invalid
+ * signature header fails closed.
+ */
+describe("mounted request guards (SEC-010/SEC-150)", () => {
+  let app: Awaited<typeof import("../app")>["app"];
+
+  beforeAll(async () => {
+    process.env.STEWARD_PGLITE_MEMORY = "true";
+    process.env.STEWARD_MASTER_PASSWORD = "mounted-guards-master-password";
+    process.env.STEWARD_AUDIT_HMAC_KEY = "mounted-guards-audit-hmac-key-with-enough-entropy";
+    process.env.STEWARD_REQUEST_SIGNING_SECRETS = "mounted-guards-signing-secret";
+    const { db, client } = await createPGLiteDb("memory://");
+    setPGLiteOverride(db, async () => {
+      await client.close();
+    });
+    ({ app } = await import("../app"));
+  }, 120_000);
+
+  afterAll(async () => {
+    await closeDb();
+    delete process.env.STEWARD_PGLITE_MEMORY;
+    delete process.env.STEWARD_MASTER_PASSWORD;
+    delete process.env.STEWARD_AUDIT_HMAC_KEY;
+    delete process.env.STEWARD_REQUEST_SIGNING_SECRETS;
+  });
+
+  function stalePost(path: string, headers: Record<string, string> = {}) {
+    return app.request(path, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-steward-request-timestamp": String(Math.floor(Date.now() / 1000) - 3600),
+        ...headers,
+      },
+      body: "{}",
+    });
+  }
+
+  it("rejects stale freshness headers on sensitive mutating routes", async () => {
+    const response = await stalePost("/vault/agent-1/sign");
+    expect(response.status).toBe(408);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: "Request timestamp is stale",
+    });
+  });
+
+  it("rejects invalid request signatures on sensitive mutating routes", async () => {
+    const response = await app.request("/vault/agent-1/sign", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-steward-request-timestamp": String(Math.floor(Date.now() / 1000)),
+        "x-steward-signature": `v1=${"0".repeat(64)}`,
+        "idempotency-key": "mounted-guards-invalid-signature",
+      },
+      body: "{}",
+    });
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: "Invalid request signature",
+    });
+  });
+
+  it("admits unsigned sensitive requests through to route auth (verify-when-present)", async () => {
+    const response = await app.request("/vault/agent-1/sign", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    // Reaches tenantAuth (403), NOT a guard rejection (400/408/401) — unsigned
+    // browser/SDK clients keep working until an operator opts into strict mode.
+    expect(response.status).toBe(403);
+  });
+
+  it("covers the previously-missing sensitive prefixes (SEC-150)", async () => {
+    for (const path of [
+      "/v1/kms/keys/key-1/decrypt",
+      "/v2/provider-actions/action-1/execute",
+      "/dashboard/some-mutation",
+      "/agent-enroll",
+      "/v1/agent-enroll",
+    ]) {
+      const response = await stalePost(path);
+      expect(response.status).toBe(408);
+    }
+  });
+});

--- a/packages/api/src/__tests__/request-logger.test.ts
+++ b/packages/api/src/__tests__/request-logger.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test";
+import { Hono } from "hono";
+import { requestLogger } from "../middleware/request-logger";
+
+/**
+ * SEC-015 regression: the global request logger must never write query
+ * strings to logs — live one-time credentials flow through them
+ * (`GET /auth/callback/email?token=…`, OAuth `?code=…&state=…`).
+ */
+describe("requestLogger (SEC-015)", () => {
+  it("logs method + path + status but never the query string", async () => {
+    const lines: string[] = [];
+    const app = new Hono();
+    app.use("*", requestLogger((line) => lines.push(line)));
+    app.get("/auth/callback/email", (c) => c.json({ ok: true }));
+
+    const res = await app.request("/auth/callback/email?token=super-secret-one-time-token");
+    expect(res.status).toBe(200);
+
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toBe("<-- GET /auth/callback/email");
+    expect(lines[1]).toMatch(/^--> GET \/auth\/callback\/email 200 /);
+    for (const line of lines) {
+      expect(line).not.toContain("super-secret-one-time-token");
+      expect(line).not.toContain("?");
+    }
+  });
+
+  it("defaults to console.log when no sink is provided", async () => {
+    const app = new Hono();
+    app.use("*", requestLogger());
+    app.get("/x", (c) => c.json({ ok: true }));
+    const res = await app.request("/x?a=1");
+    expect(res.status).toBe(200);
+  });
+});

--- a/packages/api/src/__tests__/request-logger.test.ts
+++ b/packages/api/src/__tests__/request-logger.test.ts
@@ -11,7 +11,10 @@ describe("requestLogger (SEC-015)", () => {
   it("logs method + path + status but never the query string", async () => {
     const lines: string[] = [];
     const app = new Hono();
-    app.use("*", requestLogger((line) => lines.push(line)));
+    app.use(
+      "*",
+      requestLogger((line) => lines.push(line)),
+    );
     app.get("/auth/callback/email", (c) => c.json({ ok: true }));
 
     const res = await app.request("/auth/callback/email?token=super-secret-one-time-token");

--- a/packages/api/src/__tests__/runtime-gate.test.ts
+++ b/packages/api/src/__tests__/runtime-gate.test.ts
@@ -14,14 +14,14 @@ describe("resolveClientIp (SEC-014)", () => {
   }
 
   it("ignores X-Forwarded-For/X-Real-IP entirely with zero trusted proxy hops", () => {
-    expect(
-      resolveClientIp(headers({ "x-forwarded-for": "1.2.3.4" }), "10.0.0.9", 0),
-    ).toBe("10.0.0.9");
+    expect(resolveClientIp(headers({ "x-forwarded-for": "1.2.3.4" }), "10.0.0.9", 0)).toBe(
+      "10.0.0.9",
+    );
     expect(resolveClientIp(headers({ "x-real-ip": "1.2.3.4" }), "10.0.0.9", 0)).toBe("10.0.0.9");
     // So rotating a spoofed header cannot mint fresh rate-limit identities:
-    expect(
-      resolveClientIp(headers({ "x-forwarded-for": "5.6.7.8" }), "10.0.0.9", 0),
-    ).toBe("10.0.0.9");
+    expect(resolveClientIp(headers({ "x-forwarded-for": "5.6.7.8" }), "10.0.0.9", 0)).toBe(
+      "10.0.0.9",
+    );
   });
 
   it("falls back to a shared unknown bucket when no peer is available", () => {

--- a/packages/api/src/__tests__/runtime-gate.test.ts
+++ b/packages/api/src/__tests__/runtime-gate.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "bun:test";
+import { InMemoryRateLimiter, resolveClientIp } from "../services/runtime-gate";
+
+/**
+ * SEC-014 regression: the global rate limiter must not key on spoofable
+ * client headers. Client-supplied X-Forwarded-For / X-Real-IP are ignored
+ * unless they arrive through a declared number of trusted proxy hops, and the
+ * in-memory key space is capped (fail closed) so flooding unique identities
+ * cannot grow it without bound.
+ */
+describe("resolveClientIp (SEC-014)", () => {
+  function headers(init: Record<string, string>): Headers {
+    return new Headers(init);
+  }
+
+  it("ignores X-Forwarded-For/X-Real-IP entirely with zero trusted proxy hops", () => {
+    expect(
+      resolveClientIp(headers({ "x-forwarded-for": "1.2.3.4" }), "10.0.0.9", 0),
+    ).toBe("10.0.0.9");
+    expect(resolveClientIp(headers({ "x-real-ip": "1.2.3.4" }), "10.0.0.9", 0)).toBe("10.0.0.9");
+    // So rotating a spoofed header cannot mint fresh rate-limit identities:
+    expect(
+      resolveClientIp(headers({ "x-forwarded-for": "5.6.7.8" }), "10.0.0.9", 0),
+    ).toBe("10.0.0.9");
+  });
+
+  it("falls back to a shared unknown bucket when no peer is available", () => {
+    expect(resolveClientIp(headers({}), null, 0)).toBe("unknown");
+    expect(resolveClientIp(headers({ "x-forwarded-for": "1.2.3.4" }), null, 0)).toBe("unknown");
+  });
+
+  it("takes the entry N trusted hops from the right, ignoring spoofed prefixes", () => {
+    // client(1.1.1.1) -> proxy1 -> proxy2 -> server, attacker-controlled
+    // XFF prefix preserved by append-mode proxies.
+    const spoofed = headers({ "x-forwarded-for": "9.9.9.9, 8.8.8.8, 1.1.1.1, 2.2.2.2" });
+    expect(resolveClientIp(spoofed, "3.3.3.3", 2)).toBe("1.1.1.1");
+    expect(resolveClientIp(spoofed, "3.3.3.3", 1)).toBe("2.2.2.2");
+  });
+
+  it("uses the leftmost entry when the chain is shorter than the configured trust", () => {
+    const h = headers({ "x-forwarded-for": "1.1.1.1" });
+    expect(resolveClientIp(h, "2.2.2.2", 3)).toBe("1.1.1.1");
+  });
+
+  it("honors X-Real-IP only through trusted proxies", () => {
+    expect(resolveClientIp(headers({ "x-real-ip": "1.2.3.4" }), "10.0.0.9", 1)).toBe("1.2.3.4");
+  });
+});
+
+describe("InMemoryRateLimiter (SEC-014)", () => {
+  it("limits after maxRequests within the window and resets afterwards", () => {
+    const limiter = new InMemoryRateLimiter(2, 60_000);
+    const now = Date.now();
+    expect(limiter.check("ip-a", now)).toEqual({ limited: false });
+    expect(limiter.check("ip-a", now)).toEqual({ limited: false });
+    const third = limiter.check("ip-a", now);
+    expect(third.limited).toBe(true);
+    expect(limiter.check("ip-b", now)).toEqual({ limited: false });
+    // Window rolls over.
+    expect(limiter.check("ip-a", now + 61_000)).toEqual({ limited: false });
+  });
+
+  it("caps the key space and fails closed when full", () => {
+    const limiter = new InMemoryRateLimiter(100, 60_000, 3);
+    const now = Date.now();
+    expect(limiter.check("a", now).limited).toBe(false);
+    expect(limiter.check("b", now).limited).toBe(false);
+    expect(limiter.check("c", now).limited).toBe(false);
+    // Fourth distinct identity within the window: rejected rather than
+    // growing the map (flooding unique identities cannot cause unbounded
+    // memory pressure).
+    const verdict = limiter.check("d", now);
+    expect(verdict.limited).toBe(true);
+    expect(limiter.size).toBe(3);
+    // After the window expires the sweep frees space again.
+    expect(limiter.check("d", now + 61_000).limited).toBe(false);
+  });
+});

--- a/packages/api/src/__tests__/webhook-dispatch.test.ts
+++ b/packages/api/src/__tests__/webhook-dispatch.test.ts
@@ -110,6 +110,14 @@ mock.module("@stwd/webhooks", () => ({
   isEncryptedWebhookSecret,
 }));
 
+// SEC-017 delivery-time re-validation resolves the destination hostname via
+// node:dns/promises. Mock it to an instant public answer so the dispatch chain
+// stays microtask-only (a real DNS round-trip would outlive the tests'
+// setTimeout(0) flush) while still exercising the re-validation path.
+mock.module("node:dns/promises", () => ({
+  lookup: async () => [{ address: "93.184.216.34", family: 4 }],
+}));
+
 const { dispatchWebhook } = await import("../services/webhook-dispatch");
 const { webhookEventRegistry } = await import("../services/webhook-events");
 

--- a/packages/api/src/__tests__/webhook-url-validation.test.ts
+++ b/packages/api/src/__tests__/webhook-url-validation.test.ts
@@ -79,9 +79,10 @@ describe("validateWebhookUrlResolved (SEC-017)", () => {
   const publicAnswer = [{ address: "93.184.216.34", family: 4 }];
 
   it("rejects a public hostname that resolves to a private address (nip.io style)", async () => {
-    const result = await validateWebhookUrlResolved("https://169.254.169.254.nip.io/hook", async () => [
-      { address: "169.254.169.254", family: 4 },
-    ]);
+    const result = await validateWebhookUrlResolved(
+      "https://169.254.169.254.nip.io/hook",
+      async () => [{ address: "169.254.169.254", family: 4 }],
+    );
     expect(result).toBe("url host must resolve to a public address");
   });
 

--- a/packages/api/src/__tests__/webhook-url-validation.test.ts
+++ b/packages/api/src/__tests__/webhook-url-validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { validateWebhookUrl } from "../services/webhook-url";
+import { validateWebhookUrl, validateWebhookUrlResolved } from "../services/webhook-url";
 
 describe("webhook URL validation", () => {
   it("rejects IPv4-mapped IPv6 private addresses in dotted and hex forms", () => {
@@ -72,5 +72,62 @@ describe("webhook URL validation", () => {
     ]) {
       expect(validateWebhookUrl(url)).toBe("url host must be public");
     }
+  });
+});
+
+describe("validateWebhookUrlResolved (SEC-017)", () => {
+  const publicAnswer = [{ address: "93.184.216.34", family: 4 }];
+
+  it("rejects a public hostname that resolves to a private address (nip.io style)", async () => {
+    const result = await validateWebhookUrlResolved("https://169.254.169.254.nip.io/hook", async () => [
+      { address: "169.254.169.254", family: 4 },
+    ]);
+    expect(result).toBe("url host must resolve to a public address");
+  });
+
+  it("rejects when ANY DNS answer is non-public (rebinding hedge)", async () => {
+    const result = await validateWebhookUrlResolved("https://hooks.example.com/hook", async () => [
+      { address: "93.184.216.34", family: 4 },
+      { address: "10.0.0.7", family: 4 },
+    ]);
+    expect(result).toBe("url host must resolve to a public address");
+  });
+
+  it("rejects IPv6 answers that embed private IPv4 targets", async () => {
+    const result = await validateWebhookUrlResolved("https://hooks.example.com/hook", async () => [
+      { address: "::ffff:127.0.0.1", family: 6 },
+    ]);
+    expect(result).toBe("url host must resolve to a public address");
+  });
+
+  it("fails closed when the hostname cannot be resolved", async () => {
+    const result = await validateWebhookUrlResolved("https://gone.example.com/hook", async () => {
+      throw new Error("ENOTFOUND");
+    });
+    expect(result).toBe("url host could not be resolved");
+
+    const empty = await validateWebhookUrlResolved("https://gone.example.com/hook", async () => []);
+    expect(empty).toBe("url host could not be resolved");
+  });
+
+  it("accepts a public hostname with only public answers", async () => {
+    const result = await validateWebhookUrlResolved(
+      "https://hooks.example.com/hook",
+      async () => publicAnswer,
+    );
+    expect(result).toBeNull();
+  });
+
+  it("keeps string-level rejections and skips DNS for IP literals", async () => {
+    expect(await validateWebhookUrlResolved("https://10.0.0.1/hook")).toBe(
+      "url host must be public",
+    );
+    let called = false;
+    const literal = await validateWebhookUrlResolved("https://93.184.216.34/hook", async () => {
+      called = true;
+      return [];
+    });
+    expect(literal).toBeNull();
+    expect(called).toBe(false);
   });
 });

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -39,8 +39,10 @@ import { platformAuthMiddleware } from "@stwd/auth";
 import { Hono } from "hono";
 import { bodyLimit } from "hono/body-limit";
 import { logger } from "hono/logger";
+import { authorizationSignature } from "./middleware/authorization-signature";
 import { correlationId } from "./middleware/correlation";
 import { idempotencyMiddleware } from "./middleware/idempotency";
+import { requestExpiry } from "./middleware/request-expiry";
 import { securityHeaders } from "./middleware/security-headers";
 import { tenantCors } from "./middleware/tenant-cors";
 import { getOpenApiSpec } from "./openapi";
@@ -127,6 +129,23 @@ export function createApp(): Hono<{ Variables: AppVariables }> {
       onError: (c) =>
         c.json<ApiResponse>({ ok: false, error: "Request body too large (max 1MB)" }, 413),
     }),
+  );
+
+  // ─── Request freshness + signature guards (SEC-010) ────────────────────────
+  // Mounted globally so freshness headers and request signatures are actually
+  // verified on every sensitive mutating route (they were unmounted dead code
+  // while /openapi.json and the tenant security checklist claimed enforcement).
+  // Default posture is verify-when-present: a request carrying stale/invalid
+  // freshness or signature headers fails closed, but the headers are not
+  // required unless the operator opts in via STEWARD_REQUIRE_REQUEST_EXPIRY /
+  // STEWARD_REQUIRE_AUTH_SIGNATURE. The env opt-in (not NODE_ENV) drives the
+  // strict mode so browser/unsigned SDK clients keep working until an operator
+  // has rolled out signing clients. Mounted here (phase 1) so they always run
+  // BEFORE the idempotency middleware (phase 2).
+  app.use("*", requestExpiry({ required: process.env.STEWARD_REQUIRE_REQUEST_EXPIRY === "true" }));
+  app.use(
+    "*",
+    authorizationSignature({ required: process.env.STEWARD_REQUIRE_AUTH_SIGNATURE === "true" }),
   );
 
   // ─── Auth middleware per route group ────────────────────────────────────────

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -38,11 +38,11 @@
 import { platformAuthMiddleware } from "@stwd/auth";
 import { Hono } from "hono";
 import { bodyLimit } from "hono/body-limit";
-import { logger } from "hono/logger";
 import { authorizationSignature } from "./middleware/authorization-signature";
 import { correlationId } from "./middleware/correlation";
 import { idempotencyMiddleware } from "./middleware/idempotency";
 import { requestExpiry } from "./middleware/request-expiry";
+import { requestLogger } from "./middleware/request-logger";
 import { securityHeaders } from "./middleware/security-headers";
 import { tenantCors } from "./middleware/tenant-cors";
 import { getOpenApiSpec } from "./openapi";
@@ -119,7 +119,9 @@ export function createApp(): Hono<{ Variables: AppVariables }> {
 
   app.use("*", securityHeaders);
   app.use("*", tenantCors);
-  app.use("*", logger());
+  // SEC-015: query-stripping logger — hono's logger() would write one-time
+  // auth tokens in callback query strings to stdout.
+  app.use("*", requestLogger());
   app.use("*", correlationId);
 
   app.use(

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -29,6 +29,12 @@ import {
 import { startProviderReservationReconciliationScheduler } from "./services/provider-reservation-reconciliation-scheduler";
 import { startRetentionScheduler } from "./services/retention";
 import { startTransactionReceiptPollingScheduler } from "./services/transaction-receipt-poller";
+import {
+  InMemoryRateLimiter,
+  parseNonNegativeInt,
+  parsePositiveInt,
+  resolveClientIp,
+} from "./services/runtime-gate";
 import { configuredVaultStartupLogLine, getConfiguredVault } from "./services/vault-factory";
 import { startWebhookRetryScheduler } from "./services/webhook-retry-scheduler";
 
@@ -53,15 +59,25 @@ const app = await composeApp();
 //
 // NOT used by the Workers entry — Workers should rely on the Redis-backed
 // sliding-window rate limiter (or a Workers-native KV-backed alternative).
+//
+// SEC-014: the limiter keys on the socket peer unless the operator declares
+// STEWARD_TRUSTED_PROXY_HOPS > 0, in which case the client IP is derived from
+// the rightmost trusted XFF entries (client-supplied XFF prefixes are never
+// trusted). The key space is capped and fails closed when full.
 
-const requestLog = new Map<string, { count: number; resetAt: number }>();
+const trustedProxyHops = parseNonNegativeInt(process.env.STEWARD_TRUSTED_PROXY_HOPS, 0);
+const rateLimiter = new InMemoryRateLimiter(
+  RATE_LIMIT_MAX_REQUESTS,
+  RATE_LIMIT_WINDOW_MS,
+  parsePositiveInt(process.env.STEWARD_RATE_LIMIT_MAX_KEYS, 10_000),
+);
 let isShuttingDown = false;
 let cancelRetention: (() => void) | undefined;
 let cancelProviderReservationReconciliation: (() => void) | undefined;
 let cancelTransactionReceiptPolling: (() => void) | undefined;
 let cancelWebhookRetryScheduler: (() => void) | undefined;
 
-function runtimeGate(request: Request): Response | null {
+function runtimeGate(request: Request, peerAddress: string | null): Response | null {
   const url = new URL(request.url);
   if (url.pathname === "/health" || url.pathname === "/ready") return null;
 
@@ -71,35 +87,22 @@ function runtimeGate(request: Request): Response | null {
     });
   }
 
-  const forwardedFor = request.headers.get("x-forwarded-for");
-  const ip = forwardedFor?.split(",")[0]?.trim() || request.headers.get("x-real-ip") || "unknown";
-  const now = Date.now();
-  const current = requestLog.get(ip);
-
-  if (!current || current.resetAt <= now) {
-    requestLog.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
-    return null;
-  }
-
-  if (current.count >= RATE_LIMIT_MAX_REQUESTS) {
-    return Response.json({ ok: false, error: "Rate limit exceeded" } satisfies ApiResponse, {
-      status: 429,
-      headers: {
-        "Retry-After": Math.ceil((current.resetAt - now) / 1000).toString(),
+  const ip = resolveClientIp(request.headers, peerAddress, trustedProxyHops);
+  const verdict = rateLimiter.check(ip);
+  if (verdict.limited) {
+    return Response.json(
+      { ok: false, error: "Rate limit exceeded" } satisfies ApiResponse,
+      {
+        status: 429,
+        headers: { "Retry-After": verdict.retryAfterSeconds.toString() },
       },
-    });
+    );
   }
-
-  current.count += 1;
-  requestLog.set(ip, current);
   return null;
 }
 
 const requestLogCleanupTimer = setInterval(() => {
-  const now = Date.now();
-  for (const [ip, entry] of requestLog.entries()) {
-    if (entry.resetAt <= now) requestLog.delete(ip);
-  }
+  rateLimiter.sweep();
 }, RATE_LIMIT_WINDOW_MS);
 
 // ─── /ready — deep readiness probe ───────────────────────────────────────────
@@ -324,7 +327,8 @@ const BIND_HOST = process.env.STEWARD_BIND_HOST || "127.0.0.1";
 const serverOptions = {
   hostname: BIND_HOST,
   port: PORT,
-  fetch: (request: Request) => runtimeGate(request) ?? app.fetch(request),
+  fetch: (request: Request, server: { requestIP(req: Request): { address: string } | null }) =>
+    runtimeGate(request, server.requestIP(request)?.address ?? null) ?? app.fetch(request),
   idleTimeout: 30,
 } as Parameters<typeof Bun.serve>[0] & { hostname?: string };
 
@@ -342,7 +346,7 @@ const shutdown = async (signal: string) => {
   if (cancelProviderReservationReconciliation) cancelProviderReservationReconciliation();
   if (cancelTransactionReceiptPolling) cancelTransactionReceiptPolling();
   if (cancelWebhookRetryScheduler) cancelWebhookRetryScheduler();
-  requestLog.clear();
+  rateLimiter.clear();
 
   try {
     await Promise.all([closeDb(), shutdownRedis()]);

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -28,13 +28,13 @@ import {
 } from "./services/context";
 import { startProviderReservationReconciliationScheduler } from "./services/provider-reservation-reconciliation-scheduler";
 import { startRetentionScheduler } from "./services/retention";
-import { startTransactionReceiptPollingScheduler } from "./services/transaction-receipt-poller";
 import {
   InMemoryRateLimiter,
   parseNonNegativeInt,
   parsePositiveInt,
   resolveClientIp,
 } from "./services/runtime-gate";
+import { startTransactionReceiptPollingScheduler } from "./services/transaction-receipt-poller";
 import { configuredVaultStartupLogLine, getConfiguredVault } from "./services/vault-factory";
 import { startWebhookRetryScheduler } from "./services/webhook-retry-scheduler";
 
@@ -90,13 +90,10 @@ function runtimeGate(request: Request, peerAddress: string | null): Response | n
   const ip = resolveClientIp(request.headers, peerAddress, trustedProxyHops);
   const verdict = rateLimiter.check(ip);
   if (verdict.limited) {
-    return Response.json(
-      { ok: false, error: "Rate limit exceeded" } satisfies ApiResponse,
-      {
-        status: 429,
-        headers: { "Retry-After": verdict.retryAfterSeconds.toString() },
-      },
-    );
+    return Response.json({ ok: false, error: "Rate limit exceeded" } satisfies ApiResponse, {
+      status: 429,
+      headers: { "Retry-After": verdict.retryAfterSeconds.toString() },
+    });
   }
   return null;
 }

--- a/packages/api/src/middleware/redis.ts
+++ b/packages/api/src/middleware/redis.ts
@@ -116,7 +116,13 @@ export async function checkAgentRateLimit(
   windowMs: number,
   maxRequests: number,
 ): Promise<RateLimitResult> {
-  if (!redisAvailable) return PERMISSIVE_RATE_LIMIT;
+  // Redis not available: only skip enforcement when Redis was never configured
+  // (documented dev path). If Redis IS configured (production), an unavailable
+  // backend must fail CLOSED — mirroring checkAgentSpendLimit (SEC-016).
+  if (!redisAvailable) {
+    if (!isRedisConfigured()) return PERMISSIVE_RATE_LIMIT;
+    return { allowed: false, remaining: 0, resetMs: 60_000 };
+  }
 
   try {
     const key = `ratelimit:vault:${agentId}:${windowMs}`;
@@ -141,7 +147,12 @@ export async function checkProxyRateLimit(
   windowMs: number,
   maxRequests: number,
 ): Promise<RateLimitResult> {
-  if (!redisAvailable) return PERMISSIVE_RATE_LIMIT;
+  // Same fail-closed posture as checkAgentRateLimit (SEC-016): permissive only
+  // when Redis was never configured; a configured-but-down backend denies.
+  if (!redisAvailable) {
+    if (!isRedisConfigured()) return PERMISSIVE_RATE_LIMIT;
+    return { allowed: false, remaining: 0, resetMs: 60_000 };
+  }
 
   try {
     const key = `ratelimit:proxy:${agentId}:${host}:${windowMs}`;

--- a/packages/api/src/middleware/request-logger.ts
+++ b/packages/api/src/middleware/request-logger.ts
@@ -1,0 +1,54 @@
+/**
+ * request-logger.ts — drop-in replacement for hono's `logger()` that never
+ * writes the request QUERY STRING to logs.
+ *
+ * SEC-015: hono's global logger records `url.slice(url.indexOf("/", 8))` —
+ * the full path INCLUDING the query string. Live one-time credentials flow
+ * through query strings on GET auth callbacks mounted in this app
+ * (`GET /auth/callback/email?token=…`, `GET /auth/oauth/:provider/callback
+ * ?code=…&state=…`), so anyone with log access (aggregators, container logs)
+ * could replay an unconsumed magic-link token to mint a session. This logger
+ * keeps hono's output format but logs only the path (`getPath` strips the
+ * query), so credentials in query strings never reach stdout.
+ */
+
+import { createMiddleware } from "hono/factory";
+import { getPath } from "hono/utils/url";
+
+const humanize = (times: string[]) => {
+  const [delimiter, separator] = [",", "."];
+  const orderTimes = times.map((v) => v.replace(/(\d)(?=(\d\d\d)+(?!\d))/g, `$1${delimiter}`));
+  return orderTimes.join(separator);
+};
+
+const time = (start: number) => {
+  const delta = Date.now() - start;
+  return humanize([delta < 1e3 ? `${delta}ms` : `${Math.round(delta / 1e3)}s`]);
+};
+
+function log(fn: (message: string) => void, prefix: string, method: string, path: string) {
+  fn(`${prefix} ${method} ${path}`);
+}
+
+function logResponse(
+  fn: (message: string) => void,
+  prefix: string,
+  method: string,
+  path: string,
+  status: number,
+  elapsed: string,
+) {
+  fn(`${prefix} ${method} ${path} ${status} ${elapsed}`);
+}
+
+export const requestLogger = (fn: (message: string) => void = console.log) =>
+  createMiddleware(async (c, next) => {
+    const { method } = c.req;
+    // getPath returns the request path WITHOUT the query string — the whole
+    // point of this middleware (SEC-015).
+    const path = getPath(c.req.raw);
+    log(fn, "<--", method, path);
+    const start = Date.now();
+    await next();
+    logResponse(fn, "-->", method, path, c.res.status, time(start));
+  });

--- a/packages/api/src/middleware/sensitive-paths.ts
+++ b/packages/api/src/middleware/sensitive-paths.ts
@@ -13,8 +13,10 @@
  *
  * The prefix set is the conservative UNION of what each copy historically
  * treated as sensitive (the two copies were already identical, so the union is
- * that same set). Adding a prefix here tightens BOTH guards together; never
- * narrow it without auditing both call sites.
+ * that same set), plus the money-/key-/auth-adjacent surfaces added in SEC-150
+ * (`/v1/kms`, `/v2/provider-actions`, `/dashboard`, `/agent-enroll`). Adding a
+ * prefix here tightens BOTH guards together; never narrow it without auditing
+ * both call sites.
  */
 
 /** Path prefixes whose mutating requests are treated as sensitive. */
@@ -51,6 +53,14 @@ export const SENSITIVE_PATH_PREFIXES: readonly string[] = [
   "/v2/provider-accounts",
   "/v2/provider-role-bindings",
   "/v2/provider-grants",
+  // Money-movement + key-material + auth-adjacent surfaces that must stay
+  // covered (SEC-150): KMS key ops, provider action execution/approval,
+  // dashboard session mutations, and agent enrollment.
+  "/v1/kms",
+  "/v2/provider-actions",
+  "/dashboard",
+  "/agent-enroll",
+  "/v1/agent-enroll",
 ];
 
 /**

--- a/packages/api/src/openapi.ts
+++ b/packages/api/src/openapi.ts
@@ -6261,12 +6261,16 @@ function addHardeningInventory(spec: OpenApiSpec): OpenApiSpec {
         sensitive: true,
         sensitivePrefix: sensitivePrefixForOpenApiPath(path),
         requestExpiry: {
-          requiredWhen:
-            "STEWARD_REQUIRE_REQUEST_EXPIRY=true or production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true",
+          // Mounted globally (app.ts): freshness headers are always validated
+          // when present; they are REQUIRED only under the explicit opt-in.
+          requiredWhen: "STEWARD_REQUIRE_REQUEST_EXPIRY=true",
           acceptedHeaders: ["X-Steward-Request-Timestamp", "X-Steward-Request-Expires-At"],
         },
         authorizationSignature: {
-          requiredWhen: "STEWARD_REQUIRE_AUTH_SIGNATURE=true or NODE_ENV=production",
+          // Mounted globally (app.ts): a presented X-Steward-Signature is
+          // always verified (fail closed); it is REQUIRED only under the
+          // explicit opt-in.
+          requiredWhen: "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
           header: "X-Steward-Signature",
           schemes: ["v1=hmac-sha256", "p256=ecdsa-secp256r1"],
           optionalSigningKeyHeader: "X-Steward-Signing-Key-Id",

--- a/packages/api/src/routes/agents.ts
+++ b/packages/api/src/routes/agents.ts
@@ -278,6 +278,26 @@ function requireTenantAdminOrApiKey(c: Parameters<typeof requireTenantLevel>[0])
   return requireTenantAdminSession(c);
 }
 
+/**
+ * SEC-209: agent-token minting, vault-policy-set replacement, and agent
+ * deletion are root-equivalent mutations. A bare tenant API key (one shared
+ * secret, no step-up possible) is no longer sufficient for them by default —
+ * they require a human owner/admin session with recent MFA, consistent with
+ * the sibling webhooks/secrets/audit surfaces. Operators that depend on
+ * machine automation can explicitly restore the legacy api-key path via
+ * STEWARD_ALLOW_API_KEY_ADMIN_MUTATIONS=true (documented as fully-root).
+ */
+function allowApiKeyAdminMutations(c: Parameters<typeof requireTenantLevel>[0]): boolean {
+  return (
+    c.get("authType") === "api-key" &&
+    process.env.STEWARD_ALLOW_API_KEY_ADMIN_MUTATIONS === "true"
+  );
+}
+
+function requireSensitiveMutationPrincipal(c: Parameters<typeof requireTenantLevel>[0]): boolean {
+  return requireTenantAdminSession(c) || allowApiKeyAdminMutations(c);
+}
+
 function generateAgentId(): string {
   return `agt_${crypto.randomUUID()}`;
 }
@@ -1359,7 +1379,9 @@ agentRoutes.post("/:agentId/token", async (c) => {
   const tenantId = c.get("tenantId");
   const agentId = c.req.param("agentId");
 
-  if (!requireTenantAdminOrApiKey(c)) {
+  // SEC-209: minting agent tokens is root-equivalent — human admin session
+  // (API key only via explicit STEWARD_ALLOW_API_KEY_ADMIN_MUTATIONS opt-in).
+  if (!requireSensitiveMutationPrincipal(c)) {
     return c.json<ApiResponse>(
       {
         ok: false,
@@ -1845,7 +1867,9 @@ agentRoutes.get("/:agentId", async (c) => {
 // ─── Delete agent ─────────────────────────────────────────────────────────────
 
 agentRoutes.delete("/:agentId", async (c) => {
-  if (!requireTenantAdminOrApiKey(c)) {
+  // SEC-209: deleting an agent destroys its key material — human admin
+  // session (API key only via explicit opt-in).
+  if (!requireSensitiveMutationPrincipal(c)) {
     return c.json<ApiResponse>(
       {
         ok: false,
@@ -3523,7 +3547,9 @@ agentRoutes.get("/:agentId/policies", async (c) => {
 // ─── Update agent policies ────────────────────────────────────────────────────
 
 agentRoutes.put("/:agentId/policies", async (c) => {
-  if (!requireTenantAdminOrApiKey(c)) {
+  // SEC-209: replacing an agent's vault policy set removes its spend caps —
+  // human admin session (API key only via explicit opt-in).
+  if (!requireSensitiveMutationPrincipal(c)) {
     return c.json<ApiResponse>(
       { ok: false, error: "Policy updates require owner or admin session" },
       403,

--- a/packages/api/src/routes/agents.ts
+++ b/packages/api/src/routes/agents.ts
@@ -874,6 +874,47 @@ function hasBuilderPerpAsset(assets: readonly string[]): boolean {
   return assets.some((asset) => /^[a-z0-9]+:[A-Z0-9]+$/.test(asset));
 }
 
+/**
+ * SEC-208: `agentPolicies` is the enforcement source for trade-session
+ * ceilings, so an agent token must never RAISE its own limits (that would
+ * defeat the human-ceiling model — any compromised agent token could mint
+ * itself unlimited trading authority). Returns a human-readable violation
+ * when `next` loosens any dimension relative to `before` (the current row,
+ * or the platform defaults when no row exists yet); null when the change is
+ * a pure tightening. Widening requires the owner/admin + recent-MFA path.
+ */
+function policyLooseningViolation(
+  before: AgentTradePolicySnapshot,
+  next: {
+    dailyCap: number;
+    perOrderCap: number;
+    leverageCap: number;
+    allowedAssets: string[];
+    allowedVenues: string[];
+    allowBuilderPerps: boolean;
+  },
+): string | null {
+  if (next.dailyCap > before.dailyCap) {
+    return `dailyCap cannot be raised above ${before.dailyCap} with an agent token (use an owner/admin session with recent MFA to loosen limits)`;
+  }
+  if (next.perOrderCap > before.perOrderCap) {
+    return `perOrderCap cannot be raised above ${before.perOrderCap} with an agent token (use an owner/admin session with recent MFA to loosen limits)`;
+  }
+  if (next.leverageCap > before.leverageCap) {
+    return `leverageCap cannot be raised above ${before.leverageCap} with an agent token (use an owner/admin session with recent MFA to loosen limits)`;
+  }
+  if (!next.allowedAssets.every((asset) => before.allowedAssets.includes(asset))) {
+    return "allowedAssets cannot be widened with an agent token (use an owner/admin session with recent MFA to loosen limits)";
+  }
+  if (!next.allowedVenues.every((venue) => before.allowedVenues.includes(venue))) {
+    return "allowedVenues cannot be widened with an agent token (use an owner/admin session with recent MFA to loosen limits)";
+  }
+  if (next.allowBuilderPerps && !before.allowBuilderPerps) {
+    return "allowBuilderPerps cannot be enabled with an agent token (use an owner/admin session with recent MFA to loosen limits)";
+  }
+  return null;
+}
+
 // ─── Create agent ─────────────────────────────────────────────────────────────
 
 agentRoutes.post("/", async (c) => {
@@ -1600,17 +1641,33 @@ agentRoutes.get("/:agentId/policy", async (c) => {
 });
 
 agentRoutes.put("/:agentId/policy", async (c) => {
-  if (c.get("authType") !== "agent-token") {
-    return c.json<ApiResponse>(
-      { ok: false, error: "Agent policy updates require agent JWT authentication" },
-      403,
-    );
-  }
-  if (!requireAgentAccess(c)) {
-    return c.json<ApiResponse>(
-      { ok: false, error: "Forbidden: token scope does not match agent" },
-      403,
-    );
+  // SEC-208: two write paths into the trade-policy table —
+  //   1. agent token (self-update): TIGHTEN-ONLY, enforced below after
+  //      validation via policyLooseningViolation.
+  //   2. human owner/admin session with recent MFA: unrestricted (subject to
+  //      the platform ceilings), restoring the human-ceiling administration
+  //      path this route previously lacked.
+  // Tenant API keys stay rejected, as before.
+  const isAgentSelfUpdate = c.get("authType") === "agent-token";
+  if (isAgentSelfUpdate) {
+    if (!requireAgentAccess(c)) {
+      return c.json<ApiResponse>(
+        { ok: false, error: "Forbidden: token scope does not match agent" },
+        403,
+      );
+    }
+  } else {
+    if (!requireTenantAdminSession(c)) {
+      return c.json<ApiResponse>(
+        {
+          ok: false,
+          error: "Agent policy updates require an agent token or an owner/admin session",
+        },
+        403,
+      );
+    }
+    const mfaResponse = requireRecentAdminMfa(c, "Agent policy updates");
+    if (mfaResponse) return mfaResponse;
   }
 
   const tenantId = c.get("tenantId");
@@ -1683,7 +1740,25 @@ agentRoutes.put("/:agentId/policy", async (c) => {
     return c.json<ApiResponse>({ ok: false, error: "perOrderCap cannot exceed dailyCap" }, 400);
   }
 
-  const updatedBy = c.get("agentSubject") ?? `agent:${agentId}`;
+  // SEC-208: agent self-updates are tighten-only — reject any loosening here
+  // (fail closed, AFTER input validation so malformed bodies still 400).
+  if (isAgentSelfUpdate) {
+    const loosening = policyLooseningViolation(before, {
+      dailyCap: dailyCapValue,
+      perOrderCap: perOrderCapValue,
+      leverageCap: leverageCapValue,
+      allowedAssets: allowedAssetsValue,
+      allowedVenues: allowedVenuesValue,
+      allowBuilderPerps: allowBuilderPerpsValue,
+    });
+    if (loosening) {
+      return c.json<ApiResponse>({ ok: false, error: loosening }, 403);
+    }
+  }
+
+  const updatedBy = isAgentSelfUpdate
+    ? (c.get("agentSubject") ?? `agent:${agentId}`)
+    : (c.get("userId") ?? "unknown");
   const updatedReason = body.reason.trim();
   const [upserted] = await db
     .insert(agentPolicies)
@@ -1720,7 +1795,7 @@ agentRoutes.put("/:agentId/policy", async (c) => {
   const diff = policyDiff(before, after);
   await writeAuditEvent({
     tenantId,
-    actorType: "agent",
+    actorType: isAgentSelfUpdate ? "agent" : "user",
     actorId: updatedBy,
     action: "agent.policy.updated",
     resourceType: "agent_policy",

--- a/packages/api/src/routes/agents.ts
+++ b/packages/api/src/routes/agents.ts
@@ -289,8 +289,7 @@ function requireTenantAdminOrApiKey(c: Parameters<typeof requireTenantLevel>[0])
  */
 function allowApiKeyAdminMutations(c: Parameters<typeof requireTenantLevel>[0]): boolean {
   return (
-    c.get("authType") === "api-key" &&
-    process.env.STEWARD_ALLOW_API_KEY_ADMIN_MUTATIONS === "true"
+    c.get("authType") === "api-key" && process.env.STEWARD_ALLOW_API_KEY_ADMIN_MUTATIONS === "true"
   );
 }
 

--- a/packages/api/src/routes/erc8004.ts
+++ b/packages/api/src/routes/erc8004.ts
@@ -21,7 +21,7 @@ import {
   hasAgentTokenScope,
   requireTenantLevel,
 } from "../services/context";
-import { validateWebhookUrl } from "../services/webhook-url";
+import { validateWebhookUrlResolved } from "../services/webhook-url";
 
 export const erc8004Routes = new Hono<{ Variables: AppVariables }>();
 type AgentRegistrationRow = typeof agentRegistrations.$inferSelect;
@@ -84,9 +84,9 @@ function signedFeedbackWritesEnabled(): boolean {
   return false;
 }
 
-function validateAgentCardApiUrl(apiUrl: string): string | null {
+async function validateAgentCardApiUrl(apiUrl: string): Promise<string | null> {
   if (!apiUrl) return null;
-  const destinationError = validateWebhookUrl(apiUrl);
+  const destinationError = await validateWebhookUrlResolved(apiUrl);
   if (destinationError) return `apiUrl ${destinationError}`;
   if (new URL(apiUrl).protocol !== "https:") return "apiUrl must use https";
   return null;
@@ -185,7 +185,7 @@ erc8004Routes.post("/:id/register-onchain", async (c) => {
   }
 
   const { chainId, apiUrl, capabilities, services } = parsed.data;
-  const apiUrlError = validateAgentCardApiUrl(apiUrl);
+  const apiUrlError = await validateAgentCardApiUrl(apiUrl);
   if (apiUrlError) {
     return c.json<ApiResponse>({ ok: false, error: apiUrlError }, 400);
   }

--- a/packages/api/src/routes/tenant-config.ts
+++ b/packages/api/src/routes/tenant-config.ts
@@ -621,10 +621,12 @@ function buildTenantSecurityChecklist(
   requestSigningKeys: TenantRequestSigningKey[],
 ): TenantSecurityChecklist {
   const production = process.env.NODE_ENV === "production";
-  const requestExpiryRequired =
-    process.env.STEWARD_REQUIRE_REQUEST_EXPIRY === "true" ||
-    (production && process.env.STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS !== "true");
-  const authSignatureRequired = process.env.STEWARD_REQUIRE_AUTH_SIGNATURE === "true" || production;
+  // SEC-010: these mirror the ACTUAL enforcement posture of the mounted
+  // guards (app.ts). Freshness/signature headers are always verified when
+  // present; they are REQUIRED only via the explicit env opt-ins, so the
+  // checklist must not claim production enforcement that does not exist.
+  const requestExpiryRequired = process.env.STEWARD_REQUIRE_REQUEST_EXPIRY === "true";
+  const authSignatureRequired = process.env.STEWARD_REQUIRE_AUTH_SIGNATURE === "true";
   const signingSecrets = configuredRequestSigningSecrets();
   const appClientSigningSecrets = appClientSecrets.filter(
     (secret) =>
@@ -689,7 +691,7 @@ function buildTenantSecurityChecklist(
         : "Sensitive mutating requests validate freshness headers when present but do not require them.",
       remediation: requestExpiryRequired
         ? undefined
-        : "Set STEWARD_REQUIRE_REQUEST_EXPIRY=true or run production without STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true.",
+        : "Set STEWARD_REQUIRE_REQUEST_EXPIRY=true to require freshness headers on sensitive mutating requests.",
     },
     {
       id: "authorization-signatures",

--- a/packages/api/src/routes/tenants.ts
+++ b/packages/api/src/routes/tenants.ts
@@ -36,7 +36,7 @@ import {
   webhookConfigs,
 } from "../services/context";
 import { getPolicyRulesValidationError } from "../services/policy-validation";
-import { validateWebhookUrl } from "../services/webhook-url";
+import { validateWebhookUrlResolved } from "../services/webhook-url";
 
 export const tenantRoutes = new Hono<{ Variables: AppVariables }>();
 const LEGACY_TENANT_WEBHOOK_DESCRIPTION = "legacy:tenant-webhook";
@@ -260,7 +260,7 @@ tenantRoutes.post("/", platformAuthMiddleware(), async (c) => {
   }
   if (body.webhookUrl !== undefined) {
     const urlError = isNonEmptyString(body.webhookUrl)
-      ? validateWebhookUrl(body.webhookUrl)
+      ? await validateWebhookUrlResolved(body.webhookUrl)
       : "webhookUrl must be a non-empty string";
     if (urlError) return c.json<ApiResponse>({ ok: false, error: urlError }, 400);
   }
@@ -387,7 +387,7 @@ tenantRoutes.put("/:id/webhook", requireTenantId, async (c) => {
 
   if (body.webhookUrl !== undefined) {
     const urlError = isNonEmptyString(body.webhookUrl)
-      ? validateWebhookUrl(body.webhookUrl)
+      ? await validateWebhookUrlResolved(body.webhookUrl)
       : "webhookUrl must be a non-empty string";
     if (urlError) return c.json<ApiResponse>({ ok: false, error: urlError }, 400);
   }

--- a/packages/api/src/routes/webhooks.ts
+++ b/packages/api/src/routes/webhooks.ts
@@ -30,7 +30,7 @@ import {
   isValidConfigurableWebhookEvent,
   listValidConfigurableWebhookEvents,
 } from "../services/webhook-events";
-import { validateWebhookUrl } from "../services/webhook-url";
+import { validateWebhookUrlResolved } from "../services/webhook-url";
 
 export const webhookRoutes = new Hono<{ Variables: AppVariables }>();
 
@@ -342,7 +342,11 @@ webhookRoutes.post("/", async (c) => {
     return c.json<ApiResponse>({ ok: false, error: "Invalid JSON in request body" }, 400);
   }
 
-  const urlError = isNonEmptyString(body.url) ? validateWebhookUrl(body.url) : "url is required";
+  // SEC-017: resolve DNS and reject non-public answers (string checks alone
+  // miss public-hostname-to-private-IP and rebinding).
+  const urlError = isNonEmptyString(body.url)
+    ? await validateWebhookUrlResolved(body.url)
+    : "url is required";
   if (urlError) {
     return c.json<ApiResponse>({ ok: false, error: urlError }, 400);
   }
@@ -532,7 +536,9 @@ webhookRoutes.put("/:id", async (c) => {
   }
 
   if (body.url !== undefined) {
-    const urlError = isNonEmptyString(body.url) ? validateWebhookUrl(body.url) : "url is required";
+    const urlError = isNonEmptyString(body.url)
+      ? await validateWebhookUrlResolved(body.url)
+      : "url is required";
     if (urlError) {
       return c.json<ApiResponse>({ ok: false, error: urlError }, 400);
     }

--- a/packages/api/src/runtime.d.ts
+++ b/packages/api/src/runtime.d.ts
@@ -7,7 +7,10 @@ declare const process: {
 declare const Bun: {
   serve(options: {
     port: number;
-    fetch(request: Request): Response | Promise<Response>;
+    fetch(
+      request: Request,
+      server: { requestIP(request: Request): { address: string } | null },
+    ): Response | Promise<Response>;
     idleTimeout?: number;
   }): {
     port: number;

--- a/packages/api/src/services/runtime-gate.ts
+++ b/packages/api/src/services/runtime-gate.ts
@@ -64,9 +64,7 @@ export function resolveClientIp(
   return peerAddress ?? "unknown";
 }
 
-export type RateLimitVerdict =
-  | { limited: false }
-  | { limited: true; retryAfterSeconds: number };
+export type RateLimitVerdict = { limited: false } | { limited: true; retryAfterSeconds: number };
 
 /**
  * Fixed-window in-memory limiter with a hard cap on tracked keys. Only safe

--- a/packages/api/src/services/runtime-gate.ts
+++ b/packages/api/src/services/runtime-gate.ts
@@ -1,0 +1,121 @@
+/**
+ * runtime-gate.ts — pure logic behind the Bun entry's global rate limiter
+ * (index.ts). Extracted so the derivation and eviction rules are unit-testable
+ * (index.ts itself boots a server at module scope and cannot be imported by
+ * tests).
+ *
+ * SEC-014: the limiter previously keyed on the LEFTMOST `x-forwarded-for`
+ * value with no trusted-proxy validation, so a client could rotate a spoofed
+ * XFF header per request for unlimited requests (and grow the in-memory log
+ * unboundedly with unique values). Client-supplied forwarding headers are now
+ * honored ONLY when the operator declares how many trusted proxy hops sit in
+ * front of the server (`STEWARD_TRUSTED_PROXY_HOPS`):
+ *
+ *   - each proxy appends the peer it observed, so with N trusted hops the real
+ *     client is the entry N positions from the RIGHT of the XFF list — every
+ *     entry to its left is attacker-controlled prefix and ignored;
+ *   - with zero trusted hops (default) both forwarding headers are ignored and
+ *     the socket peer is used;
+ *   - when the chain is shorter than the configured trust, the leftmost
+ *     (earliest trusted) entry is the best available signal.
+ *
+ * The log is also capped (`STEWARD_RATE_LIMIT_MAX_KEYS`): when full it sweeps
+ * expired entries inline and then fails CLOSED (429) rather than letting the
+ * map grow without bound.
+ */
+
+export const DEFAULT_RATE_LIMIT_MAX_KEYS = 10_000;
+
+export function parseNonNegativeInt(value: string | undefined, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+export function parsePositiveInt(value: string | undefined, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+/**
+ * Derive the rate-limit key for a request. `peerAddress` is the socket peer
+ * (`server.requestIP()` on Bun; null when the runtime cannot provide it).
+ */
+export function resolveClientIp(
+  headers: Headers,
+  peerAddress: string | null,
+  trustedProxyHops: number,
+): string {
+  if (trustedProxyHops > 0) {
+    const forwardedFor = headers.get("x-forwarded-for");
+    if (forwardedFor) {
+      const hops = forwardedFor
+        .split(",")
+        .map((part) => part.trim())
+        .filter(Boolean);
+      if (hops.length > 0) {
+        const clientIndex = Math.max(hops.length - trustedProxyHops, 0);
+        const derived = hops[clientIndex];
+        if (derived) return derived;
+      }
+    }
+    const realIp = headers.get("x-real-ip")?.trim();
+    if (realIp) return realIp;
+  }
+  return peerAddress ?? "unknown";
+}
+
+export type RateLimitVerdict =
+  | { limited: false }
+  | { limited: true; retryAfterSeconds: number };
+
+/**
+ * Fixed-window in-memory limiter with a hard cap on tracked keys. Only safe
+ * for the single-process Bun entry (the Workers entry must not use it).
+ */
+export class InMemoryRateLimiter {
+  private readonly log = new Map<string, { count: number; resetAt: number }>();
+
+  constructor(
+    private readonly maxRequests: number,
+    private readonly windowMs: number,
+    private readonly maxKeys: number = DEFAULT_RATE_LIMIT_MAX_KEYS,
+  ) {}
+
+  check(key: string, now: number = Date.now()): RateLimitVerdict {
+    const current = this.log.get(key);
+
+    if (!current || current.resetAt <= now) {
+      if (!current && this.log.size >= this.maxKeys) {
+        this.sweep(now);
+        if (this.log.size >= this.maxKeys) {
+          // Fail closed: rather track nothing new than grow without bound.
+          return { limited: true, retryAfterSeconds: Math.ceil(this.windowMs / 1000) };
+        }
+      }
+      this.log.set(key, { count: 1, resetAt: now + this.windowMs });
+      return { limited: false };
+    }
+
+    if (current.count >= this.maxRequests) {
+      return { limited: true, retryAfterSeconds: Math.ceil((current.resetAt - now) / 1000) };
+    }
+
+    current.count += 1;
+    this.log.set(key, current);
+    return { limited: false };
+  }
+
+  sweep(now: number = Date.now()): void {
+    for (const [key, entry] of this.log.entries()) {
+      if (entry.resetAt <= now) this.log.delete(key);
+    }
+  }
+
+  clear(): void {
+    this.log.clear();
+  }
+
+  get size(): number {
+    return this.log.size;
+  }
+}

--- a/packages/api/src/services/webhook-dispatch.ts
+++ b/packages/api/src/services/webhook-dispatch.ts
@@ -16,6 +16,7 @@ import {
   webhookEventRegistry,
 } from "./webhook-events";
 import { redactWebhookSecrets } from "./webhook-redaction";
+import { validateWebhookUrlResolved } from "./webhook-url";
 
 const INLINE_DELIVERY_VISIBILITY_TIMEOUT_MS = 5 * 60 * 1000;
 
@@ -250,6 +251,24 @@ async function dispatchConfiguredWebhook(
 
   if (!delivery) {
     throw new Error("Failed to create webhook delivery record");
+  }
+
+  // SEC-017: re-validate the destination at delivery time with FRESH DNS
+  // answers — registration-time validation cannot see DNS rebinding (public A
+  // record at config time, private at fetch time). Fail closed: no fetch.
+  const deliveryUrlError = await validateWebhookUrlResolved(config.url);
+  if (deliveryUrlError) {
+    const [rejected] = await db
+      .update(webhookDeliveries)
+      .set({
+        status: "failed",
+        attempts: 0,
+        lastError: `delivery blocked: ${deliveryUrlError}`,
+        payload: eventWithDelivery as unknown as Record<string, unknown>,
+      })
+      .where(eq(webhookDeliveries.id, delivery.id))
+      .returning();
+    return rejected ?? delivery;
   }
 
   const dispatcher = new WebhookDispatcher({

--- a/packages/api/src/services/webhook-url.ts
+++ b/packages/api/src/services/webhook-url.ts
@@ -1,3 +1,4 @@
+import { lookup } from "node:dns/promises";
 import { isIP } from "node:net";
 
 const ALLOW_INSECURE_WEBHOOK_URLS = process.env.STEWARD_ALLOW_INSECURE_WEBHOOK_URLS === "true";
@@ -143,4 +144,63 @@ export function validateWebhookUrl(url: string): string | null {
   } catch {
     return "url must be a valid HTTPS URL";
   }
+}
+
+// ─── DNS-resolving validation (SEC-017) ──────────────────────────────────────
+
+export type DnsAnswer = { address: string; family: number };
+export type DnsResolver = (hostname: string) => Promise<DnsAnswer[]>;
+
+const defaultResolver: DnsResolver = (hostname) => lookup(hostname, { all: true, verbatim: true });
+
+function isNonPublicAddress(address: string): boolean {
+  const normalized = address.toLowerCase();
+  const version = isIP(normalized);
+  if (version === 4) return isNonPublicIpv4(normalized);
+  if (version === 6) return isNonPublicIpv6(normalized);
+  // Unexpected answer form — fail closed.
+  return true;
+}
+
+/**
+ * SEC-017: `validateWebhookUrl` only inspects the hostname STRING, so a name
+ * like `169.254.169.254.nip.io` (public DNS → link-local) or a DNS rebinding
+ * (public A record at config time, private at fetch time) passes it. This
+ * async variant additionally resolves the hostname and rejects when ANY
+ * answer is a non-public address, failing closed on resolution errors. Use it
+ * at registration time AND at delivery time (fresh answers close the
+ * config→fetch rebinding window). The resolver is injectable for tests.
+ */
+export async function validateWebhookUrlResolved(
+  url: string,
+  resolver: DnsResolver = defaultResolver,
+): Promise<string | null> {
+  const stringError = validateWebhookUrl(url);
+  if (stringError) return stringError;
+
+  let hostname: string;
+  try {
+    hostname = new URL(url).hostname
+      .replace(/^\[|\]$/g, "")
+      .replace(/\.+$/g, "")
+      .toLowerCase();
+  } catch {
+    return "url must be a valid HTTPS URL";
+  }
+  // IP literals are fully covered by the string-level checks above.
+  if (isIP(hostname)) return null;
+
+  let answers: DnsAnswer[];
+  try {
+    answers = await resolver(hostname);
+  } catch {
+    return "url host could not be resolved";
+  }
+  if (answers.length === 0) return "url host could not be resolved";
+  for (const answer of answers) {
+    if (isNonPublicAddress(answer.address)) {
+      return "url host must resolve to a public address";
+    }
+  }
+  return null;
 }


### PR DESCRIPTION
## Summary

Batch 2 (api: app/middleware/services/routes, non-auth) of the wave-2 security-audit remediation. All 7 assigned HIGH/MEDIUM findings are fixed with regression tests. LOW/INFO findings not in this PR are explicitly deferred (see table) — the batch was time-boxed to land the HIGH/MEDIUM set correctly rather than everything partially.

## SEC-ID status

| SEC ID | Severity | Status | Change |
|---|---|---|---|
| SEC-010 | HIGH | FIXED | Remounted `requestExpiry` + `authorizationSignature` globally in `createApp()` (before idempotency) in verify-when-present mode: stale/invalid freshness/signature headers fail closed; strict requirement is explicit operator opt-in via `STEWARD_REQUIRE_REQUEST_EXPIRY` / `STEWARD_REQUIRE_AUTH_SIGNATURE`. Aligned `/openapi.json` hardening inventory + tenant security checklist with the real posture (they claimed production enforcement that did not exist). |
| SEC-208 | HIGH | FIXED | `PUT /agents/:agentId/policy` agent self-updates are now tighten-only relative to the current row (or platform defaults when no row exists); unrestricted writes require an owner/admin session with recent MFA (the human-ceiling path this only-writer route previously lacked). Tenant API keys remain rejected. |
| SEC-014 | MEDIUM | FIXED | Global rate limiter no longer keys on spoofable leftmost XFF. Uses the Bun socket peer unless `STEWARD_TRUSTED_PROXY_HOPS` > 0 (client IP derived N trusted hops from the right of the XFF list; attacker prefix entries ignored), and the key space is capped via `STEWARD_RATE_LIMIT_MAX_KEYS` (default 10k), failing closed with 429 when full. Logic extracted to `services/runtime-gate.ts`. |
| SEC-015 | MEDIUM | FIXED | Replaced hono `logger()` with a format-compatible `requestLogger` that strips query strings — live one-time tokens in `/auth/callback/email?token=…` and OAuth callback query params no longer reach logs. |
| SEC-016 | MEDIUM | FIXED | `checkAgentRateLimit`/`checkProxyRateLimit` now mirror `checkAgentSpendLimit`: permissive only when Redis was never configured; a configured-but-down Redis fails closed instead of silently disabling proxy/vault rate limiting. |
| SEC-017 | MEDIUM | FIXED | New `validateWebhookUrlResolved` (string checks + DNS resolution, rejects when ANY answer is non-public, fail closed on resolution errors) wired into all registration-time call sites (webhook config create/update, tenant `webhookUrl` create/update, erc8004 agent-card `apiUrl`) and the delivery path, which re-resolves with fresh answers at dispatch time to close the config→fetch rebinding window. |
| SEC-209 | MEDIUM | FIXED | `POST /agents/:id/token`, `PUT /agents/:id/policies`, `DELETE /agents/:id` now require a human owner/admin session with recent MFA (previously a bare tenant API key sufficed). `STEWARD_ALLOW_API_KEY_ADMIN_MUTATIONS=true` is the explicit opt-in restoring the legacy api-key path (documented as fully-root). |
| SEC-150 | INFO | FIXED | Added missing sensitive-path prefixes (`/v1/kms`, `/v2/provider-actions`, `/dashboard`, `/agent-enroll`, `/v1/agent-enroll`) so the remounted guards cover key-material/money-movement surfaces (done with SEC-010). |
| SEC-067 | LOW | DEFERRED | CORS default/Vary/negative-cache — not reached in the time-boxed run; no behavior regression risk from this PR. |
| SEC-068 | LOW | DEFERRED | Workers global rate limiting gap — not reached. |
| SEC-069 | LOW | DEFERRED | Hardcoded dev JWKS trust anchor — not reached. |
| SEC-070 | LOW | DEFERRED | Idempotency caching of secret-bearing bodies — not reached. |
| SEC-071 | LOW | DEFERRED | `/ready` fingerprint disclosure — not reached. |
| SEC-072 | LOW | DEFERRED | Paymaster/bundler URL SSRF guard — not reached. |
| SEC-073 | LOW | DEFERRED | Signer credential pepper empty-string degradation — not reached. |
| SEC-074 | LOW | DEFERRED | v1 execution-authorization HMAC key reuse — not reached. |
| SEC-149 | LOW | DEFERRED | Dead `POST /tenants` guard branch — not reached. |
| SEC-210 | LOW | DEFERRED | Raw internal error messages in user/agent/account routes — not reached. |
| SEC-211 | LOW | DEFERRED | Unmounted session-signers route module — not reached. |
| SEC-147 | INFO | DEFERRED | Embedded-mode random master password per boot — not reached. |
| SEC-148 | INFO | DEFERRED | `hydrateProcessEnv` once-per-isolate doc/behavior — not reached. |
| SEC-151 | INFO | DEFERRED | OIDC JIT provisioning default — not reached. |
| SEC-152 | INFO | DEFERRED | 1-confirmation default — not reached. |
| SEC-153 | INFO | DEFERRED | Legacy tenant API key documentation — not reached. |
| SEC-212 | INFO | DEFERRED | Global-wallet client-asserted origin documentation — not reached. |
| SEC-213 | INFO | DEFERRED | Public erc8004 discovery listing — not reached (no fix specified by reporter; intended public discovery). |

## Trade-offs / breaking changes

- **SEC-010**: guards are mounted in *verify-when-present* mode rather than required-by-default-in-production (the pre-`38d061a5` behavior). Required-by-default breaks browser/dashboard clients that cannot hold HMAC signing secrets — the breakage that got the middleware removed. Operators opt into strict enforcement via `STEWARD_REQUIRE_REQUEST_EXPIRY=true` / `STEWARD_REQUIRE_AUTH_SIGNATURE=true` after rolling out signing clients. The tenant checklist now reports `fail`/`warning` honestly until then.
- **SEC-208**: agents can no longer raise their own trade caps or widen asset/venue allowlists with an agent token (403); widening requires a human owner/admin session with recent MFA. Deployments relying on agent self-provisioning of looser policies must use the human path.
- **SEC-209**: automation that mints agent tokens, replaces agent vault policy sets, or deletes agents with a tenant API key must either move to human session + MFA or set `STEWARD_ALLOW_API_KEY_ADMIN_MUTATIONS=true` (fully-root api-key, explicitly opted in).
- **SEC-017**: webhook/tenant/erc8004 URL registration now performs a DNS lookup and rejects unresolvable or privately-resolving hosts; delivery re-resolves per dispatch. Environments without outbound DNS at request time will see registration/delivery failures (fail closed, intended).
- **SEC-014**: default (no trusted proxy hops) rate-limits on the socket peer; operators behind a proxy must set `STEWARD_TRUSTED_PROXY_HOPS` to preserve per-client limiting.

## Testing

- New regression tests (all fail without the corresponding fix, pass with it): `request-guards-mounted.test.ts` (SEC-010/150), `agent-trade-policy-admin.test.ts` + updated `agent-policy.test.ts` (SEC-208), `runtime-gate.test.ts` (SEC-014), `request-logger.test.ts` (SEC-015), extended `redis-rate-limit-fail-closed.test.ts` (SEC-016), extended `webhook-url-validation.test.ts` (SEC-017), `agent-admin-mutations-mfa.test.ts` (SEC-209).
- Targeted suites run green: agent-policy, agent-trade-policy-admin, agent-admin-mutations-mfa, agent-audit-order, agent-audit-rollback, agent-policy-rules, webhooks, webhook-dispatch, webhook-signed-delivery, webhook-events, webhook-payload-redaction, webhook-retry-hardening, user-lifecycle-webhooks, intent-finalization-webhooks, webhook-audit-order, user-wallet-created-webhook, authorization-signature-middleware, authorization-keys, request-expiry-middleware, openapi-contract, openapi-spec, idempotency-middleware, middleware-security-hardening, lean-full-parity, adapters-app-mount, agent-enroll-route, auth-client-ip, session-signers, agent-freeze.
- `bunx tsc --noEmit -p packages/api` clean; `bunx biome check` clean on all changed files.
- Notes: `packages/api/scripts/generate-openapi.ts` is broken at HEAD (pre-existing, stale `getOpenAPI31Document` call — unrelated); `docs/openapi.json` was re-synced directly from `getOpenApiSpec()`. `agent-auth.test.ts` / `agent-route-scope.test.ts` are entirely env-gated skips (pre-existing). The full per-file isolated suite was not run end-to-end in this run (time-boxed); CI should run `cd packages/api && bun run test`.