### PR TITLE
fix(security): W3-D re-audit batch — policy/trading fail-closed residuals

### DIFF
--- a/packages/plugin-trading/src/__tests__/idempotency-store.test.ts
+++ b/packages/plugin-trading/src/__tests__/idempotency-store.test.ts
@@ -172,6 +172,52 @@ describe("DurableIdempotencyStore (SEC-043)", () => {
     expect(await store.check("scope", undefined, "hash-1")).toEqual({});
   });
 
+  it("fails closed instead of evicting live records when the memory fallback is saturated", async () => {
+    const store = new DurableIdempotencyStore<TestRecord>({
+      namespace: "trade",
+      getRedisClient: () => null,
+    });
+    // Fill the fallback map to the 1_000-entry cap with LIVE records.
+    for (let i = 0; i < 1_000; i++) {
+      const checked = await store.check("scope", `flood-${i}`, `hash-${i}`);
+      const claim = await checked.claim?.();
+      await claim?.store?.({ status: 200, body: { ok: true, i } });
+    }
+    // A new key must be refused — shedding the oldest live record would
+    // silently re-enable a duplicate fund movement on its retry.
+    const overflow = await store.check("scope", "flood-overflow", "hash-overflow");
+    await expect(overflow.claim?.()).rejects.toThrow("saturated with live records");
+
+    // …and the oldest record is still intact: its retry replays, never re-executes.
+    const replay = await store.check("scope", "flood-0", "hash-0");
+    expect(replay.record).toEqual({ status: 200, body: { ok: true, i: 0 } });
+  });
+
+  it("still sweeps expired entries before refusing a new claim", async () => {
+    const realNow = Date.now;
+    const t0 = realNow();
+    let fakeNow = t0;
+    Date.now = () => fakeNow;
+    try {
+      const store = new DurableIdempotencyStore<TestRecord>({
+        namespace: "trade",
+        getRedisClient: () => null,
+      });
+      for (let i = 0; i < 1_000; i++) {
+        const checked = await store.check("scope", `old-${i}`, `hash-${i}`);
+        await (await checked.claim?.())?.store?.({ status: 200, body: { i } });
+      }
+      // 25h later every entry is past the 24h TTL; the expired-only sweep must
+      // free the map so a new claim succeeds (no false saturation).
+      fakeNow = t0 + 25 * 60 * 60 * 1000;
+      const checked = await store.check("scope", "new-key", "new-hash");
+      const claim = await checked.claim?.();
+      expect(claim?.store).toBeDefined();
+    } finally {
+      Date.now = realNow;
+    }
+  });
+
   it("atomically admits only one concurrent replica for the same key", async () => {
     const { client } = fakeRedis();
     const replicaA = new DurableIdempotencyStore<TestRecord>({

--- a/packages/plugin-trading/src/__tests__/idempotency-store.test.ts
+++ b/packages/plugin-trading/src/__tests__/idempotency-store.test.ts
@@ -193,6 +193,29 @@ describe("DurableIdempotencyStore (SEC-043)", () => {
     expect(replay.record).toEqual({ status: 200, body: { ok: true, i: 0 } });
   });
 
+  it("preserves an in-flight claim when completed records saturate the memory fallback", async () => {
+    const store = new DurableIdempotencyStore<TestRecord>({
+      namespace: "trade",
+      getRedisClient: () => null,
+    });
+    const inFlight = await store.check("scope", "in-flight", "in-flight-hash");
+    expect((await inFlight.claim?.())?.store).toBeDefined();
+
+    for (let i = 0; i < 999; i++) {
+      const checked = await store.check("scope", `completed-${i}`, `hash-${i}`);
+      await (await checked.claim?.())?.store?.({ status: 200, body: { i } });
+    }
+
+    const overflow = await store.check("scope", "overflow", "overflow-hash");
+    await expect(overflow.claim?.()).rejects.toThrow("saturated with live records");
+
+    // Losing this pending marker would allow a retry to claim the key and
+    // execute the external movement a second time while the first is ongoing.
+    const retry = await store.check("scope", "in-flight", "in-flight-hash");
+    expect(retry.inProgress).toBe(true);
+    expect(retry.claim).toBeUndefined();
+  });
+
   it("still sweeps expired entries before refusing a new claim", async () => {
     const realNow = Date.now;
     const t0 = realNow();

--- a/packages/plugin-trading/src/__tests__/operator-recovery-policy-gates.test.ts
+++ b/packages/plugin-trading/src/__tests__/operator-recovery-policy-gates.test.ts
@@ -314,8 +314,9 @@ describe("SEC-004: usd-send policy gate + caps", () => {
   it("fails closed (429) when the process-local rate-limit map is saturated with live windows", async () => {
     // The fallback map caps at 1_000 keys. Under a distinct-agent flood the
     // limiter must deny new keys instead of growing unbounded or resetting
-    // live budgets. The rate limiter runs BEFORE the agent-exists check, so
-    // unknown agents still consume map slots (404s below).
+    // live budgets. Agent existence is checked first, so seed the distinct
+    // principals that exercise the fallback instead of relying on unknown
+    // request identities to mutate limiter state.
     const { tenantId, agentId } = await seedAgent({
       policies: [
         { type: "approved-addresses", config: { mode: "whitelist", addresses: [DEST_A] } },
@@ -323,6 +324,17 @@ describe("SEC-004: usd-send policy gate + caps", () => {
     });
     usdSendCalls.length = 0;
     const app = await buildApp();
+
+    await getDb()
+      .insert(agents)
+      .values(
+        Array.from({ length: 1_000 }, (_, i) => ({
+          id: i === 999 ? "flood-agent-overflow" : `flood-agent-${i}`,
+          tenantId,
+          name: `Flood Agent ${i}`,
+          walletAddress: "0x1111111111111111111111111111111111111111",
+        })),
+      );
 
     // One real call so the agent has a LIVE window recorded.
     const first = await postTransfer(app, "usd-send", tenantId, {

--- a/packages/plugin-trading/src/__tests__/operator-recovery-policy-gates.test.ts
+++ b/packages/plugin-trading/src/__tests__/operator-recovery-policy-gates.test.ts
@@ -310,6 +310,55 @@ describe("SEC-004: usd-send policy gate + caps", () => {
     expect(res.status).toBe(429);
     expect(usdSendCalls).toHaveLength(10);
   });
+
+  it("fails closed (429) when the process-local rate-limit map is saturated with live windows", async () => {
+    // The fallback map caps at 1_000 keys. Under a distinct-agent flood the
+    // limiter must deny new keys instead of growing unbounded or resetting
+    // live budgets. The rate limiter runs BEFORE the agent-exists check, so
+    // unknown agents still consume map slots (404s below).
+    const { tenantId, agentId } = await seedAgent({
+      policies: [
+        { type: "approved-addresses", config: { mode: "whitelist", addresses: [DEST_A] } },
+      ],
+    });
+    usdSendCalls.length = 0;
+    const app = await buildApp();
+
+    // One real call so the agent has a LIVE window recorded.
+    const first = await postTransfer(app, "usd-send", tenantId, {
+      agentId,
+      destination: DEST_A,
+      amount: "1",
+    });
+    expect(first.status).toBe(200);
+
+    // Fill the remaining 999 slots with distinct keys.
+    for (let i = 0; i < 999; i++) {
+      await postTransfer(app, "usd-send", tenantId, {
+        agentId: `flood-agent-${i}`,
+        destination: DEST_A,
+        amount: "1",
+      });
+    }
+
+    // The real agent's live window survived the flood: its next call is
+    // counted, not reset or dropped.
+    const second = await postTransfer(app, "usd-send", tenantId, {
+      agentId,
+      destination: DEST_A,
+      amount: "1",
+    });
+    expect(second.status).toBe(200);
+
+    // A NEW key beyond the cap is denied (fail closed), not tracked.
+    const overflow = await postTransfer(app, "usd-send", tenantId, {
+      agentId: "flood-agent-overflow",
+      destination: DEST_A,
+      amount: "1",
+    });
+    expect(overflow.status).toBe(429);
+    expect(usdSendCalls).toHaveLength(2);
+  });
 });
 
 describe("SEC-042: withdraw policy evaluation is real", () => {

--- a/packages/plugin-trading/src/__tests__/operator-recovery.test.ts
+++ b/packages/plugin-trading/src/__tests__/operator-recovery.test.ts
@@ -382,6 +382,48 @@ describe("operator recovery approve-builder", () => {
 });
 
 describe("operator recovery add-margin", () => {
+  it("requires idempotency keys for every operator fund movement", async () => {
+    const tenantId = `tenant-required-idempotency-${Date.now()}`;
+    const app = await buildApp();
+    const cases = [
+      {
+        path: "/v1/trade/hyperliquid/deposit",
+        body: { agentId: "missing-agent", amount: "5" },
+      },
+      {
+        path: "/v1/trade/hyperliquid/add-margin",
+        body: { agentId: "missing-agent", coin: "xyz:SPCX", amountUsdc: "1" },
+      },
+      {
+        path: "/v1/trade/hyperliquid/transfer",
+        body: {
+          agentId: "missing-agent",
+          sourceDex: "xyz",
+          destinationDex: "",
+          amountUsdc: "1",
+        },
+      },
+    ] as const;
+
+    for (const testCase of cases) {
+      const res = await app.request(testCase.path, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Steward-Platform-Key": PLATFORM_KEY,
+          "X-Steward-Tenant": tenantId,
+        },
+        body: JSON.stringify(testCase.body),
+      });
+
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({
+        ok: false,
+        error: "Idempotency-Key is required and must be at most 256 characters",
+      });
+    }
+  });
+
   it("rejects add-margin without a valid platform key", async () => {
     const app = await buildApp();
     const res = await app.request("/v1/trade/hyperliquid/add-margin", {
@@ -403,6 +445,7 @@ describe("operator recovery add-margin", () => {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
+        "Idempotency-Key": `margin-${agentId}`,
         "X-Steward-Platform-Key": PLATFORM_KEY,
         "X-Steward-Tenant": tenantId,
       },

--- a/packages/plugin-trading/src/routes/idempotency.ts
+++ b/packages/plugin-trading/src/routes/idempotency.ts
@@ -89,11 +89,13 @@ export class DurableIdempotencyStore<TRecord extends IdempotencyRecord> {
   }
 
   private sweepMemory(now: number): void {
+    // Evict EXPIRED entries only. Previously this also evicted live records
+    // oldest-first once the map hit the cap, which silently dropped replay
+    // protection for in-flight fund movements under key flooding: a retried
+    // request whose record was evicted would re-execute. Saturation with live
+    // records is handled by the claim path failing closed instead.
     for (const [entryKey, entry] of this.memory) {
-      if (entry.expiresAt <= now || this.memory.size >= MAX_MEMORY_ENTRIES) {
-        this.memory.delete(entryKey);
-      }
-      if (this.memory.size < MAX_MEMORY_ENTRIES) break;
+      if (entry.expiresAt <= now) this.memory.delete(entryKey);
     }
   }
 
@@ -245,6 +247,15 @@ export class DurableIdempotencyStore<TRecord extends IdempotencyRecord> {
           return { record: raced.record } as IdempotencyCheck<TRecord>;
         }
         this.sweepMemory(claimNow);
+        if (this.memory.size >= MAX_MEMORY_ENTRIES) {
+          // Full of LIVE records: shedding an existing entry would silently
+          // drop replay protection for an in-flight fund movement, and
+          // admitting the new key anyway would let a flood grow the map
+          // without bound. Fail closed — refuse the new claim.
+          throw new Error(
+            "Trading idempotency memory fallback is saturated with live records; refusing a new claim — configure Redis or retry after existing records expire",
+          );
+        }
         const claimToken = crypto.randomUUID();
         this.memory.set(mapKey, {
           bodyHash,

--- a/packages/plugin-trading/src/routes/operator-recovery.ts
+++ b/packages/plugin-trading/src/routes/operator-recovery.ts
@@ -219,8 +219,9 @@ export function createOperatorRecoveryRoutes(
   // REPLAYS the recorded outcome instead of re-executing a possibly-completed
   // fund movement. SEC-043: records are Redis-backed when a client is available
   // (multi-replica dedup survives restarts); without Redis the store falls back
-  // to a bounded (1_000 entries, expired-sweep only; new claims fail closed
-  // when saturated with live records) process-local map.
+  // to a bounded (1_000 entries, expired-only sweep) process-local map. When
+  // that map is full of live records, new claims fail closed rather than
+  // evicting replay protection for an earlier fund movement.
   type OperatorIdempotencyRecord = { status: 200 | 409 | 502; body: unknown };
   type OperatorIdempotency = {
     conflict?: boolean;

--- a/packages/plugin-trading/src/routes/operator-recovery.ts
+++ b/packages/plugin-trading/src/routes/operator-recovery.ts
@@ -327,14 +327,17 @@ export function createOperatorRecoveryRoutes(
     const current = operatorTransferRateLimit.get(key);
     if (!current || current.resetAt <= now) {
       if (operatorTransferRateLimit.size >= 1_000) {
+        // Expired-sweep ONLY: evicting a live window under pressure would
+        // silently reset that agent's budget. When the map stays full of live
+        // windows, fail closed (deny as rate-limited) instead of growing the
+        // process-local map without bound — a flooded distinct key always
+        // getting a fresh budget is precisely the loop this limiter exists to
+        // close when Redis is unconfigured.
         for (const [k, v] of operatorTransferRateLimit) {
           if (v.resetAt <= now) operatorTransferRateLimit.delete(k);
         }
-        // All entries may still be live. Keep the fallback strictly bounded;
-        // Map iteration order makes this an oldest-entry eviction.
         if (operatorTransferRateLimit.size >= 1_000) {
-          const oldest = operatorTransferRateLimit.keys().next().value;
-          if (oldest !== undefined) operatorTransferRateLimit.delete(oldest);
+          return { allowed: false, resetMs: OPERATOR_TRANSFER_RATE_WINDOW_MS };
         }
       }
       operatorTransferRateLimit.set(key, {

--- a/packages/plugin-trading/src/routes/operator-recovery.ts
+++ b/packages/plugin-trading/src/routes/operator-recovery.ts
@@ -219,7 +219,8 @@ export function createOperatorRecoveryRoutes(
   // REPLAYS the recorded outcome instead of re-executing a possibly-completed
   // fund movement. SEC-043: records are Redis-backed when a client is available
   // (multi-replica dedup survives restarts); without Redis the store falls back
-  // to a bounded (1_000 entries, expired-sweep + oldest-evict) process-local map.
+  // to a bounded (1_000 entries, expired-sweep only; new claims fail closed
+  // when saturated with live records) process-local map.
   type OperatorIdempotencyRecord = { status: 200 | 409 | 502; body: unknown };
   type OperatorIdempotency = {
     conflict?: boolean;

--- a/packages/plugin-trading/src/routes/operator-recovery.ts
+++ b/packages/plugin-trading/src/routes/operator-recovery.ts
@@ -756,6 +756,12 @@ export function createOperatorRecoveryRoutes(
       ...parsed.data,
       idempotencyKey: c.req.header("Idempotency-Key") ?? parsed.data.idempotencyKey,
     };
+    if (!body.idempotencyKey || body.idempotencyKey.length > 256) {
+      return c.json<ApiResponse>(
+        { ok: false, error: "Idempotency-Key is required and must be at most 256 characters" },
+        400,
+      );
+    }
     const { agentId } = body;
 
     // Parse + validate the USDC amount.
@@ -1005,6 +1011,12 @@ export function createOperatorRecoveryRoutes(
       ...parsed.data,
       idempotencyKey: c.req.header("Idempotency-Key") ?? parsed.data.idempotencyKey,
     };
+    if (!body.idempotencyKey || body.idempotencyKey.length > 256) {
+      return c.json<ApiResponse>(
+        { ok: false, error: "Idempotency-Key is required and must be at most 256 characters" },
+        400,
+      );
+    }
     const { agentId, coin } = body;
 
     if (hasTooManyUsdcDecimals(body.amountUsdc)) {
@@ -1423,6 +1435,12 @@ export function createOperatorRecoveryRoutes(
       ...parsed.data,
       idempotencyKey: c.req.header("Idempotency-Key") ?? parsed.data.idempotencyKey,
     };
+    if (!body.idempotencyKey || body.idempotencyKey.length > 256) {
+      return c.json<ApiResponse>(
+        { ok: false, error: "Idempotency-Key is required and must be at most 256 characters" },
+        400,
+      );
+    }
     const { agentId, sourceDex, destinationDex } = body;
 
     if (hasTooManyUsdcDecimals(body.amountUsdc)) {


### PR DESCRIPTION
Security re-audit residuals for plugin-trading.

- Durable idempotency fallback fails closed instead of evicting live or in-flight records when bounded local storage is saturated.
- Operator recovery rate-limit fallback likewise fails closed when all bounded windows are live.
- Redis-backed production behavior and existing durable reservation semantics remain unchanged.

Exact head: 37c988cb0012fc308d67964d950afbe11264eabb
Included develop: a7b1d566b6e09136ac7f6e723fa5e053203b3907

- focused idempotency and operator policy suites: 31/31, 86 assertions
- plugin-trading dependency build: 12/12
- Biome and diff-check: green
- independent semantic review: accept

Fresh hosted CI and required review remain merge gates.