### PR TITLE
fix(security): bind operator reservation integrity

### DIFF
--- a/packages/api/src/__tests__/operator-transfer-postgres-concurrency.integration.test.ts
+++ b/packages/api/src/__tests__/operator-transfer-postgres-concurrency.integration.test.ts
@@ -138,3 +138,58 @@ realPostgresIt(
     }
   },
 );
+
+realPostgresIt(
+  "preserves ambiguous cross-rail counters and releases only reconciled failures",
+  async () => {
+    const suffix = crypto.randomUUID().replaceAll("-", "");
+    const tenantId = `operator-stats-tenant-${suffix}`;
+    const agentId = `operator-stats-agent-${suffix}`;
+    const otherAgentId = `operator-stats-other-${suffix}`;
+    const admin = postgres(databaseUrl!, { max: 1 });
+    try {
+      await admin`insert into tenants (id, name, api_key_hash) values (${tenantId}, ${tenantId}, ${`hash-${tenantId}`})`;
+      await admin`
+        insert into agents (id, tenant_id, name, wallet_address) values
+          (${agentId}, ${tenantId}, ${agentId}, '0x1234567890123456789012345678901234567890'),
+          (${otherAgentId}, ${tenantId}, ${otherAgentId}, '0x2234567890123456789012345678901234567890')
+      `;
+      await admin`
+        insert into transactions (id, agent_id, status, to_address, value, chain_id, policy_results) values
+          (${`unknown-${suffix}`}, ${agentId}, 'outcome_unknown', '0x3234567890123456789012345678901234567890', '95', 42161, '[]'::jsonb),
+          (${`failed-${suffix}`}, ${agentId}, 'failed', '0x3234567890123456789012345678901234567890', '999', 42161, '[]'::jsonb),
+          (${`other-${suffix}`}, ${otherAgentId}, 'confirmed', '0x3234567890123456789012345678901234567890', '777', 42161, '[]'::jsonb)
+      `;
+      await admin`
+        insert into operator_transfer_reservations
+          (tenant_id, agent_id, rail, idempotency_key, destination, amount_base_units, status, finalized_at)
+        values
+          (${tenantId}, ${agentId}, 'withdraw', ${`pending-${suffix}`}, '0x4234567890123456789012345678901234567890', '60000000', 'pending', null),
+          (${tenantId}, ${agentId}, 'usd-send', ${`final-${suffix}`}, '0x4234567890123456789012345678901234567890', '10000000', 'final', now()),
+          (${tenantId}, ${agentId}, 'withdraw', ${`released-${suffix}`}, '0x4234567890123456789012345678901234567890', '999000000', 'released', now()),
+          (${tenantId}, ${otherAgentId}, 'withdraw', ${`other-${suffix}`}, '0x4234567890123456789012345678901234567890', '888000000', 'final', now())
+      `;
+
+      const { getTransactionStats } = await import("../services/context");
+      const ambiguous = await getTransactionStats(agentId, 42161);
+      expect(ambiguous.recentTxCount1h).toBe(3);
+      expect(ambiguous.recentTxCount24h).toBe(3);
+      expect(ambiguous.spentToday).toBe(95n);
+      expect(ambiguous.additionalUsdSpentTodayMicros).toBe(70_000_000n);
+
+      await admin`update transactions set status = 'failed' where id = ${`unknown-${suffix}`}`;
+      await admin`
+        update operator_transfer_reservations set status = 'released', finalized_at = now()
+        where tenant_id = ${tenantId} and agent_id = ${agentId} and idempotency_key = ${`pending-${suffix}`}
+      `;
+      const reconciled = await getTransactionStats(agentId, 42161);
+      expect(reconciled.recentTxCount1h).toBe(1);
+      expect(reconciled.recentTxCount24h).toBe(1);
+      expect(reconciled.spentToday).toBe(0n);
+      expect(reconciled.additionalUsdSpentTodayMicros).toBe(10_000_000n);
+    } finally {
+      await admin`delete from tenants where id = ${tenantId}`;
+      await admin.end();
+    }
+  },
+);

