### PR TITLE
fix(security): validate OAuth bearer credentials

### DIFF
--- a/packages/api/src/__tests__/provider-x-connect.test.ts
+++ b/packages/api/src/__tests__/provider-x-connect.test.ts
@@ -604,6 +604,44 @@ describe("connect state validation", () => {
     expect(retried.xUserId).toBe("x-user-123");
     ok.restore();
   });
+
+  test("rejects malformed token endpoint credentials before identity fetch or persistence", async () => {
+    for (const exchangeToken of [
+      { access_token: "" },
+      { access_token: "access\ncontrol" },
+      { access_token: "x".repeat(16_385) },
+      { refresh_token: "" },
+      { refresh_token: "refresh\rcontrol" },
+      { refresh_token: "r".repeat(16_385) },
+    ]) {
+      const store = new MemoryConnectStore();
+      const fake = installFakeX({ exchangeToken });
+      const initiated = await initiateXConnect({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        initiatedByUserId: ADMIN,
+        redirectUri: REDIRECT,
+        config: CONFIG,
+        store,
+      });
+      await expect(
+        completeXConnect({
+          tenantId: TENANT,
+          workspaceId: WORKSPACE,
+          callerUserId: ADMIN,
+          code: "auth-code",
+          state: initiated.state,
+          connectToken: initiated.connectToken,
+          redirectUri: REDIRECT,
+          config: CONFIG,
+          store,
+          vault,
+        }),
+      ).rejects.toMatchObject({ code: "X_TOKEN_EXCHANGE_FAILED" });
+      expect(fake.counters.identity).toBe(0);
+      fake.restore();
+    }
+  });
 });
 
 // ── Refresh: rotation, single-flight, revoke ──────────────────────────────────
