### PR TITLE
feat(provider-google): refresh governed Google actions at dispatch

### DIFF
--- a/packages/api/src/__tests__/provider-authority.test.ts
+++ b/packages/api/src/__tests__/provider-authority.test.ts
@@ -9,12 +9,14 @@ import {
   providerGrants,
   providerOperations,
   providerRoleBindings,
+  secretRoutes,
   tenants,
   users,
   userTenants,
   workspaces,
 } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { SecretVault } from "@stwd/vault";
 import { and, eq } from "drizzle-orm";
 import { type AuthorityAudit, ProviderAuthorityStore } from "../services/provider-authority-store";
 
@@ -32,6 +34,7 @@ const ACCOUNT_B = "30000000-0000-4000-8000-000000000002";
 const OP_A_READ = "40000000-0000-4000-8000-000000000001";
 const OP_A_WRITE = "40000000-0000-4000-8000-000000000002";
 const OP_B_READ = "40000000-0000-4000-8000-000000000003";
+const MASTER_PASSWORD = "provider-authority-google-route-test-master";
 const store = new ProviderAuthorityStore();
 const auditEvents: Array<{ action: string; resourceType: string }> = [];
 const audit: AuthorityAudit = async (event) => {
@@ -156,6 +159,7 @@ async function seedCore() {
 describe("provider authority foundation", () => {
   beforeAll(async () => {
     process.env.STEWARD_PGLITE_MEMORY = "true";
+    process.env.STEWARD_MASTER_PASSWORD = MASTER_PASSWORD;
     const { db, client } = await createPGLiteDb("memory://");
     setPGLiteOverride(db, async () => client.close());
     await seedCore();
@@ -164,6 +168,7 @@ describe("provider authority foundation", () => {
   afterAll(async () => {
     await closeDb();
     delete process.env.STEWARD_PGLITE_MEMORY;
+    delete process.env.STEWARD_MASTER_PASSWORD;
   });
 
   test("owner bootstrap transitions one way to explicit tenant authority", async () => {
@@ -468,6 +473,109 @@ describe("provider authority foundation", () => {
         })
       ).effect,
     ).toBe("deny");
+  });
+
+  test("Google governed operations require the exact host/path/Bearer route contract and no understated risk", async () => {
+    const vault = new SecretVault(MASTER_PASSWORD);
+    const [workspace] = await getDb()
+      .select()
+      .from(workspaces)
+      .where(eq(workspaces.id, WORKSPACE_A));
+    const secret = await vault.createSecret("tenant-main", `google-${crypto.randomUUID()}`, "stub");
+    const exactRoute = await vault.createRoute("tenant-main", secret.id, {
+      agentId: "agent-x",
+      hostPattern: "gmail.googleapis.com",
+      pathPattern: "/gmail/v1/users/me/messages/send",
+      method: "POST",
+      injectAs: "header",
+      injectKey: "authorization",
+      injectFormat: "Bearer {value}",
+    });
+    const account = await store.createProviderAccount(
+      mutation({
+        actorUserId: ADMIN,
+        tenantRole: "admin",
+        expectedRevision: workspace.revision,
+      }),
+      {
+        workspaceId: WORKSPACE_A,
+        adapterKey: "google",
+        externalRef: `google-user-${crypto.randomUUID()}`,
+        displayName: "Google Account",
+        credentialSecretId: secret.id,
+        credentialVersion: secret.version,
+      },
+    );
+    const registered = await store.registerOperation(
+      mutation({
+        actorUserId: ADMIN,
+        tenantRole: "admin",
+        expectedRevision: account.revision,
+      }),
+      account.id,
+      {
+        operationKey: "google.gmail.messages.send",
+        riskClass: "consequential",
+        secretRouteId: exactRoute.id,
+      },
+    );
+    expect(registered.operationKey).toBe("google.gmail.messages.send");
+    const [promoted] = await getDb()
+      .select({
+        authorityMode: secretRoutes.authorityMode,
+        providerOperationId: secretRoutes.providerOperationId,
+      })
+      .from(secretRoutes)
+      .where(eq(secretRoutes.id, exactRoute.id));
+    expect(promoted.authorityMode).toBe("governed_v2");
+    expect(promoted.providerOperationId).toBe(registered.id);
+
+    const exactRoute2 = await vault.createRoute("tenant-main", secret.id, {
+      agentId: "agent-y",
+      hostPattern: "gmail.googleapis.com",
+      pathPattern: "/gmail/v1/users/me/messages/send",
+      method: "POST",
+      injectAs: "header",
+      injectKey: "authorization",
+      injectFormat: "Token {value}",
+    });
+    const [liveAccount] = await getDb()
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, account.id));
+    await expect(
+      store.registerOperation(
+        mutation({
+          actorUserId: ADMIN,
+          tenantRole: "admin",
+          expectedRevision: liveAccount.revision,
+        }),
+        account.id,
+        {
+          operationKey: "google.gmail.messages.send",
+          riskClass: "write",
+          secretRouteId: exactRoute2.id,
+        },
+      ),
+    ).rejects.toMatchObject({ code: "forbidden" });
+    const [rejectedRoute] = await getDb()
+      .select({
+        authorityMode: secretRoutes.authorityMode,
+        providerOperationId: secretRoutes.providerOperationId,
+      })
+      .from(secretRoutes)
+      .where(eq(secretRoutes.id, exactRoute2.id));
+    expect(rejectedRoute.authorityMode).toBe("legacy");
+    expect(rejectedRoute.providerOperationId).toBeNull();
+    const operations = await getDb()
+      .select({
+        id: providerOperations.id,
+        operationKey: providerOperations.operationKey,
+      })
+      .from(providerOperations)
+      .where(eq(providerOperations.providerAccountId, account.id));
+    expect(operations).toHaveLength(1);
+    expect(operations[0]?.operationKey).toBe("google.gmail.messages.send");
   });
 
   test("Client A allow cannot be replayed against Client B or mixed identifiers", async () => {

--- a/packages/api/src/services/provider-authority-store.ts
+++ b/packages/api/src/services/provider-authority-store.ts
@@ -53,48 +53,82 @@ const SLACK_OPERATION_EXACT_PATH = {
   "slack.conversations.list": "/api/conversations.list",
   "slack.users.info": "/api/users.info",
 } as const satisfies Readonly<Record<SlackOperationKey, string>>;
-const PROVIDER_OPERATION_ALLOWLIST: Readonly<
-  Record<string, Readonly<Record<string, "GET" | "POST" | "DELETE">>>
+type FixedAdapterOperationContract = Readonly<{
+  method: "GET" | "POST" | "DELETE";
+  host: string;
+  exactPath?: string;
+  minimumRiskClass?: ProviderRiskClass;
+  injectAs?: "header";
+  injectKey?: string;
+  injectFormat?: string;
+}>;
+const FIXED_ADAPTER_OPERATION_CONTRACTS: Readonly<
+  Record<string, Readonly<Record<string, FixedAdapterOperationContract>>>
 > = {
   github: {
-    "github.issue.list": "GET",
-    "github.pr.comment.create": "POST",
+    "github.issue.list": { method: "GET", host: "api.github.com", minimumRiskClass: "read" },
+    "github.pr.comment.create": {
+      method: "POST",
+      host: "api.github.com",
+      minimumRiskClass: "consequential",
+    },
+  },
+  google: {
+    "google.gmail.messages.send": {
+      method: "POST",
+      host: "gmail.googleapis.com",
+      exactPath: "/gmail/v1/users/me/messages/send",
+      minimumRiskClass: "consequential",
+      injectAs: "header",
+      injectKey: "authorization",
+      injectFormat: "Bearer {value}",
+    },
+    "google.calendar.events.list": {
+      method: "GET",
+      host: "www.googleapis.com",
+      exactPath: "/calendar/v3/calendars/primary/events",
+      minimumRiskClass: "read",
+      injectAs: "header",
+      injectKey: "authorization",
+      injectFormat: "Bearer {value}",
+    },
+    "google.calendar.events.insert": {
+      method: "POST",
+      host: "www.googleapis.com",
+      exactPath: "/calendar/v3/calendars/primary/events",
+      minimumRiskClass: "consequential",
+      injectAs: "header",
+      injectKey: "authorization",
+      injectFormat: "Bearer {value}",
+    },
   },
   x: {
-    "x.tweet.create": "POST",
-    "x.tweet.delete": "DELETE",
-    "x.user.me.read": "GET",
+    "x.tweet.create": { method: "POST", host: "api.x.com", minimumRiskClass: "consequential" },
+    "x.tweet.delete": { method: "DELETE", host: "api.x.com", minimumRiskClass: "write" },
+    "x.user.me.read": { method: "GET", host: "api.x.com", minimumRiskClass: "read" },
   },
-  slack: SLACK_OPERATION_METHOD,
-};
-const PROVIDER_OPERATION_MINIMUM_RISK: Readonly<
-  Record<string, Readonly<Record<string, ProviderRiskClass>>>
-> = {
-  github: {
-    "github.issue.list": "read",
-    "github.pr.comment.create": "write",
+  slack: {
+    "slack.chat.postMessage": {
+      method: SLACK_OPERATION_METHOD["slack.chat.postMessage"],
+      host: "slack.com",
+      exactPath: SLACK_OPERATION_EXACT_PATH["slack.chat.postMessage"],
+      minimumRiskClass: SLACK_OPERATION_RISK["slack.chat.postMessage"],
+    },
+    "slack.conversations.list": {
+      method: SLACK_OPERATION_METHOD["slack.conversations.list"],
+      host: "slack.com",
+      exactPath: SLACK_OPERATION_EXACT_PATH["slack.conversations.list"],
+      minimumRiskClass: SLACK_OPERATION_RISK["slack.conversations.list"],
+    },
+    "slack.users.info": {
+      method: SLACK_OPERATION_METHOD["slack.users.info"],
+      host: "slack.com",
+      exactPath: SLACK_OPERATION_EXACT_PATH["slack.users.info"],
+      minimumRiskClass: SLACK_OPERATION_RISK["slack.users.info"],
+    },
   },
-  x: {
-    "x.tweet.create": "write",
-    "x.tweet.delete": "write",
-    "x.user.me.read": "read",
-  },
-  slack: SLACK_OPERATION_RISK,
 };
-const PROVIDER_OPERATION_EXACT_PATH: Readonly<Record<string, Readonly<Record<string, string>>>> = {
-  slack: SLACK_OPERATION_EXACT_PATH,
-};
-const PROVIDER_RISK_RANK: Readonly<Record<ProviderRiskClass, number>> = {
-  read: 0,
-  write: 1,
-  consequential: 2,
-};
-const PROVIDER_HOST_ALLOWLIST: Readonly<Record<string, string>> = {
-  github: "api.github.com",
-  x: "api.x.com",
-  slack: "slack.com",
-};
-const REGISTERED_ADAPTER_KEYS = new Set(["github", "x", "slack", "generic-http"]);
+const REGISTERED_ADAPTER_KEYS = new Set(["github", "google", "x", "slack", "generic-http"]);
 const ENVIRONMENTS = new Set(["development", "staging", "production"]);
 const PRINCIPAL_TYPES = new Set(["human", "agent"]);
 const ROLES = new Set([
@@ -107,6 +141,11 @@ const ROLES = new Set([
 const RISK_CLASSES = new Set(["read", "write", "consequential"]);
 const BUDGET_DIMENSIONS = new Set(["count", "notional"]);
 const MAX_BUDGET_WINDOW_SECONDS = 30 * 24 * 60 * 60;
+const RISK_RANK: Readonly<Record<ProviderRiskClass, number>> = {
+  read: 0,
+  write: 1,
+  consequential: 2,
+};
 
 type DbBase = ReturnType<typeof getDb>;
 type DbExecutor = DbBase | Parameters<Parameters<DbBase["transaction"]>[0]>[0];
@@ -269,6 +308,42 @@ function operationIncluded(keys: string[], operationKey: string): boolean {
 function subset(candidate: string[], allowed: string[]): boolean {
   const set = new Set(allowed);
   return candidate.every((key) => set.has(key));
+}
+
+function fixedAdapterOperationContract(
+  adapterKey: string,
+  operationKey: string,
+): FixedAdapterOperationContract | null {
+  return FIXED_ADAPTER_OPERATION_CONTRACTS[adapterKey]?.[operationKey] ?? null;
+}
+
+function routeSatisfiesFixedContract(
+  route: {
+    hostPattern: string;
+    method: string | null;
+    pathPattern: string | null;
+    injectAs: string | null;
+    injectKey: string | null;
+    injectFormat: string | null;
+  },
+  contract: FixedAdapterOperationContract,
+): boolean {
+  const method = route.method?.toUpperCase();
+  if (route.hostPattern !== contract.host || !method || method !== contract.method) return false;
+  if (contract.exactPath) {
+    if (route.pathPattern !== contract.exactPath) return false;
+  } else if (!route.pathPattern || route.pathPattern.includes("*")) {
+    return false;
+  }
+  if (contract.injectAs && route.injectAs !== contract.injectAs) return false;
+  if (
+    contract.injectKey &&
+    route.injectKey?.trim().toLowerCase() !== contract.injectKey.trim().toLowerCase()
+  ) {
+    return false;
+  }
+  if (contract.injectFormat && route.injectFormat !== contract.injectFormat) return false;
+  return true;
 }
 
 export class ProviderAuthorityStore {
@@ -795,6 +870,7 @@ export class ProviderAuthorityStore {
     // make the registered adapter impossible to configure.
     if (account.adapterKey === "generic-http" && !OPERATION_KEY.test(operationKey))
       throw new ProviderAuthorityError("invalid operationKey", "bad_request", 400);
+    let fixedContract: FixedAdapterOperationContract | null = null;
     let allowedMethods: readonly string[];
     let genericDescriptor: ReturnType<typeof validateGenericHttpDescriptor> | undefined;
     if (account.adapterKey === "generic-http") {
@@ -815,22 +891,24 @@ export class ProviderAuthorityStore {
         );
       }
     } else {
-      const fixedMethod = PROVIDER_OPERATION_ALLOWLIST[account.adapterKey]?.[operationKey];
-      if (!fixedMethod)
+      fixedContract = fixedAdapterOperationContract(account.adapterKey, operationKey);
+      if (!fixedContract)
         throw new ProviderAuthorityError(
           "operation is not in the adapter allowlist",
           "forbidden",
           403,
         );
-      const minimumRisk = PROVIDER_OPERATION_MINIMUM_RISK[account.adapterKey]?.[operationKey];
-      if (!minimumRisk || PROVIDER_RISK_RANK[input.riskClass] < PROVIDER_RISK_RANK[minimumRisk]) {
+      allowedMethods = [fixedContract.method];
+      if (
+        fixedContract.minimumRiskClass &&
+        RISK_RANK[input.riskClass] < RISK_RANK[fixedContract.minimumRiskClass]
+      ) {
         throw new ProviderAuthorityError(
-          "riskClass understates the adapter operation risk",
-          "bad_request",
-          400,
+          "riskClass understates the adapter operation",
+          "forbidden",
+          403,
         );
       }
-      allowedMethods = [fixedMethod];
     }
     if (account.adapterKey === "generic-http" && !input.secretRouteId) {
       throw new ProviderAuthorityError(
@@ -859,27 +937,21 @@ export class ProviderAuthorityStore {
           ),
         )
         .limit(1);
-      const expectedHost = genericDescriptor
-        ? new URL(genericDescriptor.origin).hostname
-        : PROVIDER_HOST_ALLOWLIST[account.adapterKey];
-      const method = route?.method?.toUpperCase();
-      const pathAllowed = genericDescriptor
-        ? Boolean(
-            route?.pathPattern &&
-              genericDescriptorAllowsExactPath(genericDescriptor, route.pathPattern),
-          )
-        : PROVIDER_OPERATION_EXACT_PATH[account.adapterKey]?.[operationKey]
-          ? route?.pathPattern === PROVIDER_OPERATION_EXACT_PATH[account.adapterKey]?.[operationKey]
-          : Boolean(route?.pathPattern && !route.pathPattern.includes("*"));
+      const routeMatchesFixedContract =
+        route && fixedContract ? routeSatisfiesFixedContract(route, fixedContract) : false;
+      const pathAllowed =
+        route && genericDescriptor
+          ? Boolean(
+              route.pathPattern &&
+                genericDescriptorAllowsExactPath(genericDescriptor, route.pathPattern),
+            )
+          : routeMatchesFixedContract;
       if (
         !route ||
         route.secretId !== credentialSecretId ||
         !route.agentId ||
         route.authorityMode !== "legacy" ||
         route.providerOperationId !== null ||
-        route.hostPattern !== expectedHost ||
-        !method ||
-        !allowedMethods.includes(method) ||
         !pathAllowed
       ) {
         throw new ProviderAuthorityError(
@@ -890,7 +962,7 @@ export class ProviderAuthorityStore {
       }
       const promotedPath = genericDescriptor
         ? genericDescriptorGovernedRoutePattern(genericDescriptor)
-        : route.pathPattern;
+        : (fixedContract?.exactPath ?? route.pathPattern);
       // This early overlap check is only a fast rejection. The transaction below
       // repeats it after locking the agent's route namespace.
       const siblings = await this.db()
@@ -966,19 +1038,15 @@ export class ProviderAuthorityStore {
           )
           .limit(1);
         const credentialSecretId = account.credentialSecretId;
-        const expectedHost = genericDescriptor
-          ? new URL(genericDescriptor.origin).hostname
-          : PROVIDER_HOST_ALLOWLIST[account.adapterKey];
-        const method = route?.method?.toUpperCase();
-        const pathAllowed = genericDescriptor
-          ? Boolean(
-              route?.pathPattern &&
-                genericDescriptorAllowsExactPath(genericDescriptor, route.pathPattern),
-            )
-          : PROVIDER_OPERATION_EXACT_PATH[account.adapterKey]?.[operationKey]
-            ? route?.pathPattern ===
-              PROVIDER_OPERATION_EXACT_PATH[account.adapterKey]?.[operationKey]
-            : Boolean(route?.pathPattern && !route.pathPattern.includes("*"));
+        const routeMatchesFixedContract =
+          route && fixedContract ? routeSatisfiesFixedContract(route, fixedContract) : false;
+        const pathAllowed =
+          route && genericDescriptor
+            ? Boolean(
+                route.pathPattern &&
+                  genericDescriptorAllowsExactPath(genericDescriptor, route.pathPattern),
+              )
+            : routeMatchesFixedContract;
         if (
           !credentialSecretId ||
           !route ||
@@ -986,9 +1054,6 @@ export class ProviderAuthorityStore {
           route.secretId !== credentialSecretId ||
           route.authorityMode !== "legacy" ||
           route.providerOperationId !== null ||
-          route.hostPattern !== expectedHost ||
-          !method ||
-          !allowedMethods.includes(method) ||
           !pathAllowed
         ) {
           throw new ProviderAuthorityError(
@@ -1004,7 +1069,7 @@ export class ProviderAuthorityStore {
             authorityMode: "governed_v2",
             pathPattern: genericDescriptor
               ? genericDescriptorGovernedRoutePattern(genericDescriptor)
-              : route.pathPattern,
+              : (fixedContract?.exactPath ?? route.pathPattern),
           });
         } catch (error) {
           if (error instanceof SecretRouteAuthorityConflict) {

--- a/packages/proxy/src/__tests__/google-credential-envelope.test.ts
+++ b/packages/proxy/src/__tests__/google-credential-envelope.test.ts
@@ -1,6 +1,19 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 import { GOOGLE_GOLDEN_VECTORS } from "@stwd/shared";
-import { extractProviderCredentialForHost } from "../handlers/proxy";
+import {
+  __setGoogleRefreshFetcherForTests,
+  extractProviderCredentialForHost,
+  resolveProviderCredentialForHost,
+} from "../handlers/proxy";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  __setGoogleRefreshFetcherForTests(null);
+  delete process.env.GOOGLE_PROVIDER_CLIENT_ID;
+  delete process.env.GOOGLE_PROVIDER_CLIENT_SECRET;
+  globalThis.fetch = originalFetch;
+});
 
 describe("Google OAuth credential envelope", () => {
   it("imports the shared canonical corpus used by the API", () => {
@@ -11,6 +24,11 @@ describe("Google OAuth credential envelope", () => {
       schemaVersion: "steward.provider-google.credential.v1",
       accessToken: "access-canary",
       refreshToken: "refresh-canary",
+      scopesGranted: ["openid", "email", "https://www.googleapis.com/auth/gmail.send"],
+      googleUserId: "google-user-123",
+      googleEmail: "approver@example.com",
+      obtainedAt: new Date(Date.now() - 30_000).toISOString(),
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
     });
     expect(extractProviderCredentialForHost("gmail.googleapis.com", value)).toBe("access-canary");
     expect(extractProviderCredentialForHost("gmail.googleapis.com", value)).not.toContain(
@@ -34,5 +52,163 @@ describe("Google OAuth credential envelope", () => {
     expect(() =>
       extractProviderCredentialForHost("www.googleapis.com", JSON.stringify({ accessToken: "x" })),
     ).toThrow();
+  });
+
+  it("mints a fresh access token from the server-held refresh token when the cached token is near expiry", async () => {
+    process.env.GOOGLE_PROVIDER_CLIENT_ID = "google-provider-client";
+    process.env.GOOGLE_PROVIDER_CLIENT_SECRET = "google-provider-secret";
+    let refreshTokenSeen: string | null = null;
+    __setGoogleRefreshFetcherForTests(async ({ refreshToken, allowedScopes }) => {
+      refreshTokenSeen = refreshToken;
+      expect(allowedScopes).toEqual([
+        "openid",
+        "email",
+        "https://www.googleapis.com/auth/gmail.send",
+      ]);
+      return {
+        revoked: false,
+        accessToken: "access-fresh-from-refresh",
+        scopes: [...allowedScopes],
+        expiresIn: 3600,
+      };
+    });
+    const value = JSON.stringify({
+      schemaVersion: "steward.provider-google.credential.v1",
+      accessToken: "access-expiring",
+      refreshToken: "refresh-server-held-canary",
+      scopesGranted: ["openid", "email", "https://www.googleapis.com/auth/gmail.send"],
+      googleUserId: "google-user-123",
+      googleEmail: "approver@example.com",
+      obtainedAt: new Date(Date.now() - 30_000).toISOString(),
+      expiresAt: new Date(Date.now() + 1_000).toISOString(),
+    });
+    const token = await resolveProviderCredentialForHost("gmail.googleapis.com", value);
+    expect(token).toBe("access-fresh-from-refresh");
+    expect(token).not.toContain("refresh-server-held-canary");
+    expect(refreshTokenSeen).toBe("refresh-server-held-canary");
+  });
+
+  it("fails closed when dispatch-time refresh rotates the Google refresh token", async () => {
+    process.env.GOOGLE_PROVIDER_CLIENT_ID = "google-provider-client";
+    process.env.GOOGLE_PROVIDER_CLIENT_SECRET = "google-provider-secret";
+    __setGoogleRefreshFetcherForTests(async () => ({
+      revoked: false,
+      accessToken: "access-fresh-from-refresh",
+      refreshToken: "rotated-refresh-token",
+      scopes: ["openid", "email", "https://www.googleapis.com/auth/gmail.send"],
+      expiresIn: 3600,
+    }));
+    const value = JSON.stringify({
+      schemaVersion: "steward.provider-google.credential.v1",
+      accessToken: "access-expiring",
+      refreshToken: "refresh-server-held-canary",
+      scopesGranted: ["openid", "email", "https://www.googleapis.com/auth/gmail.send"],
+      googleUserId: "google-user-123",
+      googleEmail: "approver@example.com",
+      obtainedAt: new Date(Date.now() - 30_000).toISOString(),
+      expiresAt: new Date(Date.now() + 1_000).toISOString(),
+    });
+    await expect(resolveProviderCredentialForHost("gmail.googleapis.com", value)).rejects.toThrow(
+      "Google refresh rotated the credential during governed dispatch",
+    );
+  });
+
+  it("fails closed when dispatch-time refresh returns a still-near-expiry access token", async () => {
+    process.env.GOOGLE_PROVIDER_CLIENT_ID = "google-provider-client";
+    process.env.GOOGLE_PROVIDER_CLIENT_SECRET = "google-provider-secret";
+    __setGoogleRefreshFetcherForTests(async () => ({
+      revoked: false,
+      accessToken: "access-too-short-lived",
+      scopes: ["openid", "email", "https://www.googleapis.com/auth/gmail.send"],
+      expiresIn: 299,
+    }));
+    const value = JSON.stringify({
+      schemaVersion: "steward.provider-google.credential.v1",
+      accessToken: "access-expiring",
+      refreshToken: "refresh-server-held-canary",
+      scopesGranted: ["openid", "email", "https://www.googleapis.com/auth/gmail.send"],
+      googleUserId: "google-user-123",
+      googleEmail: "approver@example.com",
+      obtainedAt: new Date(Date.now() - 30_000).toISOString(),
+      expiresAt: new Date(Date.now() + 1_000).toISOString(),
+    });
+    await expect(resolveProviderCredentialForHost("gmail.googleapis.com", value)).rejects.toThrow(
+      "Google refresh returned an access token that expires too soon",
+    );
+  });
+
+  it("fails closed when dispatch-time refresh broadens granted scopes", async () => {
+    process.env.GOOGLE_PROVIDER_CLIENT_ID = "google-provider-client";
+    process.env.GOOGLE_PROVIDER_CLIENT_SECRET = "google-provider-secret";
+    __setGoogleRefreshFetcherForTests(async () => ({
+      revoked: false,
+      accessToken: "access-broadened",
+      scopes: [
+        "openid",
+        "email",
+        "https://www.googleapis.com/auth/gmail.send",
+        "https://www.googleapis.com/auth/calendar.events",
+      ],
+      expiresIn: 3600,
+    }));
+    const value = JSON.stringify({
+      schemaVersion: "steward.provider-google.credential.v1",
+      accessToken: "access-expiring",
+      refreshToken: "refresh-server-held-canary",
+      scopesGranted: ["openid", "email", "https://www.googleapis.com/auth/gmail.send"],
+      googleUserId: "google-user-123",
+      googleEmail: "approver@example.com",
+      obtainedAt: new Date(Date.now() - 30_000).toISOString(),
+      expiresAt: new Date(Date.now() + 1_000).toISOString(),
+    });
+    await expect(resolveProviderCredentialForHost("gmail.googleapis.com", value)).rejects.toThrow(
+      "Google refresh returned invalid scopes",
+    );
+  });
+
+  it("uses the default Google refresh transport with redirect=error and form-encoded credentials", async () => {
+    process.env.GOOGLE_PROVIDER_CLIENT_ID = "google-provider-client";
+    process.env.GOOGLE_PROVIDER_CLIENT_SECRET = "google-provider-secret";
+    let seenUrl: string | null = null;
+    let seenInit: RequestInit | null = null;
+    globalThis.fetch = (async (input, init) => {
+      seenUrl = String(input);
+      seenInit = init ?? null;
+      return new Response(
+        JSON.stringify({
+          access_token: "access-fresh-from-upstream",
+          scope: "openid email https://www.googleapis.com/auth/gmail.send",
+          expires_in: 3600,
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    }) as typeof fetch;
+    const value = JSON.stringify({
+      schemaVersion: "steward.provider-google.credential.v1",
+      accessToken: "access-expiring",
+      refreshToken: "refresh-server-held-canary",
+      scopesGranted: ["openid", "email", "https://www.googleapis.com/auth/gmail.send"],
+      googleUserId: "google-user-123",
+      googleEmail: "approver@example.com",
+      obtainedAt: new Date(Date.now() - 30_000).toISOString(),
+      expiresAt: new Date(Date.now() + 1_000).toISOString(),
+    });
+    await expect(resolveProviderCredentialForHost("gmail.googleapis.com", value)).resolves.toBe(
+      "access-fresh-from-upstream",
+    );
+    expect(seenUrl).toBe("https://oauth2.googleapis.com/token");
+    expect(seenInit?.redirect).toBe("error");
+    expect(seenInit?.method).toBe("POST");
+    expect(seenInit?.headers).toMatchObject({
+      "Content-Type": "application/x-www-form-urlencoded",
+      Accept: "application/json",
+    });
+    expect(String(seenInit?.body)).toContain("grant_type=refresh_token");
+    expect(String(seenInit?.body)).toContain("refresh_token=refresh-server-held-canary");
+    expect(String(seenInit?.body)).toContain("client_id=google-provider-client");
+    expect(String(seenInit?.body)).toContain("client_secret=google-provider-secret");
   });
 });

--- a/packages/proxy/src/handlers/proxy.ts
+++ b/packages/proxy/src/handlers/proxy.ts
@@ -154,24 +154,306 @@ function isSlackBotTokenCredential(value: string): boolean {
   return suffix.length >= 10 && !/[^A-Za-z0-9-]/.test(suffix);
 }
 
-export function extractProviderCredentialForHost(host: string, credential: string): string {
+interface GoogleCredentialEnvelope {
+  schemaVersion: "steward.provider-google.credential.v1";
+  accessToken: string;
+  refreshToken: string | null;
+  scopesGranted: string[];
+  googleUserId: string;
+  googleEmail: string;
+  obtainedAt: string;
+  expiresAt: string | null;
+}
+
+interface GoogleProxyRefreshConfig {
+  clientId: string;
+  clientSecret: string;
+}
+
+interface GoogleRefreshUpstreamResult {
+  revoked: boolean;
+  accessToken: string;
+  refreshToken?: string;
+  scopes?: string[];
+  expiresIn?: number;
+}
+
+interface GoogleRefreshRequest {
+  config: GoogleProxyRefreshConfig;
+  refreshToken: string;
+  allowedScopes: readonly string[];
+}
+
+type GoogleRefreshFetcher = (input: GoogleRefreshRequest) => Promise<GoogleRefreshUpstreamResult>;
+
+class GoogleCredentialResolutionError extends Error {
+  constructor(
+    message: string,
+    readonly governedCode: "EXEC_AUTH_ACCOUNT_DISABLED" | "EXEC_AUTH_STALE_SECRET" | null,
+  ) {
+    super(message);
+    this.name = "GoogleCredentialResolutionError";
+  }
+}
+
+const GOOGLE_PROVIDER_TOKEN_URL = "https://oauth2.googleapis.com/token";
+const GOOGLE_REFRESH_SKEW_MS = 5 * 60 * 1000;
+const GOOGLE_REFRESH_TIMEOUT_MS = 10_000;
+const GOOGLE_REFRESH_MAX_RESPONSE_BYTES = 1024 * 1024;
+
+function parseGoogleCredentialEnvelope(
+  host: string,
+  credential: string,
+): GoogleCredentialEnvelope | null {
   const parsed = safeJsonParseString<Record<string, unknown>>(credential);
   const googleHost = host === "gmail.googleapis.com" || host === "www.googleapis.com";
   if (parsed?.schemaVersion !== "steward.provider-google.credential.v1") {
     if (googleHost) throw new Error("invalid Google OAuth credential envelope");
-    return credential;
+    return null;
   }
-  // Bind the credential type to its intended provider. Merely transforming the
-  // envelope when the destination happens to be Google would let a misbound
-  // route forward the whole JSON value, including the server-held refresh token.
   if (!googleHost) throw new Error("Google OAuth credential used for a non-Google host");
+  const bounded = (v: unknown, max: number): v is string =>
+    typeof v === "string" && v.length > 0 && v.length <= max;
+  const validIso = (v: unknown): v is string => bounded(v, 64) && Number.isFinite(Date.parse(v));
   if (
-    typeof parsed.accessToken !== "string" ||
-    parsed.accessToken.length < 1 ||
-    parsed.accessToken.length > 16_384
-  )
+    !bounded(parsed.accessToken, 16_384) ||
+    !(parsed.refreshToken === null || bounded(parsed.refreshToken, 16_384)) ||
+    !Array.isArray(parsed.scopesGranted) ||
+    parsed.scopesGranted.length === 0 ||
+    parsed.scopesGranted.length > 64 ||
+    !parsed.scopesGranted.every((scope) => bounded(scope, 512)) ||
+    new Set(parsed.scopesGranted).size !== parsed.scopesGranted.length ||
+    !bounded(parsed.googleUserId, 512) ||
+    !bounded(parsed.googleEmail, 512) ||
+    !validIso(parsed.obtainedAt) ||
+    !(parsed.expiresAt === null || validIso(parsed.expiresAt))
+  ) {
     throw new Error("invalid Google OAuth credential envelope");
-  return parsed.accessToken;
+  }
+  return parsed as unknown as GoogleCredentialEnvelope;
+}
+
+function isNearGoogleExpiry(expiresAtIso: string | null): boolean {
+  if (!expiresAtIso) return true;
+  const expiresAt = new Date(expiresAtIso).getTime();
+  return Number.isNaN(expiresAt) || expiresAt - Date.now() <= GOOGLE_REFRESH_SKEW_MS;
+}
+
+function resolveGoogleProxyRefreshConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): GoogleProxyRefreshConfig {
+  const clientId = env.GOOGLE_PROVIDER_CLIENT_ID?.trim();
+  const clientSecret = env.GOOGLE_PROVIDER_CLIENT_SECRET?.trim();
+  if (!clientId || !clientSecret) {
+    throw new GoogleCredentialResolutionError(
+      "Google provider OAuth client configuration is missing",
+      null,
+    );
+  }
+  return { clientId, clientSecret };
+}
+
+async function readBoundedGoogleRefreshText(res: Response): Promise<string> {
+  const declaredLength = res.headers.get("content-length");
+  if (declaredLength) {
+    const length = Number(declaredLength);
+    if (!Number.isFinite(length) || length < 0 || length > GOOGLE_REFRESH_MAX_RESPONSE_BYTES) {
+      await res.body?.cancel().catch(() => {});
+      throw new GoogleCredentialResolutionError(
+        "Google refresh response exceeded maximum size",
+        null,
+      );
+    }
+  }
+  if (!res.body) return "";
+  const reader = res.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > GOOGLE_REFRESH_MAX_RESPONSE_BYTES) {
+        await reader.cancel().catch(() => {});
+        throw new GoogleCredentialResolutionError(
+          "Google refresh response exceeded maximum size",
+          null,
+        );
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(bytes);
+}
+
+function validateGoogleRefreshScopes(
+  scopes: readonly string[],
+  allowedScopes: readonly string[],
+): string[] {
+  if (scopes.length === 0 || scopes.length > allowedScopes.length) {
+    throw new GoogleCredentialResolutionError(
+      "Google refresh returned invalid scopes",
+      "EXEC_AUTH_STALE_SECRET",
+    );
+  }
+  const allowed = new Set(allowedScopes);
+  if (scopes.some((scope) => !allowed.has(scope))) {
+    throw new GoogleCredentialResolutionError(
+      "Google refresh broadened the granted scopes",
+      "EXEC_AUTH_STALE_SECRET",
+    );
+  }
+  return [...scopes];
+}
+
+function validateGoogleRefreshLifetime(expiresIn: number | undefined): number | undefined {
+  if (expiresIn === undefined) return undefined;
+  if (expiresIn * 1000 <= GOOGLE_REFRESH_SKEW_MS) {
+    throw new GoogleCredentialResolutionError(
+      "Google refresh returned an access token that expires too soon",
+      "EXEC_AUTH_STALE_SECRET",
+    );
+  }
+  return expiresIn;
+}
+
+async function defaultGoogleRefreshFetcher(
+  input: GoogleRefreshRequest,
+): Promise<GoogleRefreshUpstreamResult> {
+  const body = new URLSearchParams({
+    grant_type: "refresh_token",
+    refresh_token: input.refreshToken,
+    client_id: input.config.clientId,
+    client_secret: input.config.clientSecret,
+  });
+  const res = await fetch(GOOGLE_PROVIDER_TOKEN_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Accept: "application/json",
+    },
+    body: body.toString(),
+    redirect: "error",
+    signal: AbortSignal.timeout(GOOGLE_REFRESH_TIMEOUT_MS),
+  });
+  const text = await readBoundedGoogleRefreshText(res);
+  const parsed = text.length > 0 ? safeJsonParseString<Record<string, unknown>>(text) : null;
+  if (!res.ok) {
+    if (parsed?.error === "invalid_grant") {
+      return { revoked: true, accessToken: "" };
+    }
+    throw new GoogleCredentialResolutionError(`Google refresh failed (${res.status})`, null);
+  }
+  if (
+    !parsed ||
+    typeof parsed.access_token !== "string" ||
+    parsed.access_token.length < 1 ||
+    parsed.access_token.length > 16_384
+  ) {
+    throw new GoogleCredentialResolutionError("Google refresh response missing access_token", null);
+  }
+  if (
+    parsed.refresh_token !== undefined &&
+    (typeof parsed.refresh_token !== "string" ||
+      parsed.refresh_token.length < 1 ||
+      parsed.refresh_token.length > 16_384)
+  ) {
+    throw new GoogleCredentialResolutionError(
+      "Google refresh returned an invalid refresh token",
+      null,
+    );
+  }
+  if (
+    parsed.scope !== undefined &&
+    (typeof parsed.scope !== "string" || parsed.scope.length > 32_768)
+  ) {
+    throw new GoogleCredentialResolutionError("Google refresh returned invalid scopes", null);
+  }
+  const expiresIn = parsed.expires_in;
+  if (expiresIn !== undefined && expiresIn !== null) {
+    if (
+      typeof expiresIn !== "number" ||
+      !Number.isSafeInteger(expiresIn) ||
+      expiresIn <= 0 ||
+      expiresIn > 30 * 24 * 60 * 60
+    ) {
+      throw new GoogleCredentialResolutionError(
+        "Google refresh returned an invalid expires_in",
+        null,
+      );
+    }
+  }
+  const scopes = parsed.scope
+    ? validateGoogleRefreshScopes(
+        [...new Set(parsed.scope.split(/\s+/).filter(Boolean))],
+        input.allowedScopes,
+      )
+    : undefined;
+  return {
+    revoked: false,
+    accessToken: parsed.access_token,
+    refreshToken: parsed.refresh_token as string | undefined,
+    scopes,
+    expiresIn: validateGoogleRefreshLifetime(expiresIn as number | undefined),
+  };
+}
+
+let googleRefreshFetcherForHandler: GoogleRefreshFetcher = defaultGoogleRefreshFetcher;
+
+export function __setGoogleRefreshFetcherForTests(fetcher: GoogleRefreshFetcher | null): void {
+  googleRefreshFetcherForHandler = fetcher ?? defaultGoogleRefreshFetcher;
+}
+
+export function extractProviderCredentialForHost(host: string, credential: string): string {
+  const envelope = parseGoogleCredentialEnvelope(host, credential);
+  return envelope ? envelope.accessToken : credential;
+}
+
+export async function resolveProviderCredentialForHost(
+  host: string,
+  credential: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<string> {
+  const envelope = parseGoogleCredentialEnvelope(host, credential);
+  if (!envelope) return credential;
+  if (!isNearGoogleExpiry(envelope.expiresAt)) return envelope.accessToken;
+  if (!envelope.refreshToken) {
+    throw new GoogleCredentialResolutionError(
+      "Google OAuth credential cannot mint a fresh access token",
+      "EXEC_AUTH_STALE_SECRET",
+    );
+  }
+  const refreshed = await googleRefreshFetcherForHandler({
+    config: resolveGoogleProxyRefreshConfig(env),
+    refreshToken: envelope.refreshToken,
+    allowedScopes: envelope.scopesGranted,
+  });
+  if (refreshed.revoked) {
+    throw new GoogleCredentialResolutionError(
+      "Google refresh token revoked",
+      "EXEC_AUTH_ACCOUNT_DISABLED",
+    );
+  }
+  if (refreshed.refreshToken !== undefined && refreshed.refreshToken !== envelope.refreshToken) {
+    throw new GoogleCredentialResolutionError(
+      "Google refresh rotated the credential during governed dispatch",
+      "EXEC_AUTH_STALE_SECRET",
+    );
+  }
+  if (refreshed.scopes) {
+    validateGoogleRefreshScopes(refreshed.scopes, envelope.scopesGranted);
+  }
+  validateGoogleRefreshLifetime(refreshed.expiresIn);
+  return refreshed.accessToken;
 }
 
 // ─── Credential injection ────────────────────────────────────────────────────
@@ -1836,8 +2118,21 @@ export async function handleProxy(c: Context): Promise<Response> {
     credential = await decryptSecret(tenantId, route.secretId);
     // Only Google's short-lived access token crosses the provider boundary.
     // Its refresh token remains server-side inside the encrypted envelope.
-    credential = extractProviderCredentialForHost(target.host, credential);
+    credential = await resolveProviderCredentialForHost(target.host, credential);
   } catch (err) {
+    if (
+      authorityMode === "governed_v2" &&
+      governedClaim &&
+      err instanceof GoogleCredentialResolutionError &&
+      err.governedCode
+    ) {
+      return denyGovernedAtDecryptBoundary(
+        err.governedCode,
+        err.governedCode === "EXEC_AUTH_ACCOUNT_DISABLED"
+          ? "governed-google-refresh-revoked"
+          : "governed-google-refresh-stale",
+      );
+    }
     console.error(`[proxy] Failed to decrypt secret ${route.secretId}:`, err);
     await recordAudit({
       agentId,


### PR DESCRIPTION
## Summary
- add exact fixed-contract Google governed route binding in `ProviderAuthorityStore` for host, method, path, Bearer injection, and minimum risk
- refresh near-expiry governed Google credentials at proxy execution time without mutating provider-account revision or forwarding the server-held refresh token
- add hostile transport and rollback coverage while preserving the exact three Google action builders and reconstruction/conformance tests

## Testing
- `bun test --timeout 120000 packages/api/src/__tests__/provider-authority.test.ts`
- `bun test --timeout 120000 packages/api/src/__tests__/provider-google-approval-rebuild.test.ts`
- `bun test --timeout 120000 packages/api/src/__tests__/production-profile-conformance.test.ts`
- `bun test --timeout 120000 packages/proxy/src/__tests__/google-credential-envelope.test.ts`
- `bun test --timeout 120000 packages/proxy/src/__tests__/governed-execution.test.ts`
- `bun run build --filter=@stwd/provider-google`
- `bun run build --filter=@stwd/api`
- `bun run build --filter=@stwd/proxy` (cache-green on this head)

## Known blocker on current develop
A no-cache local turbo build on current `develop` is already red in workspace dependencies (`@stwd/redis` failing to resolve `@upstash/redis`), so this PR stays draft until exact CI runs on GitHub and that base/build condition is sorted.

Related: #203 remains open until this follow-up merges and exact CI is green.
