### PR TITLE
fix(security): wave-2b plugins batch — deferred LOW/INFO findings (SEC-095/096/109/112/170/171/172/173)

### DIFF
--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -68,6 +68,8 @@ mount hono routes/middleware onto the core app. `ctx` is injected: it carries th
 
 ```ts
 register(app, ctx) {
+  // NOTE: /example/ping is deliberately unauthenticated (constant payload,
+  // hello-world only). Any route touching real state MUST be gated:
   app.get("/example/ping", (c) => c.json({ ok: true }));
   // gate a route: app.post("/example/do", ctx.requireAgentJwt, handler);
 }

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -41,6 +41,12 @@ migrations run at boot before the server accepts traffic. that's it - the core i
 
 ## door 2 - write a plugin (author)
 
+> **Security boundary:** plugins execute in-process with full host trust. The
+> injected context includes the raw database and vault, so a plugin can read or
+> rewrite tenant state and sign outside the policy engine. There is no sandbox.
+> Register only code you would trust with root access and master signing keys;
+> pin and audit its dependency tree, and never load an untrusted runtime plugin.
+
 a plugin is one object. you import everything from a single package:
 
 ```ts

--- a/packages/api/src/__tests__/auth-client-ip.test.ts
+++ b/packages/api/src/__tests__/auth-client-ip.test.ts
@@ -263,10 +263,16 @@ describe("trustedClientIp", () => {
     expect(
       await probeIp({ "cf-connecting-ip": "9.9.9.9", "x-forwarded-for": "198.51.100.7" }),
     ).toBe("9.9.9.9");
-    // Flag on + invalid CF value falls through to the XFF path.
-    expect(await probeIp({ "cf-connecting-ip": "junk", "x-forwarded-for": "198.51.100.7" })).toBe(
-      "198.51.100.7",
-    );
+    // Flag on makes CF authoritative. Missing/invalid values fail closed and
+    // cannot fall through to client-controlled proxy headers.
+    expect(
+      await probeIp({
+        "cf-connecting-ip": "junk",
+        "x-forwarded-for": "198.51.100.7",
+        "x-envoy-external-address": "203.0.113.9",
+      }),
+    ).toBeNull();
+    expect(await probeIp({ "x-envoy-external-address": "203.0.113.9" })).toBeNull();
   });
 });
 

--- a/packages/api/src/__tests__/auth-client-ip.test.ts
+++ b/packages/api/src/__tests__/auth-client-ip.test.ts
@@ -225,13 +225,14 @@ describe("trustedClientIp", () => {
         "x-forwarded-for": "203.0.113.5, 198.51.100.7, 10.0.0.9",
       }),
     ).toBe("198.51.100.7");
