### PR TITLE
fix(vault): complete SEC-162 and SEC-164 boundaries

### DIFF
--- a/packages/api/src/__tests__/vault-bitcoin-psbt-signing.test.ts
+++ b/packages/api/src/__tests__/vault-bitcoin-psbt-signing.test.ts
@@ -164,27 +164,32 @@ describe("vault Bitcoin PSBT signing", () => {
     await vault.createAgent(TENANT_ID, TAPROOT_AGENT_ID, "Bitcoin PSBT Taproot Agent");
     const wallet = await vault.createWallet({
       agentId: AGENT_ID,
+      tenantId: TENANT_ID,
       chainType: "bitcoin",
       bitcoin: { network: "testnet", addressType: "p2wpkh" },
     });
     const changeWallet = await vault.createWallet({
       agentId: AGENT_ID,
+      tenantId: TENANT_ID,
       chainType: "bitcoin",
       bitcoin: { network: "testnet", addressType: "p2wpkh", index: 1 },
     });
     await vault.createWallet({
       agentId: DENIED_AGENT_ID,
+      tenantId: TENANT_ID,
       scope: wallet.venue ?? undefined,
       chainType: "bitcoin",
       bitcoin: { network: "testnet", addressType: "p2wpkh" },
     });
     const spendLimitWallet = await vault.createWallet({
       agentId: SPEND_LIMIT_AGENT_ID,
+      tenantId: TENANT_ID,
       chainType: "bitcoin",
       bitcoin: { network: "testnet", addressType: "p2wpkh" },
     });
     const taprootWallet = await vault.createWallet({
       agentId: TAPROOT_AGENT_ID,
+      tenantId: TENANT_ID,
       chainType: "bitcoin",
       bitcoin: { network: "testnet", addressType: "p2tr" },
     });

--- a/packages/api/src/__tests__/vault-mfa-sensitive-actions.test.ts
+++ b/packages/api/src/__tests__/vault-mfa-sensitive-actions.test.ts
@@ -366,6 +366,7 @@ describe("vault MFA-sensitive actions", () => {
     const { vault } = await import("../services/context");
     const bitcoinWallet = await vault.createWallet({
       agentId: AGENT_ID,
+      tenantId: TENANT_ID,
       chainType: "bitcoin",
       bitcoin: { network: "testnet", addressType: "p2wpkh" },
     });

--- a/packages/api/src/__tests__/vault-monero-transfer.test.ts
+++ b/packages/api/src/__tests__/vault-monero-transfer.test.ts
@@ -215,7 +215,11 @@ describe("vault Monero transfer + balance routes", () => {
       FROZEN_AGENT_ID,
     ]) {
       await setupVault.createAgent(TENANT_ID, agentId, `Agent ${agentId}`);
-      const wallet = await setupVault.createWallet({ agentId, chainType: "monero" });
+      const wallet = await setupVault.createWallet({
+        tenantId: TENANT_ID,
+        agentId,
+        chainType: "monero",
+      });
       if (agentId === AGENT_ID) walletAddress = wallet.address;
     }
 

--- a/packages/plugin-trading/src/__tests__/trade-polymarket-order.test.ts
+++ b/packages/plugin-trading/src/__tests__/trade-polymarket-order.test.ts
@@ -510,6 +510,7 @@ describe("POST /v1/trade/polymarket/order", () => {
     // getWallet/signing spy and no raw private key leaves the vault.
     const wallet = await sharedTestContext.vault.createWallet({
       agentId,
+      tenantId,
       venue: "polymarket",
       chainType: "evm",
     });

--- a/packages/vault/src/__tests__/monero-vault-lifecycle.test.ts
+++ b/packages/vault/src/__tests__/monero-vault-lifecycle.test.ts
@@ -149,7 +149,11 @@ describe("Monero wallet lifecycle (DB-backed)", () => {
   test("createWallet stores an AAD-bound canonical payload and public-only metadata", async () => {
     const { vault, keyStore, backend } = await freshVault();
 
-    const wallet = await vault.createWallet({ agentId: AGENT_ID, chainType: "monero" });
+    const wallet = await vault.createWallet({
+      tenantId: TENANT_ID,
+      agentId: AGENT_ID,
+      chainType: "monero",
+    });
     expect(wallet.venue).toBe(SCOPE);
     expect(wallet.address.startsWith("4")).toBe(true);
     expect(backend.calls).toContain("getDaemonHeight");
@@ -201,9 +205,9 @@ describe("Monero wallet lifecycle (DB-backed)", () => {
 
   test("createWallet fails closed without a configured backend", async () => {
     const { vault } = await freshVault({ backend: null });
-    await expect(vault.createWallet({ agentId: AGENT_ID, chainType: "monero" })).rejects.toThrow(
-      MoneroNotConfiguredError,
-    );
+    await expect(
+      vault.createWallet({ tenantId: TENANT_ID, agentId: AGENT_ID, chainType: "monero" }),
+    ).rejects.toThrow(MoneroNotConfiguredError);
     const rows = await getDb()
       .select()
       .from(agentWallets)
@@ -216,18 +220,24 @@ describe("Monero wallet lifecycle (DB-backed)", () => {
     await expect(
       vault.createWallet({
         agentId: AGENT_ID,
+        tenantId: TENANT_ID,
         chainType: "monero",
         monero: { network: "stagenet" },
       }),
     ).rejects.toThrow(/operates on mainnet/);
     await expect(
-      vault.createWallet({ agentId: AGENT_ID, chainType: "monero", monero: { account: 1 } }),
+      vault.createWallet({
+        tenantId: TENANT_ID,
+        agentId: AGENT_ID,
+        chainType: "monero",
+        monero: { account: 1 },
+      }),
     ).rejects.toThrow(/account 0/);
   });
 
   test("getMoneroBalance round-trips through the backend with the decrypted payload", async () => {
     const { vault } = await freshVault();
-    await vault.createWallet({ agentId: AGENT_ID, chainType: "monero" });
+    await vault.createWallet({ tenantId: TENANT_ID, agentId: AGENT_ID, chainType: "monero" });
 
     const balance = await vault.getMoneroBalance({
       tenantId: TENANT_ID,
@@ -253,7 +263,7 @@ describe("Monero wallet lifecycle (DB-backed)", () => {
 
   test("prepareMoneroTransfer validates amounts/destinations and relays only prepared metadata", async () => {
     const { vault, backend } = await freshVault();
-    await vault.createWallet({ agentId: AGENT_ID, chainType: "monero" });
+    await vault.createWallet({ tenantId: TENANT_ID, agentId: AGENT_ID, chainType: "monero" });
     // Any valid mainnet address works as a destination.
     const destinationAddress =
       "45AmZ2FRjuqZts5NGzb7ZXSNRuwS9MUqEeakpyEeSHsB5mywLwBzzq2cTsbJzTVUuLSHxtbfgKyZJVBqPffpP8fm79sjAcK";
@@ -305,7 +315,7 @@ describe("Monero wallet lifecycle (DB-backed)", () => {
 
   test("signing freeze blocks prepare and relay (but not balance reads)", async () => {
     const { vault } = await freshVault();
-    await vault.createWallet({ agentId: AGENT_ID, chainType: "monero" });
+    await vault.createWallet({ tenantId: TENANT_ID, agentId: AGENT_ID, chainType: "monero" });
     await getDb().insert(vaultSigningFreezes).values({
       tenantId: TENANT_ID,
       scopeType: "agent",
@@ -351,7 +361,11 @@ describe("Monero wallet lifecycle (DB-backed)", () => {
 
   test("break-glass export returns spend/view keys and restore height", async () => {
     const { vault } = await freshVault();
-    const wallet = await vault.createWallet({ agentId: AGENT_ID, chainType: "monero" });
+    const wallet = await vault.createWallet({
+      tenantId: TENANT_ID,
+      agentId: AGENT_ID,
+      chainType: "monero",
+    });
 
     await expect(vault.exportPrivateKey(TENANT_ID, AGENT_ID)).rejects.toThrow(/break-glass/);
 

--- a/packages/vault/src/__tests__/rotate-master-password.test.ts
+++ b/packages/vault/src/__tests__/rotate-master-password.test.ts
@@ -128,6 +128,7 @@ describe("master-password rotation (DB-backed, real encrypt paths)", () => {
     // A venue-scoped wallet (non-null venue in the AAD).
     await vault.createWallet({
       agentId: "agent-a",
+      tenantId: TENANT_ID,
       venue: "hyperliquid",
       chainType: "evm",
       purpose: "perp",

--- a/packages/vault/src/__tests__/secret-legacy-root-migration.test.ts
+++ b/packages/vault/src/__tests__/secret-legacy-root-migration.test.ts
@@ -184,6 +184,61 @@ describe("SEC-164 legacy-root secret re-encryption", () => {
     expect(res).toEqual({ scanned: 3, migrated: 0, alreadyDomainSeparated: 3, failed: [] });
   });
 
+  it("does not overwrite a concurrent secret re-encryption from a stale classified row", async () => {
+    const concurrent = await insertLegacySecret("legacy-concurrent", "stale-value");
+    const context = contextFor(concurrent);
+    const replacement = domainRoot().encrypt("concurrent-value", context);
+    const realDb = getDb();
+    const originalUpdate = realDb.update.bind(realDb);
+    let injected = false;
+    const migrationDb = new Proxy(realDb, {
+      get(target, property, receiver) {
+        if (property !== "update") return Reflect.get(target, property, receiver);
+        return ((table: Parameters<typeof originalUpdate>[0]) => {
+          const updateBuilder = originalUpdate(table);
+          return {
+            set(values: Parameters<typeof updateBuilder.set>[0]) {
+              const setBuilder = updateBuilder.set(values);
+              return {
+                where(condition: Parameters<typeof setBuilder.where>[0]) {
+                  const whereBuilder = setBuilder.where(condition);
+                  return {
+                    async returning(fields: Parameters<typeof whereBuilder.returning>[0]) {
+                      if (!injected) {
+                        injected = true;
+                        // Deterministically emulate a password rotation after
+                        // classification and immediately before our stale CAS.
+                        await originalUpdate(secrets)
+                          .set({
+                            ciphertext: replacement.ciphertext,
+                            iv: replacement.iv,
+                            authTag: replacement.tag,
+                            salt: replacement.salt,
+                          })
+                          .where(eq(secrets.id, concurrent.id));
+                      }
+                      return whereBuilder.returning(fields);
+                    },
+                  };
+                },
+              };
+            },
+          };
+        }) as typeof realDb.update;
+      },
+    });
+
+    try {
+      const res = await vault.migrateLegacyRootSecrets({ db: migrationDb });
+      expect(res.failed).toContain(concurrent.id);
+      expect(res.migrated).toBe(0);
+      const row = await freshRow(concurrent.id);
+      expect(domainRoot().decrypt(rawEnc(row), context)).toBe("concurrent-value");
+    } finally {
+      await getDb().delete(secrets).where(eq(secrets.id, concurrent.id));
+    }
+  });
+
   it("fails closed with the fallback disabled, until the row is migrated", async () => {
     const late = await insertLegacySecret("legacy-late", "legacy-value-c");
     process.env.STEWARD_SECRET_VAULT_LEGACY_ROOT_FALLBACK = "false";

--- a/packages/vault/src/__tests__/venue-scoping.test.ts
+++ b/packages/vault/src/__tests__/venue-scoping.test.ts
@@ -107,6 +107,7 @@ describe("Vault venue scoping (Sprint 4 Day 1)", () => {
 
     const wallet = await vault.createWallet({
       agentId: "sol",
+      tenantId: TENANT_ID,
       venue: "hyperliquid",
       chainType: "evm",
       purpose: "perp",
@@ -124,6 +125,7 @@ describe("Vault venue scoping (Sprint 4 Day 1)", () => {
 
     const wallet = await vault.createWallet({
       agentId: "sol",
+      tenantId: TENANT_ID,
       venue: "drift",
       chainType: "solana",
     });
@@ -140,6 +142,7 @@ describe("Vault venue scoping (Sprint 4 Day 1)", () => {
     await vault.createAgent(TENANT_ID, "sol", "Sol");
     const created = await vault.createWallet({
       agentId: "sol",
+      tenantId: TENANT_ID,
       venue: "hyperliquid",
       chainType: "evm",
     });
@@ -191,12 +194,22 @@ describe("Vault venue scoping (Sprint 4 Day 1)", () => {
 
   test("createWallet enforces venue uniqueness per (agentId, chainFamily)", async () => {
     await vault.createAgent(TENANT_ID, "sol", "Sol");
-    await vault.createWallet({ agentId: "sol", venue: "hyperliquid", chainType: "evm" });
+    await vault.createWallet({
+      tenantId: TENANT_ID,
+      agentId: "sol",
+      venue: "hyperliquid",
+      chainType: "evm",
+    });
 
     // Second insert for the same (agentId, chainFamily, venue) tuple must
     // be rejected by the unique index from migration 0022.
     await expect(
-      vault.createWallet({ agentId: "sol", venue: "hyperliquid", chainType: "evm" }),
+      vault.createWallet({
+        tenantId: TENANT_ID,
+        agentId: "sol",
+        venue: "hyperliquid",
+        chainType: "evm",
+      }),
     ).rejects.toThrow();
   });
 
@@ -204,12 +217,14 @@ describe("Vault venue scoping (Sprint 4 Day 1)", () => {
     await vault.createAgent(TENANT_ID, "sol", "Sol");
     const hl = await vault.createWallet({
       agentId: "sol",
+      tenantId: TENANT_ID,
       venue: "hyperliquid",
       chainType: "evm",
       purpose: "perp",
     });
     const pm = await vault.createWallet({
       agentId: "sol",
+      tenantId: TENANT_ID,
       venue: "polymarket",
       chainType: "evm",
       purpose: "predictions",
@@ -225,7 +240,12 @@ describe("Vault venue scoping (Sprint 4 Day 1)", () => {
 
   test("legacy + venue-scoped wallets coexist for the same agent + chainFamily", async () => {
     const identity = await vault.createAgent(TENANT_ID, "sol", "Sol");
-    await vault.createWallet({ agentId: "sol", venue: "hyperliquid", chainType: "evm" });
+    await vault.createWallet({
+      tenantId: TENANT_ID,
+      agentId: "sol",
+      venue: "hyperliquid",
+      chainType: "evm",
+    });
 
     const legacy = await vault.getWallet({ agentId: "sol", chainId: 8453 });
     const hl = await vault.getWallet({ agentId: "sol", venue: "hyperliquid" });
@@ -236,9 +256,24 @@ describe("Vault venue scoping (Sprint 4 Day 1)", () => {
 
   test("listWallets returns every wallet across venues and chain families", async () => {
     await vault.createAgent(TENANT_ID, "sol", "Sol");
-    await vault.createWallet({ agentId: "sol", venue: "hyperliquid", chainType: "evm" });
-    await vault.createWallet({ agentId: "sol", venue: "polymarket", chainType: "evm" });
-    await vault.createWallet({ agentId: "sol", venue: "drift", chainType: "solana" });
+    await vault.createWallet({
+      tenantId: TENANT_ID,
+      agentId: "sol",
+      venue: "hyperliquid",
+      chainType: "evm",
+    });
+    await vault.createWallet({
+      tenantId: TENANT_ID,
+      agentId: "sol",
+      venue: "polymarket",
+      chainType: "evm",
+    });
+    await vault.createWallet({
+      tenantId: TENANT_ID,
+      agentId: "sol",
+      venue: "drift",
+      chainType: "solana",
+    });
 
     const all = await vault.listWallets({ agentId: "sol" });
 
@@ -260,6 +295,7 @@ describe("Vault venue scoping (Sprint 4 Day 1)", () => {
 
     const wallet = await vault.createWallet({
       agentId: "satoshi",
+      tenantId: TENANT_ID,
       chainType: "bitcoin",
       bitcoin: { network: "mainnet", addressType: "p2wpkh" },
     });
@@ -283,6 +319,7 @@ describe("Vault venue scoping (Sprint 4 Day 1)", () => {
     await vault.createAgent(TENANT_ID, "satoshi", "Satoshi");
     const created = await vault.createWallet({
       agentId: "satoshi",
+      tenantId: TENANT_ID,
       chainType: "bitcoin",
       bitcoin: { network: "testnet", addressType: "p2tr", account: 1, index: 7 },
     });
@@ -308,6 +345,7 @@ describe("Vault venue scoping (Sprint 4 Day 1)", () => {
     await vault.createAgent(TENANT_ID, "satoshi", "Satoshi");
     const created = await vault.createWallet({
       agentId: "satoshi",
+      tenantId: TENANT_ID,
       chainType: "bitcoin",
       bitcoin: { network: "testnet", addressType: "p2tr", account: 2, index: 9 },
     });
@@ -347,13 +385,23 @@ describe("Vault venue scoping (Sprint 4 Day 1)", () => {
   test("createWallet rejects unknown chainType", async () => {
     await vault.createAgent(TENANT_ID, "sol", "Sol");
     await expect(
-      vault.createWallet({ agentId: "sol", venue: "x", chainType: "unknown" as any }),
+      vault.createWallet({
+        tenantId: TENANT_ID,
+        agentId: "sol",
+        venue: "x",
+        chainType: "unknown" as any,
+      }),
     ).rejects.toThrow(/unsupported chainType/);
   });
 
   test("createWallet rejects unknown agentId with a clear error (no FK leak)", async () => {
     await expect(
-      vault.createWallet({ agentId: "ghost", venue: "hyperliquid", chainType: "evm" }),
+      vault.createWallet({
+        tenantId: TENANT_ID,
+        agentId: "ghost",
+        venue: "hyperliquid",
+        chainType: "evm",
+      }),
     ).rejects.toThrow(/Agent ghost not found/);
   });
 
@@ -374,7 +422,7 @@ describe("Vault venue scoping (Sprint 4 Day 1)", () => {
       (await vault.listWallets({ agentId: "sol" })).filter((w) => w.venue === "hyperliquid"),
     ).toHaveLength(0);
 
-    // The matching tenant passes, and omitting tenantId stays backward compatible.
+    // The matching tenant passes.
     const asserted = await vault.createWallet({
       agentId: "sol",
       tenantId: TENANT_ID,
@@ -382,18 +430,13 @@ describe("Vault venue scoping (Sprint 4 Day 1)", () => {
       chainType: "evm",
     });
     expect(asserted.venue).toBe("hyperliquid");
-    const unasserted = await vault.createWallet({
-      agentId: "sol",
-      venue: "polymarket",
-      chainType: "evm",
-    });
-    expect(unasserted.venue).toBe("polymarket");
   });
 
   test("private key is never returned by createWallet", async () => {
     await vault.createAgent(TENANT_ID, "sol", "Sol");
     const wallet = await vault.createWallet({
       agentId: "sol",
+      tenantId: TENANT_ID,
       venue: "hyperliquid",
       chainType: "evm",
     });

--- a/packages/vault/src/secret-vault.ts
+++ b/packages/vault/src/secret-vault.ts
@@ -535,7 +535,7 @@ export class SecretVault {
           const plaintext = this.legacyKeyStore.decrypt(encrypted, context);
           if (!options?.dryRun) {
             const reEncrypted = this.keyStore.encrypt(plaintext, context);
-            await db
+            const rewritten = await db
               .update(secrets)
               .set({
                 ciphertext: reEncrypted.ciphertext,
@@ -543,7 +543,25 @@ export class SecretVault {
                 authTag: reEncrypted.tag,
                 salt: reEncrypted.salt,
               })
-              .where(eq(secrets.id, row.id));
+              // Compare-and-set all authenticated bytes. A concurrent master
+              // password rotation or secret rewrite must win rather than be
+              // silently overwritten with ciphertext derived from our stale
+              // read. The enclosing migration transaction will roll back if
+              // this row changed after classification.
+              .where(
+                and(
+                  eq(secrets.id, row.id),
+                  eq(secrets.ciphertext, row.ciphertext),
+                  eq(secrets.iv, row.iv),
+                  eq(secrets.authTag, row.authTag),
+                  eq(secrets.salt, row.salt),
+                ),
+              )
+              .returning({ id: secrets.id });
+            if (rewritten.length !== 1) {
+              result.failed.push(row.id);
+              continue;
+            }
           }
           result.migrated += 1;
         } catch {

--- a/packages/vault/src/vault.ts
+++ b/packages/vault/src/vault.ts
@@ -3763,15 +3763,16 @@ export class Vault {
   async createWallet(args: {
     agentId: string;
     /**
-     * SEC-162: optional caller-asserted tenant, verified against the agent's
+     * SEC-162: required caller-asserted tenant, verified against the agent's
      * real tenant before any wallet row is written. The AAD on the encrypted
      * key material was always bound to `agentRow.tenantId` (so cross-tenant
      * key theft was never possible); this check closes the residual DoS —
      * a caller reaching this method with another tenant's agentId can no
      * longer squat venue wallet slots for that agent. Routes that know the
-     * tenant MUST pass it.
+     * tenant must pass it. Keeping this optional would preserve the original
+     * in-process cross-tenant venue-slot-squatting path.
      */
-    tenantId?: string;
+    tenantId: string;
     venue?: string;
     scope?: string;
     chainType: WalletChainFamily;
@@ -3803,7 +3804,7 @@ export class Vault {
     // Defense-in-depth tenant binding (SEC-162). Same "not found" phrasing as
     // the other tenant-scoped lookups so a mismatch does not confirm the
     // agent's existence under another tenant.
-    if (args.tenantId !== undefined && agentRow.tenantId !== args.tenantId) {
+    if (agentRow.tenantId !== args.tenantId) {
       throw new Error(`Agent ${agentId} not found for tenant ${args.tenantId}`);
     }
 

--- a/scripts/provision-agent.ts
+++ b/scripts/provision-agent.ts
@@ -64,6 +64,7 @@ async function ensureHyperliquidWallet(agentId: string) {
   } catch {
     const created = await vault.createWallet({
       agentId,
+      tenantId: DEFAULT_TENANT_ID,
       venue: "hyperliquid",
       chainType: "evm",
       purpose: "hyperliquid-deposit",


### PR DESCRIPTION
## Summary

Follow-up to #330 after independent security review.

- make `tenantId` mandatory for every in-process `Vault.createWallet` call so omitting it cannot preserve the cross-tenant venue-slot-squatting path from SEC-162
- update all production and test call sites to pass their authenticated/known tenant
- make legacy-secret re-encryption updates compare-and-set all authenticated ciphertext fields, so a stale migration read cannot overwrite a concurrent master-password rotation
- add a deterministic concurrency regression proving the competing ciphertext wins and the migration reports the row as failed

## Validation

- `bunx biome check` on all 10 changed files
- `bunx turbo build --filter=@stwd/vault --filter=@stwd/api` (21/21)
- SEC-082/162/163/164 Vault suites: 37 pass, 0 fail
- concurrent secret-rotation regression: 1 pass, 0 fail
- pre-follow-up #330 exact-head CI: all 19 required checks passed before merge

No related standalone issue was found; this is a correctness follow-up to #330.