### PR TITLE
fix(security): close runtime telemetry redaction gaps

### DIFF
--- a/packages/api/src/__tests__/cumulative-spend-cap-e2e.test.ts
+++ b/packages/api/src/__tests__/cumulative-spend-cap-e2e.test.ts
@@ -808,7 +808,7 @@ describeRedis("#206 cumulativeSpend cap - full-chain E2E (real service + real Re
       .where(eq(providerActionReservationGenerations.intentId, out.intentId));
     expect(crashed.state).toBe("pending");
     expect(crashed.attempts).toBe(1);
-    expect(crashed.lastError).toContain("injected crash");
+    expect(crashed.lastError).toBe("reservation reconciliation failed");
     expect(crashed.nextRetryAt).not.toBeNull();
     expect(crashed.handles).toMatchObject({
       schemaVersion: "steward.provider-policy-reservations.v2",

--- a/packages/api/src/__tests__/retention-audit-gate.test.ts
+++ b/packages/api/src/__tests__/retention-audit-gate.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { closeDb, getDb } from "@stwd/db";
+import { closeDb, getDb, tenants } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
-import { sql } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import type { AuditEventInput } from "../services/audit";
 
 const TENANT_ID = "retention-audit-gate";
@@ -86,5 +86,33 @@ describe("retention audit gate", () => {
       "system.retention.sweep",
     ]);
     expect(await proxyPaths()).toEqual(["/fresh"]);
+  });
+
+  it("returns a stable audit-retention failure without exposing the runner exception", async () => {
+    const { runRetentionSweep } = await import("../services/retention");
+    const canary = "postgres://operator:retention-secret@example.test/audit";
+    await getDb()
+      .insert(tenants)
+      .values({ id: TENANT_ID, name: TENANT_ID, apiKeyHash: `hash-${TENANT_ID}` })
+      .onConflictDoNothing();
+    await getDb().execute(sql`
+      INSERT INTO audit_retention_policies
+        (tenant_id, retention_days, enabled, updated_at)
+      VALUES (${TENANT_ID}, 365, true, now())
+      ON CONFLICT (tenant_id) DO UPDATE SET enabled = true
+    `);
+
+    const results = await runRetentionSweep({
+      auditWriter: async () => {},
+      auditRetentionRunner: async () => {
+        throw new Error(canary);
+      },
+    });
+    const audit = results.find((result) => result.table === "audit_events");
+    expect(audit?.failures).toEqual([{ tenantId: TENANT_ID, error: "audit retention failed" }]);
+    expect(JSON.stringify(audit)).not.toContain(canary);
+
+    await getDb().execute(sql`DELETE FROM audit_retention_policies WHERE tenant_id = ${TENANT_ID}`);
+    await getDb().delete(tenants).where(eq(tenants.id, TENANT_ID));
   });
 });

