### PR TITLE
fix(provider-google): close governed write and refresh replay gaps

### DIFF
--- a/packages/api/src/__tests__/provider-google-authority-registration.test.ts
+++ b/packages/api/src/__tests__/provider-google-authority-registration.test.ts
@@ -141,13 +141,20 @@ describe("Google provider authority registration", () => {
       store.registerOperation(context(1), account.id, {
         operationKey: "google.gmail.messages.send",
         riskClass: "write",
+        secretRouteId: gmailRouteId,
+      }),
+    ).rejects.toMatchObject({ code: "bad_request", status: 400 });
+    await expect(
+      store.registerOperation(context(1), account.id, {
+        operationKey: "google.gmail.messages.send",
+        riskClass: "consequential",
         secretRouteId: wrongRouteId,
       }),
     ).rejects.toMatchObject({ code: "forbidden", status: 403 });
     await expect(
       store.registerOperation(context(1), account.id, {
         operationKey: "google.gmail.messages.send",
-        riskClass: "write",
+        riskClass: "consequential",
         secretRouteId: wrongInjectionRouteId,
       }),
     ).rejects.toMatchObject({ code: "forbidden", status: 403 });
@@ -167,7 +174,7 @@ describe("Google provider authority registration", () => {
 
     const gmail = await store.registerOperation(context(1), account.id, {
       operationKey: "google.gmail.messages.send",
-      riskClass: "write",
+      riskClass: "consequential",
       secretRouteId: gmailRouteId,
     });
     const list = await store.registerOperation(context(2), account.id, {
@@ -177,7 +184,7 @@ describe("Google provider authority registration", () => {
     });
     const insert = await store.registerOperation(context(3), account.id, {
       operationKey: "google.calendar.events.insert",
-      riskClass: "write",
+      riskClass: "consequential",
       secretRouteId: calendarInsertRouteId,
     });
     expect([gmail.operationKey, list.operationKey, insert.operationKey]).toEqual([

--- a/packages/api/src/services/provider-authority-store.ts
+++ b/packages/api/src/services/provider-authority-store.ts
@@ -60,9 +60,9 @@ const GOOGLE_OPERATION_METHOD = {
   "google.calendar.events.insert": "POST",
 } as const satisfies Readonly<Record<GoogleOperationKey, "GET" | "POST" | "DELETE">>;
 const GOOGLE_OPERATION_MINIMUM_RISK = {
-  "google.gmail.messages.send": "write",
+  "google.gmail.messages.send": "consequential",
   "google.calendar.events.list": "read",
-  "google.calendar.events.insert": "write",
+  "google.calendar.events.insert": "consequential",
 } as const satisfies Readonly<Record<GoogleOperationKey, ProviderRiskClass>>;
 const GOOGLE_OPERATION_EXACT_PATH = {
   "google.gmail.messages.send": "/gmail/v1/users/me/messages/send",

--- a/packages/provider-google/src/__tests__/operations.test.ts
+++ b/packages/provider-google/src/__tests__/operations.test.ts
@@ -8,6 +8,7 @@ describe("Google governed operations", () => {
       subject: "Board",
       body: "canary-secret-body",
     });
+    expect(b.risk).toBe("consequential");
     expect(b.policyArgs).toEqual({
       toDomainSet: ["example.com", "other.test"],
       hasAttachment: false,
@@ -89,6 +90,7 @@ describe("Google governed operations", () => {
       end: "2026-01-01T01:00:00Z",
       attendees: ["B@Other.test", "a@example.com", "a@example.com"],
     });
+    expect(first.risk).toBe("consequential");
     const reordered = buildGoogleAction("google.calendar.events.insert", {
       summary: "review",
       start: "2026-01-01T00:00:00Z",

--- a/packages/provider-google/src/operations.ts
+++ b/packages/provider-google/src/operations.ts
@@ -17,7 +17,7 @@ export const isGoogleOperationKey = (v: unknown): v is GoogleOperationKey =>
 export interface GoogleActionBuild {
   operationKey: GoogleOperationKey;
   method: "GET" | "POST";
-  risk: "read" | "write";
+  risk: "read" | "consequential";
   action: GoogleCanonicalActionV1;
   safeSummary: Record<string, unknown>;
   policyArgs: Record<string, unknown>;
@@ -130,7 +130,7 @@ function gmail(raw: unknown): GoogleActionBuild {
   return {
     operationKey: "google.gmail.messages.send",
     method: "POST",
-    risk: "write",
+    risk: "consequential",
     action,
     safeSummary: {
       operation: "google.gmail.messages.send",
@@ -212,7 +212,7 @@ function insert(raw: unknown): GoogleActionBuild {
   return {
     operationKey: "google.calendar.events.insert",
     method: "POST",
-    risk: "write",
+    risk: "consequential",
     action,
     safeSummary: {
       operation: "google.calendar.events.insert",

--- a/packages/proxy/src/__tests__/google-execution-refresh.test.ts
+++ b/packages/proxy/src/__tests__/google-execution-refresh.test.ts
@@ -231,16 +231,19 @@ describe("Google execution-time token mint", () => {
       .set({ status: "active", revision: 6 })
       .where(eq(providerAccounts.id, accountId))
       .returning();
-    __setGoogleExecutionTokenForwarderForTests(async () =>
-      Response.json({
+    let refreshCalls = 0;
+    __setGoogleExecutionTokenForwarderForTests(async () => {
+      refreshCalls += 1;
+      return Response.json({
         access_token: "ephemeral-widened",
+        refresh_token: "rotated-widened-refresh",
         token_type: "Bearer",
         scope:
           "openid email https://www.googleapis.com/auth/gmail.send https://www.googleapis.com/auth/calendar.events",
         expires_in: 3600,
-      }),
-    );
-    await expect(
+      });
+    });
+    const mint = () =>
       mintGoogleExecutionAccessToken({
         tenantId: TENANT,
         workspaceId: WORKSPACE,
@@ -250,8 +253,10 @@ describe("Google execution-time token mint", () => {
         vault,
         clientId: "provider-client",
         clientSecret: "provider-secret",
-      }),
-    ).rejects.toThrow("Google refresh widened OAuth scope");
+      });
+    await expect(mint()).rejects.toThrow("Google refresh widened OAuth scope");
+    await expect(mint()).rejects.toThrow("Google provider account changed before token mint");
+    expect(refreshCalls).toBe(1);
     const [disabled] = await getDb()
       .select()
       .from(providerAccounts)
@@ -261,7 +266,9 @@ describe("Google execution-time token mint", () => {
       .select()
       .from(providerGoogleCredentialLifecycles)
       .where(eq(providerGoogleCredentialLifecycles.providerAccountId, accountId));
-    expect(rows.some((row) => row.state === "revocation_pending")).toBeTrue();
+    const pending = rows.find((row) => row.state === "revocation_pending");
+    expect(pending?.lastErrorCode).toBe("INVALID_REFRESH_RESPONSE");
+    expect(pending?.credentialSecretId).toBeTruthy();
   });
 
   test("never dispatches a token minted from a stale account revision", async () => {


### PR DESCRIPTION
Closes #203

Follow-up to the merged Google execution/lifecycle stack.

## Security corrections
- classifies Gmail send and Calendar insert as `consequential` at both canonical action construction and authority registration, preventing risk downgrade
- proves an invalid or scope-widened successful refresh response disables the exact account revision, retains encrypted staged revocation material, and cannot trigger a second provider refresh
- preserves the merged execution-time final account-revision check and the existing durable lifecycle/scheduler recovery paths

## Exact-head evidence
- Google lifecycle, execution, authority, conformance, and authenticated boundary suites: 105 passed, 0 failed, 653 assertions
- focused post-rebase regression: 13 passed, 0 failed, 51 assertions
- `@stwd/provider-google`, `@stwd/proxy`, and `@stwd/api` TypeScript builds: green
- Biome changed surfaces and `git diff --check`: green

Exact head: `954861f6bae7edd3289d144f8fbbd5ee5f475544`
Exact base: `c40b5bff105e69e963adc736ce626dd7bd388bfc`