### PR TITLE
test(trading): restore tenant-bound Polymarket cache setup

### DIFF
--- a/packages/plugin-trading/src/__tests__/trade-polymarket-creds-cache.test.ts
+++ b/packages/plugin-trading/src/__tests__/trade-polymarket-creds-cache.test.ts
@@ -178,6 +178,7 @@ describe("SEC-108: Polymarket L2 creds Redis cache is encrypted at rest", () => 
     // Real provisioning into the encrypted venue-scoped vault; no key material
     // leaves the vault, and the L1->L2 derivation signs for real.
     const wallet = await ctx.vault.createWallet({
+      tenantId,
       agentId,
       venue: "polymarket",
       chainType: "evm",
@@ -282,6 +283,7 @@ describe("SEC-108: Polymarket L2 creds Redis cache is encrypted at rest", () => 
 
     const { tenantId, agentId } = await seedTenantAgent();
     const wallet = await ctx.vault.createWallet({
+      tenantId,
       agentId,
       venue: "polymarket",
       chainType: "evm",


### PR DESCRIPTION
## Summary

- pass the seeded tenant ID into both SEC-108 Polymarket cache wallet fixtures
- restore compatibility with the tenant-bound vault API landed in #342

## Failure fixed

Current exact `develop` integration failed both `trade-polymarket-creds-cache` cases with `Agent ... not found for tenant undefined` in PR Checks job `95547162882`.

## Validation

- `biome check` passes for the changed test
- `git diff --check` passes
- exact-head PR matrix is authoritative for the full package run