### PR TITLE
fix(db): bound Workers transaction transport

### DIFF
--- a/packages/db/CLOUDFLARE.md
+++ b/packages/db/CLOUDFLARE.md
@@ -92,7 +92,8 @@ Worker request finishes. Connection acquisition is capped at 10 seconds; query,
 statement, lock, idle-connection, and idle-in-transaction phases are capped at
 30 seconds (with PostgreSQL cancellation scheduled slightly earlier). Production
 TLS policy is evaluated from the Worker bindings passed to the handle, not from
-a Node compatibility shim's `process.env`.
+a Node compatibility shim's `process.env`; because Cloudflare does not provide
+`NODE_ENV` automatically, missing `NODE_ENV` defaults to production enforcement.
 
 This is a transport primitive, not RLS activation. The shipped Worker remains
 on `DATABASE_DRIVER=neon-http` until authenticated request middleware can mint

--- a/packages/db/CLOUDFLARE.md
+++ b/packages/db/CLOUDFLARE.md
@@ -88,7 +88,11 @@ that would not work over HTTP, and Steward's actual posture on each, are:
 pool with exactly one connection. It supports Drizzle callback transactions and
 is therefore eligible for `withTenantRlsTransaction(..., "neon-websocket", ...)`.
 The handle exposes an idempotent `close()` which callers must await before a
-Worker request finishes.
+Worker request finishes. Connection acquisition is capped at 10 seconds; query,
+statement, lock, idle-connection, and idle-in-transaction phases are capped at
+30 seconds (with PostgreSQL cancellation scheduled slightly earlier). Production
+TLS policy is evaluated from the Worker bindings passed to the handle, not from
+a Node compatibility shim's `process.env`.
 
 This is a transport primitive, not RLS activation. The shipped Worker remains
 on `DATABASE_DRIVER=neon-http` until authenticated request middleware can mint

