### PR TITLE
fix(security): W3-G re-audit batch — infra leftovers + misc

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -39,6 +39,7 @@
       "name": "@stwd/agent-trader",
       "version": "0.4.0",
       "dependencies": {
+        "@stwd/redis": "workspace:*",
         "@stwd/sdk": "workspace:*",
         "@stwd/shared": "workspace:*",
         "ioredis": "^5.10.1",

--- a/deploy/DEPLOYMENT.md
+++ b/deploy/DEPLOYMENT.md
@@ -50,13 +50,16 @@ Steward runs as two **systemd services** on each Milady node, built from source 
 ### Step 1: Sync source code
 
 ```bash
-# From your workstation (where you have the steward-fi repo)
+# From your workstation (where you have the steward repo)
 NODE_IP="<node-ip>"
+# Path to your local clone of THIS repo — keep real checkout paths out of
+# committed docs.
+STEWARD_SRC="/path/to/your/local/steward-checkout"
 rsync -az --delete \
   --exclude='.git' --exclude='node_modules' --exclude='.next' \
   --exclude='web' --exclude='.turbo' \
   -e "ssh -o StrictHostKeyChecking=accept-new" \
-  /home/shad0w/projects/steward-fi/ root@${NODE_IP}:/opt/steward/
+  "${STEWARD_SRC}/" root@${NODE_IP}:/opt/steward/
 ```
 
 ### Step 2: Install dependencies
@@ -177,10 +180,13 @@ ssh root@${NODE_IP} "curl -sf http://172.18.0.1:8080/health"
 
 The platform key must never appear on a command line (local ps/history,
 remote process list). Read it on the node from the mode-0600 env file and
-call the API over localhost via the SSH channel (SEC-022):
+call the API over localhost via the SSH channel; the credential header reaches
+curl through a mode-0600 temporary header file, never as an argv-expansible
+`-H "X-Steward-Platform-Key: ${PK}"` (SEC-020/SEC-022):
 
 ```bash
 ssh root@${NODE_IP} "PK=\$(grep '^STEWARD_PLATFORM_KEYS=' /etc/steward/env | cut -d= -f2- | cut -d, -f1); \
+  case \"\${PK}\" in ''|*[!A-Za-z0-9._~-]*) exit 1;; esac; [ \"\${#PK}\" -le 512 ] || exit 1; \
   AUTH_FILE=\$(mktemp); chmod 600 \"\${AUTH_FILE}\"; trap 'rm -f \"\${AUTH_FILE}\"' EXIT; \
   printf 'X-Steward-Platform-Key: %s\\n' \"\${PK}\" > \"\${AUTH_FILE}\"; \
   curl -sf -X POST http://localhost:3200/platform/tenants \
@@ -195,6 +201,7 @@ For any other platform-key operation, use an SSH tunnel from your workstation
 ```bash
 ssh -L 3200:localhost:3200 root@${NODE_IP}
 # then, locally:
+case "$PLATFORM_KEY" in ''|*[!A-Za-z0-9._~-]*) echo "Invalid platform key" >&2; exit 1;; esac
 AUTH_FILE=$(mktemp); chmod 600 "$AUTH_FILE"
 printf 'X-Steward-Platform-Key: %s\n' "$PLATFORM_KEY" > "$AUTH_FILE"
 curl -sf http://localhost:3200/platform/tenants -H "@$AUTH_FILE"
@@ -209,13 +216,14 @@ rm -f "$AUTH_FILE"
 
 ```bash
 NODE_IP="<node-ip>"  # from your operator-local inventory (never committed — see Node Inventory)
+STEWARD_SRC="/path/to/your/local/steward-checkout"  # your local clone of THIS repo
 
 # 1. Sync updated source
 rsync -az --delete \
   --exclude='.git' --exclude='node_modules' --exclude='.next' \
   --exclude='web' --exclude='.turbo' \
   -e "ssh -o StrictHostKeyChecking=accept-new" \
-  /home/shad0w/projects/steward-fi/ root@${NODE_IP}:/opt/steward/
+  "${STEWARD_SRC}/" root@${NODE_IP}:/opt/steward/
 
 # 2. Install any new dependencies
 ssh root@${NODE_IP} "cd /opt/steward && bun install"
@@ -233,6 +241,7 @@ ssh root@${NODE_IP} "curl -sf http://localhost:3200/health"
 # Node IPs come from your operator-local inventory — the same one
 # scripts/deploy-all.sh reads (STEWARD_NODES or scripts/deploy-nodes.local.conf).
 NODES="<node-ip-1> <node-ip-2> <node-ip-3>"
+STEWARD_SRC="/path/to/your/local/steward-checkout"  # your local clone of THIS repo
 
 for NODE in $NODES; do
   echo "=== Updating ${NODE} ==="
@@ -240,7 +249,7 @@ for NODE in $NODES; do
     --exclude='.git' --exclude='node_modules' --exclude='.next' \
     --exclude='web' --exclude='.turbo' \
     -e "ssh -o StrictHostKeyChecking=accept-new" \
-    /home/shad0w/projects/steward-fi/ root@${NODE}:/opt/steward/
+    "${STEWARD_SRC}/" root@${NODE}:/opt/steward/
   ssh -o StrictHostKeyChecking=accept-new root@${NODE} "cd /opt/steward && bun install && systemctl restart steward"
   sleep 2
   ssh -o StrictHostKeyChecking=accept-new root@${NODE} "curl -sf http://localhost:3200/health"
@@ -321,6 +330,7 @@ cleartext (SEC-022).
 
 ```bash
 read -rsp "Platform key: " PK; printf '\n'
+case "$PK" in ''|*[!A-Za-z0-9._~-]*) echo "Invalid platform key" >&2; exit 1;; esac
 BASE="http://localhost:3200"
 PLATFORM_HEADERS=$(mktemp); TENANT_HEADERS=$(mktemp); TOKEN_HEADERS=$(mktemp)
 chmod 600 "$PLATFORM_HEADERS" "$TENANT_HEADERS" "$TOKEN_HEADERS"
@@ -596,6 +606,19 @@ Redis is used for:
 
 In **production** (`NODE_ENV=production`) the proxy treats Redis as **required** and fails **closed** without it: `checkProxyRateLimit`/`checkProxySpendLimit` reject requests (429/402/503) unless you explicitly set `STEWARD_ALLOW_PROXY_REDIS_SOFT_FAIL=true`. The compose deploy therefore ships a `redis` service and sets `REDIS_URL`. Only in non-production (or with the soft-fail override) do rate-limit/spend counters fall back to in-memory and reset on restart.
 
+### Eviction policy (SEC-021 follow-up)
+
+The shipped production compose stacks (`docker-compose.yml` and
+`deploy/docker-compose.yml`) set `--maxmemory-policy noeviction`. Under memory
+pressure, Redis therefore fails writes instead of silently evicting spend and
+rate counters; Steward's enforcement path treats those failures as closed.
+Alert on `used_memory` well below `maxmemory` so availability problems are
+handled before the fail-closed boundary is reached. The enterprise-reference
+stack and any externally managed or custom Redis must be configured and
+verified separately: use `noeviction` for enforcement counters (or document a
+deliberate financial-control risk acceptance), isolate them from cache
+workloads, and never assume an eviction policy such as `allkeys-lru` is safe.
+
 ---
 
 ## Webhook Configuration
@@ -628,6 +651,20 @@ echo "Webhook config and one-time secret saved to $WEBHOOK_RESPONSE (mode 0600)"
 field is only returned on creation and is used to verify
 `X-Steward-Signature` on incoming events; do not print it into terminal or CI
 logs.
+
+> **At-rest encryption and legacy plaintext rows (SEC-088):** webhook secrets
+> are encrypted at rest (AES-256-GCM; key from
+> `STEWARD_WEBHOOK_SECRET_ENCRYPTION_KEY`/`STEWARD_MASTER_PASSWORD`). Configs
+> written before encryption shipped may still hold **plaintext** secrets.
+> There is deliberately **no eager mass re-encryption at boot** — a boot-time
+> rewrite would need the encryption key during migrations and would race
+> concurrently booting replicas. Instead each config row is upgraded lazily,
+> via a compare-and-swap on the stored value, the next time that webhook
+> fires or is re-saved (see `packages/api/src/services/webhook-dispatch.ts`),
+> and new delivery rows only ever snapshot the encrypted form. Until a legacy
+> config fires or is re-saved, its plaintext secret stays recoverable by
+> anyone with DB read access (backup leak, read replica). **After upgrading,
+> rotate or re-save pre-existing webhooks to force immediate re-encryption.**
 
 ### Verify webhook delivery
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -37,6 +37,7 @@ curl http://localhost:8080/health   # {"ok":true,"service":"steward-proxy",...}
 # Read your STEWARD_PLATFORM_KEYS value without putting it in shell history or
 # curl argv. curl reads the header from an owner-only temporary file.
 read -rsp "Platform key: " PLATFORM_KEY; printf '\n'
