### PR TITLE
fix(security): redact runtime failure telemetry

### DIFF
--- a/packages/agent-trader/src/__tests__/logger-redaction.test.ts
+++ b/packages/agent-trader/src/__tests__/logger-redaction.test.ts
@@ -4,7 +4,7 @@
  * `items: [{ apiKey: ... }]`) previously logged secrets in the clear.
  */
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
-import { logWebhook } from "../logger";
+import { logError, logSubmission, logWebhook } from "../logger";
 
 let writeSpy: ReturnType<typeof spyOn> | undefined;
 let lines: string[];
@@ -64,5 +64,38 @@ describe("logWebhook redaction (SEC-110)", () => {
     expect(data.plain).toEqual([1, "two", null]);
     expect(data.txHash).toBe("0xabc123");
     expect(lines[0]).not.toContain("object-secret-value");
+  });
+});
+
+describe("runtime error log redaction", () => {
+  it("never emits thrown messages, stacks, raw values, or submission diagnostics", () => {
+    const stderr: string[] = [];
+    const stderrSpy = spyOn(process.stderr, "write").mockImplementation(((chunk: unknown) => {
+      stderr.push(String(chunk));
+      return true;
+    }) as never);
+    try {
+      logError("operation failed", new Error("TOKEN_AND_DATABASE_URL_CANARY"));
+      logSubmission({
+        agentId: "agent-1",
+        status: "error",
+        to: "0x0000000000000000000000000000000000000001",
+        value: "0",
+        dataLen: 0,
+        chainId: 1,
+        error: "PROVIDER_RESPONSE_SECRET_CANARY",
+      });
+    } finally {
+      stderrSpy.mockRestore();
+    }
+
+    expect(stderr).toHaveLength(2);
+    expect(stderr.join("\n")).not.toContain("TOKEN_AND_DATABASE_URL_CANARY");
+    expect(stderr.join("\n")).not.toContain("PROVIDER_RESPONSE_SECRET_CANARY");
+    expect(JSON.parse(stderr[0] as string)).toMatchObject({
+      errorClass: "Error",
+      errorCode: null,
+    });
+    expect(JSON.parse(stderr[1] as string)).toMatchObject({ error: "operation failed" });
   });
 });

--- a/packages/agent-trader/src/__tests__/logger-redaction.test.ts
+++ b/packages/agent-trader/src/__tests__/logger-redaction.test.ts
@@ -76,6 +76,12 @@ describe("runtime error log redaction", () => {
     }) as never);
     try {
       logError("operation failed", new Error("TOKEN_AND_DATABASE_URL_CANARY"));
+      logError("webhook failure", undefined, {
+        data: {
+          error: "NESTED_PROVIDER_DIAGNOSTIC_CANARY",
+          authorization: "Bearer NESTED_TOKEN_CANARY",
+        },
+      });
       logSubmission({
         agentId: "agent-1",
         status: "error",
@@ -89,13 +95,18 @@ describe("runtime error log redaction", () => {
       stderrSpy.mockRestore();
     }
 
-    expect(stderr).toHaveLength(2);
+    expect(stderr).toHaveLength(3);
     expect(stderr.join("\n")).not.toContain("TOKEN_AND_DATABASE_URL_CANARY");
     expect(stderr.join("\n")).not.toContain("PROVIDER_RESPONSE_SECRET_CANARY");
+    expect(stderr.join("\n")).not.toContain("NESTED_PROVIDER_DIAGNOSTIC_CANARY");
+    expect(stderr.join("\n")).not.toContain("NESTED_TOKEN_CANARY");
     expect(JSON.parse(stderr[0] as string)).toMatchObject({
       errorClass: "Error",
       errorCode: null,
     });
-    expect(JSON.parse(stderr[1] as string)).toMatchObject({ error: "operation failed" });
+    expect(JSON.parse(stderr[1] as string)).toMatchObject({
+      data: { error: "[redacted]", authorization: "[redacted]" },
+    });
+    expect(JSON.parse(stderr[2] as string)).toMatchObject({ error: "operation failed" });
   });
 });

--- a/packages/agent-trader/src/index.ts
+++ b/packages/agent-trader/src/index.ts
@@ -10,6 +10,7 @@
  */
 
 import { StewardClient } from "@stwd/sdk";
+import { redactedThrownDiagnostics } from "@stwd/shared";
 import { loadConfig } from "./config.js";
 import { logError, logInfo, logWarn } from "./logger.js";
 import type { AgentLoop } from "./loop.js";
@@ -72,7 +73,7 @@ async function main(): Promise<void> {
     logInfo("Steward API reachable ✓");
   } catch (err) {
     logWarn("Steward API connectivity check failed — will retry on first tick", {
-      error: err instanceof Error ? err.message : String(err),
+      ...redactedThrownDiagnostics(err),
     });
   }
 
@@ -153,6 +154,6 @@ async function main(): Promise<void> {
 }
 
 main().catch((err) => {
-  console.error("Fatal startup error:", err);
+  logError("Fatal startup error", err);
   process.exit(1);
 });

--- a/packages/agent-trader/src/logger.ts
+++ b/packages/agent-trader/src/logger.ts
@@ -85,6 +85,8 @@ const SENSITIVE_WEBHOOK_FIELDS = [
   "signature",
 ];
 
+const FAILURE_TEXT_FIELDS = new Set(["error", "errormessage", "errorraw", "stack"]);
+
 function redactWebhookValue(value: unknown): unknown {
   // SEC-110: recurse into arrays too — batch-shaped payloads carry objects
   // inside arrays (e.g. `items: [{ apiKey: ... }]`) and must get the same
@@ -100,7 +102,10 @@ function redactWebhookData(data: Record<string, unknown>): Record<string, unknow
   const out: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(data)) {
     const normalized = key.toLowerCase().replace(/[_-]/g, "");
-    if (SENSITIVE_WEBHOOK_FIELDS.some((f) => normalized.includes(f))) {
+    if (
+      FAILURE_TEXT_FIELDS.has(normalized) ||
+      SENSITIVE_WEBHOOK_FIELDS.some((f) => normalized.includes(f))
+    ) {
       out[key] = "[redacted]";
     } else {
       out[key] = redactWebhookValue(value);
@@ -121,7 +126,7 @@ export function logInfo(message: string, meta?: Record<string, unknown>): void {
   emit("info", "info", {
     timestamp: new Date().toISOString(),
     message,
-    ...meta,
+    ...redactWebhookData(meta ?? {}),
   });
 }
 
@@ -129,7 +134,7 @@ export function logWarn(message: string, meta?: Record<string, unknown>): void {
   emit("warn", "warn", {
     timestamp: new Date().toISOString(),
     message,
-    ...meta,
+    ...redactWebhookData(meta ?? {}),
   });
 }
 
@@ -139,6 +144,6 @@ export function logError(message: string, error?: unknown, meta?: Record<string,
     timestamp: new Date().toISOString(),
     message,
     ...errMeta,
-    ...meta,
+    ...redactWebhookData(meta ?? {}),
   });
 }

--- a/packages/agent-trader/src/logger.ts
+++ b/packages/agent-trader/src/logger.ts
@@ -5,6 +5,8 @@
  * grep, and jq can consume the output without any parsing logic.
  */
 
+import { redactedThrownDiagnostics } from "@stwd/shared";
+
 export type LogLevel = "info" | "warn" | "error" | "debug";
 
 export interface DecisionLog {
@@ -57,7 +59,12 @@ export function logDecision(entry: Omit<DecisionLog, "timestamp">): void {
 export function logSubmission(entry: Omit<SubmissionLog, "timestamp">): void {
   const level: LogLevel =
     entry.status === "error" || entry.status === "rejected" ? "error" : "info";
-  emit(level, "submission", { timestamp: new Date().toISOString(), ...entry });
+  const { error, ...safeEntry } = entry;
+  emit(level, "submission", {
+    timestamp: new Date().toISOString(),
+    ...safeEntry,
+    ...(error === undefined ? {} : { error: "operation failed" }),
+  });
 }
 
 /**
@@ -127,12 +134,7 @@ export function logWarn(message: string, meta?: Record<string, unknown>): void {
 }
 
 export function logError(message: string, error?: unknown, meta?: Record<string, unknown>): void {
-  const errMeta =
-    error instanceof Error
-      ? { errorMessage: error.message, stack: error.stack }
-      : error
-        ? { errorRaw: String(error) }
-        : {};
+  const errMeta = error === undefined ? {} : redactedThrownDiagnostics(error);
   emit("error", "error", {
     timestamp: new Date().toISOString(),
     message,

--- a/packages/agent-trader/src/loop.ts
+++ b/packages/agent-trader/src/loop.ts
@@ -189,7 +189,7 @@ export async function runTick(
         amount: decision.amount,
         slippageBps: slippageBps ?? 100,
         priceConfidence: state.priceConfidence,
-        reason: err.message,
+        reason: "unsafe-swap-configuration",
       });
       return;
     }

--- a/packages/agent-trader/src/state.ts
+++ b/packages/agent-trader/src/state.ts
@@ -22,7 +22,7 @@
  */
 
 import type { StewardClient } from "@stwd/sdk";
-import { createPriceOracle, type PriceOracle } from "@stwd/shared";
+import { createPriceOracle, type PriceOracle, redactedThrownDiagnostics } from "@stwd/shared";
 import type { PublicClient } from "viem";
 import { createPublicClient, http } from "viem";
 import { base } from "viem/chains";
@@ -190,7 +190,7 @@ async function getTokenPrice(tokenAddress: string, chainId: number): Promise<Pri
     } catch (err) {
       logWarn("DEX reserve price lookup failed", {
         tokenAddress,
-        error: err instanceof Error ? err.message : String(err),
+        ...redactedThrownDiagnostics(err),
       });
     }
   }
@@ -226,7 +226,7 @@ async function getHardenedOracleQuote(
   } catch (err) {
     logWarn("Hardened price oracle lookup failed, falling back", {
       tokenAddress,
-      error: err instanceof Error ? err.message : String(err),
+      ...redactedThrownDiagnostics(err),
     });
     return null;
   }
@@ -258,28 +258,28 @@ export async function fetchAgentState(
     getNativeBalance(walletAddress, chainId).catch((err) => {
       logWarn("Failed to fetch native balance", {
         agentId: agentConfig.agentId,
-        error: String(err),
+        ...redactedThrownDiagnostics(err),
       });
       return 0n;
     }),
     getTokenBalance(walletAddress, agentConfig.tokenAddress, chainId).catch((err) => {
       logWarn("Failed to fetch token balance", {
         agentId: agentConfig.agentId,
-        error: String(err),
+        ...redactedThrownDiagnostics(err),
       });
       return 0n;
     }),
     getTokenPrice(agentConfig.tokenAddress, chainId).catch((err): PricedQuote => {
       logWarn("Failed to fetch token price", {
         agentId: agentConfig.agentId,
-        error: String(err),
+        ...redactedThrownDiagnostics(err),
       });
       return NO_PRICE;
     }),
     steward.getHistory(agentConfig.agentId).catch((err) => {
       logWarn("Failed to fetch Steward history", {
         agentId: agentConfig.agentId,
-        error: String(err),
+        ...redactedThrownDiagnostics(err),
       });
       return [];
     }),

--- a/packages/agent-trader/src/webhook-delivery-store.ts
+++ b/packages/agent-trader/src/webhook-delivery-store.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import { assertRedisUrlTls } from "@stwd/redis";
+import { redactedThrownDiagnostics } from "@stwd/shared";
 import { Redis } from "ioredis";
 
 export const WEBHOOK_DELIVERY_REPLAY_TTL_MS = 10 * 60 * 1000;
@@ -195,7 +196,7 @@ function defaultRedisFactory(kind: "redis" | "upstash", env: NodeJS.ProcessEnv):
     // Prevent an EventEmitter "error" event from terminating the process. SET
     // still rejects, and the request path converts that failure to a 503.
     client.on("error", (error) => {
-      console.error("[agent-trader] webhook replay Redis error:", error.message);
+      console.error("[agent-trader] webhook replay Redis error", redactedThrownDiagnostics(error));
     });
     return client;
   }

--- a/packages/api/src/__tests__/auth-audit-hardening.test.ts
+++ b/packages/api/src/__tests__/auth-audit-hardening.test.ts
@@ -269,7 +269,9 @@ describe("auth and audit hardening", () => {
     expect(catchStart).toBeGreaterThanOrEqual(0);
     const catchSource = routeSource.slice(catchStart, routeSource.indexOf("}", catchStart + 1));
     expect(catchSource).not.toContain("err.message");
-    expect(catchSource).toContain('console.warn("[PasskeyAuth] Registration failed:", err)');
+    expect(catchSource).toContain(
+      'console.warn("[PasskeyAuth] Registration failed", redactedThrownDiagnostics(err))',
+    );
     expect(catchSource).toContain('error: "Registration verification failed"');
   });
 

--- a/packages/api/src/__tests__/upstream-credential-lease-scheduler.test.ts
+++ b/packages/api/src/__tests__/upstream-credential-lease-scheduler.test.ts
@@ -103,7 +103,12 @@ test("lease scheduler health fails closed after a sweep error and recovers on su
   await attempted;
   await new Promise((resolve) => setTimeout(resolve, 0));
   expect(getUpstreamCredentialLeaseSchedulerHealth().ok).toBe(false);
-  expect(getUpstreamCredentialLeaseSchedulerHealth().lastError).toBe("provider unavailable");
+  expect(getUpstreamCredentialLeaseSchedulerHealth().lastError).toBe(
+    "credential lease recovery failed",
+  );
+  expect(getUpstreamCredentialLeaseSchedulerHealth().lastError).not.toContain(
+    "provider unavailable",
+  );
   await retried;
   await new Promise((resolve) => setTimeout(resolve, 1));
   expect(getUpstreamCredentialLeaseSchedulerHealth().ok).toBe(true);

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -36,6 +36,7 @@
  */
 
 import { platformAuthMiddleware } from "@stwd/auth";
+import { redactedThrownDiagnostics } from "@stwd/shared";
 import { Hono } from "hono";
 import { bodyLimit } from "hono/body-limit";
 import { authorizationSignature } from "./middleware/authorization-signature";
@@ -108,7 +109,7 @@ export function createApp(): Hono<{ Variables: AppVariables }> {
       return c.json<ApiResponse>({ ok: false, error: "Invalid JSON in request body" }, 400);
     }
 
-    console.error(`[${requestId}] Unhandled API error:`, err);
+    console.error(`[${requestId}] Unhandled API error`, redactedThrownDiagnostics(err));
     return c.json<ApiResponse>({ ok: false, error: "Internal server error" }, 500);
   });
 

--- a/packages/api/src/embedded.ts
+++ b/packages/api/src/embedded.ts
@@ -15,6 +15,7 @@
  */
 
 import { createPGLiteDb, getDataDir, setPGLiteOverride } from "@stwd/db/pglite";
+import { redactedThrownDiagnostics } from "@stwd/shared";
 import { loadOrCreateEmbeddedMasterPassword } from "./services/embedded-master-password";
 
 // Force PGLite/embedded mode
