### PR TITLE
fix(security): harden SDK redirects and CLI output

### DIFF
--- a/packages/cli/src/__tests__/evidence-bundle-verify.test.ts
+++ b/packages/cli/src/__tests__/evidence-bundle-verify.test.ts
@@ -1,9 +1,19 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, isAbsolute, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { evidenceBundleVerifierScript } from "../index";
+import { evidenceBundleVerifierScript, writeOwnerOnlyFile } from "../index";
 
 const CLI_ENTRY = join(dirname(dirname(fileURLToPath(import.meta.url))), "index.ts");
 
@@ -38,6 +48,10 @@ describe("evidence bundle offline verification", () => {
           "process.exit(0);\n",
       );
       const out = join(dir, "bundle.json");
+      // `mode` on writeFile only affects creation. Exercise replacement of a
+      // pre-existing permissive file, which must be tightened before data lands.
+      writeFileSync(out, "stale");
+      chmodSync(out, 0o644);
       const proc = Bun.spawn(
         [
           "bun",
@@ -67,4 +81,19 @@ describe("evidence bundle offline verification", () => {
       rmSync(dir, { recursive: true, force: true });
     }
   }, 15_000);
+
+  test("owner-only output refuses symlinks", () => {
+    const dir = mkdtempSync(join(tmpdir(), "steward-cli-output-"));
+    try {
+      const target = join(dir, "target");
+      const output = join(dir, "output");
+      writeFileSync(target, "untouched");
+      symlinkSync(target, output);
+
+      expect(() => writeOwnerOnlyFile(output, "sensitive")).toThrow();
+      expect(readFileSync(target, "utf8")).toBe("untouched");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/cli/src/__tests__/evidence-bundle-verify.test.ts
+++ b/packages/cli/src/__tests__/evidence-bundle-verify.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   chmodSync,
   existsSync,
+  linkSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -92,6 +93,22 @@ describe("evidence bundle offline verification", () => {
 
       expect(() => writeOwnerOnlyFile(output, "sensitive")).toThrow();
       expect(readFileSync(target, "utf8")).toBe("untouched");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("owner-only output refuses hard links without mutating the target", () => {
+    const dir = mkdtempSync(join(tmpdir(), "steward-cli-output-"));
+    try {
+      const target = join(dir, "target");
+      const output = join(dir, "output");
+      writeFileSync(target, "untouched", { mode: 0o644 });
+      linkSync(target, output);
+
+      expect(() => writeOwnerOnlyFile(output, "sensitive")).toThrow(/hard-linked/);
+      expect(readFileSync(target, "utf8")).toBe("untouched");
+      expect(statSync(target).mode & 0o777).toBe(0o644);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/packages/cli/src/__tests__/output-security.test.ts
+++ b/packages/cli/src/__tests__/output-security.test.ts
@@ -1,0 +1,122 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { redactForDisplay, redactSensitiveText, sanitizeTerminalText } from "../format";
+
+const CLI_ENTRY = join(dirname(dirname(fileURLToPath(import.meta.url))), "index.ts");
+const TOKEN = "agent-secret-token-value";
+let server: ReturnType<typeof Bun.serve>;
+let hits = 0;
+
+async function runCli(args: string[]) {
+  const proc = Bun.spawn(["bun", CLI_ENTRY, ...args], { stdout: "pipe", stderr: "pipe" });
+  const [exitCode, stdout, stderr] = await Promise.all([
+    proc.exited,
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  return { exitCode, stdout, stderr };
+}
+
+beforeAll(() => {
+  server = Bun.serve({
+    port: 0,
+    fetch(request) {
+      hits += 1;
+      if (new URL(request.url).pathname === "/agents/agent-a/token") {
+        return Response.json({
+          ok: true,
+          data: {
+            token: TOKEN,
+            agentId: "agent-a",
+            tenantId: "tenant-a",
+            scope: "agent",
+            scopes: ["agent"],
+            expiresIn: "24h",
+          },
+        });
+      }
+      return Response.json({ error: `bad\u001b[2J\nforged bearer-token-value` }, { status: 400 });
+    },
+  });
+});
+
+afterAll(() => server.stop(true));
+
+describe("CLI secret and terminal output boundary", () => {
+  test("terminal text escapes control characters and exact secrets", () => {
+    expect(sanitizeTerminalText("bad\u001b[2J\nforged")).toBe("bad\\u001b[2J\\u000aforged");
+    expect(redactSensitiveText("failed bearer-token-value", ["bearer-token-value"])).toBe(
+      "failed [REDACTED]",
+    );
+    expect(
+      redactForDisplay({
+        token: "agent-token",
+        nested: { refreshToken: "refresh", secretId: "non-secret-id", publicKey: "public" },
+      }),
+    ).toEqual({
+      token: "[REDACTED]",
+      nested: { refreshToken: "[REDACTED]", secretId: "non-secret-id", publicKey: "public" },
+    });
+  });
+
+  test("agent tokens go to an owner-only file and never stdout by default", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "steward-cli-token-output-"));
+    try {
+      const out = join(dir, "token.json");
+      const result = await runCli([
+        "agent",
+        "token",
+        "--agent-id",
+        "agent-a",
+        "--api-url",
+        `http://127.0.0.1:${server.port}`,
+        "--tenant-key",
+        "tenant-key-value",
+        "--out",
+        out,
+      ]);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).not.toContain(TOKEN);
+      expect(result.stdout).toContain("[REDACTED]");
+      expect(readFileSync(out, "utf8")).toContain(TOKEN);
+      expect(statSync(out).mode & 0o777).toBe(0o600);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("missing token output destination fails before minting", async () => {
+    const before = hits;
+    const result = await runCli([
+      "agent",
+      "token",
+      "--agent-id",
+      "agent-a",
+      "--api-url",
+      `http://127.0.0.1:${server.port}`,
+      "--tenant-key",
+      "tenant-key-value",
+    ]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("requires --out");
+    expect(hits).toBe(before);
+  });
+
+  test("API errors redact configured tokens and cannot inject terminal lines", async () => {
+    const result = await runCli([
+      "agent",
+      "list",
+      "--api-url",
+      `http://127.0.0.1:${server.port}`,
+      "--token",
+      "bearer-token-value",
+    ]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).not.toContain("bearer-token-value");
+    expect(result.stderr).not.toContain("\u001b");
+    expect(result.stderr).toContain("\\u001b[2J\\u000aforged [REDACTED]");
+  });
+});

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -1,3 +1,5 @@
+import { redactSensitiveText } from "./format";
+
 export type ApiClientOptions = {
   baseUrl?: string;
   tenantId?: string;
@@ -29,6 +31,19 @@ const API_REQUEST_TIMEOUT_MS = 10_000;
 const API_ARCHIVE_REQUEST_TIMEOUT_MS = 60_000;
 const API_RESPONSE_MAX_BYTES = 1024 * 1024;
 const API_ARCHIVE_CHUNK_MAX_BYTES = 25 * 1024 * 1024;
+const SENSITIVE_BODY_KEY =
+  /(token|secret|password|credential|api.?key|private.?key|mnemonic|value)/i;
+
+function sensitiveBodyValues(value: unknown): string[] {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return [];
+  const found: string[] = [];
+  for (const [key, candidate] of Object.entries(value as Record<string, unknown>)) {
+    if (SENSITIVE_BODY_KEY.test(key) && typeof candidate === "string" && candidate.length > 0) {
+      found.push(candidate);
+    }
+  }
+  return found;
+}
 
 function responseLimitLabel(maxBytes: number): string {
   return maxBytes === API_RESPONSE_MAX_BYTES ? "1 MiB" : `${maxBytes} byte`;
@@ -145,7 +160,16 @@ export class StewardApiClient {
         parsed && typeof parsed === "object" && "error" in parsed
           ? String((parsed as { error: unknown }).error)
           : `${method} ${path} failed with HTTP ${res.status}`;
-      throw new ApiError(message, res.status, parsed ?? text);
+      throw new ApiError(
+        redactSensitiveText(message, [
+          this.token,
+          this.platformKey,
+          this.tenantKey,
+          ...sensitiveBodyValues(body),
+        ]),
+        res.status,
+        parsed ?? text,
+      );
     }
     if (parsed && typeof parsed === "object" && "ok" in parsed && "data" in parsed) {
       return (parsed as { data: T }).data;
@@ -202,7 +226,11 @@ export class StewardApiClient {
         parsed && typeof parsed === "object" && "error" in parsed
           ? String((parsed as { error: unknown }).error)
           : `${method} ${path} failed with HTTP ${res.status}`;
-      throw new ApiError(message, res.status, parsed ?? text);
+      throw new ApiError(
+        redactSensitiveText(message, [this.token, this.platformKey, this.tenantKey]),
+        res.status,
+        parsed ?? text,
+      );
     }
     if (parsed && typeof parsed === "object" && "ok" in parsed && "data" in parsed) {
       return (parsed as { data: T }).data;

--- a/packages/cli/src/format.ts
+++ b/packages/cli/src/format.ts
@@ -1,19 +1,71 @@
 export type OutputFormat = "json" | "pretty";
 
+/** Render untrusted text without terminal control sequences or forged lines. */
+export function sanitizeTerminalText(value: string): string {
+  return value.replace(/[\u0000-\u001f\u007f-\u009f\u2028\u2029]/g, (character) => {
+    const code = character.codePointAt(0) ?? 0;
+    return `\\u${code.toString(16).padStart(4, "0")}`;
+  });
+}
+
+/** Remove exact credentials known to the caller before an error reaches logs. */
+export function redactSensitiveText(value: string, secrets: Array<string | undefined>): string {
+  let redacted = value;
+  const unique = [...new Set(secrets.filter((secret): secret is string => Boolean(secret)))].sort(
+    (a, b) => b.length - a.length,
+  );
+  for (const secret of unique) redacted = redacted.replaceAll(secret, "[REDACTED]");
+  return redacted;
+}
+
+function isSensitiveOutputKey(key: string): boolean {
+  const normalized = key.replace(/[^A-Za-z0-9]/g, "").toLowerCase();
+  return [
+    "token",
+    "accesstoken",
+    "refreshtoken",
+    "claimtoken",
+    "pollsecret",
+    "secret",
+    "clientsecret",
+    "credentialsecret",
+    "password",
+    "apikey",
+    "platformkey",
+    "tenantkey",
+    "privatekey",
+    "mnemonic",
+    "seedphrase",
+  ].some((suffix) => normalized === suffix || normalized.endsWith(suffix));
+}
+
+/** Redact secret-shaped response fields before printing API data. */
+export function redactForDisplay(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(redactForDisplay);
+  if (!value || typeof value !== "object") return value;
+  if (value instanceof Date) return value;
+  const output: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    output[key] = isSensitiveOutputKey(key) ? "[REDACTED]" : redactForDisplay(child);
+  }
+  return output;
+}
+
 export function printJson(value: unknown): void {
   console.log(JSON.stringify(value, null, 2));
 }
 
-export function printResult(value: unknown, format: OutputFormat): void {
+export function printResult(value: unknown, format: OutputFormat, allowSensitive = false): void {
+  const printable = allowSensitive ? value : redactForDisplay(value);
   if (format === "json") {
-    printJson(value);
+    printJson(printable);
     return;
   }
-  if (typeof value === "string") {
-    console.log(value);
+  if (typeof printable === "string") {
+    console.log(sanitizeTerminalText(printable));
     return;
   }
-  printJson(value);
+  printJson(printable);
 }
 
 /**

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -8,6 +8,7 @@ import {
   fchmodSync,
   constants as fsConstants,
   fstatSync,
+  ftruncateSync,
   mkdirSync,
   openSync,
   readFileSync,
@@ -43,19 +44,23 @@ const MAX_ARCHIVE_ENVELOPE_BYTES = 1024 * 1024;
 export function writeOwnerOnlyFile(path: string, contents: string): void {
   const fd = openSync(
     path,
-    fsConstants.O_WRONLY |
-      fsConstants.O_CREAT |
-      fsConstants.O_TRUNC |
-      fsConstants.O_NOFOLLOW |
-      fsConstants.O_NONBLOCK,
+    fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_NOFOLLOW | fsConstants.O_NONBLOCK,
     0o600,
   );
   try {
-    if (!fstatSync(fd).isFile()) {
+    const stat = fstatSync(fd);
+    if (!stat.isFile()) {
       throw new Error(`Sensitive output is not a regular file: ${path}`);
+    }
+    if (stat.nlink !== 1) {
+      throw new Error(`Sensitive output must not be hard-linked: ${path}`);
     }
     // The open() mode is creation-only. Tighten reused output before writing.
     fchmodSync(fd, 0o600);
+    // Truncate only after the descriptor has passed the type/link checks and
+    // its permissions have been tightened. O_TRUNC would destroy the previous
+    // target before those validations ran.
+    ftruncateSync(fd, 0);
     writeFileSync(fd, contents, { encoding: "utf8" });
   } finally {
     closeSync(fd);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -19,7 +19,12 @@ import { join } from "node:path";
 import { StewardApiClient } from "./api";
 import { boolFlag, intFlag, parseArgs, parseJsonFlag, required, stringFlag } from "./args";
 import { runDoctor } from "./doctor";
-import { type OutputFormat, printResult } from "./format";
+import {
+  type OutputFormat,
+  printResult,
+  redactSensitiveText,
+  sanitizeTerminalText,
+} from "./format";
 import { runInit } from "./init";
 
 type CommandContext = {
@@ -42,6 +47,15 @@ const MAX_ARCHIVE_ENVELOPE_BYTES = 1024 * 1024;
 /** Write sensitive output without following symlinks and make an existing
  * permissive file owner-only before any secret bytes are written. */
 export function writeOwnerOnlyFile(path: string, contents: string): void {
+  const fd = openOwnerOnlyFile(path);
+  try {
+    writeOwnerOnlyFileDescriptor(fd, contents);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function openOwnerOnlyFile(path: string): number {
   const fd = openSync(
     path,
     fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_NOFOLLOW | fsConstants.O_NONBLOCK,
@@ -55,16 +69,23 @@ export function writeOwnerOnlyFile(path: string, contents: string): void {
     if (stat.nlink !== 1) {
       throw new Error(`Sensitive output must not be hard-linked: ${path}`);
     }
+    if (typeof process.geteuid === "function" && stat.uid !== process.geteuid()) {
+      throw new Error(`Sensitive output is not owned by the current user: ${path}`);
+    }
     // The open() mode is creation-only. Tighten reused output before writing.
     fchmodSync(fd, 0o600);
-    // Truncate only after the descriptor has passed the type/link checks and
-    // its permissions have been tightened. O_TRUNC would destroy the previous
-    // target before those validations ran.
-    ftruncateSync(fd, 0);
-    writeFileSync(fd, contents, { encoding: "utf8" });
-  } finally {
+    return fd;
+  } catch (error) {
     closeSync(fd);
+    throw error;
   }
+}
+
+function writeOwnerOnlyFileDescriptor(fd: number, contents: string): void {
+  // Truncate only after all inode checks and the permission change. O_TRUNC
+  // would destroy a special/hard-linked target before it could be rejected.
+  ftruncateSync(fd, 0);
+  writeFileSync(fd, contents, { encoding: "utf8" });
 }
 
 /** Read an untrusted archive file without following symlinks, blocking on
@@ -189,7 +210,8 @@ Usage:
   steward tenant create --id ID --name NAME [--api-key-file F] [--api-key-env VAR]
                         (key via stdin/--api-key-file/--api-key-env preferred; --api-key warns)
   steward agent create --name NAME [--id ID]
-  steward agent token --agent-id ID [--expires-in 24h] [--scopes agent,api:proxy]
+  steward agent token --agent-id ID --out token.json [--expires-in 24h] [--scopes agent,api:proxy]
+                      [--show-token]  # explicit unsafe terminal compatibility mode
   steward secret add --name NAME [--file F] [--description TEXT]   (value via stdin or --file preferred; --value warns)
   steward secret rotate --id ID [--file F]                          (value via stdin or --file preferred; --value warns)
   steward route add --secret-id ID --agent-id ID --host HOST --path PATH --method METHOD --inject-as header --inject-key KEY
@@ -263,14 +285,45 @@ async function agentCommand(action: string | undefined, ctx: CommandContext) {
   if (action === "list") return ctx.api.request("GET", "/agents");
   if (action === "token") {
     const agentId = required(stringFlag(ctx.flags, "agent-id"), "agent-id");
+    const out = stringFlag(ctx.flags, "out");
+    const showToken = boolFlag(ctx.flags, "show-token");
+    if (!out && !showToken) {
+      throw new Error(
+        "agent token output requires --out <owner-only-file>; use --show-token only when terminal/log capture is disabled",
+      );
+    }
+    // Open, validate, and permission the destination before minting, then keep
+    // this exact inode open across the request. That closes the path-swap race
+    // that could otherwise orphan a live token after a successful response.
+    const outFd = out ? openOwnerOnlyFile(out) : undefined;
     const scopes = stringFlag(ctx.flags, "scopes")
       ?.split(",")
       .map((scope) => scope.trim())
       .filter(Boolean);
-    return ctx.api.request("POST", `/agents/${encodeURIComponent(agentId)}/token`, {
-      expiresIn: stringFlag(ctx.flags, "expires-in"),
-      scopes,
-    });
+    try {
+      const result = await ctx.api.request<Record<string, unknown> & { token: string }>(
+        "POST",
+        `/agents/${encodeURIComponent(agentId)}/token`,
+        {
+          expiresIn: stringFlag(ctx.flags, "expires-in"),
+          scopes,
+        },
+      );
+      if (typeof result.token !== "string" || result.token.length === 0) {
+        throw new Error("Steward returned an invalid agent token response");
+      }
+      if (outFd !== undefined && out) {
+        writeOwnerOnlyFileDescriptor(outFd, `${JSON.stringify(result, null, 2)}\n`);
+        const { token: _token, ...receipt } = result;
+        return { ...receipt, token: "[REDACTED]", wrote: out };
+      }
+      console.error(
+        "[steward] WARNING: --show-token writes a bearer credential to stdout; disable terminal and CI log capture",
+      );
+      return result;
+    } finally {
+      if (outFd !== undefined) closeSync(outFd);
+    }
   }
   throw new Error("Supported agent commands: agent create|list|token");
 }
@@ -749,12 +802,30 @@ async function main(argv: string[]) {
   };
   const handler = handlers[command];
   if (!handler) throw new Error(`Unknown command '${command}'. Run steward help.`);
-  printResult(await handler(action, ctx), ctx.format);
+  printResult(
+    await handler(action, ctx),
+    ctx.format,
+    command === "agent" && action === "token" && boolFlag(parsed.flags, "show-token"),
+  );
 }
 
 if (import.meta.main) {
-  main(Bun.argv.slice(2)).catch((error) => {
-    console.error(`steward: ${(error as Error).message}`);
+  const cliArgv = Bun.argv.slice(2);
+  main(cliArgv).catch((error) => {
+    const parsed = parseArgs(cliArgv);
+    const sensitiveFlagNames = ["token", "tenant-key", "platform-key", "api-key", "value"];
+    const knownSecrets = [
+      ...sensitiveFlagNames.map((name) => stringFlag(parsed.flags, name)),
+      process.env.STEWARD_TOKEN,
+      process.env.STEWARD_API_TOKEN,
+      process.env.STEWARD_TENANT_KEY,
+      process.env.STEWARD_PLATFORM_KEY,
+    ];
+    const message = redactSensitiveText(
+      error instanceof Error ? error.message : String(error),
+      knownSecrets,
+    );
+    console.error(`steward: ${sanitizeTerminalText(message)}`);
     process.exit(1);
   });
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,6 +5,7 @@ import { createHash } from "node:crypto";
 import {
   closeSync,
   existsSync,
+  fchmodSync,
   constants as fsConstants,
   fstatSync,
   mkdirSync,
@@ -36,6 +37,30 @@ type ArchiveChunkReference = {
 const MAX_ARCHIVE_CHUNKS = 2_048;
 const MAX_ARCHIVE_MANIFEST_BYTES = 768 * 1024;
 const MAX_ARCHIVE_ENVELOPE_BYTES = 1024 * 1024;
+
+/** Write sensitive output without following symlinks and make an existing
+ * permissive file owner-only before any secret bytes are written. */
+export function writeOwnerOnlyFile(path: string, contents: string): void {
+  const fd = openSync(
+    path,
+    fsConstants.O_WRONLY |
+      fsConstants.O_CREAT |
+      fsConstants.O_TRUNC |
+      fsConstants.O_NOFOLLOW |
+      fsConstants.O_NONBLOCK,
+    0o600,
+  );
+  try {
+    if (!fstatSync(fd).isFile()) {
+      throw new Error(`Sensitive output is not a regular file: ${path}`);
+    }
+    // The open() mode is creation-only. Tighten reused output before writing.
+    fchmodSync(fd, 0o600);
+    writeFileSync(fd, contents, { encoding: "utf8" });
+  } finally {
+    closeSync(fd);
+  }
+}
 
 /** Read an untrusted archive file without following symlinks, blocking on
  * special files, or allocating beyond its validated size. */
@@ -561,7 +586,7 @@ async function auditCommand(action: string | undefined, ctx: CommandContext) {
   if (to !== undefined) params.set("to", String(to));
   const bundle = await ctx.api.request("GET", `/audit/bundle?${params}`);
   const out = stringFlag(ctx.flags, "out");
-  if (out) writeFileSync(out, JSON.stringify(bundle, null, 2), { mode: 0o600 });
+  if (out) writeOwnerOnlyFile(out, JSON.stringify(bundle, null, 2));
   if (boolFlag(ctx.flags, "verify")) {
     if (!out) throw new Error("--verify requires --out so the offline verifier has a file");
     const result = spawnSync(process.execPath, [evidenceBundleVerifierScript(), out], {
@@ -647,7 +672,7 @@ async function providerActionCommand(action: string | undefined, ctx: CommandCon
     // trusted key fingerprint (E7): --out bundle.json [--verify --fp <hex>].
     const bundle = await ctx.api.request("GET", `/v2/provider-actions/${id()}/evidence`);
     const out = stringFlag(ctx.flags, "out");
-    if (out) writeFileSync(out, JSON.stringify(bundle, null, 2), { mode: 0o600 });
+    if (out) writeOwnerOnlyFile(out, JSON.stringify(bundle, null, 2));
     if (boolFlag(ctx.flags, "verify")) {
       if (!out) throw new Error("--verify requires --out so the offline verifier has a file");
       const fp = stringFlag(ctx.flags, "fp") ?? stringFlag(ctx.flags, "expected-key-fingerprint");

--- a/packages/go/steward/client.go
+++ b/packages/go/steward/client.go
@@ -88,17 +88,6 @@ var sensitivePrefixes = []string{
 	"/accounts",
 }
 
-var stewardCredentialHeaders = []string{
-	"Authorization",
-	"X-Steward-Key",
-	"X-Steward-Platform-Key",
-	"X-Steward-App-Id",
-	"X-Steward-Signature",
-	"X-Steward-Signing-Key-Id",
-	"X-Steward-Request-Timestamp",
-	"Idempotency-Key",
-}
-
 func isLoopbackHost(hostname string) bool {
 	return hostname == "localhost" || hostname == "127.0.0.1" || hostname == "::1"
 }
@@ -143,17 +132,19 @@ func sameOrigin(a *url.URL, b *url.URL) bool {
 		effectivePort(a) == effectivePort(b)
 }
 
-// stripStewardCredentialsOnCrossHostRedirect drops credential and signing
-// headers when a redirect targets a different origin, so an open redirect or
-// hostile proxy cannot exfiltrate them (SEC-126).
-func stripStewardCredentialsOnCrossHostRedirect(req *http.Request, via []*http.Request) error {
+// stewardRedirectPolicy permits only same-origin, credential-free redirect
+// targets. Merely stripping Steward headers is insufficient: following an
+// attacker-selected cross-origin Location turns server-side SDK consumers into
+// an SSRF primitive. Embedded URL credentials are also never accepted.
+func stewardRedirectPolicy(req *http.Request, via []*http.Request) error {
 	if len(via) == 0 {
 		return nil
 	}
-	if !sameOrigin(req.URL, via[0].URL) {
-		for _, header := range stewardCredentialHeaders {
-			req.Header.Del(header)
-		}
+	if len(via) >= 10 {
+		return errors.New("stopped after 10 redirects")
+	}
+	if req.URL.User != nil || !sameOrigin(req.URL, via[0].URL) {
+		return fmt.Errorf("refusing cross-origin or credential-bearing redirect to %q", req.URL.Redacted())
 	}
 	return nil
 }
@@ -174,12 +165,22 @@ func NewClient(config Config) (*Client, error) {
 	if httpClient == nil {
 		httpClient = &http.Client{
 			Timeout: 30 * time.Second,
-			// Never forward Steward credential headers to a different host on
-			// redirect: net/http strips only Authorization/Cookie and copies
-			// X-Steward-* headers to any host (SEC-126).
-			CheckRedirect: stripStewardCredentialsOnCrossHostRedirect,
 		}
 	}
+	// Copy caller-owned clients instead of mutating them, then compose their
+	// redirect policy behind Steward's mandatory origin boundary.
+	configuredRedirect := httpClient.CheckRedirect
+	httpClientCopy := *httpClient
+	httpClientCopy.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if err := stewardRedirectPolicy(req, via); err != nil {
+			return err
+		}
+		if configuredRedirect != nil {
+			return configuredRedirect(req, via)
+		}
+		return nil
+	}
+	httpClient = &httpClientCopy
 	now := config.Now
 	if now == nil {
 		now = time.Now

--- a/packages/go/steward/client.go
+++ b/packages/go/steward/client.go
@@ -124,15 +124,33 @@ func assertSecureBaseURL(base *url.URL, allowInsecure bool) error {
 	return errors.New("base URL must use HTTPS unless it targets loopback (http://localhost, http://127.0.0.1, http://[::1]); set AllowInsecureBaseURL to override on trusted private networks")
 }
 
+func effectivePort(u *url.URL) string {
+	if port := u.Port(); port != "" {
+		return port
+	}
+	if strings.EqualFold(u.Scheme, "https") {
+		return "443"
+	}
+	if strings.EqualFold(u.Scheme, "http") {
+		return "80"
+	}
+	return ""
+}
+
+func sameOrigin(a *url.URL, b *url.URL) bool {
+	return strings.EqualFold(a.Scheme, b.Scheme) &&
+		strings.EqualFold(a.Hostname(), b.Hostname()) &&
+		effectivePort(a) == effectivePort(b)
+}
+
 // stripStewardCredentialsOnCrossHostRedirect drops credential and signing
-// headers when a redirect targets a different host, so an open redirect or
+// headers when a redirect targets a different origin, so an open redirect or
 // hostile proxy cannot exfiltrate them (SEC-126).
 func stripStewardCredentialsOnCrossHostRedirect(req *http.Request, via []*http.Request) error {
 	if len(via) == 0 {
 		return nil
 	}
-	if !strings.EqualFold(req.URL.Hostname(), via[0].URL.Hostname()) ||
-		(strings.EqualFold(via[0].URL.Scheme, "https") && !strings.EqualFold(req.URL.Scheme, "https")) {
+	if !sameOrigin(req.URL, via[0].URL) {
 		for _, header := range stewardCredentialHeaders {
 			req.Header.Del(header)
 		}

--- a/packages/go/steward/client.go
+++ b/packages/go/steward/client.go
@@ -176,9 +176,14 @@ func NewClient(config Config) (*Client, error) {
 			return err
 		}
 		if configuredRedirect != nil {
-			return configuredRedirect(req, via)
+			if err := configuredRedirect(req, via); err != nil {
+				return err
+			}
 		}
-		return nil
+		// A caller policy is allowed to mutate req. Re-enforce Steward's mandatory
+		// boundary after it runs so mutation cannot redirect credentials or turn
+		// the client into an SSRF primitive after the initial check.
+		return stewardRedirectPolicy(req, via)
 	}
 	httpClient = &httpClientCopy
 	now := config.Now

--- a/packages/go/steward/client_test.go
+++ b/packages/go/steward/client_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"regexp"
 	"strings"
 	"testing"
@@ -174,9 +175,9 @@ func TestAccountsAndGlobalWalletMutationsAreSigned(t *testing.T) {
 	}
 }
 
-// SEC-126: the default HTTP client must not forward credential headers to a
-// different origin when a redirect is followed. A port change is cross-origin.
-func TestCrossOriginRedirectStripsCredentialHeaders(t *testing.T) {
+// SEC-126: a port change is cross-origin and must not be followed at all. Header
+// stripping alone would still make a server-side SDK caller an SSRF primitive.
+func TestCrossOriginRedirectIsRefused(t *testing.T) {
 	var redirected *http.Request
 	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		redirected = req
@@ -194,30 +195,55 @@ func TestCrossOriginRedirectStripsCredentialHeaders(t *testing.T) {
 		t.Fatal(err)
 	}
 	var out map[string]any
-	if err := client.Get(context.Background(), "/accounts", nil, &out); err != nil {
-		t.Fatal(err)
+	if err := client.Get(context.Background(), "/accounts", nil, &out); err == nil || !strings.Contains(err.Error(), "refusing cross-origin") {
+		t.Fatalf("expected cross-origin redirect refusal, got %v", err)
 	}
-	if redirected == nil {
-		t.Fatal("redirect was not followed")
-	}
-	if got := redirected.Header.Get("X-Steward-Key"); got != "" {
-		t.Fatalf("credential header leaked cross-origin: X-Steward-Key=%q", got)
+	if redirected != nil {
+		t.Fatal("cross-origin redirect target was contacted")
 	}
 }
 
-func TestSameHostHTTPSDowngradeStripsCredentialHeaders(t *testing.T) {
+func TestRedirectPolicyRejectsDowngradeCredentialsAndExcessiveChains(t *testing.T) {
 	original, _ := http.NewRequest(http.MethodGet, "https://api.example.test/accounts", nil)
 	downgrade, _ := http.NewRequest(http.MethodGet, "http://api.example.test/harvest", nil)
 	downgrade.Header.Set("Authorization", "Bearer user-token")
 	downgrade.Header.Set("X-Steward-Key", "tenant-key")
 	downgrade.Header.Set("X-Steward-Signature", "v1=deadbeef")
-	if err := stripStewardCredentialsOnCrossHostRedirect(downgrade, []*http.Request{original}); err != nil {
+	if err := stewardRedirectPolicy(downgrade, []*http.Request{original}); err == nil {
+		t.Fatal("HTTPS downgrade was accepted")
+	}
+	credentialURL, _ := url.Parse("https://user:password@api.example.test/other")
+	credentialRedirect := &http.Request{URL: credentialURL}
+	if err := stewardRedirectPolicy(credentialRedirect, []*http.Request{original}); err == nil {
+		t.Fatal("credential-bearing redirect was accepted")
+	}
+	via := make([]*http.Request, 10)
+	for i := range via {
+		via[i] = original
+	}
+	sameOriginURL, _ := url.Parse("https://api.example.test/other")
+	if err := stewardRedirectPolicy(&http.Request{URL: sameOriginURL}, via); err == nil {
+		t.Fatal("excessive redirect chain was accepted")
+	}
+}
+
+func TestCustomHTTPClientCannotDisableRedirectBoundary(t *testing.T) {
+	customCalled := false
+	custom := &http.Client{CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+		customCalled = true
+		return nil
+	}}
+	client, err := NewClient(Config{BaseURL: "https://api.example.test", HTTPClient: custom})
+	if err != nil {
 		t.Fatal(err)
 	}
-	for _, name := range []string{"Authorization", "X-Steward-Key", "X-Steward-Signature"} {
-		if got := downgrade.Header.Get(name); got != "" {
-			t.Fatalf("credential header leaked on HTTPS downgrade: %s=%q", name, got)
-		}
+	original, _ := http.NewRequest(http.MethodGet, "https://api.example.test/accounts", nil)
+	cross, _ := http.NewRequest(http.MethodGet, "https://evil.example/harvest", nil)
+	if err := client.http.CheckRedirect(cross, []*http.Request{original}); err == nil {
+		t.Fatal("custom client disabled mandatory cross-origin refusal")
+	}
+	if customCalled {
+		t.Fatal("custom redirect callback ran before mandatory boundary")
 	}
 }
 

--- a/packages/go/steward/client_test.go
+++ b/packages/go/steward/client_test.go
@@ -247,6 +247,26 @@ func TestCustomHTTPClientCannotDisableRedirectBoundary(t *testing.T) {
 	}
 }
 
+func TestCustomRedirectPolicyCannotMutatePastRedirectBoundary(t *testing.T) {
+	custom := &http.Client{CheckRedirect: func(req *http.Request, _ []*http.Request) error {
+		mutated, err := url.Parse("http://127.0.0.1:1/internal-metadata")
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.URL = mutated
+		return nil
+	}}
+	client, err := NewClient(Config{BaseURL: "https://api.example.test", HTTPClient: custom})
+	if err != nil {
+		t.Fatal(err)
+	}
+	original, _ := http.NewRequest(http.MethodGet, "https://api.example.test/accounts", nil)
+	redirect, _ := http.NewRequest(http.MethodGet, "https://api.example.test/other", nil)
+	if err := client.http.CheckRedirect(redirect, []*http.Request{original}); err == nil || !strings.Contains(err.Error(), "refusing cross-origin") {
+		t.Fatalf("caller mutation bypassed redirect boundary: %v", err)
+	}
+}
+
 func TestAPIErrorIncludesStatusAndPayload(t *testing.T) {
 	client, err := NewClient(Config{
 		BaseURL: "https://api.example.test",

--- a/packages/go/steward/client_test.go
+++ b/packages/go/steward/client_test.go
@@ -175,8 +175,8 @@ func TestAccountsAndGlobalWalletMutationsAreSigned(t *testing.T) {
 }
 
 // SEC-126: the default HTTP client must not forward credential headers to a
-// different host when a redirect is followed.
-func TestCrossHostRedirectStripsCredentialHeaders(t *testing.T) {
+// different origin when a redirect is followed. A port change is cross-origin.
+func TestCrossOriginRedirectStripsCredentialHeaders(t *testing.T) {
 	var redirected *http.Request
 	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		redirected = req
@@ -184,11 +184,8 @@ func TestCrossHostRedirectStripsCredentialHeaders(t *testing.T) {
 		_, _ = w.Write([]byte(`{"ok":true,"data":{"id":"ok"}}`))
 	}))
 	defer target.Close()
-	// Redirect to the same listener under a DIFFERENT hostname (both names are
-	// loopback, but the host string differs) so the cross-host check engages.
-	crossHostURL := strings.Replace(target.URL, "127.0.0.1", "localhost", 1)
 	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		http.Redirect(w, req, crossHostURL+"/harvest", http.StatusFound)
+		http.Redirect(w, req, target.URL+"/harvest", http.StatusFound)
 	}))
 	defer redirector.Close()
 
@@ -204,7 +201,7 @@ func TestCrossHostRedirectStripsCredentialHeaders(t *testing.T) {
 		t.Fatal("redirect was not followed")
 	}
 	if got := redirected.Header.Get("X-Steward-Key"); got != "" {
-		t.Fatalf("credential header leaked cross-host: X-Steward-Key=%q", got)
+		t.Fatalf("credential header leaked cross-origin: X-Steward-Key=%q", got)
 	}
 }
 

--- a/packages/python/steward_sdk/client.py
+++ b/packages/python/steward_sdk/client.py
@@ -103,15 +103,18 @@ class _StewardRedirectHandler(HTTPRedirectHandler):
         new_req = super().redirect_request(req, fp, code, msg, headers, newurl)
         if new_req is None:
             return None
-        old_host = (urlparse(req.full_url).hostname or "").lower()
-        new_host = (urlparse(new_req.full_url).hostname or "").lower()
-        old_scheme = urlparse(req.full_url).scheme.lower()
-        new_scheme = urlparse(new_req.full_url).scheme.lower()
-        if new_host != old_host or (old_scheme == "https" and new_scheme != "https"):
+        if _origin(new_req.full_url) != _origin(req.full_url):
             for store in (new_req.headers, new_req.unredirected_hdrs):
                 for name in [key for key in store if key.lower() in _CREDENTIAL_HEADERS]:
                     del store[name]
         return new_req
+
+
+def _origin(raw_url: str) -> tuple[str, str, int | None]:
+    parsed = urlparse(raw_url)
+    scheme = parsed.scheme.lower()
+    default_port = 443 if scheme == "https" else 80 if scheme == "http" else None
+    return (scheme, (parsed.hostname or "").lower(), parsed.port or default_port)
 
 
 _default_opener = build_opener(_StewardRedirectHandler())

--- a/packages/python/steward_sdk/client.py
+++ b/packages/python/steward_sdk/client.py
@@ -75,38 +75,22 @@ SENSITIVE_SIGNED_PREFIXES = (
 MUTATING_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
 
 
-# Headers that carry credentials or signing material. urllib capitalizes header
-# names ("X-steward-key"), so comparisons must be case-insensitive.
-_CREDENTIAL_HEADERS = frozenset(
-    name.lower()
-    for name in (
-        "Authorization",
-        "X-Steward-Key",
-        "X-Steward-Platform-Key",
-        "X-Steward-App-Id",
-        "X-Steward-Signature",
-        "X-Steward-Signing-Key-Id",
-        "X-Steward-Request-Timestamp",
-        "Idempotency-Key",
-    )
-)
-
-
 class _StewardRedirectHandler(HTTPRedirectHandler):
-    """Follow redirects, but never forward credential headers to a different
-    host. urllib's default handler converts 301/302/303 POSTs to GET yet copies
-    every header — including API keys and HMAC signatures — to the redirect
-    target, so an open redirect or hostile proxy would exfiltrate them
-    (SEC-125)."""
+    """Follow only same-origin redirects without embedded URL credentials.
+
+    Header stripping alone still lets a hostile Location turn a server-side
+    SDK caller into an SSRF primitive, so cross-origin redirects fail closed.
+    """
 
     def redirect_request(self, req: Request, fp: Any, code: int, msg: str, headers: Any, newurl: str) -> Request | None:
         new_req = super().redirect_request(req, fp, code, msg, headers, newurl)
         if new_req is None:
             return None
+        parsed = urlparse(new_req.full_url)
+        if parsed.username is not None or parsed.password is not None:
+            return None
         if _origin(new_req.full_url) != _origin(req.full_url):
-            for store in (new_req.headers, new_req.unredirected_hdrs):
-                for name in [key for key in store if key.lower() in _CREDENTIAL_HEADERS]:
-                    del store[name]
+            return None
         return new_req
 
 

--- a/packages/python/tests/test_client.py
+++ b/packages/python/tests/test_client.py
@@ -140,6 +140,13 @@ class StewardClientTests(unittest.TestCase):
         self.assertIsNone(downgrade.get_header("X-steward-signature"))
         self.assertEqual(same_host.get_header("X-steward-key"), "tenant-key")
 
+        different_port = handler.redirect_request(
+            original, None, 302, "Found", {}, "https://api.example.test:444/harvest"
+        )
+        self.assertIsNone(different_port.get_header("Authorization"))
+        self.assertIsNone(different_port.get_header("X-steward-key"))
+        self.assertIsNone(different_port.get_header("X-steward-signature"))
+
     def test_path_parameters_are_url_encoded(self):
         # SEC-127: raw interpolation lets `/`, `?`, `#` in an id silently
         # alter the request path/query.

--- a/packages/python/tests/test_client.py
+++ b/packages/python/tests/test_client.py
@@ -110,9 +110,9 @@ class StewardClientTests(unittest.TestCase):
                 f"unsigned mutation: {path}",
             )
 
-    def test_redirect_strips_credential_headers_cross_host(self):
-        # SEC-125: urllib's default redirect handling copies every header to
-        # the redirect target; an open redirect must not receive credentials.
+    def test_redirect_refuses_cross_origin_and_embedded_credentials(self):
+        # SEC-125: stripping headers is insufficient because following an open
+        # redirect would still expose server-side SDK callers to SSRF.
         handler = _StewardRedirectHandler()
         original = Request(
             "https://api.example.test/accounts",
@@ -126,26 +126,24 @@ class StewardClientTests(unittest.TestCase):
         )
 
         cross = handler.redirect_request(original, None, 302, "Found", {}, "https://evil.example/harvest")
-        self.assertIsNone(cross.get_header("Authorization"))
-        self.assertIsNone(cross.get_header("X-steward-key"))
-        self.assertIsNone(cross.get_header("X-steward-platform-key"))
-        self.assertIsNone(cross.get_header("X-steward-signature"))
+        self.assertIsNone(cross)
 
         same_host = handler.redirect_request(original, None, 302, "Found", {}, "https://api.example.test/other")
         self.assertEqual(same_host.get_header("Authorization"), "Bearer user-token")
 
         downgrade = handler.redirect_request(original, None, 302, "Found", {}, "http://api.example.test/other")
-        self.assertIsNone(downgrade.get_header("Authorization"))
-        self.assertIsNone(downgrade.get_header("X-steward-key"))
-        self.assertIsNone(downgrade.get_header("X-steward-signature"))
+        self.assertIsNone(downgrade)
         self.assertEqual(same_host.get_header("X-steward-key"), "tenant-key")
 
         different_port = handler.redirect_request(
             original, None, 302, "Found", {}, "https://api.example.test:444/harvest"
         )
-        self.assertIsNone(different_port.get_header("Authorization"))
-        self.assertIsNone(different_port.get_header("X-steward-key"))
-        self.assertIsNone(different_port.get_header("X-steward-signature"))
+        self.assertIsNone(different_port)
+
+        credential_target = handler.redirect_request(
+            original, None, 302, "Found", {}, "https://user:password@api.example.test/other"
+        )
+        self.assertIsNone(credential_target)
 
     def test_path_parameters_are_url_encoded(self):
         # SEC-127: raw interpolation lets `/`, `?`, `#` in an id silently

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -5,10 +5,12 @@
 ### Security (BREAKING)
 - `authProxyUrl` now enforces its documented same-origin, credential-free URL contract, refuses redirects, and rejects protocol-relative/query/fragment destinations before any refresh token can be deposited.
 - Production auth-proxy custody now uses a `__Host-` refresh cookie, preventing sibling subdomains from shadowing the host-only session with a parent-domain cookie.
+- SDK HTTP clients now refuse redirects rather than replaying Steward bearer,
+  API-key, app-secret, or request-signature headers to a `Location` selected by
+  an intermediary or compromised endpoint. Configure the canonical API URL;
+  redirect aliases are no longer followed.
 - `StewardClient`, `StewardAuth`, and `AgentClient` constructors now REJECT a plaintext non-loopback `baseUrl` (fail closed, SEC-048). These clients transmit platform keys, app secrets, bearer tokens, and HMAC-signed credentials, which must never travel cleartext off-loopback — the CLI has always enforced this. `http://localhost`/`127.0.0.1`/`[::1]` stay allowed for local development; operators on trusted private networks can opt out with the new `allowInsecureBaseUrl: true` config (warns loudly at construction). Previously-working insecure configs must pass the flag or switch to HTTPS.
 - `/accounts` and `/global-wallet` mutations are now HMAC-signed when `requestSigningSecret` is configured, aligning the request-signing prefix list with all eight other SDKs (SEC-049). Servers that enforce signatures on these routes previously saw unsigned mutations from this SDK.
-- Steward SDK clients now reject HTTP redirects so API keys, bearer tokens, and request signatures cannot be replayed to a redirected origin.
-
 ### Added
 - Add `approveVaultTransaction()` and its typed result so SDK consumers can execute an approved vault transaction through the policy-revalidating vault route.
 - `StewardAuthConfig.authProxyUrl`: optional same-origin auth proxy prefix (e.g. `/api/auth`) that keeps the long-lived refresh token in an HttpOnly, SameSite=Strict cookie instead of JS-readable storage (SEC-018). When set, sign-in deposits the refresh token with the proxy (failing closed if the deposit cannot be completed), and refresh / revoke / tenant-switch calls go through the proxy — only the short-lived access token is kept in `storage`. Unset keeps the previous behavior unchanged.

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Production auth-proxy custody now uses a `__Host-` refresh cookie, preventing sibling subdomains from shadowing the host-only session with a parent-domain cookie.
 - `StewardClient`, `StewardAuth`, and `AgentClient` constructors now REJECT a plaintext non-loopback `baseUrl` (fail closed, SEC-048). These clients transmit platform keys, app secrets, bearer tokens, and HMAC-signed credentials, which must never travel cleartext off-loopback — the CLI has always enforced this. `http://localhost`/`127.0.0.1`/`[::1]` stay allowed for local development; operators on trusted private networks can opt out with the new `allowInsecureBaseUrl: true` config (warns loudly at construction). Previously-working insecure configs must pass the flag or switch to HTTPS.
 - `/accounts` and `/global-wallet` mutations are now HMAC-signed when `requestSigningSecret` is configured, aligning the request-signing prefix list with all eight other SDKs (SEC-049). Servers that enforce signatures on these routes previously saw unsigned mutations from this SDK.
+- Steward SDK clients now reject HTTP redirects so API keys, bearer tokens, and request signatures cannot be replayed to a redirected origin.
 
 ### Added
 - Add `approveVaultTransaction()` and its typed result so SDK consumers can execute an approved vault transaction through the policy-revalidating vault route.

--- a/packages/sdk/src/__tests__/agent-client.test.ts
+++ b/packages/sdk/src/__tests__/agent-client.test.ts
@@ -88,6 +88,21 @@ afterEach(() => {
 });
 
 describe("AgentClient — enroll (keypair-only boot)", () => {
+  test("refuses redirects for enrollment and authenticated requests", async () => {
+    const { client, server } = await setup();
+    const realFetch = server.fetch;
+    let requests = 0;
+    (client as unknown as { fetchImpl: typeof fetch }).fetchImpl = async (input, init) => {
+      requests += 1;
+      expect(init?.redirect).toBe("error");
+      return realFetch(input, init);
+    };
+
+    await client.enroll();
+    await client.manifest();
+    expect(requests).toBeGreaterThanOrEqual(3);
+  });
+
   test("boots with keypair only and gets a short-lived agent token", async () => {
     const { client, server } = await setup();
     const result = await client.enroll();

--- a/packages/sdk/src/__tests__/auth-email-otp.test.ts
+++ b/packages/sdk/src/__tests__/auth-email-otp.test.ts
@@ -5,7 +5,7 @@ import { StewardApiError } from "../client";
 // Captures each outbound request so assertions can verify the SDK hit the
 // right Steward endpoints with the right bodies (Privy-style email-OTP +
 // emailGrant passkey signup).
-type Captured = { url: string; body?: Record<string, unknown> };
+type Captured = { url: string; body?: Record<string, unknown>; redirect?: RequestRedirect };
 let captured: Captured[];
 let originalFetch: typeof fetch;
 let originalWindow: unknown;
@@ -43,7 +43,7 @@ function installFetch(): void {
           ? input.toString()
           : (input as Request).url;
     const body = init?.body ? JSON.parse(init.body as string) : undefined;
-    captured.push({ url, body });
+    captured.push({ url, body, redirect: init?.redirect });
     const path = url.replace("https://api.example.test", "");
     const handler = routes[path];
     if (handler) return handler();
@@ -124,6 +124,7 @@ describe("StewardAuth email magic-link companion code", () => {
       tenantId: "elizacloud",
       captchaToken: "captcha-123",
     });
+    expect(captured[0]?.redirect).toBe("error");
     expect(res).toMatchObject({
       ok: true,
       expiresAt: "2026-01-01T00:10:00Z",

--- a/packages/sdk/src/__tests__/client.test.ts
+++ b/packages/sdk/src/__tests__/client.test.ts
@@ -46,6 +46,7 @@ interface CapturedRequest {
   headers: Record<string, string>;
   rawBody: string | undefined;
   body: unknown;
+  redirect: RequestRedirect | undefined;
 }
 
 let lastCapture: CapturedRequest | null = null;
@@ -71,6 +72,7 @@ function installMockFetch(responseBody: object, status = 200): void {
       headers,
       rawBody: init?.body as string | undefined,
       body: init?.body ? JSON.parse(init.body as string) : undefined,
+      redirect: init?.redirect,
     };
     return new Response(JSON.stringify(responseBody), {
       status,
@@ -100,6 +102,7 @@ function installTextMockFetch(responseBody: string, status = 200): void {
       headers,
       rawBody: init?.body as string | undefined,
       body: init?.body ? JSON.parse(init.body as string) : undefined,
+      redirect: init?.redirect,
     };
     return new Response(responseBody, {
       status,
@@ -1068,6 +1071,12 @@ describe("Request headers", () => {
 // ─── HTTP Request Building Tests ──────────────────────────────────────────
 
 describe("HTTP request building", () => {
+  it("refuses redirects so Steward credentials cannot be replayed", async () => {
+    installMockFetch({ ok: true, data: [mockAgent] });
+    await makeClient({ apiKey: "tenant-key" }).listAgents();
+    expect(lastCapture?.redirect).toBe("error");
+  });
+
   it("listAgents → GET /agents", async () => {
     installMockFetch({ ok: true, data: [mockAgent] });
     await makeClient().listAgents();

--- a/packages/sdk/src/agent-client.ts
+++ b/packages/sdk/src/agent-client.ts
@@ -549,6 +549,7 @@ export class AgentClient {
           Authorization: `Bearer ${this.token}`,
         },
         body: JSON.stringify(payload ?? {}),
+        redirect: "error",
       },
     );
 

--- a/packages/sdk/src/auth.ts
+++ b/packages/sdk/src/auth.ts
@@ -776,6 +776,7 @@ export class StewardAuth {
         device_code: input.deviceCode,
         ...(input.clientId ? { client_id: input.clientId } : {}),
       }),
+      redirect: "error",
     }).catch((err) => {
       throw new StewardApiError(err instanceof Error ? err.message : "Network request failed", 0);
     });

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -4939,6 +4939,7 @@ export class StewardClient {
     try {
       response = await fetch(url, {
         headers: this.buildHeaders({ Accept: "text/csv" }),
+        redirect: "error",
       });
     } catch (error) {
       throw new StewardApiError(
@@ -5431,7 +5432,7 @@ export class StewardClient {
     const url = `${this.baseUrl}/audit/export${qs ? `?${qs}` : ""}`;
     let response: Response;
     try {
-      response = await fetch(url, { headers: this.buildHeaders() });
+      response = await fetch(url, { headers: this.buildHeaders(), redirect: "error" });
     } catch (error) {
       throw new StewardApiError(
         error instanceof Error ? error.message : "Network request failed",
@@ -5542,7 +5543,7 @@ export class StewardClient {
     const url = `${this.baseUrl}/user/me/tenants/${encodeURIComponent(tenantId)}/users/export${qs ? `?${qs}` : ""}`;
     let response: Response;
     try {
-      response = await fetch(url, { headers: this.buildHeaders() });
+      response = await fetch(url, { headers: this.buildHeaders(), redirect: "error" });
     } catch (error) {
       throw new StewardApiError(
         error instanceof Error ? error.message : "Network request failed",
@@ -5884,6 +5885,7 @@ export class StewardClient {
       const response = await fetch(`${this.baseUrl}${path}`, {
         ...init,
         headers,
+        redirect: "error",
         signal: controller.signal,
       });
       const payload = await this.parseJson<T>(response, controller.signal);


### PR DESCRIPTION
Post-merge security follow-up to #327.

Two residual issues remained on current `develop`:

- Go/Python redirect guards compared hostnames but not ports, so a redirect to the same hostname on another port retained Steward credentials. TypeScript SDK/auth/agent clients followed redirects with custom credential/signature headers. This patch compares full origins in Go/Python and makes the TypeScript clients fail redirects.
- CLI evidence/audit writes used `mode: 0o600`, which only affects file creation. Overwriting an existing permissive file retained its old mode, and normal writes followed symlinks. This patch opens without following symlinks, verifies a regular file, and applies `fchmod(0600)` before writing.

Exact base: `337bc82bc5522628c385cf989d73435946e22368`
Exact head: `99d5b6a44586f1d85a305064211cea8ea2f6b662`

Validation on the exact head:

- `bun test packages/cli/src/__tests__/evidence-bundle-verify.test.ts packages/sdk/src/__tests__/client.test.ts packages/sdk/src/__tests__/auth-email-otp.test.ts packages/sdk/src/__tests__/agent-client.test.ts` (170 pass)
- `cd packages/go && go test ./... && go vet ./...`
- `PYTHONPATH=packages/python python3 -m unittest discover -s packages/python/tests` (9 pass)
- `cd packages/sdk && bun run build`
- `cd packages/cli && bun run typecheck`
- `git diff --check origin/develop...HEAD`