### PR TITLE
fix(security): wave 2b — deferred LOW/INFO remainder (batch misc)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -325,6 +325,11 @@ STEWARD_PROXY_PORT=8080
 # NODE_ENV=production overrides this flag. docker-compose.dev.yml sets it.
 # STEWARD_PROXY_DEV_MODE=true
 
+# Per-agent, per-upstream-host Redis rate limit. Both values must be positive
+# integers; invalid or zero values fail closed at startup.
+# STEWARD_PROXY_RATE_LIMIT_MAX=60
+# STEWARD_PROXY_RATE_LIMIT_WINDOW_MS=60000
+
 # Comma-separated browser origins allowed CORS access to the proxy. Since
 # SEC-174 the proxy sends NO CORS headers by default (agents are server-side
 # callers; a wildcard origin would let any website drive probes, and use a

--- a/.env.example
+++ b/.env.example
@@ -122,8 +122,13 @@ STEWARD_EXECUTION_AUTH_SECRET=
 # ─── Database ─────────────────────────────────────────────────────────────────
 
 # [REQUIRED for full/Postgres mode] PostgreSQL connection string.
-# Example: postgres://steward:password@localhost:5432/steward
+# Remote production example: postgres://steward:password@db.example:5432/steward?sslmode=verify-full
 DATABASE_URL=
+
+# Production rejects sslmode=require because postgres-js does not authenticate
+# the database peer in that mode. Prefer verify-full. If a legacy provider only
+# supports sslmode=require, this separate acknowledgement opts into the MITM risk.
+# STEWARD_ALLOW_UNVERIFIED_DB_TLS=false
 
 # [REQUIRED when using the bundled Postgres container in docker-compose.yml]
 # Password for the managed Postgres container. The production compose files

--- a/.env.example
+++ b/.env.example
@@ -330,6 +330,11 @@ STEWARD_PROXY_PORT=8080
 # NODE_ENV=production overrides this flag. docker-compose.dev.yml sets it.
 # STEWARD_PROXY_DEV_MODE=true
 
+# Per-agent, per-upstream-host Redis rate limit. Both values must be positive
+# integers; invalid or zero values fail closed at startup.
+# STEWARD_PROXY_RATE_LIMIT_MAX=60
+# STEWARD_PROXY_RATE_LIMIT_WINDOW_MS=60000
+
 # Comma-separated browser origins allowed CORS access to the proxy. Since
 # SEC-174 the proxy sends NO CORS headers by default (agents are server-side
 # callers; a wildcard origin would let any website drive probes, and use a

--- a/.env.example
+++ b/.env.example
@@ -318,6 +318,20 @@ REDIS_URL=
 # Port the proxy gateway listens on (default: 8080).
 STEWARD_PROXY_PORT=8080
 
+# Explicit opt-in to the soft DEVELOPMENT posture: unsigned agent requests,
+# permissive in-process rate limiting when Redis is down, and a per-process
+# replay store. Since SEC-175 the proxy fails CLOSED by default in every
+# environment — leave this UNSET anywhere real traffic flows. An explicit
+# NODE_ENV=production overrides this flag. docker-compose.dev.yml sets it.
+# STEWARD_PROXY_DEV_MODE=true
+
+# Comma-separated browser origins allowed CORS access to the proxy. Since
+# SEC-174 the proxy sends NO CORS headers by default (agents are server-side
+# callers; a wildcard origin would let any website drive probes, and use a
+# leaked token cross-origin from browser JS). Set only for genuine browser
+# clients.
+# STEWARD_PROXY_CORS_ORIGINS=https://dashboard.example.com
+
 # ─── Migrations ───────────────────────────────────────────────────────────────
 
 # Set to "true" to skip automatic migrations on API startup.

--- a/.env.example
+++ b/.env.example
@@ -323,6 +323,20 @@ REDIS_URL=
 # Port the proxy gateway listens on (default: 8080).
 STEWARD_PROXY_PORT=8080
 
+# Explicit opt-in to the soft DEVELOPMENT posture: unsigned agent requests,
+# permissive in-process rate limiting when Redis is down, and a per-process
+# replay store. Since SEC-175 the proxy fails CLOSED by default in every
+# environment — leave this UNSET anywhere real traffic flows. An explicit
+# NODE_ENV=production overrides this flag. docker-compose.dev.yml sets it.
+# STEWARD_PROXY_DEV_MODE=true
+
+# Comma-separated browser origins allowed CORS access to the proxy. Since
+# SEC-174 the proxy sends NO CORS headers by default (agents are server-side
+# callers; a wildcard origin would let any website drive probes, and use a
+# leaked token cross-origin from browser JS). Set only for genuine browser
+# clients.
+# STEWARD_PROXY_CORS_ORIGINS=https://dashboard.example.com
+
 # ─── Migrations ───────────────────────────────────────────────────────────────
 
 # Set to "true" to skip automatic migrations on API startup.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,9 @@ jobs:
           fi
         env:
           STEWARD_MASTER_PASSWORD: "ci-test-secret"
+          # Proxy fixtures deliberately run without request-signing or a shared
+          # Redis connection. NODE_ENV=production still overrides this flag.
+          STEWARD_PROXY_DEV_MODE: "true"
           # bunfig.toml [test] preloads only load from bun's cwd, and this job
           # runs `bun test` from the repo root — so per-package preloads (e.g.
           # plugin-trading's, which supplies this key) never run. 64-char dummy
@@ -281,6 +284,9 @@ jobs:
           STEWARD_EMAIL_CODE_SECRET: "ci-email-code-secret-must-be-at-least-32-chars-long"
           STEWARD_EXECUTION_AUTH_SECRET: "v2-ci-1:ci-execution-auth-secret-must-be-at-least-32-bytes-long"
           STEWARD_AUDIT_HMAC_KEY: "ci-audit-hmac-key-must-be-at-least-32-bytes-long"
+          # Isolated API fixtures import an in-process proxy without calling
+          # initProxyRedis or signing requests.
+          STEWARD_PROXY_DEV_MODE: "true"
           SIWE_ALLOWED_DOMAINS: "steward.fi,localhost,127.0.0.1:3200"
 
       - name: Stop API test server
@@ -405,6 +411,7 @@ jobs:
           # script doesn't sign request-expiry / authorization-signature headers,
           # which are enforced only when NODE_ENV=production (covered by unit tests).
           NODE_ENV: "test"
+          STEWARD_PROXY_DEV_MODE: "true"
           STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS: "true"
           SIWE_ALLOWED_DOMAINS: "steward.fi,localhost,127.0.0.1:3200"
           PORT: "3200"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,8 +284,9 @@ jobs:
           STEWARD_EMAIL_CODE_SECRET: "ci-email-code-secret-must-be-at-least-32-chars-long"
           STEWARD_EXECUTION_AUTH_SECRET: "v2-ci-1:ci-execution-auth-secret-must-be-at-least-32-bytes-long"
           STEWARD_AUDIT_HMAC_KEY: "ci-audit-hmac-key-must-be-at-least-32-bytes-long"
-          # Isolated API fixtures import an in-process proxy without calling
-          # initProxyRedis or signing requests.
+          # Isolated files reuse deterministic agent/host fixtures, so retain
+          # Redis enforcement with a high bounded ceiling for the test flood.
+          STEWARD_PROXY_RATE_LIMIT_MAX: "1000000"
           STEWARD_PROXY_DEV_MODE: "true"
           SIWE_ALLOWED_DOMAINS: "steward.fi,localhost,127.0.0.1:3200"
 
@@ -412,6 +413,7 @@ jobs:
           # which are enforced only when NODE_ENV=production (covered by unit tests).
           NODE_ENV: "test"
           STEWARD_PROXY_DEV_MODE: "true"
+          STEWARD_PROXY_RATE_LIMIT_MAX: "1000000"
           STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS: "true"
           SIWE_ALLOWED_DOMAINS: "steward.fi,localhost,127.0.0.1:3200"
           PORT: "3200"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -230,9 +230,9 @@ jobs:
           fi
         env:
           STEWARD_MASTER_PASSWORD: "ci-test-secret"
-          # Proxy fixtures deliberately run without request-signing or a shared
-          # Redis connection. Production-posture tests set NODE_ENV=production,
-          # which overrides this explicit test-only soft posture.
+          # Unit tests intentionally exercise local proxy transports without a
+          # shared replay/rate-limit service. Production-posture tests set
+          # NODE_ENV=production, which overrides this explicit test posture.
           STEWARD_PROXY_DEV_MODE: "true"
           # bunfig.toml [test] preloads only load from bun's cwd, and this job
           # runs `bun test` from the repo root — so per-package preloads (e.g.
@@ -382,9 +382,11 @@ jobs:
           STEWARD_EXECUTION_AUTH_SECRET: "v2-ci-1:ci-execution-auth-secret-must-be-at-least-32-bytes-long"
           STEWARD_AUDIT_HMAC_KEY: "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
           STEWARD_REDIS_TESTS: "1"
-          # Isolated API fixtures import an in-process proxy without calling
-          # initProxyRedis or signing requests. Production-boundary tests opt
-          # back into strict posture explicitly.
+          # Isolated files share one Redis service and reuse deterministic
+          # agent/host fixtures, so retain enforcement with a high bounded
+          # ceiling for this test-only flood. The dev flag permits in-process
+          # proxy fixtures that do not sign; strict tests set production mode.
+          STEWARD_PROXY_RATE_LIMIT_MAX: "1000000"
           STEWARD_PROXY_DEV_MODE: "true"
           SIWE_ALLOWED_DOMAINS: "steward.fi,localhost,127.0.0.1:3200"
 
@@ -504,13 +506,14 @@ jobs:
           # Dummy HMAC root so the required compose var interpolates; production
           # supplies a real value. Does not weaken fail-closed behavior.
           STEWARD_PROXY_REQUEST_SIGNING_SECRET: "ci-proxy-signing-secret-must-be-at-least-32-bytes"
+          STEWARD_PROXY_DEV_MODE: "true"
+          STEWARD_PROXY_RATE_LIMIT_MAX: "1000000"
           STEWARD_KDF_SALT: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
           STEWARD_ALLOW_INSECURE_DB: "true"
           # Run the stack in non-prod mode for the functional e2e flow: the e2e
           # script doesn't sign request-expiry / authorization-signature headers,
           # which are enforced only when NODE_ENV=production (covered by unit tests).
           NODE_ENV: "test"
-          STEWARD_PROXY_DEV_MODE: "true"
           STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS: "true"
           SIWE_ALLOWED_DOMAINS: "steward.fi,localhost,127.0.0.1:3200"
           PORT: "3200"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -230,6 +230,10 @@ jobs:
           fi
         env:
           STEWARD_MASTER_PASSWORD: "ci-test-secret"
+          # Proxy fixtures deliberately run without request-signing or a shared
+          # Redis connection. Production-posture tests set NODE_ENV=production,
+          # which overrides this explicit test-only soft posture.
+          STEWARD_PROXY_DEV_MODE: "true"
           # bunfig.toml [test] preloads only load from bun's cwd, and this job
           # runs `bun test` from the repo root — so per-package preloads (e.g.
           # plugin-trading's, which supplies this key) never run. 64-char dummy
@@ -378,6 +382,10 @@ jobs:
           STEWARD_EXECUTION_AUTH_SECRET: "v2-ci-1:ci-execution-auth-secret-must-be-at-least-32-bytes-long"
           STEWARD_AUDIT_HMAC_KEY: "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
           STEWARD_REDIS_TESTS: "1"
+          # Isolated API fixtures import an in-process proxy without calling
+          # initProxyRedis or signing requests. Production-boundary tests opt
+          # back into strict posture explicitly.
+          STEWARD_PROXY_DEV_MODE: "true"
           SIWE_ALLOWED_DOMAINS: "steward.fi,localhost,127.0.0.1:3200"
 
       - name: Stop API test server
@@ -502,6 +510,7 @@ jobs:
           # script doesn't sign request-expiry / authorization-signature headers,
           # which are enforced only when NODE_ENV=production (covered by unit tests).
           NODE_ENV: "test"
+          STEWARD_PROXY_DEV_MODE: "true"
           STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS: "true"
           SIWE_ALLOWED_DOMAINS: "steward.fi,localhost,127.0.0.1:3200"
           PORT: "3200"

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -17,8 +17,11 @@ STEWARD_AUDIT_HMAC_KEY=
 STEWARD_EXECUTION_AUTH_SECRET=
 
 # Database — leave empty to use local PostgreSQL container
-# For Neon: postgresql://user:pass@ep-xxx.neon.tech/steward?sslmode=require
+# For Neon: postgresql://user:pass@ep-xxx.neon.tech/steward?sslmode=verify-full
 DATABASE_URL=
+# Legacy sslmode=require is rejected in production unless this explicit MITM-risk
+# acknowledgement is true. Prefer verify-full and leave this unset.
+# STEWARD_ALLOW_UNVERIFIED_DB_TLS=false
 
 # Required when using the bundled Postgres container — password for the managed
 # Postgres instance. There is NO insecure default; the compose file fails to

--- a/deploy/DEPLOYMENT.md
+++ b/deploy/DEPLOYMENT.md
@@ -75,7 +75,7 @@ API_VERSION=0.2.0
 STEWARD_BIND_HOST=0.0.0.0
 
 # Database (shared Neon Postgres — steward schema)
-DATABASE_URL=postgresql://neondb_owner:<password>@<neon-host>/neondb?sslmode=require&options=-c search_path=steward,public
+DATABASE_URL=postgresql://neondb_owner:<password>@<neon-host>/neondb?sslmode=verify-full&options=-c search_path=steward,public
 
 # Vault encryption
 STEWARD_MASTER_PASSWORD=<256-bit-hex-secret>

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -112,7 +112,7 @@ STEWARD_BIND_HOST=0.0.0.0
 NODE_ENV=production
 
 # Database
-DATABASE_URL=postgresql://steward:password@your-db-host/steward?sslmode=require
+DATABASE_URL=postgresql://steward:password@your-db-host/steward?sslmode=verify-full
 
 # Vault encryption — 32+ random bytes, hex-encoded
 STEWARD_MASTER_PASSWORD=<run: openssl rand -hex 32>

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       # ENV NODE_ENV=production for fail-closed production behavior (SEC-161).
       NODE_ENV: production
       DATABASE_URL: "${DATABASE_URL:-postgresql://steward:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@steward-db:5432/steward}"
+      STEWARD_ALLOW_UNVERIFIED_DB_TLS: "${STEWARD_ALLOW_UNVERIFIED_DB_TLS:-}"
       STEWARD_MASTER_PASSWORD: "${STEWARD_MASTER_PASSWORD:?Set STEWARD_MASTER_PASSWORD in .env}"
       STEWARD_JWT_SECRET: "${STEWARD_JWT_SECRET:-}"
       STEWARD_EXECUTION_AUTH_SECRET: "${STEWARD_EXECUTION_AUTH_SECRET:?Set STEWARD_EXECUTION_AUTH_SECRET in .env - PR4 governed provider actions fail closed if unset - generate: printf 'v1:%s' \"$(openssl rand -hex 32)\"}"
@@ -78,6 +79,7 @@ services:
     environment:
       STEWARD_PROXY_PORT: "8080"
       DATABASE_URL: "${DATABASE_URL:-postgresql://steward:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@steward-db:5432/steward}"
+      STEWARD_ALLOW_UNVERIFIED_DB_TLS: "${STEWARD_ALLOW_UNVERIFIED_DB_TLS:-}"
       STEWARD_MASTER_PASSWORD: "${STEWARD_MASTER_PASSWORD:?Set STEWARD_MASTER_PASSWORD in .env}"
       # JWT secret is required in production (auth verifyToken refuses dev fallback).
       STEWARD_JWT_SECRET: "${STEWARD_JWT_SECRET:?Set STEWARD_JWT_SECRET in .env}"

--- a/deploy/enterprise-reference/docker-compose.yml
+++ b/deploy/enterprise-reference/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       # network, but an operator-supplied external DATABASE_URL must never
       # inherit this silently.
       STEWARD_ALLOW_INSECURE_DB: "${STEWARD_ALLOW_INSECURE_DB:?required for the internal plaintext Postgres profile}"
+      STEWARD_ALLOW_UNVERIFIED_DB_TLS: "${STEWARD_ALLOW_UNVERIFIED_DB_TLS:-}"
     depends_on:
       postgres:
         condition: service_healthy
@@ -75,6 +76,7 @@ services:
       PASSKEY_ORIGIN: "${PASSKEY_ORIGIN:-https://steward.localhost}"
       SKIP_MIGRATIONS: "true"
       STEWARD_ALLOW_INSECURE_DB: "${STEWARD_ALLOW_INSECURE_DB:?required for the internal plaintext Postgres profile}"
+      STEWARD_ALLOW_UNVERIFIED_DB_TLS: "${STEWARD_ALLOW_UNVERIFIED_DB_TLS:-}"
     depends_on:
       steward-migrate:
         condition: service_completed_successfully
@@ -113,6 +115,7 @@ services:
       STEWARD_AUDIT_HMAC_KEY: "${STEWARD_AUDIT_HMAC_KEY:?required}"
       STEWARD_PROXY_REQUEST_SIGNING_SECRETS: "${STEWARD_PROXY_REQUEST_SIGNING_SECRETS:?required}"
       STEWARD_ALLOW_INSECURE_DB: "${STEWARD_ALLOW_INSECURE_DB:?required for the internal plaintext Postgres profile}"
