### PR TITLE
fix(security): unify operator transfer spend fencing

### DIFF
--- a/packages/api/src/__tests__/operator-transfer-postgres-concurrency.integration.test.ts
+++ b/packages/api/src/__tests__/operator-transfer-postgres-concurrency.integration.test.ts
@@ -18,6 +18,22 @@ const postgres = ((postgresModule as { default?: unknown }).default ?? postgresM
 const databaseUrl = process.env.DATABASE_URL;
 const realPostgresIt = databaseUrl && !process.env.STEWARD_PGLITE_MEMORY ? it : it.skip;
 
+it("keeps every cumulative spend path on the same 64-bit advisory key", async () => {
+  const sources = await Promise.all(
+    [
+      "../routes/intents.ts",
+      "../routes/vault.ts",
+      "../routes/user.ts",
+      "../../../plugin-trading/src/routes/operator-recovery.ts",
+    ].map((path) => Bun.file(new URL(path, import.meta.url)).text()),
+  );
+  const sharedLock = "pg_advisory_xact_lock(hashtextextended(${";
+  for (const source of sources) {
+    expect(source).toContain(sharedLock);
+    expect(source).not.toContain("pg_advisory_xact_lock(hashtext(${agentId}))");
+  }
+});
+
 realPostgresIt("serializes cumulative operator reservations across real connections", async () => {
   const suffix = crypto.randomUUID().replaceAll("-", "");
   const table = `operator_lock_test_${suffix}`;
@@ -32,7 +48,7 @@ realPostgresIt("serializes cumulative operator reservations across real connecti
     );
     const reserve = (client: Sql) =>
       client.begin(async (tx) => {
-        await tx`select pg_advisory_xact_lock(hashtext(${agentId}))`;
+        await tx`select pg_advisory_xact_lock(hashtextextended(${agentId}, 0))`;
         const [row] = await tx.unsafe<{ total: string }[]>(
           `select coalesce(sum(amount), 0)::text as total from "${table}" where status in ('pending', 'final')`,
         );

--- a/packages/api/src/__tests__/operator-transfer-postgres-concurrency.integration.test.ts
+++ b/packages/api/src/__tests__/operator-transfer-postgres-concurrency.integration.test.ts
@@ -21,7 +21,8 @@ const realPostgresIt = databaseUrl && !process.env.STEWARD_PGLITE_MEMORY ? it : 
 realPostgresIt("serializes cumulative operator reservations across real connections", async () => {
   const suffix = crypto.randomUUID().replaceAll("-", "");
   const table = `operator_lock_test_${suffix}`;
-  const lockKey = `operator-transfer:test:${suffix}`;
+  // Match the shared per-agent lock used by vault/intents/operator transfers.
+  const agentId = `operator-lock-test-${suffix}`;
   const admin = postgres(databaseUrl!, { max: 1 });
   const first = postgres(databaseUrl!, { max: 1 });
   const second = postgres(databaseUrl!, { max: 1 });
@@ -31,7 +32,7 @@ realPostgresIt("serializes cumulative operator reservations across real connecti
     );
     const reserve = (client: Sql) =>
       client.begin(async (tx) => {
-        await tx`select pg_advisory_xact_lock(hashtextextended(${lockKey}, 0))`;
+        await tx`select pg_advisory_xact_lock(hashtext(${agentId}))`;
         const [row] = await tx.unsafe<{ total: string }[]>(
           `select coalesce(sum(amount), 0)::text as total from "${table}" where status in ('pending', 'final')`,
         );

--- a/packages/api/src/routes/intents.ts
+++ b/packages/api/src/routes/intents.ts
@@ -1119,7 +1119,7 @@ async function withAgentSpendLock<T>(agentId: string, fn: () => Promise<T>): Pro
     return fn();
   }
   return db.transaction(async (tx) => {
-    await tx.execute(sql`select pg_advisory_xact_lock(hashtext(${agentId}))`);
+    await tx.execute(sql`select pg_advisory_xact_lock(hashtextextended(${agentId}, 0))`);
     return fn();
   });
 }

--- a/packages/api/src/routes/user.ts
+++ b/packages/api/src/routes/user.ts
@@ -1524,7 +1524,7 @@ async function withAgentSpendLock<T>(agentId: string, fn: () => Promise<T>): Pro
   }
   const db = getDb();
   return db.transaction(async (tx) => {
-    await tx.execute(sql`select pg_advisory_xact_lock(hashtext(${agentId}))`);
+    await tx.execute(sql`select pg_advisory_xact_lock(hashtextextended(${agentId}, 0))`);
     return fn();
   });
 }

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -1978,7 +1978,7 @@ async function withAgentSpendLock<T>(agentId: string, fn: () => Promise<T>): Pro
     return fn();
   }
   return db.transaction(async (tx) => {
-    await tx.execute(sql`select pg_advisory_xact_lock(hashtext(${agentId}))`);
+    await tx.execute(sql`select pg_advisory_xact_lock(hashtextextended(${agentId}, 0))`);
     return fn();
   });
 }

--- a/packages/plugin-trading/src/__tests__/operator-recovery-policy-gates.test.ts
+++ b/packages/plugin-trading/src/__tests__/operator-recovery-policy-gates.test.ts
@@ -398,6 +398,25 @@ describe("SEC-042: withdraw policy evaluation is real", () => {
 });
 
 describe("SEC-043: operator idempotency stores ambiguous outcomes", () => {
+  it("releases durable spend before freeing the idempotency claim", async () => {
+    const source = await Bun.file(
+      new URL("../routes/operator-recovery.ts", import.meta.url),
+    ).text();
+    const helperStart = source.indexOf("async function releaseOperatorTransfer");
+    const helperEnd = source.indexOf("function operatorActor", helperStart);
+    const helper = source.slice(helperStart, helperEnd);
+    expect(helperStart).toBeGreaterThan(-1);
+    expect(helperEnd).toBeGreaterThan(helperStart);
+    expect(helper.indexOf("finishOperatorReservation")).toBeLessThan(
+      helper.indexOf("idempotency.release"),
+    );
+    expect(helper).toContain("if (released)");
+
+    const finishStart = source.indexOf("async function finishOperatorReservation");
+    const finish = source.slice(finishStart, helperStart);
+    expect(finish).toContain('eq(operatorTransferReservations.status, "pending")');
+  });
+
   it("releases a usd-send reservation after a definite local signing failure", async () => {
     const { tenantId, agentId } = await seedAgent({
       policies: [

--- a/packages/plugin-trading/src/routes/operator-recovery.ts
+++ b/packages/plugin-trading/src/routes/operator-recovery.ts
@@ -466,14 +466,14 @@ export function createOperatorRecoveryRoutes(
     // Stored agent policy rows are re-read under the table lock below.
     const defaultPolicySet = await getPolicySet(input.tenantId, input.agentId);
     return db.transaction(async (tx) => {
-      // Cross-replica serialization: every operator rail for this tenant+agent
-      // evaluates counters and inserts its reservation under the same lock.
+      // Cross-replica serialization: use the same per-agent spend lock as the
+      // core vault and intent paths. Agent ids are global primary keys, so this
+      // serializes operator reservations with both other operator rails and
+      // on-chain transaction evaluation/commit for the cumulative cap.
       const pgliteRuntime =
         process.env.STEWARD_DB_MODE === "pglite" || process.env.STEWARD_PGLITE_MEMORY === "true";
       if (!pgliteRuntime) {
-        await tx.execute(
-          sql`select pg_advisory_xact_lock(hashtextextended(${`operator-transfer:${input.tenantId}:${input.agentId}`}, 0))`,
-        );
+        await tx.execute(sql`select pg_advisory_xact_lock(hashtext(${input.agentId}))`);
       }
       // Stabilize the authorization snapshot until the reservation commits.
       // Policy writes take ROW EXCLUSIVE table locks, which conflict with SHARE;
@@ -627,7 +627,7 @@ export function createOperatorRecoveryRoutes(
     id: string,
     status: "final" | "released",
   ) {
-    await db
+    const [finished] = await db
       .update(operatorTransferReservations)
       .set({ status, finalizedAt: new Date() })
       .where(
@@ -635,8 +635,25 @@ export function createOperatorRecoveryRoutes(
           eq(operatorTransferReservations.id, id),
           eq(operatorTransferReservations.tenantId, tenantId),
           eq(operatorTransferReservations.agentId, agentId),
+          eq(operatorTransferReservations.status, "pending"),
         ),
-      );
+      )
+      .returning({ id: operatorTransferReservations.id });
+    return Boolean(finished);
+  }
+
+  async function releaseOperatorTransfer(
+    tenantId: string,
+    agentId: string,
+    reservationId: string,
+    idempotency: OperatorIdempotency,
+  ) {
+    // Release the durable reservation before freeing the idempotency claim.
+    // If the process stops between these operations, retaining the claim is
+    // fail-closed; the reverse order can admit a retry that then collides with
+    // the still-pending reservation's partial unique index.
+    const released = await finishOperatorReservation(tenantId, agentId, reservationId, "released");
+    if (released) await idempotency.release?.();
   }
 
   function operatorActor(c: Context<{ Variables: AppVariables }>): {
@@ -1202,8 +1219,7 @@ export function createOperatorRecoveryRoutes(
     try {
       signedUsdSend = await adapter.signUsdSend({ destination, amount });
     } catch (err) {
-      await idempotency.release?.();
-      await finishOperatorReservation(tenantId, agentId, policy.reservationId, "released");
+      await releaseOperatorTransfer(tenantId, agentId, policy.reservationId, idempotency);
       try {
         await auditRecoveryEvent(c, tenantId, agentId, "trade.usdsend.failed", {
           venue,
@@ -1228,8 +1244,7 @@ export function createOperatorRecoveryRoutes(
     } catch (_err) {
       // Nothing has reached the venue yet, so an audit outage is a definite
       // pre-submit failure and must not poison the durable spend reservation.
-      await idempotency.release?.();
-      await finishOperatorReservation(tenantId, agentId, policy.reservationId, "released");
+      await releaseOperatorTransfer(tenantId, agentId, policy.reservationId, idempotency);
       return c.json<ApiResponse>({ ok: false, error: "Failed to audit usdSend request" }, 502);
     }
 
@@ -1239,8 +1254,7 @@ export function createOperatorRecoveryRoutes(
     } catch (err) {
       const definitelyRejected = isDefiniteVenueRejection(err);
       if (definitelyRejected) {
-        await idempotency.release?.();
-        await finishOperatorReservation(tenantId, agentId, policy.reservationId, "released");
+        await releaseOperatorTransfer(tenantId, agentId, policy.reservationId, idempotency);
       } else {
         const errorBody = { ok: false as const, error: "Failed to submit usdSend" };
         await idempotency.storeFailure?.(errorBody);
@@ -1771,8 +1785,7 @@ export function createOperatorRecoveryRoutes(
     try {
       signedWithdraw = await adapter.signWithdraw({ amount, destination });
     } catch (err) {
-      await idempotency.release?.();
-      await finishOperatorReservation(tenantId, agentId, policy.reservationId, "released");
+      await releaseOperatorTransfer(tenantId, agentId, policy.reservationId, idempotency);
       try {
         await auditRecoveryEvent(c, tenantId, agentId, "trade.recovery.withdraw.failed", {
           venue,
@@ -1793,8 +1806,7 @@ export function createOperatorRecoveryRoutes(
     } catch (err) {
       const definitelyRejected = isDefiniteVenueRejection(err);
       if (definitelyRejected) {
-        await idempotency.release?.();
-        await finishOperatorReservation(tenantId, agentId, policy.reservationId, "released");
+        await releaseOperatorTransfer(tenantId, agentId, policy.reservationId, idempotency);
       }
       const errorBody = { ok: false as const, error: "Failed to submit withdraw" };
       if (!definitelyRejected) await idempotency.storeFailure?.(errorBody);

--- a/packages/plugin-trading/src/routes/operator-recovery.ts
+++ b/packages/plugin-trading/src/routes/operator-recovery.ts
@@ -473,7 +473,7 @@ export function createOperatorRecoveryRoutes(
       const pgliteRuntime =
         process.env.STEWARD_DB_MODE === "pglite" || process.env.STEWARD_PGLITE_MEMORY === "true";
       if (!pgliteRuntime) {
-        await tx.execute(sql`select pg_advisory_xact_lock(hashtext(${input.agentId}))`);
+        await tx.execute(sql`select pg_advisory_xact_lock(hashtextextended(${input.agentId}, 0))`);
       }
       // Stabilize the authorization snapshot until the reservation commits.
       // Policy writes take ROW EXCLUSIVE table locks, which conflict with SHARE;


### PR DESCRIPTION
## Summary

- serialize operator transfer reservations with the same per-agent advisory lock used by vault and intent spend accounting
- durably mark definite failures released before freeing their idempotency claim
- gate claim release on a successful pending-to-released transition
- update the real-Postgres concurrency fixture and add a regression for release ordering

## Why

PR #371 used a separate namespaced advisory-lock key for operator transfers, so concurrent core vault/intent and operator paths could evaluate the same cumulative cap under different locks. Its definite-failure paths also freed the idempotency claim before making the durable reservation reusable, exposing a retry window against the pending reservation.

## Validation

- `bun test packages/plugin-trading/src/__tests__/operator-recovery-policy-gates.test.ts` (14 pass)
- `bunx turbo run build --filter=@stwd/plugin-trading --filter=@stwd/api` (21/21)
- `bunx @biomejs/biome check packages/plugin-trading/src/routes/operator-recovery.ts packages/plugin-trading/src/__tests__/operator-recovery-policy-gates.test.ts packages/api/src/__tests__/operator-transfer-postgres-concurrency.integration.test.ts`
- `git diff --check`

The real-Postgres fixture is preserved for CI; no local PostgreSQL service was available.