### PR TITLE
feat(db): establish tenant RLS transaction groundwork

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,6 +223,11 @@ jobs:
         env:
           DATABASE_URL: "postgres://steward:steward_ci@localhost:5432/steward_test"
 
+      - name: RLS pool isolation proof (real Postgres)
+        run: bun test packages/db/src/__tests__/tenant-rls-postgres.test.ts
+        env:
+          DATABASE_URL: "postgres://steward:steward_ci@localhost:5432/steward_test"
+
       - name: Start API test server
         env:
           DATABASE_URL: "postgres://steward:steward_ci@localhost:5432/steward_test"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -313,6 +313,11 @@ jobs:
         env:
           DATABASE_URL: "postgres://steward:steward_ci@localhost:5432/steward_test"
 
+      - name: RLS pool isolation proof (real Postgres)
+        run: bun test packages/db/src/__tests__/tenant-rls-postgres.test.ts
+        env:
+          DATABASE_URL: "postgres://steward:steward_ci@localhost:5432/steward_test"
+
       - name: Start API test server
         env:
           DATABASE_URL: "postgres://steward:steward_ci@localhost:5432/steward_test"

--- a/docs/security/database-rls-rollout.mdx
+++ b/docs/security/database-rls-rollout.mdx
@@ -24,6 +24,23 @@ unit of work on that same transaction object, and releases it. The `true`
 argument is load-bearing: it makes the setting transaction-local and prevents
 pool reuse from inheriting a prior tenant.
 
+Before binding, the helper also requires the connection's tenant setting to be
+empty. A non-empty value indicates session-level contamination and fails
+closed. The helper clears that session-level value, commits the cleanup, and
+only then reports the error; throwing before commit would roll the reset back
+and return a contaminated connection to the pool. It also rejects a Drizzle
+`PgTransaction` as its database argument: a `SET LOCAL` issued by a nested
+`.transaction()` runs inside a savepoint and would otherwise survive its
+release until the caller's outer transaction ended. Tenant contexts are tracked
+by object identity, not a copyable property, so cloning a context cannot change
+its tenant authority.
+
+Custom PostgreSQL settings are assignable by the application role. This design
+therefore catches missing application predicates and connection-lifecycle bugs;
+it is not a boundary against SQL injection or arbitrary SQL execution by a
+compromised application process. Tenant transaction callbacks must never
+execute claimant-supplied SQL or expose a general-purpose query interface.
+
 `neon-http` has no callback transaction support in the current Drizzle version.
 Workers must move to a transaction-capable transport (Neon WebSockets or
 Cloudflare Hyperdrive with a PostgreSQL driver) before RLS activation. The
@@ -43,12 +60,14 @@ fixed-shape, SQL-language SECURITY DEFINER functions for these lookups:
 | `agent_subject(agent_id, tenant_id, jti)` | agent JWT signature, issuer, audience, expiry, and scope checks | exact agent and optional session-signer state |
 | `app_client_subject(tenant_id, client_id)` | syntactically valid app id | active/retiring secret hashes and client status |
 
-Each function must set `search_path = pg_catalog, public`, use no dynamic SQL,
-select explicit columns, return at most the rows needed for credential
-verification, and be owned by a role that the application cannot assume.
-Revoke all schema/function privileges from `PUBLIC`; grant EXECUTE only to the
-NO-BYPASS application role. No general-purpose bootstrap query or arbitrary
-tenant setter is permitted.
+Each function must set `search_path = pg_catalog`, fully schema-qualify every
+application relation, use no dynamic SQL, select explicit columns, return at
+most the rows needed for credential verification, and be owned by a role that
+the application cannot assume. Do not put `public` or any application-writable
+schema on a SECURITY DEFINER search path. Revoke `CREATE` on schema `public`
+and all bootstrap schema/function privileges from `PUBLIC`; grant EXECUTE only
+to the NO-BYPASS application role. No general-purpose bootstrap query or
+arbitrary tenant setter is permitted.
 
 After a bootstrap credential is verified, the application mints the trusted
 context and starts a tenant transaction. Bootstrap output is not itself tenant

