### PR TITLE
fix(ci): repair round-2 develop failures (provider-aws matrix, swift Linux, AWS profile fixture)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,7 @@ jobs:
           - packages/plugin-capabilities
           - packages/plugin-example
           - packages/plugin-sdk
+          - packages/provider-aws
           - packages/provider-github
           - packages/provider-google
           - packages/provider-slack

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -191,6 +191,7 @@ jobs:
           - packages/plugin-capabilities
           - packages/plugin-example
           - packages/plugin-sdk
+          - packages/provider-aws
           - packages/provider-github
           - packages/provider-google
           - packages/provider-slack

--- a/packages/api/src/__tests__/production-profile-boundary-e2e.test.ts
+++ b/packages/api/src/__tests__/production-profile-boundary-e2e.test.ts
@@ -33,6 +33,7 @@ import {
 } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import {
+  AWS_PROVIDER_ACTION_PROFILE,
   GENERIC_HTTP_PROVIDER_ACTION_PROFILE,
   GITHUB_PROVIDER_ACTION_PROFILE,
   GOOGLE_PROVIDER_ACTION_PROFILE,
@@ -99,6 +100,21 @@ const PROFILES = [
     method: "GET",
     path: "/calendar/v3/calendars/primary/events",
     args: { maxResults: 50 },
+    requestProfile: {},
+  },
+  {
+    // AWS resolves its one permitted origin dynamically from the canonical
+    // action bytes (registry dynamicOriginPolicy "aws-ec2-region"), so the
+    // host below MUST equal `ec2.${args.region}.amazonaws.com` and the route
+    // must carry the exact SigV4 binding (see the credential/route
+    // special-cases in runAuthenticatedBoundary).
+    profile: AWS_PROVIDER_ACTION_PROFILE,
+    adapterKey: "aws",
+    operationKey: "aws.ec2.DescribeInstances",
+    host: "ec2.us-west-2.amazonaws.com",
+    method: "POST",
+    path: "/",
+    args: { region: "us-west-2" },
     requestProfile: {},
   },
   {
@@ -172,9 +188,9 @@ beforeAll(async () => {
   process.env.STEWARD_EXECUTION_AUTH_SECRET = "1".repeat(64);
   process.env.STEWARD_MASTER_PASSWORD = "profile-boundary-master-password";
   process.env.STEWARD_SECRET_ROUTE_ALLOWED_HOSTS =
-    "api.github.com,api.x.com,slack.com,www.googleapis.com,api.example.com";
+    "api.github.com,api.x.com,slack.com,www.googleapis.com,api.example.com,ec2.us-west-2.amazonaws.com";
   process.env.STEWARD_PROXY_ALLOWED_HOSTS =
-    "api.github.com,api.x.com,slack.com,www.googleapis.com,api.example.com";
+    "api.github.com,api.x.com,slack.com,www.googleapis.com,api.example.com,ec2.us-west-2.amazonaws.com";
   process.env.STEWARD_JWT_SECRET = "profile-boundary-jwt-secret-0123456789abcdef0123456789";
   const signingKeys = generateKeyPairSync("ed25519");
   process.env.STEWARD_AUDIT_SIGNING_KEY = signingKeys.privateKey
@@ -298,7 +314,15 @@ async function runAuthenticatedBoundary(
             refreshToken: "profile-boundary-refresh",
             scopesGranted: ["openid", "email", "https://www.googleapis.com/auth/calendar.readonly"],
           })
-        : "profile-boundary-credential";
+        : fixture.profile === AWS_PROVIDER_ACTION_PROFILE
+          ? // Strict SigV4 credential schema (packages/proxy/src/sigv4.ts):
+            // accessKeyId is /^[A-Z0-9]{16,128}$/, secretAccessKey 16..256
+            // printable chars, optional sessionToken. No other keys allowed.
+            JSON.stringify({
+              accessKeyId: "AKIAPROFILEBOUNDARY0",
+              secretAccessKey: "profile-boundary-aws-secret-key",
+            })
+          : "profile-boundary-credential";
   const encrypted = vault.encrypt(credential, {
     tenantId: F.TENANT,
     name: "github",
@@ -334,6 +358,17 @@ async function runAuthenticatedBoundary(
       agentId: F.AGENT,
       authorityMode: "governed_v2",
       providerOperationId: F.OP,
+      // The AWS profile dispatches through the SigV4 final-boundary signer,
+      // which requires the route's exact sigv4 binding (service ec2 + the
+      // region the fixture host commits to). Both assertAwsCredentialRouteBinding
+      // (ingress) and injectAwsSigV4AtFinalBoundary (dispatch) fail closed
+      // without it. Other profiles keep the seeded header-injection strategy.
+      ...(fixture.profile === AWS_PROVIDER_ACTION_PROFILE
+        ? {
+            injectionStrategy: "sigv4",
+            injectionConfig: { service: "ec2", region: "us-west-2" },
+          }
+        : {}),
     })
     .where(and(eq(secretRoutes.tenantId, F.TENANT), eq(secretRoutes.id, F.ROUTE)));
 

--- a/packages/swift/Sources/Steward/StewardClient.swift
+++ b/packages/swift/Sources/Steward/StewardClient.swift
@@ -7,6 +7,12 @@ import CryptoKit
 import Crypto
 #endif
 import Foundation
+#if canImport(FoundationNetworking)
+// Linux/Windows: URLRequest/URLSession/HTTPURLResponse live in the separate
+// FoundationNetworking module; on Apple platforms Foundation already provides
+// them (defaultTransport is the only consumer).
+import FoundationNetworking
+#endif
 
 public typealias StewardJSON = [String: Any]
 public typealias StewardTransport = (String, URL, [String: String], Data?, TimeInterval) throws -> (Int, [String: String], Data)


### PR DESCRIPTION
Repairs the 4 failing jobs from develop run
https://github.com/Steward-Fi/steward/actions/runs/32110508415 (develop @ 4968cf1f,
still HEAD when this branch was cut — nothing was already fixed upstream).

## Per-failure status

### 1. Lint + Typecheck / scripts\_\_tests\_\_ — CI test inventory missing `packages/provider-aws` — FIXED, verified locally

Upstream added `packages/provider-aws` (plain `bun test`, `src/__tests__`) without
registering it in the unit-test matrix, so `scripts/check-ci-test-inventory.ts`
failed with `test-bearing targets missing from CI: packages/provider-aws` in both
the Lint + Typecheck job and the scripts/\_\_tests\_\_ job.

Fix: added `- packages/provider-aws` to the unit matrix in **both**
`.github/workflows/ci.yml` and `.github/workflows/pr.yml`, grouped with the other
`provider-*` entries. No per-package special-casing needed (no bunfig preload;
falls through to the default `bun test --isolate ${{ matrix.package }}` leg).

Verified locally:
- `bun run scripts/check-ci-test-inventory.ts` → "CI test inventory covers all 47 test-bearing targets"
- Exact matrix leg invocation from repo root with the CI env
  (`STEWARD_MASTER_PASSWORD=ci-test-secret STEWARD_PROXY_DEV_MODE=true STEWARD_AUDIT_HMAC_KEY=aaaa…`):
  `bun test --isolate packages/provider-aws` → 4 pass / 0 fail
- `bunx turbo run build --filter="@stwd/provider-aws..."` → 6/6 successful (the matrix build step)
- `bun test --isolate scripts/__tests__/check-ci-test-inventory.test.ts` → 8 pass / 0 fail

### 2. Unit Tests (packages/swift) — Linux compile failure — FIXED, macOS-verified only

`StewardClient.swift` failed on ubuntu with `cannot find 'URLRequest' in scope` /
`'URLSession' has no member 'shared'`: on Linux, `URLRequest`/`URLSession`/
`HTTPURLResponse` live in the separate `FoundationNetworking` module.

Fix: added the standard conditional import immediately after `import Foundation`:

```swift
#if canImport(FoundationNetworking)
import FoundationNetworking
#endif
```

`StewardClient.swift` is the only file in `Sources/` or `Tests/` touching those
types (test file stubs the transport). Audited the rest of the file for
Apple-only APIs: `DispatchSemaphore`, `URLComponents`, `JSONSerialization`,
`FileHandle` are all in swift-corelibs-foundation on Linux; HMAC/SHA256 were
already gated behind `canImport(CryptoKit)` + the conditional swift-crypto
dependency. No `SecItem*`/Keychain/CommonCrypto/`os_log` usage.

Verified locally: `swift build` + `swift test` pass on macOS (6/6 tests).
**NOT verified locally: the actual Linux compile** — macOS host, no Docker.
The gated import is inert on Apple platforms and is the canonical fix; CI's
ubuntu leg is the real proof.

### 3. Integration Tests (Postgres) — missing AWS profile fixture — FIXED, verified locally

`production-profile-boundary-e2e.test.ts` asserted its `PROFILES` fixture array
equals `REGISTERED_PROFILES`, but upstream registered
`AWS_PROVIDER_ACTION_PROFILE` (registry descriptor with
`dynamicOriginPolicy: "aws-ec2-region"`) without adding the e2e fixture.

Fix: added an AWS fixture modeled on the existing adapter-fixed entries —
`aws.ec2.DescribeInstances`, `POST /` against `ec2.us-west-2.amazonaws.com`,
`args: { region: "us-west-2" }` — plus the two AWS-specific bindings the
production boundary enforces (traced through `governed-execution.ts`,
`provider-action-service.ts::assertAwsCredentialRouteBinding`, and
`proxy/src/sigv4.ts::injectAwsSigV4AtFinalBoundary`):

- the credential secret uses the strict SigV4 JSON schema
  (`accessKeyId` /^[A-Z0-9]{16,128}$/, printable `secretAccessKey`);
- the secret route gets `injectionStrategy: "sigv4"` +
  `injectionConfig: { service: "ec2", region: "us-west-2" }` — required at both
  ingress and dispatch, and the region must match the `aws-ec2-region` dynamic
  origin derived from the canonical action bytes
  (`awsEc2AllowedOriginFromCanonicalBytes`), which is why the fixture host is
  region-bound;
- `ec2.us-west-2.amazonaws.com` added to the suite's
  `STEWARD_SECRET_ROUTE_ALLOWED_HOSTS` / `STEWARD_PROXY_ALLOWED_HOSTS`.

No dispatch-path code changes were needed — `runAuthenticatedBoundary`'s generic
machinery already routes dynamic origins correctly once the fixture host matches
the produced host.

Verified locally via the exact integration-job runner:
`TEST_JOBS=1 TEST_TIMEOUT=120000 bun packages/api/scripts/run-tests-isolated.ts production-profile-boundary`
→ PASS, and directly: 8/8 tests pass, including the new
`aws.provider-action.v1: identical authenticated ingress→dispatch→evidence runner`
through the real SigV4 final-boundary signer (forward stubbed, as for the other
profiles). Also `bunx turbo run build --filter=@stwd/api` (tsc --noEmit) → clean.

### 4. Hygiene

Each fix is a separate commit (`fix(ci):` / `fix(security):`). `bunx biome check`
run on changed files (only the .ts test file is biome-applicable; yml/swift are
out of its scope) → clean.

## What CI still needs to prove

- The swift Linux leg (see #2) — the one thing not locally reproducible here.
- Full integration matrix on real Postgres (locally ran against PGLite exactly as
  the job's isolated runner does).
