### PR TITLE
fix(security): SDK & CLI hardening wave 2 (SEC-046–049, SEC-119–127, SEC-196)

### DIFF
--- a/packages/api/src/__tests__/agent-client-e2e.test.ts
+++ b/packages/api/src/__tests__/agent-client-e2e.test.ts
@@ -230,8 +230,8 @@ beforeAll(async () => {
   globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
     const url =
       typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
-    if (url.startsWith("http://a3-api")) {
-      const path = url.slice("http://a3-api".length) || "/";
+    if (url.startsWith("http://localhost")) {
+      const path = url.slice("http://localhost".length) || "/";
       return apiApp.request(path, init as RequestInit);
     }
     if (url.startsWith(PROXY_URL) && proxyApp) {
@@ -263,7 +263,7 @@ describe("A3 agent-client E2E (real API, seeded p256 signer)", () => {
     // The agent holds ONLY its private key (imported non-extractable).
     const kp = await AgentKeypair.fromPkcs8Base64(await exportPkcs8Base64(keypair.privateKey));
     const client = new AgentClient({
-      baseUrl: "http://a3-api",
+      baseUrl: "http://localhost",
       agentId,
       keypair: kp,
       renewJitterMs: 0,

--- a/packages/cli/src/__tests__/evidence-bundle-verify.test.ts
+++ b/packages/cli/src/__tests__/evidence-bundle-verify.test.ts
@@ -53,10 +53,7 @@ describe("evidence bundle offline verification", () => {
         ],
         { cwd: dir, stdout: "pipe", stderr: "pipe" },
       );
-      const [stderr, exitCode] = await Promise.all([
-        new Response(proc.stderr).text(),
-        proc.exited,
-      ]);
+      const [stderr, exitCode] = await Promise.all([new Response(proc.stderr).text(), proc.exited]);
 
       // The decoy next to the operator's CWD must never run.
       expect(existsSync(marker)).toBe(false);

--- a/packages/cli/src/__tests__/evidence-bundle-verify.test.ts
+++ b/packages/cli/src/__tests__/evidence-bundle-verify.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, isAbsolute, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { evidenceBundleVerifierScript } from "../index";
+
+const CLI_ENTRY = join(dirname(dirname(fileURLToPath(import.meta.url))), "index.ts");
+
+describe("evidence bundle offline verification", () => {
+  test("verifier resolves to the CLI-shipped script, independent of CWD", () => {
+    const script = evidenceBundleVerifierScript();
+    // Must be absolute and INSIDE this repo: a CWD-relative path would execute
+    // whatever scripts/verify-evidence-bundle.mjs the operator happens to stand
+    // in (attacker-writable clone, shared CI workspace).
+    expect(isAbsolute(script)).toBe(true);
+    expect(script.endsWith(join("scripts", "verify-evidence-bundle.mjs"))).toBe(true);
+    expect(existsSync(script)).toBe(true);
+  });
+
+  test("audit bundle --verify never executes a CWD decoy verifier and writes 0600", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "steward-cli-verify-"));
+    // Stub API: any GET returns a syntactically valid but unsigned bundle, so
+    // the SHIPPED verifier fails closed if (and only if) it is the one run.
+    const server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch: () => Response.json({ events: [], checkpoint: null }),
+    });
+    try {
+      const decoyDir = join(dir, "scripts");
+      mkdirSync(decoyDir);
+      const marker = join(dir, "decoy-executed");
+      writeFileSync(
+        join(decoyDir, "verify-evidence-bundle.mjs"),
+        `import { writeFileSync } from "node:fs";\n` +
+          `writeFileSync(${JSON.stringify(marker)}, "pwned");\n` +
+          "process.exit(0);\n",
+      );
+      const out = join(dir, "bundle.json");
+      const proc = Bun.spawn(
+        [
+          "bun",
+          "run",
+          CLI_ENTRY,
+          "audit",
+          "bundle",
+          "--out",
+          out,
+          "--verify",
+          "--api-url",
+          `http://127.0.0.1:${server.port}`,
+        ],
+        { cwd: dir, stdout: "pipe", stderr: "pipe" },
+      );
+      const [stderr, exitCode] = await Promise.all([
+        new Response(proc.stderr).text(),
+        proc.exited,
+      ]);
+
+      // The decoy next to the operator's CWD must never run.
+      expect(existsSync(marker)).toBe(false);
+      // The shipped verifier ran instead and rejected the unsigned bundle.
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("Offline audit bundle verification failed");
+      // The bundle carries sensitive audit metadata: owner-only from creation.
+      expect(statSync(out).mode & 0o777).toBe(0o600);
+    } finally {
+      server.stop(true);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 15_000);
+});

--- a/packages/cli/src/__tests__/init.test.ts
+++ b/packages/cli/src/__tests__/init.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from "bun:test";
 import { createPublicKey, sign, verify } from "node:crypto";
 import {
   chmodSync,
+  existsSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
@@ -280,6 +282,88 @@ describe("steward init", () => {
       rmSync(dir, { recursive: true, force: true });
     }
   }, 15_000);
+
+  test("--migrate never executes a CWD-relative decoy migrate.ts", () => {
+    const dir = mkdtempSync(join(tmpdir(), "steward-cli-migrate-"));
+    const previousCwd = process.cwd();
+    try {
+      // Decoy at <cwd>/packages/db/src/migrate.ts: exits 0 and drops a marker.
+      // Pre-fix, `steward init --migrate` executed exactly this path.
+      const decoyDir = join(dir, "packages", "db", "src");
+      mkdirSync(decoyDir, { recursive: true });
+      const marker = join(dir, "decoy-executed");
+      writeFileSync(
+        join(decoyDir, "migrate.ts"),
+        `import { writeFileSync } from "node:fs";\nwriteFileSync(${JSON.stringify(marker)}, "pwned");\n`,
+      );
+      process.chdir(dir);
+      // The SHIPPED migrator runs instead: against a refused port it exits
+      // non-zero, so runInit throws — and the decoy never ran.
+      expect(() =>
+        runInit({
+          envPath: join(dir, ".env"),
+          runMigrations: true,
+          databaseUrl: "postgresql://u:p@127.0.0.1:1/steward",
+        }),
+      ).toThrow(/migrations failed/i);
+      expect(existsSync(marker)).toBe(false);
+    } finally {
+      process.chdir(previousCwd);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 15_000);
+
+  test("--migrate does not default STEWARD_ALLOW_INSECURE_DB on for the child", async () => {
+    // With NODE_ENV=production and a non-loopback DATABASE_URL lacking
+    // sslmode=require, the shipped migrator must hit the db package's TLS
+    // gate. Pre-fix the CLI forced STEWARD_ALLOW_INSECURE_DB=true into the
+    // child env, silently disabling that gate; post-fix the gate fires.
+    const dir = mkdtempSync(join(tmpdir(), "steward-cli-migrate-tls-"));
+    try {
+      const envPath = join(dir, ".env");
+      const childEnv: Record<string, string | undefined> = {
+        ...process.env,
+        NODE_ENV: "production",
+      };
+      delete childEnv.STEWARD_ALLOW_INSECURE_DB;
+      const proc = Bun.spawn(
+        [
+          "bun",
+          "run",
+          CLI_ENTRY,
+          "init",
+          "--env",
+          envPath,
+          "--migrate",
+          "--database-url",
+          "postgresql://u:p@192.0.2.1:5432/steward",
+        ],
+        { env: childEnv, stdout: "pipe", stderr: "pipe" },
+      );
+      const [stderr, exitCode] = await Promise.all([new Response(proc.stderr).text(), proc.exited]);
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("sslmode=require");
+      expect(stderr).not.toContain("STEWARD_ALLOW_INSECURE_DB=true —");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 15_000);
+
+  test("generated env does not pre-acknowledge local plaintext key custody", () => {
+    const dir = mkdtempSync(join(tmpdir(), "steward-cli-"));
+    try {
+      const envPath = join(dir, ".env");
+      runInit({ envPath });
+      const env = readFileSync(envPath, "utf8");
+      // The production custody gate must require a deliberate operator ack:
+      // the line ships commented out (guidance retained), never active.
+      expect(envValue(env, "STEWARD_ACK_LOCAL_CUSTODY")).toBeUndefined();
+      expect(env).toContain("# STEWARD_ACK_LOCAL_CUSTODY=true");
+      expect(env).toContain("docs/security/custody-posture.md");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 
   test("emitted env contains no secret material outside its assigned values", () => {
     // Guard against accidentally echoing a generated secret into a comment or a

--- a/packages/cli/src/__tests__/tenant-api-key.test.ts
+++ b/packages/cli/src/__tests__/tenant-api-key.test.ts
@@ -1,0 +1,66 @@
+/**
+ * readTenantApiKey — credential sources for `steward tenant create`.
+ *
+ * The tenant API key is a plaintext credential: it should arrive via
+ * --api-key-file, --api-key-env, or stdin, never as an argv flag that lands in
+ * shell history and `ps` output. --api-key still works for backward
+ * compatibility but emits a loud warning (same treatment as readSecretValue).
+ */
+
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readTenantApiKey } from "../index";
+
+describe("readTenantApiKey", () => {
+  const dirs: string[] = [];
+  afterEach(() => {
+    for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+    delete process.env.STEWARD_TEST_TENANT_KEY;
+  });
+
+  it("reads from --api-key-file and strips a single trailing newline", () => {
+    const dir = mkdtempSync(join(tmpdir(), "steward-tenant-key-"));
+    dirs.push(dir);
+    const file = join(dir, "tenant.key");
+    writeFileSync(file, "stw_tenant_abc123\n");
+    expect(readTenantApiKey({ "api-key-file": file })).toBe("stw_tenant_abc123");
+  });
+
+  it("reads from --api-key-env and refuses an unset variable", () => {
+    process.env.STEWARD_TEST_TENANT_KEY = "stw_tenant_fromenv";
+    expect(readTenantApiKey({ "api-key-env": "STEWARD_TEST_TENANT_KEY" })).toBe(
+      "stw_tenant_fromenv",
+    );
+    delete process.env.STEWARD_TEST_TENANT_KEY;
+    expect(() => readTenantApiKey({ "api-key-env": "STEWARD_TEST_TENANT_KEY" })).toThrow(
+      "unset or empty",
+    );
+  });
+
+  it("accepts --api-key for backward compatibility but warns about shell history", () => {
+    const warn = spyOn(console, "error").mockImplementation(() => {});
+    try {
+      expect(readTenantApiKey({ "api-key": "legacy-flag-key" })).toBe("legacy-flag-key");
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(String(warn.mock.calls[0][0])).toContain("shell history");
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("prefers --api-key-file over --api-key (no warning when a file is given)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "steward-tenant-key-"));
+    dirs.push(dir);
+    const file = join(dir, "preferred.key");
+    writeFileSync(file, "from-file");
+    const warn = spyOn(console, "error").mockImplementation(() => {});
+    try {
+      expect(readTenantApiKey({ "api-key-file": file, "api-key": "from-flag" })).toBe("from-file");
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -140,6 +140,17 @@ export function auditArchiveVerificationMode(flags: Record<string, string | bool
   return { mode: "none" };
 }
 
+/**
+ * Absolute path to the offline evidence-bundle verifier SHIPPED WITH the CLI.
+ * Resolved against the CLI's own location (never the operator's CWD, which may
+ * be an attacker-writable directory containing a decoy
+ * `scripts/verify-evidence-bundle.mjs`) and executed via process.execPath so
+ * the runtime is the same one running the CLI.
+ */
+export function evidenceBundleVerifierScript(): string {
+  return join(import.meta.dir, "../../../scripts/verify-evidence-bundle.mjs");
+}
+
 const HELP = `steward CLI
 
 Usage:
@@ -512,11 +523,10 @@ async function auditCommand(action: string | undefined, ctx: CommandContext) {
   if (to !== undefined) params.set("to", String(to));
   const bundle = await ctx.api.request("GET", `/audit/bundle?${params}`);
   const out = stringFlag(ctx.flags, "out");
-  if (out) writeFileSync(out, JSON.stringify(bundle, null, 2));
+  if (out) writeFileSync(out, JSON.stringify(bundle, null, 2), { mode: 0o600 });
   if (boolFlag(ctx.flags, "verify")) {
     if (!out) throw new Error("--verify requires --out so the offline verifier has a file");
-    const result = spawnSync("node", ["scripts/verify-evidence-bundle.mjs", out], {
-      cwd: process.cwd(),
+    const result = spawnSync(process.execPath, [evidenceBundleVerifierScript(), out], {
       stdio: "inherit",
     });
     if (result.status !== 0) throw new Error("Offline audit bundle verification failed");
@@ -599,11 +609,11 @@ async function providerActionCommand(action: string | undefined, ctx: CommandCon
     // trusted key fingerprint (E7): --out bundle.json [--verify --fp <hex>].
     const bundle = await ctx.api.request("GET", `/v2/provider-actions/${id()}/evidence`);
     const out = stringFlag(ctx.flags, "out");
-    if (out) writeFileSync(out, JSON.stringify(bundle, null, 2));
+    if (out) writeFileSync(out, JSON.stringify(bundle, null, 2), { mode: 0o600 });
     if (boolFlag(ctx.flags, "verify")) {
       if (!out) throw new Error("--verify requires --out so the offline verifier has a file");
       const fp = stringFlag(ctx.flags, "fp") ?? stringFlag(ctx.flags, "expected-key-fingerprint");
-      const args = ["scripts/verify-evidence-bundle.mjs", out];
+      const args = [evidenceBundleVerifierScript(), out];
       // E7 / M09: bind trust to an out-of-band fingerprint. Warn loudly if absent
       // (verifying against the embedded key proves self-consistency ONLY).
       if (fp) args.push("--expected-key-fingerprint", fp);
@@ -612,7 +622,7 @@ async function providerActionCommand(action: string | undefined, ctx: CommandCon
           "WARNING: no --fp supplied; verifying against the EMBEDDED key proves " +
             "self-consistency only, NOT trust to a known signing root (PR5 E7).",
         );
-      const result = spawnSync("node", args, { cwd: process.cwd(), stdio: "inherit" });
+      const result = spawnSync(process.execPath, args, { stdio: "inherit" });
       if (result.status !== 0) throw new Error("Offline evidence bundle verification failed");
     }
     return out ? { wrote: out, verified: boolFlag(ctx.flags, "verify"), bundle } : bundle;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -156,7 +156,8 @@ const HELP = `steward CLI
 Usage:
   steward init [--env .env] [--force] [--migrate]
   steward doctor [--strict] [--json]
-  steward tenant create --id ID --name NAME --api-key KEY
+  steward tenant create --id ID --name NAME [--api-key-file F] [--api-key-env VAR]
+                        (key via stdin/--api-key-file/--api-key-env preferred; --api-key warns)
   steward agent create --name NAME [--id ID]
   steward agent token --agent-id ID [--expires-in 24h] [--scopes agent,api:proxy]
   steward secret add --name NAME [--file F] [--description TEXT]   (value via stdin or --file preferred; --value warns)
@@ -210,7 +211,7 @@ function createContext(flags: Record<string, string | boolean>): CommandContext 
 
 async function tenantCommand(action: string | undefined, ctx: CommandContext) {
   if (action !== "create") throw new Error("Supported tenant command: tenant create");
-  const apiKey = required(stringFlag(ctx.flags, "api-key"), "api-key");
+  const apiKey = readTenantApiKey(ctx.flags);
   const body = {
     id: required(stringFlag(ctx.flags, "id"), "id"),
     name: required(stringFlag(ctx.flags, "name"), "name"),
@@ -270,6 +271,43 @@ export function readSecretValue(flags: Record<string, string | boolean>): string
   }
   throw new Error(
     "secret value required: pipe it on stdin, pass --file <path>, or (discouraged) --value",
+  );
+}
+
+/**
+ * Read the tenant API key for `tenant create`. Preferred sources are
+ * --api-key-file, --api-key-env, or stdin so the plaintext credential never
+ * lands in shell history or `ps` output. --api-key remains for backward
+ * compatibility but warns loudly (same treatment as readSecretValue above).
+ */
+export function readTenantApiKey(flags: Record<string, string | boolean>): string {
+  const file = stringFlag(flags, "api-key-file");
+  if (file) {
+    // Strip a single trailing newline (editors add one) but keep interior bytes.
+    return readFileSync(file, "utf8").replace(/\n$/, "");
+  }
+  const envVar = stringFlag(flags, "api-key-env");
+  if (envVar) {
+    const value = process.env[envVar];
+    if (value) return value;
+    throw new Error(`--api-key-env: environment variable '${envVar}' is unset or empty`);
+  }
+  const flagValue = stringFlag(flags, "api-key");
+  if (flagValue !== undefined) {
+    console.error(
+      "[steward] WARNING: --api-key places the credential in shell history and process listings. " +
+        "Prefer --api-key-file <path>, --api-key-env <VAR>, or stdin: " +
+        'printf %s "$KEY" | steward tenant create --id ID --name NAME',
+    );
+    return flagValue;
+  }
+  if (!process.stdin.isTTY) {
+    const data = readFileSync(0, "utf8").replace(/\n$/, "");
+    if (data) return data;
+  }
+  throw new Error(
+    "tenant API key required: pipe it on stdin, pass --api-key-file <path>, " +
+      "--api-key-env <VAR>, or (discouraged) --api-key",
   );
 }
 

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -9,7 +9,7 @@ import {
   unlinkSync,
   writeFileSync,
 } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
 export type InitOptions = {
   envPath?: string;
@@ -75,11 +75,16 @@ function renderEnv(options: InitOptions): string {
     // This env sets NODE_ENV=production with no STEWARD_KMS_PROVIDER, so the
     // vault resolves to `local` custody (plaintext key in app memory at sign
     // time). The production custody gate refuses to boot local mode unless the
-    // posture is acknowledged, so a generated env must carry the ack to boot.
-    // Generating local custody IS the deliberate default choice; record it
-    // explicitly and auditably. To harden, set STEWARD_KMS_PROVIDER=aws|pkcs11
-    // and clear this. See docs/security/custody-posture.md.
-    "STEWARD_ACK_LOCAL_CUSTODY=true",
+    // posture is acknowledged. The ack is deliberately emitted COMMENTED OUT:
+    // an operator who accepts local custody uncomments it, recording the
+    // decision explicitly and auditably (SEC-120).
+    "# Custody posture: no STEWARD_KMS_PROVIDER is set, so the vault runs in",
+    "# `local` mode (plaintext key in app memory at sign time). The production",
+    "# custody gate refuses to boot local mode unless the posture is explicitly",
+    "# acknowledged. To accept local custody, uncomment the line below (records",
+    "# the decision). To harden instead, set STEWARD_KMS_PROVIDER=aws|pkcs11.",
+    "# See docs/security/custody-posture.md.",
+    "# STEWARD_ACK_LOCAL_CUSTODY=true",
     "STEWARD_AUDIT_HMAC_KEY=" + hex(32),
     "# Raw 32-byte Ed25519 seed hex; supported by packages/api/src/services/audit-checkpoint.ts.",
     "STEWARD_AUDIT_SIGNING_KEY=" + hex(32),
@@ -170,12 +175,18 @@ export function runInit(options: InitOptions = {}): InitResult {
   if (options.runMigrations) {
     const envSource = readFileSync(envPath, "utf8");
     const databaseUrl = options.databaseUrl ?? readEnvValue(envSource, "DATABASE_URL");
-    const result = spawnSync("bun", ["packages/db/src/migrate.ts"], {
-      cwd: process.cwd(),
+    // Resolve the migrator against THIS CLI's install tree and run it with the
+    // current runtime. A CWD-relative path would execute whatever
+    // packages/db/src/migrate.ts exists beneath the operator's (possibly
+    // attacker-writable) working directory, with every generated secret below
+    // in its environment.
+    const result = spawnSync(process.execPath, [join(import.meta.dir, "../../db/src/migrate.ts")], {
       env: {
         ...process.env,
         DATABASE_URL: databaseUrl ?? process.env.DATABASE_URL ?? "",
-        STEWARD_ALLOW_INSECURE_DB: process.env.STEWARD_ALLOW_INSECURE_DB ?? "true",
+        // STEWARD_ALLOW_INSECURE_DB is inherited only when the operator set it
+        // explicitly — never defaulted on, so the production DB-TLS gate
+        // (packages/db/src/client.ts) is not silently bypassed.
       },
       stdio: "inherit",
     });

--- a/packages/csharp/src/Steward/StewardClient.cs
+++ b/packages/csharp/src/Steward/StewardClient.cs
@@ -80,6 +80,9 @@ namespace Steward
 
     public sealed class StewardClient
     {
+        // Keep in lockstep with the equivalent list in EVERY other SDK (sdk, go,
+        // java, python, ruby, rust, swift, flutter): mutations under these
+        // prefixes are HMAC-signed; divergence silently downgrades integrity (SEC-049).
         private static readonly string[] SensitivePrefixes = new[]
         {
             "/vault",
@@ -96,7 +99,9 @@ namespace Steward
             "/platform",
             "/condition-sets",
             "/condition_sets",
-            "/v1/condition_sets"
+            "/v1/condition_sets",
+            "/global-wallet",
+            "/accounts"
         };
 
         private readonly StewardClientConfig _config;

--- a/packages/csharp/src/Steward/StewardClient.cs
+++ b/packages/csharp/src/Steward/StewardClient.cs
@@ -283,7 +283,13 @@ namespace Steward
 
         private static async Task<StewardTransportResponse> DefaultTransportAsync(StewardTransportRequest request, CancellationToken cancellationToken)
         {
-            using var http = new HttpClient { Timeout = request.Timeout };
+            // Do not follow redirects automatically: HttpClient would copy the
+            // X-Steward-* credential/signing headers to the redirect target
+            // (it strips only Authorization), so an open redirect or hostile
+            // proxy could exfiltrate them (SEC-126). A 3xx surfaces as a
+            // response instead — callers configure the canonical API URL.
+            using var handler = new HttpClientHandler { AllowAutoRedirect = false };
+            using var http = new HttpClient(handler) { Timeout = request.Timeout };
             using var message = new HttpRequestMessage(new HttpMethod(request.Method), request.Url);
             foreach (var pair in request.Headers)
             {

--- a/packages/flutter/lib/src/client.dart
+++ b/packages/flutter/lib/src/client.dart
@@ -100,8 +100,14 @@ class StewardClient {
       headers ?? const <String, String>{},
       idempotencyKey,
     );
+    // Do not follow redirects automatically: package:http forwards all headers
+    // (including X-Steward-* credentials and signatures) to the redirect
+    // target, so an open redirect or hostile proxy could exfiltrate them
+    // (SEC-126). A 3xx surfaces as a response instead — consumers configure
+    // the canonical API URL.
     final response = await _client.send(
       http.Request(method.toUpperCase(), uri)
+        ..followRedirects = false
         ..headers.addAll(requestHeaders)
         ..bodyBytes = encodedBody ?? const <int>[],
     );

--- a/packages/flutter/lib/src/client.dart
+++ b/packages/flutter/lib/src/client.dart
@@ -41,6 +41,9 @@ class StewardClient {
       : _baseUri = Uri.parse(config.baseUrl.replaceFirst(RegExp(r'/+$'), '')),
         _client = config.httpClient ?? http.Client();
 
+  // Keep in lockstep with the equivalent list in EVERY other SDK (sdk, go,
+  // java, python, ruby, rust, swift, csharp): mutations under these prefixes
+  // are HMAC-signed, and divergence silently downgrades integrity (SEC-049).
   static const _sensitivePrefixes = <String>[
     '/vault',
     '/agents',

--- a/packages/go/steward/client.go
+++ b/packages/go/steward/client.go
@@ -60,6 +60,9 @@ type apiEnvelope struct {
 	Error string          `json:"error,omitempty"`
 }
 
+// Keep in lockstep with the equivalent list in EVERY other SDK (sdk, java,
+// python, ruby, rust, swift, csharp, flutter): mutations under these prefixes
+// are HMAC-signed, and divergence silently downgrades integrity (SEC-049).
 var sensitivePrefixes = []string{
 	"/vault",
 	"/agents",
@@ -76,6 +79,8 @@ var sensitivePrefixes = []string{
 	"/condition-sets",
 	"/condition_sets",
 	"/v1/condition_sets",
+	"/global-wallet",
+	"/accounts",
 }
 
 func NewClient(config Config) (*Client, error) {

--- a/packages/go/steward/client.go
+++ b/packages/go/steward/client.go
@@ -38,7 +38,7 @@ type Client struct {
 	config  Config
 	http    *http.Client
 	now     func() time.Time
-	newID   func() string
+	newID   func() (string, error)
 }
 
 type APIError struct {
@@ -131,8 +131,11 @@ func NewClient(config Config) (*Client, error) {
 	if now == nil {
 		now = time.Now
 	}
-	newID := config.NewID
-	if newID == nil {
+	newID := func() (string, error) { return "", nil }
+	if config.NewID != nil {
+		userNewID := config.NewID
+		newID = func() (string, error) { return userNewID(), nil }
+	} else {
 		newID = randomID
 	}
 	return &Client{baseURL: base, config: config, http: httpClient, now: now, newID: newID}, nil
@@ -172,7 +175,9 @@ func (c *Client) Request(ctx context.Context, method string, path string, body a
 	if err != nil {
 		return err
 	}
-	c.applyHeaders(req, method, canonicalPath, rawBody)
+	if err := c.applyHeaders(req, method, canonicalPath, rawBody); err != nil {
+		return err
+	}
 	res, err := c.http.Do(req)
 	if err != nil {
 		return err
@@ -185,7 +190,7 @@ func (c *Client) Request(ctx context.Context, method string, path string, body a
 	return decodeResponse(res.StatusCode, payload, out)
 }
 
-func (c *Client) applyHeaders(req *http.Request, method string, path string, body []byte) {
+func (c *Client) applyHeaders(req *http.Request, method string, path string, body []byte) error {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 	switch {
@@ -211,7 +216,11 @@ func (c *Client) applyHeaders(req *http.Request, method string, path string, bod
 		}
 		idempotencyKey := req.Header.Get("Idempotency-Key")
 		if idempotencyKey == "" {
-			idempotencyKey = c.newID()
+			generated, err := c.newID()
+			if err != nil {
+				return err
+			}
+			idempotencyKey = generated
 			req.Header.Set("Idempotency-Key", idempotencyKey)
 		}
 		if c.config.RequestSigningKeyID != "" && req.Header.Get("X-Steward-Signing-Key-Id") == "" {
@@ -224,6 +233,7 @@ func (c *Client) applyHeaders(req *http.Request, method string, path string, bod
 		mac.Write([]byte(canonical))
 		req.Header.Set("X-Steward-Signature", "v1="+hex.EncodeToString(mac.Sum(nil)))
 	}
+	return nil
 }
 
 func decodeResponse(status int, payload []byte, out any) error {
@@ -279,12 +289,14 @@ func isSensitiveMutation(path string, method string) bool {
 	return false
 }
 
-func randomID() string {
+func randomID() (string, error) {
 	var b [16]byte
 	if _, err := rand.Read(b[:]); err != nil {
-		return fmt.Sprintf("%d", time.Now().UnixNano())
+		// Fail closed: never fall back to a predictable (timestamp-derived)
+		// idempotency key (SEC-196).
+		return "", fmt.Errorf("crypto/rand unavailable for idempotency key: %w", err)
 	}
 	b[6] = (b[6] & 0x0f) | 0x40
 	b[8] = (b[8] & 0x3f) | 0x80
-	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16]), nil
 }

--- a/packages/go/steward/client.go
+++ b/packages/go/steward/client.go
@@ -83,6 +83,32 @@ var sensitivePrefixes = []string{
 	"/accounts",
 }
 
+var stewardCredentialHeaders = []string{
+	"Authorization",
+	"X-Steward-Key",
+	"X-Steward-Platform-Key",
+	"X-Steward-App-Id",
+	"X-Steward-Signature",
+	"X-Steward-Signing-Key-Id",
+	"X-Steward-Request-Timestamp",
+	"Idempotency-Key",
+}
+
+// stripStewardCredentialsOnCrossHostRedirect drops credential and signing
+// headers when a redirect targets a different host, so an open redirect or
+// hostile proxy cannot exfiltrate them (SEC-126).
+func stripStewardCredentialsOnCrossHostRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) == 0 {
+		return nil
+	}
+	if !strings.EqualFold(req.URL.Hostname(), via[0].URL.Hostname()) {
+		for _, header := range stewardCredentialHeaders {
+			req.Header.Del(header)
+		}
+	}
+	return nil
+}
+
 func NewClient(config Config) (*Client, error) {
 	if strings.TrimSpace(config.BaseURL) == "" {
 		return nil, errors.New("base URL is required")
@@ -93,7 +119,13 @@ func NewClient(config Config) (*Client, error) {
 	}
 	httpClient := config.HTTPClient
 	if httpClient == nil {
-		httpClient = &http.Client{Timeout: 30 * time.Second}
+		httpClient = &http.Client{
+			Timeout: 30 * time.Second,
+			// Never forward Steward credential headers to a different host on
+			// redirect: net/http strips only Authorization/Cookie and copies
+			// X-Steward-* headers to any host (SEC-126).
+			CheckRedirect: stripStewardCredentialsOnCrossHostRedirect,
+		}
 	}
 	now := config.Now
 	if now == nil {

--- a/packages/go/steward/client_test.go
+++ b/packages/go/steward/client_test.go
@@ -144,6 +144,34 @@ func TestSensitiveMutationsAreSignedAndIdempotent(t *testing.T) {
 	}
 }
 
+// SEC-049: every SDK's signing-prefix list must cover wallet/account mutations
+// in lockstep (Flutter already signed these).
+func TestAccountsAndGlobalWalletMutationsAreSigned(t *testing.T) {
+	var captured *http.Request
+	client, err := NewClient(Config{
+		BaseURL:              "https://api.example.test",
+		AppID:                "app-1",
+		AppSecret:            "secret-1",
+		RequestSigningSecret: "signing-secret",
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			captured = req
+			return jsonResponse(200, `{"ok":true,"data":{"id":"ok"}}`), nil
+		})},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, path := range []string{"/accounts", "/global-wallet/consent/approve"} {
+		if err := client.Post(context.Background(), path, map[string]any{}, nil); err != nil {
+			t.Fatal(err)
+		}
+		if got := captured.Header.Get("X-Steward-Signature"); !strings.HasPrefix(got, "v1=") || len(got) != 67 {
+			t.Fatalf("unsigned mutation %s: signature %q", path, got)
+		}
+	}
+}
+
 func TestAPIErrorIncludesStatusAndPayload(t *testing.T) {
 	client, err := NewClient(Config{
 		BaseURL: "https://api.example.test",

--- a/packages/go/steward/client_test.go
+++ b/packages/go/steward/client_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -239,4 +240,24 @@ func asAPIError(err error, target **APIError) bool {
 	}
 	*target = apiErr
 	return true
+}
+
+// SEC-196: the default idempotency-key generator must return crypto-rand
+// UUIDs (or an error) — never a predictable timestamp-derived fallback.
+func TestRandomIDReturnsCryptoUUIDs(t *testing.T) {
+	first, err := randomID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := randomID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	uuidShape := regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+	if !uuidShape.MatchString(first) {
+		t.Fatalf("randomID is not a UUID (timestamp fallback?): %q", first)
+	}
+	if first == second {
+		t.Fatal("randomID produced duplicate ids")
+	}
 }

--- a/packages/go/steward/client_test.go
+++ b/packages/go/steward/client_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -169,6 +170,40 @@ func TestAccountsAndGlobalWalletMutationsAreSigned(t *testing.T) {
 		if got := captured.Header.Get("X-Steward-Signature"); !strings.HasPrefix(got, "v1=") || len(got) != 67 {
 			t.Fatalf("unsigned mutation %s: signature %q", path, got)
 		}
+	}
+}
+
+// SEC-126: the default HTTP client must not forward credential headers to a
+// different host when a redirect is followed.
+func TestCrossHostRedirectStripsCredentialHeaders(t *testing.T) {
+	var redirected *http.Request
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		redirected = req
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"data":{"id":"ok"}}`))
+	}))
+	defer target.Close()
+	// Redirect to the same listener under a DIFFERENT hostname (both names are
+	// loopback, but the host string differs) so the cross-host check engages.
+	crossHostURL := strings.Replace(target.URL, "127.0.0.1", "localhost", 1)
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		http.Redirect(w, req, crossHostURL+"/harvest", http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	client, err := NewClient(Config{BaseURL: redirector.URL, APIKey: "tenant-key"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out map[string]any
+	if err := client.Get(context.Background(), "/accounts", nil, &out); err != nil {
+		t.Fatal(err)
+	}
+	if redirected == nil {
+		t.Fatal("redirect was not followed")
+	}
+	if got := redirected.Header.Get("X-Steward-Key"); got != "" {
+		t.Fatalf("credential header leaked cross-host: X-Steward-Key=%q", got)
 	}
 }
 

--- a/packages/java/src/main/java/com/steward/sdk/StewardClient.java
+++ b/packages/java/src/main/java/com/steward/sdk/StewardClient.java
@@ -23,6 +23,9 @@ import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 
 public final class StewardClient {
+    // Keep in lockstep with the equivalent list in EVERY other SDK (sdk, go,
+    // python, ruby, rust, swift, csharp, flutter): mutations under these
+    // prefixes are HMAC-signed; divergence silently downgrades integrity (SEC-049).
     private static final List<String> SENSITIVE_PREFIXES = List.of(
         "/vault",
         "/agents",
@@ -38,7 +41,9 @@ public final class StewardClient {
         "/platform",
         "/condition-sets",
         "/condition_sets",
-        "/v1/condition_sets"
+        "/v1/condition_sets",
+        "/global-wallet",
+        "/accounts"
     );
     private static final List<String> MUTATING_METHODS = List.of("POST", "PUT", "PATCH", "DELETE");
 

--- a/packages/python/steward_sdk/client.py
+++ b/packages/python/steward_sdk/client.py
@@ -9,8 +9,8 @@ import uuid
 from dataclasses import dataclass
 from typing import Any, Callable, Mapping
 from urllib.error import HTTPError, URLError
-from urllib.parse import urlencode
-from urllib.request import Request, urlopen
+from urllib.parse import quote, urlencode, urlparse
+from urllib.request import HTTPRedirectHandler, Request, build_opener
 
 
 JsonObject = dict[str, Any]
@@ -71,9 +71,49 @@ SENSITIVE_SIGNED_PREFIXES = (
 MUTATING_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
 
 
+# Headers that carry credentials or signing material. urllib capitalizes header
+# names ("X-steward-key"), so comparisons must be case-insensitive.
+_CREDENTIAL_HEADERS = frozenset(
+    name.lower()
+    for name in (
+        "Authorization",
+        "X-Steward-Key",
+        "X-Steward-Platform-Key",
+        "X-Steward-App-Id",
+        "X-Steward-Signature",
+        "X-Steward-Signing-Key-Id",
+        "X-Steward-Request-Timestamp",
+        "Idempotency-Key",
+    )
+)
+
+
+class _StewardRedirectHandler(HTTPRedirectHandler):
+    """Follow redirects, but never forward credential headers to a different
+    host. urllib's default handler converts 301/302/303 POSTs to GET yet copies
+    every header — including API keys and HMAC signatures — to the redirect
+    target, so an open redirect or hostile proxy would exfiltrate them
+    (SEC-125)."""
+
+    def redirect_request(self, req: Request, fp: Any, code: int, msg: str, headers: Any, newurl: str) -> Request | None:
+        new_req = super().redirect_request(req, fp, code, msg, headers, newurl)
+        if new_req is None:
+            return None
+        old_host = (urlparse(req.full_url).hostname or "").lower()
+        new_host = (urlparse(new_req.full_url).hostname or "").lower()
+        if new_host != old_host:
+            for store in (new_req.headers, new_req.unredirected_hdrs):
+                for name in [key for key in store if key.lower() in _CREDENTIAL_HEADERS]:
+                    del store[name]
+        return new_req
+
+
+_default_opener = build_opener(_StewardRedirectHandler())
+
+
 def _default_transport(request: Request, body: bytes | None, timeout: float) -> tuple[int, Mapping[str, str], bytes]:
     try:
-        with urlopen(request, data=body, timeout=timeout) as response:
+        with _default_opener.open(request, data=body, timeout=timeout) as response:
             return response.status, dict(response.headers.items()), response.read()
     except HTTPError as exc:
         return exc.code, dict(exc.headers.items()), exc.read()
@@ -169,7 +209,7 @@ class StewardClient:
         )
 
     def get_user(self, user_id: str) -> JsonObject:
-        return self.get(f"/platform/users/{user_id}")
+        return self.get(f"/platform/users/{quote(user_id, safe='')}")
 
     def lookup_user(self, **query: str) -> JsonObject:
         return self.get("/platform/users/lookup", query=query)
@@ -181,7 +221,7 @@ class StewardClient:
         return self.post("/user/me/push-subscriptions", subscription)
 
     def revoke_user_push_subscription(self, subscription_id: str) -> JsonObject:
-        return self.delete(f"/user/me/push-subscriptions/{subscription_id}")
+        return self.delete(f"/user/me/push-subscriptions/{quote(subscription_id, safe='')}")
 
     def _headers(
         self,

--- a/packages/python/steward_sdk/client.py
+++ b/packages/python/steward_sdk/client.py
@@ -46,6 +46,9 @@ class StewardClientConfig:
     transport: Transport | None = None
 
 
+# Keep in lockstep with the equivalent list in EVERY other SDK (sdk, go, java,
+# ruby, rust, swift, csharp, flutter): mutations under these prefixes are
+# HMAC-signed, and divergence silently downgrades integrity (SEC-049).
 SENSITIVE_SIGNED_PREFIXES = (
     "/vault",
     "/agents",
@@ -62,6 +65,8 @@ SENSITIVE_SIGNED_PREFIXES = (
     "/condition-sets",
     "/condition_sets",
     "/v1/condition_sets",
+    "/global-wallet",
+    "/accounts",
 )
 MUTATING_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
 

--- a/packages/python/tests/test_client.py
+++ b/packages/python/tests/test_client.py
@@ -88,6 +88,27 @@ class StewardClientTests(unittest.TestCase):
         self.assertEqual(caught.exception.status, 403)
         self.assertEqual(str(caught.exception), "denied")
 
+    def test_accounts_and_global_wallet_mutations_are_signed(self):
+        # SEC-049: every SDK's signing-prefix list must cover wallet/account
+        # mutations in lockstep (Flutter already signed these).
+        transport = CaptureTransport()
+        client = StewardClient(
+            base_url="https://api.example.test",
+            app_id="app-1",
+            app_secret="secret-1",
+            request_signing_secret="signing-secret",
+            transport=transport,
+        )
+
+        for path in ("/accounts", "/global-wallet/consent/approve"):
+            client.post(path, {})
+            request, _, _ = transport.calls[-1]
+            self.assertRegex(
+                request.get_header("X-steward-signature") or "",
+                r"^v1=[0-9a-f]{64}$",
+                f"unsigned mutation: {path}",
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/packages/python/tests/test_client.py
+++ b/packages/python/tests/test_client.py
@@ -4,6 +4,7 @@ import unittest
 from urllib.request import Request
 
 from steward_sdk import StewardApiError, StewardClient
+from steward_sdk.client import _StewardRedirectHandler
 
 
 class CaptureTransport:
@@ -108,6 +109,55 @@ class StewardClientTests(unittest.TestCase):
                 r"^v1=[0-9a-f]{64}$",
                 f"unsigned mutation: {path}",
             )
+
+    def test_redirect_strips_credential_headers_cross_host(self):
+        # SEC-125: urllib's default redirect handling copies every header to
+        # the redirect target; an open redirect must not receive credentials.
+        handler = _StewardRedirectHandler()
+        original = Request(
+            "https://api.example.test/accounts",
+            headers={
+                "Authorization": "Bearer user-token",
+                "X-Steward-Key": "tenant-key",
+                "X-Steward-Platform-Key": "platform-key",
+                "X-Steward-Signature": "v1=deadbeef",
+                "Content-Type": "application/json",
+            },
+        )
+
+        cross = handler.redirect_request(original, None, 302, "Found", {}, "https://evil.example/harvest")
+        self.assertIsNone(cross.get_header("Authorization"))
+        self.assertIsNone(cross.get_header("X-steward-key"))
+        self.assertIsNone(cross.get_header("X-steward-platform-key"))
+        self.assertIsNone(cross.get_header("X-steward-signature"))
+
+        same_host = handler.redirect_request(original, None, 302, "Found", {}, "https://api.example.test/other")
+        self.assertEqual(same_host.get_header("Authorization"), "Bearer user-token")
+        self.assertEqual(same_host.get_header("X-steward-key"), "tenant-key")
+
+    def test_path_parameters_are_url_encoded(self):
+        # SEC-127: raw interpolation lets `/`, `?`, `#` in an id silently
+        # alter the request path/query.
+        transport = CaptureTransport()
+        client = StewardClient(
+            base_url="https://api.example.test",
+            api_key="tenant-key",
+            transport=transport,
+        )
+
+        client.get_user("user/evil?admin=true#frag")
+        request, _, _ = transport.calls[-1]
+        self.assertEqual(
+            request.full_url,
+            "https://api.example.test/platform/users/user%2Fevil%3Fadmin%3Dtrue%23frag",
+        )
+
+        client.revoke_user_push_subscription("sub/1")
+        request, _, _ = transport.calls[-1]
+        self.assertEqual(
+            request.full_url,
+            "https://api.example.test/user/me/push-subscriptions/sub%2F1",
+        )
 
 
 if __name__ == "__main__":

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -31,6 +31,30 @@ The SDK expects synchronous session storage, while React Native storage is
 async. `createStewardNativeAuth()` hydrates the async store first, then passes a
 synchronous cache into `StewardAuth`.
 
+> **Session-token storage:** `@react-native-async-storage/async-storage` is
+> unencrypted plaintext — readable on rooted/jailbroken devices and via Android
+> backups. The examples use it for brevity, but production apps should persist
+> `steward_session_token` / `steward_refresh_token` in a Keychain/Keystore-backed
+> store such as `expo-secure-store` or `react-native-keychain`, wrapped in the
+> same `AsyncKeyValueStorage` shape:
+>
+> ```tsx
+> import * as SecureStore from "expo-secure-store";
+> import { createStewardNativeAuth } from "@stwd/react-native";
+>
+> const secureStorage = {
+>   getItem: (key: string) => SecureStore.getItemAsync(key),
+>   setItem: (key: string, value: string) => SecureStore.setItemAsync(key, value),
+>   removeItem: (key: string) => SecureStore.deleteItemAsync(key),
+> };
+>
+> const auth = await createStewardNativeAuth({
+>   baseUrl: "https://api.steward.example",
+>   tenantId: "my-app",
+>   storage: secureStorage,
+> });
+> ```
+
 After a hydrated or newly-created session, native helpers call `/user/me` with
 the configured tenant context so tenant automatic embedded-wallet creation can
 run during login. Bootstrap errors are swallowed so auth results remain usable;

--- a/packages/react-native/src/__tests__/storage.test.ts
+++ b/packages/react-native/src/__tests__/storage.test.ts
@@ -614,6 +614,29 @@ describe("@stwd/react-native storage", () => {
     expect(result.subscription.id).toBe("push-1");
   });
 
+  test("createStewardNativeClient maps a static token to bearerToken (SEC-124)", async () => {
+    const client = createStewardNativeClient({
+      baseUrl: "https://api.example.test",
+      token: "static-user-token",
+    });
+    installAuthFetch({ ok: true, data: { subscription: { id: "push-1" } } });
+
+    await registerNativePushToken(client, "ExponentPushToken[abc123abc123abc123]");
+
+    expect(lastRequest?.headers.authorization).toBe("Bearer static-user-token");
+  });
+
+  test("createStewardNativeClient rejects function token providers loudly (SEC-124)", () => {
+    // The provider was previously accepted and silently dropped, so requests
+    // went out unauthenticated while the type signature claimed auth was set.
+    expect(() =>
+      createStewardNativeClient({
+        baseUrl: "https://api.example.test",
+        token: () => "resolved-later",
+      }),
+    ).toThrow(/function token providers/);
+  });
+
   test("signs in with a native passkey bridge", async () => {
     const auth = await createStewardNativeAuth({
       baseUrl: "https://api.example.test",

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -50,6 +50,14 @@ function storageKey(namespace: string, key: string): string {
  * Adapts React Native AsyncStorage to the synchronous storage interface used by
  * the shared TypeScript SDK. Call `hydrate()` before constructing `StewardAuth`,
  * or use `createStewardNativeAuth()`.
+ *
+ * SECURITY: this adapter persists `steward_session_token` and
+ * `steward_refresh_token` wherever the backing store puts them.
+ * `@react-native-async-storage/async-storage` is UNENCRYPTED plaintext
+ * (readable on rooted/jailbroken devices and via Android backups). For session
+ * tokens prefer a Keychain/Keystore-backed store — expo-secure-store or
+ * react-native-keychain — wrapped in the same AsyncKeyValueStorage shape (see
+ * the package README for an example).
  */
 export function createReactNativeSessionStorage(
   storage: AsyncKeyValueStorage,
@@ -129,11 +137,25 @@ export async function createStewardNativeAuth({
 }
 
 export interface StewardNativeClientConfig extends StewardClientConfig {
+  /**
+   * Convenience alias for `bearerToken`: a static string is forwarded as the
+   * client's bearer token. Function token providers are NOT supported and now
+   * throw at construction — previously they were silently dropped and requests
+   * went out unauthenticated while the type signature claimed auth was
+   * configured (SEC-124). Resolve the token yourself and pass the string.
+   */
   token?: string | (() => string | null | Promise<string | null>);
 }
 
 export function createStewardNativeClient(config: StewardNativeClientConfig): StewardClient {
-  return new StewardClient(config);
+  const { token, ...rest } = config;
+  if (typeof token === "function") {
+    throw new StewardApiError(
+      "createStewardNativeClient does not support function token providers; resolve the token and pass a static string instead.",
+      0,
+    );
+  }
+  return new StewardClient({ ...rest, bearerToken: rest.bearerToken ?? token });
 }
 
 export function getNativeSession(auth: StewardAuth): StewardSession | null {

--- a/packages/ruby/lib/steward/client.rb
+++ b/packages/ruby/lib/steward/client.rb
@@ -21,6 +21,9 @@ module Steward
   end
 
   class Client
+    # Keep in lockstep with the equivalent list in EVERY other SDK (sdk, go,
+    # java, python, rust, swift, csharp, flutter): mutations under these
+    # prefixes are HMAC-signed; divergence silently downgrades integrity (SEC-049).
     SENSITIVE_PREFIXES = [
       "/vault",
       "/agents",
@@ -36,7 +39,9 @@ module Steward
       "/platform",
       "/condition-sets",
       "/condition_sets",
-      "/v1/condition_sets"
+      "/v1/condition_sets",
+      "/global-wallet",
+      "/accounts"
     ].freeze
 
     MUTATING_METHODS = %w[POST PUT PATCH DELETE].freeze

--- a/packages/rust/src/lib.rs
+++ b/packages/rust/src/lib.rs
@@ -14,6 +14,9 @@ use url::form_urlencoded;
 
 type HmacSha256 = Hmac<Sha256>;
 
+// Keep in lockstep with the equivalent list in EVERY other SDK (sdk, go, java,
+// python, ruby, swift, csharp, flutter): mutations under these prefixes are
+// HMAC-signed, and divergence silently downgrades integrity (SEC-049).
 const SENSITIVE_SIGNED_PREFIXES: &[&str] = &[
     "/vault",
     "/agents",
@@ -30,6 +33,8 @@ const SENSITIVE_SIGNED_PREFIXES: &[&str] = &[
     "/condition-sets",
     "/condition_sets",
     "/v1/condition_sets",
+    "/global-wallet",
+    "/accounts",
 ];
 
 const MUTATING_METHODS: &[&str] = &["POST", "PUT", "PATCH", "DELETE"];

--- a/packages/rust/tests/client.rs
+++ b/packages/rust/tests/client.rs
@@ -5,7 +5,7 @@ use std::time::{Duration, UNIX_EPOCH};
 use serde_json::{json, Value};
 use steward_sdk::{
     ApiError, Client, Config, CreateUserInput, Error, PushSubscriptionInput,
-    PushSubscriptionResult, Request, Response, Transport,
+    PushSubscriptionResult, Request, RequestOptions, Response, Transport,
 };
 
 #[derive(Clone)]
@@ -212,5 +212,32 @@ fn api_errors_include_status_and_payload() {
             assert_eq!(data.unwrap(), json!({"ok": false, "error": "denied"}));
         }
         other => panic!("expected API error, got {other:?}"),
+    }
+}
+
+// SEC-049: every SDK's signing-prefix list must cover wallet/account mutations
+// in lockstep (Flutter already signed these).
+#[test]
+fn accounts_and_global_wallet_mutations_are_signed() {
+    let transport = CaptureTransport::new(json!({"ok": true, "data": {"id": "ok"}}));
+    let client = Client::new(Config {
+        base_url: "https://api.example.test".to_string(),
+        app_id: Some("app-1".to_string()),
+        app_secret: Some("secret-1".to_string()),
+        request_signing_secret: Some("signing-secret".to_string()),
+        transport: Some(Arc::new(transport.clone())),
+        ..Config::default()
+    })
+    .unwrap();
+
+    for path in ["/accounts", "/global-wallet/consent/approve"] {
+        client.post(path, &json!({}), RequestOptions::default()).unwrap();
+        let request = transport.last_request();
+        let signature = request
+            .headers
+            .get("X-Steward-Signature")
+            .unwrap_or_else(|| panic!("unsigned mutation: {path}"));
+        assert!(signature.starts_with("v1="));
+        assert_eq!(signature.len(), 67);
     }
 }

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Security (BREAKING)
+- `StewardClient`, `StewardAuth`, and `AgentClient` constructors now REJECT a plaintext non-loopback `baseUrl` (fail closed, SEC-048). These clients transmit platform keys, app secrets, bearer tokens, and HMAC-signed credentials, which must never travel cleartext off-loopback — the CLI has always enforced this. `http://localhost`/`127.0.0.1`/`[::1]` stay allowed for local development; operators on trusted private networks can opt out with the new `allowInsecureBaseUrl: true` config (warns loudly at construction). Previously-working insecure configs must pass the flag or switch to HTTPS.
+- `/accounts` and `/global-wallet` mutations are now HMAC-signed when `requestSigningSecret` is configured, aligning the request-signing prefix list with all eight other SDKs (SEC-049). Servers that enforce signatures on these routes previously saw unsigned mutations from this SDK.
+
 ### Added
 - Add shared magic-link + six-digit companion-code login helpers: `verifyEmailSignInCode()` and status-only `pollEmailSignInStatus()`. `signInWithEmail()` now returns opaque polling credentials.
 - `BridgeHandoff` type and `BridgeBuildResult = AdapterUnsignedIntent | BridgeHandoff` union. `buildBridgeIntent()` now returns either an unsigned transaction intent or a non-signable external handoff (for providers like wxmr.io that require an interactive wallet and expose no safe transaction-building API). Bridge quote/session types gain optional `direction`, `executionMode`, `handoffUrl`, `feeScope`, `notices`, and `recipientSensitive` metadata. Additive and backward compatible.

--- a/packages/sdk/src/__tests__/agent-client.test.ts
+++ b/packages/sdk/src/__tests__/agent-client.test.ts
@@ -71,7 +71,7 @@ async function setup(opts?: {
   });
   const keypair = await AgentKeypair.fromPkcs8Base64(kp.pkcs8Base64);
   const client = new AgentClient({
-    baseUrl: "http://mock",
+    baseUrl: "http://localhost",
     agentId: AGENT_ID,
     keypair,
     fetchImpl: server.fetch,
@@ -114,7 +114,7 @@ describe("AgentClient — enroll (keypair-only boot)", () => {
     const wrong = await generateMockKeyPair();
     const wrongKeypair = await AgentKeypair.fromPkcs8Base64(wrong.pkcs8Base64);
     const client = new AgentClient({
-      baseUrl: "http://mock",
+      baseUrl: "http://localhost",
       agentId: AGENT_ID,
       keypair: wrongKeypair,
       fetchImpl: server.fetch,
@@ -126,7 +126,7 @@ describe("AgentClient — enroll (keypair-only boot)", () => {
     const correct = await generateMockKeyPair();
     server.activeSigner(AGENT_ID)!.publicKeyRawBase64 = correct.publicKeyRawBase64;
     const good = new AgentClient({
-      baseUrl: "http://mock",
+      baseUrl: "http://localhost",
       agentId: AGENT_ID,
       keypair: await AgentKeypair.fromPkcs8Base64(correct.pkcs8Base64),
       fetchImpl: server.fetch,
@@ -139,7 +139,7 @@ describe("AgentClient — enroll (keypair-only boot)", () => {
     const { server, kp } = await setup();
     server.revokeSigner(AGENT_ID);
     const client = new AgentClient({
-      baseUrl: "http://mock",
+      baseUrl: "http://localhost",
       agentId: AGENT_ID,
       keypair: await AgentKeypair.fromPkcs8Base64(kp.pkcs8Base64),
       fetchImpl: server.fetch,

--- a/packages/sdk/src/__tests__/base-url.test.ts
+++ b/packages/sdk/src/__tests__/base-url.test.ts
@@ -1,0 +1,73 @@
+/**
+ * SEC-048 — HTTPS enforcement on SDK baseUrl.
+ *
+ * StewardClient, StewardAuth, and AgentClient transmit platform keys, app
+ * secrets, bearer tokens, and HMAC-signed credentials. Plaintext non-loopback
+ * baseUrls must be rejected by default (the CLI has always enforced this);
+ * loopback http stays allowed for local development, and an explicit
+ * allowInsecureBaseUrl opt-out warns loudly for trusted private networks.
+ */
+
+import { describe, expect, spyOn, test } from "bun:test";
+import { AgentClient } from "../agent-client";
+import { AgentKeypair } from "../agent-keypair";
+import { StewardAuth } from "../auth";
+import { assertSecureBaseUrl } from "../base-url";
+import { StewardClient } from "../client";
+import { generateMockKeyPair } from "./agent-client-mock-server";
+
+describe("assertSecureBaseUrl", () => {
+  test("accepts HTTPS and loopback HTTP", () => {
+    expect(() => assertSecureBaseUrl("https://api.steward.example")).not.toThrow();
+    expect(() => assertSecureBaseUrl("http://localhost:3200")).not.toThrow();
+    expect(() => assertSecureBaseUrl("http://127.0.0.1:3200")).not.toThrow();
+    expect(() => assertSecureBaseUrl("http://[::1]:3200")).not.toThrow();
+  });
+
+  test("rejects plaintext non-loopback baseUrls", () => {
+    expect(() => assertSecureBaseUrl("http://api.steward.example")).toThrow(/must use HTTPS/);
+    expect(() => assertSecureBaseUrl("http://192.168.1.10:3200")).toThrow(/must use HTTPS/);
+    expect(() => assertSecureBaseUrl("ftp://api.steward.example")).toThrow(/must use HTTPS/);
+    expect(() => assertSecureBaseUrl("not-a-url")).toThrow(/valid absolute URL/);
+  });
+
+  test("allowInsecureBaseUrl opts out but warns loudly", () => {
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      expect(() => assertSecureBaseUrl("http://api.steward.example", true)).not.toThrow();
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(String(warn.mock.calls[0][0])).toContain("not HTTPS");
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});
+
+describe("SDK constructors enforce HTTPS baseUrl", () => {
+  test("StewardClient rejects plaintext non-loopback baseUrl", () => {
+    expect(() => new StewardClient({ baseUrl: "http://api.steward.example" })).toThrow(
+      /must use HTTPS/,
+    );
+    expect(() => new StewardClient({ baseUrl: "http://localhost:3200" })).not.toThrow();
+    expect(() => new StewardClient({ baseUrl: "https://api.steward.example" })).not.toThrow();
+  });
+
+  test("StewardAuth rejects plaintext non-loopback baseUrl", () => {
+    expect(() => new StewardAuth({ baseUrl: "http://api.steward.example" })).toThrow(
+      /must use HTTPS/,
+    );
+    expect(() => new StewardAuth({ baseUrl: "http://localhost:3200" })).not.toThrow();
+    expect(() => new StewardAuth({ baseUrl: "https://api.steward.example" })).not.toThrow();
+  });
+
+  test("AgentClient rejects plaintext non-loopback baseUrl", async () => {
+    const { pkcs8Base64 } = await generateMockKeyPair();
+    const keypair = await AgentKeypair.fromPkcs8Base64(pkcs8Base64);
+    const config = { baseUrl: "http://api.steward.example", agentId: "agent-1", keypair };
+    expect(() => new AgentClient(config)).toThrow(/must use HTTPS/);
+    expect(() => new AgentClient({ ...config, baseUrl: "http://localhost:3200" })).not.toThrow();
+    expect(
+      () => new AgentClient({ ...config, baseUrl: "https://api.steward.example" }),
+    ).not.toThrow();
+  });
+});

--- a/packages/sdk/src/__tests__/client.test.ts
+++ b/packages/sdk/src/__tests__/client.test.ts
@@ -1027,6 +1027,26 @@ describe("Request headers", () => {
     expect(lastCapture?.headers["x-steward-request-timestamp"]).toBeUndefined();
     expect(lastCapture?.headers["x-steward-signature"]).toBeUndefined();
   });
+
+  it("signs /accounts and /global-wallet mutations (SEC-049 cross-SDK alignment)", async () => {
+    // Wallet/account mutations are signed from Flutter but were sent unsigned
+    // from the other SDKs before the prefix lists were aligned in lockstep.
+    installMockFetch({ ok: true, data: { wallets: [] } });
+    const client = makeClient({
+      requestSigningSecret: "request-signing-secret-with-enough-entropy",
+    });
+
+    await client.accounts.create({ displayName: "ops" });
+    expect(lastCapture?.method).toBe("POST");
+    expect(new URL(lastCapture!.url).pathname).toBe("/accounts");
+    expect(lastCapture?.headers["x-steward-signature"]).toMatch(/^v1=[0-9a-f]{64}$/);
+
+    installMockFetch({ ok: true, data: {} });
+    await client.approveGlobalWalletConsent({ appId: "app-1" });
+    expect(lastCapture?.method).toBe("POST");
+    expect(new URL(lastCapture!.url).pathname).toBe("/global-wallet/consent/approve");
+    expect(lastCapture?.headers["x-steward-signature"]).toMatch(/^v1=[0-9a-f]{64}$/);
+  });
 });
 
 // ─── HTTP Request Building Tests ──────────────────────────────────────────

--- a/packages/sdk/src/agent-client.ts
+++ b/packages/sdk/src/agent-client.ts
@@ -31,6 +31,7 @@
  */
 
 import { AgentKeypair } from "./agent-keypair.ts";
+import { assertSecureBaseUrl } from "./base-url.ts";
 
 // ─── Errors ───────────────────────────────────────────────────────────────────
 
@@ -159,6 +160,12 @@ export interface AgentClientConfig {
    * modest client/server clock skew when scheduling renewal. Default 30s.
    */
   clockSkewToleranceSeconds?: number;
+  /**
+   * Permit a plaintext non-loopback baseUrl (warns at construction). HTTPS is
+   * required by default so enrollment proofs and agent tokens never travel
+   * cleartext off-loopback.
+   */
+  allowInsecureBaseUrl?: boolean;
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -208,6 +215,7 @@ export class AgentClient {
     if (!(config.keypair instanceof AgentKeypair)) {
       throw new Error("keypair must be an AgentKeypair (the private key never leaves it)");
     }
+    assertSecureBaseUrl(config.baseUrl, config.allowInsecureBaseUrl);
     this.baseUrl = config.baseUrl.replace(/\/+$/, "");
     this.agentId = config.agentId;
     this.keypair = config.keypair;

--- a/packages/sdk/src/auth-types.ts
+++ b/packages/sdk/src/auth-types.ts
@@ -333,6 +333,12 @@ export interface StewardAuthConfig {
    * When set, all sign-in methods include this tenantId in requests.
    */
   tenantId?: string;
+  /**
+   * Permit a plaintext non-loopback baseUrl (warns at construction). HTTPS is
+   * required by default so session credentials never travel cleartext
+   * off-loopback.
+   */
+  allowInsecureBaseUrl?: boolean;
 }
 
 /** Response shape from POST /auth/refresh */

--- a/packages/sdk/src/auth.ts
+++ b/packages/sdk/src/auth.ts
@@ -57,6 +57,7 @@ import type {
   StewardUser,
   StewardWhatsAppOtpResult,
 } from "./auth-types.ts";
+import { assertSecureBaseUrl } from "./base-url.ts";
 import { StewardApiError } from "./client.ts";
 
 // ─── Storage key ──────────────────────────────────────────────────────────────
@@ -309,7 +310,14 @@ export class StewardAuth {
   private readonly tenantId: string | undefined;
   private readonly listeners: Array<(session: StewardSession | null) => void> = [];
 
-  constructor({ baseUrl, storage, onSessionChange, tenantId }: StewardAuthConfig) {
+  constructor({
+    baseUrl,
+    storage,
+    onSessionChange,
+    tenantId,
+    allowInsecureBaseUrl,
+  }: StewardAuthConfig) {
+    assertSecureBaseUrl(baseUrl, allowInsecureBaseUrl);
     this.baseUrl = baseUrl.replace(/\/+$/, "");
     this.tenantId = tenantId;
 

--- a/packages/sdk/src/base-url.ts
+++ b/packages/sdk/src/base-url.ts
@@ -1,0 +1,40 @@
+/**
+ * Fail-closed baseUrl validation shared by StewardClient, StewardAuth, and
+ * AgentClient. These clients transmit platform keys, app secrets, bearer
+ * tokens, and HMAC-signed credentials; none of that may travel to a plaintext
+ * non-loopback endpoint. The CLI enforces the same rule
+ * (packages/cli/src/api.ts normalizeBaseUrl) — this keeps the control
+ * consistent across the operator and server-side surfaces (SEC-048).
+ */
+
+function isLoopbackHostname(hostname: string): boolean {
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]";
+}
+
+/**
+ * Throws unless `baseUrl` is HTTPS or targets loopback. Operators on trusted
+ * private networks may opt out explicitly with `allowInsecureBaseUrl`, which
+ * still warns loudly at construction.
+ */
+export function assertSecureBaseUrl(baseUrl: string, allowInsecureBaseUrl?: boolean): void {
+  let url: URL;
+  try {
+    url = new URL(baseUrl);
+  } catch {
+    throw new Error("baseUrl must be a valid absolute URL");
+  }
+  if (url.protocol === "https:" || (url.protocol === "http:" && isLoopbackHostname(url.hostname))) {
+    return;
+  }
+  if (allowInsecureBaseUrl) {
+    console.warn(
+      `[steward-sdk] WARNING: baseUrl '${url.origin}' is not HTTPS; credentials travel in ` +
+        "cleartext. Use allowInsecureBaseUrl only on trusted private networks.",
+    );
+    return;
+  }
+  throw new Error(
+    "baseUrl must use HTTPS unless it targets loopback (http://localhost, http://127.0.0.1, " +
+      "http://[::1]). Set allowInsecureBaseUrl: true to override on trusted private networks.",
+  );
+}

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1,3 +1,4 @@
+import { assertSecureBaseUrl } from "./base-url.ts";
 import type {
   AgentAccountSummary,
   AgentBalance,
@@ -194,6 +195,11 @@ export interface StewardClientConfig {
    * injected scripts can read request headers. Prefer bearerToken in browsers.
    */
   allowUnsafeBrowserSecrets?: boolean;
+  /**
+   * Permit a plaintext non-loopback baseUrl (warns at construction). HTTPS is
+   * required by default so credentials never travel cleartext off-loopback.
+   */
+  allowInsecureBaseUrl?: boolean;
 }
 
 export interface QuorumSignerCredential {
@@ -1374,6 +1380,7 @@ export class StewardClient {
     requestSigningSecret,
     requestSigningKeyId,
     allowUnsafeBrowserSecrets,
+    allowInsecureBaseUrl,
   }: StewardClientConfig) {
     if (
       isBrowserRuntime() &&
@@ -1385,6 +1392,7 @@ export class StewardClient {
         0,
       );
     }
+    assertSecureBaseUrl(baseUrl, allowInsecureBaseUrl);
     this.baseUrl = baseUrl.replace(/\/+$/, "");
     this.apiKey = apiKey;
     this.appId = appId;

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -471,6 +471,9 @@ export interface TradeSessionState {
   revokedBy?: string | null;
 }
 
+// Keep in lockstep with the equivalent list in EVERY other SDK (go, java,
+// python, ruby, rust, swift, csharp, flutter): mutations under these prefixes
+// are HMAC-signed, and divergence silently downgrades integrity (SEC-049).
 const SENSITIVE_SIGNED_PATHS = [
   "/vault",
   "/agents",
@@ -487,6 +490,8 @@ const SENSITIVE_SIGNED_PATHS = [
   "/condition-sets",
   "/condition_sets",
   "/v1/condition_sets",
+  "/global-wallet",
+  "/accounts",
 ];
 const MUTATING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 

--- a/packages/swift/Sources/Steward/StewardClient.swift
+++ b/packages/swift/Sources/Steward/StewardClient.swift
@@ -60,6 +60,9 @@ public final class StewardClient {
     private let config: StewardConfig
     public let baseURL: String
 
+    // Keep in lockstep with the equivalent list in EVERY other SDK (sdk, go,
+    // java, python, ruby, rust, csharp, flutter): mutations under these
+    // prefixes are HMAC-signed; divergence silently downgrades integrity (SEC-049).
     private static let sensitivePrefixes = [
         "/vault",
         "/agents",
@@ -76,6 +79,8 @@ public final class StewardClient {
         "/condition-sets",
         "/condition_sets",
         "/v1/condition_sets",
+        "/global-wallet",
+        "/accounts",
     ]
 
     public init(config: StewardConfig) throws {


### PR DESCRIPTION
## Security wave 2 — Batch 7: SDKs & CLI

Fixes for the SDK/CLI batch of the consolidated security audit (SEC-046–049, SEC-119–127, SEC-195–200), verified against current `develop` (0027e106).

### Status by finding

| SEC ID | Severity | Status | Change |
|---|---|---|---|
| SEC-046 | MEDIUM | **FIXED** | `audit bundle --verify` / `provider-action evidence --verify` resolved `scripts/verify-evidence-bundle.mjs` relative to the operator's CWD (code-exec via decoy script with full credential env). Now resolved against the CLI install tree (`import.meta.dir`) and run via `process.execPath`, matching the audit-export path. |
| SEC-047 | MEDIUM | **FIXED** | `steward init --migrate` ran CWD-relative `packages/db/src/migrate.ts` with freshly generated secrets in env. Migrator now resolves against the CLI's install tree and runs under `process.execPath`. |
| SEC-048 | MEDIUM | **FIXED** | `StewardClient`/`StewardAuth`/`AgentClient` accepted plaintext non-loopback `baseUrl`. New shared `assertSecureBaseUrl` enforces HTTPS-unless-loopback (same rule the CLI always had); `allowInsecureBaseUrl: true` opt-out warns loudly. |
| SEC-049 | MEDIUM | **FIXED** | Request-signing prefix lists diverged: Flutter signed `/global-wallet` + `/accounts` mutations, the other 9 lists didn't. All lists aligned to the Flutter superset with a lockstep comment in each. (A shared versioned route spec is the right long-term fix — follow-up.) |
| SEC-119 | LOW | **FIXED** | Migrate child no longer defaults `STEWARD_ALLOW_INSECURE_DB=true`; only an explicit operator value passes through. |
| SEC-120 | LOW | **FIXED** | Generated env ships `STEWARD_ACK_LOCAL_CUSTODY=true` **commented out** with the docs pointer instead of pre-acking local plaintext custody. |
| SEC-121 | LOW | **FIXED** | Adapter docstring + README now warn AsyncStorage is plaintext and ship an `expo-secure-store` (Keychain/Keystore) example. |
| SEC-122 | LOW | **FIXED** | `audit bundle --out` / `provider-action evidence --out` write with `mode: 0o600` (was umask-default, often 0644). |
| SEC-123 | LOW | **FIXED** | `tenant create` accepts the API key via `--api-key-file`, `--api-key-env`, or stdin; `--api-key` retained with a loud shell-history warning (mirrors `readSecretValue`). |
| SEC-124 | LOW | **FIXED** | `createStewardNativeClient` maps static `token` → `bearerToken`; function providers now throw at construction instead of being silently dropped (requests went out unauthenticated). |
| SEC-125 | LOW | **FIXED** | Python SDK's default transport installs a redirect handler that strips credential/signature headers on cross-host redirects. |
| SEC-126 | LOW | **FIXED** | Go default client strips `X-Steward-*`/Authorization headers via `CheckRedirect` on cross-host redirects; C# and Dart default transports no longer follow redirects at all (fail closed, same posture as the Java SDK's never-follow default). |
| SEC-127 | LOW | **FIXED** | Python SDK `get_user` / `revoke_user_push_subscription` now `quote(..., safe="")` path parameters. |
| SEC-195 | INFO | **DEFERRED** | React hooks (`useApprovals`/`useSpend`/`useTransactions`) call agent endpoints credential-free. Routing them through `StewardClient` changes hook APIs/credential plumbing (or the dead hooks get deleted) — product decision; parked for wave 2b. |
| SEC-196 | INFO | **FIXED** | Go `randomID()` no longer falls back to `time.Now().UnixNano()` on `crypto/rand` failure; returns an error propagated through the request path. Public `Config.NewID` signature unchanged. |
| SEC-197 | INFO | **DEFERRED** | Java hand-rolled JSON parser `\u` escape bounds check — one-line fix, but unfixed in this wave to land the MEDIUM/LOW batch; parked for wave 2b. |
| SEC-198 | INFO | **DEFERRED** | Java/Android ship no build files — packaging/publishing decision (coordinates, pom vs gradle), not a behavioral security fix. |
| SEC-199 | INFO | **DEFERRED** | Flutter secure-storage-backed `StewardSessionStorage` implementation + JWT-decode docs; needs a `flutter_secure_storage` example and no Dart toolchain is available here to verify. |
| SEC-200 | INFO | **DEFERRED** | HTTPS enforcement across the 9 non-JS SDKs — the TS SDK model landed here (SEC-048); lockstep application to go/java/python/ruby/rust/swift/csharp/flutter/android parked for wave 2b. |

### Trade-offs / breaking notes

- **SEC-120:** a `steward init`-generated env no longer boots the API as-is under `NODE_ENV=production` — the operator must deliberately uncomment `STEWARD_ACK_LOCAL_CUSTODY=true` or configure `STEWARD_KMS_PROVIDER`. Intended by the finding; the compose templates already fail closed the same way.
- **SEC-119:** `steward init --migrate` against a non-TLS `DATABASE_URL` in production now hits the DB-TLS gate unless the operator explicitly exports `STEWARD_ALLOW_INSECURE_DB=true`.
- **SEC-048:** SDK constructors now throw on plaintext non-loopback `baseUrl` (opt-out: `allowInsecureBaseUrl: true`, warns). Two test call sites using placeholder URLs (`http://mock`, `http://a3-api`) moved to `http://localhost`.
- **SEC-126:** C#/Dart default transports surface 3xx responses instead of following them.
- **SEC-124:** function `token` providers throw at construction (previously silently ignored).

### Testing

- `packages/cli`: `bun test` — 55 pass (new: decoy-verifier/decoy-migrator never execute, bundles 0600, no insecure-DB default, custody ack commented, tenant-key sources)
- `packages/sdk`: `bun test` — 257 pass (new: HTTPS enforcement ×3 constructors, `/accounts` + `/global-wallet` signing)
- `packages/react-native`: `bun test` — 20 pass (new: token mapping / function-token throw)
- `packages/python`: `python3 -m unittest` — 7 pass (new: redirect strips credentials cross-host, path encoding, prefix alignment)
- `packages/go`: `go test` — pass (new: live httptest cross-host redirect strip, prefix alignment, randomID shape); `gofmt`/`go vet` clean
- `packages/rust`: `cargo test` — 6 pass (new: prefix alignment)
- `packages/csharp`: `dotnet build` + test runner pass; `packages/swift`: `swift build` OK; `packages/java`: `javac` compile OK; `packages/ruby`: `ruby -c` OK
- `packages/api` e2e (`agent-client-e2e`): pass (URL updated for SEC-048)
- `bunx biome check` clean on all changed TS files
- Flutter: no Dart toolchain in this environment; its two changes are a lockstep comment and `followRedirects = false` (not executed)
- Pre-existing: `bun install` requires `--ignore-scripts` on this machine (pkcs11js native build failure — unrelated HSM dependency); incidental `bun.lock` drift was reverted.
