### PR TITLE
fix(vault): bind legacy EVM custody conflicts

### DIFF
--- a/packages/vault/src/__tests__/import-key-custody.test.ts
+++ b/packages/vault/src/__tests__/import-key-custody.test.ts
@@ -312,6 +312,37 @@ describe("Vault.importKey custody hardening", () => {
     expect(provider.registrationCalls).toBe(0);
   });
 
+  test("rejects a legacy EVM key after a Solana import changes the primary wallet family", async () => {
+    const provider = new RaceTestProvider();
+    vault = await freshVault(provider);
+    const agentId = "legacy-evm-after-solana-agent";
+
+    await vault.importKey(TENANT_ID, agentId, generatePrivateKey(), "evm");
+    // Reproduce a pre-multi-wallet EVM agent: only encrypted_keys retains its
+    // EVM key. A later Solana import changes agents.walletAddress to Solana but
+    // intentionally preserves that legacy EVM row (SEC-023).
+    await getDb()
+      .delete(encryptedChainKeys)
+      .where(
+        and(eq(encryptedChainKeys.agentId, agentId), eq(encryptedChainKeys.chainFamily, "evm")),
+      );
+    await getDb()
+      .delete(agentWallets)
+      .where(and(eq(agentWallets.agentId, agentId), eq(agentWallets.chainFamily, "evm")));
+    await vault.importKey(TENANT_ID, agentId, solanaKeyHex(), "solana");
+
+    await expect(
+      vault.importExternalKeyHandle({
+        tenantId: TENANT_ID,
+        agentId,
+        chainFamily: "evm",
+        address: "0x1111111111111111111111111111111111111111",
+        handle: { providerId: "race-hsm", keyId: "must-not-be-disclosed-after-solana" },
+      }),
+    ).rejects.toThrow(/legacy server-managed key/);
+    expect(provider.registrationCalls).toBe(0);
+  });
+
   // Structural guard (PGlite serializes transactions, so the lock itself is
   // exercised but cannot interleave here): both custody transitions must take
   // the advisory lock INSIDE their transaction, before any custody check or

--- a/packages/vault/src/vault.ts
+++ b/packages/vault/src/vault.ts
@@ -2298,7 +2298,10 @@ export class Vault {
 
     // Fast-fail before the provider round-trip on the common rejection; the
     // authoritative re-check happens inside the locked transaction below.
-    if (!request.venue && detectChainType(agentRow.walletAddress) === request.chainFamily) {
+    // `encrypted_keys` is always the legacy EVM store. Do not infer its
+    // relevance from agents.walletAddress: importing a Solana key updates that
+    // primary address while deliberately preserving the legacy EVM row.
+    if (!request.venue && request.chainFamily === "evm") {
       const [legacyKey] = await db
         .select({ agentId: encryptedKeys.agentId })
         .from(encryptedKeys)
@@ -2364,7 +2367,7 @@ export class Vault {
         );
       }
 
-      if (!venue && detectChainType(agentRow.walletAddress) === request.chainFamily) {
+      if (!venue && request.chainFamily === "evm") {
         const [legacyKey] = await tx
           .select({ agentId: encryptedKeys.agentId })
           .from(encryptedKeys)


### PR DESCRIPTION
## Summary

Post-merge audit follow-up for #399.

The legacy `encrypted_keys` table is EVM-only, but external-custody conflict detection inferred whether to inspect it from the agent primary wallet address. A later Solana import can legitimately change that primary address while preserving the legacy EVM row. In that state, default-scope external EVM registration could skip both legacy checks, disclose the handle to the provider, and register external custody alongside server-managed key material.

This change:
- keys legacy-row conflict checks directly to `request.chainFamily === "evm"`
- applies the same rule before provider registration and again under the tenant-scoped advisory lock
- adds a regression for EVM legacy key -> Solana primary wallet -> external EVM registration, including proof the provider is not called

## Exact evidence

Base: `d8293bc4733f6d11d0235758f69c3cccfc02e646`
Head: `a4c25d7371638c138cbd8ace7aa5232ed29b25aa`

- `bun test --isolate packages/vault/src/__tests__/import-key-custody.test.ts` — 7 pass, 25 assertions
- `bunx turbo run build --filter=@stwd/vault... --force` — 6/6 packages successful
- `bunx biome check packages/vault/src/vault.ts packages/vault/src/__tests__/import-key-custody.test.ts` — clean
- `git diff --check` — clean

Kept draft pending hosted CI on this exact head.