@@ -63,6 +64,6 @@ async function main() {
 }
 
 main().catch((err) => {
-  console.error("[embedded] Fatal error:", err);
+  console.error("[embedded] Fatal error", redactedThrownDiagnostics(err));
   process.exit(1);
 });

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -16,6 +16,7 @@ import { createHash, timingSafeEqual } from "node:crypto";
 import { validateJwtSecretEnv } from "@stwd/auth";
 import { closeDb, getDb, getMigrationExpectation, runMigrations } from "@stwd/db";
 import { shouldUsePGLite } from "@stwd/db/pglite";
+import { redactedThrownDiagnostics } from "@stwd/shared";
 import { sql } from "drizzle-orm";
 import { composeApp } from "./compose";
 import { getRedisClient, initRedis, isRedisConfigured, shutdownRedis } from "./middleware/redis";
@@ -189,8 +190,8 @@ app.get("/ready", async (c) => {
           : { actualCreatedAt: Number.isFinite(migrationCreatedAt) ? migrationCreatedAt : null }),
       },
     };
-  } catch (err: unknown) {
-    checks.database = { ok: false, error: err instanceof Error ? err.message : "unknown" };
+  } catch {
+    checks.database = { ok: false, error: "Database health check failed" };
   }
 
   try {
@@ -200,8 +201,8 @@ app.get("/ready", async (c) => {
       : isRedisConfigured()
         ? { ok: false, error: "Redis is configured but not connected" }
         : { ok: false, required: false, error: "Redis is not configured (optional mode)" };
-  } catch (err: unknown) {
-    checks.redis = { ok: false, error: err instanceof Error ? err.message : "unknown" };
+  } catch {
+    checks.redis = { ok: false, error: "Redis health check failed" };
   }
 
   const proxyUrl = process.env.STEWARD_PROXY_URL?.replace(/\/+$/, "");
@@ -224,8 +225,8 @@ app.get("/ready", async (c) => {
         ok: response.ok && Number.isFinite(proxyTime) && skewMs <= 30_000,
         detail: { clockSkewMs: Math.round(skewMs) },
       };
-    } catch (err: unknown) {
-      checks.proxyClock = { ok: false, error: err instanceof Error ? err.message : "unknown" };
+    } catch {
+      checks.proxyClock = { ok: false, error: "Proxy health check failed" };
     }
   }
 
@@ -310,7 +311,10 @@ if (shouldUsePGLite()) {
           metadata: { count: applied.length, names: applied },
         });
       } catch (auditErr) {
-        console.error("[steward] Failed to record migration audit event:", auditErr);
+        console.error(
+          "[steward] Failed to record migration audit event",
+          redactedThrownDiagnostics(auditErr),
+        );
       }
     } else {
       console.log("[steward] Migrations already up to date.");
@@ -332,7 +336,7 @@ if (shouldUsePGLite()) {
       );
     }
   } catch (err) {
-    console.error("[steward] Migration failed — cannot start:", err);
+    console.error("[steward] Migration failed — cannot start", redactedThrownDiagnostics(err));
     process.exit(1);
   }
 }
@@ -343,7 +347,10 @@ let redisOk = false;
 try {
   redisOk = await initRedis();
 } catch (err) {
-  console.warn("[steward] Redis initialization failed; trying Postgres auth storage:", err);
+  console.warn(
+    "[steward] Redis initialization failed; trying Postgres auth storage",
+    redactedThrownDiagnostics(err),
+  );
 }
 
 // Postgres is the durable fallback for the long-lived server when Redis is not
@@ -419,7 +426,7 @@ const shutdown = async (signal: string) => {
   try {
     await Promise.all([closeDb(), shutdownRedis()]);
   } catch (error) {
-    console.error("Failed to close connections cleanly", error);
+    console.error("Failed to close connections cleanly", redactedThrownDiagnostics(error));
   }
 
   process.exit(0);

--- a/packages/api/src/middleware/idempotency.ts
+++ b/packages/api/src/middleware/idempotency.ts
@@ -1,3 +1,4 @@
+import { redactedThrownDiagnostics } from "@stwd/shared";
 import { createMiddleware } from "hono/factory";
 import type { ApiResponse, AppVariables } from "../services/context";
 import { getRedisClient } from "./redis";
@@ -186,8 +187,8 @@ async function recordIdempotencyMetricInRedis(
     await pipeline.exec();
   } catch (error) {
     console.error(
-      "[steward:idempotency] Failed to record Redis idempotency metrics:",
-      error instanceof Error ? error.message : String(error),
+      "[steward:idempotency] Failed to record Redis idempotency metrics",
+      redactedThrownDiagnostics(error),
     );
   }
 }

--- a/packages/api/src/middleware/redis.ts
+++ b/packages/api/src/middleware/redis.ts
@@ -17,6 +17,7 @@ import {
   recordSpend,
   type SpendPeriod,
 } from "@stwd/redis";
+import { redactedThrownDiagnostics } from "@stwd/shared";
 
 // ─── Redis availability flag ─────────────────────────────────────────────────
 
@@ -59,8 +60,8 @@ export async function initRedis(env?: Record<string, unknown>): Promise<boolean>
     return true;
   } catch (err) {
     console.warn(
-      "[steward:redis] Failed to connect — Redis enforcement disabled:",
-      (err as Error).message,
+      "[steward:redis] Failed to connect — Redis enforcement disabled",
+      redactedThrownDiagnostics(err),
     );
     redisAvailable = false;
     return false;
@@ -129,8 +130,8 @@ export async function checkAgentRateLimit(
     return await checkRateLimit(key, windowMs, maxRequests);
   } catch (err) {
     console.error(
-      "[steward:redis] Rate limit check failed, denying sensitive request:",
-      (err as Error).message,
+      "[steward:redis] Rate limit check failed, denying sensitive request",
+      redactedThrownDiagnostics(err),
     );
     return { allowed: false, remaining: 0, resetMs: 60_000 };
   }
@@ -159,8 +160,8 @@ export async function checkProxyRateLimit(
     return await checkRateLimit(key, windowMs, maxRequests);
   } catch (err) {
     console.error(
-      "[steward:redis] Proxy rate limit check failed, denying request:",
-      (err as Error).message,
+      "[steward:redis] Proxy rate limit check failed, denying request",
+      redactedThrownDiagnostics(err),
     );
     return { allowed: false, remaining: 0, resetMs: 60_000 };
   }
@@ -189,8 +190,8 @@ export async function checkAgentSpendLimit(
   } catch (err) {
     // Configured backend threw: fail CLOSED — we cannot prove the spend is within limit.
     console.error(
-      "[steward:redis] Spend limit check failed, denying request (fail-closed):",
-      (err as Error).message,
+      "[steward:redis] Spend limit check failed, denying request (fail-closed)",
+      redactedThrownDiagnostics(err),
     );
     return { allowed: false, spent: 0, remaining: 0 };
   }
@@ -210,7 +211,7 @@ export async function recordAgentSpend(
   try {
     await recordSpend(agentId, tenantId, costUsd, host);
   } catch (err) {
-    console.error("[steward:redis] Failed to record spend:", (err as Error).message);
+    console.error("[steward:redis] Failed to record spend", redactedThrownDiagnostics(err));
   }
 }
 

--- a/packages/api/src/middleware/tenant-cors.ts
+++ b/packages/api/src/middleware/tenant-cors.ts
@@ -19,6 +19,7 @@ import {
   tenantAppClients as tenantAppClientsTable,
   tenantConfigs as tenantConfigsTable,
 } from "@stwd/db";
+import { redactedThrownDiagnostics } from "@stwd/shared";
 import { and, eq } from "drizzle-orm";
 import type { Context, Next } from "hono";
 
@@ -181,7 +182,10 @@ export async function tenantCors(c: Context, next: Next): Promise<Response | und
       }
       // unknown origin outside production → wildcard fallback below (dev mode)
     } catch (err) {
-      console.warn("[tenant-cors] Failed to load global origins, denying CORS:", err);
+      console.warn(
+        "[tenant-cors] Failed to load global origins, denying CORS",
+        redactedThrownDiagnostics(err),
+      );
       if (c.req.method === "OPTIONS") {
         return c.newResponse(null, 403);
       }
@@ -213,7 +217,10 @@ export async function tenantCors(c: Context, next: Next): Promise<Response | und
       }
       // origins.length === 0 → no config yet → fall through to wildcard outside production
     } catch (err) {
-      console.warn("[tenant-cors] Failed to load origins for tenant, denying CORS:", err);
+      console.warn(
+        "[tenant-cors] Failed to load origins for tenant, denying CORS",
+        redactedThrownDiagnostics(err),
+      );
       if (c.req.method === "OPTIONS") {
         return c.newResponse(null, 403);
       }

--- a/packages/api/src/routes/accounts.ts
+++ b/packages/api/src/routes/accounts.ts
@@ -16,6 +16,7 @@ import {
   users,
   userTenants,
 } from "@stwd/db";
+import { redactedThrownDiagnostics } from "@stwd/shared";
 import { and, eq, inArray, isNull, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { writeAuditEvent } from "../services/audit";
@@ -527,7 +528,10 @@ async function writeAccountAudit(input: Parameters<typeof writeAuditEvent>[0]) {
   try {
     await writeAuditEvent(input);
   } catch (error) {
-    console.error("[accounts] Failed to write account audit event:", error);
+    console.error(
+      "[accounts] Failed to write account audit event",
+      redactedThrownDiagnostics(error),
+    );
   }
 }
 

--- a/packages/api/src/routes/adapters.ts
+++ b/packages/api/src/routes/adapters.ts
@@ -38,6 +38,7 @@ import {
   evaluateTradeOrder,
   perOrderCapEvaluator,
 } from "@stwd/policy-engine";
+import { redactedThrownDiagnostics } from "@stwd/shared";
 import { and, eq } from "drizzle-orm";
 import { type Context, Hono } from "hono";
 import { z } from "zod";
@@ -283,7 +284,7 @@ function handleAdapterError(c: Context<{ Variables: AppVariables }>, err: unknow
   const { status, message } = adapterErrorStatus(err);
   if (status === 500) {
     const requestId = c.get("requestId") ?? "unknown";
-    console.error(`[${requestId}] adapter route error:`, err);
+    console.error(`[${requestId}] adapter route error`, redactedThrownDiagnostics(err));
   }
   return c.json<ApiResponse>({ ok: false, error: message }, status);
 }

--- a/packages/api/src/routes/agents.ts
+++ b/packages/api/src/routes/agents.ts
@@ -7,6 +7,7 @@
 import { hashSha256Hex, importP256PublicKey, revocationStore } from "@stwd/auth";
 import { agentPolicies, toPersistedPolicyRule } from "@stwd/db";
 import { getSpend, getSpendByHost, invalidateCache, type SpendPeriod } from "@stwd/redis";
+import { redactedThrownDiagnostics } from "@stwd/shared";
 import { and, eq, gte, inArray, isNull, sql } from "drizzle-orm";
 import { type Context, Hono } from "hono";
 import { isRedisAvailable } from "../middleware/redis";
@@ -453,7 +454,7 @@ async function invalidateAgentPolicyCache(agentId: string, tenantId: string): Pr
   try {
     await invalidateCache(agentId, tenantId);
   } catch (err) {
-    console.error("[policy] Failed to invalidate policy cache:", err);
+    console.error("[policy] Failed to invalidate policy cache", redactedThrownDiagnostics(err));
   }
 }
 
@@ -1484,7 +1485,10 @@ agentRoutes.post("/:agentId/token", async (c) => {
     });
   } catch (e: unknown) {
     const requestId = c.get("requestId") || "unknown";
-    console.error(`[${requestId}] Failed to generate agent token for ${agentId}:`, e);
+    console.error(
+      `[${requestId}] Failed to generate agent token for ${agentId}`,
+      redactedThrownDiagnostics(e),
+    );
     return c.json<ApiResponse>({ ok: false, error: "Failed to generate token" }, 500);
   }
 });
@@ -2036,7 +2040,7 @@ agentRoutes.delete("/:agentId", async (c) => {
       });
     }
     const requestId = c.get("requestId") || "unknown";
-    console.error(`[${requestId}] Failed to delete agent ${agentId}:`, e);
+    console.error(`[${requestId}] Failed to delete agent ${agentId}`, redactedThrownDiagnostics(e));
     return c.json<ApiResponse>({ ok: false, error: sanitizeErrorMessage(e) }, 500);
   }
 });

--- a/packages/api/src/routes/audit.ts
+++ b/packages/api/src/routes/audit.ts
@@ -7,6 +7,7 @@
 
 import { auditChainHeads, auditCheckpoints, proxyAuditLog } from "@stwd/db";
 import { shouldUsePGLite } from "@stwd/db/pglite";
+import { redactedThrownDiagnostics } from "@stwd/shared";
 import { and, count, desc, eq, gte, inArray, lte, type SQL, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { auditOwnerAdminMfaGate } from "../middleware/audit-gate";
@@ -1010,7 +1011,7 @@ auditRoutes.get("/archives", async (c) => {
     });
     return c.json({ ok: true, data: archives });
   } catch (error) {
-    console.error("[audit] archive list failed:", error);
+    console.error("[audit] archive list failed", redactedThrownDiagnostics(error));
     return c.json<ApiResponse>({ ok: false, error: "Failed to list audit archives" }, 500);
   }
 });
@@ -1175,7 +1176,10 @@ auditRoutes.post("/retention/run", async (c) => {
     }
     return c.json({ ok: true, data: result });
   } catch (error) {
-    console.error(`[audit] retention run failed for tenant ${tenantId}:`, error);
+    console.error(
+      `[audit] retention run failed for tenant ${tenantId}`,
+      redactedThrownDiagnostics(error),
+    );
     return c.json<ApiResponse>({ ok: false, error: "Audit retention failed" }, 500);
   }
 });
