### PR TITLE
fix(release): enforce immutable publication boundaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,13 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           scope: "@stwd"
 
+      # Refuse reruns after a release is published before any registry writes.
+      # Drafts remain recoverable; a missing release is the normal first run.
+      - name: Verify release tag is unpublished
+        run: bun scripts/check-release-rerun.ts "$GITHUB_REPOSITORY" "$GITHUB_REF_NAME"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       # Install all monorepo dependencies
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,13 @@ on:
   push:
     tags: ["v*"]
 
+# A second run for the same tag must wait for the first run to publish its
+# release. It will then fail the immutable-release preflight instead of racing
+# through the same registry writes.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/docs/runbooks/immutable-releases.md
+++ b/docs/runbooks/immutable-releases.md
@@ -8,6 +8,9 @@ or package publication:
 - an existing draft for the tag: continue draft recovery;
 - an existing published release: stop without publishing or replacing assets.
 
+The preflight also tombstones the known legacy `v0.3.16` draft, so pushing or
+rerunning that tag fails before any registry or release write.
+
 The release action is pinned to a full commit SHA. A published immutable
 release's tag, metadata, and assets are not an operator repair surface. Publish
 a new patch version instead.

--- a/docs/runbooks/immutable-releases.md
+++ b/docs/runbooks/immutable-releases.md
@@ -1,0 +1,56 @@
+# Immutable release operations
+
+Steward enables GitHub's repository-level immutable releases setting. Every
+release workflow run also performs a preflight before dependency installation
+or package publication:
+
+- no release for the tag: continue with the first publication;
+- an existing draft for the tag: continue draft recovery;
+- an existing published release: stop without publishing or replacing assets.
+
+The release action is pinned to a full commit SHA. A published immutable
+release's tag, metadata, and assets are not an operator repair surface. Publish
+a new patch version instead.
+
+## Legacy `v0.3.16` draft
+
+The repository has a legacy `v0.3.16` draft created on 2026-05-21. It has no
+assets and no corresponding Git tag, and later versions through `v0.4.2` have
+already been published. It must not be published or reused. Keep it as an
+explicitly recorded legacy draft until a repository administrator approves its
+deletion; deleting it is not required for immutable releases and is deliberately
+outside automated release recovery.
+
+## Verification
+
+Before a production release, an administrator must verify the authoritative
+repository setting:
+
+```sh
+gh api \
+  -H 'Accept: application/vnd.github+json' \
+  -H 'X-GitHub-Api-Version: 2026-03-10' \
+  repos/Steward-Fi/steward/immutable-releases
+```
+
+The response must include `"enabled": true`. After the next release, also run
+`gh release view <tag> --json isDraft,isImmutable,tagName`; the published release
+must report `isDraft: false` and `isImmutable: true`.
+
+The script contract can be checked without a network mutation:
+
+```sh
+bun test scripts/__tests__/check-release-rerun.test.ts
+```
+
+## Failure and rollback
+
+If first publication fails while the release is still a draft, rerun the same
+tag only after checking that package versions and draft assets match the tagged
+commit. If the release is already published, do not disable immutability or
+move/delete its tag; fix the cause and publish a new patch tag.
+
+Disabling the repository setting is an incident escalation, not a routine
+rollback. It requires repository-administrator approval, a recorded reason and
+time window, and immediate re-enablement and API verification. Existing
+immutable releases remain immutable even if the setting is later disabled.

--- a/docs/runbooks/immutable-releases.md
+++ b/docs/runbooks/immutable-releases.md
@@ -15,6 +15,13 @@ The release action is pinned to a full commit SHA. A published immutable
 release's tag, metadata, and assets are not an operator repair surface. Publish
 a new patch version instead.
 
+GitHub applies this setting only to releases published after it was enabled.
+The existing Steward releases through `v0.4.2` currently report
+`isImmutable: false`; enabling the setting does not retroactively lock them.
+Treat those legacy releases as historical artifacts and do not edit, delete,
+or move their tags. The first release published after enablement is the first
+one expected to report `isImmutable: true`.
+
 Release workflow runs are serialized per tag with cancellation disabled. A
 manual rerun waits for an in-progress publication and then repeats the
 published-release preflight; it must not execute registry writes concurrently
