### PR TITLE
fix(approvals): filter agent queues before pagination

### DIFF
--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -75913,7 +75913,7 @@
           "Approvals"
         ],
         "summary": "List manual approval queue entries",
-        "description": "Requires an owner/admin browser session with recent MFA. Tenant API keys and agent tokens cannot review or mutate manual approvals. Supports status and tenant-scoped agent filters before limit/offset pagination.",
+        "description": "Requires an owner/admin browser session with recent MFA. Tenant API keys and agent tokens cannot review or mutate manual approvals. Supports status and tenant-scoped agent filters before stable (requestedAt, id) keyset pagination.",
         "security": [
           {
             "bearerAuth": []
@@ -75962,6 +75962,25 @@
               "type": "integer",
               "minimum": 0,
               "maximum": 10000
+            }
+          },
+          {
+            "name": "cursorRequestedAt",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "cursorId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 128
             }
           }
         ],

--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -75913,7 +75913,7 @@
           "Approvals"
         ],
         "summary": "List manual approval queue entries",
-        "description": "Requires an owner/admin browser session with recent MFA. Tenant API keys and agent tokens cannot review or mutate manual approvals. Supports status, limit, and offset filters.",
+        "description": "Requires an owner/admin browser session with recent MFA. Tenant API keys and agent tokens cannot review or mutate manual approvals. Supports status and tenant-scoped agent filters before limit/offset pagination.",
         "security": [
           {
             "bearerAuth": []
@@ -75932,6 +75932,16 @@
                 "rejected",
                 "all"
               ]
+            }
+          },
+          {
+            "name": "agentId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 64
             }
           },
           {

--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -75980,7 +75980,7 @@
             "schema": {
               "type": "string",
               "minLength": 1,
-              "maxLength": 128
+              "maxLength": 64
             }
           }
         ],

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -75913,7 +75913,7 @@
           "Approvals"
         ],
         "summary": "List manual approval queue entries",
-        "description": "Requires an owner/admin browser session with recent MFA. Tenant API keys and agent tokens cannot review or mutate manual approvals. Supports status and tenant-scoped agent filters before limit/offset pagination.",
+        "description": "Requires an owner/admin browser session with recent MFA. Tenant API keys and agent tokens cannot review or mutate manual approvals. Supports status and tenant-scoped agent filters before stable (requestedAt, id) keyset pagination.",
         "security": [
           {
             "bearerAuth": []
@@ -75962,6 +75962,25 @@
               "type": "integer",
               "minimum": 0,
               "maximum": 10000
+            }
+          },
+          {
+            "name": "cursorRequestedAt",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "cursorId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 128
             }
           }
         ],

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -75913,7 +75913,7 @@
           "Approvals"
         ],
         "summary": "List manual approval queue entries",
-        "description": "Requires an owner/admin browser session with recent MFA. Tenant API keys and agent tokens cannot review or mutate manual approvals. Supports status, limit, and offset filters.",
+        "description": "Requires an owner/admin browser session with recent MFA. Tenant API keys and agent tokens cannot review or mutate manual approvals. Supports status and tenant-scoped agent filters before limit/offset pagination.",
         "security": [
           {
             "bearerAuth": []
@@ -75932,6 +75932,16 @@
                 "rejected",
                 "all"
               ]
+            }
+          },
+          {
+            "name": "agentId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 64
             }
           },
           {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -75980,7 +75980,7 @@
             "schema": {
               "type": "string",
               "minLength": 1,
-              "maxLength": 128
+              "maxLength": 64
             }
           }
         ],

--- a/packages/api/src/__tests__/approvals.test.ts
+++ b/packages/api/src/__tests__/approvals.test.ts
@@ -26,6 +26,9 @@ const TEST_TX_APPROVE = `test-tx-approve-${RUN_ID}`;
 const TEST_TX_DENY = `test-tx-deny-${RUN_ID}`;
 const TEST_APPROVAL_APPROVE = `test-approval-approve-${RUN_ID}`;
 const TEST_APPROVAL_DENY = `test-approval-deny-${RUN_ID}`;
+const PAGINATION_OTHER_AGENT = `approval-page-other-${RUN_ID}`;
+const PAGINATION_TARGET_TX = `approval-page-target-tx-${RUN_ID}`;
+const PAGINATION_TARGET_APPROVAL = `approval-page-target-${RUN_ID}`;
 const OWNER_USER_ID = crypto.randomUUID();
 
 let validApiKey: string;
@@ -110,15 +113,61 @@ beforeAll(async () => {
       status: "pending",
     })
     .onConflictDoNothing();
+
+  await db.insert(agents).values({
+    id: PAGINATION_OTHER_AGENT,
+    tenantId: TEST_TENANT,
+    name: "Pagination Noise Agent",
+    walletAddress: "0x2234567890123456789012345678901234567890",
+  });
+  await db.insert(transactions).values({
+    id: PAGINATION_TARGET_TX,
+    agentId: TEST_AGENT,
+    status: "pending",
+    toAddress: "0x0000000000000000000000000000000000000001",
+    value: "1",
+    chainId: 84532,
+    createdAt: new Date("2025-01-01T00:00:00.000Z"),
+  });
+  await db.insert(approvalQueue).values({
+    id: PAGINATION_TARGET_APPROVAL,
+    txId: PAGINATION_TARGET_TX,
+    agentId: TEST_AGENT,
+    status: "pending",
+    requestedAt: new Date("2025-01-01T00:00:00.000Z"),
+  });
+
+  const noiseTransactions = Array.from({ length: 51 }, (_, index) => ({
+    id: `approval-noise-tx-${RUN_ID}-${index}`,
+    agentId: PAGINATION_OTHER_AGENT,
+    status: "pending" as const,
+    toAddress: "0x0000000000000000000000000000000000000002",
+    value: "1",
+    chainId: 84532,
+    createdAt: new Date(`2026-01-01T00:${String(index).padStart(2, "0")}:00.000Z`),
+  }));
+  await db.insert(transactions).values(noiseTransactions);
+  await db.insert(approvalQueue).values(
+    noiseTransactions.map((transaction, index) => ({
+      id: `approval-noise-${RUN_ID}-${index}`,
+      txId: transaction.id,
+      agentId: PAGINATION_OTHER_AGENT,
+      status: "pending" as const,
+      requestedAt: transaction.createdAt,
+    })),
+  );
 });
 
 afterAll(async () => {
   if (SKIP) return;
   const db = getDb();
+  await db.delete(approvalQueue).where(eq(approvalQueue.agentId, PAGINATION_OTHER_AGENT));
+  await db.delete(transactions).where(eq(transactions.agentId, PAGINATION_OTHER_AGENT));
   await db.delete(approvalQueue).where(eq(approvalQueue.agentId, TEST_AGENT));
   await db.delete(transactions).where(eq(transactions.agentId, TEST_AGENT));
   await db.delete(autoApprovalRules).where(eq(autoApprovalRules.tenantId, TEST_TENANT));
   await db.delete(agents).where(eq(agents.id, TEST_AGENT));
+  await db.delete(agents).where(eq(agents.id, PAGINATION_OTHER_AGENT));
   await db.delete(userTenants).where(eq(userTenants.tenantId, TEST_TENANT));
   await db.delete(users).where(eq(users.id, OWNER_USER_ID));
   await db.delete(tenants).where(eq(tenants.id, TEST_TENANT));
@@ -167,6 +216,34 @@ describe.skipIf(SKIP)("Approval Workflow API", () => {
       expect(body.ok).toBe(true);
       // No approvals should be approved yet
       expect(body.data.length).toBe(0);
+    });
+
+    it("filters by agent before pagination when 51 newer mixed-agent rows exist", async () => {
+      const unfiltered = await fetch(`${BASE_URL}/approvals?status=pending&limit=50`, {
+        headers: adminHeaders(),
+      });
+      expect(unfiltered.status).toBe(200);
+      const unfilteredBody = await unfiltered.json();
+      expect(unfilteredBody.data).toHaveLength(50);
+      expect(
+        unfilteredBody.data.some(
+          (entry: { id: string }) => entry.id === PAGINATION_TARGET_APPROVAL,
+        ),
+      ).toBe(false);
+
+      const filtered = await fetch(
+        `${BASE_URL}/approvals?status=pending&agentId=${encodeURIComponent(TEST_AGENT)}&limit=50`,
+        { headers: adminHeaders() },
+      );
+      expect(filtered.status).toBe(200);
+      const filteredBody = await filtered.json();
+      expect(filteredBody.data.length).toBeGreaterThanOrEqual(1);
+      expect(
+        filteredBody.data.every((entry: { agentId: string }) => entry.agentId === TEST_AGENT),
+      ).toBe(true);
+      expect(
+        filteredBody.data.some((entry: { id: string }) => entry.id === PAGINATION_TARGET_APPROVAL),
+      ).toBe(true);
     });
   });
 

--- a/packages/api/src/__tests__/approvals.test.ts
+++ b/packages/api/src/__tests__/approvals.test.ts
@@ -14,7 +14,7 @@ import {
   users,
   userTenants,
 } from "@stwd/db";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { createSessionToken } from "../routes/auth";
 
 const TEST_PORT = parseInt(process.env.PORT || "3200", 10);
