### PR TITLE
fix(security): re-audit W3-B — registry quorum PEM canonicalization, vault custody seams, FROST nonce eviction

### DIFF
--- a/packages/signer-frost/THRESHOLD-SIGNING.md
+++ b/packages/signer-frost/THRESHOLD-SIGNING.md
@@ -71,9 +71,11 @@ ECDSA (CGGMP21-class) for the first prototype. The short version:
 | POST | `/aggregate` | combine signature shares → group signature (verifies) | public op |
 | POST | `/verify` | verify a provided signature against the group key | public op |
 
-Every endpoint except `GET /health` requires `Authorization: Bearer <token>`
-(`--auth-token` or `FROST_SHARE_AUTH_TOKEN`; the service refuses to start
-without one). Use a distinct token per share. The coordinator never trusts the
+Every endpoint except `GET /health` requires `Authorization: Bearer <token>`.
+Set a random token of at least 32 bytes through `FROST_SHARE_AUTH_TOKEN`; the
+service refuses to start without one. Command-line tokens are intentionally not
+supported because process arguments are commonly visible to other local users.
+Use a distinct token per share. The coordinator never trusts the
 aggregating share: after `/aggregate` it re-verifies the signature over the
 original message via a different share, so a single-share (1-of-1) group —
 where no independent verifier exists — is rejected at construction.
@@ -194,11 +196,11 @@ cargo build --release --manifest-path sidecar/Cargo.toml
 sidecar/target/release/frost-signer keygen --threshold 2 --participants 3 --out ./shares
 
 # 3. start three share services (each = one enclave stand-in)
-#    each requires its own bearer token (flag or FROST_SHARE_AUTH_TOKEN);
+#    each requires its own strong FROST_SHARE_AUTH_TOKEN;
 #    the service refuses to start unauthenticated
-frost-signer share --share-file ./shares/share-0000...0001.json --port 7401 --auth-token "$FROST_TOKEN_1" &
-frost-signer share --share-file ./shares/share-0000...0002.json --port 7402 --auth-token "$FROST_TOKEN_2" &
-frost-signer share --share-file ./shares/share-0000...0003.json --port 7403 --auth-token "$FROST_TOKEN_3" &
+FROST_SHARE_AUTH_TOKEN="$FROST_TOKEN_1" frost-signer share --share-file ./shares/share-0000...0001.json --port 7401 &
+FROST_SHARE_AUTH_TOKEN="$FROST_TOKEN_2" frost-signer share --share-file ./shares/share-0000...0002.json --port 7402 &
+FROST_SHARE_AUTH_TOKEN="$FROST_TOKEN_3" frost-signer share --share-file ./shares/share-0000...0003.json --port 7403 &
 
 # 4. use FrostSignerBackend from TS (see @stwd/vault KEYSTORE-BACKENDS.md)
 

--- a/packages/signer-frost/THRESHOLD-SIGNING.md
+++ b/packages/signer-frost/THRESHOLD-SIGNING.md
@@ -72,9 +72,10 @@ ECDSA (CGGMP21-class) for the first prototype. The short version:
 | POST | `/verify` | verify a provided signature against the group key | public op |
 
 Every endpoint except `GET /health` requires `Authorization: Bearer <token>`.
-Set a random token of at least 32 bytes through `FROST_SHARE_AUTH_TOKEN`; the
-service refuses to start without one. Command-line tokens are intentionally not
-supported because process arguments are commonly visible to other local users.
+Encode at least 32 random bytes (for example, as 64 hex characters) through
+`FROST_SHARE_AUTH_TOKEN`; the service refuses to start with a token shorter than
+32 bytes. Command-line tokens are intentionally not supported because process
+arguments are commonly visible to other local users.
 Use a distinct token per share. The coordinator never trusts the
 aggregating share: after `/aggregate` it re-verifies the signature over the
 original message via a different share, so a single-share (1-of-1) group —

