### PR TITLE
fix(security): make agent policy tightening atomic

### DIFF
--- a/packages/api/src/__tests__/agent-audit-rollback.test.ts
+++ b/packages/api/src/__tests__/agent-audit-rollback.test.ts
@@ -12,6 +12,27 @@ function functionBody(marker: string, endMarker = "\n}\n\nagentRoutes.") {
 }
 
 describe("agent audit rollback hardening", () => {
+  it("commits trade-policy mutations only with their required audit event", () => {
+    const policyStart = routeSource.indexOf('agentRoutes.put("/:agentId/policy"');
+    expect(policyStart).toBeGreaterThanOrEqual(0);
+    const policyRoute = routeSource.slice(
+      policyStart,
+      routeSource.indexOf('agentRoutes.get("/:agentId"', policyStart),
+    );
+
+    expect(policyRoute).toContain("withTenantAuditedTransaction(");
+    expect(policyRoute).toContain("async (txRaw, appendRequiredAudit) =>");
+    const transaction = policyRoute.indexOf("withTenantAuditedTransaction(");
+    const update = policyRoute.indexOf(".update(agentPolicies)", transaction);
+    const insert = policyRoute.indexOf(".insert(agentPolicies)", transaction);
+    const audit = policyRoute.indexOf("await appendRequiredAudit({", transaction);
+    expect(update).toBeGreaterThan(transaction);
+    expect(insert).toBeGreaterThan(transaction);
+    expect(audit).toBeGreaterThan(update);
+    expect(audit).toBeGreaterThan(insert);
+    expect(policyRoute).not.toContain("await writeAuditEvent({");
+  });
+
   it("removes newly persisted agent and wallet rows when final audit writes fail", () => {
     expect(routeSource).toContain("async function deleteAgentRows");
     expect(routeSource).toContain("async function deleteAgentWalletRows");

--- a/packages/api/src/__tests__/agent-policy.test.ts
+++ b/packages/api/src/__tests__/agent-policy.test.ts
@@ -272,6 +272,30 @@ describe("agent trade policy", () => {
     expect(Number(row?.leverageCap)).toBe(5);
   });
 
+  it("SEC-208: one stale attribution-only CAS loses deterministically", async () => {
+    const { buildAgentPolicyCompareAndSwapPredicate } = await import("../routes/agents");
+    const [expected] = await getDb()
+      .select()
+      .from(agentPolicies)
+      .where(eq(agentPolicies.agentId, agentId));
+    expect(expected).toBeDefined();
+    if (!expected) throw new Error("expected seeded agent policy");
+
+    // Both writes preserve every enforcement field, but claim a different
+    // reason. Only one may commit against this exact audit snapshot.
+    const results = await Promise.all(
+      ["first concurrent reason", "second concurrent reason"].map((reason) =>
+        getDb()
+          .update(agentPolicies)
+          .set({ updatedReason: reason })
+          .where(buildAgentPolicyCompareAndSwapPredicate(agentId, tenantId, expected))
+          .returning({ agentId: agentPolicies.agentId }),
+      ),
+    );
+
+    expect(results.map((rows) => rows.length).sort()).toEqual([0, 1]);
+  });
+
   it("rejects values exceeding Layer 1 ceilings", async () => {
     const res = await putPolicy({ dailyCap: 50_001, reason: "too high" });
 

--- a/packages/api/src/__tests__/agent-policy.test.ts
+++ b/packages/api/src/__tests__/agent-policy.test.ts
@@ -287,7 +287,12 @@ describe("agent trade policy", () => {
       ["first concurrent reason", "second concurrent reason"].map((reason) =>
         getDb()
           .update(agentPolicies)
-          .set({ updatedReason: reason })
+          .set({
+            updatedReason: reason,
+            updatedAt: new Date(
+              expected.updatedAt.getTime() + (reason.startsWith("first") ? 1 : 2),
+            ),
+          })
           .where(buildAgentPolicyCompareAndSwapPredicate(agentId, tenantId, expected))
           .returning({ agentId: agentPolicies.agentId }),
       ),

--- a/packages/api/src/__tests__/agent-policy.test.ts
+++ b/packages/api/src/__tests__/agent-policy.test.ts
@@ -6,7 +6,7 @@ import { eq } from "drizzle-orm";
 
 process.env.DATABASE_URL = "postgres://test:test@localhost:5432/test";
 process.env.STEWARD_MASTER_PASSWORD = "test-master-password";
-setDefaultTimeout(30000);
+setDefaultTimeout(60000);
 
 const tenantId = "tenant-agent-policy-test";
 const agentId = "agent-policy-test";
@@ -245,6 +245,33 @@ describe("agent trade policy", () => {
     expect(body.data.diff.allowedAssets).toEqual({ before: ["BTC", "ETH"], after: ["BTC"] });
   });
 
+  it("SEC-208: concurrent partial tightenings cannot overwrite and re-raise each other", async () => {
+    const requests = [
+      { dailyCap: 600, reason: "concurrent daily tightening" },
+      { leverageCap: 5, reason: "concurrent leverage tightening" },
+    ];
+    const firstResponses = await Promise.all(requests.map((body) => putPolicy(body)));
+
+    // Depending on scheduling, the second request either observes the first
+    // commit and succeeds, or its stale conditional update is rejected. Retry
+    // only the stale request against the new row.
+    for (let i = 0; i < firstResponses.length; i += 1) {
+      const response = firstResponses[i];
+      expect([200, 409]).toContain(response.status);
+      if (response.status === 409) {
+        const retry = await putPolicy(requests[i]);
+        expect(retry.status).toBe(200);
+      }
+    }
+
+    const [row] = await getDb()
+      .select()
+      .from(agentPolicies)
+      .where(eq(agentPolicies.agentId, agentId));
+    expect(Number(row?.dailyCapUsd)).toBe(600);
+    expect(Number(row?.leverageCap)).toBe(5);
+  });
+
   it("rejects values exceeding Layer 1 ceilings", async () => {
     const res = await putPolicy({ dailyCap: 50_001, reason: "too high" });
 
@@ -336,9 +363,11 @@ describe("agent trade policy", () => {
       .where(eq(auditEvents.action, "agent.policy.updated"));
 
     expect(rows.length).toBeGreaterThanOrEqual(2);
-    const latest = rows.at(-1);
-    expect(latest).toMatchObject({ tenantId, actorId: `agent:${agentId}`, resourceId: agentId });
-    expect(latest?.metadata).toMatchObject({
+    const tightened = rows.find(
+      (row) => (row.metadata as { reason?: string } | null)?.reason === "tighten risk",
+    );
+    expect(tightened).toMatchObject({ tenantId, actorId: `agent:${agentId}`, resourceId: agentId });
+    expect(tightened?.metadata).toMatchObject({
       agentId,
       reason: "tighten risk",
     });

--- a/packages/api/src/__tests__/agent-trade-policy-admin.test.ts
+++ b/packages/api/src/__tests__/agent-trade-policy-admin.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
-import { agentPolicies, agents, closeDb, getDb, tenants } from "@stwd/db";
+import { agentPolicies, agents, auditEvents, closeDb, getDb, tenants } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
-import { eq } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import type { AppVariables } from "../services/context";
 
@@ -137,5 +137,40 @@ describe("agent trade policy admin path (SEC-208)", () => {
       .from(agentPolicies)
       .where(eq(agentPolicies.agentId, AGENT_ID));
     expect(row?.updatedBy).toBe("trade-policy-admin");
+  });
+
+  it("serializes concurrent human partial patches and audits the exact committed chain", async () => {
+    const app = await makeApp("admin");
+    const reasons = ["concurrent human daily patch", "concurrent human leverage patch"];
+    const responses = await Promise.all([
+      putPolicy(app, { dailyCap: 4500, reason: reasons[0] }),
+      putPolicy(app, { leverageCap: 18, reason: reasons[1] }),
+    ]);
+    expect(responses.map((response) => response.status)).toEqual([200, 200]);
+
+    const [row] = await getDb()
+      .select()
+      .from(agentPolicies)
+      .where(eq(agentPolicies.agentId, AGENT_ID));
+    expect(row).toMatchObject({ dailyCapUsd: "4500", leverageCap: "18" });
+
+    const events = (
+      await getDb()
+        .select()
+        .from(auditEvents)
+        .where(
+          and(
+            eq(auditEvents.tenantId, TENANT_ID),
+            eq(auditEvents.action, "agent.policy.updated"),
+            eq(auditEvents.resourceId, AGENT_ID),
+          ),
+        )
+        .orderBy(asc(auditEvents.seq))
+    ).filter((event) => reasons.includes(String(event.metadata.reason)));
+    expect(events).toHaveLength(2);
+    expect(events[1].seq).toBe(events[0].seq + 1);
+    expect(Buffer.from(events[1].prevHash).equals(Buffer.from(events[0].hmac))).toBe(true);
+    expect(events[1].metadata.before).toEqual(events[0].metadata.after);
+    expect(events.map((event) => event.metadata.reason).sort()).toEqual([...reasons].sort());
   });
 });

--- a/packages/api/src/routes/agents.ts
+++ b/packages/api/src/routes/agents.ts
@@ -1736,136 +1736,125 @@ agentRoutes.put("/:agentId/policy", async (c) => {
     return c.json<ApiResponse>({ ok: false, error: "reason is required" }, 400);
   }
 
-  const [existing] = await db
-    .select()
-    .from(agentPolicies)
-    .where(and(eq(agentPolicies.agentId, agentId), eq(agentPolicies.tenantId, tenantId)));
-  const before = existing ? policyRowToResponse(existing) : defaultPolicySnapshot(agentId);
-
-  const nextDailyCap =
-    body.dailyCap === undefined ? before.dailyCap : validatePolicyNumber("dailyCap", body.dailyCap);
-  const nextPerOrderCap =
-    body.perOrderCap === undefined
-      ? before.perOrderCap
-      : validatePolicyNumber("perOrderCap", body.perOrderCap);
-  const nextLeverageCap =
-    body.leverageCap === undefined
-      ? before.leverageCap
-      : validatePolicyNumber("leverageCap", body.leverageCap);
-  const nextAllowedAssets =
-    body.allowedAssets === undefined
-      ? before.allowedAssets
-      : validatePolicyStringArray("allowedAssets", body.allowedAssets);
-  const nextAllowedVenues =
-    body.allowedVenues === undefined
-      ? before.allowedVenues
-      : validatePolicyStringArray("allowedVenues", body.allowedVenues);
-  const nextAllowBuilderPerps =
-    body.allowBuilderPerps === undefined
-      ? before.allowBuilderPerps
-      : validateOptionalBoolean("allowBuilderPerps", body.allowBuilderPerps);
-
-  const validationError = [
-    nextDailyCap,
-    nextPerOrderCap,
-    nextLeverageCap,
-    nextAllowedAssets,
-    nextAllowedVenues,
-    nextAllowBuilderPerps,
-  ].find((value) => typeof value === "string");
+  // Validate caller-provided fields before opening the write transaction, but
+  // do not fill omitted partial-patch fields yet. Their values must come from
+  // the row locked and re-read inside the audited transaction.
+  const validatedPatch = {
+    dailyCap:
+      body.dailyCap === undefined ? undefined : validatePolicyNumber("dailyCap", body.dailyCap),
+    perOrderCap:
+      body.perOrderCap === undefined
+        ? undefined
+        : validatePolicyNumber("perOrderCap", body.perOrderCap),
+    leverageCap:
+      body.leverageCap === undefined
+        ? undefined
+        : validatePolicyNumber("leverageCap", body.leverageCap),
+    allowedAssets:
+      body.allowedAssets === undefined
+        ? undefined
+        : validatePolicyStringArray("allowedAssets", body.allowedAssets),
+    allowedVenues:
+      body.allowedVenues === undefined
+        ? undefined
+        : validatePolicyStringArray("allowedVenues", body.allowedVenues),
+    allowBuilderPerps:
+      body.allowBuilderPerps === undefined
+        ? undefined
+        : validateOptionalBoolean("allowBuilderPerps", body.allowBuilderPerps),
+  };
+  const validationError = Object.values(validatedPatch).find((value) => typeof value === "string");
   if (typeof validationError === "string") {
     return c.json<ApiResponse>({ ok: false, error: validationError }, 400);
-  }
-
-  const dailyCapValue = nextDailyCap as number;
-  const perOrderCapValue = nextPerOrderCap as number;
-  const leverageCapValue = nextLeverageCap as number;
-  const allowedAssetsValue = nextAllowedAssets as string[];
-  const allowedVenuesValue = nextAllowedVenues as string[];
-  const allowBuilderPerpsValue = nextAllowBuilderPerps as boolean;
-
-  if (hasBuilderPerpAsset(allowedAssetsValue) && !allowBuilderPerpsValue) {
-    return c.json<ApiResponse>(
-      { ok: false, error: "builder perp assets require allowBuilderPerps=true" },
-      400,
-    );
-  }
-
-  if (perOrderCapValue > dailyCapValue) {
-    return c.json<ApiResponse>({ ok: false, error: "perOrderCap cannot exceed dailyCap" }, 400);
-  }
-
-  // SEC-208: agent self-updates are tighten-only — reject any loosening here
-  // (fail closed, AFTER input validation so malformed bodies still 400).
-  if (isAgentSelfUpdate) {
-    // SEC-208 residual: tighten-only constrains updates against the CURRENT
-    // row, but a policy-less agent could still CREATE its initial policy at
-    // full platform defaults — activating trade ceilings (the trade route
-    // fails closed when the row is absent) with no human approval. Initial
-    // creation is therefore reserved for the human owner/admin+MFA path.
-    if (!existing) {
-      return c.json<ApiResponse>(
-        {
-          ok: false,
-          error: "Initial trade policy creation requires an owner/admin session with recent MFA",
-        },
-        403,
-      );
-    }
-    const loosening = policyLooseningViolation(before, {
-      dailyCap: dailyCapValue,
-      perOrderCap: perOrderCapValue,
-      leverageCap: leverageCapValue,
-      allowedAssets: allowedAssetsValue,
-      allowedVenues: allowedVenuesValue,
-      allowBuilderPerps: allowBuilderPerpsValue,
-    });
-    if (loosening) {
-      return c.json<ApiResponse>({ ok: false, error: loosening }, 403);
-    }
   }
 
   const updatedBy = isAgentSelfUpdate
     ? (c.get("agentSubject") ?? `agent:${agentId}`)
     : (c.get("userId") ?? "unknown");
   const updatedReason = body.reason.trim();
-  const nextPolicyValues = {
-    dailyCapUsd: String(dailyCapValue),
-    perOrderCapUsd: String(perOrderCapValue),
-    leverageCap: String(leverageCapValue),
-    allowedAssets: allowedAssetsValue,
-    allowedVenues: allowedVenuesValue,
-    allowBuilderPerps: allowBuilderPerpsValue,
-    updatedAt: new Date(),
-    updatedBy,
-    updatedReason,
-  };
 
   const mutation = await withTenantAuditedTransaction(
     tenantId,
     async (txRaw, appendRequiredAudit) => {
       const tx = txRaw as typeof db;
-      let upserted: typeof agentPolicies.$inferSelect | undefined;
+      // Serialize the complete partial-patch read/materialize/write sequence,
+      // including initial-row creation where SELECT FOR UPDATE has no row to
+      // lock. PGLite runs tests on one connection and lacks this PG function.
+      if (process.env.STEWARD_PGLITE_MEMORY !== "true") {
+        await tx.execute(
+          sql`SELECT pg_advisory_xact_lock(hashtextextended(${`agent-policy:${tenantId}:${agentId}`}, 0))`,
+        );
+      }
+      const [existing] = await tx
+        .select()
+        .from(agentPolicies)
+        .where(and(eq(agentPolicies.agentId, agentId), eq(agentPolicies.tenantId, tenantId)))
+        .for("update");
+      const before = existing ? policyRowToResponse(existing) : defaultPolicySnapshot(agentId);
+      const dailyCapValue = (validatedPatch.dailyCap ?? before.dailyCap) as number;
+      const perOrderCapValue = (validatedPatch.perOrderCap ?? before.perOrderCap) as number;
+      const leverageCapValue = (validatedPatch.leverageCap ?? before.leverageCap) as number;
+      const allowedAssetsValue = (validatedPatch.allowedAssets ?? before.allowedAssets) as string[];
+      const allowedVenuesValue = (validatedPatch.allowedVenues ?? before.allowedVenues) as string[];
+      const allowBuilderPerpsValue = (validatedPatch.allowBuilderPerps ??
+        before.allowBuilderPerps) as boolean;
+
+      if (hasBuilderPerpAsset(allowedAssetsValue) && !allowBuilderPerpsValue) {
+        return {
+          kind: "invalid" as const,
+          status: 400 as const,
+          error: "builder perp assets require allowBuilderPerps=true",
+        };
+      }
+      if (perOrderCapValue > dailyCapValue) {
+        return {
+          kind: "invalid" as const,
+          status: 400 as const,
+          error: "perOrderCap cannot exceed dailyCap",
+        };
+      }
       if (isAgentSelfUpdate) {
-        // SEC-208 concurrency fence: authorize against one exact row and commit
-        // that CAS together with its required audit. A stale writer changes
-        // neither policy nor evidence and retries from a fresh snapshot.
-        const expected = existing;
-        if (!expected) return { kind: "conflict" as const };
+        if (!existing) {
+          return {
+            kind: "invalid" as const,
+            status: 403 as const,
+            error: "Initial trade policy creation requires an owner/admin session with recent MFA",
+          };
+        }
+        const loosening = policyLooseningViolation(before, {
+          dailyCap: dailyCapValue,
+          perOrderCap: perOrderCapValue,
+          leverageCap: leverageCapValue,
+          allowedAssets: allowedAssetsValue,
+          allowedVenues: allowedVenuesValue,
+          allowBuilderPerps: allowBuilderPerpsValue,
+        });
+        if (loosening) return { kind: "invalid" as const, status: 403 as const, error: loosening };
+      }
+
+      const nextPolicyValues = {
+        dailyCapUsd: String(dailyCapValue),
+        perOrderCapUsd: String(perOrderCapValue),
+        leverageCap: String(leverageCapValue),
+        allowedAssets: allowedAssetsValue,
+        allowedVenues: allowedVenuesValue,
+        allowBuilderPerps: allowBuilderPerpsValue,
+        updatedAt: new Date(),
+        updatedBy,
+        updatedReason,
+      };
+      let upserted: typeof agentPolicies.$inferSelect | undefined;
+      if (existing) {
         [upserted] = await tx
           .update(agentPolicies)
           .set(nextPolicyValues)
-          .where(buildAgentPolicyCompareAndSwapPredicate(agentId, tenantId, expected))
+          .where(buildAgentPolicyCompareAndSwapPredicate(agentId, tenantId, existing))
           .returning();
         if (!upserted) return { kind: "conflict" as const };
       } else {
         [upserted] = await tx
           .insert(agentPolicies)
           .values({ agentId, tenantId, ...nextPolicyValues })
-          .onConflictDoUpdate({
-            target: agentPolicies.agentId,
-            set: { ...nextPolicyValues },
-          })
           .returning();
       }
       if (!upserted) throw new Error("Failed to update agent policy");
@@ -1895,6 +1884,9 @@ agentRoutes.put("/:agentId/policy", async (c) => {
     },
   );
 
+  if (mutation.kind === "invalid") {
+    return c.json<ApiResponse>({ ok: false, error: mutation.error }, mutation.status);
+  }
   if (mutation.kind === "conflict") {
     return c.json<ApiResponse>(
       { ok: false, error: "Agent policy changed concurrently; retry against the latest policy" },

--- a/packages/api/src/routes/agents.ts
+++ b/packages/api/src/routes/agents.ts
@@ -934,6 +934,33 @@ function policyLooseningViolation(
   return null;
 }
 
+/**
+ * Exact policy compare-and-swap fence used after authorizing an agent-token
+ * tightening. The attribution fields are part of the expected snapshot too:
+ * two concurrent requests that produce identical limits but claim different
+ * reasons must not both commit against the same audit `before` state.
+ */
+export function buildAgentPolicyCompareAndSwapPredicate(
+  agentId: string,
+  tenantId: string,
+  expected: typeof agentPolicies.$inferSelect,
+) {
+  return and(
+    eq(agentPolicies.agentId, agentId),
+    eq(agentPolicies.tenantId, tenantId),
+    eq(agentPolicies.dailyCapUsd, expected.dailyCapUsd),
+    eq(agentPolicies.perOrderCapUsd, expected.perOrderCapUsd),
+    eq(agentPolicies.leverageCap, expected.leverageCap),
+    eq(agentPolicies.allowedAssets, expected.allowedAssets),
+    eq(agentPolicies.allowedVenues, expected.allowedVenues),
+    eq(agentPolicies.allowBuilderPerps, expected.allowBuilderPerps),
+    eq(agentPolicies.updatedBy, expected.updatedBy),
+    expected.updatedReason === null
+      ? isNull(agentPolicies.updatedReason)
+      : eq(agentPolicies.updatedReason, expected.updatedReason),
+  );
+}
+
 // ─── Create agent ─────────────────────────────────────────────────────────────
 
 agentRoutes.post("/", async (c) => {
@@ -1834,18 +1861,7 @@ agentRoutes.put("/:agentId/policy", async (c) => {
     [upserted] = await db
       .update(agentPolicies)
       .set(nextPolicyValues)
-      .where(
-        and(
-          eq(agentPolicies.agentId, agentId),
-          eq(agentPolicies.tenantId, tenantId),
-          eq(agentPolicies.dailyCapUsd, expected.dailyCapUsd),
-          eq(agentPolicies.perOrderCapUsd, expected.perOrderCapUsd),
-          eq(agentPolicies.leverageCap, expected.leverageCap),
-          eq(agentPolicies.allowedAssets, expected.allowedAssets),
-          eq(agentPolicies.allowedVenues, expected.allowedVenues),
-          eq(agentPolicies.allowBuilderPerps, expected.allowBuilderPerps),
-        ),
-      )
+      .where(buildAgentPolicyCompareAndSwapPredicate(agentId, tenantId, expected))
       .returning();
     if (!upserted) {
       return c.json<ApiResponse>(

--- a/packages/api/src/routes/agents.ts
+++ b/packages/api/src/routes/agents.ts
@@ -10,7 +10,7 @@ import { getSpend, getSpendByHost, invalidateCache, type SpendPeriod } from "@st
 import { and, eq, gte, inArray, isNull, sql } from "drizzle-orm";
 import { type Context, Hono } from "hono";
 import { isRedisAvailable } from "../middleware/redis";
-import { writeAuditEvent } from "../services/audit";
+import { withTenantAuditedTransaction, writeAuditEvent } from "../services/audit";
 import {
   AGENT_TOKEN_EXPIRY,
   type AgentIdentity,
@@ -954,6 +954,7 @@ export function buildAgentPolicyCompareAndSwapPredicate(
     eq(agentPolicies.allowedAssets, expected.allowedAssets),
     eq(agentPolicies.allowedVenues, expected.allowedVenues),
     eq(agentPolicies.allowBuilderPerps, expected.allowBuilderPerps),
+    eq(agentPolicies.updatedAt, expected.updatedAt),
     eq(agentPolicies.updatedBy, expected.updatedBy),
     expected.updatedReason === null
       ? isNull(agentPolicies.updatedReason)
@@ -1840,73 +1841,67 @@ agentRoutes.put("/:agentId/policy", async (c) => {
     updatedReason,
   };
 
-  let upserted: typeof agentPolicies.$inferSelect | undefined;
-  if (isAgentSelfUpdate) {
-    // SEC-208 concurrency fence: the earlier comparison is useful for a clear
-    // error, but it is not authorization by itself. Two requests can read the
-    // same row, both appear to tighten it, and then overwrite each other. Make
-    // the write conditional on the exact row that was authorized above. This
-    // is stricter than comparing only the proposed caps/allowlists: accepting a
-    // stale-but-stricter proposal would preserve safety, but its audit `before`
-    // snapshot and returned diff would describe a row that was no longer
-    // current. Exact optimistic CAS keeps both the policy and its evidence
-    // linearizable; a stale writer retries from a fresh snapshot.
-    const expected = existing;
-    if (!expected) {
-      return c.json<ApiResponse>(
-        { ok: false, error: "Agent policy changed concurrently; retry against the latest policy" },
-        409,
-      );
-    }
-    [upserted] = await db
-      .update(agentPolicies)
-      .set(nextPolicyValues)
-      .where(buildAgentPolicyCompareAndSwapPredicate(agentId, tenantId, expected))
-      .returning();
-    if (!upserted) {
-      return c.json<ApiResponse>(
-        { ok: false, error: "Agent policy changed concurrently; retry against the latest policy" },
-        409,
-      );
-    }
-  } else {
-    [upserted] = await db
-      .insert(agentPolicies)
-      .values({ agentId, tenantId, ...nextPolicyValues })
-      .onConflictDoUpdate({
-        target: agentPolicies.agentId,
-        set: {
-          ...nextPolicyValues,
-        },
-      })
-      .returning();
-  }
-
-  if (!upserted) {
-    return c.json<ApiResponse>({ ok: false, error: "Failed to update agent policy" }, 500);
-  }
-
-  const after = policyRowToResponse(upserted);
-  const diff = policyDiff(before, after);
-  await writeAuditEvent({
+  const mutation = await withTenantAuditedTransaction(
     tenantId,
-    actorType: isAgentSelfUpdate ? "agent" : "user",
-    actorId: updatedBy,
-    action: "agent.policy.updated",
-    resourceType: "agent_policy",
-    resourceId: agentId,
-    metadata: {
-      agentId,
-      reason: updatedReason,
-      diff,
-      before,
-      after,
-      multisigApprovalProvided: body.multisigApproval !== undefined,
+    async (txRaw, appendRequiredAudit) => {
+      const tx = txRaw as typeof db;
+      let upserted: typeof agentPolicies.$inferSelect | undefined;
+      if (isAgentSelfUpdate) {
+        // SEC-208 concurrency fence: authorize against one exact row and commit
+        // that CAS together with its required audit. A stale writer changes
+        // neither policy nor evidence and retries from a fresh snapshot.
+        const expected = existing;
+        if (!expected) return { kind: "conflict" as const };
+        [upserted] = await tx
+          .update(agentPolicies)
+          .set(nextPolicyValues)
+          .where(buildAgentPolicyCompareAndSwapPredicate(agentId, tenantId, expected))
+          .returning();
+        if (!upserted) return { kind: "conflict" as const };
+      } else {
+        [upserted] = await tx
+          .insert(agentPolicies)
+          .values({ agentId, tenantId, ...nextPolicyValues })
+          .onConflictDoUpdate({
+            target: agentPolicies.agentId,
+            set: { ...nextPolicyValues },
+          })
+          .returning();
+      }
+      if (!upserted) throw new Error("Failed to update agent policy");
+
+      const after = policyRowToResponse(upserted);
+      const diff = policyDiff(before, after);
+      await appendRequiredAudit({
+        tenantId,
+        actorType: isAgentSelfUpdate ? "agent" : "user",
+        actorId: updatedBy,
+        action: "agent.policy.updated",
+        resourceType: "agent_policy",
+        resourceId: agentId,
+        metadata: {
+          agentId,
+          reason: updatedReason,
+          diff,
+          before,
+          after,
+          multisigApprovalProvided: body.multisigApproval !== undefined,
+        },
+        ipAddress: c.req.header("x-forwarded-for") ?? null,
+        userAgent: c.req.header("user-agent") ?? null,
+        requestId: c.get("requestId") ?? null,
+      });
+      return { kind: "updated" as const, after, diff };
     },
-    ipAddress: c.req.header("x-forwarded-for") ?? null,
-    userAgent: c.req.header("user-agent") ?? null,
-    requestId: c.get("requestId") ?? null,
-  });
+  );
+
+  if (mutation.kind === "conflict") {
+    return c.json<ApiResponse>(
+      { ok: false, error: "Agent policy changed concurrently; retry against the latest policy" },
+      409,
+    );
+  }
+  const { after, diff } = mutation;
 
   return c.json<
     ApiResponse<{ policy: AgentTradePolicyResponse; diff: ReturnType<typeof policyDiff> }>

--- a/packages/api/src/routes/agents.ts
+++ b/packages/api/src/routes/agents.ts
@@ -7,7 +7,7 @@
 import { hashSha256Hex, importP256PublicKey, revocationStore } from "@stwd/auth";
 import { agentPolicies, toPersistedPolicyRule } from "@stwd/db";
 import { getSpend, getSpendByHost, invalidateCache, type SpendPeriod } from "@stwd/redis";
-import { and, eq, gte, inArray, isNull, sql } from "drizzle-orm";
+import { and, arrayContains, eq, gte, inArray, isNull, sql } from "drizzle-orm";
 import { type Context, Hono } from "hono";
 import { isRedisAvailable } from "../middleware/redis";
 import { writeAuditEvent } from "../services/audit";
@@ -1801,36 +1801,64 @@ agentRoutes.put("/:agentId/policy", async (c) => {
     ? (c.get("agentSubject") ?? `agent:${agentId}`)
     : (c.get("userId") ?? "unknown");
   const updatedReason = body.reason.trim();
-  const [upserted] = await db
-    .insert(agentPolicies)
-    .values({
-      agentId,
-      tenantId,
-      dailyCapUsd: String(dailyCapValue),
-      perOrderCapUsd: String(perOrderCapValue),
-      leverageCap: String(leverageCapValue),
-      allowedAssets: allowedAssetsValue,
-      allowedVenues: allowedVenuesValue,
-      allowBuilderPerps: allowBuilderPerpsValue,
-      updatedAt: new Date(),
-      updatedBy,
-      updatedReason,
-    })
-    .onConflictDoUpdate({
-      target: agentPolicies.agentId,
-      set: {
-        dailyCapUsd: String(dailyCapValue),
-        perOrderCapUsd: String(perOrderCapValue),
-        leverageCap: String(leverageCapValue),
-        allowedAssets: allowedAssetsValue,
-        allowedVenues: allowedVenuesValue,
-        allowBuilderPerps: allowBuilderPerpsValue,
-        updatedAt: new Date(),
-        updatedBy,
-        updatedReason,
-      },
-    })
-    .returning();
+  const nextPolicyValues = {
+    dailyCapUsd: String(dailyCapValue),
+    perOrderCapUsd: String(perOrderCapValue),
+    leverageCap: String(leverageCapValue),
+    allowedAssets: allowedAssetsValue,
+    allowedVenues: allowedVenuesValue,
+    allowBuilderPerps: allowBuilderPerpsValue,
+    updatedAt: new Date(),
+    updatedBy,
+    updatedReason,
+  };
+
+  let upserted: typeof agentPolicies.$inferSelect | undefined;
+  if (isAgentSelfUpdate) {
+    // SEC-208 concurrency fence: the earlier comparison is useful for a clear
+    // error, but it is not authorization by itself. Two requests can read the
+    // same row, both appear to tighten it, and then overwrite each other. Make
+    // the write conditional on the CURRENT database row still being at least
+    // as permissive as the proposed policy in every dimension. A stale write
+    // therefore fails instead of re-raising a cap or widening an allowlist.
+    [upserted] = await db
+      .update(agentPolicies)
+      .set(nextPolicyValues)
+      .where(
+        and(
+          eq(agentPolicies.agentId, agentId),
+          eq(agentPolicies.tenantId, tenantId),
+          gte(agentPolicies.dailyCapUsd, String(dailyCapValue)),
+          gte(agentPolicies.perOrderCapUsd, String(perOrderCapValue)),
+          gte(agentPolicies.leverageCap, String(leverageCapValue)),
+          arrayContains(agentPolicies.allowedAssets, allowedAssetsValue),
+          arrayContains(agentPolicies.allowedVenues, allowedVenuesValue),
+          allowBuilderPerpsValue ? eq(agentPolicies.allowBuilderPerps, true) : undefined,
+        ),
+      )
+      .returning();
+    if (!upserted) {
+      return c.json<ApiResponse>(
+        { ok: false, error: "Agent policy changed concurrently; retry against the latest policy" },
+        409,
+      );
+    }
+  } else {
+    [upserted] = await db
+      .insert(agentPolicies)
+      .values({ agentId, tenantId, ...nextPolicyValues })
+      .onConflictDoUpdate({
+        target: agentPolicies.agentId,
+        set: {
+          ...nextPolicyValues,
+        },
+      })
+      .returning();
+  }
+
+  if (!upserted) {
+    return c.json<ApiResponse>({ ok: false, error: "Failed to update agent policy" }, 500);
+  }
 
   const after = policyRowToResponse(upserted);
   const diff = policyDiff(before, after);

--- a/packages/api/src/routes/agents.ts
+++ b/packages/api/src/routes/agents.ts
@@ -7,7 +7,7 @@
 import { hashSha256Hex, importP256PublicKey, revocationStore } from "@stwd/auth";
 import { agentPolicies, toPersistedPolicyRule } from "@stwd/db";
 import { getSpend, getSpendByHost, invalidateCache, type SpendPeriod } from "@stwd/redis";
-import { and, arrayContains, eq, gte, inArray, isNull, sql } from "drizzle-orm";
+import { and, eq, gte, inArray, isNull, sql } from "drizzle-orm";
 import { type Context, Hono } from "hono";
 import { isRedisAvailable } from "../middleware/redis";
 import { writeAuditEvent } from "../services/audit";
@@ -1818,9 +1818,19 @@ agentRoutes.put("/:agentId/policy", async (c) => {
     // SEC-208 concurrency fence: the earlier comparison is useful for a clear
     // error, but it is not authorization by itself. Two requests can read the
     // same row, both appear to tighten it, and then overwrite each other. Make
-    // the write conditional on the CURRENT database row still being at least
-    // as permissive as the proposed policy in every dimension. A stale write
-    // therefore fails instead of re-raising a cap or widening an allowlist.
+    // the write conditional on the exact row that was authorized above. This
+    // is stricter than comparing only the proposed caps/allowlists: accepting a
+    // stale-but-stricter proposal would preserve safety, but its audit `before`
+    // snapshot and returned diff would describe a row that was no longer
+    // current. Exact optimistic CAS keeps both the policy and its evidence
+    // linearizable; a stale writer retries from a fresh snapshot.
+    const expected = existing;
+    if (!expected) {
+      return c.json<ApiResponse>(
+        { ok: false, error: "Agent policy changed concurrently; retry against the latest policy" },
+        409,
+      );
+    }
     [upserted] = await db
       .update(agentPolicies)
       .set(nextPolicyValues)
@@ -1828,12 +1838,12 @@ agentRoutes.put("/:agentId/policy", async (c) => {
         and(
           eq(agentPolicies.agentId, agentId),
           eq(agentPolicies.tenantId, tenantId),
-          gte(agentPolicies.dailyCapUsd, String(dailyCapValue)),
-          gte(agentPolicies.perOrderCapUsd, String(perOrderCapValue)),
-          gte(agentPolicies.leverageCap, String(leverageCapValue)),
-          arrayContains(agentPolicies.allowedAssets, allowedAssetsValue),
-          arrayContains(agentPolicies.allowedVenues, allowedVenuesValue),
-          allowBuilderPerpsValue ? eq(agentPolicies.allowBuilderPerps, true) : undefined,
+          eq(agentPolicies.dailyCapUsd, expected.dailyCapUsd),
+          eq(agentPolicies.perOrderCapUsd, expected.perOrderCapUsd),
+          eq(agentPolicies.leverageCap, expected.leverageCap),
+          eq(agentPolicies.allowedAssets, expected.allowedAssets),
+          eq(agentPolicies.allowedVenues, expected.allowedVenues),
+          eq(agentPolicies.allowBuilderPerps, expected.allowBuilderPerps),
         ),
       )
       .returning();


### PR DESCRIPTION
Post-merge corrective for #322 (SEC-208).

Every trade-policy partial patch now materializes from a row locked and re-read inside the tenant-scoped audited transaction. Production uses a tenant-and-agent transaction advisory lock to cover both existing rows and initial creation; the exact snapshot CAS, mutation, and required audit then commit together. This prevents concurrent human owner/admin partial patches from overwriting each other or emitting a false before-state, while preserving tighten-only agent-token enforcement.

Exact base: 73454819ea020dcd676cb36066dbd60d07e4ec98
Exact head: f49f519d1ed9088c1a6b4a9472da523320863472

Validation:
- agent policy route suite: 14 passed, 0 failed, 51 assertions
- human concurrency plus audit rollback suites: 11 passed, 0 failed, 100 assertions
- concurrent human partial patches both return 200, preserve both fields, and produce consecutive before/after and HMAC-linked audit evidence
- API TypeScript check: passed
- Biome and git diff --check: clean

The PR remains draft pending exact-head CI.