### PR TITLE
fix(auth): align revocation markers and effective lines

### DIFF
--- a/packages/auth/src/__tests__/redis-revocation.integration.test.ts
+++ b/packages/auth/src/__tests__/redis-revocation.integration.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import { Redis } from "ioredis";
-import { MONOTONIC_REVOCATION_SCRIPT } from "../revocation";
+import { MONOTONIC_REVOCATION_SCRIPT } from "../revocation-script";
 
 const redisUrl = process.env.REDIS_URL;
 const redisTest = redisUrl ? test : test.skip;
@@ -18,25 +18,36 @@ describe("Redis revocation line monotonicity", () => {
 
     const suffix = crypto.randomUUID();
     const latestKey = `test:revocation:${suffix}:latest`;
-    const markerKey = `test:revocation:${suffix}:marker`;
+    const markerKey = (line: number) => `test:revocation:${suffix}:marker:${line}`;
 
     try {
-      await redis.set(latestKey, "200", "PX", 10_000);
-      await redis.eval(MONOTONIC_REVOCATION_SCRIPT, 2, markerKey, latestKey, 100, 100);
+      expect(
+        await redis.eval(MONOTONIC_REVOCATION_SCRIPT, 2, markerKey(200), latestKey, 200, 10_000),
+      ).toBe(200);
+      expect(
+        await redis.eval(MONOTONIC_REVOCATION_SCRIPT, 2, markerKey(100), latestKey, 100, 100),
+      ).toBe(200);
 
       expect(await redis.get(latestKey)).toBe("200");
       expect(await redis.pttl(latestKey)).toBeGreaterThan(8_000);
+      expect(await redis.pttl(markerKey(100))).toBeGreaterThan(8_000);
 
-      await redis.eval(MONOTONIC_REVOCATION_SCRIPT, 2, markerKey, latestKey, 300, 1_000);
+      expect(
+        await redis.eval(MONOTONIC_REVOCATION_SCRIPT, 2, markerKey(300), latestKey, 300, 1_000),
+      ).toBe(300);
       expect(await redis.get(latestKey)).toBe("300");
       expect(await redis.pttl(latestKey)).toBeGreaterThan(8_000);
+      expect(await redis.pttl(markerKey(300))).toBeGreaterThan(8_000);
 
       await redis.persist(latestKey);
-      await redis.eval(MONOTONIC_REVOCATION_SCRIPT, 2, markerKey, latestKey, 400, 100);
+      expect(
+        await redis.eval(MONOTONIC_REVOCATION_SCRIPT, 2, markerKey(400), latestKey, 400, 100),
+      ).toBe(400);
       expect(await redis.get(latestKey)).toBe("400");
       expect(await redis.pttl(latestKey)).toBe(-1);
+      expect(await redis.pttl(markerKey(400))).toBe(-1);
     } finally {
-      await redis.del(markerKey, latestKey);
+      await redis.del(markerKey(100), markerKey(200), markerKey(300), markerKey(400), latestKey);
     }
   });
 });

--- a/packages/auth/src/__tests__/session-revocation.test.ts
+++ b/packages/auth/src/__tests__/session-revocation.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { jwtVerify } from "jose";
-import {
-  MONOTONIC_REVOCATION_SCRIPT,
-  revocationStore,
-  SessionManager,
-  TokenRevokedError,
-} from "../index";
+import { revocationStore, SessionManager, TokenRevokedError } from "../index";
 
 const secret = "test-session-revocation-secret-at-least-32-chars";
 
