### PR TITLE
fix(policy): restore multichain approved addresses

### DIFF
--- a/packages/api/src/__tests__/policy-validation-addresses.test.ts
+++ b/packages/api/src/__tests__/policy-validation-addresses.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "bun:test";
+import { getPolicyRuleValidationError } from "../services/policy-validation";
+
+function addressRule(addresses: unknown[]) {
+  return {
+    id: "addresses",
+    type: "approved-addresses",
+    enabled: true,
+    config: { addresses, mode: "whitelist" },
+  };
+}
+
+describe("approved-addresses write validation", () => {
+  it("accepts exact supported address-family syntax, including mixed-chain lists", () => {
+    expect(
+      getPolicyRuleValidationError(
+        addressRule([
+          "0x1234567890123456789012345678901234567890",
+          "7J9kqM5kV8Fh1Q3b6N2pR4tYwLcXzAaBbCcDdEeFfGg",
+          "tb1q50rtrmj2f8vl9tem8qpfw36ylw5jg9j20l03x8",
+          "49wsWmQA1WyM4gNpPkx1cRUCAamWaSBbMMmiGWNWGfWZRiXUH9DdMMi5ZJUM98K2xk62AEX3C6pCDMp1iXt2PLqX54LVKjA",
+        ]),
+      ),
+    ).toBeNull();
+  });
+
+  it("rejects malformed, checksum-invalid, mixed-case, and unsupported addresses", () => {
+    for (const address of [
+      "0x1234",
+      "1111111111111111111111111111111",
+      "tb1Q50rtrmj2f8vl9tem8qpfw36ylw5jg9j20l03x8",
+      "tb1q50rtrmj2f8vl9tem8qpfw36ylw5jg9j20l03x9",
+      "4".repeat(94),
+      "not-an-address",
+    ]) {
+      expect(getPolicyRuleValidationError(addressRule([address]))).toContain(
+        "valid EVM, Solana, Bitcoin, or Monero addresses",
+      );
+    }
+  });
+});

--- a/packages/api/src/__tests__/tenant-audit-rollback.test.ts
+++ b/packages/api/src/__tests__/tenant-audit-rollback.test.ts
@@ -20,7 +20,7 @@ describe("tenant audit rollback hardening", () => {
     expect(createRoute).toContain("db.delete(tenants).where(eq(tenants.id, body.id))");
   });
 
