### PR TITLE
fix(vault): reject invalid Monero subgroup keys

### DIFF
--- a/packages/vault/src/__tests__/monero.test.ts
+++ b/packages/vault/src/__tests__/monero.test.ts
@@ -134,6 +134,39 @@ describe("assertMoneroAddress", () => {
   const mainnetAddress = OFFICIAL_VECTORS[0].address;
   const stagenetAddress = OFFICIAL_VECTORS[3].address;
 
+  const INVALID_SUBGROUP_ADDRESSES = [
+    {
+      kind: "identity spend key",
+      address:
+        "41fJjQDhryD11111111111111111111111111111111116M6xLGByLYcTsbJzTVUuLSHxtbfgKyZJVBqPffpP8fm7BapnRj",
+    },
+    {
+      kind: "small-order/torsion spend key",
+      address:
+        "41d7FXjswpK11111111111111111111111111111111116M6xLGByLYcTsbJzTVUuLSHxtbfgKyZJVBqPffpP8fm7C8GNnw",
+    },
+    {
+      kind: "mixed-torsion spend key",
+      address:
+        "44k3tGVyLFA9efcSHz2Dk6UCpb99gwLnfijVWRfCuCWxgESWDDscFwacTsbJzTVUuLSHxtbfgKyZJVBqPffpP8fm784itQD",
+    },
+    {
+      kind: "identity view key",
+      address:
+        "45AmZ2FRjuqZts5NGzb7ZXSNRuwS9MUqEeakpyEeSHsB5gg2sUQdweP11111111111111111111111111111111113vBvjU",
+    },
+    {
+      kind: "small-order/torsion view key",
+      address:
+        "45AmZ2FRjuqZts5NGzb7ZXSNRuwS9MUqEeakpyEeSHsB5gdqPbvp2VV111111111111111111111111111111111179TEUy",
+    },
+    {
+      kind: "mixed-torsion view key",
+      address:
+        "45AmZ2FRjuqZts5NGzb7ZXSNRuwS9MUqEeakpyEeSHsB5jkn2LguQvL9efcSHz2Dk6UCpb99gwLnfijVWRfCuCWxTRobhDd",
+    },
+  ] as const;
+
   test("accepts standard and subaddress destinations on the right network", () => {
     expect(assertMoneroAddress(mainnetAddress, "mainnet").kind).toBe("standard");
     expect(assertMoneroAddress(OFFICIAL_VECTORS[0].subaddress, "mainnet").kind).toBe("subaddress");
@@ -155,6 +188,32 @@ describe("assertMoneroAddress", () => {
     expect(() => decodeMoneroAddress("")).toThrow();
     expect(() => decodeMoneroAddress("4".repeat(94))).toThrow();
     expect(() => decodeMoneroAddress("not-an-address")).toThrow();
+  });
+
+  test("rejects checksum-valid identity, small-order, and mixed-torsion public keys", () => {
+    for (const { kind, address } of INVALID_SUBGROUP_ADDRESSES) {
+      expect(() => decodeMoneroAddress(address), kind).toThrow(/prime-order ed25519 subgroup/);
+      expect(() => assertMoneroAddress(address, "mainnet"), kind).toThrow(
+        /prime-order ed25519 subgroup/,
+      );
+    }
+  });
+
+  test("refuses to construct addresses from invalid subgroup points", () => {
+    const valid = decodeMoneroAddress(mainnetAddress);
+    const badKeys = [
+      "0100000000000000000000000000000000000000000000000000000000000000", // identity
+      "0000000000000000000000000000000000000000000000000000000000000000", // order 4
+      "5252cc0a7f208133b620acbd4537eba2a4123bf0a8c2e4f980c3b31bb69765ea", // base + torsion
+    ];
+    for (const badKey of badKeys) {
+      expect(() => moneroAddressFromPublicKeys(badKey, valid.publicViewKey, "mainnet")).toThrow(
+        /prime-order ed25519 subgroup/,
+      );
+      expect(() => moneroAddressFromPublicKeys(valid.publicSpendKey, badKey, "mainnet")).toThrow(
+        /prime-order ed25519 subgroup/,
+      );
+    }
   });
 });
 

--- a/packages/vault/src/monero.ts
+++ b/packages/vault/src/monero.ts
@@ -197,6 +197,23 @@ function moneroChecksum(payload: Uint8Array): Uint8Array {
   return keccak_256(payload).subarray(0, 4);
 }
 
+/**
+ * Monero public keys must be non-identity points in ed25519's prime-order
+ * subgroup. Merely accepting a canonical compressed encoding also accepts the
+ * identity, low-order torsion points, and points with a torsion component.
+ */
+function assertValidMoneroPublicKey(encoded: Uint8Array): void {
+  let point: typeof ed25519.ExtendedPoint.BASE;
+  try {
+    point = ed25519.ExtendedPoint.fromHex(encoded);
+  } catch {
+    throw new Error("Monero address embeds an invalid ed25519 public key");
+  }
+  if (point.is0() || point.isSmallOrder() || !point.isTorsionFree()) {
+    throw new Error("Monero public key is not in the prime-order ed25519 subgroup");
+  }
+}
+
 export interface GeneratedMoneroWallet {
   /** Private spend key, 64-hex (SECRET). */
   spendKey: string;
@@ -221,6 +238,8 @@ export function moneroAddressFromPublicKeys(
   if (!isMoneroKeyHex(publicSpendKey) || !isMoneroKeyHex(publicViewKey)) {
     throw new Error("Monero public keys must be 32-byte lowercase hex strings");
   }
+  assertValidMoneroPublicKey(decodeHex(publicSpendKey));
+  assertValidMoneroPublicKey(decodeHex(publicViewKey));
   const payload = new Uint8Array(69);
   payload[0] = ADDRESS_PREFIXES[network].standard;
   payload.set(decodeHex(publicSpendKey), 1);
@@ -316,15 +335,13 @@ export function decodeMoneroAddress(address: string): DecodedMoneroAddress {
   if (payload.length !== expectedLength) {
     throw new Error(`Monero ${kind} address has an invalid payload length`);
   }
-  const publicSpendKey = encodeHex(payload.subarray(1, 33));
-  const publicViewKey = encodeHex(payload.subarray(33, 65));
-  for (const key of [publicSpendKey, publicViewKey]) {
-    try {
-      ed25519.ExtendedPoint.fromHex(key);
-    } catch {
-      throw new Error("Monero address embeds an invalid ed25519 public key");
-    }
+  const publicSpendKeyBytes = payload.subarray(1, 33);
+  const publicViewKeyBytes = payload.subarray(33, 65);
+  for (const key of [publicSpendKeyBytes, publicViewKeyBytes]) {
+    assertValidMoneroPublicKey(key);
   }
+  const publicSpendKey = encodeHex(publicSpendKeyBytes);
+  const publicViewKey = encodeHex(publicViewKeyBytes);
   return {
     network,
     kind,


### PR DESCRIPTION
## Security finding

Vault address validation accepted checksum-valid Monero addresses whose embedded spend or view key was the identity, a small-order point, or a mixed-torsion point. The policy engine rejects those points, so direct vault consumers had a weaker validation boundary.

## Fix

- Require both embedded public keys to be non-identity, non-small-order, torsion-free ed25519 points.
- Apply the same invariant when constructing a Monero address from public keys.
- Add checksum-valid regression vectors for identity, small-order, and mixed-torsion points in both spend and view positions.

## Exact-head validation

Validated commit: d83363a7e3148900f4a68ff434b016c18fa0d5fc
Base: d97445454e7764222656b0a437b7bfcb46fc1d9c

- 46/46 focused Monero unit and DB lifecycle tests passed (204 assertions).
- Dependency-aware vault build passed: 6/6 packages.
- Biome and git diff checks passed.