### PR TITLE
fix(policy): reject invalid Monero subgroup points

### DIFF
--- a/packages/policy-engine/src/__tests__/evaluators.test.ts
+++ b/packages/policy-engine/src/__tests__/evaluators.test.ts
@@ -2229,17 +2229,22 @@ describe("Malformed evaluator config fails closed instead of throwing (SEC-105)"
     }
   });
 
-  it("rejects a checksum-valid Monero address with a non-canonical public key", async () => {
-    const moneroWithZeroSpendKey =
-      "41a6wB6x6y171M4XwwjJ4F3cfT4qMmkZaM3vR2n5nhQwfoSqoFktSX9HEjQppn8ewfo9fz4hPWWfknP4jM8w14iA5GZyG6s";
-    const result = await evaluatePolicy(
-      makeAddressRule({ addresses: [moneroWithZeroSpendKey], mode: "whitelist" }),
-      makeContext({
-        request: { ...makeContext().request, to: moneroWithZeroSpendKey, chainId: 301 },
-      }),
-    );
-    expect(result.passed).toBe(false);
-    expect(result.reason).toContain("address family");
+  it("rejects checksum-valid Monero identity and torsion points in both public keys", async () => {
+    for (const address of [
+      // Identity and small-order/torsion public spend keys, respectively.
+      "41fJjQDhryD11111111111111111111111111111111116M6xLGByLYcTsbJzTVUuLSHxtbfgKyZJVBqPffpP8fm7BapnRj",
+      "41d7FXjswpK11111111111111111111111111111111116M6xLGByLYcTsbJzTVUuLSHxtbfgKyZJVBqPffpP8fm7C8GNnw",
+      // The same invalid points in the public view-key position.
+      "45AmZ2FRjuqZts5NGzb7ZXSNRuwS9MUqEeakpyEeSHsB5gg2sUQdweP11111111111111111111111111111111113vBvjU",
+      "45AmZ2FRjuqZts5NGzb7ZXSNRuwS9MUqEeakpyEeSHsB5gdqPbvp2VV111111111111111111111111111111111179TEUy",
+    ]) {
+      const result = await evaluatePolicy(
+        makeAddressRule({ addresses: [address], mode: "whitelist" }),
+        makeContext({ request: { ...makeContext().request, to: address, chainId: 301 } }),
+      );
+      expect(result.passed).toBe(false);
+      expect(result.reason).toContain("address family");
+    }
   });
 
   it("filters valid mixed-family policy entries to the request chain", async () => {

--- a/packages/policy-engine/src/evaluators.ts
+++ b/packages/policy-engine/src/evaluators.ts
@@ -223,8 +223,10 @@ function isMoneroAddress(value: string, stagenet: boolean): boolean {
   const integrated = prefix === (stagenet ? 25 : 19);
   if (decoded.length !== (integrated ? 77 : 69)) return false;
   try {
-    ed25519.ExtendedPoint.fromHex(decoded.subarray(1, 33));
-    ed25519.ExtendedPoint.fromHex(decoded.subarray(33, 65));
+    for (const encodedPoint of [decoded.subarray(1, 33), decoded.subarray(33, 65)]) {
+      const point = ed25519.ExtendedPoint.fromHex(encodedPoint);
+      if (point.is0() || point.isSmallOrder() || !point.isTorsionFree()) return false;
+    }
     return true;
   } catch {
     return false;


### PR DESCRIPTION
## Security correction

Post-merge audit of #418 found that `ExtendedPoint.fromHex` validates an Ed25519 encoding but does not reject identity, small-order, or torsion-component points. A correctly checksummed Monero address could therefore pass policy validation with an invalid spend or view public key.

This correction preserves the runtime-neutral direct `@noble/curves` approach and explicitly rejects zero, small-order, and non-torsion-free points in both key positions.

## Regression coverage

- valid-checksum identity public spend key
- valid-checksum small-order/torsion public spend key
- the same two invalid points in the public view-key position
- full policy suite and canonical vault Monero suite

## Exact-head validation

- policy-engine: 490 passing tests across 15 files
- focused evaluator after final restack: 125 passing tests / 282 expectations
- vault Monero: 37 passing tests / 144 expectations
- shared, DB, vault, and policy TypeScript builds
- Biome and `git diff --check` clean