### PR TITLE
style(ci): format security inventory regression

### DIFF
--- a/scripts/__tests__/check-ci-test-inventory.test.ts
+++ b/scripts/__tests__/check-ci-test-inventory.test.ts
@@ -19,9 +19,9 @@ describe("CI test inventory", () => {
   test("direct Bun test-file commands use explicit relative paths", () => {
     for (const workflow of [".github/workflows/ci.yml", ".github/workflows/pr.yml"]) {
       const source = readFileSync(workflow, "utf8");
-      expect(source.match(/\bbun test packages\/[^\s]+\.(?:test|spec)\.[cm]?[jt]sx?/g) ?? []).toEqual(
-        [],
-      );
+      expect(
+        source.match(/\bbun test packages\/[^\s]+\.(?:test|spec)\.[cm]?[jt]sx?/g) ?? [],
+      ).toEqual([]);
     }
   });
 


### PR DESCRIPTION
## Summary
- format the security test-path inventory regression added by #435
- restore the repository-wide Biome gate on the current `develop` head

## Exact failure
Current `develop` CI run `32106756205`, job `95617651515`, failed because Biome would reflow the direct Bun test-file assertion in `scripts/__tests__/check-ci-test-inventory.test.ts`.

## Local verification
- `bun scripts/check-ci-test-inventory.ts` (all 46 test-bearing targets covered)
- `bun test scripts/__tests__/check-ci-test-inventory.test.ts` (8 passed)
- `bun run lint` (1,289 files clean)
- `git diff --check`