@@ -284,6 +284,40 @@ describe.skipIf(SKIP)("Approval Workflow API", () => {
       expect(second.status).toBe(200);
       const secondBody = await second.json();
       expect(secondBody.data.every((entry: { id: string }) => entry.id !== boundary.id)).toBe(true);
+    });
+
+    it("does not skip approvals whose database timestamps differ below JSON precision", async () => {
+      const db = getDb();
+      // Put the lexically smaller ID later at microsecond precision. The API
+      // serializes both values as .123Z, so a correct keyset must deliberately
+      // order and compare at that same precision and then use ID as its tie.
+      await db.execute(sql`
+        UPDATE approval_queue
+        SET requested_at = CASE id
+          WHEN ${TEST_APPROVAL_APPROVE} THEN TIMESTAMPTZ '2030-01-01 00:00:00.123900+00'
+          WHEN ${TEST_APPROVAL_DENY} THEN TIMESTAMPTZ '2030-01-01 00:00:00.123100+00'
+        END
+        WHERE id IN (${TEST_APPROVAL_APPROVE}, ${TEST_APPROVAL_DENY})
+      `);
+
+      const first = await fetch(
+        `${BASE_URL}/approvals?status=pending&agentId=${encodeURIComponent(TEST_AGENT)}&limit=1`,
+        { headers: adminHeaders() },
+      );
+      expect(first.status).toBe(200);
+      const firstBody = await first.json();
+      const boundary = firstBody.data[0] as { id: string; requestedAt: string };
+
+      const second = await fetch(
+        `${BASE_URL}/approvals?status=pending&agentId=${encodeURIComponent(TEST_AGENT)}&limit=1&cursorRequestedAt=${encodeURIComponent(boundary.requestedAt)}&cursorId=${encodeURIComponent(boundary.id)}`,
+        { headers: adminHeaders() },
+      );
+      expect(second.status).toBe(200);
+      const secondBody = await second.json();
+      expect(secondBody.data).toHaveLength(1);
+      expect(new Set([boundary.id, secondBody.data[0]?.id])).toEqual(
+        new Set([TEST_APPROVAL_APPROVE, TEST_APPROVAL_DENY]),
+      );
     });
 
     it("rejects partial, malformed, and offset-combined cursors", async () => {

--- a/packages/api/src/__tests__/approvals.test.ts
+++ b/packages/api/src/__tests__/approvals.test.ts
@@ -33,6 +33,7 @@ const OWNER_USER_ID = crypto.randomUUID();
 
 let validApiKey: string;
 let adminToken: string;
+let futureMfaToken: string;
 
 // ─── Setup ────────────────────────────────────────────────────────────────
 
@@ -67,6 +68,16 @@ beforeAll(async () => {
     mfaVerifiedAt: Date.now(),
     mfaMethod: "totp",
   });
+  futureMfaToken = await createSessionToken(
+    "0x0000000000000000000000000000000000000001",
+    TEST_TENANT,
+    {
+      userId: OWNER_USER_ID,
+      email: `approvals-${RUN_ID}@example.test`,
+      mfaVerifiedAt: Date.now() + 24 * 60 * 60_000,
+      mfaMethod: "totp",
+    },
+  );
 
   await db
     .insert(agents)
@@ -203,6 +214,17 @@ describe.skipIf(SKIP)("Approval Workflow API", () => {
       expect(body.error).toContain("owner or admin user session");
     });
 
+    it("rejects a future-dated MFA assertion", async () => {
+      const res = await fetch(`${BASE_URL}/approvals`, {
+        headers: {
+          ...adminHeaders(),
+          Authorization: `Bearer ${futureMfaToken}`,
+        },
+      });
+      expect(res.status).toBe(403);
+      expect((await res.json()).error).toContain("recent MFA");
+    });
+
     it("lists pending approvals for tenant", async () => {
       const res = await fetch(`${BASE_URL}/approvals`, {
         headers: adminHeaders(),
@@ -256,8 +278,8 @@ describe.skipIf(SKIP)("Approval Workflow API", () => {
       ).toBe(true);
     });
 
-    it("rejects empty, padded, and overlong agent filters", async () => {
-      for (const agentId of ["", ` ${TEST_AGENT}`, "x".repeat(65)]) {
+    it("rejects empty, padded, overlong, and control-byte agent filters", async () => {
+      for (const agentId of ["", ` ${TEST_AGENT}`, "x".repeat(65), `${TEST_AGENT}\0`]) {
         const res = await fetch(`${BASE_URL}/approvals?agentId=${encodeURIComponent(agentId)}`, {
           headers: adminHeaders(),
         });
@@ -325,7 +347,18 @@ describe.skipIf(SKIP)("Approval Workflow API", () => {
         "cursorId=approval-1",
         "cursorRequestedAt=not-a-date&cursorId=approval-1",
         "cursorRequestedAt=2026-01-01T00%3A00%3A00.000Z&cursorId=approval-1&offset=1",
+        "cursorRequestedAt=0000-01-01T00%3A00%3A00.000Z&cursorId=approval-1",
+        "cursorRequestedAt=%2B010000-01-01T00%3A00%3A00.000Z&cursorId=approval-1",
+        "cursorRequestedAt=2026-01-01T00%3A00%3A00.000Z&cursorId=approval%00bad",
+        `cursorRequestedAt=2026-01-01T00%3A00%3A00.000Z&cursorId=${"x".repeat(65)}`,
       ]) {
+        const res = await fetch(`${BASE_URL}/approvals?${query}`, { headers: adminHeaders() });
+        expect(res.status).toBe(400);
+      }
+    });
+
+    it("rejects explicitly empty status, limit, and offset parameters", async () => {
+      for (const query of ["status=", "limit=", "offset="]) {
         const res = await fetch(`${BASE_URL}/approvals?${query}`, { headers: adminHeaders() });
         expect(res.status).toBe(400);
       }

--- a/packages/api/src/__tests__/approvals.test.ts
+++ b/packages/api/src/__tests__/approvals.test.ts
@@ -266,6 +266,36 @@ describe.skipIf(SKIP)("Approval Workflow API", () => {
         expect(body.error).toContain("agentId must be a non-empty string of at most 64 characters");
       }
     });
+
+    it("paginates by the stable requestedAt and id keyset", async () => {
+      const first = await fetch(
+        `${BASE_URL}/approvals?status=pending&agentId=${encodeURIComponent(TEST_AGENT)}&limit=1`,
+        { headers: adminHeaders() },
+      );
+      expect(first.status).toBe(200);
+      const firstBody = await first.json();
+      expect(firstBody.data).toHaveLength(1);
+      const boundary = firstBody.data[0] as { id: string; requestedAt: string };
+
+      const second = await fetch(
+        `${BASE_URL}/approvals?status=pending&agentId=${encodeURIComponent(TEST_AGENT)}&limit=50&cursorRequestedAt=${encodeURIComponent(boundary.requestedAt)}&cursorId=${encodeURIComponent(boundary.id)}`,
+        { headers: adminHeaders() },
+      );
+      expect(second.status).toBe(200);
+      const secondBody = await second.json();
+      expect(secondBody.data.every((entry: { id: string }) => entry.id !== boundary.id)).toBe(true);
+    });
+
+    it("rejects partial, malformed, and offset-combined cursors", async () => {
+      for (const query of [
+        "cursorId=approval-1",
+        "cursorRequestedAt=not-a-date&cursorId=approval-1",
+        "cursorRequestedAt=2026-01-01T00%3A00%3A00.000Z&cursorId=approval-1&offset=1",
+      ]) {
+        const res = await fetch(`${BASE_URL}/approvals?${query}`, { headers: adminHeaders() });
+        expect(res.status).toBe(400);
+      }
+    });
   });
 
   describe("GET /approvals/stats", () => {

--- a/packages/api/src/__tests__/approvals.test.ts
+++ b/packages/api/src/__tests__/approvals.test.ts
@@ -193,6 +193,16 @@ function adminHeaders() {
 
 describe.skipIf(SKIP)("Approval Workflow API", () => {
   describe("GET /approvals", () => {
+    it("rejects API-key access even when an agent filter is supplied", async () => {
+      const res = await fetch(`${BASE_URL}/approvals?agentId=${encodeURIComponent(TEST_AGENT)}`, {
+        headers: authHeaders(),
+      });
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toContain("owner or admin user session");
+    });
+
     it("lists pending approvals for tenant", async () => {
       const res = await fetch(`${BASE_URL}/approvals`, {
         headers: adminHeaders(),
@@ -244,6 +254,17 @@ describe.skipIf(SKIP)("Approval Workflow API", () => {
       expect(
         filteredBody.data.some((entry: { id: string }) => entry.id === PAGINATION_TARGET_APPROVAL),
       ).toBe(true);
+    });
+
+    it("rejects empty, padded, and overlong agent filters", async () => {
+      for (const agentId of ["", ` ${TEST_AGENT}`, "x".repeat(65)]) {
+        const res = await fetch(`${BASE_URL}/approvals?agentId=${encodeURIComponent(agentId)}`, {
+          headers: adminHeaders(),
+        });
+        expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(body.error).toContain("agentId must be a non-empty string of at most 64 characters");
+      }
     });
   });
 

--- a/packages/api/src/__tests__/openapi-contract.test.ts
+++ b/packages/api/src/__tests__/openapi-contract.test.ts
@@ -507,6 +507,11 @@ describe("generated OpenAPI contract", () => {
       "rejected",
       "all",
     ]);
+    expect(approvalsList.parameters.find((param) => param.name === "agentId").schema).toEqual({
+      type: "string",
+      minLength: 1,
+      maxLength: 64,
+    });
     expect(
       approvalsList.responses["200"].content["application/json"].schema.properties.data.items
         .properties.status.enum,

--- a/packages/api/src/openapi.ts
+++ b/packages/api/src/openapi.ts
@@ -2727,13 +2727,14 @@ function approvalPaths(prefix = ""): Record<string, unknown> {
       get: {
         tags: ["Approvals"],
         summary: "List manual approval queue entries",
-        description: `${approvalDescription} Supports status, limit, and offset filters.`,
+        description: `${approvalDescription} Supports status and tenant-scoped agent filters before limit/offset pagination.`,
         security: [{ bearerAuth: [] }],
         parameters: [
           parameter("status", "query", {
             type: "string",
             enum: ["pending", "approved", "rejected", "all"],
           }),
+          parameter("agentId", "query", { type: "string", minLength: 1, maxLength: 64 }),
           parameter("limit", "query", { type: "integer", minimum: 1, maximum: 200 }),
           parameter("offset", "query", { type: "integer", minimum: 0, maximum: 10000 }),
         ],

--- a/packages/api/src/openapi.ts
+++ b/packages/api/src/openapi.ts
@@ -2727,7 +2727,7 @@ function approvalPaths(prefix = ""): Record<string, unknown> {
       get: {
         tags: ["Approvals"],
         summary: "List manual approval queue entries",
-        description: `${approvalDescription} Supports status and tenant-scoped agent filters before limit/offset pagination.`,
+        description: `${approvalDescription} Supports status and tenant-scoped agent filters before stable (requestedAt, id) keyset pagination.`,
         security: [{ bearerAuth: [] }],
         parameters: [
           parameter("status", "query", {
@@ -2737,6 +2737,8 @@ function approvalPaths(prefix = ""): Record<string, unknown> {
           parameter("agentId", "query", { type: "string", minLength: 1, maxLength: 64 }),
           parameter("limit", "query", { type: "integer", minimum: 1, maximum: 200 }),
           parameter("offset", "query", { type: "integer", minimum: 0, maximum: 10000 }),
+          parameter("cursorRequestedAt", "query", { type: "string", format: "date-time" }),
+          parameter("cursorId", "query", { type: "string", minLength: 1, maxLength: 128 }),
         ],
         responses: {
           "200": jsonResponse(apiResponse({ type: "array", items: approvalQueueEntrySchema })),

--- a/packages/api/src/openapi.ts
+++ b/packages/api/src/openapi.ts
@@ -2738,7 +2738,7 @@ function approvalPaths(prefix = ""): Record<string, unknown> {
           parameter("limit", "query", { type: "integer", minimum: 1, maximum: 200 }),
           parameter("offset", "query", { type: "integer", minimum: 0, maximum: 10000 }),
           parameter("cursorRequestedAt", "query", { type: "string", format: "date-time" }),
-          parameter("cursorId", "query", { type: "string", minLength: 1, maxLength: 128 }),
+          parameter("cursorId", "query", { type: "string", minLength: 1, maxLength: 64 }),
         ],
         responses: {
           "200": jsonResponse(apiResponse({ type: "array", items: approvalQueueEntrySchema })),

--- a/packages/api/src/routes/approvals.ts
+++ b/packages/api/src/routes/approvals.ts
@@ -56,6 +56,11 @@ const MAX_APPROVAL_AGENT_ID_LENGTH = 64;
 const MAX_APPROVAL_CURSOR_ID_LENGTH = 128;
 
 const approvalTransactionMatchesQueue = sql`${transactions.agentId} = ${approvalQueue.agentId}`;
+// JSON/JavaScript Date values retain milliseconds while PostgreSQL timestamps
+// may retain microseconds. Use the serialized precision for both ordering and
+// cursor comparisons, with id as the deterministic tie-breaker, so sub-ms rows
+// cannot fall into a gap between pages.
+const approvalRequestedAtMs = sql<Date>`date_trunc('milliseconds', ${approvalQueue.requestedAt})`;
 
 function approvalActor(c: Context<{ Variables: AppVariables }>): string {
   return c.get("userId") ?? `${c.get("authType") ?? "tenant"}:${c.get("tenantId")}`;
@@ -319,15 +324,13 @@ approvalRoutes.get("/", async (c) => {
         statusFilter !== "all" ? eq(approvalQueue.status, statusFilter) : undefined,
         cursorRequestedAt && cursorId
           ? or(
-              lt(approvalQueue.requestedAt, cursorRequestedAt),
-              and(eq(approvalQueue.requestedAt, cursorRequestedAt), lt(approvalQueue.id, cursorId)),
+              lt(approvalRequestedAtMs, cursorRequestedAt),
+              and(eq(approvalRequestedAtMs, cursorRequestedAt), lt(approvalQueue.id, cursorId)),
             )
           : undefined,
       ),
     )
-    // Stable ordering is required for offset pagination when multiple queue
-    // entries share the same requestedAt timestamp.
-    .orderBy(desc(approvalQueue.requestedAt), desc(approvalQueue.id))
+    .orderBy(desc(approvalRequestedAtMs), desc(approvalQueue.id))
     .limit(limit)
     .offset(offset);
 

--- a/packages/api/src/routes/approvals.ts
+++ b/packages/api/src/routes/approvals.ts
@@ -160,11 +160,24 @@ function parseApprovalListParams(c: Context<{ Variables: AppVariables }>) {
     };
   }
 
+  const rawAgentId = c.req.query("agentId");
+  const agentId = rawAgentId?.trim();
+  if (
+    rawAgentId !== undefined &&
+    (!agentId || agentId.length > MAX_APPROVAL_TEXT_LENGTH || agentId !== rawAgentId)
+  ) {
+    return {
+      ok: false as const,
+      error: `agentId must be a non-empty string of at most ${MAX_APPROVAL_TEXT_LENGTH} characters`,
+    };
+  }
+
   return {
     ok: true as const,
     status: rawStatus as ApprovalStatusFilter,
     limit: rawLimit,
     offset: rawOffset,
+    agentId,
   };
 }
 
@@ -235,7 +248,7 @@ approvalRoutes.get("/", async (c) => {
   if (!params.ok) {
     return c.json<ApiResponse>({ ok: false, error: params.error }, 400);
   }
-  const { status: statusFilter, limit, offset } = params;
+  const { status: statusFilter, limit, offset, agentId } = params;
 
   // Join approval_queue with agents to filter by tenant
   const results = await db
@@ -265,6 +278,7 @@ approvalRoutes.get("/", async (c) => {
       and(
         eq(agents.tenantId, tenantId),
         approvalTransactionMatchesQueue,
+        agentId ? eq(approvalQueue.agentId, agentId) : undefined,
         statusFilter !== "all" ? eq(approvalQueue.status, statusFilter) : undefined,
       ),
     )

--- a/packages/api/src/routes/approvals.ts
+++ b/packages/api/src/routes/approvals.ts
@@ -52,6 +52,7 @@ const APPROVAL_STATUS_FILTERS = new Set<ApprovalStatusFilter>([
 const MAX_APPROVAL_LIST_LIMIT = 200;
 const MAX_APPROVAL_LIST_OFFSET = 10_000;
 const MAX_APPROVAL_TEXT_LENGTH = 1_000;
+const MAX_APPROVAL_AGENT_ID_LENGTH = 64;
 
 const approvalTransactionMatchesQueue = sql`${transactions.agentId} = ${approvalQueue.agentId}`;
 
@@ -164,11 +165,11 @@ function parseApprovalListParams(c: Context<{ Variables: AppVariables }>) {
   const agentId = rawAgentId?.trim();
   if (
     rawAgentId !== undefined &&
-    (!agentId || agentId.length > MAX_APPROVAL_TEXT_LENGTH || agentId !== rawAgentId)
+    (!agentId || agentId.length > MAX_APPROVAL_AGENT_ID_LENGTH || agentId !== rawAgentId)
   ) {
     return {
       ok: false as const,
-      error: `agentId must be a non-empty string of at most ${MAX_APPROVAL_TEXT_LENGTH} characters`,
+      error: `agentId must be a non-empty string of at most ${MAX_APPROVAL_AGENT_ID_LENGTH} characters`,
     };
   }
 
@@ -282,7 +283,9 @@ approvalRoutes.get("/", async (c) => {
         statusFilter !== "all" ? eq(approvalQueue.status, statusFilter) : undefined,
       ),
     )
-    .orderBy(desc(approvalQueue.requestedAt))
+    // Stable ordering is required for offset pagination when multiple queue
+    // entries share the same requestedAt timestamp.
+    .orderBy(desc(approvalQueue.requestedAt), desc(approvalQueue.id))
     .limit(limit)
     .offset(offset);
 

--- a/packages/api/src/routes/approvals.ts
+++ b/packages/api/src/routes/approvals.ts
@@ -191,15 +191,18 @@ function parseApprovalListParams(c: Context<{ Variables: AppVariables }>) {
     return { ok: false as const, error: "cursor pagination cannot be combined with offset" };
   }
 
-  let cursorRequestedAt: Date | undefined;
+  let cursorRequestedAt: string | undefined;
   if (rawCursorRequestedAt !== undefined && rawCursorId !== undefined) {
-    cursorRequestedAt = new Date(rawCursorRequestedAt);
+    const parsedCursorRequestedAt = new Date(rawCursorRequestedAt);
     if (
-      Number.isNaN(cursorRequestedAt.getTime()) ||
-      cursorRequestedAt.toISOString() !== rawCursorRequestedAt
+      Number.isNaN(parsedCursorRequestedAt.getTime()) ||
+      parsedCursorRequestedAt.toISOString() !== rawCursorRequestedAt
     ) {
       return { ok: false as const, error: "cursorRequestedAt must be an ISO 8601 timestamp" };
     }
+    // Keep the canonical wire representation. Passing a Date as a parameter to
+    // a raw SQL expression is driver-dependent and postgres.js expects a string.
+    cursorRequestedAt = rawCursorRequestedAt;
     if (
       rawCursorId.length === 0 ||
       rawCursorId.length > MAX_APPROVAL_CURSOR_ID_LENGTH ||
@@ -291,6 +294,9 @@ approvalRoutes.get("/", async (c) => {
     return c.json<ApiResponse>({ ok: false, error: params.error }, 400);
   }
   const { status: statusFilter, limit, offset, agentId, cursorRequestedAt, cursorId } = params;
+  const cursorRequestedAtSql = cursorRequestedAt
+    ? sql<Date>`${cursorRequestedAt}::timestamptz`
+    : undefined;
 
   // Join approval_queue with agents to filter by tenant
   const results = await db
@@ -322,10 +328,10 @@ approvalRoutes.get("/", async (c) => {
         approvalTransactionMatchesQueue,
         agentId ? eq(approvalQueue.agentId, agentId) : undefined,
         statusFilter !== "all" ? eq(approvalQueue.status, statusFilter) : undefined,
-        cursorRequestedAt && cursorId
+        cursorRequestedAtSql && cursorId
           ? or(
-              lt(approvalRequestedAtMs, cursorRequestedAt),
-              and(eq(approvalRequestedAtMs, cursorRequestedAt), lt(approvalQueue.id, cursorId)),
+              lt(approvalRequestedAtMs, cursorRequestedAtSql),
+              and(eq(approvalRequestedAtMs, cursorRequestedAtSql), lt(approvalQueue.id, cursorId)),
             )
           : undefined,
       ),

--- a/packages/api/src/routes/approvals.ts
+++ b/packages/api/src/routes/approvals.ts
@@ -53,7 +53,7 @@ const MAX_APPROVAL_LIST_LIMIT = 200;
 const MAX_APPROVAL_LIST_OFFSET = 10_000;
 const MAX_APPROVAL_TEXT_LENGTH = 1_000;
 const MAX_APPROVAL_AGENT_ID_LENGTH = 64;
-const MAX_APPROVAL_CURSOR_ID_LENGTH = 128;
+const MAX_APPROVAL_CURSOR_ID_LENGTH = 64;
 
 const approvalTransactionMatchesQueue = sql`${transactions.agentId} = ${approvalQueue.agentId}`;
 // JSON/JavaScript Date values retain milliseconds while PostgreSQL timestamps
@@ -139,14 +139,14 @@ function isNonNegativeIntegerString(value: unknown): value is string {
 }
 
 function parseNonNegativeIntegerParam(value: string | undefined, fallback: number): number | null {
-  if (value === undefined || value === "") return fallback;
+  if (value === undefined) return fallback;
   if (!/^\d+$/.test(value)) return null;
   const parsed = Number(value);
   return Number.isSafeInteger(parsed) ? parsed : null;
 }
 
 function parseApprovalListParams(c: Context<{ Variables: AppVariables }>) {
-  const rawStatus = c.req.query("status") || "pending";
+  const rawStatus = c.req.query("status") ?? "pending";
   if (!APPROVAL_STATUS_FILTERS.has(rawStatus as ApprovalStatusFilter)) {
     return { ok: false as const, error: "status must be pending, approved, rejected, or all" };
   }
@@ -171,7 +171,10 @@ function parseApprovalListParams(c: Context<{ Variables: AppVariables }>) {
   const agentId = rawAgentId?.trim();
   if (
     rawAgentId !== undefined &&
-    (!agentId || agentId.length > MAX_APPROVAL_AGENT_ID_LENGTH || agentId !== rawAgentId)
+    (!agentId ||
+      agentId.length > MAX_APPROVAL_AGENT_ID_LENGTH ||
+      agentId !== rawAgentId ||
+      /[\u0000-\u001f\u007f]/.test(agentId))
   ) {
     return {
       ok: false as const,
@@ -196,7 +199,8 @@ function parseApprovalListParams(c: Context<{ Variables: AppVariables }>) {
     const parsedCursorRequestedAt = new Date(rawCursorRequestedAt);
     if (
       Number.isNaN(parsedCursorRequestedAt.getTime()) ||
-      parsedCursorRequestedAt.toISOString() !== rawCursorRequestedAt
+      parsedCursorRequestedAt.toISOString() !== rawCursorRequestedAt ||
+      !/^(?!0000-)\d{4}-/.test(rawCursorRequestedAt)
     ) {
       return { ok: false as const, error: "cursorRequestedAt must be an ISO 8601 timestamp" };
     }
@@ -206,7 +210,8 @@ function parseApprovalListParams(c: Context<{ Variables: AppVariables }>) {
     if (
       rawCursorId.length === 0 ||
       rawCursorId.length > MAX_APPROVAL_CURSOR_ID_LENGTH ||
-      rawCursorId.trim() !== rawCursorId
+      rawCursorId.trim() !== rawCursorId ||
+      /[\u0000-\u001f\u007f]/.test(rawCursorId)
     ) {
       return {
         ok: false as const,

--- a/packages/api/src/routes/approvals.ts
+++ b/packages/api/src/routes/approvals.ts
@@ -4,7 +4,7 @@
  * Mount: app.route("/approvals", approvalRoutes)
  */
 
-import { and, desc, eq, inArray, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, lt, or, sql } from "drizzle-orm";
 import { type Context, Hono } from "hono";
 import { withTenantAuditedTransaction, writeAuditEvent } from "../services/audit";
 import {
@@ -53,6 +53,7 @@ const MAX_APPROVAL_LIST_LIMIT = 200;
 const MAX_APPROVAL_LIST_OFFSET = 10_000;
 const MAX_APPROVAL_TEXT_LENGTH = 1_000;
 const MAX_APPROVAL_AGENT_ID_LENGTH = 64;
+const MAX_APPROVAL_CURSOR_ID_LENGTH = 128;
 
 const approvalTransactionMatchesQueue = sql`${transactions.agentId} = ${approvalQueue.agentId}`;
 
@@ -173,12 +174,47 @@ function parseApprovalListParams(c: Context<{ Variables: AppVariables }>) {
     };
   }
 
+  const rawCursorRequestedAt = c.req.query("cursorRequestedAt");
+  const rawCursorId = c.req.query("cursorId");
+  if ((rawCursorRequestedAt === undefined) !== (rawCursorId === undefined)) {
+    return {
+      ok: false as const,
+      error: "cursorRequestedAt and cursorId must be supplied together",
+    };
+  }
+  if (rawCursorRequestedAt !== undefined && c.req.query("offset") !== undefined) {
+    return { ok: false as const, error: "cursor pagination cannot be combined with offset" };
+  }
+
+  let cursorRequestedAt: Date | undefined;
+  if (rawCursorRequestedAt !== undefined && rawCursorId !== undefined) {
+    cursorRequestedAt = new Date(rawCursorRequestedAt);
+    if (
+      Number.isNaN(cursorRequestedAt.getTime()) ||
+      cursorRequestedAt.toISOString() !== rawCursorRequestedAt
+    ) {
+      return { ok: false as const, error: "cursorRequestedAt must be an ISO 8601 timestamp" };
+    }
+    if (
+      rawCursorId.length === 0 ||
+      rawCursorId.length > MAX_APPROVAL_CURSOR_ID_LENGTH ||
+      rawCursorId.trim() !== rawCursorId
+    ) {
+      return {
+        ok: false as const,
+        error: `cursorId must be a non-empty string of at most ${MAX_APPROVAL_CURSOR_ID_LENGTH} characters`,
+      };
+    }
+  }
+
   return {
     ok: true as const,
     status: rawStatus as ApprovalStatusFilter,
     limit: rawLimit,
     offset: rawOffset,
     agentId,
+    cursorRequestedAt,
+    cursorId: rawCursorId,
   };
 }
 
@@ -249,7 +285,7 @@ approvalRoutes.get("/", async (c) => {
   if (!params.ok) {
     return c.json<ApiResponse>({ ok: false, error: params.error }, 400);
   }
-  const { status: statusFilter, limit, offset, agentId } = params;
+  const { status: statusFilter, limit, offset, agentId, cursorRequestedAt, cursorId } = params;
 
   // Join approval_queue with agents to filter by tenant
   const results = await db
@@ -281,6 +317,12 @@ approvalRoutes.get("/", async (c) => {
         approvalTransactionMatchesQueue,
         agentId ? eq(approvalQueue.agentId, agentId) : undefined,
         statusFilter !== "all" ? eq(approvalQueue.status, statusFilter) : undefined,
+        cursorRequestedAt && cursorId
+          ? or(
+              lt(approvalQueue.requestedAt, cursorRequestedAt),
+              and(eq(approvalQueue.requestedAt, cursorRequestedAt), lt(approvalQueue.id, cursorId)),
+            )
+          : undefined,
       ),
     )
     // Stable ordering is required for offset pagination when multiple queue

--- a/packages/db/drizzle/0095_approval_queue_agent_pagination.sql
+++ b/packages/db/drizzle/0095_approval_queue_agent_pagination.sql
@@ -1,0 +1,7 @@
+-- Bound agent-scoped approval queue scans before the serialized-precision
+-- keyset sort. The requested_at column remains in the index even though the
+-- route deliberately truncates it to milliseconds for its JavaScript cursor;
+-- PostgreSQL can use the (agent_id, status) prefix to isolate the small queue
+-- before sorting, and raw requested_at keeps the index useful to other readers.
+CREATE INDEX IF NOT EXISTS "approval_queue_agent_status_requested_idx"
+  ON "approval_queue" ("agent_id", "status", "requested_at" DESC, "id" DESC);

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -526,6 +526,13 @@
       "when": 1785264000000,
       "tag": "0094_operator_transfer_reservations",
       "breakpoints": true
+    },
+    {
+      "idx": 95,
+      "version": "7",
+      "when": 1787020069000,
+      "tag": "0095_approval_queue_agent_pagination",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/__tests__/approval-pagination-index.test.ts
+++ b/packages/db/src/__tests__/approval-pagination-index.test.ts
@@ -1,0 +1,40 @@
+import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { createPGLiteDb } from "../pglite";
+
+setDefaultTimeout(30_000);
+
+let client: Awaited<ReturnType<typeof createPGLiteDb>>["client"] | undefined;
+
+beforeAll(async () => {
+  ({ client } = await createPGLiteDb("memory://"));
+});
+
+afterAll(async () => {
+  await client?.close();
+});
+
+describe("approval queue pagination index", () => {
+  test("is journaled with the exact filtering and raw-order columns", async () => {
+    const result = await client!.query<{ indexdef: string }>(
+      `SELECT indexdef FROM pg_indexes
+       WHERE tablename = 'approval_queue'
+         AND indexname = 'approval_queue_agent_status_requested_idx'`,
+    );
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]?.indexdef).toContain("(agent_id, status, requested_at DESC, id DESC)");
+  });
+
+  test("the filtered keyset query can use the composite index prefix", async () => {
+    await client!.exec("SET enable_seqscan = off");
+    const plan = await client!.query<{ "QUERY PLAN": string }>(`
+      EXPLAIN SELECT id
+      FROM approval_queue
+      WHERE agent_id = 'agent-index-probe' AND status = 'pending'
+      ORDER BY date_trunc('milliseconds', requested_at) DESC, id DESC
+      LIMIT 200
+    `);
+    expect(plan.rows.map((row) => row["QUERY PLAN"]).join("\n")).toContain(
+      "approval_queue_agent_status_requested_idx",
+    );
+  });
+});

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1185,6 +1185,12 @@ export const approvalQueue = pgTable(
   (table) => ({
     txIdUniqueIdx: uniqueIndex("approval_queue_tx_id_idx").on(table.txId),
     statusIdx: index("approval_queue_status_idx").on(table.status),
+    agentStatusRequestedIdx: index("approval_queue_agent_status_requested_idx").on(
+      table.agentId,
+      table.status,
+      table.requestedAt.desc(),
+      table.id.desc(),
+    ),
   }),
 );
 

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to `@stwd/react` are documented here.
 ## Unreleased
 
 ### Changed
+- Approval hooks now use stable cursor pagination and pass their agent scope to the server, avoiding offset shifts and client-only filtering of tenant-wide queue pages.
 - Route approval, transaction-history, and spend-stat requests through the credentialed `StewardClient`; remove unauthenticated raw-fetch paths and derive pagination and spend aggregates from authenticated history (SEC-195).
 
 ### Added

--- a/packages/react/src/__tests__/approvals.util.test.ts
+++ b/packages/react/src/__tests__/approvals.util.test.ts
@@ -1,61 +1,61 @@
 import { describe, expect, mock, test } from "bun:test";
 import { getAllPendingApprovals } from "../utils/approvals.js";
 
-function approval(id: string) {
-  return { id, agentId: "agent/1", txId: `tx-${id}`, status: "pending" };
+function approval(index: number) {
+  const id = `approval-${String(index).padStart(3, "0")}`;
+  return {
+    id,
+    agentId: "agent/1",
+    txId: `tx-${id}`,
+    status: "pending",
+    requestedAt: new Date(Date.UTC(2026, 0, 1, 0, 0, 1000 - index)),
+  };
 }
 
 describe("getAllPendingApprovals", () => {
   test("exhausts agent-filtered 200-row pages before returning", async () => {
-    const first = Array.from({ length: 200 }, (_, index) => approval(`approval-${index}`));
-    const second = [approval("approval-199"), approval("approval-200")];
-    const listApprovals = mock(async (opts: { offset?: number }) =>
-      opts.offset === 0 ? first : second,
+    const first = Array.from({ length: 200 }, (_, index) => approval(index));
+    const second = [approval(200)];
+    const listApprovals = mock(async (opts: { cursorId?: string }) =>
+      opts.cursorId === undefined ? first : second,
     );
 
     const result = await getAllPendingApprovals({ listApprovals } as any, "agent/1");
 
     expect(result).toHaveLength(201);
     expect(listApprovals.mock.calls).toEqual([
-      [{ status: "pending", agentId: "agent/1", limit: 200, offset: 0 }],
-      [{ status: "pending", agentId: "agent/1", limit: 200, offset: 199 }],
+      [{ status: "pending", agentId: "agent/1", limit: 200 }],
+      [
+        {
+          status: "pending",
+          agentId: "agent/1",
+          limit: 200,
+          cursorRequestedAt: first[199]?.requestedAt.toISOString(),
+          cursorId: first[199]?.id,
+        },
+      ],
     ]);
   });
 
-  test("restarts once when a concurrent insert shifts offset pagination", async () => {
-    const first = Array.from({ length: 200 }, (_, index) => approval(`approval-${index}`));
+  test("does not skip ID 200 or duplicate rows after a status change and deletion", async () => {
+    const first = Array.from({ length: 200 }, (_, index) => approval(index));
     let calls = 0;
-    const listApprovals = mock(async (opts: { offset?: number }) => {
+    const listApprovals = mock(async (opts: { cursorId?: string }) => {
       calls += 1;
       if (calls === 1) return first;
-      if (calls === 2) return [approval("approval-198"), approval("approval-199")];
-      return opts.offset === 0 ? first : [approval("approval-199"), approval("approval-200")];
+      // Between pages, one page-1 row changes status and another is deleted.
+      // An offset of 200 would now advance past approval-200. The immutable
+      // keyset boundary still selects it directly.
+      first[20] = { ...first[20], status: "approved" };
+      first.splice(40, 1);
+      expect(opts.cursorId).toBe("approval-199");
+      return [approval(200)];
     });
 
     const result = await getAllPendingApprovals({ listApprovals } as any, "agent/1");
 
-    expect(result).toHaveLength(201);
-    expect(calls).toBe(4);
-  });
-
-  test("restarts when a concurrent resolution shifts an unseen approval backward", async () => {
-    const first = Array.from({ length: 200 }, (_, index) => approval(`approval-${index}`));
-    let calls = 0;
-    const listApprovals = mock(async (opts: { offset?: number }) => {
-      calls += 1;
-      if (calls === 1) return first;
-      // A row in the first page was resolved. A non-overlapping offset would
-      // now start at approval-200 and silently omit approval-199.
-      if (calls === 2) return [approval("approval-200")];
-      return opts.offset === 0
-        ? [...first.slice(1), approval("approval-200")]
-        : [approval("approval-200")];
-    });
-
-    const result = await getAllPendingApprovals({ listApprovals } as any, "agent/1");
-
-    expect(result.map(({ id }) => id)).toContain("approval-199");
     expect(result.map(({ id }) => id)).toContain("approval-200");
-    expect(calls).toBe(4);
+    expect(new Set(result.map(({ id }) => id)).size).toBe(201);
+    expect(calls).toBe(2);
   });
 });

--- a/packages/react/src/__tests__/approvals.util.test.ts
+++ b/packages/react/src/__tests__/approvals.util.test.ts
@@ -8,7 +8,7 @@ function approval(id: string) {
 describe("getAllPendingApprovals", () => {
   test("exhausts agent-filtered 200-row pages before returning", async () => {
     const first = Array.from({ length: 200 }, (_, index) => approval(`approval-${index}`));
-    const second = [approval("approval-200")];
+    const second = [approval("approval-199"), approval("approval-200")];
     const listApprovals = mock(async (opts: { offset?: number }) =>
       opts.offset === 0 ? first : second,
     );
@@ -18,7 +18,7 @@ describe("getAllPendingApprovals", () => {
     expect(result).toHaveLength(201);
     expect(listApprovals.mock.calls).toEqual([
       [{ status: "pending", agentId: "agent/1", limit: 200, offset: 0 }],
-      [{ status: "pending", agentId: "agent/1", limit: 200, offset: 200 }],
+      [{ status: "pending", agentId: "agent/1", limit: 200, offset: 199 }],
     ]);
   });
 
@@ -28,13 +28,34 @@ describe("getAllPendingApprovals", () => {
     const listApprovals = mock(async (opts: { offset?: number }) => {
       calls += 1;
       if (calls === 1) return first;
-      if (calls === 2) return [approval("approval-199")];
-      return opts.offset === 0 ? first : [approval("approval-200")];
+      if (calls === 2) return [approval("approval-198"), approval("approval-199")];
+      return opts.offset === 0 ? first : [approval("approval-199"), approval("approval-200")];
     });
 
     const result = await getAllPendingApprovals({ listApprovals } as any, "agent/1");
 
     expect(result).toHaveLength(201);
+    expect(calls).toBe(4);
+  });
+
+  test("restarts when a concurrent resolution shifts an unseen approval backward", async () => {
+    const first = Array.from({ length: 200 }, (_, index) => approval(`approval-${index}`));
+    let calls = 0;
+    const listApprovals = mock(async (opts: { offset?: number }) => {
+      calls += 1;
+      if (calls === 1) return first;
+      // A row in the first page was resolved. A non-overlapping offset would
+      // now start at approval-200 and silently omit approval-199.
+      if (calls === 2) return [approval("approval-200")];
+      return opts.offset === 0
+        ? [...first.slice(1), approval("approval-200")]
+        : [approval("approval-200")];
+    });
+
+    const result = await getAllPendingApprovals({ listApprovals } as any, "agent/1");
+
+    expect(result.map(({ id }) => id)).toContain("approval-199");
+    expect(result.map(({ id }) => id)).toContain("approval-200");
     expect(calls).toBe(4);
   });
 });

--- a/packages/react/src/__tests__/approvals.util.test.ts
+++ b/packages/react/src/__tests__/approvals.util.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, mock, test } from "bun:test";
+import { getAllPendingApprovals } from "../utils/approvals.js";
+
+function approval(id: string) {
+  return { id, agentId: "agent/1", txId: `tx-${id}`, status: "pending" };
+}
+
+describe("getAllPendingApprovals", () => {
+  test("exhausts agent-filtered 200-row pages before returning", async () => {
+    const first = Array.from({ length: 200 }, (_, index) => approval(`approval-${index}`));
+    const second = [approval("approval-200")];
+    const listApprovals = mock(async (opts: { offset?: number }) =>
+      opts.offset === 0 ? first : second,
+    );
+
+    const result = await getAllPendingApprovals({ listApprovals } as any, "agent/1");
+
+    expect(result).toHaveLength(201);
+    expect(listApprovals.mock.calls).toEqual([
+      [{ status: "pending", agentId: "agent/1", limit: 200, offset: 0 }],
+      [{ status: "pending", agentId: "agent/1", limit: 200, offset: 200 }],
+    ]);
+  });
+
+  test("restarts once when a concurrent insert shifts offset pagination", async () => {
+    const first = Array.from({ length: 200 }, (_, index) => approval(`approval-${index}`));
+    let calls = 0;
+    const listApprovals = mock(async (opts: { offset?: number }) => {
+      calls += 1;
+      if (calls === 1) return first;
+      if (calls === 2) return [approval("approval-199")];
+      return opts.offset === 0 ? first : [approval("approval-200")];
+    });
+
+    const result = await getAllPendingApprovals({ listApprovals } as any, "agent/1");
+
+    expect(result).toHaveLength(201);
+    expect(calls).toBe(4);
+  });
+});

--- a/packages/react/src/__tests__/hooks.useApprovals.test.tsx
+++ b/packages/react/src/__tests__/hooks.useApprovals.test.tsx
@@ -94,7 +94,6 @@ describe("useApprovals()", () => {
       status: "pending",
       agentId: "agent x",
       limit: 200,
-      offset: 0,
     });
     // SEC-195: no credential-less raw fetch on any path.
     expect(fetchMock).not.toHaveBeenCalled();
@@ -126,7 +125,6 @@ describe("useApprovals()", () => {
       status: "pending",
       agentId: "agent x",
       limit: 200,
-      offset: 0,
     });
     expect(listApprovalsMock.mock.results[0]?.value).resolves.toEqual([targetApproval]);
   });

--- a/packages/react/src/__tests__/hooks.useApprovals.test.tsx
+++ b/packages/react/src/__tests__/hooks.useApprovals.test.tsx
@@ -15,7 +15,8 @@ import * as React from "react";
 import { renderToString } from "react-dom/server";
 
 const listApprovalsMock = mock(
-  async (_opts?: { status?: string; agentId?: string }) => [] as any[],
+  async (_opts?: { status?: string; agentId?: string; limit?: number; offset?: number }) =>
+    [] as any[],
 );
 const approveVaultTransactionMock = mock(async (_agentId: string, _txId: string) => ({}) as any);
 const denyTransactionMock = mock(async (_txId: string, _reason: string) => ({}) as any);
@@ -89,7 +90,12 @@ describe("useApprovals()", () => {
     const api = captureHook();
     await api.refetch();
     expect(listApprovalsMock).toHaveBeenCalledTimes(1);
-    expect(listApprovalsMock).toHaveBeenCalledWith({ status: "pending", agentId: "agent x" });
+    expect(listApprovalsMock).toHaveBeenCalledWith({
+      status: "pending",
+      agentId: "agent x",
+      limit: 200,
+      offset: 0,
+    });
     // SEC-195: no credential-less raw fetch on any path.
     expect(fetchMock).not.toHaveBeenCalled();
   });
@@ -116,7 +122,12 @@ describe("useApprovals()", () => {
     const api = captureHook();
     await api.refetch();
 
-    expect(listApprovalsMock).toHaveBeenCalledWith({ status: "pending", agentId: "agent x" });
+    expect(listApprovalsMock).toHaveBeenCalledWith({
+      status: "pending",
+      agentId: "agent x",
+      limit: 200,
+      offset: 0,
+    });
     expect(listApprovalsMock.mock.results[0]?.value).resolves.toEqual([targetApproval]);
   });
 

--- a/packages/react/src/__tests__/hooks.useApprovals.test.tsx
+++ b/packages/react/src/__tests__/hooks.useApprovals.test.tsx
@@ -14,7 +14,9 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import * as React from "react";
 import { renderToString } from "react-dom/server";
 
-const listApprovalsMock = mock(async (_opts?: { status?: string }) => [] as any[]);
+const listApprovalsMock = mock(
+  async (_opts?: { status?: string; agentId?: string }) => [] as any[],
+);
 const approveVaultTransactionMock = mock(async (_agentId: string, _txId: string) => ({}) as any);
 const denyTransactionMock = mock(async (_txId: string, _reason: string) => ({}) as any);
 
@@ -87,9 +89,35 @@ describe("useApprovals()", () => {
     const api = captureHook();
     await api.refetch();
     expect(listApprovalsMock).toHaveBeenCalledTimes(1);
-    expect(listApprovalsMock).toHaveBeenCalledWith({ status: "pending" });
+    expect(listApprovalsMock).toHaveBeenCalledWith({ status: "pending", agentId: "agent x" });
     // SEC-195: no credential-less raw fetch on any path.
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("asks the server to filter before the tenant-wide first page", async () => {
+    const otherAgentPage = Array.from({ length: 50 }, (_, index) => ({
+      id: `other-${index}`,
+      txId: `other-tx-${index}`,
+      agentId: "other-agent",
+      status: "pending",
+      requestedAt: new Date(),
+    }));
+    const targetApproval = {
+      id: "target-approval",
+      txId: "target-tx",
+      agentId: "agent x",
+      status: "pending",
+      requestedAt: new Date(),
+    };
+    listApprovalsMock.mockImplementation(async (opts) =>
+      opts?.agentId === "agent x" ? [targetApproval] : otherAgentPage,
+    );
+
+    const api = captureHook();
+    await api.refetch();
+
+    expect(listApprovalsMock).toHaveBeenCalledWith({ status: "pending", agentId: "agent x" });
+    expect(listApprovalsMock.mock.results[0]?.value).resolves.toEqual([targetApproval]);
   });
 
   test("approve() goes through the credentialed client", async () => {

--- a/packages/react/src/hooks/useApprovals.ts
+++ b/packages/react/src/hooks/useApprovals.ts
@@ -51,8 +51,12 @@ export function useApprovals(refreshInterval?: number) {
 
   const fetchApprovals = useCallback(async () => {
     try {
-      // Tenant-scoped list; narrow to this provider's agent client-side.
-      const entries = await client.listApprovals({ status: "pending" });
+      // Filter at the server before pagination. Filtering a tenant-wide first
+      // page client-side can silently hide this agent's approvals when another
+      // agent owns the newest 50 queue entries.
+      const entries = await client.listApprovals({ status: "pending", agentId });
+      // Keep the local check as defense in depth against a mismatched or older
+      // server, but correctness no longer depends on tenant-wide pagination.
       setPending(entries.filter((e) => e.agentId === agentId).map(toQueueEntry));
       setError(null);
     } catch (err) {

--- a/packages/react/src/hooks/useApprovals.ts
+++ b/packages/react/src/hooks/useApprovals.ts
@@ -2,6 +2,7 @@ import type { ApprovalQueueEntry as SdkApprovalQueueEntry } from "@stwd/sdk";
 import { useCallback, useEffect, useState } from "react";
 import { useStewardContext } from "../provider.js";
 import type { ApprovalQueueEntry } from "../types.js";
+import { getAllPendingApprovals } from "../utils/approvals.js";
 
 /**
  * Map the SDK tenant-level approval entry onto the dashboard shape. The
@@ -54,7 +55,7 @@ export function useApprovals(refreshInterval?: number) {
       // Filter at the server before pagination. Filtering a tenant-wide first
       // page client-side can silently hide this agent's approvals when another
       // agent owns the newest 50 queue entries.
-      const entries = await client.listApprovals({ status: "pending", agentId });
+      const entries = await getAllPendingApprovals(client, agentId);
       // Keep the local check as defense in depth against a mismatched or older
       // server, but correctness no longer depends on tenant-wide pagination.
       setPending(entries.filter((e) => e.agentId === agentId).map(toQueueEntry));

--- a/packages/react/src/utils/approvals.ts
+++ b/packages/react/src/utils/approvals.ts
@@ -8,9 +8,11 @@ const MAX_APPROVAL_PAGES = 51;
 /**
  * Load an agent's complete pending approval queue through the credentialed SDK.
  *
- * Offset pagination over a newest-first queue can shift while it is read. A
- * duplicate ID proves an insertion shifted the snapshot, so retry once rather
- * than showing a duplicated or partial security-sensitive queue.
+ * Offset pagination over a newest-first queue can shift while it is read. Each
+ * page after the first deliberately overlaps the preceding page by one row.
+ * A changed boundary detects both forward shifts (inserts) and backward shifts
+ * (resolutions/deletes), so retry once rather than showing a partial
+ * security-sensitive queue.
  */
 export async function getAllPendingApprovals(
   client: Pick<StewardClient, "listApprovals">,
@@ -29,7 +31,16 @@ export async function getAllPendingApprovals(
         limit: APPROVAL_PAGE_SIZE,
         offset,
       });
-      for (const approval of page) {
+      let pageStart = 0;
+      if (pageNumber > 0) {
+        const expectedBoundaryId = approvals.at(-1)?.id;
+        if (!expectedBoundaryId || page[0]?.id !== expectedBoundaryId) {
+          shifted = true;
+          break;
+        }
+        pageStart = 1;
+      }
+      for (const approval of page.slice(pageStart)) {
         if (seen.has(approval.id)) {
           shifted = true;
           break;
@@ -39,7 +50,10 @@ export async function getAllPendingApprovals(
       }
       if (shifted) break;
       if (page.length < APPROVAL_PAGE_SIZE) return approvals;
-      offset += page.length;
+      // Keep the final row as an overlap sentinel for the next page. Without
+      // this, a resolved row before the offset can shift an unseen approval
+      // backward and make it disappear from the assembled queue.
+      offset += page.length - 1;
     }
 
     if (!shifted) {

--- a/packages/react/src/utils/approvals.ts
+++ b/packages/react/src/utils/approvals.ts
@@ -1,65 +1,51 @@
 import type { ApprovalQueueEntry, StewardClient } from "@stwd/sdk";
 
 const APPROVAL_PAGE_SIZE = 200;
-// The API accepts offsets through 10,000, so pages starting at 0..10,000 are
-// the largest complete snapshot an offset client can request.
+// Bound an unexpectedly large queue instead of polling without limit.
 const MAX_APPROVAL_PAGES = 51;
 
 /**
  * Load an agent's complete pending approval queue through the credentialed SDK.
  *
- * Offset pagination over a newest-first queue can shift while it is read. Each
- * page after the first deliberately overlaps the preceding page by one row.
- * A changed boundary detects both forward shifts (inserts) and backward shifts
- * (resolutions/deletes), so retry once rather than showing a partial
- * security-sensitive queue.
+ * Keyset pagination follows the stable (requestedAt, id) ordering. Concurrent
+ * inserts, resolutions, and deletions cannot shift an unseen row across an
+ * offset boundary.
  */
 export async function getAllPendingApprovals(
   client: Pick<StewardClient, "listApprovals">,
   agentId: string,
 ): Promise<ApprovalQueueEntry[]> {
-  for (let snapshotAttempt = 0; snapshotAttempt < 2; snapshotAttempt++) {
-    const approvals: ApprovalQueueEntry[] = [];
-    const seen = new Set<string>();
-    let offset = 0;
-    let shifted = false;
+  const approvals: ApprovalQueueEntry[] = [];
+  const seen = new Set<string>();
+  let cursorRequestedAt: string | undefined;
+  let cursorId: string | undefined;
 
-    for (let pageNumber = 0; pageNumber < MAX_APPROVAL_PAGES; pageNumber++) {
-      const page = await client.listApprovals({
-        status: "pending",
-        agentId,
-        limit: APPROVAL_PAGE_SIZE,
-        offset,
-      });
-      let pageStart = 0;
-      if (pageNumber > 0) {
-        const expectedBoundaryId = approvals.at(-1)?.id;
-        if (!expectedBoundaryId || page[0]?.id !== expectedBoundaryId) {
-          shifted = true;
-          break;
-        }
-        pageStart = 1;
+  for (let pageNumber = 0; pageNumber < MAX_APPROVAL_PAGES; pageNumber++) {
+    const page = await client.listApprovals({
+      status: "pending",
+      agentId,
+      limit: APPROVAL_PAGE_SIZE,
+      ...(cursorRequestedAt && cursorId ? { cursorRequestedAt, cursorId } : {}),
+    });
+    for (const approval of page) {
+      if (seen.has(approval.id)) {
+        throw new Error("Approval server returned a duplicate keyset page entry");
       }
-      for (const approval of page.slice(pageStart)) {
-        if (seen.has(approval.id)) {
-          shifted = true;
-          break;
-        }
-        seen.add(approval.id);
-        approvals.push(approval);
-      }
-      if (shifted) break;
-      if (page.length < APPROVAL_PAGE_SIZE) return approvals;
-      // Keep the final row as an overlap sentinel for the next page. Without
-      // this, a resolved row before the offset can shift an unseen approval
-      // backward and make it disappear from the assembled queue.
-      offset += page.length - 1;
+      seen.add(approval.id);
+      approvals.push(approval);
     }
+    if (page.length < APPROVAL_PAGE_SIZE) return approvals;
 
-    if (!shifted) {
-      throw new Error("Approval queue exceeds the supported pagination bound");
+    const last = page.at(-1);
+    if (!last) return approvals;
+    const requestedAt =
+      last.requestedAt instanceof Date ? last.requestedAt : new Date(last.requestedAt);
+    if (Number.isNaN(requestedAt.getTime())) {
+      throw new Error("Approval server returned an invalid pagination timestamp");
     }
+    cursorRequestedAt = requestedAt.toISOString();
+    cursorId = last.id;
   }
 
-  throw new Error("Approval queue changed during pagination; retry the request");
+  throw new Error("Approval queue exceeds the supported pagination bound");
 }

--- a/packages/react/src/utils/approvals.ts
+++ b/packages/react/src/utils/approvals.ts
@@ -1,0 +1,51 @@
+import type { ApprovalQueueEntry, StewardClient } from "@stwd/sdk";
+
+const APPROVAL_PAGE_SIZE = 200;
+// The API accepts offsets through 10,000, so pages starting at 0..10,000 are
+// the largest complete snapshot an offset client can request.
+const MAX_APPROVAL_PAGES = 51;
+
+/**
+ * Load an agent's complete pending approval queue through the credentialed SDK.
+ *
+ * Offset pagination over a newest-first queue can shift while it is read. A
+ * duplicate ID proves an insertion shifted the snapshot, so retry once rather
+ * than showing a duplicated or partial security-sensitive queue.
+ */
+export async function getAllPendingApprovals(
+  client: Pick<StewardClient, "listApprovals">,
+  agentId: string,
+): Promise<ApprovalQueueEntry[]> {
+  for (let snapshotAttempt = 0; snapshotAttempt < 2; snapshotAttempt++) {
+    const approvals: ApprovalQueueEntry[] = [];
+    const seen = new Set<string>();
+    let offset = 0;
+    let shifted = false;
+
+    for (let pageNumber = 0; pageNumber < MAX_APPROVAL_PAGES; pageNumber++) {
+      const page = await client.listApprovals({
+        status: "pending",
+        agentId,
+        limit: APPROVAL_PAGE_SIZE,
+        offset,
+      });
+      for (const approval of page) {
+        if (seen.has(approval.id)) {
+          shifted = true;
+          break;
+        }
+        seen.add(approval.id);
+        approvals.push(approval);
+      }
+      if (shifted) break;
+      if (page.length < APPROVAL_PAGE_SIZE) return approvals;
+      offset += page.length;
+    }
+
+    if (!shifted) {
+      throw new Error("Approval queue exceeds the supported pagination bound");
+    }
+  }
+
+  throw new Error("Approval queue changed during pagination; retry the request");
+}

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -9,6 +9,7 @@
   API-key, app-secret, or request-signature headers to a `Location` selected by
   an intermediary or compromised endpoint. Configure the canonical API URL;
   redirect aliases are no longer followed.
+- Approval-list requests now support stable cursor pagination and an optional server-enforced agent filter, preventing concurrent queue mutations from shifting or leaking items across pages.
 - `StewardClient`, `StewardAuth`, and `AgentClient` constructors now REJECT a plaintext non-loopback `baseUrl` (fail closed, SEC-048). These clients transmit platform keys, app secrets, bearer tokens, and HMAC-signed credentials, which must never travel cleartext off-loopback — the CLI has always enforced this. `http://localhost`/`127.0.0.1`/`[::1]` stay allowed for local development; operators on trusted private networks can opt out with the new `allowInsecureBaseUrl: true` config (warns loudly at construction). Previously-working insecure configs must pass the flag or switch to HTTPS.
 - `/accounts` and `/global-wallet` mutations are now HMAC-signed when `requestSigningSecret` is configured, aligning the request-signing prefix list with all eight other SDKs (SEC-049). Servers that enforce signatures on these routes previously saw unsigned mutations from this SDK.
 ### Added

--- a/packages/sdk/src/__tests__/client.test.ts
+++ b/packages/sdk/src/__tests__/client.test.ts
@@ -5085,3 +5085,20 @@ describe("StewardClient proxy approvals", () => {
     expect(lastCapture?.url).toEndWith("/approvals/proxy/p1");
   });
 });
+
+describe("StewardClient tenant approvals", () => {
+  it("sends the agent filter with pagination parameters", async () => {
+    installMockFetch({ ok: true, data: [] });
+
+    await makeClient().listApprovals({
+      status: "pending",
+      agentId: "agent with spaces",
+      limit: 200,
+      offset: 50,
+    });
+
+    expect(lastCapture?.url).toBe(
+      "https://api.steward.example/approvals?status=pending&agentId=agent+with+spaces&limit=200&offset=50",
+    );
+  });
+});

--- a/packages/sdk/src/__tests__/client.test.ts
+++ b/packages/sdk/src/__tests__/client.test.ts
@@ -5094,11 +5094,12 @@ describe("StewardClient tenant approvals", () => {
       status: "pending",
       agentId: "agent with spaces",
       limit: 200,
-      offset: 50,
+      cursorRequestedAt: "2026-01-01T00:00:00.000Z",
+      cursorId: "approval-200",
     });
 
     expect(lastCapture?.url).toBe(
-      "https://api.steward.example/approvals?status=pending&agentId=agent+with+spaces&limit=200&offset=50",
+      "https://api.steward.example/approvals?status=pending&agentId=agent+with+spaces&limit=200&cursorRequestedAt=2026-01-01T00%3A00%3A00.000Z&cursorId=approval-200",
     );
   });
 

--- a/packages/sdk/src/__tests__/client.test.ts
+++ b/packages/sdk/src/__tests__/client.test.ts
@@ -5101,4 +5101,14 @@ describe("StewardClient tenant approvals", () => {
       "https://api.steward.example/approvals?status=pending&agentId=agent+with+spaces&limit=200&offset=50",
     );
   });
+
+  it("does not silently drop explicitly invalid filter and pagination values", async () => {
+    installMockFetch({ ok: true, data: [] });
+
+    await makeClient().listApprovals({ agentId: "", limit: 0, offset: 0 });
+
+    expect(lastCapture?.url).toBe(
+      "https://api.steward.example/approvals?agentId=&limit=0&offset=0",
+    );
+  });
 });

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -4627,12 +4627,17 @@ export class StewardClient {
     agentId?: string;
     limit?: number;
     offset?: number;
+    cursorRequestedAt?: string;
+    cursorId?: string;
   }): Promise<ApprovalQueueEntry[]> {
     const params = new URLSearchParams();
     if (opts?.status) params.set("status", opts.status);
     if (opts?.agentId !== undefined) params.set("agentId", opts.agentId);
     if (opts?.limit !== undefined) params.set("limit", String(opts.limit));
     if (opts?.offset !== undefined) params.set("offset", String(opts.offset));
+    if (opts?.cursorRequestedAt !== undefined)
+      params.set("cursorRequestedAt", opts.cursorRequestedAt);
+    if (opts?.cursorId !== undefined) params.set("cursorId", opts.cursorId);
     const qs = params.toString();
     const response = await this.request<ApprovalQueueEntry[], StewardErrorResponse>(
       `/approvals${qs ? `?${qs}` : ""}`,

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -4630,9 +4630,9 @@ export class StewardClient {
   }): Promise<ApprovalQueueEntry[]> {
     const params = new URLSearchParams();
     if (opts?.status) params.set("status", opts.status);
-    if (opts?.agentId) params.set("agentId", opts.agentId);
-    if (opts?.limit) params.set("limit", String(opts.limit));
-    if (opts?.offset) params.set("offset", String(opts.offset));
+    if (opts?.agentId !== undefined) params.set("agentId", opts.agentId);
+    if (opts?.limit !== undefined) params.set("limit", String(opts.limit));
+    if (opts?.offset !== undefined) params.set("offset", String(opts.offset));
     const qs = params.toString();
     const response = await this.request<ApprovalQueueEntry[], StewardErrorResponse>(
       `/approvals${qs ? `?${qs}` : ""}`,

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -4624,11 +4624,13 @@ export class StewardClient {
   /** List approval queue entries for the tenant. */
   async listApprovals(opts?: {
     status?: string;
+    agentId?: string;
     limit?: number;
     offset?: number;
   }): Promise<ApprovalQueueEntry[]> {
     const params = new URLSearchParams();
     if (opts?.status) params.set("status", opts.status);
+    if (opts?.agentId) params.set("agentId", opts.agentId);
     if (opts?.limit) params.set("limit", String(opts.limit));
     if (opts?.offset) params.set("offset", String(opts.offset));
     const qs = params.toString();

--- a/packages/sdk/src/generated/api-types.ts
+++ b/packages/sdk/src/generated/api-types.ts
@@ -34371,7 +34371,7 @@ export interface paths {
         };
         /**
          * List manual approval queue entries
-         * @description Requires an owner/admin browser session with recent MFA. Tenant API keys and agent tokens cannot review or mutate manual approvals. Supports status and tenant-scoped agent filters before limit/offset pagination.
+         * @description Requires an owner/admin browser session with recent MFA. Tenant API keys and agent tokens cannot review or mutate manual approvals. Supports status and tenant-scoped agent filters before stable (requestedAt, id) keyset pagination.
          */
         get: {
             parameters: {
@@ -34380,6 +34380,8 @@ export interface paths {
                     agentId?: string;
                     limit?: number;
                     offset?: number;
+                    cursorRequestedAt?: string;
+                    cursorId?: string;
                 };
                 header?: never;
                 path?: never;

--- a/packages/sdk/src/generated/api-types.ts
+++ b/packages/sdk/src/generated/api-types.ts
@@ -34371,12 +34371,13 @@ export interface paths {
         };
         /**
          * List manual approval queue entries
-         * @description Requires an owner/admin browser session with recent MFA. Tenant API keys and agent tokens cannot review or mutate manual approvals. Supports status, limit, and offset filters.
+         * @description Requires an owner/admin browser session with recent MFA. Tenant API keys and agent tokens cannot review or mutate manual approvals. Supports status and tenant-scoped agent filters before limit/offset pagination.
          */
         get: {
             parameters: {
                 query?: {
                     status?: "pending" | "approved" | "rejected" | "all";
+                    agentId?: string;
                     limit?: number;
                     offset?: number;
                 };


### PR DESCRIPTION
## Summary

- add a tenant-scoped `agentId` filter before pagination across the approval API, OpenAPI contract, SDK, and React hook
- replace shifting offset traversal with bounded keyset pagination over the stable serialized-precision `(requestedAt, id)` order
- retain the client-side agent check as defense in depth against older or mismatched servers
- reject partial, malformed, or offset-combined cursors while preserving the existing MFA, owner/admin, and tenant-auth gates

## Security impact

This corrects the post-merge finding from #331. A tenant-wide first page could hide a target agent's approvals, and offset pagination could skip unseen approvals when rows were resolved or deleted between page reads. The keyset boundary is unaffected by inserts, status changes, or deletes before the boundary and uses the same millisecond timestamp precision exposed to JavaScript clients.

## Exact current-head validation

Head `d16d58a6662e2402f6d84e5a2a773b8220bfbe3f`, base `090ac9cb375fcf9f6c3405895d110a12e539285f`:

- isolated API approvals + OpenAPI contract: 2/2 files passed
- SDK/React/PGLite pagination suites: 153 passed, 832 assertions
- dependency-aware API/SDK/React build: 22/22 tasks passed
- Biome on changed TypeScript surfaces and `git diff --check`: passed
- deterministic 201-row regression changes one page-1 row's status and deletes another before page 2, then proves item 200 is present with no duplicates
- PGLite applies the contiguous post-PR #371 migration sequence and proves the composite keyset index plan

The branch is now restacked after merged migrations `0093_upstream_credential_leases` and `0094_operator_transfer_reservations`; approval pagination is contiguous migration `0095`.

Refs #331
