### PR TITLE
feat(policy): authenticate X summon provenance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -125,6 +125,10 @@ STEWARD_AUDIT_HMAC_KEY=
 # signs, all listed keys verify for the token TTL window. Governed provider
 # actions FAIL CLOSED if this is unset. Generate: printf 'v1:%s' "$(openssl rand -hex 32)"
 STEWARD_EXECUTION_AUTH_SECRET=
+# JSON object mapping trusted X adapter key ids to raw 32-byte Ed25519 public
+# keys encoded as unpadded base64url. Positive summoned-only provenance is
+# unavailable (fail closed) when this is empty or malformed.
+STEWARD_X_SUMMON_ATTESTATION_PUBLIC_KEYS=
 
 # ─── Database ─────────────────────────────────────────────────────────────────
 

--- a/.env.example
+++ b/.env.example
@@ -129,6 +129,9 @@ STEWARD_EXECUTION_AUTH_SECRET=
 # keys encoded as unpadded base64url. Positive summoned-only provenance is
 # unavailable (fail closed) when this is empty or malformed.
 STEWARD_X_SUMMON_ATTESTATION_PUBLIC_KEYS=
+# Required verifier audience for X summon attestations. Use a distinct value
+# per deployment/environment to prevent cross-environment replay.
+STEWARD_X_SUMMON_ATTESTATION_AUDIENCE=
 
 # ─── Database ─────────────────────────────────────────────────────────────────
 

--- a/docs/security/permissioned-x.mdx
+++ b/docs/security/permissioned-x.mdx
@@ -105,8 +105,12 @@ provenance can produce authoritative `summoned: true`.
 The optional top-level `summonAttestation` is a strict
 `steward.x-summon-attestation.v1` document signed with Ed25519. Configure trusted
 raw public keys in `STEWARD_X_SUMMON_ATTESTATION_PUBLIC_KEYS` as a JSON object
-from key id to unpadded base64url. The signature is domain-separated and binds:
+from key id to unpadded base64url. Set a unique deployment audience in
+`STEWARD_X_SUMMON_ATTESTATION_AUDIENCE` (and configure the adapter to sign that
+same audience); verification fails closed when it is absent or different. The
+signature is domain-separated and binds:
 
+- the deployment audience, preventing staging-to-production replay;
 - tenant, workspace, actor agent, and provider account;
 - the fixed `x.tweet.create` operation and canonical reply source post id;
 - the hash of the request's idempotency key;

--- a/docs/security/permissioned-x.mdx
+++ b/docs/security/permissioned-x.mdx
@@ -87,17 +87,39 @@ multiple trackers (tekedia, phemex, piunikaweb, Feb 2026).
 
 **Modeled as:** `replyPolicy.mode`:
 - `'any'` — replies allowed (operator accepts the upstream risk).
-- `'summoned-only'` — a reply is allowed ONLY when the action is marked
-  `summoned` (the caller asserts the account was @mentioned/quoted). An
+- `'summoned-only'` — a reply is allowed ONLY when a configured provider adapter
+  signs an unexpired summon attestation proving the account was mentioned or
+  quoted by the exact source post. A caller's `summoned: true` is ignored. An
   un-summoned reply is a policy **hard_deny** (`POLICY_X_REPLY_NOT_SUMMONED`)
   BEFORE dispatch. This is the **expected upstream-denial class** made explicit:
   Steward denies locally what X would 403 at the wire.
 - `'none'` — replies forbidden entirely (`POLICY_X_REPLY_FORBIDDEN`); only
   original posts pass.
 
-`isReply` and `replyToTweetId` are already adapter-validated policy args
-(`buildXAction`). `summoned` is a new validated boolean policy arg (see
-"Summoned detection" below).
+`isReply` and `replyToTweetId` are adapter-derived from the canonical action.
+`summoned: false` remains a safe negative assertion; only verified adapter
+provenance can produce authoritative `summoned: true`.
+
+### Authenticated summon provenance
+
+The optional top-level `summonAttestation` is a strict
+`steward.x-summon-attestation.v1` document signed with Ed25519. Configure trusted
+raw public keys in `STEWARD_X_SUMMON_ATTESTATION_PUBLIC_KEYS` as a JSON object
+from key id to unpadded base64url. The signature is domain-separated and binds:
+
+- tenant, workspace, actor agent, and provider account;
+- the fixed `x.tweet.create` operation and canonical reply source post id;
+- the hash of the request's idempotency key;
+- `summoned: true`, key id, issue time, and expiry.
+
+Attestations allow at most five minutes of validity and 30 seconds of future
+clock skew. Steward verifies the signature and exact binding at proposal,
+approval resume, and proxy dispatch. Expiry, key removal/rotation, provider
+outage, or any scope/post/retry mismatch fails closed. The immutable request
+envelope stores only the attestation digest. The frozen safe summary stores the
+signed identifier-level evidence needed for later verification; it contains no
+provider credential or post body, and audit decisions contain only hashes and
+reason codes.
 
 ### 2. Content conditions (`contentPolicy`)
 
@@ -197,10 +219,10 @@ rule type, NO new policy registry, NO new evaluator dispatch.
 - X adds `constraints.x` (an OPTIONAL, X-only sub-block). A non-X operation with
   an `x` constraint block is a config error (fail closed) — the sub-block only
   applies to `x.*` operations.
-- The composer reads adapter-validated policy args
+- The composer reads adapter-derived policy args
   (`isReply`, `replyToTweetId`, `hasUrl`, `textCodePointLength`, `summoned`) — it
-  NEVER lifts a raw body field. New args (`hasUrl`, `summoned`) are derived and
-  validated in `buildXAction`.
+  NEVER lifts a raw body field. `hasUrl` is derived in `buildXAction`; positive
+  `summoned` authority is supplied only by the verified attestation channel.
 - **Required-signal fail-closed:** a boolean signal a policy CONSUMES
   (`isReply` for replyPolicy, `summoned` for summoned-only, `hasUrl` for
   allowUrls / URL-escalation / spend pricing) that is ABSENT or non-boolean on
@@ -250,7 +272,7 @@ persisted document.
   and the fail-closed behavior; the trailing-window accumulator wiring in the
   live route is a follow-on (the same posture as `invokeCount1h` on develop,
   which is `undefined` in the service and fails closed by design).
-- **Summoned assertion is caller-supplied** — Steward cannot itself verify the
-  post @mentioned/quoted the account without a read call; `summoned-only` gates
-  on the asserted arg and the upstream 403 remains the backstop. This is
-  documented, not hidden.
+- **Adapter trust is explicit** — Steward does not perform a live X read during
+  dispatch. The authenticated provider adapter is responsible for establishing
+  mention/quote provenance, and its Ed25519 public key is an operator-managed
+  trust root. Missing or indeterminate provenance denies locally.

--- a/docs/security/permissioned-x.mdx
+++ b/docs/security/permissioned-x.mdx
@@ -279,4 +279,7 @@ persisted document.
 - **Adapter trust is explicit** — Steward does not perform a live X read during
   dispatch. The authenticated provider adapter is responsible for establishing
   mention/quote provenance, and its Ed25519 public key is an operator-managed
-  trust root. Missing or indeterminate provenance denies locally.
+  trust root. The signer MUST derive the tenant, workspace, actor, provider
+  account, source post, audience, and summon fact from its authenticated route
+  and live X result; it must never copy those authority fields from an
+  untrusted summon claimant. Missing or indeterminate provenance denies locally.

