### PR TITLE
fix(attestation): bound registry and quote ingestion

### DIFF
--- a/packages/attestation/src/__tests__/attestation.test.ts
+++ b/packages/attestation/src/__tests__/attestation.test.ts
@@ -7,6 +7,7 @@ import {
   type MeasurementRegistryFile,
   type MeasurementRegistryPayload,
   normalizeReportData,
+  parseMeasurementRegistryJson,
   publicKeyFingerprint,
   registryPayloadDigest,
   verifyQuoteAgainstRegistry,
@@ -581,6 +582,36 @@ describe("measurement registry", () => {
 
     expect(() => canonicalizeJson(nested)).toThrow(
       "registry payload exceeded the maximum depth of 64",
+    );
+  });
+
+  test("rejects malformed UTF-8 before parsing a registry file", () => {
+    expect(() => parseMeasurementRegistryJson(Uint8Array.from([0x7b, 0xff, 0x7d]))).toThrow(
+      "measurement registry file is not valid UTF-8 JSON",
+    );
+  });
+
+  test("rejects excessive JSON depth and structure before JSON.parse", () => {
+    const deep = Buffer.from(`${"[".repeat(73)}0${"]".repeat(73)}`);
+    expect(() => parseMeasurementRegistryJson(deep)).toThrow(
+      "measurement registry JSON exceeded the maximum depth of 72",
+    );
+
+    const wide = Buffer.from(`[${"0,".repeat(100_001)}0]`);
+    expect(() => parseMeasurementRegistryJson(wide)).toThrow(
+      "measurement registry JSON exceeded the structural token limit",
+    );
+  });
+
+  test("counts canonical UTF-8 bytes, escaped bytes, keys, and nodes", () => {
+    expect(() => canonicalizeJson({ value: "\u0000".repeat(200_000) })).toThrow(
+      "registry payload exceeded the 1 MiB limit",
+    );
+    expect(() => canonicalizeJson({ ["💥".repeat(262_145)]: true })).toThrow(
+      "registry payload exceeded the 1 MiB limit",
+    );
+    expect(() => canonicalizeJson(Array.from({ length: 100_001 }, () => null))).toThrow(
+      "registry payload exceeded the maximum node count of 100000",
     );
   });
 });

--- a/packages/attestation/src/registry.ts
+++ b/packages/attestation/src/registry.ts
@@ -60,6 +60,8 @@ const MAX_REGISTRY_SIGNATURES = 64;
 const MAX_REGISTRY_PAYLOAD_BYTES = 1024 * 1024;
 const MAX_REGISTRY_PAYLOAD_DEPTH = 64;
 const MAX_REGISTRY_PAYLOAD_NODES = 100_000;
+const MAX_REGISTRY_JSON_DEPTH = MAX_REGISTRY_PAYLOAD_DEPTH + 8;
+const MAX_REGISTRY_JSON_STRUCTURAL_TOKENS = 100_000;
 const MAX_PUBLIC_KEY_PEM_BYTES = 16 * 1024;
 export const MAX_MEASUREMENT_REGISTRY_FILE_BYTES = 4 * 1024 * 1024;
 const MAX_REGISTRY_DEPLOYMENTS = 1024;
