### PR TITLE
fix(infra): close post-merge #328 safety gaps

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,3 +15,5 @@ packages/db/ @0xSolace
 .github/ @0xSolace @lalalune
 Dockerfile @0xSolace @lalalune
 docker-compose*.yml @0xSolace @lalalune
+deploy/ @0xSolace @lalalune
+scripts/ @0xSolace @lalalune

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,11 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    # Major action upgrades can change runtime/permissions semantics and need a
+    # deliberate manual migration. Security updates are unaffected.
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   # Keep digest-pinned base images in the root Dockerfile current.
   - package-ecosystem: "docker"
@@ -21,6 +26,12 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    # Keep routine automation to patch/minor image updates; major base-runtime
+    # changes require an explicit compatibility review. Security updates still
+    # bypass update-type filtering.
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   # bun workspaces (root package.json + packages/* + web/): security updates
   # only. Routine version bumps stay a deliberate, lockfile-reviewed process.

--- a/deploy/enterprise-reference/README.md
+++ b/deploy/enterprise-reference/README.md
@@ -2,6 +2,10 @@
 
 This profile is the hardened compose path for PR6. It includes PostgreSQL, Redis, a one-shot migration job, the API, the credential proxy, Caddy TLS termination, health/readiness checks, and a `backup` service that writes `pg_dump` files into `deploy/enterprise-reference/backups`.
 
