### PR TITLE
test(provider): isolate governed rate-limit fixture

### DIFF
--- a/packages/api/src/__tests__/provider-authority-e2e.test.ts
+++ b/packages/api/src/__tests__/provider-authority-e2e.test.ts
@@ -67,6 +67,7 @@ type ProxyMod = typeof import("@stwd/proxy/src/handlers/proxy");
 type DispatchMod = typeof import("@stwd/proxy/src/handlers/governed-execution");
 let proxyMod: ProxyMod;
 let dispatchGovernedExecution: DispatchMod["dispatchGovernedExecution"];
+let restoreProxyRateLimit: (() => void) | undefined;
 
 // Shared fixture (real create/decide services) — imported dynamically so the
 // PGLite override is installed before the fixture's db handle resolves.
@@ -326,14 +327,19 @@ beforeAll(async () => {
   const { db, client } = await createPGLiteDb("memory://");
   setPGLiteOverride(db, async () => client.close());
   proxyMod = await import("@stwd/proxy/src/handlers/proxy");
+  const redisEnforcement = await import("@stwd/proxy/src/middleware/redis-enforcement");
   ({ dispatchGovernedExecution } = await import("@stwd/proxy/src/handlers/governed-execution"));
   ({ F, principal } = await import("./provider-approval-fixture"));
   ({ seedCaseFixture, wipeCase } = await import("./provider-case-fixture"));
   // Pin DNS to a public address so the SSRF guard passes without a real lookup.
   proxyMod.__setResolveProxyHostForTests(async () => [{ address: "140.82.112.6", family: 4 }]);
+  proxyMod.__setCheckProxyRateLimitForTests(async () => ({ allowed: true, resetMs: 0 }));
+  restoreProxyRateLimit = () =>
+    proxyMod.__setCheckProxyRateLimitForTests(redisEnforcement.checkProxyRateLimit);
 });
 
 afterAll(async () => {
+  restoreProxyRateLimit?.();
   await closeDb();
 });
 


### PR DESCRIPTION
## Summary

- make the provider-authority E2E explicitly permit its deterministic fake dispatch through the production rate-limit seam
- restore the real Redis enforcement function after the suite
- keep production fail-closed behavior unchanged

## Why

The suite claims to exercise the governed terminal forwarder, but the newer fail-closed Redis rate limiter returns 429 before the fake transport when Redis is intentionally absent. This made all positive dispatch assertions fail with zero forwards and hid the boundary the test is supposed to prove.

## Exact validation

Head `aee0855bcd52439e2f68026d327099515187c80f`, base `8d7da9e26bc1020a0d89c20955d3f3cab7d10f94`:

- isolated provider-authority E2E: 12/12 passed
- API dependency build: 21/21 tasks passed
- Biome and `git diff --check`: passed