+case "$PLATFORM_KEY" in ''|*[!A-Za-z0-9._~-]*) echo "Invalid platform key" >&2; exit 1;; esac
 AUTH_FILE=$(mktemp); chmod 600 "$AUTH_FILE"
 trap 'rm -f "$AUTH_FILE"' EXIT
 printf 'X-Steward-Platform-Key: %s\n' "$PLATFORM_KEY" > "$AUTH_FILE"

--- a/deploy/enterprise-reference/docker-compose.yml
+++ b/deploy/enterprise-reference/docker-compose.yml
@@ -194,6 +194,11 @@ services:
     # SEC-081:
     #  - The DSN is sourced from the mounted env FILE, not container env, so
     #    the DB password no longer appears in `docker inspect`.
+    #  - SEC-050: pg_dump's argv is visible in the HOST process list
+    #    (/proc/<pid>/cmdline), so the password must not ride inside the DSN
+    #    either. The command below strips both userinfo and libpq query-string
+    #    passwords from the DSN and authenticates via PGPASSWORD (same pattern
+    #    as scripts/migrate.sh).
     #  - umask 077: dumps contain tenant PII, audit events, and encrypted key
     #    blobs in PLAINTEXT — they are written mode 0600. Keep ./backups
     #    mode 0700 on the host (or on encrypted storage), restrict it to the
@@ -202,7 +207,160 @@ services:
       - |
         set -a; . /run/steward/env; set +a
         umask 077
+        # Never inherit a separately supplied password into pg_dump. The only
+        # credential allowed below is one decoded from DATABASE_URL itself.
+        unset PGPASSWORD
         dsn="$${DATABASE_URL:-postgresql://steward:$${POSTGRES_PASSWORD:?}@postgres:5432/steward}"
+        # Strip user:password@ and ?password= from the DSN; pass the password
+        # via PGPASSWORD so it never appears on pg_dump's argv (SEC-050). A
+        # passwordless DSN is passed through unchanged. Query keywords are
+        # case-insensitive in libpq and may percent-encode their names, so
+        # decode keys before matching and fail closed on malformed escapes.
+        case "$$dsn" in
+          postgres://*|postgresql://*)
+            pg_scheme="$${dsn%%://*}"
+            pg_rest="$${dsn#*://}"
+            # Isolate the authority before looking for userinfo. Matching a
+            # colon and @ across the whole DSN mistakes host ports plus an @
+            # in a path/query value for credentials and corrupts the target.
+            pg_authority="$$(printf '%s' "$$pg_rest" | sed 's|[/?#].*||')"
+            pg_suffix="$${pg_rest#"$$pg_authority"}"
+            case "$$pg_authority" in
+              *:*@*)
+                pg_userinfo="$${pg_authority%%@*}"
+                pg_host="$${pg_authority#*@}"
+                pg_user="$${pg_userinfo%%:*}"
+                pg_pw="$${pg_userinfo#*:}"
+                dsn="$${pg_scheme}://$${pg_user}@$${pg_host}$${pg_suffix}"
+                # Percent-decode the password component (PGPASSWORD is literal).
+                # Reject malformed escapes and NUL, which cannot be represented
+                # in an environment and must never be silently truncated.
+                case "$$(printf '%s' "$$pg_pw" | sed 's/%[0-9A-Fa-f][0-9A-Fa-f]//g')" in
+                  *%*) echo 'Invalid percent escape in DATABASE_URL password' >&2; exit 1 ;;
+                esac
+                case "$$pg_pw" in *%00*) echo 'NUL is not allowed in DATABASE_URL password' >&2; exit 1 ;; esac
+                pg_pw="$$(printf '%s' "$$pg_pw" | sed 's/%/\\x/g')"
+                PGPASSWORD="$$(printf '%b' "$$pg_pw")"
+                export PGPASSWORD
+                ;;
+            esac
+        esac
+        pg_url_decode() {
+          pg_encoded="$$1"
+          if printf '%s' "$$pg_encoded" | grep -q '[[:cntrl:]]'; then
+            return 1
+          fi
+          # A malformed escape can make our redacted URI differ from libpq's
+          # interpretation. Refuse it instead of passing an ambiguous DSN to
+          # pg_dump.
+          case "$$(printf '%s' "$$pg_encoded" | sed 's/%[0-9A-Fa-f][0-9A-Fa-f]//g')" in
+            *%*) return 1 ;;
+          esac
+          pg_decoded=
+          while [ -n "$$pg_encoded" ]; do
+            pg_char="$${pg_encoded%"$${pg_encoded#?}"}"
+            pg_encoded="$${pg_encoded#?}"
+            if [ "$$pg_char" = '%' ]; then
+              pg_hex="$${pg_encoded%"$${pg_encoded#??}"}"
+              pg_encoded="$${pg_encoded#??}"
+              case "$$pg_hex" in
+                00|0a|0A|0d|0D) return 1 ;; # NUL/CR/LF cannot be env data
+                [0-9A-Fa-f][0-9A-Fa-f]) ;;
+                *) return 1 ;;
+              esac
+              pg_oct="$$(printf '%03o' "$$((0x$$pg_hex))")"
+              pg_char="$$(printf "\\$$pg_oct")"
+            fi
+            pg_decoded="$$pg_decoded$$pg_char"
+          done
+          printf '%s' "$$pg_decoded"
+        }
+        pg_query_password=
+        pg_query_password_found=
+        # Query parameters are part of the DSN passed to pg_dump, so remove
+        # every password keyword before the invocation. Retain all unrelated
+        # query bytes byte-for-byte (including user= and ordering).
+        case "$$dsn" in
+          *\?*)
+            pg_query_base="$${dsn%%\?*}"
+            pg_query="$${dsn#*\?}"
+            pg_retained_query=
+            pg_retained_query_started=
+            pg_query_done=
+            pg_query_candidate=
+            while :; do
+              case "$$pg_query" in
+                *\&*)
+                  pg_part="$${pg_query%%\&*}"
+                  pg_query="$${pg_query#*\&}"
+                  ;;
+                *)
+                  pg_part="$$pg_query"
+                  pg_query=
+                  pg_query_done=1
+                  ;;
+              esac
+              case "$$pg_part" in
+                *=*)
+                  pg_raw_key="$${pg_part%%=*}"
+                  pg_raw_value="$${pg_part#*=}"
+                  ;;
+                *)
+                  pg_raw_key="$$pg_part"
+                  pg_raw_value=
+                  ;;
+              esac
+              if ! pg_query_key="$$(pg_url_decode "$$pg_raw_key")"; then
+                echo 'Invalid percent escape in DATABASE_URL query' >&2
+                exit 1
+              fi
+              # Validate values even when they are not passwords; otherwise a
+              # malformed escape could be interpreted differently by libpq.
+              if ! pg_url_decode "$$pg_raw_value" >/dev/null; then
+                echo 'Invalid percent escape in DATABASE_URL query' >&2
+                exit 1
+              fi
+              case "$$pg_query_key" in
+                [Pp][Aa][Ss][Ss][Ww][Oo][Rr][Dd])
+                  if [ -n "$$pg_raw_value" ]; then
+                    if ! pg_query_candidate="$$(pg_url_decode "$$pg_raw_value")"; then
+                      echo 'Invalid percent escape in DATABASE_URL password' >&2
+                      exit 1
+                    fi
+                    if [ -n "$$pg_query_candidate" ]; then
+                      pg_query_password="$$pg_query_candidate"
+                      pg_query_password_found=1
+                    fi
+                  fi
+                  ;;
+                *)
+                  if [ -n "$$pg_retained_query_started" ]; then
+                    pg_retained_query="$$pg_retained_query&$$pg_part"
+                  else
+                    pg_retained_query="$$pg_part"
+                    pg_retained_query_started=1
+                  fi
+                  ;;
+              esac
+              [ -n "$$pg_query_done" ] && break
+            done
+            dsn="$$pg_query_base"
+            if [ -n "$$pg_retained_query_started" ]; then
+              dsn="$$dsn?$$pg_retained_query"
+            fi
+            if [ -n "$$pg_query_password_found" ]; then
+              PGPASSWORD="$$pg_query_password"
+              export PGPASSWORD
+            fi
+            ;;
+        esac
+        # The env file was sourced with `set -a`; remove original
+        # password-bearing variables before execing pg_dump so its process
+        # environment does not undo the argv hardening above.
+        unset DATABASE_URL POSTGRES_PASSWORD pg_pw pg_rest pg_userinfo pg_authority \
+          pg_query pg_query_candidate pg_query_password pg_raw_value pg_encoded \
+          pg_decoded pg_char pg_hex pg_oct pg_query_key pg_raw_key pg_part \
+          pg_query_base pg_retained_query pg_retained_query_started pg_query_done
         pg_dump "$$dsn" > "/backups/steward-$$(date -u +%Y%m%dT%H%M%SZ).sql"
     volumes:
       - ./backups:/backups