-    // ...but Envoy still rescues when the positional read cannot parse.
+    // A missing positional entry is a topology failure. Envoy names the
+    // adjacent proxy here and must not be accepted as the external client.
     expect(
       await probeIp({
         "x-envoy-external-address": "10.0.0.9",
         "x-forwarded-for": "203.0.113.5",
       }),
-    ).toBe("10.0.0.9");
+    ).toBeNull();
   });
 
   it("parses ip:port and [ipv6]:port in the trusted XFF position; bare IPv6 is never mangled", async () => {

--- a/packages/api/src/plugin.ts
+++ b/packages/api/src/plugin.ts
@@ -43,6 +43,23 @@
  *
  * that way `@stwd/api` itself stays trading-free for anyone importing it, while a
  * deploy that wants trading opts in by registering the plugin.
+ *
+ * PLUGIN TRUST MODEL (SEC-170)
+ * ----------------------------
+ * plugins run IN-PROCESS with FULL trust — there is no sandbox. the injected
+ * ctx hands a plugin the live `vault` (it can sign arbitrary transactions for
+ * any agent/tenant, bypassing the policy engine) and the raw drizzle `db`
+ * handle (it can rewrite `agent_policies`, insert `secret_routes`, read
+ * ciphertext). the host's fail-closed guarantees cover CONTRIBUTION COLLISIONS
+ * (duplicate plugin names, missing deps, cycles, migration conflicts), NOT
+ * privilege: a malicious or compromised plugin package is full RCE with
+ * signing authority. therefore:
+ *   - only register first-party plugins or third-party plugins you would
+ *     trust with root on the host AND the master signing keys;
+ *   - pin + audit plugin dependencies exactly as you would the core itself;
+ *   - never register a plugin supplied at runtime by an untrusted party.
+ * a policy-gated signing facade in place of the raw vault handle is a
+ * considered future hardening, not currently implemented (SEC-170).
  */
 
 import { type AdapterCategory, AdapterRegistry, adapterRegistry } from "@stwd/adapters";

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -241,9 +241,8 @@ let clientIpDiagLoggedAt = 0;
 /**
  * TEMPORARY diagnostics — remove once Railway's forwarded-header shape is
  * confirmed in production logs. Fires (throttled) only when trust IS
- * configured yet no candidate validated, dumping the raw header values so a
- * still-failing parse can be fixed precisely instead of guessed at.
- * JSON.stringify keeps attacker-controlled header bytes on one escaped line.
+ * configured yet no candidate validated. Never log raw forwarded headers:
+ * they are attacker-controlled and may contain credential-shaped content.
  */
 function logNoTrustedClientIpDiag(c: Context, hops: number): void {
   const now = Date.now();
@@ -253,10 +252,9 @@ function logNoTrustedClientIpDiag(c: Context, hops: number): void {
     "[AuthRateLimit][diag] trust configured but no client IP derived; falling back to coarse subject",
     JSON.stringify({
       hops,
-      "x-forwarded-for": c.req.header("x-forwarded-for") ?? null,
-      "x-real-ip": c.req.header("x-real-ip") ?? null,
-      "x-envoy-external-address": c.req.header("x-envoy-external-address") ?? null,
-      "cf-connecting-ip": c.req.header("cf-connecting-ip") ?? null,
+      forwardedForPresent: Boolean(c.req.header("x-forwarded-for")),
+      envoyAddressPresent: Boolean(c.req.header("x-envoy-external-address")),
+      cloudflareAddressPresent: Boolean(c.req.header("cf-connecting-ip")),
     }),
   );
 }
@@ -270,8 +268,8 @@ function logNoTrustedClientIpDiag(c: Context, hops: number): void {
  *   ignored as client-forgeable.
  * - x-envoy-external-address: Railway's Envoy edge sets this to the single
  *   external client address it observed (possibly with a :port). It is only
- *   consulted once the operator has opted into a trusted edge (hops > 0 or
- *   Cloudflare trust) — on a bare deployment a client could set it — and it
+ *   consulted once the operator has configured trusted proxy hops — on a bare
+ *   deployment a client could set it — and it
  *   identifies the CLIENT only when that edge is the outermost trusted hop,
  *   so with hops >= 2 the positional x-forwarded-for read stays authoritative
  *   and Envoy's value is only a rescue when that read fails.
@@ -291,9 +289,15 @@ export function trustedClientIp(c: Context): string | undefined {
   if (trustCloudflare) {
     const cf = c.req.header("cf-connecting-ip")?.trim();
     if (cf && isIP(cf)) return cf;
+    // Cloudflare mode is an exclusive trust contract. If the authoritative
+    // header is absent or malformed, do not fall through to other forwarded
+    // headers: those may be supplied by the client when the request bypasses
+    // the configured edge.
+    logNoTrustedClientIpDiag(c, 0);
+    return undefined;
   }
   const hops = trustedProxyHops();
-  if (hops === 0 && !trustCloudflare) return undefined;
+  if (hops === 0) return undefined;
 
   const fromEnvoy = () => normalizeIpCandidate(c.req.header("x-envoy-external-address"));
   const fromForwardedFor = () => {

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -272,7 +272,7 @@ function logNoTrustedClientIpDiag(c: Context, hops: number): void {
  *   deployment a client could set it — and it
  *   identifies the CLIENT only when that edge is the outermost trusted hop,
  *   so with hops >= 2 the positional x-forwarded-for read stays authoritative
- *   and Envoy's value is only a rescue when that read fails.
+ *   and Envoy's value is never used as a fallback.
  * - x-forwarded-for: each trusted proxy APPENDS the peer it observed, so with
  *   N trusted hops the trustworthy entry is the N-th from the RIGHT. The
  *   left-most entry is client-supplied and is never read.
@@ -309,7 +309,10 @@ export function trustedClientIp(c: Context): string | undefined {
     return normalizeIpCandidate(entries[entries.length - hops]);
   };
 
-  const ip = hops >= 2 ? (fromForwardedFor() ?? fromEnvoy()) : (fromEnvoy() ?? fromForwardedFor());
+  // In a multi-hop topology Envoy observes the adjacent proxy, not the
+  // external client. Falling back to that header when XFF is missing or too
+  // short would turn a topology/configuration failure into false attribution.
+  const ip = hops >= 2 ? fromForwardedFor() : (fromEnvoy() ?? fromForwardedFor());
   if (ip) return ip;
   logNoTrustedClientIpDiag(c, hops);
   return undefined;

--- a/packages/eliza-plugin/CHANGELOG.md
+++ b/packages/eliza-plugin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Security
+- submit-trade now applies the shared `assertSecureApiUrl` guard to `STEWARD_API_URL`, so a non-localhost plaintext `http://` URL can no longer send the agent JWT in cleartext (SEC-095). Loopback http stays allowed for local dev.
+- Proxy request HMAC signing is now mandatory whenever a signing secret is configured, regardless of `NODE_ENV` or the enforcement flag — a provisioned secret can never silently downgrade to unsigned proxy calls (SEC-171).
+
 ### Changed
 - Fail closed on non-JSON provider-action arguments, sanitize lifecycle failures, and keep concurrent polling results bound to their original action IDs.
 - Reject nested password, passphrase, auth, client-secret-value, and cookie-header fields through the shared credential-key classifier before provider submission.

--- a/packages/eliza-plugin/src/__tests__/proxy-signing.test.ts
+++ b/packages/eliza-plugin/src/__tests__/proxy-signing.test.ts
@@ -122,6 +122,24 @@ describe("Eliza plugin proxy request signing", () => {
     expect(lastProxyRequest).toBeNull();
   });
 
+  it("signs whenever a secret is configured, even with enforcement disabled", async () => {
+    delete process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE;
+    try {
+      lastProxyRequest = null;
+      // configuredService() includes proxyRequestSigningSecret — dev-mode must
+      // not downgrade this deployment to unsigned proxy calls (SEC-171).
+      const result = await configuredService().callGovernedApi({
+        url: "https://api.example.com/v1/items",
+      });
+
+      expect(result.status).toBe(200);
+      expect(lastProxyRequest?.headers.get("x-steward-signature")).toMatch(/^v1=[0-9a-f]{64}$/);
+      expect(lastProxyRequest?.headers.get("x-steward-request-timestamp")).toMatch(/^\d+$/);
+    } finally {
+      process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE = "true";
+    }
+  });
+
   it("keeps unsigned local/dev proxy operation available when enforcement is disabled", async () => {
     delete process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE;
     try {

--- a/packages/eliza-plugin/src/__tests__/submit-trade.test.ts
+++ b/packages/eliza-plugin/src/__tests__/submit-trade.test.ts
@@ -142,4 +142,34 @@ describe("SUBMIT_TRADE action", () => {
     expect(result?.success).toBe(false);
     expect(result?.text).toBe("venue error, will retry later");
   });
+
+  it("rejects a non-localhost plaintext STEWARD_API_URL before any request", async () => {
+    process.env.STEWARD_API_URL = "http://steward.example";
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      submitTradeAction.validate({} as any, mockMemory("buy 0.01 BTC") as any),
+    ).resolves.toBe(false);
+
+    const result = await submitTradeAction.handler({} as any, mockMemory("buy 0.01 BTC") as any);
+    expect(result?.success).toBe(false);
+    expect(result?.text).toBe(
+      "Trading is unavailable because Steward JWT/API env is not configured.",
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("still allows loopback http STEWARD_API_URL for local dev", async () => {
+    process.env.STEWARD_API_URL = "http://127.0.0.1:7860";
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ ok: true, data: { status: "active" } }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      submitTradeAction.validate({} as any, mockMemory("buy 0.01 BTC") as any),
+    ).resolves.toBe(true);
+  });
 });

--- a/packages/eliza-plugin/src/actions/submit-trade.ts
+++ b/packages/eliza-plugin/src/actions/submit-trade.ts
@@ -9,6 +9,7 @@ import type {
   Memory,
   State,
 } from "@elizaos/core";
+import { assertSecureApiUrl } from "../services/StewardService.js";
 
 const ACTION_NAME = "SUBMIT_TRADE";
 const DEFAULT_LEVERAGE = 1;
@@ -75,7 +76,11 @@ function stewardJwt(runtime: IAgentRuntime): string | undefined {
 }
 
 function stewardApiUrl(runtime: IAgentRuntime): string | undefined {
-  return envValue(runtime, "STEWARD_API_URL")?.replace(/\/+$/, "");
+  const apiUrl = envValue(runtime, "STEWARD_API_URL")?.replace(/\/+$/, "");
+  // Reject plaintext non-localhost URLs here too: this action reads the env URL
+  // directly and would otherwise send the agent JWT in cleartext.
+  if (apiUrl) assertSecureApiUrl(apiUrl);
+  return apiUrl;
 }
 
 function configuredSessionId(runtime: IAgentRuntime): string | undefined {
@@ -244,7 +249,12 @@ async function postOrder(
 }
 
 async function hasActiveSession(runtime: IAgentRuntime): Promise<boolean> {
-  const apiUrl = stewardApiUrl(runtime);
+  let apiUrl: string | undefined;
+  try {
+    apiUrl = stewardApiUrl(runtime);
+  } catch {
+    return false;
+  }
   const jwt = stewardJwt(runtime);
   const sessionId = configuredSessionId(runtime);
   if (!apiUrl || !jwt || !sessionId) return false;
@@ -398,7 +408,7 @@ export const submitTradeAction: Action = {
       data = result.data;
     } catch (err) {
       const text =
-        err instanceof Error && /STEWARD_API_URL|STEWARD_JWT/.test(err.message)
+        err instanceof Error && /STEWARD_API_URL|STEWARD_JWT|apiUrl/.test(err.message)
           ? "Trading is unavailable because Steward JWT/API env is not configured."
           : "venue error, will retry later";
       await callback?.({ text, action: ACTION_NAME }, ACTION_NAME);

--- a/packages/eliza-plugin/src/services/StewardService.ts
+++ b/packages/eliza-plugin/src/services/StewardService.ts
@@ -386,9 +386,15 @@ export class StewardService extends Service {
     }
     assertSecureApiUrl(config.proxyUrl);
 
+    // Signing is mandatory in production, when the operator opted in via env,
+    // or whenever a signing secret is configured at all: a provisioned secret
+    // means this deployment intends signed proxy requests, so never fall back
+    // to unsigned calls regardless of NODE_ENV. Unsigned operation is reserved
+    // for local dev where NO secret exists and enforcement is off.
     const signingRequired =
       process.env.NODE_ENV === "production" ||
-      process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE === "true";
+      process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE === "true" ||
+      Boolean(config.proxyRequestSigningSecret);
     if (signingRequired && !config.proxyRequestSigningSecret) {
       throw new Error(
         "STEWARD_PROXY_REQUEST_SIGNING_SECRET is required when proxy request signing is enforced",

--- a/packages/eliza-plugin/src/services/StewardService.ts
+++ b/packages/eliza-plugin/src/services/StewardService.ts
@@ -386,15 +386,14 @@ export class StewardService extends Service {
     }
     assertSecureApiUrl(config.proxyUrl);
 
-    // Signing is mandatory in production, when the operator opted in via env,
-    // or whenever a signing secret is configured at all: a provisioned secret
-    // means this deployment intends signed proxy requests, so never fall back
-    // to unsigned calls regardless of NODE_ENV. Unsigned operation is reserved
-    // for local dev where NO secret exists and enforcement is off.
+    // StewardProxyClient signs whenever a signing secret is supplied; the
+    // regression suite pins that invariant even when explicit enforcement is
+    // off. This flag controls the separate fail-closed rule for deployments
+    // where a secret is mandatory but absent. Unsigned operation is reserved
+    // for local dev where no secret exists and enforcement is off.
     const signingRequired =
       process.env.NODE_ENV === "production" ||
-      process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE === "true" ||
-      Boolean(config.proxyRequestSigningSecret);
+      process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE === "true";
     if (signingRequired && !config.proxyRequestSigningSecret) {
       throw new Error(
         "STEWARD_PROXY_REQUEST_SIGNING_SECRET is required when proxy request signing is enforced",

--- a/packages/erc8004/src/chains.ts
+++ b/packages/erc8004/src/chains.ts
@@ -45,6 +45,15 @@ function registryConfig(
 }
 
 export const REGISTRY_CONFIGS: Record<number, RegistryConfig> = {
+  // SECURITY (SEC-112): the baked-in rpcUrl values are single, public,
+  // third-party endpoints. getRegistration/getReputation flag results
+  // `verified: true` based solely on whatever that ONE endpoint returns — a
+  // compromised or MitM'd public RPC can forge "verified" registration and
+  // reputation data. These defaults exist so dev/testnet integrations work
+  // out of the box. Production deployments MUST pass their own RegistryConfig
+  // with an operator-controlled rpcUrl (or an injected `publicClient`),
+  // ideally backed by redundant providers; there is no quorum or
+  // second-source comparison in this client.
   8453: registryConfig({
     chainId: 8453,
     name: "Base",

--- a/packages/erc8004/src/types.ts
+++ b/packages/erc8004/src/types.ts
@@ -48,8 +48,9 @@ export interface RegistrationResult {
   payload: AgentRegistrationPayload;
   /**
    * True only when the registration was confirmed against a real, configured
-   * on-chain registry. Callers MUST NOT treat the result as authoritative when
-   * this is false.
+   * on-chain registry — via the single configured `rpcUrl`, whose operator is
+   * trusted absolutely (see SEC-112 note on RegistryConfig.rpcUrl). Callers
+   * MUST NOT treat the result as authoritative when this is false.
    */
   verified: boolean;
 }
@@ -58,7 +59,9 @@ export interface RegistrationResult {
  * Aggregated reputation for a registered agent.
  *
  * `verified` is true only when the score was read from a real, configured
- * on-chain reputation registry. When false, the numeric `score*` fields are
+ * on-chain reputation registry — via the single configured `rpcUrl`, whose
+ * operator is trusted absolutely (see SEC-112 note on RegistryConfig.rpcUrl).
+ * When false, the numeric `score*` fields are
  * absent (undefined) — they must never be presented as authoritative on-chain
  * data and must not be displayed as a real "score of 0".
  */
@@ -87,6 +90,13 @@ export interface FeedbackSignal {
 export interface RegistryConfig {
   chainId: number;
   name: string;
+  /**
+   * Single RPC endpoint ALL "verified" chain reads trust. Whatever this one
+   * endpoint returns is what `verified: true` attests to — there is no quorum
+   * or second-source check. Point it at operator-controlled (ideally
+   * redundant) infrastructure in production; the public defaults in
+   * REGISTRY_CONFIGS are dev/testnet conveniences only.
+   */
   rpcUrl: string;
   /** Backward-compatible alias for identityRegistry. */
   registryAddress: Address;

--- a/packages/erc8183/src/__tests__/client.test.ts
+++ b/packages/erc8183/src/__tests__/client.test.ts
@@ -128,6 +128,45 @@ describe("ERC8183Client", () => {
       });
     }).toThrow("missing evaluatorRouter, optimisticPolicy, paymentToken");
   });
+
+  test("createJob ignores lookalike JobCreated logs from other emitters", async () => {
+    const lookalike = "0x0000000000000000000000000000000000000bad" as Address;
+    const client = makeClient({
+      publicClient: {
+        async waitForTransactionReceipt() {
+          // the forged log comes FIRST: without an emitter check it wins.
+          return { logs: [jobCreatedLog(999n, lookalike), jobCreatedLog(42n)] };
+        },
+      },
+    });
+
+    const result = await client.createJob({
+      provider: PROVIDER,
+      expiredAt: 1_800_000_000n,
+      description: "agent delivery",
+    });
+
+    expect(result.jobId).toBe(42n);
+  });
+
+  test("createJob throws when only foreign-emitter JobCreated logs are present", async () => {
+    const lookalike = "0x0000000000000000000000000000000000000bad" as Address;
+    const client = makeClient({
+      publicClient: {
+        async waitForTransactionReceipt() {
+          return { logs: [jobCreatedLog(999n, lookalike)] };
+        },
+      },
+    });
+
+    await expect(
+      client.createJob({
+        provider: PROVIDER,
+        expiredAt: 1_800_000_000n,
+        description: "agent delivery",
+      }),
+    ).rejects.toThrow("JobCreated event not found in createJob receipt");
+  });
 });
 
 function makeClient(overrides: {
@@ -158,7 +197,10 @@ function mockSigner(): SignerAdapter {
   };
 }
 
-function jobCreatedLog(jobId: bigint): { data: Hex; topics: Hex[] } {
+function jobCreatedLog(
+  jobId: bigint,
+  emitter: Address = AGENTIC_COMMERCE,
+): { address: Address; data: Hex; topics: Hex[] } {
   const topics = encodeEventTopics({
     abi: AGENTIC_COMMERCE_ABI,
     eventName: "JobCreated",
@@ -172,5 +214,9 @@ function jobCreatedLog(jobId: bigint): { data: Hex; topics: Hex[] } {
     ],
     [EVALUATOR_ROUTER, 1_800_000_000n, "agent delivery"],
   );
-  return { data, topics: topics.filter((topic): topic is Hex => typeof topic === "string") };
+  return {
+    address: emitter,
+    data,
+    topics: topics.filter((topic): topic is Hex => typeof topic === "string"),
+  };
 }

--- a/packages/erc8183/src/client.ts
+++ b/packages/erc8183/src/client.ts
@@ -288,7 +288,7 @@ function decodeJobCreatedId(
     // Only the commerce contract's JobCreated is authoritative: a lookalike
     // event from another contract the tx touched would yield a wrong jobId
     // that later setBudget/fund calls would then fund.
-    if (log.address.toLowerCase() !== expectedEmitter) continue;
+    if (typeof log.address !== "string" || log.address.toLowerCase() !== expectedEmitter) continue;
     try {
       const decoded = decodeEventLog({
         abi: AGENTIC_COMMERCE_ABI,

--- a/packages/erc8183/src/client.ts
+++ b/packages/erc8183/src/client.ts
@@ -183,7 +183,7 @@ export class ERC8183Client {
     });
     const txHash = await this.signer.sendTransaction({ to: this.addresses.agenticCommerce, data });
     const receipt = await this.publicClient.waitForTransactionReceipt({ hash: txHash });
-    return { jobId: decodeJobCreatedId(receipt.logs), txHash };
+    return { jobId: decodeJobCreatedId(receipt.logs, this.addresses.agenticCommerce), txHash };
   }
 
   registerJob(jobId: bigint, policy = this.addresses.optimisticPolicy): Promise<Hex> {
@@ -279,8 +279,16 @@ function validateAddresses(addresses: Partial<RequiredERC8183Addresses>): Requir
   return addresses as RequiredERC8183Addresses;
 }
 
-function decodeJobCreatedId(logs: readonly { data: Hex; topics: readonly Hex[] }[]): bigint {
+function decodeJobCreatedId(
+  logs: readonly { address: Address; data: Hex; topics: readonly Hex[] }[],
+  commerceAddress: Address,
+): bigint {
+  const expectedEmitter = commerceAddress.toLowerCase();
   for (const log of logs) {
+    // Only the commerce contract's JobCreated is authoritative: a lookalike
+    // event from another contract the tx touched would yield a wrong jobId
+    // that later setBudget/fund calls would then fund.
+    if (log.address.toLowerCase() !== expectedEmitter) continue;
     try {
       const decoded = decodeEventLog({
         abi: AGENTIC_COMMERCE_ABI,

--- a/packages/erc8183/src/types.ts
+++ b/packages/erc8183/src/types.ts
@@ -19,6 +19,11 @@ export interface ERC8183Addresses {
 export interface ERC8183ChainConfig {
   chainId: number;
   name: string;
+  /**
+   * Single RPC endpoint all chain reads for this deployment trust (same
+   * single-source caveat as ERC-8004's RegistryConfig.rpcUrl, SEC-112): use
+   * operator-controlled, ideally redundant infrastructure for production.
+   */
   rpcUrl: string;
   addresses: ERC8183Addresses;
 }

--- a/packages/mcp/src/__tests__/provider-tools.test.ts
+++ b/packages/mcp/src/__tests__/provider-tools.test.ts
@@ -244,7 +244,7 @@ describe("credential redaction", () => {
     expect(clean).toContain("[redacted]");
   });
 
-  test("redacts password/private-key/jwt/signature keyed fields", () => {
+  test("redacts password/private-key/jwt/request-signature keyed fields", () => {
     const canary = "keyed-canary-b51f0";
     const clean = JSON.stringify(
       sanitizeProviderPayload({
@@ -255,7 +255,7 @@ describe("credential redaction", () => {
         clientSecretValue: canary,
         cookieHeader: canary,
         accessKeyId: canary,
-        signature: canary,
+        requestSignature: canary,
         nested: { sessionPassword: canary },
       }),
     );
@@ -271,7 +271,7 @@ describe("credential redaction", () => {
     const opaqueJwt = "opaque-jwt-canary";
     const signature = "signature-canary";
     const clean = sanitizeProviderPayload(
-      `upstream 500: jwt=${jwt} opaque jwt=${opaqueJwt} key=${apiKey} gh=${ghToken} slack=${slackToken} password: ${password} signature=${signature}`,
+      `upstream 500: jwt=${jwt} opaque jwt=${opaqueJwt} key=${apiKey} gh=${ghToken} slack=${slackToken} password: ${password} request_signature=${signature}`,
     ) as string;
     for (const canary of [jwt, opaqueJwt, apiKey, ghToken, slackToken, password, signature]) {
       expect(clean).not.toContain(canary);
@@ -313,7 +313,12 @@ describe("credential redaction", () => {
   });
 
   test("leaves non-secret free text and identifiers intact", () => {
-    const text = "order oid_123 failed: insufficient balance for 0.01 BTC; tx 0x" + "a".repeat(64);
+    const text =
+      "order oid_123 failed: insufficient balance for 0.01 BTC; transaction signature=5publicTxSignature; tx 0x" +
+      "a".repeat(64);
     expect(sanitizeProviderPayload(text)).toBe(text);
+    expect(sanitizeProviderPayload({ signature: "5publicTxSignature" })).toEqual({
+      signature: "5publicTxSignature",
+    });
   });
 });

--- a/packages/mcp/src/__tests__/provider-tools.test.ts
+++ b/packages/mcp/src/__tests__/provider-tools.test.ts
@@ -279,6 +279,19 @@ describe("credential redaction", () => {
     expect(clean).toContain("[redacted]");
   });
 
+  test("redacts current credential formats and armored private keys in free text", () => {
+    const openAiKey = "sk-proj-example_canary_1234567890";
+    const awsAccessKey = "AKIAIOSFODNN7EXAMPLE";
+    const privateKey = "-----BEGIN PRIVATE KEY-----\nprivate-key-canary\n-----END PRIVATE KEY-----";
+    const clean = sanitizeProviderPayload(
+      `provider failed: ${openAiKey} ${awsAccessKey}\n${privateKey}`,
+    ) as string;
+
+    for (const canary of [openAiKey, awsAccessKey, "private-key-canary"]) {
+      expect(clean).not.toContain(canary);
+    }
+  });
+
   test("fails closed on accessors and cycles without invoking provider code", () => {
     let invoked = false;
     const payload: Record<string, unknown> = { public: "safe" };

--- a/packages/mcp/src/__tests__/provider-tools.test.ts
+++ b/packages/mcp/src/__tests__/provider-tools.test.ts
@@ -243,4 +243,40 @@ describe("credential redaction", () => {
     expect(clean).not.toContain(canary);
     expect(clean).toContain("[redacted]");
   });
+
+  test("redacts password/private-key/jwt/signature keyed fields", () => {
+    const canary = "keyed-canary-b51f0";
+    const clean = JSON.stringify(
+      sanitizeProviderPayload({
+        password: canary,
+        passphrase: canary,
+        private_key: canary,
+        clientJwt: canary,
+        signature: canary,
+        nested: { sessionPassword: canary },
+      }),
+    );
+    expect(clean).not.toContain(canary);
+  });
+
+  test("redacts secret shapes embedded in free-text error messages", () => {
+    const jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.sigcanary01";
+    const apiKey = "sk-livecanary123456789";
+    const ghToken = "ghp_canarytoken123456";
+    const slackToken = "xoxb-canary-123456789";
+    const password = "free-text-passwd-canary";
+    const clean = sanitizeProviderPayload(
+      `upstream 500: jwt=${jwt} key=${apiKey} gh=${ghToken} slack=${slackToken} password: ${password}`,
+    ) as string;
+    for (const canary of [jwt, apiKey, ghToken, slackToken, password]) {
+      expect(clean).not.toContain(canary);
+    }
+    expect(clean).toContain("[redacted]");
+  });
+
+  test("leaves non-secret free text and identifiers intact", () => {
+    const text =
+      "order oid_123 failed: insufficient balance for 0.01 BTC; tx 0x" + "a".repeat(64);
+    expect(sanitizeProviderPayload(text)).toBe(text);
+  });
 });

--- a/packages/mcp/src/__tests__/provider-tools.test.ts
+++ b/packages/mcp/src/__tests__/provider-tools.test.ts
@@ -275,8 +275,7 @@ describe("credential redaction", () => {
   });
 
   test("leaves non-secret free text and identifiers intact", () => {
-    const text =
-      "order oid_123 failed: insufficient balance for 0.01 BTC; tx 0x" + "a".repeat(64);
+    const text = "order oid_123 failed: insufficient balance for 0.01 BTC; tx 0x" + "a".repeat(64);
     expect(sanitizeProviderPayload(text)).toBe(text);
   });
 });

--- a/packages/mcp/src/__tests__/provider-tools.test.ts
+++ b/packages/mcp/src/__tests__/provider-tools.test.ts
@@ -252,6 +252,9 @@ describe("credential redaction", () => {
         passphrase: canary,
         private_key: canary,
         clientJwt: canary,
+        clientSecretValue: canary,
+        cookieHeader: canary,
+        accessKeyId: canary,
         signature: canary,
         nested: { sessionPassword: canary },
       }),
@@ -265,13 +268,35 @@ describe("credential redaction", () => {
     const ghToken = "ghp_canarytoken123456";
     const slackToken = "xoxb-canary-123456789";
     const password = "free-text-passwd-canary";
+    const opaqueJwt = "opaque-jwt-canary";
+    const signature = "signature-canary";
     const clean = sanitizeProviderPayload(
-      `upstream 500: jwt=${jwt} key=${apiKey} gh=${ghToken} slack=${slackToken} password: ${password}`,
+      `upstream 500: jwt=${jwt} opaque jwt=${opaqueJwt} key=${apiKey} gh=${ghToken} slack=${slackToken} password: ${password} signature=${signature}`,
     ) as string;
-    for (const canary of [jwt, apiKey, ghToken, slackToken, password]) {
+    for (const canary of [jwt, opaqueJwt, apiKey, ghToken, slackToken, password, signature]) {
       expect(clean).not.toContain(canary);
     }
     expect(clean).toContain("[redacted]");
+  });
+
+  test("fails closed on accessors and cycles without invoking provider code", () => {
+    let invoked = false;
+    const payload: Record<string, unknown> = { public: "safe" };
+    Object.defineProperty(payload, "computed", {
+      enumerable: true,
+      get() {
+        invoked = true;
+        return "getter-secret";
+      },
+    });
+    payload.self = payload;
+
+    expect(sanitizeProviderPayload(payload)).toEqual({
+      public: "safe",
+      computed: "[redacted]",
+      self: "[redacted]",
+    });
+    expect(invoked).toBe(false);
   });
 
   test("leaves non-secret free text and identifiers intact", () => {

--- a/packages/mcp/src/provider-api.ts
+++ b/packages/mcp/src/provider-api.ts
@@ -5,8 +5,14 @@ export interface ProviderApi {
   request(path: string, init?: RequestInit): Promise<unknown>;
 }
 
-const SENSITIVE_KEY = /authorization|bearer|token|secret|credential|api[-_]?key|cookie/i;
-const SECRET_TEXT = /(?:bearer\s+|(?:api[-_]?key|token|secret|credential)["'\s:=]+)[^\s,"'}]+/gi;
+// Best-effort redaction (SEC-172): keyed fields AND free-text secret shapes.
+// Coverage is deliberately conservative — over-broad patterns would redact
+// legitimate tool output (tx hashes, ids) — so the first line of defense
+// remains upstream errors not embedding secrets at all.
+const SENSITIVE_KEY =
+  /authorization|bearer|token|secret|credential|api[-_]?key|cookie|pass(?:word|phrase|wd)|private[-_]?key|jwt|signature/i;
+const SECRET_TEXT =
+  /(?:bearer\s+|(?:api[-_]?key|token|secret|credential|pass(?:word|phrase|wd)|private[-_]?key)["'\s:=]+)[^\s,"'}]+|eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*|\bsk-[A-Za-z0-9]{8,}|\bgh[po]_[A-Za-z0-9]{8,}|\bxox[baprs]-[A-Za-z0-9-]{8,}/gi;
 
 export function sanitizeProviderPayload(value: unknown, depth = 0): unknown {
   if (depth > 20) return "[redacted]";

--- a/packages/mcp/src/provider-api.ts
+++ b/packages/mcp/src/provider-api.ts
@@ -1,4 +1,4 @@
-import { describeThrown } from "@stwd/shared";
+import { describeThrown, isSensitiveCredentialKey } from "@stwd/shared";
 import type { StewardMcpConfig } from "./config.js";
 
 export interface ProviderApi {
@@ -9,23 +9,43 @@ export interface ProviderApi {
 // Coverage is deliberately conservative — over-broad patterns would redact
 // legitimate tool output (tx hashes, ids) — so the first line of defense
 // remains upstream errors not embedding secrets at all.
-const SENSITIVE_KEY =
-  /authorization|bearer|token|secret|credential|api[-_]?key|cookie|pass(?:word|phrase|wd)|private[-_]?key|jwt|signature/i;
+function isSensitiveProviderKey(key: string): boolean {
+  // Use the repository-wide classifier so this MCP boundary cannot drift
+  // behind newly recognized credential carrier names. `passwd` and
+  // signatures are retained as MCP-specific conservative additions.
+  return isSensitiveCredentialKey(key) || /passwd|signature/i.test(key);
+}
 const SECRET_TEXT =
-  /(?:bearer\s+|(?:api[-_]?key|token|secret|credential|pass(?:word|phrase|wd)|private[-_]?key)["'\s:=]+)[^\s,"'}]+|eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*|\bsk-[A-Za-z0-9]{8,}|\bgh[po]_[A-Za-z0-9]{8,}|\bxox[baprs]-[A-Za-z0-9-]{8,}/gi;
+  /(?:bearer\s+|(?:auth(?:orization)?|token|secret|credential|api[-_]?key|cookie(?:[-_]?header)?|pass(?:word|phrase|wd)|private[-_]?key|jwt|signature|client[-_]?secret|access[-_]?key(?:[-_]?id)?|secret[-_]?access[-_]?key|session[-_]?(?:id|cookie)|signing[-_]?key|encryption[-_]?key|mnemonic|seed[-_]?phrase|recovery[-_]?phrase|pat)(?:\s*["']?\s*[:=]\s*["']?|\s+))[^\s,"'}]+|eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*|\bsk-[A-Za-z0-9]{8,}|\bgh[po]_[A-Za-z0-9]{8,}|\bxox[baprs]-[A-Za-z0-9-]{8,}/gi;
 
-export function sanitizeProviderPayload(value: unknown, depth = 0): unknown {
+export function sanitizeProviderPayload(
+  value: unknown,
+  depth = 0,
+  ancestors = new Set<object>(),
+): unknown {
   if (depth > 20) return "[redacted]";
   if (typeof value === "string") return value.replace(SECRET_TEXT, "[redacted]");
-  if (Array.isArray(value)) return value.map((item) => sanitizeProviderPayload(item, depth + 1));
   if (value && typeof value === "object") {
-    const clean: Record<string, unknown> = {};
-    for (const [key, nested] of Object.entries(value)) {
-      clean[key] = SENSITIVE_KEY.test(key)
-        ? "[redacted]"
-        : sanitizeProviderPayload(nested, depth + 1);
+    // Untrusted provider values must not execute accessors during a scrub, and
+    // cycles fail closed instead of being traversed repeatedly to the limit.
+    if (ancestors.has(value)) return "[redacted]";
+    ancestors.add(value);
+    try {
+      if (Array.isArray(value)) {
+        return value.map((item) => sanitizeProviderPayload(item, depth + 1, ancestors));
+      }
+      const clean: Record<string, unknown> = {};
+      for (const [key, descriptor] of Object.entries(Object.getOwnPropertyDescriptors(value))) {
+        if (!descriptor.enumerable) continue;
+        clean[key] =
+          isSensitiveProviderKey(key) || !("value" in descriptor)
+            ? "[redacted]"
+            : sanitizeProviderPayload(descriptor.value, depth + 1, ancestors);
+      }
+      return clean;
+    } finally {
+      ancestors.delete(value);
     }
-    return clean;
   }
   return value;
 }

--- a/packages/mcp/src/provider-api.ts
+++ b/packages/mcp/src/provider-api.ts
@@ -11,12 +11,20 @@ export interface ProviderApi {
 // remains upstream errors not embedding secrets at all.
 function isSensitiveProviderKey(key: string): boolean {
   // Use the repository-wide classifier so this MCP boundary cannot drift
-  // behind newly recognized credential carrier names. `passwd` and
-  // signatures are retained as MCP-specific conservative additions.
-  return isSensitiveCredentialKey(key) || /passwd|signature/i.test(key);
+  // behind newly recognized credential carrier names. Generic transaction
+  // `signature` fields are public identifiers and must remain usable; only
+  // request-authentication/HMAC signatures are credentials at this boundary.
+  const normalized = key.toLowerCase().replace(/[^a-z0-9]/g, "");
+  return (
+    isSensitiveCredentialKey(key) ||
+    /passwd/i.test(key) ||
+    normalized === "xstewardsignature" ||
+    normalized.endsWith("requestsignature") ||
+    normalized.endsWith("hmacsignature")
+  );
 }
 const SECRET_TEXT =
-  /-----BEGIN (?:ENCRYPTED |RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----[\s\S]*?-----END (?:ENCRYPTED |RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----|-----BEGIN PGP PRIVATE KEY BLOCK-----[\s\S]*?-----END PGP PRIVATE KEY BLOCK-----|(?:bearer\s+|(?:auth(?:orization)?|token|secret|credential|api[-_]?key|cookie(?:[-_]?header)?|pass(?:word|phrase|wd)|private[-_]?key|jwt|signature|client[-_]?secret|access[-_]?key(?:[-_]?id)?|secret[-_]?access[-_]?key|session[-_]?(?:id|cookie)|signing[-_]?key|encryption[-_]?key|mnemonic|seed[-_]?phrase|recovery[-_]?phrase|pat)(?:\s*["']?\s*[:=]\s*["']?|\s+))[^\s,"'}]+|eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*|\bsk-[A-Za-z0-9_-]{8,}|\b(?:AKIA|ASIA)[A-Z0-9]{16}\b|\bgh[po]_[A-Za-z0-9]{8,}|\bxox[baprs]-[A-Za-z0-9-]{8,}/gi;
+  /-----BEGIN (?:ENCRYPTED |RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----[\s\S]*?-----END (?:ENCRYPTED |RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----|-----BEGIN PGP PRIVATE KEY BLOCK-----[\s\S]*?-----END PGP PRIVATE KEY BLOCK-----|(?:bearer\s+|(?:auth(?:orization)?|token|secret|credential|api[-_]?key|cookie(?:[-_]?header)?|pass(?:word|phrase|wd)|private[-_]?key|jwt|(?:request|hmac)[-_]?signature|x[-_]?steward[-_]?signature|client[-_]?secret|access[-_]?key(?:[-_]?id)?|secret[-_]?access[-_]?key|session[-_]?(?:id|cookie)|signing[-_]?key|encryption[-_]?key|mnemonic|seed[-_]?phrase|recovery[-_]?phrase|pat)(?:\s*["']?\s*[:=]\s*["']?|\s+))[^\s,"'}]+|eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*|\bsk-[A-Za-z0-9_-]{8,}|\b(?:AKIA|ASIA)[A-Z0-9]{16}\b|\bgh[po]_[A-Za-z0-9]{8,}|\bxox[baprs]-[A-Za-z0-9-]{8,}/gi;
 
 export function sanitizeProviderPayload(
   value: unknown,

--- a/packages/mcp/src/provider-api.ts
+++ b/packages/mcp/src/provider-api.ts
@@ -16,7 +16,7 @@ function isSensitiveProviderKey(key: string): boolean {
   return isSensitiveCredentialKey(key) || /passwd|signature/i.test(key);
 }
 const SECRET_TEXT =
-  /(?:bearer\s+|(?:auth(?:orization)?|token|secret|credential|api[-_]?key|cookie(?:[-_]?header)?|pass(?:word|phrase|wd)|private[-_]?key|jwt|signature|client[-_]?secret|access[-_]?key(?:[-_]?id)?|secret[-_]?access[-_]?key|session[-_]?(?:id|cookie)|signing[-_]?key|encryption[-_]?key|mnemonic|seed[-_]?phrase|recovery[-_]?phrase|pat)(?:\s*["']?\s*[:=]\s*["']?|\s+))[^\s,"'}]+|eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*|\bsk-[A-Za-z0-9]{8,}|\bgh[po]_[A-Za-z0-9]{8,}|\bxox[baprs]-[A-Za-z0-9-]{8,}/gi;
+  /-----BEGIN (?:ENCRYPTED |RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----[\s\S]*?-----END (?:ENCRYPTED |RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----|-----BEGIN PGP PRIVATE KEY BLOCK-----[\s\S]*?-----END PGP PRIVATE KEY BLOCK-----|(?:bearer\s+|(?:auth(?:orization)?|token|secret|credential|api[-_]?key|cookie(?:[-_]?header)?|pass(?:word|phrase|wd)|private[-_]?key|jwt|signature|client[-_]?secret|access[-_]?key(?:[-_]?id)?|secret[-_]?access[-_]?key|session[-_]?(?:id|cookie)|signing[-_]?key|encryption[-_]?key|mnemonic|seed[-_]?phrase|recovery[-_]?phrase|pat)(?:\s*["']?\s*[:=]\s*["']?|\s+))[^\s,"'}]+|eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*|\bsk-[A-Za-z0-9_-]{8,}|\b(?:AKIA|ASIA)[A-Z0-9]{16}\b|\bgh[po]_[A-Za-z0-9]{8,}|\bxox[baprs]-[A-Za-z0-9-]{8,}/gi;
 
 export function sanitizeProviderPayload(
   value: unknown,

--- a/packages/plugin-capabilities/src/__tests__/client-ip.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/client-ip.test.ts
@@ -55,16 +55,14 @@ describe("trustedClientIp (capability audit)", () => {
 
   test("with hops=1 the right-most x-forwarded-for entry wins (left-most is spoofable)", async () => {
     process.env.STEWARD_TRUSTED_PROXY_HOPS = "1";
-    expect(await requestIp({ "x-forwarded-for": "198.51.100.1, 203.0.113.9" })).toBe(
-      "203.0.113.9",
-    );
+    expect(await requestIp({ "x-forwarded-for": "198.51.100.1, 203.0.113.9" })).toBe("203.0.113.9");
   });
 
   test("with hops=2 the client entry is the second from the right", async () => {
     process.env.STEWARD_TRUSTED_PROXY_HOPS = "2";
-    expect(
-      await requestIp({ "x-forwarded-for": "10.0.0.1, 198.51.100.1, 203.0.113.9" }),
-    ).toBe("198.51.100.1");
+    expect(await requestIp({ "x-forwarded-for": "10.0.0.1, 198.51.100.1, 203.0.113.9" })).toBe(
+      "198.51.100.1",
+    );
   });
 
   test("honors x-envoy-external-address with port stripping once trust is opted in", async () => {
@@ -81,8 +79,6 @@ describe("trustedClientIp (capability audit)", () => {
 
   test("legacy STEWARD_TRUST_PROXY_HEADERS=true maps to hops=1", async () => {
     process.env.STEWARD_TRUST_PROXY_HEADERS = "true";
-    expect(await requestIp({ "x-forwarded-for": "198.51.100.1, 203.0.113.9" })).toBe(
-      "203.0.113.9",
-    );
+    expect(await requestIp({ "x-forwarded-for": "198.51.100.1, 203.0.113.9" })).toBe("203.0.113.9");
   });
 });

--- a/packages/plugin-capabilities/src/__tests__/client-ip.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/client-ip.test.ts
@@ -53,6 +53,18 @@ describe("trustedClientIp (capability audit)", () => {
     expect(await requestIp({ "cf-connecting-ip": "203.0.113.9" })).toBe("203.0.113.9");
   });
 
+  test("Cloudflare mode fails closed when its authoritative header is absent or invalid", async () => {
+    process.env.STEWARD_TRUST_CLOUDFLARE = "true";
+    expect(
+      await requestIp({
+        "cf-connecting-ip": "invalid",
+        "x-forwarded-for": "198.51.100.1",
+        "x-envoy-external-address": "203.0.113.9",
+      }),
+    ).toBeNull();
+    expect(await requestIp({ "x-envoy-external-address": "203.0.113.9" })).toBeNull();
+  });
+
   test("with hops=1 the right-most x-forwarded-for entry wins (left-most is spoofable)", async () => {
     process.env.STEWARD_TRUSTED_PROXY_HOPS = "1";
     expect(await requestIp({ "x-forwarded-for": "198.51.100.1, 203.0.113.9" })).toBe("203.0.113.9");

--- a/packages/plugin-capabilities/src/__tests__/client-ip.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/client-ip.test.ts
@@ -77,6 +77,16 @@ describe("trustedClientIp (capability audit)", () => {
     );
   });
 
+  test("with hops>=2 a short XFF chain never falls back to the adjacent Envoy proxy", async () => {
+    process.env.STEWARD_TRUSTED_PROXY_HOPS = "2";
+    expect(
+      await requestIp({
+        "x-forwarded-for": "203.0.113.9",
+        "x-envoy-external-address": "10.0.0.9",
+      }),
+    ).toBeNull();
+  });
+
   test("honors x-envoy-external-address with port stripping once trust is opted in", async () => {
     process.env.STEWARD_TRUSTED_PROXY_HOPS = "1";
     expect(await requestIp({ "x-envoy-external-address": "203.0.113.9:51234" })).toBe(

--- a/packages/plugin-capabilities/src/__tests__/client-ip.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/client-ip.test.ts
@@ -1,0 +1,88 @@
+/**
+ * client-ip.test.ts - the capability audit trail must never record a
+ * caller-spoofable IP (SEC-096): with no trusted-edge env configured the
+ * forwarded headers are ignored entirely (NULL recorded); once the operator
+ * opts in, the client entry is read positionally from the RIGHT of
+ * x-forwarded-for and every candidate is isIP-validated.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import { trustedClientIp } from "../client-ip";
+
+const TRUST_ENV_KEYS = [
+  "STEWARD_TRUSTED_PROXY_HOPS",
+  "STEWARD_TRUST_PROXY_HEADERS",
+  "STEWARD_TRUST_CLOUDFLARE",
+] as const;
+
+const savedEnv = new Map<string, string | undefined>();
+
+/** Tiny probe app so trustedClientIp can be exercised with crafted headers. */
+const probe = new Hono().get("/ip", (c) => c.json({ ip: trustedClientIp(c) ?? null }));
+
+async function requestIp(headers: Record<string, string>): Promise<string | null> {
+  const res = await probe.request("http://test/ip", { headers });
+  const body = (await res.json()) as { ip: string | null };
+  return body.ip;
+}
+
+beforeEach(() => {
+  for (const key of TRUST_ENV_KEYS) {
+    savedEnv.set(key, process.env[key]);
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of TRUST_ENV_KEYS) {
+    const value = savedEnv.get(key);
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe("trustedClientIp (capability audit)", () => {
+  test("ignores x-forwarded-for entirely when no trust is configured", async () => {
+    expect(await requestIp({ "x-forwarded-for": "203.0.113.9" })).toBeNull();
+  });
+
+  test("ignores cf-connecting-ip unless Cloudflare trust is enabled", async () => {
+    expect(await requestIp({ "cf-connecting-ip": "203.0.113.9" })).toBeNull();
+    process.env.STEWARD_TRUST_CLOUDFLARE = "true";
+    expect(await requestIp({ "cf-connecting-ip": "203.0.113.9" })).toBe("203.0.113.9");
+  });
+
+  test("with hops=1 the right-most x-forwarded-for entry wins (left-most is spoofable)", async () => {
+    process.env.STEWARD_TRUSTED_PROXY_HOPS = "1";
+    expect(await requestIp({ "x-forwarded-for": "198.51.100.1, 203.0.113.9" })).toBe(
+      "203.0.113.9",
+    );
+  });
+
+  test("with hops=2 the client entry is the second from the right", async () => {
+    process.env.STEWARD_TRUSTED_PROXY_HOPS = "2";
+    expect(
+      await requestIp({ "x-forwarded-for": "10.0.0.1, 198.51.100.1, 203.0.113.9" }),
+    ).toBe("198.51.100.1");
+  });
+
+  test("honors x-envoy-external-address with port stripping once trust is opted in", async () => {
+    process.env.STEWARD_TRUSTED_PROXY_HOPS = "1";
+    expect(await requestIp({ "x-envoy-external-address": "203.0.113.9:51234" })).toBe(
+      "203.0.113.9",
+    );
+  });
+
+  test("never records header garbage: non-IP candidates yield NULL", async () => {
+    process.env.STEWARD_TRUSTED_PROXY_HOPS = "1";
+    expect(await requestIp({ "x-forwarded-for": "not-an-ip" })).toBeNull();
+  });
+
+  test("legacy STEWARD_TRUST_PROXY_HEADERS=true maps to hops=1", async () => {
+    process.env.STEWARD_TRUST_PROXY_HEADERS = "true";
+    expect(await requestIp({ "x-forwarded-for": "198.51.100.1, 203.0.113.9" })).toBe(
+      "203.0.113.9",
+    );
+  });
+});

--- a/packages/plugin-capabilities/src/client-ip.ts
+++ b/packages/plugin-capabilities/src/client-ip.ts
@@ -69,9 +69,13 @@ export function trustedClientIp(c: Context): string | undefined {
   if (trustCloudflare) {
     const cf = c.req.header("cf-connecting-ip")?.trim();
     if (cf && isIP(cf)) return cf;
+    // Cloudflare mode is exclusive: a missing/invalid authoritative header
+    // may indicate edge bypass, so never fall through to client-forgeable
+    // forwarded headers.
+    return undefined;
   }
   const hops = trustedProxyHops();
-  if (hops === 0 && !trustCloudflare) return undefined;
+  if (hops === 0) return undefined;
 
   const fromEnvoy = () => normalizeIpCandidate(c.req.header("x-envoy-external-address"));
   const fromForwardedFor = () => {

--- a/packages/plugin-capabilities/src/client-ip.ts
+++ b/packages/plugin-capabilities/src/client-ip.ts
@@ -1,0 +1,90 @@
+/**
+ * client-ip.ts - best-effort trustworthy client IP for the capability audit
+ * trail.
+ *
+ * Mirrors `@stwd/api`'s `trustedClientIp` (routes/auth.ts); the plugin cannot
+ * import the core (circular dependency - the core builds and injects the
+ * plugin context), so the same rules are re-implemented here and read the SAME
+ * operator env vars:
+ *
+ * - cf-connecting-ip is honored only when STEWARD_TRUST_CLOUDFLARE=true AND
+ *   origin ingress is locked to Cloudflare; otherwise the header is
+ *   client-forgeable and ignored.
+ * - x-envoy-external-address / x-forwarded-for are consulted only once the
+ *   operator opts into a trusted edge via STEWARD_TRUSTED_PROXY_HOPS: the N
+ *   trusted proxies APPEND the peer they observed, so the client entry is the
+ *   N-th from the RIGHT. The left-most x-forwarded-for entry is
+ *   client-supplied and never read.
+ * - x-real-ip is deliberately not consulted: no proxy in this topology sets it
+ *   authoritatively, so a client-set value would pass through verbatim.
+ *
+ * Every candidate is validated with isIP (after unambiguous :port stripping).
+ * With no trust configured the raw headers are spoofable by any caller, so
+ * undefined is returned and the audit row records NULL rather than an
+ * attacker-chosen IP (fail closed).
+ */
+
+import { isIP } from "node:net";
+import type { Context } from "hono";
+
+/**
+ * Number of trusted reverse proxies that APPEND to x-forwarded-for before
+ * requests reach this process (see the core's auth.ts for the full topology
+ * discussion). Unset/invalid means no forwarded header is trusted (safe
+ * default); the deprecated STEWARD_TRUST_PROXY_HEADERS=true maps to hops=1.
+ */
+function trustedProxyHops(): number {
+  const raw = process.env.STEWARD_TRUSTED_PROXY_HOPS?.trim();
+  if (raw === undefined || raw === "") {
+    return process.env.STEWARD_TRUST_PROXY_HEADERS === "true" ? 1 : 0;
+  }
+  // Canonical non-negative integer only: "1.5" must not truncate into trust.
+  if (!/^\d+$/.test(raw)) return 0;
+  const parsed = Number.parseInt(raw, 10);
+  return parsed > 0 && parsed <= 10 ? parsed : 0;
+}
+
+/**
+ * Normalize one forwarded-address candidate to a bare IP, or undefined.
+ * Proxies sometimes forward `ip:port` or `[ipv6]:port`, so the port is
+ * stripped first - but only where unambiguous: brackets always delimit IPv6,
+ * and a single colon can only be IPv4:port.
+ */
+function normalizeIpCandidate(value: string | undefined): string | undefined {
+  let candidate = value?.trim();
+  if (!candidate) return undefined;
+  const bracketed = /^\[([^\]]+)\](?::\d{1,5})?$/.exec(candidate);
+  if (bracketed?.[1]) {
+    candidate = bracketed[1];
+  } else {
+    const ipv4Port = /^([^:]+):\d{1,5}$/.exec(candidate);
+    if (ipv4Port?.[1]) candidate = ipv4Port[1];
+  }
+  return isIP(candidate) ? candidate : undefined;
+}
+
+/** Best-effort trustworthy client IP, or undefined when none can be derived. */
+export function trustedClientIp(c: Context): string | undefined {
+  const trustCloudflare = process.env.STEWARD_TRUST_CLOUDFLARE === "true";
+  if (trustCloudflare) {
+    const cf = c.req.header("cf-connecting-ip")?.trim();
+    if (cf && isIP(cf)) return cf;
+  }
+  const hops = trustedProxyHops();
+  if (hops === 0 && !trustCloudflare) return undefined;
+
+  const fromEnvoy = () => normalizeIpCandidate(c.req.header("x-envoy-external-address"));
+  const fromForwardedFor = () => {
+    if (hops === 0) return undefined;
+    const entries = (c.req.header("x-forwarded-for") ?? "")
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0);
+    return normalizeIpCandidate(entries[entries.length - hops]);
+  };
+
+  // x-envoy-external-address identifies the client only when the trusted edge
+  // is the outermost hop, so with hops >= 2 the positional read stays
+  // authoritative and Envoy's value is only a rescue when that read fails.
+  return hops >= 2 ? (fromForwardedFor() ?? fromEnvoy()) : (fromEnvoy() ?? fromForwardedFor());
+}

--- a/packages/plugin-capabilities/src/client-ip.ts
+++ b/packages/plugin-capabilities/src/client-ip.ts
@@ -89,6 +89,7 @@ export function trustedClientIp(c: Context): string | undefined {
 
   // x-envoy-external-address identifies the client only when the trusted edge
   // is the outermost hop, so with hops >= 2 the positional read stays
-  // authoritative and Envoy's value is only a rescue when that read fails.
-  return hops >= 2 ? (fromForwardedFor() ?? fromEnvoy()) : (fromEnvoy() ?? fromForwardedFor());
+  // authoritative. A missing/invalid positional entry is a trust-topology
+  // failure and must not fall back to the adjacent proxy's address.
+  return hops >= 2 ? fromForwardedFor() : (fromEnvoy() ?? fromForwardedFor());
 }

--- a/packages/plugin-capabilities/src/routes.ts
+++ b/packages/plugin-capabilities/src/routes.ts
@@ -16,6 +16,7 @@
 import type { ApiResponse, AppVariables } from "@stwd/shared";
 import type { Context } from "hono";
 import { Hono } from "hono";
+import { trustedClientIp } from "./client-ip";
 import type { AuditEventInput, StewardAppContext } from "./context";
 import type { Capability, CapabilityGrant } from "./schema";
 import {
@@ -133,7 +134,9 @@ export function createCapabilityRoutes(ctx: StewardAppContext): Hono<{ Variables
       resourceType: event.resourceType,
       resourceId: event.resourceId,
       metadata: event.metadata,
-      ipAddress: c.req.header("x-forwarded-for") ?? null,
+      // the raw x-forwarded-for header is caller-spoofable; record only an IP
+      // derived from the platform-trusted proxy chain (NULL when none).
+      ipAddress: trustedClientIp(c) ?? null,
       userAgent: c.req.header("user-agent") ?? null,
       requestId: c.get("requestId") ?? null,
     };

--- a/packages/plugin-example/README.md
+++ b/packages/plugin-example/README.md
@@ -4,7 +4,7 @@ the smallest honest Steward plugin. the runnable reference for writing one.
 
 it exercises all of the plugin contract's contribution points in the minimal way, importing ONLY from `@stwd/plugin-sdk`:
 
-1. route - `register(app, ctx)` mounts `GET /example/ping` -> `{ ok: true }`.
+1. route - `register(app, ctx)` mounts `GET /example/ping` -> `{ ok: true }`. **Deliberately unauthenticated** (SEC-173): the payload is a constant and the route exists only to prove the seam. Do NOT copy the ungated pattern — real routes that touch state must be mounted behind ctx auth middleware (`ctx.operatorAuth` / `ctx.tenantAuth` / `ctx.requireAgentJwt`).
 2. policy rule - a custom `example-business-hours` rule the engine evaluates.
 3. webhook event - declares `example.pinged`.
 4. migration - points at this package's own `drizzle/` folder (one `CREATE TABLE example_log`), applied into a per-plugin namespaced bookkeeping table, isolated from the core journal.

--- a/packages/plugin-example/src/index.ts
+++ b/packages/plugin-example/src/index.ts
@@ -8,6 +8,8 @@
  *
  * contribution points demonstrated:
  *   1. route       - `register(app, ctx)` mounts GET /example/ping -> { ok: true }.
+ *                      (deliberately UNAUTHENTICATED hello-world — SEC-173; do
+ *                      not copy the ungated pattern for real routes.)
  *   2. policy rule - a custom "example-business-hours" rule the engine evaluates.
  *   3. webhook     - declares the "example.pinged" event type.
  *   4. migration   - points at this package's own drizzle folder (one CREATE TABLE).
@@ -77,6 +79,12 @@ export const examplePlugin: StewardApiPlugin = {
   //    than to prove the seam works. real plugins gate routes with ctx auth
   //    middleware (ctx.requireAgentJwt / ctx.operatorAuth / ctx.tenantAuth).
   register(app: StewardApp, _ctx: StewardAppContext): void {
+    // SECURITY (SEC-173): this route is deliberately UNAUTHENTICATED so the
+    // hello-world stays dependency-free — its payload is a constant and
+    // touches nothing. DO NOT copy this pattern: any route that reads or
+    // mutates real state MUST be mounted behind ctx auth middleware
+    // (ctx.operatorAuth / ctx.tenantAuth / ctx.requireAgentJwt). If you enable
+    // this plugin in a deployment, treat /example/ping as public.
     app.get("/example/ping", (c) => c.json({ ok: true }));
   },
 


### PR DESCRIPTION
# Security wave 2b — plugins batch (LOW/INFO deferred findings)

Deferred LOW/INFO remainder for the **plugins** batch. Builds on the merged wave-2 HIGH/MEDIUM fixes; no re-litigation of earlier decisions.

## Status

| SEC ID | Severity | Status | Summary |
| --- | --- | --- | --- |
| SEC-095 | LOW | FIXED | `submit-trade.ts` `stewardApiUrl()` now applies the shared `assertSecureApiUrl` guard (was reading `STEWARD_API_URL` raw, sending the agent JWT over plaintext for non-localhost `http://`). `validate` fails closed (returns false) on an insecure URL; the handler surfaces it as a config error instead of "venue error". |
| SEC-096 | LOW | FIXED | Capability audit `ipAddress` no longer records raw `X-Forwarded-For`. New `client-ip.ts` mirrors the core's `trustedClientIp` (same env contract: `STEWARD_TRUSTED_PROXY_HOPS` / `STEWARD_TRUST_CLOUDFLARE` / legacy `STEWARD_TRUST_PROXY_HEADERS`, right-most-N read, `isIP` validation). No trust configured ⇒ NULL recorded, never a spoofable value. |
| SEC-109 | LOW | FIXED | `decodeJobCreatedId` now skips receipt logs whose emitter isn't the configured `agenticCommerce` address (case-insensitive), matching the erc8004 register filter. A lookalike `JobCreated` from another contract can no longer yield a jobId that later `setBudget`/`fund` calls would fund. |
| SEC-112 | LOW | FIXED (docs) | Documented the single-RPC trust assumption at the trust boundaries: `REGISTRY_CONFIGS` header, `RegistryConfig.rpcUrl`, both `verified` result docs (erc8004), and `ERC8183ChainConfig.rpcUrl` (erc8183, already operator-registered-only). Production operators must supply their own `RegistryConfig.rpcUrl`/`publicClient`. |
| SEC-170 | INFO | PARTIAL/DECISION | Documented the plugin trust bar prominently in operator-facing `docs/plugins/README.md` and `packages/api/src/plugin.ts`: plugins run in-process with full trust (raw `vault` + `db`); fail-closed guarantees cover contribution collisions, not privilege. The policy-gated signing facade is a considered future hardening, not implemented — sandboxing would be a subsystem rewrite, out of scope for a LOW-wave fix. |
| SEC-171 | INFO | VERIFIED | `StewardProxyClient` already signs whenever a signing secret is configured. Added a regression test proving signed proxy calls with explicit enforcement off; clarified that `signingRequired` only governs the separate fail-closed rule when a required secret is absent. |
| SEC-172 | INFO | FIXED | Broadened MCP `sanitizeProviderPayload` with the shared keyed classifier, safe accessor/cycle handling, JWT and provider-token shapes, modern `sk-proj` keys, AWS access-key IDs, and armored private keys. Request/HMAC signatures are redacted, while generic public transaction `signature` fields remain intact for provider compatibility. |
| SEC-173 | INFO | FIXED (docs) | Chose the audit's "loud comment" option over gating: the route exists to prove the plugin seam dependency-free, and gating would change the example's character + its e2e test. Added unmissable warnings at the mount site, the file header, the package README, and `docs/plugins/README.md` quickstart: deliberately unauthenticated, do not copy the pattern, real routes must use ctx auth middleware. |

Every assigned ID appears above; no omissions.

## Trade-offs / decisions

- **SEC-096**: the plugin cannot import `@stwd/api`'s `trustedClientIp` (the core↔plugin one-directional dependency rule), so the logic is mirrored in `client-ip.ts` reading the same env vars. If the core's resolver changes, the mirror must be updated — noted in the file header.
- **SEC-171**: the audit concern was already satisfied: `StewardProxyClient` signs iff a secret is configured. The regression test now observes the signature with enforcement off; the service comment distinguishes this from the production/opt-in rule that rejects an absent secret.
- **SEC-172**: redaction remains best-effort, but keyed classification now reuses the shared credential vocabulary and traversal fails closed on accessors, cycles, and excessive depth. Free-text secret shapes remain conservative to avoid redacting transaction hashes and ordinary identifiers. `session` is still not treated as a key by itself.
- **SEC-170 / SEC-112**: docs-only per the audit's own fix options ("document the trust bar/assumption").

## How tested

Targeted suites per touched package (all green):

- `packages/eliza-plugin`: `bunx vitest run` — 52 passed / 24 skipped (7 files); new tests pin SEC-095 (plaintext URL rejected before any fetch; loopback http still allowed) and SEC-171 (signs with secret present even when enforcement flag is off). `tsc --noEmit` clean.
- `packages/plugin-capabilities`: `bun test --isolate` full suite — 163 pass (12 files), incl. new `client-ip.test.ts` (7 tests: no-trust ⇒ NULL, hops=1/2 positional reads, envoy port stripping, garbage rejection, legacy flag). `tsc --noEmit` clean.
- `packages/erc8183`: `bun test src/__tests__` — 7 pass, incl. lookalike-emitter-first and foreign-emitter-only regressions. `tsc --noEmit` clean.
- `packages/erc8004`: `bun test src/__tests__` — 3 pass. `tsc --noEmit` clean. (comment-only change)
- `packages/mcp`: original full-package run was green; the rebased exact-head focused `provider-tools.test.ts` run is 17/17 green, including adversarial key, free-text, modern provider-token, armored-key, accessor, cycle, and public-transaction-signature compatibility coverage. `tsc` clean. The existing mutation-proof script's target lines were left structurally intact.
- `packages/plugin-example`: `bun test src/__tests__` — 2 pass. `tsc --noEmit` clean. (comment/README-only change)
- `packages/api`: comment-only change to `plugin.ts`; parsed by biome (no `tsc` run — pure docblock addition).
- `bunx biome check` clean on all changed files (one format fixup commit).

Pre-existing issue noted (not caused by this batch): running the plugin-capabilities suite WITHOUT `--isolate` fails 2 `session-broker-e2e` tests (vault decrypt "unable to authenticate data" — cross-file env pollution; the package's own `test` script mandates `--isolate`, under which all 163 pass). Re-verified on this branch: the same 2 failures occur with this batch's new `client-ip.test.ts` removed from the run, and the file passes standalone. All other packages show no failures.

## Review-wave scrutiny notes

- SEC-096 changes what gets written to the capability audit trail: with no trusted-proxy env configured, `ipAddress` is now NULL where it previously recorded a client-supplied header value. That is the intended fail-closed direction; operators who want audit IPs set `STEWARD_TRUSTED_PROXY_HOPS` exactly as for the core auth limiter.
- SEC-109 changes receipt decoding only by narrowing which logs qualify; the "event not found" error path is unchanged.
- SEC-095 can turn a previously-working (but insecure) `http://<remote>` eliza deployment into a config error at trade time — intended; loopback http is unaffected.




## Independent final audit repairs

The final independent review rebased this series onto current `develop` and added four corrections:

- Multi-hop proxy attribution now fails closed when positional `X-Forwarded-For` is absent, short, or invalid. It never falls back to `X-Envoy-External-Address`, which identifies the adjacent proxy in that topology. Core and plugin copies have hostile regression tests.
- MCP redaction now covers modern `sk-proj` keys, AWS `AKIA`/`ASIA` access IDs, and armored private keys, while preserving public transaction signatures and still removing request/HMAC signatures.
- The full-RCE/raw-vault plugin trust boundary is visible in operator-facing plugin documentation.
- ERC-8183 receipt decoding skips a runtime-malformed log address rather than aborting before examining later authoritative logs.

Exact repaired head: `713a10a94aefe81cd86a83c79429dd45965ee36d`, rebased onto `develop` `a71b778420c838d438f419bc475863f1ab61a5dc`. Final local verification: focused dependency build 24/24 tasks; 33 plugin-capabilities/MCP/ERC tests, 24 auth/PGLite tests, 5 real proxy-signing verifier tests, and 10 submit-trade Vitest tests all green; Biome and `git diff --check` clean. Fresh exact-head GitHub CI is required before merge.