### PR TITLE
feat(db): add transaction-capable Workers transport

### DIFF
--- a/packages/db/CLOUDFLARE.md
+++ b/packages/db/CLOUDFLARE.md
@@ -81,3 +81,20 @@ that would not work over HTTP, and Steward's actual posture on each, are:
     correctly over the HTTP transport) must be re-reviewed before adopting it.
 - Long-running multi-statement transactions — the audit chain relies on them
   on postgres-js; on neon-http they fail closed as described above.
+
+## Transaction-capable RLS transport checkpoint
+
+`createNeonTransactionDbForRequest()` provides a request-scoped Neon WebSocket
+pool with exactly one connection. It supports Drizzle callback transactions and
+is therefore eligible for `withTenantRlsTransaction(..., "neon-websocket", ...)`.
+The handle exposes an idempotent `close()` which callers must await before a
+Worker request finishes.
+
+This is a transport primitive, not RLS activation. The shipped Worker remains
+on `DATABASE_DRIVER=neon-http` until authenticated request middleware can mint
+a trusted tenant capability and propagate the transaction-bound database to
+every downstream query. To prevent partial adoption, `getDb()` and the legacy
+`createDbForRequest()` reject `neon-websocket`; callers must use the explicit
+request-scoped handle. FORCE RLS remains blocked until bootstrap credential
+functions, request-wide propagation, background-job scoping, schema backfills,
+and all-table policies are complete (SEC-169).

--- a/packages/db/src/__tests__/neon-transaction-driver.test.ts
+++ b/packages/db/src/__tests__/neon-transaction-driver.test.ts
@@ -19,10 +19,38 @@ describe("transaction-capable Workers database driver", () => {
   });
 
   test("does not silently route a request-scoped socket through the legacy helper", () => {
+    expect(() =>
+      createDbForRequest({
+        DATABASE_DRIVER: " neon-websocket ",
+        DATABASE_URL: "postgresql://example.invalid/steward",
+      }),
+    ).toThrow("RLS_TRANSACTION_HANDLE_REQUIRED");
+  });
+
+  test("also rejects process-level socket selection for non-Worker callers", () => {
     process.env.DATABASE_DRIVER = "neon-websocket";
     expect(() =>
       createDbForRequest({ DATABASE_URL: "postgresql://example.invalid/steward" }),
     ).toThrow("RLS_TRANSACTION_HANDLE_REQUIRED");
+  });
+
+  test("does not let an empty binding bypass process-level socket selection", () => {
+    process.env.DATABASE_DRIVER = "neon-websocket";
+    expect(() =>
+      createDbForRequest({
+        DATABASE_DRIVER: "   ",
+        DATABASE_URL: "postgresql://example.invalid/steward",
+      }),
+    ).toThrow("RLS_TRANSACTION_HANDLE_REQUIRED");
+  });
+
+  test("rejects unknown request driver bindings instead of silently using HTTP", () => {
+    expect(() =>
+      createDbForRequest({
+        DATABASE_DRIVER: "bogus",
+        DATABASE_URL: "postgresql://example.invalid/steward",
+      }),
+    ).toThrow("DATABASE_DRIVER_UNSUPPORTED");
   });
 
   test("requires explicit driver selection before opening a socket", () => {

--- a/packages/db/src/__tests__/neon-transaction-driver.test.ts
+++ b/packages/db/src/__tests__/neon-transaction-driver.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  createDbForRequest,
+  createNeonTransactionDbForRequest,
+  getDatabaseDriver,
+} from "../client";
+
+const originalDriver = process.env.DATABASE_DRIVER;
+
+afterEach(() => {
+  if (originalDriver === undefined) delete process.env.DATABASE_DRIVER;
+  else process.env.DATABASE_DRIVER = originalDriver;
+});
+
+describe("transaction-capable Workers database driver", () => {
+  test("recognizes the explicit transaction-capable driver", () => {
+    process.env.DATABASE_DRIVER = "neon-websocket";
+    expect(getDatabaseDriver()).toBe("neon-websocket");
+  });
+
+  test("does not silently route a request-scoped socket through the legacy helper", () => {
+    process.env.DATABASE_DRIVER = "neon-websocket";
+    expect(() =>
+      createDbForRequest({ DATABASE_URL: "postgresql://example.invalid/steward" }),
+    ).toThrow("RLS_TRANSACTION_HANDLE_REQUIRED");
+  });
+
+  test("requires explicit driver selection before opening a socket", () => {
+    expect(() =>
+      createNeonTransactionDbForRequest({
+        DATABASE_DRIVER: "neon-http",
+        DATABASE_URL: "postgresql://example.invalid/steward",
+      }),
+    ).toThrow("RLS_TRANSACTION_DRIVER_REQUIRED");
+  });
+
+  test("returns an explicitly closeable request handle with idempotent cleanup", async () => {
+    const handle = createNeonTransactionDbForRequest({
+      DATABASE_DRIVER: "neon-websocket",
+      DATABASE_URL: "postgresql://example.invalid/steward",
+    });
+    expect(handle.driver).toBe("neon-websocket");
+    expect(typeof handle.db.transaction).toBe("function");
+    await Promise.all([handle.close(), handle.close()]);
+  });
+});

--- a/packages/db/src/__tests__/tenant-rls-context.test.ts
+++ b/packages/db/src/__tests__/tenant-rls-context.test.ts
@@ -58,6 +58,7 @@ describe("tenant RLS transaction context", () => {
       }),
     ).toThrow("RLS_TENANT_AUTHORITY_INVALID");
     expect(() => assertTenantRlsDriver("neon-http")).toThrow("RLS_TRANSACTION_UNSUPPORTED");
