### PR TITLE
fix(provider-x): recover rotating refresh outcomes

### DIFF
--- a/packages/api/src/__tests__/provider-x-connect.test.ts
+++ b/packages/api/src/__tests__/provider-x-connect.test.ts
@@ -856,7 +856,7 @@ describe("refresh", () => {
     expect(reconnected.completed.reconnected).toBe(true);
   });
 
-  test("failed staged revocation retains the exact handle and retries without refresh", async () => {
+  test("non-200 2xx revocation retains the exact handle and retries without refresh", async () => {
     const { completed } = await connectHappy(new MemoryConnectStore());
     const invalid = installFakeX({
       refreshResponses: [
@@ -869,7 +869,7 @@ describe("refresh", () => {
           },
         },
       ],
-      revokeStatuses: [503, 200],
+      revokeStatuses: [202, 200],
     });
     await expect(
       refreshXProviderCredential({
@@ -1357,11 +1357,14 @@ test("XConnectError carries code + http status", () => {
 
 test("real X transport rejects oversized provider responses before parsing", async () => {
   const originalFetch = globalThis.fetch;
-  globalThis.fetch = (async () =>
-    new Response("{}", {
+  let redirect: RequestRedirect | undefined;
+  globalThis.fetch = (async (_input, init) => {
+    redirect = init?.redirect;
+    return new Response("{}", {
       status: 200,
       headers: { "content-type": "application/json", "content-length": "1048577" },
-    })) as typeof fetch;
+    });
+  }) as typeof fetch;
   try {
     await expect(
       __runDefaultXForwardForTests({
@@ -1370,6 +1373,7 @@ test("real X transport rejects oversized provider responses before parsing", asy
         headers: { accept: "application/json" },
       }),
     ).rejects.toThrow("X provider response exceeded maximum size");
+    expect(redirect).toBe("error");
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/packages/api/src/__tests__/provider-x-connect.test.ts
+++ b/packages/api/src/__tests__/provider-x-connect.test.ts
@@ -1253,7 +1253,53 @@ describe("refresh", () => {
       .select()
       .from(providerAccounts)
       .where(eq(providerAccounts.id, completed.providerAccountId));
-    expect(account.status).toBe("disabled");
+    expect(account.status).toBe("revoked");
+    const [lifecycle] = await getDb()
+      .select()
+      .from(providerXCredentialLifecycles)
+      .where(eq(providerXCredentialLifecycles.providerAccountId, completed.providerAccountId));
+    expect(lifecycle).toMatchObject({
+      state: "revoked",
+      credentialSecretId: null,
+      lastErrorCode: "ROTATED_GRANT_REVOKED_AFTER_STAGING_FAILURE",
+    });
+    fake.restore();
+
+    const reconnected = await connectHappy(new MemoryConnectStore());
+    expect(reconnected.completed.providerAccountId).toBe(completed.providerAccountId);
+  });
+
+  test("blocks reconnect when a rotated grant cannot be staged or confirmed revoked", async () => {
+    const { completed } = await connectHappy(new MemoryConnectStore());
+    const fake = installFakeX({ revokeStatuses: [503] });
+    const originalCreate = vault.createSecretWithinTx;
+    Object.defineProperty(vault, "createSecretWithinTx", {
+      configurable: true,
+      value: async (...args: Parameters<typeof originalCreate>) => {
+        if (String(args[2]).startsWith("provider-x-lifecycle:")) {
+          throw new Error("simulated encrypted staging failure");
+        }
+        return originalCreate.apply(vault, args);
+      },
+    });
+    try {
+      await expect(
+        refreshXProviderCredential({
+          tenantId: TENANT,
+          workspaceId: WORKSPACE,
+          accountId: completed.providerAccountId,
+          vault,
+          config: CONFIG,
+          force: true,
+        }),
+      ).rejects.toThrow("simulated encrypted staging failure");
+    } finally {
+      Object.defineProperty(vault, "createSecretWithinTx", {
+        configurable: true,
+        value: originalCreate,
+      });
+    }
+    expect(fake.counters).toMatchObject({ refresh: 1, revoke: 1 });
     const [lifecycle] = await getDb()
       .select()
       .from(providerXCredentialLifecycles)
@@ -1261,12 +1307,13 @@ describe("refresh", () => {
     expect(lifecycle).toMatchObject({
       state: "needs_attention",
       credentialSecretId: null,
-      lastErrorCode: "REFRESH_OUTCOME_UNKNOWN",
+      lastErrorCode: "REFRESH_RESPONSE_STAGING_FAILED",
     });
     fake.restore();
 
-    const reconnected = await connectHappy(new MemoryConnectStore());
-    expect(reconnected.completed.providerAccountId).toBe(completed.providerAccountId);
+    await expect(connectHappy(new MemoryConnectStore())).rejects.toMatchObject({
+      code: "X_CREDENTIAL_NEEDS_ATTENTION",
+    });
   });
 
   test("the autonomous sweep fails closed a crashed pre-provider intent", async () => {

--- a/packages/api/src/__tests__/provider-x-connect.test.ts
+++ b/packages/api/src/__tests__/provider-x-connect.test.ts
@@ -188,7 +188,7 @@ function installFakeX(opts: FakeXOptions = {}): {
       counters.identity += 1;
       const status = opts.identityStatus ?? 200;
       if (status !== 200) return jsonResponse(status, {});
-      const identity = opts.identity ?? { id: "x-user-123", username: "solsundial", name: "Sol" };
+      const identity = opts.identity ?? { id: "1234567890", username: "solsundial", name: "Sol" };
       return jsonResponse(200, { data: identity });
     }
     if (req.url.includes("/oauth2/revoke")) {
@@ -396,7 +396,7 @@ describe("connect", () => {
     const store = new MemoryConnectStore();
     const { completed } = await connectHappy(store);
     expect(completed.reconnected).toBe(false);
-    expect(completed.xUserId).toBe("x-user-123");
+    expect(completed.xUserId).toBe("1234567890");
     expect(completed.xUsername).toBe("solsundial");
     expect(completed.credentialVersion).toBe(1);
 
@@ -406,7 +406,7 @@ describe("connect", () => {
       .from(providerAccounts)
       .where(eq(providerAccounts.id, completed.providerAccountId));
     expect(acct.adapterKey).toBe(X_ADAPTER_KEY);
-    expect(acct.externalRef).toBe("x-user-123");
+    expect(acct.externalRef).toBe("1234567890");
     expect(acct.displayName).toBe("@solsundial");
     expect(acct.status).toBe("active");
     expect(acct.credentialSecretId).toBeTruthy();
@@ -415,7 +415,7 @@ describe("connect", () => {
     const cred = await decryptCredential(completed.providerAccountId);
     expect(cred.accessToken).toBe("access-initial");
     expect(cred.refreshToken).toBe("refresh-initial");
-    expect(cred.xUserId).toBe("x-user-123");
+    expect(cred.xUserId).toBe("1234567890");
 
     const events = await readAuditActions(TENANT);
     expect(events.includes("provider.x.connect.completed")).toBe(true);
@@ -441,7 +441,7 @@ describe("connect", () => {
         and(
           eq(providerAccounts.tenantId, TENANT),
           eq(providerAccounts.adapterKey, X_ADAPTER_KEY),
-          eq(providerAccounts.externalRef, "x-user-123"),
+          eq(providerAccounts.externalRef, "1234567890"),
         ),
       );
     expect(rows.length).toBe(1);
@@ -588,7 +588,7 @@ describe("connect state validation", () => {
     fake.restore();
   });
 
-  test("token exchange failure does NOT consume the state (retryable)", async () => {
+  test("claims state before token exchange so a failed callback cannot be replayed", async () => {
     const store = new MemoryConnectStore();
     const failing = installFakeX({ exchangeStatus: 400 });
     const initiated = await initiateXConnect({
@@ -614,12 +614,126 @@ describe("connect state validation", () => {
     await expect(completeXConnect(args)).rejects.toMatchObject({
       code: "X_TOKEN_EXCHANGE_FAILED",
     });
+    expect(failing.counters.exchange).toBe(1);
     failing.restore();
-    // The state must still be present for a retry.
+    // Security-fail-closed: retrying requires a fresh connect attempt. Keeping
+    // the state live would let two replicas exchange one code and orphan the
+    // losing callback's newly issued grant.
     const ok = installFakeX();
-    const retried = await completeXConnect(args);
-    expect(retried.xUserId).toBe("x-user-123");
+    await expect(completeXConnect(args)).rejects.toMatchObject({ code: "X_STATE_INVALID" });
+    expect(ok.counters.exchange).toBe(0);
     ok.restore();
+  });
+
+  test("rejects malformed or oversized connect tokens before decoding", async () => {
+    const store = new MemoryConnectStore();
+    const fake = installFakeX();
+    const initiated = await initiateXConnect({
+      tenantId: TENANT,
+      workspaceId: WORKSPACE,
+      initiatedByUserId: ADMIN,
+      redirectUri: REDIRECT,
+      config: CONFIG,
+      store,
+    });
+    for (const connectToken of ["A".repeat(1025), `${initiated.connectToken}=`, "***"]) {
+      await expect(
+        completeXConnect({
+          tenantId: TENANT,
+          workspaceId: WORKSPACE,
+          callerUserId: ADMIN,
+          code: "auth-code",
+          state: initiated.state,
+          connectToken,
+          redirectUri: REDIRECT,
+          config: CONFIG,
+          store,
+          vault,
+        }),
+      ).rejects.toMatchObject({ code: "X_PKCE_MISMATCH" });
+    }
+    expect(fake.counters.exchange).toBe(0);
+    fake.restore();
+  });
+
+  test("rejects malformed provider identities before persistence", async () => {
+    for (const identity of [
+      { id: "not-numeric", username: "valid_name", name: "Name" },
+      { id: "1".repeat(33), username: "valid_name", name: "Name" },
+      { id: "123", username: "bad-name", name: "Name" },
+      { id: "123", username: "valid_name", name: "Name\nInjected" },
+    ]) {
+      const store = new MemoryConnectStore();
+      const fake = installFakeX({ identity });
+      const initiated = await initiateXConnect({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        initiatedByUserId: ADMIN,
+        redirectUri: REDIRECT,
+        config: CONFIG,
+        store,
+      });
+      await expect(
+        completeXConnect({
+          tenantId: TENANT,
+          workspaceId: WORKSPACE,
+          callerUserId: ADMIN,
+          code: "auth-code",
+          state: initiated.state,
+          connectToken: initiated.connectToken,
+          redirectUri: REDIRECT,
+          config: CONFIG,
+          store,
+          vault,
+        }),
+      ).rejects.toMatchObject({ code: "X_IDENTITY_FAILED" });
+      expect(fake.counters.identity).toBe(1);
+      expect(fake.counters.revoke).toBe(1);
+      fake.restore();
+    }
+  });
+
+  test("revokes the new grant when reconnect persistence fails", async () => {
+    const { completed } = await connectHappy(new MemoryConnectStore());
+    await getDb().insert(providerXCredentialLifecycles).values({
+      tenantId: TENANT,
+      workspaceId: WORKSPACE,
+      providerAccountId: completed.providerAccountId,
+      state: "inflight",
+      expectedAccountRevision: 1,
+    });
+
+    const store = new MemoryConnectStore();
+    const fake = installFakeX();
+    const initiated = await initiateXConnect({
+      tenantId: TENANT,
+      workspaceId: WORKSPACE,
+      initiatedByUserId: ADMIN,
+      redirectUri: REDIRECT,
+      config: CONFIG,
+      store,
+    });
+    await expect(
+      completeXConnect({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        callerUserId: ADMIN,
+        code: "auth-code",
+        state: initiated.state,
+        connectToken: initiated.connectToken,
+        redirectUri: REDIRECT,
+        config: CONFIG,
+        store,
+        vault,
+      }),
+    ).rejects.toMatchObject({ code: "X_CREDENTIAL_NEEDS_ATTENTION" });
+    expect(fake.counters).toMatchObject({ exchange: 1, identity: 1, revoke: 1 });
+    const [account] = await getDb()
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, completed.providerAccountId));
+    expect(account.credentialVersion).toBe(1);
+    fake.restore();
   });
 
   test("rejects malformed token endpoint credentials before identity fetch or persistence", async () => {
@@ -666,6 +780,67 @@ describe("connect state validation", () => {
 
 // ── Refresh: rotation, single-flight, revoke ──────────────────────────────────
 describe("refresh", () => {
+  test("rejects a credential secret whose X identity does not match the account", async () => {
+    const { completed } = await connectHappy(new MemoryConnectStore());
+    const current = await decryptCredential(completed.providerAccountId);
+    const wrong = await vault.createSecret(
+      TENANT,
+      "provider-x/wrong-account-binding",
+      JSON.stringify({ ...current, xUserId: "999999999" }),
+    );
+    await getDb()
+      .update(providerAccounts)
+      .set({ credentialSecretId: wrong.id, credentialVersion: wrong.version })
+      .where(eq(providerAccounts.id, completed.providerAccountId));
+    const fake = installFakeX();
+    await expect(
+      refreshXProviderCredential({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        accountId: completed.providerAccountId,
+        vault,
+        config: CONFIG,
+        force: true,
+      }),
+    ).rejects.toThrow("credential account binding mismatch");
+    expect(fake.counters.refresh).toBe(0);
+    fake.restore();
+  });
+
+  test("database constraints reject invalid lifecycle revision and secret-state shapes", async () => {
+    const { completed } = await connectHappy(new MemoryConnectStore());
+    const base = {
+      tenantId: TENANT,
+      workspaceId: WORKSPACE,
+      providerAccountId: completed.providerAccountId,
+    };
+    await expect(
+      Promise.resolve(
+        getDb()
+          .insert(providerXCredentialLifecycles)
+          .values({
+            ...base,
+            state: "inflight",
+            expectedAccountRevision: 0,
+          })
+          .returning(),
+      ),
+    ).rejects.toThrow();
+    await expect(
+      Promise.resolve(
+        getDb()
+          .insert(providerXCredentialLifecycles)
+          .values({
+            ...base,
+            state: "credential_staged",
+            expectedAccountRevision: 1,
+            credentialSecretId: null,
+          })
+          .returning(),
+      ),
+    ).rejects.toThrow();
+  });
+
   test("force refresh rotates token to a new credential version + audit", async () => {
     const store = new MemoryConnectStore();
     const { completed } = await connectHappy(store);
@@ -833,7 +1008,7 @@ describe("refresh", () => {
     const swept = await runXCredentialLifecycleSweep({
       vault,
       config: CONFIG,
-      now: new Date(Date.now() + 20_000),
+      now: new Date(Date.now() + 70_000),
     });
     expect(swept).toMatchObject({ processed: 1, revoked: 1, attention: 0 });
     expect(revoker.counters.revoke).toBe(1);
@@ -890,7 +1065,7 @@ describe("refresh", () => {
     const first = await runXCredentialLifecycleSweep({
       vault,
       config: CONFIG,
-      now: new Date(Date.now() + 20_000),
+      now: new Date(Date.now() + 70_000),
     });
     expect(first).toMatchObject({ processed: 1, revoked: 0, attention: 1 });
     const [retained] = await getDb()
@@ -903,7 +1078,7 @@ describe("refresh", () => {
     const second = await runXCredentialLifecycleSweep({
       vault,
       config: CONFIG,
-      now: new Date(Date.now() + 40_000),
+      now: new Date(Date.now() + 140_000),
     });
     expect(second).toMatchObject({ processed: 1, revoked: 1, attention: 0 });
     expect(invalid.counters).toMatchObject({ refresh: 1, revoke: 2 });
@@ -945,7 +1120,7 @@ describe("refresh", () => {
     const swept = await runXCredentialLifecycleSweep({
       vault,
       config: CONFIG,
-      now: new Date(Date.now() + 20_000),
+      now: new Date(Date.now() + 70_000),
     });
     expect(swept).toMatchObject({ processed: 1, revoked: 1, attention: 0 });
     expect(fake.counters.refresh).toBe(1);
@@ -1043,6 +1218,57 @@ describe("refresh", () => {
     expect(events).toContain("provider.x.refresh.superseded_by_reconnect");
   });
 
+  test("revokes a rotated grant held in memory when encrypted staging fails", async () => {
+    const { completed } = await connectHappy(new MemoryConnectStore());
+    const fake = installFakeX({ revokeStatuses: [200] });
+    const originalCreate = vault.createSecretWithinTx;
+    Object.defineProperty(vault, "createSecretWithinTx", {
+      configurable: true,
+      value: async (...args: Parameters<typeof originalCreate>) => {
+        if (String(args[2]).startsWith("provider-x-lifecycle:")) {
+          throw new Error("simulated encrypted staging failure");
+        }
+        return originalCreate.apply(vault, args);
+      },
+    });
+    try {
+      await expect(
+        refreshXProviderCredential({
+          tenantId: TENANT,
+          workspaceId: WORKSPACE,
+          accountId: completed.providerAccountId,
+          vault,
+          config: CONFIG,
+          force: true,
+        }),
+      ).rejects.toThrow("simulated encrypted staging failure");
+    } finally {
+      Object.defineProperty(vault, "createSecretWithinTx", {
+        configurable: true,
+        value: originalCreate,
+      });
+    }
+    expect(fake.counters).toMatchObject({ refresh: 1, revoke: 1 });
+    const [account] = await getDb()
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, completed.providerAccountId));
+    expect(account.status).toBe("disabled");
+    const [lifecycle] = await getDb()
+      .select()
+      .from(providerXCredentialLifecycles)
+      .where(eq(providerXCredentialLifecycles.providerAccountId, completed.providerAccountId));
+    expect(lifecycle).toMatchObject({
+      state: "needs_attention",
+      credentialSecretId: null,
+      lastErrorCode: "REFRESH_OUTCOME_UNKNOWN",
+    });
+    fake.restore();
+
+    const reconnected = await connectHappy(new MemoryConnectStore());
+    expect(reconnected.completed.providerAccountId).toBe(completed.providerAccountId);
+  });
+
   test("the autonomous sweep fails closed a crashed pre-provider intent", async () => {
     const store = new MemoryConnectStore();
     const { completed } = await connectHappy(store);
@@ -1074,7 +1300,7 @@ describe("refresh", () => {
     const swept = await runXCredentialLifecycleSweep({
       vault,
       config: CONFIG,
-      now: new Date(Date.now() + 20_000),
+      now: new Date(Date.now() + 70_000),
     });
     expect(swept).toMatchObject({ processed: 1, adopted: 0, attention: 1 });
     const [account] = await getDb()
@@ -1157,6 +1383,53 @@ describe("refresh", () => {
 
     const cred = await decryptCredential(completed.providerAccountId);
     expect(cred.accessToken).toBe("access-refreshed-1");
+    fake.restore();
+  });
+
+  test("a slow healthy refresh is not disabled by a concurrent waiter timeout", async () => {
+    const { completed } = await connectHappy(new MemoryConnectStore(), {
+      exchangeToken: { expires_in: 1 },
+    });
+    const fake = installFakeX({
+      refreshResponses: [
+        {
+          status: 200,
+          delayMs: 2_500,
+          body: {
+            access_token: "access-slow-winner",
+            refresh_token: "refresh-slow-winner",
+            scope: "tweet.read tweet.write users.read offline.access",
+            expires_in: 7200,
+          },
+        },
+      ],
+    });
+    const input = {
+      tenantId: TENANT,
+      workspaceId: WORKSPACE,
+      accountId: completed.providerAccountId,
+      vault,
+      config: CONFIG,
+    } as const;
+    const results = await Promise.allSettled([
+      refreshXProviderCredential(input),
+      refreshXProviderCredential(input),
+    ]);
+    expect(fake.counters.refresh).toBe(1);
+    expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    const rejected = results.find((result) => result.status === "rejected");
+    expect(rejected).toMatchObject({
+      status: "rejected",
+      reason: { code: "X_REFRESH_FAILED", httpStatus: 409 },
+    });
+    const [account] = await getDb()
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, completed.providerAccountId));
+    expect(account.status).toBe("active");
+    expect((await decryptCredential(completed.providerAccountId)).refreshToken).toBe(
+      "refresh-slow-winner",
+    );
     fake.restore();
   });
 
@@ -1346,7 +1619,7 @@ describe("disconnect", () => {
 
 // ── Sanity: secret lineage name is deterministic per (workspace, x user) ──────
 test("credential secret name is stable per workspace+x user (reconnect lineage)", () => {
-  expect(xCredentialSecretName(WORKSPACE, "x-user-123")).toBe(`provider-x/${WORKSPACE}/x-user-123`);
+  expect(xCredentialSecretName(WORKSPACE, "1234567890")).toBe(`provider-x/${WORKSPACE}/1234567890`);
 });
 
 test("XConnectError carries code + http status", () => {
@@ -1374,6 +1647,28 @@ test("real X transport rejects oversized provider responses before parsing", asy
       }),
     ).rejects.toThrow("X provider response exceeded maximum size");
     expect(redirect).toBe("error");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("real X transport refuses redirects before credentials can be replayed", async () => {
+  const originalFetch = globalThis.fetch;
+  let redirectMode: RequestRedirect | undefined;
+  globalThis.fetch = (async (_input, init) => {
+    redirectMode = init?.redirect;
+    throw new TypeError("redirect blocked");
+  }) as typeof fetch;
+  try {
+    await expect(
+      __runDefaultXForwardForTests({
+        url: "https://api.x.com/2/oauth2/token",
+        method: "POST",
+        headers: { authorization: "Basic secret-canary" },
+        body: "refresh_token=refresh-secret-canary",
+      }),
+    ).rejects.toThrow("redirect blocked");
+    expect(redirectMode).toBe("error");
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/packages/api/src/__tests__/provider-x-connect.test.ts
+++ b/packages/api/src/__tests__/provider-x-connect.test.ts
@@ -24,6 +24,7 @@ import {
   getDb,
   providerAccounts,
   providerRoleBindings,
+  providerXCredentialLifecycles,
   secrets,
   tenants,
   users,
@@ -36,12 +37,15 @@ import { and, eq } from "drizzle-orm";
 import { providerAuthorityStore } from "../services/provider-authority-store";
 import {
   __runDefaultXForwardForTests,
+  __setAfterXCredentialStageForTests,
+  __setAfterXRefreshIntentForTests,
   __setXForwardForTests,
   completeXConnect,
   disconnectXProviderCredential,
   initiateXConnect,
   type PendingConnectStore,
   refreshXProviderCredential,
+  runXCredentialLifecycleSweep,
   X_ADAPTER_KEY,
   XConnectError,
   type XCredentialPayload,
@@ -116,6 +120,7 @@ interface FakeXOptions {
     access_token: string;
     refresh_token: string;
     scope: string;
+    token_type: string;
     expires_in: number;
   }>;
   exchangeStatus?: number;
@@ -285,6 +290,8 @@ afterAll(async () => {
 
 afterEach(async () => {
   __setXForwardForTests(null);
+  __setAfterXCredentialStageForTests(null);
+  __setAfterXRefreshIntentForTests(null);
   // Reset connected accounts + credential secrets between tests.
   const db = getDb();
   await db.delete(providerAccounts).where(eq(providerAccounts.tenantId, TENANT));
@@ -613,6 +620,9 @@ describe("connect state validation", () => {
       { refresh_token: "" },
       { refresh_token: "refresh\rcontrol" },
       { refresh_token: "r".repeat(16_385) },
+      { token_type: "mac" },
+      { expires_in: Number.NaN },
+      { scope: "tweet.read admin.write" },
     ]) {
       const store = new MemoryConnectStore();
       const fake = installFakeX({ exchangeToken });
@@ -672,14 +682,28 @@ describe("refresh", () => {
     expect(events.includes("provider.x.refresh.completed")).toBe(true);
   });
 
-  test("rejects malformed refresh credentials without rotating the stored secret", async () => {
+  test("malformed rotating responses disable the account, retain an encrypted handle, and never replay", async () => {
     for (const body of [
       { access_token: "bad token", refresh_token: "refresh-valid" },
       { access_token: "access-valid", refresh_token: "r".repeat(16_385) },
+      {
+        access_token: "access-valid",
+        refresh_token: "refresh-valid",
+        scope: "tweet.read offline.access admin.write",
+      },
+      {
+        access_token: "access-valid",
+        refresh_token: "refresh-valid",
+        expires_in: "7200",
+      },
+      {
+        access_token: "access-valid",
+        refresh_token: "refresh-valid",
+        token_type: "mac",
+      },
     ]) {
       const store = new MemoryConnectStore();
       const { completed } = await connectHappy(store);
-      const before = await decryptCredential(completed.providerAccountId);
       const fake = installFakeX({ refreshResponses: [{ status: 200, body }] });
       await expect(
         refreshXProviderCredential({
@@ -691,12 +715,229 @@ describe("refresh", () => {
           force: true,
         }),
       ).rejects.toMatchObject({ code: "X_REFRESH_FAILED" });
-      const after = await decryptCredential(completed.providerAccountId);
-      expect(after).toEqual(before);
+      expect(fake.counters.refresh).toBe(1);
+      const db = getDb();
+      const [account] = await db
+        .select()
+        .from(providerAccounts)
+        .where(eq(providerAccounts.id, completed.providerAccountId));
+      expect(account.status).toBe("disabled");
+      const [lifecycle] = await db
+        .select()
+        .from(providerXCredentialLifecycles)
+        .where(
+          and(
+            eq(providerXCredentialLifecycles.tenantId, TENANT),
+            eq(providerXCredentialLifecycles.providerAccountId, completed.providerAccountId),
+          ),
+        );
+      expect(lifecycle.state).toBe("needs_attention");
+      expect(lifecycle.credentialSecretId).toBeTruthy();
+      expect(JSON.stringify(lifecycle)).not.toContain("refresh-valid");
+      expect(await vault.decryptSecret(TENANT, lifecycle.credentialSecretId as string)).toContain(
+        '"schemaVersion":"steward.provider-x.lifecycle.v1"',
+      );
+      await expect(
+        refreshXProviderCredential({
+          tenantId: TENANT,
+          workspaceId: WORKSPACE,
+          accountId: completed.providerAccountId,
+          vault,
+          config: CONFIG,
+          force: true,
+        }),
+      ).rejects.toMatchObject({ code: "X_REFRESH_REVOKED" });
+      expect(fake.counters.refresh).toBe(1);
       fake.restore();
-      await getDb().delete(providerAccounts).where(eq(providerAccounts.tenantId, TENANT));
-      await getDb().delete(secrets).where(eq(secrets.tenantId, TENANT));
+      await db.delete(providerAccounts).where(eq(providerAccounts.tenantId, TENANT));
+      await db.delete(secrets).where(eq(secrets.tenantId, TENANT));
     }
+  });
+
+  test("reconnect supersedes an unresolved rotation and restores refresh without replay", async () => {
+    const store = new MemoryConnectStore();
+    const { completed } = await connectHappy(store);
+    const invalid = installFakeX({
+      refreshResponses: [
+        {
+          status: 200,
+          body: {
+            access_token: "bad token",
+            refresh_token: "rotated-one-time-refresh",
+            scope: "tweet.read tweet.write users.read offline.access",
+            expires_in: 7200,
+          },
+        },
+      ],
+    });
+    await expect(
+      refreshXProviderCredential({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        accountId: completed.providerAccountId,
+        vault,
+        config: CONFIG,
+        force: true,
+      }),
+    ).rejects.toMatchObject({ code: "X_REFRESH_FAILED" });
+    expect(invalid.counters.refresh).toBe(1);
+
+    const db = getDb();
+    const [pending] = await db
+      .select()
+      .from(providerXCredentialLifecycles)
+      .where(eq(providerXCredentialLifecycles.providerAccountId, completed.providerAccountId));
+    expect(pending.state).toBe("needs_attention");
+    const stagedSecretId = pending.credentialSecretId as string;
+
+    const reconnectStore = new MemoryConnectStore();
+    const reconnected = await connectHappy(reconnectStore);
+    expect(reconnected.completed.providerAccountId).toBe(completed.providerAccountId);
+    const [superseded] = await db
+      .select()
+      .from(providerXCredentialLifecycles)
+      .where(eq(providerXCredentialLifecycles.id, pending.id));
+    expect(superseded.state).toBe("superseded");
+    expect(superseded.credentialSecretId).toBeNull();
+    const [deletedHandle] = await db
+      .select({ id: secrets.id })
+      .from(secrets)
+      .where(eq(secrets.id, stagedSecretId));
+    expect(deletedHandle).toBeUndefined();
+
+    const refreshed = installFakeX();
+    const result = await refreshXProviderCredential({
+      tenantId: TENANT,
+      workspaceId: WORKSPACE,
+      accountId: completed.providerAccountId,
+      vault,
+      config: CONFIG,
+      force: true,
+    });
+    expect(result.refreshed).toBe(true);
+    expect(refreshed.counters.refresh).toBe(1);
+    expect(invalid.counters.refresh).toBe(1);
+    refreshed.restore();
+    invalid.restore();
+
+    const events = await readAuditActions(TENANT);
+    expect(events).toContain("provider.x.refresh.superseded_by_reconnect");
+  });
+
+  test("a crash after encrypted staging adopts on retry without a second provider call", async () => {
+    const store = new MemoryConnectStore();
+    const { completed } = await connectHappy(store);
+    const fake = installFakeX();
+    const restoreCrash = __setAfterXCredentialStageForTests(async () => {
+      throw new Error("simulated process exit after durable stage");
+    });
+    const input = {
+      tenantId: TENANT,
+      workspaceId: WORKSPACE,
+      accountId: completed.providerAccountId,
+      vault,
+      config: CONFIG,
+      force: true,
+    } as const;
+    await expect(refreshXProviderCredential(input)).rejects.toThrow("simulated process exit");
+    expect(fake.counters.refresh).toBe(1);
+    restoreCrash();
+
+    const recovered = await refreshXProviderCredential(input);
+    expect(recovered.credentialVersion).toBe(2);
+    expect(fake.counters.refresh).toBe(1);
+    const credential = await decryptCredential(completed.providerAccountId);
+    expect(credential.refreshToken).toBe("refresh-rotated-1");
+    const [lifecycle] = await getDb()
+      .select()
+      .from(providerXCredentialLifecycles)
+      .where(eq(providerXCredentialLifecycles.providerAccountId, completed.providerAccountId));
+    expect(lifecycle.state).toBe("adopted");
+    expect(lifecycle.credentialSecretId).toBeNull();
+    fake.restore();
+  });
+
+  test("an ambiguous provider outcome disables the account and cannot replay the old token", async () => {
+    const store = new MemoryConnectStore();
+    const { completed } = await connectHappy(store);
+    let refreshCalls = 0;
+    const restore = __setXForwardForTests(async (request) => {
+      if (request.url === "https://api.x.com/2/oauth2/token") {
+        refreshCalls += 1;
+        throw new Error("connection lost after provider accepted rotation");
+      }
+      throw new Error("unexpected request");
+    });
+    const input = {
+      tenantId: TENANT,
+      workspaceId: WORKSPACE,
+      accountId: completed.providerAccountId,
+      vault,
+      config: CONFIG,
+      force: true,
+    } as const;
+    await expect(refreshXProviderCredential(input)).rejects.toThrow("connection lost");
+    expect(refreshCalls).toBe(1);
+    await expect(refreshXProviderCredential(input)).rejects.toMatchObject({
+      code: "X_REFRESH_REVOKED",
+    });
+    expect(refreshCalls).toBe(1);
+
+    const [account] = await getDb()
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, completed.providerAccountId));
+    expect(account.status).toBe("disabled");
+    const [lifecycle] = await getDb()
+      .select()
+      .from(providerXCredentialLifecycles)
+      .where(eq(providerXCredentialLifecycles.providerAccountId, completed.providerAccountId));
+    expect(lifecycle.state).toBe("needs_attention");
+    expect(lifecycle.credentialSecretId).toBeNull();
+    expect(lifecycle.lastErrorCode).toBe("REFRESH_OUTCOME_UNKNOWN");
+    restore();
+  });
+
+  test("the autonomous sweep fails closed a crashed pre-provider intent", async () => {
+    const store = new MemoryConnectStore();
+    const { completed } = await connectHappy(store);
+    const fake = installFakeX();
+    const restoreCrash = __setAfterXRefreshIntentForTests(async () => {
+      throw new Error("simulated exit after durable intent");
+    });
+    const input = {
+      tenantId: TENANT,
+      workspaceId: WORKSPACE,
+      accountId: completed.providerAccountId,
+      vault,
+      config: CONFIG,
+      force: true,
+    } as const;
+    await expect(refreshXProviderCredential(input)).rejects.toThrow("simulated exit");
+    expect(fake.counters.refresh).toBe(0);
+    restoreCrash();
+
+    const swept = await runXCredentialLifecycleSweep({
+      vault,
+      now: new Date(Date.now() + 20_000),
+    });
+    expect(swept).toMatchObject({ processed: 1, adopted: 0, attention: 1 });
+    const [account] = await getDb()
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, completed.providerAccountId));
+    expect(account.status).toBe("disabled");
+    const [lifecycle] = await getDb()
+      .select()
+      .from(providerXCredentialLifecycles)
+      .where(eq(providerXCredentialLifecycles.providerAccountId, completed.providerAccountId));
+    expect(lifecycle.state).toBe("needs_attention");
+    expect(lifecycle.lastErrorCode).toBe("REFRESH_OUTCOME_UNKNOWN");
+    await expect(refreshXProviderCredential(input)).rejects.toMatchObject({
+      code: "X_REFRESH_REVOKED",
+    });
+    expect(fake.counters.refresh).toBe(0);
+    fake.restore();
   });
 
   test("SINGLE-FLIGHT: two concurrent refreshes of a near-expiry token make exactly ONE token call", async () => {

--- a/packages/api/src/__tests__/provider-x-connect.test.ts
+++ b/packages/api/src/__tests__/provider-x-connect.test.ts
@@ -139,13 +139,20 @@ interface FakeXCounters {
   identity: number;
   refresh: number;
   revoke: number;
+  revokeBodies: string[];
 }
 
 function installFakeX(opts: FakeXOptions = {}): {
   counters: FakeXCounters;
   restore: () => void;
 } {
-  const counters: FakeXCounters = { exchange: 0, identity: 0, refresh: 0, revoke: 0 };
+  const counters: FakeXCounters = {
+    exchange: 0,
+    identity: 0,
+    refresh: 0,
+    revoke: 0,
+    revokeBodies: [],
+  };
   let refreshIdx = 0;
   const fn = async (req: XForwardRequest): Promise<XForwardResponse> => {
     // Token endpoint: distinguish exchange vs refresh by grant_type.
@@ -186,6 +193,7 @@ function installFakeX(opts: FakeXOptions = {}): {
     }
     if (req.url.includes("/oauth2/revoke")) {
       counters.revoke += 1;
+      counters.revokeBodies.push(req.body ?? "");
       const status = opts.revokeStatuses?.[counters.revoke - 1] ?? 200;
       return jsonResponse(status, status === 200 ? {} : { error: "temporarily_unavailable" });
     }
@@ -906,6 +914,47 @@ describe("refresh", () => {
     expect(revoked.state).toBe("revoked");
     expect(revoked.credentialSecretId).toBeNull();
     invalid.restore();
+  });
+
+  test("revokes the exact bounded rotated refresh token even when adoption rejects its grammar", async () => {
+    const { completed } = await connectHappy(new MemoryConnectStore());
+    const invalidRefresh = "rotated refresh with spaces";
+    const fake = installFakeX({
+      refreshResponses: [
+        {
+          status: 200,
+          body: {
+            access_token: "access-valid",
+            refresh_token: invalidRefresh,
+            scope: "tweet.read tweet.write users.read offline.access",
+          },
+        },
+      ],
+    });
+    await expect(
+      refreshXProviderCredential({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        accountId: completed.providerAccountId,
+        vault,
+        config: CONFIG,
+        force: true,
+      }),
+    ).rejects.toMatchObject({ code: "X_REFRESH_FAILED" });
+
+    const swept = await runXCredentialLifecycleSweep({
+      vault,
+      config: CONFIG,
+      now: new Date(Date.now() + 20_000),
+    });
+    expect(swept).toMatchObject({ processed: 1, revoked: 1, attention: 0 });
+    expect(fake.counters.refresh).toBe(1);
+    expect(fake.counters.revoke).toBe(1);
+    expect(new URLSearchParams(fake.counters.revokeBodies[0]).get("token")).toBe(invalidRefresh);
+    expect(new URLSearchParams(fake.counters.revokeBodies[0]).get("token_type_hint")).toBe(
+      "refresh_token",
+    );
+    fake.restore();
   });
 
   test("a crash after encrypted staging adopts on retry without a second provider call", async () => {

--- a/packages/api/src/__tests__/provider-x-connect.test.ts
+++ b/packages/api/src/__tests__/provider-x-connect.test.ts
@@ -754,7 +754,7 @@ describe("refresh", () => {
     }
   });
 
-  test("reconnect supersedes an unresolved rotation and restores refresh without replay", async () => {
+  test("reconnect preserves a staged rotating credential until it is reconciled", async () => {
     const store = new MemoryConnectStore();
     const { completed } = await connectHappy(store);
     const invalid = installFakeX({
@@ -789,39 +789,35 @@ describe("refresh", () => {
       .where(eq(providerXCredentialLifecycles.providerAccountId, completed.providerAccountId));
     expect(pending.state).toBe("needs_attention");
     const stagedSecretId = pending.credentialSecretId as string;
+    const [accountBefore] = await db
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, completed.providerAccountId));
 
     const reconnectStore = new MemoryConnectStore();
-    const reconnected = await connectHappy(reconnectStore);
-    expect(reconnected.completed.providerAccountId).toBe(completed.providerAccountId);
-    const [superseded] = await db
+    await expect(connectHappy(reconnectStore)).rejects.toMatchObject({
+      code: "X_CREDENTIAL_NEEDS_ATTENTION",
+    });
+    const [preserved] = await db
       .select()
       .from(providerXCredentialLifecycles)
       .where(eq(providerXCredentialLifecycles.id, pending.id));
-    expect(superseded.state).toBe("superseded");
-    expect(superseded.credentialSecretId).toBeNull();
-    const [deletedHandle] = await db
+    expect(preserved.state).toBe("needs_attention");
+    expect(preserved.credentialSecretId).toBe(stagedSecretId);
+    const [retainedHandle] = await db
       .select({ id: secrets.id })
       .from(secrets)
       .where(eq(secrets.id, stagedSecretId));
-    expect(deletedHandle).toBeUndefined();
-
-    const refreshed = installFakeX();
-    const result = await refreshXProviderCredential({
-      tenantId: TENANT,
-      workspaceId: WORKSPACE,
-      accountId: completed.providerAccountId,
-      vault,
-      config: CONFIG,
-      force: true,
-    });
-    expect(result.refreshed).toBe(true);
-    expect(refreshed.counters.refresh).toBe(1);
+    expect(retainedHandle.id).toBe(stagedSecretId);
+    const [accountAfter] = await db
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, completed.providerAccountId));
+    expect(accountAfter.credentialSecretId).toBe(accountBefore.credentialSecretId);
+    expect(accountAfter.credentialVersion).toBe(accountBefore.credentialVersion);
+    expect(accountAfter.revision).toBe(accountBefore.revision);
     expect(invalid.counters.refresh).toBe(1);
-    refreshed.restore();
     invalid.restore();
-
-    const events = await readAuditActions(TENANT);
-    expect(events).toContain("provider.x.refresh.superseded_by_reconnect");
   });
 
   test("a crash after encrypted staging adopts on retry without a second provider call", async () => {
@@ -896,6 +892,18 @@ describe("refresh", () => {
     expect(lifecycle.credentialSecretId).toBeNull();
     expect(lifecycle.lastErrorCode).toBe("REFRESH_OUTCOME_UNKNOWN");
     restore();
+
+    const reconnectStore = new MemoryConnectStore();
+    const reconnected = await connectHappy(reconnectStore);
+    expect(reconnected.completed.providerAccountId).toBe(completed.providerAccountId);
+    const [superseded] = await getDb()
+      .select()
+      .from(providerXCredentialLifecycles)
+      .where(eq(providerXCredentialLifecycles.id, lifecycle.id));
+    expect(superseded.state).toBe("superseded");
+    expect(superseded.credentialSecretId).toBeNull();
+    const events = await readAuditActions(TENANT);
+    expect(events).toContain("provider.x.refresh.superseded_by_reconnect");
   });
 
   test("the autonomous sweep fails closed a crashed pre-provider intent", async () => {
@@ -916,6 +924,15 @@ describe("refresh", () => {
     await expect(refreshXProviderCredential(input)).rejects.toThrow("simulated exit");
     expect(fake.counters.refresh).toBe(0);
     restoreCrash();
+
+    await expect(connectHappy(new MemoryConnectStore())).rejects.toMatchObject({
+      code: "X_CREDENTIAL_NEEDS_ATTENTION",
+    });
+    const [stillInflight] = await getDb()
+      .select()
+      .from(providerXCredentialLifecycles)
+      .where(eq(providerXCredentialLifecycles.providerAccountId, completed.providerAccountId));
+    expect(stillInflight.state).toBe("inflight");
 
     const swept = await runXCredentialLifecycleSweep({
       vault,

--- a/packages/api/src/__tests__/provider-x-connect.test.ts
+++ b/packages/api/src/__tests__/provider-x-connect.test.ts
@@ -131,6 +131,7 @@ interface FakeXOptions {
     body: Record<string, unknown>;
     delayMs?: number;
   }>;
+  revokeStatuses?: number[];
 }
 
 interface FakeXCounters {
@@ -185,7 +186,8 @@ function installFakeX(opts: FakeXOptions = {}): {
     }
     if (req.url.includes("/oauth2/revoke")) {
       counters.revoke += 1;
-      return jsonResponse(200, {});
+      const status = opts.revokeStatuses?.[counters.revoke - 1] ?? 200;
+      return jsonResponse(status, status === 200 ? {} : { error: "temporarily_unavailable" });
     }
     throw new Error(`unexpected X call: ${req.url}`);
   };
@@ -754,7 +756,7 @@ describe("refresh", () => {
     }
   });
 
-  test("reconnect preserves a staged rotating credential until it is reconciled", async () => {
+  test("reconnect preserves a staged credential until autonomous exact-token revocation", async () => {
     const store = new MemoryConnectStore();
     const { completed } = await connectHappy(store);
     const invalid = installFakeX({
@@ -817,6 +819,92 @@ describe("refresh", () => {
     expect(accountAfter.credentialVersion).toBe(accountBefore.credentialVersion);
     expect(accountAfter.revision).toBe(accountBefore.revision);
     expect(invalid.counters.refresh).toBe(1);
+    invalid.restore();
+    const revoker = installFakeX();
+
+    const swept = await runXCredentialLifecycleSweep({
+      vault,
+      config: CONFIG,
+      now: new Date(Date.now() + 20_000),
+    });
+    expect(swept).toMatchObject({ processed: 1, revoked: 1, attention: 0 });
+    expect(revoker.counters.revoke).toBe(1);
+    expect(invalid.counters.refresh).toBe(1);
+    const [revoked] = await db
+      .select()
+      .from(providerXCredentialLifecycles)
+      .where(eq(providerXCredentialLifecycles.id, pending.id));
+    expect(revoked.state).toBe("revoked");
+    expect(revoked.credentialSecretId).toBeNull();
+    const [deletedHandle] = await db
+      .select({ id: secrets.id })
+      .from(secrets)
+      .where(eq(secrets.id, stagedSecretId));
+    expect(deletedHandle).toBeUndefined();
+    revoker.restore();
+
+    const reconnected = await connectHappy(new MemoryConnectStore());
+    expect(reconnected.completed.providerAccountId).toBe(completed.providerAccountId);
+    expect(reconnected.completed.reconnected).toBe(true);
+  });
+
+  test("failed staged revocation retains the exact handle and retries without refresh", async () => {
+    const { completed } = await connectHappy(new MemoryConnectStore());
+    const invalid = installFakeX({
+      refreshResponses: [
+        {
+          status: 200,
+          body: {
+            access_token: "access-valid",
+            refresh_token: "rotated-one-time-refresh",
+            scope: "tweet.read offline.access admin.write",
+          },
+        },
+      ],
+      revokeStatuses: [503, 200],
+    });
+    await expect(
+      refreshXProviderCredential({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        accountId: completed.providerAccountId,
+        vault,
+        config: CONFIG,
+        force: true,
+      }),
+    ).rejects.toMatchObject({ code: "X_REFRESH_FAILED" });
+    const [pending] = await getDb()
+      .select()
+      .from(providerXCredentialLifecycles)
+      .where(eq(providerXCredentialLifecycles.providerAccountId, completed.providerAccountId));
+    const handleId = pending.credentialSecretId as string;
+
+    const first = await runXCredentialLifecycleSweep({
+      vault,
+      config: CONFIG,
+      now: new Date(Date.now() + 20_000),
+    });
+    expect(first).toMatchObject({ processed: 1, revoked: 0, attention: 1 });
+    const [retained] = await getDb()
+      .select()
+      .from(providerXCredentialLifecycles)
+      .where(eq(providerXCredentialLifecycles.id, pending.id));
+    expect(retained.state).toBe("needs_attention");
+    expect(retained.credentialSecretId).toBe(handleId);
+
+    const second = await runXCredentialLifecycleSweep({
+      vault,
+      config: CONFIG,
+      now: new Date(Date.now() + 40_000),
+    });
+    expect(second).toMatchObject({ processed: 1, revoked: 1, attention: 0 });
+    expect(invalid.counters).toMatchObject({ refresh: 1, revoke: 2 });
+    const [revoked] = await getDb()
+      .select()
+      .from(providerXCredentialLifecycles)
+      .where(eq(providerXCredentialLifecycles.id, pending.id));
+    expect(revoked.state).toBe("revoked");
+    expect(revoked.credentialSecretId).toBeNull();
     invalid.restore();
   });
 
@@ -936,6 +1024,7 @@ describe("refresh", () => {
 
     const swept = await runXCredentialLifecycleSweep({
       vault,
+      config: CONFIG,
       now: new Date(Date.now() + 20_000),
     });
     expect(swept).toMatchObject({ processed: 1, adopted: 0, attention: 1 });

--- a/packages/api/src/__tests__/worker-runtime-sentinel.test.ts
+++ b/packages/api/src/__tests__/worker-runtime-sentinel.test.ts
@@ -3,6 +3,7 @@ import {
   hydrateProcessEnv,
   runWorkerGoogleCredentialLifecycleSweep,
   runWorkerUpstreamCredentialLeaseSweep,
+  runWorkerXCredentialLifecycleSweep,
 } from "../worker";
 
 test("Worker hydration cannot be overridden by a STEWARD_RUNTIME binding", () => {
@@ -69,4 +70,42 @@ test("Worker cron runs Google lifecycle recovery when provider credentials are c
   );
   expect(calls).toBe(1);
   expect(result).toEqual({ processed: 2, adopted: 1, revoked: 1, attention: 0, remaining: false });
+});
+
+test("Worker cron runs X lifecycle recovery when provider credentials are configured", async () => {
+  let calls = 0;
+  const result = await runWorkerXCredentialLifecycleSweep(
+    {
+      DATABASE_URL: "postgresql://worker.invalid/steward",
+      X_CLIENT_ID: "provider-client",
+      X_CLIENT_SECRET: "provider-secret",
+      STEWARD_MASTER_PASSWORD: "worker-master",
+    },
+    {
+      sweep: async () => {
+        calls += 1;
+        return { processed: 2, adopted: 1, attention: 1, remaining: false };
+      },
+    },
+  );
+  expect(calls).toBe(1);
+  expect(result).toEqual({ processed: 2, adopted: 1, attention: 1, remaining: false });
+});
+
+test("Worker X lifecycle recovery is inert when the provider is unavailable", async () => {
+  let calls = 0;
+  const result = await runWorkerXCredentialLifecycleSweep(
+    {
+      DATABASE_URL: "postgresql://worker.invalid/steward",
+      STEWARD_MASTER_PASSWORD: "worker-master",
+    },
+    {
+      sweep: async () => {
+        calls += 1;
+        return {};
+      },
+    },
+  );
+  expect(calls).toBe(0);
+  expect(result).toBeNull();
 });

--- a/packages/api/src/__tests__/worker-runtime-sentinel.test.ts
+++ b/packages/api/src/__tests__/worker-runtime-sentinel.test.ts
@@ -84,12 +84,18 @@ test("Worker cron runs X lifecycle recovery when provider credentials are config
     {
       sweep: async () => {
         calls += 1;
-        return { processed: 2, adopted: 1, attention: 1, remaining: false };
+        return { processed: 2, adopted: 1, revoked: 0, attention: 1, remaining: false };
       },
     },
   );
   expect(calls).toBe(1);
-  expect(result).toEqual({ processed: 2, adopted: 1, attention: 1, remaining: false });
+  expect(result).toEqual({
+    processed: 2,
+    adopted: 1,
+    revoked: 0,
+    attention: 1,
+    remaining: false,
+  });
 });
 
 test("Worker X lifecycle recovery is inert when the provider is unavailable", async () => {

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -358,7 +358,9 @@ if (migrationsRan) {
   if (process.env.GOOGLE_PROVIDER_CLIENT_ID && process.env.GOOGLE_PROVIDER_CLIENT_SECRET) {
     cancelGoogleCredentialLifecycleScheduler = startGoogleCredentialLifecycleScheduler();
   }
-  cancelXCredentialLifecycleScheduler = startXCredentialLifecycleScheduler();
+  if (process.env.X_CLIENT_ID && process.env.X_CLIENT_SECRET) {
+    cancelXCredentialLifecycleScheduler = startXCredentialLifecycleScheduler();
+  }
   cancelRetention = startRetentionScheduler();
   if (redisOk) {
     cancelProviderReservationReconciliation = startProviderReservationReconciliationScheduler();

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -30,6 +30,7 @@ import {
 } from "./services/context";
 import { startGoogleCredentialLifecycleScheduler } from "./services/provider-google-lifecycle-scheduler";
 import { startProviderReservationReconciliationScheduler } from "./services/provider-reservation-reconciliation-scheduler";
+import { startXCredentialLifecycleScheduler } from "./services/provider-x-lifecycle-scheduler";
 import { startRetentionScheduler } from "./services/retention";
 import {
   InMemoryRateLimiter,
@@ -88,6 +89,7 @@ let cancelTransactionReceiptPolling: (() => void) | undefined;
 let cancelWebhookRetryScheduler: (() => void) | undefined;
 let cancelUpstreamCredentialLeaseScheduler: (() => Promise<void>) | undefined;
 let cancelGoogleCredentialLifecycleScheduler: (() => Promise<void>) | undefined;
+let cancelXCredentialLifecycleScheduler: (() => Promise<void>) | undefined;
 
 function runtimeGate(request: Request, peerAddress: string | null): Response | null {
   const url = new URL(request.url);
@@ -356,6 +358,7 @@ if (migrationsRan) {
   if (process.env.GOOGLE_PROVIDER_CLIENT_ID && process.env.GOOGLE_PROVIDER_CLIENT_SECRET) {
     cancelGoogleCredentialLifecycleScheduler = startGoogleCredentialLifecycleScheduler();
   }
+  cancelXCredentialLifecycleScheduler = startXCredentialLifecycleScheduler();
   cancelRetention = startRetentionScheduler();
   if (redisOk) {
     cancelProviderReservationReconciliation = startProviderReservationReconciliationScheduler();
@@ -408,6 +411,7 @@ const shutdown = async (signal: string) => {
   if (cancelWebhookRetryScheduler) cancelWebhookRetryScheduler();
   if (cancelUpstreamCredentialLeaseScheduler) await cancelUpstreamCredentialLeaseScheduler();
   if (cancelGoogleCredentialLifecycleScheduler) await cancelGoogleCredentialLifecycleScheduler();
+  if (cancelXCredentialLifecycleScheduler) await cancelXCredentialLifecycleScheduler();
   rateLimiter.clear();
 
   try {

--- a/packages/api/src/services/provider-x-connect.ts
+++ b/packages/api/src/services/provider-x-connect.ts
@@ -48,7 +48,11 @@ import {
   sql,
   withTenantAuditedTransaction,
 } from "@stwd/db";
-import { isValidOAuthBearerToken, isValidOAuthOpaqueToken } from "@stwd/shared";
+import {
+  isValidOAuthBearerToken,
+  isValidOAuthOpaqueToken,
+  MAX_OAUTH_TOKEN_LENGTH,
+} from "@stwd/shared";
 import type { SecretVault } from "@stwd/vault";
 
 type DbBase = ReturnType<typeof getDb>;
@@ -1731,11 +1735,11 @@ async function reconcileStagedXRefreshRevocation(
       throw new Error("staged token invalid");
     }
     const raw = token as Record<string, unknown>;
-    // Prefer the rotating refresh credential when X returned one. A malformed
-    // access token must not prevent us from revoking the exact valid refresh
-    // handle that was already durably staged.
-    accessToken = isValidOAuthBearerToken(raw.access_token) ? raw.access_token : null;
-    refreshToken = isValidOAuthOpaqueToken(raw.refresh_token) ? raw.refresh_token : null;
+    // Adoption applies the strict token grammar. Revocation instead uses the
+    // exact bounded string X returned: a rotated refresh credential that fails
+    // Steward's grammar may still be live upstream and must not be discarded.
+    accessToken = boundedStagedToken(raw.access_token);
+    refreshToken = boundedStagedToken(raw.refresh_token);
     if (!accessToken && !refreshToken) throw new Error("no revocable staged token");
   } catch {
     await finishStagedXRefreshRevocation(input, claimed, false, "STAGED_REVOCATION_HANDLE_INVALID");
@@ -1759,6 +1763,12 @@ async function reconcileStagedXRefreshRevocation(
     revoked ? "STAGED_CREDENTIAL_REVOKED" : "STAGED_REVOCATION_FAILED",
   );
   return revoked;
+}
+
+function boundedStagedToken(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 && value.length <= MAX_OAUTH_TOKEN_LENGTH
+    ? value
+    : null;
 }
 
 async function finishStagedXRefreshRevocation(

--- a/packages/api/src/services/provider-x-connect.ts
+++ b/packages/api/src/services/provider-x-connect.ts
@@ -201,6 +201,9 @@ async function defaultForward(req: XForwardRequest): Promise<XForwardResponse> {
     method: req.method,
     headers: req.headers,
     body: req.body,
+    // OAuth requests carry credentials in both headers and bodies. Never let a
+    // provider redirect replay them to a different endpoint or origin.
+    redirect: "error",
     signal: AbortSignal.timeout(X_FORWARD_TIMEOUT_MS),
   });
   const text = await readBoundedXResponse(res);
@@ -2035,7 +2038,10 @@ async function revokeUpstreamBestEffort(
     },
     body: body.toString(),
   });
-  return res.ok;
+  // RFC 7009 specifies HTTP 200 for a processed revocation request, including
+  // an already-invalid token. Do not treat an arbitrary 2xx (especially an
+  // asynchronous 202) as proof strong enough to destroy our only staged handle.
+  return res.status === 200;
 }
 
 // re-export sql for callers/tests that need raw predicates

--- a/packages/api/src/services/provider-x-connect.ts
+++ b/packages/api/src/services/provider-x-connect.ts
@@ -15,8 +15,8 @@
  *     verifier, so a store compromise cannot replay a connect or forge the code
  *     exchange. The raw state travels only in the browser round-trip; the raw
  *     verifier is re-derived from a sealed payload the caller carries back.
- *   - State is consumed exactly once, only after the upstream token exchange and
- *     identity fetch succeed, so a bad provider code cannot burn a live attempt.
+ *   - State is consumed exactly once before provider I/O, so concurrent replicas
+ *     cannot exchange one authorization code and orphan a losing grant.
  *   - Tokens land as a NEW versioned vault secret; provider_accounts links the
  *     current {credential_secret_id, credential_version}. Reconnect for the same
  *     X user id updates the version + bumps revision, never duplicates the row.
@@ -350,6 +350,44 @@ export interface PendingConnectRecord {
   createdAt: string;
 }
 
+function isCanonicalIsoTimestamp(value: unknown): value is string {
+  if (typeof value !== "string" || value.length > 32) return false;
+  const parsed = new Date(value);
+  return Number.isFinite(parsed.getTime()) && parsed.toISOString() === value;
+}
+
+function validatePendingConnectRecord(value: unknown): PendingConnectRecord | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  if (
+    record.schemaVersion !== "steward.provider-x.pending-connect.v1" ||
+    typeof record.tenantId !== "string" ||
+    record.tenantId.length === 0 ||
+    record.tenantId.length > 64 ||
+    typeof record.workspaceId !== "string" ||
+    record.workspaceId.length > 64 ||
+    typeof record.initiatedByUserId !== "string" ||
+    record.initiatedByUserId.length > 128 ||
+    typeof record.verifierHash !== "string" ||
+    !/^[a-f0-9]{64}$/.test(record.verifierHash) ||
+    typeof record.redirectUri !== "string" ||
+    record.redirectUri.length === 0 ||
+    record.redirectUri.length > 2048 ||
+    !isCanonicalIsoTimestamp(record.createdAt) ||
+    !Array.isArray(record.scopes) ||
+    record.scopes.length === 0 ||
+    record.scopes.length > X_DEFAULT_SCOPES.length ||
+    record.scopes.some(
+      (scope) =>
+        typeof scope !== "string" || !(X_DEFAULT_SCOPES as readonly string[]).includes(scope),
+    ) ||
+    new Set(record.scopes).size !== record.scopes.length
+  ) {
+    return null;
+  }
+  return record as unknown as PendingConnectRecord;
+}
+
 // ── Initiate ──────────────────────────────────────────────────────────────────
 export interface InitiateConnectInput {
   tenantId: string;
@@ -439,12 +477,21 @@ export interface ParsedConnectToken {
 
 export function parseConnectToken(token: string): ParsedConnectToken | null {
   try {
+    if (token.length === 0 || token.length > 1024 || !/^[A-Za-z0-9_-]+$/.test(token)) return null;
     const json = base64ToUtf8(token);
-    const parsed = JSON.parse(json) as ParsedConnectToken;
-    if (typeof parsed.state !== "string" || typeof parsed.verifier !== "string") {
+    if (base64url(Buffer.from(json, "utf8")) !== token) return null;
+    const parsed = JSON.parse(json) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+    const candidate = parsed as Record<string, unknown>;
+    if (
+      typeof candidate.state !== "string" ||
+      !/^[a-f0-9]{64}$/.test(candidate.state) ||
+      typeof candidate.verifier !== "string" ||
+      !/^[a-f0-9]{96}$/.test(candidate.verifier)
+    ) {
       return null;
     }
-    return parsed;
+    return { state: candidate.state, verifier: candidate.verifier };
   } catch {
     return null;
   }
@@ -483,11 +530,17 @@ export async function completeXConnect(
   const raw = await input.store.get(key);
   if (!raw) throw new XConnectError("X_STATE_INVALID", 401, "unknown or expired connect state");
 
-  let record: PendingConnectRecord;
+  let parsedRecord: unknown;
   try {
-    record = JSON.parse(raw) as PendingConnectRecord;
+    parsedRecord = JSON.parse(raw);
   } catch {
     throw new XConnectError("X_STATE_INVALID", 400, "malformed connect state");
+  }
+  const record = validatePendingConnectRecord(parsedRecord);
+  if (!record) throw new XConnectError("X_STATE_INVALID", 400, "malformed connect state");
+  const recordAgeMs = Date.now() - new Date(record.createdAt).getTime();
+  if (recordAgeMs < 0 || recordAgeMs > X_CONNECT_STATE_TTL_MS) {
+    throw new XConnectError("X_STATE_EXPIRED", 401, "expired connect state");
   }
 
   // Bind the state to THIS tenant/workspace/caller — a state minted for another
@@ -514,59 +567,73 @@ export async function completeXConnect(
     throw new XConnectError("X_PKCE_MISMATCH", 400, "PKCE verifier mismatch");
   }
 
-  // 3. Exchange the code (PKCE). Failure here does NOT consume the state.
+  // 3. Claim the state BEFORE any provider call. Security takes precedence over
+  // retrying a bad authorization code: two replicas must never both exchange a
+  // one-time code and strand the losing callback's newly issued grant.
+  const consumed = await input.store.consume(key);
+  if (consumed !== raw) {
+    throw new XConnectError("X_STATE_REUSED", 401, "connect state already used");
+  }
+
+  // 4. Exchange the code (PKCE).
   const tokenRes = await exchangeAuthorizationCode({
     config: input.config,
     code: input.code,
     redirectUri: input.redirectUri,
     verifier: parsedToken.verifier,
   });
-  const scopesGranted = parseXGrantedScopes(
-    tokenRes.scope,
-    record.scopes,
-    "X_TOKEN_EXCHANGE_FAILED",
-  );
+  try {
+    const scopesGranted = parseXGrantedScopes(
+      tokenRes.scope,
+      record.scopes,
+      "X_TOKEN_EXCHANGE_FAILED",
+    );
 
-  // 4. Identify the connected account.
-  const identity = await fetchXIdentity(tokenRes.access_token);
+    // 5. Identify the connected account.
+    const identity = await fetchXIdentity(tokenRes.access_token);
 
-  // 5. Consume the state EXACTLY ONCE, only after upstream success. A concurrent
-  //    duplicate callback loses the race and gets X_STATE_REUSED.
-  const consumed = await input.store.consume(key);
-  if (consumed !== raw) {
-    throw new XConnectError("X_STATE_REUSED", 401, "connect state already used");
+    const obtainedAt = new Date();
+    const expiresAt =
+      typeof tokenRes.expires_in === "number"
+        ? new Date(obtainedAt.getTime() + tokenRes.expires_in * 1000)
+        : null;
+
+    const payload: XCredentialPayload = {
+      schemaVersion: "steward.provider-x.credential.v1",
+      accessToken: tokenRes.access_token,
+      refreshToken: tokenRes.refresh_token ?? null,
+      scopesGranted,
+      xUserId: identity.id,
+      xUsername: identity.username,
+      obtainedAt: obtainedAt.toISOString(),
+      expiresAt: expiresAt ? expiresAt.toISOString() : null,
+    };
+
+    // 6. Persist tokens as a versioned vault secret + create/update the account,
+    //    all inside one tenant-audited transaction so the audit event commits with
+    //    the state mutation.
+    return await persistConnectedAccount({
+      tenantId: input.tenantId,
+      workspaceId: input.workspaceId,
+      callerUserId: input.callerUserId,
+      vault: input.vault,
+      identity,
+      payload,
+      scopesGranted,
+      requestId: input.requestId ?? null,
+    });
+  } catch (error) {
+    // Once X has issued a grant, any identity or local persistence failure would
+    // otherwise strand a live credential that Steward cannot recover. Revoke the
+    // exact newly issued grant best-effort, while preserving the original,
+    // sanitized application error.
+    await revokeUpstreamBestEffort(
+      input.config,
+      tokenRes.access_token,
+      tokenRes.refresh_token ?? null,
+    ).catch(() => false);
+    throw error;
   }
-
-  const obtainedAt = new Date();
-  const expiresAt =
-    typeof tokenRes.expires_in === "number"
-      ? new Date(obtainedAt.getTime() + tokenRes.expires_in * 1000)
-      : null;
-
-  const payload: XCredentialPayload = {
-    schemaVersion: "steward.provider-x.credential.v1",
-    accessToken: tokenRes.access_token,
-    refreshToken: tokenRes.refresh_token ?? null,
-    scopesGranted,
-    xUserId: identity.id,
-    xUsername: identity.username,
-    obtainedAt: obtainedAt.toISOString(),
-    expiresAt: expiresAt ? expiresAt.toISOString() : null,
-  };
-
-  // 6. Persist tokens as a versioned vault secret + create/update the account,
-  //    all inside one tenant-audited transaction so the audit event commits with
-  //    the state mutation.
-  return persistConnectedAccount({
-    tenantId: input.tenantId,
-    workspaceId: input.workspaceId,
-    callerUserId: input.callerUserId,
-    vault: input.vault,
-    identity,
-    payload,
-    scopesGranted,
-    requestId: input.requestId ?? null,
-  });
 }
 
 interface XIdentity {
@@ -585,7 +652,17 @@ async function fetchXIdentity(accessToken: string): Promise<XIdentity> {
     throw new XConnectError("X_IDENTITY_FAILED", 502, `X identity fetch failed (${res.status})`);
   }
   const data = (res.json as XUserResponse | null)?.data;
-  if (!data || !data.id) {
+  if (
+    !data ||
+    typeof data.id !== "string" ||
+    !/^\d{1,32}$/.test(data.id) ||
+    (data.username !== undefined &&
+      (typeof data.username !== "string" || !/^[A-Za-z0-9_]{1,64}$/.test(data.username))) ||
+    (data.name !== undefined &&
+      (typeof data.name !== "string" ||
+        data.name.length > 128 ||
+        /[\u0000-\u001f\u007f]/.test(data.name)))
+  ) {
     throw new XConnectError("X_IDENTITY_FAILED", 502, "X identity response missing user id");
   }
   return { id: data.id, username: data.username ?? "", name: data.name ?? "" };
@@ -971,6 +1048,9 @@ export async function refreshXProviderCredential(input: RefreshInput): Promise<R
         account.credentialSecretId,
         tx,
       );
+      if (current.payload.xUserId !== account.externalRef) {
+        throw new XConnectError("X_REFRESH_FAILED", 409, "credential account binding mismatch");
+      }
 
       // Single-flight fast path: a concurrent winner already rotated us to a fresh
       // token while we waited for the lock. If not forced and the token is still
@@ -1105,11 +1185,10 @@ export async function refreshXProviderCredential(input: RefreshInput): Promise<R
       }
       await new Promise((resolve) => setTimeout(resolve, 10));
     }
-    await disableXAccountForLifecycle(input, prepared.lifecycleId, "REFRESH_OUTCOME_UNKNOWN");
     throw new XConnectError(
-      "X_CREDENTIAL_NEEDS_ATTENTION",
+      "X_REFRESH_FAILED",
       409,
-      "X refresh outcome is unknown; reconnect required",
+      "X refresh is already in progress; retry shortly",
     );
   }
 
@@ -1128,11 +1207,26 @@ export async function refreshXProviderCredential(input: RefreshInput): Promise<R
   try {
     await stageXRefreshResponse(input, prepared.lifecycleId, tokenRes.raw);
   } catch (error) {
-    await disableXAccountForLifecycle(
-      input,
-      prepared.lifecycleId,
-      "REFRESH_RESPONSE_STAGING_FAILED",
-    );
+    // The provider may already have rotated the one-time refresh token. Use the
+    // response still held in memory to revoke that exact new grant before it can
+    // become an orphan, then fail closed locally. Reconnect remains the recovery
+    // boundary whether revocation succeeds or the outcome is unknowable.
+    const candidate =
+      tokenRes.raw && typeof tokenRes.raw === "object" && !Array.isArray(tokenRes.raw)
+        ? (tokenRes.raw as Record<string, unknown>)
+        : null;
+    // Revocation uses the exact bounded strings returned by X. A credential may
+    // fail Steward's adoption grammar while still being live at the provider.
+    const accessToken = candidate ? boundedStagedToken(candidate.access_token) : null;
+    const refreshToken = candidate ? boundedStagedToken(candidate.refresh_token) : null;
+    if (accessToken || refreshToken) {
+      await revokeUpstreamBestEffort(
+        input.config,
+        accessToken ?? (refreshToken as string),
+        refreshToken,
+      ).catch(() => false);
+    }
+    await disableXAccountForLifecycle(input, prepared.lifecycleId, "REFRESH_OUTCOME_UNKNOWN");
     throw error;
   }
   await afterXCredentialStageForTests?.();
@@ -1439,6 +1533,9 @@ export async function reconcileXRefreshLifecycle(
         account.credentialSecretId,
         tx,
       );
+      if (current.payload.xUserId !== account.externalRef) {
+        throw new XConnectError("X_REFRESH_FAILED", 409, "credential account binding mismatch");
+      }
       const [stagedSecret] = (await tx
         .select()
         .from(secrets)
@@ -1599,7 +1696,10 @@ export interface XCredentialLifecycleSweepResult {
 }
 
 const X_LIFECYCLE_SWEEP_BATCH_SIZE = 25;
-const X_LIFECYCLE_STALE_AFTER_MS = X_FORWARD_TIMEOUT_MS + 5_000;
+// Provider I/O is capped at 10s, but DB scheduling and encrypted staging occur
+// afterwards. A one-minute lease prevents a recovery replica from racing a
+// healthy slow winner and disabling its account mid-rotation.
+const X_LIFECYCLE_STALE_AFTER_MS = 60_000;
 
 /** Bounded all-tenant recovery for abandoned single-use X refresh rotations. */
 export async function runXCredentialLifecycleSweep(input: {
@@ -1858,7 +1958,21 @@ async function loadCredential(
   if (
     candidate.schemaVersion !== "steward.provider-x.credential.v1" ||
     !isValidOAuthBearerToken(candidate.accessToken) ||
-    !(candidate.refreshToken === null || isValidOAuthOpaqueToken(candidate.refreshToken))
+    !(candidate.refreshToken === null || isValidOAuthOpaqueToken(candidate.refreshToken)) ||
+    !Array.isArray(candidate.scopesGranted) ||
+    candidate.scopesGranted.length === 0 ||
+    candidate.scopesGranted.length > X_DEFAULT_SCOPES.length ||
+    candidate.scopesGranted.some(
+      (scope) =>
+        typeof scope !== "string" || !(X_DEFAULT_SCOPES as readonly string[]).includes(scope),
+    ) ||
+    new Set(candidate.scopesGranted).size !== candidate.scopesGranted.length ||
+    typeof candidate.xUserId !== "string" ||
+    !/^\d{1,32}$/.test(candidate.xUserId) ||
+    typeof candidate.xUsername !== "string" ||
+    (candidate.xUsername !== "" && !/^[A-Za-z0-9_]{1,64}$/.test(candidate.xUsername)) ||
+    !isCanonicalIsoTimestamp(candidate.obtainedAt) ||
+    !(candidate.expiresAt === null || isCanonicalIsoTimestamp(candidate.expiresAt))
   ) {
     throw new XConnectError("X_REFRESH_FAILED", 409, "credential payload invalid");
   }
@@ -1967,6 +2081,9 @@ export async function disconnectXProviderCredential(
           account.credentialSecretId,
           tx,
         );
+        if (cred.payload.xUserId !== account.externalRef) {
+          throw new XConnectError("X_REFRESH_FAILED", 409, "credential account binding mismatch");
+        }
         revokedAtUpstream = await revokeUpstreamBestEffort(
           input.config,
           cred.payload.accessToken,

--- a/packages/api/src/services/provider-x-connect.ts
+++ b/packages/api/src/services/provider-x-connect.ts
@@ -679,19 +679,12 @@ export function xCredentialSecretName(workspaceId: string, xUserId: string): str
 }
 
 async function persistConnectedAccount(input: PersistInput): Promise<CompleteConnectResult> {
-  // Write the credential secret OUTSIDE the audited tx (the vault owns its own
-  // encryption + version row); then link + audit atomically. createSecret always
-  // writes version 1; a reconnect uses rotateSecret to bump the version so the
-  // lineage (secret name) is stable and the OLD ciphertext is soft-deleted.
+  // Serialize reconnect against the account/lifecycle rows, then write the
+  // credential and account link in the same transaction. Do not rotate the
+  // active secret until every unresolved refresh is safe to supersede: a staged
+  // response is a live provider handle, not garbage.
   const secretName = xCredentialSecretName(input.workspaceId, input.identity.id);
   const serialized = JSON.stringify(input.payload);
-
-  const existing = await input.vault.getSecret(input.tenantId, secretName);
-  const meta = existing
-    ? await input.vault.rotateSecret(input.tenantId, secretName, serialized)
-    : await input.vault.createSecret(input.tenantId, secretName, serialized, {
-        description: "X (Twitter) provider-account OAuth credential",
-      });
 
   return withTenantAuditedTransaction(input.tenantId, async (txRaw, append) => {
     const tx = txRaw as DbExecutor;
@@ -712,7 +705,13 @@ async function persistConnectedAccount(input: PersistInput): Promise<CompleteCon
 
     const unresolvedRefreshes = account
       ? await tx
-          .select()
+          .select({
+            id: providerXCredentialLifecycles.id,
+            state: providerXCredentialLifecycles.state,
+            credentialSecretId: providerXCredentialLifecycles.credentialSecretId,
+            expectedAccountRevision: providerXCredentialLifecycles.expectedAccountRevision,
+            lastErrorCode: providerXCredentialLifecycles.lastErrorCode,
+          })
           .from(providerXCredentialLifecycles)
           .where(
             and(
@@ -726,8 +725,45 @@ async function persistConnectedAccount(input: PersistInput): Promise<CompleteCon
               ]),
             ),
           )
+          .orderBy(asc(providerXCredentialLifecycles.createdAt))
           .for("update")
       : [];
+
+    const supersedableRefreshes = account
+      ? unresolvedRefreshes.filter(
+          (row) =>
+            row.state === "needs_attention" &&
+            row.credentialSecretId === null &&
+            row.lastErrorCode === "REFRESH_OUTCOME_UNKNOWN" &&
+            row.expectedAccountRevision !== null &&
+            row.expectedAccountRevision <= account.revision,
+        )
+      : [];
+    if (supersedableRefreshes.length !== unresolvedRefreshes.length) {
+      throw new XConnectError(
+        "X_CREDENTIAL_NEEDS_ATTENTION",
+        409,
+        "previous X refresh must be reconciled before reconnect",
+      );
+    }
+
+    const [existingSecret] = await tx
+      .select({ id: secrets.id })
+      .from(secrets)
+      .where(
+        and(
+          eq(secrets.tenantId, input.tenantId),
+          eq(secrets.name, secretName),
+          sql`${secrets.deletedAt} IS NULL`,
+        ),
+      )
+      .limit(1)
+      .for("update");
+    const meta = existingSecret
+      ? await input.vault.rotateSecretWithinTx(tx, input.tenantId, secretName, serialized)
+      : await input.vault.createSecretWithinTx(tx, input.tenantId, secretName, serialized, {
+          description: "X (Twitter) provider-account OAuth credential",
+        });
 
     const displayName = input.identity.username ? `@${input.identity.username}` : input.identity.id;
 
@@ -795,36 +831,33 @@ async function persistConnectedAccount(input: PersistInput): Promise<CompleteCon
       },
     });
 
-    if (unresolvedRefreshes.length > 0) {
-      const lifecycleIds = unresolvedRefreshes.map((row) => row.id).sort();
-      const transientSecretIds = unresolvedRefreshes
-        .map((row) => row.credentialSecretId)
-        .filter((id): id is string => id !== null);
-      await tx
+    if (supersedableRefreshes.length > 0) {
+      const lifecycleIds = supersedableRefreshes.map((row) => row.id).sort();
+      const superseded = await tx
         .update(providerXCredentialLifecycles)
         .set({
           state: "superseded",
-          credentialSecretId: null,
           lastErrorCode: "SUPERSEDED_BY_RECONNECT",
           updatedAt: new Date(),
         })
         .where(
           and(
             eq(providerXCredentialLifecycles.tenantId, input.tenantId),
+            eq(providerXCredentialLifecycles.workspaceId, input.workspaceId),
+            eq(providerXCredentialLifecycles.providerAccountId, providerAccountId),
             inArray(providerXCredentialLifecycles.id, lifecycleIds),
-            inArray(providerXCredentialLifecycles.state, [
-              "inflight",
-              "credential_staged",
-              "needs_attention",
-            ]),
+            eq(providerXCredentialLifecycles.state, "needs_attention"),
+            sql`${providerXCredentialLifecycles.credentialSecretId} IS NULL`,
+            eq(providerXCredentialLifecycles.lastErrorCode, "REFRESH_OUTCOME_UNKNOWN"),
           ),
+        )
+        .returning({ id: providerXCredentialLifecycles.id });
+      if (superseded.length !== supersedableRefreshes.length) {
+        throw new XConnectError(
+          "X_CREDENTIAL_NEEDS_ATTENTION",
+          409,
+          "X refresh lifecycle changed during reconnect",
         );
-      if (transientSecretIds.length > 0) {
-        await tx
-          .delete(secrets)
-          .where(
-            and(eq(secrets.tenantId, input.tenantId), inArray(secrets.id, transientSecretIds)),
-          );
       }
       await append({
         tenantId: input.tenantId,
@@ -836,7 +869,7 @@ async function persistConnectedAccount(input: PersistInput): Promise<CompleteCon
         metadata: {
           workspaceId: input.workspaceId,
           lifecycleIds,
-          priorStates: unresolvedRefreshes.map((row) => row.state).sort(),
+          priorStates: supersedableRefreshes.map((row) => row.state).sort(),
           newAccountRevision: account ? account.revision + 1 : 1,
           requestId: input.requestId,
         },

--- a/packages/api/src/services/provider-x-connect.ts
+++ b/packages/api/src/services/provider-x-connect.ts
@@ -721,6 +721,7 @@ async function persistConnectedAccount(input: PersistInput): Promise<CompleteCon
               inArray(providerXCredentialLifecycles.state, [
                 "inflight",
                 "credential_staged",
+                "revocation_pending",
                 "needs_attention",
               ]),
             ),
@@ -994,13 +995,17 @@ export async function refreshXProviderCredential(input: RefreshInput): Promise<R
             inArray(providerXCredentialLifecycles.state, [
               "inflight",
               "credential_staged",
+              "revocation_pending",
               "needs_attention",
             ]),
           ),
         )
         .limit(1);
       if (activeLifecycle) {
-        if (activeLifecycle.state === "needs_attention") {
+        if (
+          activeLifecycle.state === "needs_attention" ||
+          activeLifecycle.state === "revocation_pending"
+        ) {
           throw new XConnectError(
             "X_CREDENTIAL_NEEDS_ATTENTION",
             409,
@@ -1080,7 +1085,11 @@ export async function refreshXProviderCredential(input: RefreshInput): Promise<R
           };
         }
       }
-      if (row?.state === "needs_attention" || row?.state === "revoked") {
+      if (
+        row?.state === "needs_attention" ||
+        row?.state === "revocation_pending" ||
+        row?.state === "revoked"
+      ) {
         throw new XConnectError(
           "X_CREDENTIAL_NEEDS_ATTENTION",
           409,
@@ -1247,6 +1256,7 @@ async function disableXAccountForLifecycle(
             inArray(providerXCredentialLifecycles.state, [
               "inflight",
               "credential_staged",
+              "revocation_pending",
               "needs_attention",
             ]),
           ),
@@ -1576,6 +1586,7 @@ async function readAdoptedXRefreshResult(
 export interface XCredentialLifecycleSweepResult {
   processed: number;
   adopted: number;
+  revoked: number;
   attention: number;
   remaining: boolean;
 }
@@ -1586,6 +1597,7 @@ const X_LIFECYCLE_STALE_AFTER_MS = X_FORWARD_TIMEOUT_MS + 5_000;
 /** Bounded all-tenant recovery for abandoned single-use X refresh rotations. */
 export async function runXCredentialLifecycleSweep(input: {
   vault: SecretVault;
+  config: XConnectConfig;
   limit?: number;
   now?: Date;
 }): Promise<XCredentialLifecycleSweepResult> {
@@ -1600,7 +1612,13 @@ export async function runXCredentialLifecycleSweep(input: {
     .from(providerXCredentialLifecycles)
     .where(
       and(
-        inArray(providerXCredentialLifecycles.state, ["inflight", "credential_staged"]),
+        inArray(providerXCredentialLifecycles.state, [
+          "inflight",
+          "credential_staged",
+          "revocation_pending",
+          "needs_attention",
+        ]),
+        sql`(${providerXCredentialLifecycles.state} IN ('inflight', 'credential_staged') OR ${providerXCredentialLifecycles.credentialSecretId} IS NOT NULL)`,
         lte(providerXCredentialLifecycles.updatedAt, staleBefore),
       ),
     )
@@ -1609,6 +1627,7 @@ export async function runXCredentialLifecycleSweep(input: {
   const result: XCredentialLifecycleSweepResult = {
     processed: 0,
     adopted: 0,
+    revoked: 0,
     attention: 0,
     remaining: false,
   };
@@ -1627,6 +1646,14 @@ export async function runXCredentialLifecycleSweep(input: {
       if (row.state === "credential_staged") {
         await reconcileXRefreshLifecycle(recoveryInput);
         result.adopted += 1;
+      } else if (row.state === "needs_attention" || row.state === "revocation_pending") {
+        const revoked = await reconcileStagedXRefreshRevocation({
+          ...recoveryInput,
+          config: input.config,
+          expectedUpdatedAt: row.updatedAt,
+        });
+        if (revoked) result.revoked += 1;
+        else result.attention += 1;
       } else {
         await disableXAccountForLifecycle(recoveryInput, row.id, "REFRESH_OUTCOME_UNKNOWN");
         result.attention += 1;
@@ -1637,6 +1664,149 @@ export async function runXCredentialLifecycleSweep(input: {
   }
   result.remaining = rows.length === limit && result.attention === 0;
   return result;
+}
+
+async function reconcileStagedXRefreshRevocation(
+  input: RefreshInput & { lifecycleId: string; expectedUpdatedAt: Date },
+): Promise<boolean> {
+  const claimed = await withTenantAuditedTransaction(input.tenantId, async (txRaw, append) => {
+    const tx = txRaw as DbExecutor;
+    const [lifecycle] = await tx
+      .select()
+      .from(providerXCredentialLifecycles)
+      .where(
+        and(
+          eq(providerXCredentialLifecycles.tenantId, input.tenantId),
+          eq(providerXCredentialLifecycles.id, input.lifecycleId),
+          eq(providerXCredentialLifecycles.workspaceId, input.workspaceId),
+          eq(providerXCredentialLifecycles.providerAccountId, input.accountId),
+          inArray(providerXCredentialLifecycles.state, ["needs_attention", "revocation_pending"]),
+          eq(providerXCredentialLifecycles.updatedAt, input.expectedUpdatedAt),
+          sql`${providerXCredentialLifecycles.credentialSecretId} IS NOT NULL`,
+        ),
+      )
+      .limit(1)
+      .for("update");
+    if (!lifecycle?.credentialSecretId) return null;
+    const claimedAt = new Date();
+    const [updated] = await tx
+      .update(providerXCredentialLifecycles)
+      .set({ state: "revocation_pending", updatedAt: claimedAt })
+      .where(
+        and(
+          eq(providerXCredentialLifecycles.tenantId, input.tenantId),
+          eq(providerXCredentialLifecycles.id, lifecycle.id),
+          eq(providerXCredentialLifecycles.updatedAt, input.expectedUpdatedAt),
+        ),
+      )
+      .returning({ credentialSecretId: providerXCredentialLifecycles.credentialSecretId });
+    if (!updated?.credentialSecretId) return null;
+    await append({
+      tenantId: input.tenantId,
+      actorType: "system",
+      actorId: "system",
+      action: "provider.x.refresh.revocation_claimed",
+      resourceType: "provider_x_credential_lifecycle",
+      resourceId: lifecycle.id,
+      metadata: { providerAccountId: input.accountId, workspaceId: input.workspaceId },
+    });
+    return { credentialSecretId: updated.credentialSecretId, claimedAt };
+  });
+  if (!claimed) return false;
+
+  let accessToken: string | null = null;
+  let refreshToken: string | null = null;
+  try {
+    const [secret] = (await (getDb() as DbExecutor)
+      .select()
+      .from(secrets)
+      .where(and(eq(secrets.tenantId, input.tenantId), eq(secrets.id, claimed.credentialSecretId)))
+      .limit(1)) as Secret[];
+    if (!secret) throw new Error("staged secret missing");
+    const staged = JSON.parse(
+      input.vault.decryptSecretRow(input.tenantId, secret),
+    ) as XRefreshLifecycleSecret;
+    const token = staged?.token;
+    if (!token || typeof token !== "object" || Array.isArray(token)) {
+      throw new Error("staged token invalid");
+    }
+    const raw = token as Record<string, unknown>;
+    // Prefer the rotating refresh credential when X returned one. A malformed
+    // access token must not prevent us from revoking the exact valid refresh
+    // handle that was already durably staged.
+    accessToken = isValidOAuthBearerToken(raw.access_token) ? raw.access_token : null;
+    refreshToken = isValidOAuthOpaqueToken(raw.refresh_token) ? raw.refresh_token : null;
+    if (!accessToken && !refreshToken) throw new Error("no revocable staged token");
+  } catch {
+    await finishStagedXRefreshRevocation(input, claimed, false, "STAGED_REVOCATION_HANDLE_INVALID");
+    return false;
+  }
+
+  let revoked = false;
+  try {
+    revoked = await revokeUpstreamBestEffort(
+      input.config,
+      accessToken ?? (refreshToken as string),
+      refreshToken,
+    );
+  } catch {
+    revoked = false;
+  }
+  await finishStagedXRefreshRevocation(
+    input,
+    claimed,
+    revoked,
+    revoked ? "STAGED_CREDENTIAL_REVOKED" : "STAGED_REVOCATION_FAILED",
+  );
+  return revoked;
+}
+
+async function finishStagedXRefreshRevocation(
+  input: RefreshInput & { lifecycleId: string },
+  claimed: { credentialSecretId: string; claimedAt: Date },
+  revoked: boolean,
+  reason: string,
+): Promise<void> {
+  await withTenantAuditedTransaction(input.tenantId, async (txRaw, append) => {
+    const tx = txRaw as DbExecutor;
+    const [updated] = await tx
+      .update(providerXCredentialLifecycles)
+      .set({
+        state: revoked ? "revoked" : "needs_attention",
+        credentialSecretId: revoked ? null : claimed.credentialSecretId,
+        lastErrorCode: reason,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(providerXCredentialLifecycles.tenantId, input.tenantId),
+          eq(providerXCredentialLifecycles.id, input.lifecycleId),
+          eq(providerXCredentialLifecycles.state, "revocation_pending"),
+          eq(providerXCredentialLifecycles.credentialSecretId, claimed.credentialSecretId),
+          eq(providerXCredentialLifecycles.updatedAt, claimed.claimedAt),
+        ),
+      )
+      .returning({ id: providerXCredentialLifecycles.id });
+    if (!updated) return;
+    if (revoked) {
+      await tx
+        .delete(secrets)
+        .where(
+          and(eq(secrets.tenantId, input.tenantId), eq(secrets.id, claimed.credentialSecretId)),
+        );
+    }
+    await append({
+      tenantId: input.tenantId,
+      actorType: "system",
+      actorId: "system",
+      action: revoked
+        ? "provider.x.refresh.staged_credential_revoked"
+        : "provider.x.refresh.staged_revocation_failed",
+      resourceType: "provider_x_credential_lifecycle",
+      resourceId: input.lifecycleId,
+      metadata: { providerAccountId: input.accountId, workspaceId: input.workspaceId, reason },
+    });
+  });
 }
 
 interface LoadedCredential {

--- a/packages/api/src/services/provider-x-connect.ts
+++ b/packages/api/src/services/provider-x-connect.ts
@@ -32,13 +32,18 @@
  * withTenantAuditedTransaction / appendRequiredAudit.
  */
 
-import { createHash, randomBytes } from "node:crypto";
+import { createHash, randomBytes, randomUUID } from "node:crypto";
 import {
   and,
+  asc,
   eq,
   getDb,
+  inArray,
+  lte,
   providerAccounts,
+  providerXCredentialLifecycles,
   type Secret,
+  secretRoutes,
   secrets,
   sql,
   withTenantAuditedTransaction,
@@ -88,6 +93,7 @@ export type XConnectErrorCode =
   | "X_ACCOUNT_NOT_X"
   | "X_REFRESH_TOKEN_MISSING"
   | "X_REFRESH_REVOKED"
+  | "X_CREDENTIAL_NEEDS_ATTENTION"
   | "X_REFRESH_FAILED";
 
 export class XConnectError extends Error {
@@ -209,6 +215,8 @@ export function __runDefaultXForwardForTests(req: XForwardRequest): Promise<XFor
 }
 
 let forwardImpl: XForwardFn = defaultForward;
+let afterXRefreshIntentForTests: (() => Promise<void>) | null = null;
+let afterXCredentialStageForTests: (() => Promise<void>) | null = null;
 
 /**
  * Test-only seam setter. Mirrors the repo's `__setForwardProxyRequestForTests`
@@ -219,6 +227,24 @@ export function __setXForwardForTests(fn: XForwardFn | null): () => void {
   forwardImpl = fn ?? defaultForward;
   return () => {
     forwardImpl = previous;
+  };
+}
+
+/** Test-only crash seam after durable staging and before adoption. */
+export function __setAfterXCredentialStageForTests(fn: (() => Promise<void>) | null): () => void {
+  const previous = afterXCredentialStageForTests;
+  afterXCredentialStageForTests = fn;
+  return () => {
+    afterXCredentialStageForTests = previous;
+  };
+}
+
+/** Test-only crash seam after the durable intent and before provider I/O. */
+export function __setAfterXRefreshIntentForTests(fn: (() => Promise<void>) | null): () => void {
+  const previous = afterXRefreshIntentForTests;
+  afterXRefreshIntentForTests = fn;
+  return () => {
+    afterXRefreshIntentForTests = previous;
   };
 }
 
@@ -488,6 +514,11 @@ export async function completeXConnect(
     redirectUri: input.redirectUri,
     verifier: parsedToken.verifier,
   });
+  const scopesGranted = parseXGrantedScopes(
+    tokenRes.scope,
+    record.scopes,
+    "X_TOKEN_EXCHANGE_FAILED",
+  );
 
   // 4. Identify the connected account.
   const identity = await fetchXIdentity(tokenRes.access_token);
@@ -499,9 +530,6 @@ export async function completeXConnect(
     throw new XConnectError("X_STATE_REUSED", 401, "connect state already used");
   }
 
-  const scopesGranted = tokenRes.scope
-    ? tokenRes.scope.split(/\s+/).filter(Boolean)
-    : record.scopes;
   const obtainedAt = new Date();
   const expiresAt =
     typeof tokenRes.expires_in === "number"
@@ -586,7 +614,16 @@ async function exchangeAuthorizationCode(input: ExchangeInput): Promise<XTokenRe
     !res.ok ||
     !parsed ||
     !isValidOAuthBearerToken(parsed.access_token) ||
-    (parsed.refresh_token !== undefined && !isValidOAuthOpaqueToken(parsed.refresh_token))
+    (parsed.refresh_token !== undefined && !isValidOAuthOpaqueToken(parsed.refresh_token)) ||
+    (parsed.token_type !== undefined &&
+      (typeof parsed.token_type !== "string" || parsed.token_type.toLowerCase() !== "bearer")) ||
+    (parsed.expires_in !== undefined &&
+      (typeof parsed.expires_in !== "number" ||
+        !Number.isSafeInteger(parsed.expires_in) ||
+        parsed.expires_in <= 0 ||
+        parsed.expires_in > 86_400)) ||
+    (parsed.scope !== undefined &&
+      (typeof parsed.scope !== "string" || parsed.scope.length === 0 || parsed.scope.length > 4096))
   ) {
     throw new XConnectError(
       "X_TOKEN_EXCHANGE_FAILED",
@@ -595,6 +632,27 @@ async function exchangeAuthorizationCode(input: ExchangeInput): Promise<XTokenRe
     );
   }
   return parsed;
+}
+
+function parseXGrantedScopes(
+  raw: unknown,
+  allowedScopes: string[],
+  errorCode: "X_TOKEN_EXCHANGE_FAILED" | "X_REFRESH_FAILED",
+): string[] {
+  if (raw === undefined) return [...new Set(allowedScopes)].sort();
+  if (typeof raw !== "string" || raw.length === 0 || raw.length > 4096) {
+    throw new XConnectError(errorCode, 502, "X OAuth scope is invalid");
+  }
+  const scopes = raw.split(/\s+/).filter(Boolean);
+  if (
+    scopes.length === 0 ||
+    scopes.length > 64 ||
+    scopes.some((scope) => !/^[A-Za-z0-9._:-]{1,128}$/.test(scope)) ||
+    scopes.some((scope) => !allowedScopes.includes(scope))
+  ) {
+    throw new XConnectError(errorCode, 502, "X OAuth scope is invalid");
+  }
+  return [...new Set(scopes)].sort();
 }
 
 /** X token endpoint accepts confidential-client creds via HTTP Basic. */
@@ -651,6 +709,25 @@ async function persistConnectedAccount(input: PersistInput): Promise<CompleteCon
       )
       .limit(1)
       .for("update");
+
+    const unresolvedRefreshes = account
+      ? await tx
+          .select()
+          .from(providerXCredentialLifecycles)
+          .where(
+            and(
+              eq(providerXCredentialLifecycles.tenantId, input.tenantId),
+              eq(providerXCredentialLifecycles.workspaceId, input.workspaceId),
+              eq(providerXCredentialLifecycles.providerAccountId, account.id),
+              inArray(providerXCredentialLifecycles.state, [
+                "inflight",
+                "credential_staged",
+                "needs_attention",
+              ]),
+            ),
+          )
+          .for("update")
+      : [];
 
     const displayName = input.identity.username ? `@${input.identity.username}` : input.identity.id;
 
@@ -718,6 +795,54 @@ async function persistConnectedAccount(input: PersistInput): Promise<CompleteCon
       },
     });
 
+    if (unresolvedRefreshes.length > 0) {
+      const lifecycleIds = unresolvedRefreshes.map((row) => row.id).sort();
+      const transientSecretIds = unresolvedRefreshes
+        .map((row) => row.credentialSecretId)
+        .filter((id): id is string => id !== null);
+      await tx
+        .update(providerXCredentialLifecycles)
+        .set({
+          state: "superseded",
+          credentialSecretId: null,
+          lastErrorCode: "SUPERSEDED_BY_RECONNECT",
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(providerXCredentialLifecycles.tenantId, input.tenantId),
+            inArray(providerXCredentialLifecycles.id, lifecycleIds),
+            inArray(providerXCredentialLifecycles.state, [
+              "inflight",
+              "credential_staged",
+              "needs_attention",
+            ]),
+          ),
+        );
+      if (transientSecretIds.length > 0) {
+        await tx
+          .delete(secrets)
+          .where(
+            and(eq(secrets.tenantId, input.tenantId), inArray(secrets.id, transientSecretIds)),
+          );
+      }
+      await append({
+        tenantId: input.tenantId,
+        actorType: "user",
+        actorId: input.callerUserId,
+        action: "provider.x.refresh.superseded_by_reconnect",
+        resourceType: "provider_account",
+        resourceId: providerAccountId,
+        metadata: {
+          workspaceId: input.workspaceId,
+          lifecycleIds,
+          priorStates: unresolvedRefreshes.map((row) => row.state).sort(),
+          newAccountRevision: account ? account.revision + 1 : 1,
+          requestId: input.requestId,
+        },
+      });
+    }
+
     return {
       providerAccountId,
       xUserId: input.identity.id,
@@ -756,22 +881,26 @@ export interface RefreshResult {
 
 /**
  * Refresh a connected X account's access token. SINGLE-FLIGHT per account: the
- * SELECT ... FOR UPDATE on the provider_accounts row inside the tenant-audited
- * transaction serializes concurrent callers, so the rotating refresh token is
- * spent exactly once. A loser blocks until the winner commits, then observes the
- * already-rotated credential version and returns without a second token call.
+ * A durable lifecycle intent serializes concurrent callers before provider I/O,
+ * so the rotating refresh token is spent exactly once. A loser observes the
+ * staged/adopted lifecycle and never makes a second token call.
  *
  * On upstream `invalid_grant` (revoked) the account is degraded + audited and we
- * throw X_REFRESH_REVOKED (fail closed). The vault write happens INSIDE the
- * critical section so a crash after the network call cannot leave the DB
- * pointing at a superseded (already-rotated-away) refresh token.
+ * throw X_REFRESH_REVOKED (fail closed). Every successful one-time response is
+ * encrypted before semantic validation; crashes adopt the staged response, and
+ * ambiguous outcomes disable the exact account revision until reconnect.
  */
 export async function refreshXProviderCredential(input: RefreshInput): Promise<RefreshResult> {
-  // The tx returns a discriminated outcome. A `revoked` outcome COMMITS the
-  // degrade + audit, then we throw AFTER the commit so the failure signal does
-  // not roll back the very degrade it is reporting (fail closed + durable).
-  type Outcome = { kind: "ok"; result: RefreshResult } | { kind: "revoked" };
-  const outcome = await withTenantAuditedTransaction<Outcome>(
+  type Prepared =
+    | { kind: "fresh"; result: RefreshResult }
+    | { kind: "wait"; lifecycleId: string }
+    | {
+        kind: "call";
+        lifecycleId: string;
+        refreshToken: string;
+        allowedScopes: string[];
+      };
+  const prepared = await withTenantAuditedTransaction<Prepared>(
     input.tenantId,
     async (txRaw, append) => {
       const tx = txRaw as DbExecutor;
@@ -789,28 +918,7 @@ export async function refreshXProviderCredential(input: RefreshInput): Promise<R
         .limit(1)
         .for("update");
 
-      if (!account)
-        throw new XConnectError("X_ACCOUNT_NOT_FOUND", 404, "provider account not found");
-      // Cross-workspace IDOR guard: the account MUST belong to the workspace the
-      // caller was authorized for. 404 (not 403) so account existence in another
-      // workspace does not leak.
-      if (account.workspaceId !== input.workspaceId) {
-        throw new XConnectError("X_ACCOUNT_NOT_FOUND", 404, "provider account not found");
-      }
-      if (account.adapterKey !== X_ADAPTER_KEY) {
-        throw new XConnectError("X_ACCOUNT_NOT_X", 400, "provider account is not an X account");
-      }
-      // Do NOT resurrect a locally revoked/disconnected account via refresh. A
-      // revoked account requires a fresh OAuth connect to become active again;
-      // silently reactivating it (especially after a best-effort upstream revoke
-      // failed) would restore an account the operator intended to kill.
-      if (account.status !== "active") {
-        throw new XConnectError(
-          "X_REFRESH_REVOKED",
-          409,
-          "provider account is not active; reconnect required",
-        );
-      }
+      assertXRefreshAccount(account, input.workspaceId);
       if (!account.credentialSecretId || account.credentialVersion == null) {
         throw new XConnectError("X_REFRESH_TOKEN_MISSING", 409, "account has no credential");
       }
@@ -828,7 +936,7 @@ export async function refreshXProviderCredential(input: RefreshInput): Promise<R
       // valid, skip the network call entirely.
       if (!input.force && !isNearExpiry(current.expiresAt)) {
         return {
-          kind: "ok",
+          kind: "fresh",
           result: {
             refreshed: false,
             credentialVersion: account.credentialVersion,
@@ -840,64 +948,499 @@ export async function refreshXProviderCredential(input: RefreshInput): Promise<R
       if (!current.refreshToken) {
         throw new XConnectError("X_REFRESH_TOKEN_MISSING", 409, "no refresh token on record");
       }
-
-      // Spend the rotating refresh token exactly once (still holding the lock).
-      const tokenRes = await refreshUpstream(input.config, current.refreshToken);
-
-      if (tokenRes.revoked) {
-        const [degraded] = await tx
-          .update(providerAccounts)
-          .set({ status: "revoked", revision: account.revision + 1, updatedAt: new Date() })
+      const [activeLifecycle] = await tx
+        .select({
+          id: providerXCredentialLifecycles.id,
+          state: providerXCredentialLifecycles.state,
+        })
+        .from(providerXCredentialLifecycles)
+        .where(
+          and(
+            eq(providerXCredentialLifecycles.tenantId, input.tenantId),
+            eq(providerXCredentialLifecycles.providerAccountId, account.id),
+            inArray(providerXCredentialLifecycles.state, [
+              "inflight",
+              "credential_staged",
+              "needs_attention",
+            ]),
+          ),
+        )
+        .limit(1);
+      if (activeLifecycle) {
+        if (activeLifecycle.state === "needs_attention") {
+          throw new XConnectError(
+            "X_CREDENTIAL_NEEDS_ATTENTION",
+            409,
+            "X refresh outcome must be recovered by reconnect",
+          );
+        }
+        return { kind: "wait", lifecycleId: activeLifecycle.id };
+      }
+      const lifecycleId = randomUUID();
+      await tx.insert(providerXCredentialLifecycles).values({
+        id: lifecycleId,
+        tenantId: input.tenantId,
+        workspaceId: account.workspaceId,
+        providerAccountId: account.id,
+        state: "inflight",
+        expectedAccountRevision: account.revision,
+      });
+      await append({
+        tenantId: input.tenantId,
+        actorType: input.actorId ? "user" : "system",
+        actorId: input.actorId ?? "system",
+        action: "provider.x.refresh.intent_staged",
+        resourceType: "provider_x_credential_lifecycle",
+        resourceId: lifecycleId,
+        metadata: {
+          workspaceId: account.workspaceId,
+          providerAccountId: account.id,
+          expectedAccountRevision: account.revision,
+          requestId: input.requestId ?? null,
+        },
+      });
+      return {
+        kind: "call",
+        lifecycleId,
+        refreshToken: current.refreshToken,
+        allowedScopes: current.payload.scopesGranted,
+      };
+    },
+  );
+  if (prepared.kind === "fresh") return prepared.result;
+  if (prepared.kind === "wait") {
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const [row] = await (getDb() as DbExecutor)
+        .select({ state: providerXCredentialLifecycles.state })
+        .from(providerXCredentialLifecycles)
+        .where(
+          and(
+            eq(providerXCredentialLifecycles.tenantId, input.tenantId),
+            eq(providerXCredentialLifecycles.id, prepared.lifecycleId),
+          ),
+        )
+        .limit(1);
+      if (row?.state === "credential_staged") {
+        return reconcileXRefreshLifecycle({ ...input, lifecycleId: prepared.lifecycleId });
+      }
+      if (row?.state === "adopted") {
+        const [account] = await (getDb() as DbExecutor)
+          .select()
+          .from(providerAccounts)
           .where(
             and(
               eq(providerAccounts.tenantId, input.tenantId),
-              eq(providerAccounts.id, account.id),
-              eq(providerAccounts.revision, account.revision),
+              eq(providerAccounts.id, input.accountId),
             ),
           )
-          .returning();
-        await append({
-          tenantId: input.tenantId,
-          actorType: input.actorId ? "user" : "system",
-          actorId: input.actorId ?? "system",
-          action: "provider.x.refresh.revoked",
-          resourceType: "provider_account",
-          resourceId: account.id,
-          metadata: {
-            workspaceId: account.workspaceId,
-            xUserId: account.externalRef,
-            previousRevision: account.revision,
-            newRevision: degraded?.revision ?? null,
-            requestId: input.requestId ?? null,
-          },
-        });
-        // COMMIT the degrade + audit; the caller-facing failure is thrown below.
-        return { kind: "revoked" };
+          .limit(1);
+        if (account?.credentialSecretId && account.credentialVersion != null) {
+          const credential = await loadCredential(
+            input.vault,
+            input.tenantId,
+            account.credentialSecretId,
+          );
+          return {
+            refreshed: false,
+            credentialVersion: account.credentialVersion,
+            expiresAt: credential.expiresAt,
+          };
+        }
       }
+      if (row?.state === "needs_attention" || row?.state === "revoked") {
+        throw new XConnectError(
+          "X_CREDENTIAL_NEEDS_ATTENTION",
+          409,
+          "concurrent X refresh did not complete",
+        );
+      }
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    await disableXAccountForLifecycle(input, prepared.lifecycleId, "REFRESH_OUTCOME_UNKNOWN");
+    throw new XConnectError(
+      "X_CREDENTIAL_NEEDS_ATTENTION",
+      409,
+      "X refresh outcome is unknown; reconnect required",
+    );
+  }
 
-      // Rotate the vault secret to a new version with the freshly issued tokens.
+  await afterXRefreshIntentForTests?.();
+  let tokenRes: RefreshUpstreamResult;
+  try {
+    tokenRes = await refreshUpstream(input.config, prepared.refreshToken);
+  } catch (error) {
+    await disableXAccountForLifecycle(input, prepared.lifecycleId, "REFRESH_OUTCOME_UNKNOWN");
+    throw error;
+  }
+  if (tokenRes.revoked) {
+    await revokeXAccountForLifecycle(input, prepared.lifecycleId);
+    throw new XConnectError("X_REFRESH_REVOKED", 409, "X refresh token revoked");
+  }
+  try {
+    await stageXRefreshResponse(input, prepared.lifecycleId, tokenRes.raw);
+  } catch (error) {
+    await disableXAccountForLifecycle(
+      input,
+      prepared.lifecycleId,
+      "REFRESH_RESPONSE_STAGING_FAILED",
+    );
+    throw error;
+  }
+  await afterXCredentialStageForTests?.();
+  return reconcileXRefreshLifecycle({
+    ...input,
+    lifecycleId: prepared.lifecycleId,
+    allowedScopes: prepared.allowedScopes,
+  });
+}
+
+interface XRefreshLifecycleSecret {
+  schemaVersion: "steward.provider-x.lifecycle.v1";
+  token: unknown;
+}
+
+function assertXRefreshAccount(
+  account: typeof providerAccounts.$inferSelect | undefined,
+  workspaceId: string,
+): asserts account is typeof providerAccounts.$inferSelect {
+  if (!account || account.workspaceId !== workspaceId) {
+    throw new XConnectError("X_ACCOUNT_NOT_FOUND", 404, "provider account not found");
+  }
+  if (account.adapterKey !== X_ADAPTER_KEY) {
+    throw new XConnectError("X_ACCOUNT_NOT_X", 400, "provider account is not an X account");
+  }
+  if (account.status !== "active") {
+    throw new XConnectError(
+      "X_REFRESH_REVOKED",
+      409,
+      "provider account is not active; reconnect required",
+    );
+  }
+}
+
+async function stageXRefreshResponse(
+  input: RefreshInput,
+  lifecycleId: string,
+  raw: unknown,
+): Promise<void> {
+  await withTenantAuditedTransaction(input.tenantId, async (txRaw, append) => {
+    const tx = txRaw as DbExecutor;
+    const secret = await input.vault.createSecretWithinTx(
+      tx,
+      input.tenantId,
+      `provider-x-lifecycle:${lifecycleId}`,
+      JSON.stringify({
+        schemaVersion: "steward.provider-x.lifecycle.v1",
+        token: raw,
+      } satisfies XRefreshLifecycleSecret),
+      { description: "Encrypted transient X OAuth rotation response" },
+    );
+    const [updated] = await tx
+      .update(providerXCredentialLifecycles)
+      .set({ state: "credential_staged", credentialSecretId: secret.id, updatedAt: new Date() })
+      .where(
+        and(
+          eq(providerXCredentialLifecycles.tenantId, input.tenantId),
+          eq(providerXCredentialLifecycles.id, lifecycleId),
+          eq(providerXCredentialLifecycles.state, "inflight"),
+        ),
+      )
+      .returning();
+    if (!updated) {
+      throw new XConnectError(
+        "X_CREDENTIAL_NEEDS_ATTENTION",
+        409,
+        "X refresh lifecycle changed before staging",
+      );
+    }
+    await append({
+      tenantId: input.tenantId,
+      actorType: "system",
+      actorId: "system",
+      action: "provider.x.refresh.credential_staged",
+      resourceType: "provider_x_credential_lifecycle",
+      resourceId: lifecycleId,
+      metadata: { providerAccountId: input.accountId, workspaceId: input.workspaceId },
+    });
+  });
+}
+
+async function disableXAccountForLifecycle(
+  input: RefreshInput,
+  lifecycleId: string,
+  reason: string,
+): Promise<void> {
+  await withTenantAuditedTransaction(input.tenantId, async (txRaw, append) => {
+    const tx = txRaw as DbExecutor;
+    const [lifecycle] = await tx
+      .select()
+      .from(providerXCredentialLifecycles)
+      .where(
+        and(
+          eq(providerXCredentialLifecycles.tenantId, input.tenantId),
+          eq(providerXCredentialLifecycles.id, lifecycleId),
+          eq(providerXCredentialLifecycles.workspaceId, input.workspaceId),
+          eq(providerXCredentialLifecycles.providerAccountId, input.accountId),
+        ),
+      )
+      .limit(1)
+      .for("update");
+    let accountDisabled = false;
+    if (lifecycle) {
+      const [disabled] = await tx
+        .update(providerAccounts)
+        .set({
+          status: "disabled",
+          revision: sql`${providerAccounts.revision} + 1`,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(providerAccounts.tenantId, input.tenantId),
+            eq(providerAccounts.workspaceId, input.workspaceId),
+            eq(providerAccounts.id, input.accountId),
+            eq(providerAccounts.revision, lifecycle.expectedAccountRevision),
+          ),
+        )
+        .returning({ id: providerAccounts.id });
+      accountDisabled = Boolean(disabled);
+      await tx
+        .update(providerXCredentialLifecycles)
+        .set({ state: "needs_attention", lastErrorCode: reason, updatedAt: new Date() })
+        .where(
+          and(
+            eq(providerXCredentialLifecycles.tenantId, input.tenantId),
+            eq(providerXCredentialLifecycles.id, lifecycleId),
+            inArray(providerXCredentialLifecycles.state, [
+              "inflight",
+              "credential_staged",
+              "needs_attention",
+            ]),
+          ),
+        );
+    }
+    await append({
+      tenantId: input.tenantId,
+      actorType: "system",
+      actorId: "system",
+      action: "provider.x.refresh.needs_attention",
+      resourceType: "provider_account",
+      resourceId: input.accountId,
+      metadata: { lifecycleId, reason, workspaceId: input.workspaceId, accountDisabled },
+    });
+  });
+}
+
+async function revokeXAccountForLifecycle(input: RefreshInput, lifecycleId: string): Promise<void> {
+  await withTenantAuditedTransaction(input.tenantId, async (txRaw, append) => {
+    const tx = txRaw as DbExecutor;
+    const [lifecycle] = await tx
+      .select()
+      .from(providerXCredentialLifecycles)
+      .where(
+        and(
+          eq(providerXCredentialLifecycles.tenantId, input.tenantId),
+          eq(providerXCredentialLifecycles.id, lifecycleId),
+          eq(providerXCredentialLifecycles.workspaceId, input.workspaceId),
+          eq(providerXCredentialLifecycles.providerAccountId, input.accountId),
+        ),
+      )
+      .limit(1)
+      .for("update");
+    let accountRevoked = false;
+    if (lifecycle) {
+      const [revoked] = await tx
+        .update(providerAccounts)
+        .set({
+          status: "revoked",
+          revision: sql`${providerAccounts.revision} + 1`,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(providerAccounts.tenantId, input.tenantId),
+            eq(providerAccounts.workspaceId, input.workspaceId),
+            eq(providerAccounts.id, input.accountId),
+            eq(providerAccounts.revision, lifecycle.expectedAccountRevision),
+          ),
+        )
+        .returning({ id: providerAccounts.id });
+      accountRevoked = Boolean(revoked);
+      await tx
+        .update(providerXCredentialLifecycles)
+        .set({ state: "revoked", lastErrorCode: "INVALID_GRANT", updatedAt: new Date() })
+        .where(
+          and(
+            eq(providerXCredentialLifecycles.tenantId, input.tenantId),
+            eq(providerXCredentialLifecycles.id, lifecycleId),
+          ),
+        );
+    }
+    await append({
+      tenantId: input.tenantId,
+      actorType: input.actorId ? "user" : "system",
+      actorId: input.actorId ?? "system",
+      action: "provider.x.refresh.revoked",
+      resourceType: "provider_account",
+      resourceId: input.accountId,
+      metadata: { lifecycleId, workspaceId: input.workspaceId, accountRevoked },
+    });
+  });
+}
+
+interface ValidatedXRefreshResponse {
+  accessToken: string;
+  refreshToken: string;
+  scopes: string[];
+  expiresIn?: number;
+}
+
+function validateXRefreshResponse(
+  raw: unknown,
+  allowedScopes: string[],
+): ValidatedXRefreshResponse {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new XConnectError("X_REFRESH_FAILED", 502, "X refresh response is invalid");
+  }
+  const token = raw as Record<string, unknown>;
+  if (
+    !isValidOAuthBearerToken(token.access_token) ||
+    !isValidOAuthOpaqueToken(token.refresh_token)
+  ) {
+    throw new XConnectError("X_REFRESH_FAILED", 502, "X refresh response is invalid");
+  }
+  if (
+    token.token_type !== undefined &&
+    (typeof token.token_type !== "string" || token.token_type.toLowerCase() !== "bearer")
+  ) {
+    throw new XConnectError("X_REFRESH_FAILED", 502, "X refresh token_type is invalid");
+  }
+  if (
+    token.expires_in !== undefined &&
+    (typeof token.expires_in !== "number" ||
+      !Number.isSafeInteger(token.expires_in) ||
+      token.expires_in <= 0 ||
+      token.expires_in > 86_400)
+  ) {
+    throw new XConnectError("X_REFRESH_FAILED", 502, "X refresh expires_in is invalid");
+  }
+  const scopes = parseXGrantedScopes(token.scope, allowedScopes, "X_REFRESH_FAILED");
+  return {
+    accessToken: token.access_token,
+    refreshToken: token.refresh_token,
+    scopes,
+    expiresIn: token.expires_in as number | undefined,
+  };
+}
+
+/** Adopt an encrypted single-use X refresh response without another provider call. */
+export async function reconcileXRefreshLifecycle(
+  input: RefreshInput & { lifecycleId: string; allowedScopes?: string[] },
+): Promise<RefreshResult> {
+  try {
+    return await withTenantAuditedTransaction(input.tenantId, async (txRaw, append) => {
+      const tx = txRaw as DbExecutor;
+      const [lifecycle] = await tx
+        .select()
+        .from(providerXCredentialLifecycles)
+        .where(
+          and(
+            eq(providerXCredentialLifecycles.tenantId, input.tenantId),
+            eq(providerXCredentialLifecycles.id, input.lifecycleId),
+            eq(providerXCredentialLifecycles.workspaceId, input.workspaceId),
+            eq(providerXCredentialLifecycles.providerAccountId, input.accountId),
+          ),
+        )
+        .limit(1)
+        .for("update");
+      if (!lifecycle || lifecycle.state !== "credential_staged" || !lifecycle.credentialSecretId) {
+        throw new XConnectError(
+          "X_CREDENTIAL_NEEDS_ATTENTION",
+          409,
+          "no staged X refresh credential",
+        );
+      }
+      const [account] = await tx
+        .select()
+        .from(providerAccounts)
+        .where(
+          and(
+            eq(providerAccounts.tenantId, input.tenantId),
+            eq(providerAccounts.id, input.accountId),
+          ),
+        )
+        .limit(1)
+        .for("update");
+      assertXRefreshAccount(account, input.workspaceId);
+      if (
+        account.revision !== lifecycle.expectedAccountRevision ||
+        !account.credentialSecretId ||
+        account.credentialVersion == null
+      ) {
+        throw new XConnectError(
+          "X_CREDENTIAL_NEEDS_ATTENTION",
+          409,
+          "X refresh account revision changed",
+        );
+      }
+      const current = await loadCredential(
+        input.vault,
+        input.tenantId,
+        account.credentialSecretId,
+        tx,
+      );
+      const [stagedSecret] = (await tx
+        .select()
+        .from(secrets)
+        .where(
+          and(eq(secrets.tenantId, input.tenantId), eq(secrets.id, lifecycle.credentialSecretId)),
+        )
+        .limit(1)) as Secret[];
+      if (!stagedSecret) {
+        throw new XConnectError(
+          "X_CREDENTIAL_NEEDS_ATTENTION",
+          409,
+          "staged X refresh credential is missing",
+        );
+      }
+      const staged = JSON.parse(
+        input.vault.decryptSecretRow(input.tenantId, stagedSecret),
+      ) as XRefreshLifecycleSecret;
+      if (staged.schemaVersion !== "steward.provider-x.lifecycle.v1") {
+        throw new XConnectError("X_REFRESH_FAILED", 502, "staged X refresh response is invalid");
+      }
+      const token = validateXRefreshResponse(
+        staged.token,
+        input.allowedScopes ?? current.payload.scopesGranted,
+      );
       const obtainedAt = new Date();
       const expiresAt =
-        typeof tokenRes.expiresIn === "number"
-          ? new Date(obtainedAt.getTime() + tokenRes.expiresIn * 1000)
-          : null;
-      const newPayload: XCredentialPayload = {
+        token.expiresIn === undefined
+          ? null
+          : new Date(obtainedAt.getTime() + token.expiresIn * 1000);
+      const payload: XCredentialPayload = {
         ...current.payload,
-        accessToken: tokenRes.accessToken,
-        // X rotates the refresh token; fall back to the prior one only if upstream
-        // omits it (should not happen with offline.access).
-        refreshToken: tokenRes.refreshToken ?? current.refreshToken,
-        scopesGranted: tokenRes.scopes ?? current.payload.scopesGranted,
+        accessToken: token.accessToken,
+        refreshToken: token.refreshToken,
+        scopesGranted: token.scopes,
         obtainedAt: obtainedAt.toISOString(),
-        expiresAt: expiresAt ? expiresAt.toISOString() : null,
+        expiresAt: expiresAt?.toISOString() ?? null,
       };
       const meta = await input.vault.rotateSecretWithinTx(
         tx,
         input.tenantId,
         current.secretName,
-        JSON.stringify(newPayload),
+        JSON.stringify(payload),
       );
-
+      await tx
+        .update(secretRoutes)
+        .set({ secretId: meta.id })
+        .where(
+          and(
+            eq(secretRoutes.tenantId, input.tenantId),
+            eq(secretRoutes.secretId, account.credentialSecretId),
+          ),
+        );
       const [updated] = await tx
         .update(providerAccounts)
         .set({
@@ -914,11 +1457,28 @@ export async function refreshXProviderCredential(input: RefreshInput): Promise<R
             eq(providerAccounts.revision, account.revision),
           ),
         )
-        .returning();
+        .returning({ id: providerAccounts.id });
       if (!updated) {
-        throw new XConnectError("X_REFRESH_FAILED", 409, "account revision conflict on refresh");
+        throw new XConnectError(
+          "X_CREDENTIAL_NEEDS_ATTENTION",
+          409,
+          "X refresh account changed before adoption",
+        );
       }
-
+      await tx
+        .update(providerXCredentialLifecycles)
+        .set({ state: "adopted", credentialSecretId: null, updatedAt: new Date() })
+        .where(
+          and(
+            eq(providerXCredentialLifecycles.tenantId, input.tenantId),
+            eq(providerXCredentialLifecycles.id, lifecycle.id),
+          ),
+        );
+      await tx
+        .delete(secrets)
+        .where(
+          and(eq(secrets.tenantId, input.tenantId), eq(secrets.id, lifecycle.credentialSecretId)),
+        );
       await append({
         tenantId: input.tenantId,
         actorType: input.actorId ? "user" : "system",
@@ -927,29 +1487,123 @@ export async function refreshXProviderCredential(input: RefreshInput): Promise<R
         resourceType: "provider_account",
         resourceId: account.id,
         metadata: {
-          workspaceId: account.workspaceId,
-          xUserId: account.externalRef,
-          credentialSecretId: meta.id,
+          lifecycleId: lifecycle.id,
+          workspaceId: input.workspaceId,
           credentialVersion: meta.version,
           requestId: input.requestId ?? null,
         },
       });
-
-      return {
-        kind: "ok",
-        result: {
-          refreshed: true,
-          credentialVersion: meta.version,
-          expiresAt: newPayload.expiresAt,
-        },
-      };
-    },
-  );
-
-  if (outcome.kind === "revoked") {
-    throw new XConnectError("X_REFRESH_REVOKED", 409, "X refresh token revoked");
+      return { refreshed: true, credentialVersion: meta.version, expiresAt: payload.expiresAt };
+    });
+  } catch (error) {
+    const adopted = await readAdoptedXRefreshResult(input);
+    if (adopted) return adopted;
+    await disableXAccountForLifecycle(input, input.lifecycleId, "STAGED_ADOPTION_FAILED");
+    throw error;
   }
-  return outcome.result;
+}
+
+async function readAdoptedXRefreshResult(
+  input: RefreshInput & { lifecycleId: string },
+): Promise<RefreshResult | null> {
+  const db = getDb() as DbExecutor;
+  const [lifecycle] = await db
+    .select({ state: providerXCredentialLifecycles.state })
+    .from(providerXCredentialLifecycles)
+    .where(
+      and(
+        eq(providerXCredentialLifecycles.tenantId, input.tenantId),
+        eq(providerXCredentialLifecycles.id, input.lifecycleId),
+        eq(providerXCredentialLifecycles.workspaceId, input.workspaceId),
+        eq(providerXCredentialLifecycles.providerAccountId, input.accountId),
+      ),
+    )
+    .limit(1);
+  if (lifecycle?.state !== "adopted") return null;
+  const [account] = await db
+    .select()
+    .from(providerAccounts)
+    .where(
+      and(
+        eq(providerAccounts.tenantId, input.tenantId),
+        eq(providerAccounts.workspaceId, input.workspaceId),
+        eq(providerAccounts.id, input.accountId),
+      ),
+    )
+    .limit(1);
+  if (!account?.credentialSecretId || account.credentialVersion == null) return null;
+  const credential = await loadCredential(input.vault, input.tenantId, account.credentialSecretId);
+  return {
+    refreshed: false,
+    credentialVersion: account.credentialVersion,
+    expiresAt: credential.expiresAt,
+  };
+}
+
+export interface XCredentialLifecycleSweepResult {
+  processed: number;
+  adopted: number;
+  attention: number;
+  remaining: boolean;
+}
+
+const X_LIFECYCLE_SWEEP_BATCH_SIZE = 25;
+const X_LIFECYCLE_STALE_AFTER_MS = X_FORWARD_TIMEOUT_MS + 5_000;
+
+/** Bounded all-tenant recovery for abandoned single-use X refresh rotations. */
+export async function runXCredentialLifecycleSweep(input: {
+  vault: SecretVault;
+  limit?: number;
+  now?: Date;
+}): Promise<XCredentialLifecycleSweepResult> {
+  const limit = Math.min(
+    X_LIFECYCLE_SWEEP_BATCH_SIZE,
+    Math.max(1, Math.floor(input.limit ?? X_LIFECYCLE_SWEEP_BATCH_SIZE)),
+  );
+  const now = input.now ?? new Date();
+  const staleBefore = new Date(now.getTime() - X_LIFECYCLE_STALE_AFTER_MS);
+  const rows = await (getDb() as DbExecutor)
+    .select()
+    .from(providerXCredentialLifecycles)
+    .where(
+      and(
+        inArray(providerXCredentialLifecycles.state, ["inflight", "credential_staged"]),
+        lte(providerXCredentialLifecycles.updatedAt, staleBefore),
+      ),
+    )
+    .orderBy(asc(providerXCredentialLifecycles.updatedAt))
+    .limit(limit);
+  const result: XCredentialLifecycleSweepResult = {
+    processed: 0,
+    adopted: 0,
+    attention: 0,
+    remaining: false,
+  };
+  for (const row of rows) {
+    result.processed += 1;
+    const recoveryInput: RefreshInput & { lifecycleId: string } = {
+      tenantId: row.tenantId,
+      workspaceId: row.workspaceId,
+      accountId: row.providerAccountId,
+      lifecycleId: row.id,
+      vault: input.vault,
+      config: { clientId: "recovery", clientSecret: "recovery" },
+      force: true,
+    };
+    try {
+      if (row.state === "credential_staged") {
+        await reconcileXRefreshLifecycle(recoveryInput);
+        result.adopted += 1;
+      } else {
+        await disableXAccountForLifecycle(recoveryInput, row.id, "REFRESH_OUTCOME_UNKNOWN");
+        result.attention += 1;
+      }
+    } catch {
+      result.attention += 1;
+    }
+  }
+  result.remaining = rows.length === limit && result.attention === 0;
+  return result;
 }
 
 interface LoadedCredential {
@@ -1009,10 +1663,7 @@ function isNearExpiry(expiresAtIso: string | null): boolean {
 
 interface RefreshUpstreamResult {
   revoked: boolean;
-  accessToken: string;
-  refreshToken?: string;
-  scopes?: string[];
-  expiresIn?: number;
+  raw: unknown;
 }
 
 async function refreshUpstream(
@@ -1038,24 +1689,14 @@ async function refreshUpstream(
   if (!res.ok) {
     // invalid_grant => the refresh token was revoked or already rotated away.
     if (parsed?.error === "invalid_grant") {
-      return { revoked: true, accessToken: "" };
+      return { revoked: true, raw: parsed };
     }
     throw new XConnectError("X_REFRESH_FAILED", 502, `X refresh failed (${res.status})`);
   }
-  if (
-    !parsed ||
-    !isValidOAuthBearerToken(parsed.access_token) ||
-    (parsed.refresh_token !== undefined && !isValidOAuthOpaqueToken(parsed.refresh_token))
-  ) {
-    throw new XConnectError("X_REFRESH_FAILED", 502, "X refresh response missing access_token");
-  }
-  return {
-    revoked: false,
-    accessToken: parsed.access_token,
-    refreshToken: parsed.refresh_token,
-    scopes: parsed.scope ? parsed.scope.split(/\s+/).filter(Boolean) : undefined,
-    expiresIn: parsed.expires_in,
-  };
+  // Successful rotating responses are intentionally returned unparsed. The
+  // caller encrypts the exact response before token/scope/time validation so a
+  // malformed one-time response can never strand the account on a spent token.
+  return { revoked: false, raw: res.json };
 }
 
 // ── Disconnect ────────────────────────────────────────────────────────────────

--- a/packages/api/src/services/provider-x-connect.ts
+++ b/packages/api/src/services/provider-x-connect.ts
@@ -1219,14 +1219,30 @@ export async function refreshXProviderCredential(input: RefreshInput): Promise<R
     // fail Steward's adoption grammar while still being live at the provider.
     const accessToken = candidate ? boundedStagedToken(candidate.access_token) : null;
     const refreshToken = candidate ? boundedStagedToken(candidate.refresh_token) : null;
-    if (accessToken || refreshToken) {
-      await revokeUpstreamBestEffort(
-        input.config,
-        accessToken ?? (refreshToken as string),
-        refreshToken,
-      ).catch(() => false);
+    const revokedAtUpstream =
+      accessToken || refreshToken
+        ? await revokeUpstreamBestEffort(
+            input.config,
+            accessToken ?? (refreshToken as string),
+            refreshToken,
+          ).catch(() => false)
+        : false;
+    if (revokedAtUpstream) {
+      await revokeXAccountForLifecycle(
+        input,
+        prepared.lifecycleId,
+        "ROTATED_GRANT_REVOKED_AFTER_STAGING_FAILURE",
+      );
+    } else {
+      // There is no durable handle because staging itself failed. Keep this
+      // lifecycle non-supersedable: reconnect must not proceed while the new
+      // rotated grant may still be live upstream.
+      await disableXAccountForLifecycle(
+        input,
+        prepared.lifecycleId,
+        "REFRESH_RESPONSE_STAGING_FAILED",
+      );
     }
-    await disableXAccountForLifecycle(input, prepared.lifecycleId, "REFRESH_OUTCOME_UNKNOWN");
     throw error;
   }
   await afterXCredentialStageForTests?.();
@@ -1375,7 +1391,11 @@ async function disableXAccountForLifecycle(
   });
 }
 
-async function revokeXAccountForLifecycle(input: RefreshInput, lifecycleId: string): Promise<void> {
+async function revokeXAccountForLifecycle(
+  input: RefreshInput,
+  lifecycleId: string,
+  reason = "INVALID_GRANT",
+): Promise<void> {
   await withTenantAuditedTransaction(input.tenantId, async (txRaw, append) => {
     const tx = txRaw as DbExecutor;
     const [lifecycle] = await tx
@@ -1412,7 +1432,7 @@ async function revokeXAccountForLifecycle(input: RefreshInput, lifecycleId: stri
       accountRevoked = Boolean(revoked);
       await tx
         .update(providerXCredentialLifecycles)
-        .set({ state: "revoked", lastErrorCode: "INVALID_GRANT", updatedAt: new Date() })
+        .set({ state: "revoked", lastErrorCode: reason, updatedAt: new Date() })
         .where(
           and(
             eq(providerXCredentialLifecycles.tenantId, input.tenantId),
@@ -1427,7 +1447,7 @@ async function revokeXAccountForLifecycle(input: RefreshInput, lifecycleId: stri
       action: "provider.x.refresh.revoked",
       resourceType: "provider_account",
       resourceId: input.accountId,
-      metadata: { lifecycleId, workspaceId: input.workspaceId, accountRevoked },
+      metadata: { lifecycleId, workspaceId: input.workspaceId, accountRevoked, reason },
     });
   });
 }

--- a/packages/api/src/services/provider-x-lifecycle-scheduler.ts
+++ b/packages/api/src/services/provider-x-lifecycle-scheduler.ts
@@ -1,0 +1,77 @@
+import { redactedThrownDiagnostics } from "@stwd/shared";
+import { SecretVault } from "@stwd/vault";
+import {
+  runXCredentialLifecycleSweep,
+  type XCredentialLifecycleSweepResult,
+} from "./provider-x-connect";
+
+const DEFAULT_INTERVAL_MS = 60_000;
+const MIN_INTERVAL_MS = 5_000;
+const MAX_INTERVAL_MS = 5 * 60_000;
+
+function configuredInterval(): number {
+  const raw = process.env.STEWARD_X_LIFECYCLE_SWEEP_INTERVAL_MS;
+  if (raw === undefined) return DEFAULT_INTERVAL_MS;
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed < MIN_INTERVAL_MS || parsed > MAX_INTERVAL_MS) {
+    throw new Error(
+      `STEWARD_X_LIFECYCLE_SWEEP_INTERVAL_MS must be between ${MIN_INTERVAL_MS} and ${MAX_INTERVAL_MS}`,
+    );
+  }
+  return parsed;
+}
+
+export async function runXCredentialLifecycleRecoverySweep(): Promise<XCredentialLifecycleSweepResult> {
+  const password = process.env.STEWARD_MASTER_PASSWORD?.trim();
+  if (!password) throw new Error("STEWARD_MASTER_PASSWORD is required for X OAuth recovery");
+  return runXCredentialLifecycleSweep({ vault: new SecretVault(password) });
+}
+
+export function startXCredentialLifecycleScheduler(options?: {
+  intervalMs?: number;
+  sweep?: () => Promise<XCredentialLifecycleSweepResult>;
+}): () => Promise<void> {
+  const sweep = options?.sweep ?? runXCredentialLifecycleRecoverySweep;
+  let active: Promise<void> | undefined;
+  let stopped = false;
+  let rerunRequested = false;
+  const tick = () => {
+    if (stopped) return;
+    if (active) {
+      rerunRequested = true;
+      return;
+    }
+    active = sweep()
+      .then((result) => {
+        rerunRequested ||= result.remaining;
+        if (result.processed > 0) {
+          console.log(
+            `[provider-x] reconciled ${result.processed} lifecycle(s): ` +
+              `${result.adopted} adopted, ${result.attention} attention`,
+          );
+        }
+      })
+      .catch((error) => {
+        const classified = redactedThrownDiagnostics(error);
+        console.error("[provider-x] lifecycle sweep failed", {
+          errorClass: classified.errorClass,
+          errorCode: classified.errorCode,
+        });
+      })
+      .finally(() => {
+        active = undefined;
+        if (rerunRequested && !stopped) {
+          rerunRequested = false;
+          queueMicrotask(tick);
+        }
+      });
+  };
+  const timer = setInterval(tick, options?.intervalMs ?? configuredInterval());
+  timer.unref?.();
+  tick();
+  return async () => {
+    stopped = true;
+    clearInterval(timer);
+    await active;
+  };
+}

--- a/packages/api/src/services/provider-x-lifecycle-scheduler.ts
+++ b/packages/api/src/services/provider-x-lifecycle-scheduler.ts
@@ -1,6 +1,7 @@
 import { redactedThrownDiagnostics } from "@stwd/shared";
 import { SecretVault } from "@stwd/vault";
 import {
+  resolveXConnectConfig,
   runXCredentialLifecycleSweep,
   type XCredentialLifecycleSweepResult,
 } from "./provider-x-connect";
@@ -24,7 +25,10 @@ function configuredInterval(): number {
 export async function runXCredentialLifecycleRecoverySweep(): Promise<XCredentialLifecycleSweepResult> {
   const password = process.env.STEWARD_MASTER_PASSWORD?.trim();
   if (!password) throw new Error("STEWARD_MASTER_PASSWORD is required for X OAuth recovery");
-  return runXCredentialLifecycleSweep({ vault: new SecretVault(password) });
+  return runXCredentialLifecycleSweep({
+    vault: new SecretVault(password),
+    config: resolveXConnectConfig(),
+  });
 }
 
 export function startXCredentialLifecycleScheduler(options?: {
@@ -47,7 +51,7 @@ export function startXCredentialLifecycleScheduler(options?: {
         if (result.processed > 0) {
           console.log(
             `[provider-x] reconciled ${result.processed} lifecycle(s): ` +
-              `${result.adopted} adopted, ${result.attention} attention`,
+              `${result.adopted} adopted, ${result.revoked} revoked, ${result.attention} attention`,
           );
         }
       })

--- a/packages/api/src/worker.ts
+++ b/packages/api/src/worker.ts
@@ -64,6 +64,8 @@ export interface Env {
   GITHUB_CLIENT_SECRET?: string;
   TWITTER_CLIENT_ID?: string;
   TWITTER_CLIENT_SECRET?: string;
+  X_CLIENT_ID?: string;
+  X_CLIENT_SECRET?: string;
   PASSKEY_RP_ID?: string;
   PASSKEY_ORIGIN?: string;
   PASSKEY_RP_NAME?: string;
@@ -122,6 +124,26 @@ export async function runWorkerGoogleCredentialLifecycleSweep(
     options?.sweep ??
     (await import("./services/provider-google-lifecycle-scheduler"))
       .runGoogleCredentialLifecycleRecoverySweep;
+  return sweep();
+}
+
+export async function runWorkerXCredentialLifecycleSweep(
+  env: Env,
+  options?: { sweep?: () => Promise<unknown> },
+): Promise<unknown | null> {
+  hydrateProcessEnv(env);
+  if (
+    process.env.STEWARD_X_LIFECYCLE_SWEEPER === "false" ||
+    !process.env.X_CLIENT_ID ||
+    !process.env.X_CLIENT_SECRET ||
+    !process.env.STEWARD_MASTER_PASSWORD
+  ) {
+    return null;
+  }
+  const sweep =
+    options?.sweep ??
+    (await import("./services/provider-x-lifecycle-scheduler"))
+      .runXCredentialLifecycleRecoverySweep;
   return sweep();
 }
 
@@ -262,6 +284,7 @@ export default {
       Promise.all([
         runWorkerUpstreamCredentialLeaseSweep(env),
         runWorkerGoogleCredentialLifecycleSweep(env),
+        runWorkerXCredentialLifecycleSweep(env),
       ]),
     );
   },

--- a/packages/db/drizzle/0104_x_refresh_rotation_recovery.sql
+++ b/packages/db/drizzle/0104_x_refresh_rotation_recovery.sql
@@ -1,0 +1,20 @@
+CREATE TABLE "provider_x_credential_lifecycles" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" varchar(64) NOT NULL,
+	"workspace_id" uuid NOT NULL,
+	"provider_account_id" uuid NOT NULL,
+	"state" varchar(32) NOT NULL,
+	"credential_secret_id" uuid,
+	"expected_account_revision" integer NOT NULL,
+	"last_error_code" varchar(64),
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "provider_x_lifecycle_state_check" CHECK ("state" IN ('inflight', 'credential_staged', 'adopted', 'revoked', 'needs_attention', 'superseded')),
+	CONSTRAINT "provider_x_lifecycle_workspace_fk" FOREIGN KEY ("tenant_id", "workspace_id") REFERENCES "workspaces"("tenant_id", "id") ON DELETE cascade,
+	CONSTRAINT "provider_x_lifecycle_account_fk" FOREIGN KEY ("tenant_id", "workspace_id", "provider_account_id") REFERENCES "provider_accounts"("tenant_id", "workspace_id", "id") ON DELETE cascade,
+	CONSTRAINT "provider_x_lifecycle_secret_fk" FOREIGN KEY ("tenant_id", "credential_secret_id") REFERENCES "secrets"("tenant_id", "id") ON DELETE restrict
+);
+--> statement-breakpoint
+CREATE INDEX "provider_x_lifecycle_account_state_idx" ON "provider_x_credential_lifecycles" USING btree ("tenant_id", "provider_account_id", "state");
+--> statement-breakpoint
+CREATE UNIQUE INDEX "provider_x_lifecycle_active_refresh_idx" ON "provider_x_credential_lifecycles" USING btree ("tenant_id", "provider_account_id") WHERE "state" IN ('inflight', 'credential_staged', 'needs_attention');

--- a/packages/db/drizzle/0104_x_refresh_rotation_recovery.sql
+++ b/packages/db/drizzle/0104_x_refresh_rotation_recovery.sql
@@ -10,6 +10,8 @@ CREATE TABLE "provider_x_credential_lifecycles" (
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
 	CONSTRAINT "provider_x_lifecycle_state_check" CHECK ("state" IN ('inflight', 'credential_staged', 'revocation_pending', 'adopted', 'revoked', 'needs_attention', 'superseded')),
+	CONSTRAINT "provider_x_lifecycle_revision_check" CHECK ("expected_account_revision" >= 1),
+	CONSTRAINT "provider_x_lifecycle_secret_state_check" CHECK (("state" = 'inflight' AND "credential_secret_id" IS NULL) OR ("state" IN ('credential_staged', 'revocation_pending') AND "credential_secret_id" IS NOT NULL) OR "state" = 'needs_attention' OR ("state" IN ('adopted', 'revoked', 'superseded') AND "credential_secret_id" IS NULL)),
 	CONSTRAINT "provider_x_lifecycle_workspace_fk" FOREIGN KEY ("tenant_id", "workspace_id") REFERENCES "workspaces"("tenant_id", "id") ON DELETE cascade,
 	CONSTRAINT "provider_x_lifecycle_account_fk" FOREIGN KEY ("tenant_id", "workspace_id", "provider_account_id") REFERENCES "provider_accounts"("tenant_id", "workspace_id", "id") ON DELETE cascade,
 	CONSTRAINT "provider_x_lifecycle_secret_fk" FOREIGN KEY ("tenant_id", "credential_secret_id") REFERENCES "secrets"("tenant_id", "id") ON DELETE restrict

--- a/packages/db/drizzle/0104_x_refresh_rotation_recovery.sql
+++ b/packages/db/drizzle/0104_x_refresh_rotation_recovery.sql
@@ -9,7 +9,7 @@ CREATE TABLE "provider_x_credential_lifecycles" (
 	"last_error_code" varchar(64),
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
-	CONSTRAINT "provider_x_lifecycle_state_check" CHECK ("state" IN ('inflight', 'credential_staged', 'adopted', 'revoked', 'needs_attention', 'superseded')),
+	CONSTRAINT "provider_x_lifecycle_state_check" CHECK ("state" IN ('inflight', 'credential_staged', 'revocation_pending', 'adopted', 'revoked', 'needs_attention', 'superseded')),
 	CONSTRAINT "provider_x_lifecycle_workspace_fk" FOREIGN KEY ("tenant_id", "workspace_id") REFERENCES "workspaces"("tenant_id", "id") ON DELETE cascade,
 	CONSTRAINT "provider_x_lifecycle_account_fk" FOREIGN KEY ("tenant_id", "workspace_id", "provider_account_id") REFERENCES "provider_accounts"("tenant_id", "workspace_id", "id") ON DELETE cascade,
 	CONSTRAINT "provider_x_lifecycle_secret_fk" FOREIGN KEY ("tenant_id", "credential_secret_id") REFERENCES "secrets"("tenant_id", "id") ON DELETE restrict
@@ -17,4 +17,4 @@ CREATE TABLE "provider_x_credential_lifecycles" (
 --> statement-breakpoint
 CREATE INDEX "provider_x_lifecycle_account_state_idx" ON "provider_x_credential_lifecycles" USING btree ("tenant_id", "provider_account_id", "state");
 --> statement-breakpoint
-CREATE UNIQUE INDEX "provider_x_lifecycle_active_refresh_idx" ON "provider_x_credential_lifecycles" USING btree ("tenant_id", "provider_account_id") WHERE "state" IN ('inflight', 'credential_staged', 'needs_attention');
+CREATE UNIQUE INDEX "provider_x_lifecycle_active_refresh_idx" ON "provider_x_credential_lifecycles" USING btree ("tenant_id", "provider_account_id") WHERE "state" IN ('inflight', 'credential_staged', 'revocation_pending', 'needs_attention');

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -589,6 +589,13 @@
       "when": 1787107600000,
       "tag": "0103_google_refresh_reconnect_recovery",
       "breakpoints": true
+    },
+    {
+      "idx": 104,
+      "version": "7",
+      "when": 1787107601000,
+      "tag": "0104_x_refresh_rotation_recovery",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/rls-inventory.ts
+++ b/packages/db/src/rls-inventory.ts
@@ -37,6 +37,7 @@ export const DIRECT_TENANT_TABLES = [
   "provider_grants",
   "provider_operations",
   "provider_role_bindings",
+  "provider_x_credential_lifecycles",
   "proxy_audit_log",
   "refresh_tokens",
   "secret_routes",

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -2149,7 +2149,7 @@ export const providerXCredentialLifecycles = pgTable(
     }).onDelete("restrict"),
     stateCheck: check(
       "provider_x_lifecycle_state_check",
-      sql`${table.state} IN ('inflight', 'credential_staged', 'adopted', 'revoked', 'needs_attention', 'superseded')`,
+      sql`${table.state} IN ('inflight', 'credential_staged', 'revocation_pending', 'adopted', 'revoked', 'needs_attention', 'superseded')`,
     ),
     accountStateIdx: index("provider_x_lifecycle_account_state_idx").on(
       table.tenantId,
@@ -2158,7 +2158,9 @@ export const providerXCredentialLifecycles = pgTable(
     ),
     activeRefreshIdx: uniqueIndex("provider_x_lifecycle_active_refresh_idx")
       .on(table.tenantId, table.providerAccountId)
-      .where(sql`${table.state} IN ('inflight', 'credential_staged', 'needs_attention')`),
+      .where(
+        sql`${table.state} IN ('inflight', 'credential_staged', 'revocation_pending', 'needs_attention')`,
+      ),
   }),
 );
 

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -2151,6 +2151,14 @@ export const providerXCredentialLifecycles = pgTable(
       "provider_x_lifecycle_state_check",
       sql`${table.state} IN ('inflight', 'credential_staged', 'revocation_pending', 'adopted', 'revoked', 'needs_attention', 'superseded')`,
     ),
+    revisionCheck: check(
+      "provider_x_lifecycle_revision_check",
+      sql`${table.expectedAccountRevision} >= 1`,
+    ),
+    secretStateCheck: check(
+      "provider_x_lifecycle_secret_state_check",
+      sql`(${table.state} = 'inflight' AND ${table.credentialSecretId} IS NULL) OR (${table.state} IN ('credential_staged', 'revocation_pending') AND ${table.credentialSecretId} IS NOT NULL) OR ${table.state} = 'needs_attention' OR (${table.state} IN ('adopted', 'revoked', 'superseded') AND ${table.credentialSecretId} IS NULL)`,
+    ),
     accountStateIdx: index("provider_x_lifecycle_account_state_idx").on(
       table.tenantId,
       table.providerAccountId,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -2108,6 +2108,60 @@ export const providerGoogleCredentialLifecycles = pgTable(
   }),
 );
 
+/**
+ * Durable hand-off journal for X OAuth refresh-token rotation. X refresh
+ * tokens are single use, so a provider response must be encrypted before any
+ * semantic validation that can fail. Reconnect is the explicit recovery
+ * boundary for unresolved outcomes.
+ */
+export const providerXCredentialLifecycles = pgTable(
+  "provider_x_credential_lifecycles",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    tenantId: varchar("tenant_id", { length: 64 }).notNull(),
+    workspaceId: uuid("workspace_id").notNull(),
+    providerAccountId: uuid("provider_account_id").notNull(),
+    state: varchar("state", { length: 32 }).notNull(),
+    credentialSecretId: uuid("credential_secret_id"),
+    expectedAccountRevision: integer("expected_account_revision").notNull(),
+    lastErrorCode: varchar("last_error_code", { length: 64 }),
+    ...timestamps,
+  },
+  (table) => ({
+    workspaceFk: foreignKey({
+      columns: [table.tenantId, table.workspaceId],
+      foreignColumns: [workspaces.tenantId, workspaces.id],
+      name: "provider_x_lifecycle_workspace_fk",
+    }).onDelete("cascade"),
+    accountFk: foreignKey({
+      columns: [table.tenantId, table.workspaceId, table.providerAccountId],
+      foreignColumns: [
+        providerAccounts.tenantId,
+        providerAccounts.workspaceId,
+        providerAccounts.id,
+      ],
+      name: "provider_x_lifecycle_account_fk",
+    }).onDelete("cascade"),
+    secretFk: foreignKey({
+      columns: [table.tenantId, table.credentialSecretId],
+      foreignColumns: [secrets.tenantId, secrets.id],
+      name: "provider_x_lifecycle_secret_fk",
+    }).onDelete("restrict"),
+    stateCheck: check(
+      "provider_x_lifecycle_state_check",
+      sql`${table.state} IN ('inflight', 'credential_staged', 'adopted', 'revoked', 'needs_attention', 'superseded')`,
+    ),
+    accountStateIdx: index("provider_x_lifecycle_account_state_idx").on(
+      table.tenantId,
+      table.providerAccountId,
+      table.state,
+    ),
+    activeRefreshIdx: uniqueIndex("provider_x_lifecycle_active_refresh_idx")
+      .on(table.tenantId, table.providerAccountId)
+      .where(sql`${table.state} IN ('inflight', 'credential_staged', 'needs_attention')`),
+  }),
+);
+
 // NOTE: owner immutability enforced by `provider_operations_immutable_owner`
 // trigger in 0079 raw SQL. Not visible to drizzle-kit.
 export const providerOperations = pgTable(


### PR DESCRIPTION
Refs #195

Follow-up to merged #438.

## Summary

- commit a tenant/account/revision-bound refresh intent before spending X's single-use refresh token
- encrypt the exact successful provider response before validating access token, rotated refresh token, scope, token type, or expiry
- adopt a valid staged response after crashes without another provider call; disable the exact account revision on ambiguous or invalid outcomes
- retain invalid/scope-widened staged credentials as encrypted revocation handles, autonomously revoke the exact rotated credential, and retry ambiguous revocation without replaying refresh
- run bounded autonomous recovery for abandoned intents, staged responses, and pending revocations in both Bun and Cloudflare Worker runtimes
- block reconnect while an exact staged handle is unresolved; allow reconnect only after proven revocation or safe handle-less supersession
- validate connect-time scope/token type/expiry before identity lookup or state consumption
- classify the new tenant table in the SEC-169 RLS inventory

## Security invariants

- the old rotating refresh token is never posted twice
- malformed/scope-widened/time-invalid successful responses retain encrypted recovery evidence and disable execution
- a pre-provider crash is detected by autonomous recovery; a valid post-stage crash adopts from escrow
- a staged invalid credential is revoked through X's fixed revocation endpoint; failure retains the exact encrypted handle for a later retry
- credential-bearing OAuth calls refuse redirects, and only RFC 7009 HTTP 200 counts as synchronous revocation proof
- Worker cron recovery is enabled only when provider credentials and the master password are present
- reconnect and late recovery are revision-bound, so stale work cannot disable or overwrite the new credential
- raw OAuth material never enters lifecycle or audit rows

## Exact-head evidence

Head: `2fd139dcb7f340f4631f61f6320670af9fd8ecde`
Base: `f4671bf3f705c7db72cf6c28f632284513a5511a`

- combined X lifecycle + actual Worker recovery + migration-tip suite: 40/40, 200 assertions
- migration journal-tip validation: 2/2, 3 assertions
- dependency-aware API build: 24/24 on the exact live head
- Biome and diff-check: green
- frozen dependency install: green

The revocation regressions prove reconnect is denied before cleanup, successful cleanup removes the transient handle, an upstream 503 retains it for a second exact-token attempt, a grammar-rejected rotated refresh string is still revoked exactly as returned, and provider refresh count remains exactly one throughout.