@@ -239,6 +241,65 @@ function decodeEd25519Signature(signatureBase64: unknown): Buffer | null {
 
 class RegistryPayloadLimitError extends Error {}
 
+/** Parse a registry file through the same byte and complexity limits as the verifier. */
+export function parseMeasurementRegistryJson(bytes: Uint8Array): MeasurementRegistryFile {
+  if (bytes.byteLength > MAX_MEASUREMENT_REGISTRY_FILE_BYTES) {
+    throw new Error("measurement registry file exceeded the 4 MiB ingestion limit");
+  }
+
+  let text: string;
+  try {
+    text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    throw new Error("measurement registry file is not valid UTF-8 JSON");
+  }
+
+  let depth = 0;
+  let structuralTokens = 0;
+  let inString = false;
+  let escaped = false;
+  for (let index = 0; index < text.length; index += 1) {
+    const character = text[index];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (character === "\\") {
+        escaped = true;
+      } else if (character === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (character === '"') {
+      inString = true;
+      structuralTokens += 1;
+    } else if (character === "{" || character === "[") {
+      depth += 1;
+      structuralTokens += 1;
+      if (depth > MAX_REGISTRY_JSON_DEPTH) {
+        throw new Error(
+          `measurement registry JSON exceeded the maximum depth of ${MAX_REGISTRY_JSON_DEPTH}`,
+        );
+      }
+    } else if (character === "}" || character === "]") {
+      depth -= 1;
+      if (depth < 0) throw new Error("measurement registry file is not valid JSON");
+    } else if (character === ":" || character === ",") {
+      structuralTokens += 1;
+    }
+    if (structuralTokens > MAX_REGISTRY_JSON_STRUCTURAL_TOKENS) {
+      throw new Error("measurement registry JSON exceeded the structural token limit");
+    }
+  }
+
+  if (inString || depth !== 0) throw new Error("measurement registry file is not valid JSON");
+  try {
+    return JSON.parse(text) as MeasurementRegistryFile;
+  } catch {
+    throw new Error("measurement registry file is not valid JSON");
+  }
+}
+
 export function canonicalizeJson(value: unknown): string {
   const chunks: string[] = [];
   let bytes = 0;
@@ -307,7 +368,13 @@ export function canonicalizeJson(value: unknown): string {
         return;
       }
       if (!isPlainObject(entry)) throw new Error("value is not a plain JSON object");
-      const entries = Reflect.ownKeys(entry).map((key): [string, unknown] => {
+      const ownKeys = Reflect.ownKeys(entry);
+      if (ownKeys.length > MAX_REGISTRY_PAYLOAD_NODES) {
+        throw new RegistryPayloadLimitError(
+          `registry payload exceeded the maximum node count of ${MAX_REGISTRY_PAYLOAD_NODES}`,
+        );
+      }
+      const entries = ownKeys.map((key): [string, unknown] => {
         if (typeof key !== "string" || !isWellFormedUnicode(key))
           throw new Error("JSON object has a non-JSON property key");
         const descriptor = Object.getOwnPropertyDescriptor(entry, key);
@@ -315,11 +382,6 @@ export function canonicalizeJson(value: unknown): string {
           throw new Error("JSON object has a non-JSON property");
         return [key, descriptor.value];
       });
-      if (entries.length > MAX_REGISTRY_PAYLOAD_NODES) {
-        throw new RegistryPayloadLimitError(
-          `registry payload exceeded the maximum node count of ${MAX_REGISTRY_PAYLOAD_NODES}`,
-        );
-      }
       entries.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
       append("{");
       for (const [index, [key, item]] of entries.entries()) {

--- a/scripts/__tests__/check-attestation.test.ts
+++ b/scripts/__tests__/check-attestation.test.ts
@@ -1,20 +1,32 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createHash, createPublicKey } from "node:crypto";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { gzipSync } from "node:zlib";
 
-function runCheck(registryPath: string) {
-  return Bun.spawnSync([process.execPath, "scripts/check-attestation.ts"], {
-    cwd: join(import.meta.dir, "../.."),
-    env: {
-      ...process.env,
-      STEWARD_ATTESTATION_ENDPOINT: "http://127.0.0.1:1/never-requested",
-      STEWARD_MEASUREMENT_REGISTRY: registryPath,
-      STEWARD_REGISTRY_ALLOW_UNPINNED: "true",
-    },
-    stdout: "pipe",
-    stderr: "pipe",
-  });
+const ROOT = join(import.meta.dir, "../..");
+const VALID_REGISTRY_PATH = join(ROOT, "docs/attestation/measurements.json");
+const validRegistry = JSON.parse(readFileSync(VALID_REGISTRY_PATH, "utf8")) as {
+  signatures: Array<{ publicKeyPem: string }>;
+};
+const TRUSTED_FINGERPRINT = createHash("sha256")
+  .update(
+    createPublicKey(validRegistry.signatures[0]?.publicKeyPem).export({
+      format: "der",
+      type: "spki",
+    }),
+  )
+  .digest("hex");
+
+function cliEnv(registryPath: string, endpoint: string): Record<string, string | undefined> {
+  return {
+    ...process.env,
+    STEWARD_ATTESTATION_ENDPOINT: endpoint,
+    STEWARD_MEASUREMENT_REGISTRY: registryPath,
+    STEWARD_REGISTRY_TRUSTED_KEY_SHA256: TRUSTED_FINGERPRINT,
+    STEWARD_REGISTRY_ALLOW_UNPINNED: undefined,
+  };
 }
 
 describe("check-attestation bounded registry ingestion", () => {
@@ -23,7 +35,12 @@ describe("check-attestation bounded registry ingestion", () => {
     const registryPath = join(directory, "oversized.json");
     try {
       writeFileSync(registryPath, Buffer.alloc(4 * 1024 * 1024 + 1, 0x20));
-      const result = runCheck(registryPath);
+      const result = Bun.spawnSync([process.execPath, "scripts/check-attestation.ts"], {
+        cwd: ROOT,
+        env: cliEnv(registryPath, "http://127.0.0.1:1/never-requested"),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
 
       expect(result.exitCode).not.toBe(0);
       expect(result.stderr.toString()).toContain(
@@ -35,18 +52,85 @@ describe("check-attestation bounded registry ingestion", () => {
     }
   });
 
-  test("rejects malformed UTF-8 before network access", () => {
+  test("rejects malformed registry UTF-8 without exposing parser diagnostics", () => {
     const directory = mkdtempSync(join(tmpdir(), "steward-attestation-"));
     const registryPath = join(directory, "invalid-utf8.json");
     try {
-      writeFileSync(registryPath, Buffer.from([0x7b, 0x22, 0xff, 0x22, 0x7d]));
-      const result = runCheck(registryPath);
-
-      expect(result.exitCode).toBe(2);
-      expect(result.stderr.toString()).toContain("not valid UTF-8 JSON");
-      expect(result.stderr.toString()).not.toContain("fetch");
+      writeFileSync(registryPath, Uint8Array.from([0x7b, 0xff, 0x7d]));
+      const result = Bun.spawnSync([process.execPath, "scripts/check-attestation.ts"], {
+        cwd: ROOT,
+        env: cliEnv(registryPath, "http://127.0.0.1:1/never-requested"),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr.toString()).toContain(
+        "measurement registry file is not valid UTF-8 JSON",
+      );
+      expect(result.stderr.toString()).not.toContain("SyntaxError");
     } finally {
       rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("cancels a streamed quote response over the decoded byte limit", async () => {
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: () => {
+        let chunks = 0;
+        return new Response(
+          new ReadableStream({
+            pull(controller) {
+              if (chunks >= 17) {
+                controller.close();
+                return;
+              }
+              chunks += 1;
+              controller.enqueue(new Uint8Array(64 * 1024).fill(0x20));
+            },
+          }),
+        );
+      },
+    });
+    try {
+      const processHandle = Bun.spawn([process.execPath, "scripts/check-attestation.ts"], {
+        cwd: ROOT,
+        env: cliEnv(VALID_REGISTRY_PATH, `${server.url}quote`),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const stderr = await new Response(processHandle.stderr).text();
+      expect(await processHandle.exited).not.toBe(0);
+      expect(stderr).toContain("quote endpoint response exceeded the 1 MiB limit");
+      expect(stderr).not.toContain("padding");
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("applies the quote cap after gzip decompression", async () => {
+    const compressed = gzipSync(new Uint8Array(1024 * 1024 + 1).fill(0x20));
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: () =>
+        new Response(compressed, {
+          headers: { "content-encoding": "gzip", "content-type": "application/json" },
+        }),
+    });
+    try {
+      const processHandle = Bun.spawn([process.execPath, "scripts/check-attestation.ts"], {
+        cwd: ROOT,
+        env: cliEnv(VALID_REGISTRY_PATH, `${server.url}quote`),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const stderr = await new Response(processHandle.stderr).text();
+      expect(await processHandle.exited).not.toBe(0);
+      expect(stderr).toContain("quote endpoint response exceeded the 1 MiB limit");
+    } finally {
+      server.stop(true);
     }
   });
 });

--- a/scripts/__tests__/check-attestation.test.ts
+++ b/scripts/__tests__/check-attestation.test.ts
@@ -133,4 +133,74 @@ describe("check-attestation bounded registry ingestion", () => {
       server.stop(true);
     }
   });
+
+  test.each([
+    ["URL credentials", "http://user:secret@127.0.0.1:1/quote", "must not contain URL credentials"],
+    ["a fragment", "http://127.0.0.1:1/quote#ignored", "must not contain a URL fragment"],
+    ["a non-HTTP protocol", "file:///tmp/quote.json", "must use HTTP or HTTPS"],
+  ])("rejects an endpoint containing %s before fetch", (_label, endpoint, expected) => {
+    const result = Bun.spawnSync([process.execPath, "scripts/check-attestation.ts"], {
+      cwd: ROOT,
+      env: cliEnv(VALID_REGISTRY_PATH, endpoint),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr.toString()).toContain(expected);
+  });
+
+  test("refuses redirects without following them or exposing the destination", async () => {
+    let destinationRequests = 0;
+    const destination = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: () => {
+        destinationRequests += 1;
+        return new Response("should never be reached");
+      },
+    });
+    const redirect = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: () => Response.redirect(`${destination.url}sensitive-destination`, 302),
+    });
+    try {
+      const processHandle = Bun.spawn([process.execPath, "scripts/check-attestation.ts"], {
+        cwd: ROOT,
+        env: cliEnv(VALID_REGISTRY_PATH, `${redirect.url}quote`),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const stderr = await new Response(processHandle.stderr).text();
+      expect(await processHandle.exited).toBe(1);
+      expect(stderr).toContain("quote endpoint request failed");
+      expect(stderr).not.toContain("sensitive-destination");
+      expect(destinationRequests).toBe(0);
+    } finally {
+      redirect.stop(true);
+      destination.stop(true);
+    }
+  });
+
+  test("reports only the status for upstream HTTP errors", async () => {
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: () => new Response("upstream-secret-token", { status: 401 }),
+    });
+    try {
+      const processHandle = Bun.spawn([process.execPath, "scripts/check-attestation.ts"], {
+        cwd: ROOT,
+        env: cliEnv(VALID_REGISTRY_PATH, `${server.url}quote`),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const stderr = await new Response(processHandle.stderr).text();
+      expect(await processHandle.exited).toBe(1);
+      expect(stderr).toContain("quote endpoint failed with HTTP 401");
+      expect(stderr).not.toContain("upstream-secret-token");
+    } finally {
+      server.stop(true);
+    }
+  });
 });

--- a/scripts/check-attestation.ts
+++ b/scripts/check-attestation.ts
@@ -12,6 +12,26 @@ import {
 const MAX_QUOTE_RESPONSE_BYTES = 1024 * 1024;
 const QUOTE_REQUEST_TIMEOUT_MS = 10_000;
 
+function quoteRequestUrl(rawEndpoint: string, nonce: string): URL {
+  let url: URL;
+  try {
+    url = new URL(rawEndpoint);
+  } catch {
+    throw new Error("STEWARD_ATTESTATION_ENDPOINT must be a valid HTTP(S) URL");
+  }
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    throw new Error("STEWARD_ATTESTATION_ENDPOINT must use HTTP or HTTPS");
+  }
+  if (url.username || url.password) {
+    throw new Error("STEWARD_ATTESTATION_ENDPOINT must not contain URL credentials");
+  }
+  if (url.hash) {
+    throw new Error("STEWARD_ATTESTATION_ENDPOINT must not contain a URL fragment");
+  }
+  url.searchParams.set("nonce", nonce);
+  return url;
+}
+
 async function readBoundedRegistry(path: string): Promise<MeasurementRegistryFile> {
   const handle = await open(path, "r");
   try {
@@ -34,7 +54,7 @@ async function readBoundedRegistry(path: string): Promise<MeasurementRegistryFil
 async function readBoundedQuoteResponse(response: Response): Promise<unknown> {
   const declaredLength = Number(response.headers.get("content-length"));
   if (Number.isFinite(declaredLength) && declaredLength > MAX_QUOTE_RESPONSE_BYTES) {
-    await response.body?.cancel();
+    await response.body?.cancel().catch(() => undefined);
     throw new Error("quote endpoint response exceeded the 1 MiB limit");
   }
   if (!response.body) throw new Error("quote endpoint returned an empty response");
@@ -149,15 +169,19 @@ if (!registryOk.ok) {
 }
 
 const nonce = crypto.randomUUID();
+let requestUrl: URL;
+try {
+  requestUrl = quoteRequestUrl(endpoint, nonce);
+} catch (error) {
+  console.error(error instanceof Error ? error.message : "invalid attestation endpoint");
+  process.exit(2);
+}
 let response: Response;
 try {
-  response = await fetch(
-    `${endpoint}${endpoint.includes("?") ? "&" : "?"}nonce=${encodeURIComponent(nonce)}`,
-    {
-      redirect: "error",
-      signal: AbortSignal.timeout(QUOTE_REQUEST_TIMEOUT_MS),
-    },
-  );
+  response = await fetch(requestUrl, {
+    redirect: "error",
+    signal: AbortSignal.timeout(QUOTE_REQUEST_TIMEOUT_MS),
+  });
 } catch {
   console.error("quote endpoint request failed");
   process.exit(1);
@@ -180,7 +204,13 @@ const quoteEnvelope = rawQuote as { raw?: { quote?: unknown } | unknown };
 const raw = quoteEnvelope?.raw;
 const quote =
   raw && typeof raw === "object" && "quote" in raw ? (raw as { quote: unknown }).quote : raw;
-const verifiedQuote = await provider.verifyQuote(quote ?? rawQuote, { nonce });
+let verifiedQuote;
+try {
+  verifiedQuote = await provider.verifyQuote(quote ?? rawQuote, { nonce });
+} catch {
+  console.error("quote verification failed");
+  process.exit(1);
+}
 const match = verifyQuoteAgainstRegistry(verifiedQuote, registry, deployment);
 if (!match.ok) {
   console.error(`attestation measurement check failed: ${match.reason}`);

--- a/scripts/check-attestation.ts
+++ b/scripts/check-attestation.ts
@@ -2,34 +2,79 @@
 import { open } from "node:fs/promises";
 import {
   createDstackTdxProvider,
+  MAX_MEASUREMENT_REGISTRY_FILE_BYTES,
   type MeasurementRegistryFile,
+  parseMeasurementRegistryJson,
   verifyQuoteAgainstRegistry,
   verifyRegistrySignatures,
 } from "@stwd/attestation";
 
-const MAX_REGISTRY_FILE_BYTES = 4 * 1024 * 1024;
-
-class RegistryFileLimitError extends Error {}
+const MAX_QUOTE_RESPONSE_BYTES = 1024 * 1024;
+const QUOTE_REQUEST_TIMEOUT_MS = 10_000;
 
 async function readBoundedRegistry(path: string): Promise<MeasurementRegistryFile> {
   const handle = await open(path, "r");
   try {
-    const bytes = Buffer.alloc(MAX_REGISTRY_FILE_BYTES + 1);
+    const bytes = Buffer.alloc(MAX_MEASUREMENT_REGISTRY_FILE_BYTES + 1);
     let offset = 0;
     while (offset < bytes.byteLength) {
       const { bytesRead } = await handle.read(bytes, offset, bytes.byteLength - offset, null);
       if (bytesRead === 0) break;
       offset += bytesRead;
     }
-    if (offset > MAX_REGISTRY_FILE_BYTES) {
-      throw new RegistryFileLimitError(
-        "measurement registry file exceeded the 4 MiB ingestion limit",
-      );
+    if (offset > MAX_MEASUREMENT_REGISTRY_FILE_BYTES) {
+      throw new Error("measurement registry file exceeded the 4 MiB ingestion limit");
     }
-    const text = new TextDecoder("utf-8", { fatal: true }).decode(bytes.subarray(0, offset));
-    return JSON.parse(text) as MeasurementRegistryFile;
+    return parseMeasurementRegistryJson(bytes.subarray(0, offset));
   } finally {
     await handle.close();
+  }
+}
+
+async function readBoundedQuoteResponse(response: Response): Promise<unknown> {
+  const declaredLength = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_QUOTE_RESPONSE_BYTES) {
+    await response.body?.cancel();
+    throw new Error("quote endpoint response exceeded the 1 MiB limit");
+  }
+  if (!response.body) throw new Error("quote endpoint returned an empty response");
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > MAX_QUOTE_RESPONSE_BYTES) {
+        await reader.cancel();
+        throw new Error("quote endpoint response exceeded the 1 MiB limit");
+      }
+      chunks.push(value);
+    }
+  } catch (error) {
+    await reader.cancel().catch(() => undefined);
+    if (
+      error instanceof Error &&
+      error.message === "quote endpoint response exceeded the 1 MiB limit"
+    ) {
+      throw error;
+    }
+    throw new Error("quote endpoint response could not be read");
+  }
+
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  try {
+    const text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+    return JSON.parse(text);
+  } catch {
+    throw new Error("quote endpoint returned invalid JSON");
   }
 }
 
@@ -84,13 +129,11 @@ let registry: MeasurementRegistryFile;
 try {
   registry = await readBoundedRegistry(registryPath);
 } catch (error) {
-  if (error instanceof RegistryFileLimitError) {
-    console.error(error.message);
-  } else if (error instanceof SyntaxError || error instanceof TypeError) {
-    console.error(`measurement registry is not valid UTF-8 JSON: ${registryPath}`);
-  } else {
-    console.error(`measurement registry could not be read: ${registryPath}`);
-  }
+  const safeMessage =
+    error instanceof Error && error.message.startsWith("measurement registry")
+      ? error.message
+      : "measurement registry file could not be read";
+  console.error(safeMessage);
   process.exit(2);
 }
 const registryOk = verifyRegistrySignatures(
@@ -106,19 +149,38 @@ if (!registryOk.ok) {
 }
 
 const nonce = crypto.randomUUID();
-const response = await fetch(
-  `${endpoint}${endpoint.includes("?") ? "&" : "?"}nonce=${encodeURIComponent(nonce)}`,
-);
+let response: Response;
+try {
+  response = await fetch(
+    `${endpoint}${endpoint.includes("?") ? "&" : "?"}nonce=${encodeURIComponent(nonce)}`,
+    {
+      redirect: "error",
+      signal: AbortSignal.timeout(QUOTE_REQUEST_TIMEOUT_MS),
+    },
+  );
+} catch {
+  console.error("quote endpoint request failed");
+  process.exit(1);
+}
 if (!response.ok && response.status !== 503) {
-  console.error(`quote endpoint failed: ${response.status} ${await response.text()}`);
+  await response.body?.cancel().catch(() => undefined);
+  console.error(`quote endpoint failed with HTTP ${response.status}`);
   process.exit(1);
 }
 
-const rawQuote = await response.json();
+let rawQuote: unknown;
+try {
+  rawQuote = await readBoundedQuoteResponse(response);
+} catch (error) {
+  console.error(error instanceof Error ? error.message : "quote endpoint response was invalid");
+  process.exit(1);
+}
 const provider = createDstackTdxProvider();
-const verifiedQuote = await provider.verifyQuote(rawQuote.raw?.quote ?? rawQuote.raw ?? rawQuote, {
-  nonce,
-});
+const quoteEnvelope = rawQuote as { raw?: { quote?: unknown } | unknown };
+const raw = quoteEnvelope?.raw;
+const quote =
+  raw && typeof raw === "object" && "quote" in raw ? (raw as { quote: unknown }).quote : raw;
+const verifiedQuote = await provider.verifyQuote(quote ?? rawQuote, { nonce });
 const match = verifyQuoteAgainstRegistry(verifiedQuote, registry, deployment);
 if (!match.ok) {
   console.error(`attestation measurement check failed: ${match.reason}`);


### PR DESCRIPTION
## Summary

Complementary follow-up to merged #383 and #376 after exact-merge adversarial review.

- reject excessive registry JSON depth/structure before `JSON.parse`
- enforce canonical UTF-8, escaped-byte, key, depth, and node ceilings before oversized aggregate construction
- bound quote endpoint reads after decompression, honor a 10-second wall-clock timeout, reject redirects, cancel oversized/error streams, and sanitize endpoint/parser/verifier errors
- parse the endpoint structurally, reject credentials/fragments/non-HTTP protocols, and set the freshness nonce without corrupting existing query strings
- use the actual pinned example key in CLI regressions so tests remain fail-closed in CI

#383 landed its stronger immutable snapshot handling for accessor/proxy/non-enumerable registry envelopes in base `c807d9d325d706529a3950606d24cbdba090bf76`; this branch is rebased on that merge and preserves it.

## Validation

Exact base: `c807d9d325d706529a3950606d24cbdba090bf76`
Exact head: `3cd64746baf661a5b22dce576f66b5cf3546d6f0`

- focused attestation + CLI suites: 32 passed, 109 assertions
- `@stwd/attestation` TypeScript build: passed
- Biome on all changed files: passed
- `git diff --check`: passed

The quote-response tests cover chunked decoded streaming, gzip expansion beyond 1 MiB, URL credential/fragment/protocol rejection, redirect refusal without follow, and sanitized HTTP error bodies.