+      STEWARD_ALLOW_UNVERIFIED_DB_TLS: "${STEWARD_ALLOW_UNVERIFIED_DB_TLS:-}"
     depends_on:
       steward-api:
         condition: service_healthy

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -77,6 +77,10 @@ services:
     environment:
       NODE_ENV: "development"
       STEWARD_PROXY_PORT: "8080"
+      # SEC-175: the proxy fails closed by default (request signing, shared
+      # replay store, Redis rate limiting). Dev has no Redis/signing secrets,
+      # so opt into the soft posture explicitly.
+      STEWARD_PROXY_DEV_MODE: "true"
       # Proxy also uses PGLite in dev
       STEWARD_DB_MODE: "pglite"
       STEWARD_PGLITE_PATH: "/app/.pglite"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -158,6 +158,8 @@ services:
       # Explicit soft posture for functional dev/test stacks. Empty by default;
       # NODE_ENV=production always overrides it in proxy security guards.
       STEWARD_PROXY_DEV_MODE: "${STEWARD_PROXY_DEV_MODE:-}"
+      STEWARD_PROXY_RATE_LIMIT_MAX: "${STEWARD_PROXY_RATE_LIMIT_MAX:-60}"
+      STEWARD_PROXY_RATE_LIMIT_WINDOW_MS: "${STEWARD_PROXY_RATE_LIMIT_WINDOW_MS:-60000}"
       REDIS_URL: "redis://redis:6379"
       # Cleartext redis:// on the private compose network requires an explicit
       # opt-out in production (mirrors STEWARD_ALLOW_INSECURE_DB). Set

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -155,6 +155,9 @@ services:
       STEWARD_AUDIT_HMAC_KEY: "${STEWARD_AUDIT_HMAC_KEY:?STEWARD_AUDIT_HMAC_KEY is required - generate with: openssl rand -hex 32}"
       STEWARD_ALLOW_INSECURE_DB: "${STEWARD_ALLOW_INSECURE_DB:-}"
       STEWARD_PROXY_REQUEST_SIGNING_SECRET: "${STEWARD_PROXY_REQUEST_SIGNING_SECRET:?STEWARD_PROXY_REQUEST_SIGNING_SECRET is required - generate with: openssl rand -hex 32}"
+      # Explicit soft posture for functional dev/test stacks. Empty by default;
+      # NODE_ENV=production always overrides it in proxy security guards.
+      STEWARD_PROXY_DEV_MODE: "${STEWARD_PROXY_DEV_MODE:-}"
       REDIS_URL: "redis://redis:6379"
       # Cleartext redis:// on the private compose network requires an explicit
       # opt-out in production (mirrors STEWARD_ALLOW_INSECURE_DB). Set

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,6 +91,7 @@ services:
       STEWARD_AUDIT_HMAC_KEY: "${STEWARD_AUDIT_HMAC_KEY:?STEWARD_AUDIT_HMAC_KEY is required - generate with: openssl rand -hex 32}"
       SIWE_ALLOWED_DOMAINS: "${SIWE_ALLOWED_DOMAINS:-}"
       STEWARD_ALLOW_INSECURE_DB: "${STEWARD_ALLOW_INSECURE_DB:-}"
+      STEWARD_ALLOW_UNVERIFIED_DB_TLS: "${STEWARD_ALLOW_UNVERIFIED_DB_TLS:-}"
       # ── Monero (optional; empty = Monero endpoints fail closed with 503) ──
       # Enable the monero-wallet-rpc sidecar with: COMPOSE_PROFILES=monero
       # and set STEWARD_MONERO_WALLET_RPC_URL to the sidecar's endpoint below.
@@ -154,6 +155,7 @@ services:
       # fail closed with a 5xx in production.
       STEWARD_AUDIT_HMAC_KEY: "${STEWARD_AUDIT_HMAC_KEY:?STEWARD_AUDIT_HMAC_KEY is required - generate with: openssl rand -hex 32}"
       STEWARD_ALLOW_INSECURE_DB: "${STEWARD_ALLOW_INSECURE_DB:-}"
+      STEWARD_ALLOW_UNVERIFIED_DB_TLS: "${STEWARD_ALLOW_UNVERIFIED_DB_TLS:-}"
       STEWARD_PROXY_REQUEST_SIGNING_SECRET: "${STEWARD_PROXY_REQUEST_SIGNING_SECRET:?STEWARD_PROXY_REQUEST_SIGNING_SECRET is required - generate with: openssl rand -hex 32}"
       # Explicit soft posture for functional dev/test stacks. Empty by default;
       # NODE_ENV=production always overrides it in proxy security guards.

--- a/packages/api/src/__tests__/audit-chain-strict.test.ts
+++ b/packages/api/src/__tests__/audit-chain-strict.test.ts
@@ -6,6 +6,7 @@ import { verifyAuditChain, writeAuditEvent } from "../services/audit";
 
 const TENANT_ID = `audit-strict-${Date.now()}`;
 const EMPTY_TENANT_ID = `audit-strict-empty-${Date.now()}`;