--- a/packages/api/src/__tests__/transaction-stats-chain-scope.test.ts
+++ b/packages/api/src/__tests__/transaction-stats-chain-scope.test.ts
@@ -108,6 +108,7 @@ describe("getTransactionStats chain scoping (issue #110)", () => {
           destination: RECIPIENT,
           amountBaseUnits: "35000000",
           status: "final",
+          finalizedAt: new Date(),
         },
         {
           tenantId: TENANT_ID,
@@ -117,6 +118,7 @@ describe("getTransactionStats chain scoping (issue #110)", () => {
           destination: RECIPIENT,
           amountBaseUnits: "900000000",
           status: "released",
+          finalizedAt: new Date(),
         },
       ]);
   });

--- a/packages/db/drizzle/0101_operator_transfer_integrity.sql
+++ b/packages/db/drizzle/0101_operator_transfer_integrity.sql
@@ -1,0 +1,28 @@
+-- Bind every operator reservation to the tenant that owns its agent. Independent
+-- tenant_id and agent_id foreign keys do not reject a cross-tenant pair.
+ALTER TABLE "operator_transfer_reservations"
+  ADD CONSTRAINT "operator_transfer_reservations_tenant_agent_fk"
+  FOREIGN KEY ("tenant_id", "agent_id")
+  REFERENCES "agents" ("tenant_id", "id")
+  ON DELETE CASCADE;
+--> statement-breakpoint
+ALTER TABLE "operator_transfer_reservations"
+  ADD CONSTRAINT "operator_transfer_reservation_rail_chk"
+  CHECK ("rail" in ('withdraw', 'usd-send'));
+--> statement-breakpoint
+-- Application writes already pair terminal states with finalized_at. Normalize
+-- legacy rows before making that lifecycle shape database-enforced.
+UPDATE "operator_transfer_reservations"
+SET "finalized_at" = COALESCE("finalized_at", "created_at")
+WHERE "status" in ('final', 'released');
+--> statement-breakpoint
+UPDATE "operator_transfer_reservations"
+SET "finalized_at" = NULL
+WHERE "status" = 'pending';
+--> statement-breakpoint
+ALTER TABLE "operator_transfer_reservations"
+  ADD CONSTRAINT "operator_transfer_reservation_status_finalized_chk"
+  CHECK (
+    ("status" = 'pending' AND "finalized_at" IS NULL)
+    OR ("status" in ('final', 'released') AND "finalized_at" IS NOT NULL)
+  );

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -568,6 +568,13 @@
       "when": 1787031495000,
       "tag": "0100_sigv4_injection",
       "breakpoints": true
