### PR TITLE
fix(attestation): validate bounded registry structure

### DIFF
--- a/docs/ATTESTATION.md
+++ b/docs/ATTESTATION.md
@@ -78,6 +78,8 @@ The registry lives at `docs/attestation/measurements.json` and has this shape:
 
 Registry signatures are over canonical JSON of `payload`. CI **must** pin trusted release-key fingerprints in `STEWARD_REGISTRY_TRUSTED_KEY_SHA256=...`; each fingerprint is lowercase SHA-256 of the canonical DER-encoded SubjectPublicKeyInfo (SPKI), as returned by `publicKeyFingerprint`. `STEWARD_REGISTRY_TRUSTED_KEY_IDS` may additionally select among those keys but is not itself a trust anchor because the registry supplies its own key IDs. Unpinned verification fails closed (`STEWARD_REGISTRY_ALLOW_UNPINNED=true` exists for local development only and is rejected in CI or production). CI can require more than one valid signature with `STEWARD_REGISTRY_REQUIRED_SIGNATURES=2`; the count must be a positive integer and counts **distinct cryptographic keys**, so reformatting or duplicating one PEM cannot satisfy the intended two-person rule. Any production measurement update must be an explicit PR that reviewers can compare against build/deploy evidence. Optionally pin `STEWARD_REGISTRY_ID` and `STEWARD_REGISTRY_MIN_UPDATED_AT` to bind the expected registry identity and reject registries older than the last-known-good update (replay/rollback protection).
 
+The verifier accepts only the versioned registry fields shown above, bounds the file, payload, deployment and signature counts, and rejects malformed keys, signatures, timestamps and measurements before performing trust checks. Canonical payload keys use deterministic UTF-16 code-unit order rather than locale-sensitive sorting.
+
 ## CI check
 
 Run:

--- a/packages/attestation/src/__tests__/attestation.test.ts
+++ b/packages/attestation/src/__tests__/attestation.test.ts
@@ -371,6 +371,19 @@ describe("measurement registry", () => {
         ["0".repeat(64)],
       ).ok,
     ).toBe(false);