@@ -1251,7 +1255,10 @@ auditRoutes.get("/bundle", async (c) => {
   try {
     bundleData = await readAuditBundleData(tenantId, fromSeq, toSeq);
   } catch (err) {
-    console.error(`[audit] bundle read failed for tenant ${tenantId}:`, err);
+    console.error(
+      `[audit] bundle read failed for tenant ${tenantId}`,
+      redactedThrownDiagnostics(err),
+    );
     return c.json<ApiResponse>({ ok: false, error: "Failed to read audit chain" }, 500);
   }
 
@@ -1269,7 +1276,10 @@ auditRoutes.get("/bundle", async (c) => {
     if (err instanceof AuditCheckpointAnchorError) {
       return c.json<ApiResponse>({ ok: false, error: "Required checkpoint anchoring failed" }, 503);
     }
-    console.error(`[audit] checkpoint signing failed for tenant ${tenantId}:`, err);
+    console.error(
+      `[audit] checkpoint signing failed for tenant ${tenantId}`,
+      redactedThrownDiagnostics(err),
+    );
     return c.json<ApiResponse>({ ok: false, error: "Failed to sign checkpoint" }, 500);
   }
 });

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -124,13 +124,14 @@ import {
   users,
   userTenants,
 } from "@stwd/db";
-import type {
-  ApiResponse,
-  SsoDiscoveryResult,
-  TenantAuthAbuseConfig,
-  TenantOidcProviderConfig,
-  TenantSamlSsoConfig,
-  TenantTestAccountConfig,
+import {
+  type ApiResponse,
+  redactedThrownDiagnostics,
+  type SsoDiscoveryResult,
+  type TenantAuthAbuseConfig,
+  type TenantOidcProviderConfig,
+  type TenantSamlSsoConfig,
+  type TenantTestAccountConfig,
 } from "@stwd/shared";
 import { KeyStore, provisionUserWallet, Vault } from "@stwd/vault";
 import bs58 from "bs58";
@@ -3593,7 +3594,10 @@ async function provisionOidcUser(opts: {
       const wallet = await provisionWalletForUser(user.id, syntheticEmail);
       walletAddress = wallet.walletAddress;
     } catch (err) {
-      console.error(`[OidcAuth:${provider.id}] Wallet provision failed:`, err);
+      console.error(
+        `[OidcAuth:${provider.id}] Wallet provision failed`,
+        redactedThrownDiagnostics(err),
+      );
       return { ok: false, status: 500, error: "Wallet provisioning failed" };
     }
     const verifiedEmail = emailVerified === true ? email : undefined;
@@ -3646,10 +3650,13 @@ async function provisionOidcUser(opts: {
       ),
     };
   } catch (err) {
-    console.error(`[OidcAuth:${provider.id}] provisionOidcUser failed:`, err);
+    console.error(
+      `[OidcAuth:${provider.id}] provisionOidcUser failed`,
+      redactedThrownDiagnostics(err),
+    );
     return {
       ok: false,
-      error: err instanceof Error ? err.message : "Internal server error",
+      error: "Internal server error",
     };
   }
 }
@@ -3736,7 +3743,7 @@ async function provisionSamlUser(opts: {
       const wallet = await provisionWalletForUser(user.id, email);
       walletAddress = wallet.walletAddress;
     } catch (err) {
-      console.error("[SamlAuth] Wallet provision failed:", err);
+      console.error("[SamlAuth] Wallet provision failed", redactedThrownDiagnostics(err));
       return { ok: false, status: 500, error: "Wallet provisioning failed" };
     }
 
@@ -3775,8 +3782,8 @@ async function provisionSamlUser(opts: {
       ),
     };
   } catch (err) {
-    console.error("[SamlAuth] provisionSamlUser failed:", err);
-    return { ok: false, error: err instanceof Error ? err.message : "Internal server error" };
+    console.error("[SamlAuth] provisionSamlUser failed", redactedThrownDiagnostics(err));
+    return { ok: false, error: "Internal server error" };
   }
 }
 
@@ -3840,7 +3847,7 @@ async function completeEmailAuth(
     const w = await provisionWalletForUser(user.id, email);
     walletAddress = w.walletAddress;
   } catch (err) {
-    console.error("[EmailAuth] Wallet provision failed:", err);
+    console.error("[EmailAuth] Wallet provision failed", redactedThrownDiagnostics(err));
   }
 
   // Resolve requesting tenant and link user.
@@ -4530,7 +4537,7 @@ auth.post("/telegram/verify", async (c) => {
       const wallet = await provisionWalletForUser(user.id, `telegram:${telegramUser.id}`);
       walletAddress = wallet.walletAddress;
     } catch (err) {
-      console.error("[TelegramAuth] Wallet provision failed:", err);
+      console.error("[TelegramAuth] Wallet provision failed", redactedThrownDiagnostics(err));
     }
 
     const tenantResult = await resolveAndValidateTenant(c, user.id, requestedTenantId);
@@ -4573,11 +4580,8 @@ auth.post("/telegram/verify", async (c) => {
     );
     return authExchangeJson(c, response);
   } catch (error) {
-    console.error("[TelegramAuth] verify failed:", error);
-    return c.json<ApiResponse>(
-      { ok: false, error: error instanceof Error ? error.message : "Telegram login failed" },
-      500,
-    );
+    console.error("[TelegramAuth] verify failed", redactedThrownDiagnostics(error));
+    return c.json<ApiResponse>({ ok: false, error: "Telegram login failed" }, 500);
   }
 });
 
@@ -4675,7 +4679,7 @@ auth.post("/farcaster/verify", async (c) => {
       const wallet = await provisionWalletForUser(user.id, `farcaster:${providerAccountId}`);
       walletAddress = wallet.walletAddress;
     } catch (err) {
-      console.error("[FarcasterAuth] Wallet provision failed:", err);
+      console.error("[FarcasterAuth] Wallet provision failed", redactedThrownDiagnostics(err));
     }
 
     const tenantResult = await resolveAndValidateTenant(c, user.id, requestedTenantId);
@@ -4717,11 +4721,8 @@ auth.post("/farcaster/verify", async (c) => {
     );
     return authExchangeJson(c, response);
   } catch (error) {
-    console.error("[FarcasterAuth] verify failed:", error);
-    return c.json<ApiResponse>(
-      { ok: false, error: error instanceof Error ? error.message : "Farcaster login failed" },
-      500,
-    );
+    console.error("[FarcasterAuth] verify failed", redactedThrownDiagnostics(error));
+    return c.json<ApiResponse>({ ok: false, error: "Farcaster login failed" }, 500);
   }
 });
 
@@ -8087,7 +8088,7 @@ auth.post("/passkey/register/verify", async (c) => {
       body.response as unknown as Parameters<PasskeyAuth["verifyRegistration"]>[1],
     );
   } catch (err) {
-    console.warn("[PasskeyAuth] Registration failed:", err);
+    console.warn("[PasskeyAuth] Registration failed", redactedThrownDiagnostics(err));
     return c.json<ApiResponse>(
       {
         ok: false,
@@ -8136,7 +8137,10 @@ auth.post("/passkey/register/verify", async (c) => {
     const w = await provisionWalletForUser(user.id, email);
     walletAddress = w.walletAddress;
   } catch (err) {
-    console.error("[PasskeyAuth] Wallet provision failed on register:", err);
+    console.error(
+      "[PasskeyAuth] Wallet provision failed on register",
+      redactedThrownDiagnostics(err),
+    );
   }
 
   // Link the user only after tenant authorization has been validated.
@@ -8284,7 +8288,7 @@ auth.post("/passkey/login/verify", async (c) => {
       cred.counter,
     );
   } catch (err) {
-    console.warn("[PasskeyAuth] Authentication failed:", err);
+    console.warn("[PasskeyAuth] Authentication failed", redactedThrownDiagnostics(err));
     return c.json<ApiResponse>(
       {
         ok: false,
@@ -8327,7 +8331,10 @@ auth.post("/passkey/login/verify", async (c) => {
       const w = await provisionWalletForUser(user.id, email);
       walletAddress = w.walletAddress;
     } catch (err) {
-      console.error("[PasskeyAuth] Wallet provision failed on login:", err);
+      console.error(
+        "[PasskeyAuth] Wallet provision failed on login",
+        redactedThrownDiagnostics(err),
+      );
     }
   } else {
     // Wallet exists — still ensure personal tenant is in place
@@ -8984,7 +8991,7 @@ auth.post("/guest", async (c) => {
     const provisioned = await provisionWalletForUser(guest.id, `guest-${guest.id}`);
     walletAddress = provisioned.walletAddress;
   } catch (err) {
-    console.error("[GuestAuth] Wallet provision failed:", err);
+    console.error("[GuestAuth] Wallet provision failed", redactedThrownDiagnostics(err));
   }
 
   const sessionClaims: Record<string, unknown> = {
@@ -10207,7 +10214,10 @@ async function provisionOAuthUser(opts: {
       const w = await provisionWalletForUser(user.id, email);
       walletAddress = w.walletAddress;
     } catch (err) {
-      console.error(`[OAuthAuth:${providerName}] Wallet provision failed:`, err);
+      console.error(
+        `[OAuthAuth:${providerName}] Wallet provision failed`,
+        redactedThrownDiagnostics(err),
+      );
     }
 
     // 4. Link user to the already-authorized requesting tenant.
@@ -10235,10 +10245,13 @@ async function provisionOAuthUser(opts: {
       ),
     };
   } catch (err) {
-    console.error(`[OAuthAuth:${providerName}] provisionOAuthUser failed:`, err);
+    console.error(
+      `[OAuthAuth:${providerName}] provisionOAuthUser failed`,
+      redactedThrownDiagnostics(err),
+    );
     return {
       ok: false,
-      error: err instanceof Error ? err.message : "Internal server error",
+      error: "Internal server error",
     };
   }
 }
@@ -10399,7 +10412,7 @@ async function exchangeOidcAuthorizationCode(opts: {
     // Keep resolver, TLS, socket, and certificate diagnostics server-side.
     // They may contain configured hostnames or runtime network details and are
     // not useful to an unauthenticated callback client.
-    console.warn("[OIDC] Token endpoint request failed:", error);
+    console.warn("[OIDC] Token endpoint request failed", redactedThrownDiagnostics(error));
     throw new Error("OIDC token endpoint request failed");
   }
   const text = response.text;
@@ -10410,9 +10423,8 @@ async function exchangeOidcAuthorizationCode(opts: {
     throw new Error("OIDC token endpoint returned invalid JSON");
   }
   if (!response.ok) {
-    // SEC-139: the IdP-supplied `error` string is untrusted text. Log it
-    // server-side for operators, but never echo it into the client-facing
-    // 502 response.
+    // SEC-139: the IdP-supplied `error` string is untrusted text. Do not echo
+    // it into logs or the client-facing 502 response.
     const idpError =
       payload &&
       typeof payload === "object" &&
@@ -10421,7 +10433,7 @@ async function exchangeOidcAuthorizationCode(opts: {
         ? payload.error
         : undefined;
     if (idpError) {
-      console.warn("[OIDC] Token endpoint rejected authorization code:", idpError);
+      console.warn("[OIDC] Token endpoint rejected authorization code");
     }
     throw new Error("OIDC token endpoint rejected authorization code");
   }

--- a/packages/api/src/routes/erc8004.ts
+++ b/packages/api/src/routes/erc8004.ts
@@ -9,6 +9,7 @@
  */
 
 import { agentRegistrations, registryIndex } from "@stwd/db";
+import { redactedThrownDiagnostics } from "@stwd/shared";
 import { and, eq, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { z } from "zod";
@@ -255,7 +256,7 @@ erc8004Routes.post("/:id/register-onchain", async (c) => {
       },
     });
   } catch (err: unknown) {
-    console.error("[erc8004] register-onchain error:", err);
+    console.error("[erc8004] register-onchain error", redactedThrownDiagnostics(err));
     return c.json<ApiResponse>({ ok: false, error: "Failed to create registration" }, 500);
   }
 });
@@ -313,7 +314,7 @@ erc8004Routes.get("/:id/onchain", async (c) => {
       },
     });
   } catch (err: unknown) {
-    console.error("[erc8004] onchain lookup error:", err);
+    console.error("[erc8004] onchain lookup error", redactedThrownDiagnostics(err));
     return c.json<ApiResponse>({ ok: false, error: "Failed to fetch on-chain data" }, 500);
   }
 });
@@ -445,7 +446,7 @@ erc8004Routes.post("/:id/feedback", async (c) => {
       },
     });
   } catch (err: unknown) {
-    console.error("[erc8004] feedback error:", err);
+    console.error("[erc8004] feedback error", redactedThrownDiagnostics(err));
     return c.json<ApiResponse>({ ok: false, error: "Failed to record feedback" }, 500);
   }
 });
@@ -513,7 +514,7 @@ discoveryRoutes.get("/agents", async (c) => {
       data: agents,
     });
   } catch (err: unknown) {
-    console.error("[erc8004] discovery/agents error:", err);
+    console.error("[erc8004] discovery/agents error", redactedThrownDiagnostics(err));
     return c.json<ApiResponse>({ ok: false, error: "Failed to query agents" }, 500);
   }
 });
@@ -536,7 +537,7 @@ discoveryRoutes.get("/registries", async (c) => {
       data: rows.sort((a, b) => a.chain_id - b.chain_id),
     });
   } catch (err: unknown) {
-    console.error("[erc8004] discovery/registries error:", err);
+    console.error("[erc8004] discovery/registries error", redactedThrownDiagnostics(err));
     return c.json<ApiResponse>({ ok: false, error: "Failed to query registries" }, 500);
   }
 });

--- a/packages/api/src/routes/intents.ts
+++ b/packages/api/src/routes/intents.ts
@@ -5,7 +5,7 @@
  */
 
 import { toPersistedPolicyRule, users, userTenants } from "@stwd/db";
-import type { PolicyRule } from "@stwd/shared";
+import { type PolicyRule, redactedThrownDiagnostics } from "@stwd/shared";
 import { and, desc, eq, inArray, type SQL, sql } from "drizzle-orm";
 import { type Context, Hono } from "hono";
 import { enforceRateLimit, recordVaultSpend } from "../middleware/redis-enforcement";
@@ -627,22 +627,29 @@ async function executeTransferIntent(row: typeof intents.$inferSelect) {
         .where(eq(transactions.id, txId));
       if (request.broadcast !== false) {
         recordVaultSpend(request.agentId, row.tenantId, request.value, request.chainId).catch(
-          (error) => console.error("[intents] Failed to record transfer intent spend:", error),
+          (error) =>
+            console.error(
+              "[intents] Failed to record transfer intent spend",
+              redactedThrownDiagnostics(error),
+            ),
         );
       }
       return completedResult;
     } catch (error) {
       if (completedResult) {
-        console.error("[intents] Post-transfer intent bookkeeping failed after signing:", error);
+        console.error(
+          "[intents] Post-transfer intent bookkeeping failed after signing",
+          redactedThrownDiagnostics(error),
+        );
         return completedResult;
       }
-      const message = error instanceof Error ? error.message : "Transfer execution failed";
       dispatchWebhook(row.tenantId, request.agentId, "wallet_action.transfer.failed", {
         actionId: txId,
         intent_id: row.id,
-        error: message,
+        error: "Transfer execution failed",
+        ...redactedThrownDiagnostics(error),
       });
-      throw new IntentExecutionError(message, 502);
+      throw new IntentExecutionError("Transfer execution failed", 502);
     }
   });
 }
@@ -759,7 +766,11 @@ async function executeSendCallsIntent(row: typeof intents.$inferSelect) {
       }
       if (request.broadcast) {
         recordVaultSpend(request.agentId, row.tenantId, request.totalValue, request.chainId).catch(
-          (error) => console.error("[intents] Failed to record send-calls intent spend:", error),
+          (error) =>
+            console.error(
+              "[intents] Failed to record send-calls intent spend",
+              redactedThrownDiagnostics(error),
+            ),
         );
       }
       return {
@@ -773,13 +784,13 @@ async function executeSendCallsIntent(row: typeof intents.$inferSelect) {
         signedCalls,
       };
     } catch (error) {
-      const message = error instanceof Error ? error.message : "Batch call execution failed";
       dispatchWebhook(row.tenantId, request.agentId, "wallet_action.send_calls.failed", {
         actionId: row.id,
         intent_id: row.id,
-        error: message,
+        error: "Batch call execution failed",
+        ...redactedThrownDiagnostics(error),
       });
-      throw new IntentExecutionError(message, 502);
+      throw new IntentExecutionError("Batch call execution failed", 502);
     }
   });
 }

--- a/packages/api/src/routes/platform.ts
+++ b/packages/api/src/routes/platform.ts
@@ -46,14 +46,15 @@ import {
   userTenants,
   vaultSigningFreezes,
 } from "@stwd/db";