+    },
+    {
+      "idx": 101,
+      "version": "7",
+      "when": 1787106472000,
+      "tag": "0101_operator_transfer_integrity",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/__tests__/operator-transfer-integrity-migration.test.ts
+++ b/packages/db/src/__tests__/operator-transfer-integrity-migration.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, setDefaultTimeout, test } from "bun:test";
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { PGlite } from "@electric-sql/pglite";
+
+setDefaultTimeout(120_000);
+const migrations = new URL("../../drizzle", import.meta.url).pathname;
+
+async function applyAll(client: PGlite) {
+  const files = (await readdir(migrations)).filter((file) => file.endsWith(".sql")).sort();
+  for (const file of files) {
+    await applyMigration(client, file);
+  }
+}
+
+async function applyMigration(client: PGlite, file: string) {
+  const migration = await readFile(join(migrations, file), "utf8");
+  for (const statement of migration.split("--> statement-breakpoint")) {
+    if (statement.trim()) await client.exec(statement);
+  }
+}
+
+async function expectRejected(client: PGlite, statement: string) {
+  await expect(client.exec(statement)).rejects.toBeDefined();
+}
+
+describe("0101 operator transfer reservation integrity", () => {
+  test("follows the SigV4 migration without reusing its journal index", async () => {
+    const journal = JSON.parse(
+      await readFile(join(migrations, "meta", "_journal.json"), "utf8"),
+    ) as { entries: Array<{ idx: number; tag: string }> };
+    expect(journal.entries.slice(-2).map(({ idx, tag }) => ({ idx, tag }))).toEqual([
+      { idx: 100, tag: "0100_sigv4_injection" },
+      { idx: 101, tag: "0101_operator_transfer_integrity" },
+    ]);
+  });
+
+  test("binds tenant/agent identity, rail, and terminal timestamp shape", async () => {
+    const client = new PGlite("memory://");
+    try {
+      await applyAll(client);
+      await client.exec(`
+        INSERT INTO tenants(id,name,api_key_hash) VALUES
+          ('operator-integrity-a','A','operator-integrity-hash-a'),
+          ('operator-integrity-b','B','operator-integrity-hash-b');
+        INSERT INTO agents(id,tenant_id,name,wallet_address) VALUES
+          ('operator-integrity-agent-a','operator-integrity-a','A','0x1111111111111111111111111111111111111111'),
+          ('operator-integrity-agent-b','operator-integrity-b','B','0x2222222222222222222222222222222222222222');
+      `);
+
+      const values = (
+        id: string,
+        tenantId: string,
+        agentId: string,
+        rail: string,
+        tail: string,
+      ) => `
+        INSERT INTO operator_transfer_reservations
+          (id,tenant_id,agent_id,rail,idempotency_key,destination,amount_base_units,status,finalized_at)
+        VALUES ('${id}','${tenantId}','${agentId}','${rail}','${id}',
+          '0x3333333333333333333333333333333333333333','1',${tail})
+      `;
+
+      await client.exec(
+        values(
+          "10000000-0000-4000-8000-000000000001",
+          "operator-integrity-a",
+          "operator-integrity-agent-a",
+          "withdraw",
+          "'pending',NULL",
+        ),
+      );
+      await client.exec(
+        values(
+          "10000000-0000-4000-8000-000000000002",
+          "operator-integrity-a",
+          "operator-integrity-agent-a",
+          "usd-send",
+          "'final',now()",
+        ),
+      );
+      await expectRejected(
+        client,
+        values(
+          "10000000-0000-4000-8000-000000000003",
+          "operator-integrity-a",
+          "operator-integrity-agent-b",
+          "withdraw",
+          "'pending',NULL",
+        ),
+      );
+      await expectRejected(
+        client,
+        values(
+          "10000000-0000-4000-8000-000000000004",
+          "operator-integrity-a",
+          "operator-integrity-agent-a",
+          "withdraw ",
+          "'pending',NULL",
+        ),
+      );
+      await expectRejected(
+        client,
+        values(
+          "10000000-0000-4000-8000-000000000005",
+          "operator-integrity-a",
+          "operator-integrity-agent-a",
+          "withdraw",
+          "'final',NULL",
+        ),
+      );
+      await expectRejected(
+        client,
+        values(
+          "10000000-0000-4000-8000-000000000006",
+          "operator-integrity-a",
+          "operator-integrity-agent-a",
+          "withdraw",
+          "'pending',now()",
+        ),
+      );
+      await expectRejected(
+        client,
+        `UPDATE operator_transfer_reservations
+         SET status = 'final'
+         WHERE id = '10000000-0000-4000-8000-000000000001'`,
+      );
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("normalizes legacy lifecycle timestamps before enforcing the shape", async () => {
+    const client = new PGlite("memory://");
+    try {
+      const files = (await readdir(migrations)).filter((file) => file.endsWith(".sql")).sort();
+      for (const file of files) {
+        if (file === "0101_operator_transfer_integrity.sql") break;
+        await applyMigration(client, file);
+      }
+      await client.exec(`
+        INSERT INTO tenants(id,name,api_key_hash)
+        VALUES ('operator-normalize','Normalize','operator-normalize-hash');
+        INSERT INTO agents(id,tenant_id,name,wallet_address)
+        VALUES ('operator-normalize-agent','operator-normalize','Agent',
+          '0x4444444444444444444444444444444444444444');
+        INSERT INTO operator_transfer_reservations
+          (id,tenant_id,agent_id,rail,idempotency_key,destination,amount_base_units,status,finalized_at)
+        VALUES
+          ('10000000-0000-4000-8000-000000000010','operator-normalize',
+           'operator-normalize-agent','withdraw','legacy-final',
+           '0x5555555555555555555555555555555555555555','1','final',NULL),
+          ('10000000-0000-4000-8000-000000000011','operator-normalize',
+           'operator-normalize-agent','usd-send','legacy-pending',
+           '0x5555555555555555555555555555555555555555','1','pending',now());
+      `);
+
+      await applyMigration(client, "0101_operator_transfer_integrity.sql");
+      const rows = await client.query<{ id: string; finalized: boolean }>(`
+        SELECT id, finalized_at IS NOT NULL AS finalized
+        FROM operator_transfer_reservations
+        WHERE tenant_id = 'operator-normalize'
+        ORDER BY id
+      `);
+      expect(rows.rows).toEqual([
+        { id: "10000000-0000-4000-8000-000000000010", finalized: true },
+        { id: "10000000-0000-4000-8000-000000000011", finalized: false },
+      ]);
+    } finally {
+      await client.close();
+    }
+  });
+});

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -985,6 +985,15 @@ export const operatorTransferReservations = pgTable(
       table.agentId,
       table.createdAt,
     ),
+    tenantAgentFk: foreignKey({
+      columns: [table.tenantId, table.agentId],
+      foreignColumns: [agents.tenantId, agents.id],
+      name: "operator_transfer_reservations_tenant_agent_fk",
+    }).onDelete("cascade"),
+    railValid: check(
+      "operator_transfer_reservation_rail_chk",
+      sql`${table.rail} in ('withdraw', 'usd-send')`,
+    ),
     amountIsUsdc: check(
       "operator_transfer_reservation_amount_base_units_chk",
       sql`${table.amountBaseUnits} ~ '^[0-9]+$'`,
@@ -992,6 +1001,11 @@ export const operatorTransferReservations = pgTable(
     statusValid: check(
       "operator_transfer_reservation_status_chk",
       sql`${table.status} in ('pending', 'final', 'released')`,
+    ),
+    statusFinalizedShape: check(
+      "operator_transfer_reservation_status_finalized_chk",
+      sql`(${table.status} = 'pending' and ${table.finalizedAt} is null)
+          or (${table.status} in ('final', 'released') and ${table.finalizedAt} is not null)`,
     ),
   }),
 );

--- a/packages/plugin-trading/src/__tests__/operator-recovery-policy-gates.test.ts
+++ b/packages/plugin-trading/src/__tests__/operator-recovery-policy-gates.test.ts
@@ -656,6 +656,7 @@ describe("SEC-043: operator idempotency stores ambiguous outcomes", () => {
           destination: DEST_A,
           amountBaseUnits: "1",
           status: "final",
+          finalizedAt: new Date(),
         })),
       );
     const app = await buildApp();


