### PR TITLE
test(proxy-client): isolate Redis enforcement fixture

### DIFF
--- a/packages/proxy-client/src/__tests__/proxy-e2e.test.ts
+++ b/packages/proxy-client/src/__tests__/proxy-e2e.test.ts
@@ -38,8 +38,7 @@ let setForwardProxyRequestForTests: typeof import("@stwd/proxy/src/handlers/prox
 let setResolveProxyHostForTests: typeof import("@stwd/proxy/src/handlers/proxy")["__setResolveProxyHostForTests"];
 let setCheckProxyRateLimitForTests: typeof import("@stwd/proxy/src/handlers/proxy")["__setCheckProxyRateLimitForTests"];
 let setCheckProxySpendLimitForTests: typeof import("@stwd/proxy/src/handlers/proxy")["__setCheckProxySpendLimitForTests"];
-let restoreProxyRateLimit: (() => void) | undefined;
-let restoreProxySpendLimit: (() => void) | undefined;
+let resetProxyHandlerTestHooks: typeof import("@stwd/proxy/src/handlers/proxy")["__resetProxyHandlerTestHooksForTests"];
 
 // Capture what the proxy tried to forward upstream.
 interface ForwardedCapture {
@@ -75,18 +74,20 @@ beforeAll(async () => {
     __setResolveProxyHostForTests: setResolveProxyHostForTests,
     __setCheckProxyRateLimitForTests: setCheckProxyRateLimitForTests,
     __setCheckProxySpendLimitForTests: setCheckProxySpendLimitForTests,
+    __resetProxyHandlerTestHooksForTests: resetProxyHandlerTestHooks,
   } = await import("@stwd/proxy/src/handlers/proxy"));
-  const redisEnforcement = await import("@stwd/proxy/src/middleware/redis-enforcement");
 
   // This suite proves client signing, credential injection, and response
   // scrubbing without a shared Redis service. Keep the production default-deny
-  // enforcement intact outside this fixture and restore its exact functions.
+  // enforcement intact outside this fixture and restore every exact handler
+  // dependency after the test.
   setCheckProxyRateLimitForTests(async () => ({ allowed: true, resetMs: 0 }));
-  setCheckProxySpendLimitForTests(async () => ({ allowed: true }));
-  restoreProxyRateLimit = () =>
-    setCheckProxyRateLimitForTests(redisEnforcement.checkProxyRateLimit);
-  restoreProxySpendLimit = () =>
-    setCheckProxySpendLimitForTests(redisEnforcement.checkProxySpendLimit);
+  setCheckProxySpendLimitForTests(async () => ({
+    allowed: true,
+    configured: false,
+    spent: 0,
+    remaining: Number.POSITIVE_INFINITY,
+  }));
 
   // Hermeticity: the proxy resolves the target host via DNS BEFORE it calls the
   // (stubbed) forwarder, and rejects private/reserved addresses. In a
@@ -111,8 +112,7 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  restoreProxyRateLimit?.();
-  restoreProxySpendLimit?.();
+  resetProxyHandlerTestHooks();
   await closeDb().catch(() => {});
   delete process.env.STEWARD_PGLITE_MEMORY;
   delete process.env.STEWARD_MASTER_PASSWORD;

--- a/packages/proxy-client/src/__tests__/proxy-e2e.test.ts
+++ b/packages/proxy-client/src/__tests__/proxy-e2e.test.ts
@@ -36,6 +36,10 @@ let authMiddleware: typeof import("@stwd/proxy/src/middleware/auth")["authMiddle
 let handleProxy: typeof import("@stwd/proxy/src/handlers/proxy")["handleProxy"];
 let setForwardProxyRequestForTests: typeof import("@stwd/proxy/src/handlers/proxy")["__setForwardProxyRequestForTests"];
 let setResolveProxyHostForTests: typeof import("@stwd/proxy/src/handlers/proxy")["__setResolveProxyHostForTests"];
+let setCheckProxyRateLimitForTests: typeof import("@stwd/proxy/src/handlers/proxy")["__setCheckProxyRateLimitForTests"];
+let setCheckProxySpendLimitForTests: typeof import("@stwd/proxy/src/handlers/proxy")["__setCheckProxySpendLimitForTests"];
+let restoreProxyRateLimit: (() => void) | undefined;
+let restoreProxySpendLimit: (() => void) | undefined;
 
 // Capture what the proxy tried to forward upstream.
 interface ForwardedCapture {
@@ -69,7 +73,20 @@ beforeAll(async () => {
     handleProxy,
     __setForwardProxyRequestForTests: setForwardProxyRequestForTests,
     __setResolveProxyHostForTests: setResolveProxyHostForTests,
+    __setCheckProxyRateLimitForTests: setCheckProxyRateLimitForTests,
+    __setCheckProxySpendLimitForTests: setCheckProxySpendLimitForTests,
   } = await import("@stwd/proxy/src/handlers/proxy"));
+  const redisEnforcement = await import("@stwd/proxy/src/middleware/redis-enforcement");
+
+  // This suite proves client signing, credential injection, and response
+  // scrubbing without a shared Redis service. Keep the production default-deny
+  // enforcement intact outside this fixture and restore its exact functions.
+  setCheckProxyRateLimitForTests(async () => ({ allowed: true, resetMs: 0 }));
+  setCheckProxySpendLimitForTests(async () => ({ allowed: true }));
+  restoreProxyRateLimit = () =>
+    setCheckProxyRateLimitForTests(redisEnforcement.checkProxyRateLimit);
+  restoreProxySpendLimit = () =>
+    setCheckProxySpendLimitForTests(redisEnforcement.checkProxySpendLimit);
 
   // Hermeticity: the proxy resolves the target host via DNS BEFORE it calls the
   // (stubbed) forwarder, and rejects private/reserved addresses. In a
@@ -94,6 +111,8 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
+  restoreProxyRateLimit?.();
+  restoreProxySpendLimit?.();
   await closeDb().catch(() => {});
   delete process.env.STEWARD_PGLITE_MEMORY;
   delete process.env.STEWARD_MASTER_PASSWORD;


### PR DESCRIPTION
## Summary
- explicitly allow the proxy-client credential-injection E2E through deterministic rate and spend enforcement without requiring shared Redis
- return the full typed spend-enforcement result
- restore every mutable proxy handler dependency through the canonical production reset seam

## Exact validation

Head `20536d6bd6ac61e50559100677eac6c0d7a64813` on base `b69463463b3e4dfe6125aa6df573144370804db2`:

- full `packages/proxy-client` suite: 21/21, 56 assertions
- dependency build: 10/10 packages
- Biome and `git diff --check`: green

Production defaults and assertions are unchanged.