### PR TITLE
fix(capabilities): normalize issuer timeout diagnostics

### DIFF
--- a/packages/plugin-capabilities/src/__tests__/github-app-issuer.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/github-app-issuer.test.ts
@@ -70,6 +70,24 @@ describe("GitHub App upstream issuer transport", () => {
     expect(signal?.aborted).toBe(true);
   });
 
+  test("normalizes fetch abort diagnostics after the issuer deadline", async () => {
+    const issuer = new GitHubAppInstallationTokenIssuer(
+      ((_url, init) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => reject(new Error("secret provider cancellation diagnostic")),
+            { once: true },
+          );
+        })) as typeof fetch,
+      25,
+    );
+
+    const error = await issuer.issue(request).catch((caught) => caught as Error);
+    expect(error.message).toBe("GitHub request timed out");
+    expect(error.message).not.toContain("secret provider cancellation diagnostic");
+  });
+
   test("bounds stalled response bodies and contains hostile cancel rejection", async () => {
     let cancelCalled = false;
     const issuer = new GitHubAppInstallationTokenIssuer(

--- a/packages/plugin-capabilities/src/github-app-issuer.ts
+++ b/packages/plugin-capabilities/src/github-app-issuer.ts
@@ -80,14 +80,22 @@ export class GitHubAppInstallationTokenIssuer implements UpstreamTokenIssuer {
   private async withDeadline<T>(run: (signal: AbortSignal) => Promise<T>): Promise<T> {
     const controller = new AbortController();
     let timer: ReturnType<typeof setTimeout> | undefined;
+    let timedOut = false;
     const deadline = new Promise<never>((_resolve, reject) => {
       timer = setTimeout(() => {
+        timedOut = true;
         controller.abort();
         reject(new Error("GitHub request timed out"));
       }, this.requestTimeoutMs);
     });
     try {
       return await Promise.race([run(controller.signal), deadline]);
+    } catch (error) {
+      // abort() can synchronously cause fetch/stream implementations to reject
+      // before the deadline promise wins the race. Never surface provider or
+      // cancellation diagnostics once our own deadline has elapsed.
+      if (timedOut) throw new Error("GitHub request timed out");
+      throw error;
     } finally {
       if (timer) clearTimeout(timer);
     }


### PR DESCRIPTION
Post-merge corrective follow-up for #381.

`AbortController.abort()` can synchronously or immediately reject an injected/provider fetch before the deadline promise wins `Promise.race`. That exposed provider cancellation diagnostics even after Steward's own deadline elapsed. Track deadline ownership and always return the fixed `GitHub request timed out` error once that deadline fires.

Adds a regression whose fetch rejects on abort with a secret diagnostic and proves it is not surfaced.

Validation on exact head:
- `bun test packages/plugin-capabilities/src/__tests__/github-app-issuer.test.ts` (8 pass, 25 assertions)
- Biome 2.5.0 on both changed files (clean)
- `git diff --check origin/develop...HEAD` (clean)
- package build attempted, but this isolated checkout currently lacks unrelated optional workspace modules `@scure/bip32`, `@scure/bip39`, and its English wordlist after concurrent installs; the changed package source itself typechecks through the focused suite.

The separate cancel-safe database lifecycle deadline gap is tracked in #387. This PR deliberately does not use an unsafe `Promise.race` around database mutations.