### PR TITLE
fix(api): register Slack authority fail closed

### DIFF
--- a/packages/api/src/__tests__/provider-slack-authority-registration.test.ts
+++ b/packages/api/src/__tests__/provider-slack-authority-registration.test.ts
@@ -1,0 +1,122 @@
+import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
+import {
+  agents,
+  closeDb,
+  getDb,
+  providerOperations,
+  secretRoutes,
+  tenants,
+  users,
+  userTenants,
+  workspaces,
+} from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { SecretVault } from "@stwd/vault";
+import { eq } from "drizzle-orm";
+import { ProviderAuthorityStore } from "../services/provider-authority-store";
+
+setDefaultTimeout(120_000);
+
+const TENANT = "tenant-slack-authority";
+const OWNER = "10000000-0000-4000-8000-000000000091";
+const WORKSPACE = "20000000-0000-4000-8000-000000000091";
+const AGENT = "agent-slack-authority";
+const MASTER = "slack-authority-registration-test-master";
+
+describe("Slack provider authority registration", () => {
+  const store = new ProviderAuthorityStore();
+  let secretId: string;
+  let routeId: string;
+
+  beforeAll(async () => {
+    process.env.STEWARD_PGLITE_MEMORY = "true";
+    process.env.STEWARD_AUDIT_HMAC_KEY = "a".repeat(64);
+    process.env.STEWARD_MASTER_PASSWORD = MASTER;
+    const { db, client } = await createPGLiteDb("memory://");
+    setPGLiteOverride(db, async () => client.close());
+    await db.insert(tenants).values({ id: TENANT, name: TENANT, apiKeyHash: `hash-${TENANT}` });
+    await db.insert(users).values({ id: OWNER, email: "slack-authority@example.test" });
+    await db.insert(userTenants).values({ userId: OWNER, tenantId: TENANT, role: "owner" });
+    await db.insert(agents).values({
+      id: AGENT,
+      tenantId: TENANT,
+      name: "Slack authority agent",
+      walletAddress: `0x${"9".repeat(40)}`,
+    });
+    await db.insert(workspaces).values({
+      id: WORKSPACE,
+      tenantId: TENANT,
+      key: "slack-authority",
+      name: "Slack Authority",
+      environment: "production",
+      createdBy: OWNER,
+    });
+    const vault = new SecretVault(MASTER);
+    const secret = await vault.createSecret(TENANT, "slack-authority-token", "xoxb-test-token-123");
+    secretId = secret.id;
+    const route = await vault.createRoute(TENANT, secret.id, {
+      agentId: AGENT,
+      hostPattern: "slack.com",
+      pathPattern: "/api/chat.postMessage",
+      method: "POST",
+      injectAs: "header",
+      injectKey: "authorization",
+      injectFormat: "Bearer {value}",
+    });
+    routeId = route.id;
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    delete process.env.STEWARD_PGLITE_MEMORY;
+    delete process.env.STEWARD_AUDIT_HMAC_KEY;
+    delete process.env.STEWARD_MASTER_PASSWORD;
+  });
+
+  test("registers Slack while rejecting a read-risk downgrade for chat.postMessage", async () => {
+    const context = (expectedRevision: number) => ({
+      tenantId: TENANT,
+      actorUserId: OWNER,
+      tenantRole: "owner",
+      mfaVerifiedAt: Date.now(),
+      idempotencyKey: `idem-${crypto.randomUUID()}`,
+      expectedRevision,
+      reason: "Slack authority regression",
+      audit: async () => {},
+    });
+
+    const account = await store.createProviderAccount(context(1), {
+      workspaceId: WORKSPACE,
+      adapterKey: "slack",
+      externalRef: "T01234567",
+      displayName: "Slack bot",
+      credentialSecretId: secretId,
+      credentialVersion: 1,
+    });
+    expect(account.adapterKey).toBe("slack");
+
+    await expect(
+      store.registerOperation(context(1), account.id, {
+        operationKey: "slack.chat.postMessage",
+        riskClass: "read",
+        secretRouteId: routeId,
+      }),
+    ).rejects.toMatchObject({ code: "bad_request", status: 400 });
+
+    const operation = await store.registerOperation(context(1), account.id, {
+      operationKey: "slack.chat.postMessage",
+      riskClass: "write",
+      secretRouteId: routeId,
+    });
+    expect(operation).toMatchObject({
+      operationKey: "slack.chat.postMessage",
+      riskClass: "write",
+    });
+    expect(await getDb().select().from(providerOperations)).toHaveLength(1);
+    const [route] = await getDb()
+      .select({ mode: secretRoutes.authorityMode, operationId: secretRoutes.providerOperationId })
+      .from(secretRoutes)
+      .where(eq(secretRoutes.id, routeId));
+    expect(route).toEqual({ mode: "governed_v2", operationId: operation.id });
+  });
+});

