### PR TITLE
fix(provider-google): classify writes, redact failures, block refresh replay

### DIFF
--- a/packages/api/src/__tests__/production-profile-boundary-e2e.test.ts
+++ b/packages/api/src/__tests__/production-profile-boundary-e2e.test.ts
@@ -28,6 +28,7 @@ import {
   providerActionBindings,
   providerGrants,
   providerOperations,
+  proxyAuditLog,
   secretRoutes,
   secrets,
 } from "@stwd/db";
@@ -59,6 +60,7 @@ let app: Hono<{ Variables: AppVariables }>;
 let jwksServer: Server;
 let agentPrivateKey: KeyLike;
 let dispatchGovernedExecution: typeof import("@stwd/proxy/src/handlers/governed-execution")["dispatchGovernedExecution"];
+let proxy: typeof import("@stwd/proxy/src/handlers/proxy");
 let forwardCount = 0;
 
 const PROFILES = [
@@ -221,7 +223,7 @@ beforeAll(async () => {
   const { resetCheckpointSignerCache } = await import("../services/audit-checkpoint");
   resetCheckpointSignerCache();
   app = (await import("../app")).app as Hono<{ Variables: AppVariables }>;
-  const proxy = await import("@stwd/proxy/src/handlers/proxy");
+  proxy = await import("@stwd/proxy/src/handlers/proxy");
   proxy.__resetSecretVaultForTests();
   ({ dispatchGovernedExecution } = await import("@stwd/proxy/src/handlers/governed-execution"));
   proxy.__setCheckProxyRateLimitForTests(async () => ({
@@ -245,14 +247,7 @@ beforeAll(async () => {
     forwardCount += 1;
     return new Response('{"ok":true}', { status: 201 });
   });
-  proxy.__setGoogleExecutionTokenForwarderForTests(async () =>
-    Response.json({
-      access_token: "profile-boundary-ephemeral-access",
-      token_type: "Bearer",
-      scope: "openid email https://www.googleapis.com/auth/calendar.readonly",
-      expires_in: 3600,
-    }),
-  );
+  resetGoogleExecutionTokenForwarder();
 });
 
 beforeEach(async () => {
@@ -261,6 +256,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  resetGoogleExecutionTokenForwarder();
   await getDb()
     .update(secretRoutes)
     .set({ authorityMode: "legacy", providerOperationId: null })
@@ -290,10 +286,21 @@ afterAll(async () => {
 
 type BoundaryFixture = (typeof PROFILES)[number];
 
-async function runAuthenticatedBoundary(
+function resetGoogleExecutionTokenForwarder(): void {
+  proxy.__setGoogleExecutionTokenForwarderForTests(async () =>
+    Response.json({
+      access_token: "profile-boundary-ephemeral-access",
+      token_type: "Bearer",
+      scope: "openid email https://www.googleapis.com/auth/calendar.readonly",
+      expires_in: 3600,
+    }),
+  );
+}
+
+async function prepareAuthenticatedBoundary(
   fixture: BoundaryFixture,
   options: { maliciousOperationDescriptor?: boolean } = {},
-): Promise<void> {
+): Promise<{ actionId: string }> {
   const requestProfile = {
     ...fixture.requestProfile,
     policyRules: approvalRules(fixture.operationKey),
@@ -461,7 +468,16 @@ async function runAuthenticatedBoundary(
     await db.execute(sql`UPDATE provider_operations SET revision = 1 WHERE id = ${F.OP}`);
   }
 
-  const dispatch = await dispatchGovernedExecution(action.id, F.TENANT);
+  return { actionId: action.id };
+}
+
+async function runAuthenticatedBoundary(
+  fixture: BoundaryFixture,
+  options: { maliciousOperationDescriptor?: boolean } = {},
+): Promise<void> {
+  const { actionId } = await prepareAuthenticatedBoundary(fixture, options);
+
+  const dispatch = await dispatchGovernedExecution(actionId, F.TENANT);
   if (options.maliciousOperationDescriptor) {
     expect(dispatch).toMatchObject({
       ok: false,
@@ -476,16 +492,16 @@ async function runAuthenticatedBoundary(
 
   const admin = await sessionToken(F.APPROVER_2);
   const humanHeaders = { authorization: `Bearer ${admin}`, "x-steward-tenant": F.TENANT };
-  const caseResponse = await app.request(`/v2/provider-actions/${action.id}/case`, {
+  const caseResponse = await app.request(`/v2/provider-actions/${actionId}/case`, {
     headers: humanHeaders,
   });
   expect(caseResponse.status).toBe(200);
   expect(await caseResponse.json()).toMatchObject({
-    caseId: action.id,
+    caseId: actionId,
     operation: { key: fixture.operationKey, canonicalProfile: fixture.profile },
     terminalState: options.maliciousOperationDescriptor ? "execution_ready" : "succeeded",
   });
-  const evidenceResponse = await app.request(`/v2/provider-actions/${action.id}/evidence`, {
+  const evidenceResponse = await app.request(`/v2/provider-actions/${actionId}/evidence`, {
     headers: humanHeaders,
   });
   expect(evidenceResponse.status).toBe(200);
@@ -494,7 +510,7 @@ async function runAuthenticatedBoundary(
     bundle: { events: unknown[] };
   };
   expect(evidence.manifest).toMatchObject({
-    caseId: action.id,
+    caseId: actionId,
     operation: { canonicalProfile: fixture.profile },
   });
   expect(evidence.bundle.events.length).toBeGreaterThan(0);
@@ -518,5 +534,44 @@ describe("#220 real production profile boundaries", () => {
     expect(genericFixture).toBeDefined();
     if (!genericFixture) throw new Error("generic HTTP production fixture is missing");
     await runAuthenticatedBoundary(genericFixture, { maliciousOperationDescriptor: true });
+  });
+
+  test("google governed dispatch redacts thrown execution-token canaries from logs, response, and audit", async () => {
+    const googleFixture = PROFILES.find(
+      ({ profile }) => profile === GOOGLE_PROVIDER_ACTION_PROFILE,
+    );
+    expect(googleFixture).toBeDefined();
+    if (!googleFixture) throw new Error("google production fixture is missing");
+    const canary = "profile-boundary-refresh-canary profile-boundary-error-canary";
+    const logged: string[] = [];
+    const originalError = console.error;
+    console.error = (...args: unknown[]) => {
+      logged.push(
+        args.map((value) => (typeof value === "string" ? value : JSON.stringify(value))).join(" "),
+      );
+    };
+    proxy.__setGoogleExecutionTokenForwarderForTests(async () => {
+      const error = Object.assign(new Error(canary), { code: "ECONNRESET" });
+      throw error;
+    });
+    try {
+      const { actionId } = await prepareAuthenticatedBoundary(googleFixture);
+      const dispatch = await dispatchGovernedExecution(actionId, F.TENANT);
+      expect(dispatch).toMatchObject({ ok: false });
+      expect(JSON.stringify(dispatch)).not.toContain(canary);
+      expect(forwardCount).toBe(0);
+    } finally {
+      console.error = originalError;
+      resetGoogleExecutionTokenForwarder();
+    }
+    const audits = await getDb()
+      .select()
+      .from(proxyAuditLog)
+      .where(eq(proxyAuditLog.tenantId, F.TENANT));
+    expect(audits.some((audit) => audit.reason === "credential-decrypt-failed")).toBeTrue();
+    expect(JSON.stringify(audits)).not.toContain(canary);
+    expect(logged.join("\n")).toContain('"errorClass":"Error"');
+    expect(logged.join("\n")).toContain('"errorCode":"ECONNRESET"');
+    expect(logged.join("\n")).not.toContain(canary);
   });
 });

--- a/packages/api/src/__tests__/production-profile-boundary-e2e.test.ts
+++ b/packages/api/src/__tests__/production-profile-boundary-e2e.test.ts
@@ -116,7 +116,7 @@ const PROFILES = [
     host: "ec2.us-west-2.amazonaws.com",
     method: "POST",
     path: "/",
-    args: { region: "us-west-2" },
+    args: { region: "us-west-2", instanceIds: ["i-0123456789abcdef0"] },
     requestProfile: {},
   },
   {
@@ -370,12 +370,11 @@ async function prepareAuthenticatedBoundary(
       // region the fixture host commits to). Both assertAwsCredentialRouteBinding
       // (ingress) and injectAwsSigV4AtFinalBoundary (dispatch) fail closed
       // without it. Other profiles keep the seeded header-injection strategy.
-      ...(fixture.profile === AWS_PROVIDER_ACTION_PROFILE
-        ? {
-            injectionStrategy: "sigv4",
-            injectionConfig: { service: "ec2", region: "us-west-2" },
-          }
-        : {}),
+      injectionStrategy: fixture.profile === AWS_PROVIDER_ACTION_PROFILE ? "sigv4" : "header",
+      injectionConfig:
+        fixture.profile === AWS_PROVIDER_ACTION_PROFILE
+          ? { service: "ec2", region: "us-west-2" }
+          : {},
     })
     .where(and(eq(secretRoutes.tenantId, F.TENANT), eq(secretRoutes.id, F.ROUTE)));
 
@@ -551,7 +550,7 @@ describe("#220 real production profile boundaries", () => {
       );
     };
     proxy.__setGoogleExecutionTokenForwarderForTests(async () => {
-      const error = Object.assign(new Error(canary), { code: "ECONNRESET" });
+      const error = Object.assign(new Error(canary), { name: canary, code: canary });
       throw error;
     });
     try {
@@ -571,7 +570,7 @@ describe("#220 real production profile boundaries", () => {
     expect(audits.some((audit) => audit.reason === "credential-decrypt-failed")).toBeTrue();
     expect(JSON.stringify(audits)).not.toContain(canary);
     expect(logged.join("\n")).toContain('"errorClass":"Error"');
-    expect(logged.join("\n")).toContain('"errorCode":"ECONNRESET"');
+    expect(logged.join("\n")).toContain('"errorCode":null');
     expect(logged.join("\n")).not.toContain(canary);
   });
 });

--- a/packages/api/src/__tests__/production-profile-boundary-e2e.test.ts
+++ b/packages/api/src/__tests__/production-profile-boundary-e2e.test.ts
@@ -567,10 +567,11 @@ describe("#220 real production profile boundaries", () => {
       .select()
       .from(proxyAuditLog)
       .where(eq(proxyAuditLog.tenantId, F.TENANT));
-    expect(audits.some((audit) => audit.reason === "credential-decrypt-failed")).toBeTrue();
+    expect(audits.some((audit) => audit.reason === "credential-resolution-failed")).toBeTrue();
     expect(JSON.stringify(audits)).not.toContain(canary);
     expect(logged.join("\n")).toContain('"errorClass":"Error"');
     expect(logged.join("\n")).toContain('"errorCode":null');
     expect(logged.join("\n")).not.toContain(canary);
+    expect(logged.join("\n")).not.toContain("profile-boundary-name-canary");
   });
 });

--- a/packages/api/src/__tests__/provider-google-authority-registration.test.ts
+++ b/packages/api/src/__tests__/provider-google-authority-registration.test.ts
@@ -141,13 +141,20 @@ describe("Google provider authority registration", () => {
       store.registerOperation(context(1), account.id, {
         operationKey: "google.gmail.messages.send",
         riskClass: "write",
+        secretRouteId: gmailRouteId,
+      }),
+    ).rejects.toMatchObject({ code: "bad_request", status: 400 });
+    await expect(
+      store.registerOperation(context(1), account.id, {
+        operationKey: "google.gmail.messages.send",
+        riskClass: "consequential",
         secretRouteId: wrongRouteId,
       }),
     ).rejects.toMatchObject({ code: "forbidden", status: 403 });
     await expect(
       store.registerOperation(context(1), account.id, {
         operationKey: "google.gmail.messages.send",
-        riskClass: "write",
+        riskClass: "consequential",
         secretRouteId: wrongInjectionRouteId,
       }),
     ).rejects.toMatchObject({ code: "forbidden", status: 403 });
@@ -167,7 +174,7 @@ describe("Google provider authority registration", () => {
 
     const gmail = await store.registerOperation(context(1), account.id, {
       operationKey: "google.gmail.messages.send",
-      riskClass: "write",
+      riskClass: "consequential",
       secretRouteId: gmailRouteId,
     });
     const list = await store.registerOperation(context(2), account.id, {
@@ -177,7 +184,7 @@ describe("Google provider authority registration", () => {
     });
     const insert = await store.registerOperation(context(3), account.id, {
       operationKey: "google.calendar.events.insert",
-      riskClass: "write",
+      riskClass: "consequential",
       secretRouteId: calendarInsertRouteId,
     });
     expect([gmail.operationKey, list.operationKey, insert.operationKey]).toEqual([

--- a/packages/api/src/__tests__/provider-google-lifecycle-scheduler.test.ts
+++ b/packages/api/src/__tests__/provider-google-lifecycle-scheduler.test.ts
@@ -43,7 +43,7 @@ test("Google lifecycle scheduler redacts failure logs to class/code only", async
     const stop = startGoogleCredentialLifecycleScheduler({
       intervalMs: 60_000,
       sweep: async () => {
-        const error = Object.assign(new Error(canary), { code: "ECONNRESET" });
+        const error = Object.assign(new Error(canary), { name: canary, code: canary });
         throw error;
       },
     });
@@ -52,6 +52,7 @@ test("Google lifecycle scheduler redacts failure logs to class/code only", async
   } finally {
     console.error = originalError;
   }
-  expect(logged.join("\n")).toContain("ECONNRESET");
+  expect(logged.join("\n")).toContain('"errorClass":"Error"');
+  expect(logged.join("\n")).toContain('"errorCode":null');
   expect(logged.join("\n")).not.toContain(canary);
 });

--- a/packages/api/src/__tests__/provider-google-lifecycle-scheduler.test.ts
+++ b/packages/api/src/__tests__/provider-google-lifecycle-scheduler.test.ts
@@ -29,3 +29,29 @@ test("Google lifecycle scheduler runs immediately, drains bounded pages, and sto
   expect(calls).toBe(2);
   expect(maxConcurrent).toBe(1);
 });
+
+test("Google lifecycle scheduler redacts failure logs to class/code only", async () => {
+  const canary = "refresh-canary-never-log secret-canary-never-log";
+  const logged: string[] = [];
+  const originalError = console.error;
+  console.error = (...args: unknown[]) => {
+    logged.push(
+      args.map((value) => (typeof value === "string" ? value : JSON.stringify(value))).join(" "),
+    );
+  };
+  try {
+    const stop = startGoogleCredentialLifecycleScheduler({
+      intervalMs: 60_000,
+      sweep: async () => {
+        const error = Object.assign(new Error(canary), { code: "ECONNRESET" });
+        throw error;
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    await stop();
+  } finally {
+    console.error = originalError;
+  }
+  expect(logged.join("\n")).toContain("ECONNRESET");
+  expect(logged.join("\n")).not.toContain(canary);
+});

--- a/packages/api/src/__tests__/provider-google-lifecycle-scheduler.test.ts
+++ b/packages/api/src/__tests__/provider-google-lifecycle-scheduler.test.ts
@@ -55,4 +55,5 @@ test("Google lifecycle scheduler redacts failure logs to class/code only", async
   expect(logged.join("\n")).toContain('"errorClass":"Error"');
   expect(logged.join("\n")).toContain('"errorCode":null');
   expect(logged.join("\n")).not.toContain(canary);
+  expect(logged.join("\n")).not.toContain("secret-name-canary");
 });

--- a/packages/api/src/services/provider-authority-store.ts
+++ b/packages/api/src/services/provider-authority-store.ts
@@ -60,9 +60,9 @@ const GOOGLE_OPERATION_METHOD = {
   "google.calendar.events.insert": "POST",
 } as const satisfies Readonly<Record<GoogleOperationKey, "GET" | "POST" | "DELETE">>;
 const GOOGLE_OPERATION_MINIMUM_RISK = {
-  "google.gmail.messages.send": "write",
+  "google.gmail.messages.send": "consequential",
   "google.calendar.events.list": "read",
-  "google.calendar.events.insert": "write",
+  "google.calendar.events.insert": "consequential",
 } as const satisfies Readonly<Record<GoogleOperationKey, ProviderRiskClass>>;
 const GOOGLE_OPERATION_EXACT_PATH = {
   "google.gmail.messages.send": "/gmail/v1/users/me/messages/send",

--- a/packages/api/src/services/provider-google-lifecycle-scheduler.ts
+++ b/packages/api/src/services/provider-google-lifecycle-scheduler.ts
@@ -8,19 +8,39 @@ import {
 const DEFAULT_INTERVAL_MS = 60_000;
 const MIN_INTERVAL_MS = 5_000;
 const MAX_INTERVAL_MS = 5 * 60_000;
+const SAFE_ERROR_CODES = new Set([
+  "ABORT_ERR",
+  "EAI_AGAIN",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "ENOTFOUND",
+  "ETIMEDOUT",
+  "UND_ERR_CONNECT_TIMEOUT",
+]);
 
 function classifySweepFailure(error: unknown): {
   errorClass: string;
   errorCode: string | null;
 } {
-  const errorClass = error instanceof Error ? error.name : typeof error;
-  const errorCode =
-    typeof error === "object" &&
-    error !== null &&
-    "code" in error &&
-    typeof (error as { code?: unknown }).code === "string"
-      ? ((error as { code: string }).code ?? null)
-      : null;
+  let errorClass: string = typeof error;
+  try {
+    if (error instanceof TypeError) errorClass = "TypeError";
+    else if (error instanceof RangeError) errorClass = "RangeError";
+    else if (error instanceof SyntaxError) errorClass = "SyntaxError";
+    else if (error instanceof Error) errorClass = "Error";
+  } catch {
+    errorClass = "unknown";
+  }
+  let errorCode: string | null = null;
+  try {
+    const rawCode =
+      typeof error === "object" && error !== null
+        ? Reflect.get(error as object, "code")
+        : undefined;
+    if (typeof rawCode === "string" && SAFE_ERROR_CODES.has(rawCode)) errorCode = rawCode;
+  } catch {
+    // A hostile getter/proxy must not break the scheduler's rejection handler.
+  }
   return { errorClass, errorCode };
 }
 

--- a/packages/api/src/services/provider-google-lifecycle-scheduler.ts
+++ b/packages/api/src/services/provider-google-lifecycle-scheduler.ts
@@ -1,3 +1,4 @@
+import { redactedThrownDiagnostics } from "@stwd/shared";
 import { SecretVault } from "@stwd/vault";
 import {
   type GoogleCredentialLifecycleSweepResult,
@@ -8,42 +9,6 @@ import {
 const DEFAULT_INTERVAL_MS = 60_000;
 const MIN_INTERVAL_MS = 5_000;
 const MAX_INTERVAL_MS = 5 * 60_000;
-const SAFE_ERROR_CODES = new Set([
-  "ABORT_ERR",
-  "EAI_AGAIN",
-  "ECONNREFUSED",
-  "ECONNRESET",
-  "ENOTFOUND",
-  "ETIMEDOUT",
-  "UND_ERR_CONNECT_TIMEOUT",
-]);
-
-function classifySweepFailure(error: unknown): {
-  errorClass: string;
-  errorCode: string | null;
-} {
-  let errorClass: string = typeof error;
-  try {
-    if (error instanceof TypeError) errorClass = "TypeError";
-    else if (error instanceof RangeError) errorClass = "RangeError";
-    else if (error instanceof SyntaxError) errorClass = "SyntaxError";
-    else if (error instanceof Error) errorClass = "Error";
-  } catch {
-    errorClass = "unknown";
-  }
-  let errorCode: string | null = null;
-  try {
-    const rawCode =
-      typeof error === "object" && error !== null
-        ? Reflect.get(error as object, "code")
-        : undefined;
-    if (typeof rawCode === "string" && SAFE_ERROR_CODES.has(rawCode)) errorCode = rawCode;
-  } catch {
-    // A hostile getter/proxy must not break the scheduler's rejection handler.
-  }
-  return { errorClass, errorCode };
-}
-
 function configuredInterval(): number {
   const raw = process.env.STEWARD_GOOGLE_LIFECYCLE_SWEEP_INTERVAL_MS;
   if (raw === undefined) return DEFAULT_INTERVAL_MS;
@@ -91,7 +56,7 @@ export function startGoogleCredentialLifecycleScheduler(options?: {
         }
       })
       .catch((error) => {
-        const classified = classifySweepFailure(error);
+        const classified = redactedThrownDiagnostics(error);
         console.error("[provider-google] lifecycle sweep failed", {
           errorClass: classified.errorClass,
           errorCode: classified.errorCode,

--- a/packages/api/src/services/provider-google-lifecycle-scheduler.ts
+++ b/packages/api/src/services/provider-google-lifecycle-scheduler.ts
@@ -9,6 +9,21 @@ const DEFAULT_INTERVAL_MS = 60_000;
 const MIN_INTERVAL_MS = 5_000;
 const MAX_INTERVAL_MS = 5 * 60_000;
 
+function classifySweepFailure(error: unknown): {
+  errorClass: string;
+  errorCode: string | null;
+} {
+  const errorClass = error instanceof Error ? error.name : typeof error;
+  const errorCode =
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    typeof (error as { code?: unknown }).code === "string"
+      ? ((error as { code: string }).code ?? null)
+      : null;
+  return { errorClass, errorCode };
+}
+
 function configuredInterval(): number {
   const raw = process.env.STEWARD_GOOGLE_LIFECYCLE_SWEEP_INTERVAL_MS;
   if (raw === undefined) return DEFAULT_INTERVAL_MS;
@@ -55,7 +70,13 @@ export function startGoogleCredentialLifecycleScheduler(options?: {
           );
         }
       })
-      .catch((error) => console.error("[provider-google] lifecycle sweep failed:", error))
+      .catch((error) => {
+        const classified = classifySweepFailure(error);
+        console.error("[provider-google] lifecycle sweep failed", {
+          errorClass: classified.errorClass,
+          errorCode: classified.errorCode,
+        });
+      })
       .finally(() => {
         active = undefined;
         if (rerunRequested && !stopped) {

--- a/packages/db/drizzle/0102_google_consequential_write_risk.sql
+++ b/packages/db/drizzle/0102_google_consequential_write_risk.sql
@@ -1,0 +1,18 @@
+-- Existing Google write operations may have been registered before Gmail send
+-- and Calendar insert were classified as consequential. Upgrade those rows and
+-- bump their revision so every in-flight approval/commitment becomes stale.
+UPDATE "provider_operations" AS operation
+SET
+  "risk_class" = 'consequential',
+  "revision" = operation."revision" + 1,
+  "updated_at" = now()
+FROM "provider_accounts" AS account
+WHERE operation."provider_account_id" = account."id"
+  AND operation."tenant_id" = account."tenant_id"
+  AND operation."workspace_id" = account."workspace_id"
+  AND account."adapter_key" = 'google'
+  AND operation."operation_key" IN (
+    'google.gmail.messages.send',
+    'google.calendar.events.insert'
+  )
+  AND operation."risk_class" <> 'consequential';

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -575,6 +575,13 @@
       "when": 1787106472000,
       "tag": "0101_operator_transfer_integrity",
       "breakpoints": true
+    },
+    {
+      "idx": 102,
+      "version": "7",
+      "when": 1787106473000,
+      "tag": "0102_google_consequential_write_risk",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/__tests__/google-consequential-risk-migration.test.ts
+++ b/packages/db/src/__tests__/google-consequential-risk-migration.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, setDefaultTimeout, test } from "bun:test";
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { PGlite } from "@electric-sql/pglite";
+
+setDefaultTimeout(120_000);
+const migrations = new URL("../../drizzle", import.meta.url).pathname;
+const migrationUnderTest = "0102_google_consequential_write_risk.sql";
+
+async function applyFile(client: PGlite, file: string): Promise<void> {
+  const sql = await readFile(join(migrations, file), "utf8");
+  for (const statement of sql.split("--> statement-breakpoint")) {
+    if (statement.trim()) await client.exec(statement);
+  }
+}
+
+async function applyBeforeMigration(client: PGlite): Promise<void> {
+  const files = (await readdir(migrations))
+    .filter((file) => file.endsWith(".sql") && file < migrationUnderTest)
+    .sort();
+  for (const file of files) await applyFile(client, file);
+}
+
+describe("Google consequential write risk migration (0102)", () => {
+  test("upgrades existing write rows, stales commitments, and is idempotent", async () => {
+    const client = new PGlite("memory://");
+    await applyBeforeMigration(client);
+    await client.exec(`
+      INSERT INTO tenants(id,name,api_key_hash) VALUES ('tg','Google','hg');
+      INSERT INTO users(id,email,created_at,updated_at) VALUES
+        ('00000000-0000-4000-8000-000000000001','owner@example.test',now(),now());
+      INSERT INTO workspaces(id,tenant_id,key,name,environment,created_by) VALUES
+        ('00000000-0000-4000-8000-000000000101','tg','google','Google','production',
+         '00000000-0000-4000-8000-000000000001');
+      INSERT INTO provider_accounts(
+        id,tenant_id,workspace_id,adapter_key,external_ref,display_name
+      ) VALUES
+        ('00000000-0000-4000-8000-000000000201','tg',
+         '00000000-0000-4000-8000-000000000101','google','google-1','Google'),
+        ('00000000-0000-4000-8000-000000000202','tg',
+         '00000000-0000-4000-8000-000000000101','github','github-1','GitHub');
+      INSERT INTO provider_operations(
+        id,tenant_id,workspace_id,provider_account_id,operation_key,risk_class,revision
+      ) VALUES
+        ('00000000-0000-4000-8000-000000000301','tg',
+         '00000000-0000-4000-8000-000000000101',
+         '00000000-0000-4000-8000-000000000201','google.gmail.messages.send','write',7),
+        ('00000000-0000-4000-8000-000000000302','tg',
+         '00000000-0000-4000-8000-000000000101',
+         '00000000-0000-4000-8000-000000000201','google.calendar.events.insert','read',9),
+        ('00000000-0000-4000-8000-000000000303','tg',
+         '00000000-0000-4000-8000-000000000101',
+         '00000000-0000-4000-8000-000000000201','google.calendar.events.list','read',11),
+        ('00000000-0000-4000-8000-000000000304','tg',
+         '00000000-0000-4000-8000-000000000101',
+         '00000000-0000-4000-8000-000000000202','github.pr.comment.create','write',13);
+    `);
+
+    await applyFile(client, migrationUnderTest);
+    const first = await client.query<{
+      operation_key: string;
+      risk_class: string;
+      revision: number;
+    }>(`
+      SELECT operation_key,risk_class,revision
+      FROM provider_operations ORDER BY operation_key
+    `);
+    expect(first.rows).toEqual([
+      { operation_key: "github.pr.comment.create", risk_class: "write", revision: 13 },
+      { operation_key: "google.calendar.events.insert", risk_class: "consequential", revision: 10 },
+      { operation_key: "google.calendar.events.list", risk_class: "read", revision: 11 },
+      { operation_key: "google.gmail.messages.send", risk_class: "consequential", revision: 8 },
+    ]);
+
+    await applyFile(client, migrationUnderTest);
+    const second = await client.query<{ revision: number }>(`
+      SELECT revision FROM provider_operations
+      WHERE operation_key='google.gmail.messages.send'
+    `);
+    expect(second.rows[0]?.revision).toBe(8);
+    await client.close();
+  });
+});

--- a/packages/provider-google/src/__tests__/operations.test.ts
+++ b/packages/provider-google/src/__tests__/operations.test.ts
@@ -8,6 +8,7 @@ describe("Google governed operations", () => {
       subject: "Board",
       body: "canary-secret-body",
     });
+    expect(b.risk).toBe("consequential");
     expect(b.policyArgs).toEqual({
       toDomainSet: ["example.com", "other.test"],
       hasAttachment: false,
@@ -89,6 +90,7 @@ describe("Google governed operations", () => {
       end: "2026-01-01T01:00:00Z",
       attendees: ["B@Other.test", "a@example.com", "a@example.com"],
     });
+    expect(first.risk).toBe("consequential");
     const reordered = buildGoogleAction("google.calendar.events.insert", {
       summary: "review",
       start: "2026-01-01T00:00:00Z",

--- a/packages/provider-google/src/operations.ts
+++ b/packages/provider-google/src/operations.ts
@@ -17,7 +17,7 @@ export const isGoogleOperationKey = (v: unknown): v is GoogleOperationKey =>
 export interface GoogleActionBuild {
   operationKey: GoogleOperationKey;
   method: "GET" | "POST";
-  risk: "read" | "write";
+  risk: "read" | "consequential";
   action: GoogleCanonicalActionV1;
   safeSummary: Record<string, unknown>;
   policyArgs: Record<string, unknown>;
@@ -130,7 +130,7 @@ function gmail(raw: unknown): GoogleActionBuild {
   return {
     operationKey: "google.gmail.messages.send",
     method: "POST",
-    risk: "write",
+    risk: "consequential",
     action,
     safeSummary: {
       operation: "google.gmail.messages.send",
@@ -212,7 +212,7 @@ function insert(raw: unknown): GoogleActionBuild {
   return {
     operationKey: "google.calendar.events.insert",
     method: "POST",
-    risk: "write",
+    risk: "consequential",
     action,
     safeSummary: {
       operation: "google.calendar.events.insert",

--- a/packages/proxy/src/__tests__/google-execution-refresh.test.ts
+++ b/packages/proxy/src/__tests__/google-execution-refresh.test.ts
@@ -231,16 +231,19 @@ describe("Google execution-time token mint", () => {
       .set({ status: "active", revision: 6 })
       .where(eq(providerAccounts.id, accountId))
       .returning();
-    __setGoogleExecutionTokenForwarderForTests(async () =>
-      Response.json({
+    let refreshCalls = 0;
+    __setGoogleExecutionTokenForwarderForTests(async () => {
+      refreshCalls += 1;
+      return Response.json({
         access_token: "ephemeral-widened",
+        refresh_token: "rotated-widened-refresh",
         token_type: "Bearer",
         scope:
           "openid email https://www.googleapis.com/auth/gmail.send https://www.googleapis.com/auth/calendar.events",
         expires_in: 3600,
-      }),
-    );
-    await expect(
+      });
+    });
+    const mint = () =>
       mintGoogleExecutionAccessToken({
         tenantId: TENANT,
         workspaceId: WORKSPACE,
@@ -250,8 +253,10 @@ describe("Google execution-time token mint", () => {
         vault,
         clientId: "provider-client",
         clientSecret: "provider-secret",
-      }),
-    ).rejects.toThrow("Google refresh widened OAuth scope");
+      });
+    await expect(mint()).rejects.toThrow("Google refresh widened OAuth scope");
+    await expect(mint()).rejects.toThrow("Google provider account changed before token mint");
+    expect(refreshCalls).toBe(1);
     const [disabled] = await getDb()
       .select()
       .from(providerAccounts)
@@ -261,7 +266,9 @@ describe("Google execution-time token mint", () => {
       .select()
       .from(providerGoogleCredentialLifecycles)
       .where(eq(providerGoogleCredentialLifecycles.providerAccountId, accountId));
-    expect(rows.some((row) => row.state === "revocation_pending")).toBeTrue();
+    const pending = rows.find((row) => row.state === "revocation_pending");
+    expect(pending?.lastErrorCode).toBe("INVALID_REFRESH_RESPONSE");
+    expect(pending?.credentialSecretId).toBeTruthy();
   });
 
   test("never dispatches a token minted from a stale account revision", async () => {

--- a/packages/proxy/src/__tests__/google-execution-refresh.test.ts
+++ b/packages/proxy/src/__tests__/google-execution-refresh.test.ts
@@ -311,4 +311,61 @@ describe("Google execution-time token mint", () => {
       .where(eq(providerGoogleCredentialLifecycles.providerAccountId, accountId));
     expect(rows.some((row) => row.lastErrorCode === "ACCOUNT_REVISION_CHANGED")).toBeTrue();
   });
+
+  test("blocks replay when a concurrent revision bump leaves the lifecycle unresolved", async () => {
+    await getDb()
+      .update(providerGoogleCredentialLifecycles)
+      .set({ state: "adopted", credentialSecretId: null })
+      .where(eq(providerGoogleCredentialLifecycles.providerAccountId, accountId));
+    const [account] = await getDb()
+      .update(providerAccounts)
+      .set({ status: "active", revision: 10 })
+      .where(eq(providerAccounts.id, accountId))
+      .returning();
+    let tokenRequests = 0;
+    __setGoogleExecutionTokenForwarderForTests(async () => {
+      tokenRequests += 1;
+      await getDb()
+        .update(providerAccounts)
+        .set({ revision: account.revision + 1, updatedAt: new Date() })
+        .where(eq(providerAccounts.id, accountId));
+      throw new Error("refresh-replay-canary");
+    });
+    await expect(
+      mintGoogleExecutionAccessToken({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        accountId,
+        accountRevision: account.revision,
+        credential,
+        vault,
+        clientId: "provider-client",
+        clientSecret: "provider-secret",
+      }),
+    ).rejects.toThrow("refresh-replay-canary");
+    const [afterBump] = await getDb()
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, accountId));
+    expect(afterBump.status).toBe("active");
+    expect(afterBump.revision).toBe(account.revision + 1);
+    const rows = await getDb()
+      .select()
+      .from(providerGoogleCredentialLifecycles)
+      .where(eq(providerGoogleCredentialLifecycles.providerAccountId, accountId));
+    expect(rows.some((row) => row.state === "needs_attention")).toBeTrue();
+    await expect(
+      mintGoogleExecutionAccessToken({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        accountId,
+        accountRevision: afterBump.revision,
+        credential,
+        vault,
+        clientId: "provider-client",
+        clientSecret: "provider-secret",
+      }),
+    ).rejects.toThrow("Google credential refresh lifecycle must be reconciled before token mint");
+    expect(tokenRequests).toBe(1);
+  });
 });

--- a/packages/proxy/src/handlers/google-execution-credential.ts
+++ b/packages/proxy/src/handlers/google-execution-credential.ts
@@ -228,18 +228,32 @@ export async function mintGoogleExecutionAccessToken(
       .for("update");
     if (!account) throw new Error("Google provider account changed before token mint");
     const [active] = await tx
-      .select({ id: providerGoogleCredentialLifecycles.id })
+      .select({
+        id: providerGoogleCredentialLifecycles.id,
+        state: providerGoogleCredentialLifecycles.state,
+      })
       .from(providerGoogleCredentialLifecycles)
       .where(
         and(
           eq(providerGoogleCredentialLifecycles.tenantId, input.tenantId),
           eq(providerGoogleCredentialLifecycles.providerAccountId, input.accountId),
           eq(providerGoogleCredentialLifecycles.kind, "refresh_rotation"),
-          inArray(providerGoogleCredentialLifecycles.state, ["inflight", "credential_staged"]),
+          inArray(providerGoogleCredentialLifecycles.state, [
+            "inflight",
+            "credential_staged",
+            "needs_attention",
+            "revocation_pending",
+          ]),
         ),
       )
       .limit(1);
-    if (active) throw new Error("Google credential refresh is already in progress");
+    if (active) {
+      throw new Error(
+        active.state === "needs_attention" || active.state === "revocation_pending"
+          ? "Google credential refresh lifecycle must be reconciled before token mint"
+          : "Google credential refresh is already in progress",
+      );
+    }
     await tx.insert(providerGoogleCredentialLifecycles).values({
       id: lifecycleId,
       tenantId: input.tenantId,

--- a/packages/proxy/src/handlers/proxy.ts
+++ b/packages/proxy/src/handlers/proxy.ts
@@ -1896,7 +1896,17 @@ export async function handleProxy(c: Context): Promise<Response> {
       credential = extractProviderCredentialForHost(target.host, credential);
     }
   } catch (err) {
-    console.error(`[proxy] Failed to decrypt secret ${route.secretId}:`, err);
+    const errorCode =
+      typeof err === "object" &&
+      err !== null &&
+      "code" in err &&
+      typeof (err as { code?: unknown }).code === "string"
+        ? ((err as { code: string }).code ?? null)
+        : null;
+    console.error("[proxy] Failed to resolve provider credential", {
+      errorClass: err instanceof Error ? err.name : typeof err,
+      errorCode,
+    });
     await recordAudit({
       agentId,
       tenantId,

--- a/packages/proxy/src/handlers/proxy.ts
+++ b/packages/proxy/src/handlers/proxy.ts
@@ -31,7 +31,11 @@ import {
   workspaces,
 } from "@stwd/db";
 import { getRedis, type SpendReservation, settleReservedSpend } from "@stwd/redis";
-import { isValidOAuthBearerToken, strictParseJson } from "@stwd/shared";
+import {
+  isValidOAuthBearerToken,
+  redactedThrownDiagnostics,
+  strictParseJson,
+} from "@stwd/shared";
 import { SecretVault } from "@stwd/vault";
 import type { Context } from "hono";
 import { boundedPositiveIntegerEnv, isProxyDevMode } from "../config";
@@ -61,15 +65,6 @@ export { __setGoogleExecutionTokenForwarderForTests };
 
 let _secretVault: SecretVault | null = null;
 let checkProxyRateLimitForHandler = checkProxyRateLimit;
-const SAFE_LOG_ERROR_CODES = new Set([
-  "ABORT_ERR",
-  "EAI_AGAIN",
-  "ECONNREFUSED",
-  "ECONNRESET",
-  "ENOTFOUND",
-  "ETIMEDOUT",
-  "UND_ERR_CONNECT_TIMEOUT",
-]);
 
 function getSecretVault(): SecretVault {
   if (!_secretVault) {
@@ -1905,28 +1900,10 @@ export async function handleProxy(c: Context): Promise<Response> {
       credential = extractProviderCredentialForHost(target.host, credential);
     }
   } catch (err) {
-    let errorClass: string = typeof err;
-    try {
-      if (err instanceof TypeError) errorClass = "TypeError";
-      else if (err instanceof RangeError) errorClass = "RangeError";
-      else if (err instanceof SyntaxError) errorClass = "SyntaxError";
-      else if (err instanceof Error) errorClass = "Error";
-    } catch {
-      errorClass = "unknown";
-    }
-    let errorCode: string | null = null;
-    try {
-      const rawCode =
-        typeof err === "object" && err !== null ? Reflect.get(err as object, "code") : undefined;
-      if (typeof rawCode === "string" && SAFE_LOG_ERROR_CODES.has(rawCode)) {
-        errorCode = rawCode;
-      }
-    } catch {
-      // A hostile getter/proxy must not break the fail-closed credential path.
-    }
+    const classified = redactedThrownDiagnostics(err);
     console.error("[proxy] Failed to resolve provider credential", {
-      errorClass,
-      errorCode,
+      errorClass: classified.errorClass,
+      errorCode: classified.errorCode,
     });
     await recordAudit({
       agentId,
@@ -1936,12 +1913,12 @@ export async function handleProxy(c: Context): Promise<Response> {
       method,
       statusCode: 500,
       latencyMs: Date.now() - startTime,
-      reason: "credential-decrypt-failed",
+      reason: "credential-resolution-failed",
     });
     await releaseProxySpendReservation(agentId, tenantId, target.host, spendReservation);
     await releaseUnsafeProxyRequest(replayClaim);
     proxySlot.release();
-    return c.json({ ok: false, error: "Failed to decrypt credential" }, 500);
+    return c.json({ ok: false, error: "Failed to resolve credential" }, 500);
   }
 
   if (target.host === "slack.com" && !isSlackBotTokenCredential(credential)) {

--- a/packages/proxy/src/handlers/proxy.ts
+++ b/packages/proxy/src/handlers/proxy.ts
@@ -61,6 +61,15 @@ export { __setGoogleExecutionTokenForwarderForTests };
 
 let _secretVault: SecretVault | null = null;
 let checkProxyRateLimitForHandler = checkProxyRateLimit;
+const SAFE_LOG_ERROR_CODES = new Set([
+  "ABORT_ERR",
+  "EAI_AGAIN",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "ENOTFOUND",
+  "ETIMEDOUT",
+  "UND_ERR_CONNECT_TIMEOUT",
+]);
 
 function getSecretVault(): SecretVault {
   if (!_secretVault) {
@@ -1896,15 +1905,27 @@ export async function handleProxy(c: Context): Promise<Response> {
       credential = extractProviderCredentialForHost(target.host, credential);
     }
   } catch (err) {
-    const errorCode =
-      typeof err === "object" &&
-      err !== null &&
-      "code" in err &&
-      typeof (err as { code?: unknown }).code === "string"
-        ? ((err as { code: string }).code ?? null)
-        : null;
+    let errorClass: string = typeof err;
+    try {
+      if (err instanceof TypeError) errorClass = "TypeError";
+      else if (err instanceof RangeError) errorClass = "RangeError";
+      else if (err instanceof SyntaxError) errorClass = "SyntaxError";
+      else if (err instanceof Error) errorClass = "Error";
+    } catch {
+      errorClass = "unknown";
+    }
+    let errorCode: string | null = null;
+    try {
+      const rawCode =
+        typeof err === "object" && err !== null ? Reflect.get(err as object, "code") : undefined;
+      if (typeof rawCode === "string" && SAFE_LOG_ERROR_CODES.has(rawCode)) {
+        errorCode = rawCode;
+      }
+    } catch {
+      // A hostile getter/proxy must not break the fail-closed credential path.
+    }
     console.error("[proxy] Failed to resolve provider credential", {
-      errorClass: err instanceof Error ? err.name : typeof err,
+      errorClass,
       errorCode,
     });
     await recordAudit({

--- a/packages/proxy/src/handlers/proxy.ts
+++ b/packages/proxy/src/handlers/proxy.ts
@@ -31,11 +31,7 @@ import {
   workspaces,
 } from "@stwd/db";
 import { getRedis, type SpendReservation, settleReservedSpend } from "@stwd/redis";
-import {
-  isValidOAuthBearerToken,
-  redactedThrownDiagnostics,
-  strictParseJson,
-} from "@stwd/shared";
+import { isValidOAuthBearerToken, redactedThrownDiagnostics, strictParseJson } from "@stwd/shared";
 import { SecretVault } from "@stwd/vault";
 import type { Context } from "hono";
 import { boundedPositiveIntegerEnv, isProxyDevMode } from "../config";

--- a/packages/shared/src/__tests__/safe-error.test.ts
+++ b/packages/shared/src/__tests__/safe-error.test.ts
@@ -6,7 +6,11 @@
  */
 
 import { describe, expect, it } from "bun:test";
-import { describeThrown, UNPRINTABLE_THROWN_VALUE } from "../safe-error.js";
+import {
+  describeThrown,
+  redactedThrownDiagnostics,
+  UNPRINTABLE_THROWN_VALUE,
+} from "../safe-error.js";
 
 describe("describeThrown — well-behaved values (message preserved)", () => {
   it("returns the message of a normal Error", () => {
@@ -119,5 +123,43 @@ describe("describeThrown — HOSTILE values (NEVER throws, static fallback)", ()
     }).not.toThrow();
     expect(typeof out).toBe("string");
     expect((out as string).length).toBeGreaterThan(0);
+  });
+});
+
+describe("redactedThrownDiagnostics", () => {
+  it("retains only fixed classes and bounded machine codes", () => {
+    const error = Object.assign(new Error("refresh-token-canary"), { code: "ECONNRESET" });
+    error.name = "secret-name-canary";
+    expect(redactedThrownDiagnostics(error)).toEqual({
+      errorClass: "Error",
+      errorCode: "ECONNRESET",
+    });
+    expect(
+      redactedThrownDiagnostics(
+        Object.assign(new Error("message-canary"), { code: "SECRET code canary" }),
+      ),
+    ).toEqual({ errorClass: "Error", errorCode: null });
+  });
+
+  it("never throws when instanceof or code access is hostile", () => {
+    const hostile = new Proxy(
+      {},
+      {
+        getPrototypeOf() {
+          throw new Error("prototype-canary");
+        },
+        has() {
+          throw new Error("has-canary");
+        },
+        get() {
+          throw new Error("get-canary");
+        },
+      },
+    );
+    expect(() => redactedThrownDiagnostics(hostile)).not.toThrow();
+    expect(redactedThrownDiagnostics(hostile)).toEqual({
+      errorClass: "object",
+      errorCode: null,
+    });
   });
 });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -22,7 +22,11 @@ export * from "./provider-execution-auth.js";
 export * from "./provider-profile-conformance.js";
 export * from "./provider-profile-registry.js";
 // ─── Non-throwing description of an arbitrary thrown value (fail-closed catches) ───
-export { describeThrown, UNPRINTABLE_THROWN_VALUE } from "./safe-error.js";
+export {
+  describeThrown,
+  redactedThrownDiagnostics,
+  UNPRINTABLE_THROWN_VALUE,
+} from "./safe-error.js";
 export * from "./secret-route-matching.js";
 export * from "./security-surface.js";
 export * from "./sensitive-keys.js";

--- a/packages/shared/src/safe-error.ts
+++ b/packages/shared/src/safe-error.ts
@@ -33,6 +33,47 @@
 /** Last-resort description when every coercion of the thrown value misbehaves. */
 export const UNPRINTABLE_THROWN_VALUE = "policy evaluator threw an unprintable value";
 
+export interface RedactedThrownDiagnostics {
+  errorClass: string;
+  errorCode: string | null;
+}
+
+const SAFE_ERROR_CODE = /^[A-Z][A-Z0-9_]{0,63}$/;
+
+/**
+ * Return bounded, non-secret diagnostics for logs at credential boundaries.
+ * Both `instanceof` and property access are guarded because hostile proxies can
+ * throw from either operation. Arbitrary error names and codes are never
+ * returned: names can contain secrets, while codes are limited to the usual
+ * uppercase machine-code grammar.
+ */
+export function redactedThrownDiagnostics(value: unknown): RedactedThrownDiagnostics {
+  let errorClass: string = typeof value;
+  try {
+    if (value instanceof Error) errorClass = "Error";
+  } catch {
+    errorClass = "object";
+  }
+
+  let errorCode: string | null = null;
+  try {
+    if (
+      value !== null &&
+      (typeof value === "object" || typeof value === "function") &&
+      "code" in value
+    ) {
+      const candidate = (value as { code?: unknown }).code;
+      if (typeof candidate === "string" && SAFE_ERROR_CODE.test(candidate)) {
+        errorCode = candidate;
+      }
+    }
+  } catch {
+    // A hostile proxy/getter is intentionally reduced to the fixed fallback.
+  }
+
+  return { errorClass, errorCode };
+}
+
 /**
  * Try to read a hostile-safe `.message` off a value that claims to be an Error.
  * The property access itself can throw (Proxy get-trap / throwing getter), so it


### PR DESCRIPTION
Post-merge corrective for the Google governed-credential lifecycle.

Security changes:
- classify Gmail send and Calendar insert as consequential at both canonical-action and authority-registration boundaries, preventing risk downgrade
- block every unresolved refresh lifecycle state before another execution-time mint, including needs_attention and revocation_pending after revision races
- retain encrypted staged recovery material when a successful refresh is invalid or scope-widened, disable the exact account revision, and prevent a second provider refresh
- redact scheduler and proxy failures to fixed error class/allowlisted code fields; provider-controlled message/name/code values are never reflected
- preserve the full authenticated production profile boundary, including the current AWS SigV4 fixture, and assert Google canaries do not reach logs, responses, or audit rows

Exact head: 0f5bbd4835cb0dd943d6117733c889c89e6ced69
Exact base: 63285ab08028af2a5c78d0a33d72052ed153a4bb

Local exact-head evidence:
- focused Google execution/lifecycle/authority/operation/production-boundary suites: 25 tests, 0 failures, 163 assertions
- dependency-aware API/proxy/provider build graph: 24/24 packages
- Biome on all 10 changed files: clean
- git diff --check: clean

Keep draft until the newly triggered exact-head hosted checks are green.

Closes #203