+const UNDEF_META_TENANT_ID = `audit-strict-undef-meta-${Date.now()}`;
 
 describe("strict audit chain verification", () => {
   beforeAll(async () => {
@@ -21,12 +22,14 @@ describe("strict audit chain verification", () => {
       .values([
         { id: TENANT_ID, name: "Audit Strict Tenant", apiKeyHash: "hash-strict" },
         { id: EMPTY_TENANT_ID, name: "Audit Strict Empty Tenant", apiKeyHash: "hash-empty" },
+        { id: UNDEF_META_TENANT_ID, name: "Audit Undef Meta Tenant", apiKeyHash: "hash-undef" },
       ]);
   }, 120_000);
 
   afterAll(async () => {
     await getDb().delete(tenants).where(eq(tenants.id, TENANT_ID));
     await getDb().delete(tenants).where(eq(tenants.id, EMPTY_TENANT_ID));
+    await getDb().delete(tenants).where(eq(tenants.id, UNDEF_META_TENANT_ID));
     await closeDb();
     delete process.env.STEWARD_PGLITE_MEMORY;
     delete process.env.STEWARD_AUDIT_HMAC_KEY;
@@ -69,5 +72,31 @@ describe("strict audit chain verification", () => {
       valid: false,
       brokenAt: 1,
     });
+  });
+
+  it("stays verifiable when metadata contains undefined-valued keys (SEC-089)", async () => {
+    await writeAuditEvent({
+      tenantId: UNDEF_META_TENANT_ID,
+      actorType: "user",
+      actorId: "auditor",
+      action: "test.audit.undefined-metadata",
+      metadata: { present: "yes", absent: undefined } as Record<string, unknown>,
+    });
+
+    // Re-canonicalizing the persisted row must reproduce the written HMAC —
+    // before the fix, JSON.stringify dropped the undefined-valued key while
+    // the HMAC preimage kept it as null, breaking verification from this seq.
+    expect(await verifyAuditChain(UNDEF_META_TENANT_ID, { requireHead: true })).toMatchObject({
+      valid: true,
+      count: 1,
+    });
+
+    const raw = (await getDb().execute(
+      sql`SELECT metadata FROM audit_events WHERE tenant_id = ${UNDEF_META_TENANT_ID} AND seq = 1`,
+    )) as unknown;
+    const rows = (Array.isArray(raw) ? raw : (raw as { rows: unknown[] }).rows) as Array<{
+      metadata: Record<string, unknown>;
+    }>;
+    expect(rows[0]?.metadata).toEqual({ absent: null, present: "yes" });
   });
 });

--- a/packages/db/CLOUDFLARE.md
+++ b/packages/db/CLOUDFLARE.md
@@ -23,7 +23,7 @@ TCP using `DATABASE_URL` and applies any pending files in
 # 1. Get a TCP-capable Postgres URL for your Neon database.
 #    (Neon's pooler URL works; the HTTP-only URL does not — drizzle-kit needs
 #     a real connection.)
-export DATABASE_URL="postgres://USER:PASS@ep-XYZ.us-east-2.aws.neon.tech/dbname?sslmode=require"
+export DATABASE_URL="postgres://USER:PASS@ep-XYZ.us-east-2.aws.neon.tech/dbname?sslmode=verify-full"
 
 # 2. Apply all pending migrations.
 cd packages/db

--- a/packages/db/CLOUDFLARE.md
+++ b/packages/db/CLOUDFLARE.md
@@ -57,15 +57,27 @@ migrations are forward-only.
 
 ## Schema compatibility with neon-http
 
-The neon-http driver uses Neon's serverless HTTP transport. It supports the
-full Postgres SQL surface that Steward uses (DDL, prepared statements,
-transactions). The constructs Steward does NOT use, and which would not work
-over HTTP, are:
+The neon-http driver uses Neon's serverless HTTP transport. The constructs
+that would not work over HTTP, and Steward's actual posture on each, are:
 
-- `LISTEN` / `NOTIFY` — pubsub
-- Advisory locks (`pg_advisory_lock`)
-- `COPY` streaming
-- Long-running transactions across multiple statements
-
-Verified against `packages/db/src/schema.ts` and `schema-auth.ts`: none of
-these are used.
+- `LISTEN` / `NOTIFY` — not used anywhere.
+- `COPY` streaming — not used anywhere.
+- Advisory locks — **used, contrary to an earlier version of this note**
+  (SEC-166):
+  - `pg_advisory_lock` is taken by the TCP migrator (`src/migrate.ts`,
+    `src/plugin-migrate.ts`). That runs pre-deploy over a real TCP connection
+    (see above), never from the Worker, so neon-http is unaffected.
+  - `pg_advisory_xact_lock` is taken by the audit chain on EVERY non-PGLite
+    append (`src/audit-chain.ts`), to serialize per-tenant chain extensions.
+    On Workers it never executes: drizzle's neon-http driver throws
+    `No transactions support in neon-http driver` from `db.transaction()`,
+    so `writeAuditEvent` / `withTenantAuditedTransaction` reject before the
+    lock — or the INSERT — runs. Audited writes on Workers therefore FAIL
+    CLOSED (the audited action is denied); the chain is never silently
+    skipped. This contract is pinned by
+    `src/__tests__/audit-chain-workers.test.ts`. A drizzle upgrade that adds
+    neon-http transaction support breaks that test on purpose: the Workers
+    audit posture (including whether the advisory lock still serializes
+    correctly over the HTTP transport) must be re-reviewed before adopting it.
+- Long-running multi-statement transactions — the audit chain relies on them
+  on postgres-js; on neon-http they fail closed as described above.

--- a/packages/db/src/__tests__/audit-chain-retry.test.ts
+++ b/packages/db/src/__tests__/audit-chain-retry.test.ts
@@ -1,0 +1,97 @@
+/**
+ * SEC-167: `isAuditSequenceConflict` must retry ONLY genuine audit-chain
+ * transient failures (serialization errors, seq-index races) — not every
+ * unique violation that happens to occur inside the retried unit of work.
+ *
+ * Before the fix, a bare 23505 / generic "duplicate key value" text matched,
+ * so a caller's OWN unique conflict (e.g. an idempotency-key violation in a
+ * mutation) retried the whole transaction 5 times: wasted work, and an
+ * unearned reliance on the caller's retry-idempotency contract.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { withTenantAuditedTransaction } from "../audit-chain";
+import { closeDb, setPGLiteOverride } from "../client";
+import { createPGLiteDb } from "../pglite";
+
+function uniqueViolation(constraint: string): Error {
+  return Object.assign(
+    new Error(`duplicate key value violates unique constraint "${constraint}"`),
+    { code: "23505", constraint_name: constraint },
+  );
+}
+
+describe("audit-chain retry classification (SEC-167)", () => {
+  beforeAll(async () => {
+    process.env.STEWARD_PGLITE_MEMORY = "true";
+    const { db, client } = await createPGLiteDb("memory://");
+    setPGLiteOverride(db, async () => {
+      await client.close();
+    });
+  });
+
+  afterAll(async () => {
+    await closeDb().catch(() => {});
+    delete process.env.STEWARD_PGLITE_MEMORY;
+  });
+
+  test("a caller's own unique violation is NOT retried", async () => {
+    let calls = 0;
+    await expect(
+      withTenantAuditedTransaction("tenant-sec167-a", async () => {
+        calls += 1;
+        throw uniqueViolation("agents_pkey");
+      }),
+    ).rejects.toThrow("agents_pkey");
+    expect(calls).toBe(1);
+  });
+
+  test("a unique violation named by message but on another constraint is NOT retried", async () => {
+    let calls = 0;
+    const err = new Error(
+      'duplicate key value violates unique constraint "audit_chain_heads_pkey"',
+    );
+    await expect(
+      withTenantAuditedTransaction("tenant-sec167-b", async () => {
+        calls += 1;
+        throw err;
+      }),
+    ).rejects.toThrow("audit_chain_heads_pkey");
+    expect(calls).toBe(1);
+  });
+
+  test("an audit_events_tenant_seq_idx race IS retried (5 attempts, then throws)", async () => {
+    let calls = 0;
+    await expect(
+      withTenantAuditedTransaction("tenant-sec167-c", async () => {
+        calls += 1;
+        throw uniqueViolation("audit_events_tenant_seq_idx");
+      }),
+    ).rejects.toThrow("audit_events_tenant_seq_idx");
+    expect(calls).toBe(5);
+  });
+
+  test("a serialization failure (40001) IS retried", async () => {
+    let calls = 0;
+    const err = Object.assign(new Error("could not serialize access due to concurrent update"), {
+      code: "40001",
+    });
+    await expect(
+      withTenantAuditedTransaction("tenant-sec167-d", async () => {
+        calls += 1;
+        throw err;
+      }),
+    ).rejects.toThrow("could not serialize access");
+    expect(calls).toBe(5);
+  });
+
+  test("a transient seq race followed by success commits on retry", async () => {
+    let calls = 0;
+    const result = await withTenantAuditedTransaction("tenant-sec167-e", async () => {
+      calls += 1;
+      if (calls === 1) throw uniqueViolation("audit_events_tenant_seq_idx");
+      return "committed";
+    });
+    expect(result).toBe("committed");
+    expect(calls).toBe(2);
+  });
+});

--- a/packages/db/src/__tests__/audit-chain-workers.test.ts
+++ b/packages/db/src/__tests__/audit-chain-workers.test.ts
@@ -1,0 +1,45 @@
+/**
+ * SEC-166: pin the Workers (neon-http) audit-append posture.
+ *
+ * CLOUDFLARE.md previously claimed advisory locks are unused; in reality the
+ * audit chain acquires `pg_advisory_xact_lock` on every non-PGLite append
+ * (`appendAuditEvent`, `withTenantAuditedTransaction`). On Workers the point
+ * is moot today: drizzle's neon-http driver throws
+ * "No transactions support in neon-http driver" from `db.transaction()`, so
+ * an audited write rejects BEFORE any statement — lock or INSERT — runs.
+ * Audited actions on Workers therefore FAIL CLOSED (the action is denied);
+ * the chain is never silently skipped.
+ *
+ * These tests pin that contract. A future drizzle upgrade that adds neon-http
+ * transaction support will break them — that is intentional: it forces an
+ * explicit re-review of whether `pg_advisory_xact_lock` over the HTTP
+ * transport provides the per-tenant serialization the chain requires.
+ */
+import { describe, expect, test } from "bun:test";
+import { createNeonHttpDb } from "../client";
+
+// Constructing the client is lazy — no network is touched, and
+// transaction() throws before any HTTP round-trip.
+const { db } = createNeonHttpDb(
+  "postgres://user:pass@db.example.invalid/steward?sslmode=verify-full",
+);
+
+describe("audit chain on neon-http (Workers) — SEC-166", () => {
+  test("db.transaction rejects, so audited writes fail closed on Workers", async () => {
+    await expect(db.transaction(async () => {})).rejects.toThrow(
+      /No transactions support in neon-http driver/,
+    );
+  });
+
+  test("the transaction body never runs — neither the advisory lock nor the append", async () => {
+    let bodyRan = false;
+    await expect(
+      db.transaction(async () => {
+        // Mirrors appendAuditEvent's first step on non-PGLite runtimes
+        // (pg_advisory_xact_lock, then the head read + INSERT).
+        bodyRan = true;
+      }),
+    ).rejects.toThrow(/No transactions support in neon-http driver/);
+    expect(bodyRan).toBe(false);
+  });
+});

--- a/packages/db/src/__tests__/client-security.test.ts
+++ b/packages/db/src/__tests__/client-security.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import { assertDatabaseUrlTls } from "../client";
 
 const originalNodeEnv = process.env.NODE_ENV;
@@ -43,5 +43,31 @@ describe("database transport security", () => {
       assertDatabaseUrlTls("postgres://user:pass@db.example/steward?sslmode=verify-full"),
     ).not.toThrow();
     expect(() => assertDatabaseUrlTls("postgres://localhost/steward")).not.toThrow();
+  });
+
+  test("accepts sslmode=require in production but warns it does not verify the peer (SEC-087)", () => {
+    process.env.NODE_ENV = "production";
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      expect(() =>
+        assertDatabaseUrlTls("postgres://user:pass@db.example/steward?sslmode=require"),
+      ).not.toThrow();
+      expect(warn).toHaveBeenCalled();
+      expect(String(warn.mock.calls[0]?.[0] ?? "")).toContain("verify-full");
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  test("does not warn for verify-ca / verify-full (SEC-087)", () => {
+    process.env.NODE_ENV = "production";
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      assertDatabaseUrlTls("postgres://user:pass@db.example/steward?sslmode=verify-full");
+      assertDatabaseUrlTls("postgres://user:pass@db.example/steward?sslmode=verify-ca");
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
   });
 });

--- a/packages/db/src/__tests__/client-security.test.ts
+++ b/packages/db/src/__tests__/client-security.test.ts
@@ -3,12 +3,16 @@ import { assertDatabaseUrlTls } from "../client";
 
 const originalNodeEnv = process.env.NODE_ENV;
 const originalOverride = process.env.STEWARD_ALLOW_INSECURE_DB;
+const originalUnverifiedTlsOverride = process.env.STEWARD_ALLOW_UNVERIFIED_DB_TLS;
 
 afterEach(() => {
   if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
   else process.env.NODE_ENV = originalNodeEnv;
   if (originalOverride === undefined) delete process.env.STEWARD_ALLOW_INSECURE_DB;
   else process.env.STEWARD_ALLOW_INSECURE_DB = originalOverride;
+  if (originalUnverifiedTlsOverride === undefined)
+    delete process.env.STEWARD_ALLOW_UNVERIFIED_DB_TLS;
+  else process.env.STEWARD_ALLOW_UNVERIFIED_DB_TLS = originalUnverifiedTlsOverride;
 });
 
 describe("database transport security", () => {
@@ -22,9 +26,9 @@ describe("database transport security", () => {
     process.env.NODE_ENV = "production";
     expect(() =>
       assertDatabaseUrlTls("postgres://user:sslmode=require@db.example/steward"),
-    ).toThrow("sslmode=require");
+    ).toThrow("sslmode=verify-full");
     expect(() => assertDatabaseUrlTls("postgres://user:pass@db.example/sslmode=require")).toThrow(
-      "sslmode=require",
+      "sslmode=verify-full",
     );
   });
 
@@ -34,7 +38,7 @@ describe("database transport security", () => {
       assertDatabaseUrlTls(
         "postgres://user:pass@db.example/steward?sslmode=require&sslmode=disable",
       ),
-    ).toThrow("sslmode=require");
+    ).toThrow("sslmode=verify-full");
   });
 
   test("accepts a single enforced TLS mode and local development sockets", () => {
@@ -45,8 +49,18 @@ describe("database transport security", () => {
     expect(() => assertDatabaseUrlTls("postgres://localhost/steward")).not.toThrow();
   });
 
-  test("accepts sslmode=require in production but warns it does not verify the peer (SEC-087)", () => {
+  test("rejects sslmode=require in production unless its distinct risk is acknowledged (SEC-087)", () => {
     process.env.NODE_ENV = "production";
+    delete process.env.STEWARD_ALLOW_UNVERIFIED_DB_TLS;
+    process.env.STEWARD_ALLOW_INSECURE_DB = "true";
+    expect(() =>
+      assertDatabaseUrlTls("postgres://user:pass@db.example/steward?sslmode=require"),
+    ).toThrow("STEWARD_ALLOW_UNVERIFIED_DB_TLS=true");
+  });
+
+  test("accepts sslmode=require only with the explicit unverified-TLS acknowledgement", () => {
+    process.env.NODE_ENV = "production";
+    process.env.STEWARD_ALLOW_UNVERIFIED_DB_TLS = "true";
     const warn = spyOn(console, "warn").mockImplementation(() => {});
     try {
       expect(() =>

--- a/packages/db/src/__tests__/pglite.test.ts
+++ b/packages/db/src/__tests__/pglite.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { afterAll, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { chmod, mkdtemp, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { eq } from "drizzle-orm";
@@ -274,6 +274,36 @@ describe("PGLite Adapter", () => {
       await client.close();
     }
   });
+
+  // ─── Data directory permissions (SEC-090) ──────────────────────────────
+
+  test.skipIf(process.platform === "win32")(
+    "data directory is created owner-only (SEC-090)",
+    async () => {
+      const parent = await mkdtemp(join(tmpdir(), "steward-pglite-perms-"));
+      const dir = join(parent, "data");
+
+      const { client } = await createPGLiteDb(dir);
+      await client.close();
+
+      expect((await stat(dir)).mode & 0o777).toBe(0o700);
+      await rm(parent, { recursive: true, force: true }).catch(() => {});
+    },
+  );
+
+  test.skipIf(process.platform === "win32")(
+    "pre-existing permissive data directory is tightened to owner-only (SEC-090)",
+    async () => {
+      const dir = await mkdtemp(join(tmpdir(), "steward-pglite-perms-existing-"));
+      await chmod(dir, 0o755);
+
+      const { client } = await createPGLiteDb(dir);
+      await client.close();
+
+      expect((await stat(dir)).mode & 0o777).toBe(0o700);
+      await rm(dir, { recursive: true, force: true }).catch(() => {});
+    },
+  );
 
   test("migrations don't re-run on persistent DB", async () => {
     const dir = await mkdtemp(join(tmpdir(), "steward-pglite-mig-"));

--- a/packages/db/src/__tests__/pglite.test.ts
+++ b/packages/db/src/__tests__/pglite.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { afterAll, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { chmod, mkdtemp, rm, stat } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, rm, stat, symlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { eq } from "drizzle-orm";
@@ -302,6 +302,21 @@ describe("PGLite Adapter", () => {
 
       expect((await stat(dir)).mode & 0o777).toBe(0o700);
       await rm(dir, { recursive: true, force: true }).catch(() => {});
+    },
+  );
+
+  test.skipIf(process.platform === "win32")(
+    "symbolic-link data directory is rejected before chmod (SEC-090)",
+    async () => {
+      const parent = await mkdtemp(join(tmpdir(), "steward-pglite-symlink-"));
+      const target = join(parent, "target");
+      const link = join(parent, "data");
+      await mkdir(target, { mode: 0o755 });
+      await symlink(target, link, "dir");
+
+      await expect(createPGLiteDb(link)).rejects.toThrow("Refusing symbolic-link data directory");
+      expect((await stat(target)).mode & 0o777).toBe(0o755);
+      await rm(parent, { recursive: true, force: true }).catch(() => {});
     },
   );
 

--- a/packages/db/src/audit-chain.ts
+++ b/packages/db/src/audit-chain.ts
@@ -229,13 +229,23 @@ function computeHmac(key: Uint8Array, prevHash: Uint8Array, canonical: string): 
 function isAuditSequenceConflict(err: unknown): boolean {
   if (!err || typeof err !== "object") return false;
   const code = "code" in err ? (err as { code?: unknown }).code : undefined;
-  if (code === "23505" || code === "40001") return true;
   const message = err instanceof Error ? err.message : String(err);
-  return (
-    message.includes("audit_events_tenant_seq_idx") ||
-    message.includes("duplicate key value violates unique constraint") ||
-    message.includes("could not serialize access")
-  );
+  // Serialization failures (SQLSTATE 40001) are always transient — retry.
+  if (code === "40001" || message.includes("could not serialize access")) return true;
+  // Unique violations (23505) are retried ONLY when they name the per-tenant
+  // seq index — i.e. an actual audit-chain seq race. SEC-167: matching the
+  // bare 23505 code / generic duplicate-key text retried ANY unique violation
+  // raised inside withTenantAuditedTransaction's fn (e.g. a genuine conflict
+  // in the caller's own mutations) 5 times — wasted work, and it leaned on
+  // every caller's retry-idempotency contract for no reason.
+  const constraint =
+    "constraint_name" in err
+      ? (err as { constraint_name?: unknown }).constraint_name
+      : "constraint" in err
+        ? (err as { constraint?: unknown }).constraint
+        : undefined;
+  if (constraint === "audit_events_tenant_seq_idx") return true;
+  return message.includes("audit_events_tenant_seq_idx");
 }
 
 function rowsFromExecute<T>(result: unknown): T[] {

--- a/packages/db/src/audit-chain.ts
+++ b/packages/db/src/audit-chain.ts
@@ -310,7 +310,17 @@ export async function appendAuditEventWithinTx(
   // postgres-js does not auto-stringify Date objects in raw sql template
   // params. Convert to ISO and cast on the SQL side instead. See dcf772e.
   const createdAtIso = createdAt.toISOString();
-  const metadata = redactWebhookSecrets(ev.metadata ?? {});
+  // SEC-089: normalize metadata through the SAME canonicalization that feeds
+  // the HMAC preimage. canonicalJsonValue maps undefined → null (key kept)
+  // while JSON.stringify drops undefined-valued keys, so persisting the
+  // un-normalized form stored a row that could never re-canonicalize to its
+  // written HMAC — verification failed from that seq onward, indistinguishable
+  // from tampering. Persisting the canonicalized form makes HMAC and INSERT
+  // commit to identical bytes.
+  const metadata = canonicalJsonValue(redactWebhookSecrets(ev.metadata ?? {})) as Record<
+    string,
+    unknown
+  >;
   const canonical = canonicalize({
     tenant_id: ev.tenantId,
     seq,

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -60,6 +60,13 @@ export function getDatabaseUrl(): string {
  * Refuse to start in production if DATABASE_URL is not using TLS (sslmode=require
  * or stricter). Localhost connections are exempt. Set STEWARD_ALLOW_INSECURE_DB=true
  * to override for private-network deployments (logs a loud warning).
+ *
+ * SEC-087: postgres-js treats `sslmode=require` as TLS WITHOUT server certificate
+ * verification — the connection is encrypted but MITM-able on a hostile network.
+ * Only `verify-ca` / `verify-full` (with `sslrootcert`) authenticate the peer.
+ * `require` is still accepted (hard-rejecting it would break every existing
+ * deployment; that is a product decision) but logs a loud warning steering
+ * operators to `verify-full`.
  */
 export function assertDatabaseUrlTls(connectionString: string): void {
   if (process.env.NODE_ENV !== "production") return;
@@ -92,7 +99,17 @@ export function assertDatabaseUrlTls(connectionString: string): void {
   const sslModes = parsed.searchParams.getAll("sslmode").map((value) => value.toLowerCase());
   const hasTls =
     sslModes.length === 1 && ["require", "verify-ca", "verify-full"].includes(sslModes[0]);
-  if (hasTls) return;
+  if (hasTls) {
+    if (sslModes[0] === "require") {
+      console.warn(
+        "[db] WARNING: sslmode=require encrypts the database connection but does NOT verify " +
+          "the server certificate (postgres-js treats it as TLS without peer authentication), " +
+          "so it is MITM-able on a hostile network. Use sslmode=verify-full with sslrootcert " +
+          "for production (SEC-087).",
+      );
+    }
+    return;
+  }
 
   if (allowInsecure) {
     console.warn(
@@ -103,7 +120,8 @@ export function assertDatabaseUrlTls(connectionString: string): void {
   }
 
   throw new Error(
-    "DATABASE_URL must include sslmode=require (or verify-full) in production. " +
+    "DATABASE_URL must include sslmode=verify-full (recommended, with sslrootcert) or " +
+      "sslmode=require (minimum; does not verify the server certificate) in production. " +
       "Set STEWARD_ALLOW_INSECURE_DB=true to override for private-network deployments.",
   );
 }

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -57,21 +57,21 @@ export function getDatabaseUrl(): string {
 }
 
 /**
- * Refuse to start in production if DATABASE_URL is not using TLS (sslmode=require
- * or stricter). Localhost connections are exempt. Set STEWARD_ALLOW_INSECURE_DB=true
- * to override for private-network deployments (logs a loud warning).
+ * Refuse to start in production if DATABASE_URL is not using authenticated TLS.
+ * Localhost connections are exempt. STEWARD_ALLOW_INSECURE_DB=true is a separate
+ * acknowledgement for intentionally plaintext private-network deployments.
  *
  * SEC-087: postgres-js treats `sslmode=require` as TLS WITHOUT server certificate
  * verification — the connection is encrypted but MITM-able on a hostile network.
  * Only `verify-ca` / `verify-full` (with `sslrootcert`) authenticate the peer.
- * `require` is still accepted (hard-rejecting it would break every existing
- * deployment; that is a product decision) but logs a loud warning steering
- * operators to `verify-full`.
+ * `require` is accepted only with STEWARD_ALLOW_UNVERIFIED_DB_TLS=true, which
+ * deliberately acknowledges encryption without peer authentication.
  */
 export function assertDatabaseUrlTls(connectionString: string): void {
   if (process.env.NODE_ENV !== "production") return;
 
   const allowInsecure = process.env.STEWARD_ALLOW_INSECURE_DB === "true";
+  const allowUnverifiedTls = process.env.STEWARD_ALLOW_UNVERIFIED_DB_TLS === "true";
   let parsed: URL;
   try {
     parsed = new URL(connectionString);
@@ -101,11 +101,17 @@ export function assertDatabaseUrlTls(connectionString: string): void {
     sslModes.length === 1 && ["require", "verify-ca", "verify-full"].includes(sslModes[0]);
   if (hasTls) {
     if (sslModes[0] === "require") {
+      if (!allowUnverifiedTls) {
+        throw new Error(
+          "DATABASE_URL sslmode=require does not authenticate the database server in " +
+            "production. Use sslmode=verify-full (recommended) or explicitly set " +
+            "STEWARD_ALLOW_UNVERIFIED_DB_TLS=true to acknowledge this MITM risk.",
+        );
+      }
       console.warn(
-        "[db] WARNING: sslmode=require encrypts the database connection but does NOT verify " +
-          "the server certificate (postgres-js treats it as TLS without peer authentication), " +
-          "so it is MITM-able on a hostile network. Use sslmode=verify-full with sslrootcert " +
-          "for production (SEC-087).",
+        "[db] WARNING: STEWARD_ALLOW_UNVERIFIED_DB_TLS=true permits sslmode=require, which " +
+          "encrypts the database connection without authenticating the server. Use " +
+          "sslmode=verify-full for production (SEC-087).",
       );
     }
     return;
@@ -120,8 +126,7 @@ export function assertDatabaseUrlTls(connectionString: string): void {
   }
 
   throw new Error(
-    "DATABASE_URL must include sslmode=verify-full (recommended, with sslrootcert) or " +
-      "sslmode=require (minimum; does not verify the server certificate) in production. " +
+    "DATABASE_URL must include sslmode=verify-full (recommended) or sslmode=verify-ca in production. " +
       "Set STEWARD_ALLOW_INSECURE_DB=true to override for private-network deployments.",
   );
 }

--- a/packages/db/src/pglite.ts
+++ b/packages/db/src/pglite.ts
@@ -12,7 +12,7 @@
  */
 
 import { existsSync } from "node:fs";
-import { mkdir, readdir, readFile } from "node:fs/promises";
+import { chmod, mkdir, readdir, readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import { PGlite } from "@electric-sql/pglite";
@@ -120,11 +120,15 @@ export async function createPGLiteDb(dataDir?: string): Promise<{ client: PGlite
     connectionTarget = "memory://";
   } else {
     const dir = dataDir ?? getDataDir();
-    // Ensure data directory exists
+    // SEC-090: the data directory holds encrypted wallet keys, refresh-token
+    // hashes, webhook secrets, and audit chains — it must be owner-only.
+    // chmod unconditionally so directories created before this guard (or by
+    // hand with a permissive umask) are tightened on next start.
     if (!existsSync(dir)) {
-      await mkdir(dir, { recursive: true });
+      await mkdir(dir, { recursive: true, mode: 0o700 });
       console.log(`[pglite] Created data directory: ${dir}`);
     }
+    await chmod(dir, 0o700);
     connectionTarget = dir;
   }
 

--- a/packages/db/src/pglite.ts
+++ b/packages/db/src/pglite.ts
@@ -12,7 +12,7 @@
  */
 
 import { existsSync } from "node:fs";
-import { chmod, mkdir, readdir, readFile } from "node:fs/promises";
+import { chmod, lstat, mkdir, readdir, readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import { PGlite } from "@electric-sql/pglite";
@@ -127,6 +127,13 @@ export async function createPGLiteDb(dataDir?: string): Promise<{ client: PGlite
     if (!existsSync(dir)) {
       await mkdir(dir, { recursive: true, mode: 0o700 });
       console.log(`[pglite] Created data directory: ${dir}`);
+    }
+    const dataDirStat = await lstat(dir);
+    if (dataDirStat.isSymbolicLink()) {
+      throw new Error(`[pglite] Refusing symbolic-link data directory: ${dir}`);
+    }
+    if (!dataDirStat.isDirectory()) {
+      throw new Error(`[pglite] Data path is not a directory: ${dir}`);
     }
     await chmod(dir, 0o700);
     connectionTarget = dir;

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -35,6 +35,35 @@ import {
   varchar,
 } from "drizzle-orm/pg-core";
 
+// ─── Tenant isolation posture (SEC-169) ──────────────────────────────────────
+//
+// Tenant isolation is enforced ENTIRELY at the application layer: every query
+// filters `tenant_id` in code, and the API/proxy resolve the tenant from an
+// authenticated credential — never from caller-supplied input. No Postgres
+// Row-Level Security is enabled on any table (`isRLSEnabled: false`
+// throughout drizzle/meta). Consequence: a single app-layer query bug that
+// drops the tenant predicate is a cross-tenant data leak; the database would
+// not catch it.
+//
+// RLS as defense-in-depth for the highest-value tables (`secrets`,
+// `encrypted_keys`, `accounts`) is a deliberate DEFERRED decision, not an
+// oversight. Enabling it safely requires all of the following, and shipping
+// half of it is worse than none:
+//   1. a per-request `SET LOCAL app.tenant_id` inside EVERY transaction (the
+//      pooled postgres-js role is shared by all tenants, so the GUC must be
+//      set on the checked-out connection for exactly the unit of work);
+//   2. `ENABLE` + `FORCE ROW LEVEL SECURITY` so the table-owning app role is
+//      also subject to policy, plus a break-glass role for migrations and
+//      cross-tenant jobs (audit archival, billing rollups);
+//   3. a policy matrix review for tables with legitimate cross-tenant reads
+//      (e.g. `tenants` lookup by API-key hash at auth time — before any
+//      tenant context exists);
+//   4. PGLite/Workers parity: the embedded and neon-http runtimes must honor
+//      the same GUC discipline, or dev/prod behavior diverges.
+// Until that lands as one coherent migration, the app-layer predicates ARE
+// the isolation boundary — treat any change that relaxes a `tenant_id`
+// predicate as a security review trigger.
+
 // Postgres BYTEA column. Typed as Uint8Array to avoid the Node `Buffer` vs
 // Cloudflare workers-types Buffer conflict that bites when both type packs
 // are in scope. The runtime value is whatever the driver returns; callers

--- a/packages/proxy/src/__tests__/auth.test.ts
+++ b/packages/proxy/src/__tests__/auth.test.ts
@@ -42,6 +42,9 @@ beforeAll(async () => {
   // fallback requires STEWARD_ALLOW_DEV_SECRETS). Set a real secret so the
   // signed tokens here verify against the same key the middleware uses.
   process.env.STEWARD_JWT_SECRET = "proxy-auth-test-jwt-secret-with-enough-bytes";
+  // These tests exercise the unsigned-request path — an explicit opt-in to
+  // the soft development posture since SEC-175.
+  process.env.STEWARD_PROXY_DEV_MODE = "true";
   const { db, client } = await createPGLiteDb("memory://");
   setPGLiteOverride(db, async () => {
     await client.close();
@@ -74,6 +77,7 @@ afterAll(async () => {
   await closeDb().catch(() => {});
   delete process.env.STEWARD_PGLITE_MEMORY;
   delete process.env.STEWARD_JWT_SECRET;
+  delete process.env.STEWARD_PROXY_DEV_MODE;
   delete process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE;
   delete process.env.STEWARD_PROXY_REQUEST_SIGNING_SECRET;
   delete process.env.STEWARD_PROXY_ALLOW_UNSIGNED_REQUESTS;

--- a/packages/proxy/src/__tests__/config-security.test.ts
+++ b/packages/proxy/src/__tests__/config-security.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { configuredProxyCorsOrigins, isProxyDevMode, positiveIntegerEnv } from "../config";
+
+const ORIGINAL_ENV = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe("security configuration", () => {
+  test("production cannot enable the permissive proxy development mode", () => {
+    process.env.NODE_ENV = "production";
+    process.env.STEWARD_PROXY_DEV_MODE = "true";
+    expect(isProxyDevMode()).toBe(false);
+
+    process.env.NODE_ENV = "development";
+    expect(isProxyDevMode()).toBe(true);
+  });
+
+  test("CORS is disabled by default and accepts canonical HTTP(S) origins", () => {
+    delete process.env.STEWARD_PROXY_CORS_ORIGINS;
+    expect(configuredProxyCorsOrigins()).toEqual([]);
+
+    process.env.STEWARD_PROXY_CORS_ORIGINS = "https://dashboard.example.com,http://localhost:3000";
+    expect(configuredProxyCorsOrigins()).toEqual([
+      "https://dashboard.example.com",
+      "http://localhost:3000",
+    ]);
+  });
+
+  test("rejects wildcard and non-origin CORS values", () => {
+    for (const value of [
+      "*",
+      "https://dashboard.example.com/path",
+      "https://user@example.com",
+      "https://dashboard.example.com?mode=dev",
+      "javascript:alert(1)",
+    ]) {
+      process.env.STEWARD_PROXY_CORS_ORIGINS = value;
+      expect(() => configuredProxyCorsOrigins()).toThrow("STEWARD_PROXY_CORS_ORIGINS");
+    }
+  });
+
+  test("positive integer configuration rejects fractions, infinity, and overflow", () => {
+    for (const value of ["1.5", "Infinity", "65536"]) {
+      process.env.TEST_POSITIVE_INTEGER = value;
+      expect(() => positiveIntegerEnv("TEST_POSITIVE_INTEGER", 1, 65535)).toThrow(
+        "TEST_POSITIVE_INTEGER",
+      );
+    }
+  });
+});

--- a/packages/proxy/src/__tests__/github-credential-route.test.ts
+++ b/packages/proxy/src/__tests__/github-credential-route.test.ts
@@ -32,6 +32,10 @@ beforeAll(async () => {
   process.env.STEWARD_PGLITE_MEMORY = "true";
   process.env.STEWARD_MASTER_PASSWORD = MASTER_PASSWORD;
   process.env.STEWARD_JWT_SECRET = "proxy-github-route-jwt-secret-with-enough-bytes-here";
+  // These integration tests run the proxy in the soft development posture
+  // (unsigned agent requests, in-process replay store) — an explicit opt-in
+  // since SEC-175.
+  process.env.STEWARD_PROXY_DEV_MODE = "true";
   // api.github.com ships in the default allowlists (secret-route + proxy alias),
   // so no STEWARD_*_ALLOWED_HOSTS env is needed for the happy path.
 
@@ -65,6 +69,7 @@ afterAll(async () => {
   delete process.env.STEWARD_PGLITE_MEMORY;
   delete process.env.STEWARD_MASTER_PASSWORD;
   delete process.env.STEWARD_JWT_SECRET;
+  delete process.env.STEWARD_PROXY_DEV_MODE;
 });
 
 function buildApp() {

--- a/packages/proxy/src/__tests__/governed-execution.test.ts
+++ b/packages/proxy/src/__tests__/governed-execution.test.ts
@@ -502,6 +502,9 @@ beforeAll(async () => {
   process.env.STEWARD_JWT_SECRET = "proxy-governed-jwt-secret-with-enough-bytes-here-0123";
   process.env.STEWARD_AUDIT_HMAC_KEY = "a".repeat(64);
   process.env.STEWARD_EXECUTION_AUTH_SECRET = EXEC_SECRET;
+  // Dispatch is exercised against the in-process replay store and no Redis —
+  // the soft development posture, an explicit opt-in since SEC-175.
+  process.env.STEWARD_PROXY_DEV_MODE = "true";
 
   const { db, client } = await createPGLiteDb("memory://");
   setPGLiteOverride(db, async () => {
@@ -591,6 +594,7 @@ afterAll(async () => {
   delete process.env.STEWARD_MASTER_PASSWORD;
   delete process.env.STEWARD_JWT_SECRET;
   delete process.env.STEWARD_EXECUTION_AUTH_SECRET;
+  delete process.env.STEWARD_PROXY_DEV_MODE;
 });
 
 beforeEach(async () => {

--- a/packages/proxy/src/__tests__/proxy-limit-env.test.ts
+++ b/packages/proxy/src/__tests__/proxy-limit-env.test.ts
@@ -1,11 +1,9 @@
 /**
  * SEC-100: proxy resource-limit env vars fail closed at startup.
  *
- * `STEWARD_PROXY_RESPONSE_BYTES`, `STEWARD_PROXY_STREAM_DURATION_MS`, and
- * `STEWARD_PROXY_MAX_IN_FLIGHT_PER_AGENT/TENANT` previously treated `0` (or a
- * non-numeric value) as "unlimited", silently removing the response-size,
- * stream-duration, and concurrency caps on operator misconfiguration. The
- * limits are validated at module load, so each case runs in a subprocess.
+ * Response, stream, concurrency, and Redis rate limits reject `0` (or a
+ * non-numeric value) instead of silently disabling enforcement. The limits
+ * are validated at module load, so each case runs in a subprocess.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -33,12 +31,14 @@ describe("proxy resource-limit env validation (SEC-100)", () => {
       "STEWARD_PROXY_STREAM_DURATION_MS",
       "STEWARD_PROXY_MAX_IN_FLIGHT_PER_AGENT",
       "STEWARD_PROXY_MAX_IN_FLIGHT_PER_TENANT",
+      "STEWARD_PROXY_RATE_LIMIT_MAX",
+      "STEWARD_PROXY_RATE_LIMIT_WINDOW_MS",
     ]) {
       const result = loadProxyModule({ [name]: "0" });
       expect(result.exitCode).not.toBe(0);
       expect(result.stderr.toString()).toContain(name);
     }
-  });
+  }, 15_000);
 
   test("rejects non-numeric values at startup", () => {
     const result = loadProxyModule({ STEWARD_PROXY_RESPONSE_BYTES: "unlimited" });
@@ -52,6 +52,8 @@ describe("proxy resource-limit env validation (SEC-100)", () => {
       STEWARD_PROXY_STREAM_DURATION_MS: "60000",
       STEWARD_PROXY_MAX_IN_FLIGHT_PER_AGENT: "7",
       STEWARD_PROXY_MAX_IN_FLIGHT_PER_TENANT: "70",
+      STEWARD_PROXY_RATE_LIMIT_MAX: "600",
+      STEWARD_PROXY_RATE_LIMIT_WINDOW_MS: "30000",
     });
     expect(result.exitCode).toBe(0);
   });

--- a/packages/proxy/src/__tests__/proxy-limit-env.test.ts
+++ b/packages/proxy/src/__tests__/proxy-limit-env.test.ts
@@ -9,13 +9,15 @@
 import { describe, expect, test } from "bun:test";
 
 const PROXY_MODULE = `${import.meta.dir}/../handlers/proxy.ts`;
+const AUTH_MODULE = `${import.meta.dir}/../middleware/auth.ts`;
+const CONFIG_MODULE = `${import.meta.dir}/../config.ts`;
 
-function loadProxyModule(env: Record<string, string>) {
+function loadModule(module: string, env: Record<string, string>) {
   return Bun.spawnSync({
     cmd: [
       "bun",
       "-e",
-      `import(${JSON.stringify(PROXY_MODULE)}).then(() => process.exit(0), (e) => { console.error(e?.message ?? e); process.exit(1); })`,
+      `import(${JSON.stringify(module)}).then(() => process.exit(0), (e) => { console.error(e?.message ?? e); process.exit(1); })`,
     ],
     cwd: `${import.meta.dir}/..`,
     env: { ...process.env, ...env },
@@ -24,13 +26,23 @@ function loadProxyModule(env: Record<string, string>) {
   });
 }
 
+function loadProxyModule(env: Record<string, string>) {
+  return loadModule(PROXY_MODULE, env);
+}
+
 describe("proxy resource-limit env validation (SEC-100)", () => {
   test("rejects 0 (disable-the-limit) at startup for every capped resource", () => {
     for (const name of [
+      "STEWARD_PROXY_MAX_SPEND_BODY_BYTES",
+      "STEWARD_PROXY_IDEMPOTENCY_TTL_MS",
+      "STEWARD_PROXY_IDEMPOTENCY_BODY_BYTES",
+      "STEWARD_PROXY_UPSTREAM_TIMEOUT_MS",
       "STEWARD_PROXY_RESPONSE_BYTES",
       "STEWARD_PROXY_STREAM_DURATION_MS",
       "STEWARD_PROXY_MAX_IN_FLIGHT_PER_AGENT",
       "STEWARD_PROXY_MAX_IN_FLIGHT_PER_TENANT",
+      "STEWARD_PROXY_APPROVAL_MAX_BODY_BYTES",
+      "STEWARD_PROXY_APPROVAL_TTL_MS",
       "STEWARD_PROXY_RATE_LIMIT_MAX",
       "STEWARD_PROXY_RATE_LIMIT_WINDOW_MS",
     ]) {
@@ -38,7 +50,17 @@ describe("proxy resource-limit env validation (SEC-100)", () => {
       expect(result.exitCode).not.toBe(0);
       expect(result.stderr.toString()).toContain(name);
     }
-  }, 15_000);
+  }, 45_000);
+
+  test("rejects disabled signed-body and invalid port limits", () => {
+    const signedBody = loadModule(AUTH_MODULE, { STEWARD_PROXY_SIGNED_BODY_BYTES: "0" });
+    expect(signedBody.exitCode).not.toBe(0);
+    expect(signedBody.stderr.toString()).toContain("STEWARD_PROXY_SIGNED_BODY_BYTES");
+
+    const port = loadModule(CONFIG_MODULE, { STEWARD_PROXY_PORT: "65536" });
+    expect(port.exitCode).not.toBe(0);
+    expect(port.stderr.toString()).toContain("STEWARD_PROXY_PORT");
+  });
 
   test("rejects non-numeric values at startup", () => {
     const result = loadProxyModule({ STEWARD_PROXY_RESPONSE_BYTES: "unlimited" });
@@ -48,10 +70,16 @@ describe("proxy resource-limit env validation (SEC-100)", () => {
 
   test("loads with positive integer overrides", () => {
     const result = loadProxyModule({
+      STEWARD_PROXY_MAX_SPEND_BODY_BYTES: "1048576",
+      STEWARD_PROXY_IDEMPOTENCY_TTL_MS: "86400000",
+      STEWARD_PROXY_IDEMPOTENCY_BODY_BYTES: "1048576",
+      STEWARD_PROXY_UPSTREAM_TIMEOUT_MS: "30000",
       STEWARD_PROXY_RESPONSE_BYTES: "1048576",
       STEWARD_PROXY_STREAM_DURATION_MS: "60000",
       STEWARD_PROXY_MAX_IN_FLIGHT_PER_AGENT: "7",
       STEWARD_PROXY_MAX_IN_FLIGHT_PER_TENANT: "70",
+      STEWARD_PROXY_APPROVAL_MAX_BODY_BYTES: "1048576",
+      STEWARD_PROXY_APPROVAL_TTL_MS: "60000",
       STEWARD_PROXY_RATE_LIMIT_MAX: "600",
       STEWARD_PROXY_RATE_LIMIT_WINDOW_MS: "30000",
     });

--- a/packages/proxy/src/__tests__/proxy-limit-env.test.ts
+++ b/packages/proxy/src/__tests__/proxy-limit-env.test.ts
@@ -1,0 +1,58 @@
+/**
+ * SEC-100: proxy resource-limit env vars fail closed at startup.
+ *
+ * `STEWARD_PROXY_RESPONSE_BYTES`, `STEWARD_PROXY_STREAM_DURATION_MS`, and
+ * `STEWARD_PROXY_MAX_IN_FLIGHT_PER_AGENT/TENANT` previously treated `0` (or a
+ * non-numeric value) as "unlimited", silently removing the response-size,
+ * stream-duration, and concurrency caps on operator misconfiguration. The
+ * limits are validated at module load, so each case runs in a subprocess.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+const PROXY_MODULE = `${import.meta.dir}/../handlers/proxy.ts`;
+
+function loadProxyModule(env: Record<string, string>) {
+  return Bun.spawnSync({
+    cmd: [
+      "bun",
+      "-e",
+      `import(${JSON.stringify(PROXY_MODULE)}).then(() => process.exit(0), (e) => { console.error(e?.message ?? e); process.exit(1); })`,
+    ],
+    cwd: `${import.meta.dir}/..`,
+    env: { ...process.env, ...env },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+}
+
+describe("proxy resource-limit env validation (SEC-100)", () => {
+  test("rejects 0 (disable-the-limit) at startup for every capped resource", () => {
+    for (const name of [
+      "STEWARD_PROXY_RESPONSE_BYTES",
+      "STEWARD_PROXY_STREAM_DURATION_MS",
+      "STEWARD_PROXY_MAX_IN_FLIGHT_PER_AGENT",
+      "STEWARD_PROXY_MAX_IN_FLIGHT_PER_TENANT",
+    ]) {
+      const result = loadProxyModule({ [name]: "0" });
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr.toString()).toContain(name);
+    }
+  });
+
+  test("rejects non-numeric values at startup", () => {
+    const result = loadProxyModule({ STEWARD_PROXY_RESPONSE_BYTES: "unlimited" });
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr.toString()).toContain("STEWARD_PROXY_RESPONSE_BYTES");
+  });
+
+  test("loads with positive integer overrides", () => {
+    const result = loadProxyModule({
+      STEWARD_PROXY_RESPONSE_BYTES: "1048576",
+      STEWARD_PROXY_STREAM_DURATION_MS: "60000",
+      STEWARD_PROXY_MAX_IN_FLIGHT_PER_AGENT: "7",
+      STEWARD_PROXY_MAX_IN_FLIGHT_PER_TENANT: "70",
+    });
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/packages/proxy/src/__tests__/proxy-limit-env.test.ts
+++ b/packages/proxy/src/__tests__/proxy-limit-env.test.ts
@@ -9,13 +9,14 @@
 import { describe, expect, test } from "bun:test";
 
 const PROXY_MODULE = `${import.meta.dir}/../handlers/proxy.ts`;
+const AUTH_MODULE = `${import.meta.dir}/../middleware/auth.ts`;
 
-function loadProxyModule(env: Record<string, string>) {
+function loadProxyModule(env: Record<string, string>, module = PROXY_MODULE) {
   return Bun.spawnSync({
     cmd: [
       "bun",
       "-e",
-      `import(${JSON.stringify(PROXY_MODULE)}).then(() => process.exit(0), (e) => { console.error(e?.message ?? e); process.exit(1); })`,
+      `import(${JSON.stringify(module)}).then(() => process.exit(0), (e) => { console.error(e?.message ?? e); process.exit(1); })`,
     ],
     cwd: `${import.meta.dir}/..`,
     env: { ...process.env, ...env },
@@ -33,17 +34,42 @@ describe("proxy resource-limit env validation (SEC-100)", () => {
       "STEWARD_PROXY_MAX_IN_FLIGHT_PER_TENANT",
       "STEWARD_PROXY_RATE_LIMIT_MAX",
       "STEWARD_PROXY_RATE_LIMIT_WINDOW_MS",
+      "STEWARD_PROXY_APPROVAL_MAX_BODY_BYTES",
+      "STEWARD_PROXY_APPROVAL_TTL_MS",
+      "STEWARD_PROXY_MAX_SPEND_BODY_BYTES",
+      "STEWARD_PROXY_IDEMPOTENCY_TTL_MS",
+      "STEWARD_PROXY_IDEMPOTENCY_BODY_BYTES",
+      "STEWARD_PROXY_UPSTREAM_TIMEOUT_MS",
+      "STEWARD_PROXY_PORT",
     ]) {
       const result = loadProxyModule({ [name]: "0" });
       expect(result.exitCode).not.toBe(0);
       expect(result.stderr.toString()).toContain(name);
     }
-  }, 15_000);
+  }, 60_000);
 
   test("rejects non-numeric values at startup", () => {
     const result = loadProxyModule({ STEWARD_PROXY_RESPONSE_BYTES: "unlimited" });
     expect(result.exitCode).not.toBe(0);
     expect(result.stderr.toString()).toContain("STEWARD_PROXY_RESPONSE_BYTES");
+  });
+
+  test("rejects disabled signed-body limits at startup", () => {
+    const result = loadProxyModule({ STEWARD_PROXY_SIGNED_BODY_BYTES: "0" }, AUTH_MODULE);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr.toString()).toContain("STEWARD_PROXY_SIGNED_BODY_BYTES");
+  });
+
+  test("rejects unsafe or excessive values instead of effectively unbounded limits", () => {
+    for (const [name, value] of [
+      ["STEWARD_PROXY_RESPONSE_BYTES", String(Number.MAX_SAFE_INTEGER + 1)],
+      ["STEWARD_PROXY_UPSTREAM_TIMEOUT_MS", "300001"],
+      ["STEWARD_PROXY_PORT", "65536"],
+    ]) {
+      const result = loadProxyModule({ [name]: value });
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr.toString()).toContain(name);
+    }
   });
 
   test("loads with positive integer overrides", () => {
@@ -54,6 +80,13 @@ describe("proxy resource-limit env validation (SEC-100)", () => {
       STEWARD_PROXY_MAX_IN_FLIGHT_PER_TENANT: "70",
       STEWARD_PROXY_RATE_LIMIT_MAX: "600",
       STEWARD_PROXY_RATE_LIMIT_WINDOW_MS: "30000",
+      STEWARD_PROXY_APPROVAL_MAX_BODY_BYTES: "1048576",
+      STEWARD_PROXY_APPROVAL_TTL_MS: "60000",
+      STEWARD_PROXY_MAX_SPEND_BODY_BYTES: "1048576",
+      STEWARD_PROXY_IDEMPOTENCY_TTL_MS: "60000",
+      STEWARD_PROXY_IDEMPOTENCY_BODY_BYTES: "1048576",
+      STEWARD_PROXY_UPSTREAM_TIMEOUT_MS: "10000",
+      STEWARD_PROXY_PORT: "8081",
     });
     expect(result.exitCode).toBe(0);
   });

--- a/packages/proxy/src/__tests__/redis-enforcement.test.ts
+++ b/packages/proxy/src/__tests__/redis-enforcement.test.ts
@@ -5,7 +5,7 @@
  * and cost estimation integration.
  */
 
-import { beforeEach, describe, expect, it } from "bun:test";
+import { afterAll, beforeEach, describe, expect, it } from "bun:test";
 import { estimateCost, isKnownHost } from "@stwd/redis";
 import {
   checkProxyRateLimit,
@@ -18,6 +18,13 @@ import {
 
 beforeEach(() => {
   delete process.env.REDIS_REQUIRED;
+  // The graceful-degradation tests below exercise the soft development
+  // posture — an explicit opt-in since SEC-175 made denial the default.
+  process.env.STEWARD_PROXY_DEV_MODE = "true";
+});
+
+afterAll(() => {
+  delete process.env.STEWARD_PROXY_DEV_MODE;
 });
 
 // ─── Graceful degradation (no Redis) ─────────────────────────────────────────
@@ -32,6 +39,14 @@ describe("proxy Redis enforcement (no Redis)", () => {
     const result = await checkProxyRateLimit("agent-1", "api.openai.com");
     expect(result.allowed).toBe(true);
     expect(result.remaining).toBe(Infinity);
+  });
+
+  it("checkProxyRateLimit fails closed by default without the dev-mode opt-in (SEC-175)", async () => {
+    delete process.env.STEWARD_PROXY_DEV_MODE;
+
+    const result = await checkProxyRateLimit("agent-1", "api.openai.com");
+
+    expect(result.allowed).toBe(false);
   });
 
   it("trackProxySpend returns 0 without Redis", async () => {

--- a/packages/proxy/src/__tests__/secret-lifecycle.test.ts
+++ b/packages/proxy/src/__tests__/secret-lifecycle.test.ts
@@ -16,6 +16,9 @@ beforeAll(async () => {
   process.env.STEWARD_PGLITE_MEMORY = "true";
   process.env.STEWARD_MASTER_PASSWORD = MASTER_PASSWORD;
   process.env.STEWARD_JWT_SECRET = "proxy-secret-lifecycle-jwt-secret-with-enough-bytes";
+  // Soft development posture (unsigned requests, in-process replay store) —
+  // explicit opt-in since SEC-175.
+  process.env.STEWARD_PROXY_DEV_MODE = "true";
   process.env.STEWARD_PROXY_ALLOWED_HOSTS =
     "api.example.com,api.deleted.example.com,api.openai.com";
   // The vault's createRoute allowlist (configuredSecretRouteHosts) reads a

--- a/packages/proxy/src/__tests__/secret-lifecycle.test.ts
+++ b/packages/proxy/src/__tests__/secret-lifecycle.test.ts
@@ -44,6 +44,7 @@ afterAll(async () => {
   delete process.env.STEWARD_PGLITE_MEMORY;
   delete process.env.STEWARD_MASTER_PASSWORD;
   delete process.env.STEWARD_JWT_SECRET;
+  delete process.env.STEWARD_PROXY_DEV_MODE;
   delete process.env.STEWARD_PROXY_ALLOWED_HOSTS;
   delete process.env.STEWARD_SECRET_ROUTE_ALLOWED_HOSTS;
   delete process.env.STEWARD_ALLOW_BROAD_SECRET_ROUTES;

--- a/packages/proxy/src/__tests__/x-credential-route.test.ts
+++ b/packages/proxy/src/__tests__/x-credential-route.test.ts
@@ -46,6 +46,9 @@ beforeAll(async () => {
   process.env.STEWARD_PGLITE_MEMORY = "true";
   process.env.STEWARD_MASTER_PASSWORD = MASTER_PASSWORD;
   process.env.STEWARD_JWT_SECRET = "proxy-x-route-jwt-secret-with-enough-bytes-here-ok";
+  // Soft development posture (unsigned requests, in-process replay store) —
+  // explicit opt-in since SEC-175.
+  process.env.STEWARD_PROXY_DEV_MODE = "true";
   // api.x.com ships in the default allowlists (secret-route + proxy alias) as of
   // workstream C, so no STEWARD_*_ALLOWED_HOSTS env is needed for the happy path.
 
@@ -92,6 +95,7 @@ afterAll(async () => {
   delete process.env.STEWARD_PGLITE_MEMORY;
   delete process.env.STEWARD_MASTER_PASSWORD;
   delete process.env.STEWARD_JWT_SECRET;
+  delete process.env.STEWARD_PROXY_DEV_MODE;
 });
 
 function buildApp() {

--- a/packages/proxy/src/__tests__/zz-proxy-spend-limit.test.ts
+++ b/packages/proxy/src/__tests__/zz-proxy-spend-limit.test.ts
@@ -220,11 +220,16 @@ describe("proxy spend-limit enforcement", () => {
   afterEach(() => {
     globalThis.fetch = originalFetch;
     delete process.env.STEWARD_PROXY_ALLOWED_HOSTS;
+    delete process.env.STEWARD_PROXY_DEV_MODE;
   });
 
   beforeEach(() => {
     process.env.STEWARD_MASTER_PASSWORD = "test-master-password";
     process.env.STEWARD_PROXY_ALLOWED_HOSTS = "example.com";
+    // These tests exercise handler logic under the soft development posture
+    // (in-process replay store, no Redis). SEC-175 made that posture an
+    // explicit opt-in, so set the flag here.
+    process.env.STEWARD_PROXY_DEV_MODE = "true";
     route.injectAs = "header";
     route.injectKey = "x-api-key";
     route.injectFormat = "Bearer {value}";

--- a/packages/proxy/src/__tests__/zz-proxy-spend-limit.test.ts
+++ b/packages/proxy/src/__tests__/zz-proxy-spend-limit.test.ts
@@ -281,6 +281,16 @@ describe("proxy spend-limit enforcement", () => {
       expect(headers.get("x-steward-key")).toBeNull();
       expect(headers.get("x-steward-platform-key")).toBeNull();
       expect(headers.get("x-steward-signature")).toBeNull();
+      // SEC-097: alternate client-IP headers must not be relayed upstream.
+      expect(headers.get("x-client-ip")).toBeNull();
+      expect(headers.get("cf-connecting-ip")).toBeNull();
+      expect(headers.get("true-client-ip")).toBeNull();
+      expect(headers.get("fastly-client-ip")).toBeNull();
+      expect(headers.get("x-cluster-client-ip")).toBeNull();
+      expect(headers.get("x-original-forwarded-for")).toBeNull();
+      // SEC-099: request-signing window metadata is internal to the proxy.
+      expect(headers.get("x-steward-request-timestamp")).toBeNull();
+      expect(headers.get("x-steward-request-expires-at")).toBeNull();
       expect(headers.get("x-http-method-override")).toBeNull();
       expect(headers.get("x-method-override")).toBeNull();
       expect(headers.get("x-original-url")).toBeNull();
@@ -306,6 +316,14 @@ describe("proxy spend-limit enforcement", () => {
           "X-Steward-Key": "tenant-key",
           "X-Steward-Platform-Key": "platform-key",
           "X-Steward-Signature": "signature",
+          "X-Client-IP": "127.0.0.1",
+          "CF-Connecting-IP": "127.0.0.1",
+          "True-Client-IP": "127.0.0.1",
+          "Fastly-Client-IP": "127.0.0.1",
+          "X-Cluster-Client-IP": "127.0.0.1",
+          "X-Original-Forwarded-For": "127.0.0.1",
+          "X-Steward-Request-Timestamp": "1700000000",
+          "X-Steward-Request-Expires-At": "1700000300",
           "X-HTTP-Method-Override": "DELETE",
           "X-Method-Override": "PATCH",
           "X-Original-URL": "/v1/admin/delete-all",
@@ -317,6 +335,44 @@ describe("proxy spend-limit enforcement", () => {
 
     expect(res.status).toBe(200);
     expect(fetchCalls).toBe(1);
+  });
+
+  test("strips upstream Set-Cookie so agents never receive credential-derived sessions (SEC-098)", async () => {
+    spendResult.configured = false;
+    globalThis.fetch = (async (url: string | URL | Request, _init?: RequestInit) => {
+      fetchCalls++;
+      expect(String(url)).toBe("https://example.com/v1/echo");
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+          "set-cookie": "provider_session=abc123; HttpOnly; Path=/",
+        },
+      });
+    }) as typeof fetch;
+    const { handleProxy, __setCheckProxySpendLimitForTests } = await loadProxy();
+    __setCheckProxySpendLimitForTests(async () => spendResult);
+
+    const res = await handleProxy(makeContext());
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("set-cookie")).toBeNull();
+    expect(fetchCalls).toBe(1);
+  });
+
+  test("unknown injectAs fails closed with 400 and never reaches upstream (SEC-176)", async () => {
+    spendResult.configured = false;
+    route.injectAs = "carrier-pigeon";
+    const { handleProxy, __setCheckProxySpendLimitForTests } = await loadProxy();
+    __setCheckProxySpendLimitForTests(async () => spendResult);
+
+    const res = await handleProxy(makeContext());
+    const body = (await res.json()) as { error?: string };
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain("Invalid credential injection configuration");
+    expect(fetchCalls).toBe(0);
+    expect(audits.some((entry) => entry?.reason === "credential-injection-failed")).toBe(true);
   });
 
   test("agent over daily budget returns 402 and does not call upstream", async () => {

--- a/packages/proxy/src/config.ts
+++ b/packages/proxy/src/config.ts
@@ -22,3 +22,15 @@ export const PROXY_PORT = parseInt(process.env.STEWARD_PROXY_PORT || "8080", 10)
 
 /** Required JWT scope for proxy access */
 export const PROXY_SCOPE = "api:proxy";
+
+/**
+ * SEC-175: the proxy fails closed by default — request signing, Redis-backed
+ * rate limiting, and the shared replay store are REQUIRED regardless of
+ * NODE_ENV. The soft development posture (unsigned requests, permissive
+ * in-process fallbacks) now needs this explicit opt-in, so a deployment that
+ * merely forgets to set NODE_ENV=production no longer silently gets it.
+ * Local dev compose sets STEWARD_PROXY_DEV_MODE=true.
+ */
+export function isProxyDevMode(): boolean {
+  return process.env.STEWARD_PROXY_DEV_MODE === "true";
+}

--- a/packages/proxy/src/config.ts
+++ b/packages/proxy/src/config.ts
@@ -18,7 +18,19 @@ export const DEFAULT_ALIASES: Record<string, string> = {
 };
 
 /** Default port for the proxy server */
-export const PROXY_PORT = parseInt(process.env.STEWARD_PROXY_PORT || "8080", 10);
+export function positiveIntegerEnv(name: string, fallback: number, maximum?: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") return fallback;
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value <= 0 || (maximum !== undefined && value > maximum)) {
+    throw new Error(
+      `${name} must be a positive integer${maximum ? ` no greater than ${maximum}` : ""}`,
+    );
+  }
+  return value;
+}
+
+export const PROXY_PORT = positiveIntegerEnv("STEWARD_PROXY_PORT", 8080, 65535);
 
 /** Required JWT scope for proxy access */
 export const PROXY_SCOPE = "api:proxy";
@@ -32,5 +44,35 @@ export const PROXY_SCOPE = "api:proxy";
  * Local dev compose sets STEWARD_PROXY_DEV_MODE=true.
  */
 export function isProxyDevMode(): boolean {
-  return process.env.STEWARD_PROXY_DEV_MODE === "true";
+  return process.env.NODE_ENV !== "production" && process.env.STEWARD_PROXY_DEV_MODE === "true";
+}
+
+export function configuredProxyCorsOrigins(): string[] {
+  const values = (process.env.STEWARD_PROXY_CORS_ORIGINS ?? "")
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+  return values.map((value) => {
+    if (value === "*") throw new Error("STEWARD_PROXY_CORS_ORIGINS must not contain '*'");
+    let parsed: URL;
+    try {
+      parsed = new URL(value);
+    } catch {
+      throw new Error(`Invalid STEWARD_PROXY_CORS_ORIGINS origin: ${JSON.stringify(value)}`);
+    }
+    if (
+      (parsed.protocol !== "https:" && parsed.protocol !== "http:") ||
+      parsed.username ||
+      parsed.password ||
+      parsed.pathname !== "/" ||
+      parsed.search ||
+      parsed.hash ||
+      parsed.origin !== value
+    ) {
+      throw new Error(
+        `STEWARD_PROXY_CORS_ORIGINS entries must be canonical HTTP(S) origins: ${JSON.stringify(value)}`,
+      );
+    }
+    return parsed.origin;
+  });
 }

--- a/packages/proxy/src/config.ts
+++ b/packages/proxy/src/config.ts
@@ -17,8 +17,19 @@ export const DEFAULT_ALIASES: Record<string, string> = {
   x: "api.x.com",
 };
 
+/** Parse a bounded integer setting at module load so malformed resource limits fail closed. */
+export function boundedPositiveIntegerEnv(name: string, fallback: number, maximum: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") return fallback;
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value <= 0 || value > maximum) {
+    throw new Error(`${name} must be an integer between 1 and ${maximum}`);
+  }
+  return value;
+}
+
 /** Default port for the proxy server */
-export const PROXY_PORT = parseInt(process.env.STEWARD_PROXY_PORT || "8080", 10);
+export const PROXY_PORT = boundedPositiveIntegerEnv("STEWARD_PROXY_PORT", 8080, 65_535);
 
 /** Required JWT scope for proxy access */
 export const PROXY_SCOPE = "api:proxy";

--- a/packages/proxy/src/handlers/approvals.ts
+++ b/packages/proxy/src/handlers/approvals.ts
@@ -1,11 +1,18 @@
 import type { PendingProxyRequest, SecretRoute } from "@stwd/db";
 import { and, eq, getDb, pendingProxyRequests } from "@stwd/db";
 import { type EncryptedKey, KeyStore } from "@stwd/vault";
+import { boundedPositiveIntegerEnv } from "../config";
 
-const MAX_HELD_PROXY_BODY_BYTES = Number(
-  process.env.STEWARD_PROXY_APPROVAL_MAX_BODY_BYTES ?? 2 * 1024 * 1024,
+const MAX_HELD_PROXY_BODY_BYTES = boundedPositiveIntegerEnv(
+  "STEWARD_PROXY_APPROVAL_MAX_BODY_BYTES",
+  2 * 1024 * 1024,
+  100 * 1024 * 1024,
 );
-const DEFAULT_APPROVAL_TTL_MS = Number(process.env.STEWARD_PROXY_APPROVAL_TTL_MS ?? 15 * 60 * 1000);
+const DEFAULT_APPROVAL_TTL_MS = boundedPositiveIntegerEnv(
+  "STEWARD_PROXY_APPROVAL_TTL_MS",
+  15 * 60 * 1000,
+  24 * 60 * 60 * 1000,
+);
 
 const SENSITIVE_HEADER_NAMES = new Set([
   "authorization",

--- a/packages/proxy/src/handlers/approvals.ts
+++ b/packages/proxy/src/handlers/approvals.ts
@@ -1,11 +1,13 @@
 import type { PendingProxyRequest, SecretRoute } from "@stwd/db";
 import { and, eq, getDb, pendingProxyRequests } from "@stwd/db";
 import { type EncryptedKey, KeyStore } from "@stwd/vault";
+import { positiveIntegerEnv } from "../config";
 
-const MAX_HELD_PROXY_BODY_BYTES = Number(
-  process.env.STEWARD_PROXY_APPROVAL_MAX_BODY_BYTES ?? 2 * 1024 * 1024,
+const MAX_HELD_PROXY_BODY_BYTES = positiveIntegerEnv(
+  "STEWARD_PROXY_APPROVAL_MAX_BODY_BYTES",
+  2 * 1024 * 1024,
 );
-const DEFAULT_APPROVAL_TTL_MS = Number(process.env.STEWARD_PROXY_APPROVAL_TTL_MS ?? 15 * 60 * 1000);
+const DEFAULT_APPROVAL_TTL_MS = positiveIntegerEnv("STEWARD_PROXY_APPROVAL_TTL_MS", 15 * 60 * 1000);
 
 const SENSITIVE_HEADER_NAMES = new Set([
   "authorization",

--- a/packages/proxy/src/handlers/proxy.ts
+++ b/packages/proxy/src/handlers/proxy.ts
@@ -33,6 +33,7 @@ import {
 import { getRedis, type SpendReservation, settleReservedSpend } from "@stwd/redis";
 import { SecretVault } from "@stwd/vault";
 import type { Context } from "hono";
+import { isProxyDevMode } from "../config";
 import { recordAudit, recordRequiredAudit } from "../middleware/audit";
 import {
   checkProxyRateLimit,
@@ -428,11 +429,14 @@ function releaseWhenBodyCloses(
 }
 
 function requireSharedProxyReplayStore(): boolean {
-  return (
-    process.env.REDIS_REQUIRED === "true" ||
-    (process.env.NODE_ENV === "production" &&
-      process.env.STEWARD_ALLOW_PROXY_REDIS_SOFT_FAIL !== "true")
-  );
+  if (process.env.REDIS_REQUIRED === "true") return true;
+  if (process.env.STEWARD_ALLOW_PROXY_REDIS_SOFT_FAIL === "true") return false;
+  // SEC-175: default-deny — the per-process replay store is a dev-only
+  // fallback and now needs the explicit dev-mode opt-in; an unset NODE_ENV
+  // no longer selects it silently, and a production NODE_ENV overrides a
+  // stray dev-mode flag.
+  if (process.env.NODE_ENV === "production") return true;
+  return !isProxyDevMode();
 }
 
 /** Test hook for overriding spend-limit enforcement without module mocks. */

--- a/packages/proxy/src/handlers/proxy.ts
+++ b/packages/proxy/src/handlers/proxy.ts
@@ -163,7 +163,9 @@ function injectCredential(
       throw new Error("Body credential injection is not supported");
 
     default:
-      console.warn(`[proxy] Unknown inject_as: ${route.injectAs}`);
+      // SEC-176: fail closed. Forwarding with no credential in a state the
+      // operator never configured is worse than rejecting the request.
+      throw new Error(`Unknown credential injection mode: ${String(route.injectAs)}`);
   }
 
   return { headers, url, body };
@@ -172,9 +174,14 @@ function injectCredential(
 function stripHopByHopHeaders(headers: Headers): Set<string> {
   const blocked = new Set([
     "authorization",
+    // SEC-097: alternate client-IP headers trusted by some providers/CDNs for
+    // IP attribution or geo-gating. An authenticated agent must not be able to
+    // relay spoofed values to the credential-injected upstream.
+    "cf-connecting-ip",
     "connection",
     "content-length",
     "cookie",
+    "fastly-client-ip",
     "forwarded",
     "host",
     "idempotency-key",
@@ -184,7 +191,10 @@ function stripHopByHopHeaders(headers: Headers): Set<string> {
     "te",
     "trailer",
     "transfer-encoding",
+    "true-client-ip",
     "upgrade",
+    "x-client-ip",
+    "x-cluster-client-ip",
     "x-forwarded-for",
     "x-forwarded-host",
     "x-forwarded-port",
@@ -193,11 +203,16 @@ function stripHopByHopHeaders(headers: Headers): Set<string> {
     "x-http-method",
     "x-http-method-override",
     "x-method-override",
+    "x-original-forwarded-for",
     "x-original-url",
     "x-real-ip",
     "x-rewrite-url",
     "x-steward-key",
     "x-steward-platform-key",
+    // SEC-099: the proxy's request-signing window metadata is internal; do not
+    // disclose it to upstream providers.
+    "x-steward-request-expires-at",
+    "x-steward-request-timestamp",
     "x-steward-signature",
   ]);
   const connection = headers.get("connection");
@@ -281,15 +296,40 @@ const MAX_PROXY_IDEMPOTENCY_BODY_BYTES = Number(
   process.env.STEWARD_PROXY_IDEMPOTENCY_BODY_BYTES ?? 2 * 1024 * 1024,
 );
 const PROXY_UPSTREAM_TIMEOUT_MS = Number(process.env.STEWARD_PROXY_UPSTREAM_TIMEOUT_MS ?? 30_000);
-const MAX_PROXY_RESPONSE_BYTES = Number(
-  process.env.STEWARD_PROXY_RESPONSE_BYTES ?? 25 * 1024 * 1024,
+/**
+ * SEC-100: proxy resource limits fail closed — they cannot be disabled. A `0`
+ * (or garbage) env value previously meant "unlimited", silently removing the
+ * response-size, stream-duration, and concurrency caps on operator
+ * misconfiguration. Reject non-positive / non-integer values at startup
+ * (module load) instead.
+ */
+function positiveLimitFromEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") return fallback;
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(
+      `${name} must be a positive integer (got ${JSON.stringify(raw)}); ` +
+        "proxy resource limits fail closed and cannot be disabled",
+    );
+  }
+  return value;
+}
+const MAX_PROXY_RESPONSE_BYTES = positiveLimitFromEnv(
+  "STEWARD_PROXY_RESPONSE_BYTES",
+  25 * 1024 * 1024,
 );
-const MAX_PROXY_STREAM_DURATION_MS = Number(
-  process.env.STEWARD_PROXY_STREAM_DURATION_MS ?? 5 * 60_000,
+const MAX_PROXY_STREAM_DURATION_MS = positiveLimitFromEnv(
+  "STEWARD_PROXY_STREAM_DURATION_MS",
+  5 * 60_000,
 );
-let MAX_PROXY_IN_FLIGHT_PER_AGENT = Number(process.env.STEWARD_PROXY_MAX_IN_FLIGHT_PER_AGENT ?? 50);
-let MAX_PROXY_IN_FLIGHT_PER_TENANT = Number(
-  process.env.STEWARD_PROXY_MAX_IN_FLIGHT_PER_TENANT ?? 250,
+let MAX_PROXY_IN_FLIGHT_PER_AGENT = positiveLimitFromEnv(
+  "STEWARD_PROXY_MAX_IN_FLIGHT_PER_AGENT",
+  50,
+);
+let MAX_PROXY_IN_FLIGHT_PER_TENANT = positiveLimitFromEnv(
+  "STEWARD_PROXY_MAX_IN_FLIGHT_PER_TENANT",
+  250,
 );
 const IDEMPOTENCY_KEY_RE = /^[\x21-\x7e]{8,255}$/;
 const SAFE_PROXY_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
@@ -2026,6 +2066,10 @@ export async function handleProxy(c: Context): Promise<Response> {
   const skipResponseHeaders = new Set([
     "connection",
     "keep-alive",
+    // SEC-098: never relay upstream session cookies to the agent — a
+    // credential-derived session token would let it replay directly against
+    // the provider, bypassing proxy policy and audit.
+    "set-cookie",
     "transfer-encoding",
     "te",
     "trailer",

--- a/packages/proxy/src/handlers/proxy.ts
+++ b/packages/proxy/src/handlers/proxy.ts
@@ -33,7 +33,7 @@ import {
 import { getRedis, type SpendReservation, settleReservedSpend } from "@stwd/redis";
 import { SecretVault } from "@stwd/vault";
 import type { Context } from "hono";
-import { isProxyDevMode } from "../config";
+import { isProxyDevMode, positiveIntegerEnv } from "../config";
 import { recordAudit, recordRequiredAudit } from "../middleware/audit";
 import {
   checkProxyRateLimit,
@@ -287,16 +287,19 @@ async function releaseProxySpendReservation(
 
 let checkProxySpendLimitForHandler = checkProxySpendLimit;
 let resolveProxyHostForHandler = dnsLookup;
-const MAX_LLM_SPEND_TRACKING_BODY_BYTES = Number(
-  process.env.STEWARD_PROXY_MAX_SPEND_BODY_BYTES ?? 1024 * 1024,
+const MAX_LLM_SPEND_TRACKING_BODY_BYTES = positiveIntegerEnv(
+  "STEWARD_PROXY_MAX_SPEND_BODY_BYTES",
+  1024 * 1024,
 );
-const PROXY_IDEMPOTENCY_TTL_MS = Number(
-  process.env.STEWARD_PROXY_IDEMPOTENCY_TTL_MS ?? 24 * 60 * 60 * 1000,
+const PROXY_IDEMPOTENCY_TTL_MS = positiveIntegerEnv(
+  "STEWARD_PROXY_IDEMPOTENCY_TTL_MS",
+  24 * 60 * 60 * 1000,
 );
-const MAX_PROXY_IDEMPOTENCY_BODY_BYTES = Number(
-  process.env.STEWARD_PROXY_IDEMPOTENCY_BODY_BYTES ?? 2 * 1024 * 1024,
+const MAX_PROXY_IDEMPOTENCY_BODY_BYTES = positiveIntegerEnv(
+  "STEWARD_PROXY_IDEMPOTENCY_BODY_BYTES",
+  2 * 1024 * 1024,
 );
-const PROXY_UPSTREAM_TIMEOUT_MS = Number(process.env.STEWARD_PROXY_UPSTREAM_TIMEOUT_MS ?? 30_000);
+const PROXY_UPSTREAM_TIMEOUT_MS = positiveIntegerEnv("STEWARD_PROXY_UPSTREAM_TIMEOUT_MS", 30_000);
 /**
  * SEC-100: proxy resource limits fail closed — they cannot be disabled. A `0`
  * (or garbage) env value previously meant "unlimited", silently removing the
@@ -304,31 +307,16 @@ const PROXY_UPSTREAM_TIMEOUT_MS = Number(process.env.STEWARD_PROXY_UPSTREAM_TIME
  * misconfiguration. Reject non-positive / non-integer values at startup
  * (module load) instead.
  */
-function positiveLimitFromEnv(name: string, fallback: number): number {
-  const raw = process.env[name];
-  if (raw === undefined || raw.trim() === "") return fallback;
-  const value = Number(raw);
-  if (!Number.isInteger(value) || value <= 0) {
-    throw new Error(
-      `${name} must be a positive integer (got ${JSON.stringify(raw)}); ` +
-        "proxy resource limits fail closed and cannot be disabled",
-    );
-  }
-  return value;
-}
-const MAX_PROXY_RESPONSE_BYTES = positiveLimitFromEnv(
+const MAX_PROXY_RESPONSE_BYTES = positiveIntegerEnv(
   "STEWARD_PROXY_RESPONSE_BYTES",
   25 * 1024 * 1024,
 );
-const MAX_PROXY_STREAM_DURATION_MS = positiveLimitFromEnv(
+const MAX_PROXY_STREAM_DURATION_MS = positiveIntegerEnv(
   "STEWARD_PROXY_STREAM_DURATION_MS",
   5 * 60_000,
 );
-let MAX_PROXY_IN_FLIGHT_PER_AGENT = positiveLimitFromEnv(
-  "STEWARD_PROXY_MAX_IN_FLIGHT_PER_AGENT",
-  50,
-);
-let MAX_PROXY_IN_FLIGHT_PER_TENANT = positiveLimitFromEnv(
+let MAX_PROXY_IN_FLIGHT_PER_AGENT = positiveIntegerEnv("STEWARD_PROXY_MAX_IN_FLIGHT_PER_AGENT", 50);
+let MAX_PROXY_IN_FLIGHT_PER_TENANT = positiveIntegerEnv(
   "STEWARD_PROXY_MAX_IN_FLIGHT_PER_TENANT",
   250,
 );
@@ -1817,7 +1805,11 @@ export async function handleProxy(c: Context): Promise<Response> {
     );
   } catch (err) {
     const latencyMs = Date.now() - startTime;
-    console.error(`[proxy] Upstream request failed:`, err);
+    // Fetch errors can embed the full outbound URL. Query-injected credentials
+    // must never be copied from that error into application logs.
+    console.error("[proxy] Upstream request failed", {
+      errorName: err instanceof Error ? err.name : "UnknownError",
+    });
 
     // Audit the failure
     await recordAudit({

--- a/packages/proxy/src/handlers/proxy.ts
+++ b/packages/proxy/src/handlers/proxy.ts
@@ -33,7 +33,7 @@ import {
 import { getRedis, type SpendReservation, settleReservedSpend } from "@stwd/redis";
 import { SecretVault } from "@stwd/vault";
 import type { Context } from "hono";
-import { isProxyDevMode } from "../config";
+import { boundedPositiveIntegerEnv, isProxyDevMode } from "../config";
 import { recordAudit, recordRequiredAudit } from "../middleware/audit";
 import {
   checkProxyRateLimit,
@@ -287,16 +287,26 @@ async function releaseProxySpendReservation(
 
 let checkProxySpendLimitForHandler = checkProxySpendLimit;
 let resolveProxyHostForHandler = dnsLookup;
-const MAX_LLM_SPEND_TRACKING_BODY_BYTES = Number(
-  process.env.STEWARD_PROXY_MAX_SPEND_BODY_BYTES ?? 1024 * 1024,
+const MAX_LLM_SPEND_TRACKING_BODY_BYTES = boundedPositiveIntegerEnv(
+  "STEWARD_PROXY_MAX_SPEND_BODY_BYTES",
+  1024 * 1024,
+  100 * 1024 * 1024,
 );
-const PROXY_IDEMPOTENCY_TTL_MS = Number(
-  process.env.STEWARD_PROXY_IDEMPOTENCY_TTL_MS ?? 24 * 60 * 60 * 1000,
+const PROXY_IDEMPOTENCY_TTL_MS = boundedPositiveIntegerEnv(
+  "STEWARD_PROXY_IDEMPOTENCY_TTL_MS",
+  24 * 60 * 60 * 1000,
+  30 * 24 * 60 * 60 * 1000,
 );
-const MAX_PROXY_IDEMPOTENCY_BODY_BYTES = Number(
-  process.env.STEWARD_PROXY_IDEMPOTENCY_BODY_BYTES ?? 2 * 1024 * 1024,
+const MAX_PROXY_IDEMPOTENCY_BODY_BYTES = boundedPositiveIntegerEnv(
+  "STEWARD_PROXY_IDEMPOTENCY_BODY_BYTES",
+  2 * 1024 * 1024,
+  100 * 1024 * 1024,
 );
-const PROXY_UPSTREAM_TIMEOUT_MS = Number(process.env.STEWARD_PROXY_UPSTREAM_TIMEOUT_MS ?? 30_000);
+const PROXY_UPSTREAM_TIMEOUT_MS = boundedPositiveIntegerEnv(
+  "STEWARD_PROXY_UPSTREAM_TIMEOUT_MS",
+  30_000,
+  5 * 60_000,
+);
 /**
  * SEC-100: proxy resource limits fail closed — they cannot be disabled. A `0`
  * (or garbage) env value previously meant "unlimited", silently removing the
@@ -304,33 +314,25 @@ const PROXY_UPSTREAM_TIMEOUT_MS = Number(process.env.STEWARD_PROXY_UPSTREAM_TIME
  * misconfiguration. Reject non-positive / non-integer values at startup
  * (module load) instead.
  */
-function positiveLimitFromEnv(name: string, fallback: number): number {
-  const raw = process.env[name];
-  if (raw === undefined || raw.trim() === "") return fallback;
-  const value = Number(raw);
-  if (!Number.isInteger(value) || value <= 0) {
-    throw new Error(
-      `${name} must be a positive integer (got ${JSON.stringify(raw)}); ` +
-        "proxy resource limits fail closed and cannot be disabled",
-    );
-  }
-  return value;
-}
-const MAX_PROXY_RESPONSE_BYTES = positiveLimitFromEnv(
+const MAX_PROXY_RESPONSE_BYTES = boundedPositiveIntegerEnv(
   "STEWARD_PROXY_RESPONSE_BYTES",
   25 * 1024 * 1024,
+  100 * 1024 * 1024,
 );
-const MAX_PROXY_STREAM_DURATION_MS = positiveLimitFromEnv(
+const MAX_PROXY_STREAM_DURATION_MS = boundedPositiveIntegerEnv(
   "STEWARD_PROXY_STREAM_DURATION_MS",
   5 * 60_000,
+  30 * 60_000,
 );
-let MAX_PROXY_IN_FLIGHT_PER_AGENT = positiveLimitFromEnv(
+let MAX_PROXY_IN_FLIGHT_PER_AGENT = boundedPositiveIntegerEnv(
   "STEWARD_PROXY_MAX_IN_FLIGHT_PER_AGENT",
   50,
+  10_000,
 );
-let MAX_PROXY_IN_FLIGHT_PER_TENANT = positiveLimitFromEnv(
+let MAX_PROXY_IN_FLIGHT_PER_TENANT = boundedPositiveIntegerEnv(
   "STEWARD_PROXY_MAX_IN_FLIGHT_PER_TENANT",
   250,
+  100_000,
 );
 const IDEMPOTENCY_KEY_RE = /^[\x21-\x7e]{8,255}$/;
 const SAFE_PROXY_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -16,7 +16,7 @@ import { validateJwtSecretEnv } from "@stwd/auth";
 import { metricsTokenIsValid, renderSecurityMetrics, securityMetricsEnabled } from "@stwd/shared";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
-import { PROXY_PORT } from "./config";
+import { configuredProxyCorsOrigins, PROXY_PORT } from "./config";
 import { getAliasNames } from "./handlers/alias";
 import { handleProxy } from "./handlers/proxy";
 import { handlePendingProxyRequest, listPendingProxyRequests } from "./handlers/release";
@@ -45,10 +45,7 @@ const app = new Hono();
 // leaked token cross-origin from browser JS). Set STEWARD_PROXY_CORS_ORIGINS
 // (comma-separated) only if a browser client genuinely needs cross-origin
 // access.
-const corsOrigins = (process.env.STEWARD_PROXY_CORS_ORIGINS ?? "")
-  .split(",")
-  .map((origin) => origin.trim())
-  .filter(Boolean);
+const corsOrigins = configuredProxyCorsOrigins();
 if (corsOrigins.length > 0) {
   app.use("*", cors({ origin: corsOrigins }));
 }

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -40,18 +40,28 @@ createDb(dbUrl);
 
 const app = new Hono();
 
-// CORS — allow all origins for now (agents call from Docker network)
-app.use("*", cors());
+// SEC-174: agents are server-side callers, so CORS is OFF by default — a
+// wildcard origin lets any website drive unauthenticated probes (and use a
+// leaked token cross-origin from browser JS). Set STEWARD_PROXY_CORS_ORIGINS
+// (comma-separated) only if a browser client genuinely needs cross-origin
+// access.
+const corsOrigins = (process.env.STEWARD_PROXY_CORS_ORIGINS ?? "")
+  .split(",")
+  .map((origin) => origin.trim())
+  .filter(Boolean);
+if (corsOrigins.length > 0) {
+  app.use("*", cors({ origin: corsOrigins }));
+}
 
 // ─── Health check (unauthenticated) ──────────────────────────────────────────
 
+// SEC-174: keep the unauthenticated response minimal — no service version or
+// alias list (recon details). The API readiness probe only reads serverTime.
 app.get("/health", (c) =>
   c.json({
     ok: true,
     service: "steward-proxy",
-    version: "0.3.0",
     serverTime: new Date().toISOString(),
-    aliases: getAliasNames(),
   }),
 );
 

--- a/packages/proxy/src/middleware/auth.ts
+++ b/packages/proxy/src/middleware/auth.ts
@@ -8,7 +8,7 @@
 import { assertTokenNotRevoked, verifyToken } from "@stwd/auth";
 import { agents, and, eq, getDb } from "@stwd/db";
 import type { Context, Next } from "hono";
-import { isProxyDevMode, PROXY_SCOPE } from "../config";
+import { boundedPositiveIntegerEnv, isProxyDevMode, PROXY_SCOPE } from "../config";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -23,8 +23,10 @@ export interface AgentClaims {
 
 const SIGNATURE_PREFIX = "v1=";
 const MAX_SIGNATURE_AGE_MS = 5 * 60_000;
-const MAX_SIGNED_PROXY_BODY_BYTES = Number(
-  process.env.STEWARD_PROXY_SIGNED_BODY_BYTES ?? 2 * 1024 * 1024,
+const MAX_SIGNED_PROXY_BODY_BYTES = boundedPositiveIntegerEnv(
+  "STEWARD_PROXY_SIGNED_BODY_BYTES",
+  2 * 1024 * 1024,
+  100 * 1024 * 1024,
 );
 
 function proxyRequestSignatureRequired(): boolean {

--- a/packages/proxy/src/middleware/auth.ts
+++ b/packages/proxy/src/middleware/auth.ts
@@ -8,7 +8,7 @@
 import { assertTokenNotRevoked, verifyToken } from "@stwd/auth";
 import { agents, and, eq, getDb } from "@stwd/db";
 import type { Context, Next } from "hono";
-import { isProxyDevMode, PROXY_SCOPE } from "../config";
+import { isProxyDevMode, PROXY_SCOPE, positiveIntegerEnv } from "../config";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -23,8 +23,9 @@ export interface AgentClaims {
 
 const SIGNATURE_PREFIX = "v1=";
 const MAX_SIGNATURE_AGE_MS = 5 * 60_000;
-const MAX_SIGNED_PROXY_BODY_BYTES = Number(
-  process.env.STEWARD_PROXY_SIGNED_BODY_BYTES ?? 2 * 1024 * 1024,
+const MAX_SIGNED_PROXY_BODY_BYTES = positiveIntegerEnv(
+  "STEWARD_PROXY_SIGNED_BODY_BYTES",
+  2 * 1024 * 1024,
 );
 
 function proxyRequestSignatureRequired(): boolean {

--- a/packages/proxy/src/middleware/auth.ts
+++ b/packages/proxy/src/middleware/auth.ts
@@ -8,7 +8,7 @@
 import { assertTokenNotRevoked, verifyToken } from "@stwd/auth";
 import { agents, and, eq, getDb } from "@stwd/db";
 import type { Context, Next } from "hono";
-import { PROXY_SCOPE } from "../config";
+import { isProxyDevMode, PROXY_SCOPE } from "../config";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -28,10 +28,13 @@ const MAX_SIGNED_PROXY_BODY_BYTES = Number(
 );
 
 function proxyRequestSignatureRequired(): boolean {
-  return (
-    process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE === "true" ||
-    process.env.NODE_ENV === "production"
-  );
+  if (process.env.STEWARD_PROXY_REQUIRE_REQUEST_SIGNATURE === "true") return true;
+  // SEC-175: default-deny. Unsigned requests are allowed only with an
+  // explicit dev-mode opt-in — never silently because NODE_ENV is unset.
+  // An explicit production NODE_ENV overrides even the opt-in, so a stray
+  // STEWARD_PROXY_DEV_MODE can never weaken a production deployment.
+  if (process.env.NODE_ENV === "production") return true;
+  return !isProxyDevMode();
 }
 
 function configuredProxySigningSecrets(): string[] {

--- a/packages/proxy/src/middleware/redis-enforcement.ts
+++ b/packages/proxy/src/middleware/redis-enforcement.ts
@@ -22,7 +22,7 @@ import {
   settleReservedSpend,
 } from "@stwd/redis";
 import { and, eq } from "drizzle-orm";
-import { isProxyDevMode } from "../config";
+import { isProxyDevMode, positiveIntegerEnv } from "../config";
 
 // ─── State ───────────────────────────────────────────────────────────────────
 
@@ -65,16 +65,6 @@ export async function shutdownProxyRedis(): Promise<void> {
 }
 
 // ─── Default rate limits for proxy (per-agent per-host) ──────────────────────
-
-function positiveIntegerEnv(name: string, fallback: number): number {
-  const raw = process.env[name];
-  if (raw === undefined || raw.trim() === "") return fallback;
-  const value = Number(raw);
-  if (!Number.isInteger(value) || value <= 0) {
-    throw new Error(`${name} must be a positive integer`);
-  }
-  return value;
-}
 
 const DEFAULT_PROXY_RATE_LIMIT_WINDOW_MS = positiveIntegerEnv(
   "STEWARD_PROXY_RATE_LIMIT_WINDOW_MS",

--- a/packages/proxy/src/middleware/redis-enforcement.ts
+++ b/packages/proxy/src/middleware/redis-enforcement.ts
@@ -22,7 +22,7 @@ import {
   settleReservedSpend,
 } from "@stwd/redis";
 import { and, eq } from "drizzle-orm";
-import { isProxyDevMode } from "../config";
+import { boundedPositiveIntegerEnv, isProxyDevMode } from "../config";
 
 // ─── State ───────────────────────────────────────────────────────────────────
 
@@ -66,21 +66,16 @@ export async function shutdownProxyRedis(): Promise<void> {
 
 // ─── Default rate limits for proxy (per-agent per-host) ──────────────────────
 
-function positiveIntegerEnv(name: string, fallback: number): number {
-  const raw = process.env[name];
-  if (raw === undefined || raw.trim() === "") return fallback;
-  const value = Number(raw);
-  if (!Number.isInteger(value) || value <= 0) {
-    throw new Error(`${name} must be a positive integer`);
-  }
-  return value;
-}
-
-const DEFAULT_PROXY_RATE_LIMIT_WINDOW_MS = positiveIntegerEnv(
+const DEFAULT_PROXY_RATE_LIMIT_WINDOW_MS = boundedPositiveIntegerEnv(
   "STEWARD_PROXY_RATE_LIMIT_WINDOW_MS",
   60_000,
+  24 * 60 * 60 * 1000,
 );
-const DEFAULT_PROXY_RATE_LIMIT_MAX = positiveIntegerEnv("STEWARD_PROXY_RATE_LIMIT_MAX", 60);
+const DEFAULT_PROXY_RATE_LIMIT_MAX = boundedPositiveIntegerEnv(
+  "STEWARD_PROXY_RATE_LIMIT_MAX",
+  60,
+  1_000_000,
+);
 
 const PERMISSIVE: RateLimitResult = {
   allowed: true,

--- a/packages/proxy/src/middleware/redis-enforcement.ts
+++ b/packages/proxy/src/middleware/redis-enforcement.ts
@@ -22,6 +22,7 @@ import {
   settleReservedSpend,
 } from "@stwd/redis";
 import { and, eq } from "drizzle-orm";
+import { isProxyDevMode } from "../config";
 
 // ─── State ───────────────────────────────────────────────────────────────────
 
@@ -75,11 +76,17 @@ const PERMISSIVE: RateLimitResult = {
 };
 
 function isRedisRequired(): boolean {
-  return (
-    process.env.REDIS_REQUIRED === "true" ||
-    (process.env.NODE_ENV === "production" &&
-      process.env.STEWARD_ALLOW_PROXY_REDIS_SOFT_FAIL !== "true")
-  );
+  if (process.env.REDIS_REQUIRED === "true") return true;
+  // Explicit operator opt-out, honored in every environment (as before
+  // SEC-175) — but an explicit production NODE_ENV still overrides a stray
+  // STEWARD_PROXY_DEV_MODE below.
+  if (process.env.STEWARD_ALLOW_PROXY_REDIS_SOFT_FAIL === "true") return false;
+  // SEC-175: default-deny — Redis enforcement is required in every
+  // environment unless the operator explicitly opts into the soft
+  // development posture. NODE_ENV alone no longer unlocks it, and a
+  // production NODE_ENV overrides the dev-mode flag.
+  if (process.env.NODE_ENV === "production") return true;
+  return !isProxyDevMode();
 }
 
 /**

--- a/packages/proxy/src/middleware/redis-enforcement.ts
+++ b/packages/proxy/src/middleware/redis-enforcement.ts
@@ -66,8 +66,21 @@ export async function shutdownProxyRedis(): Promise<void> {
 
 // ─── Default rate limits for proxy (per-agent per-host) ──────────────────────
 
-const DEFAULT_PROXY_RATE_LIMIT_WINDOW_MS = 60_000; // 1 minute
-const DEFAULT_PROXY_RATE_LIMIT_MAX = 60; // 60 requests/minute per agent per host
+function positiveIntegerEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") return fallback;
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return value;
+}
+
+const DEFAULT_PROXY_RATE_LIMIT_WINDOW_MS = positiveIntegerEnv(
+  "STEWARD_PROXY_RATE_LIMIT_WINDOW_MS",
+  60_000,
+);
+const DEFAULT_PROXY_RATE_LIMIT_MAX = positiveIntegerEnv("STEWARD_PROXY_RATE_LIMIT_MAX", 60);
 
 const PERMISSIVE: RateLimitResult = {
   allowed: true,

--- a/packages/redis/src/__tests__/spend-tracker.test.ts
+++ b/packages/redis/src/__tests__/spend-tracker.test.ts
@@ -180,4 +180,30 @@ describeRedis("Spend Tracker", () => {
     expect(settled.reserved).toBe(0);
     expect(settled.remaining).toBeCloseTo(0.75, 4);
   });
+
+  test("a double-settle floors reserved at zero instead of freeing budget (SEC-168)", async () => {
+    const reservation = await reserveSpend(TEST_AGENT, TEST_TENANT, 0.4, { day: 1 });
+
+    // Settle twice: the second call is a caller bug, and it must NOT drive
+    // `reserved` negative — that would subtract from the effective spend and
+    // silently hand back budget the agent never had.
+    for (let i = 0; i < 2; i++) {
+      await settleReservedSpend(
+        TEST_AGENT,
+        TEST_TENANT,
+        reservation.reservedUsd,
+        0.25,
+        "api.openai.com",
+        reservation.periods,
+        reservation.buckets,
+      );
+    }
+
+    const snap = await checkSpendLimit(TEST_AGENT, 1, "day");
+    expect(snap.reserved).toBe(0);
+    // effectiveSpent = spent + reserved must not dip below the settled total.
+    expect(snap.effectiveSpent).toBeCloseTo(0.5, 4);
+    // And the limit gate must treat the agent as having spent, not gained.
+    expect(snap.remaining).toBeCloseTo(0.5, 4);
+  });
 });

--- a/packages/redis/src/__tests__/upstash-adapter.test.ts
+++ b/packages/redis/src/__tests__/upstash-adapter.test.ts
@@ -147,3 +147,35 @@ describe("upstash adapter — getdel (issue #100)", () => {
     );
   });
 });
+
+describe("upstash adapter — pipeline eval (SEC-168)", () => {
+  test("pipeline eval maps ioredis positional args to Upstash keys/args arrays", async () => {
+    // Minimal fake: record how the underlying Upstash pipeline is driven.
+    const calls: unknown[] = [];
+    const fakePipeline = {
+      eval(script: string, keys: string[], args: string[]) {
+        calls.push({ script, keys, args });
+        return fakePipeline;
+      },
+      async exec() {
+        return [42];
+      },
+    };
+    const client = {
+      multi() {
+        return fakePipeline;
+      },
+    } as unknown as UpstashRedis;
+
+    const adapter = createUpstashIoredisAdapter(client);
+    const pipeline = adapter.multi();
+    pipeline.eval("return 42", 1, "spend:agent:day:2026-01-01", "4000");
+    const results = await pipeline.exec();
+
+    expect(calls).toEqual([
+      { script: "return 42", keys: ["spend:agent:day:2026-01-01"], args: ["4000"] },
+    ]);
+    // ioredis-style [err, value] tuples.
+    expect(results).toEqual([[null, 42]]);
+  });
+});

--- a/packages/redis/src/spend-tracker.ts
+++ b/packages/redis/src/spend-tracker.ts
@@ -53,6 +53,20 @@ redis.call('EXPIRE', KEYS[1], tonumber(ARGV[4]))
 return {1, settled, after}
 `;
 
+// ARGV: releaseUnits. Returns reservedAfter.
+// Decrement `reserved` but FLOOR AT ZERO: a double-settle (caller bug) must
+// not drive the field negative — a negative `reserved` would subtract from
+// the effective spend in checkSpendLimit/reserveSpend and silently free
+// budget (fail-open). SEC-168. Atomic so a concurrent reserve cannot observe
+// a transient negative either.
+const SETTLE_RESERVED_LUA = `
+local release = tonumber(ARGV[1])
+local current = tonumber(redis.call('HGET', KEYS[1], 'reserved') or '0')
+local after = math.max(0, current - release)
+redis.call('HSET', KEYS[1], 'reserved', after)
+return after
+`;
+
 /**
  * Get the date key for a given period.
  * - day:   "2026-03-27"
@@ -269,7 +283,8 @@ export async function settleReservedSpend(
   const pipeline = redis.multi();
 
   for (const { period, key } of settlementBuckets) {
-    pipeline.hincrby(key, "reserved", -reservedUnits);
+    // SEC-168: clamped Lua decrement — never let `reserved` go negative.
+    pipeline.eval(SETTLE_RESERVED_LUA, 1, key, String(reservedUnits));
     if (actualUnits > 0) {
       pipeline.hincrby(key, "total", actualUnits);
       pipeline.hincrby(key, `host:${host}`, actualUnits);

--- a/packages/redis/src/upstash-adapter.ts
+++ b/packages/redis/src/upstash-adapter.ts
@@ -86,6 +86,12 @@ export interface IoredisPipelineLike {
   hset(key: string, field: string, value: string): IoredisPipelineLike;
   expire(key: string, ttlSeconds: number): IoredisPipelineLike;
   /**
+   * Queue a server-side Lua script inside the transaction. ioredis positional
+   * form (numKeys, ...keysThenArgs) — the Upstash implementation maps it to
+   * (script, keys[], args[]). Used by the spend-tracker settle clamp.
+   */
+  eval(script: string, numKeys: number, ...args: (string | number)[]): IoredisPipelineLike;
+  /**
    * Returns ioredis-style [err, value] tuples for each queued command, in
    * order. Errors are swallowed into the per-command tuple so callers see
    * `null` in the err slot on success and an Error instance on failure.
@@ -139,6 +145,14 @@ class UpstashPipeline implements IoredisPipelineLike {
 
   expire(key: string, ttlSeconds: number): IoredisPipelineLike {
     this.ops.push((m) => m.expire(key, ttlSeconds));
+    return this;
+  }
+
+  eval(script: string, numKeys: number, ...args: (string | number)[]): IoredisPipelineLike {
+    // Same positional→array mapping as the client-level eval below.
+    const keys = args.slice(0, numKeys).map(String);
+    const argv = args.slice(numKeys).map(String);
+    this.ops.push((m) => m.eval(script, keys, argv));
     return this;
   }
 

--- a/packages/shared/src/__tests__/provider-action-canon.test.ts
+++ b/packages/shared/src/__tests__/provider-action-canon.test.ts
@@ -415,6 +415,18 @@ describe("jcsStringify rejects non-JSON runtime values", () => {
   });
   it("non-integer runtime number", () =>
     expectCanon(() => jcsStringify({ a: 1.5 }), "CANON_RUNTIME_VALUE_UNSUPPORTED"));
+  it("accessor property — getter is rejected, never invoked (SEC-191)", () => {
+    let getterRan = false;
+    const exotic = Object.defineProperty({}, "a", {
+      enumerable: true,
+      get() {
+        getterRan = true;
+        return 1;
+      },
+    });
+    expectCanon(() => jcsStringify(exotic), "CANON_RUNTIME_VALUE_UNSUPPORTED");
+    expect(getterRan).toBe(false);
+  });
 });
 
 describe("jcs key ordering (UTF-16 code units)", () => {

--- a/packages/shared/src/__tests__/webhook-event-registry.test.ts
+++ b/packages/shared/src/__tests__/webhook-event-registry.test.ts
@@ -1,0 +1,36 @@
+/**
+ * SEC-192: describeContributions() builds its result with a null-prototype
+ * object so a plugin literally named "__proto__" cannot vanish — assigning
+ * `out["__proto__"]` on a plain {} sets the prototype instead of an own
+ * property, silently dropping the plugin from JSON diagnostics.
+ */
+import { describe, expect, it } from "bun:test";
+import { WebhookEventRegistry } from "../webhook-event-registry";
+
+describe("WebhookEventRegistry.describeContributions (SEC-192)", () => {
+  it('a plugin named "__proto__" survives as an own property', () => {
+    const registry = new WebhookEventRegistry(["core.event"]);
+    registry.registerPluginEvents("__proto__", ["odd.event"]);
+    registry.registerPluginEvents("normal-plugin", ["normal.event"]);
+
+    const contributions = registry.describeContributions();
+
+    expect(Object.hasOwn(contributions, "__proto__")).toBe(true);
+    expect(contributions["__proto__" as keyof typeof contributions]).toEqual(["odd.event"]);
+    expect(contributions["normal-plugin"]).toEqual(["normal.event"]);
+    // And the result survives the JSON diagnostics round-trip intact.
+    expect(JSON.parse(JSON.stringify(contributions))).toEqual({
+      __proto__: ["odd.event"],
+      "normal-plugin": ["normal.event"],
+    });
+  });
+
+  it("registry lookups are unaffected by the __proto__ plugin name", () => {
+    const registry = new WebhookEventRegistry(["core.event"]);
+    registry.registerPluginEvents("__proto__", ["odd.event"]);
+
+    expect(registry.has("core.event")).toBe(true);
+    expect(registry.has("odd.event")).toBe(true);
+    expect(registry.has("missing.event")).toBe(false);
+  });
+});

--- a/packages/shared/src/provider-action.ts
+++ b/packages/shared/src/provider-action.ts
@@ -591,7 +591,18 @@ function serializeObject(obj: Record<string, unknown>): string {
   const keys = Object.keys(obj).sort(compareUtf16);
   const parts: string[] = [];
   for (const k of keys) {
-    const val = obj[k];
+    // Read via the property descriptor, NOT obj[k]: an accessor property
+    // would run user code, and a value-changing getter could desync
+    // mint-vs-verify digests. SEC-191: the header contract rejects getter
+    // side effects — enforce it instead of invoking them (fail closed).
+    const desc = Object.getOwnPropertyDescriptor(obj, k);
+    if (!desc || desc.get !== undefined || desc.set !== undefined) {
+      fail(
+        "CANON_RUNTIME_VALUE_UNSUPPORTED",
+        `member '${k}' is an accessor property (getter side effects are rejected)`,
+      );
+    }
+    const val = desc.value;
     // JCS drops nothing: an explicit `undefined` member is a runtime error here
     // (it is not a JSON value). Members we intend to omit must be omitted by the
     // builder, never present-as-undefined.

--- a/packages/shared/src/sensitive-keys.ts
+++ b/packages/shared/src/sensitive-keys.ts
@@ -65,6 +65,20 @@ const SENSITIVE_CREDENTIAL_KEY_DECORATORS = ["header", "value", "pem"];
 const PRIVATE_KEY_ARMOR =
   /-----BEGIN (?:ENCRYPTED |RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----|-----BEGIN PGP PRIVATE KEY BLOCK-----/;
 
+/**
+ * Lowercase and strip every non-[a-z0-9] character so carrier names compare
+ * punctuation/case-insensitively ("X-API-Key" → "xapikey").
+ *
+ * KNOWN LIMITATION (SEC-194): non-ASCII lookalike key names evade this
+ * heuristic — e.g. Cyrillic `secrеt` normalizes to `secrt` (the Cyrillic
+ * letters are stripped, not folded), which matches no sensitive key. This is
+ * accepted residual risk: the heuristic is a defense-in-depth canary for
+ * diagnostics/redaction, not the credential boundary — credential-carrying
+ * headers are separately forbidden outright, and actual credential injection
+ * flows only through the vault's allowlisted routes. Do not widen this into a
+ * security-critical gate without adding confusable folding (e.g. NFKC +
+ * skeleton mapping) first.
+ */
 function normalizeSensitiveKey(key: string): string {
   return key.toLowerCase().replace(/[^a-z0-9]/g, "");
 }

--- a/packages/shared/src/webhook-event-registry.ts
+++ b/packages/shared/src/webhook-event-registry.ts
@@ -84,7 +84,10 @@ export class WebhookEventRegistry {
    * contribute" surface.
    */
   describeContributions(): Record<string, string[]> {
-    const out: Record<string, string[]> = {};
+    // SEC-192: null-prototype — a plugin literally named "__proto__" assigned
+    // through a plain object literal would set the prototype and silently
+    // vanish from JSON diagnostics.
+    const out: Record<string, string[]> = Object.create(null);
     for (const [plugin, names] of this.pluginEvents) {
       out[plugin] = [...names].sort();
     }


### PR DESCRIPTION
# Security wave 2b — deferred LOW/INFO remainder (batch: misc)

Final wave-2 batch covering the deferred LOW and INFO findings assigned to the
"misc" batch. Wave-2 HIGH/MEDIUM fixes are already merged; this builds on them.

## Status

| SEC ID | Severity | Status | Summary |
|---|---|---|---|
| SEC-087 | LOW | **FIXED** | Production now REJECTS `sslmode=require` (postgres-js treats it as TLS without peer verification) and steers to `verify-full`/`verify-ca`; `STEWARD_ALLOW_UNVERIFIED_DB_TLS=true` is the explicit risk-acknowledgement escape hatch for legacy providers. (Escalated from the initial warn-only fix during PR review — commit 909c84d7.) |
| SEC-089 | LOW | **FIXED** | Audit metadata is normalized through the same `canonicalJsonValue` for both the HMAC preimage and the INSERT, so a stored row can always re-canonicalize to its written HMAC (previously `undefined`-valued keys broke chain verification from that seq onward). |
| SEC-090 | LOW | **FIXED** | PGLite data directory created `mode: 0o700`, and existing dirs are chmodded to owner-only. |
| SEC-097 | LOW | **FIXED** | Outbound header blocklist extended: `x-client-ip`, `cf-connecting-ip`, `true-client-ip`, `fastly-client-ip`, `x-cluster-client-ip`, `x-original-forwarded-for`. |
| SEC-098 | LOW | **FIXED** | `set-cookie` stripped from upstream responses on credential-injected routes so agents never receive credential-derived session tokens. |
| SEC-099 | LOW | **FIXED** | `x-steward-request-timestamp` / `x-steward-request-expires-at` stripped before forwarding. |
| SEC-100 | LOW | **FIXED** | Proxy limit env vars (`STEWARD_PROXY_RESPONSE_BYTES`, stream duration, in-flight caps) reject `0`/invalid values at startup with a clear error — limits can no longer be silently disabled; default response cap lowered to 25 MB. |
| SEC-166 | INFO | **FIXED** | CLOUDFLARE.md reconciled with reality: the audit chain *does* take `pg_advisory_xact_lock` on every non-PGLite append. On Workers, drizzle's neon-http driver throws `No transactions support in neon-http driver` from `db.transaction()`, so audited writes reject before lock or INSERT — they **fail closed**, never silently skip the chain. Pinned by a Workers-path test that deliberately breaks if a drizzle upgrade adds neon-http transactions (forcing re-review). |
| SEC-167 | INFO | **FIXED** | `isAuditSequenceConflict` no longer retries on the bare `23505` SQLSTATE or generic duplicate-key text — only serialization failures (`40001`) and conflicts naming `audit_events_tenant_seq_idx`. A caller's own unique violation inside the audited transaction now propagates immediately instead of 5 wasted retries. |
| SEC-168 | INFO | **FIXED** | `settleReservedSpend` decrements `reserved` through a Lua clamp (`max(0, current − release)`) — a double-settle can no longer drive it negative and silently free budget. Atomic with the read; `IoredisPipelineLike.eval` added (Upstash mapping covered by test). |
| SEC-169 | INFO | **PARTIAL / DECISION** | Tenant isolation remains application-layer only (no Postgres RLS). Full RLS enablement halfway is worse than none; the four preconditions (per-request `app.tenant_id` GUC discipline, `FORCE RLS` + break-glass role, cross-tenant-read policy matrix, PGLite/Workers parity) are now documented at the top of `schema.ts` as the rollout contract. No schema change. |
| SEC-174 | INFO | **FIXED** | Wildcard CORS removed — the proxy sends no CORS headers unless `STEWARD_PROXY_CORS_ORIGINS` lists explicit origins (agents are server-side callers). `/health` no longer discloses version or the route alias list; the API readiness probe only reads `serverTime` (verified). |
| SEC-175 | INFO | **FIXED** | Fail-closed by default in every environment: request signing, Redis rate limiting, and the shared replay store are REQUIRED unless `STEWARD_PROXY_DEV_MODE=true` explicitly opts into the soft dev posture (set by `docker-compose.dev.yml`, documented in `.env.example`). `NODE_ENV=production` overrides the dev flag, so a stray opt-in can never weaken production; `STEWARD_ALLOW_PROXY_REDIS_SOFT_FAIL` keeps its pre-existing explicit opt-out semantics. |
| SEC-176 | INFO | **FIXED** | Unknown `injectAs` now fails closed with a 400 config error instead of forwarding upstream with no credential. |
| SEC-191 | INFO | **FIXED** | JCS `serializeObject` reads members via `Object.getOwnPropertyDescriptor` and rejects accessor properties with `CANON_RUNTIME_VALUE_UNSUPPORTED` — getters are never invoked, matching the documented contract (prevents mint-vs-verify digest desync from value-changing getters). |
| SEC-192 | INFO | **FIXED** | `describeContributions()` builds its result with `Object.create(null)`; a plugin literally named `__proto__` no longer vanishes from JSON diagnostics. |
| SEC-194 | INFO | **FIXED** (docs) | Documented on `normalizeSensitiveKey`: non-ASCII lookalike key names (e.g. Cyrillic `secrеt`) evade the credential-carrier heuristic — accepted residual risk for a defense-in-depth canary, with the actual credential boundary (forbidden credential headers, vault-allowlisted injection) noted. |

## Trade-offs / decisions

- **SEC-087 (warn-not-reject):** `sslmode=require` is still accepted in production because hard rejection breaks existing deployments; the warning steers operators to `verify-full`. Cutover to rejection is a product decision, flagged in code.
- **SEC-175 (behavior change):** deployments running the proxy outside `NODE_ENV=production` *without* Redis/signing config will now fail closed at request time. This is the intended posture change from the audit; the explicit escape hatch is `STEWARD_PROXY_DEV_MODE=true` (dev compose updated). `NODE_ENV=production` always wins over the dev flag.
- **SEC-174 (CORS off by default):** any browser client calling the proxy cross-origin now needs `STEWARD_PROXY_CORS_ORIGINS`. No in-repo consumer does (agents and the API probe are server-side).
- **SEC-169 (documented, not implemented):** RLS requires a coherent migration (GUC discipline + FORCE + break-glass role + runtime parity); shipping half is worse than none. Documented as the rollout contract instead.

## How tested

- `packages/db`: **92/92 pass** (`bun test`), incl. new `audit-chain-retry.test.ts` (SEC-167: no retry on caller's own 23505; retries on seq-index race/40001; retry-then-commit) and `audit-chain-workers.test.ts` (SEC-166: neon-http transactions throw → audited writes fail closed). `tsc --noEmit` clean.
- `packages/redis`: **81/81 pass** with a live throwaway Redis (`STEWARD_REDIS_TESTS=1`, container removed after), incl. new double-settle floor-at-zero regression (SEC-168) and Upstash pipeline-`eval` arg-mapping test. Gated suites skip cleanly without a server. `tsc --noEmit` clean.
- `packages/shared`: **429/429 pass**, incl. new SEC-191 accessor-rejection test (getter never invoked) and SEC-192 `__proto__` plugin-name tests. `tsc --noEmit` clean.
- `packages/proxy`: suite **192 pass / 35 fail — identical to the pre-existing baseline on `origin/develop`** (same 35 failures, confirmed by stash-compare before/after; they are cross-file env-pollution artifacts — e.g. PR4/query-preservation/spend-limit files — plus `proxy-approval-lifecycle` / `proxy-approval-expiry-audit-atomicity`, which fail in isolation on develop too). New SEC-175 regression test added; the 4 strict-posture test files now set `STEWARD_PROXY_DEV_MODE` explicitly. `tsc --noEmit` clean.
- `packages/api`: `audit-chain-strict` (SEC-089) and `plugin-host` (SEC-192 consumer) pass; `tsc --noEmit` clean.
- `bunx biome check` on all 31 changed TS files: clean.

### Pre-existing failures (not caused by this PR)

The 35 proxy full-suite failures above pre-date this branch on `origin/develop`
(verified by running the suite with all branch changes stashed). Individual
files pass in isolation except `proxy-approval-lifecycle` and
`proxy-approval-expiry-audit-atomicity`, which fail on develop as-is.

## Post-review follow-ups on this branch

After the initial push, the automated review loop landed additional hardening
on top of the commits above (all assigned-ID statuses unchanged):

- `909c84d7` fix(db): require authenticated production TLS — SEC-087 escalated
  from warn to reject (row above updated).
- `b8c70e83` fix(security): complete proxy fail-closed hardening — extends
  SEC-175 with config-security test coverage and PGLite permission assertions.
- `60722d0e` fix(proxy): bound every resource-limit setting — extends the
  SEC-100 startup validation to the remaining proxy limit env vars.
- `749b8d58` / `f9ed3ec8` — test/CI posture wiring for the fail-closed
  defaults (explicit STEWARD_PROXY_DEV_MODE in CI jobs and fixtures).
- Branch merged with develop (`f6a0c614`), pulling in the other wave-2b batch
  PRs (#328 infra/scripts, #329 plugins, #330 vault).
