### PR TITLE
fix(ci): pin PR metadata diff to event SHAs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -65,21 +65,13 @@ jobs:
           # Compare the immutable commits captured by the pull_request event.
           # The base branch can advance while this job runs; diffing its live
           # remote tip would then attribute unrelated merged changes to the PR.
-          git fetch --no-tags origin "${BASE_SHA}" "${HEAD_SHA}"
-          changed_files=$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}")
-
-          status=0
-          for pkg in sdk react eliza-plugin; do
-            pkg_dir="packages/${pkg}"
-            if echo "$changed_files" | grep -qE "^${pkg_dir}/"; then
-              if ! echo "$changed_files" | grep -qE "^${pkg_dir}/(package.json|CHANGELOG.md|CHANGELOG|changelog.md)$"; then
-                echo "::error::${pkg_dir} changed without a package.json version bump or changelog update"
-                status=1
-              fi
-            fi
-          done
-
-          exit "$status"
+          # The helper validates both values as full commit IDs, verifies/fetches
+          # missing objects independently (fork heads are normally already
+          # parents of the checked-out PR merge commit), and consumes Git's
+          # NUL-delimited filename output so hostile filenames cannot bypass the
+          # package check.
+          bun test scripts/__tests__/check-public-package-metadata.test.ts
+          bun scripts/check-public-package-metadata.ts "$BASE_SHA" "$HEAD_SHA"
 
       - name: Check PR title
         # PR title is attacker-controlled. Pass it through env (never inline into

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -65,7 +65,12 @@ jobs:
           # Compare the immutable commits captured by the pull_request event.
           # The base branch can advance while this job runs; diffing its live
           # remote tip would then attribute unrelated merged changes to the PR.
-          git fetch --no-tags origin "${BASE_SHA}" "${HEAD_SHA}"
+          # checkout uses fetch-depth: 0 and the pull_request merge ref, so both
+          # immutable parent commits are already present. Do not fetch HEAD_SHA
+          # from origin: fork commits are not public branch tips in the base repo
+          # and a SHA fetch is not a portable upload-pack contract.
+          git cat-file -e "${BASE_SHA}^{commit}"
+          git cat-file -e "${HEAD_SHA}^{commit}"
           changed_files=$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}")
 
           status=0

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -58,14 +58,15 @@ jobs:
 
       - name: Check public package version bumps
         env:
-          BASE_REF: ${{ github.base_ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          # Checkout above is intentionally unshallow. Keep it that way: a
-          # depth-1 fetch can rewrite origin/${BASE_REF} as a shallow tip and
-          # remove the merge base needed by the three-dot diff below.
-          git fetch --no-tags origin "${BASE_REF}"
-          changed_files=$(git diff --name-only "origin/${BASE_REF}...HEAD")
+          # Compare the immutable commits captured by the pull_request event.
+          # The base branch can advance while this job runs; diffing its live
+          # remote tip would then attribute unrelated merged changes to the PR.
+          git fetch --no-tags origin "${BASE_SHA}" "${HEAD_SHA}"
+          changed_files=$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}")
 
           status=0
           for pkg in sdk react eliza-plugin; do

--- a/scripts/__tests__/check-public-package-metadata.test.ts
+++ b/scripts/__tests__/check-public-package-metadata.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   evaluatePublicPackageMetadata,
   isFullCommitSha,
+  isStrictSemverIncrease,
   parseNulDelimitedFiles,
 } from "../check-public-package-metadata";
 
@@ -44,6 +45,26 @@ describe("public package metadata check", () => {
         versions: unchangedVersions,
       }),
     ).toEqual([]);
