### PR TITLE
feat(solana-signer): Steward-governed Solana signer + loopback bridge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,7 @@ jobs:
           - packages/plugin-wxmr
           - packages/plugin-trading
           - packages/plugin-capabilities
+          - packages/solana-signer
           - packages/trade-sessions
           # packages/signer-frost is intentionally absent: its test harness
           # builds the Rust sidecar via `cargo build --release` and this job

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -185,6 +185,7 @@ jobs:
           - packages/plugin-wxmr
           - packages/plugin-trading
           - packages/plugin-capabilities
+          - packages/solana-signer
           - packages/trade-sessions
           # packages/signer-frost is intentionally absent: its test harness
           # builds the Rust sidecar via `cargo build --release` and this job

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,7 @@ COPY packages/redis/package.json             packages/redis/package.json
 COPY packages/seed/package.json              packages/seed/package.json
 COPY packages/shared/package.json            packages/shared/package.json
 COPY packages/signer-frost/package.json      packages/signer-frost/package.json
+COPY packages/solana-signer/package.json     packages/solana-signer/package.json
 COPY packages/sdk/package.json               packages/sdk/package.json
 COPY packages/trade-sessions/package.json    packages/trade-sessions/package.json
 COPY packages/vault/package.json             packages/vault/package.json
@@ -114,6 +115,7 @@ COPY packages/redis/package.json             packages/redis/package.json
 COPY packages/seed/package.json              packages/seed/package.json
 COPY packages/shared/package.json            packages/shared/package.json
 COPY packages/signer-frost/package.json      packages/signer-frost/package.json
+COPY packages/solana-signer/package.json     packages/solana-signer/package.json
 COPY packages/sdk/package.json               packages/sdk/package.json
 COPY packages/trade-sessions/package.json    packages/trade-sessions/package.json
 COPY packages/vault/package.json             packages/vault/package.json
@@ -219,6 +221,7 @@ COPY packages/redis/package.json             packages/redis/package.json
 COPY packages/seed/package.json              packages/seed/package.json
 COPY packages/shared/package.json            packages/shared/package.json
 COPY packages/signer-frost/package.json      packages/signer-frost/package.json
+COPY packages/solana-signer/package.json     packages/solana-signer/package.json
 COPY packages/sdk/package.json               packages/sdk/package.json
 COPY packages/trade-sessions/package.json    packages/trade-sessions/package.json
 COPY packages/vault/package.json             packages/vault/package.json

