### PR TITLE
feat(db): propagate request-owned Worker database

### DIFF
--- a/packages/api/src/__tests__/worker-runtime-sentinel.test.ts
+++ b/packages/api/src/__tests__/worker-runtime-sentinel.test.ts
@@ -1,9 +1,13 @@
 import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { getDb } from "@stwd/db";
 import {
   hydrateProcessEnv,
   runWorkerGoogleCredentialLifecycleSweep,
   runWorkerUpstreamCredentialLeaseSweep,
   runWorkerXCredentialLifecycleSweep,
+  withWorkerRequestDatabase,
 } from "../worker";
 
 test("Worker hydration cannot be overridden by a STEWARD_RUNTIME binding", () => {
@@ -18,6 +22,121 @@ test("Worker hydration cannot be overridden by a STEWARD_RUNTIME binding", () =>
     if (previous === undefined) delete process.env.STEWARD_RUNTIME;
     else process.env.STEWARD_RUNTIME = previous;
   }
+});
+
+test("Worker request database is exact, request-owned, and always closed", async () => {
+  const requestDb = { marker: "worker-request" } as unknown as ReturnType<typeof getDb>;
+  let closes = 0;
+  const createHandle = () => ({
+    driver: "neon-websocket" as const,
+    db: requestDb as never,
+    async close() {
+      closes += 1;
+    },
+  });
+  const env = {
+    DATABASE_URL: "postgresql://worker.invalid/steward",
+    DATABASE_DRIVER: "neon-websocket",
+  };
+
+  expect(
+    await withWorkerRequestDatabase(
+      env,
+      async () => {
+        await Promise.resolve();
+        expect(getDb()).toBe(requestDb);
+        return "ok";
+      },
+      { createHandle },
+    ),
+  ).toBe("ok");
+  expect(closes).toBe(1);
+
+  await expect(
+    withWorkerRequestDatabase(
+      env,
+      async () => {
+        expect(getDb()).toBe(requestDb);
+        throw new Error("handler failed");
+      },
+      { createHandle },
+    ),
+  ).rejects.toThrow("handler failed");
+  expect(closes).toBe(2);
+});
+
+test("Worker HTTP mode binds an exact request database without a persistent handle", async () => {
+  let created = 0;
+  const requestDb = { marker: "worker-http-request" } as unknown as ReturnType<typeof getDb>;
+  const result = await withWorkerRequestDatabase(
+    {
+      DATABASE_URL: "postgresql://worker.invalid/steward",
+      DATABASE_DRIVER: "neon-http",
+    },
+    async () => {
+      await Promise.resolve();
+      expect(getDb()).toBe(requestDb);
+      return "http";
+    },
+    {
+      createHttpDb: () => requestDb,
+      createHandle: () => {
+        created += 1;
+        throw new Error("must not create socket handle");
+      },
+    },
+  );
+  expect(result).toBe("http");
+  expect(created).toBe(0);
+});
+
+test("Worker database selection rejects missing or unsupported drivers", async () => {
+  for (const DATABASE_DRIVER of [undefined, "", "postgres-js", "bogus"]) {
+    await expect(
+      withWorkerRequestDatabase(
+        { DATABASE_URL: "postgresql://worker.invalid/steward", DATABASE_DRIVER },
+        async () => "unreachable",
+      ),
+    ).rejects.toThrow("WORKER_DATABASE_DRIVER_UNSUPPORTED");
+  }
+});
+
+test("every autonomous recovery sweep owns its own request database", () => {
+  const source = readFileSync(join(import.meta.dir, "../worker.ts"), "utf8");
+  for (const sweep of [
+    "runWorkerUpstreamCredentialLeaseSweep",
+    "runWorkerGoogleCredentialLifecycleSweep",
+    "runWorkerXCredentialLifecycleSweep",
+  ]) {
+    expect(source).toContain(`withWorkerRequestDatabase(env, () => ${sweep}(env))`);
+  }
+});
+
+test("Worker socket cleanup diagnostics are fixed and cannot replace handler errors", async () => {
+  const requestDb = { marker: "worker-request" } as unknown as ReturnType<typeof getDb>;
+  const createHandle = () => ({
+    driver: "neon-websocket" as const,
+    db: requestDb as never,
+    async close() {
+      throw new Error("socket secret canary");
+    },
+  });
+  const env = {
+    DATABASE_URL: "postgresql://worker.invalid/steward",
+    DATABASE_DRIVER: "neon-websocket",
+  };
+  await expect(withWorkerRequestDatabase(env, async () => "ok", { createHandle })).rejects.toThrow(
+    "WORKER_DATABASE_CLOSE_FAILED",
+  );
+  await expect(
+    withWorkerRequestDatabase(
+      env,
+      async () => {
+        throw new Error("handler failed");
+      },
+      { createHandle },
+    ),
+  ).rejects.toThrow("handler failed");
 });
 
 test("Worker scheduled recovery processes pre-existing leases when capabilities are enabled", async () => {

--- a/packages/api/src/services/audit.ts
+++ b/packages/api/src/services/audit.ts
@@ -217,8 +217,8 @@ function rowsFromExecute<T>(result: unknown): T[] {
  * failure (deny / roll back / surface), so a security event cannot occur without
  * a durable record.
  */
-export function trackAuditEvent(ev: AuditEventInput): void {
-  writeAuditEvent(ev).catch((err) => {
+export function trackAuditEvent(ev: AuditEventInput): Promise<void> {
+  return writeAuditEvent(ev).catch((err) => {
     console.error(
       `[audit] Failed to write event ${ev.action} for tenant ${ev.tenantId}`,
       redactedThrownDiagnostics(err),

--- a/packages/api/src/worker.ts
+++ b/packages/api/src/worker.ts
@@ -259,6 +259,14 @@ export function hydrateProcessEnv(env: Env): void {
 
 let workerInit: Promise<void> | null = null;
 
+async function validateWorkerSecurityEnv(): Promise<void> {
+  // Validate authentication-critical bindings before opening a database
+  // connection. A missing DATABASE_DRIVER must not mask a weak JWT secret or
+  // malformed token lifetime during cold-start validation.
+  const { validateJwtSecretEnv } = await import("@stwd/auth");
+  validateJwtSecretEnv();
+}
+
 async function ensureWorkerInit(env: Env): Promise<void> {
   if (workerInit) return workerInit;
   workerInit = (async () => {
@@ -269,8 +277,7 @@ async function ensureWorkerInit(env: Env): Promise<void> {
     // run the same validation on the Workers boot path so a bad/missing JWT
     // secret or malformed AGENT_TOKEN_EXPIRY fails closed at cold start instead
     // of surfacing at first token sign/verify.
-    const { validateJwtSecretEnv } = await import("@stwd/auth");
-    validateJwtSecretEnv();
+    await validateWorkerSecurityEnv();
     const redisOk = await initRedis(env);
     // Auth stores (passkey challenges, magic-link tokens, SIWE/SIWS nonces)
     // must be initialized too — without this they stay on the lazy memory
@@ -341,6 +348,7 @@ export default {
     // request (not once per isolate) so rotated bindings take effect promptly;
     // the once-per-isolate init below only bootstraps stores/imports.
     hydrateProcessEnv(env);
+    await validateWorkerSecurityEnv();
     return withWorkerRequestDatabase(env, async () => {
       await ensureWorkerInit(env);
       const app = await getComposedApp();

--- a/packages/api/src/worker.ts
+++ b/packages/api/src/worker.ts
@@ -39,11 +39,21 @@
  *                                   configured Redis is unreachable
  */
 
+import {
+  createDbForRequest,
+  createNeonTransactionDbForRequest,
+  getDb,
+  type NeonTransactionDbHandle,
+  withRequestDatabase,
+} from "@stwd/db";
 import { initRedis } from "./middleware/redis";
 
 export interface Env {
   DATABASE_URL: string;
   DATABASE_DRIVER?: string;
+  NODE_ENV?: string;
+  STEWARD_ALLOW_INSECURE_DB?: string;
+  STEWARD_ALLOW_UNVERIFIED_DB_TLS?: string;
   REDIS_DRIVER?: string;
   KV_REST_API_URL?: string;
   KV_REST_API_TOKEN?: string;
@@ -73,6 +83,63 @@ export interface Env {
   STEWARD_TRUST_CLOUDFLARE?: string;
   STEWARD_AUTH_RATE_LIMIT_OUTAGE_VALVE_MAX?: string;
   [key: string]: unknown;
+}
+
+type WorkerDatabaseHandleFactory = (env: {
+  DATABASE_URL?: string;
+  DATABASE_DRIVER?: string;
+  NODE_ENV?: string;
+  STEWARD_ALLOW_INSECURE_DB?: string;
+  STEWARD_ALLOW_UNVERIFIED_DB_TLS?: string;
+}) => NeonTransactionDbHandle;
+type WorkerHttpDatabaseFactory = (env: {
+  DATABASE_URL?: string;
+  DATABASE_DRIVER?: string;
+}) => ReturnType<typeof getDb>;
+
+/**
+ * Run one Worker unit of work with its request-owned database handle.
+ *
+ * neon-http remains the shipped default and needs no persistent cleanup. The
+ * transaction-capable WebSocket driver is explicit: its handle is bound to the
+ * async request so every legacy getDb() call resolves the same Drizzle object,
+ * then close() is awaited on success and failure. No handle is cached on the
+ * isolate.
+ */
+export async function withWorkerRequestDatabase<T>(
+  env: Env,
+  callback: () => Promise<T>,
+  options?: {
+    createHandle?: WorkerDatabaseHandleFactory;
+    createHttpDb?: WorkerHttpDatabaseFactory;
+  },
+): Promise<T> {
+  const driver = env.DATABASE_DRIVER?.trim().toLowerCase();
+  if (driver !== "neon-http" && driver !== "neon-websocket") {
+    throw new Error(
+      "WORKER_DATABASE_DRIVER_UNSUPPORTED: DATABASE_DRIVER must be neon-http or neon-websocket",
+    );
+  }
+  if (driver === "neon-http") {
+    const db = (options?.createHttpDb ?? createDbForRequest)(env);
+    return withRequestDatabase(db as unknown as ReturnType<typeof getDb>, callback);
+  }
+  const handle = (options?.createHandle ?? createNeonTransactionDbForRequest)(env);
+  const noCallbackError = Symbol("no-callback-error");
+  let callbackError: unknown | typeof noCallbackError = noCallbackError;
+  let result: T | undefined;
+  try {
+    result = await withRequestDatabase(handle.db as unknown as ReturnType<typeof getDb>, callback);
+  } catch (error) {
+    callbackError = error;
+  }
+  try {
+    await handle.close();
+  } catch {
+    if (callbackError === noCallbackError) throw new Error("WORKER_DATABASE_CLOSE_FAILED");
+  }
+  if (callbackError !== noCallbackError) throw callbackError;
+  return result as T;
 }
 
 type WorkerLeaseSweepResult = {
@@ -213,10 +280,13 @@ async function ensureWorkerInit(env: Env): Promise<void> {
     const dbUrl = (env.DATABASE_URL || "").toLowerCase();
     // Best-effort boot telemetry (a one-time observability breadcrumb of the
     // TLS/HSTS posture at cold start) — NOT a security mutation or a tamper-
-    // evident control event, and there is no client action to deny. So this
-    // intentionally stays fire-and-forget: a write failure here must not abort
-    // worker init. Security/compliance events use awaited writeAuditEvent.
-    trackAuditEvent({
+    // evident control event, and there is no client action to deny. A write
+    // failure here must not abort worker init. Security/compliance events use
+    // awaited writeAuditEvent.
+    // Await even this best-effort breadcrumb before releasing a request-owned
+    // WebSocket handle. trackAuditEvent absorbs/logs its own failure, so boot
+    // still proceeds without leaving background DB work on a closed handle.
+    await trackAuditEvent({
       tenantId: "system",
       actorType: "system",
       action: "system.tls.config",
@@ -271,9 +341,11 @@ export default {
     // request (not once per isolate) so rotated bindings take effect promptly;
     // the once-per-isolate init below only bootstraps stores/imports.
     hydrateProcessEnv(env);
-    await ensureWorkerInit(env);
-    const app = await getComposedApp();
-    return app.fetch(request, env, ctx as never);
+    return withWorkerRequestDatabase(env, async () => {
+      await ensureWorkerInit(env);
+      const app = await getComposedApp();
+      return app.fetch(request, env, ctx as never);
+    });
   },
   async scheduled(
     _controller: unknown,
@@ -282,9 +354,9 @@ export default {
   ) {
     ctx.waitUntil(
       Promise.all([
-        runWorkerUpstreamCredentialLeaseSweep(env),
-        runWorkerGoogleCredentialLifecycleSweep(env),
-        runWorkerXCredentialLifecycleSweep(env),
+        withWorkerRequestDatabase(env, () => runWorkerUpstreamCredentialLeaseSweep(env)),
+        withWorkerRequestDatabase(env, () => runWorkerGoogleCredentialLifecycleSweep(env)),
+        withWorkerRequestDatabase(env, () => runWorkerXCredentialLifecycleSweep(env)),
       ]),
     );
   },

--- a/packages/db/CLOUDFLARE.md
+++ b/packages/db/CLOUDFLARE.md
@@ -95,6 +95,16 @@ TLS policy is evaluated from the Worker bindings passed to the handle, not from
 a Node compatibility shim's `process.env`; because Cloudflare does not provide
 `NODE_ENV` automatically, missing `NODE_ENV` defaults to production enforcement.
 
+Both `neon-http` and `neon-websocket` are bound through request-local async
+context. The context is revoked as soon as the owning callback settles, so any
+detached async task fails before reusing a database handle after cleanup.
+
+`withRequestDatabase()` propagates that explicit handle through the async
+request so existing services calling `getDb()` resolve the request-owned
+Drizzle database rather than an isolate-global singleton. Concurrent contexts
+are isolated, nested replacement and raw `getSql()` bypass are rejected, and
+the Worker fetch/cron entrypoints await handle cleanup on success or failure.
+
 This is a transport primitive, not RLS activation. The shipped Worker remains
 on `DATABASE_DRIVER=neon-http` until authenticated request middleware can mint
 a trusted tenant capability and propagate the transaction-bound database to

--- a/packages/db/CLOUDFLARE.md
+++ b/packages/db/CLOUDFLARE.md
@@ -98,6 +98,10 @@ a Node compatibility shim's `process.env`; because Cloudflare does not provide
 Both `neon-http` and `neon-websocket` are bound through request-local async
 context. The context is revoked as soon as the owning callback settles, so any
 detached async task fails before reusing a database handle after cleanup.
+Before enabling the WebSocket driver, every database-backed fire-and-forget
+task must be made part of the owning callback (or an explicitly owned Worker
+lifetime); revocation prevents stale-handle use but cannot preserve unawaited
+work.
 
 `withRequestDatabase()` propagates that explicit handle through the async
 request so existing services calling `getDb()` resolve the request-owned

--- a/packages/db/src/__tests__/request-database-context.test.ts
+++ b/packages/db/src/__tests__/request-database-context.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { closeDb, getDb, getSql, withRequestDatabase } from "../client";
+
+const originalDriver = process.env.DATABASE_DRIVER;
+
+afterEach(async () => {
+  await closeDb();
+  if (originalDriver === undefined) delete process.env.DATABASE_DRIVER;
+  else process.env.DATABASE_DRIVER = originalDriver;
+});
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe("request-scoped database context", () => {
+  test("routes getDb through the exact async request and clears it afterward", async () => {
+    const requestDb = { marker: "request" } as unknown as ReturnType<typeof getDb>;
+    expect(
+      await withRequestDatabase(requestDb, async () => {
+        await Promise.resolve();
+        return getDb();
+      }),
+    ).toBe(requestDb);
+
+    process.env.DATABASE_DRIVER = "neon-websocket";
+    expect(() => getDb()).toThrow("RLS_TRANSACTION_HANDLE_REQUIRED");
+  });
+
+  test("keeps concurrent request handles isolated across interleaving awaits", async () => {
+    const dbA = { marker: "a" } as unknown as ReturnType<typeof getDb>;
+    const dbB = { marker: "b" } as unknown as ReturnType<typeof getDb>;
+    const aEntered = deferred();
+    const releaseA = deferred();
+
+    const a = withRequestDatabase(dbA, async () => {
+      expect(getDb()).toBe(dbA);
+      aEntered.resolve();
+      await releaseA.promise;
+      expect(getDb()).toBe(dbA);
+      return "a";
+    });
+    await aEntered.promise;
+    const b = withRequestDatabase(dbB, async () => {
+      expect(getDb()).toBe(dbB);
+      await Promise.resolve();
+      expect(getDb()).toBe(dbB);
+      return "b";
+    });
+    expect(await b).toBe("b");
+    releaseA.resolve();
+    expect(await a).toBe("a");
+  });
+
+  test("rejects nested replacement and raw SQL bypass", async () => {
+    const outer = { marker: "outer" } as unknown as ReturnType<typeof getDb>;
+    const inner = { marker: "inner" } as unknown as ReturnType<typeof getDb>;
+    await withRequestDatabase(outer, async () => {
+      await expect(withRequestDatabase(inner, async () => undefined)).rejects.toThrow(
+        "REQUEST_DATABASE_CONTEXT_NESTED",
+      );
+      expect(() => getSql()).toThrow("REQUEST_DATABASE_RAW_SQL_UNAVAILABLE");
+      expect(getDb()).toBe(outer);
+    });
+  });
+
+  test("revokes the database capability inherited by detached async work", async () => {
+    const requestDb = { marker: "request" } as unknown as ReturnType<typeof getDb>;
+    const release = deferred();
+    let detached!: Promise<ReturnType<typeof getDb>>;
+    await withRequestDatabase(requestDb, async () => {
+      detached = (async () => {
+        await release.promise;
+        return getDb();
+      })();
+    });
+    release.resolve();
+    await expect(detached).rejects.toThrow("REQUEST_DATABASE_CONTEXT_CLOSED");
+  });
+});

--- a/packages/db/src/__tests__/request-database-context.test.ts
+++ b/packages/db/src/__tests__/request-database-context.test.ts
@@ -71,14 +71,15 @@ describe("request-scoped database context", () => {
   test("revokes the database capability inherited by detached async work", async () => {
     const requestDb = { marker: "request" } as unknown as ReturnType<typeof getDb>;
     const release = deferred();
-    let detached!: Promise<ReturnType<typeof getDb>>;
+    let detached!: Promise<void>;
     await withRequestDatabase(requestDb, async () => {
       detached = (async () => {
         await release.promise;
-        return getDb();
+        expect(() => getDb()).toThrow("REQUEST_DATABASE_CONTEXT_CLOSED");
+        expect(() => getSql()).toThrow("REQUEST_DATABASE_CONTEXT_CLOSED");
       })();
     });
     release.resolve();
-    await expect(detached).rejects.toThrow("REQUEST_DATABASE_CONTEXT_CLOSED");
+    await detached;
   });
 });

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -24,6 +24,7 @@
  *   - neon-http  : creates one fetch-based client and reuses it
  */
 
+import { AsyncLocalStorage } from "node:async_hooks";
 import { drizzle as drizzleNeon, type NeonHttpDatabase } from "drizzle-orm/neon-http";
 import { drizzle as drizzleNeonWebSocket, type NeonDatabase } from "drizzle-orm/neon-serverless";
 import { drizzle as drizzlePostgres, type PostgresJsDatabase } from "drizzle-orm/postgres-js";
@@ -473,6 +474,41 @@ export function setPGLiteOverride(
   pgliteOverride = { db, close };
 }
 
+// ─── Request-scoped database propagation ────────────────────────────────────
+
+type RequestDatabase = ReturnType<typeof createDb>["db"];
+interface RequestDatabaseContext {
+  db: RequestDatabase;
+  active: boolean;
+}
+const requestDatabaseStorage = new AsyncLocalStorage<RequestDatabaseContext>();
+
+/**
+ * Bind one explicitly owned database handle to the current async request.
+ *
+ * Existing services resolve their database through getDb(). Keeping the
+ * request handle in AsyncLocalStorage lets a Worker use its own WebSocket pool
+ * without turning that pool into isolate-global mutable state. Nested bindings
+ * are rejected because silently replacing an outer tenant transaction would
+ * break SET LOCAL's connection and lifetime guarantees.
+ */
+export async function withRequestDatabase<T>(
+  db: RequestDatabase,
+  callback: () => Promise<T>,
+): Promise<T> {
+  if (requestDatabaseStorage.getStore()) {
+    throw new Error("REQUEST_DATABASE_CONTEXT_NESTED");
+  }
+  const context: RequestDatabaseContext = { db, active: true };
+  try {
+    return await requestDatabaseStorage.run(context, callback);
+  } finally {
+    // Detached tasks inherit AsyncLocalStorage. Revoke their capability before
+    // the owning Worker closes its socket so late getDb() calls fail before I/O.
+    context.active = false;
+  }
+}
+
 // ─── Global singleton ─────────────────────────────────────────────────────────
 
 type GlobalDbHandle =
@@ -505,6 +541,11 @@ function buildGlobalDb(): GlobalDbHandle {
 }
 
 export function getDb() {
+  const requestContext = requestDatabaseStorage.getStore();
+  if (requestContext) {
+    if (!requestContext.active) throw new Error("REQUEST_DATABASE_CONTEXT_CLOSED");
+    return requestContext.db;
+  }
   if (pgliteOverride) return pgliteOverride.db as ReturnType<typeof createDb>["db"];
   globalDb ??= buildGlobalDb();
   // Both postgres-js and neon-http drivers expose the same Drizzle surface
@@ -525,6 +566,13 @@ export function getDb() {
  * template, which is portable across both.
  */
 export function getSql() {
+  const requestContext = requestDatabaseStorage.getStore();
+  if (requestContext) {
+    if (!requestContext.active) throw new Error("REQUEST_DATABASE_CONTEXT_CLOSED");
+    throw new Error(
+      "REQUEST_DATABASE_RAW_SQL_UNAVAILABLE: use the request-scoped Drizzle database",
+    );
+  }
   if (pgliteOverride) {
     throw new Error("getSql() is not available in PGLite mode — use getDb() instead");
   }

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -478,7 +478,7 @@ export function setPGLiteOverride(
 
 type RequestDatabase = ReturnType<typeof createDb>["db"];
 interface RequestDatabaseContext {
-  db: RequestDatabase;
+  db: RequestDatabase | undefined;
   active: boolean;
 }
 const requestDatabaseStorage = new AsyncLocalStorage<RequestDatabaseContext>();
@@ -506,6 +506,7 @@ export async function withRequestDatabase<T>(
     // Detached tasks inherit AsyncLocalStorage. Revoke their capability before
     // the owning Worker closes its socket so late getDb() calls fail before I/O.
     context.active = false;
+    context.db = undefined;
   }
 }
 
@@ -544,6 +545,7 @@ export function getDb() {
   const requestContext = requestDatabaseStorage.getStore();
   if (requestContext) {
     if (!requestContext.active) throw new Error("REQUEST_DATABASE_CONTEXT_CLOSED");
+    if (!requestContext.db) throw new Error("REQUEST_DATABASE_CONTEXT_INVALID");
     return requestContext.db;
   }
   if (pgliteOverride) return pgliteOverride.db as ReturnType<typeof createDb>["db"];

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -37,6 +37,7 @@ export {
   getSql,
   setPGLiteOverride,
   withDatabaseDeadline,
+  withRequestDatabase,
 } from "./client";
 export { runMigrations } from "./migrate";
 export { getMigrationExpectation, type MigrationExpectation } from "./migration-status";


### PR DESCRIPTION
SEC-169 checkpoint: request-owned transaction-capable Worker database propagation.

## Summary

- add async request-local database propagation so existing getDb() consumers use one explicit Worker-owned handle
- bind both neon-http and neon-websocket fetches plus every scheduled recovery job to independent request database capabilities
- reject unsupported Worker drivers, nested request database replacement, detached use after close, and raw getSql() bypass inside a request context
- await socket cleanup on success/failure without allowing cleanup diagnostics to replace a handler error
- validate authentication-critical Worker configuration before opening the request database on every fetch
- await the best-effort boot audit so no database work survives handle cleanup
- document that this is transport plumbing only; RLS remains disabled until trusted tenant middleware and route propagation land

## Exact-head evidence

Head: `8674485fe2b32734db132ad4076bec1371b02520`
Base: `63e0b8ddd705e43e0415651d2880034a8d38ba83`

- exact Worker boot/runtime suites: 14/14 tests, 32 assertions
- dependency-aware API graph: 24/24 builds
- Biome on all changed TS files and diff-check: green
- three-commit range-diff from the independently reviewed predecessor is patch-identical after the #461 rebase

This PR intentionally does not close SEC-169 and does not enable RLS.