+  });
+
+  test("requires a strict semver increase over the immutable event base", () => {
+    const changedFiles = ["packages/sdk/src/index.ts", "packages/sdk/package.json"];
+    expect(
+      evaluatePublicPackageMetadata({
+        changedFiles,
+        versions: { ...unchangedVersions, sdk: { base: "1.0.1", head: "1.0.1" } },
+      }),
+    ).toHaveLength(1);
+    expect(
+      evaluatePublicPackageMetadata({
+        changedFiles,
+        versions: { ...unchangedVersions, sdk: { base: "1.0.1", head: "1.0.0" } },
+      }),
+    ).toHaveLength(1);
+    expect(isStrictSemverIncrease("1.0.0-beta.2", "1.0.0-beta.10")).toBe(true);
+    expect(isStrictSemverIncrease("1.0.0", "1.0.1")).toBe(true);
+    expect(isStrictSemverIncrease("1.0.0", "2.0")).toBe(false);
+    expect(isStrictSemverIncrease("1.0.0-1", "1.0.0-01")).toBe(false);
   });
 
   test("rejects malformed or ref-like SHA inputs before invoking git", () => {

--- a/scripts/__tests__/check-public-package-metadata.test.ts
+++ b/scripts/__tests__/check-public-package-metadata.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import {
+  evaluatePublicPackageMetadata,
+  isFullCommitSha,
+  parseNulDelimitedFiles,
+} from "../check-public-package-metadata";
+
+const unchangedVersions = {
+  sdk: { base: "1.0.0", head: "1.0.0" },
+  react: { base: "1.0.0", head: "1.0.0" },
+  "eliza-plugin": { base: "1.0.0", head: "1.0.0" },
+};
+
+describe("public package metadata check", () => {
+  test("treats newlines in filenames as data, not line delimiters", () => {
+    const files = parseNulDelimitedFiles(
+      new TextEncoder().encode("packages/sdk/src/hostile\npackages/sdk/CHANGELOG.md\0"),
+    );
+    expect(files).toEqual(["packages/sdk/src/hostile\npackages/sdk/CHANGELOG.md"]);
+    expect(
+      evaluatePublicPackageMetadata({ changedFiles: files, versions: unchangedVersions }),
+    ).toEqual(["packages/sdk changed without a package.json version bump or changelog update"]);
+  });
+
+  test("does not accept a package.json touch without an actual version change", () => {
+    expect(
+      evaluatePublicPackageMetadata({
+        changedFiles: ["packages/sdk/src/index.ts", "packages/sdk/package.json"],
+        versions: unchangedVersions,
+      }),
+    ).toEqual(["packages/sdk changed without a package.json version bump or changelog update"]);
+  });
+
+  test("accepts an actual version bump or an exact changelog file", () => {
+    expect(
+      evaluatePublicPackageMetadata({
+        changedFiles: ["packages/sdk/src/index.ts", "packages/sdk/package.json"],
+        versions: { ...unchangedVersions, sdk: { base: "1.0.0", head: "1.0.1" } },
+      }),
+    ).toEqual([]);
+    expect(
+      evaluatePublicPackageMetadata({
+        changedFiles: ["packages/react/src/index.ts", "packages/react/CHANGELOG.md"],
+        versions: unchangedVersions,
+      }),
+    ).toEqual([]);
+  });
+
+  test("rejects malformed or ref-like SHA inputs before invoking git", () => {
+    expect(isFullCommitSha("develop")).toBe(false);
+    expect(isFullCommitSha("HEAD^{commit}")).toBe(false);
+    expect(isFullCommitSha("A".repeat(40))).toBe(false);
+    expect(isFullCommitSha("50d4d6b2c111accb6dc2c83eb065f877af304251")).toBe(true);
+  });
+});

--- a/scripts/__tests__/check-public-package-metadata.test.ts
+++ b/scripts/__tests__/check-public-package-metadata.test.ts
@@ -65,6 +65,7 @@ describe("public package metadata check", () => {
     expect(isStrictSemverIncrease("1.0.0", "1.0.1")).toBe(true);
     expect(isStrictSemverIncrease("1.0.0", "2.0")).toBe(false);
     expect(isStrictSemverIncrease("1.0.0-1", "1.0.0-01")).toBe(false);
+    expect(isStrictSemverIncrease("1.0.0", `${"9".repeat(257)}.0.0`)).toBe(false);
   });
 
   test("rejects malformed or ref-like SHA inputs before invoking git", () => {

--- a/scripts/check-public-package-metadata.ts
+++ b/scripts/check-public-package-metadata.ts
@@ -13,9 +13,50 @@
 const PUBLIC_PACKAGES = ["sdk", "react", "eliza-plugin"] as const;
 const FULL_SHA1 = /^[0-9a-f]{40}$/;
 const CHANGELOG_NAMES = new Set(["CHANGELOG.md", "CHANGELOG", "changelog.md"]);
+const SEMVER =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 
 export function isFullCommitSha(value: string | undefined): value is string {
   return typeof value === "string" && FULL_SHA1.test(value);
+}
+
+function comparePrerelease(left: string | undefined, right: string | undefined): number {
+  if (left === right) return 0;
+  if (left === undefined) return 1;
+  if (right === undefined) return -1;
+  const leftParts = left.split(".");
+  const rightParts = right.split(".");
+  for (let index = 0; index < Math.max(leftParts.length, rightParts.length); index += 1) {
+    const a = leftParts[index];
+    const b = rightParts[index];
+    if (a === undefined) return -1;
+    if (b === undefined) return 1;
+    if (a === b) continue;
+    const aNumeric = /^\d+$/.test(a);
+    const bNumeric = /^\d+$/.test(b);
+    if (aNumeric && bNumeric) return BigInt(a) < BigInt(b) ? -1 : 1;
+    if (aNumeric !== bNumeric) return aNumeric ? -1 : 1;
+    return a < b ? -1 : 1;
+  }
+  return 0;
+}
+
+export function isStrictSemverIncrease(base: string | null, head: string | null): boolean {
+  if (base === null || head === null) return false;
+  const before = SEMVER.exec(base);
+  const after = SEMVER.exec(head);
+  if (!before || !after) return false;
+  for (const prerelease of [before[4], after[4]]) {
+    if (prerelease?.split(".").some((part) => /^\d+$/.test(part) && part.length > 1 && part[0] === "0")) {
+      return false;
+    }
+  }
+  for (let index = 1; index <= 3; index += 1) {
+    const left = BigInt(before[index]);
+    const right = BigInt(after[index]);
+    if (left !== right) return right > left;
+  }
+  return comparePrerelease(before[4], after[4]) < 0;
 }
 
 export interface PackageMetadataInput {
@@ -36,10 +77,7 @@ export function evaluatePublicPackageMetadata(input: PackageMetadataInput): stri
     const packageJsonChanged = relative.includes("package.json");
     const version = input.versions[pkg];
     const versionBumped =
-      packageJsonChanged &&
-      version?.base !== null &&
-      version?.head !== null &&
-      version?.base !== version?.head;
+      packageJsonChanged && isStrictSemverIncrease(version?.base ?? null, version?.head ?? null);
 
     if (!changelogChanged && !versionBumped) {
       errors.push(
@@ -114,7 +152,11 @@ export function main(argv: string[]): number {
     const versions: Record<string, { base: string | null; head: string | null }> = {};
     for (const pkg of PUBLIC_PACKAGES) {
       versions[pkg] = {
-        base: readVersion(mergeBase, pkg),
+        // Changed-file attribution remains three-dot/merge-base based, but a
+        // release version must advance beyond the immutable event base. If the
+        // base branch independently reached the same version as the PR, the PR
+        // must choose another version (or add a changelog) before merging.
+        base: readVersion(baseSha, pkg),
         head: readVersion(headSha, pkg),
       };
     }

--- a/scripts/check-public-package-metadata.ts
+++ b/scripts/check-public-package-metadata.ts
@@ -1,0 +1,133 @@
+#!/usr/bin/env bun
+
+/**
+ * Validate public-package release metadata for an immutable PR base/head pair.
+ *
+ * Security properties:
+ * - only full SHA-1 object IDs are accepted (no attacker-controlled refspecs),
+ * - a fork head already present through refs/pull/... is not fetched again,
+ * - filenames are read with `-z` (newlines and other metacharacters are data),
+ * - merely touching package.json is not called a version bump.
+ */
+
+const PUBLIC_PACKAGES = ["sdk", "react", "eliza-plugin"] as const;
+const FULL_SHA1 = /^[0-9a-f]{40}$/;
+const CHANGELOG_NAMES = new Set(["CHANGELOG.md", "CHANGELOG", "changelog.md"]);
+
+export function isFullCommitSha(value: string | undefined): value is string {
+  return typeof value === "string" && FULL_SHA1.test(value);
+}
+
+export interface PackageMetadataInput {
+  changedFiles: readonly string[];
+  versions: Readonly<Record<string, { base: string | null; head: string | null }>>;
+}
+
+export function evaluatePublicPackageMetadata(input: PackageMetadataInput): string[] {
+  const errors: string[] = [];
+  for (const pkg of PUBLIC_PACKAGES) {
+    const prefix = `packages/${pkg}/`;
+    const relative = input.changedFiles
+      .filter((file) => file.startsWith(prefix))
+      .map((file) => file.slice(prefix.length));
+    if (relative.length === 0) continue;
+
+    const changelogChanged = relative.some((file) => CHANGELOG_NAMES.has(file));
+    const packageJsonChanged = relative.includes("package.json");
+    const version = input.versions[pkg];
+    const versionBumped =
+      packageJsonChanged &&
+      version?.base !== null &&
+      version?.head !== null &&
+      version?.base !== version?.head;
+
+    if (!changelogChanged && !versionBumped) {
+      errors.push(
+        `${prefix.slice(0, -1)} changed without a package.json version bump or changelog update`,
+      );
+    }
+  }
+  return errors;
+}
+
+function git(args: string[], allowFailure = false): Uint8Array {
+  const result = Bun.spawnSync(["git", ...args], { stdout: "pipe", stderr: "pipe" });
+  if (result.exitCode !== 0 && !allowFailure) {
+    const detail = new TextDecoder().decode(result.stderr).trim();
+    throw new Error(`git ${args[0] ?? "command"} failed${detail ? `: ${detail}` : ""}`);
+  }
+  return result.stdout;
+}
+
+function hasCommit(sha: string): boolean {
+  return (
+    Bun.spawnSync(["git", "cat-file", "-e", `${sha}^{commit}`], {
+      stdout: "ignore",
+      stderr: "ignore",
+    }).exitCode === 0
+  );
+}
+
+function ensureCommit(sha: string): void {
+  if (hasCommit(sha)) return;
+  // A missing object may occur with a shallow checkout. Fetch the validated
+  // immutable ID alone; never combine an untrusted value into a refspec.
+  git(["fetch", "--no-tags", "origin", sha]);
+  if (!hasCommit(sha)) throw new Error(`fetched object is not a commit: ${sha}`);
+}
+
+function readVersion(commit: string, pkg: string): string | null {
+  const result = Bun.spawnSync(["git", "show", `${commit}:packages/${pkg}/package.json`], {
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  if (result.exitCode !== 0) return null;
+  try {
+    const parsed = JSON.parse(new TextDecoder().decode(result.stdout)) as { version?: unknown };
+    return typeof parsed.version === "string" ? parsed.version : null;
+  } catch {
+    return null;
+  }
+}
+
+export function parseNulDelimitedFiles(bytes: Uint8Array): string[] {
+  return new TextDecoder()
+    .decode(bytes)
+    .split("\0")
+    .filter((file) => file.length > 0);
+}
+
+export function main(argv: string[]): number {
+  const [baseSha, headSha] = argv;
+  if (!isFullCommitSha(baseSha) || !isFullCommitSha(headSha)) {
+    console.error("::error::base and head must be full lowercase 40-character commit SHAs");
+    return 2;
+  }
+
+  try {
+    ensureCommit(baseSha);
+    ensureCommit(headSha);
+    const mergeBase = new TextDecoder().decode(git(["merge-base", baseSha, headSha])).trim();
+    if (!FULL_SHA1.test(mergeBase)) throw new Error("no valid merge base for PR commits");
+
+    const changedFiles = parseNulDelimitedFiles(
+      git(["diff", "--name-only", "-z", `${mergeBase}..${headSha}`]),
+    );
+    const versions: Record<string, { base: string | null; head: string | null }> = {};
+    for (const pkg of PUBLIC_PACKAGES) {
+      versions[pkg] = {
+        base: readVersion(mergeBase, pkg),
+        head: readVersion(headSha, pkg),
+      };
+    }
+    const errors = evaluatePublicPackageMetadata({ changedFiles, versions });
+    for (const error of errors) console.error(`::error::${error}`);
+    return errors.length === 0 ? 0 : 1;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "metadata validation failed";
+    console.error(`::error::${message}`);
+    return 2;
+  }
+}
+
+if (import.meta.main) process.exit(main(Bun.argv.slice(2)));

--- a/scripts/check-public-package-metadata.ts
+++ b/scripts/check-public-package-metadata.ts
@@ -43,11 +43,19 @@ function comparePrerelease(left: string | undefined, right: string | undefined):
 
 export function isStrictSemverIncrease(base: string | null, head: string | null): boolean {
   if (base === null || head === null) return false;
+  // package.json is PR-controlled input. Bound parsing/BigInt work so an
+  // absurdly long numeric version cannot turn this required check into a CI
+  // memory/CPU denial of service.
+  if (base.length > 256 || head.length > 256) return false;
   const before = SEMVER.exec(base);
   const after = SEMVER.exec(head);
   if (!before || !after) return false;
   for (const prerelease of [before[4], after[4]]) {
-    if (prerelease?.split(".").some((part) => /^\d+$/.test(part) && part.length > 1 && part[0] === "0")) {
+    if (
+      prerelease
+        ?.split(".")
+        .some((part) => /^\d+$/.test(part) && part.length > 1 && part[0] === "0")
+    ) {
       return false;
     }
   }


### PR DESCRIPTION
## Summary

- retain merge-base only for changed-file attribution
- read package versions from the immutable pull_request event base SHA and head SHA
- accept package.json metadata only when the head version is a strict SemVer increase
- reject unchanged versions, downgrades, malformed versions, and numeric prerelease identifiers with leading zeroes

Exact base: 3ca87c1cef516b93051304e07070988c91a4d1aa
Exact head: 75bc7813e9ae915fc14059d4b3a2abf3487fd2a6

## Validation

- metadata checker: 5 passed, 0 failed, 15 assertions
- actionlint: passed
- Biome and git diff --check: clean

The PR remains draft pending exact-head CI.