### PR TITLE
fix(db): keep migration ordering test forward-compatible

### DIFF
--- a/packages/db/src/__tests__/operator-transfer-integrity-migration.test.ts
+++ b/packages/db/src/__tests__/operator-transfer-integrity-migration.test.ts
@@ -29,7 +29,11 @@ describe("0101 operator transfer reservation integrity", () => {
     const journal = JSON.parse(
       await readFile(join(migrations, "meta", "_journal.json"), "utf8"),
     ) as { entries: Array<{ idx: number; tag: string }> };
-    expect(journal.entries.slice(-2).map(({ idx, tag }) => ({ idx, tag }))).toEqual([
+    const sigV4Index = journal.entries.findIndex(({ tag }) => tag === "0100_sigv4_injection");
+    expect(sigV4Index).toBeGreaterThanOrEqual(0);
+    expect(
+      journal.entries.slice(sigV4Index, sigV4Index + 2).map(({ idx, tag }) => ({ idx, tag })),
+    ).toEqual([
       { idx: 100, tag: "0100_sigv4_injection" },
       { idx: 101, tag: "0101_operator_transfer_integrity" },
     ]);


### PR DESCRIPTION
## Summary
- verify the 0100 to 0101 migration adjacency by locating the 0100 entry
- allow later migrations such as 0102 without invalidating the older migration invariant

## Validation
- operator transfer integrity + Google consequential risk migrations: 4/4
- full workspace build: 38/38 tasks
- CI inventory: all 47 test-bearing targets covered
- Biome and diff check clean