### PR TITLE
fix(ci): enforce complete workspace test inventory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Check CI unit-test inventory
+        run: bun scripts/check-ci-test-inventory.ts
+
       - name: Lint
         run: bun run lint
 
@@ -96,22 +99,30 @@ jobs:
           - packages/webhooks
           - packages/db
           - packages/shared
+          - packages/attestation
           - packages/plugin-wxmr
           - packages/plugin-trading
           - packages/plugin-capabilities
+          - packages/plugin-example
+          - packages/plugin-sdk
+          - packages/provider-github
+          - packages/provider-google
+          - packages/provider-slack
+          - packages/provider-x
           - packages/solana-signer
           - packages/trade-sessions
           - packages/cli
           - packages/react
           - packages/react-native
           - packages/mcp
+          - packages/erc8004
           - packages/erc8183
           - packages/adapters
+          - packages/proxy-client
+          - packages/seed
+          - packages/venue-hyperliquid
+          - packages/venue-polymarket
           - scripts/__tests__
-          # packages/signer-frost is intentionally absent: its test harness
-          # builds the Rust sidecar via `cargo build --release` and this job
-          # has no Rust toolchain (and a release build would strain the
-          # 10-minute timeout). Add it alongside a rust-toolchain step.
           # packages/eliza-plugin is intentionally absent: its test script is
           # `vitest run`, not `bun test` — see the unit-eliza-plugin job.
 
@@ -151,6 +162,11 @@ jobs:
           if [ "${{ matrix.package }}" = "packages/sdk" ]; then
             mapfile -t sdk_tests < <(find packages/sdk/src -type f \( -name '*.test.ts' -o -name '*.spec.ts' \) | sort)
             bun test --isolate "${sdk_tests[@]}"
+          elif [ "${{ matrix.package }}" = "packages/plugin-sdk" ] || [ "${{ matrix.package }}" = "packages/plugin-example" ]; then
+            # These facade suites intentionally preload a hermetic PGLite
+            # context from their package-local bunfig.toml. Running them from
+            # the repository root skips that preload and fails at module init.
+            (cd "${{ matrix.package }}" && bun run test)
           else
             bun test --isolate ${{ matrix.package }}
           fi
@@ -189,6 +205,42 @@ jobs:
 
       - name: Test packages/eliza-plugin
         working-directory: packages/eliza-plugin
+        run: bun run test
+
+  unit-signer-frost:
+    # The FROST tests build and exercise the real Rust threshold-signing
+    # sidecar. GitHub's Ubuntu image includes stable Rust; a dedicated job
+    # avoids both silently skipping the suite and constraining it to the Bun
+    # matrix's shorter timeout.
+    name: Unit Tests (packages/signer-frost)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.3"
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+        with:
+          toolchain: "1.85.0"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build workspace dependencies
+        run: bunx turbo run build --filter=@stwd/signer-frost...
+
+      - name: Build FROST sidecar
+        run: cargo build --locked --release --manifest-path packages/signer-frost/sidecar/Cargo.toml
+
+      - name: Test packages/signer-frost
+        working-directory: packages/signer-frost
         run: bun run test
 
   unit-flutter:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Check CI unit-test inventory
+        run: bun scripts/check-ci-test-inventory.ts
+
       - name: Lint
         run: bun run lint
 
@@ -182,22 +185,30 @@ jobs:
           - packages/webhooks
           - packages/db
           - packages/shared
+          - packages/attestation
           - packages/plugin-wxmr
           - packages/plugin-trading
           - packages/plugin-capabilities
+          - packages/plugin-example
+          - packages/plugin-sdk
+          - packages/provider-github
+          - packages/provider-google
+          - packages/provider-slack
+          - packages/provider-x
           - packages/solana-signer
           - packages/trade-sessions
           - packages/cli
           - packages/react
           - packages/react-native
           - packages/mcp
+          - packages/erc8004
           - packages/erc8183
           - packages/adapters
+          - packages/proxy-client
+          - packages/seed
+          - packages/venue-hyperliquid
+          - packages/venue-polymarket
           - scripts/__tests__