--- a/docs/security/database-rls-rollout.mdx
+++ b/docs/security/database-rls-rollout.mdx
@@ -1,0 +1,110 @@
+---
+title: "PostgreSQL tenant RLS rollout"
+description: "SEC-169 activation design, bootstrap boundary, runtime requirements, and rollback"
+---
+
+# PostgreSQL tenant RLS rollout
+
+SEC-169 is not active yet. Application predicates remain the production tenant
+boundary until every activation gate below is complete. The executable
+`withTenantRlsTransaction` helper and schema inventory are groundwork; they do
+not justify enabling a partial policy set.
+
+## Non-forgeable context boundary
+
+Only verified JWT/API-key/app-secret middleware may mint
+`tenantContextFromAuthenticatedPrincipal`. A route parameter, header, JSON
+field, or provider payload must never be passed directly to the RLS helper.
+Background workers must first enumerate tenant ids using a maintenance path,
+then mint one `tenantContextForInternalJob` and one transaction per tenant.
+
+The helper checks out one transaction connection, executes
+`set_config('steward.tenant_id', tenant_id, true)`, verifies the value, runs the
+unit of work on that same transaction object, and releases it. The `true`
+argument is load-bearing: it makes the setting transaction-local and prevents
+pool reuse from inheriting a prior tenant.
+
+`neon-http` has no callback transaction support in the current Drizzle version.
+Workers must move to a transaction-capable transport (Neon WebSockets or
+Cloudflare Hyperdrive with a PostgreSQL driver) before RLS activation. The
+helper rejects `neon-http` rather than silently falling back to a session GUC or
+separate HTTP statements.
+
+## Bootstrap SECURITY DEFINER surface
+
+Authentication necessarily reads before tenant context exists. Activation must
+create a separate, NOLOGIN-owned `steward_bootstrap` schema containing only
+fixed-shape, SQL-language SECURITY DEFINER functions for these lookups:
+
+| Function | Input accepted only after | Narrow result |
+| --- | --- | --- |
+| `tenant_api_key_subject(tenant_id)` | tenant id is a lookup hint; supplied key is still constant-time verified in app | tenant id, name, API-key hash |
+| `session_subject(user_id, tenant_id)` | JWT signature, type, expiry, and revocation checks | user active/guest state and exact membership role |
+| `agent_subject(agent_id, tenant_id, jti)` | agent JWT signature, issuer, audience, expiry, and scope checks | exact agent and optional session-signer state |
+| `app_client_subject(tenant_id, client_id)` | syntactically valid app id | active/retiring secret hashes and client status |
+
+Each function must set `search_path = pg_catalog, public`, use no dynamic SQL,
+select explicit columns, return at most the rows needed for credential
+verification, and be owned by a role that the application cannot assume.
+Revoke all schema/function privileges from `PUBLIC`; grant EXECUTE only to the
+NO-BYPASS application role. No general-purpose bootstrap query or arbitrary
+tenant setter is permitted.
+
+After a bootstrap credential is verified, the application mints the trusted
+context and starts a tenant transaction. Bootstrap output is not itself tenant
+authority.
+
+## Policy inventory
+
+`packages/db/src/rls-inventory.ts` is the machine-checked inventory. CI fails if
+a Drizzle table is added without classification.
+
+- Direct tables compare their `tenant_id` with
+  `NULLIF(current_setting('steward.tenant_id', true), '')` in both `USING` and
+  `WITH CHECK`.
+- Indirect tables (`policies`, `transactions`, encrypted key/wallet tables,
+  reputation cache, and archive chunks) use an `EXISTS` policy through their
+  tenant-owned parent. Parent indexes and immutable ownership constraints are
+  activation prerequisites.
+- EVM nonce tables cannot safely infer a tenant from wallet address because an
+  address is not tenant-unique. Add and backfill `tenant_id` plus a composite
+  ownership foreign key before enabling their policies.
+- `user_push_subscriptions` has intentionally nullable `tenant_id`. Tenant
+  subscriptions and global user subscriptions require separate, explicit
+  policies; it must not inherit the uniform direct-table policy generator.
+- `approval_queue` is also hybrid: provider-action rows carry `tenant_id`, while
+  legacy transaction approvals derive tenant ownership through `agent_id`.
+- `tenants` is a bootstrap root: tenant transactions see only `id = current
+  tenant`; credential lookup uses the restricted functions above.
+- Global user identity tables remain outside tenant RLS because one user can
+  belong to several tenants. Tenant-owned access must join through the RLS
+  protected `user_tenants` table. `registry_index` is a public-chain cache.
+
+Partitioned tables require policies on the parent plus an activation assertion
+over `pg_partition_tree`. The catalog gate must also reject every non-inventory
+table in future migrations.
+
+## Roles and activation order
+
+1. Create a NOLOGIN migration owner and a distinct LOGIN application role with
+   `rolsuper = false`, `rolbypassrls = false`, and no membership in the owner.
+2. Deploy transaction-capable Bun and Workers paths. Convert request handlers
+   and background jobs to use only the transaction object inside a trusted
+   tenant context.
+3. Deploy the restricted bootstrap functions and switch pre-context auth reads.
+4. Apply policies to every direct and indirect tenant table, then `ENABLE ROW
+   LEVEL SECURITY` and `FORCE ROW LEVEL SECURITY` in one maintenance window.
+5. Assert at startup that the connected role is neither table owner nor
+   BYPASSRLS and that every catalog table/partition matches the inventory.
+6. Run real-Postgres cross-tenant read/write/upsert/delete/join tests plus
+   concurrent pool-reuse and background-job tests against the deployment role.
+
+## Rollback
+
+Rollback is an operator action using the migration role, never a permission
+granted to the API. Stop API/workers, retain application-layer tenant
+predicates, disable RLS on the complete activated table set in one audited
+maintenance transaction, roll back the application to pre-RLS transaction
+plumbing, and restart. Do not selectively disable one policy while routine
+traffic continues. Preserve the catalog snapshot, migration id, actor, time,
+and incident reason in the audit record.

--- a/packages/db/src/__tests__/rls-inventory.test.ts
+++ b/packages/db/src/__tests__/rls-inventory.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { getTableName } from "drizzle-orm";
+import {
+  ALL_INVENTORIED_TABLES,
+  BOOTSTRAP_ROOT_TABLES,
+  DIRECT_TENANT_TABLES,
+  HYBRID_SCOPE_TABLES,
+  INDIRECT_TENANT_TABLES,
+  INTENTIONALLY_GLOBAL_TABLES,
+  TENANT_COLUMN_BACKFILL_TABLES,
+} from "../rls-inventory";
+import * as schema from "../schema";
+import * as authSchema from "../schema-auth";
+
+function schemaTableNames(): string[] {
+  const names: string[] = [];
+  for (const value of Object.values({ ...schema, ...authSchema })) {
+    try {
+      const name = getTableName(value as never);
+      if (typeof name === "string") names.push(name);
+    } catch {
+      // Enums, relations, and helpers are intentionally not tables.
+    }
+  }
+  return [...new Set(names)].sort();
+}
+
+describe("SEC-169 RLS inventory", () => {
+  test("classifies every schema table exactly once", () => {
+    const inventory = [...ALL_INVENTORIED_TABLES].sort();
+    expect(inventory).toEqual([...new Set(inventory)]);
+    expect(inventory).toEqual(schemaTableNames());
+  });
+
+  test("direct tables really expose tenantId and exclusions are justified", () => {
+    const tables = Object.values({ ...schema, ...authSchema }) as Array<Record<string, unknown>>;
+    const directNames = tables
+      .filter((table) => table && typeof table === "object" && "tenantId" in table)
+      .map((table) => getTableName(table as never))
+      .filter((name): name is string => typeof name === "string")
+      .sort();
+    expect([...DIRECT_TENANT_TABLES, ...Object.keys(HYBRID_SCOPE_TABLES)].sort()).toEqual(
+      directNames,
+    );
+    for (const table of tables.filter(
+      (value) => value && typeof value === "object" && "tenantId" in value,
+    )) {
+      const name = getTableName(table as never);
+      const tenantColumn = table.tenantId as { notNull?: boolean };
+      if (name in HYBRID_SCOPE_TABLES) expect(tenantColumn.notNull).toBe(false);
+      else expect(tenantColumn.notNull).toBe(true);
+    }
+    for (const rationale of [
+      ...Object.values(INDIRECT_TENANT_TABLES),
+      ...Object.values(TENANT_COLUMN_BACKFILL_TABLES),
+      ...Object.values(HYBRID_SCOPE_TABLES),
+      ...Object.values(BOOTSTRAP_ROOT_TABLES),
+      ...Object.values(INTENTIONALLY_GLOBAL_TABLES),
+    ]) {
+      expect(rationale.length).toBeGreaterThan(20);
+    }
+  });
+});

