### PR TITLE
fix(provider-google): recover and mint execution credentials

### DIFF
--- a/packages/api/src/__tests__/production-profile-boundary-e2e.test.ts
+++ b/packages/api/src/__tests__/production-profile-boundary-e2e.test.ts
@@ -198,6 +198,8 @@ beforeAll(async () => {
   const address = jwksServer.address();
   const port = typeof address === "object" && address ? address.port : 0;
   process.env.ELIZA_CLOUD_JWKS_URL = `http://127.0.0.1:${port}/jwks`;
+  process.env.GOOGLE_PROVIDER_CLIENT_ID = "boundary-google-client";
+  process.env.GOOGLE_PROVIDER_CLIENT_SECRET = "boundary-google-secret";
   const { clearAgentJwksCacheForTests } = await import("../middleware/agent-jwt");
   clearAgentJwksCacheForTests();
   const { resetCheckpointSignerCache } = await import("../services/audit-checkpoint");
@@ -227,6 +229,14 @@ beforeAll(async () => {
     forwardCount += 1;
     return new Response('{"ok":true}', { status: 201 });
   });
+  proxy.__setGoogleExecutionTokenForwarderForTests(async () =>
+    Response.json({
+      access_token: "profile-boundary-ephemeral-access",
+      token_type: "Bearer",
+      scope: "openid email https://www.googleapis.com/auth/calendar.readonly",
+      expires_in: 3600,
+    }),
+  );
 });
 
 beforeEach(async () => {
@@ -255,6 +265,8 @@ afterAll(async () => {
     "STEWARD_JWT_SECRET",
     "STEWARD_AUDIT_SIGNING_KEY",
     "ELIZA_CLOUD_JWKS_URL",
+    "GOOGLE_PROVIDER_CLIENT_ID",
+    "GOOGLE_PROVIDER_CLIENT_SECRET",
   ]) {
     delete process.env[key];
   }
@@ -282,7 +294,9 @@ async function runAuthenticatedBoundary(
       : fixture.profile === GOOGLE_PROVIDER_ACTION_PROFILE
         ? JSON.stringify({
             schemaVersion: "steward.provider-google.credential.v1",
-            accessToken: "profile-boundary-credential",
+            accessToken: "profile-boundary-stale-access",
+            refreshToken: "profile-boundary-refresh",
+            scopesGranted: ["openid", "email", "https://www.googleapis.com/auth/calendar.readonly"],
           })
         : "profile-boundary-credential";
   const encrypted = vault.encrypt(credential, {

--- a/packages/api/src/__tests__/provider-google-authority-registration.test.ts
+++ b/packages/api/src/__tests__/provider-google-authority-registration.test.ts
@@ -1,0 +1,181 @@
+import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
+import {
+  agents,
+  closeDb,
+  getDb,
+  providerOperations,
+  secretRoutes,
+  tenants,
+  users,
+  userTenants,
+  workspaces,
+} from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { SecretVault } from "@stwd/vault";
+import { eq } from "drizzle-orm";
+import { ProviderAuthorityStore } from "../services/provider-authority-store";
+
+setDefaultTimeout(120_000);
+
+const TENANT = "tenant-google-authority";
+const OWNER = "10000000-0000-4000-8000-000000000092";
+const WORKSPACE = "20000000-0000-4000-8000-000000000092";
+const AGENT = "agent-google-authority";
+const MASTER = "google-authority-registration-test-master";
+
+describe("Google provider authority registration", () => {
+  const store = new ProviderAuthorityStore();
+  let secretId: string;
+  let gmailRouteId: string;
+  let calendarListRouteId: string;
+  let calendarInsertRouteId: string;
+  let wrongRouteId: string;
+  let wrongInjectionRouteId: string;
+
+  beforeAll(async () => {
+    process.env.STEWARD_PGLITE_MEMORY = "true";
+    process.env.STEWARD_AUDIT_HMAC_KEY = "a".repeat(64);
+    process.env.STEWARD_MASTER_PASSWORD = MASTER;
+    const { db, client } = await createPGLiteDb("memory://");
+    setPGLiteOverride(db, async () => client.close());
+    await db.insert(tenants).values({ id: TENANT, name: TENANT, apiKeyHash: `hash-${TENANT}` });
+    await db.insert(users).values({ id: OWNER, email: "google-authority@example.test" });
+    await db.insert(userTenants).values({ userId: OWNER, tenantId: TENANT, role: "owner" });
+    await db.insert(agents).values({
+      id: AGENT,
+      tenantId: TENANT,
+      name: "Google authority agent",
+      walletAddress: `0x${"8".repeat(40)}`,
+    });
+    await db.insert(workspaces).values({
+      id: WORKSPACE,
+      tenantId: TENANT,
+      key: "google-authority",
+      name: "Google Authority",
+      environment: "production",
+      createdBy: OWNER,
+    });
+    const vault = new SecretVault(MASTER);
+    const secret = await vault.createSecret(
+      TENANT,
+      "google-authority-token",
+      JSON.stringify({
+        schemaVersion: "steward.provider-google.credential.v1",
+        accessToken: "stale-access",
+        refreshToken: "server-refresh",
+        scopesGranted: ["openid", "email", "https://www.googleapis.com/auth/gmail.send"],
+      }),
+    );
+    secretId = secret.id;
+    const createRoute = (
+      hostPattern: string,
+      pathPattern: string,
+      method: string,
+      injectKey = "authorization",
+    ) =>
+      vault.createRoute(TENANT, secret.id, {
+        agentId: AGENT,
+        hostPattern,
+        pathPattern,
+        method,
+        injectAs: "header",
+        injectKey,
+        injectFormat: "Bearer {value}",
+      });
+    gmailRouteId = (
+      await createRoute("gmail.googleapis.com", "/gmail/v1/users/me/messages/send", "POST")
+    ).id;
+    calendarListRouteId = (
+      await createRoute("www.googleapis.com", "/calendar/v3/calendars/primary/events", "GET")
+    ).id;
+    calendarInsertRouteId = (
+      await createRoute("www.googleapis.com", "/calendar/v3/calendars/primary/events", "POST")
+    ).id;
+    wrongRouteId = (
+      await createRoute("www.googleapis.com", "/drive/v3/files/attacker/export", "POST")
+    ).id;
+    wrongInjectionRouteId = (
+      await createRoute(
+        "gmail.googleapis.com",
+        "/gmail/v1/users/me/messages/send",
+        "POST",
+        "x-api-key",
+      )
+    ).id;
+  });
+
+  afterAll(async () => {
+    await closeDb();
+    delete process.env.STEWARD_PGLITE_MEMORY;
+    delete process.env.STEWARD_AUDIT_HMAC_KEY;
+    delete process.env.STEWARD_MASTER_PASSWORD;
+  });
+
+  test("registers only fixed Google host/path/method/injection tuples without risk downgrade", async () => {
+    const context = (expectedRevision: number) => ({
+      tenantId: TENANT,
+      actorUserId: OWNER,
+      tenantRole: "owner",
+      mfaVerifiedAt: Date.now(),
+      idempotencyKey: `idem-${crypto.randomUUID()}`,
+      expectedRevision,
+      reason: "Google authority regression",
+      audit: async () => {},
+    });
+    const account = await store.createProviderAccount(context(1), {
+      workspaceId: WORKSPACE,
+      adapterKey: "google",
+      externalRef: "google-user-123",
+      displayName: "Google user",
+      credentialSecretId: secretId,
+      credentialVersion: 1,
+    });
+    await expect(
+      store.registerOperation(context(1), account.id, {
+        operationKey: "google.gmail.messages.send",
+        riskClass: "read",
+        secretRouteId: gmailRouteId,
+      }),
+    ).rejects.toMatchObject({ code: "bad_request", status: 400 });
+    await expect(
+      store.registerOperation(context(1), account.id, {
+        operationKey: "google.gmail.messages.send",
+        riskClass: "write",
+        secretRouteId: wrongRouteId,
+      }),
+    ).rejects.toMatchObject({ code: "forbidden", status: 403 });
+    await expect(
+      store.registerOperation(context(1), account.id, {
+        operationKey: "google.gmail.messages.send",
+        riskClass: "write",
+        secretRouteId: wrongInjectionRouteId,
+      }),
+    ).rejects.toMatchObject({ code: "forbidden", status: 403 });
+    await getDb()
+      .update(secretRoutes)
+      .set({ enabled: false })
+      .where(eq(secretRoutes.id, wrongInjectionRouteId));
+
+    const gmail = await store.registerOperation(context(1), account.id, {
+      operationKey: "google.gmail.messages.send",
+      riskClass: "write",
+      secretRouteId: gmailRouteId,
+    });
+    const list = await store.registerOperation(context(2), account.id, {
+      operationKey: "google.calendar.events.list",
+      riskClass: "read",
+      secretRouteId: calendarListRouteId,
+    });
+    const insert = await store.registerOperation(context(3), account.id, {
+      operationKey: "google.calendar.events.insert",
+      riskClass: "write",
+      secretRouteId: calendarInsertRouteId,
+    });
+    expect([gmail.operationKey, list.operationKey, insert.operationKey]).toEqual([
+      "google.gmail.messages.send",
+      "google.calendar.events.list",
+      "google.calendar.events.insert",
+    ]);
+    expect(await getDb().select().from(providerOperations)).toHaveLength(3);
+  });
+});

--- a/packages/api/src/__tests__/provider-google-authority-registration.test.ts
+++ b/packages/api/src/__tests__/provider-google-authority-registration.test.ts
@@ -151,6 +151,15 @@ describe("Google provider authority registration", () => {
         secretRouteId: wrongInjectionRouteId,
       }),
     ).rejects.toMatchObject({ code: "forbidden", status: 403 });
+    const [rejectedRoute] = await getDb()
+      .select({
+        authorityMode: secretRoutes.authorityMode,
+        providerOperationId: secretRoutes.providerOperationId,
+      })
+      .from(secretRoutes)
+      .where(eq(secretRoutes.id, wrongInjectionRouteId));
+    expect(rejectedRoute.authorityMode).toBe("legacy");
+    expect(rejectedRoute.providerOperationId).toBeNull();
     await getDb()
       .update(secretRoutes)
       .set({ enabled: false })

--- a/packages/api/src/__tests__/provider-google-connect.test.ts
+++ b/packages/api/src/__tests__/provider-google-connect.test.ts
@@ -41,6 +41,8 @@ import {
   __runDefaultGoogleForwardForTests,
   __setGoogleConnectCommitHookForTests,
   __setGoogleCredentialStageHookForTests,
+  __setGoogleDisconnectJournalHookForTests,
+  __setGoogleDisconnectRevokeHookForTests,
   __setGoogleForwardForTests,
   __setGoogleRefreshIntentHookForTests,
   assertGoogleConnectStoreIsSafe,
@@ -310,6 +312,8 @@ afterAll(async () => {
   __setGoogleForwardForTests(null);
   __setGoogleConnectCommitHookForTests(null);
   __setGoogleCredentialStageHookForTests(null);
+  __setGoogleDisconnectJournalHookForTests(null);
+  __setGoogleDisconnectRevokeHookForTests(null);
   __setGoogleRefreshIntentHookForTests(null);
   await closeDb();
 });
@@ -318,6 +322,8 @@ afterEach(async () => {
   __setGoogleForwardForTests(null);
   __setGoogleConnectCommitHookForTests(null);
   __setGoogleCredentialStageHookForTests(null);
+  __setGoogleDisconnectJournalHookForTests(null);
+  __setGoogleDisconnectRevokeHookForTests(null);
   __setGoogleRefreshIntentHookForTests(null);
   // Reset connected accounts + credential secrets between tests.
   const db = getDb();
@@ -1690,6 +1696,126 @@ describe("disconnect", () => {
 
     const events = await readAuditActions(TENANT);
     expect(events.includes("provider.google.disconnect.completed")).toBe(true);
+  });
+
+  test("journal crash revokes local authority before scheduled upstream recovery", async () => {
+    const store = new MemoryConnectStore();
+    const { completed } = await connectHappy(store);
+    const fake = installFakeX();
+    const restoreHook = __setGoogleDisconnectJournalHookForTests(() => {
+      throw new Error("crash after disconnect journal");
+    });
+    await expect(
+      disconnectGoogleProviderCredential({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        accountId: completed.providerAccountId,
+        callerUserId: ADMIN,
+        vault,
+        config: CONFIG,
+      }),
+    ).rejects.toThrow("crash after disconnect journal");
+    restoreHook();
+    const db = getDb();
+    const [account] = await db
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, completed.providerAccountId));
+    expect(account.status).toBe("revoked");
+    expect(fake.counters.revoke).toBe(0);
+    const [pending] = await db
+      .select()
+      .from(providerGoogleCredentialLifecycles)
+      .where(eq(providerGoogleCredentialLifecycles.kind, "disconnect_revoke"));
+    expect(pending.state).toBe("revocation_pending");
+    expect(JSON.stringify(pending)).not.toContain("refresh-initial");
+    await db
+      .update(providerGoogleCredentialLifecycles)
+      .set({ updatedAt: new Date(Date.now() - 60_000) })
+      .where(eq(providerGoogleCredentialLifecycles.id, pending.id));
+    const result = await runGoogleCredentialLifecycleSweep({ vault, config: CONFIG });
+    expect(result.revoked).toBe(1);
+    expect(fake.counters.revoke).toBe(1);
+    const [recovered] = await db
+      .select()
+      .from(providerGoogleCredentialLifecycles)
+      .where(eq(providerGoogleCredentialLifecycles.id, pending.id));
+    expect(recovered.state).toBe("revoked");
+    expect(recovered.credentialSecretId).toBeNull();
+    fake.restore();
+  });
+
+  test("post-revoke crash stays locally revoked and retries without terminal rollback", async () => {
+    const store = new MemoryConnectStore();
+    const { completed } = await connectHappy(store);
+    const fake = installFakeX();
+    const restoreHook = __setGoogleDisconnectRevokeHookForTests(() => {
+      throw new Error("crash after upstream revoke");
+    });
+    await expect(
+      disconnectGoogleProviderCredential({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        accountId: completed.providerAccountId,
+        callerUserId: ADMIN,
+        vault,
+        config: CONFIG,
+      }),
+    ).rejects.toThrow("crash after upstream revoke");
+    restoreHook();
+    const db = getDb();
+    const [account] = await db
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, completed.providerAccountId));
+    expect(account.status).toBe("revoked");
+    expect(fake.counters.revoke).toBe(1);
+    const [pending] = await db
+      .select()
+      .from(providerGoogleCredentialLifecycles)
+      .where(eq(providerGoogleCredentialLifecycles.kind, "disconnect_revoke"));
+    await db
+      .update(providerGoogleCredentialLifecycles)
+      .set({ updatedAt: new Date(Date.now() - 60_000) })
+      .where(eq(providerGoogleCredentialLifecycles.id, pending.id));
+    const result = await runGoogleCredentialLifecycleSweep({ vault, config: CONFIG });
+    expect(result.revoked).toBe(1);
+    expect(fake.counters.revoke).toBe(2);
+    const [terminal] = await db
+      .select()
+      .from(providerGoogleCredentialLifecycles)
+      .where(eq(providerGoogleCredentialLifecycles.id, pending.id));
+    expect(terminal.state).toBe("revoked");
+    fake.restore();
+  });
+
+  test("reconnect cannot race a pending disconnect revoker", async () => {
+    const store = new MemoryConnectStore();
+    const { completed } = await connectHappy(store);
+    const fake = installFakeX();
+    const restoreHook = __setGoogleDisconnectJournalHookForTests(() => {
+      throw new Error("crash after disconnect journal");
+    });
+    await expect(
+      disconnectGoogleProviderCredential({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        accountId: completed.providerAccountId,
+        callerUserId: ADMIN,
+        vault,
+        config: CONFIG,
+      }),
+    ).rejects.toThrow("crash after disconnect journal");
+    restoreHook();
+    fake.restore();
+    await expect(connectHappy(new MemoryConnectStore())).rejects.toMatchObject({
+      code: "GOOGLE_CREDENTIAL_NEEDS_ATTENTION",
+    });
+    const [account] = await getDb()
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, completed.providerAccountId));
+    expect(account.status).toBe("revoked");
   });
 
   test("disconnect of a missing account => GOOGLE_ACCOUNT_NOT_FOUND", async () => {

--- a/packages/api/src/__tests__/provider-google-connect.test.ts
+++ b/packages/api/src/__tests__/provider-google-connect.test.ts
@@ -19,12 +19,14 @@ import {
   test,
 } from "bun:test";
 import {
+  agents,
   auditEvents as auditEventsTable,
   closeDb,
   getDb,
   providerAccounts,
   providerGoogleCredentialLifecycles,
   providerRoleBindings,
+  secretRoutes,
   secrets,
   tenants,
   users,
@@ -56,6 +58,7 @@ import {
   reconcileGoogleRefreshLifecycle,
   refreshGoogleProviderCredential,
   resolveGoogleConnectConfig,
+  runGoogleCredentialLifecycleSweep,
 } from "../services/provider-google-connect";
 
 setDefaultTimeout(120_000);
@@ -68,6 +71,7 @@ const VIEWER = "10000000-0000-4000-8000-0000000000a3";
 const OUTSIDER = "10000000-0000-4000-8000-0000000000a4";
 const WORKSPACE = "20000000-0000-4000-8000-0000000000b1";
 const WORKSPACE_OTHER = "20000000-0000-4000-8000-0000000000b2";
+const AGENT = "agent-google-connect-test";
 const ADMIN_BINDING = "30000000-0000-4000-8000-0000000000c1";
 const APPROVER_BINDING = "30000000-0000-4000-8000-0000000000c2";
 const VIEWER_BINDING = "30000000-0000-4000-8000-0000000000c3";
@@ -227,6 +231,12 @@ async function seed() {
     { userId: VIEWER, tenantId: TENANT, role: "member" },
     // OUTSIDER is deliberately NOT a tenant member.
   ]);
+  await db.insert(agents).values({
+    id: AGENT,
+    tenantId: TENANT,
+    name: "Google connect test agent",
+    walletAddress: `0x${"7".repeat(40)}`,
+  });
   await db.insert(workspaces).values([
     {
       id: WORKSPACE,
@@ -587,13 +597,12 @@ describe("connect", () => {
     expect(JSON.stringify(encryptedHandle)).not.toContain("refresh-initial");
     expect(await vault.decryptSecret(TENANT, encryptedHandle.id)).toContain("refresh-initial");
     await expect(
-      reconcileGoogleCredentialRevocation({
-        tenantId: TENANT,
-        lifecycleId: lifecycle.id,
+      runGoogleCredentialLifecycleSweep({
         vault,
         config: CONFIG,
+        now: new Date(Date.now() + 20_000),
       }),
-    ).resolves.toBe("revoked");
+    ).resolves.toMatchObject({ processed: 1, revoked: 1, attention: 0 });
     await expect(
       reconcileGoogleCredentialRevocation({
         tenantId: TENANT,
@@ -1087,6 +1096,19 @@ describe("refresh", () => {
   test("force refresh rotates token to a new credential version + audit", async () => {
     const store = new MemoryConnectStore();
     const { completed } = await connectHappy(store);
+    const [beforeAccount] = await getDb()
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, completed.providerAccountId));
+    const route = await vault.createRoute(TENANT, beforeAccount.credentialSecretId as string, {
+      agentId: AGENT,
+      hostPattern: "gmail.googleapis.com",
+      pathPattern: "/gmail/v1/users/me/messages/send",
+      method: "POST",
+      injectAs: "header",
+      injectKey: "authorization",
+      injectFormat: "Bearer {value}",
+    });
 
     const fake = installFakeX();
     const result = await refreshGoogleProviderCredential({
@@ -1104,6 +1126,16 @@ describe("refresh", () => {
     const cred = await decryptCredential(completed.providerAccountId);
     expect(cred.accessToken).toBe("access-refreshed-1");
     expect(cred.refreshToken).toBe("refresh-rotated-1");
+    const [afterAccount] = await getDb()
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, completed.providerAccountId));
+    const [updatedRoute] = await getDb()
+      .select()
+      .from(secretRoutes)
+      .where(eq(secretRoutes.id, route.id));
+    expect(updatedRoute.secretId).toBe(afterAccount.credentialSecretId);
+    expect(updatedRoute.authorityRevision).toBeGreaterThan(1);
     fake.restore();
 
     const events = await readAuditActions(TENANT);
@@ -1267,8 +1299,12 @@ describe("refresh", () => {
       .where(eq(providerGoogleCredentialLifecycles.kind, "refresh_rotation"));
     expect(lifecycle.state).toBe("inflight");
     await expect(
-      reconcileGoogleRefreshLifecycle({ ...refreshInput, lifecycleId: lifecycle.id }),
-    ).rejects.toMatchObject({ code: "GOOGLE_CREDENTIAL_NEEDS_ATTENTION" });
+      runGoogleCredentialLifecycleSweep({
+        vault,
+        config: CONFIG,
+        now: new Date(Date.now() + 20_000),
+      }),
+    ).resolves.toMatchObject({ processed: 1, attention: 1 });
     expect(fake.counters.refresh).toBe(0);
   });
 

--- a/packages/api/src/__tests__/provider-google-connect.test.ts
+++ b/packages/api/src/__tests__/provider-google-connect.test.ts
@@ -602,13 +602,21 @@ describe("connect", () => {
     expect(JSON.stringify(encryptedHandle)).not.toContain("access-initial");
     expect(JSON.stringify(encryptedHandle)).not.toContain("refresh-initial");
     expect(await vault.decryptSecret(TENANT, encryptedHandle.id)).toContain("refresh-initial");
-    await expect(
+    const concurrentRecovery = await Promise.all([
       runGoogleCredentialLifecycleSweep({
         vault,
         config: CONFIG,
         now: new Date(Date.now() + 20_000),
       }),
-    ).resolves.toMatchObject({ processed: 1, revoked: 1, attention: 0 });
+      runGoogleCredentialLifecycleSweep({
+        vault,
+        config: CONFIG,
+        now: new Date(Date.now() + 20_000),
+      }),
+    ]);
+    expect(concurrentRecovery.reduce((sum, result) => sum + result.processed, 0)).toBe(1);
+    expect(concurrentRecovery.reduce((sum, result) => sum + result.revoked, 0)).toBe(1);
+    expect(concurrentRecovery.reduce((sum, result) => sum + result.attention, 0)).toBe(0);
     await expect(
       reconcileGoogleCredentialRevocation({
         tenantId: TENANT,

--- a/packages/api/src/__tests__/provider-google-lifecycle-scheduler.test.ts
+++ b/packages/api/src/__tests__/provider-google-lifecycle-scheduler.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test";
+import { startGoogleCredentialLifecycleScheduler } from "../services/provider-google-lifecycle-scheduler";
+
+test("Google lifecycle scheduler runs immediately, drains bounded pages, and stops cleanly", async () => {
+  let calls = 0;
+  let concurrent = 0;
+  let maxConcurrent = 0;
+  const stop = startGoogleCredentialLifecycleScheduler({
+    intervalMs: 60_000,
+    sweep: async () => {
+      calls += 1;
+      concurrent += 1;
+      maxConcurrent = Math.max(maxConcurrent, concurrent);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      concurrent -= 1;
+      return {
+        processed: 1,
+        adopted: 1,
+        revoked: 0,
+        attention: 0,
+        remaining: calls === 1,
+      };
+    },
+  });
+  for (let attempt = 0; attempt < 100 && calls < 2; attempt += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 2));
+  }
+  await stop();
+  expect(calls).toBe(2);
+  expect(maxConcurrent).toBe(1);
+});

--- a/packages/api/src/__tests__/worker-runtime-sentinel.test.ts
+++ b/packages/api/src/__tests__/worker-runtime-sentinel.test.ts
@@ -1,5 +1,9 @@
 import { expect, test } from "bun:test";
-import { hydrateProcessEnv, runWorkerUpstreamCredentialLeaseSweep } from "../worker";
+import {
+  hydrateProcessEnv,
+  runWorkerGoogleCredentialLifecycleSweep,
+  runWorkerUpstreamCredentialLeaseSweep,
+} from "../worker";
 
 test("Worker hydration cannot be overridden by a STEWARD_RUNTIME binding", () => {
   const previous = process.env.STEWARD_RUNTIME;
@@ -45,4 +49,24 @@ test("Worker scheduled recovery is inert without the capabilities plugin", async
   );
   expect(calls).toBe(0);
   expect(result).toBeNull();
+});
+
+test("Worker cron runs Google lifecycle recovery when provider credentials are configured", async () => {
+  let calls = 0;
+  const result = await runWorkerGoogleCredentialLifecycleSweep(
+    {
+      DATABASE_URL: "postgresql://worker.invalid/steward",
+      GOOGLE_PROVIDER_CLIENT_ID: "provider-client",
+      GOOGLE_PROVIDER_CLIENT_SECRET: "provider-secret",
+      STEWARD_MASTER_PASSWORD: "worker-master",
+    },
+    {
+      sweep: async () => {
+        calls += 1;
+        return { processed: 2, adopted: 1, revoked: 1, attention: 0, remaining: false };
+      },
+    },
+  );
+  expect(calls).toBe(1);
+  expect(result).toEqual({ processed: 2, adopted: 1, revoked: 1, attention: 0, remaining: false });
 });

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -28,6 +28,7 @@ import {
   RATE_LIMIT_MAX_REQUESTS,
   RATE_LIMIT_WINDOW_MS,
 } from "./services/context";
+import { startGoogleCredentialLifecycleScheduler } from "./services/provider-google-lifecycle-scheduler";
 import { startProviderReservationReconciliationScheduler } from "./services/provider-reservation-reconciliation-scheduler";
 import { startRetentionScheduler } from "./services/retention";
 import {
@@ -86,6 +87,7 @@ let cancelProviderReservationReconciliation: (() => void) | undefined;
 let cancelTransactionReceiptPolling: (() => void) | undefined;
 let cancelWebhookRetryScheduler: (() => void) | undefined;
 let cancelUpstreamCredentialLeaseScheduler: (() => Promise<void>) | undefined;
+let cancelGoogleCredentialLifecycleScheduler: (() => Promise<void>) | undefined;
 
 function runtimeGate(request: Request, peerAddress: string | null): Response | null {
   const url = new URL(request.url);
@@ -351,6 +353,9 @@ assertAuthStoresAreSafe();
 // ─── Data retention scheduler (SOC2 CC2) ────────────────────────────────────
 
 if (migrationsRan) {
+  if (process.env.GOOGLE_PROVIDER_CLIENT_ID && process.env.GOOGLE_PROVIDER_CLIENT_SECRET) {
+    cancelGoogleCredentialLifecycleScheduler = startGoogleCredentialLifecycleScheduler();
+  }
   cancelRetention = startRetentionScheduler();
   if (redisOk) {
     cancelProviderReservationReconciliation = startProviderReservationReconciliationScheduler();
@@ -402,6 +407,7 @@ const shutdown = async (signal: string) => {
   if (cancelTransactionReceiptPolling) cancelTransactionReceiptPolling();
   if (cancelWebhookRetryScheduler) cancelWebhookRetryScheduler();
   if (cancelUpstreamCredentialLeaseScheduler) await cancelUpstreamCredentialLeaseScheduler();
+  if (cancelGoogleCredentialLifecycleScheduler) await cancelGoogleCredentialLifecycleScheduler();
   rateLimiter.clear();
 
   try {

--- a/packages/api/src/services/provider-authority-store.ts
+++ b/packages/api/src/services/provider-authority-store.ts
@@ -15,6 +15,7 @@ import {
   withTenantAuditedTransaction,
   workspaces,
 } from "@stwd/db";
+import type { GoogleOperationKey } from "@stwd/provider-google";
 import { SLACK_OPERATION_RISK, type SlackOperationKey } from "@stwd/provider-slack";
 import {
   GENERIC_HTTP_PROVIDER_ACTION_PROFILE,
@@ -53,6 +54,26 @@ const SLACK_OPERATION_EXACT_PATH = {
   "slack.conversations.list": "/api/conversations.list",
   "slack.users.info": "/api/users.info",
 } as const satisfies Readonly<Record<SlackOperationKey, string>>;
+const GOOGLE_OPERATION_METHOD = {
+  "google.gmail.messages.send": "POST",
+  "google.calendar.events.list": "GET",
+  "google.calendar.events.insert": "POST",
+} as const satisfies Readonly<Record<GoogleOperationKey, "GET" | "POST" | "DELETE">>;
+const GOOGLE_OPERATION_MINIMUM_RISK = {
+  "google.gmail.messages.send": "write",
+  "google.calendar.events.list": "read",
+  "google.calendar.events.insert": "write",
+} as const satisfies Readonly<Record<GoogleOperationKey, ProviderRiskClass>>;
+const GOOGLE_OPERATION_EXACT_PATH = {
+  "google.gmail.messages.send": "/gmail/v1/users/me/messages/send",
+  "google.calendar.events.list": "/calendar/v3/calendars/primary/events",
+  "google.calendar.events.insert": "/calendar/v3/calendars/primary/events",
+} as const satisfies Readonly<Record<GoogleOperationKey, string>>;
+const GOOGLE_OPERATION_HOST = {
+  "google.gmail.messages.send": "gmail.googleapis.com",
+  "google.calendar.events.list": "www.googleapis.com",
+  "google.calendar.events.insert": "www.googleapis.com",
+} as const satisfies Readonly<Record<GoogleOperationKey, string>>;
 const PROVIDER_OPERATION_ALLOWLIST: Readonly<
   Record<string, Readonly<Record<string, "GET" | "POST" | "DELETE">>>
 > = {
@@ -66,6 +87,7 @@ const PROVIDER_OPERATION_ALLOWLIST: Readonly<
     "x.user.me.read": "GET",
   },
   slack: SLACK_OPERATION_METHOD,
+  google: GOOGLE_OPERATION_METHOD,
 };
 const PROVIDER_OPERATION_MINIMUM_RISK: Readonly<
   Record<string, Readonly<Record<string, ProviderRiskClass>>>
@@ -80,9 +102,11 @@ const PROVIDER_OPERATION_MINIMUM_RISK: Readonly<
     "x.user.me.read": "read",
   },
   slack: SLACK_OPERATION_RISK,
+  google: GOOGLE_OPERATION_MINIMUM_RISK,
 };
 const PROVIDER_OPERATION_EXACT_PATH: Readonly<Record<string, Readonly<Record<string, string>>>> = {
   slack: SLACK_OPERATION_EXACT_PATH,
+  google: GOOGLE_OPERATION_EXACT_PATH,
 };
 const PROVIDER_RISK_RANK: Readonly<Record<ProviderRiskClass, number>> = {
   read: 0,
@@ -94,7 +118,7 @@ const PROVIDER_HOST_ALLOWLIST: Readonly<Record<string, string>> = {
   x: "api.x.com",
   slack: "slack.com",
 };
-const REGISTERED_ADAPTER_KEY_LIST = ["github", "x", "slack", "generic-http"] as const;
+const REGISTERED_ADAPTER_KEY_LIST = ["github", "x", "slack", "google", "generic-http"] as const;
 type RegisteredAdapterKey = (typeof REGISTERED_ADAPTER_KEY_LIST)[number];
 type FixedProviderAdapterKey = Exclude<RegisteredAdapterKey, "generic-http">;
 const BEARER_ROUTE_INJECTION = {
@@ -108,6 +132,7 @@ const FIXED_PROVIDER_ROUTE_INJECTION = {
   github: BEARER_ROUTE_INJECTION,
   x: BEARER_ROUTE_INJECTION,
   slack: BEARER_ROUTE_INJECTION,
+  google: BEARER_ROUTE_INJECTION,
 } as const satisfies Readonly<Record<FixedProviderAdapterKey, typeof BEARER_ROUTE_INJECTION>>;
 const REGISTERED_ADAPTER_KEYS = new Set<string>(REGISTERED_ADAPTER_KEY_LIST);
 const ENVIRONMENTS = new Set(["development", "staging", "production"]);
@@ -122,6 +147,13 @@ const ROLES = new Set([
 const RISK_CLASSES = new Set(["read", "write", "consequential"]);
 const BUDGET_DIMENSIONS = new Set(["count", "notional"]);
 const MAX_BUDGET_WINDOW_SECONDS = 30 * 24 * 60 * 60;
+
+function fixedProviderHost(adapterKey: string, operationKey: string): string | undefined {
+  if (adapterKey === "google") {
+    return GOOGLE_OPERATION_HOST[operationKey as GoogleOperationKey];
+  }
+  return PROVIDER_HOST_ALLOWLIST[adapterKey];
+}
 
 type DbBase = ReturnType<typeof getDb>;
 type DbExecutor = DbBase | Parameters<Parameters<DbBase["transaction"]>[0]>[0];
@@ -901,7 +933,7 @@ export class ProviderAuthorityStore {
         .limit(1);
       const expectedHost = genericDescriptor
         ? new URL(genericDescriptor.origin).hostname
-        : PROVIDER_HOST_ALLOWLIST[account.adapterKey];
+        : fixedProviderHost(account.adapterKey, operationKey);
       const method = route?.method?.toUpperCase();
       const pathAllowed = genericDescriptor
         ? Boolean(
@@ -1010,7 +1042,7 @@ export class ProviderAuthorityStore {
         const credentialSecretId = account.credentialSecretId;
         const expectedHost = genericDescriptor
           ? new URL(genericDescriptor.origin).hostname
-          : PROVIDER_HOST_ALLOWLIST[account.adapterKey];
+          : fixedProviderHost(account.adapterKey, operationKey);
         const method = route?.method?.toUpperCase();
         const pathAllowed = genericDescriptor
           ? Boolean(

--- a/packages/api/src/services/provider-google-connect.ts
+++ b/packages/api/src/services/provider-google-connect.ts
@@ -1954,6 +1954,29 @@ export interface GoogleCredentialLifecycleSweepResult {
   remaining: boolean;
 }
 
+export const GOOGLE_LIFECYCLE_SWEEP_BATCH_SIZE = 25;
+export const GOOGLE_LIFECYCLE_MAX_ATTEMPTS = 5;
+const GOOGLE_LIFECYCLE_BASE_BACKOFF_MS = 5_000;
+const GOOGLE_LIFECYCLE_MAX_BACKOFF_MS = 5 * 60_000;
+
+function googleLifecycleBackoffMs(attempts: number): number {
+  return Math.min(
+    GOOGLE_LIFECYCLE_MAX_BACKOFF_MS,
+    GOOGLE_LIFECYCLE_BASE_BACKOFF_MS * 2 ** Math.max(0, attempts - 1),
+  );
+}
+
+function googleLifecycleRetryableState(
+  state: string,
+): state is "inflight" | "credential_staged" | "revocation_pending" | "needs_attention" {
+  return (
+    state === "inflight" ||
+    state === "credential_staged" ||
+    state === "revocation_pending" ||
+    state === "needs_attention"
+  );
+}
+
 /**
  * Bounded all-tenant recovery pass for one-time Google OAuth responses.
  * Fresh inflight rows are left to their live caller; only rows older than the
@@ -1965,7 +1988,10 @@ export async function runGoogleCredentialLifecycleSweep(input: {
   limit?: number;
   now?: Date;
 }): Promise<GoogleCredentialLifecycleSweepResult> {
-  const limit = Math.min(Math.max(input.limit ?? 50, 1), 200);
+  const limit = Math.min(
+    GOOGLE_LIFECYCLE_SWEEP_BATCH_SIZE,
+    Math.max(1, Math.floor(input.limit ?? GOOGLE_LIFECYCLE_SWEEP_BATCH_SIZE)),
+  );
   const now = input.now ?? new Date();
   const recoveryBefore = new Date(now.getTime() - GOOGLE_FORWARD_TIMEOUT_MS - 5_000);
   const staleInflightBefore = new Date(now.getTime() - GOOGLE_FORWARD_TIMEOUT_MS - 5_000);
@@ -1973,18 +1999,21 @@ export async function runGoogleCredentialLifecycleSweep(input: {
     .select()
     .from(providerGoogleCredentialLifecycles)
     .where(
-      or(
-        and(
-          inArray(providerGoogleCredentialLifecycles.state, [
-            "credential_staged",
-            "revocation_pending",
-            "needs_attention",
-          ]),
-          lte(providerGoogleCredentialLifecycles.updatedAt, recoveryBefore),
-        ),
-        and(
-          eq(providerGoogleCredentialLifecycles.state, "inflight"),
-          lte(providerGoogleCredentialLifecycles.updatedAt, staleInflightBefore),
+      and(
+        sql`${providerGoogleCredentialLifecycles.attempts} < ${GOOGLE_LIFECYCLE_MAX_ATTEMPTS}`,
+        or(
+          and(
+            inArray(providerGoogleCredentialLifecycles.state, [
+              "credential_staged",
+              "revocation_pending",
+              "needs_attention",
+            ]),
+            lte(providerGoogleCredentialLifecycles.updatedAt, recoveryBefore),
+          ),
+          and(
+            eq(providerGoogleCredentialLifecycles.state, "inflight"),
+            lte(providerGoogleCredentialLifecycles.updatedAt, staleInflightBefore),
+          ),
         ),
       ),
     )
@@ -1998,7 +2027,57 @@ export async function runGoogleCredentialLifecycleSweep(input: {
     attention: 0,
     remaining: false,
   };
-  for (const row of rows) {
+  for (const candidate of rows) {
+    const row = await withTenantAuditedTransaction(candidate.tenantId, async (txRaw, append) => {
+      const tx = txRaw as DbExecutor;
+      const [current] = await tx
+        .select()
+        .from(providerGoogleCredentialLifecycles)
+        .where(
+          and(
+            eq(providerGoogleCredentialLifecycles.tenantId, candidate.tenantId),
+            eq(providerGoogleCredentialLifecycles.id, candidate.id),
+          ),
+        )
+        .limit(1)
+        .for("update");
+      if (
+        !current ||
+        !googleLifecycleRetryableState(current.state) ||
+        current.attempts >= GOOGLE_LIFECYCLE_MAX_ATTEMPTS ||
+        current.attempts !== candidate.attempts ||
+        now.getTime() - current.updatedAt.getTime() < googleLifecycleBackoffMs(current.attempts)
+      ) {
+        return null;
+      }
+      const [claimed] = await tx
+        .update(providerGoogleCredentialLifecycles)
+        .set({ attempts: current.attempts + 1, updatedAt: new Date() })
+        .where(
+          and(
+            eq(providerGoogleCredentialLifecycles.tenantId, current.tenantId),
+            eq(providerGoogleCredentialLifecycles.id, current.id),
+            eq(providerGoogleCredentialLifecycles.attempts, current.attempts),
+          ),
+        )
+        .returning();
+      if (!claimed) return null;
+      await append({
+        tenantId: current.tenantId,
+        actorType: "system",
+        actorId: "system",
+        action: "provider.google.lifecycle.recovery_claimed",
+        resourceType: "provider_google_credential_lifecycle",
+        resourceId: current.id,
+        metadata: {
+          kind: current.kind,
+          attempts: claimed.attempts,
+          workspaceId: current.workspaceId,
+        },
+      });
+      return claimed;
+    });
+    if (!row) continue;
     result.processed += 1;
     try {
       if (row.kind === "connect_exchange") {
@@ -2045,7 +2124,7 @@ export async function runGoogleCredentialLifecycleSweep(input: {
   // Do not tight-loop a permanently failing revoker. Failed rows update their
   // timestamp and are retried on the next scheduled pass, while a clean full
   // page can be drained immediately.
-  result.remaining = rows.length === limit && result.attention === 0;
+  result.remaining = result.processed > 0 && rows.length === limit && result.attention === 0;
   return result;
 }
 

--- a/packages/api/src/services/provider-google-connect.ts
+++ b/packages/api/src/services/provider-google-connect.ts
@@ -258,6 +258,8 @@ export function __setGoogleForwardForTests(fn: GoogleForwardFn | null): () => vo
 let beforeConnectCommitForTests: (() => void | Promise<void>) | null = null;
 let afterGoogleCredentialStageForTests: (() => void | Promise<void>) | null = null;
 let afterGoogleRefreshIntentForTests: (() => void | Promise<void>) | null = null;
+let afterGoogleDisconnectJournalForTests: (() => void | Promise<void>) | null = null;
+let afterGoogleDisconnectRevokeForTests: (() => void | Promise<void>) | null = null;
 
 /** Inject a failure immediately before the connect audit append. Test-only. */
 export function __setGoogleConnectCommitHookForTests(
@@ -289,6 +291,28 @@ export function __setGoogleRefreshIntentHookForTests(
   afterGoogleRefreshIntentForTests = hook;
   return () => {
     afterGoogleRefreshIntentForTests = previous;
+  };
+}
+
+/** Inject a crash after local authority is revoked and the revoke handle commits. */
+export function __setGoogleDisconnectJournalHookForTests(
+  hook: (() => void | Promise<void>) | null,
+): () => void {
+  const previous = afterGoogleDisconnectJournalForTests;
+  afterGoogleDisconnectJournalForTests = hook;
+  return () => {
+    afterGoogleDisconnectJournalForTests = previous;
+  };
+}
+
+/** Inject a crash after the upstream revoke returns but before terminalization. */
+export function __setGoogleDisconnectRevokeHookForTests(
+  hook: (() => void | Promise<void>) | null,
+): () => void {
+  const previous = afterGoogleDisconnectRevokeForTests;
+  afterGoogleDisconnectRevokeForTests = hook;
+  return () => {
+    afterGoogleDisconnectRevokeForTests = previous;
   };
 }
 
@@ -554,7 +578,7 @@ async function stageGoogleCredentialResponse(input: {
   tenantId: string;
   workspaceId: string;
   vault: SecretVault;
-  kind: "connect_exchange" | "refresh_rotation";
+  kind: "connect_exchange" | "refresh_rotation" | "disconnect_revoke";
   token: GoogleTokenResponse;
   providerAccountId?: string;
   expectedAccountRevision?: number;
@@ -629,6 +653,12 @@ async function setGoogleLifecycleState(
         and(
           eq(providerGoogleCredentialLifecycles.tenantId, tenantId),
           eq(providerGoogleCredentialLifecycles.id, lifecycleId),
+          inArray(providerGoogleCredentialLifecycles.state, [
+            "inflight",
+            "credential_staged",
+            "revocation_pending",
+            "needs_attention",
+          ]),
         ),
       )
       .limit(1)
@@ -646,6 +676,12 @@ async function setGoogleLifecycleState(
         and(
           eq(providerGoogleCredentialLifecycles.tenantId, tenantId),
           eq(providerGoogleCredentialLifecycles.id, lifecycleId),
+          inArray(providerGoogleCredentialLifecycles.state, [
+            "inflight",
+            "credential_staged",
+            "revocation_pending",
+            "needs_attention",
+          ]),
         ),
       )
       .returning();
@@ -689,7 +725,10 @@ export async function reconcileGoogleCredentialRevocation(input: {
     !row ||
     (row.state !== "revocation_pending" &&
       row.state !== "needs_attention" &&
-      !(row.kind === "connect_exchange" && row.state === "credential_staged"))
+      !(
+        (row.kind === "connect_exchange" || row.kind === "disconnect_revoke") &&
+        row.state === "credential_staged"
+      ))
   ) {
     return "already_terminal";
   }
@@ -1049,6 +1088,35 @@ async function persistConnectedAccount(input: PersistInput): Promise<CompleteCon
       )
       .limit(1)
       .for("update");
+
+    if (account) {
+      const [pendingDisconnect] = await tx
+        .select({ id: providerGoogleCredentialLifecycles.id })
+        .from(providerGoogleCredentialLifecycles)
+        .where(
+          and(
+            eq(providerGoogleCredentialLifecycles.tenantId, input.tenantId),
+            eq(providerGoogleCredentialLifecycles.workspaceId, input.workspaceId),
+            eq(providerGoogleCredentialLifecycles.providerAccountId, account.id),
+            eq(providerGoogleCredentialLifecycles.kind, "disconnect_revoke"),
+            inArray(providerGoogleCredentialLifecycles.state, [
+              "inflight",
+              "credential_staged",
+              "revocation_pending",
+              "needs_attention",
+            ]),
+          ),
+        )
+        .limit(1)
+        .for("update");
+      if (pendingDisconnect) {
+        throw new GoogleConnectError(
+          "GOOGLE_CREDENTIAL_NEEDS_ATTENTION",
+          409,
+          "previous Google disconnect is still awaiting upstream revocation",
+        );
+      }
+    }
 
     const [existingSecret] = await tx
       .select({ id: secrets.id })
@@ -2161,14 +2229,15 @@ export interface DisconnectResult {
 }
 
 /**
- * Disconnect a connected Google account: best-effort revoke at Google, degrade the account
- * (status revoked), bump revision, audit. Revocation failure at Google does NOT block
- * the local degrade — we fail CLOSED locally regardless.
+ * Disconnect a connected Google account. Local authority is revoked in the
+ * same transaction that commits an encrypted upstream-revocation handle. A
+ * crash can therefore delay provider cleanup, but can never leave the old
+ * credential executable or race a reconnect into the pending revoker.
  */
 export async function disconnectGoogleProviderCredential(
   input: DisconnectInput,
 ): Promise<DisconnectResult> {
-  return withTenantAuditedTransaction(input.tenantId, async (txRaw, append) => {
+  const prepared = await withTenantAuditedTransaction(input.tenantId, async (txRaw, append) => {
     const tx = txRaw as DbExecutor;
     const [account] = await tx
       .select()
@@ -2191,26 +2260,20 @@ export async function disconnectGoogleProviderCredential(
         "provider account is not a Google account",
       );
     }
-
-    let revokedAtUpstream = false;
-    if (account.credentialSecretId) {
-      try {
-        const cred = await loadCredential(
-          input.vault,
-          input.tenantId,
-          account.credentialSecretId,
-          tx,
-        );
-        revokedAtUpstream = await revokeUpstreamBestEffort(
-          cred.payload.accessToken,
-          cred.refreshToken,
-        );
-      } catch {
-        // Best-effort only. Local degrade proceeds regardless.
-        revokedAtUpstream = false;
-      }
+    if (account.status === "revoked") {
+      return { lifecycleId: null, accessToken: null, refreshToken: null };
     }
 
+    let credential: LoadedCredential | null = null;
+    if (account.credentialSecretId) {
+      credential = await loadCredential(
+        input.vault,
+        input.tenantId,
+        account.credentialSecretId,
+        tx,
+      );
+    }
+    const lifecycleId = credential ? randomUUID() : null;
     const [degraded] = await tx
       .update(providerAccounts)
       .set({ status: "revoked", revision: account.revision + 1, updatedAt: new Date() })
@@ -2230,6 +2293,41 @@ export async function disconnectGoogleProviderCredential(
       );
     }
 
+    if (credential && lifecycleId) {
+      const secret = await input.vault.createSecretWithinTx(
+        tx,
+        input.tenantId,
+        `provider-google-lifecycle:${lifecycleId}`,
+        JSON.stringify({
+          schemaVersion: "steward.provider-google.lifecycle.v1",
+          token: {
+            access_token: credential.payload.accessToken,
+            refresh_token: credential.refreshToken ?? undefined,
+          },
+        } satisfies GoogleLifecycleSecret),
+        { description: "Encrypted transient Google OAuth revocation material" },
+      );
+      await tx.insert(providerGoogleCredentialLifecycles).values({
+        id: lifecycleId,
+        tenantId: input.tenantId,
+        workspaceId: input.workspaceId,
+        providerAccountId: account.id,
+        kind: "disconnect_revoke",
+        state: "revocation_pending",
+        credentialSecretId: secret.id,
+        expectedAccountRevision: degraded.revision,
+      });
+      await append({
+        tenantId: input.tenantId,
+        actorType: "user",
+        actorId: input.callerUserId,
+        action: "provider.google.disconnect.intent_staged",
+        resourceType: "provider_google_credential_lifecycle",
+        resourceId: lifecycleId,
+        metadata: { workspaceId: input.workspaceId, providerAccountId: account.id },
+      });
+    }
+
     await append({
       tenantId: input.tenantId,
       actorType: "user",
@@ -2240,15 +2338,38 @@ export async function disconnectGoogleProviderCredential(
       metadata: {
         workspaceId: input.workspaceId,
         googleUserId: account.externalRef,
-        revokedAtUpstream,
+        revokedAtUpstream: false,
+        upstreamRevocationPending: Boolean(lifecycleId),
         previousRevision: account.revision,
         newRevision: degraded.revision,
         requestId: input.requestId ?? null,
       },
     });
-
-    return { providerAccountId: account.id, revoked: revokedAtUpstream };
+    return {
+      lifecycleId,
+      accessToken: credential?.payload.accessToken ?? null,
+      refreshToken: credential?.refreshToken ?? null,
+    };
   });
+
+  if (!prepared.lifecycleId || !prepared.accessToken) {
+    return { providerAccountId: input.accountId, revoked: false };
+  }
+  await afterGoogleDisconnectJournalForTests?.();
+  let revokedAtUpstream = false;
+  try {
+    revokedAtUpstream = await revokeUpstreamBestEffort(prepared.accessToken, prepared.refreshToken);
+  } catch {
+    revokedAtUpstream = false;
+  }
+  await afterGoogleDisconnectRevokeForTests?.();
+  await setGoogleLifecycleState(
+    input.tenantId,
+    prepared.lifecycleId,
+    revokedAtUpstream ? "revoked" : "needs_attention",
+    revokedAtUpstream ? null : "REVOCATION_FAILED",
+  );
+  return { providerAccountId: input.accountId, revoked: revokedAtUpstream };
 }
 
 async function revokeUpstreamBestEffort(

--- a/packages/api/src/services/provider-google-connect.ts
+++ b/packages/api/src/services/provider-google-connect.ts
@@ -33,12 +33,16 @@
 import { createHash, randomBytes, randomUUID } from "node:crypto";
 import {
   and,
+  asc,
   eq,
   getDb,
   inArray,
+  lte,
+  or,
   providerAccounts,
   providerGoogleCredentialLifecycles,
   type Secret,
+  secretRoutes,
   secrets,
   sql,
   withTenantAuditedTransaction,
@@ -1783,6 +1787,19 @@ export async function reconcileGoogleRefreshLifecycle(
         current.secretName,
         JSON.stringify(payload),
       );
+      // Keep every credential route on the same versioned lineage. Rotating
+      // only provider_accounts would leave governed routes decrypting the
+      // superseded secret. Bumping route revision intentionally invalidates
+      // already-minted execution authorizations.
+      await tx
+        .update(secretRoutes)
+        .set({ secretId: meta.id })
+        .where(
+          and(
+            eq(secretRoutes.tenantId, input.tenantId),
+            eq(secretRoutes.secretId, account.credentialSecretId),
+          ),
+        );
       const [updated] = await tx
         .update(providerAccounts)
         .set({
@@ -1859,6 +1876,109 @@ export async function reconcileGoogleRefreshLifecycle(
     }
     throw error;
   }
+}
+
+export interface GoogleCredentialLifecycleSweepResult {
+  processed: number;
+  adopted: number;
+  revoked: number;
+  attention: number;
+  remaining: boolean;
+}
+
+/**
+ * Bounded all-tenant recovery pass for one-time Google OAuth responses.
+ * Fresh inflight rows are left to their live caller; only rows older than the
+ * provider timeout are classified outcome-unknown and failed closed.
+ */
+export async function runGoogleCredentialLifecycleSweep(input: {
+  vault: SecretVault;
+  config: GoogleConnectConfig;
+  limit?: number;
+  now?: Date;
+}): Promise<GoogleCredentialLifecycleSweepResult> {
+  const limit = Math.min(Math.max(input.limit ?? 50, 1), 200);
+  const now = input.now ?? new Date();
+  const recoveryBefore = new Date(now.getTime() - GOOGLE_FORWARD_TIMEOUT_MS - 5_000);
+  const staleInflightBefore = new Date(now.getTime() - GOOGLE_FORWARD_TIMEOUT_MS - 5_000);
+  const rows = await (getDb() as DbExecutor)
+    .select()
+    .from(providerGoogleCredentialLifecycles)
+    .where(
+      or(
+        and(
+          inArray(providerGoogleCredentialLifecycles.state, [
+            "credential_staged",
+            "revocation_pending",
+            "needs_attention",
+          ]),
+          lte(providerGoogleCredentialLifecycles.updatedAt, recoveryBefore),
+        ),
+        and(
+          eq(providerGoogleCredentialLifecycles.state, "inflight"),
+          lte(providerGoogleCredentialLifecycles.updatedAt, staleInflightBefore),
+        ),
+      ),
+    )
+    .orderBy(asc(providerGoogleCredentialLifecycles.updatedAt))
+    .limit(limit);
+
+  const result: GoogleCredentialLifecycleSweepResult = {
+    processed: 0,
+    adopted: 0,
+    revoked: 0,
+    attention: 0,
+    remaining: false,
+  };
+  for (const row of rows) {
+    result.processed += 1;
+    try {
+      if (row.kind === "connect_exchange") {
+        const outcome = await reconcileGoogleCredentialRevocation({
+          tenantId: row.tenantId,
+          lifecycleId: row.id,
+          vault: input.vault,
+          config: input.config,
+        });
+        if (outcome === "revoked") result.revoked += 1;
+        else if (outcome === "needs_attention") result.attention += 1;
+        continue;
+      }
+      if (!row.providerAccountId) {
+        await setGoogleLifecycleState(row.tenantId, row.id, "needs_attention", "MISSING_ACCOUNT");
+        result.attention += 1;
+        continue;
+      }
+      if (row.state === "credential_staged" || row.state === "inflight") {
+        await reconcileGoogleRefreshLifecycle({
+          tenantId: row.tenantId,
+          workspaceId: row.workspaceId,
+          accountId: row.providerAccountId,
+          lifecycleId: row.id,
+          vault: input.vault,
+          config: input.config,
+          force: true,
+        });
+        result.adopted += 1;
+        continue;
+      }
+      const outcome = await reconcileGoogleCredentialRevocation({
+        tenantId: row.tenantId,
+        lifecycleId: row.id,
+        vault: input.vault,
+        config: input.config,
+      });
+      if (outcome === "revoked") result.revoked += 1;
+      else result.attention += 1;
+    } catch {
+      result.attention += 1;
+    }
+  }
+  // Do not tight-loop a permanently failing revoker. Failed rows update their
+  // timestamp and are retried on the next scheduled pass, while a clean full
+  // page can be drained immediately.
+  result.remaining = rows.length === limit && result.attention === 0;
+  return result;
 }
 
 interface LoadedCredential {

--- a/packages/api/src/services/provider-google-lifecycle-scheduler.ts
+++ b/packages/api/src/services/provider-google-lifecycle-scheduler.ts
@@ -1,0 +1,75 @@
+import { SecretVault } from "@stwd/vault";
+import {
+  type GoogleCredentialLifecycleSweepResult,
+  resolveGoogleConnectConfig,
+  runGoogleCredentialLifecycleSweep,
+} from "./provider-google-connect";
+
+const DEFAULT_INTERVAL_MS = 60_000;
+const MIN_INTERVAL_MS = 5_000;
+const MAX_INTERVAL_MS = 5 * 60_000;
+
+function configuredInterval(): number {
+  const raw = process.env.STEWARD_GOOGLE_LIFECYCLE_SWEEP_INTERVAL_MS;
+  if (raw === undefined) return DEFAULT_INTERVAL_MS;
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed < MIN_INTERVAL_MS || parsed > MAX_INTERVAL_MS) {
+    throw new Error(
+      `STEWARD_GOOGLE_LIFECYCLE_SWEEP_INTERVAL_MS must be between ${MIN_INTERVAL_MS} and ${MAX_INTERVAL_MS}`,
+    );
+  }
+  return parsed;
+}
+
+export async function runGoogleCredentialLifecycleRecoverySweep(): Promise<GoogleCredentialLifecycleSweepResult> {
+  const password = process.env.STEWARD_MASTER_PASSWORD?.trim();
+  if (!password) throw new Error("STEWARD_MASTER_PASSWORD is required for Google OAuth recovery");
+  return runGoogleCredentialLifecycleSweep({
+    vault: new SecretVault(password),
+    config: resolveGoogleConnectConfig(),
+  });
+}
+
+export function startGoogleCredentialLifecycleScheduler(options?: {
+  intervalMs?: number;
+  sweep?: () => Promise<GoogleCredentialLifecycleSweepResult>;
+}): () => Promise<void> {
+  if (process.env.STEWARD_GOOGLE_LIFECYCLE_SWEEPER === "false") return async () => {};
+  const sweep = options?.sweep ?? runGoogleCredentialLifecycleRecoverySweep;
+  let active: Promise<void> | undefined;
+  let stopped = false;
+  let rerunRequested = false;
+  const tick = () => {
+    if (stopped) return;
+    if (active) {
+      rerunRequested = true;
+      return;
+    }
+    active = sweep()
+      .then((result) => {
+        rerunRequested ||= result.remaining;
+        if (result.processed > 0) {
+          console.log(
+            `[provider-google] reconciled ${result.processed} lifecycle(s): ` +
+              `${result.adopted} adopted, ${result.revoked} revoked, ${result.attention} attention`,
+          );
+        }
+      })
+      .catch((error) => console.error("[provider-google] lifecycle sweep failed:", error))
+      .finally(() => {
+        active = undefined;
+        if (rerunRequested && !stopped) {
+          rerunRequested = false;
+          queueMicrotask(tick);
+        }
+      });
+  };
+  const timer = setInterval(tick, options?.intervalMs ?? configuredInterval());
+  timer.unref?.();
+  tick();
+  return async () => {
+    stopped = true;
+    clearInterval(timer);
+    await active;
+  };
+}

--- a/packages/api/src/worker.ts
+++ b/packages/api/src/worker.ts
@@ -106,6 +106,25 @@ export async function runWorkerUpstreamCredentialLeaseSweep(
   return sweep();
 }
 
+export async function runWorkerGoogleCredentialLifecycleSweep(
+  env: Env,
+  options?: { sweep?: () => Promise<unknown> },
+): Promise<unknown | null> {
+  hydrateProcessEnv(env);
+  if (
+    process.env.STEWARD_GOOGLE_LIFECYCLE_SWEEPER === "false" ||
+    !process.env.GOOGLE_PROVIDER_CLIENT_ID ||
+    !process.env.GOOGLE_PROVIDER_CLIENT_SECRET
+  ) {
+    return null;
+  }
+  const sweep =
+    options?.sweep ??
+    (await import("./services/provider-google-lifecycle-scheduler"))
+      .runGoogleCredentialLifecycleRecoverySweep;
+  return sweep();
+}
+
 /**
  * Pull Worker `env` bindings into `globalThis.process.env` so any code that
  * reads `process.env.X` at request time (e.g. JWT secret, RPC URL) can find it.
@@ -239,6 +258,11 @@ export default {
     env: Env,
     ctx: { waitUntil(promise: Promise<unknown>): void },
   ) {
-    ctx.waitUntil(runWorkerUpstreamCredentialLeaseSweep(env));
+    ctx.waitUntil(
+      Promise.all([
+        runWorkerUpstreamCredentialLeaseSweep(env),
+        runWorkerGoogleCredentialLifecycleSweep(env),
+      ]),
+    );
   },
 };

--- a/packages/db/drizzle/0099_google_disconnect_lifecycle_kind.sql
+++ b/packages/db/drizzle/0099_google_disconnect_lifecycle_kind.sql
@@ -1,0 +1,8 @@
+-- Permit encrypted, durable Google disconnect revocation handles. This is a
+-- separate migration because 0098 is already deployed.
+ALTER TABLE "provider_google_credential_lifecycles"
+  DROP CONSTRAINT "provider_google_lifecycle_kind_check";
+--> statement-breakpoint
+ALTER TABLE "provider_google_credential_lifecycles"
+  ADD CONSTRAINT "provider_google_lifecycle_kind_check"
+  CHECK ("kind" IN ('connect_exchange', 'refresh_rotation', 'disconnect_revoke'));

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -554,6 +554,13 @@
       "when": 1787020072000,
       "tag": "0098_google_credential_lifecycles",
       "breakpoints": true
+    },
+    {
+      "idx": 99,
+      "version": "7",
+      "when": 1787020073000,
+      "tag": "0099_google_disconnect_lifecycle_kind",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -2074,7 +2074,7 @@ export const providerGoogleCredentialLifecycles = pgTable(
     ),
     kindCheck: check(
       "provider_google_lifecycle_kind_check",
-      sql`${table.kind} IN ('connect_exchange', 'refresh_rotation')`,
+      sql`${table.kind} IN ('connect_exchange', 'refresh_rotation', 'disconnect_revoke')`,
     ),
     accountStateIdx: index("provider_google_lifecycle_account_state_idx").on(
       table.tenantId,

--- a/packages/proxy/src/__tests__/google-execution-refresh.test.ts
+++ b/packages/proxy/src/__tests__/google-execution-refresh.test.ts
@@ -1,0 +1,186 @@
+import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
+import {
+  closeDb,
+  getDb,
+  providerAccounts,
+  providerGoogleCredentialLifecycles,
+  secrets,
+  tenants,
+  users,
+  workspaces,
+} from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { SecretVault } from "@stwd/vault";
+import { eq } from "drizzle-orm";
+import {
+  __setGoogleExecutionTokenForwarderForTests,
+  mintGoogleExecutionAccessToken,
+} from "../handlers/google-execution-credential";
+
+setDefaultTimeout(120_000);
+
+const TENANT = "tenant-google-execution-refresh";
+const USER = "10000000-0000-4000-8000-000000000093";
+const WORKSPACE = "20000000-0000-4000-8000-000000000093";
+const MASTER = "google-execution-refresh-test-master";
+const vault = new SecretVault(MASTER);
+const credential = JSON.stringify({
+  schemaVersion: "steward.provider-google.credential.v1",
+  accessToken: "persisted-stale-access-canary",
+  refreshToken: "server-refresh-canary",
+  scopesGranted: ["openid", "email", "https://www.googleapis.com/auth/gmail.send"],
+  googleUserId: "google-user-123",
+  googleEmail: "user@example.test",
+  obtainedAt: new Date(0).toISOString(),
+  expiresAt: new Date(1).toISOString(),
+});
+let accountId = "";
+
+describe("Google execution-time token mint", () => {
+  beforeAll(async () => {
+    process.env.STEWARD_PGLITE_MEMORY = "true";
+    process.env.STEWARD_AUDIT_HMAC_KEY = "a".repeat(64);
+    const { db, client } = await createPGLiteDb("memory://");
+    setPGLiteOverride(db, async () => client.close());
+    await db.insert(tenants).values({ id: TENANT, name: TENANT, apiKeyHash: `hash-${TENANT}` });
+    await db.insert(users).values({ id: USER, email: "google-refresh@example.test" });
+    await db.insert(workspaces).values({
+      id: WORKSPACE,
+      tenantId: TENANT,
+      key: "google-refresh",
+      name: "Google Refresh",
+      environment: "production",
+      createdBy: USER,
+    });
+    const secret = await vault.createSecret(TENANT, "google-refresh", credential);
+    const [account] = await db
+      .insert(providerAccounts)
+      .values({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        adapterKey: "google",
+        externalRef: "google-user-123",
+        displayName: "Google user",
+        credentialSecretId: secret.id,
+        credentialVersion: secret.version,
+      })
+      .returning();
+    accountId = account.id;
+  });
+
+  afterAll(async () => {
+    __setGoogleExecutionTokenForwarderForTests(null);
+    await closeDb();
+    delete process.env.STEWARD_PGLITE_MEMORY;
+    delete process.env.STEWARD_AUDIT_HMAC_KEY;
+  });
+
+  test("ignores persisted access token and injects a newly minted short-lived token", async () => {
+    let requestBody = "";
+    __setGoogleExecutionTokenForwarderForTests(async (body) => {
+      requestBody = body;
+      return Response.json({
+        access_token: "ephemeral-access",
+        token_type: "Bearer",
+        scope: "openid email https://www.googleapis.com/auth/gmail.send",
+        expires_in: 3600,
+      });
+    });
+    await expect(
+      mintGoogleExecutionAccessToken({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        accountId,
+        accountRevision: 1,
+        credential,
+        vault,
+        clientId: "provider-client",
+        clientSecret: "provider-secret",
+      }),
+    ).resolves.toBe("ephemeral-access");
+    expect(requestBody).toContain("refresh_token=server-refresh-canary");
+    expect(requestBody).not.toContain("persisted-stale-access-canary");
+    const [lifecycle] = await getDb()
+      .select()
+      .from(providerGoogleCredentialLifecycles)
+      .where(eq(providerGoogleCredentialLifecycles.providerAccountId, accountId));
+    expect(lifecycle.state).toBe("adopted");
+    expect(lifecycle.credentialSecretId).toBeNull();
+    expect(await getDb().select().from(secrets).where(eq(secrets.tenantId, TENANT))).toHaveLength(
+      1,
+    );
+  });
+
+  test("durably escrows an unexpectedly rotated refresh response", async () => {
+    __setGoogleExecutionTokenForwarderForTests(async () =>
+      Response.json({
+        access_token: "ephemeral-rotated-access",
+        refresh_token: "rotated-refresh-canary",
+        token_type: "Bearer",
+        scope: "openid email https://www.googleapis.com/auth/gmail.send",
+        expires_in: 3600,
+      }),
+    );
+    await expect(
+      mintGoogleExecutionAccessToken({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        accountId,
+        accountRevision: 1,
+        credential,
+        vault,
+        clientId: "provider-client",
+        clientSecret: "provider-secret",
+      }),
+    ).resolves.toBe("ephemeral-rotated-access");
+    const rows = await getDb()
+      .select()
+      .from(providerGoogleCredentialLifecycles)
+      .where(eq(providerGoogleCredentialLifecycles.providerAccountId, accountId));
+    const lifecycle = rows.find((row) => row.state === "credential_staged");
+    expect(lifecycle?.credentialSecretId).toBeTruthy();
+    const [escrow] = await getDb()
+      .select()
+      .from(secrets)
+      .where(eq(secrets.id, lifecycle?.credentialSecretId as string));
+    expect(JSON.stringify(escrow)).not.toContain("rotated-refresh-canary");
+    expect(await vault.decryptSecret(TENANT, escrow.id)).toContain("rotated-refresh-canary");
+  });
+
+  test("disables execution after an outcome-unknown token request", async () => {
+    await getDb()
+      .update(providerGoogleCredentialLifecycles)
+      .set({ state: "adopted", credentialSecretId: null })
+      .where(eq(providerGoogleCredentialLifecycles.providerAccountId, accountId));
+    const [account] = await getDb()
+      .update(providerAccounts)
+      .set({ status: "active", revision: 2 })
+      .where(eq(providerAccounts.id, accountId))
+      .returning();
+    __setGoogleExecutionTokenForwarderForTests(async () => {
+      throw new Error("connection reset after request body was sent");
+    });
+    await expect(
+      mintGoogleExecutionAccessToken({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        accountId,
+        accountRevision: account.revision,
+        credential,
+        vault,
+        clientId: "provider-client",
+        clientSecret: "provider-secret",
+      }),
+    ).rejects.toThrow("connection reset");
+    const [disabled] = await getDb()
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, accountId));
+    expect(disabled.status).toBe("disabled");
+    const rows = await getDb()
+      .select()
+      .from(providerGoogleCredentialLifecycles)
+      .where(eq(providerGoogleCredentialLifecycles.providerAccountId, accountId));
+    expect(rows.some((row) => row.state === "needs_attention")).toBeTrue();
+  });
+});

--- a/packages/proxy/src/__tests__/google-execution-refresh.test.ts
+++ b/packages/proxy/src/__tests__/google-execution-refresh.test.ts
@@ -183,4 +183,84 @@ describe("Google execution-time token mint", () => {
       .where(eq(providerGoogleCredentialLifecycles.providerAccountId, accountId));
     expect(rows.some((row) => row.state === "needs_attention")).toBeTrue();
   });
+
+  test("rejects a newly minted token that is still too close to expiry", async () => {
+    await getDb()
+      .update(providerGoogleCredentialLifecycles)
+      .set({ state: "adopted", credentialSecretId: null })
+      .where(eq(providerGoogleCredentialLifecycles.providerAccountId, accountId));
+    const [account] = await getDb()
+      .update(providerAccounts)
+      .set({ status: "active", revision: 4 })
+      .where(eq(providerAccounts.id, accountId))
+      .returning();
+    __setGoogleExecutionTokenForwarderForTests(async () =>
+      Response.json({
+        access_token: "ephemeral-too-short",
+        token_type: "Bearer",
+        scope: "openid email https://www.googleapis.com/auth/gmail.send",
+        expires_in: 299,
+      }),
+    );
+    await expect(
+      mintGoogleExecutionAccessToken({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        accountId,
+        accountRevision: account.revision,
+        credential,
+        vault,
+        clientId: "provider-client",
+        clientSecret: "provider-secret",
+      }),
+    ).rejects.toThrow("invalid Google refresh response");
+    const [disabled] = await getDb()
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, accountId));
+    expect(disabled.status).toBe("disabled");
+  });
+
+  test("rejects scope widening and freezes the account before another mint", async () => {
+    await getDb()
+      .update(providerGoogleCredentialLifecycles)
+      .set({ state: "adopted", credentialSecretId: null })
+      .where(eq(providerGoogleCredentialLifecycles.providerAccountId, accountId));
+    const [account] = await getDb()
+      .update(providerAccounts)
+      .set({ status: "active", revision: 6 })
+      .where(eq(providerAccounts.id, accountId))
+      .returning();
+    __setGoogleExecutionTokenForwarderForTests(async () =>
+      Response.json({
+        access_token: "ephemeral-widened",
+        token_type: "Bearer",
+        scope:
+          "openid email https://www.googleapis.com/auth/gmail.send https://www.googleapis.com/auth/calendar.events",
+        expires_in: 3600,
+      }),
+    );
+    await expect(
+      mintGoogleExecutionAccessToken({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        accountId,
+        accountRevision: account.revision,
+        credential,
+        vault,
+        clientId: "provider-client",
+        clientSecret: "provider-secret",
+      }),
+    ).rejects.toThrow("Google refresh widened OAuth scope");
+    const [disabled] = await getDb()
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, accountId));
+    expect(disabled.status).toBe("disabled");
+    const rows = await getDb()
+      .select()
+      .from(providerGoogleCredentialLifecycles)
+      .where(eq(providerGoogleCredentialLifecycles.providerAccountId, accountId));
+    expect(rows.some((row) => row.state === "revocation_pending")).toBeTrue();
+  });
 });

--- a/packages/proxy/src/__tests__/google-execution-refresh.test.ts
+++ b/packages/proxy/src/__tests__/google-execution-refresh.test.ts
@@ -263,4 +263,45 @@ describe("Google execution-time token mint", () => {
       .where(eq(providerGoogleCredentialLifecycles.providerAccountId, accountId));
     expect(rows.some((row) => row.state === "revocation_pending")).toBeTrue();
   });
+
+  test("never dispatches a token minted from a stale account revision", async () => {
+    await getDb()
+      .update(providerGoogleCredentialLifecycles)
+      .set({ state: "adopted", credentialSecretId: null })
+      .where(eq(providerGoogleCredentialLifecycles.providerAccountId, accountId));
+    const [account] = await getDb()
+      .update(providerAccounts)
+      .set({ status: "active", revision: 8 })
+      .where(eq(providerAccounts.id, accountId))
+      .returning();
+    __setGoogleExecutionTokenForwarderForTests(async () => {
+      await getDb()
+        .update(providerAccounts)
+        .set({ revision: 9 })
+        .where(eq(providerAccounts.id, accountId));
+      return Response.json({
+        access_token: "must-not-dispatch",
+        token_type: "Bearer",
+        scope: "openid email https://www.googleapis.com/auth/gmail.send",
+        expires_in: 3600,
+      });
+    });
+    await expect(
+      mintGoogleExecutionAccessToken({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        accountId,
+        accountRevision: account.revision,
+        credential,
+        vault,
+        clientId: "provider-client",
+        clientSecret: "provider-secret",
+      }),
+    ).rejects.toThrow("changed during token mint");
+    const rows = await getDb()
+      .select()
+      .from(providerGoogleCredentialLifecycles)
+      .where(eq(providerGoogleCredentialLifecycles.providerAccountId, accountId));
+    expect(rows.some((row) => row.lastErrorCode === "ACCOUNT_REVISION_CHANGED")).toBeTrue();
+  });
 });

--- a/packages/proxy/src/handlers/google-execution-credential.ts
+++ b/packages/proxy/src/handlers/google-execution-credential.ts
@@ -384,22 +384,75 @@ export async function mintGoogleExecutionAccessToken(
     throw error;
   }
 
-  if (raw.refresh_token === undefined) {
-    await withTenantAuditedTransaction(input.tenantId, async (txRaw, append) => {
+  const accountStillCurrent = await withTenantAuditedTransaction(
+    input.tenantId,
+    async (txRaw, append) => {
       const tx = txRaw as DbExecutor;
-      await tx
-        .update(providerGoogleCredentialLifecycles)
-        .set({ state: "adopted", credentialSecretId: null, updatedAt: new Date() })
+      const [account] = await tx
+        .select({ id: providerAccounts.id })
+        .from(providerAccounts)
         .where(
           and(
-            eq(providerGoogleCredentialLifecycles.tenantId, input.tenantId),
-            eq(providerGoogleCredentialLifecycles.id, lifecycleId),
-            eq(providerGoogleCredentialLifecycles.credentialSecretId, stagedSecretId as string),
+            eq(providerAccounts.tenantId, input.tenantId),
+            eq(providerAccounts.workspaceId, input.workspaceId),
+            eq(providerAccounts.id, input.accountId),
+            eq(providerAccounts.revision, input.accountRevision),
+            eq(providerAccounts.status, "active"),
           ),
-        );
-      await tx
-        .delete(secrets)
-        .where(and(eq(secrets.tenantId, input.tenantId), eq(secrets.id, stagedSecretId as string)));
+        )
+        .limit(1)
+        .for("update");
+      if (!account) {
+        await tx
+          .update(providerGoogleCredentialLifecycles)
+          .set({
+            state: "revocation_pending",
+            lastErrorCode: "ACCOUNT_REVISION_CHANGED",
+            updatedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(providerGoogleCredentialLifecycles.tenantId, input.tenantId),
+              eq(providerGoogleCredentialLifecycles.id, lifecycleId),
+              eq(providerGoogleCredentialLifecycles.state, "credential_staged"),
+            ),
+          );
+        await append({
+          tenantId: input.tenantId,
+          actorType: "system",
+          actorId: "credential-proxy",
+          action: "provider.google.refresh.needs_attention",
+          resourceType: "provider_account",
+          resourceId: input.accountId,
+          metadata: {
+            lifecycleId,
+            workspaceId: input.workspaceId,
+            reason: "ACCOUNT_REVISION_CHANGED",
+          },
+        });
+        return false;
+      }
+
+      if (raw.refresh_token === undefined) {
+        const [adopted] = await tx
+          .update(providerGoogleCredentialLifecycles)
+          .set({ state: "adopted", credentialSecretId: null, updatedAt: new Date() })
+          .where(
+            and(
+              eq(providerGoogleCredentialLifecycles.tenantId, input.tenantId),
+              eq(providerGoogleCredentialLifecycles.id, lifecycleId),
+              eq(providerGoogleCredentialLifecycles.credentialSecretId, stagedSecretId as string),
+              eq(providerGoogleCredentialLifecycles.state, "credential_staged"),
+            ),
+          )
+          .returning({ id: providerGoogleCredentialLifecycles.id });
+        if (!adopted) return false;
+        await tx
+          .delete(secrets)
+          .where(
+            and(eq(secrets.tenantId, input.tenantId), eq(secrets.id, stagedSecretId as string)),
+          );
+      }
       await append({
         tenantId: input.tenantId,
         actorType: "system",
@@ -409,7 +462,11 @@ export async function mintGoogleExecutionAccessToken(
         resourceId: input.accountId,
         metadata: { lifecycleId, workspaceId: input.workspaceId },
       });
-    });
+      return true;
+    },
+  );
+  if (!accountStillCurrent) {
+    throw new Error("Google provider account changed during token mint");
   }
 
   return raw.access_token;

--- a/packages/proxy/src/handlers/google-execution-credential.ts
+++ b/packages/proxy/src/handlers/google-execution-credential.ts
@@ -1,0 +1,396 @@
+import { randomUUID } from "node:crypto";
+import {
+  and,
+  eq,
+  getDb,
+  inArray,
+  providerAccounts,
+  providerGoogleCredentialLifecycles,
+  secrets,
+  withTenantAuditedTransaction,
+} from "@stwd/db";
+import { strictParseJson } from "@stwd/shared";
+import type { SecretVault } from "@stwd/vault";
+
+const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
+const MAX_RESPONSE_BYTES = 1024 * 1024;
+
+type DbBase = ReturnType<typeof getDb>;
+type DbExecutor = DbBase | Parameters<Parameters<DbBase["transaction"]>[0]>[0];
+
+type GoogleCredentialEnvelope = {
+  schemaVersion: "steward.provider-google.credential.v1";
+  refreshToken: string;
+  scopesGranted: string[];
+};
+
+type GoogleRefreshResponse = {
+  access_token?: unknown;
+  refresh_token?: unknown;
+  scope?: unknown;
+  token_type?: unknown;
+  expires_in?: unknown;
+  error?: unknown;
+};
+
+type GoogleTokenForwarder = (body: string) => Promise<Response>;
+
+async function defaultGoogleTokenForwarder(body: string): Promise<Response> {
+  return fetch(GOOGLE_TOKEN_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Accept: "application/json",
+    },
+    body,
+    redirect: "error",
+    signal: AbortSignal.timeout(10_000),
+  });
+}
+
+let googleTokenForwarder: GoogleTokenForwarder = defaultGoogleTokenForwarder;
+
+export function __setGoogleExecutionTokenForwarderForTests(
+  forwarder: GoogleTokenForwarder | null,
+): void {
+  googleTokenForwarder = forwarder ?? defaultGoogleTokenForwarder;
+}
+
+async function readBoundedJson(response: Response): Promise<unknown> {
+  const contentLength = response.headers.get("content-length");
+  if (contentLength !== null) {
+    const parsed = Number(contentLength);
+    if (!Number.isSafeInteger(parsed) || parsed < 0 || parsed > MAX_RESPONSE_BYTES) {
+      await response.body?.cancel().catch(() => {});
+      throw new Error("Google token response exceeded maximum size");
+    }
+  }
+  const reader = response.body?.getReader();
+  if (!reader) return null;
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > MAX_RESPONSE_BYTES) {
+        await reader.cancel().catch(() => {});
+        throw new Error("Google token response exceeded maximum size");
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return strictParseJson(new TextDecoder().decode(bytes));
+}
+
+function parseEnvelope(value: string): GoogleCredentialEnvelope {
+  const parsed = strictParseJson(value) as Record<string, unknown>;
+  if (
+    parsed.schemaVersion !== "steward.provider-google.credential.v1" ||
+    typeof parsed.refreshToken !== "string" ||
+    parsed.refreshToken.length < 1 ||
+    parsed.refreshToken.length > 16_384 ||
+    !Array.isArray(parsed.scopesGranted) ||
+    parsed.scopesGranted.length < 1 ||
+    parsed.scopesGranted.length > 64 ||
+    !parsed.scopesGranted.every(
+      (scope) =>
+        typeof scope === "string" &&
+        scope.length > 0 &&
+        scope.length <= 512 &&
+        /^[\x21-\x7e]+$/.test(scope),
+    )
+  ) {
+    throw new Error("invalid Google OAuth credential envelope");
+  }
+  return parsed as unknown as GoogleCredentialEnvelope;
+}
+
+function validateResponse(
+  raw: unknown,
+  allowedScopes: readonly string[],
+): asserts raw is GoogleRefreshResponse & { access_token: string } {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error("invalid Google refresh response");
+  }
+  const response = raw as GoogleRefreshResponse;
+  if (
+    typeof response.access_token !== "string" ||
+    response.access_token.length < 1 ||
+    response.access_token.length > 16_384 ||
+    !/^[A-Za-z0-9\-._~+/]+=*$/.test(response.access_token) ||
+    (response.refresh_token !== undefined &&
+      (typeof response.refresh_token !== "string" ||
+        response.refresh_token.length < 1 ||
+        response.refresh_token.length > 16_384 ||
+        !/^[A-Za-z0-9\-._~+/]+=*$/.test(response.refresh_token))) ||
+    (response.token_type !== undefined &&
+      (typeof response.token_type !== "string" ||
+        response.token_type.toLowerCase() !== "bearer")) ||
+    (response.expires_in !== undefined &&
+      (typeof response.expires_in !== "number" ||
+        !Number.isSafeInteger(response.expires_in) ||
+        response.expires_in < 1 ||
+        response.expires_in > 86_400))
+  ) {
+    throw new Error("invalid Google refresh response");
+  }
+  const returnedScopes =
+    response.scope === undefined
+      ? [...allowedScopes]
+      : typeof response.scope === "string" && response.scope.length <= 32_768
+        ? [...new Set(response.scope.split(/\s+/).filter(Boolean))]
+        : [];
+  const allow = new Set(allowedScopes);
+  if (
+    returnedScopes.length < 1 ||
+    returnedScopes.length > 64 ||
+    returnedScopes.some(
+      (scope) => scope.length > 512 || !/^[\x21-\x7e]+$/.test(scope) || !allow.has(scope),
+    )
+  ) {
+    throw new Error("Google refresh widened OAuth scope");
+  }
+}
+
+async function setUnknownOutcome(input: GoogleExecutionCredentialInput, lifecycleId: string) {
+  await withTenantAuditedTransaction(input.tenantId, async (txRaw, append) => {
+    const tx = txRaw as DbExecutor;
+    await tx
+      .update(providerAccounts)
+      .set({ status: "disabled", revision: input.accountRevision + 1, updatedAt: new Date() })
+      .where(
+        and(
+          eq(providerAccounts.tenantId, input.tenantId),
+          eq(providerAccounts.workspaceId, input.workspaceId),
+          eq(providerAccounts.id, input.accountId),
+          eq(providerAccounts.revision, input.accountRevision),
+          eq(providerAccounts.status, "active"),
+        ),
+      );
+    await tx
+      .update(providerGoogleCredentialLifecycles)
+      .set({
+        state: "needs_attention",
+        lastErrorCode: "REFRESH_OUTCOME_UNKNOWN",
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(providerGoogleCredentialLifecycles.tenantId, input.tenantId),
+          eq(providerGoogleCredentialLifecycles.id, lifecycleId),
+          eq(providerGoogleCredentialLifecycles.providerAccountId, input.accountId),
+        ),
+      );
+    await append({
+      tenantId: input.tenantId,
+      actorType: "system",
+      actorId: "credential-proxy",
+      action: "provider.google.refresh.needs_attention",
+      resourceType: "provider_account",
+      resourceId: input.accountId,
+      metadata: { lifecycleId, workspaceId: input.workspaceId, reason: "REFRESH_OUTCOME_UNKNOWN" },
+    });
+  });
+}
+
+export interface GoogleExecutionCredentialInput {
+  tenantId: string;
+  workspaceId: string;
+  accountId: string;
+  accountRevision: number;
+  credential: string;
+  vault: SecretVault;
+  clientId: string;
+  clientSecret: string;
+}
+
+/** Mint a short-lived access token at the exact governed execution boundary. */
+export async function mintGoogleExecutionAccessToken(
+  input: GoogleExecutionCredentialInput,
+): Promise<string> {
+  const envelope = parseEnvelope(input.credential);
+  const lifecycleId = randomUUID();
+  await withTenantAuditedTransaction(input.tenantId, async (txRaw, append) => {
+    const tx = txRaw as DbExecutor;
+    const [account] = await tx
+      .select({ id: providerAccounts.id })
+      .from(providerAccounts)
+      .where(
+        and(
+          eq(providerAccounts.tenantId, input.tenantId),
+          eq(providerAccounts.workspaceId, input.workspaceId),
+          eq(providerAccounts.id, input.accountId),
+          eq(providerAccounts.revision, input.accountRevision),
+          eq(providerAccounts.status, "active"),
+        ),
+      )
+      .limit(1)
+      .for("update");
+    if (!account) throw new Error("Google provider account changed before token mint");
+    const [active] = await tx
+      .select({ id: providerGoogleCredentialLifecycles.id })
+      .from(providerGoogleCredentialLifecycles)
+      .where(
+        and(
+          eq(providerGoogleCredentialLifecycles.tenantId, input.tenantId),
+          eq(providerGoogleCredentialLifecycles.providerAccountId, input.accountId),
+          eq(providerGoogleCredentialLifecycles.kind, "refresh_rotation"),
+          inArray(providerGoogleCredentialLifecycles.state, ["inflight", "credential_staged"]),
+        ),
+      )
+      .limit(1);
+    if (active) throw new Error("Google credential refresh is already in progress");
+    await tx.insert(providerGoogleCredentialLifecycles).values({
+      id: lifecycleId,
+      tenantId: input.tenantId,
+      workspaceId: input.workspaceId,
+      providerAccountId: input.accountId,
+      kind: "refresh_rotation",
+      state: "inflight",
+      expectedAccountRevision: input.accountRevision,
+    });
+    await append({
+      tenantId: input.tenantId,
+      actorType: "system",
+      actorId: "credential-proxy",
+      action: "provider.google.refresh.intent_staged",
+      resourceType: "provider_google_credential_lifecycle",
+      resourceId: lifecycleId,
+      metadata: { workspaceId: input.workspaceId, providerAccountId: input.accountId },
+    });
+  });
+
+  let response: Response;
+  try {
+    response = await googleTokenForwarder(
+      new URLSearchParams({
+        grant_type: "refresh_token",
+        refresh_token: envelope.refreshToken,
+        client_id: input.clientId,
+        client_secret: input.clientSecret,
+      }).toString(),
+    );
+  } catch (error) {
+    await setUnknownOutcome(input, lifecycleId);
+    throw error;
+  }
+
+  let raw: unknown;
+  try {
+    raw = await readBoundedJson(response);
+  } catch (error) {
+    await setUnknownOutcome(input, lifecycleId);
+    throw error;
+  }
+  if (!response.ok) {
+    await setUnknownOutcome(input, lifecycleId);
+    throw new Error(
+      (raw as GoogleRefreshResponse | null)?.error === "invalid_grant"
+        ? "Google refresh token revoked"
+        : "Google refresh failed",
+    );
+  }
+
+  let stagedSecretId: string | null = null;
+  try {
+    await withTenantAuditedTransaction(input.tenantId, async (txRaw, append) => {
+      const tx = txRaw as DbExecutor;
+      const secret = await input.vault.createSecretWithinTx(
+        tx,
+        input.tenantId,
+        `provider-google-lifecycle:${lifecycleId}`,
+        JSON.stringify({ schemaVersion: "steward.provider-google.lifecycle.v1", token: raw }),
+        { description: "Encrypted transient Google OAuth recovery material" },
+      );
+      stagedSecretId = secret.id;
+      const [updated] = await tx
+        .update(providerGoogleCredentialLifecycles)
+        .set({ state: "credential_staged", credentialSecretId: secret.id, updatedAt: new Date() })
+        .where(
+          and(
+            eq(providerGoogleCredentialLifecycles.tenantId, input.tenantId),
+            eq(providerGoogleCredentialLifecycles.id, lifecycleId),
+            eq(providerGoogleCredentialLifecycles.state, "inflight"),
+          ),
+        )
+        .returning({ id: providerGoogleCredentialLifecycles.id });
+      if (!updated) throw new Error("Google refresh lifecycle changed before staging");
+      await append({
+        tenantId: input.tenantId,
+        actorType: "system",
+        actorId: "credential-proxy",
+        action: "provider.google.refresh.credential_staged",
+        resourceType: "provider_google_credential_lifecycle",
+        resourceId: lifecycleId,
+        metadata: { providerAccountId: input.accountId },
+      });
+    });
+  } catch (error) {
+    // The provider may have rotated the refresh token even though its response
+    // could not be durably escrowed. Freeze the old authority before returning.
+    await setUnknownOutcome(input, lifecycleId);
+    throw error;
+  }
+
+  try {
+    validateResponse(raw, envelope.scopesGranted);
+  } catch (error) {
+    await withTenantAuditedTransaction(input.tenantId, async (txRaw) => {
+      const tx = txRaw as DbExecutor;
+      await tx
+        .update(providerGoogleCredentialLifecycles)
+        .set({
+          state: "revocation_pending",
+          lastErrorCode: "INVALID_REFRESH_RESPONSE",
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(providerGoogleCredentialLifecycles.tenantId, input.tenantId),
+            eq(providerGoogleCredentialLifecycles.id, lifecycleId),
+          ),
+        );
+    });
+    throw error;
+  }
+
+  if (raw.refresh_token === undefined) {
+    await withTenantAuditedTransaction(input.tenantId, async (txRaw, append) => {
+      const tx = txRaw as DbExecutor;
+      await tx
+        .update(providerGoogleCredentialLifecycles)
+        .set({ state: "adopted", credentialSecretId: null, updatedAt: new Date() })
+        .where(
+          and(
+            eq(providerGoogleCredentialLifecycles.tenantId, input.tenantId),
+            eq(providerGoogleCredentialLifecycles.id, lifecycleId),
+            eq(providerGoogleCredentialLifecycles.credentialSecretId, stagedSecretId as string),
+          ),
+        );
+      await tx
+        .delete(secrets)
+        .where(and(eq(secrets.tenantId, input.tenantId), eq(secrets.id, stagedSecretId as string)));
+      await append({
+        tenantId: input.tenantId,
+        actorType: "system",
+        actorId: "credential-proxy",
+        action: "provider.google.refresh.execution_token_minted",
+        resourceType: "provider_account",
+        resourceId: input.accountId,
+        metadata: { lifecycleId, workspaceId: input.workspaceId },
+      });
+    });
+  }
+
+  return raw.access_token;
+}

--- a/packages/proxy/src/handlers/google-execution-credential.ts
+++ b/packages/proxy/src/handlers/google-execution-credential.ts
@@ -136,11 +136,10 @@ function validateResponse(
     (response.token_type !== undefined &&
       (typeof response.token_type !== "string" ||
         response.token_type.toLowerCase() !== "bearer")) ||
-    (response.expires_in !== undefined &&
-      (typeof response.expires_in !== "number" ||
-        !Number.isSafeInteger(response.expires_in) ||
-        response.expires_in < 1 ||
-        response.expires_in > 86_400))
+    typeof response.expires_in !== "number" ||
+    !Number.isSafeInteger(response.expires_in) ||
+    response.expires_in < 300 ||
+    response.expires_in > 86_400
   ) {
     throw new Error("invalid Google refresh response");
   }
@@ -345,8 +344,20 @@ export async function mintGoogleExecutionAccessToken(
   try {
     validateResponse(raw, envelope.scopesGranted);
   } catch (error) {
-    await withTenantAuditedTransaction(input.tenantId, async (txRaw) => {
+    await withTenantAuditedTransaction(input.tenantId, async (txRaw, append) => {
       const tx = txRaw as DbExecutor;
+      await tx
+        .update(providerAccounts)
+        .set({ status: "disabled", revision: input.accountRevision + 1, updatedAt: new Date() })
+        .where(
+          and(
+            eq(providerAccounts.tenantId, input.tenantId),
+            eq(providerAccounts.workspaceId, input.workspaceId),
+            eq(providerAccounts.id, input.accountId),
+            eq(providerAccounts.revision, input.accountRevision),
+            eq(providerAccounts.status, "active"),
+          ),
+        );
       await tx
         .update(providerGoogleCredentialLifecycles)
         .set({
@@ -360,6 +371,15 @@ export async function mintGoogleExecutionAccessToken(
             eq(providerGoogleCredentialLifecycles.id, lifecycleId),
           ),
         );
+      await append({
+        tenantId: input.tenantId,
+        actorType: "system",
+        actorId: "credential-proxy",
+        action: "provider.google.refresh.invalid_response",
+        resourceType: "provider_account",
+        resourceId: input.accountId,
+        metadata: { lifecycleId, workspaceId: input.workspaceId },
+      });
     });
     throw error;
   }

--- a/packages/proxy/src/handlers/proxy.ts
+++ b/packages/proxy/src/handlers/proxy.ts
@@ -47,8 +47,14 @@ import {
 } from "../middleware/redis-enforcement";
 import { resolveTarget } from "./alias";
 import { holdProxyApprovalRequest } from "./approvals";
+import {
+  __setGoogleExecutionTokenForwarderForTests,
+  mintGoogleExecutionAccessToken,
+} from "./google-execution-credential";
 import { compareRouteMatchSpecificity, matchHost, matchPath } from "./matching";
 import { applyGovernedQuery, extractRawQuery } from "./query-forwarding";
+
+export { __setGoogleExecutionTokenForwarderForTests };
 
 // ─── Secret Vault singleton ──────────────────────────────────────────────────
 
@@ -1235,6 +1241,7 @@ export function __resetProxyHandlerTestHooksForTests(): void {
   checkProxyRateLimitForHandler = checkProxyRateLimit;
   resolveProxyHostForHandler = dnsLookup;
   forwardProxyRequestForHandler = forwardWithVettedDns;
+  __setGoogleExecutionTokenForwarderForTests(null);
 }
 
 // ─── Main proxy handler ──────────────────────────────────────────────────────
@@ -1781,6 +1788,7 @@ export async function handleProxy(c: Context): Promise<Response> {
       : c.json({ ok: false, error }, 409);
   };
 
+  let governedLiveAccountRevision: number | null = null;
   if (authorityMode === "governed_v2" && governedClaim) {
     const db = getDb();
     const [liveWorkspace] = await db
@@ -1838,6 +1846,7 @@ export async function handleProxy(c: Context): Promise<Response> {
         "governed-operation-revision-stale",
       );
     }
+    governedLiveAccountRevision = liveAccount.revision;
     const [liveSecret] = await db
       .select({ version: secrets.version })
       .from(secrets)
@@ -1854,9 +1863,28 @@ export async function handleProxy(c: Context): Promise<Response> {
   let credential: string;
   try {
     credential = await decryptSecret(tenantId, route.secretId);
-    // Only Google's short-lived access token crosses the provider boundary.
-    // Its refresh token remains server-side inside the encrypted envelope.
-    credential = extractProviderCredentialForHost(target.host, credential);
+    const googleHost =
+      target.host === "gmail.googleapis.com" || target.host === "www.googleapis.com";
+    if (googleHost) {
+      if (!governedClaim || governedLiveAccountRevision === null) {
+        throw new Error("Google OAuth credentials require governed execution");
+      }
+      const clientId = process.env.GOOGLE_PROVIDER_CLIENT_ID?.trim();
+      const clientSecret = process.env.GOOGLE_PROVIDER_CLIENT_SECRET?.trim();
+      if (!clientId || !clientSecret) throw new Error("Google provider OAuth is not configured");
+      credential = await mintGoogleExecutionAccessToken({
+        tenantId,
+        workspaceId: governedClaim.workspaceId as string,
+        accountId: governedClaim.providerAccountId as string,
+        accountRevision: governedLiveAccountRevision,
+        credential,
+        vault: getSecretVault(),
+        clientId,
+        clientSecret,
+      });
+    } else {
+      credential = extractProviderCredentialForHost(target.host, credential);
+    }
   } catch (err) {
     console.error(`[proxy] Failed to decrypt secret ${route.secretId}:`, err);
     await recordAudit({


### PR DESCRIPTION
## Summary

Canonical corrective follow-up to the prematurely merged #417. This draft consolidates the stronger security properties from superseded drafts #424 and #427.

- automatically reconcile bounded Google OAuth credential lifecycles at long-lived startup/interval and Worker cron
- mint ephemeral Google access tokens at the exact governed execution boundary; never rely on persisted access tokens
- durably escrow rotating refresh responses, freeze authority on outcome-unknown or escrow failure, and move credential routes to the adopted secret lineage
- journal disconnect revocation before provider I/O while revoking local authority in the same transaction; block reconnect until the old revoker reaches a terminal state
- register fixed Google Gmail/Calendar authority tuples with exact host, path, method, risk, and Authorization header constraints

## Security properties

- refresh tokens and OAuth responses remain encrypted at rest
- only a newly minted bounded Bearer access token crosses the Google provider boundary
- short-lived refresh results, scope widening, malformed tokens, generic/classic route use, route confusion, and risk downgrade fail closed
- invalid refresh responses disable local authority before another mint and retain an encrypted revocation handle
- disconnect crashes before or after provider revocation leave local authority revoked and recover through migration 0099-backed scheduled reconciliation
- a pending disconnect revoker cannot race a reconnect into revoking newly installed credentials
- terminal lifecycle rows cannot be rolled back by a stale concurrent reconciler
- stale execution authorizations are invalidated when credential adoption bumps route/account revision

## Validation

Exact head: `80e78d1a9ffceff1e91e0548605be821f25dc484`
Base validated: `1ac3bd4a032d1f73d3d61537bad355a0d914b395`

- focused Google/auth/authority/provider-boundary suites: 119 passed, 0 failed
- Redis monotonic-TTL integration test is present and environment-gated; skipped locally without Redis
- migration 0099 applied successfully in isolated PGlite suites
- DB, proxy, and API TypeScript builds passed
- Biome and `git diff --check` passed

This PR is intentionally left draft for exact-head review.