--- a/packages/db/src/__tests__/neon-transaction-driver.test.ts
+++ b/packages/db/src/__tests__/neon-transaction-driver.test.ts
@@ -64,6 +64,15 @@ describe("transaction-capable Workers database driver", () => {
   });
 
   test("uses Worker bindings as the production TLS authority", () => {
+    // Cloudflare's checked-in bindings do not define NODE_ENV. The transaction
+    // transport must therefore default to production enforcement, not skip it.
+    expect(() =>
+      createNeonTransactionDbForRequest({
+        DATABASE_DRIVER: "neon-websocket",
+        DATABASE_URL: "postgresql://db.example.test/steward",
+      }),
+    ).toThrow("DATABASE_URL must include sslmode=verify-full");
+
     expect(() =>
       createNeonTransactionDbForRequest({
         DATABASE_DRIVER: "neon-websocket",
@@ -104,6 +113,7 @@ describe("transaction-capable Workers database driver", () => {
     const handle = createNeonTransactionDbForRequest({
       DATABASE_DRIVER: "neon-websocket",
       DATABASE_URL: "postgresql://example.invalid/steward",
+      NODE_ENV: "test",
     });
     expect(handle.driver).toBe("neon-websocket");
     expect(typeof handle.db.transaction).toBe("function");

--- a/packages/db/src/__tests__/neon-transaction-driver.test.ts
+++ b/packages/db/src/__tests__/neon-transaction-driver.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import {
+  __buildNeonTransactionPoolConfigForTests,
   createDbForRequest,
   createNeonTransactionDbForRequest,
   getDatabaseDriver,
@@ -60,6 +61,43 @@ describe("transaction-capable Workers database driver", () => {
         DATABASE_URL: "postgresql://example.invalid/steward",
       }),
     ).toThrow("RLS_TRANSACTION_DRIVER_REQUIRED");
+  });
+
+  test("uses Worker bindings as the production TLS authority", () => {
+    expect(() =>
+      createNeonTransactionDbForRequest({
+        DATABASE_DRIVER: "neon-websocket",
+        DATABASE_URL: "postgresql://db.example.test/steward",
+        NODE_ENV: "production",
+      }),
+    ).toThrow("DATABASE_URL must include sslmode=verify-full");
+
+    expect(() =>
+      createNeonTransactionDbForRequest({
+        DATABASE_DRIVER: "neon-websocket",
+        DATABASE_URL: "postgresql://db.example.test/steward?sslmode=require",
+        NODE_ENV: "production",
+      }),
+    ).toThrow("does not authenticate the database server");
+  });
+
+  test("bounds connection, query, lock, statement, and idle transaction phases", () => {
+    const config = __buildNeonTransactionPoolConfigForTests({
+      DATABASE_DRIVER: "neon-websocket",
+      DATABASE_URL: "postgresql://db.example.test/steward?sslmode=verify-full",
+      NODE_ENV: "production",
+    });
+    expect(config.max).toBe(1);
+    expect(config.connectionTimeoutMillis).toBe(10_000);
+    expect(config.idleTimeoutMillis).toBe(30_000);
+    expect(config.query_timeout).toBe(30_000);
+    expect(config.statement_timeout).toBe(29_900);
+    expect(config.lock_timeout).toBe(29_900);
+    expect(config.idle_in_transaction_session_timeout).toBe(29_900);
+    const options = new URL(config.connectionString).searchParams.get("options") ?? "";
+    expect(options).toContain("statement_timeout=29900");
+    expect(options).toContain("lock_timeout=29900");
+    expect(options).toContain("idle_in_transaction_session_timeout=29900");
   });
 
   test("returns an explicitly closeable request handle with idempotent cleanup", async () => {

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -365,8 +365,13 @@ export function __buildNeonTransactionPoolConfigForTests(
   }
 
   // Worker bindings, not a Node compatibility shim's process.env, are the
-  // deployment authority. Enforce production TLS against that exact object.
-  assertDatabaseUrlTls(connectionString, env);
+  // deployment authority. Cloudflare does not synthesize NODE_ENV, so fail
+  // secure: a request-owned production transport is the default unless the
+  // caller explicitly declares a non-production environment.
+  assertDatabaseUrlTls(connectionString, {
+    ...env,
+    NODE_ENV: env.NODE_ENV ?? "production",
+  });
   const serverMs = NEON_TRANSACTION_DEADLINE_MS - DATABASE_DEADLINE_CLEANUP_GRACE_MS;
   return {
     connectionString: withServerDeadlineInUrl(connectionString, NEON_TRANSACTION_DEADLINE_MS),

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -71,11 +71,20 @@ export function getDatabaseUrl(): string {
  * `require` is accepted only with STEWARD_ALLOW_UNVERIFIED_DB_TLS=true, which
  * deliberately acknowledges encryption without peer authentication.
  */
-export function assertDatabaseUrlTls(connectionString: string): void {
-  if (process.env.NODE_ENV !== "production") return;
+type DatabaseSecurityEnv = {
+  NODE_ENV?: string;
+  STEWARD_ALLOW_INSECURE_DB?: string;
+  STEWARD_ALLOW_UNVERIFIED_DB_TLS?: string;
+};
 
-  const allowInsecure = process.env.STEWARD_ALLOW_INSECURE_DB === "true";
-  const allowUnverifiedTls = process.env.STEWARD_ALLOW_UNVERIFIED_DB_TLS === "true";
+export function assertDatabaseUrlTls(
+  connectionString: string,
+  securityEnv: DatabaseSecurityEnv = process.env,
+): void {
+  if (securityEnv.NODE_ENV !== "production") return;
+
+  const allowInsecure = securityEnv.STEWARD_ALLOW_INSECURE_DB === "true";
+  const allowUnverifiedTls = securityEnv.STEWARD_ALLOW_UNVERIFIED_DB_TLS === "true";
   let parsed: URL;
   try {
     parsed = new URL(connectionString);
@@ -320,21 +329,29 @@ export interface NeonTransactionDbHandle {
   close(): Promise<void>;
 }
 
-/**
- * Create one request-scoped, transaction-capable Neon database handle.
- *
- * Unlike neon-http, the WebSocket transport pins an interactive transaction
- * to one checked-out connection, so `withTenantRlsTransaction()` can safely
- * use transaction-local `set_config`. The caller MUST await `close()` after
- * every request (normally from a `finally` block before returning the
- * response). This handle is deliberately excluded from the global singleton:
- * a Worker isolate must not retain request-owned sockets after the request's
- * lifetime.
- */
-export function createNeonTransactionDbForRequest(env: {
+const NEON_TRANSACTION_DEADLINE_MS = 30_000;
+const NEON_TRANSACTION_CONNECT_TIMEOUT_MS = 10_000;
+
+interface NeonTransactionRequestEnv extends DatabaseSecurityEnv {
   DATABASE_URL?: string;
   DATABASE_DRIVER?: string;
-}): NeonTransactionDbHandle {
+}
+
+interface NeonTransactionPoolConfig {
+  connectionString: string;
+  max: 1;
+  connectionTimeoutMillis: number;
+  idleTimeoutMillis: number;
+  query_timeout: number;
+  statement_timeout: number;
+  lock_timeout: number;
+  idle_in_transaction_session_timeout: number;
+}
+
+/** @internal Exported only so security invariants can inspect the driver config without I/O. */
+export function __buildNeonTransactionPoolConfigForTests(
+  env: NeonTransactionRequestEnv,
+): NeonTransactionPoolConfig {
   if (env.DATABASE_DRIVER?.trim().toLowerCase() !== "neon-websocket") {
     throw new Error(
       "RLS_TRANSACTION_DRIVER_REQUIRED: set DATABASE_DRIVER=neon-websocket for transaction-capable Workers database access",
@@ -346,16 +363,46 @@ export function createNeonTransactionDbForRequest(env: {
       "DATABASE_URL binding is required for transaction-capable Workers database access",
     );
   }
-  assertDatabaseUrlTls(connectionString);
+
+  // Worker bindings, not a Node compatibility shim's process.env, are the
+  // deployment authority. Enforce production TLS against that exact object.
+  assertDatabaseUrlTls(connectionString, env);
+  const serverMs = NEON_TRANSACTION_DEADLINE_MS - DATABASE_DEADLINE_CLEANUP_GRACE_MS;
+  return {
+    connectionString: withServerDeadlineInUrl(connectionString, NEON_TRANSACTION_DEADLINE_MS),
+    max: 1,
+    connectionTimeoutMillis: NEON_TRANSACTION_CONNECT_TIMEOUT_MS,
+    idleTimeoutMillis: NEON_TRANSACTION_DEADLINE_MS,
+    query_timeout: NEON_TRANSACTION_DEADLINE_MS,
+    statement_timeout: serverMs,
+    lock_timeout: serverMs,
+    idle_in_transaction_session_timeout: serverMs,
+  };
+}
+
+/**
+ * Create one request-scoped, transaction-capable Neon database handle.
+ *
+ * Unlike neon-http, the WebSocket transport pins an interactive transaction
+ * to one checked-out connection, so `withTenantRlsTransaction()` can safely
+ * use transaction-local `set_config`. The caller MUST await `close()` after
+ * every request (normally from a `finally` block before returning the
+ * response). This handle is deliberately excluded from the global singleton:
+ * a Worker isolate must not retain request-owned sockets after the request's
+ * lifetime.
+ */
+export function createNeonTransactionDbForRequest(
+  env: NeonTransactionRequestEnv,
+): NeonTransactionDbHandle {
+  const poolConfig = __buildNeonTransactionPoolConfigForTests(env);
   const { Pool } = require("@neondatabase/serverless") as {
-    Pool: new (config: {
-      connectionString: string;
-      max: number;
-    }) => {
+    Pool: new (
+      config: NeonTransactionPoolConfig,
+    ) => {
       end(): Promise<void>;
     };
   };
-  const pool = new Pool({ connectionString, max: 1 });
+  const pool = new Pool(poolConfig);
   const db = drizzleNeonWebSocket(pool as never, { schema: FULL_SCHEMA });
   let closePromise: Promise<void> | undefined;
   return {


### PR DESCRIPTION
## Security corrective after #457

The merged transport primitive was sound in its explicit handle/close and transaction-local RLS semantics, but a post-merge audit found two defense-in-depth gaps before activation:

- production TLS policy consulted process.env, not the authoritative Worker bindings passed with the database URL;
- the request-scoped Neon pool inherited unbounded connection/query/lock/idle transaction defaults.

This corrective validates TLS against the exact Worker binding object and configures a 10s connection-acquisition bound plus 30s client/server query, statement, lock, idle-pool, and idle-transaction limits. PostgreSQL cancellation is scheduled 100ms before the client hard bound. Documentation records the contract.

## Exact-head evidence

Head: `9d7f811e4be3d45fcb20276865eb050f2ceec654`
Base: `ce75a7d28854c1a974658d9a362e3908dc93be96`

- DB deadline, RLS context, and Neon driver: 17/17 tests, 48 assertions
- direct @stwd/db build: green
- Biome and diff-check: green
- one-commit range-diff across the rebase: patch-identical

Keep unmerged until exact-head hosted CI and required review complete.