### PR TITLE
fix(security): suppress credential lease replay bodies

### DIFF
--- a/packages/api/src/__tests__/idempotency-middleware.test.ts
+++ b/packages/api/src/__tests__/idempotency-middleware.test.ts
@@ -350,6 +350,22 @@ describe("idempotencyMiddleware", () => {
       count += 1;
       return c.json({ ok: true, count, recovery: { mnemonic: `word-${count} …` } });
     });
+    app.post("/capabilities/manifest/github/issue", async (c) => {
+      count += 1;
+      return c.json({ ok: true, data: { token: `ghs_issue_${count}` } });
+    });
+    app.post("/capabilities/manifest/github/renew", async (c) => {
+      count += 1;
+      return c.json({ ok: true, data: { token: `ghs_renew_${count}` } });
+    });
+    app.post("/v1/capabilities/manifest/github/issue", async (c) => {
+      count += 1;
+      return c.json({ ok: true, data: { token: `ghs_v1_issue_${count}` } });
+    });
+    app.post("/v1/capabilities/manifest/github/renew", async (c) => {
+      count += 1;
+      return c.json({ ok: true, data: { token: `ghs_v1_renew_${count}` } });
+    });
 
     for (const [path, body] of [
       ["/vault/agent-1/export", {}],
@@ -357,6 +373,10 @@ describe("idempotencyMiddleware", () => {
       ["/v1/kms/keys/key-1/decrypt", { ciphertext_b64: "AA==" }],
       ["/secrets", { name: "n", value: "v" }],
       ["/user/me/wallet/recovery/setup", {}],
+      ["/capabilities/manifest/github/issue", { resources: { repositories: ["org/repo"] } }],
+      ["/capabilities/manifest/github/renew", { resources: { repositories: ["org/repo"] } }],
+      ["/v1/capabilities/manifest/github/issue", { resources: { repositories: ["org/repo"] } }],
+      ["/v1/capabilities/manifest/github/renew", { resources: { repositories: ["org/repo"] } }],
     ] as const) {
       const init = {
         method: "POST",
@@ -378,7 +398,7 @@ describe("idempotencyMiddleware", () => {
         error: "Idempotency key has already been used",
       });
     }
-    expect(count).toBe(5);
+    expect(count).toBe(9);
   });
 
   it("uses a verified request signature as replay-safe auth material", async () => {

--- a/packages/api/src/middleware/idempotency.ts
+++ b/packages/api/src/middleware/idempotency.ts
@@ -592,6 +592,7 @@ const SECRET_BEARING_RESPONSE_PATTERNS = [
   /^\/user\/me\/wallet\/export$/, // POST /user/me/wallet/export — user wallet key material
   /^\/v1\/kms\/keys\/[^/]+\/decrypt$/, // POST /v1/kms/keys/:keyId/decrypt — plaintext
   /^\/secrets(?:\/|$)/, // POST /secrets — secret values
+  /^\/(?:v1\/)?capabilities\/manifest\/[^/]+\/(?:issue|renew)$/, // POST …/issue|renew — one-time upstream credential
   // Review-wave extension of the audit's named list (same issue class):
   // recovery setup returns the one-time BIP39 mnemonic ("shown once, not
   // stored"), so its body must never land in the idempotency store either.

--- a/packages/plugin-capabilities/src/upstream-leases.ts
+++ b/packages/plugin-capabilities/src/upstream-leases.ts
@@ -1192,7 +1192,7 @@ export async function issueUpstreamCredentialLease(input: {
   const issuedLifetimeMs = issued.expiresAt.getTime() - now.getTime();
   if (
     !issued.token ||
-    Buffer.from(issued.token, "utf8").length > MAX_GITHUB_TOKEN_BYTES ||
+    new TextEncoder().encode(issued.token).length > MAX_GITHUB_TOKEN_BYTES ||
     !Number.isFinite(issued.expiresAt.getTime()) ||
     issuedLifetimeMs < MIN_GITHUB_ISSUED_TTL_MS ||
     issuedLifetimeMs > MAX_GITHUB_ISSUED_TTL_MS


### PR DESCRIPTION
## Summary
- suppress idempotency response-body persistence for both capability credential issue/renew route prefixes
- cover all four `/capabilities` and `/v1/capabilities` issue/renew paths with replay-suppression regressions
- use `TextEncoder` for the upstream token byte bound so the provider contract check remains portable outside Node globals

## Validation
- `bun test packages/api/src/__tests__/idempotency-middleware.test.ts` (17 pass, 126 assertions)
- `bun test packages/plugin-capabilities/src/__tests__/upstream-leases.test.ts --test-name-pattern "an overlong issued token"` (1 pass, 9 assertions)
- `bunx turbo run build --filter=@stwd/api --filter=@stwd/plugin-capabilities` (21/21 tasks)
- `bunx @biomejs/biome check` on all three changed files

Follow-up to #308. Issue #150 remains open pending integration/acceptance evidence.