+    expect(() => assertTenantRlsDriver("neon-websocket")).not.toThrow();
 
     const db = { transaction: async () => undefined };
     await expect(
@@ -147,5 +148,28 @@ describe("tenant RLS transaction context", () => {
       ),
     ).rejects.toThrow("RLS_TRANSACTION_UNSUPPORTED");
     expect(opened).toBe(false);
+  });
+
+  test("binds tenant context through the transaction-capable Workers driver", async () => {
+    let executeCount = 0;
+    const tx = {
+      async execute() {
+        executeCount += 1;
+        return executeCount === 3 ? [{ tenant_id: "tenant-worker" }] : [];
+      },
+    };
+    const db = {
+      async transaction<T>(callback: (value: typeof tx) => Promise<T>) {
+        return callback(tx);
+      },
+    };
+    const result = await withTenantRlsTransaction(
+      db,
+      "neon-websocket",
+      tenantContextForInternalJob({ tenantId: "tenant-worker", job: "worker-request" }),
+      async () => "bound",
+    );
+    expect(result).toBe("bound");
+    expect(executeCount).toBe(3);
   });
 });

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -380,8 +380,16 @@ export function createNeonTransactionDbForRequest(env: {
  * @param env  An object with a DATABASE_URL string field. Workers pass in the
  *             whole `env` binding object.
  */
-export function createDbForRequest(env: { DATABASE_URL?: string }) {
-  if (getDatabaseDriver() === "neon-websocket") {
+export function createDbForRequest(env: { DATABASE_URL?: string; DATABASE_DRIVER?: string }) {
+  // Worker bindings are the authority for this request. Falling back to the
+  // process-level selector keeps the helper compatible with Bun/Node callers,
+  // but must not let an explicit WebSocket binding silently create neon-http.
+  const bindingDriver = env.DATABASE_DRIVER?.trim().toLowerCase();
+  if (bindingDriver && bindingDriver !== "neon-http" && bindingDriver !== "neon-websocket") {
+    throw new Error("DATABASE_DRIVER_UNSUPPORTED: createDbForRequest() supports neon-http only");
+  }
+  const driver = bindingDriver || getDatabaseDriver();
+  if (driver === "neon-websocket") {
     throw new Error(
       "RLS_TRANSACTION_HANDLE_REQUIRED: use createNeonTransactionDbForRequest() and await close()",
     );

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -6,6 +6,8 @@
  *                                  Used by Bun/Node entry points.
  *   - "neon-http"                — HTTP-only fetch driver via @neondatabase/serverless.
  *                                  Used by Cloudflare Workers (no TCP, no pools).
+ *   - "neon-websocket"           — request-scoped Neon WebSocket pool.
+ *                                  Transaction-capable Workers transport for RLS.
  *   - PGLite                     — in-process WASM, set via setPGLiteOverride()
  *                                  from the embedded/desktop entry point.
  *
@@ -23,6 +25,7 @@
  */
 
 import { drizzle as drizzleNeon, type NeonHttpDatabase } from "drizzle-orm/neon-http";
+import { drizzle as drizzleNeonWebSocket, type NeonDatabase } from "drizzle-orm/neon-serverless";
 import { drizzle as drizzlePostgres, type PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import type { PGLiteDb } from "./pglite";
@@ -34,7 +37,7 @@ declare const process: {
   env: Record<string, string | undefined>;
 };
 
-export type DatabaseDriver = "postgres-js" | "neon-http";
+export type DatabaseDriver = "postgres-js" | "neon-http" | "neon-websocket";
 
 const FULL_SCHEMA = { ...schema, ...schemaAuth };
 type FullSchema = typeof FULL_SCHEMA;
@@ -42,6 +45,7 @@ type FullSchema = typeof FULL_SCHEMA;
 export function getDatabaseDriver(): DatabaseDriver {
   const raw = process.env.DATABASE_DRIVER?.trim().toLowerCase();
   if (raw === "neon-http") return "neon-http";
+  if (raw === "neon-websocket") return "neon-websocket";
   return "postgres-js";
 }
 
@@ -308,6 +312,62 @@ export function createNeonHttpDb(
   return { client, db };
 }
 
+// ─── neon-websocket (transaction-capable Workers) ───────────────────────────
+
+export interface NeonTransactionDbHandle {
+  driver: "neon-websocket";
+  db: NeonDatabase<FullSchema>;
+  close(): Promise<void>;
+}
+
+/**
+ * Create one request-scoped, transaction-capable Neon database handle.
+ *
+ * Unlike neon-http, the WebSocket transport pins an interactive transaction
+ * to one checked-out connection, so `withTenantRlsTransaction()` can safely
+ * use transaction-local `set_config`. The caller MUST await `close()` after
+ * every request (normally from a `finally` block before returning the
+ * response). This handle is deliberately excluded from the global singleton:
+ * a Worker isolate must not retain request-owned sockets after the request's
+ * lifetime.
+ */
+export function createNeonTransactionDbForRequest(env: {
+  DATABASE_URL?: string;
+  DATABASE_DRIVER?: string;
+}): NeonTransactionDbHandle {
+  if (env.DATABASE_DRIVER?.trim().toLowerCase() !== "neon-websocket") {
+    throw new Error(
+      "RLS_TRANSACTION_DRIVER_REQUIRED: set DATABASE_DRIVER=neon-websocket for transaction-capable Workers database access",
+    );
+  }
+  const connectionString = env.DATABASE_URL;
+  if (!connectionString) {
+    throw new Error(
+      "DATABASE_URL binding is required for transaction-capable Workers database access",
+    );
+  }
+  assertDatabaseUrlTls(connectionString);
+  const { Pool } = require("@neondatabase/serverless") as {
+    Pool: new (config: {
+      connectionString: string;
+      max: number;
+    }) => {
+      end(): Promise<void>;
+    };
+  };
+  const pool = new Pool({ connectionString, max: 1 });
+  const db = drizzleNeonWebSocket(pool as never, { schema: FULL_SCHEMA });
+  let closePromise: Promise<void> | undefined;
+  return {
+    driver: "neon-websocket",
+    db,
+    close() {
+      closePromise ??= pool.end();
+      return closePromise;
+    },
+  };
+}
+
 /**
  * Build a Drizzle instance from Worker `env` bindings. Intended to be wired
  * into a per-request Hono middleware:
@@ -321,6 +381,11 @@ export function createNeonHttpDb(
  *             whole `env` binding object.
  */
 export function createDbForRequest(env: { DATABASE_URL?: string }) {
+  if (getDatabaseDriver() === "neon-websocket") {
+    throw new Error(
+      "RLS_TRANSACTION_HANDLE_REQUIRED: use createNeonTransactionDbForRequest() and await close()",
+    );
+  }
   const url = env.DATABASE_URL;
   if (!url) throw new Error("DATABASE_URL binding is required for createDbForRequest()");
   return createNeonHttpDb(url).db;
@@ -366,6 +431,11 @@ let globalDb: GlobalDbHandle | undefined;
 
 function buildGlobalDb(): GlobalDbHandle {
   const driver = getDatabaseDriver();
+  if (driver === "neon-websocket") {
+    throw new Error(
+      "RLS_TRANSACTION_HANDLE_REQUIRED: neon-websocket is request-scoped and cannot back getDb()",
+    );
+  }
   if (driver === "neon-http") {
     const { client, db } = createNeonHttpDb();
     return { driver: "neon-http", client, db };

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -21,12 +21,13 @@ export {
   withTenantAuditQueue,
   writeAuditEvent,
 } from "./audit-chain";
-export type { DatabaseDriver } from "./client";
+export type { DatabaseDriver, NeonTransactionDbHandle } from "./client";
 export {
   closeDb,
   createDb,
   createDbForRequest,
   createNeonHttpDb,
+  createNeonTransactionDbForRequest,
   createPostgresClient,
   DATABASE_DEADLINE_EXCEEDED_MESSAGE,
   DatabaseDeadlineExceededError,

--- a/packages/db/src/tenant-rls-context.ts
+++ b/packages/db/src/tenant-rls-context.ts
@@ -6,7 +6,7 @@ const trustedTenantContexts = new WeakSet<object>();
 const TENANT_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,63}$/;
 const AUTHORITY_METHOD_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,63}$/;
 
-export type TenantRlsDriver = "postgres-js" | "pglite" | "neon-http";
+export type TenantRlsDriver = "postgres-js" | "pglite" | "neon-http" | "neon-websocket";
 
 /**
  * An application-internal capability minted only after authentication or by a


### PR DESCRIPTION
SEC-169 checkpoint

## Summary

- add an explicit request-scoped Neon WebSocket/Drizzle database handle for Cloudflare Workers
- admit that driver through the trusted tenant RLS transaction helper while keeping `neon-http` fail-closed
- reject accidental use through `getDb()` or the legacy request helper so sockets cannot become isolate-global
- honor the request's `DATABASE_DRIVER` binding before any process-level fallback; an explicit socket binding cannot silently route through Neon HTTP
- document that shipped Workers remain on `neon-http` until request-wide trusted transaction propagation is implemented

This is a bounded SEC-169 checkpoint, not RLS activation. SEC-169 intentionally remains open.

## Security invariants

- one connection per request handle so callback transactions and `SET LOCAL` share a connection
- explicit, idempotent `close()` lifecycle
- no silent global singleton adoption
- invalid, empty, request-bound, and process-bound driver selections fail closed
- current production Worker configuration unchanged and fail-closed

## Exact-head validation

Exact head: `8f607a191d2346276544ace1555254cccf5ebc60`
Exact base: `6bf366acaa173c81c34dbbfdeb6f5fea14a95e56`

- tenant/driver focused tests and request-binding regressions: green
- API dependency build: 24/24
- Wrangler dry-run: 6,985.48 KiB / 1,878.41 KiB gzip
- Biome + `git diff --check`: green
- hosted exact-head CI: 52 substantive jobs green; final vault job still running at the latest update
