### PR TITLE
fix(proxy): preserve opaque legacy X tokens

### DIFF
--- a/packages/proxy/src/__tests__/google-credential-envelope.test.ts
+++ b/packages/proxy/src/__tests__/google-credential-envelope.test.ts
@@ -68,5 +68,10 @@ describe("X OAuth credential envelope", () => {
     expect(extractProviderCredentialForHost("api.x.com", "legacy-raw-x-access-token")).toBe(
       "legacy-raw-x-access-token",
     );
+    // OAuth bearer values are opaque. Legacy raw credentials that happen to be
+    // valid JSON primitives must not be mistaken for structured envelopes.
+    for (const rawToken of ["1234567890", "true", '"quoted-legacy-token"']) {
+      expect(extractProviderCredentialForHost("api.x.com", rawToken)).toBe(rawToken);
+    }
   });
 });

--- a/packages/proxy/src/handlers/proxy.ts
+++ b/packages/proxy/src/handlers/proxy.ts
@@ -155,10 +155,14 @@ function isSlackBotTokenCredential(value: string): boolean {
 }
 
 export function extractProviderCredentialForHost(host: string, credential: string): string {
-  const parsed = safeJsonParseString<Record<string, unknown>>(credential);
+  const parsed = safeJsonParseString<unknown>(credential);
+  const parsedEnvelope =
+    typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
   const googleHost = host === "gmail.googleapis.com" || host === "www.googleapis.com";
   const xHost = host === "api.x.com";
-  const schemaVersion = parsed?.schemaVersion;
+  const schemaVersion = parsedEnvelope?.schemaVersion;
   if (schemaVersion === "steward.provider-google.credential.v1") {
     // Bind the credential type to its intended provider. Merely transforming the
     // envelope when the destination happens to be Google would let a misbound
@@ -172,21 +176,22 @@ export function extractProviderCredentialForHost(host: string, credential: strin
     if (googleHost) throw new Error("invalid Google OAuth credential envelope");
     // A parseable object at the X boundary is an envelope, not a legacy raw
     // token. Unknown/malformed envelopes must never be formatted into a header.
-    if (xHost && parsed !== null) throw new Error("invalid X OAuth credential envelope");
+    if (xHost && typeof parsed === "object" && parsed !== null)
+      throw new Error("invalid X OAuth credential envelope");
     return credential;
   }
-  if (!parsed) throw new Error("invalid provider OAuth credential envelope");
+  if (!parsedEnvelope) throw new Error("invalid provider OAuth credential envelope");
   if (
-    typeof parsed.accessToken !== "string" ||
-    parsed.accessToken.length < 1 ||
-    parsed.accessToken.length > 16_384
+    typeof parsedEnvelope.accessToken !== "string" ||
+    parsedEnvelope.accessToken.length < 1 ||
+    parsedEnvelope.accessToken.length > 16_384
   )
     throw new Error(
       googleHost
         ? "invalid Google OAuth credential envelope"
         : "invalid X OAuth credential envelope",
     );
-  return parsed.accessToken;
+  return parsedEnvelope.accessToken;
 }
 
 // ─── Credential injection ────────────────────────────────────────────────────


### PR DESCRIPTION
Post-merge follow-up to #421.

X OAuth bearer tokens are opaque. The merged envelope discriminator treated every JSON-parseable value as a structured envelope, so legacy raw tokens such as an all-numeric token were rejected. This accepts JSON primitives as raw legacy credentials while continuing to reject malformed structured objects/arrays and provider-mismatched Google/X envelopes. Refresh tokens remain server-side.

Exact head: 40f8561ea4734dbb58da6bf496cf949b419a85a9
Included develop: 1ac3bd4a032d1f73d3d61537bad355a0d914b395

- focused envelope suite: 7/7, 15 assertions
- proxy dependency build before exact restack: 6/6; restack only added unrelated #431
- Biome and diff-check: green

Draft pending fresh hosted CI.