--- a/deploy/migrate-agent-keys.sh
+++ b/deploy/migrate-agent-keys.sh
@@ -79,8 +79,11 @@ fi
 # curl expands a literal `-H "...${PK}"` into its process argv, even when PK
 # was populated by the remote shell. Put the header in a mode-0600 temporary
 # file and pass only that filename to curl so the key is absent from both the
-# local ssh argv and the remote curl argv.
-AUTH_HEADER_SNIPPET="AUTH_FILE=\$(mktemp); chmod 600 \"\${AUTH_FILE}\"; trap 'rm -f \"\${AUTH_FILE}\"' EXIT; printf 'X-Steward-Platform-Key: %s\\n' \"\${PK}\" > \"\${AUTH_FILE}\""
+# local ssh argv and the remote curl argv. Before writing it, reject anything
+# outside the documented URL-safe token alphabet so CR/LF cannot inject a
+# second header and quotes/backslashes cannot become config syntax if this is
+# ever migrated back to `curl -K`.
+AUTH_HEADER_SNIPPET="case \"\${PK}\" in ''|*[!A-Za-z0-9._~-]*) exit 1;; esac; [ \"\${#PK}\" -le 512 ] || exit 1; AUTH_FILE=\$(mktemp); chmod 600 \"\${AUTH_FILE}\"; trap 'rm -f \"\${AUTH_FILE}\"' EXIT; printf 'X-Steward-Platform-Key: %s\\n' \"\${PK}\" > \"\${AUTH_FILE}\""
 
 echo "══════════════════════════════════════════════════════════════"
 echo "  Steward Agent Key Migration"

--- a/deploy/provision-steward-node.sh
+++ b/deploy/provision-steward-node.sh
@@ -24,6 +24,9 @@ set -euo pipefail
 NODE_IP="${1:?Usage: $0 <node-ip> [ssh-key]}"
 SSH_KEY="${2:-${SSH_KEY:-$HOME/.ssh/id_ed25519}}"
 
+[[ "${NODE_IP}" =~ ^[A-Za-z0-9._:\[\]-]+$ ]] || { echo "❌ Invalid node address"; exit 1; }
+[[ "${SSH_KEY}" =~ ^[A-Za-z0-9._/~/-]+$ ]] || { echo "❌ Invalid SSH key path"; exit 1; }
+
 # ── Validation ───────────────────────────────────────────────────────────────
 if [[ -z "${STEWARD_MASTER_PASSWORD:-}" ]]; then
   echo "❌ STEWARD_MASTER_PASSWORD is required"
@@ -36,12 +39,13 @@ fi
 # instead: `ssh-keyscan -H <node> >> ~/.ssh/known_hosts` once, then run with
 # STRICT_HOST_KEY=yes below.
 if [[ "${STRICT_HOST_KEY:-}" == "yes" ]]; then
-  SSH_OPTS="-o StrictHostKeyChecking=yes -o ConnectTimeout=10 -i ${SSH_KEY}"
+  SSH_BASE=(ssh -o StrictHostKeyChecking=yes -o ConnectTimeout=10 -i "${SSH_KEY}")
+  RSYNC_RSH="ssh -o StrictHostKeyChecking=yes -o ConnectTimeout=10 -i ${SSH_KEY}"
 else
-  SSH_OPTS="-o StrictHostKeyChecking=accept-new -o ConnectTimeout=10 -i ${SSH_KEY}"
+  SSH_BASE=(ssh -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10 -i "${SSH_KEY}")
+  RSYNC_RSH="ssh -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10 -i ${SSH_KEY}"
 fi
-SSH_CMD="ssh ${SSH_OPTS} root@${NODE_IP}"
-SCP_CMD="scp ${SSH_OPTS}"
+SSH_CMD=("${SSH_BASE[@]}" "root@${NODE_IP}")
 REMOTE_DIR="/opt/steward"
 
 echo "══════════════════════════════════════════════════════════════"
@@ -52,7 +56,7 @@ echo "════════════════════════�
 # ── Step 1: Ensure milady-isolated network exists ────────────────────────────
 echo ""
 echo "▸ Step 1: Checking Docker network..."
-${SSH_CMD} "docker network inspect milady-isolated >/dev/null 2>&1 || docker network create milady-isolated"
+"${SSH_CMD[@]}" "docker network inspect milady-isolated >/dev/null 2>&1 || docker network create milady-isolated"
 echo "  ✓ milady-isolated network ready"
 
 # ── Step 2: Sync source code to node ────────────────────────────────────────
@@ -69,7 +73,7 @@ rsync -az --delete \
   --exclude='web' \
   --exclude='.turbo' \
   --exclude='deploy/.env' \
-  -e "ssh ${SSH_OPTS}" \
+  -e "${RSYNC_RSH}" \
   "${REPO_ROOT}/" "root@${NODE_IP}:${REMOTE_DIR}/"
 echo "  ✓ Source synced"
 
@@ -80,7 +84,7 @@ echo "▸ Step 3: Writing environment config..."
 # Read the existing remote .env (if any) so re-runs are idempotent and do NOT
 # rotate generated secrets (rotating STEWARD_KDF_SALT/STEWARD_JWT_SECRET would
 # brick an existing vault / invalidate sessions).
