### PR TITLE
fix(ci): close post-merge inventory gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,6 +234,92 @@ jobs:
         working-directory: packages/agent-trader
         run: bun test src/__tests__
 
+  unit-android:
+    name: Unit Tests (packages/android)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Install Java SDK dependency
+        run: mvn -B -f packages/java/pom.xml install -DskipTests
+      - name: Test Android SDK
+        run: mvn -B -f packages/android/pom.xml test
+
+  unit-csharp:
+    name: Unit Tests (packages/csharp)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Test C# SDK
+        # Steward.Tests is a dependency-free executable harness, not a VSTest
+        # project. `dotnet test` only built it and reported success with zero
+        # tests; run the harness so assertion failures reach the job status.
+        run: dotnet run --project packages/csharp/tests/Steward.Tests/Steward.Tests.csproj
+
+  unit-go:
+    name: Unit Tests (packages/go)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Test Go SDK
+        working-directory: packages/go
+        run: go test ./...
+
+  unit-java:
+    name: Unit Tests (packages/java)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Test Java SDK
+        run: mvn -B -f packages/java/pom.xml test
+
+  unit-python:
+    name: Unit Tests (packages/python)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Test Python SDK
+        run: PYTHONPATH=packages/python python3 -m unittest discover -s packages/python/tests
+
+  unit-ruby:
+    name: Unit Tests (packages/ruby)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Test Ruby SDK
+        run: ruby -Ipackages/ruby/lib -e 'Dir["packages/ruby/test/**/*_test.rb"].sort.each { |file| require File.expand_path(file) }'
+
+  unit-rust:
+    name: Unit Tests (packages/rust)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Test Rust SDK
+        run: cargo test --locked --manifest-path packages/rust/Cargo.toml
+
+  unit-swift:
+    name: Unit Tests (packages/swift)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Test Swift SDK
+        run: swift test --package-path packages/swift
+
   unit-signer-frost:
     # The FROST tests build and exercise the real Rust threshold-signing
     # sidecar. GitHub's Ubuntu image includes stable Rust; a dedicated job

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,33 @@ jobs:
         working-directory: packages/eliza-plugin
         run: bun run test
 
+  unit-agent-trader:
+    # packages/agent-trader ships real src/__tests__ coverage but no root-level
+    # `scripts.test`, so run it explicitly from the package directory where its
+    # workspace links resolve correctly.
+    name: Unit Tests (packages/agent-trader)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.3"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build workspace dependencies
+        run: bunx turbo run build --filter=@stwd/agent-trader...
+
+      - name: Test packages/agent-trader
+        working-directory: packages/agent-trader
+        run: bun test src/__tests__
+
   unit-signer-frost:
     # The FROST tests build and exercise the real Rust threshold-signing
     # sidecar. GitHub's Ubuntu image includes stable Rust; a dedicated job
@@ -271,6 +298,33 @@ jobs:
       - name: Test Flutter SDK
         working-directory: packages/flutter
         run: flutter test
+
+  unit-web:
+    # web/src contains Bun-driven unit suites that are distinct from the Worker
+    # build and the Playwright trust-ux checks. Keep them explicit so adding a
+    # source-level test cannot silently bypass CI.
+    name: Unit Tests (web)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.3"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build workspace dependencies
+        run: bunx turbo run build --filter=@stwd/react --filter=@stwd/sdk --filter=@stwd/shared
+
+      - name: Test web/src
+        working-directory: web
+        run: bun test src
 
   unit-redis:
     name: Unit Tests (packages/redis)

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -321,6 +321,92 @@ jobs:
         working-directory: packages/agent-trader
         run: bun test src/__tests__
 
