### PR TITLE
fix(security): enforce public webhook address parity

### DIFF
--- a/packages/api/src/__tests__/webhook-url-validation.test.ts
+++ b/packages/api/src/__tests__/webhook-url-validation.test.ts
@@ -62,9 +62,25 @@ describe("webhook URL validation", () => {
     ]) {
       expect(validateWebhookUrl(url)).toBe("url host must be public");
     }
-    // Adjacent prefixes are not accidentally widened by the exact word masks.
-    expect(validateWebhookUrl("https://[2001:2:1::1]/hook")).toBeNull();
-    expect(validateWebhookUrl("https://[100:0:0:1::1]/hook")).toBeNull();
+    // These are outside the two narrow prefixes but are still not public:
+    // 2001:2:1:: remains in 2001::/23 and 100:0:0:1:: is outside 2000::/3.
+    expect(validateWebhookUrl("https://[2001:2:1::1]/hook")).toBe("url host must be public");
+    expect(validateWebhookUrl("https://[100:0:0:1::1]/hook")).toBe("url host must be public");
+    expect(validateWebhookUrl("https://[2001:4860:4860::8888]/hook")).toBeNull();
+  });
+
+  it("rejects the remaining special-purpose Internet address blocks", () => {
+    for (const url of [
+      "https://192.31.196.1/hook",
+      "https://192.52.193.1/hook",
+      "https://192.175.48.1/hook",
+      "https://[2001:100::1]/hook",
+      "https://[2620:4f:8000::1]/hook",
+      "https://[3fff::1]/hook",
+      "https://[4000::1]/hook",
+    ]) {
+      expect(validateWebhookUrl(url)).toBe("url host must be public");
+    }
   });
 
   it("rejects IPv6 site-local addresses", () => {

--- a/packages/api/src/services/webhook-url.ts
+++ b/packages/api/src/services/webhook-url.ts
@@ -21,7 +21,10 @@ function isNonPublicIpv4(hostname: string): boolean {
     (a === 192 && b === 168) ||
     (a === 100 && b >= 64 && b <= 127) ||
     (a === 192 && b === 0 && (octets[2] === 0 || octets[2] === 2)) ||
+    (a === 192 && b === 31 && octets[2] === 196) ||
+    (a === 192 && b === 52 && octets[2] === 193) ||
     (a === 192 && b === 88 && octets[2] === 99) ||
+    (a === 192 && b === 175 && octets[2] === 48) ||
     (a === 198 && (b === 18 || b === 19)) ||
     (a === 198 && b === 51 && octets[2] === 100) ||
     (a === 203 && b === 0 && octets[2] === 113) ||
@@ -121,13 +124,22 @@ function isNonPublicIpv6(hostname: string): boolean {
   // `[::127.0.0.1]` / `[::7f00:1]` (parity with the dispatcher screen).
   if (words && words.slice(0, 6).every((word) => word === 0) && (words[6] !== 0 || words[7] !== 0))
     return true;
-  if (words?.[0] === 0x2001 && (words[1] === 0 || words[1] === 0xdb8)) return true;
+  // Only ordinary global-unicast space is a valid literal destination. Public
+  // IPv4 embeddings above return before this check; everything else outside
+  // 2000::/3 is reserved, local, discard-only, or currently unallocated.
+  if (words?.[0] !== undefined && (words[0] & 0xe000) !== 0x2000) return true;
+  // IANA protocol assignments occupy 2001::/23. Individual sub-prefixes such
+  // as benchmarking 2001:2::/48 do not make the adjacent space public.
+  if (words?.[0] === 0x2001 && words[1] <= 0x01ff) return true;
+  if (words?.[0] === 0x2001 && words[1] === 0xdb8) return true;
   // Keep registration-time screening aligned with the delivery dispatcher for
   // the complete benchmarking and discard-only special-use prefixes.
   if (words?.[0] === 0x2001 && words[1] === 0x0002 && words[2] === 0) return true;
   if (words?.[0] === 0x0100 && words[1] === 0 && words[2] === 0 && words[3] === 0) return true;
   if (words?.[0] !== undefined && (words[0] & 0xffc0) === 0xfe80) return true;
   if (words?.[0] !== undefined && (words[0] & 0xffc0) === 0xfec0) return true;
+  if (words?.[0] === 0x2620 && words[1] === 0x004f && words[2] === 0x8000) return true;
+  if (words?.[0] === 0x3fff && (words[1] & 0xf000) === 0) return true;
   return (
     normalized === "::" ||
     normalized === "::1" ||

--- a/packages/webhooks/src/__tests__/dispatcher-ssrf-literal.test.ts
+++ b/packages/webhooks/src/__tests__/dispatcher-ssrf-literal.test.ts
@@ -119,7 +119,7 @@ describe("WebhookDispatcher SSRF guard for IP-literal URLs", () => {
     }
   });
 
-  it("does not over-block adjacent public IPv6 prefixes", async () => {
+  it("rejects adjacent special-use space without over-blocking public IPv6", async () => {
     const dispatcher = new WebhookDispatcher({
       maxRetries: 0,
       retryDelayMs: 1,
@@ -128,15 +128,40 @@ describe("WebhookDispatcher SSRF guard for IP-literal URLs", () => {
       allowInsecureHttp: true,
     });
 
+    for (const url of ["http://[100:1::]/hook", "http://[2001:2:1::]/hook"]) {
+      const result = await dispatcher.dispatch(makeEvent(), { url, secret: SECRET });
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("must resolve to a public address");
+    }
+
+    const publicResult = await dispatcher.dispatch(makeEvent(), {
+      url: "http://[2001:4860:4860::8888]/hook",
+      secret: SECRET,
+    });
+    expect(publicResult.success).toBe(false);
+    expect(publicResult.error ?? "").not.toContain("must resolve to a public address");
+  });
+
+  it("rejects remaining special-purpose and unallocated literals", async () => {
+    const dispatcher = new WebhookDispatcher({
+      maxRetries: 0,
+      retryDelayMs: 1,
+      timeoutMs: 500,
+      allowPrivateNetwork: false,
+      allowInsecureHttp: true,
+    });
     for (const url of [
-      "http://[100:1::]/hook", // outside 100::/64
-      "http://[2001:2:1::]/hook", // outside 2001:2::/48
-      "http://[::ffff:1:7f00:1]/hook", // words[5] !== 0: not the translated prefix
+      "http://192.31.196.1/hook",
+      "http://192.52.193.1/hook",
+      "http://192.175.48.1/hook",
+      "http://[2001:100::1]/hook",
+      "http://[2620:4f:8000::1]/hook",
+      "http://[3fff::1]/hook",
+      "http://[4000::1]/hook",
     ]) {
       const result = await dispatcher.dispatch(makeEvent(), { url, secret: SECRET });
       expect(result.success).toBe(false);
-      // Rejected by the network failure path (no route), NOT by the SSRF guard.
-      expect(result.error ?? "").not.toContain("must resolve to a public address");
+      expect(result.error).toContain("must resolve to a public address");
     }
   });
 

--- a/packages/webhooks/src/__tests__/queue.test.ts
+++ b/packages/webhooks/src/__tests__/queue.test.ts
@@ -406,6 +406,30 @@ describe("RetryQueue", () => {
     }
   });
 
+  it("fails closed on malformed or family-confused DNS answers", async () => {
+    for (const [address, family] of [
+      ["not-an-ip", 4],
+      ["8.8.8.8", 6],
+      ["2606:4700:4700::1111", 4],
+    ] as const) {
+      const lookup: LookupFunction = (_hostname, _options, callback) => {
+        callback(null, address, family);
+      };
+      const dispatcher = new WebhookDispatcher({
+        maxRetries: 0,
+        timeoutMs: 1000,
+        lookup,
+        allowInsecureHttp: true,
+      });
+      const result = await dispatcher.dispatch(makeEvent(), {
+        url: "http://dns-answer.example.test/hook",
+        secret: "dns-answer-test-secret",
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Webhook host must resolve to a public address");
+    }
+  });
+
   it("blocks DNS rebinding to special-use IPv4 addresses at connection time", async () => {
     for (const address of [
       "192.0.2.10",

--- a/packages/webhooks/src/dispatcher.ts
+++ b/packages/webhooks/src/dispatcher.ts
@@ -92,8 +92,11 @@ function isNonPublicIpv4(address: string): boolean {
     (a === 172 && b >= 16 && b <= 31) ||
     (a === 192 && b === 168) ||
     (a === 100 && b >= 64 && b <= 127) ||
-    (a === 192 && b === 0) ||
+    (a === 192 && b === 0 && (octets[2] === 0 || octets[2] === 2)) ||
+    (a === 192 && b === 31 && octets[2] === 196) ||
+    (a === 192 && b === 52 && octets[2] === 193) ||
     (a === 192 && b === 88 && octets[2] === 99) ||
+    (a === 192 && b === 175 && octets[2] === 48) ||
     (a === 198 && (b === 18 || b === 19)) ||
     (a === 198 && b === 51 && octets[2] === 100) ||
     (a === 203 && b === 0 && octets[2] === 113) ||
@@ -193,7 +196,11 @@ function isNonPublicIpv6(address: string): boolean {
   if (ipv4Mapped) return isNonPublicIpv4(ipv4Mapped);
   const ipv4Embedded = embeddedIpv4FromIpv6(normalized);
   if (ipv4Embedded) return isNonPublicIpv4(ipv4Embedded);
-  if (words?.[0] === 0x2001 && (words[1] === 0 || words[1] === 0xdb8)) return true;
+  // Public IPv4 embeddings return above. Other literals must be ordinary
+  // global-unicast addresses; reserved/local/unallocated space is fail-closed.
+  if (words?.[0] !== undefined && (words[0] & 0xe000) !== 0x2000) return true;
+  if (words?.[0] === 0x2001 && words[1] <= 0x01ff) return true;
+  if (words?.[0] === 0x2001 && words[1] === 0xdb8) return true;
   // 2001:2::/48 benchmarking (RFC 5180) — documentation/special-use, never a
   // public webhook target (SEC-178).
   if (words?.[0] === 0x2001 && words[1] === 0x0002 && words[2] === 0) return true;
@@ -201,6 +208,8 @@ function isNonPublicIpv6(address: string): boolean {
   if (words?.[0] === 0x0100 && words[1] === 0 && words[2] === 0 && words[3] === 0) return true;
   if (words?.[0] !== undefined && (words[0] & 0xffc0) === 0xfe80) return true;
   if (words?.[0] !== undefined && (words[0] & 0xffc0) === 0xfec0) return true;
+  if (words?.[0] === 0x2620 && words[1] === 0x004f && words[2] === 0x8000) return true;
+  if (words?.[0] === 0x3fff && (words[1] & 0xf000) === 0) return true;
   return (
     normalized === "::" ||
     normalized === "::1" ||
@@ -243,10 +252,12 @@ function assertPublicWebhookHostname(hostname: string): void {
 }
 
 function assertPublicAddress(address: string, family?: number): void {
+  const detectedFamily = isIP(address);
   if (
-    (family === 4 && isNonPublicIpv4(address)) ||
-    (family === 6 && isNonPublicIpv6(address)) ||
-    (family !== 4 && family !== 6 && (isNonPublicIpv4(address) || isNonPublicIpv6(address)))
+    detectedFamily === 0 ||
+    (family !== undefined && family !== detectedFamily) ||
+    (detectedFamily === 4 && isNonPublicIpv4(address)) ||
+    (detectedFamily === 6 && isNonPublicIpv6(address))
   ) {
     throw new WebhookValidationError("Webhook host must resolve to a public address");
   }


### PR DESCRIPTION
## Summary
- reject non-global and omitted special-purpose IPv4/IPv6 webhook destinations at registration and delivery
- correct the post-#445 assumption that adjacent special-use space is public
- fail closed on malformed or DNS-family-confused connection-time answers

## Validation
- 44 focused webhook/API tests (254 assertions)
- Biome check on all five changed files
- @stwd/webhooks TypeScript build
- standalone strict TypeScript check for webhook URL validator
- @stwd/api TypeScript build on the prior exact base before the accounting-only restack