### PR TITLE
fix(security): wave-2b deferred LOW/INFO — webhooks + policy-engine (SEC-101..107, 177..183)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,6 +71,8 @@ AGENT_TOKEN_EXPIRY=24h
 # This prevents a staging/preview deploy that forgot NODE_ENV=production from
 # silently running on predictable, well-known secrets. Leave UNSET in any shared
 # or internet-reachable environment. Set to "true" only for local development.
+# The webhook secret codec is stricter still: it accepts the dev key only when
+# NODE_ENV is explicitly "development" or "test" (unset is not enough).
 # STEWARD_ALLOW_DEV_SECRETS=true
 
 # [REQUIRED in production] HMAC key for the tamper-evident audit chain.

--- a/packages/api/src/__tests__/policy-validation.test.ts
+++ b/packages/api/src/__tests__/policy-validation.test.ts
@@ -16,6 +16,31 @@ describe("policy rule validation", () => {
     ).toContain("auto-approve-threshold");
   });
 
+  it("rejects an enabled time-window rule with no windows at all (SEC-180)", () => {
+    expect(
+      getPolicyRulesValidationError([
+        {
+          id: "tw",
+          type: "time-window",
+          enabled: true,
+          config: { allowedHours: [], allowedDays: [] },
+        },
+      ]),
+    ).toBe("time-window requires at least one allowed hour window or allowed day");
+
+    // A single gated dimension is valid: the other stays unconstrained.
+    expect(
+      getPolicyRulesValidationError([
+        {
+          id: "tw",
+          type: "time-window",
+          enabled: true,
+          config: { allowedHours: [{ start: 9, end: 17 }], allowedDays: [] },
+        },
+      ]),
+    ).toBeNull();
+  });
+
   it("accepts valid persisted policy configs", () => {
     expect(
       getPolicyRulesValidationError([

--- a/packages/api/src/services/policy-validation.ts
+++ b/packages/api/src/services/policy-validation.ts
@@ -165,6 +165,11 @@ function validatePolicyConfig(policy: PolicyRule): string | null {
       ) {
         return "time-window.allowedDays must contain weekdays 0-6";
       }
+      // An enabled rule with no windows at all is a fail-open no-op in the
+      // engine (SEC-180); reject it at write time.
+      if (config.allowedHours.length === 0 && config.allowedDays.length === 0) {
+        return "time-window requires at least one allowed hour window or allowed day";
+      }
       return null;
 
     case "rate-limit":

--- a/packages/api/src/services/provider-action-service.ts
+++ b/packages/api/src/services/provider-action-service.ts
@@ -314,6 +314,30 @@ function asRecord(value: unknown): Record<string, unknown> {
   return value as Record<string, unknown>;
 }
 
+/**
+ * SEC-182: lift the adapter-derived X security signals from the validated
+ * `policyArgs` onto the composer's typed `ctx.x` channel, so the reply/URL/
+ * length gates no longer depend solely on the caller-influenced args bag.
+ * Only correctly-shaped values are lifted; anything else stays unwired and a
+ * dependent rule fails closed (POLICY_INPUT_UNAVAILABLE).
+ */
+function xPolicySignalsFrom(args: Record<string, unknown>): {
+  isReply?: boolean;
+  summoned?: boolean;
+  hasUrl?: boolean;
+  textCodePointLength?: number;
+} {
+  return {
+    ...(typeof args.isReply === "boolean" ? { isReply: args.isReply } : {}),
+    ...(typeof args.summoned === "boolean" ? { summoned: args.summoned } : {}),
+    ...(typeof args.hasUrl === "boolean" ? { hasUrl: args.hasUrl } : {}),
+    ...(typeof args.textCodePointLength === "number" &&
+    Number.isInteger(args.textCodePointLength)
+      ? { textCodePointLength: args.textCodePointLength }
+      : {}),
+  };
+}
+
 function genericScalarFromCanonicalText(value: string, type: GenericSegmentType): unknown {
   if (type !== "int") return value;
   const parsed = Number(value);
@@ -2250,7 +2274,11 @@ class ProviderActionService {
         // fails closed (POLICY_INPUT_UNAVAILABLE) until the trailing-window
         // accumulator lands. Content/reply/URL rules need no external input and are
         // fully live now.
-        x: undefined,
+        // SEC-182: the adapter-derived content signals (isReply / summoned /
+        // hasUrl / textCodePointLength) ARE wired — lifted from the adapter's
+        // validated policyArgs onto the typed channel the composer prefers over
+        // the caller-influenced args bag.
+        x: xPolicySignalsFrom(build.policyArgs),
       };
 
       const ruleEvaluation = composeProviderActionPolicyDecision(rules, context);

--- a/packages/api/src/services/provider-action-service.ts
+++ b/packages/api/src/services/provider-action-service.ts
@@ -331,8 +331,7 @@ function xPolicySignalsFrom(args: Record<string, unknown>): {
     ...(typeof args.isReply === "boolean" ? { isReply: args.isReply } : {}),
     ...(typeof args.summoned === "boolean" ? { summoned: args.summoned } : {}),
     ...(typeof args.hasUrl === "boolean" ? { hasUrl: args.hasUrl } : {}),
-    ...(typeof args.textCodePointLength === "number" &&
-    Number.isInteger(args.textCodePointLength)
+    ...(typeof args.textCodePointLength === "number" && Number.isInteger(args.textCodePointLength)
       ? { textCodePointLength: args.textCodePointLength }
       : {}),
   };

--- a/packages/policy-engine/src/__tests__/aggregation-condition.test.ts
+++ b/packages/policy-engine/src/__tests__/aggregation-condition.test.ts
@@ -265,6 +265,22 @@ describe("window resolution and boundary", () => {
     );
     expect(result.passed).toBe(false);
   });
+
+  test("prototype-key named windows resolve to null (SEC-106)", () => {
+    // `NAMED_WINDOW_SECONDS["__proto__"]` on a plain object would return
+    // Object.prototype — an object, not a number — escaping the
+    // unknown-window → deny contract.
+    for (const named of ["__proto__", "constructor", "toString"]) {
+      expect(
+        resolveWindowSeconds({
+          metric: "tx_count",
+          window: { named: named as "1h" },
+          comparator: "gt",
+          threshold: "1",
+        }),
+      ).toBeNull();
+    }
+  });
 });
 
 // ─── scope coverage ─────────────────────────────────────────────────────────────

--- a/packages/policy-engine/src/__tests__/capability-intent.test.ts
+++ b/packages/policy-engine/src/__tests__/capability-intent.test.ts
@@ -200,6 +200,24 @@ describe("capability-intent — argMatches constraint", () => {
     expect(r.passed).toBe(false);
     expect(r.reason).toContain("invalid regex");
   });
+
+  it("denies an over-long operator pattern (SEC-107 ReDoS bound)", () => {
+    const r = evaluateCapabilityIntent(
+      rule({ ...base, constraints: { argMatches: { branch: `(a+)+${".".repeat(300)}` } } }),
+      makeContext({ capability: cap({ args: { branch: "feat/x" } }) }),
+    );
+    expect(r.passed).toBe(false);
+    expect(r.reason).toContain("must not exceed 256 chars");
+  });
+
+  it("denies an over-long agent-controlled arg value (SEC-107 ReDoS bound)", () => {
+    const r = evaluateCapabilityIntent(
+      rule({ ...base, constraints: { argMatches: { branch: "feat/.+" } } }),
+      makeContext({ capability: cap({ args: { branch: `feat/${"x".repeat(9000)}` } }) }),
+    );
+    expect(r.passed).toBe(false);
+    expect(r.reason).toContain("match input cap");
+  });
 });
 
 describe("capability-intent — maxCallsPerHour constraint (fail closed)", () => {

--- a/packages/policy-engine/src/__tests__/capability-intent.test.ts
+++ b/packages/policy-engine/src/__tests__/capability-intent.test.ts
@@ -331,6 +331,25 @@ describe("capability-intent — config validation (fail closed)", () => {
     expect(r.reason).toContain("effect");
   });
 
+  it("malformed rule provably scoped elsewhere stays inert; ambiguous scope still denies (SEC-181)", () => {
+    // Same malformed-input precedence as both composers: a broken rule whose
+    // selector is well-formed and names a DIFFERENT capability is not
+    // governing this invoke.
+    const inert = evaluateCapabilityIntent(
+      rule({ capabilities: ["x.tweet.create"], effect: "maybe" }),
+      makeContext({ capability: cap() }),
+    );
+    expect(inert.passed).toBe(true);
+    expect(inert.reason).toContain("not governed");
+
+    // An unrecoverable selector makes the rule's scope ambiguous => deny.
+    const ambiguous = evaluateCapabilityIntent(
+      rule({ capabilities: "not-an-array", effect: "allow" }),
+      makeContext({ capability: cap() }),
+    );
+    expect(ambiguous.passed).toBe(false);
+  });
+
   it("denies a non-integer maxCallsPerHour", () => {
     const r = evaluateCapabilityIntent(
       rule({ capabilities: ["github.*"], effect: "allow", constraints: { maxCallsPerHour: 1.5 } }),

--- a/packages/policy-engine/src/__tests__/evaluators.test.ts
+++ b/packages/policy-engine/src/__tests__/evaluators.test.ts
@@ -1073,7 +1073,7 @@ describe("Rate Limit Policy", () => {
 // ─── Time Window Tests ────────────────────────────────────────────────────
 
 describe("Time Window Policy", () => {
-  it("passes when no hour or day restrictions are set (always open)", async () => {
+  it("fails closed when no hour or day restrictions are set (SEC-180: empty rule is a misconfigured no-op)", async () => {
     const rule = makeTimeWindowRule({
       allowedHours: [],
       allowedDays: [],
@@ -1082,7 +1082,8 @@ describe("Time Window Policy", () => {
     const ctx = makeContext();
     const result = await evaluatePolicy(rule, ctx);
 
-    expect(result.passed).toBe(true);
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("no allowed days or hours");
   });
 
   it("passes when window covers all 24 hours and all 7 days", async () => {

--- a/packages/policy-engine/src/__tests__/evaluators.test.ts
+++ b/packages/policy-engine/src/__tests__/evaluators.test.ts
@@ -1804,3 +1804,38 @@ describe("PolicyEngine.evaluate()", () => {
     expect(result.results).toHaveLength(2);
   });
 });
+
+describe("Malformed evaluator config fails closed instead of throwing (SEC-105)", () => {
+  it("time-window with non-array allowedDays/allowedHours returns a structured deny", async () => {
+    for (const config of [
+      { allowedDays: undefined, allowedHours: [] },
+      { allowedDays: [], allowedHours: "9-17" },
+      {},
+    ]) {
+      const result = await evaluatePolicy(makeTimeWindowRule(config), makeContext());
+      expect(result.passed).toBe(false);
+      expect(result.reason).toContain("must be arrays");
+    }
+  });
+
+  it("allowed-chains with a non-array chains config returns a structured deny", async () => {
+    const rule: PolicyRule = {
+      id: "chains-bad",
+      type: "allowed-chains",
+      enabled: true,
+      config: { chains: "eip155:8453" },
+    };
+    const result = await evaluatePolicy(rule, makeContext());
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("must be an array");
+  });
+
+  it("approved-addresses with a non-array addresses config returns a structured deny", async () => {
+    const result = await evaluatePolicy(
+      makeAddressRule({ addresses: "0x1234567890123456789012345678901234567890" }),
+      makeContext(),
+    );
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("must be an array");
+  });
+});

--- a/packages/policy-engine/src/__tests__/evaluators.test.ts
+++ b/packages/policy-engine/src/__tests__/evaluators.test.ts
@@ -85,11 +85,15 @@ describe("Contract Allowlist Policy", () => {
     contracts: [{ address: contract, selectors: [selector] }],
   });
 
-  it("passes native value transfers with no calldata", async () => {
+  it("passes native value transfers with no calldata (SEC-183 documented seam)", async () => {
     const result = await evaluatePolicy(rule, makeContext());
 
     expect(result.passed).toBe(true);
-    expect(result.reason).toBe("No contract calldata");
+    // The reason names the seam so the audit trail shows the rule did not
+    // gate this transfer.
+    expect(result.reason).toBe(
+      "No contract calldata: native transfer is not gated by contract-allowlist",
+    );
   });
 
   it("passes when target contract and selector are explicitly allowed", async () => {

--- a/packages/policy-engine/src/__tests__/permissioned-x.test.ts
+++ b/packages/policy-engine/src/__tests__/permissioned-x.test.ts
@@ -170,6 +170,28 @@ describe("permissioned-X: contentPolicy", () => {
     expect(d.effect).toBe("hard_deny");
     expect(d.reasonCodes).toContain(R.CONFIGURATION_INVALID);
   });
+
+  it("over-long blockedPatterns fail closed as a config error (SEC-107 ReDoS bound)", () => {
+    const rule: ProviderPolicyRule = {
+      id: "r-long-regex",
+      type: "capability-intent",
+      enabled: true,
+      config: {
+        capabilities: [OP_TWEET],
+        effect: "allow",
+        constraints: { x: { contentPolicy: { blockedPatterns: [`(a+)+${".".repeat(300)}`] } } },
+      },
+    };
+    const d = composeProviderActionPolicyDecision([rule], ctx({}, { policyText: "anything" }));
+    expect(d.effect).toBe("hard_deny");
+    expect(d.reasonCodes).toContain(R.CONFIGURATION_INVALID);
+  });
+
+  it("over-long policyText fails closed instead of being scanned (SEC-107 ReDoS bound)", () => {
+    const x: XConstraints = { contentPolicy: { blockedPatterns: ["spam"] } };
+    const c = ctx({}, { policyText: `gm ${"x".repeat(9000)}` });
+    expect(decide(x, c).reasonCodes).toContain(R.INPUT_UNAVAILABLE);
+  });
 });
 
 // ─── maxPostsPerWindow ──────────────────────────────────────────────────────

--- a/packages/policy-engine/src/__tests__/permissioned-x.test.ts
+++ b/packages/policy-engine/src/__tests__/permissioned-x.test.ts
@@ -135,6 +135,23 @@ describe("permissioned-X: contentPolicy", () => {
     expect(decide(x, c).reasonCodes).toContain(R.INPUT_UNAVAILABLE);
   });
 
+  it("typed ctx.x signals win over contradictory caller args (SEC-182)", () => {
+    const noUrls: XConstraints = { contentPolicy: { allowUrls: false } };
+    // args (caller-influenced) claims a URL; the adapter-derived typed channel
+    // says there is none — the typed channel is authoritative.
+    expect(decide(noUrls, ctx({ hasUrl: true }, { x: { hasUrl: false } })).effect).toBe("allow");
+    // and the reverse: typed hasUrl=true denies even when args claims none.
+    const d = decide(noUrls, ctx({ hasUrl: false }, { x: { hasUrl: true } }));
+    expect(d.reasonCodes).toContain(R.X_URL_FORBIDDEN);
+
+    // same preference for the length signal
+    const maxLen: XConstraints = { contentPolicy: { maxLength: 10 } };
+    expect(decide(maxLen, ctx({}, { x: { textCodePointLength: 5 } })).effect).toBe("allow");
+    expect(decide(maxLen, ctx({}, { x: { textCodePointLength: 11 } })).reasonCodes).toContain(
+      R.X_CONTENT_TOO_LONG,
+    );
+  });
+
   it("blockedPatterns denies a matching text via the in-memory policyText channel", () => {
     // Patterns are standard JS RegExp source (no inline (?i) flag). Author
     // case-insensitivity into the pattern itself.

--- a/packages/policy-engine/src/__tests__/provider-policy-composition.test.ts
+++ b/packages/policy-engine/src/__tests__/provider-policy-composition.test.ts
@@ -112,6 +112,31 @@ describe("composeProviderActionPolicyDecision precedence", () => {
     expect(d.reasonCodes).toContain(PROVIDER_POLICY_REASON.CONFIGURATION_INVALID);
   });
 
+  it("malformed rule provably scoped to a DIFFERENT operation stays inert (SEC-181)", () => {
+    // Same malformed-config semantics as the legacy-plane composer: a broken
+    // rule must not brick operations it does not govern.
+    const scopedElsewhere: ProviderPolicyRule = {
+      id: "bad-elsewhere",
+      type: "capability-intent",
+      enabled: true,
+      config: { capabilities: ["x.tweet.create"], effect: "allow", bogusKey: 1 },
+    };
+    const d = composeProviderActionPolicyDecision([scopedElsewhere, rule("a", "allow")], ctx);
+    expect(d.effect).toBe("allow");
+  });
+
+  it("malformed rule with an unrecoverable selector still hard-denies (SEC-181)", () => {
+    const ambiguous: ProviderPolicyRule = {
+      id: "bad-ambiguous",
+      type: "capability-intent",
+      enabled: true,
+      config: { capabilities: "not-an-array", effect: "allow" },
+    };
+    const d = composeProviderActionPolicyDecision([ambiguous, rule("a", "allow")], ctx);
+    expect(d.effect).toBe("hard_deny");
+    expect(d.reasonCodes).toContain(PROVIDER_POLICY_REASON.CONFIGURATION_INVALID);
+  });
+
   it("unknown rule type => hard_deny", () => {
     const foreign: ProviderPolicyRule = {
       id: "x",

--- a/packages/policy-engine/src/__tests__/reputation.test.ts
+++ b/packages/policy-engine/src/__tests__/reputation.test.ts
@@ -263,3 +263,36 @@ describe("reputation-scaling evaluator", () => {
     expect(result.type).toBe("reputation-scaling");
   });
 });
+
+describe("reputation-scaling malformed input (SEC-105)", () => {
+  const linearConfig = {
+    baseMaxPerTx: "100000000000000000", // 0.1 ETH
+    maxMaxPerTx: "10000000000000000000", // 10 ETH
+    curve: "linear",
+  };
+
+  it("denies with a structured reason on non-numeric wei limits instead of throwing", () => {
+    const rule = makeRule("reputation-scaling", {
+      baseMaxPerTx: "not-a-number",
+      maxMaxPerTx: "10000000000000000000",
+      curve: "linear",
+    });
+    const result = evaluateReputationScaling(rule, {
+      reputationScore: 50,
+      txValue: 1n,
+    });
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("wei strings");
+  });
+
+  it("treats a non-finite score as 0 instead of throwing inside BigInt(NaN)", () => {
+    const limit = computeScaledLimit(linearConfig as any, Number.NaN);
+    expect(limit).toBe(BigInt("100000000000000000")); // base limit at score 0
+    const rule = makeRule("reputation-scaling", linearConfig);
+    const result = evaluateReputationScaling(rule, {
+      reputationScore: Number.NaN,
+      txValue: BigInt("100000000000000000"),
+    });
+    expect(result.passed).toBe(true); // exactly at the score-0 base limit
+  });
+});

--- a/packages/policy-engine/src/__tests__/venue-leverage.test.ts
+++ b/packages/policy-engine/src/__tests__/venue-leverage.test.ts
@@ -198,6 +198,77 @@ describe("PolicyEngine audit hook", () => {
     });
     expect(result.approved).toBe(true);
   });
+
+  it("emits verdict=NACK on the empty-policy-set deny (SEC-104)", async () => {
+    const events: { verdict: string }[] = [];
+    const engine = new PolicyEngine({
+      auditHook: (e) => {
+        events.push(e as { verdict: string });
+      },
+    });
+    const result = await engine.evaluate([], {
+      request: makeSignRequest(),
+      recentTxCount1h: 0,
+      recentTxCount24h: 0,
+      spentToday: 0n,
+      spentThisWeek: 0n,
+    });
+    expect(result.approved).toBe(false);
+    expect(events.length).toBe(1);
+    expect(events[0]!.verdict).toBe("NACK");
+  });
+
+  it("emits verdict=NACK before an evaluator throw propagates (SEC-104)", async () => {
+    const events: { verdict: string }[] = [];
+    const engine = new PolicyEngine({
+      auditHook: (e) => {
+        events.push(e as { verdict: string });
+      },
+    });
+    // A hostile config getter throws inside the evaluator, rejecting
+    // Promise.all — the denial must still reach the audit trail.
+    const hostile = {
+      id: "hostile-1",
+      type: "venue-allowlist",
+      enabled: true,
+    } as PolicyRule;
+    Object.defineProperty(hostile, "config", {
+      get() {
+        throw new Error("hostile config getter");
+      },
+    });
+    await expect(
+      engine.evaluate([hostile], {
+        request: makeSignRequest(),
+        recentTxCount1h: 0,
+        recentTxCount24h: 0,
+        spentToday: 0n,
+        spentThisWeek: 0n,
+        venue: "hyperliquid",
+      }),
+    ).rejects.toThrow("hostile config getter");
+    expect(events.length).toBe(1);
+    expect(events[0]!.verdict).toBe("NACK");
+  });
+
+  it("counts swallowed audit-hook failures instead of dropping them silently (SEC-104)", async () => {
+    const engine = new PolicyEngine({
+      auditHook: () => {
+        throw new Error("audit table is on fire");
+      },
+    });
+    expect(engine.auditHookFailures).toBe(0);
+    const result = await engine.evaluate([venueRule(["hyperliquid"])], {
+      request: makeSignRequest(),
+      recentTxCount1h: 0,
+      recentTxCount24h: 0,
+      spentToday: 0n,
+      spentThisWeek: 0n,
+      venue: "hyperliquid",
+    });
+    expect(result.approved).toBe(true);
+    expect(engine.auditHookFailures).toBe(1);
+  });
 });
 
 describe("PolicyEngine.evaluate (venue + leverage end-to-end)", () => {

--- a/packages/policy-engine/src/capability-intent.ts
+++ b/packages/policy-engine/src/capability-intent.ts
@@ -1164,6 +1164,19 @@ export function evaluateCapabilityIntent(
   // 2. Config must be well-formed (fail closed).
   const parsed = parseConfig(rule.config);
   if ("error" in parsed) {
+    // SEC-181: same malformed-input precedence as both composers — a malformed
+    // rule whose selector is well-formed and provably scoped to a DIFFERENT
+    // capability is not governing this invoke and stays inert. Only a
+    // malformed GOVERNING rule, or one whose selector is unrecoverable
+    // (ambiguous scope), denies.
+    const sel = recoverSelectorMatch(rule.config, ctx.capability.name);
+    if (sel.recoverable && !sel.matches) {
+      return {
+        ...base,
+        passed: true,
+        reason: `capability "${ctx.capability.name}" not governed by this rule`,
+      };
+    }
     return { ...base, passed: false, reason: parsed.error };
   }
 
@@ -1631,6 +1644,14 @@ export function composeProviderActionPolicyDecision(
 
       const parsed = parseConfig(rule.config);
       if ("error" in parsed) {
+        // SEC-181: malformed-input precedence is scoped to GOVERNING rules,
+        // matching the legacy-plane composer (composeCapabilityIntentDecision)
+        // and master-plan §5.3. A well-formed selector provably scoped to a
+        // DIFFERENT operation stays inert even though the rest of the config
+        // is broken; only a malformed rule that governs THIS operation, or
+        // whose selector is unrecoverable (ambiguous scope), hard-denies.
+        const sel = recoverSelectorMatch(rule.config, context.operationKey);
+        if (sel.recoverable && !sel.matches) continue;
         sawHardDeny = true;
         reasonCodes.add(PROVIDER_POLICY_REASON.CONFIGURATION_INVALID);
         results.push({

--- a/packages/policy-engine/src/capability-intent.ts
+++ b/packages/policy-engine/src/capability-intent.ts
@@ -65,6 +65,17 @@ import type { EvaluatorContext } from "./evaluators";
 /** the contributed rule-type discriminator. */
 export const CAPABILITY_INTENT_RULE_TYPE = "capability-intent" as const;
 
+/**
+ * ReDoS blast-radius bounds for operator-supplied patterns (SEC-107).
+ * `argMatches` / X `blockedPatterns` regexes come from tenant-admin policy
+ * config and run against agent-influenced invoke args / tweet text with no
+ * engine-side match timeout, so a catastrophically-backtracking pattern (even
+ * pasted innocently) could hang the API event loop. Both the pattern and the
+ * matched input are length-capped; anything over the cap fails closed (deny).
+ */
+export const MAX_POLICY_PATTERN_LENGTH = 256;
+export const MAX_POLICY_PATTERN_INPUT_LENGTH = 8_192;
+
 // ─── Permissioned-X: per-post price table (versioned constant) ────────────────
 //
 // SOURCE (captured 2026-07-16, docs.x.com pay-per-use, effective Feb 6 2026):
@@ -664,6 +675,12 @@ function parseXConstraints(rawInput: unknown): XConstraints | { error: string } 
           error:
             "capability-intent: `x.contentPolicy.blockedPatterns` must be a non-empty string[] of non-empty strings",
         };
+      // SEC-107: bound operator-supplied regexes at parse time (same cap as
+      // argMatches) so a pathological pattern fails closed as a config error.
+      if (cp.blockedPatterns.some((p) => (p as string).length > MAX_POLICY_PATTERN_LENGTH))
+        return {
+          error: `capability-intent: \`x.contentPolicy.blockedPatterns\` patterns must not exceed ${MAX_POLICY_PATTERN_LENGTH} chars`,
+        };
       content.blockedPatterns = cp.blockedPatterns as string[];
     }
     out.contentPolicy = content;
@@ -911,6 +928,18 @@ function parseConfig(rawInput: unknown): CapabilityIntentConfig | { error: strin
     if (c.argMatches !== undefined && !isStringRecord(c.argMatches)) {
       return { error: "capability-intent: `constraints.argMatches` must be Record<string,string>" };
     }
+    // SEC-107: bound operator-supplied regexes at store/parse time, not just at
+    // evaluation time, so a pathological pattern fails closed as a config error.
+    if (
+      c.argMatches !== undefined &&
+      Object.values(c.argMatches as Record<string, string>).some(
+        (p) => p.length > MAX_POLICY_PATTERN_LENGTH,
+      )
+    ) {
+      return {
+        error: `capability-intent: \`constraints.argMatches\` patterns must not exceed ${MAX_POLICY_PATTERN_LENGTH} chars`,
+      };
+    }
 
     let timeWindow: CapabilityTimeWindow | undefined;
     if (c.timeWindow !== undefined) {
@@ -1010,6 +1039,15 @@ function evaluateConstraints(
   // compiled) regex. Invalid regex in config => deny (never throw).
   if (constraints.argMatches) {
     for (const [key, pattern] of Object.entries(constraints.argMatches)) {
+      // SEC-107: cap the operator-supplied pattern length so a pathological
+      // regex cannot be smuggled in via config.
+      if (typeof pattern !== "string" || pattern.length > MAX_POLICY_PATTERN_LENGTH) {
+        return {
+          ...base,
+          passed: false,
+          reason: `capability-intent: regex for arg "${key}" missing or exceeds ${MAX_POLICY_PATTERN_LENGTH} chars`,
+        };
+      }
       let re: RegExp;
       try {
         // anchor full-string so a partial match can't slip a governed arg.
@@ -1029,6 +1067,15 @@ function evaluateConstraints(
         };
       }
       const value = args[key];
+      // SEC-107: cap the agent-controlled input the regex runs against; an
+      // oversized arg cannot be verified within the bound => deny.
+      if (typeof value === "string" && value.length > MAX_POLICY_PATTERN_INPUT_LENGTH) {
+        return {
+          ...base,
+          passed: false,
+          reason: `capability-intent: arg "${key}" exceeds the ${MAX_POLICY_PATTERN_INPUT_LENGTH}-char match input cap`,
+        };
+      }
       if (typeof value !== "string" || !re.test(value)) {
         return {
           ...base,
@@ -1708,6 +1755,10 @@ function evaluateProviderConstraints(
   }
   if (constraints.argMatches) {
     for (const [key, pattern] of Object.entries(constraints.argMatches)) {
+      // SEC-107: same ReDoS bounds as the legacy-plane evaluator.
+      if (typeof pattern !== "string" || pattern.length > MAX_POLICY_PATTERN_LENGTH) {
+        return PROVIDER_POLICY_REASON.CONFIGURATION_INVALID;
+      }
       let re: RegExp;
       try {
         re = new RegExp(`^(?:${pattern})$`);
@@ -1715,6 +1766,9 @@ function evaluateProviderConstraints(
         return PROVIDER_POLICY_REASON.CONFIGURATION_INVALID;
       }
       const value = args[key];
+      if (typeof value === "string" && value.length > MAX_POLICY_PATTERN_INPUT_LENGTH) {
+        return PROVIDER_POLICY_REASON.HARD_DENY;
+      }
       if (typeof value !== "string" || !re.test(value)) return PROVIDER_POLICY_REASON.HARD_DENY;
     }
   }
@@ -1946,7 +2000,17 @@ export function evaluateXConstraints(
       if (typeof text !== "string") {
         return { kind: "deny", reasonCode: PROVIDER_POLICY_REASON.INPUT_UNAVAILABLE };
       }
+      // SEC-107: cap the agent-controlled input the patterns run against; text
+      // too large to scan within the bound cannot be proven clean => deny.
+      if (text.length > MAX_POLICY_PATTERN_INPUT_LENGTH) {
+        return { kind: "deny", reasonCode: PROVIDER_POLICY_REASON.INPUT_UNAVAILABLE };
+      }
       for (const pattern of x.contentPolicy.blockedPatterns) {
+        // SEC-107: cap the operator-supplied pattern length so a pathological
+        // regex cannot be smuggled in via config.
+        if (typeof pattern !== "string" || pattern.length > MAX_POLICY_PATTERN_LENGTH) {
+          return { kind: "deny", reasonCode: PROVIDER_POLICY_REASON.CONFIGURATION_INVALID };
+        }
         let re: RegExp;
         try {
           re = new RegExp(pattern);

--- a/packages/policy-engine/src/capability-intent.ts
+++ b/packages/policy-engine/src/capability-intent.ts
@@ -1502,6 +1502,18 @@ export interface ProviderPolicyContext {
     readonly accumulatedSpendMicros?: number;
     /** authoritative current minute-of-day UTC, 0..1439 (used by quietHours). */
     readonly nowMinuteUtc?: number;
+    /** adapter-derived "the post is a reply" signal (replyPolicy). PREFERRED
+     *  over the same-named `args` entry, which is caller-influenced (SEC-182). */
+    readonly isReply?: boolean;
+    /** adapter-derived "the user summoned the agent" signal (replyPolicy
+     *  summoned-only). PREFERRED over `args` (SEC-182). */
+    readonly summoned?: boolean;
+    /** adapter-derived "the post body contains a URL" signal (allowUrls /
+     *  spend / escalation policies). PREFERRED over `args` (SEC-182). */
+    readonly hasUrl?: boolean;
+    /** adapter-counted code-point length of the post text (maxLength).
+     *  PREFERRED over `args` (SEC-182). */
+    readonly textCodePointLength?: number;
   };
   /**
    * The operation's DECLARED spend field (#206). The operation - not the caller
@@ -1938,6 +1950,23 @@ function readBool(args: Record<string, unknown>, key: string): boolean | undefin
 }
 
 /**
+ * Read an X security signal, PREFERRING the typed, adapter-populated `ctx.x`
+ * channel over the caller-influenced `args` bag (SEC-182). The engine cannot
+ * distinguish adapter-derived values from pass-through caller args inside
+ * `args`; the typed channel is populated server-side from the adapter's
+ * validated build. The args read remains as the legacy fallback for adapters
+ * that do not wire the typed fields yet — the fail-closed contract (missing =>
+ * POLICY_INPUT_UNAVAILABLE) is unchanged either way.
+ */
+function xBoolSignal(
+  ctx: ProviderPolicyContext,
+  key: "isReply" | "summoned" | "hasUrl",
+): boolean | undefined {
+  const typed = ctx.x?.[key];
+  return typeof typed === "boolean" ? typed : readBool(ctx.args, key);
+}
+
+/**
  * Evaluate the permissioned-X constraint sub-block against the provider-policy
  * context. Returns:
  *   - { kind: "deny", reasonCode }  on the FIRST hard failure (deny wins),
@@ -1967,7 +1996,7 @@ export function evaluateXConstraints(
   // closed (an operation whose build doesn't carry isReply must NOT slip a reply
   // gate). `summoned` is only required when we actually reach the summoned check.
   if (x.replyPolicy) {
-    const isReply = readBool(args, "isReply");
+    const isReply = xBoolSignal(ctx, "isReply");
     if (isReply === undefined) {
       return { kind: "deny", reasonCode: PROVIDER_POLICY_REASON.INPUT_UNAVAILABLE };
     }
@@ -1976,7 +2005,7 @@ export function evaluateXConstraints(
         return { kind: "deny", reasonCode: PROVIDER_POLICY_REASON.X_REPLY_FORBIDDEN };
       }
       if (x.replyPolicy.mode === "summoned-only") {
-        const summoned = readBool(args, "summoned");
+        const summoned = xBoolSignal(ctx, "summoned");
         if (summoned === undefined) {
           return { kind: "deny", reasonCode: PROVIDER_POLICY_REASON.INPUT_UNAVAILABLE };
         }
@@ -1996,7 +2025,7 @@ export function evaluateXConstraints(
   if (x.contentPolicy) {
     // allowUrls DEPENDS on the `hasUrl` signal; absent/non-boolean => fail closed.
     if (x.contentPolicy.allowUrls === false) {
-      const hasUrl = readBool(args, "hasUrl");
+      const hasUrl = xBoolSignal(ctx, "hasUrl");
       if (hasUrl === undefined) {
         return { kind: "deny", reasonCode: PROVIDER_POLICY_REASON.INPUT_UNAVAILABLE };
       }
@@ -2005,7 +2034,9 @@ export function evaluateXConstraints(
       }
     }
     if (x.contentPolicy.maxLength !== undefined) {
-      const len = args.textCodePointLength;
+      // SEC-182: prefer the typed, adapter-populated length signal over the
+      // caller-influenced `args` bag (same fallback contract as xBoolSignal).
+      const len = ctx.x?.textCodePointLength ?? args.textCodePointLength;
       // A content-length policy REQUIRES the length signal. Absent => fail closed.
       if (typeof len !== "number" || !Number.isInteger(len)) {
         return { kind: "deny", reasonCode: PROVIDER_POLICY_REASON.INPUT_UNAVAILABLE };
@@ -2080,7 +2111,7 @@ export function evaluateXConstraints(
     x.escalation?.urlPostRequiresApproval === true;
   let hasUrl: boolean | undefined;
   if (needsHasUrl) {
-    hasUrl = readBool(args, "hasUrl");
+    hasUrl = xBoolSignal(ctx, "hasUrl");
     if (hasUrl === undefined) {
       return { kind: "deny", reasonCode: PROVIDER_POLICY_REASON.INPUT_UNAVAILABLE };
     }

--- a/packages/policy-engine/src/engine.ts
+++ b/packages/policy-engine/src/engine.ts
@@ -158,7 +158,9 @@ export interface PolicyEngineOptions {
    * Sprint 4: optional sink for `policy.evaluated` audit events. Trade-
    * sessions wires this to the proxy audit log so every evaluation is
    * traceable to its inputs and verdict. Failures inside the hook are
-   * swallowed so they don't block the trade.
+   * swallowed so they don't block the trade — but counted on
+   * `auditHookFailures` and logged, so a persistently failing hook cannot
+   * silently disable the audit trail (SEC-104).
    */
   auditHook?: AuditHook;
 }
@@ -173,9 +175,20 @@ export interface PolicyEngineOptions {
  */
 export class PolicyEngine {
   private readonly auditHook?: AuditHook;
+  private auditHookFailureCount = 0;
 
   constructor(options: PolicyEngineOptions = {}) {
     if (options.auditHook) this.auditHook = options.auditHook;
+  }
+
+  /**
+   * Number of audit-hook failures swallowed since engine construction. A
+   * growing count means the policy audit trail is silently going dark — hook
+   * failures must never block a trade, but they must not be invisible either
+   * (SEC-104).
+   */
+  get auditHookFailures(): number {
+    return this.auditHookFailureCount;
   }
 
   /**
@@ -188,7 +201,12 @@ export class PolicyEngine {
     ctx: PolicyEvaluationContext & { correlationId?: string },
   ): Promise<EvaluationResult> {
     if (policies.length === 0) {
-      return { approved: false, results: [], requiresManualApproval: false };
+      // "No policies configured" is a deny and MUST be audited like any other
+      // — returning before emitAuditEvent leaves no trace of the rejection
+      // (SEC-104).
+      const evaluationResult = { approved: false, results: [], requiresManualApproval: false };
+      await this.emitAuditEvent(ctx, [], evaluationResult);
+      return evaluationResult;
     }
 
     const evaluatorCtx: EvaluatorContext = {
@@ -210,9 +228,22 @@ export class PolicyEngine {
       capabilityInvokeCount1h: ctx.capabilityInvokeCount1h,
     };
 
-    const results: EnginePolicyResult[] = await Promise.all(
-      policies.map((policy) => evaluatePolicy(policy, evaluatorCtx)),
-    );
+    // SEC-104: an evaluator throw rejects `Promise.all` past the audit call
+    // below, erasing the denial from the audit trail. Emit a NACK event before
+    // propagating so even a 500-surfacing failure stays traceable. (SEC-105
+    // makes config-malformation a structured deny; this catch is the residual
+    // guard for unexpected evaluator bugs.)
+    let results: EnginePolicyResult[];
+    try {
+      results = await Promise.all(policies.map((policy) => evaluatePolicy(policy, evaluatorCtx)));
+    } catch (err) {
+      await this.emitAuditEvent(ctx, [], {
+        approved: false,
+        results: [],
+        requiresManualApproval: false,
+      });
+      throw err;
+    }
 
     // Same falsy check as evaluatePolicy: a rule with `enabled: undefined`/
     // null/0 is disabled for pass purposes, so an all-such policy set hits
@@ -282,8 +313,16 @@ export class PolicyEngine {
     };
     try {
       await this.auditHook(event);
-    } catch {
-      // Audit failures must never block a trade. The engine swallows.
+    } catch (err) {
+      // Audit failures must never block a trade. The engine swallows, but not
+      // silently (SEC-104): count and log every failure so a persistently
+      // failing hook is visible to operators instead of quietly disabling the
+      // whole policy audit trail.
+      this.auditHookFailureCount += 1;
+      console.warn(
+        `[steward] policy audit hook failed (${this.auditHookFailureCount} since engine start); policy.evaluated events are being dropped`,
+        err,
+      );
     }
   }
 

--- a/packages/policy-engine/src/evaluators.ts
+++ b/packages/policy-engine/src/evaluators.ts
@@ -533,6 +533,17 @@ async function evaluateSpendingLimit(
 function evaluateApprovedAddresses(rule: PolicyRule, ctx: EvaluatorContext): PolicyResult {
   const config = rule.config as unknown as ApprovedAddressesConfig;
   const base = { policyId: rule.id, type: rule.type } as const;
+
+  // Fail closed with a structured deny on malformed config instead of throwing
+  // on `.map` (SEC-105).
+  if (!Array.isArray(config.addresses)) {
+    return {
+      ...base,
+      passed: false,
+      reason: "Approved addresses must be an array",
+    };
+  }
+
   const targetAddress = getApprovedAddressTarget(ctx.request);
   if (!targetAddress) {
     return {
@@ -688,6 +699,17 @@ function evaluateRateLimit(rule: PolicyRule, ctx: EvaluatorContext): PolicyResul
 function evaluateTimeWindow(rule: PolicyRule, _ctx: EvaluatorContext): PolicyResult {
   const config = rule.config as unknown as TimeWindowConfig;
   const base = { policyId: rule.id, type: rule.type } as const;
+
+  // Fail closed with a structured deny on malformed config instead of throwing
+  // on `.length` (SEC-105) — consistent with the other defensive evaluators.
+  if (!Array.isArray(config.allowedDays) || !Array.isArray(config.allowedHours)) {
+    return {
+      ...base,
+      passed: false,
+      reason: "Time-window allowedDays and allowedHours must be arrays",
+    };
+  }
+
   const now = new Date();
   const hour = now.getUTCHours();
   const day = now.getUTCDay();
@@ -721,6 +743,16 @@ function evaluateAllowedChains(rule: PolicyRule, ctx: EvaluatorContext): PolicyR
   const config = rule.config as unknown as AllowedChainsConfig;
   const base = { policyId: rule.id, type: rule.type } as const;
   const chainId = ctx.request.chainId;
+
+  // Fail closed with a structured deny on malformed config instead of throwing
+  // on `.includes` (SEC-105).
+  if (!Array.isArray(config.chains)) {
+    return {
+      ...base,
+      passed: false,
+      reason: "Allowed chains must be an array of CAIP-2 identifiers",
+    };
+  }
 
   if (!Number.isSafeInteger(chainId) || chainId <= 0) {
     return {

--- a/packages/policy-engine/src/evaluators.ts
+++ b/packages/policy-engine/src/evaluators.ts
@@ -710,6 +710,18 @@ function evaluateTimeWindow(rule: PolicyRule, _ctx: EvaluatorContext): PolicyRes
     };
   }
 
+  // An enabled time-window rule with NO windows at all is a misconfigured
+  // no-op that would pass everything — fail closed instead (SEC-180),
+  // consistent with venue-allowlist's empty-config deny. An empty array on
+  // exactly ONE dimension still means "unconstrained on that dimension".
+  if (config.allowedDays.length === 0 && config.allowedHours.length === 0) {
+    return {
+      ...base,
+      passed: false,
+      reason: "Time-window rule has no allowed days or hours configured",
+    };
+  }
+
   const now = new Date();
   const hour = now.getUTCHours();
   const day = now.getUTCDay();

--- a/packages/policy-engine/src/evaluators.ts
+++ b/packages/policy-engine/src/evaluators.ts
@@ -886,8 +886,23 @@ function evaluateContractAllowlist(rule: PolicyRule, ctx: EvaluatorContext): Pol
   const base = { policyId: rule.id, type: rule.type } as const;
   const data = ctx.request.data;
 
+  // SEC-183 (documented seam): a request with NO calldata is a plain native
+  // transfer, and this rule does NOT gate it — it passes unconditionally,
+  // regardless of the allowlist. This is intentional (the rule's job is
+  // contract/selector gating) but a common misconfiguration seam: operators
+  // who expect contract-allowlist to also constrain native sends MUST pair it
+  // with an approved-addresses rule (note: the write validator restricts
+  // approved-addresses to EVM addresses, so on Solana/Monero paths that rule
+  // can never match and always denies — native-transfer gating there needs a
+  // chain-appropriate rule). Flipping this branch to deny would silently
+  // break existing tenants that rely on the documented behavior, so the
+  // decision to gate native transfers explicitly is deferred (see SEC-183).
   if (!data || data === "0x") {
-    return { ...base, passed: true, reason: "No contract calldata" };
+    return {
+      ...base,
+      passed: true,
+      reason: "No contract calldata: native transfer is not gated by contract-allowlist",
+    };
   }
 
   if (!/^0x(?:[a-fA-F0-9]{2})+$/.test(data) || data.length < 10) {

--- a/packages/policy-engine/src/evaluators/aggregation.ts
+++ b/packages/policy-engine/src/evaluators/aggregation.ts
@@ -155,8 +155,18 @@ function resolveWindowSeconds(config: AggregationConditionConfig): number | null
   }
 
   if (window.named !== undefined) {
+    // Prototype-key safe lookup (SEC-106): `NAMED_WINDOW_SECONDS["__proto__"]`
+    // on a plain object returns Object.prototype — an object, not null — which
+    // would escape the "unknown window → deny" contract below. hasOwn restricts
+    // to own keys and the finite check guarantees the number|null return type.
+    if (
+      typeof window.named !== "string" ||
+      !Object.hasOwn(NAMED_WINDOW_SECONDS, window.named)
+    ) {
+      return null;
+    }
     const seconds = NAMED_WINDOW_SECONDS[window.named];
-    return seconds ?? null;
+    return typeof seconds === "number" && Number.isFinite(seconds) ? seconds : null;
   }
 
   return null;

--- a/packages/policy-engine/src/evaluators/aggregation.ts
+++ b/packages/policy-engine/src/evaluators/aggregation.ts
@@ -159,10 +159,7 @@ function resolveWindowSeconds(config: AggregationConditionConfig): number | null
     // on a plain object returns Object.prototype — an object, not null — which
     // would escape the "unknown window → deny" contract below. hasOwn restricts
     // to own keys and the finite check guarantees the number|null return type.
-    if (
-      typeof window.named !== "string" ||
-      !Object.hasOwn(NAMED_WINDOW_SECONDS, window.named)
-    ) {
+    if (typeof window.named !== "string" || !Object.hasOwn(NAMED_WINDOW_SECONDS, window.named)) {
       return null;
     }
     const seconds = NAMED_WINDOW_SECONDS[window.named];

--- a/packages/policy-engine/src/evaluators/reputation-scaling.ts
+++ b/packages/policy-engine/src/evaluators/reputation-scaling.ts
@@ -23,11 +23,16 @@ export interface ReputationScalingContext {
 
 /**
  * Compute the effective limit for a given reputation score and config.
+ *
+ * Total on the score: a non-finite score (NaN/±Infinity from a corrupt
+ * reputation feed) is treated as 0 — the lowest limit — rather than throwing
+ * inside `BigInt(NaN)` (SEC-105).
  */
 export function computeScaledLimit(config: ReputationScalingConfig, score: number): bigint {
   const base = BigInt(config.baseMaxPerTx);
   const max = BigInt(config.maxMaxPerTx);
-  const clampedScore = Math.max(0, Math.min(score, 100));
+  const finiteScore = Number.isFinite(score) ? score : 0;
+  const clampedScore = Math.max(0, Math.min(finiteScore, 100));
 
   if (config.curve === "logarithmic") {
     // ln(1 + score) / ln(101) gives 0..1 with diminishing returns
@@ -48,6 +53,17 @@ export function evaluateReputationScaling(
 ): PolicyResult {
   const config = rule.config as unknown as ReputationScalingConfig;
   const base = { policyId: rule.id, type: rule.type } as const;
+
+  // Fail closed with a structured deny on malformed config instead of throwing
+  // inside `BigInt(...)` (SEC-105) — consistent with the other defensive
+  // evaluators.
+  if (!/^\d+$/.test(config.baseMaxPerTx) || !/^\d+$/.test(config.maxMaxPerTx)) {
+    return {
+      ...base,
+      passed: false,
+      reason: "Reputation-scaling limits must be base-10 wei strings",
+    };
+  }
 
   // Default to score 0 (lowest limit) when no score available
   const score = ctx.reputationScore ?? 0;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -462,6 +462,14 @@ export interface AggregationConditionConfig {
   denomination?: AggregationDenomination;
 }
 
+/**
+ * SEC-183 (documented seam): `contract-allowlist` gates CONTRACT CALLS ONLY.
+ * A transaction with no calldata — a plain native-value transfer — passes
+ * this rule unconditionally regardless of the allowlist below. Operators who
+ * expect it to also constrain native sends MUST pair it with an
+ * `approved-addresses` rule (whose write validator currently restricts
+ * addresses to EVM format).
+ */
 export interface ContractAllowlistConfig {
   contracts: Array<{
     address: string;

--- a/packages/webhooks/src/__tests__/dispatcher-legacy-secret.test.ts
+++ b/packages/webhooks/src/__tests__/dispatcher-legacy-secret.test.ts
@@ -115,12 +115,16 @@ describe("WebhookDispatcher legacy string-URL signing (SEC-101)", () => {
       const signatureB = String(requestB?.headers["x-steward-signature"]);
 
       // Tenant A's delivery verifies under A's derived key only.
-      expect(signatureA).toBe(signatureFor(requestA!, deriveLegacySecret(MASTER_SECRET, "tenant-a")));
+      expect(signatureA).toBe(
+        signatureFor(requestA!, deriveLegacySecret(MASTER_SECRET, "tenant-a")),
+      );
       expect(signatureA).not.toBe(
         signatureFor(requestA!, deriveLegacySecret(MASTER_SECRET, "tenant-b")),
       );
       // Tenant B's delivery verifies under B's derived key only.
-      expect(signatureB).toBe(signatureFor(requestB!, deriveLegacySecret(MASTER_SECRET, "tenant-b")));
+      expect(signatureB).toBe(
+        signatureFor(requestB!, deriveLegacySecret(MASTER_SECRET, "tenant-b")),
+      );
       expect(signatureB).not.toBe(
         signatureFor(requestB!, deriveLegacySecret(MASTER_SECRET, "tenant-a")),
       );
@@ -135,8 +139,8 @@ describe("WebhookDispatcher legacy string-URL signing (SEC-101)", () => {
   it("still requires STEWARD_WEBHOOK_SECRET for the string form", async () => {
     delete process.env.STEWARD_WEBHOOK_SECRET;
     const dispatcher = new WebhookDispatcher({ maxRetries: 0, timeoutMs: 1_000 });
-    await expect(dispatcher.dispatch(makeEvent("tenant-a"), "https://example.com/hook")).rejects.toThrow(
-      "Webhook secret is required",
-    );
+    await expect(
+      dispatcher.dispatch(makeEvent("tenant-a"), "https://example.com/hook"),
+    ).rejects.toThrow("Webhook secret is required");
   });
 });

--- a/packages/webhooks/src/__tests__/dispatcher-legacy-secret.test.ts
+++ b/packages/webhooks/src/__tests__/dispatcher-legacy-secret.test.ts
@@ -1,0 +1,142 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { createHmac } from "node:crypto";
+import { createServer, type IncomingMessage } from "node:http";
+import type { AddressInfo } from "node:net";
+import type { WebhookEvent } from "@stwd/shared";
+import { WebhookDispatcher } from "../dispatcher";
+
+const MASTER_SECRET = "legacy-master-secret-for-tests";
+
+const makeEvent = (tenantId: string): WebhookEvent => ({
+  type: "tx_signed",
+  tenantId,
+  agentId: "agent-a",
+  data: { txHash: "0xabc" },
+  timestamp: new Date("2026-05-30T09:00:00.000Z"),
+});
+
+type CapturedRequest = {
+  headers: IncomingMessage["headers"];
+  bodyText: string;
+};
+
+async function readBody(req: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+async function withWebhookServer() {
+  const requests: CapturedRequest[] = [];
+  const server = createServer(async (req, res) => {
+    requests.push({ headers: req.headers, bodyText: await readBody(req) });
+    res.writeHead(200, { "Content-Type": "text/plain" });
+    res.end("");
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.listen(0, "127.0.0.1", (error?: Error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}/hook`,
+    requests,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      }),
+  };
+}
+
+function hmac(payload: string, secret: string): string {
+  return createHmac("sha256", secret).update(payload).digest("hex");
+}
+
+function canonicalSignedPayload(
+  timestamp: string,
+  deliveryId: string,
+  eventType: string,
+  body: string,
+): string {
+  return `v2:${timestamp}.${deliveryId.length}:${deliveryId}.${eventType.length}:${eventType}.${body}`;
+}
+
+function deriveLegacySecret(masterSecret: string, tenantId: string): string {
+  return createHmac("sha256", masterSecret)
+    .update(`steward-legacy-webhook-secret:${tenantId}`)
+    .digest("hex");
+}
+
+function signatureFor(request: CapturedRequest, secret: string): string {
+  const sentAt = String(request.headers["x-steward-sent-at"]);
+  const deliveryId = String(request.headers["x-steward-delivery-id"]);
+  const eventType = String(request.headers["x-steward-event"]);
+  return `v2=${hmac(canonicalSignedPayload(sentAt, deliveryId, eventType, request.bodyText), secret)}`;
+}
+
+describe("WebhookDispatcher legacy string-URL signing (SEC-101)", () => {
+  const ORIGINAL_SECRET = process.env.STEWARD_WEBHOOK_SECRET;
+
+  beforeAll(() => {
+    process.env.STEWARD_WEBHOOK_SECRET = MASTER_SECRET;
+  });
+
+  afterAll(() => {
+    if (ORIGINAL_SECRET === undefined) delete process.env.STEWARD_WEBHOOK_SECRET;
+    else process.env.STEWARD_WEBHOOK_SECRET = ORIGINAL_SECRET;
+  });
+
+  it("signs the legacy path with a per-tenant derived key, not the global master secret", async () => {
+    const server = await withWebhookServer();
+    const dispatcher = new WebhookDispatcher({
+      maxRetries: 0,
+      timeoutMs: 1_000,
+      allowPrivateNetwork: true,
+      allowInsecureHttp: true,
+    });
+
+    try {
+      // Bare string URL — the legacy tenant-config fan-out form.
+      const resultA = await dispatcher.dispatch(makeEvent("tenant-a"), server.url);
+      const resultB = await dispatcher.dispatch(makeEvent("tenant-b"), server.url);
+      expect(resultA.success).toBe(true);
+      expect(resultB.success).toBe(true);
+      expect(server.requests).toHaveLength(2);
+
+      const [requestA, requestB] = server.requests;
+      const signatureA = String(requestA?.headers["x-steward-signature"]);
+      const signatureB = String(requestB?.headers["x-steward-signature"]);
+
+      // Tenant A's delivery verifies under A's derived key only.
+      expect(signatureA).toBe(signatureFor(requestA!, deriveLegacySecret(MASTER_SECRET, "tenant-a")));
+      expect(signatureA).not.toBe(
+        signatureFor(requestA!, deriveLegacySecret(MASTER_SECRET, "tenant-b")),
+      );
+      // Tenant B's delivery verifies under B's derived key only.
+      expect(signatureB).toBe(signatureFor(requestB!, deriveLegacySecret(MASTER_SECRET, "tenant-b")));
+      expect(signatureB).not.toBe(
+        signatureFor(requestB!, deriveLegacySecret(MASTER_SECRET, "tenant-a")),
+      );
+      // Neither is signed with the raw process-wide master secret.
+      expect(signatureA).not.toBe(signatureFor(requestA!, MASTER_SECRET));
+      expect(signatureB).not.toBe(signatureFor(requestB!, MASTER_SECRET));
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("still requires STEWARD_WEBHOOK_SECRET for the string form", async () => {
+    delete process.env.STEWARD_WEBHOOK_SECRET;
+    const dispatcher = new WebhookDispatcher({ maxRetries: 0, timeoutMs: 1_000 });
+    await expect(dispatcher.dispatch(makeEvent("tenant-a"), "https://example.com/hook")).rejects.toThrow(
+      "Webhook secret is required",
+    );
+  });
+});

--- a/packages/webhooks/src/__tests__/dispatcher-retry-classification.test.ts
+++ b/packages/webhooks/src/__tests__/dispatcher-retry-classification.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "bun:test";
+import type { WebhookEvent } from "@stwd/shared";
+import { WebhookDispatcher } from "../dispatcher";
+
+const SECRET = "retry-classification-secret";
+
+const makeEvent = (): WebhookEvent => ({
+  type: "tx_signed",
+  tenantId: "tenant-a",
+  agentId: "agent-a",
+  data: { txHash: "0xabc" },
+  timestamp: new Date("2026-05-30T09:00:00.000Z"),
+});
+
+describe("WebhookDispatcher retry classification (SEC-179)", () => {
+  it("does not retry deterministic validation rejections", async () => {
+    const dispatcher = new WebhookDispatcher({
+      maxRetries: 3,
+      retryDelayMs: 1,
+      timeoutMs: 500,
+      allowPrivateNetwork: false,
+      allowInsecureHttp: true,
+    });
+
+    // SSRF-guard rejection: permanent, must not burn maxRetries+1 attempts.
+    const ssrf = await dispatcher.dispatch(makeEvent(), {
+      url: "http://127.0.0.1:9/hook",
+      secret: SECRET,
+    });
+    expect(ssrf.success).toBe(false);
+    expect(ssrf.attempts).toBe(1);
+    expect(ssrf.error).toContain("must resolve to a public address");
+
+    // https-scheme rejection (no insecure-http escape hatch): permanent as well.
+    const httpsOnly = new WebhookDispatcher({
+      maxRetries: 3,
+      retryDelayMs: 1,
+      timeoutMs: 500,
+      allowPrivateNetwork: false,
+      allowInsecureHttp: false,
+    });
+    const plainHttp = await httpsOnly.dispatch(makeEvent(), {
+      url: "http://example.com/hook",
+      secret: SECRET,
+    });
+    expect(plainHttp.success).toBe(false);
+    expect(plainHttp.attempts).toBe(1);
+    expect(plainHttp.error).toContain("must use https");
+
+    const badScheme = await dispatcher.dispatch(makeEvent(), {
+      url: "ftp://example.com/hook",
+      secret: SECRET,
+    });
+    expect(badScheme.success).toBe(false);
+    expect(badScheme.attempts).toBe(1);
+
+    const unparseable = await dispatcher.dispatch(makeEvent(), {
+      url: "not a url",
+      secret: SECRET,
+    });
+    expect(unparseable.success).toBe(false);
+    expect(unparseable.attempts).toBe(1);
+  });
+
+  it("still retries transient network failures", async () => {
+    // A private-network-enabled dispatcher skips the SSRF guard, so a dead
+    // loopback port is a plain connection-refused network error: retryable.
+    const dispatcher = new WebhookDispatcher({
+      maxRetries: 2,
+      retryDelayMs: 1,
+      timeoutMs: 500,
+      allowPrivateNetwork: true,
+      allowInsecureHttp: true,
+    });
+
+    const result = await dispatcher.dispatch(makeEvent(), {
+      url: "http://127.0.0.1:9/hook",
+      secret: SECRET,
+    });
+    expect(result.success).toBe(false);
+    expect(result.attempts).toBe(3);
+  });
+});

--- a/packages/webhooks/src/__tests__/dispatcher-security.test.ts
+++ b/packages/webhooks/src/__tests__/dispatcher-security.test.ts
@@ -5,6 +5,7 @@ import type { AddressInfo } from "node:net";
 import type { WebhookEvent } from "@stwd/shared";
 import { WebhookDispatcher } from "../dispatcher";
 import { RetryQueue } from "../queue";
+import { verifyWebhookSignature } from "../verify";
 
 const SECRET = "super-secret-webhook-key";
 
@@ -90,12 +91,24 @@ function expectedSignature(request: CapturedRequest, secret: string): string {
   )}`;
 }
 
+// Receivers verify with the package helper (timing-safe HMAC compare plus a
+// freshness window) — never a `signature === expected` string compare, which
+// leaks the matching prefix through timing (SEC-177).
+function requestVerifies(request: CapturedRequest, secret: string): boolean {
+  return verifyWebhookSignature({
+    body: request.bodyText,
+    deliveryId: String(request.headers["x-steward-delivery-id"]),
+    eventType: String(request.headers["x-steward-event"]),
+    sentAt: String(request.headers["x-steward-sent-at"]),
+    signature: String(request.headers["x-steward-signature"]),
+    secret,
+  });
+}
+
 describe("WebhookDispatcher HMAC signing", () => {
   it("sends an HMAC-SHA256 signature that verifies against the exact request body", async () => {
     const server = await withWebhookServer((request) => {
-      const signature = String(request.headers["x-steward-signature"]);
-      const expected = expectedSignature(request, SECRET);
-      return { status: signature === expected ? 200 : 401 };
+      return { status: requestVerifies(request, SECRET) ? 200 : 401 };
     });
 
     try {
@@ -126,7 +139,7 @@ describe("WebhookDispatcher HMAC signing", () => {
         `v2=${hmac(canonicalSignedPayload(timestamp, deliveryId, "tx_signed", tamperedBody), SECRET)}`,
       );
       expect(signature).not.toBe(expectedSignature(request, "wrong-secret"));
-      return { status: signature === expectedSignature(request, SECRET) ? 200 : 401 };
+      return { status: requestVerifies(request, SECRET) ? 200 : 401 };
     });
 
     try {
@@ -155,7 +168,7 @@ describe("WebhookDispatcher HMAC signing", () => {
       expect(signature).not.toBe(
         `v2=${hmac(canonicalSignedPayload(tamperedSentAt, deliveryId, eventType, request.bodyText), SECRET)}`,
       );
-      return { status: signature === expectedSignature(request, SECRET) ? 200 : 401 };
+      return { status: requestVerifies(request, SECRET) ? 200 : 401 };
     });
 
     try {

--- a/packages/webhooks/src/__tests__/dispatcher-ssrf-literal.test.ts
+++ b/packages/webhooks/src/__tests__/dispatcher-ssrf-literal.test.ts
@@ -94,6 +94,50 @@ describe("WebhookDispatcher SSRF guard for IP-literal URLs", () => {
     }
   });
 
+  it("rejects IPv4-translated and special-use IPv6 literals (SEC-178)", async () => {
+    const dispatcher = new WebhookDispatcher({
+      maxRetries: 0,
+      retryDelayMs: 1,
+      timeoutMs: 500,
+      allowPrivateNetwork: false,
+      allowInsecureHttp: true,
+    });
+
+    for (const url of [
+      "http://[::ffff:0:7f00:1]/hook", // RFC 8215 translated, embeds 127.0.0.1
+      "http://[::ffff:0:a00:1]/hook", // translated, embeds 10.0.0.1
+      "http://[::ffff:0:ac10:1]/hook", // translated, embeds 172.16.0.1
+      "http://[::ffff:7f00:1]/hook", // IPv4-mapped hex form of 127.0.0.1
+      "http://[100::5]/hook", // 100::/64 discard-only (RFC 6666)
+      "http://[2001:2::1]/hook", // 2001:2::/48 benchmarking (RFC 5180)
+    ]) {
+      const result = await dispatcher.dispatch(makeEvent(), { url, secret: SECRET });
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("must resolve to a public address");
+    }
+  });
+
+  it("does not over-block adjacent public IPv6 prefixes", async () => {
+    const dispatcher = new WebhookDispatcher({
+      maxRetries: 0,
+      retryDelayMs: 1,
+      timeoutMs: 500,
+      allowPrivateNetwork: false,
+      allowInsecureHttp: true,
+    });
+
+    for (const url of [
+      "http://[100:1::]/hook", // outside 100::/64
+      "http://[2001:2:1::]/hook", // outside 2001:2::/48
+      "http://[::ffff:1:7f00:1]/hook", // words[5] !== 0: not the translated prefix
+    ]) {
+      const result = await dispatcher.dispatch(makeEvent(), { url, secret: SECRET });
+      expect(result.success).toBe(false);
+      // Rejected by the network failure path (no route), NOT by the SSRF guard.
+      expect(result.error ?? "").not.toContain("must resolve to a public address");
+    }
+  });
+
   it("still delivers to loopback when the private-network escape hatch is explicit", async () => {
     const server = await withLoopbackServer();
     const dispatcher = new WebhookDispatcher({

--- a/packages/webhooks/src/__tests__/secret-codec.test.ts
+++ b/packages/webhooks/src/__tests__/secret-codec.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { decryptWebhookSecret, encryptWebhookSecret } from "../secret-codec";
+
+/**
+ * SEC-102: the hardcoded dev key must require BOTH an explicit opt-in flag AND
+ * an explicit development NODE_ENV — an unset NODE_ENV must never fall through
+ * to a publicly-known key.
+ */
+describe("webhook secret-codec dev-key gate (SEC-102)", () => {
+  const ENV_KEYS = [
+    "NODE_ENV",
+    "STEWARD_WEBHOOK_SECRET_ENCRYPTION_KEY",
+    "STEWARD_MASTER_PASSWORD",
+    "STEWARD_ALLOW_DEV_SECRETS",
+    "STEWARD_ALLOW_DEV_SECRET",
+  ] as const;
+  let snapshot: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    snapshot = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
+    for (const key of ENV_KEYS) delete process.env[key];
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (snapshot[key] === undefined) delete process.env[key];
+      else process.env[key] = snapshot[key];
+    }
+  });
+
+  it("refuses the dev key when NODE_ENV is unset, even with the opt-in flag", () => {
+    process.env.STEWARD_ALLOW_DEV_SECRETS = "true";
+    expect(() => encryptWebhookSecret("tenant-secret")).toThrow(
+      /NODE_ENV is not an explicit development value/,
+    );
+  });
+
+  it("refuses the dev key for a non-development NODE_ENV, even with the opt-in flag", () => {
+    process.env.NODE_ENV = "staging";
+    process.env.STEWARD_ALLOW_DEV_SECRETS = "true";
+    expect(() => encryptWebhookSecret("tenant-secret")).toThrow(
+      /NODE_ENV is not an explicit development value/,
+    );
+  });
+
+  it("still refuses in production with the dedicated message", () => {
+    process.env.NODE_ENV = "production";
+    process.env.STEWARD_ALLOW_DEV_SECRETS = "true";
+    expect(() => encryptWebhookSecret("tenant-secret")).toThrow(
+      /STEWARD_WEBHOOK_SECRET_ENCRYPTION_KEY or STEWARD_MASTER_PASSWORD is required/,
+    );
+  });
+
+  it("still requires the opt-in flag in an explicit development environment", () => {
+    process.env.NODE_ENV = "development";
+    expect(() => encryptWebhookSecret("tenant-secret")).toThrow(/STEWARD_ALLOW_DEV_SECRETS=true/);
+  });
+
+  it("round-trips with the dev key only when explicitly opted into a development environment", () => {
+    process.env.NODE_ENV = "development";
+    process.env.STEWARD_ALLOW_DEV_SECRETS = "true";
+    const encrypted = encryptWebhookSecret("tenant-secret");
+    expect(decryptWebhookSecret(encrypted)).toBe("tenant-secret");
+  });
+
+  it("round-trips with the dev key under NODE_ENV=test (bun test default)", () => {
+    process.env.NODE_ENV = "test";
+    process.env.STEWARD_ALLOW_DEV_SECRETS = "true";
+    const encrypted = encryptWebhookSecret("tenant-secret");
+    expect(decryptWebhookSecret(encrypted)).toBe("tenant-secret");
+  });
+
+  it("prefers a configured master password regardless of NODE_ENV", () => {
+    process.env.STEWARD_MASTER_PASSWORD = "a-real-master-password-for-tests";
+    const encrypted = encryptWebhookSecret("tenant-secret");
+    expect(decryptWebhookSecret(encrypted)).toBe("tenant-secret");
+  });
+});

--- a/packages/webhooks/src/__tests__/verify.test.ts
+++ b/packages/webhooks/src/__tests__/verify.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "bun:test";
+import { createHmac } from "node:crypto";
+import { canonicalSignedPayload } from "../dispatcher";
+import { verifyWebhookSignature } from "../verify";
+
+const SECRET = "receiver-side-secret";
+
+function sign(input: {
+  sentAt: string;
+  deliveryId: string;
+  eventType: string;
+  body: string;
+  secret?: string;
+}): string {
+  const hex = createHmac("sha256", input.secret ?? SECRET)
+    .update(canonicalSignedPayload(input.sentAt, input.deliveryId, input.eventType, input.body))
+    .digest("hex");
+  return `v2=${hex}`;
+}
+
+const NOW = 1_800_000_000;
+const baseInput = {
+  body: '{"type":"tx_signed"}',
+  deliveryId: "delivery-123",
+  eventType: "tx_signed",
+  sentAt: String(NOW),
+  secret: SECRET,
+  nowSeconds: NOW,
+};
+
+describe("verifyWebhookSignature (SEC-177)", () => {
+  it("accepts a correctly signed delivery", () => {
+    const signature = sign(baseInput);
+    expect(verifyWebhookSignature({ ...baseInput, signature })).toBe(true);
+  });
+
+  it("rejects a tampered body, wrong secret, and re-split fields", () => {
+    const signature = sign(baseInput);
+    expect(verifyWebhookSignature({ ...baseInput, signature, body: '{"type":"tx_failed"}' })).toBe(
+      false,
+    );
+    expect(
+      verifyWebhookSignature({ ...baseInput, signature: sign({ ...baseInput, secret: "nope" }) }),
+    ).toBe(false);
+    // Field-boundary shift: same dotted string, different field split.
+    const shifted = sign({
+      sentAt: baseInput.sentAt,
+      deliveryId: "delivery-12",
+      eventType: "3tx_signed",
+      body: baseInput.body,
+    });
+    expect(verifyWebhookSignature({ ...baseInput, signature: shifted })).toBe(false);
+  });
+
+  it("rejects replays outside the freshness window", () => {
+    const stale = { ...baseInput, sentAt: String(NOW - 400) };
+    expect(verifyWebhookSignature({ ...stale, signature: sign(stale) })).toBe(false);
+    const future = { ...baseInput, sentAt: String(NOW + 400) };
+    expect(verifyWebhookSignature({ ...future, signature: sign(future) })).toBe(false);
+    const within = { ...baseInput, sentAt: String(NOW - 299) };
+    expect(verifyWebhookSignature({ ...within, signature: sign(within) })).toBe(true);
+  });
+
+  it("honours a custom tolerance", () => {
+    const skewed = { ...baseInput, sentAt: String(NOW - 60), toleranceSeconds: 30 };
+    expect(verifyWebhookSignature({ ...skewed, signature: sign(skewed) })).toBe(false);
+    expect(
+      verifyWebhookSignature({ ...skewed, toleranceSeconds: 120, signature: sign(skewed) }),
+    ).toBe(true);
+  });
+
+  it("fails closed on malformed headers", () => {
+    const signature = sign(baseInput);
+    expect(verifyWebhookSignature({ ...baseInput, signature: signature.slice(2) })).toBe(false);
+    expect(verifyWebhookSignature({ ...baseInput, signature: "v2=nothex" })).toBe(false);
+    expect(verifyWebhookSignature({ ...baseInput, signature: `v1=${signature.slice(3)}` })).toBe(
+      false,
+    );
+    expect(verifyWebhookSignature({ ...baseInput, signature, sentAt: "soon" })).toBe(false);
+    expect(verifyWebhookSignature({ ...baseInput, signature, deliveryId: "" })).toBe(false);
+    expect(verifyWebhookSignature({ ...baseInput, signature, eventType: "" })).toBe(false);
+    // Uppercase hex is not the emitted format; reject rather than coerce.
+    expect(verifyWebhookSignature({ ...baseInput, signature: signature.toUpperCase() })).toBe(
+      false,
+    );
+  });
+});

--- a/packages/webhooks/src/dispatcher.ts
+++ b/packages/webhooks/src/dispatcher.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHmac, randomUUID } from "node:crypto";
 import type { LookupAddress } from "node:dns";
 import type { RequestOptions } from "node:http";
 import { isIP, type LookupFunction } from "node:net";
@@ -354,20 +354,35 @@ async function postWebhook(
   });
 }
 
-function normalizeWebhook(webhook: WebhookConfig | string): WebhookConfig {
+/**
+ * SEC-101: the bare-URL (legacy) form carries no per-tenant secret, so the
+ * process-wide STEWARD_WEBHOOK_SECRET used to sign every tenant's legacy
+ * endpoint directly — one key compromise forged events for ALL of them. Derive
+ * a per-tenant signing key from the master secret instead: a captured derived
+ * key is scoped to a single tenant's legacy endpoint. (Receivers on this path
+ * were never provisioned a key, so verification there was never possible; the
+ * derivation bounds blast radius without changing the wire scheme.)
+ */
+function deriveLegacyWebhookSecret(masterSecret: string, tenantId: string): string {
+  return createHmac("sha256", masterSecret)
+    .update(`steward-legacy-webhook-secret:${tenantId}`)
+    .digest("hex");
+}
+
+function normalizeWebhook(webhook: WebhookConfig | string, tenantId: string): WebhookConfig {
   if (typeof webhook !== "string") {
     return webhook;
   }
 
-  const secret = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process
-    ?.env?.STEWARD_WEBHOOK_SECRET;
-  if (!secret) {
+  const masterSecret = (globalThis as { process?: { env?: Record<string, string | undefined> } })
+    .process?.env?.STEWARD_WEBHOOK_SECRET;
+  if (!masterSecret) {
     throw new Error(
       "Webhook secret is required. Pass a WebhookConfig or set STEWARD_WEBHOOK_SECRET.",
     );
   }
 
-  return { url: webhook, secret };
+  return { url: webhook, secret: deriveLegacyWebhookSecret(masterSecret, tenantId) };
 }
 
 export class WebhookDispatcher {
@@ -391,7 +406,7 @@ export class WebhookDispatcher {
     event: WebhookEvent,
     webhook: WebhookConfig | string,
   ): Promise<WebhookDeliveryResult> {
-    const config = normalizeWebhook(webhook);
+    const config = normalizeWebhook(webhook, event.tenantId);
 
     // An empty events array means "subscribe to all" everywhere else
     // (acceptsConfiguredWebhookEvent, persistent-queue) — a truthy [] must

--- a/packages/webhooks/src/dispatcher.ts
+++ b/packages/webhooks/src/dispatcher.ts
@@ -14,7 +14,8 @@ const SIGNATURE_SCHEME = "v2";
 // bodies contain '.', and a plain `.`-join would let an attacker re-split a
 // captured signature (e.g. eventType "a.b"+body "c" vs "a"+body "b.c") to forge
 // a colliding-but-valid message. body is last/unbounded so needs no prefix.
-function canonicalSignedPayload(
+// Exported so receivers (verifyWebhookSignature) sign the identical material.
+export function canonicalSignedPayload(
   timestamp: string,
   deliveryId: string,
   eventType: string,

--- a/packages/webhooks/src/dispatcher.ts
+++ b/packages/webhooks/src/dispatcher.ts
@@ -31,6 +31,9 @@ const ALLOW_PRIVATE_WEBHOOK_NETWORKS =
   (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env
     ?.STEWARD_ALLOW_PRIVATE_WEBHOOK_NETWORKS === "true";
 
+// Once-per-process latch for the SEC-102 escape-hatch warning below.
+let warnedPrivateWebhookNetworks = false;
+
 function toHex(buffer: ArrayBuffer): string {
   return Array.from(new Uint8Array(buffer), (byte) => byte.toString(16).padStart(2, "0")).join("");
 }
@@ -400,6 +403,16 @@ export class WebhookDispatcher {
     this.allowPrivateNetwork = options.allowPrivateNetwork ?? ALLOW_PRIVATE_WEBHOOK_NETWORKS;
     this.allowInsecureHttp = options.allowInsecureHttp ?? false;
     this.lookup = options.lookup;
+    // SEC-102: the SSRF escape hatch disables the private-network guard for
+    // every delivery this dispatcher makes (STEWARD_ALLOW_PRIVATE_WEBHOOK_NETWORKS
+    // does it process-wide at module load). Announce it loudly once per process
+    // instead of running unguarded in silence.
+    if (this.allowPrivateNetwork && !warnedPrivateWebhookNetworks) {
+      warnedPrivateWebhookNetworks = true;
+      console.warn(
+        "[steward] WARNING: webhook SSRF guard is DISABLED (allowPrivateNetwork / STEWARD_ALLOW_PRIVATE_WEBHOOK_NETWORKS=true). Loopback, link-local, and private-range webhook targets will be fetched. Use only for local development or trusted test harnesses.",
+      );
+    }
   }
 
   async dispatch(

--- a/packages/webhooks/src/dispatcher.ts
+++ b/packages/webhooks/src/dispatcher.ts
@@ -159,6 +159,19 @@ function embeddedIpv4FromIpv6(address: string): string | null {
     words[0] === 0x64 && words[1] === 0xff9b && words[2] === 1 && words[3] === 0;
   if (isNat64LocalUse) return fromWords(words[6], words[7]);
 
+  // RFC 8215 IPv4-translated ::ffff:0:0/96 — distinct from the IPv4-mapped form
+  // (handled by mappedIpv4FromIpv6, which has words[5] === 0xffff). The IPv4 is
+  // embedded in the low 32 bits and is reachable through NAT64/SIIT paths, so it
+  // must face the same non-public checks (SEC-178).
+  const isIpv4Translated =
+    words[0] === 0 &&
+    words[1] === 0 &&
+    words[2] === 0 &&
+    words[3] === 0 &&
+    words[4] === 0xffff &&
+    words[5] === 0;
+  if (isIpv4Translated) return fromWords(words[6], words[7]);
+
   if (words[0] === 0x2002) return fromWords(words[1], words[2]);
   return null;
 }
@@ -171,6 +184,11 @@ function isNonPublicIpv6(address: string): boolean {
   if (ipv4Embedded) return isNonPublicIpv4(ipv4Embedded);
   const words = expandIpv6Words(normalized);
   if (words?.[0] === 0x2001 && (words[1] === 0 || words[1] === 0xdb8)) return true;
+  // 2001:2::/48 benchmarking (RFC 5180) — documentation/special-use, never a
+  // public webhook target (SEC-178).
+  if (words?.[0] === 0x2001 && words[1] === 0x0002 && words[2] === 0) return true;
+  // 100::/64 discard-only (RFC 6666) (SEC-178).
+  if (words?.[0] === 0x0100 && words[1] === 0 && words[2] === 0 && words[3] === 0) return true;
   if (words?.[0] !== undefined && (words[0] & 0xffc0) === 0xfe80) return true;
   if (words?.[0] !== undefined && (words[0] & 0xffc0) === 0xfec0) return true;
   return (

--- a/packages/webhooks/src/dispatcher.ts
+++ b/packages/webhooks/src/dispatcher.ts
@@ -213,7 +213,7 @@ export class WebhookValidationError extends Error {
 }
 
 function assertPublicWebhookHostname(hostname: string): void {
-  if (!hostname) throw new Error("Webhook URL must include a host");
+  if (!hostname) throw new WebhookValidationError("Webhook URL must include a host");
   if (
     hostname === "localhost" ||
     hostname.endsWith(".localhost") ||
@@ -238,7 +238,7 @@ function assertPublicAddress(address: string, family?: number): void {
     (family === 6 && isNonPublicIpv6(address)) ||
     (family !== 4 && family !== 6 && (isNonPublicIpv4(address) || isNonPublicIpv6(address)))
   ) {
-    throw new Error("Webhook host must resolve to a public address");
+    throw new WebhookValidationError("Webhook host must resolve to a public address");
   }
 }
 
@@ -301,12 +301,18 @@ async function postWebhook(
     lookup?: LookupFunction;
   },
 ): Promise<{ status: number; ok: boolean }> {
-  const parsed = new URL(url);
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    // An unparseable URL can never succeed on retry (SEC-179).
+    throw new WebhookValidationError("Webhook URL is not a valid URL");
+  }
   if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
-    throw new Error("Webhook URL must use https");
+    throw new WebhookValidationError("Webhook URL must use https");
   }
   if (parsed.protocol === "http:" && !init.allowInsecureHttp) {
-    throw new Error("Webhook URL must use https");
+    throw new WebhookValidationError("Webhook URL must use https");
   }
 
   const transport =
@@ -517,7 +523,11 @@ export class WebhookDispatcher {
         }
       } catch (error) {
         lastError = error instanceof Error ? error.message : "Unknown webhook delivery error";
-        if (attempts > this.maxRetries) {
+        // SEC-179: a deterministic validation rejection (bad scheme, non-public
+        // host/address, unparseable URL) can never succeed on retry — stop
+        // immediately instead of burning maxRetries+1 attempts with backoff and
+        // repeated DNS lookups.
+        if (error instanceof WebhookValidationError || attempts > this.maxRetries) {
           break;
         }
       }

--- a/packages/webhooks/src/index.ts
+++ b/packages/webhooks/src/index.ts
@@ -1,4 +1,4 @@
-export { WebhookDispatcher } from "./dispatcher";
+export { WebhookDispatcher, WebhookValidationError } from "./dispatcher";
 export type {
   PersistentQueueOptions,
   PersistentQueueStats as PersistentStats,

--- a/packages/webhooks/src/index.ts
+++ b/packages/webhooks/src/index.ts
@@ -10,8 +10,6 @@ export {
   encryptWebhookSecret,
   isEncryptedWebhookSecret,
 } from "./secret-codec";
-export type { VerifyWebhookSignatureInput } from "./verify";
-export { verifyWebhookSignature } from "./verify";
 export type {
   QueuedWebhookDelivery,
   RetryQueueOptions,
@@ -20,3 +18,5 @@ export type {
   WebhookDeliveryResult,
   WebhookDispatcherOptions,
 } from "./types";
+export type { VerifyWebhookSignatureInput } from "./verify";
+export { verifyWebhookSignature } from "./verify";

--- a/packages/webhooks/src/index.ts
+++ b/packages/webhooks/src/index.ts
@@ -10,6 +10,8 @@ export {
   encryptWebhookSecret,
   isEncryptedWebhookSecret,
 } from "./secret-codec";
+export type { VerifyWebhookSignatureInput } from "./verify";
+export { verifyWebhookSignature } from "./verify";
 export type {
   QueuedWebhookDelivery,
   RetryQueueOptions,

--- a/packages/webhooks/src/secret-codec.ts
+++ b/packages/webhooks/src/secret-codec.ts
@@ -28,6 +28,16 @@ function rootKey(): Buffer {
         "STEWARD_WEBHOOK_SECRET_ENCRYPTION_KEY or STEWARD_MASTER_PASSWORD is required to encrypt webhook secrets",
       );
     }
+    // SEC-102: the insecure dev key is reachable ONLY when NODE_ENV is
+    // explicitly a development value. A deploy that simply forgot NODE_ENV must
+    // not fall through to a publicly-known key on the strength of an env flag.
+    if (currentEnv.NODE_ENV !== "development" && currentEnv.NODE_ENV !== "test") {
+      throw new Error(
+        `Refusing the insecure webhook dev key: NODE_ENV is not an explicit development value (${
+          currentEnv.NODE_ENV === undefined ? "unset" : JSON.stringify(currentEnv.NODE_ENV)
+        }). Set NODE_ENV=development for local development, or configure STEWARD_WEBHOOK_SECRET_ENCRYPTION_KEY / STEWARD_MASTER_PASSWORD.`,
+      );
+    }
     // The insecure dev fallback must be explicitly opted into; never in production.
     // Canonical var is STEWARD_ALLOW_DEV_SECRETS; singular accepted for back-compat.
     if (

--- a/packages/webhooks/src/verify.ts
+++ b/packages/webhooks/src/verify.ts
@@ -1,0 +1,66 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+import { canonicalSignedPayload } from "./dispatcher";
+
+/**
+ * Receiver-side input for {@link verifyWebhookSignature}: the Steward delivery
+ * headers plus the raw request body, exactly as received.
+ */
+export interface VerifyWebhookSignatureInput {
+  /** Raw, unparsed request body (the exact bytes Steward signed). */
+  body: string;
+  /** `X-Steward-Delivery-Id` header. */
+  deliveryId: string;
+  /** `X-Steward-Event` header. */
+  eventType: string;
+  /** `X-Steward-Sent-At` header (unix seconds). */
+  sentAt: string;
+  /** `X-Steward-Signature` header (`v2=<hex>`). */
+  signature: string;
+  /** The webhook's signing secret. */
+  secret: string;
+  /** Maximum sender/receiver clock skew in seconds. Default 300 (5 minutes). */
+  toleranceSeconds?: number;
+  /** Current time in unix seconds (injectable for tests). */
+  nowSeconds?: number;
+}
+
+/**
+ * Receiver-side verification for Steward's v2 webhook signature scheme
+ * (SEC-177).
+ *
+ * Recomputes HMAC-SHA256 over the canonical signed payload (scheme version,
+ * freshness timestamp, length-prefixed deliveryId + eventType, raw body) and
+ * compares with `crypto.timingSafeEqual` — NEVER `===`, which leaks prefix
+ * length through timing. Also enforces a freshness window on
+ * `X-Steward-Sent-At` so a captured signature cannot be replayed outside the
+ * tolerance.
+ *
+ * Fails closed: returns false on any malformed input; never throws.
+ */
+export function verifyWebhookSignature(input: VerifyWebhookSignatureInput): boolean {
+  try {
+    const tolerance = input.toleranceSeconds ?? 300;
+    const now = input.nowSeconds ?? Math.floor(Date.now() / 1000);
+
+    const sentAtSeconds = Number(input.sentAt);
+    if (!Number.isFinite(sentAtSeconds)) return false;
+    if (Math.abs(now - sentAtSeconds) > tolerance) return false;
+
+    // The signed material is only meaningful with real field values; an empty
+    // delivery id or event type would verify an attacker-shaped payload.
+    if (!input.deliveryId || !input.eventType) return false;
+
+    if (!input.signature.startsWith("v2=")) return false;
+    const providedHex = input.signature.slice(3);
+    if (!/^[0-9a-f]{64}$/.test(providedHex)) return false;
+
+    const expected = createHmac("sha256", input.secret)
+      .update(canonicalSignedPayload(input.sentAt, input.deliveryId, input.eventType, input.body))
+      .digest();
+    const provided = Buffer.from(providedHex, "hex");
+    return expected.length === provided.length && timingSafeEqual(expected, provided);
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

Deferred LOW/INFO remainder of the security audit for the **webhooks** and **policy-engine** packages, building on the wave-2 HIGH/MEDIUM merges. All fixes fail closed; no fail-open direction was introduced anywhere.

| SEC ID | Severity | Status | Commit(s) |
|---|---|---|---|
| SEC-101 | LOW | FIXED | d8f88a99 — per-tenant derived signing key for legacy string-URL webhooks (HKDF-derives from STEWARD_WEBHOOK_SECRET + tenantId so one tenant's key no longer signs for all) |
| SEC-102 | LOW | FIXED | 8508783a — dev key only when NODE_ENV is explicitly development/test; loud startup warning when the private-network SSRF escape hatch is on |
| SEC-104 | LOW | FIXED | 6cc77056 — empty-policy-set deny and evaluator-throw paths now emit policy.evaluated NACK events; hook failures counted on engine.auditHookFailures + logged instead of silently swallowed |
| SEC-105 | LOW | FIXED | 56c58eae — time-window / allowed-chains / approved-addresses return structured denies on non-array config; reputation-scaling validates wei strings and treats non-finite scores as 0 (no more BigInt(NaN) throw → 500) |
| SEC-106 | LOW | FIXED | 23028eaa — named-window lookup is hasOwn-guarded and requires a finite number ("__proto__" no longer resolves to Object.prototype) |
| SEC-107 | LOW | FIXED | f855785f — argMatches (both planes) + X blockedPatterns capped at 256 chars (parse-time config error + runtime fail-closed guards); matched inputs capped at 8192 chars, over-cap denies |
| SEC-177 | INFO | FIXED | def847fe — new verifyWebhookSignature helper (timingSafeEqual + timestamp tolerance); tests no longer model === comparison |
| SEC-178 | INFO | FIXED | 1d5b10b0 — SSRF guard covers RFC 8215 IPv4-translated ::ffff:0:0/96 plus discard/documentation ranges (100::/64, 2001:2::/48) |
| SEC-179 | INFO | FIXED | bec6c24d — deterministic validation rejections (bad scheme, non-public host, unparseable URL) classified non-retryable via WebhookValidationError |
| SEC-180 | INFO | FIXED | 88394348 — time-window with both allowedHours and allowedDays empty now denies (evaluator) and is rejected at write time (validator); one empty dimension still means unconstrained on that dimension |
| SEC-181 | INFO | FIXED | ecfc2be1 — composeProviderActionPolicyDecision + generic evaluateCapabilityIntent now scope malformed-config precedence to governing rules via recoverSelectorMatch, matching the legacy composer |
| SEC-182 | INFO | PARTIAL/DECISION | ee2b36de — typed ctx.x fields (isReply/summoned/hasUrl/textCodePointLength) added and preferred by evaluateXConstraints; provider-action-service populates them from the adapter's validated policyArgs. The args-bag read remains as a legacy fallback with the same fail-closed contract — removing it outright is a breaking change for third-party adapters, deferred |
| SEC-183 | INFO | PARTIAL/DECISION | 106e972a — documented loudly (evaluator comment, ContractAllowlistConfig doc, explicit pass reason surfaced in audit trail). Flipping the native-transfer pass to a deny would silently break existing tenants relying on the documented behavior — gating native transfers is a product decision, deferred |

## Trade-offs / decisions

- **SEC-107**: length caps (256-pattern / 8192-input) rather than a safe-regex engine — no new dependency; a RE2-class engine is a follow-up packaging decision.
- **SEC-182**: typed-channel preference with legacy fallback, not a hard cutover (breaking change). The engine still cannot cryptographically prove signal provenance; that needs adapter attestation, out of scope for INFO.
- **SEC-183**: documentation-only hardening per rule 4; behavior unchanged by design.
- **SEC-181**: the provider composer drops a malformed rule provably scoped elsewhere entirely (no result row), matching legacy-plane semantics byte-for-byte.

## How tested

- bun test packages/policy-engine → 453 pass / 0 fail (14 files)
- bun test packages/webhooks → 51 pass / 0 fail (9 files)
- bun test packages/api/src/__tests__/{policy-validation,provider-action-service,provider-x-permissioned-e2e}.test.ts → 43 pass / 0 fail
- bunx tsc --noEmit → clean in policy-engine, webhooks, api, shared
- bunx biome check → clean on all 26 changed files
- New regression tests per finding (retry classification, audit-on-deny, malformed-config denies, prototype-key windows, ReDoS caps, empty-window deny, composer scoping, typed-channel precedence)

## Pre-existing failure (NOT caused by this branch)

packages/api/src/__tests__/provider-x-governed-e2e.test.ts › "x.tweet.create: propose -> policy -> approval_required -> approve -> resume" fails on this branch AND with every file this PR touches reverted to origin/develop (fails in isolation too). Left untouched; flagging for the owner batch.