### PR TITLE
fix(security): preserve ambiguous cross-rail counters

### DIFF
--- a/packages/api/src/__tests__/transaction-stats-chain-scope.test.ts
+++ b/packages/api/src/__tests__/transaction-stats-chain-scope.test.ts
@@ -150,8 +150,9 @@ describe("getTransactionStats chain scoping (issue #110)", () => {
     const combined = (BigInt(ETH_SPEND) + BigInt(SOL_SPEND)).toString();
     expect(stats.spentToday.toString()).toBe(combined);
     expect(stats.spentThisWeek.toString()).toBe(combined);
-    // Counts remain agent-wide (chain-agnostic) regardless of chain scoping.
-    expect(stats.recentTxCount24h).toBe(2);
+    // Counts remain agent-wide (chain-agnostic) regardless of chain scoping and
+    // include the two active operator transfers seeded above.
+    expect(stats.recentTxCount24h).toBe(4);
   });
 
   it("returns pending and final operator USDC separately from native-chain spend", async () => {
@@ -161,6 +162,14 @@ describe("getTransactionStats chain scoping (issue #110)", () => {
     // Released reservations are reusable and therefore no longer consume cap.
     expect(stats.additionalUsdSpentTodayMicros).not.toBe(960_000_000n);
     expect(stats.spentToday.toString()).toBe(ETH_SPEND);
+  });
+
+  it("counts pending and final operator transfers in core rate limits", async () => {
+    const stats = await getTransactionStats(AGENT_ID, ETH_MAINNET);
+    expect(stats.recentTxCount1h).toBe(4);
+    expect(stats.recentTxCount24h).toBe(4);
+    // The released reservation is excluded from both counters.
+    expect(stats.recentTxCount24h).not.toBe(5);
   });
 });
 

