### PR TITLE
fix(capabilities): enforce cancel-safe lease deadlines

### DIFF
--- a/packages/api/src/services/upstream-credential-lease-scheduler.ts
+++ b/packages/api/src/services/upstream-credential-lease-scheduler.ts
@@ -40,8 +40,11 @@ export function getUpstreamCredentialLeaseSchedulerHealth(
 }
 
 export async function runUpstreamCredentialLeaseSweep() {
-  const { GitHubAppInstallationTokenIssuer, recoverAllInterruptedUpstreamCredentialLeases } =
-    await import("@stwd/plugin-capabilities");
+  const {
+    GitHubAppInstallationTokenIssuer,
+    recoverAllInterruptedUpstreamCredentialLeases,
+    runLeaseDatabasePhase,
+  } = await import("@stwd/plugin-capabilities");
   const { buildPluginContext } = await import("../plugin");
   const ctx = buildPluginContext();
   if (!ctx.exerciseCredentialLeaseToken) {
@@ -52,6 +55,7 @@ export async function runUpstreamCredentialLeaseSweep() {
     issuer: new GitHubAppInstallationTokenIssuer(),
     exerciseToken: ctx.exerciseCredentialLeaseToken,
     auditedTransaction: ctx.withTenantAuditedTransaction,
+    databasePhase: runLeaseDatabasePhase,
   });
 }
 

--- a/packages/db/src/__tests__/client-deadline.test.ts
+++ b/packages/db/src/__tests__/client-deadline.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { sql } from "drizzle-orm";
+import { withTenantAuditQueue } from "../audit-chain";
+import { DatabaseDeadlineExceededError, withDatabaseDeadline } from "../client";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("database deadlines", () => {
+  test("a timed-out audit queue waiter never begins later in the background", async () => {
+    let release!: () => void;
+    let entered!: () => void;
+    const blocked = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const firstEntered = new Promise<void>((resolve) => {
+      entered = resolve;
+    });
+    const first = withTenantAuditQueue("deadline-queue", async () => {
+      entered();
+      await blocked;
+    });
+    await firstEntered;
+
+    let lateMutation = false;
+    await expect(
+      withTenantAuditQueue(
+        "deadline-queue",
+        async () => {
+          lateMutation = true;
+        },
+        Date.now() + 30,
+      ),
+    ).rejects.toBeInstanceOf(DatabaseDeadlineExceededError);
+    release();
+    await first;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(lateMutation).toBe(false);
+  });
+
+  test("neon-http aborts a stalled fetch and returns only a normalized error", async () => {
+    globalThis.fetch = ((_input: RequestInfo | URL, init?: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener(
+          "abort",
+          () => reject(new DOMException("fixture leaked diagnostics", "AbortError")),
+          { once: true },
+        );
+      })) as typeof fetch;
+
+    const startedAt = Date.now();
+    const operation = withDatabaseDeadline(Date.now() + 75, (db) => db.execute(sql`select 1`), {
+      driver: "neon-http",
+      connectionString: "postgresql://test:test@example.invalid/steward?sslmode=require",
+    });
+    await expect(operation).rejects.toEqual(new DatabaseDeadlineExceededError());
+    expect(Date.now() - startedAt).toBeLessThan(1_000);
+  });
+
+  const postgresUrl = process.env.STEWARD_TEST_POSTGRES_URL;
+  test.skipIf(!postgresUrl)(
+    "postgres cancels pg_sleep and rolls back before control returns",
+    async () => {
+      const table = `deadline_rollback_${crypto.randomUUID().replaceAll("-", "")}`;
+      await withDatabaseDeadline(
+        Date.now() + 5_000,
+        (db) => db.execute(sql.raw(`create table ${table} (value integer not null)`)),
+        { driver: "postgres-js", connectionString: postgresUrl },
+      );
+      try {
+        await expect(
+          withDatabaseDeadline(Date.now() + 100, (db) => db.execute(sql`select pg_sleep(1)`), {
+            driver: "postgres-js",
+            connectionString: postgresUrl,
+          }),
+        ).rejects.toBeInstanceOf(DatabaseDeadlineExceededError);
+
+        const timedOut = withDatabaseDeadline(
+          Date.now() + 100,
+          (db) =>
+            db.transaction(async (tx) => {
+              await tx.execute(sql.raw(`insert into ${table} (value) values (1)`));
+              await tx.execute(sql`select pg_sleep(1)`);
+            }),
+          { driver: "postgres-js", connectionString: postgresUrl },
+        );
+        await expect(timedOut).rejects.toBeInstanceOf(DatabaseDeadlineExceededError);
+
+        const rows = await withDatabaseDeadline(
+          Date.now() + 5_000,
+          (db) => db.execute(sql.raw(`select count(*)::int as count from ${table}`)),
+          { driver: "postgres-js", connectionString: postgresUrl },
+        );
+        const resultRows = Array.isArray(rows) ? rows : ((rows as { rows?: unknown[] }).rows ?? []);
+        expect((resultRows[0] as { count: number }).count).toBe(0);
+
+        await expect(
+          withDatabaseDeadline(
+            Date.now() + 75,
+            async (db) => {
+              await new Promise((resolve) => setTimeout(resolve, 150));
+              await db.execute(sql.raw(`insert into ${table} (value) values (2)`));
+            },
+            { driver: "postgres-js", connectionString: postgresUrl },
+          ),
+        ).rejects.toBeInstanceOf(DatabaseDeadlineExceededError);
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        const afterReturn = await withDatabaseDeadline(
+          Date.now() + 5_000,
+          (db) => db.execute(sql.raw(`select count(*)::int as count from ${table}`)),
+          { driver: "postgres-js", connectionString: postgresUrl },
+        );
+        const afterRows = Array.isArray(afterReturn)
+          ? afterReturn
+          : ((afterReturn as { rows?: unknown[] }).rows ?? []);
+        expect((afterRows[0] as { count: number }).count).toBe(0);
+      } finally {
+        await withDatabaseDeadline(
+          Date.now() + 5_000,
+          (db) => db.execute(sql.raw(`drop table if exists ${table}`)),
+          { driver: "postgres-js", connectionString: postgresUrl },
+        );
+      }
+    },
+  );
+});

--- a/packages/db/src/audit-chain.ts
+++ b/packages/db/src/audit-chain.ts
@@ -25,7 +25,7 @@
 import { createHmac } from "node:crypto";
 import { observeSecurityAuditEvent } from "@stwd/shared";
 import { sql } from "drizzle-orm";