--- a/packages/signer-frost/sidecar/src/main.rs
+++ b/packages/signer-frost/sidecar/src/main.rs
@@ -149,8 +149,10 @@ struct ShareState {
     key_package: KeyPackage,
     pubkey_package: PublicKeyPackage,
     identifier: Identifier,
-    // Nonces are single-use and kept per commit round, keyed by nonce id.
-    nonces: BTreeMap<String, frost::round1::SigningNonces>,
+    // Nonces are single-use and kept per commit round, keyed by the numeric
+    // nonce counter (nonce ids on the wire are "n<counter>"). BTreeMap order
+    // is ascending counter, so the front entry is the oldest parked round.
+    nonces: BTreeMap<u64, frost::round1::SigningNonces>,
     next_nonce_id: u64,
     // SEC-025: per-share bearer token authenticating the coordinator.
     auth_token: String,
@@ -296,18 +298,24 @@ fn handle(state: &mut ShareState, method: &str, url: &str, body: &str) -> (u16, 
                 .to_string(),
         ),
         ("POST", "/commit") => {
+            // SEC-083 bounds the map; the re-audit follow-up: a hard 429 at
+            // the cap let an authenticated coordinator park 1024 rounds
+            // forever and wedge the signer (availability). Evict the oldest
+            // parked round instead — its /sign will fail closed with
+            // "unknown or reused nonce_id", and an evicted unused nonce is
+            // never signed with, so FROST nonce-reuse safety is preserved.
             if state.nonces.len() >= MAX_PENDING_NONCES {
-                return (429, err_json("too many outstanding commit rounds"));
+                state.nonces.pop_first();
             }
             let mut rng = OsRng;
             let (nonces, commitments) =
                 frost::round1::commit(state.key_package.signing_share(), &mut rng);
-            let nonce_id = format!("n{}", state.next_nonce_id);
+            let nonce_id = state.next_nonce_id;
             state.next_nonce_id += 1;
-            state.nonces.insert(nonce_id.clone(), nonces);
+            state.nonces.insert(nonce_id, nonces);
             let resp = CommitResponse {
                 identifier_hex: hex::encode(state.identifier.serialize()),
-                nonce_id,
+                nonce_id: format!("n{nonce_id}"),
                 commitments_hex: hex::encode(commitments.serialize().expect("ser commitments")),
             };
             (200, serde_json::to_string(&resp).unwrap())
@@ -347,7 +355,11 @@ fn handle(state: &mut ShareState, method: &str, url: &str, body: &str) -> (u16, 
                 Ok(r) => r,
                 Err(e) => return (400, err_json(&format!("bad /sign body: {e}"))),
             };
-            let nonces = match state.nonces.remove(&req.nonce_id) {
+            let nonce_key = req
+                .nonce_id
+                .strip_prefix('n')
+                .and_then(|suffix| suffix.parse::<u64>().ok());
+            let nonces = match nonce_key.and_then(|key| state.nonces.remove(&key)) {
                 Some(n) => n,
                 None => return (400, err_json("unknown or reused nonce_id")),
             };
@@ -492,5 +504,120 @@ fn main() {
             eprintln!("usage: frost-signer <keygen|share> ...");
             std::process::exit(2);
         }
+    }
+}
+
+// --------------------------------- tests ------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_state() -> ShareState {
+        let rng = OsRng;
+        let (shares, pubkey_package) = frost::keys::generate_with_dealer(
+            2,
+            2,
+            frost::keys::IdentifierList::Default,
+            rng,
+        )
+        .expect("trusted-dealer keygen");
+        let (identifier, secret_share) = shares.into_iter().next().expect("one share");
+        let key_package = KeyPackage::try_from(secret_share).expect("share -> key package");
+        ShareState {
+            key_package,
+            pubkey_package,
+            identifier,
+            nonces: BTreeMap::new(),
+            next_nonce_id: 0,
+            auth_token: "test-token".to_string(),
+        }
+    }
+
+    fn commit(state: &mut ShareState) -> (u16, String) {
+        let (code, payload) = handle(state, "POST", "/commit", "");
+        let nonce_id = serde_json::from_str::<serde_json::Value>(&payload)
+            .expect("commit response json")["nonce_id"]
+            .as_str()
+            .expect("nonce_id string")
+            .to_string();
+        (code, nonce_id)
+    }
+
+    // Re-audit: the bare 429 cap let an authenticated coordinator park
+    // MAX_PENDING_NONCES rounds forever and wedge the share service. /commit
+    // must evict the oldest parked round instead of refusing new rounds.
+    #[test]
+    fn commit_evicts_oldest_parked_round_at_the_cap() {
+        let mut state = test_state();
+        for expected in 0..MAX_PENDING_NONCES {
+            let (code, nonce_id) = commit(&mut state);
+            assert_eq!(code, 200);
+            assert_eq!(nonce_id, format!("n{expected}"));
+        }
+        assert_eq!(state.nonces.len(), MAX_PENDING_NONCES);
+
+        // One more commit: succeeds, evicts the oldest round ("n0"), keeps the
+        // map bounded at the cap.
+        let (code, nonce_id) = commit(&mut state);
+        assert_eq!(code, 200);
+        assert_eq!(nonce_id, format!("n{}", MAX_PENDING_NONCES));
+        assert_eq!(state.nonces.len(), MAX_PENDING_NONCES);
+        assert!(!state.nonces.contains_key(&0));
+        assert!(state.nonces.contains_key(&(MAX_PENDING_NONCES as u64)));
+
+        // The evicted round fails closed if the coordinator tries to use it.
+        let (code, payload) = handle(
+            &mut state,
+            "POST",
+            "/sign",
+            &serde_json::json!({ "signing_package_hex": "00", "nonce_id": "n0" }).to_string(),
+        );
+        assert_eq!(code, 400);
+        assert!(payload.contains("unknown or reused nonce_id"));
+    }
+
+    // The nonce id wire format ("n<counter>") round-trips: a parked round is
+    // consumed exactly once by /sign, and unknown or malformed ids fail closed.
+    #[test]
+    fn sign_consumes_a_parked_round_exactly_once() {
+        let mut state = test_state();
+        let (code, nonce_id) = commit(&mut state);
+        assert_eq!(code, 200);
+        assert_eq!(nonce_id, "n0");
+
+        for bad_id in ["n9", "garbage", ""] {
+            let (code, payload) = handle(
+                &mut state,
+                "POST",
+                "/sign",
+                &serde_json::json!({ "signing_package_hex": "00", "nonce_id": bad_id })
+                    .to_string(),
+            );
+            assert_eq!(code, 400, "nonce id {bad_id:?} must fail closed");
+            assert!(payload.contains("unknown or reused nonce_id"));
+        }
+
+        // The parked round is consumed on first use (here failing only on the
+        // deliberately invalid package, AFTER the nonce lookup succeeded) and
+        // cannot be replayed.
+        let (code, payload) = handle(
+            &mut state,
+            "POST",
+            "/sign",
+            &serde_json::json!({ "signing_package_hex": "00", "nonce_id": "n0" }).to_string(),
+        );
+        assert_eq!(code, 400);
+        assert!(payload.contains("bad signing_package_hex"));
+        assert!(!state.nonces.contains_key(&0));
+
+        let (code, payload) = handle(
+            &mut state,
+            "POST",
+            "/sign",
+            &serde_json::json!({ "signing_package_hex": "00", "nonce_id": "n0" }).to_string(),
+        );
+        assert_eq!(code, 400);
+        assert!(payload.contains("unknown or reused nonce_id"));
     }
 }

