### PR TITLE
fix(security): wave-2b trading batch — deferred LOW/INFO + SEC-043 durable idempotency

### DIFF
--- a/packages/agent-trader/src/__tests__/config.test.ts
+++ b/packages/agent-trader/src/__tests__/config.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadConfig } from "../config.js";
+
+/**
+ * SEC-188: a config file that EXISTS but does not parse must fail fast instead
+ * of silently starting on defaults (apiKey "", localhost API). A MISSING file
+ * stays supported (env-only configuration).
+ */
+
+const TOUCHED_ENV = [
+  "CONFIG_PATH",
+  "STEWARD_AGENT_TRADER_ALLOW_UNSIGNED_WEBHOOKS",
+  "STEWARD_API_URL",
+  "STEWARD_TENANT_ID",
+  "STEWARD_API_KEY",
+  "WEBHOOK_PORT",
+  "DRY_RUN",
+] as const;
+
+let savedEnv: Record<string, string | undefined>;
+let dir: string;
+
+beforeEach(() => {
+  savedEnv = Object.fromEntries(TOUCHED_ENV.map((k) => [k, process.env[k]]));
+  for (const k of TOUCHED_ENV) delete process.env[k];
+  dir = mkdtempSync(join(tmpdir(), "agent-trader-config-test-"));
+});
+
+afterEach(() => {
+  for (const k of TOUCHED_ENV) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("loadConfig (SEC-188)", () => {
+  it("throws when the config file exists but does not parse", () => {
+    const path = join(dir, "agent-trader.config.json");
+    writeFileSync(path, "{ not json !!");
+    process.env.CONFIG_PATH = path;
+
+    expect(() => loadConfig()).toThrow(/exists but could not be parsed/);
+  });
+
+  it("still supports a missing config file (env-only configuration)", () => {
+    process.env.CONFIG_PATH = join(dir, "does-not-exist.json");
+    process.env.STEWARD_AGENT_TRADER_ALLOW_UNSIGNED_WEBHOOKS = "true";
+
+    const config = loadConfig();
+    expect(config.agents).toEqual([]);
+    expect(config.steward.apiUrl).toBe("http://localhost:3000");
+  });
+
+  it("loads a valid config file", () => {
+    const path = join(dir, "agent-trader.config.json");
+    writeFileSync(path, JSON.stringify({ webhookSecret: "s", agents: [], dryRun: true }));
+    process.env.CONFIG_PATH = path;
+
+    const config = loadConfig();
+    expect(config.webhookSecret).toBe("s");
+    expect(config.dryRun).toBe(true);
+  });
+});

--- a/packages/agent-trader/src/__tests__/logger-redaction.test.ts
+++ b/packages/agent-trader/src/__tests__/logger-redaction.test.ts
@@ -1,0 +1,68 @@
+/**
+ * SEC-110 regression coverage: webhook log redaction must recurse into
+ * ARRAYS, not just plain objects — batch-shaped payloads (e.g.
+ * `items: [{ apiKey: ... }]`) previously logged secrets in the clear.
+ */
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import { logWebhook } from "../logger";
+
+let writeSpy: ReturnType<typeof spyOn> | undefined;
+let lines: string[];
+
+beforeEach(() => {
+  lines = [];
+  writeSpy = spyOn(process.stdout, "write").mockImplementation(((chunk: unknown) => {
+    lines.push(String(chunk));
+    return true;
+  }) as never);
+});
+
+afterEach(() => {
+  writeSpy?.mockRestore();
+  writeSpy = undefined;
+});
+
+function loggedData(): Record<string, unknown> {
+  expect(lines).toHaveLength(1);
+  return (JSON.parse(lines[0] as string) as { data: Record<string, unknown> }).data;
+}
+
+describe("logWebhook redaction (SEC-110)", () => {
+  it("redacts sensitive fields nested inside arrays", () => {
+    logWebhook({
+      event: "test.event",
+      data: {
+        items: [{ apiKey: "array-secret-value", note: "keep-me" }],
+        deeply: { nested: [{ private_key: "0xdeadbeef", ok: 1 }] },
+      },
+    });
+    const data = loggedData();
+    const items = data.items as Array<Record<string, unknown>>;
+    expect(items[0]?.apiKey).toBe("[redacted]");
+    expect(items[0]?.note).toBe("keep-me");
+    const deeply = data.deeply as { nested: Array<Record<string, unknown>> };
+    expect(deeply.nested[0]?.private_key).toBe("[redacted]");
+    expect(deeply.nested[0]?.ok).toBe(1);
+    expect(lines[0]).not.toContain("array-secret-value");
+    expect(lines[0]).not.toContain("0xdeadbeef");
+  });
+
+  it("keeps prior behavior: object-nested redaction, primitives and arrays of primitives untouched", () => {
+    logWebhook({
+      event: "test.event",
+      data: {
+        token: "object-secret-value",
+        nested: { authorization: "Bearer xyz", fine: true },
+        plain: [1, "two", null],
+        txHash: "0xabc123",
+      },
+    });
+    const data = loggedData();
+    expect(data.token).toBe("[redacted]");
+    expect((data.nested as Record<string, unknown>).authorization).toBe("[redacted]");
+    expect((data.nested as Record<string, unknown>).fine).toBe(true);
+    expect(data.plain).toEqual([1, "two", null]);
+    expect(data.txHash).toBe("0xabc123");
+    expect(lines[0]).not.toContain("object-secret-value");
+  });
+});

--- a/packages/agent-trader/src/__tests__/loop-wallet-cache.test.ts
+++ b/packages/agent-trader/src/__tests__/loop-wallet-cache.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import type { StewardClient } from "@stwd/sdk";
+import type { AgentTraderConfig, TraderConfig } from "../config.js";
+import { clearWalletCacheForTest, runTick, setWalletCacheTtlForTest } from "../loop.js";
+import type { AgentState, Strategy } from "../strategies/types.js";
+
+/**
+ * SEC-188: the agentId → walletAddress cache must REFRESH — a wallet rotation
+ * has to be picked up after the TTL instead of trading against a stale address
+ * forever.
+ */
+
+const WALLET_A = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const WALLET_B = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const TOKEN = "0x1111111111111111111111111111111111111111";
+const PORTAL = "0x2222222222222222222222222222222222222222";
+
+const agentConfig: AgentTraderConfig = {
+  agentId: "agent-wallet-rotation",
+  tokenAddress: TOKEN,
+  strategy: "threshold",
+  intervalSeconds: 60,
+  enabled: true,
+  chainId: 8453,
+  portalAddress: PORTAL,
+  slippageBps: 100,
+  params: {},
+};
+
+const globalConfig: TraderConfig = {
+  steward: { apiUrl: "http://localhost", tenantId: "t", apiKey: "k" },
+  webhookPort: 4210,
+  webhookSecret: "s",
+  dryRun: false,
+  agents: [agentConfig],
+};
+
+const holdStrategy: Strategy = {
+  name: "hold-test",
+  requiresPriceConfidence: false,
+  evaluate: async () => ({ action: "hold", amount: "0", reason: "hold", confidence: 1 }),
+};
+
+const state: AgentState = {
+  nativeBalance: 10n ** 19n,
+  tokenBalance: 10n ** 21n,
+  tokenPrice: 10n ** 15n,
+  priceConfidence: "high",
+  lastTradeAge: 100_000,
+  dailyVolume: 0n,
+  treasuryValue: 10n ** 19n,
+};
+
+/** Steward fake that serves wallets[current] and counts getAgent calls. */
+function rotatingSteward(wallets: string[]) {
+  const fake = { calls: 0 };
+  const steward = {
+    getAgent: async () => ({ walletAddress: wallets[Math.min(fake.calls++, wallets.length - 1)] }),
+    getHistory: async () => [],
+  } as unknown as StewardClient;
+  return { steward, fake };
+}
+
+afterEach(() => {
+  clearWalletCacheForTest();
+});
+
+describe("runTick — wallet cache refresh (SEC-188)", () => {
+  it("reuses the cached wallet within the TTL (one getAgent call)", async () => {
+    clearWalletCacheForTest();
+    const { steward, fake } = rotatingSteward([WALLET_A, WALLET_B]);
+    const seen: string[] = [];
+    const deps = {
+      fetchState: async (_c: AgentTraderConfig, walletAddress: string) => {
+        seen.push(walletAddress);
+        return state;
+      },
+    };
+
+    await runTick(agentConfig, holdStrategy, steward, globalConfig, deps);
+    await runTick(agentConfig, holdStrategy, steward, globalConfig, deps);
+
+    expect(seen).toEqual([WALLET_A, WALLET_A]);
+    expect(fake.calls).toBe(1);
+  });
+
+  it("picks up a wallet rotation after the cache entry expires", async () => {
+    clearWalletCacheForTest();
+    setWalletCacheTtlForTest(0); // every entry expires immediately
+    const { steward, fake } = rotatingSteward([WALLET_A, WALLET_B]);
+    const seen: string[] = [];
+    const deps = {
+      fetchState: async (_c: AgentTraderConfig, walletAddress: string) => {
+        seen.push(walletAddress);
+        return state;
+      },
+    };
+
+    await runTick(agentConfig, holdStrategy, steward, globalConfig, deps);
+    await runTick(agentConfig, holdStrategy, steward, globalConfig, deps);
+
+    expect(seen).toEqual([WALLET_A, WALLET_B]); // rotation picked up, not stale
+    expect(fake.calls).toBe(2);
+  });
+});

--- a/packages/agent-trader/src/config.ts
+++ b/packages/agent-trader/src/config.ts
@@ -89,11 +89,26 @@ function allowUnsignedWebhooks(): boolean {
 // ─── Loader ──────────────────────────────────────────────────────────────────
 
 function loadJsonConfig(path: string): Partial<TraderConfig> {
+  let raw: string;
   try {
-    const raw = readFileSync(path, "utf-8");
+    raw = readFileSync(path, "utf-8");
+  } catch (err) {
+    // A MISSING config file is fine (env-only configuration); any other read
+    // failure is not.
+    if ((err as NodeJS.ErrnoException | null)?.code === "ENOENT") return {};
+    throw err;
+  }
+  try {
     return JSON.parse(raw) as Partial<TraderConfig>;
-  } catch {
-    return {};
+  } catch (err) {
+    // SEC-188: a config file that exists but does not parse must fail fast.
+    // Silently starting on defaults (apiKey "", localhost API) masks operator
+    // error and points the trader at the wrong backend.
+    throw new Error(
+      `agent-trader config at ${path} exists but could not be parsed: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
   }
 }
 

--- a/packages/agent-trader/src/logger.ts
+++ b/packages/agent-trader/src/logger.ts
@@ -78,16 +78,25 @@ const SENSITIVE_WEBHOOK_FIELDS = [
   "signature",
 ];
 
+function redactWebhookValue(value: unknown): unknown {
+  // SEC-110: recurse into arrays too — batch-shaped payloads carry objects
+  // inside arrays (e.g. `items: [{ apiKey: ... }]`) and must get the same
+  // redaction as object-nested values.
+  if (Array.isArray(value)) return value.map(redactWebhookValue);
+  if (value && typeof value === "object") {
+    return redactWebhookData(value as Record<string, unknown>);
+  }
+  return value;
+}
+
 function redactWebhookData(data: Record<string, unknown>): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(data)) {
     const normalized = key.toLowerCase().replace(/[_-]/g, "");
     if (SENSITIVE_WEBHOOK_FIELDS.some((f) => normalized.includes(f))) {
       out[key] = "[redacted]";
-    } else if (value && typeof value === "object" && !Array.isArray(value)) {
-      out[key] = redactWebhookData(value as Record<string, unknown>);
     } else {
-      out[key] = value;
+      out[key] = redactWebhookValue(value);
     }
   }
   return out;

--- a/packages/agent-trader/src/loop.ts
+++ b/packages/agent-trader/src/loop.ts
@@ -29,15 +29,34 @@ export interface AgentLoop {
 
 // ─── Agent wallet cache ────────────────────────────────────────────────────────
 
-const walletCache = new Map<string, string>(); // agentId → walletAddress
+// SEC-188: cache entries expire so a wallet rotation is picked up on a later
+// tick instead of trading against a stale address forever. The map is keyed by
+// agentId, so its size is bounded by the configured agent set.
+const WALLET_CACHE_TTL_MS = 5 * 60 * 1000;
+let walletCacheTtlMs = WALLET_CACHE_TTL_MS;
+const walletCache = new Map<string, { address: string; expiresAt: number }>(); // agentId → wallet
+
+/** Test-only: clear the wallet cache + restore the default TTL. */
+export function clearWalletCacheForTest(): void {
+  walletCache.clear();
+  walletCacheTtlMs = WALLET_CACHE_TTL_MS;
+}
+
+/** Test-only: override the wallet-cache TTL (SEC-188 expiry regression tests). */
+export function setWalletCacheTtlForTest(ttlMs: number): void {
+  walletCacheTtlMs = ttlMs;
+}
 
 async function resolveWallet(steward: StewardClient, agentId: string): Promise<string | null> {
   const cachedWallet = walletCache.get(agentId);
-  if (cachedWallet) return cachedWallet;
+  if (cachedWallet && cachedWallet.expiresAt > Date.now()) return cachedWallet.address;
 
   try {
     const agent = await steward.getAgent(agentId);
-    walletCache.set(agentId, agent.walletAddress);
+    walletCache.set(agentId, {
+      address: agent.walletAddress,
+      expiresAt: Date.now() + walletCacheTtlMs,
+    });
     return agent.walletAddress;
   } catch (err) {
     logError("Could not resolve agent wallet address", err, { agentId });

--- a/packages/plugin-trading/src/__tests__/agent-token-expiry-monitoring.test.ts
+++ b/packages/plugin-trading/src/__tests__/agent-token-expiry-monitoring.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
-import { generateApiKey } from "@stwd/auth";
+import { generateApiKey, signAgentToken } from "@stwd/auth";
 import { closeDb, getDb, tenants } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { Hono } from "hono";
@@ -8,6 +8,8 @@ import { exportJWK, generateKeyPair, SignJWT } from "jose";
 const TENANT_ID = "test-agent-token-expiry";
 const TENANT_NO_KEY_ID = "test-agent-token-expiry-no-key";
 const AGENT_ID = "test-token-watch-agent";
+const OTHER_TENANT_ID = "test-agent-token-expiry-other";
+const FOREIGN_AGENT_ID = "test-token-watch-foreign";
 const KID = "test-agent-token-kid";
 
 const auditEvents: Array<{ action: string; metadata?: Record<string, unknown>; actorId?: string }> =
@@ -43,6 +45,9 @@ beforeAll(async () => {
   process.env.STEWARD_PGLITE_MEMORY = "true";
   process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
   process.env.STEWARD_MASTER_PASSWORD ??= "test-master-password";
+  // Platform agent-token signing (SEC-091 test): tenantAuth verifies Bearer
+  // tokens with the canonical JWT secret, so configure one explicitly.
+  process.env.STEWARD_JWT_SECRET ??= "test-jwt-secret-32-chars-minimum!!!!";
 
   const { db, client } = await createPGLiteDb("memory://");
   setPGLiteOverride(db, async () => {
@@ -87,12 +92,22 @@ beforeAll(async () => {
         name: "Agent Token Expiry No Key Tenant",
         apiKeyHash: "",
       },
+      {
+        id: OTHER_TENANT_ID,
+        name: "Agent Token Expiry Other Tenant",
+        // api_key_hash has a unique index; a second "" row would be silently
+        // dropped by onConflictDoNothing and break the agents FK below.
+        apiKeyHash: "not-a-real-key-hash-other-tenant",
+      },
     ])
     .onConflictDoNothing();
 
   // PR #79 hardening: requireAgentJwt rejects tokens for agents that are not
   // registered for the tenant, so provision the agent (and its signing key).
   await contextModule.vault.createAgent(TENANT_ID, AGENT_ID, "Token Watch Agent");
+  // SEC-091: a second tenant with its own agent, used to prove the token-status
+  // route no longer leaks cross-tenant agent/token state.
+  await contextModule.vault.createAgent(OTHER_TENANT_ID, FOREIGN_AGENT_ID, "Foreign Token Watch");
 });
 
 afterAll(async () => {
@@ -116,6 +131,23 @@ async function signTradeToken(expiresAt: number): Promise<string> {
   })
     .setProtectedHeader({ alg: "RS256", typ: "JWT", kid: KID })
     .setSubject(`agent:${AGENT_ID}`)
+    .setIssuer("eliza-cloud")
+    .setAudience("steward")
+    .setIssuedAt(now - 10)
+    .setNotBefore(now - 10)
+    .setExpirationTime(expiresAt)
+    .sign(privateKey);
+}
+
+async function signForeignTradeToken(expiresAt: number): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  return new SignJWT({
+    agent_id: FOREIGN_AGENT_ID,
+    tenant_id: OTHER_TENANT_ID,
+    scopes: ["trade:order"],
+  })
+    .setProtectedHeader({ alg: "RS256", typ: "JWT", kid: KID })
+    .setSubject(`agent:${FOREIGN_AGENT_ID}`)
     .setIssuer("eliza-cloud")
     .setAudience("steward")
     .setIssuedAt(now - 10)
@@ -233,5 +265,66 @@ describe("agent trade token expiry monitoring", () => {
     expect(observedBody.data.agentId).toBe(AGENT_ID);
     expect(observedBody.data.exp).toBe(exp);
     expect(observedBody.data.expiresInSeconds).toBeGreaterThan(0);
+  });
+
+  it("SEC-091: reports a foreign tenant's agent as unknown even when its token was observed", async () => {
+    // Observe the foreign agent's token through the order endpoint (records
+    // global agent-token status), then query it with THIS tenant's api key.
+    const exp = Math.floor(Date.now() / 1000) + 600;
+    const foreignToken = await signForeignTradeToken(exp);
+    const agentJwtApp = buildAgentJwtApp();
+    const observedWrite = await agentJwtApp.request("/v1/trade/hyperliquid/order", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${foreignToken}`,
+        "X-Steward-Tenant": OTHER_TENANT_ID,
+      },
+    });
+    expect(observedWrite.status).toBe(200);
+
+    const app = buildTokenStatusApp();
+    const crossTenant = await app.request(
+      `/v1/trade/token-status?agentId=${encodeURIComponent(FOREIGN_AGENT_ID)}`,
+      {
+        headers: {
+          "X-Steward-Tenant": TENANT_ID,
+          "X-Steward-Key": apiKey,
+        },
+      },
+    );
+    expect(crossTenant.status).toBe(200);
+    const crossTenantBody = (await crossTenant.json()) as {
+      data: { status: string; exp: number | null };
+    };
+    // A foreign tenant's agent is indistinguishable from a nonexistent one.
+    expect(crossTenantBody.data.status).toBe("unknown");
+    expect(crossTenantBody.data.exp).toBeNull();
+  });
+
+  it("SEC-091: forbids an agent-scoped token from querying another agent's token status", async () => {
+    const token = await signAgentToken({ agentId: AGENT_ID, tenantId: TENANT_ID });
+    const app = buildTokenStatusApp();
+
+    const other = await app.request("/v1/trade/token-status?agentId=some-other-agent", {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "X-Steward-Tenant": TENANT_ID,
+      },
+    });
+    expect(other.status).toBe(403);
+
+    const self = await app.request(
+      `/v1/trade/token-status?agentId=${encodeURIComponent(AGENT_ID)}`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "X-Steward-Tenant": TENANT_ID,
+        },
+      },
+    );
+    expect(self.status).toBe(200);
+    const selfBody = (await self.json()) as { data: { status: string } };
+    // Status store is cleared in beforeEach; self-query returns the unknown shape.
+    expect(selfBody.data.status).toBe("unknown");
   });
 });

