### PR TITLE
fix(provider-google): complete durable governed Google execution

### DIFF
--- a/packages/api/src/__tests__/provider-google-connect.test.ts
+++ b/packages/api/src/__tests__/provider-google-connect.test.ts
@@ -39,6 +39,8 @@ import {
   __runDefaultGoogleForwardForTests,
   __setGoogleConnectCommitHookForTests,
   __setGoogleCredentialStageHookForTests,
+  __setGoogleDisconnectJournalHookForTests,
+  __setGoogleDisconnectRevokeHookForTests,
   __setGoogleForwardForTests,
   __setGoogleRefreshIntentHookForTests,
   assertGoogleConnectStoreIsSafe,
@@ -56,6 +58,7 @@ import {
   reconcileGoogleRefreshLifecycle,
   refreshGoogleProviderCredential,
   resolveGoogleConnectConfig,
+  runGoogleCredentialLifecycleSweep,
 } from "../services/provider-google-connect";
 
 setDefaultTimeout(120_000);
@@ -300,6 +303,8 @@ afterAll(async () => {
   __setGoogleForwardForTests(null);
   __setGoogleConnectCommitHookForTests(null);
   __setGoogleCredentialStageHookForTests(null);
+  __setGoogleDisconnectJournalHookForTests(null);
+  __setGoogleDisconnectRevokeHookForTests(null);
   __setGoogleRefreshIntentHookForTests(null);
   await closeDb();
 });
@@ -308,6 +313,8 @@ afterEach(async () => {
   __setGoogleForwardForTests(null);
   __setGoogleConnectCommitHookForTests(null);
   __setGoogleCredentialStageHookForTests(null);
+  __setGoogleDisconnectJournalHookForTests(null);
+  __setGoogleDisconnectRevokeHookForTests(null);
   __setGoogleRefreshIntentHookForTests(null);
   // Reset connected accounts + credential secrets between tests.
   const db = getDb();
@@ -1272,6 +1279,52 @@ describe("refresh", () => {
     expect(fake.counters.refresh).toBe(0);
   });
 
+  test("bounded recovery freezes an intent crash without replaying the refresh token", async () => {
+    const store = new MemoryConnectStore();
+    const { completed } = await connectHappy(store);
+    const fake = installFakeX();
+    const restoreHook = __setGoogleRefreshIntentHookForTests(() => {
+      throw new Error("crash after refresh intent");
+    });
+    const refreshInput = {
+      tenantId: TENANT,
+      workspaceId: WORKSPACE,
+      accountId: completed.providerAccountId,
+      vault,
+      config: CONFIG,
+      force: true,
+    };
+    await expect(refreshGoogleProviderCredential(refreshInput)).rejects.toThrow(
+      "crash after refresh intent",
+    );
+    restoreHook();
+    const db = getDb();
+    const [lifecycle] = await db
+      .select()
+      .from(providerGoogleCredentialLifecycles)
+      .where(eq(providerGoogleCredentialLifecycles.kind, "refresh_rotation"));
+    await db
+      .update(providerGoogleCredentialLifecycles)
+      .set({ updatedAt: new Date(Date.now() - 60_000) })
+      .where(eq(providerGoogleCredentialLifecycles.id, lifecycle.id));
+
+    const result = await runGoogleCredentialLifecycleSweep({ vault, config: CONFIG });
+    expect(result.claimed).toBe(1);
+    expect(result.failed).toBe(1);
+    expect(fake.counters.refresh).toBe(0);
+    const [account] = await db
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, completed.providerAccountId));
+    expect(account.status).toBe("disabled");
+    const [recovered] = await db
+      .select()
+      .from(providerGoogleCredentialLifecycles)
+      .where(eq(providerGoogleCredentialLifecycles.id, lifecycle.id));
+    expect(recovered.state).toBe("needs_attention");
+    fake.restore();
+  });
+
   test("a rotated response that cannot be staged disables the unchanged account", async () => {
     const store = new MemoryConnectStore();
     const { completed } = await connectHappy(store);
@@ -1654,6 +1707,101 @@ describe("disconnect", () => {
 
     const events = await readAuditActions(TENANT);
     expect(events.includes("provider.google.disconnect.completed")).toBe(true);
+  });
+
+  test("journals before revoke so a disconnect crash is recoverable", async () => {
+    const store = new MemoryConnectStore();
+    const { completed } = await connectHappy(store);
+    const fake = installFakeX();
+    const restoreHook = __setGoogleDisconnectJournalHookForTests(() => {
+      throw new Error("crash after disconnect journal");
+    });
+    await expect(
+      disconnectGoogleProviderCredential({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        accountId: completed.providerAccountId,
+        callerUserId: ADMIN,
+        vault,
+        config: CONFIG,
+      }),
+    ).rejects.toThrow("crash after disconnect journal");
+    restoreHook();
+    const db = getDb();
+    const [staged] = await db
+      .select()
+      .from(providerGoogleCredentialLifecycles)
+      .where(eq(providerGoogleCredentialLifecycles.kind, "disconnect_revoke"));
+    expect(staged.state).toBe("credential_staged");
+    expect(fake.counters.revoke).toBe(0);
+    await db
+      .update(providerGoogleCredentialLifecycles)
+      .set({ updatedAt: new Date(Date.now() - 60_000) })
+      .where(eq(providerGoogleCredentialLifecycles.id, staged.id));
+
+    const result = await runGoogleCredentialLifecycleSweep({ vault, config: CONFIG });
+    expect(result.claimed).toBe(1);
+    expect(result.revoked).toBe(1);
+    expect(fake.counters.revoke).toBe(1);
+    const [account] = await db
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, completed.providerAccountId));
+    expect(account.status).toBe("revoked");
+    expect(account.credentialSecretId).toBeNull();
+    const [recovered] = await db
+      .select()
+      .from(providerGoogleCredentialLifecycles)
+      .where(eq(providerGoogleCredentialLifecycles.id, staged.id));
+    expect(recovered.state).toBe("revoked");
+    fake.restore();
+  });
+
+  test("keeps local disconnect truthful when revoke outcome is ambiguous", async () => {
+    const store = new MemoryConnectStore();
+    const { completed } = await connectHappy(store);
+    const fake = installFakeX();
+    const restoreHook = __setGoogleDisconnectRevokeHookForTests(() => {
+      throw new Error("crash after upstream revoke");
+    });
+    await expect(
+      disconnectGoogleProviderCredential({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        accountId: completed.providerAccountId,
+        callerUserId: ADMIN,
+        vault,
+        config: CONFIG,
+      }),
+    ).rejects.toThrow("crash after upstream revoke");
+    restoreHook();
+    expect(fake.counters.revoke).toBe(1);
+    const db = getDb();
+    const [accountBefore] = await db
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, completed.providerAccountId));
+    expect(accountBefore.status).toBe("active");
+    const [staged] = await db
+      .select()
+      .from(providerGoogleCredentialLifecycles)
+      .where(eq(providerGoogleCredentialLifecycles.kind, "disconnect_revoke"));
+    await db
+      .update(providerGoogleCredentialLifecycles)
+      .set({ updatedAt: new Date(Date.now() - 60_000) })
+      .where(eq(providerGoogleCredentialLifecycles.id, staged.id));
+    await runGoogleCredentialLifecycleSweep({ vault, config: CONFIG });
+    const [accountAfter] = await db
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, completed.providerAccountId));
+    expect(accountAfter.status).toBe("revoked");
+    const [recovered] = await db
+      .select()
+      .from(providerGoogleCredentialLifecycles)
+      .where(eq(providerGoogleCredentialLifecycles.id, staged.id));
+    expect(recovered.state).toBe("revoked");
+    fake.restore();
   });
 
   test("disconnect of a missing account => GOOGLE_ACCOUNT_NOT_FOUND", async () => {

--- a/packages/api/src/__tests__/provider-google-lifecycle-scheduler.test.ts
+++ b/packages/api/src/__tests__/provider-google-lifecycle-scheduler.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  getGoogleCredentialLifecycleSchedulerHealth,
+  startGoogleCredentialLifecycleScheduler,
+} from "../services/provider-google-lifecycle-scheduler";
+
+const cleanResult = {
+  claimed: 0,
+  adopted: 0,
+  revoked: 0,
+  needsAttention: 0,
+  failed: 0,
+  remaining: false,
+};
+
+const disposers: Array<() => void> = [];
+afterEach(() => {
+  while (disposers.length) disposers.pop()?.();
+});
+
+describe("Google credential lifecycle scheduler", () => {
+  test("runs an immediate bounded sweep and stops without overlap", async () => {
+    let calls = 0;
+    let concurrent = 0;
+    let peak = 0;
+    const stop = startGoogleCredentialLifecycleScheduler({
+      intervalMs: 1_000,
+      sweep: async () => {
+        calls += 1;
+        concurrent += 1;
+        peak = Math.max(peak, concurrent);
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        concurrent -= 1;
+        return cleanResult;
+      },
+    });
+    disposers.push(stop);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(calls).toBe(1);
+    expect(peak).toBe(1);
+    expect(getGoogleCredentialLifecycleSchedulerHealth().lastSucceededAt).toBeNumber();
+    stop();
+    await new Promise((resolve) => setTimeout(resolve, 1_020));
+    expect(calls).toBe(1);
+  });
+
+  test("records unresolved recovery without treating the sweep as clean", async () => {
+    const stop = startGoogleCredentialLifecycleScheduler({
+      intervalMs: 1_000,
+      sweep: async () => ({ ...cleanResult, needsAttention: 1 }),
+    });
+    disposers.push(stop);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(getGoogleCredentialLifecycleSchedulerHealth().lastError).toContain("unresolved");
+  });
+});

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -28,6 +28,7 @@ import {
   RATE_LIMIT_MAX_REQUESTS,
   RATE_LIMIT_WINDOW_MS,
 } from "./services/context";
+import { startGoogleCredentialLifecycleScheduler } from "./services/provider-google-lifecycle-scheduler";
 import { startProviderReservationReconciliationScheduler } from "./services/provider-reservation-reconciliation-scheduler";
 import { startRetentionScheduler } from "./services/retention";
 import {
@@ -83,6 +84,7 @@ const rateLimiter = new InMemoryRateLimiter(
 let isShuttingDown = false;
 let cancelRetention: (() => void) | undefined;
 let cancelProviderReservationReconciliation: (() => void) | undefined;
+let cancelGoogleCredentialLifecycleScheduler: (() => void) | undefined;
 let cancelTransactionReceiptPolling: (() => void) | undefined;
 let cancelWebhookRetryScheduler: (() => void) | undefined;
 let cancelUpstreamCredentialLeaseScheduler: (() => Promise<void>) | undefined;
@@ -355,6 +357,7 @@ if (migrationsRan) {
   if (redisOk) {
     cancelProviderReservationReconciliation = startProviderReservationReconciliationScheduler();
   }
+  cancelGoogleCredentialLifecycleScheduler = startGoogleCredentialLifecycleScheduler();
   cancelTransactionReceiptPolling = startTransactionReceiptPollingScheduler();
   cancelWebhookRetryScheduler = startWebhookRetryScheduler();
   if (capabilitiesEnabled) {
@@ -399,6 +402,7 @@ const shutdown = async (signal: string) => {
   if (nonceCleanupTimer) clearInterval(nonceCleanupTimer);
   if (cancelRetention) cancelRetention();
   if (cancelProviderReservationReconciliation) cancelProviderReservationReconciliation();
+  if (cancelGoogleCredentialLifecycleScheduler) cancelGoogleCredentialLifecycleScheduler();
   if (cancelTransactionReceiptPolling) cancelTransactionReceiptPolling();
   if (cancelWebhookRetryScheduler) cancelWebhookRetryScheduler();
   if (cancelUpstreamCredentialLeaseScheduler) await cancelUpstreamCredentialLeaseScheduler();

--- a/packages/api/src/services/provider-google-connect.ts
+++ b/packages/api/src/services/provider-google-connect.ts
@@ -254,6 +254,8 @@ export function __setGoogleForwardForTests(fn: GoogleForwardFn | null): () => vo
 let beforeConnectCommitForTests: (() => void | Promise<void>) | null = null;
 let afterGoogleCredentialStageForTests: (() => void | Promise<void>) | null = null;
 let afterGoogleRefreshIntentForTests: (() => void | Promise<void>) | null = null;
+let afterGoogleDisconnectJournalForTests: (() => void | Promise<void>) | null = null;
+let afterGoogleDisconnectRevokeForTests: (() => void | Promise<void>) | null = null;
 
 /** Inject a failure immediately before the connect audit append. Test-only. */
 export function __setGoogleConnectCommitHookForTests(
@@ -285,6 +287,26 @@ export function __setGoogleRefreshIntentHookForTests(
   afterGoogleRefreshIntentForTests = hook;
   return () => {
     afterGoogleRefreshIntentForTests = previous;
+  };
+}
+
+export function __setGoogleDisconnectJournalHookForTests(
+  hook: (() => void | Promise<void>) | null,
+): () => void {
+  const previous = afterGoogleDisconnectJournalForTests;
+  afterGoogleDisconnectJournalForTests = hook;
+  return () => {
+    afterGoogleDisconnectJournalForTests = previous;
+  };
+}
+
+export function __setGoogleDisconnectRevokeHookForTests(
+  hook: (() => void | Promise<void>) | null,
+): () => void {
+  const previous = afterGoogleDisconnectRevokeForTests;
+  afterGoogleDisconnectRevokeForTests = hook;
+  return () => {
+    afterGoogleDisconnectRevokeForTests = previous;
   };
 }
 
@@ -550,7 +572,7 @@ async function stageGoogleCredentialResponse(input: {
   tenantId: string;
   workspaceId: string;
   vault: SecretVault;
-  kind: "connect_exchange" | "refresh_rotation";
+  kind: "connect_exchange" | "refresh_rotation" | "disconnect_revoke";
   token: GoogleTokenResponse;
   providerAccountId?: string;
   expectedAccountRevision?: number;
@@ -625,6 +647,12 @@ async function setGoogleLifecycleState(
         and(
           eq(providerGoogleCredentialLifecycles.tenantId, tenantId),
           eq(providerGoogleCredentialLifecycles.id, lifecycleId),
+          inArray(providerGoogleCredentialLifecycles.state, [
+            "inflight",
+            "credential_staged",
+            "revocation_pending",
+            "needs_attention",
+          ]),
         ),
       )
       .limit(1)
@@ -663,6 +691,143 @@ async function setGoogleLifecycleState(
   });
 }
 
+/**
+ * Complete a disconnect journal only when its account revision still denotes
+ * the credential that was journaled. A reconnect racing this operation must
+ * win by revision and keep its newer active credential untouched.
+ */
+async function finalizeDisconnectLifecycle(
+  tenantId: string,
+  lifecycleId: string,
+  terminalState: "revoked" | "needs_attention" = "revoked",
+  lastErrorCode: string | null = null,
+): Promise<boolean> {
+  return withTenantAuditedTransaction(tenantId, async (txRaw, append) => {
+    const tx = txRaw as DbExecutor;
+    const [lifecycle] = await tx
+      .select()
+      .from(providerGoogleCredentialLifecycles)
+      .where(
+        and(
+          eq(providerGoogleCredentialLifecycles.tenantId, tenantId),
+          eq(providerGoogleCredentialLifecycles.id, lifecycleId),
+          eq(providerGoogleCredentialLifecycles.kind, "disconnect_revoke"),
+        ),
+      )
+      .limit(1)
+      .for("update");
+    if (!lifecycle || !lifecycle.providerAccountId || !lifecycle.credentialSecretId) return false;
+    const [account] = await tx
+      .select()
+      .from(providerAccounts)
+      .where(
+        and(
+          eq(providerAccounts.tenantId, tenantId),
+          eq(providerAccounts.id, lifecycle.providerAccountId),
+          eq(providerAccounts.workspaceId, lifecycle.workspaceId),
+        ),
+      )
+      .limit(1)
+      .for("update");
+    if (!account) return false;
+    if (account.status === "active" && account.revision !== lifecycle.expectedAccountRevision) {
+      await tx
+        .update(providerGoogleCredentialLifecycles)
+        .set({
+          state: "needs_attention",
+          lastErrorCode: "ACCOUNT_REVISION_CHANGED",
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(providerGoogleCredentialLifecycles.tenantId, tenantId),
+            eq(providerGoogleCredentialLifecycles.id, lifecycleId),
+          ),
+        );
+      return false;
+    }
+    const previousCredentialSecretId = account.credentialSecretId;
+    const [updatedAccount] = await tx
+      .update(providerAccounts)
+      .set({
+        status: "revoked",
+        credentialSecretId: null,
+        credentialVersion: null,
+        ...(account.status === "active" ? { revision: account.revision + 1 } : {}),
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(providerAccounts.tenantId, tenantId),
+          eq(providerAccounts.id, account.id),
+          ...(account.status === "active" ? [eq(providerAccounts.revision, account.revision)] : []),
+        ),
+      )
+      .returning({ id: providerAccounts.id });
+    if (!updatedAccount) return false;
+    const [updatedLifecycle] = await tx
+      .update(providerGoogleCredentialLifecycles)
+      .set({
+        state: terminalState,
+        lastErrorCode,
+        ...(terminalState === "revoked" ? { credentialSecretId: null } : {}),
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(providerGoogleCredentialLifecycles.tenantId, tenantId),
+          eq(providerGoogleCredentialLifecycles.id, lifecycleId),
+          inArray(providerGoogleCredentialLifecycles.state, [
+            "credential_staged",
+            "revocation_pending",
+            "needs_attention",
+          ]),
+        ),
+      )
+      .returning();
+    if (!updatedLifecycle) return false;
+    if (terminalState === "revoked") {
+      await tx
+        .delete(secrets)
+        .where(and(eq(secrets.tenantId, tenantId), eq(secrets.id, lifecycle.credentialSecretId)));
+    }
+    if (previousCredentialSecretId) {
+      await tx
+        .delete(secrets)
+        .where(and(eq(secrets.tenantId, tenantId), eq(secrets.id, previousCredentialSecretId)));
+    }
+    await append({
+      tenantId,
+      actorType: "system",
+      actorId: "system",
+      action:
+        terminalState === "revoked"
+          ? "provider.google.disconnect.reconciled"
+          : "provider.google.disconnect.needs_attention",
+      resourceType: "provider_account",
+      resourceId: account.id,
+      metadata: { lifecycleId, workspaceId: lifecycle.workspaceId, lastErrorCode },
+    });
+    if (terminalState === "revoked") {
+      await append({
+        tenantId,
+        actorType: "system",
+        actorId: "system",
+        action: "provider.google.disconnect.completed",
+        resourceType: "provider_account",
+        resourceId: account.id,
+        metadata: {
+          lifecycleId,
+          workspaceId: lifecycle.workspaceId,
+          reconciled: true,
+          lastErrorCode,
+        },
+      });
+    }
+    return true;
+  });
+}
+
 /** Retry a durable revocation handle. Terminal rows are strict single-use. */
 export async function reconcileGoogleCredentialRevocation(input: {
   tenantId: string;
@@ -685,7 +850,10 @@ export async function reconcileGoogleCredentialRevocation(input: {
     !row ||
     (row.state !== "revocation_pending" &&
       row.state !== "needs_attention" &&
-      !(row.kind === "connect_exchange" && row.state === "credential_staged"))
+      !(
+        (row.kind === "connect_exchange" || row.kind === "disconnect_revoke") &&
+        row.state === "credential_staged"
+      ))
   ) {
     return "already_terminal";
   }
@@ -723,6 +891,11 @@ export async function reconcileGoogleCredentialRevocation(input: {
       body: new URLSearchParams({ token, client_id: input.config.clientId }).toString(),
     });
     if (!response.ok) throw new Error("revoker rejected handle");
+    if (row.kind === "disconnect_revoke") {
+      return (await finalizeDisconnectLifecycle(input.tenantId, input.lifecycleId))
+        ? "revoked"
+        : "needs_attention";
+    }
     await setGoogleLifecycleState(input.tenantId, input.lifecycleId, "revoked");
     return "revoked";
   } catch {
@@ -2041,14 +2214,18 @@ export interface DisconnectResult {
 }
 
 /**
- * Disconnect a connected Google account: best-effort revoke at Google, degrade the account
- * (status revoked), bump revision, audit. Revocation failure at Google does NOT block
- * the local degrade — we fail CLOSED locally regardless.
+ * Disconnect a connected Google account. The encrypted revoke handle and the
+ * expected account revision commit BEFORE the upstream call, so a crash or
+ * ambiguous provider response is recoverable without leaving local authority
+ * active against an unknown upstream grant.
  */
 export async function disconnectGoogleProviderCredential(
   input: DisconnectInput,
 ): Promise<DisconnectResult> {
-  return withTenantAuditedTransaction(input.tenantId, async (txRaw, append) => {
+  let lifecycleId = "";
+  let revokeToken: { accessToken: string; refreshToken: string | null } | null = null;
+  let expectedRevision: number | null = null;
+  await withTenantAuditedTransaction(input.tenantId, async (txRaw, append) => {
     const tx = txRaw as DbExecutor;
     const [account] = await tx
       .select()
@@ -2071,64 +2248,117 @@ export async function disconnectGoogleProviderCredential(
         "provider account is not a Google account",
       );
     }
-
-    let revokedAtUpstream = false;
-    if (account.credentialSecretId) {
-      try {
-        const cred = await loadCredential(
-          input.vault,
-          input.tenantId,
-          account.credentialSecretId,
-          tx,
+    if (!account.credentialSecretId) {
+      const [degraded] = await tx
+        .update(providerAccounts)
+        .set({ status: "revoked", revision: account.revision + 1, updatedAt: new Date() })
+        .where(
+          and(
+            eq(providerAccounts.tenantId, input.tenantId),
+            eq(providerAccounts.id, account.id),
+            eq(providerAccounts.revision, account.revision),
+          ),
+        )
+        .returning({ id: providerAccounts.id, revision: providerAccounts.revision });
+      if (!degraded)
+        throw new GoogleConnectError(
+          "GOOGLE_REFRESH_FAILED",
+          409,
+          "account revision conflict on disconnect",
         );
-        revokedAtUpstream = await revokeUpstreamBestEffort(
-          cred.payload.accessToken,
-          cred.refreshToken,
-        );
-      } catch {
-        // Best-effort only. Local degrade proceeds regardless.
-        revokedAtUpstream = false;
-      }
+      await append({
+        tenantId: input.tenantId,
+        actorType: "user",
+        actorId: input.callerUserId,
+        action: "provider.google.disconnect.completed",
+        resourceType: "provider_account",
+        resourceId: account.id,
+        metadata: {
+          workspaceId: input.workspaceId,
+          revokedAtUpstream: false,
+          requestId: input.requestId ?? null,
+        },
+      });
+      return;
     }
-
-    const [degraded] = await tx
-      .update(providerAccounts)
-      .set({ status: "revoked", revision: account.revision + 1, updatedAt: new Date() })
-      .where(
-        and(
-          eq(providerAccounts.tenantId, input.tenantId),
-          eq(providerAccounts.id, account.id),
-          eq(providerAccounts.revision, account.revision),
-        ),
-      )
-      .returning();
-    if (!degraded) {
-      throw new GoogleConnectError(
-        "GOOGLE_REFRESH_FAILED",
-        409,
-        "account revision conflict on disconnect",
-      );
-    }
-
+    const cred = await loadCredential(input.vault, input.tenantId, account.credentialSecretId, tx);
+    lifecycleId = randomUUID();
+    expectedRevision = account.revision;
+    revokeToken = { accessToken: cred.payload.accessToken, refreshToken: cred.refreshToken };
+    const secret = await input.vault.createSecretWithinTx(
+      tx,
+      input.tenantId,
+      `provider-google-lifecycle:${lifecycleId}`,
+      JSON.stringify({
+        schemaVersion: "steward.provider-google.lifecycle.v1",
+        token: {
+          access_token: cred.payload.accessToken,
+          refresh_token: cred.refreshToken ?? undefined,
+        },
+      } satisfies GoogleLifecycleSecret),
+      { description: "Encrypted transient Google OAuth revocation material" },
+    );
+    await tx.insert(providerGoogleCredentialLifecycles).values({
+      id: lifecycleId,
+      tenantId: input.tenantId,
+      workspaceId: input.workspaceId,
+      providerAccountId: account.id,
+      kind: "disconnect_revoke",
+      state: "credential_staged",
+      credentialSecretId: secret.id,
+      expectedAccountRevision: account.revision,
+    });
     await append({
       tenantId: input.tenantId,
       actorType: "user",
       actorId: input.callerUserId,
-      action: "provider.google.disconnect.completed",
-      resourceType: "provider_account",
-      resourceId: account.id,
+      action: "provider.google.disconnect.intent_staged",
+      resourceType: "provider_google_credential_lifecycle",
+      resourceId: lifecycleId,
       metadata: {
         workspaceId: input.workspaceId,
-        googleUserId: account.externalRef,
-        revokedAtUpstream,
-        previousRevision: account.revision,
-        newRevision: degraded.revision,
+        providerAccountId: account.id,
         requestId: input.requestId ?? null,
       },
     });
-
-    return { providerAccountId: account.id, revoked: revokedAtUpstream };
   });
+  // Assignments made inside the transaction callback are intentionally
+  // observed only after its commit; make that boundary explicit to TypeScript.
+  const tokenToRevoke = revokeToken as {
+    accessToken: string;
+    refreshToken: string | null;
+  } | null;
+  if (!lifecycleId || !tokenToRevoke || expectedRevision === null) {
+    return { providerAccountId: input.accountId, revoked: false };
+  }
+  await afterGoogleDisconnectJournalForTests?.();
+
+  let revokedAtUpstream = false;
+  let outcomeUnknown = false;
+  try {
+    revokedAtUpstream = await revokeUpstreamBestEffort(
+      tokenToRevoke.accessToken,
+      tokenToRevoke.refreshToken,
+    );
+  } catch {
+    outcomeUnknown = true;
+  }
+  await afterGoogleDisconnectRevokeForTests?.();
+  const finalized = await finalizeDisconnectLifecycle(
+    input.tenantId,
+    lifecycleId,
+    revokedAtUpstream ? "revoked" : "needs_attention",
+    outcomeUnknown ? "REVOCATION_OUTCOME_UNKNOWN" : "REVOCATION_FAILED",
+  );
+  if (!finalized) {
+    await setGoogleLifecycleState(
+      input.tenantId,
+      lifecycleId,
+      "needs_attention",
+      "ACCOUNT_REVISION_CHANGED",
+    );
+  }
+  return { providerAccountId: input.accountId, revoked: revokedAtUpstream && finalized };
 }
 
 async function revokeUpstreamBestEffort(
@@ -2149,6 +2379,205 @@ async function revokeUpstreamBestEffort(
     body: body.toString(),
   });
   return res.ok;
+}
+
+export const GOOGLE_LIFECYCLE_SWEEP_BATCH_SIZE = 25;
+export const GOOGLE_LIFECYCLE_MAX_ATTEMPTS = 5;
+const GOOGLE_LIFECYCLE_BASE_BACKOFF_MS = 5_000;
+const GOOGLE_LIFECYCLE_MAX_BACKOFF_MS = 5 * 60_000;
+
+export interface GoogleCredentialLifecycleSweepResult {
+  claimed: number;
+  adopted: number;
+  revoked: number;
+  needsAttention: number;
+  failed: number;
+  remaining: boolean;
+}
+
+function googleLifecycleBackoffMs(attempts: number): number {
+  return Math.min(
+    GOOGLE_LIFECYCLE_MAX_BACKOFF_MS,
+    GOOGLE_LIFECYCLE_BASE_BACKOFF_MS * 2 ** Math.max(0, attempts - 1),
+  );
+}
+
+function googleLifecycleRetryableState(
+  state: string,
+): state is "inflight" | "credential_staged" | "revocation_pending" | "needs_attention" {
+  return (
+    state === "inflight" ||
+    state === "credential_staged" ||
+    state === "revocation_pending" ||
+    state === "needs_attention"
+  );
+}
+
+/**
+ * Claim and reconcile a bounded page of lifecycle rows. Claims increment the
+ * attempt counter and refresh `updatedAt` before any provider I/O; a process
+ * crash therefore leaves the row retryable after exponential backoff without
+ * allowing two schedulers to process it concurrently.
+ */
+export async function runGoogleCredentialLifecycleSweep(input: {
+  vault: SecretVault;
+  config: GoogleConnectConfig;
+  batchSize?: number;
+}): Promise<GoogleCredentialLifecycleSweepResult> {
+  const batchSize = Math.min(
+    GOOGLE_LIFECYCLE_SWEEP_BATCH_SIZE,
+    Math.max(1, Math.floor(input.batchSize ?? GOOGLE_LIFECYCLE_SWEEP_BATCH_SIZE)),
+  );
+  const db = getDb() as DbExecutor;
+  const candidates = await db
+    .select()
+    .from(providerGoogleCredentialLifecycles)
+    .where(
+      and(
+        inArray(providerGoogleCredentialLifecycles.state, [
+          "inflight",
+          "credential_staged",
+          "revocation_pending",
+          "needs_attention",
+        ]),
+        sql`${providerGoogleCredentialLifecycles.attempts} < ${GOOGLE_LIFECYCLE_MAX_ATTEMPTS}`,
+      ),
+    )
+    .orderBy(providerGoogleCredentialLifecycles.updatedAt)
+    .limit(batchSize);
+  const result: GoogleCredentialLifecycleSweepResult = {
+    claimed: 0,
+    adopted: 0,
+    revoked: 0,
+    needsAttention: 0,
+    failed: 0,
+    remaining: candidates.length >= batchSize,
+  };
+  for (const candidate of candidates) {
+    const claimed = await withTenantAuditedTransaction(
+      candidate.tenantId,
+      async (txRaw, append) => {
+        const tx = txRaw as DbExecutor;
+        const [row] = await tx
+          .select()
+          .from(providerGoogleCredentialLifecycles)
+          .where(
+            and(
+              eq(providerGoogleCredentialLifecycles.tenantId, candidate.tenantId),
+              eq(providerGoogleCredentialLifecycles.id, candidate.id),
+            ),
+          )
+          .limit(1)
+          .for("update");
+        if (
+          !row ||
+          !googleLifecycleRetryableState(row.state) ||
+          row.attempts >= GOOGLE_LIFECYCLE_MAX_ATTEMPTS ||
+          Date.now() - row.updatedAt.getTime() < googleLifecycleBackoffMs(row.attempts)
+        ) {
+          return null;
+        }
+        const [updated] = await tx
+          .update(providerGoogleCredentialLifecycles)
+          .set({ attempts: row.attempts + 1, updatedAt: new Date() })
+          .where(
+            and(
+              eq(providerGoogleCredentialLifecycles.tenantId, row.tenantId),
+              eq(providerGoogleCredentialLifecycles.id, row.id),
+              eq(providerGoogleCredentialLifecycles.attempts, row.attempts),
+            ),
+          )
+          .returning();
+        if (!updated) return null;
+        await append({
+          tenantId: row.tenantId,
+          actorType: "system",
+          actorId: "system",
+          action: "provider.google.lifecycle.recovery_claimed",
+          resourceType: "provider_google_credential_lifecycle",
+          resourceId: row.id,
+          metadata: { kind: row.kind, attempts: updated.attempts, workspaceId: row.workspaceId },
+        });
+        return updated;
+      },
+    );
+    if (!claimed) continue;
+    result.claimed += 1;
+    try {
+      if (
+        claimed.kind === "refresh_rotation" &&
+        (claimed.state === "inflight" || claimed.state === "credential_staged") &&
+        claimed.providerAccountId
+      ) {
+        await reconcileGoogleRefreshLifecycle({
+          tenantId: claimed.tenantId,
+          workspaceId: claimed.workspaceId,
+          accountId: claimed.providerAccountId,
+          lifecycleId: claimed.id,
+          vault: input.vault,
+          config: input.config,
+        });
+        result.adopted += 1;
+      } else if (
+        claimed.kind === "refresh_rotation" &&
+        (claimed.state === "inflight" || claimed.state === "credential_staged")
+      ) {
+        result.needsAttention += 1;
+        await setGoogleLifecycleState(
+          claimed.tenantId,
+          claimed.id,
+          "needs_attention",
+          "ACCOUNT_BINDING_MISSING",
+        );
+      } else {
+        const outcome = await reconcileGoogleCredentialRevocation({
+          tenantId: claimed.tenantId,
+          lifecycleId: claimed.id,
+          vault: input.vault,
+          config: input.config,
+        });
+        if (outcome === "revoked") result.revoked += 1;
+        else if (outcome === "needs_attention") result.needsAttention += 1;
+      }
+    } catch (error) {
+      result.failed += 1;
+      if (
+        claimed.kind === "refresh_rotation" &&
+        claimed.state === "inflight" &&
+        claimed.providerAccountId
+      ) {
+        try {
+          await disableGoogleAccountForLifecycle(
+            {
+              tenantId: claimed.tenantId,
+              workspaceId: claimed.workspaceId,
+              accountId: claimed.providerAccountId,
+              vault: input.vault,
+              config: input.config,
+            },
+            claimed.id,
+            "RECOVERY_FAILED",
+          );
+        } catch {
+          // The lifecycle remains durable and the next sweep can retry it.
+        }
+      }
+      try {
+        // A staged refresh can have been fully compensated by its own catch
+        // path before the error reaches this boundary. Never turn an adopted
+        // or revoked terminal row back into needs_attention.
+        await setGoogleLifecycleState(
+          claimed.tenantId,
+          claimed.id,
+          "needs_attention",
+          error instanceof GoogleConnectError ? error.code : "RECOVERY_FAILED",
+        );
+      } catch {
+        // Preserve the original failure; the claimed row remains retryable.
+      }
+    }
+  }
+  return result;
 }
 
 // re-export sql for callers/tests that need raw predicates

--- a/packages/api/src/services/provider-google-lifecycle-scheduler.ts
+++ b/packages/api/src/services/provider-google-lifecycle-scheduler.ts
@@ -1,0 +1,108 @@
+import { SecretVault } from "@stwd/vault";
+import {
+  resolveGoogleConnectConfig,
+  runGoogleCredentialLifecycleSweep,
+} from "./provider-google-connect";
+
+const DEFAULT_INTERVAL_MS = 15_000;
+const MAX_INTERVAL_MS = 60_000;
+
+export interface GoogleCredentialLifecycleSchedulerHealth {
+  enabled: boolean;
+  inFlight: boolean;
+  lastStartedAt: number | null;
+  lastSucceededAt: number | null;
+  lastFailedAt: number | null;
+  lastError: string | null;
+}
+
+const health: GoogleCredentialLifecycleSchedulerHealth = {
+  enabled: false,
+  inFlight: false,
+  lastStartedAt: null,
+  lastSucceededAt: null,
+  lastFailedAt: null,
+  lastError: null,
+};
+
+export function getGoogleCredentialLifecycleSchedulerHealth(): GoogleCredentialLifecycleSchedulerHealth {
+  return { ...health };
+}
+
+function intervalMs(): number {
+  const raw = process.env.STEWARD_GOOGLE_LIFECYCLE_SWEEP_INTERVAL_MS;
+  if (raw === undefined) return DEFAULT_INTERVAL_MS;
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed < 1_000 || parsed > MAX_INTERVAL_MS) {
+    throw new Error(
+      `STEWARD_GOOGLE_LIFECYCLE_SWEEP_INTERVAL_MS must be between 1000 and ${MAX_INTERVAL_MS}`,
+    );
+  }
+  return parsed;
+}
+
+async function defaultSweep() {
+  const { MASTER_PASSWORD } = await import("./context");
+  return runGoogleCredentialLifecycleSweep({
+    vault: new SecretVault(MASTER_PASSWORD),
+    config: resolveGoogleConnectConfig(),
+  });
+}
+
+/** Start the immediate and periodic bounded Google OAuth lifecycle recovery. */
+export function startGoogleCredentialLifecycleScheduler(options?: {
+  intervalMs?: number;
+  sweep?: typeof defaultSweep;
+}): () => void {
+  if (process.env.STEWARD_GOOGLE_LIFECYCLE_SWEEPER === "false") {
+    Object.assign(health, { enabled: false, lastError: "scheduler disabled" });
+    return () => {};
+  }
+  const sweep = options?.sweep ?? defaultSweep;
+  const every = options?.intervalMs ?? intervalMs();
+  if (!Number.isSafeInteger(every) || every < 1_000 || every > MAX_INTERVAL_MS) {
+    throw new Error(
+      `Google lifecycle scheduler interval must be between 1000 and ${MAX_INTERVAL_MS}`,
+    );
+  }
+  Object.assign(health, {
+    enabled: true,
+    inFlight: false,
+    lastStartedAt: null,
+    lastSucceededAt: null,
+    lastFailedAt: null,
+    lastError: null,
+  });
+  let stopped = false;
+  let active: Promise<void> | undefined;
+  const tick = () => {
+    if (stopped || active) return;
+    health.inFlight = true;
+    health.lastStartedAt = Date.now();
+    active = sweep()
+      .then((result) => {
+        health.lastSucceededAt = Date.now();
+        health.lastError =
+          result.needsAttention > 0 || result.failed > 0
+            ? `recovery left ${result.needsAttention + result.failed} lifecycle(s) unresolved`
+            : null;
+      })
+      .catch((error) => {
+        health.lastFailedAt = Date.now();
+        health.lastError = error instanceof Error ? error.message : "unknown sweep failure";
+        console.error("[google-lifecycle] sweep failed:", error);
+      })
+      .finally(() => {
+        health.inFlight = false;
+        active = undefined;
+      });
+  };
+  const timer = setInterval(tick, every);
+  timer.unref?.();
+  tick();
+  return () => {
+    stopped = true;
+    clearInterval(timer);
+    health.enabled = false;
+  };
+}

--- a/packages/db/drizzle/0099_google_disconnect_lifecycle_kind.sql
+++ b/packages/db/drizzle/0099_google_disconnect_lifecycle_kind.sql
@@ -1,0 +1,9 @@
+-- #417: allow the durable lifecycle journal to carry a disconnect revoke handle.
+-- 0098 is already deployed on existing databases, so this constraint change is
+-- intentionally a separate migration rather than an edit to 0098.
+ALTER TABLE "provider_google_credential_lifecycles"
+  DROP CONSTRAINT "provider_google_lifecycle_kind_check";
+--> statement-breakpoint
+ALTER TABLE "provider_google_credential_lifecycles"
+  ADD CONSTRAINT "provider_google_lifecycle_kind_check"
+  CHECK ("kind" IN ('connect_exchange', 'refresh_rotation', 'disconnect_revoke'));

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -554,6 +554,13 @@
       "when": 1787020072000,
       "tag": "0098_google_credential_lifecycles",
       "breakpoints": true
+    },
+    {
+      "idx": 99,
+      "version": "7",
+      "when": 1787031494000,
+      "tag": "0099_google_disconnect_lifecycle_kind",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -2074,7 +2074,7 @@ export const providerGoogleCredentialLifecycles = pgTable(
     ),
     kindCheck: check(
       "provider_google_lifecycle_kind_check",
-      sql`${table.kind} IN ('connect_exchange', 'refresh_rotation')`,
+      sql`${table.kind} IN ('connect_exchange', 'refresh_rotation', 'disconnect_revoke')`,
     ),
     accountStateIdx: index("provider_google_lifecycle_account_state_idx").on(
       table.tenantId,


### PR DESCRIPTION
## Summary

Final corrective for merged #417 and the incomplete parallel follow-ups #426/#427.

- preserves durable connect, rotating-refresh, and disconnect lifecycle journals with encrypted staged responses, tenant/account binding, bounded claims, retry/backoff, and truthful needs_attention
- starts immediate and periodic long-lived recovery, drains clean bounded backlogs without overlap, avoids hot loops for not-yet-due or unresolved rows, waits for in-flight shutdown, and runs Worker cron recovery
- mints a fresh short-lived Google access token only at the governed execution boundary; persisted access tokens are ignored and the refresh token never crosses the provider boundary
- durably stages and adopts unexpected rotating refresh responses before use; outcome-unknown refresh disables execution instead of replaying the old token
- registers exact Gmail and Calendar host, method, path, Bearer injection, operation, and minimum-risk authority tuples under the same locked exact-route contract as the other fixed providers
- retains scope-widening rejection, recipient-domain and exact-recipient commitments, MFA and tenant/workspace gates, bounded no-redirect transport, and full authenticated profile-boundary coverage
- adds contiguous migration 0099_google_disconnect_lifecycle_kind after deployed Google lifecycle migration 0098

Closes #203

## Exact evidence

Head: be9be6f038dc10a82300426624e7b7ce534b85b7
Base/develop: 0bcfbb003ffb251a424a71549ce7bab401097df2

- Google lifecycle, scheduler, authority, Worker, execution minting, and operation suites: 66/66, 230 assertions
- authenticated production-profile boundary plus execution-mint focused run: 10/10, 88 assertions
- Google operation plus migration status: 8/8, 21 assertions
- dependency-aware provider-google/API/proxy build: 23/23
- Biome changed surfaces: clean
- git diff --check: clean

Hosted exact-head CI and independent review are required before merge.