### PR TITLE
fix(capabilities): broker GitHub until native token mint

### DIFF
--- a/packages/plugin-capabilities/PROVIDER-MODES.md
+++ b/packages/plugin-capabilities/PROVIDER-MODES.md
@@ -17,7 +17,7 @@ for a provider we have not deliberately classified as token-safe).
 | Provider | Mode   | Rationale |
 |----------|--------|-----------|
 | `discord` | **broker** | Discord bot tokens cannot be down-scoped or short-lived by Discord; handing the raw token to an agent would leak a long-lived credential. Steward brokers the call so the token never leaves the enclave. **This is the canonical broker-mode case.** |
-| `github` | **token** | GitHub App installation tokens are natively short-lived (≈1h) and scopable per installation/permission; Steward can mint a scoped installation token. (A raw PAT-backed github provider would instead be broker mode.) |
+| `github` | **broker** | GitHub App installation tokens can be short-lived and scoped, but Steward does not yet perform the provider-native installation-token exchange. GitHub remains brokered until it does; an internal Steward JWT is not a GitHub credential. |
 | `llm` | **broker** | A shared LLM pool seat is a long-lived provider API key that cannot be down-scoped per agent; Steward brokers completions through the credential-injection proxy so the key stays in the enclave (spend/rate policy enforced server-side). |
 | `wallet` | **broker** | Signing authority must never leave custody. The agent requests a signature; Steward (vault / future threshold signer, Pillar D) performs it and returns only the signature. There is no "scoped short-lived private key" to hand out. |
 | `openai` | **broker** | OpenAI API keys are long-lived and not per-call scopable; brokered through the existing OpenAI-compatible capability adapter so the key stays server-side. |
@@ -26,16 +26,14 @@ for a provider we have not deliberately classified as token-safe).
 
 ## How modes are exercised
 
