### PR TITLE
fix(policy): verify multichain address checksums at evaluation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -307,6 +307,7 @@
       "name": "@stwd/policy-engine",
       "version": "0.4.0",
       "dependencies": {
+        "@noble/hashes": "^1.7.0",
         "@stwd/shared": "workspace:*",
         "re2-wasm": "1.0.2",
       },

--- a/packages/policy-engine/package.json
+++ b/packages/policy-engine/package.json
@@ -10,6 +10,7 @@
     "test": "bun test"
   },
   "dependencies": {
+    "@noble/hashes": "^1.7.0",
     "@stwd/shared": "workspace:*",
     "re2-wasm": "1.0.2"
   },

--- a/packages/policy-engine/src/__tests__/evaluators.test.ts
+++ b/packages/policy-engine/src/__tests__/evaluators.test.ts
@@ -2135,6 +2135,22 @@ describe("Malformed evaluator config fails closed instead of throwing (SEC-105)"
     }
   });
 
+  it("accepts checksum-valid Bitcoin and Monero addresses on their own networks", async () => {
+    for (const [address, chainId] of [
+      ["tb1q50rtrmj2f8vl9tem8qpfw36ylw5jg9j20l03x8", 202],
+      [
+        "49wsWmQA1WyM4gNpPkx1cRUCAamWaSBbMMmiGWNWGfWZRiXUH9DdMMi5ZJUM98K2xk62AEX3C6pCDMp1iXt2PLqX54LVKjA",
+        301,
+      ],
+    ] as const) {
+      const result = await evaluatePolicy(
+        makeAddressRule({ addresses: [address], mode: "whitelist" }),
+        makeContext({ request: { ...makeContext().request, to: address, chainId } }),
+      );
+      expect(result.passed).toBe(true);
+    }
+  });
+
   it("rejects malformed decoded lengths and tampered Monero checksums", async () => {
     const monero =
       "45AmZ2FRjuqZts5NGzb7ZXSNRuwS9MUqEeakpyEeSHsB5mywLwBzzq2cTsbJzTVUuLSHxtbfgKyZJVBqPffpP8fm79sjAcK";

--- a/packages/policy-engine/src/__tests__/evaluators.test.ts
+++ b/packages/policy-engine/src/__tests__/evaluators.test.ts
@@ -2084,7 +2084,7 @@ describe("Malformed evaluator config fails closed instead of throwing (SEC-105)"
         makeContext(),
       );
       expect(result.passed).toBe(false);
-      expect(result.reason).toContain("supported address family");
+      expect(result.reason).toMatch(/address family|invalid address/);
     }
 
     const crossChain = await evaluatePolicy(
@@ -2092,7 +2092,7 @@ describe("Malformed evaluator config fails closed instead of throwing (SEC-105)"
       makeContext({ request: { ...makeContext().request, to: evm, chainId: 101 } }),
     );
     expect(crossChain.passed).toBe(false);
-    expect(crossChain.reason).toContain("destination chain");
+    expect(crossChain.reason).toContain("destination address family");
   });
 
   it("rejects mixed-case and checksum-invalid Bitcoin addresses", async () => {

--- a/packages/policy-engine/src/__tests__/evaluators.test.ts
+++ b/packages/policy-engine/src/__tests__/evaluators.test.ts
@@ -2031,7 +2031,7 @@ describe("Malformed evaluator config fails closed instead of throwing (SEC-105)"
     ]) {
       const result = await evaluatePolicy(makeAddressRule(config as never), makeContext());
       expect(result.passed).toBe(false);
-      expect(result.reason).toMatch(/array of strings|address family/);
+      expect(result.reason).toMatch(/array of strings|address family|invalid address/);
     }
   });
 
@@ -2093,5 +2093,77 @@ describe("Malformed evaluator config fails closed instead of throwing (SEC-105)"
     );
     expect(crossChain.passed).toBe(false);
     expect(crossChain.reason).toContain("destination chain");
