### PR TITLE
fix(policy): preserve partial canonical spending caps

### DIFF
--- a/packages/policy-engine/src/__tests__/evaluators.test.ts
+++ b/packages/policy-engine/src/__tests__/evaluators.test.ts
@@ -617,6 +617,47 @@ describe("Spending Limit Policy", () => {
     expect(result.reason).toContain("daily spending limit");
   });
 
+  it("fails closed without throwing on non-record spending configs", async () => {
+    for (const config of [null, [], "1000"]) {
+      const rule = makeSpendingRule(config as never);
+      const result = await evaluatePolicy(rule, makeContext());
+      expect(result.passed).toBe(false);
+      expect(result.reason).toContain("non-empty canonical or legacy limit config");
+    }
+  });
+
+  it("fails closed for an empty spending config even on a zero-value request", async () => {
+    const result = await evaluatePolicy(
+      makeSpendingRule({}),
+      makeContext({ request: { ...makeContext().request, value: "0" } }),
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("non-empty canonical or legacy limit config");
+  });
+
+  it("ignores inherited canonical fields that would erase a legacy daily cap", async () => {
+    const config = Object.assign(
+      Object.create({
+        maxPerTx: "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+      }),
+      {
+        maxAmount: "1000",
+        period: "day",
+      },
+    ) as Record<string, unknown>;
+    const result = await evaluatePolicy(
+      makeSpendingRule(config),
+      makeContext({
+        request: { ...makeContext().request, value: "200" },
+        spentToday: 900n,
+      }),
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("daily spending limit");
+  });
+
   // ─── Per-tx boundary tests ─────────────────────────────────────────────
 
   it("passes when value is exactly at the per-tx limit (boundary)", async () => {

--- a/packages/policy-engine/src/__tests__/evaluators.test.ts
+++ b/packages/policy-engine/src/__tests__/evaluators.test.ts
@@ -547,6 +547,57 @@ describe("Spending Limit Policy", () => {
     expect(result.passed).toBe(true);
   });
 
+  it("enforces a mixed daily wei cap when maxPerTx is omitted", async () => {
+    const rule = makeSpendingRule({
+      maxPerDay: "1000000000000000000", // 1 ETH
+      maxPerDayUsd: 5000,
+    });
+
+    const result = await evaluatePolicy(
+      rule,
+      makeContext({
+        request: { ...makeContext().request, value: "200000000000000000" }, // 0.2 ETH
+        spentToday: BigInt("900000000000000000"), // 0.9 ETH
+        priceOracle: ethPriceOracle,
+      }),
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("daily spending limit");
+  });
+
+  it("enforces a canonical daily wei cap without requiring maxPerTx", async () => {
+    const rule = makeSpendingRule({ maxPerDay: "1000" });
+    const result = await evaluatePolicy(
+      rule,
+      makeContext({
+        request: { ...makeContext().request, value: "200" },
+        spentToday: 900n,
+      }),
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("daily spending limit");
+  });
+
+  it("enforces a mixed weekly wei cap when per-tx and daily caps are omitted", async () => {
+    const rule = makeSpendingRule({
+      maxPerWeek: "1000000000000000000", // 1 ETH
+      maxPerWeekUsd: 5000,
+    });
+    const result = await evaluatePolicy(
+      rule,
+      makeContext({
+        request: { ...makeContext().request, value: "200000000000000000" },
+        spentThisWeek: BigInt("900000000000000000"),
+        priceOracle: ethPriceOracle,
+      }),
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("weekly spending limit");
+  });
+
   // ─── Per-tx boundary tests ─────────────────────────────────────────────
 
   it("passes when value is exactly at the per-tx limit (boundary)", async () => {

--- a/packages/policy-engine/src/__tests__/evaluators.test.ts
+++ b/packages/policy-engine/src/__tests__/evaluators.test.ts
@@ -598,6 +598,25 @@ describe("Spending Limit Policy", () => {
     expect(result.reason).toContain("weekly spending limit");
   });
 
+  it("preserves a legacy maxAmount cap when a USD cap is added", async () => {
+    const rule = makeSpendingRule({
+      maxAmount: "1000000000000000000", // 1 ETH daily and per transaction
+      period: "day",
+      maxPerDayUsd: 5000,
+    });
+    const result = await evaluatePolicy(
+      rule,
+      makeContext({
+        request: { ...makeContext().request, value: "200000000000000000" }, // 0.2 ETH
+        spentToday: BigInt("900000000000000000"), // 0.9 ETH
+        priceOracle: ethPriceOracle,
+      }),
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("daily spending limit");
+  });
+
   // ─── Per-tx boundary tests ─────────────────────────────────────────────
 
   it("passes when value is exactly at the per-tx limit (boundary)", async () => {

--- a/packages/policy-engine/src/__tests__/evaluators.test.ts
+++ b/packages/policy-engine/src/__tests__/evaluators.test.ts
@@ -658,6 +658,41 @@ describe("Spending Limit Policy", () => {
     expect(result.reason).toContain("daily spending limit");
   });
 
+  it("preserves untouched legacy dimensions when a canonical weekly cap is added", async () => {
+    const rule = makeSpendingRule({
+      maxAmount: "100",
+      period: "day",
+      maxPerWeek: "1000",
+    });
+    const result = await evaluatePolicy(
+      rule,
+      makeContext({
+        request: { ...makeContext().request, value: "20" },
+        spentToday: 90n,
+      }),
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("daily spending limit");
+  });
+
+  it("lets an explicit canonical dimension replace only its legacy counterpart", async () => {
+    const rule = makeSpendingRule({
+      maxAmount: "100",
+      period: "day",
+      maxPerTx: "200",
+    });
+    const result = await evaluatePolicy(
+      rule,
+      makeContext({
+        request: { ...makeContext().request, value: "150" },
+      }),
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("daily spending limit");
+  });
+
   // ─── Per-tx boundary tests ─────────────────────────────────────────────
 
   it("passes when value is exactly at the per-tx limit (boundary)", async () => {

--- a/packages/policy-engine/src/evaluators.ts
+++ b/packages/policy-engine/src/evaluators.ts
@@ -295,24 +295,23 @@ function evaluateRawSigningChain(rule: PolicyRule, ctx: EvaluatorContext): Polic
  * Accepts both the canonical format and the simplified maxAmount/period format.
  */
 function normalizeSpendingLimitConfig(config: Record<string, unknown>): SpendingLimitConfig {
-  // If already in canonical format (has any of the standard fields), fill in missing with MAX_UINT
-  if (config.maxPerTx !== undefined || config.maxPerTxUsd !== undefined) {
+  // Any canonical wei or USD field selects the canonical format. Missing wei
+  // caps are unbounded, but every explicitly declared cap must survive
+  // normalization. Checking only the per-tx fields caused a mixed config such
+  // as { maxPerDay, maxPerDayUsd } to take the USD-only branch and silently
+  // discard maxPerDay.
+  if (
+    config.maxPerTx !== undefined ||
+    config.maxPerDay !== undefined ||
+    config.maxPerWeek !== undefined ||
+    config.maxPerTxUsd !== undefined ||
+    config.maxPerDayUsd !== undefined ||
+    config.maxPerWeekUsd !== undefined
+  ) {
     return {
       maxPerTx: config.maxPerTx !== undefined ? String(config.maxPerTx) : MAX_UINT256_DECIMAL,
       maxPerDay: config.maxPerDay !== undefined ? String(config.maxPerDay) : MAX_UINT256_DECIMAL,
       maxPerWeek: config.maxPerWeek !== undefined ? String(config.maxPerWeek) : MAX_UINT256_DECIMAL,
-      maxPerTxUsd: config.maxPerTxUsd as number | undefined,
-      maxPerDayUsd: config.maxPerDayUsd as number | undefined,
-      maxPerWeekUsd: config.maxPerWeekUsd as number | undefined,
-    };
-  }
-
-  // Also check if any USD field is present
-  if (config.maxPerDayUsd !== undefined || config.maxPerWeekUsd !== undefined) {
-    return {
-      maxPerTx: MAX_UINT256_DECIMAL,
-      maxPerDay: MAX_UINT256_DECIMAL,
-      maxPerWeek: MAX_UINT256_DECIMAL,
       maxPerTxUsd: config.maxPerTxUsd as number | undefined,
       maxPerDayUsd: config.maxPerDayUsd as number | undefined,
       maxPerWeekUsd: config.maxPerWeekUsd as number | undefined,

--- a/packages/policy-engine/src/evaluators.ts
+++ b/packages/policy-engine/src/evaluators.ts
@@ -31,10 +31,6 @@ const MAX_UINT256_DECIMAL =
   "115792089237316195423570985008687907853269984665640564039457584007913129639935";
 const MAX_UINT256_DECIMAL_DIGITS = 78;
 
-function hasOwnDefined(record: Record<string, unknown>, key: string): boolean {
-  return Object.hasOwn(record, key) && record[key] !== undefined;
-}
-
 export interface EvaluatorContext {
   request: SignRequest;
   recentTxCount24h: number;
@@ -298,6 +294,10 @@ function evaluateRawSigningChain(rule: PolicyRule, ctx: EvaluatorContext): Polic
  * Normalize spending-limit config to the canonical format (maxPerTx/maxPerDay/maxPerWeek).
  * Accepts both the canonical format and the simplified maxAmount/period format.
  */
+function hasOwnDefined(record: Record<string, unknown>, key: string): boolean {
+  return Object.hasOwn(record, key) && record[key] !== undefined;
+}
+
 function normalizeSpendingLimitConfig(config: Record<string, unknown>): SpendingLimitConfig {
   const simplifiedWeiCaps = (): Pick<
     SpendingLimitConfig,

--- a/packages/policy-engine/src/evaluators.ts
+++ b/packages/policy-engine/src/evaluators.ts
@@ -31,6 +31,10 @@ const MAX_UINT256_DECIMAL =
   "115792089237316195423570985008687907853269984665640564039457584007913129639935";
 const MAX_UINT256_DECIMAL_DIGITS = 78;
 
+function hasOwnDefined(record: Record<string, unknown>, key: string): boolean {
+  return Object.hasOwn(record, key) && record[key] !== undefined;
+}
+
 export interface EvaluatorContext {
   request: SignRequest;
   recentTxCount24h: number;
@@ -336,13 +340,13 @@ function normalizeSpendingLimitConfig(config: Record<string, unknown>): Spending
   };
 
   const hasCanonicalWeiCap =
-    config.maxPerTx !== undefined ||
-    config.maxPerDay !== undefined ||
-    config.maxPerWeek !== undefined;
+    hasOwnDefined(config, "maxPerTx") ||
+    hasOwnDefined(config, "maxPerDay") ||
+    hasOwnDefined(config, "maxPerWeek");
   const hasUsdCap =
-    config.maxPerTxUsd !== undefined ||
-    config.maxPerDayUsd !== undefined ||
-    config.maxPerWeekUsd !== undefined;
+    hasOwnDefined(config, "maxPerTxUsd") ||
+    hasOwnDefined(config, "maxPerDayUsd") ||
+    hasOwnDefined(config, "maxPerWeekUsd");
 
   // Any canonical wei or USD field selects the canonical format. Missing wei
   // caps are unbounded, but every explicitly declared cap must survive
@@ -355,20 +359,30 @@ function normalizeSpendingLimitConfig(config: Record<string, unknown>): Spending
     // Explicit canonical wei fields still take precedence over the legacy
     // representation when both are present.
     const weiCaps =
-      !hasCanonicalWeiCap && config.maxAmount !== undefined
+      !hasCanonicalWeiCap && hasOwnDefined(config, "maxAmount")
         ? simplifiedWeiCaps()
         : {
-            maxPerTx: config.maxPerTx !== undefined ? String(config.maxPerTx) : MAX_UINT256_DECIMAL,
-            maxPerDay:
-              config.maxPerDay !== undefined ? String(config.maxPerDay) : MAX_UINT256_DECIMAL,
-            maxPerWeek:
-              config.maxPerWeek !== undefined ? String(config.maxPerWeek) : MAX_UINT256_DECIMAL,
+            maxPerTx: hasOwnDefined(config, "maxPerTx")
+              ? String(config.maxPerTx)
+              : MAX_UINT256_DECIMAL,
+            maxPerDay: hasOwnDefined(config, "maxPerDay")
+              ? String(config.maxPerDay)
+              : MAX_UINT256_DECIMAL,
+            maxPerWeek: hasOwnDefined(config, "maxPerWeek")
+              ? String(config.maxPerWeek)
+              : MAX_UINT256_DECIMAL,
           };
     return {
       ...weiCaps,
-      maxPerTxUsd: config.maxPerTxUsd as number | undefined,
-      maxPerDayUsd: config.maxPerDayUsd as number | undefined,
-      maxPerWeekUsd: config.maxPerWeekUsd as number | undefined,
+      maxPerTxUsd: hasOwnDefined(config, "maxPerTxUsd")
+        ? (config.maxPerTxUsd as number)
+        : undefined,
+      maxPerDayUsd: hasOwnDefined(config, "maxPerDayUsd")
+        ? (config.maxPerDayUsd as number)
+        : undefined,
+      maxPerWeekUsd: hasOwnDefined(config, "maxPerWeekUsd")
+        ? (config.maxPerWeekUsd as number)
+        : undefined,
     };
   }
 
@@ -404,8 +418,34 @@ async function evaluateSpendingLimit(
   rule: PolicyRule,
   ctx: EvaluatorContext,
 ): Promise<PolicyResult> {
-  const config = normalizeSpendingLimitConfig(rule.config);
   const base = { policyId: rule.id, type: rule.type } as const;
+  const rawConfig: unknown = rule.config;
+  if (typeof rawConfig !== "object" || rawConfig === null || Array.isArray(rawConfig)) {
+    return {
+      ...base,
+      passed: false,
+      reason: "Spending limit requires a non-empty canonical or legacy limit config",
+    };
+  }
+  const configRecord = rawConfig as Record<string, unknown>;
+  if (
+    ![
+      "maxPerTx",
+      "maxPerDay",
+      "maxPerWeek",
+      "maxPerTxUsd",
+      "maxPerDayUsd",
+      "maxPerWeekUsd",
+      "maxAmount",
+    ].some((field) => hasOwnDefined(configRecord, field))
+  ) {
+    return {
+      ...base,
+      passed: false,
+      reason: "Spending limit requires a non-empty canonical or legacy limit config",
+    };
+  }
+  const config = normalizeSpendingLimitConfig(configRecord);
   const txValue = parseUint256Decimal(ctx.request.value);
   if (txValue === null) {
     return {
@@ -496,10 +536,10 @@ async function evaluateSpendingLimit(
     // unenforced (SEC-037). Fall through to the wei evaluation — undeclared
     // wei fields normalize to MAX_UINT256, so only explicit caps bite.
     if (
-      rule.config.maxPerTx === undefined &&
-      rule.config.maxPerDay === undefined &&
-      rule.config.maxPerWeek === undefined &&
-      rule.config.maxAmount === undefined
+      !hasOwnDefined(configRecord, "maxPerTx") &&
+      !hasOwnDefined(configRecord, "maxPerDay") &&
+      !hasOwnDefined(configRecord, "maxPerWeek") &&
+      !hasOwnDefined(configRecord, "maxAmount")
     ) {
       return { ...base, passed: true };
     }

--- a/packages/policy-engine/src/evaluators.ts
+++ b/packages/policy-engine/src/evaluators.ts
@@ -354,24 +354,28 @@ function normalizeSpendingLimitConfig(config: Record<string, unknown>): Spending
   // as { maxPerDay, maxPerDayUsd } to take the USD-only branch and silently
   // discard maxPerDay.
   if (hasCanonicalWeiCap || hasUsdCap) {
-    // Legacy policies can legitimately contain `{ maxAmount, period }` plus a
-    // newer USD cap. Do not let the USD field erase that existing wei limit.
-    // Explicit canonical wei fields still take precedence over the legacy
-    // representation when both are present.
-    const weiCaps =
-      !hasCanonicalWeiCap && hasOwnDefined(config, "maxAmount")
-        ? simplifiedWeiCaps()
-        : {
-            maxPerTx: hasOwnDefined(config, "maxPerTx")
-              ? String(config.maxPerTx)
-              : MAX_UINT256_DECIMAL,
-            maxPerDay: hasOwnDefined(config, "maxPerDay")
-              ? String(config.maxPerDay)
-              : MAX_UINT256_DECIMAL,
-            maxPerWeek: hasOwnDefined(config, "maxPerWeek")
-              ? String(config.maxPerWeek)
-              : MAX_UINT256_DECIMAL,
-          };
+    // Legacy policies can legitimately gain canonical or USD fields one at a
+    // time. Preserve the legacy limits for every dimension that was not
+    // explicitly replaced; treating the first canonical wei field as a switch
+    // for the whole representation could silently erase the other legacy caps.
+    const inheritedWeiCaps = hasOwnDefined(config, "maxAmount")
+      ? simplifiedWeiCaps()
+      : {
+          maxPerTx: MAX_UINT256_DECIMAL,
+          maxPerDay: MAX_UINT256_DECIMAL,
+          maxPerWeek: MAX_UINT256_DECIMAL,
+        };
+    const weiCaps = {
+      maxPerTx: hasOwnDefined(config, "maxPerTx")
+        ? String(config.maxPerTx)
+        : inheritedWeiCaps.maxPerTx,
+      maxPerDay: hasOwnDefined(config, "maxPerDay")
+        ? String(config.maxPerDay)
+        : inheritedWeiCaps.maxPerDay,
+      maxPerWeek: hasOwnDefined(config, "maxPerWeek")
+        ? String(config.maxPerWeek)
+        : inheritedWeiCaps.maxPerWeek,
+    };
     return {
       ...weiCaps,
       maxPerTxUsd: hasOwnDefined(config, "maxPerTxUsd")

--- a/packages/policy-engine/src/evaluators.ts
+++ b/packages/policy-engine/src/evaluators.ts
@@ -295,23 +295,77 @@ function evaluateRawSigningChain(rule: PolicyRule, ctx: EvaluatorContext): Polic
  * Accepts both the canonical format and the simplified maxAmount/period format.
  */
 function normalizeSpendingLimitConfig(config: Record<string, unknown>): SpendingLimitConfig {
+  const simplifiedWeiCaps = (): Pick<
+    SpendingLimitConfig,
+    "maxPerTx" | "maxPerDay" | "maxPerWeek"
+  > => {
+    const maxAmount = String(config.maxAmount ?? "0");
+    const period = String(config.period ?? "day").toLowerCase();
+
+    switch (period) {
+      case "tx":
+      case "transaction":
+        return {
+          maxPerTx: maxAmount,
+          maxPerDay: MAX_UINT256_DECIMAL,
+          maxPerWeek: MAX_UINT256_DECIMAL,
+        };
+      case "day":
+      case "daily":
+        return {
+          maxPerTx: maxAmount,
+          maxPerDay: maxAmount,
+          maxPerWeek: MAX_UINT256_DECIMAL,
+        };
+      case "week":
+      case "weekly":
+        return {
+          maxPerTx: maxAmount,
+          maxPerDay: MAX_UINT256_DECIMAL,
+          maxPerWeek: maxAmount,
+        };
+      default:
+        // Preserve the historical fail-safe fallback: an unknown period is
+        // treated as a per-transaction cap rather than as unbounded spend.
+        return {
+          maxPerTx: maxAmount,
+          maxPerDay: MAX_UINT256_DECIMAL,
+          maxPerWeek: MAX_UINT256_DECIMAL,
+        };
+    }
+  };
+
+  const hasCanonicalWeiCap =
+    config.maxPerTx !== undefined ||
+    config.maxPerDay !== undefined ||
+    config.maxPerWeek !== undefined;
+  const hasUsdCap =
+    config.maxPerTxUsd !== undefined ||
+    config.maxPerDayUsd !== undefined ||
+    config.maxPerWeekUsd !== undefined;
+
   // Any canonical wei or USD field selects the canonical format. Missing wei
   // caps are unbounded, but every explicitly declared cap must survive
   // normalization. Checking only the per-tx fields caused a mixed config such
   // as { maxPerDay, maxPerDayUsd } to take the USD-only branch and silently
   // discard maxPerDay.
-  if (
-    config.maxPerTx !== undefined ||
-    config.maxPerDay !== undefined ||
-    config.maxPerWeek !== undefined ||
-    config.maxPerTxUsd !== undefined ||
-    config.maxPerDayUsd !== undefined ||
-    config.maxPerWeekUsd !== undefined
-  ) {
+  if (hasCanonicalWeiCap || hasUsdCap) {
+    // Legacy policies can legitimately contain `{ maxAmount, period }` plus a
+    // newer USD cap. Do not let the USD field erase that existing wei limit.
+    // Explicit canonical wei fields still take precedence over the legacy
+    // representation when both are present.
+    const weiCaps =
+      !hasCanonicalWeiCap && config.maxAmount !== undefined
+        ? simplifiedWeiCaps()
+        : {
+            maxPerTx: config.maxPerTx !== undefined ? String(config.maxPerTx) : MAX_UINT256_DECIMAL,
+            maxPerDay:
+              config.maxPerDay !== undefined ? String(config.maxPerDay) : MAX_UINT256_DECIMAL,
+            maxPerWeek:
+              config.maxPerWeek !== undefined ? String(config.maxPerWeek) : MAX_UINT256_DECIMAL,
+          };
     return {
-      maxPerTx: config.maxPerTx !== undefined ? String(config.maxPerTx) : MAX_UINT256_DECIMAL,
-      maxPerDay: config.maxPerDay !== undefined ? String(config.maxPerDay) : MAX_UINT256_DECIMAL,
-      maxPerWeek: config.maxPerWeek !== undefined ? String(config.maxPerWeek) : MAX_UINT256_DECIMAL,
+      ...weiCaps,
       maxPerTxUsd: config.maxPerTxUsd as number | undefined,
       maxPerDayUsd: config.maxPerDayUsd as number | undefined,
       maxPerWeekUsd: config.maxPerWeekUsd as number | undefined,
@@ -319,39 +373,7 @@ function normalizeSpendingLimitConfig(config: Record<string, unknown>): Spending
   }
 
   // Convert from maxAmount/period format
-  const maxAmount = String(config.maxAmount ?? "0");
-  const period = String(config.period ?? "day").toLowerCase();
-
-  switch (period) {
-    case "tx":
-    case "transaction":
-      return {
-        maxPerTx: maxAmount,
-        maxPerDay: MAX_UINT256_DECIMAL,
-        maxPerWeek: MAX_UINT256_DECIMAL,
-      };
-    case "day":
-    case "daily":
-      return {
-        maxPerTx: maxAmount,
-        maxPerDay: maxAmount,
-        maxPerWeek: MAX_UINT256_DECIMAL,
-      };
-    case "week":
-    case "weekly":
-      return {
-        maxPerTx: maxAmount,
-        maxPerDay: MAX_UINT256_DECIMAL,
-        maxPerWeek: maxAmount,
-      };
-    default:
-      // Fallback: treat as per-tx limit
-      return {
-        maxPerTx: maxAmount,
-        maxPerDay: MAX_UINT256_DECIMAL,
-        maxPerWeek: MAX_UINT256_DECIMAL,
-      };
-  }
+  return simplifiedWeiCaps();
 }
 
 /**
@@ -476,7 +498,8 @@ async function evaluateSpendingLimit(
     if (
       rule.config.maxPerTx === undefined &&
       rule.config.maxPerDay === undefined &&
-      rule.config.maxPerWeek === undefined
+      rule.config.maxPerWeek === undefined &&
+      rule.config.maxAmount === undefined
     ) {
       return { ...base, passed: true };
     }


### PR DESCRIPTION
Post-merge corrective for #320 (SEC-037).

This change normalizes mixed legacy and canonical spending policies field by field. Each explicitly supplied canonical wei cap overrides only its own dimension; untouched dimensions retain the legacy `maxAmount`/`period` cap. Own-property checks and malformed-config fail-closed hardening from the concurrent branch advances are preserved.

Exact base: `73454819ea020dcd676cb36066dbd60d07e4ec98`  
Exact head: `8f18f3122030e5b15d263022887898ac410b005e`

Validation:

- five-commit rebase range-diff: all commits patch-equivalent (`=`), with no conflict-resolution delta
- policy-engine focused suite: 109 passed, 0 failed, 213 assertions
- dependency-aware policy-engine build: 5/5 packages successful
- `bun install --frozen-lockfile`: no changes
- Biome on all changed files: clean
- `git diff --check`: clean

The PR remains draft pending exact-head CI and independent review.
