### PR TITLE
fix(ci): repair red develop jobs — proxy db-mock stubs + swift Linux crypto

### DIFF
--- a/packages/proxy/src/__tests__/zz-proxy-spend-limit.test.ts
+++ b/packages/proxy/src/__tests__/zz-proxy-spend-limit.test.ts
@@ -26,6 +26,7 @@ const route = {
   pathPattern: "/*",
   method: "*",
   injectAs: "header",
+  injectionStrategy: "header",
   injectKey: "x-api-key",
   injectFormat: "Bearer {value}",
   priority: 0,
@@ -108,6 +109,21 @@ mock.module("@stwd/db", () => {
     workspaces,
     policies,
     proxyAuditLog,
+    // Table/function stubs for modules outside this suite's scope (provider
+    // authority, google/slack credential lifecycles, audit chain). bun
+    // validates named imports against this mock namespace at link time, so
+    // every name any transitively-loaded module imports must exist here.
+    approvalQueue: { id: "id" },
+    auditEvents: { id: "id" },
+    executionAuthorizationNonces: { id: "id" },
+    intents: { id: "id" },
+    providerActionBindings: { id: "id" },
+    providerGoogleCredentialLifecycles: { id: "id" },
+    users: { id: "id" },
+    withTenantAuditedTransaction: async (
+      _tenantId: unknown,
+      fn: (tx: unknown, appendRequiredAudit: (event: unknown) => Promise<void>) => Promise<unknown>,
+    ) => fn({}, async () => {}),
     getDb: () => ({
       select: () => ({
         from: (table: unknown) => ({

--- a/packages/swift/Package.resolved
+++ b/packages/swift/Package.resolved
@@ -1,0 +1,23 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
+        "version" : "3.15.1"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/packages/swift/Package.swift
+++ b/packages/swift/Package.swift
@@ -11,9 +11,22 @@ let package = Package(
     products: [
         .library(name: "Steward", targets: ["Steward"]),
     ],
+    dependencies: [
+        // CryptoKit is Apple-only; swift-crypto supplies the same API as the
+        // `Crypto` module on Linux/Windows (CI runs `swift test` on ubuntu).
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "3.0.0"),
+    ],
     targets: [
-        .target(name: "Steward"),
+        .target(
+            name: "Steward",
+            dependencies: [
+                .product(
+                    name: "Crypto",
+                    package: "swift-crypto",
+                    condition: .when(platforms: [.linux, .windows, .android])
+                ),
+            ]
+        ),
         .testTarget(name: "StewardTests", dependencies: ["Steward"]),
     ]
 )
-

--- a/packages/swift/Sources/Steward/StewardClient.swift
+++ b/packages/swift/Sources/Steward/StewardClient.swift
@@ -1,4 +1,11 @@
+#if canImport(CryptoKit)
 import CryptoKit
+#else
+// Linux/Windows: swift-crypto provides the same HMAC/SHA256/SymmetricKey API
+// surface under the `Crypto` module (declared in Package.swift for non-Apple
+// platforms only).
+import Crypto
+#endif
 import Foundation
 
 public typealias StewardJSON = [String: Any]


### PR DESCRIPTION
Repairs the two real failures from the first completed develop CI run after the security waves (the lint failure was already fixed by #440). 1) packages/proxy zz-proxy-spend-limit suite: the @stwd/db mock namespace predated upstream merges (google credential lifecycles, governed execution) and failed at link time (SyntaxError, 32 red tests); adds the missing table/function stubs and the new injectionStrategy field the handler now consults. Verified: full proxy suite 312 pass / 0 fail with the exact CI invocation + env (bun test --isolate packages/proxy, STEWARD_AUDIT_HMAC_KEY etc.). 2) packages/swift: SEC-049 added HMAC request signing via CryptoKit, which does not exist on Linux CI — conditional import (CryptoKit on Apple, swift-crypto's Crypto module elsewhere) + conditional Package.swift dependency. Verified locally: swift package resolve + build + test all green (6/6); Linux branch exercised by CI.