--- a/packages/plugin-trading/src/__tests__/evm-swap-prepare.test.ts
+++ b/packages/plugin-trading/src/__tests__/evm-swap-prepare.test.ts
@@ -386,6 +386,17 @@ describe("governed EVM swap prepare", () => {
     expect(smuggled.status).toBe(400);
   });
 
+  it("SEC-185: rejects slippageBps at or above the 5000 bps doctrine", async () => {
+    const { app } = await buildApp({ simulator: { ok: true } });
+    for (const slippageBps of [5_000, 10_000]) {
+      const res = await postPrepare(app, { ...requestBody(), slippageBps });
+      expect(res.status).toBe(400);
+    }
+    // The doctrine boundary is exclusive; the highest sane value still passes.
+    const ok = await postPrepare(app, { ...requestBody(), slippageBps: 4_999 });
+    expect(ok.status).toBe(200);
+  });
+
   it("denies chain, target, selector, and native value outside EVM policy", async () => {
     const cases: Array<[string, Partial<FakeSwapAdapter>, Parameters<typeof seedPolicy>[0]]> = [
       ["chain", {}, { chainId: 1 }],

--- a/packages/plugin-trading/src/__tests__/idempotency-store.test.ts
+++ b/packages/plugin-trading/src/__tests__/idempotency-store.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "bun:test";
+import type { IoredisLike } from "@stwd/redis";
+import { DurableIdempotencyStore } from "../routes/idempotency";
+
+/**
+ * SEC-043: trade/operator idempotency records must be DURABLE — backed by
+ * Redis when a client is available so a restart or a second replica still
+ * dedups a retried withdraw/order — with the bounded in-memory map as the
+ * dev/single-replica fallback.
+ */
+
+type TestRecord = { status: number; body: unknown };
+
+/** Minimal in-memory IoredisLike double (records raw set args for assertions). */
+function fakeRedis() {
+  const data = new Map<string, string>();
+  const setCalls: Array<{ key: string; ttlMs?: number }> = [];
+  const client = {
+    get: async (key: string) => data.get(key) ?? null,
+    set: async (...args: unknown[]) => {
+      const key = args[0] as string;
+      const value = args[1] as string;
+      const mode = args[2] as string | undefined;
+      const ttlMs = mode === "PX" ? (args[3] as number) : undefined;
+      setCalls.push({ key, ttlMs });
+      data.set(key, value);
+      return "OK";
+    },
+  } as unknown as IoredisLike;
+  return { client, data, setCalls };
+}
+
+describe("DurableIdempotencyStore (SEC-043)", () => {
+  it("replays a stored outcome across store instances sharing Redis (restart / second replica)", async () => {
+    const { client } = fakeRedis();
+    const replicaA = new DurableIdempotencyStore<TestRecord>({
+      namespace: "trade:operator",
+      getRedisClient: () => client,
+    });
+    const first = await replicaA.check("tenant:withdraw", "key-1", "hash-1");
+    expect(first.record).toBeUndefined();
+    expect(first.conflict).toBeUndefined();
+    await first.store?.({ status: 200, body: { ok: true, data: { moved: true } } });
+
+    // A fresh instance = a restarted process or a second replica. Its memory
+    // map is empty; the replay must come from the durable record.
+    const replicaB = new DurableIdempotencyStore<TestRecord>({
+      namespace: "trade:operator",
+      getRedisClient: () => client,
+    });
+    const replay = await replicaB.check("tenant:withdraw", "key-1", "hash-1");
+    expect(replay.record).toEqual({ status: 200, body: { ok: true, data: { moved: true } } });
+    expect(replay.store).toBeUndefined();
+  });
+
+  it("flags a same-key/different-body reuse as a conflict (via Redis)", async () => {
+    const { client } = fakeRedis();
+    const store = new DurableIdempotencyStore<TestRecord>({
+      namespace: "trade",
+      getRedisClient: () => client,
+    });
+    const first = await store.check("scope", "key-1", "hash-1");
+    await first.store?.({ status: 502, body: { ok: false } });
+
+    const conflict = await store.check("scope", "key-1", "hash-DIFFERENT");
+    expect(conflict.conflict).toBe(true);
+    expect(conflict.record).toBeUndefined();
+    expect(conflict.store).toBeUndefined();
+  });
+
+  it("stores with the 24h TTL via PX", async () => {
+    const { client, setCalls } = fakeRedis();
+    const store = new DurableIdempotencyStore<TestRecord>({
+      namespace: "trade",
+      getRedisClient: () => client,
+    });
+    const check = await store.check("scope", "key-1", "hash-1");
+    await check.store?.({ status: 200, body: { ok: true } });
+    expect(setCalls).toHaveLength(1);
+    expect(setCalls[0]?.ttlMs).toBe(24 * 60 * 60 * 1000);
+  });
+
+  it("fails CLOSED when the Redis check errors (never executes without the dedup record)", async () => {
+    const broken = {
+      get: async () => {
+        throw new Error("redis down");
+      },
+      set: async () => "OK",
+    } as unknown as IoredisLike;
+    const store = new DurableIdempotencyStore<TestRecord>({
+      namespace: "trade",
+      getRedisClient: () => broken,
+    });
+    await expect(store.check("scope", "key-1", "hash-1")).rejects.toThrow("redis down");
+  });
+
+  it("swallows a Redis store error (the movement already executed; caller gets the real outcome)", async () => {
+    const broken = {
+      get: async () => null,
+      set: async () => {
+        throw new Error("redis down");
+      },
+    } as unknown as IoredisLike;
+    const store = new DurableIdempotencyStore<TestRecord>({
+      namespace: "trade",
+      getRedisClient: () => broken,
+    });
+    const check = await store.check("scope", "key-1", "hash-1");
+    await expect(check.store?.({ status: 200, body: {} })).resolves.toBeUndefined();
+  });
+
+  it("falls back to bounded process-local memory without Redis (replay in-process only)", async () => {
+    const noRedis = () => null;
+    const storeA = new DurableIdempotencyStore<TestRecord>({
+      namespace: "trade",
+      getRedisClient: noRedis,
+    });
+    const first = await storeA.check("scope", "key-1", "hash-1");
+    await first.store?.({ status: 200, body: { ok: true } });
+
+    // Same process: replay works.
+    const replay = await storeA.check("scope", "key-1", "hash-1");
+    expect(replay.record).toEqual({ status: 200, body: { ok: true } });
+
+    // A fresh instance (restart) does NOT see it — the documented fallback
+    // limitation that Redis closes in production.
+    const storeB = new DurableIdempotencyStore<TestRecord>({
+      namespace: "trade",
+      getRedisClient: noRedis,
+    });
+    const missed = await storeB.check("scope", "key-1", "hash-1");
+    expect(missed.record).toBeUndefined();
+  });
+
+  it("no key -> no dedup (unchanged wave-2 semantics)", async () => {
+    const { client } = fakeRedis();
+    const store = new DurableIdempotencyStore<TestRecord>({
+      namespace: "trade",
+      getRedisClient: () => client,
+    });
+    expect(await store.check("scope", undefined, "hash-1")).toEqual({});
+  });
+});

--- a/packages/plugin-trading/src/__tests__/trade-policy-audit.test.ts
+++ b/packages/plugin-trading/src/__tests__/trade-policy-audit.test.ts
@@ -275,6 +275,170 @@ describe("trade policy audit", () => {
     });
   });
 
+  it("SEC-114: sizes market orders (no limitPx) against caps instead of rejecting a zero estimate", async () => {
+    const tenantId = `tenant-trade-mkt-${Date.now()}`;
+    const agentId = `agent-trade-mkt-${Date.now()}`;
+    const sessionId = `ses_${crypto.randomUUID()}`;
+
+    await getDb()
+      .insert(tenants)
+      .values({
+        id: tenantId,
+        name: "Trade Market Order Test Tenant",
+        apiKeyHash: `test-hash-${tenantId}`,
+        ownerAddress: `0x${crypto.randomUUID().replace(/-/g, "").slice(0, 40).padEnd(40, "0")}`,
+      });
+    await getDb().insert(agents).values({
+      id: agentId,
+      tenantId,
+      name: "Trade Market Order Test Agent",
+      walletAddress: "0x0000000000000000000000000000000000000001",
+    });
+    await getDb()
+      .insert(tradeSessions)
+      .values({
+        id: sessionId,
+        tenantId,
+        agentId,
+        venue: "hyperliquid",
+        walletId: "0x0000000000000000000000000000000000000001",
+        status: "active",
+        dailySpendUsd: "0",
+        dailyCapUsd: "100000",
+        perOrderCapUsd: "50",
+        leverageCap: "2",
+        allowedAssets: ["BTC", "ETH"],
+        expiresAt: new Date(Date.now() + 60_000),
+      });
+
+    globalThis.fetch = mock(async (_input: unknown, init?: RequestInit) => {
+      const venueCall = JSON.parse(String(init?.body ?? "{}")) as { type?: string };
+      if (venueCall.type === "l2Book") {
+        return new Response(
+          JSON.stringify({ levels: [[{ px: "59000", sz: "1" }], [{ px: "60000", sz: "1" }]] }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response(JSON.stringify({ BTC: "60000", ETH: "3000" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    process.env.STEWARD_MASTER_PASSWORD ??= "test-master-password";
+    const { createTradeRoutes } = await import("../routes/trade");
+    const { testCtx } = await import("./_ctx");
+    const app = new Hono<{
+      Variables: {
+        tenantId: string;
+        agentScope: string;
+        authType: string;
+      };
+    }>();
+    app.use("*", async (c, next) => {
+      c.set("tenantId", tenantId);
+      c.set("agentScope", agentId);
+      c.set("authType", "agent");
+      await next();
+    });
+    app.route("/v1/trade", createTradeRoutes(testCtx()));
+
+    // No limitPx: the preliminary check must not reject on a zero USD estimate
+    // ("estimated order USD is required"); the order is sized from the live book
+    // (60000 ask * 1.005 marketable markup = 60300) and the real cap verdict
+    // applies.
+    const res = await app.request("/v1/trade/hyperliquid/order", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "Idempotency-Key": crypto.randomUUID() },
+      body: JSON.stringify({
+        sessionId,
+        asset: "BTC",
+        side: "buy",
+        size: 1,
+        leverage: 1,
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      code: "policy-violation",
+      reason: "per-order-cap: order $60300 exceeds cap $50",
+    });
+  });
+
+  it("SEC-114: market orders (no limitPx) are still pre-checked for venue/asset/leverage", async () => {
+    const tenantId = `tenant-trade-mktlev-${Date.now()}`;
+    const agentId = `agent-trade-mktlev-${Date.now()}`;
+    const sessionId = `ses_${crypto.randomUUID()}`;
+
+    await getDb()
+      .insert(tenants)
+      .values({
+        id: tenantId,
+        name: "Trade Market Leverage Test Tenant",
+        apiKeyHash: `test-hash-${tenantId}`,
+        ownerAddress: `0x${crypto.randomUUID().replace(/-/g, "").slice(0, 40).padEnd(40, "0")}`,
+      });
+    await getDb().insert(agents).values({
+      id: agentId,
+      tenantId,
+      name: "Trade Market Leverage Test Agent",
+      walletAddress: "0x0000000000000000000000000000000000000001",
+    });
+    await getDb()
+      .insert(tradeSessions)
+      .values({
+        id: sessionId,
+        tenantId,
+        agentId,
+        venue: "hyperliquid",
+        walletId: "0x0000000000000000000000000000000000000001",
+        status: "active",
+        dailySpendUsd: "0",
+        dailyCapUsd: "100",
+        perOrderCapUsd: "50",
+        leverageCap: "2",
+        allowedAssets: ["BTC", "ETH"],
+        expiresAt: new Date(Date.now() + 60_000),
+      });
+
+    process.env.STEWARD_MASTER_PASSWORD ??= "test-master-password";
+    const { createTradeRoutes } = await import("../routes/trade");
+    const { testCtx } = await import("./_ctx");
+    const app = new Hono<{
+      Variables: {
+        tenantId: string;
+        agentScope: string;
+        authType: string;
+      };
+    }>();
+    app.use("*", async (c, next) => {
+      c.set("tenantId", tenantId);
+      c.set("agentScope", agentId);
+      c.set("authType", "agent");
+      await next();
+    });
+    app.route("/v1/trade", createTradeRoutes(testCtx()));
+
+    const res = await app.request("/v1/trade/hyperliquid/order", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "Idempotency-Key": crypto.randomUUID() },
+      body: JSON.stringify({
+        sessionId,
+        asset: "ETH",
+        side: "buy",
+        size: 1,
+        leverage: 3,
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      code: "policy-violation",
+      reason: "leverage-cap: leverage 3 exceeds cap 2",
+    });
+  });
+
   it("rejects non-decimal Hyperliquid prices before policy reservation", async () => {
     const tenantId = `tenant-trade-price-${Date.now()}`;
     const agentId = `agent-trade-price-${Date.now()}`;

--- a/packages/plugin-trading/src/__tests__/trade-polymarket-creds-cache.test.ts
+++ b/packages/plugin-trading/src/__tests__/trade-polymarket-creds-cache.test.ts
@@ -25,7 +25,6 @@ import { agents, closeDb, getDb, tenants, tradeSessions } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import type { AppVariables } from "@stwd/shared";
 import { TradeSessionManager } from "@stwd/trade-sessions";
-import { eq } from "drizzle-orm";
 import { Hono } from "hono";
 import type { StewardAppContext } from "../context";
 
@@ -36,6 +35,12 @@ setDefaultTimeout(30000);
 const redisStore = new Map<string, string>();
 const fakeRedis = {
   get: async (key: string) => redisStore.get(key) ?? null,
+  // IoredisLike.set — the durable idempotency store (SEC-043) writes through
+  // this with a PX TTL; the creds cache itself uses setex below.
+  set: async (key: string, value: string, _mode?: "PX", _ttlMs?: number) => {
+    redisStore.set(key, value);
+    return "OK";
+  },
   setex: async (key: string, _ttlSeconds: number, value: string) => {
     redisStore.set(key, value);
     return "OK";
@@ -97,11 +102,7 @@ async function seedTenantAgent(): Promise<{ tenantId: string; agentId: string }>
   return { tenantId, agentId };
 }
 
-async function seedSession(
-  tenantId: string,
-  agentId: string,
-  walletId: string,
-): Promise<string> {
+async function seedSession(tenantId: string, agentId: string, walletId: string): Promise<string> {
   const sessionId = `ses_${crypto.randomUUID()}`;
   await getDb()
     .insert(tradeSessions)

--- a/packages/plugin-trading/src/__tests__/trade-polymarket-creds-cache.test.ts
+++ b/packages/plugin-trading/src/__tests__/trade-polymarket-creds-cache.test.ts
@@ -1,0 +1,353 @@
+/**
+ * SEC-108 regression coverage: the Polymarket L2 CLOB creds cached in Redis
+ * are AES-256-GCM encrypted at rest (never plaintext), a second order hits the
+ * cache instead of re-deriving, and a legacy plaintext entry is treated as a
+ * cache miss and rewritten encrypted.
+ *
+ * Harness mirrors trade-polymarket-order.test.ts's deterministic E2E: real
+ * in-memory PGLite, real vault wallet + signer, the CLOB SDK intercepted at
+ * the network edge — plus an in-memory Redis injected through the plugin ctx
+ * so the RAW stored bytes are assertable.
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  setDefaultTimeout,
+  spyOn,
+} from "bun:test";
+import { ClobClient } from "@polymarket/clob-client";
+import { agents, closeDb, getDb, tenants, tradeSessions } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import type { AppVariables } from "@stwd/shared";
+import { TradeSessionManager } from "@stwd/trade-sessions";
+import { eq } from "drizzle-orm";
+import { Hono } from "hono";
+import type { StewardAppContext } from "../context";
+
+setDefaultTimeout(30000);
+
+// In-memory Redis stand-in injected via the plugin ctx. Records RAW stored
+// values so the test can assert the cached L2 creds are encrypted (SEC-108).
+const redisStore = new Map<string, string>();
+const fakeRedis = {
+  get: async (key: string) => redisStore.get(key) ?? null,
+  setex: async (key: string, _ttlSeconds: number, value: string) => {
+    redisStore.set(key, value);
+    return "OK";
+  },
+  del: async (...keys: string[]) => {
+    let deleted = 0;
+    for (const key of keys) if (redisStore.delete(key)) deleted += 1;
+    return deleted;
+  },
+};
+
+// With a Redis client present the route's rate limiter calls the real
+// @stwd/redis singleton; keep it in-memory for this harness.
+mock.module("@stwd/redis", () => ({
+  checkRateLimit: async () => ({ allowed: true, remaining: 9, resetMs: 1_000 }),
+  checkSpendLimit: async () => ({ allowed: true, spent: 0, remaining: 1 }),
+  createUpstashIoredisAdapter: () => ({ ping: async () => "PONG" }),
+  disconnectRedis: async () => undefined,
+  estimateCost: () => 0,
+  getAggregationSnapshot: async () => null,
+  getCachedPolicies: async () => null,
+  getPricingTable: () => ({}),
+  getRedis: () => fakeRedis,
+  getRedisDriver: () => "ioredis",
+  getSpend: async () => 0,
+  getSpendByHost: async () => ({}),
+  invalidateCache: async () => undefined,
+  invalidateTenantCache: async () => undefined,
+  isKnownHost: () => false,
+  recordAggregationEvent: async () => undefined,
+  recordSpend: async () => undefined,
+  reserveSpend: async () => ({ allowed: true, reservationId: "reservation-test" }),
+  setCachedPolicies: async () => undefined,
+  settleReservedSpend: async () => undefined,
+}));
+
+const TOKEN_ID = "71321045679252212594626385532706912750332728571942532289631379312455583992563";
+const DERIVED_CREDS = {
+  apiKey: "cache-test-key",
+  secret: "cache-test-secret-plaintext",
+  passphrase: "cache-test-pass",
+};
+
+let fenceSpy: ReturnType<typeof spyOn> | undefined;
+
+async function seedTenantAgent(): Promise<{ tenantId: string; agentId: string }> {
+  const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const tenantId = `pm-cache-tenant-${suffix}`;
+  const agentId = `pm-cache-agent-${suffix}`;
+  await getDb()
+    .insert(tenants)
+    .values({ id: tenantId, name: "PM Cache Tenant", apiKeyHash: `hash-${tenantId}` });
+  await getDb().insert(agents).values({
+    id: agentId,
+    tenantId,
+    name: "PM Cache Agent",
+    walletAddress: "0x0000000000000000000000000000000000000001",
+  });
+  return { tenantId, agentId };
+}
+
+async function seedSession(
+  tenantId: string,
+  agentId: string,
+  walletId: string,
+): Promise<string> {
+  const sessionId = `ses_${crypto.randomUUID()}`;
+  await getDb()
+    .insert(tradeSessions)
+    .values({
+      id: sessionId,
+      tenantId,
+      agentId,
+      venue: "polymarket",
+      walletId,
+      status: "active",
+      dailySpendUsd: "0",
+      dailyCapUsd: "100",
+      perOrderCapUsd: "50",
+      leverageCap: "1",
+      allowedAssets: [`pm:${TOKEN_ID}`],
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+  return sessionId;
+}
+
+function makeApp(tenantId: string, agentId: string, routes: Hono) {
+  const app = new Hono<{ Variables: AppVariables }>();
+  app.use("*", async (c, next) => {
+    c.set("tenantId", tenantId);
+    c.set("agentScope", agentId);
+    c.set("authType", "agent-token");
+    await next();
+  });
+  app.route("/v1/trade", routes);
+  return app;
+}
+
+beforeAll(async () => {
+  process.env.STEWARD_PGLITE_MEMORY = "true";
+  process.env.STEWARD_MASTER_PASSWORD ??= "pm-creds-cache-master-password";
+  process.env.STEWARD_AUDIT_HMAC_KEY ??= "pm-creds-cache-audit-hmac-key-0123456789abcdef";
+  const { db, client } = await createPGLiteDb("memory://");
+  setPGLiteOverride(db, async () => {
+    await client.close();
+  });
+  // Same faithful fence pass-through as trade-polymarket-order.test.ts (the
+  // real wrapper's outer transaction would deadlock single-connection PGLite).
+  fenceSpy = spyOn(TradeSessionManager.prototype, "withActiveSubmissionFence").mockImplementation(
+    (async (input: { tenantId: string; id: string }, cb: () => Promise<unknown>) => {
+      const active = await new TradeSessionManager().getActive(input.tenantId, input.id);
+      if (!active) return null;
+      return cb();
+    }) as never,
+  );
+});
+
+afterAll(async () => {
+  fenceSpy?.mockRestore();
+  await closeDb();
+  delete process.env.STEWARD_PGLITE_MEMORY;
+});
+
+beforeEach(() => {
+  redisStore.clear();
+});
+
+describe("SEC-108: Polymarket L2 creds Redis cache is encrypted at rest", () => {
+  it("caches creds encrypted, serves the next order from cache, and rewrites legacy plaintext", async () => {
+    const { createTradeRoutes } = await import("../routes/trade");
+    const { testCtx } = await import("./_ctx");
+    const ctx = {
+      ...testCtx(),
+      getRedisClient: () => fakeRedis,
+    } as unknown as StewardAppContext;
+    const tradeRoutes = createTradeRoutes(ctx);
+
+    const { tenantId, agentId } = await seedTenantAgent();
+    // Real provisioning into the encrypted venue-scoped vault; no key material
+    // leaves the vault, and the L1->L2 derivation signs for real.
+    const wallet = await ctx.vault.createWallet({
+      agentId,
+      venue: "polymarket",
+      chainType: "evm",
+    });
+    const sessionId = await seedSession(tenantId, agentId, wallet.address);
+    const app = makeApp(tenantId, agentId, tradeRoutes);
+
+    const authKeyRequests: unknown[] = [];
+    type ClobHttpOptions = { headers?: Record<string, string>; data?: unknown };
+    type ClobHttpPrototype = {
+      get(endpoint: string, options?: ClobHttpOptions): Promise<unknown>;
+      post(endpoint: string, options?: ClobHttpOptions): Promise<unknown>;
+    };
+    const clobPrototype = ClobClient.prototype as unknown as ClobHttpPrototype;
+    const getSpy = spyOn(clobPrototype, "get").mockImplementation((async (endpoint: string) => {
+      const path = new URL(endpoint).pathname;
+      if (path === "/tick-size") return { minimum_tick_size: 0.01 };
+      if (path === "/fee-rate") return { base_fee: 0 };
+      throw new Error(`unexpected CLOB GET ${path}`);
+    }) as never);
+    const postSpy = spyOn(clobPrototype, "post").mockImplementation((async (
+      endpoint: string,
+      options?: ClobHttpOptions,
+    ) => {
+      const path = new URL(endpoint).pathname;
+      const headers = new Headers(options?.headers);
+      if (path === "/auth/api-key") {
+        authKeyRequests.push(options?.data);
+        return DERIVED_CREDS;
+      }
+      if (path === "/order") {
+        expect(headers.get("poly_api_key")).toBe(DERIVED_CREDS.apiKey);
+        return {
+          orderID: "pm-cache-order-1",
+          status: "matched",
+          success: true,
+          makingAmount: "10000000",
+          takingAmount: "20000000",
+        };
+      }
+      throw new Error(`unexpected CLOB POST ${path}`);
+    }) as never);
+
+    process.env.POLYMARKET_CLOB_API_URL = "https://clob.e2e.invalid";
+    try {
+      const postOrder = () =>
+        app.request("/v1/trade/polymarket/order", {
+          method: "POST",
+          headers: { "content-type": "application/json", "Idempotency-Key": crypto.randomUUID() },
+          body: JSON.stringify({
+            sessionId,
+            tokenId: TOKEN_ID,
+            side: "buy",
+            amount: 10,
+            price: 0.5,
+            tickSize: "0.01",
+            negRisk: true,
+          }),
+        });
+
+      // 1) Cache miss -> real L1->L2 derivation -> encrypted cache write.
+      const first = await postOrder();
+      expect(first.status).toBe(200);
+      expect(authKeyRequests).toHaveLength(1);
+
+      const pmKeys = [...redisStore.keys()].filter((key) => key.startsWith("pm:clob-l2:"));
+      expect(pmKeys).toHaveLength(1);
+      const storedRaw = redisStore.get(pmKeys[0] as string) as string;
+      expect(storedRaw.startsWith("stwd_pmclob_v1:")).toBe(true);
+      expect(storedRaw.includes(DERIVED_CREDS.secret)).toBe(false);
+      expect(storedRaw.includes(DERIVED_CREDS.apiKey)).toBe(false);
+
+      // 2) Second order resolves from the cache: no second derivation.
+      const second = await postOrder();
+      expect(second.status).toBe(200);
+      expect(authKeyRequests).toHaveLength(1);
+
+      // 3) A legacy PLAINTEXT entry is not trusted: it is treated as a cache
+      // miss (re-derive) and rewritten encrypted.
+      redisStore.set(pmKeys[0] as string, JSON.stringify(DERIVED_CREDS));
+      const third = await postOrder();
+      expect(third.status).toBe(200);
+      expect(authKeyRequests).toHaveLength(2);
+      const rewritten = redisStore.get(pmKeys[0] as string) as string;
+      expect(rewritten.startsWith("stwd_pmclob_v1:")).toBe(true);
+      expect(rewritten.includes(DERIVED_CREDS.secret)).toBe(false);
+    } finally {
+      delete process.env.POLYMARKET_CLOB_API_URL;
+      getSpy.mockRestore();
+      postSpy.mockRestore();
+    }
+  });
+
+  it("skips the cache entirely when no encryption key material is configured", async () => {
+    const { createTradeRoutes } = await import("../routes/trade");
+    const { testCtx } = await import("./_ctx");
+    const ctx = {
+      ...testCtx(),
+      getRedisClient: () => fakeRedis,
+    } as unknown as StewardAppContext;
+    const tradeRoutes = createTradeRoutes(ctx);
+
+    const { tenantId, agentId } = await seedTenantAgent();
+    const wallet = await ctx.vault.createWallet({
+      agentId,
+      venue: "polymarket",
+      chainType: "evm",
+    });
+    const sessionId = await seedSession(tenantId, agentId, wallet.address);
+    const app = makeApp(tenantId, agentId, tradeRoutes);
+
+    type ClobHttpOptions = { headers?: Record<string, string>; data?: unknown };
+    type ClobHttpPrototype = {
+      get(endpoint: string, options?: ClobHttpOptions): Promise<unknown>;
+      post(endpoint: string, options?: ClobHttpOptions): Promise<unknown>;
+    };
+    const clobPrototype = ClobClient.prototype as unknown as ClobHttpPrototype;
+    const getSpy = spyOn(clobPrototype, "get").mockImplementation((async (endpoint: string) => {
+      const path = new URL(endpoint).pathname;
+      if (path === "/tick-size") return { minimum_tick_size: 0.01 };
+      if (path === "/fee-rate") return { base_fee: 0 };
+      throw new Error(`unexpected CLOB GET ${path}`);
+    }) as never);
+    let deriveCount = 0;
+    const postSpy = spyOn(clobPrototype, "post").mockImplementation((async (endpoint: string) => {
+      const path = new URL(endpoint).pathname;
+      if (path === "/auth/api-key") {
+        deriveCount += 1;
+        return DERIVED_CREDS;
+      }
+      if (path === "/order") {
+        return {
+          orderID: "pm-cache-order-2",
+          status: "matched",
+          success: true,
+          makingAmount: "10000000",
+          takingAmount: "20000000",
+        };
+      }
+      throw new Error(`unexpected CLOB POST ${path}`);
+    }) as never);
+
+    const prevMasterPassword = process.env.STEWARD_MASTER_PASSWORD;
+    delete process.env.STEWARD_MASTER_PASSWORD;
+    process.env.POLYMARKET_CLOB_API_URL = "https://clob.e2e.invalid";
+    try {
+      const res = await app.request("/v1/trade/polymarket/order", {
+        method: "POST",
+        headers: { "content-type": "application/json", "Idempotency-Key": crypto.randomUUID() },
+        body: JSON.stringify({
+          sessionId,
+          tokenId: TOKEN_ID,
+          side: "buy",
+          amount: 10,
+          price: 0.5,
+          tickSize: "0.01",
+          negRisk: true,
+        }),
+      });
+      // Fail closed WITHOUT failing the order: the order still executes (creds
+      // are derived fresh), but nothing is written to the shared Redis.
+      expect(res.status).toBe(200);
+      expect(deriveCount).toBe(1);
+      const pmKeys = [...redisStore.keys()].filter((key) => key.startsWith("pm:clob-l2:"));
+      expect(pmKeys).toHaveLength(0);
+    } finally {
+      if (prevMasterPassword === undefined) delete process.env.STEWARD_MASTER_PASSWORD;
+      else process.env.STEWARD_MASTER_PASSWORD = prevMasterPassword;
+      delete process.env.POLYMARKET_CLOB_API_URL;
+      getSpy.mockRestore();
+      postSpy.mockRestore();
+    }
+  });
+});

--- a/packages/plugin-trading/src/__tests__/trade-polymarket-order.test.ts
+++ b/packages/plugin-trading/src/__tests__/trade-polymarket-order.test.ts
@@ -434,6 +434,70 @@ describe("POST /v1/trade/polymarket/order", () => {
     expect(await dailySpendOf(sessionId)).toBe(0);
   });
 
+  it("SEC-111: STEWARD_PM_TEST_CREDS is hard-disabled in production", async () => {
+    const { tenantId, agentId, sessionId } = await seedSession({});
+    stubWallet(true); // wallet + funder present, but no provisioned L2 creds
+    const app = makeApp(tenantId, agentId, tradeRoutes);
+
+    const prevNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    process.env.STEWARD_PM_TEST_CREDS = "1";
+    try {
+      const res = await postOrder(app, sessionId, crypto.randomUUID());
+      // The test-creds seam is ignored in production, so creds resolution falls
+      // through to real L2 derivation, which fails closed in this harness.
+      expect(res.status).toBe(409);
+      expect(((await res.json()) as { error?: string }).error).toContain(
+        "credentials are not provisioned",
+      );
+      expect(await dailySpendOf(sessionId)).toBe(0);
+    } finally {
+      if (prevNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = prevNodeEnv;
+      delete process.env.STEWARD_PM_TEST_CREDS;
+    }
+  });
+
+  it("SEC-111: a plain-http POLYMARKET_CLOB_API_URL is refused in production", async () => {
+    const { tenantId, agentId, sessionId } = await seedSession({});
+    stubWallet(true);
+    // Mock the adapter edge so the ONLY thing that can fail the order is creds
+    // resolution: pre-fix the http override + test creds would reach submit.
+    buildSpy = spyOn(PolymarketExecutionAdapter.prototype, "buildSignedOrder").mockResolvedValue(
+      {} as never,
+    );
+    submitSpy = spyOn(PolymarketExecutionAdapter.prototype, "submitSignedOrder").mockResolvedValue({
+      venue: "polymarket" as const,
+      orderId: "pm-http-guard",
+      status: "matched",
+      success: true,
+      makingAmount: "10",
+      takingAmount: "20",
+      actualAmount: 20,
+      actualPrice: 0.5,
+    } as Awaited<ReturnType<PolymarketExecutionAdapter["submitSignedOrder"]>>);
+    const app = makeApp(tenantId, agentId, tradeRoutes);
+
+    const prevNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    process.env.POLYMARKET_CLOB_API_URL = "http://clob.e2e.invalid";
+    process.env.STEWARD_PM_TEST_CREDS = "1";
+    try {
+      const res = await postOrder(app, sessionId, crypto.randomUUID());
+      expect(res.status).toBe(409);
+      expect(((await res.json()) as { error?: string }).error).toContain(
+        "credentials are not provisioned",
+      );
+      expect(submitSpy).not.toHaveBeenCalled();
+      expect(await dailySpendOf(sessionId)).toBe(0);
+    } finally {
+      if (prevNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = prevNodeEnv;
+      delete process.env.POLYMARKET_CLOB_API_URL;
+      delete process.env.STEWARD_PM_TEST_CREDS;
+    }
+  });
+
   it("happy path: filled order -> 200, spend reserved, submitted + authorized audits (mocked adapter)", async () => {
     const { tenantId, agentId, sessionId } = await seedSession({});
     const app = makeApp(tenantId, agentId, tradeRoutes);

--- a/packages/plugin-trading/src/index.ts
+++ b/packages/plugin-trading/src/index.ts
@@ -21,6 +21,7 @@
  */
 
 import type { AppVariables, StewardPlugin } from "@stwd/shared";
+import { validateBuilderFeeEnv } from "@stwd/venue-hyperliquid";
 import type { Hono } from "hono";
 import type { StewardAppContext } from "./context";
 import { createEvmSwapRoutes } from "./routes/evm-swap";
@@ -103,6 +104,10 @@ export const tradingPlugin: StewardApiPlugin = {
   webhookEvents: TRADING_WEBHOOK_EVENTS,
   register(app, ctx) {
     const { requireAgentJwt, operatorAuth, tenantAuth } = ctx;
+
+    // SEC-186: fail fast at composition (startup) when the HL builder-fee env
+    // config is malformed instead of throwing at order time.
+    validateBuilderFeeEnv();
 
     // ── trade-specific auth middleware (verbatim from app.ts ~lines 172-182) ──
     for (const path of [

--- a/packages/plugin-trading/src/routes/evm-swap.ts
+++ b/packages/plugin-trading/src/routes/evm-swap.ts
@@ -59,7 +59,9 @@ const prepareSwapSchema = z
     fromToken: tokenRefSchema,
     toToken: tokenRefSchema,
     amount: z.string().regex(/^\d+$/, "amount must be a decimal base-unit string").max(80),
-    slippageBps: z.number().int().min(0).max(10_000).optional(),
+    // SEC-185: clamp to the agent-trader MAX_SLIPPAGE_BPS doctrine ([0, 5000)) —
+    // a 100%-slippage quote yields minAmountOut ≈ 0 and is fully sandwichable.
+    slippageBps: z.number().int().min(0).lt(5_000).optional(),
   })
   .strict();
 

--- a/packages/plugin-trading/src/routes/idempotency.ts
+++ b/packages/plugin-trading/src/routes/idempotency.ts
@@ -1,0 +1,141 @@
+/**
+ * idempotency.ts — durable idempotency backing for the trade + operator routes
+ * (SEC-043).
+ *
+ * Wave-2 bounded the process-local maps (1_000 entries + expired-sweep) and
+ * stored ambiguous-outcome 502 envelopes, but the maps were still per-process:
+ * a restart or a second replica silently lost dedup, so a retried
+ * withdraw/order could double-execute a fund movement.
+ *
+ * This store keeps the wave-2 semantics and adds a Redis-backed record when a
+ * client is available (production always has one — durable stores are asserted
+ * at startup), keyed `idempotency:<namespace>:<scope>:<key>` with the same 24h
+ * TTL. Without Redis it falls back to the bounded process-local map (dev /
+ * single-replica), exactly like the routes' rate limiters.
+ *
+ * Semantics (unchanged from wave-2):
+ *   - same key + same body      -> replay the stored outcome (no re-execution)
+ *   - same key + DIFFERENT body -> conflict (the routes answer 409)
+ *   - missing/expired           -> fresh; `store` records the final outcome
+ *                                  (success OR ambiguous 502) so retries replay
+ *
+ * Failure posture:
+ *   - a Redis error on CHECK fails CLOSED (throws): executing without the
+ *     dedup record risks a double fund-movement; the caller's retry replays
+ *     once Redis recovers.
+ *   - a Redis error on STORE is logged and swallowed: the movement already
+ *     executed, so the caller must still see the real outcome. A later retry
+ *     may re-execute — the same accepted residual as a crash between venue
+ *     execution and persistence.
+ *
+ * Known residual (pre-existing, unchanged): two requests with the same key
+ * in-flight CONCURRENTLY can both pass the check before either stores. This
+ * store closes the sequential-retry / restart / multi-replica gaps the audit
+ * flagged; claim-before-execute hardening is separate work.
+ */
+
+import type { IoredisLike } from "@stwd/redis";
+
+export interface IdempotencyRecord {
+  status: number;
+  body: unknown;
+}
+
+export interface IdempotencyCheck<TRecord extends IdempotencyRecord> {
+  conflict?: boolean;
+  record?: TRecord;
+  store?: (record: TRecord) => Promise<void>;
+}
+
+const IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000;
+const MAX_MEMORY_ENTRIES = 1_000;
+
+export class DurableIdempotencyStore<TRecord extends IdempotencyRecord> {
+  private readonly memory = new Map<
+    string,
+    { bodyHash: string; record: TRecord; expiresAt: number }
+  >();
+
+  constructor(
+    private readonly options: {
+      /** Key prefix segment, e.g. "trade" or "trade:operator". */
+      namespace: string;
+      getRedisClient: () => IoredisLike | null;
+    },
+  ) {}
+
+  private redisKey(scope: string, key: string): string {
+    return `idempotency:${this.options.namespace}:${scope}:${key}`;
+  }
+
+  private sweepMemory(now: number): void {
+    for (const [entryKey, entry] of this.memory) {
+      if (entry.expiresAt <= now || this.memory.size >= MAX_MEMORY_ENTRIES) {
+        this.memory.delete(entryKey);
+      }
+      if (this.memory.size < MAX_MEMORY_ENTRIES) break;
+    }
+  }
+
+  /**
+   * Look up `key` within `scope`. `bodyHash` is the caller-computed canonical
+   * body fingerprint; a mismatch on an existing entry is a conflict.
+   */
+  async check(
+    scope: string,
+    key: string | undefined,
+    bodyHash: string,
+  ): Promise<IdempotencyCheck<TRecord>> {
+    if (!key) return {};
+    const now = Date.now();
+    const redis = this.options.getRedisClient();
+    if (redis) {
+      // Fail CLOSED on a Redis error (see the module doc).
+      const raw = await redis.get(this.redisKey(scope, key));
+      if (raw !== null) {
+        let existing: { bodyHash?: unknown; record?: unknown } | null = null;
+        try {
+          existing = JSON.parse(raw) as { bodyHash?: unknown; record?: unknown };
+        } catch {
+          existing = null;
+        }
+        if (typeof existing?.bodyHash === "string" && existing.record) {
+          if (existing.bodyHash !== bodyHash) return { conflict: true };
+          return { record: existing.record as TRecord };
+        }
+        // An unparsable entry cannot vouch for a prior execution — treat as
+        // absent and let store() overwrite it below.
+      }
+      return {
+        store: async (record) => {
+          const payload = JSON.stringify({ bodyHash, record });
+          await redis
+            .set(this.redisKey(scope, key), payload, "PX", IDEMPOTENCY_TTL_MS)
+            .catch((err) => {
+              // The movement already executed; losing the record means a later
+              // retry re-executes. Log loudly — nothing safer remains.
+              console.error(
+                "[idempotency] failed to persist the outcome record; a retry may re-execute:",
+                err,
+              );
+            });
+        },
+      };
+    }
+
+    // Process-local fallback (dev / single-replica): bounded + swept, mirroring
+    // the wave-2 maps.
+    const mapKey = `${scope}:${key}`;
+    const existing = this.memory.get(mapKey);
+    if (existing && existing.expiresAt > now) {
+      if (existing.bodyHash !== bodyHash) return { conflict: true };
+      return { record: existing.record };
+    }
+    return {
+      store: async (record) => {
+        this.sweepMemory(now);
+        this.memory.set(mapKey, { bodyHash, record, expiresAt: now + IDEMPOTENCY_TTL_MS });
+      },
+    };
+  }
+}

--- a/packages/plugin-trading/src/routes/operator-recovery.ts
+++ b/packages/plugin-trading/src/routes/operator-recovery.ts
@@ -46,6 +46,7 @@ import type { Context } from "hono";
 import { Hono } from "hono";
 import { z } from "zod";
 import type { StewardAppContext } from "../context";
+import { DurableIdempotencyStore } from "./idempotency";
 
 const closeAllSchema = z.object({
   agentId: z.string().min(1),
@@ -210,66 +211,38 @@ export function createOperatorRecoveryRoutes(
 
   const operatorRecoveryRoutes = new Hono<{ Variables: AppVariables }>();
 
-  // ── Idempotency (mirrors trade.ts in-memory helper) ───────────────────────────
+  // ── Idempotency (mirrors trade.ts store) ─────────────────────────────────────
   // Entries are stored for BOTH successful responses and ambiguous-outcome 502s
   // (a submit that may have landed at the venue), so a retry with the same key
   // REPLAYS the recorded outcome instead of re-executing a possibly-completed
-  // fund movement. The map is bounded: expired entries are swept on store and
-  // the oldest entries are evicted past MAX_OPERATOR_IDEMPOTENCY_ENTRIES so a
-  // caller cannot grow process memory without bound (SEC-043).
-  const MAX_OPERATOR_IDEMPOTENCY_ENTRIES = 1_000;
-  const operatorIdempotency = new Map<
-    string,
-    { bodyHash: string; status: 200 | 502; body: unknown; expiresAt: number }
-  >();
+  // fund movement. SEC-043: records are Redis-backed when a client is available
+  // (multi-replica dedup survives restarts); without Redis the store falls back
+  // to a bounded (1_000 entries, expired-sweep + oldest-evict) process-local map.
+  type OperatorIdempotencyRecord = { status: 200 | 502; body: unknown };
+  const operatorIdempotencyStore = new DurableIdempotencyStore<OperatorIdempotencyRecord>({
+    namespace: "trade:operator",
+    getRedisClient,
+  });
 
-  function sweepOperatorIdempotency(now: number): void {
-    for (const [entryKey, entry] of operatorIdempotency) {
-      if (entry.expiresAt <= now || operatorIdempotency.size >= MAX_OPERATOR_IDEMPOTENCY_ENTRIES) {
-        operatorIdempotency.delete(entryKey);
-      }
-      if (operatorIdempotency.size < MAX_OPERATOR_IDEMPOTENCY_ENTRIES) break;
-    }
-  }
-
-  function getOperatorIdempotency(
+  async function getOperatorIdempotency(
     scope: string,
     key: string | undefined,
     body: unknown,
-  ): {
+  ): Promise<{
     conflict?: boolean;
-    entry?: { status: 200 | 502; body: unknown };
-    store?: (response: unknown) => void;
-    storeFailure?: (errorBody: unknown) => void;
-  } {
-    if (!key) return {};
-    const now = Date.now();
-    const mapKey = `${scope}:${key}`;
-    const bodyHash = JSON.stringify(body);
-    const existing = operatorIdempotency.get(mapKey);
-    if (existing && existing.expiresAt > now) {
-      if (existing.bodyHash !== bodyHash) return { conflict: true };
-      return { entry: { status: existing.status, body: existing.body } };
+    entry?: OperatorIdempotencyRecord;
+    store?: (response: unknown) => Promise<void>;
+    storeFailure?: (errorBody: unknown) => Promise<void>;
+  }> {
+    const check = await operatorIdempotencyStore.check(scope, key, JSON.stringify(body));
+    if (check.conflict || check.record) {
+      return { conflict: check.conflict, entry: check.record };
     }
+    if (!check.store) return {};
+    const persist = check.store;
     return {
-      store(response: unknown) {
-        sweepOperatorIdempotency(now);
-        operatorIdempotency.set(mapKey, {
-          bodyHash,
-          status: 200,
-          body: { ok: true, data: response },
-          expiresAt: now + 24 * 60 * 60 * 1000,
-        });
-      },
-      storeFailure(errorBody: unknown) {
-        sweepOperatorIdempotency(now);
-        operatorIdempotency.set(mapKey, {
-          bodyHash,
-          status: 502,
-          body: errorBody,
-          expiresAt: now + 24 * 60 * 60 * 1000,
-        });
-      },
+      store: (response: unknown) => persist({ status: 200, body: { ok: true, data: response } }),
+      storeFailure: (errorBody: unknown) => persist({ status: 502, body: errorBody }),
     };
   }
 
@@ -591,7 +564,7 @@ export function createOperatorRecoveryRoutes(
 
     // Idempotency keyed on (agent, amount). Computed BEFORE broadcast so a retried
     // deposit with the same key returns the original result instead of double-sending.
-    const idempotency = getOperatorIdempotency(`${tenantId}:deposit`, body.idempotencyKey, {
+    const idempotency = await getOperatorIdempotency(`${tenantId}:deposit`, body.idempotencyKey, {
       agentId,
       venue,
       amount: amountBaseUnits.toString(),
@@ -633,7 +606,7 @@ export function createOperatorRecoveryRoutes(
       // The broadcast may have landed — record the ambiguous outcome so a retry
       // replays this 502 instead of double-broadcasting the ERC-20 transfer.
       const errorBody = { ok: false as const, error: "Failed to submit deposit" };
-      idempotency.storeFailure?.(errorBody);
+      await idempotency.storeFailure?.(errorBody);
       return c.json<ApiResponse>(errorBody, 502);
     }
 
@@ -653,7 +626,7 @@ export function createOperatorRecoveryRoutes(
       amountBaseUnits: amountBaseUnits.toString(),
       txHash,
     };
-    idempotency.store?.(response);
+    await idempotency.store?.(response);
     return c.json<ApiResponse>({ ok: true, data: response });
   });
 
@@ -687,7 +660,7 @@ export function createOperatorRecoveryRoutes(
     const effectiveLeverage = builderPerp ? Math.min(body.leverage, 3) : body.leverage;
     const isCross = builderPerp ? false : (body.isCross ?? false);
 
-    const idempotency = getOperatorIdempotency(`${tenantId}:leverage`, body.idempotencyKey, {
+    const idempotency = await getOperatorIdempotency(`${tenantId}:leverage`, body.idempotencyKey, {
       agentId,
       venue,
       coin,
@@ -745,7 +718,7 @@ export function createOperatorRecoveryRoutes(
       // The venue call may have landed — record the ambiguous outcome so a
       // retry replays this 502 instead of re-executing the leverage update.
       const errorBody = { ok: false as const, error: "Failed to update leverage" };
-      idempotency.storeFailure?.(errorBody);
+      await idempotency.storeFailure?.(errorBody);
       return c.json<ApiResponse>(errorBody, 502);
     }
 
@@ -769,7 +742,7 @@ export function createOperatorRecoveryRoutes(
       builderPerp,
       result,
     };
-    idempotency.store?.(response);
+    await idempotency.store?.(response);
     return c.json<ApiResponse>({ ok: true, data: response });
   });
 
@@ -824,12 +797,16 @@ export function createOperatorRecoveryRoutes(
       );
     }
 
-    const idempotency = getOperatorIdempotency(`${tenantId}:add-margin`, body.idempotencyKey, {
-      agentId,
-      venue,
-      coin,
-      amount: amountBaseUnits.toString(),
-    });
+    const idempotency = await getOperatorIdempotency(
+      `${tenantId}:add-margin`,
+      body.idempotencyKey,
+      {
+        agentId,
+        venue,
+        coin,
+        amount: amountBaseUnits.toString(),
+      },
+    );
     if (idempotency.conflict) {
       return c.json<ApiResponse>(
         { ok: false, error: "Idempotency key reused with a different body" },
@@ -876,7 +853,7 @@ export function createOperatorRecoveryRoutes(
       // The venue call may have landed — record the ambiguous outcome so a
       // retry replays this 502 instead of moving margin a second time.
       const errorBody = { ok: false as const, error: "Failed to add isolated margin" };
-      idempotency.storeFailure?.(errorBody);
+      await idempotency.storeFailure?.(errorBody);
       return c.json<ApiResponse>(errorBody, 502);
     }
 
@@ -896,7 +873,7 @@ export function createOperatorRecoveryRoutes(
       amountBaseUnits: amountBaseUnits.toString(),
       result,
     };
-    idempotency.store?.(response);
+    await idempotency.store?.(response);
     return c.json<ApiResponse>({ ok: true, data: response });
   });
 
@@ -958,7 +935,7 @@ export function createOperatorRecoveryRoutes(
       );
     }
 
-    const idempotency = getOperatorIdempotency(`${tenantId}:usd-send`, body.idempotencyKey, {
+    const idempotency = await getOperatorIdempotency(`${tenantId}:usd-send`, body.idempotencyKey, {
       agentId,
       venue,
       destination,
@@ -1031,7 +1008,7 @@ export function createOperatorRecoveryRoutes(
       // the transfer may have landed. Record the outcome so a retry replays
       // this 502 instead of double-sending USDC.
       const errorBody = { ok: false as const, error: "Failed to submit usdSend" };
-      idempotency.storeFailure?.(errorBody);
+      await idempotency.storeFailure?.(errorBody);
       return c.json<ApiResponse>(errorBody, 502);
     }
 
@@ -1043,7 +1020,7 @@ export function createOperatorRecoveryRoutes(
     });
 
     const response = { venue, walletAddress, destination, amount, result };
-    idempotency.store?.(response);
+    await idempotency.store?.(response);
     return c.json<ApiResponse>({ ok: true, data: response });
   });
 
@@ -1075,12 +1052,16 @@ export function createOperatorRecoveryRoutes(
     };
     const { agentId, builder, maxFeeRate } = body;
 
-    const idempotency = getOperatorIdempotency(`${tenantId}:approve-builder`, body.idempotencyKey, {
-      agentId,
-      venue,
-      builder,
-      maxFeeRate,
-    });
+    const idempotency = await getOperatorIdempotency(
+      `${tenantId}:approve-builder`,
+      body.idempotencyKey,
+      {
+        agentId,
+        venue,
+        builder,
+        maxFeeRate,
+      },
+    );
     if (idempotency.conflict) {
       return c.json<ApiResponse>(
         { ok: false, error: "Idempotency key reused with a different body" },
@@ -1125,7 +1106,7 @@ export function createOperatorRecoveryRoutes(
       // The venue call may have landed — record the ambiguous outcome so a
       // retry replays this 502 instead of re-submitting the approval.
       const errorBody = { ok: false as const, error: "Failed to approve builder fee" };
-      idempotency.storeFailure?.(errorBody);
+      await idempotency.storeFailure?.(errorBody);
       return c.json<ApiResponse>(errorBody, 502);
     }
 
@@ -1137,7 +1118,7 @@ export function createOperatorRecoveryRoutes(
     });
 
     const response = { venue, walletAddress, builder, maxFeeRate, result };
-    idempotency.store?.(response);
+    await idempotency.store?.(response);
     return c.json<ApiResponse>({ ok: true, data: response });
   });
 
@@ -1196,7 +1177,7 @@ export function createOperatorRecoveryRoutes(
       );
     }
 
-    const idempotency = getOperatorIdempotency(`${tenantId}:transfer`, body.idempotencyKey, {
+    const idempotency = await getOperatorIdempotency(`${tenantId}:transfer`, body.idempotencyKey, {
       agentId,
       venue,
       sourceDex,
@@ -1274,7 +1255,7 @@ export function createOperatorRecoveryRoutes(
         error: err instanceof Error ? err.message : String(err),
       });
       const errorBody = { ok: false as const, error: "Failed to submit collateral transfer" };
-      idempotency.storeFailure?.(errorBody);
+      await idempotency.storeFailure?.(errorBody);
       return c.json<ApiResponse>(errorBody, 502);
     }
 
@@ -1296,7 +1277,7 @@ export function createOperatorRecoveryRoutes(
       amountUsdc: String(body.amountUsdc),
       result,
     };
-    idempotency.store?.(response);
+    await idempotency.store?.(response);
     return c.json<ApiResponse>({ ok: true, data: response });
   });
 
@@ -1319,7 +1300,7 @@ export function createOperatorRecoveryRoutes(
     };
     const { agentId } = body;
 
-    const idempotency = getOperatorIdempotency(`${tenantId}:close-all`, body.idempotencyKey, {
+    const idempotency = await getOperatorIdempotency(`${tenantId}:close-all`, body.idempotencyKey, {
       agentId,
       venue,
     });
@@ -1358,7 +1339,7 @@ export function createOperatorRecoveryRoutes(
       // Positions may have been partially closed — record the ambiguous outcome
       // so a retry replays this 502 instead of firing another close batch.
       const errorBody = { ok: false as const, error: "Failed to close positions" };
-      idempotency.storeFailure?.(errorBody);
+      await idempotency.storeFailure?.(errorBody);
       return c.json<ApiResponse>(errorBody, 502);
     }
 
@@ -1374,7 +1355,7 @@ export function createOperatorRecoveryRoutes(
     }
 
     const response = { venue, walletAddress, closed: results };
-    idempotency.store?.(response);
+    await idempotency.store?.(response);
     return c.json<ApiResponse>({ ok: true, data: response });
   });
 
@@ -1442,7 +1423,7 @@ export function createOperatorRecoveryRoutes(
 
     const explicitIdempotencyAmount =
       explicitAmountBaseUnits !== null ? explicitAmountBaseUnits.toString() : null;
-    const idempotency = getOperatorIdempotency(`${tenantId}:withdraw`, body.idempotencyKey, {
+    const idempotency = await getOperatorIdempotency(`${tenantId}:withdraw`, body.idempotencyKey, {
       agentId,
       venue,
       destination,
@@ -1558,7 +1539,7 @@ export function createOperatorRecoveryRoutes(
         error: err instanceof Error ? err.message : String(err),
       });
       const errorBody = { ok: false as const, error: "Failed to submit withdraw" };
-      idempotency.storeFailure?.(errorBody);
+      await idempotency.storeFailure?.(errorBody);
       return c.json<ApiResponse>(errorBody, 502);
     }
 
@@ -1570,7 +1551,7 @@ export function createOperatorRecoveryRoutes(
     });
 
     const response = { venue, walletAddress, destination, amount, result };
-    idempotency.store?.(response);
+    await idempotency.store?.(response);
     return c.json<ApiResponse>({ ok: true, data: response });
   });
 

--- a/packages/plugin-trading/src/routes/trade.ts
+++ b/packages/plugin-trading/src/routes/trade.ts
@@ -1051,6 +1051,28 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
       return rejectPolicy(policy.reason ?? "order violates trading policy", sizeUsd, policyLimitPx);
     }
 
+    const order: HyperliquidOrder = {
+      asset: parsedAsset.data,
+      side: body.side,
+      size: body.size,
+      limitPx: policyLimitPx,
+      leverage: effectiveLeverage,
+      reduceOnly: body.reduceOnly,
+      ...(body.orderType ? { orderType: body.orderType } : {}),
+    };
+    // SEC-184: enforce the adapter contract check (the result was previously
+    // discarded) BEFORE reserving spend or signing. Every field is already
+    // validated upstream, so a failure here is an internal inconsistency —
+    // fail closed.
+    const parsedOrder = hyperliquidOrderSchema.safeParse(order);
+    if (!parsedOrder.success) {
+      return rejectPolicy(
+        `order-schema: ${parsedOrder.error.issues[0]?.message ?? "invalid order"}`,
+        sizeUsd,
+        policyLimitPx,
+      );
+    }
+
     const walletAddress = session.walletId;
     const manager = getSessionManager();
     const fenced = await manager.withActiveSubmissionFence(
@@ -1100,16 +1122,6 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
             vault.signTypedData({ ...input, tenantId, venue: "hyperliquid" }),
         };
         const adapter = new HyperliquidAdapter(vaultClient, agentId, walletAddress);
-        const order: HyperliquidOrder = {
-          asset: parsedAsset.data,
-          side: body.side,
-          size: body.size,
-          limitPx: policyLimitPx,
-          leverage: effectiveLeverage,
-          reduceOnly: body.reduceOnly,
-          ...(body.orderType ? { orderType: body.orderType } : {}),
-        };
-        hyperliquidOrderSchema.safeParse(order);
         if (builderPerp) {
           try {
             await adapter.updateLeverage({

--- a/packages/plugin-trading/src/routes/trade.ts
+++ b/packages/plugin-trading/src/routes/trade.ts
@@ -18,7 +18,12 @@
 
 import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from "node:crypto";
 import { agentPolicies, eq, getDb, proxyAuditLog } from "@stwd/db";
-import { evaluateTradeOrder } from "@stwd/policy-engine";
+import {
+  assetAllowlistEvaluator,
+  evaluateTradeOrder,
+  tradeLeverageCapEvaluator,
+  tradeVenueAllowlistEvaluator,
+} from "@stwd/policy-engine";
 import { checkRateLimit } from "@stwd/redis";
 import type { ApiResponse, AppVariables } from "@stwd/shared";
 import { type TradeSession, TradeSessionManager } from "@stwd/trade-sessions";
@@ -1011,7 +1016,16 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
       );
     }
     if (limitPx === undefined) {
-      const preliminaryPolicy = orderPolicy(0);
+      // SEC-114: marketable order without an explicit limit — the notional is
+      // unknown until resolveSizingPx floors the price below, so the USD-cap
+      // evaluators cannot run yet (they fail closed on a zero estimate and
+      // would reject every market order). Pre-check venue/asset/leverage only;
+      // caps are still enforced on the sized notional right after.
+      const preliminaryPolicy = evaluateTradeOrder(
+        sessionPolicy,
+        { venue: "hyperliquid", asset: coin, leverage: effectiveLeverage },
+        [tradeVenueAllowlistEvaluator, assetAllowlistEvaluator, tradeLeverageCapEvaluator],
+      );
       if (!preliminaryPolicy.allow) {
         return rejectPolicy(preliminaryPolicy.reason ?? "order violates trading policy", 0);
       }

--- a/packages/plugin-trading/src/routes/trade.ts
+++ b/packages/plugin-trading/src/routes/trade.ts
@@ -512,7 +512,20 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
       return c.json<ApiResponse>({ ok: false, error: "agentId is required" }, 400);
     }
 
-    const status = await getAgentTokenStatus(agentId);
+    // SEC-091: fail closed against the cross-tenant agent/token oracle. An
+    // agent-scoped token may only query ITSELF; a tenant credential may only
+    // observe agents registered to ITS tenant. A foreign agent is reported
+    // exactly like a nonexistent one ("unknown"), so agent existence and
+    // token-expiry/observation state no longer leak across tenants.
+    if (!canAccessAgent(c, agentId)) {
+      return c.json<ApiResponse>(
+        { ok: false, error: "Forbidden: agent token cannot query another agent's token status" },
+        403,
+      );
+    }
+    const tenantId = c.get("tenantId");
+    const agent = tenantId ? await ensureAgentForTenant(tenantId, agentId) : undefined;
+    const status = agent ? await getAgentTokenStatus(agentId) : null;
     if (!status) {
       return c.json(
         responseData({

--- a/packages/plugin-trading/src/routes/trade.ts
+++ b/packages/plugin-trading/src/routes/trade.ts
@@ -52,6 +52,7 @@ import type { Context } from "hono";
 import { Hono } from "hono";
 import { z } from "zod";
 import type { StewardAppContext } from "../context";
+import { DurableIdempotencyStore } from "./idempotency";
 
 // Prediction-market session asset: pm:<tokenId> (a single outcome token) or
 // pm:cond:<conditionId> (a whole market). Mirrors @stwd/trade-sessions'
@@ -173,31 +174,19 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
   const tradeRoutes = new Hono<{ Variables: AppVariables }>();
 
   const memoryRateLimit = new Map<string, { count: number; resetAt: number }>();
-  const memoryIdempotency = new Map<
-    string,
-    { bodyHash: string; response: TradeIdempotencyResponse; expiresAt: number }
-  >();
-  const pmMemoryIdempotency = new Map<
-    string,
-    { bodyHash: string; response: TradeIdempotencyResponse; expiresAt: number }
-  >();
 
-  // The in-memory idempotency fallbacks are bounded (SEC-043): expired entries
-  // are swept on store and the oldest entries are evicted past the cap, so a
-  // caller minting unique keys cannot grow process memory without bound.
-  // (Mirrors evm-swap.ts's MAX_IDEMPOTENCY_ENTRIES.)
-  const MAX_MEMORY_IDEMPOTENCY_ENTRIES = 1_000;
-  function sweepMemoryIdempotency(
-    map: Map<string, { bodyHash: string; response: TradeIdempotencyResponse; expiresAt: number }>,
-    now: number,
-  ): void {
-    for (const [entryKey, entry] of map) {
-      if (entry.expiresAt <= now || map.size >= MAX_MEMORY_IDEMPOTENCY_ENTRIES) {
-        map.delete(entryKey);
-      }
-      if (map.size < MAX_MEMORY_IDEMPOTENCY_ENTRIES) break;
-    }
-  }
+  // SEC-043: idempotency records are Redis-backed when a client is available
+  // (multi-replica dedup survives restarts), with the bounded wave-2
+  // process-local map as the dev/single-replica fallback. Two namespaces so
+  // the Hyperliquid and Polymarket routes never collide on a shared key.
+  const hlIdempotencyStore = new DurableIdempotencyStore<TradeIdempotencyResponse>({
+    namespace: "trade:hl",
+    getRedisClient,
+  });
+  const pmIdempotencyStore = new DurableIdempotencyStore<TradeIdempotencyResponse>({
+    namespace: "trade:pm",
+    getRedisClient,
+  });
 
   function getSessionManager(): TradeSessionManager {
     return new TradeSessionManager({ redis: getRedisClient() });
@@ -349,35 +338,22 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
     return { allowed: true, resetMs: current.resetAt - now };
   }
 
-  function getIdempotency(
+  async function getIdempotency(
     tenantId: string,
     agentId: string,
     key: string | undefined,
     body: SubmitOrderBody,
-  ): {
+  ): Promise<{
     conflict?: boolean;
     response?: TradeIdempotencyResponse;
-    store?: (response: TradeIdempotencyResponse) => void;
-  } {
-    if (!key) return {};
-    const now = Date.now();
-    const mapKey = `${tenantId}:${agentId}:${key}`;
-    const bodyHash = hashBody({ ...body, idempotencyKey: undefined });
-    const existing = memoryIdempotency.get(mapKey);
-    if (existing && existing.expiresAt > now) {
-      if (existing.bodyHash !== bodyHash) return { conflict: true };
-      return { response: existing.response };
-    }
-    return {
-      store(response: TradeIdempotencyResponse) {
-        sweepMemoryIdempotency(memoryIdempotency, now);
-        memoryIdempotency.set(mapKey, {
-          bodyHash,
-          response,
-          expiresAt: now + 24 * 60 * 60 * 1000,
-        });
-      },
-    };
+    store?: (response: TradeIdempotencyResponse) => Promise<void>;
+  }> {
+    const check = await hlIdempotencyStore.check(
+      `${tenantId}:${agentId}`,
+      key,
+      hashBody({ ...body, idempotencyKey: undefined }),
+    );
+    return { conflict: check.conflict, response: check.record, store: check.store };
   }
 
   async function resolvePolicyLimitPx(
@@ -472,11 +448,11 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
   }
 
   async function completeTradeIdempotencyBestEffort(
-    idempotency: ReturnType<typeof getIdempotency>,
+    idempotency: Awaited<ReturnType<typeof getIdempotency>>,
     envelope: TradeIdempotencyResponse,
   ): Promise<void> {
     try {
-      idempotency.store?.(envelope);
+      await idempotency.store?.(envelope);
     } catch {
       // Idempotency replay is best effort for this in-memory fallback path.
     }
@@ -933,7 +909,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
       return c.json<ApiResponse>({ ok: false, error: "Idempotency-Key is required" }, 400);
     }
 
-    const idempotency = getIdempotency(tenantId, agentId, body.idempotencyKey, body);
+    const idempotency = await getIdempotency(tenantId, agentId, body.idempotencyKey, body);
     if (idempotency.conflict) {
       return c.json<ApiResponse>(
         { ok: false, error: "Idempotency key reused with a different body" },
@@ -1088,7 +1064,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
               error: "Trade session was revoked before order submission",
             },
           };
-          idempotency.store?.(envelope);
+          await idempotency.store?.(envelope);
           return envelope;
         }
 
@@ -1102,7 +1078,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
             status: 400,
             body: { ok: false, error: "Trade session cap exceeded" },
           };
-          idempotency.store?.(envelope);
+          await idempotency.store?.(envelope);
           return envelope;
         }
 
@@ -1156,7 +1132,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
                 error: "Failed to set leverage before order; order not submitted",
               },
             };
-            idempotency.store?.(envelope);
+            await idempotency.store?.(envelope);
             return envelope;
           }
           await auditTradeEvent(tenantId, agentId, "trade.order.leverage.set", {
@@ -1184,7 +1160,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
               error: "Trade session was revoked before order submission",
             },
           };
-          idempotency.store?.(envelope);
+          await idempotency.store?.(envelope);
           return envelope;
         }
 
@@ -1196,7 +1172,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
             status: 502,
             body: { ok: false, error: "Trade submission status unknown" },
           };
-          idempotency.store?.(envelope);
+          await idempotency.store?.(envelope);
           return envelope;
         }
 
@@ -1226,7 +1202,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
             orderId: result.orderId ?? null,
             reason: result.error ?? "Trade order rejected",
           });
-          idempotency.store?.(envelope);
+          await idempotency.store?.(envelope);
           return envelope;
         }
 
@@ -1285,7 +1261,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
         status: 409,
         body: { ok: false, error: "Trade session was revoked before order submission" },
       };
-      idempotency.store?.(envelope);
+      await idempotency.store?.(envelope);
       return c.json(envelope.body, envelope.status);
     }
     if (fenced instanceof Response) return fenced;
@@ -1309,36 +1285,23 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
   // ===========================================================================
 
   // Idempotency for the Polymarket body shape. Mirrors getIdempotency() but keyed
-  // for PmSubmitOrderBody so the two routes never collide on a shared map type.
-  function getPmIdempotency(
+  // for PmSubmitOrderBody so the two routes never collide on a shared namespace.
+  async function getPmIdempotency(
     tenantId: string,
     agentId: string,
     key: string | undefined,
     body: PmSubmitOrderBody,
-  ): {
+  ): Promise<{
     conflict?: boolean;
     response?: TradeIdempotencyResponse;
-    store?: (response: TradeIdempotencyResponse) => void;
-  } {
-    if (!key) return {};
-    const now = Date.now();
-    const mapKey = `${tenantId}:${agentId}:pm:${key}`;
-    const bodyHash = hashBody({ ...body, idempotencyKey: undefined });
-    const existing = pmMemoryIdempotency.get(mapKey);
-    if (existing && existing.expiresAt > now) {
-      if (existing.bodyHash !== bodyHash) return { conflict: true };
-      return { response: existing.response };
-    }
-    return {
-      store(response: TradeIdempotencyResponse) {
-        sweepMemoryIdempotency(pmMemoryIdempotency, now);
-        pmMemoryIdempotency.set(mapKey, {
-          bodyHash,
-          response,
-          expiresAt: now + 24 * 60 * 60 * 1000,
-        });
-      },
-    };
+    store?: (response: TradeIdempotencyResponse) => Promise<void>;
+  }> {
+    const check = await pmIdempotencyStore.check(
+      `${tenantId}:${agentId}`,
+      key,
+      hashBody({ ...body, idempotencyKey: undefined }),
+    );
+    return { conflict: check.conflict, response: check.record, store: check.store };
   }
 
   async function enforcePolymarketOrderRateLimit(
@@ -1710,7 +1673,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
       return c.json<ApiResponse>({ ok: false, error: "Idempotency-Key is required" }, 400);
     }
 
-    const idempotency = getPmIdempotency(tenantId, agentId, body.idempotencyKey, body);
+    const idempotency = await getPmIdempotency(tenantId, agentId, body.idempotencyKey, body);
     if (idempotency.conflict) {
       return c.json<ApiResponse>(
         { ok: false, error: "Idempotency key reused with a different body" },
@@ -1765,7 +1728,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
           status: 400,
           body: { code: "policy-violation", reason },
         };
-        idempotency.store?.(envelope);
+        await idempotency.store?.(envelope);
         return c.json(envelope.body, envelope.status);
       }
     } else {
@@ -1825,7 +1788,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
         status: 400,
         body: { code: "policy-violation", reason: check.reason },
       };
-      idempotency.store?.(envelope);
+      await idempotency.store?.(envelope);
       return c.json(envelope.body, envelope.status);
     }
 
@@ -1918,7 +1881,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
             status: 400,
             body: { ok: false, error: "Trade session cap exceeded" },
           };
-          idempotency.store?.(envelope);
+          await idempotency.store?.(envelope);
           return envelope;
         }
 
@@ -1968,7 +1931,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
             status: 400,
             body: { ok: false, error: "Order could not be built; not submitted" },
           };
-          idempotency.store?.(envelope);
+          await idempotency.store?.(envelope);
           return envelope;
         }
 
@@ -1990,7 +1953,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
               error: "Trade session was revoked before order submission",
             },
           };
-          idempotency.store?.(envelope);
+          await idempotency.store?.(envelope);
           return envelope;
         }
 
@@ -2034,7 +1997,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
               status: 400,
               body: { ok: false, error: "Trade submission could not be built" },
             };
-            idempotency.store?.(envelope);
+            await idempotency.store?.(envelope);
             return envelope;
           }
           // Otherwise the POST was attempted and the order may have landed —
@@ -2052,7 +2015,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
             status: 502,
             body: { ok: false, error: "Trade submission status unknown" },
           };
-          idempotency.store?.(envelope);
+          await idempotency.store?.(envelope);
           return envelope;
         }
 
@@ -2101,7 +2064,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
               data: { status: result.status ?? "rejected" },
             },
           };
-          idempotency.store?.(envelope);
+          await idempotency.store?.(envelope);
           return envelope;
         }
 
@@ -2138,7 +2101,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
         // The order HAS landed at the venue. Persist the idempotency record BEFORE
         // the audit write so a retry after an audit failure replays this response
         // instead of re-submitting a duplicate order.
-        idempotency.store?.(envelope);
+        await idempotency.store?.(envelope);
         // The audit write is best-effort here: the order is final + the response is
         // recorded, so an audit failure must NOT turn a successful fill into an
         // error to the client (which could prompt a duplicate retry). Log + proceed.
@@ -2171,7 +2134,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
         status: 409,
         body: { ok: false, error: "Trade session was revoked before order submission" },
       };