+  });
+
+  it("rejects mixed-case and checksum-invalid Bitcoin addresses", async () => {
+    const bitcoin = "bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu";
+    const upper = bitcoin.toUpperCase();
+    const uppercaseMatch = await evaluatePolicy(
+      makeAddressRule({ addresses: [upper], mode: "whitelist" }),
+      makeContext({ request: { ...makeContext().request, to: bitcoin, chainId: 201 } }),
+    );
+    expect(uppercaseMatch.passed).toBe(true);
+
+    for (const invalid of [
+      `bC${bitcoin.slice(2)}`,
+      `${bitcoin.slice(0, -1)}q`,
+      "1BoatSLRHtKNngkdXEeobR76b53LETtpyU",
+    ]) {
+      const result = await evaluatePolicy(
+        makeAddressRule({ addresses: [bitcoin], mode: "whitelist" }),
+        makeContext({ request: { ...makeContext().request, to: invalid, chainId: 201 } }),
+      );
+      expect(result.passed).toBe(false);
+      expect(result.reason).toContain("address family");
+    }
+  });
+
+  it("binds Bitcoin and Monero policy addresses to the request network", async () => {
+    const bitcoinMainnet = "1BoatSLRHtKNngkdXEeobR76b53LETtpyT";
+    const moneroMainnet =
+      "45AmZ2FRjuqZts5NGzb7ZXSNRuwS9MUqEeakpyEeSHsB5mywLwBzzq2cTsbJzTVUuLSHxtbfgKyZJVBqPffpP8fm79sjAcK";
+    for (const [address, chainId] of [
+      [bitcoinMainnet, 202],
+      [moneroMainnet, 302],
+    ] as const) {
+      const result = await evaluatePolicy(
+        makeAddressRule({ addresses: [address], mode: "whitelist" }),
+        makeContext({ request: { ...makeContext().request, to: address, chainId } }),
+      );
+      expect(result.passed).toBe(false);
+      expect(result.reason).toContain("address family");
+    }
+  });
+
+  it("rejects malformed decoded lengths and tampered Monero checksums", async () => {
+    const monero =
+      "45AmZ2FRjuqZts5NGzb7ZXSNRuwS9MUqEeakpyEeSHsB5mywLwBzzq2cTsbJzTVUuLSHxtbfgKyZJVBqPffpP8fm79sjAcK";
+    for (const [address, chainId] of [
+      ["111111111111111111111111111111111", 101],
+      [`${monero.slice(0, -1)}M`, 301],
+    ] as const) {
+      const result = await evaluatePolicy(
+        makeAddressRule({ addresses: [address], mode: "whitelist" }),
+        makeContext({ request: { ...makeContext().request, to: address, chainId } }),
+      );
+      expect(result.passed).toBe(false);
+      expect(result.reason).toContain("address family");
+    }
+  });
+
+  it("filters valid mixed-family policy entries to the request chain", async () => {
+    const evm = "0x1234567890123456789012345678901234567890";
+    const solana = "11111111111111111111111111111111";
+    const rule = makeAddressRule({ addresses: [evm, solana], mode: "whitelist" });
+    const evmResult = await evaluatePolicy(
+      rule,
+      makeContext({ request: { ...makeContext().request, to: evm, chainId: 1 } }),
+    );
+    const solanaResult = await evaluatePolicy(
+      rule,
+      makeContext({ request: { ...makeContext().request, to: solana, chainId: 101 } }),
+    );
+    expect(evmResult.passed).toBe(true);
+    expect(solanaResult.passed).toBe(true);
   });
 });

--- a/packages/policy-engine/src/evaluators.ts
+++ b/packages/policy-engine/src/evaluators.ts
@@ -1215,9 +1215,8 @@ function evaluateContractAllowlist(rule: PolicyRule, ctx: EvaluatorContext): Pol
   // contract/selector gating) but a common misconfiguration seam: operators
   // who expect contract-allowlist to also constrain native sends MUST pair it
   // with an approved-addresses rule (note: the write validator restricts
