### PR TITLE
fix(security): align webhook special-use prefixes

### DIFF
--- a/packages/api/src/__tests__/webhook-url-validation.test.ts
+++ b/packages/api/src/__tests__/webhook-url-validation.test.ts
@@ -53,6 +53,20 @@ describe("webhook URL validation", () => {
     }
   });
 
+  it("rejects complete benchmarking and discard-only IPv6 prefixes", () => {
+    for (const url of [
+      "https://[2001:2::1]/hook",
+      "https://[2001:2:0:ffff:ffff:ffff:ffff:ffff]/hook",
+      "https://[100::1]/hook",
+      "https://[100::ffff:ffff:ffff:ffff]/hook",
+    ]) {
+      expect(validateWebhookUrl(url)).toBe("url host must be public");
+    }
+    // Adjacent prefixes are not accidentally widened by the exact word masks.
+    expect(validateWebhookUrl("https://[2001:2:1::1]/hook")).toBeNull();
+    expect(validateWebhookUrl("https://[100:0:0:1::1]/hook")).toBeNull();
+  });
+
   it("rejects IPv6 site-local addresses", () => {
     for (const url of ["https://[fec0::1]/hook", "https://[feff::1]/hook"]) {
       expect(validateWebhookUrl(url)).toBe("url host must be public");

--- a/packages/api/src/services/webhook-url.ts
+++ b/packages/api/src/services/webhook-url.ts
@@ -122,6 +122,10 @@ function isNonPublicIpv6(hostname: string): boolean {
   if (words && words.slice(0, 6).every((word) => word === 0) && (words[6] !== 0 || words[7] !== 0))
     return true;
   if (words?.[0] === 0x2001 && (words[1] === 0 || words[1] === 0xdb8)) return true;
+  // Keep registration-time screening aligned with the delivery dispatcher for
+  // the complete benchmarking and discard-only special-use prefixes.
+  if (words?.[0] === 0x2001 && words[1] === 0x0002 && words[2] === 0) return true;
+  if (words?.[0] === 0x0100 && words[1] === 0 && words[2] === 0 && words[3] === 0) return true;
   if (words?.[0] !== undefined && (words[0] & 0xffc0) === 0xfe80) return true;
   if (words?.[0] !== undefined && (words[0] & 0xffc0) === 0xfec0) return true;
   return (


### PR DESCRIPTION
Post-merge classifier-parity follow-up to #439.

The translated/deprecated fixes in #439 are sound, but registration-time validation still allowed two complete special-use prefixes that the delivery dispatcher rejects: RFC 5180 benchmarking `2001:2::/48` and RFC 6666 discard-only `100::/64`. This leaves a weaker registration boundary and defers deterministic rejection until delivery.

This adds the exact dispatcher word masks at registration and proves both full-prefix rejection and adjacent-prefix non-widening.

Exact head: 33fb6582cebc7eeccd463d338edcdc773ea326bb
Base: 75373749888f8af8868f1c04664cbe4fd52c642c

- webhook URL validation: 17/17, 55 assertions
- focused Biome and diff-check: green

Draft pending fresh hosted CI.