+Docker Compose 2.33.1 or newer is required. The profile uses `gw_priority` to
+make the egress-capable network the deterministic default gateway for its
+dual-homed API, proxy, migration, and backup containers.
+
 ```bash
 bun install
 bun run packages/cli/src/index.ts init --env deploy/enterprise-reference/.env --force

--- a/deploy/enterprise-reference/docker-compose.yml
+++ b/deploy/enterprise-reference/docker-compose.yml
@@ -30,8 +30,11 @@ services:
     networks:
       # Dual-homed: reaches the bundled postgres via steward-data, and an
       # operator-supplied external DATABASE_URL via steward-backend egress.
-      - steward-backend
-      - steward-data
+      steward-backend:
+        # Compose does not define a default gateway for equal priorities. Pin
+        # the egress-capable network explicitly (Compose >= 2.33.1).
+        gw_priority: 1
+      steward-data: {}
     restart: "no"
 
   steward-api:
@@ -87,8 +90,9 @@ services:
       start_period: 30s
       retries: 8
     networks:
-      - steward-backend
-      - steward-data
+      steward-backend:
+        gw_priority: 1
+      steward-data: {}
 
   steward-proxy:
     profiles: ["enterprise-reference"]
@@ -123,8 +127,9 @@ services:
       start_period: 15s
       retries: 5
     networks:
-      - steward-backend
-      - steward-data
+      steward-backend:
+        gw_priority: 1
+      steward-data: {}
 
   caddy:
     profiles: ["enterprise-reference"]
@@ -205,8 +210,9 @@ services:
     networks:
       # Dual-homed like steward-migrate: bundled postgres via steward-data,
       # external DATABASE_URL (if overridden) via steward-backend egress.
-      - steward-backend
-      - steward-data
+      steward-backend:
+        gw_priority: 1
+      steward-data: {}
     restart: "no"
 
 volumes:

--- a/packages/proxy/src/__tests__/deploy-artifacts.test.ts
+++ b/packages/proxy/src/__tests__/deploy-artifacts.test.ts
@@ -213,8 +213,8 @@ describe("SEC-161 enterprise data-plane network isolation", () => {
       expect(serviceBlock(name)).not.toContain("- steward-backend");
     }
     for (const name of ["steward-api", "steward-proxy", "steward-migrate", "backup"]) {
-      expect(serviceBlock(name)).toContain("- steward-backend");
-      expect(serviceBlock(name)).toContain("- steward-data");
+      expect(serviceBlock(name)).toMatch(/steward-backend:[\s\S]*?gw_priority: 1/);
+      expect(serviceBlock(name)).toContain("steward-data: {}");
     }
     expect(compose).toMatch(/steward-data:\n\s+driver: bridge\n\s+internal: true/);
   });

--- a/scripts/__tests__/mutation-proof-shell-safety.test.ts
+++ b/scripts/__tests__/mutation-proof-shell-safety.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const repoRoot = join(import.meta.dir, "..", "..");
+
+function readScript(name: string): string {
+  return readFileSync(join(repoRoot, "scripts", name), "utf8");
+}
+
+describe("SEC-201 mutation-proof temporary-file cleanup", () => {
+  test("custody proof never restores from an uninitialized backup", () => {
+    const script = readScript("custody-ack-gate-mutation-proofs.sh");
+    expect(script.indexOf("trap cleanup EXIT")).toBeLessThan(script.indexOf('BACKUP="$(mktemp)"'));
+    expect(script.indexOf("BACKUP_READY=true")).toBeGreaterThan(
+      script.indexOf('cp "$FACTORY" "$BACKUP"'),
+    );
+    expect(script).toContain("if $BACKUP_READY; then");
+  });
+
+  test("key-rotation proof arms restoration only after both backups exist", () => {
+    const script = readScript("key-rotation-mutation-proofs.sh");
+    expect(script.indexOf("trap restore EXIT")).toBeLessThan(
+      script.indexOf("rotation_copy=$(mktemp)"),
+    );
+    expect(script.indexOf("backups_ready=true")).toBeGreaterThan(
+      script.indexOf('cp "$auth" "$auth_copy"'),
+    );
+    expect(script).toContain("if $backups_ready; then");
+  });
+});
+
+describe("post-merge infrastructure ownership and update policy", () => {
+  test("sensitive operational trees have both infrastructure owners", () => {
+    const owners = readFileSync(join(repoRoot, ".github", "CODEOWNERS"), "utf8");
+    expect(owners).toContain("deploy/ @0xSolace @lalalune");
+    expect(owners).toContain("scripts/ @0xSolace @lalalune");
+  });
+
+  test("routine action and base-image automation excludes major migrations", () => {
+    const dependabot = readFileSync(join(repoRoot, ".github", "dependabot.yml"), "utf8");
+    for (const ecosystem of ["github-actions", "docker"]) {
+      const start = dependabot.indexOf(`package-ecosystem: "${ecosystem}"`);
+      expect(start).toBeGreaterThanOrEqual(0);
+      const next = dependabot.indexOf("package-ecosystem:", start + 1);
+      const block = dependabot.slice(start, next < 0 ? undefined : next);
+      expect(block).toContain('update-types: ["version-update:semver-major"]');
+    }
+  });
+});

--- a/scripts/custody-ack-gate-mutation-proofs.sh
+++ b/scripts/custody-ack-gate-mutation-proofs.sh
@@ -10,18 +10,29 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 FACTORY="$ROOT/packages/api/src/services/vault-factory.ts"
-BACKUP="$(mktemp)"
-# SEC-201: mktemp instead of a predictable /tmp path (symlink-safe on shared hosts)
-LOG="$(mktemp -t custody-ack-mut.XXXXXX)"
+BACKUP=""
+LOG=""
+BACKUP_READY=false
 TEST="vault-factory.test.ts"
 
 cleanup() {
-  cp "$BACKUP" "$FACTORY"
-  rm -f "$BACKUP" "$LOG"
+  # Never restore from a merely-created (still empty) mktemp file. If the
+  # initial source copy fails, overwriting FACTORY from that file would turn a
+  # setup error into source destruction.
+  if $BACKUP_READY; then
+    cp "$BACKUP" "$FACTORY"
+  fi
+  [[ -n "$BACKUP" ]] && rm -f -- "$BACKUP"
+  [[ -n "$LOG" ]] && rm -f -- "$LOG"
 }
 trap cleanup EXIT
 
+# SEC-201: mktemp instead of a predictable /tmp path (symlink-safe on shared hosts).
+# Install the cleanup trap before allocation so partial setup cannot leak files.
+BACKUP="$(mktemp)"
+LOG="$(mktemp -t custody-ack-mut.XXXXXX)"
 cp "$FACTORY" "$BACKUP"
+BACKUP_READY=true
 
 run_tests() {
   ( cd "$ROOT/packages/api" && bun scripts/run-tests-isolated.ts "$TEST" ) >"$LOG" 2>&1

--- a/scripts/key-rotation-mutation-proofs.sh
+++ b/scripts/key-rotation-mutation-proofs.sh
@@ -3,18 +3,30 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 rotation=scripts/rotate-master-password.ts
 auth=packages/shared/src/provider-execution-auth.ts
+rotation_copy=""
+auth_copy=""
+log_file=""
+backups_ready=false
+restore() {
+  # Do not restore from empty mktemp files when initial backup setup failed.
+  if $backups_ready; then
+    cp "$rotation_copy" "$rotation"
+    cp "$auth_copy" "$auth"
+  fi
+  [[ -n "$rotation_copy" ]] && rm -f -- "$rotation_copy"
+  [[ -n "$auth_copy" ]] && rm -f -- "$auth_copy"
+  [[ -n "$log_file" ]] && rm -f -- "$log_file"
+}
+trap restore EXIT
+
+# SEC-201: allocate under mktemp and trap before setup so partial failures are
+# leak-free without risking an empty-file restore over either source.
 rotation_copy=$(mktemp)
 auth_copy=$(mktemp)
-# SEC-201: mktemp instead of a predictable /tmp path (symlink-safe on shared hosts)
 log_file=$(mktemp -t steward-key-rotation-mutation.XXXXXX)
 cp "$rotation" "$rotation_copy"
 cp "$auth" "$auth_copy"
-restore() {
-  cp "$rotation_copy" "$rotation"
-  cp "$auth_copy" "$auth"
-  rm -f "$rotation_copy" "$auth_copy" "$log_file"
-}
-trap restore EXIT
+backups_ready=true
 
 expect_killed() {
   local label=$1


### PR DESCRIPTION
## Post-merge audit of #328

PR #328 source `c4c2f1227451a8c8c3155140d697ba5059650d23` and merge `dcce8cfffce5f2931607a96b21182085051d35ed` have byte-identical trees. The merged controls for SEC-158..161 and SEC-201..205 are directionally correct, but an independent hostile-path audit found three residual implementation gaps.

### Repairs

- Make the egress-capable `steward-backend` network the deterministic default gateway (`gw_priority: 1`) for all four dual-homed enterprise services. With equal/default priorities, Compose does not specify which network supplies the default gateway, so the internal data network could break chain/provider/external-DB access. Document the Compose >=2.33.1 requirement and pin it in the deploy-artifact regression.
- Make both mutation-proof cleanup traps safe during partial initialization. The merged scripts armed an unconditional restore before the source-to-backup copy completed; if that copy failed, EXIT could overwrite a source file from an empty `mktemp` file. Restoration is now armed only after every backup is populated, while cleanup is installed before allocation.
- Keep routine Dependabot action/image updates to patch/minor releases; major runtime migrations remain explicit reviews while security updates remain unaffected. Extend dual-owner review requests to `deploy/` and `scripts/`, which contain the nginx, Compose, migration, custody, and key-rotation surfaces audited here.

### Verification

- `bun test scripts/__tests__/mutation-proof-shell-safety.test.ts packages/proxy/src/__tests__/deploy-artifacts.test.ts scripts/__tests__/sweep-builder-fees.test.ts scripts/__tests__/migrate-sh.test.ts` — 49/49 pass.
- `bunx turbo build --filter=@stwd/proxy` — 6/6 tasks pass.
- Full Biome sweep — 1,166 files clean.
- `bash -n` clean for all affected shell scripts.
- Both exact merged Compose files rendered clean before repair; repaired enterprise Compose renders `gw_priority: 1` on API, proxy, migration, and backup with the data network still internal-only.
- YAML parse, insecure-URL hostile probes, frozen lock installation, and `git diff --check` clean.

### Environment limitation

The local Docker daemon currently fails image/container operations with containerd metadata/overlay I/O errors. `docker compose config` is load-bearing and green, but live `nginx -t` and dual-network container boot could not be repeated locally. Exact-head CI remains required before merge.

### Remaining administrative control

Current `develop` protection requires one approval and does **not** require code-owner review. CODEOWNERS therefore requests reviewers but cannot enforce two independent approvals; changing that remains an organization/repository ruleset action, not a repository-code repair.