### PR TITLE
fix(security): trading batch 4b — operator rails, PM sell notional, session fence (SEC-004/034/041/042/043/044)

### DIFF
--- a/packages/plugin-trading/src/__tests__/operator-recovery-policy-gates.test.ts
+++ b/packages/plugin-trading/src/__tests__/operator-recovery-policy-gates.test.ts
@@ -1,0 +1,415 @@
+/**
+ * operator-recovery-policy-gates.test.ts — regression coverage for the operator
+ * TRANSFER rail guardrails:
+ *
+ *   SEC-004 — /usd-send previously moved arbitrary USDC to any address with no
+ *     policy gate, no per-call cap, and no rate limit. It now runs the same
+ *     policy evaluation as /withdraw (approved-addresses + spend/rate caps),
+ *     enforces the per-call 2000 USDC ceiling, and is rate limited.
+ *   SEC-042 — /withdraw's policy evaluation was largely inert: recent-tx counts
+ *     and spend counters were hardcoded to 0 (rate-limit + daily/weekly rules
+ *     could never fire), and `value` was passed as 6-decimal USDC base units
+ *     while the spending-limit evaluator prices `value` as native wei (so even
+ *     per-tx USD caps never tripped). The gate now denominates `value` in wei
+ *     via the price oracle and feeds real chain-scoped counters.
+ *   SEC-043 — operator routes stored idempotency records only on success, so a
+ *     retry of a possibly-landed submit re-executed. Ambiguous-outcome 502s are
+ *     now stored and replayed.
+ *
+ * The HyperliquidAdapter is mocked (no signing / no network). The price oracle
+ * is a deterministic stub injected via the plugin context.
+ */
+
+import { afterAll, beforeAll, describe, expect, it, mock } from "bun:test";
+import {
+  agents,
+  agentWallets,
+  closeDb,
+  getDb,
+  policies as policiesTable,
+  tenants,
+  transactions,
+} from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import type { PriceOracle } from "@stwd/shared";
+import { Hono } from "hono";
+import { z } from "zod";
+import type { StewardAppContext } from "../context";
+
+const PLATFORM_KEY = "stw_platform_test_operator_gates_key";
+const ARBITRUM_CHAIN_ID = 42161;
+// Deterministic stub ETH price for the spending-limit denomination tests.
+const STUB_ETH_USD = 4000;
+
+// ── Mock the Hyperliquid adapter (no signing / no network) ────────────────────
+const signWithdrawCalls: Array<{ amount: string | number; destination: string }> = [];
+const submitWithdrawCalls: unknown[] = [];
+const usdSendCalls: Array<{ destination: string; amount: string }> = [];
+let failNextSubmitWithdraw = false;
+
+class MockHyperliquidAdapter {
+  constructor(
+    public vault: unknown,
+    public agentId: string,
+    public walletAddress: string,
+  ) {}
+
+  async signWithdraw(params: { amount: string | number; destination: string }) {
+    signWithdrawCalls.push(params);
+    return {
+      action: { type: "withdraw3", destination: params.destination },
+      nonce: 1,
+      signature: { r: "0x1", s: "0x2", v: 27 },
+    };
+  }
+
+  async submitWithdraw(signed: unknown) {
+    submitWithdrawCalls.push(signed);
+    if (failNextSubmitWithdraw) {
+      failNextSubmitWithdraw = false;
+      throw new Error("simulated submit failure (may have landed)");
+    }
+    return { status: "ok", response: { type: "default" } };
+  }
+
+  async usdSend(params: { destination: string; amount: string }) {
+    usdSendCalls.push(params);
+    return { status: "ok", raw: { response: { type: "default" } } };
+  }
+}
+
+mock.module("@stwd/venue-hyperliquid", () => ({
+  HyperliquidAdapter: MockHyperliquidAdapter,
+  hyperliquidAssetSchema: z.union([
+    z.enum(["BTC", "ETH", "BNB", "SOL", "AVAX", "ARB", "OP", "NEAR", "HYPE", "ZEC", "XMR"]),
+    z.string().regex(/^[a-z0-9]+:[A-Z0-9]+$/),
+  ]),
+  isBuilderPerpSymbol: (coin: string) => /^[a-z0-9]+:[A-Z0-9]+$/.test(coin),
+  getMarketableLimitPx: async () => "1",
+}));
+
+const stubPriceOracle: PriceOracle = {
+  async getNativeUsdPrice() {
+    return STUB_ETH_USD;
+  },
+  async getTokenUsdPrice() {
+    return STUB_ETH_USD;
+  },
+  async weiToUsd(weiValue: string) {
+    return (Number(BigInt(weiValue)) / 1e18) * STUB_ETH_USD;
+  },
+  async usdToWei(usdValue: number) {
+    return BigInt(Math.floor((usdValue / STUB_ETH_USD) * 1e18)).toString();
+  },
+};
+
+beforeAll(async () => {
+  process.env.STEWARD_PGLITE_MEMORY = "true";
+  process.env.STEWARD_PLATFORM_KEYS = PLATFORM_KEY;
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+  process.env.STEWARD_MASTER_PASSWORD ??= "test-master-password";
+  process.env.STEWARD_AUDIT_HMAC_KEY ??= "test-audit-hmac-key-operator-gates";
+  const { db, client } = await createPGLiteDb("memory://");
+  setPGLiteOverride(db, async () => {
+    await client.close();
+  });
+});
+
+afterAll(async () => {
+  await closeDb();
+});
+
+let seedSeq = 0;
+async function seedAgent(opts: {
+  policies?: Array<{ type: string; config: Record<string, unknown> }>;
+}): Promise<{ tenantId: string; agentId: string }> {
+  seedSeq += 1;
+  const tenantId = `tenant-gates-${Date.now()}-${seedSeq}`;
+  const agentId = `agent-gates-${Date.now()}-${seedSeq}`;
+  await getDb()
+    .insert(tenants)
+    .values({
+      id: tenantId,
+      name: "Operator Gates Tenant",
+      apiKeyHash: `test-hash-${tenantId}`,
+      ownerAddress: `0x${tenantId
+        .replace(/[^a-fA-F0-9]/g, "")
+        .padEnd(40, "0")
+        .slice(0, 40)}`,
+    });
+  await getDb().insert(agents).values({
+    id: agentId,
+    tenantId,
+    name: "Gates Agent",
+    walletAddress: "0x00000000000000000000000000000000000000aa",
+  });
+  await getDb().insert(agentWallets).values({
+    agentId,
+    chainFamily: "evm",
+    address: "0x00000000000000000000000000000000000000bb",
+    venue: "hyperliquid",
+    purpose: "perp",
+  });
+  for (const [i, policy] of (opts.policies ?? []).entries()) {
+    await getDb()
+      .insert(policiesTable)
+      .values({
+        id: `pol_${agentId}_${i}`,
+        agentId,
+        type: policy.type,
+        enabled: true,
+        config: policy.config,
+      });
+  }
+  return { tenantId, agentId };
+}
+
+async function buildApp(ctxOverrides: Partial<StewardAppContext> = {}) {
+  const { isValidPlatformKey } = await import("@stwd/auth");
+  const { createOperatorRecoveryRoutes } = await import("../routes/operator-recovery");
+  const { testCtx } = await import("./_ctx");
+  const app = new Hono();
+  app.use("/v1/trade/*", async (c, next) => {
+    const key = c.req.header("X-Steward-Platform-Key");
+    if (!key) {
+      return c.json({ ok: false, error: "X-Steward-Platform-Key header is required" }, 401);
+    }
+    if (!isValidPlatformKey(key)) {
+      return c.json({ ok: false, error: "Invalid platform key" }, 403);
+    }
+    c.set("tenantId", c.req.header("X-Steward-Tenant") || "default");
+    c.set("authType", "platform");
+    return next();
+  });
+  app.route("/v1/trade", createOperatorRecoveryRoutes({ ...testCtx(), ...ctxOverrides }));
+  return app;
+}
+
+function postTransfer(
+  app: Hono,
+  rail: "withdraw" | "usd-send",
+  tenantId: string,
+  body: Record<string, unknown>,
+  idempotencyKey?: string,
+) {
+  return app.request(`/v1/trade/hyperliquid/${rail}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Steward-Platform-Key": PLATFORM_KEY,
+      "X-Steward-Tenant": tenantId,
+      ...(idempotencyKey ? { "Idempotency-Key": idempotencyKey } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+const DEST_A = "0x1111111111111111111111111111111111111111";
+const DEST_B = "0x2222222222222222222222222222222222222222";
+
+describe("SEC-004: usd-send policy gate + caps", () => {
+  it("rejects a usd-send to a destination NOT in approved-addresses (no adapter call)", async () => {
+    const { tenantId, agentId } = await seedAgent({
+      policies: [
+        { type: "approved-addresses", config: { mode: "whitelist", addresses: [DEST_A] } },
+      ],
+    });
+    usdSendCalls.length = 0;
+    const app = await buildApp();
+
+    const res = await postTransfer(app, "usd-send", tenantId, {
+      agentId,
+      destination: DEST_B,
+      amount: "100",
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { code?: string };
+    expect(body.code).toBe("policy-violation");
+    expect(usdSendCalls).toHaveLength(0);
+  });
+
+  it("rejects a usd-send for an agent with NO policies (default-deny)", async () => {
+    const { tenantId, agentId } = await seedAgent({});
+    usdSendCalls.length = 0;
+    const app = await buildApp();
+
+    const res = await postTransfer(app, "usd-send", tenantId, {
+      agentId,
+      destination: DEST_A,
+      amount: "100",
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { code?: string };
+    expect(body.code).toBe("policy-violation");
+    expect(usdSendCalls).toHaveLength(0);
+  });
+
+  it("rejects a usd-send above the per-call 2000 USDC ceiling before any signing", async () => {
+    const { tenantId, agentId } = await seedAgent({
+      policies: [
+        { type: "approved-addresses", config: { mode: "whitelist", addresses: [DEST_A] } },
+      ],
+    });
+    usdSendCalls.length = 0;
+    const app = await buildApp();
+
+    const res = await postTransfer(app, "usd-send", tenantId, {
+      agentId,
+      destination: DEST_A,
+      amount: "2000.000001",
+    });
+    expect(res.status).toBe(400);
+    expect(usdSendCalls).toHaveLength(0);
+  });
+
+  it("rate-limits repeated usd-send calls (11th call in a minute -> 429)", async () => {
+    const { tenantId, agentId } = await seedAgent({
+      policies: [
+        { type: "approved-addresses", config: { mode: "whitelist", addresses: [DEST_A] } },
+      ],
+    });
+    usdSendCalls.length = 0;
+    const app = await buildApp();
+
+    let lastStatus = 0;
+    for (let i = 0; i < 10; i++) {
+      const res = await postTransfer(app, "usd-send", tenantId, {
+        agentId,
+        destination: DEST_A,
+        amount: "1",
+      });
+      lastStatus = res.status;
+    }
+    expect(lastStatus).toBe(200);
+    const res = await postTransfer(app, "usd-send", tenantId, {
+      agentId,
+      destination: DEST_A,
+      amount: "1",
+    });
+    expect(res.status).toBe(429);
+    expect(usdSendCalls).toHaveLength(10);
+  });
+});
+
+describe("SEC-042: withdraw policy evaluation is real", () => {
+  it("enforces a per-tx USD spending limit against the REAL notional (not USDC-as-wei)", async () => {
+    // maxPerTxUsd 50 with a 100 USDC withdraw. Pre-fix the evaluator priced the
+    // 6-decimal USDC base units (100000000) as wei (~$0.0000004) and approved;
+    // the fixed gate converts to wei first, so the engine sees ~$100 and denies.
+    const { tenantId, agentId } = await seedAgent({
+      policies: [
+        { type: "approved-addresses", config: { mode: "whitelist", addresses: [DEST_A] } },
+        { type: "spending-limit", config: { maxPerTxUsd: 50 } },
+      ],
+    });
+    signWithdrawCalls.length = 0;
+    submitWithdrawCalls.length = 0;
+    const app = await buildApp({ priceOracle: stubPriceOracle });
+
+    const res = await postTransfer(app, "withdraw", tenantId, {
+      agentId,
+      destination: DEST_A,
+      amount: "100",
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { code?: string; reason?: string };
+    expect(body.code).toBe("policy-violation");
+    expect(body.reason).toContain("per-tx USD limit");
+    expect(signWithdrawCalls).toHaveLength(0);
+    expect(submitWithdrawCalls).toHaveLength(0);
+  });
+
+  it("allows a withdraw UNDER the per-tx USD limit (denomination is not over-broad)", async () => {
+    const { tenantId, agentId } = await seedAgent({
+      policies: [
+        { type: "approved-addresses", config: { mode: "whitelist", addresses: [DEST_A] } },
+        { type: "spending-limit", config: { maxPerTxUsd: 500 } },
+      ],
+    });
+    signWithdrawCalls.length = 0;
+    submitWithdrawCalls.length = 0;
+    const app = await buildApp({ priceOracle: stubPriceOracle });
+
+    const res = await postTransfer(app, "withdraw", tenantId, {
+      agentId,
+      destination: DEST_A,
+      amount: "100",
+    });
+    expect(res.status).toBe(200);
+    expect(signWithdrawCalls).toHaveLength(1);
+    expect(submitWithdrawCalls).toHaveLength(1);
+  });
+
+  it("enforces a rate-limit policy using the agent's REAL recent tx count", async () => {
+    // maxTxPerHour 1 with one confirmed tx in the trailing hour. Pre-fix the
+    // route hardcoded recentTxCount1h: 0 and the rule could never fire.
+    const { tenantId, agentId } = await seedAgent({
+      policies: [
+        { type: "approved-addresses", config: { mode: "whitelist", addresses: [DEST_A] } },
+        { type: "rate-limit", config: { maxTxPerHour: 1, maxTxPerDay: 100 } },
+      ],
+    });
+    await getDb()
+      .insert(transactions)
+      .values({
+        id: `tx_${agentId}`,
+        agentId,
+        status: "confirmed",
+        toAddress: DEST_A,
+        value: "1000000",
+        chainId: ARBITRUM_CHAIN_ID,
+        signedAt: new Date(),
+      });
+    signWithdrawCalls.length = 0;
+    const app = await buildApp();
+
+    const res = await postTransfer(app, "withdraw", tenantId, {
+      agentId,
+      destination: DEST_A,
+      amount: "100",
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { code?: string; reason?: string };
+    expect(body.code).toBe("policy-violation");
+    expect(body.reason).toContain("Hourly tx limit");
+    expect(signWithdrawCalls).toHaveLength(0);
+  });
+});
+
+describe("SEC-043: operator idempotency stores ambiguous outcomes", () => {
+  it("replays the stored 502 for a possibly-landed withdraw instead of re-submitting", async () => {
+    const { tenantId, agentId } = await seedAgent({
+      policies: [
+        { type: "approved-addresses", config: { mode: "whitelist", addresses: [DEST_A] } },
+      ],
+    });
+    signWithdrawCalls.length = 0;
+    submitWithdrawCalls.length = 0;
+    failNextSubmitWithdraw = true;
+    const app = await buildApp();
+    const key = `wd-ambiguous-${Date.now()}`;
+
+    const first = await postTransfer(
+      app,
+      "withdraw",
+      tenantId,
+      { agentId, destination: DEST_A, amount: "100" },
+      key,
+    );
+    expect(first.status).toBe(502);
+    expect(submitWithdrawCalls).toHaveLength(1);
+
+    // Same key + same body: the recorded ambiguous outcome is replayed — the
+    // venue is NOT touched again (no second sign, no second submit).
+    const retry = await postTransfer(
+      app,
+      "withdraw",
+      tenantId,
+      { agentId, destination: DEST_A, amount: "100" },
+      key,
+    );
+    expect(retry.status).toBe(502);
+    expect(signWithdrawCalls).toHaveLength(1);
+    expect(submitWithdrawCalls).toHaveLength(1);
+  });
+});

--- a/packages/plugin-trading/src/__tests__/operator-recovery-withdraw-validation.test.ts
+++ b/packages/plugin-trading/src/__tests__/operator-recovery-withdraw-validation.test.ts
@@ -80,9 +80,10 @@ async function seedAgent(opts: {
   tenantId: string;
   agentId: string;
   approvedAddresses?: string[];
-  // spending-limit config in canonical wei format, e.g. { maxPerTx: "50000000" }.
-  // The withdraw amount is fed to the policy engine as USDC 6-decimal base units,
-  // so 100 USDC == 100000000 base units.
+  // spending-limit config. After SEC-042 the withdraw gate denominates `value`
+  // in native wei (converted from USDC via the price oracle), so wei-style caps
+  // (maxPerTx/maxPerDay/maxPerWeek) compare against real wei and USD-style caps
+  // (maxPerTxUsd/...) see the real USD notional.
   spendingLimit?: Record<string, unknown>;
 }) {
   await getDb()
@@ -133,7 +134,7 @@ async function seedAgent(opts: {
   }
 }
 
-async function buildApp() {
+async function buildApp(ctxOverrides: Record<string, unknown> = {}) {
   const { isValidPlatformKey } = await import("@stwd/auth");
   const { createOperatorRecoveryRoutes } = await import("../routes/operator-recovery");
   const { testCtx } = await import("./_ctx");
@@ -151,9 +152,28 @@ async function buildApp() {
     c.set("authType", "platform");
     return next();
   });
-  app.route("/v1/trade", createOperatorRecoveryRoutes(testCtx()));
+  app.route("/v1/trade", createOperatorRecoveryRoutes({ ...testCtx(), ...ctxOverrides }));
   return app;
 }
+
+// Deterministic stub oracle (ETH = $4000) for the spend-cap tests: after
+// SEC-042 the gate converts USDC to native wei through the price oracle, so a
+// 100 USDC withdraw evaluates as 0.025 ETH = 2.5e16 wei.
+const STUB_ETH_USD = 4000;
+const stubPriceOracle = {
+  async getNativeUsdPrice() {
+    return STUB_ETH_USD;
+  },
+  async getTokenUsdPrice() {
+    return STUB_ETH_USD;
+  },
+  async weiToUsd(weiValue: string) {
+    return (Number(BigInt(weiValue)) / 1e18) * STUB_ETH_USD;
+  },
+  async usdToWei(usdValue: number) {
+    return BigInt(Math.floor((usdValue / STUB_ETH_USD) * 1e18)).toString();
+  },
+};
 
 async function postWithdraw(
   app: Awaited<ReturnType<typeof buildApp>>,
@@ -269,17 +289,18 @@ describe("operator recovery withdraw spend-cap enforcement (issue #109)", () => 
   it("rejects an in-bounds amount that exceeds the spend-cap, even to an approved destination", async () => {
     const tenantId = `tenant-wd-cap-${Date.now()}`;
     const agentId = `agent-wd-cap-${Date.now()}`;
-    // maxPerTx = 50 USDC in base units; a 100 USDC withdraw (100000000 base
-    // units) exceeds it. Before the fix the policy saw value:"0" and PASSED.
+    // maxPerTx = 0.01 ETH in wei; a 100 USDC withdraw (~0.025 ETH at the
+    // stubbed $4000) exceeds it. Before the fix the policy saw value:"0" and
+    // PASSED; with USDC-as-wei denomination it would still pass (1e8 < 1e16).
     await seedAgent({
       tenantId,
       agentId,
       approvedAddresses: [approved],
-      spendingLimit: { maxPerTx: "50000000" },
+      spendingLimit: { maxPerTx: "10000000000000000" },
     });
     signWithdrawCalls.length = 0;
 
-    const app = await buildApp();
+    const app = await buildApp({ priceOracle: stubPriceOracle });
     const res = await postWithdraw(app, tenantId, {
       agentId,
       amount: "100",
@@ -295,17 +316,18 @@ describe("operator recovery withdraw spend-cap enforcement (issue #109)", () => 
   it("signs a withdraw whose amount is within the spend-cap", async () => {
     const tenantId = `tenant-wd-cap-ok-${Date.now()}`;
     const agentId = `agent-wd-cap-ok-${Date.now()}`;
-    // maxPerTx = 200 USDC base units; a 100 USDC withdraw is within the cap.
+    // maxPerTx = 0.1 ETH in wei; a 100 USDC withdraw (~0.025 ETH at the stubbed
+    // $4000) is within the cap.
     await seedAgent({
       tenantId,
       agentId,
       approvedAddresses: [approved],
-      spendingLimit: { maxPerTx: "200000000" },
+      spendingLimit: { maxPerTx: "100000000000000000" },
     });
     signWithdrawCalls.length = 0;
     submitWithdrawCalls.length = 0;
 
-    const app = await buildApp();
+    const app = await buildApp({ priceOracle: stubPriceOracle });
     const res = await postWithdraw(app, tenantId, {
       agentId,
       amount: "100",

--- a/packages/plugin-trading/src/__tests__/operator-recovery.test.ts
+++ b/packages/plugin-trading/src/__tests__/operator-recovery.test.ts
@@ -259,7 +259,10 @@ describe("operator recovery usd-send", () => {
   it("submits usdSend through the platform-gated adapter path", async () => {
     const tenantId = `tenant-usdsend-ok-${Date.now()}`;
     const agentId = `agent-usdsend-ok-${Date.now()}`;
-    await seedAgent({ tenantId, agentId });
+    // SEC-004: usd-send is a withdrawal rail and now runs the same policy gate
+    // as /withdraw — the destination must be on the agent's approved list.
+    const destination = "0xABCDEF0123456789abcdef0123456789ABCDEF01";
+    await seedAgent({ tenantId, agentId, approvedAddresses: [destination] });
     usdSendCalls.length = 0;
 
     const app = await buildApp();

--- a/packages/plugin-trading/src/__tests__/trade-polymarket-order.test.ts
+++ b/packages/plugin-trading/src/__tests__/trade-polymarket-order.test.ts
@@ -275,6 +275,88 @@ describe("POST /v1/trade/polymarket/order", () => {
     expect(await dailySpendOf(sessionId)).toBe(0);
   });
 
+  it("SEC-041: SELL notional is floored at the CLOB best bid (low-limit cap bypass fails)", async () => {
+    // perOrderCap 50. A FOK sell of 100 shares at limit 0.01 would fill at the
+    // best bid (0.90): real notional ~$90 must be capped, not the caller-stated
+    // $1. Pre-fix the route sized on the caller's price and passed the gate.
+    const { tenantId, agentId, sessionId } = await seedSession({
+      perOrderCapUsd: "50",
+    });
+    const app = makeApp(tenantId, agentId, tradeRoutes);
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(
+      (async () =>
+        new Response(JSON.stringify({ [TOKEN_ID]: { SELL: "0.90" } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })) as typeof fetch,
+    );
+
+    try {
+      const res = await postOrder(app, sessionId, crypto.randomUUID(), {
+        side: "sell",
+        amount: 100,
+        price: 0.01,
+      });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { code?: string; reason?: string };
+      expect(body.code).toBe("policy-violation");
+      expect(body.reason).toBe("per-order-cap-exceeded");
+      expect(await dailySpendOf(sessionId)).toBe(0);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("SEC-041: SELL with bid BELOW the limit sizes on the limit (no over-denial)", async () => {
+    // best bid 0.40 < limit 0.50 -> notional 100 * 0.50 = 50, exactly the cap
+    // (cap is >-compared, so it passes). The order then fails closed at the
+    // creds gate (409), proving the cap gate let it through.
+    const { tenantId, agentId, sessionId } = await seedSession({
+      perOrderCapUsd: "50",
+    });
+    stubWallet(true);
+    const app = makeApp(tenantId, agentId, tradeRoutes);
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(
+      (async () =>
+        new Response(JSON.stringify({ [TOKEN_ID]: { SELL: "0.40" } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })) as typeof fetch,
+    );
+
+    try {
+      const res = await postOrder(app, sessionId, crypto.randomUUID(), {
+        side: "sell",
+        amount: 100,
+        price: 0.5,
+      });
+      expect(res.status).toBe(409);
+      expect(await dailySpendOf(sessionId)).toBe(0);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("SEC-041: SELL fails closed when the best bid cannot be resolved", async () => {
+    const { tenantId, agentId, sessionId } = await seedSession({});
+    const app = makeApp(tenantId, agentId, tradeRoutes);
+    const fetchSpy = spyOn(globalThis, "fetch").mockRejectedValue(new Error("clob down"));
+
+    try {
+      const res = await postOrder(app, sessionId, crypto.randomUUID(), {
+        side: "sell",
+        amount: 10,
+        price: 0.5,
+      });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { code?: string; reason?: string };
+      expect(body.code).toBe("policy-violation");
+      expect(await dailySpendOf(sessionId)).toBe(0);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
   it("honors an exact pm:<tokenId> allowlist entry (passes the policy gate)", async () => {
     // The per-token entry IS the executable unit — it grants exactly this token.
     const { tenantId, agentId, sessionId } = await seedSession({
@@ -671,6 +753,14 @@ describe("POST /v1/trade/polymarket/order", () => {
 
     process.env.STEWARD_PM_TEST_CREDS = "1";
     stubWallet(true);
+    // SEC-041: sells now resolve the CLOB best bid for notional sizing first.
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(
+      (async () =>
+        new Response(JSON.stringify({ [TOKEN_ID]: { SELL: "0.5" } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })) as typeof fetch,
+    );
     submitSpy = spyOn(PolymarketExecutionAdapter.prototype, "submitSignedOrder").mockResolvedValue({
       venue: "polymarket" as const,
     } as Awaited<ReturnType<PolymarketExecutionAdapter["submitSignedOrder"]>>);
@@ -689,6 +779,7 @@ describe("POST /v1/trade/polymarket/order", () => {
       expect(await dailySpendOf(sessionId)).toBe(0);
       expect(await auditCount(tenantId, "trade.order.submitted")).toBe(0);
     } finally {
+      fetchSpy.mockRestore();
       delete process.env.STEWARD_PM_TEST_CREDS;
     }
   });

--- a/packages/plugin-trading/src/__tests__/trade-session-gates.test.ts
+++ b/packages/plugin-trading/src/__tests__/trade-session-gates.test.ts
@@ -58,6 +58,8 @@ type Posture =
   | "api-key"
   | "session-no-mfa"
   | "session-with-mfa"
+  // MFA verified 10 minutes ago — outside the 5-minute recency window (SEC-034).
+  | "session-stale-mfa"
   // agent's own bearer, scoped to AGENT_ID — the autonomous self-service path.
   | "agent-self"
   // agent bearer scoped to a DIFFERENT agent — must be refused.
@@ -87,6 +89,8 @@ async function makeApp(posture: Posture) {
     } else {
       c.set("authType", "session-jwt");
       if (posture === "session-with-mfa") c.set("sessionMfaVerifiedAt", Date.now());
+      if (posture === "session-stale-mfa")
+        c.set("sessionMfaVerifiedAt", Date.now() - 10 * 60_000);
     }
     await next();
   });
@@ -221,6 +225,36 @@ describe("trade session control-plane gates (real routes)", () => {
     expect(await errorOf(noMfaRes)).toBe(
       "Trade session management requires recent MFA verification",
     );
+  });
+
+  it("SEC-034: a STALE MFA verification (10 min ago) no longer manages trade sessions", async () => {
+    // Presence-only MFA previously passed these gates for a session that
+    // completed MFA hours/days ago. The gates now require recency (5-minute
+    // window), so a 10-minute-old verification is refused exactly like no MFA.
+    const createRes = await post(await makeApp("session-stale-mfa"), "/sessions", CREATE_BODY);
+    expect(createRes.status).toBe(403);
+    expect(await errorOf(createRes)).toBe(
+      "Trade session management requires recent MFA verification",
+    );
+
+    const getRes = await (await makeApp("session-stale-mfa")).request(
+      `/v1/trade/sessions/${SEEDED_SESSION_ID}`,
+    );
+    expect(getRes.status).toBe(403);
+
+    const revokeRes = await post(
+      await makeApp("session-stale-mfa"),
+      `/sessions/${SEEDED_SESSION_ID}/revoke`,
+      {},
+    );
+    expect(revokeRes.status).toBe(403);
+
+    // The denied revoke never mutated the session — it is still active.
+    const [row] = await getDb()
+      .select({ status: tradeSessions.status })
+      .from(tradeSessions)
+      .where(eq(tradeSessions.id, SEEDED_SESSION_ID));
+    expect(row.status).toBe("active");
   });
 
   it("revoke session: allows api-key while refusing owner-session-without-MFA, leaving the seeded session active", async () => {

--- a/packages/plugin-trading/src/__tests__/trade-session-gates.test.ts
+++ b/packages/plugin-trading/src/__tests__/trade-session-gates.test.ts
@@ -89,8 +89,7 @@ async function makeApp(posture: Posture) {
     } else {
       c.set("authType", "session-jwt");
       if (posture === "session-with-mfa") c.set("sessionMfaVerifiedAt", Date.now());
-      if (posture === "session-stale-mfa")
-        c.set("sessionMfaVerifiedAt", Date.now() - 10 * 60_000);
+      if (posture === "session-stale-mfa") c.set("sessionMfaVerifiedAt", Date.now() - 10 * 60_000);
     }
     await next();
   });

--- a/packages/plugin-trading/src/__tests__/trade-session-revocation-fence.test.ts
+++ b/packages/plugin-trading/src/__tests__/trade-session-revocation-fence.test.ts
@@ -14,7 +14,7 @@ const hyperliquidSource = readFileSync(
 );
 
 describe("trade session revocation fence", () => {
-  it("serializes revocation with the final order sign and submit phase", () => {
+  it("checks activity in the fence and re-checks between sign and submit (SEC-044)", () => {
     expect(tradeSessionSource).toContain("function sessionFenceKey");
     expect(tradeSessionSource).toContain("pg_advisory_xact_lock");
     expect(tradeSessionSource).toContain("withActiveSubmissionFence");

--- a/packages/plugin-trading/src/routes/operator-recovery.ts
+++ b/packages/plugin-trading/src/routes/operator-recovery.ts
@@ -33,13 +33,15 @@
  * signWithdraw, submitWithdraw) — no signing is reimplemented here.
  */
 
-import { proxyAuditLog } from "@stwd/db";
+import { proxyAuditLog, transactions } from "@stwd/db";
+import { checkRateLimit } from "@stwd/redis";
 import type { ApiResponse, AppVariables } from "@stwd/shared";
 import {
   HyperliquidAdapter,
   hyperliquidAssetSchema,
   isBuilderPerpSymbol,
 } from "@stwd/venue-hyperliquid";
+import { and, eq, gte, sql } from "drizzle-orm";
 import type { Context } from "hono";
 import { Hono } from "hono";
 import { z } from "zod";
@@ -203,21 +205,43 @@ export function createOperatorRecoveryRoutes(
     priceOracle,
     safeJsonParse,
     writeAuditEvent,
+    getRedisClient,
   } = ctx;
 
   const operatorRecoveryRoutes = new Hono<{ Variables: AppVariables }>();
 
   // ── Idempotency (mirrors trade.ts in-memory helper) ───────────────────────────
+  // Entries are stored for BOTH successful responses and ambiguous-outcome 502s
+  // (a submit that may have landed at the venue), so a retry with the same key
+  // REPLAYS the recorded outcome instead of re-executing a possibly-completed
+  // fund movement. The map is bounded: expired entries are swept on store and
+  // the oldest entries are evicted past MAX_OPERATOR_IDEMPOTENCY_ENTRIES so a
+  // caller cannot grow process memory without bound (SEC-043).
+  const MAX_OPERATOR_IDEMPOTENCY_ENTRIES = 1_000;
   const operatorIdempotency = new Map<
     string,
-    { bodyHash: string; response: unknown; expiresAt: number }
+    { bodyHash: string; status: 200 | 502; body: unknown; expiresAt: number }
   >();
+
+  function sweepOperatorIdempotency(now: number): void {
+    for (const [entryKey, entry] of operatorIdempotency) {
+      if (entry.expiresAt <= now || operatorIdempotency.size >= MAX_OPERATOR_IDEMPOTENCY_ENTRIES) {
+        operatorIdempotency.delete(entryKey);
+      }
+      if (operatorIdempotency.size < MAX_OPERATOR_IDEMPOTENCY_ENTRIES) break;
+    }
+  }
 
   function getOperatorIdempotency(
     scope: string,
     key: string | undefined,
     body: unknown,
-  ): { conflict?: boolean; response?: unknown; store?: (response: unknown) => void } {
+  ): {
+    conflict?: boolean;
+    entry?: { status: 200 | 502; body: unknown };
+    store?: (response: unknown) => void;
+    storeFailure?: (errorBody: unknown) => void;
+  } {
     if (!key) return {};
     const now = Date.now();
     const mapKey = `${scope}:${key}`;
@@ -225,16 +249,198 @@ export function createOperatorRecoveryRoutes(
     const existing = operatorIdempotency.get(mapKey);
     if (existing && existing.expiresAt > now) {
       if (existing.bodyHash !== bodyHash) return { conflict: true };
-      return { response: existing.response };
+      return { entry: { status: existing.status, body: existing.body } };
     }
     return {
       store(response: unknown) {
+        sweepOperatorIdempotency(now);
         operatorIdempotency.set(mapKey, {
           bodyHash,
-          response,
+          status: 200,
+          body: { ok: true, data: response },
           expiresAt: now + 24 * 60 * 60 * 1000,
         });
       },
+      storeFailure(errorBody: unknown) {
+        sweepOperatorIdempotency(now);
+        operatorIdempotency.set(mapKey, {
+          bodyHash,
+          status: 502,
+          body: errorBody,
+          expiresAt: now + 24 * 60 * 60 * 1000,
+        });
+      },
+    };
+  }
+
+  // ── Operator transfer rate limit (withdraw + usd-send) ────────────────────────
+  // The per-call USDC cap bounds one call; this bounds the LOOP. A compromised
+  // operator credential cannot drain an arbitrarily large balance by repeating
+  // capped calls. Mirrors trade.ts's order rate limit (Redis when available,
+  // process-local fallback otherwise).
+  const OPERATOR_TRANSFER_RATE_WINDOW_MS = 60_000;
+  const OPERATOR_TRANSFER_MAX_CALLS = 10;
+  const operatorTransferRateLimit = new Map<string, { count: number; resetAt: number }>();
+
+  async function enforceOperatorTransferRateLimit(
+    rail: "withdraw" | "usd-send",
+    tenantId: string,
+    agentId: string,
+  ): Promise<{ allowed: boolean; resetMs: number }> {
+    const redis = getRedisClient();
+    if (redis) {
+      const result = await checkRateLimit(
+        `ratelimit:trade:operator:${rail}:${tenantId}:${agentId}:${OPERATOR_TRANSFER_RATE_WINDOW_MS}`,
+        OPERATOR_TRANSFER_RATE_WINDOW_MS,
+        OPERATOR_TRANSFER_MAX_CALLS,
+      );
+      return { allowed: result.allowed, resetMs: result.resetMs };
+    }
+
+    const now = Date.now();
+    const key = `${rail}:${tenantId}:${agentId}`;
+    const current = operatorTransferRateLimit.get(key);
+    if (!current || current.resetAt <= now) {
+      if (operatorTransferRateLimit.size >= 1_000) {
+        for (const [k, v] of operatorTransferRateLimit) {
+          if (v.resetAt <= now) operatorTransferRateLimit.delete(k);
+          if (operatorTransferRateLimit.size < 1_000) break;
+        }
+      }
+      operatorTransferRateLimit.set(key, {
+        count: 1,
+        resetAt: now + OPERATOR_TRANSFER_RATE_WINDOW_MS,
+      });
+      return { allowed: true, resetMs: OPERATOR_TRANSFER_RATE_WINDOW_MS };
+    }
+    if (current.count >= OPERATOR_TRANSFER_MAX_CALLS) {
+      return { allowed: false, resetMs: current.resetAt - now };
+    }
+    current.count += 1;
+    return { allowed: true, resetMs: current.resetAt - now };
+  }
+
+  /**
+   * Real spend/tx counters for the operator transfer rails, mirroring the API's
+   * getTransactionStats(agentId, chainId): the recent-tx counts feed rate-limit
+   * rules, and the spend sums — scoped to Arbitrum so they stay in the same
+   * native-wei unit the policy gate denominates `value` in — feed daily/weekly
+   * spending-limit rules. Previously both routes hardcoded zeroes here, which
+   * made every rate-limit and daily/weekly spend rule structurally inert.
+   */
+  async function getOperatorSpendStats(agentId: string): Promise<{
+    recentTxCount1h: number;
+    recentTxCount24h: number;
+    spentToday: bigint;
+    spentThisWeek: bigint;
+  }> {
+    const now = new Date();
+    const oneHourAgo = new Date(now.getTime() - 3600_000).toISOString();
+    const oneDayAgo = new Date(now.getTime() - 86400_000).toISOString();
+    const oneWeekAgo = new Date(now.getTime() - 604800_000);
+    const chainFilter = sql` and ${transactions.chainId} = ${ARBITRUM_CHAIN_ID}`;
+
+    const [stats] = await db
+      .select({
+        recentTxCount1h: sql<number>`count(*) filter (where ${transactions.createdAt} >= ${oneHourAgo}::timestamptz)`,
+        recentTxCount24h: sql<number>`count(*) filter (where ${transactions.createdAt} >= ${oneDayAgo}::timestamptz)`,
+        spentToday: sql<string>`
+          coalesce(
+            sum(
+              case
+                when ${transactions.createdAt} >= ${oneDayAgo}::timestamptz${chainFilter} then (${transactions.value})::numeric
+                else 0
+              end
+            ),
+            0
+          )::text
+        `,
+        spentThisWeek: sql<string>`coalesce(sum((${transactions.value})::numeric) filter (where true${chainFilter}), 0)::text`,
+      })
+      .from(transactions)
+      .where(
+        and(
+          eq(transactions.agentId, agentId),
+          gte(transactions.createdAt, oneWeekAgo),
+          sql`${transactions.status} in ('signed', 'broadcast', 'confirmed')`,
+        ),
+      );
+
+    return {
+      recentTxCount1h: Number(stats?.recentTxCount1h ?? 0),
+      recentTxCount24h: Number(stats?.recentTxCount24h ?? 0),
+      spentToday: BigInt(stats?.spentToday ?? "0"),
+      spentThisWeek: BigInt(stats?.spentThisWeek ?? "0"),
+    };
+  }
+
+  /**
+   * Shared policy gate for the operator TRANSFER rails (withdraw + usd-send).
+   * Both move USDC value OUT of the venue to a destination address — one is an
+   * HL withdraw to Arbitrum, the other an HL-internal USDC transfer — so both
+   * run the same evaluation POST /vault/sign runs: approved-addresses reads
+   * `request.to`, spending-limit reads `request.value`, rate-limit reads the
+   * recent-tx counters, and daily/weekly caps read the spent counters.
+   *
+   * Denomination invariant: `request.value` is converted from USDC to the
+   * evaluation chain's NATIVE base units (wei on Arbitrum) via the price
+   * oracle, because the spending-limit evaluator prices `value` as native wei
+   * — passing 6-decimal USDC base units would understate the notional by
+   * ~1e12 and silently disable every USD-denominated cap. The conversion is
+   * skipped (the oracle never consulted) when the policy set has no enabled
+   * spending-limit rule, since no other rule consumes `value` here; when a
+   * spending-limit rule IS configured and the oracle cannot quote, the gate
+   * FAILS CLOSED. An empty policy set approves nothing (engine default-deny),
+   * so a policy-less agent cannot use either rail — set an approved-addresses
+   * policy first, exactly as the withdraw route already required.
+   */
+  async function evaluateOperatorTransferPolicy(input: {
+    tenantId: string;
+    agentId: string;
+    destination: string;
+    amountBaseUnits: bigint;
+  }): Promise<{ approved: true } | { approved: false; reason: string }> {
+    const policySet = await getPolicySet(input.tenantId, input.agentId);
+    const hasSpendingLimit = policySet.some(
+      (rule) => rule.type === "spending-limit" && rule.enabled,
+    );
+    let value = input.amountBaseUnits.toString();
+    if (hasSpendingLimit) {
+      const amountUsdc = Number(input.amountBaseUnits) / 10 ** USDC_DECIMALS;
+      const valueWei = await priceOracle.usdToWei(amountUsdc, ARBITRUM_CHAIN_ID);
+      if (valueWei === null) {
+        return {
+          approved: false,
+          reason:
+            "spending-limit policy cannot be evaluated: no USD price available for the destination chain",
+        };
+      }
+      value = valueWei;
+    }
+    const stats = await getOperatorSpendStats(input.agentId);
+    const evaluation = await policyEngine.evaluate(policySet, {
+      request: {
+        agentId: input.agentId,
+        tenantId: input.tenantId,
+        to: input.destination,
+        value,
+        chainId: ARBITRUM_CHAIN_ID, // Arbitrum HL withdraw destination chain
+      },
+      // `venue` must be top-level on the evaluation context: the engine reads
+      // `ctx.venue` (engine.ts) for the venue-allowlist evaluator. Nesting it
+      // inside `request` leaves ctx.venue undefined → venue-allowlist fails closed.
+      venue: "hyperliquid" as const,
+      recentTxCount1h: stats.recentTxCount1h,
+      recentTxCount24h: stats.recentTxCount24h,
+      spentToday: stats.spentToday,
+      spentThisWeek: stats.spentThisWeek,
+      priceOracle,
+    });
+    if (evaluation.approved) return { approved: true };
+    const failed = evaluation.results.find((r) => !r.passed);
+    return {
+      approved: false,
+      reason: failed?.reason ?? "transfer destination violates policy",
     };
   }
 
@@ -396,8 +602,8 @@ export function createOperatorRecoveryRoutes(
         409,
       );
     }
-    if (idempotency.response) {
-      return c.json<ApiResponse>({ ok: true, data: idempotency.response });
+    if (idempotency.entry) {
+      return c.json(idempotency.entry.body, idempotency.entry.status);
     }
 
     // Build the ERC-20 transfer(bridge, amount) calldata and have the vault sign +
@@ -424,7 +630,11 @@ export function createOperatorRecoveryRoutes(
         amount: amountBaseUnits.toString(),
         error: err instanceof Error ? err.message : String(err),
       });
-      return c.json<ApiResponse>({ ok: false, error: "Failed to submit deposit" }, 502);
+      // The broadcast may have landed — record the ambiguous outcome so a retry
+      // replays this 502 instead of double-broadcasting the ERC-20 transfer.
+      const errorBody = { ok: false as const, error: "Failed to submit deposit" };
+      idempotency.storeFailure?.(errorBody);
+      return c.json<ApiResponse>(errorBody, 502);
     }
 
     await auditRecoveryEvent(c, tenantId, agentId, "trade.recovery.deposit.submitted", {
@@ -491,8 +701,8 @@ export function createOperatorRecoveryRoutes(
         409,
       );
     }
-    if (idempotency.response) {
-      return c.json<ApiResponse>({ ok: true, data: idempotency.response });
+    if (idempotency.entry) {
+      return c.json(idempotency.entry.body, idempotency.entry.status);
     }
 
     const agent = await ensureAgentForTenant(tenantId, agentId);
@@ -532,7 +742,11 @@ export function createOperatorRecoveryRoutes(
         builderPerp,
         error: err instanceof Error ? err.message : String(err),
       });
-      return c.json<ApiResponse>({ ok: false, error: "Failed to update leverage" }, 502);
+      // The venue call may have landed — record the ambiguous outcome so a
+      // retry replays this 502 instead of re-executing the leverage update.
+      const errorBody = { ok: false as const, error: "Failed to update leverage" };
+      idempotency.storeFailure?.(errorBody);
+      return c.json<ApiResponse>(errorBody, 502);
     }
 
     await auditRecoveryEvent(c, tenantId, agentId, "trade.recovery.leverage.submitted", {
@@ -622,8 +836,8 @@ export function createOperatorRecoveryRoutes(
         409,
       );
     }
-    if (idempotency.response) {
-      return c.json<ApiResponse>({ ok: true, data: idempotency.response });
+    if (idempotency.entry) {
+      return c.json(idempotency.entry.body, idempotency.entry.status);
     }
 
     const agent = await ensureAgentForTenant(tenantId, agentId);
@@ -659,7 +873,11 @@ export function createOperatorRecoveryRoutes(
         amountBaseUnits: amountBaseUnits.toString(),
         error: err instanceof Error ? err.message : String(err),
       });
-      return c.json<ApiResponse>({ ok: false, error: "Failed to add isolated margin" }, 502);
+      // The venue call may have landed — record the ambiguous outcome so a
+      // retry replays this 502 instead of moving margin a second time.
+      const errorBody = { ok: false as const, error: "Failed to add isolated margin" };
+      idempotency.storeFailure?.(errorBody);
+      return c.json<ApiResponse>(errorBody, 502);
     }
 
     await auditRecoveryEvent(c, tenantId, agentId, "trade.recovery.add-margin.submitted", {
@@ -707,6 +925,36 @@ export function createOperatorRecoveryRoutes(
     };
     const { agentId, destination, amount } = body;
 
+    // Validate the USDC amount exactly like /withdraw: reject over-precision the
+    // 6-decimal conversion can't represent, and enforce the per-call safety
+    // ceiling so a compromised operator client cannot move the whole venue
+    // balance in one call (previously this rail had NO cap at all).
+    if (hasTooManyUsdcDecimals(amount)) {
+      return c.json<ApiResponse>(
+        { ok: false, error: "amount has more than 6 decimal places" },
+        400,
+      );
+    }
+    const amountBaseUnits = parseUsdcBaseUnits(amount);
+    if (amountBaseUnits === null || amountBaseUnits <= 0n) {
+      return c.json<ApiResponse>({ ok: false, error: "amount must be a positive number" }, 400);
+    }
+    if (amountBaseUnits > HL_MAX_WITHDRAW_BASE_UNITS) {
+      return c.json<ApiResponse>(
+        {
+          ok: false,
+          error: `amount exceeds the per-usd-send maximum of ${HL_MAX_WITHDRAW_USDC} USDC; split into smaller transfers`,
+        },
+        400,
+      );
+    }
+
+    const rate = await enforceOperatorTransferRateLimit("usd-send", tenantId, agentId);
+    if (!rate.allowed) {
+      c.header("Retry-After", String(Math.ceil(rate.resetMs / 1000)));
+      return c.json<ApiResponse>({ ok: false, error: "Operator transfer rate limit exceeded" }, 429);
+    }
+
     const idempotency = getOperatorIdempotency(`${tenantId}:usd-send`, body.idempotencyKey, {
       agentId,
       venue,
@@ -719,8 +967,8 @@ export function createOperatorRecoveryRoutes(
         409,
       );
     }
-    if (idempotency.response) {
-      return c.json<ApiResponse>({ ok: true, data: idempotency.response });
+    if (idempotency.entry) {
+      return c.json(idempotency.entry.body, idempotency.entry.status);
     }
 
     const agent = await ensureAgentForTenant(tenantId, agentId);
@@ -732,6 +980,28 @@ export function createOperatorRecoveryRoutes(
         { ok: false, error: "Hyperliquid venue wallet not found for agent" },
         404,
       );
+    }
+
+    // ── Policy gate (BEFORE signing) ─────────────────────────────────────────────
+    // usdSend moves USDC to an ARBITRARY Hyperliquid account — functionally a
+    // withdrawal rail. It must satisfy the same policy evaluation as /withdraw
+    // (approved-addresses + spend/rate caps); before this gate a leaked platform
+    // key could drain the full HL balance to any destination in one call.
+    const policy = await evaluateOperatorTransferPolicy({
+      tenantId,
+      agentId,
+      destination,
+      amountBaseUnits,
+    });
+    if (!policy.approved) {
+      await auditRecoveryEvent(c, tenantId, agentId, "trade.usdsend.policy-rejected", {
+        venue,
+        walletAddress,
+        destination,
+        amount,
+        reason: policy.reason,
+      });
+      return c.json({ code: "policy-violation", reason: policy.reason }, 400);
     }
 
     const adapter = buildAdapter(tenantId, agentId, walletAddress);
@@ -754,7 +1024,12 @@ export function createOperatorRecoveryRoutes(
         amount,
         error: err instanceof Error ? err.message : String(err),
       });
-      return c.json<ApiResponse>({ ok: false, error: "Failed to submit usdSend" }, 502);
+      // usdSend signs + submits in one adapter call, so a throw is ambiguous:
+      // the transfer may have landed. Record the outcome so a retry replays
+      // this 502 instead of double-sending USDC.
+      const errorBody = { ok: false as const, error: "Failed to submit usdSend" };
+      idempotency.storeFailure?.(errorBody);
+      return c.json<ApiResponse>(errorBody, 502);
     }
 
     await auditRecoveryEvent(c, tenantId, agentId, "trade.usdsend.completed", {
@@ -809,8 +1084,8 @@ export function createOperatorRecoveryRoutes(
         409,
       );
     }
-    if (idempotency.response) {
-      return c.json<ApiResponse>({ ok: true, data: idempotency.response });
+    if (idempotency.entry) {
+      return c.json(idempotency.entry.body, idempotency.entry.status);
     }
 
     const agent = await ensureAgentForTenant(tenantId, agentId);
@@ -844,7 +1119,11 @@ export function createOperatorRecoveryRoutes(
         maxFeeRate,
         error: err instanceof Error ? err.message : String(err),
       });
-      return c.json<ApiResponse>({ ok: false, error: "Failed to approve builder fee" }, 502);
+      // The venue call may have landed — record the ambiguous outcome so a
+      // retry replays this 502 instead of re-submitting the approval.
+      const errorBody = { ok: false as const, error: "Failed to approve builder fee" };
+      idempotency.storeFailure?.(errorBody);
+      return c.json<ApiResponse>(errorBody, 502);
     }
 
     await auditRecoveryEvent(c, tenantId, agentId, "trade.builder.approved", {
@@ -928,8 +1207,8 @@ export function createOperatorRecoveryRoutes(
         409,
       );
     }
-    if (idempotency.response) {
-      return c.json<ApiResponse>({ ok: true, data: idempotency.response });
+    if (idempotency.entry) {
+      return c.json(idempotency.entry.body, idempotency.entry.status);
     }
 
     const agent = await ensureAgentForTenant(tenantId, agentId);
@@ -954,17 +1233,33 @@ export function createOperatorRecoveryRoutes(
       amountBaseUnits: amountBaseUnits.toString(),
     });
 
-    let result: unknown;
-    let action: unknown;
+    // Signing is local (nothing reaches the venue), so a sign failure is safe to
+    // retry and is NOT stored; a submit failure means the transfer may have
+    // landed, so the ambiguous outcome IS stored and retries replay it.
+    let signed: Awaited<ReturnType<HyperliquidAdapter["signSendAsset"]>>;
     try {
-      const signed = await adapter.signSendAsset({
+      signed = await adapter.signSendAsset({
         destination: walletAddress,
         sourceDex,
         destinationDex,
         token: body.token,
         amount: body.amountUsdc,
       });
-      action = signed.action;
+    } catch (err) {
+      await auditRecoveryEvent(c, tenantId, agentId, "trade.recovery.transfer.failed", {
+        venue,
+        walletAddress,
+        sourceDex,
+        destinationDex,
+        amountUsdc: String(body.amountUsdc),
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return c.json<ApiResponse>({ ok: false, error: "Failed to sign collateral transfer" }, 502);
+    }
+
+    let result: unknown;
+    const action: unknown = signed.action;
+    try {
       result = await adapter.submitSendAsset(signed);
     } catch (err) {
       await auditRecoveryEvent(c, tenantId, agentId, "trade.recovery.transfer.failed", {
@@ -975,7 +1270,9 @@ export function createOperatorRecoveryRoutes(
         amountUsdc: String(body.amountUsdc),
         error: err instanceof Error ? err.message : String(err),
       });
-      return c.json<ApiResponse>({ ok: false, error: "Failed to submit collateral transfer" }, 502);
+      const errorBody = { ok: false as const, error: "Failed to submit collateral transfer" };
+      idempotency.storeFailure?.(errorBody);
+      return c.json<ApiResponse>(errorBody, 502);
     }
 
     await auditRecoveryEvent(c, tenantId, agentId, "trade.recovery.transfer.submitted", {
@@ -1029,8 +1326,8 @@ export function createOperatorRecoveryRoutes(
         409,
       );
     }
-    if (idempotency.response) {
-      return c.json<ApiResponse>({ ok: true, data: idempotency.response });
+    if (idempotency.entry) {
+      return c.json(idempotency.entry.body, idempotency.entry.status);
     }
 
     const agent = await ensureAgentForTenant(tenantId, agentId);
@@ -1055,7 +1352,11 @@ export function createOperatorRecoveryRoutes(
         walletAddress,
         error: err instanceof Error ? err.message : String(err),
       });
-      return c.json<ApiResponse>({ ok: false, error: "Failed to close positions" }, 502);
+      // Positions may have been partially closed — record the ambiguous outcome
+      // so a retry replays this 502 instead of firing another close batch.
+      const errorBody = { ok: false as const, error: "Failed to close positions" };
+      idempotency.storeFailure?.(errorBody);
+      return c.json<ApiResponse>(errorBody, 502);
     }
 
     // Audit every per-coin close so the recovery action is fully traceable.
@@ -1150,15 +1451,15 @@ export function createOperatorRecoveryRoutes(
         409,
       );
     }
-    if (idempotency.response) {
-      return c.json<ApiResponse>({ ok: true, data: idempotency.response });
+    if (idempotency.entry) {
+      return c.json(idempotency.entry.body, idempotency.entry.status);
     }
 
     // Resolve amount after the idempotency cache lookup, so a retry for a
     // previous full-balance withdraw returns the cached success before reading a
     // changed live balance.
     // `amount` stays human-readable for signing; `amountBaseUnits` (USDC 6-decimal
-    // base units, a uint256 integer string) is what the policy spend-cap sees.
+    // base units) is what the policy gate converts to native wei for the spend-cap.
     let amount = body.amount;
     let amountBaseUnits = explicitAmountBaseUnits;
     if (amount === undefined) {
@@ -1191,47 +1492,43 @@ export function createOperatorRecoveryRoutes(
 
     // ── Policy gate (BEFORE signing) ─────────────────────────────────────────────
     // The withdraw destination must be on the agent's approved list AND the amount
-    // must satisfy the spend-cap. We evaluate the full policy set the same way POST
-    // /vault/sign does; the approved-addresses evaluator reads `request.to`, and the
-    // spending-limit evaluator reads `request.value` (the real USDC base-unit
-    // notional, NOT the previous hardcoded "0" which bypassed the spend-cap).
-    const policySet = await getPolicySet(tenantId, agentId);
-    const evaluation = await policyEngine.evaluate(policySet, {
-      request: {
-        agentId,
-        tenantId,
-        to: destination,
-        value: amountBaseUnits.toString(),
-        chainId: 42161, // Arbitrum HL withdraw destination chain
-      },
-      // `venue` must be top-level on the evaluation context: the engine reads
-      // `ctx.venue` (engine.ts) for the venue-allowlist evaluator. Nesting it
-      // inside `request` leaves ctx.venue undefined → venue-allowlist fails closed.
-      venue: "hyperliquid" as const,
-      recentTxCount1h: 0,
-      recentTxCount24h: 0,
-      spentToday: 0n,
-      spentThisWeek: 0n,
-      priceOracle,
+    // must satisfy the spend/rate caps. The shared operator-transfer gate
+    // denominates `value` in native wei (so USD spending limits see the REAL
+    // notional, not 6-decimal USDC misread as wei) and feeds the evaluator the
+    // agent's REAL recent-tx counts + chain-scoped spend counters (the previous
+    // hardcoded zeroes made rate-limit and daily/weekly rules structurally
+    // inert, and the misdenominated `value` disabled even per-tx USD caps).
+    const rate = await enforceOperatorTransferRateLimit("withdraw", tenantId, agentId);
+    if (!rate.allowed) {
+      c.header("Retry-After", String(Math.ceil(rate.resetMs / 1000)));
+      return c.json<ApiResponse>({ ok: false, error: "Operator transfer rate limit exceeded" }, 429);
+    }
+
+    const policy = await evaluateOperatorTransferPolicy({
+      tenantId,
+      agentId,
+      destination,
+      amountBaseUnits,
     });
-    if (!evaluation.approved) {
-      const failed = evaluation.results.find((r) => !r.passed);
-      const reason = failed?.reason ?? "withdraw destination violates policy";
+    if (!policy.approved) {
       await auditRecoveryEvent(c, tenantId, agentId, "trade.recovery.withdraw.policy-rejected", {
         venue,
         walletAddress,
         destination,
-        reason,
+        reason: policy.reason,
       });
-      return c.json({ code: "policy-violation", reason }, 400);
+      return c.json({ code: "policy-violation", reason: policy.reason }, 400);
     }
 
     const adapter = buildAdapter(tenantId, agentId, walletAddress);
 
-    let result: unknown;
+    // Signing is local (nothing reaches the venue), so a sign failure is safe to
+    // retry and is NOT stored; a submit failure means the withdraw may have
+    // landed, so the ambiguous outcome IS stored and retries replay it (mirrors
+    // the HL order route's 502 "status unknown" envelope).
+    let signedWithdraw: Awaited<ReturnType<HyperliquidAdapter["signWithdraw"]>>;
     try {
-      const signed = await adapter.signWithdraw({ amount, destination });
-      result = await adapter.submitWithdraw(signed);
+      signedWithdraw = await adapter.signWithdraw({ amount, destination });
     } catch (err) {
       await auditRecoveryEvent(c, tenantId, agentId, "trade.recovery.withdraw.failed", {
         venue,
@@ -1240,7 +1537,23 @@ export function createOperatorRecoveryRoutes(
         amount,
         error: err instanceof Error ? err.message : String(err),
       });
-      return c.json<ApiResponse>({ ok: false, error: "Failed to submit withdraw" }, 502);
+      return c.json<ApiResponse>({ ok: false, error: "Failed to sign withdraw" }, 502);
+    }
+
+    let result: unknown;
+    try {
+      result = await adapter.submitWithdraw(signedWithdraw);
+    } catch (err) {
+      await auditRecoveryEvent(c, tenantId, agentId, "trade.recovery.withdraw.failed", {
+        venue,
+        walletAddress,
+        destination,
+        amount,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      const errorBody = { ok: false as const, error: "Failed to submit withdraw" };
+      idempotency.storeFailure?.(errorBody);
+      return c.json<ApiResponse>(errorBody, 502);
     }
 
     await auditRecoveryEvent(c, tenantId, agentId, "trade.recovery.withdraw.submitted", {

--- a/packages/plugin-trading/src/routes/operator-recovery.ts
+++ b/packages/plugin-trading/src/routes/operator-recovery.ts
@@ -952,7 +952,10 @@ export function createOperatorRecoveryRoutes(
     const rate = await enforceOperatorTransferRateLimit("usd-send", tenantId, agentId);
     if (!rate.allowed) {
       c.header("Retry-After", String(Math.ceil(rate.resetMs / 1000)));
-      return c.json<ApiResponse>({ ok: false, error: "Operator transfer rate limit exceeded" }, 429);
+      return c.json<ApiResponse>(
+        { ok: false, error: "Operator transfer rate limit exceeded" },
+        429,
+      );
     }
 
     const idempotency = getOperatorIdempotency(`${tenantId}:usd-send`, body.idempotencyKey, {
@@ -1501,7 +1504,10 @@ export function createOperatorRecoveryRoutes(
     const rate = await enforceOperatorTransferRateLimit("withdraw", tenantId, agentId);
     if (!rate.allowed) {
       c.header("Retry-After", String(Math.ceil(rate.resetMs / 1000)));
-      return c.json<ApiResponse>({ ok: false, error: "Operator transfer rate limit exceeded" }, 429);
+      return c.json<ApiResponse>(
+        { ok: false, error: "Operator transfer rate limit exceeded" },
+        429,
+      );
     }
 
     const policy = await evaluateOperatorTransferPolicy({

--- a/packages/plugin-trading/src/routes/trade.ts
+++ b/packages/plugin-trading/src/routes/trade.ts
@@ -279,6 +279,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
       | "trade.session.created"
       | "trade.session.revoked"
       | "trade.order.submitted"
+      | "trade.order.submitted-after-revoke"
       | "trade.order.submit.authorized"
       | "trade.order.leverage.set"
       | "trade.order.leverage.failed"
@@ -1197,6 +1198,23 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
           return envelope;
         }
 
+        // SEC-044: the submission fence no longer blocks revocation across
+        // venue I/O, so a revoke may have committed while the order was in
+        // flight. The order has landed regardless — detect + audit the race so
+        // operators can flatten manually.
+        const activeAfterSubmit = await getSessionManager().getActive(tenantId, session.id);
+        if (!activeAfterSubmit) {
+          await auditTradeEvent(tenantId, agentId, "trade.order.submitted-after-revoke", {
+            sessionId: session.id,
+            venue: "hyperliquid",
+            asset: parsedAsset.data,
+            leverage: effectiveLeverage,
+            size: body.size,
+            sizeUsd,
+            orderId: result.orderId ?? null,
+          });
+        }
+
         const response = {
           orderId: result.orderId ?? crypto.randomUUID(),
           status: result.status,
@@ -1776,9 +1794,11 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
 
     const manager = getSessionManager();
     // Fence reserve→submit against concurrent revocation (mirrors HL's
-    // withActiveSubmissionFence): the spend reservation and the venue submit run
-    // under an advisory lock that the revoke path also takes, so a revoke that
-    // commits before this block cannot interleave with an in-flight submit.
+    // withActiveSubmissionFence). After SEC-044 the fence's advisory lock covers
+    // ONLY the DB-level active check — it is released before this callback runs
+    // (never held across signing/venue I/O) — so revoke-vs-submit ordering here
+    // rests on the atomic reserveSpend re-check, the pre-submit activity
+    // re-check below, and the post-submit re-verification.
     const fenced = await manager.withActiveSubmissionFence(
       { tenantId, id: session.id },
       async () => {
@@ -1843,6 +1863,28 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
           const envelope: TradeIdempotencyResponse = {
             status: 400,
             body: { ok: false, error: "Order could not be built; not submitted" },
+          };
+          idempotency.store?.(envelope);
+          return envelope;
+        }
+
+        // SEC-044: re-confirm the session is still active BEFORE submitting
+        // (the fence no longer holds the advisory lock across venue I/O). A
+        // revoke that landed during the build must abort the submit; the
+        // reserved spend is released because nothing reached the venue.
+        const activeAfterBuild = await getSessionManager().getActive(tenantId, session.id);
+        if (!activeAfterBuild) {
+          await getSessionManager().releaseSpend({
+            tenantId,
+            id: session.id,
+            amountUsd: notionalUsd,
+          });
+          const envelope: TradeIdempotencyResponse = {
+            status: 409,
+            body: {
+              ok: false,
+              error: "Trade session was revoked before order submission",
+            },
           };
           idempotency.store?.(envelope);
           return envelope;
@@ -1957,6 +1999,25 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
           };
           idempotency.store?.(envelope);
           return envelope;
+        }
+
+        // SEC-044: the submission fence no longer blocks revocation across
+        // venue I/O, so a revoke may have committed while the order was in
+        // flight. The order has landed regardless — detect + audit the race so
+        // operators can flatten manually.
+        const activeAfterSubmit = await getSessionManager().getActive(tenantId, session.id);
+        if (!activeAfterSubmit) {
+          await auditTradeEvent(tenantId, agentId, "trade.order.submitted-after-revoke", {
+            sessionId: session.id,
+            venue: "polymarket",
+            tokenId: body.tokenId,
+            conditionId: body.conditionId ?? null,
+            side: body.side,
+            amount,
+            price,
+            notionalUsd,
+            orderId: result.orderId ?? null,
+          });
         }
 
         const response = {

--- a/packages/plugin-trading/src/routes/trade.ts
+++ b/packages/plugin-trading/src/routes/trade.ts
@@ -32,6 +32,7 @@ import {
   clobApiCredentialsSchema,
   deriveApiCredentials,
   type EthersSignerLike,
+  getPrices,
   isPolymarketPostNotAttempted,
   isPolymarketUnauthorized,
   POLY_EOA_SIGNATURE_TYPE,
@@ -1296,6 +1297,31 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
     return side === "buy" ? amount : amount * price;
   }
 
+  /**
+   * Notional USD for a Polymarket SELL, floored at the CLOB best bid. A FOK sell
+   * at limit 0.01 fills at the best bid (e.g. 0.90), so sizing caps on the
+   * caller's limit would understate the real notional and defeat
+   * perOrderCapUsd/dailyCapUsd (the HL path guards the same trick via
+   * resolveSizingPx). FAIL CLOSED: a sell whose market price cannot be verified
+   * is rejected, never sized on the caller's limit alone.
+   */
+  async function polymarketSellNotionalUsd(
+    amount: number,
+    price: number,
+    tokenId: string,
+    clobUrl?: string,
+  ): Promise<number> {
+    const [best] = await getPrices(
+      [{ tokenId, side: "sell" }],
+      clobUrl ? { clobUrl } : undefined,
+    );
+    const bestBid = Number(best?.price);
+    if (!Number.isFinite(bestBid) || bestBid <= 0) {
+      throw new Error("unable to resolve CLOB best bid for sell notional sizing");
+    }
+    return amount * Math.max(price, bestBid);
+  }
+
   // Map a structured checkOrderAllowed reason to its HTTP status. Allowlist/cap
   // rejections are client errors (400); a non-active session is a 403 (mirrors the
   // HL "Active session required" 403).
@@ -1570,7 +1596,40 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
         400,
       );
     }
-    const notionalUsd = polymarketNotionalUsd(body.side, amount, price);
+    // SEC-041: a SELL's notional must be floored at the live best bid — a FOK
+    // sell at an arbitrarily low limit fills at the bid, so sizing on the
+    // caller's price would understate notional and bypass the session caps.
+    // Fail closed (policy-violation, no spend) when the book can't be read.
+    let notionalUsd: number;
+    if (body.side === "sell") {
+      let clobUrl: string | undefined;
+      try {
+        clobUrl = configuredPolymarketClobUrl();
+      } catch {
+        clobUrl = undefined;
+      }
+      try {
+        notionalUsd = await polymarketSellNotionalUsd(amount, price, body.tokenId, clobUrl);
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : "unable to size sell notional";
+        await auditTradeEvent(tenantId, agentId, "trade.order.policy-rejected", {
+          venue: "polymarket",
+          tokenId: body.tokenId,
+          side: body.side,
+          amount,
+          price,
+          reason,
+        });
+        const envelope: TradeIdempotencyResponse = {
+          status: 400,
+          body: { code: "policy-violation", reason },
+        };
+        idempotency.store?.(envelope);
+        return c.json(envelope.body, envelope.status);
+      }
+    } else {
+      notionalUsd = polymarketNotionalUsd(body.side, amount, price);
+    }
 
     // Session fetch + ownership + venue check + the prediction-market policy gate,
     // all in one pass. checkActiveOrder loads the session and runs checkOrderAllowed

--- a/packages/plugin-trading/src/routes/trade.ts
+++ b/packages/plugin-trading/src/routes/trade.ts
@@ -560,11 +560,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
     // MFA recency is a human-session protection. The agent-self path has no human
     // session to MFA; its protection is the agent_policies cap clamp below + the
     // per-order policy evaluation on submission. Only enforce MFA on the human path.
-    if (
-      c.get("authType") === "session-jwt" &&
-      createByHumanAdmin &&
-      !hasRecentSessionMfa(c)
-    ) {
+    if (c.get("authType") === "session-jwt" && createByHumanAdmin && !hasRecentSessionMfa(c)) {
       return c.json<ApiResponse>(
         { ok: false, error: "Trade session management requires recent MFA verification" },
         403,
@@ -850,11 +846,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
         403,
       );
     }
-    if (
-      c.get("authType") === "session-jwt" &&
-      revokeByHumanAdmin &&
-      !hasRecentSessionMfa(c)
-    ) {
+    if (c.get("authType") === "session-jwt" && revokeByHumanAdmin && !hasRecentSessionMfa(c)) {
       return c.json<ApiResponse>(
         { ok: false, error: "Trade session management requires recent MFA verification" },
         403,
@@ -1348,10 +1340,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
     tokenId: string,
     clobUrl?: string,
   ): Promise<number> {
-    const [best] = await getPrices(
-      [{ tokenId, side: "sell" }],
-      clobUrl ? { clobUrl } : undefined,
-    );
+    const [best] = await getPrices([{ tokenId, side: "sell" }], clobUrl ? { clobUrl } : undefined);
     const bestBid = Number(best?.price);
     if (!Number.isFinite(bestBid) || bestBid <= 0) {
       throw new Error("unable to resolve CLOB best bid for sell notional sizing");

--- a/packages/plugin-trading/src/routes/trade.ts
+++ b/packages/plugin-trading/src/routes/trade.ts
@@ -176,6 +176,23 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
     { bodyHash: string; response: TradeIdempotencyResponse; expiresAt: number }
   >();
 
+  // The in-memory idempotency fallbacks are bounded (SEC-043): expired entries
+  // are swept on store and the oldest entries are evicted past the cap, so a
+  // caller minting unique keys cannot grow process memory without bound.
+  // (Mirrors evm-swap.ts's MAX_IDEMPOTENCY_ENTRIES.)
+  const MAX_MEMORY_IDEMPOTENCY_ENTRIES = 1_000;
+  function sweepMemoryIdempotency(
+    map: Map<string, { bodyHash: string; response: TradeIdempotencyResponse; expiresAt: number }>,
+    now: number,
+  ): void {
+    for (const [entryKey, entry] of map) {
+      if (entry.expiresAt <= now || map.size >= MAX_MEMORY_IDEMPOTENCY_ENTRIES) {
+        map.delete(entryKey);
+      }
+      if (map.size < MAX_MEMORY_IDEMPOTENCY_ENTRIES) break;
+    }
+  }
+
   function getSessionManager(): TradeSessionManager {
     return new TradeSessionManager({ redis: getRedisClient() });
   }
@@ -346,6 +363,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
     }
     return {
       store(response: TradeIdempotencyResponse) {
+        sweepMemoryIdempotency(memoryIdempotency, now);
         memoryIdempotency.set(mapKey, {
           bodyHash,
           response,
@@ -1263,6 +1281,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
     }
     return {
       store(response: TradeIdempotencyResponse) {
+        sweepMemoryIdempotency(pmMemoryIdempotency, now);
         pmMemoryIdempotency.set(mapKey, {
           bodyHash,
           response,

--- a/packages/plugin-trading/src/routes/trade.ts
+++ b/packages/plugin-trading/src/routes/trade.ts
@@ -232,6 +232,24 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
     return typeof body === "object" && body !== null && Object.hasOwn(body, key);
   }
 
+  /**
+   * Recent-MFA check for the human (session-jwt) trade-session gates. A session
+   * that completed MFA hours or days ago must NOT manage fund-moving trade
+   * sessions — presence of a historical verification is not recency. Mirrors
+   * the plugin-capabilities + core /secrets gate (5-minute default).
+   */
+  function hasRecentSessionMfa(
+    c: Context<{ Variables: AppVariables }>,
+    maxAgeMs = 5 * 60_000,
+  ): boolean {
+    const verifiedAt = c.get("sessionMfaVerifiedAt");
+    return (
+      typeof verifiedAt === "number" &&
+      Number.isFinite(verifiedAt) &&
+      Date.now() - verifiedAt <= maxAgeMs
+    );
+  }
+
   function policyViolation(message: string) {
     return { code: "policy-violation", message };
   }
@@ -525,7 +543,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
     if (
       c.get("authType") === "session-jwt" &&
       createByHumanAdmin &&
-      !c.get("sessionMfaVerifiedAt")
+      !hasRecentSessionMfa(c)
     ) {
       return c.json<ApiResponse>(
         { ok: false, error: "Trade session management requires recent MFA verification" },
@@ -774,7 +792,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
         403,
       );
     }
-    if (c.get("authType") === "session-jwt" && readByHumanAdmin && !c.get("sessionMfaVerifiedAt")) {
+    if (c.get("authType") === "session-jwt" && readByHumanAdmin && !hasRecentSessionMfa(c)) {
       return c.json<ApiResponse>(
         { ok: false, error: "Trade session management requires recent MFA verification" },
         403,
@@ -815,7 +833,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
     if (
       c.get("authType") === "session-jwt" &&
       revokeByHumanAdmin &&
-      !c.get("sessionMfaVerifiedAt")
+      !hasRecentSessionMfa(c)
     ) {
       return c.json<ApiResponse>(
         { ok: false, error: "Trade session management requires recent MFA verification" },

--- a/packages/trade-sessions/src/__tests__/trade-sessions.test.ts
+++ b/packages/trade-sessions/src/__tests__/trade-sessions.test.ts
@@ -254,7 +254,10 @@ describe("TradeSessionManager", () => {
         },
       ),
       new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error("fence callback deadlocked inside the transaction")), 8000),
+        setTimeout(
+          () => reject(new Error("fence callback deadlocked inside the transaction")),
+          8000,
+        ),
       ),
     ]);
 

--- a/packages/trade-sessions/src/__tests__/trade-sessions.test.ts
+++ b/packages/trade-sessions/src/__tests__/trade-sessions.test.ts
@@ -228,6 +228,56 @@ describe("TradeSessionManager", () => {
     expect(expired?.status).toBe("expired");
     expect(await manager.getActive(TENANT_ID, session.id)).toBeNull();
   });
+
+  test("SEC-044: the submission fence does not hold its transaction across the callback", async () => {
+    const manager = await freshManager();
+    const session = await manager.createSession(baseInput());
+
+    // A callback that issues its OWN base-connection DB reads/writes (exactly
+    // what the order routes do: reserveSpend, releaseSpend, audit writes)
+    // deadlocks against the fence's open transaction under a single-connection
+    // database. After SEC-044 the advisory lock + active check COMMIT before
+    // the callback runs, so these complete. Pre-fix this test would hang; the
+    // race turns the deadlock into a failure instead of a stuck suite.
+    const result = await Promise.race([
+      manager.withActiveSubmissionFence(
+        { tenantId: TENANT_ID, id: session.id },
+        async (fencedSession) => {
+          expect(fencedSession.id).toBe(session.id);
+          const fresh = await manager.getSession({ tenantId: TENANT_ID, id: session.id });
+          const reserved = await manager.reserveSpend({
+            tenantId: TENANT_ID,
+            id: session.id,
+            amountUsd: 10,
+          });
+          return { freshId: fresh?.id ?? null, reserved: reserved !== null };
+        },
+      ),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("fence callback deadlocked inside the transaction")), 8000),
+      ),
+    ]);
+
+    expect(result).toEqual({ freshId: session.id, reserved: true });
+  });
+
+  test("SEC-044: the submission fence returns null for a revoked session", async () => {
+    const manager = await freshManager();
+    const session = await manager.createSession(baseInput());
+    await manager.revokeSession({ tenantId: TENANT_ID, id: session.id });
+
+    let callbackRan = false;
+    const result = await manager.withActiveSubmissionFence(
+      { tenantId: TENANT_ID, id: session.id },
+      async () => {
+        callbackRan = true;
+        return "submitted";
+      },
+    );
+
+    expect(result).toBeNull();
+    expect(callbackRan).toBe(false);
+  });
 });
 
 describe("prediction-market allowlist (pure)", () => {

--- a/packages/trade-sessions/src/index.ts
+++ b/packages/trade-sessions/src/index.ts
@@ -486,7 +486,17 @@ export class TradeSessionManager {
     input: SessionFenceInput,
     callback: (session: TradeSession) => Promise<T>,
   ): Promise<T | null> {
-    return getDb().transaction(async (tx) => {
+    // SEC-044: hold the advisory lock + transaction ONLY around the DB-level
+    // active check — never across the callback. The order routes' callbacks
+    // perform vault signing and venue HTTP round-trips (seconds under load);
+    // holding the lock across that network I/O serialized all submissions for
+    // a session, blocked revocation for the duration, and pinned a
+    // connection-pool slot per in-flight order (pool-exhaustion /
+    // revocation-latency DoS). Revoke-vs-submit ordering is re-established by
+    // (a) the atomic reserveSpend, whose WHERE clause re-checks
+    // status="active", and (b) the routes' pre-submit activity re-check and
+    // post-submit re-verification.
+    const session = await getDb().transaction(async (tx) => {
       await tx.execute(
         sql`select pg_advisory_xact_lock(hashtextextended(${sessionFenceKey(input.tenantId, input.id)}, 0))`,
       );
@@ -501,9 +511,10 @@ export class TradeSessionManager {
             sql`${tradeSessions.expiresAt} > ${this.now().toISOString()}`,
           ),
         );
-      if (!row) return null;
-      return callback(rowToSession(row));
+      return row ? rowToSession(row) : null;
     });
+    if (!session) return null;
+    return callback(session);
   }
 
   async releaseSpend(input: IncrementSpendInput): Promise<TradeSession | null> {

--- a/packages/venue-polymarket/src/discovery.ts
+++ b/packages/venue-polymarket/src/discovery.ts
@@ -11,6 +11,12 @@ import { type PolymarketEvent, type PolymarketMarket } from "./types";
 export interface PolymarketFetchOptions {
   fetch?: typeof fetch;
   signal?: AbortSignal;
+  /**
+   * CLOB API base override (e.g. a compatible gateway). Applies to CLOB-edge
+   * reads only (marketdata); Gamma reads ignore it. Defaults to
+   * POLYMARKET_CLOB_API_BASE.
+   */
+  clobUrl?: string;
 }
 
 function gammaUrl(

--- a/packages/venue-polymarket/src/marketdata.ts
+++ b/packages/venue-polymarket/src/marketdata.ts
@@ -193,7 +193,8 @@ export async function getPrices(
 ): Promise<PolymarketBestPrice[]> {
   if (requests.length === 0) return [];
   const doFetch = opts?.fetch ?? fetch;
-  const response = await doFetch(`${POLYMARKET_CLOB_API_BASE}/prices`, {
+  const clobBase = opts?.clobUrl ?? POLYMARKET_CLOB_API_BASE;
+  const response = await doFetch(`${clobBase}/prices`, {
     method: "POST",
     headers: { Accept: "application/json", "Content-Type": "application/json" },
     body: JSON.stringify(


### PR DESCRIPTION
## Summary

Batch 4b (trading) of the wave-2 security audit fixes. Scope: `packages/plugin-trading`, `packages/trade-sessions`, `packages/venue-polymarket`. All HIGH + MEDIUM findings are fixed with regression tests that fail without the fix. LOW/INFO findings are **DEFERRED** (time-boxed batch; see table).

| SEC ID | Severity | Status | Change |
|---|---|---|---|
| SEC-004 | HIGH | FIXED | `/usd-send` now runs the same policy evaluation as `/withdraw` (approved-addresses + spend/rate caps, default-deny on empty policy set), enforces the per-call 2000 USDC ceiling, and is rate-limited 10/min/agent. Previously: arbitrary USDC to any address with no gate, no cap, no limit. |
| SEC-034 | MEDIUM | FIXED | Trade-session create/read/revoke now require **recent** MFA (5-min `hasRecentSessionMfa` window, mirroring plugin-capabilities + core `/secrets`) instead of presence-only. |
| SEC-041 | MEDIUM | FIXED | Polymarket SELL notional is floored at the CLOB best bid (`max(limit, bestBid)` via `/prices`, honoring the endpoint override), fail-closed when the book is unreadable — a FOK sell at limit 0.01 can no longer bypass per-order/daily caps while filling at 0.90. Mirrors HL `resolveSizingPx`. |
| SEC-042 | MEDIUM | FIXED | Withdraw policy gate is real: `value` is converted USDC→native wei via the price oracle when a spending-limit rule exists (was 6-dec USDC priced as wei, ~1e12x understated; fail-closed if unpriceable), and the evaluator now gets the agent's real recent-tx counts + Arbitrum-scoped spend counters (were hardcoded 0). Route-level 10/min limit added. |
| SEC-043 | MEDIUM | FIXED (partial) | Operator-recovery + HL/PM order idempotency maps are bounded (1000 entries, expired-sweep + oldest-evict, mirroring `evm-swap.ts`), and all operator routes now store ambiguous-outcome 502 envelopes so retries replay instead of re-executing (sign-phase failures remain retryable). **Not done:** Redis/DB-backed durable idempotency — restarts/multi-replica still lose dedup (follow-up). |
| SEC-044 | MEDIUM | FIXED | `withActiveSubmissionFence` no longer holds the DB transaction + advisory lock across vault signing/venue HTTP. Lock covers only the DB-level active check; ordering is preserved via atomic `reserveSpend`, a new pre-submit re-check on the PM route, and post-submit re-verification auditing `trade.order.submitted-after-revoke`. |
| SEC-091 | LOW | DEFERRED | token-status cross-tenant oracle — not reached in this batch. |
| SEC-108 | LOW | DEFERRED | PM L2 creds plaintext in Redis — not reached. |
| SEC-110 | LOW | DEFERRED | agent-trader webhook redaction arrays — not reached. |
| SEC-111 | LOW | DEFERRED | PM test-creds/CLOB-URL prod guards — not reached. |
| SEC-113 | LOW | DEFERRED | `submitWithdraw` fetch timeout — not reached. |
| SEC-114 | LOW | DEFERRED | market-order preliminary policy rejection — not reached. |
| SEC-184 | INFO | DEFERRED | discarded `hyperliquidOrderSchema.safeParse` — not reached. |
| SEC-185 | INFO | DEFERRED | `slippageBps` 10_000 clamp — not reached. |
| SEC-186 | INFO | DEFERRED | builder precedence docs/startup validation — not reached. |
| SEC-187 | INFO | DEFERRED | PM fill-unit heuristic — not reached. |
| SEC-188 | INFO | DEFERRED | agent-trader config/cache — not reached. |

## Trade-offs / breaking changes

- **usd-send + withdraw are default-deny for policy-less agents** (the engine denies on an empty policy set; withdraw already behaved this way). Operators must configure an `approved-addresses` policy before using these rails.
- **Wei-denominated `maxPerTx`/`maxPerDay` caps on withdraws are now compared against REAL wei** (USDC converted via the price oracle). A tenant that configured wei-style caps in USDC micro-units (matching the old mis-denominated behavior, e.g. issue-#109-era configs) must re-denominate. USD-style caps (`maxPerTxUsd` etc.) simply start working correctly. The spend-cap path now also requires a reachable price oracle (fail-closed otherwise).
- **Revocation semantics (SEC-044):** `revokeSession` no longer blocks until in-flight submissions complete. A revoke that races an in-flight order is *detected and audited* (`trade.order.submitted-after-revoke`) instead of prevented; operators should watch for that event and flatten manually. This is the recommended fix from the audit (the old behavior was a pool-exhaustion/revocation-latency DoS).
- **Operator transfer rate limit:** 10 calls/min/agent/rail for withdraw + usd-send (429 with Retry-After).

## How tested

- New regression tests (all verified to **fail without the fix** by stashing the implementation):
  - `operator-recovery-policy-gates.test.ts` (8 tests): usd-send non-allowlisted dest / no-policy default-deny / per-call cap / rate-limit loop → 429; withdraw per-tx USD cap enforced at real notional (stub oracle) / under-cap allowed / rate-limit policy from real tx counts; 502 idempotent replay without re-submit.
  - `trade-session-gates.test.ts`: stale-MFA (10 min old) posture → 403 on create/get/revoke.
  - `trade-polymarket-order.test.ts`: SEC-041 sell floored at bid → per-order-cap-exceeded; bid-below-limit no over-denial; book unreadable → fail-closed. Existing sub-0.01 SELL test updated for the new best-bid lookup.
  - `trade-sessions.test.ts`: fence callback runs outside the DB transaction (deadlock-guard regression) + revoked-session null.
  - Existing issue-#109 withdraw spend-cap tests updated to the corrected wei denomination + stub oracle.
- Suites: plugin-trading 125/125 (two halves — a single all-files run trips a Bun SIGSEGV that is environmental, not a test failure), trade-sessions 25/25, venue-polymarket 56/56.
- `bunx biome check` clean on all changed files.
- Note: `bun.lock` was churned by `bun install` locally and is intentionally **not** included in this PR.