-          # packages/signer-frost is intentionally absent: its test harness
-          # builds the Rust sidecar via `cargo build --release` and this job
-          # has no Rust toolchain (and a release build would strain the
-          # 10-minute timeout). Add it alongside a rust-toolchain step.
           # packages/eliza-plugin is intentionally absent: its test script is
           # `vitest run`, not `bun test` — see the unit-eliza-plugin job.
 
@@ -237,6 +248,11 @@ jobs:
           if [ "${{ matrix.package }}" = "packages/sdk" ]; then
             mapfile -t sdk_tests < <(find packages/sdk/src -type f \( -name '*.test.ts' -o -name '*.spec.ts' \) | sort)
             bun test --isolate "${sdk_tests[@]}"
+          elif [ "${{ matrix.package }}" = "packages/plugin-sdk" ] || [ "${{ matrix.package }}" = "packages/plugin-example" ]; then
+            # These facade suites intentionally preload a hermetic PGLite
+            # context from their package-local bunfig.toml. Running them from
+            # the repository root skips that preload and fails at module init.
+            (cd "${{ matrix.package }}" && bun run test)
           else
             bun test --isolate ${{ matrix.package }}
           fi
@@ -276,6 +292,42 @@ jobs:
 
       - name: Test packages/eliza-plugin
         working-directory: packages/eliza-plugin
+        run: bun run test
+
+  unit-signer-frost:
+    # The FROST tests build and exercise the real Rust threshold-signing
+    # sidecar. GitHub's Ubuntu image includes stable Rust; a dedicated job
+    # avoids both silently skipping the suite and constraining it to the Bun
+    # matrix's shorter timeout.
+    name: Unit Tests (packages/signer-frost)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.3"
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+        with:
+          toolchain: "1.85.0"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build workspace dependencies
+        run: bunx turbo run build --filter=@stwd/signer-frost...
+
+      - name: Build FROST sidecar
+        run: cargo build --locked --release --manifest-path packages/signer-frost/sidecar/Cargo.toml
+
+      - name: Test packages/signer-frost
+        working-directory: packages/signer-frost
         run: bun run test
 
   unit-flutter:

--- a/scripts/__tests__/check-ci-test-inventory.test.ts
+++ b/scripts/__tests__/check-ci-test-inventory.test.ts
@@ -4,6 +4,7 @@ import {
   checkCiTestInventory,
   extractJob,
   extractUnitMatrix,
+  jobExecutesPackageTests,
 } from "../check-ci-test-inventory";
 
 describe("CI test inventory", () => {
@@ -45,5 +46,35 @@ describe("CI test inventory", () => {
     expect(extractUnitMatrix(workflow)).toEqual(["packages/a", "scripts/__tests__"]);
     expect(extractJob(workflow, "dedicated")).toContain("bun test packages/b");
     expect(extractJob(workflow, "dedicated")).not.toContain("later");
+  });
+
+  test("dedicated coverage requires an actual package test command", () => {
+    const valid = [
+      "  dedicated:",
+      "    steps:",
+      "      - name: Test package",
+      "        working-directory: packages/a",
+      "        run: bun run test",
+    ].join("\n");
+    const commentOnly = [
+      "  dedicated:",
+      "    # bun test packages/a",
+      "    steps:",
+      "      - name: packages/a bun test",
+      "        run: bun run build",
+    ].join("\n");
+    const unrelated = [
+      "  dedicated:",
+      "    steps:",
+      "      - name: Test another package",
+      "        working-directory: packages/b",
+      "        run: |",
+      "          bun test packages/b",
+      "          echo packages/a",
+    ].join("\n");
+
+    expect(jobExecutesPackageTests(extractJob(valid, "dedicated"), "packages/a")).toBe(true);
+    expect(jobExecutesPackageTests(extractJob(commentOnly, "dedicated"), "packages/a")).toBe(false);
+    expect(jobExecutesPackageTests(extractJob(unrelated, "dedicated"), "packages/a")).toBe(false);
   });
 });

