### PR TITLE
fix(policy): align spending limit config contracts

### DIFF
--- a/packages/api/src/__tests__/policy-validation.test.ts
+++ b/packages/api/src/__tests__/policy-validation.test.ts
@@ -332,6 +332,39 @@ describe("policy rule validation", () => {
     ).toContain("wei strings");
   });
 
+  it("accepts canonical, mixed, and legacy spending-limit write contracts", () => {
+    for (const config of [
+      { maxPerTx: "0" },
+      { maxPerDay: "100", maxPerWeekUsd: 0 },
+      { maxPerWeek: "1000", maxPerDayUsd: 25 },
+      { maxAmount: "500", period: "day" },
+      { maxAmount: "500" },
+      { maxAmount: "500", period: "week", maxPerTxUsd: 10 },
+    ]) {
+      expect(
+        getPolicyRulesValidationError([
+          { id: "spend", type: "spending-limit", enabled: true, config },
+        ]),
+        JSON.stringify(config),
+      ).toBeNull();
+    }
+  });
+
+  it("rejects ambiguous legacy spending-limit write contracts", () => {
+    for (const config of [
+      { maxAmount: 500, period: "day" },
+      { maxAmount: "500", period: "month" },
+      { period: "day" },
+    ]) {
+      expect(
+        getPolicyRulesValidationError([
+          { id: "spend", type: "spending-limit", enabled: true, config },
+        ]),
+        JSON.stringify(config),
+      ).not.toBeNull();
+    }
+  });
+
   it("rejects oversized policy lists before deep validation", () => {
     expect(
       getPolicyRulesValidationError(

--- a/packages/api/src/__tests__/redis-enforcement.test.ts
+++ b/packages/api/src/__tests__/redis-enforcement.test.ts
@@ -104,6 +104,34 @@ describe("extractSpendLimitPolicy", () => {
     expect(result).toEqual({ maxPerDay: "1000000", maxPerWeek: "5000000" });
   });
 
+  it("extracts a weekly-only canonical cap without inventing a zero daily cap", () => {
+    const result = extractSpendLimitPolicy([
+      {
+        id: "p1",
+        type: "spending-limit",
+        enabled: true,
+        config: { maxPerWeek: "5000000" },
+      },
+    ]);
+    expect(result).toEqual({
+      maxPerDay: "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+      maxPerWeek: "5000000",
+    });
+  });
+
+  it("returns null for a pure-USD policy because it has no rolling wei cap", () => {
+    expect(
+      extractSpendLimitPolicy([
+        {
+          id: "p1",
+          type: "spending-limit",
+          enabled: true,
+          config: { maxPerDayUsd: 100 },
+        },
+      ]),
+    ).toBeNull();
+  });
+
   it("handles simplified period format (day)", () => {
     const policies: PolicyRule[] = [
       {

--- a/packages/api/src/middleware/redis-enforcement.ts
+++ b/packages/api/src/middleware/redis-enforcement.ts
@@ -64,29 +64,27 @@ export function extractSpendLimitPolicy(
 
   const config = slPolicy.config as Record<string, unknown>;
 
-  // Handle both canonical and simplified formats
-  if (config.maxPerDay !== undefined) {
-    return {
-      maxPerDay: String(config.maxPerDay),
-      maxPerWeek: String(config.maxPerWeek ?? config.maxPerDay),
-    };
-  }
-
-  // Simplified format: maxAmount/period
-  const maxAmount = String(config.maxAmount ?? "0");
-  const period = String(config.period ?? "day").toLowerCase();
-
   const MAX = "115792089237316195423570985008687907853269984665640564039457584007913129639935";
-  switch (period) {
-    case "day":
-    case "daily":
-      return { maxPerDay: maxAmount, maxPerWeek: MAX };
-    case "week":
-    case "weekly":
-      return { maxPerDay: MAX, maxPerWeek: maxAmount };
-    default:
-      return { maxPerDay: maxAmount, maxPerWeek: MAX };
+  let legacyDaily = MAX;
+  let legacyWeekly = MAX;
+  const hasLegacy = typeof config.maxAmount === "string";
+  if (hasLegacy) {
+    const period = typeof config.period === "string" ? config.period.toLowerCase() : "day";
+    if (period === "week" || period === "weekly") legacyWeekly = config.maxAmount as string;
+    else if (period !== "tx" && period !== "transaction") legacyDaily = config.maxAmount as string;
   }
+
+  const hasDaily = typeof config.maxPerDay === "string";
+  const hasWeekly = typeof config.maxPerWeek === "string";
+  // Per-transaction-only and pure-USD policies have no rolling wei cap for
+  // this helper to extract. In particular, do not turn them into a zero daily
+  // cap by falling through the legacy default.
+  if (!hasDaily && !hasWeekly && !hasLegacy) return null;
+
+  return {
+    maxPerDay: hasDaily ? (config.maxPerDay as string) : legacyDaily,
+    maxPerWeek: hasWeekly ? (config.maxPerWeek as string) : legacyWeekly,
+  };
 }
 
 // ─── Pre-signing checks ──────────────────────────────────────────────────────

--- a/packages/api/src/services/policy-validation.ts
+++ b/packages/api/src/services/policy-validation.ts
@@ -32,6 +32,10 @@ function isPositiveFiniteNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value) && value > 0;
 }
 
+function isNonNegativeFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
 function isPositiveInteger(value: unknown): value is number {
   return Number.isSafeInteger(value) && Number(value) > 0;
 }
@@ -105,19 +109,45 @@ function validatePolicyConfig(policy: PolicyRule): string | null {
       const weiFields = ["maxPerTx", "maxPerDay", "maxPerWeek"] as const;
       const usdFields = ["maxPerTxUsd", "maxPerDayUsd", "maxPerWeekUsd"] as const;
       for (const field of weiFields) {
-        if (config[field] !== undefined && !isWeiString(config[field])) {
+        if (
+          Object.hasOwn(config, field) &&
+          config[field] !== undefined &&
+          !isWeiString(config[field])
+        ) {
           return `spending-limit.${field} must be a wei string`;
         }
       }
       for (const field of usdFields) {
-        if (config[field] !== undefined && !isPositiveFiniteNumber(config[field])) {
-          return `spending-limit.${field} must be a positive number`;
+        if (
+          Object.hasOwn(config, field) &&
+          config[field] !== undefined &&
+          !isNonNegativeFiniteNumber(config[field])
+        ) {
+          return `spending-limit.${field} must be a non-negative finite number`;
         }
       }
-      const hasWeiLimit = weiFields.some((field) => isWeiString(config[field]));
-      const hasUsdLimit = usdFields.some((field) => isPositiveFiniteNumber(config[field]));
-      if (!hasWeiLimit && !hasUsdLimit) {
-        return "spending-limit requires at least one positive wei or USD limit";
+      if (Object.hasOwn(config, "maxAmount") && !isWeiString(config.maxAmount)) {
+        return "spending-limit.maxAmount must be a wei string";
+      }
+      const legacyPeriods = new Set(["tx", "transaction", "day", "daily", "week", "weekly"]);
+      if (
+        Object.hasOwn(config, "period") &&
+        (typeof config.period !== "string" || !legacyPeriods.has(config.period))
+      ) {
+        return "spending-limit.period must be tx, transaction, day, daily, week, or weekly";
+      }
+      if (Object.hasOwn(config, "period") && !isWeiString(config.maxAmount)) {
+        return "spending-limit.period requires maxAmount";
+      }
+      const hasWeiLimit = weiFields.some(
+        (field) => Object.hasOwn(config, field) && isWeiString(config[field]),
+      );
+      const hasUsdLimit = usdFields.some(
+        (field) => Object.hasOwn(config, field) && isNonNegativeFiniteNumber(config[field]),
+      );
+      const hasLegacyLimit = Object.hasOwn(config, "maxAmount") && isWeiString(config.maxAmount);
+      if (!hasWeiLimit && !hasUsdLimit && !hasLegacyLimit) {
+        return "spending-limit requires at least one wei or USD limit";
       }
       return null;
     }

--- a/packages/policy-engine/src/__tests__/evaluators.test.ts
+++ b/packages/policy-engine/src/__tests__/evaluators.test.ts
@@ -626,6 +626,26 @@ describe("Spending Limit Policy", () => {
     }
   });
 
+  it("rejects numeric wei config instead of accepting a precision-lost BigInt cap", async () => {
+    const result = await evaluatePolicy(
+      makeSpendingRule({ maxPerTx: Number.MAX_SAFE_INTEGER + 2 }),
+      makeContext({ request: { ...makeContext().request, value: "1" } }),
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("uint256 strings");
+  });
+
+  it("rejects numeric legacy maxAmount instead of coercing it", async () => {
+    const result = await evaluatePolicy(
+      makeSpendingRule({ maxAmount: Number.MAX_SAFE_INTEGER + 2, period: "day" }),
+      makeContext({ request: { ...makeContext().request, value: "1" } }),
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("uint256 strings");
+  });
+
   it("fails closed for an empty spending config even on a zero-value request", async () => {
     const result = await evaluatePolicy(
       makeSpendingRule({}),

--- a/packages/policy-engine/src/evaluators.ts
+++ b/packages/policy-engine/src/evaluators.ts
@@ -311,8 +311,17 @@ function normalizeSpendingLimitConfig(config: Record<string, unknown>): Spending
     SpendingLimitConfig,
     "maxPerTx" | "maxPerDay" | "maxPerWeek"
   > => {
-    const maxAmount = String(config.maxAmount ?? "0");
-    const period = String(config.period ?? "day").toLowerCase();
+    // Wei values are an exact-integer contract. Never coerce JSON numbers:
+    // values above Number.MAX_SAFE_INTEGER have already lost precision before
+    // BigInt sees them. Malformed legacy fields flow to the common uint256
+    // parser below and fail closed.
+    const maxAmount = typeof config.maxAmount === "string" ? config.maxAmount : "";
+    const period =
+      config.period === undefined
+        ? "day"
+        : typeof config.period === "string"
+          ? config.period.toLowerCase()
+          : "";
 
     switch (period) {
       case "tx":
@@ -375,13 +384,19 @@ function normalizeSpendingLimitConfig(config: Record<string, unknown>): Spending
         };
     const weiCaps = {
       maxPerTx: hasOwnDefined(config, "maxPerTx")
-        ? String(config.maxPerTx)
+        ? typeof config.maxPerTx === "string"
+          ? config.maxPerTx
+          : ""
         : inheritedWeiCaps.maxPerTx,
       maxPerDay: hasOwnDefined(config, "maxPerDay")
-        ? String(config.maxPerDay)
+        ? typeof config.maxPerDay === "string"
+          ? config.maxPerDay
+          : ""
         : inheritedWeiCaps.maxPerDay,
       maxPerWeek: hasOwnDefined(config, "maxPerWeek")
-        ? String(config.maxPerWeek)
+        ? typeof config.maxPerWeek === "string"
+          ? config.maxPerWeek
+          : ""
         : inheritedWeiCaps.maxPerWeek,
     };
     return {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -338,14 +338,19 @@ export interface PolicyRule {
 }
 
 export interface SpendingLimitConfig {
-  // Wei-based (legacy/direct)
+  // Canonical wei-based limits. Wei values are decimal strings so conversion
+  // to bigint is exact across JSON and JavaScript runtimes.
   maxPerTx?: string;
   maxPerDay?: string;
   maxPerWeek?: string;
-  // USD-based (preferred — takes precedence when price oracle is available)
+  // USD limits are conjunctive with any canonical or legacy wei limits.
   maxPerTxUsd?: number;
   maxPerDayUsd?: number;
   maxPerWeekUsd?: number;
+  // Legacy simplified representation retained for persisted-policy and API
+  // compatibility. A missing period means "day".
+  maxAmount?: string;
+  period?: "tx" | "transaction" | "day" | "daily" | "week" | "weekly";
 }
 
 export interface ApprovedAddressesConfig {


### PR DESCRIPTION
## Summary

Post-merge corrective for #360:

- reject numeric wei caps instead of coercing precision-lost JavaScript numbers before `BigInt`
- align shared types and API writes with the evaluator’s legacy `maxAmount`/`period` compatibility
- keep canonical, USD, and legacy limits conjunctive and accept explicit zero-valued deny-all USD caps
- prevent the supplemental rolling-wei extractor from inventing a zero daily cap for weekly-only or pure-USD policies

## Exact validation

Base: `c33d61f67e027526a60c8dd8ced310c1ed642be1`
Head: `82268ee89e31423b25c66d38f16726c2c4665a29`

- policy-engine focused: 126 passed, 271 assertions
- API validation/extraction focused: 35 passed, 93 assertions
- dependency-aware policy-engine + API build: 21/21 successful
- Biome and `git diff --check`: clean

Draft pending exact-head CI and independent review.