--- a/packages/db/src/__tests__/tenant-rls-context.test.ts
+++ b/packages/db/src/__tests__/tenant-rls-context.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import {
+  assertTenantRlsDriver,
+  tenantContextForInternalJob,
+  tenantContextFromAuthenticatedPrincipal,
+  withTenantRlsTransaction,
+} from "../tenant-rls-context";
+
+describe("tenant RLS transaction context", () => {
+  test("binds and verifies context before exposing the transaction", async () => {
+    const calls: string[] = [];
+    let executeCount = 0;
+    const tx = {
+      async execute() {
+        executeCount += 1;
+        calls.push(`execute-${executeCount}`);
+        return executeCount === 2 ? [{ tenant_id: "tenant-a" }] : [];
+      },
+    };
+    const db = {
+      async transaction<T>(callback: (value: typeof tx) => Promise<T>) {
+        calls.push("transaction");
+        return callback(tx);
+      },
+    };
+    const context = tenantContextFromAuthenticatedPrincipal({
+      tenantId: "tenant-a",
+      method: "session-jwt",
+      subject: "user:123",
+    });
+    const result = await withTenantRlsTransaction(db, "postgres-js", context, async () => {
+      calls.push("callback");
+      return 42;
+    });
+    expect(result).toBe(42);
+    expect(calls).toEqual(["transaction", "execute-1", "execute-2", "callback"]);
+    expect(Object.isFrozen(context)).toBe(true);
+    expect(Object.isFrozen(context.authority)).toBe(true);
+  });
+
+  test("rejects invalid identities, forged objects, and transactionless Workers", async () => {
+    expect(() =>
+      tenantContextFromAuthenticatedPrincipal({
+        tenantId: "tenant-a\nSET ROLE owner",
+        method: "jwt",
+        subject: "user:1",
+      }),
+    ).toThrow("RLS_TENANT_CONTEXT_INVALID");
+    expect(() => tenantContextForInternalJob({ tenantId: "tenant-a", job: "" })).toThrow(
+      "RLS_TENANT_JOB_INVALID",
+    );
+    expect(() => assertTenantRlsDriver("neon-http")).toThrow("RLS_TRANSACTION_UNSUPPORTED");
+
+    const db = { transaction: async () => undefined };
+    await expect(
+      withTenantRlsTransaction(
+        db as never,
+        "postgres-js",
+        {
+          tenantId: "tenant-a",
+          authority: { kind: "internal-job", job: "forged" },
+        } as never,
+        async () => undefined,
+      ),
+    ).rejects.toThrow("RLS_TENANT_CONTEXT_UNTRUSTED");
+  });
+
+  test("fails before opening a transaction on neon-http", async () => {
+    let opened = false;
+    const db = {
+      async transaction() {
+        opened = true;
+      },
+    };
+    await expect(
+      withTenantRlsTransaction(
+        db as never,
+        "neon-http",
+        tenantContextForInternalJob({ tenantId: "tenant-a", job: "retention" }),
+        async () => undefined,
+      ),
+    ).rejects.toThrow("RLS_TRANSACTION_UNSUPPORTED");
+    expect(opened).toBe(false);
+  });
+});

