### PR TITLE
fix(provider-x): recover disconnect revocations

### DIFF
--- a/packages/api/src/__tests__/provider-x-connect.test.ts
+++ b/packages/api/src/__tests__/provider-x-connect.test.ts
@@ -2061,6 +2061,16 @@ describe("disconnect", () => {
     });
     expect(exhausted).toMatchObject({ processed: 1, attention: 1, revoked: 0 });
     expect(fake.counters.revoke).toBe(0);
+    const [terminal] = await getDb()
+      .select()
+      .from(providerXCredentialLifecycles)
+      .where(eq(providerXCredentialLifecycles.id, pending.id));
+    expect(terminal).toMatchObject({
+      state: "needs_attention",
+      attempts: 5,
+      nextRetryAt: null,
+    });
+    expect(terminal.credentialSecretId).toBe(pending.credentialSecretId);
     await getDb()
       .update(providerXCredentialLifecycles)
       .set({ attempts: 0, state: "revocation_pending", nextRetryAt: new Date() })

--- a/packages/api/src/__tests__/provider-x-connect.test.ts
+++ b/packages/api/src/__tests__/provider-x-connect.test.ts
@@ -302,6 +302,7 @@ afterAll(async () => {
 afterEach(async () => {
   __setXForwardForTests(null);
   __setAfterXCredentialStageForTests(null);
+  __setAfterXDisconnectJournalForTests(null);
   __setAfterXRefreshIntentForTests(null);
   __setAfterXRevocationClaimForTests(null);
   // Reset connected accounts + credential secrets between tests.
@@ -2039,7 +2040,12 @@ describe("disconnect", () => {
     const [pending] = await getDb()
       .select()
       .from(providerXCredentialLifecycles)
-      .where(eq(providerXCredentialLifecycles.providerAccountId, completed.providerAccountId));
+      .where(
+        and(
+          eq(providerXCredentialLifecycles.providerAccountId, completed.providerAccountId),
+          eq(providerXCredentialLifecycles.kind, "disconnect_revoke"),
+        ),
+      );
     expect(pending.kind).toBe("disconnect_revoke");
     expect(pending.state).toBe("revocation_pending");
     expect(pending.credentialSecretId).not.toBeNull();
@@ -2053,11 +2059,11 @@ describe("disconnect", () => {
       config: CONFIG,
       now: new Date(Date.now() + 120_000),
     });
-    expect(exhausted.processed).toBe(0);
+    expect(exhausted).toMatchObject({ processed: 1, attention: 1, revoked: 0 });
     expect(fake.counters.revoke).toBe(0);
     await getDb()
       .update(providerXCredentialLifecycles)
-      .set({ attempts: 0 })
+      .set({ attempts: 0, state: "revocation_pending", nextRetryAt: new Date() })
       .where(eq(providerXCredentialLifecycles.id, pending.id));
 
     const swept = await runXCredentialLifecycleSweep({
@@ -2072,6 +2078,54 @@ describe("disconnect", () => {
       .from(providerXCredentialLifecycles)
       .where(eq(providerXCredentialLifecycles.id, pending.id));
     expect(recovered.state).toBe("revoked");
+    expect(recovered.credentialSecretId).toBeNull();
+    fake.restore();
+  });
+
+  test("disconnect retains its exact handle until X returns RFC 7009 status 200", async () => {
+    const { completed } = await connectHappy(new MemoryConnectStore());
+    const fake = installFakeX({ revokeStatuses: [202, 200] });
+
+    const disconnected = await disconnectXProviderCredential({
+      tenantId: TENANT,
+      workspaceId: WORKSPACE,
+      accountId: completed.providerAccountId,
+      callerUserId: ADMIN,
+      vault,
+      config: CONFIG,
+    });
+    expect(disconnected.revoked).toBe(false);
+    expect(fake.counters.revoke).toBe(1);
+
+    const [pending] = await getDb()
+      .select()
+      .from(providerXCredentialLifecycles)
+      .where(
+        and(
+          eq(providerXCredentialLifecycles.providerAccountId, completed.providerAccountId),
+          eq(providerXCredentialLifecycles.kind, "disconnect_revoke"),
+        ),
+      );
+    expect(pending).toMatchObject({
+      kind: "disconnect_revoke",
+      state: "revocation_pending",
+      attempts: 1,
+    });
+    expect(pending.credentialSecretId).not.toBeNull();
+    expect(pending.nextRetryAt).not.toBeNull();
+
+    const swept = await runXCredentialLifecycleSweep({
+      vault,
+      config: CONFIG,
+      now: new Date(Date.now() + 120_000),
+    });
+    expect(swept).toMatchObject({ processed: 1, revoked: 1, attention: 0 });
+    expect(fake.counters.revoke).toBe(2);
+    const [recovered] = await getDb()
+      .select()
+      .from(providerXCredentialLifecycles)
+      .where(eq(providerXCredentialLifecycles.id, pending.id));
+    expect(recovered).toMatchObject({ state: "revoked", attempts: 2 });
     expect(recovered.credentialSecretId).toBeNull();
     fake.restore();
   });

--- a/packages/api/src/__tests__/provider-x-connect.test.ts
+++ b/packages/api/src/__tests__/provider-x-connect.test.ts
@@ -37,6 +37,7 @@ import { providerAuthorityStore } from "../services/provider-authority-store";
 import {
   __runDefaultXForwardForTests,
   __setAfterXCredentialStageForTests,
+  __setAfterXDisconnectJournalForTests,
   __setAfterXRefreshIntentForTests,
   __setAfterXRevocationClaimForTests,
   __setXForwardForTests,
@@ -1120,6 +1121,32 @@ describe("refresh", () => {
           .returning(),
       ),
     ).rejects.toThrow();
+    await expect(
+      Promise.resolve(
+        getDb()
+          .insert(providerXCredentialLifecycles)
+          .values({
+            ...base,
+            kind: "unknown" as "refresh_rotation",
+            state: "inflight",
+            expectedAccountRevision: 1,
+          })
+          .returning(),
+      ),
+    ).rejects.toThrow();
+    await expect(
+      Promise.resolve(
+        getDb()
+          .insert(providerXCredentialLifecycles)
+          .values({
+            ...base,
+            state: "inflight",
+            expectedAccountRevision: 1,
+            attempts: 6,
+          })
+          .returning(),
+      ),
+    ).rejects.toThrow();
   });
 
   test("force refresh rotates token to a new credential version + audit", async () => {
@@ -1982,6 +2009,120 @@ describe("disconnect", () => {
         config: CONFIG,
       }),
     ).rejects.toMatchObject({ code: "X_ACCOUNT_NOT_FOUND" });
+    fake.restore();
+  });
+
+  test("crash after local revoke retains an encrypted handle for bounded recovery", async () => {
+    const { completed } = await connectHappy(new MemoryConnectStore());
+    const fake = installFakeX();
+    const restoreCrash = __setAfterXDisconnectJournalForTests(async () => {
+      throw new Error("simulated disconnect crash");
+    });
+    await expect(
+      disconnectXProviderCredential({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        accountId: completed.providerAccountId,
+        callerUserId: ADMIN,
+        vault,
+        config: CONFIG,
+      }),
+    ).rejects.toThrow("simulated disconnect crash");
+    restoreCrash();
+
+    const [account] = await getDb()
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, completed.providerAccountId));
+    expect(account.status).toBe("revoked");
+    expect(fake.counters.revoke).toBe(0);
+    const [pending] = await getDb()
+      .select()
+      .from(providerXCredentialLifecycles)
+      .where(eq(providerXCredentialLifecycles.providerAccountId, completed.providerAccountId));
+    expect(pending.kind).toBe("disconnect_revoke");
+    expect(pending.state).toBe("revocation_pending");
+    expect(pending.credentialSecretId).not.toBeNull();
+
+    await getDb()
+      .update(providerXCredentialLifecycles)
+      .set({ attempts: 5 })
+      .where(eq(providerXCredentialLifecycles.id, pending.id));
+    const exhausted = await runXCredentialLifecycleSweep({
+      vault,
+      config: CONFIG,
+      now: new Date(Date.now() + 120_000),
+    });
+    expect(exhausted.processed).toBe(0);
+    expect(fake.counters.revoke).toBe(0);
+    await getDb()
+      .update(providerXCredentialLifecycles)
+      .set({ attempts: 0 })
+      .where(eq(providerXCredentialLifecycles.id, pending.id));
+
+    const swept = await runXCredentialLifecycleSweep({
+      vault,
+      config: CONFIG,
+      now: new Date(Date.now() + 120_000),
+    });
+    expect(swept.revoked).toBe(1);
+    expect(fake.counters.revoke).toBe(1);
+    const [recovered] = await getDb()
+      .select()
+      .from(providerXCredentialLifecycles)
+      .where(eq(providerXCredentialLifecycles.id, pending.id));
+    expect(recovered.state).toBe("revoked");
+    expect(recovered.credentialSecretId).toBeNull();
+    fake.restore();
+  });
+
+  test("disconnect serializes with an in-flight rotating refresh without losing revocation", async () => {
+    const { completed } = await connectHappy(new MemoryConnectStore());
+    const fake = installFakeX();
+    let releaseRefresh!: () => void;
+    let refreshIntentReached!: () => void;
+    const intentReached = new Promise<void>((resolve) => {
+      refreshIntentReached = resolve;
+    });
+    const holdRefresh = new Promise<void>((resolve) => {
+      releaseRefresh = resolve;
+    });
+    const restoreHook = __setAfterXRefreshIntentForTests(async () => {
+      refreshIntentReached();
+      await holdRefresh;
+    });
+    const refreshing = refreshXProviderCredential({
+      tenantId: TENANT,
+      workspaceId: WORKSPACE,
+      accountId: completed.providerAccountId,
+      vault,
+      config: CONFIG,
+      force: true,
+    });
+    await intentReached;
+
+    const disconnected = await disconnectXProviderCredential({
+      tenantId: TENANT,
+      workspaceId: WORKSPACE,
+      accountId: completed.providerAccountId,
+      callerUserId: ADMIN,
+      vault,
+      config: CONFIG,
+    });
+    expect(disconnected.revoked).toBe(true);
+    releaseRefresh();
+    await expect(refreshing).rejects.toThrow();
+    restoreHook();
+
+    const [account] = await getDb()
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, completed.providerAccountId));
+    expect(account.status).toBe("revoked");
+    expect(fake.counters.refresh).toBe(1);
+    // One revoke covers the old stored grant and one compensates the rotated
+    // response that could no longer be staged after disconnect took ownership.
+    expect(fake.counters.revoke).toBe(2);
     fake.restore();
   });
 });

