### PR TITLE
fix(security): W3-A2 re-audit batch — api middleware/services hardening

### DIFF
--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -403,7 +403,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -435,7 +435,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -708,7 +709,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -740,7 +741,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -1026,7 +1028,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -1058,7 +1060,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -1342,7 +1345,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -1374,7 +1377,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -1644,7 +1648,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -1676,7 +1680,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -1967,7 +1972,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -1999,7 +2004,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -2267,7 +2273,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -2299,7 +2305,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -2571,7 +2578,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -2603,7 +2610,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -2875,7 +2883,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -2907,7 +2915,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -3179,7 +3188,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -3211,7 +3220,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -3476,7 +3486,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -3508,7 +3518,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -3744,7 +3755,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -3776,7 +3787,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -4055,7 +4067,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -4087,7 +4099,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -4366,7 +4379,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -4398,7 +4411,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -4631,7 +4645,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -4663,7 +4677,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -4930,7 +4945,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -4962,7 +4977,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -5194,7 +5210,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -5226,7 +5242,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -5587,7 +5604,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -5619,7 +5636,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -5837,7 +5855,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -6073,7 +6091,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -6145,7 +6164,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -6381,7 +6400,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -6608,7 +6628,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -6844,7 +6864,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -6916,7 +6937,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -7152,7 +7173,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -7389,7 +7411,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -7625,7 +7647,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -7852,7 +7875,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -8088,7 +8111,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -8160,7 +8184,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -8396,7 +8420,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -8623,7 +8648,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -8859,7 +8884,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -8931,7 +8957,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -9167,7 +9193,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -10074,7 +10101,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -10106,7 +10133,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -10366,7 +10394,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -10398,7 +10426,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -12483,7 +12512,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -12515,7 +12544,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -13656,7 +13686,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -13688,7 +13718,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -13910,7 +13941,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -13942,7 +13973,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -15077,7 +15109,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -15109,7 +15141,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -15591,7 +15624,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -15623,7 +15656,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -16762,7 +16796,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -16794,7 +16828,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -17935,7 +17970,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -17967,7 +18002,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -18189,7 +18225,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -18221,7 +18257,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -19356,7 +19393,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -19388,7 +19425,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -19870,7 +19908,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -19902,7 +19940,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -20416,7 +20455,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -20448,7 +20487,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -20814,7 +20854,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -20846,7 +20886,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -21341,7 +21382,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -21373,7 +21414,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -21592,7 +21634,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -21624,7 +21666,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -21892,7 +21935,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -21924,7 +21967,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -22438,7 +22482,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -22470,7 +22514,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -22836,7 +22881,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -22868,7 +22913,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -23363,7 +23409,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -23395,7 +23441,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -23614,7 +23661,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -23646,7 +23693,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -23914,7 +23962,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -23946,7 +23994,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -24475,7 +24524,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -24507,7 +24556,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -25002,7 +25052,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -25034,7 +25084,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -25249,7 +25300,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -25281,7 +25332,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -25810,7 +25862,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -25842,7 +25894,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -26140,7 +26193,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -26172,7 +26225,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -26666,7 +26720,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -26698,7 +26752,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -26913,7 +26968,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -26945,7 +27000,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -27474,7 +27530,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -27506,7 +27562,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -28001,7 +28058,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -28033,7 +28090,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -28248,7 +28306,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -28280,7 +28338,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -28809,7 +28868,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -28841,7 +28900,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -29139,7 +29199,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -29171,7 +29231,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -29665,7 +29726,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -29697,7 +29758,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -29912,7 +29974,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -29944,7 +30006,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -30833,7 +30896,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -30865,7 +30928,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -31320,7 +31384,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -31352,7 +31416,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -31690,7 +31755,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -31722,7 +31787,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -32324,7 +32390,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -32356,7 +32422,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -32715,7 +32782,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -32747,7 +32814,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -33037,7 +33105,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -33069,7 +33137,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -33958,7 +34027,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -33990,7 +34059,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -34445,7 +34515,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -34477,7 +34547,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -34815,7 +34886,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -34847,7 +34918,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -35449,7 +35521,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -35481,7 +35553,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -35840,7 +35913,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -35872,7 +35945,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -36162,7 +36236,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -36194,7 +36268,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -37251,7 +37326,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -37283,7 +37358,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -38108,7 +38184,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -38140,7 +38216,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -38597,7 +38674,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -38629,7 +38706,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -39085,7 +39163,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -39117,7 +39195,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -39573,7 +39652,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -39605,7 +39684,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -40061,7 +40141,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -40093,7 +40173,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -40549,7 +40630,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -40581,7 +40662,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -41037,7 +41119,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -41069,7 +41151,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -45500,7 +45583,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -45532,7 +45615,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -45828,7 +45912,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -45860,7 +45944,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -46594,7 +46679,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -46626,7 +46711,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -46710,7 +46796,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -47029,7 +47115,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -48842,7 +48929,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -48874,7 +48961,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -49220,7 +49308,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -49252,7 +49340,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -49801,7 +49890,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -49833,7 +49922,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -50215,7 +50305,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -50247,7 +50337,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -50986,7 +51077,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -51018,7 +51109,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -51320,7 +51412,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -51352,7 +51444,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -51789,7 +51882,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -51821,7 +51914,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -52360,7 +52454,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -52392,7 +52486,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -52824,7 +52919,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -52856,7 +52951,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -53382,7 +53478,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -53414,7 +53510,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -54148,7 +54245,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -54180,7 +54277,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -54482,7 +54580,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -54514,7 +54612,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -54813,7 +54912,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -54845,7 +54944,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -55366,7 +55466,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -55398,7 +55498,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -55707,7 +55808,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -55739,7 +55840,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -56052,7 +56154,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -56084,7 +56186,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -56331,7 +56434,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -56363,7 +56466,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -56667,7 +56771,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -56699,7 +56803,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -57370,7 +57475,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -57402,7 +57507,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -57951,7 +58057,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -57983,7 +58089,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -58365,7 +58472,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -58397,7 +58504,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -59136,7 +59244,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -59168,7 +59276,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -59470,7 +59579,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -59502,7 +59611,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -59939,7 +60049,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -59971,7 +60081,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -60510,7 +60621,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -60542,7 +60653,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -60974,7 +61086,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -61006,7 +61118,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -61532,7 +61645,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -61564,7 +61677,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -62298,7 +62412,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -62330,7 +62444,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -62632,7 +62747,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -62664,7 +62779,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -62963,7 +63079,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -62995,7 +63111,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -63516,7 +63633,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -63548,7 +63665,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -63857,7 +63975,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -63889,7 +64007,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -64202,7 +64321,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -64234,7 +64353,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -64481,7 +64601,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -64513,7 +64633,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -64817,7 +64938,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -64849,7 +64970,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -65520,7 +65642,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -65552,7 +65674,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -66156,7 +66279,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -66188,7 +66311,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -66504,7 +66628,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -66536,7 +66660,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -67069,7 +67194,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -67101,7 +67226,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -67402,7 +67528,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -67434,7 +67560,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -67757,7 +67884,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -67789,7 +67916,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -68342,7 +68470,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -68374,7 +68502,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -69806,7 +69935,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -70052,7 +70181,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -70745,7 +70875,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -70777,7 +70907,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -71366,7 +71497,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -71398,7 +71529,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -71750,7 +71882,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -71782,7 +71914,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -72002,7 +72135,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -72034,7 +72167,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -72520,7 +72654,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -72552,7 +72686,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -72772,7 +72907,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -72804,7 +72939,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -73094,7 +73230,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -73126,7 +73262,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -73722,7 +73859,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -73754,7 +73891,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -74119,7 +74257,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -74151,7 +74289,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -74375,7 +74514,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -74407,7 +74546,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -74648,7 +74788,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -74680,7 +74820,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -75545,7 +75686,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -75577,7 +75718,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -75865,7 +76007,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -75897,7 +76039,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -76702,7 +76845,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -76734,7 +76877,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -77061,7 +77205,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -77093,7 +77237,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -77654,7 +77799,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -77686,7 +77831,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -78525,7 +78671,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -78557,7 +78703,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -79165,7 +79312,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -79197,7 +79344,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -79513,7 +79661,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -79545,7 +79693,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -79931,7 +80080,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -79963,7 +80112,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -80247,7 +80397,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -80279,7 +80429,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -80764,7 +80915,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -80796,7 +80947,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -81307,7 +81459,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -81339,7 +81491,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -81738,7 +81891,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -81770,7 +81923,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -82082,7 +82236,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -82114,7 +82268,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -82410,7 +82565,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -82442,7 +82597,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -82808,7 +82964,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -82840,7 +82996,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -83143,7 +83300,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -83175,7 +83332,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -83480,7 +83638,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -83512,7 +83670,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -83832,7 +83991,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -83864,7 +84023,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -84349,7 +84509,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -84381,7 +84541,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -84892,7 +85053,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -84924,7 +85085,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -85323,7 +85485,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -85355,7 +85517,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -85667,7 +85830,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -85699,7 +85862,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -85995,7 +86159,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -86027,7 +86191,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -86393,7 +86558,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -86425,7 +86590,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -86728,7 +86894,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -86760,7 +86926,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -87065,7 +87232,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -87097,7 +87264,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -87417,7 +87585,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -87449,7 +87617,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -88343,7 +88512,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -88375,7 +88544,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -88832,7 +89002,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -88864,7 +89034,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -89280,7 +89451,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -89312,7 +89483,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -90388,7 +90560,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -90420,7 +90592,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -90716,7 +90889,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -90748,7 +90921,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -91266,7 +91440,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -91298,7 +91472,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -91577,7 +91752,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -91609,7 +91784,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -91824,7 +92000,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -91856,7 +92032,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -92504,7 +92681,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -92536,7 +92713,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -92771,7 +92949,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -92803,7 +92981,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -93108,7 +93287,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -93140,7 +93319,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -93806,7 +93986,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -93838,7 +94018,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -94115,7 +94296,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -94147,7 +94328,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -94506,7 +94688,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -94538,7 +94720,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -95065,7 +95248,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -95097,7 +95280,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -95871,7 +96055,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -95903,7 +96087,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -96407,7 +96592,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -96439,7 +96624,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -96724,7 +96910,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -96756,7 +96942,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -97225,7 +97412,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -97257,7 +97444,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -97736,7 +97924,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -97768,7 +97956,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -98367,7 +98556,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -98399,7 +98588,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -98873,7 +99063,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -98905,7 +99095,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -99482,7 +99673,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -99514,7 +99705,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -100053,7 +100245,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -100085,7 +100277,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -403,7 +403,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -435,7 +435,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -708,7 +709,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -740,7 +741,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -1026,7 +1028,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -1058,7 +1060,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -1342,7 +1345,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -1374,7 +1377,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -1644,7 +1648,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -1676,7 +1680,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -1967,7 +1972,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -1999,7 +2004,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -2267,7 +2273,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -2299,7 +2305,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -2571,7 +2578,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -2603,7 +2610,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -2875,7 +2883,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -2907,7 +2915,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -3179,7 +3188,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -3211,7 +3220,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -3476,7 +3486,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -3508,7 +3518,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -3744,7 +3755,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -3776,7 +3787,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -4055,7 +4067,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -4087,7 +4099,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -4366,7 +4379,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -4398,7 +4411,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -4631,7 +4645,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -4663,7 +4677,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -4930,7 +4945,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -4962,7 +4977,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -5194,7 +5210,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -5226,7 +5242,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -5587,7 +5604,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -5619,7 +5636,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -5837,7 +5855,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -6073,7 +6091,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -6145,7 +6164,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -6381,7 +6400,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -6608,7 +6628,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -6844,7 +6864,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -6916,7 +6937,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -7152,7 +7173,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -7389,7 +7411,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -7625,7 +7647,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -7852,7 +7875,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -8088,7 +8111,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -8160,7 +8184,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -8396,7 +8420,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -8623,7 +8648,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -8859,7 +8884,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -8931,7 +8957,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -9167,7 +9193,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -10074,7 +10101,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -10106,7 +10133,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -10366,7 +10394,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -10398,7 +10426,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -12483,7 +12512,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -12515,7 +12544,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -13656,7 +13686,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -13688,7 +13718,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -13910,7 +13941,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -13942,7 +13973,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -15077,7 +15109,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -15109,7 +15141,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -15591,7 +15624,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -15623,7 +15656,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -16762,7 +16796,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -16794,7 +16828,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -17935,7 +17970,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -17967,7 +18002,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -18189,7 +18225,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -18221,7 +18257,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -19356,7 +19393,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -19388,7 +19425,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -19870,7 +19908,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -19902,7 +19940,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -20416,7 +20455,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -20448,7 +20487,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -20814,7 +20854,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -20846,7 +20886,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -21341,7 +21382,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -21373,7 +21414,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -21592,7 +21634,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -21624,7 +21666,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -21892,7 +21935,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -21924,7 +21967,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -22438,7 +22482,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -22470,7 +22514,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -22836,7 +22881,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -22868,7 +22913,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -23363,7 +23409,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -23395,7 +23441,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -23614,7 +23661,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -23646,7 +23693,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -23914,7 +23962,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -23946,7 +23994,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -24475,7 +24524,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -24507,7 +24556,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -25002,7 +25052,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -25034,7 +25084,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -25249,7 +25300,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -25281,7 +25332,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -25810,7 +25862,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -25842,7 +25894,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -26140,7 +26193,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -26172,7 +26225,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -26666,7 +26720,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -26698,7 +26752,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -26913,7 +26968,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -26945,7 +27000,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -27474,7 +27530,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -27506,7 +27562,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -28001,7 +28058,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -28033,7 +28090,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -28248,7 +28306,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -28280,7 +28338,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -28809,7 +28868,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -28841,7 +28900,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -29139,7 +29199,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -29171,7 +29231,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -29665,7 +29726,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -29697,7 +29758,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -29912,7 +29974,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -29944,7 +30006,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -30833,7 +30896,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -30865,7 +30928,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -31320,7 +31384,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -31352,7 +31416,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -31690,7 +31755,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -31722,7 +31787,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -32324,7 +32390,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -32356,7 +32422,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -32715,7 +32782,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -32747,7 +32814,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -33037,7 +33105,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -33069,7 +33137,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -33958,7 +34027,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -33990,7 +34059,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -34445,7 +34515,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -34477,7 +34547,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -34815,7 +34886,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -34847,7 +34918,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -35449,7 +35521,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -35481,7 +35553,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -35840,7 +35913,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -35872,7 +35945,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -36162,7 +36236,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -36194,7 +36268,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -37251,7 +37326,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -37283,7 +37358,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -38108,7 +38184,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -38140,7 +38216,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -38597,7 +38674,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -38629,7 +38706,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -39085,7 +39163,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -39117,7 +39195,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -39573,7 +39652,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -39605,7 +39684,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -40061,7 +40141,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -40093,7 +40173,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -40549,7 +40630,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -40581,7 +40662,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -41037,7 +41119,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -41069,7 +41151,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -45500,7 +45583,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -45532,7 +45615,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -45828,7 +45912,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -45860,7 +45944,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -46594,7 +46679,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -46626,7 +46711,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -46710,7 +46796,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -47029,7 +47115,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -48842,7 +48929,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -48874,7 +48961,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -49220,7 +49308,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -49252,7 +49340,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -49801,7 +49890,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -49833,7 +49922,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -50215,7 +50305,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -50247,7 +50337,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -50986,7 +51077,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -51018,7 +51109,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -51320,7 +51412,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -51352,7 +51444,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -51789,7 +51882,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -51821,7 +51914,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -52360,7 +52454,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -52392,7 +52486,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -52824,7 +52919,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -52856,7 +52951,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -53382,7 +53478,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -53414,7 +53510,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -54148,7 +54245,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -54180,7 +54277,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -54482,7 +54580,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -54514,7 +54612,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -54813,7 +54912,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -54845,7 +54944,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -55366,7 +55466,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -55398,7 +55498,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -55707,7 +55808,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -55739,7 +55840,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -56052,7 +56154,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -56084,7 +56186,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -56331,7 +56434,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -56363,7 +56466,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -56667,7 +56771,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -56699,7 +56803,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -57370,7 +57475,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -57402,7 +57507,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -57951,7 +58057,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -57983,7 +58089,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -58365,7 +58472,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -58397,7 +58504,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -59136,7 +59244,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -59168,7 +59276,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -59470,7 +59579,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -59502,7 +59611,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -59939,7 +60049,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -59971,7 +60081,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -60510,7 +60621,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -60542,7 +60653,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -60974,7 +61086,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -61006,7 +61118,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -61532,7 +61645,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -61564,7 +61677,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -62298,7 +62412,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -62330,7 +62444,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -62632,7 +62747,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -62664,7 +62779,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -62963,7 +63079,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -62995,7 +63111,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -63516,7 +63633,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -63548,7 +63665,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -63857,7 +63975,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -63889,7 +64007,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -64202,7 +64321,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -64234,7 +64353,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -64481,7 +64601,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -64513,7 +64633,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -64817,7 +64938,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -64849,7 +64970,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -65520,7 +65642,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -65552,7 +65674,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -66156,7 +66279,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -66188,7 +66311,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -66504,7 +66628,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -66536,7 +66660,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -67069,7 +67194,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -67101,7 +67226,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -67402,7 +67528,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -67434,7 +67560,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -67757,7 +67884,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -67789,7 +67916,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -68342,7 +68470,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -68374,7 +68502,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -69806,7 +69935,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -70052,7 +70181,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -70745,7 +70875,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -70777,7 +70907,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -71366,7 +71497,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -71398,7 +71529,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -71750,7 +71882,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -71782,7 +71914,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -72002,7 +72135,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -72034,7 +72167,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -72520,7 +72654,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -72552,7 +72686,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -72772,7 +72907,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -72804,7 +72939,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -73094,7 +73230,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -73126,7 +73262,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -73722,7 +73859,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -73754,7 +73891,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -74119,7 +74257,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -74151,7 +74289,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -74375,7 +74514,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -74407,7 +74546,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -74648,7 +74788,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -74680,7 +74820,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -75545,7 +75686,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -75577,7 +75718,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -75865,7 +76007,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -75897,7 +76039,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -76702,7 +76845,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -76734,7 +76877,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -77061,7 +77205,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -77093,7 +77237,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -77654,7 +77799,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -77686,7 +77831,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -78525,7 +78671,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -78557,7 +78703,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -79165,7 +79312,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -79197,7 +79344,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -79513,7 +79661,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -79545,7 +79693,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -79931,7 +80080,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -79963,7 +80112,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -80247,7 +80397,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -80279,7 +80429,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -80764,7 +80915,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -80796,7 +80947,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -81307,7 +81459,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -81339,7 +81491,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -81738,7 +81891,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -81770,7 +81923,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -82082,7 +82236,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -82114,7 +82268,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -82410,7 +82565,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -82442,7 +82597,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -82808,7 +82964,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -82840,7 +82996,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -83143,7 +83300,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -83175,7 +83332,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -83480,7 +83638,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -83512,7 +83670,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -83832,7 +83991,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -83864,7 +84023,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -84349,7 +84509,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -84381,7 +84541,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -84892,7 +85053,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -84924,7 +85085,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -85323,7 +85485,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -85355,7 +85517,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -85667,7 +85830,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -85699,7 +85862,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -85995,7 +86159,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -86027,7 +86191,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -86393,7 +86558,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -86425,7 +86590,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -86728,7 +86894,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -86760,7 +86926,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -87065,7 +87232,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -87097,7 +87264,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -87417,7 +87585,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -87449,7 +87617,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -88343,7 +88512,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -88375,7 +88544,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -88832,7 +89002,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -88864,7 +89034,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -89280,7 +89451,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -89312,7 +89483,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -90388,7 +90560,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -90420,7 +90592,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -90716,7 +90889,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -90748,7 +90921,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -91266,7 +91440,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -91298,7 +91472,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -91577,7 +91752,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -91609,7 +91784,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -91824,7 +92000,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -91856,7 +92032,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -92504,7 +92681,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -92536,7 +92713,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -92771,7 +92949,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -92803,7 +92981,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -93108,7 +93287,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -93140,7 +93319,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -93806,7 +93986,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -93838,7 +94018,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -94115,7 +94296,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -94147,7 +94328,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -94506,7 +94688,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -94538,7 +94720,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -95065,7 +95248,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -95097,7 +95280,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -95871,7 +96055,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -95903,7 +96087,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -96407,7 +96592,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -96439,7 +96624,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -96724,7 +96910,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -96756,7 +96942,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -97225,7 +97412,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -97257,7 +97444,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -97736,7 +97924,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -97768,7 +97956,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -98367,7 +98556,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -98399,7 +98588,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -98873,7 +99063,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -98905,7 +99095,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -99482,7 +99673,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -99514,7 +99705,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",
@@ -100053,7 +100245,7 @@
             "name": "X-Steward-Signing-Key-Id",
             "in": "header",
             "required": false,
