### PR TITLE
fix(ci): repair expanded workflow coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,7 @@ jobs:
           - packages/plugin-capabilities
           - packages/plugin-example
           - packages/plugin-sdk
+          - packages/provider-aws
           - packages/provider-github
           - packages/provider-google
           - packages/provider-slack

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -191,6 +191,7 @@ jobs:
           - packages/plugin-capabilities
           - packages/plugin-example
           - packages/plugin-sdk
+          - packages/provider-aws
           - packages/provider-github
           - packages/provider-google
           - packages/provider-slack

--- a/packages/proxy/src/__tests__/zz-proxy-spend-limit.test.ts
+++ b/packages/proxy/src/__tests__/zz-proxy-spend-limit.test.ts
@@ -28,6 +28,8 @@ const route = {
   injectAs: "header",
   injectKey: "x-api-key",
   injectFormat: "Bearer {value}",
+  injectionStrategy: "header",
+  injectionConfig: {},
   priority: 0,
   enabled: true,
   createdAt: new Date(),
@@ -62,6 +64,14 @@ mock.module("@stwd/db", () => {
   };
   const secrets = { id: "id" };
   const providerAccounts = { id: "id" };
+  const providerGoogleCredentialLifecycles = {
+    id: "id",
+    tenantId: "tenantId",
+    providerAccountId: "providerAccountId",
+    kind: "kind",
+    state: "state",
+    credentialSecretId: "credentialSecretId",
+  };
   const providerOperations = { id: "id" };
   const workspaces = { id: "id" };
   const policies = {
@@ -104,10 +114,14 @@ mock.module("@stwd/db", () => {
     secretRoutes,
     secrets,
     providerAccounts,
+    providerGoogleCredentialLifecycles,
     providerOperations,
     workspaces,
     policies,
     proxyAuditLog,
+    withTenantAuditedTransaction: async () => {
+      throw new Error("unexpected audited transaction in proxy spend-limit fixture");
+    },
     getDb: () => ({
       select: () => ({
         from: (table: unknown) => ({

--- a/packages/swift/Package.resolved
+++ b/packages/swift/Package.resolved
@@ -1,0 +1,23 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
+        "version" : "3.15.1"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/packages/swift/Package.swift
+++ b/packages/swift/Package.swift
@@ -11,9 +11,16 @@ let package = Package(
     products: [
         .library(name: "Steward", targets: ["Steward"]),
     ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "3.0.0"),
+    ],
     targets: [
-        .target(name: "Steward"),
+        .target(
+            name: "Steward",
+            dependencies: [
+                .product(name: "Crypto", package: "swift-crypto"),
+            ]
+        ),
         .testTarget(name: "StewardTests", dependencies: ["Steward"]),
     ]
 )
-

--- a/packages/swift/Sources/Steward/StewardClient.swift
+++ b/packages/swift/Sources/Steward/StewardClient.swift
@@ -1,4 +1,8 @@
+#if canImport(CryptoKit)
 import CryptoKit
+#else
+import Crypto
+#endif
 import Foundation
 
 public typealias StewardJSON = [String: Any]


### PR DESCRIPTION
## Summary
- make the Swift SDK compile on Linux by using Swift Crypto when CryptoKit is unavailable
- pin SwiftPM dependencies for deterministic CI resolution
- update the proxy spend-limit fixture for Google lifecycle and AWS injection imports/defaults

## Verification
- `swift test --package-path packages/swift -j 2` (6 tests pass)
- `bun test --isolate packages/proxy` (306 tests pass on the pre-rebase exact failure base)
- focused proxy suite on current develop (32 tests pass)
- `bun run lint` (1,299 files clean)
- `git diff --check origin/develop...HEAD`