--- a/packages/api/src/services/provider-x-connect.ts
+++ b/packages/api/src/services/provider-x-connect.ts
@@ -224,6 +224,7 @@ let forwardImpl: XForwardFn = defaultForward;
 let afterXRefreshIntentForTests: (() => Promise<void>) | null = null;
 let afterXCredentialStageForTests: (() => Promise<void>) | null = null;
 let afterXRevocationClaimForTests: (() => Promise<void>) | null = null;
+let afterXDisconnectJournalForTests: (() => Promise<void>) | null = null;
 
 /**
  * Test-only seam setter. Mirrors the repo's `__setForwardProxyRequestForTests`
@@ -261,6 +262,15 @@ export function __setAfterXRevocationClaimForTests(fn: (() => Promise<void>) | n
   afterXRevocationClaimForTests = fn;
   return () => {
     afterXRevocationClaimForTests = previous;
+  };
+}
+
+/** Test-only crash seam after local revocation and durable upstream handoff. */
+export function __setAfterXDisconnectJournalForTests(fn: (() => Promise<void>) | null): () => void {
+  const previous = afterXDisconnectJournalForTests;
+  afterXDisconnectJournalForTests = fn;
+  return () => {
+    afterXDisconnectJournalForTests = previous;
   };
 }
 
@@ -2499,7 +2509,7 @@ export interface DisconnectResult {
 export async function disconnectXProviderCredential(
   input: DisconnectInput,
 ): Promise<DisconnectResult> {
-  return withTenantAuditedTransaction(input.tenantId, async (txRaw, append) => {
+  const prepared = await withTenantAuditedTransaction(input.tenantId, async (txRaw, append) => {
     const tx = txRaw as DbExecutor;
     const [account] = await tx
       .select()
@@ -2518,28 +2528,35 @@ export async function disconnectXProviderCredential(
       throw new XConnectError("X_ACCOUNT_NOT_X", 400, "provider account is not an X account");
     }
 
-    let revokedAtUpstream = false;
+    let credential: LoadedCredential | null = null;
     if (account.credentialSecretId) {
-      try {
-        const cred = await loadCredential(
-          input.vault,
-          input.tenantId,
-          account.credentialSecretId,
-          tx,
-        );
-        if (cred.payload.xUserId !== account.externalRef) {
-          throw new XConnectError("X_REFRESH_FAILED", 409, "credential account binding mismatch");
-        }
-        revokedAtUpstream = await revokeUpstreamBestEffort(
-          input.config,
-          cred.payload.accessToken,
-          cred.refreshToken,
-        );
-      } catch {
-        // Best-effort only. Local degrade proceeds regardless.
-        revokedAtUpstream = false;
+      credential = await loadCredential(
+        input.vault,
+        input.tenantId,
+        account.credentialSecretId,
+        tx,
+      );
+      if (credential.payload.xUserId !== account.externalRef) {
+        throw new XConnectError("X_REFRESH_FAILED", 409, "credential account binding mismatch");
       }
     }
+    const [activeLifecycle] = await tx
+      .select()
+      .from(providerXCredentialLifecycles)
+      .where(
+        and(
+          eq(providerXCredentialLifecycles.tenantId, input.tenantId),
+          eq(providerXCredentialLifecycles.providerAccountId, account.id),
+          inArray(providerXCredentialLifecycles.state, [
+            "inflight",
+            "credential_staged",
+            "revocation_pending",
+            "needs_attention",
+          ]),
+        ),
+      )
+      .limit(1)
+      .for("update");
 
     const [degraded] = await tx
       .update(providerAccounts)
@@ -2556,6 +2573,71 @@ export async function disconnectXProviderCredential(
       throw new XConnectError("X_REFRESH_FAILED", 409, "account revision conflict on disconnect");
     }
 
+    const lifecycleId = credential ? (activeLifecycle?.id ?? randomUUID()) : null;
+    let lifecycleSecretId = activeLifecycle?.credentialSecretId ?? null;
+    if (credential && lifecycleId) {
+      if (!lifecycleSecretId) {
+        const secret = await input.vault.createSecretWithinTx(
+          tx,
+          input.tenantId,
+          `provider-x-lifecycle:${lifecycleId}:disconnect`,
+          JSON.stringify({
+            schemaVersion: "steward.provider-x.lifecycle.v1",
+            token: {
+              access_token: credential.payload.accessToken,
+              refresh_token: credential.refreshToken ?? undefined,
+            },
+          } satisfies XRefreshLifecycleSecret),
+          { description: "Encrypted transient X OAuth revocation material" },
+        );
+        lifecycleSecretId = secret.id;
+      }
+      if (activeLifecycle) {
+        const retryAt = new Date();
+        await tx
+          .update(providerXCredentialLifecycles)
+          .set({
+            kind: activeLifecycle.credentialSecretId ? activeLifecycle.kind : "disconnect_revoke",
+            state: "revocation_pending",
+            credentialSecretId: lifecycleSecretId,
+            expectedAccountRevision: degraded.revision,
+            attempts: 0,
+            nextRetryAt: retryAt,
+            lastErrorCode: "DISCONNECT_REVOCATION_PENDING",
+            updatedAt: retryAt,
+          })
+          .where(
+            and(
+              eq(providerXCredentialLifecycles.tenantId, input.tenantId),
+              eq(providerXCredentialLifecycles.id, lifecycleId),
+            ),
+          );
+      } else {
+        const retryAt = new Date();
+        await tx.insert(providerXCredentialLifecycles).values({
+          id: lifecycleId,
+          tenantId: input.tenantId,
+          workspaceId: input.workspaceId,
+          providerAccountId: account.id,
+          kind: "disconnect_revoke",
+          state: "revocation_pending",
+          credentialSecretId: lifecycleSecretId,
+          expectedAccountRevision: degraded.revision,
+          attempts: 0,
+          nextRetryAt: retryAt,
+        });
+      }
+      await append({
+        tenantId: input.tenantId,
+        actorType: "user",
+        actorId: input.callerUserId,
+        action: "provider.x.disconnect.intent_staged",
+        resourceType: "provider_x_credential_lifecycle",
+        resourceId: lifecycleId,
+        metadata: { workspaceId: input.workspaceId, providerAccountId: account.id },
+      });
+    }
+
     await append({
       tenantId: input.tenantId,
       actorType: "user",
@@ -2566,15 +2648,41 @@ export async function disconnectXProviderCredential(
       metadata: {
         workspaceId: input.workspaceId,
         xUserId: account.externalRef,
-        revokedAtUpstream,
+        revokedAtUpstream: false,
+        upstreamRevocationPending: Boolean(lifecycleId),
         previousRevision: account.revision,
         newRevision: degraded.revision,
         requestId: input.requestId ?? null,
       },
     });
 
-    return { providerAccountId: account.id, revoked: revokedAtUpstream };
+    return {
+      lifecycleId,
+    };
   });
+
+  if (!prepared.lifecycleId) {
+    return { providerAccountId: input.accountId, revoked: false };
+  }
+  await afterXDisconnectJournalForTests?.();
+  const [lifecycle] = await (getDb() as DbExecutor)
+    .select({ nextRetryAt: providerXCredentialLifecycles.nextRetryAt })
+    .from(providerXCredentialLifecycles)
+    .where(
+      and(
+        eq(providerXCredentialLifecycles.tenantId, input.tenantId),
+        eq(providerXCredentialLifecycles.id, prepared.lifecycleId),
+      ),
+    )
+    .limit(1);
+  const revokedAtUpstream = lifecycle
+    ? await reconcileStagedXCredentialRevocation({
+        ...input,
+        lifecycleId: prepared.lifecycleId,
+        now: lifecycle.nextRetryAt ?? new Date(),
+      })
+    : false;
+  return { providerAccountId: input.accountId, revoked: revokedAtUpstream };
 }
 
 async function revokeUpstreamBestEffort(

--- a/packages/db/drizzle/0106_x_disconnect_recovery_bounds.sql
+++ b/packages/db/drizzle/0106_x_disconnect_recovery_bounds.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "provider_x_credential_lifecycles"
+  DROP CONSTRAINT "provider_x_lifecycle_kind_check",
+  DROP CONSTRAINT "provider_x_lifecycle_refresh_binding_check",
+  ADD CONSTRAINT "provider_x_lifecycle_kind_check"
+    CHECK ("kind" IN ('connect_exchange', 'refresh_rotation', 'disconnect_revoke')),
+  ADD CONSTRAINT "provider_x_lifecycle_refresh_binding_check"
+    CHECK ("kind" = 'connect_exchange' OR ("provider_account_id" IS NOT NULL AND "expected_account_revision" IS NOT NULL));

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -603,6 +603,13 @@
       "when": 1787107602000,
       "tag": "0105_x_connect_exchange_recovery",
       "breakpoints": true
+    },
+    {
+      "idx": 106,
+      "version": "7",
+      "when": 1787111200000,
+      "tag": "0106_x_disconnect_recovery_bounds",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -2155,7 +2155,7 @@ export const providerXCredentialLifecycles = pgTable(
     ),
     kindCheck: check(
       "provider_x_lifecycle_kind_check",
-      sql`${table.kind} IN ('connect_exchange', 'refresh_rotation')`,
+      sql`${table.kind} IN ('connect_exchange', 'refresh_rotation', 'disconnect_revoke')`,
     ),
     revisionCheck: check(
       "provider_x_lifecycle_revision_check",
@@ -2163,7 +2163,7 @@ export const providerXCredentialLifecycles = pgTable(
     ),
     refreshBindingCheck: check(
       "provider_x_lifecycle_refresh_binding_check",
-      sql`${table.kind} <> 'refresh_rotation' OR (${table.providerAccountId} IS NOT NULL AND ${table.expectedAccountRevision} IS NOT NULL)`,
+      sql`${table.kind} = 'connect_exchange' OR (${table.providerAccountId} IS NOT NULL AND ${table.expectedAccountRevision} IS NOT NULL)`,
     ),
     retryCheck: check(
       "provider_x_lifecycle_retry_check",


### PR DESCRIPTION
## Security findings fixed

- revoke X accounts locally and durably stage encrypted upstream revocation material before provider I/O, so crashes or lost responses cannot silently discard the cleanup handle
- serialize disconnect against an in-flight rotating refresh and compensate both the stored grant and any newly rotated response without violating the one-active-lifecycle invariant
- reuse the connect/refresh durable revocation claim, lease, exponential backoff, and five-attempt terminal state for disconnect cleanup
- retain the exact encrypted handle until X returns the required RFC 7009 success status

## Exact-head evidence

Head: `609f2c419e6cb77cbcda37cc16895a405632caba`
Base: `5c241e6de9970922c52cd06e903d8c91908e0bce`

- combined X connect/refresh/disconnect lifecycle suite: 49/49 tests, 301 assertions
- dependency-aware API build: 24/24 tasks
- Biome and diff-check: green

Closes #195.