-import { getDb } from "./client";
+import { DatabaseDeadlineExceededError, getDb } from "./client";
 
 const ZERO_HASH = new Uint8Array(32);
 
@@ -263,21 +263,51 @@ const tenantAuditQueues = new Map<string, Promise<void>>();
  * guarantee and also gates the real-Postgres advisory-lock acquisition so
  * concurrent appends within one process cannot interleave the seq read/insert.
  */
-export async function withTenantAuditQueue<T>(tenantId: string, fn: () => Promise<T>): Promise<T> {
+export async function withTenantAuditQueue<T>(
+  tenantId: string,
+  fn: () => Promise<T>,
+  deadlineAt?: number,
+): Promise<T> {
   const prior = tenantAuditQueues.get(tenantId) ?? Promise.resolve();
-  const run = prior.catch(() => undefined).then(fn);
+  let cancelled = false;
+  const run = prior
+    .catch(() => undefined)
+    .then(() => {
+      if (cancelled || (deadlineAt !== undefined && Date.now() >= deadlineAt)) {
+        throw new DatabaseDeadlineExceededError();
+      }
+      return fn();
+    });
   const tail = run.then(
     () => undefined,
     () => undefined,
   );
   tenantAuditQueues.set(tenantId, tail);
-
-  try {
-    return await run;
-  } finally {
+  void tail.then(() => {
     if (tenantAuditQueues.get(tenantId) === tail) {
       tenantAuditQueues.delete(tenantId);
     }
+  });
+  if (deadlineAt === undefined) return run;
+
+  const remainingMs = deadlineAt - Date.now();
+  if (remainingMs <= 0) {
+    cancelled = true;
+    throw new DatabaseDeadlineExceededError();
+  }
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      cancelled = true;
+      reject(new DatabaseDeadlineExceededError());
+    }, remainingMs);
+  });
+  try {
+    // Racing is safe here because cancellation is checked before fn can begin;
+    // no database mutation is abandoned after it starts.
+    return await Promise.race([run, deadline]);
+  } finally {
+    if (timer) clearTimeout(timer);
   }
 }
 
