### PR TITLE
fix(provider-google): recover refresh state on reconnect

### DIFF
--- a/packages/api/src/__tests__/provider-google-connect.test.ts
+++ b/packages/api/src/__tests__/provider-google-connect.test.ts
@@ -34,6 +34,10 @@ import {
   workspaces,
 } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import {
+  __setGoogleExecutionTokenForwarderForTests,
+  mintGoogleExecutionAccessToken,
+} from "@stwd/proxy/src/handlers/google-execution-credential";
 import { SecretVault } from "@stwd/vault";
 import { and, eq } from "drizzle-orm";
 import { providerAuthorityStore } from "../services/provider-authority-store";
@@ -486,6 +490,111 @@ describe("connect", () => {
     expect(rows.length).toBe(1);
     expect(rows[0].revision).toBe(2);
     expect(rows[0].credentialVersion).toBe(2);
+  });
+
+  test("reconnect supersedes an unresolved refresh lifecycle and restores minting without replay", async () => {
+    const first = await connectHappy(new MemoryConnectStore());
+    const db = getDb();
+    const [beforeAccount] = await db
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, first.completed.providerAccountId));
+    const strandedHandle = await vault.createSecret(
+      TENANT,
+      `provider-google-lifecycle:${crypto.randomUUID()}`,
+      JSON.stringify({
+        schemaVersion: "steward.provider-google.lifecycle.v1",
+        token: { access_token: "stranded-access", refresh_token: "stranded-refresh" },
+      }),
+    );
+    const lifecycleId = crypto.randomUUID();
+    await db.insert(providerGoogleCredentialLifecycles).values({
+      id: lifecycleId,
+      tenantId: TENANT,
+      workspaceId: WORKSPACE,
+      providerAccountId: beforeAccount.id,
+      kind: "refresh_rotation",
+      state: "needs_attention",
+      credentialSecretId: strandedHandle.id,
+      expectedAccountRevision: beforeAccount.revision,
+      lastErrorCode: "REFRESH_OUTCOME_UNKNOWN",
+    });
+
+    let tokenRequests = 0;
+    __setGoogleExecutionTokenForwarderForTests(async () => {
+      tokenRequests += 1;
+      return Response.json({
+        access_token: "execution-access-after-reconnect",
+        token_type: "Bearer",
+        expires_in: 3600,
+      });
+    });
+    try {
+      const blockedRefresh = installFakeX();
+      try {
+        await expect(
+          refreshGoogleProviderCredential({
+            tenantId: TENANT,
+            workspaceId: WORKSPACE,
+            accountId: beforeAccount.id,
+            vault,
+            config: CONFIG,
+            force: true,
+          }),
+        ).rejects.toMatchObject({ code: "GOOGLE_CREDENTIAL_NEEDS_ATTENTION" });
+        expect(blockedRefresh.counters.refresh).toBe(0);
+      } finally {
+        blockedRefresh.restore();
+      }
+
+      await expect(
+        mintGoogleExecutionAccessToken({
+          tenantId: TENANT,
+          workspaceId: WORKSPACE,
+          accountId: beforeAccount.id,
+          accountRevision: beforeAccount.revision,
+          credential: JSON.stringify(await decryptCredential(beforeAccount.id)),
+          vault,
+          clientId: CONFIG.clientId,
+          clientSecret: CONFIG.clientSecret,
+        }),
+      ).rejects.toThrow("Google credential refresh lifecycle must be reconciled before token mint");
+      expect(tokenRequests).toBe(0);
+
+      const second = await connectHappy(new MemoryConnectStore());
+      expect(second.completed.reconnected).toBe(true);
+      const [afterAccount] = await db
+        .select()
+        .from(providerAccounts)
+        .where(eq(providerAccounts.id, beforeAccount.id));
+      const [superseded] = await db
+        .select()
+        .from(providerGoogleCredentialLifecycles)
+        .where(eq(providerGoogleCredentialLifecycles.id, lifecycleId));
+      expect(superseded.state).toBe("superseded");
+      expect(superseded.credentialSecretId).toBeNull();
+      expect(await db.select().from(secrets).where(eq(secrets.id, strandedHandle.id))).toHaveLength(
+        0,
+      );
+
+      const minted = await mintGoogleExecutionAccessToken({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        accountId: afterAccount.id,
+        accountRevision: afterAccount.revision,
+        credential: JSON.stringify(await decryptCredential(afterAccount.id)),
+        vault,
+        clientId: CONFIG.clientId,
+        clientSecret: CONFIG.clientSecret,
+      });
+      expect(minted).toBe("execution-access-after-reconnect");
+      expect(tokenRequests).toBe(1);
+      expect(await readAuditActions(TENANT)).toContain(
+        "provider.google.refresh.superseded_by_reconnect",
+      );
+    } finally {
+      __setGoogleExecutionTokenForwarderForTests(null);
+    }
   });
 
   test("injected initial persistence failure rolls back secret/account and revokes issued grant", async () => {

--- a/packages/api/src/services/provider-google-connect.ts
+++ b/packages/api/src/services/provider-google-connect.ts
@@ -1119,6 +1119,32 @@ async function persistConnectedAccount(input: PersistInput): Promise<CompleteCon
       }
     }
 
