### PR TITLE
fix(proxy): block full NAT64 local-use prefix

### DIFF
--- a/packages/proxy/src/__tests__/zz-proxy-spend-limit.test.ts
+++ b/packages/proxy/src/__tests__/zz-proxy-spend-limit.test.ts
@@ -688,7 +688,17 @@ describe("proxy spend-limit enforcement", () => {
       await loadProxy();
     __setCheckProxySpendLimitForTests(async () => spendResult);
 
-    for (const address of ["64:ff9b::a9fe:a9fe", "64:ff9b:1::a9fe:a9fe", "2002:7f00:1::"]) {
+    for (const address of [
+      "64:ff9b::a9fe:a9fe",
+      "64:ff9b:1::a9fe:a9fe",
+      // RFC 8215 local-use /48: the embedded IPv4 position is operator-defined,
+      // so a non-zero fourth word must not bypass the public-address boundary.
+      "64:ff9b:1:1::808:808",
+      // Exercise the final address in the reserved /48 so the guard cannot
+      // accidentally regress to a narrower implementation-defined subnet.
+      "64:ff9b:1:ffff:ffff:ffff:ffff:ffff",
+      "2002:7f00:1::",
+    ]) {
       audits.length = 0;
       __setResolveProxyHostForTests(async () => [{ address, family: 6 }]);
 

--- a/packages/proxy/src/handlers/proxy.ts
+++ b/packages/proxy/src/handlers/proxy.ts
@@ -902,11 +902,16 @@ function ipv4FromEmbeddedIPv6(address: string): string | null {
 
 function isUnsafeIPv6Address(address: string): boolean {
   const normalized = address.toLowerCase();
+  const words = expandIPv6Words(normalized);
+  // RFC 8215 reserves 64:ff9b:1::/48 for operator-local translation and
+  // explicitly does not fix the embedded IPv4 position. Treat the entire
+  // prefix as non-public instead of applying the /96 low-word extraction
+  // used for the well-known 64:ff9b::/96 prefix.
+  if (words?.[0] === 0x0064 && words[1] === 0xff9b && words[2] === 0x0001) return true;
   const mappedV4 = ipv4FromMappedIPv6(normalized);
   if (mappedV4) return isUnsafeIPv4Address(mappedV4);
   const embeddedV4 = ipv4FromEmbeddedIPv6(normalized);
   if (embeddedV4) return isUnsafeIPv4Address(embeddedV4);
-  const words = expandIPv6Words(normalized);
   if (!words || words.length !== 8) return true;
   if (words?.[0] === 0x2001 && (words[1] === 0 || words[1] === 0xdb8)) return true;
   const first = words[0];


### PR DESCRIPTION
## Security finding

The proxy SSRF resolver blocked only a `/96` interpretation of the RFC 8215 local-use NAT64 space. RFC 8215 reserves the full `64:ff9b:1::/48`; the IANA IPv6 Special-Purpose Address Registry marks that block as not globally reachable, and operators may choose translation layouts anywhere within it. A DNS answer such as `64:ff9b:1:1::808:808` could therefore be misclassified as public.

## Fix

- reject the entire `64:ff9b:1::/48` before embedded-IPv4 extraction
- test an operator-defined interior layout and the final address of the reserved `/48`
- retain the existing fail-closed 403, zero-forward, and audit-reason assertions

## Validation

Exact head `7fa6a5e6f76659e4e52bdaa2f28dfedd789c2fcc` on base `93322dd1a809cdcc298be3a15ec450b9f16d66e7`:

- isolated proxy spend-limit/SSRF suite: 30 pass, 0 fail, 172 expectations
- proxy dependency build: 9/9 packages pass
- Biome (2 changed files): pass
- `git diff --check`: pass
- exact-head CI: queued

Primary references: RFC 8215 and the IANA IPv6 Special-Purpose Address Registry.

This is a distinct residual found while reviewing #393; no duplicate PR was found.
