### PR TITLE
fix(audit): redact best-effort writer failures

### DIFF
--- a/packages/api/src/__tests__/audit-chain-strict.test.ts
+++ b/packages/api/src/__tests__/audit-chain-strict.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { closeDb, getDb, tenants } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { eq, sql } from "drizzle-orm";
-import { verifyAuditChain, writeAuditEvent } from "../services/audit";
+import { trackAuditEvent, verifyAuditChain, writeAuditEvent } from "../services/audit";
 
 const TENANT_ID = `audit-strict-${Date.now()}`;
 const EMPTY_TENANT_ID = `audit-strict-empty-${Date.now()}`;
@@ -98,5 +98,46 @@ describe("strict audit chain verification", () => {
       metadata: Record<string, unknown>;
     }>;
     expect(rows[0]?.metadata).toEqual({ absent: null, present: "yes" });
+  });
+
+  it("redacts thrown audit-writer diagnostics before best-effort logging", async () => {
+    const canary = "DATABASE_PASSWORD_AND_TOKEN_CANARY";
+    const metadata: Record<string, unknown> = {};
+    Object.defineProperty(metadata, "safe", {
+      enumerable: true,
+      get() {
+        throw new Error(canary);
+      },
+    });
+    const originalError = console.error;
+    const logged: unknown[][] = [];
+    let resolveLogged: (() => void) | undefined;
+    const logObserved = new Promise<void>((resolve) => {
+      resolveLogged = resolve;
+    });
+    console.error = (...args: unknown[]) => {
+      logged.push(args);
+      resolveLogged?.();
+    };
+    try {
+      trackAuditEvent({
+        tenantId: TENANT_ID,
+        actorType: "system",
+        action: "test.audit.redacted-failure",
+        metadata,
+      });
+      await Promise.race([
+        logObserved,
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error("audit failure was not logged")), 2_000),
+        ),
+      ]);
+    } finally {
+      console.error = originalError;
+    }
+
+    expect(JSON.stringify(logged)).not.toContain(canary);
+    expect(logged).toHaveLength(1);
+    expect(logged[0]?.[1]).toEqual({ errorClass: "Error", errorCode: null });
   });
 });

--- a/packages/api/src/services/audit.ts
+++ b/packages/api/src/services/audit.ts
@@ -27,7 +27,7 @@ import {
   withTenantAuditQueue,
   writeAuditEvent,
 } from "@stwd/db";
-import { observeAuditCheckpoint } from "@stwd/shared";
+import { observeAuditCheckpoint, redactedThrownDiagnostics } from "@stwd/shared";
 import { sql } from "drizzle-orm";
 import {
   type CheckpointEventContent,
@@ -219,7 +219,10 @@ function rowsFromExecute<T>(result: unknown): T[] {
  */
 export function trackAuditEvent(ev: AuditEventInput): void {
   writeAuditEvent(ev).catch((err) => {
-    console.error(`[audit] Failed to write event ${ev.action} for tenant ${ev.tenantId}:`, err);
+    console.error(
+      `[audit] Failed to write event ${ev.action} for tenant ${ev.tenantId}`,
+      redactedThrownDiagnostics(err),
+    );
   });
 }
 


### PR DESCRIPTION
## Security finding

The best-effort audit path logged the raw thrown database/canonicalization object. A hostile metadata getter or lower-layer failure could therefore place token, credential, or connection diagnostics into production logs.

This routes the failure through the shared bounded diagnostic sanitizer and logs only the error class plus an explicitly allowlisted platform error code. The regression injects a secret canary through a throwing metadata getter and proves it never reaches `console.error`.

## Exact-head evidence

- `bun test packages/api/src/__tests__/audit-chain-strict.test.ts`: 4 pass, 0 fail, 10 assertions
- `bunx turbo run build --filter=@stwd/api...`: 24/24 packages
- Biome: clean
- `git diff --check`: clean

Keep draft until exact-head CI is green.