+
+    const valid = signRegistry(basePayload());
+    expect(
+      verifyRegistrySignatures(
+        {
+          ...valid,
+          signatures: [valid.signatures[0], { ...valid.signatures[0], unexpected: true } as never],
+        },
+        1,
+        undefined,
+        registryFingerprints(valid),
+      ).ok,
+    ).toBe(false);
   });
 
   test("malformed pins and signatures fail closed", () => {

--- a/packages/attestation/src/__tests__/attestation.test.ts
+++ b/packages/attestation/src/__tests__/attestation.test.ts
@@ -163,6 +163,7 @@ describe("measurement registry", () => {
     );
     expect(registryPayloadDigest(payload)).toHaveLength(64);
     expect(canonicalizeJson({ b: 1, a: 2 })).toBe('{"a":2,"b":1}');
+    expect(canonicalizeJson({ ä: 1, z: 2 })).toBe('{"z":2,"ä":1}');
     expect(
       verifyQuoteAgainstRegistry(
         {
@@ -390,6 +391,66 @@ describe("measurement registry", () => {
         registryFingerprints(registry),
       ).ok,
     ).toBe(false);
+  });
+
+  test("registry structure and canonicalization are bounded and fail closed", () => {
+    const registry = signRegistry(basePayload());
+    for (const payload of [
+      { ...basePayload(), updatedAt: "2026-07-30" },
+      { ...basePayload(), unexpected: true },
+      { ...basePayload(), deployments: [] },
+      {
+        ...basePayload(),
+        deployments: {
+          prod: {
+            ...basePayload().deployments.prod,
+            measurement: { imageDigest: "x".repeat(1025), configHash: "compose" },
+          },
+        },
+      },
+    ]) {
+      expect(
+        verifyRegistrySignatures(
+          { ...registry, payload: payload as never },
+          1,
+          undefined,
+          registryFingerprints(registry),
+        ).ok,
+      ).toBe(false);
+    }
+
+    const tooManyDeployments = Object.fromEntries(
+      Array.from({ length: 1025 }, (_, index) => [
+        `deployment-${index}`,
+        basePayload().deployments.prod,
+      ]),
+    );
+    expect(
+      verifyRegistrySignatures(
+        { ...registry, payload: { ...basePayload(), deployments: tooManyDeployments } },
+        1,
+        undefined,
+        registryFingerprints(registry),
+      ).ok,
+    ).toBe(false);
+
+    expect(() => canonicalizeJson({ value: Number.NaN })).toThrow();
+    expect(() => canonicalizeJson({ value: undefined })).toThrow();
+    const decoratedArray = [1];
+    Object.assign(decoratedArray, { extra: true });
+    expect(() => canonicalizeJson(decoratedArray)).toThrow();
+    const disguisedSparseArray = Array(2);
+    disguisedSparseArray[1] = 1;
+    Object.assign(disguisedSparseArray, { extra: true });
+    expect(() => canonicalizeJson(disguisedSparseArray)).toThrow();
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    expect(() => canonicalizeJson(cyclic)).toThrow();
+
+    const malformedQuote = () =>
+      verifyQuoteAgainstRegistry({ verified: true, measurement: null } as never, registry, "prod");
+    expect(malformedQuote).not.toThrow();
+    expect(malformedQuote().ok).toBe(false);
   });
 });
 

--- a/packages/attestation/src/__tests__/attestation.test.ts
+++ b/packages/attestation/src/__tests__/attestation.test.ts
@@ -436,6 +436,8 @@ describe("measurement registry", () => {
 
     expect(() => canonicalizeJson({ value: Number.NaN })).toThrow();
     expect(() => canonicalizeJson({ value: undefined })).toThrow();
+    expect(() => canonicalizeJson({ value: "\ud800" })).toThrow();
+    expect(() => canonicalizeJson({ "\udc00": true })).toThrow();
     const decoratedArray = [1];
     Object.assign(decoratedArray, { extra: true });
     expect(() => canonicalizeJson(decoratedArray)).toThrow();
@@ -443,6 +445,12 @@ describe("measurement registry", () => {
     disguisedSparseArray[1] = 1;
     Object.assign(disguisedSparseArray, { extra: true });
     expect(() => canonicalizeJson(disguisedSparseArray)).toThrow();
+    const symbolDecorated = { value: 1 };
+    Object.assign(symbolDecorated, { [Symbol("extra")]: true });
+    expect(() => canonicalizeJson(symbolDecorated)).toThrow();
+    const accessorDecorated = {};
+    Object.defineProperty(accessorDecorated, "value", { enumerable: true, get: () => 1 });
+    expect(() => canonicalizeJson(accessorDecorated)).toThrow();
     const cyclic: Record<string, unknown> = {};
     cyclic.self = cyclic;
     expect(() => canonicalizeJson(cyclic)).toThrow();
@@ -451,6 +459,50 @@ describe("measurement registry", () => {
       verifyQuoteAgainstRegistry({ verified: true, measurement: null } as never, registry, "prod");
     expect(malformedQuote).not.toThrow();
     expect(malformedQuote().ok).toBe(false);
+    expect(
+      verifyQuoteAgainstRegistry(
+        {
+          provider: "dstack-tdx",
+          measurement: { imageDigest: "sha256:img", configHash: "compose" },
+          timestamp: new Date().toISOString(),
+          verified: "true",
+          raw: {},
+        } as never,
+        registry,
+        "prod",
+      ).ok,
+    ).toBe(false);
+    expect(
+      verifyQuoteAgainstRegistry(
+        {
+          provider: "dstack-tdx",
+          measurement: { imageDigest: "sha256:img", configHash: "compose" },
+          timestamp: 42,
+          verified: true,
+          raw: {},
+        } as never,
+        registry,
+        "prod",
+      ).ok,
+    ).toBe(false);
+    const throwingQuote = Object.defineProperty({}, "timestamp", {
+      enumerable: true,
+      get() {
+        throw new Error("hostile accessor");
+      },
+    });
+    expect(() =>
+      verifyQuoteAgainstRegistry(throwingQuote as never, registry, "prod"),
+    ).not.toThrow();
+    expect(verifyQuoteAgainstRegistry(throwingQuote as never, registry, "prod").ok).toBe(false);
+    expect(
+      verifyRegistrySignatures(
+        { ...registry, unsignedMetadata: "misleading" } as never,
+        1,
+        undefined,
+        registryFingerprints(registry),
+      ).ok,
+    ).toBe(false);
   });
 });
 

--- a/packages/attestation/src/registry.ts
+++ b/packages/attestation/src/registry.ts
@@ -59,6 +59,90 @@ export interface RegistryVerificationOptions {
 const MAX_REGISTRY_SIGNATURES = 64;
 const MAX_REGISTRY_PAYLOAD_BYTES = 1024 * 1024;
 const MAX_PUBLIC_KEY_PEM_BYTES = 16 * 1024;
+export const MAX_MEASUREMENT_REGISTRY_FILE_BYTES = 3 * 1024 * 1024;
+const MAX_REGISTRY_DEPLOYMENTS = 1024;
+const REGISTRY_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+const PROVIDER_IDS = new Set<AttestationProviderId>([
+  "dstack-tdx",
+  "noop-dev",
+  "aws-nitro",
+  "amd-sev-snp",
+]);
+const DEPLOYMENT_STATUSES = new Set(["active", "pending", "retired"]);
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function isBoundedText(value: unknown, maxBytes: number, allowEmpty = false): value is string {
+  return (
+    typeof value === "string" &&
+    (allowEmpty || value.length > 0) &&
+    Buffer.byteLength(value, "utf8") <= maxBytes
+  );
+}
+
+function hasOnlyKeys(value: Record<string, unknown>, allowed: ReadonlySet<string>): boolean {
+  return Object.keys(value).every((key) => allowed.has(key));
+}
+
+function validateRegistryPayload(payload: unknown): string | null {
+  if (!isPlainObject(payload)) return "registry payload must be an object";
+  if (!hasOnlyKeys(payload, new Set(["schemaVersion", "registryId", "updatedAt", "deployments"])))
+    return "registry payload has unknown fields";
+  if (payload.schemaVersion !== 1) return "unsupported registry schema";
+  if (typeof payload.registryId !== "string" || !REGISTRY_ID_PATTERN.test(payload.registryId))
+    return "registryId is invalid";
+  if (!isBoundedText(payload.updatedAt, 64)) return "registry updatedAt is invalid";
+  const updatedAt = Date.parse(payload.updatedAt);
+  if (!Number.isFinite(updatedAt) || new Date(updatedAt).toISOString() !== payload.updatedAt)
+    return "registry updatedAt must be a canonical ISO timestamp";
+  if (!isPlainObject(payload.deployments)) return "registry deployments must be an object";
+  const deployments = Object.entries(payload.deployments);
+  if (deployments.length > MAX_REGISTRY_DEPLOYMENTS)
+    return `registry has too many deployments (max ${MAX_REGISTRY_DEPLOYMENTS})`;
+
+  let estimatedBytes = 256;
+  const addText = (value: string) => {
+    estimatedBytes += Buffer.byteLength(JSON.stringify(value), "utf8") + 16;
+    return estimatedBytes <= MAX_REGISTRY_PAYLOAD_BYTES;
+  };
+  for (const [deploymentId, rawEntry] of deployments) {
+    if (!REGISTRY_ID_PATTERN.test(deploymentId) || !addText(deploymentId))
+      return "registry deployment id is invalid or payload is too large";
+    if (!isPlainObject(rawEntry)) return `deployment ${deploymentId} must be an object`;
+    if (!hasOnlyKeys(rawEntry, new Set(["provider", "measurement", "endpoint", "status", "notes"])))
+      return `deployment ${deploymentId} has unknown fields`;
+    if (!PROVIDER_IDS.has(rawEntry.provider as AttestationProviderId))
+      return `deployment ${deploymentId} has an invalid provider`;
+    if (!DEPLOYMENT_STATUSES.has(rawEntry.status as string))
+      return `deployment ${deploymentId} has an invalid status`;
+    if (!isPlainObject(rawEntry.measurement))
+      return `deployment ${deploymentId} measurement must be an object`;
+    if (!hasOnlyKeys(rawEntry.measurement, new Set(["imageDigest", "configHash"])))
+      return `deployment ${deploymentId} measurement has unknown fields`;
+    if (
+      !isBoundedText(rawEntry.measurement.imageDigest, 1024) ||
+      !isBoundedText(rawEntry.measurement.configHash, 1024) ||
+      !addText(rawEntry.measurement.imageDigest) ||
+      !addText(rawEntry.measurement.configHash)
+    )
+      return `deployment ${deploymentId} measurement is invalid or payload is too large`;
+    if (
+      rawEntry.endpoint !== undefined &&
+      (!isBoundedText(rawEntry.endpoint, 2048) || !addText(rawEntry.endpoint))
+    )
+      return `deployment ${deploymentId} endpoint is invalid or payload is too large`;
+    if (
+      rawEntry.notes !== undefined &&
+      (!isBoundedText(rawEntry.notes, 4096, true) || !addText(rawEntry.notes))
+    )
+      return `deployment ${deploymentId} notes are invalid or payload is too large`;
+  }
+  return null;
+}
 
 function parseEd25519PublicKey(publicKeyPem: unknown): {
   key: ReturnType<typeof createPublicKey>;
@@ -99,12 +183,41 @@ function decodeEd25519Signature(signatureBase64: unknown): Buffer | null {
 }
 
 export function canonicalizeJson(value: unknown): string {
-  if (value === null || typeof value !== "object") return JSON.stringify(value);
-  if (Array.isArray(value)) return `[${value.map((entry) => canonicalizeJson(entry)).join(",")}]`;
-  return `{${Object.entries(value as Record<string, unknown>)
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([key, entry]) => `${JSON.stringify(key)}:${canonicalizeJson(entry)}`)
-    .join(",")}}`;
+  const ancestors = new Set<object>();
+  const visit = (entry: unknown, depth: number): string => {
+    if (depth > 64) throw new Error("JSON nesting exceeds canonicalization limit");
+    if (entry === null || typeof entry === "string" || typeof entry === "boolean")
+      return JSON.stringify(entry);
+    if (typeof entry === "number") {
+      if (!Number.isFinite(entry)) throw new Error("non-finite JSON number");
+      return JSON.stringify(entry);
+    }
+    if (typeof entry !== "object") throw new Error("value is not JSON-serializable");
+    if (ancestors.has(entry)) throw new Error("cyclic JSON value");
+    ancestors.add(entry);
+    try {
+      if (Array.isArray(entry)) {
+        if (
+          Object.keys(entry).length !== entry.length ||
+          !Array.from({ length: entry.length }, (_, index) => Object.hasOwn(entry, index)).every(
+            Boolean,
+          )
+        )
+          throw new Error("sparse or decorated JSON array");
+        return `[${entry.map((item) => visit(item, depth + 1)).join(",")}]`;
+      }
+      if (!isPlainObject(entry)) throw new Error("value is not a plain JSON object");
+      return `{${Object.entries(entry)
+        // RFC 8785/JCS orders property names by UTF-16 code units, not the
+        // process locale. localeCompare can produce different signed bytes.
+        .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+        .map(([key, item]) => `${JSON.stringify(key)}:${visit(item, depth + 1)}`)
+        .join(",")}}`;
+    } finally {
+      ancestors.delete(entry);
+    }
+  };
+  return visit(value, 0);
 }
 
 export function registryPayloadDigest(payload: MeasurementRegistryPayload): string {
@@ -142,8 +255,22 @@ export function verifyRegistrySignatures(
       reason: `invalid requiredSignatureCount: ${requiredSignatureCount} (must be an integer >= 1)`,
     };
   }
-  if (registry.payload.schemaVersion !== 1)
-    return { ok: false, reason: "unsupported registry schema" };
+  let payloadError: string | null;
+  try {
+    payloadError = validateRegistryPayload(registry.payload);
+  } catch {
+    return { ok: false, reason: "malformed measurement registry payload" };
+  }
+  if (payloadError) return { ok: false, reason: payloadError };
+  let payload: Buffer;
+  try {
+    payload = Buffer.from(canonicalizeJson(registry.payload));
+  } catch {
+    return { ok: false, reason: "registry payload is not canonicalizable JSON" };
+  }
+  if (payload.byteLength > MAX_REGISTRY_PAYLOAD_BYTES) {
+    return { ok: false, reason: "registry payload exceeded the 1 MiB limit" };
+  }
 
   // SEC-086: bind registry metadata so signed files cannot be swapped across
   // environments or replayed to roll back retired measurements.
@@ -201,11 +328,13 @@ export function verifyRegistrySignatures(
     fingerprint: string;
   }> = [];
   for (const value of registry.signatures as unknown[]) {
-    if (!value || typeof value !== "object") continue;
-    const signature = value as MeasurementRegistrySignature;
+    if (!isPlainObject(value)) continue;
+    const signature = value as unknown as MeasurementRegistrySignature;
     if (
+      !hasOnlyKeys(value, new Set(["keyId", "algorithm", "publicKeyPem", "signatureBase64"])) ||
       signature.algorithm !== "ed25519" ||
       typeof signature.keyId !== "string" ||
+      !REGISTRY_ID_PATTERN.test(signature.keyId) ||
       (trustedIds && !trustedIds.has(signature.keyId))
     ) {
       continue;
@@ -221,15 +350,6 @@ export function verifyRegistrySignatures(
     };
   }
 
-  let payload: Buffer;
-  try {
-    payload = Buffer.from(canonicalizeJson(registry.payload));
-  } catch {
-    return { ok: false, reason: "registry payload is not canonicalizable JSON" };
-  }
-  if (payload.byteLength > MAX_REGISTRY_PAYLOAD_BYTES) {
-    return { ok: false, reason: "registry payload exceeded the 1 MiB limit" };
-  }
   // SEC-008: count DISTINCT keys, not signature array entries — the same
   // signature pasted twice must not satisfy a two-person quorum.
   const validKeyFingerprints = new Set<string>();
@@ -270,6 +390,15 @@ export function verifyQuoteAgainstRegistry(
   registry: MeasurementRegistryFile,
   deployment: string,
 ): RegistryVerificationResult {
+  let payloadError: string | null;
+  try {
+    payloadError = validateRegistryPayload(registry?.payload);
+  } catch {
+    return { ok: false, reason: "malformed measurement registry payload" };
+  }
+  if (payloadError) return { ok: false, reason: payloadError };
+  if (!quote || typeof quote !== "object" || !isPlainObject(quote.measurement))
+    return { ok: false, reason: "malformed attestation quote" };
   const entry = registry.payload.deployments[deployment];
   if (!entry) return { ok: false, reason: `unknown deployment: ${deployment}` };
   if (entry.status !== "active")

--- a/packages/attestation/src/registry.ts
+++ b/packages/attestation/src/registry.ts
@@ -349,27 +349,41 @@ export function verifyRegistrySignatures(
         "(or dangerouslyAllowUnpinned for local development only)",
     };
   }
-  const candidateSignatures: Array<{
+  const parsedSignatures: Array<{
     signature: MeasurementRegistrySignature;
     key: ReturnType<typeof createPublicKey>;
     fingerprint: string;
+    signatureBytes: Buffer;
   }> = [];
-  for (const value of registry.signatures as unknown[]) {
-    if (!isPlainObject(value)) continue;
-    const signature = value as unknown as MeasurementRegistrySignature;
-    if (
-      !hasOnlyKeys(value, new Set(["keyId", "algorithm", "publicKeyPem", "signatureBase64"])) ||
-      signature.algorithm !== "ed25519" ||
-      typeof signature.keyId !== "string" ||
-      !REGISTRY_ID_PATTERN.test(signature.keyId) ||
-      (trustedIds && !trustedIds.has(signature.keyId))
-    ) {
-      continue;
+  try {
+    for (const value of registry.signatures as unknown[]) {
+      if (!isPlainObject(value)) {
+        return { ok: false, reason: "registry has a malformed signature entry" };
+      }
+      const signature = value as unknown as MeasurementRegistrySignature;
+      if (
+        !hasOnlyKeys(value, new Set(["keyId", "algorithm", "publicKeyPem", "signatureBase64"])) ||
+        signature.algorithm !== "ed25519" ||
+        typeof signature.keyId !== "string" ||
+        !REGISTRY_ID_PATTERN.test(signature.keyId)
+      ) {
+        return { ok: false, reason: "registry has a malformed signature entry" };
+      }
+      const parsed = parseEd25519PublicKey(signature.publicKeyPem);
+      const signatureBytes = decodeEd25519Signature(signature.signatureBase64);
+      if (!parsed || !signatureBytes) {
+        return { ok: false, reason: "registry has a malformed signature entry" };
+      }
+      parsedSignatures.push({ signature, ...parsed, signatureBytes });
     }
-    const parsed = parseEd25519PublicKey(signature.publicKeyPem);
-    if (!parsed || (trustedFingerprints && !trustedFingerprints.has(parsed.fingerprint))) continue;
-    candidateSignatures.push({ signature, ...parsed });
+  } catch {
+    return { ok: false, reason: "registry has a malformed signature entry" };
   }
+  const candidateSignatures = parsedSignatures.filter(
+    ({ signature, fingerprint }) =>
+      (!trustedIds || trustedIds.has(signature.keyId)) &&
+      (!trustedFingerprints || trustedFingerprints.has(fingerprint)),
+  );
   if (candidateSignatures.length < requiredSignatureCount) {
     return {
       ok: false,
@@ -381,10 +395,8 @@ export function verifyRegistrySignatures(
   // signature pasted twice must not satisfy a two-person quorum.
   const validKeyFingerprints = new Set<string>();
   for (const candidate of candidateSignatures) {
-    const signatureBytes = decodeEd25519Signature(candidate.signature.signatureBase64);
-    if (!signatureBytes) continue;
     try {
-      const valid = verifySignature(null, payload, candidate.key, signatureBytes);
+      const valid = verifySignature(null, payload, candidate.key, candidate.signatureBytes);
       // Count the canonical SPKI key, not textual PEM formatting. Re-wrapping
       // one PEM must not turn one signing key into two quorum participants.
       if (valid) {

--- a/packages/attestation/src/registry.ts
+++ b/packages/attestation/src/registry.ts
@@ -76,6 +76,20 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return prototype === Object.prototype || prototype === null;
 }
 
+function isWellFormedUnicode(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) return false;
+      index += 1;
+    } else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+      return false;
+    }
+  }
+  return true;
+}
+
 function isBoundedText(value: unknown, maxBytes: number, allowEmpty = false): value is string {
   return (
     typeof value === "string" &&
@@ -186,8 +200,11 @@ export function canonicalizeJson(value: unknown): string {
   const ancestors = new Set<object>();
   const visit = (entry: unknown, depth: number): string => {
     if (depth > 64) throw new Error("JSON nesting exceeds canonicalization limit");
-    if (entry === null || typeof entry === "string" || typeof entry === "boolean")
+    if (entry === null || typeof entry === "boolean") return JSON.stringify(entry);
+    if (typeof entry === "string") {
+      if (!isWellFormedUnicode(entry)) throw new Error("JSON string contains a lone surrogate");
       return JSON.stringify(entry);
+    }
     if (typeof entry === "number") {
       if (!Number.isFinite(entry)) throw new Error("non-finite JSON number");
       return JSON.stringify(entry);
@@ -197,17 +214,27 @@ export function canonicalizeJson(value: unknown): string {
     ancestors.add(entry);
     try {
       if (Array.isArray(entry)) {
-        if (
-          Object.keys(entry).length !== entry.length ||
-          !Array.from({ length: entry.length }, (_, index) => Object.hasOwn(entry, index)).every(
-            Boolean,
-          )
-        )
+        const ownKeys = Reflect.ownKeys(entry);
+        if (ownKeys.length !== entry.length + 1 || !ownKeys.includes("length"))
           throw new Error("sparse or decorated JSON array");
-        return `[${entry.map((item) => visit(item, depth + 1)).join(",")}]`;
+        const items = Array.from({ length: entry.length }, (_, index) => {
+          const descriptor = Object.getOwnPropertyDescriptor(entry, String(index));
+          if (!descriptor?.enumerable || !("value" in descriptor))
+            throw new Error("sparse or decorated JSON array");
+          return visit(descriptor.value, depth + 1);
+        });
+        return `[${items.join(",")}]`;
       }
       if (!isPlainObject(entry)) throw new Error("value is not a plain JSON object");
-      return `{${Object.entries(entry)
+      const entries = Reflect.ownKeys(entry).map((key): [string, unknown] => {
+        if (typeof key !== "string" || !isWellFormedUnicode(key))
+          throw new Error("JSON object has a non-JSON property key");
+        const descriptor = Object.getOwnPropertyDescriptor(entry, key);
+        if (!descriptor?.enumerable || !("value" in descriptor))
+          throw new Error("JSON object has a non-JSON property");
+        return [key, descriptor.value];
+      });
+      return `{${entries
         // RFC 8785/JCS orders property names by UTF-16 code units, not the
         // process locale. localeCompare can produce different signed bytes.
         .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
@@ -232,8 +259,8 @@ export function verifyRegistrySignatures(
   options?: RegistryVerificationOptions,
 ): RegistryVerificationResult {
   if (
-    !registry ||
-    typeof registry !== "object" ||
+    !isPlainObject(registry) ||
+    !hasOnlyKeys(registry, new Set(["payload", "signatures"])) ||
     !registry.payload ||
     typeof registry.payload !== "object" ||
     !Array.isArray(registry.signatures)
@@ -397,9 +424,28 @@ export function verifyQuoteAgainstRegistry(
     return { ok: false, reason: "malformed measurement registry payload" };
   }
   if (payloadError) return { ok: false, reason: payloadError };
-  if (!quote || typeof quote !== "object" || !isPlainObject(quote.measurement))
+  let malformedQuote: boolean;
+  try {
+    const timestamp = isPlainObject(quote) && quote.timestamp;
+    malformedQuote =
+      !isPlainObject(quote) ||
+      typeof quote.verified !== "boolean" ||
+      !PROVIDER_IDS.has(quote.provider as AttestationProviderId) ||
+      !isPlainObject(quote.measurement) ||
+      !isBoundedText(quote.measurement.imageDigest, 1024) ||
+      !isBoundedText(quote.measurement.configHash, 1024) ||
+      !isBoundedText(timestamp, 64) ||
+      !Number.isFinite(Date.parse(timestamp)) ||
+      new Date(timestamp).toISOString() !== timestamp;
+  } catch {
     return { ok: false, reason: "malformed attestation quote" };
-  const entry = registry.payload.deployments[deployment];
+  }
+  if (malformedQuote) return { ok: false, reason: "malformed attestation quote" };
+  if (typeof deployment !== "string" || !REGISTRY_ID_PATTERN.test(deployment))
+    return { ok: false, reason: "malformed deployment id" };
+  const entry = Object.hasOwn(registry.payload.deployments, deployment)
+    ? registry.payload.deployments[deployment]
+    : undefined;
   if (!entry) return { ok: false, reason: `unknown deployment: ${deployment}` };
   if (entry.status !== "active")
     return { ok: false, reason: `deployment ${deployment} is ${entry.status}` };

--- a/scripts/check-attestation.ts
+++ b/scripts/check-attestation.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 import {
   createDstackTdxProvider,
+  MAX_MEASUREMENT_REGISTRY_FILE_BYTES,
   type MeasurementRegistryFile,
   verifyQuoteAgainstRegistry,
   verifyRegistrySignatures,
@@ -53,7 +54,20 @@ if (!endpoint) {
   process.exit(2);
 }
 
-const registry = (await Bun.file(registryPath).json()) as MeasurementRegistryFile;
+const registryFile = Bun.file(registryPath);
+if (registryFile.size > MAX_MEASUREMENT_REGISTRY_FILE_BYTES) {
+  console.error(
+    `measurement registry exceeds ${MAX_MEASUREMENT_REGISTRY_FILE_BYTES} bytes: ${registryPath}`,
+  );
+  process.exit(2);
+}
+let registry: MeasurementRegistryFile;
+try {
+  registry = (await registryFile.json()) as MeasurementRegistryFile;
+} catch {
+  console.error(`measurement registry is not valid JSON: ${registryPath}`);
+  process.exit(2);
+}
 const registryOk = verifyRegistrySignatures(
   registry,
   requiredSignatures,


### PR DESCRIPTION
## Summary

Post-merge security audit follow-up for #370.

- validate the complete signed registry payload shape and reject unknown or malformed fields before signature verification
- bound registry files, payloads, deployments, identifiers, measurements, endpoints, notes, signatures and PEMs
- canonicalize JSON with deterministic UTF-16 key ordering instead of locale-sensitive sorting, rejecting non-JSON, cyclic, sparse and decorated values
- make quote matching fail closed on malformed runtime inputs
- give the attestation CLI bounded-file and malformed-JSON diagnostics

## Security rationale

The new registry trust implementation merged in #370 correctly pins canonical Ed25519 SPKI fingerprints and counts distinct cryptographic identities, but its signed payload was only shallowly checked. A malformed but validly signed payload could exceed intended structural bounds or throw later during quote matching, and `localeCompare` made signed bytes locale-dependent.

## Validation

- `bun test packages/attestation/src/__tests__/attestation.test.ts`: 18 pass, 0 fail, 62 assertions
- focused vault regressions: 13 pass, 0 fail
- API/vault/FROST dependency build graph: 22/22 packages successful
- oversized CLI registry fixture exits 2 before parsing
- Biome and `git diff --check`
