### PR TITLE
fix(security): closing-sweep leftovers — IPv6 screening parity + stale gate assertion

### DIFF
--- a/packages/api/src/__tests__/middleware-security-hardening.test.ts
+++ b/packages/api/src/__tests__/middleware-security-hardening.test.ts
@@ -85,9 +85,13 @@ describe("middleware security hardening", () => {
     expect(indexSource).toContain(
       "function runtimeGate(request: Request, peerAddress: string | null)",
     );
-    expect(indexSource).toContain(
-      "runtimeGate(request, server.requestIP(request)?.address ?? null) ?? app.fetch(request)",
-    );
+    expect(indexSource).toContain("const peerAddress = server.requestIP(request)?.address ?? null");
+    expect(indexSource).toContain("runtimeGate(request, peerAddress)");
+    // The runtime gate must run before Hono route dispatch.
+    const gateAt = indexSource.indexOf("runtimeGate(request, peerAddress)");
+    const fetchAt = indexSource.indexOf("app.fetch(request,");
+    expect(gateAt).toBeGreaterThanOrEqual(0);
+    expect(fetchAt).toBeGreaterThan(gateAt);
     expect(indexSource).not.toContain('app.use("*", async (c, next) => {');
   });
 

--- a/packages/api/src/__tests__/webhook-url-validation.test.ts
+++ b/packages/api/src/__tests__/webhook-url-validation.test.ts
@@ -43,6 +43,8 @@ describe("webhook URL validation", () => {
   it("still allows public IPv6 and well-known NAT64 embeddings of public IPv4", () => {
     expect(validateWebhookUrl("https://[2001:4860:4860::8888]/hook")).toBeNull();
     expect(validateWebhookUrl("https://[64:ff9b::808:808]/hook")).toBeNull();
+    // IPv4-translated form with a public embedding stays allowed (no over-block).
+    expect(validateWebhookUrl("https://[::ffff:0:808:808]/hook")).toBeNull();
   });
 
   it("rejects Teredo and documentation IPv6 addresses", () => {
@@ -89,6 +91,20 @@ describe("webhook URL validation", () => {
       "https://[::ffff:c633:6414]/hook",
       "https://[64:ff9b::cb00:711e]/hook",
       "https://[2002:c000:020a::]/hook",
+    ]) {
+      expect(validateWebhookUrl(url)).toBe("url host must be public");
+    }
+  });
+
+  it("rejects IPv4-translated ::ffff:0:0/96 and deprecated ::/96 forms at registration", () => {
+    // Parity with the delivery-time dispatcher screen (SEC-178): these forms
+    // embed an IPv4 reachable via NAT64/SIIT translators and must be refused
+    // up front, not only at delivery.
+    for (const url of [
+      "https://[::ffff:0:7f00:1]/hook",
+      "https://[::ffff:0:a9fe:a9fe]/hook",
+      "https://[::7f00:1]/hook",
+      "https://[::127.0.0.1]/hook",
     ]) {
       expect(validateWebhookUrl(url)).toBe("url host must be public");
     }

--- a/packages/api/src/services/webhook-url.ts
+++ b/packages/api/src/services/webhook-url.ts
@@ -85,6 +85,20 @@ function embeddedIpv4FromIpv6(hostname: string): string | null {
     words[5] === 0;
   if (isNat64WellKnown) return fromWords(words[6], words[7]);
 
+  // RFC 8215 IPv4-translated ::ffff:0:0/96 — distinct from the IPv4-mapped
+  // form (words[5] === 0xffff, handled by mappedIpv4FromIpv6). The IPv4 is
+  // embedded in the low 32 bits and reachable through NAT64/SIIT paths, so
+  // it must face the same non-public checks. Parity with the delivery-time
+  // dispatcher screen (SEC-178); registration should reject these up front.
+  const isIpv4Translated =
+    words[0] === 0 &&
+    words[1] === 0 &&
+    words[2] === 0 &&
+    words[3] === 0 &&
+    words[4] === 0xffff &&
+    words[5] === 0;
+  if (isIpv4Translated) return fromWords(words[6], words[7]);
+
   if (words[0] === 0x2002) return fromWords(words[1], words[2]);
 
   return null;
@@ -102,6 +116,11 @@ function isNonPublicIpv6(hostname: string): boolean {
   // Treat the entire non-globally-reachable prefix as non-public (matching the
   // OIDC screeners) instead of extracting a would-be /96 suffix.
   if (words?.[0] === 0x64 && words[1] === 0xff9b && words[2] === 1) return true;
+  // Deprecated IPv4-compatible ::/96 space is special-use, not a public
+  // webhook destination. Closes parser-dependent forms such as
+  // `[::127.0.0.1]` / `[::7f00:1]` (parity with the dispatcher screen).
+  if (words && words.slice(0, 6).every((word) => word === 0) && (words[6] !== 0 || words[7] !== 0))
+    return true;
   if (words?.[0] === 0x2001 && (words[1] === 0 || words[1] === 0xdb8)) return true;
   if (words?.[0] !== undefined && (words[0] & 0xffc0) === 0xfe80) return true;
   if (words?.[0] !== undefined && (words[0] & 0xffc0) === 0xfec0) return true;


### PR DESCRIPTION
Final items from the closing verification sweep: (1) webhook registration-time IPv6 screener now rejects IPv4-translated `::ffff:0:0/96` and deprecated `::/96` forms up front (parity with the delivery-time dispatcher SEC-178 screen; previously fail-closed only at delivery). Public translated embeddings (e.g. `[::ffff:0:808:808]`) remain allowed. (2) Repaired the stale source-grep assertion in middleware-security-hardening.test.ts (red on develop since #413's peerAddress hoist); now pins the hoisted form and asserts the gate precedes app.fetch. Tests: webhook-url-validation 16/16, middleware-security-hardening 8/8 (one bun process per file).