--- a/packages/api/src/__tests__/provider-x-permissioned-e2e.test.ts
+++ b/packages/api/src/__tests__/provider-x-permissioned-e2e.test.ts
@@ -448,6 +448,28 @@ describe("Permissioned-X full-chain E2E (authority plane, PGLite)", () => {
       .select()
       .from(providerOperations)
       .where(eq(providerOperations.id, P.OP_URL_DENY));
+
+    const digestMismatch = await providerActionService.evaluateApprovedExecution({
+      tenantId: P.TENANT,
+      workspaceId: P.WORKSPACE,
+      actorAgentId: P.AGENT,
+      operation,
+      intentId: b.intentId,
+      requestHash: b.requestHash,
+      actionDigest: b.actionDigest,
+      canonicalActionBytes: new Uint8Array(b.canonicalActionBytes),
+      safeSummary: b.safeSummary,
+      expectedXSummonAttestationDigest: `sha256:${"0".repeat(64)}`,
+      matchedGrantIds: b.matchedGrantIds,
+      priorGeneration: 1,
+      idempotencyKeyHash: b.idempotencyKeyHash,
+    });
+    expect(digestMismatch).toEqual({
+      ok: false,
+      code: "APPROVAL_ACTION_INTEGRITY_FAILED",
+      httpStatus: 409,
+    });
+
     __setProviderPolicyClockForTests(() => new Date(Date.parse(attestation.expiresAt) + 1));
     try {
       const resumed = await providerActionService.evaluateApprovedExecution({
@@ -460,13 +482,14 @@ describe("Permissioned-X full-chain E2E (authority plane, PGLite)", () => {
         actionDigest: b.actionDigest,
         canonicalActionBytes: new Uint8Array(b.canonicalActionBytes),
         safeSummary: b.safeSummary,
+        expectedXSummonAttestationDigest: b.requestEnvelope.xSummonAttestationDigest,
         matchedGrantIds: b.matchedGrantIds,
         priorGeneration: 1,
         idempotencyKeyHash: b.idempotencyKeyHash,
       });
       expect(resumed.ok).toBe(false);
       if (resumed.ok) throw new Error("stale summon provenance unexpectedly passed resume");
-      expect(resumed.code).toBe("POLICY_INPUT_UNAVAILABLE");
+      expect(resumed.code).toBe("APPROVAL_SUMMON_ATTESTATION_INVALID");
     } finally {
       __setProviderPolicyClockForTests(null);
     }

--- a/packages/api/src/__tests__/provider-x-permissioned-e2e.test.ts
+++ b/packages/api/src/__tests__/provider-x-permissioned-e2e.test.ts
@@ -43,6 +43,7 @@ import {
   setDefaultTimeout,
   test,
 } from "bun:test";
+import { generateKeyPairSync, sign } from "node:crypto";
 import {
   agents,
   approvalQueue,
@@ -70,11 +71,16 @@ import {
   computeXActionDigest,
   jcsStringify,
   sha256HexPrefixed,
+  type XSummonAttestationV1,
   xCanonicalActionBytes,
+  xSummonAttestationSignatureInput,
 } from "@stwd/shared";
 import { eq } from "drizzle-orm";
 import type { ProviderPrincipalV1 } from "../middleware/provider-principal";
-import { providerActionService } from "../services/provider-action-service";
+import {
+  __setProviderPolicyClockForTests,
+  providerActionService,
+} from "../services/provider-action-service";
 
 setDefaultTimeout(120_000);
 
@@ -98,6 +104,11 @@ const P = {
 
 const OP_TWEET = "x.tweet.create";
 const FUTURE = new Date(Date.now() + 365 * 24 * 3600_000);
+const SUMMON_KEY_ID = "permissioned-x-test";
+const summonKeyPair = generateKeyPairSync("ed25519");
+const summonPublicRaw = summonKeyPair.publicKey
+  .export({ format: "der", type: "spki" })
+  .subarray(-32);
 
 function principal(): ProviderPrincipalV1 {
   return {
@@ -261,7 +272,32 @@ function idemHash(seedStr: string): string {
   return `sha256:${Buffer.from(seedStr.padEnd(32, "0")).toString("hex").slice(0, 64)}`;
 }
 
-async function propose(args: unknown, seedStr: string) {
+function signedSummonAttestation(seedStr: string, sourcePostId: string) {
+  const now = new Date();
+  const a: XSummonAttestationV1 = {
+    schemaVersion: "steward.x-summon-attestation.v1",
+    keyId: SUMMON_KEY_ID,
+    tenantId: P.TENANT,
+    workspaceId: P.WORKSPACE,
+    actorAgentId: P.AGENT,
+    providerAccountId: P.ACCOUNT,
+    operationKey: "x.tweet.create",
+    sourcePostId,
+    idempotencyKeyHash: idemHash(seedStr),
+    summoned: true,
+    attestedAt: new Date(now.getTime() - 1_000).toISOString(),
+    expiresAt: new Date(now.getTime() + 299_000).toISOString(),
+    signature: "A".repeat(86),
+  };
+  a.signature = sign(
+    null,
+    Buffer.from(xSummonAttestationSignatureInput(a), "utf8"),
+    summonKeyPair.privateKey,
+  ).toString("base64url");
+  return a;
+}
+
+async function propose(args: unknown, seedStr: string, summonAttestation?: unknown) {
   const now = new Date();
   return providerActionService.createProviderAction({
     principal: principal(),
@@ -274,6 +310,7 @@ async function propose(args: unknown, seedStr: string) {
     expiresAt: new Date(now.getTime() + 300_000).toISOString(),
     nonce: seedStr.padEnd(32, "N").slice(0, 32),
     requestId: null,
+    summonAttestation,
   });
 }
 
@@ -289,12 +326,16 @@ describe("Permissioned-X full-chain E2E (authority plane, PGLite)", () => {
   beforeAll(async () => {
     process.env.STEWARD_PGLITE_MEMORY = "true";
     process.env.STEWARD_AUDIT_HMAC_KEY ||= "0".repeat(64);
+    process.env.STEWARD_X_SUMMON_ATTESTATION_PUBLIC_KEYS = JSON.stringify({
+      [SUMMON_KEY_ID]: summonPublicRaw.toString("base64url"),
+    });
     const { db, client } = await createPGLiteDb("memory://");
     setPGLiteOverride(db, async () => client.close());
   });
   afterAll(async () => {
     await closeDb();
     delete process.env.STEWARD_PGLITE_MEMORY;
+    delete process.env.STEWARD_X_SUMMON_ATTESTATION_PUBLIC_KEYS;
   });
   beforeEach(async () => {
     await wipe();
@@ -368,6 +409,121 @@ describe("Permissioned-X full-chain E2E (authority plane, PGLite)", () => {
     expect(out.code).toBe("POLICY_INPUT_UNAVAILABLE");
     const b = await bindingRow(out.intentId);
     expect(b.status).not.toBe("stub_succeeded");
+  });
+
+  test("replyPolicy summoned-only accepts exact authenticated adapter provenance", async () => {
+    await seed([
+      allowRule("11111111-1111-4111-8111-1111111111b2", { replyPolicy: { mode: "summoned-only" } }),
+    ]);
+    const seedStr = "summon-attested";
+    const sourcePostId = "1750000000000000000";
+    const attestation = signedSummonAttestation(seedStr, sourcePostId);
+    const out = await propose(
+      { text: "thanks for the mention!", replyToTweetId: sourcePostId, summoned: true },
+      seedStr,
+      attestation,
+    );
+    expect(out.kind).toBe("allowed");
+    if (out.kind !== "allowed") throw new Error(`got ${out.kind}`);
+    const b = await bindingRow(out.intentId);
+    expect(b.requestEnvelope.xSummonAttestationDigest).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(b.safeSummary.xSummonAttestation).toEqual(attestation);
+    expect(JSON.stringify(b)).not.toContain("thanks for the mention!");
+    const auditRows = await getDb()
+      .select()
+      .from(providerActionAuditOutbox)
+      .where(eq(providerActionAuditOutbox.intentId, out.intentId));
+    expect(
+      auditRows.some(
+        (row) =>
+          (row.metadata as Record<string, unknown>).xSummonAttestationDigest ===
+          b.requestEnvelope.xSummonAttestationDigest,
+      ),
+    ).toBe(true);
+
+    const [operation] = await getDb()
+      .select()
+      .from(providerOperations)
+      .where(eq(providerOperations.id, P.OP_URL_DENY));
+    __setProviderPolicyClockForTests(() => new Date(Date.parse(attestation.expiresAt) + 1));
+    try {
+      const resumed = await providerActionService.evaluateApprovedExecution({
+        tenantId: P.TENANT,
+        workspaceId: P.WORKSPACE,
+        actorAgentId: P.AGENT,
+        operation,
+        intentId: b.intentId,
+        requestHash: b.requestHash,
+        actionDigest: b.actionDigest,
+        canonicalActionBytes: new Uint8Array(b.canonicalActionBytes),
+        safeSummary: b.safeSummary,
+        matchedGrantIds: b.matchedGrantIds,
+        priorGeneration: 1,
+        idempotencyKeyHash: b.idempotencyKeyHash,
+      });
+      expect(resumed.ok).toBe(false);
+      if (resumed.ok) throw new Error("stale summon provenance unexpectedly passed resume");
+      expect(resumed.code).toBe("POLICY_INPUT_UNAVAILABLE");
+    } finally {
+      __setProviderPolicyClockForTests(null);
+    }
+  });
+
+  test("summon provenance fails closed when replayed across a source post or retry identity", async () => {
+    await seed([
+      allowRule("11111111-1111-4111-8111-1111111111b2", { replyPolicy: { mode: "summoned-only" } }),
+    ]);
+    const attestation = signedSummonAttestation("attested-original", "1750000000000000000");
+    const postReplay = await propose(
+      { text: "reply", replyToTweetId: "1750000000000000001", summoned: true },
+      "attested-original",
+      attestation,
+    );
+    expect(postReplay.kind).toBe("policy_denied");
+    const retryReplay = await propose(
+      { text: "reply", replyToTweetId: "1750000000000000000", summoned: true },
+      "attested-other-key",
+      attestation,
+    );
+    expect(retryReplay.kind).toBe("policy_denied");
+  });
+
+  test("summon provenance conflicts when a retry key is rebound to different signed evidence", async () => {
+    await seed([
+      allowRule("11111111-1111-4111-8111-1111111111b2", { replyPolicy: { mode: "summoned-only" } }),
+    ]);
+    const retryKey = "attested-rebind";
+    const sourcePostId = "1750000000000000000";
+    const firstAttestation = signedSummonAttestation(retryKey, sourcePostId);
+    const first = await propose(
+      { text: "reply", replyToTweetId: sourcePostId, summoned: true },
+      retryKey,
+      firstAttestation,
+    );
+    expect(first.kind).toBe("allowed");
+
+    const reboundAttestation = {
+      ...firstAttestation,
+      attestedAt: new Date(Date.parse(firstAttestation.attestedAt) + 1).toISOString(),
+      expiresAt: new Date(Date.parse(firstAttestation.expiresAt) + 1).toISOString(),
+    };
+    reboundAttestation.signature = sign(
+      null,
+      Buffer.from(xSummonAttestationSignatureInput(reboundAttestation), "utf8"),
+      summonKeyPair.privateKey,
+    ).toString("base64url");
+    expect(reboundAttestation.signature).not.toBe(firstAttestation.signature);
+
+    const replay = await propose(
+      { text: "reply", replyToTweetId: sourcePostId, summoned: true },
+      retryKey,
+      reboundAttestation,
+    );
+    expect(replay).toEqual({
+      kind: "replay_conflict",
+      code: "REPLAY_IDEMPOTENCY_CONFLICT",
+      httpStatus: 409,
+    });
   });
 
   test("policy-input replay identity: exact summoned replay returns the original outcome", async () => {

--- a/packages/api/src/__tests__/provider-x-permissioned-e2e.test.ts
+++ b/packages/api/src/__tests__/provider-x-permissioned-e2e.test.ts
@@ -277,6 +277,7 @@ function signedSummonAttestation(seedStr: string, sourcePostId: string) {
   const a: XSummonAttestationV1 = {
     schemaVersion: "steward.x-summon-attestation.v1",
     keyId: SUMMON_KEY_ID,
+    audience: "steward-test",
     tenantId: P.TENANT,
     workspaceId: P.WORKSPACE,
     actorAgentId: P.AGENT,
@@ -329,6 +330,7 @@ describe("Permissioned-X full-chain E2E (authority plane, PGLite)", () => {
     process.env.STEWARD_X_SUMMON_ATTESTATION_PUBLIC_KEYS = JSON.stringify({
       [SUMMON_KEY_ID]: summonPublicRaw.toString("base64url"),
     });
+    process.env.STEWARD_X_SUMMON_ATTESTATION_AUDIENCE = "steward-test";
     const { db, client } = await createPGLiteDb("memory://");
     setPGLiteOverride(db, async () => client.close());
   });
@@ -336,6 +338,7 @@ describe("Permissioned-X full-chain E2E (authority plane, PGLite)", () => {
     await closeDb();
     delete process.env.STEWARD_PGLITE_MEMORY;
     delete process.env.STEWARD_X_SUMMON_ATTESTATION_PUBLIC_KEYS;
+    delete process.env.STEWARD_X_SUMMON_ATTESTATION_AUDIENCE;
   });
   beforeEach(async () => {
     await wipe();

--- a/packages/api/src/__tests__/provider-x-summon-replay-race-postgres.test.ts
+++ b/packages/api/src/__tests__/provider-x-summon-replay-race-postgres.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Real-Postgres proof for the provider-action creation advisory-lock replay path.
+ * PGLite cannot exercise pg_advisory_xact_lock or separate pooled connections.
+ */
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  setDefaultTimeout,
+  test,
+} from "bun:test";
+import { generateKeyPairSync, sign } from "node:crypto";
+import {
+  approvalQueue,
+  getDb,
+  intents,
+  providerAccounts,
+  providerActionAuditOutbox,
+  providerActionBindings,
+  providerGrants,
+  providerOperations,
+  providerRoleBindings,
+  secretRoutes,
+  secrets,
+  tenants,
+  users,
+  userTenants,
+  workspaces,
+} from "@stwd/db";
+import { buildXAction } from "@stwd/provider-x";
+import {
+  computeXSummonAttestationDigest,
+  type XSummonAttestationV1,
+  xSummonAttestationSignatureInput,
+} from "@stwd/shared";
+import { eq } from "drizzle-orm";
+import {
+  __setProviderCreateAfterOptimisticReplayLookupForTests,
+  providerActionService,
+} from "../services/provider-action-service";
+import { F, principal, seedFixture } from "./provider-approval-fixture";
+
+setDefaultTimeout(120_000);
+
+const SKIP = !process.env.DATABASE_URL;
+const OPERATION_KEY = "x.tweet.create";
+const SOURCE_POST_ID = "1750000000000000000";
+const RETRY_SEED = "summon-race-retry";
+const SUMMON_KEY_ID = "summon-race-postgres";
+const summonKeyPair = generateKeyPairSync("ed25519");
+const summonPublicRaw = summonKeyPair.publicKey
+  .export({ format: "der", type: "spki" })
+  .subarray(-32);
+
+function idempotencyKeyHash(): string {
+  return `sha256:${Buffer.from(RETRY_SEED.padEnd(32, "0")).toString("hex").slice(0, 64)}`;
+}
+
+function signedAttestation(offsetMs: number): XSummonAttestationV1 {
+  const now = Date.now();
+  const attestation: XSummonAttestationV1 = {
+    schemaVersion: "steward.x-summon-attestation.v1",
+    keyId: SUMMON_KEY_ID,
+    audience: "steward-postgres-race",
+    tenantId: F.TENANT,
+    workspaceId: F.WORKSPACE,
+    actorAgentId: F.AGENT,
+    providerAccountId: F.ACCOUNT,
+    operationKey: OPERATION_KEY,
+    sourcePostId: SOURCE_POST_ID,
+    idempotencyKeyHash: idempotencyKeyHash(),
+    summoned: true,
+    attestedAt: new Date(now - 1_000 + offsetMs).toISOString(),
+    expiresAt: new Date(now + 299_000 + offsetMs).toISOString(),
+    signature: "A".repeat(86),
+  };
+  attestation.signature = sign(
+    null,
+    Buffer.from(xSummonAttestationSignatureInput(attestation), "utf8"),
+    summonKeyPair.privateKey,
+  ).toString("base64url");
+  return attestation;
+}
+
+async function wipe() {
+  const db = getDb();
+  await db.delete(providerActionAuditOutbox);
+  await db.delete(approvalQueue);
+  await db.delete(providerActionBindings);
+  await db.delete(intents);
+  await db.delete(providerGrants);
+  await db.delete(providerRoleBindings);
+  await db.delete(providerOperations);
+  await db.delete(providerAccounts);
+  await db.delete(secretRoutes);
+  await db.delete(secrets);
+  await db.delete(workspaces);
+  await db.delete(userTenants);
+  await db.delete(users);
+  await db.delete(tenants);
+}
+
+async function seedXFixture() {
+  await seedFixture();
+  const db = getDb();
+  await db
+    .update(providerAccounts)
+    .set({ adapterKey: "x", externalRef: "9999", displayName: "@summon-race" })
+    .where(eq(providerAccounts.id, F.ACCOUNT));
+  await db
+    .update(providerOperations)
+    .set({
+      operationKey: OPERATION_KEY,
+      riskClass: "write",
+      requestProfile: {
+        policyRules: [
+          {
+            id: "11111111-1111-4111-8111-1111111111b2",
+            type: "capability-intent",
+            enabled: true,
+            config: {
+              capabilities: [OPERATION_KEY],
+              effect: "allow",
+              constraints: { x: { replyPolicy: { mode: "summoned-only" } } },
+            },
+          },
+        ],
+      },
+    })
+    .where(eq(providerOperations.id, F.OP));
+  await db
+    .update(providerGrants)
+    .set({ operationKeys: [OPERATION_KEY] })
+    .where(eq(providerGrants.id, F.GRANT));
+}
+
+async function propose(attestation: XSummonAttestationV1) {
+  const now = new Date();
+  return providerActionService.createProviderAction({
+    principal: principal(),
+    workspaceId: F.WORKSPACE,
+    providerAccountId: F.ACCOUNT,
+    operationKey: OPERATION_KEY,
+    build: buildXAction(OPERATION_KEY as never, {
+      text: "same canonical reply",
+      replyToTweetId: SOURCE_POST_ID,
+      summoned: true,
+    }),
+    idempotencyKeyHash: idempotencyKeyHash(),
+    requestedAt: now.toISOString(),
+    expiresAt: new Date(now.getTime() + 300_000).toISOString(),
+    nonce: RETRY_SEED.padEnd(32, "N").slice(0, 32),
+    requestId: null,
+    summonAttestation: attestation,
+  });
+}
+
+describe.skipIf(SKIP)("X summon replay race (real Postgres)", () => {
+  beforeAll(() => {
+    process.env.STEWARD_AUDIT_HMAC_KEY ||= "0".repeat(64);
+    process.env.STEWARD_X_SUMMON_ATTESTATION_PUBLIC_KEYS = JSON.stringify({
+      [SUMMON_KEY_ID]: summonPublicRaw.toString("base64url"),
+    });
+    process.env.STEWARD_X_SUMMON_ATTESTATION_AUDIENCE = "steward-postgres-race";
+  });
+
+  afterAll(async () => {
+    __setProviderCreateAfterOptimisticReplayLookupForTests(null);
+    delete process.env.STEWARD_X_SUMMON_ATTESTATION_PUBLIC_KEYS;
+    delete process.env.STEWARD_X_SUMMON_ATTESTATION_AUDIENCE;
+    if (!SKIP) await wipe();
+  });
+
+  beforeEach(async () => {
+    await wipe();
+    await seedXFixture();
+  });
+
+  test("different valid attestations racing after the optimistic miss conflict under the advisory lock", async () => {
+    const firstAttestation = signedAttestation(0);
+    const secondAttestation = signedAttestation(1);
+    expect(computeXSummonAttestationDigest(firstAttestation)).not.toBe(
+      computeXSummonAttestationDigest(secondAttestation),
+    );
+
+    let arrivals = 0;
+    let release!: () => void;
+    const bothArrived = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    __setProviderCreateAfterOptimisticReplayLookupForTests(async () => {
+      arrivals += 1;
+      if (arrivals === 2) release();
+      await bothArrived;
+    });
+
+    let results!: Awaited<ReturnType<typeof propose>>[];
+    try {
+      results = await Promise.all([propose(firstAttestation), propose(secondAttestation)]);
+    } finally {
+      __setProviderCreateAfterOptimisticReplayLookupForTests(null);
+    }
+
+    expect(arrivals).toBe(2);
+    expect(results.filter((result) => result.kind === "allowed")).toHaveLength(1);
+    expect(results.filter((result) => result.kind === "replay_conflict")).toEqual([
+      {
+        kind: "replay_conflict",
+        code: "REPLAY_IDEMPOTENCY_CONFLICT",
+        httpStatus: 409,
+      },
+    ]);
+
+    const [persisted] = await getDb()
+      .select()
+      .from(providerActionBindings)
+      .where(eq(providerActionBindings.idempotencyKeyHash, idempotencyKeyHash()));
+    expect(persisted).toBeDefined();
+    expect([
+      computeXSummonAttestationDigest(firstAttestation),
+      computeXSummonAttestationDigest(secondAttestation),
+    ]).toContain((persisted.requestEnvelope as Record<string, unknown>).xSummonAttestationDigest);
+  });
+});

--- a/packages/api/src/routes/provider-actions.ts
+++ b/packages/api/src/routes/provider-actions.ts
@@ -81,6 +81,7 @@ const TOP_LEVEL_KEYS = new Set([
   "operationKey",
   "arguments",
   "idempotencyKey",
+  "summonAttestation",
   // #201: for config-driven (generic-http) operations the caller supplies the
   // HTTP method explicitly (the descriptor may allow several); adapter-fixed
   // github/x operations ignore it (their method is fixed by the operation key).
@@ -241,6 +242,7 @@ async function handleCreateProviderAction(c: RouteContext) {
   const idempotencyKey = body.idempotencyKey;
   const args = body.arguments;
   const method = body.method;
+  const summonAttestation = body.summonAttestation;
 
   if (
     workspaceId === undefined ||
@@ -317,6 +319,7 @@ async function handleCreateProviderAction(c: RouteContext) {
       expiresAt: toRfc3339Millis(expiresAt),
       nonce,
       requestId: c.get("requestId") ?? null,
+      summonAttestation,
     });
   } catch (e) {
     if (isCanonError(e)) return deny(c, e.code, e.httpStatus);

--- a/packages/api/src/services/provider-action-service.ts
+++ b/packages/api/src/services/provider-action-service.ts
@@ -905,6 +905,7 @@ class ProviderActionService {
         const verification = verifyXSummonAttestation(
           input.summonAttestation,
           {
+            audience: process.env.STEWARD_X_SUMMON_ATTESTATION_AUDIENCE ?? "",
             tenantId,
             workspaceId: input.workspaceId,
             actorAgentId,
@@ -2624,6 +2625,7 @@ class ProviderActionService {
         authenticatedXSummoned = verifyXSummonAttestation(
           args.safeSummary.xSummonAttestation,
           {
+            audience: process.env.STEWARD_X_SUMMON_ATTESTATION_AUDIENCE ?? "",
             tenantId: args.tenantId,
             workspaceId: args.workspaceId,
             actorAgentId: args.actorAgentId,

--- a/packages/api/src/services/provider-action-service.ts
+++ b/packages/api/src/services/provider-action-service.ts
@@ -2575,6 +2575,7 @@ class ProviderActionService {
     actionDigest: string;
     canonicalActionBytes: Uint8Array;
     safeSummary: Record<string, unknown>;
+    expectedXSummonAttestationDigest: unknown;
     matchedGrantIds: string[];
     priorGeneration: number;
     idempotencyKeyHash: string;
@@ -2612,18 +2613,29 @@ class ProviderActionService {
       return { ok: false, code: "APPROVAL_ACTION_INTEGRITY_FAILED", httpStatus: 409 };
     }
 
-    // Re-verify the frozen provider attestation at safe-resume. A signature
-    // that expired during human approval, a rotated/removed adapter key, or any
-    // cross-scope substitution removes the positive signal and makes
-    // summoned-only policy fail closed.
+    // Re-verify the frozen provider attestation at safe-resume and bind it to
+    // the digest captured in the immutable request envelope. A signature that
+    // expired during human approval, a rotated/removed adapter key, or any
+    // substitution must fail before an approval is consumed, even when the
+    // current policy would no longer require summoned-only provenance.
     let authenticatedXSummoned = false;
     if (args.operation.operationKey === "x.tweet.create") {
       const canonicalBody = asRecord(build.action.canonicalBody);
       const reply = canonicalBody.reply === undefined ? undefined : asRecord(canonicalBody.reply);
       const sourcePostId = reply?.in_reply_to_tweet_id;
-      if (typeof sourcePostId === "string" && args.safeSummary.xSummonAttestation !== undefined) {
-        authenticatedXSummoned = verifyXSummonAttestation(
-          args.safeSummary.xSummonAttestation,
+      const persistedAttestation = args.safeSummary.xSummonAttestation;
+      const expectedDigest = args.expectedXSummonAttestationDigest;
+      if (persistedAttestation !== undefined || expectedDigest !== undefined) {
+        if (
+          typeof sourcePostId !== "string" ||
+          persistedAttestation === undefined ||
+          typeof expectedDigest !== "string" ||
+          !/^sha256:[0-9a-f]{64}$/.test(expectedDigest)
+        ) {
+          return { ok: false, code: "APPROVAL_SUMMON_ATTESTATION_INVALID", httpStatus: 409 };
+        }
+        const verification = verifyXSummonAttestation(
+          persistedAttestation,
           {
             audience: process.env.STEWARD_X_SUMMON_ATTESTATION_AUDIENCE ?? "",
             tenantId: args.tenantId,
@@ -2635,7 +2647,14 @@ class ProviderActionService {
           },
           process.env.STEWARD_X_SUMMON_ATTESTATION_PUBLIC_KEYS,
           providerPolicyClockForTests?.() ?? new Date(),
-        ).ok;
+        );
+        if (!verification.ok) {
+          return { ok: false, code: "APPROVAL_SUMMON_ATTESTATION_INVALID", httpStatus: 409 };
+        }
+        if (verification.digest !== expectedDigest) {
+          return { ok: false, code: "APPROVAL_ACTION_INTEGRITY_FAILED", httpStatus: 409 };
+        }
+        authenticatedXSummoned = true;
       }
     }
 

--- a/packages/api/src/services/provider-action-service.ts
+++ b/packages/api/src/services/provider-action-service.ts
@@ -213,6 +213,7 @@ type ReservationReconciliationTarget = "settled" | "released";
 let reservationReconciliationFaultForTests: "before_apply" | "after_apply" | null = null;
 let providerPolicyClockForTests: (() => Date) | null = null;
 let decisionReservationCrashForTests = false;
+let providerCreateAfterOptimisticReplayLookupForTests: (() => Promise<void>) | null = null;
 
 class SimulatedDecisionReservationCrash extends Error {}
 
@@ -233,6 +234,14 @@ export function __setProviderPolicyClockForTests(clock: (() => Date) | null): vo
  * create transaction can persist its intent/generation. */
 export function __setDecisionReservationCrashForTests(enabled: boolean): void {
   decisionReservationCrashForTests = enabled;
+}
+
+/** Test-only barrier after the unlocked replay miss. This lets the real-Postgres
+ * suite deterministically put two requests on the production advisory-lock path. */
+export function __setProviderCreateAfterOptimisticReplayLookupForTests(
+  hook: (() => Promise<void>) | null,
+): void {
+  providerCreateAfterOptimisticReplayLookupForTests = hook;
 }
 
 function persistedReservationHandles(
@@ -982,6 +991,8 @@ class ProviderActionService {
       return await this.outcomeFromBinding(priorBinding);
     }
 
+    await providerCreateAfterOptimisticReplayLookupForTests?.();
+
     // Reservation identity must survive a process death after Redis admission
     // but before PostgreSQL commit. Derive the intent from the already-scoped
     // idempotency identity; the transaction advisory lock below serializes
@@ -1361,12 +1372,14 @@ class ProviderActionService {
 
     if (transactionReplay) {
       const replay = transactionReplay as typeof providerActionBindings.$inferSelect;
-      const persistedPolicyInputDigest = (replay.requestEnvelope as Record<string, unknown>)
-        .policyInputDigest;
+      const persistedEnvelope = replay.requestEnvelope as Record<string, unknown>;
+      const persistedPolicyInputDigest = persistedEnvelope.policyInputDigest;
+      const persistedXSummonAttestationDigest = persistedEnvelope.xSummonAttestationDigest;
       if (
         replay.actionDigest !== actionDigest ||
         (persistedPolicyInputDigest !== undefined &&
-          persistedPolicyInputDigest !== policyInputDigest)
+          persistedPolicyInputDigest !== policyInputDigest) ||
+        persistedXSummonAttestationDigest !== xSummonAttestationDigest
       ) {
         return {
           kind: "replay_conflict",

--- a/packages/api/src/services/provider-action-service.ts
+++ b/packages/api/src/services/provider-action-service.ts
@@ -75,6 +75,7 @@ import {
   sha256HexPrefixed,
   UnregisteredProfileError,
   validateGenericHttpDescriptor,
+  verifyXSummonAttestation,
   type XCanonicalActionV1,
 } from "@stwd/shared";
 
@@ -385,9 +386,12 @@ function asRecord(value: unknown): Record<string, unknown> {
  * would let callers bypass summoned-only reply policy. Until an authenticated X
  * lookup supplies that fact, summoned-only fails closed.
  */
-function xPolicySignalsFrom(args: Record<string, unknown>): {
+function xPolicySignalsFrom(
+  args: Record<string, unknown>,
+  authenticatedSummoned = false,
+): {
   isReply?: boolean;
-  summoned?: false;
+  summoned?: boolean;
   hasUrl?: boolean;
   textCodePointLength?: number;
 } {
@@ -396,7 +400,11 @@ function xPolicySignalsFrom(args: Record<string, unknown>): {
     // A negative assertion cannot grant authority, so it is safe to preserve
     // the specific not-summoned deny. A positive assertion remains unavailable
     // until independently attested.
-    ...(args.summoned === false ? { summoned: false as const } : {}),
+    ...(authenticatedSummoned
+      ? { summoned: true as const }
+      : args.summoned === false
+        ? { summoned: false as const }
+        : {}),
     ...(typeof args.hasUrl === "boolean" ? { hasUrl: args.hasUrl } : {}),
     ...(typeof args.textCodePointLength === "number" && Number.isInteger(args.textCodePointLength)
       ? { textCodePointLength: args.textCodePointLength }
@@ -618,6 +626,9 @@ export interface CreateProviderActionInput {
   nonce: string;
   /** Audit provenance (never authority). */
   requestId?: string | null;
+  /** Authenticated adapter provenance. Caller transport is untrusted; the
+   * service verifies its Ed25519 signature and exact scope before use. */
+  summonAttestation?: unknown;
 }
 
 // ─── The in-process executor stub (PR2 only — NEVER real dispatch) ─────────────
@@ -874,6 +885,51 @@ class ProviderActionService {
       );
     }
 
+    // Caller-supplied `summoned: true` is never authority. Only a configured
+    // provider adapter's signed attestation can promote the signal. Freeze the
+    // verified record for resume/dispatch revalidation and bind its digest into
+    // the immutable request envelope.
+    let authenticatedXSummoned = false;
+    let xSummonAttestationDigest: string | undefined;
+    if (input.operationKey === "x.tweet.create") {
+      build = {
+        ...build,
+        safeSummary: { ...build.safeSummary, summoned: false },
+      } as ConcreteProviderActionBuild;
+    }
+    if (input.operationKey === "x.tweet.create" && input.summonAttestation !== undefined) {
+      const canonicalBody = asRecord(build.action.canonicalBody);
+      const reply = canonicalBody.reply === undefined ? undefined : asRecord(canonicalBody.reply);
+      const sourcePostId = reply?.in_reply_to_tweet_id;
+      if (typeof sourcePostId === "string") {
+        const verification = verifyXSummonAttestation(
+          input.summonAttestation,
+          {
+            tenantId,
+            workspaceId: input.workspaceId,
+            actorAgentId,
+            providerAccountId: account.id,
+            sourcePostId,
+            idempotencyKeyHash: input.idempotencyKeyHash,
+          },
+          process.env.STEWARD_X_SUMMON_ATTESTATION_PUBLIC_KEYS,
+          providerPolicyClockForTests?.() ?? new Date(),
+        );
+        if (verification.ok) {
+          authenticatedXSummoned = true;
+          xSummonAttestationDigest = verification.digest;
+          build = {
+            ...build,
+            safeSummary: {
+              ...build.safeSummary,
+              summoned: true,
+              xSummonAttestation: verification.attestation,
+            },
+          } as ConcreteProviderActionBuild;
+        }
+      }
+    }
+
     // Compute the canonical action digest + request envelope/hash up-front (they
     // are pure and needed for the binding + idempotency conflict check).
     const actionDigest = sha256HexPrefixed(jcsStringify(this.canonicalActionObject(build.action)));
@@ -907,12 +963,14 @@ class ProviderActionService {
       // Legacy envelopes have no such member and retain the historical
       // action-only replay behavior; this is a bounded compatibility path for
       // pre-rollout rows, never used by a newly-created binding.
-      const persistedPolicyInputDigest = (priorBinding.requestEnvelope as Record<string, unknown>)
-        .policyInputDigest;
+      const persistedEnvelope = priorBinding.requestEnvelope as Record<string, unknown>;
+      const persistedPolicyInputDigest = persistedEnvelope.policyInputDigest;
+      const persistedXSummonAttestationDigest = persistedEnvelope.xSummonAttestationDigest;
       if (
         priorBinding.actionDigest !== actionDigest ||
         (persistedPolicyInputDigest !== undefined &&
-          persistedPolicyInputDigest !== policyInputDigest)
+          persistedPolicyInputDigest !== policyInputDigest) ||
+        persistedXSummonAttestationDigest !== xSummonAttestationDigest
       ) {
         return {
           kind: "replay_conflict",
@@ -1030,6 +1088,7 @@ class ProviderActionService {
           operationRevision: txOperation.revision,
           actionDigest,
           policyInputDigest,
+          xSummonAttestationDigest,
         });
         requestHash = sha256HexPrefixed(jcsStringify(this.envelopeObject(envelope)));
 
@@ -1062,6 +1121,7 @@ class ProviderActionService {
                 // scope resolves to "" and the composer fails closed if a rule
                 // aggregates over grant without one.
                 grantId: access.doc.matchedGrantIds[0] ?? null,
+                authenticatedXSummoned,
               })
             : null;
         cumulativeSpendReservations = policy?.cumulativeSpendReservations ?? [];
@@ -1222,6 +1282,7 @@ class ProviderActionService {
             operationKey: input.operationKey,
             actionDigest,
             requestHash,
+            xSummonAttestationDigest: xSummonAttestationDigest ?? null,
             accessDecisionId,
             accessDecisionHash,
             accessEffect: effects.access,
@@ -2209,6 +2270,8 @@ class ProviderActionService {
     /** Append-only reservation generation. Stable identities derived from this
      * make an approval retry idempotent across the Redis-before-PG crash gap. */
     reservationGeneration?: number;
+    /** Verified independently at this evaluation boundary. */
+    authenticatedXSummoned?: boolean;
   }): Promise<{
     doc: PersistedPolicyDecisionV1;
     evaluation: ProviderPolicyEvaluationV1;
@@ -2394,7 +2457,7 @@ class ProviderActionService {
         // `summoned` assertion is intentionally not promoted to this trusted
         // channel; a summoned-only rule denies until an authenticated adapter
         // attestation is available.
-        x: xPolicySignalsFrom(build.policyArgs),
+        x: xPolicySignalsFrom(build.policyArgs, args.authenticatedXSummoned === true),
       };
 
       const ruleEvaluation = composeProviderActionPolicyDecision(rules, context);
@@ -2513,6 +2576,7 @@ class ProviderActionService {
     safeSummary: Record<string, unknown>;
     matchedGrantIds: string[];
     priorGeneration: number;
+    idempotencyKeyHash: string;
   }): Promise<
     | {
         ok: true;
@@ -2547,6 +2611,32 @@ class ProviderActionService {
       return { ok: false, code: "APPROVAL_ACTION_INTEGRITY_FAILED", httpStatus: 409 };
     }
 
+    // Re-verify the frozen provider attestation at safe-resume. A signature
+    // that expired during human approval, a rotated/removed adapter key, or any
+    // cross-scope substitution removes the positive signal and makes
+    // summoned-only policy fail closed.
+    let authenticatedXSummoned = false;
+    if (args.operation.operationKey === "x.tweet.create") {
+      const canonicalBody = asRecord(build.action.canonicalBody);
+      const reply = canonicalBody.reply === undefined ? undefined : asRecord(canonicalBody.reply);
+      const sourcePostId = reply?.in_reply_to_tweet_id;
+      if (typeof sourcePostId === "string" && args.safeSummary.xSummonAttestation !== undefined) {
+        authenticatedXSummoned = verifyXSummonAttestation(
+          args.safeSummary.xSummonAttestation,
+          {
+            tenantId: args.tenantId,
+            workspaceId: args.workspaceId,
+            actorAgentId: args.actorAgentId,
+            providerAccountId: args.operation.providerAccountId,
+            sourcePostId,
+            idempotencyKeyHash: args.idempotencyKeyHash,
+          },
+          process.env.STEWARD_X_SUMMON_ATTESTATION_PUBLIC_KEYS,
+          providerPolicyClockForTests?.() ?? new Date(),
+        ).ok;
+      }
+    }
+
     const policy = await this.evaluatePolicy({
       db: args.db,
       tenantId: args.tenantId,
@@ -2559,6 +2649,7 @@ class ProviderActionService {
       actionDigest: args.actionDigest,
       grantId: args.matchedGrantIds[0] ?? null,
       reservationGeneration: generation,
+      authenticatedXSummoned,
     });
     if (policy.doc.effect === "hard_deny") {
       await this.releasePolicyReservationHandles(
@@ -2943,6 +3034,7 @@ class ProviderActionService {
       operationRevision: number;
       actionDigest: string;
       policyInputDigest: string;
+      xSummonAttestationDigest?: string;
     },
   ): ProviderRequestEnvelopeV1 {
     return {
@@ -2955,6 +3047,9 @@ class ProviderActionService {
       operationRevision: ids.operationRevision,
       actionDigest: ids.actionDigest,
       policyInputDigest: ids.policyInputDigest,
+      ...(ids.xSummonAttestationDigest !== undefined
+        ? { xSummonAttestationDigest: ids.xSummonAttestationDigest }
+        : {}),
       idempotencyKeyHash: input.idempotencyKeyHash,
       requestedAt: input.requestedAt,
       expiresAt: input.expiresAt,
@@ -2978,6 +3073,8 @@ class ProviderActionService {
       nonce: e.nonce,
     };
     if (e.policyInputDigest !== undefined) envelope.policyInputDigest = e.policyInputDigest;
+    if (e.xSummonAttestationDigest !== undefined)
+      envelope.xSummonAttestationDigest = e.xSummonAttestationDigest;
     return envelope;
   }
 

--- a/packages/api/src/services/provider-approval.ts
+++ b/packages/api/src/services/provider-approval.ts
@@ -2104,6 +2104,7 @@ class ProviderApprovalService {
             actionDigest: binding.actionDigest,
             canonicalActionBytes: new Uint8Array(binding.canonicalActionBytes as Uint8Array),
             safeSummary: binding.safeSummary,
+            expectedXSummonAttestationDigest: binding.requestEnvelope.xSummonAttestationDigest,
             matchedGrantIds: binding.matchedGrantIds,
             priorGeneration: priorGeneration?.generation ?? 0,
             idempotencyKeyHash: binding.idempotencyKeyHash,

--- a/packages/api/src/services/provider-approval.ts
+++ b/packages/api/src/services/provider-approval.ts
@@ -2106,6 +2106,7 @@ class ProviderApprovalService {
             safeSummary: binding.safeSummary,
             matchedGrantIds: binding.matchedGrantIds,
             priorGeneration: priorGeneration?.generation ?? 0,
+            idempotencyKeyHash: binding.idempotencyKeyHash,
           });
           if (!executionPolicy.ok) {
             await append({

--- a/packages/proxy/src/__tests__/x-summon-provenance.test.ts
+++ b/packages/proxy/src/__tests__/x-summon-provenance.test.ts
@@ -107,9 +107,9 @@ describe("dispatch X summon provenance boundary", () => {
     const tampered = fixture();
     tampered.requestEnvelope.workspaceId = "22000000-0000-4000-8000-000000000002";
     expect(verifyDispatchXSummonProvenance(tampered)).toBe("invalid");
-    expect(
-      verifyDispatchXSummonProvenance({ ...fixture(), audience: "steward-staging" }),
-    ).toBe("invalid");
+    expect(verifyDispatchXSummonProvenance({ ...fixture(), audience: "steward-staging" })).toBe(
+      "invalid",
+    );
   });
 
   test("allows truly absent provenance for non-summon-governed actions", () => {

--- a/packages/proxy/src/__tests__/x-summon-provenance.test.ts
+++ b/packages/proxy/src/__tests__/x-summon-provenance.test.ts
@@ -13,11 +13,13 @@ const rawPublic = pair.publicKey.export({ format: "der", type: "spki" }).subarra
 const keysJson = JSON.stringify({ dispatch: rawPublic.toString("base64url") });
 const now = new Date("2026-08-18T01:00:00.000Z");
 const idempotencyKeyHash = `sha256:${"c".repeat(64)}`;
+const audience = "steward-prod-us";
 
 function signed(): XSummonAttestationV1 {
   const a: XSummonAttestationV1 = {
     schemaVersion: "steward.x-summon-attestation.v1",
     keyId: "dispatch",
+    audience,
     tenantId: "tenant-a",
     workspaceId: "22000000-0000-4000-8000-000000000001",
     actorAgentId: "agent-a",
@@ -57,6 +59,7 @@ function fixture() {
     nonce: "nonce",
   };
   return {
+    audience,
     tenantId: "tenant-a",
     workspaceId: "22000000-0000-4000-8000-000000000001",
     actorAgentId: "agent-a",
@@ -104,6 +107,9 @@ describe("dispatch X summon provenance boundary", () => {
     const tampered = fixture();
     tampered.requestEnvelope.workspaceId = "22000000-0000-4000-8000-000000000002";
     expect(verifyDispatchXSummonProvenance(tampered)).toBe("invalid");
+    expect(
+      verifyDispatchXSummonProvenance({ ...fixture(), audience: "steward-staging" }),
+    ).toBe("invalid");
   });
 
   test("allows truly absent provenance for non-summon-governed actions", () => {

--- a/packages/proxy/src/__tests__/x-summon-provenance.test.ts
+++ b/packages/proxy/src/__tests__/x-summon-provenance.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "bun:test";
+import { createHash, generateKeyPairSync, sign } from "node:crypto";
+import {
+  computeXSummonAttestationDigest,
+  jcsStringify,
+  type XSummonAttestationV1,
+  xSummonAttestationSignatureInput,
+} from "@stwd/shared";
+import { verifyDispatchXSummonProvenance } from "../handlers/governed-execution";
+
+const pair = generateKeyPairSync("ed25519");
+const rawPublic = pair.publicKey.export({ format: "der", type: "spki" }).subarray(-32);
+const keysJson = JSON.stringify({ dispatch: rawPublic.toString("base64url") });
+const now = new Date("2026-08-18T01:00:00.000Z");
+const idempotencyKeyHash = `sha256:${"c".repeat(64)}`;
+
+function signed(): XSummonAttestationV1 {
+  const a: XSummonAttestationV1 = {
+    schemaVersion: "steward.x-summon-attestation.v1",
+    keyId: "dispatch",
+    tenantId: "tenant-a",
+    workspaceId: "22000000-0000-4000-8000-000000000001",
+    actorAgentId: "agent-a",
+    providerAccountId: "32000000-0000-4000-8000-000000000001",
+    operationKey: "x.tweet.create",
+    sourcePostId: "1900000000000000000",
+    idempotencyKeyHash,
+    summoned: true,
+    attestedAt: "2026-08-18T00:59:00.000Z",
+    expiresAt: "2026-08-18T01:04:00.000Z",
+    signature: "A".repeat(86),
+  };
+  a.signature = sign(
+    null,
+    Buffer.from(xSummonAttestationSignatureInput(a), "utf8"),
+    pair.privateKey,
+  ).toString("base64url");
+  return a;
+}
+
+function fixture() {
+  const attestation = signed();
+  const requestEnvelope = {
+    schemaVersion: "steward.provider-request.v1",
+    tenantId: "tenant-a",
+    workspaceId: "22000000-0000-4000-8000-000000000001",
+    actorAgentId: "agent-a",
+    providerAccountId: "32000000-0000-4000-8000-000000000001",
+    operationId: "42000000-0000-4000-8000-000000000001",
+    operationRevision: 1,
+    actionDigest: `sha256:${"d".repeat(64)}`,
+    policyInputDigest: `sha256:${"e".repeat(64)}`,
+    idempotencyKeyHash,
+    xSummonAttestationDigest: computeXSummonAttestationDigest(attestation),
+    requestedAt: "2026-08-18T00:59:01.000Z",
+    expiresAt: "2026-08-18T01:04:01.000Z",
+    nonce: "nonce",
+  };
+  return {
+    tenantId: "tenant-a",
+    workspaceId: "22000000-0000-4000-8000-000000000001",
+    actorAgentId: "agent-a",
+    providerAccountId: "32000000-0000-4000-8000-000000000001",
+    idempotencyKeyHash,
+    requestEnvelope,
+    requestHash: `sha256:${createHash("sha256").update(jcsStringify(requestEnvelope)).digest("hex")}`,
+    safeSummary: { xSummonAttestation: attestation },
+    canonicalAction: {
+      profile: "x.provider-action.v1",
+      method: "POST" as const,
+      origin: "https://api.x.com",
+      normalizedPath: "/2/tweets",
+      orderedQueryPairs: [],
+      selectedHeaders: [["content-type", "application/json"]] as Array<[string, string]>,
+      canonicalBody: {
+        text: "not persisted in provenance",
+        reply: { in_reply_to_tweet_id: "1900000000000000000" },
+      },
+    } as never,
+    keysJson,
+    now,
+  };
+}
+
+describe("dispatch X summon provenance boundary", () => {
+  test("accepts exact signed and request-hash-bound provenance", () => {
+    expect(verifyDispatchXSummonProvenance(fixture())).toBe("valid");
+  });
+
+  test("fails closed on expired, removed, cross-post, or envelope-tampered evidence", () => {
+    expect(
+      verifyDispatchXSummonProvenance({
+        ...fixture(),
+        now: new Date("2026-08-18T01:04:00.001Z"),
+      }),
+    ).toBe("invalid");
+    expect(verifyDispatchXSummonProvenance({ ...fixture(), safeSummary: {} })).toBe("invalid");
+    const crossPost = fixture();
+    crossPost.canonicalAction.canonicalBody = {
+      text: "reply",
+      reply: { in_reply_to_tweet_id: "1900000000000000001" },
+    };
+    expect(verifyDispatchXSummonProvenance(crossPost)).toBe("invalid");
+    const tampered = fixture();
+    tampered.requestEnvelope.workspaceId = "22000000-0000-4000-8000-000000000002";
+    expect(verifyDispatchXSummonProvenance(tampered)).toBe("invalid");
+  });
+
+  test("allows truly absent provenance for non-summon-governed actions", () => {
+    const absent = fixture();
+    delete absent.requestEnvelope.xSummonAttestationDigest;
+    absent.requestHash = `sha256:${createHash("sha256")
+      .update(jcsStringify(absent.requestEnvelope))
+      .digest("hex")}`;
+    absent.safeSummary = {};
+    expect(verifyDispatchXSummonProvenance(absent)).toBe("absent");
+  });
+});

--- a/packages/proxy/src/handlers/governed-execution.ts
+++ b/packages/proxy/src/handlers/governed-execution.ts
@@ -171,6 +171,7 @@ interface LoadedGovernedExecution {
  * valid for actions whose policy did not require summon provenance; a one-sided
  * or invalid persisted record is always a deny. */
 export function verifyDispatchXSummonProvenance(input: {
+  audience: string;
   tenantId: string;
   workspaceId: string;
   actorAgentId: string;
@@ -200,6 +201,7 @@ export function verifyDispatchXSummonProvenance(input: {
   const verification = verifyXSummonAttestation(
     persistedAttestation,
     {
+      audience: input.audience,
       tenantId: input.tenantId,
       workspaceId: input.workspaceId,
       actorAgentId: input.actorAgentId,
@@ -419,6 +421,7 @@ export async function dispatchGovernedExecution(
   // current expiry before any claim or credential decrypt.
   const summonProvenance = verifyDispatchXSummonProvenance({
     ...loaded,
+    audience: process.env.STEWARD_X_SUMMON_ATTESTATION_AUDIENCE ?? "",
     keysJson: process.env.STEWARD_X_SUMMON_ATTESTATION_PUBLIC_KEYS,
   });
   if (summonProvenance === "invalid") {

--- a/packages/proxy/src/handlers/governed-execution.ts
+++ b/packages/proxy/src/handlers/governed-execution.ts
@@ -60,6 +60,7 @@ import {
   validateGenericHttpDescriptor,
   verifyProviderExecutionCommitmentV2,
   verifyProviderExecutionPolicyEvidence,
+  verifyXSummonAttestation,
 } from "@stwd/shared";
 import { and, eq, sql } from "drizzle-orm";
 import type { Context } from "hono";
@@ -78,6 +79,7 @@ export type GovernedDispatchCode =
   | "EXEC_AUTH_KEY_UNAVAILABLE"
   | "EXEC_AUTH_SIGNATURE_INVALID"
   | "EXEC_AUTH_POLICY_EVIDENCE_MISSING"
+  | "EXEC_AUTH_SUMMON_ATTESTATION_INVALID"
   | "EXEC_DISPATCH_OUTCOME_UNKNOWN"
   | "EXEC_DISPATCH_UPSTREAM_ERROR"
   | "EXEC_AUDIT_UNAVAILABLE"
@@ -158,8 +160,57 @@ interface LoadedGovernedExecution {
   executionPolicyDecision: Record<string, unknown> | null;
   executionPolicyDecisionHash: string | null;
   executionPolicyEvaluatedAt: string | null;
+  requestEnvelope: Record<string, unknown>;
+  safeSummary: Record<string, unknown>;
+  idempotencyKeyHash: string;
   issuedAt: string;
   expiresAt: string;
+}
+
+/** Pure final-boundary verifier used by dispatch and hostile tests. Absence is
+ * valid for actions whose policy did not require summon provenance; a one-sided
+ * or invalid persisted record is always a deny. */
+export function verifyDispatchXSummonProvenance(input: {
+  tenantId: string;
+  workspaceId: string;
+  actorAgentId: string;
+  providerAccountId: string;
+  idempotencyKeyHash: string;
+  requestHash: string;
+  requestEnvelope: Record<string, unknown>;
+  safeSummary: Record<string, unknown>;
+  canonicalAction: GithubCanonicalActionV1;
+  keysJson: string | undefined;
+  now?: Date;
+}): "absent" | "valid" | "invalid" {
+  if (sha256Hex(jcsStringify(input.requestEnvelope)) !== input.requestHash) return "invalid";
+  const summonDigest = input.requestEnvelope.xSummonAttestationDigest;
+  const persistedAttestation = input.safeSummary.xSummonAttestation;
+  if (summonDigest === undefined && persistedAttestation === undefined) return "absent";
+  const body = input.canonicalAction.canonicalBody;
+  const reply =
+    body && typeof body === "object" && !Array.isArray(body)
+      ? (body as Record<string, unknown>).reply
+      : undefined;
+  const sourcePostId =
+    reply && typeof reply === "object" && !Array.isArray(reply)
+      ? (reply as Record<string, unknown>).in_reply_to_tweet_id
+      : undefined;
+  if (typeof summonDigest !== "string" || typeof sourcePostId !== "string") return "invalid";
+  const verification = verifyXSummonAttestation(
+    persistedAttestation,
+    {
+      tenantId: input.tenantId,
+      workspaceId: input.workspaceId,
+      actorAgentId: input.actorAgentId,
+      providerAccountId: input.providerAccountId,
+      sourcePostId,
+      idempotencyKeyHash: input.idempotencyKeyHash,
+    },
+    input.keysJson,
+    input.now,
+  );
+  return verification.ok && verification.digest === summonDigest ? "valid" : "invalid";
 }
 
 /**
@@ -291,6 +342,9 @@ async function loadGovernedExecution(
     executionPolicyDecision: binding.executionPolicyDecision,
     executionPolicyDecisionHash: binding.executionPolicyDecisionHash,
     executionPolicyEvaluatedAt: binding.executionPolicyEvaluatedAt?.toISOString() ?? null,
+    requestEnvelope: binding.requestEnvelope,
+    safeSummary: binding.safeSummary,
+    idempotencyKeyHash: binding.idempotencyKeyHash,
     issuedAt: (nonce.issuedAt as Date).toISOString(),
     expiresAt: (nonce.expiresAt as Date).toISOString(),
   };
@@ -358,6 +412,18 @@ export async function dispatchGovernedExecution(
   }
   await hook("afterLoad");
   if (!loaded) return deny("EXEC_AUTH_NOT_READY", 409, intentId);
+
+  // Revalidate authenticated X summon provenance at the final dispatch
+  // boundary. The request hash makes the attestation digest load-bearing; the
+  // proxy independently verifies the adapter signature, exact scope/source and
+  // current expiry before any claim or credential decrypt.
+  const summonProvenance = verifyDispatchXSummonProvenance({
+    ...loaded,
+    keysJson: process.env.STEWARD_X_SUMMON_ATTESTATION_PUBLIC_KEYS,
+  });
+  if (summonProvenance === "invalid") {
+    return deny("EXEC_AUTH_SUMMON_ATTESTATION_INVALID", 409, intentId);
+  }
 
   // Terminal / already-dispatched: never re-dispatch (X8, P26). A consumed nonce
   // with a terminal dispatch_state returns its current state without dispatching.

--- a/packages/shared/src/__tests__/x-summon-attestation.test.ts
+++ b/packages/shared/src/__tests__/x-summon-attestation.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import { generateKeyPairSync, sign } from "node:crypto";
+import {
+  verifyXSummonAttestation,
+  type XSummonAttestationV1,
+  xSummonAttestationSignatureInput,
+} from "../x-summon-attestation";
+
+const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+const rawPublicKey = publicKey.export({ format: "der", type: "spki" }).subarray(-32);
+const keysJson = JSON.stringify({ "adapter-2026-08": rawPublicKey.toString("base64url") });
+const now = new Date("2026-08-18T01:00:00.000Z");
+const expected = {
+  tenantId: "tenant-a",
+  workspaceId: "22000000-0000-4000-8000-000000000001",
+  actorAgentId: "agent-a",
+  providerAccountId: "32000000-0000-4000-8000-000000000001",
+  sourcePostId: "1900000000000000000",
+  idempotencyKeyHash: `sha256:${"a".repeat(64)}`,
+};
+
+function attestation(overrides: Partial<XSummonAttestationV1> = {}): XSummonAttestationV1 {
+  const unsigned: XSummonAttestationV1 = {
+    schemaVersion: "steward.x-summon-attestation.v1",
+    keyId: "adapter-2026-08",
+    ...expected,
+    operationKey: "x.tweet.create",
+    summoned: true,
+    attestedAt: "2026-08-18T00:59:30.000Z",
+    expiresAt: "2026-08-18T01:04:30.000Z",
+    signature: "A".repeat(86),
+    ...overrides,
+  };
+  unsigned.signature = sign(
+    null,
+    Buffer.from(xSummonAttestationSignatureInput(unsigned), "utf8"),
+    privateKey,
+  ).toString("base64url");
+  return unsigned;
+}
+
+describe("authenticated X summon provenance", () => {
+  test("accepts an exact, current adapter signature", () => {
+    const result = verifyXSummonAttestation(attestation(), expected, keysJson, now);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.digest).toMatch(/^sha256:[0-9a-f]{64}$/);
+  });
+
+  test.each([
+    ["tenant", { tenantId: "tenant-b" }],
+    ["workspace", { workspaceId: "22000000-0000-4000-8000-000000000002" }],
+    ["agent", { actorAgentId: "agent-b" }],
+    ["account", { providerAccountId: "32000000-0000-4000-8000-000000000002" }],
+    ["post", { sourcePostId: "1900000000000000001" }],
+    ["retry identity", { idempotencyKeyHash: `sha256:${"b".repeat(64)}` }],
+  ])("rejects replay across %s", (_name, overrides) => {
+    expect(verifyXSummonAttestation(attestation(overrides), expected, keysJson, now)).toEqual({
+      ok: false,
+      reason: "binding_mismatch",
+    });
+  });
+
+  test("rejects forged, stale, overlong and unknown-key attestations", () => {
+    const forged = attestation();
+    forged.signature = `${forged.signature.startsWith("A") ? "B" : "A"}${forged.signature.slice(1)}`;
+    expect(verifyXSummonAttestation(forged, expected, keysJson, now).ok).toBe(false);
+    expect(
+      verifyXSummonAttestation(
+        attestation({ expiresAt: "2026-08-18T00:59:59.000Z" }),
+        expected,
+        keysJson,
+        now,
+      ),
+    ).toEqual({ ok: false, reason: "stale" });
+    expect(
+      verifyXSummonAttestation(
+        attestation({ attestedAt: "2026-08-18T00:50:00.000Z" }),
+        expected,
+        keysJson,
+        now,
+      ),
+    ).toEqual({ ok: false, reason: "stale" });
+    expect(
+      verifyXSummonAttestation(attestation({ keyId: "retired" }), expected, keysJson, now),
+    ).toEqual({ ok: false, reason: "unknown_key" });
+  });
+
+  test("rejects unknown fields and missing key configuration", () => {
+    expect(
+      verifyXSummonAttestation({ ...attestation(), rawPost: "secret" }, expected, keysJson, now),
+    ).toEqual({ ok: false, reason: "malformed" });
+    expect(verifyXSummonAttestation(attestation(), expected, undefined, now)).toEqual({
+      ok: false,
+      reason: "unknown_key",
+    });
+  });
+});

--- a/packages/shared/src/__tests__/x-summon-attestation.test.ts
+++ b/packages/shared/src/__tests__/x-summon-attestation.test.ts
@@ -11,6 +11,7 @@ const rawPublicKey = publicKey.export({ format: "der", type: "spki" }).subarray(
 const keysJson = JSON.stringify({ "adapter-2026-08": rawPublicKey.toString("base64url") });
 const now = new Date("2026-08-18T01:00:00.000Z");
 const expected = {
+  audience: "steward-prod-us",
   tenantId: "tenant-a",
   workspaceId: "22000000-0000-4000-8000-000000000001",
   actorAgentId: "agent-a",
@@ -47,6 +48,7 @@ describe("authenticated X summon provenance", () => {
   });
 
   test.each([
+    ["deployment audience", { audience: "steward-staging" }],
     ["tenant", { tenantId: "tenant-b" }],
     ["workspace", { workspaceId: "22000000-0000-4000-8000-000000000002" }],
     ["agent", { actorAgentId: "agent-b" }],
@@ -83,6 +85,14 @@ describe("authenticated X summon provenance", () => {
     expect(
       verifyXSummonAttestation(attestation({ keyId: "retired" }), expected, keysJson, now),
     ).toEqual({ ok: false, reason: "unknown_key" });
+    expect(
+      verifyXSummonAttestation(
+        attestation({ attestedAt: "2026-02-31T00:59:30.000Z" }),
+        expected,
+        keysJson,
+        now,
+      ),
+    ).toEqual({ ok: false, reason: "stale" });
   });
 
   test("rejects unknown fields and missing key configuration", () => {
@@ -92,6 +102,32 @@ describe("authenticated X summon provenance", () => {
     expect(verifyXSummonAttestation(attestation(), expected, undefined, now)).toEqual({
       ok: false,
       reason: "unknown_key",
+    });
+  });
+
+  test("rejects inherited key ids and non-canonical signature encodings without throwing", () => {
+    expect(
+      verifyXSummonAttestation(
+        attestation({ keyId: "toString" }),
+        expected,
+        keysJson,
+        now,
+      ),
+    ).toEqual({ ok: false, reason: "unknown_key" });
+
+    const nonCanonical = attestation();
+    const last = nonCanonical.signature.at(-1) ?? "";
+    // An Ed25519 signature's 86th base64url character has four unused bits.
+    // Flip only those bits so decoding yields the same 64 signature bytes.
+    const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    const index = alphabet.indexOf(last);
+    nonCanonical.signature = `${nonCanonical.signature.slice(0, -1)}${alphabet[index ^ 1]}`;
+    expect(Buffer.from(nonCanonical.signature, "base64url")).toEqual(
+      Buffer.from(attestation().signature, "base64url"),
+    );
+    expect(verifyXSummonAttestation(nonCanonical, expected, keysJson, now)).toEqual({
+      ok: false,
+      reason: "signature_invalid",
     });
   });
 });

--- a/packages/shared/src/__tests__/x-summon-attestation.test.ts
+++ b/packages/shared/src/__tests__/x-summon-attestation.test.ts
@@ -87,10 +87,13 @@ describe("authenticated X summon provenance", () => {
     ).toEqual({ ok: false, reason: "unknown_key" });
     expect(
       verifyXSummonAttestation(
-        attestation({ attestedAt: "2026-02-31T00:59:30.000Z" }),
+        attestation({
+          attestedAt: "2026-02-31T00:00:00.000Z",
+          expiresAt: "2026-03-03T00:04:00.000Z",
+        }),
         expected,
         keysJson,
-        now,
+        new Date("2026-03-03T00:01:00.000Z"),
       ),
     ).toEqual({ ok: false, reason: "stale" });
   });
@@ -107,12 +110,7 @@ describe("authenticated X summon provenance", () => {
 
   test("rejects inherited key ids and non-canonical signature encodings without throwing", () => {
     expect(
-      verifyXSummonAttestation(
-        attestation({ keyId: "toString" }),
-        expected,
-        keysJson,
-        now,
-      ),
+      verifyXSummonAttestation(attestation({ keyId: "toString" }), expected, keysJson, now),
     ).toEqual({ ok: false, reason: "unknown_key" });
 
     const nonCanonical = attestation();

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -40,6 +40,7 @@ export * from "./types/venue.js";
 // ─── Runtime-extensible webhook event registry (core ∪ plugin-declared) ───
 export { WebhookEventRegistry } from "./webhook-event-registry.js";
 export * from "./x-provider-action.js";
+export * from "./x-summon-attestation.js";
 
 // ─── Tenancy ───
 

--- a/packages/shared/src/provider-action.ts
+++ b/packages/shared/src/provider-action.ts
@@ -725,6 +725,10 @@ export interface ProviderRequestEnvelopeV1 {
    * provider request includes it.
    */
   policyInputDigest?: string;
+  /** Digest of an authenticated X summon provenance record. The signed record
+   * is stored separately in the immutable safe summary; this digest makes it a
+   * load-bearing part of requestHash without putting raw post content here. */
+  xSummonAttestationDigest?: string;
   idempotencyKeyHash: string;
   requestedAt: string;
   expiresAt: string;
@@ -793,6 +797,8 @@ function toEnvelopeObject(e: ProviderRequestEnvelopeV1): Record<string, unknown>
   };
   // Preserve the byte-for-byte hash of legacy envelopes that predate #229.
   if (e.policyInputDigest !== undefined) envelope.policyInputDigest = e.policyInputDigest;
+  if (e.xSummonAttestationDigest !== undefined)
+    envelope.xSummonAttestationDigest = e.xSummonAttestationDigest;
   return envelope;
 }
 

--- a/packages/shared/src/x-summon-attestation.ts
+++ b/packages/shared/src/x-summon-attestation.ts
@@ -1,0 +1,182 @@
+import { createPublicKey, verify } from "node:crypto";
+import { jcsStringify, sha256HexPrefixed } from "./provider-action.js";
+
+export const X_SUMMON_ATTESTATION_SCHEMA = "steward.x-summon-attestation.v1" as const;
+export const X_SUMMON_ATTESTATION_DOMAIN = "steward.x-summon-attestation.v1\n" as const;
+const MAX_VALIDITY_MS = 5 * 60_000;
+const MAX_FUTURE_SKEW_MS = 30_000;
+const EXACT_KEYS = new Set([
+  "schemaVersion",
+  "keyId",
+  "tenantId",
+  "workspaceId",
+  "actorAgentId",
+  "providerAccountId",
+  "operationKey",
+  "sourcePostId",
+  "idempotencyKeyHash",
+  "summoned",
+  "attestedAt",
+  "expiresAt",
+  "signature",
+]);
+const RFC3339_MILLIS = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+const B64URL_64 = /^[A-Za-z0-9_-]{86}$/;
+const B64URL_32 = /^[A-Za-z0-9_-]{43}$/;
+
+export interface XSummonAttestationV1 {
+  schemaVersion: typeof X_SUMMON_ATTESTATION_SCHEMA;
+  keyId: string;
+  tenantId: string;
+  workspaceId: string;
+  actorAgentId: string;
+  providerAccountId: string;
+  operationKey: "x.tweet.create";
+  sourcePostId: string;
+  idempotencyKeyHash: string;
+  summoned: true;
+  attestedAt: string;
+  expiresAt: string;
+  signature: string;
+}
+
+export interface XSummonAttestationExpected {
+  tenantId: string;
+  workspaceId: string;
+  actorAgentId: string;
+  providerAccountId: string;
+  sourcePostId: string;
+  idempotencyKeyHash: string;
+}
+
+function canonicalClaims(a: XSummonAttestationV1): Record<string, unknown> {
+  return {
+    schemaVersion: a.schemaVersion,
+    keyId: a.keyId,
+    tenantId: a.tenantId,
+    workspaceId: a.workspaceId,
+    actorAgentId: a.actorAgentId,
+    providerAccountId: a.providerAccountId,
+    operationKey: a.operationKey,
+    sourcePostId: a.sourcePostId,
+    idempotencyKeyHash: a.idempotencyKeyHash,
+    summoned: a.summoned,
+    attestedAt: a.attestedAt,
+    expiresAt: a.expiresAt,
+  };
+}
+
+export function xSummonAttestationSignatureInput(a: XSummonAttestationV1): string {
+  return `${X_SUMMON_ATTESTATION_DOMAIN}${jcsStringify(canonicalClaims(a))}`;
+}
+
+export function computeXSummonAttestationDigest(a: XSummonAttestationV1): string {
+  return sha256HexPrefixed(jcsStringify({ ...canonicalClaims(a), signature: a.signature }));
+}
+
+function parseAttestation(value: unknown): XSummonAttestationV1 | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const a = value as Record<string, unknown>;
+  if (
+    Object.keys(a).some((key) => !EXACT_KEYS.has(key)) ||
+    Object.keys(a).length !== EXACT_KEYS.size
+  )
+    return null;
+  if (
+    a.schemaVersion !== X_SUMMON_ATTESTATION_SCHEMA ||
+    typeof a.keyId !== "string" ||
+    !/^[A-Za-z0-9._-]{1,64}$/.test(a.keyId) ||
+    typeof a.tenantId !== "string" ||
+    typeof a.workspaceId !== "string" ||
+    typeof a.actorAgentId !== "string" ||
+    typeof a.providerAccountId !== "string" ||
+    a.operationKey !== "x.tweet.create" ||
+    typeof a.sourcePostId !== "string" ||
+    !/^[0-9]{1,25}$/.test(a.sourcePostId) ||
+    typeof a.idempotencyKeyHash !== "string" ||
+    !/^sha256:[0-9a-f]{64}$/.test(a.idempotencyKeyHash) ||
+    a.summoned !== true ||
+    typeof a.attestedAt !== "string" ||
+    !RFC3339_MILLIS.test(a.attestedAt) ||
+    typeof a.expiresAt !== "string" ||
+    !RFC3339_MILLIS.test(a.expiresAt) ||
+    typeof a.signature !== "string" ||
+    !B64URL_64.test(a.signature)
+  )
+    return null;
+  return a as unknown as XSummonAttestationV1;
+}
+
+function readKey(keysJson: string | undefined, keyId: string): Uint8Array | null {
+  if (!keysJson || keysJson.length > 16 * 1024) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(keysJson);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  const entries = Object.entries(parsed as Record<string, unknown>);
+  if (entries.length === 0 || entries.length > 16) return null;
+  for (const [id, value] of entries) {
+    if (!/^[A-Za-z0-9._-]{1,64}$/.test(id) || typeof value !== "string" || !B64URL_32.test(value))
+      return null;
+  }
+  const encoded = (parsed as Record<string, string>)[keyId];
+  return encoded ? new Uint8Array(Buffer.from(encoded, "base64url")) : null;
+}
+
+export type XSummonAttestationVerification =
+  | { ok: true; attestation: XSummonAttestationV1; digest: string }
+  | { ok: false; reason: string };
+
+export function verifyXSummonAttestation(
+  value: unknown,
+  expected: XSummonAttestationExpected,
+  keysJson: string | undefined,
+  now = new Date(),
+): XSummonAttestationVerification {
+  const a = parseAttestation(value);
+  if (!a) return { ok: false, reason: "malformed" };
+  if (
+    a.tenantId !== expected.tenantId ||
+    a.workspaceId !== expected.workspaceId ||
+    a.actorAgentId !== expected.actorAgentId ||
+    a.providerAccountId !== expected.providerAccountId ||
+    a.sourcePostId !== expected.sourcePostId ||
+    a.idempotencyKeyHash !== expected.idempotencyKeyHash
+  )
+    return { ok: false, reason: "binding_mismatch" };
+  const attestedAt = Date.parse(a.attestedAt);
+  const expiresAt = Date.parse(a.expiresAt);
+  if (
+    !Number.isFinite(attestedAt) ||
+    !Number.isFinite(expiresAt) ||
+    expiresAt <= attestedAt ||
+    expiresAt - attestedAt > MAX_VALIDITY_MS ||
+    attestedAt > now.getTime() + MAX_FUTURE_SKEW_MS ||
+    expiresAt <= now.getTime()
+  )
+    return { ok: false, reason: "stale" };
+  const rawKey = readKey(keysJson, a.keyId);
+  if (!rawKey || rawKey.byteLength !== 32) return { ok: false, reason: "unknown_key" };
+  try {
+    const derPrefix = Buffer.from("302a300506032b6570032100", "hex");
+    const publicKey = createPublicKey({
+      key: Buffer.concat([derPrefix, Buffer.from(rawKey)]),
+      format: "der",
+      type: "spki",
+    });
+    const valid = verify(
+      null,
+      Buffer.from(xSummonAttestationSignatureInput(a), "utf8"),
+      publicKey,
+      Buffer.from(a.signature, "base64url"),
+    );
+    return valid
+      ? { ok: true, attestation: a, digest: computeXSummonAttestationDigest(a) }
+      : { ok: false, reason: "signature_invalid" };
+  } catch {
+    return { ok: false, reason: "signature_invalid" };
+  }
+}

--- a/packages/shared/src/x-summon-attestation.ts
+++ b/packages/shared/src/x-summon-attestation.ts
@@ -8,6 +8,7 @@ const MAX_FUTURE_SKEW_MS = 30_000;
 const EXACT_KEYS = new Set([
   "schemaVersion",
   "keyId",
+  "audience",
   "tenantId",
   "workspaceId",
   "actorAgentId",
@@ -27,6 +28,8 @@ const B64URL_32 = /^[A-Za-z0-9_-]{43}$/;
 export interface XSummonAttestationV1 {
   schemaVersion: typeof X_SUMMON_ATTESTATION_SCHEMA;
   keyId: string;
+  /** Deployment-specific verifier audience (for example, steward-prod-us). */
+  audience: string;
   tenantId: string;
   workspaceId: string;
   actorAgentId: string;
@@ -41,6 +44,7 @@ export interface XSummonAttestationV1 {
 }
 
 export interface XSummonAttestationExpected {
+  audience: string;
   tenantId: string;
   workspaceId: string;
   actorAgentId: string;
@@ -53,6 +57,7 @@ function canonicalClaims(a: XSummonAttestationV1): Record<string, unknown> {
   return {
     schemaVersion: a.schemaVersion,
     keyId: a.keyId,
+    audience: a.audience,
     tenantId: a.tenantId,
     workspaceId: a.workspaceId,
     actorAgentId: a.actorAgentId,
@@ -86,6 +91,8 @@ function parseAttestation(value: unknown): XSummonAttestationV1 | null {
     a.schemaVersion !== X_SUMMON_ATTESTATION_SCHEMA ||
     typeof a.keyId !== "string" ||
     !/^[A-Za-z0-9._-]{1,64}$/.test(a.keyId) ||
+    typeof a.audience !== "string" ||
+    !/^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$/.test(a.audience) ||
     typeof a.tenantId !== "string" ||
     typeof a.workspaceId !== "string" ||
     typeof a.actorAgentId !== "string" ||
@@ -122,8 +129,13 @@ function readKey(keysJson: string | undefined, keyId: string): Uint8Array | null
     if (!/^[A-Za-z0-9._-]{1,64}$/.test(id) || typeof value !== "string" || !B64URL_32.test(value))
       return null;
   }
+  if (!Object.hasOwn(parsed, keyId)) return null;
   const encoded = (parsed as Record<string, string>)[keyId];
-  return encoded ? new Uint8Array(Buffer.from(encoded, "base64url")) : null;
+  if (!encoded) return null;
+  const decoded = Buffer.from(encoded, "base64url");
+  // Reject alternate encodings with non-zero unused bits. Otherwise the same
+  // key/signature bytes can have multiple textual digests.
+  return decoded.toString("base64url") === encoded ? new Uint8Array(decoded) : null;
 }
 
 export type XSummonAttestationVerification =
@@ -139,6 +151,7 @@ export function verifyXSummonAttestation(
   const a = parseAttestation(value);
   if (!a) return { ok: false, reason: "malformed" };
   if (
+    a.audience !== expected.audience ||
     a.tenantId !== expected.tenantId ||
     a.workspaceId !== expected.workspaceId ||
     a.actorAgentId !== expected.actorAgentId ||
@@ -152,6 +165,8 @@ export function verifyXSummonAttestation(
   if (
     !Number.isFinite(attestedAt) ||
     !Number.isFinite(expiresAt) ||
+    new Date(attestedAt).toISOString() !== a.attestedAt ||
+    new Date(expiresAt).toISOString() !== a.expiresAt ||
     expiresAt <= attestedAt ||
     expiresAt - attestedAt > MAX_VALIDITY_MS ||
     attestedAt > now.getTime() + MAX_FUTURE_SKEW_MS ||
@@ -167,11 +182,14 @@ export function verifyXSummonAttestation(
       format: "der",
       type: "spki",
     });
+    const signature = Buffer.from(a.signature, "base64url");
+    if (signature.toString("base64url") !== a.signature)
+      return { ok: false, reason: "signature_invalid" };
     const valid = verify(
       null,
       Buffer.from(xSummonAttestationSignatureInput(a), "utf8"),
       publicKey,
-      Buffer.from(a.signature, "base64url"),
+      signature,
     );
     return valid
       ? { ok: true, attestation: a, digest: computeXSummonAttestationDigest(a) }


### PR DESCRIPTION
## Summary

- replace caller-authoritative `summoned: true` with strict Ed25519 provider-adapter attestations
- bind provenance to tenant, workspace, actor, provider account, source post, operation, expiry, deployment audience, and idempotency-key hash
- revalidate the frozen signature and exact binding at proposal, approval resume, and final proxy dispatch
- bind the attestation digest into the immutable request envelope, replay-conflict paths, and required audit evidence without persisting post content or credentials
- fail closed on malformed keys, forged or stale signatures, key removal, scope/source/retry replay, concurrent rebinding, or envelope tampering

## Corrective replay proof

The optimistic and transaction-locked replay checks enforce the same `actionDigest`, `policyInputDigest`, and `xSummonAttestationDigest`. The real-Postgres regression deterministically places two differently-attested requests after the optimistic miss; the advisory lock permits one winner and returns `REPLAY_IDEMPOTENCY_CONFLICT` for the other.

## Exact validation

Exact head: `45e5cc1a0ec56d5e7329cc5b360086f680dd7747`
Exact base: `1dcfecbdb059ec1fd27dec6045eedee726b4962b`

- API dependency build graph: 21/21 successful
- shared + proxy + PGLite permissioned-X suites: 32 pass, 0 fail, 91 assertions
- real PostgreSQL 16 replay-race regression: 1 pass, 0 fail, 6 assertions
- Biome across nine implementation/regression files: clean
- `git diff --check`: clean

Hostile coverage includes forged signatures, expiry, overlong validity, unknown/removed keys, cross-tenant/workspace/agent/account/post/retry replay, concurrent retry-attestation rebinding, request-envelope tampering, caller-only `summoned: true`, approval-resume expiry, and final-dispatch revalidation.

Closes #359