### PR TITLE
fix(security): close residual DNS and log-token leaks

### DIFF
--- a/packages/api/src/__tests__/webhook-url-validation.test.ts
+++ b/packages/api/src/__tests__/webhook-url-validation.test.ts
@@ -167,6 +167,18 @@ describe("validateWebhookUrlResolved (SEC-017)", () => {
     expect(result).toBe("url host must resolve to a public address");
   });
 
+  it("fails closed on malformed or family-confused DNS answers", async () => {
+    for (const answer of [
+      { address: "not-an-ip", family: 4 },
+      { address: "8.8.8.8", family: 6 },
+      { address: "2606:4700:4700::1111", family: 4 },
+    ]) {
+      expect(
+        await validateWebhookUrlResolved("https://hooks.example.com/hook", async () => [answer]),
+      ).toBe("url host must resolve to a public address");
+    }
+  });
+
   it("fails closed when the hostname cannot be resolved", async () => {
     const result = await validateWebhookUrlResolved("https://gone.example.com/hook", async () => {
       throw new Error("ENOTFOUND");

--- a/packages/api/src/services/webhook-url.ts
+++ b/packages/api/src/services/webhook-url.ts
@@ -189,12 +189,13 @@ export type DnsResolver = (hostname: string) => Promise<DnsAnswer[]>;
 
 const defaultResolver: DnsResolver = (hostname) => lookup(hostname, { all: true, verbatim: true });
 
-function isNonPublicAddress(address: string): boolean {
+function isNonPublicAddress(address: string, family?: number): boolean {
   const normalized = address.toLowerCase();
   const version = isIP(normalized);
+  if (version === 0 || (family !== undefined && family !== version)) return true;
   if (version === 4) return isNonPublicIpv4(normalized);
   if (version === 6) return isNonPublicIpv6(normalized);
-  // Unexpected answer form — fail closed.
+  // Kept as an explicit fail-closed fallback if Node adds another family.
   return true;
 }
 
@@ -234,7 +235,7 @@ export async function validateWebhookUrlResolved(
   }
   if (answers.length === 0) return "url host could not be resolved";
   for (const answer of answers) {
-    if (isNonPublicAddress(answer.address)) {
+    if (isNonPublicAddress(answer.address, answer.family)) {
       return "url host must resolve to a public address";
     }
   }

--- a/packages/shared/src/__tests__/safe-error.test.ts
+++ b/packages/shared/src/__tests__/safe-error.test.ts
@@ -139,6 +139,11 @@ describe("redactedThrownDiagnostics", () => {
         Object.assign(new Error("message-canary"), { code: "SECRET code canary" }),
       ),
     ).toEqual({ errorClass: "Error", errorCode: null });
+    expect(
+      redactedThrownDiagnostics(
+        Object.assign(new Error("message-canary"), { code: "SECRET_TOKEN_CANARY" }),
+      ),
+    ).toEqual({ errorClass: "Error", errorCode: null });
   });
 
   it("never throws when instanceof or code access is hostile", () => {

--- a/packages/shared/src/safe-error.ts
+++ b/packages/shared/src/safe-error.ts
@@ -52,8 +52,8 @@ const SAFE_ERROR_CODES = new Set([
  * Return bounded, non-secret diagnostics for logs at credential boundaries.
  * Both `instanceof` and property access are guarded because hostile proxies can
  * throw from either operation. Arbitrary error names and codes are never
- * returned: names can contain secrets, while codes are limited to the usual
- * uppercase machine-code grammar.
+ * returned: names and arbitrary machine-looking codes can contain secrets, so
+ * codes are limited to a fixed allowlist of transport failures.
  */
 export function redactedThrownDiagnostics(value: unknown): RedactedThrownDiagnostics {
   let errorClass: string = typeof value;

--- a/packages/shared/src/safe-error.ts
+++ b/packages/shared/src/safe-error.ts
@@ -38,7 +38,15 @@ export interface RedactedThrownDiagnostics {
   errorCode: string | null;
 }
 
-const SAFE_ERROR_CODE = /^[A-Z][A-Z0-9_]{0,63}$/;
+const SAFE_ERROR_CODES = new Set([
+  "ABORT_ERR",
+  "EAI_AGAIN",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "ENOTFOUND",
+  "ETIMEDOUT",
+  "UND_ERR_CONNECT_TIMEOUT",
+]);
 
 /**
  * Return bounded, non-secret diagnostics for logs at credential boundaries.
@@ -63,7 +71,7 @@ export function redactedThrownDiagnostics(value: unknown): RedactedThrownDiagnos
       "code" in value
     ) {
       const candidate = (value as { code?: unknown }).code;
-      if (typeof candidate === "string" && SAFE_ERROR_CODE.test(candidate)) {
+      if (typeof candidate === "string" && SAFE_ERROR_CODES.has(candidate)) {
         errorCode = candidate;
       }
     }


### PR DESCRIPTION
Post-merge corrective for audited #442/#447 bytes.

## Findings fixed

- registration-time resolved webhook validation checked address text but ignored DNS family metadata, unlike the connection-bound dispatcher; malformed and IPv4/IPv6-confused answers now fail closed before persistence
- the shared credential-boundary log sanitizer accepted any uppercase-shaped code, so a provider-controlled value such as SECRET_TOKEN_CANARY could still be reflected; only an explicit fixed network-error allowlist is loggable

## Regression coverage

- malformed address, IPv4-as-family-6, and IPv6-as-family-4 registration answers are rejected
- uppercase secret-shaped error codes reduce to null while reviewed network codes remain available

## Exact evidence

- head: a65672c904aca4858f656fe45933d03442d76fb9
- base: 6393ea8f4698309de24f9c7806a35ed524cbc008
- exact final-head registration + sanitizer suites: 32/32, 90 assertions
- broader patch-equivalent security matrix: 77/77, 420 assertions
- dependency-aware API/proxy/webhooks graph: 24/24 builds
- range-diff across final restack: both commits patch-equivalent
- Biome and diff-check: green

Keep draft until fresh exact-head hosted checks are green.