@@ -60,5 +67,7 @@ move/delete its tag; fix the cause and publish a new patch tag.
 
 Disabling the repository setting is an incident escalation, not a routine
 rollback. It requires repository-administrator approval, a recorded reason and
-time window, and immediate re-enablement and API verification. Existing
-immutable releases remain immutable even if the setting is later disabled.
+time window, and immediate re-enablement and API verification. Releases that
+were published as immutable remain immutable even if the setting is later
+disabled; legacy releases published before enablement do not gain that
+protection retroactively.

--- a/docs/runbooks/immutable-releases.md
+++ b/docs/runbooks/immutable-releases.md
@@ -15,6 +15,11 @@ The release action is pinned to a full commit SHA. A published immutable
 release's tag, metadata, and assets are not an operator repair surface. Publish
 a new patch version instead.
 
+Release workflow runs are serialized per tag with cancellation disabled. A
+manual rerun waits for an in-progress publication and then repeats the
+published-release preflight; it must not execute registry writes concurrently
+with the original run.
+
 ## Legacy `v0.3.16` draft
 
 The repository has a legacy `v0.3.16` draft created on 2026-05-21. It has no

--- a/scripts/__tests__/check-release-rerun.test.ts
+++ b/scripts/__tests__/check-release-rerun.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "bun:test";
+import { checkReleaseRerun, classifyReleaseResponse } from "../check-release-rerun";
+
+describe("release rerun preflight", () => {
+  it("permits a missing release and recoverable draft", () => {
+    expect(classifyReleaseResponse(404, undefined, "v1.2.3")).toBe("missing");
+    expect(
+      classifyReleaseResponse(200, { draft: true, tag_name: "v1.2.3" }, "v1.2.3"),
+    ).toBe("draft");
+  });
+
+  it("fails closed for an already-published release", () => {
+    expect(
+      classifyReleaseResponse(200, { draft: false, tag_name: "v1.2.3" }, "v1.2.3"),
+    ).toBe("published");
+  });
+
+  it("rejects malformed, mismatched, and failed responses", () => {
+    expect(() => classifyReleaseResponse(200, { draft: true }, "v1.2.3")).toThrow();
+    expect(() =>
+      classifyReleaseResponse(200, { draft: true, tag_name: "v9.9.9" }, "v1.2.3"),
+    ).toThrow();
+    expect(() => classifyReleaseResponse(403, undefined, "v1.2.3")).toThrow();
+  });
+
+  it("finds a tagless draft through the bounded authenticated release list", async () => {
+    const capturedUrls: string[] = [];
+    let capturedAuthorization = "";
+    const state = await checkReleaseRerun(
+      "Steward-Fi/steward",
+      "v1.2.3",
+      "test-secret",
+      (async (input, init) => {
+        capturedUrls.push(String(input));
+        capturedAuthorization = new Headers(init?.headers).get("authorization") ?? "";
+        if (capturedUrls.length === 1) return new Response("not found", { status: 404 });
+        return Response.json([{ tag_name: "v1.2.3", draft: true }]);
+      }) as typeof fetch,
+    );
+    expect(state).toBe("draft");
+    expect(capturedUrls).toEqual([
+      "https://api.github.com/repos/Steward-Fi/steward/releases/tags/v1.2.3",
+      "https://api.github.com/repos/Steward-Fi/steward/releases?per_page=100&page=1",
+    ]);
+    expect(capturedAuthorization).toBe("Bearer test-secret");
+  });
+
+  it("permits a truly missing release only after scanning drafts", async () => {
+    let calls = 0;
+    const state = await checkReleaseRerun(
+      "Steward-Fi/steward",
+      "v1.2.3",
+      "test-secret",
+      (async () => {
+        calls += 1;
+        return calls === 1
+          ? new Response("not found", { status: 404 })
+          : Response.json([]);
+      }) as typeof fetch,
+    );
+    expect(state).toBe("missing");
+    expect(calls).toBe(2);
+  });
+
+  it("rejects attacker-controlled repository and tag inputs before fetch", async () => {
+    const neverFetch = (async () => {
+      throw new Error("fetch should not run");
+    }) as typeof fetch;
+    await expect(
+      checkReleaseRerun("example/repo/extra", "v1.2.3", "token", neverFetch),
+    ).rejects.toThrow("Invalid GITHUB_REPOSITORY");
+    await expect(
+      checkReleaseRerun("example/repo", "not-a-release", "token", neverFetch),
+    ).rejects.toThrow("bounded v* tag");
+  });
+});

