### PR TITLE
fix(security): close PR #347 idempotency and fill-accounting gaps

### DIFF
--- a/packages/plugin-trading/src/__tests__/idempotency-store.test.ts
+++ b/packages/plugin-trading/src/__tests__/idempotency-store.test.ts
@@ -2,19 +2,12 @@ import { describe, expect, it } from "bun:test";
 import type { IoredisLike } from "@stwd/redis";
 import { DurableIdempotencyStore } from "../routes/idempotency";
 
-/**
- * SEC-043: trade/operator idempotency records must be DURABLE — backed by
- * Redis when a client is available so a restart or a second replica still
- * dedups a retried withdraw/order — with the bounded in-memory map as the
- * dev/single-replica fallback.
- */
-
 type TestRecord = { status: number; body: unknown };
 
-/** Minimal in-memory IoredisLike double (records raw set args for assertions). */
+/** Minimal Redis double with real SET NX and owner-CAS completion semantics. */
 function fakeRedis() {
   const data = new Map<string, string>();
-  const setCalls: Array<{ key: string; ttlMs?: number }> = [];
+  const setCalls: Array<{ key: string; ttlMs?: number; condition?: string }> = [];
   const client = {
     get: async (key: string) => data.get(key) ?? null,
     set: async (...args: unknown[]) => {
@@ -22,122 +15,153 @@ function fakeRedis() {
       const value = args[1] as string;
       const mode = args[2] as string | undefined;
       const ttlMs = mode === "PX" ? (args[3] as number) : undefined;
-      setCalls.push({ key, ttlMs });
+      const condition = args[4] as string | undefined;
+      setCalls.push({ key, ttlMs, condition });
+      if (condition === "NX" && data.has(key)) return null;
       data.set(key, value);
       return "OK";
+    },
+    eval: async (_script: string, _numKeys: number, ...args: Array<string | number>) => {
+      const [key, expected, replacement] = args as [string, string, string, number];
+      if (data.get(key) !== expected) return 0;
+      data.set(key, replacement);
+      return 1;
     },
   } as unknown as IoredisLike;
   return { client, data, setCalls };
 }
 
-describe("DurableIdempotencyStore (SEC-043)", () => {
-  it("replays a stored outcome across store instances sharing Redis (restart / second replica)", async () => {
-    const { client } = fakeRedis();
-    const replicaA = new DurableIdempotencyStore<TestRecord>({
-      namespace: "trade:operator",
-      getRedisClient: () => client,
-    });
-    const first = await replicaA.check("tenant:withdraw", "key-1", "hash-1");
-    expect(first.record).toBeUndefined();
-    expect(first.conflict).toBeUndefined();
-    await first.store?.({ status: 200, body: { ok: true, data: { moved: true } } });
+function makeStore(client: IoredisLike | null, namespace = "trade") {
+  return new DurableIdempotencyStore<TestRecord>({
+    namespace,
+    getRedisClient: () => client,
+  });
+}
 
-    // A fresh instance = a restarted process or a second replica. Its memory
-    // map is empty; the replay must come from the durable record.
-    const replicaB = new DurableIdempotencyStore<TestRecord>({
-      namespace: "trade:operator",
-      getRedisClient: () => client,
-    });
+describe("DurableIdempotencyStore (SEC-043)", () => {
+  it("replays a completed outcome across restarts / replicas", async () => {
+    const { client } = fakeRedis();
+    const replicaA = makeStore(client, "trade:operator");
+    expect(await replicaA.check("tenant:withdraw", "key-1", "hash-1")).toEqual({});
+    const claim = await replicaA.reserve("tenant:withdraw", "key-1", "hash-1");
+    expect(claim.store).toBeFunction();
+    await claim.store?.({ status: 200, body: { ok: true, data: { moved: true } } });
+
+    const replicaB = makeStore(client, "trade:operator");
     const replay = await replicaB.check("tenant:withdraw", "key-1", "hash-1");
     expect(replay.record).toEqual({ status: 200, body: { ok: true, data: { moved: true } } });
     expect(replay.store).toBeUndefined();
   });
 
-  it("flags a same-key/different-body reuse as a conflict (via Redis)", async () => {
+  it("atomically permits only one concurrent claimant across replicas", async () => {
     const { client } = fakeRedis();
-    const store = new DurableIdempotencyStore<TestRecord>({
-      namespace: "trade",
-      getRedisClient: () => client,
-    });
-    const first = await store.check("scope", "key-1", "hash-1");
-    await first.store?.({ status: 502, body: { ok: false } });
-
-    const conflict = await store.check("scope", "key-1", "hash-DIFFERENT");
-    expect(conflict.conflict).toBe(true);
-    expect(conflict.record).toBeUndefined();
-    expect(conflict.store).toBeUndefined();
+    const replicaA = makeStore(client);
+    const replicaB = makeStore(client);
+    const [a, b] = await Promise.all([
+      replicaA.reserve("scope", "same-key", "same-hash"),
+      replicaB.reserve("scope", "same-key", "same-hash"),
+    ]);
+    expect([a, b].filter((result) => result.store)).toHaveLength(1);
+    expect([a, b].filter((result) => result.pending)).toHaveLength(1);
   });
 
-  it("stores with the 24h TTL via PX", async () => {
+  it("keeps retries fail-closed after a crash before completion", async () => {
+    const { client } = fakeRedis();
+    const replicaA = makeStore(client);
+    const claim = await replicaA.reserve("scope", "key-1", "hash-1");
+    expect(claim.store).toBeFunction();
+
+    // Simulate process death: never invoke store(). A restarted replica sees
+    // the durable processing marker and must not receive execution ownership.
+    const replicaB = makeStore(client);
+    expect(await replicaB.check("scope", "key-1", "hash-1")).toEqual({ pending: true });
+    expect(await replicaB.reserve("scope", "key-1", "hash-1")).toEqual({ pending: true });
+  });
+
+  it("flags same-key/different-body reuse while processing or completed", async () => {
+    const { client } = fakeRedis();
+    const store = makeStore(client);
+    const claim = await store.reserve("scope", "key-1", "hash-1");
+    expect((await store.reserve("scope", "key-1", "different")).conflict).toBe(true);
+    await claim.store?.({ status: 502, body: { ok: false } });
+    expect((await store.check("scope", "key-1", "different")).conflict).toBe(true);
+  });
+
+  it("claims with a 24h PX TTL and NX", async () => {
     const { client, setCalls } = fakeRedis();
-    const store = new DurableIdempotencyStore<TestRecord>({
-      namespace: "trade",
-      getRedisClient: () => client,
-    });
-    const check = await store.check("scope", "key-1", "hash-1");
-    await check.store?.({ status: 200, body: { ok: true } });
-    expect(setCalls).toHaveLength(1);
-    expect(setCalls[0]?.ttlMs).toBe(24 * 60 * 60 * 1000);
+    const store = makeStore(client);
+    await store.reserve("scope", "key-1", "hash-1");
+    expect(setCalls).toEqual([
+      {
+        key: "idempotency:trade:scope:key-1",
+        ttlMs: 24 * 60 * 60 * 1000,
+        condition: "NX",
+      },
+    ]);
   });
 
-  it("fails CLOSED when the Redis check errors (never executes without the dedup record)", async () => {
-    const broken = {
+  it("fails closed on Redis read/reservation errors and malformed durable state", async () => {
+    const readBroken = {
       get: async () => {
         throw new Error("redis down");
       },
-      set: async () => "OK",
     } as unknown as IoredisLike;
-    const store = new DurableIdempotencyStore<TestRecord>({
-      namespace: "trade",
-      getRedisClient: () => broken,
-    });
-    await expect(store.check("scope", "key-1", "hash-1")).rejects.toThrow("redis down");
-  });
+    await expect(makeStore(readBroken).check("scope", "key-1", "hash-1")).rejects.toThrow(
+      "redis down",
+    );
 
-  it("swallows a Redis store error (the movement already executed; caller gets the real outcome)", async () => {
-    const broken = {
+    const reserveBroken = {
       get: async () => null,
       set: async () => {
         throw new Error("redis down");
       },
     } as unknown as IoredisLike;
-    const store = new DurableIdempotencyStore<TestRecord>({
-      namespace: "trade",
-      getRedisClient: () => broken,
-    });
-    const check = await store.check("scope", "key-1", "hash-1");
-    await expect(check.store?.({ status: 200, body: {} })).resolves.toBeUndefined();
+    await expect(makeStore(reserveBroken).reserve("scope", "key-1", "hash-1")).rejects.toThrow(
+      "redis down",
+    );
+
+    const malformed = fakeRedis();
+    malformed.data.set("idempotency:trade:scope:key-1", "not-json");
+    await expect(makeStore(malformed.client).check("scope", "key-1", "hash-1")).rejects.toThrow(
+      "malformed",
+    );
   });
 
-  it("falls back to bounded process-local memory without Redis (replay in-process only)", async () => {
-    const noRedis = () => null;
-    const storeA = new DurableIdempotencyStore<TestRecord>({
-      namespace: "trade",
-      getRedisClient: noRedis,
-    });
-    const first = await storeA.check("scope", "key-1", "hash-1");
-    await first.store?.({ status: 200, body: { ok: true } });
-
-    // Same process: replay works.
-    const replay = await storeA.check("scope", "key-1", "hash-1");
-    expect(replay.record).toEqual({ status: 200, body: { ok: true } });
-
-    // A fresh instance (restart) does NOT see it — the documented fallback
-    // limitation that Redis closes in production.
-    const storeB = new DurableIdempotencyStore<TestRecord>({
-      namespace: "trade",
-      getRedisClient: noRedis,
-    });
-    const missed = await storeB.check("scope", "key-1", "hash-1");
-    expect(missed.record).toBeUndefined();
+  it("leaves the processing marker in place when completion persistence fails", async () => {
+    const { client, data } = fakeRedis();
+    const brokenCompletion = {
+      ...client,
+      eval: async () => {
+        throw new Error("redis down");
+      },
+    } as IoredisLike;
+    const store = makeStore(brokenCompletion);
+    const claim = await store.reserve("scope", "key-1", "hash-1");
+    await expect(claim.store?.({ status: 200, body: {} })).resolves.toBeUndefined();
+    expect(JSON.parse(data.get("idempotency:trade:scope:key-1") ?? "{}").state).toBe("processing");
+    expect((await store.check("scope", "key-1", "hash-1")).pending).toBe(true);
   });
 
-  it("no key -> no dedup (unchanged wave-2 semantics)", async () => {
+  it("atomically suppresses concurrent requests in the memory fallback", async () => {
+    const store = makeStore(null);
+    const [a, b] = await Promise.all([
+      store.reserve("scope", "key-1", "hash-1"),
+      store.reserve("scope", "key-1", "hash-1"),
+    ]);
+    expect([a, b].filter((result) => result.store)).toHaveLength(1);
+    expect([a, b].filter((result) => result.pending)).toHaveLength(1);
+    const owner = a.store ? a : b;
+    await owner.store?.({ status: 200, body: { ok: true } });
+    expect((await store.check("scope", "key-1", "hash-1")).record).toEqual({
+      status: 200,
+      body: { ok: true },
+    });
+  });
+
+  it("no key leaves the request outside idempotency", async () => {
     const { client } = fakeRedis();
-    const store = new DurableIdempotencyStore<TestRecord>({
-      namespace: "trade",
-      getRedisClient: () => client,
-    });
+    const store = makeStore(client);
     expect(await store.check("scope", undefined, "hash-1")).toEqual({});
+    expect(await store.reserve("scope", undefined, "hash-1")).toEqual({});
   });
 });

--- a/packages/plugin-trading/src/__tests__/trade-polymarket-creds-cache.test.ts
+++ b/packages/plugin-trading/src/__tests__/trade-polymarket-creds-cache.test.ts
@@ -37,9 +37,16 @@ const fakeRedis = {
   get: async (key: string) => redisStore.get(key) ?? null,
   // IoredisLike.set — the durable idempotency store (SEC-043) writes through
   // this with a PX TTL; the creds cache itself uses setex below.
-  set: async (key: string, value: string, _mode?: "PX", _ttlMs?: number) => {
+  set: async (key: string, value: string, _mode?: "PX", _ttlMs?: number, condition?: "NX") => {
+    if (condition === "NX" && redisStore.has(key)) return null;
     redisStore.set(key, value);
     return "OK";
+  },
+  eval: async (_script: string, _numKeys: number, ...args: Array<string | number>) => {
+    const [key, expected, replacement] = args as [string, string, string, number];
+    if (redisStore.get(key) !== expected) return 0;
+    redisStore.set(key, replacement);
+    return 1;
   },
   setex: async (key: string, _ttlSeconds: number, value: string) => {
     redisStore.set(key, value);
@@ -255,12 +262,48 @@ describe("SEC-108: Polymarket L2 creds Redis cache is encrypted at rest", () => 
       expect(second.status).toBe(200);
       expect(authKeyRequests).toHaveLength(1);
 
-      // 3) A legacy PLAINTEXT entry is not trusted: it is treated as a cache
+      // 3) An opaque ciphertext copied into another agent's cache slot does
+      // not authenticate there. AAD binds the blob to the full cache key, so
+      // the second agent must derive its own credentials.
+      const secondIdentity = await seedTenantAgent();
+      const secondWallet = await ctx.vault.createWallet({
+        agentId: secondIdentity.agentId,
+        venue: "polymarket",
+        chainType: "evm",
+      });
+      const secondSessionId = await seedSession(
+        secondIdentity.tenantId,
+        secondIdentity.agentId,
+        secondWallet.address,
+      );
+      const secondCacheKey = `pm:clob-l2:${secondIdentity.tenantId}:${secondIdentity.agentId}:${secondWallet.address.toLowerCase()}:${encodeURIComponent("https://clob.e2e.invalid")}`;
+      redisStore.set(secondCacheKey, storedRaw);
+      const transplanted = await makeApp(
+        secondIdentity.tenantId,
+        secondIdentity.agentId,
+        createTradeRoutes(ctx),
+      ).request("/v1/trade/polymarket/order", {
+        method: "POST",
+        headers: { "content-type": "application/json", "Idempotency-Key": crypto.randomUUID() },
+        body: JSON.stringify({
+          sessionId: secondSessionId,
+          tokenId: TOKEN_ID,
+          side: "buy",
+          amount: 10,
+          price: 0.5,
+          tickSize: "0.01",
+          negRisk: true,
+        }),
+      });
+      expect(transplanted.status).toBe(200);
+      expect(authKeyRequests).toHaveLength(2);
+
+      // 4) A legacy PLAINTEXT entry is not trusted: it is treated as a cache
       // miss (re-derive) and rewritten encrypted.
       redisStore.set(pmKeys[0] as string, JSON.stringify(DERIVED_CREDS));
       const third = await postOrder();
       expect(third.status).toBe(200);
-      expect(authKeyRequests).toHaveLength(2);
+      expect(authKeyRequests).toHaveLength(3);
       const rewritten = redisStore.get(pmKeys[0] as string) as string;
       expect(rewritten.startsWith("stwd_pmclob_v1:")).toBe(true);
       expect(rewritten.includes(DERIVED_CREDS.secret)).toBe(false);

--- a/packages/plugin-trading/src/__tests__/trade-polymarket-order.test.ts
+++ b/packages/plugin-trading/src/__tests__/trade-polymarket-order.test.ts
@@ -471,8 +471,8 @@ describe("POST /v1/trade/polymarket/order", () => {
       orderId: "pm-http-guard",
       status: "matched",
       success: true,
-      makingAmount: "10",
-      takingAmount: "20",
+      makingAmount: "10.0",
+      takingAmount: "20.0",
       actualAmount: 20,
       actualPrice: 0.5,
     } as Awaited<ReturnType<PolymarketExecutionAdapter["submitSignedOrder"]>>);
@@ -516,8 +516,8 @@ describe("POST /v1/trade/polymarket/order", () => {
       orderId: "pm-ok-1",
       status: "matched",
       success: true,
-      makingAmount: "10",
-      takingAmount: "20",
+      makingAmount: "10.0",
+      takingAmount: "20.0",
       actualAmount: 20,
       actualPrice: 0.5,
     } as Awaited<ReturnType<PolymarketExecutionAdapter["submitSignedOrder"]>>);
@@ -712,8 +712,8 @@ describe("POST /v1/trade/polymarket/order", () => {
       orderId: "pm-eoa-1",
       status: "matched",
       success: true,
-      makingAmount: "10",
-      takingAmount: "20",
+      makingAmount: "10.0",
+      takingAmount: "20.0",
       actualAmount: 20,
       actualPrice: 0.5,
     } as Awaited<ReturnType<PolymarketExecutionAdapter["submitSignedOrder"]>>);

--- a/packages/plugin-trading/src/routes/idempotency.ts
+++ b/packages/plugin-trading/src/routes/idempotency.ts
@@ -1,37 +1,12 @@
 /**
- * idempotency.ts — durable idempotency backing for the trade + operator routes
- * (SEC-043).
+ * Durable, claim-before-execute idempotency for fund-moving trading routes.
  *
- * Wave-2 bounded the process-local maps (1_000 entries + expired-sweep) and
- * stored ambiguous-outcome 502 envelopes, but the maps were still per-process:
- * a restart or a second replica silently lost dedup, so a retried
- * withdraw/order could double-execute a fund movement.
- *
- * This store keeps the wave-2 semantics and adds a Redis-backed record when a
- * client is available (production always has one — durable stores are asserted
- * at startup), keyed `idempotency:<namespace>:<scope>:<key>` with the same 24h
- * TTL. Without Redis it falls back to the bounded process-local map (dev /
- * single-replica), exactly like the routes' rate limiters.
- *
- * Semantics (unchanged from wave-2):
- *   - same key + same body      -> replay the stored outcome (no re-execution)
- *   - same key + DIFFERENT body -> conflict (the routes answer 409)
- *   - missing/expired           -> fresh; `store` records the final outcome
- *                                  (success OR ambiguous 502) so retries replay
- *
- * Failure posture:
- *   - a Redis error on CHECK fails CLOSED (throws): executing without the
- *     dedup record risks a double fund-movement; the caller's retry replays
- *     once Redis recovers.
- *   - a Redis error on STORE is logged and swallowed: the movement already
- *     executed, so the caller must still see the real outcome. A later retry
- *     may re-execute — the same accepted residual as a crash between venue
- *     execution and persistence.
- *
- * Known residual (pre-existing, unchanged): two requests with the same key
- * in-flight CONCURRENTLY can both pass the check before either stores. This
- * store closes the sequential-retry / restart / multi-replica gaps the audit
- * flagged; claim-before-execute hardening is separate work.
+ * A lookup is intentionally separate from `reserve()`: callers can replay a
+ * completed response before consulting mutable session/venue state, then do
+ * all safe validation and policy work before atomically claiming the key at
+ * the last pre-execution boundary. Once claimed, the processing marker stays
+ * for the full 24-hour window. A concurrent request, process restart, crash,
+ * or failed completion write therefore fails closed instead of re-executing.
  */
 
 import type { IoredisLike } from "@stwd/redis";
@@ -43,22 +18,44 @@ export interface IdempotencyRecord {
 
 export interface IdempotencyCheck<TRecord extends IdempotencyRecord> {
   conflict?: boolean;
+  pending?: boolean;
   record?: TRecord;
   store?: (record: TRecord) => Promise<void>;
 }
 
+type StoredEntry<TRecord extends IdempotencyRecord> =
+  | {
+      bodyHash: string;
+      state: "processing";
+      claimId: string;
+      claimedAt: number;
+    }
+  | {
+      bodyHash: string;
+      state: "completed";
+      record: TRecord;
+    };
+
 const IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000;
 const MAX_MEMORY_ENTRIES = 1_000;
 
+// Complete only the processing record created by this claimant. A stale owner
+// must never overwrite a newer claim after its TTL has elapsed.
+const COMPLETE_IF_OWNER_LUA = `
+local current = redis.call("GET", KEYS[1])
+if current ~= ARGV[1] then
+  return 0
+end
+redis.call("SET", KEYS[1], ARGV[2], "PX", ARGV[3])
+return 1
+`;
+
 export class DurableIdempotencyStore<TRecord extends IdempotencyRecord> {
-  private readonly memory = new Map<
-    string,
-    { bodyHash: string; record: TRecord; expiresAt: number }
-  >();
+  private readonly memory = new Map<string, { entry: StoredEntry<TRecord>; expiresAt: number }>();
 
   constructor(
     private readonly options: {
-      /** Key prefix segment, e.g. "trade" or "trade:operator". */
+      /** Key prefix segment, e.g. "trade:hl" or "trade:operator". */
       namespace: string;
       getRedisClient: () => IoredisLike | null;
     },
@@ -66,6 +63,10 @@ export class DurableIdempotencyStore<TRecord extends IdempotencyRecord> {
 
   private redisKey(scope: string, key: string): string {
     return `idempotency:${this.options.namespace}:${scope}:${key}`;
+  }
+
+  private memoryKey(scope: string, key: string): string {
+    return `${scope}:${key}`;
   }
 
   private sweepMemory(now: number): void {
@@ -77,64 +78,166 @@ export class DurableIdempotencyStore<TRecord extends IdempotencyRecord> {
     }
   }
 
-  /**
-   * Look up `key` within `scope`. `bodyHash` is the caller-computed canonical
-   * body fingerprint; a mismatch on an existing entry is a conflict.
-   */
+  private parseStored(raw: string): StoredEntry<TRecord> {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      throw new Error("Durable idempotency record is malformed");
+    }
+    if (!parsed || typeof parsed !== "object") {
+      throw new Error("Durable idempotency record is malformed");
+    }
+    const value = parsed as Record<string, unknown>;
+    if (typeof value.bodyHash !== "string") {
+      throw new Error("Durable idempotency record is malformed");
+    }
+    if (
+      value.state === "processing" &&
+      typeof value.claimId === "string" &&
+      typeof value.claimedAt === "number" &&
+      Number.isFinite(value.claimedAt)
+    ) {
+      return value as StoredEntry<TRecord>;
+    }
+    if (value.state === "completed" && value.record && typeof value.record === "object") {
+      const record = value.record as Record<string, unknown>;
+      if (typeof record.status === "number" && Object.hasOwn(record, "body")) {
+        return value as StoredEntry<TRecord>;
+      }
+    }
+    throw new Error("Durable idempotency record is malformed");
+  }
+
+  private resultForExisting(
+    entry: StoredEntry<TRecord>,
+    bodyHash: string,
+  ): IdempotencyCheck<TRecord> {
+    if (entry.bodyHash !== bodyHash) return { conflict: true };
+    if (entry.state === "processing") return { pending: true };
+    return { record: entry.record };
+  }
+
+  /** Read an existing claim/outcome without claiming an absent key. */
   async check(
     scope: string,
     key: string | undefined,
     bodyHash: string,
   ): Promise<IdempotencyCheck<TRecord>> {
     if (!key) return {};
-    const now = Date.now();
     const redis = this.options.getRedisClient();
     if (redis) {
-      // Fail CLOSED on a Redis error (see the module doc).
+      // Redis errors and malformed records both fail closed. Neither condition
+      // can prove that a prior movement did not occur.
       const raw = await redis.get(this.redisKey(scope, key));
-      if (raw !== null) {
-        let existing: { bodyHash?: unknown; record?: unknown } | null = null;
-        try {
-          existing = JSON.parse(raw) as { bodyHash?: unknown; record?: unknown };
-        } catch {
-          existing = null;
+      return raw === null ? {} : this.resultForExisting(this.parseStored(raw), bodyHash);
+    }
+
+    const now = Date.now();
+    const mapKey = this.memoryKey(scope, key);
+    const existing = this.memory.get(mapKey);
+    if (!existing) return {};
+    if (existing.expiresAt <= now) {
+      this.memory.delete(mapKey);
+      return {};
+    }
+    return this.resultForExisting(existing.entry, bodyHash);
+  }
+
+  /** Atomically claim an absent key immediately before an external side effect. */
+  async reserve(
+    scope: string,
+    key: string | undefined,
+    bodyHash: string,
+  ): Promise<IdempotencyCheck<TRecord>> {
+    if (!key) return {};
+    const now = Date.now();
+    const claim: StoredEntry<TRecord> = {
+      bodyHash,
+      state: "processing",
+      claimId: crypto.randomUUID(),
+      claimedAt: now,
+    };
+    const claimPayload = JSON.stringify(claim);
+    const redis = this.options.getRedisClient();
+    if (redis) {
+      const redisKey = this.redisKey(scope, key);
+      const reserved = await redis.set(redisKey, claimPayload, "PX", IDEMPOTENCY_TTL_MS, "NX");
+      if (!reserved) {
+        // SET NX and GET are separate operations. If the key expires between
+        // them, retry the atomic reservation once; otherwise absence is
+        // ambiguous and must fail closed.
+        const raw = await redis.get(redisKey);
+        if (raw === null) {
+          const retried = await redis.set(redisKey, claimPayload, "PX", IDEMPOTENCY_TTL_MS, "NX");
+          if (!retried) {
+            const raced = await redis.get(redisKey);
+            if (raced === null) throw new Error("Durable idempotency reservation is ambiguous");
+            return this.resultForExisting(this.parseStored(raced), bodyHash);
+          }
+        } else {
+          return this.resultForExisting(this.parseStored(raw), bodyHash);
         }
-        if (typeof existing?.bodyHash === "string" && existing.record) {
-          if (existing.bodyHash !== bodyHash) return { conflict: true };
-          return { record: existing.record as TRecord };
-        }
-        // An unparsable entry cannot vouch for a prior execution — treat as
-        // absent and let store() overwrite it below.
       }
+
       return {
         store: async (record) => {
-          const payload = JSON.stringify({ bodyHash, record });
-          await redis
-            .set(this.redisKey(scope, key), payload, "PX", IDEMPOTENCY_TTL_MS)
-            .catch((err) => {
-              // The movement already executed; losing the record means a later
-              // retry re-executes. Log loudly — nothing safer remains.
+          const completedPayload = JSON.stringify({
+            bodyHash,
+            state: "completed",
+            record,
+          } satisfies StoredEntry<TRecord>);
+          try {
+            const completed = await redis.eval(
+              COMPLETE_IF_OWNER_LUA,
+              1,
+              redisKey,
+              claimPayload,
+              completedPayload,
+              IDEMPOTENCY_TTL_MS,
+            );
+            if (Number(completed) !== 1) {
               console.error(
-                "[idempotency] failed to persist the outcome record; a retry may re-execute:",
-                err,
+                "[idempotency] outcome was not persisted because claim ownership changed; retries remain fail-closed",
               );
-            });
+            }
+          } catch (err) {
+            // The durable processing marker was written before execution and
+            // remains in place. Return the real movement outcome, but keep all
+            // retries fail-closed rather than risk a duplicate.
+            console.error(
+              "[idempotency] failed to complete the outcome record; retries remain fail-closed:",
+              err,
+            );
+          }
         },
       };
     }
 
-    // Process-local fallback (dev / single-replica): bounded + swept, mirroring
-    // the wave-2 maps.
-    const mapKey = `${scope}:${key}`;
+    // Single-process fallback. JavaScript executes this check-and-set without
+    // an await, so concurrent requests cannot both claim the same key.
+    const mapKey = this.memoryKey(scope, key);
     const existing = this.memory.get(mapKey);
     if (existing && existing.expiresAt > now) {
-      if (existing.bodyHash !== bodyHash) return { conflict: true };
-      return { record: existing.record };
+      return this.resultForExisting(existing.entry, bodyHash);
     }
+    if (existing) this.memory.delete(mapKey);
+    this.sweepMemory(now);
+    this.memory.set(mapKey, { entry: claim, expiresAt: now + IDEMPOTENCY_TTL_MS });
     return {
       store: async (record) => {
-        this.sweepMemory(now);
-        this.memory.set(mapKey, { bodyHash, record, expiresAt: now + IDEMPOTENCY_TTL_MS });
+        const current = this.memory.get(mapKey);
+        if (
+          !current ||
+          current.entry.state !== "processing" ||
+          current.entry.claimId !== claim.claimId
+        ) {
+          return;
+        }
+        this.memory.set(mapKey, {
+          entry: { bodyHash, state: "completed", record },
+          expiresAt: Date.now() + IDEMPOTENCY_TTL_MS,
+        });
       },
     };
   }

--- a/packages/plugin-trading/src/routes/operator-recovery.ts
+++ b/packages/plugin-trading/src/routes/operator-recovery.ts
@@ -230,20 +230,60 @@ export function createOperatorRecoveryRoutes(
     body: unknown,
   ): Promise<{
     conflict?: boolean;
+    pending?: boolean;
     entry?: OperatorIdempotencyRecord;
     store?: (response: unknown) => Promise<void>;
     storeFailure?: (errorBody: unknown) => Promise<void>;
+    claim?: () => Promise<{
+      conflict?: boolean;
+      pending?: boolean;
+      entry?: OperatorIdempotencyRecord;
+    }>;
   }> {
-    const check = await operatorIdempotencyStore.check(scope, key, JSON.stringify(body));
-    if (check.conflict || check.record) {
-      return { conflict: check.conflict, entry: check.record };
-    }
-    if (!check.store) return {};
-    const persist = check.store;
-    return {
-      store: (response: unknown) => persist({ status: 200, body: { ok: true, data: response } }),
-      storeFailure: (errorBody: unknown) => persist({ status: 502, body: errorBody }),
+    const bodyHash = JSON.stringify(body);
+    const check = await operatorIdempotencyStore.check(scope, key, bodyHash);
+    const result: Awaited<ReturnType<typeof getOperatorIdempotency>> = {
+      conflict: check.conflict,
+      pending: check.pending,
+      entry: check.record,
     };
+    result.claim = async () => {
+      const claim = await operatorIdempotencyStore.reserve(scope, key, bodyHash);
+      if (claim.store) {
+        const persist = claim.store;
+        result.store = (response: unknown) =>
+          persist({ status: 200, body: { ok: true, data: response } });
+        result.storeFailure = (errorBody: unknown) => persist({ status: 502, body: errorBody });
+      }
+      return {
+        conflict: claim.conflict,
+        pending: claim.pending,
+        entry: claim.record,
+      };
+    };
+    return result;
+  }
+
+  function operatorPendingResponse(c: Context<{ Variables: AppVariables }>) {
+    c.header("Retry-After", "1");
+    return c.json<ApiResponse>({ ok: false, error: "Idempotency key is already processing" }, 409);
+  }
+
+  async function claimOperatorIdempotency(
+    c: Context<{ Variables: AppVariables }>,
+    idempotency: Awaited<ReturnType<typeof getOperatorIdempotency>>,
+  ): Promise<Response | null> {
+    const claim = await idempotency.claim?.();
+    if (!claim) return null;
+    if (claim.conflict) {
+      return c.json<ApiResponse>(
+        { ok: false, error: "Idempotency key reused with a different body" },
+        409,
+      );
+    }
+    if (claim.entry) return c.json(claim.entry.body, claim.entry.status);
+    if (claim.pending) return operatorPendingResponse(c);
+    return null;
   }
 
   // ── Operator transfer rate limit (withdraw + usd-send) ────────────────────────
@@ -578,11 +618,14 @@ export function createOperatorRecoveryRoutes(
     if (idempotency.entry) {
       return c.json(idempotency.entry.body, idempotency.entry.status);
     }
+    if (idempotency.pending) return operatorPendingResponse(c);
 
     // Build the ERC-20 transfer(bridge, amount) calldata and have the vault sign +
     // broadcast it FROM the agent's venue wallet on Arbitrum. The raw key never
     // leaves the vault. venue is set so the vault selects the hyperliquid-scoped key.
     const data = encodeErc20Transfer(HYPERLIQUID_ARBITRUM_BRIDGE, amountBaseUnits);
+    const claimResponse = await claimOperatorIdempotency(c, idempotency);
+    if (claimResponse) return claimResponse;
     let txHash: string;
     try {
       txHash = await vault.signTransaction({
@@ -677,6 +720,7 @@ export function createOperatorRecoveryRoutes(
     if (idempotency.entry) {
       return c.json(idempotency.entry.body, idempotency.entry.status);
     }
+    if (idempotency.pending) return operatorPendingResponse(c);
 
     const agent = await ensureAgentForTenant(tenantId, agentId);
     if (!agent) return c.json<ApiResponse>({ ok: false, error: "Agent not found" }, 404);
@@ -701,6 +745,8 @@ export function createOperatorRecoveryRoutes(
       builderPerp,
     });
 
+    const claimResponse = await claimOperatorIdempotency(c, idempotency);
+    if (claimResponse) return claimResponse;
     let result: unknown;
     try {
       result = await adapter.updateLeverage({ coin, leverage: effectiveLeverage, isCross });
@@ -816,6 +862,7 @@ export function createOperatorRecoveryRoutes(
     if (idempotency.entry) {
       return c.json(idempotency.entry.body, idempotency.entry.status);
     }
+    if (idempotency.pending) return operatorPendingResponse(c);
 
     const agent = await ensureAgentForTenant(tenantId, agentId);
     if (!agent) return c.json<ApiResponse>({ ok: false, error: "Agent not found" }, 404);
@@ -838,6 +885,8 @@ export function createOperatorRecoveryRoutes(
       amountBaseUnits: amountBaseUnits.toString(),
     });
 
+    const claimResponse = await claimOperatorIdempotency(c, idempotency);
+    if (claimResponse) return claimResponse;
     let result: unknown;
     try {
       result = await adapter.addIsolatedMargin({ coin, amountUsdc: body.amountUsdc });
@@ -950,6 +999,7 @@ export function createOperatorRecoveryRoutes(
     if (idempotency.entry) {
       return c.json(idempotency.entry.body, idempotency.entry.status);
     }
+    if (idempotency.pending) return operatorPendingResponse(c);
 
     const agent = await ensureAgentForTenant(tenantId, agentId);
     if (!agent) return c.json<ApiResponse>({ ok: false, error: "Agent not found" }, 404);
@@ -993,6 +1043,8 @@ export function createOperatorRecoveryRoutes(
       amount,
     });
 
+    const claimResponse = await claimOperatorIdempotency(c, idempotency);
+    if (claimResponse) return claimResponse;
     let result: unknown;
     try {
       result = await adapter.usdSend({ destination, amount });
@@ -1071,6 +1123,7 @@ export function createOperatorRecoveryRoutes(
     if (idempotency.entry) {
       return c.json(idempotency.entry.body, idempotency.entry.status);
     }
+    if (idempotency.pending) return operatorPendingResponse(c);
 
     const agent = await ensureAgentForTenant(tenantId, agentId);
     if (!agent) return c.json<ApiResponse>({ ok: false, error: "Agent not found" }, 404);
@@ -1092,6 +1145,8 @@ export function createOperatorRecoveryRoutes(
       maxFeeRate,
     });
 
+    const claimResponse = await claimOperatorIdempotency(c, idempotency);
+    if (claimResponse) return claimResponse;
     let result: unknown;
     try {
       result = await adapter.approveBuilderFee({ builder, maxFeeRate });
@@ -1194,6 +1249,7 @@ export function createOperatorRecoveryRoutes(
     if (idempotency.entry) {
       return c.json(idempotency.entry.body, idempotency.entry.status);
     }
+    if (idempotency.pending) return operatorPendingResponse(c);
 
     const agent = await ensureAgentForTenant(tenantId, agentId);
     if (!agent) return c.json<ApiResponse>({ ok: false, error: "Agent not found" }, 404);
@@ -1241,6 +1297,8 @@ export function createOperatorRecoveryRoutes(
       return c.json<ApiResponse>({ ok: false, error: "Failed to sign collateral transfer" }, 502);
     }
 
+    const claimResponse = await claimOperatorIdempotency(c, idempotency);
+    if (claimResponse) return claimResponse;
     let result: unknown;
     const action: unknown = signed.action;
     try {
@@ -1313,6 +1371,7 @@ export function createOperatorRecoveryRoutes(
     if (idempotency.entry) {
       return c.json(idempotency.entry.body, idempotency.entry.status);
     }
+    if (idempotency.pending) return operatorPendingResponse(c);
 
     const agent = await ensureAgentForTenant(tenantId, agentId);
     if (!agent) return c.json<ApiResponse>({ ok: false, error: "Agent not found" }, 404);
@@ -1327,6 +1386,8 @@ export function createOperatorRecoveryRoutes(
 
     const adapter = buildAdapter(tenantId, agentId, walletAddress);
 
+    const claimResponse = await claimOperatorIdempotency(c, idempotency);
+    if (claimResponse) return claimResponse;
     let results: Awaited<ReturnType<HyperliquidAdapter["closeAllPositions"]>>;
     try {
       results = await adapter.closeAllPositions();
@@ -1438,6 +1499,7 @@ export function createOperatorRecoveryRoutes(
     if (idempotency.entry) {
       return c.json(idempotency.entry.body, idempotency.entry.status);
     }
+    if (idempotency.pending) return operatorPendingResponse(c);
 
     // Resolve amount after the idempotency cache lookup, so a retry for a
     // previous full-balance withdraw returns the cached success before reading a
@@ -1527,6 +1589,8 @@ export function createOperatorRecoveryRoutes(
       return c.json<ApiResponse>({ ok: false, error: "Failed to sign withdraw" }, 502);
     }
 
+    const claimResponse = await claimOperatorIdempotency(c, idempotency);
+    if (claimResponse) return claimResponse;
     let result: unknown;
     try {
       result = await adapter.submitWithdraw(signedWithdraw);

--- a/packages/plugin-trading/src/routes/trade.ts
+++ b/packages/plugin-trading/src/routes/trade.ts
@@ -345,15 +345,33 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
     body: SubmitOrderBody,
   ): Promise<{
     conflict?: boolean;
+    pending?: boolean;
     response?: TradeIdempotencyResponse;
     store?: (response: TradeIdempotencyResponse) => Promise<void>;
+    claim?: () => Promise<{
+      conflict?: boolean;
+      pending?: boolean;
+      response?: TradeIdempotencyResponse;
+    }>;
   }> {
-    const check = await hlIdempotencyStore.check(
-      `${tenantId}:${agentId}`,
-      key,
-      hashBody({ ...body, idempotencyKey: undefined }),
-    );
-    return { conflict: check.conflict, response: check.record, store: check.store };
+    const scope = `${tenantId}:${agentId}`;
+    const bodyHash = hashBody({ ...body, idempotencyKey: undefined });
+    const check = await hlIdempotencyStore.check(scope, key, bodyHash);
+    const result: Awaited<ReturnType<typeof getIdempotency>> = {
+      conflict: check.conflict,
+      pending: check.pending,
+      response: check.record,
+    };
+    result.claim = async () => {
+      const claim = await hlIdempotencyStore.reserve(scope, key, bodyHash);
+      result.store = claim.store;
+      return {
+        conflict: claim.conflict,
+        pending: claim.pending,
+        response: claim.record,
+      };
+    };
+    return result;
   }
 
   async function resolvePolicyLimitPx(
@@ -445,6 +463,34 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
       c.header(name, value);
     }
     return c.json(envelope.body, envelope.status);
+  }
+
+  function tradePendingResponse(c: Context<{ Variables: AppVariables }>) {
+    c.header("Retry-After", "1");
+    return c.json<ApiResponse>({ ok: false, error: "Idempotency key is already processing" }, 409);
+  }
+
+  async function claimTradeIdempotency(
+    c: Context<{ Variables: AppVariables }>,
+    idempotency: {
+      claim?: () => Promise<{
+        conflict?: boolean;
+        pending?: boolean;
+        response?: TradeIdempotencyResponse;
+      }>;
+    },
+  ): Promise<Response | null> {
+    const claim = await idempotency.claim?.();
+    if (!claim) return null;
+    if (claim.conflict) {
+      return c.json<ApiResponse>(
+        { ok: false, error: "Idempotency key reused with a different body" },
+        409,
+      );
+    }
+    if (claim.response) return tradeReplayResponse(c, claim.response);
+    if (claim.pending) return tradePendingResponse(c);
+    return null;
   }
 
   async function completeTradeIdempotencyBestEffort(
@@ -919,6 +965,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
     if (idempotency.response) {
       return tradeReplayResponse(c, idempotency.response);
     }
+    if (idempotency.pending) return tradePendingResponse(c);
 
     const session = await getSessionManager().getActive(tenantId, body.sessionId);
     if (!session || session.agentId !== agentId || session.venue !== "hyperliquid") {
@@ -1048,6 +1095,13 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
         policyLimitPx,
       );
     }
+
+    // Last safe boundary before spend reservation, leverage mutation, signing,
+    // and venue submission. SET NX makes concurrent replicas mutually
+    // exclusive; a crash leaves a durable processing marker that suppresses
+    // all retries for the idempotency window.
+    const claimResponse = await claimTradeIdempotency(c, idempotency);
+    if (claimResponse) return claimResponse;
 
     const walletAddress = session.walletId;
     const manager = getSessionManager();
@@ -1293,15 +1347,33 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
     body: PmSubmitOrderBody,
   ): Promise<{
     conflict?: boolean;
+    pending?: boolean;
     response?: TradeIdempotencyResponse;
     store?: (response: TradeIdempotencyResponse) => Promise<void>;
+    claim?: () => Promise<{
+      conflict?: boolean;
+      pending?: boolean;
+      response?: TradeIdempotencyResponse;
+    }>;
   }> {
-    const check = await pmIdempotencyStore.check(
-      `${tenantId}:${agentId}`,
-      key,
-      hashBody({ ...body, idempotencyKey: undefined }),
-    );
-    return { conflict: check.conflict, response: check.record, store: check.store };
+    const scope = `${tenantId}:${agentId}`;
+    const bodyHash = hashBody({ ...body, idempotencyKey: undefined });
+    const check = await pmIdempotencyStore.check(scope, key, bodyHash);
+    const result: Awaited<ReturnType<typeof getPmIdempotency>> = {
+      conflict: check.conflict,
+      pending: check.pending,
+      response: check.record,
+    };
+    result.claim = async () => {
+      const claim = await pmIdempotencyStore.reserve(scope, key, bodyHash);
+      result.store = claim.store;
+      return {
+        conflict: claim.conflict,
+        pending: claim.pending,
+        response: claim.record,
+      };
+    };
+    return result;
   }
 
   async function enforcePolymarketOrderRateLimit(
@@ -1399,11 +1471,15 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
     return key;
   }
 
-  function encryptPmCredsCacheValue(plaintext: string): string | null {
+  function encryptPmCredsCacheValue(plaintext: string, cacheKey: string): string | null {
     const key = pmCredsCacheEncryptionKey();
     if (!key) return null;
     const iv = randomBytes(12);
     const cipher = createCipheriv("aes-256-gcm", key, iv);
+    // Bind the ciphertext to its tenant/agent/wallet/endpoint cache key. A
+    // Redis reader-writer can copy opaque bytes but cannot transplant one
+    // agent's CLOB authority into another agent's cache slot.
+    cipher.setAAD(Buffer.from(cacheKey, "utf8"));
     let ciphertext = cipher.update(plaintext, "utf8", "hex");
     ciphertext += cipher.final("hex");
     return `${PM_CREDS_CACHE_PREFIX}${JSON.stringify({
@@ -1416,7 +1492,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
   // Returns null for anything that is not a valid envelope for THIS key —
   // including legacy plaintext entries — so the caller treats it as a cache
   // miss, re-derives, and overwrites with an encrypted value.
-  function decryptPmCredsCacheValue(stored: string): string | null {
+  function decryptPmCredsCacheValue(stored: string, cacheKey: string): string | null {
     if (!stored.startsWith(PM_CREDS_CACHE_PREFIX)) return null;
     const key = pmCredsCacheEncryptionKey();
     if (!key) return null;
@@ -1427,6 +1503,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
         tag: string;
       };
       const decipher = createDecipheriv("aes-256-gcm", key, Buffer.from(payload.iv, "hex"));
+      decipher.setAAD(Buffer.from(cacheKey, "utf8"));
       decipher.setAuthTag(Buffer.from(payload.tag, "hex"));
       let plaintext = decipher.update(payload.ciphertext, "hex", "utf8");
       plaintext += decipher.final("utf8");
@@ -1539,7 +1616,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
     if (redis) {
       try {
         const cached = await redis.get(cacheKey);
-        const cachedPlaintext = cached ? decryptPmCredsCacheValue(cached) : null;
+        const cachedPlaintext = cached ? decryptPmCredsCacheValue(cached, cacheKey) : null;
         if (cachedPlaintext) {
           const parsed = clobApiCredentialsSchema.safeParse(JSON.parse(cachedPlaintext));
           if (parsed.success) {
@@ -1569,7 +1646,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
     if (redis) {
       // Fail closed: without cache encryption key material, skip the write and
       // re-derive per order rather than ever storing the creds in plaintext.
-      const cacheValue = encryptPmCredsCacheValue(JSON.stringify(apiCredentials));
+      const cacheValue = encryptPmCredsCacheValue(JSON.stringify(apiCredentials), cacheKey);
       if (cacheValue) {
         await redis.setex(cacheKey, PM_CREDS_CACHE_TTL_SECONDS, cacheValue).catch(() => undefined);
       }
@@ -1683,6 +1760,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
     if (idempotency.response) {
       return tradeReplayResponse(c, idempotency.response);
     }
+    if (idempotency.pending) return tradePendingResponse(c);
 
     // Validate price + amount as positive finite numbers up front (the policy gate
     // needs the notional; the adapter re-validates the (0,1) price range).
@@ -1728,6 +1806,8 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
           status: 400,
           body: { code: "policy-violation", reason },
         };
+        const claimResponse = await claimTradeIdempotency(c, idempotency);
+        if (claimResponse) return claimResponse;
         await idempotency.store?.(envelope);
         return c.json(envelope.body, envelope.status);
       }
@@ -1788,6 +1868,8 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
         status: 400,
         body: { code: "policy-violation", reason: check.reason },
       };
+      const claimResponse = await claimTradeIdempotency(c, idempotency);
+      if (claimResponse) return claimResponse;
       await idempotency.store?.(envelope);
       return c.json(envelope.body, envelope.status);
     }
@@ -1858,6 +1940,12 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
       ...(body.tickSize ? { tickSize: body.tickSize } : {}),
       ...(typeof body.negRisk === "boolean" ? { negRisk: body.negRisk } : {}),
     };
+
+    // Last safe boundary before reserving session spend, signing, and posting
+    // the CLOB order. The durable processing claim suppresses concurrent and
+    // post-crash retries even when completion persistence later fails.
+    const claimResponse = await claimTradeIdempotency(c, idempotency);
+    if (claimResponse) return claimResponse;
 
     const manager = getSessionManager();
     // Fence reserve→submit against concurrent revocation (mirrors HL's

--- a/packages/venue-polymarket/src/execution.ts
+++ b/packages/venue-polymarket/src/execution.ts
@@ -120,32 +120,19 @@ function isAmbiguousPostError(raw: RawPostOrderResult): boolean {
   );
 }
 
-// USDC + outcome-token base-unit scale (6 decimals). The CLOB can report the
-// post-order making/taking amounts either as human-readable units (what matchr
-// observed live and consumed directly) or as 6-decimal base-unit strings
-// (matching the signed makerAmount/takerAmount). We detect + normalize so a
-// filled 20-share order is never reported as 20_000_000.
+// USDC + outcome-token fixed-math scale (6 decimals). The documented POST
+// /order response contract returns integer strings in fixed math. Some deployed
+// client/API paths have also returned decimal strings already expressed in
+// human units. The textual representation disambiguates those two contracts:
+// integer strings are fixed math; strings containing a decimal point are human.
 const BASE_UNIT_SCALE = 1e6;
-// Above this magnitude an "amount of shares/USD" is implausibly large for a
-// human unit and is almost certainly a 6-decimal base-unit value. Only used
-// when the order-size context cannot disambiguate (SEC-187).
-const BASE_UNIT_DETECT_THRESHOLD = 1e6;
-// Slack for venue rounding when bounding a fill by the signed order size.
-const FILL_ORDER_SIZE_TOLERANCE = 1.005;
 
-function normalizeFillUnit(value: number, orderSizeShares: number): number {
-  // SEC-187: derive the unit from the ORDER context instead of a bare
-  // magnitude guess. A fill can never exceed the signed order size, so:
-  //  - value fits the order size            -> human units (return as-is, even
-  //    for a genuine >=1M-share fill the magnitude heuristic shrank 1e6x);
-  //  - value exceeds it but fits scaled-down -> 6-dec base units (scale down,
-  //    even for sub-1e6 base-unit values the heuristic passed through as-is);
-  //  - exceeds it under BOTH interpretations -> inconsistent venue data; fall
-  //    back to the magnitude heuristic (trusted venue, accounting-only).
-  const allowance = orderSizeShares * FILL_ORDER_SIZE_TOLERANCE;
-  if (value <= allowance) return value;
-  if (value / BASE_UNIT_SCALE <= allowance) return value / BASE_UNIT_SCALE;
-  return value >= BASE_UNIT_DETECT_THRESHOLD ? value / BASE_UNIT_SCALE : value;
+function isHumanDecimalAmount(raw: string): boolean {
+  return raw.includes(".");
+}
+
+function normalizeFillUnit(value: number, raw: string): number {
+  return isHumanDecimalAmount(raw) ? value : value / BASE_UNIT_SCALE;
 }
 
 /**
@@ -154,9 +141,10 @@ function normalizeFillUnit(value: number, orderSizeShares: number): number {
  *
  * actualPrice = making/taking is unit-invariant (the 1e6 scale cancels), so it
  * is computed on the RAW amounts. actualAmount is normalized to human units
- * (shares) so callers never record base-unit-inflated sizes. The unit is
- * derived from the order context (fallback.amount — the signed order size in
- * shares at the call site): a fill can never exceed it (SEC-187).
+ * (shares) so callers never record base-unit-inflated sizes. Integer strings
+ * follow the venue's documented 6-decimal fixed-math contract; decimal strings
+ * are the human-unit response variant. This remains unambiguous for tiny fills
+ * and million-share orders, where magnitude/order-size heuristics cannot.
  *
  * Cases:
  *  - amounts MISSING/unparsable -> use fallback (accepted-no-amounts case).
@@ -184,14 +172,14 @@ export function deriveActualFill(
   if (side === "buy") {
     // BUY: taking = shares acquired, making = USD spent. price = making/taking.
     return {
-      actualAmount: normalizeFillUnit(takingAmount, fallback.amount),
+      actualAmount: normalizeFillUnit(takingAmount, result.takingAmount),
       actualPrice: makingAmount / takingAmount,
     };
   }
   // SELL: making = shares sold, taking = USD received. price = taking/making.
   // (Zero amounts already handled above as the resting/unfilled case.)
   return {
-    actualAmount: normalizeFillUnit(makingAmount, fallback.amount),
+    actualAmount: normalizeFillUnit(makingAmount, result.makingAmount),
     actualPrice: takingAmount / makingAmount,
   };
 }

--- a/packages/venue-polymarket/src/index.test.ts
+++ b/packages/venue-polymarket/src/index.test.ts
@@ -95,7 +95,7 @@ describe("deriveActualFill", () => {
   test("BUY: takingAmount = shares, price = making/taking", () => {
     const r = deriveActualFill(
       "buy",
-      { makingAmount: "10", takingAmount: "20" },
+      { makingAmount: "10.0", takingAmount: "20.0" },
       // Order size context: a 20-share buy (10 USDC at 0.5). The fill can never
       // exceed the signed size, so 20 reads as human units.
       { amount: 20, price: 0.5 },
@@ -107,7 +107,7 @@ describe("deriveActualFill", () => {
   test("SELL: makingAmount = shares, price = taking/making", () => {
     const r = deriveActualFill(
       "sell",
-      { makingAmount: "20", takingAmount: "12" },
+      { makingAmount: "20.0", takingAmount: "12.0" },
       { amount: 20, price: 0.6 },
     );
     expect(r.actualAmount).toBe(20);
@@ -167,18 +167,18 @@ describe("deriveActualFill", () => {
     expect(r).toEqual({ actualAmount: 7, actualPrice: 0.42 });
   });
 
-  test("SEC-187: a genuine >=1M-share fill in human units is NOT shrunk by the magnitude heuristic", () => {
+  test("SEC-187: a genuine >=1M-share decimal-unit fill is not shrunk", () => {
     // 2,000,000-share order filled in full, reported in human units.
     const r = deriveActualFill(
       "buy",
-      { makingAmount: "1000000", takingAmount: "2000000" },
+      { makingAmount: "1000000.0", takingAmount: "2000000.0" },
       { amount: 2_000_000, price: 0.5 },
     );
     expect(r.actualAmount).toBe(2_000_000); // NOT 2
     expect(r.actualPrice).toBeCloseTo(0.5, 10);
   });
 
-  test("SEC-187: a sub-1e6 base-unit fill is scaled down via order-size context", () => {
+  test("SEC-187: a sub-1e6 integer fixed-math fill is scaled down", () => {
     // 0.5-share fill on a 1-share order, reported as 6-decimal base units —
     // below the old magnitude threshold yet still base units.
     const r = deriveActualFill(
@@ -187,6 +187,19 @@ describe("deriveActualFill", () => {
       { amount: 1, price: 0.5 },
     );
     expect(r.actualAmount).toBe(0.5); // NOT 500000
+    expect(r.actualPrice).toBeCloseTo(0.5, 10);
+  });
+
+  test("SEC-187: a sub-order-size fixed-math fill on a million-share order is still scaled", () => {
+    // Magnitude/order-size inference misclassified this as 500,000 human
+    // shares because it fits inside the signed order. Integer response strings
+    // are authoritatively fixed-math, so this is a 0.5-share fill.
+    const r = deriveActualFill(
+      "buy",
+      { makingAmount: "250000", takingAmount: "500000" },
+      { amount: 1_000_000, price: 0.5 },
+    );
+    expect(r.actualAmount).toBe(0.5);
     expect(r.actualPrice).toBeCloseTo(0.5, 10);
   });
 });


### PR DESCRIPTION
## Security follow-up to #347

PR #347 merged while its security audit was still in progress. This follow-up fixes release-blocking defects in the merged SEC-043/SEC-108/SEC-187 implementation.

- replace check-then-execute-then-store with an atomic Redis `SET NX PX` processing claim at the last safe pre-execution boundary
- suppress concurrent, cross-replica, restart, crash, and completion-write-failure retries for 24h instead of permitting a duplicate fund movement
- fail closed on malformed durable records and use an owner-checked Lua completion CAS
- mirror atomic processing claims in the bounded single-process fallback
- bind encrypted Polymarket L2 credential cache blobs to tenant/agent/wallet/endpoint via AES-GCM AAD, preventing ciphertext transplantation between cache slots
- follow Polymarket POST /order wire semantics: integer amount strings are 6-decimal fixed math; decimal strings are the human-unit variant, avoiding both tiny-fill and million-order misaccounting

## Validation

- repository dependency build: 34/34 tasks green, including plugin-trading and both venue packages
- `bunx tsc -p packages/plugin-trading/tsconfig.json --noEmit`
- `bunx tsc -p packages/venue-polymarket/tsconfig.json --noEmit`
- idempotency store: 9/9
- venue-polymarket: 59/59
- encrypted credential cache: 2/2
- Polymarket order lifecycle: 28/28
- operator recovery suites completed green before the final narrow rebase
- Biome and `git diff --check` clean

The original #347 head documented concurrent duplicate execution and post-execution store loss as accepted residuals; those are not acceptable for fund-moving routes and are eliminated here.