### PR TITLE
fix(auth): prevent stale revocation TTL shortening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -596,6 +596,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Verify Redis revocation monotonicity
+        run: bun test packages/auth/src/__tests__/redis-revocation.integration.test.ts
+
       - name: Start embedded API
         env:
           PORT: "3200"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -689,6 +689,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Verify Redis revocation monotonicity
+        run: bun test packages/auth/src/__tests__/redis-revocation.integration.test.ts
+
       - name: Start embedded API
         env:
           PORT: "3200"

--- a/packages/auth/src/__tests__/in-memory-revocation.test.ts
+++ b/packages/auth/src/__tests__/in-memory-revocation.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+const originalDateNow = Date.now;
+let nowMs = 1_800_000_000_000;
+let originalNodeEnv: string | undefined;
+let originalRedisUrl: string | undefined;
+
+beforeEach(() => {
+  originalNodeEnv = process.env.NODE_ENV;
+  originalRedisUrl = process.env.REDIS_URL;
+  nowMs = 1_800_000_000_000;
+  Date.now = () => nowMs;
+  delete process.env.REDIS_URL;
+  process.env.NODE_ENV = "test";
+});
+
+afterEach(() => {
+  Date.now = originalDateNow;
+  if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+  else process.env.NODE_ENV = originalNodeEnv;
+  if (originalRedisUrl === undefined) delete process.env.REDIS_URL;
+  else process.env.REDIS_URL = originalRedisUrl;
+});
+
+describe("in-memory revocation line monotonicity", () => {
+  test("a newer line cannot shorten the active expiry", async () => {
+    const { revocationStore } = await import(`../revocation?newer=${crypto.randomUUID()}`);
+    await revocationStore.revokeAgentTokens("agent-newer-shorter", 200, nowMs + 10_000);
+    await revocationStore.revokeAgentTokens("agent-newer-shorter", 300, nowMs + 1_000);
+
+    nowMs += 2_000;
+    await expect(revocationStore.getAgentRevokedBefore("agent-newer-shorter")).resolves.toBe(300);
+  });
+
+  test("a stale line can extend but cannot lower the active line", async () => {
+    const { revocationStore } = await import(`../revocation?stale=${crypto.randomUUID()}`);
+    await revocationStore.revokeUserTokens("user-stale-longer", 300, nowMs + 1_000);
+    await revocationStore.revokeUserTokens("user-stale-longer", 200, nowMs + 10_000);
+
+    nowMs += 2_000;
+    await expect(revocationStore.getUserRevokedBefore("user-stale-longer")).resolves.toBe(300);
+  });
+
+  test("an expired high line cannot suppress a fresh lower line", async () => {
+    const { revocationStore } = await import(`../revocation?expired=${crypto.randomUUID()}`);
+    await revocationStore.revokeAgentTokens("agent-expired-line", 300, nowMs + 1_000);
+
+    nowMs += 2_000;
+    await revocationStore.revokeAgentTokens("agent-expired-line", 200, nowMs + 10_000);
+    await expect(revocationStore.getAgentRevokedBefore("agent-expired-line")).resolves.toBe(200);
+  });
+});