+    const unresolvedRefreshes = account
+      ? await tx
+          .select({
+            id: providerGoogleCredentialLifecycles.id,
+            state: providerGoogleCredentialLifecycles.state,
+            credentialSecretId: providerGoogleCredentialLifecycles.credentialSecretId,
+          })
+          .from(providerGoogleCredentialLifecycles)
+          .where(
+            and(
+              eq(providerGoogleCredentialLifecycles.tenantId, input.tenantId),
+              eq(providerGoogleCredentialLifecycles.workspaceId, input.workspaceId),
+              eq(providerGoogleCredentialLifecycles.providerAccountId, account.id),
+              eq(providerGoogleCredentialLifecycles.kind, "refresh_rotation"),
+              inArray(providerGoogleCredentialLifecycles.state, [
+                "inflight",
+                "credential_staged",
+                "revocation_pending",
+                "needs_attention",
+              ]),
+            ),
+          )
+          .orderBy(asc(providerGoogleCredentialLifecycles.createdAt))
+          .for("update")
+      : [];
+
     const [existingSecret] = await tx
       .select({ id: secrets.id })
       .from(secrets)
@@ -1169,6 +1195,66 @@ async function persistConnectedAccount(input: PersistInput): Promise<CompleteCon
           409,
           "account revision conflict on reconnect",
         );
+      }
+
+      if (unresolvedRefreshes.length > 0) {
+        const unresolvedIds = unresolvedRefreshes.map(({ id }) => id);
+        const superseded = await tx
+          .update(providerGoogleCredentialLifecycles)
+          .set({
+            state: "superseded",
+            credentialSecretId: null,
+            lastErrorCode: "SUPERSEDED_BY_RECONNECT",
+            updatedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(providerGoogleCredentialLifecycles.tenantId, input.tenantId),
+              eq(providerGoogleCredentialLifecycles.workspaceId, input.workspaceId),
+              eq(providerGoogleCredentialLifecycles.providerAccountId, account.id),
+              eq(providerGoogleCredentialLifecycles.kind, "refresh_rotation"),
+              inArray(providerGoogleCredentialLifecycles.id, unresolvedIds),
+              inArray(providerGoogleCredentialLifecycles.state, [
+                "inflight",
+                "credential_staged",
+                "revocation_pending",
+                "needs_attention",
+              ]),
+            ),
+          )
+          .returning({ id: providerGoogleCredentialLifecycles.id });
+        if (superseded.length !== unresolvedRefreshes.length) {
+          throw new GoogleConnectError(
+            "GOOGLE_CREDENTIAL_NEEDS_ATTENTION",
+            409,
+            "refresh lifecycle changed during reconnect",
+          );
+        }
+        const handleIds = unresolvedRefreshes
+          .map(({ credentialSecretId }) => credentialSecretId)
+          .filter((id): id is string => id !== null);
+        if (handleIds.length > 0) {
+          await tx
+            .delete(secrets)
+            .where(and(eq(secrets.tenantId, input.tenantId), inArray(secrets.id, handleIds)));
+        }
+        await append({
+          tenantId: input.tenantId,
+          actorType: "user",
+          actorId: input.callerUserId,
+          action: "provider.google.refresh.superseded_by_reconnect",
+          resourceType: "provider_account",
+          resourceId: account.id,
+          metadata: {
+            workspaceId: input.workspaceId,
+            priorAccountRevision: account.revision,
+            newAccountRevision: account.revision + 1,
+            lifecycleIds: [...unresolvedIds].sort(),
+            priorStates: unresolvedRefreshes
+              .map(({ id, state }) => ({ id, state }))
+              .sort((a, b) => a.id.localeCompare(b.id)),
+          },
+        });
       }
     } else {
       reconnected = false;
@@ -1376,18 +1462,38 @@ export async function refreshGoogleProviderCredential(input: RefreshInput): Prom
           "no refresh token on record",
         );
       const [activeLifecycle] = await tx
