### PR TITLE
fix(vault): keep post-broadcast failures terminal

### DIFF
--- a/packages/api/src/__tests__/vault-execution-gateway.test.ts
+++ b/packages/api/src/__tests__/vault-execution-gateway.test.ts
@@ -954,7 +954,7 @@ describe("vault EVM execution gateway", () => {
     }
   });
 
-  it("keeps an ambiguous external broadcast terminal when its vault write fails and never reopens approval", async () => {
+  it("keeps a successful external broadcast terminal when final bookkeeping fails and never reopens approval", async () => {
     await seedExternalCustodyAgent();
     const txId = "tx-ext-custody-outcome-unknown";
     const txHash = `0x${"ef".repeat(32)}`;
@@ -1011,9 +1011,10 @@ describe("vault EVM execution gateway", () => {
       async registerKeyHandle(): Promise<ExternalKeyHandleRegistration> {
         throw new Error("registerKeyHandle is not used by this test");
       },
-      async signTransaction(): Promise<ExternalKeySignTransactionResult> {
+      async signTransaction(request): Promise<ExternalKeySignTransactionResult> {
         this.signCalls += 1;
-        throw new ExternalBroadcastOutcomeUnknownError(txHash);
+        await request.onPreparedBroadcast?.(txHash);
+        return { result: txHash, broadcast: true };
       },
     };
     const routeVault = getConfiguredVault({
@@ -1024,9 +1025,12 @@ describe("vault EVM execution gateway", () => {
     };
     const priorProvider = routeVault.externalKeyCustodyProvider;
     const originalRecord = routeVault.recordSignedTransaction;
+    let writes = 0;
     routeVault.externalKeyCustodyProvider = provider;
-    routeVault.recordSignedTransaction = async () => {
-      throw new Error("injected approval outcome write failure");
+    routeVault.recordSignedTransaction = async (...args) => {
+      writes += 1;
+      if (writes === 2) throw new Error("injected final approval write failure");
+      await originalRecord.apply(routeVault, args);
     };
     try {
       const app = await makeApp();
@@ -1060,6 +1064,7 @@ describe("vault EVM execution gateway", () => {
       });
       expect(retry.status).toBe(404);
       expect(provider.signCalls).toBe(1);
+      expect(writes).toBe(2);
     } finally {
       routeVault.externalKeyCustodyProvider = priorProvider;
       routeVault.recordSignedTransaction = originalRecord;

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -2608,15 +2608,22 @@ vaultRoutes.post("/:agentId/sign", async (c) => {
         // This is also the fallback for a failed Vault.recordSignedTransaction
         // write. Preserve the irreversible hash on the pre-staged intent before
         // returning the typed 202 response.
-        await db
-          .update(transactions)
-          .set({
-            status: "outcome_unknown",
-            txHash:
-              e instanceof ExternalBroadcastOutcomeUnknownError ? e.transactionHash : undefined,
-            signedAt: new Date(),
-          })
-          .where(and(eq(transactions.id, executionTxId), eq(transactions.agentId, agentId)));
+        try {
+          await db
+            .update(transactions)
+            .set({
+              status: "outcome_unknown",
+              txHash:
+                e instanceof ExternalBroadcastOutcomeUnknownError ? e.transactionHash : undefined,
+              signedAt: new Date(),
+            })
+            .where(and(eq(transactions.id, executionTxId), eq(transactions.agentId, agentId)));
+        } catch {
+          // The awaited pre-broadcast checkpoint is already durable. Do not
+          // replace the non-retryable result with a generic 500 merely because
+          // this redundant bookkeeping write is temporarily unavailable.
+          console.error("[vault] Failed to refresh durable outcome_unknown transaction state");
+        }
 
         // A lost response may still represent real spend. Account for it
         // conservatively before releasing the per-agent spend lock.
@@ -4457,15 +4464,22 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
           });
         }
       } else {
-        await db
-          .update(transactions)
-          .set({
-            status:
-              e instanceof ExternalBroadcastOutcomeUnknownError ? "outcome_unknown" : "broadcast",
-            txHash: completedTxHash ?? transactionRow.txHash ?? null,
-            signedAt: resolvedAt,
-          })
-          .where(and(eq(transactions.id, txId), eq(transactions.agentId, agentId)));
+        try {
+          await db
+            .update(transactions)
+            .set({
+              status:
+                e instanceof ExternalBroadcastOutcomeUnknownError ? "outcome_unknown" : "broadcast",
+              txHash: completedTxHash ?? transactionRow.txHash ?? null,
+              signedAt: resolvedAt,
+            })
+            .where(and(eq(transactions.id, txId), eq(transactions.agentId, agentId)));
+        } catch {
+          // Approval execution already crossed the durable checkpoint. Keep
+          // the approval terminal and preserve the typed response; reopening
+          // here would permit a duplicate external broadcast.
+          console.error("[vault] Failed to refresh approved irreversible transaction state");
+        }
       }
 
       if (bindingMismatch) return bindingMismatch;

--- a/packages/vault/src/__tests__/external-key-custody.test.ts
+++ b/packages/vault/src/__tests__/external-key-custody.test.ts
@@ -574,6 +574,63 @@ describe("external key custody seam", () => {
     expect(tx).toEqual({ status: "outcome_unknown", txHash });
   });
 
+  for (const scenario of [
+    {
+      name: "provider fails after the durable checkpoint",
+      complete: async () => {
+        throw new Error("provider failed after preparing the broadcast");
+      },
+    },
+    {
+      name: "provider substitutes the returned transaction hash",
+      complete: async () => ({ result: `0x${"ef".repeat(32)}`, broadcast: true as const }),
+    },
+  ]) {
+    test(`preserves the prepared hash when the ${scenario.name}`, async () => {
+      const preparedHash = `0x${"de".repeat(32)}`;
+      const provider = new TestExternalKeyProvider("provider-signing", async (request) => {
+        expect(request.onPreparedBroadcast).toBeFunction();
+        await request.onPreparedBroadcast?.(preparedHash);
+        return scenario.complete();
+      });
+      vault = await freshVault(provider);
+      await vault.createAgent(TENANT_ID, "agent-external", "External Agent");
+      await vault.importExternalKeyHandle(externalHandleRequest());
+      const target = await vault.resolveExecutionTarget({
+        tenantId: TENANT_ID,
+        agentId: "agent-external",
+        chainId: 8453,
+        venue: "hsm-primary",
+      });
+
+      let thrown: unknown;
+      try {
+        await vault.signTransaction(
+          {
+            tenantId: TENANT_ID,
+            agentId: "agent-external",
+            chainId: 8453,
+            to: "0x2222222222222222222222222222222222222222",
+            value: "1",
+            venue: "hsm-primary",
+            broadcast: true,
+          },
+          {
+            txId: `external-${scenario.name.replaceAll(" ", "-")}`,
+            expectedBackend: target.backend,
+            expectedBackendIdentityDigest: target.backendIdentityDigest,
+          },
+        );
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBeInstanceOf(ExternalBroadcastOutcomeUnknownError);
+      expect((thrown as ExternalBroadcastOutcomeUnknownError).transactionHash).toBe(preparedHash);
+      expect(provider.signCalls).toHaveLength(1);
+    });
+  }
+
   // ── ROUND 3 / ITEM 3: backend-resolution TOCTOU (fail closed at sign) ────
   // resolveExecutionBackend is a separate, stale-able DB read. Between the
   // gateway's precheck (which may see "local-vault") and the raw sign, the

--- a/packages/vault/src/__tests__/external-key-custody.test.ts
+++ b/packages/vault/src/__tests__/external-key-custody.test.ts
@@ -514,6 +514,66 @@ describe("external key custody seam", () => {
     expect(provider.signCalls).toHaveLength(1);
   });
 
+  test("keeps a successful external broadcast unknown when final bookkeeping fails", async () => {
+    const txHash = `0x${"cd".repeat(32)}`;
+    const provider = new TestExternalKeyProvider("provider-signing", async (request) => {
+      expect(request.onPreparedBroadcast).toBeFunction();
+      await request.onPreparedBroadcast?.(txHash);
+      return { result: txHash, broadcast: true };
+    });
+    vault = await freshVault(provider);
+    await vault.createAgent(TENANT_ID, "agent-external", "External Agent");
+    await vault.importExternalKeyHandle(externalHandleRequest());
+    const target = await vault.resolveExecutionTarget({
+      tenantId: TENANT_ID,
+      agentId: "agent-external",
+      chainId: 8453,
+      venue: "hsm-primary",
+    });
+    const writableVault = vault as unknown as {
+      recordSignedTransaction: (...args: unknown[]) => Promise<void>;
+    };
+    const originalRecord = writableVault.recordSignedTransaction.bind(vault);
+    let writes = 0;
+    writableVault.recordSignedTransaction = async (...args) => {
+      writes += 1;
+      if (writes === 2) throw new Error("injected final transaction write failure");
+      await originalRecord(...args);
+    };
+
+    let thrown: unknown;
+    try {
+      await vault.signTransaction(
+        {
+          tenantId: TENANT_ID,
+          agentId: "agent-external",
+          chainId: 8453,
+          to: "0x2222222222222222222222222222222222222222",
+          value: "1",
+          venue: "hsm-primary",
+          broadcast: true,
+        },
+        {
+          txId: "external-final-write-failure",
+          expectedBackend: target.backend,
+          expectedBackendIdentityDigest: target.backendIdentityDigest,
+        },
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(ExternalBroadcastOutcomeUnknownError);
+    expect((thrown as ExternalBroadcastOutcomeUnknownError).transactionHash).toBe(txHash);
+    expect(provider.signCalls).toHaveLength(1);
+    expect(writes).toBe(2);
+    const [tx] = await getDb()
+      .select({ status: transactions.status, txHash: transactions.txHash })
+      .from(transactions)
+      .where(eq(transactions.id, "external-final-write-failure"));
+    expect(tx).toEqual({ status: "outcome_unknown", txHash });
+  });
+
   // ── ROUND 3 / ITEM 3: backend-resolution TOCTOU (fail closed at sign) ────
   // resolveExecutionBackend is a separate, stale-able DB read. Between the
   // gateway's precheck (which may see "local-vault") and the raw sign, the

--- a/packages/vault/src/vault.ts
+++ b/packages/vault/src/vault.ts
@@ -1576,6 +1576,7 @@ export class Vault {
           ? (this.config.rpcUrl ?? resolveSolanaRpc(chainId))
           : (CHAIN_RPCS[chainId] ?? this.config.rpcUrl);
         let signed;
+        let preparedBroadcastHash: string | undefined;
         try {
           signed = await this.externalKeyCustodyProvider.signTransaction({
             tenantId: request.tenantId,
@@ -1600,16 +1601,34 @@ export class Vault {
             ...(shouldBroadcast
               ? {
                   onPreparedBroadcast: async (transactionHash: string) => {
+                    if (
+                      preparedBroadcastHash &&
+                      preparedBroadcastHash.toLowerCase() !== transactionHash.toLowerCase()
+                    ) {
+                      throw new Error(
+                        "External custody signer changed the prepared transaction hash",
+                      );
+                    }
                     await this.recordSignedTransaction(request, chainId, true, transactionHash, {
                       ...options,
                       status: "outcome_unknown",
                     });
+                    preparedBroadcastHash = transactionHash;
                   },
                 }
               : {}),
           });
         } catch (error) {
-          if (error instanceof ExternalBroadcastOutcomeUnknownError) {
+          const outcomeError =
+            error instanceof ExternalBroadcastOutcomeUnknownError
+              ? preparedBroadcastHash &&
+                preparedBroadcastHash.toLowerCase() !== error.transactionHash.toLowerCase()
+                ? new ExternalBroadcastOutcomeUnknownError(preparedBroadcastHash, { cause: error })
+                : error
+              : shouldBroadcast && preparedBroadcastHash
+                ? new ExternalBroadcastOutcomeUnknownError(preparedBroadcastHash, { cause: error })
+                : null;
+          if (outcomeError) {
             // The provider has already produced a deterministic local hash and
             // may have handed the signed bytes to the RPC.  A database failure
             // must never replace this irreversible outcome with a generic
@@ -1619,30 +1638,61 @@ export class Vault {
             // have a transaction row), so it can durably recover the exact
             // hash even when this first write fails.
             try {
-              await this.recordSignedTransaction(request, chainId, true, error.transactionHash, {
-                ...options,
-                status: "outcome_unknown",
-              });
+              await this.recordSignedTransaction(
+                request,
+                chainId,
+                true,
+                outcomeError.transactionHash,
+                {
+                  ...options,
+                  status: "outcome_unknown",
+                },
+              );
             } catch {
               // Deliberately preserve the typed error and its hash. Do not log
               // the persistence exception: provider/RPC errors may contain
               // credential-bearing URLs, and the gateway owns the bounded
               // fallback persistence/audit path.
             }
+            throw outcomeError;
           }
           throw error;
         }
-        assertNoExternalPrivateKeyMaterial(signed, "externalSignTransactionResult");
-        if (signed.broadcast !== shouldBroadcast) {
-          throw new Error("External key custody signer returned an unexpected broadcast mode");
+        try {
+          assertNoExternalPrivateKeyMaterial(signed, "externalSignTransactionResult");
+          if (signed.broadcast !== shouldBroadcast) {
+            throw new Error("External key custody signer returned an unexpected broadcast mode");
+          }
+          if (
+            shouldBroadcast &&
+            preparedBroadcastHash &&
+            signed.result.toLowerCase() !== preparedBroadcastHash.toLowerCase()
+          ) {
+            throw new ExternalBroadcastOutcomeUnknownError(preparedBroadcastHash, {
+              cause: new Error("External custody signer returned a mismatched transaction hash"),
+            });
+          }
+          await this.recordSignedTransaction(
+            request,
+            chainId,
+            shouldBroadcast,
+            signed.result,
+            options,
+          );
+        } catch (error) {
+          // Once the durable checkpoint has completed, every later failure is
+          // post-irreversibility: the provider may already have submitted the
+          // signed bytes. Preserve the exact prepared hash and never let the
+          // approval gateway classify this as retryable.
+          if (
+            shouldBroadcast &&
+            preparedBroadcastHash &&
+            !(error instanceof ExternalBroadcastOutcomeUnknownError)
+          ) {
+            throw new ExternalBroadcastOutcomeUnknownError(preparedBroadcastHash, { cause: error });
+          }
+          throw error;
         }
-        await this.recordSignedTransaction(
-          request,
-          chainId,
-          shouldBroadcast,
-          signed.result,
-          options,
-        );
         return signed.result;
       }
       if (venue) {


### PR DESCRIPTION
## Summary

- treat every error after the awaited external-custody pre-broadcast checkpoint as an irreversible, reconciliation-required outcome
- preserve the exact prepared transaction hash and reject provider hash changes
- prevent redundant API bookkeeping failures from replacing the typed 202 response or reopening an approved transaction
- add vault and approval-route regressions for successful provider broadcast followed by final bookkeeping failure

## Safety invariant

Once `onPreparedBroadcast` returns, the approval remains terminal even if later validation or persistence fails. A retry cannot invoke the external signer again.

## Validation

- `bunx biome check` (4 changed files)
- `bunx turbo build --filter=@stwd/vault --filter=@stwd/api` (21/21)
- API vault execution gateway: 27 pass, 0 fail
- focused vault regression: 1 pass, 0 fail

Closes #214