### PR TITLE
test(proxy): isolate query preservation fixture

### DIFF
--- a/packages/proxy/src/__tests__/proxy-query-preservation.test.ts
+++ b/packages/proxy/src/__tests__/proxy-query-preservation.test.ts
@@ -88,6 +88,10 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
+  // This file replaces DNS and the final network forwarder. Restore the real
+  // production functions so a shared-process run cannot leak its permissive
+  // transport hooks into a later security test.
+  proxyMod.__resetProxyHandlerTestHooksForTests();
   await closeDb().catch(() => {});
   delete process.env.STEWARD_PGLITE_MEMORY;
   delete process.env.STEWARD_MASTER_PASSWORD;

--- a/packages/proxy/src/__tests__/proxy-query-preservation.test.ts
+++ b/packages/proxy/src/__tests__/proxy-query-preservation.test.ts
@@ -46,6 +46,7 @@ const FINE_GRAINED_PAT = "github_pat_11QUERYCASE_examplefinegrainedtokenvalue";
 let authMiddleware: typeof import("../middleware/auth")["authMiddleware"];
 let handleProxy: typeof import("../handlers/proxy")["handleProxy"];
 let proxyMod: typeof import("../handlers/proxy");
+let originalProxyDevMode: string | undefined;
 
 // Captures the outbound URL the proxy would have shipped upstream.
 let captured: { url: URL; method: string; path: string } | null = null;
@@ -54,6 +55,12 @@ beforeAll(async () => {
   process.env.STEWARD_PGLITE_MEMORY = "true";
   process.env.STEWARD_MASTER_PASSWORD = MASTER_PASSWORD;
   process.env.STEWARD_JWT_SECRET = "proxy-query-preservation-jwt-secret-with-enough-bytes";
+  originalProxyDevMode = process.env.STEWARD_PROXY_DEV_MODE;
+  // The production proxy correctly requires shared replay/rate-limit storage
+  // and signed requests. This isolated transport fixture intentionally uses
+  // neither, so opt into the explicit test/dev posture before importing the
+  // handler instead of depending on ambient CI environment.
+  process.env.STEWARD_PROXY_DEV_MODE = "true";
 
   const { db, client } = await createPGLiteDb("memory://");
   setPGLiteOverride(db, async () => {
@@ -85,6 +92,8 @@ afterAll(async () => {
   delete process.env.STEWARD_PGLITE_MEMORY;
   delete process.env.STEWARD_MASTER_PASSWORD;
   delete process.env.STEWARD_JWT_SECRET;
+  if (originalProxyDevMode === undefined) delete process.env.STEWARD_PROXY_DEV_MODE;
+  else process.env.STEWARD_PROXY_DEV_MODE = originalProxyDevMode;
 });
 
 function buildApp() {

--- a/packages/proxy/src/handlers/proxy.ts
+++ b/packages/proxy/src/handlers/proxy.ts
@@ -1143,6 +1143,14 @@ export function __setForwardProxyRequestForTests(forwarder: ProxyForwarder): voi
   forwardProxyRequestForHandler = forwarder;
 }
 
+/** Restore every mutable proxy-handler dependency after an integration fixture. */
+export function __resetProxyHandlerTestHooksForTests(): void {
+  checkProxySpendLimitForHandler = checkProxySpendLimit;
+  checkProxyRateLimitForHandler = checkProxyRateLimit;
+  resolveProxyHostForHandler = dnsLookup;
+  forwardProxyRequestForHandler = forwardWithVettedDns;
+}
+
 // ─── Main proxy handler ──────────────────────────────────────────────────────
 
 /**


### PR DESCRIPTION
## Finding

The query-preservation integration suite relied on an ambient `STEWARD_PROXY_DEV_MODE=true`. From a clean environment all 11 cases stopped at the production fail-closed proxy gate with 401, so the test never exercised query preservation.

## Fix

Opt into the explicit local-test proxy posture before importing the handler and restore the caller's original environment afterward. Production defaults and assertions remain unchanged.

## Validation

- clean-env query-preservation suite: 11 pass, 65 expectations
- proxy dependency build graph: 9/9 pass
- Biome and git diff check: pass