--- a/bun.lock
+++ b/bun.lock
@@ -266,7 +266,6 @@
       "name": "@stwd/plugin-trading",
       "version": "0.1.0",
       "dependencies": {
-        "@stwd/adapters": "workspace:*",
         "@stwd/db": "workspace:*",
         "@stwd/policy-engine": "workspace:*",
         "@stwd/redis": "workspace:*",
@@ -2183,7 +2182,7 @@
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
-    "camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
+    "camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
     "camelcase-css": ["camelcase-css@2.0.1", "", {}, "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="],
 
@@ -2217,7 +2216,7 @@
 
     "client-only": ["client-only@0.0.1", "", {}, "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="],
 
-    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+    "cliui": ["cliui@9.0.1", "", { "dependencies": { "string-width": "^7.2.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w=="],
 
     "cloudflare": ["cloudflare@4.5.0", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" } }, "sha512-fPcbPKx4zF45jBvQ0z7PCdgejVAPBBCZxwqk1k7krQNfpM07Cfj97/Q6wBzvYqlWXx/zt1S9+m8vnfCe06umbQ=="],
 
@@ -2237,7 +2236,7 @@
 
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
-    "commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
+    "commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
     "comment-json": ["comment-json@4.6.2", "", { "dependencies": { "array-timsort": "^1.0.3", "esprima": "^4.0.1" } }, "sha512-R2rze/hDX30uul4NZoIZ76ImSJLFxn/1/ZxtKC1L77y2X1k+yYu1joKbAtMA2Fg3hZrTOiw0I5mwVMo0cf250w=="],
 
@@ -2377,7 +2376,7 @@
 
     "elliptic": ["elliptic@6.6.1", "", { "dependencies": { "bn.js": "^4.11.9", "brorand": "^1.1.0", "hash.js": "^1.0.0", "hmac-drbg": "^1.0.1", "inherits": "^2.0.4", "minimalistic-assert": "^1.0.1", "minimalistic-crypto-utils": "^1.0.1" } }, "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g=="],
 
-    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "encode-utf8": ["encode-utf8@1.0.3", "", {}, "sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw=="],
 
@@ -3333,7 +3332,7 @@
 
     "strict-uri-encode": ["strict-uri-encode@2.0.0", "", {}, "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ=="],
 
-    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+    "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -3541,7 +3540,7 @@
 
     "wrangler": ["wrangler@4.105.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.28.1", "miniflare": "4.20260625.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260625.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260625.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "cf-wrangler": "bin/cf-wrangler.js", "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-7dXFH6OLj1Fv0y6ZeRPUxFTkp+duWD7/xxVi/1c0vfOeEYwIFKWB7cdqnY05DvY1Ta3BnqAwRkXfLs8PDj538g=="],
 
-    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+    "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
@@ -3573,7 +3572,7 @@
 
     "yaml-ast-parser": ["yaml-ast-parser@0.0.43", "", {}, "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A=="],
 
-    "yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
+    "yargs": ["yargs@18.0.0", "", { "dependencies": { "cliui": "^9.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "string-width": "^7.2.0", "y18n": "^5.0.5", "yargs-parser": "^22.0.0" } }, "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg=="],
 
     "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
@@ -3855,8 +3854,6 @@
 
     "@opennextjs/aws/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
-    "@opennextjs/cloudflare/yargs": ["yargs@18.0.0", "", { "dependencies": { "cliui": "^9.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "string-width": "^7.2.0", "y18n": "^5.0.5", "yargs-parser": "^22.0.0" } }, "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg=="],
-
     "@particle-network/solana-wallet/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
 
     "@polymarket/abstract-signer/ethers": ["ethers@5.7.2", "", { "dependencies": { "@ethersproject/abi": "5.7.0", "@ethersproject/abstract-provider": "5.7.0", "@ethersproject/abstract-signer": "5.7.0", "@ethersproject/address": "5.7.0", "@ethersproject/base64": "5.7.0", "@ethersproject/basex": "5.7.0", "@ethersproject/bignumber": "5.7.0", "@ethersproject/bytes": "5.7.0", "@ethersproject/constants": "5.7.0", "@ethersproject/contracts": "5.7.0", "@ethersproject/hash": "5.7.0", "@ethersproject/hdnode": "5.7.0", "@ethersproject/json-wallets": "5.7.0", "@ethersproject/keccak256": "5.7.0", "@ethersproject/logger": "5.7.0", "@ethersproject/networks": "5.7.1", "@ethersproject/pbkdf2": "5.7.0", "@ethersproject/properties": "5.7.0", "@ethersproject/providers": "5.7.2", "@ethersproject/random": "5.7.0", "@ethersproject/rlp": "5.7.0", "@ethersproject/sha2": "5.7.0", "@ethersproject/signing-key": "5.7.0", "@ethersproject/solidity": "5.7.0", "@ethersproject/strings": "5.7.0", "@ethersproject/transactions": "5.7.0", "@ethersproject/units": "5.7.0", "@ethersproject/wallet": "5.7.0", "@ethersproject/web": "5.7.1", "@ethersproject/wordlists": "5.7.0" } }, "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg=="],
@@ -3874,6 +3871,8 @@
     "@project-serum/sol-wallet-adapter/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
 
     "@project-serum/sol-wallet-adapter/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
+
+    "@react-native/codegen/yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
 
     "@react-native/dev-middleware/serve-static": ["serve-static@1.16.3", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "~0.19.1" } }, "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA=="],
 
@@ -4215,6 +4214,8 @@
 
     "cbw-sdk/preact": ["preact@10.29.3", "", {}, "sha512-D9NL1GAnJZhc3RndVs4gDdxEeU9TcHgywMrhhOsnpdlvFjdbx0gAsLUnH6JEhlJH5giL7Tx5biWPUSEXE/HPzw=="],
 
+    "cliui/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
     "cloudflare/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
 
     "connect/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
@@ -4277,6 +4278,8 @@
 
     "jest-util/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
+    "jest-validate/camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
+
     "jest-validate/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
@@ -4294,6 +4297,8 @@
     "metro/hermes-parser": ["hermes-parser@0.35.0", "", { "dependencies": { "hermes-estree": "0.35.0" } }, "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA=="],
 
     "metro/source-map": ["source-map@0.5.7", "", {}, "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="],
+
+    "metro/yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
 
     "metro-babel-transformer/hermes-parser": ["hermes-parser@0.35.0", "", { "dependencies": { "hermes-estree": "0.35.0" } }, "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA=="],
 
@@ -4327,9 +4332,13 @@
 
     "qrcode.react/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 
+    "react-native/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
+
     "react-native/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 
     "react-native/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "react-native/yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
 
     "react-qr-reader/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 
@@ -4353,9 +4362,11 @@
 
     "stream-browserify/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
-    "string_decoder/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+    "string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
-    "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
+    "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "string_decoder/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "tailwindcss/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
@@ -4385,15 +4396,21 @@
 
     "wif/bs58check": ["bs58check@4.0.0", "", { "dependencies": { "@noble/hashes": "^1.2.0", "bs58": "^6.0.0" } }, "sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g=="],
 
-    "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+    "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "wrap-ansi/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "xml-crypto/xpath": ["xpath@0.0.33", "", {}, "sha512-NNXnzrkDrAzalLhIUc01jO2mOzXGXh1JwPgkihcLLzw98c0WgYDmmjSh1Kl3wzaxSVWMuA+fe0WTWOBDWCBmNA=="],
 
     "xml-encryption/xpath": ["xpath@0.0.32", "", {}, "sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw=="],
 
     "xml2js/xmlbuilder": ["xmlbuilder@11.0.1", "", {}, "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="],
+
+    "yargs/yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
 
     "youch/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
@@ -4721,17 +4738,15 @@
 
     "@metamask/utils/@ethereumjs/tx/@ethereumjs/common": ["@ethereumjs/common@3.2.0", "", { "dependencies": { "@ethereumjs/util": "^8.1.0", "crc-32": "^1.2.0" } }, "sha512-pksvzI0VyLgmuEF2FA/JR/4/y6hcPq8OUail3/AvycBaW1d5VSauOZzqGvJ3RTmR4MU35lWE8KseKOsEhrFRBA=="],
 
-    "@opennextjs/cloudflare/yargs/cliui": ["cliui@9.0.1", "", { "dependencies": { "string-width": "^7.2.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w=="],
-
-    "@opennextjs/cloudflare/yargs/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
-
-    "@opennextjs/cloudflare/yargs/yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
-
     "@particle-network/solana-wallet/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
 
     "@polymarket/builder-signing-sdk/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
     "@project-serum/sol-wallet-adapter/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
+
+    "@react-native/codegen/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "@react-native/codegen/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "@react-native/dev-middleware/serve-static/send": ["send@0.19.2", "", { "dependencies": { "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "fresh": "~0.5.2", "http-errors": "~2.0.1", "mime": "1.6.0", "ms": "2.1.3", "on-finished": "~2.4.1", "range-parser": "~1.2.1", "statuses": "~2.0.2" } }, "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg=="],
 
@@ -5215,6 +5230,8 @@
 
     "bs58check/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
 
+    "cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
     "cloudflare/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
     "connect/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
@@ -5253,21 +5270,37 @@
 
     "metro/hermes-parser/hermes-estree": ["hermes-estree@0.35.0", "", {}, "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg=="],
 
+    "metro/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "metro/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
     "porto/ox/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
 
     "qrcode/yargs/cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
+
+    "qrcode/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "qrcode/yargs/y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
 
     "qrcode/yargs/yargs-parser": ["yargs-parser@18.1.3", "", { "dependencies": { "camelcase": "^5.0.0", "decamelize": "^1.2.0" } }, "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ=="],
 
+    "react-native/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "react-native/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
     "react-qr-reader/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "tailwindcss/chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "tailwindcss/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
     "unstorage/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
+
+    "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "@aws-sdk/client-cloudfront/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-ini/@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.55", "", { "dependencies": { "@aws-sdk/core": "^3.974.23", "@aws-sdk/nested-clients": "^3.997.23", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-hBBkANo3cDn+h2qxxzER4a+J8JCO9o9Z/YYmU7iky6AcaarX5RRdRcHNC6SLdwY0vAXQygn6soUbDqPn3GghaA=="],
 
@@ -5453,13 +5486,9 @@
 
     "@metamask/providers/@metamask/utils/@ethereumjs/tx/@ethereumjs/common": ["@ethereumjs/common@3.2.0", "", { "dependencies": { "@ethereumjs/util": "^8.1.0", "crc-32": "^1.2.0" } }, "sha512-pksvzI0VyLgmuEF2FA/JR/4/y6hcPq8OUail3/AvycBaW1d5VSauOZzqGvJ3RTmR4MU35lWE8KseKOsEhrFRBA=="],
 
-    "@opennextjs/cloudflare/yargs/cliui/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+    "@react-native/codegen/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
-    "@opennextjs/cloudflare/yargs/cliui/wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
-
-    "@opennextjs/cloudflare/yargs/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
-
-    "@opennextjs/cloudflare/yargs/string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+    "@react-native/codegen/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "@react-native/dev-middleware/serve-static/send/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
@@ -5502,6 +5531,8 @@
     "@reown/appkit-pay/@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils": ["@walletconnect/utils@2.21.0", "", { "dependencies": { "@noble/ciphers": "1.2.1", "@noble/curves": "1.8.1", "@noble/hashes": "1.7.1", "@walletconnect/jsonrpc-utils": "1.0.8", "@walletconnect/keyvaluestorage": "1.1.1", "@walletconnect/relay-api": "1.0.11", "@walletconnect/relay-auth": "1.1.0", "@walletconnect/safe-json": "1.0.2", "@walletconnect/time": "1.0.2", "@walletconnect/types": "2.21.0", "@walletconnect/window-getters": "1.0.1", "@walletconnect/window-metadata": "1.0.1", "bs58": "6.0.0", "detect-browser": "5.3.0", "query-string": "7.1.3", "uint8arrays": "3.1.0", "viem": "2.23.2" } }, "sha512-zfHLiUoBrQ8rP57HTPXW7rQMnYxYI4gT9yTACxVW6LhIFROTF6/ytm5SKNoIvi4a5nX5dfXG4D9XwQUCu8Ilig=="],
 
     "@reown/appkit-ui/qrcode/yargs/cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
+
+    "@reown/appkit-ui/qrcode/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "@reown/appkit-ui/qrcode/yargs/y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
 
@@ -6067,9 +6098,17 @@
 
     "eth-block-tracker/@metamask/utils/@ethereumjs/tx/@ethereumjs/common": ["@ethereumjs/common@3.2.0", "", { "dependencies": { "@ethereumjs/util": "^8.1.0", "crc-32": "^1.2.0" } }, "sha512-pksvzI0VyLgmuEF2FA/JR/4/y6hcPq8OUail3/AvycBaW1d5VSauOZzqGvJ3RTmR4MU35lWE8KseKOsEhrFRBA=="],
 
+    "metro/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "metro/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
     "qrcode/yargs/cliui/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
-    "qrcode/yargs/yargs-parser/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
+    "qrcode/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "react-native/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "react-native/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "tailwindcss/chokidar/readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
@@ -6131,11 +6170,7 @@
 
     "@metamask/providers/@metamask/rpc-errors/@metamask/utils/@ethereumjs/tx/@ethereumjs/common": ["@ethereumjs/common@3.2.0", "", { "dependencies": { "@ethereumjs/util": "^8.1.0", "crc-32": "^1.2.0" } }, "sha512-pksvzI0VyLgmuEF2FA/JR/4/y6hcPq8OUail3/AvycBaW1d5VSauOZzqGvJ3RTmR4MU35lWE8KseKOsEhrFRBA=="],
 
-    "@opennextjs/cloudflare/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
-
-    "@opennextjs/cloudflare/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
-
-    "@opennextjs/cloudflare/yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+    "@react-native/codegen/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "@react-native/dev-middleware/serve-static/send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
@@ -6161,6 +6196,8 @@
 
     "@reown/appkit-pay/@reown/appkit-ui/qrcode/yargs/cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
 
+    "@reown/appkit-pay/@reown/appkit-ui/qrcode/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
     "@reown/appkit-pay/@reown/appkit-ui/qrcode/yargs/y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
 
     "@reown/appkit-pay/@reown/appkit-ui/qrcode/yargs/yargs-parser": ["yargs-parser@18.1.3", "", { "dependencies": { "camelcase": "^5.0.0", "decamelize": "^1.2.0" } }, "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ=="],
@@ -6177,7 +6214,7 @@
 
     "@reown/appkit-ui/qrcode/yargs/cliui/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
-    "@reown/appkit-ui/qrcode/yargs/yargs-parser/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
+    "@reown/appkit-ui/qrcode/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils/viem/@scure/bip32": ["@scure/bip32@1.6.2", "", { "dependencies": { "@noble/curves": "~1.8.1", "@noble/hashes": "~1.7.1", "@scure/base": "~1.2.2" } }, "sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw=="],
 
@@ -6307,7 +6344,11 @@
 
     "@walletconnect/utils/viem/ox/@scure/bip39/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 
+    "metro/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
     "qrcode/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "react-native/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "@aws-sdk/client-cloudfront/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-ini/@aws-sdk/nested-clients/@aws-sdk/signature-v4-multi-region/@smithy/signature-v4": ["@smithy/signature-v4@5.5.2", "", { "dependencies": { "@smithy/core": "^3.26.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-7xHpmPY4rt0IOmeAA8EfjgEH8isT+587TCdy9H6a7d4OMi5CQ0oEHhWllunvPu4j4Cq0vTFwdxXN/kABWPjdyA=="],
 
@@ -6367,7 +6408,7 @@
 
     "@reown/appkit-pay/@reown/appkit-ui/qrcode/yargs/cliui/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
-    "@reown/appkit-pay/@reown/appkit-ui/qrcode/yargs/yargs-parser/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
+    "@reown/appkit-pay/@reown/appkit-ui/qrcode/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "@reown/appkit-pay/@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils/viem/@scure/bip32": ["@scure/bip32@1.6.2", "", { "dependencies": { "@noble/curves": "~1.8.1", "@noble/hashes": "~1.7.1", "@scure/base": "~1.2.2" } }, "sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw=="],
 
@@ -6414,6 +6455,8 @@
     "@walletconnect/core/@walletconnect/utils/viem/ox/@scure/bip39/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 
     "@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode/yargs/cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
+
+    "@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode/yargs/y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
 
@@ -6481,7 +6524,7 @@
 
     "@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode/yargs/cliui/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
-    "@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode/yargs/yargs-parser/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
+    "@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "@walletconnect/ethereum-provider/@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils/viem/@scure/bip32/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -482,6 +482,17 @@
         "@types/node": "^25.5.0",
       },
     },
+    "packages/solana-signer": {
+      "name": "@stwd/solana-signer",
+      "version": "0.1.0",
+      "dependencies": {
+        "@solana/web3.js": "^1.98.0",
+        "@stwd/sdk": "workspace:*",
+      },
+      "devDependencies": {
+        "@types/node": "^25.5.0",
+      },
+    },
     "packages/trade-sessions": {
       "name": "@stwd/trade-sessions",
       "version": "0.1.1",
@@ -1763,6 +1774,8 @@
     "@stwd/shared": ["@stwd/shared@workspace:packages/shared"],
 
     "@stwd/signer-frost": ["@stwd/signer-frost@workspace:packages/signer-frost"],
+
+    "@stwd/solana-signer": ["@stwd/solana-signer@workspace:packages/solana-signer"],
 
     "@stwd/trade-sessions": ["@stwd/trade-sessions@workspace:packages/trade-sessions"],
 

--- a/packages/api/src/__tests__/idempotency-middleware.test.ts
+++ b/packages/api/src/__tests__/idempotency-middleware.test.ts
@@ -38,6 +38,19 @@ function makeApp() {
       refreshToken: `refresh-${count}-${body.refreshToken}`,
     });
   });
+  app.post("/vault/:agentId/sign-solana", async (c) => {
+    count += 1;
+    const body = await c.req.json<{ transaction: string; broadcast: boolean; chainId: number }>();
+    return c.json({
+      ok: true,
+      data: {
+        txId: `solana-sign-${count}`,
+        signature: `signed-${body.transaction}`,
+        broadcast: body.broadcast,
+        chainId: body.chainId,
+      },
+    });
+  });
   app.get("/mutate", (c) => c.json({ ok: true, count }));
 
   return { app, getCount: () => count };
@@ -96,6 +109,29 @@ describe("idempotencyMiddleware", () => {
     expect(second.headers.get("Idempotency-Replayed")).toBe("true");
     expect(await first.json()).toEqual({ ok: true, count: 1, value: "first" });
     expect(await second.json()).toEqual({ ok: true, count: 1, value: "first" });
+    expect(getCount()).toBe(1);
+  });
+
+  it("replays a non-broadcast Solana signature for a stable lost-response retry", async () => {
+    const { app, getCount } = makeApp();
+    const init = {
+      method: "POST",
+      headers: {
+        Authorization: AUTHORIZATION,
+        "Content-Type": "application/json",
+        "Idempotency-Key": "steward-solana-sign-v1-deadbeef",
+      },
+      body: JSON.stringify({ transaction: "dHg=", broadcast: false, chainId: 101 }),
+    };
+
+    const first = await app.request("/vault/agent-1/sign-solana", init);
+    const retry = await app.request("/vault/agent-1/sign-solana", init);
+
+    expect(first.status).toBe(200);
+    expect(retry.status).toBe(200);
+    expect(first.headers.get("Idempotency-Replayed")).toBe("false");
+    expect(retry.headers.get("Idempotency-Replayed")).toBe("true");
+    expect(await retry.json()).toEqual(await first.json());
     expect(getCount()).toBe(1);
   });
 

--- a/packages/api/src/__tests__/sign-solana-priority-fee.test.ts
+++ b/packages/api/src/__tests__/sign-solana-priority-fee.test.ts
@@ -107,6 +107,32 @@ describe("sign-solana priority-fee cap", () => {
     }
   });
 
+  it("rejects non-Solana chain ids before policy evaluation or signing", async () => {
+    const context = await import("../services/context");
+    const originalSignSolanaTransaction = context.vault.signSolanaTransaction.bind(context.vault);
+    context.vault.signSolanaTransaction = async () => {
+      throw new Error("invalid chain id should not reach signing");
+    };
+    try {
+      const response = await app.request(`/vault/${AGENT_ID}/sign-solana`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          transaction: WITHIN_CAP_V0_TRANSFER,
+          chainId: 1,
+          broadcast: false,
+        }),
+      });
+      expect(response.status).toBe(400);
+      expect(await response.json()).toMatchObject({
+        ok: false,
+        error: expect.stringMatching(/101/),
+      });
+    } finally {
+      context.vault.signSolanaTransaction = originalSignSolanaTransaction;
+    }
+  });
+
   it("accepts a v0 transfer whose priority fee is within the cap", async () => {
     const context = await import("../services/context");
     const originalSignSolanaTransaction = context.vault.signSolanaTransaction.bind(context.vault);

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -7944,6 +7944,12 @@ vaultRoutes.post("/:agentId/sign-solana", async (c) => {
   }
 
   const chainId = body.chainId ?? 101;
+  if (!isSolanaActionChain(chainId)) {
+    return c.json<ApiResponse>(
+      { ok: false, error: "'chainId' must be 101 (Solana mainnet) or 102 (Solana devnet)" },
+      400,
+    );
+  }
 
   // ── Derive authoritative policy fields from the transaction bytes ───────────
   // This is the core spoof-resistance control: nothing the caller claims about

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -54,6 +54,8 @@ new StewardClient(config: StewardClientConfig)
 | `baseUrl` | `string` | ✅ | Base URL of your self-hosted Steward API (e.g. `http://localhost:3200`) |
 | `apiKey` | `string` | — | API key sent as `X-Steward-Key` header |
 | `tenantId` | `string` | — | Tenant ID sent as `X-Steward-Tenant` header |
+| `requestTimeoutMs` | `number` | — | End-to-end request deadline; defaults to 30,000 ms and is capped at 300,000 ms |
+| `maxResponseBodyBytes` | `number` | — | Decoded response-body limit; defaults to 8 MiB and is capped at 16 MiB |
 
 ---
 

--- a/packages/sdk/src/__tests__/client.test.ts
+++ b/packages/sdk/src/__tests__/client.test.ts
@@ -269,8 +269,23 @@ describe("StewardClient construction", () => {
       platformKey: "test-platform-key",
       bearerToken: "test-bearer-token",
       tenantId: "test-tenant",
+      requestTimeoutMs: 10_000,
+      maxResponseBodyBytes: 1024 * 1024,
     });
     expect(client).toBeInstanceOf(StewardClient);
+  });
+
+  it("rejects request limits that are unbounded or invalid", () => {
+    for (const requestTimeoutMs of [0, -1, 1.5, 300_001, Number.POSITIVE_INFINITY]) {
+      expect(
+        () => new StewardClient({ baseUrl: "https://api.example.com", requestTimeoutMs }),
+      ).toThrow(/requestTimeoutMs must be a positive integer/);
+    }
+    for (const maxResponseBodyBytes of [0, -1, 1.5, 16 * 1024 * 1024 + 1]) {
+      expect(
+        () => new StewardClient({ baseUrl: "https://api.example.com", maxResponseBodyBytes }),
+      ).toThrow(/maxResponseBodyBytes must be a positive integer/);
+    }
   });
 
   it("creates a client with apiKey only", () => {
@@ -1211,6 +1226,19 @@ describe("HTTP request building", () => {
     expect(lastCapture?.headers["x-steward-signer-id"]).toBe("signer-auth-1");
     expect(lastCapture?.headers["x-steward-signer-secret"]).toBe("secret-auth-1");
     expect(lastCapture?.body).toEqual(input);
+  });
+
+  it("signSolanaTransaction forwards an explicit idempotency key", async () => {
+    installMockFetch({
+      ok: true,
+      data: { txId: "tx-sol-1", signature: "signed", broadcast: false, chainId: 101 },
+    });
+    await makeClient().signSolanaTransaction(
+      "agent-1",
+      { transaction: "dHg=", broadcast: false, chainId: 101 },
+      { idempotencyKey: "stable-solana-signing-key" },
+    );
+    expect(lastCapture?.headers["idempotency-key"]).toBe("stable-solana-signing-key");
   });
 
   it("signTypedData → POST /vault/:agentId/sign-typed-data", async () => {
@@ -4699,7 +4727,83 @@ describe("Error handling", () => {
     expect(caught).not.toBeNull();
     expect(caught?.name).toBe("StewardApiError");
     expect(caught?.status).toBe(0);
-    expect(caught?.message).toContain("Network error");
+    expect(caught?.message).toBe("Network request failed");
+    expect(caught?.message).not.toContain("connection refused");
+  });
+
+  it("bounds stalled response headers with an end-to-end deadline", async () => {
+    global.fetch = (_input: RequestInfo | URL, init?: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal;
+        const rejectOnAbort = () => reject(new Error("socket secret from abort rejection"));
+        if (signal?.aborted) rejectOnAbort();
+        else signal?.addEventListener("abort", rejectOnAbort, { once: true });
+      });
+
+    const startedAt = Date.now();
+    const error = await makeClient({ requestTimeoutMs: 25 })
+      .listAgents()
+      .catch((caught) => caught);
+
+    expect(error).toBeInstanceOf(StewardApiError);
+    expect(error.status).toBe(0);
+    expect(error.message).toBe("Steward API request timed out");
+    expect(error.message).not.toContain("socket secret");
+    expect(Date.now() - startedAt).toBeLessThan(1_000);
+  });
+
+  it("bounds a stalled response body and swallows body-cancel rejection details", async () => {
+    let cancelCalled = false;
+    global.fetch = async () =>
+      new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode('{"ok":true,"data":'));
+          },
+          cancel() {
+            cancelCalled = true;
+            return Promise.reject(new Error("stream cancel secret"));
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+
+    const error = await makeClient({ requestTimeoutMs: 25 })
+      .listAgents()
+      .catch((caught) => caught);
+
+    expect(error).toBeInstanceOf(StewardApiError);
+    expect(error.status).toBe(0);
+    expect(error.message).toBe("Steward API request timed out");
+    expect(error.message).not.toContain("stream cancel secret");
+    expect(cancelCalled).toBe(true);
+  });
+
+  it("rejects oversized declared and streaming response bodies without echoing content", async () => {
+    const secret = "upstream-response-secret";
+    global.fetch = async () =>
+      new Response(secret, {
+        status: 200,
+        headers: { "Content-Length": "4096", "Content-Type": "application/json" },
+      });
+    let error = await makeClient({ maxResponseBodyBytes: 32 })
+      .listAgents()
+      .catch((caught) => caught);
+    expect(error).toBeInstanceOf(StewardApiError);
+    expect(error.message).toBe("Steward API response exceeded the configured size limit");
+    expect(error.message).not.toContain(secret);
+
+    global.fetch = async () =>
+      new Response(new TextEncoder().encode(`{"ok":false,"error":"${secret}"}`), {
+        status: 502,
+        headers: { "Content-Type": "application/json" },
+      });
+    error = await makeClient({ maxResponseBodyBytes: 16 })
+      .listAgents()
+      .catch((caught) => caught);
+    expect(error).toBeInstanceOf(StewardApiError);
+    expect(error.message).toBe("Steward API response exceeded the configured size limit");
+    expect(error.message).not.toContain(secret);
   });
 
   it("throws StewardApiError on invalid JSON response", async () => {

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -200,6 +200,16 @@ export interface StewardClientConfig {
    * required by default so credentials never travel cleartext off-loopback.
    */
   allowInsecureBaseUrl?: boolean;
+  /**
+   * End-to-end request deadline, including request-header signing, receipt of
+   * response headers, and consumption of the response body. Defaults to 30s.
+   */
+  requestTimeoutMs?: number;
+  /**
+   * Maximum decoded response-body bytes accepted from the API. Defaults to
+   * 8 MiB and can never exceed the SDK's 16 MiB safety ceiling.
+   */
+  maxResponseBodyBytes?: number;
 }
 
 export interface QuorumSignerCredential {
@@ -1392,6 +1402,24 @@ function isBrowserRuntime(): boolean {
   return typeof globalThis.window !== "undefined" && typeof globalThis.document !== "undefined";
 }
 
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+const MAX_REQUEST_TIMEOUT_MS = 5 * 60_000;
+const DEFAULT_MAX_RESPONSE_BODY_BYTES = 8 * 1024 * 1024;
+const MAX_RESPONSE_BODY_BYTES = 16 * 1024 * 1024;
+
+function boundedPositiveInteger(
+  name: string,
+  value: number | undefined,
+  fallback: number,
+  maximum: number,
+): number {
+  const resolved = value ?? fallback;
+  if (!Number.isSafeInteger(resolved) || resolved <= 0 || resolved > maximum) {
+    throw new StewardApiError(`${name} must be a positive integer no greater than ${maximum}`, 0);
+  }
+  return resolved;
+}
+
 export class StewardClient {
   private readonly baseUrl: string;
   private readonly apiKey?: string;
@@ -1402,6 +1430,8 @@ export class StewardClient {
   private readonly tenantId?: string;
   private readonly requestSigningSecret?: string;
   private readonly requestSigningKeyId?: string;
+  private readonly requestTimeoutMs: number;
+  private readonly maxResponseBodyBytes: number;
 
   constructor({
     baseUrl,
@@ -1415,6 +1445,8 @@ export class StewardClient {
     requestSigningKeyId,
     allowUnsafeBrowserSecrets,
     allowInsecureBaseUrl,
+    requestTimeoutMs,
+    maxResponseBodyBytes,
   }: StewardClientConfig) {
     if (
       isBrowserRuntime() &&
@@ -1436,6 +1468,18 @@ export class StewardClient {
     this.tenantId = tenantId;
     this.requestSigningSecret = requestSigningSecret;
     this.requestSigningKeyId = requestSigningKeyId;
+    this.requestTimeoutMs = boundedPositiveInteger(
+      "requestTimeoutMs",
+      requestTimeoutMs,
+      DEFAULT_REQUEST_TIMEOUT_MS,
+      MAX_REQUEST_TIMEOUT_MS,
+    );
+    this.maxResponseBodyBytes = boundedPositiveInteger(
+      "maxResponseBodyBytes",
+      maxResponseBodyBytes,
+      DEFAULT_MAX_RESPONSE_BODY_BYTES,
+      MAX_RESPONSE_BODY_BYTES,
+    );
   }
 
   readonly tradeSessions = {
@@ -2679,11 +2723,15 @@ export class StewardClient {
   async signSolanaTransaction(
     agentId: string,
     input: SignSolanaTransactionInput,
+    options?: IdempotencyOptions,
   ): Promise<SignSolanaTransactionResult> {
     const response = await this.request<SignSolanaTransactionResult, StewardErrorResponse>(
       `/vault/${encodeURIComponent(agentId)}/sign-solana`,
       {
         method: "POST",
+        headers: options?.idempotencyKey
+          ? { "Idempotency-Key": options.idempotencyKey }
+          : undefined,
         body: JSON.stringify(input),
       },
     );
@@ -5688,22 +5736,10 @@ export class StewardClient {
     path: string,
     init: RequestInit = {},
   ): Promise<ApiRequestResult<TSuccess, TFailure>> {
-    let response: Response;
-
-    try {
-      const headers = await this.buildRequestHeaders(path, init);
-      response = await fetch(`${this.baseUrl}${path}`, {
-        ...init,
-        headers,
-      });
-    } catch (error) {
-      throw new StewardApiError(
-        error instanceof Error ? error.message : "Network request failed",
-        0,
-      );
-    }
-
-    const payload = await this.parseJson<ApiResponse<TSuccess | TFailure>>(response);
+    const { response, payload } = await this.fetchJson<ApiResponse<TSuccess | TFailure>>(
+      path,
+      init,
+    );
 
     if (!payload.ok) {
       return {
@@ -5727,20 +5763,7 @@ export class StewardClient {
 
   /** Handle lifecycle endpoints whose successful response is intentionally raw. */
   private async requestRawJson<T>(path: string, init: RequestInit = {}): Promise<T> {
-    let response: Response;
-    try {
-      response = await fetch(`${this.baseUrl}${path}`, {
-        ...init,
-        headers: await this.buildRequestHeaders(path, init),
-      });
-    } catch (error) {
-      throw new StewardApiError(
-        error instanceof Error ? error.message : "Network request failed",
-        0,
-      );
-    }
-
-    const payload = await this.parseJson<unknown>(response);
+    const { response, payload } = await this.fetchJson<unknown>(path, init);
     if (!response.ok) {
       let message = `Request failed with status ${response.status}`;
       if (payload && typeof payload === "object") {
@@ -5835,8 +5858,101 @@ export class StewardClient {
     return headers;
   }
 
-  private async parseJson<T>(response: Response): Promise<T> {
-    const text = await response.text();
+  private async fetchJson<T>(
+    path: string,
+    init: RequestInit,
+  ): Promise<{ response: Response; payload: T }> {
+    const controller = new AbortController();
+    const deadlineAt = Date.now() + this.requestTimeoutMs;
+    const callerSignal = init.signal;
+    let timedOut = false;
+    let callerCancelled = callerSignal?.aborted ?? false;
+    const cancelFromCaller = () => {
+      callerCancelled = true;
+      controller.abort();
+    };
+    callerSignal?.addEventListener("abort", cancelFromCaller, { once: true });
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, this.requestTimeoutMs);
+
+    try {
+      if (callerCancelled) throw new DOMException("Request cancelled", "AbortError");
+      const headers = await this.buildRequestHeaders(path, init);
+      if (controller.signal.aborted) throw new DOMException("Request aborted", "AbortError");
+      const response = await fetch(`${this.baseUrl}${path}`, {
+        ...init,
+        headers,
+        signal: controller.signal,
+      });
+      const payload = await this.parseJson<T>(response, controller.signal);
+      if (Date.now() >= deadlineAt) {
+        timedOut = true;
+        controller.abort();
+        throw new DOMException("Request deadline elapsed", "AbortError");
+      }
+      return { response, payload };
+    } catch (error) {
+      if (timedOut) throw new StewardApiError("Steward API request timed out", 0);
+      if (callerCancelled) throw new StewardApiError("Steward API request was cancelled", 0);
+      if (error instanceof StewardApiError) throw error;
+      throw new StewardApiError("Network request failed", 0);
+    } finally {
+      clearTimeout(timeout);
+      callerSignal?.removeEventListener("abort", cancelFromCaller);
+    }
+  }
+
+  private async parseJson<T>(response: Response, signal: AbortSignal): Promise<T> {
+    const declaredLength = response.headers.get("content-length");
+    if (declaredLength !== null) {
+      const parsedLength = Number(declaredLength);
+      if (Number.isFinite(parsedLength) && parsedLength > this.maxResponseBodyBytes) {
+        void response.body?.cancel().catch(() => undefined);
+        throw new StewardApiError(
+          "Steward API response exceeded the configured size limit",
+          response.status,
+        );
+      }
+    }
+
+    const reader = response.body?.getReader();
+    const chunks: Uint8Array[] = [];
+    let totalBytes = 0;
+    if (reader) {
+      try {
+        while (true) {
+          const { done, value } = await this.readResponseChunk(reader, signal);
+          if (done) break;
+          totalBytes += value.byteLength;
+          if (totalBytes > this.maxResponseBodyBytes) {
+            void reader.cancel().catch(() => undefined);
+            throw new StewardApiError(
+              "Steward API response exceeded the configured size limit",
+              response.status,
+            );
+          }
+          chunks.push(value);
+        }
+      } finally {
+        if (signal.aborted) void reader.cancel().catch(() => undefined);
+        try {
+          reader.releaseLock();
+        } catch {
+          // An abort may leave a hostile/custom stream's read pending. The
+          // controller and cancel above still ensure this request stops waiting.
+        }
+      }
+    }
+
+    const body = new Uint8Array(totalBytes);
+    let offset = 0;
+    for (const chunk of chunks) {
+      body.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    const text = new TextDecoder().decode(body);
 
     if (!text) {
       return { ok: response.ok } as T;
@@ -5846,6 +5962,23 @@ export class StewardClient {
       return JSON.parse(text) as T;
     } catch {
       throw new StewardApiError("Received invalid JSON from Steward API", response.status);
+    }
+  }
+
+  private async readResponseChunk(
+    reader: ReadableStreamDefaultReader<Uint8Array>,
+    signal: AbortSignal,
+  ): Promise<{ done: false; value: Uint8Array } | { done: true; value?: Uint8Array }> {
+    if (signal.aborted) throw new DOMException("Request aborted", "AbortError");
+    let onAbort: (() => void) | undefined;
+    const aborted = new Promise<never>((_resolve, reject) => {
+      onAbort = () => reject(new DOMException("Request aborted", "AbortError"));
+      signal.addEventListener("abort", onAbort, { once: true });
+    });
+    try {
+      return await Promise.race([reader.read(), aborted]);
+    } finally {
+      if (onAbort) signal.removeEventListener("abort", onAbort);
     }
   }
 

--- a/packages/solana-signer/README.md
+++ b/packages/solana-signer/README.md
@@ -1,0 +1,87 @@
+# @stwd/solana-signer
+
+Standard Solana signer shape backed by the Steward governed vault. Gives any
+consumer that accepts an external signer (`{ publicKey, signTransaction,
+signAllTransactions }`, the wallet-adapter shape and iqlabs-sdk's
+`WalletSigner`) a Steward-governed key without exposing key material.
+
+Every signature is one `POST /vault/:agentId/sign-solana` with
+`broadcast:false`: policy evaluates server-side on the real transaction bytes,
+the signed transaction comes back, and the caller keeps its own send+confirm
+path. This package never broadcasts and never sees a private key.
+
+```ts
+import { createStewardSolanaSigner } from "@stwd/solana-signer";
+
+const signer = await createStewardSolanaSigner({
+  baseUrl: "http://127.0.0.1:3000",
+  agentId: "agent-1",
+  bearerToken: process.env.STEWARD_AGENT_TOKEN,
+  chainId: 102, // devnet; 101 (default) is mainnet
+});
+
+const signed = await signer.signTransaction(tx); // same object, signatures filled
+```
+
+## Refusals are typed
+
+Policy outcomes surface as `StewardSignerError` with a `kind`:
+
+- `policy_rejected`: the vault said no (403/422); `policyResults` carries the
+  failed rules and the message names the reason.
+- `pending_approval`: the transaction was queued for a human (202); `txId`
+  identifies the approval to act on. A signer cannot block on a human, so this
+  is an error by design.
+- `auth`: bad or out-of-scope credentials.
+- `api`: anything else.
+
+## Loopback bridge for out-of-process consumers
+
+Processes that cannot hold the signer object (the AgentNet MCP stdio server
+via its remote-wallet hook) speak a three-endpoint loopback protocol:
+
+```ts
+import { createStewardSolanaSigner, startSignerBridge } from "@stwd/solana-signer";
+
+const signer = await createStewardSolanaSigner({ /* as above */ });
+const bridge = await startSignerBridge(signer); // 127.0.0.1, ephemeral port
+console.log(bridge.url); // hand this to AGENTNET_WALLET_REMOTE
+console.log(bridge.token); // the session's shared secret for the consumer's env
+```
+
+- `GET /pubkey` returns `{ address }`
+- `POST /sign-transaction` takes `{ transaction }` (base64) and returns the
+  signed transaction, base64
+- `POST /sign-message` is always 501: Steward signs transactions under policy,
+  not raw messages, so message-derived features on the consumer side stay off
+
+A loopback port is reachable by every process on the machine, so the bridge
+requires a shared secret in the `x-steward-bridge-token` header of every
+request. The secret is `STEWARD_SIGNER_BRIDGE_TOKEN` from the env when set
+(export the same var in the consumer process so both sides read one source),
+otherwise a fresh random token per session, exposed as `bridge.token`.
+Requests without the right header get 401 before the signer is touched. For a
+consumer that cannot send headers yet, pass `token: null` to run the bridge
+open; that is an explicit choice to let any local process request signatures,
+so keep the vault's policy tight when using it.
+
+## Blind-signing hints
+
+Transactions whose instructions Steward cannot decode (custom programs) are
+rejected fail-closed unless the server opts into audited blind signing, which
+requires advisory `to`/`value` fields. Pass a `hints` callback in the config
+(or `to`/`value` in the bridge's sign body) to supply them; the server treats
+hints as advisory only and rejects conflicts with the parsed transaction.
+
+## Tests
+
+`bun test` runs against a stub Steward API: request recording (headers, JWT
+shape, `broadcast:false` on every call), legacy and v0 signing, partial-sig
+preservation, refusal propagation for reject/pending/forbidden envelopes, and
+the bridge's shared-secret gate (default random token, env token, wrong or
+missing header refused before any vault call, explicit `token: null`).
+
+The suite runs from a clean checkout: every fixture is created in-process
+(the stub API binds an ephemeral loopback port), and `test-preload.ts` builds
+the `@stwd/sdk` dist entry the signer imports when it is missing or stale, so
+`bun install` + `bun test` is the whole setup.

--- a/packages/solana-signer/README.md
+++ b/packages/solana-signer/README.md
@@ -65,6 +65,11 @@ consumer that cannot send headers yet, pass `token: null` to run the bridge
 open; that is an explicit choice to let any local process request signatures,
 so keep the vault's policy tight when using it.
 
+The bridge rejects non-loopback bind hosts, empty tokens, and request bodies
+larger than 16 KiB. Returned transactions are accepted only when the original
+message and existing co-signer signatures are unchanged and the declared
+Steward public key has supplied a valid Ed25519 signature.
+
 ## Blind-signing hints
 
 Transactions whose instructions Steward cannot decode (custom programs) are

--- a/packages/solana-signer/README.md
+++ b/packages/solana-signer/README.md
@@ -46,7 +46,7 @@ import { createStewardSolanaSigner, startSignerBridge } from "@stwd/solana-signe
 const signer = await createStewardSolanaSigner({ /* as above */ });
 const bridge = await startSignerBridge(signer); // 127.0.0.1, ephemeral port
 console.log(bridge.url); // hand this to AGENTNET_WALLET_REMOTE
-console.log(bridge.token); // the session's shared secret for the consumer's env
+// Pass bridge.token directly into the child process environment; do not log it.
 ```
 
 - `GET /pubkey` returns `{ address }`
@@ -60,31 +60,32 @@ requires a shared secret in the `x-steward-bridge-token` header of every
 request. The secret is `STEWARD_SIGNER_BRIDGE_TOKEN` from the env when set
 (export the same var in the consumer process so both sides read one source),
 otherwise a fresh random token per session, exposed as `bridge.token`.
-Requests without the right header get 401 before the signer is touched. For a
-consumer that cannot send headers yet, pass `token: null` to run the bridge
-open; that is an explicit choice to let any local process request signatures,
-so keep the vault's policy tight when using it.
+Requests without the right header get 401 before the signer is touched. Tokens
+must contain at least 32 bytes. There is deliberately no headerless mode:
+unrelated local processes and browser CSRF can both reach loopback ports.
 
-The bridge rejects non-loopback bind hosts, empty tokens, and request bodies
-larger than 16 KiB. Returned transactions are accepted only when the original
+The bridge binds only literal `127.0.0.1` or `::1` addresses (never a DNS
+hostname), and rejects weak tokens, concurrent signing
+requests, and request bodies larger than 16 KiB. Returned transactions are accepted only when the original
 message and existing co-signer signatures are unchanged and the declared
 Steward public key has supplied a valid Ed25519 signature.
 
 ## Blind-signing hints
 
 Transactions whose instructions Steward cannot decode (custom programs) are
-rejected fail-closed unless the server opts into audited blind signing, which
-requires advisory `to`/`value` fields. Pass a `hints` callback in the config
-(or `to`/`value` in the bridge's sign body) to supply them; the server treats
-hints as advisory only and rejects conflicts with the parsed transaction.
+rejected fail-closed unless the server operator explicitly enables unsafe blind
+signing. In that mode `to`/`value` cannot be verified from transaction bytes and
+are caller assertions, not authoritative evidence. Keep that option off for
+untrusted bridge consumers. For fully parsed transactions, Steward rejects any
+supplied hints that conflict with the parsed transaction.
 
 ## Tests
 
 `bun test` runs against a stub Steward API: request recording (headers, JWT
 shape, `broadcast:false` on every call), legacy and v0 signing, partial-sig
 preservation, refusal propagation for reject/pending/forbidden envelopes, and
-the bridge's shared-secret gate (default random token, env token, wrong or
-missing header refused before any vault call, explicit `token: null`).
+the bridge's shared-secret gate (default random token, strong env token, and
+wrong or missing headers refused before any vault call).
 
 The suite runs from a clean checkout: every fixture is created in-process
 (the stub API binds an ephemeral loopback port), and `test-preload.ts` builds

--- a/packages/solana-signer/README.md
+++ b/packages/solana-signer/README.md
@@ -10,6 +10,12 @@ Every signature is one `POST /vault/:agentId/sign-solana` with
 the signed transaction comes back, and the caller keeps its own send+confirm
 path. This package never broadcasts and never sees a private key.
 
+The signer supplies a stable, request-body-bound idempotency key. Retrying the
+same serialized transaction after a lost response can therefore recover the
+completed non-broadcast signature from Steward's authenticated idempotency
+store. Configure Steward with its durable Redis store when retries may reach
+different API replicas.
+
 ```ts
 import { createStewardSolanaSigner } from "@stwd/solana-signer";
 
@@ -18,6 +24,7 @@ const signer = await createStewardSolanaSigner({
   agentId: "agent-1",
   bearerToken: process.env.STEWARD_AGENT_TOKEN,
   chainId: 102, // devnet; 101 (default) is mainnet
+  requestTimeoutMs: 10_000, // covers headers and bounded response consumption
 });
 
 const signed = await signer.signTransaction(tx); // same object, signatures filled

--- a/packages/solana-signer/bunfig.toml
+++ b/packages/solana-signer/bunfig.toml
@@ -1,0 +1,8 @@
+# Test bootstrap for @stwd/solana-signer, the same preload pattern @stwd/api
+# uses. The signer imports @stwd/sdk, whose package entry is dist/index.js, a
+# tsc build output that a clean checkout does not have. test-preload.ts
+# creates that one missing artifact itself, so `bun test` is green from a
+# clean checkout after `bun install`, with no manual build step and no
+# reliance on another package's leftover state.
+[test]
+preload = ["./test-preload.ts"]

--- a/packages/solana-signer/package.json
+++ b/packages/solana-signer/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@stwd/solana-signer",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "dev": "tsc --watch",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@solana/web3.js": "^1.98.0",
+    "@stwd/sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.0"
+  },
+  "description": "Standard Solana signer shape ({publicKey, signTransaction, signAllTransactions}) backed by the Steward governed vault's /vault/:agentId/sign-solana route, plus a loopback HTTP bridge for out-of-process consumers (AgentNet remote-wallet hook). Sign-only: broadcast stays with the caller."
+}

--- a/packages/solana-signer/src/__tests__/bridge.test.ts
+++ b/packages/solana-signer/src/__tests__/bridge.test.ts
@@ -1,6 +1,11 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
 import { Keypair, Transaction } from "@solana/web3.js";
-import { BRIDGE_TOKEN_ENV, BRIDGE_TOKEN_HEADER, startSignerBridge } from "../bridge";
+import {
+  BRIDGE_MAX_BODY_BYTES,
+  BRIDGE_TOKEN_ENV,
+  BRIDGE_TOKEN_HEADER,
+  startSignerBridge,
+} from "../bridge";
 import { createStewardSolanaSigner, type StewardSolanaSigner } from "../steward-signer";
 import { legacyTransfer, type StubSteward, startStubSteward } from "./harness";
 
@@ -110,6 +115,17 @@ describe("signer bridge", () => {
     expect(res.status).toBe(400);
     expect(stub.requests.length).toBe(before);
   });
+
+  it("rejects oversized request bodies before any vault call", async () => {
+    const before = stub.requests.length;
+    const res = await authed("/sign-transaction", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ transaction: "A".repeat(BRIDGE_MAX_BODY_BYTES) }),
+    });
+    expect(res.status).toBe(413);
+    expect(stub.requests.length).toBe(before);
+  });
 });
 
 describe("bridge shared-secret auth", () => {
@@ -164,5 +180,15 @@ describe("bridge shared-secret auth", () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ address: vaultKeypair.publicKey.toBase58() });
     await bridge.close();
+  });
+
+  it("rejects an empty shared secret", async () => {
+    await expect(startSignerBridge(signer, { token: "" })).rejects.toThrow(/must not be empty/);
+  });
+
+  it("rejects non-loopback bind hosts", async () => {
+    await expect(startSignerBridge(signer, { host: "0.0.0.0" })).rejects.toThrow(
+      /must be loopback/,
+    );
   });
 });

--- a/packages/solana-signer/src/__tests__/bridge.test.ts
+++ b/packages/solana-signer/src/__tests__/bridge.test.ts
@@ -245,4 +245,48 @@ describe("bridge shared-secret auth", () => {
     expect((await first).status).toBe(200);
     await concurrentBridge.close();
   });
+
+  it("returns a bounded 502 when the signer throws a hostile value", async () => {
+    const hostile = new Proxy(new Error("secret diagnostic"), {
+      get(_target, property) {
+        if (property === "message") throw new Error("message trap secret");
+        return Reflect.get(_target, property);
+      },
+      getPrototypeOf() {
+        throw new Error("prototype trap secret");
+      },
+    });
+    const hostileSigner: StewardSolanaSigner = {
+      address: signer.address,
+      publicKey: signer.publicKey,
+      async signTransaction(tx) {
+        return tx;
+      },
+      async signAllTransactions(txs) {
+        return txs;
+      },
+      async signSerializedTransaction() {
+        throw hostile;
+      },
+    };
+    const hostileBridge = await startSignerBridge(hostileSigner);
+    try {
+      const transaction = legacyTransfer(signer.publicKey)
+        .serialize({ requireAllSignatures: false })
+        .toString("base64");
+      const response = await fetch(`${hostileBridge.url}/sign-transaction`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          [BRIDGE_TOKEN_HEADER]: hostileBridge.token,
+        },
+        body: JSON.stringify({ transaction }),
+      });
+      expect(response.status).toBe(502);
+      const body = (await response.json()) as { error: string; kind: string };
+      expect(body).toEqual({ error: "Steward signing service failed", kind: "api" });
+    } finally {
+      await hostileBridge.close();
+    }
+  });
 });

--- a/packages/solana-signer/src/__tests__/bridge.test.ts
+++ b/packages/solana-signer/src/__tests__/bridge.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test"
 import { Keypair, Transaction } from "@solana/web3.js";
 import {
   BRIDGE_MAX_BODY_BYTES,
+  BRIDGE_MIN_TOKEN_BYTES,
   BRIDGE_TOKEN_ENV,
   BRIDGE_TOKEN_HEADER,
   startSignerBridge,
@@ -32,7 +33,6 @@ beforeAll(async () => {
   });
   const bridge = await startSignerBridge(signer);
   bridgeUrl = bridge.url;
-  if (bridge.token === null) throw new Error("default bridge must arm a token");
   bridgeToken = bridge.token;
   closeBridge = bridge.close;
 });
@@ -116,6 +116,16 @@ describe("signer bridge", () => {
     expect(stub.requests.length).toBe(before);
   });
 
+  it("requires JSON content type before reading or signing", async () => {
+    const before = stub.requests.length;
+    const res = await authed("/sign-transaction", {
+      method: "POST",
+      body: JSON.stringify({ transaction: "AAAA" }),
+    });
+    expect(res.status).toBe(415);
+    expect(stub.requests.length).toBe(before);
+  });
+
   it("rejects oversized request bodies before any vault call", async () => {
     const before = stub.requests.length;
     const res = await authed("/sign-transaction", {
@@ -159,12 +169,13 @@ describe("bridge shared-secret auth", () => {
   });
 
   it(`honors ${BRIDGE_TOKEN_ENV} from the env, the var both sides read`, async () => {
-    process.env[BRIDGE_TOKEN_ENV] = "env-shared-secret";
+    const envToken = "e".repeat(BRIDGE_MIN_TOKEN_BYTES);
+    process.env[BRIDGE_TOKEN_ENV] = envToken;
     try {
       const bridge = await startSignerBridge(signer);
-      expect(bridge.token).toBe("env-shared-secret");
+      expect(bridge.token).toBe(envToken);
       const res = await fetch(`${bridge.url}/pubkey`, {
-        headers: { [BRIDGE_TOKEN_HEADER]: "env-shared-secret" },
+        headers: { [BRIDGE_TOKEN_HEADER]: envToken },
       });
       expect(res.status).toBe(200);
       await bridge.close();
@@ -173,22 +184,65 @@ describe("bridge shared-secret auth", () => {
     }
   });
 
-  it("runs open only on an explicit token: null", async () => {
-    const bridge = await startSignerBridge(signer, { token: null });
-    expect(bridge.token).toBeNull();
-    const res = await fetch(`${bridge.url}/pubkey`);
-    expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ address: vaultKeypair.publicKey.toBase58() });
-    await bridge.close();
-  });
-
-  it("rejects an empty shared secret", async () => {
-    await expect(startSignerBridge(signer, { token: "" })).rejects.toThrow(/must not be empty/);
+  it("rejects empty and weak shared secrets", async () => {
+    await expect(startSignerBridge(signer, { token: "" })).rejects.toThrow(/at least 32 bytes/);
+    await expect(startSignerBridge(signer, { token: "too-short" })).rejects.toThrow(
+      /at least 32 bytes/,
+    );
   });
 
   it("rejects non-loopback bind hosts", async () => {
     await expect(startSignerBridge(signer, { host: "0.0.0.0" })).rejects.toThrow(
-      /must be loopback/,
+      /loopback IP literal/,
     );
+    await expect(startSignerBridge(signer, { host: "localhost" })).rejects.toThrow(
+      /loopback IP literal/,
+    );
+  });
+
+  it("allows only one signing request in flight", async () => {
+    let release!: () => void;
+    let entered!: () => void;
+    const started = new Promise<void>((resolve) => {
+      entered = resolve;
+    });
+    const blocked = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const blockingSigner: StewardSolanaSigner = {
+      address: signer.address,
+      publicKey: signer.publicKey,
+      async signTransaction(tx) {
+        return tx;
+      },
+      async signAllTransactions(txs) {
+        return txs;
+      },
+      async signSerializedTransaction(transaction) {
+        entered();
+        await blocked;
+        return transaction;
+      },
+    };
+    const concurrentBridge = await startSignerBridge(blockingSigner);
+    const tx = legacyTransfer(signer.publicKey)
+      .serialize({ requireAllSignatures: false })
+      .toString("base64");
+    const request = () =>
+      fetch(`${concurrentBridge.url}/sign-transaction`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          [BRIDGE_TOKEN_HEADER]: concurrentBridge.token,
+        },
+        body: JSON.stringify({ transaction: tx }),
+      });
+    const first = request();
+    await started;
+    const second = await request();
+    expect(second.status).toBe(429);
+    release();
+    expect((await first).status).toBe(200);
+    await concurrentBridge.close();
   });
 });

--- a/packages/solana-signer/src/__tests__/bridge.test.ts
+++ b/packages/solana-signer/src/__tests__/bridge.test.ts
@@ -1,0 +1,168 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { Keypair, Transaction } from "@solana/web3.js";
+import { BRIDGE_TOKEN_ENV, BRIDGE_TOKEN_HEADER, startSignerBridge } from "../bridge";
+import { createStewardSolanaSigner, type StewardSolanaSigner } from "../steward-signer";
+import { legacyTransfer, type StubSteward, startStubSteward } from "./harness";
+
+const vaultKeypair = Keypair.fromSeed(new Uint8Array(32).fill(11));
+
+let stub: StubSteward;
+let signer: StewardSolanaSigner;
+let bridgeUrl: string;
+let bridgeToken: string;
+let closeBridge: () => Promise<void>;
+let envTokenBefore: string | undefined;
+
+beforeAll(async () => {
+  // The suite must see the DEFAULT token path (a random per-session secret),
+  // so shield it from any ambient env token; restored in afterAll.
+  envTokenBefore = process.env[BRIDGE_TOKEN_ENV];
+  delete process.env[BRIDGE_TOKEN_ENV];
+
+  stub = startStubSteward(vaultKeypair);
+  signer = await createStewardSolanaSigner({
+    baseUrl: stub.url,
+    agentId: "agent-bridge",
+    bearerToken: "stub.jwt.token",
+  });
+  const bridge = await startSignerBridge(signer);
+  bridgeUrl = bridge.url;
+  if (bridge.token === null) throw new Error("default bridge must arm a token");
+  bridgeToken = bridge.token;
+  closeBridge = bridge.close;
+});
+
+afterAll(async () => {
+  await closeBridge();
+  stub.stop();
+  if (envTokenBefore !== undefined) process.env[BRIDGE_TOKEN_ENV] = envTokenBefore;
+});
+
+beforeEach(() => {
+  stub.setMode("sign");
+});
+
+/** fetch with this session's shared secret in the bridge token header. */
+function authed(path: string, init: RequestInit = {}): Promise<Response> {
+  return fetch(`${bridgeUrl}${path}`, {
+    ...init,
+    headers: { ...(init.headers ?? {}), [BRIDGE_TOKEN_HEADER]: bridgeToken },
+  });
+}
+
+describe("signer bridge", () => {
+  it("serves the agent address on GET /pubkey", async () => {
+    const res = await authed("/pubkey");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ address: vaultKeypair.publicKey.toBase58() });
+  });
+
+  it("round-trips a serialized transaction through /sign-transaction", async () => {
+    const tx = legacyTransfer(vaultKeypair.publicKey);
+    const unsigned = tx.serialize({ requireAllSignatures: false }).toString("base64");
+
+    const res = await authed("/sign-transaction", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ transaction: unsigned }),
+    });
+    expect(res.status).toBe(200);
+    const { transaction } = (await res.json()) as { transaction: string };
+    const signed = Transaction.from(Buffer.from(transaction, "base64"));
+    expect(signed.verifySignatures()).toBe(true);
+  });
+
+  it("maps a policy refusal to a clean 403 JSON error", async () => {
+    stub.setMode("reject");
+    const tx = legacyTransfer(vaultKeypair.publicKey);
+    const unsigned = tx.serialize({ requireAllSignatures: false }).toString("base64");
+
+    const res = await authed("/sign-transaction", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ transaction: unsigned }),
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string; kind: string; txId?: string };
+    expect(body.kind).toBe("policy_rejected");
+    expect(body.txId).toBe("tx-reject-1");
+    expect(body.error).toContain("daily cap 0.5 SOL exceeded");
+  });
+
+  it("fails closed on /sign-message with 501", async () => {
+    const res = await authed("/sign-message", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: Buffer.from("hello").toString("base64") }),
+    });
+    expect(res.status).toBe(501);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/not raw messages/);
+  });
+
+  it("rejects a missing transaction field with 400 before any vault call", async () => {
+    const before = stub.requests.length;
+    const res = await authed("/sign-transaction", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    expect(stub.requests.length).toBe(before);
+  });
+});
+
+describe("bridge shared-secret auth", () => {
+  it("arms a random per-session token by default", () => {
+    expect(bridgeToken).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("refuses a request without the token header, before any vault call", async () => {
+    const before = stub.requests.length;
+    const tx = legacyTransfer(vaultKeypair.publicKey);
+    const unsigned = tx.serialize({ requireAllSignatures: false }).toString("base64");
+    const res = await fetch(`${bridgeUrl}/sign-transaction`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ transaction: unsigned }),
+    });
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain(BRIDGE_TOKEN_HEADER);
+    expect(stub.requests.length).toBe(before);
+
+    const pubkey = await fetch(`${bridgeUrl}/pubkey`);
+    expect(pubkey.status).toBe(401);
+  });
+
+  it("refuses a wrong token with 401", async () => {
+    const res = await fetch(`${bridgeUrl}/pubkey`, {
+      headers: { [BRIDGE_TOKEN_HEADER]: `${bridgeToken}x` },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it(`honors ${BRIDGE_TOKEN_ENV} from the env, the var both sides read`, async () => {
+    process.env[BRIDGE_TOKEN_ENV] = "env-shared-secret";
+    try {
+      const bridge = await startSignerBridge(signer);
+      expect(bridge.token).toBe("env-shared-secret");
+      const res = await fetch(`${bridge.url}/pubkey`, {
+        headers: { [BRIDGE_TOKEN_HEADER]: "env-shared-secret" },
+      });
+      expect(res.status).toBe(200);
+      await bridge.close();
+    } finally {
+      delete process.env[BRIDGE_TOKEN_ENV];
+    }
+  });
+
+  it("runs open only on an explicit token: null", async () => {
+    const bridge = await startSignerBridge(signer, { token: null });
+    expect(bridge.token).toBeNull();
+    const res = await fetch(`${bridge.url}/pubkey`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ address: vaultKeypair.publicKey.toBase58() });
+    await bridge.close();
+  });
+});

--- a/packages/solana-signer/src/__tests__/harness.ts
+++ b/packages/solana-signer/src/__tests__/harness.ts
@@ -26,6 +26,7 @@ export type StubMode =
   | "forbidden"
   | "invalid-signature"
   | "changed-cosigner"
+  | "injected-cosigner"
   | "missing-broadcast-proof"
   | "wrong-chain";
 
@@ -149,6 +150,9 @@ export function startStubSteward(kp: Keypair): StubSteward {
           }
           if (mode === "changed-cosigner" && tx.signatures[1]?.signature) {
             tx.signatures[1].signature[0] ^= 1;
+          }
+          if (mode === "injected-cosigner" && tx.signatures[1]) {
+            tx.signatures[1].signature = new Uint8Array(64).fill(1);
           }
           signed = new Uint8Array(
             tx.serialize({ requireAllSignatures: false, verifySignatures: false }),

--- a/packages/solana-signer/src/__tests__/harness.ts
+++ b/packages/solana-signer/src/__tests__/harness.ts
@@ -25,7 +25,9 @@ export type StubMode =
   | "pending"
   | "forbidden"
   | "invalid-signature"
-  | "changed-cosigner";
+  | "changed-cosigner"
+  | "missing-broadcast-proof"
+  | "wrong-chain";
 
 export interface StubSteward {
   url: string;
@@ -152,14 +154,16 @@ export function startStubSteward(kp: Keypair): StubSteward {
             tx.serialize({ requireAllSignatures: false, verifySignatures: false }),
           );
         }
+        const data: Record<string, unknown> = {
+          txId: crypto.randomUUID(),
+          signature: Buffer.from(signed).toString("base64"),
+          broadcast: false,
+          chainId: mode === "wrong-chain" ? 102 : (chainId ?? 101),
+        };
+        if (mode === "missing-broadcast-proof") delete data.broadcast;
         return json({
           ok: true,
-          data: {
-            txId: crypto.randomUUID(),
-            signature: Buffer.from(signed).toString("base64"),
-            broadcast: false,
-            chainId: chainId ?? 101,
-          },
+          data,
         });
       }
 

--- a/packages/solana-signer/src/__tests__/harness.ts
+++ b/packages/solana-signer/src/__tests__/harness.ts
@@ -19,7 +19,13 @@ export interface RecordedRequest {
   body: unknown;
 }
 
-export type StubMode = "sign" | "reject" | "pending" | "forbidden";
+export type StubMode =
+  | "sign"
+  | "reject"
+  | "pending"
+  | "forbidden"
+  | "invalid-signature"
+  | "changed-cosigner";
 
 export interface StubSteward {
   url: string;
@@ -136,7 +142,15 @@ export function startStubSteward(kp: Keypair): StubSteward {
         } else {
           const tx = Transaction.from(bytes);
           tx.partialSign(kp);
-          signed = new Uint8Array(tx.serialize({ requireAllSignatures: false }));
+          if (mode === "invalid-signature" && tx.signatures[0]?.signature) {
+            tx.signatures[0].signature[0] ^= 1;
+          }
+          if (mode === "changed-cosigner" && tx.signatures[1]?.signature) {
+            tx.signatures[1].signature[0] ^= 1;
+          }
+          signed = new Uint8Array(
+            tx.serialize({ requireAllSignatures: false, verifySignatures: false }),
+          );
         }
         return json({
           ok: true,

--- a/packages/solana-signer/src/__tests__/harness.ts
+++ b/packages/solana-signer/src/__tests__/harness.ts
@@ -27,6 +27,7 @@ export type StubMode =
   | "invalid-signature"
   | "changed-cosigner"
   | "injected-cosigner"
+  | "trailing-response-bytes"
   | "missing-broadcast-proof"
   | "wrong-chain";
 
@@ -157,6 +158,9 @@ export function startStubSteward(kp: Keypair): StubSteward {
           signed = new Uint8Array(
             tx.serialize({ requireAllSignatures: false, verifySignatures: false }),
           );
+        }
+        if (mode === "trailing-response-bytes") {
+          signed = new Uint8Array([...signed, 0xa5]);
         }
         const data: Record<string, unknown> = {
           txId: crypto.randomUUID(),

--- a/packages/solana-signer/src/__tests__/harness.ts
+++ b/packages/solana-signer/src/__tests__/harness.ts
@@ -27,6 +27,9 @@ export type StubMode =
   | "invalid-signature"
   | "changed-cosigner"
   | "injected-cosigner"
+  | "malformed-addresses"
+  | "malformed-sign-result"
+  | "slow-sign"
   | "trailing-response-bytes"
   | "missing-broadcast-proof"
   | "wrong-chain";
@@ -78,6 +81,9 @@ export function startStubSteward(kp: Keypair): StubSteward {
       requests.push({ method: req.method, path: url.pathname, headers, body });
 
       if (req.method === "GET" && /^\/vault\/[^/]+\/addresses$/.test(url.pathname)) {
+        if (mode === "malformed-addresses") {
+          return json({ ok: true, data: { addresses: null } });
+        }
         return json({
           ok: true,
           data: {
@@ -91,6 +97,10 @@ export function startStubSteward(kp: Keypair): StubSteward {
       }
 
       if (req.method === "POST" && /^\/vault\/[^/]+\/sign-solana$/.test(url.pathname)) {
+        if (mode === "malformed-sign-result") {
+          return json({ ok: true, data: null });
+        }
+        if (mode === "slow-sign") await Bun.sleep(25);
         if (mode === "forbidden") {
           return json({ ok: false, error: "Forbidden: token scope does not match agent" }, 403);
         }
@@ -142,6 +152,12 @@ export function startStubSteward(kp: Keypair): StubSteward {
         if (isVersionedTransactionBytes(bytes)) {
           const vtx = VersionedTransaction.deserialize(bytes);
           vtx.sign([kp]);
+          if (mode === "changed-cosigner" && vtx.signatures[1]) {
+            vtx.signatures[1][0] ^= 1;
+          }
+          if (mode === "injected-cosigner" && vtx.signatures[1]) {
+            vtx.signatures[1] = new Uint8Array(64).fill(1);
+          }
           signed = vtx.serialize();
         } else {
           const tx = Transaction.from(bytes);

--- a/packages/solana-signer/src/__tests__/harness.ts
+++ b/packages/solana-signer/src/__tests__/harness.ts
@@ -1,0 +1,188 @@
+// Stub Steward API for signer tests: records every request (method, path,
+// headers, body) and plays the vault's documented response shapes for the two
+// routes the signer touches. `mode` switches the sign route between a real
+// stub signature and the refusal envelopes the API emits.
+
+import {
+  Keypair,
+  MessageV0,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+  VersionedTransaction,
+} from "@solana/web3.js";
+
+export interface RecordedRequest {
+  method: string;
+  path: string;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+export type StubMode = "sign" | "reject" | "pending" | "forbidden";
+
+export interface StubSteward {
+  url: string;
+  requests: RecordedRequest[];
+  setMode(mode: StubMode): void;
+  stop(): void;
+}
+
+// Same detection the real vault uses: skip the compact-u16 signature count and
+// the signature slots, then check the message version byte's high bit.
+function isVersionedTransactionBytes(bytes: Uint8Array): boolean {
+  let sigCount = 0;
+  let bytesRead = 0;
+  for (let shift = 0; ; shift += 7) {
+    const byte = bytes[bytesRead];
+    if (byte === undefined) return false;
+    bytesRead += 1;
+    sigCount |= (byte & 0x7f) << shift;
+    if ((byte & 0x80) === 0) break;
+  }
+  const firstMessageByte = bytes[bytesRead + sigCount * 64];
+  return firstMessageByte !== undefined && (firstMessageByte & 0x80) !== 0;
+}
+
+function json(body: object, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export function startStubSteward(kp: Keypair): StubSteward {
+  const requests: RecordedRequest[] = [];
+  let mode: StubMode = "sign";
+
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch: async (req) => {
+      const url = new URL(req.url);
+      const headers: Record<string, string> = {};
+      req.headers.forEach((value, key) => {
+        headers[key.toLowerCase()] = value;
+      });
+      const body = req.method === "POST" ? await req.json() : undefined;
+      requests.push({ method: req.method, path: url.pathname, headers, body });
+
+      if (req.method === "GET" && /^\/vault\/[^/]+\/addresses$/.test(url.pathname)) {
+        return json({
+          ok: true,
+          data: {
+            agentId: url.pathname.split("/")[2],
+            addresses: [
+              { chainFamily: "evm", address: "0x1111111111111111111111111111111111111111" },
+              { chainFamily: "solana", address: kp.publicKey.toBase58() },
+            ],
+          },
+        });
+      }
+
+      if (req.method === "POST" && /^\/vault\/[^/]+\/sign-solana$/.test(url.pathname)) {
+        if (mode === "forbidden") {
+          return json({ ok: false, error: "Forbidden: token scope does not match agent" }, 403);
+        }
+        if (mode === "reject") {
+          return json(
+            {
+              ok: false,
+              error: "Transaction rejected by policy",
+              data: {
+                txId: "tx-reject-1",
+                results: [
+                  {
+                    policyId: "policy-spend",
+                    type: "spending-limit",
+                    passed: false,
+                    reason: "daily cap 0.5 SOL exceeded",
+                  },
+                ],
+              },
+            },
+            403,
+          );
+        }
+        if (mode === "pending") {
+          return json(
+            {
+              ok: false,
+              error: "Transaction requires manual approval",
+              data: {
+                txId: "tx-pending-1",
+                status: "pending_approval",
+                results: [
+                  {
+                    policyId: "policy-threshold",
+                    type: "auto-approve-threshold",
+                    passed: false,
+                    reason: "above the auto-approve threshold",
+                  },
+                ],
+              },
+            },
+            202,
+          );
+        }
+        const { transaction, chainId } = body as { transaction: string; chainId?: number };
+        const bytes = Uint8Array.from(Buffer.from(transaction, "base64"));
+        let signed: Uint8Array;
+        // Same version-byte branch the real vault uses.
+        if (isVersionedTransactionBytes(bytes)) {
+          const vtx = VersionedTransaction.deserialize(bytes);
+          vtx.sign([kp]);
+          signed = vtx.serialize();
+        } else {
+          const tx = Transaction.from(bytes);
+          tx.partialSign(kp);
+          signed = new Uint8Array(tx.serialize({ requireAllSignatures: false }));
+        }
+        return json({
+          ok: true,
+          data: {
+            txId: crypto.randomUUID(),
+            signature: Buffer.from(signed).toString("base64"),
+            broadcast: false,
+            chainId: chainId ?? 101,
+          },
+        });
+      }
+
+      return json({ ok: false, error: "not found" }, 404);
+    },
+  });
+
+  return {
+    url: `http://127.0.0.1:${server.port}`,
+    requests,
+    setMode(next: StubMode) {
+      mode = next;
+    },
+    stop() {
+      server.stop(true);
+    },
+  };
+}
+
+// Deterministic blockhash-shaped base58 string for offline tx building.
+export const STUB_BLOCKHASH = new PublicKey(new Uint8Array(32).fill(7)).toBase58();
+
+export const SINK = new PublicKey(new Uint8Array(32).fill(9));
+
+export function legacyTransfer(from: PublicKey): Transaction {
+  const tx = new Transaction();
+  tx.add(SystemProgram.transfer({ fromPubkey: from, toPubkey: SINK, lamports: 1_000 }));
+  tx.recentBlockhash = STUB_BLOCKHASH;
+  tx.feePayer = from;
+  return tx;
+}
+
+export function versionedTransfer(from: PublicKey): VersionedTransaction {
+  const message = MessageV0.compile({
+    payerKey: from,
+    recentBlockhash: STUB_BLOCKHASH,
+    instructions: [SystemProgram.transfer({ fromPubkey: from, toPubkey: SINK, lamports: 1_000 })],
+  });
+  return new VersionedTransaction(message);
+}

--- a/packages/solana-signer/src/__tests__/steward-signer.test.ts
+++ b/packages/solana-signer/src/__tests__/steward-signer.test.ts
@@ -352,6 +352,33 @@ describe("signTransaction", () => {
     );
   });
 
+  it("returns the exact signature bytes it validated from a mutable client response", async () => {
+    const tx = legacyTransfer(vaultKeypair.publicKey);
+    const unsigned = tx.serialize({ requireAllSignatures: false }).toString("base64");
+    tx.partialSign(vaultKeypair);
+    const valid = tx.serialize({ requireAllSignatures: false }).toString("base64");
+    let signatureReads = 0;
+    const client = {
+      async signSolanaTransaction() {
+        return {
+          broadcast: false,
+          chainId: 101,
+          get signature() {
+            signatureReads += 1;
+            return signatureReads === 1 ? valid : "AAAA";
+          },
+        };
+      },
+    };
+    const signer = await newSigner({
+      address: vaultKeypair.publicKey.toBase58(),
+      client,
+    });
+
+    expect(await signer.signSerializedTransaction(unsigned)).toBe(valid);
+    expect(signatureReads).toBe(1);
+  });
+
   it("forwards advisory to/value hints for the blind-signing path", async () => {
     const signer = await newSigner({
       hints: () => ({ to: SINK.toBase58(), value: "1000" }),

--- a/packages/solana-signer/src/__tests__/steward-signer.test.ts
+++ b/packages/solana-signer/src/__tests__/steward-signer.test.ts
@@ -4,6 +4,7 @@ import {
   createStewardSolanaSigner,
   SOLANA_MAX_TRANSACTION_BYTES,
   StewardSignerError,
+  toSignerError,
 } from "../steward-signer";
 import {
   legacyTransfer,
@@ -265,6 +266,23 @@ describe("signTransaction", () => {
 });
 
 describe("refusal propagation", () => {
+  it("maps hostile thrown values without invoking attacker-controlled coercion", () => {
+    const hostile = new Proxy(new Error("secret backend diagnostic"), {
+      get(_target, property) {
+        if (property === "message") throw new Error("message trap secret");
+        return Reflect.get(_target, property);
+      },
+      getPrototypeOf() {
+        throw new Error("prototype trap secret");
+      },
+    });
+
+    const mapped = toSignerError(hostile);
+    expect(mapped.kind).toBe("api");
+    expect(mapped.message).toBe("Steward signing service failed");
+    expect(mapped.message).not.toContain("secret");
+  });
+
   it("surfaces a policy rejection as StewardSignerError kind policy_rejected", async () => {
     const signer = await newSigner();
     stub.setMode("reject");

--- a/packages/solana-signer/src/__tests__/steward-signer.test.ts
+++ b/packages/solana-signer/src/__tests__/steward-signer.test.ts
@@ -1,6 +1,10 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
 import { Keypair, SystemProgram, Transaction } from "@solana/web3.js";
-import { createStewardSolanaSigner, StewardSignerError } from "../steward-signer";
+import {
+  createStewardSolanaSigner,
+  SOLANA_MAX_TRANSACTION_BYTES,
+  StewardSignerError,
+} from "../steward-signer";
 import {
   legacyTransfer,
   SINK,
@@ -70,6 +74,12 @@ describe("createStewardSolanaSigner", () => {
     await expect(
       createStewardSolanaSigner({ agentId: AGENT_ID, bearerToken: JWT }),
     ).rejects.toThrow(/baseUrl/);
+  });
+
+  it("rejects empty agent ids and non-Solana chain ids before any API call", async () => {
+    await expect(newSigner({ agentId: " " })).rejects.toThrow(/agentId/);
+    await expect(newSigner({ chainId: 1 })).rejects.toThrow(/101.*102/);
+    expect(stub.requests).toHaveLength(0);
   });
 });
 
@@ -161,6 +171,32 @@ describe("signTransaction", () => {
     const tx = legacyTransfer(vaultKeypair.publicKey);
 
     await expect(signer.signTransaction(tx)).rejects.toThrow(/not a required transaction signer/);
+  });
+
+  it("rejects malformed and oversized transaction encodings before any vault call", async () => {
+    const signer = await newSigner();
+    const before = stub.requests.length;
+    await expect(signer.signSerializedTransaction("not base64!")).rejects.toThrow(
+      /canonical base64/,
+    );
+    await expect(
+      signer.signSerializedTransaction(
+        Buffer.alloc(SOLANA_MAX_TRANSACTION_BYTES + 1).toString("base64"),
+      ),
+    ).rejects.toThrow(/canonical base64/);
+    expect(stub.requests.length).toBe(before);
+  });
+
+  it("requires explicit non-broadcast and matching-chain proof from Steward", async () => {
+    const signer = await newSigner();
+    stub.setMode("missing-broadcast-proof");
+    await expect(signer.signTransaction(legacyTransfer(signer.publicKey))).rejects.toThrow(
+      /broadcast:false was honored/,
+    );
+    stub.setMode("wrong-chain");
+    await expect(signer.signTransaction(legacyTransfer(signer.publicKey))).rejects.toThrow(
+      /mismatched Solana chainId/,
+    );
   });
 
   it("signs a v0 versioned transaction", async () => {

--- a/packages/solana-signer/src/__tests__/steward-signer.test.ts
+++ b/packages/solana-signer/src/__tests__/steward-signer.test.ts
@@ -201,6 +201,28 @@ describe("signTransaction", () => {
     expect(stub.requests.length).toBe(before);
   });
 
+  it("rejects a valid transaction prefix with trailing bytes before any vault call", async () => {
+    const signer = await newSigner();
+    const before = stub.requests.length;
+    const canonical = legacyTransfer(signer.publicKey).serialize({
+      requireAllSignatures: false,
+      verifySignatures: false,
+    });
+    const nonCanonical = Buffer.concat([canonical, Buffer.from([0xa5])]).toString("base64");
+
+    await expect(signer.signSerializedTransaction(nonCanonical)).rejects.toThrow(/non-canonical/);
+    expect(stub.requests.length).toBe(before);
+  });
+
+  it("rejects a Steward response with trailing parser-ignored bytes", async () => {
+    const signer = await newSigner();
+    stub.setMode("trailing-response-bytes");
+
+    await expect(signer.signTransaction(legacyTransfer(signer.publicKey))).rejects.toThrow(
+      /non-canonical/,
+    );
+  });
+
   it("requires explicit non-broadcast and matching-chain proof from Steward", async () => {
     const signer = await newSigner();
     stub.setMode("missing-broadcast-proof");

--- a/packages/solana-signer/src/__tests__/steward-signer.test.ts
+++ b/packages/solana-signer/src/__tests__/steward-signer.test.ts
@@ -132,6 +132,37 @@ describe("signTransaction", () => {
     for (const slot of tx.signatures) expect(slot.signature).not.toBeNull();
   });
 
+  it("rejects an invalid signature returned by the Steward API", async () => {
+    const signer = await newSigner();
+    stub.setMode("invalid-signature");
+    await expect(signer.signTransaction(legacyTransfer(signer.publicKey))).rejects.toThrow(
+      /invalid Solana signature/,
+    );
+  });
+
+  it("rejects a response that changes an existing co-signer signature", async () => {
+    const signer = await newSigner();
+    const coSigner = Keypair.fromSeed(new Uint8Array(32).fill(6));
+    const tx = new Transaction().add(
+      SystemProgram.transfer({ fromPubkey: signer.publicKey, toPubkey: SINK, lamports: 1_000 }),
+      SystemProgram.transfer({ fromPubkey: coSigner.publicKey, toPubkey: SINK, lamports: 1 }),
+    );
+    tx.recentBlockhash = STUB_BLOCKHASH;
+    tx.feePayer = signer.publicKey;
+    tx.partialSign(coSigner);
+    stub.setMode("changed-cosigner");
+
+    await expect(signer.signTransaction(tx)).rejects.toThrow(/changed an existing co-signer/);
+  });
+
+  it("rejects a configured Steward address that is not a required signer", async () => {
+    const outsider = Keypair.fromSeed(new Uint8Array(32).fill(12)).publicKey;
+    const signer = await newSigner({ address: outsider.toBase58() });
+    const tx = legacyTransfer(vaultKeypair.publicKey);
+
+    await expect(signer.signTransaction(tx)).rejects.toThrow(/not a required transaction signer/);
+  });
+
   it("signs a v0 versioned transaction", async () => {
     const signer = await newSigner();
     const vtx = versionedTransfer(signer.publicKey);

--- a/packages/solana-signer/src/__tests__/steward-signer.test.ts
+++ b/packages/solana-signer/src/__tests__/steward-signer.test.ts
@@ -162,7 +162,21 @@ describe("signTransaction", () => {
     tx.partialSign(coSigner);
     stub.setMode("changed-cosigner");
 
-    await expect(signer.signTransaction(tx)).rejects.toThrow(/changed an existing co-signer/);
+    await expect(signer.signTransaction(tx)).rejects.toThrow(/changed a co-signer/);
+  });
+
+  it("rejects a response that injects a previously absent co-signer signature", async () => {
+    const signer = await newSigner();
+    const coSigner = Keypair.fromSeed(new Uint8Array(32).fill(6));
+    const tx = new Transaction().add(
+      SystemProgram.transfer({ fromPubkey: signer.publicKey, toPubkey: SINK, lamports: 1_000 }),
+      SystemProgram.transfer({ fromPubkey: coSigner.publicKey, toPubkey: SINK, lamports: 1 }),
+    );
+    tx.recentBlockhash = STUB_BLOCKHASH;
+    tx.feePayer = signer.publicKey;
+    stub.setMode("injected-cosigner");
+
+    await expect(signer.signTransaction(tx)).rejects.toThrow(/changed a co-signer/);
   });
 
   it("rejects a configured Steward address that is not a required signer", async () => {

--- a/packages/solana-signer/src/__tests__/steward-signer.test.ts
+++ b/packages/solana-signer/src/__tests__/steward-signer.test.ts
@@ -1,5 +1,11 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
-import { Keypair, SystemProgram, Transaction } from "@solana/web3.js";
+import {
+  Keypair,
+  MessageV0,
+  SystemProgram,
+  Transaction,
+  VersionedTransaction,
+} from "@solana/web3.js";
 import {
   createStewardSolanaSigner,
   SOLANA_MAX_TRANSACTION_BYTES,
@@ -44,6 +50,22 @@ function newSigner(overrides: Record<string, unknown> = {}) {
   });
 }
 
+function versionedMultiSignerTransfer(
+  payer: Keypair["publicKey"],
+  coSigner: Keypair["publicKey"],
+): VersionedTransaction {
+  return new VersionedTransaction(
+    MessageV0.compile({
+      payerKey: payer,
+      recentBlockhash: STUB_BLOCKHASH,
+      instructions: [
+        SystemProgram.transfer({ fromPubkey: payer, toPubkey: SINK, lamports: 1_000 }),
+        SystemProgram.transfer({ fromPubkey: coSigner, toPubkey: SINK, lamports: 1 }),
+      ],
+    }),
+  );
+}
+
 describe("createStewardSolanaSigner", () => {
   it("resolves the agent's Solana address from the vault and sends the bearer JWT", async () => {
     const signer = await newSigner();
@@ -81,6 +103,16 @@ describe("createStewardSolanaSigner", () => {
     await expect(newSigner({ agentId: " " })).rejects.toThrow(/agentId/);
     await expect(newSigner({ chainId: 1 })).rejects.toThrow(/101.*102/);
     expect(stub.requests).toHaveLength(0);
+  });
+
+  it("normalizes a malformed successful address response", async () => {
+    stub.setMode("malformed-addresses");
+    const err = await newSigner().catch((cause: unknown) => cause);
+    expect(err).toBeInstanceOf(StewardSignerError);
+    expect((err as StewardSignerError).kind).toBe("api");
+    expect((err as StewardSignerError).message).toBe(
+      "Steward returned a malformed address response",
+    );
   });
 });
 
@@ -252,6 +284,72 @@ describe("signTransaction", () => {
       return copy.signatures[0];
     })();
     expect(Buffer.from(vtx.signatures[0]).equals(Buffer.from(expected))).toBe(true);
+  });
+
+  it("preserves existing and empty v0 co-signer slots byte-for-byte", async () => {
+    const signer = await newSigner();
+    const coSigner = Keypair.fromSeed(new Uint8Array(32).fill(16));
+
+    const signedCoSigner = versionedMultiSignerTransfer(signer.publicKey, coSigner.publicKey);
+    signedCoSigner.sign([coSigner]);
+    const prior = signedCoSigner.signatures[1].slice();
+    await signer.signTransaction(signedCoSigner);
+    expect(Buffer.from(signedCoSigner.signatures[1]).equals(Buffer.from(prior))).toBe(true);
+
+    const emptyCoSigner = versionedMultiSignerTransfer(signer.publicKey, coSigner.publicKey);
+    const empty = emptyCoSigner.signatures[1].slice();
+    await signer.signTransaction(emptyCoSigner);
+    expect(Buffer.from(emptyCoSigner.signatures[1]).equals(Buffer.from(empty))).toBe(true);
+  });
+
+  it("rejects changed and injected v0 co-signer slots", async () => {
+    const signer = await newSigner();
+    const coSigner = Keypair.fromSeed(new Uint8Array(32).fill(17));
+    const changed = versionedMultiSignerTransfer(signer.publicKey, coSigner.publicKey);
+    changed.sign([coSigner]);
+    stub.setMode("changed-cosigner");
+    await expect(signer.signTransaction(changed)).rejects.toThrow(/changed a co-signer/);
+
+    const injected = versionedMultiSignerTransfer(signer.publicKey, coSigner.publicKey);
+    stub.setMode("injected-cosigner");
+    await expect(signer.signTransaction(injected)).rejects.toThrow(/changed a co-signer/);
+  });
+
+  it("rejects transaction mutation by hints or while signing", async () => {
+    const mutatedByHints = legacyTransfer(vaultKeypair.publicKey);
+    const hintSigner = await newSigner({
+      address: vaultKeypair.publicKey.toBase58(),
+      hints: (tx: Transaction) => {
+        tx.recentBlockhash = new Keypair().publicKey.toBase58();
+        return undefined;
+      },
+    });
+    const before = stub.requests.length;
+    await expect(hintSigner.signTransaction(mutatedByHints)).rejects.toThrow(
+      /changed while preparing signing/,
+    );
+    expect(stub.requests.length).toBe(before);
+
+    const signer = await newSigner();
+    const mutatedInFlight = legacyTransfer(signer.publicKey);
+    stub.setMode("slow-sign");
+    const pending = signer.signTransaction(mutatedInFlight);
+    await Bun.sleep(5);
+    mutatedInFlight.recentBlockhash = new Keypair().publicKey.toBase58();
+    await expect(pending).rejects.toThrow(/changed during signing/);
+  });
+
+  it("normalizes a malformed successful signing response", async () => {
+    const signer = await newSigner();
+    stub.setMode("malformed-sign-result");
+    const err = await signer
+      .signTransaction(legacyTransfer(signer.publicKey))
+      .catch((cause: unknown) => cause);
+    expect(err).toBeInstanceOf(StewardSignerError);
+    expect((err as StewardSignerError).kind).toBe("api");
+    expect((err as StewardSignerError).message).toBe(
+      "Steward returned a malformed signing response",
+    );
   });
 
   it("forwards advisory to/value hints for the blind-signing path", async () => {

--- a/packages/solana-signer/src/__tests__/steward-signer.test.ts
+++ b/packages/solana-signer/src/__tests__/steward-signer.test.ts
@@ -1,0 +1,222 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { Keypair, SystemProgram, Transaction } from "@solana/web3.js";
+import { createStewardSolanaSigner, StewardSignerError } from "../steward-signer";
+import {
+  legacyTransfer,
+  SINK,
+  STUB_BLOCKHASH,
+  type StubSteward,
+  startStubSteward,
+  versionedTransfer,
+} from "./harness";
+
+const AGENT_ID = "agent-1";
+const JWT = "eyJhbGciOiJIUzI1NiJ9.eyJhZ2VudElkIjoiYWdlbnQtMSJ9.stub-signature";
+
+const vaultKeypair = Keypair.fromSeed(new Uint8Array(32).fill(42));
+
+let stub: StubSteward;
+
+beforeAll(() => {
+  stub = startStubSteward(vaultKeypair);
+});
+
+afterAll(() => {
+  stub.stop();
+});
+
+beforeEach(() => {
+  stub.setMode("sign");
+  stub.requests.length = 0;
+});
+
+function newSigner(overrides: Record<string, unknown> = {}) {
+  return createStewardSolanaSigner({
+    baseUrl: stub.url,
+    agentId: AGENT_ID,
+    bearerToken: JWT,
+    ...overrides,
+  });
+}
+
+describe("createStewardSolanaSigner", () => {
+  it("resolves the agent's Solana address from the vault and sends the bearer JWT", async () => {
+    const signer = await newSigner();
+    expect(signer.address).toBe(vaultKeypair.publicKey.toBase58());
+    expect(signer.publicKey.equals(vaultKeypair.publicKey)).toBe(true);
+
+    expect(stub.requests).toHaveLength(1);
+    const req = stub.requests[0];
+    expect(req.method).toBe("GET");
+    expect(req.path).toBe(`/vault/${AGENT_ID}/addresses`);
+    expect(req.headers.authorization).toBe(`Bearer ${JWT}`);
+    expect(req.headers["x-steward-key"]).toBeUndefined();
+  });
+
+  it("skips the address lookup when the address is supplied", async () => {
+    const signer = await newSigner({ address: vaultKeypair.publicKey.toBase58() });
+    expect(signer.address).toBe(vaultKeypair.publicKey.toBase58());
+    expect(stub.requests).toHaveLength(0);
+  });
+
+  it("uses X-Steward-Key when configured with an API key", async () => {
+    await createStewardSolanaSigner({ baseUrl: stub.url, agentId: AGENT_ID, apiKey: "sk-test" });
+    const req = stub.requests[0];
+    expect(req.headers["x-steward-key"]).toBe("sk-test");
+    expect(req.headers.authorization).toBeUndefined();
+  });
+
+  it("refuses construction without baseUrl or client", async () => {
+    await expect(
+      createStewardSolanaSigner({ agentId: AGENT_ID, bearerToken: JWT }),
+    ).rejects.toThrow(/baseUrl/);
+  });
+});
+
+describe("signTransaction", () => {
+  it("signs a legacy transaction through the vault with broadcast:false", async () => {
+    const signer = await newSigner();
+    const tx = legacyTransfer(signer.publicKey);
+
+    const signed = await signer.signTransaction(tx);
+    expect(signed).toBe(tx);
+    expect(tx.verifySignatures()).toBe(true);
+
+    const req = stub.requests.at(-1);
+    expect(req?.method).toBe("POST");
+    expect(req?.path).toBe(`/vault/${AGENT_ID}/sign-solana`);
+    expect(req?.headers.authorization).toBe(`Bearer ${JWT}`);
+    const body = req?.body as { transaction: string; broadcast: boolean; chainId: number };
+    expect(body.broadcast).toBe(false);
+    expect(body.chainId).toBe(101);
+    expect(Buffer.from(body.transaction, "base64").length).toBeGreaterThan(0);
+  });
+
+  it("never asks the vault to broadcast, on every request", async () => {
+    const signer = await newSigner();
+    await signer.signAllTransactions([
+      legacyTransfer(signer.publicKey),
+      legacyTransfer(signer.publicKey),
+    ]);
+    const signBodies = stub.requests
+      .filter((r) => r.path.endsWith("/sign-solana"))
+      .map((r) => r.body as { broadcast?: boolean });
+    expect(signBodies).toHaveLength(2);
+    for (const body of signBodies) expect(body.broadcast).toBe(false);
+  });
+
+  it("preserves partial signatures added by co-signing keypairs", async () => {
+    const signer = await newSigner();
+    const mintKeypair = Keypair.fromSeed(new Uint8Array(32).fill(5));
+
+    const tx = new Transaction();
+    tx.add(
+      SystemProgram.transfer({ fromPubkey: signer.publicKey, toPubkey: SINK, lamports: 1_000 }),
+    );
+    tx.add(
+      SystemProgram.transfer({
+        fromPubkey: mintKeypair.publicKey,
+        toPubkey: SINK,
+        lamports: 500,
+      }),
+    );
+    tx.recentBlockhash = STUB_BLOCKHASH;
+    tx.feePayer = signer.publicKey;
+    tx.partialSign(mintKeypair);
+
+    await signer.signTransaction(tx);
+    expect(tx.verifySignatures()).toBe(true);
+    const signerSlots = tx.signatures.map((s) => s.publicKey.toBase58());
+    expect(signerSlots).toContain(signer.publicKey.toBase58());
+    expect(signerSlots).toContain(mintKeypair.publicKey.toBase58());
+    for (const slot of tx.signatures) expect(slot.signature).not.toBeNull();
+  });
+
+  it("signs a v0 versioned transaction", async () => {
+    const signer = await newSigner();
+    const vtx = versionedTransfer(signer.publicKey);
+    const unsignedBytes = vtx.serialize();
+
+    const signed = await signer.signTransaction(vtx);
+    expect(signed).toBe(vtx);
+
+    // ed25519 is deterministic: signing the same bytes locally must match.
+    const expected = (() => {
+      const copy = versionedTransfer(signer.publicKey);
+      void unsignedBytes;
+      copy.sign([vaultKeypair]);
+      return copy.signatures[0];
+    })();
+    expect(Buffer.from(vtx.signatures[0]).equals(Buffer.from(expected))).toBe(true);
+  });
+
+  it("forwards advisory to/value hints for the blind-signing path", async () => {
+    const signer = await newSigner({
+      hints: () => ({ to: SINK.toBase58(), value: "1000" }),
+    });
+    await signer.signTransaction(legacyTransfer(signer.publicKey));
+    const body = stub.requests.at(-1)?.body as { to?: string; value?: string };
+    expect(body.to).toBe(SINK.toBase58());
+    expect(body.value).toBe("1000");
+  });
+});
+
+describe("refusal propagation", () => {
+  it("surfaces a policy rejection as StewardSignerError kind policy_rejected", async () => {
+    const signer = await newSigner();
+    stub.setMode("reject");
+    const before = stub.requests.length;
+
+    const err = await signer.signTransaction(legacyTransfer(signer.publicKey)).then(
+      () => {
+        throw new Error("expected a rejection");
+      },
+      (e: unknown) => e,
+    );
+
+    expect(err).toBeInstanceOf(StewardSignerError);
+    const signerErr = err as StewardSignerError;
+    expect(signerErr.kind).toBe("policy_rejected");
+    expect(signerErr.status).toBe(403);
+    expect(signerErr.txId).toBe("tx-reject-1");
+    expect(signerErr.policyResults).toHaveLength(1);
+    expect(signerErr.message).toContain("daily cap 0.5 SOL exceeded");
+    expect(stub.requests.length - before).toBe(1);
+  });
+
+  it("surfaces manual-approval queueing as kind pending_approval with the txId", async () => {
+    const signer = await newSigner();
+    stub.setMode("pending");
+
+    const err = await signer.signTransaction(legacyTransfer(signer.publicKey)).then(
+      () => {
+        throw new Error("expected a pending refusal");
+      },
+      (e: unknown) => e,
+    );
+
+    const signerErr = err as StewardSignerError;
+    expect(signerErr).toBeInstanceOf(StewardSignerError);
+    expect(signerErr.kind).toBe("pending_approval");
+    expect(signerErr.txId).toBe("tx-pending-1");
+    expect(signerErr.message).toMatch(/approval/i);
+  });
+
+  it("surfaces a scope refusal as kind auth", async () => {
+    const signer = await newSigner();
+    stub.setMode("forbidden");
+
+    const err = await signer.signTransaction(legacyTransfer(signer.publicKey)).then(
+      () => {
+        throw new Error("expected an auth refusal");
+      },
+      (e: unknown) => e,
+    );
+
+    const signerErr = err as StewardSignerError;
+    expect(signerErr).toBeInstanceOf(StewardSignerError);
+    expect(signerErr.kind).toBe("auth");
+    expect(signerErr.status).toBe(403);
+    expect(signerErr.message).toContain("token scope");
+  });
+});

--- a/packages/solana-signer/src/__tests__/steward-signer.test.ts
+++ b/packages/solana-signer/src/__tests__/steward-signer.test.ts
@@ -148,6 +148,23 @@ describe("signTransaction", () => {
     for (const body of signBodies) expect(body.broadcast).toBe(false);
   });
 
+  it("uses a stable body-bound idempotency key for lost-response retries", async () => {
+    const signer = await newSigner();
+    await signer.signTransaction(legacyTransfer(signer.publicKey));
+    await signer.signTransaction(legacyTransfer(signer.publicKey));
+    const repeated = stub.requests.filter((request) => request.path.endsWith("/sign-solana"));
+    expect(repeated).toHaveLength(2);
+    const firstKey = repeated[0]?.headers["idempotency-key"];
+    expect(firstKey).toMatch(/^steward-solana-sign-v1-[0-9a-f]{64}$/);
+    expect(repeated[1]?.headers["idempotency-key"]).toBe(firstKey);
+
+    const hintedSigner = await newSigner({
+      hints: () => ({ to: SINK.toBase58(), value: "1000" }),
+    });
+    await hintedSigner.signTransaction(legacyTransfer(hintedSigner.publicKey));
+    expect(stub.requests.at(-1)?.headers["idempotency-key"]).not.toBe(firstKey);
+  });
+
   it("preserves partial signatures added by co-signing keypairs", async () => {
     const signer = await newSigner();
     const mintKeypair = Keypair.fromSeed(new Uint8Array(32).fill(5));

--- a/packages/solana-signer/src/bridge.ts
+++ b/packages/solana-signer/src/bridge.ts
@@ -35,6 +35,9 @@ export const BRIDGE_TOKEN_HEADER = "x-steward-bridge-token";
 /** Env var supplying the shared secret on BOTH sides of the bridge. */
 export const BRIDGE_TOKEN_ENV = "STEWARD_SIGNER_BRIDGE_TOKEN";
 
+/** Enough for Solana's transaction limit plus JSON/hints, while bounding RAM. */
+export const BRIDGE_MAX_BODY_BYTES = 16 * 1024;
+
 export interface SignerBridgeOptions {
   /** Bind host. Loopback by default; never expose this beyond the machine. */
   host?: string;
@@ -86,8 +89,23 @@ function respond(res: ServerResponse, status: number, body: object): void {
 }
 
 async function readJson(req: IncomingMessage): Promise<Record<string, unknown>> {
+  const declaredLength = Number(req.headers["content-length"]);
+  if (
+    req.headers["content-length"] !== undefined &&
+    (!Number.isSafeInteger(declaredLength) ||
+      declaredLength < 0 ||
+      declaredLength > BRIDGE_MAX_BODY_BYTES)
+  ) {
+    throw new PayloadTooLargeError();
+  }
   const chunks: Buffer[] = [];
-  for await (const chunk of req) chunks.push(chunk as Buffer);
+  let received = 0;
+  for await (const chunk of req) {
+    const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as Uint8Array);
+    received += bytes.length;
+    if (received > BRIDGE_MAX_BODY_BYTES) throw new PayloadTooLargeError();
+    chunks.push(bytes);
+  }
   const text = Buffer.concat(chunks).toString("utf8");
   const parsed: unknown = JSON.parse(text);
   if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
@@ -96,15 +114,30 @@ async function readJson(req: IncomingMessage): Promise<Record<string, unknown>> 
   return parsed as Record<string, unknown>;
 }
 
+class PayloadTooLargeError extends Error {}
+
+function assertLoopbackHost(host: string): void {
+  if (host !== "127.0.0.1" && host !== "::1" && host !== "localhost") {
+    throw new StewardSignerError(
+      "api",
+      `signer bridge host must be loopback (127.0.0.1, ::1, or localhost), got ${host}`,
+    );
+  }
+}
+
 export async function startSignerBridge(
   signer: StewardSolanaSigner,
   options: SignerBridgeOptions = {},
 ): Promise<SignerBridge> {
   const host = options.host ?? "127.0.0.1";
+  assertLoopbackHost(host);
   const token =
     options.token === undefined
       ? process.env[BRIDGE_TOKEN_ENV] || randomBytes(32).toString("hex")
       : options.token;
+  if (token !== null && token.length === 0) {
+    throw new StewardSignerError("api", "signer bridge token must not be empty");
+  }
 
   const server = createServer((req, res) => {
     void handle(req, res);
@@ -131,6 +164,10 @@ export async function startSignerBridge(
         try {
           body = await readJson(req);
         } catch (err) {
+          if (err instanceof PayloadTooLargeError) {
+            respond(res, 413, { error: `request body exceeds ${BRIDGE_MAX_BODY_BYTES} bytes` });
+            return;
+          }
           respond(res, 400, { error: err instanceof Error ? err.message : "invalid JSON body" });
           return;
         }
@@ -172,7 +209,7 @@ export async function startSignerBridge(
     throw new StewardSignerError("api", "signer bridge failed to bind a TCP port");
   }
   return {
-    url: `http://${host}:${bound.port}`,
+    url: `http://${host.includes(":") ? `[${host}]` : host}:${bound.port}`,
     token,
     server,
     close: () =>

--- a/packages/solana-signer/src/bridge.ts
+++ b/packages/solana-signer/src/bridge.ts
@@ -17,10 +17,9 @@
 // STEWARD_SIGNER_BRIDGE_TOKEN env var when set (the same var the consumer
 // process reads to send the header), otherwise a fresh random token is
 // generated per session and exposed as `token` on the returned bridge. A
-// missing or wrong header is 401 before the signer is touched. Consumers that
-// cannot send headers yet (the current AgentNet remote-wallet draft) need the
-// operator to pass `token: null`, an explicit, visible opt-in to an open
-// loopback port.
+// missing or wrong header is 401 before the signer is touched. There is no
+// unauthenticated mode: browser CSRF and unrelated local processes can reach
+// loopback ports too.
 //
 // Policy refusals map to JSON errors with the refusal text and kind, so the
 // remote side can print WHY the vault said no instead of a bare status code.
@@ -37,6 +36,7 @@ export const BRIDGE_TOKEN_ENV = "STEWARD_SIGNER_BRIDGE_TOKEN";
 
 /** Enough for Solana's transaction limit plus JSON/hints, while bounding RAM. */
 export const BRIDGE_MAX_BODY_BYTES = 16 * 1024;
+export const BRIDGE_MIN_TOKEN_BYTES = 32;
 
 export interface SignerBridgeOptions {
   /** Bind host. Loopback by default; never expose this beyond the machine. */
@@ -46,16 +46,14 @@ export interface SignerBridgeOptions {
   /** Shared secret required in the x-steward-bridge-token header of every
    *  request. Omitted: STEWARD_SIGNER_BRIDGE_TOKEN from the env when set,
    *  else a fresh random token per session (read it from the returned
-   *  bridge's `token`). Pass null, explicitly, to run the bridge open for
-   *  consumers that cannot send headers yet; any local process can then use
-   *  the signer, so prefer the token whenever the consumer supports it. */
-  token?: string | null;
+   *  bridge's `token`). Must contain at least 32 UTF-8 bytes. */
+  token?: string;
 }
 
 export interface SignerBridge {
   url: string;
-  /** The armed shared secret, or null when the bridge was explicitly opened. */
-  token: string | null;
+  /** The armed shared secret. */
+  token: string;
   server: Server;
   close(): Promise<void>;
 }
@@ -84,7 +82,11 @@ function statusFor(kind: StewardSignerError["kind"]): number {
 
 function respond(res: ServerResponse, status: number, body: object): void {
   const payload = JSON.stringify(body);
-  res.writeHead(status, { "Content-Type": "application/json" });
+  res.writeHead(status, {
+    "Cache-Control": "no-store",
+    "Content-Type": "application/json",
+    "X-Content-Type-Options": "nosniff",
+  });
   res.end(payload);
 }
 
@@ -117,10 +119,10 @@ async function readJson(req: IncomingMessage): Promise<Record<string, unknown>> 
 class PayloadTooLargeError extends Error {}
 
 function assertLoopbackHost(host: string): void {
-  if (host !== "127.0.0.1" && host !== "::1" && host !== "localhost") {
+  if (host !== "127.0.0.1" && host !== "::1") {
     throw new StewardSignerError(
       "api",
-      `signer bridge host must be loopback (127.0.0.1, ::1, or localhost), got ${host}`,
+      `signer bridge host must be a loopback IP literal (127.0.0.1 or ::1), got ${host}`,
     );
   }
 }
@@ -135,9 +137,14 @@ export async function startSignerBridge(
     options.token === undefined
       ? process.env[BRIDGE_TOKEN_ENV] || randomBytes(32).toString("hex")
       : options.token;
-  if (token !== null && token.length === 0) {
-    throw new StewardSignerError("api", "signer bridge token must not be empty");
+  if (Buffer.byteLength(token, "utf8") < BRIDGE_MIN_TOKEN_BYTES) {
+    throw new StewardSignerError(
+      "api",
+      `signer bridge token must contain at least ${BRIDGE_MIN_TOKEN_BYTES} bytes`,
+    );
   }
+
+  let signing = false;
 
   const server = createServer((req, res) => {
     void handle(req, res);
@@ -146,7 +153,7 @@ export async function startSignerBridge(
   async function handle(req: IncomingMessage, res: ServerResponse): Promise<void> {
     // Auth before routing: an unauthenticated caller learns nothing and the
     // signer is never touched.
-    if (token !== null && !tokenMatches(req.headers[BRIDGE_TOKEN_HEADER], token)) {
+    if (!tokenMatches(req.headers[BRIDGE_TOKEN_HEADER], token)) {
       respond(res, 401, {
         error:
           `missing or wrong ${BRIDGE_TOKEN_HEADER} header; this bridge only answers ` +
@@ -160,26 +167,44 @@ export async function startSignerBridge(
         return;
       }
       if (req.method === "POST" && req.url === "/sign-transaction") {
-        let body: Record<string, unknown>;
+        if (signing) {
+          respond(res, 429, { error: "another signing request is already in progress" });
+          return;
+        }
+        if (!req.headers["content-type"]?.toLowerCase().startsWith("application/json")) {
+          respond(res, 415, { error: "content-type must be application/json" });
+          return;
+        }
+        // Reserve the single signing slot before the first await. Otherwise two
+        // slow/chunked bodies can both observe `signing === false` and race into
+        // the vault together after parsing.
+        signing = true;
         try {
-          body = await readJson(req);
-        } catch (err) {
-          if (err instanceof PayloadTooLargeError) {
-            respond(res, 413, { error: `request body exceeds ${BRIDGE_MAX_BODY_BYTES} bytes` });
+          let body: Record<string, unknown>;
+          try {
+            body = await readJson(req);
+          } catch (err) {
+            if (err instanceof PayloadTooLargeError) {
+              respond(res, 413, { error: `request body exceeds ${BRIDGE_MAX_BODY_BYTES} bytes` });
+              return;
+            }
+            respond(res, 400, { error: err instanceof Error ? err.message : "invalid JSON body" });
             return;
           }
-          respond(res, 400, { error: err instanceof Error ? err.message : "invalid JSON body" });
-          return;
+          if (typeof body.transaction !== "string" || body.transaction.length === 0) {
+            respond(res, 400, {
+              error: "'transaction' (base64 serialized Solana tx) is required",
+            });
+            return;
+          }
+          const transaction = await signer.signSerializedTransaction(body.transaction, {
+            to: typeof body.to === "string" ? body.to : undefined,
+            value: typeof body.value === "string" ? body.value : undefined,
+          });
+          respond(res, 200, { transaction });
+        } finally {
+          signing = false;
         }
-        if (typeof body.transaction !== "string" || body.transaction.length === 0) {
-          respond(res, 400, { error: "'transaction' (base64 serialized Solana tx) is required" });
-          return;
-        }
-        const transaction = await signer.signSerializedTransaction(body.transaction, {
-          to: typeof body.to === "string" ? body.to : undefined,
-          value: typeof body.value === "string" ? body.value : undefined,
-        });
-        respond(res, 200, { transaction });
         return;
       }
       if (req.method === "POST" && req.url === "/sign-message") {
@@ -193,7 +218,7 @@ export async function startSignerBridge(
     } catch (err) {
       const mapped = toSignerError(err);
       respond(res, statusFor(mapped.kind), {
-        error: mapped.message,
+        error: mapped.kind === "api" ? "Steward signing service failed" : mapped.message,
         kind: mapped.kind,
         ...(mapped.txId ? { txId: mapped.txId } : {}),
       });
@@ -204,6 +229,9 @@ export async function startSignerBridge(
     server.once("error", reject);
     server.listen(options.port ?? 0, host, resolve);
   });
+  server.requestTimeout = 10_000;
+  server.headersTimeout = 5_000;
+  server.keepAliveTimeout = 5_000;
   const bound = server.address();
   if (bound === null || typeof bound === "string") {
     throw new StewardSignerError("api", "signer bridge failed to bind a TCP port");

--- a/packages/solana-signer/src/bridge.ts
+++ b/packages/solana-signer/src/bridge.ts
@@ -1,0 +1,183 @@
+// Loopback HTTP bridge: the out-of-process face of the Steward Solana signer.
+//
+// Consumers that spawn their own process (the AgentNet MCP stdio server via its
+// remote-wallet hook) cannot hold the in-process signer object, so they speak
+// this three-endpoint protocol over the operator's loopback instead:
+//
+//   GET  /pubkey            -> { "address": "<base58>" }
+//   POST /sign-transaction  { "transaction": "<base64>", "to"?, "value"? }
+//                           -> { "transaction": "<base64 signed>" }
+//   POST /sign-message      -> 501 always. Steward signs transactions under
+//                              policy, not raw messages, so the endpoint fails
+//                              closed and message-derived features stay off.
+//
+// Loopback is a machine-wide surface: ANY local process can connect to a
+// 127.0.0.1 port, so by default every request must present a shared secret in
+// the x-steward-bridge-token header. The token comes from the
+// STEWARD_SIGNER_BRIDGE_TOKEN env var when set (the same var the consumer
+// process reads to send the header), otherwise a fresh random token is
+// generated per session and exposed as `token` on the returned bridge. A
+// missing or wrong header is 401 before the signer is touched. Consumers that
+// cannot send headers yet (the current AgentNet remote-wallet draft) need the
+// operator to pass `token: null`, an explicit, visible opt-in to an open
+// loopback port.
+//
+// Policy refusals map to JSON errors with the refusal text and kind, so the
+// remote side can print WHY the vault said no instead of a bare status code.
+
+import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { StewardSignerError, type StewardSolanaSigner, toSignerError } from "./steward-signer";
+
+/** Header every bridge request must carry (unless the bridge runs open). */
+export const BRIDGE_TOKEN_HEADER = "x-steward-bridge-token";
+
+/** Env var supplying the shared secret on BOTH sides of the bridge. */
+export const BRIDGE_TOKEN_ENV = "STEWARD_SIGNER_BRIDGE_TOKEN";
+
+export interface SignerBridgeOptions {
+  /** Bind host. Loopback by default; never expose this beyond the machine. */
+  host?: string;
+  /** 0 (default) picks an ephemeral port; read the final one from `url`. */
+  port?: number;
+  /** Shared secret required in the x-steward-bridge-token header of every
+   *  request. Omitted: STEWARD_SIGNER_BRIDGE_TOKEN from the env when set,
+   *  else a fresh random token per session (read it from the returned
+   *  bridge's `token`). Pass null, explicitly, to run the bridge open for
+   *  consumers that cannot send headers yet; any local process can then use
+   *  the signer, so prefer the token whenever the consumer supports it. */
+  token?: string | null;
+}
+
+export interface SignerBridge {
+  url: string;
+  /** The armed shared secret, or null when the bridge was explicitly opened. */
+  token: string | null;
+  server: Server;
+  close(): Promise<void>;
+}
+
+/** Constant-time header check; hashing first keeps lengths equal. */
+function tokenMatches(presented: string | string[] | undefined, expected: string): boolean {
+  if (typeof presented !== "string") return false;
+  return timingSafeEqual(
+    createHash("sha256").update(presented).digest(),
+    createHash("sha256").update(expected).digest(),
+  );
+}
+
+function statusFor(kind: StewardSignerError["kind"]): number {
+  switch (kind) {
+    case "policy_rejected":
+      return 403;
+    case "pending_approval":
+      return 409;
+    case "auth":
+      return 401;
+    default:
+      return 502;
+  }
+}
+
+function respond(res: ServerResponse, status: number, body: object): void {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(payload);
+}
+
+async function readJson(req: IncomingMessage): Promise<Record<string, unknown>> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) chunks.push(chunk as Buffer);
+  const text = Buffer.concat(chunks).toString("utf8");
+  const parsed: unknown = JSON.parse(text);
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("request body must be a JSON object");
+  }
+  return parsed as Record<string, unknown>;
+}
+
+export async function startSignerBridge(
+  signer: StewardSolanaSigner,
+  options: SignerBridgeOptions = {},
+): Promise<SignerBridge> {
+  const host = options.host ?? "127.0.0.1";
+  const token =
+    options.token === undefined
+      ? process.env[BRIDGE_TOKEN_ENV] || randomBytes(32).toString("hex")
+      : options.token;
+
+  const server = createServer((req, res) => {
+    void handle(req, res);
+  });
+
+  async function handle(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    // Auth before routing: an unauthenticated caller learns nothing and the
+    // signer is never touched.
+    if (token !== null && !tokenMatches(req.headers[BRIDGE_TOKEN_HEADER], token)) {
+      respond(res, 401, {
+        error:
+          `missing or wrong ${BRIDGE_TOKEN_HEADER} header; this bridge only answers ` +
+          "callers holding its session's shared secret",
+      });
+      return;
+    }
+    try {
+      if (req.method === "GET" && req.url === "/pubkey") {
+        respond(res, 200, { address: signer.address });
+        return;
+      }
+      if (req.method === "POST" && req.url === "/sign-transaction") {
+        let body: Record<string, unknown>;
+        try {
+          body = await readJson(req);
+        } catch (err) {
+          respond(res, 400, { error: err instanceof Error ? err.message : "invalid JSON body" });
+          return;
+        }
+        if (typeof body.transaction !== "string" || body.transaction.length === 0) {
+          respond(res, 400, { error: "'transaction' (base64 serialized Solana tx) is required" });
+          return;
+        }
+        const transaction = await signer.signSerializedTransaction(body.transaction, {
+          to: typeof body.to === "string" ? body.to : undefined,
+          value: typeof body.value === "string" ? body.value : undefined,
+        });
+        respond(res, 200, { transaction });
+        return;
+      }
+      if (req.method === "POST" && req.url === "/sign-message") {
+        respond(res, 501, {
+          error:
+            "Steward signs transactions under policy, not raw messages; message signing stays closed",
+        });
+        return;
+      }
+      respond(res, 404, { error: "not found" });
+    } catch (err) {
+      const mapped = toSignerError(err);
+      respond(res, statusFor(mapped.kind), {
+        error: mapped.message,
+        kind: mapped.kind,
+        ...(mapped.txId ? { txId: mapped.txId } : {}),
+      });
+    }
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(options.port ?? 0, host, resolve);
+  });
+  const bound = server.address();
+  if (bound === null || typeof bound === "string") {
+    throw new StewardSignerError("api", "signer bridge failed to bind a TCP port");
+  }
+  return {
+    url: `http://${host}:${bound.port}`,
+    token,
+    server,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      }),
+  };
+}

--- a/packages/solana-signer/src/index.ts
+++ b/packages/solana-signer/src/index.ts
@@ -1,0 +1,16 @@
+export {
+  BRIDGE_TOKEN_ENV,
+  BRIDGE_TOKEN_HEADER,
+  type SignerBridge,
+  type SignerBridgeOptions,
+  startSignerBridge,
+} from "./bridge";
+export {
+  createStewardSolanaSigner,
+  type SolanaPolicyHints,
+  StewardSignerError,
+  type StewardSignerErrorKind,
+  type StewardSolanaSigner,
+  type StewardSolanaSignerConfig,
+  toSignerError,
+} from "./steward-signer";

--- a/packages/solana-signer/src/steward-signer.ts
+++ b/packages/solana-signer/src/steward-signer.ts
@@ -177,10 +177,6 @@ function isVersioned(tx: Transaction | VersionedTransaction): tx is VersionedTra
   return "version" in tx;
 }
 
-function hasSignature(signature: Uint8Array | null): signature is Uint8Array {
-  return signature !== null && signature.some((byte) => byte !== 0);
-}
-
 function assertSameBytes(actual: Uint8Array, expected: Uint8Array, message: string): void {
   if (!Buffer.from(actual).equals(Buffer.from(expected))) {
     throw new StewardSignerError("api", message);
@@ -233,11 +229,11 @@ function validateSignedResponse(
     }
     for (let index = 0; index < submitted.signatures.length; index += 1) {
       const prior = submitted.signatures[index];
-      if (index !== signerIndex && hasSignature(prior)) {
+      if (index !== signerIndex) {
         assertSameBytes(
           returned.signatures[index] ?? new Uint8Array(),
           prior,
-          "Steward changed an existing co-signer signature",
+          "Steward changed a co-signer signature slot",
         );
       }
     }
@@ -270,12 +266,18 @@ function validateSignedResponse(
   }
   for (let index = 0; index < submittedLegacy.signatures.length; index += 1) {
     const prior = submittedLegacy.signatures[index]?.signature;
-    if (index !== signerIndex && hasSignature(prior)) {
+    if (index !== signerIndex) {
       const returnedSignature = returnedLegacy.signatures[index]?.signature;
-      if (!returnedSignature) {
-        throw new StewardSignerError("api", "Steward removed an existing co-signer signature");
+      if (prior === null || prior === undefined) {
+        if (returnedSignature !== null && returnedSignature !== undefined) {
+          throw new StewardSignerError("api", "Steward changed a co-signer signature slot");
+        }
+      } else {
+        if (!returnedSignature) {
+          throw new StewardSignerError("api", "Steward changed a co-signer signature slot");
+        }
+        assertSameBytes(returnedSignature, prior, "Steward changed a co-signer signature slot");
       }
-      assertSameBytes(returnedSignature, prior, "Steward changed an existing co-signer signature");
     }
   }
   const stewardSignature = returnedLegacy.signatures[signerIndex]?.signature;

--- a/packages/solana-signer/src/steward-signer.ts
+++ b/packages/solana-signer/src/steward-signer.ts
@@ -16,6 +16,7 @@
 //
 // Sign-only by design: this module never broadcasts and never touches keys.
 
+import { createPublicKey, verify } from "node:crypto";
 import { PublicKey, Transaction, VersionedTransaction } from "@solana/web3.js";
 import { type PolicyResult, StewardApiError, StewardClient } from "@stwd/sdk";
 
@@ -152,6 +153,133 @@ function isVersioned(tx: Transaction | VersionedTransaction): tx is VersionedTra
   return "version" in tx;
 }
 
+function hasSignature(signature: Uint8Array | null): signature is Uint8Array {
+  return signature !== null && signature.some((byte) => byte !== 0);
+}
+
+function assertSameBytes(actual: Uint8Array, expected: Uint8Array, message: string): void {
+  if (!Buffer.from(actual).equals(Buffer.from(expected))) {
+    throw new StewardSignerError("api", message);
+  }
+}
+
+function verifySolanaSignature(
+  publicKey: PublicKey,
+  message: Uint8Array,
+  signature: Uint8Array,
+): boolean {
+  // RFC 8410 SubjectPublicKeyInfo prefix for a raw 32-byte Ed25519 public key.
+  const spki = Buffer.concat([
+    Buffer.from("302a300506032b6570032100", "hex"),
+    Buffer.from(publicKey.toBytes()),
+  ]);
+  return verify(
+    null,
+    Buffer.from(message),
+    createPublicKey({ key: spki, format: "der", type: "spki" }),
+    signature,
+  );
+}
+
+function validateSignedResponse(
+  submitted: Transaction | VersionedTransaction,
+  returned: Transaction | VersionedTransaction,
+  publicKey: PublicKey,
+): void {
+  if (isVersioned(submitted) !== isVersioned(returned)) {
+    throw new StewardSignerError("api", "Steward returned a different Solana transaction format");
+  }
+
+  if (isVersioned(submitted) && isVersioned(returned)) {
+    const submittedMessage = submitted.message.serialize();
+    assertSameBytes(
+      returned.message.serialize(),
+      submittedMessage,
+      "Steward returned signatures for a different Solana message",
+    );
+    const required = submitted.message.header.numRequiredSignatures;
+    const signerIndex = submitted.message.staticAccountKeys
+      .slice(0, required)
+      .findIndex((key) => key.equals(publicKey));
+    if (signerIndex < 0) {
+      throw new StewardSignerError(
+        "api",
+        "the Steward Solana address is not a required transaction signer",
+      );
+    }
+    for (let index = 0; index < submitted.signatures.length; index += 1) {
+      const prior = submitted.signatures[index];
+      if (index !== signerIndex && hasSignature(prior)) {
+        assertSameBytes(
+          returned.signatures[index] ?? new Uint8Array(),
+          prior,
+          "Steward changed an existing co-signer signature",
+        );
+      }
+    }
+    const stewardSignature = returned.signatures[signerIndex];
+    if (
+      !stewardSignature ||
+      !verifySolanaSignature(publicKey, submittedMessage, stewardSignature)
+    ) {
+      throw new StewardSignerError("api", "Steward returned an invalid Solana signature");
+    }
+    return;
+  }
+
+  const submittedLegacy = submitted as Transaction;
+  const returnedLegacy = returned as Transaction;
+  const submittedMessage = submittedLegacy.serializeMessage();
+  assertSameBytes(
+    returnedLegacy.serializeMessage(),
+    submittedMessage,
+    "Steward returned signatures for a different Solana message",
+  );
+  const signerIndex = submittedLegacy.signatures.findIndex((entry) =>
+    entry.publicKey.equals(publicKey),
+  );
+  if (signerIndex < 0) {
+    throw new StewardSignerError(
+      "api",
+      "the Steward Solana address is not a required transaction signer",
+    );
+  }
+  for (let index = 0; index < submittedLegacy.signatures.length; index += 1) {
+    const prior = submittedLegacy.signatures[index]?.signature;
+    if (index !== signerIndex && hasSignature(prior)) {
+      const returnedSignature = returnedLegacy.signatures[index]?.signature;
+      if (!returnedSignature) {
+        throw new StewardSignerError("api", "Steward removed an existing co-signer signature");
+      }
+      assertSameBytes(returnedSignature, prior, "Steward changed an existing co-signer signature");
+    }
+  }
+  const stewardSignature = returnedLegacy.signatures[signerIndex]?.signature;
+  if (!stewardSignature || !verifySolanaSignature(publicKey, submittedMessage, stewardSignature)) {
+    throw new StewardSignerError("api", "Steward returned an invalid Solana signature");
+  }
+}
+
+function deserializeTransaction(bytes: Uint8Array): Transaction | VersionedTransaction {
+  // A serialized transaction starts with compact-u16 signature count and slots;
+  // the following message byte has its high bit set for versioned messages.
+  let signatureCount = 0;
+  let bytesRead = 0;
+  for (let shift = 0; ; shift += 7) {
+    const byte = bytes[bytesRead];
+    if (byte === undefined || shift > 21)
+      throw new StewardSignerError("api", "invalid Solana transaction");
+    bytesRead += 1;
+    signatureCount |= (byte & 0x7f) << shift;
+    if ((byte & 0x80) === 0) break;
+  }
+  const messageByte = bytes[bytesRead + signatureCount * 64];
+  if (messageByte === undefined) throw new StewardSignerError("api", "invalid Solana transaction");
+  return (messageByte & 0x80) !== 0
+    ? VersionedTransaction.deserialize(bytes)
+    : Transaction.from(bytes);
+}
+
 /** Build a signer for one Steward agent. Async because it resolves the agent's
  *  Solana address from the vault unless `address` is supplied. */
 export async function createStewardSolanaSigner(
@@ -190,6 +318,12 @@ export async function createStewardSolanaSigner(
     txBase64: string,
     hints?: SolanaPolicyHints,
   ): Promise<string> {
+    let submitted: Transaction | VersionedTransaction;
+    try {
+      submitted = deserializeTransaction(Uint8Array.from(Buffer.from(txBase64, "base64")));
+    } catch (err) {
+      throw toSignerError(err);
+    }
     let result: Awaited<ReturnType<StewardClient["signSolanaTransaction"]>>;
     try {
       // The SDK input type does not model the advisory to/value hints the
@@ -209,6 +343,13 @@ export async function createStewardSolanaSigner(
         "api",
         "Steward broadcast the transaction although broadcast:false was requested",
       );
+    }
+    let returned: Transaction | VersionedTransaction;
+    try {
+      returned = deserializeTransaction(Uint8Array.from(Buffer.from(result.signature, "base64")));
+      validateSignedResponse(submitted, returned, publicKey);
+    } catch (err) {
+      throw toSignerError(err);
     }
     // With broadcast:false the route returns the FULL signed transaction,
     // base64-serialized, in the `signature` field.

--- a/packages/solana-signer/src/steward-signer.ts
+++ b/packages/solana-signer/src/steward-signer.ts
@@ -444,8 +444,16 @@ export async function createStewardSolanaSigner(
     } catch (err) {
       throw toSignerError(err);
     }
+    let signedTransaction: string;
     try {
-      if (!result || typeof result !== "object" || typeof result.signature !== "string") {
+      if (!result || typeof result !== "object") {
+        throw new Error("signing response is not an object with a signature");
+      }
+      // Capture every response field once. A custom StewardClient may return
+      // accessors or a Proxy; validation must cover the exact bytes returned to
+      // the caller rather than reading a mutable `signature` property again.
+      signedTransaction = result.signature;
+      if (typeof signedTransaction !== "string") {
         throw new Error("signing response is not an object with a signature");
       }
       if (result.broadcast !== false) {
@@ -457,14 +465,14 @@ export async function createStewardSolanaSigner(
       if (result.chainId !== chainId) {
         throw new StewardSignerError("api", "Steward returned a mismatched Solana chainId");
       }
-      const returned = deserializeTransaction(decodeCanonicalTransactionBase64(result.signature));
+      const returned = deserializeTransaction(decodeCanonicalTransactionBase64(signedTransaction));
       validateSignedResponse(submitted, returned, publicKey);
     } catch (err) {
       throw malformedSuccessResponse("Steward returned a malformed signing response", err);
     }
     // With broadcast:false the route returns the FULL signed transaction,
     // base64-serialized, in the `signature` field.
-    return result.signature;
+    return signedTransaction;
   }
 
   async function signOne<T extends Transaction | VersionedTransaction>(tx: T): Promise<T> {

--- a/packages/solana-signer/src/steward-signer.ts
+++ b/packages/solana-signer/src/steward-signer.ts
@@ -16,7 +16,7 @@
 //
 // Sign-only by design: this module never broadcasts and never touches keys.
 
-import { createPublicKey, verify } from "node:crypto";
+import { createHash, createPublicKey, verify } from "node:crypto";
 import { PublicKey, Transaction, VersionedTransaction } from "@solana/web3.js";
 import { type PolicyResult, StewardApiError, StewardClient } from "@stwd/sdk";
 
@@ -147,7 +147,11 @@ export interface StewardSolanaSignerConfig {
   apiKey?: string;
   /** Multi-tenant header (X-Steward-Tenant), when the deployment needs it. */
   tenantId?: string;
-  /** Preconfigured client; wins over baseUrl/bearerToken/apiKey/tenantId. */
+  /** End-to-end Steward request deadline in milliseconds (default: 30s). */
+  requestTimeoutMs?: number;
+  /** Maximum Steward response body bytes accepted by the SDK (default: 8 MiB). */
+  maxResponseBodyBytes?: number;
+  /** Preconfigured client; wins over baseUrl/auth/tenant and request-limit options. */
   client?: StewardClient;
   /** Solana chain id understood by Steward: 101 mainnet (default), 102 devnet. */
   chainId?: number;
@@ -379,6 +383,8 @@ export async function createStewardSolanaSigner(
       bearerToken: config.bearerToken,
       apiKey: config.apiKey,
       tenantId: config.tenantId,
+      requestTimeoutMs: config.requestTimeoutMs,
+      maxResponseBodyBytes: config.maxResponseBodyBytes,
     });
   const { agentId } = config;
 
@@ -430,17 +436,32 @@ export async function createStewardSolanaSigner(
     } catch (err) {
       throw toSignerError(err);
     }
+    const request = {
+      transaction: txBase64,
+      chainId,
+      broadcast: false,
+      ...(hints?.to !== undefined ? { to: hints.to } : {}),
+      ...(hints?.value !== undefined ? { value: hints.value } : {}),
+    };
+    // The API's authenticated idempotency middleware scopes this key to the
+    // tenant and credential, fingerprints the complete request body, and can
+    // replay the signed (never broadcast) response. A caller retry after a
+    // response is lost therefore recovers the same deterministic signature
+    // instead of producing another signing/audit side effect.
+    const idempotencyKey = `steward-solana-sign-v1-${createHash("sha256")
+      .update(agentId)
+      .update("\0")
+      .update(JSON.stringify(request))
+      .digest("hex")}`;
     let result: Awaited<ReturnType<StewardClient["signSolanaTransaction"]>>;
     try {
       // The SDK input type does not model the advisory to/value hints the
       // route accepts, so widen at the call; extra JSON fields ride along.
-      result = await client.signSolanaTransaction(agentId, {
-        transaction: txBase64,
-        chainId,
-        broadcast: false,
-        ...(hints?.to !== undefined ? { to: hints.to } : {}),
-        ...(hints?.value !== undefined ? { value: hints.value } : {}),
-      } as Parameters<StewardClient["signSolanaTransaction"]>[1]);
+      result = await client.signSolanaTransaction(
+        agentId,
+        request as Parameters<StewardClient["signSolanaTransaction"]>[1],
+        { idempotencyKey },
+      );
     } catch (err) {
       throw toSignerError(err);
     }

--- a/packages/solana-signer/src/steward-signer.ts
+++ b/packages/solana-signer/src/steward-signer.ts
@@ -66,8 +66,24 @@ function failedRuleSummary(results: PolicyResult[] | undefined): string {
 
 /** Map any thrown value from the Steward client into a StewardSignerError. */
 export function toSignerError(err: unknown): StewardSignerError {
-  if (err instanceof StewardSignerError) return err;
-  if (err instanceof StewardApiError) {
+  try {
+    if (err instanceof StewardSignerError) return err;
+  } catch {
+    return new StewardSignerError("api", "Steward signing service failed");
+  }
+  try {
+    if (!(err instanceof StewardApiError)) {
+      let message = "Steward signing service failed";
+      try {
+        if (err instanceof Error && typeof err.message === "string" && err.message.trim()) {
+          message = err.message;
+        }
+      } catch {
+        // A Proxy or exotic thrown value can trap instanceof/property access.
+        // Error handling must remain fail-closed and non-throwing.
+      }
+      return new StewardSignerError("api", message, { cause: err });
+    }
     const data = (err.data ?? {}) as {
       txId?: string;
       results?: PolicyResult[];
@@ -112,10 +128,12 @@ export function toSignerError(err: unknown): StewardSignerError {
       `Steward API error (${err.status}): ${err.message}`,
       carried,
     );
+  } catch {
+    // Never coerce an unknown thrown value with String(): Symbol.toPrimitive,
+    // valueOf, message, or prototype traps could throw a second time and leave
+    // the bridge request hanging instead of returning a bounded 502.
+    return new StewardSignerError("api", "Steward signing service failed");
   }
-  return new StewardSignerError("api", err instanceof Error ? err.message : String(err), {
-    cause: err,
-  });
 }
 
 export interface StewardSolanaSignerConfig {

--- a/packages/solana-signer/src/steward-signer.ts
+++ b/packages/solana-signer/src/steward-signer.ts
@@ -345,6 +345,21 @@ function deserializeTransaction(bytes: Uint8Array): Transaction | VersionedTrans
   return transaction;
 }
 
+function serializeTransaction(tx: Transaction | VersionedTransaction): Uint8Array {
+  return isVersioned(tx)
+    ? tx.serialize()
+    : tx.serialize({ requireAllSignatures: false, verifySignatures: false });
+}
+
+function malformedSuccessResponse(message: string, cause: unknown): StewardSignerError {
+  try {
+    if (cause instanceof StewardSignerError) return cause;
+  } catch {
+    // A hostile Proxy can trap prototype access. Always return a bounded error.
+  }
+  return new StewardSignerError("api", message, { cause });
+}
+
 /** Build a signer for one Steward agent. Async because it resolves the agent's
  *  Solana address from the vault unless `address` is supplied. */
 export async function createStewardSolanaSigner(
@@ -369,13 +384,26 @@ export async function createStewardSolanaSigner(
 
   let address = config.address;
   if (!address) {
-    let addresses: Array<{ chainFamily: string; address: string }>;
+    let response: Awaited<ReturnType<StewardClient["getAddresses"]>>;
     try {
-      ({ addresses } = await client.getAddresses(agentId));
+      response = await client.getAddresses(agentId);
     } catch (err) {
       throw toSignerError(err);
     }
-    address = addresses.find((a) => a.chainFamily === "solana")?.address;
+    try {
+      if (!response || !Array.isArray(response.addresses)) {
+        throw new Error("addresses is not an array");
+      }
+      address = response.addresses.find(
+        (entry) =>
+          entry !== null &&
+          typeof entry === "object" &&
+          entry.chainFamily === "solana" &&
+          typeof entry.address === "string",
+      )?.address;
+    } catch (err) {
+      throw malformedSuccessResponse("Steward returned a malformed address response", err);
+    }
     if (!address) {
       throw new StewardSignerError(
         "api",
@@ -416,18 +444,23 @@ export async function createStewardSolanaSigner(
     } catch (err) {
       throw toSignerError(err);
     }
-    if (result.broadcast !== false) {
-      throw new StewardSignerError("api", "Steward did not prove that broadcast:false was honored");
-    }
-    if (result.chainId !== chainId) {
-      throw new StewardSignerError("api", "Steward returned a mismatched Solana chainId");
-    }
-    let returned: Transaction | VersionedTransaction;
     try {
-      returned = deserializeTransaction(decodeCanonicalTransactionBase64(result.signature));
+      if (!result || typeof result !== "object" || typeof result.signature !== "string") {
+        throw new Error("signing response is not an object with a signature");
+      }
+      if (result.broadcast !== false) {
+        throw new StewardSignerError(
+          "api",
+          "Steward did not prove that broadcast:false was honored",
+        );
+      }
+      if (result.chainId !== chainId) {
+        throw new StewardSignerError("api", "Steward returned a mismatched Solana chainId");
+      }
+      const returned = deserializeTransaction(decodeCanonicalTransactionBase64(result.signature));
       validateSignedResponse(submitted, returned, publicKey);
     } catch (err) {
-      throw toSignerError(err);
+      throw malformedSuccessResponse("Steward returned a malformed signing response", err);
     }
     // With broadcast:false the route returns the FULL signed transaction,
     // base64-serialized, in the `signature` field.
@@ -437,13 +470,26 @@ export async function createStewardSolanaSigner(
   async function signOne<T extends Transaction | VersionedTransaction>(tx: T): Promise<T> {
     // requireAllSignatures:false preserves partial signatures already added by
     // co-signing keypairs (mint keypairs, protocol minters) through the round trip.
-    const bytes = isVersioned(tx)
-      ? tx.serialize()
-      : tx.serialize({ requireAllSignatures: false, verifySignatures: false });
-    const signedB64 = await signSerializedTransaction(
-      Buffer.from(bytes).toString("base64"),
-      config.hints?.(tx),
-    );
+    const bytes = serializeTransaction(tx);
+    const hints = config.hints?.(tx);
+    let currentBytes: Uint8Array;
+    try {
+      currentBytes = serializeTransaction(tx);
+    } catch (err) {
+      throw new StewardSignerError("api", "caller transaction changed while preparing signing", {
+        cause: err,
+      });
+    }
+    assertSameBytes(currentBytes, bytes, "caller transaction changed while preparing signing");
+    const signedB64 = await signSerializedTransaction(Buffer.from(bytes).toString("base64"), hints);
+    try {
+      currentBytes = serializeTransaction(tx);
+    } catch (err) {
+      throw new StewardSignerError("api", "caller transaction changed during signing", {
+        cause: err,
+      });
+    }
+    assertSameBytes(currentBytes, bytes, "caller transaction changed during signing");
     const signedBytes = Buffer.from(signedB64, "base64");
     // Copy signatures back onto the caller's object so identity is preserved,
     // the way in-process keypair signers mutate and return the same tx.

--- a/packages/solana-signer/src/steward-signer.ts
+++ b/packages/solana-signer/src/steward-signer.ts
@@ -1,0 +1,261 @@
+// Client-side Solana signer backed by the Steward governed vault.
+//
+// Exposes the standard wallet-adapter signer shape, the same structural type
+// Phantom exposes and the same one @iqlabs-official/solana-sdk calls WalletSigner:
+//
+//   { publicKey, signTransaction(tx), signAllTransactions(txs) }
+//
+// so any consumer that accepts an external signer (the AgentNet MCP server,
+// an iqlabs SDK writer, a wallet-adapter app) can hold a Steward-governed key
+// without ever seeing key material. Every signature goes through
+// POST /vault/:agentId/sign-solana with broadcast:false, which means:
+//
+//   - policy runs server-side on the REAL transaction bytes (spoof-resistant),
+//   - the caller keeps its own send+confirm path (sendTx and friends),
+//   - refusals surface here as typed StewardSignerError values, never raw HTTP.
+//
+// Sign-only by design: this module never broadcasts and never touches keys.
+
+import { PublicKey, Transaction, VersionedTransaction } from "@solana/web3.js";
+import { type PolicyResult, StewardApiError, StewardClient } from "@stwd/sdk";
+
+/** Advisory fields for Steward's audited blind-signing path (instructions the
+ *  server cannot decode). The server treats them as hints only and rejects
+ *  conflicts with the parsed transaction, so passing them is always safe. */
+export interface SolanaPolicyHints {
+  to?: string;
+  value?: string;
+}
+
+export type StewardSignerErrorKind = "policy_rejected" | "pending_approval" | "auth" | "api";
+
+/** Every failure from the signer, normalized. `kind` tells the caller whether
+ *  a human can fix it (policy_rejected, pending_approval), the credentials are
+ *  wrong (auth), or the API misbehaved (api). */
+export class StewardSignerError extends Error {
+  readonly kind: StewardSignerErrorKind;
+  readonly status?: number;
+  readonly txId?: string;
+  readonly policyResults?: PolicyResult[];
+
+  constructor(
+    kind: StewardSignerErrorKind,
+    message: string,
+    options: {
+      status?: number;
+      txId?: string;
+      policyResults?: PolicyResult[];
+      cause?: unknown;
+    } = {},
+  ) {
+    super(message, options.cause === undefined ? undefined : { cause: options.cause });
+    this.name = "StewardSignerError";
+    this.kind = kind;
+    this.status = options.status;
+    this.txId = options.txId;
+    this.policyResults = options.policyResults;
+  }
+}
+
+function failedRuleSummary(results: PolicyResult[] | undefined): string {
+  const failed = (results ?? []).filter((r) => !r.passed);
+  if (failed.length === 0) return "";
+  return `: ${failed.map((r) => r.reason ?? r.type).join("; ")}`;
+}
+
+/** Map any thrown value from the Steward client into a StewardSignerError. */
+export function toSignerError(err: unknown): StewardSignerError {
+  if (err instanceof StewardSignerError) return err;
+  if (err instanceof StewardApiError) {
+    const data = (err.data ?? {}) as {
+      txId?: string;
+      results?: PolicyResult[];
+      status?: string;
+    };
+    const carried = {
+      status: err.status,
+      txId: data.txId,
+      policyResults: data.results,
+      cause: err,
+    };
+    if (data.status === "pending_approval") {
+      return new StewardSignerError(
+        "pending_approval",
+        `Steward queued the transaction for manual approval (txId ${data.txId ?? "unknown"}). A signer cannot wait on a human; approve it in Steward and retry the operation.`,
+        carried,
+      );
+    }
+    if (err.status === 403 && data.results) {
+      return new StewardSignerError(
+        "policy_rejected",
+        `Steward policy rejected the transaction${failedRuleSummary(data.results)}`,
+        carried,
+      );
+    }
+    if (err.status === 422) {
+      return new StewardSignerError(
+        "policy_rejected",
+        `Steward refused to sign: ${err.message}`,
+        carried,
+      );
+    }
+    if (err.status === 401 || err.status === 403) {
+      return new StewardSignerError(
+        "auth",
+        `Steward rejected the credentials: ${err.message}`,
+        carried,
+      );
+    }
+    return new StewardSignerError(
+      "api",
+      `Steward API error (${err.status}): ${err.message}`,
+      carried,
+    );
+  }
+  return new StewardSignerError("api", err instanceof Error ? err.message : String(err), {
+    cause: err,
+  });
+}
+
+export interface StewardSolanaSignerConfig {
+  /** Agent whose vault key signs. */
+  agentId: string;
+  /** Steward API base URL, e.g. http://127.0.0.1:3000. Ignored when `client` is given. */
+  baseUrl?: string;
+  /** Agent-scoped bearer JWT. One of bearerToken, apiKey, or client is required. */
+  bearerToken?: string;
+  /** API-key auth alternative (X-Steward-Key). */
+  apiKey?: string;
+  /** Multi-tenant header (X-Steward-Tenant), when the deployment needs it. */
+  tenantId?: string;
+  /** Preconfigured client; wins over baseUrl/bearerToken/apiKey/tenantId. */
+  client?: StewardClient;
+  /** Solana chain id understood by Steward: 101 mainnet (default), 102 devnet. */
+  chainId?: number;
+  /** Skip the /addresses round trip when the agent's Solana address is known. */
+  address?: string;
+  /** Per-transaction advisory hints for the audited blind-signing path. */
+  hints?: (tx: Transaction | VersionedTransaction) => SolanaPolicyHints | undefined;
+}
+
+export interface StewardSolanaSigner {
+  /** Base58 form of publicKey, for callers that want the string. */
+  readonly address: string;
+  readonly publicKey: PublicKey;
+  signTransaction<T extends Transaction | VersionedTransaction>(tx: T): Promise<T>;
+  signAllTransactions<T extends Transaction | VersionedTransaction>(txs: T[]): Promise<T[]>;
+  /** One round trip for callers that already hold serialized bytes (the HTTP bridge). */
+  signSerializedTransaction(txBase64: string, hints?: SolanaPolicyHints): Promise<string>;
+}
+
+function isVersioned(tx: Transaction | VersionedTransaction): tx is VersionedTransaction {
+  return "version" in tx;
+}
+
+/** Build a signer for one Steward agent. Async because it resolves the agent's
+ *  Solana address from the vault unless `address` is supplied. */
+export async function createStewardSolanaSigner(
+  config: StewardSolanaSignerConfig,
+): Promise<StewardSolanaSigner> {
+  const client =
+    config.client ??
+    new StewardClient({
+      baseUrl: requireBaseUrl(config),
+      bearerToken: config.bearerToken,
+      apiKey: config.apiKey,
+      tenantId: config.tenantId,
+    });
+  const { agentId } = config;
+  const chainId = config.chainId ?? 101;
+
+  let address = config.address;
+  if (!address) {
+    let addresses: Array<{ chainFamily: string; address: string }>;
+    try {
+      ({ addresses } = await client.getAddresses(agentId));
+    } catch (err) {
+      throw toSignerError(err);
+    }
+    address = addresses.find((a) => a.chainFamily === "solana")?.address;
+    if (!address) {
+      throw new StewardSignerError(
+        "api",
+        `Agent ${agentId} has no Solana wallet in Steward (legacy EVM-only agent?)`,
+      );
+    }
+  }
+  const publicKey = new PublicKey(address);
+
+  async function signSerializedTransaction(
+    txBase64: string,
+    hints?: SolanaPolicyHints,
+  ): Promise<string> {
+    let result: Awaited<ReturnType<StewardClient["signSolanaTransaction"]>>;
+    try {
+      // The SDK input type does not model the advisory to/value hints the
+      // route accepts, so widen at the call; extra JSON fields ride along.
+      result = await client.signSolanaTransaction(agentId, {
+        transaction: txBase64,
+        chainId,
+        broadcast: false,
+        ...(hints?.to !== undefined ? { to: hints.to } : {}),
+        ...(hints?.value !== undefined ? { value: hints.value } : {}),
+      } as Parameters<StewardClient["signSolanaTransaction"]>[1]);
+    } catch (err) {
+      throw toSignerError(err);
+    }
+    if (result.broadcast) {
+      throw new StewardSignerError(
+        "api",
+        "Steward broadcast the transaction although broadcast:false was requested",
+      );
+    }
+    // With broadcast:false the route returns the FULL signed transaction,
+    // base64-serialized, in the `signature` field.
+    return result.signature;
+  }
+
+  async function signOne<T extends Transaction | VersionedTransaction>(tx: T): Promise<T> {
+    // requireAllSignatures:false preserves partial signatures already added by
+    // co-signing keypairs (mint keypairs, protocol minters) through the round trip.
+    const bytes = isVersioned(tx)
+      ? tx.serialize()
+      : tx.serialize({ requireAllSignatures: false, verifySignatures: false });
+    const signedB64 = await signSerializedTransaction(
+      Buffer.from(bytes).toString("base64"),
+      config.hints?.(tx),
+    );
+    const signedBytes = Buffer.from(signedB64, "base64");
+    // Copy signatures back onto the caller's object so identity is preserved,
+    // the way in-process keypair signers mutate and return the same tx.
+    if (isVersioned(tx)) {
+      tx.signatures = VersionedTransaction.deserialize(signedBytes).signatures;
+    } else {
+      tx.signatures = Transaction.from(signedBytes).signatures;
+    }
+    return tx;
+  }
+
+  return {
+    address,
+    publicKey,
+    signTransaction: signOne,
+    async signAllTransactions<T extends Transaction | VersionedTransaction>(
+      txs: T[],
+    ): Promise<T[]> {
+      for (const tx of txs) await signOne(tx);
+      return txs;
+    },
+    signSerializedTransaction,
+  };
+}
+
+function requireBaseUrl(config: StewardSolanaSignerConfig): string {
+  if (!config.baseUrl) {
+    throw new StewardSignerError(
+      "api",
+      "createStewardSolanaSigner needs either `client` or `baseUrl`",
+    );
+  }
+  return config.baseUrl;
+}

--- a/packages/solana-signer/src/steward-signer.ts
+++ b/packages/solana-signer/src/steward-signer.ts
@@ -218,6 +218,13 @@ function validateSignedResponse(
       "Steward returned signatures for a different Solana message",
     );
     const required = submitted.message.header.numRequiredSignatures;
+    if (
+      submitted.signatures.length !== required ||
+      returned.signatures.length !== required ||
+      returned.signatures.length !== submitted.signatures.length
+    ) {
+      throw new StewardSignerError("api", "Steward returned a mismatched signature-slot count");
+    }
     const signerIndex = submitted.message.staticAccountKeys
       .slice(0, required)
       .findIndex((key) => key.equals(publicKey));
@@ -255,6 +262,9 @@ function validateSignedResponse(
     submittedMessage,
     "Steward returned signatures for a different Solana message",
   );
+  if (returnedLegacy.signatures.length !== submittedLegacy.signatures.length) {
+    throw new StewardSignerError("api", "Steward returned a mismatched signature-slot count");
+  }
   const signerIndex = submittedLegacy.signatures.findIndex((entry) =>
     entry.publicKey.equals(publicKey),
   );
@@ -301,9 +311,20 @@ function deserializeTransaction(bytes: Uint8Array): Transaction | VersionedTrans
   }
   const messageByte = bytes[bytesRead + signatureCount * 64];
   if (messageByte === undefined) throw new StewardSignerError("api", "invalid Solana transaction");
-  return (messageByte & 0x80) !== 0
-    ? VersionedTransaction.deserialize(bytes)
-    : Transaction.from(bytes);
+  const transaction =
+    (messageByte & 0x80) !== 0 ? VersionedTransaction.deserialize(bytes) : Transaction.from(bytes);
+  // web3.js deserializers accept a valid transaction prefix followed by
+  // arbitrary trailing bytes; Transaction.from also normalizes extra legacy
+  // signature records away. Reject every parser-differential representation by
+  // requiring the parsed transaction to serialize to the exact submitted byte
+  // string. This applies to both caller input and Steward's signed response.
+  const canonical = isVersioned(transaction)
+    ? transaction.serialize()
+    : transaction.serialize({ requireAllSignatures: false, verifySignatures: false });
+  if (!Buffer.from(canonical).equals(Buffer.from(bytes))) {
+    throw new StewardSignerError("api", "non-canonical Solana transaction encoding");
+  }
+  return transaction;
 }
 
 /** Build a signer for one Steward agent. Async because it resolves the agent's

--- a/packages/solana-signer/src/steward-signer.ts
+++ b/packages/solana-signer/src/steward-signer.ts
@@ -20,9 +20,9 @@ import { createPublicKey, verify } from "node:crypto";
 import { PublicKey, Transaction, VersionedTransaction } from "@solana/web3.js";
 import { type PolicyResult, StewardApiError, StewardClient } from "@stwd/sdk";
 
-/** Advisory fields for Steward's audited blind-signing path (instructions the
- *  server cannot decode). The server treats them as hints only and rejects
- *  conflicts with the parsed transaction, so passing them is always safe. */
+/** Policy fields for the server's explicitly unsafe blind-signing mode. For
+ * parsed transactions Steward rejects conflicts; for unparsed instructions
+ * these are unverifiable caller assertions and must not be trusted. */
 export interface SolanaPolicyHints {
   to?: string;
   value?: string;
@@ -147,6 +147,30 @@ export interface StewardSolanaSigner {
   signAllTransactions<T extends Transaction | VersionedTransaction>(txs: T[]): Promise<T[]>;
   /** One round trip for callers that already hold serialized bytes (the HTTP bridge). */
   signSerializedTransaction(txBase64: string, hints?: SolanaPolicyHints): Promise<string>;
+}
+
+/** Solana's serialized transaction packet limit. Reject larger inputs locally
+ * before allocating, parsing, or sending policy-bearing bytes to Steward. */
+export const SOLANA_MAX_TRANSACTION_BYTES = 1232;
+
+function decodeCanonicalTransactionBase64(value: string): Uint8Array {
+  const maxBase64Length = Math.ceil(SOLANA_MAX_TRANSACTION_BYTES / 3) * 4;
+  if (
+    value.length === 0 ||
+    value.length > maxBase64Length ||
+    !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value)
+  ) {
+    throw new StewardSignerError("api", "invalid canonical base64 Solana transaction");
+  }
+  const decoded = Buffer.from(value, "base64");
+  if (
+    decoded.length === 0 ||
+    decoded.length > SOLANA_MAX_TRANSACTION_BYTES ||
+    decoded.toString("base64") !== value
+  ) {
+    throw new StewardSignerError("api", "invalid canonical base64 Solana transaction");
+  }
+  return decoded;
 }
 
 function isVersioned(tx: Transaction | VersionedTransaction): tx is VersionedTransaction {
@@ -285,6 +309,13 @@ function deserializeTransaction(bytes: Uint8Array): Transaction | VersionedTrans
 export async function createStewardSolanaSigner(
   config: StewardSolanaSignerConfig,
 ): Promise<StewardSolanaSigner> {
+  if (!config.agentId.trim()) {
+    throw new StewardSignerError("api", "agentId must not be empty");
+  }
+  const chainId = config.chainId ?? 101;
+  if (chainId !== 101 && chainId !== 102) {
+    throw new StewardSignerError("api", "Solana chainId must be 101 (mainnet) or 102 (devnet)");
+  }
   const client =
     config.client ??
     new StewardClient({
@@ -294,7 +325,6 @@ export async function createStewardSolanaSigner(
       tenantId: config.tenantId,
     });
   const { agentId } = config;
-  const chainId = config.chainId ?? 101;
 
   let address = config.address;
   if (!address) {
@@ -312,7 +342,14 @@ export async function createStewardSolanaSigner(
       );
     }
   }
-  const publicKey = new PublicKey(address);
+  let publicKey: PublicKey;
+  try {
+    publicKey = new PublicKey(address);
+  } catch (err) {
+    throw new StewardSignerError("api", "Steward returned an invalid Solana address", {
+      cause: err,
+    });
+  }
 
   async function signSerializedTransaction(
     txBase64: string,
@@ -320,7 +357,7 @@ export async function createStewardSolanaSigner(
   ): Promise<string> {
     let submitted: Transaction | VersionedTransaction;
     try {
-      submitted = deserializeTransaction(Uint8Array.from(Buffer.from(txBase64, "base64")));
+      submitted = deserializeTransaction(decodeCanonicalTransactionBase64(txBase64));
     } catch (err) {
       throw toSignerError(err);
     }
@@ -338,15 +375,15 @@ export async function createStewardSolanaSigner(
     } catch (err) {
       throw toSignerError(err);
     }
-    if (result.broadcast) {
-      throw new StewardSignerError(
-        "api",
-        "Steward broadcast the transaction although broadcast:false was requested",
-      );
+    if (result.broadcast !== false) {
+      throw new StewardSignerError("api", "Steward did not prove that broadcast:false was honored");
+    }
+    if (result.chainId !== chainId) {
+      throw new StewardSignerError("api", "Steward returned a mismatched Solana chainId");
     }
     let returned: Transaction | VersionedTransaction;
     try {
-      returned = deserializeTransaction(Uint8Array.from(Buffer.from(result.signature, "base64")));
+      returned = deserializeTransaction(decodeCanonicalTransactionBase64(result.signature));
       validateSignedResponse(submitted, returned, publicKey);
     } catch (err) {
       throw toSignerError(err);

--- a/packages/solana-signer/test-preload.ts
+++ b/packages/solana-signer/test-preload.ts
@@ -1,0 +1,41 @@
+// Runs once per `bun test` process, before any test file's module graph
+// loads (bunfig.toml [test].preload).
+//
+// Every fixture this suite needs is created in-process by the tests
+// themselves: the stub Steward API in __tests__/harness.ts binds an ephemeral
+// loopback port per file. One dependency cannot be, and gets created here
+// instead: steward-signer.ts imports @stwd/sdk, whose package entry is
+// dist/index.js, a tsc build output absent from a clean checkout. The preload
+// runs the sdk's own `bun run build` when that entry is missing or older than
+// any sdk source file. typescript arrives with the root `bun install`, so a
+// clean checkout needs nothing beyond install + `bun test`.
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const sdkDir = join(import.meta.dir, "..", "sdk");
+const distEntry = join(sdkDir, "dist", "index.js");
+
+function newestMtimeMs(dir: string): number {
+  let newest = 0;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    newest = Math.max(newest, entry.isDirectory() ? newestMtimeMs(path) : statSync(path).mtimeMs);
+  }
+  return newest;
+}
+
+const stale =
+  !existsSync(distEntry) || statSync(distEntry).mtimeMs < newestMtimeMs(join(sdkDir, "src"));
+
+if (stale) {
+  const build = Bun.spawnSync(["bun", "run", "build"], {
+    cwd: sdkDir,
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  if (build.exitCode !== 0) {
+    throw new Error(
+      `@stwd/sdk build failed (exit ${build.exitCode}); the signer tests import its dist entry`,
+    );
+  }
+}

--- a/packages/solana-signer/tsconfig.json
+++ b/packages/solana-signer/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["src/__tests__"]
+}


### PR DESCRIPTION
## What

Adds workspace package `@stwd/solana-signer`: a standard Solana signer (`publicKey`, `signTransaction`, `signAllTransactions`) backed by the policy-checked `sign-solana` vault route, plus an authenticated loopback bridge for subprocess consumers.

## Security and behavior

- Signing is sign-only: every vault request uses `broadcast: false`, and the response must prove the same chain and non-broadcast mode.
- Returned legacy and v0 transactions must contain the submitted message, a valid Ed25519 signature from the configured Steward address, and every non-Steward signature slot byte-for-byte unchanged, including originally empty slots.
- Caller input and Steward responses must be canonical transaction encodings: parser-ignored trailing bytes, normalized extra signature records, and mismatched signature-slot counts fail closed.
- Only chain IDs 101 and 102 are accepted by both the signer and API route.
- The bridge binds only to `127.0.0.1` or `::1`, always requires a secret of at least 32 UTF-8 bytes, compares token hashes in constant time, caps request bodies at 16 KiB, permits one signing request at a time, and fails raw-message signing closed with 501.
- Docker workspace reconstruction includes the new package manifest in dependency, build, and runtime stages. The signer package is included in PR and develop CI test matrices.

## Tests and evidence

Exact-head focused validation covers legacy and v0 signing, invalid or mismatched returned signatures, altered and injected co-signatures, chain proof, canonical and bounded transaction encodings (including parser-ignored trailing bytes on input and response), refusal propagation, auth modes, bridge host/token/body/concurrency boundaries, and the API non-Solana-chain rejection.

Local exact-head results:
- `packages/solana-signer`: 35 tests, 92 assertions; TypeScript clean.
- API priority-fee/chain suite: 3 tests, 16 assertions on the prior head; the isolated audit worktree lacked a built `@stwd/shared` workspace module for a repeat run after the canonical-encoding patch.
- Biome clean on all changed TypeScript and package files; `git diff --check` clean.
- Frozen production filtered install used by the Docker runtime stage succeeds with 626 packages.

The GitHub checks attached to the current head are the authoritative full-suite, Compose, and Docker evidence.