-import type {
-  AgentIdentity,
-  ApiResponse,
-  PolicyRule,
-  SponsoredGasSpendSummary,
-  TenantAuthAbuseConfig,
-  TenantOidcProviderConfig,
-  TenantTestAccountConfig,
+import {
+  type AgentIdentity,
+  type ApiResponse,
+  type PolicyRule,
+  redactedThrownDiagnostics,
+  type SponsoredGasSpendSummary,
+  type TenantAuthAbuseConfig,
+  type TenantOidcProviderConfig,
+  type TenantTestAccountConfig,
 } from "@stwd/shared";
 import { KeyStore, Vault } from "@stwd/vault";
 import { and, count, eq, ilike, inArray, isNull, ne, or, type SQL, sql } from "drizzle-orm";
@@ -2499,7 +2500,10 @@ platform.post("/tenants/:id/agents/:agentId/token", async (c) => {
       data: { token, agentId, tenantId, scope: "agent", scopes },
     });
   } catch (e: unknown) {
-    console.error(`[platform] Failed to generate agent token for ${agentId}:`, e);
+    console.error(
+      `[platform] Failed to generate agent token for ${agentId}`,
+      redactedThrownDiagnostics(e),
+    );
     return c.json<ApiResponse>({ ok: false, error: "Failed to generate token" }, 500);
   }
 });
@@ -4526,7 +4530,7 @@ platform.post("/tenants/:id/invitations", async (c) => {
       await emailAuth.sendTenantInvitation(email, { tenantId, token, expiresAt });
       emailSent = true;
     } catch (error) {
-      console.error("[TenantInvitation] Email delivery failed:", error);
+      console.error("[TenantInvitation] Email delivery failed", redactedThrownDiagnostics(error));
     }
   }
 

--- a/packages/api/src/routes/provider-case.ts
+++ b/packages/api/src/routes/provider-case.ts
@@ -21,6 +21,7 @@
  */
 
 import { getDb, workspaces } from "@stwd/db";