--- a/scripts/__tests__/check-ci-test-inventory.test.ts
+++ b/scripts/__tests__/check-ci-test-inventory.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import {
+  assertCompleteCoverage,
+  checkCiTestInventory,
+  extractJob,
+  extractUnitMatrix,
+} from "../check-ci-test-inventory";
+
+describe("CI test inventory", () => {
+  test("the repository workflows cover every test-bearing workspace package", () => {
+    expect(() => checkCiTestInventory()).not.toThrow();
+  });
+
+  test("a future unlisted test package fails closed", () => {
+    expect(() =>
+      assertCompleteCoverage(["packages/a", "packages/new"], ["packages/a"], []),
+    ).toThrow("workspace test packages missing from CI: packages/new");
+  });
+
+  test("duplicate and stale declarations are rejected", () => {
+    expect(() => assertCompleteCoverage(["packages/a"], ["packages/a", "packages/a"], [])).toThrow(
+      "duplicate unit matrix entries: packages/a",
+    );
+    expect(() =>
+      assertCompleteCoverage(["packages/a"], ["packages/a"], ["packages/removed"]),
+    ).toThrow("CI inventory contains non-test workspace packages: packages/removed");
+  });
+
+  test("workflow extraction is scoped to the unit and dedicated job blocks", () => {
+    const workflow = [
+      "jobs:",
+      "  unit:",
+      "    strategy:",
+      "      matrix:",
+      "        package:",
+      "          - packages/a",
+      "          - scripts/__tests__",
+      "    steps: []",
+      "  dedicated:",
+      "    steps:",
+      "      - run: bun test packages/b",
+      "  later:",
+      "    steps: []",
+    ].join("\n");
+    expect(extractUnitMatrix(workflow)).toEqual(["packages/a", "scripts/__tests__"]);
+    expect(extractJob(workflow, "dedicated")).toContain("bun test packages/b");
+    expect(extractJob(workflow, "dedicated")).not.toContain("later");
+  });
+});

--- a/scripts/check-ci-test-inventory.ts
+++ b/scripts/check-ci-test-inventory.ts
@@ -72,6 +72,64 @@ export function extractJob(workflow: string, jobName: string): string {
   return lines.slice(start, end < 0 ? undefined : end).join("\n");
 }
 
