### PR TITLE
fix(attestation): reject duplicate registry JSON keys

### DIFF
--- a/packages/attestation/src/__tests__/attestation.test.ts
+++ b/packages/attestation/src/__tests__/attestation.test.ts
@@ -603,6 +603,25 @@ describe("measurement registry", () => {
     );
   });
 
+  test.each([
+    ['{"payload":{},"payload":{},"signatures":[]}', "literal duplicate"],
+    [
+      '{"payload":{"registryId":"test","\\u0072egistryId":"other"},"signatures":[]}',
+      "escape-equivalent duplicate",
+    ],
+    ['{"payload":{},"signatures":[{"keyId":"one","keyId":"two"}]}', "nested duplicate"],
+  ])("rejects %s before JSON.parse (%s)", (json) => {
+    expect(() => parseMeasurementRegistryJson(Buffer.from(json))).toThrow(
+      "measurement registry JSON contains a duplicate object key",
+    );
+  });
+
+  test("allows the same decoded key in separate object scopes", () => {
+    expect(
+      parseMeasurementRegistryJson(Buffer.from('{"payload":{"id":1},"other":{"id":2}}')),
+    ).toEqual({ payload: { id: 1 }, other: { id: 2 } });
+  });
+
   test("counts canonical UTF-8 bytes, escaped bytes, keys, and nodes", () => {
     expect(() => canonicalizeJson({ value: "\u0000".repeat(200_000) })).toThrow(
       "registry payload exceeded the 1 MiB limit",

--- a/packages/attestation/src/registry.ts
+++ b/packages/attestation/src/registry.ts
@@ -241,6 +241,157 @@ function decodeEd25519Signature(signatureBase64: unknown): Buffer | null {
 
 class RegistryPayloadLimitError extends Error {}
 
+class RegistryJsonError extends SyntaxError {}
+
+/**
+ * Validate JSON grammar and reject duplicate decoded object names before
+ * JSON.parse can apply last-key-wins semantics. Property names are decoded
+ * with the platform parser, so raw and escape-equivalent spellings compare as
+ * the same key.
+ */
+function assertUnambiguousRegistryJson(text: string): void {
+  let offset = 0;
+  let structuralTokens = 0;
+  const fail = (message: string): never => {
+    throw new RegistryJsonError(message);
+  };
+  const countToken = (): void => {
+    structuralTokens += 1;
+    if (structuralTokens > MAX_REGISTRY_JSON_STRUCTURAL_TOKENS) {
+      fail("measurement registry JSON exceeded the structural token limit");
+    }
+  };
+  const skipWhitespace = (): void => {
+    while (/^[\u0009\u000a\u000d\u0020]$/.test(text[offset] ?? "")) offset += 1;
+  };
+  const parseString = (): string => {
+    const start = offset;
+    if (text[offset] !== '"') fail("measurement registry file is not valid JSON");
+    countToken();
+    offset += 1;
+    while (offset < text.length) {
+      const codeUnit = text.charCodeAt(offset);
+      if (text[offset] === '"') {
+        offset += 1;
+        try {
+          return JSON.parse(text.slice(start, offset)) as string;
+        } catch {
+          return fail("measurement registry file is not valid JSON");
+        }
+      }
+      if (codeUnit <= 0x1f) fail("measurement registry file is not valid JSON");
+      if (text[offset] === "\\") {
+        offset += 1;
+        const escape = text[offset];
+        if (escape === "u") {
+          if (!/^[0-9a-fA-F]{4}$/.test(text.slice(offset + 1, offset + 5))) {
+            fail("measurement registry file is not valid JSON");
+          }
+          offset += 5;
+          continue;
+        }
+        if (!escape || !'"\\/bfnrt'.includes(escape)) {
+          fail("measurement registry file is not valid JSON");
+        }
+      }
+      offset += 1;
+    }
+    return fail("measurement registry file is not valid JSON");
+  };
+  const parseNumber = (): void => {
+    if (text[offset] === "-") offset += 1;
+    if (text[offset] === "0") {
+      offset += 1;
+    } else {
+      if (!/^[1-9]$/.test(text[offset] ?? "")) fail("measurement registry file is not valid JSON");
+      while (/^[0-9]$/.test(text[offset] ?? "")) offset += 1;
+    }
+    if (text[offset] === ".") {
+      offset += 1;
+      if (!/^[0-9]$/.test(text[offset] ?? "")) fail("measurement registry file is not valid JSON");
+      while (/^[0-9]$/.test(text[offset] ?? "")) offset += 1;
+    }
+    if (text[offset] === "e" || text[offset] === "E") {
+      offset += 1;
+      if (text[offset] === "+" || text[offset] === "-") offset += 1;
+      if (!/^[0-9]$/.test(text[offset] ?? "")) fail("measurement registry file is not valid JSON");
+      while (/^[0-9]$/.test(text[offset] ?? "")) offset += 1;
+    }
+  };
+  const parseValue = (containerDepth: number): void => {
+    skipWhitespace();
+    const token = text[offset];
+    if (token === '"') {
+      parseString();
+      return;
+    }
+    if (token === "{" || token === "[") {
+      if (containerDepth >= MAX_REGISTRY_JSON_DEPTH) {
+        fail(`measurement registry JSON exceeded the maximum depth of ${MAX_REGISTRY_JSON_DEPTH}`);
+      }
+      countToken();
+      offset += 1;
+      skipWhitespace();
+      if (token === "{") {
+        const keys = new Set<string>();
+        if (text[offset] === "}") {
+          offset += 1;
+          return;
+        }
+        while (true) {
+          skipWhitespace();
+          const key = parseString();
+          if (keys.has(key)) fail("measurement registry JSON contains a duplicate object key");
+          keys.add(key);
+          skipWhitespace();
+          if (text[offset] !== ":") fail("measurement registry file is not valid JSON");
+          countToken();
+          offset += 1;
+          parseValue(containerDepth + 1);
+          skipWhitespace();
+          if (text[offset] === "}") {
+            offset += 1;
+            return;
+          }
+          if (text[offset] !== ",") fail("measurement registry file is not valid JSON");
+          countToken();
+          offset += 1;
+        }
+      }
+      if (text[offset] === "]") {
+        offset += 1;
+        return;
+      }
+      while (true) {
+        parseValue(containerDepth + 1);
+        skipWhitespace();
+        if (text[offset] === "]") {
+          offset += 1;
+          return;
+        }
+        if (text[offset] !== ",") fail("measurement registry file is not valid JSON");
+        countToken();
+        offset += 1;
+      }
+    }
+    if (token === "-" || /^[0-9]$/.test(token ?? "")) {
+      parseNumber();
+      return;
+    }
+    for (const literal of ["true", "false", "null"]) {
+      if (text.startsWith(literal, offset)) {
+        offset += literal.length;
+        return;
+      }
+    }
+    fail("measurement registry file is not valid JSON");
+  };
+
+  parseValue(0);
+  skipWhitespace();
+  if (offset !== text.length) fail("measurement registry file is not valid JSON");
+}
+
 /** Parse a registry file through the same byte and complexity limits as the verifier. */
 export function parseMeasurementRegistryJson(bytes: Uint8Array): MeasurementRegistryFile {
   if (bytes.byteLength > MAX_MEASUREMENT_REGISTRY_FILE_BYTES) {
@@ -254,45 +405,7 @@ export function parseMeasurementRegistryJson(bytes: Uint8Array): MeasurementRegi
     throw new Error("measurement registry file is not valid UTF-8 JSON");
   }
 
-  let depth = 0;
-  let structuralTokens = 0;
-  let inString = false;
-  let escaped = false;
-  for (let index = 0; index < text.length; index += 1) {
-    const character = text[index];
-    if (inString) {
-      if (escaped) {
-        escaped = false;
-      } else if (character === "\\") {
-        escaped = true;
-      } else if (character === '"') {
-        inString = false;
-      }
-      continue;
-    }
-    if (character === '"') {
-      inString = true;
-      structuralTokens += 1;
-    } else if (character === "{" || character === "[") {
-      depth += 1;
-      structuralTokens += 1;
-      if (depth > MAX_REGISTRY_JSON_DEPTH) {
-        throw new Error(
-          `measurement registry JSON exceeded the maximum depth of ${MAX_REGISTRY_JSON_DEPTH}`,
-        );
-      }
-    } else if (character === "}" || character === "]") {
-      depth -= 1;
-      if (depth < 0) throw new Error("measurement registry file is not valid JSON");
-    } else if (character === ":" || character === ",") {
-      structuralTokens += 1;
-    }
-    if (structuralTokens > MAX_REGISTRY_JSON_STRUCTURAL_TOKENS) {
-      throw new Error("measurement registry JSON exceeded the structural token limit");
-    }
-  }
-
-  if (inString || depth !== 0) throw new Error("measurement registry file is not valid JSON");
+  assertUnambiguousRegistryJson(text);
   try {
     return JSON.parse(text) as MeasurementRegistryFile;
   } catch {

--- a/scripts/__tests__/check-attestation.test.ts
+++ b/scripts/__tests__/check-attestation.test.ts
@@ -73,6 +73,35 @@ describe("check-attestation bounded registry ingestion", () => {
     }
   });
 
+  test.each([
+    ['{"payload":{},"payload":{},"signatures":[]}', "top-level duplicate"],
+    [
+      '{"payload":{"registryId":"test","\\u0072egistryId":"other"},"signatures":[]}',
+      "escape-equivalent duplicate",
+    ],
+    ['{"payload":{},"signatures":[{"keyId":"one","keyId":"two"}]}', "nested duplicate"],
+  ])("rejects ambiguous registry JSON before network access (%s)", (contents) => {
+    const directory = mkdtempSync(join(tmpdir(), "steward-attestation-"));
+    const registryPath = join(directory, "duplicate-key.json");
+    try {
+      writeFileSync(registryPath, contents);
+      const result = Bun.spawnSync([process.execPath, "scripts/check-attestation.ts"], {
+        cwd: ROOT,
+        env: cliEnv(registryPath, "http://127.0.0.1:1/never-requested"),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      expect(result.exitCode).toBe(2);
+      expect(result.stderr.toString()).toContain(
+        "measurement registry JSON contains a duplicate object key",
+      );
+      expect(result.stderr.toString()).not.toContain("fetch");
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
   test("cancels a streamed quote response over the decoded byte limit", async () => {
     const server = Bun.serve({
       hostname: "127.0.0.1",


### PR DESCRIPTION
## Summary

Consolidated follow-up to merged #383 and #384:

- reject duplicate decoded object names in the shared `parseMeasurementRegistryJson` API before `JSON.parse` can apply last-key-wins semantics
- compare raw and escape-equivalent property spellings as the same key, at every object depth, while allowing the same key in independent object scopes
- preserve #384’s 4 MiB byte ceiling, 72-level nesting ceiling, and 100,000 structural-token ceiling in the single shared parser
- keep the CLI on the package parser rather than maintaining a divergent second parser

## Security rationale

Duplicate JSON names can make reviewers, signing tools, and verifiers assign different meanings to the same envelope bytes. The check belongs at the package ingestion boundary so every current caller receives identical semantics; runtime registry objects continue to use #383’s immutable descriptor snapshots and canonical validation.

## Validation

Exact base: `a6b7ab2bcda11ea000f6f35d39bc3cc3c094be07`
Exact head: `6170c19f4b6de0980588d27c3e1f5aaa5c683525`

- focused package + CLI suites: 39 passed, 122 assertions
- `@stwd/attestation` TypeScript build: passed
- Biome on all four relevant files: passed
- `git diff --check`: passed

Duplicate regressions cover top-level, nested, and Unicode-escape-equivalent names plus separate-scope acceptance.