@@ -462,44 +492,58 @@ export async function withTenantAuditedTransaction<T>(
 ): Promise<T> {
   const db = getDb();
 
-  return withTenantAuditQueue(tenantId, async () => {
-    for (let attempt = 0; attempt < 5; attempt++) {
-      try {
-        const committedEvents: AuditEventInput[] = [];
-        const result = await db.transaction(async (tx) => {
-          if (!isPGLiteRuntime()) {
-            await tx.execute(
-              sql`SELECT pg_advisory_xact_lock(hashtextextended(${`steward_audit_${tenantId}`}, 0))`,
-            );
-          }
-          const appendRequiredAudit: AppendRequiredAudit = async (event) => {
-            if (event.tenantId !== tenantId) {
-              throw new Error(
-                "withTenantAuditedTransaction: audit event tenant does not match transaction tenant",
+  return withTenantAuditedTransactionOnDb(db, tenantId, fn);
+}
+
+/** Deadline-aware variant used when the caller owns a bounded database handle. */
+export async function withTenantAuditedTransactionOnDb<T>(
+  db: ReturnType<typeof getDb>,
+  tenantId: string,
+  fn: (tx: unknown, appendRequiredAudit: AppendRequiredAudit) => Promise<T>,
+  deadlineAt?: number,
+): Promise<T> {
+  return withTenantAuditQueue(
+    tenantId,
+    async () => {
+      for (let attempt = 0; attempt < 5; attempt++) {
+        try {
+          const committedEvents: AuditEventInput[] = [];
+          const result = await db.transaction(async (tx) => {
+            if (!isPGLiteRuntime()) {
+              await tx.execute(
+                sql`SELECT pg_advisory_xact_lock(hashtextextended(${`steward_audit_${tenantId}`}, 0))`,
               );
             }
-            await appendAuditEventWithinTx(tx as AuditTxLike, event);
-            committedEvents.push(event);
-          };
-          return await fn(tx, appendRequiredAudit);
-        });
-        for (const event of committedEvents) {
-          try {
-            observeSecurityAuditEvent(event.action, event.metadata);
-          } catch {
-            // Monitoring must never become part of the security decision path.
+            const appendRequiredAudit: AppendRequiredAudit = async (event) => {
+              if (event.tenantId !== tenantId) {
+                throw new Error(
+                  "withTenantAuditedTransaction: audit event tenant does not match transaction tenant",
+                );
+              }
+              await appendAuditEventWithinTx(tx as AuditTxLike, event);
+              committedEvents.push(event);
+            };
+            return await fn(tx, appendRequiredAudit);
+          });
+          for (const event of committedEvents) {
+            try {
+              observeSecurityAuditEvent(event.action, event.metadata);
+            } catch {
+              // Monitoring must never become part of the security decision path.
+            }
           }
+          return result;
+        } catch (err) {
+          if (attempt < 4 && isAuditSequenceConflict(err)) {
+            await new Promise((resolve) => setTimeout(resolve, 5 * (attempt + 1)));
+            continue;
+          }
+          throw err;
         }
-        return result;
-      } catch (err) {
-        if (attempt < 4 && isAuditSequenceConflict(err)) {
-          await new Promise((resolve) => setTimeout(resolve, 5 * (attempt + 1)));
-          continue;
-        }
-        throw err;
       }
-    }
-    // Unreachable: the loop either returns or throws.
-    throw new Error("withTenantAuditedTransaction: exhausted retries");
-  });
+      // Unreachable: the loop either returns or throws.
+      throw new Error("withTenantAuditedTransaction: exhausted retries");
+    },
+    deadlineAt,
+  );
 }

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -36,6 +36,39 @@ declare const process: {
 
 export type DatabaseDriver = "postgres-js" | "neon-http";
 
+export class DatabaseDeadlineExceededError extends Error {
+  readonly code = "database_deadline_exceeded";
+
+  constructor() {
+    super("database operation timed out");
+    this.name = "DatabaseDeadlineExceededError";
+  }
+}
+
+export type DeadlineDb = ReturnType<typeof createDb>["db"];
+
+const MIN_DATABASE_DEADLINE_MS = 25;
+const MAX_DATABASE_DEADLINE_MS = 30_000;
+
+function checkedDeadlineMs(deadlineAt: number): number {
+  if (!Number.isFinite(deadlineAt)) throw new DatabaseDeadlineExceededError();
+  const remaining = Math.floor(deadlineAt - Date.now());
+  if (remaining < MIN_DATABASE_DEADLINE_MS) throw new DatabaseDeadlineExceededError();
+  return Math.min(remaining, MAX_DATABASE_DEADLINE_MS);
+}
+
+function isDatabaseTimeout(error: unknown): boolean {
+  if (error instanceof DatabaseDeadlineExceededError) return true;
+  if (!error || typeof error !== "object") return false;
+  const value = error as { name?: unknown; code?: unknown };
+  return (
+    value.name === "AbortError" ||
+    value.name === "TimeoutError" ||
+    value.code === "57014" ||
+    value.code === "CONNECT_TIMEOUT"
+  );
+}
+
 const FULL_SCHEMA = { ...schema, ...schemaAuth };
 type FullSchema = typeof FULL_SCHEMA;
 
@@ -131,11 +164,17 @@ export function assertDatabaseUrlTls(connectionString: string): void {
   );
 }
 
-export function createPostgresClient(connectionString = getDatabaseUrl()) {
+export function createPostgresClient(
+  connectionString = getDatabaseUrl(),
+  options: { max?: number; connectTimeoutSeconds?: number } = {},
+) {
   assertDatabaseUrlTls(connectionString);
   return postgres(connectionString, {
-    max: 10,
+    max: options.max ?? 10,
     prepare: false,
+    ...(options.connectTimeoutSeconds === undefined
+      ? {}
+      : { connect_timeout: options.connectTimeoutSeconds }),
   });
 }
 
@@ -157,14 +196,98 @@ export function createDb(connectionString = getDatabaseUrl()) {
  * Each call returns a fresh client; for per-request use this is intentional —
  * the underlying transport is HTTP, so there is no TCP connection to reuse.
  */
-export function createNeonHttpDb(connectionString = getDatabaseUrl()) {
+export function createNeonHttpDb(
+  connectionString = getDatabaseUrl(),
+  options: { signal?: AbortSignal } = {},
+) {
   assertDatabaseUrlTls(connectionString);
   // Lazy-require so Bun/Node entry points don't pull @neondatabase/serverless
   // into their bundle when the postgres-js driver is in use.
-  const { neon } = require("@neondatabase/serverless") as { neon: (url: string) => any };
-  const client = neon(connectionString);
+  const { neon } = require("@neondatabase/serverless") as {
+    neon: (url: string, options?: { fetchOptions?: Record<string, unknown> }) => any;
+  };
+  const client = neon(connectionString, {
+    fetchOptions: {
+      ...(options.signal ? { signal: options.signal } : {}),
+    },
+  });
   const db = drizzleNeon(client, { schema: FULL_SCHEMA });
   return { client, db };
+}
+
+/**
+ * Run a database phase inside a cancel-safe wall-clock deadline.
+ *
+ * postgres-js uses a fresh single-connection client for each bounded phase.
+ * Its connect timeout therefore covers connection establishment/acquisition,
+ * while PostgreSQL's server-enforced `statement_timeout` cancels statements.
+ * Drizzle transactions opened by the callback inherit that server timeout;
+ * postgres-js observes the cancellation and completes rollback before the
+ * transaction promise rejects.
+ *
+ * neon-http has no pooled connection to acquire. Its per-phase AbortSignal is
+ * passed to the actual fetch request and the timer is kept alive until the
+ * request has settled. A timeout is always normalized and never exposes SQL,
+ * parameters, hosts, or provider diagnostics.
+ */
+export async function withDatabaseDeadline<T>(
+  deadlineAt: number,
+  fn: (db: DeadlineDb) => Promise<T>,
+  options: {
+    driver?: DatabaseDriver;
+    connectionString?: string;
+  } = {},
+): Promise<T> {
+  const budgetMs = checkedDeadlineMs(deadlineAt);
+  const driver = options.driver ?? getDatabaseDriver();
+  const connectionString = options.connectionString ?? getDatabaseUrl();
+
+  if (driver === "neon-http") {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), budgetMs);
+    try {
+      const { db } = createNeonHttpDb(connectionString, {
+        signal: controller.signal,
+      });
+      return await fn(db as unknown as DeadlineDb);
+    } catch (error) {
+      if (controller.signal.aborted || isDatabaseTimeout(error)) {
+        throw new DatabaseDeadlineExceededError();
+      }
+      throw error;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  const client = createPostgresClient(connectionString, {
+    max: 1,
+    connectTimeoutSeconds: Math.max(0.025, budgetMs / 1_000),
+  });
+  let expired = false;
+  const timer = setTimeout(() => {
+    expired = true;
+    // This client is dedicated to the bounded phase and is never returned to a
+    // shared pool. Closing it cancels any in-flight statement and makes a later
+    // query fail immediately if the callback was idle when the deadline hit.
+    void client.end({ timeout: 0 }).catch(() => undefined);
+  }, budgetMs);
+  try {
+    const remainingMs = checkedDeadlineMs(deadlineAt);
+    // max:1 makes this setup query acquire the only connection. Every later
+    // query/transaction in fn uses that same session and inherits the timeout.
+    await client`select set_config('statement_timeout', ${`${remainingMs}ms`}, false)`;
+    const db = drizzlePostgres(client, { schema: FULL_SCHEMA });
+    return await fn(db as unknown as DeadlineDb);
+  } catch (error) {
+    if (expired || Date.now() >= deadlineAt || isDatabaseTimeout(error)) {
+      throw new DatabaseDeadlineExceededError();
+    }
+    throw error;
+  } finally {
+    clearTimeout(timer);
+    await client.end({ timeout: 1 }).catch(() => undefined);
+  }
 }
 
 /**

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -17,6 +17,7 @@ export {
   appendAuditEventWithinTx,
   redactWebhookSecrets,
   withTenantAuditedTransaction,
+  withTenantAuditedTransactionOnDb,
   withTenantAuditQueue,
   writeAuditEvent,
 } from "./audit-chain";
@@ -27,11 +28,13 @@ export {
   createDbForRequest,
   createNeonHttpDb,
   createPostgresClient,
+  DatabaseDeadlineExceededError,
   getDatabaseDriver,
   getDatabaseUrl,
   getDb,
   getSql,
   setPGLiteOverride,
+  withDatabaseDeadline,
 } from "./client";
 export { runMigrations } from "./migrate";
 export { getMigrationExpectation, type MigrationExpectation } from "./migration-status";

--- a/packages/plugin-capabilities/PROVIDER-MODES.md
+++ b/packages/plugin-capabilities/PROVIDER-MODES.md
@@ -71,6 +71,24 @@ so token-mode issuance fails closed there; broker mode remains available. The
 long-lived server also refuses token-mode issuance when the sweeper is disabled
 or configured above 15 seconds (half of the delivery acknowledgement window).
 
+GitHub lease issue, acknowledgement, revoke, tenant recovery, and global
+recovery share one absolute deadline. Interactive delivery uses a 30-second
+wall-clock budget. The GitHub transport consumes at most 10 seconds of the
+remaining budget; database work receives only the time still available and a
+new provider or database phase is not started with less than 100ms remaining.
+
+For `postgres-js`, each bounded lifecycle phase owns a fresh, single-connection
+client. Connection establishment and acquisition are therefore included in the
+budget (there is no wait behind the process-wide pool), while PostgreSQL
+`statement_timeout` cancels reads and transaction statements server-side. If a
+callback is idle when its deadline expires, its dedicated connection is closed,
+so a later mutation cannot begin and the connection is never returned to a
+shared pool. A timed-out transaction finishes rollback before its promise
+rejects. For `neon-http`, the absolute deadline is carried by the request's
+`AbortSignal` and cancels a stalled Workers fetch. Both drivers expose only a
+fixed timeout error; SQL, parameters, hosts, and provider diagnostics are not
+included.
+
 ### broker mode
 ```
 POST /capabilities/manifest/discord:bot-token:soliza/issue

--- a/packages/plugin-capabilities/src/__tests__/github-app-issuer.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/github-app-issuer.test.ts
@@ -88,6 +88,32 @@ describe("GitHub App upstream issuer transport", () => {
     expect(error.message).not.toContain("secret provider cancellation diagnostic");
   });
 
+  test("uses the remaining lifecycle budget instead of restarting its full timeout", async () => {
+    let calls = 0;
+    const issuer = new GitHubAppInstallationTokenIssuer(
+      ((_url, init) => {
+        calls += 1;
+        return new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("aborted", "AbortError")),
+            { once: true },
+          );
+        });
+      }) as typeof fetch,
+      5_000,
+    );
+    const startedAt = Date.now();
+    await expect(issuer.issue(request, { deadlineAt: Date.now() + 30 })).rejects.toThrow(
+      "GitHub request timed out",
+    );
+    expect(Date.now() - startedAt).toBeLessThan(1_000);
+    await expect(issuer.revoke("token", { deadlineAt: Date.now() - 1 })).rejects.toThrow(
+      "GitHub request timed out",
+    );
+    expect(calls).toBe(1);
+  });
+
   test("bounds stalled response bodies and contains hostile cancel rejection", async () => {
     let cancelCalled = false;
     const issuer = new GitHubAppInstallationTokenIssuer(

--- a/packages/plugin-capabilities/src/__tests__/upstream-leases.test.ts
+++ b/packages/plugin-capabilities/src/__tests__/upstream-leases.test.ts
@@ -940,6 +940,30 @@ describe("upstream credential leases", () => {
     expect(oldest?.status).toBe("needs_attention");
   });
 
+  test("global recovery does not begin a database phase without the minimum budget", async () => {
+    let databasePhases = 0;
+    const result = await recoverAllInterruptedUpstreamCredentialLeases({
+      db: harness.db,
+      issuer: new FakeIssuer(),
+      exerciseToken,
+      auditedTransaction: auditedTransaction(),
+      deadlineAt: Date.now() + 50,
+      databasePhase: async (_deadlineAt, run) => {
+        databasePhases += 1;
+        return run(harness.db, auditedTransaction());
+      },
+    });
+    expect(databasePhases).toBe(0);
+    expect(result).toMatchObject({
+      tenants: 0,
+      unknown: 0,
+      revoked: 0,
+      attention: 0,
+      expired: 0,
+      remaining: true,
+    });
+  });
+
   test("global ordering chooses older expiry and authority deadlines before interrupted delivery", async () => {
     const issuer = new FakeIssuer();
     const expiring = await issueUpstreamCredentialLease(

--- a/packages/plugin-capabilities/src/github-app-issuer.ts
+++ b/packages/plugin-capabilities/src/github-app-issuer.ts
@@ -77,7 +77,15 @@ export class GitHubAppInstallationTokenIssuer implements UpstreamTokenIssuer {
     }
   }
 
-  private async withDeadline<T>(run: (signal: AbortSignal) => Promise<T>): Promise<T> {
+  private async withDeadline<T>(
+    run: (signal: AbortSignal) => Promise<T>,
+    deadlineAt?: number,
+  ): Promise<T> {
+    const remainingMs = deadlineAt === undefined ? this.requestTimeoutMs : deadlineAt - Date.now();
+    if (!Number.isFinite(remainingMs) || remainingMs < 10) {
+      throw new Error("GitHub request timed out");
+    }
+    const timeoutMs = Math.min(this.requestTimeoutMs, Math.floor(remainingMs));
     const controller = new AbortController();
     let timer: ReturnType<typeof setTimeout> | undefined;
     let timedOut = false;
@@ -86,7 +94,7 @@ export class GitHubAppInstallationTokenIssuer implements UpstreamTokenIssuer {
         timedOut = true;
         controller.abort();
         reject(new Error("GitHub request timed out"));
-      }, this.requestTimeoutMs);
+      }, timeoutMs);
     });
     try {
       return await Promise.race([run(controller.signal), deadline]);
@@ -101,7 +109,10 @@ export class GitHubAppInstallationTokenIssuer implements UpstreamTokenIssuer {
     }
   }
 
-  async issue(input: Parameters<UpstreamTokenIssuer["issue"]>[0]) {
+  async issue(
+    input: Parameters<UpstreamTokenIssuer["issue"]>[0],
+    options?: { deadlineAt?: number },
+  ) {
     return this.withDeadline(async (signal) => {
       const key = await importPKCS8(input.privateKeyPem, "RS256");
       const now = Math.floor(Date.now() / 1000);
@@ -149,10 +160,10 @@ export class GitHubAppInstallationTokenIssuer implements UpstreamTokenIssuer {
       const expiresAt = new Date(body.expires_at);
       if (!Number.isFinite(expiresAt.getTime())) throw new Error("GitHub token expiry was invalid");
       return { token: body.token, expiresAt };
-    });
+    }, options?.deadlineAt);
   }
 
-  async revoke(token: string): Promise<void> {
+  async revoke(token: string, options?: { deadlineAt?: number }): Promise<void> {
     await this.withDeadline(async (signal) => {
       const response = await this.fetchImpl(`${GITHUB_API}/installation/token`, {
         method: "DELETE",
@@ -174,6 +185,6 @@ export class GitHubAppInstallationTokenIssuer implements UpstreamTokenIssuer {
         throw new Error(`GitHub installation-token revocation failed (${response.status})`);
       }
       void response.body?.cancel().catch(() => {});
-    });
+    }, options?.deadlineAt);
   }
 }

--- a/packages/plugin-capabilities/src/index.ts
+++ b/packages/plugin-capabilities/src/index.ts
@@ -83,7 +83,10 @@ export type { CapabilitySpec } from "./store";
 export { AgentNotFoundError, CapabilityStore, GrantExistsError, isExpired } from "./store";
 export {
   type LeaseAuditedTransaction,
+  type LeaseDatabasePhase,
   recoverAllInterruptedUpstreamCredentialLeases,
+  runLeaseDatabasePhase,
+  UPSTREAM_LEASE_RUN_DEADLINE_MS,
 } from "./upstream-leases";
 export {
   createCapabilitySchema,

--- a/packages/plugin-capabilities/src/manifest-routes.ts
+++ b/packages/plugin-capabilities/src/manifest-routes.ts
@@ -44,6 +44,8 @@ import {
   MAX_UPSTREAM_LEASE_SWEEP_INTERVAL_MS,
   recoverInterruptedUpstreamCredentialLeases,
   revokeUpstreamCredentialLease,
+  runLeaseDatabasePhase,
+  UPSTREAM_LEASE_RUN_DEADLINE_MS,
 } from "./upstream-leases";
 
 export function upstreamLeaseIssuanceAvailableInRuntime(): boolean {
@@ -244,50 +246,55 @@ export function createManifestRoutes(ctx: StewardAppContext): Hono<{ Variables: 
           );
         }
         try {
+          const deadlineAt = Date.now() + UPSTREAM_LEASE_RUN_DEADLINE_MS;
           await recoverInterruptedUpstreamCredentialLeases({
             db: ctx.db,
             tenantId,
             issuer: githubIssuer,
             exerciseToken: ctx.exerciseCredentialLeaseToken,
             auditedTransaction: ctx.withTenantAuditedTransaction,
+            deadlineAt,
+            databasePhase: runLeaseDatabasePhase,
+          });
+          const leased = await issueUpstreamCredentialLease({
+            db: ctx.db,
+            tenantId,
+            agentId,
+            workspaceId: leaseBody.workspaceId,
+            idempotencyKey,
+            ttlSeconds: leaseBody.ttlSeconds,
+            resource: leaseBody.resource,
+            resolved,
+            exerciseSecret: ctx.exerciseCredentialSecret,
+            sealToken: ctx.sealCredentialLeaseToken,
+            auditedTransaction: ctx.withTenantAuditedTransaction,
+            issuer: githubIssuer,
+            deadlineAt,
+            databasePhase: runLeaseDatabasePhase,
+          });
+          if (!leased.ok) {
+            return c.json<ApiResponse>({ ok: false, error: leased.error }, leased.status);
+          }
+          c.header("Cache-Control", "no-store, max-age=0");
+          c.header("Pragma", "no-cache");
+          return c.json<ApiResponse>({
+            ok: true,
+            data: {
+              mode: "token",
+              issuer: GITHUB_APP_LEASE_ISSUER,
+              leaseId: leased.leaseId,
+              token: leased.token,
+              acknowledgementRequired: true,
+              acknowledgementDeadlineSeconds: DELIVERY_ACK_TIMEOUT_MS / 1000,
+              expiresAt: leased.expiresAt,
+              resource: leased.resource,
+              manifest: manifestId,
+              capabilityId: resolved.capability.id,
+            },
           });
         } catch {
           return c.json<ApiResponse>({ ok: false, error: "credential lease recovery failed" }, 503);
         }
-        const leased = await issueUpstreamCredentialLease({
-          db: ctx.db,
-          tenantId,
-          agentId,
-          workspaceId: leaseBody.workspaceId,
-          idempotencyKey,
-          ttlSeconds: leaseBody.ttlSeconds,
-          resource: leaseBody.resource,
-          resolved,
-          exerciseSecret: ctx.exerciseCredentialSecret,
-          sealToken: ctx.sealCredentialLeaseToken,
-          auditedTransaction: ctx.withTenantAuditedTransaction,
-          issuer: githubIssuer,
-        });
-        if (!leased.ok) {
-          return c.json<ApiResponse>({ ok: false, error: leased.error }, leased.status);
-        }
-        c.header("Cache-Control", "no-store, max-age=0");
-        c.header("Pragma", "no-cache");
-        return c.json<ApiResponse>({
-          ok: true,
-          data: {
-            mode: "token",
-            issuer: GITHUB_APP_LEASE_ISSUER,
-            leaseId: leased.leaseId,
-            token: leased.token,
-            acknowledgementRequired: true,
-            acknowledgementDeadlineSeconds: DELIVERY_ACK_TIMEOUT_MS / 1000,
-            expiresAt: leased.expiresAt,
-            resource: leased.resource,
-            manifest: manifestId,
-            capabilityId: resolved.capability.id,
-          },
-        });
       }
 
       const result = await issueCapability({
@@ -332,6 +339,8 @@ export function createManifestRoutes(ctx: StewardAppContext): Hono<{ Variables: 
       token: body.token,
       issuer: githubIssuer,
       auditedTransaction: ctx.withTenantAuditedTransaction,
+      deadlineAt: Date.now() + UPSTREAM_LEASE_RUN_DEADLINE_MS,
+      databasePhase: runLeaseDatabasePhase,
     });
     if (!result.ok) return c.json<ApiResponse>({ ok: false, error: result.error }, result.status);
     c.header("Cache-Control", "no-store, max-age=0");
@@ -355,6 +364,8 @@ export function createManifestRoutes(ctx: StewardAppContext): Hono<{ Variables: 
       leaseId: c.req.param("leaseId"),
       token: body.token,
       auditedTransaction: ctx.withTenantAuditedTransaction,
+      deadlineAt: Date.now() + UPSTREAM_LEASE_RUN_DEADLINE_MS,
+      databasePhase: runLeaseDatabasePhase,
     });
     if (!result.ok) return c.json<ApiResponse>({ ok: false, error: result.error }, result.status);
     c.header("Cache-Control", "no-store, max-age=0");

--- a/packages/plugin-capabilities/src/upstream-leases.ts
+++ b/packages/plugin-capabilities/src/upstream-leases.ts
@@ -11,6 +11,8 @@ import {
   or,
   upstreamCredentialLeaseEvents,
   upstreamCredentialLeases,
+  withDatabaseDeadline,
+  withTenantAuditedTransactionOnDb,
 } from "@stwd/db";
 import { capabilities, capabilityGrants } from "./schema";
 
@@ -26,6 +28,8 @@ export const UPSTREAM_LEASE_AUTHORITY_RECHECK_INTERVAL_MS = MAX_UPSTREAM_LEASE_S
 const MAX_GITHUB_PERMISSION_COUNT = 100;
 const GITHUB_PERMISSION_NAME = /^[a-z][a-z0-9_]{0,63}$/;
 const MAX_GITHUB_TOKEN_BYTES = 4096;
+export const UPSTREAM_LEASE_RUN_DEADLINE_MS = 30_000;
+export const MIN_UPSTREAM_LEASE_PHASE_BUDGET_MS = 100;
 
 export interface GitHubLeaseResource {
   repositories: string[];
@@ -43,13 +47,16 @@ export interface GitHubAppLeaseConfig {
 }
 
 export interface UpstreamTokenIssuer {
-  issue(input: {
-    appId: string;
-    installationId: string;
-    privateKeyPem: string;
-    resource: GitHubLeaseResource;
-  }): Promise<{ token: string; expiresAt: Date }>;
-  revoke(token: string): Promise<void>;
+  issue(
+    input: {
+      appId: string;
+      installationId: string;
+      privateKeyPem: string;
+      resource: GitHubLeaseResource;
+    },
+    options?: { deadlineAt?: number },
+  ): Promise<{ token: string; expiresAt: Date }>;
+  revoke(token: string, options?: { deadlineAt?: number }): Promise<void>;
 }
 
 export type ExerciseCredentialSecret = <T>(
@@ -79,7 +86,27 @@ export type LeaseAuditedTransaction = <T>(
   fn: (tx: Db, appendRequiredAudit: AppendRequiredAudit) => Promise<T>,
 ) => Promise<T>;
 
+export type LeaseDatabasePhase = <T>(
+  deadlineAt: number,
+  fn: (db: Db, auditedTransaction: LeaseAuditedTransaction) => Promise<T>,
+) => Promise<T>;
+
 type Db = any;
+
+export const runLeaseDatabasePhase: LeaseDatabasePhase = (deadlineAt, fn) =>
+  withDatabaseDeadline(deadlineAt, (db) =>
+    fn(db, (tenantId, callback) =>
+      withTenantAuditedTransactionOnDb(db, tenantId, callback as never, deadlineAt),
+    ),
+  );
+
+function leaseDeadline(deadlineAt?: number): number {
+  return deadlineAt ?? Date.now() + UPSTREAM_LEASE_RUN_DEADLINE_MS;
+}
+
+function hasPhaseBudget(deadlineAt: number): boolean {
+  return deadlineAt - Date.now() >= MIN_UPSTREAM_LEASE_PHASE_BUDGET_MS;
+}
 
 let beforeRecoveryClaimForTests: ((leaseId: string) => Promise<void>) | undefined;
 
@@ -498,7 +525,24 @@ export async function recoverInterruptedUpstreamCredentialLeases(input: {
   auditedTransaction: LeaseAuditedTransaction;
   now?: Date;
   limit?: number;
+  deadlineAt?: number;
+  databasePhase?: LeaseDatabasePhase;
 }): Promise<{ unknown: number; revoked: number; attention: number }> {
+  const deadlineAt = leaseDeadline(input.deadlineAt);
+  if (!hasPhaseBudget(deadlineAt)) {
+    throw new Error("credential lease deadline exceeded");
+  }
+  if (input.databasePhase) {
+    return input.databasePhase(deadlineAt, (db, auditedTransaction) =>
+      recoverInterruptedUpstreamCredentialLeases({
+        ...input,
+        db,
+        auditedTransaction,
+        deadlineAt,
+        databasePhase: undefined,
+      }),
+    );
+  }
   const now = input.now ?? new Date();
   const cutoff = new Date(now.getTime() - DELIVERY_ACK_TIMEOUT_MS);
   const limit = Math.max(1, Math.min(input.limit ?? 100, 500));
@@ -553,6 +597,7 @@ export async function recoverInterruptedUpstreamCredentialLeases(input: {
       auditedTransaction: input.auditedTransaction,
       now,
       mode: "authority_teardown",
+      deadlineAt,
     });
     if (result.ok) revoked += result.revoked;
     else attention += 1;
@@ -646,6 +691,7 @@ export async function recoverInterruptedUpstreamCredentialLeases(input: {
       now,
       mode: "stale_recovery",
       staleCutoff: cutoff,
+      deadlineAt,
     });
     if (result.ok) revoked += result.revoked;
     else attention += 1;
@@ -669,6 +715,7 @@ async function recoverOneDueLease(input: {
   auditedTransaction: LeaseAuditedTransaction;
   now: Date;
   cutoff: Date;
+  deadlineAt: number;
 }): Promise<RecoveryTotals> {
   const { lease } = input;
   if (lease.status === "issuing") {
@@ -723,6 +770,7 @@ async function recoverOneDueLease(input: {
     now: input.now,
     mode: "stale_recovery",
     staleCutoff: input.cutoff,
+    deadlineAt: input.deadlineAt,
   });
   return result.ok
     ? { unknown: 0, revoked: result.revoked, attention: 0 }
@@ -736,6 +784,7 @@ async function recoverOneActiveLease(input: {
   exerciseToken: ExerciseLeaseToken;
   auditedTransaction: LeaseAuditedTransaction;
   now: Date;
+  deadlineAt: number;
 }): Promise<RecoveryTotals> {
   const { lease } = input;
   const live = await readLiveLeaseAuthority(
@@ -775,6 +824,7 @@ async function recoverOneActiveLease(input: {
     auditedTransaction: input.auditedTransaction,
     now: input.now,
     mode: "authority_teardown",
+    deadlineAt: input.deadlineAt,
   });
   return result.ok
     ? { unknown: 0, revoked: result.revoked, attention: 0 }
@@ -826,7 +876,7 @@ async function mapWithDeadline<T>(input: {
   let cursor = 0;
   let started = 0;
   const worker = async () => {
-    while (Date.now() < input.deadlineAt) {
+    while (hasPhaseBudget(input.deadlineAt)) {
       const index = cursor++;
       const item = input.items[index];
       if (item === undefined) return;
@@ -855,6 +905,8 @@ export async function recoverAllInterruptedUpstreamCredentialLeases(input: {
   concurrency?: number;
   /** Stop claiming new work after this wall-clock budget; already claimed work is awaited. */
   runDeadlineMs?: number;
+  deadlineAt?: number;
+  databasePhase?: LeaseDatabasePhase;
 }): Promise<{
   tenants: number;
   unknown: number;
@@ -863,13 +915,38 @@ export async function recoverAllInterruptedUpstreamCredentialLeases(input: {
   expired: number;
   remaining: boolean;
 }> {
+  const requestedRunDeadlineMs = Math.max(
+    100,
+    Math.min(input.runDeadlineMs ?? 5_000, UPSTREAM_LEASE_RUN_DEADLINE_MS),
+  );
+  const outerDeadlineAt = input.deadlineAt ?? Date.now() + requestedRunDeadlineMs;
+  if (!hasPhaseBudget(outerDeadlineAt)) {
+    return {
+      tenants: 0,
+      unknown: 0,
+      revoked: 0,
+      attention: 0,
+      expired: 0,
+      remaining: true,
+    };
+  }
+  if (input.databasePhase) {
+    return input.databasePhase(outerDeadlineAt, (db, auditedTransaction) =>
+      recoverAllInterruptedUpstreamCredentialLeases({
+        ...input,
+        db,
+        auditedTransaction,
+        deadlineAt: outerDeadlineAt,
+        databasePhase: undefined,
+      }),
+    );
+  }
   const now = input.now ?? new Date();
   const cutoff = new Date(now.getTime() - DELIVERY_ACK_TIMEOUT_MS);
   const authorityCutoff = new Date(now.getTime() - UPSTREAM_LEASE_AUTHORITY_RECHECK_INTERVAL_MS);
   const workLimit = Math.max(1, Math.min(input.workLimit ?? 500, 2_000));
   const concurrency = Math.max(1, Math.min(input.concurrency ?? 16, 64));
-  const runDeadlineMs = Math.max(100, Math.min(input.runDeadlineMs ?? 5_000, 10_000));
-  const deadlineAt = Date.now() + runDeadlineMs;
+  const deadlineAt = outerDeadlineAt;
   // Pull at most one global page from each independently indexed deadline
   // class, then merge them by their actual recovery deadline. Fetching
   // workLimit + 1 from each class is sufficient to identify the global first
@@ -978,8 +1055,8 @@ export async function recoverAllInterruptedUpstreamCredentialLeases(input: {
         } else {
           const recovered =
             candidate.phase === "interrupted"
-              ? await recoverOneDueLease({ ...input, lease, now, cutoff })
-              : await recoverOneActiveLease({ ...input, lease, now });
+              ? await recoverOneDueLease({ ...input, lease, now, cutoff, deadlineAt })
+              : await recoverOneActiveLease({ ...input, lease, now, deadlineAt });
           totals.unknown += recovered.unknown;
           totals.revoked += recovered.revoked;
           totals.attention += recovered.attention;
@@ -1012,7 +1089,38 @@ export async function issueUpstreamCredentialLease(input: {
   auditedTransaction: LeaseAuditedTransaction;
   issuer: UpstreamTokenIssuer;
   now?: Date;
+  deadlineAt?: number;
+  databasePhase?: LeaseDatabasePhase;
 }): Promise<LeaseIssueResult> {
+  const deadlineAt = leaseDeadline(input.deadlineAt);
+  if (!hasPhaseBudget(deadlineAt)) {
+    return {
+      ok: false,
+      status: 503,
+      code: "lease_deadline_exceeded",
+      error: "credential lease deadline exceeded",
+    };
+  }
+  if (input.databasePhase) {
+    try {
+      return await input.databasePhase(deadlineAt, (db, auditedTransaction) =>
+        issueUpstreamCredentialLease({
+          ...input,
+          db,
+          auditedTransaction,
+          deadlineAt,
+          databasePhase: undefined,
+        }),
+      );
+    } catch {
+      return {
+        ok: false,
+        status: 503,
+        code: "lease_store_unavailable",
+        error: "credential lease store unavailable",
+      };
+    }
+  }
   try {
     await expireUpstreamCredentialLeases({
       db: input.db,
@@ -1140,12 +1248,15 @@ export async function issueUpstreamCredentialLease(input: {
       input.tenantId,
       input.resolved.capability.secretId,
       async (privateKeyPem) =>
-        input.issuer.issue({
-          appId: config.appId,
-          installationId: config.installationId,
-          privateKeyPem,
-          resource,
-        }),
+        input.issuer.issue(
+          {
+            appId: config.appId,
+            installationId: config.installationId,
+            privateKeyPem,
+            resource,
+          },
+          { deadlineAt },
+        ),
     );
   } catch {
     await recordFailure(
@@ -1167,7 +1278,7 @@ export async function issueUpstreamCredentialLease(input: {
   try {
     sealed = await input.sealToken(input.tenantId, claim.id, issued.token);
   } catch {
-    const revoked = await input.issuer.revoke(issued.token).then(
+    const revoked = await input.issuer.revoke(issued.token, { deadlineAt }).then(
       () => true,
       () => false,
     );
@@ -1213,7 +1324,7 @@ export async function issueUpstreamCredentialLease(input: {
       // A storage outage must not prevent the only in-frame cleanup attempt.
       // If provider revocation is also ambiguous, make one final durable escrow
       // attempt and otherwise propagate rather than pretending cleanup worked.
-      const revoked = await input.issuer.revoke(issued.token).then(
+      const revoked = await input.issuer.revoke(issued.token, { deadlineAt }).then(
         () => true,
         () => false,
       );
@@ -1245,7 +1356,7 @@ export async function issueUpstreamCredentialLease(input: {
         error: "upstream issuer returned an invalid credential",
       };
     }
-    const revoked = await input.issuer.revoke(issued.token).then(
+    const revoked = await input.issuer.revoke(issued.token, { deadlineAt }).then(
       () => true,
       () => false,
     );
@@ -1349,7 +1460,7 @@ export async function issueUpstreamCredentialLease(input: {
       );
     });
     if (authorityInvalidated) {
-      const revoked = await input.issuer.revoke(issued.token).then(
+      const revoked = await input.issuer.revoke(issued.token, { deadlineAt }).then(
         () => true,
         () => false,
       );
@@ -1385,7 +1496,7 @@ export async function issueUpstreamCredentialLease(input: {
     // The token only exists in this frame. If durable finalization fails, revoke
     // it before dropping the reference; a hard kill inside this tiny boundary is
     // the documented provider-lifetime precommit-orphan case.
-    const revoked = await input.issuer.revoke(issued.token).then(
+    const revoked = await input.issuer.revoke(issued.token, { deadlineAt }).then(
       () => true,
       () => false,
     );
@@ -1457,7 +1568,28 @@ export async function acknowledgeUpstreamCredentialLease(input: {
   token: string;
   auditedTransaction: LeaseAuditedTransaction;
   now?: Date;
+  deadlineAt?: number;
+  databasePhase?: LeaseDatabasePhase;
 }): Promise<{ ok: true } | { ok: false; status: 403 | 404 | 409 | 503; error: string }> {
+  const deadlineAt = leaseDeadline(input.deadlineAt);
+  if (!hasPhaseBudget(deadlineAt)) {
+    return { ok: false, status: 503, error: "credential lease deadline exceeded" };
+  }
+  if (input.databasePhase) {
+    try {
+      return await input.databasePhase(deadlineAt, (db, auditedTransaction) =>
+        acknowledgeUpstreamCredentialLease({
+          ...input,
+          db,
+          auditedTransaction,
+          deadlineAt,
+          databasePhase: undefined,
+        }),
+      );
+    } catch {
+      return { ok: false, status: 503, error: "credential lease store unavailable" };
+    }
+  }
   const now = input.now ?? new Date();
   const [lease] = await input.db
     .select()
@@ -1565,7 +1697,28 @@ export async function revokeUpstreamCredentialLease(input: {
   issuer: UpstreamTokenIssuer;
   auditedTransaction: LeaseAuditedTransaction;
   now?: Date;
+  deadlineAt?: number;
+  databasePhase?: LeaseDatabasePhase;
 }): Promise<{ ok: true } | { ok: false; status: 403 | 404 | 409 | 503; error: string }> {
+  const deadlineAt = leaseDeadline(input.deadlineAt);
+  if (!hasPhaseBudget(deadlineAt)) {
+    return { ok: false, status: 503, error: "credential lease deadline exceeded" };
+  }
+  if (input.databasePhase) {
+    try {
+      return await input.databasePhase(deadlineAt, (db, auditedTransaction) =>
+        revokeUpstreamCredentialLease({
+          ...input,
+          db,
+          auditedTransaction,
+          deadlineAt,
+          databasePhase: undefined,
+        }),
+      );
+    } catch {
+      return { ok: false, status: 503, error: "credential lease store unavailable" };
+    }
+  }
   const now = input.now ?? new Date();
   const [lease] = await input.db
     .select()
@@ -1648,7 +1801,7 @@ export async function revokeUpstreamCredentialLease(input: {
     .returning({ id: upstreamCredentialLeases.id });
   if (!claimed) return { ok: false, status: 409, error: "lease is not active" };
   try {
-    await input.issuer.revoke(input.token);
+    await input.issuer.revoke(input.token, { deadlineAt });
   } catch {
     await input
       .auditedTransaction(input.tenantId, async (tx: Db, appendRequiredAudit) => {
@@ -1754,6 +1907,7 @@ async function revokeExactSealedLease(input: {
   now: Date;
   mode?: "authority_teardown" | "stale_recovery";
   staleCutoff?: Date;
+  deadlineAt?: number;
 }): Promise<{ ok: true; revoked: number } | { ok: false; error: string }> {
   const sealed = sealedTokenFromLease(input.lease);
   if (!sealed) {
@@ -1842,7 +1996,7 @@ async function revokeExactSealedLease(input: {
   }
   try {
     await input.exerciseToken(input.tenantId, input.lease.id, sealed, (token) =>
-      input.issuer.revoke(token),
+      input.issuer.revoke(token, { deadlineAt: input.deadlineAt }),
     );
   } catch {
     await input.auditedTransaction(input.tenantId, async (tx: Db, appendRequiredAudit) => {


### PR DESCRIPTION
## Summary
- add a driver-owned database deadline primitive: dedicated postgres-js connections use bounded connect acquisition plus server `statement_timeout`, while Neon HTTP receives an abort signal on the actual request
- thread one remaining wall-clock budget through GitHub lease issue, ACK, revoke, tenant recovery, and the global scheduler; provider calls cannot restart their full timeout
- make tenant audit-queue deadline cancellation prevent queued work from starting later, normalize timeout errors, and document the 30-second phase budget contract

## Safety contract
- no mutation/transaction is abandoned with `Promise.race`
- postgres timeout/cancellation closes a dedicated connection that is never returned to the shared pool; transaction rollback finishes before rejection
- a timed-out in-process audit waiter is cancelled before its callback can begin
- Neon abort and postgres errors are normalized without SQL, parameters, hostnames, or provider diagnostics

## Exact-head validation
Validated commit: `a8738acf2244a27a7df240242e82330d29bc8bd3`
Base: `f96d3754f5c559f79c18eba60157328f79dbedf2`

- `bun run --cwd packages/db build`
- `bun run --cwd packages/plugin-capabilities build`
- `bun run --cwd packages/shared build && bun run --cwd packages/provider-slack build && bun run --cwd packages/api build`
- `STEWARD_TEST_POSTGRES_URL=postgresql://127.0.0.1:55439/steward_test bun test packages/db/src/__tests__/client-deadline.test.ts` — 3 pass, including read `pg_sleep`, transaction rollback, stalled Neon fetch, and no late queued mutation
- `bun test packages/plugin-capabilities/src/__tests__/github-app-issuer.test.ts` — 9 pass
- `bun test packages/plugin-capabilities/src/__tests__/upstream-leases.test.ts` — 39 pass / 230 assertions
- `bun test packages/api/src/__tests__/upstream-credential-lease-scheduler.test.ts` — 5 pass
- Biome on all changed TypeScript files; `git diff --check`

Closes #387
