### PR TITLE
fix(deploy): reject ambiguous backup DSNs

### DIFF
--- a/deploy/enterprise-reference/docker-compose.yml
+++ b/deploy/enterprise-reference/docker-compose.yml
@@ -287,6 +287,16 @@ services:
               *) pg_authority="$$(printf '%s' "$$pg_rest" | sed 's|[?].*||')" ;;
             esac
             pg_suffix="$${pg_rest#"$$pg_authority"}"
+            # A raw '/' inside userinfo terminates the authority before '@',
+            # while multiple raw '@' delimiters have no safe, unique split.
+            # Reject both ambiguous forms instead of letting their secret bytes
+            # survive in the redacted DSN passed on pg_dump's argv.
+            case "$${pg_suffix%%\?*}" in
+              *@*) echo 'DATABASE_URL contains ambiguous user information' >&2; exit 1 ;;
+            esac
+            case "$$pg_authority" in
+              *@*@*) echo 'DATABASE_URL contains ambiguous user information' >&2; exit 1 ;;
+            esac
             case "$$pg_authority" in
               *:*@*)
                 pg_userinfo="$${pg_authority%%@*}"
@@ -310,6 +320,14 @@ services:
                 export PGPASSWORD
                 ;;
             esac
+            ;;
+          *)
+            # Steward DATABASE_URL accepts only libpq URI form. In particular,
+            # never pass a keyword/value conninfo string through unchanged: it
+            # can carry password=... directly on pg_dump's argv.
+            echo 'DATABASE_URL must use postgres:// or postgresql://' >&2
+            exit 1
+            ;;
         esac
         pg_query_password=
         pg_query_password_found=

--- a/packages/proxy/src/__tests__/deploy-artifacts.test.ts
+++ b/packages/proxy/src/__tests__/deploy-artifacts.test.ts
@@ -293,10 +293,21 @@ describe("SEC-081 enterprise backup service keeps the DSN out of container env a
       // With no slash, libpq's raw-userinfo extension is indistinguishable
       // from an @ in a query value. Reject rather than leak either reading.
       "postgresql://steward:p?ss@postgres:5432",
+      // A raw slash terminates the authority before the apparent userinfo
+      // delimiter; multiple raw delimiters are likewise not uniquely parseable.
+      // Neither secret-bearing input may survive into pg_dump's argv.
+      "postgresql://steward:slash-secret/part@postgres:5432/steward",
+      "postgresql://steward:first-secret@second-secret@postgres:5432/steward",
+      // Steward's database client requires URI form. Passing libpq's alternate
+      // keyword/value form through unchanged would expose password= in argv.
+      "host=postgres dbname=steward user=steward password=keyword-secret",
     ]) {
-      const result = runParser(malformed);
-      expect(result.exitCode).not.toBe(0);
-      expect(result.stderr.toString()).not.toContain(malformed);
+      for (const shell of ["sh", "dash"]) {
+        const result = runParser(malformed, shell);
+        expect(result.exitCode).not.toBe(0);
+        expect(result.stdout.toString()).toBe("");
+        expect(result.stderr.toString()).not.toContain(malformed);
+      }
     }
   });
 });


### PR DESCRIPTION
## Summary

- fail closed when raw `/` or multiple raw `@` delimiters make URI userinfo ambiguous
- reject non-URI libpq conninfo so `password=...` can never be forwarded on `pg_dump` argv
- prove rejection under both `sh` and `dash`, without echoing the malformed input

Post-merge audit follow-up to #434 / #429.

## Exact-head verification

- `bun test packages/proxy/src/__tests__/deploy-artifacts.test.ts` — 46 passed, 232 assertions
- `bunx biome check packages/proxy/src/__tests__/deploy-artifacts.test.ts`
- `git diff --check origin/develop...HEAD`
- `bun run --cwd packages/proxy build`

Base: `c40b5bff105e69e963adc736ce626dd7bd388bfc`
Head: `0eb2f2984420dc63ff8eb6bf0e15466d7f69bd0f`