--- a/packages/api/src/__tests__/provider-slack-authority-registration.test.ts
+++ b/packages/api/src/__tests__/provider-slack-authority-registration.test.ts
@@ -3,6 +3,7 @@ import {
   agents,
   closeDb,
   getDb,
+  providerAccounts,
   providerOperations,
   secretRoutes,
   tenants,
@@ -27,6 +28,7 @@ describe("Slack provider authority registration", () => {
   const store = new ProviderAuthorityStore();
   let secretId: string;
   let routeId: string;
+  let wrongPathRouteId: string;
 
   beforeAll(async () => {
     process.env.STEWARD_PGLITE_MEMORY = "true";
@@ -64,6 +66,16 @@ describe("Slack provider authority registration", () => {
       injectFormat: "Bearer {value}",
     });
     routeId = route.id;
+    const wrongPathRoute = await vault.createRoute(TENANT, secret.id, {
+      agentId: AGENT,
+      hostPattern: "slack.com",
+      pathPattern: "/api/admin.users.session.reset",
+      method: "POST",
+      injectAs: "header",
+      injectKey: "authorization",
+      injectFormat: "Bearer {value}",
+    });
+    wrongPathRouteId = wrongPathRoute.id;
   });
 
   afterAll(async () => {
@@ -102,6 +114,38 @@ describe("Slack provider authority registration", () => {
         secretRouteId: routeId,
       }),
     ).rejects.toMatchObject({ code: "bad_request", status: 400 });
+
+    await expect(
+      store.registerOperation(context(1), account.id, {
+        operationKey: "slack.chat.postMessage",
+        riskClass: "write",
+        secretRouteId: wrongPathRouteId,
+      }),
+    ).rejects.toMatchObject({ code: "forbidden", status: 403 });
+
+    // The completed audit is part of the same transaction as the account CAS,
+    // operation insert, and route promotion. If audit signing fails, all three
+    // mutations must roll back together.
+    delete process.env.STEWARD_AUDIT_HMAC_KEY;
+    await expect(
+      store.registerOperation(context(1), account.id, {
+        operationKey: "slack.chat.postMessage",
+        riskClass: "write",
+        secretRouteId: routeId,
+      }),
+    ).rejects.toThrow("STEWARD_AUDIT_HMAC_KEY is required");
+    process.env.STEWARD_AUDIT_HMAC_KEY = "a".repeat(64);
+    expect(await getDb().select().from(providerOperations)).toHaveLength(0);
+    const [rolledBackAccount] = await getDb()
+      .select({ revision: providerAccounts.revision })
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, account.id));
+    expect(rolledBackAccount?.revision).toBe(1);
+    const [rolledBackRoute] = await getDb()
+      .select({ mode: secretRoutes.authorityMode, operationId: secretRoutes.providerOperationId })
+      .from(secretRoutes)
+      .where(eq(secretRoutes.id, routeId));
+    expect(rolledBackRoute).toEqual({ mode: "legacy", operationId: null });
 
     const operation = await store.registerOperation(context(1), account.id, {
       operationKey: "slack.chat.postMessage",

--- a/packages/api/src/services/provider-authority-store.ts
+++ b/packages/api/src/services/provider-authority-store.ts
@@ -15,6 +15,7 @@ import {
   withTenantAuditedTransaction,
   workspaces,
 } from "@stwd/db";
+import { SLACK_OPERATION_RISK, type SlackOperationKey } from "@stwd/provider-slack";
 import {
   GENERIC_HTTP_PROVIDER_ACTION_PROFILE,
   genericDescriptorAllowsExactPath,
@@ -42,6 +43,16 @@ import {
 const RECENT_MFA_MS = 5 * 60_000;
 const OPERATION_KEY = /^[a-z][a-z0-9]*(?:\.[a-z][a-z0-9_]*)+$/;
 const KEY = /^[a-z][a-z0-9_-]{0,127}$/;
+const SLACK_OPERATION_METHOD = {
+  "slack.chat.postMessage": "POST",
+  "slack.conversations.list": "GET",
+  "slack.users.info": "GET",
+} as const satisfies Readonly<Record<SlackOperationKey, "GET" | "POST" | "DELETE">>;
+const SLACK_OPERATION_EXACT_PATH = {
+  "slack.chat.postMessage": "/api/chat.postMessage",
+  "slack.conversations.list": "/api/conversations.list",
+  "slack.users.info": "/api/users.info",
+} as const satisfies Readonly<Record<SlackOperationKey, string>>;
 const PROVIDER_OPERATION_ALLOWLIST: Readonly<
   Record<string, Readonly<Record<string, "GET" | "POST" | "DELETE">>>
 > = {
@@ -54,11 +65,7 @@ const PROVIDER_OPERATION_ALLOWLIST: Readonly<
     "x.tweet.delete": "DELETE",
     "x.user.me.read": "GET",
   },
-  slack: {
-    "slack.chat.postMessage": "POST",
-    "slack.conversations.list": "GET",
-    "slack.users.info": "GET",
-  },
+  slack: SLACK_OPERATION_METHOD,
 };
 const PROVIDER_OPERATION_MINIMUM_RISK: Readonly<
   Record<string, Readonly<Record<string, ProviderRiskClass>>>
@@ -72,11 +79,10 @@ const PROVIDER_OPERATION_MINIMUM_RISK: Readonly<
     "x.tweet.delete": "write",
     "x.user.me.read": "read",
   },
-  slack: {
-    "slack.chat.postMessage": "write",
-    "slack.conversations.list": "read",
-    "slack.users.info": "read",
-  },
+  slack: SLACK_OPERATION_RISK,
+};
+const PROVIDER_OPERATION_EXACT_PATH: Readonly<Record<string, Readonly<Record<string, string>>>> = {
+  slack: SLACK_OPERATION_EXACT_PATH,
 };
 const PROVIDER_RISK_RANK: Readonly<Record<ProviderRiskClass, number>> = {
   read: 0,
@@ -862,7 +868,9 @@ export class ProviderAuthorityStore {
             route?.pathPattern &&
               genericDescriptorAllowsExactPath(genericDescriptor, route.pathPattern),
           )
-        : Boolean(route?.pathPattern && !route.pathPattern.includes("*"));
+        : PROVIDER_OPERATION_EXACT_PATH[account.adapterKey]?.[operationKey]
+          ? route?.pathPattern === PROVIDER_OPERATION_EXACT_PATH[account.adapterKey]?.[operationKey]
+          : Boolean(route?.pathPattern && !route.pathPattern.includes("*"));
       if (
         !route ||
         route.secretId !== credentialSecretId ||
@@ -967,7 +975,10 @@ export class ProviderAuthorityStore {
               route?.pathPattern &&
                 genericDescriptorAllowsExactPath(genericDescriptor, route.pathPattern),
             )
-          : Boolean(route?.pathPattern && !route.pathPattern.includes("*"));
+          : PROVIDER_OPERATION_EXACT_PATH[account.adapterKey]?.[operationKey]
+            ? route?.pathPattern ===
+              PROVIDER_OPERATION_EXACT_PATH[account.adapterKey]?.[operationKey]
+            : Boolean(route?.pathPattern && !route.pathPattern.includes("*"));
         if (
           !credentialSecretId ||
           !route ||

--- a/packages/api/src/services/provider-authority-store.ts
+++ b/packages/api/src/services/provider-authority-store.ts
@@ -54,12 +54,41 @@ const PROVIDER_OPERATION_ALLOWLIST: Readonly<
     "x.tweet.delete": "DELETE",
     "x.user.me.read": "GET",
   },
+  slack: {
+    "slack.chat.postMessage": "POST",
+    "slack.conversations.list": "GET",
+    "slack.users.info": "GET",
+  },
+};
+const PROVIDER_OPERATION_MINIMUM_RISK: Readonly<
+  Record<string, Readonly<Record<string, ProviderRiskClass>>>
+> = {
+  github: {
+    "github.issue.list": "read",
+    "github.pr.comment.create": "write",
+  },
+  x: {
+    "x.tweet.create": "write",
+    "x.tweet.delete": "write",
+    "x.user.me.read": "read",
+  },
+  slack: {
+    "slack.chat.postMessage": "write",
+    "slack.conversations.list": "read",
+    "slack.users.info": "read",
+  },
+};
+const PROVIDER_RISK_RANK: Readonly<Record<ProviderRiskClass, number>> = {
+  read: 0,
+  write: 1,
+  consequential: 2,
 };
 const PROVIDER_HOST_ALLOWLIST: Readonly<Record<string, string>> = {
   github: "api.github.com",
   x: "api.x.com",
+  slack: "slack.com",
 };
-const REGISTERED_ADAPTER_KEYS = new Set(["github", "x", "generic-http"]);
+const REGISTERED_ADAPTER_KEYS = new Set(["github", "x", "slack", "generic-http"]);
 const ENVIRONMENTS = new Set(["development", "staging", "production"]);
 const PRINCIPAL_TYPES = new Set(["human", "agent"]);
 const ROLES = new Set([
@@ -753,7 +782,12 @@ export class ProviderAuthorityStore {
     const operationKey = assertText(input.operationKey, "operationKey", 128);
     if (!RISK_CLASSES.has(input.riskClass))
       throw new ProviderAuthorityError("invalid riskClass", "bad_request", 400);
-    if (!OPERATION_KEY.test(operationKey))
+    // Config-driven keys follow the operator-authored lowercase grammar. Fixed
+    // adapters are instead constrained by their exact compile-time allowlist;
+    // Slack's upstream operation names intentionally include camelCase (for
+    // example chat.postMessage), so applying the generic grammar first would
+    // make the registered adapter impossible to configure.
+    if (account.adapterKey === "generic-http" && !OPERATION_KEY.test(operationKey))
       throw new ProviderAuthorityError("invalid operationKey", "bad_request", 400);
     let allowedMethods: readonly string[];
     let genericDescriptor: ReturnType<typeof validateGenericHttpDescriptor> | undefined;
@@ -782,6 +816,14 @@ export class ProviderAuthorityStore {
           "forbidden",
           403,
         );
+      const minimumRisk = PROVIDER_OPERATION_MINIMUM_RISK[account.adapterKey]?.[operationKey];
+      if (!minimumRisk || PROVIDER_RISK_RANK[input.riskClass] < PROVIDER_RISK_RANK[minimumRisk]) {
+        throw new ProviderAuthorityError(
+          "riskClass understates the adapter operation risk",
+          "bad_request",
+          400,
+        );
+      }
       allowedMethods = [fixedMethod];
     }
     if (account.adapterKey === "generic-http" && !input.secretRouteId) {


### PR DESCRIPTION
## Summary

- register the merged Slack adapter, host, and fixed operations in the provider-authority mutation boundary
- allow exact fixed-adapter operation keys such as Slack `chat.postMessage` while retaining the lowercase grammar for operator-authored generic HTTP keys
- reject fixed-operation risk downgrades (`chat.postMessage` as `read`) while allowing equal or stricter classifications
- cover real Slack account creation and narrow credential-route promotion to governed mode

## Security rationale

Before this fix, the lower action/profile layers recognized Slack but the authoritative configuration store did not, so the official mutation path could not configure it. More importantly, fixed operation registration trusted the caller-supplied risk class; classifying `slack.chat.postMessage` as `read` could admit `workspace_viewer` authority to a write action.

## Validation

- `provider-slack-authority-registration.test.ts`: 1 passed, 5 assertions
- `provider-authority.test.ts`: 14 passed, 52 assertions
- `@stwd/api` TypeScript build: passed
- Biome: passed
- `git diff --check`: passed

Based on current develop `142a074ff18f8f7278f1936d9f50335dec1e8b0d`. No overlap with the separate Slack response-stream remediation.