@@ -632,6 +670,33 @@ describe("refresh", () => {
 
     const events = await readAuditActions(TENANT);
     expect(events.includes("provider.x.refresh.completed")).toBe(true);
+  });
+
+  test("rejects malformed refresh credentials without rotating the stored secret", async () => {
+    for (const body of [
+      { access_token: "bad token", refresh_token: "refresh-valid" },
+      { access_token: "access-valid", refresh_token: "r".repeat(16_385) },
+    ]) {
+      const store = new MemoryConnectStore();
+      const { completed } = await connectHappy(store);
+      const before = await decryptCredential(completed.providerAccountId);
+      const fake = installFakeX({ refreshResponses: [{ status: 200, body }] });
+      await expect(
+        refreshXProviderCredential({
+          tenantId: TENANT,
+          workspaceId: WORKSPACE,
+          accountId: completed.providerAccountId,
+          vault,
+          config: CONFIG,
+          force: true,
+        }),
+      ).rejects.toMatchObject({ code: "X_REFRESH_FAILED" });
+      const after = await decryptCredential(completed.providerAccountId);
+      expect(after).toEqual(before);
+      fake.restore();
+      await getDb().delete(providerAccounts).where(eq(providerAccounts.tenantId, TENANT));
+      await getDb().delete(secrets).where(eq(secrets.tenantId, TENANT));
+    }
   });
 
   test("SINGLE-FLIGHT: two concurrent refreshes of a near-expiry token make exactly ONE token call", async () => {

--- a/packages/api/src/services/provider-google-connect.ts
+++ b/packages/api/src/services/provider-google-connect.ts
@@ -47,6 +47,7 @@ import {
   sql,
   withTenantAuditedTransaction,
 } from "@stwd/db";
+import { isValidOAuthBearerToken, isValidOAuthOpaqueToken } from "@stwd/shared";
 import type { SecretVault } from "@stwd/vault";
 
 type DbBase = ReturnType<typeof getDb>;
@@ -753,9 +754,9 @@ export async function reconcileGoogleCredentialRevocation(input: {
     ) as GoogleLifecycleSecret;
     if (parsed.schemaVersion !== "steward.provider-google.lifecycle.v1")
       throw new Error("invalid handle");
-    const token = boundedString(parsed.token.refresh_token, 16_384)
+    const token = isValidOAuthOpaqueToken(parsed.token.refresh_token)
       ? parsed.token.refresh_token
-      : boundedString(parsed.token.access_token, 16_384)
+      : isValidOAuthBearerToken(parsed.token.access_token)
         ? parsed.token.access_token
         : null;
     if (!token) throw new Error("invalid handle");
@@ -997,8 +998,8 @@ function validateTokenEnvelope(
   code: "GOOGLE_TOKEN_EXCHANGE_FAILED" | "GOOGLE_REFRESH_FAILED",
 ): void {
   if (
-    !boundedString(parsed.access_token, 16_384) ||
-    (parsed.refresh_token !== undefined && !boundedString(parsed.refresh_token, 16_384)) ||
+    !isValidOAuthBearerToken(parsed.access_token) ||
+    (parsed.refresh_token !== undefined && !isValidOAuthOpaqueToken(parsed.refresh_token)) ||
     (parsed.token_type !== undefined &&
       (typeof parsed.token_type !== "string" || parsed.token_type.toLowerCase() !== "bearer")) ||
     (parsed.expires_in !== undefined &&
@@ -2209,8 +2210,8 @@ function parseGoogleCredential(value: string): GoogleCredentialPayload {
   };
   if (
     p.schemaVersion !== "steward.provider-google.credential.v1" ||
-    !bounded(p.accessToken, 16_384) ||
-    !(p.refreshToken === null || bounded(p.refreshToken, 16_384)) ||
+    !isValidOAuthBearerToken(p.accessToken) ||
+    !(p.refreshToken === null || isValidOAuthOpaqueToken(p.refreshToken)) ||
     !Array.isArray(p.scopesGranted) ||
     p.scopesGranted.length === 0 ||
     p.scopesGranted.length > GOOGLE_DEFAULT_SCOPES.length ||

--- a/packages/api/src/services/provider-x-connect.ts
+++ b/packages/api/src/services/provider-x-connect.ts
@@ -43,6 +43,7 @@ import {
   sql,
   withTenantAuditedTransaction,
 } from "@stwd/db";
+import { isValidOAuthBearerToken, isValidOAuthOpaqueToken } from "@stwd/shared";
 import type { SecretVault } from "@stwd/vault";
 
 type DbBase = ReturnType<typeof getDb>;
@@ -581,7 +582,12 @@ async function exchangeAuthorizationCode(input: ExchangeInput): Promise<XTokenRe
     body: body.toString(),
   });
   const parsed = res.json as XTokenResponse | null;
-  if (!res.ok || !parsed || typeof parsed.access_token !== "string") {
+  if (
+    !res.ok ||
+    !parsed ||
+    !isValidOAuthBearerToken(parsed.access_token) ||
+    (parsed.refresh_token !== undefined && !isValidOAuthOpaqueToken(parsed.refresh_token))
+  ) {
     throw new XConnectError(
       "X_TOKEN_EXCHANGE_FAILED",
       502,
@@ -969,7 +975,24 @@ async function loadCredential(
   // Decrypt from the ALREADY-READ row so we do not issue a second getDb() read
   // that would block behind an outer transaction on single-connection PGLite.
   const decrypted = vault.decryptSecretRow(tenantId, row);
-  const payload = JSON.parse(decrypted) as XCredentialPayload;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(decrypted);
+  } catch {
+    throw new XConnectError("X_REFRESH_FAILED", 409, "credential payload invalid");
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new XConnectError("X_REFRESH_FAILED", 409, "credential payload invalid");
+  }
+  const candidate = parsed as Record<string, unknown>;
+  if (
+    candidate.schemaVersion !== "steward.provider-x.credential.v1" ||
+    !isValidOAuthBearerToken(candidate.accessToken) ||
+    !(candidate.refreshToken === null || isValidOAuthOpaqueToken(candidate.refreshToken))
+  ) {
+    throw new XConnectError("X_REFRESH_FAILED", 409, "credential payload invalid");
+  }
+  const payload = candidate as unknown as XCredentialPayload;
   return {
     secretName: row.name,
     payload,
@@ -1019,7 +1042,11 @@ async function refreshUpstream(
     }
     throw new XConnectError("X_REFRESH_FAILED", 502, `X refresh failed (${res.status})`);
   }
-  if (!parsed || typeof parsed.access_token !== "string") {
+  if (
+    !parsed ||
+    !isValidOAuthBearerToken(parsed.access_token) ||
+    (parsed.refresh_token !== undefined && !isValidOAuthOpaqueToken(parsed.refresh_token))
+  ) {
     throw new XConnectError("X_REFRESH_FAILED", 502, "X refresh response missing access_token");
   }
   return {

--- a/packages/proxy/src/__tests__/google-credential-envelope.test.ts
+++ b/packages/proxy/src/__tests__/google-credential-envelope.test.ts
@@ -70,8 +70,19 @@ describe("X OAuth credential envelope", () => {
     );
     // OAuth bearer values are opaque. Legacy raw credentials that happen to be
     // valid JSON primitives must not be mistaken for structured envelopes.
-    for (const rawToken of ["1234567890", "true", '"quoted-legacy-token"']) {
+    for (const rawToken of ["1234567890", "true", "null"]) {
       expect(extractProviderCredentialForHost("api.x.com", rawToken)).toBe(rawToken);
+    }
+    for (const invalid of [
+      '"quoted-legacy-token"',
+      "",
+      "token with space",
+      "token\nwith-control",
+      "x".repeat(16_385),
+    ]) {
+      expect(() => extractProviderCredentialForHost("api.x.com", invalid)).toThrow(
+        "invalid X OAuth bearer credential",
+      );
     }
   });
 });

--- a/packages/proxy/src/__tests__/x-credential-route.test.ts
+++ b/packages/proxy/src/__tests__/x-credential-route.test.ts
@@ -217,6 +217,42 @@ describe("x narrow credential route (integration)", () => {
     expect(await res.text()).not.toContain(refreshCanary);
   });
 
+  it("rejects a JSON-quoted legacy token before constructing an outbound request", async () => {
+    captured = null;
+    const tenantId = `tenant-x-invalid-bearer-${crypto.randomUUID()}`;
+    const agentId = `agent-x-invalid-bearer-${crypto.randomUUID()}`;
+    await ensureTenant(tenantId);
+    await ensureAgent(tenantId, agentId);
+
+    const invalidToken = '"quoted-legacy-token"';
+    const vault = new SecretVault(MASTER_PASSWORD);
+    const secret = await vault.createSecret(tenantId, "x-invalid-bearer", invalidToken);
+    await vault.createRoute(tenantId, secret.id, {
+      agentId,
+      hostPattern: "api.x.com",
+      pathPattern: "/2/tweets",
+      method: "POST",
+      injectAs: "header",
+      injectKey: "authorization",
+      injectFormat: "Bearer {value}",
+    });
+
+    const token = await signAgentToken({ agentId, tenantId, scopes: ["agent", PROXY_SCOPE] }, "1h");
+    const res = await buildApp().request("/x/2/tweets", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+        "idempotency-key": crypto.randomUUID(),
+      },
+      body: JSON.stringify({ text: "must not reach the wire" }),
+    });
+
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(captured).toBeNull();
+    expect(await res.text()).not.toContain(invalidToken);
+  });
+
   it("MUTATION: a route/endpoint mismatch fails closed; the Bearer is NEVER injected or leaked", async () => {
     // A route for /2/users/me must NOT inject on a POST /2/tweets request: the
     // credential is pinned to one exact endpoint+verb. With only that route

--- a/packages/proxy/src/handlers/google-execution-credential.ts
+++ b/packages/proxy/src/handlers/google-execution-credential.ts
@@ -9,7 +9,7 @@ import {
   secrets,
   withTenantAuditedTransaction,
 } from "@stwd/db";
-import { strictParseJson } from "@stwd/shared";
+import { isValidOAuthBearerToken, isValidOAuthOpaqueToken, strictParseJson } from "@stwd/shared";
 import type { SecretVault } from "@stwd/vault";
 
 const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
@@ -96,9 +96,7 @@ function parseEnvelope(value: string): GoogleCredentialEnvelope {
   const parsed = strictParseJson(value) as Record<string, unknown>;
   if (
     parsed.schemaVersion !== "steward.provider-google.credential.v1" ||
-    typeof parsed.refreshToken !== "string" ||
-    parsed.refreshToken.length < 1 ||
-    parsed.refreshToken.length > 16_384 ||
+    !isValidOAuthOpaqueToken(parsed.refreshToken) ||
     !Array.isArray(parsed.scopesGranted) ||
     parsed.scopesGranted.length < 1 ||
     parsed.scopesGranted.length > 64 ||
@@ -124,15 +122,8 @@ function validateResponse(
   }
   const response = raw as GoogleRefreshResponse;
   if (
-    typeof response.access_token !== "string" ||
-    response.access_token.length < 1 ||
-    response.access_token.length > 16_384 ||
-    !/^[A-Za-z0-9\-._~+/]+=*$/.test(response.access_token) ||
-    (response.refresh_token !== undefined &&
-      (typeof response.refresh_token !== "string" ||
-        response.refresh_token.length < 1 ||
-        response.refresh_token.length > 16_384 ||
-        !/^[A-Za-z0-9\-._~+/]+=*$/.test(response.refresh_token))) ||
+    !isValidOAuthBearerToken(response.access_token) ||
+    (response.refresh_token !== undefined && !isValidOAuthOpaqueToken(response.refresh_token)) ||
     (response.token_type !== undefined &&
       (typeof response.token_type !== "string" ||
         response.token_type.toLowerCase() !== "bearer")) ||

--- a/packages/proxy/src/handlers/proxy.ts
+++ b/packages/proxy/src/handlers/proxy.ts
@@ -31,7 +31,7 @@ import {
   workspaces,
 } from "@stwd/db";
 import { getRedis, type SpendReservation, settleReservedSpend } from "@stwd/redis";
-import { strictParseJson } from "@stwd/shared";
+import { isValidOAuthBearerToken, strictParseJson } from "@stwd/shared";
 import { SecretVault } from "@stwd/vault";
 import type { Context } from "hono";
 import { boundedPositiveIntegerEnv, isProxyDevMode } from "../config";
@@ -183,16 +183,16 @@ export function extractProviderCredentialForHost(host: string, credential: strin
     if (googleHost) throw new Error("invalid Google OAuth credential envelope");
     // A parseable object at the X boundary is an envelope, not a legacy raw
     // token. Unknown/malformed envelopes must never be formatted into a header.
-    if (xHost && typeof parsed === "object" && parsed !== null)
-      throw new Error("invalid X OAuth credential envelope");
+    if (xHost) {
+      if (typeof parsed === "object" && parsed !== null)
+        throw new Error("invalid X OAuth credential envelope");
+      if (!isValidOAuthBearerToken(credential))
+        throw new Error("invalid X OAuth bearer credential");
+    }
     return credential;
   }
   if (!parsedEnvelope) throw new Error("invalid provider OAuth credential envelope");
-  if (
-    typeof parsedEnvelope.accessToken !== "string" ||
-    parsedEnvelope.accessToken.length < 1 ||
-    parsedEnvelope.accessToken.length > 16_384
-  )
+  if (!isValidOAuthBearerToken(parsedEnvelope.accessToken))
     throw new Error(
       googleHost
         ? "invalid Google OAuth credential envelope"

--- a/packages/shared/src/__tests__/oauth-token.test.ts
+++ b/packages/shared/src/__tests__/oauth-token.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import {
+  isValidOAuthBearerToken,
+  isValidOAuthOpaqueToken,
+  MAX_OAUTH_TOKEN_LENGTH,
+} from "../oauth-token";
+
+describe("OAuth token validation", () => {
+  test("implements the RFC 6750 b64token grammar exactly", () => {
+    for (const token of ["a", "AZaz09-._~+/", "abc=", "abc====", "ya29.a0-token_value"]) {
+      expect(isValidOAuthBearerToken(token), token).toBe(true);
+    }
+    for (const token of ["", "=abc", "ab=c", '"quoted"', "with space", "line\nfeed"]) {
+      expect(isValidOAuthBearerToken(token), token).toBe(false);
+    }
+  });
+
+  test("enforces the shared bound and keeps opaque refresh tokens off headers", () => {
+    expect(isValidOAuthBearerToken("x".repeat(MAX_OAUTH_TOKEN_LENGTH))).toBe(true);
+    expect(isValidOAuthBearerToken("x".repeat(MAX_OAUTH_TOKEN_LENGTH + 1))).toBe(false);
+    expect(isValidOAuthOpaqueToken("opaque:{refresh}=token&value")).toBe(true);
+    expect(isValidOAuthOpaqueToken("opaque refresh")).toBe(false);
+    expect(isValidOAuthOpaqueToken("refresh\rcontrol")).toBe(false);
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -11,6 +11,7 @@ export * from "./execution-payload.js";
 export * from "./generic-http-provider-action.js";
 export * from "./google-provider-action.js";
 export * from "./google-provider-action.js";
+export * from "./oauth-token.js";
 export type { PriceOracle } from "./price-oracle.js";
 export { createPriceOracle } from "./price-oracle.js";
 export * from "./provider-action.js";

--- a/packages/shared/src/oauth-token.ts
+++ b/packages/shared/src/oauth-token.ts
@@ -1,0 +1,27 @@
+/** RFC 6750 `b64token` syntax used by OAuth 2.0 Bearer credentials. */
+const OAUTH_BEARER_TOKEN_RE = /^[A-Za-z0-9._~+/-]+={0,}$/;
+
+export const MAX_OAUTH_TOKEN_LENGTH = 16_384;
+
+export function isValidOAuthBearerToken(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= MAX_OAUTH_TOKEN_LENGTH &&
+    OAUTH_BEARER_TOKEN_RE.test(value)
+  );
+}
+
+/**
+ * Refresh tokens are opaque rather than Bearer-header values, but X token
+ * endpoint responses still need a strict storage bound and must not contain
+ * controls or whitespace that can create log/form/header ambiguity later.
+ */
+export function isValidOAuthOpaqueToken(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= MAX_OAUTH_TOKEN_LENGTH &&
+    /^[\x21-\x7e]+$/.test(value)
+  );
+}


### PR DESCRIPTION
## Summary
- add one shared RFC 6750 `b64token` validator with a strict 16 KiB bound and direct grammar/padding tests
- apply it across X connect/refresh, Google connect/refresh persistence boundaries, Google execution minting, and proxy wire injection
- reject malformed decrypted X envelopes before refresh/revoke use while preserving valid opaque primitive-like legacy route tokens

## Security properties
- malformed provider responses fail before identity lookup or primary credential adoption; Google lifecycle escrow remains encrypted and revocable before semantic adoption
- malformed refresh responses cannot rotate the active stored credential
- malformed legacy credentials fail before outbound request construction and are not reflected in responses
- object/array envelope confusion and cross-provider host binding continue to fail closed

## Exact validation
Head: ea082e5c50bfa4ac0dc2ec958ad75329c6d580e2
Base: 78da6afae42aa24d7552de3075737f97b97b1d9c

- shared grammar: 2/2, 16 assertions
- proxy Google envelope/execution + X routes: 19/19, 59 assertions
- API X + Google lifecycle: 74/74, 255 assertions
- dependency-aware API/proxy build: 23/23
- focused Biome and diff-check: green

Draft pending fresh hosted CI.