--- a/packages/db/src/__tests__/tenant-rls-context.test.ts
+++ b/packages/db/src/__tests__/tenant-rls-context.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { PgTransaction } from "drizzle-orm/pg-core";
 import {
   assertTenantRlsDriver,
   tenantContextForInternalJob,
@@ -14,7 +15,7 @@ describe("tenant RLS transaction context", () => {
       async execute() {
         executeCount += 1;
         calls.push(`execute-${executeCount}`);
-        return executeCount === 2 ? [{ tenant_id: "tenant-a" }] : [];
+        return executeCount === 3 ? [{ tenant_id: "tenant-a" }] : [];
       },
     };
     const db = {
@@ -33,7 +34,7 @@ describe("tenant RLS transaction context", () => {
       return 42;
     });
     expect(result).toBe(42);
-    expect(calls).toEqual(["transaction", "execute-1", "execute-2", "callback"]);
+    expect(calls).toEqual(["transaction", "execute-1", "execute-2", "execute-3", "callback"]);
     expect(Object.isFrozen(context)).toBe(true);
     expect(Object.isFrozen(context.authority)).toBe(true);
   });
@@ -49,6 +50,13 @@ describe("tenant RLS transaction context", () => {
     expect(() => tenantContextForInternalJob({ tenantId: "tenant-a", job: "" })).toThrow(
       "RLS_TENANT_JOB_INVALID",
     );
+    expect(() =>
+      tenantContextFromAuthenticatedPrincipal({
+        tenantId: "tenant-a",
+        method: "session-jwt\nforged",
+        subject: "user:1",
+      }),
+    ).toThrow("RLS_TENANT_AUTHORITY_INVALID");
     expect(() => assertTenantRlsDriver("neon-http")).toThrow("RLS_TRANSACTION_UNSUPPORTED");
 
     const db = { transaction: async () => undefined };
@@ -63,6 +71,64 @@ describe("tenant RLS transaction context", () => {
         async () => undefined,
       ),
     ).rejects.toThrow("RLS_TENANT_CONTEXT_UNTRUSTED");
+
+    const genuine = tenantContextForInternalJob({ tenantId: "tenant-a", job: "retention" });
+    const cloned = Object.assign({}, genuine, { tenantId: "tenant-b" });
+    await expect(
+      withTenantRlsTransaction(db as never, "postgres-js", cloned as never, async () => undefined),
+    ).rejects.toThrow("RLS_TENANT_CONTEXT_UNTRUSTED");
+  });
+
+  test("rejects a dirty connection before changing or exposing it", async () => {
+    let callbackCalled = false;
+    let executeCount = 0;
+    const tx = {
+      async execute() {
+        executeCount += 1;
+        return executeCount === 1 ? [{ tenant_id: "tenant-from-prior-session" }] : [];
+      },
+    };
+    const db = {
+      async transaction<T>(callback: (value: typeof tx) => Promise<T>) {
+        return callback(tx);
+      },
+    };
+    await expect(
+      withTenantRlsTransaction(
+        db,
+        "postgres-js",
+        tenantContextForInternalJob({ tenantId: "tenant-a", job: "retention" }),
+        async () => {
+          callbackCalled = true;
+        },
+      ),
+    ).rejects.toThrow("RLS_TENANT_CONTEXT_DIRTY");
+    expect(executeCount).toBe(3);
+    expect(callbackCalled).toBe(false);
+  });
+
+  test("rejects a nested transaction before binding tenant authority", async () => {
+    let executeCount = 0;
+    const tx = {
+      async execute() {
+        executeCount += 1;
+        return [];
+      },
+    };
+    const db = Object.assign(Object.create(PgTransaction.prototype), {
+      async transaction<T>(callback: (value: typeof tx) => Promise<T>) {
+        return callback(tx);
+      },
+    });
+    await expect(
+      withTenantRlsTransaction(
+        db,
+        "postgres-js",
+        tenantContextForInternalJob({ tenantId: "tenant-a", job: "retention" }),
+        async () => undefined,
+      ),
+    ).rejects.toThrow("RLS_TENANT_TRANSACTION_NESTED");
+    expect(executeCount).toBe(0);
   });
 
   test("fails before opening a transaction on neon-http", async () => {

--- a/packages/db/src/__tests__/tenant-rls-postgres.test.ts
+++ b/packages/db/src/__tests__/tenant-rls-postgres.test.ts
@@ -1,0 +1,102 @@
+import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { sql } from "drizzle-orm";
+import { createDb } from "../client";
+import { tenantContextForInternalJob, withTenantRlsTransaction } from "../tenant-rls-context";
+
+const describeWithPostgres = process.env.DATABASE_URL ? describe : describe.skip;
+setDefaultTimeout(30_000);
+const schemaName = `rls_test_${randomUUID().replaceAll("-", "")}`;
+const tableName = `${schemaName}.records`;
+
+function rowsOf(value: unknown): Array<Record<string, unknown>> {
+  return Array.isArray(value) ? value : ((value as { rows?: [] } | null)?.rows ?? []);
+}
+
+async function expectRlsRejected(operation: Promise<unknown>): Promise<void> {
+  try {
+    await operation;
+    throw new Error("expected RLS rejection");
+  } catch (error) {
+    const outer = error as { message?: string; code?: string; cause?: unknown };
+    const cause = outer.cause as { message?: string; code?: string } | undefined;
+    expect(cause?.code ?? outer.code).toBe("42501");
+    expect(`${outer.message ?? ""} ${cause?.message ?? ""}`).toMatch(/row-level security policy/);
+  }
+}
+
+describeWithPostgres("SEC-169 transaction context on a real Postgres pool", () => {
+  let handle: ReturnType<typeof createDb>;
+
+  beforeAll(async () => {
+    handle = createDb(process.env.DATABASE_URL as string);
+    const roleRows = await handle.client`
+      SELECT rolbypassrls, rolsuper FROM pg_roles WHERE rolname = current_user
+    `;
+    expect(roleRows[0]?.rolbypassrls).toBe(false);
+    expect(roleRows[0]?.rolsuper).toBe(false);
+    await handle.client.unsafe(`CREATE SCHEMA ${schemaName}`);
+    await handle.client.unsafe(`
+      CREATE TABLE ${tableName} (
+        id text PRIMARY KEY,
+        tenant_id text NOT NULL,
+        value text NOT NULL
+      );
+      INSERT INTO ${tableName} VALUES ('a-seed', 'tenant-a', 'a'), ('b-seed', 'tenant-b', 'b');
+      ALTER TABLE ${tableName} ENABLE ROW LEVEL SECURITY;
+      ALTER TABLE ${tableName} FORCE ROW LEVEL SECURITY;
+      CREATE POLICY tenant_isolation ON ${tableName}
+        USING (tenant_id = NULLIF(current_setting('steward.tenant_id', true), ''))
+        WITH CHECK (tenant_id = NULLIF(current_setting('steward.tenant_id', true), ''));
+    `);
+  });
+
+  afterAll(async () => {
+    await handle.client.unsafe(`DROP SCHEMA IF EXISTS ${schemaName} CASCADE`);
+    await handle.client.end();
+  });
+
+  test("missing context denies reads and writes", async () => {
+    const rows = await handle.client.unsafe(`SELECT * FROM ${tableName}`);
+    expect(rows).toHaveLength(0);
+    await expectRlsRejected(
+      handle.client.unsafe(`INSERT INTO ${tableName} VALUES ('missing', 'tenant-a', 'must fail')`),
+    );
+  });
+
+  test("concurrent pooled transactions cannot cross tenants or leak context", async () => {
+    const tasks = Array.from({ length: 24 }, async (_, index) => {
+      const tenantId = index % 2 === 0 ? "tenant-a" : "tenant-b";
+      const context = tenantContextForInternalJob({ tenantId, job: "rls-concurrency-test" });
+      return withTenantRlsTransaction(handle.db as never, "postgres-js", context, async (tx) => {
+        const visible = rowsOf(await tx.execute(sql.raw(`SELECT tenant_id FROM ${tableName}`)));
+        expect(visible.length).toBeGreaterThan(0);
+        expect(visible.every((row) => row.tenant_id === tenantId)).toBe(true);
+        return tenantId;
+      });
+    });
+    const results = await Promise.all(tasks);
+    expect(results).toHaveLength(24);
+
+    // Every new unit of work starts without context, regardless of which pooled
+    // connection served a prior tenant transaction.
+    const resetChecks = await Promise.all(
+      Array.from({ length: 12 }, () => handle.client.unsafe(`SELECT * FROM ${tableName}`)),
+    );
+    expect(resetChecks.every((rows) => rows.length === 0)).toBe(true);
+  });
+
+  test("WITH CHECK rejects a cross-tenant write", async () => {
+    const context = tenantContextForInternalJob({
+      tenantId: "tenant-a",
+      job: "rls-cross-tenant-write-test",
+    });
+    await expectRlsRejected(
+      withTenantRlsTransaction(handle.db as never, "postgres-js", context, async (tx) =>
+        tx.execute(
+          sql.raw(`INSERT INTO ${tableName} VALUES ('bad-write', 'tenant-b', 'must fail')`),
+        ),
+      ),
+    );
+  });
+});

--- a/packages/db/src/__tests__/tenant-rls-postgres.test.ts
+++ b/packages/db/src/__tests__/tenant-rls-postgres.test.ts
@@ -1,6 +1,8 @@
 import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { randomUUID } from "node:crypto";
 import { sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
 import { createDb } from "../client";
 import { tenantContextForInternalJob, withTenantRlsTransaction } from "../tenant-rls-context";
 
@@ -91,6 +93,34 @@ describeWithPostgres("SEC-169 transaction context on a real Postgres pool", () =
     );
   });
 
+  test("detects and clears a session-contaminated pooled connection", async () => {
+    const contaminatedClient = postgres(process.env.DATABASE_URL as string, {
+      max: 1,
+      prepare: false,
+    });
+    const contaminatedDb = drizzle(contaminatedClient);
+    try {
+      await contaminatedClient`SELECT set_config('steward.tenant_id', 'tenant-b', false)`;
+      await expect(
+        withTenantRlsTransaction(
+          contaminatedDb,
+          "postgres-js",
+          tenantContextForInternalJob({
+            tenantId: "tenant-a",
+            job: "rls-dirty-session-test",
+          }),
+          async () => undefined,
+        ),
+      ).rejects.toThrow("RLS_TENANT_CONTEXT_DIRTY");
+      const setting = await contaminatedClient`
+        SELECT NULLIF(current_setting('steward.tenant_id', true), '') AS tenant_id
+      `;
+      expect(setting[0]?.tenant_id ?? null).toBeNull();
+    } finally {
+      await contaminatedClient.end();
+    }
+  });
+
   test("concurrent pooled transactions cannot cross tenants or leak context", async () => {
     const tasks = Array.from({ length: 24 }, async (_, index) => {
       const tenantId = index % 2 === 0 ? "tenant-a" : "tenant-b";
@@ -125,5 +155,41 @@ describeWithPostgres("SEC-169 transaction context on a real Postgres pool", () =
         ),
       ),
     );
+  });
+
+  test("rollback clears context and nesting cannot replace an outer tenant", async () => {
+    const context = tenantContextForInternalJob({
+      tenantId: "tenant-a",
+      job: "rls-rollback-test",
+    });
+    await expect(
+      withTenantRlsTransaction(handle.db as never, "postgres-js", context, async () => {
+        throw new Error("ROLL_BACK_ME");
+      }),
+    ).rejects.toThrow("ROLL_BACK_ME");
+    const postRollback = await Promise.all(
+      Array.from({ length: 12 }, () => handle.client.unsafe(`SELECT * FROM ${tableName}`)),
+    );
+    expect(postRollback.every((rows) => rows.length === 0)).toBe(true);
+
+    await handle.db.transaction(async (outerTx) => {
+      await expect(
+        withTenantRlsTransaction(
+          outerTx as never,
+          "postgres-js",
+          tenantContextForInternalJob({
+            tenantId: "tenant-b",
+            job: "rls-nested-transaction-test",
+          }),
+          async () => undefined,
+        ),
+      ).rejects.toThrow("RLS_TENANT_TRANSACTION_NESTED");
+      const tenantSetting = rowsOf(
+        await outerTx.execute(
+          sql`SELECT NULLIF(current_setting('steward.tenant_id', true), '') AS tenant_id`,
+        ),
+      );
+      expect(tenantSetting[0]?.tenant_id ?? null).toBeNull();
+    });
   });
 });