-      idempotency.store?.(envelope);
+      await idempotency.store?.(envelope);
       return c.json(envelope.body, envelope.status);
     }
     return c.json(fenced.body, fenced.status);

--- a/packages/plugin-trading/src/routes/trade.ts
+++ b/packages/plugin-trading/src/routes/trade.ts
@@ -16,6 +16,7 @@
  * /trade + /v1/trade.
  */
 
+import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from "node:crypto";
 import { agentPolicies, eq, getDb, proxyAuditLog } from "@stwd/db";
 import { evaluateTradeOrder } from "@stwd/policy-engine";
 import { checkRateLimit } from "@stwd/redis";
@@ -1384,21 +1385,83 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
     | { ok: false; reason: "wallet-not-found" | "creds-not-provisioned" | "derive-failed" };
 
   // L2 CLOB creds are derived from the L1 delegate signer and cached. They are
-  // SECRET; cache them only in Redis with a TTL (never in the DB here). The same
-  // signer deterministically yields the same creds, so a cache miss safely
-  // re-derives. TTL bounds exposure + tolerates a CLOB key rotation.
-  const PM_CREDS_CACHE_TTL_SECONDS = 6 * 60 * 60; // 6h
+  // SECRET; cache them only in Redis, ENCRYPTED, with a TTL (never in the DB
+  // here). The same signer deterministically yields the same creds, so a cache
+  // miss safely re-derives. TTL bounds exposure + tolerates a CLOB key rotation.
+  const PM_CREDS_CACHE_TTL_SECONDS = 60 * 60; // 1h (SEC-108: was 6h)
+
+  // SEC-108: the cached L2 creds carry full trading authority on the venue as
+  // the agent (outside Steward's session caps and audit), so they never touch
+  // the shared Redis in plaintext. The cache value is AES-256-GCM encrypted
+  // with a key scrypt-derived from STEWARD_MASTER_PASSWORD under a
+  // domain-separated label (same idiom as the webhook secret codec + embedded
+  // JWT derivation), so a process or tenant with read access to Redis cannot
+  // lift them. If no master password is configured the cache is SKIPPED
+  // entirely (fail closed: never write plaintext; re-derive per order).
+  const PM_CREDS_CACHE_PREFIX = "stwd_pmclob_v1:";
+  let pmCredsDerivedKey: { source: string; key: Buffer } | null = null;
+
+  function pmCredsCacheEncryptionKey(): Buffer | null {
+    const masterPassword = process.env.STEWARD_MASTER_PASSWORD;
+    if (!masterPassword) return null;
+    if (pmCredsDerivedKey?.source === masterPassword) return pmCredsDerivedKey.key;
+    const key = scryptSync(masterPassword, "steward-kdf:pm-clob-l2-cache:v1", 32) as Buffer;
+    pmCredsDerivedKey = { source: masterPassword, key };
+    return key;
+  }
+
+  function encryptPmCredsCacheValue(plaintext: string): string | null {
+    const key = pmCredsCacheEncryptionKey();
+    if (!key) return null;
+    const iv = randomBytes(12);
+    const cipher = createCipheriv("aes-256-gcm", key, iv);
+    let ciphertext = cipher.update(plaintext, "utf8", "hex");
+    ciphertext += cipher.final("hex");
+    return `${PM_CREDS_CACHE_PREFIX}${JSON.stringify({
+      ciphertext,
+      iv: iv.toString("hex"),
+      tag: cipher.getAuthTag().toString("hex"),
+    })}`;
+  }
+
+  // Returns null for anything that is not a valid envelope for THIS key —
+  // including legacy plaintext entries — so the caller treats it as a cache
+  // miss, re-derives, and overwrites with an encrypted value.
+  function decryptPmCredsCacheValue(stored: string): string | null {
+    if (!stored.startsWith(PM_CREDS_CACHE_PREFIX)) return null;
+    const key = pmCredsCacheEncryptionKey();
+    if (!key) return null;
+    try {
+      const payload = JSON.parse(stored.slice(PM_CREDS_CACHE_PREFIX.length)) as {
+        ciphertext: string;
+        iv: string;
+        tag: string;
+      };
+      const decipher = createDecipheriv("aes-256-gcm", key, Buffer.from(payload.iv, "hex"));
+      decipher.setAuthTag(Buffer.from(payload.tag, "hex"));
+      let plaintext = decipher.update(payload.ciphertext, "hex", "utf8");
+      plaintext += decipher.final("utf8");
+      return plaintext;
+    } catch {
+      return null;
+    }
+  }
 
   // Optional endpoint override for deterministic integration environments and
   // compatible CLOB gateways. It is deployment configuration, not a test-creds
   // bypass: the real clob-client still performs L1 derivation, EIP-712 signing,
   // L2 HMAC auth, and order serialization against the configured HTTP edge.
