### PR TITLE
fix(api): install bitcoin signer in production

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -56,6 +56,7 @@
       "dependencies": {
         "@aws-sdk/client-kms": "^3.700.0",
         "@hono/zod-openapi": "^1.4.0",
+        "@scure/btc-signer": "^2.2.0",
         "@stwd/adapters": "workspace:*",
         "@stwd/attestation": "workspace:*",
         "@stwd/auth": "workspace:*",
@@ -83,7 +84,6 @@
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20241218.0",
-        "@scure/btc-signer": "^2.2.0",
         "@stwd/proxy": "workspace:*",
         "@stwd/sdk": "workspace:*",
         "@types/node": "^25.5.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@aws-sdk/client-kms": "^3.700.0",
     "@hono/zod-openapi": "^1.4.0",
+    "@scure/btc-signer": "^2.2.0",
     "@stwd/adapters": "workspace:*",
     "@stwd/attestation": "workspace:*",
     "@stwd/auth": "workspace:*",
@@ -54,7 +55,6 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20241218.0",
-    "@scure/btc-signer": "^2.2.0",
     "@stwd/proxy": "workspace:*",
     "@stwd/sdk": "workspace:*",
     "@types/node": "^25.5.0",

--- a/packages/api/src/__tests__/runtime-dependencies.test.ts
+++ b/packages/api/src/__tests__/runtime-dependencies.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+interface PackageManifest {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+}
+
+describe("API production dependency closure", () => {
+  test("declares the Bitcoin policy parser as a runtime dependency", async () => {
+    const packageJson = JSON.parse(
+      readFileSync(resolve(import.meta.dir, "../../package.json"), "utf8"),
+    ) as PackageManifest;
+
+    expect(packageJson.dependencies?.["@scure/btc-signer"]).toBe("^2.2.0");
+    expect(packageJson.devDependencies?.["@scure/btc-signer"]).toBeUndefined();
+
+    const signer = await import("@scure/btc-signer");
+    expect(typeof signer.Address).toBe("function");
+  });
+});


### PR DESCRIPTION
## Summary
- declare `@scure/btc-signer` as an API runtime dependency because `policy-validation.ts` imports it in production
- synchronize the lockfile with the current merged workspace manifests
- retain the formatting repair needed for the current test-inventory checker to pass repository lint

## Failure evidence
E2E Compose run `32100474197` repeatedly crashed the API container with:

```
Cannot find module '@scure/btc-signer' from '/app/packages/api/src/services/policy-validation.ts'
```

The Docker runtime intentionally uses `bun install --production`, so a production import cannot be declared only in `devDependencies`.

## Local verification
- `bun install --frozen-lockfile`
- production-filtered install, followed by import resolution from `packages/api`
- `bun scripts/check-ci-test-inventory.ts` (all 35 currently detected test-bearing workspaces covered)
- `bun run lint` (1,273 files clean)
- focused API/proxy tests (23 passed, 0 failed)
- `git diff --check`
