### PR TITLE
fix(proxy): fail closed on Slack response errors

### DIFF
--- a/packages/proxy/src/__tests__/slack-credential-route.test.ts
+++ b/packages/proxy/src/__tests__/slack-credential-route.test.ts
@@ -126,6 +126,65 @@ describe("Slack narrow credential route", () => {
     expect(audit.at(-1)?.reason).toBe("slack-api-error:channel_not_found");
   });
 
+  test("fails closed on an interrupted Slack body and releases the proxy slot", async () => {
+    const { tenantId, agentId } = await fixture();
+    proxyMod.__setProxyInFlightCapsForTests({ perAgent: 1, perTenant: 1 });
+    try {
+      proxyMod.__setForwardProxyRequestForTests(
+        async () =>
+          new Response(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.enqueue(new TextEncoder().encode('{"ok":true,"secret":"xoxb-CANARY'));
+                controller.error(new Error("xoxb-CANARY hostile stream diagnostic"));
+              },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+      );
+
+      const interrupted = await invoke(tenantId, agentId);
+      const interruptedBody = await interrupted.text();
+      expect(interrupted.status).toBe(502);
+      expect(interruptedBody).toContain("Slack upstream operation failed");
+      expect(interruptedBody).not.toContain("CANARY");
+
+      // A disturbed provider stream must not strand the one allowed slot.
+      proxyMod.__setForwardProxyRequestForTests(
+        async () =>
+          new Response('{"ok":true}', {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+      );
+      const retry = await invoke(tenantId, agentId);
+      expect(retry.status).toBe(200);
+    } finally {
+      proxyMod.__setProxyInFlightCapsForTests({ perAgent: 50, perTenant: 250 });
+    }
+  });
+
+  test("does not audit Slack success before credential-reflection checks", async () => {
+    const { tenantId, agentId } = await fixture();
+    proxyMod.__setForwardProxyRequestForTests(
+      async () =>
+        new Response(JSON.stringify({ ok: true, reflected: SLACK_TOKEN }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+
+    const response = await invoke(tenantId, agentId);
+    expect(response.status).toBe(502);
+    expect(await response.text()).not.toContain(SLACK_TOKEN);
+    const audit = await getDb()
+      .select()
+      .from(proxyAuditLog)
+      .where(eq(proxyAuditLog.tenantId, tenantId));
+    expect(audit.map((row) => row.statusCode)).toEqual([102, 502]);
+    expect(audit.some((row) => row.statusCode === 200)).toBe(false);
+  });
+
   for (const [label, invalidCredential] of [
     ["user token", "xoxp-CANARY-user-token-must-not-forward"],
     ["arbitrary plaintext", "CANARY-not-a-slack-token"],

--- a/packages/proxy/src/__tests__/zz-proxy-spend-limit.test.ts
+++ b/packages/proxy/src/__tests__/zz-proxy-spend-limit.test.ts
@@ -609,6 +609,50 @@ describe("proxy spend-limit enforcement", () => {
     );
   });
 
+  for (const [label, declaredLength] of [
+    ["missing Content-Length", undefined],
+    ["lying small Content-Length", "1"],
+  ] as const) {
+    test(`bounds credential response inspection with ${label}`, async () => {
+      spendResult.configured = false;
+      let cancelled = false;
+      globalThis.fetch = (async () => {
+        fetchCalls++;
+        let chunks = 0;
+        const stream = new ReadableStream<Uint8Array>({
+          pull(controller) {
+            chunks += 1;
+            controller.enqueue(new Uint8Array(64 * 1024));
+            if (chunks >= 40) controller.close();
+          },
+          cancel() {
+            cancelled = true;
+          },
+        });
+        const headers = new Headers({ "content-type": "application/octet-stream" });
+        if (declaredLength !== undefined) headers.set("content-length", declaredLength);
+        return new Response(stream, { status: 200, headers });
+      }) as typeof fetch;
+
+      const { handleProxy, __setCheckProxySpendLimitForTests } = await loadProxy();
+      __setCheckProxySpendLimitForTests(async () => spendResult);
+
+      const response = await handleProxy(makeContext());
+      const body = await response.text();
+      expect(response.status).toBe(502);
+      expect(body).toContain("could not be inspected safely");
+      expect(body).not.toContain("test-secret");
+      expect(cancelled).toBe(true);
+      expect(audits).toContainEqual(
+        expect.objectContaining({
+          targetHost: "example.com",
+          statusCode: 502,
+          reason: "credential-response-inspection-failed",
+        }),
+      );
+    });
+  }
+
   test("blocks streaming responses after injecting a credential", async () => {
     spendResult.configured = false;
     globalThis.fetch = (async (url: string | URL | Request) => {

--- a/packages/proxy/src/handlers/proxy.ts
+++ b/packages/proxy/src/handlers/proxy.ts
@@ -358,6 +358,9 @@ const MAX_PROXY_RESPONSE_BYTES = boundedPositiveIntegerEnv(
   25 * 1024 * 1024,
   100 * 1024 * 1024,
 );
+// Credential-bearing responses are buffered for reflection inspection. Keep
+// this security boundary independent from the much larger generic proxy cap.
+const MAX_CREDENTIAL_RESPONSE_BODY_BYTES = 2 * 1024 * 1024;
 const MAX_PROXY_STREAM_DURATION_MS = boundedPositiveIntegerEnv(
   "STEWARD_PROXY_STREAM_DURATION_MS",
   5 * 60_000,
@@ -545,6 +548,69 @@ function responseHasEncodedBody(headers: Headers): boolean {
 
 function responseTextReflectsAnyCredential(bodyText: string, credentialValues: string[]): boolean {
   return credentialValues.some((value) => bodyText.includes(value));
+}
+
+function cancelResponseBody(body: ReadableStream<Uint8Array>): void {
+  try {
+    void body.cancel().catch(() => undefined);
+  } catch {
+    // Hostile/custom streams may throw synchronously from cancel().
+  }
+}
+
+async function readResponseBodyBounded(
+  body: ReadableStream<Uint8Array>,
+  headers: Headers,
+  maxBytes: number,
+): Promise<ArrayBuffer> {
+  const declared = headers.get("content-length");
+  if (declared !== null) {
+    const length = Number(declared);
+    if (!Number.isSafeInteger(length) || length < 0 || length > maxBytes) {
+      cancelResponseBody(body);
+      throw new Error("Upstream response body inspection failed");
+    }
+  }
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  const cancelReader = () => {
+    try {
+      void reader.cancel().catch(() => undefined);
+    } catch {
+      // See cancelResponseBody: contain custom stream diagnostics.
+    }
+  };
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        cancelReader();
+        throw new Error("Upstream response body inspection failed");
+      }
+      chunks.push(value);
+    }
+  } catch {
+    cancelReader();
+    throw new Error("Upstream response body inspection failed");
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      // A disturbed custom stream may retain its reader; it is never reused.
+    }
+  }
+
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes.buffer;
 }
 
 function credentialLeakVariants(values: string[]): string[] {
@@ -1938,6 +2004,30 @@ export async function handleProxy(c: Context): Promise<Response> {
   const isJsonResponse = contentType.includes("application/json");
   let slackSemanticFailure: string | null = null;
   let deferSlackSuccessAudit = false;
+  let credentialResponseInspectionFailed = false;
+
+  // Every credential-bearing, non-streaming identity-encoded body is consumed
+  // exactly once through an independent 2 MiB reader. This bounds allocation
+  // even when Content-Length is absent or false, and the resulting bytes are
+  // reused by provider semantics, spend parsing, reflection scanning, and the
+  // downstream response.
+  if (
+    sensitiveCredentialValues.length > 0 &&
+    responseBody instanceof ReadableStream &&
+    responseBodyCanReflectCredential(response.headers) &&
+    !responseHasEncodedBody(response.headers)
+  ) {
+    try {
+      responseBody = await readResponseBodyBounded(
+        responseBody,
+        response.headers,
+        MAX_CREDENTIAL_RESPONSE_BODY_BYTES,
+      );
+    } catch {
+      responseBody = new ArrayBuffer(0);
+      credentialResponseInspectionFailed = true;
+    }
+  }
 
   // Slack Web API encodes operation failures as HTTP 200 + {ok:false}. Treat
   // that envelope as a failed dispatch, while retaining the buffered bytes for
@@ -1945,20 +2035,13 @@ export async function handleProxy(c: Context): Promise<Response> {
   // also fail-closed: it cannot prove that the requested action succeeded.
   if (target.host === "slack.com" && response.status >= 200 && response.status < 300) {
     try {
-      const length = Number(response.headers.get("content-length") ?? "0");
-      if (Number.isFinite(length) && length > MAX_PROXY_RESPONSE_BYTES) {
-        throw new Error("Slack response too large");
+      if (credentialResponseInspectionFailed || !(responseBody instanceof ArrayBuffer)) {
+        throw new Error("Slack response inspection failed");
       }
-      const buffer = await response.arrayBuffer();
-      if (buffer.byteLength > MAX_PROXY_RESPONSE_BYTES) throw new Error("Slack response too large");
-      responseBody = buffer;
-      slackSemanticFailure = classifySlackWebApiPayload(new TextDecoder().decode(buffer));
+      slackSemanticFailure = classifySlackWebApiPayload(new TextDecoder().decode(responseBody));
       deferSlackSuccessAudit = slackSemanticFailure === null;
     } catch {
-      // `arrayBuffer()` can reject after disturbing/locking the original body.
-      // Never hand that stream to the later credential scanner or client: a
-      // second read would throw outside this fail-closed boundary and could
-      // retain the per-agent proxy slot. Discard all partial provider bytes.
+      // Never hand partial provider bytes to a later scanner or the client.
       responseBody = new ArrayBuffer(0);
       slackSemanticFailure = "invalid_response";
     }
@@ -1983,13 +2066,13 @@ export async function handleProxy(c: Context): Promise<Response> {
     isProxyRedisAvailable() &&
     (target.host === "api.openai.com" || target.host === "api.anthropic.com");
 
-  if (isLLMHost && isJsonResponse && response.body) {
+  if (isLLMHost && isJsonResponse && responseBody instanceof ArrayBuffer) {
     try {
       const contentLength = Number(response.headers.get("content-length") ?? "0");
       if (Number.isFinite(contentLength) && contentLength > MAX_LLM_SPEND_TRACKING_BODY_BYTES) {
         throw new Error("LLM response too large for spend parsing");
       }
-      const bodyBuffer = await response.arrayBuffer();
+      const bodyBuffer = responseBody;
       if (bodyBuffer.byteLength > MAX_LLM_SPEND_TRACKING_BODY_BYTES) {
         responseBody = bodyBuffer;
         throw new Error("LLM response too large for spend parsing");
@@ -2128,32 +2211,23 @@ export async function handleProxy(c: Context): Promise<Response> {
     responseBodyCanReflectCredential(response.headers) &&
     responseBody instanceof ReadableStream
   ) {
-    const contentLength = Number(response.headers.get("content-length") ?? "0");
-    if (
-      MAX_PROXY_RESPONSE_BYTES <= 0 ||
-      !Number.isFinite(contentLength) ||
-      contentLength <= MAX_PROXY_RESPONSE_BYTES
-    ) {
-      const bodyBuffer = await new Response(responseBody).arrayBuffer();
-      const bodyText = new TextDecoder().decode(bodyBuffer);
-      if (responseTextReflectsAnyCredential(bodyText, sensitiveCredentialValues)) {
-        await recordAudit({
-          agentId,
-          tenantId,
-          targetHost: target.host,
-          targetPath: target.path,
-          method,
-          statusCode: 502,
-          latencyMs: Date.now() - startTime,
-          reason: "credential-reflected-in-response-body",
-        });
-        injectedCredentialValue = null;
-        sensitiveCredentialValues = [];
-        proxySlot.release();
-        return c.json({ ok: false, error: "Upstream response reflected injected credential" }, 502);
-      }
-      responseBody = bodyBuffer;
-    }
+    // Defensive invariant: every inspectable credential-bearing stream was
+    // converted to a bounded ArrayBuffer above.
+    cancelResponseBody(responseBody);
+    await recordAudit({
+      agentId,
+      tenantId,
+      targetHost: target.host,
+      targetPath: target.path,
+      method,
+      statusCode: 502,
+      latencyMs: Date.now() - startTime,
+      reason: "credential-response-inspection-failed",
+    });
+    injectedCredentialValue = null;
+    sensitiveCredentialValues = [];
+    proxySlot.release();
+    return c.json({ ok: false, error: "Upstream response could not be inspected safely" }, 502);
   } else if (
     sensitiveCredentialValues.length > 0 &&
     responseBody instanceof ArrayBuffer &&
@@ -2199,6 +2273,22 @@ export async function handleProxy(c: Context): Promise<Response> {
       },
       502,
     );
+  }
+  if (sensitiveCredentialValues.length > 0 && credentialResponseInspectionFailed) {
+    await recordAudit({
+      agentId,
+      tenantId,
+      targetHost: target.host,
+      targetPath: target.path,
+      method,
+      statusCode: 502,
+      latencyMs: Date.now() - startTime,
+      reason: "credential-response-inspection-failed",
+    });
+    injectedCredentialValue = null;
+    sensitiveCredentialValues = [];
+    proxySlot.release();
+    return c.json({ ok: false, error: "Upstream response could not be inspected safely" }, 502);
   }
   if (deferSlackSuccessAudit) {
     // A Slack `ok:true` envelope is not a successful Steward dispatch until

--- a/packages/proxy/src/handlers/proxy.ts
+++ b/packages/proxy/src/handlers/proxy.ts
@@ -1937,6 +1937,7 @@ export async function handleProxy(c: Context): Promise<Response> {
   const contentType = response.headers.get("content-type") || "";
   const isJsonResponse = contentType.includes("application/json");
   let slackSemanticFailure: string | null = null;
+  let deferSlackSuccessAudit = false;
 
   // Slack Web API encodes operation failures as HTTP 200 + {ok:false}. Treat
   // that envelope as a failed dispatch, while retaining the buffered bytes for
@@ -1952,14 +1953,20 @@ export async function handleProxy(c: Context): Promise<Response> {
       if (buffer.byteLength > MAX_PROXY_RESPONSE_BYTES) throw new Error("Slack response too large");
       responseBody = buffer;
       slackSemanticFailure = classifySlackWebApiPayload(new TextDecoder().decode(buffer));
+      deferSlackSuccessAudit = slackSemanticFailure === null;
     } catch {
+      // `arrayBuffer()` can reject after disturbing/locking the original body.
+      // Never hand that stream to the later credential scanner or client: a
+      // second read would throw outside this fail-closed boundary and could
+      // retain the per-agent proxy slot. Discard all partial provider bytes.
+      responseBody = new ArrayBuffer(0);
       slackSemanticFailure = "invalid_response";
     }
   }
 
   // Slack can report failure in an HTTP 200 envelope. Do not persist a
   // contradictory successful audit row before the semantic failure row below.
-  if (!slackSemanticFailure) {
+  if (!slackSemanticFailure && !deferSlackSuccessAudit) {
     await recordAudit({
       agentId,
       tenantId,
@@ -2192,6 +2199,21 @@ export async function handleProxy(c: Context): Promise<Response> {
       },
       502,
     );
+  }
+  if (deferSlackSuccessAudit) {
+    // A Slack `ok:true` envelope is not a successful Steward dispatch until
+    // response headers/body have also passed the credential-reflection gates
+    // above. Persist success only at that final boundary so blocked responses
+    // cannot leave a contradictory 200 audit row.
+    await recordAudit({
+      agentId,
+      tenantId,
+      targetHost: target.host,
+      targetPath: target.path,
+      method,
+      statusCode: response.status,
+      latencyMs: Date.now() - startTime,
+    });
   }
   injectedCredentialValue = null;
   sensitiveCredentialValues = [];


### PR DESCRIPTION
## Security finding and repair

Post-merge review of #302 found three residual response-boundary failures:

- an interrupted Slack response left a disturbed stream for later credential scanning
- Slack `ok:true` was audited before credential-reflection checks
- Slack semantic parsing and the generic credential scanner used `arrayBuffer()` before checking size, so absent or false `Content-Length` could allocate beyond the intended inspection bound

This draft preserves the disturbed-stream and audit-order fixes, and adds one independent fixed 2 MiB bounded reader for every inspectable credential-bearing response. It counts actual streamed bytes, validates declared length, cancels on overflow/error, discards partial bytes, and exposes only fixed errors. The same resulting bytes are reused by Slack semantics, LLM spend parsing, credential reflection scanning, and the downstream response—no second read and no contradictory Slack success audit.

Hostile regressions cover interrupted bodies, missing `Content-Length`, lying-small `Content-Length`, chunk overflow/cancellation, split credential reflection, audit ordering, and slot release.

Exact validated head: `56fd28a7e91d96eb3d43816b0855e62a0d7a459f`
Base: `93322dd1a809cdcc298be3a15ec450b9f16d66e7`

- Slack credential routes: 8/8 (39 assertions)
- generic proxy spend/SSRF/credential suite: 32/32 (174 assertions)
- proxy TypeScript build, Biome, and diff check: clean

Fresh exact-head CI is required before merge; keep draft until green.