+import { redactedThrownDiagnostics } from "@stwd/shared";
 import { eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { auditOwnerAdminMfaGate } from "../middleware/audit-gate";
@@ -79,7 +80,10 @@ providerCaseRoutes.get("/provider-actions/:id/case", async (c) => {
     const assembly = await getProviderCase(tenantId, caseId, authorized);
     manifestOrNull = assembly?.manifest ?? null;
   } catch (err) {
-    console.error(`[provider-case] /case read failed for ${tenantId}/${caseId}:`, err);
+    console.error(
+      `[provider-case] /case read failed for ${tenantId}/${caseId}`,
+      redactedThrownDiagnostics(err),
+    );
     return c.json<ApiResponse>({ ok: false, error: "CASE_CHAIN_UNAVAILABLE" }, 500);
   }
 
@@ -117,7 +121,10 @@ providerCaseRoutes.get("/provider-actions/:id/evidence", async (c) => {
       // large to export as one signed bundle. /case still serves the manifest.
       return c.json<ApiResponse>({ ok: false, error: "CASE_RANGE_TOO_LARGE" }, 400);
     }
-    console.error(`[provider-case] /evidence read failed for ${tenantId}/${caseId}:`, err);
+    console.error(
+      `[provider-case] /evidence read failed for ${tenantId}/${caseId}`,
+      redactedThrownDiagnostics(err),
+    );
     return c.json<ApiResponse>({ ok: false, error: "CASE_CHAIN_UNAVAILABLE" }, 500);
   }
 

--- a/packages/api/src/routes/quote.ts
+++ b/packages/api/src/routes/quote.ts
@@ -3,6 +3,7 @@ import {
   createDstackTdxProvider,
   createNoopDevProvider,
 } from "@stwd/attestation";
+import { redactedThrownDiagnostics } from "@stwd/shared";
 import { Hono } from "hono";
 import type { AppVariables } from "../services/context";
 import { checkAuthRateLimit } from "./auth";
@@ -69,7 +70,7 @@ quoteRoutes.get("/", async (c) => {
   } catch (error) {
     // SEC-085: provider failures (guest agent unreachable, misconfigured
     // provider) must not leak internals to anonymous callers.
-    console.error("attestation quote generation failed:", error);
+    console.error("attestation quote generation failed", redactedThrownDiagnostics(error));
     return c.json({ error: "attestation unavailable" }, 503);
   }
 });

--- a/packages/api/src/routes/session-signers.ts
+++ b/packages/api/src/routes/session-signers.ts
@@ -30,9 +30,9 @@
  */
 
 import { randomUUID } from "node:crypto";
-
 import { revocationStore, signAgentToken } from "@stwd/auth";
 import { auditEvents, sessionSigners } from "@stwd/db";
+import { redactedThrownDiagnostics } from "@stwd/shared";
 import { and, desc, eq, isNull } from "drizzle-orm";
 import { Hono } from "hono";
 import { writeAuditEvent } from "../services/audit";
@@ -255,15 +255,18 @@ sessionSignerRoutes.post("/", async (c) => {
       requestId: c.get("requestId") ?? null,
     });
   } catch (err) {
-    console.error(`[session-signer] audit write failed; rolling back issuance ${row.id}:`, err);
+    console.error(
+      `[session-signer] audit write failed; rolling back issuance ${row.id}`,
+      redactedThrownDiagnostics(err),
+    );
     try {
       await revocationStore.revokeToken(jti, Math.floor(expiresAt.getTime() / 1000));
       await db.delete(sessionSigners).where(eq(sessionSigners.id, row.id));
     } catch (rollbackErr) {
       // Best-effort cleanup failed; the jti was at least revocation-attempted.
       console.error(
-        `[session-signer] rollback after audit failure failed for ${row.id}:`,
-        rollbackErr,
+        `[session-signer] rollback after audit failure failed for ${row.id}`,
+        redactedThrownDiagnostics(rollbackErr),
       );
     }
     return c.json<ApiResponse>(
@@ -379,8 +382,8 @@ sessionSignerRoutes.delete("/:id", async (c) => {
         await writeSessionSignerRevokedAudit(c, tenantId, agentId, signerId, existing.jti);
       } catch (err) {
         console.error(
-          `[session-signer] audit repair failed for already-revoked signer ${signerId}:`,
-          err,
+          `[session-signer] audit repair failed for already-revoked signer ${signerId}`,
+          redactedThrownDiagnostics(err),
         );
         return c.json<ApiResponse>(
           {
@@ -409,7 +412,10 @@ sessionSignerRoutes.delete("/:id", async (c) => {
   try {
     await writeSessionSignerRevokedAudit(c, tenantId, agentId, signerId, existing.jti);
   } catch (err) {
-    console.error(`[session-signer] audit write failed for revocation ${signerId}:`, err);
+    console.error(
+      `[session-signer] audit write failed for revocation ${signerId}`,
+      redactedThrownDiagnostics(err),
+    );
     return c.json<ApiResponse>(
       {
         ok: false,

--- a/packages/api/src/routes/user.ts
+++ b/packages/api/src/routes/user.ts
@@ -65,14 +65,15 @@ import {
   userWalletAppConsents,
 } from "@stwd/db";
 import { PolicyEngine } from "@stwd/policy-engine";
-import type {
-  AgentBalance,
-  AgentIdentity,
-  ApiResponse,
-  ChainFamily,
-  PolicyRule,
-  SignRequest,
-  TenantAuthAbuseConfig,
+import {
+  type AgentBalance,
+  type AgentIdentity,
+  type ApiResponse,
+  type ChainFamily,
+  type PolicyRule,
+  redactedThrownDiagnostics,
+  type SignRequest,
+  type TenantAuthAbuseConfig,
 } from "@stwd/shared";
 import {
   applyUserWalletDefaults,
@@ -947,7 +948,10 @@ async function writeInvalidUserWalletIndexAudit(
       },
     });
   } catch (error) {
-    console.warn("[UserWallet] Failed to audit invalid wallet index selector:", error);
+    console.warn(
+      "[UserWallet] Failed to audit invalid wallet index selector",
+      redactedThrownDiagnostics(error),
+    );
   }
 }
 
@@ -2183,7 +2187,10 @@ user.get("/me", async (c) => {
           createOnLogin: embeddedWalletConfig.createOnLogin,
         },
       }).catch((error) => {
-        console.error("[user] Failed to audit create-on-login wallet success:", error);
+        console.error(
+          "[user] Failed to audit create-on-login wallet success",
+          redactedThrownDiagnostics(error),
+        );
       });
     }
     if (wallet) {
@@ -4414,7 +4421,10 @@ user.post("/me/wallet/recovery/setup", async (c) => {
       201,
     );
   } catch (e) {
-    console.error(`[UserWallet] recovery setup failed for user "${userId}":`, e);
+    console.error(
+      `[UserWallet] recovery setup failed for user "${userId}"`,
+      redactedThrownDiagnostics(e),
+    );
     return c.json<ApiResponse>(
       { ok: false, error: `Failed to set up recovery: ${sanitizeErrorMessage(e)}` },
       500,
@@ -5220,16 +5230,15 @@ user.post("/me/wallet/sign", async (c) => {
   } catch (e) {
     if (completedResult) {
       console.error(
-        `[UserWallet] Post-sign bookkeeping failed for user "${userId}" after transaction "${completedResult.txId}" completed:`,
-        e,
+        `[UserWallet] Post-sign bookkeeping failed for user "${userId}" after transaction "${completedResult.txId}" completed`,
+        redactedThrownDiagnostics(e),
       );
       return c.json<ApiResponse<{ txId: string; txHash: string }>>({
         ok: true,
         data: completedResult,
       });
     }
-    const msg = e instanceof Error ? e.message : "Unknown error";
-    console.error(`[UserWallet] Sign failed for user "${userId}":`, e);
+    console.error(`[UserWallet] Sign failed for user "${userId}"`, redactedThrownDiagnostics(e));
     try {
       await writeUserAudit(c, {
         tenantId: `personal-${userId}`,
@@ -5238,10 +5247,13 @@ user.post("/me/wallet/sign", async (c) => {
         action: "user.wallet.sign.failed",
         resourceType: "wallet",
         resourceId: wallet.id,
-        metadata: { error: msg, walletIndex: walletIndex.value },
+        metadata: { ...redactedThrownDiagnostics(e), walletIndex: walletIndex.value },
       });
     } catch (auditErr) {
-      console.error(`[UserWallet] Failed to audit signing failure for user "${userId}":`, auditErr);
+      console.error(
+        `[UserWallet] Failed to audit signing failure for user "${userId}"`,
+        redactedThrownDiagnostics(auditErr),
+      );
     }
     // SEC-210: the raw message stays in server-side logs/audit metadata only;
     // the client gets the sanitized form.
@@ -5461,7 +5473,10 @@ user.post("/me/wallet/sign-message", async (c) => {
       data: { signature, address: wallet.walletAddress },
     });
   } catch (e) {
-    console.error(`[UserWallet] sign-message failed for user "${userId}":`, e);
+    console.error(
+      `[UserWallet] sign-message failed for user "${userId}"`,
+      redactedThrownDiagnostics(e),
+    );
     return c.json<ApiResponse>({ ok: false, error: sanitizeErrorMessage(e) }, 500);
   }
 });
@@ -5746,7 +5761,10 @@ user.post("/me/wallet/import/submit", async (c) => {
       },
     });
   } catch (e) {
-    console.error(`[UserWallet] encrypted import failed for user "${userId}":`, e);
+    console.error(
+      `[UserWallet] encrypted import failed for user "${userId}"`,
+      redactedThrownDiagnostics(e),
+    );
     return c.json<ApiResponse>({ ok: false, error: sanitizeErrorMessage(e) }, 500);
   }
 });
@@ -5862,7 +5880,7 @@ user.post("/me/wallet/export", async (c) => {
       },
     });
   } catch (e) {
-    console.error(`[UserWallet] export failed for user "${userId}":`, e);
+    console.error(`[UserWallet] export failed for user "${userId}"`, redactedThrownDiagnostics(e));
     return c.json<ApiResponse>({ ok: false, error: sanitizeErrorMessage(e) }, 500);
   }
 });
@@ -6615,7 +6633,7 @@ user.post("/me/tenants/:tenantId/invitations", async (c) => {
       await emailAuth.sendTenantInvitation(email, { tenantId, token, expiresAt });
       emailSent = true;
     } catch (error) {
-      console.error("[TenantInvitation] Email delivery failed:", error);
+      console.error("[TenantInvitation] Email delivery failed", redactedThrownDiagnostics(error));
     }
   }
 

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -26,6 +26,7 @@ import {
   ExecutionPayloadNormalizationError,
   type PolicyResult,
   rawSigningChainSupport,
+  redactedThrownDiagnostics,
   type TenantAuthAbuseConfig,
   toCaip2,
 } from "@stwd/shared";
@@ -160,7 +161,10 @@ async function writeOutcomeUnknownAudit(
     // The deterministic hash and outcome_unknown row are already durable. An
     // audit sink failure must never replace the non-retryable 202 response with
     // a generic 500 that could induce a fresh broadcast.
-    console.error("[vault] Failed to append outcome_unknown audit:", error);
+    console.error(
+      "[vault] Failed to append outcome_unknown audit",
+      redactedThrownDiagnostics(error),
+    );
   }
 }
 // ─── Unsafe-signing opt-in flags (read LIVE, not captured at module-init) ──────
@@ -2488,7 +2492,7 @@ vaultRoutes.post("/:agentId/sign", async (c) => {
                   metadata: {
                     txId,
                     payloadDigest: expected.payloadDigest,
-                    error: error instanceof Error ? error.message : "authorization rejected",
+                    ...redactedThrownDiagnostics(error),
                   },
                 });
                 throw error;
@@ -2532,7 +2536,7 @@ vaultRoutes.post("/:agentId/sign", async (c) => {
 
       // ── Record spend in Redis (fire-and-forget) ──────────────────────────────
       recordVaultSpend(agentId, tenantId, signRequest.value, resolvedChainId).catch((err) =>
-        console.error("[vault] Failed to record spend:", err),
+        console.error("[vault] Failed to record spend", redactedThrownDiagnostics(err)),
       );
 
       // ── Record the authoritative aggregation event ───────────────────────────
@@ -2551,7 +2555,7 @@ vaultRoutes.post("/:agentId/sign", async (c) => {
           chainId: resolvedChainId,
         });
       } catch (err) {
-        console.error("[vault] Failed to record aggregation event:", err);
+        console.error("[vault] Failed to record aggregation event", redactedThrownDiagnostics(err));
       }
 
       await writeVaultAudit(c, {
@@ -2631,7 +2635,7 @@ vaultRoutes.post("/:agentId/sign", async (c) => {
         // A lost response may still represent real spend. Account for it
         // conservatively before releasing the per-agent spend lock.
         recordVaultSpend(agentId, tenantId, signRequest.value, resolvedChainId).catch((err) =>
-          console.error("[vault] Failed to record ambiguous spend:", err),
+          console.error("[vault] Failed to record ambiguous spend", redactedThrownDiagnostics(err)),
         );
         try {
           await recordAggregationEvent({
@@ -2641,8 +2645,13 @@ vaultRoutes.post("/:agentId/sign", async (c) => {
             chainId: resolvedChainId,
           });
         } catch (err) {
-          console.error("[vault] Failed to record ambiguous aggregation event:", err);
+          console.error(
+            "[vault] Failed to record ambiguous aggregation event",
+            redactedThrownDiagnostics(err),
+          );
         }
+        const outcomeUnknownTransactionHash =
+          e instanceof ExternalBroadcastOutcomeUnknownError ? e.transactionHash : null;
         await writeOutcomeUnknownAudit(c, {
           tenantId,
           actorType: "agent",
@@ -2653,7 +2662,7 @@ vaultRoutes.post("/:agentId/sign", async (c) => {
           metadata: {
             agentId,
             txId: executionTxId,
-            txHash: e instanceof ExternalBroadcastOutcomeUnknownError ? e.transactionHash : null,
+            txHash: outcomeUnknownTransactionHash,
             chainId: resolvedChainId,
           },
         });
@@ -3474,7 +3483,10 @@ vaultRoutes.post("/:agentId/actions/transfer", async (c) => {
 
       if (transfer.broadcast) {
         recordVaultSpend(agentId, tenantId, signRequest.value, signRequest.chainId).catch((err) =>
-          console.error("[vault] Failed to record transfer action spend:", err),
+          console.error(
+            "[vault] Failed to record transfer action spend",
+            redactedThrownDiagnostics(err),
+          ),
         );
       }
       await recordSponsoredActionIfNeeded({
@@ -3791,6 +3803,7 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
       transactionPayload = getTransactionActionPayload(transactionRow.actionPayload);
     } catch (error) {
       if (error instanceof TransactionActionPayloadValidationError) {
+        const malformedField = error.field;
         await writeVaultAudit(c, {
           tenantId,
           actorType: "user",
@@ -3801,8 +3814,7 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
           metadata: {
             agentId,
             reason: "malformed_transaction_action_payload",
-            field: error.field,
-            error: error.message,
+            field: malformedField,
           },
         });
         return c.json<ApiResponse>(
@@ -4276,7 +4288,7 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
                 metadata: {
                   txId,
                   payloadDigest: expected.payloadDigest,
-                  error: error instanceof Error ? error.message : "authorization rejected",
+                  ...redactedThrownDiagnostics(error),
                 },
               });
               throw error;
@@ -4357,7 +4369,11 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
 
       if (!isSolana && shouldBroadcast) {
         recordVaultSpend(agentId, tenantId, transactionRow.value, transactionRow.chainId).catch(
-          (err) => console.error("[vault] Failed to record approved transaction spend:", err),
+          (err) =>
+            console.error(
+              "[vault] Failed to record approved transaction spend",
+              redactedThrownDiagnostics(err),
+            ),
         );
       }
       if (transferPayload) {
@@ -4497,7 +4513,11 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
       const outcomeUnknown = externalBroadcastOutcomeUnknownResponse(c, e, txId);
       if (outcomeUnknown) {
         recordVaultSpend(agentId, tenantId, transactionRow.value, transactionRow.chainId).catch(
-          (err) => console.error("[vault] Failed to record ambiguous approved spend:", err),
+          (err) =>
+            console.error(
+              "[vault] Failed to record ambiguous approved spend",
+              redactedThrownDiagnostics(err),
+            ),
         );
         try {
           await recordAggregationEvent({
@@ -4507,7 +4527,10 @@ vaultRoutes.post("/:agentId/approve/:txId", async (c) => {
             chainId: transactionRow.chainId,
           });
         } catch (err) {
-          console.error("[vault] Failed to record ambiguous approved aggregation event:", err);
+          console.error(
+            "[vault] Failed to record ambiguous approved aggregation event",
+            redactedThrownDiagnostics(err),
+          );
         }
         await writeOutcomeUnknownAudit(c, {
           tenantId,
@@ -5408,7 +5431,10 @@ vaultRoutes.post("/:agentId/sign-message", async (c) => {
   } catch (e) {
     const frozen = frozenSigningResponse(c, e);
     if (frozen) return frozen;
-    console.error(`[Vault] sign-message failed for ${tenantId}/${agentId}:`, e);
+    console.error(
+      `[Vault] sign-message failed for ${tenantId}/${agentId}`,
+      redactedThrownDiagnostics(e),
+    );
     return c.json<ApiResponse>({ ok: false, error: sanitizeErrorMessage(e) }, 500);
   }
 });
@@ -5507,7 +5533,10 @@ vaultRoutes.post("/:agentId/sign-raw-hash", async (c) => {
     setNoStoreHeaders(c);
     return c.json<ApiResponse>({ ok: true, data: result });
   } catch (e) {
-    console.error(`[Vault] sign-raw-hash failed for ${tenantId}/${agentId}:`, e);
+    console.error(
+      `[Vault] sign-raw-hash failed for ${tenantId}/${agentId}`,
+      redactedThrownDiagnostics(e),
+    );
     return c.json<ApiResponse>({ ok: false, error: sanitizeErrorMessage(e) }, 500);
   }
 });
@@ -5735,7 +5764,10 @@ vaultRoutes.post("/:agentId/sign-raw-digest", async (c) => {
     setNoStoreHeaders(c);
     return c.json<ApiResponse>({ ok: true, data: result });
   } catch (e) {
-    console.error(`[Vault] sign-raw-digest failed for ${tenantId}/${agentId}:`, e);
+    console.error(
+      `[Vault] sign-raw-digest failed for ${tenantId}/${agentId}`,
+      redactedThrownDiagnostics(e),
+    );
     return c.json<ApiResponse>({ ok: false, error: sanitizeErrorMessage(e) }, 500);
   }
 });
@@ -6095,7 +6127,10 @@ vaultRoutes.post("/:agentId/sign-bitcoin-psbt", async (c) => {
       setNoStoreHeaders(c);
       return c.json<ApiResponse>({ ok: true, data: { ...result, transactionId } });
     } catch (e) {
-      console.error(`[Vault] sign-bitcoin-psbt failed for ${tenantId}/${agentId}:`, e);
+      console.error(
+        `[Vault] sign-bitcoin-psbt failed for ${tenantId}/${agentId}`,
+        redactedThrownDiagnostics(e),
+      );
       const rawError = e instanceof Error ? e.message : String(e);
       const isFinalizationFailure = rawError.includes("Bitcoin PSBT finalization failed");
       const noSpendableInput = rawError.includes(
@@ -6190,7 +6225,10 @@ vaultRoutes.get("/:agentId/monero/balance", async (c) => {
   } catch (e) {
     const mapped = moneroErrorResponse(c, e);
     if (mapped) return mapped;
-    console.error(`[Vault] monero/balance failed for ${tenantId}/${agentId}:`, e);
+    console.error(
+      `[Vault] monero/balance failed for ${tenantId}/${agentId}`,
+      redactedThrownDiagnostics(e),
+    );
     return c.json<ApiResponse>({ ok: false, error: sanitizeErrorMessage(e) }, 500);
   }
 });
@@ -6472,7 +6510,10 @@ vaultRoutes.post("/:agentId/monero/transfer", async (c) => {
     } catch (e) {
       const mapped = moneroErrorResponse(c, e);
       if (mapped) return mapped;
-      console.error(`[Vault] monero/transfer prepare failed for ${tenantId}/${agentId}:`, e);
+      console.error(
+        `[Vault] monero/transfer prepare failed for ${tenantId}/${agentId}`,
+        redactedThrownDiagnostics(e),
+      );
       const raw = e instanceof Error ? e.message : String(e);
       const isFundsError = /not enough (unlocked )?money|not enough outputs/i.test(raw);
       return c.json<ApiResponse>(
@@ -6609,7 +6650,10 @@ vaultRoutes.post("/:agentId/monero/transfer", async (c) => {
       });
 
       recordVaultSpend(agentId, tenantId, totalPiconero.toString(), moneroChainId).catch((err) =>
-        console.error(`[Vault] recordVaultSpend failed for ${agentId}:`, err),
+        console.error(
+          `[Vault] recordVaultSpend failed for ${agentId}`,
+          redactedThrownDiagnostics(err),
+        ),
       );
 
       await writeVaultAudit(c, {
@@ -6659,7 +6703,10 @@ vaultRoutes.post("/:agentId/monero/transfer", async (c) => {
       });
     } catch (e) {
       await discardPrepared();
-      console.error(`[Vault] monero/transfer relay failed for ${tenantId}/${agentId}:`, e);
+      console.error(
+        `[Vault] monero/transfer relay failed for ${tenantId}/${agentId}`,
+        redactedThrownDiagnostics(e),
+      );
       await writeVaultAudit(c, {
         tenantId,
         actorType: "user",
@@ -6673,7 +6720,7 @@ vaultRoutes.post("/:agentId/monero/transfer", async (c) => {
           feePiconero: feePiconero.toString(),
           totalPiconero: totalPiconero.toString(),
           referenceId: referenceId ?? null,
-          error: sanitizeErrorMessage(e),
+          ...redactedThrownDiagnostics(e),
           policyResults,
           ...signerAuthAuditMetadata(signerAuthorization.auth),
         },
@@ -6978,7 +7025,10 @@ vaultRoutes.post("/:agentId/sign-typed-data", async (c) => {
     if (frozen) return frozen;
     const requestId = c.get("requestId") || "unknown";
     const rawMessage = e instanceof Error ? e.message : "Unknown error";
-    console.error(`[${requestId}] Sign typed data failed for agent ${agentId}:`, e);
+    console.error(
+      `[${requestId}] Sign typed data failed for agent ${agentId}`,
+      redactedThrownDiagnostics(e),
+    );
 
     dispatchWebhook(tenantId, agentId, "tx_failed", {
       txId,
@@ -7310,13 +7360,14 @@ vaultRoutes.post("/:agentId/sign-user-operation", async (c) => {
           chainId: signRequest.chainId,
           sender: userOperation.sender,
           ...signerAuthAuditMetadata(signerAuthorization.auth),
-          error: e instanceof Error ? e.message : "Unknown error",
+          ...redactedThrownDiagnostics(e),
         },
       });
 
       dispatchWebhook(tenantId, agentId, "tx_failed", {
         txId,
-        error: e instanceof Error ? e.message : "Unknown error",
+        error: "Transaction failed",
+        ...redactedThrownDiagnostics(e),
       });
 
       return c.json<ApiResponse>({ ok: false, error: sanitizeErrorMessage(e) }, 500);
@@ -7668,13 +7719,14 @@ vaultRoutes.post("/:agentId/sign-authorization", async (c) => {
           contractAddress,
           nonce,
           ...signerAuthAuditMetadata(signerAuthorization.auth),
-          error: e instanceof Error ? e.message : "Unknown error",
+          ...redactedThrownDiagnostics(e),
         },
       });
 
       dispatchWebhook(tenantId, agentId, "tx_failed", {
         txId,
-        error: e instanceof Error ? e.message : "Unknown error",
+        error: "Transaction failed",
+        ...redactedThrownDiagnostics(e),
       });
 
       return c.json<ApiResponse>({ ok: false, error: sanitizeErrorMessage(e) }, 500);
@@ -7833,7 +7885,7 @@ async function signSolanaBlind(
         signedAt: new Date(),
       });
       recordVaultSpend(agentId, tenantId, txValue, chainId).catch((err) =>
-        console.error("[vault] Failed to record Solana spend:", err),
+        console.error("[vault] Failed to record Solana spend", redactedThrownDiagnostics(err)),
       );
       await writeVaultAudit(c, {
         tenantId,
@@ -7870,7 +7922,10 @@ async function signSolanaBlind(
       const frozen = frozenSigningResponse(c, e);
       if (frozen) return frozen;
       const requestId = c.get("requestId") || "unknown";
-      console.error(`[${requestId}] Solana blind sign failed for agent ${agentId}:`, e);
+      console.error(
+        `[${requestId}] Solana blind sign failed for agent ${agentId}`,
+        redactedThrownDiagnostics(e),
+      );
       if (completedResult?.broadcast) {
         console.error(
           `[${requestId}] Solana blind sign completed before bookkeeping failed for agent ${agentId}, tx ${txId}; returning completed result to prevent duplicate retry`,
@@ -7887,7 +7942,8 @@ async function signSolanaBlind(
         >({ ok: true, data: completedResult });
       }
       dispatchWebhook(tenantId, agentId, "tx_failed", {
-        error: e instanceof Error ? e.message : "Unknown error",
+        error: "Transaction failed",
+        ...redactedThrownDiagnostics(e),
         requestId,
       });
       if (isRpcError(e)) {
@@ -8309,7 +8365,7 @@ vaultRoutes.post("/:agentId/sign-solana", async (c) => {
 
       // ── Record spend in Redis (fire-and-forget) ──────────────────────────────
       recordVaultSpend(agentId, tenantId, txValue, chainId).catch((err) =>
-        console.error("[vault] Failed to record Solana spend:", err),
+        console.error("[vault] Failed to record Solana spend", redactedThrownDiagnostics(err)),
       );
 
       await writeVaultAudit(c, {
@@ -8360,7 +8416,10 @@ vaultRoutes.post("/:agentId/sign-solana", async (c) => {
       const frozen = frozenSigningResponse(c, e);
       if (frozen) return frozen;
       const requestId = c.get("requestId") || "unknown";
-      console.error(`[${requestId}] Solana sign failed for agent ${agentId}:`, e);
+      console.error(
+        `[${requestId}] Solana sign failed for agent ${agentId}`,
+        redactedThrownDiagnostics(e),
+      );
       if (completedResult?.broadcast) {
         console.error(
           `[${requestId}] Solana sign completed before bookkeeping failed for agent ${agentId}, tx ${txId}; returning completed result to prevent duplicate retry`,
@@ -8378,7 +8437,8 @@ vaultRoutes.post("/:agentId/sign-solana", async (c) => {
       }
 
       dispatchWebhook(tenantId, agentId, "tx_failed", {
-        error: e instanceof Error ? e.message : "Unknown error",
+        error: "Transaction failed",
+        ...redactedThrownDiagnostics(e),
         requestId,
       });
 
@@ -8436,7 +8496,10 @@ vaultRoutes.post("/:agentId/rpc", async (c) => {
   } catch (e: unknown) {
     const requestId = c.get("requestId") || "unknown";
     const message = e instanceof Error ? e.message : "Unknown error";
-    console.error(`[${requestId}] RPC passthrough failed for agent ${agentId}:`, e);
+    console.error(
+      `[${requestId}] RPC passthrough failed for agent ${agentId}`,
+      redactedThrownDiagnostics(e),
+    );
     return c.json<ApiResponse>({ ok: false, error: message }, 400);
   }
 });
@@ -8474,7 +8537,10 @@ vaultRoutes.get("/:agentId/addresses", async (c) => {
     });
   } catch (e: unknown) {
     const requestId = c.get("requestId") || "unknown";
-    console.error(`[${requestId}] getAddresses failed for agent ${agentId}:`, e);
+    console.error(
+      `[${requestId}] getAddresses failed for agent ${agentId}`,
+      redactedThrownDiagnostics(e),
+    );
     return c.json<ApiResponse>({ ok: false, error: sanitizeErrorMessage(e) }, 500);
   }
 });
@@ -8670,7 +8736,10 @@ vaultRoutes.post("/:agentId/import/submit", async (c) => {
     });
   } catch (e: unknown) {
     const requestId = c.get("requestId") || "unknown";
-    console.error(`[${requestId}] Encrypted key import failed for agent ${agentId}:`, e);
+    console.error(
+      `[${requestId}] Encrypted key import failed for agent ${agentId}`,
+      redactedThrownDiagnostics(e),
+    );
     return c.json<ApiResponse>({ ok: false, error: sanitizeErrorMessage(e) }, 500);
   }
 });
@@ -8772,7 +8841,10 @@ vaultRoutes.post("/:agentId/import", async (c) => {
     });
   } catch (e: unknown) {
     const requestId = c.get("requestId") || "unknown";
-    console.error(`[${requestId}] Key import failed for agent ${agentId}:`, e);
+    console.error(
+      `[${requestId}] Key import failed for agent ${agentId}`,
+      redactedThrownDiagnostics(e),
+    );
     return c.json<ApiResponse>({ ok: false, error: sanitizeErrorMessage(e) }, 500);
   }
 });
@@ -8893,7 +8965,10 @@ vaultRoutes.post("/:agentId/export", async (c) => {
     });
   } catch (e: unknown) {
     const requestId = c.get("requestId") || "unknown";
-    console.error(`[${requestId}] Key export failed for agent ${agentId}:`, e);
+    console.error(
+      `[${requestId}] Key export failed for agent ${agentId}`,
+      redactedThrownDiagnostics(e),
+    );
     return c.json<ApiResponse>({ ok: false, error: sanitizeErrorMessage(e) }, 500);
   }
 });

--- a/packages/api/src/routes/webhooks.ts
+++ b/packages/api/src/routes/webhooks.ts
@@ -6,7 +6,7 @@
 
 import { randomBytes } from "node:crypto";
 import { tenantConfigs as tenantConfigsTable } from "@stwd/db";
-import type { TenantAuthAbuseConfig } from "@stwd/shared";
+import { redactedThrownDiagnostics, type TenantAuthAbuseConfig } from "@stwd/shared";
 import { encryptWebhookSecret } from "@stwd/webhooks";
 import { and, count, desc, eq, or, type SQL, sql } from "drizzle-orm";
 import { Hono } from "hono";
@@ -800,8 +800,8 @@ webhookRoutes.post("/:id/test", async (c) => {
     });
   } catch (error) {
     console.error(
-      `[webhooks] Test webhook ${delivery.id} was dispatched but final audit failed:`,
-      error,
+      `[webhooks] Test webhook ${delivery.id} was dispatched but final audit failed`,
+      redactedThrownDiagnostics(error),
     );
     return c.json<ApiResponse>(
       {
@@ -1035,8 +1035,8 @@ webhookRoutes.post("/deliveries/:id/replay", async (c) => {
     });
   } catch (error) {
     console.error(
-      `[webhooks] Replay webhook ${replayed.id} was dispatched but final audit failed:`,
-      error,
+      `[webhooks] Replay webhook ${replayed.id} was dispatched but final audit failed`,
+      redactedThrownDiagnostics(error),
     );
     return c.json<ApiResponse>(
       {

--- a/packages/api/src/services/agent-token-status.ts
+++ b/packages/api/src/services/agent-token-status.ts
@@ -1,3 +1,4 @@
+import { redactedThrownDiagnostics } from "@stwd/shared";
 import { getRedisClient } from "../middleware/redis";
 
 const TOKEN_STATUS_KEY_PREFIX = "agent-token-status";
@@ -33,7 +34,7 @@ export async function recordAgentTokenExp(agentId: string, exp: number): Promise
   } catch (error) {
     console.warn("[steward:agent-token] failed to record token status in redis", {
       agentId,
-      error: error instanceof Error ? error.message : String(error),
+      ...redactedThrownDiagnostics(error),
     });
   }
 }
@@ -59,7 +60,7 @@ export async function getAgentTokenStatus(agentId: string): Promise<AgentTokenSt
     } catch (error) {
       console.warn("[steward:agent-token] failed to read token status from redis", {
         agentId,
-        error: error instanceof Error ? error.message : String(error),
+        ...redactedThrownDiagnostics(error),
       });
     }
   }

--- a/packages/api/src/services/audit.ts
+++ b/packages/api/src/services/audit.ts
@@ -673,7 +673,10 @@ export async function signAuditBundle(
           { cause: err },
         );
       }
-      console.error(`[audit] checkpoint persistence failed for tenant ${tenantId}:`, err);
+      console.error(
+        `[audit] checkpoint persistence failed for tenant ${tenantId}`,
+        redactedThrownDiagnostics(err),
+      );
     }
   }
 

--- a/packages/api/src/services/context.ts
+++ b/packages/api/src/services/context.ts
@@ -44,6 +44,7 @@ import {
   createPriceOracle,
   type PolicyRule,
   type PriceOracle,
+  redactedThrownDiagnostics,
   type SignRequest,
   type Tenant,
   type TenantConfig,
@@ -769,8 +770,8 @@ export async function tenantAuth(
                   .where(eq(sessionSigners.id, sessionSigner.id));
               } catch (err) {
                 console.error(
-                  `[session-signer] failed to update lastUsedAt for ${sessionSigner.id}:`,
-                  err,
+                  `[session-signer] failed to update lastUsedAt for ${sessionSigner.id}`,
+                  redactedThrownDiagnostics(err),
                 );
               }
             }

--- a/packages/api/src/services/provider-action-service.ts
+++ b/packages/api/src/services/provider-action-service.ts
@@ -85,6 +85,7 @@ import {
   isGenericDescriptorError,
   jcsStringify,
   type ProviderRequestEnvelopeV1,
+  redactedThrownDiagnostics,
   type SlackCanonicalActionV1,
   sha256HexPrefixed,
   UnregisteredProfileError,
@@ -3039,7 +3040,10 @@ class ProviderActionService {
         // Draining is best effort here; a signer outage cannot erase the durable
         // attention row or outbox event and normal C2 recovery will retry it.
         await this.recoverUnsignedIntents(row.tenantId, row.intentId).catch((error) =>
-          console.error("[provider-reservations] malformed-generation audit drain failed:", error),
+          console.error(
+            "[provider-reservations] malformed-generation audit drain failed",
+            redactedThrownDiagnostics(error),
+          ),
         );
         continue;
       }

--- a/packages/api/src/services/provider-approval.ts
+++ b/packages/api/src/services/provider-approval.ts
@@ -45,6 +45,7 @@ import {
   PROVIDER_APPROVAL_AUDIT_SCHEMA,
   type ProviderApprovalAuditPayloadV1,
   type ProviderApprovalCommitmentV1,
+  redactedThrownDiagnostics,
   sha256HexPrefixed,
   verifyProviderExecutionPolicyEvidence,
 } from "@stwd/shared";
@@ -2289,8 +2290,8 @@ class ProviderApprovalService {
           .releasePolicyReservationHandles(executionHandlesToRelease, input.tenantId)
           .catch((releaseError) =>
             console.error(
-              "[provider-approval] failed to release rolled-back reservation:",
-              releaseError,
+              "[provider-approval] failed to release rolled-back reservation",
+              redactedThrownDiagnostics(releaseError),
             ),
           );
       }
@@ -2304,7 +2305,7 @@ class ProviderApprovalService {
         if (e.code === "EXEC_AUTH_KEY_UNAVAILABLE") return fail("EXEC_AUTH_KEY_UNAVAILABLE", 503);
         return fail("RESUME_PREPARATION_FAILED", 503);
       }
-      console.error("[provider-approval] resume preparation failed:", e);
+      console.error("[provider-approval] resume preparation failed", redactedThrownDiagnostics(e));
       return fail("RESUME_PREPARATION_FAILED", 503);
     }
   }

--- a/packages/api/src/services/provider-reservation-reconciliation-scheduler.ts
+++ b/packages/api/src/services/provider-reservation-reconciliation-scheduler.ts
@@ -1,3 +1,4 @@
+import { redactedThrownDiagnostics } from "@stwd/shared";
 import { providerActionService } from "./provider-action-service";
 
 const DEFAULT_INTERVAL_MS = 15_000;
@@ -25,7 +26,9 @@ export function startProviderReservationReconciliationScheduler(): () => void {
       .then((count) => {
         if (count > 0) console.log(`[provider-reservations] reconciled ${count} reservation(s)`);
       })
-      .catch((error) => console.error("[provider-reservations] sweep failed:", error))
+      .catch((error) =>
+        console.error("[provider-reservations] sweep failed", redactedThrownDiagnostics(error)),
+      )
       .finally(() => {
         running = false;
       });

--- a/packages/api/src/services/retention.ts
+++ b/packages/api/src/services/retention.ts
@@ -13,6 +13,7 @@
  */
 
 import { getDb } from "@stwd/db";
+import { redactedThrownDiagnostics } from "@stwd/shared";
 import { sql } from "drizzle-orm";
 import { writeAuditEvent } from "./audit";
 import { runTenantAuditRetention } from "./audit-archive";
@@ -176,7 +177,10 @@ async function sweepAuditEvents(ctx: RetentionSweepContext): Promise<SweepResult
     } catch (error) {
       const message = error instanceof Error ? error.message : "unknown retention failure";
       failures.push({ tenantId: policy.tenant_id, error: message });
-      console.error(`[retention] audit retention failed for tenant ${policy.tenant_id}:`, error);
+      console.error(
+        `[retention] audit retention failed for tenant ${policy.tenant_id}`,
+        redactedThrownDiagnostics(error),
+      );
     }
   }
   return { table: "audit_events", deleted, ...(failures.length > 0 ? { failures } : {}) };
@@ -321,8 +325,8 @@ export async function runRetentionSweep(
         } catch (auditErr) {
           r.auditFailed = true;
           console.error(
-            `[retention] audit record for sweep of ${r.table} (${r.deleted} rows deleted) FAILED to persist:`,
-            auditErr,
+            `[retention] audit record for sweep of ${r.table} (${r.deleted} rows deleted) FAILED to persist`,
+            redactedThrownDiagnostics(auditErr),
           );
         }
       }
@@ -330,11 +334,11 @@ export async function runRetentionSweep(
       if (err instanceof RetentionAuthorizationAuditError) {
         results.push({ table: err.table, deleted: 0, auditFailed: true });
         console.error(
-          `[retention] authorization audit record for sweep of ${err.table} FAILED to persist; delete skipped:`,
-          err.cause ?? err,
+          "[retention] authorization audit record failed; delete skipped",
+          redactedThrownDiagnostics(err.cause ?? err),
         );
       } else {
-        console.error("[retention] sweep failed:", err);
+        console.error("[retention] sweep failed", redactedThrownDiagnostics(err));
       }
     }
   }
@@ -361,7 +365,9 @@ export function startRetentionScheduler(): () => void {
         const total = r.reduce((acc, x) => acc + x.deleted, 0);
         console.log(`[retention] initial sweep complete: ${total} rows across ${r.length} tables`);
       })
-      .catch((err) => console.error("[retention] initial sweep error:", err));
+      .catch((err) =>
+        console.error("[retention] initial sweep error", redactedThrownDiagnostics(err)),
+      );
 
     interval = setInterval(() => {
       runRetentionSweep()
@@ -371,7 +377,7 @@ export function startRetentionScheduler(): () => void {
             console.log(`[retention] sweep complete: ${total} rows across ${r.length} tables`);
           }
         })
-        .catch((err) => console.error("[retention] sweep error:", err));
+        .catch((err) => console.error("[retention] sweep error", redactedThrownDiagnostics(err)));
     }, SWEEP_INTERVAL_MS);
     if (typeof interval.unref === "function") interval.unref();
   }, INITIAL_DELAY_MS);

--- a/packages/api/src/services/transaction-receipt-poller.ts
+++ b/packages/api/src/services/transaction-receipt-poller.ts
@@ -1,4 +1,4 @@
-import { toCaip2 } from "@stwd/shared";
+import { redactedThrownDiagnostics, toCaip2 } from "@stwd/shared";
 import { and, asc, eq, inArray, isNotNull, sql } from "drizzle-orm";
 import { createPublicClient, http, type TransactionReceipt } from "viem";
 import { withTenantAuditedTransaction, writeAuditEvent } from "./audit";
@@ -447,7 +447,10 @@ async function pollOneTransaction(
   } catch (error) {
     const message = error instanceof Error ? error.message.toLowerCase() : String(error);
     if (!message.includes("not found") && !message.includes("could not find")) {
-      console.warn(`[tx-poller] Receipt lookup failed for ${row.id}:`, error);
+      console.warn(
+        `[tx-poller] Receipt lookup failed for ${row.id}`,
+        redactedThrownDiagnostics(error),
+      );
     }
   }
 
@@ -613,7 +616,7 @@ export function startTransactionReceiptPollingScheduler(): () => void {
         }
       })
       .catch((error) => {
-        console.error("[tx-poller] Receipt polling tick failed:", error);
+        console.error("[tx-poller] Receipt polling tick failed", redactedThrownDiagnostics(error));
       })
       .finally(() => {
         running = false;

--- a/packages/api/src/services/upstream-credential-lease-scheduler.ts
+++ b/packages/api/src/services/upstream-credential-lease-scheduler.ts
@@ -1,3 +1,5 @@
+import { redactedThrownDiagnostics } from "@stwd/shared";
+
 const DEFAULT_INTERVAL_MS = 15_000;
 const MAX_INTERVAL_MS = 15_000;
 const HEALTH_STALE_AFTER_MS = MAX_INTERVAL_MS * 3;
@@ -135,9 +137,8 @@ export async function startUpstreamCredentialLeaseScheduler(options?: {
       })
       .catch((error) => {
         schedulerHealth.lastFailedAt = Date.now();
-        schedulerHealth.lastError =
-          error instanceof Error ? error.message : "unknown sweep failure";
-        console.error("[upstream-leases] sweep failed:", error);
+        schedulerHealth.lastError = "credential lease recovery failed";
+        console.error("[upstream-leases] sweep failed", redactedThrownDiagnostics(error));
       })
       .finally(() => {
         schedulerHealth.inFlight = false;

--- a/packages/api/src/services/webhook-dispatch.ts
+++ b/packages/api/src/services/webhook-dispatch.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { and, eq, webhookConfigs, webhookDeliveries } from "@stwd/db";
-import type { WebhookEvent } from "@stwd/shared";
+import { redactedThrownDiagnostics, type WebhookEvent } from "@stwd/shared";
 import {
   decryptWebhookSecret,
   encryptWebhookSecret,
@@ -53,7 +53,10 @@ export function dispatchWebhook(
   };
   void dispatchConfiguredWebhooks(event, configuredType, isPluginEvent ? type : null).catch(
     (error) => {
-      console.error("[webhooks] Failed to dispatch configured webhooks:", error);
+      console.error(
+        "[webhooks] Failed to dispatch configured webhooks",
+        redactedThrownDiagnostics(error),
+      );
     },
   );
 

--- a/packages/api/src/services/webhook-retry-scheduler.ts
+++ b/packages/api/src/services/webhook-retry-scheduler.ts
@@ -1,3 +1,4 @@
+import { redactedThrownDiagnostics } from "@stwd/shared";
 import { PersistentQueue } from "@stwd/webhooks";
 
 const DEFAULT_WEBHOOK_RETRY_INTERVAL_MS = 30_000;
@@ -40,7 +41,7 @@ export function startWebhookRetryScheduler(): () => void {
         }
       })
       .catch((error) => {
-        console.error("[webhooks] Retry scheduler tick failed:", error);
+        console.error("[webhooks] Retry scheduler tick failed", redactedThrownDiagnostics(error));
       })
       .finally(() => {
         running = false;

--- a/packages/auth/src/challenge-store.ts
+++ b/packages/auth/src/challenge-store.ts
@@ -14,6 +14,7 @@
  *   const store = new ChallengeStore({ backend: new RedisBackend(redisClient) });
  */
 
+import { redactedThrownDiagnostics } from "@stwd/shared";
 import type { StoreBackend } from "./store-backends";
 import { MemoryBackend } from "./store-backends";
 
@@ -80,7 +81,10 @@ export class ChallengeStore {
     try {
       await this.backend.delete(key);
     } catch (err) {
-      console.warn("[ChallengeStore] delete failed; entry will expire via TTL:", err);
+      console.warn(
+        "[ChallengeStore] delete failed; entry will expire via TTL",
+        redactedThrownDiagnostics(err),
+      );
     }
   }
 

--- a/packages/auth/src/email.ts
+++ b/packages/auth/src/email.ts
@@ -1,4 +1,5 @@
 import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+import { redactedThrownDiagnostics } from "@stwd/shared";
 
 import { hashSha256Hex } from "./crypto";
 import type { EmailDeliveryReceipt, EmailProvider } from "./email-provider";
@@ -378,10 +379,7 @@ export class EmailAuth {
         replyTo: this.replyTo,
       });
     } catch (err) {
-      console.error(
-        "[steward:auth] email provider rejected send:",
-        err instanceof Error ? err.name : typeof err,
-      );
+      console.error("[steward:auth] email provider rejected send", redactedThrownDiagnostics(err));
       await invalidate().catch(() => {});
       throw new EmailDeliveryError();
     }

--- a/packages/auth/src/revocation.ts
+++ b/packages/auth/src/revocation.ts
@@ -9,6 +9,7 @@
  */
 
 import { assertRedisUrlTls } from "@stwd/redis";
+import { redactedThrownDiagnostics } from "@stwd/shared";
 import { Redis } from "ioredis";
 import { MONOTONIC_REVOCATION_SCRIPT } from "./revocation-script";
 
@@ -153,7 +154,7 @@ class RedisRevocationStore implements RevocationStore {
         enableReadyCheck: true,
       });
       this.redis.on("error", (err) => {
-        console.warn("[steward:auth] Redis revocation unavailable:", err.message);
+        console.warn("[steward:auth] Redis revocation unavailable", redactedThrownDiagnostics(err));
       });
     }
     return this.redis;

--- a/packages/auth/src/store-backends.ts
+++ b/packages/auth/src/store-backends.ts
@@ -13,6 +13,7 @@
  */
 
 import { getSql } from "@stwd/db";
+import { redactedThrownDiagnostics } from "@stwd/shared";
 
 // ─── Interface ────────────────────────────────────────────────────────────────
 
@@ -306,8 +307,8 @@ export async function buildBackend(
       return { backend, source: "redis" };
     } catch (err) {
       console.warn(
-        `[steward:auth] Redis backend unavailable for "${namespace}", falling back:`,
-        (err as Error).message,
+        `[steward:auth] Redis backend unavailable for "${namespace}", falling back`,
+        redactedThrownDiagnostics(err),
       );
     }
   }
@@ -322,8 +323,8 @@ export async function buildBackend(
       return { backend, source: "postgres" };
     } catch (err) {
       console.warn(
-        `[steward:auth] Postgres backend unavailable for "${namespace}", falling back to memory:`,
-        (err as Error).message,
+        `[steward:auth] Postgres backend unavailable for "${namespace}", falling back to memory`,
+        redactedThrownDiagnostics(err),
       );
     }
   }

--- a/packages/plugin-trading/src/routes/idempotency.ts
+++ b/packages/plugin-trading/src/routes/idempotency.ts
@@ -10,6 +10,7 @@
 
 import { createHash } from "node:crypto";
 import type { IoredisLike } from "@stwd/redis";
+import { redactedThrownDiagnostics } from "@stwd/shared";
 
 export interface IdempotencyRecord {
   status: number;
@@ -167,7 +168,10 @@ export class DurableIdempotencyStore<TRecord extends IdempotencyRecord> {
           }
         } catch (err) {
           // The pending marker remains fail-closed, preventing a duplicate retry.
-          console.error("[idempotency] failed to persist outcome; claim remains pending:", err);
+          console.error(
+            "[idempotency] failed to persist outcome; claim remains pending",
+            redactedThrownDiagnostics(err),
+          );
         }
       },
       release: async () => {
@@ -176,7 +180,10 @@ export class DurableIdempotencyStore<TRecord extends IdempotencyRecord> {
         } catch (err) {
           // A failed release leaves the claim pending, which is inconvenient
           // but safe: a later request must not execute while ownership is unknown.
-          console.error("[idempotency] failed to release pre-execution claim:", err);
+          console.error(
+            "[idempotency] failed to release pre-execution claim",
+            redactedThrownDiagnostics(err),
+          );
         }
       },
     };

--- a/packages/plugin-trading/src/routes/operator-recovery.ts
+++ b/packages/plugin-trading/src/routes/operator-recovery.ts
@@ -35,7 +35,12 @@
 
 import { operatorTransferReservations, policies, proxyAuditLog, transactions } from "@stwd/db";
 import { checkRateLimit } from "@stwd/redis";
-import type { ApiResponse, AppVariables, PolicyRule } from "@stwd/shared";
+import {
+  type ApiResponse,
+  type AppVariables,
+  type PolicyRule,
+  redactedThrownDiagnostics,
+} from "@stwd/shared";
 import {
   HyperliquidAdapter,
   hyperliquidAssetSchema,
@@ -848,7 +853,7 @@ export function createOperatorRecoveryRoutes(
         walletAddress,
         bridge: HYPERLIQUID_ARBITRUM_BRIDGE,
         amount: amountBaseUnits.toString(),
-        error: err instanceof Error ? err.message : String(err),
+        ...redactedThrownDiagnostics(err),
       });
       // The broadcast may have landed — record the ambiguous outcome so a retry
       // replays this 502 instead of double-broadcasting the ERC-20 transfer.
@@ -956,7 +961,7 @@ export function createOperatorRecoveryRoutes(
         requestedLeverage: body.leverage,
         isCross,
         builderPerp,
-        error: err instanceof Error ? err.message : String(err),
+        ...redactedThrownDiagnostics(err),
       });
       // The venue call may have landed — record the ambiguous outcome so a
       // retry replays this 502 instead of re-executing the leverage update.
@@ -1089,7 +1094,7 @@ export function createOperatorRecoveryRoutes(
         coin,
         amountUsdc: String(body.amountUsdc),
         amountBaseUnits: amountBaseUnits.toString(),
-        error: err instanceof Error ? err.message : String(err),
+        ...redactedThrownDiagnostics(err),
       });
       // The venue call may have landed — record the ambiguous outcome so a
       // retry replays this 502 instead of moving margin a second time.
@@ -1244,10 +1249,13 @@ export function createOperatorRecoveryRoutes(
           walletAddress,
           destination,
           amount,
-          error: err instanceof Error ? err.message : String(err),
+          ...redactedThrownDiagnostics(err),
         });
       } catch (auditErr) {
-        console.error("[operator-recovery] usdSend sign-failure audit failed", auditErr);
+        console.error(
+          "[operator-recovery] usdSend sign-failure audit failed",
+          redactedThrownDiagnostics(auditErr),
+        );
       }
       return c.json<ApiResponse>({ ok: false, error: "Failed to sign usdSend" }, 502);
     }
@@ -1284,10 +1292,13 @@ export function createOperatorRecoveryRoutes(
           destination,
           amount,
           definiteRejection: definitelyRejected,
-          error: err instanceof Error ? err.message : String(err),
+          ...redactedThrownDiagnostics(err),
         });
       } catch (auditErr) {
-        console.error("[operator-recovery] usdSend failure audit failed", auditErr);
+        console.error(
+          "[operator-recovery] usdSend failure audit failed",
+          redactedThrownDiagnostics(auditErr),
+        );
       }
       return c.json<ApiResponse>(
         {
@@ -1310,7 +1321,10 @@ export function createOperatorRecoveryRoutes(
         amount,
       });
     } catch (auditErr) {
-      console.error("[operator-recovery] usdSend completed audit failed", auditErr);
+      console.error(
+        "[operator-recovery] usdSend completed audit failed",
+        redactedThrownDiagnostics(auditErr),
+      );
     }
     return c.json<ApiResponse>({ ok: true, data: response });
   });
@@ -1388,7 +1402,7 @@ export function createOperatorRecoveryRoutes(
         walletAddress,
         builder,
         maxFeeRate,
-        error: err instanceof Error ? err.message : String(err),
+        ...redactedThrownDiagnostics(err),
       });
       // The venue call may have landed — record the ambiguous outcome so a
       // retry replays this 502 instead of re-submitting the approval.
@@ -1525,7 +1539,7 @@ export function createOperatorRecoveryRoutes(
         sourceDex,
         destinationDex,
         amountUsdc: String(body.amountUsdc),
-        error: err instanceof Error ? err.message : String(err),
+        ...redactedThrownDiagnostics(err),
       });
       await idempotency.release?.();
       return c.json<ApiResponse>({ ok: false, error: "Failed to sign collateral transfer" }, 502);
@@ -1542,7 +1556,7 @@ export function createOperatorRecoveryRoutes(
         sourceDex,
         destinationDex,
         amountUsdc: String(body.amountUsdc),
-        error: err instanceof Error ? err.message : String(err),
+        ...redactedThrownDiagnostics(err),
       });
       const errorBody = { ok: false as const, error: "Failed to submit collateral transfer" };
       await idempotency.storeFailure?.(errorBody);
@@ -1620,7 +1634,7 @@ export function createOperatorRecoveryRoutes(
       await auditRecoveryEvent(c, tenantId, agentId, "trade.recovery.close-all.failed", {
         venue,
         walletAddress,
-        error: err instanceof Error ? err.message : String(err),
+        ...redactedThrownDiagnostics(err),
       });
       // Positions may have been partially closed — record the ambiguous outcome
       // so a retry replays this 502 instead of firing another close batch.
@@ -1816,10 +1830,13 @@ export function createOperatorRecoveryRoutes(
           walletAddress,
           destination,
           amount,
-          error: err instanceof Error ? err.message : String(err),
+          ...redactedThrownDiagnostics(err),
         });
       } catch (auditErr) {
-        console.error("[operator-recovery] withdraw sign-failure audit failed", auditErr);
+        console.error(
+          "[operator-recovery] withdraw sign-failure audit failed",
+          redactedThrownDiagnostics(auditErr),
+        );
       }
       return c.json<ApiResponse>({ ok: false, error: "Failed to sign withdraw" }, 502);
     }