+  // SEC-111: in production the override must use https — a stray plain-http
+  // endpoint would send L1-signed derivations + L2 HMAC headers in cleartext.
   function configuredPolymarketClobUrl(): string | undefined {
     const raw = process.env.POLYMARKET_CLOB_API_URL?.trim();
     if (!raw) return undefined;
     const url = new URL(raw);
     if (url.protocol !== "http:" && url.protocol !== "https:") {
       throw new Error("POLYMARKET_CLOB_API_URL must use http or https");
+    }
+    if (process.env.NODE_ENV === "production" && url.protocol !== "https:") {
+      throw new Error("POLYMARKET_CLOB_API_URL must use https in production");
     }
     return url.toString().replace(/\/$/, "");
   }
@@ -1461,25 +1524,35 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
     }
 
     // 2) L2 CLOB apiCredentials. Test-only deterministic seam first (inert in prod).
+    // SEC-111: hard-disabled in production (same force-off idiom as the
+    // unsigned-webhook escape hatch) so a stray env var can never swap in the
+    // hardcoded test creds on a live deployment.
     if (process.env.STEWARD_PM_TEST_CREDS === "1") {
-      return {
-        ok: true,
-        apiCredentials: { key: "test-key", secret: "test-secret", passphrase: "test-pass" },
-        funderAddress,
-        walletAddress,
-        signatureType,
-        ...(clobUrl ? { clobUrl } : {}),
-      };
+      if (process.env.NODE_ENV === "production") {
+        console.error(
+          "[trade] STEWARD_PM_TEST_CREDS is set but ignored in production; real L2 creds stay required.",
+        );
+      } else {
+        return {
+          ok: true,
+          apiCredentials: { key: "test-key", secret: "test-secret", passphrase: "test-pass" },
+          funderAddress,
+          walletAddress,
+          signatureType,
+          ...(clobUrl ? { clobUrl } : {}),
+        };
+      }
     }
 