--- a/packages/signer-frost/sidecar/src/main.rs
+++ b/packages/signer-frost/sidecar/src/main.rs
@@ -476,9 +476,9 @@ fn arg(args: &[String], key: &str) -> Option<String> {
 
 fn validate_share_auth_token(token: String) -> Result<String, &'static str> {
     // SEC-025: an empty/short token turns the loopback bearer check into a
-    // guessable credential. Require at least 256 bits when represented as a
-    // conventional raw/hex/base64 secret. Operators should supply a randomly
-    // generated token through the environment, never through argv.
+    // guessable credential. Require a 32-byte floor and instruct operators to
+    // encode at least 32 random bytes (for example, as 64 hex characters).
+    // Supply the token through the environment, never through argv.
     if token.len() < 32
         || token
             .bytes()

--- a/packages/signer-frost/sidecar/src/main.rs
+++ b/packages/signer-frost/sidecar/src/main.rs
@@ -264,8 +264,8 @@ fn cmd_share(share_file: &str, port: u16, auth_token: String) {
                 .iter()
                 .any(|h| h.field.equiv("authorization") && h.value.as_str() == expected);
             if !authorized {
-                let response =
-                    tiny_http::Response::from_string(err_json("unauthorized")).with_status_code(401);
+                let response = tiny_http::Response::from_string(err_json("unauthorized"))
+                    .with_status_code(401);
                 let _ = request.respond(response);
                 continue;
             }
@@ -304,14 +304,19 @@ fn handle(state: &mut ShareState, method: &str, url: &str, body: &str) -> (u16, 
             // parked round instead — its /sign will fail closed with
             // "unknown or reused nonce_id", and an evicted unused nonce is
             // never signed with, so FROST nonce-reuse safety is preserved.
+            // Never wrap the wire-id counter: wrapping could alias and
+            // overwrite a still-parked nonce, violating single-use safety.
+            let nonce_id = state.next_nonce_id;
+            let Some(next_nonce_id) = nonce_id.checked_add(1) else {
+                return (503, err_json("nonce id space exhausted"));
+            };
             if state.nonces.len() >= MAX_PENDING_NONCES {
                 state.nonces.pop_first();
             }
             let mut rng = OsRng;
             let (nonces, commitments) =
                 frost::round1::commit(state.key_package.signing_share(), &mut rng);
-            let nonce_id = state.next_nonce_id;
-            state.next_nonce_id += 1;
+            state.next_nonce_id = next_nonce_id;
             state.nonces.insert(nonce_id, nonces);
             let resp = CommitResponse {
                 identifier_hex: hex::encode(state.identifier.serialize()),
@@ -358,7 +363,10 @@ fn handle(state: &mut ShareState, method: &str, url: &str, body: &str) -> (u16, 
             let nonce_key = req
                 .nonce_id
                 .strip_prefix('n')
-                .and_then(|suffix| suffix.parse::<u64>().ok());
+                .and_then(|suffix| suffix.parse::<u64>().ok())
+                // Preserve the original exact wire identity. Numeric aliases
+                // such as n01 must not be able to consume the nonce named n1.
+                .filter(|key| req.nonce_id == format!("n{key}"));
             let nonces = match nonce_key.and_then(|key| state.nonces.remove(&key)) {
                 Some(n) => n,
                 None => return (400, err_json("unknown or reused nonce_id")),
@@ -515,13 +523,9 @@ mod tests {
 
     fn test_state() -> ShareState {
         let rng = OsRng;
-        let (shares, pubkey_package) = frost::keys::generate_with_dealer(
-            2,
-            2,
-            frost::keys::IdentifierList::Default,
-            rng,
-        )
-        .expect("trusted-dealer keygen");
+        let (shares, pubkey_package) =
+            frost::keys::generate_with_dealer(2, 2, frost::keys::IdentifierList::Default, rng)
+                .expect("trusted-dealer keygen");
         let (identifier, secret_share) = shares.into_iter().next().expect("one share");
         let key_package = KeyPackage::try_from(secret_share).expect("share -> key package");
         ShareState {
@@ -586,13 +590,12 @@ mod tests {
         assert_eq!(code, 200);
         assert_eq!(nonce_id, "n0");
 
-        for bad_id in ["n9", "garbage", ""] {
+        for bad_id in ["n9", "n00", "n01", "n+1", "garbage", ""] {
             let (code, payload) = handle(
                 &mut state,
                 "POST",
                 "/sign",
-                &serde_json::json!({ "signing_package_hex": "00", "nonce_id": bad_id })
-                    .to_string(),
+                &serde_json::json!({ "signing_package_hex": "00", "nonce_id": bad_id }).to_string(),
             );
             assert_eq!(code, 400, "nonce id {bad_id:?} must fail closed");
             assert!(payload.contains("unknown or reused nonce_id"));
@@ -619,5 +622,19 @@ mod tests {
         );
         assert_eq!(code, 400);
         assert!(payload.contains("unknown or reused nonce_id"));
+    }
+
+    #[test]
+    fn commit_fails_closed_before_nonce_counter_overflow() {
+        let mut state = test_state();
+        state.next_nonce_id = u64::MAX;
+        let before = state.nonces.len();
+
+        let (code, payload) = handle(&mut state, "POST", "/commit", "");
+
+        assert_eq!(code, 503);
+        assert!(payload.contains("nonce id space exhausted"));
+        assert_eq!(state.next_nonce_id, u64::MAX);
+        assert_eq!(state.nonces.len(), before);
     }
 }

--- a/packages/signer-frost/sidecar/src/main.rs
+++ b/packages/signer-frost/sidecar/src/main.rs
@@ -9,15 +9,17 @@
 //!           Trusted-dealer keygen. Writes DIR/group.json (public) and
 //!           DIR/share-<id>.json (secret share per participant).
 //!
-//!   share   --share-file FILE --port P [--auth-token TOKEN]
+//!   share   --share-file FILE --port P
 //!           Runs an HTTP service holding ONE secret share. Endpoints:
 //!             GET  /health
 //!             POST /commit  { }                      -> round1 commitments (public)
 //!             POST /sign    { signing_package, nonces_id } -> round2 sig share
 //!           The share never leaves this process.
 //!           Every endpoint except GET /health requires
-//!           `Authorization: Bearer TOKEN` (flag or FROST_SHARE_AUTH_TOKEN);
-//!           the service refuses to start without one (SEC-025). Shares must
+//!           `Authorization: Bearer TOKEN` (`FROST_SHARE_AUTH_TOKEN`);
+//!           the service refuses to start without a strong token (SEC-025).
+//!           Tokens are not accepted on the command line because process
+//!           arguments are commonly visible to other local users. Shares must
 //!           never share a network namespace with untrusted code.
 //!
 //!   aggregate (offline helper for tests) reads a signing package + shares from
@@ -472,6 +474,21 @@ fn arg(args: &[String], key: &str) -> Option<String> {
         .cloned()
 }
 
+fn validate_share_auth_token(token: String) -> Result<String, &'static str> {
+    // SEC-025: an empty/short token turns the loopback bearer check into a
+    // guessable credential. Require at least 256 bits when represented as a
+    // conventional raw/hex/base64 secret. Operators should supply a randomly
+    // generated token through the environment, never through argv.
+    if token.len() < 32
+        || token
+            .bytes()
+            .any(|byte| byte.is_ascii_whitespace() || byte.is_ascii_control())
+    {
+        return Err("FROST_SHARE_AUTH_TOKEN must contain at least 32 non-whitespace bytes");
+    }
+    Ok(token)
+}
+
 fn main() {
     let args: Vec<String> = std::env::args().collect();
     let cmd = args.get(1).map(String::as_str).unwrap_or("");
@@ -495,15 +512,14 @@ fn main() {
                 .expect("--port required")
                 .parse()
                 .expect("port");
-            // SEC-025: the share service refuses to run unauthenticated —
-            // require a per-share bearer token via flag or environment.
-            let auth_token = arg(&args, "--auth-token")
-                .or_else(|| std::env::var("FROST_SHARE_AUTH_TOKEN").ok())
-                .unwrap_or_else(|| {
-                    eprintln!(
-                        "--auth-token or FROST_SHARE_AUTH_TOKEN is required: \
-                         the share service refuses to run unauthenticated"
-                    );
+            // SEC-025: require a strong per-share bearer token via the
+            // environment. Command-line tokens are intentionally unsupported:
+            // argv is commonly exposed by process inspection tools.
+            let auth_token = std::env::var("FROST_SHARE_AUTH_TOKEN")
+                .map_err(|_| "FROST_SHARE_AUTH_TOKEN is required")
+                .and_then(validate_share_auth_token)
+                .unwrap_or_else(|message| {
+                    eprintln!("{message}: the share service refuses to run unauthenticated");
                     std::process::exit(2);
                 });
             cmd_share(&share_file, port, auth_token);
@@ -636,5 +652,14 @@ mod tests {
         assert!(payload.contains("nonce id space exhausted"));
         assert_eq!(state.next_nonce_id, u64::MAX);
         assert_eq!(state.nonces.len(), before);
+    }
+
+    #[test]
+    fn share_auth_token_rejects_missing_strength() {
+        for weak in ["", "short", "                                "] {
+            assert!(validate_share_auth_token(weak.to_string()).is_err());
+        }
+        let strong = "0123456789abcdef0123456789abcdef".to_string();
+        assert_eq!(validate_share_auth_token(strong.clone()), Ok(strong));
     }
 }

--- a/packages/signer-frost/src/__tests__/harness.ts
+++ b/packages/signer-frost/src/__tests__/harness.ts
@@ -8,6 +8,7 @@
  */
 
 import { spawn, spawnSync } from "node:child_process";
+import { randomBytes } from "node:crypto";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -93,14 +94,11 @@ export async function startFrostCluster(threshold = 2, participants = 3): Promis
 
   for (let i = 0; i < participants; i++) {
     const port = port0 + i;
-    const authToken = `test-share-token-${port0}-${i}`;
-    const p = spawn(
-      BIN,
-      ["share", "--share-file", shareFiles[i], "--port", String(port), "--auth-token", authToken],
-      {
-        stdio: "ignore",
-      },
-    );
+    const authToken = randomBytes(32).toString("hex");
+    const p = spawn(BIN, ["share", "--share-file", shareFiles[i], "--port", String(port)], {
+      stdio: "ignore",
+      env: { ...process.env, FROST_SHARE_AUTH_TOKEN: authToken },
+    });
     procs.push(p);
     endpoints.push(`http://127.0.0.1:${port}`);
     authTokens.push(authToken);

--- a/packages/vault/src/__tests__/external-key-custody.test.ts
+++ b/packages/vault/src/__tests__/external-key-custody.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeEach, describe, expect, setDefaultTimeout, test } from 
 import { agentWallets, encryptedChainKeys, eq, getDb, tenants, transactions } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { and } from "drizzle-orm";
+import { generatePrivateKey } from "viem/accounts";
 import type {
   ExternalKeyCustodyProvider,
   ExternalKeyHandleImportRequest,
@@ -687,6 +688,102 @@ describe("external key custody seam", () => {
       .from(transactions)
       .where(eq(transactions.id, "toctou-mismatch-1"));
     expect(rows).toHaveLength(0);
+  });
+
+  test("fails closed when an external-custody-bound sign re-resolves to the legacy encrypted_keys fallback", async () => {
+    const provider = new TestExternalKeyProvider("provider-signing", async () => {
+      // If this ever runs, the guard failed: an external-custody-bound
+      // authorization fell through to local key material.
+      throw new Error("provider must not be reached for a legacy-fallback sign");
+    });
+    vault = await freshVault(provider);
+    const legacyPrivateKey = generatePrivateKey();
+    await vault.importKey(TENANT_ID, "agent-legacy", legacyPrivateKey, "evm");
+    // Simulate a pre-multi-chain legacy agent: the EVM key lives ONLY in the
+    // legacy encrypted_keys table (no encrypted_chain_keys / agent_wallets).
+    await getDb()
+      .delete(encryptedChainKeys)
+      .where(
+        and(
+          eq(encryptedChainKeys.agentId, "agent-legacy"),
+          eq(encryptedChainKeys.chainFamily, "evm"),
+        ),
+      );
+    await getDb()
+      .delete(agentWallets)
+      .where(
+        and(eq(agentWallets.agentId, "agent-legacy"), eq(agentWallets.chainFamily, "evm")),
+      );
+
+    let error: unknown;
+    try {
+      await vault.signTransaction(
+        {
+          tenantId: TENANT_ID,
+          agentId: "agent-legacy",
+          chainId: 8453,
+          to: "0x2222222222222222222222222222222222222222",
+          value: "1",
+          data: "0x",
+          broadcast: false,
+        },
+        { txId: "toctou-legacy-fallback-1", expectedBackend: "external-custody" },
+      );
+    } catch (err) {
+      error = err;
+    }
+
+    expect(error).toBeInstanceOf(BackendBindingMismatchError);
+    expect((error as BackendBindingMismatchError).code).toBe("backend_binding_mismatch");
+    expect((error as BackendBindingMismatchError).expectedBackend).toBe("external-custody");
+    expect((error as BackendBindingMismatchError).resolvedBackend).toBe("local-vault");
+    // The provider signer was NEVER invoked.
+    expect(provider.signCalls).toHaveLength(0);
+
+    // No transaction row was written for the refused sign.
+    const rows = await getDb()
+      .select()
+      .from(transactions)
+      .where(eq(transactions.id, "toctou-legacy-fallback-1"));
+    expect(rows).toHaveLength(0);
+  });
+
+  test("a local-vault-bound sign still reaches the legacy encrypted_keys fallback", async () => {
+    vault = await freshVault();
+    const legacyPrivateKey = generatePrivateKey();
+    await vault.importKey(TENANT_ID, "agent-legacy", legacyPrivateKey, "evm");
+    await getDb()
+      .delete(encryptedChainKeys)
+      .where(
+        and(
+          eq(encryptedChainKeys.agentId, "agent-legacy"),
+          eq(encryptedChainKeys.chainFamily, "evm"),
+        ),
+      );
+    await getDb()
+      .delete(agentWallets)
+      .where(
+        and(eq(agentWallets.agentId, "agent-legacy"), eq(agentWallets.chainFamily, "evm")),
+      );
+
+    // The new guard must let local-vault-bound callers through: the request
+    // gets past custody resolution, decrypts the legacy key, and fails only at
+    // the deterministic address check (deliberately mismatched, so no RPC).
+    await expect(
+      vault.signTransaction(
+        {
+          tenantId: TENANT_ID,
+          agentId: "agent-legacy",
+          chainId: 8453,
+          to: "0x2222222222222222222222222222222222222222",
+          value: "1",
+          data: "0x",
+          walletAddress: "0x3333333333333333333333333333333333333333",
+          broadcast: false,
+        },
+        { txId: "toctou-legacy-fallback-2", expectedBackend: "local-vault" },
+      ),
+    ).rejects.toThrow(/Wallet address mismatch/);
   });
 
   test("blocks external custody before the provider when the caller has no backend binding", async () => {

--- a/packages/vault/src/__tests__/external-key-custody.test.ts
+++ b/packages/vault/src/__tests__/external-key-custody.test.ts
@@ -711,9 +711,7 @@ describe("external key custody seam", () => {
       );
     await getDb()
       .delete(agentWallets)
-      .where(
-        and(eq(agentWallets.agentId, "agent-legacy"), eq(agentWallets.chainFamily, "evm")),
-      );
+      .where(and(eq(agentWallets.agentId, "agent-legacy"), eq(agentWallets.chainFamily, "evm")));
 
     let error: unknown;
     try {
@@ -762,9 +760,7 @@ describe("external key custody seam", () => {
       );
     await getDb()
       .delete(agentWallets)
-      .where(
-        and(eq(agentWallets.agentId, "agent-legacy"), eq(agentWallets.chainFamily, "evm")),
-      );
+      .where(and(eq(agentWallets.agentId, "agent-legacy"), eq(agentWallets.chainFamily, "evm")));
 
     // The new guard must let local-vault-bound callers through: the request
     // gets past custody resolution, decrypts the legacy key, and fails only at

--- a/packages/vault/src/__tests__/import-key-custody.test.ts
+++ b/packages/vault/src/__tests__/import-key-custody.test.ts
@@ -9,6 +9,8 @@
 // custody while the metadata kept claiming external custody.
 
 import { afterAll, beforeEach, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { Keypair } from "@solana/web3.js";
 import {
   agentWallets,
@@ -22,6 +24,11 @@ import {
 } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { generatePrivateKey } from "viem/accounts";
+import type {
+  ExternalKeyCustodyProvider,
+  ExternalKeyHandleImportRequest,
+  ExternalKeyHandleRegistration,
+} from "../external-key-custody";
 import { Vault } from "../vault";
 
 setDefaultTimeout(30000);
@@ -31,7 +38,7 @@ const TENANT_ID = "import-tenant";
 
 const openClients: Array<{ close: () => Promise<void> }> = [];
 
-async function freshVault(): Promise<Vault> {
+async function freshVault(provider?: ExternalKeyCustodyProvider): Promise<Vault> {
   const { db, client } = await createPGLiteDb("memory://");
   openClients.push(client);
   setPGLiteOverride(db as never, async () => {
@@ -44,11 +51,35 @@ async function freshVault(): Promise<Vault> {
     apiKeyHash: "import-hash",
   });
 
-  return new Vault({ masterPassword: MASTER_PASSWORD });
+  return new Vault({ masterPassword: MASTER_PASSWORD, externalKeyCustodyProvider: provider });
 }
 
 function solanaKeyHex(): string {
   return Buffer.from(Keypair.generate().secretKey).toString("hex");
+}
+
+class RaceTestProvider implements ExternalKeyCustodyProvider {
+  id = "race-test-provider";
+  readonly contractVersion = 1 as const;
+
+  async registerKeyHandle(
+    request: ExternalKeyHandleImportRequest,
+  ): Promise<ExternalKeyHandleRegistration> {
+    return {
+      custody: "external",
+      tenantId: request.tenantId,
+      agentId: request.agentId,
+      chainFamily: request.chainFamily,
+      address: request.address,
+      handle: request.handle,
+      venue: request.venue ?? null,
+      purpose: request.purpose ?? null,
+      metadata: request.metadata ?? {},
+      registeredAt: new Date("2026-06-05T00:00:00.000Z"),
+      exportablePrivateKey: false,
+      signingAvailability: "not-supported",
+    };
+  }
 }
 
 describe("Vault.importKey custody hardening", () => {
@@ -191,5 +222,106 @@ describe("Vault.importKey custody hardening", () => {
     await expect(vault.importKey(TENANT_ID, agentId, solanaKeyHex(), "solana")).rejects.toThrow(
       /external-custody/,
     );
+  });
+
+  // Re-audit: the importKey / importExternalKeyHandle custody guards were
+  // check-then-act with no DB-level serialization — two concurrent admin
+  // custody ops for the same scope could interleave and BOTH commit, leaving
+  // a server-managed key shadowing an external-custody wallet. The guards now
+  // run inside a per-scope advisory-locked transaction, so exactly one
+  // transition can commit and the loser fails closed.
+  test("concurrent importKey and importExternalKeyHandle cannot both win a custody transition", async () => {
+    vault = await freshVault(new RaceTestProvider());
+    const agentId = "race-agent";
+    await vault.createAgent(TENANT_ID, agentId, "Race Agent");
+    // Bare agent: strip the server-managed rows createAgent provisioned so
+    // both custody transitions start from an empty (evm, venue-less) scope.
+    await getDb()
+      .delete(encryptedChainKeys)
+      .where(
+        and(eq(encryptedChainKeys.agentId, agentId), eq(encryptedChainKeys.chainFamily, "evm")),
+      );
+    await getDb()
+      .delete(agentWallets)
+      .where(and(eq(agentWallets.agentId, agentId), eq(agentWallets.chainFamily, "evm")));
+
+    const results = await Promise.allSettled([
+      vault.importKey(TENANT_ID, agentId, generatePrivateKey(), "evm"),
+      vault.importExternalKeyHandle({
+        tenantId: TENANT_ID,
+        agentId,
+        chainFamily: "evm",
+        address: "0x1111111111111111111111111111111111111111",
+        handle: { providerId: "race-hsm", keyId: "key-1" },
+      }),
+    ]);
+
+    // Exactly one custody transition may commit; the loser must fail closed.
+    expect(results.filter((r) => r.status === "fulfilled")).toHaveLength(1);
+    expect(results.filter((r) => r.status === "rejected")).toHaveLength(1);
+
+    // Final state must be consistent: never both a server-managed key AND an
+    // external-custody wallet row in the same scope.
+    const [chainKey] = await getDb()
+      .select({ id: encryptedChainKeys.id })
+      .from(encryptedChainKeys)
+      .where(
+        and(
+          eq(encryptedChainKeys.agentId, agentId),
+          eq(encryptedChainKeys.chainFamily, "evm"),
+          isNull(encryptedChainKeys.venue),
+        ),
+      );
+    const [wallet] = await getDb()
+      .select({ metadata: agentWallets.metadata })
+      .from(agentWallets)
+      .where(
+        and(
+          eq(agentWallets.agentId, agentId),
+          eq(agentWallets.chainFamily, "evm"),
+          isNull(agentWallets.venue),
+        ),
+      );
+    const walletIsExternal =
+      wallet?.metadata != null &&
+      typeof wallet.metadata === "object" &&
+      (wallet.metadata as Record<string, unknown>).custody === "external";
+    expect(chainKey != null && walletIsExternal).toBe(false);
+  });
+
+  // Structural guard (PGlite serializes transactions, so the lock itself is
+  // exercised but cannot interleave here): both custody transitions must take
+  // the advisory lock INSIDE their transaction, before any custody check or
+  // write, and the provider call must stay outside the lock.
+  test("custody transitions lock before their guards (source structure)", () => {
+    const source = readFileSync(join(import.meta.dir, "..", "vault.ts"), "utf8");
+
+    const importKeyBody = source.slice(
+      source.indexOf("async importKey("),
+      source.indexOf("async importExternalKeyHandle("),
+    );
+    const ikTx = importKeyBody.indexOf("await db.transaction(");
+    const ikLock = importKeyBody.indexOf("pg_advisory_xact_lock");
+    const ikGuard = importKeyBody.indexOf("isExternalKeyWalletMetadata(externalWallet.metadata)");
+    expect(ikTx).toBeGreaterThanOrEqual(0);
+    expect(ikLock).toBeGreaterThan(ikTx);
+    expect(ikGuard).toBeGreaterThan(ikLock);
+    expect(importKeyBody).toContain("custodyTransitionLockKey(agentId, chainType, null)");
+
+    const importExternalBody = source.slice(
+      source.indexOf("async importExternalKeyHandle("),
+      source.indexOf("async registerExternalKeyHandle("),
+    );
+    const ieTx = importExternalBody.indexOf("await db.transaction(");
+    const ieLock = importExternalBody.indexOf("pg_advisory_xact_lock");
+    const ieGuard = importExternalBody.indexOf("over a server-managed signing key");
+    const ieWrite = importExternalBody.indexOf(".insert(agentWallets)");
+    const ieProvider = importExternalBody.indexOf("registerKeyHandle(request)");
+    expect(ieTx).toBeGreaterThanOrEqual(0);
+    expect(ieLock).toBeGreaterThan(ieTx);
+    expect(ieGuard).toBeGreaterThan(ieLock);
+    expect(ieWrite).toBeGreaterThan(ieLock);
+    expect(ieProvider).toBeGreaterThanOrEqual(0);
+    expect(ieProvider).toBeLessThan(ieTx);
   });
 });

--- a/packages/vault/src/__tests__/import-key-custody.test.ts
+++ b/packages/vault/src/__tests__/import-key-custody.test.ts
@@ -61,10 +61,12 @@ function solanaKeyHex(): string {
 class RaceTestProvider implements ExternalKeyCustodyProvider {
   id = "race-test-provider";
   readonly contractVersion = 1 as const;
+  registrationCalls = 0;
 
   async registerKeyHandle(
     request: ExternalKeyHandleImportRequest,
   ): Promise<ExternalKeyHandleRegistration> {
+    this.registrationCalls += 1;
     return {
       custody: "external",
       tenantId: request.tenantId,
@@ -289,6 +291,27 @@ describe("Vault.importKey custody hardening", () => {
     expect(chainKey != null && walletIsExternal).toBe(false);
   });
 
+  test("rejects known local-custody conflicts before contacting the external provider", async () => {
+    const provider = new RaceTestProvider();
+    vault = await freshVault(provider);
+    const agentId = "provider-precheck-agent";
+    await vault.createAgent(TENANT_ID, agentId, "Provider Precheck Agent");
+    // Exercise the multi-chain-key fast-fail specifically, not the older
+    // legacy-key precheck. The local encrypted_chain_keys/wallet rows remain.
+    await getDb().delete(encryptedKeys).where(eq(encryptedKeys.agentId, agentId));
+
+    await expect(
+      vault.importExternalKeyHandle({
+        tenantId: TENANT_ID,
+        agentId,
+        chainFamily: "evm",
+        address: "0x1111111111111111111111111111111111111111",
+        handle: { providerId: "race-hsm", keyId: "must-not-be-disclosed" },
+      }),
+    ).rejects.toThrow(/server-managed/);
+    expect(provider.registrationCalls).toBe(0);
+  });
+
   // Structural guard (PGlite serializes transactions, so the lock itself is
   // exercised but cannot interleave here): both custody transitions must take
   // the advisory lock INSIDE their transaction, before any custody check or
@@ -306,7 +329,8 @@ describe("Vault.importKey custody hardening", () => {
     expect(ikTx).toBeGreaterThanOrEqual(0);
     expect(ikLock).toBeGreaterThan(ikTx);
     expect(ikGuard).toBeGreaterThan(ikLock);
-    expect(importKeyBody).toContain("custodyTransitionLockKey(agentId, chainType, null)");
+    expect(importKeyBody).toContain("custodyTransitionLockKey(tenantId, agentId, chainType, null)");
+    expect(importKeyBody).toContain("hashtextextended");
 
     const importExternalBody = source.slice(
       source.indexOf("async importExternalKeyHandle("),
@@ -314,7 +338,7 @@ describe("Vault.importKey custody hardening", () => {
     );
     const ieTx = importExternalBody.indexOf("await db.transaction(");
     const ieLock = importExternalBody.indexOf("pg_advisory_xact_lock");
-    const ieGuard = importExternalBody.indexOf("over a server-managed signing key");
+    const ieGuard = importExternalBody.indexOf("over a server-managed signing key", ieLock);
     const ieWrite = importExternalBody.indexOf(".insert(agentWallets)");
     const ieProvider = importExternalBody.indexOf("registerKeyHandle(request)");
     expect(ieTx).toBeGreaterThanOrEqual(0);
@@ -323,5 +347,6 @@ describe("Vault.importKey custody hardening", () => {
     expect(ieWrite).toBeGreaterThan(ieLock);
     expect(ieProvider).toBeGreaterThanOrEqual(0);
     expect(ieProvider).toBeLessThan(ieTx);
+    expect(importExternalBody).toContain("hashtextextended");
   });
 });

--- a/packages/vault/src/__tests__/mnemonic-restore.test.ts
+++ b/packages/vault/src/__tests__/mnemonic-restore.test.ts
@@ -1,5 +1,14 @@
 import { afterAll, beforeEach, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { agents, encryptedChainKeys, encryptedKeys, getDb, tenants } from "@stwd/db";
+import {
+  agents,
+  agentWallets,
+  and,
+  encryptedChainKeys,
+  encryptedKeys,
+  getDb,
+  isNull,
+  tenants,
+} from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { eq } from "drizzle-orm";
 import { Vault } from "../vault";
@@ -155,5 +164,58 @@ describe("Vault mnemonic restore", () => {
         { walletType: "recoverable_user" },
       ),
     ).rejects.toThrow(/does not match/);
+  });
+
+  test("refuses to restore local keys over an external-custody wallet", async () => {
+    const agentId = "external-recoverable-agent";
+    await vault.createAgentFromMnemonic(
+      TENANT_ID,
+      agentId,
+      "External Recoverable Agent",
+      TEST_MNEMONIC,
+      { walletType: "recoverable_user" },
+    );
+    await getDb().delete(encryptedKeys).where(eq(encryptedKeys.agentId, agentId));
+    await getDb().delete(encryptedChainKeys).where(eq(encryptedChainKeys.agentId, agentId));
+    await getDb()
+      .update(agentWallets)
+      .set({
+        metadata: {
+          custody: "external",
+          externalKey: {
+            providerId: "test-hsm",
+            keyId: "recoverable-key",
+            registeredAt: new Date().toISOString(),
+            exportablePrivateKey: false,
+            signingAvailability: "provider-signing",
+          },
+        },
+      })
+      .where(
+        and(
+          eq(agentWallets.agentId, agentId),
+          eq(agentWallets.chainFamily, "evm"),
+          isNull(agentWallets.venue),
+        ),
+      );
+
+    await expect(
+      vault.restoreAgentFromMnemonic(
+        TENANT_ID,
+        agentId,
+        "External Recoverable Agent",
+        TEST_MNEMONIC,
+        { walletType: "recoverable_user" },
+      ),
+    ).rejects.toThrow(/external-custody/);
+    expect(
+      await getDb().select().from(encryptedKeys).where(eq(encryptedKeys.agentId, agentId)),
+    ).toHaveLength(0);
+    expect(
+      await getDb()
+        .select()
+        .from(encryptedChainKeys)
+        .where(eq(encryptedChainKeys.agentId, agentId)),
+    ).toHaveLength(0);
   });
 });

--- a/packages/vault/src/vault.ts
+++ b/packages/vault/src/vault.ts
@@ -510,6 +510,29 @@ export class BackendBindingMismatchError extends Error {
   }
 }
 
+/**
+ * Lock scope for custody-affecting writes (importKey / importExternalKeyHandle):
+ * one (agent, chain family, venue) tuple. importKey always operates on the
+ * venue-less scope, matching the legacy/unscoped key rows it writes.
+ */
+function custodyTransitionLockKey(
+  agentId: string,
+  chainFamily: string,
+  venue: string | null,
+): string {
+  return `vault-custody:${agentId}:${chainFamily}:${venue ?? ""}`;
+}
+
+/**
+ * PGlite (tests, desktop mode) is a single-connection harness where
+ * transactions already serialize; the repo convention is to skip advisory
+ * locks there. Production Postgres takes the xact lock so concurrent custody
+ * transitions across replicas/connections cannot interleave check-then-act.
+ */
+function usesCustodyAdvisoryLock(): boolean {
+  return process.env.STEWARD_DB_MODE !== "pglite" && process.env.STEWARD_PGLITE_MEMORY !== "true";
+}
+
 interface MnemonicWalletMaterial {
   evmPrivateKey: `0x${string}`;
   evmAddress: string;
@@ -2071,28 +2094,42 @@ export class Vault {
       .from(agents)
       .where(and(eq(agents.id, agentId), eq(agents.tenantId, tenantId)));
 
-    // SEC-024: refuse to silently convert an external-custody wallet back to
-    // server custody — the reverse guard of importExternalKeyHandle. A local
-    // chain key here would shadow the HSM on every future sign while the DB
-    // still claims external custody.
-    const [externalWallet] = await db
-      .select({ metadata: agentWallets.metadata })
-      .from(agentWallets)
-      .where(
-        and(
-          eq(agentWallets.agentId, agentId),
-          eq(agentWallets.chainFamily, chainType),
-          isNull(agentWallets.venue),
-        ),
-      );
-    if (externalWallet && isExternalKeyWalletMetadata(externalWallet.metadata)) {
-      throw new Error(
-        `Cannot import a server-managed key over the external-custody ${chainType} wallet of agent ${agentId}`,
-      );
-    }
-
     // Wrap all writes atomically - roll back on any failure
     await db.transaction(async (tx) => {
+      // Re-audit: the SEC-024 custody guard below used to run BEFORE this
+      // transaction — check-then-act with no DB serialization. A concurrent
+      // importExternalKeyHandle for the same (agent, chain family) could
+      // interleave between the check and these writes, leaving both a
+      // server-managed key and an external-custody wallet row. Serialize
+      // custody transitions per scope and run the guard INSIDE the lock so
+      // the interleave fails closed. Skipped on single-connection PGlite,
+      // where transactions already serialize.
+      if (usesCustodyAdvisoryLock()) {
+        await tx.execute(
+          sql`select pg_advisory_xact_lock(hashtext(${custodyTransitionLockKey(agentId, chainType, null)}))`,
+        );
+      }
+
+      // SEC-024: refuse to silently convert an external-custody wallet back to
+      // server custody — the reverse guard of importExternalKeyHandle. A local
+      // chain key here would shadow the HSM on every future sign while the DB
+      // still claims external custody.
+      const [externalWallet] = await tx
+        .select({ metadata: agentWallets.metadata })
+        .from(agentWallets)
+        .where(
+          and(
+            eq(agentWallets.agentId, agentId),
+            eq(agentWallets.chainFamily, chainType),
+            isNull(agentWallets.venue),
+          ),
+        );
+      if (externalWallet && isExternalKeyWalletMetadata(externalWallet.metadata)) {
+        throw new Error(
+          `Cannot import a server-managed key over the external-custody ${chainType} wallet of agent ${agentId}`,
+        );
+      }
+
       if (existingAgent) {
         // Update wallet address and replace encrypted key
         await tx
@@ -2220,6 +2257,8 @@ export class Vault {
       throw new Error(`Agent ${request.agentId} not found for tenant ${request.tenantId}`);
     }
 
+    // Fast-fail before the provider round-trip on the common rejection; the
+    // authoritative re-check happens inside the locked transaction below.
     if (!request.venue && detectChainType(agentRow.walletAddress) === request.chainFamily) {
       const [legacyKey] = await db
         .select({ agentId: encryptedKeys.agentId })
@@ -2230,6 +2269,9 @@ export class Vault {
       }
     }
 
+    // Provider registration is read-only public-handle validation (no custody
+    // state changes) and stays OUTSIDE the lock: network I/O must never hold
+    // a transaction-scoped advisory lock.
     const registration = normalizeExternalKeyHandleRegistration(
       request,
       await this.externalKeyCustodyProvider.registerKeyHandle(request),
@@ -2238,54 +2280,80 @@ export class Vault {
     const venue = request.venue ?? null;
     const now = new Date();
 
-    const [existingEncryptedKey] = await db
-      .select({ id: encryptedChainKeys.id })
-      .from(encryptedChainKeys)
-      .where(
-        and(
-          eq(encryptedChainKeys.agentId, request.agentId),
-          eq(encryptedChainKeys.chainFamily, request.chainFamily),
-          venue ? eq(encryptedChainKeys.venue, venue) : isNull(encryptedChainKeys.venue),
-        ),
-      );
-    if (existingEncryptedKey) {
-      throw new Error("Cannot register external key handle over a server-managed signing key");
-    }
+    await db.transaction(async (tx) => {
+      // Re-audit: the custody guards below were check-then-act with no DB
+      // serialization — a concurrent importKey (or a second handle import)
+      // for the same (agent, chain family, venue) scope could interleave
+      // between the checks and the wallet write, leaving both a
+      // server-managed key and an external-custody wallet row. Serialize
+      // custody transitions per scope and run every guard INSIDE the lock so
+      // the interleave fails closed. Skipped on single-connection PGlite,
+      // where transactions already serialize.
+      if (usesCustodyAdvisoryLock()) {
+        await tx.execute(
+          sql`select pg_advisory_xact_lock(hashtext(${custodyTransitionLockKey(request.agentId, request.chainFamily, venue)}))`,
+        );
+      }
 
-    const [existingWallet] = await db
-      .select({ id: agentWallets.id, metadata: agentWallets.metadata })
-      .from(agentWallets)
-      .where(
-        and(
-          eq(agentWallets.agentId, request.agentId),
-          eq(agentWallets.chainFamily, request.chainFamily),
-          venue ? eq(agentWallets.venue, venue) : isNull(agentWallets.venue),
-        ),
-      );
-    if (existingWallet && !isExternalKeyWalletMetadata(existingWallet.metadata)) {
-      throw new Error("Cannot register external key handle over a server-managed wallet");
-    }
+      if (!venue && detectChainType(agentRow.walletAddress) === request.chainFamily) {
+        const [legacyKey] = await tx
+          .select({ agentId: encryptedKeys.agentId })
+          .from(encryptedKeys)
+          .where(eq(encryptedKeys.agentId, request.agentId));
+        if (legacyKey) {
+          throw new Error("Cannot register external key handle over a legacy server-managed key");
+        }
+      }
 
-    if (existingWallet) {
-      await db
-        .update(agentWallets)
-        .set({
-          address: registration.address,
+      const [existingEncryptedKey] = await tx
+        .select({ id: encryptedChainKeys.id })
+        .from(encryptedChainKeys)
+        .where(
+          and(
+            eq(encryptedChainKeys.agentId, request.agentId),
+            eq(encryptedChainKeys.chainFamily, request.chainFamily),
+            venue ? eq(encryptedChainKeys.venue, venue) : isNull(encryptedChainKeys.venue),
+          ),
+        );
+      if (existingEncryptedKey) {
+        throw new Error("Cannot register external key handle over a server-managed signing key");
+      }
+
+      const [existingWallet] = await tx
+        .select({ id: agentWallets.id, metadata: agentWallets.metadata })
+        .from(agentWallets)
+        .where(
+          and(
+            eq(agentWallets.agentId, request.agentId),
+            eq(agentWallets.chainFamily, request.chainFamily),
+            venue ? eq(agentWallets.venue, venue) : isNull(agentWallets.venue),
+          ),
+        );
+      if (existingWallet && !isExternalKeyWalletMetadata(existingWallet.metadata)) {
+        throw new Error("Cannot register external key handle over a server-managed wallet");
+      }
+
+      if (existingWallet) {
+        await tx
+          .update(agentWallets)
+          .set({
+            address: registration.address,
+            purpose: registration.purpose,
+            metadata,
+          })
+          .where(eq(agentWallets.id, existingWallet.id));
+      } else {
+        await tx.insert(agentWallets).values({
+          agentId: registration.agentId,
+          chainFamily: registration.chainFamily,
+          venue,
           purpose: registration.purpose,
+          address: registration.address,
           metadata,
-        })
-        .where(eq(agentWallets.id, existingWallet.id));
-    } else {
-      await db.insert(agentWallets).values({
-        agentId: registration.agentId,
-        chainFamily: registration.chainFamily,
-        venue,
-        purpose: registration.purpose,
-        address: registration.address,
-        metadata,
-        createdAt: now,
-      });
-    }
+          createdAt: now,
+        });
+      }
+    });
 
     return registration;
   }

--- a/packages/vault/src/vault.ts
+++ b/packages/vault/src/vault.ts
@@ -1241,6 +1241,16 @@ export class Vault {
       (wallet) => wallet.chainFamily === "solana" && wallet.venue === null,
     );
 
+    // A recovery phrase proves the local key identity, but it does not grant
+    // permission to silently switch a wallet that is explicitly routed to an
+    // external custodian back to server-managed custody.
+    if (
+      (evmWallet && isExternalKeyWalletMetadata(evmWallet.metadata)) ||
+      (solanaWallet && isExternalKeyWalletMetadata(solanaWallet.metadata))
+    ) {
+      throw new Error("Cannot restore local mnemonic keys over an external-custody wallet");
+    }
+
     if (existingAgent.walletAddress.toLowerCase() !== material.evmAddress.toLowerCase()) {
       throw new Error("Mnemonic does not match the existing wallet identity");
     }
@@ -1266,6 +1276,31 @@ export class Vault {
     const now = new Date();
 
     await db.transaction(async (tx) => {
+      // Restore writes both venue-less key families. Join the same
+      // custody-transition fence as importKey/importExternalKeyHandle in a
+      // deterministic order, then repeat the guard under the locks so a
+      // concurrent handle import cannot commit between the check and writes.
+      if (usesCustodyAdvisoryLock()) {
+        for (const family of ["evm", "solana"] as const) {
+          await tx.execute(
+            sql`select pg_advisory_xact_lock(hashtextextended(${custodyTransitionLockKey(tenantId, agentId, family, null)}, 0))`,
+          );
+        }
+      }
+      const lockedWallets = await tx
+        .select({ metadata: agentWallets.metadata })
+        .from(agentWallets)
+        .where(
+          and(
+            eq(agentWallets.agentId, agentId),
+            inArray(agentWallets.chainFamily, ["evm", "solana"]),
+            isNull(agentWallets.venue),
+          ),
+        );
+      if (lockedWallets.some((wallet) => isExternalKeyWalletMetadata(wallet.metadata))) {
+        throw new Error("Cannot restore local mnemonic keys over an external-custody wallet");
+      }
+
       await tx
         .update(agents)
         .set({

--- a/packages/vault/src/vault.ts
+++ b/packages/vault/src/vault.ts
@@ -1698,7 +1698,15 @@ export class Vault {
       if (venue) {
         throw missingSigningKeyError(request.agentId, chainFamilyToUse, venue);
       }
-      // Fallback: legacy encrypted_keys table (EVM only)
+      // Fallback: legacy encrypted_keys table (EVM only).
+      // Same backend-binding guard as the encryptedChainKeys branch above:
+      // an external-custody-bound authorization must never fall through to
+      // local key material — if the wallet flipped custody after the gateway
+      // precheck, signing with a stale legacy key would bypass the bound
+      // provider. Fail closed before reading any key material.
+      if (options.expectedBackend === "external-custody") {
+        throw new BackendBindingMismatchError("external-custody", "local-vault");
+      }
       const [legacyKey] = await db
         .select()
         .from(encryptedKeys)

--- a/packages/vault/src/vault.ts
+++ b/packages/vault/src/vault.ts
@@ -516,11 +516,15 @@ export class BackendBindingMismatchError extends Error {
  * venue-less scope, matching the legacy/unscoped key rows it writes.
  */
 function custodyTransitionLockKey(
+  tenantId: string,
   agentId: string,
   chainFamily: string,
   venue: string | null,
 ): string {
-  return `vault-custody:${agentId}:${chainFamily}:${venue ?? ""}`;
+  // JSON array encoding preserves tuple boundaries even when operator-defined
+  // ids/venues contain colons. Include tenant identity explicitly rather than
+  // relying on the current globally-unique agent-id schema forever.
+  return JSON.stringify(["vault-custody-v1", tenantId, agentId, chainFamily, venue]);
 }
 
 /**
@@ -2106,7 +2110,7 @@ export class Vault {
       // where transactions already serialize.
       if (usesCustodyAdvisoryLock()) {
         await tx.execute(
-          sql`select pg_advisory_xact_lock(hashtext(${custodyTransitionLockKey(agentId, chainType, null)}))`,
+          sql`select pg_advisory_xact_lock(hashtextextended(${custodyTransitionLockKey(tenantId, agentId, chainType, null)}, 0))`,
         );
       }
 
@@ -2269,6 +2273,37 @@ export class Vault {
       }
     }
 
+    // Non-authoritative fast-fail checks keep a request that is already known
+    // to conflict with local custody from reaching the external provider. All
+    // checks are repeated under the transaction-scoped lock below because a
+    // concurrent writer can change them after this read.
+    const venue = request.venue ?? null;
+    const scope = and(
+      eq(encryptedChainKeys.agentId, request.agentId),
+      eq(encryptedChainKeys.chainFamily, request.chainFamily),
+      venue ? eq(encryptedChainKeys.venue, venue) : isNull(encryptedChainKeys.venue),
+    );
+    const [preexistingEncryptedKey] = await db
+      .select({ id: encryptedChainKeys.id })
+      .from(encryptedChainKeys)
+      .where(scope);
+    if (preexistingEncryptedKey) {
+      throw new Error("Cannot register external key handle over a server-managed signing key");
+    }
+    const [preexistingWallet] = await db
+      .select({ metadata: agentWallets.metadata })
+      .from(agentWallets)
+      .where(
+        and(
+          eq(agentWallets.agentId, request.agentId),
+          eq(agentWallets.chainFamily, request.chainFamily),
+          venue ? eq(agentWallets.venue, venue) : isNull(agentWallets.venue),
+        ),
+      );
+    if (preexistingWallet && !isExternalKeyWalletMetadata(preexistingWallet.metadata)) {
+      throw new Error("Cannot register external key handle over a server-managed wallet");
+    }
+
     // Provider registration is read-only public-handle validation (no custody
     // state changes) and stays OUTSIDE the lock: network I/O must never hold
     // a transaction-scoped advisory lock.
@@ -2277,7 +2312,6 @@ export class Vault {
       await this.externalKeyCustodyProvider.registerKeyHandle(request),
     );
     const metadata = toExternalKeyWalletMetadata(registration) as Record<string, unknown>;
-    const venue = request.venue ?? null;
     const now = new Date();
 
     await db.transaction(async (tx) => {
@@ -2291,7 +2325,7 @@ export class Vault {
       // where transactions already serialize.
       if (usesCustodyAdvisoryLock()) {
         await tx.execute(
-          sql`select pg_advisory_xact_lock(hashtext(${custodyTransitionLockKey(request.agentId, request.chainFamily, venue)}))`,
+          sql`select pg_advisory_xact_lock(hashtextextended(${custodyTransitionLockKey(request.tenantId, request.agentId, request.chainFamily, venue)}, 0))`,
         );
       }
 


### PR DESCRIPTION
## Re-audit batch W3-B (vault + attestation + FROST sidecar)

This draft is rebased onto `a7b1d566` and contains the remaining vault/FROST repairs. The original canonical-DER attestation commit was dropped during rebase because merged PR #383 already provides the stronger implementation on `develop`: canonical SPKI DER fingerprints, fail-closed malformed-key handling, and bounded registry parsing.

### Included repairs

- Bind the legacy `encrypted_keys` fallback to `expectedBackend`; external-custody authorizations cannot fall through to local key material.
- Serialize local/external custody transitions with a transaction-scoped PostgreSQL advisory lock. The lock identity is a tenant-bound JSON tuple and uses `hashtextextended(..., 0)` rather than ambiguous colon joining plus 32-bit `hashtext`.
- Keep provider network validation outside the transaction/lock, but fast-fail all already-visible local key/wallet conflicts before disclosing a handle to the provider. Repeat the authoritative checks after acquiring the lock to close the TOCTOU window.
- Refuse mnemonic restoration over an external-custody wallet, with the guard repeated under the same custody-transition locks.
- Bound parked FROST rounds at 1024 with oldest-round eviction; evicted unused nonces remain unusable.
- Fail closed before the monotonic `u64` nonce counter would wrap, and reject numeric wire aliases (`n01`, `n+1`, etc.) so only the exact issued nonce ID can consume a round.
- Keep FROST bearer tokens out of process arguments, require an environment-provided token of at least 32 non-whitespace bytes, and generate independent random per-share test tokens.

### Exact validation at `5bb0a6df7a481ee9db2e95f103077e8d562d705d`

- Vault focused tests: 30 pass / 0 fail (109 assertions)
- Vault and signer-frost TypeScript builds: clean
- FROST Rust: 4/4 unit tests; strict Clippy; rustfmt; release build
- FROST real-sidecar E2E: 14/14
- Changed-file Biome and `git diff --check`: clean

Fresh exact-head CI is pending. Keep draft until it is green.