--- a/packages/auth/src/__tests__/redis-revocation.integration.test.ts
+++ b/packages/auth/src/__tests__/redis-revocation.integration.test.ts
@@ -1,0 +1,42 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { Redis } from "ioredis";
+import { MONOTONIC_REVOCATION_SCRIPT } from "../revocation";
+
+const redisUrl = process.env.REDIS_URL;
+const redisTest = redisUrl ? test : test.skip;
+const redis = redisUrl
+  ? new Redis(redisUrl, { enableReadyCheck: true, maxRetriesPerRequest: 1 })
+  : null;
+
+afterAll(async () => {
+  if (redis) await redis.quit();
+});
+
+describe("Redis revocation line monotonicity", () => {
+  redisTest("never lowers the latest value or shortens its TTL", async () => {
+    if (!redis) throw new Error("REDIS_URL is required");
+
+    const suffix = crypto.randomUUID();
+    const latestKey = `test:revocation:${suffix}:latest`;
+    const markerKey = `test:revocation:${suffix}:marker`;
+
+    try {
+      await redis.set(latestKey, "200", "PX", 10_000);
+      await redis.eval(MONOTONIC_REVOCATION_SCRIPT, 2, markerKey, latestKey, 100, 100);
+
+      expect(await redis.get(latestKey)).toBe("200");
+      expect(await redis.pttl(latestKey)).toBeGreaterThan(8_000);
+
+      await redis.eval(MONOTONIC_REVOCATION_SCRIPT, 2, markerKey, latestKey, 300, 1_000);
+      expect(await redis.get(latestKey)).toBe("300");
+      expect(await redis.pttl(latestKey)).toBeGreaterThan(8_000);
+
+      await redis.persist(latestKey);
+      await redis.eval(MONOTONIC_REVOCATION_SCRIPT, 2, markerKey, latestKey, 400, 100);
+      expect(await redis.get(latestKey)).toBe("400");
+      expect(await redis.pttl(latestKey)).toBe(-1);
+    } finally {
+      await redis.del(markerKey, latestKey);
+    }
+  });
+});

--- a/packages/auth/src/__tests__/session-revocation.test.ts
+++ b/packages/auth/src/__tests__/session-revocation.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "bun:test";
 import { jwtVerify } from "jose";
-import { revocationStore, SessionManager, TokenRevokedError } from "../index";
+import {
+  MONOTONIC_REVOCATION_SCRIPT,
+  revocationStore,
+  SessionManager,
+  TokenRevokedError,
+} from "../index";
 
 const secret = "test-session-revocation-secret-at-least-32-chars";
 
