### PR TITLE
test(security): align fixtures with API hardening

### DIFF
--- a/packages/api/src/__tests__/user-wallet-recovery-setup.test.ts
+++ b/packages/api/src/__tests__/user-wallet-recovery-setup.test.ts
@@ -898,8 +898,11 @@ describe("user wallet recovery setup", () => {
     expect(response.headers.get("Cache-Control")).toContain("no-store");
     const text = await response.text();
     expect(text).not.toContain(mnemonic);
-    expect(text).toContain("Failed to restore wallet: Internal server error");
     expect(text).not.toContain("not mnemonic-recoverable");
+    expect(JSON.parse(text)).toEqual({
+      ok: false,
+      error: "Failed to restore wallet: Internal server error",
+    });
   }, 30_000);
 
   it("does not mint a fake recovery phrase for an existing wallet", async () => {

--- a/packages/api/src/__tests__/user-wallet-recovery-setup.test.ts
+++ b/packages/api/src/__tests__/user-wallet-recovery-setup.test.ts
@@ -898,7 +898,8 @@ describe("user wallet recovery setup", () => {
     expect(response.headers.get("Cache-Control")).toContain("no-store");
     const text = await response.text();
     expect(text).not.toContain(mnemonic);
-    expect(text).toContain("not mnemonic-recoverable");
+    expect(text).toContain("Failed to restore wallet: Internal server error");
+    expect(text).not.toContain("not mnemonic-recoverable");
   }, 30_000);
 
   it("does not mint a fake recovery phrase for an existing wallet", async () => {

--- a/packages/plugin-trading/src/__tests__/agent-token-expiry-monitoring.test.ts
+++ b/packages/plugin-trading/src/__tests__/agent-token-expiry-monitoring.test.ts
@@ -1,4 +1,13 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  setDefaultTimeout,
+} from "bun:test";
 import { generateApiKey, signAgentToken } from "@stwd/auth";
 import { closeDb, getDb, tenants } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
@@ -16,6 +25,8 @@ const originalDefaultJwksOptIn = process.env.STEWARD_ALLOW_DEFAULT_ELIZA_JWKS;
 // This suite deliberately mocks the built-in development JWKS endpoint. SEC-069
 // requires callers to opt into that trust anchor explicitly, including tests.
 process.env.STEWARD_ALLOW_DEFAULT_ELIZA_JWKS = "true";
+
+setDefaultTimeout(30_000);
 
 const auditEvents: Array<{ action: string; metadata?: Record<string, unknown>; actorId?: string }> =
   [];

--- a/packages/plugin-trading/src/__tests__/agent-token-expiry-monitoring.test.ts
+++ b/packages/plugin-trading/src/__tests__/agent-token-expiry-monitoring.test.ts
@@ -11,6 +11,11 @@ const AGENT_ID = "test-token-watch-agent";
 const OTHER_TENANT_ID = "test-agent-token-expiry-other";
 const FOREIGN_AGENT_ID = "test-token-watch-foreign";
 const KID = "test-agent-token-kid";
+const originalDefaultJwksOptIn = process.env.STEWARD_ALLOW_DEFAULT_ELIZA_JWKS;
+
+// This suite deliberately mocks the built-in development JWKS endpoint. SEC-069
+// requires callers to opt into that trust anchor explicitly, including tests.
+process.env.STEWARD_ALLOW_DEFAULT_ELIZA_JWKS = "true";
 
 const auditEvents: Array<{ action: string; metadata?: Record<string, unknown>; actorId?: string }> =
   [];
@@ -111,6 +116,11 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
+  if (originalDefaultJwksOptIn === undefined) {
+    delete process.env.STEWARD_ALLOW_DEFAULT_ELIZA_JWKS;
+  } else {
+    process.env.STEWARD_ALLOW_DEFAULT_ELIZA_JWKS = originalDefaultJwksOptIn;
+  }
   await closeDb();
 });
 

--- a/packages/plugin-trading/src/__tests__/evm-swap-prepare.test.ts
+++ b/packages/plugin-trading/src/__tests__/evm-swap-prepare.test.ts
@@ -25,6 +25,10 @@ process.env.STEWARD_PGLITE_MEMORY = "true";
 process.env.STEWARD_DB_MODE = "pglite";
 process.env.STEWARD_MASTER_PASSWORD = "evm-swap-master-password";
 process.env.STEWARD_AUDIT_HMAC_KEY = "evm-swap-audit-hmac-key-with-enough-entropy";
+const originalDefaultJwksOptIn = process.env.STEWARD_ALLOW_DEFAULT_ELIZA_JWKS;
+// This suite deliberately mocks the built-in development JWKS endpoint. SEC-069
+// requires callers to opt into that trust anchor explicitly, including tests.
+process.env.STEWARD_ALLOW_DEFAULT_ELIZA_JWKS = "true";
 
 setDefaultTimeout(30000);
 
@@ -293,6 +297,11 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
+  if (originalDefaultJwksOptIn === undefined) {
+    delete process.env.STEWARD_ALLOW_DEFAULT_ELIZA_JWKS;
+  } else {
+    process.env.STEWARD_ALLOW_DEFAULT_ELIZA_JWKS = originalDefaultJwksOptIn;
+  }
   mock.restore();
   await closeDb();
 });


### PR DESCRIPTION
## Summary

- align the wallet recovery test with the sanitized post-#348 error contract and explicitly assert the internal error is not leaked
- explicitly opt mocked-default-JWKS trading tests into the development trust anchor required by SEC-069
- restore the caller's environment after each affected suite

This is a test-fixture-only follow-up. It does not change production behavior.

## Verification

- `TEST_JOBS=1 TEST_TIMEOUT=120000 bun packages/api/scripts/run-tests-isolated.ts user-wallet-recovery-setup` (1/1 passed)
- `bun test --isolate --timeout 30000 packages/plugin-trading/src/__tests__/agent-token-expiry-monitoring.test.ts` (5/5 passed)
- `bun test --isolate --timeout 30000 packages/plugin-trading/src/__tests__/evm-swap-prepare.test.ts` (14/14 passed)
- `bunx turbo run build --filter=@stwd/api... --filter=@stwd/plugin-trading...` (21/21 packages passed)
- `bunx biome check` on all changed files
- `git diff --check`

## Base

- `develop`: `3ca87c1cef516b93051304e07070988c91a4d1aa`
- head: `fdcccf6bc61010d2c630749857b965ccb002a530`
