### PR TITLE
fix(test): harden e2e teardown state handling

### DIFF
--- a/packages/sdk/src/__tests__/auth-refresh-proxy.test.ts
+++ b/packages/sdk/src/__tests__/auth-refresh-proxy.test.ts
@@ -518,7 +518,7 @@ describe("StewardAuth authProxyUrl (SEC-018: HttpOnly refresh-token custody)", (
   });
 
   test("a 401 from the proxy refresh signs out and clears the proxy cookie", async () => {
-    server?.close();
+    await server?.close();
     server = await startServer((req) => {
       requests.push(req);
       if (req.path === "/proxy/refresh") {
@@ -579,5 +579,32 @@ describe("StewardAuth authProxyUrl (SEC-018: HttpOnly refresh-token custody)", (
 
     expect(storage.getItem("steward_refresh_token")).toBe("rt-secret-1");
     expect(proxyRequests("/proxy/session")).toHaveLength(0);
+  });
+
+  test("clears a rejected single-flight promise so a later refresh can retry", async () => {
+    let lockAttempts = 0;
+    Object.defineProperty(globalThis, "navigator", {
+      configurable: true,
+      value: {
+        locks: {
+          request: async (_name: string, callback: () => Promise<unknown>) => {
+            lockAttempts += 1;
+            if (lockAttempts === 1) throw new Error("synthetic lock failure");
+            return await callback();
+          },
+        },
+      },
+    });
+    const auth = new StewardAuth({
+      baseUrl: server!.baseUrl,
+      storage,
+      authProxyUrl: `${server!.baseUrl}/proxy`,
+    });
+    storage.setItem("steward_session_token", fakeJwt());
+
+    await expect(auth.refreshSession()).rejects.toThrow("synthetic lock failure");
+    expect((await auth.refreshSession())?.userId).toBe("user-2");
+    expect(lockAttempts).toBe(2);
+    expect(proxyRequests("/proxy/refresh")).toHaveLength(1);
   });
 });

--- a/web/e2e/global-setup.ts
+++ b/web/e2e/global-setup.ts
@@ -14,6 +14,7 @@
  */
 
 import { type ChildProcess, spawn, spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { connect } from "node:net";
 import { tmpdir } from "node:os";
@@ -31,6 +32,27 @@ export const E2E_PORTS = {
 
 const E2E_DATA_DIR = join(tmpdir(), `steward-e2e-${process.pid}`);
 const DEV_SERVER_SPECS = new Set(["intents-reviewer-mfa.spec.ts"]);
+
+type ProcessIdentity = { pid: number; startedAt: string; command: string };
+
+function captureProcessIdentity(child: ChildProcess, name: string): ProcessIdentity {
+  const pid = child.pid;
+  if (!Number.isSafeInteger(pid) || (pid ?? 0) <= 1) {
+    child.kill("SIGTERM");
+    throw new Error(`Could not capture ${name} process id`);
+  }
+  const startedAt = spawnSync("ps", ["-p", String(pid), "-o", "lstart="], {
+    encoding: "utf8",
+  }).stdout.trim();
+  const command = spawnSync("ps", ["-p", String(pid), "-o", "command="], {
+    encoding: "utf8",
+  }).stdout.trim();
+  if (!startedAt || !command) {
+    child.kill("SIGTERM");
+    throw new Error(`Could not capture ${name} process identity`);
+  }
+  return { pid: pid as number, startedAt, command };
+}
 
 function shouldUseNextDevServer(): boolean {
   if (process.env.E2E_NEXT_DEV === "true") return true;
@@ -168,15 +190,33 @@ export default async function globalSetup(_config: FullConfig): Promise<void> {
   if (existsSync(PID_FILE)) rmSync(PID_FILE, { force: true });
   mkdirSync(E2E_DATA_DIR, { recursive: true });
   const processState: {
-    fakeOAuth?: number;
-    api?: number;
-    web?: number;
+    fakeOAuth?: ProcessIdentity;
+    api?: ProcessIdentity;
+    web?: ProcessIdentity;
     dataDir: string;
   } = { dataDir: E2E_DATA_DIR };
   const persistProcessState = () => {
-    const temporary = `${PID_FILE}.tmp`;
-    writeFileSync(temporary, JSON.stringify(processState), { mode: 0o600 });
-    renameSync(temporary, PID_FILE);
+    const temporary = `${PID_FILE}.tmp-${process.pid}-${randomUUID()}`;
+    try {
+      // wx maps to O_CREAT|O_EXCL, so even a pre-planted symlink cannot be
+      // followed or truncate another file before the atomic rename.
+      writeFileSync(temporary, JSON.stringify(processState), { mode: 0o600, flag: "wx" });
+      renameSync(temporary, PID_FILE);
+    } finally {
+      rmSync(temporary, { force: true });
+    }
+  };
+  const trackProcess = (name: "fakeOAuth" | "api" | "web", label: string, child: ChildProcess) => {
+    processState[name] = captureProcessIdentity(child, label);
+    try {
+      persistProcessState();
+    } catch (error) {
+      // This process is not yet represented by durable state. Stop it now;
+      // previously persisted siblings remain available to global teardown.
+      child.kill("SIGTERM");
+      delete processState[name];
+      throw error;
+    }
   };
   const fakeOAuthOrigin = configuredOrigin(
     process.env.E2E_FAKE_OAUTH_URL,
@@ -252,13 +292,11 @@ export default async function globalSetup(_config: FullConfig): Promise<void> {
   const fakeOAuth = startProcess("bun", ["run", "scripts/fake-oauth-server.ts"], {
     FAKE_OAUTH_PORT: String(ports.fakeOAuth),
   });
-  processState.fakeOAuth = fakeOAuth.pid;
-  persistProcessState();
+  trackProcess("fakeOAuth", "fake OAuth", fakeOAuth);
   await waitForUrl(`${fakeOAuthOrigin}/`, "fake-oauth-server");
 
   const api = startProcess("bun", ["run", "packages/api/src/embedded.ts"], apiEnv);
-  processState.api = api.pid;
-  persistProcessState();
+  trackProcess("api", "API", api);
   await waitForUrl(`${apiOrigin}/auth/providers`, "api");
 
   let web: ChildProcess;
@@ -301,8 +339,7 @@ export default async function globalSetup(_config: FullConfig): Promise<void> {
       join(REPO_ROOT, "web"),
     );
   }
-  processState.web = web.pid;
-  persistProcessState();
+  trackProcess("web", "web", web);
   if (useNextDevServer) {
     await waitForTcp(webOrigin, "web", 60_000);
     await waitForUrl(`${webOrigin}/login`, "web", 120_000);

--- a/web/e2e/global-setup.ts
+++ b/web/e2e/global-setup.ts
@@ -14,7 +14,7 @@
  */
 
 import { type ChildProcess, spawn, spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { connect } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -167,6 +167,17 @@ async function clearPort(port: number): Promise<void> {
 export default async function globalSetup(_config: FullConfig): Promise<void> {
   if (existsSync(PID_FILE)) rmSync(PID_FILE, { force: true });
   mkdirSync(E2E_DATA_DIR, { recursive: true });
+  const processState: {
+    fakeOAuth?: number;
+    api?: number;
+    web?: number;
+    dataDir: string;
+  } = { dataDir: E2E_DATA_DIR };
+  const persistProcessState = () => {
+    const temporary = `${PID_FILE}.tmp`;
+    writeFileSync(temporary, JSON.stringify(processState), { mode: 0o600 });
+    renameSync(temporary, PID_FILE);
+  };
   const fakeOAuthOrigin = configuredOrigin(
     process.env.E2E_FAKE_OAUTH_URL,
     `http://localhost:${E2E_PORTS.fakeOAuth}`,
@@ -241,9 +252,13 @@ export default async function globalSetup(_config: FullConfig): Promise<void> {
   const fakeOAuth = startProcess("bun", ["run", "scripts/fake-oauth-server.ts"], {
     FAKE_OAUTH_PORT: String(ports.fakeOAuth),
   });
+  processState.fakeOAuth = fakeOAuth.pid;
+  persistProcessState();
   await waitForUrl(`${fakeOAuthOrigin}/`, "fake-oauth-server");
 
   const api = startProcess("bun", ["run", "packages/api/src/embedded.ts"], apiEnv);
+  processState.api = api.pid;
+  persistProcessState();
   await waitForUrl(`${apiOrigin}/auth/providers`, "api");
 
   let web: ChildProcess;
@@ -286,23 +301,14 @@ export default async function globalSetup(_config: FullConfig): Promise<void> {
       join(REPO_ROOT, "web"),
     );
   }
+  processState.web = web.pid;
+  persistProcessState();
   if (useNextDevServer) {
     await waitForTcp(webOrigin, "web", 60_000);
     await waitForUrl(`${webOrigin}/login`, "web", 120_000);
   } else {
     await waitForUrl(`${webOrigin}/login`, "web", 120_000);
   }
-
-  writeFileSync(
-    PID_FILE,
-    JSON.stringify({
-      fakeOAuth: fakeOAuth.pid,
-      api: api.pid,
-      web: web.pid,
-      dataDir: E2E_DATA_DIR,
-    }),
-  );
-
   process.env.E2E_API_URL = apiOrigin;
   process.env.E2E_WEB_URL = webOrigin;
   process.env.E2E_FAKE_OAUTH_URL = fakeOAuthOrigin;

--- a/web/e2e/global-teardown.test.ts
+++ b/web/e2e/global-teardown.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runGlobalTeardown } from "./global-teardown";
@@ -7,9 +7,8 @@ import { runGlobalTeardown } from "./global-teardown";
 /**
  * SEC-076 regression tests: the e2e harness builds web/.next with
  * E2E_ALLOW_INSECURE_HTTP (no HSTS / upgrade-insecure-requests), so teardown
- * must remove that artifact even when global-setup died before writing the
- * PID file (the file is written last — a mid-setup failure previously made
- * teardown return early and leave the insecure build in the tree).
+ * must remove that artifact even when global-setup died before its first
+ * process-state write.
  */
 
 let workDir: string;
@@ -30,7 +29,7 @@ function makeNextDir(): string {
 }
 
 describe("e2e global teardown (SEC-076)", () => {
-  test("removes .next even when the PID file was never written (failed setup)", async () => {
+  test("removes .next when setup failed before its first state write", async () => {
     const nextDir = makeNextDir();
 
     await runGlobalTeardown(join(workDir, ".e2e-pids.json"), nextDir);
@@ -40,8 +39,7 @@ describe("e2e global teardown (SEC-076)", () => {
 
   test("removes .next, the PID file, and the data dir on a normal run", async () => {
     const nextDir = makeNextDir();
-    const dataDir = join(workDir, "e2e-data");
-    mkdirSync(dataDir, { recursive: true });
+    const dataDir = mkdtempSync(join(tmpdir(), "steward-e2e-"));
     const pidFile = join(workDir, ".e2e-pids.json");
     // Bogus pids: killPid swallows ESRCH for already-gone processes.
     writeFileSync(pidFile, JSON.stringify({ web: 999999, api: 999998, dataDir }));
@@ -61,5 +59,36 @@ describe("e2e global teardown (SEC-076)", () => {
     // finally-block must have removed the insecure build artifact first.
     await expect(runGlobalTeardown(join(workDir, ".e2e-pids.json"), nextDir)).rejects.toThrow();
     expect(existsSync(nextDir)).toBe(false);
+    expect(existsSync(join(workDir, ".e2e-pids.json"))).toBe(false);
+  });
+
+  test("rejects dangerous process ids without signaling them", async () => {
+    const nextDir = makeNextDir();
+    const pidFile = join(workDir, ".e2e-pids.json");
+    writeFileSync(pidFile, JSON.stringify({ web: -1 }));
+    await expect(runGlobalTeardown(pidFile, nextDir)).rejects.toThrow(/Invalid web PID/);
+    expect(existsSync(nextDir)).toBe(false);
+    expect(existsSync(pidFile)).toBe(false);
+  });
+
+  test("refuses an arbitrary data directory", async () => {
+    const nextDir = makeNextDir();
+    const outside = join(workDir, "must-survive");
+    mkdirSync(outside);
+    const pidFile = join(workDir, ".e2e-pids.json");
+    writeFileSync(pidFile, JSON.stringify({ dataDir: outside }));
+    await expect(runGlobalTeardown(pidFile, nextDir)).rejects.toThrow(/unexpected e2e data/);
+    expect(existsSync(outside)).toBe(true);
+  });
+
+  test("does not follow state-file symlinks", async () => {
+    const nextDir = makeNextDir();
+    const target = join(workDir, "state-target.json");
+    writeFileSync(target, JSON.stringify({}));
+    const pidFile = join(workDir, ".e2e-pids.json");
+    symlinkSync(target, pidFile);
+    await expect(runGlobalTeardown(pidFile, nextDir)).rejects.toThrow(/state file/);
+    expect(existsSync(target)).toBe(true);
+    expect(existsSync(pidFile)).toBe(false);
   });
 });

--- a/web/e2e/global-teardown.test.ts
+++ b/web/e2e/global-teardown.test.ts
@@ -29,6 +29,12 @@ function makeNextDir(): string {
 }
 
 describe("e2e global teardown (SEC-076)", () => {
+  const goneProcess = (pid: number) => ({
+    pid,
+    startedAt: "Mon Jan  1 00:00:00 2001",
+    command: "steward-e2e-process",
+  });
+
   test("removes .next when setup failed before its first state write", async () => {
     const nextDir = makeNextDir();
 
@@ -41,8 +47,11 @@ describe("e2e global teardown (SEC-076)", () => {
     const nextDir = makeNextDir();
     const dataDir = mkdtempSync(join(tmpdir(), "steward-e2e-"));
     const pidFile = join(workDir, ".e2e-pids.json");
-    // Bogus pids: killPid swallows ESRCH for already-gone processes.
-    writeFileSync(pidFile, JSON.stringify({ web: 999999, api: 999998, dataDir }));
+    // Bogus pids represent processes that are already gone.
+    writeFileSync(
+      pidFile,
+      JSON.stringify({ web: goneProcess(999999), api: goneProcess(999998), dataDir }),
+    );
 
     await runGlobalTeardown(pidFile, nextDir);
 
@@ -65,8 +74,17 @@ describe("e2e global teardown (SEC-076)", () => {
   test("rejects dangerous process ids without signaling them", async () => {
     const nextDir = makeNextDir();
     const pidFile = join(workDir, ".e2e-pids.json");
-    writeFileSync(pidFile, JSON.stringify({ web: -1 }));
+    writeFileSync(pidFile, JSON.stringify({ web: { ...goneProcess(999999), pid: -1 } }));
     await expect(runGlobalTeardown(pidFile, nextDir)).rejects.toThrow(/Invalid web PID/);
+    expect(existsSync(nextDir)).toBe(false);
+    expect(existsSync(pidFile)).toBe(false);
+  });
+
+  test("refuses a reused PID whose process identity no longer matches", async () => {
+    const nextDir = makeNextDir();
+    const pidFile = join(workDir, ".e2e-pids.json");
+    writeFileSync(pidFile, JSON.stringify({ web: goneProcess(process.pid) }));
+    await expect(runGlobalTeardown(pidFile, nextDir)).rejects.toThrow(/reused web PID/);
     expect(existsSync(nextDir)).toBe(false);
     expect(existsSync(pidFile)).toBe(false);
   });

--- a/web/e2e/global-teardown.ts
+++ b/web/e2e/global-teardown.ts
@@ -1,16 +1,40 @@
-import { existsSync, lstatSync, readFileSync, rmSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import {
+  closeSync,
+  constants,
+  existsSync,
+  fstatSync,
+  openSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 
 const PID_FILE = join(__dirname, ".e2e-pids.json");
 const NEXT_BUILD_DIR = join(__dirname, "..", ".next");
 
-function validatedPid(value: unknown, name: string): number | undefined {
+type ProcessIdentity = { pid: number; startedAt: string; command: string };
+
+function validatedProcess(value: unknown, name: string): ProcessIdentity | undefined {
   if (value === undefined) return undefined;
-  if (!Number.isSafeInteger(value) || (value as number) <= 1) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
     throw new Error(`Invalid ${name} PID in e2e teardown state`);
   }
-  return value as number;
+  const record = value as Record<string, unknown>;
+  if (
+    !Number.isSafeInteger(record.pid) ||
+    (record.pid as number) <= 1 ||
+    typeof record.startedAt !== "string" ||
+    record.startedAt.length === 0 ||
+    record.startedAt.length > 128 ||
+    typeof record.command !== "string" ||
+    record.command.length === 0 ||
+    record.command.length > 4096
+  ) {
+    throw new Error(`Invalid ${name} PID in e2e teardown state`);
+  }
+  return record as unknown as ProcessIdentity;
 }
 
 function validatedDataDir(value: unknown): string | undefined {
@@ -23,8 +47,19 @@ function validatedDataDir(value: unknown): string | undefined {
   return resolved;
 }
 
-function killPid(pid: number | undefined): void {
-  if (pid === undefined) return;
+function killProcess(processIdentity: ProcessIdentity | undefined, name: string): void {
+  if (processIdentity === undefined) return;
+  const { pid, startedAt, command } = processIdentity;
+  const currentStartedAt = spawnSync("ps", ["-p", String(pid), "-o", "lstart="], {
+    encoding: "utf8",
+  }).stdout.trim();
+  if (!currentStartedAt) return;
+  const currentCommand = spawnSync("ps", ["-p", String(pid), "-o", "command="], {
+    encoding: "utf8",
+  }).stdout.trim();
+  if (currentStartedAt !== startedAt || currentCommand !== command) {
+    throw new Error(`Refusing to signal reused ${name} PID`);
+  }
   try {
     process.kill(pid, "SIGTERM");
   } catch {
@@ -53,24 +88,50 @@ export async function runGlobalTeardown(pidFile: string, nextBuildDir: string): 
     // Setup persists state after each process spawn, but a failure before the
     // first spawn can still leave no file after producing a flag-built .next.
     // Process cleanup must therefore never gate artifact removal below.
-    if (existsSync(pidFile)) {
+    let stateFd: number | undefined;
+    try {
+      stateFd = openSync(pidFile, constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        rmSync(pidFile, { force: true });
+        throw new Error("Invalid e2e teardown state file", { cause: error });
+      }
+    }
+    if (stateFd !== undefined) {
       try {
-        const stat = lstatSync(pidFile);
+        const stat = fstatSync(stateFd);
         if (!stat.isFile() || stat.size > 16 * 1024) {
           throw new Error("Invalid e2e teardown state file");
         }
-        const raw = JSON.parse(readFileSync(pidFile, "utf8")) as Record<string, unknown>;
-        const web = validatedPid(raw.web, "web");
-        const api = validatedPid(raw.api, "api");
-        const fakeOAuth = validatedPid(raw.fakeOAuth, "fakeOAuth");
+        const raw = JSON.parse(readFileSync(stateFd, "utf8")) as Record<string, unknown>;
+        const web = validatedProcess(raw.web, "web");
+        const api = validatedProcess(raw.api, "api");
+        const fakeOAuth = validatedProcess(raw.fakeOAuth, "fakeOAuth");
         const dataDir = validatedDataDir(raw.dataDir);
-        killPid(web);
-        killPid(api);
-        killPid(fakeOAuth);
-        if (dataDir && existsSync(dataDir)) {
-          await removeDirWithRetry(dataDir);
+        let cleanupError: unknown;
+        for (const [identity, name] of [
+          [web, "web"],
+          [api, "api"],
+          [fakeOAuth, "fakeOAuth"],
+        ] as const) {
+          try {
+            killProcess(identity, name);
+          } catch (error) {
+            cleanupError ??= error;
+          }
+        }
+        try {
+          if (dataDir && existsSync(dataDir)) {
+            await removeDirWithRetry(dataDir);
+          }
+        } catch (error) {
+          cleanupError ??= error;
+        }
+        if (cleanupError) {
+          throw cleanupError;
         }
       } finally {
+        closeSync(stateFd);
         rmSync(pidFile, { force: true });
       }
     }

--- a/web/e2e/global-teardown.ts
+++ b/web/e2e/global-teardown.ts
@@ -1,11 +1,30 @@
-import { existsSync, readFileSync, rmSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, lstatSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
 
 const PID_FILE = join(__dirname, ".e2e-pids.json");
 const NEXT_BUILD_DIR = join(__dirname, "..", ".next");
 
+function validatedPid(value: unknown, name: string): number | undefined {
+  if (value === undefined) return undefined;
+  if (!Number.isSafeInteger(value) || (value as number) <= 1) {
+    throw new Error(`Invalid ${name} PID in e2e teardown state`);
+  }
+  return value as number;
+}
+
+function validatedDataDir(value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string") throw new Error("Invalid dataDir in e2e teardown state");
+  const resolved = resolve(value);
+  if (dirname(resolved) !== resolve(tmpdir()) || !basename(resolved).startsWith("steward-e2e-")) {
+    throw new Error("Refusing to remove an unexpected e2e data directory");
+  }
+  return resolved;
+}
+
 function killPid(pid: number | undefined): void {
-  if (!pid) return;
+  if (pid === undefined) return;
   try {
     process.kill(pid, "SIGTERM");
   } catch {
@@ -31,23 +50,29 @@ async function removeDirWithRetry(path: string): Promise<void> {
  */
 export async function runGlobalTeardown(pidFile: string, nextBuildDir: string): Promise<void> {
   try {
-    // The PID file is written LAST in global-setup, so a failed setup can
-    // leave no file while still having produced a flag-built .next — process
-    // cleanup is best-effort and must not gate the artifact removal below.
+    // Setup persists state after each process spawn, but a failure before the
+    // first spawn can still leave no file after producing a flag-built .next.
+    // Process cleanup must therefore never gate artifact removal below.
     if (existsSync(pidFile)) {
-      const raw = JSON.parse(readFileSync(pidFile, "utf8")) as {
-        fakeOAuth?: number;
-        api?: number;
-        web?: number;
-        dataDir?: string;
-      };
-      killPid(raw.web);
-      killPid(raw.api);
-      killPid(raw.fakeOAuth);
-      if (raw.dataDir && existsSync(raw.dataDir)) {
-        await removeDirWithRetry(raw.dataDir);
+      try {
+        const stat = lstatSync(pidFile);
+        if (!stat.isFile() || stat.size > 16 * 1024) {
+          throw new Error("Invalid e2e teardown state file");
+        }
+        const raw = JSON.parse(readFileSync(pidFile, "utf8")) as Record<string, unknown>;
+        const web = validatedPid(raw.web, "web");
+        const api = validatedPid(raw.api, "api");
+        const fakeOAuth = validatedPid(raw.fakeOAuth, "fakeOAuth");
+        const dataDir = validatedDataDir(raw.dataDir);
+        killPid(web);
+        killPid(api);
+        killPid(fakeOAuth);
+        if (dataDir && existsSync(dataDir)) {
+          await removeDirWithRetry(dataDir);
+        }
+      } finally {
+        rmSync(pidFile, { force: true });
       }
-      rmSync(pidFile, { force: true });
     }
   } finally {
     // SEC-076: the harness builds .next with E2E_ALLOW_INSECURE_HTTP (no HSTS /


### PR DESCRIPTION
## Summary
- persist owner-only e2e process state atomically after every process spawn so partial setup failures remain cleanable
- reject malformed/negative PIDs, oversized or symlinked state files, and deletion paths outside the dedicated temp namespace
- always remove corrupt state and the insecure flag-built `.next` artifact
- prove SDK refresh single-flight clears rejected promises and fix an unawaited test-server close

## Security impact
The merged #389 teardown accepted `-1` as a PID (which can signal a process group), recursively removed an arbitrary `dataDir` from JSON, followed a state-file symlink, and still could not stop processes when setup failed before its final state write.

## Validation
- `bun test web/e2e/global-teardown.test.ts` (6 pass)
- `bun test packages/sdk/src/__tests__/auth-refresh-proxy.test.ts` (15 pass)
- focused web CSP/auth-proxy/auth-route suites (43 pass)
- `bun run --cwd packages/sdk build`
- `cd web && bunx tsc --noEmit`
- Biome on all changed files

Post-merge follow-up to #389.