### PR DESCRIPTION
## Summary
- enforce same-tenant agent ownership for durable operator transfer reservations
- constrain rail values and status/finalized timestamp lifecycle at the database boundary
- place migration `0101` / journal index 101 after merged AWS SigV4 migration 0100
- add database and accounting regressions for cross-rail ambiguous outcomes, reconciliation, legacy normalization, and update-time enforcement

## Security properties
- cross-tenant tenant/agent pairs fail at the database boundary
- unknown or whitespace-malleated rails cannot split the idempotency/accounting namespace
- pending/final/released rows cannot carry contradictory finalization timestamps
- ambiguous transfers remain counted until a definite failure is reconciled
- terminal writes remain compare-and-set transitions from pending with an atomic finalization timestamp

## Exact-head validation (`054ca8a45dc7d3669f010c0cba1b29698e0600a1`)
- operator integrity migration: 3 pass / 7 assertions (full PGlite migration chain through 0101)
- transaction stats: 8 pass / 18 assertions
- operator policy gates: 18 pass / 61 assertions
- PostgreSQL concurrency file: 1 static pass / 5 assertions; 3 real-DB cases skipped locally because `DATABASE_URL` is unavailable
- `packages/db`, `packages/api`, and `packages/plugin-trading` dependency build graph: 24/24 tasks pass
- focused Biome and `git diff --check` pass