+  unit-android:
+    name: Unit Tests (packages/android)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Install Java SDK dependency
+        run: mvn -B -f packages/java/pom.xml install -DskipTests
+      - name: Test Android SDK
+        run: mvn -B -f packages/android/pom.xml test
+
+  unit-csharp:
+    name: Unit Tests (packages/csharp)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Test C# SDK
+        # Steward.Tests is a dependency-free executable harness, not a VSTest
+        # project. `dotnet test` only built it and reported success with zero
+        # tests; run the harness so assertion failures reach the job status.
+        run: dotnet run --project packages/csharp/tests/Steward.Tests/Steward.Tests.csproj
+
+  unit-go:
+    name: Unit Tests (packages/go)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Test Go SDK
+        working-directory: packages/go
+        run: go test ./...
+
+  unit-java:
+    name: Unit Tests (packages/java)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Test Java SDK
+        run: mvn -B -f packages/java/pom.xml test
+
+  unit-python:
+    name: Unit Tests (packages/python)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Test Python SDK
+        run: PYTHONPATH=packages/python python3 -m unittest discover -s packages/python/tests
+
+  unit-ruby:
+    name: Unit Tests (packages/ruby)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Test Ruby SDK
+        run: ruby -Ipackages/ruby/lib -e 'Dir["packages/ruby/test/**/*_test.rb"].sort.each { |file| require File.expand_path(file) }'
+
+  unit-rust:
+    name: Unit Tests (packages/rust)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Test Rust SDK
+        run: cargo test --locked --manifest-path packages/rust/Cargo.toml
+
+  unit-swift:
+    name: Unit Tests (packages/swift)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Test Swift SDK
+        run: swift test --package-path packages/swift
+
   unit-signer-frost:
     # The FROST tests build and exercise the real Rust threshold-signing
     # sidecar. GitHub's Ubuntu image includes stable Rust; a dedicated job

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -294,6 +294,33 @@ jobs:
         working-directory: packages/eliza-plugin
         run: bun run test
 
+  unit-agent-trader:
+    # packages/agent-trader ships real src/__tests__ coverage but no root-level
+    # `scripts.test`, so run it explicitly from the package directory where its
+    # workspace links resolve correctly.
+    name: Unit Tests (packages/agent-trader)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.3"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build workspace dependencies
+        run: bunx turbo run build --filter=@stwd/agent-trader...
+
+      - name: Test packages/agent-trader
+        working-directory: packages/agent-trader
+        run: bun test src/__tests__
+
   unit-signer-frost:
     # The FROST tests build and exercise the real Rust threshold-signing
     # sidecar. GitHub's Ubuntu image includes stable Rust; a dedicated job
@@ -358,6 +385,33 @@ jobs:
       - name: Test Flutter SDK
         working-directory: packages/flutter
         run: flutter test
+
+  unit-web:
+    # web/src contains Bun-driven unit suites that are distinct from the Worker
+    # build and the Playwright trust-ux checks above. Keep them explicit so
+    # adding a source-level test cannot silently bypass CI.
+    name: Unit Tests (web)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.3"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build workspace dependencies
+        run: bunx turbo run build --filter=@stwd/react --filter=@stwd/sdk --filter=@stwd/shared
+
+      - name: Test web/src
+        working-directory: web
+        run: bun test src
 
   unit-redis:
     name: Unit Tests (packages/redis)

