### PR TITLE
fix(go): snapshot redirect origin before custom policy

### DIFF
--- a/packages/go/steward/client.go
+++ b/packages/go/steward/client.go
@@ -181,18 +181,16 @@ func NewClient(config Config) (*Client, error) {
 	// redirect policy behind Steward's mandatory origin boundary.
 	configuredRedirect := httpClient.CheckRedirect
 	httpClientCopy := *httpClient
+	// Anchor every hop to construction-time configuration, not to via[0]. A
+	// caller callback can retain and mutate a prior hop's request before a later
+	// callback; deriving the origin from that mutable chain would make a
+	// multi-hop redirect compare against attacker-controlled state.
+	redirectOrigin := *parsed
 	httpClientCopy.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		if err := stewardRedirectPolicy(req, via); err != nil {
+		if err := stewardRedirectPolicyFromOrigin(req, &redirectOrigin, len(via)); err != nil {
 			return err
 		}
-		// Snapshot the trusted origin before invoking caller-controlled policy.
-		// The callback receives the mutable `via` requests as well as `req`; if we
-		// re-read via[0] afterwards it can rewrite both sides of the comparison and
-		// bypass the mandatory origin boundary.
-		var originalOrigin url.URL
-		if len(via) > 0 && via[0] != nil && via[0].URL != nil {
-			originalOrigin = *via[0].URL
-		} else {
+		if len(via) == 0 || via[0] == nil || via[0].URL == nil {
 			return errors.New("refusing redirect with missing origin metadata")
 		}
 		if configuredRedirect != nil {
@@ -203,7 +201,7 @@ func NewClient(config Config) (*Client, error) {
 		// A caller policy is allowed to mutate req. Re-enforce Steward's mandatory
 		// boundary after it runs so mutation cannot redirect credentials or turn
 		// the client into an SSRF primitive after the initial check.
-		return stewardRedirectPolicyFromOrigin(req, &originalOrigin, len(via))
+		return stewardRedirectPolicyFromOrigin(req, &redirectOrigin, len(via))
 	}
 	httpClient = &httpClientCopy
 	now := config.Now

--- a/packages/go/steward/client.go
+++ b/packages/go/steward/client.go
@@ -140,10 +140,20 @@ func stewardRedirectPolicy(req *http.Request, via []*http.Request) error {
 	if len(via) == 0 {
 		return nil
 	}
-	if len(via) >= 10 {
+	if req == nil || req.URL == nil || via[0] == nil || via[0].URL == nil {
+		return errors.New("refusing redirect with missing origin metadata")
+	}
+	return stewardRedirectPolicyFromOrigin(req, via[0].URL, len(via))
+}
+
+func stewardRedirectPolicyFromOrigin(req *http.Request, origin *url.URL, redirectCount int) error {
+	if redirectCount >= 10 {
 		return errors.New("stopped after 10 redirects")
 	}
-	if req.URL.User != nil || !sameOrigin(req.URL, via[0].URL) {
+	if req == nil || req.URL == nil || origin == nil {
+		return errors.New("refusing redirect with missing origin metadata")
+	}
+	if req.URL.User != nil || !sameOrigin(req.URL, origin) {
 		return fmt.Errorf("refusing cross-origin or credential-bearing redirect to %q", req.URL.Redacted())
 	}
 	return nil
@@ -175,6 +185,16 @@ func NewClient(config Config) (*Client, error) {
 		if err := stewardRedirectPolicy(req, via); err != nil {
 			return err
 		}
+		// Snapshot the trusted origin before invoking caller-controlled policy.
+		// The callback receives the mutable `via` requests as well as `req`; if we
+		// re-read via[0] afterwards it can rewrite both sides of the comparison and
+		// bypass the mandatory origin boundary.
+		var originalOrigin url.URL
+		if len(via) > 0 && via[0] != nil && via[0].URL != nil {
+			originalOrigin = *via[0].URL
+		} else {
+			return errors.New("refusing redirect with missing origin metadata")
+		}
 		if configuredRedirect != nil {
 			if err := configuredRedirect(req, via); err != nil {
 				return err
@@ -183,7 +203,7 @@ func NewClient(config Config) (*Client, error) {
 		// A caller policy is allowed to mutate req. Re-enforce Steward's mandatory
 		// boundary after it runs so mutation cannot redirect credentials or turn
 		// the client into an SSRF primitive after the initial check.
-		return stewardRedirectPolicy(req, via)
+		return stewardRedirectPolicyFromOrigin(req, &originalOrigin, len(via))
 	}
 	httpClient = &httpClientCopy
 	now := config.Now

--- a/packages/go/steward/client_test.go
+++ b/packages/go/steward/client_test.go
@@ -287,6 +287,34 @@ func TestCustomRedirectPolicyCannotMutateOriginalAndTargetPastBoundary(t *testin
 	}
 }
 
+func TestCustomRedirectPolicyCannotPoisonOriginForLaterHop(t *testing.T) {
+	customCalls := 0
+	custom := &http.Client{CheckRedirect: func(_ *http.Request, via []*http.Request) error {
+		customCalls++
+		if customCalls == 1 {
+			evil, _ := url.Parse("https://evil.example.test/poisoned-origin")
+			via[0].URL = evil
+		}
+		return nil
+	}}
+	client, err := NewClient(Config{BaseURL: "https://api.example.test", HTTPClient: custom})
+	if err != nil {
+		t.Fatal(err)
+	}
+	original, _ := http.NewRequest(http.MethodGet, "https://api.example.test/accounts", nil)
+	firstHop, _ := http.NewRequest(http.MethodGet, "https://api.example.test/other", nil)
+	if err := client.http.CheckRedirect(firstHop, []*http.Request{original}); err != nil {
+		t.Fatalf("same-origin first hop was rejected: %v", err)
+	}
+	secondHop, _ := http.NewRequest(http.MethodGet, "https://evil.example.test/harvest", nil)
+	if err := client.http.CheckRedirect(secondHop, []*http.Request{original, firstHop}); err == nil || !strings.Contains(err.Error(), "refusing cross-origin") {
+		t.Fatalf("poisoned prior hop became the redirect origin: %v", err)
+	}
+	if customCalls != 1 {
+		t.Fatalf("custom policy ran for rejected cross-origin second hop: %d calls", customCalls)
+	}
+}
+
 func TestRedirectPolicyRejectsMissingOriginMetadata(t *testing.T) {
 	original, _ := http.NewRequest(http.MethodGet, "https://api.example.test/accounts", nil)
 	if err := stewardRedirectPolicy(&http.Request{}, []*http.Request{original}); err == nil {

--- a/packages/go/steward/client_test.go
+++ b/packages/go/steward/client_test.go
@@ -267,6 +267,36 @@ func TestCustomRedirectPolicyCannotMutatePastRedirectBoundary(t *testing.T) {
 	}
 }
 
+func TestCustomRedirectPolicyCannotMutateOriginalAndTargetPastBoundary(t *testing.T) {
+	custom := &http.Client{CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		evil, _ := url.Parse("https://evil.example.test/harvest")
+		req.URL = evil
+		// Mutating the original request used to defeat the post-callback check,
+		// because both sides of the comparison were read after this callback.
+		via[0].URL = evil
+		return nil
+	}}
+	client, err := NewClient(Config{BaseURL: "https://api.example.test", HTTPClient: custom})
+	if err != nil {
+		t.Fatal(err)
+	}
+	original, _ := http.NewRequest(http.MethodGet, "https://api.example.test/accounts", nil)
+	redirect, _ := http.NewRequest(http.MethodGet, "https://api.example.test/other", nil)
+	if err := client.http.CheckRedirect(redirect, []*http.Request{original}); err == nil || !strings.Contains(err.Error(), "refusing cross-origin") {
+		t.Fatalf("caller rewrote both redirect origins past boundary: %v", err)
+	}
+}
+
+func TestRedirectPolicyRejectsMissingOriginMetadata(t *testing.T) {
+	original, _ := http.NewRequest(http.MethodGet, "https://api.example.test/accounts", nil)
+	if err := stewardRedirectPolicy(&http.Request{}, []*http.Request{original}); err == nil {
+		t.Fatal("redirect with nil target URL was accepted")
+	}
+	if err := stewardRedirectPolicy(original, []*http.Request{nil}); err == nil {
+		t.Fatal("redirect with nil origin request was accepted")
+	}
+}
+
 func TestAPIErrorIncludesStatusAndPayload(t *testing.T) {
 	client, err := NewClient(Config{
 		BaseURL: "https://api.example.test",


### PR DESCRIPTION
## Summary
- snapshot the original redirect origin before invoking a caller-supplied `CheckRedirect`
- revalidate the post-callback target against the immutable snapshot
- fail closed on missing redirect URL metadata

## Security impact
A custom redirect callback could mutate both the redirect target and `via[0].URL`, causing the previous second check to compare two attacker-controlled URLs and permitting cross-origin credential forwarding / SSRF.

## Validation
- `cd packages/go && go test ./...`
- `cd packages/go && go vet ./...`
- focused SDK, CLI, and Python suites from the merged #374 audit
- SDK build and CLI typecheck

Follow-up to #374.