### PR TITLE
fix(provider-google): preserve unresolved refresh handles

### DIFF
--- a/packages/api/src/__tests__/provider-google-connect.test.ts
+++ b/packages/api/src/__tests__/provider-google-connect.test.ts
@@ -319,6 +319,7 @@ afterAll(async () => {
   __setGoogleDisconnectJournalHookForTests(null);
   __setGoogleDisconnectRevokeHookForTests(null);
   __setGoogleRefreshIntentHookForTests(null);
+  __setGoogleExecutionTokenForwarderForTests(null);
   await closeDb();
 });
 
@@ -329,6 +330,7 @@ afterEach(async () => {
   __setGoogleDisconnectJournalHookForTests(null);
   __setGoogleDisconnectRevokeHookForTests(null);
   __setGoogleRefreshIntentHookForTests(null);
+  __setGoogleExecutionTokenForwarderForTests(null);
   // Reset connected accounts + credential secrets between tests.
   const db = getDb();
   await db
@@ -492,21 +494,13 @@ describe("connect", () => {
     expect(rows[0].credentialVersion).toBe(2);
   });
 
-  test("reconnect supersedes an unresolved refresh lifecycle and restores minting without replay", async () => {
+  test("reconnect supersedes only a null-handle unknown refresh and restores minting without replay", async () => {
     const first = await connectHappy(new MemoryConnectStore());
     const db = getDb();
     const [beforeAccount] = await db
       .select()
       .from(providerAccounts)
       .where(eq(providerAccounts.id, first.completed.providerAccountId));
-    const strandedHandle = await vault.createSecret(
-      TENANT,
-      `provider-google-lifecycle:${crypto.randomUUID()}`,
-      JSON.stringify({
-        schemaVersion: "steward.provider-google.lifecycle.v1",
-        token: { access_token: "stranded-access", refresh_token: "stranded-refresh" },
-      }),
-    );
     const lifecycleId = crypto.randomUUID();
     await db.insert(providerGoogleCredentialLifecycles).values({
       id: lifecycleId,
@@ -515,7 +509,7 @@ describe("connect", () => {
       providerAccountId: beforeAccount.id,
       kind: "refresh_rotation",
       state: "needs_attention",
-      credentialSecretId: strandedHandle.id,
+      credentialSecretId: null,
       expectedAccountRevision: beforeAccount.revision,
       lastErrorCode: "REFRESH_OUTCOME_UNKNOWN",
     });
@@ -573,9 +567,7 @@ describe("connect", () => {
         .where(eq(providerGoogleCredentialLifecycles.id, lifecycleId));
       expect(superseded.state).toBe("superseded");
       expect(superseded.credentialSecretId).toBeNull();
-      expect(await db.select().from(secrets).where(eq(secrets.id, strandedHandle.id))).toHaveLength(
-        0,
-      );
+      expect(superseded.lastErrorCode).toBe("SUPERSEDED_BY_RECONNECT");
 
       const minted = await mintGoogleExecutionAccessToken({
         tenantId: TENANT,
@@ -595,6 +587,52 @@ describe("connect", () => {
     } finally {
       __setGoogleExecutionTokenForwarderForTests(null);
     }
+  });
+
+  test("reconnect preserves and rejects every unresolved staged refresh credential handle", async () => {
+    const first = await connectHappy(new MemoryConnectStore());
+    const db = getDb();
+    const [beforeAccount] = await db
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, first.completed.providerAccountId));
+    const strandedHandle = await vault.createSecret(
+      TENANT,
+      `provider-google-lifecycle:${crypto.randomUUID()}`,
+      JSON.stringify({
+        schemaVersion: "steward.provider-google.lifecycle.v1",
+        token: { access_token: "stranded-access", refresh_token: "stranded-refresh" },
+      }),
+    );
+    const lifecycleId = crypto.randomUUID();
+    await db.insert(providerGoogleCredentialLifecycles).values({
+      id: lifecycleId,
+      tenantId: TENANT,
+      workspaceId: WORKSPACE,
+      providerAccountId: beforeAccount.id,
+      kind: "refresh_rotation",
+      state: "needs_attention",
+      credentialSecretId: strandedHandle.id,
+      expectedAccountRevision: beforeAccount.revision,
+      lastErrorCode: "REFRESH_OUTCOME_UNKNOWN",
+    });
+
+    await expect(connectHappy(new MemoryConnectStore())).rejects.toMatchObject({
+      code: "GOOGLE_CREDENTIAL_NEEDS_ATTENTION",
+    });
+
+    const [unchangedLifecycle] = await db
+      .select()
+      .from(providerGoogleCredentialLifecycles)
+      .where(eq(providerGoogleCredentialLifecycles.id, lifecycleId));
+    const [unchangedAccount] = await db
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, beforeAccount.id));
+    expect(unchangedLifecycle.state).toBe("needs_attention");
+    expect(unchangedLifecycle.credentialSecretId).toBe(strandedHandle.id);
+    expect(unchangedAccount.revision).toBe(beforeAccount.revision);
+    expect(await vault.decryptSecret(TENANT, strandedHandle.id)).toContain("stranded-refresh");
   });
 
   test("injected initial persistence failure rolls back secret/account and revokes issued grant", async () => {

--- a/packages/api/src/services/provider-google-connect.ts
+++ b/packages/api/src/services/provider-google-connect.ts
@@ -1125,6 +1125,8 @@ async function persistConnectedAccount(input: PersistInput): Promise<CompleteCon
             id: providerGoogleCredentialLifecycles.id,
             state: providerGoogleCredentialLifecycles.state,
             credentialSecretId: providerGoogleCredentialLifecycles.credentialSecretId,
+            expectedAccountRevision: providerGoogleCredentialLifecycles.expectedAccountRevision,
+            lastErrorCode: providerGoogleCredentialLifecycles.lastErrorCode,
           })
           .from(providerGoogleCredentialLifecycles)
           .where(
@@ -1144,6 +1146,26 @@ async function persistConnectedAccount(input: PersistInput): Promise<CompleteCon
           .orderBy(asc(providerGoogleCredentialLifecycles.createdAt))
           .for("update")
       : [];
+    const supersedableRefreshes = account
+      ? unresolvedRefreshes.filter(
+          (row) =>
+            row.state === "needs_attention" &&
+            row.credentialSecretId === null &&
+            row.lastErrorCode === "REFRESH_OUTCOME_UNKNOWN" &&
+            row.expectedAccountRevision !== null &&
+            row.expectedAccountRevision <= account.revision,
+        )
+      : [];
+    if (supersedableRefreshes.length !== unresolvedRefreshes.length) {
+      // Never discard a staged/revocation handle: it may contain a live rotated
+      // provider credential and must be durably revoked first. A live inflight
+      // refresh must also finish or become outcome-unknown before reconnect.
+      throw new GoogleConnectError(
+        "GOOGLE_CREDENTIAL_NEEDS_ATTENTION",
+        409,
+        "previous Google refresh must be reconciled before reconnect",
+      );
+    }
 
     const [existingSecret] = await tx
       .select({ id: secrets.id })
@@ -1197,13 +1219,12 @@ async function persistConnectedAccount(input: PersistInput): Promise<CompleteCon
         );
       }
 
-      if (unresolvedRefreshes.length > 0) {
-        const unresolvedIds = unresolvedRefreshes.map(({ id }) => id);
+      if (supersedableRefreshes.length > 0) {
+        const unresolvedIds = supersedableRefreshes.map(({ id }) => id);
         const superseded = await tx
           .update(providerGoogleCredentialLifecycles)
           .set({
             state: "superseded",
-            credentialSecretId: null,
             lastErrorCode: "SUPERSEDED_BY_RECONNECT",
             updatedAt: new Date(),
           })
@@ -1214,29 +1235,18 @@ async function persistConnectedAccount(input: PersistInput): Promise<CompleteCon
               eq(providerGoogleCredentialLifecycles.providerAccountId, account.id),
               eq(providerGoogleCredentialLifecycles.kind, "refresh_rotation"),
               inArray(providerGoogleCredentialLifecycles.id, unresolvedIds),
-              inArray(providerGoogleCredentialLifecycles.state, [
-                "inflight",
-                "credential_staged",
-                "revocation_pending",
-                "needs_attention",
-              ]),
+              eq(providerGoogleCredentialLifecycles.state, "needs_attention"),
+              sql`${providerGoogleCredentialLifecycles.credentialSecretId} IS NULL`,
+              eq(providerGoogleCredentialLifecycles.lastErrorCode, "REFRESH_OUTCOME_UNKNOWN"),
             ),
           )
           .returning({ id: providerGoogleCredentialLifecycles.id });
-        if (superseded.length !== unresolvedRefreshes.length) {
+        if (superseded.length !== supersedableRefreshes.length) {
           throw new GoogleConnectError(
             "GOOGLE_CREDENTIAL_NEEDS_ATTENTION",
             409,
             "refresh lifecycle changed during reconnect",
           );
-        }
-        const handleIds = unresolvedRefreshes
-          .map(({ credentialSecretId }) => credentialSecretId)
-          .filter((id): id is string => id !== null);
-        if (handleIds.length > 0) {
-          await tx
-            .delete(secrets)
-            .where(and(eq(secrets.tenantId, input.tenantId), inArray(secrets.id, handleIds)));
         }
         await append({
           tenantId: input.tenantId,
@@ -1250,9 +1260,6 @@ async function persistConnectedAccount(input: PersistInput): Promise<CompleteCon
             priorAccountRevision: account.revision,
             newAccountRevision: account.revision + 1,
             lifecycleIds: [...unresolvedIds].sort(),
-            priorStates: unresolvedRefreshes
-              .map(({ id, state }) => ({ id, state }))
-              .sort((a, b) => a.id.localeCompare(b.id)),
           },
         });
       }


### PR DESCRIPTION
Closes #203

Post-merge corrective for #450.

## Summary

- allow reconnect supersession only for an exact needs_attention / REFRESH_OUTCOME_UNKNOWN refresh lifecycle with no encrypted credential handle
- reject reconnect for every inflight, staged, revocation-pending, or handle-bearing lifecycle until durable reconciliation completes
- never clear or delete a staged/revocation handle without an upstream revoke
- preserve safe null-handle recovery and restore execution minting after the new revision is installed

## Why #450 required correction

The merged path terminalized every unresolved refresh state and deleted each referenced vault secret. A credential_staged or revocation_pending handle can contain a live rotated provider credential; discarding it without upstream revocation loses the only durable reconciliation authority.

## Exact evidence

- head: 12393bc24ad4ca2922b631dcb241ccbd655778ab
- base: 2f9e86950dd1064ce6a4ae17ae976ad70559d8be
- exact repair semantics: Google connect + execution refresh 57/57, 224 assertions
- dependency-aware API/proxy graph: 24/24 builds
- final rebase imported only #452 webhook/log-sanitizer changes; repair commit is patch-identical
- Biome and diff-check: green

Keep draft until fresh exact-head hosted checks are green.