@@ -101,6 +106,17 @@ describe("session revocation", () => {
     await revocationStore.revokeAgentTokens("agent-monotonic-line", 100, Date.now() + 60_000);
 
     await expect(revocationStore.getAgentRevokedBefore("agent-monotonic-line")).resolves.toBe(200);
+  });
+
+  it("keeps the Redis revocation TTL monotonic for stale lines", () => {
+    // The in-memory fallback already preserves its existing expiration. Keep a
+    // deterministic guard on the Redis Lua path so a stale concurrent request
+    // cannot reintroduce the TTL-shortening resurrection bug.
+    expect(MONOTONIC_REVOCATION_SCRIPT).toContain(
+      'local existingTtlMs = redis.call("PTTL", latestKey)',
+    );
+    expect(MONOTONIC_REVOCATION_SCRIPT).toContain("if existingTtlMs > effectiveTtlMs then");
+    expect(MONOTONIC_REVOCATION_SCRIPT).toContain("elseif effectiveTtlMs > existingTtlMs then");
   });
 
   it("fails closed in production when no shared revocation backend is configured", async () => {

--- a/packages/auth/src/revocation.ts
+++ b/packages/auth/src/revocation.ts
@@ -113,9 +113,11 @@ class InMemoryRevocationStore implements RevocationStore {
   ): Promise<number> {
     const expiresAtMs = toMillis(expiresAt);
     const existing = this.agentIssuedBefore.get(agentId);
-    if (!existing || issuedBefore > existing.issuedBefore) {
-      this.agentIssuedBefore.set(agentId, { issuedBefore, expiresAtMs });
-    }
+    const active = existing && existing.expiresAtMs > Date.now() ? existing : null;
+    this.agentIssuedBefore.set(agentId, {
+      issuedBefore: Math.max(active?.issuedBefore ?? -1, issuedBefore),
+      expiresAtMs: Math.max(active?.expiresAtMs ?? -1, expiresAtMs),
+    });
     return issuedBefore;
   }
 
@@ -136,9 +138,11 @@ class InMemoryRevocationStore implements RevocationStore {
   ): Promise<number> {
     const expiresAtMs = toMillis(expiresAt);
     const existing = this.userIssuedBefore.get(userId);
-    if (!existing || issuedBefore > existing.issuedBefore) {
-      this.userIssuedBefore.set(userId, { issuedBefore, expiresAtMs });
-    }
+    const active = existing && existing.expiresAtMs > Date.now() ? existing : null;
+    this.userIssuedBefore.set(userId, {
+      issuedBefore: Math.max(active?.issuedBefore ?? -1, issuedBefore),
+      expiresAtMs: Math.max(active?.expiresAtMs ?? -1, expiresAtMs),
+    });
     return issuedBefore;
   }
 

--- a/packages/auth/src/revocation.ts
+++ b/packages/auth/src/revocation.ts
@@ -60,11 +60,19 @@ end
 -- A stale revocation request must not shorten the current revocation line.
 -- Retain the longer of the existing and incoming TTLs for every value update.
 local effectiveTtlMs = ttlMs
-if existingTtlMs > effectiveTtlMs then
+if existingTtlMs == -1 then
+  -- A persistent line is safer than any expiring replacement. Preserve it if
+  -- legacy/operator data ever lacks the expected TTL.
+  effectiveTtlMs = -1
+elseif existingTtlMs > effectiveTtlMs then
   effectiveTtlMs = existingTtlMs
 end
 if issuedBefore > existing then
-  redis.call("SET", latestKey, ARGV[1], "PX", effectiveTtlMs)
+  if effectiveTtlMs == -1 then
+    redis.call("SET", latestKey, ARGV[1])
+  else
+    redis.call("SET", latestKey, ARGV[1], "PX", effectiveTtlMs)
+  end
 elseif effectiveTtlMs > existingTtlMs then
   redis.call("PEXPIRE", latestKey, effectiveTtlMs)
 end

--- a/packages/auth/src/revocation.ts
+++ b/packages/auth/src/revocation.ts
@@ -38,18 +38,36 @@ function ttlMs(expiresAt: ExpiresAt, now = Date.now()): number {
 }
 
 const DEFAULT_AGENT_REVOCATION_TTL_MS = 30 * 24 * 60 * 60 * 1000;
-const MONOTONIC_REVOCATION_SCRIPT = `
+export const MONOTONIC_REVOCATION_SCRIPT = `
 local markerKey = KEYS[1]
 local latestKey = KEYS[2]
 local issuedBefore = tonumber(ARGV[1])
 local ttlMs = tonumber(ARGV[2])
-local existing = tonumber(redis.call("GET", latestKey) or "-1")
+local existingRaw = redis.call("GET", latestKey)
+local existingTtlMs = redis.call("PTTL", latestKey)
 redis.call("SET", markerKey, "1", "PX", ttlMs)
-if existing == nil or issuedBefore > existing then
+if existingRaw == false then
   redis.call("SET", latestKey, ARGV[1], "PX", ttlMs)
   return issuedBefore
 end
-redis.call("PEXPIRE", latestKey, ttlMs)
+
+local existing = tonumber(existingRaw)
+if existing == nil then
+  redis.call("SET", latestKey, ARGV[1], "PX", ttlMs)
+  return issuedBefore
+end
+
+-- A stale revocation request must not shorten the current revocation line.
+-- Retain the longer of the existing and incoming TTLs for every value update.
+local effectiveTtlMs = ttlMs
+if existingTtlMs > effectiveTtlMs then
+  effectiveTtlMs = existingTtlMs
+end
+if issuedBefore > existing then
+  redis.call("SET", latestKey, ARGV[1], "PX", effectiveTtlMs)
+elseif effectiveTtlMs > existingTtlMs then
+  redis.call("PEXPIRE", latestKey, effectiveTtlMs)
+end
 return existing
 `;
 


### PR DESCRIPTION
Follow-up corrective for merged #413.

The Redis revocation Lua script previously applied every incoming TTL to the latest revocation line, including stale/lower concurrent requests. A stale request could shorten the latest marker's TTL and allow revoked tokens to verify again after premature expiry.

This patch keeps value and TTL monotonic atomically by retaining the longer existing/incoming TTL, and adds a deterministic regression guard plus Redis reproduction coverage.

Related: #413

Validation:
- `bun install --frozen-lockfile`
- `bunx turbo run build --filter=@stwd/auth`
- auth session revocation: 11 passed
- Redis TTL regression: latest value 200, TTL 9999ms after stale 100ms request
- Biome and `git diff --check` pass