-### token mode
-```
-POST /capabilities/manifest/github:app:org/issue   { "ttlSeconds": 120 }
-→ { "mode": "token", "token": "<short-lived JWT>", "ttlSeconds": 120,
-    "scopes": ["cap:github:app:org"] }
-```
-The token is a minute-scale agent JWT scoped to exactly this capability
-(`cap:<manifest-id>`) — it carries ONLY the `cap:` scope (never the broad
-`agent` scope) and the tenant surface refuses `cap:`-scoped tokens, so it is
-not a general agent credential. The agent renews before expiry (`.../renew`).
+### token mode (no provider currently enabled)
+
+When a provider-native scoped-token minter is implemented and enabled, issuance
+may return that provider's short-lived credential. Steward must not substitute
+one of its own session JWTs for a provider credential.
+
+GitHub is deliberately broker mode today. Its credential stays in Steward and
+the agent invokes the granted capability through the defended broker path.
 
 ### broker mode
 ```
@@ -53,11 +51,11 @@ only the scrubbed upstream response.
 
 ## Renewal & revocation
 
-- **TTL** is minute-scale (`DEFAULT_ISSUE_TTL_SECONDS = 120`, hard ceiling
+- For a future token-mode provider, **TTL** is minute-scale (`DEFAULT_ISSUE_TTL_SECONDS = 120`, hard ceiling
   `MAX_ISSUE_TTL_SECONDS = 300`). Agents auto-renew.
 - **Revocation** is an operator act: disable the capability or revoke the grant
   via the existing capability CRUD. The change takes effect at the agent's **next
   renewal** — bounded by the TTL, satisfying the Pillar-A green criterion
   (<5 min). Every renewal is a fresh, fully-checked issuance.
-- For an immediate kill, the minted `jti` is surfaced so it can be revoked via the
+- For an immediate token-mode kill, the minted `jti` is surfaced so it can be revoked via the
   existing JWT revocation store.

--- a/packages/plugin-capabilities/src/__tests__/issuance.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/issuance.test.ts
@@ -11,7 +11,6 @@
 import { describe, expect, test } from "bun:test";
 import {
   type CapabilityAuditEvent,
-  capabilityTokenScope,
   clampTtlSeconds,
   DEFAULT_ISSUE_TTL_SECONDS,
   issueCapability,
@@ -114,37 +113,33 @@ describe("issueCapability", () => {
     });
   });
 
-  test("token mode: mints a short-lived capability-scoped token", async () => {
+  test("github remains brokered until a provider-native token minter exists", async () => {
     const { events, sink } = collectAudit();
+    let minted = false;
     const res = await issueCapability({
       tenantId: "t1",
       agentId: "a1",
       manifest: "github:app:org",
       resolved: resolved("github", "github:app:org"),
       ttlSeconds: 60,
-      mintToken: fakeMinter,
+      mintToken: async (args) => {
+        minted = true;
+        return fakeMinter(args);
+      },
       emitAudit: sink,
     });
     expect(res.ok).toBe(true);
-    if (!res.ok || res.mode !== "token") throw new Error("expected token mode");
-    expect(res.token).toBe("tok.ttl=60");
-    expect(res.ttlSeconds).toBe(60);
-    expect(res.jti).toBe("jti-123");
-    // Least privilege (SEC-033): the token carries ONLY the capability scope.
-    // Stamping the broad `agent` scope would make it a general agent credential
-    // for the whole tenant surface.
-    expect(res.scopes).toEqual([capabilityTokenScope("github:app:org")]);
-    expect(res.scopes).not.toContain("agent");
+    if (!res.ok || res.mode !== "broker") throw new Error("expected broker mode");
+    expect(minted).toBe(false);
+    expect(res.delegation.capabilityName).toBe("github:app:org");
     expect(events[0]).toMatchObject({
       action: "capability.issue",
-      mode: "token",
+      mode: "broker",
       decision: "allow",
-      jti: "jti-123",
-      ttlSeconds: 60,
     });
   });
 
-  test("token mode: rejects out-of-range ttl with deny audit", async () => {
+  test("broker mode does not pretend to honor token TTL parameters", async () => {
     const { events, sink } = collectAudit();
     const res = await issueCapability({
       tenantId: "t1",
@@ -155,10 +150,10 @@ describe("issueCapability", () => {
       mintToken: fakeMinter,
       emitAudit: sink,
     });
-    expect(res.ok).toBe(false);
-    if (res.ok) throw new Error("expected deny");
-    expect(res.code).toBe("ttl_out_of_range");
-    expect(events[0]).toMatchObject({ decision: "deny", reason: "requested ttl out of range" });
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error("expected allow");
+    expect(res.mode).toBe("broker");
+    expect(events[0]).toMatchObject({ decision: "allow", mode: "broker" });
   });
 
   test("revocation: unresolved (no live grant) denies", async () => {
@@ -193,26 +188,6 @@ describe("issueCapability", () => {
     });
     expect(res.ok).toBe(true);
     expect(events[0].action).toBe("capability.renew");
-  });
-
-  test("mint failure denies (mint_failed) and never leaks", async () => {
-    const { events, sink } = collectAudit();
-    const failingMinter: ShortLivedTokenMinter = async () => {
-      throw new Error("hsm offline");
-    };
-    const res = await issueCapability({
-      tenantId: "t1",
-      agentId: "a1",
-      manifest: "github:app:org",
-      resolved: resolved("github", "github:app:org"),
-      mintToken: failingMinter,
-      emitAudit: sink,
-    });
-    expect(res.ok).toBe(false);
-    if (res.ok) throw new Error("expected deny");
-    expect(res.code).toBe("mint_failed");
-    expect(res.error).not.toContain("hsm");
-    expect(events[0]).toMatchObject({ decision: "deny", reason: "token mint failed" });
   });
 
   test("audit sink failure never changes the decision", async () => {

--- a/packages/plugin-capabilities/src/__tests__/manifest-routes.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/manifest-routes.test.ts
@@ -3,8 +3,7 @@
  * routes (lane A1, scope 2-5). Mounts createManifestRoutes on a bare hono app
  * with an agent-token stub + real pglite store. Proves:
  *   - GET /manifest lists the agent's manifest entries,
- *   - token-mode (github) issue returns a short-lived scoped token,
- *   - broker-mode (discord) issue returns a delegation (no token),
+ *   - broker-mode GitHub and Discord issuance return delegations (no token),
  *   - renew hits the same path,
  *   - revoked/absent manifest entry → 403,
  *   - audit events are emitted for each outcome,
@@ -12,7 +11,6 @@
  */
 
 import { afterEach, beforeEach, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { verifyToken } from "@stwd/auth";
 import type { AppVariables } from "@stwd/shared";
 import { Hono } from "hono";
 import type { StewardAppContext } from "../context";
@@ -126,7 +124,7 @@ describe("manifest routes", () => {
     expect(ids).toEqual(["discord:bot-token:soliza", "github:app:org"]);
   });
 
-  test("token mode: github issue returns a short-lived scoped token", async () => {
+  test("github stays brokered until a provider-native installation token minter exists", async () => {
     await seedManifestCapability("gh-comment", "github:app:org");
     const app = buildApp(harness!.db, { agent: true });
 
@@ -138,23 +136,16 @@ describe("manifest routes", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
       ok: boolean;
-      data: { mode: string; token: string; ttlSeconds: number; scopes: string[] };
+      data: { mode: string; token?: string; delegation: { capabilityName: string } };
     };
-    expect(body.data.mode).toBe("token");
-    expect(body.data.ttlSeconds).toBe(90);
-    expect(body.data.scopes).toContain("cap:github:app:org");
-    // SEC-033: never the broad `agent` scope on a capability token.
-    expect(body.data.scopes).not.toContain("agent");
-
-    const payload = await verifyToken(body.data.token);
-    expect(payload.agentId).toBe(agentId);
-    expect((payload.scopes as string[]) ?? []).toContain("cap:github:app:org");
-    expect((payload.scopes as string[]) ?? []).not.toContain("agent");
+    expect(body.data.mode).toBe("broker");
+    expect(body.data.token).toBeUndefined();
+    expect(body.data.delegation.capabilityName).toBe("gh-comment");
 
     // audit: exactly one issue/allow/token event.
     expect(
       auditLog.some(
-        (e) => e.action === "capability.issue" && e.decision === "allow" && e.mode === "token",
+        (e) => e.action === "capability.issue" && e.decision === "allow" && e.mode === "broker",
       ),
     ).toBe(true);
   });
@@ -202,7 +193,7 @@ describe("manifest routes", () => {
     expect(auditLog.some((e) => e.decision === "deny")).toBe(true);
   });
 
-  test("ttl out of range → 400", async () => {
+  test("brokered GitHub issuance ignores token-only TTL parameters", async () => {
     await seedManifestCapability("gh-comment", "github:app:org");
     const app = buildApp(harness!.db, { agent: true });
     const res = await app.request("/capabilities/manifest/github:app:org/issue", {
@@ -210,6 +201,11 @@ describe("manifest routes", () => {
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ ttlSeconds: 99999 }),
     });
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: { mode: string; token?: string };
+    };
+    expect(body.data.mode).toBe("broker");
+    expect(body.data.token).toBeUndefined();
   });
 });

--- a/packages/plugin-capabilities/src/__tests__/manifest-routes.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/manifest-routes.test.ts
@@ -16,6 +16,7 @@ import { Hono } from "hono";
 import type { StewardAppContext } from "../context";
 import type { CapabilityAuditEvent } from "../issuance";
 import { createManifestRoutes } from "../manifest-routes";
+import { PROVIDER_MODES } from "../provider-modes";
 import { CapabilityStore } from "../store";
 import { validateCapabilitySpec } from "../validate";
 import { ensureAgent, ensureSecret, ensureTenant, type Harness, makeHarness } from "./_harness";
@@ -148,6 +149,39 @@ describe("manifest routes", () => {
         (e) => e.action === "capability.issue" && e.decision === "allow" && e.mode === "broker",
       ),
     ).toBe(true);
+  });
+
+  test("fails closed if GitHub is classified as token before a native minter exists", async () => {
+    await seedManifestCapability("gh-comment", "github:app:org");
+    const github = PROVIDER_MODES.find((entry) => entry.provider === "github");
+    if (!github) throw new Error("github provider mode is missing");
+    const mutable = github as { mode: "broker" | "token" };
+    const original = mutable.mode;
+    try {
+      // Model a future one-line registry edit. Production must not fall back to
+      // returning a Steward agent JWT as though it were a GitHub credential.
+      mutable.mode = "token";
+      const app = buildApp(harness!.db, { agent: true });
+      const res = await app.request("/capabilities/manifest/github:app:org/issue", {
+        method: "POST",
+      });
+      expect(res.status).toBe(500);
+      const body = (await res.json()) as { ok: boolean; data?: { token?: string }; error?: string };
+      expect(body.ok).toBe(false);
+      expect(body.data?.token).toBeUndefined();
+      expect(body.error).toBe("token issuance failed");
+      expect(
+        auditLog.some(
+          (event) =>
+            event.action === "capability.issue" &&
+            event.mode === "token" &&
+            event.decision === "deny" &&
+            event.reason === "token mint failed",
+        ),
+      ).toBe(true);
+    } finally {
+      mutable.mode = original;
+    }
   });
 
   test("broker mode: discord issue returns a delegation, no token", async () => {

--- a/packages/plugin-capabilities/src/__tests__/provider-modes.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/provider-modes.test.ts
@@ -16,8 +16,8 @@ describe("provider modes", () => {
     expect(resolveProviderMode("discord")).toBe("broker");
   });
 
-  test("github is token (short-lived installation tokens)", () => {
-    expect(resolveProviderMode("github")).toBe("token");
+  test("github is broker until Steward mints a real installation token", () => {
+    expect(resolveProviderMode("github")).toBe("broker");
   });
 
   test("llm and wallet are broker", () => {
@@ -32,7 +32,7 @@ describe("provider modes", () => {
 
   test("resolution is case-insensitive", () => {
     expect(resolveProviderMode("DisCord")).toBe("broker");
-    expect(resolveProviderMode("GITHUB")).toBe("token");
+    expect(resolveProviderMode("GITHUB")).toBe("broker");
   });
 
   test("registry entries all carry a rationale", () => {

--- a/packages/plugin-capabilities/src/manifest-routes.ts
+++ b/packages/plugin-capabilities/src/manifest-routes.ts
@@ -20,8 +20,6 @@
  * agent's next renewal. The short TTL bounds the window (<5min, Pillar-A green).
  */
 
-import { randomUUID } from "node:crypto";
-import { signAgentToken } from "@stwd/auth";
 import type { ApiResponse, AppVariables } from "@stwd/shared";
 import type { Context } from "hono";
 import { Hono } from "hono";
@@ -37,17 +35,17 @@ import { listAgentManifest, resolveManifestEntry } from "./manifest";
 import { enforceCapabilityRateLimit } from "./rate-limit";
 import { CapabilityStore } from "./store";
 
-/** Mint a short-lived agent token carrying the given scopes; pre-generate the jti
- * so we can return it (for out-of-band revocation) and audit it. */
-const mintShortLivedToken: ShortLivedTokenMinter = async ({
-  agentId,
-  tenantId,
-  scopes,
-  ttlSeconds,
-}) => {
-  const jti = randomUUID();
-  const token = await signAgentToken({ agentId, tenantId, scopes, jti }, `${ttlSeconds}s`);
-  return { token, jti };
+/**
+ * Fail closed until a provider-native token exchange is implemented.
+ *
+ * A Steward agent JWT is authentication for Steward itself; it is not a
+ * provider credential and must never be returned as one.  Keeping the
+ * production route wired to an unavailable minter also makes a future registry
+ * edit from `broker` to `token` safe by default: the request fails rather than
+ * silently leaking a Steward session token to provider-facing client code.
+ */
+const mintProviderNativeToken: ShortLivedTokenMinter = async () => {
+  throw new Error("provider-native token issuance is not implemented");
 };
 
 /** Build the audit sink from the injected core audit writer. Maps the structured
@@ -153,7 +151,7 @@ export function createManifestRoutes(ctx: StewardAppContext): Hono<{ Variables: 
         resolved,
         ttlSeconds: parseTtl(body),
         isRenewal,
-        mintToken: mintShortLivedToken,
+        mintToken: mintProviderNativeToken,
         emitAudit,
       });
 

--- a/packages/plugin-capabilities/src/provider-modes.ts
+++ b/packages/plugin-capabilities/src/provider-modes.ts
@@ -76,11 +76,12 @@ export const PROVIDER_MODES: readonly ProviderModeEntry[] = [
   },
   {
     provider: "github",
-    mode: "token",
+    mode: "broker",
     rationale:
-      "GitHub App installation tokens are natively short-lived (≈1h) and scopable per " +
-      "installation/permission; Steward can mint a scoped installation token in token mode. " +
-      "(A raw PAT-backed github provider would instead be broker mode.)",
+      "GitHub App installation tokens can be short-lived and scoped, but Steward does not yet " +
+      "exchange an installation identity for a GitHub-issued token. Until that provider-native " +
+      "mint exists, GitHub stays brokered so Steward never misrepresents an internal JWT as a " +
+      "provider credential.",
   },
   {
     provider: "llm",


### PR DESCRIPTION
## Summary

Post-merge audit follow-up for #319.

- classify GitHub capability issuance as broker mode until Steward implements a real GitHub App installation-token exchange
- never return an internal Steward session JWT as though it were a provider-native GitHub credential
- update provider-mode documentation and route/core regression coverage

## Security rationale

GitHub App installation tokens can be scoped and short-lived, but the current issuance callback uses `signAgentToken`, producing a Steward HS256 JWT that GitHub cannot consume. Broker mode is the fail-closed honest behavior until a provider-native minter exists.

## Validation

- `bunx turbo run build --filter=@stwd/plugin-capabilities` (9/9)
- focused provider-mode, issuance, manifest-route, and rate-limit tests
- Biome and `git diff --check` clean

Follow-up to #319.