@@ -95,28 +90,25 @@ describe("session revocation", () => {
   });
 
   it("keeps user revocation lines monotonic when an older line is written later", async () => {
-    await revocationStore.revokeUserTokens("user-monotonic-line", 200, Date.now() + 60_000);
-    await revocationStore.revokeUserTokens("user-monotonic-line", 100, Date.now() + 60_000);
+    await expect(
+      revocationStore.revokeUserTokens("user-monotonic-line", 200, Date.now() + 60_000),
+    ).resolves.toBe(200);
+    await expect(
+      revocationStore.revokeUserTokens("user-monotonic-line", 100, Date.now() + 60_000),
+    ).resolves.toBe(200);
 
     await expect(revocationStore.getUserRevokedBefore("user-monotonic-line")).resolves.toBe(200);
   });
 
   it("keeps agent revocation lines monotonic when an older line is written later", async () => {
-    await revocationStore.revokeAgentTokens("agent-monotonic-line", 200, Date.now() + 60_000);
-    await revocationStore.revokeAgentTokens("agent-monotonic-line", 100, Date.now() + 60_000);
+    await expect(
+      revocationStore.revokeAgentTokens("agent-monotonic-line", 200, Date.now() + 60_000),
+    ).resolves.toBe(200);
+    await expect(
+      revocationStore.revokeAgentTokens("agent-monotonic-line", 100, Date.now() + 60_000),
+    ).resolves.toBe(200);
 
     await expect(revocationStore.getAgentRevokedBefore("agent-monotonic-line")).resolves.toBe(200);
-  });
-
-  it("keeps the Redis revocation TTL monotonic for stale lines", () => {
-    // The in-memory fallback already preserves its existing expiration. Keep a
-    // deterministic guard on the Redis Lua path so a stale concurrent request
-    // cannot reintroduce the TTL-shortening resurrection bug.
-    expect(MONOTONIC_REVOCATION_SCRIPT).toContain(
-      'local existingTtlMs = redis.call("PTTL", latestKey)',
-    );
-    expect(MONOTONIC_REVOCATION_SCRIPT).toContain("if existingTtlMs > effectiveTtlMs then");
-    expect(MONOTONIC_REVOCATION_SCRIPT).toContain("elseif effectiveTtlMs > existingTtlMs then");
   });
 
   it("fails closed in production when no shared revocation backend is configured", async () => {

--- a/packages/auth/src/revocation-script.ts
+++ b/packages/auth/src/revocation-script.ts
@@ -1,0 +1,43 @@
+/** Internal Redis primitive for atomically advancing a revocation line. */
+export const MONOTONIC_REVOCATION_SCRIPT = `
+local markerKey = KEYS[1]
+local latestKey = KEYS[2]
+local issuedBefore = tonumber(ARGV[1])
+local ttlMs = tonumber(ARGV[2])
+
+local function setWithTtl(key, value, effectiveTtlMs)
+  if effectiveTtlMs == -1 then
+    redis.call("SET", key, value)
+  else
+    redis.call("SET", key, value, "PX", effectiveTtlMs)
+  end
+end
+
+local existingRaw = redis.call("GET", latestKey)
+local existingTtlMs = redis.call("PTTL", latestKey)
+local existing = tonumber(existingRaw)
+if existingRaw == false or existing == nil then
+  setWithTtl(markerKey, "1", ttlMs)
+  setWithTtl(latestKey, ARGV[1], ttlMs)
+  return issuedBefore
+end
+
+-- A stale revocation request must not shorten either the current revocation
+-- line or its event marker. A persistent line remains persistent.
+local effectiveTtlMs = ttlMs
+if existingTtlMs == -1 then
+  effectiveTtlMs = -1
+elseif existingTtlMs > effectiveTtlMs then
+  effectiveTtlMs = existingTtlMs
+end
+setWithTtl(markerKey, "1", effectiveTtlMs)
+
+if issuedBefore > existing then
+  setWithTtl(latestKey, ARGV[1], effectiveTtlMs)
+  return issuedBefore
+end
+if effectiveTtlMs > existingTtlMs then
+  redis.call("PEXPIRE", latestKey, effectiveTtlMs)
+end
+return existing
+`;

--- a/packages/auth/src/revocation.ts
+++ b/packages/auth/src/revocation.ts
@@ -10,6 +10,7 @@
 
 import { assertRedisUrlTls } from "@stwd/redis";
 import { Redis } from "ioredis";
+import { MONOTONIC_REVOCATION_SCRIPT } from "./revocation-script";
 
 export class TokenRevokedError extends Error {
   constructor(message = "Token has been revoked") {
@@ -38,46 +39,6 @@ function ttlMs(expiresAt: ExpiresAt, now = Date.now()): number {
 }
 
 const DEFAULT_AGENT_REVOCATION_TTL_MS = 30 * 24 * 60 * 60 * 1000;
-export const MONOTONIC_REVOCATION_SCRIPT = `
-local markerKey = KEYS[1]
-local latestKey = KEYS[2]
-local issuedBefore = tonumber(ARGV[1])
-local ttlMs = tonumber(ARGV[2])
-local existingRaw = redis.call("GET", latestKey)
-local existingTtlMs = redis.call("PTTL", latestKey)
-redis.call("SET", markerKey, "1", "PX", ttlMs)
-if existingRaw == false then
-  redis.call("SET", latestKey, ARGV[1], "PX", ttlMs)
-  return issuedBefore
-end
-
-local existing = tonumber(existingRaw)
-if existing == nil then
-  redis.call("SET", latestKey, ARGV[1], "PX", ttlMs)
-  return issuedBefore
-end
-
--- A stale revocation request must not shorten the current revocation line.
--- Retain the longer of the existing and incoming TTLs for every value update.
-local effectiveTtlMs = ttlMs
-if existingTtlMs == -1 then
-  -- A persistent line is safer than any expiring replacement. Preserve it if
-  -- legacy/operator data ever lacks the expected TTL.
-  effectiveTtlMs = -1
-elseif existingTtlMs > effectiveTtlMs then
-  effectiveTtlMs = existingTtlMs
-end
-if issuedBefore > existing then
-  if effectiveTtlMs == -1 then
-    redis.call("SET", latestKey, ARGV[1])
-  else
-    redis.call("SET", latestKey, ARGV[1], "PX", effectiveTtlMs)
-  end
-elseif effectiveTtlMs > existingTtlMs then
-  redis.call("PEXPIRE", latestKey, effectiveTtlMs)
-end
-return existing
-`;
 
 class InMemoryRevocationStore implements RevocationStore {
   private readonly revokedJtis = new Map<string, number>();
@@ -114,11 +75,12 @@ class InMemoryRevocationStore implements RevocationStore {
     const expiresAtMs = toMillis(expiresAt);
     const existing = this.agentIssuedBefore.get(agentId);
     const active = existing && existing.expiresAtMs > Date.now() ? existing : null;
+    const effectiveIssuedBefore = Math.max(active?.issuedBefore ?? -1, issuedBefore);
     this.agentIssuedBefore.set(agentId, {
-      issuedBefore: Math.max(active?.issuedBefore ?? -1, issuedBefore),
+      issuedBefore: effectiveIssuedBefore,
       expiresAtMs: Math.max(active?.expiresAtMs ?? -1, expiresAtMs),
     });
-    return issuedBefore;
+    return effectiveIssuedBefore;
   }
 
   async getAgentRevokedBefore(agentId: string): Promise<number | null> {
@@ -139,11 +101,12 @@ class InMemoryRevocationStore implements RevocationStore {
     const expiresAtMs = toMillis(expiresAt);
     const existing = this.userIssuedBefore.get(userId);
     const active = existing && existing.expiresAtMs > Date.now() ? existing : null;
+    const effectiveIssuedBefore = Math.max(active?.issuedBefore ?? -1, issuedBefore);
     this.userIssuedBefore.set(userId, {
-      issuedBefore: Math.max(active?.issuedBefore ?? -1, issuedBefore),
+      issuedBefore: effectiveIssuedBefore,
       expiresAtMs: Math.max(active?.expiresAtMs ?? -1, expiresAtMs),
     });
-    return issuedBefore;
+    return effectiveIssuedBefore;
   }
 
   async getUserRevokedBefore(userId: string): Promise<number | null> {
@@ -239,11 +202,14 @@ class RedisRevocationStore implements RevocationStore {
     try {
       const markerKey = `revoked-agent:${agentId}:${issuedBefore}`;
       const latestKey = `revoked-agent:${agentId}:issued-before`;
-      await redis.eval(MONOTONIC_REVOCATION_SCRIPT, 2, markerKey, latestKey, issuedBefore, ms);
+      const effective = Number(
+        await redis.eval(MONOTONIC_REVOCATION_SCRIPT, 2, markerKey, latestKey, issuedBefore, ms),
+      );
+      if (!Number.isFinite(effective)) throw new Error("invalid Redis revocation line result");
+      return effective;
     } catch (error) {
       throw new Error("Shared agent revocation store unavailable", { cause: error });
     }
-    return issuedBefore;
   }
 
   async getAgentRevokedBefore(agentId: string): Promise<number | null> {
@@ -272,11 +238,14 @@ class RedisRevocationStore implements RevocationStore {
     try {
       const markerKey = `revoked-user:${userId}:${issuedBefore}`;
       const latestKey = `revoked-user:${userId}:issued-before`;
-      await redis.eval(MONOTONIC_REVOCATION_SCRIPT, 2, markerKey, latestKey, issuedBefore, ms);
+      const effective = Number(
+        await redis.eval(MONOTONIC_REVOCATION_SCRIPT, 2, markerKey, latestKey, issuedBefore, ms),
+      );
+      if (!Number.isFinite(effective)) throw new Error("invalid Redis revocation line result");
+      return effective;
     } catch (error) {
       throw new Error("Shared user revocation store unavailable", { cause: error });
     }
-    return issuedBefore;
   }
 
   async getUserRevokedBefore(userId: string): Promise<number | null> {


### PR DESCRIPTION
Post-merge follow-up to #428.

The merged monotonic latest-key fix left two residuals: event marker TTLs could still be shorter than the effective latest-line TTL (including a persistent latest key), and revokeAgentTokens/revokeUserTokens returned the incoming cutoff rather than the effective enforced cutoff on stale writes.

This makes marker/latest TTL semantics atomic and consistent, returns the effective cutoff in both Redis and memory backends, and moves the Lua primitive to an internal module instead of exposing it through the public auth surface solely for a string test.

Exact head: 85a8393a1f20a249c788005e0715365d7f63cfaa
Included develop: 1ac3bd4a032d1f73d3d61537bad355a0d914b395

- session revocation: 10/10, 18 assertions
- real local Redis integration: 1/1, 13 assertions (stale/new returns, marker/latest TTL, persistent PTTL=-1)
- auth dependency build: 4/4
- Biome and diff-check: green

Draft pending fresh hosted CI.