### PR TITLE
fix(security): close infra hardening residuals

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,8 +6,10 @@
       "name": "steward",
       "dependencies": {
         "@stwd/attestation": "workspace:*",
+        "@stwd/db": "workspace:*",
         "@stwd/venue-hyperliquid": "workspace:*",
         "@stwd/venue-polymarket": "workspace:*",
+        "drizzle-orm": "^0.44.5",
         "ioredis": "^5.10.1",
         "jose": "^6.2.1",
         "siwe": "^3.0.0",
@@ -264,6 +266,7 @@
       "name": "@stwd/plugin-trading",
       "version": "0.1.0",
       "dependencies": {
+        "@stwd/adapters": "workspace:*",
         "@stwd/db": "workspace:*",
         "@stwd/policy-engine": "workspace:*",
         "@stwd/redis": "workspace:*",
@@ -2166,7 +2169,7 @@
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
-    "camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
+    "camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
 
     "camelcase-css": ["camelcase-css@2.0.1", "", {}, "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="],
 
@@ -2200,7 +2203,7 @@
 
     "client-only": ["client-only@0.0.1", "", {}, "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="],
 
-    "cliui": ["cliui@9.0.1", "", { "dependencies": { "string-width": "^7.2.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w=="],
+    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
     "cloudflare": ["cloudflare@4.5.0", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" } }, "sha512-fPcbPKx4zF45jBvQ0z7PCdgejVAPBBCZxwqk1k7krQNfpM07Cfj97/Q6wBzvYqlWXx/zt1S9+m8vnfCe06umbQ=="],
 
@@ -2220,7 +2223,7 @@
 
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
-    "commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
+    "commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
 
     "comment-json": ["comment-json@4.6.2", "", { "dependencies": { "array-timsort": "^1.0.3", "esprima": "^4.0.1" } }, "sha512-R2rze/hDX30uul4NZoIZ76ImSJLFxn/1/ZxtKC1L77y2X1k+yYu1joKbAtMA2Fg3hZrTOiw0I5mwVMo0cf250w=="],
 
@@ -2360,7 +2363,7 @@
 
     "elliptic": ["elliptic@6.6.1", "", { "dependencies": { "bn.js": "^4.11.9", "brorand": "^1.1.0", "hash.js": "^1.0.0", "hmac-drbg": "^1.0.1", "inherits": "^2.0.4", "minimalistic-assert": "^1.0.1", "minimalistic-crypto-utils": "^1.0.1" } }, "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g=="],
 
-    "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "encode-utf8": ["encode-utf8@1.0.3", "", {}, "sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw=="],
 
@@ -3314,7 +3317,7 @@
 
     "strict-uri-encode": ["strict-uri-encode@2.0.0", "", {}, "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ=="],
 
-    "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -3522,7 +3525,7 @@
 
     "wrangler": ["wrangler@4.105.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.28.1", "miniflare": "4.20260625.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260625.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260625.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "cf-wrangler": "bin/cf-wrangler.js", "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-7dXFH6OLj1Fv0y6ZeRPUxFTkp+duWD7/xxVi/1c0vfOeEYwIFKWB7cdqnY05DvY1Ta3BnqAwRkXfLs8PDj538g=="],
 
-    "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
@@ -3554,7 +3557,7 @@
 
     "yaml-ast-parser": ["yaml-ast-parser@0.0.43", "", {}, "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A=="],
 
-    "yargs": ["yargs@18.0.0", "", { "dependencies": { "cliui": "^9.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "string-width": "^7.2.0", "y18n": "^5.0.5", "yargs-parser": "^22.0.0" } }, "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg=="],
+    "yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
 
     "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
@@ -3836,6 +3839,8 @@
 
     "@opennextjs/aws/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
+    "@opennextjs/cloudflare/yargs": ["yargs@18.0.0", "", { "dependencies": { "cliui": "^9.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "string-width": "^7.2.0", "y18n": "^5.0.5", "yargs-parser": "^22.0.0" } }, "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg=="],
+
     "@particle-network/solana-wallet/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
 
     "@polymarket/abstract-signer/ethers": ["ethers@5.7.2", "", { "dependencies": { "@ethersproject/abi": "5.7.0", "@ethersproject/abstract-provider": "5.7.0", "@ethersproject/abstract-signer": "5.7.0", "@ethersproject/address": "5.7.0", "@ethersproject/base64": "5.7.0", "@ethersproject/basex": "5.7.0", "@ethersproject/bignumber": "5.7.0", "@ethersproject/bytes": "5.7.0", "@ethersproject/constants": "5.7.0", "@ethersproject/contracts": "5.7.0", "@ethersproject/hash": "5.7.0", "@ethersproject/hdnode": "5.7.0", "@ethersproject/json-wallets": "5.7.0", "@ethersproject/keccak256": "5.7.0", "@ethersproject/logger": "5.7.0", "@ethersproject/networks": "5.7.1", "@ethersproject/pbkdf2": "5.7.0", "@ethersproject/properties": "5.7.0", "@ethersproject/providers": "5.7.2", "@ethersproject/random": "5.7.0", "@ethersproject/rlp": "5.7.0", "@ethersproject/sha2": "5.7.0", "@ethersproject/signing-key": "5.7.0", "@ethersproject/solidity": "5.7.0", "@ethersproject/strings": "5.7.0", "@ethersproject/transactions": "5.7.0", "@ethersproject/units": "5.7.0", "@ethersproject/wallet": "5.7.0", "@ethersproject/web": "5.7.1", "@ethersproject/wordlists": "5.7.0" } }, "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg=="],
@@ -3853,8 +3858,6 @@
     "@project-serum/sol-wallet-adapter/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
 
     "@project-serum/sol-wallet-adapter/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
-
-    "@react-native/codegen/yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
 
     "@react-native/dev-middleware/serve-static": ["serve-static@1.16.3", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "~0.19.1" } }, "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA=="],
 
@@ -4196,8 +4199,6 @@
 
     "cbw-sdk/preact": ["preact@10.29.3", "", {}, "sha512-D9NL1GAnJZhc3RndVs4gDdxEeU9TcHgywMrhhOsnpdlvFjdbx0gAsLUnH6JEhlJH5giL7Tx5biWPUSEXE/HPzw=="],
 
-    "cliui/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
-
     "cloudflare/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
 
     "connect/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
@@ -4260,8 +4261,6 @@
 
     "jest-util/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
-    "jest-validate/camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
-
     "jest-validate/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
@@ -4279,8 +4278,6 @@
     "metro/hermes-parser": ["hermes-parser@0.35.0", "", { "dependencies": { "hermes-estree": "0.35.0" } }, "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA=="],
 
     "metro/source-map": ["source-map@0.5.7", "", {}, "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="],
-
-    "metro/yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
 
     "metro-babel-transformer/hermes-parser": ["hermes-parser@0.35.0", "", { "dependencies": { "hermes-estree": "0.35.0" } }, "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA=="],
 
@@ -4314,13 +4311,9 @@
 
     "qrcode.react/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 
-    "react-native/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
-
     "react-native/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 
     "react-native/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
-
-    "react-native/yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
 
     "react-qr-reader/react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 
@@ -4344,11 +4337,9 @@
 
     "stream-browserify/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
-    "string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
-
-    "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
     "string_decoder/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
+    "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
     "tailwindcss/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
@@ -4378,21 +4369,15 @@
 
     "wif/bs58check": ["bs58check@4.0.0", "", { "dependencies": { "@noble/hashes": "^1.2.0", "bs58": "^6.0.0" } }, "sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g=="],
 
-    "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
-
-    "wrap-ansi/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+    "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
-    "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "xml-crypto/xpath": ["xpath@0.0.33", "", {}, "sha512-NNXnzrkDrAzalLhIUc01jO2mOzXGXh1JwPgkihcLLzw98c0WgYDmmjSh1Kl3wzaxSVWMuA+fe0WTWOBDWCBmNA=="],
 
     "xml-encryption/xpath": ["xpath@0.0.32", "", {}, "sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw=="],
 
     "xml2js/xmlbuilder": ["xmlbuilder@11.0.1", "", {}, "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="],
-
-    "yargs/yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
 
     "youch/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
@@ -4720,15 +4705,17 @@
 
     "@metamask/utils/@ethereumjs/tx/@ethereumjs/common": ["@ethereumjs/common@3.2.0", "", { "dependencies": { "@ethereumjs/util": "^8.1.0", "crc-32": "^1.2.0" } }, "sha512-pksvzI0VyLgmuEF2FA/JR/4/y6hcPq8OUail3/AvycBaW1d5VSauOZzqGvJ3RTmR4MU35lWE8KseKOsEhrFRBA=="],
 
+    "@opennextjs/cloudflare/yargs/cliui": ["cliui@9.0.1", "", { "dependencies": { "string-width": "^7.2.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w=="],
+
+    "@opennextjs/cloudflare/yargs/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "@opennextjs/cloudflare/yargs/yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
+
     "@particle-network/solana-wallet/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
 
     "@polymarket/builder-signing-sdk/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
     "@project-serum/sol-wallet-adapter/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
-
-    "@react-native/codegen/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
-
-    "@react-native/codegen/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "@react-native/dev-middleware/serve-static/send": ["send@0.19.2", "", { "dependencies": { "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "fresh": "~0.5.2", "http-errors": "~2.0.1", "mime": "1.6.0", "ms": "2.1.3", "on-finished": "~2.4.1", "range-parser": "~1.2.1", "statuses": "~2.0.2" } }, "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg=="],
 
@@ -5212,8 +5199,6 @@
 
     "bs58check/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
 
-    "cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
-
     "cloudflare/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
     "connect/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
@@ -5252,37 +5237,21 @@
 
     "metro/hermes-parser/hermes-estree": ["hermes-estree@0.35.0", "", {}, "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg=="],
 
-    "metro/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
-
-    "metro/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
     "porto/ox/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
 
     "qrcode/yargs/cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
-
-    "qrcode/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "qrcode/yargs/y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
 
     "qrcode/yargs/yargs-parser": ["yargs-parser@18.1.3", "", { "dependencies": { "camelcase": "^5.0.0", "decamelize": "^1.2.0" } }, "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ=="],
 
-    "react-native/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
-
-    "react-native/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
     "react-qr-reader/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
-
-    "string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "tailwindcss/chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "tailwindcss/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
     "unstorage/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
-
-    "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "@aws-sdk/client-cloudfront/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-ini/@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.55", "", { "dependencies": { "@aws-sdk/core": "^3.974.23", "@aws-sdk/nested-clients": "^3.997.23", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-hBBkANo3cDn+h2qxxzER4a+J8JCO9o9Z/YYmU7iky6AcaarX5RRdRcHNC6SLdwY0vAXQygn6soUbDqPn3GghaA=="],
 
@@ -5468,9 +5437,13 @@
 
     "@metamask/providers/@metamask/utils/@ethereumjs/tx/@ethereumjs/common": ["@ethereumjs/common@3.2.0", "", { "dependencies": { "@ethereumjs/util": "^8.1.0", "crc-32": "^1.2.0" } }, "sha512-pksvzI0VyLgmuEF2FA/JR/4/y6hcPq8OUail3/AvycBaW1d5VSauOZzqGvJ3RTmR4MU35lWE8KseKOsEhrFRBA=="],
 
-    "@react-native/codegen/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+    "@opennextjs/cloudflare/yargs/cliui/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
-    "@react-native/codegen/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "@opennextjs/cloudflare/yargs/cliui/wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+
+    "@opennextjs/cloudflare/yargs/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "@opennextjs/cloudflare/yargs/string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "@react-native/dev-middleware/serve-static/send/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
@@ -5513,8 +5486,6 @@
     "@reown/appkit-pay/@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils": ["@walletconnect/utils@2.21.0", "", { "dependencies": { "@noble/ciphers": "1.2.1", "@noble/curves": "1.8.1", "@noble/hashes": "1.7.1", "@walletconnect/jsonrpc-utils": "1.0.8", "@walletconnect/keyvaluestorage": "1.1.1", "@walletconnect/relay-api": "1.0.11", "@walletconnect/relay-auth": "1.1.0", "@walletconnect/safe-json": "1.0.2", "@walletconnect/time": "1.0.2", "@walletconnect/types": "2.21.0", "@walletconnect/window-getters": "1.0.1", "@walletconnect/window-metadata": "1.0.1", "bs58": "6.0.0", "detect-browser": "5.3.0", "query-string": "7.1.3", "uint8arrays": "3.1.0", "viem": "2.23.2" } }, "sha512-zfHLiUoBrQ8rP57HTPXW7rQMnYxYI4gT9yTACxVW6LhIFROTF6/ytm5SKNoIvi4a5nX5dfXG4D9XwQUCu8Ilig=="],
 
     "@reown/appkit-ui/qrcode/yargs/cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
-
-    "@reown/appkit-ui/qrcode/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "@reown/appkit-ui/qrcode/yargs/y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
 
@@ -6080,17 +6051,9 @@
 
     "eth-block-tracker/@metamask/utils/@ethereumjs/tx/@ethereumjs/common": ["@ethereumjs/common@3.2.0", "", { "dependencies": { "@ethereumjs/util": "^8.1.0", "crc-32": "^1.2.0" } }, "sha512-pksvzI0VyLgmuEF2FA/JR/4/y6hcPq8OUail3/AvycBaW1d5VSauOZzqGvJ3RTmR4MU35lWE8KseKOsEhrFRBA=="],
 
-    "metro/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
-
-    "metro/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
     "qrcode/yargs/cliui/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
-    "qrcode/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "react-native/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
-
-    "react-native/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "qrcode/yargs/yargs-parser/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
     "tailwindcss/chokidar/readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
@@ -6152,7 +6115,11 @@
 
     "@metamask/providers/@metamask/rpc-errors/@metamask/utils/@ethereumjs/tx/@ethereumjs/common": ["@ethereumjs/common@3.2.0", "", { "dependencies": { "@ethereumjs/util": "^8.1.0", "crc-32": "^1.2.0" } }, "sha512-pksvzI0VyLgmuEF2FA/JR/4/y6hcPq8OUail3/AvycBaW1d5VSauOZzqGvJ3RTmR4MU35lWE8KseKOsEhrFRBA=="],
 
-    "@react-native/codegen/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+    "@opennextjs/cloudflare/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "@opennextjs/cloudflare/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "@opennextjs/cloudflare/yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "@react-native/dev-middleware/serve-static/send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
@@ -6178,8 +6145,6 @@
 
     "@reown/appkit-pay/@reown/appkit-ui/qrcode/yargs/cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
 
-    "@reown/appkit-pay/@reown/appkit-ui/qrcode/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
     "@reown/appkit-pay/@reown/appkit-ui/qrcode/yargs/y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
 
     "@reown/appkit-pay/@reown/appkit-ui/qrcode/yargs/yargs-parser": ["yargs-parser@18.1.3", "", { "dependencies": { "camelcase": "^5.0.0", "decamelize": "^1.2.0" } }, "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ=="],
@@ -6196,7 +6161,7 @@
 
     "@reown/appkit-ui/qrcode/yargs/cliui/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
-    "@reown/appkit-ui/qrcode/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "@reown/appkit-ui/qrcode/yargs/yargs-parser/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
     "@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils/viem/@scure/bip32": ["@scure/bip32@1.6.2", "", { "dependencies": { "@noble/curves": "~1.8.1", "@noble/hashes": "~1.7.1", "@scure/base": "~1.2.2" } }, "sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw=="],
 
@@ -6326,11 +6291,7 @@
 
     "@walletconnect/utils/viem/ox/@scure/bip39/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 
-    "metro/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
     "qrcode/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
-    "react-native/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "@aws-sdk/client-cloudfront/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-ini/@aws-sdk/nested-clients/@aws-sdk/signature-v4-multi-region/@smithy/signature-v4": ["@smithy/signature-v4@5.5.2", "", { "dependencies": { "@smithy/core": "^3.26.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-7xHpmPY4rt0IOmeAA8EfjgEH8isT+587TCdy9H6a7d4OMi5CQ0oEHhWllunvPu4j4Cq0vTFwdxXN/kABWPjdyA=="],
 
@@ -6390,7 +6351,7 @@
 
     "@reown/appkit-pay/@reown/appkit-ui/qrcode/yargs/cliui/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
-    "@reown/appkit-pay/@reown/appkit-ui/qrcode/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "@reown/appkit-pay/@reown/appkit-ui/qrcode/yargs/yargs-parser/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
     "@reown/appkit-pay/@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils/viem/@scure/bip32": ["@scure/bip32@1.6.2", "", { "dependencies": { "@noble/curves": "~1.8.1", "@noble/hashes": "~1.7.1", "@scure/base": "~1.2.2" } }, "sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw=="],
 
@@ -6437,8 +6398,6 @@
     "@walletconnect/core/@walletconnect/utils/viem/ox/@scure/bip39/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 
     "@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode/yargs/cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
-
-    "@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode/yargs/y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
 
@@ -6506,7 +6465,7 @@
 
     "@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode/yargs/cliui/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
-    "@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode/yargs/yargs-parser/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
     "@walletconnect/ethereum-provider/@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils/viem/@scure/bip32/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 

--- a/deploy/DEPLOYMENT.md
+++ b/deploy/DEPLOYMENT.md
@@ -181,9 +181,11 @@ call the API over localhost via the SSH channel (SEC-022):
 
 ```bash
 ssh root@${NODE_IP} "PK=\$(grep '^STEWARD_PLATFORM_KEYS=' /etc/steward/env | cut -d= -f2- | cut -d, -f1); \
+  AUTH_FILE=\$(mktemp); chmod 600 \"\${AUTH_FILE}\"; trap 'rm -f \"\${AUTH_FILE}\"' EXIT; \
+  printf 'X-Steward-Platform-Key: %s\\n' \"\${PK}\" > \"\${AUTH_FILE}\"; \
   curl -sf -X POST http://localhost:3200/platform/tenants \
   -H 'Content-Type: application/json' \
-  -H \"X-Steward-Platform-Key: \${PK}\" \
+  -H \"@\${AUTH_FILE}\" \
   -d '{\"id\": \"milady-cloud\", \"name\": \"Milady Cloud\"}'"
 ```
 
@@ -193,7 +195,10 @@ For any other platform-key operation, use an SSH tunnel from your workstation
 ```bash
 ssh -L 3200:localhost:3200 root@${NODE_IP}
 # then, locally:
-curl -sf http://localhost:3200/platform/tenants -H "X-Steward-Platform-Key: $PLATFORM_KEY"
+AUTH_FILE=$(mktemp); chmod 600 "$AUTH_FILE"
+printf 'X-Steward-Platform-Key: %s\n' "$PLATFORM_KEY" > "$AUTH_FILE"
+curl -sf http://localhost:3200/platform/tenants -H "@$AUTH_FILE"
+rm -f "$AUTH_FILE"
 ```
 
 ---
@@ -315,49 +320,51 @@ internet — the platform key and tenant keys would cross the network in
 cleartext (SEC-022).
 
 ```bash
-PK="<platform-key>"
+read -rsp "Platform key: " PK; printf '\n'
 BASE="http://localhost:3200"
+PLATFORM_HEADERS=$(mktemp); TENANT_HEADERS=$(mktemp); TOKEN_HEADERS=$(mktemp)
+chmod 600 "$PLATFORM_HEADERS" "$TENANT_HEADERS" "$TOKEN_HEADERS"
+trap 'rm -f "$PLATFORM_HEADERS" "$TENANT_HEADERS" "$TOKEN_HEADERS"' EXIT
+printf 'X-Steward-Platform-Key: %s\n' "$PK" > "$PLATFORM_HEADERS"
 
 # Create test tenant
 RESP=$(curl -sf -X POST $BASE/platform/tenants \
   -H "Content-Type: application/json" \
-  -H "X-Steward-Platform-Key: $PK" \
+  -H "@$PLATFORM_HEADERS" \
   -d '{"id":"smoke-test","name":"Smoke Test"}')
 API_KEY=$(echo $RESP | jq -r '.data.apiKey')
+printf 'X-Steward-Tenant: smoke-test\nX-Steward-Key: %s\n' "$API_KEY" > "$TENANT_HEADERS"
 
 # Create agent
 curl -sf -X POST $BASE/agents \
   -H "Content-Type: application/json" \
-  -H "X-Steward-Tenant: smoke-test" \
-  -H "X-Steward-Key: $API_KEY" \
+  -H "@$TENANT_HEADERS" \
   -d '{"id":"test-1","name":"Test Agent"}'
 
 # Set policies
 curl -sf -X PUT $BASE/agents/test-1/policies \
   -H "Content-Type: application/json" \
-  -H "X-Steward-Tenant: smoke-test" \
-  -H "X-Steward-Key: $API_KEY" \
+  -H "@$TENANT_HEADERS" \
   -d '[{"type":"spending-limit","enabled":true,"config":{"maxPerTx":"1000000000000000000","maxPerDay":"5000000000000000000"}}]'
 
 # Get JWT
 TOKEN=$(curl -sf -X POST $BASE/agents/test-1/token \
-  -H "X-Steward-Tenant: smoke-test" \
-  -H "X-Steward-Key: $API_KEY" | jq -r '.data.token')
+  -H "@$TENANT_HEADERS" | jq -r '.data.token')
+printf 'Authorization: Bearer %s\n' "$TOKEN" > "$TOKEN_HEADERS"
 
 # Check balance
 curl -sf $BASE/agents/test-1/balance \
-  -H "Authorization: Bearer $TOKEN"
+  -H "@$TOKEN_HEADERS"
 
 # Sign (no broadcast)
 curl -sf -X POST $BASE/vault/test-1/sign \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $TOKEN" \
+  -H "@$TOKEN_HEADERS" \
   -d '{"to":"0x0000000000000000000000000000000000000001","value":"0","data":"0x","broadcast":false}'
 
 # Clean up
 curl -sf -X DELETE $BASE/agents/test-1 \
-  -H "X-Steward-Tenant: smoke-test" \
-  -H "X-Steward-Key: $API_KEY"
+  -H "@$TENANT_HEADERS"
 ```
 
 ---

--- a/deploy/DEPLOYMENT.md
+++ b/deploy/DEPLOYMENT.md
@@ -395,7 +395,9 @@ Common causes:
 - Check logs: `journalctl -u steward --since "5 minutes ago"`
 
 ### "Tenant not found" errors
-- Verify tenant exists: `curl -sf http://localhost:3200/platform/tenants -H 'X-Steward-Platform-Key: <key>'`
+- Verify the tenant through the owner-only platform header file created in the
+  smoke-test procedure above:
+  `curl -sf http://localhost:3200/platform/tenants -H "@$PLATFORM_HEADERS"`
 - Create missing tenant via platform API
 
 ### High memory usage
@@ -601,13 +603,16 @@ In **production** (`NODE_ENV=production`) the proxy treats Redis as **required**
 After deploying, configure webhooks for your tenants to receive real-time event notifications:
 
 ```bash
-PK="<your-platform-key>"
-API_KEY="<tenant-api-key>"
 BASE="http://localhost:3200"
+read -rsp "Tenant API key: " API_KEY; printf '\n'
+TENANT_HEADERS=$(mktemp); WEBHOOK_RESPONSE=$(mktemp)
+chmod 600 "$TENANT_HEADERS" "$WEBHOOK_RESPONSE"
+trap 'rm -f "$TENANT_HEADERS"' EXIT
+printf 'X-Steward-Key: %s\n' "$API_KEY" > "$TENANT_HEADERS"
 
 # Register a webhook endpoint
 curl -sf -X POST $BASE/webhooks \
-  -H "X-Steward-Key: $API_KEY" \
+  -H "@$TENANT_HEADERS" \
   -H "Content-Type: application/json" \
   -d '{
     "url": "https://your-app.com/webhooks/steward",
@@ -615,11 +620,14 @@ curl -sf -X POST $BASE/webhooks \
     "description": "Production webhook",
     "maxRetries": 5,
     "retryBackoffMs": 60000
-  }'
-# → Returns webhook config including "secret" (save this!)
+  }' > "$WEBHOOK_RESPONSE"
+echo "Webhook config and one-time secret saved to $WEBHOOK_RESPONSE (mode 0600)"
 ```
 
-**Save the `secret` field** — it's only returned on creation. Use it to verify `X-Steward-Signature` on incoming events.
+**Securely move or consume `WEBHOOK_RESPONSE`, then delete it.** The `secret`
+field is only returned on creation and is used to verify
+`X-Steward-Signature` on incoming events; do not print it into terminal or CI
+logs.
 
 ### Verify webhook delivery
 
@@ -627,7 +635,7 @@ curl -sf -X POST $BASE/webhooks \
 # List recent deliveries
 WEBHOOK_ID="wh_..."
 curl -sf "$BASE/webhooks/$WEBHOOK_ID/deliveries" \
-  -H "X-Steward-Key: $API_KEY"
+  -H "@$TENANT_HEADERS"
 ```
 
 ---

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -34,12 +34,16 @@ curl http://localhost:8080/health   # {"ok":true,"service":"steward-proxy",...}
 ### First-run: create a tenant
 
 ```bash
-# Replace with your STEWARD_PLATFORM_KEYS value
-PLATFORM_KEY="your_platform_key"
+# Read your STEWARD_PLATFORM_KEYS value without putting it in shell history or
+# curl argv. curl reads the header from an owner-only temporary file.
+read -rsp "Platform key: " PLATFORM_KEY; printf '\n'
+AUTH_FILE=$(mktemp); chmod 600 "$AUTH_FILE"
+trap 'rm -f "$AUTH_FILE"' EXIT
+printf 'X-Steward-Platform-Key: %s\n' "$PLATFORM_KEY" > "$AUTH_FILE"
 
 curl -s -X POST http://localhost:3200/platform/tenants \
   -H "Content-Type: application/json" \
-  -H "X-Steward-Platform-Key: $PLATFORM_KEY" \
+  -H "@$AUTH_FILE" \
   -d '{"id": "default", "name": "Default Tenant"}' | jq .
 
 # Save the returned apiKey — that is your tenant API key

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -130,7 +130,10 @@ services:
       - "--maxmemory"
       - "256mb"
       - "--maxmemory-policy"
-      - "allkeys-lru"
+      # Enforcement counters must never be silently evicted. When the bound is
+      # reached, noeviction makes writes fail and the production proxy's
+      # Redis-required path fails closed.
+      - "noeviction"
     volumes:
       - steward-redis-data:/data
     healthcheck:

--- a/deploy/migrate-agent-keys.sh
+++ b/deploy/migrate-agent-keys.sh
@@ -48,21 +48,29 @@ SSH_KEY="${SSH_KEY:-$HOME/.ssh/id_ed25519}"
 # Host-key checking: TOFU (accept-new) at minimum — never "no" (SEC-019).
 # Set STRICT_HOST_KEY=yes to require a pre-pinned known_hosts entry instead.
 if [[ "${STRICT_HOST_KEY:-}" == "yes" ]]; then
-  SSH_OPTS="-o StrictHostKeyChecking=yes -o ConnectTimeout=10 -i ${SSH_KEY}"
+  SSH_CMD=(ssh -o StrictHostKeyChecking=yes -o ConnectTimeout=10 -i "${SSH_KEY}" "root@${NODE_IP}")
 else
-  SSH_OPTS="-o StrictHostKeyChecking=accept-new -o ConnectTimeout=10 -i ${SSH_KEY}"
+  SSH_CMD=(ssh -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10 -i "${SSH_KEY}" "root@${NODE_IP}")
 fi
-SSH_CMD="ssh ${SSH_OPTS} root@${NODE_IP}"
 STEWARD_URL="${STEWARD_URL:-http://localhost:3200}"
 TENANT_ID="${TENANT_ID:-milady-cloud}"
 DEFAULT_DAILY_LIMIT="${DEFAULT_DAILY_LIMIT:-100}"
 REMOTE_DIR="${REMOTE_DIR:-/opt/steward}"
 
+# Values below are embedded into a remote shell program. Keep their accepted
+# syntax deliberately narrow so operator configuration or container metadata
+# cannot terminate a quoted argument and execute commands as remote root.
+[[ "${NODE_IP}" =~ ^[A-Za-z0-9._:\[\]-]+$ ]] || { echo "❌ Invalid node address"; exit 1; }
+[[ "${STEWARD_URL}" =~ ^https?://[A-Za-z0-9._:\[\]/-]+$ ]] || { echo "❌ Invalid Steward URL"; exit 1; }
+[[ "${TENANT_ID}" =~ ^[A-Za-z0-9._-]+$ ]] || { echo "❌ Invalid tenant ID"; exit 1; }
+[[ "${DEFAULT_DAILY_LIMIT}" =~ ^[0-9]+([.][0-9]{1,2})?$ ]] || { echo "❌ Invalid daily limit"; exit 1; }
+[[ "${REMOTE_DIR}" =~ ^/[A-Za-z0-9._/-]+$ ]] || { echo "❌ Invalid remote directory"; exit 1; }
+
 # ── Platform key handling (SEC-020) ──────────────────────────────────────────
 # The remote shell reads the key from the node's mode-0600 deploy/.env.
 PK_SNIPPET="PK=\$(sed -n 's/^STEWARD_PLATFORM_KEY=//p' ${REMOTE_DIR}/deploy/.env | head -n1)"
 # Fail-closed preflight: the key must be readable on the node.
-if ! ${SSH_CMD} "grep -q '^STEWARD_PLATFORM_KEY=.\+' ${REMOTE_DIR}/deploy/.env" 2>/dev/null; then
+if ! "${SSH_CMD[@]}" "grep -q '^STEWARD_PLATFORM_KEY=.\+' ${REMOTE_DIR}/deploy/.env" 2>/dev/null; then
   echo "❌ No STEWARD_PLATFORM_KEY found in ${REMOTE_DIR}/deploy/.env on ${NODE_IP}"
   echo "   Provision the node first (deploy/provision-steward-node.sh)."
   exit 1
@@ -84,7 +92,7 @@ echo ""
 
 # ── Check Steward health ────────────────────────────────────────────────────
 echo "▸ Checking Steward health..."
-if ! ${SSH_CMD} "curl -sf ${STEWARD_URL}/health" >/dev/null 2>&1; then
+if ! "${SSH_CMD[@]}" "curl -sf ${STEWARD_URL}/health" >/dev/null 2>&1; then
   echo "❌ Steward is not reachable at ${STEWARD_URL}"
   echo "   Make sure Steward is running: docker compose -f /opt/steward/deploy/docker-compose.yml up -d"
   exit 1
@@ -94,7 +102,7 @@ echo ""
 
 # ── Discover agent containers ───────────────────────────────────────────────
 echo "▸ Discovering agent containers..."
-CONTAINERS=$(${SSH_CMD} "docker ps --format '{{.Names}}' | grep '^milady-'" || true)
+CONTAINERS=$("${SSH_CMD[@]}" "docker ps --format '{{.Names}}' | grep '^milady-'" || true)
 
 if [[ -z "${CONTAINERS}" ]]; then
   echo "  ⚠  No milady agent containers found"
@@ -120,13 +128,17 @@ while IFS= read -r CONTAINER; do
   echo "  Container: ${CONTAINER}"
 
   # Read env vars from container
-  AGENT_ENV=$(${SSH_CMD} "docker inspect ${CONTAINER} --format '{{range .Config.Env}}{{println .}}{{end}}'" 2>/dev/null || true)
+  AGENT_ENV=$("${SSH_CMD[@]}" "docker inspect ${CONTAINER} --format '{{range .Config.Env}}{{println .}}{{end}}'" 2>/dev/null || true)
 
   # Extract relevant keys
   MILADY_API_TOKEN=$(echo "${AGENT_ENV}" | grep '^MILADY_API_TOKEN=' | cut -d= -f2- || true)
   EVM_PRIVATE_KEY=$(echo "${AGENT_ENV}" | grep '^EVM_PRIVATE_KEY=' | cut -d= -f2- || true)
   SOLANA_PRIVATE_KEY=$(echo "${AGENT_ENV}" | grep '^SOLANA_PRIVATE_KEY=' | cut -d= -f2- || true)
   AGENT_NAME=$(echo "${AGENT_ENV}" | grep '^AGENT_NAME=' | cut -d= -f2- || echo "agent-${AGENT_UUID:0:8}")
+  if [[ ! "${AGENT_NAME}" =~ ^[A-Za-z0-9._\ -]{1,128}$ ]]; then
+    echo "  ⚠  Unsafe AGENT_NAME metadata ignored"
+    AGENT_NAME="agent-${AGENT_UUID:0:8}"
+  fi
 
   echo "  Name: ${AGENT_NAME}"
   echo "  Has MILADY_API_TOKEN: $([[ -n "${MILADY_API_TOKEN}" ]] && echo 'yes' || echo 'no')"
@@ -143,7 +155,7 @@ while IFS= read -r CONTAINER; do
   echo "  Creating agent in Steward..."
   # The platform key is resolved on the REMOTE side (${PK_SNIPPET}) and never
   # placed on the remote curl argv (visible in the node's process list).
-  CREATE_RESP=$(${SSH_CMD} "${PK_SNIPPET}; ${AUTH_HEADER_SNIPPET}; curl -sf -X POST '${STEWARD_URL}/platform/tenants/${TENANT_ID}/agents' \
+  CREATE_RESP=$("${SSH_CMD[@]}" "${PK_SNIPPET}; ${AUTH_HEADER_SNIPPET}; curl -sf -X POST '${STEWARD_URL}/platform/tenants/${TENANT_ID}/agents' \
     -H 'Content-Type: application/json' \
     -H \"@\${AUTH_FILE}\" \
     -d '{
@@ -165,7 +177,7 @@ while IFS= read -r CONTAINER; do
 
   # ── Set default policies ─────────────────────────────────────────────────
   echo "  Setting default policies..."
-  POLICY_RESP=$(${SSH_CMD} "${PK_SNIPPET}; ${AUTH_HEADER_SNIPPET}; curl -sf -X PUT '${STEWARD_URL}/platform/tenants/${TENANT_ID}/policies' \
+  POLICY_RESP=$("${SSH_CMD[@]}" "${PK_SNIPPET}; ${AUTH_HEADER_SNIPPET}; curl -sf -X PUT '${STEWARD_URL}/platform/tenants/${TENANT_ID}/policies' \
     -H 'Content-Type: application/json' \
     -H \"@\${AUTH_FILE}\" \
     -d '{

--- a/deploy/migrate-agent-keys.sh
+++ b/deploy/migrate-agent-keys.sh
@@ -84,6 +84,12 @@ else
   fi
 fi
 
+# curl expands a literal `-H "...${PK}"` into its process argv, even when PK
+# was populated by the remote shell. Put the header in a mode-0600 temporary
+# file and pass only that filename to curl so the key is absent from both the
+# local ssh argv and the remote curl argv.
+AUTH_HEADER_SNIPPET="AUTH_FILE=\$(mktemp); chmod 600 \"\${AUTH_FILE}\"; trap 'rm -f \"\${AUTH_FILE}\"' EXIT; printf 'X-Steward-Platform-Key: %s\\n' \"\${PK}\" > \"\${AUTH_FILE}\""
+
 echo "══════════════════════════════════════════════════════════════"
 echo "  Steward Agent Key Migration"
 echo "  Node: ${NODE_IP}"
@@ -153,9 +159,9 @@ while IFS= read -r CONTAINER; do
   echo "  Creating agent in Steward..."
   # The platform key is resolved on the REMOTE side (${PK_SNIPPET}) and never
   # placed on the remote curl argv (visible in the node's process list).
-  CREATE_RESP=$(printf '%s' "${PLATFORM_KEY}" | ${SSH_CMD} "${PK_SNIPPET}; curl -sf -X POST '${STEWARD_URL}/platform/tenants/${TENANT_ID}/agents' \
+  CREATE_RESP=$(printf '%s' "${PLATFORM_KEY}" | ${SSH_CMD} "${PK_SNIPPET}; ${AUTH_HEADER_SNIPPET}; curl -sf -X POST '${STEWARD_URL}/platform/tenants/${TENANT_ID}/agents' \
     -H 'Content-Type: application/json' \
-    -H \"X-Steward-Platform-Key: \${PK}\" \
+    -H \"@\${AUTH_FILE}\" \
     -d '{
       \"id\": \"${AGENT_UUID}\",
       \"name\": \"${AGENT_NAME}\",
@@ -175,9 +181,9 @@ while IFS= read -r CONTAINER; do
 
   # ── Set default policies ─────────────────────────────────────────────────
   echo "  Setting default policies..."
-  POLICY_RESP=$(printf '%s' "${PLATFORM_KEY}" | ${SSH_CMD} "${PK_SNIPPET}; curl -sf -X PUT '${STEWARD_URL}/platform/tenants/${TENANT_ID}/policies' \
+  POLICY_RESP=$(printf '%s' "${PLATFORM_KEY}" | ${SSH_CMD} "${PK_SNIPPET}; ${AUTH_HEADER_SNIPPET}; curl -sf -X PUT '${STEWARD_URL}/platform/tenants/${TENANT_ID}/policies' \
     -H 'Content-Type: application/json' \
-    -H \"X-Steward-Platform-Key: \${PK}\" \
+    -H \"@\${AUTH_FILE}\" \
     -d '{
       \"agentId\": \"${AGENT_UUID}\",
       \"policies\": [

--- a/deploy/migrate-agent-keys.sh
+++ b/deploy/migrate-agent-keys.sh
@@ -7,12 +7,10 @@
 # spending policies.
 #
 # Usage:
-#   ./deploy/migrate-agent-keys.sh <node-ip> [--dry-run] [platform-key]
+#   ./deploy/migrate-agent-keys.sh <node-ip> [--dry-run]
 #
-# The platform key is read ON THE NODE from the mode-0600 deploy/.env (never
-# on any argv). Passing it as a positional arg is DEPRECATED: it leaks into
-# local ps/shell history. It is still accepted for compatibility and is then
-# piped to the remote over ssh stdin, never on a command line.
+# The platform key is read ON THE NODE from the mode-0600 deploy/.env and is
+# never accepted as an argument (argv is visible through ps and shell history).
 #
 # Requirements:
 #   - Steward must be running on the node (port 3200)
@@ -28,9 +26,8 @@
 set -euo pipefail
 
 # ── Args ─────────────────────────────────────────────────────────────────────
-NODE_IP="${1:?Usage: $0 <node-ip> [--dry-run] [platform-key]}"
+NODE_IP="${1:?Usage: $0 <node-ip> [--dry-run]}"
 shift
-PLATFORM_KEY=""
 DRY_RUN=false
 for arg in "$@"; do
   case "$arg" in
@@ -40,12 +37,8 @@ for arg in "$@"; do
       exit 1
       ;;
     *)
-      if [[ -z "${PLATFORM_KEY}" ]]; then
-        PLATFORM_KEY="$arg"
-      else
-        echo "❌ Unexpected argument: $arg"
-        exit 1
-      fi
+      echo "❌ Unexpected positional argument (platform keys are never accepted on argv)"
+      exit 1
       ;;
   esac
 done
@@ -66,22 +59,13 @@ DEFAULT_DAILY_LIMIT="${DEFAULT_DAILY_LIMIT:-100}"
 REMOTE_DIR="${REMOTE_DIR:-/opt/steward}"
 
 # ── Platform key handling (SEC-020) ──────────────────────────────────────────
-# The key must never appear on a local or remote command line. Default path:
-# the remote shell reads it from the node's mode-0600 deploy/.env. The
-# deprecated positional-arg path pipes it over ssh stdin instead.
-if [[ -n "${PLATFORM_KEY}" ]]; then
-  echo "⚠  DEPRECATED: passing the platform key as an argument exposes it in"
-  echo "   local ps/shell history. Omit it to read the key on the node from"
-  echo "   ${REMOTE_DIR}/deploy/.env instead."
-  PK_SNIPPET="PK=\$(cat)"
-else
-  PK_SNIPPET="PK=\$(sed -n 's/^STEWARD_PLATFORM_KEY=//p' ${REMOTE_DIR}/deploy/.env | head -n1)"
-  # Fail-closed preflight: the key must be readable on the node.
-  if ! ${SSH_CMD} "grep -q '^STEWARD_PLATFORM_KEY=.\+' ${REMOTE_DIR}/deploy/.env" 2>/dev/null; then
-    echo "❌ No STEWARD_PLATFORM_KEY found in ${REMOTE_DIR}/deploy/.env on ${NODE_IP}"
-    echo "   Provision the node first (deploy/provision-steward-node.sh)."
-    exit 1
-  fi
+# The remote shell reads the key from the node's mode-0600 deploy/.env.
+PK_SNIPPET="PK=\$(sed -n 's/^STEWARD_PLATFORM_KEY=//p' ${REMOTE_DIR}/deploy/.env | head -n1)"
+# Fail-closed preflight: the key must be readable on the node.
+if ! ${SSH_CMD} "grep -q '^STEWARD_PLATFORM_KEY=.\+' ${REMOTE_DIR}/deploy/.env" 2>/dev/null; then
+  echo "❌ No STEWARD_PLATFORM_KEY found in ${REMOTE_DIR}/deploy/.env on ${NODE_IP}"
+  echo "   Provision the node first (deploy/provision-steward-node.sh)."
+  exit 1
 fi
 
 # curl expands a literal `-H "...${PK}"` into its process argv, even when PK
@@ -159,7 +143,7 @@ while IFS= read -r CONTAINER; do
   echo "  Creating agent in Steward..."
   # The platform key is resolved on the REMOTE side (${PK_SNIPPET}) and never
   # placed on the remote curl argv (visible in the node's process list).
-  CREATE_RESP=$(printf '%s' "${PLATFORM_KEY}" | ${SSH_CMD} "${PK_SNIPPET}; ${AUTH_HEADER_SNIPPET}; curl -sf -X POST '${STEWARD_URL}/platform/tenants/${TENANT_ID}/agents' \
+  CREATE_RESP=$(${SSH_CMD} "${PK_SNIPPET}; ${AUTH_HEADER_SNIPPET}; curl -sf -X POST '${STEWARD_URL}/platform/tenants/${TENANT_ID}/agents' \
     -H 'Content-Type: application/json' \
     -H \"@\${AUTH_FILE}\" \
     -d '{
@@ -181,7 +165,7 @@ while IFS= read -r CONTAINER; do
 
   # ── Set default policies ─────────────────────────────────────────────────
   echo "  Setting default policies..."
-  POLICY_RESP=$(printf '%s' "${PLATFORM_KEY}" | ${SSH_CMD} "${PK_SNIPPET}; ${AUTH_HEADER_SNIPPET}; curl -sf -X PUT '${STEWARD_URL}/platform/tenants/${TENANT_ID}/policies' \
+  POLICY_RESP=$(${SSH_CMD} "${PK_SNIPPET}; ${AUTH_HEADER_SNIPPET}; curl -sf -X PUT '${STEWARD_URL}/platform/tenants/${TENANT_ID}/policies' \
     -H 'Content-Type: application/json' \
     -H \"@\${AUTH_FILE}\" \
     -d '{

--- a/deploy/provision-steward-node.sh
+++ b/deploy/provision-steward-node.sh
@@ -163,9 +163,11 @@ echo "▸ Step 7: Creating milady-cloud tenant..."
 # (PK=$(...)) so the secret is never placed on the local->remote command line
 # nor printed to this script's stdout / CI logs.
 TENANT_RESP=$(${SSH_CMD} "set -e; PK=\$(sed -n 's/^STEWARD_PLATFORM_KEY=//p' ${REMOTE_DIR}/deploy/.env | head -n1); \
+AUTH_FILE=\$(mktemp); chmod 600 \"\${AUTH_FILE}\"; trap 'rm -f \"\${AUTH_FILE}\"' EXIT; \
+printf 'X-Steward-Platform-Key: %s\\n' \"\${PK}\" > \"\${AUTH_FILE}\"; \
 curl -sf -X POST http://localhost:3200/platform/tenants \
   -H 'Content-Type: application/json' \
-  -H \"X-Steward-Platform-Key: \${PK}\" \
+  -H \"@\${AUTH_FILE}\" \
   -d '{\"id\": \"milady-cloud\", \"name\": \"Milady Cloud\"}'" 2>&1 || true)
 
 if echo "${TENANT_RESP}" | grep -q '"ok":true'; then

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -282,12 +282,14 @@ services:
     image: redis:7-alpine@sha256:e7723ff73d963f5cc6d9c4643ea3d989527a402a319239054e9472a7fb9219a2
     container_name: steward-redis
     restart: unless-stopped
+    # Spend/rate-limit keys are enforcement state: reject writes at the memory
+    # bound so callers fail closed instead of silently evicting them.
     command: >
       redis-server
       --appendonly yes
       --appendfsync everysec
       --maxmemory 256mb
-      --maxmemory-policy allkeys-lru
+      --maxmemory-policy noeviction
     volumes:
       - redis-data:/data
     healthcheck:

--- a/package.json
+++ b/package.json
@@ -37,8 +37,10 @@
   },
   "dependencies": {
     "@stwd/attestation": "workspace:*",
+    "@stwd/db": "workspace:*",
     "@stwd/venue-hyperliquid": "workspace:*",
     "@stwd/venue-polymarket": "workspace:*",
+    "drizzle-orm": "^0.44.5",
     "ioredis": "^5.10.1",
     "jose": "^6.2.1",
     "siwe": "^3.0.0",

--- a/packages/proxy/src/__tests__/deploy-artifacts.test.ts
+++ b/packages/proxy/src/__tests__/deploy-artifacts.test.ts
@@ -270,6 +270,7 @@ describe("SEC-022 DEPLOYMENT.md installs shipped hardened units, no root units o
 
 describe("SEC-021 deploy/docker-compose.yml redis persists enforcement counters", () => {
   const compose = read("docker-compose.yml");
+  const rootCompose = readFileSync(join(DEPLOY_DIR, "..", "docker-compose.yml"), "utf8");
 
   test("redis runs with AOF persistence and a bounded memory policy", () => {
     // Redis holds spend-limit / rate-limit counters. Pre-fix it ran
@@ -291,6 +292,11 @@ describe("SEC-021 deploy/docker-compose.yml redis persists enforcement counters"
     expect(/steward-redis-data:\s*\/data/.test(compose)).toBe(true);
     expect(/^\s{2}steward-redis-data:\s*$/m.test(compose)).toBe(true);
   });
+
+  test("root development compose also never evicts enforcement state", () => {
+    expect(rootCompose).toContain("--maxmemory-policy noeviction");
+    expect(rootCompose).not.toContain("--maxmemory-policy allkeys-lru");
+  });
 });
 
 describe("SEC-020 deploy/migrate-agent-keys.sh keeps the platform key off every argv", () => {
@@ -304,9 +310,23 @@ describe("SEC-020 deploy/migrate-agent-keys.sh keeps the platform key off every 
     // The remote shell resolves the key itself (sed on the node's 0600 .env,
     // or cat from ssh stdin for the deprecated arg path).
     expect(script).toContain("sed -n 's/^STEWARD_PLATFORM_KEY=//p'");
+    expect(script).not.toContain("[platform-key]");
+    expect(script).not.toContain("printf '%s' \"${PLATFORM_KEY}\"");
     expect(script).not.toContain("X-Steward-Platform-Key: \\${PK}");
     expect(script).toContain("AUTH_HEADER_SNIPPET");
     expect(script).toContain('-H \\"@\\${AUTH_FILE}\\"');
+  });
+
+  test("legacy positional key input is rejected without echoing the credential", () => {
+    const marker = "secret-platform-key-must-not-echo";
+    const result = Bun.spawnSync(
+      ["bash", join(DEPLOY_DIR, "migrate-agent-keys.sh"), "127.0.0.1", marker],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+    const output = `${result.stdout.toString()}${result.stderr.toString()}`;
+    expect(result.exitCode).not.toBe(0);
+    expect(output).not.toContain(marker);
+    expect(output).toContain("platform keys are never accepted on argv");
   });
 
   test("provisioning and operator docs also pass platform headers by file", () => {
@@ -318,6 +338,9 @@ describe("SEC-020 deploy/migrate-agent-keys.sh keeps the platform key off every 
     expect(doc).not.toContain("X-Steward-Platform-Key: \\${PK}");
     expect(doc).toContain('-H \\"@\\${AUTH_FILE}\\"');
     expect(doc).not.toContain('-H "X-Steward-Platform-Key: $PK"');
+    expect(doc).not.toContain("X-Steward-Platform-Key: <key>");
+    expect(doc).not.toContain('-H "X-Steward-Key: $API_KEY"');
+    expect(doc).toContain('> "$WEBHOOK_RESPONSE"');
     expect(readme).not.toContain('-H "X-Steward-Platform-Key: $PLATFORM_KEY"');
   });
 

--- a/packages/proxy/src/__tests__/deploy-artifacts.test.ts
+++ b/packages/proxy/src/__tests__/deploy-artifacts.test.ts
@@ -283,6 +283,8 @@ describe("SEC-021 deploy/docker-compose.yml redis persists enforcement counters"
     expect(compose).toContain('"everysec"');
     expect(compose).toContain('"--maxmemory"');
     expect(compose).toContain('"--maxmemory-policy"');
+    expect(compose).toContain('"noeviction"');
+    expect(compose).not.toContain('"allkeys-lru"');
   });
 
   test("redis AOF data dir is on a named volume", () => {
@@ -302,7 +304,21 @@ describe("SEC-020 deploy/migrate-agent-keys.sh keeps the platform key off every 
     // The remote shell resolves the key itself (sed on the node's 0600 .env,
     // or cat from ssh stdin for the deprecated arg path).
     expect(script).toContain("sed -n 's/^STEWARD_PLATFORM_KEY=//p'");
-    expect(script).toContain("X-Steward-Platform-Key: \\${PK}");
+    expect(script).not.toContain("X-Steward-Platform-Key: \\${PK}");
+    expect(script).toContain("AUTH_HEADER_SNIPPET");
+    expect(script).toContain('-H \\"@\\${AUTH_FILE}\\"');
+  });
+
+  test("provisioning and operator docs also pass platform headers by file", () => {
+    const provision = read("provision-steward-node.sh");
+    const doc = read("DEPLOYMENT.md");
+    const readme = read("README.md");
+    expect(provision).not.toContain("X-Steward-Platform-Key: \\${PK}");
+    expect(provision).toContain('-H \\"@\\${AUTH_FILE}\\"');
+    expect(doc).not.toContain("X-Steward-Platform-Key: \\${PK}");
+    expect(doc).toContain('-H \\"@\\${AUTH_FILE}\\"');
+    expect(doc).not.toContain('-H "X-Steward-Platform-Key: $PK"');
+    expect(readme).not.toContain('-H "X-Steward-Platform-Key: $PLATFORM_KEY"');
   });
 
   test("agent tokens are written to a mode-0600 file, not echoed to stdout", () => {

--- a/packages/proxy/src/__tests__/deploy-artifacts.test.ts
+++ b/packages/proxy/src/__tests__/deploy-artifacts.test.ts
@@ -329,6 +329,15 @@ describe("SEC-020 deploy/migrate-agent-keys.sh keeps the platform key off every 
     expect(output).toContain("platform keys are never accepted on argv");
   });
 
+  test("remote commands use an argv-safe ssh array and reject injectable metadata", () => {
+    expect(script).toContain("SSH_CMD=(ssh -o StrictHostKeyChecking=");
+    expect(script).toContain('"${SSH_CMD[@]}"');
+    expect(script).not.toMatch(/\$\{SSH_CMD\}\s+"/);
+    expect(script).toContain("Unsafe AGENT_NAME metadata ignored");
+    expect(script).toContain("Invalid tenant ID");
+    expect(script).toContain("Invalid daily limit");
+  });
+
   test("provisioning and operator docs also pass platform headers by file", () => {
     const provision = read("provision-steward-node.sh");
     const doc = read("DEPLOYMENT.md");

--- a/scripts/__tests__/migrate-sh.test.ts
+++ b/scripts/__tests__/migrate-sh.test.ts
@@ -75,6 +75,15 @@ describe.serial("SEC-050 scripts/migrate.sh keeps the DB password out of psql ar
     expect(env).toBe("PGPASSWORD=query@secret");
   });
 
+  test("preserves non-password libpq query encoding byte-for-byte", () => {
+    const { argv, env } = runMigrate(
+      "postgresql://steward@db.example/steward?options=-c%20statement_timeout%3D5s&password=a+b",
+    );
+    expect(argv).toContain("options=-c%20statement_timeout%3D5s");
+    expect(argv).not.toContain("password=");
+    expect(env).toBe("PGPASSWORD=a+b");
+  });
+
   test("query password takes precedence and neither credential reaches argv", () => {
     const { argv, env } = runMigrate(
       "postgresql://steward:userinfo-secret@db.example/steward?password=query-secret",
@@ -82,5 +91,13 @@ describe.serial("SEC-050 scripts/migrate.sh keeps the DB password out of psql ar
     expect(argv).not.toContain("userinfo-secret");
     expect(argv).not.toContain("query-secret");
     expect(env).toBe("PGPASSWORD=query-secret");
+  });
+
+  test("rejects ambiguous duplicate query password parameters", () => {
+    expect(() =>
+      runMigrate(
+        "postgresql://steward@db.example/steward?password=first-secret&password=second-secret",
+      ),
+    ).toThrow();
   });
 });

--- a/scripts/__tests__/migrate-sh.test.ts
+++ b/scripts/__tests__/migrate-sh.test.ts
@@ -84,6 +84,24 @@ describe.serial("SEC-050 scripts/migrate.sh keeps the DB password out of psql ar
     expect(env).toBe("PGPASSWORD=a+b");
   });
 
+  test("preserves valid libpq multi-host authorities", () => {
+    const { argv, env } = runMigrate(
+      "postgresql://steward:multi%40secret@db-a.example:5432,db-b.example:5433/steward?target_session_attrs=read-write",
+    );
+    expect(argv).toContain(
+      "postgresql://steward@db-a.example:5432,db-b.example:5433/steward?target_session_attrs=read-write",
+    );
+    expect(env).toBe("PGPASSWORD=multi@secret");
+  });
+
+  test("preserves valid libpq percent-encoded Unix-socket hosts", () => {
+    const { argv, env } = runMigrate(
+      "postgresql://steward:socket-secret@%2Fvar%2Frun%2Fpostgresql/steward",
+    );
+    expect(argv).toContain("postgresql://steward@%2Fvar%2Frun%2Fpostgresql/steward");
+    expect(env).toBe("PGPASSWORD=socket-secret");
+  });
+
   test("query password takes precedence and neither credential reaches argv", () => {
     const { argv, env } = runMigrate(
       "postgresql://steward:userinfo-secret@db.example/steward?password=query-secret",

--- a/scripts/__tests__/migrate-sh.test.ts
+++ b/scripts/__tests__/migrate-sh.test.ts
@@ -6,7 +6,7 @@
  * that records its argv and environment; asserts the password travels via
  * PGPASSWORD and the connection string on argv carries no credentials.
  */
-import { describe, expect, test } from "bun:test";
+import { describe, expect, setDefaultTimeout, test } from "bun:test";
 import { execFileSync } from "node:child_process";
 import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -14,6 +14,11 @@ import { join } from "node:path";
 
 const REPO_ROOT = join(import.meta.dir, "..", "..");
 const CAPTURE = "capture.txt";
+
+// The real migration script invokes the psql shim once per migration file.
+// Loaded CI runners can exceed Bun's 5s default even though each shim exits
+// immediately, so keep this behavioral suite deterministic.
+setDefaultTimeout(15_000);
 
 function runMigrate(databaseUrl: string): { argv: string; env: string } {
   const dir = mkdtempSync(join(tmpdir(), "migrate-sh-test-"));
@@ -40,7 +45,7 @@ function runMigrate(databaseUrl: string): { argv: string; env: string } {
   }
 }
 
-describe("SEC-050 scripts/migrate.sh keeps the DB password out of psql argv", () => {
+describe.serial("SEC-050 scripts/migrate.sh keeps the DB password out of psql argv", () => {
   test("password in DATABASE_URL is passed via PGPASSWORD, never argv", () => {
     const { argv, env } = runMigrate("postgresql://steward:s3cret-pw@db.example:5432/steward");
     expect(argv).not.toContain("s3cret-pw");
@@ -58,5 +63,24 @@ describe("SEC-050 scripts/migrate.sh keeps the DB password out of psql argv", ()
     const { argv, env } = runMigrate("postgresql://steward@db.example:5432/steward");
     expect(argv).toContain("postgresql://steward@db.example:5432/steward");
     expect(env).toBe("PGPASSWORD=");
+  });
+
+  test("libpq query-string password is removed from argv", () => {
+    const { argv, env } = runMigrate(
+      "postgresql://steward@db.example:5432/steward?sslmode=require&password=query%40secret",
+    );
+    expect(argv).not.toContain("query%40secret");
+    expect(argv).not.toContain("password=");
+    expect(argv).toContain("sslmode=require");
+    expect(env).toBe("PGPASSWORD=query@secret");
+  });
+
+  test("query password takes precedence and neither credential reaches argv", () => {
+    const { argv, env } = runMigrate(
+      "postgresql://steward:userinfo-secret@db.example/steward?password=query-secret",
+    );
+    expect(argv).not.toContain("userinfo-secret");
+    expect(argv).not.toContain("query-secret");
+    expect(env).toBe("PGPASSWORD=query-secret");
   });
 });

--- a/scripts/__tests__/migrate-sh.test.ts
+++ b/scripts/__tests__/migrate-sh.test.ts
@@ -59,6 +59,15 @@ describe.serial("SEC-050 scripts/migrate.sh keeps the DB password out of psql ar
     expect(env).toBe("PGPASSWORD=p@ss/w0rd");
   });
 
+  test("raw question mark in libpq userinfo never reaches argv", () => {
+    const { argv, env } = runMigrate(
+      "postgresql://steward:sec?ret@db.example/steward?sslmode=require",
+    );
+    expect(argv).toContain("postgresql://steward@db.example/steward?sslmode=require");
+    expect(argv).not.toContain("sec?ret");
+    expect(env).toBe("PGPASSWORD=sec?ret");
+  });
+
   test("passwordless URL still works with an empty PGPASSWORD", () => {
     const { argv, env } = runMigrate("postgresql://steward@db.example:5432/steward");
     expect(argv).toContain("postgresql://steward@db.example:5432/steward");
@@ -82,6 +91,15 @@ describe.serial("SEC-050 scripts/migrate.sh keeps the DB password out of psql ar
     expect(argv).toContain("options=-c%20statement_timeout%3D5s");
     expect(argv).not.toContain("password=");
     expect(env).toBe("PGPASSWORD=a+b");
+  });
+
+  test("preserves an at sign in a non-password query value", () => {
+    const { argv, env } = runMigrate(
+      "postgresql://db.example/steward?application_name=ops@steward&password=query-secret",
+    );
+    expect(argv).toContain("application_name=ops@steward");
+    expect(argv).not.toContain("query-secret");
+    expect(env).toBe("PGPASSWORD=query-secret");
   });
 
   test("preserves valid libpq multi-host authorities", () => {

--- a/scripts/__tests__/migrate-sh.test.ts
+++ b/scripts/__tests__/migrate-sh.test.ts
@@ -111,11 +111,24 @@ describe.serial("SEC-050 scripts/migrate.sh keeps the DB password out of psql ar
     expect(env).toBe("PGPASSWORD=query-secret");
   });
 
-  test("rejects ambiguous duplicate query password parameters", () => {
-    expect(() =>
-      runMigrate(
-        "postgresql://steward@db.example/steward?password=first-secret&password=second-secret",
-      ),
-    ).toThrow();
+  test("uses the last non-empty duplicate query password like libpq", () => {
+    const { argv, env } = runMigrate(
+      "postgresql://steward:userinfo-secret@db.example/steward?password=first-secret&password=&password=last-secret&password=",
+    );
+    expect(argv).not.toContain("userinfo-secret");
+    expect(argv).not.toContain("first-secret");
+    expect(argv).not.toContain("last-secret");
+    expect(argv).not.toContain("password=");
+    expect(env).toBe("PGPASSWORD=last-secret");
+  });
+
+  test("empty query passwords retain a non-empty userinfo password", () => {
+    const { argv, env } = runMigrate(
+      "postgresql://steward:userinfo-secret@db.example/steward?password=&sslmode=require&password=",
+    );
+    expect(argv).not.toContain("userinfo-secret");
+    expect(argv).not.toContain("password=");
+    expect(argv).toContain("sslmode=require");
+    expect(env).toBe("PGPASSWORD=userinfo-secret");
   });
 });

--- a/scripts/__tests__/provision-agent.test.ts
+++ b/scripts/__tests__/provision-agent.test.ts
@@ -13,6 +13,8 @@
  * workspace imports) so it is testable without a database.
  */
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { validateApiKey } from "../../packages/auth/src/api-keys";
 import {
   type DefaultTenantStore,
@@ -24,20 +26,23 @@ import {
 interface FakeStore extends DefaultTenantStore {
   inserted: Array<{ id: string; apiKeyHash: string }>;
   rotations: Array<{ tenantId: string; apiKeyHash: string }>;
+  rotationWins: boolean;
 }
 
-function fakeStore(existingHash: string | null): FakeStore {
+function fakeStore(existingHash: string | null, rotationWins = true): FakeStore {
   const store: FakeStore = {
     inserted: [],
     rotations: [],
+    rotationWins,
     async getApiKeyHash() {
       return existingHash;
     },
     async insertTenant(values) {
       store.inserted.push(values);
     },
-    async rotateApiKeyHash(tenantId, apiKeyHash) {
+    async rotateApiKeyHash(tenantId, _expectedApiKeyHash, apiKeyHash) {
       store.rotations.push({ tenantId, apiKeyHash });
+      return store.rotationWins;
     },
   };
   return store;
@@ -46,6 +51,14 @@ function fakeStore(existingHash: string | null): FakeStore {
 const ARGS = { tenantId: "default", tenantName: "Default Steward Tenant", ownerAddress: "0xabc" };
 
 describe("SEC-012 ensureDefaultTenant", () => {
+  test("root manifest declares provision-agent direct imports", () => {
+    const rootPackage = JSON.parse(
+      readFileSync(join(import.meta.dir, "..", "..", "package.json"), "utf8"),
+    ) as { dependencies?: Record<string, string> };
+    expect(rootPackage.dependencies?.["@stwd/db"]).toBe("workspace:*");
+    expect(rootPackage.dependencies?.["drizzle-orm"]).toBeDefined();
+  });
+
   test("creates a missing tenant with a random (non-derivable) key", async () => {
     const store = fakeStore(null);
     const result = await ensureDefaultTenant(store, ARGS);
@@ -82,6 +95,14 @@ describe("SEC-012 ensureDefaultTenant", () => {
     expect(result.status).toBe("existing");
     expect(store.inserted).toHaveLength(0);
     expect(store.rotations).toHaveLength(0);
+  });
+
+  test("does not overwrite or print a key when a concurrent rotation wins", async () => {
+    const store = fakeStore(LEGACY_DEFAULT_TENANT_API_KEY_HASH, false);
+    const result = await ensureDefaultTenant(store, ARGS);
+
+    expect(result).toEqual({ status: "existing" });
+    expect("apiKey" in result).toBe(false);
   });
 
   test("legacy hash constant matches the pre-fix derivation", () => {

--- a/scripts/__tests__/provision-agent.test.ts
+++ b/scripts/__tests__/provision-agent.test.ts
@@ -13,8 +13,9 @@
  * workspace imports) so it is testable without a database.
  */
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
 import { validateApiKey } from "../../packages/auth/src/api-keys";
 import {
   type DefaultTenantStore,
@@ -22,6 +23,7 @@ import {
   LEGACY_DEFAULT_TENANT_API_KEY,
   LEGACY_DEFAULT_TENANT_API_KEY_HASH,
 } from "../lib/default-tenant";
+import { writeProvisionSecrets } from "../lib/provision-secrets";
 
 interface FakeStore extends DefaultTenantStore {
   inserted: Array<{ id: string; apiKeyHash: string }>;
@@ -84,7 +86,7 @@ describe("SEC-012 ensureDefaultTenant", () => {
     expect(newHash).not.toBe(LEGACY_DEFAULT_TENANT_API_KEY_HASH);
     // The pre-fix published credential must no longer validate.
     expect(validateApiKey(LEGACY_DEFAULT_TENANT_API_KEY, newHash)).toBe(false);
-    // The freshly printed key does.
+    // The freshly returned key does.
     expect(validateApiKey((result as { apiKey: string }).apiKey, newHash)).toBe(true);
   });
 
@@ -112,5 +114,43 @@ describe("SEC-012 ensureDefaultTenant", () => {
     expect(LEGACY_DEFAULT_TENANT_API_KEY_HASH).toBe(
       "93a3e57073bf915e403c48b44518efca07086ec8ada1b4b73e4a5278677d57cc",
     );
+  });
+});
+
+describe("provisioning secret output", () => {
+  test("writes credentials to a mode-0600 file and safely updates it", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "steward-provision-test-"));
+    try {
+      const first = writeProvisionSecrets({ tenantApiKey: "tenant-secret" }, undefined, tempRoot);
+      writeProvisionSecrets(
+        {
+          tenantApiKey: "tenant-secret",
+          agentId: "agent-1",
+          tradeSessionId: "session-secret",
+          jwt: "jwt-secret",
+        },
+        first,
+      );
+      expect(statSync(dirname(first)).mode & 0o777).toBe(0o700);
+      expect(statSync(first).mode & 0o777).toBe(0o600);
+      const contents = readFileSync(first, "utf8");
+      expect(contents).toContain("STEWARD_TENANT_API_KEY=tenant-secret");
+      expect(contents).toContain("STEWARD_TRADE_SESSION_ID=session-secret");
+      expect(contents).toContain("STEWARD_JWT=jwt-secret");
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects newline injection into the env output", () => {
+    expect(() => writeProvisionSecrets({ jwt: "safe\nINJECTED=value" })).toThrow(
+      "unsupported control character",
+    );
+  });
+
+  test("CLI source never prints credential values to stdout", () => {
+    const source = readFileSync(join(import.meta.dir, "..", "provision-agent.ts"), "utf8");
+    expect(source).not.toMatch(/console\.log\([^\n]*(apiKey|\$\{jwt\}|\$\{session\.id\})/);
+    expect(source).toContain("writeProvisionSecrets(provisionSecrets, credentialsPath)");
   });
 });

--- a/scripts/lib/default-tenant.ts
+++ b/scripts/lib/default-tenant.ts
@@ -34,7 +34,11 @@ export interface DefaultTenantStore {
     apiKeyHash: string;
     ownerAddress: string;
   }): Promise<void>;
-  rotateApiKeyHash(tenantId: string, apiKeyHash: string): Promise<void>;
+  rotateApiKeyHash(
+    tenantId: string,
+    expectedApiKeyHash: string,
+    apiKeyHash: string,
+  ): Promise<boolean>;
 }
 
 export type EnsureDefaultTenantResult =
@@ -63,7 +67,11 @@ export async function ensureDefaultTenant(
   // already-provisioned instances are fixed instead of staying vulnerable.
   if (existingHash === LEGACY_DEFAULT_TENANT_API_KEY_HASH) {
     const { key, hash } = generateApiKey();
-    await store.rotateApiKeyHash(args.tenantId, hash);
+    const rotated = await store.rotateApiKeyHash(args.tenantId, existingHash, hash);
+    // Another provisioner or operator may have rotated the key after our
+    // read. Never overwrite that newer operator-managed credential or print a
+    // key that was not actually stored.
+    if (!rotated) return { status: "existing" };
     return { status: "rotated", apiKey: key };
   }
 

--- a/scripts/lib/parse-psql-url.ts
+++ b/scripts/lib/parse-psql-url.ts
@@ -60,25 +60,25 @@ if (at !== -1) {
 // may interpret that as a literal plus.
 const rawQuery = rawQueryStart === -1 ? "" : raw.slice(rawQueryStart + 1);
 const retainedQueryParts: string[] = [];
-const queryPasswords: string[] = [];
+let lastNonEmptyQueryPassword: string | undefined;
 if (rawQueryStart !== -1) {
   for (const part of rawQuery.split("&")) {
     const separator = part.indexOf("=");
     const rawKey = separator === -1 ? part : part.slice(0, separator);
     const rawValue = separator === -1 ? "" : part.slice(separator + 1);
     if (decodeURIComponent(rawKey) === "password") {
-      queryPasswords.push(decodeURIComponent(rawValue));
+      const queryPassword = decodeURIComponent(rawValue);
+      // libpq processes parameters from left to right and lets the last
+      // non-empty value win. Empty query values therefore do not erase an
+      // earlier userinfo password, while duplicate non-empty values retain
+      // their documented libpq meaning.
+      if (queryPassword.length > 0) lastNonEmptyQueryPassword = queryPassword;
     } else {
       retainedQueryParts.push(part);
     }
   }
 }
-if (queryPasswords.length > 1) {
-  throw new Error("DATABASE_URL must not contain multiple password parameters");
-}
-if (queryPasswords.length === 1) {
-  password = queryPasswords[0] ?? "";
-}
+if (lastNonEmptyQueryPassword !== undefined) password = lastNonEmptyQueryPassword;
 
 if (/[\0\r\n]/.test(password)) {
   throw new Error("DATABASE_URL password contains an unsupported control character");

--- a/scripts/lib/parse-psql-url.ts
+++ b/scripts/lib/parse-psql-url.ts
@@ -15,22 +15,49 @@ if (!raw || !passwordFile) {
   throw new Error("DATABASE_URL and STEWARD_PSQL_PASSWORD_FILE are required");
 }
 
-const url = new URL(raw);
-if (url.protocol !== "postgres:" && url.protocol !== "postgresql:") {
+const schemeMatch = /^(postgres(?:ql)?):\/\//.exec(raw);
+if (!schemeMatch) {
   throw new Error("DATABASE_URL must use postgres:// or postgresql://");
 }
 
-if (url.hash) throw new Error("DATABASE_URL must not contain a fragment");
+if (/[\0\r\n]/.test(raw)) {
+  throw new Error("DATABASE_URL contains an unsupported control character");
+}
+if (raw.includes("#")) throw new Error("DATABASE_URL must not contain a fragment");
 
-let password = decodeURIComponent(url.password);
-url.password = "";
+const schemeEnd = schemeMatch[0].length;
+const rawQueryStart = raw.indexOf("?", schemeEnd);
+const hierarchyEnd = rawQueryStart === -1 ? raw.length : rawQueryStart;
+const hierarchy = raw.slice(0, hierarchyEnd);
+const authorityEndCandidate = hierarchy.indexOf("/", schemeEnd);
+const authorityEnd = authorityEndCandidate === -1 ? hierarchy.length : authorityEndCandidate;
+const authority = hierarchy.slice(schemeEnd, authorityEnd);
+
+// Do not feed the URI through WHATWG URL. Valid libpq URIs include multi-host
+// authorities and percent-encoded Unix-socket hosts, both of which WHATWG URL
+// rejects or normalizes. Instead, remove only the userinfo password and retain
+// every other byte for libpq itself to parse.
+const at = authority.indexOf("@");
+if (at !== authority.lastIndexOf("@")) {
+  throw new Error("DATABASE_URL contains ambiguous user information");
+}
+
+let password = "";
+let redactedAuthority = authority;
+if (at !== -1) {
+  const userInfo = authority.slice(0, at);
+  const passwordSeparator = userInfo.indexOf(":");
+  if (passwordSeparator !== -1) {
+    password = decodeURIComponent(userInfo.slice(passwordSeparator + 1));
+    redactedAuthority = `${userInfo.slice(0, passwordSeparator)}@${authority.slice(at + 1)}`;
+  }
+}
 
 // libpq accepts connection keywords in the URI query string. A query password
 // takes precedence over userinfo because it is parsed later by libpq. Preserve
 // every other query token byte-for-byte: WHATWG URLSearchParams would serialize
 // `%20` as `+`, but libpq URI parsing does not use HTML form-url-encoding and
 // may interpret that as a literal plus.
-const rawQueryStart = raw.indexOf("?");
 const rawQuery = rawQueryStart === -1 ? "" : raw.slice(rawQueryStart + 1);
 const retainedQueryParts: string[] = [];
 const queryPasswords: string[] = [];
@@ -58,7 +85,6 @@ if (/[\0\r\n]/.test(password)) {
 }
 
 writeFileSync(passwordFile, password, { mode: 0o600 });
-url.search = "";
-url.hash = "";
 const retainedQuery = retainedQueryParts.join("&");
-process.stdout.write(`${url.toString()}${retainedQuery ? `?${retainedQuery}` : ""}`);
+const redactedHierarchy = `${raw.slice(0, schemeEnd)}${redactedAuthority}${hierarchy.slice(authorityEnd)}`;
+process.stdout.write(`${redactedHierarchy}${retainedQuery ? `?${retainedQuery}` : ""}`);

--- a/scripts/lib/parse-psql-url.ts
+++ b/scripts/lib/parse-psql-url.ts
@@ -1,0 +1,38 @@
+/**
+ * Split a PostgreSQL URI into a credential-free URI and a password file.
+ *
+ * The URI arrives through DATABASE_URL (never argv). The password file path is
+ * a caller-created mode-0600 temporary file. Supporting both userinfo and the
+ * libpq `?password=` connection parameter keeps every valid password-bearing
+ * URI out of psql's process argv.
+ */
+import { writeFileSync } from "node:fs";
+
+const raw = process.env.DATABASE_URL;
+// biome-ignore lint/suspicious/noUndeclaredEnvVars: ephemeral file path for this standalone CLI helper, never a Turbo cache input
+const passwordFile = process.env.STEWARD_PSQL_PASSWORD_FILE;
+if (!raw || !passwordFile) {
+  throw new Error("DATABASE_URL and STEWARD_PSQL_PASSWORD_FILE are required");
+}
+
+const url = new URL(raw);
+if (url.protocol !== "postgres:" && url.protocol !== "postgresql:") {
+  throw new Error("DATABASE_URL must use postgres:// or postgresql://");
+}
+
+let password = decodeURIComponent(url.password);
+url.password = "";
+
+// libpq accepts connection keywords in the URI query string. A query password
+// takes precedence over userinfo because it is parsed later by libpq.
+if (url.searchParams.has("password")) {
+  password = url.searchParams.get("password") ?? "";
+  url.searchParams.delete("password");
+}
+
+if (/[\0\r\n]/.test(password)) {
+  throw new Error("DATABASE_URL password contains an unsupported control character");
+}
+
+writeFileSync(passwordFile, password, { mode: 0o600 });
+process.stdout.write(url.toString());

--- a/scripts/lib/parse-psql-url.ts
+++ b/scripts/lib/parse-psql-url.ts
@@ -20,14 +20,37 @@ if (url.protocol !== "postgres:" && url.protocol !== "postgresql:") {
   throw new Error("DATABASE_URL must use postgres:// or postgresql://");
 }
 
+if (url.hash) throw new Error("DATABASE_URL must not contain a fragment");
+
 let password = decodeURIComponent(url.password);
 url.password = "";
 
 // libpq accepts connection keywords in the URI query string. A query password
-// takes precedence over userinfo because it is parsed later by libpq.
-if (url.searchParams.has("password")) {
-  password = url.searchParams.get("password") ?? "";
-  url.searchParams.delete("password");
+// takes precedence over userinfo because it is parsed later by libpq. Preserve
+// every other query token byte-for-byte: WHATWG URLSearchParams would serialize
+// `%20` as `+`, but libpq URI parsing does not use HTML form-url-encoding and
+// may interpret that as a literal plus.
+const rawQueryStart = raw.indexOf("?");
+const rawQuery = rawQueryStart === -1 ? "" : raw.slice(rawQueryStart + 1);
+const retainedQueryParts: string[] = [];
+const queryPasswords: string[] = [];
+if (rawQueryStart !== -1) {
+  for (const part of rawQuery.split("&")) {
+    const separator = part.indexOf("=");
+    const rawKey = separator === -1 ? part : part.slice(0, separator);
+    const rawValue = separator === -1 ? "" : part.slice(separator + 1);
+    if (decodeURIComponent(rawKey) === "password") {
+      queryPasswords.push(decodeURIComponent(rawValue));
+    } else {
+      retainedQueryParts.push(part);
+    }
+  }
+}
+if (queryPasswords.length > 1) {
+  throw new Error("DATABASE_URL must not contain multiple password parameters");
+}
+if (queryPasswords.length === 1) {
+  password = queryPasswords[0] ?? "";
 }
 
 if (/[\0\r\n]/.test(password)) {
@@ -35,4 +58,7 @@ if (/[\0\r\n]/.test(password)) {
 }
 
 writeFileSync(passwordFile, password, { mode: 0o600 });
-process.stdout.write(url.toString());
+url.search = "";
+url.hash = "";
+const retainedQuery = retainedQueryParts.join("&");
+process.stdout.write(`${url.toString()}${retainedQuery ? `?${retainedQuery}` : ""}`);

--- a/scripts/lib/parse-psql-url.ts
+++ b/scripts/lib/parse-psql-url.ts
@@ -26,7 +26,38 @@ if (/[\0\r\n]/.test(raw)) {
 if (raw.includes("#")) throw new Error("DATABASE_URL must not contain a fragment");
 
 const schemeEnd = schemeMatch[0].length;
-const rawQueryStart = raw.indexOf("?", schemeEnd);
+// libpq accepts a raw `?` inside userinfo even though RFC 3986 normally
+// requires it to be percent-encoded. Do not mistake that byte for the query
+// delimiter: only search for the query after the userinfo terminator. Limit
+// the search for `@` to the pre-path authority candidate so an `@` in a normal
+// query value cannot be promoted to a credential delimiter.
+const pathStart = raw.indexOf("/", schemeEnd);
+const prePathEnd = pathStart === -1 ? raw.length : pathStart;
+const prePath = raw.slice(schemeEnd, prePathEnd);
+const prePathQuestion = prePath.indexOf("?");
+const prePathAt = prePath.indexOf("@");
+let userInfoTerminator = -1;
+if (prePathAt !== -1 && (prePathQuestion === -1 || prePathAt < prePathQuestion)) {
+  userInfoTerminator = schemeEnd + prePathAt;
+} else if (prePathAt > prePathQuestion) {
+  const possibleUserInfo = prePath.slice(0, prePathAt);
+  const passwordSeparator = possibleUserInfo.indexOf(":");
+  const ambiguousTail = prePath.slice(prePathQuestion + 1, prePathAt);
+  if (passwordSeparator !== -1 && passwordSeparator < prePathQuestion) {
+    // `=` or `&` makes this indistinguishable from a pre-path query containing
+    // `@`. Reject rather than risk placing either interpretation's credential
+    // bytes in argv.
+    if (/[=&]/.test(ambiguousTail)) {
+      throw new Error("DATABASE_URL contains ambiguous user information");
+    }
+    userInfoTerminator = schemeEnd + prePathAt;
+  }
+}
+
+const rawQueryStart = raw.indexOf(
+  "?",
+  userInfoTerminator === -1 ? schemeEnd : userInfoTerminator + 1,
+);
 const hierarchyEnd = rawQueryStart === -1 ? raw.length : rawQueryStart;
 const hierarchy = raw.slice(0, hierarchyEnd);
 const authorityEndCandidate = hierarchy.indexOf("/", schemeEnd);

--- a/scripts/lib/provision-secrets.ts
+++ b/scripts/lib/provision-secrets.ts
@@ -1,0 +1,52 @@
+import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export interface ProvisionSecrets {
+  tenantApiKey?: string;
+  agentId?: string;
+  apiUrl?: string;
+  tradeSessionId?: string;
+  jwt?: string;
+}
+
+function envLine(name: string, value: string | undefined): string | null {
+  if (value === undefined) return null;
+  if (/[\0\r\n]/.test(value)) {
+    throw new Error(`${name} contains an unsupported control character`);
+  }
+  return `${name}=${value}`;
+}
+
+/**
+ * Persist provisioning credentials without placing them in stdout or process
+ * argv. The first call creates a private directory/file; later calls may update
+ * that same file as provisioning produces additional credentials.
+ */
+export function writeProvisionSecrets(
+  secrets: ProvisionSecrets,
+  existingPath?: string,
+  temporaryDirectory: string = tmpdir(),
+): string {
+  const lines = [
+    "# Steward provisioning credentials — keep private and delete after use.",
+    envLine("STEWARD_TENANT_API_KEY", secrets.tenantApiKey),
+    envLine("STEWARD_AGENT_ID", secrets.agentId),
+    envLine("STEWARD_API_URL", secrets.apiUrl),
+    envLine("STEWARD_TRADE_SESSION_ID", secrets.tradeSessionId),
+    envLine("STEWARD_JWT", secrets.jwt),
+  ].filter((line): line is string => line !== null);
+  const path =
+    existingPath ??
+    join(mkdtempSync(join(temporaryDirectory, "steward-provision-")), "credentials.env");
+
+  writeFileSync(path, `${lines.join("\n")}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+    flag: existingPath ? "w" : "wx",
+  });
+  // `mode` only applies on creation. Reassert it when updating an existing
+  // output in case an operator accidentally changed its permissions.
+  chmodSync(path, 0o600);
+  return path;
+}

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -15,6 +15,10 @@ set -euo pipefail
 # =============================================================================
 
 DRY_RUN=false
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PSQL_PASSWORD_FILE=""
+MIGRATE_LOG=""
+trap 'rm -f "${PSQL_PASSWORD_FILE:-}" "${MIGRATE_LOG:-}"' EXIT
 
 for arg in "$@"; do
   case "$arg" in
@@ -58,18 +62,15 @@ fi
 # /proc/*/cmdline for the duration of every migration file. Strip the
 # password from the URL and pass it via the PGPASSWORD environment instead.
 # ---------------------------------------------------------------------------
-PSQL_URL="$DATABASE_URL"
-PSQL_PASSWORD=""
-if [[ "$DATABASE_URL" =~ ^(postgres(ql)?://)([^:@/]+):([^@]+)@(.+)$ ]]; then
-  PSQL_URL="${BASH_REMATCH[1]}${BASH_REMATCH[3]}@${BASH_REMATCH[5]}"
-  # Percent-decode the password component (PGPASSWORD is used literally).
-  PSQL_PASSWORD="$(printf '%b' "${BASH_REMATCH[4]//%/\\x}")"
-fi
+PSQL_PASSWORD_FILE="$(mktemp -t steward-psql-password.XXXXXX)"
+PSQL_URL="$(STEWARD_PSQL_PASSWORD_FILE="$PSQL_PASSWORD_FILE" bun "$SCRIPT_DIR/lib/parse-psql-url.ts")"
+PSQL_PASSWORD="$(<"$PSQL_PASSWORD_FILE")"
+rm -f "$PSQL_PASSWORD_FILE"
+PSQL_PASSWORD_FILE=""
 
 # ---------------------------------------------------------------------------
 # Find migration directory (relative to repo root or /opt/steward)
 # ---------------------------------------------------------------------------
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 MIGRATION_DIR="$REPO_ROOT/packages/db/drizzle"
 
@@ -102,7 +103,6 @@ FAILED=0
 
 # SEC-201: mktemp instead of a predictable /tmp path (symlink-safe on shared hosts)
 MIGRATE_LOG="$(mktemp -t steward-migrate.XXXXXX)"
-trap 'rm -f "$MIGRATE_LOG"' EXIT
 
 for sql_file in "${MIGRATIONS[@]}"; do
   name="$(basename "$sql_file")"

--- a/scripts/provision-agent.ts
+++ b/scripts/provision-agent.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 import { resolve } from "node:path";
 import { getDb, tenants } from "@stwd/db";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { createAgentToken, DEFAULT_TENANT_ID, vault } from "../packages/api/src/services/context";
 import { TradeSessionManager } from "../packages/trade-sessions/src/index";
 import { type DefaultTenantStore, ensureDefaultTenant } from "./lib/default-tenant";
@@ -34,8 +34,13 @@ const defaultTenantStore: DefaultTenantStore = {
   async insertTenant(values) {
     await getDb().insert(tenants).values(values);
   },
-  async rotateApiKeyHash(tenantId, apiKeyHash) {
-    await getDb().update(tenants).set({ apiKeyHash }).where(eq(tenants.id, tenantId));
+  async rotateApiKeyHash(tenantId, expectedApiKeyHash, apiKeyHash) {
+    const updated = await getDb()
+      .update(tenants)
+      .set({ apiKeyHash })
+      .where(and(eq(tenants.id, tenantId), eq(tenants.apiKeyHash, expectedApiKeyHash)))
+      .returning({ id: tenants.id });
+    return updated.length === 1;
   },
 };
 

--- a/scripts/provision-agent.ts
+++ b/scripts/provision-agent.ts
@@ -5,6 +5,7 @@ import { and, eq } from "drizzle-orm";
 import { createAgentToken, DEFAULT_TENANT_ID, vault } from "../packages/api/src/services/context";
 import { TradeSessionManager } from "../packages/trade-sessions/src/index";
 import { type DefaultTenantStore, ensureDefaultTenant } from "./lib/default-tenant";
+import { type ProvisionSecrets, writeProvisionSecrets } from "./lib/provision-secrets";
 
 const USAGE = `Usage:
   bun run scripts/provision-agent.ts <agentId> <ownerAddress>
@@ -21,8 +22,8 @@ function requireArg(value: string | undefined, name: string): string {
 }
 
 // Drizzle-backed store for the default-tenant key logic (SEC-012). The key
-// itself is generated inside ensureDefaultTenant and only ever printed once
-// to the operator — never logged elsewhere or stored in plaintext.
+// itself is generated inside ensureDefaultTenant and written once to the
+// owner-only provisioning output — never logged or stored in the database.
 const defaultTenantStore: DefaultTenantStore = {
   async getApiKeyHash(tenantId) {
     const [row] = await getDb()
@@ -88,6 +89,17 @@ async function main() {
     ownerAddress,
   });
 
+  const provisionSecrets: ProvisionSecrets = {
+    ...(tenantResult.status === "created" || tenantResult.status === "rotated"
+      ? { tenantApiKey: tenantResult.apiKey }
+      : {}),
+  };
+  // Persist a newly-created/rotated tenant key immediately. If a later wallet
+  // or session step fails, the only usable copy of that one-time key is still
+  // recoverable and was never written to terminal scrollback or CI logs.
+  const credentialsPath = writeProvisionSecrets(provisionSecrets);
+  console.log(`Sensitive provisioning output: ${credentialsPath} (mode 0600)`);
+
   const { agent, created: agentCreated } = await ensureAgent(agentId, ownerAddress);
   const { wallet, created: walletCreated } = await ensureHyperliquidWallet(agentId);
 
@@ -109,30 +121,31 @@ async function main() {
     "trade:hyperliquid:write",
   ]);
 
+  Object.assign(provisionSecrets, {
+    agentId,
+    apiUrl: "http://localhost:3200",
+    tradeSessionId: session.id,
+    jwt,
+  });
+  writeProvisionSecrets(provisionSecrets, credentialsPath);
+
   console.log("Steward Sol provisioning complete");
   console.log("================================");
   if (tenantResult.status === "created") {
-    console.log(
-      `Default tenant created. API key (shown ONCE — save it now): ${tenantResult.apiKey}`,
-    );
+    console.log("Default tenant created. Its one-time API key is in the private output file.");
   } else if (tenantResult.status === "rotated") {
     console.log("⚠  ROTATED the default tenant API key: the previous key was publicly");
     console.log("   derivable (sha256 of a string published in this repo, SEC-012) and is");
     console.log("   now INVALID. Update any client still using it.");
-    console.log(`   New API key (shown ONCE — save it now): ${tenantResult.apiKey}`);
+    console.log("   The replacement key is in the private output file.");
   }
   console.log(`Agent ID: ${agent.id} (${agentCreated ? "created" : "existing"})`);
   console.log(`Owner address: ${ownerAddress}`);
   console.log(`HL deposit address: ${wallet.address} (${walletCreated ? "created" : "existing"})`);
-  console.log(`Trade session ID: ${session.id}`);
   console.log(`Trade session expires: ${session.expiresAt.toISOString()}`);
   console.log("Policy: $100/day cap, $100/order cap, BTC+ETH only, max 2x leverage");
   console.log("");
-  console.log("Set these in Sol's eliza-cloud container env:");
-  console.log(`STEWARD_AGENT_ID=${agentId}`);
-  console.log("STEWARD_API_URL=http://localhost:3200");
-  console.log(`STEWARD_TRADE_SESSION_ID=${session.id}`);
-  console.log(`STEWARD_JWT=${jwt}`);
+  console.log("Agent environment credentials were written to the private output file above.");
   console.log("");
   console.log(
     "Manual funding step: bridge/fund the HL deposit address above with $20 USDC on Arbitrum first. Do not submit live orders from automation.",


### PR DESCRIPTION
## Summary

Post-merge audit follow-up for #323.

- keep platform and provisioning credentials out of stdout and remote curl argv by using mode-0600 files
- reject injectable remote migration metadata and use an argv-safe SSH command array
- use Redis noeviction for spend/rate enforcement state so memory pressure fails closed instead of silently resetting counters
- strip both userinfo and libpq query password credentials before invoking psql while preserving multi-host, Unix-socket, byte encoding, last-non-empty query precedence, and raw question marks accepted by libpq userinfo
- make legacy default-tenant rotation compare-and-swap so concurrent operator rotation cannot be overwritten
- declare the provisioning script direct workspace dependencies

## Audit findings closed

- SEC-020/022 residual: remote shell expansion still placed the platform header value in curl argv.
- SEC-021 residual: allkeys-lru could evict spend/rate enforcement keys.
- SEC-050 residual: credentials supplied through query parameters or a raw question mark in userinfo could reach psql argv. Query detection now occurs only after a validated userinfo terminator and ambiguous forms fail closed.
- SEC-012 residual: read-then-unconditional-update rotation could overwrite a concurrent operator-managed key.

## Validation

Exact head: 1a3f70bf8f2ed348216c0d36f05f80a718d02e76
Exact base: 47e4856de2886ffa53946e224916e8dd6e455990

- focused security/deploy suite: 64 pass, 0 fail
- migration credential suite: 12 pass, 0 fail, including raw-question userinfo, query at-sign preservation, duplicate and empty password precedence
- API/provision dependency build graph: 21/21 packages successful
- six-commit rebase range-diff: every commit patch-equivalent
- Biome on all changed TypeScript/JSON files
- bash -n on all changed shell scripts
- root and deploy Docker Compose configs validated with required placeholder inputs
- git diff --check

Awaiting independent review and exact-head hosted CI before merge.