--- a/packages/api/src/services/context.ts
+++ b/packages/api/src/services/context.ts
@@ -626,6 +626,20 @@ export async function getTransactionStats(agentId: string, chainId?: number) {
     .select({
       recentTxCount1h: sql<number>`count(*) filter (where ${transactions.createdAt} >= ${oneHourAgoStr}::timestamptz)`,
       recentTxCount24h: sql<number>`count(*) filter (where ${transactions.createdAt} >= ${oneDayAgoStr}::timestamptz)`,
+      operatorTxCount1h: sql<number>`
+        (select count(*)
+         from ${operatorTransferReservations}
+         where ${operatorTransferReservations.agentId} = ${agentId}
+           and ${operatorTransferReservations.createdAt} >= ${oneHourAgoStr}::timestamptz
+           and ${operatorTransferReservations.status} in ('pending', 'final'))
+      `,
+      operatorTxCount24h: sql<number>`
+        (select count(*)
+         from ${operatorTransferReservations}
+         where ${operatorTransferReservations.agentId} = ${agentId}
+           and ${operatorTransferReservations.createdAt} >= ${oneDayAgoStr}::timestamptz
+           and ${operatorTransferReservations.status} in ('pending', 'final'))
+      `,
       spentToday: sql<string>`
         coalesce(
           sum(
@@ -669,8 +683,8 @@ export async function getTransactionStats(agentId: string, chainId?: number) {
     );
 
   return {
-    recentTxCount1h: Number(stats?.recentTxCount1h ?? 0),
-    recentTxCount24h: Number(stats?.recentTxCount24h ?? 0),
+    recentTxCount1h: Number(stats?.recentTxCount1h ?? 0) + Number(stats?.operatorTxCount1h ?? 0),
+    recentTxCount24h: Number(stats?.recentTxCount24h ?? 0) + Number(stats?.operatorTxCount24h ?? 0),
     spentToday: BigInt(stats?.spentToday ?? "0"),
     spentThisWeek: BigInt(stats?.spentThisWeek ?? "0"),
     additionalUsdSpentTodayMicros: BigInt(stats?.additionalUsdSpentTodayMicros ?? "0"),

--- a/packages/plugin-trading/src/__tests__/operator-recovery-policy-gates.test.ts
+++ b/packages/plugin-trading/src/__tests__/operator-recovery-policy-gates.test.ts
@@ -486,6 +486,71 @@ describe("SEC-042: withdraw policy evaluation is real", () => {
     expect(body.reason).toContain("Hourly tx limit");
     expect(signWithdrawCalls).toHaveLength(0);
   });
+
+  it("keeps an outcome-unknown core transfer in operator rate counters", async () => {
+    const { tenantId, agentId } = await seedAgent({
+      policies: [
+        { type: "approved-addresses", config: { mode: "whitelist", addresses: [DEST_A] } },
+        { type: "rate-limit", config: { maxTxPerHour: 1, maxTxPerDay: 100 } },
+      ],
+    });
+    await getDb()
+      .insert(transactions)
+      .values({
+        id: `tx_unknown_rate_${agentId}`,
+        agentId,
+        status: "outcome_unknown",
+        toAddress: DEST_A,
+        value: "1000000",
+        chainId: ARBITRUM_CHAIN_ID,
+        signedAt: new Date(),
+      });
+    signWithdrawCalls.length = 0;
+    const app = await buildApp();
+
+    const res = await postTransfer(app, "withdraw", tenantId, {
+      agentId,
+      destination: DEST_A,
+      amount: "1",
+    });
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { reason?: string }).reason).toContain("Hourly tx limit");
+    expect(signWithdrawCalls).toHaveLength(0);
+  });
+
+  it("keeps an outcome-unknown core transfer in operator USD spend", async () => {
+    const { tenantId, agentId } = await seedAgent({
+      policies: [
+        { type: "approved-addresses", config: { mode: "whitelist", addresses: [DEST_A] } },
+        { type: "spending-limit", config: { maxPerDayUsd: 100 } },
+      ],
+    });
+    await getDb()
+      .insert(transactions)
+      .values({
+        id: `tx_unknown_spend_${agentId}`,
+        agentId,
+        status: "outcome_unknown",
+        toAddress: DEST_A,
+        // $95 at the pinned $4,000/ETH quote.
+        value: "23750000000000000",
+        chainId: ARBITRUM_CHAIN_ID,
+        signedAt: new Date(),
+      });
+    signWithdrawCalls.length = 0;
+    const app = await buildApp({ priceOracle: stubPriceOracle });
+
+    const res = await postTransfer(app, "withdraw", tenantId, {
+      agentId,
+      destination: DEST_A,
+      amount: "10",
+    });
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { reason?: string }).reason).toContain(
+      "daily USD spending limit",
+    );
+    expect(signWithdrawCalls).toHaveLength(0);
+  });
 });
 
 describe("SEC-043: operator idempotency stores ambiguous outcomes", () => {

--- a/packages/plugin-trading/src/routes/operator-recovery.ts
+++ b/packages/plugin-trading/src/routes/operator-recovery.ts
@@ -404,7 +404,10 @@ export function createOperatorRecoveryRoutes(
         and(
           eq(transactions.agentId, agentId),
           gte(transactions.createdAt, oneWeekAgo),
-          sql`${transactions.status} in ('signed', 'broadcast', 'confirmed')`,
+          // A timed-out broadcast may already have landed. Keep it charged to
+          // both rate and spend counters until reconciliation proves otherwise,
+          // matching the core vault/intents accounting contract.
+          sql`${transactions.status} in ('signed', 'broadcast', 'confirmed', 'outcome_unknown')`,
         ),
       );
 


### PR DESCRIPTION
Post-merge security follow-up to #401.

Two cross-rail accounting gaps remained:

- operator admission ignored core transactions in `outcome_unknown`, allowing a possibly-landed on-chain transfer to disappear from operator USD-spend and rate counters;
- core vault/intent admission counted only core transactions for rate-limit rules, so pending/final operator transfers did not consume the same hourly/daily policy budget.

This keeps ambiguous core outcomes charged until reconciliation, and includes active operator reservations in core transaction-rate counters. Released reservations remain excluded. USD-micro spend stays separate from chain-native units.

Exact head: `aa94690160fa1d302c695e92c7077a41d7ba96aa`
Included develop: `d8293bc4733f6d11d0235758f69c3cccfc02e646`

Fresh exact-head evidence:

- operator policy gates: 18/18, 61 assertions (60-second timeout for the 1,000-entry saturation case)
- transaction stats: 8/8, 18 assertions
- advisory-lock structural suite: 1/1; 2 real-PostgreSQL cases skipped because no `DATABASE_URL` is available locally
- API/plugin dependency build: 23/23
- Biome and diff-check: green

Kept draft for fresh hosted CI and real-PostgreSQL validation.
