### PR TITLE
fix(security): bound credential lease database lifecycle

### DIFF
--- a/packages/api/src/__tests__/upstream-credential-lease-scheduler.test.ts
+++ b/packages/api/src/__tests__/upstream-credential-lease-scheduler.test.ts
@@ -28,6 +28,7 @@ test("lease scheduler runs at startup, repeats, and stops cleanly", async () => 
 
 test("lease scheduler immediately drains remaining work and waits for an in-flight sweep on stop", async () => {
   let calls = 0;
+  let durableMutations = 0;
   let release!: () => void;
   const blocked = new Promise<void>((resolve) => {
     release = resolve;
@@ -43,6 +44,7 @@ test("lease scheduler immediately drains remaining work and waits for an in-flig
       if (calls === 1) return { unknown: 0, revoked: 0, attention: 0, expired: 0, remaining: true };
       entered();
       await blocked;
+      durableMutations += 1;
       return { unknown: 0, revoked: 0, attention: 0, expired: 0, remaining: false };
     },
   });
@@ -56,6 +58,9 @@ test("lease scheduler immediately drains remaining work and waits for an in-flig
   release();
   await stopping;
   expect(calls).toBe(2);
+  expect(durableMutations).toBe(1);
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  expect(durableMutations).toBe(1);
 });
 
 test("lease scheduler rejects a production interval that cannot honor the ACK deadline", async () => {

--- a/packages/api/src/plugin.ts
+++ b/packages/api/src/plugin.ts
@@ -63,7 +63,14 @@
  */
 
 import { type AdapterCategory, AdapterRegistry, adapterRegistry } from "@stwd/adapters";
-import { pluginMigrationsTable, runPluginMigrations, withTenantAuditedTransaction } from "@stwd/db";
+import {
+  getDb,
+  pluginMigrationsTable,
+  runPluginMigrations,
+  withDatabaseDeadline,
+  withTenantAuditedTransaction,
+  withTenantAuditedTransactionOnDb,
+} from "@stwd/db";
 import {
   type EvaluatorContext,
   type PolicyRuleRegistry,
@@ -185,6 +192,13 @@ export interface StewardAppContext {
   isValidAnyAddress: typeof isValidAnyAddress;
   writeAuditEvent: typeof writeAuditEvent;
   withTenantAuditedTransaction: typeof withTenantAuditedTransaction;
+  withCredentialLeaseDatabaseDeadline<T>(
+    deadlineAt: number,
+    use: (
+      db: ReturnType<typeof getDb>,
+      auditedTransaction: typeof withTenantAuditedTransaction,
+    ) => Promise<T>,
+  ): Promise<T>;
   getAgentTokenStatus: typeof getAgentTokenStatus;
   getRedisClient: typeof getRedisClient;
   exerciseCredentialSecret<T>(
@@ -260,6 +274,12 @@ export function buildPluginContext(): StewardAppContext {
     isValidAnyAddress,
     writeAuditEvent,
     withTenantAuditedTransaction,
+    withCredentialLeaseDatabaseDeadline: (deadlineAt, use) =>
+      withDatabaseDeadline(deadlineAt, (deadlineDb) =>
+        use(deadlineDb, (tenantId, fn) =>
+          withTenantAuditedTransactionOnDb(deadlineDb, tenantId, fn, deadlineAt),
+        ),
+      ),
     getAgentTokenStatus,
     getRedisClient,
     exerciseCredentialSecret: (tenantId, secretId, use) =>

--- a/packages/api/src/services/upstream-credential-lease-scheduler.ts
+++ b/packages/api/src/services/upstream-credential-lease-scheduler.ts
@@ -52,6 +52,7 @@ export async function runUpstreamCredentialLeaseSweep() {
     issuer: new GitHubAppInstallationTokenIssuer(),
     exerciseToken: ctx.exerciseCredentialLeaseToken,
     auditedTransaction: ctx.withTenantAuditedTransaction,
+    withDatabaseDeadline: ctx.withCredentialLeaseDatabaseDeadline,
   });
 }
 

--- a/packages/db/src/__tests__/database-deadline-postgres.test.ts
+++ b/packages/db/src/__tests__/database-deadline-postgres.test.ts
@@ -47,4 +47,20 @@ describeWithPostgres("cancel-safe deadline on real Postgres", () => {
     const rows = await admin.client.unsafe(`SELECT id FROM ${tableName} WHERE id = $1`, [id]);
     expect(rows).toHaveLength(0);
   });
+
+  test("a callback paused across the deadline cannot mutate through the closed handle", async () => {
+    const id = randomUUID();
+    await expect(
+      withDatabaseDeadline(Date.now() + 1_200, async (db) => {
+        await Bun.sleep(1_500);
+        await db.execute(sql.raw(`INSERT INTO ${tableName} (id) VALUES ('${id}')`));
+      }),
+    ).rejects.toThrow(DATABASE_DEADLINE_EXCEEDED_MESSAGE);
+
+    // The deadline owns and destroys the dedicated handle. A callback that was
+    // idle in user code cannot resume later and enqueue a mutation on a shared
+    // pool connection after the caller has already observed the timeout.
+    const rows = await admin.client.unsafe(`SELECT id FROM ${tableName} WHERE id = $1`, [id]);
+    expect(rows).toHaveLength(0);
+  });
 });

--- a/packages/db/src/__tests__/database-deadline-postgres.test.ts
+++ b/packages/db/src/__tests__/database-deadline-postgres.test.ts
@@ -1,0 +1,50 @@
+import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { sql } from "drizzle-orm";
+import { createDb, DATABASE_DEADLINE_EXCEEDED_MESSAGE, withDatabaseDeadline } from "../client";
+
+const databaseUrl = process.env.DATABASE_URL;
+const describeWithPostgres = databaseUrl ? describe : describe.skip;
+const tableName = `deadline_rollback_${randomUUID().replaceAll("-", "")}`;
+const previousDriver = process.env.DATABASE_DRIVER;
+setDefaultTimeout(30_000);
+
+describeWithPostgres("cancel-safe deadline on real Postgres", () => {
+  let admin: ReturnType<typeof createDb>;
+
+  beforeAll(async () => {
+    process.env.DATABASE_DRIVER = "postgres-js";
+    admin = createDb(databaseUrl as string);
+    await admin.client.unsafe(`CREATE TABLE ${tableName} (id text PRIMARY KEY)`);
+  });
+
+  afterAll(async () => {
+    await admin.client.unsafe(`DROP TABLE IF EXISTS ${tableName}`);
+    await admin.client.end();
+    if (previousDriver === undefined) delete process.env.DATABASE_DRIVER;
+    else process.env.DATABASE_DRIVER = previousDriver;
+  });
+
+  test("includes fresh connection acquisition and cancels a sleeping read", async () => {
+    const startedAt = Date.now();
+    await expect(
+      withDatabaseDeadline(Date.now() + 1_200, (db) => db.execute(sql`select pg_sleep(5)`)),
+    ).rejects.toThrow(DATABASE_DEADLINE_EXCEEDED_MESSAGE);
+    expect(Date.now() - startedAt).toBeLessThan(2_500);
+  });
+
+  test("rolls back a timed-out transaction before returning control", async () => {
+    const id = randomUUID();
+    await expect(
+      withDatabaseDeadline(Date.now() + 1_200, (db) =>
+        db.transaction(async (tx) => {
+          await tx.execute(sql.raw(`INSERT INTO ${tableName} (id) VALUES ('${id}')`));
+          await tx.execute(sql`select pg_sleep(5)`);
+        }),
+      ),
+    ).rejects.toThrow(DATABASE_DEADLINE_EXCEEDED_MESSAGE);
+
+    const rows = await admin.client.unsafe(`SELECT id FROM ${tableName} WHERE id = $1`, [id]);
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/packages/db/src/__tests__/database-deadline.test.ts
+++ b/packages/db/src/__tests__/database-deadline.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { sql } from "drizzle-orm";
+import { DATABASE_DEADLINE_EXCEEDED_MESSAGE, withDatabaseDeadline } from "../client";
+
+const originalDriver = process.env.DATABASE_DRIVER;
+const originalUrl = process.env.DATABASE_URL;
+const originalNodeEnv = process.env.NODE_ENV;
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  if (originalDriver === undefined) delete process.env.DATABASE_DRIVER;
+  else process.env.DATABASE_DRIVER = originalDriver;
+  if (originalUrl === undefined) delete process.env.DATABASE_URL;
+  else process.env.DATABASE_URL = originalUrl;
+  if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+  else process.env.NODE_ENV = originalNodeEnv;
+  globalThis.fetch = originalFetch;
+});
+
+describe("cancel-safe database deadlines", () => {
+  test("aborts a stalled Neon fetch and exposes only the normalized error", async () => {
+    process.env.DATABASE_DRIVER = "neon-http";
+    process.env.DATABASE_URL = "postgresql://lease:secret@deadline.invalid/steward";
+    process.env.NODE_ENV = "test";
+    let observedSignal: AbortSignal | undefined;
+    globalThis.fetch = (async (_url, init) => {
+      observedSignal = init?.signal as AbortSignal;
+      return new Promise<Response>((_resolve, reject) => {
+        observedSignal?.addEventListener(
+          "abort",
+          () => reject(new DOMException("fixture included a secret query", "AbortError")),
+          { once: true },
+        );
+      });
+    }) as typeof fetch;
+
+    const startedAt = Date.now();
+    let caught: unknown;
+    try {
+      await withDatabaseDeadline(Date.now() + 1_100, (db) => db.execute(sql`select 1`));
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toBe(DATABASE_DEADLINE_EXCEEDED_MESSAGE);
+    expect((caught as Error).message).not.toContain("secret");
+    expect(observedSignal?.aborted).toBe(true);
+    expect(Date.now() - startedAt).toBeLessThan(2_000);
+  });
+});

--- a/packages/db/src/__tests__/database-deadline.test.ts
+++ b/packages/db/src/__tests__/database-deadline.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { sql } from "drizzle-orm";
-import { DATABASE_DEADLINE_EXCEEDED_MESSAGE, withDatabaseDeadline } from "../client";
+import { withTenantAuditQueue } from "../audit-chain";
+import {
+  DATABASE_DEADLINE_EXCEEDED_MESSAGE,
+  DatabaseDeadlineExceededError,
+  withDatabaseDeadline,
+} from "../client";
 
 const originalDriver = process.env.DATABASE_DRIVER;
 const originalUrl = process.env.DATABASE_URL;
@@ -18,6 +23,37 @@ afterEach(() => {
 });
 
 describe("cancel-safe database deadlines", () => {
+  test("a timed-out audit queue waiter never begins later in the background", async () => {
+    let release!: () => void;
+    let entered!: () => void;
+    const blocked = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const firstEntered = new Promise<void>((resolve) => {
+      entered = resolve;
+    });
+    const first = withTenantAuditQueue("deadline-queue", async () => {
+      entered();
+      await blocked;
+    });
+    await firstEntered;
+
+    let lateMutation = false;
+    await expect(
+      withTenantAuditQueue(
+        "deadline-queue",
+        async () => {
+          lateMutation = true;
+        },
+        Date.now() + 30,
+      ),
+    ).rejects.toBeInstanceOf(DatabaseDeadlineExceededError);
+    release();
+    await first;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(lateMutation).toBe(false);
+  });
+
   test("aborts a stalled Neon fetch and exposes only the normalized error", async () => {
     process.env.DATABASE_DRIVER = "neon-http";
     process.env.DATABASE_URL = "postgresql://lease:secret@deadline.invalid/steward";

--- a/packages/db/src/__tests__/database-deadline.test.ts
+++ b/packages/db/src/__tests__/database-deadline.test.ts
@@ -23,20 +23,20 @@ afterEach(() => {
 });
 
 describe("cancel-safe database deadlines", () => {
-  test("a timed-out audit queue waiter never begins later in the background", async () => {
-    let release!: () => void;
-    let entered!: () => void;
+  test("a timed-out audit waiter never runs later, while started work is awaited", async () => {
+    let releaseFirst!: () => void;
+    let firstEntered!: () => void;
     const blocked = new Promise<void>((resolve) => {
-      release = resolve;
+      releaseFirst = resolve;
     });
-    const firstEntered = new Promise<void>((resolve) => {
-      entered = resolve;
+    const entered = new Promise<void>((resolve) => {
+      firstEntered = resolve;
     });
     const first = withTenantAuditQueue("deadline-queue", async () => {
-      entered();
+      firstEntered();
       await blocked;
     });
-    await firstEntered;
+    await entered;
 
     let lateMutation = false;
     await expect(
@@ -45,13 +45,38 @@ describe("cancel-safe database deadlines", () => {
         async () => {
           lateMutation = true;
         },
-        Date.now() + 30,
+        Date.now() + 25,
       ),
     ).rejects.toBeInstanceOf(DatabaseDeadlineExceededError);
-    release();
+    releaseFirst();
     await first;
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await Bun.sleep(0);
     expect(lateMutation).toBe(false);
+
+    let releaseStarted!: () => void;
+    const startedBlock = new Promise<void>((resolve) => {
+      releaseStarted = resolve;
+    });
+    let startedEntered!: () => void;
+    const didStart = new Promise<void>((resolve) => {
+      startedEntered = resolve;
+    });
+    let returned = false;
+    const started = withTenantAuditQueue(
+      "deadline-queue-started",
+      async () => {
+        startedEntered();
+        await startedBlock;
+      },
+      Date.now() + 25,
+    ).then(() => {
+      returned = true;
+    });
+    await didStart;
+    await Bun.sleep(40);
+    expect(returned).toBe(false);
+    releaseStarted();
+    await started;
   });
 
   test("aborts a stalled Neon fetch and exposes only the normalized error", async () => {

--- a/packages/db/src/audit-chain.ts
+++ b/packages/db/src/audit-chain.ts
@@ -270,12 +270,14 @@ export async function withTenantAuditQueue<T>(
 ): Promise<T> {
   const prior = tenantAuditQueues.get(tenantId) ?? Promise.resolve();
   let cancelled = false;
+  let started = false;
   const run = prior
     .catch(() => undefined)
     .then(() => {
       if (cancelled || (deadlineAt !== undefined && Date.now() >= deadlineAt)) {
         throw new DatabaseDeadlineExceededError();
       }
+      started = true;
       return fn();
     });
   const tail = run.then(
@@ -296,16 +298,18 @@ export async function withTenantAuditQueue<T>(
     throw new DatabaseDeadlineExceededError();
   }
   let timer: ReturnType<typeof setTimeout> | undefined;
-  const deadline = new Promise<never>((_resolve, reject) => {
+  const waitingDeadline = new Promise<never>((_resolve, reject) => {
     timer = setTimeout(() => {
+      // Once fn has begun, its driver owns cancellation and rollback. Rejecting
+      // here would abandon an in-flight mutation and let it complete after the
+      // caller regained control.
+      if (started) return;
       cancelled = true;
       reject(new DatabaseDeadlineExceededError());
     }, remainingMs);
   });
   try {
-    // Racing is safe here: cancellation is checked before `fn` begins, so no
-    // database work is abandoned after it starts.
-    return await Promise.race([run, deadline]);
+    return await Promise.race([run, waitingDeadline]);
   } finally {
     if (timer) clearTimeout(timer);
   }

--- a/packages/db/src/audit-chain.ts
+++ b/packages/db/src/audit-chain.ts
@@ -25,7 +25,7 @@
 import { createHmac } from "node:crypto";
 import { observeSecurityAuditEvent } from "@stwd/shared";
 import { sql } from "drizzle-orm";
-import { getDb } from "./client";
+import { DatabaseDeadlineExceededError, getDb } from "./client";
 
 const ZERO_HASH = new Uint8Array(32);
 
@@ -263,21 +263,51 @@ const tenantAuditQueues = new Map<string, Promise<void>>();
  * guarantee and also gates the real-Postgres advisory-lock acquisition so
  * concurrent appends within one process cannot interleave the seq read/insert.
  */
-export async function withTenantAuditQueue<T>(tenantId: string, fn: () => Promise<T>): Promise<T> {
+export async function withTenantAuditQueue<T>(
+  tenantId: string,
+  fn: () => Promise<T>,
+  deadlineAt?: number,
+): Promise<T> {
   const prior = tenantAuditQueues.get(tenantId) ?? Promise.resolve();
-  const run = prior.catch(() => undefined).then(fn);
+  let cancelled = false;
+  const run = prior
+    .catch(() => undefined)
+    .then(() => {
+      if (cancelled || (deadlineAt !== undefined && Date.now() >= deadlineAt)) {
+        throw new DatabaseDeadlineExceededError();
+      }
+      return fn();
+    });
   const tail = run.then(
     () => undefined,
     () => undefined,
   );
   tenantAuditQueues.set(tenantId, tail);
-
-  try {
-    return await run;
-  } finally {
+  void tail.then(() => {
     if (tenantAuditQueues.get(tenantId) === tail) {
       tenantAuditQueues.delete(tenantId);
     }
+  });
+  if (deadlineAt === undefined) return run;
+
+  const remainingMs = deadlineAt - Date.now();
+  if (remainingMs <= 0) {
+    cancelled = true;
+    throw new DatabaseDeadlineExceededError();
+  }
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      cancelled = true;
+      reject(new DatabaseDeadlineExceededError());
+    }, remainingMs);
+  });
+  try {
+    // Racing is safe here: cancellation is checked before `fn` begins, so no
+    // database work is abandoned after it starts.
+    return await Promise.race([run, deadline]);
+  } finally {
+    if (timer) clearTimeout(timer);
   }
 }
 
@@ -531,10 +561,5 @@ export async function withTenantAuditedTransactionOnDb<T>(
     throw new Error("withTenantAuditedTransaction: exhausted retries");
   };
 
-  // A deadline-bound network handle must not sit behind an uncancellable
-  // process-local queue. PostgreSQL's transaction advisory lock is the source
-  // of truth and is covered by lock_timeout; the queue remains necessary for
-  // PGLite, which has no advisory locks.
-  if (deadlineAt !== undefined && !isPGLiteRuntime()) return execute();
-  return withTenantAuditQueue(tenantId, execute);
+  return withTenantAuditQueue(tenantId, execute, deadlineAt);
 }

--- a/packages/db/src/audit-chain.ts
+++ b/packages/db/src/audit-chain.ts
@@ -462,12 +462,39 @@ export async function withTenantAuditedTransaction<T>(
 ): Promise<T> {
   const db = getDb();
 
-  return withTenantAuditQueue(tenantId, async () => {
+  return withTenantAuditedTransactionOnDb(db, tenantId, fn);
+}
+
+/** Deadline-aware form used by bounded credential-lease lifecycles. The
+ * supplied handle is dedicated to that lifecycle, so all reads and audited
+ * mutations share one driver cancellation boundary. */
+export async function withTenantAuditedTransactionOnDb<T>(
+  db: ReturnType<typeof getDb>,
+  tenantId: string,
+  fn: (tx: unknown, appendRequiredAudit: AppendRequiredAudit) => Promise<T>,
+  deadlineAt?: number,
+): Promise<T> {
+  const assertRemaining = () => {
+    if (deadlineAt !== undefined && deadlineAt - Date.now() < 1_000) {
+      throw new Error("database operation deadline exceeded");
+    }
+  };
+
+  const execute = async () => {
     for (let attempt = 0; attempt < 5; attempt++) {
       try {
+        assertRemaining();
         const committedEvents: AuditEventInput[] = [];
         const result = await db.transaction(async (tx) => {
           if (!isPGLiteRuntime()) {
+            if (deadlineAt !== undefined) {
+              const remaining = Math.max(1, deadlineAt - Date.now());
+              await tx.execute(sql.raw(`SET LOCAL statement_timeout = '${remaining}ms'`));
+              await tx.execute(sql.raw(`SET LOCAL lock_timeout = '${remaining}ms'`));
+              await tx.execute(
+                sql.raw(`SET LOCAL idle_in_transaction_session_timeout = '${remaining}ms'`),
+              );
+            }
             await tx.execute(
               sql`SELECT pg_advisory_xact_lock(hashtextextended(${`steward_audit_${tenantId}`}, 0))`,
             );
@@ -493,6 +520,7 @@ export async function withTenantAuditedTransaction<T>(
         return result;
       } catch (err) {
         if (attempt < 4 && isAuditSequenceConflict(err)) {
+          assertRemaining();
           await new Promise((resolve) => setTimeout(resolve, 5 * (attempt + 1)));
           continue;
         }
@@ -501,5 +529,12 @@ export async function withTenantAuditedTransaction<T>(
     }
     // Unreachable: the loop either returns or throws.
     throw new Error("withTenantAuditedTransaction: exhausted retries");
-  });
+  };
+
+  // A deadline-bound network handle must not sit behind an uncancellable
+  // process-local queue. PostgreSQL's transaction advisory lock is the source
+  // of truth and is covered by lock_timeout; the queue remains necessary for
+  // PGLite, which has no advisory locks.
+  if (deadlineAt !== undefined && !isPGLiteRuntime()) return execute();
+  return withTenantAuditQueue(tenantId, execute);
 }

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -188,6 +188,8 @@ function isDatabaseDeadlineError(error: unknown): boolean {
     const candidate = current as { code?: unknown; name?: unknown; cause?: unknown };
     if (
       candidate.code === "57014" ||
+      candidate.code === "55P03" ||
+      candidate.code === "25P03" ||
       candidate.code === "CONNECT_TIMEOUT" ||
       candidate.name === "AbortError" ||
       candidate.name === "TimeoutError"

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -139,6 +139,138 @@ export function createPostgresClient(connectionString = getDatabaseUrl()) {
   });
 }
 
+export const DATABASE_DEADLINE_EXCEEDED_MESSAGE = "database operation deadline exceeded";
+const DATABASE_DEADLINE_CLEANUP_GRACE_MS = 100;
+
+export class DatabaseDeadlineExceededError extends Error {
+  constructor() {
+    super(DATABASE_DEADLINE_EXCEEDED_MESSAGE);
+    this.name = "DatabaseDeadlineExceededError";
+  }
+}
+
+function deadlineMilliseconds(deadlineAt: number): number {
+  if (!Number.isSafeInteger(deadlineAt)) throw new Error("database deadline must be an integer");
+  const remaining = deadlineAt - Date.now();
+  if (remaining < 1_000) throw new DatabaseDeadlineExceededError();
+  return remaining;
+}
+
+function serverDeadlineConnectionParameters(remainingMs: number) {
+  // Let PostgreSQL cancel first. The driver-level timer below is the hard stop
+  // for connect/acquisition stalls and retains a small window for the server's
+  // cancellation response to reach the client before its socket is destroyed.
+  const serverMs = Math.max(1, remainingMs - DATABASE_DEADLINE_CLEANUP_GRACE_MS);
+  return {
+    statement_timeout: serverMs,
+    lock_timeout: serverMs,
+    idle_in_transaction_session_timeout: serverMs,
+  };
+}
+
+function withServerDeadlineInUrl(connectionString: string, remainingMs: number): string {
+  const parsed = new URL(connectionString);
+  const existing = parsed.searchParams.get("options")?.trim();
+  const serverMs = Math.max(1, remainingMs - DATABASE_DEADLINE_CLEANUP_GRACE_MS);
+  const limits = [
+    `-c statement_timeout=${serverMs}`,
+    `-c lock_timeout=${serverMs}`,
+    `-c idle_in_transaction_session_timeout=${serverMs}`,
+  ].join(" ");
+  parsed.searchParams.set("options", existing ? `${existing} ${limits}` : limits);
+  return parsed.toString();
+}
+
+function isDatabaseDeadlineError(error: unknown): boolean {
+  if (error instanceof DatabaseDeadlineExceededError) return true;
+  let current = error;
+  for (let depth = 0; depth < 5 && current && typeof current === "object"; depth += 1) {
+    const candidate = current as { code?: unknown; name?: unknown; cause?: unknown };
+    if (
+      candidate.code === "57014" ||
+      candidate.code === "CONNECT_TIMEOUT" ||
+      candidate.name === "AbortError" ||
+      candidate.name === "TimeoutError"
+    ) {
+      return true;
+    }
+    current = candidate.cause;
+  }
+  return false;
+}
+
+/**
+ * Run one database unit of work under an absolute, cancel-safe deadline.
+ *
+ * postgres-js uses a fresh max=1 client: there is no unbounded shared-pool
+ * queue, connect_timeout covers DNS/TCP/TLS/authentication, PostgreSQL enforces
+ * statement/lock/idle-in-transaction limits, and the absolute timer closes the
+ * driver connection. postgres-js settles active queries only after that close,
+ * so an open transaction is rolled back before this function rejects.
+ *
+ * neon-http uses a per-call AbortSignal and the same server parameters. Its HTTP
+ * response can stall independently of PostgreSQL, so the fetch abort is the hard
+ * transport bound while the earlier server limit protects transaction atomicity.
+ */
+export async function withDatabaseDeadline<T>(
+  deadlineAt: number,
+  use: (db: ReturnType<typeof createDb>["db"]) => Promise<T>,
+): Promise<T> {
+  const remainingMs = deadlineMilliseconds(deadlineAt);
+
+  if (pgliteOverride) {
+    // Embedded PGLite has no network/pool and no cancel API. Keep the same
+    // phase-start contract without pretending that WASM execution is abortable.
+    return use(pgliteOverride.db as ReturnType<typeof createDb>["db"]);
+  }
+
+  if (getDatabaseDriver() === "neon-http") {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), remainingMs);
+    try {
+      const { db } = createNeonHttpDb(withServerDeadlineInUrl(getDatabaseUrl(), remainingMs), {
+        signal: controller.signal,
+      });
+      return await use(db as unknown as ReturnType<typeof createDb>["db"]);
+    } catch (error) {
+      if (controller.signal.aborted || isDatabaseDeadlineError(error)) {
+        throw new DatabaseDeadlineExceededError();
+      }
+      throw error;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  const client = postgres(getDatabaseUrl(), {
+    max: 1,
+    prepare: false,
+    connect_timeout: Math.max(1, Math.floor(remainingMs / 1_000)),
+    connection: serverDeadlineConnectionParameters(remainingMs),
+  });
+  const db = drizzlePostgres(client, { schema: FULL_SCHEMA });
+  let deadlineClose: Promise<void> | undefined;
+  const timer = setTimeout(() => {
+    // This is driver cancellation, not an abandoned Promise.race. Destroying
+    // the sole connection makes PostgreSQL roll back any open transaction and
+    // rejects its query before `use` can settle.
+    deadlineClose = client.end({ timeout: 0 });
+  }, remainingMs);
+  try {
+    return await use(db);
+  } catch (error) {
+    if (deadlineClose || Date.now() >= deadlineAt || isDatabaseDeadlineError(error)) {
+      if (deadlineClose) await deadlineClose.catch(() => undefined);
+      throw new DatabaseDeadlineExceededError();
+    }
+    throw error;
+  } finally {
+    clearTimeout(timer);
+    if (deadlineClose) await deadlineClose.catch(() => undefined);
+    else await client.end({ timeout: 0 });
+  }
+}
+
 // ─── postgres-js (Bun/Node) ───────────────────────────────────────────────────
 
 export function createDb(connectionString = getDatabaseUrl()) {
@@ -157,12 +289,19 @@ export function createDb(connectionString = getDatabaseUrl()) {
  * Each call returns a fresh client; for per-request use this is intentional —
  * the underlying transport is HTTP, so there is no TCP connection to reuse.
  */
-export function createNeonHttpDb(connectionString = getDatabaseUrl()) {
+export function createNeonHttpDb(
+  connectionString = getDatabaseUrl(),
+  options: { signal?: AbortSignal } = {},
+) {
   assertDatabaseUrlTls(connectionString);
   // Lazy-require so Bun/Node entry points don't pull @neondatabase/serverless
   // into their bundle when the postgres-js driver is in use.
-  const { neon } = require("@neondatabase/serverless") as { neon: (url: string) => any };
-  const client = neon(connectionString);
+  const { neon } = require("@neondatabase/serverless") as {
+    neon: (url: string, options?: Record<string, unknown>) => any;
+  };
+  const client = neon(connectionString, {
+    fetchOptions: options.signal ? { signal: options.signal } : undefined,
+  });
   const db = drizzleNeon(client, { schema: FULL_SCHEMA });
   return { client, db };
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -17,6 +17,7 @@ export {
   appendAuditEventWithinTx,
   redactWebhookSecrets,
   withTenantAuditedTransaction,
+  withTenantAuditedTransactionOnDb,
   withTenantAuditQueue,
   writeAuditEvent,
 } from "./audit-chain";
@@ -27,11 +28,14 @@ export {
   createDbForRequest,
   createNeonHttpDb,
   createPostgresClient,
+  DATABASE_DEADLINE_EXCEEDED_MESSAGE,
+  DatabaseDeadlineExceededError,
   getDatabaseDriver,
   getDatabaseUrl,
   getDb,
   getSql,
   setPGLiteOverride,
+  withDatabaseDeadline,
 } from "./client";
 export { runMigrations } from "./migrate";
 export { getMigrationExpectation, type MigrationExpectation } from "./migration-status";

--- a/packages/plugin-capabilities/PROVIDER-MODES.md
+++ b/packages/plugin-capabilities/PROVIDER-MODES.md
@@ -60,14 +60,16 @@ the live grant expires before GitHub's fixed one-hour token expiry; a provider
 token is never delivered with a lifetime beyond its authority.
 
 Issue, acknowledgement, revoke, and recovery use one 25-second absolute
-lifecycle deadline inside the 30-second delivery/recovery contract. A provider
-phase requires at least 12 seconds remaining (the 10-second GitHub transport
-limit plus a two-second durable-finalization reserve), and a database phase is
-not started with less than one second remaining. postgres-js uses a fresh
-single-connection client for each lifecycle, so connection/pool acquisition,
-DNS/TCP/TLS/authentication, statements, locks, and transactions are all inside
-the deadline; timeout closes that connection and PostgreSQL rolls an open
-transaction back before control returns. Neon HTTP requests carry an abort
+lifecycle deadline inside the 30-second delivery/recovery contract. Minting is
+started only with at least 23 seconds remaining, and the GitHub transport gets
+an earlier sub-deadline that reserves 13 seconds for escrow, durable
+finalization, or compensating revocation. Revocation starts only with at least
+12 seconds remaining and reserves the final second for its database outcome. A
+database phase is not started with less than one second remaining. postgres-js
+uses a fresh single-connection client for each lifecycle, so connection/pool
+acquisition, DNS/TCP/TLS/authentication, statements, locks, and transactions are
+all inside the deadline; timeout closes that connection and PostgreSQL rolls an
+open transaction back before control returns. Neon HTTP requests carry an abort
 signal and earlier server-side statement/lock/transaction limits. Timeout
 errors are normalized and never contain SQL, parameters, provider bodies, or
 connection strings.

--- a/packages/plugin-capabilities/PROVIDER-MODES.md
+++ b/packages/plugin-capabilities/PROVIDER-MODES.md
@@ -59,6 +59,19 @@ an upstream lifetime Steward cannot enforce. Issuance also fails closed when
 the live grant expires before GitHub's fixed one-hour token expiry; a provider
 token is never delivered with a lifetime beyond its authority.
 
+Issue, acknowledgement, revoke, and recovery use one 25-second absolute
+lifecycle deadline inside the 30-second delivery/recovery contract. A provider
+phase requires at least 12 seconds remaining (the 10-second GitHub transport
+limit plus a two-second durable-finalization reserve), and a database phase is
+not started with less than one second remaining. postgres-js uses a fresh
+single-connection client for each lifecycle, so connection/pool acquisition,
+DNS/TCP/TLS/authentication, statements, locks, and transactions are all inside
+the deadline; timeout closes that connection and PostgreSQL rolls an open
+transaction back before control returns. Neon HTTP requests carry an abort
+signal and earlier server-side statement/lock/transaction limits. Timeout
+errors are normalized and never contain SQL, parameters, provider bodies, or
+connection strings.
+
 The long-lived API starts an immediate, periodic, cursor-bounded recovery sweep
 for every tenant with durable lease state. It revokes abandoned deliveries and
 stale encrypted handles without waiting for another issuance request, and

--- a/packages/plugin-capabilities/src/__tests__/github-app-issuer.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/github-app-issuer.test.ts
@@ -88,6 +88,32 @@ describe("GitHub App upstream issuer transport", () => {
     expect(error.message).not.toContain("secret provider cancellation diagnostic");
   });
 
+  test("uses the remaining lifecycle budget instead of restarting its full timeout", async () => {
+    let calls = 0;
+    const issuer = new GitHubAppInstallationTokenIssuer(
+      ((_url, init) => {
+        calls += 1;
+        return new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("aborted", "AbortError")),
+            { once: true },
+          );
+        });
+      }) as typeof fetch,
+      5_000,
+    );
+    const startedAt = Date.now();
+    await expect(issuer.issue(request, { deadlineAt: Date.now() + 30 })).rejects.toThrow(
+      "GitHub request timed out",
+    );
+    expect(Date.now() - startedAt).toBeLessThan(1_000);
+    await expect(issuer.revoke("token", { deadlineAt: Date.now() - 1 })).rejects.toThrow(
+      "GitHub request timed out",
+    );
+    expect(calls).toBe(1);
+  });
+
   test("bounds stalled response bodies and contains hostile cancel rejection", async () => {
     let cancelCalled = false;
     const issuer = new GitHubAppInstallationTokenIssuer(

--- a/packages/plugin-capabilities/src/__tests__/upstream-leases.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/upstream-leases.test.ts
@@ -1492,6 +1492,28 @@ describe("upstream credential leases", () => {
       );
     expect(recoverable.tokenHash).toBe(sha256(TOKEN));
     expect(recoverable.tokenCiphertext).toBe(Buffer.from(TOKEN).toString("base64"));
+
+    await harness.db
+      .update(upstreamCredentialLeases)
+      .set({ updatedAt: new Date(NOW.getTime() - 31_000) })
+      .where(eq(upstreamCredentialLeases.id, recoverable.id));
+    issuer.failRevoke = false;
+    expect(
+      await recoverInterruptedUpstreamCredentialLeases({
+        db: harness.db,
+        tenantId: TENANT,
+        issuer,
+        exerciseToken,
+        auditedTransaction: auditedTransaction(),
+        now: NOW,
+      }),
+    ).toEqual({ unknown: 0, revoked: 1, attention: 0 });
+    const [recovered] = await harness.db
+      .select()
+      .from(upstreamCredentialLeases)
+      .where(eq(upstreamCredentialLeases.id, recoverable.id));
+    expect(recovered.status).toBe("revoked");
+    expect(issuer.revokeCalls).toBe(2);
   });
 
   test("stale issuance is truthfully escalated because provider outcome is unknowable", async () => {

--- a/packages/plugin-capabilities/src/__tests__/upstream-leases.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/upstream-leases.test.ts
@@ -771,6 +771,13 @@ describe("upstream credential leases", () => {
       .from(upstreamCredentialLeases)
       .where(eq(upstreamCredentialLeases.id, issued.leaseId));
     expect(row.status).toBe("expired");
+    expect(row).toMatchObject({
+      tokenHash: null,
+      tokenCiphertext: null,
+      tokenIv: null,
+      tokenAuthTag: null,
+      tokenSalt: null,
+    });
     const events = await harness.db
       .select()
       .from(upstreamCredentialLeaseEvents)
@@ -1513,6 +1520,13 @@ describe("upstream credential leases", () => {
       .from(upstreamCredentialLeases)
       .where(eq(upstreamCredentialLeases.id, recoverable.id));
     expect(recovered.status).toBe("revoked");
+    expect(recovered).toMatchObject({
+      tokenHash: null,
+      tokenCiphertext: null,
+      tokenIv: null,
+      tokenAuthTag: null,
+      tokenSalt: null,
+    });
     expect(issuer.revokeCalls).toBe(2);
   });
 

--- a/packages/plugin-capabilities/src/__tests__/upstream-leases.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/upstream-leases.test.ts
@@ -216,6 +216,87 @@ describe("upstream credential leases", () => {
     expect(issuer.issueCalls).toBe(0);
   });
 
+  test("threads one absolute database deadline through issue, ACK, revoke, and recovery", async () => {
+    const observedDeadlines: number[] = [];
+    const withDatabaseDeadline = async <T>(
+      deadlineAt: number,
+      use: (db: any, audited: ReturnType<typeof auditedTransaction>) => Promise<T>,
+    ) => {
+      observedDeadlines.push(deadlineAt);
+      return use(harness.db, auditedTransaction());
+    };
+    const issuer = new FakeIssuer();
+    const issued = await issueUpstreamCredentialLease({
+      ...issueArgs(issuer, "idempotency-deadline-threading"),
+      withDatabaseDeadline,
+    });
+    if (!issued.ok) throw new Error("expected issuance");
+    expect(
+      await acknowledgeUpstreamCredentialLease({
+        db: harness.db,
+        tenantId: TENANT,
+        agentId: AGENT,
+        leaseId: issued.leaseId,
+        token: issued.token,
+        auditedTransaction: auditedTransaction(),
+        withDatabaseDeadline,
+        now: NOW,
+      }),
+    ).toEqual({ ok: true });
+    expect(
+      await revokeUpstreamCredentialLease({
+        db: harness.db,
+        tenantId: TENANT,
+        agentId: AGENT,
+        leaseId: issued.leaseId,
+        token: issued.token,
+        issuer,
+        auditedTransaction: auditedTransaction(),
+        withDatabaseDeadline,
+        now: NOW,
+      }),
+    ).toEqual({ ok: true });
+    await recoverInterruptedUpstreamCredentialLeases({
+      db: harness.db,
+      tenantId: TENANT,
+      issuer,
+      exerciseToken,
+      auditedTransaction: auditedTransaction(),
+      withDatabaseDeadline,
+      now: NOW,
+    });
+    await recoverAllInterruptedUpstreamCredentialLeases({
+      db: harness.db,
+      issuer,
+      exerciseToken,
+      auditedTransaction: auditedTransaction(),
+      withDatabaseDeadline,
+      now: NOW,
+    });
+    expect(observedDeadlines).toHaveLength(5);
+    expect(observedDeadlines.every((deadline) => deadline > Date.now())).toBe(true);
+  });
+
+  test("does not acquire a database handle when the lifecycle budget is already insufficient", async () => {
+    let acquisitions = 0;
+    await expect(
+      acknowledgeUpstreamCredentialLease({
+        db: harness.db,
+        tenantId: TENANT,
+        agentId: AGENT,
+        leaseId: "90000000-0000-4000-8000-000000000001",
+        token: TOKEN,
+        auditedTransaction: auditedTransaction(),
+        deadlineAt: Date.now() + 100,
+        withDatabaseDeadline: async (_deadlineAt, use) => {
+          acquisitions += 1;
+          return use(harness.db, auditedTransaction());
+        },
+      }),
+    ).rejects.toThrow("credential lease lifecycle timed out");
+    expect(acquisitions).toBe(0);
+  });
+
   test("denies and revokes when the fixed provider token would outlive its grant", async () => {
     const issuer = new FakeIssuer();
     await harness.db
@@ -826,6 +907,43 @@ describe("upstream credential leases", () => {
     expect(row.status).toBe("revoked");
   });
 
+  test("global recovery does not start provider work without the minimum remaining budget", async () => {
+    const issued = await issueUpstreamCredentialLease(
+      issueArgs(new FakeIssuer(), "idempotency-insufficient-recovery-budget"),
+    );
+    if (!issued.ok) throw new Error("expected issuance");
+    await harness.db
+      .update(upstreamCredentialLeases)
+      .set({ updatedAt: new Date(NOW.getTime() - DELIVERY_ACK_TIMEOUT_MS - 1_000) })
+      .where(eq(upstreamCredentialLeases.id, issued.leaseId));
+    let providerCalls = 0;
+    const issuer: UpstreamTokenIssuer = {
+      issue: async () => {
+        throw new Error("not used");
+      },
+      revoke: async () => {
+        providerCalls += 1;
+      },
+    };
+
+    const result = await recoverAllInterruptedUpstreamCredentialLeases({
+      db: harness.db,
+      issuer,
+      exerciseToken,
+      auditedTransaction: auditedTransaction(),
+      now: NOW,
+      runDeadlineMs: 5_000,
+    });
+
+    expect(providerCalls).toBe(0);
+    expect(result.remaining).toBe(true);
+    const [row] = await harness.db
+      .select({ status: upstreamCredentialLeases.status })
+      .from(upstreamCredentialLeases)
+      .where(eq(upstreamCredentialLeases.id, issued.leaseId));
+    expect(row.status).toBe("delivery_pending");
+  });
+
   test("global deadline ordering drains over 100 tenants despite a slow failing oldest tenant", async () => {
     const [baseWorkspace] = await harness.db
       .select()
@@ -913,7 +1031,7 @@ describe("upstream credential leases", () => {
       now: NOW,
       workLimit: 200,
       concurrency: 16,
-      runDeadlineMs: 5_000,
+      runDeadlineMs: 25_000,
     });
     await oldestStarted;
     const lastId = uuid(count, 2);

--- a/packages/plugin-capabilities/src/__tests__/upstream-leases.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/upstream-leases.test.ts
@@ -280,7 +280,8 @@ describe("upstream credential leases", () => {
       withDatabaseDeadline,
       now: NOW,
     });
-    expect(observedDeadlines).toHaveLength(5);
+    expect(observedDeadlines).toHaveLength(6);
+    expect(observedDeadlines[1]).toBe(observedDeadlines[0] - 12_000);
     expect(observedDeadlines.every((deadline) => deadline > Date.now())).toBe(true);
   });
 
@@ -1443,6 +1444,54 @@ describe("upstream credential leases", () => {
         now: NOW,
       }),
     ).toEqual({ unknown: 0, revoked: 1, attention: 0 });
+  });
+
+  test("checkpoints the sealed token before audited delivery finalization can fail", async () => {
+    const issuer = new FakeIssuer();
+    issuer.failRevoke = true;
+    let sawCheckpointBeforeAudit = false;
+    let databasePhases = 0;
+    const denied = await issueUpstreamCredentialLease({
+      ...issueArgs(issuer, "idempotency-pre-finalization-checkpoint"),
+      withDatabaseDeadline: async (_deadlineAt, use) => {
+        const phase = ++databasePhases;
+        const result = await use(
+          harness.db,
+          auditedTransaction(async () => {
+            throw new Error("durable audit stalled then failed");
+          }),
+        );
+        if (phase === 2) {
+          const [checkpoint] = await harness.db
+            .select()
+            .from(upstreamCredentialLeases)
+            .where(
+              eq(
+                upstreamCredentialLeases.idempotencyKeyHash,
+                sha256("idempotency-pre-finalization-checkpoint"),
+              ),
+            );
+          sawCheckpointBeforeAudit =
+            checkpoint.status === "issuing" &&
+            checkpoint.tokenHash === sha256(TOKEN) &&
+            checkpoint.tokenCiphertext === Buffer.from(TOKEN).toString("base64");
+        }
+        return result;
+      },
+    });
+    expect(denied).toMatchObject({ ok: false, code: "lease_finalization_failed" });
+    expect(sawCheckpointBeforeAudit).toBe(true);
+    const [recoverable] = await harness.db
+      .select()
+      .from(upstreamCredentialLeases)
+      .where(
+        eq(
+          upstreamCredentialLeases.idempotencyKeyHash,
+          sha256("idempotency-pre-finalization-checkpoint"),
+        ),
+      );
+    expect(recoverable.tokenHash).toBe(sha256(TOKEN));
+    expect(recoverable.tokenCiphertext).toBe(Buffer.from(TOKEN).toString("base64"));
   });
 
   test("stale issuance is truthfully escalated because provider outcome is unknowable", async () => {

--- a/packages/plugin-capabilities/src/__tests__/upstream-leases.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/upstream-leases.test.ts
@@ -43,6 +43,8 @@ let workspaceId: string;
 class FakeIssuer implements UpstreamTokenIssuer {
   issueCalls = 0;
   revokeCalls = 0;
+  issueDeadlineAts: Array<number | undefined> = [];
+  revokeDeadlineAts: Array<number | undefined> = [];
   failIssue = false;
   failRevoke = false;
   revokeFailuresRemaining = 0;
@@ -52,8 +54,12 @@ class FakeIssuer implements UpstreamTokenIssuer {
   issueBarrier?: Promise<void>;
   beforeRevoke?: () => Promise<void>;
 
-  async issue() {
+  async issue(
+    _input: Parameters<UpstreamTokenIssuer["issue"]>[0],
+    options?: Parameters<UpstreamTokenIssuer["issue"]>[1],
+  ) {
     this.issueCalls += 1;
+    this.issueDeadlineAts.push(options?.deadlineAt);
     this.issueStarted?.();
     if (this.issueBarrier) await this.issueBarrier;
     await new Promise((resolve) => setTimeout(resolve, 10));
@@ -61,8 +67,9 @@ class FakeIssuer implements UpstreamTokenIssuer {
     return { token: this.token, expiresAt: new Date(NOW.getTime() + this.expiryOffsetMs) };
   }
 
-  async revoke(token: string) {
+  async revoke(token: string, options?: Parameters<UpstreamTokenIssuer["revoke"]>[1]) {
     this.revokeCalls += 1;
+    this.revokeDeadlineAts.push(options?.deadlineAt);
     expect(token).toBe(this.token);
     await this.beforeRevoke?.();
     if (this.failRevoke) throw new Error("revoker down");
@@ -275,6 +282,82 @@ describe("upstream credential leases", () => {
     });
     expect(observedDeadlines).toHaveLength(5);
     expect(observedDeadlines.every((deadline) => deadline > Date.now())).toBe(true);
+  });
+
+  test("reserves provider and durable-finalization budgets at the actual issuer calls", async () => {
+    const issuer = new FakeIssuer();
+    const issueDeadlineAt = Date.now() + 25_000;
+    const issued = await issueUpstreamCredentialLease({
+      ...issueArgs(issuer, "idempotency-provider-deadline-threading"),
+      deadlineAt: issueDeadlineAt,
+    });
+    if (!issued.ok) throw new Error("expected issuance");
+    expect(issuer.issueDeadlineAts).toEqual([issueDeadlineAt - 13_000]);
+
+    expect(await acknowledge(issued)).toEqual({ ok: true });
+    const revokeDeadlineAt = Date.now() + 25_000;
+    expect(
+      await revokeUpstreamCredentialLease({
+        db: harness.db,
+        tenantId: TENANT,
+        agentId: AGENT,
+        leaseId: issued.leaseId,
+        token: issued.token,
+        issuer,
+        auditedTransaction: auditedTransaction(),
+        deadlineAt: revokeDeadlineAt,
+        now: NOW,
+      }),
+    ).toEqual({ ok: true });
+    expect(issuer.revokeDeadlineAts).toEqual([revokeDeadlineAt - 1_000]);
+  });
+
+  test("does not mint when the actual issuer call cannot preserve its cleanup reserve", async () => {
+    const issuer = new FakeIssuer();
+    const denied = await issueUpstreamCredentialLease({
+      ...issueArgs(issuer, "idempotency-insufficient-issuer-reserve"),
+      deadlineAt: Date.now() + 22_000,
+    });
+    expect(denied).toMatchObject({ ok: false, status: 503, code: "issuer_unavailable" });
+    expect(issuer.issueCalls).toBe(0);
+    const [lease] = await harness.db
+      .select()
+      .from(upstreamCredentialLeases)
+      .where(
+        eq(
+          upstreamCredentialLeases.idempotencyKeyHash,
+          sha256("idempotency-insufficient-issuer-reserve"),
+        ),
+      );
+    expect(lease.status).toBe("needs_attention");
+  });
+
+  test("does not revoke upstream when the actual call cannot preserve finalization time", async () => {
+    const issuer = new FakeIssuer();
+    const issued = await issueUpstreamCredentialLease(
+      issueArgs(issuer, "idempotency-insufficient-revoke-reserve"),
+    );
+    if (!issued.ok) throw new Error("expected issuance");
+    expect(await acknowledge(issued)).toEqual({ ok: true });
+
+    const denied = await revokeUpstreamCredentialLease({
+      db: harness.db,
+      tenantId: TENANT,
+      agentId: AGENT,
+      leaseId: issued.leaseId,
+      token: issued.token,
+      issuer,
+      auditedTransaction: auditedTransaction(),
+      deadlineAt: Date.now() + 11_000,
+      now: NOW,
+    });
+    expect(denied).toMatchObject({ ok: false, status: 503 });
+    expect(issuer.revokeCalls).toBe(0);
+    const [lease] = await harness.db
+      .select()
+      .from(upstreamCredentialLeases)
+      .where(eq(upstreamCredentialLeases.id, issued.leaseId));
+    expect(lease.status).toBe("needs_attention");
   });
 
   test("does not acquire a database handle when the lifecycle budget is already insufficient", async () => {

--- a/packages/plugin-capabilities/src/context.ts
+++ b/packages/plugin-capabilities/src/context.ts
@@ -84,6 +84,13 @@ export interface StewardAppContext {
     tenantId: string,
     fn: (tx: unknown, appendRequiredAudit: AppendRequiredAudit) => Promise<T>,
   ): Promise<T>;
+  withCredentialLeaseDatabaseDeadline?<T>(
+    deadlineAt: number,
+    use: (
+      db: DbHandle,
+      auditedTransaction: StewardAppContext["withTenantAuditedTransaction"],
+    ) => Promise<T>,
+  ): Promise<T>;
   getAgentTokenStatus(agentId: string): Promise<AgentTokenStatus | null>;
 
   // ── redis (from @stwd/api middleware/redis) ───────────────────────────────

--- a/packages/plugin-capabilities/src/github-app-issuer.ts
+++ b/packages/plugin-capabilities/src/github-app-issuer.ts
@@ -77,7 +77,15 @@ export class GitHubAppInstallationTokenIssuer implements UpstreamTokenIssuer {
     }
   }
 
-  private async withDeadline<T>(run: (signal: AbortSignal) => Promise<T>): Promise<T> {
+  private async withDeadline<T>(
+    run: (signal: AbortSignal) => Promise<T>,
+    deadlineAt?: number,
+  ): Promise<T> {
+    const remainingMs = deadlineAt === undefined ? this.requestTimeoutMs : deadlineAt - Date.now();
+    if (!Number.isFinite(remainingMs) || remainingMs < 10) {
+      throw new Error("GitHub request timed out");
+    }
+    const timeoutMs = Math.min(this.requestTimeoutMs, Math.floor(remainingMs));
     const controller = new AbortController();
     let timer: ReturnType<typeof setTimeout> | undefined;
     let timedOut = false;
@@ -86,7 +94,7 @@ export class GitHubAppInstallationTokenIssuer implements UpstreamTokenIssuer {
         timedOut = true;
         controller.abort();
         reject(new Error("GitHub request timed out"));
-      }, this.requestTimeoutMs);
+      }, timeoutMs);
     });
     try {
       return await Promise.race([run(controller.signal), deadline]);
@@ -101,7 +109,10 @@ export class GitHubAppInstallationTokenIssuer implements UpstreamTokenIssuer {
     }
   }
 
-  async issue(input: Parameters<UpstreamTokenIssuer["issue"]>[0]) {
+  async issue(
+    input: Parameters<UpstreamTokenIssuer["issue"]>[0],
+    options?: { deadlineAt?: number },
+  ) {
     return this.withDeadline(async (signal) => {
       const key = await importPKCS8(input.privateKeyPem, "RS256");
       const now = Math.floor(Date.now() / 1000);
@@ -149,10 +160,10 @@ export class GitHubAppInstallationTokenIssuer implements UpstreamTokenIssuer {
       const expiresAt = new Date(body.expires_at);
       if (!Number.isFinite(expiresAt.getTime())) throw new Error("GitHub token expiry was invalid");
       return { token: body.token, expiresAt };
-    });
+    }, options?.deadlineAt);
   }
 
-  async revoke(token: string): Promise<void> {
+  async revoke(token: string, options?: { deadlineAt?: number }): Promise<void> {
     await this.withDeadline(async (signal) => {
       const response = await this.fetchImpl(`${GITHUB_API}/installation/token`, {
         method: "DELETE",
@@ -174,6 +185,6 @@ export class GitHubAppInstallationTokenIssuer implements UpstreamTokenIssuer {
         throw new Error(`GitHub installation-token revocation failed (${response.status})`);
       }
       void response.body?.cancel().catch(() => {});
-    });
+    }, options?.deadlineAt);
   }
 }

--- a/packages/plugin-capabilities/src/manifest-routes.ts
+++ b/packages/plugin-capabilities/src/manifest-routes.ts
@@ -44,6 +44,7 @@ import {
   MAX_UPSTREAM_LEASE_SWEEP_INTERVAL_MS,
   recoverInterruptedUpstreamCredentialLeases,
   revokeUpstreamCredentialLease,
+  UPSTREAM_LEASE_LIFECYCLE_DEADLINE_MS,
 } from "./upstream-leases";
 
 export function upstreamLeaseIssuanceAvailableInRuntime(): boolean {
@@ -243,6 +244,7 @@ export function createManifestRoutes(ctx: StewardAppContext): Hono<{ Variables: 
             503,
           );
         }
+        const leaseDeadlineAt = Date.now() + UPSTREAM_LEASE_LIFECYCLE_DEADLINE_MS;
         try {
           await recoverInterruptedUpstreamCredentialLeases({
             db: ctx.db,
@@ -250,6 +252,8 @@ export function createManifestRoutes(ctx: StewardAppContext): Hono<{ Variables: 
             issuer: githubIssuer,
             exerciseToken: ctx.exerciseCredentialLeaseToken,
             auditedTransaction: ctx.withTenantAuditedTransaction,
+            deadlineAt: leaseDeadlineAt,
+            withDatabaseDeadline: ctx.withCredentialLeaseDatabaseDeadline,
           });
         } catch {
           return c.json<ApiResponse>({ ok: false, error: "credential lease recovery failed" }, 503);
@@ -267,6 +271,8 @@ export function createManifestRoutes(ctx: StewardAppContext): Hono<{ Variables: 
           sealToken: ctx.sealCredentialLeaseToken,
           auditedTransaction: ctx.withTenantAuditedTransaction,
           issuer: githubIssuer,
+          deadlineAt: leaseDeadlineAt,
+          withDatabaseDeadline: ctx.withCredentialLeaseDatabaseDeadline,
         });
         if (!leased.ok) {
           return c.json<ApiResponse>({ ok: false, error: leased.error }, leased.status);
@@ -332,6 +338,7 @@ export function createManifestRoutes(ctx: StewardAppContext): Hono<{ Variables: 
       token: body.token,
       issuer: githubIssuer,
       auditedTransaction: ctx.withTenantAuditedTransaction,
+      withDatabaseDeadline: ctx.withCredentialLeaseDatabaseDeadline,
     });
     if (!result.ok) return c.json<ApiResponse>({ ok: false, error: result.error }, result.status);
     c.header("Cache-Control", "no-store, max-age=0");
@@ -355,6 +362,7 @@ export function createManifestRoutes(ctx: StewardAppContext): Hono<{ Variables: 
       leaseId: c.req.param("leaseId"),
       token: body.token,
       auditedTransaction: ctx.withTenantAuditedTransaction,
+      withDatabaseDeadline: ctx.withCredentialLeaseDatabaseDeadline,
     });
     if (!result.ok) return c.json<ApiResponse>({ ok: false, error: result.error }, result.status);
     c.header("Cache-Control", "no-store, max-age=0");

--- a/packages/plugin-capabilities/src/routes.ts
+++ b/packages/plugin-capabilities/src/routes.ts
@@ -134,6 +134,7 @@ export function createCapabilityRoutes(ctx: StewardAppContext): Hono<{ Variables
           throw new Error("credential lease revocation is not configured");
         }),
       auditedTransaction: ctx.withTenantAuditedTransaction,
+      withDatabaseDeadline: ctx.withCredentialLeaseDatabaseDeadline,
     });
     if (!result.ok) throw new Error(result.error);
   }

--- a/packages/plugin-capabilities/src/upstream-leases.ts
+++ b/packages/plugin-capabilities/src/upstream-leases.ts
@@ -695,7 +695,7 @@ export async function recoverInterruptedUpstreamCredentialLeases(
     .limit(limit);
   let unknown = 0;
   for (const lease of stale) {
-    if (lease.status === "issuing") {
+    if (lease.status === "issuing" && !sealedTokenFromLease(lease)) {
       const changed = await input.auditedTransaction(
         input.tenantId,
         async (tx: Db, appendRequiredAudit) => {
@@ -773,7 +773,7 @@ async function recoverOneDueLease(input: {
   cutoff: Date;
 }): Promise<RecoveryTotals> {
   const { lease } = input;
-  if (lease.status === "issuing") {
+  if (lease.status === "issuing" && !sealedTokenFromLease(lease)) {
     const changed = await input.auditedTransaction(
       lease.tenantId,
       async (tx: Db, appendRequiredAudit) => {

--- a/packages/plugin-capabilities/src/upstream-leases.ts
+++ b/packages/plugin-capabilities/src/upstream-leases.ts
@@ -150,6 +150,18 @@ async function bindLeaseDeadline<
   );
 }
 
+async function withLeaseDatabasePhase<T>(
+  input: LeaseDeadlineInput & { db: Db; auditedTransaction: LeaseAuditedTransaction },
+  deadlineAt: number,
+  use: (db: Db, auditedTransaction: LeaseAuditedTransaction) => Promise<T>,
+): Promise<T> {
+  requireLeaseBudget(deadlineAt, MIN_DATABASE_PHASE_MS);
+  if (input.withDatabaseDeadline) {
+    return input.withDatabaseDeadline(deadlineAt, use);
+  }
+  return use(input.db, input.auditedTransaction);
+}
+
 type Db = any;
 
 let beforeRecoveryClaimForTests: ((leaseId: string) => Promise<void>) | undefined;
@@ -1275,6 +1287,72 @@ export async function issueUpstreamCredentialLease(
       "credential escrow failed",
       revoked ? "failed" : "needs_attention",
     );
+    return {
+      ok: false,
+      status: 503,
+      code: "lease_finalization_failed",
+      error: "credential delivery was aborted",
+    };
+  }
+
+  // Once the provider has minted a token, persist its exact encrypted recovery
+  // handle before any authority/audit finalization that can block. Give this
+  // checkpoint an earlier hard deadline so failure still leaves the full
+  // provider-revocation reserve. The row remains `issuing`; interrupted-lease
+  // recovery owns exact-token cleanup until the audited delivery transition
+  // commits.
+  try {
+    const checkpointDeadlineAt =
+      (input.deadlineAt ?? Date.now() + UPSTREAM_LEASE_LIFECYCLE_DEADLINE_MS) -
+      MIN_PROVIDER_AND_FINALIZE_MS;
+    await withLeaseDatabasePhase(input, checkpointDeadlineAt, async (checkpointDb) => {
+      const checkpointed = await checkpointDb
+        .update(upstreamCredentialLeases)
+        .set({
+          tokenHash: sha256(issued.token),
+          tokenCiphertext: sealed.ciphertext,
+          tokenIv: sealed.iv,
+          tokenAuthTag: sealed.tag,
+          tokenSalt: sealed.salt,
+          expiresAt: Number.isFinite(issued.expiresAt.getTime()) ? issued.expiresAt : null,
+          updatedAt: now,
+        })
+        .where(
+          and(
+            eq(upstreamCredentialLeases.id, claim.id),
+            eq(upstreamCredentialLeases.tenantId, input.tenantId),
+            eq(upstreamCredentialLeases.status, "issuing"),
+          ),
+        )
+        .returning({ id: upstreamCredentialLeases.id });
+      if (checkpointed.length !== 1) throw new Error("lease issuance claim was lost");
+    });
+  } catch {
+    const revoked = await input.issuer.revoke(issued.token).then(
+      () => true,
+      () => false,
+    );
+    if (revoked) {
+      await recordFailure(
+        input.auditedTransaction,
+        claim.id,
+        input.tenantId,
+        "credential recovery checkpoint failed after provider issuance",
+        "failed",
+      ).catch(() => undefined);
+    } else {
+      await recordRecoverableSealedFailure({
+        db: input.db,
+        auditedTransaction: input.auditedTransaction,
+        leaseId: claim.id,
+        tenantId: input.tenantId,
+        token: issued.token,
+        sealed,
+        expiresAt: Number.isFinite(issued.expiresAt.getTime()) ? issued.expiresAt : null,
+        error: "credential recovery checkpoint and provider revocation outcomes unknown",
+        now: new Date(),
+      }).catch(() => undefined);
+    }
     return {
       ok: false,
       status: 503,

--- a/packages/plugin-capabilities/src/upstream-leases.ts
+++ b/packages/plugin-capabilities/src/upstream-leases.ts
@@ -24,6 +24,8 @@ export const DELIVERY_ACK_TIMEOUT_MS = 30_000;
 export const UPSTREAM_LEASE_LIFECYCLE_DEADLINE_MS = 25_000;
 const MIN_DATABASE_PHASE_MS = 1_000;
 const MIN_PROVIDER_AND_FINALIZE_MS = 12_000;
+const POST_ISSUE_DURABLE_RESERVE_MS = 13_000;
+const MIN_ISSUER_START_MS = 23_000;
 export const MAX_UPSTREAM_LEASE_SWEEP_INTERVAL_MS = DELIVERY_ACK_TIMEOUT_MS / 2;
 export const UPSTREAM_LEASE_AUTHORITY_RECHECK_INTERVAL_MS = MAX_UPSTREAM_LEASE_SWEEP_INTERVAL_MS;
 const MAX_GITHUB_PERMISSION_COUNT = 100;
@@ -105,12 +107,15 @@ function requireLeaseBudget(deadlineAt: number | undefined, minimumMs: number): 
 function deadlineAwareIssuer(issuer: UpstreamTokenIssuer, deadlineAt: number): UpstreamTokenIssuer {
   return {
     issue: async (input) => {
-      requireLeaseBudget(deadlineAt, MIN_PROVIDER_AND_FINALIZE_MS);
-      return issuer.issue(input, { deadlineAt });
+      // A mint can create a live upstream secret. Reserve a full provider call
+      // plus durable DB cleanup after the issuance deadline, so
+      // even the worst-case successful mint still has time to escrow/revoke.
+      requireLeaseBudget(deadlineAt, MIN_ISSUER_START_MS);
+      return issuer.issue(input, { deadlineAt: deadlineAt - POST_ISSUE_DURABLE_RESERVE_MS });
     },
     revoke: async (token) => {
       requireLeaseBudget(deadlineAt, MIN_PROVIDER_AND_FINALIZE_MS);
-      return issuer.revoke(token, { deadlineAt });
+      return issuer.revoke(token, { deadlineAt: deadlineAt - MIN_DATABASE_PHASE_MS });
     },
   };
 }

--- a/packages/plugin-capabilities/src/upstream-leases.ts
+++ b/packages/plugin-capabilities/src/upstream-leases.ts
@@ -46,13 +46,16 @@ export interface GitHubAppLeaseConfig {
 }
 
 export interface UpstreamTokenIssuer {
-  issue(input: {
-    appId: string;
-    installationId: string;
-    privateKeyPem: string;
-    resource: GitHubLeaseResource;
-  }): Promise<{ token: string; expiresAt: Date }>;
-  revoke(token: string): Promise<void>;
+  issue(
+    input: {
+      appId: string;
+      installationId: string;
+      privateKeyPem: string;
+      resource: GitHubLeaseResource;
+    },
+    options?: { deadlineAt?: number },
+  ): Promise<{ token: string; expiresAt: Date }>;
+  revoke(token: string, options?: { deadlineAt?: number }): Promise<void>;
 }
 
 export type ExerciseCredentialSecret = <T>(
@@ -103,11 +106,11 @@ function deadlineAwareIssuer(issuer: UpstreamTokenIssuer, deadlineAt: number): U
   return {
     issue: async (input) => {
       requireLeaseBudget(deadlineAt, MIN_PROVIDER_AND_FINALIZE_MS);
-      return issuer.issue(input);
+      return issuer.issue(input, { deadlineAt });
     },
     revoke: async (token) => {
       requireLeaseBudget(deadlineAt, MIN_PROVIDER_AND_FINALIZE_MS);
-      return issuer.revoke(token);
+      return issuer.revoke(token, { deadlineAt });
     },
   };
 }

--- a/packages/plugin-capabilities/src/upstream-leases.ts
+++ b/packages/plugin-capabilities/src/upstream-leases.ts
@@ -555,7 +555,15 @@ export async function expireUpstreamCredentialLeases(input: {
     for (const row of due) {
       const updated = await tx
         .update(upstreamCredentialLeases)
-        .set({ status: "expired", updatedAt: now })
+        .set({
+          status: "expired",
+          tokenHash: null,
+          tokenCiphertext: null,
+          tokenIv: null,
+          tokenAuthTag: null,
+          tokenSalt: null,
+          updatedAt: now,
+        })
         .where(
           and(
             eq(upstreamCredentialLeases.id, row.id),
@@ -891,7 +899,15 @@ async function expireOneActiveLease(input: {
   return input.auditedTransaction(input.lease.tenantId, async (tx: Db, appendRequiredAudit) => {
     const updated = await tx
       .update(upstreamCredentialLeases)
-      .set({ status: "expired", updatedAt: input.now })
+      .set({
+        status: "expired",
+        tokenHash: null,
+        tokenCiphertext: null,
+        tokenIv: null,
+        tokenAuthTag: null,
+        tokenSalt: null,
+        updatedAt: input.now,
+      })
       .where(
         and(
           eq(upstreamCredentialLeases.id, input.lease.id),
@@ -1794,7 +1810,15 @@ export async function revokeUpstreamCredentialLease(
     await input.auditedTransaction(input.tenantId, async (tx: Db, appendRequiredAudit) => {
       const expired = await tx
         .update(upstreamCredentialLeases)
-        .set({ status: "expired", updatedAt: now })
+        .set({
+          status: "expired",
+          tokenHash: null,
+          tokenCiphertext: null,
+          tokenIv: null,
+          tokenAuthTag: null,
+          tokenSalt: null,
+          updatedAt: now,
+        })
         .where(
           and(
             eq(upstreamCredentialLeases.id, lease.id),
@@ -1895,7 +1919,17 @@ export async function revokeUpstreamCredentialLease(
     await input.auditedTransaction(input.tenantId, async (tx: Db, appendRequiredAudit) => {
       const finalized = await tx
         .update(upstreamCredentialLeases)
-        .set({ status: "revoked", revokedAt: now, lastError: null, updatedAt: now })
+        .set({
+          status: "revoked",
+          tokenHash: null,
+          tokenCiphertext: null,
+          tokenIv: null,
+          tokenAuthTag: null,
+          tokenSalt: null,
+          revokedAt: now,
+          lastError: null,
+          updatedAt: now,
+        })
         .where(
           and(
             eq(upstreamCredentialLeases.id, lease.id),
@@ -2083,7 +2117,17 @@ async function revokeExactSealedLease(input: {
     await input.auditedTransaction(input.tenantId, async (tx: Db, appendRequiredAudit) => {
       const finalized = await tx
         .update(upstreamCredentialLeases)
-        .set({ status: "revoked", revokedAt: input.now, lastError: null, updatedAt: input.now })
+        .set({
+          status: "revoked",
+          tokenHash: null,
+          tokenCiphertext: null,
+          tokenIv: null,
+          tokenAuthTag: null,
+          tokenSalt: null,
+          revokedAt: input.now,
+          lastError: null,
+          updatedAt: input.now,
+        })
         .where(
           and(
             eq(upstreamCredentialLeases.id, input.lease.id),

--- a/packages/plugin-capabilities/src/upstream-leases.ts
+++ b/packages/plugin-capabilities/src/upstream-leases.ts
@@ -21,6 +21,9 @@ const MIN_GITHUB_ISSUED_TTL_MS = 55 * 60 * 1000;
 const MAX_GITHUB_ISSUED_TTL_MS = (GITHUB_INSTALLATION_TOKEN_TTL_SECONDS + 30) * 1000;
 const REVOCATION_CLAIM_TIMEOUT_MS = 30_000;
 export const DELIVERY_ACK_TIMEOUT_MS = 30_000;
+export const UPSTREAM_LEASE_LIFECYCLE_DEADLINE_MS = 25_000;
+const MIN_DATABASE_PHASE_MS = 1_000;
+const MIN_PROVIDER_AND_FINALIZE_MS = 12_000;
 export const MAX_UPSTREAM_LEASE_SWEEP_INTERVAL_MS = DELIVERY_ACK_TIMEOUT_MS / 2;
 export const UPSTREAM_LEASE_AUTHORITY_RECHECK_INTERVAL_MS = MAX_UPSTREAM_LEASE_SWEEP_INTERVAL_MS;
 const MAX_GITHUB_PERMISSION_COUNT = 100;
@@ -78,6 +81,66 @@ export type LeaseAuditedTransaction = <T>(
   tenantId: string,
   fn: (tx: Db, appendRequiredAudit: AppendRequiredAudit) => Promise<T>,
 ) => Promise<T>;
+export type LeaseDatabaseDeadline = <T>(
+  deadlineAt: number,
+  use: (db: Db, auditedTransaction: LeaseAuditedTransaction) => Promise<T>,
+) => Promise<T>;
+const LEASE_DEADLINE_BOUND = Symbol("lease-deadline-bound");
+
+interface LeaseDeadlineInput {
+  deadlineAt?: number;
+  withDatabaseDeadline?: LeaseDatabaseDeadline;
+  [LEASE_DEADLINE_BOUND]?: true;
+}
+
+function requireLeaseBudget(deadlineAt: number | undefined, minimumMs: number): void {
+  if (deadlineAt !== undefined && deadlineAt - Date.now() < minimumMs) {
+    throw new Error("credential lease lifecycle timed out");
+  }
+}
+
+function deadlineAwareIssuer(issuer: UpstreamTokenIssuer, deadlineAt: number): UpstreamTokenIssuer {
+  return {
+    issue: async (input) => {
+      requireLeaseBudget(deadlineAt, MIN_PROVIDER_AND_FINALIZE_MS);
+      return issuer.issue(input);
+    },
+    revoke: async (token) => {
+      requireLeaseBudget(deadlineAt, MIN_PROVIDER_AND_FINALIZE_MS);
+      return issuer.revoke(token);
+    },
+  };
+}
+
+async function bindLeaseDeadline<
+  T extends LeaseDeadlineInput & {
+    db: Db;
+    auditedTransaction: LeaseAuditedTransaction;
+    issuer?: UpstreamTokenIssuer;
+  },
+  R,
+>(input: T, run: (bound: T) => Promise<R>): Promise<R> {
+  const deadlineAt = input.deadlineAt ?? Date.now() + UPSTREAM_LEASE_LIFECYCLE_DEADLINE_MS;
+  requireLeaseBudget(deadlineAt, MIN_DATABASE_PHASE_MS);
+  if (!input.withDatabaseDeadline || input[LEASE_DEADLINE_BOUND]) {
+    return run({
+      ...input,
+      deadlineAt,
+      [LEASE_DEADLINE_BOUND]: true,
+      issuer: input.issuer ? deadlineAwareIssuer(input.issuer, deadlineAt) : undefined,
+    });
+  }
+  return input.withDatabaseDeadline(deadlineAt, (db, auditedTransaction) =>
+    run({
+      ...input,
+      db,
+      auditedTransaction,
+      deadlineAt,
+      [LEASE_DEADLINE_BOUND]: true,
+      issuer: input.issuer ? deadlineAwareIssuer(input.issuer, deadlineAt) : undefined,
+    }),
+  );
+}
 
 type Db = any;
 
@@ -490,15 +553,20 @@ export async function expireUpstreamCredentialLeases(input: {
  * provider outcome and is escalated truthfully. A delivery that was never ACKed
  * retains an encrypted revocation handle and is revoked after the bounded ACK
  * window. */
-export async function recoverInterruptedUpstreamCredentialLeases(input: {
-  db: Db;
-  tenantId: string;
-  issuer: UpstreamTokenIssuer;
-  exerciseToken: ExerciseLeaseToken;
-  auditedTransaction: LeaseAuditedTransaction;
-  now?: Date;
-  limit?: number;
-}): Promise<{ unknown: number; revoked: number; attention: number }> {
+export async function recoverInterruptedUpstreamCredentialLeases(
+  input: {
+    db: Db;
+    tenantId: string;
+    issuer: UpstreamTokenIssuer;
+    exerciseToken: ExerciseLeaseToken;
+    auditedTransaction: LeaseAuditedTransaction;
+    now?: Date;
+    limit?: number;
+  } & LeaseDeadlineInput,
+): Promise<{ unknown: number; revoked: number; attention: number }> {
+  if (!input[LEASE_DEADLINE_BOUND]) {
+    return bindLeaseDeadline(input, recoverInterruptedUpstreamCredentialLeases);
+  }
   const now = input.now ?? new Date();
   const cutoff = new Date(now.getTime() - DELIVERY_ACK_TIMEOUT_MS);
   const limit = Math.max(1, Math.min(input.limit ?? 100, 500));
@@ -821,12 +889,13 @@ async function mapWithDeadline<T>(input: {
   items: T[];
   concurrency: number;
   deadlineAt: number;
+  minimumRemainingMs: number;
   run: (item: T) => Promise<void>;
 }): Promise<number> {
   let cursor = 0;
   let started = 0;
   const worker = async () => {
-    while (Date.now() < input.deadlineAt) {
+    while (input.deadlineAt - Date.now() >= input.minimumRemainingMs) {
       const index = cursor++;
       const item = input.items[index];
       if (item === undefined) return;
@@ -843,19 +912,21 @@ async function mapWithDeadline<T>(input: {
 /** Process-bounded autonomous sweep entrypoint. Deadline-due leases are read
  * globally from durable state and handled by a bounded worker pool, so neither
  * tenant-id pagination nor one slow provider call can starve another tenant. */
-export async function recoverAllInterruptedUpstreamCredentialLeases(input: {
-  db: Db;
-  issuer: UpstreamTokenIssuer;
-  exerciseToken: ExerciseLeaseToken;
-  auditedTransaction: LeaseAuditedTransaction;
-  now?: Date;
-  /** Global work cap. Ordering is by the oldest recovery deadline, never tenant id. */
-  workLimit?: number;
-  /** Provider calls are isolated behind a bounded pool so one tenant cannot block another. */
-  concurrency?: number;
-  /** Stop claiming new work after this wall-clock budget; already claimed work is awaited. */
-  runDeadlineMs?: number;
-}): Promise<{
+export async function recoverAllInterruptedUpstreamCredentialLeases(
+  input: {
+    db: Db;
+    issuer: UpstreamTokenIssuer;
+    exerciseToken: ExerciseLeaseToken;
+    auditedTransaction: LeaseAuditedTransaction;
+    now?: Date;
+    /** Global work cap. Ordering is by the oldest recovery deadline, never tenant id. */
+    workLimit?: number;
+    /** Provider calls are isolated behind a bounded pool so one tenant cannot block another. */
+    concurrency?: number;
+    /** Stop claiming new work after this wall-clock budget; already claimed work is awaited. */
+    runDeadlineMs?: number;
+  } & LeaseDeadlineInput,
+): Promise<{
   tenants: number;
   unknown: number;
   revoked: number;
@@ -863,13 +934,25 @@ export async function recoverAllInterruptedUpstreamCredentialLeases(input: {
   expired: number;
   remaining: boolean;
 }> {
+  if (!input[LEASE_DEADLINE_BOUND]) {
+    const runDeadlineMs = Math.max(
+      MIN_DATABASE_PHASE_MS,
+      Math.min(
+        input.runDeadlineMs ?? UPSTREAM_LEASE_LIFECYCLE_DEADLINE_MS,
+        UPSTREAM_LEASE_LIFECYCLE_DEADLINE_MS,
+      ),
+    );
+    return bindLeaseDeadline(
+      { ...input, deadlineAt: input.deadlineAt ?? Date.now() + runDeadlineMs },
+      recoverAllInterruptedUpstreamCredentialLeases,
+    );
+  }
   const now = input.now ?? new Date();
   const cutoff = new Date(now.getTime() - DELIVERY_ACK_TIMEOUT_MS);
   const authorityCutoff = new Date(now.getTime() - UPSTREAM_LEASE_AUTHORITY_RECHECK_INTERVAL_MS);
   const workLimit = Math.max(1, Math.min(input.workLimit ?? 500, 2_000));
   const concurrency = Math.max(1, Math.min(input.concurrency ?? 16, 64));
-  const runDeadlineMs = Math.max(100, Math.min(input.runDeadlineMs ?? 5_000, 10_000));
-  const deadlineAt = Date.now() + runDeadlineMs;
+  const deadlineAt = input.deadlineAt as number;
   // Pull at most one global page from each independently indexed deadline
   // class, then merge them by their actual recovery deadline. Fetching
   // workLimit + 1 from each class is sufficient to identify the global first
@@ -965,6 +1048,7 @@ export async function recoverAllInterruptedUpstreamCredentialLeases(input: {
     items: candidates,
     concurrency,
     deadlineAt,
+    minimumRemainingMs: MIN_PROVIDER_AND_FINALIZE_MS,
     run: async (candidate) => {
       const { lease } = candidate;
       touchedTenants.add(lease.tenantId);
@@ -995,24 +1079,29 @@ export async function recoverAllInterruptedUpstreamCredentialLeases(input: {
   return totals;
 }
 
-export async function issueUpstreamCredentialLease(input: {
-  db: Db;
-  tenantId: string;
-  agentId: string;
-  workspaceId: string;
-  idempotencyKey: string;
-  ttlSeconds: number;
-  resource: GitHubLeaseResource;
-  resolved: {
-    capability: { id: string; tenantId: string; secretId: string; constraints: unknown };
-    grant: { id: string; tenantId: string; agentId: string; capabilityId: string };
-  };
-  exerciseSecret: ExerciseCredentialSecret;
-  sealToken: SealLeaseToken;
-  auditedTransaction: LeaseAuditedTransaction;
-  issuer: UpstreamTokenIssuer;
-  now?: Date;
-}): Promise<LeaseIssueResult> {
+export async function issueUpstreamCredentialLease(
+  input: {
+    db: Db;
+    tenantId: string;
+    agentId: string;
+    workspaceId: string;
+    idempotencyKey: string;
+    ttlSeconds: number;
+    resource: GitHubLeaseResource;
+    resolved: {
+      capability: { id: string; tenantId: string; secretId: string; constraints: unknown };
+      grant: { id: string; tenantId: string; agentId: string; capabilityId: string };
+    };
+    exerciseSecret: ExerciseCredentialSecret;
+    sealToken: SealLeaseToken;
+    auditedTransaction: LeaseAuditedTransaction;
+    issuer: UpstreamTokenIssuer;
+    now?: Date;
+  } & LeaseDeadlineInput,
+): Promise<LeaseIssueResult> {
+  if (!input[LEASE_DEADLINE_BOUND]) {
+    return bindLeaseDeadline(input, issueUpstreamCredentialLease);
+  }
   try {
     await expireUpstreamCredentialLeases({
       db: input.db,
@@ -1449,15 +1538,20 @@ export async function issueUpstreamCredentialLease(input: {
   };
 }
 
-export async function acknowledgeUpstreamCredentialLease(input: {
-  db: Db;
-  tenantId: string;
-  agentId: string;
-  leaseId: string;
-  token: string;
-  auditedTransaction: LeaseAuditedTransaction;
-  now?: Date;
-}): Promise<{ ok: true } | { ok: false; status: 403 | 404 | 409 | 503; error: string }> {
+export async function acknowledgeUpstreamCredentialLease(
+  input: {
+    db: Db;
+    tenantId: string;
+    agentId: string;
+    leaseId: string;
+    token: string;
+    auditedTransaction: LeaseAuditedTransaction;
+    now?: Date;
+  } & LeaseDeadlineInput,
+): Promise<{ ok: true } | { ok: false; status: 403 | 404 | 409 | 503; error: string }> {
+  if (!input[LEASE_DEADLINE_BOUND]) {
+    return bindLeaseDeadline(input, acknowledgeUpstreamCredentialLease);
+  }
   const now = input.now ?? new Date();
   const [lease] = await input.db
     .select()
@@ -1556,16 +1650,21 @@ function equalHash(left: string | null, token: string): boolean {
   return timingSafeEqual(Buffer.from(left, "hex"), Buffer.from(sha256(token), "hex"));
 }
 
-export async function revokeUpstreamCredentialLease(input: {
-  db: Db;
-  tenantId: string;
-  agentId: string;
-  leaseId: string;
-  token: string;
-  issuer: UpstreamTokenIssuer;
-  auditedTransaction: LeaseAuditedTransaction;
-  now?: Date;
-}): Promise<{ ok: true } | { ok: false; status: 403 | 404 | 409 | 503; error: string }> {
+export async function revokeUpstreamCredentialLease(
+  input: {
+    db: Db;
+    tenantId: string;
+    agentId: string;
+    leaseId: string;
+    token: string;
+    issuer: UpstreamTokenIssuer;
+    auditedTransaction: LeaseAuditedTransaction;
+    now?: Date;
+  } & LeaseDeadlineInput,
+): Promise<{ ok: true } | { ok: false; status: 403 | 404 | 409 | 503; error: string }> {
+  if (!input[LEASE_DEADLINE_BOUND]) {
+    return bindLeaseDeadline(input, revokeUpstreamCredentialLease);
+  }
   const now = input.now ?? new Date();
   const [lease] = await input.db
     .select()
@@ -1956,16 +2055,21 @@ async function revokeExactSealedLease(input: {
  * changed. Provider failures are durable `needs_attention` outcomes and make the
  * operator mutation fail closed so authority cannot appear fully revoked while
  * a known-live credential remains usable. */
-export async function revokeUpstreamLeasesForAuthority(input: {
-  db: Db;
-  tenantId: string;
-  issuer: UpstreamTokenIssuer;
-  exerciseToken: ExerciseLeaseToken;
-  auditedTransaction: LeaseAuditedTransaction;
-  grantId?: string;
-  capabilityId?: string;
-  now?: Date;
-}): Promise<{ ok: true; revoked: number } | { ok: false; error: string }> {
+export async function revokeUpstreamLeasesForAuthority(
+  input: {
+    db: Db;
+    tenantId: string;
+    issuer: UpstreamTokenIssuer;
+    exerciseToken: ExerciseLeaseToken;
+    auditedTransaction: LeaseAuditedTransaction;
+    grantId?: string;
+    capabilityId?: string;
+    now?: Date;
+  } & LeaseDeadlineInput,
+): Promise<{ ok: true; revoked: number } | { ok: false; error: string }> {
+  if (!input[LEASE_DEADLINE_BOUND]) {
+    return bindLeaseDeadline(input, revokeUpstreamLeasesForAuthority);
+  }
   if (!input.grantId && !input.capabilityId)
     return { ok: false, error: "authority binding required" };
   const bindings = [eq(upstreamCredentialLeases.tenantId, input.tenantId)];

--- a/packages/plugin-capabilities/src/upstream-leases.ts
+++ b/packages/plugin-capabilities/src/upstream-leases.ts
@@ -387,7 +387,21 @@ async function recordFailure(
   await auditedTransaction(tenantId, async (tx: Db, appendRequiredAudit) => {
     const updated = await tx
       .update(upstreamCredentialLeases)
-      .set({ status, lastError: error.slice(0, 500), updatedAt: new Date() })
+      .set({
+        status,
+        lastError: error.slice(0, 500),
+        updatedAt: new Date(),
+        ...(status === "failed"
+          ? {
+              tokenHash: null,
+              tokenCiphertext: null,
+              tokenIv: null,
+              tokenAuthTag: null,
+              tokenSalt: null,
+              expiresAt: null,
+            }
+          : {}),
+      })
       .where(
         and(
           eq(upstreamCredentialLeases.id, leaseId),


### PR DESCRIPTION
Closes #387 on merge.

Adds cancel-safe absolute database deadlines across credential-lease issue, ACK, revoke, authority teardown, and recovery. Started audit work is awaited while queued work can be cancelled before it begins.

After GitHub mints a token, Steward seals it and commits an earlier-deadline encrypted checkpoint on the exact issuing row before authority and audit finalization. A later crash or stall leaves a stale exact-token handle that autonomous recovery decrypts and revokes. Confirmed revocation and expiry atomically clear every escrow field. Pre-checkpoint provider-response loss remains truthfully outcome-unknown, the documented external-provider ambiguity that cannot be removed without provider idempotency or token lookup.

Exact head: 21303902ae44a2bfee475d87fd9dde7e856f41ac
Included develop: a7b1d566b6e09136ac7f6e723fa5e053203b3907

- full lease lifecycle: 45/45, 262 assertions
- issuer, scheduler, and database deadline suites: 16/16, 50 assertions
- plugin-capabilities and API builds: green
- Biome and diff-check: green
- independent exact semantic review: accept

Fresh hosted CI and required review remain merge gates.