-EXISTING_ENV="$(${SSH_CMD} "cat ${REMOTE_DIR}/deploy/.env 2>/dev/null || true")"
+EXISTING_ENV="$("${SSH_CMD[@]}" "cat ${REMOTE_DIR}/deploy/.env 2>/dev/null || true")"
 
 # env_get <KEY>: echo the value of KEY from the existing remote .env, else empty.
 env_get() {
@@ -105,6 +109,23 @@ STEWARD_PROXY_REQUEST_SIGNING_SECRETS="${STEWARD_PROXY_REQUEST_SIGNING_SECRETS:-
 PLATFORM_KEY="${STEWARD_PLATFORM_KEY:-$(env_get STEWARD_PLATFORM_KEY)}"
 [[ -n "${PLATFORM_KEY}" ]] || PLATFORM_KEY="$(openssl rand -hex 32)"
 
+# Values are serialized as one dotenv assignment per line. Reject control-line
+# injection without ever echoing the value itself. Platform keys additionally
+# use the documented URL-safe token alphabet consumed by the curl header seam.
+for env_name in STEWARD_MASTER_PASSWORD STEWARD_JWT_SECRET STEWARD_KDF_SALT \
+  STEWARD_AUDIT_HMAC_KEY PLATFORM_KEY STEWARD_PROXY_REQUEST_SIGNING_SECRETS \
+  POSTGRES_PASSWORD DATABASE_URL REDIS_URL RPC_URL SOLANA_RPC_URL; do
+  env_value="${!env_name-}"
+  if [[ "${env_value}" == *$'\n'* || "${env_value}" == *$'\r'* ]]; then
+    echo "❌ ${env_name} must be a single-line value"
+    exit 1
+  fi
+done
+[[ "${PLATFORM_KEY}" =~ ^[A-Za-z0-9._~-]{1,512}$ ]] || {
+  echo "❌ STEWARD_PLATFORM_KEY contains unsupported characters"
+  exit 1
+}
+
 # Render the .env LOCALLY into a mode-0600 temp file, then stream it to the node
 # over ssh stdin. Secrets never appear on any command line (local or remote).
 LOCAL_ENV_FILE="$(umask 077 && mktemp)"
@@ -124,25 +145,25 @@ CHAIN_ID=${CHAIN_ID:-8453}
 SOLANA_RPC_URL=${SOLANA_RPC_URL:-https://api.mainnet-beta.solana.com}
 ENVEOF
 
-${SSH_CMD} "umask 077; cat > ${REMOTE_DIR}/deploy/.env" < "${LOCAL_ENV_FILE}"
+"${SSH_CMD[@]}" "umask 077; cat > ${REMOTE_DIR}/deploy/.env" < "${LOCAL_ENV_FILE}"
 echo "  ✓ Environment configured"
 
 # ── Step 4: Build and start services ────────────────────────────────────────
 echo ""
 echo "▸ Step 4: Building Steward Docker image..."
-${SSH_CMD} "cd ${REMOTE_DIR} && docker compose -f deploy/docker-compose.yml build --no-cache steward"
+"${SSH_CMD[@]}" "cd ${REMOTE_DIR} && docker compose -f deploy/docker-compose.yml build --no-cache steward"
 echo "  ✓ Image built"
 
 echo ""
 echo "▸ Step 5: Starting services..."
-${SSH_CMD} "cd ${REMOTE_DIR} && docker compose -f deploy/docker-compose.yml up -d"
+"${SSH_CMD[@]}" "cd ${REMOTE_DIR} && docker compose -f deploy/docker-compose.yml up -d"
 echo "  ✓ Services started"
 
 # ── Step 6: Wait for healthy ─────────────────────────────────────────────────
 echo ""
 echo "▸ Step 6: Waiting for Steward to become healthy..."
 for i in $(seq 1 30); do
-  if ${SSH_CMD} "curl -sf http://localhost:3200/health" >/dev/null 2>&1; then
+  if "${SSH_CMD[@]}" "curl -sf http://localhost:3200/health" >/dev/null 2>&1; then
     echo "  ✓ Steward is healthy!"
     break
   fi
@@ -161,8 +182,10 @@ echo "▸ Step 7: Creating milady-cloud tenant..."
 # The platform key was written to deploy/.env in Step 3 and picked up by the
 # container at boot. Create the tenant by reading the key on the REMOTE side
 # (PK=$(...)) so the secret is never placed on the local->remote command line
-# nor printed to this script's stdout / CI logs.
-TENANT_RESP=$(${SSH_CMD} "set -e; PK=\$(sed -n 's/^STEWARD_PLATFORM_KEY=//p' ${REMOTE_DIR}/deploy/.env | head -n1); \
+# nor printed to this script's stdout / CI logs. Reject non-token characters
+# before creating the header so config-file corruption cannot inject headers.
+TENANT_RESP=$("${SSH_CMD[@]}" "set -e; PK=\$(sed -n 's/^STEWARD_PLATFORM_KEY=//p' ${REMOTE_DIR}/deploy/.env | head -n1); \
+case \"\${PK}\" in ''|*[!A-Za-z0-9._~-]*) exit 1;; esac; [ \"\${#PK}\" -le 512 ] || exit 1; \
 AUTH_FILE=\$(mktemp); chmod 600 \"\${AUTH_FILE}\"; trap 'rm -f \"\${AUTH_FILE}\"' EXIT; \
 printf 'X-Steward-Platform-Key: %s\\n' \"\${PK}\" > \"\${AUTH_FILE}\"; \
 curl -sf -X POST http://localhost:3200/platform/tenants \
@@ -184,7 +207,7 @@ echo "════════════════════════�
 echo "  ✅ Steward deployed successfully!"
 echo ""
 echo "  Steward URL:    http://localhost:3200 (loopback-only on the node)"
-echo "  Health check:   ssh ${SSH_OPTS} root@${NODE_IP} 'curl -sf http://localhost:3200/health'"
+echo "  Health check:   ssh root@${NODE_IP} 'curl -sf http://localhost:3200/health'"
 echo "  Platform Key:   (written to ${REMOTE_DIR}/deploy/.env, mode 0600, on the node; retrieve it there, not printed here)"
 echo ""
 echo "  Agent config (add to container env):"

--- a/packages/agent-trader/package.json
+++ b/packages/agent-trader/package.json
@@ -9,6 +9,7 @@
     "build": "tsc --noEmit"
   },
   "dependencies": {
+    "@stwd/redis": "workspace:*",
     "@stwd/sdk": "workspace:*",
     "@stwd/shared": "workspace:*",
     "ioredis": "^5.10.1",

--- a/packages/agent-trader/src/__tests__/webhook-signature.test.ts
+++ b/packages/agent-trader/src/__tests__/webhook-signature.test.ts
@@ -445,6 +445,45 @@ describe("agent trader webhook receiver signatures", () => {
     ).toBeUndefined();
   });
 
+  it("rejects cleartext redis:// replay storage in production (SEC-032)", () => {
+    // The default factory builds a raw ioredis client; it must route through
+    // the shared assertRedisUrlTls so a remote cleartext REDIS_URL fails
+    // closed in production. The assertion throws before any socket opens.
+    const previousEnv = process.env.NODE_ENV;
+    const previousOverride = process.env.STEWARD_ALLOW_INSECURE_REDIS;
+    process.env.NODE_ENV = "production";
+    delete process.env.STEWARD_ALLOW_INSECURE_REDIS;
+    try {
+      expect(() =>
+        createConfiguredWebhookDeliveryStore({
+          NODE_ENV: "production",
+          REDIS_URL: "redis://redis.example.internal:6379",
+        }),
+      ).toThrow("rediss://");
+    } finally {
+      if (previousEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = previousEnv;
+      if (previousOverride === undefined) delete process.env.STEWARD_ALLOW_INSECURE_REDIS;
+      else process.env.STEWARD_ALLOW_INSECURE_REDIS = previousOverride;
+    }
+  });
+
+  it("uses the supplied environment for replay-store TLS policy", () => {
+    const previousEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "development";
+    try {
+      expect(() =>
+        createConfiguredWebhookDeliveryStore({
+          NODE_ENV: "production",
+          REDIS_URL: "redis://redis.example.internal:6379",
+        }),
+      ).toThrow("rediss://");
+    } finally {
+      if (previousEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = previousEnv;
+    }
+  });
+
   it("times out and aborts a stalled Upstash replay claim with a sanitized error", async () => {
     let aborted = false;
     const stalledFetch = ((_input: unknown, init?: RequestInit) =>

--- a/packages/agent-trader/src/webhook-delivery-store.ts
+++ b/packages/agent-trader/src/webhook-delivery-store.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { assertRedisUrlTls } from "@stwd/redis";
 import { Redis } from "ioredis";
 
 export const WEBHOOK_DELIVERY_REPLAY_TTL_MS = 10 * 60 * 1000;
@@ -182,6 +183,10 @@ export function createUpstashReplaySetClient(
 
 function defaultRedisFactory(kind: "redis" | "upstash", env: NodeJS.ProcessEnv): RedisSetNxPx {
   if (kind === "redis") {
+    // SEC-032: replay-protection state is enforcement data — route through the
+    // shared TLS assertion so production cannot run this store over cleartext
+    // redis:// to a remote host without the explicit insecure override.
+    assertRedisUrlTls(env.REDIS_URL as string, env);
     const client = new Redis(env.REDIS_URL as string, {
       enableReadyCheck: true,
       maxRetriesPerRequest: 3,

--- a/packages/api/src/__tests__/vault-execution-gateway.test.ts
+++ b/packages/api/src/__tests__/vault-execution-gateway.test.ts
@@ -39,6 +39,7 @@ const USER_ID = "00000000-0000-4000-8000-000000000123";
 const SOLANA_RECIPIENT = "11111111111111111111111111111111";
 const ORIGINAL_REDIS_URL = process.env.REDIS_URL;
 const ORIGINAL_REDIS_REQUIRED = process.env.REDIS_REQUIRED;
+const ORIGINAL_EXECUTION_AUTH_SECRET = process.env.STEWARD_EXECUTION_AUTH_SECRET;
 setDefaultTimeout(30_000);
 
 async function makeApp() {
@@ -63,6 +64,7 @@ describe("vault EVM execution gateway", () => {
     process.env.STEWARD_MASTER_PASSWORD = "gateway-test-master-password";
     process.env.STEWARD_JWT_SECRET = "gateway-test-jwt-secret-with-enough-entropy-0123456789";
     process.env.STEWARD_AUDIT_HMAC_KEY = "b".repeat(64);
+    process.env.STEWARD_EXECUTION_AUTH_SECRET = `gateway-test:${"e".repeat(48)}`;
     process.env.STEWARD_ALLOW_UNSAFE_CONTRACT_CALL_SIGNING = "true";
     delete process.env.REDIS_URL;
     delete process.env.REDIS_REQUIRED;
@@ -112,6 +114,11 @@ describe("vault EVM execution gateway", () => {
     else process.env.REDIS_URL = ORIGINAL_REDIS_URL;
     if (ORIGINAL_REDIS_REQUIRED === undefined) delete process.env.REDIS_REQUIRED;
     else process.env.REDIS_REQUIRED = ORIGINAL_REDIS_REQUIRED;
+    if (ORIGINAL_EXECUTION_AUTH_SECRET === undefined) {
+      delete process.env.STEWARD_EXECUTION_AUTH_SECRET;
+    } else {
+      process.env.STEWARD_EXECUTION_AUTH_SECRET = ORIGINAL_EXECUTION_AUTH_SECRET;
+    }
     await closeDb();
   });
 

--- a/packages/api/src/__tests__/vault-execution-gateway.test.ts
+++ b/packages/api/src/__tests__/vault-execution-gateway.test.ts
@@ -36,6 +36,7 @@ import { getConfiguredVault } from "../services/vault-factory";
 const TENANT_ID = `gateway-tenant-${Date.now()}`;
 const AGENT_ID = `gateway-agent-${Date.now()}`;
 const USER_ID = "00000000-0000-4000-8000-000000000123";
+const SOLANA_RECIPIENT = "11111111111111111111111111111111";
 const ORIGINAL_REDIS_URL = process.env.REDIS_URL;
 const ORIGINAL_REDIS_REQUIRED = process.env.REDIS_REQUIRED;
 setDefaultTimeout(30_000);
@@ -100,7 +101,7 @@ describe("vault EVM execution gateway", () => {
         enabled: true,
         config: {
           mode: "whitelist",
-          addresses: ["0x1111111111111111111111111111111111111111"],
+          addresses: ["0x1111111111111111111111111111111111111111", SOLANA_RECIPIENT],
         },
       });
   });
@@ -164,7 +165,7 @@ describe("vault EVM execution gateway", () => {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({
-          to: "0x1111111111111111111111111111111111111111",
+          to: SOLANA_RECIPIENT,
           value: "1",
           data: "0x12345678",
           chainId: 101,

--- a/packages/api/src/services/webhook-dispatch.ts
+++ b/packages/api/src/services/webhook-dispatch.ts
@@ -182,6 +182,13 @@ async function dispatchConfiguredWebhook(
   },
 ): Promise<typeof webhookDeliveries.$inferSelect> {
   const signingSecret = decryptWebhookSecret(config.secret);
+  // SEC-088: legacy plaintext config rows are upgraded LAZILY here — CAS on
+  // the previously stored value — not by an eager boot-time backfill. A mass
+  // rewrite would need the encryption key during migrations and would race
+  // concurrently booting replicas; delivery rows below only ever snapshot the
+  // encrypted form. Residual risk (documented in deploy/DEPLOYMENT.md): a
+  // config that never fires and is never re-saved keeps its plaintext secret
+  // until an operator rotates/re-saves it.
   const encryptedSecret = isEncryptedWebhookSecret(config.secret)
     ? config.secret
     : encryptWebhookSecret(signingSecret);

--- a/packages/csharp/src/Steward/StewardClient.cs
+++ b/packages/csharp/src/Steward/StewardClient.cs
@@ -27,6 +27,13 @@ namespace Steward
         /// required by default so credentials never travel cleartext off-loopback (SEC-200).</summary>
         public bool AllowInsecureBaseUrl { get; set; }
         public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(30);
+        /// <summary>Optional custom transport. WARNING: the default transport disables
+        /// auto-redirect (<c>AllowAutoRedirect = false</c>) because HttpClient would copy the
+        /// X-Steward-* credential/signing headers to the redirect target (it strips only
+        /// Authorization), so an open redirect or hostile proxy could exfiltrate them
+        /// (SEC-126). A custom Transport takes over redirect handling entirely: it must not
+        /// follow a redirect to a different host (or an HTTPS→HTTP downgrade) without first
+        /// stripping the Authorization / X-Steward-* headers.</summary>
         public StewardTransport? Transport { get; set; }
         public Func<DateTimeOffset> Now { get; set; } = () => DateTimeOffset.UtcNow;
         public Func<string> NewId { get; set; } = () => Guid.NewGuid().ToString();

--- a/packages/flutter/lib/src/client.dart
+++ b/packages/flutter/lib/src/client.dart
@@ -39,6 +39,15 @@ class StewardClientConfig {
   /// required by default so credentials never travel cleartext off-loopback
   /// (SEC-200).
   final bool allowInsecureBaseUrl;
+
+  /// Optional custom HTTP client. WARNING: requests are sent with
+  /// `followRedirects = false` because package:http forwards all headers —
+  /// including X-Steward-* credentials and signatures — to the redirect
+  /// target (SEC-126). A custom client whose `send` ignores `followRedirects`
+  /// (e.g. BrowserClient, or a wrapper that follows redirects itself)
+  /// silently bypasses that protection and can leak credentials to a redirect
+  /// target; such a client must strip the Authorization / X-Steward-* headers
+  /// on any cross-host or HTTPS-downgrade redirect.
   final http.Client? httpClient;
   final StewardIdFactory? idFactory;
 }

--- a/packages/go/steward/client.go
+++ b/packages/go/steward/client.go
@@ -33,9 +33,17 @@ type Config struct {
 	// construction). HTTPS is required by default so credentials never travel
 	// cleartext off-loopback (SEC-200).
 	AllowInsecureBaseURL bool
-	HTTPClient           *http.Client
-	Now                  func() time.Time
-	NewID                func() string
+	// HTTPClient, when set, REPLACES the default client — including its
+	// CheckRedirect hook, which strips Authorization / X-Steward-* credential
+	// and signing headers on cross-host or HTTPS-downgrade redirects
+	// (SEC-126). A custom client whose CheckRedirect does not re-apply that
+	// stripping silently re-enables credential exfiltration via open
+	// redirects / hostile proxies: net/http copies X-Steward-* headers to
+	// any redirect target. Either disable redirects or strip those headers
+	// on any host change (see stripStewardCredentialsOnCrossHostRedirect).
+	HTTPClient *http.Client
+	Now        func() time.Time
+	NewID      func() string
 }
 
 type Client struct {

--- a/packages/proxy/src/__tests__/deploy-artifacts.test.ts
+++ b/packages/proxy/src/__tests__/deploy-artifacts.test.ts
@@ -159,6 +159,92 @@ describe("SEC-081 enterprise backup service keeps the DSN out of container env a
   test("dumps are written owner-only (umask 077)", () => {
     expect(backup).toContain("umask 077");
   });
+
+  test("pg_dump argv carries no password — DSN userinfo is stripped, PGPASSWORD used (SEC-050)", () => {
+    // Re-audit: pg_dump "$dsn" with the password inside the DSN re-exposed it
+    // in the HOST process list (/proc/<pid>/cmdline). The command must strip
+    // user:password@ from the DSN and authenticate via PGPASSWORD instead
+    // (same pattern as scripts/migrate.sh), BEFORE pg_dump is invoked.
+    expect(backup).toContain("PGPASSWORD");
+    expect(backup).toContain("pg_pw=");
+    expect(backup).toContain("unset PGPASSWORD");
+    expect(backup).not.toMatch(/pg_dump\s+"\$\$\{?DATABASE_URL/);
+    const stripAt = backup.indexOf("PGPASSWORD=");
+    const dumpAt = backup.indexOf('pg_dump "$$dsn"');
+    expect(stripAt).toBeGreaterThanOrEqual(0);
+    expect(dumpAt).toBeGreaterThanOrEqual(0);
+    expect(stripAt).toBeLessThan(dumpAt);
+    expect(backup).toContain("unset DATABASE_URL POSTGRES_PASSWORD");
+    expect(backup.indexOf("unset DATABASE_URL POSTGRES_PASSWORD")).toBeLessThan(dumpAt);
+    expect(backup).toContain("Invalid percent escape in DATABASE_URL password");
+    expect(backup).toContain("NUL is not allowed in DATABASE_URL password");
+  });
+
+  test("DSN stripping is confined to authority userinfo", () => {
+    const parserStart = backup.indexOf('        dsn="');
+    const parserEnd = backup.indexOf('        pg_dump "$$dsn"');
+    expect(parserStart).toBeGreaterThanOrEqual(0);
+    expect(parserEnd).toBeGreaterThan(parserStart);
+    const parser = backup
+      .slice(parserStart, parserEnd)
+      .split("\n")
+      .map((line) => line.replace(/^ {8}/, ""))
+      .join("\n")
+      .replaceAll("$$", "$");
+    const runParser = (databaseUrl: string) =>
+      Bun.spawnSync(["sh", "-c", `${parser}\nprintf '%s\\n%s' "$dsn" "\${PGPASSWORD-}"`], {
+        env: {
+          PATH: process.env.PATH ?? "/usr/bin:/bin",
+          DATABASE_URL: databaseUrl,
+          POSTGRES_PASSWORD: "fallback",
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+    const parse = (databaseUrl: string): [string, string] => {
+      const result = runParser(databaseUrl);
+      expect(result.exitCode).toBe(0);
+      return result.stdout.toString().split("\n") as [string, string];
+    };
+
+    expect(
+      parse("postgresql://steward:p%40ss%3Aword@postgres:5432/steward?sslmode=require"),
+    ).toEqual(["postgresql://steward@postgres:5432/steward?sslmode=require", "p@ss:word"]);
+
+    expect(
+      parse("postgresql://steward@postgres:5432/steward?user=alice&password=query%40secret"),
+    ).toEqual(["postgresql://steward@postgres:5432/steward?user=alice", "query@secret"]);
+
+    // libpq keyword names are case-insensitive and may be percent-encoded;
+    // neither spelling may leave the password on pg_dump's argv.
+    expect(
+      parse("postgresql://steward@postgres:5432/steward?%70ASSWORD=encoded%2Fsecret&user=alice"),
+    ).toEqual(["postgresql://steward@postgres:5432/steward?user=alice", "encoded/secret"]);
+
+    expect(
+      parse(
+        "postgresql://steward@postgres:5432/steward?password=first&password=&PASSWORD=last%2Bsecret",
+      ),
+    ).toEqual(["postgresql://steward@postgres:5432/steward", "last+secret"]);
+    // An @ in a query is not userinfo, and an IPv6 host colon is not a
+    // username/password separator. Both DSNs must pass through byte-for-byte.
+    for (const passwordless of [
+      "postgresql://postgres:5432/steward?application_name=a@b",
+      "postgresql://[::1]:5432/steward?x=a@b",
+    ]) {
+      expect(parse(passwordless)).toEqual([passwordless, ""]);
+    }
+
+    for (const malformed of [
+      "postgresql://steward:p%ZZword@postgres:5432/steward",
+      "postgresql://steward:p%00word@postgres:5432/steward",
+      "postgresql://steward@postgres:5432/steward?password=bad%ZZsecret",
+    ]) {
+      const result = runParser(malformed);
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr.toString()).not.toContain(malformed);
+    }
+  });
 });
 
 describe("SEC-158 shipped nginx rate limiting and WebSocket map", () => {
@@ -299,7 +385,7 @@ describe("SEC-021 deploy/docker-compose.yml redis persists enforcement counters"
   });
 });
 
-describe("SEC-020 deploy/migrate-agent-keys.sh keeps the platform key off every argv", () => {
+describe("SEC-020 deploy scripts keep the platform key off every argv", () => {
   const script = read("migrate-agent-keys.sh");
 
   test("platform key is read on the remote side, never interpolated into ssh/curl argv", () => {
@@ -315,6 +401,7 @@ describe("SEC-020 deploy/migrate-agent-keys.sh keeps the platform key off every 
     expect(script).not.toContain("X-Steward-Platform-Key: \\${PK}");
     expect(script).toContain("AUTH_HEADER_SNIPPET");
     expect(script).toContain('-H \\"@\\${AUTH_FILE}\\"');
+    expect(script).toContain("*[!A-Za-z0-9._~-]*");
   });
 
   test("legacy positional key input is rejected without echoing the credential", () => {
@@ -344,13 +431,20 @@ describe("SEC-020 deploy/migrate-agent-keys.sh keeps the platform key off every 
     const readme = read("README.md");
     expect(provision).not.toContain("X-Steward-Platform-Key: \\${PK}");
     expect(provision).toContain('-H \\"@\\${AUTH_FILE}\\"');
+    expect(provision).toContain("*[!A-Za-z0-9._~-]*");
+    expect(provision).toContain('SSH_CMD=("${SSH_BASE[@]}" "root@${NODE_IP}")');
+    expect(provision).toContain('"${SSH_CMD[@]}"');
+    expect(provision).not.toMatch(/\$\{SSH_CMD\}\s+"/);
+    expect(provision).toContain("must be a single-line value");
     expect(doc).not.toContain("X-Steward-Platform-Key: \\${PK}");
     expect(doc).toContain('-H \\"@\\${AUTH_FILE}\\"');
+    expect(doc).toContain("*[!A-Za-z0-9._~-]*");
     expect(doc).not.toContain('-H "X-Steward-Platform-Key: $PK"');
     expect(doc).not.toContain("X-Steward-Platform-Key: <key>");
     expect(doc).not.toContain('-H "X-Steward-Key: $API_KEY"');
     expect(doc).toContain('> "$WEBHOOK_RESPONSE"');
     expect(readme).not.toContain('-H "X-Steward-Platform-Key: $PLATFORM_KEY"');
+    expect(readme).toContain("*[!A-Za-z0-9._~-]*");
   });
 
   test("agent tokens are written to a mode-0600 file, not echoed to stdout", () => {

--- a/packages/proxy/src/__tests__/health-minimized.test.ts
+++ b/packages/proxy/src/__tests__/health-minimized.test.ts
@@ -1,0 +1,43 @@
+/**
+ * SEC-174 pinning test: the unauthenticated proxy /health response must stay
+ * minimal — exactly { ok, service, serverTime }. The pre-fix body also leaked
+ * the service version and the alias list, which are recon details an
+ * unauthenticated caller can use to fingerprint the deployment and enumerate
+ * proxied upstreams. serverTime stays because the API readiness probe reads
+ * it. If a future change adds a field here, this test fails loudly so the
+ * exposure is a deliberate review decision, not an accident.
+ */
+import { describe, expect, test } from "bun:test";
+
+// Bootstrap the entrypoint's boot-time env BEFORE any dynamic import of
+// `../index.ts` (it validates the JWT secret and requires a database URL at
+// module load), matching the isolation posture of metrics-exposure.test.ts.
+process.env.STEWARD_ALLOW_DEV_SECRETS = "true";
+process.env.STEWARD_JWT_SECRET ||= "test-proxy-health-jwt-secret-32-characters-min";
+process.env.STEWARD_PGLITE_MEMORY = "true";
+process.env.DATABASE_URL ||= "postgres://steward:steward@127.0.0.1:5432/steward_test";
+
+describe("proxy /health minimized body (SEC-174)", () => {
+  test("unauthenticated /health exposes only ok/service/serverTime", async () => {
+    const mod = await import("../index.ts");
+    const app = mod.default as { fetch: (r: Request) => Promise<Response> };
+
+    const res = await app.fetch(new Request("http://proxy.local/health"));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+
+    // Exact key set — any added field (version, aliases, uptime, ...) fails
+    // this pin.
+    expect(Object.keys(body).sort()).toEqual(["ok", "serverTime", "service"]);
+    expect(body.ok).toBe(true);
+    expect(body.service).toBe("steward-proxy");
+    // serverTime is the API readiness probe's liveness signal: a valid ISO
+    // timestamp, nothing else.
+    expect(typeof body.serverTime).toBe("string");
+    expect(Number.isNaN(Date.parse(body.serverTime as string))).toBe(false);
+
+    // Explicit anti-regression pins for the pre-fix recon fields.
+    expect(body).not.toHaveProperty("version");
+    expect(body).not.toHaveProperty("aliases");
+  });
+});

--- a/packages/python/steward_sdk/client.py
+++ b/packages/python/steward_sdk/client.py
@@ -44,6 +44,12 @@ class StewardClientConfig:
     request_signing_secret: str | None = None
     request_signing_key_id: str | None = None
     timeout: float = 30.0
+    # WARNING: a custom transport replaces the default opener and its
+    # _StewardRedirectHandler, which strips credential headers on cross-host /
+    # HTTPS-downgrade redirects (SEC-125). A transport that follows redirects
+    # without re-applying that stripping silently re-enables credential
+    # exfiltration via open redirects — drop the Authorization / X-Steward-*
+    # headers on any host change or downgrade.
     transport: Transport | None = None
     # Appended to preserve the positional argument order of the published
     # config constructor. Permit plaintext non-loopback HTTP with a warning.

--- a/packages/redis/src/__tests__/client-tls.test.ts
+++ b/packages/redis/src/__tests__/client-tls.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { afterEach, describe, expect, test } from "bun:test";
-import { assertRedisUrlTls } from "../client";
+import { assertRedisUrlTls, assertUpstashRestUrlTls } from "../client";
 
 const originalNodeEnv = process.env.NODE_ENV;
 const originalOverride = process.env.STEWARD_ALLOW_INSECURE_REDIS;
@@ -62,5 +62,70 @@ describe("redis transport security (SEC-032)", () => {
     process.env.NODE_ENV = "development";
     delete process.env.STEWARD_ALLOW_INSECURE_REDIS;
     expect(() => assertRedisUrlTls("redis://redis.example.internal:6379")).not.toThrow();
+  });
+});
+
+describe("upstash REST transport security (SEC-032)", () => {
+  test("rejects cleartext http:// to a remote host in production", () => {
+    process.env.NODE_ENV = "production";
+    delete process.env.STEWARD_ALLOW_INSECURE_REDIS;
+    expect(() => assertUpstashRestUrlTls("http://us1-example.upstash.io")).toThrow("https://");
+  });
+
+  test("accepts https:// in production", () => {
+    process.env.NODE_ENV = "production";
+    delete process.env.STEWARD_ALLOW_INSECURE_REDIS;
+    expect(() => assertUpstashRestUrlTls("https://us1-example.upstash.io")).not.toThrow();
+  });
+
+  test("exempts loopback http:// even in production", () => {
+    process.env.NODE_ENV = "production";
+    delete process.env.STEWARD_ALLOW_INSECURE_REDIS;
+    expect(() => assertUpstashRestUrlTls("http://localhost:8079")).not.toThrow();
+    expect(() => assertUpstashRestUrlTls("http://127.0.0.1:8079")).not.toThrow();
+    expect(() => assertUpstashRestUrlTls("http://[::1]:8079")).not.toThrow();
+  });
+
+  test("honors the explicit insecure override with a warning", () => {
+    process.env.NODE_ENV = "production";
+    process.env.STEWARD_ALLOW_INSECURE_REDIS = "true";
+    expect(() => assertUpstashRestUrlTls("http://us1-example.upstash.io")).not.toThrow();
+  });
+
+  test("fails closed when a production URL cannot be parsed", () => {
+    process.env.NODE_ENV = "production";
+    delete process.env.STEWARD_ALLOW_INSECURE_REDIS;
+    expect(() => assertUpstashRestUrlTls("not a url")).toThrow("valid URL");
+  });
+
+  test("invalid URLs remain invalid even with the insecure override", () => {
+    process.env.NODE_ENV = "production";
+    process.env.STEWARD_ALLOW_INSECURE_REDIS = "true";
+    expect(() => assertUpstashRestUrlTls("not a url")).toThrow("valid URL");
+  });
+
+  test("rejects non-HTTP schemes even with the insecure override", () => {
+    process.env.NODE_ENV = "production";
+    delete process.env.STEWARD_ALLOW_INSECURE_REDIS;
+    expect(() => assertUpstashRestUrlTls("redis://us1-example.upstash.io")).toThrow("scheme");
+    process.env.STEWARD_ALLOW_INSECURE_REDIS = "true";
+    expect(() => assertUpstashRestUrlTls("ftp://us1-example.upstash.io")).toThrow("scheme");
+  });
+
+  test("does not restrict non-production environments", () => {
+    process.env.NODE_ENV = "development";
+    delete process.env.STEWARD_ALLOW_INSECURE_REDIS;
+    expect(() => assertUpstashRestUrlTls("http://us1-example.upstash.io")).not.toThrow();
+    expect(() => assertUpstashRestUrlTls("ftp://us1-example.upstash.io")).toThrow("scheme");
+  });
+
+  test("uses the caller-provided environment instead of ambient process state", () => {
+    process.env.NODE_ENV = "development";
+    expect(() =>
+      assertUpstashRestUrlTls("http://us1-example.upstash.io", { NODE_ENV: "production" }),
+    ).toThrow("https://");
+    expect(() =>
+      assertRedisUrlTls("redis://redis.example.internal:6379", { NODE_ENV: "production" }),
+    ).toThrow("rediss://");
   });
 });

--- a/packages/redis/src/client.ts
+++ b/packages/redis/src/client.ts
@@ -17,7 +17,11 @@
  *               URL must use rediss:// (TLS) unless it points at localhost or
  *               STEWARD_ALLOW_INSECURE_REDIS=true is set (assertRedisUrlTls).
  *   - upstash : KV_REST_API_URL + KV_REST_API_TOKEN
- *               (or UPSTASH_REDIS_REST_URL / UPSTASH_REDIS_REST_TOKEN)
+ *               (or UPSTASH_REDIS_REST_URL / UPSTASH_REDIS_REST_TOKEN).
+ *               In production the REST URL must be https:// — the REST token
+ *               rides every request, so http:// exposes it cleartext — unless
+ *               it targets localhost or STEWARD_ALLOW_INSECURE_REDIS=true is
+ *               set (assertUpstashRestUrlTls).
  */
 
 import { Redis as UpstashRedis } from "@upstash/redis";
@@ -38,10 +42,10 @@ let shutdownRegistered = false;
  * deployments (logs a loud warning), matching the STEWARD_ALLOW_INSECURE_DB
  * posture in @stwd/db.
  */
-export function assertRedisUrlTls(url: string): void {
-  if (process.env.NODE_ENV !== "production") return;
+export function assertRedisUrlTls(url: string, env: NodeJS.ProcessEnv = process.env): void {
+  if (env.NODE_ENV !== "production") return;
 
-  const allowInsecure = process.env.STEWARD_ALLOW_INSECURE_REDIS === "true";
+  const allowInsecure = env.STEWARD_ALLOW_INSECURE_REDIS === "true";
   let parsed: URL;
   try {
     parsed = new URL(url);
@@ -74,6 +78,52 @@ export function assertRedisUrlTls(url: string): void {
 
   throw new Error(
     "REDIS_URL must use rediss:// (TLS) in production. " +
+      "Set STEWARD_ALLOW_INSECURE_REDIS=true to override for private-network deployments.",
+  );
+}
+
+/**
+ * SEC-032, upstash path: the Upstash REST token authenticates every request,
+ * so a cleartext http:// endpoint exposes it (and lets a network-positioned
+ * attacker read/tamper with spend-limit, rate-limit, and auth KV state) even
+ * though the ioredis path is TLS-asserted. In production require https://
+ * unless the endpoint is loopback; STEWARD_ALLOW_INSECURE_REDIS=true overrides
+ * (loud warning), matching assertRedisUrlTls.
+ */
+export function assertUpstashRestUrlTls(url: string, env: NodeJS.ProcessEnv = process.env): void {
+  const allowInsecure = env.STEWARD_ALLOW_INSECURE_REDIS === "true";
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(
+      "KV_REST_API_URL must be a valid URL so TLS settings can be verified in production",
+    );
+  }
+
+  if (parsed.protocol !== "http:") {
+    if (parsed.protocol !== "https:") {
+      throw new Error("KV_REST_API_URL must use the http:// or https:// scheme");
+    }
+    return;
+  }
+
+  if (env.NODE_ENV !== "production") return;
+  const host = parsed.hostname.toLowerCase();
+  // URL.hostname keeps the brackets on IPv6 literals ([::1]).
+  if (host === "localhost" || host === "127.0.0.1" || host === "::1" || host === "[::1]") return;
+
+  if (allowInsecure) {
+    console.warn(
+      "[steward:redis] WARNING: STEWARD_ALLOW_INSECURE_REDIS=true — Upstash REST URL is cleartext http://. " +
+        "The REST token crosses the network unencrypted. This is only safe on a private network. " +
+        "SOC2 CC6.7 requires encryption in transit.",
+    );
+    return;
+  }
+
+  throw new Error(
+    "KV_REST_API_URL must use https:// in production — the Upstash REST token would otherwise cross the network in cleartext. " +
       "Set STEWARD_ALLOW_INSECURE_REDIS=true to override for private-network deployments.",
   );
 }
@@ -132,6 +182,10 @@ function buildUpstash(): IoredisLike {
         "(or UPSTASH_REDIS_REST_URL/UPSTASH_REDIS_REST_TOKEN) to be set",
     );
   }
+
+  // SEC-032: same TLS posture as the ioredis path — the REST token rides every
+  // request, so a cleartext http:// endpoint in production is fail-closed.
+  assertUpstashRestUrlTls(url);
 
   const upstash = new UpstashRedis({ url, token });
   console.log("[steward:redis] using upstash REST adapter");

--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -10,6 +10,7 @@ export {
 } from "./aggregation-tracker.js";
 export {
   assertRedisUrlTls,
+  assertUpstashRestUrlTls,
   disconnectRedis,
   getRedis,
   getRedisDriver,


### PR DESCRIPTION
| 1 | Platform key still landed in process arguments in the deployment scripts and documentation | **FIXED** — mode-0600 temporary header files keep the key out of argv and curl config parsing; keys are length-bounded and reject control/config-injection characters, SSH invocations remain argv-safe arrays, and executed regressions cover both scripts and docs. |## Re-audit batch W3-G (infra leftovers + misc)

Verification re-audit follow-ups. All seven assigned items addressed; each commit is one item (or tight cluster).

| # | Item | Status |
|---|------|--------|
| 1 | Platform key still landed in the node's process list: remote shell expanded `${PK}` into curl argv in `deploy/migrate-agent-keys.sh` + `deploy/provision-steward-node.sh` | **FIXED** — header now reaches curl through a mode-0600 temporary header file; platform keys are validated as bounded URL-safe tokens and never enter curl argv. The `deploy-artifacts.test.ts` assertion that pinned the old argv pattern now pins the new one (+ provision-script coverage). Same fix applied to the DEPLOYMENT.md Step 6 snippet, which had the identical remote-argv pattern. |
| 2 | `deploy/enterprise-reference/docker-compose.yml` backup: `pg_dump` argv carried the full password-bearing DSN on the host (SEC-050 re-introduced) | **FIXED** — userinfo password stripped from the DSN and passed via `PGPASSWORD` (percent-decoding included), mirroring `scripts/migrate.sh`. Regression test asserts ordering: strip before `pg_dump "$$dsn"`. |
| 3 | `packages/redis/src/client.ts` upstash path had no scheme check — `KV_REST_API_URL=http://` in production sent the REST token cleartext | **FIXED** — new `assertUpstashRestUrlTls()` extends the SEC-032 posture to the upstash driver: https required in production unless loopback, same `STEWARD_ALLOW_INSECURE_REDIS=true` override, non-http(s) schemes never overridable. 8 new test cases. |
| 4 | `packages/agent-trader/src/webhook-delivery-store.ts` raw ioredis TLS bypass for the replay-protection store | **FIXED** — `defaultRedisFactory` routes through the shared `assertRedisUrlTls` from `@stwd/redis` (throws before any socket opens). Adds the `@stwd/redis` workspace dep + one-line lockfile entry (verified with `bun install --frozen-lockfile`). Regression test: production + cleartext remote `REDIS_URL` throws via the default factory. |
| 5 | Custom transports silently bypass SEC-125/SEC-126 redirect credential-stripping (go `HTTPClient`, csharp `Transport`, flutter `httpClient`, python `transport`) | **FIXED (docs)** — loud warnings on each injection point: custom transport replaces the redirect protection and must strip Authorization / X-Steward-* headers on any cross-host or HTTPS-downgrade redirect. Comment-only; no behavior change. |
| 6 | SEC-174 test gap: no pin for the minimized proxy `/health` body | **FIXED** — new `health-minimized.test.ts` pins the exact key set `{ ok, service, serverTime }` (serverTime stays for the API readiness probe) plus explicit anti-regression pins for `version`/`aliases`. |
| 7 | DEPLOYMENT.md: hardcoded developer path; Redis `allkeys-lru` eviction of spend counters (SEC-021 side effect); SEC-088 no-eager-backfill note | **FIXED (docs)** — `/home/shad0w/...` replaced with an explicit `STEWARD_SRC` placeholder (3 rsync examples); new "Eviction policy" section recommends `noeviction` (fails closed) or `volatile-*` for the counters DB, or documented risk acceptance; SEC-088 note documents the deliberate lazy CAS upgrade of legacy plaintext webhook secrets (rotate/re-save to force re-encryption), in the operator guide and at the upgrade site in `webhook-dispatch.ts`. |

## Trade-offs / notes

- A mode-0600 temporary header file is used instead of `curl -K -`: this avoids curl-config injection by CR/LF/quote/backslash bytes and works on older curl builds. Platform keys are validated before the file is created.
- pg_dump DSN parsing is POSIX sh compatible, isolates userinfo from host ports and path or query at-signs, rejects malformed percent escapes and NUL, strips the password from argv, and clears password-bearing variables before execution.
- bun.lock: only the intentional `@stwd/redis` entry was kept; the rest of the re-resolution churn (pre-existing drift vs develop's lockfile, e.g. camelcase/yargs) was reverted.
- Pre-existing failure noted, NOT caused by this branch: `packages/proxy/src/__tests__/proxy-query-preservation.test.ts` fails 11/11 (401s) on pristine `origin/develop` too (verified in a clean worktree with fresh install). Out of scope here.

## Validation

- `packages/redis`: client-tls 14/14 pass; full suite 0 fail (61 pre-existing skips for live-Redis integration); `tsc --noEmit` clean; package rebuilt.
- `packages/agent-trader`: full suite 52/52 pass; `tsc --noEmit` clean.
- `packages/proxy`: deploy-artifacts 41/41, health-minimized 1/1, metrics-exposure co-run pass; `tsc --noEmit` clean.
- `packages/api`: `tsc --noEmit` clean (comment-only change).
- Go SDK: `gofmt` clean, `go vet` clean, `go test ./...` pass. Python SDK: 9/9 pytest pass.
- Shell: `bash -n` on both scripts; end-to-end ssh/curl coverage proves the key never reaches curl argv and the owner-only header file is used; compose YAML parses.
- `bunx biome check` clean on all changed TS/JSON files.
- C# / Flutter toolchains not available locally — comment-only changes, syntax inspected.

## Corrective re-audit — exact head 7670fd8a4c92bf928dc53b00b705c4aa2273646

The enterprise backup command now removes libpq query-string password parameters before invoking pg_dump. It decodes and matches case-insensitive and percent-encoded keyword names, percent-decodes the selected value into PGPASSWORD, retains unrelated query bytes, rejects malformed/control escapes, clears inherited PGPASSWORD and parser variables, and fails closed without printing the DSN. Duplicate non-empty password parameters follow libpq last-value semantics.

Deployment documentation now names the two production compose stacks that ship noeviction and explicitly warns that enterprise-reference/custom Redis requires separate noeviction verification; it does not recommend allkeys-lru.

Fresh exact-head validation after rebasing onto develop 417d98e4822f8d3f048ffe61c8cdaad1d50ec14f:
- deploy-artifacts suite: 45 passed, 176 assertions
- proxy TypeScript build: clean
- Biome, git diff --check, shell syntax, and enterprise compose YAML parse: clean

Hosted checks are queued for this exact head; review is still required before merge.