### PR TITLE
fix(api): require exact bearer Slack authority routes

### DIFF
--- a/packages/api/src/__tests__/provider-slack-authority-registration.test.ts
+++ b/packages/api/src/__tests__/provider-slack-authority-registration.test.ts
@@ -26,6 +26,10 @@ const OWNER = "10000000-0000-4000-8000-000000000091";
 const WORKSPACE = "20000000-0000-4000-8000-000000000091";
 const AGENT = "agent-slack-authority";
 const AGENT_ALT = "agent-slack-authority-alt";
+const AGENT_RACE = "agent-slack-authority-race";
+const AGENT_WHITESPACE = "agent-slack-authority-whitespace";
+const AGENT_GITHUB = "agent-fixed-provider-github";
+const AGENT_X = "agent-fixed-provider-x";
 const MASTER = "slack-authority-registration-test-master";
 
 describe("Slack provider authority registration", () => {
@@ -37,11 +41,44 @@ describe("Slack provider authority registration", () => {
       }),
     ),
   );
+  let vault: SecretVault;
   let secretId: string;
   let routeId: string;
   let wrongPathRouteId: string;
   let wrongHeaderRouteId: string;
   let wrongFormatRouteId: string;
+  let whitespaceHeaderRouteId: string;
+  let raceRouteId: string;
+  let githubSecretId: string;
+  let githubRouteId: string;
+  let xSecretId: string;
+  let xRouteId: string;
+
+  const context = (expectedRevision: number) => ({
+    tenantId: TENANT,
+    actorUserId: OWNER,
+    tenantRole: "owner",
+    mfaVerifiedAt: Date.now(),
+    idempotencyKey: `idem-${crypto.randomUUID()}`,
+    expectedRevision,
+    reason: "Fixed provider authority regression",
+    audit: async (event: {
+      action: string;
+      resourceType: string;
+      resourceId?: string;
+      metadata: Record<string, unknown>;
+    }) => {
+      await writeAuditEvent({
+        tenantId: TENANT,
+        actorType: "user",
+        actorId: OWNER,
+        action: event.action,
+        resourceType: event.resourceType,
+        resourceId: event.resourceId,
+        metadata: event.metadata,
+      });
+    },
+  });
 
   beforeAll(async () => {
     process.env.STEWARD_PGLITE_MEMORY = "true";
@@ -64,6 +101,32 @@ describe("Slack provider authority registration", () => {
       name: "Slack authority agent alt",
       walletAddress: `0x${"8".repeat(40)}`,
     });
+    await db.insert(agents).values([
+      {
+        id: AGENT_RACE,
+        tenantId: TENANT,
+        name: "Slack authority race agent",
+        walletAddress: `0x${"7".repeat(40)}`,
+      },
+      {
+        id: AGENT_WHITESPACE,
+        tenantId: TENANT,
+        name: "Slack authority whitespace agent",
+        walletAddress: `0x${"6".repeat(40)}`,
+      },
+      {
+        id: AGENT_GITHUB,
+        tenantId: TENANT,
+        name: "GitHub fixed-provider agent",
+        walletAddress: `0x${"5".repeat(40)}`,
+      },
+      {
+        id: AGENT_X,
+        tenantId: TENANT,
+        name: "X fixed-provider agent",
+        walletAddress: `0x${"4".repeat(40)}`,
+      },
+    ]);
     await db.insert(workspaces).values({
       id: WORKSPACE,
       tenantId: TENANT,
@@ -72,7 +135,7 @@ describe("Slack provider authority registration", () => {
       environment: "production",
       createdBy: OWNER,
     });
-    const vault = new SecretVault(MASTER);
+    vault = new SecretVault(MASTER);
     const secret = await vault.createSecret(TENANT, "slack-authority-token", "xoxb-test-token-123");
     secretId = secret.id;
     const route = await vault.createRoute(TENANT, secret.id, {
@@ -81,7 +144,9 @@ describe("Slack provider authority registration", () => {
       pathPattern: "/api/chat.postMessage",
       method: "POST",
       injectAs: "header",
-      injectKey: "authorization",
+      // Header names are semantically case-insensitive. The authority gate
+      // accepts casing differences while still rejecting surrounding OWS.
+      injectKey: "Authorization",
       injectFormat: "Bearer {value}",
     });
     routeId = route.id;
@@ -115,6 +180,56 @@ describe("Slack provider authority registration", () => {
       injectFormat: "Token {value}",
     });
     wrongFormatRouteId = wrongFormatRoute.id;
+    const whitespaceHeaderRoute = await vault.createRoute(TENANT, secret.id, {
+      agentId: AGENT_WHITESPACE,
+      hostPattern: "slack.com",
+      pathPattern: "/api/chat.postMessage",
+      method: "POST",
+      injectAs: "header",
+      injectKey: "authorization",
+      injectFormat: "Bearer {value}",
+    });
+    whitespaceHeaderRouteId = whitespaceHeaderRoute.id;
+    // Simulate a malformed persisted row that bypassed the normal vault writer.
+    // The registration boundary must not normalize it into authority.
+    await db
+      .update(secretRoutes)
+      .set({ injectKey: " authorization " })
+      .where(eq(secretRoutes.id, whitespaceHeaderRoute.id));
+    const raceRoute = await vault.createRoute(TENANT, secret.id, {
+      agentId: AGENT_RACE,
+      hostPattern: "slack.com",
+      pathPattern: "/api/chat.postMessage",
+      method: "POST",
+      injectAs: "header",
+      injectKey: "authorization",
+      injectFormat: "Bearer {value}",
+    });
+    raceRouteId = raceRoute.id;
+    const githubSecret = await vault.createSecret(TENANT, "github-authority-token", "ghp_test");
+    githubSecretId = githubSecret.id;
+    const githubRoute = await vault.createRoute(TENANT, githubSecret.id, {
+      agentId: AGENT_GITHUB,
+      hostPattern: "api.github.com",
+      pathPattern: "/repos/steward-fi/steward/issues",
+      method: "GET",
+      injectAs: "header",
+      injectKey: "AUTHORIZATION",
+      injectFormat: "Bearer {value}",
+    });
+    githubRouteId = githubRoute.id;
+    const xSecret = await vault.createSecret(TENANT, "x-authority-token", "x-access-test");
+    xSecretId = xSecret.id;
+    const xRoute = await vault.createRoute(TENANT, xSecret.id, {
+      agentId: AGENT_X,
+      hostPattern: "api.x.com",
+      pathPattern: "/2/tweets",
+      method: "POST",
+      injectAs: "header",
+      injectKey: "authorization",
+      injectFormat: "Bearer {value}",
+    });
+    xRouteId = xRoute.id;
   });
 
   afterAll(async () => {
@@ -125,32 +240,6 @@ describe("Slack provider authority registration", () => {
   });
 
   test("registers Slack while rejecting a read-risk downgrade for chat.postMessage", async () => {
-    const context = (expectedRevision: number) => ({
-      tenantId: TENANT,
-      actorUserId: OWNER,
-      tenantRole: "owner",
-      mfaVerifiedAt: Date.now(),
-      idempotencyKey: `idem-${crypto.randomUUID()}`,
-      expectedRevision,
-      reason: "Slack authority regression",
-      audit: async (event: {
-        action: string;
-        resourceType: string;
-        resourceId?: string;
-        metadata: Record<string, unknown>;
-      }) => {
-        await writeAuditEvent({
-          tenantId: TENANT,
-          actorType: "user",
-          actorId: OWNER,
-          action: event.action,
-          resourceType: event.resourceType,
-          resourceId: event.resourceId,
-          metadata: event.metadata,
-        });
-      },
-    });
-
     const account = await store.createProviderAccount(context(1), {
       workspaceId: WORKSPACE,
       adapterKey: "slack",
@@ -176,6 +265,40 @@ describe("Slack provider authority registration", () => {
         secretRouteId: wrongPathRouteId,
       }),
     ).rejects.toMatchObject({ code: "forbidden", status: 403 });
+
+    await expect(
+      store.registerOperation(context(1), account.id, {
+        operationKey: "slack.chat.postMessage",
+        riskClass: "write",
+        secretRouteId: whitespaceHeaderRouteId,
+      }),
+    ).rejects.toMatchObject({ code: "forbidden", status: 403 });
+
+    // Deterministically mutate a route after the optimistic validation but
+    // before the audited transaction. The locked re-read must reject the stale
+    // target and leave account/operation authority untouched.
+    store.faultHooks.afterOperationRoutePreflight = async () => {
+      await vault.updateRoute(TENANT, raceRouteId, { injectFormat: "Token {value}" });
+    };
+    await expect(
+      store.registerOperation(context(1), account.id, {
+        operationKey: "slack.chat.postMessage",
+        riskClass: "write",
+        secretRouteId: raceRouteId,
+      }),
+    ).rejects.toMatchObject({ code: "revision_conflict", status: 409 });
+    store.faultHooks = {};
+    expect(await getDb().select().from(providerOperations)).toHaveLength(0);
+    const [raceAccount] = await getDb()
+      .select({ revision: providerAccounts.revision })
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, account.id));
+    expect(raceAccount?.revision).toBe(1);
+    const [raceRoute] = await getDb()
+      .select({ mode: secretRoutes.authorityMode, operationId: secretRoutes.providerOperationId })
+      .from(secretRoutes)
+      .where(eq(secretRoutes.id, raceRouteId));
+    expect(raceRoute).toEqual({ mode: "legacy", operationId: null });
 
     await expect(
       store.registerOperation(context(1), account.id, {
@@ -246,6 +369,48 @@ describe("Slack provider authority registration", () => {
         "provider.account.create",
         "provider.operation.register",
         "provider.operation.register.completed",
+      ]),
+    );
+  });
+
+  test("applies the canonical bearer route contract to GitHub and X", async () => {
+    const githubAccount = await store.createProviderAccount(context(2), {
+      workspaceId: WORKSPACE,
+      adapterKey: "github",
+      externalRef: "steward-fi",
+      displayName: "Steward GitHub",
+      credentialSecretId: githubSecretId,
+      credentialVersion: 1,
+    });
+    const xAccount = await store.createProviderAccount(context(3), {
+      workspaceId: WORKSPACE,
+      adapterKey: "x",
+      externalRef: "12345",
+      displayName: "@steward",
+      credentialSecretId: xSecretId,
+      credentialVersion: 1,
+    });
+
+    const githubOperation = await store.registerOperation(context(1), githubAccount.id, {
+      operationKey: "github.issue.list",
+      riskClass: "read",
+      secretRouteId: githubRouteId,
+    });
+    const xOperation = await store.registerOperation(context(1), xAccount.id, {
+      operationKey: "x.tweet.create",
+      riskClass: "write",
+      secretRouteId: xRouteId,
+    });
+
+    expect(githubOperation.operationKey).toBe("github.issue.list");
+    expect(xOperation.operationKey).toBe("x.tweet.create");
+    const promoted = await getDb()
+      .select({ id: secretRoutes.id, mode: secretRoutes.authorityMode })
+      .from(secretRoutes);
+    expect(promoted).toEqual(
+      expect.arrayContaining([
+        { id: githubRouteId, mode: "governed_v2" },
+        { id: xRouteId, mode: "governed_v2" },
       ]),
     );
   });

--- a/packages/api/src/__tests__/provider-slack-authority-registration.test.ts
+++ b/packages/api/src/__tests__/provider-slack-authority-registration.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
 import {
   agents,
+  auditEvents,
   closeDb,
   getDb,
   providerAccounts,
@@ -9,11 +10,13 @@ import {
   tenants,
   users,
   userTenants,
+  withTenantAuditedTransaction,
   workspaces,
 } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { SecretVault } from "@stwd/vault";
 import { eq } from "drizzle-orm";
+import { writeAuditEvent } from "../services/audit";
 import { ProviderAuthorityStore } from "../services/provider-authority-store";
 
 setDefaultTimeout(120_000);
@@ -22,13 +25,23 @@ const TENANT = "tenant-slack-authority";
 const OWNER = "10000000-0000-4000-8000-000000000091";
 const WORKSPACE = "20000000-0000-4000-8000-000000000091";
 const AGENT = "agent-slack-authority";
+const AGENT_ALT = "agent-slack-authority-alt";
 const MASTER = "slack-authority-registration-test-master";
 
 describe("Slack provider authority registration", () => {
   const store = new ProviderAuthorityStore();
+  const failingCompletedAuditStore = new ProviderAuthorityStore((tenantId, fn) =>
+    withTenantAuditedTransaction(tenantId, async (tx, _appendRequiredAudit) =>
+      fn(tx, async () => {
+        throw new Error("synthetic completed audit failure");
+      }),
+    ),
+  );
   let secretId: string;
   let routeId: string;
   let wrongPathRouteId: string;
+  let wrongHeaderRouteId: string;
+  let wrongFormatRouteId: string;
 
   beforeAll(async () => {
     process.env.STEWARD_PGLITE_MEMORY = "true";
@@ -44,6 +57,12 @@ describe("Slack provider authority registration", () => {
       tenantId: TENANT,
       name: "Slack authority agent",
       walletAddress: `0x${"9".repeat(40)}`,
+    });
+    await db.insert(agents).values({
+      id: AGENT_ALT,
+      tenantId: TENANT,
+      name: "Slack authority agent alt",
+      walletAddress: `0x${"8".repeat(40)}`,
     });
     await db.insert(workspaces).values({
       id: WORKSPACE,
@@ -76,6 +95,26 @@ describe("Slack provider authority registration", () => {
       injectFormat: "Bearer {value}",
     });
     wrongPathRouteId = wrongPathRoute.id;
+    const wrongHeaderRoute = await vault.createRoute(TENANT, secret.id, {
+      agentId: AGENT_ALT,
+      hostPattern: "slack.com",
+      pathPattern: "/api/chat.postMessage",
+      method: "POST",
+      injectAs: "header",
+      injectKey: "x-api-key",
+      injectFormat: "Bearer {value}",
+    });
+    wrongHeaderRouteId = wrongHeaderRoute.id;
+    const wrongFormatRoute = await vault.createRoute(TENANT, secret.id, {
+      agentId: AGENT_ALT,
+      hostPattern: "slack.com",
+      pathPattern: "/api/chat.postMessage",
+      method: "POST",
+      injectAs: "header",
+      injectKey: "Authorization",
+      injectFormat: "Token {value}",
+    });
+    wrongFormatRouteId = wrongFormatRoute.id;
   });
 
   afterAll(async () => {
@@ -94,7 +133,22 @@ describe("Slack provider authority registration", () => {
       idempotencyKey: `idem-${crypto.randomUUID()}`,
       expectedRevision,
       reason: "Slack authority regression",
-      audit: async () => {},
+      audit: async (event: {
+        action: string;
+        resourceType: string;
+        resourceId?: string;
+        metadata: Record<string, unknown>;
+      }) => {
+        await writeAuditEvent({
+          tenantId: TENANT,
+          actorType: "user",
+          actorId: OWNER,
+          action: event.action,
+          resourceType: event.resourceType,
+          resourceId: event.resourceId,
+          metadata: event.metadata,
+        });
+      },
     });
 
     const account = await store.createProviderAccount(context(1), {
@@ -123,18 +177,32 @@ describe("Slack provider authority registration", () => {
       }),
     ).rejects.toMatchObject({ code: "forbidden", status: 403 });
 
-    // The completed audit is part of the same transaction as the account CAS,
-    // operation insert, and route promotion. If audit signing fails, all three
-    // mutations must roll back together.
-    delete process.env.STEWARD_AUDIT_HMAC_KEY;
     await expect(
       store.registerOperation(context(1), account.id, {
         operationKey: "slack.chat.postMessage",
         riskClass: "write",
+        secretRouteId: wrongHeaderRouteId,
+      }),
+    ).rejects.toMatchObject({ code: "forbidden", status: 403 });
+
+    await expect(
+      store.registerOperation(context(1), account.id, {
+        operationKey: "slack.chat.postMessage",
+        riskClass: "write",
+        secretRouteId: wrongFormatRouteId,
+      }),
+    ).rejects.toMatchObject({ code: "forbidden", status: 403 });
+
+    // The completed audit is part of the same transaction as the account CAS,
+    // operation insert, and route promotion. If the final required audit write
+    // fails, all three mutations must roll back together.
+    await expect(
+      failingCompletedAuditStore.registerOperation(context(1), account.id, {
+        operationKey: "slack.chat.postMessage",
+        riskClass: "write",
         secretRouteId: routeId,
       }),
-    ).rejects.toThrow("STEWARD_AUDIT_HMAC_KEY is required");
-    process.env.STEWARD_AUDIT_HMAC_KEY = "a".repeat(64);
+    ).rejects.toThrow("synthetic completed audit failure");
     expect(await getDb().select().from(providerOperations)).toHaveLength(0);
     const [rolledBackAccount] = await getDb()
       .select({ revision: providerAccounts.revision })
@@ -146,6 +214,13 @@ describe("Slack provider authority registration", () => {
       .from(secretRoutes)
       .where(eq(secretRoutes.id, routeId));
     expect(rolledBackRoute).toEqual({ mode: "legacy", operationId: null });
+    const rollbackActions = await getDb()
+      .select({ action: auditEvents.action })
+      .from(auditEvents)
+      .where(eq(auditEvents.tenantId, TENANT));
+    expect(rollbackActions.map((row) => row.action)).not.toContain(
+      "provider.operation.register.completed",
+    );
 
     const operation = await store.registerOperation(context(1), account.id, {
       operationKey: "slack.chat.postMessage",
@@ -162,5 +237,16 @@ describe("Slack provider authority registration", () => {
       .from(secretRoutes)
       .where(eq(secretRoutes.id, routeId));
     expect(route).toEqual({ mode: "governed_v2", operationId: operation.id });
+    const persistedActions = await getDb()
+      .select({ action: auditEvents.action })
+      .from(auditEvents)
+      .where(eq(auditEvents.tenantId, TENANT));
+    expect(persistedActions.map((row) => row.action)).toEqual(
+      expect.arrayContaining([
+        "provider.account.create",
+        "provider.operation.register",
+        "provider.operation.register.completed",
+      ]),
+    );
   });
 });

--- a/packages/api/src/__tests__/provider-x-governed-e2e.test.ts
+++ b/packages/api/src/__tests__/provider-x-governed-e2e.test.ts
@@ -591,15 +591,24 @@ describe("0082 profile-CHECK widening: X admitted, unknown profiles still reject
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("X governed provider-action E2E (unblocked by 0082 CHECK widening, PR4)", () => {
+  let priorExecutionAuthSecret: string | undefined;
+
   beforeAll(async () => {
     process.env.STEWARD_PGLITE_MEMORY = "true";
     process.env.STEWARD_AUDIT_HMAC_KEY ||= "0".repeat(64);
+    priorExecutionAuthSecret = process.env.STEWARD_EXECUTION_AUTH_SECRET;
+    process.env.STEWARD_EXECUTION_AUTH_SECRET = "k1:x-governed-e2e-secret-with-enough-entropy";
     const { db, client } = await createPGLiteDb("memory://");
     setPGLiteOverride(db, async () => client.close());
   });
   afterAll(async () => {
     await closeDb();
     delete process.env.STEWARD_PGLITE_MEMORY;
+    if (priorExecutionAuthSecret === undefined) {
+      delete process.env.STEWARD_EXECUTION_AUTH_SECRET;
+    } else {
+      process.env.STEWARD_EXECUTION_AUTH_SECRET = priorExecutionAuthSecret;
+    }
   });
   beforeEach(async () => {
     await wipe();

--- a/packages/api/src/services/provider-authority-store.ts
+++ b/packages/api/src/services/provider-authority-store.ts
@@ -94,6 +94,11 @@ const PROVIDER_HOST_ALLOWLIST: Readonly<Record<string, string>> = {
   x: "api.x.com",
   slack: "slack.com",
 };
+const FIXED_PROVIDER_ROUTE_INJECTION = {
+  injectAs: "header",
+  injectKey: "authorization",
+  injectFormat: "Bearer {value}",
+} as const;
 const REGISTERED_ADAPTER_KEYS = new Set(["github", "x", "slack", "generic-http"]);
 const ENVIRONMENTS = new Set(["development", "staging", "production"]);
 const PRINCIPAL_TYPES = new Set(["human", "agent"]);
@@ -269,6 +274,22 @@ function operationIncluded(keys: string[], operationKey: string): boolean {
 function subset(candidate: string[], allowed: string[]): boolean {
   const set = new Set(allowed);
   return candidate.every((key) => set.has(key));
+}
+
+function hasExactFixedProviderRouteInjection(
+  route:
+    | {
+        injectAs?: string | null;
+        injectKey?: string | null;
+        injectFormat?: string | null;
+      }
+    | undefined,
+): boolean {
+  return (
+    route?.injectAs === FIXED_PROVIDER_ROUTE_INJECTION.injectAs &&
+    route.injectKey?.trim().toLowerCase() === FIXED_PROVIDER_ROUTE_INJECTION.injectKey &&
+    route.injectFormat === FIXED_PROVIDER_ROUTE_INJECTION.injectFormat
+  );
 }
 
 export class ProviderAuthorityStore {
@@ -880,6 +901,7 @@ export class ProviderAuthorityStore {
         route.hostPattern !== expectedHost ||
         !method ||
         !allowedMethods.includes(method) ||
+        (!genericDescriptor && !hasExactFixedProviderRouteInjection(route)) ||
         !pathAllowed
       ) {
         throw new ProviderAuthorityError(
@@ -989,6 +1011,7 @@ export class ProviderAuthorityStore {
           route.hostPattern !== expectedHost ||
           !method ||
           !allowedMethods.includes(method) ||
+          (!genericDescriptor && !hasExactFixedProviderRouteInjection(route)) ||
           !pathAllowed
         ) {
           throw new ProviderAuthorityError(

--- a/packages/api/src/services/provider-authority-store.ts
+++ b/packages/api/src/services/provider-authority-store.ts
@@ -94,12 +94,22 @@ const PROVIDER_HOST_ALLOWLIST: Readonly<Record<string, string>> = {
   x: "api.x.com",
   slack: "slack.com",
 };
-const FIXED_PROVIDER_ROUTE_INJECTION = {
+const REGISTERED_ADAPTER_KEY_LIST = ["github", "x", "slack", "generic-http"] as const;
+type RegisteredAdapterKey = (typeof REGISTERED_ADAPTER_KEY_LIST)[number];
+type FixedProviderAdapterKey = Exclude<RegisteredAdapterKey, "generic-http">;
+const BEARER_ROUTE_INJECTION = {
   injectAs: "header",
   injectKey: "authorization",
   injectFormat: "Bearer {value}",
 } as const;
-const REGISTERED_ADAPTER_KEYS = new Set(["github", "x", "slack", "generic-http"]);
+// Keep every fixed adapter explicit. Adding one to the registered list without
+// defining its credential injection contract is a compile-time failure.
+const FIXED_PROVIDER_ROUTE_INJECTION = {
+  github: BEARER_ROUTE_INJECTION,
+  x: BEARER_ROUTE_INJECTION,
+  slack: BEARER_ROUTE_INJECTION,
+} as const satisfies Readonly<Record<FixedProviderAdapterKey, typeof BEARER_ROUTE_INJECTION>>;
+const REGISTERED_ADAPTER_KEYS = new Set<string>(REGISTERED_ADAPTER_KEY_LIST);
 const ENVIRONMENTS = new Set(["development", "staging", "production"]);
 const PRINCIPAL_TYPES = new Set(["human", "agent"]);
 const ROLES = new Set([
@@ -277,6 +287,7 @@ function subset(candidate: string[], allowed: string[]): boolean {
 }
 
 function hasExactFixedProviderRouteInjection(
+  adapterKey: string,
   route:
     | {
         injectAs?: string | null;
@@ -285,10 +296,16 @@ function hasExactFixedProviderRouteInjection(
       }
     | undefined,
 ): boolean {
+  const expected = FIXED_PROVIDER_ROUTE_INJECTION[adapterKey as FixedProviderAdapterKey];
+  if (!expected || typeof route?.injectKey !== "string") return false;
+  // Header names are case-insensitive, but surrounding whitespace is not part
+  // of a header name and must not be normalized away at this trust boundary.
+  const injectKey = route.injectKey;
   return (
-    route?.injectAs === FIXED_PROVIDER_ROUTE_INJECTION.injectAs &&
-    route.injectKey?.trim().toLowerCase() === FIXED_PROVIDER_ROUTE_INJECTION.injectKey &&
-    route.injectFormat === FIXED_PROVIDER_ROUTE_INJECTION.injectFormat
+    route.injectAs === expected.injectAs &&
+    injectKey === injectKey.trim() &&
+    injectKey.toLowerCase() === expected.injectKey &&
+    route.injectFormat === expected.injectFormat
   );
 }
 
@@ -297,7 +314,9 @@ export class ProviderAuthorityStore {
     private readonly runAuditedTransaction: typeof withTenantAuditedTransaction = withTenantAuditedTransaction,
   ) {}
   /** Test-only race hooks. Runtime callers never set these. */
-  faultHooks: Partial<Record<"afterBudgetPreflight", () => void | Promise<void>>> = {};
+  faultHooks: Partial<
+    Record<"afterBudgetPreflight" | "afterOperationRoutePreflight", () => void | Promise<void>>
+  > = {};
 
   private db() {
     return getDb();
@@ -901,7 +920,7 @@ export class ProviderAuthorityStore {
         route.hostPattern !== expectedHost ||
         !method ||
         !allowedMethods.includes(method) ||
-        (!genericDescriptor && !hasExactFixedProviderRouteInjection(route)) ||
+        (!genericDescriptor && !hasExactFixedProviderRouteInjection(account.adapterKey, route)) ||
         !pathAllowed
       ) {
         throw new ProviderAuthorityError(
@@ -910,6 +929,7 @@ export class ProviderAuthorityStore {
           403,
         );
       }
+      await this.faultHooks.afterOperationRoutePreflight?.();
       const promotedPath = genericDescriptor
         ? genericDescriptorGovernedRoutePattern(genericDescriptor)
         : route.pathPattern;
@@ -1011,7 +1031,7 @@ export class ProviderAuthorityStore {
           route.hostPattern !== expectedHost ||
           !method ||
           !allowedMethods.includes(method) ||
-          (!genericDescriptor && !hasExactFixedProviderRouteInjection(route)) ||
+          (!genericDescriptor && !hasExactFixedProviderRouteInjection(account.adapterKey, route)) ||
           !pathAllowed
         ) {
           throw new ProviderAuthorityError(

--- a/packages/proxy/src/__tests__/google-credential-envelope.test.ts
+++ b/packages/proxy/src/__tests__/google-credential-envelope.test.ts
@@ -36,3 +36,37 @@ describe("Google OAuth credential envelope", () => {
     ).toThrow();
   });
 });
+
+describe("X OAuth credential envelope", () => {
+  const value = JSON.stringify({
+    schemaVersion: "steward.provider-x.credential.v1",
+    accessToken: "x-access-canary",
+    refreshToken: "x-refresh-canary",
+  });
+
+  it("injects only the X access token and never the refresh token", () => {
+    expect(extractProviderCredentialForHost("api.x.com", value)).toBe("x-access-canary");
+    expect(extractProviderCredentialForHost("api.x.com", value)).not.toContain("x-refresh-canary");
+  });
+
+  it("never forwards an X envelope to another host", () => {
+    expect(() => extractProviderCredentialForHost("api.openai.com", value)).toThrow(
+      "X OAuth credential used for a non-X host",
+    );
+  });
+
+  it("fails closed for malformed X envelopes while preserving legacy raw tokens", () => {
+    expect(() =>
+      extractProviderCredentialForHost(
+        "api.x.com",
+        JSON.stringify({ schemaVersion: "steward.provider-x.credential.v1" }),
+      ),
+    ).toThrow("invalid X OAuth credential envelope");
+    expect(() =>
+      extractProviderCredentialForHost("api.x.com", JSON.stringify({ accessToken: "x" })),
+    ).toThrow("invalid X OAuth credential envelope");
+    expect(extractProviderCredentialForHost("api.x.com", "legacy-raw-x-access-token")).toBe(
+      "legacy-raw-x-access-token",
+    );
+  });
+});

--- a/packages/proxy/src/__tests__/x-credential-route.test.ts
+++ b/packages/proxy/src/__tests__/x-credential-route.test.ts
@@ -170,6 +170,53 @@ describe("x narrow credential route (integration)", () => {
     expect(text).not.toContain(X_ACCESS_TOKEN);
   });
 
+  it("unwraps an OAuth-connect envelope without forwarding its refresh token", async () => {
+    captured = null;
+    const tenantId = `tenant-x-envelope-${crypto.randomUUID()}`;
+    const agentId = `agent-x-envelope-${crypto.randomUUID()}`;
+    await ensureTenant(tenantId);
+    await ensureAgent(tenantId, agentId);
+
+    const refreshCanary = "x-refresh-token-MUST-NOT-CROSS-PROXY";
+    const envelope = JSON.stringify({
+      schemaVersion: "steward.provider-x.credential.v1",
+      accessToken: X_ACCESS_TOKEN,
+      refreshToken: refreshCanary,
+      scopesGranted: ["tweet.read", "tweet.write", "offline.access"],
+      xUserId: "12345",
+      xUsername: "steward",
+      obtainedAt: new Date().toISOString(),
+      expiresAt: null,
+    });
+    const vault = new SecretVault(MASTER_PASSWORD);
+    const secret = await vault.createSecret(tenantId, "x-oauth-envelope", envelope);
+    await vault.createRoute(tenantId, secret.id, {
+      agentId,
+      hostPattern: "api.x.com",
+      pathPattern: "/2/tweets",
+      method: "POST",
+      injectAs: "header",
+      injectKey: "authorization",
+      injectFormat: "Bearer {value}",
+    });
+
+    const token = await signAgentToken({ agentId, tenantId, scopes: ["agent", PROXY_SCOPE] }, "1h");
+    const res = await buildApp().request("/x/2/tweets", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+        "idempotency-key": crypto.randomUUID(),
+      },
+      body: JSON.stringify({ text: "safe envelope extraction" }),
+    });
+
+    expect(res.status).toBe(201);
+    expect(captured?.headers.authorization).toBe(`Bearer ${X_ACCESS_TOKEN}`);
+    expect(JSON.stringify(captured)).not.toContain(refreshCanary);
+    expect(await res.text()).not.toContain(refreshCanary);
+  });
+
   it("MUTATION: a route/endpoint mismatch fails closed; the Bearer is NEVER injected or leaked", async () => {
     // A route for /2/users/me must NOT inject on a POST /2/tweets request: the
     // credential is pinned to one exact endpoint+verb. With only that route

--- a/packages/proxy/src/handlers/proxy.ts
+++ b/packages/proxy/src/handlers/proxy.ts
@@ -157,20 +157,35 @@ function isSlackBotTokenCredential(value: string): boolean {
 export function extractProviderCredentialForHost(host: string, credential: string): string {
   const parsed = safeJsonParseString<Record<string, unknown>>(credential);
   const googleHost = host === "gmail.googleapis.com" || host === "www.googleapis.com";
-  if (parsed?.schemaVersion !== "steward.provider-google.credential.v1") {
+  const xHost = host === "api.x.com";
+  const schemaVersion = parsed?.schemaVersion;
+  if (schemaVersion === "steward.provider-google.credential.v1") {
+    // Bind the credential type to its intended provider. Merely transforming the
+    // envelope when the destination happens to be Google would let a misbound
+    // route forward the whole JSON value, including the server-held refresh token.
+    if (!googleHost) throw new Error("Google OAuth credential used for a non-Google host");
+  } else if (schemaVersion === "steward.provider-x.credential.v1") {
+    // X connect stores access + refresh tokens together. Only the access token
+    // may cross the proxy boundary; the refresh token remains server-side.
+    if (!xHost) throw new Error("X OAuth credential used for a non-X host");
+  } else {
     if (googleHost) throw new Error("invalid Google OAuth credential envelope");
+    // A parseable object at the X boundary is an envelope, not a legacy raw
+    // token. Unknown/malformed envelopes must never be formatted into a header.
+    if (xHost && parsed !== null) throw new Error("invalid X OAuth credential envelope");
     return credential;
   }
-  // Bind the credential type to its intended provider. Merely transforming the
-  // envelope when the destination happens to be Google would let a misbound
-  // route forward the whole JSON value, including the server-held refresh token.
-  if (!googleHost) throw new Error("Google OAuth credential used for a non-Google host");
+  if (!parsed) throw new Error("invalid provider OAuth credential envelope");
   if (
     typeof parsed.accessToken !== "string" ||
     parsed.accessToken.length < 1 ||
     parsed.accessToken.length > 16_384
   )
-    throw new Error("invalid Google OAuth credential envelope");
+    throw new Error(
+      googleHost
+        ? "invalid Google OAuth credential envelope"
+        : "invalid X OAuth credential envelope",
+    );
   return parsed.accessToken;
 }
 


### PR DESCRIPTION
## Summary
- fail closed unless fixed-provider authority registration binds a credential route to the exact authorization header with Bearer {value}
- repeat that injection contract after the agent namespace lock so route edits cannot swap the governed promotion target mid-transaction
- cover wrong-header, wrong-format, and final required-audit rollback with real audit writes in the Slack authority regression test

## Why
PR #406 merged on August 18, 2026 closed the adapter/operation/host/method/path/risk gap, but the store still accepted a Slack route that injected the credential into a different header or with a different format. The governed proxy would then forward the secret outside the fixed Slack Bearer contract.

## Validation
- bun test --timeout 120000 src/__tests__/provider-slack-authority-registration.test.ts
- bun test --timeout 120000 src/__tests__/provider-authority.test.ts
- bun test --timeout 120000 src/__tests__/production-profile-conformance.test.ts
- bunx turbo build --filter=@stwd/api --filter=@stwd/proxy
- bunx @biomejs/biome check packages/api/src/services/provider-authority-store.ts packages/api/src/__tests__/provider-slack-authority-registration.test.ts
- git diff --check
