### PR TITLE
fix(security): auth hardening — OIDC secret exfil, JWT secret policy, agent-enroll abuse surface (batch 1)

### DIFF
--- a/docs/api-reference/tenant-config.mdx
+++ b/docs/api-reference/tenant-config.mdx
@@ -326,12 +326,14 @@ Tenant OIDC providers support direct JWT exchange and enterprise authorization-c
   "audience": ["steward-api"],
   "jwksUri": "https://idp.example.com/.well-known/jwks.json",
   "clientId": "steward-dashboard",
-  "clientSecretEnv": "ACME_SSO_CLIENT_SECRET",
+  "clientSecretEnv": "STEWARD_TENANT_OIDC_SECRET_ACME_SSO",
   "authorizationUrl": "https://idp.example.com/oauth2/v1/authorize",
   "tokenUrl": "https://idp.example.com/oauth2/v1/token",
   "scopes": ["openid", "email", "profile"]
 }
 ```
+
+`clientSecretEnv` must name an environment variable in the dedicated `STEWARD_TENANT_OIDC_SECRET_*` namespace; arbitrary platform env vars are rejected so tenant config cannot exfiltrate deployment secrets through the token exchange.
 
 The SP-initiated SSO route requires app-side PKCE:
 

--- a/packages/api/src/__tests__/agent-enroll-abuse.test.ts
+++ b/packages/api/src/__tests__/agent-enroll-abuse.test.ts
@@ -1,0 +1,110 @@
+/**
+ * agent-enroll-abuse.test.ts — SEC-051 / SEC-052 regression tests.
+ *
+ * SEC-051: the public enroll endpoints must sit behind the Redis-backed auth
+ * rate limiter (fail-closed in production) and must reject oversized or
+ * invalid-charset agentIds before anything reaches the challenge store.
+ * SEC-052: enrollment challenges must live in the API's initialized
+ * ChallengeStore (getAuthChallengeStore), not the auth package's process-local
+ * memory singleton.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { challengeStore as authMemorySingleton } from "@stwd/auth";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { Hono } from "hono";
+import type { AppVariables } from "../services/context";
+
+const ORIGINAL_ENV = {
+  NODE_ENV: process.env.NODE_ENV,
+  REDIS_URL: process.env.REDIS_URL,
+  REDIS_DRIVER: process.env.REDIS_DRIVER,
+  STEWARD_ALLOW_AUTH_RATE_LIMIT_SOFT_FAIL: process.env.STEWARD_ALLOW_AUTH_RATE_LIMIT_SOFT_FAIL,
+};
+
+function restoreEnv() {
+  for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+describe("agent enrollment abuse surface (SEC-051, SEC-052)", () => {
+  let app: Hono<{ Variables: AppVariables }>;
+  let getAuthChallengeStore: typeof import("../routes/auth").getAuthChallengeStore;
+
+  beforeAll(async () => {
+    process.env.STEWARD_PGLITE_MEMORY = "true";
+    process.env.STEWARD_MASTER_PASSWORD = "enroll-abuse-master-password-32-chars";
+    process.env.STEWARD_JWT_SECRET = "enroll-abuse-jwt-secret-at-least-32-chars!";
+    const { db, client } = await createPGLiteDb("memory://");
+    setPGLiteOverride(db, async () => {
+      await client.close();
+    });
+    const { agentEnrollRoutes } = await import("../routes/agent-enroll");
+    ({ getAuthChallengeStore } = await import("../routes/auth"));
+    app = new Hono<{ Variables: AppVariables }>();
+    app.route("/agent-enroll", agentEnrollRoutes);
+  });
+
+  afterAll(async () => {
+    restoreEnv();
+    const { closeDb } = await import("@stwd/db");
+    await closeDb().catch(() => {});
+  });
+
+  it("stores challenges in the API's initialized store, not the auth memory singleton (SEC-052)", async () => {
+    const res = await app.request("/agent-enroll/challenge", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ agentId: "sec052-agent" }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; data: { nonce: string } };
+    expect(body.ok).toBe(true);
+
+    const stored = await getAuthChallengeStore().get(
+      `agent-enroll:sec052-agent:${body.data.nonce}`,
+    );
+    expect(stored).not.toBeNull();
+    // The auth package's process-local singleton must stay empty: the route
+    // must not touch it even as a fallback.
+    expect(authMemorySingleton.size).toBe(0);
+  });
+
+  it("rejects oversized and invalid-charset agentIds before the store (SEC-051)", async () => {
+    for (const agentId of ["a".repeat(200), "bad agent", "agent/id"]) {
+      const res = await app.request("/agent-enroll/challenge", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ agentId }),
+      });
+      expect(res.status).toBe(400);
+    }
+  });
+
+  it("fails closed with 429 in production when Redis was never configured (SEC-051)", async () => {
+    process.env.NODE_ENV = "production";
+    delete process.env.REDIS_URL;
+    delete process.env.REDIS_DRIVER;
+    delete process.env.STEWARD_ALLOW_AUTH_RATE_LIMIT_SOFT_FAIL;
+    try {
+      const challengeRes = await app.request("/agent-enroll/challenge", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ agentId: "sec051-agent" }),
+      });
+      expect(challengeRes.status).toBe(429);
+      expect(challengeRes.headers.get("retry-after")).toBe("60");
+
+      const verifyRes = await app.request("/agent-enroll/verify", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ agentId: "sec051-agent", nonce: "n", signature: "s" }),
+      });
+      expect(verifyRes.status).toBe(429);
+    } finally {
+      restoreEnv();
+    }
+  });
+});

--- a/packages/api/src/__tests__/tenant-oidc-providers.test.ts
+++ b/packages/api/src/__tests__/tenant-oidc-providers.test.ts
@@ -84,7 +84,7 @@ describe("tenant-admin OIDC provider config routes", () => {
             audience: ["steward-api"],
             jwksUri: "https://tenant.example.com/.well-known/jwks.json",
             clientId: "enterprise-client",
-            clientSecretEnv: "ACME_SSO_CLIENT_SECRET",
+            clientSecretEnv: "STEWARD_TENANT_OIDC_SECRET_ACME_SSO",
             authorizationUrl: "https://tenant.example.com/oauth2/v1/authorize",
             tokenUrl: "https://tenant.example.com/oauth2/v1/token",
             scopes: ["openid", "email", "profile"],
@@ -104,7 +104,7 @@ describe("tenant-admin OIDC provider config routes", () => {
         id: "auth0-prod",
         issuer: "https://tenant.example.com",
         clientId: "enterprise-client",
-        clientSecretEnv: "ACME_SSO_CLIENT_SECRET",
+        clientSecretEnv: "STEWARD_TENANT_OIDC_SECRET_ACME_SSO",
         authorizationUrl: "https://tenant.example.com/oauth2/v1/authorize",
         tokenUrl: "https://tenant.example.com/oauth2/v1/token",
         scopes: ["openid", "email", "profile"],
@@ -181,6 +181,41 @@ describe("tenant-admin OIDC provider config routes", () => {
     expect(unsafeAuthCodeResponse.status).toBe(400);
     const unsafeAuthCodeBody = (await unsafeAuthCodeResponse.json()) as { error: string };
     expect(unsafeAuthCodeBody.error).toContain("tokenUrl for provider unsafe-code-flow");
+  });
+
+  it("rejects clientSecretEnv values outside the dedicated tenant OIDC namespace", async () => {
+    const ownerToken = await tokenFor(ownerId);
+    for (const clientSecretEnv of [
+      "STEWARD_JWT_SECRET",
+      "STEWARD_MASTER_PASSWORD",
+      "ACME_SSO_CLIENT_SECRET",
+      "STEWARD_TENANT_OIDC_SECRET",
+    ]) {
+      const response = await tenantConfigRoutes.request(`/${TENANT_ID}/oidc-providers`, {
+        method: "PUT",
+        headers: {
+          Authorization: `Bearer ${ownerToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          providers: [
+            {
+              id: "env-exfil",
+              issuer: "https://tenant.example.com",
+              audience: ["steward-api"],
+              jwksUri: "https://tenant.example.com/.well-known/jwks.json",
+              clientId: "enterprise-client",
+              clientSecretEnv,
+              authorizationUrl: "https://tenant.example.com/oauth2/v1/authorize",
+              tokenUrl: "https://tenant.example.com/oauth2/v1/token",
+            },
+          ],
+        }),
+      });
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toContain("STEWARD_TENANT_OIDC_SECRET_");
+    }
   });
 
   it("rejects tenant API keys for OIDC provider config changes", async () => {

--- a/packages/api/src/routes/agent-enroll.ts
+++ b/packages/api/src/routes/agent-enroll.ts
@@ -11,18 +11,22 @@
  *
  * Reuses the shipped crypto + stores:
  *   - challenge/response + P-256 verify: @stwd/auth agent-enroll core.
+ *   - challenge persistence: the API's initialized ChallengeStore (Redis or
+ *     Postgres in production — see initAuthStores), so challenges survive
+ *     restarts and verify can land on a different instance than challenge.
  *   - registered key: `agent_signers` (keyType="p256", status="active").
  *   - token mint: signAgentToken (short TTL — minute-scale, so revocation via a
  *     signer status flip lands at the next enroll cycle).
  *
  * The tenant is derived SERVER-SIDE from the resolved signer row, never taken
  * from the request. Fail-closed everywhere: any resolution/verify failure denies
- * with a generic message (no enumeration signal beyond "denied").
+ * with a generic message (no enumeration signal beyond "denied"). Both endpoints
+ * are unauthenticated, so they sit behind the same Redis-backed auth rate
+ * limiter as the other public auth surfaces (SEC-051).
  */
 
 import {
   type AgentSignerResolver,
-  challengeStore,
   issueEnrollChallenge,
   type ResolvedAgentSigner,
   signAgentToken,
@@ -31,7 +35,14 @@ import {
 import { agentSigners, eq } from "@stwd/db";
 import { Hono } from "hono";
 import { writeAuditEvent } from "../services/audit";
-import { type ApiResponse, type AppVariables, db, safeJsonParse } from "../services/context";
+import {
+  type ApiResponse,
+  type AppVariables,
+  db,
+  isValidAgentId,
+  safeJsonParse,
+} from "../services/context";
+import { checkAuthRateLimit, getAuthChallengeStore } from "./auth";
 
 /** Short-lived enrollment token TTL. Minute-scale: the agent immediately renews
  * (or exchanges for scoped capabilities), and a revoked signer stops enrolling
@@ -70,13 +81,27 @@ async function resolveP256Signers(agentId: string): Promise<{
 
 // ── POST /challenge ──────────────────────────────────────────────────────────
 agentEnrollRoutes.post("/challenge", async (c) => {
+  const rl = await checkAuthRateLimit(c, "agent-enroll-challenge", 60_000, 30);
+  if (!rl.allowed) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Too many enrollment attempts. Try again later." },
+      429,
+      { "Retry-After": String(rl.retryAfterSecs ?? 60) },
+    );
+  }
+
   const body = await safeJsonParse<{ agentId?: unknown }>(c);
   const agentId = typeof body?.agentId === "string" ? body.agentId.trim() : "";
   if (!agentId) {
     return c.json<ApiResponse>({ ok: false, error: "agentId required" }, 400);
   }
+  // Cap length + charset (schema shape): the agentId is embedded in the store
+  // key, so an uncapped value pins attacker-controlled memory per request.
+  if (!isValidAgentId(agentId)) {
+    return c.json<ApiResponse>({ ok: false, error: "invalid agentId" }, 400);
+  }
 
-  const issued = await issueEnrollChallenge(challengeStore, agentId);
+  const issued = await issueEnrollChallenge(getAuthChallengeStore(), agentId);
   if (!issued.ok) {
     return c.json<ApiResponse>({ ok: false, error: "enrollment unavailable" }, 503);
   }
@@ -95,6 +120,15 @@ agentEnrollRoutes.post("/challenge", async (c) => {
 
 // ── POST /verify ─────────────────────────────────────────────────────────────
 agentEnrollRoutes.post("/verify", async (c) => {
+  const rl = await checkAuthRateLimit(c, "agent-enroll-verify", 60_000, 20);
+  if (!rl.allowed) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Too many enrollment attempts. Try again later." },
+      429,
+      { "Retry-After": String(rl.retryAfterSecs ?? 60) },
+    );
+  }
+
   const body = await safeJsonParse<{
     agentId?: unknown;
     nonce?: unknown;
@@ -106,6 +140,9 @@ agentEnrollRoutes.post("/verify", async (c) => {
   if (!agentId || !nonce || !signature) {
     return c.json<ApiResponse>({ ok: false, error: "agentId, nonce and signature required" }, 400);
   }
+  if (!isValidAgentId(agentId)) {
+    return c.json<ApiResponse>({ ok: false, error: "invalid agentId" }, 400);
+  }
 
   // Resolve signers ONCE; the enrollment core is handed a thin resolver closure so
   // it stays db-agnostic. We keep the tenant from the same query.
@@ -116,7 +153,7 @@ agentEnrollRoutes.post("/verify", async (c) => {
     return signers;
   };
 
-  const result = await verifyEnrollResponse(challengeStore, resolver, {
+  const result = await verifyEnrollResponse(getAuthChallengeStore(), resolver, {
     agentId,
     nonce,
     signature,

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -1043,6 +1043,7 @@ export async function verifySessionToken(token: string): Promise<{
       userId?: string;
       email?: string;
       typ?: string;
+      tokenType?: string;
       jti?: string;
       exp?: number;
       iat?: number;
@@ -1052,6 +1053,8 @@ export async function verifySessionToken(token: string): Promise<{
       mfaMethod?: string;
     };
     if (payload.typ === "identity") return null;
+    // Never accept a refresh JWT as an access token (SEC-055).
+    if (payload.tokenType === "refresh") return null;
     await assertTokenNotRevoked(payload);
     if (payload.userId) {
       const [user] = await getDb()

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -448,7 +448,7 @@ function authRateLimitOutageAllow(endpoint: string, err?: unknown): boolean {
  * @param max      - Max requests in the window (×5 for coarse fallback subjects)
  * @param subjectOverride - Per-target subject (e.g. destination email); hashed at key build
  */
-async function checkAuthRateLimit(
+export async function checkAuthRateLimit(
   c: Context,
   endpoint: string,
   windowMs: number,
@@ -1283,6 +1283,13 @@ function getChallengeStore(): ChallengeStore {
   _challengeStore ??= new ChallengeStore();
   return _challengeStore;
 }
+
+/**
+ * Exported for the public agent-enroll routes: enrollment challenges must
+ * share this initialized (Redis/Postgres in production) store instead of the
+ * auth package's process-local memory singleton (SEC-052).
+ */
+export { getChallengeStore as getAuthChallengeStore };
 
 function getOAuthCodeStore(): ChallengeStore {
   _oauthCodeStore ??= new ChallengeStore({ ttlMs: OAUTH_CODE_TTL_MS });

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -146,6 +146,7 @@ import {
   verifyCaptchaToken,
 } from "../services/auth-abuse";
 import { verifyEip1271 } from "../services/eip1271";
+import { isAllowedOidcClientSecretEnv } from "../services/oidc-provider-config";
 import { buildSamlServiceProviderUrls } from "../services/saml-sso-config";
 import { lockUserSession } from "../services/session-lock";
 import { testAccountOtpMatches } from "../services/test-account-credentials";
@@ -10298,6 +10299,11 @@ async function exchangeOidcAuthorizationCode(opts: {
     code_verifier: codeVerifier,
   });
   if (provider.clientSecretEnv) {
+    // Defense in depth: legacy rows may predate the config-time allowlist, so
+    // re-enforce the dedicated env namespace before reading any secret.
+    if (!isAllowedOidcClientSecretEnv(provider.clientSecretEnv)) {
+      throw new Error("OIDC client secret env is outside the allowed tenant namespace");
+    }
     const secret = process.env[provider.clientSecretEnv];
     if (!secret) throw new Error(`OIDC client secret env ${provider.clientSecretEnv} is not set`);
     body.set("client_secret", secret);

--- a/packages/api/src/services/context.ts
+++ b/packages/api/src/services/context.ts
@@ -161,6 +161,7 @@ export async function verifySessionToken(token: string) {
       scope?: string;
       scopes?: string[];
       typ?: string;
+      tokenType?: string;
       userId?: string;
       email?: string;
       mfaVerifiedAt?: number;
@@ -169,6 +170,8 @@ export async function verifySessionToken(token: string) {
       exp?: number;
     };
     if (payload.typ === "identity") return null;
+    // Never accept a refresh JWT as an access token (SEC-055).
+    if (payload.tokenType === "refresh") return null;
     await assertTokenNotRevoked(payload);
     if (payload.userId) {
       const [user] = await getDb()

--- a/packages/api/src/services/oidc-provider-config.ts
+++ b/packages/api/src/services/oidc-provider-config.ts
@@ -1,6 +1,18 @@
 import type { TenantOidcProviderConfig } from "@stwd/shared";
 import { validateWebhookUrl } from "./webhook-url";
 
+/**
+ * Tenant-configured OIDC client secrets may only be sourced from env vars in
+ * this dedicated namespace. Without the prefix, a tenant admin could point
+ * `clientSecretEnv` at any platform secret (e.g. STEWARD_JWT_SECRET) and have
+ * it POSTed to a tenant-controlled tokenUrl during code exchange (SEC-005).
+ */
+export const OIDC_CLIENT_SECRET_ENV_PREFIX = "STEWARD_TENANT_OIDC_SECRET_";
+
+export function isAllowedOidcClientSecretEnv(name: string): boolean {
+  return /^[A-Z_][A-Z0-9_]{0,127}$/.test(name) && name.startsWith(OIDC_CLIENT_SECRET_ENV_PREFIX);
+}
+
 function isNonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
 }
@@ -67,8 +79,8 @@ export function normalizeOidcProviders(value: unknown): TenantOidcProviderConfig
     if (clientId && clientId.length > 256) {
       return `clientId for provider ${id} may be at most 256 characters`;
     }
-    if (clientSecretEnv && !/^[A-Z_][A-Z0-9_]{0,127}$/.test(clientSecretEnv)) {
-      return `clientSecretEnv for provider ${id} must be an environment variable name`;
+    if (clientSecretEnv && !isAllowedOidcClientSecretEnv(clientSecretEnv)) {
+      return `clientSecretEnv for provider ${id} must be an environment variable name starting with ${OIDC_CLIENT_SECRET_ENV_PREFIX}`;
     }
     if (
       authorizationUrl &&

--- a/packages/auth/src/__tests__/agent-enroll.test.ts
+++ b/packages/auth/src/__tests__/agent-enroll.test.ts
@@ -220,4 +220,26 @@ describe("agent enrollment (keypair-only self-auth)", () => {
     const s = buildEnrollCanonicalString({ agentId: "a", nonce: "n", issuedAt: 42 });
     expect(s).toBe(`${AGENT_ENROLL_DOMAIN}\na\nn\n42`);
   });
+
+  test("agentId is length- and charset-capped before it reaches the store (SEC-051)", async () => {
+    const store = new ChallengeStore();
+    const oversized = "a".repeat(200);
+    const issued = await issueEnrollChallenge(store, oversized);
+    expect(issued.ok).toBe(false);
+    expect(store.size).toBe(0);
+
+    for (const bad of ["agent id", "agent/id", "agent\nid", "é".repeat(10)]) {
+      const res = await issueEnrollChallenge(store, bad);
+      expect(res.ok).toBe(false);
+    }
+    expect(store.size).toBe(0);
+
+    const verified = await verifyEnrollResponse(store, resolverFor({}), {
+      agentId: oversized,
+      nonce: "n",
+      signature: "s",
+    });
+    expect(verified).toEqual({ ok: false, error: "invalid agentId", code: "invalid_input" });
+    store.destroy();
+  });
 });

--- a/packages/auth/src/__tests__/authorization-keys.test.ts
+++ b/packages/auth/src/__tests__/authorization-keys.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  generateP256KeyPair,
+  importP256PublicKey,
+  signP256,
+  verifyP256Signature,
+} from "../authorization-keys";
+
+function base64ToBytes(value: string): Uint8Array {
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+describe("decodeFlexible hex/base64 disambiguation (SEC-063)", () => {
+  test("bare-hex raw-point public keys import and verify", async () => {
+    const kp = await generateP256KeyPair();
+    const rawHex = bytesToHex(base64ToBytes(kp.publicKeyRawBase64));
+    // Guard the premise: this bare-hex string is ALSO valid base64 alphabet,
+    // so a base64-first decode misreads it (the bug being regressed against).
+    expect(/^[0-9a-fA-F]+$/.test(rawHex)).toBe(true);
+
+    const key = await importP256PublicKey(rawHex);
+    expect(key).not.toBeNull();
+
+    const message = "steward:test:sec063";
+    const signature = await signP256(kp.privateKey, message);
+    expect(await verifyP256Signature(rawHex, message, signature)).toBe(true);
+  });
+
+  test("bare-hex SPKI public keys import", async () => {
+    const kp = await generateP256KeyPair();
+    const spkiHex = bytesToHex(base64ToBytes(kp.publicKeySpkiBase64));
+    const key = await importP256PublicKey(spkiHex);
+    expect(key).not.toBeNull();
+
+    const message = "steward:test:sec063-spki";
+    const signature = await signP256(kp.privateKey, message);
+    expect(await verifyP256Signature(spkiHex, message, signature)).toBe(true);
+  });
+
+  test("bare-hex P1363 signatures verify against base64 keys", async () => {
+    const kp = await generateP256KeyPair();
+    const message = "steward:test:sec063-sig";
+    const sigHex = bytesToHex(base64ToBytes(await signP256(kp.privateKey, message)));
+    expect(/^[0-9a-fA-F]+$/.test(sigHex)).toBe(true);
+    expect(await verifyP256Signature(kp.publicKeySpkiBase64, message, sigHex)).toBe(true);
+  });
+
+  test("base64 encodings still take precedence and verify", async () => {
+    const kp = await generateP256KeyPair();
+    const message = "steward:test:sec063-base64";
+    const signature = await signP256(kp.privateKey, message);
+    expect(await verifyP256Signature(kp.publicKeySpkiBase64, message, signature)).toBe(true);
+    expect(await verifyP256Signature(kp.publicKeyRawBase64, message, signature)).toBe(true);
+  });
+
+  test("garbage input still fails closed", async () => {
+    expect(await importP256PublicKey("not-a-key!!!")).toBeNull();
+    expect(await verifyP256Signature("not-a-key!!!", "m", "c2ln")).toBe(false);
+  });
+});

--- a/packages/auth/src/__tests__/farcaster.test.ts
+++ b/packages/auth/src/__tests__/farcaster.test.ts
@@ -88,7 +88,7 @@ describe("Farcaster SIWF verifier", () => {
     });
 
     expect(verified).toMatchObject({
-      fid: "4242",
+      claimedFid: "4242",
       custodyAddress: account.address,
       username: "alice",
       displayName: "Alice",

--- a/packages/auth/src/__tests__/jwt.test.ts
+++ b/packages/auth/src/__tests__/jwt.test.ts
@@ -64,3 +64,66 @@ describe("getJwtSecret embedded-mode master password fallback (SEC-013)", () => 
     expect(getJwtSecret({ warn: null })).toBe("explicit-jwt-secret-with-32-characters!!");
   });
 });
+
+describe("JWT secret strength policy (SEC-053, SEC-054)", () => {
+  it("hard-fails short configured secrets in production regardless of source", async () => {
+    const { checkJwtSecretStrength } = await import("../jwt");
+    expect(() =>
+      checkJwtSecretStrength("abc123", "STEWARD_JWT_SECRET", { nodeEnv: "production" }),
+    ).toThrow("must be at least 32 characters in production");
+  });
+
+  it("warns (does not throw) on short configured secrets outside production", async () => {
+    // Fresh module instance so the warn-once flag starts clean.
+    const { checkJwtSecretStrength } = await import(`../jwt?sec053=${Date.now()}`);
+    const warnings: string[] = [];
+    checkJwtSecretStrength("abc123", "STEWARD_JWT_SECRET", {
+      nodeEnv: "staging",
+      warn: (m) => warnings.push(m),
+    });
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toContain("shorter than 32 characters");
+  });
+
+  it("accepts 32+ character secrets silently", async () => {
+    const { checkJwtSecretStrength } = await import(`../jwt?sec053b=${Date.now()}`);
+    const warnings: string[] = [];
+    checkJwtSecretStrength("a".repeat(32), "STEWARD_JWT_SECRET", {
+      nodeEnv: "staging",
+      warn: (m) => warnings.push(m),
+    });
+    expect(warnings.length).toBe(0);
+  });
+
+  it("getJwtSecret warns on a short configured secret in staging", async () => {
+    const { getJwtSecret: freshGetJwtSecret } = await import(`../jwt?sec053c=${Date.now()}`);
+    const savedSecret = process.env.STEWARD_JWT_SECRET;
+    const savedEnv = process.env.NODE_ENV;
+    process.env.STEWARD_JWT_SECRET = "abc123";
+    process.env.NODE_ENV = "staging";
+    try {
+      const warnings: string[] = [];
+      expect(freshGetJwtSecret({ warn: (m) => warnings.push(m) })).toBe("abc123");
+      expect(warnings.some((m) => m.includes("shorter than 32 characters"))).toBe(true);
+    } finally {
+      if (savedSecret === undefined) delete process.env.STEWARD_JWT_SECRET;
+      else process.env.STEWARD_JWT_SECRET = savedSecret;
+      if (savedEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = savedEnv;
+    }
+  });
+
+  it("SessionManager rejects an explicit short secret in production (SEC-054)", async () => {
+    const { SessionManager } = await import(`../session?sec054=${Date.now()}`);
+    const savedEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    try {
+      expect(() => new SessionManager({ secret: "sixteen-chars-xx" })).toThrow(
+        "must be at least 32 characters in production",
+      );
+    } finally {
+      if (savedEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = savedEnv;
+    }
+  });
+});

--- a/packages/auth/src/__tests__/jwt.test.ts
+++ b/packages/auth/src/__tests__/jwt.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { scryptSync } from "node:crypto";
+
+import { getJwtSecret, signAccessToken, verifyToken } from "../jwt";
+
+const ENV_KEYS = [
+  "STEWARD_JWT_SECRET",
+  "STEWARD_SESSION_SECRET",
+  "STEWARD_MASTER_PASSWORD",
+  "STEWARD_DB_MODE",
+  "STEWARD_EMBEDDED",
+  "STEWARD_EMBEDDED_MODE",
+  "DATABASE_URL",
+  "STEWARD_ALLOW_DEV_SECRETS",
+  "NODE_ENV",
+] as const;
+
+describe("getJwtSecret embedded-mode master password fallback (SEC-013)", () => {
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+    process.env.STEWARD_DB_MODE = "pglite";
+    process.env.STEWARD_MASTER_PASSWORD = "embedded-master-password-for-tests";
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (saved[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = saved[key];
+      }
+    }
+  });
+
+  it("never uses the raw master password as the JWT secret", () => {
+    const secret = getJwtSecret({ warn: null });
+    expect(secret).not.toBe(process.env.STEWARD_MASTER_PASSWORD);
+    expect(secret.length).toBeGreaterThanOrEqual(32);
+  });
+
+  it("derives the JWT secret via domain-separated scrypt", () => {
+    const expected = (
+      scryptSync("embedded-master-password-for-tests", "steward-kdf:jwt-signing:v1", 32) as Buffer
+    ).toString("hex");
+    expect(getJwtSecret({ warn: null })).toBe(expected);
+  });
+
+  it("signs and verifies tokens with the derived secret", async () => {
+    const token = await signAccessToken({
+      address: "0x0000000000000000000000000000000000000000",
+      tenantId: "default",
+    });
+    const payload = await verifyToken(token);
+    expect(payload.tenantId).toBe("default");
+  });
+
+  it("prefers an explicit STEWARD_JWT_SECRET over the derivation", () => {
+    process.env.STEWARD_JWT_SECRET = "explicit-jwt-secret-with-32-characters!!";
+    expect(getJwtSecret({ warn: null })).toBe("explicit-jwt-secret-with-32-characters!!");
+  });
+});

--- a/packages/auth/src/__tests__/lockout.test.ts
+++ b/packages/auth/src/__tests__/lockout.test.ts
@@ -96,4 +96,32 @@ describe("Lockout", () => {
     await lo.recordFailure("x");
     expect(store.get("x")?.lockedUntil).toBeGreaterThan(0);
   });
+
+  test("checkAndRecord atomically consumes budget on parallel attempts (SEC-057)", async () => {
+    const clock = frozenClock();
+    const lo = new Lockout({ maxAttempts: 3, lockoutMs: 1000, now: clock.now });
+    // With check()+recordFailure(), three parallel attempts would all pass the
+    // check before any failure is recorded. checkAndRecord cannot interleave
+    // with the default synchronous store: the third call already locks.
+    const results = await Promise.all([
+      lo.checkAndRecord("u1"),
+      lo.checkAndRecord("u1"),
+      lo.checkAndRecord("u1"),
+    ]);
+    expect(results[0]).toEqual({ allowed: true, remaining: 2 });
+    expect(results[1]).toEqual({ allowed: true, remaining: 1 });
+    expect(results[2].allowed).toBe(false);
+    expect(results[2].retryAfterMs).toBe(1000);
+  });
+
+  test("checkAndRecord starts fresh after the idle window and honors locks", async () => {
+    const clock = frozenClock();
+    const lo = new Lockout({ maxAttempts: 2, lockoutMs: 1000, idleResetMs: 5000, now: clock.now });
+    await lo.checkAndRecord("u1");
+    const locked = await lo.checkAndRecord("u1");
+    expect(locked.allowed).toBe(false);
+    clock.advance(6000);
+    const fresh = await lo.checkAndRecord("u1");
+    expect(fresh).toEqual({ allowed: true, remaining: 1 });
+  });
 });

--- a/packages/auth/src/__tests__/recovery-codes.test.ts
+++ b/packages/auth/src/__tests__/recovery-codes.test.ts
@@ -36,8 +36,24 @@ describe("generateRecoveryCodes + verifyRecoveryCode", () => {
     const norms = codes.map(normalize);
     expect(new Set(norms).size).toBe(10);
     for (const n of norms) {
-      expect(n).toMatch(/^[A-HJ-NP-Z2-9]{10}$/);
+      expect(n).toMatch(/^[A-HJ-NP-Z2-9]{14}$/);
     }
+  });
+
+  test("legacy 10-char codes still verify (SEC-064 grace), new codes are 14 chars", async () => {
+    const store = new InMemoryRecoveryCodeStore();
+    // Simulate a pre-upgrade stored code: 10 chars, salted single SHA-256.
+    const legacyRaw = "ABCDEFGHJK";
+    const legacySalt = "SALTSALTSALTSALT";
+    const { createHash } = await import("node:crypto");
+    const legacyHash = createHash("sha256").update(`${legacySalt}:${legacyRaw}`).digest("hex");
+    await store.replaceForUser(USER, [{ hash: legacyHash, salt: legacySalt }]);
+
+    const legacy = await verifyRecoveryCode(store, USER, "ABCDE-FGHJK");
+    expect(legacy.valid).toBe(true);
+
+    const codes = await generateRecoveryCodes(store, USER, 1);
+    expect(normalize(codes[0])).toHaveLength(14);
   });
 
   test("returns valid=true for any issued code, then refuses replay", async () => {

--- a/packages/auth/src/__tests__/saml.test.ts
+++ b/packages/auth/src/__tests__/saml.test.ts
@@ -210,7 +210,7 @@ describe("SAML ACS verifier hardening", () => {
     expect(source).toContain("callbackUrl: input.acsUrl");
     expect(source).toContain("idpIssuer: input.idpEntityId");
     expect(source).toContain("ValidateInResponseTo.always");
-    expect(source).toContain("cacheProvider: new SingleUseInResponseToCache");
+    expect(source).toContain("cacheProvider: new ExpectedRequestIdEchoCache");
     expect(source).toContain('signatureAlgorithm: "sha256"');
     expect(source).toContain('digestAlgorithm: "sha256"');
     expect(source).toContain("SAML assertion ID is required for replay protection");

--- a/packages/auth/src/__tests__/session-revocation.test.ts
+++ b/packages/auth/src/__tests__/session-revocation.test.ts
@@ -132,4 +132,43 @@ describe("session revocation", () => {
       }
     }
   });
+
+  it("rejects refresh JWTs as session tokens (SEC-055)", async () => {
+    const sessions = new SessionManager({ secret, expiresIn: "1h" });
+    const refresh = await sessions.createSession("user-refresh-confusion", {
+      tokenType: "refresh",
+    });
+    expect(await sessions.verifySession(refresh)).toBeNull();
+  });
+
+  it("warns loudly when revocation degrades to per-process memory (SEC-056)", async () => {
+    const previousNodeEnv = process.env.NODE_ENV;
+    const previousRedisUrl = process.env.REDIS_URL;
+    delete process.env.NODE_ENV;
+    delete process.env.REDIS_URL;
+
+    const originalWarn = console.warn;
+    const warnings: string[] = [];
+    console.warn = (message?: unknown, ...rest: unknown[]) => {
+      warnings.push([message, ...rest].join(" "));
+    };
+    try {
+      // Fresh module instance so the warn-once flag starts clean.
+      const { revocationStore: freshStore } = await import(`../revocation?sec056=${Date.now()}`);
+      await freshStore.isRevoked("sec056-probe");
+      expect(warnings.some((m) => m.includes("per-process memory"))).toBe(true);
+    } finally {
+      console.warn = originalWarn;
+      if (previousNodeEnv === undefined) {
+        delete process.env.NODE_ENV;
+      } else {
+        process.env.NODE_ENV = previousNodeEnv;
+      }
+      if (previousRedisUrl === undefined) {
+        delete process.env.REDIS_URL;
+      } else {
+        process.env.REDIS_URL = previousRedisUrl;
+      }
+    }
+  });
 });

--- a/packages/auth/src/__tests__/siwe-guard.test.ts
+++ b/packages/auth/src/__tests__/siwe-guard.test.ts
@@ -101,4 +101,23 @@ describe("evaluateSiwePolicy", () => {
     void allowedChainIds;
     expect(evaluateSiwePolicy({ ...base, chainId: 999_999 }, rest)).toBeNull();
   });
+
+  test("rejects a message with no expirationTime once its issuedAt age exceeds maxLifetimeMs (SEC-065)", () => {
+    const { expirationTime, ...noExpiry } = base;
+    void expirationTime;
+    // issuedAt is 30s ago — within the 10-minute bound, still accepted.
+    expect(evaluateSiwePolicy(noExpiry, policy)).toBeNull();
+    // issuedAt is 20 minutes ago — rejected even though nothing "expired".
+    expect(evaluateSiwePolicy({ ...noExpiry, issuedAt: "2026-05-21T11:39:59Z" }, policy)).toBe(
+      "lifetime-too-long",
+    );
+  });
+
+  test("rejects a future-dated issuedAt beyond clock skew (SEC-065)", () => {
+    expect(evaluateSiwePolicy({ ...base, issuedAt: "2026-05-21T12:05:00Z" }, policy)).toBe(
+      "not-yet-valid",
+    );
+    // Within skew — tolerated.
+    expect(evaluateSiwePolicy({ ...base, issuedAt: "2026-05-21T12:00:15Z" }, policy)).toBeNull();
+  });
 });

--- a/packages/auth/src/agent-enroll.ts
+++ b/packages/auth/src/agent-enroll.ts
@@ -47,6 +47,11 @@ export const AGENT_ENROLL_DOMAIN = "steward:agent-enroll:v1";
  * immediately at boot; a stale challenge is worthless. */
 export const AGENT_ENROLL_CHALLENGE_TTL_MS = 2 * 60 * 1000;
 
+/** Agent-id shape accepted by the enrollment core (matches the API's
+ * isValidAgentId / agents schema charset). The id is embedded in challenge
+ * store keys, so the length cap bounds per-challenge memory (SEC-051). */
+export const AGENT_ENROLL_AGENT_ID_RE = /^[a-zA-Z0-9_\-.:]{1,128}$/;
+
 /** Key namespace inside the ChallengeStore so agent-enroll nonces never collide
  * with WebAuthn challenges sharing the same backend. */
 function challengeKey(agentId: string, nonce: string): string {
@@ -97,6 +102,9 @@ export async function issueEnrollChallenge(
 ): Promise<IssueChallengeResult> {
   const trimmed = typeof agentId === "string" ? agentId.trim() : "";
   if (!trimmed) return { ok: false, error: "agentId required" };
+  if (!AGENT_ENROLL_AGENT_ID_RE.test(trimmed)) {
+    return { ok: false, error: "invalid agentId" };
+  }
   const now = opts.now ?? Date.now();
   const ttlMs = opts.ttlMs ?? AGENT_ENROLL_CHALLENGE_TTL_MS;
   const nonce = randomUUID();
@@ -185,6 +193,9 @@ export async function verifyEnrollResponse(
   const signature = typeof input.signature === "string" ? input.signature.trim() : "";
   if (!agentId || !nonce || !signature) {
     return { ok: false, error: "agentId, nonce and signature required", code: "invalid_input" };
+  }
+  if (!AGENT_ENROLL_AGENT_ID_RE.test(agentId)) {
+    return { ok: false, error: "invalid agentId", code: "invalid_input" };
   }
 
   const now = input.now ?? Date.now();

--- a/packages/auth/src/authorization-keys.ts
+++ b/packages/auth/src/authorization-keys.ts
@@ -72,17 +72,37 @@ function hexToBytes(value: string): Uint8Array | null {
   return bytes;
 }
 
-/** Decode a string that may be hex (with/without 0x) or base64/base64url. */
-function decodeFlexible(value: string): Uint8Array | null {
+/**
+ * Decode a string that may be hex (with/without 0x) or base64/base64url into
+ * CANDIDATE byte decodings, most-likely first.
+ *
+ * Every even-length bare-hex string is also valid base64 alphabet, so a single
+ * decode is ambiguous (SEC-063): decoding base64-first makes documented
+ * bare-hex encodings unreachable, and decoding hex-first would misread
+ * all-hex-alphabet base64. Callers must therefore try each candidate in order
+ * and keep the first whose bytes actually import/normalize — the format check
+ * downstream disambiguates, and every failure still fails closed.
+ */
+function decodeFlexibleCandidates(value: string): Uint8Array[] {
   const trimmed = value.trim();
-  if (!trimmed) return null;
-  if (/^0x[0-9a-fA-F]+$/.test(trimmed)) return hexToBytes(trimmed);
-  // A pure even-length hex string is ambiguous with base64; prefer hex only when
-  // it cannot also be the canonical raw point misread. We try base64 first
-  // (covers SPKI + base64 raw), then fall back to hex.
+  if (!trimmed) return [];
+  if (/^0x[0-9a-fA-F]+$/.test(trimmed)) {
+    const hex = hexToBytes(trimmed);
+    return hex ? [hex] : [];
+  }
+  const candidates: Uint8Array[] = [];
   const asBase64 = base64ToBytes(trimmed);
-  if (asBase64) return asBase64;
-  return hexToBytes(trimmed);
+  if (asBase64) candidates.push(asBase64);
+  const asHex = hexToBytes(trimmed);
+  if (
+    asHex &&
+    (!asBase64 ||
+      asHex.length !== asBase64.length ||
+      asHex.some((byte, index) => byte !== asBase64[index]))
+  ) {
+    candidates.push(asHex);
+  }
+  return candidates;
 }
 
 function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
@@ -195,30 +215,26 @@ export async function importP256PublicKey(input: P256PublicKeyInput): Promise<Cr
       return await crypto.subtle.importKey("jwk", parsed, EC_KEY_IMPORT_PARAMS, false, ["verify"]);
     }
 
-    const bytes = decodeFlexible(text);
-    if (!bytes) return null;
+    const candidates = decodeFlexibleCandidates(text);
+    for (const bytes of candidates) {
+      // Raw uncompressed EC point: 0x04 || X || Y.
+      if (bytes.length === P256_RAW_POINT_BYTES && bytes[0] === 0x04) {
+        const key = await crypto.subtle
+          .importKey("raw", toArrayBuffer(bytes), EC_KEY_IMPORT_PARAMS, false, ["verify"])
+          .catch(() => null);
+        if (key) return key;
+        continue;
+      }
 
-    // Raw uncompressed EC point: 0x04 || X || Y.
-    if (bytes.length === P256_RAW_POINT_BYTES && bytes[0] === 0x04) {
-      return await crypto.subtle.importKey(
-        "raw",
-        toArrayBuffer(bytes),
-        EC_KEY_IMPORT_PARAMS,
-        false,
-        ["verify"],
-      );
+      // Otherwise treat as SPKI/DER. importKey enforces the curve, so a P-384 /
+      // secp256k1 SPKI blob is rejected here (fail closed) because namedCurve
+      // mismatches.
+      const key = await crypto.subtle
+        .importKey("spki", toArrayBuffer(bytes), EC_KEY_IMPORT_PARAMS, false, ["verify"])
+        .catch(() => null);
+      if (key) return key;
     }
-
-    // Otherwise treat as SPKI/DER. importKey enforces the curve, so a P-384 /
-    // secp256k1 SPKI blob is rejected here (fail closed) because namedCurve
-    // mismatches.
-    return await crypto.subtle.importKey(
-      "spki",
-      toArrayBuffer(bytes),
-      EC_KEY_IMPORT_PARAMS,
-      false,
-      ["verify"],
-    );
+    return null;
   } catch {
     return null;
   }
@@ -243,9 +259,11 @@ export async function verifyP256Signature(
     const key = await importP256PublicKey(publicKey);
     if (!key) return false;
 
-    const sigBytes = decodeFlexible(signatureBase64);
-    if (!sigBytes) return false;
-    const normalized = normalizeSignatureBytes(sigBytes);
+    // Try each decoding candidate (base64 vs bare-hex ambiguity, SEC-063)
+    // until one normalizes to a fixed-width r||s signature.
+    const normalized = decodeFlexibleCandidates(signatureBase64)
+      .map((bytes) => normalizeSignatureBytes(bytes))
+      .find((bytes) => bytes !== null);
     if (!normalized) return false;
 
     const data = new TextEncoder().encode(canonicalString);

--- a/packages/auth/src/farcaster.ts
+++ b/packages/auth/src/farcaster.ts
@@ -25,11 +25,22 @@ export interface ParsedSiwfMessage {
   notBefore?: string;
   requestId?: string;
   resources: string[];
+  /** fid claimed by the message's farcaster:// resource — self-signed, NOT
+   * verified against a hub/IdRegistry (SEC-058). Unverified metadata only. */
   fid?: string;
 }
 
 export interface VerifiedFarcasterUser {
-  fid: string;
+  /**
+   * The fid CLAIMED by the self-signed SIWF message's `farcaster://fid/N`
+   * resource. NOT cryptographically bound to the signer (SEC-058): anyone can
+   * place any fid in their own signed message, so this is unverified metadata.
+   * Never key identity or authorization decisions on it — use
+   * `custodyAddress`, which IS signature-verified. A verified fid would
+   * require checking the fid→custody-address binding against a Farcaster
+   * hub / the IdRegistry contract.
+   */
+  claimedFid: string;
   custodyAddress: `0x${string}`;
   username?: string;
   displayName?: string;
@@ -44,6 +55,8 @@ export interface VerifyFarcasterLoginOptions {
   nowMs?: number;
   clockSkewMs?: number;
   maxMessageAgeMs?: number;
+  /** Require a fid CLAIM to be present in the signed message (default true).
+   * Note the claim is unverified metadata — see VerifiedFarcasterUser.claimedFid. */
   requireFid?: boolean;
 }
 
@@ -280,7 +293,7 @@ export async function verifyFarcasterLogin(
   if ((options.requireFid ?? true) && !fid) throw new Error("Farcaster fid is required");
 
   return {
-    fid: fid ?? "",
+    claimedFid: fid ?? "",
     custodyAddress: parsed.address,
     username: optionalString(payload.username),
     displayName: optionalString(payload.displayName),

--- a/packages/auth/src/jwt.ts
+++ b/packages/auth/src/jwt.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { randomUUID, scryptSync } from "node:crypto";
 import {
   calculateJwkThumbprint,
   exportJWK,
@@ -68,6 +68,34 @@ let warnedDeprecatedSessionSecret = false;
 let warnedEmbeddedMasterFallback = false;
 let warnedDevSecret = false;
 
+/**
+ * Embedded-mode JWT secret derivation cache. Deriving via scrypt costs ~50ms,
+ * and getJwtSecret() runs on every token sign/verify, so the derived key is
+ * memoized per distinct source password.
+ */
+let embeddedJwtDerivation: { source: string; derived: string } | null = null;
+
+/**
+ * Derive the embedded-mode JWT signing secret from STEWARD_MASTER_PASSWORD.
+ *
+ * The raw master password is NEVER used as the JWT secret (SEC-013): every
+ * issued HS256 JWT would otherwise be an unlimited fast offline brute-force
+ * oracle against the same password that encrypts vault keys. Instead the JWT
+ * secret is scrypt-derived with a domain-separation label (same idiom as the
+ * vault's KeyStore domains), so the JWT key is cryptographically independent
+ * from the vault root key and offline guesses cost a scrypt each.
+ */
+function deriveEmbeddedJwtSecret(masterPassword: string): string {
+  if (embeddedJwtDerivation && embeddedJwtDerivation.source === masterPassword) {
+    return embeddedJwtDerivation.derived;
+  }
+  const derived = (scryptSync(masterPassword, "steward-kdf:jwt-signing:v1", 32) as Buffer).toString(
+    "hex",
+  );
+  embeddedJwtDerivation = { source: masterPassword, derived };
+  return derived;
+}
+
 function isEmbeddedMode(): boolean {
   return (
     process.env.STEWARD_EMBEDDED === "true" ||
@@ -112,7 +140,7 @@ function warnOnce(kind: "session" | "master" | "dev", warn: ((message: string) =
     if (warnedEmbeddedMasterFallback) return;
     warnedEmbeddedMasterFallback = true;
     warn(
-      "⚠️ [EMBEDDED/DEV ONLY] Falling back to STEWARD_MASTER_PASSWORD for JWTs. Set STEWARD_JWT_SECRET for server deployments.",
+      "⚠️ [EMBEDDED/DEV ONLY] Deriving the JWT secret from STEWARD_MASTER_PASSWORD via domain-separated scrypt. Set STEWARD_JWT_SECRET for server deployments.",
     );
     return;
   }
@@ -128,7 +156,8 @@ function warnOnce(kind: "session" | "master" | "dev", warn: ((message: string) =
  *
  * Canonical env var: STEWARD_JWT_SECRET.
  * Deprecated compatibility fallback: STEWARD_SESSION_SECRET.
- * STEWARD_MASTER_PASSWORD is only accepted in embedded/local dev mode.
+ * In embedded/local dev mode only, STEWARD_MASTER_PASSWORD is accepted as
+ * derivation input — never used verbatim (see deriveEmbeddedJwtSecret).
  */
 export function getJwtSecret(options: JwtSecretOptions = {}): string {
   const nodeEnv = options.nodeEnv ?? process.env.NODE_ENV;
@@ -152,7 +181,7 @@ export function getJwtSecret(options: JwtSecretOptions = {}): string {
     warnOnce("session", warn);
   } else if (isEmbeddedMode() && process.env.STEWARD_MASTER_PASSWORD) {
     sourceName = "STEWARD_MASTER_PASSWORD";
-    secret = process.env.STEWARD_MASTER_PASSWORD;
+    secret = deriveEmbeddedJwtSecret(process.env.STEWARD_MASTER_PASSWORD);
     warnOnce("master", warn);
   } else {
     sourceName = "dev-secret";

--- a/packages/auth/src/jwt.ts
+++ b/packages/auth/src/jwt.ts
@@ -67,6 +67,7 @@ export interface IdentityJwtConfig {
 let warnedDeprecatedSessionSecret = false;
 let warnedEmbeddedMasterFallback = false;
 let warnedDevSecret = false;
+let warnedShortSecret = false;
 
 /**
  * Embedded-mode JWT secret derivation cache. Deriving via scrypt costs ~50ms,
@@ -152,6 +153,34 @@ function warnOnce(kind: "session" | "master" | "dev", warn: ((message: string) =
 }
 
 /**
+ * Length policy for any CONFIGURED JWT secret (SEC-053): production hard-fails
+ * below 32 characters; other environments still accept shorter values (tests
+ * and local dev rely on them) but warn loudly once, so a staging/preview
+ * deploy with a weak secret is visible in logs instead of silently issuing
+ * brute-forceable tokens. The explicit dev-secret fallback is not routed here.
+ */
+export function checkJwtSecretStrength(
+  secret: string,
+  sourceName: string,
+  options: { nodeEnv?: string; warn?: ((message: string) => void) | null } = {},
+): void {
+  if (secret.length >= 32) return;
+  const nodeEnv = options.nodeEnv ?? process.env.NODE_ENV;
+  if (nodeEnv === "production") {
+    throw new Error(
+      `⛔ ${sourceName} must be at least 32 characters in production (canonical env var: STEWARD_JWT_SECRET).`,
+    );
+  }
+  const warn = options.warn === undefined ? console.warn : options.warn;
+  if (!warn || warnedShortSecret) return;
+  warnedShortSecret = true;
+  warn(
+    `⚠️ ${sourceName} is shorter than 32 characters; HS256 tokens are cheap to brute-force offline. ` +
+      "Use a long random secret anywhere outside local tests.",
+  );
+}
+
+/**
  * Resolve Steward's canonical JWT secret.
  *
  * Canonical env var: STEWARD_JWT_SECRET.
@@ -193,11 +222,9 @@ export function getJwtSecret(options: JwtSecretOptions = {}): string {
         "⛔ STEWARD_JWT_SECRET is required in production (minimum 32 characters). STEWARD_SESSION_SECRET is temporarily accepted for migration but deprecated.",
       );
     }
-    if (secret.length < 32) {
-      throw new Error(
-        `⛔ ${sourceName} must be at least 32 characters in production (canonical env var: STEWARD_JWT_SECRET).`,
-      );
-    }
+    checkJwtSecretStrength(secret, sourceName, { nodeEnv, warn });
+  } else if (secret) {
+    checkJwtSecretStrength(secret, sourceName, { nodeEnv, warn });
   }
 
   if (!secret) {

--- a/packages/auth/src/lockout.ts
+++ b/packages/auth/src/lockout.ts
@@ -18,7 +18,16 @@
  * guessers that rotate subjects.
  *
  * Storage is pluggable so production deployments can back this with Redis;
- * the default in-memory store is fine for tests and single-node dev.
+ * the default in-memory store is fine for tests and single-node dev. NOTE:
+ * the default store is per-process — each instance of a multi-instance
+ * deployment gets its own independent guess budget. Use a shared store in
+ * multi-instance deployments.
+ *
+ * Concurrency: `check()` + `recordFailure()` are separate round-trips, so N
+ * parallel attempts can all pass `check()` before any failure is recorded,
+ * multiplying the guess budget by the parallelism factor. Prefer
+ * `checkAndRecord()` on contention-prone endpoints; it is genuinely atomic
+ * with the default (synchronous) in-memory store.
  */
 
 export interface LockoutState {
@@ -142,5 +151,68 @@ export class Lockout {
   /** Clear counter on successful authentication. */
   async recordSuccess(key: string): Promise<void> {
     await this.store.delete(key);
+  }
+
+  /**
+   * Atomically check the budget and, when allowed, record a failure in one
+   * call (SEC-057). Prefer this over check()+recordFailure() pairs: separate
+   * calls let N parallel attempts all pass check() before any failure lands.
+   *
+   * With a synchronous store (the default InMemoryLockoutStore) the
+   * read-modify-write below never yields to the event loop, so it is truly
+   * atomic. With an async remote store the operations can still interleave —
+   * use a backend with server-side atomicity (e.g. a Lua-scripted Redis
+   * store) for strict guarantees across instances.
+   */
+  async checkAndRecord(key: string): Promise<CheckResult> {
+    const stateOrPromise = this.store.get(key);
+    if (stateOrPromise instanceof Promise) {
+      return this.checkAndRecordAsync(key, await stateOrPromise);
+    }
+    // Sync fast path: no awaits, so no interleaving between read and write.
+    return this.checkAndRecordSync(key, stateOrPromise);
+  }
+
+  private checkAndRecordSync(key: string, state: LockoutState | undefined): CheckResult {
+    const now = this.now();
+    const base = state && now - state.lastAttempt <= this.cfg.idleResetMs ? state : undefined;
+    if (base && base.lockedUntil > now) {
+      return { allowed: false, retryAfterMs: base.lockedUntil - now };
+    }
+    const next = this.nextFailureState(base, now);
+    this.store.set(key, next);
+    return this.failureResult(next, now);
+  }
+
+  private async checkAndRecordAsync(
+    key: string,
+    state: LockoutState | undefined,
+  ): Promise<CheckResult> {
+    const now = this.now();
+    const base = state && now - state.lastAttempt <= this.cfg.idleResetMs ? state : undefined;
+    if (base && base.lockedUntil > now) {
+      return { allowed: false, retryAfterMs: base.lockedUntil - now };
+    }
+    const next = this.nextFailureState(base, now);
+    await this.store.set(key, next);
+    return this.failureResult(next, now);
+  }
+
+  private nextFailureState(state: LockoutState | undefined, now: number): LockoutState {
+    const failures = (state?.failures ?? 0) + 1;
+    let lockedUntil = state?.lockedUntil ?? 0;
+    if (failures >= this.cfg.maxAttempts) {
+      const over = failures - this.cfg.maxAttempts;
+      const window = Math.min(this.cfg.lockoutMs * 2 ** over, this.cfg.maxLockoutMs);
+      lockedUntil = now + window;
+    }
+    return { failures, lockedUntil, lastAttempt: now };
+  }
+
+  private failureResult(state: LockoutState, now: number): CheckResult {
+    if (state.lockedUntil > now) {
+      return { allowed: false, retryAfterMs: state.lockedUntil - now };
+    }
+    return { allowed: true, remaining: Math.max(0, this.cfg.maxAttempts - state.failures) };
   }
 }

--- a/packages/auth/src/recovery-codes.ts
+++ b/packages/auth/src/recovery-codes.ts
@@ -2,10 +2,12 @@
  * Recovery codes — single-use backup codes for account recovery.
  *
  * When a user enables passkey/2FA, we issue a small batch (default 10) of
- * recovery codes. Each is a 10-character base32 string (Crockford alphabet,
- * I/L/O removed to avoid 1/0 confusion). The plaintext is shown to the user
+ * recovery codes. Each is a 14-character base32 string (Crockford alphabet,
+ * I/L/O removed to avoid 1/0 confusion); legacy 10-character codes issued
+ * before the length bump still verify. The plaintext is shown to the user
  * exactly once; the server stores only a salted hash. Verification compares
- * by hash and marks the code as used so it cannot be replayed.
+ * by hash (constant-time) and marks the code as used so it cannot be
+ * replayed.
  *
  * Codes are formatted in groups of 5 ("ABCDE-FGHJK") for human readability
  * but stored without the separator. Verification is tolerant of casing and
@@ -16,12 +18,17 @@
  * and tracks which have been consumed.
  */
 
-import { randomInt } from "node:crypto";
+import { randomInt, timingSafeEqual } from "node:crypto";
 
 import { hashSha256Hex } from "./crypto";
 
 const ALPHABET = "ABCDEFGHJKMNPQRSTUVWXYZ23456789"; // 31 chars, ambiguous removed
-const CODE_LEN = 10; // 31^10 ≈ 8.2e14 — well past brute-force with rate-limited verify
+// 14 chars ≈ 69 bits: a dumped/decrypted store no longer yields codes to
+// offline GPU cracking of a single salted SHA-256 (SEC-064). Legacy 10-char
+// codes (~49.5 bits) remain verifiable so existing printouts keep working;
+// rotating codes (regenerate) upgrades a user to the longer form.
+const CODE_LEN = 14;
+const LEGACY_CODE_LEN = 10;
 const DEFAULT_BATCH = 10;
 const SEPARATOR = "-";
 const GROUP_SIZE = 5;
@@ -57,7 +64,7 @@ function generateOne(): string {
 /** Pretty-print a raw code as "ABCDE-FGHJK" without changing its identity. */
 export function formatRecoveryCode(raw: string): string {
   const norm = normalize(raw);
-  if (norm.length !== CODE_LEN) return raw;
+  if (!isAcceptedCodeLength(norm.length)) return raw;
   const parts: string[] = [];
   for (let i = 0; i < norm.length; i += GROUP_SIZE) {
     parts.push(norm.slice(i, i + GROUP_SIZE));
@@ -86,6 +93,18 @@ function saltHex(): string {
 
 function digest(salt: string, normalized: string): string {
   return hashSha256Hex(`${salt}:${normalized}`);
+}
+
+function isAcceptedCodeLength(length: number): boolean {
+  return length === CODE_LEN || length === LEGACY_CODE_LEN;
+}
+
+/** Constant-time hex digest comparison (both sides are sha256 hex). */
+function digestEquals(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  const bufA = Buffer.from(a, "utf8");
+  const bufB = Buffer.from(b, "utf8");
+  return timingSafeEqual(bufA, bufB);
 }
 
 /**
@@ -125,12 +144,12 @@ export async function verifyRecoveryCode(
   supplied: string,
 ): Promise<{ valid: boolean }> {
   const normalized = normalize(supplied);
-  if (normalized.length !== CODE_LEN) return { valid: false };
+  if (!isAcceptedCodeLength(normalized.length)) return { valid: false };
 
   const stored = await store.listForUser(userId);
   for (const row of stored) {
     if (row.usedAt) continue;
-    if (digest(row.salt, normalized) === row.hash) {
+    if (digestEquals(digest(row.salt, normalized), row.hash)) {
       return { valid: await store.markUsed(row.id, new Date()) };
     }
   }

--- a/packages/auth/src/revocation.ts
+++ b/packages/auth/src/revocation.ts
@@ -129,11 +129,22 @@ class InMemoryRevocationStore implements RevocationStore {
 class RedisRevocationStore implements RevocationStore {
   private redis: Redis | null = null;
   private readonly fallback = new InMemoryRevocationStore();
+  private warnedMemoryFallback = false;
 
   private getRedis(): Redis | null {
     if (!process.env.REDIS_URL) {
       if (process.env.NODE_ENV === "production") {
         throw new Error("Shared token revocation store unavailable");
+      }
+      // SEC-056: revocation state silently degrading to per-process memory
+      // breaks logout/user-wide revocation across instances — say so loudly.
+      if (!this.warnedMemoryFallback) {
+        this.warnedMemoryFallback = true;
+        console.warn(
+          "[steward:auth] REDIS_URL unset — token revocation uses per-process memory; " +
+            "logout and user/agent-wide revocation do NOT propagate across instances " +
+            "(production would fail closed).",
+        );
       }
       return null;
     }

--- a/packages/auth/src/saml.ts
+++ b/packages/auth/src/saml.ts
@@ -45,7 +45,21 @@ export interface BuiltSamlAuthorizeUrl {
   requestId: string;
 }
 
-class SingleUseInResponseToCache implements CacheProvider {
+/**
+ * ExpectedRequestIdEchoCache — a CacheProvider that ECHOES the expected
+ * SAML request ID so node-saml's InResponseTo comparison can run against a
+ * caller-verified request id.
+ *
+ * Deliberately NOT a single-use replay cache (despite node-saml's cache
+ * provider shape): getAsync returns the expected id on every call and
+ * removeAsync is a no-op. Actual replay protection lives in the API layer —
+ * the atomic consumeSamlAuthnRequest + the tenantSamlAssertionReplays unique
+ * index — which consumes the authn request before this verifier runs and
+ * rejects duplicate assertion ids at insert time. When no expectedRequestId
+ * is supplied, getAsync returns null and node-saml treats InResponseTo as
+ * "never validate" — IdP-initiated SSO responses carry none by design.
+ */
+class ExpectedRequestIdEchoCache implements CacheProvider {
   constructor(private readonly expectedRequestId?: string) {}
 
   async saveAsync(key: string, value: string): Promise<CacheItem> {
@@ -116,7 +130,7 @@ export async function verifySamlAcsResponse(
     validateInResponseTo: input.expectedRequestId
       ? ValidateInResponseTo.always
       : ValidateInResponseTo.never,
-    cacheProvider: new SingleUseInResponseToCache(input.expectedRequestId),
+    cacheProvider: new ExpectedRequestIdEchoCache(input.expectedRequestId),
     signatureAlgorithm: "sha256",
     digestAlgorithm: "sha256",
     disableRequestedAuthnContext: true,
@@ -161,7 +175,7 @@ export async function buildSamlAuthorizeUrl(
     wantAssertionsSigned: true,
     wantAuthnResponseSigned: true,
     validateInResponseTo: ValidateInResponseTo.always,
-    cacheProvider: new SingleUseInResponseToCache(input.requestId),
+    cacheProvider: new ExpectedRequestIdEchoCache(input.requestId),
     generateUniqueId: () => input.requestId,
     signatureAlgorithm: "sha256",
     digestAlgorithm: "sha256",

--- a/packages/auth/src/session.ts
+++ b/packages/auth/src/session.ts
@@ -6,7 +6,7 @@
  */
 
 import type { JWTPayload } from "jose";
-import { getJwtSecret, signJwtPayload, verifyJwtPayload } from "./jwt";
+import { checkJwtSecretStrength, getJwtSecret, signJwtPayload, verifyJwtPayload } from "./jwt";
 import { assertTokenNotRevoked, revocationStore, TokenRevokedError } from "./revocation.js";
 
 // ─── Config ────────────────────────────────────────────────────────────────
@@ -44,6 +44,11 @@ export class SessionManager {
       throw new Error(
         "SessionManager: JWT secret must be at least 16 characters. Use STEWARD_JWT_SECRET with a long random string in production.",
       );
+    }
+    // An explicit secret bypasses getJwtSecret(), so re-apply its length
+    // policy here: hard-fail below 32 chars in production, warn otherwise.
+    if (config.secret !== undefined) {
+      checkJwtSecretStrength(config.secret, "SessionManager config.secret");
     }
     this.secret = new TextEncoder().encode(secret);
     this.issuer = config.issuer ?? "steward";
@@ -90,6 +95,12 @@ export class SessionManager {
 
     // Sanity-check our custom claims are present
     if (typeof payload.userId !== "string" || typeof payload.jti !== "string") {
+      return null;
+    }
+    // Token-type confusion guard (SEC-055): a refresh JWT shares issuer,
+    // audience and signing key with access tokens — never accept it as a
+    // session/access token.
+    if (payload.tokenType === "refresh") {
       return null;
     }
 

--- a/packages/auth/src/siwe-guard.ts
+++ b/packages/auth/src/siwe-guard.ts
@@ -6,7 +6,9 @@
  *   1. whether the `domain` field is one your server actually serves,
  *   2. whether `chainId` is in your allowed set,
  *   3. whether the `notBefore` / `expirationTime` window is sane (a
- *      pathologically long-lived signature is technically valid),
+ *      pathologically long-lived signature is technically valid; a missing
+ *      expirationTime falls back to bounding the message's issuedAt age, and
+ *      a future-dated issuedAt is rejected),
  *   4. whether the `statement` matches a server-side allowlist (defends
  *      against phishing sites tricking users into signing your messages),
  *   5. whether `uri` matches `domain` (some wallets fail to enforce this).
@@ -88,6 +90,8 @@ export function evaluateSiwePolicy(msg: SiweMessageLike, policy: SiwePolicy): Si
 
   const issuedAt = Date.parse(msg.issuedAt);
   if (!Number.isFinite(issuedAt)) return "not-yet-valid";
+  // A future-dated issuedAt is never acceptable beyond clock skew (SEC-065).
+  if (issuedAt - now.getTime() > clockSkewMs) return "not-yet-valid";
 
   if (msg.notBefore) {
     const nb = Date.parse(msg.notBefore);
@@ -102,6 +106,10 @@ export function evaluateSiwePolicy(msg: SiweMessageLike, policy: SiwePolicy): Si
       if (exp + clockSkewMs < now.getTime()) return "expired";
       if (exp - issuedAt > maxLifetimeMs) return "lifetime-too-long";
     }
+  } else if (now.getTime() - issuedAt > maxLifetimeMs) {
+    // No expirationTime: bound the temporal window by the message's age
+    // instead, so a signed login cannot stay valid forever (SEC-065).
+    return "lifetime-too-long";
   }
 
   return null;

--- a/packages/auth/src/sms-provider.ts
+++ b/packages/auth/src/sms-provider.ts
@@ -6,6 +6,18 @@ export interface SmsProvider {
   send(to: string, body: string): Promise<void>;
 }
 
+/**
+ * Typed delivery failure raised by SMS providers. Deliberately generic: the
+ * raw provider error body can carry account/phone metadata and must never
+ * propagate into thrown errors, logs, or API responses (SEC-061).
+ */
+export class SmsDeliveryError extends Error {
+  constructor(message = "SMS delivery failed") {
+    super(message);
+    this.name = "SmsDeliveryError";
+  }
+}
+
 export class ConsoleSmsProvider implements SmsProvider {
   async send(to: string, body: string): Promise<void> {
     console.log(
@@ -60,7 +72,10 @@ export class TwilioSmsProvider implements SmsProvider {
       body: params.toString(),
     });
     if (!res.ok) {
-      throw new Error(`Twilio send failed (${res.status}): ${await res.text()}`);
+      // Discard the provider error body — it can carry account/phone metadata.
+      // Only the status code is logged server-side.
+      console.warn(`[steward:auth] Twilio SMS send failed with status ${res.status}`);
+      throw new SmsDeliveryError();
     }
   }
 }


### PR DESCRIPTION
## Security wave 2 — Batch 1 (auth: packages/auth + auth routes in packages/api)

Fixes confirmed audit findings from the consolidated audit report. Each finding was re-verified against current develop (0027e106) before fixing.

| SEC ID | Severity | Status | Change |
|---|---|---|---|
| SEC-005 | HIGH | FIXED | `clientSecretEnv` for tenant OIDC providers must start with `STEWARD_TENANT_OIDC_SECRET_` — enforced at config validation (tenant-config + platform routes) and again at token-exchange time (defense in depth for legacy rows). Stops tenant admins exfiltrating arbitrary platform env secrets (`STEWARD_JWT_SECRET`, `STEWARD_MASTER_PASSWORD`) through the code exchange. |
| SEC-013 | MEDIUM | FIXED | Embedded mode no longer uses `STEWARD_MASTER_PASSWORD` verbatim as the JWT HMAC secret; it is scrypt-derived with a domain-separation label (same idiom as vault KeyStore domains), memoized per source password. |
| SEC-051 | MEDIUM | FIXED | `/agent-enroll/challenge` + `/verify` now sit behind `checkAuthRateLimit` (30/min, 20/min); agentId is length/charset-capped (schema shape) in the route AND in the enrollment core, so attacker-controlled text can no longer pin memory in the challenge store. |
| SEC-052 | MEDIUM | FIXED | Enroll routes use the API's `initAuthStores`-built ChallengeStore (Redis/Postgres in production) via new `getAuthChallengeStore()` export instead of the auth package's always-memory singleton. |
| SEC-053 | LOW | FIXED | New `checkJwtSecretStrength()`: hard-fails <32 chars in production (unchanged), now warns loudly once per process in every other env for any configured short secret. |
| SEC-054 | LOW | FIXED | `SessionManager` routes explicit `config.secret` through the same policy (previously bypassed getJwtSecret with only a 16-char floor). |
| SEC-055 | LOW | FIXED | `SessionManager.verifySession` and both API `verifySessionToken` implementations reject `tokenType === "refresh"` (latent token-type confusion). |
| SEC-056 | LOW | FIXED | Revocation store logs a loud once-per-process warning when degrading to per-process memory outside production (matches `buildBackend`). |
| SEC-057 | LOW | FIXED | Lockout race documented; new atomic `checkAndRecord()` (sync fast path with the default in-memory store). |
| SEC-058 | LOW | FIXED | `VerifiedFarcasterUser.fid` renamed to `claimedFid` + documented as unverified metadata; identity already keys on the signature-verified custody address in-repo. |
| SEC-059 | LOW | DEFERRED | Phone-link OTP verify attempt limiter — needs the same 5-attempt counter wired into routes/user.ts; not reached this run. |
| SEC-060 | LOW | FIXED | `SingleUseInResponseToCache` renamed to `ExpectedRequestIdEchoCache` with honest semantics docs (replay protection lives in the API layer; class is module-private so no API break). |
| SEC-061 | LOW | FIXED | Twilio provider throws generic `SmsDeliveryError` and logs only the status code; raw provider error body no longer propagates. |
| SEC-062 | LOW | DEFERRED | OIDC SSRF guard NAT64/6to4/Teredo transition-range decoding — needs careful embedded-IPv4 extraction in two places; not reached this run. |
| SEC-063 | LOW | FIXED | `decodeFlexible` became `decodeFlexibleCandidates`: bare-hex keys/signatures (also valid base64 alphabet) are now reachable — each candidate decode is tried until one imports/normalizes. All failures still fail closed. |
| SEC-064 | LOW | FIXED | New recovery codes are 14 chars (~69 bits, was ~49.5); hash comparison uses `timingSafeEqual`; legacy 10-char codes still verify (grace). |
| SEC-065 | LOW | FIXED | SIWE guard rejects future-dated `issuedAt` beyond clock skew and bounds the window by `issuedAt` age when `expirationTime` is absent. |
| SEC-066 | LOW | DEFERRED | Passkey register/verify error genericization — small route change in auth.ts; not reached this run. |
| SEC-131 | INFO | DEFERRED | challenge-store delete() fire-and-forget — not reached (INFO batch). |
| SEC-132 | INFO | DEFERRED | tenantAuthMiddleware docs/timing — not reached (INFO batch). |
| SEC-133 | INFO | DEFERRED | buildBackend GETDEL smoke probe — not reached (INFO batch). |
| SEC-134 | INFO | DEFERRED | AGENT_TOKEN_EXPIRY validation + extra-claim spread order — not reached (INFO batch). |
| SEC-135 | INFO | DEFERRED | verifyOidcJwt requiredClaims exp/iat — not reached (INFO batch). |
| SEC-136 | INFO | DEFERRED | Email-login lockout DoS lever — report itself says no fix required (documented inherent). |
| SEC-137 | INFO | DEFERRED | Custom OAuth provider namespace guard — not reached (INFO batch). |
| SEC-138 | INFO | DEFERRED | Platform-key default scope documentation — not reached (INFO batch). |
| SEC-139 | INFO | DEFERRED | IdP error string echoed in OIDC 502 — not reached (INFO batch). |
| SEC-140 | INFO | DEFERRED | eip1271 hardcoded public RPC fail-closed — not reached (INFO batch). |
| SEC-141 | INFO | DEFERRED | Passkey counter regression enforcement — not reached (INFO batch). |
| SEC-142 | INFO | DEFERRED | Shamir share envelope checksum/threshold — not reached (INFO batch). |
| SEC-143 | INFO | DEFERRED | Passkey default hardening docs — not reached (INFO batch). |
| SEC-144 | INFO | DEFERRED | SIWE Host-header domain fallback — not reached (INFO batch). |
| SEC-145 | INFO | DEFERRED | STEWARD_DEFAULT_TENANT_KEY hash documentation — not reached (INFO batch). |
| SEC-146 | INFO | DEFERRED | Recovery-code burn ordering in /mfa/totp/complete — not reached (INFO batch). |

## Trade-offs / breaking changes

- **SEC-005**: existing tenant OIDC configs whose `clientSecretEnv` points outside `STEWARD_TENANT_OIDC_SECRET_*` are rejected on next config write, and (defense-in-depth) their code exchanges fail closed until the operator renames the env var into the namespace. Docs example updated (`docs/api-reference/tenant-config.mdx`).
- **SEC-013**: sessions issued in embedded mode before this change are invalidated once at upgrade (re-login). Fail-closed by design.
- **SEC-064**: previously issued 10-char recovery codes keep working (verified grace path); users who regenerate get 14-char codes. If operators prefer hard invalidation, that is a one-line follow-up.
- **SEC-058**: `VerifiedFarcasterUser.fid` → `claimedFid` is a type-level breaking change for SDK consumers of `@stwd/auth`; no in-repo consumers of the field existed.
- **SEC-051/052**: `checkAuthRateLimit` and the initialized challenge store are now exported from `routes/auth.ts`; the enroll route imports them (acyclic — auth.ts does not import agent-enroll).

## Testing

- `packages/auth`: **233/233 pass** (`bun test`), including new regression tests: SEC-013 (raw master password never used; scrypt domain separation vector), SEC-053/054 (short-secret policy), SEC-055 (refresh rejected as session), SEC-056 (memory-fallback warning), SEC-057 (atomic checkAndRecord under parallelism), SEC-063 (bare-hex key/signature acceptance + fail-closed garbage), SEC-064 (legacy 10-char grace + 14-char new codes), SEC-065 (future issuedAt, no-expiry age bound), SEC-051 (core agentId cap).
- `packages/api` (isolated per-file runner): **15/15 files pass**, incl. new `agent-enroll-abuse.test.ts` (429 fail-closed without Redis in production; agentId 400s; challenges land in the API store, not the auth memory singleton) and the SEC-005 route regression test (env-exfil names rejected with 400).
- `bunx biome check` clean on all 26 changed files.
- Note: running several api test files in ONE `bun test` process shows pre-existing cross-file PGLite contamination ("PGlite is closed") — that is exactly why `scripts/run-tests-isolated.ts` exists; unrelated to these changes.

Deferred items are scoped, low-risk follow-ups; SEC-059/062/066 are the most valuable of the remainder.