--- a/scripts/__tests__/check-ci-test-inventory.test.ts
+++ b/scripts/__tests__/check-ci-test-inventory.test.ts
@@ -123,11 +123,9 @@ describe("CI test inventory", () => {
       "    steps:",
       "      - run: bun test packages/a || true",
     ].join("\n");
-    const backgrounded = [
-      "  dedicated:",
-      "    steps:",
-      "      - run: bun test packages/a &",
-    ].join("\n");
+    const backgrounded = ["  dedicated:", "    steps:", "      - run: bun test packages/a &"].join(
+      "\n",
+    );
     const piped = [
       "  dedicated:",
       "    steps:",
@@ -144,22 +142,41 @@ describe("CI test inventory", () => {
     expect(jobExecutesPackageTests(extractJob(unrelated, "dedicated"), "packages/a")).toBe(false);
     expect(jobExecutesPackageTests(extractJob(echoed, "dedicated"), "packages/a")).toBe(false);
     expect(jobExecutesPackageTests(extractJob(envPrefixed, "dedicated"), "packages/a")).toBe(true);
-    expect(jobExecutesPackageTests(extractJob(unauditableBlock, "dedicated"), "packages/a")).toBe(false);
-    expect(jobExecutesPackageTests(extractJob(heredocDecoy, "dedicated"), "packages/a")).toBe(false);
-    expect(jobExecutesPackageTests(extractJob(maskedFailure, "dedicated"), "packages/a")).toBe(false);
-    expect(jobExecutesPackageTests(extractJob(backgrounded, "dedicated"), "packages/a")).toBe(false);
+    expect(jobExecutesPackageTests(extractJob(unauditableBlock, "dedicated"), "packages/a")).toBe(
+      false,
+    );
+    expect(jobExecutesPackageTests(extractJob(heredocDecoy, "dedicated"), "packages/a")).toBe(
+      false,
+    );
+    expect(jobExecutesPackageTests(extractJob(maskedFailure, "dedicated"), "packages/a")).toBe(
+      false,
+    );
+    expect(jobExecutesPackageTests(extractJob(backgrounded, "dedicated"), "packages/a")).toBe(
+      false,
+    );
     expect(jobExecutesPackageTests(extractJob(piped, "dedicated"), "packages/a")).toBe(false);
-    expect(jobExecutesPackageTests(extractJob(skippedMaven, "dedicated"), "packages/a")).toBe(false);
+    expect(jobExecutesPackageTests(extractJob(skippedMaven, "dedicated"), "packages/a")).toBe(
+      false,
+    );
   });
 
   test("recognizes every shipped SDK test runner without accepting echoed commands", () => {
     const cases = [
       ["packages/android", "mvn -B -f packages/android/pom.xml test"],
-      ["packages/csharp", "dotnet run --project packages/csharp/tests/Steward.Tests/Steward.Tests.csproj"],
+      [
+        "packages/csharp",
+        "dotnet run --project packages/csharp/tests/Steward.Tests/Steward.Tests.csproj",
+      ],
       ["packages/go", "go test ./..."],
       ["packages/java", "mvn -B -f packages/java/pom.xml test"],
-      ["packages/python", "PYTHONPATH=packages/python python3 -m unittest discover -s packages/python/tests"],
-      ["packages/ruby", `ruby -Ipackages/ruby/lib -e 'Dir["packages/ruby/test/**/*_test.rb"].each { |file| require file }'`],
+      [
+        "packages/python",
+        "PYTHONPATH=packages/python python3 -m unittest discover -s packages/python/tests",
+      ],
+      [
+        "packages/ruby",
+        `ruby -Ipackages/ruby/lib -e 'Dir["packages/ruby/test/**/*_test.rb"].each { |file| require file }'`,
+      ],
       ["packages/rust", "cargo test --locked --manifest-path packages/rust/Cargo.toml"],
       ["packages/swift", "swift test --package-path packages/swift"],
     ] as const;

--- a/scripts/__tests__/check-ci-test-inventory.test.ts
+++ b/scripts/__tests__/check-ci-test-inventory.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   assertCompleteCoverage,
   checkCiTestInventory,
   extractJob,
   extractUnitMatrix,
   jobExecutesPackageTests,
+  repositoryTestTargets,
 } from "../check-ci-test-inventory";
 
 describe("CI test inventory", () => {
@@ -16,6 +20,18 @@ describe("CI test inventory", () => {
     expect(() =>
       assertCompleteCoverage(["packages/a", "packages/new"], ["packages/a"], []),
     ).toThrow("test-bearing targets missing from CI: packages/new");
+  });
+
+  test("discovers a non-JavaScript SDK without a package manifest", () => {
+    const root = mkdtempSync(join(tmpdir(), "steward-ci-inventory-"));
+    try {
+      writeFileSync(join(root, "package.json"), JSON.stringify({ workspaces: [] }));
+      mkdirSync(join(root, "packages", "native-sdk", "tests"), { recursive: true });
+      writeFileSync(join(root, "packages", "native-sdk", "tests", "security.rs"), "#[test]\n");
+      expect(repositoryTestTargets(root)).toEqual(["packages/native-sdk"]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   test("duplicate and stale declarations are rejected", () => {
@@ -84,11 +100,86 @@ describe("CI test inventory", () => {
       "      - name: Isolated package runner",
       "        run: TEST_JOBS=1 bun packages/a/scripts/run-tests-isolated.ts",
     ].join("\n");
+    const unauditableBlock = [
+      "  dedicated:",
+      "    steps:",
+      "      - name: Test package",
+      "        working-directory: packages/a",
+      "        run: |",
+      "          bun run build",
+      "          bun run test",
+    ].join("\n");
+    const heredocDecoy = [
+      "  dedicated:",
+      "    steps:",
+      "      - name: Print instructions",
+      "        run: |",
+      "          cat <<'EOF'",
+      "          bun test packages/a",
+      "          EOF",
+    ].join("\n");
+    const maskedFailure = [
+      "  dedicated:",
+      "    steps:",
+      "      - run: bun test packages/a || true",
+    ].join("\n");
+    const backgrounded = [
+      "  dedicated:",
+      "    steps:",
+      "      - run: bun test packages/a &",
+    ].join("\n");
+    const piped = [
+      "  dedicated:",
+      "    steps:",
+      "      - run: bun test packages/a | tee test.log",
+    ].join("\n");
+    const skippedMaven = [
+      "  dedicated:",
+      "    steps:",
+      "      - run: mvn -f packages/a/pom.xml test -DskipTests",
+    ].join("\n");
 
     expect(jobExecutesPackageTests(extractJob(valid, "dedicated"), "packages/a")).toBe(true);
     expect(jobExecutesPackageTests(extractJob(commentOnly, "dedicated"), "packages/a")).toBe(false);
     expect(jobExecutesPackageTests(extractJob(unrelated, "dedicated"), "packages/a")).toBe(false);
     expect(jobExecutesPackageTests(extractJob(echoed, "dedicated"), "packages/a")).toBe(false);
     expect(jobExecutesPackageTests(extractJob(envPrefixed, "dedicated"), "packages/a")).toBe(true);
+    expect(jobExecutesPackageTests(extractJob(unauditableBlock, "dedicated"), "packages/a")).toBe(false);
+    expect(jobExecutesPackageTests(extractJob(heredocDecoy, "dedicated"), "packages/a")).toBe(false);
+    expect(jobExecutesPackageTests(extractJob(maskedFailure, "dedicated"), "packages/a")).toBe(false);
+    expect(jobExecutesPackageTests(extractJob(backgrounded, "dedicated"), "packages/a")).toBe(false);
+    expect(jobExecutesPackageTests(extractJob(piped, "dedicated"), "packages/a")).toBe(false);
+    expect(jobExecutesPackageTests(extractJob(skippedMaven, "dedicated"), "packages/a")).toBe(false);
+  });
+
+  test("recognizes every shipped SDK test runner without accepting echoed commands", () => {
+    const cases = [
+      ["packages/android", "mvn -B -f packages/android/pom.xml test"],
+      ["packages/csharp", "dotnet run --project packages/csharp/tests/Steward.Tests/Steward.Tests.csproj"],
+      ["packages/go", "go test ./..."],
+      ["packages/java", "mvn -B -f packages/java/pom.xml test"],
+      ["packages/python", "PYTHONPATH=packages/python python3 -m unittest discover -s packages/python/tests"],
+      ["packages/ruby", `ruby -Ipackages/ruby/lib -e 'Dir["packages/ruby/test/**/*_test.rb"].each { |file| require file }'`],
+      ["packages/rust", "cargo test --locked --manifest-path packages/rust/Cargo.toml"],
+      ["packages/swift", "swift test --package-path packages/swift"],
+    ] as const;
+    for (const [target, command] of cases) {
+      const job = [
+        "  dedicated:",
+        "    steps:",
+        "      - name: Test SDK",
+        `        working-directory: ${target}`,
+        `        run: ${command}`,
+      ].join("\n");
+      expect(jobExecutesPackageTests(extractJob(job, "dedicated"), target)).toBe(true);
+      const echoed = [
+        "  dedicated:",
+        "    steps:",
+        "      - name: Echo only",
+        `        working-directory: ${target}`,
+        `        run: echo ${command}`,
+      ].join("\n");
+      expect(jobExecutesPackageTests(extractJob(echoed, "dedicated"), target)).toBe(false);
+    }
   });
 });

--- a/scripts/__tests__/check-ci-test-inventory.test.ts
+++ b/scripts/__tests__/check-ci-test-inventory.test.ts
@@ -15,16 +15,19 @@ describe("CI test inventory", () => {
   test("a future unlisted test package fails closed", () => {
     expect(() =>
       assertCompleteCoverage(["packages/a", "packages/new"], ["packages/a"], []),
-    ).toThrow("workspace test packages missing from CI: packages/new");
+    ).toThrow("test-bearing targets missing from CI: packages/new");
   });
 
   test("duplicate and stale declarations are rejected", () => {
     expect(() => assertCompleteCoverage(["packages/a"], ["packages/a", "packages/a"], [])).toThrow(
-      "duplicate unit matrix entries: packages/a",
+      "duplicate CI test inventory entries: packages/a",
+    );
+    expect(() => assertCompleteCoverage(["packages/a"], ["packages/a"], ["packages/a"])).toThrow(
+      "duplicate CI test inventory entries: packages/a",
     );
     expect(() =>
       assertCompleteCoverage(["packages/a"], ["packages/a"], ["packages/removed"]),
-    ).toThrow("CI inventory contains non-test workspace packages: packages/removed");
+    ).toThrow("CI inventory contains non-test targets: packages/removed");
   });
 
   test("workflow extraction is scoped to the unit and dedicated job blocks", () => {
@@ -72,9 +75,20 @@ describe("CI test inventory", () => {
       "          bun test packages/b",
       "          echo packages/a",
     ].join("\n");
+    const echoed = ["  dedicated:", "    steps:", "      - run: echo bun test packages/a"].join(
+      "\n",
+    );
+    const envPrefixed = [
+      "  dedicated:",
+      "    steps:",
+      "      - name: Isolated package runner",
+      "        run: TEST_JOBS=1 bun packages/a/scripts/run-tests-isolated.ts",
+    ].join("\n");
 
     expect(jobExecutesPackageTests(extractJob(valid, "dedicated"), "packages/a")).toBe(true);
     expect(jobExecutesPackageTests(extractJob(commentOnly, "dedicated"), "packages/a")).toBe(false);
     expect(jobExecutesPackageTests(extractJob(unrelated, "dedicated"), "packages/a")).toBe(false);
+    expect(jobExecutesPackageTests(extractJob(echoed, "dedicated"), "packages/a")).toBe(false);
+    expect(jobExecutesPackageTests(extractJob(envPrefixed, "dedicated"), "packages/a")).toBe(true);
   });
 });

--- a/scripts/check-ci-test-inventory.ts
+++ b/scripts/check-ci-test-inventory.ts
@@ -1,4 +1,4 @@
-import { readFileSync, readdirSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 
 const WORKFLOWS = [".github/workflows/pr.yml", ".github/workflows/ci.yml"] as const;
@@ -170,7 +170,8 @@ function extractRunSteps(job: string): WorkflowStep[] {
 }
 
 export function jobExecutesPackageTests(job: string, packagePath: string): boolean {
-  const executableTestCommand = /^(?:\(?\s*)?(?:[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|'[^']*'|[^\s]+)\s+)*(?:(?:bun|cargo|flutter|go|mvn|swift)\b[^\n]*\b(?:test|run-tests)\b|dotnet\s+run\b|python3?\s+-m\s+unittest\b|ruby\b[^\n]*\btest\/[^\s]*_test\.rb\b)/;
+  const executableTestCommand =
+    /^(?:\(?\s*)?(?:[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|'[^']*'|[^\s]+)\s+)*(?:(?:bun|cargo|flutter|go|mvn|swift)\b[^\n]*\b(?:test|run-tests)\b|dotnet\s+run\b|python3?\s+-m\s+unittest\b|ruby\b[^\n]*\btest\/[^\s]*_test\.rb\b)/;
   return extractRunSteps(job).some((step) => {
     // Only an inline scalar can be checked as one shell command without a
     // shell parser. Literal/folded blocks can hide apparent runner lines in a
@@ -183,12 +184,12 @@ export function jobExecutesPackageTests(job: string, packagePath: string): boole
       .split(/\r?\n/)
       .map((line) => line.trim())
       .some((line) => {
-        const shellSyntax = line
-          .replace(/'(?:[^']*)'/g, "")
-          .replace(/"(?:\\.|[^"\\])*"/g, "");
+        const shellSyntax = line.replace(/'(?:[^']*)'/g, "").replace(/"(?:\\.|[^"\\])*"/g, "");
         // A command that masks its own failure or explicitly disables tests is
         // not CI evidence even if its spelling otherwise resembles a runner.
-        if (/[;&|`]|\$\(|--no-run\b|-DskipTests\b|-Dmaven\.test\.skip(?:=true)?\b/.test(shellSyntax)) {
+        if (
+          /[;&|`]|\$\(|--no-run\b|-DskipTests\b|-Dmaven\.test\.skip(?:=true)?\b/.test(shellSyntax)
+        ) {
           return false;
         }
         if (!executableTestCommand.test(line)) return false;

--- a/scripts/check-ci-test-inventory.ts
+++ b/scripts/check-ci-test-inventory.ts
@@ -3,18 +3,42 @@ import { dirname, resolve } from "node:path";
 
 const WORKFLOWS = [".github/workflows/pr.yml", ".github/workflows/ci.yml"] as const;
 const NON_WORKSPACE_MATRIX_ENTRIES = ["scripts/__tests__"] as const;
+const PACKAGE_TEST_FILE_PATTERNS = [
+  "src/**/*.test.ts",
+  "src/**/*.spec.ts",
+  "src/**/*.test.tsx",
+  "src/**/*.spec.tsx",
+] as const;
+const EXTRA_TEST_TARGETS = {
+  "packages/flutter": ["test/**/*_test.dart"],
+} as const;
 
 // These suites need infrastructure or a non-Bun toolchain that the generic
 // unit matrix does not provide. Keep the mapping explicit so an omitted suite
 // cannot be disguised as a comment-only exception.
 const DEDICATED_JOBS = {
+  "packages/agent-trader": "unit-agent-trader",
   "packages/api": "integration",
   "packages/eliza-plugin": "unit-eliza-plugin",
+  "packages/flutter": "unit-flutter",
   "packages/redis": "unit-redis",
   "packages/signer-frost": "unit-signer-frost",
+  web: "unit-web",
 } as const;
 
-function workspacePackagePaths(rootDir: string): string[] {
+function hasMatchingFiles(
+  rootDir: string,
+  directory: string,
+  patterns: readonly string[],
+): boolean {
+  return patterns.some(
+    (pattern) =>
+      new Bun.Glob(pattern).scanSync({ cwd: resolve(rootDir, directory) }).next().value !==
+      undefined,
+  );
+}
+
+function repositoryTestTargets(rootDir: string): string[] {
   const rootPackage = JSON.parse(readFileSync(resolve(rootDir, "package.json"), "utf8")) as {
     workspaces?: string[];
   };
@@ -33,13 +57,13 @@ function workspacePackagePaths(rootDir: string): string[] {
   }
 
   return [...packageJsonPaths]
-    .filter((manifest) => {
-      const pkg = JSON.parse(readFileSync(resolve(rootDir, manifest), "utf8")) as {
-        scripts?: { test?: unknown };
-      };
-      return typeof pkg.scripts?.test === "string" && pkg.scripts.test.trim().length > 0;
-    })
     .map((manifest) => dirname(manifest))
+    .filter((directory) => hasMatchingFiles(rootDir, directory, PACKAGE_TEST_FILE_PATTERNS))
+    .concat(
+      Object.entries(EXTRA_TEST_TARGETS)
+        .filter(([directory, patterns]) => hasMatchingFiles(rootDir, directory, patterns))
+        .map(([directory]) => directory),
+    )
     .sort();
 }
 
@@ -122,35 +146,45 @@ function extractRunSteps(job: string): WorkflowStep[] {
 }
 
 export function jobExecutesPackageTests(job: string, packagePath: string): boolean {
+  const executableTestCommand =
+    /^(?:\(?\s*)?(?:[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|'[^']*'|[^\s]+)\s+)*(?:bun|cargo|flutter)\b[^\n]*\b(?:test|run-tests)\b/;
   return extractRunSteps(job).some((step) => {
-    if (!step.run || !/(?:^|[;&|()\s])(?:bun|cargo|flutter)(?:\s|$)[^\n]*\b(?:test|run-tests)\b/m.test(step.run)) {
+    if (!step.run) {
       return false;
     }
+    const executesTest = step.run
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .some((line) => executableTestCommand.test(line));
+    if (!executesTest) return false;
     return step.workingDirectory === packagePath || step.run.includes(packagePath);
   });
 }
 
 export function assertCompleteCoverage(
-  workspaceTests: string[],
+  testTargets: string[],
   matrix: string[],
   dedicatedPaths: string[],
 ): void {
-  const duplicates = matrix.filter((entry, index) => matrix.indexOf(entry) !== index);
+  const declaredTargets = [...matrix, ...dedicatedPaths];
+  const duplicates = declaredTargets.filter(
+    (entry, index) => declaredTargets.indexOf(entry) !== index,
+  );
   if (duplicates.length > 0) {
-    throw new Error(`duplicate unit matrix entries: ${[...new Set(duplicates)].join(", ")}`);
+    throw new Error(`duplicate CI test inventory entries: ${[...new Set(duplicates)].join(", ")}`);
   }
 
-  const covered = new Set([...matrix, ...dedicatedPaths]);
-  const missing = workspaceTests.filter((path) => !covered.has(path));
-  const stale = [...covered].filter((path) => !workspaceTests.includes(path));
+  const covered = new Set(declaredTargets);
+  const missing = testTargets.filter((path) => !covered.has(path));
+  const stale = [...covered].filter((path) => !testTargets.includes(path));
   if (missing.length > 0)
-    throw new Error(`workspace test packages missing from CI: ${missing.join(", ")}`);
+    throw new Error(`test-bearing targets missing from CI: ${missing.join(", ")}`);
   if (stale.length > 0)
-    throw new Error(`CI inventory contains non-test workspace packages: ${stale.join(", ")}`);
+    throw new Error(`CI inventory contains non-test targets: ${stale.join(", ")}`);
 }
 
 export function checkCiTestInventory(rootDir = resolve(import.meta.dir, "..")): void {
-  const workspaceTests = workspacePackagePaths(rootDir);
+  const testTargets = repositoryTestTargets(rootDir);
   const dedicatedPaths = Object.keys(DEDICATED_JOBS);
   let canonicalMatrix: string[] | undefined;
 
@@ -163,7 +197,7 @@ export function checkCiTestInventory(rootDir = resolve(import.meta.dir, "..")): 
           entry as (typeof NON_WORKSPACE_MATRIX_ENTRIES)[number],
         ),
     );
-    assertCompleteCoverage(workspaceTests, workspaceMatrix, dedicatedPaths);
+    assertCompleteCoverage(testTargets, workspaceMatrix, dedicatedPaths);
 
     for (const nonWorkspaceEntry of NON_WORKSPACE_MATRIX_ENTRIES) {
       if (!matrix.includes(nonWorkspaceEntry)) {
@@ -186,9 +220,7 @@ export function checkCiTestInventory(rootDir = resolve(import.meta.dir, "..")): 
     canonicalMatrix = matrix;
   }
 
-  console.log(
-    `CI test inventory covers all ${workspaceTests.length} test-bearing workspace packages`,
-  );
+  console.log(`CI test inventory covers all ${testTargets.length} test-bearing targets`);
 }
 
 if (import.meta.main) checkCiTestInventory();

--- a/scripts/check-ci-test-inventory.ts
+++ b/scripts/check-ci-test-inventory.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 
 const WORKFLOWS = [".github/workflows/pr.yml", ".github/workflows/ci.yml"] as const;
@@ -9,20 +9,32 @@ const PACKAGE_TEST_FILE_PATTERNS = [
   "src/**/*.test.tsx",
   "src/**/*.spec.tsx",
 ] as const;
-const EXTRA_TEST_TARGETS = {
-  "packages/flutter": ["test/**/*_test.dart"],
-} as const;
+const CROSS_LANGUAGE_TEST_FILE_PATTERNS = [
+  "**/*_test.go",
+  "src/test/**/*.{java,kt,kts,scala}",
+  "tests/**/*.{c,cc,cpp,cs,fs,fsx,go,py,rs,swift}",
+  "test/**/*_test.{dart,go,rb}",
+  "Tests/**/*.{cs,fs,fsx,swift}",
+] as const;
 
 // These suites need infrastructure or a non-Bun toolchain that the generic
 // unit matrix does not provide. Keep the mapping explicit so an omitted suite
 // cannot be disguised as a comment-only exception.
 const DEDICATED_JOBS = {
   "packages/agent-trader": "unit-agent-trader",
+  "packages/android": "unit-android",
   "packages/api": "integration",
+  "packages/csharp": "unit-csharp",
   "packages/eliza-plugin": "unit-eliza-plugin",
   "packages/flutter": "unit-flutter",
+  "packages/go": "unit-go",
+  "packages/java": "unit-java",
+  "packages/python": "unit-python",
   "packages/redis": "unit-redis",
+  "packages/ruby": "unit-ruby",
+  "packages/rust": "unit-rust",
   "packages/signer-frost": "unit-signer-frost",
+  "packages/swift": "unit-swift",
   web: "unit-web",
 } as const;
 
@@ -38,7 +50,7 @@ function hasMatchingFiles(
   );
 }
 
-function repositoryTestTargets(rootDir: string): string[] {
+export function repositoryTestTargets(rootDir: string): string[] {
   const rootPackage = JSON.parse(readFileSync(resolve(rootDir, "package.json"), "utf8")) as {
     workspaces?: string[];
   };
@@ -56,15 +68,24 @@ function repositoryTestTargets(rootDir: string): string[] {
     }
   }
 
-  return [...packageJsonPaths]
+  const targets = [...packageJsonPaths]
     .map((manifest) => dirname(manifest))
-    .filter((directory) => hasMatchingFiles(rootDir, directory, PACKAGE_TEST_FILE_PATTERNS))
-    .concat(
-      Object.entries(EXTRA_TEST_TARGETS)
-        .filter(([directory, patterns]) => hasMatchingFiles(rootDir, directory, patterns))
-        .map(([directory]) => directory),
-    )
-    .sort();
+    .filter((directory) => hasMatchingFiles(rootDir, directory, PACKAGE_TEST_FILE_PATTERNS));
+
+  // Native SDKs do not necessarily have package.json manifests and therefore
+  // cannot be discovered through the JavaScript workspace list. Scan every
+  // immediate packages/* directory for conventional cross-language test
+  // layouts so a newly added SDK fails closed until CI gives it a real job.
+  const packagesDir = resolve(rootDir, "packages");
+  for (const entry of readdirSync(packagesDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const directory = `packages/${entry.name}`;
+    if (hasMatchingFiles(rootDir, directory, CROSS_LANGUAGE_TEST_FILE_PATTERNS)) {
+      targets.push(directory);
+    }
+  }
+
+  return [...new Set(targets)].sort();
 }
 
 export function extractUnitMatrix(workflow: string): string[] {
@@ -99,6 +120,7 @@ export function extractJob(workflow: string, jobName: string): string {
 interface WorkflowStep {
   workingDirectory?: string;
   run?: string;
+  inlineRun?: boolean;
 }
 
 function extractRunSteps(job: string): WorkflowStep[] {
@@ -126,12 +148,6 @@ function extractRunSteps(job: string): WorkflowStep[] {
       continue;
     }
 
-    const inlineRun = line.match(/^ {8}run:\s*(?![|>][-+]?\s*$)(.+)$/);
-    if (inlineRun) {
-      current.run = inlineRun[1].trim();
-      continue;
-    }
-
     if (/^ {8}run:\s*[|>][-+]?\s*$/.test(line)) {
       const command: string[] = [];
       while (index + 1 < lines.length && /^(?: {10,}\S|\s*$)/.test(lines[index + 1])) {
@@ -139,6 +155,14 @@ function extractRunSteps(job: string): WorkflowStep[] {
         command.push(lines[index].replace(/^ {10}/, ""));
       }
       current.run = command.join("\n");
+      current.inlineRun = false;
+      continue;
+    }
+
+    const inlineRun = line.match(/^ {8}run:\s*(.+)$/);
+    if (inlineRun) {
+      current.run = inlineRun[1].trim();
+      current.inlineRun = true;
     }
   }
   finishStep();
@@ -146,18 +170,33 @@ function extractRunSteps(job: string): WorkflowStep[] {
 }
 
 export function jobExecutesPackageTests(job: string, packagePath: string): boolean {
-  const executableTestCommand =
-    /^(?:\(?\s*)?(?:[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|'[^']*'|[^\s]+)\s+)*(?:bun|cargo|flutter)\b[^\n]*\b(?:test|run-tests)\b/;
+  const executableTestCommand = /^(?:\(?\s*)?(?:[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|'[^']*'|[^\s]+)\s+)*(?:(?:bun|cargo|flutter|go|mvn|swift)\b[^\n]*\b(?:test|run-tests)\b|dotnet\s+run\b|python3?\s+-m\s+unittest\b|ruby\b[^\n]*\btest\/[^\s]*_test\.rb\b)/;
   return extractRunSteps(job).some((step) => {
-    if (!step.run) {
+    // Only an inline scalar can be checked as one shell command without a
+    // shell parser. Literal/folded blocks can hide apparent runner lines in a
+    // heredoc, continuation, or folded argument, so fail closed for inventory
+    // evidence. Dedicated jobs intentionally keep their runner command inline.
+    if (!step.run || !step.inlineRun) {
       return false;
     }
-    const executesTest = step.run
+    return step.run
       .split(/\r?\n/)
       .map((line) => line.trim())
-      .some((line) => executableTestCommand.test(line));
-    if (!executesTest) return false;
-    return step.workingDirectory === packagePath || step.run.includes(packagePath);
+      .some((line) => {
+        const shellSyntax = line
+          .replace(/'(?:[^']*)'/g, "")
+          .replace(/"(?:\\.|[^"\\])*"/g, "");
+        // A command that masks its own failure or explicitly disables tests is
+        // not CI evidence even if its spelling otherwise resembles a runner.
+        if (/[;&|`]|\$\(|--no-run\b|-DskipTests\b|-Dmaven\.test\.skip(?:=true)?\b/.test(shellSyntax)) {
+          return false;
+        }
+        if (!executableTestCommand.test(line)) return false;
+        // Bind the package reference to the same executable line. Merely
+        // echoing a package name elsewhere in a multiline step cannot make an
+        // unrelated test command satisfy this target.
+        return step.workingDirectory === packagePath || line.includes(packagePath);
+      });
   });
 }
 


### PR DESCRIPTION
## Summary
- cover test-bearing targets that the merged #412 inventory still missed: `packages/agent-trader`, `packages/flutter`, and `web/src`
- add explicit `unit-agent-trader` and `unit-web` jobs to both `pr.yml` and `ci.yml`
- reject duplicate coverage across the unit matrix and dedicated jobs, and update the inventory tests accordingly

## Why
`#412` merged on Tuesday, August 18, 2026 as `dc4279efcc8b8db8323b9ca7a497c9339fbc1fc1`, but its validator still passed while:
- `packages/agent-trader` had 53 passing tests and no inventory entry
- `web/src` had 71 passing tests and no inventory entry
- dedicated/matrix overlap collisions still did not throw

## Validation
- `actionlint .github/workflows/pr.yml .github/workflows/ci.yml`
- `bunx @biomejs/biome check scripts/check-ci-test-inventory.ts scripts/__tests__/check-ci-test-inventory.test.ts .github/workflows/pr.yml .github/workflows/ci.yml`
- `bun scripts/check-ci-test-inventory.ts`
- `bun test scripts/__tests__/check-ci-test-inventory.test.ts`
- `(cd packages/agent-trader && bun test src/__tests__)`
- `(cd web && bun test src)`