### PR TITLE
test(trading): isolate audit fixture modules

### DIFF
--- a/packages/plugin-trading/src/__tests__/agent-token-expiry-monitoring.test.ts
+++ b/packages/plugin-trading/src/__tests__/agent-token-expiry-monitoring.test.ts
@@ -149,7 +149,11 @@ beforeEach(() => {
   clearAgentTokenStatusForTests?.();
 });
 
-async function latestTokenAudit(action: "agent.token.expiring" | "agent.token.expired") {
+async function latestTokenAudit(
+  action: "agent.token.expiring" | "agent.token.expired",
+  expectedAgentId: string,
+  expectedExp: number,
+) {
   // Production telemetry uses fire-and-forget `trackAuditEvent`, so observe the
   // real durable sink instead of globally mocking the audit module. A global
   // module mock leaked into sibling test files in the same Bun worker and made
@@ -161,7 +165,13 @@ async function latestTokenAudit(action: "agent.token.expiring" | "agent.token.ex
       .where(and(eq(auditEvents.tenantId, TENANT_ID), eq(auditEvents.action, action)))
       .orderBy(desc(auditEvents.seq))
       .limit(1);
-    if (event) return event;
+    if (
+      event?.actorId === expectedAgentId &&
+      event.metadata?.agentId === expectedAgentId &&
+      event.metadata?.exp === expectedExp
+    ) {
+      return event;
+    }
     await Bun.sleep(10);
   }
   return undefined;
@@ -232,7 +242,7 @@ describe("agent trade token expiry monitoring", () => {
     });
 
     expect(res.status).toBe(200);
-    const event = await latestTokenAudit("agent.token.expiring");
+    const event = await latestTokenAudit("agent.token.expiring", AGENT_ID, exp);
     expect(event?.actorId).toBe(AGENT_ID);
     expect(event?.metadata?.agentId).toBe(AGENT_ID);
     expect(event?.metadata?.exp).toBe(exp);
@@ -254,7 +264,7 @@ describe("agent trade token expiry monitoring", () => {
     });
 
     expect(res.status).toBe(401);
-    const event = await latestTokenAudit("agent.token.expired");
+    const event = await latestTokenAudit("agent.token.expired", AGENT_ID, exp);
     expect(event?.actorId).toBe(AGENT_ID);
     expect(event?.metadata?.agentId).toBe(AGENT_ID);
     expect(event?.metadata?.exp).toBe(exp);

--- a/packages/plugin-trading/src/__tests__/agent-token-expiry-monitoring.test.ts
+++ b/packages/plugin-trading/src/__tests__/agent-token-expiry-monitoring.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it, setDefaultTimeout } from "bun:test";
 import { generateApiKey, signAgentToken } from "@stwd/auth";
-import { auditEvents, closeDb, getDb, tenants } from "@stwd/db";
+import { __resetAuditHmacKeyCacheForTests, auditEvents, closeDb, getDb, tenants } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { and, desc, eq } from "drizzle-orm";
 import { Hono } from "hono";
@@ -18,6 +18,9 @@ const TEST_JWKS_URL = "https://jwks.example.test/.well-known/jwks.json";
 const originalJwksUrl = process.env.ELIZA_CLOUD_JWKS_URL;
 const originalAuditHmacKey = process.env.STEWARD_AUDIT_HMAC_KEY;
 const originalJwtSecret = process.env.STEWARD_JWT_SECRET;
+const originalPgliteMemory = process.env.STEWARD_PGLITE_MEMORY;
+const originalDatabaseUrl = process.env.DATABASE_URL;
+const originalMasterPassword = process.env.STEWARD_MASTER_PASSWORD;
 const originalFetch = globalThis.fetch;
 
 let privateKey: CryptoKey;
@@ -35,6 +38,10 @@ beforeAll(async () => {
   process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
   process.env.STEWARD_MASTER_PASSWORD ??= "test-master-password";
   process.env.STEWARD_AUDIT_HMAC_KEY = "agent-token-expiry-audit-hmac-key-with-enough-entropy";
+  // @stwd/db memoizes the decoded HMAC key. Sibling files share Bun's module
+  // cache, so changing only process.env would otherwise keep another fixture's
+  // key (and restoring the env later would still leak this fixture's key).
+  __resetAuditHmacKeyCacheForTests();
   // Platform agent-token signing (SEC-091 test): tenantAuth verifies Bearer
   // tokens with the canonical JWT secret, so configure one explicitly.
   process.env.STEWARD_JWT_SECRET ??= "test-jwt-secret-32-chars-minimum!!!!";
@@ -103,6 +110,7 @@ beforeAll(async () => {
 
 afterAll(async () => {
   globalThis.fetch = originalFetch;
+  await closeDb();
   if (originalJwksUrl === undefined) {
     delete process.env.ELIZA_CLOUD_JWKS_URL;
   } else {
@@ -118,7 +126,22 @@ afterAll(async () => {
   } else {
     process.env.STEWARD_JWT_SECRET = originalJwtSecret;
   }
-  await closeDb();
+  if (originalPgliteMemory === undefined) {
+    delete process.env.STEWARD_PGLITE_MEMORY;
+  } else {
+    process.env.STEWARD_PGLITE_MEMORY = originalPgliteMemory;
+  }
+  if (originalDatabaseUrl === undefined) {
+    delete process.env.DATABASE_URL;
+  } else {
+    process.env.DATABASE_URL = originalDatabaseUrl;
+  }
+  if (originalMasterPassword === undefined) {
+    delete process.env.STEWARD_MASTER_PASSWORD;
+  } else {
+    process.env.STEWARD_MASTER_PASSWORD = originalMasterPassword;
+  }
+  __resetAuditHmacKeyCacheForTests();
 });
 
 beforeEach(() => {

--- a/packages/plugin-trading/src/__tests__/agent-token-expiry-monitoring.test.ts
+++ b/packages/plugin-trading/src/__tests__/agent-token-expiry-monitoring.test.ts
@@ -1,16 +1,8 @@
-import {
-  afterAll,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  mock,
-  setDefaultTimeout,
-} from "bun:test";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, setDefaultTimeout } from "bun:test";
 import { generateApiKey, signAgentToken } from "@stwd/auth";
-import { closeDb, getDb, tenants } from "@stwd/db";
+import { auditEvents, closeDb, getDb, tenants } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { and, desc, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { exportJWK, generateKeyPair, SignJWT } from "jose";
 
@@ -24,27 +16,9 @@ const FOREIGN_AGENT_ID = "test-token-watch-foreign";
 const KID = "test-agent-token-kid";
 const TEST_JWKS_URL = "https://jwks.example.test/.well-known/jwks.json";
 const originalJwksUrl = process.env.ELIZA_CLOUD_JWKS_URL;
+const originalAuditHmacKey = process.env.STEWARD_AUDIT_HMAC_KEY;
+const originalJwtSecret = process.env.STEWARD_JWT_SECRET;
 const originalFetch = globalThis.fetch;
-
-const auditEvents: Array<{ action: string; metadata?: Record<string, unknown>; actorId?: string }> =
-  [];
-
-mock.module("../../../api/src/services/audit", () => ({
-  trackAuditEvent: (event: {
-    action: string;
-    metadata?: Record<string, unknown>;
-    actorId?: string;
-  }) => {
-    auditEvents.push(event);
-  },
-  writeAuditEvent: async (event: {
-    action: string;
-    metadata?: Record<string, unknown>;
-    actorId?: string;
-  }) => {
-    auditEvents.push(event);
-  },
-}));
 
 let privateKey: CryptoKey;
 let publicJwk: JsonWebKey;
@@ -60,6 +34,7 @@ beforeAll(async () => {
   process.env.STEWARD_PGLITE_MEMORY = "true";
   process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
   process.env.STEWARD_MASTER_PASSWORD ??= "test-master-password";
+  process.env.STEWARD_AUDIT_HMAC_KEY = "agent-token-expiry-audit-hmac-key-with-enough-entropy";
   // Platform agent-token signing (SEC-091 test): tenantAuth verifies Bearer
   // tokens with the canonical JWT secret, so configure one explicitly.
   process.env.STEWARD_JWT_SECRET ??= "test-jwt-secret-32-chars-minimum!!!!";
@@ -76,7 +51,7 @@ beforeAll(async () => {
   publicJwk.alg = "RS256";
   publicJwk.use = "sig";
 
-  globalThis.fetch = mock(async (input) => {
+  globalThis.fetch = (async (input) => {
     if (String(input) !== TEST_JWKS_URL) throw new Error(`Unexpected JWKS URL: ${String(input)}`);
     return Response.json({ keys: [publicJwk] });
   }) as unknown as typeof fetch;
@@ -133,14 +108,41 @@ afterAll(async () => {
   } else {
     process.env.ELIZA_CLOUD_JWKS_URL = originalJwksUrl;
   }
+  if (originalAuditHmacKey === undefined) {
+    delete process.env.STEWARD_AUDIT_HMAC_KEY;
+  } else {
+    process.env.STEWARD_AUDIT_HMAC_KEY = originalAuditHmacKey;
+  }
+  if (originalJwtSecret === undefined) {
+    delete process.env.STEWARD_JWT_SECRET;
+  } else {
+    process.env.STEWARD_JWT_SECRET = originalJwtSecret;
+  }
   await closeDb();
 });
 
 beforeEach(() => {
-  auditEvents.length = 0;
   clearAgentJwksCacheForTests?.();
   clearAgentTokenStatusForTests?.();
 });
+
+async function latestTokenAudit(action: "agent.token.expiring" | "agent.token.expired") {
+  // Production telemetry uses fire-and-forget `trackAuditEvent`, so observe the
+  // real durable sink instead of globally mocking the audit module. A global
+  // module mock leaked into sibling test files in the same Bun worker and made
+  // their genuine audit assertions read an empty table.
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const [event] = await getDb()
+      .select()
+      .from(auditEvents)
+      .where(and(eq(auditEvents.tenantId, TENANT_ID), eq(auditEvents.action, action)))
+      .orderBy(desc(auditEvents.seq))
+      .limit(1);
+    if (event) return event;
+    await Bun.sleep(10);
+  }
+  return undefined;
+}
 
 async function signTradeToken(expiresAt: number): Promise<string> {
   const now = Math.floor(Date.now() / 1000);
@@ -207,7 +209,7 @@ describe("agent trade token expiry monitoring", () => {
     });
 
     expect(res.status).toBe(200);
-    const event = auditEvents.find((entry) => entry.action === "agent.token.expiring");
+    const event = await latestTokenAudit("agent.token.expiring");
     expect(event?.actorId).toBe(AGENT_ID);
     expect(event?.metadata?.agentId).toBe(AGENT_ID);
     expect(event?.metadata?.exp).toBe(exp);
@@ -229,7 +231,7 @@ describe("agent trade token expiry monitoring", () => {
     });
 
     expect(res.status).toBe(401);
-    const event = auditEvents.find((entry) => entry.action === "agent.token.expired");
+    const event = await latestTokenAudit("agent.token.expired");
     expect(event?.actorId).toBe(AGENT_ID);
     expect(event?.metadata?.agentId).toBe(AGENT_ID);
     expect(event?.metadata?.exp).toBe(exp);

--- a/packages/plugin-trading/src/__tests__/agent-token-expiry-monitoring.test.ts
+++ b/packages/plugin-trading/src/__tests__/agent-token-expiry-monitoring.test.ts
@@ -109,6 +109,8 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
+  clearAgentJwksCacheForTests?.();
+  clearAgentTokenStatusForTests?.();
   globalThis.fetch = originalFetch;
   await closeDb();
   if (originalJwksUrl === undefined) {


### PR DESCRIPTION
Post-merge corrective for #367.

The agent-token expiry fixture used a process-global `mock.module` replacement for the API audit service. Bun runs sibling test files in the same worker, so the mock leaked into `evm-swap-prepare.test.ts`: the swap succeeded but its real durable audit table stayed empty.

This corrective:
- removes the global audit module mock and observes the real fire-and-forget durable audit sink with a bounded poll
- configures a strong fixture HMAC key without weakening production behavior
- resets the memoized `@stwd/db` audit HMAC key before use and after restoring the prior environment, preventing module-cache key leakage into sibling files
- restores every mutated environment variable, the global fetch function, and the PGLite override

Independent audit validation at exact head:
- combined expiry + EVM swap suites: 19 passed, 0 failed
- user wallet recovery suite from merged #367: 17 passed, 0 failed
- plugin-trading TypeScript: clean
- Biome and git diff --check: clean

This is not a duplicate of #367: #367 introduced the stricter fixtures but left the audit module mock that caused this shared-worker regression. This PR is the minimal corrective and changes test code only.

Keep draft until exact-head CI is green.