--- a/packages/api/src/routes/intents.ts
+++ b/packages/api/src/routes/intents.ts
@@ -27,6 +27,7 @@ import {
   priceOracle,
   requireTenantLevel,
   safeJsonParse,
+  sanitizeErrorMessage,
   toPolicyRule,
   transactions,
   vault,
@@ -1831,7 +1832,7 @@ async function updateIntentStatus(
       await assertIntentAuthorizationBaselineCurrent(claimed);
       executionResult = await executeTypedIntent(claimed);
     } catch (error) {
-      const failureReason = error instanceof Error ? error.message : "Invalid intent execution";
+      const failureReason = sanitizeErrorMessage(error);
       const failedAt = new Date();
       const [failed] = await db
         .update(intents)

--- a/packages/api/src/routes/vault.ts
+++ b/packages/api/src/routes/vault.ts
@@ -7024,7 +7024,7 @@ vaultRoutes.post("/:agentId/sign-typed-data", async (c) => {
     const frozen = frozenSigningResponse(c, e);
     if (frozen) return frozen;
     const requestId = c.get("requestId") || "unknown";
-    const rawMessage = e instanceof Error ? e.message : "Unknown error";
+    const failureMessage = "Typed data signing failed";
     console.error(
       `[${requestId}] Sign typed data failed for agent ${agentId}`,
       redactedThrownDiagnostics(e),
@@ -7032,7 +7032,7 @@ vaultRoutes.post("/:agentId/sign-typed-data", async (c) => {
 
     dispatchWebhook(tenantId, agentId, "tx_failed", {
       txId,
-      error: rawMessage,
+      error: failureMessage,
       requestId,
     });
 

--- a/packages/api/src/services/provider-action-service.ts
+++ b/packages/api/src/services/provider-action-service.ts
@@ -3067,10 +3067,11 @@ class ProviderActionService {
         if (reservationReconciliationFaultForTests === "after_apply")
           throw new Error("injected crash after reservation reconciliation");
       } catch (error) {
-        const message = (error instanceof Error ? error.message : String(error)).slice(0, 1000);
-        await this.recordReservationFailure(row, claimId, message, false);
+        const failure = "reservation reconciliation failed";
+        await this.recordReservationFailure(row, claimId, failure, false);
         console.error(
-          `[provider-reservations] reconciliation failed intent=${row.intentId} generation=${handles.generation}: ${message}`,
+          `[provider-reservations] reconciliation failed intent=${row.intentId} generation=${handles.generation}`,
+          redactedThrownDiagnostics(error),
         );
         continue;
       }

--- a/packages/api/src/services/retention.ts
+++ b/packages/api/src/services/retention.ts
@@ -44,10 +44,13 @@ export interface SweepResult {
 
 export interface RetentionSweepOptions {
   auditWriter?: typeof writeAuditEvent;
+  /** Overrides tenant archive execution for deterministic scheduler tests. */
+  auditRetentionRunner?: typeof runTenantAuditRetention;
 }
 
 interface RetentionSweepContext {
   auditWriter: typeof writeAuditEvent;
+  auditRetentionRunner: typeof runTenantAuditRetention;
 }
 
 class RetentionAuthorizationAuditError extends Error {
@@ -172,11 +175,10 @@ async function sweepAuditEvents(ctx: RetentionSweepContext): Promise<SweepResult
   const failures: Array<{ tenantId: string; error: string }> = [];
   for (const policy of policies) {
     try {
-      const result = await runTenantAuditRetention(policy.tenant_id);
+      const result = await ctx.auditRetentionRunner(policy.tenant_id);
       deleted += result.deleted;
     } catch (error) {
-      const message = error instanceof Error ? error.message : "unknown retention failure";
-      failures.push({ tenantId: policy.tenant_id, error: message });
+      failures.push({ tenantId: policy.tenant_id, error: "audit retention failed" });
       console.error(
         `[retention] audit retention failed for tenant ${policy.tenant_id}`,
         redactedThrownDiagnostics(error),
@@ -283,6 +285,7 @@ export async function runRetentionSweep(
   const results: SweepResult[] = [];
   const ctx: RetentionSweepContext = {
     auditWriter: options.auditWriter ?? writeAuditEvent,
+    auditRetentionRunner: options.auditRetentionRunner ?? runTenantAuditRetention,
   };
 
   const sweepers: Array<(context: RetentionSweepContext) => Promise<SweepResult | null>> = [

--- a/packages/eliza-plugin/package.json
+++ b/packages/eliza-plugin/package.json
@@ -16,7 +16,8 @@
     }
   },
   "dependencies": {
-    "@stwd/sdk": "^0.10.0"
+    "@stwd/sdk": "^0.10.0",
+    "@stwd/shared": "workspace:*"
   },
   "peerDependencies": {
     "@elizaos/core": ">=2.0.0-alpha.50"
@@ -27,7 +28,6 @@
     "@stwd/db": "workspace:*",
     "@stwd/proxy": "workspace:*",
     "@stwd/proxy-client": "workspace:*",
-    "@stwd/shared": "workspace:*",
     "@types/node": "^25.5.0",
     "hono": "^4.12.34",
     "tsup": "^8.0.0",

--- a/packages/eliza-plugin/package.json
+++ b/packages/eliza-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stwd/eliza-plugin",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "ElizaOS integration for Steward-scoped wallet and provider capabilities",
   "license": "MIT",
   "type": "module",

--- a/packages/eliza-plugin/src/services/StewardService.ts
+++ b/packages/eliza-plugin/src/services/StewardService.ts
@@ -18,6 +18,7 @@ import {
   StewardApiError,
   StewardClient,
 } from "@stwd/sdk";
+import { redactedThrownDiagnostics } from "@stwd/shared";
 import type { StewardPluginConfig } from "../types.js";
 
 export interface HyperliquidSubmitOrderInput {
@@ -132,8 +133,7 @@ export class StewardService extends Service {
       if (err instanceof StewardApiError && err.status === 404 && this.pluginConfig.autoRegister) {
         await this.tryAutoRegister(runtime);
       } else {
-        const msg = err instanceof Error ? err.message : String(err);
-        console.warn(`[Steward] Could not connect: ${msg}`);
+        console.warn("[Steward] Could not connect", redactedThrownDiagnostics(err));
         if (this.pluginConfig.fallbackLocal) {
           console.info("[Steward] Falling back to local signing");
         }
@@ -148,8 +148,7 @@ export class StewardService extends Service {
       this._connected = true;
       console.info(`[Steward] Registered new wallet: ${this.agentIdentity.walletAddress}`);
     } catch (regErr) {
-      const msg = regErr instanceof Error ? regErr.message : String(regErr);
-      console.error(`[Steward] Failed to auto-register agent: ${msg}`);
+      console.error("[Steward] Failed to auto-register agent", redactedThrownDiagnostics(regErr));
     }
   }
 

--- a/packages/plugin-trading/src/routes/trade.ts
+++ b/packages/plugin-trading/src/routes/trade.ts
@@ -1823,7 +1823,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
       try {
         notionalUsd = await polymarketSellNotionalUsd(amount, price, body.tokenId, clobUrl);
       } catch (err) {
-        const reason = err instanceof Error ? err.message : "unable to size sell notional";
+        const reason = "unable to size sell notional";
         await auditTradeEvent(tenantId, agentId, "trade.order.policy-rejected", {
           venue: "polymarket",
           tokenId: body.tokenId,
@@ -1831,6 +1831,7 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
           amount,
           price,
           reason,
+          ...redactedThrownDiagnostics(err),
         });
         const envelope: TradeIdempotencyResponse = {
           status: 400,

--- a/packages/policy-engine/src/engine.ts
+++ b/packages/policy-engine/src/engine.ts
@@ -1,7 +1,8 @@
-import type {
+import {
   PolicyResult,
   PolicyRule,
   PriceOracle,
+  redactedThrownDiagnostics,
   SignRequest,
   TypedDataDomain,
   TypedDataField,
@@ -326,7 +327,7 @@ export class PolicyEngine {
       this.auditHookFailureCount += 1;
       console.warn(
         `[steward] policy audit hook failed (${this.auditHookFailureCount} since engine start); policy.evaluated events are being dropped`,
-        err,
+        redactedThrownDiagnostics(err),
       );
     }
   }

--- a/packages/proxy/src/__tests__/proxy-approval-lifecycle.test.ts
+++ b/packages/proxy/src/__tests__/proxy-approval-lifecycle.test.ts
@@ -28,6 +28,7 @@ let handlePendingProxyRequest: typeof import("../handlers/release")["handlePendi
 let holdProxyApprovalRequest: typeof import("../handlers/approvals")["holdProxyApprovalRequest"];
 let setReleaseClaimBarrier: typeof import("../handlers/release")["__setReleaseClaimBarrierForTests"];
 let resetReleaseClaimBarrier: typeof import("../handlers/release")["__resetReleaseClaimBarrierForTests"];
+let setPendingProxyExecution: typeof import("../handlers/release")["__setPendingProxyExecutionForTests"];
 let setForwardProxyRequest: typeof import("../handlers/proxy")["__setForwardProxyRequestForTests"];
 let proxyMod: typeof import("../handlers/proxy");
 
@@ -69,6 +70,7 @@ beforeAll(async () => {
     handlePendingProxyRequest,
     __setReleaseClaimBarrierForTests: setReleaseClaimBarrier,
     __resetReleaseClaimBarrierForTests: resetReleaseClaimBarrier,
+    __setPendingProxyExecutionForTests: setPendingProxyExecution,
   } = await import("../handlers/release"));
   ({ holdProxyApprovalRequest } = await import("../handlers/approvals"));
   proxyMod = await import("../handlers/proxy");
@@ -87,6 +89,7 @@ beforeAll(async () => {
 afterEach(() => {
   // Never let a barrier stub leak between tests.
   resetReleaseClaimBarrier();
+  setPendingProxyExecution(null);
   executions = 0;
 });
 
@@ -104,6 +107,17 @@ afterAll(async () => {
 function buildApp() {
   const app = new Hono();
   app.use("*", authMiddleware);
+  app.get("/approvals/proxy/:id", handlePendingProxyRequest);
+  return app;
+}
+
+function buildReleaseHandlerApp(tenantId: string, agentId: string) {
+  const app = new Hono();
+  app.use("*", async (c, next) => {
+    c.set("tenantId" as never, tenantId as never);
+    c.set("agentId" as never, agentId as never);
+    await next();
+  });
   app.get("/approvals/proxy/:id", handlePendingProxyRequest);
   return app;
 }
@@ -410,6 +424,35 @@ describe("proxy approval lifecycle enforcement (PGLite)", () => {
         ),
       );
     expect(executedAudits.length).toBe(1);
+  });
+
+  it("does not persist or return an upstream execution exception", async () => {
+    const tenantId = `t-release-error-${crypto.randomUUID()}`;
+    const agentId = `a-${crypto.randomUUID()}`;
+    const canary = "Bearer release-exception-secret";
+    await ensureTenant(tenantId);
+    await ensureAgent(tenantId, agentId);
+    const held = await holdRequest(tenantId, agentId);
+    await getDb()
+      .update(pendingProxyRequests)
+      .set({ status: "approved", approvedAt: new Date(), approvedBy: "operator" })
+      .where(eq(pendingProxyRequests.id, held.id));
+    setPendingProxyExecution(async () => {
+      throw new Error(canary);
+    });
+
+    const response = await poll(buildReleaseHandlerApp(tenantId, agentId), held.id, "unused");
+    expect(response.status).toBe(502);
+    const body = (await response.json()) as { error: string; data: { executionError?: string } };
+    expect(body.error).toBe("Approved proxy execution failed");
+    expect(JSON.stringify(body)).not.toContain(canary);
+
+    const [row] = await getDb()
+      .select()
+      .from(pendingProxyRequests)
+      .where(eq(pendingProxyRequests.id, held.id));
+    expect(row.executionError).toBe("Approved proxy execution failed");
+    expect(JSON.stringify(row)).not.toContain(canary);
   });
 
   it("never stores credentials in the pending row or audit log", async () => {

--- a/packages/proxy/src/handlers/release.ts
+++ b/packages/proxy/src/handlers/release.ts
@@ -8,6 +8,7 @@ import {
   sql,
   withTenantAuditedTransaction,
 } from "@stwd/db";
+import { redactedThrownDiagnostics } from "@stwd/shared";
 import type { Context } from "hono";
 import { recordRequiredAudit } from "../middleware/audit";
 import { canonicalProxyApprovalDigest, decryptPendingProxyBody } from "./approvals";
@@ -127,6 +128,14 @@ export async function executePendingProxyRequest(row: PendingProxyRequest): Prom
       }),
   } as unknown as Context;
   return handleProxy(context);
+}
+
+type PendingProxyExecution = typeof executePendingProxyRequest;
+let pendingProxyExecution: PendingProxyExecution = executePendingProxyRequest;
+
+/** Replaces the release executor for deterministic boundary tests. */
+export function __setPendingProxyExecutionForTests(execute: PendingProxyExecution | null): void {
+  pendingProxyExecution = execute ?? executePendingProxyRequest;
 }
 
 function publicPending(row: PendingProxyRequest) {
@@ -301,7 +310,7 @@ export async function handlePendingProxyRequest(c: Context): Promise<Response> {
   }
 
   try {
-    const response = await executePendingProxyRequest(claimed);
+    const response = await pendingProxyExecution(claimed);
     // The poll that wins the single-use claim is the only caller able to receive
     // the upstream result. Bound it so a hostile upstream cannot exhaust memory.
     const declaredLength = Number(response.headers.get("content-length") ?? "0");
@@ -378,7 +387,11 @@ export async function handlePendingProxyRequest(c: Context): Promise<Response> {
       },
     });
   } catch (error) {
-    const message = error instanceof Error ? error.message : "Approved proxy execution failed";
+    const message = "Approved proxy execution failed";
+    console.error(
+      `[proxy-approval] execution failed request=${row.id} tenant=${tenantId}`,
+      redactedThrownDiagnostics(error),
+    );
     const [failed] = await db
       .update(pendingProxyRequests)
       .set({ status: "failed", executionError: message, updatedAt: new Date() })

--- a/packages/shared/src/__tests__/price-oracle.test.ts
+++ b/packages/shared/src/__tests__/price-oracle.test.ts
@@ -186,4 +186,26 @@ describe("price oracle", () => {
       oracle.weiToUsd("1000000", 8453, "0x2222222222222222222222222222222222222222"),
     ).resolves.toBeNull();
   });
+
+  it("does not log exception text from a failed price transport", async () => {
+    const canary = "api_key=price-oracle-secret";
+    const warnings: unknown[][] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => warnings.push(args);
+    globalThis.fetch = (async () => {
+      throw new Error(canary);
+    }) as typeof fetch;
+
+    try {
+      await expect(
+        createPriceOracle({ cacheTtlMs: 0 }).getNativeUsdPrice(8453),
+      ).resolves.toBeNull();
+      expect(JSON.stringify(warnings)).not.toContain(canary);
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]?.[0]).toContain("Failed to fetch price");
+      expect(warnings[0]?.[1]).toEqual({ errorClass: "Error", errorCode: null });
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
 });

--- a/packages/shared/src/price-oracle.ts
+++ b/packages/shared/src/price-oracle.ts
@@ -6,6 +6,7 @@
  * - Graceful degradation: returns null on failure so callers can fall back to wei comparison
  */
 
+import { redactedThrownDiagnostics } from "./safe-error.js";
 import {
   getNativeDecimalsStrict,
   getTokenDecimalsStrict,
@@ -251,7 +252,10 @@ export function createPriceOracle(options?: { cacheTtlMs?: number }): PriceOracl
 
       return parsePositiveDecimal(sorted[0].priceUsd);
     } catch (err) {
-      console.warn(`[price-oracle] Failed to fetch price for ${tokenAddress}:`, err);
+      console.warn(
+        `[price-oracle] Failed to fetch price for ${tokenAddress}`,
+        redactedThrownDiagnostics(err),
+      );
       return null;
     }
   }

--- a/packages/webhooks/src/__tests__/dispatcher-retry-classification.test.ts
+++ b/packages/webhooks/src/__tests__/dispatcher-retry-classification.test.ts
@@ -29,7 +29,7 @@ describe("WebhookDispatcher retry classification (SEC-179)", () => {
     });
     expect(ssrf.success).toBe(false);
     expect(ssrf.attempts).toBe(1);
-    expect(ssrf.error).toContain("must resolve to a public address");
+    expect(ssrf.error).toBe("Webhook validation failed");
 
     // https-scheme rejection (no insecure-http escape hatch): permanent as well.
     const httpsOnly = new WebhookDispatcher({
@@ -45,7 +45,7 @@ describe("WebhookDispatcher retry classification (SEC-179)", () => {
     });
     expect(plainHttp.success).toBe(false);
     expect(plainHttp.attempts).toBe(1);
-    expect(plainHttp.error).toContain("must use https");
+    expect(plainHttp.error).toBe("Webhook validation failed");
 
     const badScheme = await dispatcher.dispatch(makeEvent(), {
       url: "ftp://example.com/hook",
@@ -79,5 +79,24 @@ describe("WebhookDispatcher retry classification (SEC-179)", () => {
     });
     expect(result.success).toBe(false);
     expect(result.attempts).toBe(3);
+  });
+
+  it("does not return transport exception text", async () => {
+    const canary = "https://user:webhook-secret@internal.example/";
+    const dispatcher = new WebhookDispatcher({
+      maxRetries: 0,
+      timeoutMs: 500,
+      allowPrivateNetwork: false,
+      allowInsecureHttp: true,
+      lookup: (_hostname, _options, callback) =>
+        callback(new Error(canary), "" as never, 0 as never),
+    });
+
+    const result = await dispatcher.dispatch(makeEvent(), {
+      url: "http://example.test/hook",
+      secret: SECRET,
+    });
+    expect(result.error).toBe("Webhook delivery failed");
+    expect(JSON.stringify(result)).not.toContain(canary);
   });
 });

--- a/packages/webhooks/src/__tests__/dispatcher-ssrf-literal.test.ts
+++ b/packages/webhooks/src/__tests__/dispatcher-ssrf-literal.test.ts
@@ -64,7 +64,7 @@ describe("WebhookDispatcher SSRF guard for IP-literal URLs", () => {
       ]) {
         const result = await dispatcher.dispatch(makeEvent(), { url, secret: SECRET });
         expect(result.success).toBe(false);
-        expect(result.error).toContain("must resolve to a public address");
+        expect(result.error).toBe("Webhook validation failed");
       }
       expect(server.hits()).toBe(0);
     } finally {
@@ -90,7 +90,7 @@ describe("WebhookDispatcher SSRF guard for IP-literal URLs", () => {
     ]) {
       const result = await dispatcher.dispatch(makeEvent(), { url, secret: SECRET });
       expect(result.success).toBe(false);
-      expect(result.error).toContain("must resolve to a public address");
+      expect(result.error).toBe("Webhook validation failed");
     }
   });
 
@@ -115,7 +115,7 @@ describe("WebhookDispatcher SSRF guard for IP-literal URLs", () => {
     ]) {
       const result = await dispatcher.dispatch(makeEvent(), { url, secret: SECRET });
       expect(result.success).toBe(false);
-      expect(result.error).toContain("must resolve to a public address");
+      expect(result.error).toBe("Webhook validation failed");
     }
   });
 
@@ -131,7 +131,7 @@ describe("WebhookDispatcher SSRF guard for IP-literal URLs", () => {
     for (const url of ["http://[100:1::]/hook", "http://[2001:2:1::]/hook"]) {
       const result = await dispatcher.dispatch(makeEvent(), { url, secret: SECRET });
       expect(result.success).toBe(false);
-      expect(result.error).toContain("must resolve to a public address");
+      expect(result.error).toBe("Webhook validation failed");
     }
 
     const publicResult = await dispatcher.dispatch(makeEvent(), {
@@ -161,7 +161,7 @@ describe("WebhookDispatcher SSRF guard for IP-literal URLs", () => {
     ]) {
       const result = await dispatcher.dispatch(makeEvent(), { url, secret: SECRET });
       expect(result.success).toBe(false);
-      expect(result.error).toContain("must resolve to a public address");
+      expect(result.error).toBe("Webhook validation failed");
     }
   });
 

--- a/packages/webhooks/src/__tests__/queue.test.ts
+++ b/packages/webhooks/src/__tests__/queue.test.ts
@@ -189,7 +189,7 @@ describe("RetryQueue", () => {
       const result = await dispatcher.dispatch(makeEvent(), server.webhook);
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe("Webhook URL must use https");
+      expect(result.error).toBe("Webhook validation failed");
       expect(server.requests).toHaveLength(0);
     } finally {
       await server.close();
@@ -399,7 +399,7 @@ describe("RetryQueue", () => {
       });
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe("Webhook host must resolve to a public address");
+      expect(result.error).toBe("Webhook validation failed");
       expect(server.requests).toHaveLength(0);
     } finally {
       await server.close();
@@ -426,7 +426,7 @@ describe("RetryQueue", () => {
         secret: "dns-answer-test-secret",
       });
       expect(result.success).toBe(false);
-      expect(result.error).toBe("Webhook host must resolve to a public address");
+      expect(result.error).toBe("Webhook validation failed");
     }
   });
 
@@ -457,7 +457,7 @@ describe("RetryQueue", () => {
         });
 
         expect(result.success).toBe(false);
-        expect(result.error).toBe("Webhook host must resolve to a public address");
+        expect(result.error).toBe("Webhook validation failed");
         expect(server.requests).toHaveLength(0);
       } finally {
         await server.close();
@@ -484,7 +484,7 @@ describe("RetryQueue", () => {
       });
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe("Webhook host must resolve to a public address");
+      expect(result.error).toBe("Webhook validation failed");
       expect(server.requests).toHaveLength(0);
     } finally {
       await server.close();
@@ -511,7 +511,7 @@ describe("RetryQueue", () => {
         });
 
         expect(result.success).toBe(false);
-        expect(result.error).toBe("Webhook host must resolve to a public address");
+        expect(result.error).toBe("Webhook validation failed");
         expect(server.requests).toHaveLength(0);
       } finally {
         await server.close();
@@ -539,7 +539,7 @@ describe("RetryQueue", () => {
         });
 
         expect(result.success).toBe(false);
-        expect(result.error).toBe("Webhook host must resolve to a public address");
+        expect(result.error).toBe("Webhook validation failed");
         expect(server.requests).toHaveLength(0);
       } finally {
         await server.close();
@@ -567,7 +567,7 @@ describe("RetryQueue", () => {
         });
 
         expect(result.success).toBe(false);
-        expect(result.error).toBe("Webhook host must resolve to a public address");
+        expect(result.error).toBe("Webhook validation failed");
         expect(server.requests).toHaveLength(0);
       } finally {
         await server.close();
@@ -595,7 +595,7 @@ describe("RetryQueue", () => {
         });
 
         expect(result.success).toBe(false);
-        expect(result.error).toBe("Webhook host must resolve to a public address");
+        expect(result.error).toBe("Webhook validation failed");
         expect(server.requests).toHaveLength(0);
       } finally {
         await server.close();
@@ -638,7 +638,7 @@ describe("RetryQueue", () => {
       });
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe("Webhook delivery timed out");
+      expect(result.error).toBe("Webhook delivery failed");
       expect(Date.now() - startedAt).toBeLessThan(500);
     } finally {
       await new Promise<void>((resolve, reject) => {

--- a/packages/webhooks/src/dispatcher.ts
+++ b/packages/webhooks/src/dispatcher.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import type { LookupAddress } from "node:dns";
 import type { RequestOptions } from "node:http";
 import { isIP, type LookupFunction } from "node:net";
-import type { WebhookEvent } from "@stwd/shared";
+import { redactedThrownDiagnostics, type WebhookEvent } from "@stwd/shared";
 
 import type { WebhookConfig, WebhookDeliveryResult, WebhookDispatcherOptions } from "./types";
 
@@ -529,7 +529,11 @@ export class WebhookDispatcher {
           break;
         }
       } catch (error) {
-        lastError = error instanceof Error ? error.message : "Unknown webhook delivery error";
+        lastError =
+          error instanceof WebhookValidationError
+            ? "Webhook validation failed"
+            : "Webhook delivery failed";
+        console.warn("[webhooks] delivery attempt failed", redactedThrownDiagnostics(error));
         // SEC-179: a deterministic validation rejection (bad scheme, non-public
         // host/address, unparseable URL) can never succeed on retry — stop
         // immediately instead of burning maxRetries+1 attempts with backoff and

--- a/scripts/__tests__/runtime-error-log-safety.test.ts
+++ b/scripts/__tests__/runtime-error-log-safety.test.ts
@@ -64,6 +64,13 @@ function unsafeTelemetryArguments(source: ts.SourceFile): string[] {
   };
   const inspectCatch = (clause: ts.CatchClause, caughtName: string): void => {
     const tainted = new Set([caughtName]);
+    const taintMutationTarget = (candidate: ts.Expression): void => {
+      let target: ts.Expression = candidate;
+      while (ts.isPropertyAccessExpression(target) || ts.isElementAccessExpression(target)) {
+        target = target.expression;
+      }
+      if (ts.isIdentifier(target)) tainted.add(target.text);
+    };
     const isTainted = (candidate: ts.Node): boolean => {
       if (
         ts.isPropertyAccessExpression(candidate) &&
@@ -120,9 +127,31 @@ function unsafeTelemetryArguments(source: ts.SourceFile): string[] {
       ) {
         if (ts.isIdentifier(node.left)) {
           tainted.add(node.left.text);
+        } else if (
+          ts.isPropertyAccessExpression(node.left) ||
+          ts.isElementAccessExpression(node.left)
+        ) {
+          taintMutationTarget(node.left);
         }
       }
       if (ts.isCallExpression(node)) {
+        if (
+          ts.isPropertyAccessExpression(node.expression) &&
+          ["push", "unshift", "splice", "set"].includes(node.expression.name.text) &&
+          node.arguments.some(isTainted)
+        ) {
+          taintMutationTarget(node.expression.expression);
+        }
+        if (
+          ts.isPropertyAccessExpression(node.expression) &&
+          ts.isIdentifier(node.expression.expression) &&
+          node.expression.expression.text === "Object" &&
+          node.expression.name.text === "assign" &&
+          node.arguments.length > 1 &&
+          node.arguments.slice(1).some(isTainted)
+        ) {
+          taintMutationTarget(node.arguments[0]);
+        }
         const isConsoleSink =
           ts.isPropertyAccessExpression(node.expression) &&
           ts.isIdentifier(node.expression.expression) &&
@@ -239,6 +268,24 @@ describe("runtime error logging", () => {
         }
       `),
     ).toHaveLength(1);
+  });
+
+  test("tracks caught values written into mutable telemetry payloads", () => {
+    expect(
+      failuresForSnippet(`
+        try {
+          doThing();
+        } catch (err) {
+          const payload = { detail: "safe" };
+          payload.detail = err.message;
+          console.error(payload);
+
+          const values = [];
+          values.push(err.stack);
+          writeAuditEvent({ values });
+        }
+      `),
+    ).toHaveLength(2);
   });
 
   test("allows aliases of bounded diagnostics", () => {

--- a/scripts/__tests__/runtime-error-log-safety.test.ts
+++ b/scripts/__tests__/runtime-error-log-safety.test.ts
@@ -4,23 +4,22 @@ import { join, relative } from "node:path";
 import ts from "typescript";
 
 const ROOT = join(import.meta.dir, "../..");
-const RUNTIME_ROOTS = [
-  "packages/api/src",
-  "packages/proxy/src",
-  "packages/auth/src",
-  "packages/plugin-trading/src",
-  "packages/redis/src",
-  "packages/agent-trader/src",
-];
+const RUNTIME_ROOTS = ["packages", "web/src"];
 
 async function runtimeSources(directory: string): Promise<string[]> {
   const paths: string[] = [];
   for (const entry of await readdir(directory, { withFileTypes: true })) {
     const path = join(directory, entry.name);
     if (entry.isDirectory()) {
-      if (entry.name === "__tests__" || entry.name === "dist") continue;
+      if (entry.name === "__tests__" || entry.name === "dist" || entry.name === "node_modules")
+        continue;
       paths.push(...(await runtimeSources(path)));
-    } else if (entry.isFile() && entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
+    } else if (
+      entry.isFile() &&
+      /\.tsx?$/.test(entry.name) &&
+      !/\.(?:test|spec)\.tsx?$/.test(entry.name) &&
+      !entry.name.endsWith(".d.ts")
+    ) {
       paths.push(path);
     }
   }
@@ -44,6 +43,7 @@ function isTelemetrySinkName(name: string): boolean {
       "recordAudit",
       "recordRequiredAudit",
       "appendRequiredAudit",
+      "recordReservationFailure",
     ].includes(name) ||
     name.endsWith("Audit") ||
     /^audit[A-Z]/.test(name)
@@ -52,65 +52,97 @@ function isTelemetrySinkName(name: string): boolean {
 
 function unsafeTelemetryArguments(source: ts.SourceFile): string[] {
   const failures: string[] = [];
-  const caughtThrowables = new Set<string>();
+  const report = (node: ts.Node): void => {
+    const line = source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1;
+    failures.push(`${source.fileName}:${line}: ${node.getText(source).slice(0, 160)}`);
+  };
+  const bindingNames = (name: ts.BindingName): string[] => {
+    if (ts.isIdentifier(name)) return [name.text];
+    return name.elements.flatMap((element) =>
+      ts.isOmittedExpression(element) ? [] : bindingNames(element.name),
+    );
+  };
+  const inspectCatch = (clause: ts.CatchClause, caughtName: string): void => {
+    const tainted = new Set([caughtName]);
+    const isTainted = (candidate: ts.Node): boolean => {
+      if (
+        ts.isPropertyAccessExpression(candidate) &&
+        ["field", "transactionHash"].includes(candidate.name.text)
+      ) {
+        // These typed domain-error fields are intentionally bounded identifiers,
+        // not provider-controlled exception text.
+        return false;
+      }
+      if (ts.isCallExpression(candidate)) {
+        const name = sinkName(candidate.expression);
+        if (
+          [
+            "extractRpcErrorMessage",
+            "isDefiniteVenueRejection",
+            "isRpcError",
+            "redactedThrownDiagnostics",
+            "sanitizeErrorMessage",
+          ].includes(name) ||
+          (ts.isPropertyAccessExpression(candidate.expression) &&
+            ["endsWith", "includes", "startsWith"].includes(candidate.expression.name.text))
+        ) {
+          return false;
+        }
+      }
+      if (ts.isConditionalExpression(candidate)) {
+        return isTainted(candidate.whenTrue) || isTainted(candidate.whenFalse);
+      }
+      if (ts.isIdentifier(candidate) && tainted.has(candidate.text)) {
+        const parent = candidate.parent;
+        if (
+          (ts.isPropertyAssignment(parent) && parent.name === candidate) ||
+          (ts.isPropertyAccessExpression(parent) && parent.name === candidate) ||
+          (ts.isMethodDeclaration(parent) && parent.name === candidate)
+        ) {
+          return false;
+        }
+        return true;
+      }
+      return candidate.getChildren(source).some(isTainted);
+    };
+    const visitCatchNode = (node: ts.Node): void => {
+      if (node !== clause.block && ts.isCatchClause(node)) return;
+      if (ts.isVariableDeclaration(node)) {
+        const names = bindingNames(node.name);
+        if (node.initializer && isTainted(node.initializer)) {
+          for (const name of names) tainted.add(name);
+        }
+      }
+      if (
+        ts.isBinaryExpression(node) &&
+        node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+        isTainted(node.right)
+      ) {
+        if (ts.isIdentifier(node.left)) {
+          tainted.add(node.left.text);
+        }
+      }
+      if (ts.isCallExpression(node)) {
+        const isConsoleSink =
+          ts.isPropertyAccessExpression(node.expression) &&
+          ts.isIdentifier(node.expression.expression) &&
+          node.expression.expression.text === "console" &&
+          ["error", "warn", "log"].includes(node.expression.name.text);
+        const name = sinkName(node.expression);
+        if (isConsoleSink || isTelemetrySinkName(name)) {
+          for (const argument of node.arguments) {
+            if (isTainted(argument)) report(argument);
+          }
+        }
+      }
+      ts.forEachChild(node, visitCatchNode);
+    };
+    visitCatchNode(clause.block);
+  };
   const visit = (node: ts.Node): void => {
     if (ts.isCatchClause(node)) {
       const variable = node.variableDeclaration?.name;
-      if (variable && ts.isIdentifier(variable)) {
-        caughtThrowables.add(variable.text);
-        ts.forEachChild(node.block, visit);
-        caughtThrowables.delete(variable.text);
-        return;
-      }
-    }
-    if (ts.isCallExpression(node)) {
-      const isConsoleSink =
-        ts.isPropertyAccessExpression(node.expression) &&
-        ts.isIdentifier(node.expression.expression) &&
-        node.expression.expression.text === "console" &&
-        ["error", "warn", "log"].includes(node.expression.name.text);
-      const name = sinkName(node.expression);
-      const isTelemetrySink = isTelemetrySinkName(name);
-      if (!isConsoleSink && !isTelemetrySink) {
-        ts.forEachChild(node, visit);
-        return;
-      }
-      for (const argument of node.arguments) {
-        const text = argument.getText(source);
-        const referencesCaughtThrowable = (candidate: ts.Node): boolean => {
-          if (
-            ts.isCallExpression(candidate) &&
-            ts.isIdentifier(candidate.expression) &&
-            candidate.expression.text === "redactedThrownDiagnostics"
-          ) {
-            return false;
-          }
-          if (ts.isIdentifier(candidate) && caughtThrowables.has(candidate.text)) {
-            const parent = candidate.parent;
-            // Property names such as `{ error: "fixed" }` and `value.error`
-            // are labels, not references to a catch binding with the same name.
-            if (
-              (ts.isPropertyAssignment(parent) && parent.name === candidate) ||
-              (ts.isPropertyAccessExpression(parent) && parent.name === candidate) ||
-              (ts.isMethodDeclaration(parent) && parent.name === candidate)
-            ) {
-              return false;
-            }
-            return true;
-          }
-          return candidate.getChildren(source).some(referencesCaughtThrowable);
-        };
-        if (
-          referencesCaughtThrowable(argument) ||
-          /^(?:err|error|e|reason|releaseError)$/i.test(text) ||
-          /(?:err|error|reason|releaseError)\s*\.\s*(?:message|stack)\b/i.test(text) ||
-          /String\(\s*(?:err|error|e|reason|releaseError)\s*\)/i.test(text) ||
-          /\$\{\s*(?:err|error|e|reason|releaseError)\s*\}/i.test(text)
-        ) {
-          const line = source.getLineAndCharacterOfPosition(argument.getStart(source)).line + 1;
-          failures.push(`${source.fileName}:${line}: ${text.slice(0, 160)}`);
-        }
-      }
+      if (variable && ts.isIdentifier(variable)) inspectCatch(node, variable.text);
     }
     ts.forEachChild(node, visit);
   };
@@ -195,7 +227,34 @@ describe("runtime error logging", () => {
     ).toHaveLength(2);
   });
 
-  test("never passes raw throwables, messages, or stacks to console sinks", async () => {
+  test("tracks aliases passed to telemetry sinks", () => {
+    expect(
+      failuresForSnippet(`
+        try {
+          doThing();
+        } catch (err) {
+          const detail = err.message;
+          const payload = { detail };
+          console.error(payload);
+        }
+      `),
+    ).toHaveLength(1);
+  });
+
+  test("allows aliases of bounded diagnostics", () => {
+    expect(
+      failuresForSnippet(`
+        try {
+          doThing();
+        } catch (err) {
+          const diagnostics = redactedThrownDiagnostics(err);
+          console.error("failed", diagnostics);
+        }
+      `),
+    ).toEqual([]);
+  });
+
+  test("never passes raw throwables, messages, or stacks to runtime telemetry", async () => {
     const failures: string[] = [];
     for (const root of RUNTIME_ROOTS) {
       for (const path of await runtimeSources(join(ROOT, root))) {


### PR DESCRIPTION
## Summary

- redact aliased exception data before persistence, logs, audit metadata, webhooks, and public responses
- cover provider reservations, proxy releases, retention, webhooks, price oracle, policy/trading, vault/intents, and Eliza runtime paths
- expand the runtime guard across package and web sources with alias-taint handling
- add hostile behavioral regressions for persisted and public failure boundaries

## Exact-head evidence

Head: `f4101e2b50342e22ab61f375e5cbfd4d5b07970e`
Base: `63e0b8ddd705e43e0415651d2880034a8d38ba83`

- focused redaction/price/webhook/retention suites: 48/48 tests, 241 assertions
- proxy persisted/public failure boundary: 6/6 tests, 48 assertions
- affected dependency build: 25/25 tasks
- Biome on all 19 changed files and diff-check: green