@@ -1841,10 +1858,13 @@ export function createOperatorRecoveryRoutes(
           destination,
           amount,
           definiteRejection: definitelyRejected,
-          error: err instanceof Error ? err.message : String(err),
+          ...redactedThrownDiagnostics(err),
         });
       } catch (auditErr) {
-        console.error("[operator-recovery] withdraw submit-failure audit failed", auditErr);
+        console.error(
+          "[operator-recovery] withdraw submit-failure audit failed",
+          redactedThrownDiagnostics(auditErr),
+        );
       }
       return c.json<ApiResponse>(errorBody, 502);
     }

--- a/packages/plugin-trading/src/routes/trade.ts
+++ b/packages/plugin-trading/src/routes/trade.ts
@@ -25,7 +25,7 @@ import {
   tradeVenueAllowlistEvaluator,
 } from "@stwd/policy-engine";
 import { checkRateLimit } from "@stwd/redis";
-import type { ApiResponse, AppVariables } from "@stwd/shared";
+import { type ApiResponse, type AppVariables, redactedThrownDiagnostics } from "@stwd/shared";
 import { type TradeSession, TradeSessionManager } from "@stwd/trade-sessions";
 import {
   getMarketableLimitPx,
@@ -1178,7 +1178,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
               requestedLeverage: body.leverage,
               isCross: false,
               builderPerp,
-              error: err instanceof Error ? err.message : String(err),
+              ...redactedThrownDiagnostics(err),
             });
             const envelope: TradeIdempotencyResponse = {
               status: 502,
@@ -1219,7 +1219,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
             asset: parsedAsset.data,
             sizeUsd,
             reason: "pre-submit-sign-failed",
-            error: err instanceof Error ? err.message : String(err),
+            ...redactedThrownDiagnostics(err),
           });
           return {
             status: 400,
@@ -2037,7 +2037,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
             conditionId: body.conditionId ?? null,
             notionalUsd,
             reason: "pre-submit-build-failed",
-            error: err instanceof Error ? err.message : String(err),
+            ...redactedThrownDiagnostics(err),
           });
           const envelope: TradeIdempotencyResponse = {
             status: 400,
@@ -2103,7 +2103,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
               conditionId: body.conditionId ?? null,
               notionalUsd,
               reason: "pre-submit-build-failed",
-              error: err.message,
+              ...redactedThrownDiagnostics(err),
             });
             const envelope: TradeIdempotencyResponse = {
               status: 400,
@@ -2121,7 +2121,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
             conditionId: body.conditionId ?? null,
             notionalUsd,
             reason: "submit-status-unknown",
-            error: err instanceof Error ? err.message : String(err),
+            ...redactedThrownDiagnostics(err),
           });
           const envelope: TradeIdempotencyResponse = {
             status: 502,
@@ -2232,7 +2232,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
         } catch (auditErr) {
           console.error(
             "[polymarket/order] submitted-audit write failed (order already final)",
-            auditErr,
+            redactedThrownDiagnostics(auditErr),
           );
         }
         return envelope;

