### PR TITLE
test(security): align fixtures with fail-closed contracts

### DIFF
--- a/packages/api/src/__tests__/user-wallet-recovery-setup.test.ts
+++ b/packages/api/src/__tests__/user-wallet-recovery-setup.test.ts
@@ -898,6 +898,7 @@ describe("user wallet recovery setup", () => {
     expect(response.headers.get("Cache-Control")).toContain("no-store");
     const text = await response.text();
     expect(text).not.toContain(mnemonic);
+    expect(text).not.toContain("not mnemonic-recoverable");
     expect(JSON.parse(text)).toEqual({
       ok: false,
       error: "Failed to restore wallet: Internal server error",

--- a/packages/api/src/__tests__/user-wallet-recovery-setup.test.ts
+++ b/packages/api/src/__tests__/user-wallet-recovery-setup.test.ts
@@ -898,7 +898,10 @@ describe("user wallet recovery setup", () => {
     expect(response.headers.get("Cache-Control")).toContain("no-store");
     const text = await response.text();
     expect(text).not.toContain(mnemonic);
-    expect(text).toContain("not mnemonic-recoverable");
+    expect(JSON.parse(text)).toEqual({
+      ok: false,
+      error: "Failed to restore wallet: Internal server error",
+    });
   }, 30_000);
 
   it("does not mint a fake recovery phrase for an existing wallet", async () => {

--- a/packages/plugin-trading/src/__tests__/agent-token-expiry-monitoring.test.ts
+++ b/packages/plugin-trading/src/__tests__/agent-token-expiry-monitoring.test.ts
@@ -1,9 +1,22 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  setDefaultTimeout,
+} from "bun:test";
 import { generateApiKey, signAgentToken } from "@stwd/auth";
 import { closeDb, getDb, tenants } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { Hono } from "hono";
 import { exportJWK, generateKeyPair, SignJWT } from "jose";
+
+process.env.ELIZA_CLOUD_JWKS_URL = "https://jwks.example.test/.well-known/jwks.json";
+
+setDefaultTimeout(30_000);
 
 const TENANT_ID = "test-agent-token-expiry";
 const TENANT_NO_KEY_ID = "test-agent-token-expiry-no-key";

--- a/packages/plugin-trading/src/__tests__/agent-token-expiry-monitoring.test.ts
+++ b/packages/plugin-trading/src/__tests__/agent-token-expiry-monitoring.test.ts
@@ -14,8 +14,6 @@ import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { Hono } from "hono";
 import { exportJWK, generateKeyPair, SignJWT } from "jose";
 
-process.env.ELIZA_CLOUD_JWKS_URL = "https://jwks.example.test/.well-known/jwks.json";
-
 setDefaultTimeout(30_000);
 
 const TENANT_ID = "test-agent-token-expiry";
@@ -24,6 +22,9 @@ const AGENT_ID = "test-token-watch-agent";
 const OTHER_TENANT_ID = "test-agent-token-expiry-other";
 const FOREIGN_AGENT_ID = "test-token-watch-foreign";
 const KID = "test-agent-token-kid";
+const TEST_JWKS_URL = "https://jwks.example.test/.well-known/jwks.json";
+const originalJwksUrl = process.env.ELIZA_CLOUD_JWKS_URL;
+const originalFetch = globalThis.fetch;
 
 const auditEvents: Array<{ action: string; metadata?: Record<string, unknown>; actorId?: string }> =
   [];
@@ -55,6 +56,7 @@ let tradeRoutes: Hono;
 let tenantAuth: typeof import("../../../api/src/services/context")["tenantAuth"];
 
 beforeAll(async () => {
+  process.env.ELIZA_CLOUD_JWKS_URL = TEST_JWKS_URL;
   process.env.STEWARD_PGLITE_MEMORY = "true";
   process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
   process.env.STEWARD_MASTER_PASSWORD ??= "test-master-password";
@@ -74,9 +76,10 @@ beforeAll(async () => {
   publicJwk.alg = "RS256";
   publicJwk.use = "sig";
 
-  globalThis.fetch = mock(async () =>
-    Response.json({ keys: [publicJwk] }),
-  ) as unknown as typeof fetch;
+  globalThis.fetch = mock(async (input) => {
+    if (String(input) !== TEST_JWKS_URL) throw new Error(`Unexpected JWKS URL: ${String(input)}`);
+    return Response.json({ keys: [publicJwk] });
+  }) as unknown as typeof fetch;
 
   ({ requireAgentJwt, clearAgentJwksCacheForTests } = await import(
     "../../../api/src/middleware/agent-jwt"
@@ -124,6 +127,12 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
+  globalThis.fetch = originalFetch;
+  if (originalJwksUrl === undefined) {
+    delete process.env.ELIZA_CLOUD_JWKS_URL;
+  } else {
+    process.env.ELIZA_CLOUD_JWKS_URL = originalJwksUrl;
+  }
   await closeDb();
 });
 

--- a/packages/plugin-trading/src/__tests__/evm-swap-prepare.test.ts
+++ b/packages/plugin-trading/src/__tests__/evm-swap-prepare.test.ts
@@ -25,14 +25,15 @@ process.env.STEWARD_PGLITE_MEMORY = "true";
 process.env.STEWARD_DB_MODE = "pglite";
 process.env.STEWARD_MASTER_PASSWORD = "evm-swap-master-password";
 process.env.STEWARD_AUDIT_HMAC_KEY = "evm-swap-audit-hmac-key-with-enough-entropy";
-process.env.ELIZA_CLOUD_JWKS_URL = "https://jwks.example.test/.well-known/jwks.json";
-
 setDefaultTimeout(30000);
 
 const TENANT_ID = "evm-swap-tenant";
 const AGENT_ID = "evm-swap-agent";
 const OTHER_AGENT_ID = "evm-swap-other-agent";
 const KID = "evm-swap-kid";
+const TEST_JWKS_URL = "https://jwks.example.test/.well-known/jwks.json";
+const originalJwksUrl = process.env.ELIZA_CLOUD_JWKS_URL;
+const originalFetch = globalThis.fetch;
 const TARGET = "0x00000000000000000000000000000000000000bb";
 const FROM_TOKEN = "0x00000000000000000000000000000000000000cc";
 const TO_TOKEN = "0x00000000000000000000000000000000000000dd";
@@ -259,6 +260,7 @@ async function postPrepare(
 }
 
 beforeAll(async () => {
+  process.env.ELIZA_CLOUD_JWKS_URL = TEST_JWKS_URL;
   const { createPGLiteDb, setPGLiteOverride } = await import("@stwd/db/pglite");
   const { db, client } = await createPGLiteDb("memory://");
   setPGLiteOverride(db, async () => {
@@ -277,9 +279,10 @@ beforeAll(async () => {
   publicJwk.kid = KID;
   publicJwk.alg = "RS256";
   publicJwk.use = "sig";
-  globalThis.fetch = mock(async () =>
-    Response.json({ keys: [publicJwk] }),
-  ) as unknown as typeof fetch;
+  globalThis.fetch = mock(async (input) => {
+    if (String(input) !== TEST_JWKS_URL) throw new Error(`Unexpected JWKS URL: ${String(input)}`);
+    return Response.json({ keys: [publicJwk] });
+  }) as unknown as typeof fetch;
 
   ({ requireAgentJwt, clearAgentJwksCacheForTests } = await import(
     "../../../api/src/middleware/agent-jwt"
@@ -294,6 +297,12 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
+  globalThis.fetch = originalFetch;
+  if (originalJwksUrl === undefined) {
+    delete process.env.ELIZA_CLOUD_JWKS_URL;
+  } else {
+    process.env.ELIZA_CLOUD_JWKS_URL = originalJwksUrl;
+  }
   mock.restore();
   await closeDb();
 });

--- a/packages/plugin-trading/src/__tests__/evm-swap-prepare.test.ts
+++ b/packages/plugin-trading/src/__tests__/evm-swap-prepare.test.ts
@@ -25,6 +25,7 @@ process.env.STEWARD_PGLITE_MEMORY = "true";
 process.env.STEWARD_DB_MODE = "pglite";
 process.env.STEWARD_MASTER_PASSWORD = "evm-swap-master-password";
 process.env.STEWARD_AUDIT_HMAC_KEY = "evm-swap-audit-hmac-key-with-enough-entropy";
+process.env.ELIZA_CLOUD_JWKS_URL = "https://jwks.example.test/.well-known/jwks.json";
 
 setDefaultTimeout(30000);
 


### PR DESCRIPTION
## Summary
- configure an explicit JWKS URL in mocked agent-token suites now that the implicit development trust anchor fails closed
- give the PGlite-backed token expiry suite enough setup time
- assert the sanitized recovery conflict response instead of the raw vault exception

## Validation
- EVM swap prepare: 14/14 passing
- agent token expiry monitoring: 5/5 passing
- user wallet recovery setup: 17/17 passing
- `bunx turbo run build --filter=@stwd/api...`
- Biome and `git diff --check`