### PR TITLE
fix(ci): execute security regression file paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -490,12 +490,12 @@ jobs:
           DATABASE_URL: "postgres://steward:steward_ci@localhost:5432/steward_test"
 
       - name: RLS pool isolation proof (real Postgres)
-        run: bun test packages/db/src/__tests__/tenant-rls-postgres.test.ts
+        run: bun test ./packages/db/src/__tests__/tenant-rls-postgres.test.ts
         env:
           DATABASE_URL: "postgres://steward:steward_ci@localhost:5432/steward_test"
 
       - name: Vault custody transition race proof (real Postgres)
-        run: bun test packages/vault/src/__tests__/custody-transition-race.real-pg.test.ts
+        run: bun test ./packages/vault/src/__tests__/custody-transition-race.real-pg.test.ts
         env:
           DATABASE_URL: "postgres://steward:steward_ci@localhost:5432/steward_test"
 
@@ -602,7 +602,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Verify Redis revocation monotonicity
-        run: bun test packages/auth/src/__tests__/redis-revocation.integration.test.ts
+        run: bun test ./packages/auth/src/__tests__/redis-revocation.integration.test.ts
 
       - name: Start embedded API
         env:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -580,12 +580,12 @@ jobs:
           DATABASE_URL: "postgres://steward:steward_ci@localhost:5432/steward_test"
 
       - name: RLS pool isolation proof (real Postgres)
-        run: bun test packages/db/src/__tests__/tenant-rls-postgres.test.ts
+        run: bun test ./packages/db/src/__tests__/tenant-rls-postgres.test.ts
         env:
           DATABASE_URL: "postgres://steward:steward_ci@localhost:5432/steward_test"
 
       - name: Vault custody transition race proof (real Postgres)
-        run: bun test packages/vault/src/__tests__/custody-transition-race.real-pg.test.ts
+        run: bun test ./packages/vault/src/__tests__/custody-transition-race.real-pg.test.ts
         env:
           DATABASE_URL: "postgres://steward:steward_ci@localhost:5432/steward_test"
 
@@ -695,7 +695,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Verify Redis revocation monotonicity
-        run: bun test packages/auth/src/__tests__/redis-revocation.integration.test.ts
+        run: bun test ./packages/auth/src/__tests__/redis-revocation.integration.test.ts
 
       - name: Start embedded API
         env:

--- a/scripts/__tests__/check-ci-test-inventory.test.ts
+++ b/scripts/__tests__/check-ci-test-inventory.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -14,6 +14,15 @@ import {
 describe("CI test inventory", () => {
   test("the repository workflows cover every test-bearing workspace package", () => {
     expect(() => checkCiTestInventory()).not.toThrow();
+  });
+
+  test("direct Bun test-file commands use explicit relative paths", () => {
+    for (const workflow of [".github/workflows/ci.yml", ".github/workflows/pr.yml"]) {
+      const source = readFileSync(workflow, "utf8");
+      expect(source.match(/\bbun test packages\/[^\s]+\.(?:test|spec)\.[cm]?[jt]sx?/g) ?? []).toEqual(
+        [],
+      );
+    }
   });
 
   test("a future unlisted test package fails closed", () => {


### PR DESCRIPTION
Bun 1.3 treats bare `packages/...test.ts` arguments as name filters, so the Redis revocation, RLS, and custody race security steps exited before executing their test files.

This switches all six workflow commands to explicit `./packages/...` paths and adds a static regression across both workflows rejecting future bare direct-test paths.

Validation:
- CI inventory: 8/8, 38 assertions
- bare pre-fix command reproduced `filters did not match`; corrected commands resolve the files
- Ruby YAML parse + actionlint: green
- Biome + diff-check: green

Draft pending exact-head hosted CI.