### PR TITLE
fix(shared): make USD conversion overflow-safe

### DIFF
--- a/packages/shared/src/__tests__/price-oracle.test.ts
+++ b/packages/shared/src/__tests__/price-oracle.test.ts
@@ -101,6 +101,34 @@ describe("price oracle", () => {
     );
   });
 
+  it("handles large scientific-notation inputs without a Number-to-BigInt overflow", async () => {
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          pairs: [{ chainId: "base", priceUsd: "1", liquidity: { usd: 100 } }],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      )) as typeof fetch;
+
+    const result = await createPriceOracle({ cacheTtlMs: 0 }).usdToWei(Number.MAX_VALUE, 8453);
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(327);
+    expect(result?.startsWith("17976931348623157")).toBe(true);
+    expect(result?.endsWith("0".repeat(310))).toBe(true);
+  });
+
+  it("rejects a non-finite upstream price instead of throwing during BigInt conversion", async () => {
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          pairs: [{ chainId: "base", priceUsd: "1e309", liquidity: { usd: 100 } }],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      )) as typeof fetch;
+
+    await expect(createPriceOracle({ cacheTtlMs: 0 }).usdToWei(1, 8453)).resolves.toBeNull();
+  });
+
   it("fails closed for unknown chains/tokens instead of assuming 18 decimals (SEC-190)", async () => {
     globalThis.fetch = (async () =>
       new Response(

--- a/packages/shared/src/__tests__/price-oracle.test.ts
+++ b/packages/shared/src/__tests__/price-oracle.test.ts
@@ -129,6 +129,41 @@ describe("price oracle", () => {
     await expect(createPriceOracle({ cacheTtlMs: 0 }).usdToWei(1, 8453)).resolves.toBeNull();
   });
 
+  it("rejects JavaScript-only numeric syntaxes in upstream decimal prices", async () => {
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          pairs: [
+            { chainId: "base", priceUsd: "0x10", liquidity: { usd: 1_000_000 } },
+            { chainId: "base", priceUsd: "0b10", liquidity: { usd: 100_000 } },
+            { chainId: "base", priceUsd: "2.5", liquidity: { usd: 100 } },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      )) as typeof fetch;
+
+    // Number("0x10") is 16, but a USD oracle must only accept the documented
+    // decimal grammar. The genuine decimal pair remains eligible.
+    await expect(createPriceOracle({ cacheTtlMs: 0 }).getNativeUsdPrice(8453)).resolves.toBe(2.5);
+  });
+
+  it("fails closed on an oversized chunked oracle response", async () => {
+    const oversized = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(2 * 1024 * 1024));
+        controller.enqueue(new Uint8Array([0]));
+        controller.close();
+      },
+    });
+    globalThis.fetch = (async () =>
+      new Response(oversized, {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })) as typeof fetch;
+
+    await expect(createPriceOracle({ cacheTtlMs: 0 }).getNativeUsdPrice(8453)).resolves.toBeNull();
+  });
+
   it("fails closed for unknown chains/tokens instead of assuming 18 decimals (SEC-190)", async () => {
     globalThis.fetch = (async () =>
       new Response(

--- a/packages/shared/src/price-oracle.ts
+++ b/packages/shared/src/price-oracle.ts
@@ -48,6 +48,9 @@ interface DexScreenerResponse {
   pairs?: DexScreenerPair[];
 }
 
+const MAX_DEX_RESPONSE_BYTES = 2 * 1024 * 1024;
+const MAX_DEX_PAIRS = 1_000;
+
 // ─── Cache Entry ──────────────────────────────────────────────────────────────
 
 interface CacheEntry {
@@ -71,6 +74,60 @@ function decimalNumberRatio(value: number): [numerator: bigint, denominator: big
     return [numerator, 1n];
   }
   return [numerator, 10n ** BigInt(-exponent)];
+}
+
+/** DexScreener documents priceUsd as a decimal string. Number() also accepts
+ * JavaScript-only syntaxes such as hexadecimal and binary; accepting those in
+ * an external price feed could turn malformed data into a valid policy price. */
+function parsePositiveDecimal(value: unknown): number | null {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > 128 ||
+    !/^\d+(?:\.\d+)?(?:e[+-]?\d+)?$/i.test(value)
+  ) {
+    return null;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+async function readBoundedDexResponse(response: Response): Promise<DexScreenerResponse> {
+  const contentLength = Number(response.headers.get("content-length") ?? "0");
+  if (Number.isFinite(contentLength) && contentLength > MAX_DEX_RESPONSE_BYTES) {
+    throw new Error("DexScreener response exceeded the size limit");
+  }
+  const reader = response.body?.getReader();
+  if (!reader) throw new Error("DexScreener returned an empty response");
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      totalBytes += value.byteLength;
+      if (totalBytes > MAX_DEX_RESPONSE_BYTES) {
+        await reader.cancel();
+        throw new Error("DexScreener response exceeded the size limit");
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const bytes = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  const decoded = JSON.parse(
+    new TextDecoder("utf-8", { fatal: true }).decode(bytes),
+  ) as DexScreenerResponse;
+  if (!decoded || typeof decoded !== "object") {
+    throw new Error("DexScreener returned an invalid response");
+  }
+  return decoded;
 }
 
 // ─── Implementation ───────────────────────────────────────────────────────────
@@ -163,23 +220,36 @@ export function createPriceOracle(options?: { cacheTtlMs?: number }): PriceOracl
         return null;
       }
 
-      const data = (await res.json()) as DexScreenerResponse;
-      if (!data.pairs || data.pairs.length === 0) {
+      const data = await readBoundedDexResponse(res);
+      if (!Array.isArray(data.pairs) || data.pairs.length === 0) {
         console.warn(`[price-oracle] No pairs found for ${tokenAddress}`);
+        return null;
+      }
+      if (data.pairs.length > MAX_DEX_PAIRS) {
+        console.warn(`[price-oracle] DexScreener returned too many pairs for ${tokenAddress}`);
         return null;
       }
 
       // Sort by liquidity (descending) and pick the best one with a valid priceUsd
       const sorted = [...data.pairs]
-        .filter((p) => {
-          const parsed = Number(p.priceUsd);
-          return p.chainId === expectedDexChainId && Number.isFinite(parsed) && parsed > 0;
-        })
-        .sort((a, b) => (b.liquidity?.usd ?? 0) - (a.liquidity?.usd ?? 0));
+        .filter(
+          (p) => p.chainId === expectedDexChainId && parsePositiveDecimal(p.priceUsd) !== null,
+        )
+        .sort((a, b) => {
+          const aLiquidity =
+            typeof a.liquidity?.usd === "number" && Number.isFinite(a.liquidity.usd)
+              ? a.liquidity.usd
+              : 0;
+          const bLiquidity =
+            typeof b.liquidity?.usd === "number" && Number.isFinite(b.liquidity.usd)
+              ? b.liquidity.usd
+              : 0;
+          return bLiquidity - aLiquidity;
+        });
 
       if (sorted.length === 0) return null;
 
-      return Number(sorted[0].priceUsd);
+      return parsePositiveDecimal(sorted[0].priceUsd);
     } catch (err) {
       console.warn(`[price-oracle] Failed to fetch price for ${tokenAddress}:`, err);
       return null;

--- a/packages/shared/src/price-oracle.ts
+++ b/packages/shared/src/price-oracle.ts
@@ -55,6 +55,24 @@ interface CacheEntry {
   fetchedAt: number;
 }
 
+/** Convert the exact decimal representation of a finite non-negative JS number
+ * into an integer ratio. This avoids routing through a scaled Number before
+ * BigInt conversion, which can overflow to Infinity or lose integer bits. */
+function decimalNumberRatio(value: number): [numerator: bigint, denominator: bigint] | null {
+  if (!Number.isFinite(value) || value < 0) return null;
+  const match = /^(\d+)(?:\.(\d+))?(?:e([+-]?\d+))?$/i.exec(value.toString());
+  if (!match) return null;
+  const fraction = match[2] ?? "";
+  let numerator = BigInt(`${match[1]}${fraction}`);
+  const exponent = Number(match[3] ?? "0") - fraction.length;
+  if (!Number.isSafeInteger(exponent)) return null;
+  if (exponent >= 0) {
+    numerator *= 10n ** BigInt(exponent);
+    return [numerator, 1n];
+  }
+  return [numerator, 10n ** BigInt(-exponent)];
+}
+
 // ─── Implementation ───────────────────────────────────────────────────────────
 
 export function createPriceOracle(options?: { cacheTtlMs?: number }): PriceOracle {
@@ -153,12 +171,15 @@ export function createPriceOracle(options?: { cacheTtlMs?: number }): PriceOracl
 
       // Sort by liquidity (descending) and pick the best one with a valid priceUsd
       const sorted = [...data.pairs]
-        .filter((p) => p.chainId === expectedDexChainId && p.priceUsd && parseFloat(p.priceUsd) > 0)
+        .filter((p) => {
+          const parsed = Number(p.priceUsd);
+          return p.chainId === expectedDexChainId && Number.isFinite(parsed) && parsed > 0;
+        })
         .sort((a, b) => (b.liquidity?.usd ?? 0) - (a.liquidity?.usd ?? 0));
 
       if (sorted.length === 0) return null;
 
-      return parseFloat(sorted[0].priceUsd!);
+      return Number(sorted[0].priceUsd);
     } catch (err) {
       console.warn(`[price-oracle] Failed to fetch price for ${tokenAddress}:`, err);
       return null;
@@ -258,16 +279,17 @@ export function createPriceOracle(options?: { cacheTtlMs?: number }): PriceOracl
 
       if (!Number.isFinite(usdValue) || usdValue < 0) return null;
 
-      // Rational arithmetic (SEC-189): scale the USD input and price to
-      // micro-unit integers and divide in BigInt, so values beyond 2^53 stay
-      // exact. Rounds to nearest (half up) — an explicit rounding policy,
-      // replacing the old double-math `Math.floor(tokenAmount * 10**decimals)`
-      // which lost precision and always rounded down.
-      const usdMicros = BigInt(Math.round(usdValue * 1_000_000));
-      const priceMicros = BigInt(Math.round(price * 1_000_000));
-      if (priceMicros <= 0n) return null;
-      const numerator = usdMicros * 10n ** BigInt(decimals);
-      const wei = (numerator * 2n + priceMicros) / (priceMicros * 2n);
+      // Rational arithmetic (SEC-189): parse each Number's exact decimal /
+      // exponent representation directly into BigInt. Never multiply a Number
+      // before conversion: a large finite input can overflow that intermediate
+      // to Infinity, while an unsafe integer has already lost bits. Round the
+      // final exact ratio to nearest, half up.
+      const usdRatio = decimalNumberRatio(usdValue);
+      const priceRatio = decimalNumberRatio(price);
+      if (!usdRatio || !priceRatio || priceRatio[0] <= 0n) return null;
+      const numerator = usdRatio[0] * priceRatio[1] * 10n ** BigInt(decimals);
+      const denominator = usdRatio[1] * priceRatio[0];
+      const wei = (numerator * 2n + denominator) / (denominator * 2n);
       return wei.toString();
     },
   };


### PR DESCRIPTION
## Summary

Post-merge audit follow-up for #321.

- parse finite USD and price values into exact decimal BigInt ratios
- reject non-finite or malformed upstream price strings before caching or conversion
- preserve explicit half-up rounding without an overflow-prone scaled Number intermediate
- bound upstream response bytes and pair cardinality before sorting

## Security / correctness rationale

The SEC-189 implementation in #321 converted `Math.round(number * 1_000_000)` to BigInt. A large but finite USD value can overflow during that multiplication and make `BigInt(Infinity)` throw. Likewise, a DexScreener `priceUsd` such as `1e309` passed the prior positivity filter and reached the throwing conversion path.

This follow-up fails closed on non-finite upstream prices and performs the final conversion as an exact rational derived from each JavaScript Number decimal/exponent representation. The public `PriceOracle` interface remains unchanged.

## Validation

- `bunx biome check packages/shared/src/price-oracle.ts packages/shared/src/__tests__/price-oracle.test.ts`
- `bun test packages/shared/src/__tests__/price-oracle.test.ts` — 9 pass
- `bun test packages/shared/src` — 433 pass, 11,221 assertions
- `bun run --cwd packages/shared build`
- focused DB/Redis/shared touched-surface tests — 247 pass, including 2 live approval-evidence migration tests
- `git diff --check`