--- a/scripts/__tests__/check-release-rerun.test.ts
+++ b/scripts/__tests__/check-release-rerun.test.ts
@@ -2,6 +2,14 @@ import { describe, expect, it } from "bun:test";
 import { checkReleaseRerun, classifyReleaseResponse } from "../check-release-rerun";
 
 describe("release rerun preflight", () => {
+  it("serializes release runs per tag so concurrent reruns cannot pass together", async () => {
+    const workflow = await Bun.file(
+      new URL("../../.github/workflows/release.yml", import.meta.url),
+    ).text();
+    expect(workflow).toContain("group: release-${{ github.ref }}");
+    expect(workflow).toContain("cancel-in-progress: false");
+  });
+
   it("permits a missing release and recoverable draft", () => {
     expect(classifyReleaseResponse(404, undefined, "v1.2.3")).toBe("missing");
     expect(classifyReleaseResponse(200, { draft: true, tag_name: "v1.2.3" }, "v1.2.3")).toBe(
@@ -21,6 +29,24 @@ describe("release rerun preflight", () => {
       classifyReleaseResponse(200, { draft: true, tag_name: "v9.9.9" }, "v1.2.3"),
     ).toThrow();
     expect(() => classifyReleaseResponse(403, undefined, "v1.2.3")).toThrow();
+  });
+
+  it("rejects an oversized chunked response before parsing it", async () => {
+    const oversized = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(`{"padding":"${"x".repeat(64 * 1024)}`));
+        controller.enqueue(new TextEncoder().encode('"}'));
+        controller.close();
+      },
+    });
+    await expect(
+      checkReleaseRerun(
+        "Steward-Fi/steward",
+        "v1.2.3",
+        "token",
+        (async () => new Response(oversized, { status: 200 })) as typeof fetch,
+      ),
+    ).rejects.toThrow("exceeded 64 KiB");
   });
 
   it("finds a tagless draft through the bounded authenticated release list", async () => {

--- a/scripts/__tests__/check-release-rerun.test.ts
+++ b/scripts/__tests__/check-release-rerun.test.ts
@@ -67,12 +67,16 @@ describe("release rerun preflight", () => {
   it("finds a tagless draft through the bounded authenticated release list", async () => {
     const capturedUrls: string[] = [];
     let capturedAuthorization = "";
+    let capturedRedirect: RequestRedirect | undefined;
+    let capturedSignal: AbortSignal | null | undefined;
     const state = await checkReleaseRerun("Steward-Fi/steward", "v1.2.3", "test-secret", (async (
       input,
       init,
     ) => {
       capturedUrls.push(String(input));
       capturedAuthorization = new Headers(init?.headers).get("authorization") ?? "";
+      capturedRedirect = init?.redirect;
+      capturedSignal = init?.signal;
       if (capturedUrls.length === 1) return new Response("not found", { status: 404 });
       return Response.json([{ tag_name: "v1.2.3", draft: true }]);
     }) as typeof fetch);
@@ -82,6 +86,8 @@ describe("release rerun preflight", () => {
       "https://api.github.com/repos/Steward-Fi/steward/releases?per_page=100&page=1",
     ]);
     expect(capturedAuthorization).toBe("Bearer test-secret");
+    expect(capturedRedirect).toBe("error");
+    expect(capturedSignal).toBeInstanceOf(AbortSignal);
   });
 
   it("permits a truly missing release only after scanning drafts", async () => {
@@ -122,6 +128,8 @@ describe("release rerun preflight", () => {
     for (const listResponse of [
       new Response("forbidden", { status: 403 }),
       Response.json({ tag_name: "v1.2.3", draft: true }),
+      Response.json([{ tag_name: "v1.2.3" }]),
+      Response.json([{ draft: true }]),
     ]) {
       let calls = 0;
       await expect(

--- a/scripts/__tests__/check-release-rerun.test.ts
+++ b/scripts/__tests__/check-release-rerun.test.ts
@@ -4,15 +4,15 @@ import { checkReleaseRerun, classifyReleaseResponse } from "../check-release-rer
 describe("release rerun preflight", () => {
   it("permits a missing release and recoverable draft", () => {
     expect(classifyReleaseResponse(404, undefined, "v1.2.3")).toBe("missing");
-    expect(
-      classifyReleaseResponse(200, { draft: true, tag_name: "v1.2.3" }, "v1.2.3"),
-    ).toBe("draft");
+    expect(classifyReleaseResponse(200, { draft: true, tag_name: "v1.2.3" }, "v1.2.3")).toBe(
+      "draft",
+    );
   });
 
   it("fails closed for an already-published release", () => {
-    expect(
-      classifyReleaseResponse(200, { draft: false, tag_name: "v1.2.3" }, "v1.2.3"),
-    ).toBe("published");
+    expect(classifyReleaseResponse(200, { draft: false, tag_name: "v1.2.3" }, "v1.2.3")).toBe(
+      "published",
+    );
   });
 
   it("rejects malformed, mismatched, and failed responses", () => {
@@ -26,17 +26,15 @@ describe("release rerun preflight", () => {
   it("finds a tagless draft through the bounded authenticated release list", async () => {
     const capturedUrls: string[] = [];
     let capturedAuthorization = "";
-    const state = await checkReleaseRerun(
-      "Steward-Fi/steward",
-      "v1.2.3",
-      "test-secret",
-      (async (input, init) => {
-        capturedUrls.push(String(input));
-        capturedAuthorization = new Headers(init?.headers).get("authorization") ?? "";
-        if (capturedUrls.length === 1) return new Response("not found", { status: 404 });
-        return Response.json([{ tag_name: "v1.2.3", draft: true }]);
-      }) as typeof fetch,
-    );
+    const state = await checkReleaseRerun("Steward-Fi/steward", "v1.2.3", "test-secret", (async (
+      input,
+      init,
+    ) => {
+      capturedUrls.push(String(input));
+      capturedAuthorization = new Headers(init?.headers).get("authorization") ?? "";
+      if (capturedUrls.length === 1) return new Response("not found", { status: 404 });
+      return Response.json([{ tag_name: "v1.2.3", draft: true }]);
+    }) as typeof fetch);
     expect(state).toBe("draft");
     expect(capturedUrls).toEqual([
       "https://api.github.com/repos/Steward-Fi/steward/releases/tags/v1.2.3",
@@ -53,9 +51,7 @@ describe("release rerun preflight", () => {
       "test-secret",
       (async () => {
         calls += 1;
-        return calls === 1
-          ? new Response("not found", { status: 404 })
-          : Response.json([]);
+        return calls === 1 ? new Response("not found", { status: 404 }) : Response.json([]);
       }) as typeof fetch,
     );
     expect(state).toBe("missing");
@@ -72,5 +68,14 @@ describe("release rerun preflight", () => {
     await expect(
       checkReleaseRerun("example/repo", "not-a-release", "token", neverFetch),
     ).rejects.toThrow("bounded v* tag");
+  });
+
+  it("refuses the repository's tombstoned legacy draft before fetch", async () => {
+    const neverFetch = (async () => {
+      throw new Error("fetch should not run");
+    }) as typeof fetch;
+    await expect(
+      checkReleaseRerun("Steward-Fi/steward", "v0.3.16", "token", neverFetch),
+    ).rejects.toThrow("tombstoned legacy draft");
   });
 });

--- a/scripts/__tests__/check-release-rerun.test.ts
+++ b/scripts/__tests__/check-release-rerun.test.ts
@@ -34,7 +34,7 @@ describe("release rerun preflight", () => {
   it("rejects an oversized chunked response before parsing it", async () => {
     const oversized = new ReadableStream<Uint8Array>({
       start(controller) {
-        controller.enqueue(new TextEncoder().encode(`{"padding":"${"x".repeat(64 * 1024)}`));
+        controller.enqueue(new TextEncoder().encode(`{"padding":"${"x".repeat(2 * 1024 * 1024)}`));
         controller.enqueue(new TextEncoder().encode('"}'));
         controller.close();
       },
@@ -46,7 +46,22 @@ describe("release rerun preflight", () => {
         "token",
         (async () => new Response(oversized, { status: 200 })) as typeof fetch,
       ),
-    ).rejects.toThrow("exceeded 64 KiB");
+    ).rejects.toThrow("exceeded 2 MiB");
+  });
+
+  it("rejects an oversized Content-Length before reading the body", async () => {
+    await expect(
+      checkReleaseRerun(
+        "Steward-Fi/steward",
+        "v1.2.3",
+        "token",
+        (async () =>
+          new Response("{}", {
+            status: 200,
+            headers: { "Content-Length": String(2 * 1024 * 1024 + 1) },
+          })) as typeof fetch,
+      ),
+    ).rejects.toThrow("exceeded 2 MiB");
   });
 
   it("finds a tagless draft through the bounded authenticated release list", async () => {
@@ -82,6 +97,58 @@ describe("release rerun preflight", () => {
     );
     expect(state).toBe("missing");
     expect(calls).toBe(2);
+  });
+
+  it("continues through full release-list pages and finds a later draft", async () => {
+    const firstPage = Array.from({ length: 100 }, (_, index) => ({
+      tag_name: `v1.0.${index}`,
+      draft: false,
+    }));
+    const requestedUrls: string[] = [];
+    const state = await checkReleaseRerun("Steward-Fi/steward", "v2.0.0", "token", (async (
+      input,
+    ) => {
+      const url = String(input);
+      requestedUrls.push(url);
+      if (requestedUrls.length === 1) return new Response("not found", { status: 404 });
+      if (url.endsWith("page=1")) return Response.json(firstPage);
+      return Response.json([{ tag_name: "v2.0.0", draft: true }]);
+    }) as typeof fetch);
+    expect(state).toBe("draft");
+    expect(requestedUrls.at(-1)).toEndWith("page=2");
+  });
+
+  it("fails closed when authenticated draft listing is unauthorized or malformed", async () => {
+    for (const listResponse of [
+      new Response("forbidden", { status: 403 }),
+      Response.json({ tag_name: "v1.2.3", draft: true }),
+    ]) {
+      let calls = 0;
+      await expect(
+        checkReleaseRerun("Steward-Fi/steward", "v1.2.3", "token", (async () => {
+          calls += 1;
+          return calls === 1 ? new Response("not found", { status: 404 }) : listResponse;
+        }) as typeof fetch),
+      ).rejects.toThrow();
+    }
+  });
+
+  it("runs the preflight before dependency installation and publication writes", async () => {
+    const workflow = await Bun.file(
+      new URL("../../.github/workflows/release.yml", import.meta.url),
+    ).text();
+    const preflight = workflow.indexOf("Verify release tag is unpublished");
+    expect(preflight).toBeGreaterThan(0);
+    for (const laterStep of [
+      "Install dependencies",
+      "Publish @stwd/sdk",
+      "Publish @stwd/react",
+      "Publish @stwd/eliza-plugin",
+      "Create GitHub Release",
+    ]) {
+      expect(workflow.indexOf(laterStep)).toBeGreaterThan(preflight);
+    }
+    expect(workflow).toContain("permissions:\n      contents: write");
   });
 
   it("rejects attacker-controlled repository and tag inputs before fetch", async () => {

--- a/scripts/check-release-rerun.ts
+++ b/scripts/check-release-rerun.ts
@@ -1,0 +1,118 @@
+const REPOSITORY_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const TAG_PATTERN = /^v[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+
+export type ReleaseState = "missing" | "draft" | "published";
+
+type ReleasePayload = {
+  draft?: unknown;
+  tag_name?: unknown;
+};
+
+async function readBoundedJson(response: Response): Promise<unknown> {
+  const contentLength = Number(response.headers.get("content-length") ?? "0");
+  if (Number.isFinite(contentLength) && contentLength > 64 * 1024) {
+    throw new Error("GitHub release lookup response exceeded 64 KiB");
+  }
+  const body = await response.text();
+  if (new TextEncoder().encode(body).byteLength > 64 * 1024) {
+    throw new Error("GitHub release lookup response exceeded 64 KiB");
+  }
+  try {
+    return JSON.parse(body) as unknown;
+  } catch {
+    throw new Error("GitHub release lookup returned invalid JSON");
+  }
+}
+
+export function classifyReleaseResponse(
+  status: number,
+  payload: ReleasePayload | undefined,
+  expectedTag: string,
+): ReleaseState {
+  if (status === 404) return "missing";
+  if (status !== 200) {
+    throw new Error(`GitHub release lookup failed with HTTP ${status}`);
+  }
+  if (!payload || payload.tag_name !== expectedTag || typeof payload.draft !== "boolean") {
+    throw new Error("GitHub release lookup returned an invalid response");
+  }
+  return payload.draft ? "draft" : "published";
+}
+
+export async function checkReleaseRerun(
+  repository: string,
+  tag: string,
+  token: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<ReleaseState> {
+  if (!REPOSITORY_PATTERN.test(repository)) throw new Error("Invalid GITHUB_REPOSITORY");
+  if (!TAG_PATTERN.test(tag)) throw new Error("Release tag must be a bounded v* tag");
+  if (!token) throw new Error("GITHUB_TOKEN is required");
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 10_000);
+  try {
+    const [owner, repo] = repository.split("/");
+    const headers = {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": "2026-03-10",
+      "User-Agent": "steward-release-preflight",
+    };
+    const baseUrl = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
+    const request = (url: string) =>
+      fetchImpl(url, {
+        headers: {
+          ...headers,
+        },
+        redirect: "error",
+        signal: controller.signal,
+      });
+    const response = await request(`${baseUrl}/releases/tags/${encodeURIComponent(tag)}`);
+
+    if (response.status !== 404) {
+      const payload = (await readBoundedJson(response)) as ReleasePayload;
+      return classifyReleaseResponse(response.status, payload, tag);
+    }
+
+    // GitHub's exact tag endpoint omits drafts that have no backing Git tag.
+    // Search the authenticated release list so those drafts remain recoverable
+    // rather than being mistaken for a first publication.
+    for (let page = 1; page <= 10; page += 1) {
+      const listResponse = await request(`${baseUrl}/releases?per_page=100&page=${page}`);
+      if (listResponse.status !== 200) {
+        throw new Error(`GitHub draft lookup failed with HTTP ${listResponse.status}`);
+      }
+      const payload = await readBoundedJson(listResponse);
+      if (!Array.isArray(payload)) throw new Error("GitHub release list returned an invalid response");
+      for (const item of payload) {
+        if (!item || typeof item !== "object") {
+          throw new Error("GitHub release list returned an invalid response");
+        }
+        const release = item as ReleasePayload;
+        if (release.tag_name === tag) {
+          return classifyReleaseResponse(200, release, tag);
+        }
+      }
+      if (payload.length < 100) return "missing";
+    }
+    throw new Error("GitHub release list exceeded the 1000-release safety bound");
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+if (import.meta.main) {
+  const repository = process.argv[2] ?? "";
+  const tag = process.argv[3] ?? "";
+  const state = await checkReleaseRerun(repository, tag, process.env.GITHUB_TOKEN ?? "");
+  if (state === "published") {
+    console.error(`Release ${tag} is already published; refusing a release-workflow rerun.`);
+    process.exit(1);
+  }
+  console.log(
+    state === "draft"
+      ? `Release ${tag} is a draft; recovery may continue.`
+      : `Release ${tag} does not exist; first publication may continue.`,
+  );
+}

--- a/scripts/check-release-rerun.ts
+++ b/scripts/check-release-rerun.ts
@@ -121,6 +121,12 @@ export async function checkReleaseRerun(
           throw new Error("GitHub release list returned an invalid response");
         }
         const release = item as ReleasePayload;
+        // Do not silently skip a partially decoded entry. A schema change or
+        // truncated object could otherwise hide the target draft and turn an
+        // uncertain lookup into permission to publish.
+        if (typeof release.tag_name !== "string" || typeof release.draft !== "boolean") {
+          throw new Error("GitHub release list returned an invalid response");
+        }
         if (release.tag_name === tag) {
           return classifyReleaseResponse(200, release, tag);
         }

--- a/scripts/check-release-rerun.ts
+++ b/scripts/check-release-rerun.ts
@@ -1,5 +1,6 @@
 const REPOSITORY_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const TAG_PATTERN = /^v[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const TOMBSTONED_DRAFTS = new Set(["Steward-Fi/steward@v0.3.16"]);
 
 export type ReleaseState = "missing" | "draft" | "published";
 
@@ -48,6 +49,9 @@ export async function checkReleaseRerun(
   if (!REPOSITORY_PATTERN.test(repository)) throw new Error("Invalid GITHUB_REPOSITORY");
   if (!TAG_PATTERN.test(tag)) throw new Error("Release tag must be a bounded v* tag");
   if (!token) throw new Error("GITHUB_TOKEN is required");
+  if (TOMBSTONED_DRAFTS.has(`${repository}@${tag}`)) {
+    throw new Error(`Release ${tag} is a tombstoned legacy draft and must not be reused`);
+  }
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), 10_000);
@@ -84,7 +88,8 @@ export async function checkReleaseRerun(
         throw new Error(`GitHub draft lookup failed with HTTP ${listResponse.status}`);
       }
       const payload = await readBoundedJson(listResponse);
-      if (!Array.isArray(payload)) throw new Error("GitHub release list returned an invalid response");
+      if (!Array.isArray(payload))
+        throw new Error("GitHub release list returned an invalid response");
       for (const item of payload) {
         if (!item || typeof item !== "object") {
           throw new Error("GitHub release list returned an invalid response");
@@ -105,6 +110,7 @@ export async function checkReleaseRerun(
 if (import.meta.main) {
   const repository = process.argv[2] ?? "";
   const tag = process.argv[3] ?? "";
+  // biome-ignore lint/suspicious/noUndeclaredEnvVars: this script runs directly in the release job, outside Turbo's cache.
   const state = await checkReleaseRerun(repository, tag, process.env.GITHUB_TOKEN ?? "");
   if (state === "published") {
     console.error(`Release ${tag} is already published; refusing a release-workflow rerun.`);

--- a/scripts/check-release-rerun.ts
+++ b/scripts/check-release-rerun.ts
@@ -10,10 +10,13 @@ type ReleasePayload = {
 };
 
 async function readBoundedJson(response: Response): Promise<unknown> {
-  const maxBytes = 64 * 1024;
+  // GitHub's list representation includes release bodies, authors, and asset
+  // metadata. This repository's current 21-release response is already about
+  // 52 KiB, so 64 KiB would make ordinary release-note growth an outage.
+  const maxBytes = 2 * 1024 * 1024;
   const contentLength = Number(response.headers.get("content-length") ?? "0");
   if (Number.isFinite(contentLength) && contentLength > maxBytes) {
-    throw new Error("GitHub release lookup response exceeded 64 KiB");
+    throw new Error("GitHub release lookup response exceeded 2 MiB");
   }
 
   const reader = response.body?.getReader();
@@ -27,7 +30,7 @@ async function readBoundedJson(response: Response): Promise<unknown> {
       totalBytes += value.byteLength;
       if (totalBytes > maxBytes) {
         await reader.cancel();
-        throw new Error("GitHub release lookup response exceeded 64 KiB");
+        throw new Error("GitHub release lookup response exceeded 2 MiB");
       }
       chunks.push(value);
     }

--- a/scripts/check-release-rerun.ts
+++ b/scripts/check-release-rerun.ts
@@ -10,16 +10,39 @@ type ReleasePayload = {
 };
 
 async function readBoundedJson(response: Response): Promise<unknown> {
+  const maxBytes = 64 * 1024;
   const contentLength = Number(response.headers.get("content-length") ?? "0");
-  if (Number.isFinite(contentLength) && contentLength > 64 * 1024) {
+  if (Number.isFinite(contentLength) && contentLength > maxBytes) {
     throw new Error("GitHub release lookup response exceeded 64 KiB");
   }
-  const body = await response.text();
-  if (new TextEncoder().encode(body).byteLength > 64 * 1024) {
-    throw new Error("GitHub release lookup response exceeded 64 KiB");
+
+  const reader = response.body?.getReader();
+  if (!reader) throw new Error("GitHub release lookup returned an empty response");
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      totalBytes += value.byteLength;
+      if (totalBytes > maxBytes) {
+        await reader.cancel();
+        throw new Error("GitHub release lookup response exceeded 64 KiB");
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const bytes = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
   }
   try {
-    return JSON.parse(body) as unknown;
+    return JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes)) as unknown;
   } catch {
     throw new Error("GitHub release lookup returned invalid JSON");
   }


### PR DESCRIPTION
## Summary

- records and operationalizes the repository immutable-release boundary
- fails the release workflow before dependency/package work when a tag already has a published release
- preserves authenticated discovery and recovery of tagless drafts while explicitly tombstoning the obsolete `v0.3.16` draft
- documents the future-only setting boundary, legacy-release disposition, exact verification, and escalation/rollback rules

The repository setting itself was enabled through GitHub's authoritative `PUT /repos/Steward-Fi/steward/immutable-releases` endpoint. A fresh read reports `{ "enabled": true, "enforced_by_owner": false }`. GitHub applies the setting only to future publications; existing releases through `v0.4.2` remain non-immutable historical artifacts.

Closes #345

## Type

- [x] `fix` — Bug fix
- [x] `docs` — Documentation
- [x] `test` — Adding or updating tests

## Scope

GitHub release workflow, release preflight, operator runbook.

## Breaking Changes

Published release tags can no longer be rerun through the publication workflow. Draft recovery and first publication remain supported, except for the explicitly tombstoned legacy `v0.3.16` draft.

## Checklist

- [x] Tests added/updated for changes
- [x] Documentation updated if needed
- [ ] CI passes (`bun test`, typecheck)
- [x] PR targets `develop` (not `main`)
- [x] Commit messages follow conventional format (`type(scope): description`)

## Exact validation

- `bun test scripts/__tests__/check-release-rerun.test.ts` — 13 passed, 0 failed
- `bunx biome check .github/workflows/release.yml scripts/check-release-rerun.ts scripts/__tests__/check-release-rerun.test.ts docs/runbooks/immutable-releases.md` — clean
- live read-only preflight: `v0.4.2` classified published and exited 1; nonexistent probe classified missing and exited 0; `v0.3.16` is rejected locally as tombstoned before fetch
- live release inventory: existing published releases through `v0.4.2` report `isImmutable: false`, consistent with GitHub's future-only setting semantics
- authoritative immutable-release API read: `{ "enabled": true, "enforced_by_owner": false }`