-            "description": "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+            "description": "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
             "schema": {
               "type": "string"
             }
@@ -100085,7 +100277,8 @@
               "v1=hmac-sha256",
               "p256=ecdsa-secp256r1"
             ],
-            "optionalSigningKeyHeader": "X-Steward-Signing-Key-Id"
+            "managedTenantKeyHeader": "X-Steward-Signing-Key-Id",
+            "requiredForManagedTenantKey": true
           },
           "idempotency": {
             "header": "Idempotency-Key",

--- a/packages/api/src/__tests__/authorization-signature-tenant-keys.test.ts
+++ b/packages/api/src/__tests__/authorization-signature-tenant-keys.test.ts
@@ -1,12 +1,8 @@
-import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
 import { closeDb, getDb, tenantRequestSigningKeys, tenants } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { KeyStore } from "@stwd/vault";
 import { Hono } from "hono";
-import {
-  authorizationSignature,
-  createAuthorizationSignature,
-} from "../middleware/authorization-signature";
 import type { AppVariables } from "../services/context";
 
 // SEC-010 re-audit regression: the authorization-signature middleware is mounted
@@ -23,6 +19,10 @@ const STATIC_SECRET = "request-signing-secret-with-enough-entropy";
 const PATH = "/vault/agent-1/sign";
 const BODY = JSON.stringify({ value: "1000" });
 const FRESH_TS = () => String(Math.floor(Date.now() / 1000));
+let tenantKeyKdfCount = 0;
+let authorizationSignature: typeof import("../middleware/authorization-signature")["authorizationSignature"];
+let createAuthorizationSignature: typeof import("../middleware/authorization-signature")["createAuthorizationSignature"];
+let __setTenantKeyKdfObserverForTests: typeof import("../middleware/authorization-signature")["__setTenantKeyKdfObserverForTests"];
 
 function makeApp() {
   const app = new Hono<{ Variables: AppVariables }>();
@@ -63,6 +63,8 @@ beforeAll(async () => {
   setPGLiteOverride(db, async () => {
     await client.close();
   });
+  ({ authorizationSignature, createAuthorizationSignature, __setTenantKeyKdfObserverForTests } =
+    await import("../middleware/authorization-signature"));
 
   await getDb()
     .insert(tenants)
@@ -94,6 +96,17 @@ afterAll(async () => {
   await closeDb();
 });
 
+beforeEach(() => {
+  tenantKeyKdfCount = 0;
+  __setTenantKeyKdfObserverForTests(() => {
+    tenantKeyKdfCount += 1;
+  });
+});
+
+afterEach(() => {
+  __setTenantKeyKdfObserverForTests(null);
+});
+
 describe("authorizationSignature tenant signing keys", () => {
   it("verifies a request signed with a named tenant signing key", async () => {
     const app = makeApp();
@@ -106,6 +119,7 @@ describe("authorizationSignature tenant signing keys", () => {
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true, verified: true });
+    expect(tenantKeyKdfCount).toBe(1);
   });
 
   it("rejects an unknown (well-formed) signing key id without decrypt work", async () => {
@@ -121,6 +135,7 @@ describe("authorizationSignature tenant signing keys", () => {
 
     expect(res.status).toBe(401);
     expect(await res.json()).toEqual({ ok: false, error: "Invalid signing key id" });
+    expect(tenantKeyKdfCount).toBe(0);
   });
 
   it("rejects a malformed signing key id cheaply (no uuid DB error)", async () => {
@@ -136,6 +151,7 @@ describe("authorizationSignature tenant signing keys", () => {
 
     expect(res.status).toBe(401);
     expect(await res.json()).toEqual({ ok: false, error: "Invalid signing key id" });
+    expect(tenantKeyKdfCount).toBe(0);
   });
 
   it("does not use tenant signing keys when no key id is named", async () => {
@@ -152,6 +168,7 @@ describe("authorizationSignature tenant signing keys", () => {
 
     expect(res.status).toBe(401);
     expect(await res.json()).toEqual({ ok: false, error: "Invalid request signature" });
+    expect(tenantKeyKdfCount).toBe(0);
   });
 
   it("still verifies key-id-less requests signed with a configured static secret", async () => {
@@ -165,5 +182,6 @@ describe("authorizationSignature tenant signing keys", () => {
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true, verified: true });
+    expect(tenantKeyKdfCount).toBe(0);
   });
 });

--- a/packages/api/src/__tests__/authorization-signature-tenant-keys.test.ts
+++ b/packages/api/src/__tests__/authorization-signature-tenant-keys.test.ts
@@ -1,0 +1,168 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { closeDb, getDb, tenantRequestSigningKeys, tenants } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { KeyStore } from "@stwd/vault";
+import { Hono } from "hono";
+import {
+  authorizationSignature,
+  createAuthorizationSignature,
+} from "../middleware/authorization-signature";
+import type { AppVariables } from "../services/context";
+
+// SEC-010 re-audit regression: the authorization-signature middleware is mounted
+// globally and runs BEFORE route auth. Tenant-key decryption costs a scrypt KDF
+// per candidate, so an unauthenticated request bearing signature headers could
+// previously force 1+N scrypt evaluations per request (CPU-amplification DoS).
+// The middleware must only pay that cost when the request names a specific,
+// well-formed, EXISTING X-Steward-Signing-Key-Id.
+
+const TENANT_ID = `sig-keys-tenant-${Date.now()}`;
+const KEY_ID = crypto.randomUUID();
+const TENANT_KEY_SECRET = "stw_sig_testtenantkeysecret";
+const STATIC_SECRET = "request-signing-secret-with-enough-entropy";
+const PATH = "/vault/agent-1/sign";
+const BODY = JSON.stringify({ value: "1000" });
+const FRESH_TS = () => String(Math.floor(Date.now() / 1000));
+
+function makeApp() {
+  const app = new Hono<{ Variables: AppVariables }>();
+  app.use("*", authorizationSignature({ required: true, secrets: [STATIC_SECRET] }));
+  app.post("/vault/:agentId/sign", (c) =>
+    c.json({ ok: true, verified: Boolean(c.get("requestSignatureVerified")) }),
+  );
+  return app;
+}
+
+async function signedWith(secret: string, extraHeaders: Record<string, string> = {}) {
+  const timestamp = FRESH_TS();
+  const signature = await createAuthorizationSignature(
+    {
+      method: "POST",
+      url: `https://api.test${PATH}`,
+      tenantId: TENANT_ID,
+      timestamp,
+      idempotencyKey: "idem-key-123",
+      body: BODY,
+    },
+    secret,
+  );
+  return {
+    "content-type": "application/json",
+    "x-steward-tenant": TENANT_ID,
+    "x-steward-request-timestamp": timestamp,
+    "idempotency-key": "idem-key-123",
+    "x-steward-signature": signature,
+    ...extraHeaders,
+  };
+}
+
+beforeAll(async () => {
+  process.env.STEWARD_PGLITE_MEMORY = "true";
+  process.env.STEWARD_MASTER_PASSWORD = "sig-keys-master-password";
+  const { db, client } = await createPGLiteDb("memory://");
+  setPGLiteOverride(db, async () => {
+    await client.close();
+  });
+
+  await getDb()
+    .insert(tenants)
+    .values({ id: TENANT_ID, name: "Signature Keys Tenant", apiKeyHash: "h" });
+
+  const encrypted = new KeyStore(process.env.STEWARD_MASTER_PASSWORD, undefined, "secret-vault")
+    .encrypt(TENANT_KEY_SECRET, {
+      tenantId: TENANT_ID,
+      name: `request-signing-key:${KEY_ID}`,
+      version: 1,
+    });
+  await getDb()
+    .insert(tenantRequestSigningKeys)
+    .values({
+      id: KEY_ID,
+      tenantId: TENANT_ID,
+      name: "primary",
+      secretCiphertext: encrypted.ciphertext,
+      secretIv: encrypted.iv,
+      secretAuthTag: encrypted.tag,
+      secretSalt: encrypted.salt,
+      secretPrefix: "stw_sig_test...cret",
+      status: "active",
+    });
+});
+
+afterAll(async () => {
+  await closeDb();
+});
+
+describe("authorizationSignature tenant signing keys", () => {
+  it("verifies a request signed with a named tenant signing key", async () => {
+    const app = makeApp();
+
+    const res = await app.request(PATH, {
+      method: "POST",
+      headers: await signedWith(TENANT_KEY_SECRET, { "x-steward-signing-key-id": KEY_ID }),
+      body: BODY,
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, verified: true });
+  });
+
+  it("rejects an unknown (well-formed) signing key id without decrypt work", async () => {
+    const app = makeApp();
+
+    const res = await app.request(PATH, {
+      method: "POST",
+      headers: await signedWith(TENANT_KEY_SECRET, {
+        "x-steward-signing-key-id": crypto.randomUUID(),
+      }),
+      body: BODY,
+    });
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ ok: false, error: "Invalid signing key id" });
+  });
+
+  it("rejects a malformed signing key id cheaply (no uuid DB error)", async () => {
+    const app = makeApp();
+
+    const res = await app.request(PATH, {
+      method: "POST",
+      headers: await signedWith(TENANT_KEY_SECRET, {
+        "x-steward-signing-key-id": "not-a-uuid",
+      }),
+      body: BODY,
+    });
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ ok: false, error: "Invalid signing key id" });
+  });
+
+  it("does not use tenant signing keys when no key id is named", async () => {
+    const app = makeApp();
+
+    // Signed with the tenant key but no X-Steward-Signing-Key-Id: the static
+    // secret does not match, and the tenant key must NOT be tried (fail closed
+    // as "Invalid request signature", not silently verified).
+    const res = await app.request(PATH, {
+      method: "POST",
+      headers: await signedWith(TENANT_KEY_SECRET),
+      body: BODY,
+    });
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ ok: false, error: "Invalid request signature" });
+  });
+
+  it("still verifies key-id-less requests signed with a configured static secret", async () => {
+    const app = makeApp();
+
+    const res = await app.request(PATH, {
+      method: "POST",
+      headers: await signedWith(STATIC_SECRET),
+      body: BODY,
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, verified: true });
+  });
+});

--- a/packages/api/src/__tests__/authorization-signature-tenant-keys.test.ts
+++ b/packages/api/src/__tests__/authorization-signature-tenant-keys.test.ts
@@ -68,25 +68,26 @@ beforeAll(async () => {
     .insert(tenants)
     .values({ id: TENANT_ID, name: "Signature Keys Tenant", apiKeyHash: "h" });
 
-  const encrypted = new KeyStore(process.env.STEWARD_MASTER_PASSWORD, undefined, "secret-vault")
-    .encrypt(TENANT_KEY_SECRET, {
-      tenantId: TENANT_ID,
-      name: `request-signing-key:${KEY_ID}`,
-      version: 1,
-    });
-  await getDb()
-    .insert(tenantRequestSigningKeys)
-    .values({
-      id: KEY_ID,
-      tenantId: TENANT_ID,
-      name: "primary",
-      secretCiphertext: encrypted.ciphertext,
-      secretIv: encrypted.iv,
-      secretAuthTag: encrypted.tag,
-      secretSalt: encrypted.salt,
-      secretPrefix: "stw_sig_test...cret",
-      status: "active",
-    });
+  const encrypted = new KeyStore(
+    process.env.STEWARD_MASTER_PASSWORD,
+    undefined,
+    "secret-vault",
+  ).encrypt(TENANT_KEY_SECRET, {
+    tenantId: TENANT_ID,
+    name: `request-signing-key:${KEY_ID}`,
+    version: 1,
+  });
+  await getDb().insert(tenantRequestSigningKeys).values({
+    id: KEY_ID,
+    tenantId: TENANT_ID,
+    name: "primary",
+    secretCiphertext: encrypted.ciphertext,
+    secretIv: encrypted.iv,
+    secretAuthTag: encrypted.tag,
+    secretSalt: encrypted.salt,
+    secretPrefix: "stw_sig_test...cret",
+    status: "active",
+  });
 });
 
 afterAll(async () => {

--- a/packages/api/src/__tests__/oidc-provider-config.test.ts
+++ b/packages/api/src/__tests__/oidc-provider-config.test.ts
@@ -71,4 +71,20 @@ describe("OIDC provider public destination validation", () => {
       expect(result).toBe("allowedAlgs for provider enterprise may only include RS256 or ES256");
     }
   });
+
+  it("defaults allowJitProvisioning to OFF when the field is omitted (SEC-151)", () => {
+    const result = normalizeOidcProviders([validProvider]);
+    expect(Array.isArray(result)).toBe(true);
+    if (!Array.isArray(result)) return;
+    // Auto-creating user accounts for any holder of a valid IdP token must be
+    // an explicit tenant opt-in — an omitted field must never normalize to on.
+    expect(result[0]?.allowJitProvisioning).toBe(false);
+  });
+
+  it("honors an explicit allowJitProvisioning opt-in", () => {
+    const result = normalizeOidcProviders([{ ...validProvider, allowJitProvisioning: true }]);
+    expect(Array.isArray(result)).toBe(true);
+    if (!Array.isArray(result)) return;
+    expect(result[0]?.allowJitProvisioning).toBe(true);
+  });
 });

--- a/packages/api/src/__tests__/runtime-gate.test.ts
+++ b/packages/api/src/__tests__/runtime-gate.test.ts
@@ -37,9 +37,10 @@ describe("resolveClientIp (SEC-014)", () => {
     expect(resolveClientIp(spoofed, "3.3.3.3", 1)).toBe("2.2.2.2");
   });
 
-  it("uses the leftmost entry when the chain is shorter than the configured trust", () => {
+  it("rejects a short forwarded chain instead of trusting its spoofable leftmost entry", () => {
     const h = headers({ "x-forwarded-for": "1.1.1.1" });
-    expect(resolveClientIp(h, "2.2.2.2", 3)).toBe("1.1.1.1");
+    expect(resolveClientIp(h, "2.2.2.2", 3)).toBe("2.2.2.2");
+    expect(resolveClientIp(h, null, 3)).toBe("unknown");
   });
 
   it("never consults X-Real-IP, even with trusted proxy hops configured", () => {

--- a/packages/api/src/__tests__/runtime-gate.test.ts
+++ b/packages/api/src/__tests__/runtime-gate.test.ts
@@ -42,8 +42,18 @@ describe("resolveClientIp (SEC-014)", () => {
     expect(resolveClientIp(h, "2.2.2.2", 3)).toBe("1.1.1.1");
   });
 
-  it("honors X-Real-IP only through trusted proxies", () => {
-    expect(resolveClientIp(headers({ "x-real-ip": "1.2.3.4" }), "10.0.0.9", 1)).toBe("1.2.3.4");
+  it("never consults X-Real-IP, even with trusted proxy hops configured", () => {
+    // X-Real-IP has no chain semantics, so a hop count cannot be applied; when
+    // XFF is absent/short a direct client could spoof it to rotate identities.
+    expect(resolveClientIp(headers({ "x-real-ip": "1.2.3.4" }), "10.0.0.9", 1)).toBe("10.0.0.9");
+    // ...but a spoofed X-Real-IP must not shadow a usable XFF chain either:
+    expect(
+      resolveClientIp(
+        headers({ "x-forwarded-for": "1.1.1.1, 2.2.2.2", "x-real-ip": "9.9.9.9" }),
+        "10.0.0.9",
+        1,
+      ),
+    ).toBe("2.2.2.2");
   });
 });
 

--- a/packages/api/src/__tests__/webhook-url-validation.test.ts
+++ b/packages/api/src/__tests__/webhook-url-validation.test.ts
@@ -25,6 +25,26 @@ describe("webhook URL validation", () => {
     }
   });
 
+  it("rejects the entire NAT64 local-use range 64:ff9b:1::/48 (RFC 8215)", () => {
+    // No assumption can be made about an embedded IPv4 address or its location
+    // in the local-use range, so the whole /48 is non-public — including
+    // variants whose fourth word is non-zero (the old /96-suffix extraction
+    // both misread the suffix placement and let these through entirely).
+    for (const url of [
+      "https://[64:ff9b:1::a9fe:a9fe]/hook",
+      "https://[64:ff9b:1:1::a9fe:a9fe]/hook",
+      "https://[64:ff9b:1:ffff::]/hook",
+      "https://[64:ff9b:1::808:808]/hook",
+    ]) {
+      expect(validateWebhookUrl(url)).toBe("url host must be public");
+    }
+  });
+
+  it("still allows public IPv6 and well-known NAT64 embeddings of public IPv4", () => {
+    expect(validateWebhookUrl("https://[2001:4860:4860::8888]/hook")).toBeNull();
+    expect(validateWebhookUrl("https://[64:ff9b::808:808]/hook")).toBeNull();
+  });
+
   it("rejects Teredo and documentation IPv6 addresses", () => {
     for (const url of ["https://[2001::]/hook", "https://[2001:db8::1]/hook"]) {
       expect(validateWebhookUrl(url)).toBe("url host must be public");

--- a/packages/api/src/middleware/authorization-signature.ts
+++ b/packages/api/src/middleware/authorization-signature.ts
@@ -149,6 +149,12 @@ async function appClientSecretSigningCandidates(request: Request): Promise<strin
 // Tenant signing-key ids are server-generated UUIDs (tenant-config.ts uses
 // `randomUUID()`), so a non-UUID header value can be rejected without a query.
 const SIGNING_KEY_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+let tenantKeyKdfObserverForTests: (() => void) | null = null;
+
+/** Test-only proof point immediately before tenant-key KDF/decrypt work begins. */
+export function __setTenantKeyKdfObserverForTests(observer: (() => void) | null): void {
+  tenantKeyKdfObserverForTests = observer;
+}
 
 async function tenantRequestSigningKeyCandidates(request: Request): Promise<string[]> {
   const tenantId = request.headers.get("X-Steward-Tenant");
@@ -179,6 +185,7 @@ async function tenantRequestSigningKeyCandidates(request: Request): Promise<stri
   // Defer KeyStore construction (itself a scrypt KDF) until a row exists, so
   // an unknown key id costs only the cheap lookup above.
   if (rows.length === 0) return [];
+  tenantKeyKdfObserverForTests?.();
   const keyStore = new KeyStore(masterPassword, undefined, "secret-vault");
   return rows.flatMap((row) => {
     if (row.revokedAt) return [];

--- a/packages/api/src/middleware/authorization-signature.ts
+++ b/packages/api/src/middleware/authorization-signature.ts
@@ -146,25 +146,39 @@ async function appClientSecretSigningCandidates(request: Request): Promise<strin
   return valid ? [basic.password] : [];
 }
 
+// Tenant signing-key ids are server-generated UUIDs (tenant-config.ts uses
+// `randomUUID()`), so a non-UUID header value can be rejected without a query.
+const SIGNING_KEY_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 async function tenantRequestSigningKeyCandidates(request: Request): Promise<string[]> {
   const tenantId = request.headers.get("X-Steward-Tenant");
   if (!isValidTenantId(tenantId)) return [];
 
+  // SEC-010 follow-up (re-audit): this middleware is mounted globally and runs
+  // BEFORE route auth, so every step an unauthenticated request can trigger
+  // must be cheap. Tenant-key decryption costs a scrypt KDF per candidate —
+  // only pay it when the request NAMES a specific, well-formed signing-key id
+  // and let the (indexed) id lookup decide existence first. Requests without
+  // `X-Steward-Signing-Key-Id` never reach for tenant keys at all.
   const keyId = request.headers.get("X-Steward-Signing-Key-Id");
+  if (!keyId || !SIGNING_KEY_ID_PATTERN.test(keyId)) return [];
   const masterPassword = process.env.STEWARD_MASTER_PASSWORD;
   if (!masterPassword) return [];
 
   const now = new Date();
-  const filters = [
-    eq(tenantRequestSigningKeys.tenantId, tenantId),
-    inArray(tenantRequestSigningKeys.status, ["active", "retiring"]),
-  ];
-  if (keyId) filters.push(eq(tenantRequestSigningKeys.id, keyId));
-
   const rows = await getDb()
     .select()
     .from(tenantRequestSigningKeys)
-    .where(and(...filters));
+    .where(
+      and(
+        eq(tenantRequestSigningKeys.tenantId, tenantId),
+        eq(tenantRequestSigningKeys.id, keyId),
+        inArray(tenantRequestSigningKeys.status, ["active", "retiring"]),
+      ),
+    );
+  // Defer KeyStore construction (itself a scrypt KDF) until a row exists, so
+  // an unknown key id costs only the cheap lookup above.
+  if (rows.length === 0) return [];
   const keyStore = new KeyStore(masterPassword, undefined, "secret-vault");
   return rows.flatMap((row) => {
     if (row.revokedAt) return [];
@@ -886,13 +900,20 @@ export function authorizationSignature(options?: AuthorizationSignatureOptions) 
     }
 
     const signingKeyId = c.req.header("X-Steward-Signing-Key-Id");
-    const tenantKeySecrets = await tenantRequestSigningKeyCandidates(c.req.raw);
+    // Only a request that NAMES a tenant signing key id pays for the tenant-key
+    // lookup (and, for a known id, the scrypt KDF + decrypt). Key-id-less
+    // requests fall through to the static/app-secret candidates and never
+    // trigger tenant-key work — closing the unauthenticated CPU-amplification
+    // DoS the global SEC-010 mount exposed.
+    const tenantKeySecrets = signingKeyId
+      ? await tenantRequestSigningKeyCandidates(c.req.raw)
+      : [];
     if (signingKeyId && tenantKeySecrets.length === 0) {
       return c.json<ApiResponse>({ ok: false, error: "Invalid signing key id" }, 401);
     }
     const candidateSecrets = signingKeyId
       ? tenantKeySecrets
-      : [...secrets, ...tenantKeySecrets, ...(await appSecretResolver(c.req.raw))];
+      : [...secrets, ...(await appSecretResolver(c.req.raw))];
     if (candidateSecrets.length === 0) {
       return c.json<ApiResponse>({ ok: false, error: "Request signing is not configured" }, 500);
     }

--- a/packages/api/src/middleware/authorization-signature.ts
+++ b/packages/api/src/middleware/authorization-signature.ts
@@ -905,9 +905,7 @@ export function authorizationSignature(options?: AuthorizationSignatureOptions) 
     // requests fall through to the static/app-secret candidates and never
     // trigger tenant-key work — closing the unauthenticated CPU-amplification
     // DoS the global SEC-010 mount exposed.
-    const tenantKeySecrets = signingKeyId
-      ? await tenantRequestSigningKeyCandidates(c.req.raw)
-      : [];
+    const tenantKeySecrets = signingKeyId ? await tenantRequestSigningKeyCandidates(c.req.raw) : [];
     if (signingKeyId && tenantKeySecrets.length === 0) {
       return c.json<ApiResponse>({ ok: false, error: "Invalid signing key id" }, 401);
     }

--- a/packages/api/src/openapi.ts
+++ b/packages/api/src/openapi.ts
@@ -436,7 +436,7 @@ const stewardSignatureHeader = headerParameter(
 );
 const signingKeyIdHeader = headerParameter(
   "X-Steward-Signing-Key-Id",
-  "Optional tenant request-signing key id used to select a managed HMAC signing key.",
+  "Tenant request-signing key id used to select a managed HMAC signing key. Required when signing with a managed tenant key; omit only for static or app-client signing secrets.",
 );
 const idempotencyKeyHeader = headerParameter(
   "Idempotency-Key",
@@ -6352,7 +6352,8 @@ function addHardeningInventory(spec: OpenApiSpec): OpenApiSpec {
           requiredWhen: "STEWARD_REQUIRE_AUTH_SIGNATURE=true",
           header: "X-Steward-Signature",
           schemes: ["v1=hmac-sha256", "p256=ecdsa-secp256r1"],
-          optionalSigningKeyHeader: "X-Steward-Signing-Key-Id",
+          managedTenantKeyHeader: "X-Steward-Signing-Key-Id",
+          requiredForManagedTenantKey: true,
         },
         idempotency: {
           header: "Idempotency-Key",

--- a/packages/api/src/services/runtime-gate.ts
+++ b/packages/api/src/services/runtime-gate.ts
@@ -19,6 +19,11 @@
  *   - when the chain is shorter than the configured trust, the leftmost
  *     (earliest trusted) entry is the best available signal.
  *
+ * `X-Real-IP` is never consulted: it carries no chain semantics, so the hop
+ * count cannot be applied to it, and whenever XFF is absent/short a direct
+ * client can simply spoof it to rotate rate-limit identities. This matches the
+ * auth-route resolver (routes/auth.ts), which deliberately ignores it too.
+ *
  * The log is also capped (`STEWARD_RATE_LIMIT_MAX_KEYS`): when full it sweeps
  * expired entries inline and then fails CLOSED (429) rather than letting the
  * map grow without bound.
@@ -58,8 +63,6 @@ export function resolveClientIp(
         if (derived) return derived;
       }
     }
-    const realIp = headers.get("x-real-ip")?.trim();
-    if (realIp) return realIp;
   }
   return peerAddress ?? "unknown";
 }

--- a/packages/api/src/services/runtime-gate.ts
+++ b/packages/api/src/services/runtime-gate.ts
@@ -16,8 +16,9 @@
  *     entry to its left is attacker-controlled prefix and ignored;
  *   - with zero trusted hops (default) both forwarding headers are ignored and
  *     the socket peer is used;
- *   - when the chain is shorter than the configured trust, the leftmost
- *     (earliest trusted) entry is the best available signal.
+ *   - when the chain is shorter than the configured trust, no forwarded entry
+ *     is trustworthy; fall back to the socket peer instead of accepting a
+ *     client-supplied leftmost value.
  *
  * `X-Real-IP` is never consulted: it carries no chain semantics, so the hop
  * count cannot be applied to it, and whenever XFF is absent/short a direct
@@ -57,8 +58,8 @@ export function resolveClientIp(
         .split(",")
         .map((part) => part.trim())
         .filter(Boolean);
-      if (hops.length > 0) {
-        const clientIndex = Math.max(hops.length - trustedProxyHops, 0);
+      if (hops.length >= trustedProxyHops) {
+        const clientIndex = hops.length - trustedProxyHops;
         const derived = hops[clientIndex];
         if (derived) return derived;
       }

--- a/packages/api/src/services/webhook-url.ts
+++ b/packages/api/src/services/webhook-url.ts
@@ -85,10 +85,6 @@ function embeddedIpv4FromIpv6(hostname: string): string | null {
     words[5] === 0;
   if (isNat64WellKnown) return fromWords(words[6], words[7]);
 
-  const isNat64LocalUse =
-    words[0] === 0x64 && words[1] === 0xff9b && words[2] === 1 && words[3] === 0;
-  if (isNat64LocalUse) return fromWords(words[6], words[7]);
-
   if (words[0] === 0x2002) return fromWords(words[1], words[2]);
 
   return null;
@@ -101,6 +97,11 @@ function isNonPublicIpv6(hostname: string): boolean {
   const ipv4Embedded = embeddedIpv4FromIpv6(normalized);
   if (ipv4Embedded) return isNonPublicIpv4(ipv4Embedded);
   const words = expandIpv6Words(normalized);
+  // RFC 8215 reserves 64:ff9b:1::/48 for local use and explicitly says no
+  // assumption can be made about an embedded IPv4 address or its location.
+  // Treat the entire non-globally-reachable prefix as non-public (matching the
+  // OIDC screeners) instead of extracting a would-be /96 suffix.
+  if (words?.[0] === 0x64 && words[1] === 0xff9b && words[2] === 1) return true;
   if (words?.[0] === 0x2001 && (words[1] === 0 || words[1] === 0xdb8)) return true;
   if (words?.[0] !== undefined && (words[0] & 0xffc0) === 0xfe80) return true;
   if (words?.[0] !== undefined && (words[0] & 0xffc0) === 0xfec0) return true;


### PR DESCRIPTION
## Summary

Current-base W3-A2 API middleware hardening:

- require a well-formed named tenant signing-key id before indexed lookup/KDF/decrypt; key-id-less requests use only static/app secrets
- remove spoofable `X-Real-IP` fallback and reject too-short X-Forwarded-For chains instead of trusting their client-controlled leftmost entry
- block the entire RFC 8215 local-use NAT64 `64:ff9b:1::/48` in the API webhook URL classifier
- pin omitted OIDC `allowJitProvisioning` to false while preserving explicit opt-in
- document that managed tenant signing keys require `X-Steward-Signing-Key-Id`

The original legacy tenant-config webhook DNS item became superseded during rebase: current develop retired that unverifiable duplicate fan-out entirely under SEC-101, so its stale commit/test were intentionally dropped. Configured webhooks retain delivery-time validation plus dispatcher-level pinned public DNS lookup.

## Audit repair

The original IP change removed X-Real-IP but still accepted the leftmost XFF value when the chain was shorter than `STEWARD_TRUSTED_PROXY_HOPS`; that value can be client supplied. The repaired code falls back to socket peer/unknown unless the positional chain is long enough.

## Validation

- runtime-gate: 7 pass, 22 assertions
- webhook URL validation: 15 pass, 44 assertions
- Biome on all changed files: clean
- `git diff --check`: clean
- OIDC and signing-key focused suites are queued in clean CI; the local shared checkout currently resolves unrelated concurrently-mutated auth/vault workspace exports and could not run those two suites reliably.

No issue is auto-closed by this batch; SEC-151 receives regression coverage only.