--- a/packages/proxy/src/handlers/proxy.ts
+++ b/packages/proxy/src/handlers/proxy.ts
@@ -1755,7 +1755,10 @@ export async function handleProxy(c: Context): Promise<Response> {
       reason: "credential-proxy-authorized",
     });
   } catch (err) {
-    console.error("[proxy] Required audit write failed before credential forwarding:", err);
+    console.error(
+      "[proxy] Required audit write failed before credential forwarding",
+      redactedThrownDiagnostics(err),
+    );
     await releaseProxySpendReservation(agentId, tenantId, target.host, spendReservation);
     await releaseUnsafeProxyRequest(replayClaim);
     proxySlot.release();
@@ -2053,9 +2056,7 @@ export async function handleProxy(c: Context): Promise<Response> {
     const latencyMs = Date.now() - startTime;
     // Fetch errors can embed the full outbound URL. Query-injected credentials
     // must never be copied from that error into application logs.
-    console.error("[proxy] Upstream request failed", {
-      errorName: err instanceof Error ? err.name : "UnknownError",
-    });
+    console.error("[proxy] Upstream request failed", redactedThrownDiagnostics(err));
 
     // Audit the failure
     await recordAudit({

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -13,7 +13,12 @@
  */
 
 import { validateJwtSecretEnv } from "@stwd/auth";
-import { metricsTokenIsValid, renderSecurityMetrics, securityMetricsEnabled } from "@stwd/shared";
+import {
+  metricsTokenIsValid,
+  redactedThrownDiagnostics,
+  renderSecurityMetrics,
+  securityMetricsEnabled,
+} from "@stwd/shared";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { configuredProxyCorsOrigins, PROXY_PORT } from "./config";
@@ -101,7 +106,10 @@ app.all("*", handleProxy);
 // ─── Redis initialization (non-blocking) ─────────────────────────────────────
 
 initProxyRedis().catch((err) => {
-  console.warn("[proxy] Redis initialization failed, continuing without Redis:", err);
+  console.warn(
+    "[proxy] Redis initialization failed, continuing without Redis",
+    redactedThrownDiagnostics(err),
+  );
 });
 
 // ─── Graceful shutdown ────────────────────────────────────────────────────────

--- a/packages/proxy/src/middleware/audit.ts
+++ b/packages/proxy/src/middleware/audit.ts
@@ -7,6 +7,7 @@
  */
 
 import { getDb, proxyAuditLog } from "@stwd/db";
+import { redactedThrownDiagnostics } from "@stwd/shared";
 
 export interface AuditEntry {
   agentId: string;
@@ -29,7 +30,7 @@ export async function recordAudit(entry: AuditEntry): Promise<void> {
   } catch (err) {
     // Best-effort audit is used only after the security-critical pre-forward
     // audit has already been persisted.
-    console.error("[audit] Failed to record audit entry:", err);
+    console.error("[audit] Failed to record audit entry", redactedThrownDiagnostics(err));
   }
 }
 

--- a/packages/proxy/src/middleware/redis-enforcement.ts
+++ b/packages/proxy/src/middleware/redis-enforcement.ts
@@ -21,6 +21,7 @@ import {
   type SpendReservation,
   settleReservedSpend,
 } from "@stwd/redis";
+import { redactedThrownDiagnostics } from "@stwd/shared";
 import { and, eq } from "drizzle-orm";
 import { boundedPositiveIntegerEnv, isProxyDevMode } from "../config";
 
@@ -48,7 +49,7 @@ export async function initProxyRedis(): Promise<boolean> {
     return true;
   } catch (err) {
     redisAvailable = false;
-    console.warn("[proxy:redis] Failed to connect:", (err as Error).message);
+    console.warn("[proxy:redis] Failed to connect", redactedThrownDiagnostics(err));
     return false;
   }
 }
@@ -122,7 +123,7 @@ export async function checkProxyRateLimit(
     const key = `ratelimit:proxy:${agentId}:${host}:${windowMs}`;
     return await checkRateLimit(key, windowMs, maxRequests);
   } catch (err) {
-    console.error("[proxy:redis] Rate limit check failed:", (err as Error).message);
+    console.error("[proxy:redis] Rate limit check failed", redactedThrownDiagnostics(err));
     if (isRedisRequired()) {
       return {
         allowed: false,
@@ -174,7 +175,7 @@ export async function trackProxySpend(
     }
     return cost;
   } catch (err) {
-    console.error("[proxy:redis] Spend tracking failed:", (err as Error).message);
+    console.error("[proxy:redis] Spend tracking failed", redactedThrownDiagnostics(err));
     return 0;
   }
 }
@@ -454,7 +455,7 @@ export async function checkProxySpendLimit(
       }
     );
   } catch (err) {
-    console.error("[proxy:redis] Spend limit check failed:", (err as Error).message);
+    console.error("[proxy:redis] Spend limit check failed", redactedThrownDiagnostics(err));
     if (isRedisRequired()) {
       return {
         allowed: false,

--- a/packages/redis/src/client.ts
+++ b/packages/redis/src/client.ts
@@ -148,7 +148,10 @@ function buildIoredis(): Redis {
   });
 
   client.on("error", (err) => {
-    console.error("[steward:redis] connection error:", (err as Error).message);
+    // Redis client errors can embed the configured URL (including its
+    // password). Keep diagnostics fixed in this low-level package, which must
+    // not depend on the shared logging layer.
+    console.error("[steward:redis] connection error");
   });
 
   client.on("connect", () => {

--- a/scripts/__tests__/runtime-error-log-safety.test.ts
+++ b/scripts/__tests__/runtime-error-log-safety.test.ts
@@ -77,9 +77,27 @@ function unsafeTelemetryArguments(source: ts.SourceFile): string[] {
       }
       for (const argument of node.arguments) {
         const text = argument.getText(source);
-        if (text.includes("redactedThrownDiagnostics(")) continue;
         const referencesCaughtThrowable = (candidate: ts.Node): boolean => {
-          if (ts.isIdentifier(candidate) && caughtThrowables.has(candidate.text)) return true;
+          if (
+            ts.isCallExpression(candidate) &&
+            ts.isIdentifier(candidate.expression) &&
+            candidate.expression.text === "redactedThrownDiagnostics"
+          ) {
+            return false;
+          }
+          if (ts.isIdentifier(candidate) && caughtThrowables.has(candidate.text)) {
+            const parent = candidate.parent;
+            // Property names such as `{ error: "fixed" }` and `value.error`
+            // are labels, not references to a catch binding with the same name.
+            if (
+              (ts.isPropertyAssignment(parent) && parent.name === candidate) ||
+              (ts.isPropertyAccessExpression(parent) && parent.name === candidate) ||
+              (ts.isMethodDeclaration(parent) && parent.name === candidate)
+            ) {
+              return false;
+            }
+            return true;
+          }
           return candidate.getChildren(source).some(referencesCaughtThrowable);
         };
         if (
@@ -160,6 +178,21 @@ describe("runtime error logging", () => {
         `,
       ),
     ).toEqual([]);
+  });
+
+  test("does not let one sanitizer call mask a sibling raw throwable", () => {
+    expect(
+      failuresForSnippet(`
+        try {
+          doThing();
+        } catch (err) {
+          console.error({ safe: redactedThrownDiagnostics(err), raw: err });
+          writeAuditEvent({
+            metadata: { diagnostics: redactedThrownDiagnostics(err), message: err.message },
+          });
+        }
+      `),
+    ).toHaveLength(2);
   });
 
   test("never passes raw throwables, messages, or stacks to console sinks", async () => {

--- a/scripts/__tests__/runtime-error-log-safety.test.ts
+++ b/scripts/__tests__/runtime-error-log-safety.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+import { readdir, readFile } from "node:fs/promises";
+import { join, relative } from "node:path";
+import ts from "typescript";
+
+const ROOT = join(import.meta.dir, "../..");
+const RUNTIME_ROOTS = [
+  "packages/api/src",
+  "packages/proxy/src",
+  "packages/auth/src",
+  "packages/plugin-trading/src",
+  "packages/redis/src",
+  "packages/agent-trader/src",
+];
+
+async function runtimeSources(directory: string): Promise<string[]> {
+  const paths: string[] = [];
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "__tests__" || entry.name === "dist") continue;
+      paths.push(...(await runtimeSources(path)));
+    } else if (entry.isFile() && entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
+      paths.push(path);
+    }
+  }
+  return paths;
+}
+
+function unsafeConsoleArguments(source: ts.SourceFile): string[] {
+  const failures: string[] = [];
+  const caughtThrowables = new Set<string>();
+  const visit = (node: ts.Node): void => {
+    if (ts.isCatchClause(node)) {
+      const variable = node.variableDeclaration?.name;
+      if (variable && ts.isIdentifier(variable)) {
+        caughtThrowables.add(variable.text);
+        ts.forEachChild(node.block, visit);
+        caughtThrowables.delete(variable.text);
+        return;
+      }
+    }
+    if (ts.isCallExpression(node)) {
+      const isConsoleSink =
+        ts.isPropertyAccessExpression(node.expression) &&
+        ts.isIdentifier(node.expression.expression) &&
+        node.expression.expression.text === "console" &&
+        ["error", "warn", "log"].includes(node.expression.name.text);
+      const sinkName = ts.isIdentifier(node.expression) ? node.expression.text : "";
+      const isTelemetrySink =
+        sinkName === "logWarn" || /(?:audit|Audit|dispatchWebhook)$/.test(sinkName);
+      if (!isConsoleSink && !isTelemetrySink) {
+        ts.forEachChild(node, visit);
+        return;
+      }
+      for (const argument of node.arguments) {
+        const text = argument.getText(source);
+        if (text.includes("redactedThrownDiagnostics(")) continue;
+        const referencesCaughtThrowable = (candidate: ts.Node): boolean => {
+          if (ts.isIdentifier(candidate) && caughtThrowables.has(candidate.text)) return true;
+          return candidate.getChildren(source).some(referencesCaughtThrowable);
+        };
+        if (
+          referencesCaughtThrowable(argument) ||
+          /^(?:err|error|e|reason|releaseError)$/i.test(text) ||
+          /(?:err|error|reason|releaseError)\s*\.\s*(?:message|stack)\b/i.test(text) ||
+          /String\(\s*(?:err|error|e|reason|releaseError)\s*\)/i.test(text) ||
+          /\$\{\s*(?:err|error|e|reason|releaseError)\s*\}/i.test(text)
+        ) {
+          const line = source.getLineAndCharacterOfPosition(argument.getStart(source)).line + 1;
+          failures.push(`${source.fileName}:${line}: ${text.slice(0, 160)}`);
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+  return failures;
+}
+
+describe("runtime error logging", () => {
+  test("never passes raw throwables, messages, or stacks to console sinks", async () => {
+    const failures: string[] = [];
+    for (const root of RUNTIME_ROOTS) {
+      for (const path of await runtimeSources(join(ROOT, root))) {
+        const text = await readFile(path, "utf8");
+        const source = ts.createSourceFile(
+          relative(ROOT, path),
+          text,
+          ts.ScriptTarget.Latest,
+          true,
+          ts.ScriptKind.TS,
+        );
+        failures.push(...unsafeConsoleArguments(source));
+      }
+    }
+    expect(failures).toEqual([]);
+  });
+});

--- a/scripts/__tests__/runtime-error-log-safety.test.ts
+++ b/scripts/__tests__/runtime-error-log-safety.test.ts
@@ -27,7 +27,30 @@ async function runtimeSources(directory: string): Promise<string[]> {
   return paths;
 }
 
-function unsafeConsoleArguments(source: ts.SourceFile): string[] {
+function sinkName(expression: ts.LeftHandSideExpression): string {
+  if (ts.isIdentifier(expression)) return expression.text;
+  if (ts.isPropertyAccessExpression(expression)) return expression.name.text;
+  return "";
+}
+
+function isTelemetrySinkName(name: string): boolean {
+  return (
+    [
+      "logWarn",
+      "dispatchWebhook",
+      "trackAuditEvent",
+      "writeAuditEvent",
+      "auditWriter",
+      "recordAudit",
+      "recordRequiredAudit",
+      "appendRequiredAudit",
+    ].includes(name) ||
+    name.endsWith("Audit") ||
+    /^audit[A-Z]/.test(name)
+  );
+}
+
+function unsafeTelemetryArguments(source: ts.SourceFile): string[] {
   const failures: string[] = [];
   const caughtThrowables = new Set<string>();
   const visit = (node: ts.Node): void => {
@@ -46,9 +69,8 @@ function unsafeConsoleArguments(source: ts.SourceFile): string[] {
         ts.isIdentifier(node.expression.expression) &&
         node.expression.expression.text === "console" &&
         ["error", "warn", "log"].includes(node.expression.name.text);
-      const sinkName = ts.isIdentifier(node.expression) ? node.expression.text : "";
-      const isTelemetrySink =
-        sinkName === "logWarn" || /(?:audit|Audit|dispatchWebhook)$/.test(sinkName);
+      const name = sinkName(node.expression);
+      const isTelemetrySink = isTelemetrySinkName(name);
       if (!isConsoleSink && !isTelemetrySink) {
         ts.forEachChild(node, visit);
         return;
@@ -78,7 +100,68 @@ function unsafeConsoleArguments(source: ts.SourceFile): string[] {
   return failures;
 }
 
+function failuresForSnippet(text: string): string[] {
+  const source = ts.createSourceFile(
+    "snippet.ts",
+    text,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  return unsafeTelemetryArguments(source);
+}
+
 describe("runtime error logging", () => {
+  test("flags raw caught throwables across audit and webhook sink variants", () => {
+    expect(
+      failuresForSnippet(
+        `
+        async function f(ctx: { writeAuditEvent: (value: unknown) => Promise<void>; auditWriter: (value: unknown) => Promise<void> }) {
+          try {
+            doThing();
+          } catch (err) {
+            await writeAuditEvent({ metadata: { error: err.message } });
+            trackAuditEvent({ metadata: { error: String(err) } });
+            await ctx.writeAuditEvent({ metadata: { error: err.message } });
+            await ctx.auditWriter({ metadata: { error: err.message } });
+            await recordAudit({ reason: err.message });
+            await recordRequiredAudit({ reason: err.message });
+            await appendRequiredAudit({ reason: err.message });
+            await auditRecoveryEvent("tenant", { error: err.message });
+            dispatchWebhook("tenant", "agent", "tx_failed", { error: err.message });
+            logWarn("warn", { error: err.message });
+            console.error("oops", err.message);
+          }
+        }
+        `,
+      ).length,
+    ).toBeGreaterThan(0);
+  });
+
+  test("allows bounded classifiers at telemetry sinks", () => {
+    expect(
+      failuresForSnippet(
+        `
+        async function f(ctx: { writeAuditEvent: (value: unknown) => Promise<void> }) {
+          try {
+            doThing();
+          } catch (err) {
+            await writeAuditEvent({ metadata: { ...redactedThrownDiagnostics(err) } });
+            trackAuditEvent({ metadata: { ...redactedThrownDiagnostics(err) } });
+            await ctx.writeAuditEvent({ metadata: { ...redactedThrownDiagnostics(err) } });
+            dispatchWebhook("tenant", "agent", "tx_failed", {
+              error: "Transaction failed",
+              ...redactedThrownDiagnostics(err),
+            });
+            logWarn("warn", { ...redactedThrownDiagnostics(err) });
+            console.error("oops", redactedThrownDiagnostics(err));
+          }
+        }
+        `,
+      ),
+    ).toEqual([]);
+  });
+
   test("never passes raw throwables, messages, or stacks to console sinks", async () => {
     const failures: string[] = [];
     for (const root of RUNTIME_ROOTS) {
@@ -91,7 +174,7 @@ describe("runtime error logging", () => {
           true,
           ts.ScriptKind.TS,
         );
-        failures.push(...unsafeConsoleArguments(source));
+        failures.push(...unsafeTelemetryArguments(source));
       }
     }
     expect(failures).toEqual([]);


### PR DESCRIPTION
## Security finding

Runtime paths still passed caught exceptions, provider diagnostics, DB/Redis failures, and failure strings directly into console logs, durable audit metadata, autonomous-agent logs, or failure webhooks. Depending on the upstream error, those values can contain tokens, credential-bearing URLs, provider bodies, database details, or other secrets.

## Fix

- route caught failures through the shared bounded redactedThrownDiagnostics classifier across API, proxy, auth, trading, Redis, and agent-trader paths
- replace raw failure text in durable audit records and outgoing failure webhooks with fixed messages plus allowlisted diagnostics
- make unauthenticated auth/provider failures return fixed public errors where raw exception text was reflected
- recursively redact nested autonomous-trader metadata, including webhook failure diagnostics and credential fields
- add a TypeScript-AST invariant rejecting raw caught values/messages/stacks at console, audit, warning, and webhook sinks

## Exact-head evidence

Head: `21208bc9d35ca3bc092385ddae9cfef7a083719e`
Base: `ce75a7d28854c1a974658d9a362e3908dc93be96`

- focused safe-error, AST invariant, logger, auth-audit, and scheduler tests: 42/42, 246 assertions
- dependency-aware API + agent-trader graph: 25/25
- Biome and diff-check: green
- original four-commit series remained patch-identical across the current-develop rebase

Broader patch-equivalent package evidence before the final nested-metadata regression: auth 278 pass / 1 environment-gated skip; agent-trader 54 pass; plugin-trading 163 pass.

Keep unmerged until exact-head hosted CI and required review complete.