### PR TITLE
fix(ci): minimize release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,11 +9,10 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    # contents:write is required to create GitHub Releases
-    # packages:write for GHCR (docker workflow handles this separately, but good to have)
+    # contents:write is required to create GitHub Releases. npm publishing uses
+    # NPM_TOKEN, while GHCR publishing is isolated to the Docker workflow.
     permissions:
       contents: write
-      packages: write
 
     steps:
       # Checkout the full repo


### PR DESCRIPTION
## Summary

- remove unused `packages: write` from the release job
- retain only `contents: write`, required for GitHub Release creation
- keep npm publishing on `NPM_TOKEN`; GHCR remains isolated to the Docker workflow

This preserves the least-privilege repair found while auditing #337 without taking the now-policy-blocked routine major action upgrade. Supersedes #337.

## Validation

- `actionlint .github/workflows/release.yml`
- `git diff --check`