-  it("restores previous tenant webhook/config state if the final update audit fails", () => {
+  it("restores previous tenant config state if the final update audit fails", () => {
     const updateStart = routeSource.indexOf('tenantRoutes.put("/:id/webhook"');
     expect(updateStart).toBeGreaterThanOrEqual(0);
     const updateRoute = routeSource.slice(updateStart);
@@ -28,9 +28,9 @@ describe("tenant audit rollback hardening", () => {
     expect(updateRoute).toContain('action: "tenant.update.authorized"');
     expect(updateRoute).toContain('action: "tenant.update"');
     expect(updateRoute).toContain("const previousConfig: TenantConfig = { ...tenantConfig }");
-    expect(updateRoute).toContain("snapshotLegacyTenantWebhooks(tenant.id)");
     expect(updateRoute).toContain("tenantConfigs.set(tenant.id, previousConfig)");
-    expect(updateRoute).toContain("restoreLegacyTenantWebhooks(tenant.id, legacyWebhookSnapshot)");
+    expect(updateRoute).not.toContain("snapshotLegacyTenantWebhooks");
+    expect(updateRoute).not.toContain("restoreLegacyTenantWebhooks");
     expect(updateRoute).toContain('actorId: c.get("userId") ?? tenant.id');
   });
 });

--- a/packages/api/src/__tests__/webhook-retry-hardening.test.ts
+++ b/packages/api/src/__tests__/webhook-retry-hardening.test.ts
@@ -93,10 +93,14 @@ describe("webhook retry hardening", () => {
     expect(enable).toBeGreaterThan(created);
   });
 
-  it("encrypts legacy tenant webhook secrets before storing them", () => {
-    expect(tenantRoutesSource).toContain('import { encryptWebhookSecret } from "@stwd/webhooks"');
-    expect(tenantRoutesSource).toContain("secret: encryptWebhookSecret(generateWebhookSecret())");
-    expect(tenantRoutesSource).not.toContain("secret: generateWebhookSecret()");
+  it("rejects retired tenant webhook secrets instead of storing them", () => {
+    const routeStart = tenantRoutesSource.indexOf('tenantRoutes.put("/:id/webhook"');
+    expect(routeStart).toBeGreaterThanOrEqual(0);
+    const route = tenantRoutesSource.slice(routeStart);
+    expect(route).toContain("if (body.webhookUrl !== undefined)");
+    expect(route).toContain("LEGACY_WEBHOOK_DEPRECATION_ERROR");
+    expect(route).toContain(", 410)");
+    expect(route).not.toContain("generateWebhookSecret");
   });
 
   it("does not copy legacy plaintext webhook secrets into delivery snapshots", () => {

--- a/packages/api/src/services/policy-validation.ts
+++ b/packages/api/src/services/policy-validation.ts
@@ -1,5 +1,7 @@
+import { Address, NETWORK, TEST_NETWORK } from "@scure/btc-signer";
 import { isPersistedPolicyType } from "@stwd/db";
 import type { PolicyRule } from "@stwd/shared";
+import { decodeMoneroAddress, isValidSolanaPublicKey } from "@stwd/vault";
 
 const CONDITION_FIELDS = new Set([
   "to",
@@ -42,6 +44,38 @@ function isPositiveInteger(value: unknown): value is number {
 
 function isEvmAddress(value: unknown): value is string {
   return typeof value === "string" && /^0x[a-fA-F0-9]{40}$/.test(value);
+}
+
+function isBitcoinAddress(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  for (const network of [NETWORK, TEST_NETWORK]) {
+    try {
+      Address(network).decode(value);
+      return true;
+    } catch {
+      // Try the other supported network.
+    }
+  }
+  return false;
+}
+
+function isMoneroAddress(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  try {
+    decodeMoneroAddress(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isSupportedPolicyAddress(value: unknown): value is string {
+  return (
+    isEvmAddress(value) ||
+    isValidSolanaPublicKey(value) ||
+    isBitcoinAddress(value) ||
+    isMoneroAddress(value)
+  );
 }
 
 function isEvmSelector(value: unknown): value is string {
@@ -153,8 +187,8 @@ function validatePolicyConfig(policy: PolicyRule): string | null {
     }
 
     case "approved-addresses":
-      if (!Array.isArray(config.addresses) || !config.addresses.every(isEvmAddress)) {
-        return "approved-addresses.addresses must be an array of EVM addresses";
+      if (!Array.isArray(config.addresses) || !config.addresses.every(isSupportedPolicyAddress)) {
+        return "approved-addresses.addresses must contain valid EVM, Solana, Bitcoin, or Monero addresses";
       }
       if (config.mode !== "whitelist" && config.mode !== "blacklist") {
         return "approved-addresses.mode must be whitelist or blacklist";

--- a/packages/policy-engine/src/__tests__/evaluators.test.ts
+++ b/packages/policy-engine/src/__tests__/evaluators.test.ts
@@ -2035,10 +2035,13 @@ describe("Malformed evaluator config fails closed instead of throwing (SEC-105)"
     }
   });
 
-  it("approved-addresses supports multichain families without lowercasing base58", async () => {
+  it("approved-addresses supports exact multichain families without lowercasing base58", async () => {
     const solana = "7J9kqM5kV8Fh1Q3b6N2pR4tYwLcXzAaBbCcDdEeFfGg";
     const matching = await evaluatePolicy(
-      makeAddressRule({ addresses: [solana], mode: "whitelist" }),
+      makeAddressRule({
+        addresses: ["0x1234567890123456789012345678901234567890", solana],
+        mode: "whitelist",
+      }),
       makeContext({ request: { ...makeContext().request, to: solana, chainId: 101 } }),
     );
     expect(matching.passed).toBe(true);
@@ -2050,5 +2053,45 @@ describe("Malformed evaluator config fails closed instead of throwing (SEC-105)"
     );
     expect(wrongCase.passed).toBe(false);
     expect(wrongCase.reason).toContain("not in whitelist");
+
+    const bitcoin = "tb1q50rtrmj2f8vl9tem8qpfw36ylw5jg9j20l03x8";
+    const bitcoinMatch = await evaluatePolicy(
+      makeAddressRule({ addresses: [bitcoin], mode: "whitelist" }),
+      makeContext({ request: { ...makeContext().request, to: bitcoin, chainId: 202 } }),
+    );
+    expect(bitcoinMatch.passed).toBe(true);
+
+    const monero =
+      "49wsWmQA1WyM4gNpPkx1cRUCAamWaSBbMMmiGWNWGfWZRiXUH9DdMMi5ZJUM98K2xk62AEX3C6pCDMp1iXt2PLqX54LVKjA";
+    const moneroMatch = await evaluatePolicy(
+      makeAddressRule({ addresses: [monero], mode: "whitelist" }),
+      makeContext({ request: { ...makeContext().request, to: monero, chainId: 301 } }),
+    );
+    expect(moneroMatch.passed).toBe(true);
+  });
+
+  it("approved-addresses rejects malformed and cross-chain address inputs", async () => {
+    const evm = "0x1234567890123456789012345678901234567890";
+    for (const address of [
+      "1111111111111111111111111111111",
+      "tb1Q50rtrmj2f8vl9tem8qpfw36ylw5jg9j20l03x8",
+      "tb1q50rtrmj2f8vl9tem8qpfw36ylw5jg9j20l03x9",
+      "4".repeat(94),
+      "not-an-address",
+    ]) {
+      const result = await evaluatePolicy(
+        makeAddressRule({ addresses: [address], mode: "whitelist" }),
+        makeContext(),
+      );
+      expect(result.passed).toBe(false);
+      expect(result.reason).toContain("supported address family");
+    }
+
+    const crossChain = await evaluatePolicy(
+      makeAddressRule({ addresses: [evm], mode: "whitelist" }),
+      makeContext({ request: { ...makeContext().request, to: evm, chainId: 101 } }),
+    );
+    expect(crossChain.passed).toBe(false);
+    expect(crossChain.reason).toContain("destination chain");
   });
 });

--- a/packages/policy-engine/src/__tests__/evaluators.test.ts
+++ b/packages/policy-engine/src/__tests__/evaluators.test.ts
@@ -2031,7 +2031,24 @@ describe("Malformed evaluator config fails closed instead of throwing (SEC-105)"
     ]) {
       const result = await evaluatePolicy(makeAddressRule(config as never), makeContext());
       expect(result.passed).toBe(false);
-      expect(result.reason).toContain("array of EVM addresses");
+      expect(result.reason).toMatch(/array of strings|address family/);
     }
+  });
+
+  it("approved-addresses supports multichain families without lowercasing base58", async () => {
+    const solana = "7J9kqM5kV8Fh1Q3b6N2pR4tYwLcXzAaBbCcDdEeFfGg";
+    const matching = await evaluatePolicy(
+      makeAddressRule({ addresses: [solana], mode: "whitelist" }),
+      makeContext({ request: { ...makeContext().request, to: solana, chainId: 101 } }),
+    );
+    expect(matching.passed).toBe(true);
+
+    const wrongCaseAddress = solana.replace("J", "j");
+    const wrongCase = await evaluatePolicy(
+      makeAddressRule({ addresses: [wrongCaseAddress], mode: "whitelist" }),
+      makeContext({ request: { ...makeContext().request, to: solana, chainId: 101 } }),
+    );
+    expect(wrongCase.passed).toBe(false);
+    expect(wrongCase.reason).toContain("not in whitelist");
   });
 });

--- a/packages/policy-engine/src/evaluators.ts
+++ b/packages/policy-engine/src/evaluators.ts
@@ -42,21 +42,105 @@ function isEvmAddress(value: unknown): value is string {
 
 type PolicyAddressFamily = "evm" | "solana" | "bitcoin" | "monero";
 
+const BASE58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+const BECH32_ALPHABET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
+
+function decodeBase58(value: string): Uint8Array | null {
+  let number = 0n;
+  for (const character of value) {
+    const digit = BASE58_ALPHABET.indexOf(character);
+    if (digit < 0) return null;
+    number = number * 58n + BigInt(digit);
+  }
+  const bytes: number[] = [];
+  while (number > 0n) {
+    bytes.push(Number(number & 0xffn));
+    number >>= 8n;
+  }
+  for (let index = 0; index < value.length && value[index] === "1"; index += 1) bytes.push(0);
+  return Uint8Array.from(bytes.reverse());
+}
+
+function bech32Polymod(values: readonly number[]): number {
+  const generators = [0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3];
+  let checksum = 1;
+  for (const value of values) {
+    const top = checksum >>> 25;
+    checksum = ((checksum & 0x1ffffff) << 5) ^ value;
+    for (let bit = 0; bit < 5; bit += 1) {
+      if ((top >>> bit) & 1) checksum ^= generators[bit];
+    }
+  }
+  return checksum >>> 0;
+}
+
+function decodeSegwitAddress(value: string): { hrp: string; version: number } | null {
+  if (value.length > 90 || (value !== value.toLowerCase() && value !== value.toUpperCase())) {
+    return null;
+  }
+  const normalized = value.toLowerCase();
+  const separator = normalized.lastIndexOf("1");
+  if (separator < 1 || separator + 7 > normalized.length) return null;
+  const hrp = normalized.slice(0, separator);
+  if (hrp !== "bc" && hrp !== "tb" && hrp !== "bcrt") return null;
+  const data = [...normalized.slice(separator + 1)].map((character) =>
+    BECH32_ALPHABET.indexOf(character),
+  );
+  if (data.some((digit) => digit < 0)) return null;
+  const expanded = [
+    ...[...hrp].map((character) => character.charCodeAt(0) >>> 5),
+    0,
+    ...[...hrp].map((character) => character.charCodeAt(0) & 31),
+    ...data,
+  ];
+  const polymod = bech32Polymod(expanded);
+  const version = data[0];
+  if (version > 16 || (version === 0 ? polymod !== 1 : polymod !== 0x2bc830a3)) return null;
+
+  let accumulator = 0;
+  let bits = 0;
+  const program: number[] = [];
+  for (const digit of data.slice(1, -6)) {
+    accumulator = (accumulator << 5) | digit;
+    bits += 5;
+    while (bits >= 8) {
+      bits -= 8;
+      program.push((accumulator >>> bits) & 0xff);
+    }
+  }
+  if (bits >= 5 || ((accumulator << (8 - bits)) & 0xff) !== 0) return null;
+  if (program.length < 2 || program.length > 40) return null;
+  if (version === 0 && program.length !== 20 && program.length !== 32) return null;
+  return { hrp, version };
+}
+
 function isPolicyAddressForFamily(value: unknown, family: PolicyAddressFamily): value is string {
   if (typeof value !== "string") return false;
   switch (family) {
     case "evm":
       return isEvmAddress(value);
-    case "solana":
-      return /^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(value);
-    case "bitcoin":
-      return (
-        /^(?:bc1|tb1|bcrt1)[ac-hj-np-z02-9]{6,87}$/i.test(value) ||
-        /^[123mn2][1-9A-HJ-NP-Za-km-z]{25,34}$/.test(value)
-      );
+    case "solana": {
+      const decoded = decodeBase58(value);
+      return decoded?.length === 32;
+    }
+    case "bitcoin": {
+      if (decodeSegwitAddress(value)) return true;
+      if (!/^[123mn2][1-9A-HJ-NP-Za-km-z]{25,34}$/.test(value)) return false;
+      const decoded = decodeBase58(value);
+      return decoded?.length === 25 && [0x00, 0x05, 0x6f, 0xc4].includes(decoded[0]);
+    }
     case "monero":
-      return /^[1-9A-HJ-NP-Za-km-z]{95}$|^[1-9A-HJ-NP-Za-km-z]{106}$/.test(value);
+      return /^(?:[1-9A-HJ-NP-Za-km-z]{95}|[1-9A-HJ-NP-Za-km-z]{106})$/.test(value);
   }
+}
+
+function isSupportedPolicyAddress(value: unknown): value is string {
+  return (
+    isPolicyAddressForFamily(value, "evm") ||
+    isPolicyAddressForFamily(value, "solana") ||
+    isPolicyAddressForFamily(value, "bitcoin") ||
+    isPolicyAddressForFamily(value, "monero")
+  );
 }
 
 function normalizePolicyAddress(value: string, family: PolicyAddressFamily): string {
@@ -679,12 +763,13 @@ function evaluateApprovedAddresses(rule: PolicyRule, ctx: EvaluatorContext): Pol
   if (
     !family ||
     !isPolicyAddressForFamily(targetAddress, family) ||
-    !config.addresses.every((address) => isPolicyAddressForFamily(address, family))
+    !config.addresses.every(isSupportedPolicyAddress)
   ) {
     return {
       ...base,
       passed: false,
-      reason: "Approved addresses must match the destination address family",
+      reason:
+        "Approved addresses must use a supported address family and match the destination chain",
     };
   }
 
@@ -1051,9 +1136,8 @@ function evaluateContractAllowlist(rule: PolicyRule, ctx: EvaluatorContext): Pol
   // contract/selector gating) but a common misconfiguration seam: operators
   // who expect contract-allowlist to also constrain native sends MUST pair it
   // with an approved-addresses rule (note: the write validator restricts
-  // approved-addresses to EVM addresses, so on Solana/Monero paths that rule
-  // can never match and always denies — native-transfer gating there needs a
-  // chain-appropriate rule). Flipping this branch to deny would silently
+  // approved-addresses to known chain address families and evaluates against
+  // the request's chain family). Flipping this branch to deny would silently
   // break existing tenants that rely on the documented behavior, so the
   // decision to gate native transfers explicitly is deferred (see SEC-183).
   if (!data || data === "0x") {

--- a/packages/policy-engine/src/evaluators.ts
+++ b/packages/policy-engine/src/evaluators.ts
@@ -4,6 +4,7 @@ import {
   type AutoApproveConfig,
   type ConditionSetConfig,
   type ContractAllowlistConfig,
+  chainFromNumeric,
   type PolicyResult,
   type PolicyRule,
   type PriceOracle,
@@ -37,6 +38,31 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function isEvmAddress(value: unknown): value is string {
   return typeof value === "string" && /^0x[a-f0-9]{40}$/i.test(value);
+}
+
+type PolicyAddressFamily = "evm" | "solana" | "bitcoin" | "monero";
+
+function isPolicyAddressForFamily(value: unknown, family: PolicyAddressFamily): value is string {
+  if (typeof value !== "string") return false;
+  switch (family) {
+    case "evm":
+      return isEvmAddress(value);
+    case "solana":
+      return /^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(value);
+    case "bitcoin":
+      return (
+        /^(?:bc1|tb1|bcrt1)[ac-hj-np-z02-9]{6,87}$/i.test(value) ||
+        /^[123mn2][1-9A-HJ-NP-Za-km-z]{25,34}$/.test(value)
+      );
+    case "monero":
+      return /^[1-9A-HJ-NP-Za-km-z]{95}$|^[1-9A-HJ-NP-Za-km-z]{106}$/.test(value);
+  }
+}
+
+function normalizePolicyAddress(value: string, family: PolicyAddressFamily): string {
+  return family === "evm" || (family === "bitcoin" && /^(?:bc1|tb1|bcrt1)/i.test(value))
+    ? value.toLowerCase()
+    : value;
 }
 
 export interface EvaluatorContext {
@@ -624,18 +650,18 @@ function evaluateApprovedAddresses(rule: PolicyRule, ctx: EvaluatorContext): Pol
   const base = { policyId: rule.id, type: rule.type } as const;
 
   // Validate the complete runtime shape, not just the outer array: a hand-edited
-  // row containing `null`/numbers used to throw in `.toLowerCase()`, while an
+  // row containing `null`/numbers used to throw during normalization, while an
   // unknown mode silently fell into blacklist semantics and could pass.
   if (
     !isRecord(rawConfig) ||
     !Array.isArray(rawConfig.addresses) ||
-    !rawConfig.addresses.every(isEvmAddress) ||
+    !rawConfig.addresses.every((address) => typeof address === "string") ||
     (rawConfig.mode !== "whitelist" && rawConfig.mode !== "blacklist")
   ) {
     return {
       ...base,
       passed: false,
-      reason: "Approved addresses must be an array of EVM addresses with a valid mode",
+      reason: "Approved addresses must be an array of strings with a valid mode",
     };
   }
   const config = rawConfig as unknown as ApprovedAddressesConfig;
@@ -649,8 +675,21 @@ function evaluateApprovedAddresses(rule: PolicyRule, ctx: EvaluatorContext): Pol
     };
   }
 
-  const target = targetAddress.toLowerCase();
-  const listed = config.addresses.map((a) => a.toLowerCase());
+  const family = chainFromNumeric(ctx.request.chainId)?.family;
+  if (
+    !family ||
+    !isPolicyAddressForFamily(targetAddress, family) ||
+    !config.addresses.every((address) => isPolicyAddressForFamily(address, family))
+  ) {
+    return {
+      ...base,
+      passed: false,
+      reason: "Approved addresses must match the destination address family",
+    };
+  }
+
+  const target = normalizePolicyAddress(targetAddress, family);
+  const listed = config.addresses.map((address) => normalizePolicyAddress(address, family));
   const mode = config.mode;
 
   if (mode === "whitelist") {

--- a/packages/vault/src/index.ts
+++ b/packages/vault/src/index.ts
@@ -168,6 +168,7 @@ export {
   generateSolanaKeypair,
   getSolanaBalance,
   getSplTokenBalances,
+  isValidSolanaPublicKey,
   restoreSolanaKeypair,
   signSolanaMessage,
   signSolanaTransaction,

--- a/packages/vault/src/solana.ts
+++ b/packages/vault/src/solana.ts
@@ -11,12 +11,23 @@ import {
   Transaction,
   type TransactionInstruction,
 } from "@solana/web3.js";
+
 import { getKnownToken } from "@stwd/shared";
 import {
   ASSOCIATED_TOKEN_PROGRAM_ID,
   TOKEN_2022_PROGRAM_ID,
   TOKEN_PROGRAM_ID,
 } from "./solana-instructions";
+
+/** Return true only for a canonical base58 encoding of one 32-byte Solana public key. */
+export function isValidSolanaPublicKey(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  try {
+    return new PublicKey(value).toBase58() === value;
+  } catch {
+    return false;
+  }
+}
 
 // ─── Internal helpers ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- validate approved-address policy entries against the request chain family
- preserve case-sensitive Solana, legacy Bitcoin, and Monero address matching while retaining normalized EVM/bech32 matching
- update retired legacy-webhook hardening assertions to match the current 410 contract

## Failure addressed
Develop-derived integration run 32096046456 failed valid Solana, Bitcoin, and Monero signing paths with HTTP 403 after approved-address evaluation became EVM-only.

## Validation
- 163 passing tests across the policy evaluator and all six affected API/hardening paths
- 22/22 dependency builds for @stwd/api
- Biome clean
- git diff --check clean