-  // approved-addresses to EVM addresses, so on Solana/Monero paths that rule
-  // can never match and always denies — native-transfer gating there needs a
-  // chain-appropriate rule). Flipping this branch to deny would silently
+  // approved-addresses to known chain address families and evaluates against
+  // the request's chain family). Flipping this branch to deny would silently
   // break existing tenants that rely on the documented behavior, so the
   // decision to gate native transfers explicitly is deferred (see SEC-183).
   if (!data || data === "0x") {

--- a/packages/policy-engine/src/evaluators.ts
+++ b/packages/policy-engine/src/evaluators.ts
@@ -1,3 +1,5 @@
+import { keccak_256 } from "@noble/hashes/sha3";
+import { sha256 } from "@noble/hashes/sha256";
 import {
   type AllowedChainsConfig,
   type ApprovedAddressesConfig,
@@ -43,9 +45,12 @@ function isEvmAddress(value: unknown): value is string {
 type PolicyAddressFamily = "evm" | "solana" | "bitcoin" | "monero";
 
 const BASE58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
-const BECH32_ALPHABET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
+const MONERO_BLOCK_BYTES = [0, 2, 3, 5, 6, 7, 9, 10, 11] as const;
 
 function decodeBase58(value: string): Uint8Array | null {
+  if (!value) return null;
+  let leadingZeroes = 0;
+  while (value[leadingZeroes] === "1") leadingZeroes += 1;
   let number = 0n;
   for (const character of value) {
     const digit = BASE58_ALPHABET.indexOf(character);
@@ -54,54 +59,65 @@ function decodeBase58(value: string): Uint8Array | null {
   }
   const bytes: number[] = [];
   while (number > 0n) {
-    bytes.push(Number(number & 0xffn));
+    bytes.unshift(Number(number & 0xffn));
     number >>= 8n;
   }
-  for (let index = 0; index < value.length && value[index] === "1"; index += 1) bytes.push(0);
-  return Uint8Array.from(bytes.reverse());
+  return Uint8Array.from([...new Array(leadingZeroes).fill(0), ...bytes]);
 }
 
-function bech32Polymod(values: readonly number[]): number {
+function isSolanaAddress(value: string): boolean {
+  return /^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(value) && decodeBase58(value)?.length === 32;
+}
+
+function bech32Polymod(values: number[]): number {
   const generators = [0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3];
   let checksum = 1;
   for (const value of values) {
     const top = checksum >>> 25;
     checksum = ((checksum & 0x1ffffff) << 5) ^ value;
     for (let bit = 0; bit < 5; bit += 1) {
-      if ((top >>> bit) & 1) checksum ^= generators[bit];
+      if ((top >>> bit) & 1) checksum ^= generators[bit] as number;
     }
   }
   return checksum >>> 0;
 }
 
-function decodeSegwitAddress(value: string): { hrp: string; version: number } | null {
-  if (value.length > 90 || (value !== value.toLowerCase() && value !== value.toUpperCase())) {
+function decodeBech32Address(
+  value: string,
+): { hrp: string; version: number; program: Uint8Array } | null {
+  if (
+    value.length < 8 ||
+    value.length > 90 ||
+    (value !== value.toLowerCase() && value !== value.toUpperCase())
+  ) {
     return null;
   }
   const normalized = value.toLowerCase();
   const separator = normalized.lastIndexOf("1");
   if (separator < 1 || separator + 7 > normalized.length) return null;
   const hrp = normalized.slice(0, separator);
-  if (hrp !== "bc" && hrp !== "tb" && hrp !== "bcrt") return null;
-  const data = [...normalized.slice(separator + 1)].map((character) =>
-    BECH32_ALPHABET.indexOf(character),
-  );
-  if (data.some((digit) => digit < 0)) return null;
+  const alphabet = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
+  const words: number[] = [];
+  for (const character of normalized.slice(separator + 1)) {
+    const word = alphabet.indexOf(character);
+    if (word < 0) return null;
+    words.push(word);
+  }
   const expanded = [
     ...[...hrp].map((character) => character.charCodeAt(0) >>> 5),
     0,
     ...[...hrp].map((character) => character.charCodeAt(0) & 31),
-    ...data,
   ];
-  const polymod = bech32Polymod(expanded);
-  const version = data[0];
-  if (version > 16 || (version === 0 ? polymod !== 1 : polymod !== 0x2bc830a3)) return null;
-
+  const encoding = bech32Polymod([...expanded, ...words]);
+  if (encoding !== 1 && encoding !== 0x2bc830a3) return null;
+  const payload = words.slice(0, -6);
+  const version = payload[0];
+  if (version === undefined || version > 16) return null;
   let accumulator = 0;
   let bits = 0;
   const program: number[] = [];
-  for (const digit of data.slice(1, -6)) {
-    accumulator = (accumulator << 5) | digit;
+  for (const word of payload.slice(1)) {
+    accumulator = (accumulator << 5) | word;
     bits += 5;
     while (bits >= 8) {
       bits -= 8;
@@ -110,36 +126,99 @@ function decodeSegwitAddress(value: string): { hrp: string; version: number } | 
   }
   if (bits >= 5 || ((accumulator << (8 - bits)) & 0xff) !== 0) return null;
   if (program.length < 2 || program.length > 40) return null;
-  if (version === 0 && program.length !== 20 && program.length !== 32) return null;
-  return { hrp, version };
+  if (version === 0 && (encoding !== 1 || (program.length !== 20 && program.length !== 32)))
+    return null;
+  if (version > 0 && encoding !== 0x2bc830a3) return null;
+  return { hrp, version, program: Uint8Array.from(program) };
 }
 
-function isPolicyAddressForFamily(value: unknown, family: PolicyAddressFamily): value is string {
+function isBitcoinAddress(value: string, testnet: boolean): boolean {
+  const bech32 = decodeBech32Address(value);
+  if (bech32) return testnet ? bech32.hrp === "tb" || bech32.hrp === "bcrt" : bech32.hrp === "bc";
+  if (!/^[123mn2][1-9A-HJ-NP-Za-km-z]{25,34}$/.test(value)) return false;
+  const decoded = decodeBase58(value);
+  if (!decoded || decoded.length !== 25) return false;
+  const expected = sha256(sha256(decoded.subarray(0, 21))).subarray(0, 4);
+  if (!expected.every((byte, index) => byte === decoded[21 + index])) return false;
+  return testnet ? decoded[0] === 111 || decoded[0] === 196 : decoded[0] === 0 || decoded[0] === 5;
+}
+
+function decodeMoneroBlock(value: string, byteLength: number): Uint8Array | null {
+  let number = 0n;
+  for (const character of value) {
+    const digit = BASE58_ALPHABET.indexOf(character);
+    if (digit < 0) return null;
+    number = number * 58n + BigInt(digit);
+  }
+  const result = new Uint8Array(byteLength);
+  for (let index = byteLength - 1; index >= 0; index -= 1) {
+    result[index] = Number(number & 0xffn);
+    number >>= 8n;
+  }
+  return number === 0n ? result : null;
+}
+
+function decodeMoneroAddress(value: string): Uint8Array | null {
+  if (value.length !== 95 && value.length !== 106) return null;
+  const fullBlocks = Math.floor(value.length / 11);
+  const trailingCharacters = value.length % 11;
+  const trailingBytes = MONERO_BLOCK_BYTES.indexOf(
+    trailingCharacters as (typeof MONERO_BLOCK_BYTES)[number],
+  );
+  if (trailingBytes < 0) return null;
+  const decoded = new Uint8Array(fullBlocks * 8 + trailingBytes);
+  for (let index = 0; index < fullBlocks; index += 1) {
+    const block = decodeMoneroBlock(value.slice(index * 11, (index + 1) * 11), 8);
+    if (!block) return null;
+    decoded.set(block, index * 8);
+  }
+  if (trailingBytes > 0) {
+    const block = decodeMoneroBlock(value.slice(fullBlocks * 11), trailingBytes);
+    if (!block) return null;
+    decoded.set(block, fullBlocks * 8);
+  }
+  return decoded;
+}
+
+function isMoneroAddress(value: string, stagenet: boolean): boolean {
+  const decoded = decodeMoneroAddress(value);
+  if (!decoded || (decoded.length !== 69 && decoded.length !== 77)) return false;
+  const body = decoded.subarray(0, -4);
+  const checksum = keccak_256(body).subarray(0, 4);
+  if (!checksum.every((byte, index) => byte === decoded[decoded.length - 4 + index])) return false;
+  const standardPrefixes = stagenet ? [24, 25, 36] : [18, 19, 42];
+  const prefix = decoded[0] as number;
+  if (!standardPrefixes.includes(prefix)) return false;
+  const integrated = prefix === (stagenet ? 25 : 19);
+  return decoded.length === (integrated ? 77 : 69);
+}
+
+function isPolicyAddressForChain(value: unknown, chainId: number): value is string {
   if (typeof value !== "string") return false;
-  switch (family) {
+  const chain = chainFromNumeric(chainId);
+  switch (chain?.family) {
     case "evm":
       return isEvmAddress(value);
-    case "solana": {
-      const decoded = decodeBase58(value);
-      return decoded?.length === 32;
-    }
-    case "bitcoin": {
-      if (decodeSegwitAddress(value)) return true;
-      if (!/^[123mn2][1-9A-HJ-NP-Za-km-z]{25,34}$/.test(value)) return false;
-      const decoded = decodeBase58(value);
-      return decoded?.length === 25 && [0x00, 0x05, 0x6f, 0xc4].includes(decoded[0]);
-    }
+    case "solana":
+      return isSolanaAddress(value);
+    case "bitcoin":
+      return isBitcoinAddress(value, chain.testnet);
     case "monero":
-      return /^(?:[1-9A-HJ-NP-Za-km-z]{95}|[1-9A-HJ-NP-Za-km-z]{106})$/.test(value);
+      return isMoneroAddress(value, chain.testnet);
+    default:
+      return false;
   }
 }
 
-function isSupportedPolicyAddress(value: unknown): value is string {
+function isRecognizedPolicyAddress(value: unknown): value is string {
   return (
-    isPolicyAddressForFamily(value, "evm") ||
-    isPolicyAddressForFamily(value, "solana") ||
-    isPolicyAddressForFamily(value, "bitcoin") ||
-    isPolicyAddressForFamily(value, "monero")
+    typeof value === "string" &&
+    (isEvmAddress(value) ||
+      isSolanaAddress(value) ||
+      isBitcoinAddress(value, false) ||
+      isBitcoinAddress(value, true) ||
+      isMoneroAddress(value, false) ||
+      isMoneroAddress(value, true))
   );
 }
 
@@ -760,21 +839,21 @@ function evaluateApprovedAddresses(rule: PolicyRule, ctx: EvaluatorContext): Pol
   }
 
   const family = chainFromNumeric(ctx.request.chainId)?.family;
-  if (
-    !family ||
-    !isPolicyAddressForFamily(targetAddress, family) ||
-    !config.addresses.every(isSupportedPolicyAddress)
-  ) {
+  if (!family || !isPolicyAddressForChain(targetAddress, ctx.request.chainId)) {
     return {
       ...base,
       passed: false,
-      reason:
-        "Approved addresses must use a supported address family and match the destination chain",
+      reason: "Approved addresses must match the destination address family",
     };
+  }
+  if (!config.addresses.every(isRecognizedPolicyAddress)) {
+    return { ...base, passed: false, reason: "Approved addresses contain an invalid address" };
   }
 
   const target = normalizePolicyAddress(targetAddress, family);
-  const listed = config.addresses.map((address) => normalizePolicyAddress(address, family));
+  const listed = config.addresses
+    .filter((address) => isPolicyAddressForChain(address, ctx.request.chainId))
+    .map((address) => normalizePolicyAddress(address, family));
   const mode = config.mode;
 
   if (mode === "whitelist") {
@@ -1136,8 +1215,9 @@ function evaluateContractAllowlist(rule: PolicyRule, ctx: EvaluatorContext): Pol
   // contract/selector gating) but a common misconfiguration seam: operators
   // who expect contract-allowlist to also constrain native sends MUST pair it
   // with an approved-addresses rule (note: the write validator restricts
-  // approved-addresses to known chain address families and evaluates against
-  // the request's chain family). Flipping this branch to deny would silently
+  // approved-addresses to EVM addresses, so on Solana/Monero paths that rule
+  // can never match and always denies — native-transfer gating there needs a
+  // chain-appropriate rule). Flipping this branch to deny would silently
   // break existing tenants that rely on the documented behavior, so the
   // decision to gate native transfers explicitly is deferred (see SEC-183).
   if (!data || data === "0x") {


### PR DESCRIPTION
## Summary
- validate legacy Bitcoin Base58Check and Monero block-base58 checksums during policy evaluation, including decoded payload lengths and Monero address-kind prefixes
- bind Bitcoin mainnet/testnet and Monero mainnet/stagenet addresses to the request chain so a valid address from another network cannot satisfy policy
- preserve exact EVM normalization, case-sensitive Solana/Monero matching, valid all-uppercase Bech32 normalization, mixed-case Bech32 rejection, and mixed-family policy filtering

## Why a follow-up
The merged #408 restored multichain matching and added strong write-time validation, but evaluator-side legacy Bitcoin and Monero checks remained syntax-only. Persisted legacy rows or a bypassed write path could therefore supply checksum-invalid entries, and valid addresses were not network-bound at evaluation.

## Validation
- policy evaluator: 119 pass / 253 assertions
- affected API/write/signing suites: 33 pass / 163 assertions (policy CRUD, Solana, Bitcoin PSBT, Monero, address write validation)
- all 23 API dependency builds green, including policy-engine and API
- Biome clean; git diff --check clean

Follow-up to #408.