+interface WorkflowStep {
+  workingDirectory?: string;
+  run?: string;
+}
+
+function extractRunSteps(job: string): WorkflowStep[] {
+  const lines = job.split(/\r?\n/);
+  const steps: WorkflowStep[] = [];
+  let current: WorkflowStep | undefined;
+
+  const finishStep = () => {
+    if (current) steps.push(current);
+    current = undefined;
+  };
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (/^ {6}- /.test(line)) {
+      finishStep();
+      current = {};
+      continue;
+    }
+    if (!current) continue;
+
+    const workingDirectory = line.match(/^ {8}working-directory:\s*["']?([^"'\s]+)["']?\s*$/);
+    if (workingDirectory) {
+      current.workingDirectory = workingDirectory[1];
+      continue;
+    }
+
+    const inlineRun = line.match(/^ {8}run:\s*(?![|>][-+]?\s*$)(.+)$/);
+    if (inlineRun) {
+      current.run = inlineRun[1].trim();
+      continue;
+    }
+
+    if (/^ {8}run:\s*[|>][-+]?\s*$/.test(line)) {
+      const command: string[] = [];
+      while (index + 1 < lines.length && /^(?: {10,}\S|\s*$)/.test(lines[index + 1])) {
+        index += 1;
+        command.push(lines[index].replace(/^ {10}/, ""));
+      }
+      current.run = command.join("\n");
+    }
+  }
+  finishStep();
+  return steps;
+}
+
+export function jobExecutesPackageTests(job: string, packagePath: string): boolean {
+  return extractRunSteps(job).some((step) => {
+    if (!step.run || !/(?:^|[;&|()\s])(?:bun|cargo|flutter)(?:\s|$)[^\n]*\b(?:test|run-tests)\b/m.test(step.run)) {
+      return false;
+    }
+    return step.workingDirectory === packagePath || step.run.includes(packagePath);
+  });
+}
+
 export function assertCompleteCoverage(
   workspaceTests: string[],
   matrix: string[],
@@ -115,7 +173,7 @@ export function checkCiTestInventory(rootDir = resolve(import.meta.dir, "..")): 
 
     for (const [packagePath, jobName] of Object.entries(DEDICATED_JOBS)) {
       const job = extractJob(workflow, jobName);
-      if (!job.includes(packagePath) || !/(?:bun|cargo|flutter).*?(?:test|run-tests)/s.test(job)) {
+      if (!jobExecutesPackageTests(job, packagePath)) {
         throw new Error(
           `${workflowPath} job ${jobName} does not visibly execute the ${packagePath} test suite`,
         );

--- a/scripts/check-ci-test-inventory.ts
+++ b/scripts/check-ci-test-inventory.ts
@@ -1,0 +1,136 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+const WORKFLOWS = [".github/workflows/pr.yml", ".github/workflows/ci.yml"] as const;
+const NON_WORKSPACE_MATRIX_ENTRIES = ["scripts/__tests__"] as const;
+
+// These suites need infrastructure or a non-Bun toolchain that the generic
+// unit matrix does not provide. Keep the mapping explicit so an omitted suite
+// cannot be disguised as a comment-only exception.
+const DEDICATED_JOBS = {
+  "packages/api": "integration",
+  "packages/eliza-plugin": "unit-eliza-plugin",
+  "packages/redis": "unit-redis",
+  "packages/signer-frost": "unit-signer-frost",
+} as const;
+
+function workspacePackagePaths(rootDir: string): string[] {
+  const rootPackage = JSON.parse(readFileSync(resolve(rootDir, "package.json"), "utf8")) as {
+    workspaces?: string[];
+  };
+  if (!Array.isArray(rootPackage.workspaces)) {
+    throw new Error("root package.json must declare a workspaces array");
+  }
+
+  const packageJsonPaths = new Set<string>();
+  for (const workspace of rootPackage.workspaces) {
+    const manifestPattern = workspace.endsWith("package.json")
+      ? workspace
+      : `${workspace}/package.json`;
+    for (const manifest of new Bun.Glob(manifestPattern).scanSync({ cwd: rootDir })) {
+      packageJsonPaths.add(manifest);
+    }
+  }
+
+  return [...packageJsonPaths]
+    .filter((manifest) => {
+      const pkg = JSON.parse(readFileSync(resolve(rootDir, manifest), "utf8")) as {
+        scripts?: { test?: unknown };
+      };
+      return typeof pkg.scripts?.test === "string" && pkg.scripts.test.trim().length > 0;
+    })
+    .map((manifest) => dirname(manifest))
+    .sort();
+}
+
+export function extractUnitMatrix(workflow: string): string[] {
+  const lines = workflow.split(/\r?\n/);
+  const unitStart = lines.indexOf("  unit:");
+  if (unitStart < 0) throw new Error("workflow is missing the unit job");
+  const unitEnd = lines.findIndex((line, index) => index > unitStart && /^ {2}[\w-]+:$/.test(line));
+  const unitLines = lines.slice(unitStart, unitEnd < 0 ? undefined : unitEnd);
+  const packageStart = unitLines.indexOf("        package:");
+  if (packageStart < 0) throw new Error("unit job is missing strategy.matrix.package");
+
+  const packages: string[] = [];
+  for (const line of unitLines.slice(packageStart + 1)) {
+    const match = line.match(/^ {10}- (\S+)$/);
+    if (match) {
+      packages.push(match[1]);
+      continue;
+    }
+    if (/^ {8}\S/.test(line)) break;
+  }
+  return packages;
+}
+
+export function extractJob(workflow: string, jobName: string): string {
+  const lines = workflow.split(/\r?\n/);
+  const start = lines.indexOf(`  ${jobName}:`);
+  if (start < 0) throw new Error(`workflow is missing dedicated job ${jobName}`);
+  const end = lines.findIndex((line, index) => index > start && /^ {2}[\w-]+:$/.test(line));
+  return lines.slice(start, end < 0 ? undefined : end).join("\n");
+}
+
+export function assertCompleteCoverage(
+  workspaceTests: string[],
+  matrix: string[],
+  dedicatedPaths: string[],
+): void {
+  const duplicates = matrix.filter((entry, index) => matrix.indexOf(entry) !== index);
+  if (duplicates.length > 0) {
+    throw new Error(`duplicate unit matrix entries: ${[...new Set(duplicates)].join(", ")}`);
+  }
+
+  const covered = new Set([...matrix, ...dedicatedPaths]);
+  const missing = workspaceTests.filter((path) => !covered.has(path));
+  const stale = [...covered].filter((path) => !workspaceTests.includes(path));
+  if (missing.length > 0)
+    throw new Error(`workspace test packages missing from CI: ${missing.join(", ")}`);
+  if (stale.length > 0)
+    throw new Error(`CI inventory contains non-test workspace packages: ${stale.join(", ")}`);
+}
+
+export function checkCiTestInventory(rootDir = resolve(import.meta.dir, "..")): void {
+  const workspaceTests = workspacePackagePaths(rootDir);
+  const dedicatedPaths = Object.keys(DEDICATED_JOBS);
+  let canonicalMatrix: string[] | undefined;
+
+  for (const workflowPath of WORKFLOWS) {
+    const workflow = readFileSync(resolve(rootDir, workflowPath), "utf8");
+    const matrix = extractUnitMatrix(workflow);
+    const workspaceMatrix = matrix.filter(
+      (entry) =>
+        !NON_WORKSPACE_MATRIX_ENTRIES.includes(
+          entry as (typeof NON_WORKSPACE_MATRIX_ENTRIES)[number],
+        ),
+    );
+    assertCompleteCoverage(workspaceTests, workspaceMatrix, dedicatedPaths);
+
+    for (const nonWorkspaceEntry of NON_WORKSPACE_MATRIX_ENTRIES) {
+      if (!matrix.includes(nonWorkspaceEntry)) {
+        throw new Error(`${workflowPath} unit matrix is missing ${nonWorkspaceEntry}`);
+      }
+    }
+
+    for (const [packagePath, jobName] of Object.entries(DEDICATED_JOBS)) {
+      const job = extractJob(workflow, jobName);
+      if (!job.includes(packagePath) || !/(?:bun|cargo|flutter).*?(?:test|run-tests)/s.test(job)) {
+        throw new Error(
+          `${workflowPath} job ${jobName} does not visibly execute the ${packagePath} test suite`,
+        );
+      }
+    }
+
+    if (canonicalMatrix && JSON.stringify(matrix) !== JSON.stringify(canonicalMatrix)) {
+      throw new Error(`${workflowPath} unit matrix diverges from ${WORKFLOWS[0]}`);
+    }
+    canonicalMatrix = matrix;
+  }
+
+  console.log(
+    `CI test inventory covers all ${workspaceTests.length} test-bearing workspace packages`,
+  );
+}
+
+if (import.meta.main) checkCiTestInventory();


### PR DESCRIPTION
## Summary
- execute every workspace package that declares a test script in PR and develop CI
- add a pinned Rust 1.85 job for the real FROST sidecar suite
- fail CI when a future test-bearing package is omitted, duplicated, stale, or diverges between workflows
- preserve package-local Bun preloads for plugin facade suites

## Validation
- inventory: all 35 test-bearing workspace packages covered
- inventory regression: 4 pass, 7 assertions
- newly covered suites: 195 pass before isolating the two package-local preload suites; plugin-sdk 3 pass; plugin-example 2 pass; Google provider 4 pass
- FROST real-sidecar suite: 14 pass after locked release build
- targeted Turbo dependency build: 25 packages passed; Google dependency build: 6 passed
- Biome, YAML parse, and git diff check passed

Draft because full GitHub Actions evidence is still required.