### PR TITLE
fix(security): keep raw DSN userinfo off backup argv

### DIFF
--- a/deploy/enterprise-reference/docker-compose.yml
+++ b/deploy/enterprise-reference/docker-compose.yml
@@ -205,12 +205,35 @@ services:
     #    operator account, and encrypt/prune dumps per your retention policy.
     command:
       - |
-        set -a; . /run/steward/env; set +a
+        # Never source the dotenv file as shell code. `steward init` accepts an
+        # operator-supplied DATABASE_URL, and URI bytes such as '&' and '$()'
+        # must remain inert data rather than becoming shell syntax. Read only
+        # the two keys this one-shot backup needs, without eval/`.`.
+        read_steward_env_value() {
+          steward_env_key="$$1"
+          steward_env_value="$$(sed -n "s/^$${steward_env_key}=//p" /run/steward/env | sed -n '1p')"
+          case "$$steward_env_value" in
+            \'*\') steward_env_value="$${steward_env_value#\'}"; steward_env_value="$${steward_env_value%\'}" ;;
+            \"*\") steward_env_value="$${steward_env_value#\"}"; steward_env_value="$${steward_env_value%\"}" ;;
+            \'*|\"*) echo "Malformed quoted $$steward_env_key in Steward env file" >&2; return 1 ;;
+          esac
+          printf '%s' "$$steward_env_value"
+        }
+        DATABASE_URL="$$(read_steward_env_value DATABASE_URL)"
+        POSTGRES_PASSWORD="$$(read_steward_env_value POSTGRES_PASSWORD)"
+        export DATABASE_URL POSTGRES_PASSWORD
         umask 077
         # Never inherit a separately supplied password into pg_dump. The only
         # credential allowed below is one decoded from DATABASE_URL itself.
         unset PGPASSWORD
         dsn="$${DATABASE_URL:-postgresql://steward:$${POSTGRES_PASSWORD:?}@postgres:5432/steward}"
+        # libpq accepts a raw '?' inside userinfo even though RFC 3986 normally
+        # requires it to be percent-encoded. A fragment, however, is never a
+        # supported connection target and makes delimiter parsing ambiguous.
+        # Reject it before any password-bearing value can reach pg_dump argv.
+        case "$$dsn" in
+          *\#*) echo 'DATABASE_URL fragments are not supported' >&2; exit 1 ;;
+        esac
         # POSIX-portable percent-decoder (octal printf works in dash/BusyBox ash;
         # printf '%b' with \xHH does not). Defined before first use.
         pg_url_decode() {
@@ -252,10 +275,17 @@ services:
           postgres://*|postgresql://*)
             pg_scheme="$${dsn%%://*}"
             pg_rest="$${dsn#*://}"
-            # Isolate the authority before looking for userinfo. Matching a
-            # colon and @ across the whole DSN mistakes host ports plus an @
-            # in a path/query value for credentials and corrupts the target.
-            pg_authority="$$(printf '%s' "$$pg_rest" | sed 's|[/?#].*||')"
+            # Isolate the authority before looking for userinfo. When a path is
+            # present, '/' is the unambiguous authority terminator; importantly,
+            # libpq accepts a raw '?' in userinfo, so treating '?' as the first
+            # terminator can leave the password-bearing DSN on pg_dump argv.
+            # Without a path, '?' followed by '@' is intrinsically ambiguous
+            # (raw userinfo vs. a query value), so reject it fail-closed.
+            case "$$pg_rest" in
+              */*) pg_authority="$${pg_rest%%/*}" ;;
+              *\?*@*) echo 'DATABASE_URL contains ambiguous user information' >&2; exit 1 ;;
+              *) pg_authority="$$(printf '%s' "$$pg_rest" | sed 's|[?].*||')" ;;
+            esac
             pg_suffix="$${pg_rest#"$$pg_authority"}"
             case "$$pg_authority" in
               *:*@*)

--- a/packages/proxy/src/__tests__/deploy-artifacts.test.ts
+++ b/packages/proxy/src/__tests__/deploy-artifacts.test.ts
@@ -16,7 +16,8 @@
  *        platform admin key to stdout.
  */
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 const DEPLOY_DIR = join(import.meta.dir, "..", "..", "..", "..", "deploy");
@@ -154,10 +155,44 @@ describe("SEC-081 enterprise backup service keeps the DSN out of container env a
     // DSN is sourced from the mounted env file instead.
     expect(backup).toContain("/run/steward/env");
     expect(backup).toContain("./.env:/run/steward/env:ro");
+    expect(backup).not.toMatch(/(?:^|[;\s])\.\s+\/run\/steward\/env/);
+    expect(backup).toContain("read_steward_env_value");
   });
 
   test("dumps are written owner-only (umask 077)", () => {
     expect(backup).toContain("umask 077");
+  });
+
+  test("dotenv values are read as inert data under sh and dash", () => {
+    const loaderStart = backup.indexOf("        read_steward_env_value() {");
+    const loaderEnd = backup.indexOf("        umask 077");
+    expect(loaderStart).toBeGreaterThanOrEqual(0);
+    expect(loaderEnd).toBeGreaterThan(loaderStart);
+    const dir = mkdtempSync(join(tmpdir(), "steward-backup-env-"));
+    try {
+      const envPath = join(dir, ".env");
+      const canary = join(dir, "shell-evaluation-canary");
+      const databaseUrl = `postgresql://steward:p@postgres:5432/steward?application_name=$(touch\${IFS}${canary})&sslmode=require`;
+      writeFileSync(envPath, `DATABASE_URL=${databaseUrl}\nPOSTGRES_PASSWORD=fallback\n`);
+      const loader = backup
+        .slice(loaderStart, loaderEnd)
+        .split("\n")
+        .map((line) => line.replace(/^ {8}/, ""))
+        .join("\n")
+        .replaceAll("$$", "$")
+        .replaceAll("/run/steward/env", envPath);
+      for (const shell of ["sh", "dash"]) {
+        const result = Bun.spawnSync([shell, "-c", `${loader}\nprintf '%s' "$DATABASE_URL"`], {
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout.toString()).toBe(databaseUrl);
+        expect(existsSync(canary)).toBe(false);
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   test("pg_dump argv carries no password — DSN userinfo is stripped, PGPASSWORD used (SEC-050)", () => {
@@ -191,8 +226,8 @@ describe("SEC-081 enterprise backup service keeps the DSN out of container env a
       .map((line) => line.replace(/^ {8}/, ""))
       .join("\n")
       .replaceAll("$$", "$");
-    const runParser = (databaseUrl: string) =>
-      Bun.spawnSync(["sh", "-c", `${parser}\nprintf '%s\\n%s' "$dsn" "\${PGPASSWORD-}"`], {
+    const runParser = (databaseUrl: string, shell = "sh") =>
+      Bun.spawnSync([shell, "-c", `${parser}\nprintf '%s\\n%s' "$dsn" "\${PGPASSWORD-}"`], {
         env: {
           PATH: process.env.PATH ?? "/usr/bin:/bin",
           DATABASE_URL: databaseUrl,
@@ -210,6 +245,21 @@ describe("SEC-081 enterprise backup service keeps the DSN out of container env a
     expect(
       parse("postgresql://steward:p%40ss%3Aword@postgres:5432/steward?sslmode=require"),
     ).toEqual(["postgresql://steward@postgres:5432/steward?sslmode=require", "p@ss:word"]);
+
+    // libpq accepts a raw '?' in userinfo. It must remain part of the password,
+    // not be mistaken for the query delimiter and leaked in pg_dump argv. Run
+    // this proof under dash as well as the platform's /bin/sh.
+    for (const shell of ["sh", "dash"]) {
+      const result = runParser(
+        "postgresql://steward:p?ss@postgres:5432/steward?sslmode=require",
+        shell,
+      );
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.toString().split("\n")).toEqual([
+        "postgresql://steward@postgres:5432/steward?sslmode=require",
+        "p?ss",
+      ]);
+    }
 
     expect(
       parse("postgresql://steward@postgres:5432/steward?user=alice&password=query%40secret"),
@@ -239,6 +289,10 @@ describe("SEC-081 enterprise backup service keeps the DSN out of container env a
       "postgresql://steward:p%ZZword@postgres:5432/steward",
       "postgresql://steward:p%00word@postgres:5432/steward",
       "postgresql://steward@postgres:5432/steward?password=bad%ZZsecret",
+      "postgresql://steward:secret@postgres:5432/steward#fragment",
+      // With no slash, libpq's raw-userinfo extension is indistinguishable
+      // from an @ in a query value. Reject rather than leak either reading.
+      "postgresql://steward:p?ss@postgres:5432",
     ]) {
       const result = runParser(malformed);
       expect(result.exitCode).not.toBe(0);


### PR DESCRIPTION
Post-merge corrective for #429.

Two password-handling gaps were found in the enterprise backup command:

1. libpq accepts a raw `?` byte in URI userinfo. The merged parser treated it as the authority/query delimiter, skipped userinfo stripping, and could pass the password-bearing DATABASE_URL to `pg_dump` argv.
2. The backup sourced the generated `.env` as shell code. An operator-supplied DATABASE_URL containing shell metacharacters could be misparsed or executed instead of remaining inert URI data.

The fix reads only DATABASE_URL and POSTGRES_PASSWORD without eval/source, uses `/` as the unambiguous authority boundary when a path is present, rejects ambiguous no-path `? ... @` forms, and rejects unsupported fragments fail-closed.

Exact head: 4bce4bb6367845e6e0ce034c1c3876109250565e
Included develop: 0bcfbb003ffb251a424a71549ce7bab401097df2

Exact-head evidence:
- enterprise deploy artifact suite: 46/46 tests, 194 assertions
- shell-evaluation canary and raw-`?` userinfo proofs under both `sh` and `dash`
- Docker Compose config validation
- Biome and git diff-check: clean

Kept draft pending hosted exact-head CI.