-    // 2a) Redis cache.
+    // 2a) Redis cache (encrypted at rest — SEC-108).
     const redis = getRedisClient();
     const cacheKey = pmCredsCacheKey(tenantId, agentId, walletAddress, clobUrl);
     if (redis) {
       try {
         const cached = await redis.get(cacheKey);
-        if (cached) {
-          const parsed = clobApiCredentialsSchema.safeParse(JSON.parse(cached));
+        const cachedPlaintext = cached ? decryptPmCredsCacheValue(cached) : null;
+        if (cachedPlaintext) {
+          const parsed = clobApiCredentialsSchema.safeParse(JSON.parse(cachedPlaintext));
           if (parsed.success) {
             return {
               ok: true,
@@ -1505,9 +1578,12 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
       return { ok: false, reason: "derive-failed" };
     }
     if (redis) {
-      await redis
-        .setex(cacheKey, PM_CREDS_CACHE_TTL_SECONDS, JSON.stringify(apiCredentials))
-        .catch(() => undefined);
+      // Fail closed: without cache encryption key material, skip the write and
+      // re-derive per order rather than ever storing the creds in plaintext.
+      const cacheValue = encryptPmCredsCacheValue(JSON.stringify(apiCredentials));
+      if (cacheValue) {
+        await redis.setex(cacheKey, PM_CREDS_CACHE_TTL_SECONDS, cacheValue).catch(() => undefined);
+      }
     }
 
     return {

--- a/packages/venue-hyperliquid/src/index.test.ts
+++ b/packages/venue-hyperliquid/src/index.test.ts
@@ -898,6 +898,56 @@ describe("Hyperliquid withdraw (user-signed action)", () => {
       signature: signed.signature,
     });
   });
+
+  test("SEC-113: submitWithdraw applies the default fetch timeout (and respects a caller signal)", async () => {
+    const account = privateKeyToAccount(PRIVATE_KEY);
+    const adapter = new HyperliquidAdapter(
+      {
+        async signTypedData(i) {
+          return account.signTypedData({
+            domain: i.domain,
+            types: i.types,
+            primaryType: i.primaryType,
+            message: i.value,
+          });
+        },
+      },
+      "sol",
+      WALLET,
+      { transport: { fetch: async () => new Response("{}", { status: 200 }) } },
+    );
+    const signed = await adapter.signWithdraw({
+      amount: "100",
+      destination: "0xABCDEF0123456789abcdef0123456789ABCDEF01",
+      time: NONCE,
+    });
+
+    // No caller signal -> the venue default timeout is applied.
+    let seenSignal: unknown;
+    await adapter.submitWithdraw(signed, {
+      transport: {
+        async fetch(_input, init) {
+          seenSignal = init?.signal;
+          return new Response(JSON.stringify({ status: "ok" }), { status: 200 });
+        },
+      },
+    });
+    expect(seenSignal).toBeInstanceOf(AbortSignal);
+
+    // A caller-provided signal is never overridden.
+    const callerSignal = new AbortController().signal;
+    seenSignal = undefined;
+    await adapter.submitWithdraw(signed, {
+      transport: {
+        async fetch(_input, init) {
+          seenSignal = init?.signal;
+          return new Response(JSON.stringify({ status: "ok" }), { status: 200 });
+        },
+      },
+      signal: callerSignal,
+    });
+    expect(seenSignal).toBe(callerSignal);
+  });
 });
 
 describe("Hyperliquid close-all", () => {

--- a/packages/venue-hyperliquid/src/index.test.ts
+++ b/packages/venue-hyperliquid/src/index.test.ts
@@ -28,6 +28,7 @@ import {
   toUpdateIsolatedMarginAction,
   toUsdSendAction,
   toWithdrawAction,
+  validateBuilderFeeEnv,
 } from "./index";
 
 const PRIVATE_KEY = "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" as const;
@@ -145,6 +146,35 @@ describe("Hyperliquid L1 signing", () => {
       expect(() =>
         toExchangeAction({ coin: "BTC", side: "buy", size: 0.02, limitPx: "30000" }),
       ).toThrow();
+    } finally {
+      if (oldAddress === undefined) delete process.env.HL_BUILDER_ADDRESS;
+      else process.env.HL_BUILDER_ADDRESS = oldAddress;
+      if (oldFee === undefined) delete process.env.HL_BUILDER_FEE_TENTHS_BP;
+      else process.env.HL_BUILDER_FEE_TENTHS_BP = oldFee;
+    }
+  });
+
+  test("SEC-186: validateBuilderFeeEnv fails fast on malformed env, no-ops when unconfigured", () => {
+    const oldAddress = process.env.HL_BUILDER_ADDRESS;
+    const oldFee = process.env.HL_BUILDER_FEE_TENTHS_BP;
+    try {
+      delete process.env.HL_BUILDER_ADDRESS;
+      delete process.env.HL_BUILDER_FEE_TENTHS_BP;
+      expect(() => validateBuilderFeeEnv()).not.toThrow();
+
+      process.env.HL_BUILDER_ADDRESS = "0xABCDEF0123456789abcdef0123456789ABCDEF01";
+      process.env.HL_BUILDER_FEE_TENTHS_BP = "10";
+      expect(() => validateBuilderFeeEnv()).not.toThrow();
+
+      process.env.HL_BUILDER_FEE_TENTHS_BP = "101";
+      expect(() => validateBuilderFeeEnv()).toThrow(/Invalid HL builder fee configuration/);
+
+      process.env.HL_BUILDER_FEE_TENTHS_BP = "10.5";
+      expect(() => validateBuilderFeeEnv()).toThrow(/Invalid HL builder fee configuration/);
+
+      process.env.HL_BUILDER_ADDRESS = "not-an-address";
+      process.env.HL_BUILDER_FEE_TENTHS_BP = "10";
+      expect(() => validateBuilderFeeEnv()).toThrow(/Invalid HL builder fee configuration/);
     } finally {
       if (oldAddress === undefined) delete process.env.HL_BUILDER_ADDRESS;
       else process.env.HL_BUILDER_ADDRESS = oldAddress;

--- a/packages/venue-hyperliquid/src/index.ts
+++ b/packages/venue-hyperliquid/src/index.ts
@@ -91,6 +91,28 @@ export const builderFeeSchema = z.object({
 });
 export type HyperliquidBuilderFee = z.infer<typeof builderFeeSchema>;
 
+/**
+ * SEC-186: validate the HL builder-fee env config at startup (the trading
+ * plugin calls this from `register`) so a malformed HL_BUILDER_ADDRESS /
+ * HL_BUILDER_FEE_TENTHS_BP fails fast at boot instead of throwing from
+ * `configuredBuilderFee()` at order time. Unset (or partially set — treated
+ * as "not configured", same as `configuredBuilderFee`) is a no-op.
+ */
+export function validateBuilderFeeEnv(): void {
+  const address = process.env.HL_BUILDER_ADDRESS;
+  const rawFee = process.env.HL_BUILDER_FEE_TENTHS_BP;
+  if (!address || rawFee === undefined || rawFee === "") return;
+  const result = builderFeeSchema.safeParse({ address, feeTenthsBps: Number(rawFee) });
+  if (!result.success) {
+    throw new Error(
+      `Invalid HL builder fee configuration (HL_BUILDER_ADDRESS / HL_BUILDER_FEE_TENTHS_BP): ${
+        result.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; ") ??
+        "malformed"
+      }`,
+    );
+  }
+}
+
 export const hyperliquidOrderSchema = z.object({
   coin: hyperliquidAssetSchema.optional(),
   asset: hyperliquidAssetSchema.optional(),
@@ -106,6 +128,12 @@ export const hyperliquidOrderSchema = z.object({
   reduceOnly: z.boolean().default(false),
   leverage: z.number().positive().max(50).optional(),
   nonce: z.number().int().positive().optional(),
+  // SEC-186 precedence: an order-supplied builder OVERRIDES the
+  // HL_BUILDER_ADDRESS / HL_BUILDER_FEE_TENTHS_BP env config (see
+  // exchangeActionFromNormalized). The hosted trade route never forwards a
+  // caller-supplied builder, so over the API the env config always wins;
+  // direct library consumers should pass `builder` only for their own
+  // (operator-approved, <=10 bps) fee recipient.
   builder: builderFeeSchema.optional(),
 });
 export type HyperliquidOrder = z.input<typeof hyperliquidOrderSchema>;
@@ -559,6 +587,8 @@ function normalizedAddIsolatedMargin(input: AddIsolatedMarginInput) {
 function exchangeActionFromNormalized(
   o: ReturnType<typeof normalized>,
   asset: AssetResolution,
+  // SEC-186 precedence: the order's own builder fee (first) wins over the
+  // env-configured builder fee. See hyperliquidOrderSchema.builder.
   builder = o.builder ?? configuredBuilderFee(),
 ): Record<string, unknown> {
   const action: Record<string, unknown> = {

--- a/packages/venue-hyperliquid/src/index.ts
+++ b/packages/venue-hyperliquid/src/index.ts
@@ -946,15 +946,23 @@ export function toWithdrawAction(params: WithdrawParams): Record<string, unknown
 
 export async function submitWithdraw(
   signed: SignedWithdraw,
-  options: { transport?: HyperliquidTransport; baseUrl?: string } = {},
+  options: { transport?: HyperliquidTransport; baseUrl?: string; signal?: AbortSignal } = {},
 ) {
   const transport = options.transport ?? { fetch };
   const baseUrl = options.baseUrl ?? DEFAULT_BASE_URL;
-  const r = await transport.fetch(`${baseUrl}/exchange`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(signedWithdrawSchema.parse(signed)),
-  });
+  // SEC-113: every other venue call goes through withTimeoutSignal; a stalled
+  // HL endpoint must not hang the operator withdraw request (or extend the
+  // submission-fence advisory-lock hold for fenced callers). A caller-provided
+  // signal always takes precedence over the default timeout.
+  const r = await transport.fetch(
+    `${baseUrl}/exchange`,
+    withTimeoutSignal({
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(signedWithdrawSchema.parse(signed)),
+      signal: options.signal,
+    }),
+  );
   const j = await r.json().catch(() => null);
   if (!r.ok) throw new Error(`Hyperliquid exchange returned ${r.status}: ${JSON.stringify(j)}`);
   return j;
@@ -1516,8 +1524,15 @@ export class HyperliquidAdapter {
       signature: { r: s.r, s: s.s, v: Number(s.v) },
     });
   }
-  submitWithdraw(signed: SignedWithdraw) {
-    return submitWithdraw(signed, { transport: this.transport, baseUrl: this.baseUrl });
+  submitWithdraw(
+    signed: SignedWithdraw,
+    options: { transport?: HyperliquidTransport; baseUrl?: string; signal?: AbortSignal } = {},
+  ) {
+    return submitWithdraw(signed, {
+      transport: options.transport ?? this.transport,
+      baseUrl: options.baseUrl ?? this.baseUrl,
+      signal: options.signal,
+    });
   }
   // Build a reduce-only market order on the OPPOSITE side of the open position
   // (long => sell, short => buy), sized abs(szi), then sign + submit it.

--- a/packages/venue-polymarket/src/execution.ts
+++ b/packages/venue-polymarket/src/execution.ts
@@ -127,12 +127,24 @@ function isAmbiguousPostError(raw: RawPostOrderResult): boolean {
 // filled 20-share order is never reported as 20_000_000.
 const BASE_UNIT_SCALE = 1e6;
 // Above this magnitude an "amount of shares/USD" is implausibly large for a
-// human unit and is almost certainly a 6-decimal base-unit value.
+// human unit and is almost certainly a 6-decimal base-unit value. Only used
+// when the order-size context cannot disambiguate (SEC-187).
 const BASE_UNIT_DETECT_THRESHOLD = 1e6;
+// Slack for venue rounding when bounding a fill by the signed order size.
+const FILL_ORDER_SIZE_TOLERANCE = 1.005;
 
-function normalizeFillUnit(value: number): number {
-  // The price ratio is unit-invariant; only absolute amounts need scaling. If a
-  // value is in base-unit magnitude, scale it down to human units.
+function normalizeFillUnit(value: number, orderSizeShares: number): number {
+  // SEC-187: derive the unit from the ORDER context instead of a bare
+  // magnitude guess. A fill can never exceed the signed order size, so:
+  //  - value fits the order size            -> human units (return as-is, even
+  //    for a genuine >=1M-share fill the magnitude heuristic shrank 1e6x);
+  //  - value exceeds it but fits scaled-down -> 6-dec base units (scale down,
+  //    even for sub-1e6 base-unit values the heuristic passed through as-is);
+  //  - exceeds it under BOTH interpretations -> inconsistent venue data; fall
+  //    back to the magnitude heuristic (trusted venue, accounting-only).
+  const allowance = orderSizeShares * FILL_ORDER_SIZE_TOLERANCE;
+  if (value <= allowance) return value;
+  if (value / BASE_UNIT_SCALE <= allowance) return value / BASE_UNIT_SCALE;
   return value >= BASE_UNIT_DETECT_THRESHOLD ? value / BASE_UNIT_SCALE : value;
 }
 
@@ -142,7 +154,9 @@ function normalizeFillUnit(value: number): number {
  *
  * actualPrice = making/taking is unit-invariant (the 1e6 scale cancels), so it
  * is computed on the RAW amounts. actualAmount is normalized to human units
- * (shares) so callers never record base-unit-inflated sizes.
+ * (shares) so callers never record base-unit-inflated sizes. The unit is
+ * derived from the order context (fallback.amount — the signed order size in
+ * shares at the call site): a fill can never exceed it (SEC-187).
  *
  * Cases:
  *  - amounts MISSING/unparsable -> use fallback (accepted-no-amounts case).
@@ -170,14 +184,14 @@ export function deriveActualFill(
   if (side === "buy") {
     // BUY: taking = shares acquired, making = USD spent. price = making/taking.
     return {
-      actualAmount: normalizeFillUnit(takingAmount),
+      actualAmount: normalizeFillUnit(takingAmount, fallback.amount),
       actualPrice: makingAmount / takingAmount,
     };
   }
   // SELL: making = shares sold, taking = USD received. price = taking/making.
   // (Zero amounts already handled above as the resting/unfilled case.)
   return {
-    actualAmount: normalizeFillUnit(makingAmount),
+    actualAmount: normalizeFillUnit(makingAmount, fallback.amount),
     actualPrice: takingAmount / makingAmount,
   };
 }

--- a/packages/venue-polymarket/src/index.test.ts
+++ b/packages/venue-polymarket/src/index.test.ts
@@ -96,7 +96,9 @@ describe("deriveActualFill", () => {
     const r = deriveActualFill(
       "buy",
       { makingAmount: "10", takingAmount: "20" },
-      { amount: 10, price: 0.5 },
+      // Order size context: a 20-share buy (10 USDC at 0.5). The fill can never
+      // exceed the signed size, so 20 reads as human units.
+      { amount: 20, price: 0.5 },
     );
     expect(r.actualAmount).toBe(20);
     expect(r.actualPrice).toBeCloseTo(0.5, 10);
@@ -163,6 +165,29 @@ describe("deriveActualFill", () => {
       { amount: 7, price: 0.42 },
     );
     expect(r).toEqual({ actualAmount: 7, actualPrice: 0.42 });
+  });
+
+  test("SEC-187: a genuine >=1M-share fill in human units is NOT shrunk by the magnitude heuristic", () => {
+    // 2,000,000-share order filled in full, reported in human units.
+    const r = deriveActualFill(
+      "buy",
+      { makingAmount: "1000000", takingAmount: "2000000" },
+      { amount: 2_000_000, price: 0.5 },
+    );
+    expect(r.actualAmount).toBe(2_000_000); // NOT 2
+    expect(r.actualPrice).toBeCloseTo(0.5, 10);
+  });
+
+  test("SEC-187: a sub-1e6 base-unit fill is scaled down via order-size context", () => {
+    // 0.5-share fill on a 1-share order, reported as 6-decimal base units —
+    // below the old magnitude threshold yet still base units.
+    const r = deriveActualFill(
+      "buy",
+      { makingAmount: "250000", takingAmount: "500000" },
+      { amount: 1, price: 0.5 },
+    );
+    expect(r.actualAmount).toBe(0.5); // NOT 500000
+    expect(r.actualPrice).toBeCloseTo(0.5, 10);
   });
 });
 


### PR DESCRIPTION
## Summary

Wave-2b (trading batch) of the security audit: the deferred LOW/INFO remainder from PR #326, plus the SEC-043 durable-idempotency follow-up called out in that PR's design notes. Scope: `packages/plugin-trading`, `packages/venue-hyperliquid`, `packages/venue-polymarket`, `packages/agent-trader`.

| SEC ID | Severity | Status | Change |
|---|---|---|---|
| SEC-043 | MEDIUM | **FIXED** (follow-up completed) | Operator-route **and** HL/PM order idempotency are now backed by a durable store (`routes/idempotency.ts`): Redis when a client is available — multi-replica dedup survives restarts, 24h `PX` TTL, `idempotency:<ns>:<scope>:<key>` — with the bounded wave-2 in-memory map as the dev/single-replica fallback (mirrors the routes' rate limiters; production always has durable stores per `assertAuthStoresAreSafe`). Redis errors **fail closed on check** (never execute without the dedup record) and log-and-continue on store (the movement already executed; caller gets the real outcome). |
| SEC-091 | LOW | FIXED | `GET /trade/token-status` tenant-scoped (cross-tenant agent/token oracle closed). |
| SEC-108 | LOW | FIXED | Polymarket L2 HMAC creds cache encrypted at rest in Redis (was plaintext, 6h). |
| SEC-110 | LOW | FIXED | agent-trader webhook log redaction now recurses into arrays. |
| SEC-111 | LOW | FIXED | `STEWARD_PM_TEST_CREDS` / `POLYMARKET_CLOB_API_URL` production guards. |
| SEC-113 | LOW | FIXED | `submitWithdraw` goes through `withTimeoutSignal` like every other venue call; caller-supplied `AbortSignal` takes precedence over the default timeout (adapter method now forwards options). |
| SEC-114 | LOW | FIXED | Market orders (no `limitPx`) no longer die in the preliminary policy check: it now evaluates venue/asset/leverage only; USD-cap evaluators still run on the sized notional right after (fail-closed preserved). |
| SEC-184 | INFO | FIXED | Discarded `hyperliquidOrderSchema.safeParse(order)` is now **enforced**, hoisted before spend reservation/signing (a failure is an internal inconsistency → policy-rejected, audited). |
| SEC-185 | INFO | FIXED | `slippageBps` clamped to the agent-trader doctrine `[0, 5000)` (was `≤ 10_000`, i.e. 100% slippage → `minAmountOut ≈ 0`). |
| SEC-186 | INFO | FIXED (docs + startup validation) | Precedence documented on `hyperliquidOrderSchema.builder` / `exchangeActionFromNormalized`: order-supplied `builder` overrides the env config for library consumers; the hosted route never forwards it. New `validateBuilderFeeEnv()` is called from the trading plugin's `register()`, so a malformed `HL_BUILDER_ADDRESS`/`HL_BUILDER_FEE_TENTHS_BP` fails fast at boot instead of at order time. |
| SEC-187 | INFO | FIXED | PM fill-unit detection now derives the unit from order context (a fill can never exceed the signed order size) instead of a bare magnitude guess: genuine ≥1M-share fills are no longer shrunk 1e6×, and sub-1e6 base-unit fills are no longer passed through raw. Falls back to the old magnitude heuristic only when both interpretations exceed the order size (inconsistent venue data; accounting-only). |
| SEC-188 | INFO | FIXED | `loadJsonConfig` throws when the config file exists but doesn't parse (missing file still supported for env-only config); `agentId → walletAddress` cache entries now expire (5-min TTL) so wallet rotation is picked up. |

No WONTFIX items. No DEFERRED items.

## Trade-offs / notes

- **SEC-043 scope:** covers the operator-recovery routes + HL/PM order routes (all the maps the audit named). `evm-swap.ts`'s map also holds in-flight `Promise`s for request coalescing, which a plain KV record can't represent — it stays in-memory (bounded since wave-2); its prepare route is policy-gated pre-sign so the double-execution blast radius is quote/simulation work, not fund movement.
- **SEC-043 known residual (pre-existing, unchanged):** two same-key requests in flight *concurrently* can both pass the check before either stores (true of the wave-2 maps too). Claim-before-execute (`SET NX` pending markers) is possible follow-up hardening; it changes pending-replay semantics and was out of scope here.
- **SEC-043 without Redis** (dev / single-replica): behavior is exactly the bounded wave-2 maps — restart/multi-replica dedup requires Redis, same doctrine as the auth stores.
- **SEC-186:** a *partially* set builder env (address without fee) keeps the current "not configured" semantics rather than failing boot — deliberate, to avoid breaking existing deployments.
- **SEC-187:** one pre-existing test fixture was corrected (`fallback.amount` 10 → 20 for a 20-share fill; the old fixture described an impossible fill-bigger-than-order case).
- `bun.lock` churn from `bun install` is intentionally **not** committed.

## How tested

New regression tests (verified to fail without the fix where the harness allows — SEC-114 verified via stash):
- `venue-hyperliquid/src/index.test.ts` — SEC-113 default-timeout + caller-signal precedence; SEC-186 `validateBuilderFeeEnv` valid/invalid/unset matrix.
- `plugin-trading/src/__tests__/trade-policy-audit.test.ts` — SEC-114 market order sized from the live book then cap-rejected with the real notional (was: misleading "estimated order USD is required"); market order still leverage/asset/venue pre-checked.
- `plugin-trading/src/__tests__/evm-swap-prepare.test.ts` — SEC-185 rejects 5_000 and 10_000 bps, accepts 4_999.
- `venue-polymarket/src/index.test.ts` — SEC-187 ≥1M-share human-unit fill not shrunk; sub-1e6 base-unit fill scaled down.
- `agent-trader/src/__tests__/config.test.ts` — SEC-188 malformed file throws, missing file loads, valid file loads.
- `agent-trader/src/__tests__/loop-wallet-cache.test.ts` — SEC-188 cache reuse within TTL, rotation picked up after expiry.
- `plugin-trading/src/__tests__/idempotency-store.test.ts` — SEC-043 cross-instance (restart/second-replica) replay via shared Redis, conflict detection, 24h `PX` TTL, fail-closed on check error, swallow-and-log on store error, memory-fallback semantics, no-key passthrough.

Suites (all green): venue-hyperliquid + venue-polymarket 97/97; plugin-trading operator + idempotency 40/40; plugin-trading trade/evm-swap 57/57; agent-trader 51/51. `bunx tsc --noEmit` clean on all four touched packages; `bunx biome check` clean on all changed files.

Pre-existing issues (confirmed identical with this branch's changes stashed; NOT caused by this PR):
- `trade-session-policy-integration.test.ts` (2 tests) fails when run without a file that sets `STEWARD_AUDIT_HMAC_KEY` — cross-file env coupling.
- Running `operator-recovery.test.ts` in the same `bun test` process as `trade-policy-audit.test.ts` fails 2 tests: `mock.module("@stwd/venue-hyperliquid", …)` leaks across files (the mock adapter lacks `signOrder`). Run in separate processes, both are green.
- `packages/sdk` needs `bun run build` before agent-trader tests resolve `@stwd/sdk` (dist-based entry) in a fresh worktree.
