### PR TITLE
fix(attestation): bound registry ingestion

### DIFF
--- a/packages/attestation/src/__tests__/attestation.test.ts
+++ b/packages/attestation/src/__tests__/attestation.test.ts
@@ -517,6 +517,21 @@ describe("measurement registry", () => {
       ).ok,
     ).toBe(false);
   });
+
+  test("rejects oversized canonical JSON before constructing a full canonical copy", () => {
+    expect(() => canonicalizeJson({ value: "x".repeat(1024 * 1024 + 1) })).toThrow(
+      "registry payload exceeded the 1 MiB limit",
+    );
+  });
+
+  test("rejects deeply nested canonical JSON without recursive stack exhaustion", () => {
+    let nested: Record<string, unknown> = {};
+    for (let depth = 0; depth < 1000; depth += 1) nested = { nested };
+
+    expect(() => canonicalizeJson(nested)).toThrow(
+      "registry payload exceeded the maximum depth of 64",
+    );
+  });
 });
 
 function basePayload(): MeasurementRegistryPayload {

--- a/packages/attestation/src/registry.ts
+++ b/packages/attestation/src/registry.ts
@@ -58,8 +58,10 @@ export interface RegistryVerificationOptions {
 
 const MAX_REGISTRY_SIGNATURES = 64;
 const MAX_REGISTRY_PAYLOAD_BYTES = 1024 * 1024;
+const MAX_REGISTRY_PAYLOAD_DEPTH = 64;
+const MAX_REGISTRY_PAYLOAD_NODES = 100_000;
 const MAX_PUBLIC_KEY_PEM_BYTES = 16 * 1024;
-export const MAX_MEASUREMENT_REGISTRY_FILE_BYTES = 3 * 1024 * 1024;
+export const MAX_MEASUREMENT_REGISTRY_FILE_BYTES = 4 * 1024 * 1024;
 const MAX_REGISTRY_DEPLOYMENTS = 1024;
 const REGISTRY_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
 const PROVIDER_IDS = new Set<AttestationProviderId>([
@@ -196,34 +198,74 @@ function decodeEd25519Signature(signatureBase64: unknown): Buffer | null {
   return decoded;
 }
 
+class RegistryPayloadLimitError extends Error {}
+
 export function canonicalizeJson(value: unknown): string {
+  const chunks: string[] = [];
+  let bytes = 0;
+  let nodes = 0;
   const ancestors = new Set<object>();
-  const visit = (entry: unknown, depth: number): string => {
-    if (depth > 64) throw new Error("JSON nesting exceeds canonicalization limit");
-    if (entry === null || typeof entry === "boolean") return JSON.stringify(entry);
+
+  const append = (chunk: string): void => {
+    bytes += Buffer.byteLength(chunk, "utf8");
+    if (bytes > MAX_REGISTRY_PAYLOAD_BYTES) {
+      throw new RegistryPayloadLimitError("registry payload exceeded the 1 MiB limit");
+    }
+    chunks.push(chunk);
+  };
+
+  const visit = (entry: unknown, depth: number): void => {
+    if (depth > MAX_REGISTRY_PAYLOAD_DEPTH) {
+      throw new RegistryPayloadLimitError(
+        `registry payload exceeded the maximum depth of ${MAX_REGISTRY_PAYLOAD_DEPTH}`,
+      );
+    }
+    nodes += 1;
+    if (nodes > MAX_REGISTRY_PAYLOAD_NODES) {
+      throw new RegistryPayloadLimitError(
+        `registry payload exceeded the maximum node count of ${MAX_REGISTRY_PAYLOAD_NODES}`,
+      );
+    }
+    if (entry === null || typeof entry === "boolean") {
+      append(JSON.stringify(entry));
+      return;
+    }
     if (typeof entry === "string") {
       if (!isWellFormedUnicode(entry)) throw new Error("JSON string contains a lone surrogate");
-      return JSON.stringify(entry);
+      if (Buffer.byteLength(entry, "utf8") > MAX_REGISTRY_PAYLOAD_BYTES) {
+        throw new RegistryPayloadLimitError("registry payload exceeded the 1 MiB limit");
+      }
+      append(JSON.stringify(entry));
+      return;
     }
     if (typeof entry === "number") {
       if (!Number.isFinite(entry)) throw new Error("non-finite JSON number");
-      return JSON.stringify(entry);
+      append(JSON.stringify(entry));
+      return;
     }
     if (typeof entry !== "object") throw new Error("value is not JSON-serializable");
     if (ancestors.has(entry)) throw new Error("cyclic JSON value");
     ancestors.add(entry);
     try {
       if (Array.isArray(entry)) {
+        if (entry.length > MAX_REGISTRY_PAYLOAD_NODES) {
+          throw new RegistryPayloadLimitError(
+            `registry payload exceeded the maximum node count of ${MAX_REGISTRY_PAYLOAD_NODES}`,
+          );
+        }
         const ownKeys = Reflect.ownKeys(entry);
         if (ownKeys.length !== entry.length + 1 || !ownKeys.includes("length"))
           throw new Error("sparse or decorated JSON array");
-        const items = Array.from({ length: entry.length }, (_, index) => {
+        append("[");
+        for (let index = 0; index < entry.length; index += 1) {
+          if (index > 0) append(",");
           const descriptor = Object.getOwnPropertyDescriptor(entry, String(index));
           if (!descriptor?.enumerable || !("value" in descriptor))
             throw new Error("sparse or decorated JSON array");
-          return visit(descriptor.value, depth + 1);
-        });
-        return `[${items.join(",")}]`;
+          visit(descriptor.value, depth + 1);
+        }
+        append("]");
+        return;
       }
       if (!isPlainObject(entry)) throw new Error("value is not a plain JSON object");
       const entries = Reflect.ownKeys(entry).map((key): [string, unknown] => {
@@ -234,17 +276,29 @@ export function canonicalizeJson(value: unknown): string {
           throw new Error("JSON object has a non-JSON property");
         return [key, descriptor.value];
       });
-      return `{${entries
-        // RFC 8785/JCS orders property names by UTF-16 code units, not the
-        // process locale. localeCompare can produce different signed bytes.
-        .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
-        .map(([key, item]) => `${JSON.stringify(key)}:${visit(item, depth + 1)}`)
-        .join(",")}}`;
+      if (entries.length > MAX_REGISTRY_PAYLOAD_NODES) {
+        throw new RegistryPayloadLimitError(
+          `registry payload exceeded the maximum node count of ${MAX_REGISTRY_PAYLOAD_NODES}`,
+        );
+      }
+      entries.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+      append("{");
+      for (const [index, [key, item]] of entries.entries()) {
+        if (index > 0) append(",");
+        if (Buffer.byteLength(key, "utf8") > MAX_REGISTRY_PAYLOAD_BYTES) {
+          throw new RegistryPayloadLimitError("registry payload exceeded the 1 MiB limit");
+        }
+        append(JSON.stringify(key));
+        append(":");
+        visit(item, depth + 1);
+      }
+      append("}");
     } finally {
       ancestors.delete(entry);
     }
   };
-  return visit(value, 0);
+  visit(value, 0);
+  return chunks.join("");
 }
 
 export function registryPayloadDigest(payload: MeasurementRegistryPayload): string {
@@ -292,7 +346,10 @@ export function verifyRegistrySignatures(
   let payload: Buffer;
   try {
     payload = Buffer.from(canonicalizeJson(registry.payload));
-  } catch {
+  } catch (error) {
+    if (error instanceof RegistryPayloadLimitError) {
+      return { ok: false, reason: error.message };
+    }
     return { ok: false, reason: "registry payload is not canonicalizable JSON" };
   }
   if (payload.byteLength > MAX_REGISTRY_PAYLOAD_BYTES) {

--- a/scripts/__tests__/check-attestation.test.ts
+++ b/scripts/__tests__/check-attestation.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+describe("check-attestation bounded registry ingestion", () => {
+  test("rejects a registry file over 4 MiB before JSON parsing or network access", () => {
+    const directory = mkdtempSync(join(tmpdir(), "steward-attestation-"));
+    const registryPath = join(directory, "oversized.json");
+    try {
+      writeFileSync(registryPath, Buffer.alloc(4 * 1024 * 1024 + 1, 0x20));
+      const result = Bun.spawnSync([process.execPath, "scripts/check-attestation.ts"], {
+        cwd: join(import.meta.dir, "../.."),
+        env: {
+          ...process.env,
+          STEWARD_ATTESTATION_ENDPOINT: "http://127.0.0.1:1/never-requested",
+          STEWARD_MEASUREMENT_REGISTRY: registryPath,
+          STEWARD_REGISTRY_ALLOW_UNPINNED: "true",
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr.toString()).toContain(
+        "measurement registry file exceeded the 4 MiB ingestion limit",
+      );
+      expect(result.stderr.toString()).not.toContain("fetch");
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/check-attestation.ts
+++ b/scripts/check-attestation.ts
@@ -1,11 +1,32 @@
 #!/usr/bin/env bun
+import { open } from "node:fs/promises";
 import {
   createDstackTdxProvider,
-  MAX_MEASUREMENT_REGISTRY_FILE_BYTES,
   type MeasurementRegistryFile,
   verifyQuoteAgainstRegistry,
   verifyRegistrySignatures,
 } from "@stwd/attestation";
+
+const MAX_REGISTRY_FILE_BYTES = 4 * 1024 * 1024;
+
+async function readBoundedRegistry(path: string): Promise<MeasurementRegistryFile> {
+  const handle = await open(path, "r");
+  try {
+    const bytes = Buffer.alloc(MAX_REGISTRY_FILE_BYTES + 1);
+    let offset = 0;
+    while (offset < bytes.byteLength) {
+      const { bytesRead } = await handle.read(bytes, offset, bytes.byteLength - offset, null);
+      if (bytesRead === 0) break;
+      offset += bytesRead;
+    }
+    if (offset > MAX_REGISTRY_FILE_BYTES) {
+      throw new Error("measurement registry file exceeded the 4 MiB ingestion limit");
+    }
+    return JSON.parse(bytes.subarray(0, offset).toString("utf8")) as MeasurementRegistryFile;
+  } finally {
+    await handle.close();
+  }
+}
 
 const endpoint = process.env.STEWARD_ATTESTATION_ENDPOINT;
 const deployment = process.env.STEWARD_ATTESTATION_DEPLOYMENT ?? "local-dev";
@@ -54,18 +75,13 @@ if (!endpoint) {
   process.exit(2);
 }
 
-const registryFile = Bun.file(registryPath);
-if (registryFile.size > MAX_MEASUREMENT_REGISTRY_FILE_BYTES) {
-  console.error(
-    `measurement registry exceeds ${MAX_MEASUREMENT_REGISTRY_FILE_BYTES} bytes: ${registryPath}`,
-  );
-  process.exit(2);
-}
 let registry: MeasurementRegistryFile;
 try {
-  registry = (await registryFile.json()) as MeasurementRegistryFile;
-} catch {
-  console.error(`measurement registry is not valid JSON: ${registryPath}`);
+  registry = await readBoundedRegistry(registryPath);
+} catch (error) {
+  console.error(
+    error instanceof Error ? error.message : `failed to read registry: ${registryPath}`,
+  );
   process.exit(2);
 }
 const registryOk = verifyRegistrySignatures(


### PR DESCRIPTION
## Summary

Follow-up to merged #370 and #375 after adversarial review.

- read registry files through a fixed 4 MiB buffer, including a one-byte overflow sentinel, avoiding stat/read replacement races
- enforce the 1 MiB canonical payload limit incrementally before constructing a full canonical copy
- cap registry payload depth at 64 and nodes at 100,000
- preserve #375 strict JSON shape, descriptor, Unicode, and RFC 8785 UTF-16 key-order validation
- reject oversized primitive strings and keys before JSON escaping
- add deterministic CLI >4 MiB, verifier >1 MiB, and 1,000-level nesting regressions

## Validation

Exact head: `cbc86a599ff9f0432feec52704a2af89f5903d85`
Exact base: `c33d61f67e027526a60c8dd8ced310c1ed642be1`

- focused attestation and ingestion tests: 21 pass, 0 fail, 77 assertions
- `@stwd/attestation` TypeScript build: pass
- Biome on all changed files: pass
- `git diff --check`: pass

The prior hosted Postgres failure was the approval-principal test from the pre-#378 base (250/251 API files passed); this head contains merged #378 and has a fresh exact-head CI run queued.