--- a/packages/db/src/__tests__/tenant-rls-postgres.test.ts
+++ b/packages/db/src/__tests__/tenant-rls-postgres.test.ts
@@ -8,6 +8,8 @@ const describeWithPostgres = process.env.DATABASE_URL ? describe : describe.skip
 setDefaultTimeout(30_000);
 const schemaName = `rls_test_${randomUUID().replaceAll("-", "")}`;
 const tableName = `${schemaName}.records`;
+const roleName = `rls_role_${randomUUID().replaceAll("-", "")}`;
+const rolePassword = randomUUID().replaceAll("-", "");
 
 function rowsOf(value: unknown): Array<Record<string, unknown>> {
   return Array.isArray(value) ? value : ((value as { rows?: [] } | null)?.rows ?? []);
@@ -27,15 +29,36 @@ async function expectRlsRejected(operation: Promise<unknown>): Promise<void> {
 
 describeWithPostgres("SEC-169 transaction context on a real Postgres pool", () => {
   let handle: ReturnType<typeof createDb>;
+  let adminHandle: ReturnType<typeof createDb> | undefined;
 
   beforeAll(async () => {
-    handle = createDb(process.env.DATABASE_URL as string);
+    const initialHandle = createDb(process.env.DATABASE_URL as string);
+    const initialRoleRows = await initialHandle.client`
+      SELECT rolbypassrls, rolsuper FROM pg_roles WHERE rolname = current_user
+    `;
+    if (initialRoleRows[0]?.rolbypassrls || initialRoleRows[0]?.rolsuper) {
+      // GitHub's Postgres service user is the bootstrap superuser. Create the
+      // role whose production properties we actually need to prove, then run
+      // every RLS assertion through its independent login/pool.
+      adminHandle = initialHandle;
+      await adminHandle.client.unsafe(
+        `CREATE ROLE ${roleName} LOGIN PASSWORD '${rolePassword}' ` +
+          "NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT NOBYPASSRLS",
+      );
+      await adminHandle.client.unsafe(`CREATE SCHEMA ${schemaName} AUTHORIZATION ${roleName}`);
+      const restrictedUrl = new URL(process.env.DATABASE_URL as string);
+      restrictedUrl.username = roleName;
+      restrictedUrl.password = rolePassword;
+      handle = createDb(restrictedUrl.toString());
+    } else {
+      handle = initialHandle;
+      await handle.client.unsafe(`CREATE SCHEMA ${schemaName}`);
+    }
     const roleRows = await handle.client`
       SELECT rolbypassrls, rolsuper FROM pg_roles WHERE rolname = current_user
     `;
     expect(roleRows[0]?.rolbypassrls).toBe(false);
     expect(roleRows[0]?.rolsuper).toBe(false);
-    await handle.client.unsafe(`CREATE SCHEMA ${schemaName}`);
     await handle.client.unsafe(`
       CREATE TABLE ${tableName} (
         id text PRIMARY KEY,
@@ -54,6 +77,10 @@ describeWithPostgres("SEC-169 transaction context on a real Postgres pool", () =
   afterAll(async () => {
     await handle.client.unsafe(`DROP SCHEMA IF EXISTS ${schemaName} CASCADE`);
     await handle.client.end();
+    if (adminHandle) {
+      await adminHandle.client.unsafe(`DROP ROLE IF EXISTS ${roleName}`);
+      await adminHandle.client.end();
+    }
   });
 
   test("missing context denies reads and writes", async () => {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -43,10 +43,27 @@ export {
   runPluginMigrations,
   sanitizePluginMigrationId,
 } from "./plugin-migrate";
+export {
+  ALL_INVENTORIED_TABLES,
+  BOOTSTRAP_ROOT_TABLES,
+  DIRECT_TENANT_TABLES,
+  HYBRID_SCOPE_TABLES,
+  INDIRECT_TENANT_TABLES,
+  INTENTIONALLY_GLOBAL_TABLES,
+  TENANT_COLUMN_BACKFILL_TABLES,
+} from "./rls-inventory";
 // PGLite exports live in the `@stwd/db/pglite` subpath so Cloudflare Worker
 // bundles can import `@stwd/db` without pulling node:fs/node:path dependencies.
 export * from "./schema";
 export * from "./schema-auth";
+export {
+  assertTenantRlsDriver,
+  type TenantRlsDriver,
+  type TrustedTenantContext,
+  tenantContextForInternalJob,
+  tenantContextFromAuthenticatedPrincipal,
+  withTenantRlsTransaction,
+} from "./tenant-rls-context";
 
 import type { Agent, Policy, Transaction } from "./schema";
 import { policyTypeEnum } from "./schema";

--- a/packages/db/src/rls-inventory.ts
+++ b/packages/db/src/rls-inventory.ts
@@ -1,0 +1,105 @@
+/**
+ * SEC-169 inventory. Every Drizzle table must appear exactly once. Activation
+ * migrations consume these categories to choose direct, join-derived,
+ * bootstrap-root, or intentionally-global policy treatment.
+ */
+export const DIRECT_TENANT_TABLES = [
+  "agent_key_quorums",
+  "agent_policies",
+  "agent_registrations",
+  "agent_signers",
+  "agents",
+  "audit_archives",
+  "audit_chain_heads",
+  "audit_checkpoints",
+  "audit_events",
+  "audit_retention_policies",
+  "auto_approval_rules",
+  "condition_set_items",
+  "condition_sets",
+  "digital_asset_account_aggregations",
+  "digital_asset_account_wallets",
+  "digital_asset_accounts",
+  "execution_authorization_nonces",
+  "global_wallet_action_confirmations",
+  "intents",
+  "pending_proxy_requests",
+  "policy_templates",
+  "provider_accounts",
+  "provider_action_approvals",
+  "provider_action_audit_outbox",
+  "provider_action_bindings",
+  "provider_action_reservation_generations",
+  "provider_agent_budgets",
+  "provider_authority_tenant_state",
+  "provider_grants",
+  "provider_operations",
+  "provider_role_bindings",
+  "proxy_audit_log",
+  "refresh_tokens",
+  "secret_routes",
+  "secrets",
+  "session_signers",
+  "sponsored_gas_events",
+  "tenant_app_client_secrets",
+  "tenant_app_clients",
+  "tenant_configs",
+  "tenant_invitations",
+  "tenant_request_signing_keys",
+  "tenant_saml_assertion_replays",
+  "tenant_saml_authn_requests",
+  "tenant_saml_sso_configs",
+  "tenant_sso_domains",
+  "trade_sessions",
+  "user_tenants",
+  "user_wallet_app_consents",
+  "vault_signing_freezes",
+  "webhook_configs",
+  "webhook_deliveries",
+  "workspaces",
+] as const;
+
+export const INDIRECT_TENANT_TABLES = {
+  agent_wallets: "EXISTS agents(id = agent_id AND tenant_id = current tenant)",
+  audit_archive_chunks: "EXISTS audit_archives(id = archive_id AND tenant_id = current tenant)",
+  encrypted_chain_keys: "EXISTS agents(id = agent_id AND tenant_id = current tenant)",
+  encrypted_keys: "EXISTS agents(id = agent_id AND tenant_id = current tenant)",
+  policies: "EXISTS agents(id = agent_id AND tenant_id = current tenant)",
+  reputation_cache: "EXISTS agents(id = agent_id AND tenant_id = current tenant)",
+  transactions: "EXISTS agents(id = agent_id AND tenant_id = current tenant)",
+} as const;
+
+export const TENANT_COLUMN_BACKFILL_TABLES = {
+  evm_wallet_nonce_inflight:
+    "wallet addresses are not tenant-unique; add tenant_id and a composite ownership FK before RLS",
+  evm_wallet_nonces:
+    "wallet addresses are not tenant-unique; add tenant_id and a composite ownership FK before RLS",
+} as const;
+
+export const HYBRID_SCOPE_TABLES = {
+  approval_queue:
+    "provider approvals have tenant_id; legacy transaction approvals derive tenant through agent_id",
+  user_push_subscriptions:
+    "tenant_id is nullable for global user subscriptions; tenant and global access need separate policies",
+} as const;
+
+export const BOOTSTRAP_ROOT_TABLES = {
+  tenants: "credential/JWT bootstrap resolves the tenant before SET LOCAL",
+} as const;
+
+export const INTENTIONALLY_GLOBAL_TABLES = {
+  accounts: "global user OAuth identities; tenant access derives through user_tenants",
+  authenticators: "global user WebAuthn identities; tenant access derives through user_tenants",
+  registry_index: "public chain registry cache, not tenant-owned",
+  sessions: "global user sessions; tenant membership is checked separately",
+  users: "global user identity; tenant access derives through user_tenants",
+} as const;
+
+export const ALL_INVENTORIED_TABLES = [
+  ...DIRECT_TENANT_TABLES,
+  ...Object.keys(INDIRECT_TENANT_TABLES),
+  ...Object.keys(TENANT_COLUMN_BACKFILL_TABLES),
+  ...Object.keys(HYBRID_SCOPE_TABLES),
+  ...Object.keys(BOOTSTRAP_ROOT_TABLES),
+  ...Object.keys(INTENTIONALLY_GLOBAL_TABLES),
+] as const;

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -45,10 +45,11 @@ import {
 // drops the tenant predicate is a cross-tenant data leak; the database would
 // not catch it.
 //
-// RLS as defense-in-depth for the highest-value tables (`secrets`,
-// `encrypted_keys`, `accounts`) is a deliberate DEFERRED decision, not an
-// oversight. Enabling it safely requires all of the following, and shipping
-// half of it is worse than none:
+// RLS activation is tracked by SEC-169. The executable transaction-context
+// primitive, complete policy inventory, and rollout gates live in
+// `tenant-rls-context.ts`, `rls-inventory.ts`, and
+// `docs/security/database-rls-rollout.mdx`. Enabling it safely requires all of
+// the following, and shipping half of it is worse than none:
 //   1. a per-request `SET LOCAL app.tenant_id` inside EVERY transaction (the
 //      pooled postgres-js role is shared by all tenants, so the GUC must be
 //      set on the checked-out connection for exactly the unit of work);

--- a/packages/db/src/tenant-rls-context.ts
+++ b/packages/db/src/tenant-rls-context.ts
@@ -1,0 +1,111 @@
+import { sql } from "drizzle-orm";
+
+const trustedTenantContextBrand: unique symbol = Symbol("steward.trusted-tenant-context");
+const TENANT_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+
+export type TenantRlsDriver = "postgres-js" | "pglite" | "neon-http";
+
+/**
+ * An application-internal capability minted only after authentication or by a
+ * named background job. Request headers and body fields are not valid inputs to
+ * the transaction helper.
+ */
+export interface TrustedTenantContext {
+  readonly tenantId: string;
+  readonly authority:
+    | {
+        readonly kind: "authenticated-principal";
+        readonly method: string;
+        readonly subject: string;
+      }
+    | { readonly kind: "internal-job"; readonly job: string };
+  readonly [trustedTenantContextBrand]: true;
+}
+
+function assertTenantId(tenantId: string): void {
+  if (!TENANT_ID_PATTERN.test(tenantId)) {
+    throw new Error("RLS_TENANT_CONTEXT_INVALID");
+  }
+}
+
+export function tenantContextFromAuthenticatedPrincipal(input: {
+  tenantId: string;
+  method: string;
+  subject: string;
+}): TrustedTenantContext {
+  assertTenantId(input.tenantId);
+  if (!input.method || !input.subject) throw new Error("RLS_TENANT_AUTHORITY_INVALID");
+  return Object.freeze({
+    tenantId: input.tenantId,
+    authority: Object.freeze({
+      kind: "authenticated-principal" as const,
+      method: input.method,
+      subject: input.subject,
+    }),
+    [trustedTenantContextBrand]: true as const,
+  });
+}
+
+export function tenantContextForInternalJob(input: {
+  tenantId: string;
+  job: string;
+}): TrustedTenantContext {
+  assertTenantId(input.tenantId);
+  if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(input.job)) {
+    throw new Error("RLS_TENANT_JOB_INVALID");
+  }
+  return Object.freeze({
+    tenantId: input.tenantId,
+    authority: Object.freeze({ kind: "internal-job" as const, job: input.job }),
+    [trustedTenantContextBrand]: true as const,
+  });
+}
+
+export function assertTenantRlsDriver(driver: TenantRlsDriver): void {
+  if (driver === "neon-http") {
+    throw new Error(
+      "RLS_TRANSACTION_UNSUPPORTED: neon-http has no callback transactions; use a transaction-capable Workers database transport",
+    );
+  }
+}
+
+interface TenantTransactionExecutor {
+  execute(query: unknown): Promise<unknown>;
+}
+
+interface TenantTransactionalDatabase<Tx extends TenantTransactionExecutor> {
+  transaction<T>(callback: (tx: Tx) => Promise<T>): Promise<T>;
+}
+
+function hasTrustedBrand(context: TrustedTenantContext): boolean {
+  return context[trustedTenantContextBrand] === true;
+}
+
+/**
+ * Run one tenant unit of work on one checked-out connection. `set_config(...,
+ * true)` is transaction-local, so commit, rollback, and pool reuse clear the
+ * context. Never replace this with session-level SET on a pooled connection.
+ */
+export async function withTenantRlsTransaction<Tx extends TenantTransactionExecutor, T>(
+  db: TenantTransactionalDatabase<Tx>,
+  driver: TenantRlsDriver,
+  context: TrustedTenantContext,
+  callback: (tx: Tx) => Promise<T>,
+): Promise<T> {
+  assertTenantRlsDriver(driver);
+  if (!hasTrustedBrand(context)) throw new Error("RLS_TENANT_CONTEXT_UNTRUSTED");
+  assertTenantId(context.tenantId);
+
+  return db.transaction(async (tx) => {
+    await tx.execute(sql`SELECT set_config('steward.tenant_id', ${context.tenantId}, true)`);
+    const result = await tx.execute(
+      sql`SELECT current_setting('steward.tenant_id', true) AS tenant_id`,
+    );
+    const rows = Array.isArray(result)
+      ? result
+      : ((result as { rows?: unknown[] } | null)?.rows ?? []);
+    const tenantId = (rows[0] as { tenant_id?: unknown } | undefined)?.tenant_id;
+    if (tenantId !== context.tenantId) throw new Error("RLS_TENANT_CONTEXT_NOT_BOUND");
+    return callback(tx);
+  });
+}

--- a/packages/db/src/tenant-rls-context.ts
+++ b/packages/db/src/tenant-rls-context.ts
@@ -1,7 +1,10 @@
-import { sql } from "drizzle-orm";
+import { is, sql } from "drizzle-orm";
+import { PgTransaction } from "drizzle-orm/pg-core";
 
-const trustedTenantContextBrand: unique symbol = Symbol("steward.trusted-tenant-context");
-const TENANT_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+declare const trustedTenantContextBrand: unique symbol;
+const trustedTenantContexts = new WeakSet<object>();
+const TENANT_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,63}$/;
+const AUTHORITY_METHOD_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,63}$/;
 
 export type TenantRlsDriver = "postgres-js" | "pglite" | "neon-http";
 
@@ -34,16 +37,23 @@ export function tenantContextFromAuthenticatedPrincipal(input: {
   subject: string;
 }): TrustedTenantContext {
   assertTenantId(input.tenantId);
-  if (!input.method || !input.subject) throw new Error("RLS_TENANT_AUTHORITY_INVALID");
-  return Object.freeze({
+  if (
+    !AUTHORITY_METHOD_PATTERN.test(input.method) ||
+    input.subject.length === 0 ||
+    input.subject.length > 255 ||
+    /[\u0000-\u001f\u007f]/.test(input.subject)
+  )
+    throw new Error("RLS_TENANT_AUTHORITY_INVALID");
+  const context = Object.freeze({
     tenantId: input.tenantId,
     authority: Object.freeze({
       kind: "authenticated-principal" as const,
       method: input.method,
       subject: input.subject,
     }),
-    [trustedTenantContextBrand]: true as const,
-  });
+  }) as TrustedTenantContext;
+  trustedTenantContexts.add(context);
+  return context;
 }
 
 export function tenantContextForInternalJob(input: {
@@ -54,11 +64,12 @@ export function tenantContextForInternalJob(input: {
   if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(input.job)) {
     throw new Error("RLS_TENANT_JOB_INVALID");
   }
-  return Object.freeze({
+  const context = Object.freeze({
     tenantId: input.tenantId,
     authority: Object.freeze({ kind: "internal-job" as const, job: input.job }),
-    [trustedTenantContextBrand]: true as const,
-  });
+  }) as TrustedTenantContext;
+  trustedTenantContexts.add(context);
+  return context;
 }
 
 export function assertTenantRlsDriver(driver: TenantRlsDriver): void {
@@ -77,8 +88,16 @@ interface TenantTransactionalDatabase<Tx extends TenantTransactionExecutor> {
   transaction<T>(callback: (tx: Tx) => Promise<T>): Promise<T>;
 }
 
-function hasTrustedBrand(context: TrustedTenantContext): boolean {
-  return context[trustedTenantContextBrand] === true;
+function hasTrustedBrand(context: unknown): context is TrustedTenantContext {
+  return typeof context === "object" && context !== null && trustedTenantContexts.has(context);
+}
+
+function rowsOf(result: unknown): unknown[] {
+  return Array.isArray(result) ? result : ((result as { rows?: unknown[] } | null)?.rows ?? []);
+}
+
+function contextTenantId(result: unknown): unknown {
+  return (rowsOf(result)[0] as { tenant_id?: unknown } | undefined)?.tenant_id;
 }
 
 /**
@@ -95,17 +114,39 @@ export async function withTenantRlsTransaction<Tx extends TenantTransactionExecu
   assertTenantRlsDriver(driver);
   if (!hasTrustedBrand(context)) throw new Error("RLS_TENANT_CONTEXT_UNTRUSTED");
   assertTenantId(context.tenantId);
+  // Calling `.transaction()` on a Drizzle PgTransaction opens a savepoint,
+  // not an independent transaction. SET LOCAL would then survive the helper
+  // callback until the unknown outer transaction ends.
+  if (is(db, PgTransaction)) throw new Error("RLS_TENANT_TRANSACTION_NESTED");
 
-  return db.transaction(async (tx) => {
+  const outcome = await db.transaction(async (tx) => {
+    // A non-empty value here means this connection carries a session-level
+    // setting or the helper was nested inside another tenant transaction.
+    // Overwriting either would conceal a lifecycle bug and could restore the
+    // stale session value after commit, so reject before exposing the tx.
+    const prior = await tx.execute(
+      sql`SELECT NULLIF(current_setting('steward.tenant_id', true), '') AS tenant_id`,
+    );
+    if (contextTenantId(prior) != null) {
+      // Clear the session-scoped contamination and commit that cleanup before
+      // reporting the error. Throwing inside this transaction would roll the
+      // reset back and return a still-dangerous connection to the pool.
+      await tx.execute(sql`SELECT set_config('steward.tenant_id', '', false)`);
+      const cleared = await tx.execute(
+        sql`SELECT NULLIF(current_setting('steward.tenant_id', true), '') AS tenant_id`,
+      );
+      if (contextTenantId(cleared) != null) throw new Error("RLS_TENANT_CONTEXT_CLEAR_FAILED");
+      return { kind: "dirty" as const };
+    }
+
     await tx.execute(sql`SELECT set_config('steward.tenant_id', ${context.tenantId}, true)`);
     const result = await tx.execute(
       sql`SELECT current_setting('steward.tenant_id', true) AS tenant_id`,
     );
-    const rows = Array.isArray(result)
-      ? result
-      : ((result as { rows?: unknown[] } | null)?.rows ?? []);
-    const tenantId = (rows[0] as { tenant_id?: unknown } | undefined)?.tenant_id;
-    if (tenantId !== context.tenantId) throw new Error("RLS_TENANT_CONTEXT_NOT_BOUND");
-    return callback(tx);
+    if (contextTenantId(result) !== context.tenantId)
+      throw new Error("RLS_TENANT_CONTEXT_NOT_BOUND");
+    return { kind: "ok" as const, value: await callback(tx) };
   });
+  if (outcome.kind === "dirty") throw new Error("RLS_TENANT_CONTEXT_DIRTY");
+  return outcome.value;
 }


### PR DESCRIPTION
## Outcome

This is a bounded first implementation PR for SEC-169. It deliberately leaves the SEC-169 tracking issue open: enabling production RLS before every request/background path and Workers transport are transaction-capable would either break authentication or create a bypass.

## What this establishes

- branded, immutable tenant contexts minted from an authenticated principal or a named internal job
- one-connection callback transactions that set and read back transaction-local `steward.tenant_id` before exposing the transaction
- explicit fail-closed rejection of current `neon-http`, whose Drizzle driver has no callback transactions
- a machine-checked classification for all 70 current Drizzle tables: 53 direct, 7 safe parent-derived, 2 requiring tenant-column backfill, 2 hybrid/nullable, 1 bootstrap root, and 5 intentionally global
- a narrow SECURITY DEFINER bootstrap design for API-key, session, agent-JWT, and app-secret lookup before tenant context exists
- activation role, partition, background-job, Workers migration, catalog, test, rollout, and rollback gates
- a real-Postgres test wired into PR and develop integration jobs

## Real PostgreSQL evidence

Executed locally with PostgreSQL 16 under a dedicated `NOSUPERUSER NOBYPASSRLS` login role:

- missing context: reads return zero rows and writes fail with `42501`
- 24 concurrent alternating tenant transactions: every read sees only its own tenant
- 12 post-transaction pooled reads: all see zero rows, proving context reset
- cross-tenant `WITH CHECK` insert: fails with `42501`
- 3 pass, 0 fail, 55 assertions

Additional validation:

- inventory/context unit tests: 5 pass, 0 fail, 85 assertions (real-PG suite correctly skips without `DATABASE_URL`)
- `bunx turbo run build --filter=@stwd/db`: 2/2 tasks successful
- Biome and `git diff --check`: clean

## Remaining activation work

1. Move Workers from `neon-http` to a transaction-capable PostgreSQL transport.
2. Deploy restricted bootstrap functions and distinct NO-BYPASS app/migration roles.
3. Thread the transaction object through all tenant routes and per-tenant background jobs.
4. Backfill tenant ownership for the EVM nonce tables and define the two hybrid policies.
5. Apply complete direct/indirect policies with `ENABLE` + `FORCE`, then run the full read/write/upsert/delete/join/migration catalog suite.