### PR TITLE
fix(security): re-audit batch W3-A1 — auth revocation TLS, per-tenant OIDC secrets, env validation, rate-limit + SMS claim-first hardening

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -106,6 +106,7 @@
         "@node-saml/node-saml": "5.1.0",
         "@simplewebauthn/server": "^13",
         "@stwd/db": "workspace:*",
+        "@stwd/redis": "workspace:*",
         "@stwd/shared": "workspace:*",
         "hono": "^4.12.34",
         "ioredis": "^5.10.1",

--- a/docs/api-reference/tenant-config.mdx
+++ b/docs/api-reference/tenant-config.mdx
@@ -326,14 +326,14 @@ Tenant OIDC providers support direct JWT exchange and enterprise authorization-c
   "audience": ["steward-api"],
   "jwksUri": "https://idp.example.com/.well-known/jwks.json",
   "clientId": "steward-dashboard",
-  "clientSecretEnv": "STEWARD_TENANT_OIDC_SECRET_ACME_SSO",
+  "clientSecretEnv": "STEWARD_TENANT_OIDC_SECRET_MY_PLATFORM_ACME_SSO",
   "authorizationUrl": "https://idp.example.com/oauth2/v1/authorize",
   "tokenUrl": "https://idp.example.com/oauth2/v1/token",
   "scopes": ["openid", "email", "profile"]
 }
 ```
 
-`clientSecretEnv` must name an environment variable in the dedicated `STEWARD_TENANT_OIDC_SECRET_*` namespace; arbitrary platform env vars are rejected so tenant config cannot exfiltrate deployment secrets through the token exchange.
+`clientSecretEnv` must name an environment variable in the dedicated `STEWARD_TENANT_OIDC_SECRET_*` namespace **and** embed the configuring tenant's id: the name must start with `STEWARD_TENANT_OIDC_SECRET_<TENANT_KEY>_`, where `<TENANT_KEY>` is the tenant id uppercased with non-`[A-Z0-9_]` characters mapped to `_` (e.g. tenant `my-platform` → `STEWARD_TENANT_OIDC_SECRET_MY_PLATFORM_...`). Arbitrary platform env vars and env vars provisioned for a different tenant are rejected, so tenant config cannot exfiltrate deployment secrets — or another tenant's IdP secret — through the token exchange. The binding is re-enforced at token-exchange time, so pre-existing rows that name an unbound env var fail closed until the env var is renamed and the config rewritten.
 
 `allowJitProvisioning` defaults to `false` when omitted (matching the SAML plane): holders of a valid IdP token for an unknown account are denied until a tenant admin explicitly opts into just-in-time account creation with `"allowJitProvisioning": true`. Configs written before this default changed keep their previously persisted value.
 

--- a/packages/api/src/__tests__/agent-enroll-token-ttl.test.ts
+++ b/packages/api/src/__tests__/agent-enroll-token-ttl.test.ts
@@ -1,0 +1,60 @@
+/**
+ * agent-enroll-token-ttl.test.ts — SEC-134-style startup validation for
+ * STEWARD_AGENT_ENROLL_TOKEN_TTL: malformed values and values beyond the
+ * one-hour bound must fail closed at module load, not at token-mint time.
+ */
+
+import { afterEach, describe, expect, it } from "bun:test";
+
+const ENV_KEY = "STEWARD_AGENT_ENROLL_TOKEN_TTL";
+
+describe("agent enrollment token TTL env validation", () => {
+  let previous: string | undefined;
+
+  afterEach(() => {
+    if (previous === undefined) {
+      delete process.env[ENV_KEY];
+    } else {
+      process.env[ENV_KEY] = previous;
+    }
+    previous = undefined;
+  });
+
+  async function importFresh() {
+    return import(`../routes/agent-enroll?ttl-test=${Date.now()}-${Math.random()}`);
+  }
+
+  it("loads with the 5m default when the env var is unset", async () => {
+    previous = process.env[ENV_KEY];
+    delete process.env[ENV_KEY];
+    const mod = await importFresh();
+    expect(mod.agentEnrollRoutes).toBeDefined();
+  });
+
+  it("rejects a malformed duration at module load", async () => {
+    previous = process.env[ENV_KEY];
+    process.env[ENV_KEY] = "not-a-duration";
+    await expect(importFresh()).rejects.toThrow(
+      'STEWARD_AGENT_ENROLL_TOKEN_TTL "not-a-duration" is not a valid positive duration',
+    );
+  });
+
+  it("rejects a non-positive duration at module load", async () => {
+    previous = process.env[ENV_KEY];
+    process.env[ENV_KEY] = "0m";
+    await expect(importFresh()).rejects.toThrow("is not a valid positive duration");
+  });
+
+  it("rejects a TTL beyond the one-hour bound at module load", async () => {
+    previous = process.env[ENV_KEY];
+    process.env[ENV_KEY] = "2h";
+    await expect(importFresh()).rejects.toThrow("exceeds the one-hour maximum");
+  });
+
+  it("accepts a valid in-bound TTL", async () => {
+    previous = process.env[ENV_KEY];
+    process.env[ENV_KEY] = "15m";
+    const mod = await importFresh();
+    expect(mod.agentEnrollRoutes).toBeDefined();
+  });
+});

--- a/packages/api/src/__tests__/auth-audit-hardening.test.ts
+++ b/packages/api/src/__tests__/auth-audit-hardening.test.ts
@@ -370,8 +370,13 @@ describe("auth and audit hardening", () => {
       smsVerifyStart,
       authSource.indexOf('auth.post("/mfa/sms/send"', smsVerifyStart),
     );
-    expect(smsVerify).toContain("getSmsVerifyFailedAttempts(pending.phone, pendingPurpose)");
-    expect(smsVerify).toContain("recordSmsVerifyFailure(pending.phone, pendingPurpose)");
+    // Claim-first boundary: the attempt slot is consumed atomically BEFORE
+    // verifyOtp runs; check-then-record must not come back.
+    expect(smsVerify).toContain("claimSmsVerifyAttempt(pending.phone, pendingPurpose)");
+    expect(smsVerify.indexOf("claimSmsVerifyAttempt(pending.phone, pendingPurpose)")).toBeLessThan(
+      smsVerify.indexOf("getPhoneAuth().verifyOtp(pending.phone, body.code, pendingPurpose)"),
+    );
+    expect(smsVerify).not.toContain("recordSmsVerifyFailure(pending.phone, pendingPurpose)");
     expect(smsVerify).toContain("clearSmsVerifyFailures(pending.phone, pendingPurpose)");
   });
 

--- a/packages/api/src/__tests__/auth-client-ip.test.ts
+++ b/packages/api/src/__tests__/auth-client-ip.test.ts
@@ -17,6 +17,7 @@ import { hashSha256Hex } from "@stwd/auth";
 import { closeDb } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { Hono } from "hono";
+import { SOCKET_PEER_ENV_KEY } from "../services/runtime-gate";
 
 // ─── @stwd/redis counting mock ───────────────────────────────────────────────
 
@@ -388,6 +389,35 @@ describe("auth rate-limit keying (route harness)", () => {
       expect(call.key).not.toContain(hashSha256Hex("global"));
       expect(call.key).not.toContain("global");
     }
+  });
+
+  it("prefers the entry-injected socket peer over the Host fallback when no trusted IP exists", async () => {
+    await connectMockRedis();
+    delete process.env.STEWARD_TRUSTED_PROXY_HOPS;
+    delete process.env.STEWARD_TRUST_PROXY_HEADERS;
+
+    // The socket peer is injected by the server entry (Bun requestIP) via the
+    // Hono env bag — no client-controlled header can mint or rotate it.
+    await authRoutes.request(
+      "/nonce",
+      { headers: { host: "api.steward.example" } },
+      { [SOCKET_PEER_ENV_KEY]: "198.51.100.60" },
+    );
+    expect(capturedKeys("siwe-nonce")).toEqual([
+      `ratelimit:auth:siwe-nonce:${hashSha256Hex("ip:198.51.100.60")}:60000`,
+    ]);
+
+    // A non-IP injection (runtime could not supply a peer) must NOT become an
+    // ip: bucket — the request degrades to the coarse per-host fallback.
+    rateLimitCalls.length = 0;
+    await authRoutes.request(
+      "/nonce",
+      { headers: { host: "api.steward.example" } },
+      { [SOCKET_PEER_ENV_KEY]: "not-an-ip" },
+    );
+    expect(capturedKeys("siwe-nonce")).toEqual([
+      `ratelimit:auth:siwe-nonce:${hashSha256Hex("host:api.steward.example")}:60000`,
+    ]);
   });
 
   it("hashes subjectOverride subjects: destination emails never reach Redis raw", async () => {

--- a/packages/api/src/__tests__/auth-mfa-sms.test.ts
+++ b/packages/api/src/__tests__/auth-mfa-sms.test.ts
@@ -794,4 +794,42 @@ describe("SMS OTP auth and TOTP MFA routes", () => {
       }),
     ]);
   });
+
+  it("claims SMS verify attempts before verifying: concurrent wrong codes cannot exceed the slot budget", async () => {
+    const phone = "+14155550901";
+    const sendRes = await authRoutes.request("/sms/send", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ phone }),
+    });
+    expect(sendRes.status).toBe(200);
+    const inboxRes = await authRoutes.request(`/test/sms-inbox/${encodeURIComponent(phone)}`);
+    const inbox = (await inboxRes.json()) as { code: string };
+    const wrongCode = inbox.code === "000000" ? "000001" : "000000";
+
+    // Six concurrent wrong-code verifies against a five-slot budget. With the
+    // claim-first boundary the attempt slot is consumed BEFORE verifyOtp runs,
+    // so the sixth request is denied without ever reaching verification — a
+    // check-then-record boundary would let all six through.
+    const statuses = await Promise.all(
+      Array.from({ length: 6 }, async () => {
+        const res = await authRoutes.request("/sms/verify", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ phone, code: wrongCode }),
+        });
+        return res.status;
+      }),
+    );
+    expect(statuses.filter((status) => status === 401)).toHaveLength(5);
+    expect(statuses.filter((status) => status === 429)).toHaveLength(1);
+
+    // The budget stays exhausted for subsequent requests.
+    const afterRes = await authRoutes.request("/sms/verify", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ phone, code: wrongCode }),
+    });
+    expect(afterRes.status).toBe(429);
+  });
 });

--- a/packages/api/src/__tests__/tenant-oidc-providers.test.ts
+++ b/packages/api/src/__tests__/tenant-oidc-providers.test.ts
@@ -84,7 +84,7 @@ describe("tenant-admin OIDC provider config routes", () => {
             audience: ["steward-api"],
             jwksUri: "https://tenant.example.com/.well-known/jwks.json",
             clientId: "enterprise-client",
-            clientSecretEnv: "STEWARD_TENANT_OIDC_SECRET_ACME_SSO",
+            clientSecretEnv: "STEWARD_TENANT_OIDC_SECRET_TENANT_OIDC_PROVIDERS_ACME_SSO",
             authorizationUrl: "https://tenant.example.com/oauth2/v1/authorize",
             tokenUrl: "https://tenant.example.com/oauth2/v1/token",
             scopes: ["openid", "email", "profile"],
@@ -104,7 +104,7 @@ describe("tenant-admin OIDC provider config routes", () => {
         id: "auth0-prod",
         issuer: "https://tenant.example.com",
         clientId: "enterprise-client",
-        clientSecretEnv: "STEWARD_TENANT_OIDC_SECRET_ACME_SSO",
+        clientSecretEnv: "STEWARD_TENANT_OIDC_SECRET_TENANT_OIDC_PROVIDERS_ACME_SSO",
         authorizationUrl: "https://tenant.example.com/oauth2/v1/authorize",
         tokenUrl: "https://tenant.example.com/oauth2/v1/token",
         scopes: ["openid", "email", "profile"],
@@ -190,6 +190,10 @@ describe("tenant-admin OIDC provider config routes", () => {
       "STEWARD_MASTER_PASSWORD",
       "ACME_SSO_CLIENT_SECRET",
       "STEWARD_TENANT_OIDC_SECRET",
+      // SEC-005 residual: the bare namespace without the tenant binding, and a
+      // name bound to a DIFFERENT tenant, must both be rejected.
+      "STEWARD_TENANT_OIDC_SECRET_ACME_SSO",
+      "STEWARD_TENANT_OIDC_SECRET_OTHER_TENANT_ACME_SSO",
     ]) {
       const response = await tenantConfigRoutes.request(`/${TENANT_ID}/oidc-providers`, {
         method: "PUT",

--- a/packages/api/src/__tests__/worker-boot-validation.test.ts
+++ b/packages/api/src/__tests__/worker-boot-validation.test.ts
@@ -1,0 +1,93 @@
+/**
+ * worker-boot-validation.test.ts — SEC-134 startup validation must also run on
+ * the Cloudflare Workers boot path (worker.ts), not only the Bun entry. A
+ * Workers deploy with a weak/missing JWT secret or a malformed
+ * AGENT_TOKEN_EXPIRY must fail closed at cold start.
+ */
+
+import { afterEach, describe, expect, it } from "bun:test";
+
+/**
+ * Keys this file mutates: bindings hydrateProcessEnv copies onto the global
+ * process.env, plus ambient suite values (see test-preload.ts) that some cases
+ * must clear to simulate a misconfigured deployment. All restored after each
+ * test.
+ */
+const MANAGED_KEYS = [
+  "STEWARD_RUNTIME",
+  "NODE_ENV",
+  "STEWARD_JWT_SECRET",
+  "STEWARD_SESSION_SECRET",
+  "STEWARD_MASTER_PASSWORD",
+  "STEWARD_DB_MODE",
+  "STEWARD_PGLITE_MEMORY",
+  "AGENT_TOKEN_EXPIRY",
+] as const;
+
+describe("workers boot JWT env validation (SEC-134)", () => {
+  const saved = new Map<string, string | undefined>();
+
+  afterEach(() => {
+    for (const key of MANAGED_KEYS) {
+      const prior = saved.get(key);
+      if (prior === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = prior;
+      }
+    }
+    saved.clear();
+  });
+
+  function snapshotEnv(): void {
+    for (const key of MANAGED_KEYS) saved.set(key, process.env[key]);
+  }
+
+  async function freshWorker() {
+    const mod = await import(`../worker?boot-validation=${Date.now()}-${Math.random()}`);
+    return mod.default;
+  }
+
+  it("rejects a short JWT secret at cold start in production", async () => {
+    snapshotEnv();
+    const worker = await freshWorker();
+    await expect(
+      worker.fetch(
+        new Request("https://workers.test/"),
+        { NODE_ENV: "production", STEWARD_JWT_SECRET: "short" },
+        {},
+      ),
+    ).rejects.toThrow("at least 32 characters in production");
+  });
+
+  it("rejects a missing JWT secret at cold start in production", async () => {
+    snapshotEnv();
+    // The suite preload supplies ambient test secrets and embedded-mode
+    // markers; a "missing secret" deployment must clear them all, or
+    // getJwtSecret would legitimately fall back to them.
+    delete process.env.STEWARD_JWT_SECRET;
+    delete process.env.STEWARD_SESSION_SECRET;
+    delete process.env.STEWARD_MASTER_PASSWORD;
+    delete process.env.STEWARD_DB_MODE;
+    delete process.env.STEWARD_PGLITE_MEMORY;
+    const worker = await freshWorker();
+    await expect(
+      worker.fetch(new Request("https://workers.test/"), { NODE_ENV: "production" }, {}),
+    ).rejects.toThrow("STEWARD_JWT_SECRET is required in production");
+  });
+
+  it("rejects a malformed AGENT_TOKEN_EXPIRY at cold start", async () => {
+    snapshotEnv();
+    const worker = await freshWorker();
+    await expect(
+      worker.fetch(
+        new Request("https://workers.test/"),
+        {
+          STEWARD_JWT_SECRET: "workers-boot-test-secret-32-chars-long!!",
+          AGENT_TOKEN_EXPIRY: "not-a-duration",
+        },
+        {},
+      ),
+    ).rejects.toThrow('AGENT_TOKEN_EXPIRY "not-a-duration" is not a valid positive duration');
+  });
+});

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -35,6 +35,7 @@ import {
   parseNonNegativeInt,
   parsePositiveInt,
   resolveClientIp,
+  SOCKET_PEER_ENV_KEY,
 } from "./services/runtime-gate";
 import { startTransactionReceiptPollingScheduler } from "./services/transaction-receipt-poller";
 import {
@@ -373,8 +374,16 @@ const BIND_HOST = process.env.STEWARD_BIND_HOST || "127.0.0.1";
 const serverOptions = {
   hostname: BIND_HOST,
   port: PORT,
-  fetch: (request: Request, server: { requestIP(req: Request): { address: string } | null }) =>
-    runtimeGate(request, server.requestIP(request)?.address ?? null) ?? app.fetch(request),
+  fetch: (request: Request, server: { requestIP(req: Request): { address: string } | null }) => {
+    const peerAddress = server.requestIP(request)?.address ?? null;
+    // Hand the runtime-observed socket peer to the app via Hono's env bag so
+    // per-route limiters (auth) can key on it when no trusted forwarding
+    // config exists — it cannot be client-influenced, unlike any header.
+    return (
+      runtimeGate(request, peerAddress) ??
+      app.fetch(request, { [SOCKET_PEER_ENV_KEY]: peerAddress })
+    );
+  },
   idleTimeout: 30,
 } as Parameters<typeof Bun.serve>[0] & { hostname?: string };
 

--- a/packages/api/src/routes/agent-enroll.ts
+++ b/packages/api/src/routes/agent-enroll.ts
@@ -28,6 +28,7 @@
 import {
   type AgentSignerResolver,
   issueEnrollChallenge,
+  parseDurationSeconds,
   type ResolvedAgentSigner,
   signAgentToken,
   verifyEnrollResponse,
@@ -47,7 +48,34 @@ import { checkAuthRateLimit, getAuthChallengeStore } from "./auth";
 /** Short-lived enrollment token TTL. Minute-scale: the agent immediately renews
  * (or exchanges for scoped capabilities), and a revoked signer stops enrolling
  * within one cycle. Overridable via env for operators who want a different bound. */
-const ENROLL_TOKEN_TTL = process.env.STEWARD_AGENT_ENROLL_TOKEN_TTL?.trim() || "5m";
+
+/** Hard upper bound for the enrollment token TTL: one hour. Enrollment tokens
+ * exist only to bootstrap renewal/capability exchange, so a longer value would
+ * blunt signer-revocation response (SEC-134-style bound for this env). */
+export const ENROLL_TOKEN_TTL_MAX_SECONDS = 3600;
+
+/** Validate STEWARD_AGENT_ENROLL_TOKEN_TTL at module load (startup), the same
+ * posture SEC-134 applied to AGENT_TOKEN_EXPIRY: a malformed value otherwise
+ * surfaces as a 500 at token-mint time, and an unbounded value mints
+ * long-lived tokens that defeat the minute-scale revocation story. */
+function resolveEnrollTokenTtl(): string {
+  const raw = process.env.STEWARD_AGENT_ENROLL_TOKEN_TTL?.trim();
+  if (!raw) return "5m";
+  const seconds = parseDurationSeconds(raw);
+  if (seconds === null) {
+    throw new Error(
+      `⛔ STEWARD_AGENT_ENROLL_TOKEN_TTL "${raw}" is not a valid positive duration (examples: "5m", "15m", "1h").`,
+    );
+  }
+  if (seconds > ENROLL_TOKEN_TTL_MAX_SECONDS) {
+    throw new Error(
+      `⛔ STEWARD_AGENT_ENROLL_TOKEN_TTL "${raw}" exceeds the one-hour maximum; enrollment tokens must stay minute-scale so signer revocation lands quickly.`,
+    );
+  }
+  return raw;
+}
+
+const ENROLL_TOKEN_TTL = resolveEnrollTokenTtl();
 
 export const agentEnrollRoutes = new Hono<{ Variables: AppVariables }>();
 

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -3435,7 +3435,7 @@ async function getTenantOidcProviders(tenantId: string): Promise<TenantOidcProvi
   // Revalidate persisted JSON on every trust-boundary read. Older rows can
   // predate write-time validation; treating their TypeScript cast as trusted
   // would re-enable unsafe algorithms or malformed endpoint configuration.
-  const normalized = normalizeOidcProviders(row?.oidcProviders ?? []);
+  const normalized = normalizeOidcProviders(row?.oidcProviders ?? [], tenantId);
   return typeof normalized === "string" ? [] : normalized;
 }
 

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -5460,9 +5460,10 @@ auth.post("/sms/verify", async (c) => {
   if (methodResponse) return methodResponse;
   const otpPurpose = smsLoginPurpose(otpTenantId);
 
-  if (
-    (await getSmsVerifyFailedAttempts(body.phone, otpPurpose)) >= SMS_VERIFY_MAX_FAILED_ATTEMPTS
-  ) {
+  // Claim-first: atomically consume one attempt slot BEFORE verifying, so
+  // concurrent requests cannot both pass a check-then-record boundary and
+  // stretch the attempt budget (~2x under a race).
+  if (!(await claimSmsVerifyAttempt(body.phone, otpPurpose))) {
     return c.json<ApiResponse>(
       {
         ok: false,
@@ -5474,7 +5475,6 @@ auth.post("/sms/verify", async (c) => {
 
   const result = await getPhoneAuth().verifyOtp(body.phone, body.code, otpPurpose);
   if (!result.valid) {
-    await recordSmsVerifyFailure(body.phone, otpPurpose);
     return c.json<ApiResponse>({ ok: false, error: "Invalid or expired code" }, 401);
   }
   await clearSmsVerifyFailures(body.phone, otpPurpose);
@@ -5631,9 +5631,10 @@ auth.post("/whatsapp/verify", async (c) => {
   if (methodResponse) return methodResponse;
   const otpPurpose = whatsappLoginPurpose(otpTenantId);
 
-  if (
-    (await getSmsVerifyFailedAttempts(body.phone, otpPurpose)) >= SMS_VERIFY_MAX_FAILED_ATTEMPTS
-  ) {
+  // Claim-first: atomically consume one attempt slot BEFORE verifying, so
+  // concurrent requests cannot both pass a check-then-record boundary and
+  // stretch the attempt budget (~2x under a race).
+  if (!(await claimSmsVerifyAttempt(body.phone, otpPurpose))) {
     return c.json<ApiResponse>(
       {
         ok: false,
@@ -5645,7 +5646,6 @@ auth.post("/whatsapp/verify", async (c) => {
 
   const result = await getPhoneAuth().verifyOtp(body.phone, body.code, otpPurpose);
   if (!result.valid) {
-    await recordSmsVerifyFailure(body.phone, otpPurpose);
     return c.json<ApiResponse>({ ok: false, error: "Invalid or expired code" }, 401);
   }
   await clearSmsVerifyFailures(body.phone, otpPurpose);
@@ -7045,8 +7045,9 @@ auth.post("/mfa/sms/verify", async (c) => {
   if (stepUpResponse) return stepUpResponse;
 
   const pendingPurpose = pending.purpose ?? smsMfaEnrollPurpose(session.payload.userId);
-  const failures = await getSmsVerifyFailedAttempts(pending.phone, pendingPurpose);
-  if (failures >= SMS_VERIFY_MAX_FAILED_ATTEMPTS) {
+  // Claim-first: atomically consume one attempt slot BEFORE verifying, so
+  // concurrent requests cannot both pass a check-then-record boundary.
+  if (!(await claimSmsVerifyAttempt(pending.phone, pendingPurpose))) {
     return c.json<ApiResponse>(
       { ok: false, error: "Too many invalid SMS verification attempts. Request a new code." },
       429,
@@ -7055,7 +7056,6 @@ auth.post("/mfa/sms/verify", async (c) => {
 
   const verified = await getPhoneAuth().verifyOtp(pending.phone, body.code, pendingPurpose);
   if (!verified.valid) {
-    await recordSmsVerifyFailure(pending.phone, pendingPurpose);
     return c.json<ApiResponse>({ ok: false, error: "Invalid or expired code" }, 401);
   }
   await clearSmsVerifyFailures(pending.phone, pendingPurpose);
@@ -7173,9 +7173,9 @@ auth.post("/mfa/sms/complete", async (c) => {
   }
 
   const otpPurpose = smsMfaChallengePurpose(body.challengeId);
-  if (
-    (await getSmsVerifyFailedAttempts(smsMfa.phone, otpPurpose)) >= SMS_VERIFY_MAX_FAILED_ATTEMPTS
-  ) {
+  // Claim-first: atomically consume one attempt slot BEFORE verifying, so
+  // concurrent requests cannot both pass a check-then-record boundary.
+  if (!(await claimSmsVerifyAttempt(smsMfa.phone, otpPurpose))) {
     return c.json<ApiResponse>(
       {
         ok: false,
@@ -7187,7 +7187,6 @@ auth.post("/mfa/sms/complete", async (c) => {
 
   const verified = await getPhoneAuth().verifyOtp(smsMfa.phone, body.code, otpPurpose);
   if (!verified.valid) {
-    await recordSmsVerifyFailure(smsMfa.phone, otpPurpose);
     return c.json<ApiResponse>({ ok: false, error: "Invalid or expired code" }, 401);
   }
   if ((await getMfaBackend().consume(challengeKey)) === null) {
@@ -7244,9 +7243,9 @@ auth.post("/mfa/sms/step-up", async (c) => {
   }
 
   const otpPurpose = smsMfaManagePurpose(session.payload.userId);
-  if (
-    (await getSmsVerifyFailedAttempts(smsMfa.phone, otpPurpose)) >= SMS_VERIFY_MAX_FAILED_ATTEMPTS
-  ) {
+  // Claim-first: atomically consume one attempt slot BEFORE verifying, so
+  // concurrent requests cannot both pass a check-then-record boundary.
+  if (!(await claimSmsVerifyAttempt(smsMfa.phone, otpPurpose))) {
     return c.json<ApiResponse>(
       { ok: false, error: "Too many invalid SMS verification attempts. Request a new code." },
       429,
@@ -7255,7 +7254,6 @@ auth.post("/mfa/sms/step-up", async (c) => {
 
   const verified = await getPhoneAuth().verifyOtp(smsMfa.phone, body.code, otpPurpose);
   if (!verified.valid) {
-    await recordSmsVerifyFailure(smsMfa.phone, otpPurpose);
     return c.json<ApiResponse>({ ok: false, error: "Invalid or expired code" }, 401);
   }
   await clearSmsVerifyFailures(smsMfa.phone, otpPurpose);
@@ -7471,9 +7469,9 @@ auth.post("/mfa/sms/unenroll", async (c) => {
     return c.json<ApiResponse>({ ok: false, error: "SMS MFA is not enabled" }, 404);
   }
   const otpPurpose = smsMfaManagePurpose(session.payload.userId);
-  if (
-    (await getSmsVerifyFailedAttempts(smsMfa.phone, otpPurpose)) >= SMS_VERIFY_MAX_FAILED_ATTEMPTS
-  ) {
+  // Claim-first: atomically consume one attempt slot BEFORE verifying, so
+  // concurrent requests cannot both pass a check-then-record boundary.
+  if (!(await claimSmsVerifyAttempt(smsMfa.phone, otpPurpose))) {
     return c.json<ApiResponse>(
       {
         ok: false,
@@ -7484,7 +7482,6 @@ auth.post("/mfa/sms/unenroll", async (c) => {
   }
   const verified = await getPhoneAuth().verifyOtp(smsMfa.phone, body.code, otpPurpose);
   if (!verified.valid) {
-    await recordSmsVerifyFailure(smsMfa.phone, otpPurpose);
     return c.json<ApiResponse>({ ok: false, error: "Invalid or expired code" }, 401);
   }
   await clearSmsVerifyFailures(smsMfa.phone, otpPurpose);

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -152,6 +152,7 @@ import {
   isAllowedOidcClientSecretEnvForTenant,
   normalizeOidcProviders,
 } from "../services/oidc-provider-config";
+import { socketPeerFromEnv } from "../services/runtime-gate";
 import { buildSamlServiceProviderUrls } from "../services/saml-sso-config";
 import { lockUserSession } from "../services/session-lock";
 import { testAccountOtpMatches } from "../services/test-account-credentials";
@@ -367,10 +368,15 @@ let coarseSubjectWarnedAt = 0;
 
 /**
  * Rate-limit subject for auth endpoints. With a trusted client IP every
- * client gets an independent budget (IPv6 at /64). Without one, requests
+ * client gets an independent budget (IPv6 at /64). Without one, the socket
+ * peer injected by the server entry point (SOCKET_PEER_ENV_KEY — set by the
+ * runtime, never client-influenceable) provides the same per-client budget.
+ * Only when neither exists (e.g. Workers, which has no socket) do requests
  * shard per Host — the edge only routes configured domains here, so Host
  * cannot be rotated to mint unbounded buckets the way client-controlled
- * headers or user-agents can — and checkAuthRateLimit widens the budget by
+ * headers or user-agents can; note this last-resort fallback does rely on
+ * that edge invariant, so deployments should prefer STEWARD_TRUSTED_PROXY_HOPS
+ * or a socket-bearing entry. checkAuthRateLimit widens the coarse budget by
  * AUTH_RATE_LIMIT_FALLBACK_HEADROOM because many clients share each bucket.
  * No configuration yields the old literal "global" chokepoint (#268), and no
  * client-controlled free text ever reaches Redis unhashed.
@@ -378,6 +384,8 @@ let coarseSubjectWarnedAt = 0;
 function authRateLimitSubject(c: Context): { subject: string; coarse: boolean } {
   const ip = trustedClientIp(c);
   if (ip) return { subject: `ip:${clientIpBucket(ip)}`, coarse: false };
+  const peer = socketPeerFromEnv(c.env);
+  if (peer && isIP(peer)) return { subject: `ip:${clientIpBucket(peer)}`, coarse: false };
   const now = Date.now();
   if (process.env.NODE_ENV === "production" && now - coarseSubjectWarnedAt >= 60_000) {
     coarseSubjectWarnedAt = now;

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -149,7 +149,7 @@ import {
 } from "../services/auth-abuse";
 import { verifyEip1271 } from "../services/eip1271";
 import {
-  isAllowedOidcClientSecretEnv,
+  isAllowedOidcClientSecretEnvForTenant,
   normalizeOidcProviders,
 } from "../services/oidc-provider-config";
 import { buildSamlServiceProviderUrls } from "../services/saml-sso-config";
@@ -5052,6 +5052,7 @@ auth.get("/oidc/:provider/callback", async (c) => {
   try {
     idToken = await exchangeOidcAuthorizationCode({
       provider,
+      tenantId: stateData.tenantId,
       code,
       redirectUri: buildOidcCallbackUrl(c, provider.id),
       codeVerifier: stateData.codeVerifier,
@@ -10358,11 +10359,12 @@ async function postPublicOidcTokenEndpoint(
 
 async function exchangeOidcAuthorizationCode(opts: {
   provider: TenantOidcProviderConfig;
+  tenantId: string;
   code: string;
   redirectUri: string;
   codeVerifier: string;
 }): Promise<string> {
-  const { provider, code, redirectUri, codeVerifier } = opts;
+  const { provider, tenantId, code, redirectUri, codeVerifier } = opts;
   if (!provider.clientId || !provider.tokenUrl) {
     throw new Error("OIDC provider is not configured for authorization-code login");
   }
@@ -10375,8 +10377,9 @@ async function exchangeOidcAuthorizationCode(opts: {
   });
   if (provider.clientSecretEnv) {
     // Defense in depth: legacy rows may predate the config-time allowlist, so
-    // re-enforce the dedicated env namespace before reading any secret.
-    if (!isAllowedOidcClientSecretEnv(provider.clientSecretEnv)) {
+    // re-enforce the tenant-bound env namespace before reading any secret
+    // (SEC-005: a cross-tenant env reference must never reach the exchange).
+    if (!isAllowedOidcClientSecretEnvForTenant(provider.clientSecretEnv, tenantId)) {
       throw new Error("OIDC client secret env is outside the allowed tenant namespace");
     }
     const secret = process.env[provider.clientSecretEnv];

--- a/packages/api/src/routes/platform.ts
+++ b/packages/api/src/routes/platform.ts
@@ -1624,7 +1624,7 @@ platform.put("/tenants/:tenantId/oidc-providers", async (c) => {
 
   const body = await safeJsonParse<{ providers?: unknown }>(c);
   if (!body) return c.json<ApiResponse>({ ok: false, error: "Invalid JSON in request body" }, 400);
-  const providers = normalizeOidcProviders(body.providers);
+  const providers = normalizeOidcProviders(body.providers, tenantId);
   if (typeof providers === "string") {
     return c.json<ApiResponse>({ ok: false, error: providers }, 400);
   }

--- a/packages/api/src/routes/tenant-config.ts
+++ b/packages/api/src/routes/tenant-config.ts
@@ -1748,7 +1748,7 @@ tenantConfigRoutes.put("/:id/oidc-providers", requireTenantId, async (c) => {
   const body = await safeJsonParse<{ providers?: unknown }>(c);
   if (!body) return c.json<ApiResponse>({ ok: false, error: "Invalid JSON in request body" }, 400);
 
-  const providers = normalizeOidcProviders(body.providers);
+  const providers = normalizeOidcProviders(body.providers, tenantId);
   if (typeof providers === "string") {
     return c.json<ApiResponse>({ ok: false, error: providers }, 400);
   }

--- a/packages/api/src/services/oidc-provider-config.ts
+++ b/packages/api/src/services/oidc-provider-config.ts
@@ -9,8 +9,32 @@ import type { TenantOidcProviderConfig } from "@stwd/shared";
  */
 export const OIDC_CLIENT_SECRET_ENV_PREFIX = "STEWARD_TENANT_OIDC_SECRET_";
 
+/**
+ * SEC-005 residual: the bare namespace above is platform-wide, so a tenant
+ * admin could reference ANOTHER tenant's OIDC secret env var. Bind the env
+ * name to the configuring tenant: it must start with
+ * STEWARD_TENANT_OIDC_SECRET_<TENANT_KEY>_, where TENANT_KEY is the tenant id
+ * uppercased with non-env-safe characters mapped to "_".
+ *
+ * Note: distinct tenant ids whose only differences are separator characters
+ * (e.g. "acme-corp" vs "acme.corp") share a TENANT_KEY. Tenant ids are
+ * provisioned by platform admins, not tenant admins, so this collision cannot
+ * be attacker-created; operators should avoid separator-only-distinct ids.
+ */
+export function oidcClientSecretEnvPrefixForTenant(tenantId: string): string {
+  const tenantKey = tenantId.toUpperCase().replace(/[^A-Z0-9_]/g, "_");
+  return `${OIDC_CLIENT_SECRET_ENV_PREFIX}${tenantKey}_`;
+}
+
 export function isAllowedOidcClientSecretEnv(name: string): boolean {
   return /^[A-Z_][A-Z0-9_]{0,127}$/.test(name) && name.startsWith(OIDC_CLIENT_SECRET_ENV_PREFIX);
+}
+
+export function isAllowedOidcClientSecretEnvForTenant(name: string, tenantId: string): boolean {
+  return (
+    isAllowedOidcClientSecretEnv(name) &&
+    name.startsWith(oidcClientSecretEnvPrefixForTenant(tenantId))
+  );
 }
 
 function isNonEmptyString(value: unknown): value is string {
@@ -41,7 +65,10 @@ function isPublicOidcIssuer(value: string): boolean {
   }
 }
 
-export function normalizeOidcProviders(value: unknown): TenantOidcProviderConfig[] | string {
+export function normalizeOidcProviders(
+  value: unknown,
+  tenantId: string,
+): TenantOidcProviderConfig[] | string {
   if (!Array.isArray(value)) return "providers must be an array";
   if (value.length > 10) return "at most 10 OIDC providers are allowed per tenant";
   const ids = new Set<string>();
@@ -90,8 +117,8 @@ export function normalizeOidcProviders(value: unknown): TenantOidcProviderConfig
     if (clientId && clientId.length > 256) {
       return `clientId for provider ${id} may be at most 256 characters`;
     }
-    if (clientSecretEnv && !isAllowedOidcClientSecretEnv(clientSecretEnv)) {
-      return `clientSecretEnv for provider ${id} must be an environment variable name starting with ${OIDC_CLIENT_SECRET_ENV_PREFIX}`;
+    if (clientSecretEnv && !isAllowedOidcClientSecretEnvForTenant(clientSecretEnv, tenantId)) {
+      return `clientSecretEnv for provider ${id} must be an environment variable name starting with ${oidcClientSecretEnvPrefixForTenant(tenantId)}`;
     }
     if (
       authorizationUrl &&

--- a/packages/api/src/services/runtime-gate.ts
+++ b/packages/api/src/services/runtime-gate.ts
@@ -32,6 +32,24 @@
 
 export const DEFAULT_RATE_LIMIT_MAX_KEYS = 10_000;
 
+/**
+ * Key in the Hono `env` bag (app.fetch's second argument) through which a
+ * server entry point hands the app the socket peer it observed (Bun's
+ * `server.requestIP`). Unlike any request header, this value is set by the
+ * runtime and cannot be client-influenced, so downstream rate limiters may
+ * key on it when no trusted forwarding config exists (SEC-014 posture
+ * extended to the per-route auth limiter). Runtimes without a socket (e.g.
+ * Cloudflare Workers) simply never set it.
+ */
+export const SOCKET_PEER_ENV_KEY = "steward.socketPeer";
+
+/** Read the entry-injected socket peer from a Hono context's env bag. */
+export function socketPeerFromEnv(env: unknown): string | undefined {
+  if (typeof env !== "object" || env === null) return undefined;
+  const peer = (env as Record<string, unknown>)[SOCKET_PEER_ENV_KEY];
+  return typeof peer === "string" && peer.length > 0 ? peer : undefined;
+}
+
 export function parseNonNegativeInt(value: string | undefined, fallback: number): number {
   const parsed = Number(value);
   return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : fallback;

--- a/packages/api/src/worker.ts
+++ b/packages/api/src/worker.ts
@@ -157,6 +157,12 @@ async function ensureWorkerInit(env: Env): Promise<void> {
     // Workers bindings are only available inside fetch(). Hydrate process.env
     // before importing app modules that read required env at module init.
     hydrateProcessEnv(env);
+    // SEC-134: the Bun entry (index.ts) runs validateJwtSecretEnv() at startup;
+    // run the same validation on the Workers boot path so a bad/missing JWT
+    // secret or malformed AGENT_TOKEN_EXPIRY fails closed at cold start instead
+    // of surfacing at first token sign/verify.
+    const { validateJwtSecretEnv } = await import("@stwd/auth");
+    validateJwtSecretEnv();
     const redisOk = await initRedis(env);
     // Auth stores (passkey challenges, magic-link tokens, SIWE/SIWS nonces)
     // must be initialized too — without this they stay on the lazy memory

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -13,6 +13,7 @@
     "@node-saml/node-saml": "5.1.0",
     "@simplewebauthn/server": "^13",
     "@stwd/db": "workspace:*",
+    "@stwd/redis": "workspace:*",
     "@stwd/shared": "workspace:*",
     "hono": "^4.12.34",
     "ioredis": "^5.10.1",

--- a/packages/auth/src/__tests__/middleware.test.ts
+++ b/packages/auth/src/__tests__/middleware.test.ts
@@ -1,0 +1,116 @@
+/**
+ * middleware.test.ts — SEC-132: tenantAuthMiddleware must fail unknown-tenant
+ * requests with the same constant-shape 403 as a bad key, and must still run
+ * the dummy-hash comparison, so response shape/timing cannot enumerate valid
+ * tenant ids.
+ *
+ * Two layers of proof:
+ *   - behavioral: known-tenant/wrong-key and unknown-tenant responses are
+ *     byte-identical 403s (status, body, content type);
+ *   - structural: the middleware source pins the dummy-hash mechanism (a
+ *     timing assertion would be flaky in CI).
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { closeDb, getDb, tenants } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { Hono } from "hono";
+
+import { generateApiKey } from "../api-keys";
+
+const TENANT_ID = "sec132-known-tenant";
+const ENV_KEYS = ["STEWARD_PGLITE_MEMORY", "STEWARD_DB_MODE", "STEWARD_MASTER_PASSWORD"] as const;
+
+describe("tenantAuthMiddleware unknown-tenant hardening (SEC-132)", () => {
+  const savedEnv: Record<string, string | undefined> = {};
+  let app: Hono;
+  let validKey: string;
+
+  beforeAll(async () => {
+    for (const key of ENV_KEYS) savedEnv[key] = process.env[key];
+    process.env.STEWARD_PGLITE_MEMORY = "true";
+    process.env.STEWARD_DB_MODE = "pglite";
+    process.env.STEWARD_MASTER_PASSWORD ??= "sec132-middleware-test-master-password";
+    const { db, client } = await createPGLiteDb("memory://");
+    setPGLiteOverride(db, async () => {
+      await client.close();
+    });
+
+    const keyPair = generateApiKey();
+    validKey = keyPair.key;
+    await getDb()
+      .insert(tenants)
+      .values({ id: TENANT_ID, name: "SEC-132 Known Tenant", apiKeyHash: keyPair.hash });
+
+    const { tenantAuthMiddleware } = await import("../middleware");
+    app = new Hono();
+    app.use("*", tenantAuthMiddleware());
+    app.get("/", (c) => c.json({ ok: true }));
+    app.get("/health", (c) => c.json({ ok: true }));
+    app.get("/probe", (c) => c.json({ ok: true }));
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    for (const key of ENV_KEYS) {
+      if (savedEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = savedEnv[key];
+      }
+    }
+  });
+
+  async function probe(tenantId: string, key: string): Promise<Response> {
+    return app.request("/probe", {
+      headers: { "X-Steward-Tenant": tenantId, "X-Steward-Key": key },
+    });
+  }
+
+  it("admits a known tenant with its valid key", async () => {
+    const res = await probe(TENANT_ID, validKey);
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects an unknown tenant with a constant-shape 403 identical to a bad key", async () => {
+    const knownBadKeyRes = await probe(TENANT_ID, "stw_wrong_key");
+    expect(knownBadKeyRes.status).toBe(403);
+    const knownBadKeyBody = await knownBadKeyRes.json();
+
+    const unknownTenantRes = await probe("sec132-no-such-tenant", "stw_wrong_key");
+    expect(unknownTenantRes.status).toBe(403);
+    const unknownTenantBody = await unknownTenantRes.json();
+
+    // Constant shape: identical status, body, and content type whether the
+    // tenant id exists or not — no enumeration signal in the response.
+    expect(unknownTenantBody).toEqual(knownBadKeyBody);
+    expect(unknownTenantBody).toEqual({ ok: false, error: "Invalid API key" });
+    expect(unknownTenantRes.headers.get("content-type")).toBe(
+      knownBadKeyRes.headers.get("content-type"),
+    );
+  });
+
+  it("pins the dummy-hash comparison in the middleware source", () => {
+    // The unknown-tenant path must still run validateApiKey against a dummy
+    // hash so response TIMING matches the known-tenant path. Pinning the
+    // construction beats a wall-clock assertion, which flakes under CI load.
+    const source = readFileSync(join(import.meta.dir, "..", "middleware.ts"), "utf8");
+    expect(source).toContain('hashApiKey("steward-unknown-tenant-dummy-key")');
+    expect(source).toContain(
+      "validateApiKey(apiKey, tenant?.apiKeyHash ?? UNKNOWN_TENANT_DUMMY_HASH)",
+    );
+    // One shared denial: no branch may reveal WHICH leg failed.
+    expect(source).toContain("if (!tenant || !keyValid)");
+  });
+
+  it("keeps the healthcheck bypass exact: GET / and /health only", async () => {
+    // No auth headers at all — the bypass serves these without a tenant.
+    expect((await app.request("/")).status).toBe(200);
+    expect((await app.request("/health")).status).toBe(200);
+    // Non-healthcheck paths and non-GET methods stay authenticated.
+    expect((await app.request("/probe")).status).toBe(401);
+    expect((await app.request("/", { method: "POST" })).status).toBe(401);
+  });
+});

--- a/packages/auth/src/__tests__/session-revocation.test.ts
+++ b/packages/auth/src/__tests__/session-revocation.test.ts
@@ -141,6 +141,43 @@ describe("session revocation", () => {
     expect(await sessions.verifySession(refresh)).toBeNull();
   });
 
+  it("refuses a cleartext non-localhost REDIS_URL in production (SEC-032)", async () => {
+    const previousNodeEnv = process.env.NODE_ENV;
+    const previousRedisUrl = process.env.REDIS_URL;
+    const previousAllowInsecure = process.env.STEWARD_ALLOW_INSECURE_REDIS;
+    process.env.NODE_ENV = "production";
+    process.env.REDIS_URL = "redis://redis.internal.example.com:6379";
+    delete process.env.STEWARD_ALLOW_INSECURE_REDIS;
+
+    try {
+      // Fresh module instance so the lazily-built client starts clean — the
+      // TLS assertion must fire before any connection is attempted.
+      const { revocationStore: freshStore } = await import(`../revocation?sec032=${Date.now()}`);
+      await expect(freshStore.isRevoked("sec032-probe")).rejects.toThrow(
+        "rediss:// (TLS) in production",
+      );
+      await expect(freshStore.revokeToken("sec032-probe", Date.now() + 60_000)).rejects.toThrow(
+        "rediss:// (TLS) in production",
+      );
+    } finally {
+      if (previousNodeEnv === undefined) {
+        delete process.env.NODE_ENV;
+      } else {
+        process.env.NODE_ENV = previousNodeEnv;
+      }
+      if (previousRedisUrl === undefined) {
+        delete process.env.REDIS_URL;
+      } else {
+        process.env.REDIS_URL = previousRedisUrl;
+      }
+      if (previousAllowInsecure === undefined) {
+        delete process.env.STEWARD_ALLOW_INSECURE_REDIS;
+      } else {
+        process.env.STEWARD_ALLOW_INSECURE_REDIS = previousAllowInsecure;
+      }
+    }
+  });
+
   it("warns loudly when revocation degrades to per-process memory (SEC-056)", async () => {
     const previousNodeEnv = process.env.NODE_ENV;
     const previousRedisUrl = process.env.REDIS_URL;

--- a/packages/auth/src/__tests__/sms-provider.test.ts
+++ b/packages/auth/src/__tests__/sms-provider.test.ts
@@ -1,0 +1,86 @@
+/**
+ * sms-provider.test.ts — SEC-061: a failed Twilio send must surface only a
+ * generic SmsDeliveryError. The provider error body can carry account/phone
+ * metadata, so it is discarded — never thrown, never logged verbatim.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { SmsDeliveryError, TwilioSmsProvider } from "../sms-provider";
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_WARN = console.warn;
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+  console.warn = ORIGINAL_WARN;
+});
+
+const PROVIDER = new TwilioSmsProvider({
+  accountSid: "ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+  authToken: "twilio-auth-token",
+  from: "+14155550000",
+});
+
+// A realistic Twilio error payload — it names the account SID and the
+// destination number, exactly the metadata that must not propagate.
+const TWILIO_ERROR_BODY = JSON.stringify({
+  code: 21608,
+  message:
+    "The number +14155550999 is unverified. Trial accounts cannot send to unverified numbers.",
+  more_info: "https://www.twilio.com/docs/errors/21608",
+  status: 400,
+  account_sid: "ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+});
+
+describe("TwilioSmsProvider failure redaction (SEC-061)", () => {
+  test("a failed send throws a generic SmsDeliveryError and discards the provider body", async () => {
+    globalThis.fetch = (async () =>
+      new Response(TWILIO_ERROR_BODY, {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      })) as typeof fetch;
+
+    const warnings: string[] = [];
+    console.warn = (message?: unknown, ...rest: unknown[]) => {
+      warnings.push([message, ...rest].join(" "));
+    };
+
+    const failure = await PROVIDER.send("+14155550999", "Your code is 123456").then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    expect(failure).toBeInstanceOf(SmsDeliveryError);
+    expect((failure as Error).message).toBe("SMS delivery failed");
+    // No provider-body bytes in the thrown error…
+    expect((failure as Error).message).not.toContain("21608");
+    expect((failure as Error).message).not.toContain("+14155550999");
+    expect((failure as Error).message).not.toContain("unverified");
+    expect((failure as Error).stack ?? "").not.toContain("21608");
+
+    // …nor in the server-side log line, which may carry the status code only.
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("400");
+    expect(warnings[0]).not.toContain("21608");
+    expect(warnings[0]).not.toContain("+14155550999");
+    expect(warnings[0]).not.toContain("unverified");
+    expect(warnings[0]).not.toContain("ACxxxxxxxx");
+  });
+
+  test("a successful send resolves without logging", async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ sid: "SMxxxxxxxx" }), {
+        status: 201,
+        headers: { "Content-Type": "application/json" },
+      })) as typeof fetch;
+
+    const warnings: string[] = [];
+    console.warn = (message?: unknown, ...rest: unknown[]) => {
+      warnings.push([message, ...rest].join(" "));
+    };
+
+    await expect(PROVIDER.send("+14155550999", "Your code is 123456")).resolves.toBeUndefined();
+    expect(warnings).toHaveLength(0);
+  });
+});

--- a/packages/auth/src/jwt.ts
+++ b/packages/auth/src/jwt.ts
@@ -403,8 +403,14 @@ export function parseDurationSeconds(value: string): number | null {
  * Validate AGENT_TOKEN_EXPIRY format and bound at startup (SEC-134). A bad
  * value otherwise surfaces as a 500 at token-signing time, and an unbounded
  * value mints effectively-permanent agent tokens.
+ *
+ * The default reads process.env at CALL time (not the module-init constant):
+ * on the Workers boot path, bindings are hydrated into process.env per request
+ * (SEC-148) and module-init constants may have been captured before hydration.
  */
-export function validateAgentTokenExpiryEnv(value: string = AGENT_TOKEN_EXPIRY): void {
+export function validateAgentTokenExpiryEnv(
+  value: string = process.env.AGENT_TOKEN_EXPIRY || "30d",
+): void {
   const seconds = parseDurationSeconds(value);
   if (seconds === null) {
     throw new Error(

--- a/packages/auth/src/jwt.ts
+++ b/packages/auth/src/jwt.ts
@@ -387,16 +387,26 @@ const DURATION_UNIT_SECONDS: Record<string, number> = {
 export const AGENT_TOKEN_EXPIRY_MAX_SECONDS = DURATION_UNIT_SECONDS.y;
 
 /**
+ * Parse a relative duration string ("30m", "12h", "5 days") into seconds.
+ * Returns null when the value is not a positive forward duration in the
+ * grammar jose accepts for setExpirationTime.
+ */
+export function parseDurationSeconds(value: string): number | null {
+  const match = DURATION_PATTERN.exec(value.trim());
+  const seconds = match
+    ? Number.parseFloat(match[1]) * (DURATION_UNIT_SECONDS[match[2].toLowerCase()] ?? Number.NaN)
+    : Number.NaN;
+  return Number.isFinite(seconds) && seconds > 0 ? seconds : null;
+}
+
+/**
  * Validate AGENT_TOKEN_EXPIRY format and bound at startup (SEC-134). A bad
  * value otherwise surfaces as a 500 at token-signing time, and an unbounded
  * value mints effectively-permanent agent tokens.
  */
 export function validateAgentTokenExpiryEnv(value: string = AGENT_TOKEN_EXPIRY): void {
-  const match = DURATION_PATTERN.exec(value.trim());
-  const seconds = match
-    ? Number.parseFloat(match[1]) * (DURATION_UNIT_SECONDS[match[2].toLowerCase()] ?? Number.NaN)
-    : Number.NaN;
-  if (!Number.isFinite(seconds) || seconds <= 0) {
+  const seconds = parseDurationSeconds(value);
+  if (seconds === null) {
     throw new Error(
       `⛔ AGENT_TOKEN_EXPIRY "${value}" is not a valid positive duration (examples: "30m", "12h", "30d").`,
     );

--- a/packages/auth/src/revocation.ts
+++ b/packages/auth/src/revocation.ts
@@ -8,6 +8,7 @@
  * back to in-memory state suitable only for single-instance/embedded mode.
  */
 
+import { assertRedisUrlTls } from "@stwd/redis";
 import { Redis } from "ioredis";
 
 export class TokenRevokedError extends Error {
@@ -149,6 +150,10 @@ class RedisRevocationStore implements RevocationStore {
       return null;
     }
     if (!this.redis) {
+      // SEC-032: enforce the same rediss:// production TLS assertion as the
+      // shared client in @stwd/redis — revocation state is auth data and must
+      // not cross a cleartext link.
+      assertRedisUrlTls(process.env.REDIS_URL);
       this.redis = new Redis(process.env.REDIS_URL, {
         maxRetriesPerRequest: 1,
         lazyConnect: false,

--- a/packages/plugin-trading/src/__tests__/trade-polymarket-creds-cache.test.ts
+++ b/packages/plugin-trading/src/__tests__/trade-polymarket-creds-cache.test.ts
@@ -71,6 +71,9 @@ const fakeRedis = {
 // With a Redis client present the route's rate limiter calls the real
 // @stwd/redis singleton; keep it in-memory for this harness.
 mock.module("@stwd/redis", () => ({
+  // @stwd/auth's revocation store (SEC-032) statically imports this; the mock
+  // namespace must provide every name importers bind or bun throws at load.
+  assertRedisUrlTls: () => undefined,
   checkRateLimit: async () => ({ allowed: true, remaining: 9, resetMs: 1_000 }),
   checkSpendLimit: async () => ({ allowed: true, spent: 0, remaining: 1 }),
   createUpstashIoredisAdapter: () => ({ ping: async () => "PONG" }),


### PR DESCRIPTION
## Re-audit batch W3-A1 — packages/auth + packages/api auth routes

Deep security re-audit of auth and API auth boundaries. The branch is restacked on current `develop` and remains draft pending exact-head CI.

### Fixed security issues

1. Revocation Redis now applies the shared production TLS assertion before connecting.
2. Tenant OIDC client-secret env names are bound to the exact tenant with an uppercase SHA-256 tenant key. This removes separator and case-folding collisions while staying within the env-name bound. Validation runs at config write, persisted-row read, and token exchange.
3. Enrollment-token TTL env parsing fails closed at startup and caps tokens at one hour.
4. Workers validate JWT secret strength and agent-token expiry after binding hydration and before store initialization.
5. Bun auth limits prefer the runtime-observed socket peer. When no trustworthy client address exists, all unattributed traffic uses one fixed coarse subject; client-controlled Host rotation cannot mint fresh buckets.
6. All six SMS/WhatsApp/MFA verification routes atomically claim an attempt slot before OTP verification.
7. Twilio HTTP failures and thrown transport exceptions both surface only generic errors and generic logs; provider body, account SID, destination, and transport diagnostics are not propagated.
8. Unknown-tenant API-key failures keep the same 403 shape as bad-key failures and still execute the dummy timing-safe hash comparison.
9. OIDC callback token-exchange failures no longer reflect internal env names, resolved hosts, or transport diagnostics to browsers.

### Migration notes

- Existing OIDC `clientSecretEnv` values must be renamed to `STEWARD_TENANT_OIDC_SECRET_<UPPERCASE_SHA256_TENANT_ID>_<SUFFIX>` and the provider config rewritten. Legacy/unbound rows fail closed.
- Socket-less deployments should configure `STEWARD_TRUST_CLOUDFLARE=true` or the exact `STEWARD_TRUSTED_PROXY_HOPS`; otherwise unattributed clients share the widened coarse availability budget.
- `packages/auth` now declares `@stwd/redis`; `bun.lock` contains the matching workspace dependency and passes frozen install.

### Exact local validation

Validated at head `71d7d253d56f7214aa8dd46c4ad3999f86dea0ca` on `develop` `bdb0dd4359aed94beec9ff92f031abd49b2d794a`:

- `bun install --frozen-lockfile --ignore-scripts`: 1,789 installs checked, no changes
- `packages/auth` focused revocation, Twilio, constant-shape middleware, and JWT suites: 26/26 green before final disjoint restacks; final-head revocation/Twilio/middleware rerun: 17/17, 47 assertions
- OIDC config, tenant routes, auth-code flow, and JWT suites run one file per Bun process: 8/8, 4/4, 6/6, and 15/15 green
- auth rate-limit, SMS/MFA, and audit suites: 46/46, 398 assertions
- worker and enrollment env-validation suites: 8/8 green; final-head focused API rerun: 16/16, 63 assertions
- direct `packages/auth` and `packages/api` TypeScript builds completed cleanly
- Biome clean on every changed code file; `git diff --check` clean

Fresh exact-head CI is required before taking the PR out of draft.