-        .select({ id: providerGoogleCredentialLifecycles.id })
+        .select({
+          id: providerGoogleCredentialLifecycles.id,
+          state: providerGoogleCredentialLifecycles.state,
+        })
         .from(providerGoogleCredentialLifecycles)
         .where(
           and(
             eq(providerGoogleCredentialLifecycles.tenantId, input.tenantId),
             eq(providerGoogleCredentialLifecycles.providerAccountId, account.id),
             eq(providerGoogleCredentialLifecycles.kind, "refresh_rotation"),
-            inArray(providerGoogleCredentialLifecycles.state, ["inflight", "credential_staged"]),
+            inArray(providerGoogleCredentialLifecycles.state, [
+              "inflight",
+              "credential_staged",
+              "needs_attention",
+              "revocation_pending",
+            ]),
           ),
         )
         .limit(1);
-      if (activeLifecycle) return { kind: "wait", lifecycleId: activeLifecycle.id };
+      if (activeLifecycle) {
+        if (
+          activeLifecycle.state === "needs_attention" ||
+          activeLifecycle.state === "revocation_pending"
+        ) {
+          throw new GoogleConnectError(
+            "GOOGLE_CREDENTIAL_NEEDS_ATTENTION",
+            409,
+            "Google credential refresh lifecycle must be reconciled before refresh",
+          );
+        }
+        return { kind: "wait", lifecycleId: activeLifecycle.id };
+      }
       const lifecycleId = randomUUID();
       await tx.insert(providerGoogleCredentialLifecycles).values({
         id: lifecycleId,

--- a/packages/db/drizzle/0103_google_refresh_reconnect_recovery.sql
+++ b/packages/db/drizzle/0103_google_refresh_reconnect_recovery.sql
@@ -1,0 +1,8 @@
+-- A fresh OAuth reconnect installs a new revision-bound credential and can
+-- therefore terminalize refresh attempts tied to the superseded credential.
+ALTER TABLE "provider_google_credential_lifecycles"
+  DROP CONSTRAINT "provider_google_lifecycle_state_check";
+--> statement-breakpoint
+ALTER TABLE "provider_google_credential_lifecycles"
+  ADD CONSTRAINT "provider_google_lifecycle_state_check"
+  CHECK ("state" IN ('inflight', 'credential_staged', 'revocation_pending', 'adopted', 'revoked', 'needs_attention', 'superseded'));

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -582,6 +582,13 @@
       "when": 1787106473000,
       "tag": "0102_google_consequential_write_risk",
       "breakpoints": true
+    },
+    {
+      "idx": 103,
+      "version": "7",
+      "when": 1787107600000,
+      "tag": "0103_google_refresh_reconnect_recovery",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -2089,7 +2089,7 @@ export const providerGoogleCredentialLifecycles = pgTable(
     }).onDelete("restrict"),
     stateCheck: check(
       "provider_google_lifecycle_state_check",
-      sql`${table.state} IN ('inflight', 'credential_staged', 'revocation_pending', 'adopted', 'revoked', 'needs_attention')`,
+      sql`${table.state} IN ('inflight', 'credential_staged', 'revocation_pending', 'adopted', 'revoked', 'needs_attention', 'superseded')`,
     ),
     kindCheck: check(
       "provider_google_lifecycle_kind_check",


### PR DESCRIPTION
Closes #203

## Summary

- fail closed before direct Google refresh when the exact account has an unresolved refresh-rotation lifecycle
- on an authorized reconnect, lock and atomically supersede unresolved refresh-rotation lifecycles only after the new account revision is durably installed
- destroy stale encrypted refresh-response handles and append required tenant audit evidence in the same transaction
- restore governed execution after reconnect without replaying the old rotating refresh token

## Security invariants

- unresolved `inflight`, `credential_staged`, `revocation_pending`, and `needs_attention` refresh rotations block both direct refresh and execution minting
- reconnect supersession is tenant/workspace/account scoped and serialized with account/lifecycle row locks
- a late pre-reconnect worker cannot disable the new credential revision because account transitions remain exact-revision bound
- no old refresh credential or staged response is replayed after reconnect

## Exact-head validation

Head: `8b73599bdbe88aaaddd15ae58e3e5628e68f4617`
Base: `b31afe05d1d8e822207b9d5039e2eb5bcfda5949`

- reconnect adversarial PGLite regression: 1/1, 11 assertions
- full provider Google connect suite on patch-equivalent predecessor: 49/49, 188 assertions
- proxy Google refresh: 7/7, 29 assertions
- scheduler: 2/2, 5 assertions
- authority/operations: 7/7, 28 assertions
- authenticated production-profile boundary: 9/9, 101 assertions
- dependency-aware API/proxy build: 24/24
- Biome and diff-check: green
