### PR TITLE
fix(proxy): allow actions without summon provenance

### DIFF
--- a/packages/proxy/src/__tests__/x-summon-provenance.test.ts
+++ b/packages/proxy/src/__tests__/x-summon-provenance.test.ts
@@ -115,10 +115,10 @@ describe("dispatch X summon provenance boundary", () => {
   test("allows truly absent provenance for non-summon-governed actions", () => {
     const absent = fixture();
     delete absent.requestEnvelope.xSummonAttestationDigest;
-    absent.requestHash = `sha256:${createHash("sha256")
-      .update(jcsStringify(absent.requestEnvelope))
-      .digest("hex")}`;
     absent.safeSummary = {};
+    // Summon validation is not the request-commitment verifier. An unrelated
+    // action with no summon evidence must proceed to the existing commitment
+    // checks, even when this fixture's request hash is intentionally stale.
     expect(verifyDispatchXSummonProvenance(absent)).toBe("absent");
   });
 });

--- a/packages/proxy/src/handlers/governed-execution.ts
+++ b/packages/proxy/src/handlers/governed-execution.ts
@@ -184,10 +184,10 @@ export function verifyDispatchXSummonProvenance(input: {
   keysJson: string | undefined;
   now?: Date;
 }): "absent" | "valid" | "invalid" {
-  if (sha256Hex(jcsStringify(input.requestEnvelope)) !== input.requestHash) return "invalid";
   const summonDigest = input.requestEnvelope.xSummonAttestationDigest;
   const persistedAttestation = input.safeSummary.xSummonAttestation;
   if (summonDigest === undefined && persistedAttestation === undefined) return "absent";
+  if (sha256Hex(jcsStringify(input.requestEnvelope)) !== input.requestHash) return "invalid";
   const body = input.canonicalAction.canonicalBody;
   const reply =
     body && typeof body === "object" && !Array.isArray(body)


### PR DESCRIPTION
## Summary
- classify truly absent X summon provenance before summon-specific request-hash validation
- preserve fail-closed hash/signature validation whenever either summon artifact is present
- add a regression proving unrelated governed actions continue to the existing commitment checks

## Failure fixed
- develop CI run 32095148347, `Unit Tests (packages/proxy)`
- 10 governed-execution assertions were masked by `EXEC_AUTH_SUMMON_ATTESTATION_INVALID`

## Validation
- `bunx turbo run build --filter=@stwd/proxy... --force` (9/9 packages)
- `bun test packages/proxy/src/__tests__/x-summon-provenance.test.ts` (3/3)
- `bun test packages/proxy/src/__tests__/governed-execution.test.ts` (42/42)
- Biome and `git diff --check` clean