### PR TITLE
fix(api): suppress trailing credential replay paths

### DIFF
--- a/packages/api/src/__tests__/idempotency-middleware.test.ts
+++ b/packages/api/src/__tests__/idempotency-middleware.test.ts
@@ -366,6 +366,14 @@ describe("idempotencyMiddleware", () => {
       count += 1;
       return c.json({ ok: true, data: { token: `ghs_v1_renew_${count}` } });
     });
+    app.post("/capabilities/manifest/github/issue/", async (c) => {
+      count += 1;
+      return c.json({ ok: true, data: { token: `ghs_issue_slash_${count}` } });
+    });
+    app.post("/v1/capabilities/manifest/github/renew/", async (c) => {
+      count += 1;
+      return c.json({ ok: true, data: { token: `ghs_v1_renew_slash_${count}` } });
+    });
 
     for (const [path, body] of [
       ["/vault/agent-1/export", {}],
@@ -377,6 +385,8 @@ describe("idempotencyMiddleware", () => {
       ["/capabilities/manifest/github/renew", { resources: { repositories: ["org/repo"] } }],
       ["/v1/capabilities/manifest/github/issue", { resources: { repositories: ["org/repo"] } }],
       ["/v1/capabilities/manifest/github/renew", { resources: { repositories: ["org/repo"] } }],
+      ["/capabilities/manifest/github/issue/", { resources: { repositories: ["org/repo"] } }],
+      ["/v1/capabilities/manifest/github/renew/", { resources: { repositories: ["org/repo"] } }],
     ] as const) {
       const init = {
         method: "POST",
@@ -398,7 +408,7 @@ describe("idempotencyMiddleware", () => {
         error: "Idempotency key has already been used",
       });
     }
-    expect(count).toBe(9);
+    expect(count).toBe(11);
   });
 
   it("uses a verified request signature as replay-safe auth material", async () => {

--- a/packages/api/src/middleware/idempotency.ts
+++ b/packages/api/src/middleware/idempotency.ts
@@ -592,7 +592,7 @@ const SECRET_BEARING_RESPONSE_PATTERNS = [
   /^\/user\/me\/wallet\/export$/, // POST /user/me/wallet/export — user wallet key material
   /^\/v1\/kms\/keys\/[^/]+\/decrypt$/, // POST /v1/kms/keys/:keyId/decrypt — plaintext
   /^\/secrets(?:\/|$)/, // POST /secrets — secret values
-  /^\/(?:v1\/)?capabilities\/manifest\/[^/]+\/(?:issue|renew)$/, // POST …/issue|renew — one-time upstream credential
+  /^\/(?:v1\/)?capabilities\/manifest\/[^/]+\/(?:issue|renew)\/?$/, // POST …/issue|renew — one-time upstream credential
   // Review-wave extension of the audit's named list (same issue class):
   // recovery setup returns the one-time BIP39 mnemonic ("shown once, not
   // stored"), so its body must never land in the idempotency store either.


### PR DESCRIPTION
Follow-up to #382 after exact review of the credential response replay boundary.

The secret-response classifier covered issue and renew routes without a trailing slash, while the capability route exposure contract accepts an optional trailing slash. This patch keeps those equivalent paths out of the idempotency response store too.

Regression coverage verifies both unversioned issue and versioned renew trailing-slash forms return the first credential once, then reject the duplicate with 409 instead of persisting or replaying its body.

Intentionally draft pending exact-head CI and maintainer review.