### PR TITLE
fix(provider-x): complete disconnect recovery

### DIFF
--- a/packages/api/src/__tests__/provider-x-connect.test.ts
+++ b/packages/api/src/__tests__/provider-x-connect.test.ts
@@ -24,6 +24,7 @@ import {
   providerAccounts,
   providerRoleBindings,
   providerXCredentialLifecycles,
+  secretRoutes,
   secrets,
   tenants,
   users,
@@ -307,10 +308,11 @@ afterEach(async () => {
   __setAfterXRevocationClaimForTests(null);
   // Reset connected accounts + credential secrets between tests.
   const db = getDb();
-  await db.delete(providerAccounts).where(eq(providerAccounts.tenantId, TENANT));
   await db
     .delete(providerXCredentialLifecycles)
     .where(eq(providerXCredentialLifecycles.tenantId, TENANT));
+  await db.delete(providerAccounts).where(eq(providerAccounts.tenantId, TENANT));
+  await db.delete(secretRoutes).where(eq(secretRoutes.tenantId, TENANT));
   await db.delete(secrets).where(eq(secrets.tenantId, TENANT));
 });
 
@@ -1545,7 +1547,7 @@ describe("refresh", () => {
     expect(superseded.state).toBe("superseded");
     expect(superseded.credentialSecretId).toBeNull();
     const events = await readAuditActions(TENANT);
-    expect(events).toContain("provider.x.refresh.superseded_by_reconnect");
+    expect(events).toContain("provider.x.lifecycle.superseded_by_reconnect");
   });
 
   test("revokes a rotated grant held in memory when encrypted staging fails", async () => {
@@ -1992,10 +1994,256 @@ describe("disconnect", () => {
       .from(providerAccounts)
       .where(eq(providerAccounts.id, completed.providerAccountId));
     expect(acct.status).toBe("revoked");
+    expect(acct.credentialSecretId).toBeNull();
+    expect(acct.credentialVersion).toBeNull();
     fake.restore();
 
     const events = await readAuditActions(TENANT);
     expect(events.includes("provider.x.disconnect.completed")).toBe(true);
+  });
+
+  test("removes local credential authority and restores only unchanged routes on reconnect", async () => {
+    const { completed } = await connectHappy(new MemoryConnectStore());
+    const db = getDb();
+    const [before] = await db
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, completed.providerAccountId));
+    const restoredRouteId = "50000000-0000-4000-8000-0000000000d1";
+    const operatorDisabledRouteId = "50000000-0000-4000-8000-0000000000d2";
+    const adminMutatedRouteId = "50000000-0000-4000-8000-0000000000d3";
+    await db.insert(secretRoutes).values([
+      {
+        id: restoredRouteId,
+        tenantId: TENANT,
+        secretId: before.credentialSecretId as string,
+        hostPattern: "api.x.com",
+        pathPattern: "/2/tweets",
+        method: "POST",
+        injectAs: "header",
+        injectKey: "Authorization",
+        injectFormat: "Bearer {value}",
+      },
+      {
+        id: operatorDisabledRouteId,
+        tenantId: TENANT,
+        secretId: before.credentialSecretId as string,
+        hostPattern: "api.x.com",
+        pathPattern: "/2/users/me",
+        method: "GET",
+        injectAs: "header",
+        injectKey: "Authorization",
+        injectFormat: "Bearer {value}",
+        enabled: false,
+      },
+      {
+        id: adminMutatedRouteId,
+        tenantId: TENANT,
+        secretId: before.credentialSecretId as string,
+        hostPattern: "api.x.com",
+        pathPattern: "/2/users/by",
+        method: "GET",
+        injectAs: "header",
+        injectKey: "Authorization",
+        injectFormat: "Bearer {value}",
+      },
+    ]);
+
+    const fake = installFakeX();
+    await expect(
+      disconnectXProviderCredential({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        accountId: completed.providerAccountId,
+        callerUserId: ADMIN,
+        vault,
+        config: CONFIG,
+      }),
+    ).resolves.toMatchObject({ revoked: true });
+    fake.restore();
+
+    const [disconnected] = await db
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, completed.providerAccountId));
+    expect(disconnected).toMatchObject({
+      status: "revoked",
+      credentialSecretId: null,
+      credentialVersion: null,
+    });
+    const [disabledRoute] = await db
+      .select()
+      .from(secretRoutes)
+      .where(eq(secretRoutes.id, restoredRouteId));
+    expect(disabledRoute).toMatchObject({ enabled: false, authorityRevision: 2 });
+    const [oldSecret] = await db
+      .select()
+      .from(secrets)
+      .where(eq(secrets.id, before.credentialSecretId as string));
+    expect(oldSecret.deletedAt).not.toBeNull();
+    await db
+      .update(secretRoutes)
+      .set({ pathPattern: "/2/users/by/changed" })
+      .where(eq(secretRoutes.id, adminMutatedRouteId));
+
+    const reconnect = await connectHappy(new MemoryConnectStore());
+    expect(reconnect.completed).toMatchObject({
+      providerAccountId: completed.providerAccountId,
+      reconnected: true,
+    });
+    const [reconnected] = await db
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, completed.providerAccountId));
+    const [restoredRoute] = await db
+      .select()
+      .from(secretRoutes)
+      .where(eq(secretRoutes.id, restoredRouteId));
+    expect(restoredRoute).toMatchObject({
+      enabled: true,
+      secretId: reconnected.credentialSecretId,
+      authorityRevision: 4,
+    });
+    const [stillOperatorDisabled] = await db
+      .select()
+      .from(secretRoutes)
+      .where(eq(secretRoutes.id, operatorDisabledRouteId));
+    expect(stillOperatorDisabled).toMatchObject({
+      enabled: false,
+      secretId: reconnected.credentialSecretId,
+      authorityRevision: 2,
+    });
+    const [stillAdminDisabled] = await db
+      .select()
+      .from(secretRoutes)
+      .where(eq(secretRoutes.id, adminMutatedRouteId));
+    expect(stillAdminDisabled).toMatchObject({
+      enabled: false,
+      pathPattern: "/2/users/by/changed",
+      secretId: reconnected.credentialSecretId,
+      authorityRevision: 4,
+    });
+  });
+
+  test("malformed credentials cannot block local revocation or later reconnect", async () => {
+    const { completed } = await connectHappy(new MemoryConnectStore());
+    const malformed = await vault.rotateSecret(
+      TENANT,
+      xCredentialSecretName(WORKSPACE, "1234567890"),
+      "{",
+    );
+    await getDb()
+      .update(providerAccounts)
+      .set({ credentialSecretId: malformed.id, credentialVersion: malformed.version })
+      .where(eq(providerAccounts.id, completed.providerAccountId));
+    const malformedFake = installFakeX();
+    await expect(
+      disconnectXProviderCredential({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        accountId: completed.providerAccountId,
+        callerUserId: ADMIN,
+        vault,
+        config: CONFIG,
+      }),
+    ).resolves.toMatchObject({ revoked: false });
+    expect(malformedFake.counters.revoke).toBe(0);
+    malformedFake.restore();
+    const [locallyRevoked] = await getDb()
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, completed.providerAccountId));
+    expect(locallyRevoked).toMatchObject({
+      status: "revoked",
+      credentialSecretId: null,
+      credentialVersion: null,
+    });
+    const [unrecoverable] = await getDb()
+      .select()
+      .from(providerXCredentialLifecycles)
+      .where(eq(providerXCredentialLifecycles.kind, "disconnect_revoke"));
+    expect(unrecoverable).toMatchObject({
+      state: "needs_attention",
+      credentialSecretId: null,
+      lastErrorCode: "DISCONNECT_REVOCATION_HANDLE_UNAVAILABLE",
+    });
+    const reconnect = await connectHappy(new MemoryConnectStore());
+    expect(reconnect.completed).toMatchObject({
+      providerAccountId: completed.providerAccountId,
+      reconnected: true,
+    });
+    const [superseded] = await getDb()
+      .select()
+      .from(providerXCredentialLifecycles)
+      .where(eq(providerXCredentialLifecycles.id, unrecoverable.id));
+    expect(superseded).toMatchObject({
+      state: "superseded",
+      lastErrorCode: "SUPERSEDED_BY_RECONNECT",
+    });
+  });
+
+  test("disconnect revokes exact bounded handles even when identity binding is invalid", async () => {
+    const { completed } = await connectHappy(new MemoryConnectStore());
+    const current = await decryptCredential(completed.providerAccountId);
+    const misbound = await vault.rotateSecret(
+      TENANT,
+      xCredentialSecretName(WORKSPACE, "1234567890"),
+      JSON.stringify({
+        ...current,
+        accessToken: "misbound-access-handle",
+        refreshToken: "misbound-refresh-handle",
+        xUserId: "999999999",
+      }),
+    );
+    await getDb()
+      .update(providerAccounts)
+      .set({ credentialSecretId: misbound.id, credentialVersion: misbound.version })
+      .where(eq(providerAccounts.id, completed.providerAccountId));
+    const fake = installFakeX();
+    await expect(
+      disconnectXProviderCredential({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        accountId: completed.providerAccountId,
+        callerUserId: ADMIN,
+        vault,
+        config: CONFIG,
+      }),
+    ).resolves.toMatchObject({ revoked: true });
+    expect(new URLSearchParams(fake.counters.revokeBodies[0]).get("token")).toBe(
+      "misbound-refresh-handle",
+    );
+    fake.restore();
+  });
+
+  test("a missing credential link cannot prevent local revocation", async () => {
+    const { completed } = await connectHappy(new MemoryConnectStore());
+    await getDb()
+      .update(providerAccounts)
+      .set({ credentialSecretId: null, credentialVersion: null })
+      .where(eq(providerAccounts.id, completed.providerAccountId));
+    const fake = installFakeX();
+    await expect(
+      disconnectXProviderCredential({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        accountId: completed.providerAccountId,
+        callerUserId: ADMIN,
+        vault,
+        config: CONFIG,
+      }),
+    ).resolves.toMatchObject({ revoked: false });
+    expect(fake.counters.revoke).toBe(0);
+    const [account] = await getDb()
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, completed.providerAccountId));
+    expect(account).toMatchObject({
+      status: "revoked",
+      credentialSecretId: null,
+      credentialVersion: null,
+    });
+    fake.restore();
   });
 
   test("disconnect of a missing account => X_ACCOUNT_NOT_FOUND", async () => {
@@ -2036,6 +2284,8 @@ describe("disconnect", () => {
       .from(providerAccounts)
       .where(eq(providerAccounts.id, completed.providerAccountId));
     expect(account.status).toBe("revoked");
+    expect(account.credentialSecretId).toBeNull();
+    expect(account.credentialVersion).toBeNull();
     expect(fake.counters.revoke).toBe(0);
     const [pending] = await getDb()
       .select()
@@ -2092,10 +2342,9 @@ describe("disconnect", () => {
     fake.restore();
   });
 
-  test("disconnect retains its exact handle until X returns RFC 7009 status 200", async () => {
+  test("retains the disconnect handle until X confirms RFC 7009 status 200", async () => {
     const { completed } = await connectHappy(new MemoryConnectStore());
     const fake = installFakeX({ revokeStatuses: [202, 200] });
-
     const disconnected = await disconnectXProviderCredential({
       tenantId: TENANT,
       workspaceId: WORKSPACE,
@@ -2127,16 +2376,95 @@ describe("disconnect", () => {
     const swept = await runXCredentialLifecycleSweep({
       vault,
       config: CONFIG,
-      now: new Date(Date.now() + 120_000),
+      now: pending.nextRetryAt as Date,
     });
     expect(swept).toMatchObject({ processed: 1, revoked: 1, attention: 0 });
     expect(fake.counters.revoke).toBe(2);
-    const [recovered] = await getDb()
+    const [revoked] = await getDb()
       .select()
       .from(providerXCredentialLifecycles)
       .where(eq(providerXCredentialLifecycles.id, pending.id));
-    expect(recovered).toMatchObject({ state: "revoked", attempts: 2 });
-    expect(recovered.credentialSecretId).toBeNull();
+    expect(revoked).toMatchObject({ state: "revoked", attempts: 2 });
+    expect(revoked.credentialSecretId).toBeNull();
+    fake.restore();
+  });
+
+  test("preserves a staged rotated grant while disconnect revokes the stored grant separately", async () => {
+    const { completed } = await connectHappy(new MemoryConnectStore());
+    const fake = installFakeX();
+    const restoreStageCrash = __setAfterXCredentialStageForTests(async () => {
+      throw new Error("simulated crash after rotated grant staging");
+    });
+    await expect(
+      refreshXProviderCredential({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        accountId: completed.providerAccountId,
+        vault,
+        config: CONFIG,
+        force: true,
+      }),
+    ).rejects.toThrow("simulated crash after rotated grant staging");
+    restoreStageCrash();
+    const [stagedBefore] = await getDb()
+      .select()
+      .from(providerXCredentialLifecycles)
+      .where(eq(providerXCredentialLifecycles.kind, "refresh_rotation"));
+    expect(stagedBefore.state).toBe("credential_staged");
+    expect(stagedBefore.credentialSecretId).not.toBeNull();
+
+    await expect(
+      disconnectXProviderCredential({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        accountId: completed.providerAccountId,
+        callerUserId: ADMIN,
+        vault,
+        config: CONFIG,
+      }),
+    ).resolves.toMatchObject({ revoked: true });
+    const rows = await getDb()
+      .select()
+      .from(providerXCredentialLifecycles)
+      .where(eq(providerXCredentialLifecycles.providerAccountId, completed.providerAccountId));
+    const stagedAfter = rows.find((row) => row.kind === "refresh_rotation");
+    const disconnect = rows.find((row) => row.kind === "disconnect_revoke");
+    expect(stagedAfter).toMatchObject({
+      id: stagedBefore.id,
+      state: "credential_staged",
+      credentialSecretId: stagedBefore.credentialSecretId,
+    });
+    expect(disconnect).toMatchObject({ state: "revoked", credentialSecretId: null });
+    expect(fake.counters.revoke).toBe(1);
+    expect(new URLSearchParams(fake.counters.revokeBodies[0]).get("token")).toBe("refresh-initial");
+
+    await runXCredentialLifecycleSweep({
+      vault,
+      config: CONFIG,
+      now: new Date(stagedBefore.updatedAt.getTime() + 60_000),
+    });
+    const [pendingRotated] = await getDb()
+      .select()
+      .from(providerXCredentialLifecycles)
+      .where(eq(providerXCredentialLifecycles.id, stagedBefore.id));
+    expect(pendingRotated).toMatchObject({
+      state: "revocation_pending",
+      credentialSecretId: stagedBefore.credentialSecretId,
+    });
+    await runXCredentialLifecycleSweep({
+      vault,
+      config: CONFIG,
+      now: pendingRotated.nextRetryAt as Date,
+    });
+    expect(fake.counters.revoke).toBe(2);
+    expect(new URLSearchParams(fake.counters.revokeBodies[1]).get("token")).toBe(
+      "refresh-rotated-1",
+    );
+    const [rotatedRevoked] = await getDb()
+      .select()
+      .from(providerXCredentialLifecycles)
+      .where(eq(providerXCredentialLifecycles.id, stagedBefore.id));
+    expect(rotatedRevoked).toMatchObject({ state: "revoked", credentialSecretId: null });
     fake.restore();
   });
 
@@ -2184,9 +2512,26 @@ describe("disconnect", () => {
       .where(eq(providerAccounts.id, completed.providerAccountId));
     expect(account.status).toBe("revoked");
     expect(fake.counters.refresh).toBe(1);
-    // One revoke covers the old stored grant and one compensates the rotated
-    // response that could no longer be staged after disconnect took ownership.
+    expect(fake.counters.revoke).toBe(1);
+    const [rotated] = await getDb()
+      .select()
+      .from(providerXCredentialLifecycles)
+      .where(
+        and(
+          eq(providerXCredentialLifecycles.providerAccountId, completed.providerAccountId),
+          eq(providerXCredentialLifecycles.kind, "refresh_rotation"),
+        ),
+      );
+    expect(rotated).toMatchObject({ state: "revocation_pending" });
+    await runXCredentialLifecycleSweep({
+      vault,
+      config: CONFIG,
+      now: rotated.nextRetryAt as Date,
+    });
     expect(fake.counters.revoke).toBe(2);
+    expect(new URLSearchParams(fake.counters.revokeBodies[1]).get("token")).toBe(
+      "refresh-rotated-1",
+    );
     fake.restore();
   });
 });

--- a/packages/api/src/services/provider-x-connect.ts
+++ b/packages/api/src/services/provider-x-connect.ts
@@ -36,6 +36,7 @@ import { createHash, randomBytes, randomUUID } from "node:crypto";
 import {
   and,
   asc,
+  desc,
   eq,
   getDb,
   inArray,
@@ -1034,6 +1035,7 @@ async function persistConnectedAccount(input: PersistInput): Promise<CompleteCon
 
   return withTenantAuditedTransaction(input.tenantId, async (txRaw, append) => {
     const tx = txRaw as DbExecutor;
+    let routesDisabledByDisconnect: Array<{ id: string; authorityRevision: number }> = [];
 
     const [connectLifecycle] = await tx
       .select()
@@ -1070,14 +1072,16 @@ async function persistConnectedAccount(input: PersistInput): Promise<CompleteCon
       .limit(1)
       .for("update");
 
-    const unresolvedRefreshes = account
+    const unresolvedLifecycles = account
       ? await tx
           .select({
             id: providerXCredentialLifecycles.id,
+            kind: providerXCredentialLifecycles.kind,
             state: providerXCredentialLifecycles.state,
             credentialSecretId: providerXCredentialLifecycles.credentialSecretId,
             expectedAccountRevision: providerXCredentialLifecycles.expectedAccountRevision,
             lastErrorCode: providerXCredentialLifecycles.lastErrorCode,
+            disabledRoutes: providerXCredentialLifecycles.disabledRoutes,
           })
           .from(providerXCredentialLifecycles)
           .where(
@@ -1097,38 +1101,61 @@ async function persistConnectedAccount(input: PersistInput): Promise<CompleteCon
           .for("update")
       : [];
 
-    const supersedableRefreshes = account
-      ? unresolvedRefreshes.filter(
+    const supersedableLifecycles = account
+      ? unresolvedLifecycles.filter(
           (row) =>
             row.state === "needs_attention" &&
             row.credentialSecretId === null &&
-            row.lastErrorCode === "REFRESH_OUTCOME_UNKNOWN" &&
             row.expectedAccountRevision !== null &&
-            row.expectedAccountRevision <= account.revision,
+            row.expectedAccountRevision <= account.revision &&
+            ((row.kind === "refresh_rotation" && row.lastErrorCode === "REFRESH_OUTCOME_UNKNOWN") ||
+              (row.kind === "disconnect_revoke" &&
+                row.lastErrorCode === "DISCONNECT_REVOCATION_HANDLE_UNAVAILABLE")),
         )
       : [];
-    if (supersedableRefreshes.length !== unresolvedRefreshes.length) {
+    if (supersedableLifecycles.length !== unresolvedLifecycles.length) {
       throw new XConnectError(
         "X_CREDENTIAL_NEEDS_ATTENTION",
         409,
-        "previous X refresh must be reconciled before reconnect",
+        "previous X credential lifecycle must be reconciled before reconnect",
       );
     }
 
+    const supersedableDisconnect = supersedableLifecycles.find(
+      (row) => row.kind === "disconnect_revoke",
+    );
+    if (supersedableDisconnect) {
+      routesDisabledByDisconnect = supersedableDisconnect.disabledRoutes;
+    } else if (account) {
+      const [completedDisconnect] = await tx
+        .select({ disabledRoutes: providerXCredentialLifecycles.disabledRoutes })
+        .from(providerXCredentialLifecycles)
+        .where(
+          and(
+            eq(providerXCredentialLifecycles.tenantId, input.tenantId),
+            eq(providerXCredentialLifecycles.workspaceId, input.workspaceId),
+            eq(providerXCredentialLifecycles.providerAccountId, account.id),
+            eq(providerXCredentialLifecycles.kind, "disconnect_revoke"),
+            eq(providerXCredentialLifecycles.state, "revoked"),
+          ),
+        )
+        .orderBy(desc(providerXCredentialLifecycles.updatedAt))
+        .limit(1)
+        .for("update");
+      routesDisabledByDisconnect = completedDisconnect?.disabledRoutes ?? [];
+    }
+
     const [existingSecret] = await tx
-      .select({ id: secrets.id })
+      .select({ id: secrets.id, deletedAt: secrets.deletedAt })
       .from(secrets)
-      .where(
-        and(
-          eq(secrets.tenantId, input.tenantId),
-          eq(secrets.name, secretName),
-          sql`${secrets.deletedAt} IS NULL`,
-        ),
-      )
+      .where(and(eq(secrets.tenantId, input.tenantId), eq(secrets.name, secretName)))
+      .orderBy(desc(secrets.version))
       .limit(1)
       .for("update");
     const meta = existingSecret
-      ? await input.vault.rotateSecretWithinTx(tx, input.tenantId, secretName, serialized)
+      ? await input.vault.rotateSecretWithinTx(tx, input.tenantId, secretName, serialized, {
+          allowDeletedCurrent: existingSecret.deletedAt !== null,
+        })
       : await input.vault.createSecretWithinTx(tx, input.tenantId, secretName, serialized, {
           description: "X (Twitter) provider-account OAuth credential",
         });
@@ -1161,6 +1188,30 @@ async function persistConnectedAccount(input: PersistInput): Promise<CompleteCon
         .returning();
       if (!updated) {
         throw new XConnectError("X_REFRESH_FAILED", 409, "account revision conflict on reconnect");
+      }
+      for (const route of routesDisabledByDisconnect) {
+        if (
+          !route ||
+          typeof route.id !== "string" ||
+          !Number.isSafeInteger(route.authorityRevision) ||
+          route.authorityRevision < 1
+        ) {
+          continue;
+        }
+        await tx
+          .update(secretRoutes)
+          .set({ enabled: true })
+          .where(
+            and(
+              eq(secretRoutes.tenantId, input.tenantId),
+              eq(secretRoutes.id, route.id),
+              eq(secretRoutes.secretId, meta.id),
+              eq(secretRoutes.enabled, false),
+              // Disconnect and credential rotation each advance the route
+              // revision. Only untouched routes are restored automatically.
+              eq(secretRoutes.authorityRevision, route.authorityRevision + 2),
+            ),
+          );
       }
     } else {
       reconnected = false;
@@ -1233,8 +1284,8 @@ async function persistConnectedAccount(input: PersistInput): Promise<CompleteCon
         ),
       );
 
-    if (supersedableRefreshes.length > 0) {
-      const lifecycleIds = supersedableRefreshes.map((row) => row.id).sort();
+    if (supersedableLifecycles.length > 0) {
+      const lifecycleIds = supersedableLifecycles.map((row) => row.id).sort();
       const superseded = await tx
         .update(providerXCredentialLifecycles)
         .set({
@@ -1250,28 +1301,27 @@ async function persistConnectedAccount(input: PersistInput): Promise<CompleteCon
             inArray(providerXCredentialLifecycles.id, lifecycleIds),
             eq(providerXCredentialLifecycles.state, "needs_attention"),
             sql`${providerXCredentialLifecycles.credentialSecretId} IS NULL`,
-            eq(providerXCredentialLifecycles.lastErrorCode, "REFRESH_OUTCOME_UNKNOWN"),
           ),
         )
         .returning({ id: providerXCredentialLifecycles.id });
-      if (superseded.length !== supersedableRefreshes.length) {
+      if (superseded.length !== supersedableLifecycles.length) {
         throw new XConnectError(
           "X_CREDENTIAL_NEEDS_ATTENTION",
           409,
-          "X refresh lifecycle changed during reconnect",
+          "X credential lifecycle changed during reconnect",
         );
       }
       await append({
         tenantId: input.tenantId,
         actorType: "user",
         actorId: input.callerUserId,
-        action: "provider.x.refresh.superseded_by_reconnect",
+        action: "provider.x.lifecycle.superseded_by_reconnect",
         resourceType: "provider_account",
         resourceId: providerAccountId,
         metadata: {
           workspaceId: input.workspaceId,
           lifecycleIds,
-          priorStates: supersedableRefreshes.map((row) => row.state).sort(),
+          priorKinds: supersedableLifecycles.map((row) => row.kind).sort(),
           newAccountRevision: account ? account.revision + 1 : 1,
           requestId: input.requestId,
         },
@@ -2502,9 +2552,10 @@ export interface DisconnectResult {
 }
 
 /**
- * Disconnect a connected X account: best-effort revoke at X, degrade the account
- * (status revoked), bump revision, audit. Revocation failure at X does NOT block
- * the local degrade — we fail CLOSED locally regardless.
+ * Disconnect a connected X account. Local credential authority and an encrypted
+ * upstream-revocation handle are committed in one transaction. Provider cleanup
+ * then uses the common leased retry path, so a crash cannot restore local access
+ * or discard either the stored grant or a separately staged rotated grant.
  */
 export async function disconnectXProviderCredential(
   input: DisconnectInput,
@@ -2528,39 +2579,108 @@ export async function disconnectXProviderCredential(
       throw new XConnectError("X_ACCOUNT_NOT_X", 400, "provider account is not an X account");
     }
 
-    let credential: LoadedCredential | null = null;
-    if (account.credentialSecretId) {
-      credential = await loadCredential(
-        input.vault,
-        input.tenantId,
-        account.credentialSecretId,
-        tx,
-      );
-      if (credential.payload.xUserId !== account.externalRef) {
-        throw new XConnectError("X_REFRESH_FAILED", 409, "credential account binding mismatch");
-      }
+    if (account.status === "revoked" && !account.credentialSecretId) {
+      return { lifecycleId: null, retryAt: null };
     }
-    const [activeLifecycle] = await tx
-      .select()
-      .from(providerXCredentialLifecycles)
-      .where(
-        and(
-          eq(providerXCredentialLifecycles.tenantId, input.tenantId),
-          eq(providerXCredentialLifecycles.providerAccountId, account.id),
-          inArray(providerXCredentialLifecycles.state, [
-            "inflight",
-            "credential_staged",
-            "revocation_pending",
-            "needs_attention",
-          ]),
-        ),
-      )
-      .limit(1)
-      .for("update");
+
+    const now = new Date();
+    const material = account.credentialSecretId
+      ? await readXDisconnectRevocationMaterial(
+          tx,
+          input.vault,
+          input.tenantId,
+          account.credentialSecretId,
+          account.externalRef,
+        )
+      : null;
+    const routesToDisable = account.credentialSecretId
+      ? await tx
+          .select({ id: secretRoutes.id, authorityRevision: secretRoutes.authorityRevision })
+          .from(secretRoutes)
+          .where(
+            and(
+              eq(secretRoutes.tenantId, input.tenantId),
+              eq(secretRoutes.secretId, account.credentialSecretId),
+              eq(secretRoutes.enabled, true),
+            ),
+          )
+          .for("update")
+      : [];
+
+    const lifecycleId = account.credentialSecretId ? randomUUID() : null;
+    let lifecycleSecretId: string | null = null;
+    const hasRevocationHandle = Boolean(material?.accessToken || material?.refreshToken);
+    if (lifecycleId && hasRevocationHandle) {
+      const secret = await input.vault.createSecretWithinTx(
+        tx,
+        input.tenantId,
+        `provider-x-lifecycle:${lifecycleId}:disconnect`,
+        JSON.stringify({
+          schemaVersion: "steward.provider-x.lifecycle.v1",
+          token: {
+            access_token: material?.accessToken ?? undefined,
+            refresh_token: material?.refreshToken ?? undefined,
+          },
+        } satisfies XRefreshLifecycleSecret),
+        { description: "Encrypted transient X OAuth revocation material" },
+      );
+      lifecycleSecretId = secret.id;
+    }
+    if (lifecycleId) {
+      await tx.insert(providerXCredentialLifecycles).values({
+        id: lifecycleId,
+        tenantId: input.tenantId,
+        workspaceId: input.workspaceId,
+        providerAccountId: account.id,
+        kind: "disconnect_revoke",
+        state: lifecycleSecretId ? "revocation_pending" : "needs_attention",
+        credentialSecretId: lifecycleSecretId,
+        expectedAccountRevision: account.revision + 1,
+        attempts: 0,
+        nextRetryAt: lifecycleSecretId ? now : null,
+        lastErrorCode: lifecycleSecretId
+          ? "DISCONNECT_REVOCATION_PENDING"
+          : "DISCONNECT_REVOCATION_HANDLE_UNAVAILABLE",
+        disabledRoutes: routesToDisable,
+      });
+      await append({
+        tenantId: input.tenantId,
+        actorType: "user",
+        actorId: input.callerUserId,
+        action: "provider.x.disconnect.intent_staged",
+        resourceType: "provider_x_credential_lifecycle",
+        resourceId: lifecycleId,
+        metadata: {
+          workspaceId: input.workspaceId,
+          providerAccountId: account.id,
+          revocationHandleAvailable: hasRevocationHandle,
+          credentialIssue: material?.issue ?? null,
+        },
+      });
+    }
+
+    if (account.credentialSecretId) {
+      await tx
+        .update(secretRoutes)
+        .set({ enabled: false })
+        .where(
+          and(
+            eq(secretRoutes.tenantId, input.tenantId),
+            eq(secretRoutes.secretId, account.credentialSecretId),
+            eq(secretRoutes.enabled, true),
+          ),
+        );
+    }
 
     const [degraded] = await tx
       .update(providerAccounts)
-      .set({ status: "revoked", revision: account.revision + 1, updatedAt: new Date() })
+      .set({
+        status: "revoked",
+        credentialSecretId: null,
+        credentialVersion: null,
+        revision: account.revision + 1,
+        updatedAt: now,
+      })
       .where(
         and(
           eq(providerAccounts.tenantId, input.tenantId),
@@ -2573,69 +2693,17 @@ export async function disconnectXProviderCredential(
       throw new XConnectError("X_REFRESH_FAILED", 409, "account revision conflict on disconnect");
     }
 
-    const lifecycleId = credential ? (activeLifecycle?.id ?? randomUUID()) : null;
-    let lifecycleSecretId = activeLifecycle?.credentialSecretId ?? null;
-    if (credential && lifecycleId) {
-      if (!lifecycleSecretId) {
-        const secret = await input.vault.createSecretWithinTx(
-          tx,
-          input.tenantId,
-          `provider-x-lifecycle:${lifecycleId}:disconnect`,
-          JSON.stringify({
-            schemaVersion: "steward.provider-x.lifecycle.v1",
-            token: {
-              access_token: credential.payload.accessToken,
-              refresh_token: credential.refreshToken ?? undefined,
-            },
-          } satisfies XRefreshLifecycleSecret),
-          { description: "Encrypted transient X OAuth revocation material" },
+    if (account.credentialSecretId) {
+      await tx
+        .update(secrets)
+        .set({ deletedAt: now, updatedAt: now })
+        .where(
+          and(
+            eq(secrets.tenantId, input.tenantId),
+            eq(secrets.id, account.credentialSecretId),
+            sql`${secrets.deletedAt} IS NULL`,
+          ),
         );
-        lifecycleSecretId = secret.id;
-      }
-      if (activeLifecycle) {
-        const retryAt = new Date();
-        await tx
-          .update(providerXCredentialLifecycles)
-          .set({
-            kind: activeLifecycle.credentialSecretId ? activeLifecycle.kind : "disconnect_revoke",
-            state: "revocation_pending",
-            credentialSecretId: lifecycleSecretId,
-            expectedAccountRevision: degraded.revision,
-            attempts: 0,
-            nextRetryAt: retryAt,
-            lastErrorCode: "DISCONNECT_REVOCATION_PENDING",
-            updatedAt: retryAt,
-          })
-          .where(
-            and(
-              eq(providerXCredentialLifecycles.tenantId, input.tenantId),
-              eq(providerXCredentialLifecycles.id, lifecycleId),
-            ),
-          );
-      } else {
-        const retryAt = new Date();
-        await tx.insert(providerXCredentialLifecycles).values({
-          id: lifecycleId,
-          tenantId: input.tenantId,
-          workspaceId: input.workspaceId,
-          providerAccountId: account.id,
-          kind: "disconnect_revoke",
-          state: "revocation_pending",
-          credentialSecretId: lifecycleSecretId,
-          expectedAccountRevision: degraded.revision,
-          attempts: 0,
-          nextRetryAt: retryAt,
-        });
-      }
-      await append({
-        tenantId: input.tenantId,
-        actorType: "user",
-        actorId: input.callerUserId,
-        action: "provider.x.disconnect.intent_staged",
-        resourceType: "provider_x_credential_lifecycle",
-        resourceId: lifecycleId,
-        metadata: { workspaceId: input.workspaceId, providerAccountId: account.id },
-      });
     }
 
     await append({
@@ -2649,7 +2717,9 @@ export async function disconnectXProviderCredential(
         workspaceId: input.workspaceId,
         xUserId: account.externalRef,
         revokedAtUpstream: false,
-        upstreamRevocationPending: Boolean(lifecycleId),
+        upstreamRevocationPending: Boolean(lifecycleSecretId),
+        revocationHandleAvailable: hasRevocationHandle,
+        disabledRouteCount: routesToDisable.length,
         previousRevision: account.revision,
         newRevision: degraded.revision,
         requestId: input.requestId ?? null,
@@ -2658,31 +2728,59 @@ export async function disconnectXProviderCredential(
 
     return {
       lifecycleId,
+      retryAt: lifecycleSecretId ? now : null,
     };
   });
 
-  if (!prepared.lifecycleId) {
+  if (!prepared.lifecycleId || !prepared.retryAt) {
     return { providerAccountId: input.accountId, revoked: false };
   }
   await afterXDisconnectJournalForTests?.();
-  const [lifecycle] = await (getDb() as DbExecutor)
-    .select({ nextRetryAt: providerXCredentialLifecycles.nextRetryAt })
-    .from(providerXCredentialLifecycles)
-    .where(
-      and(
-        eq(providerXCredentialLifecycles.tenantId, input.tenantId),
-        eq(providerXCredentialLifecycles.id, prepared.lifecycleId),
-      ),
-    )
-    .limit(1);
-  const revokedAtUpstream = lifecycle
-    ? await reconcileStagedXCredentialRevocation({
-        ...input,
-        lifecycleId: prepared.lifecycleId,
-        now: lifecycle.nextRetryAt ?? new Date(),
-      })
-    : false;
+  const revokedAtUpstream = await reconcileStagedXCredentialRevocation({
+    ...input,
+    lifecycleId: prepared.lifecycleId,
+    now: prepared.retryAt,
+  });
   return { providerAccountId: input.accountId, revoked: revokedAtUpstream };
+}
+
+async function readXDisconnectRevocationMaterial(
+  tx: DbExecutor,
+  vault: SecretVault,
+  tenantId: string,
+  secretId: string,
+  expectedXUserId: string,
+): Promise<{
+  accessToken: string | null;
+  refreshToken: string | null;
+  issue: string | null;
+}> {
+  const [row] = (await tx
+    .select()
+    .from(secrets)
+    .where(and(eq(secrets.tenantId, tenantId), eq(secrets.id, secretId)))
+    .limit(1)) as Secret[];
+  if (!row) {
+    return { accessToken: null, refreshToken: null, issue: "CREDENTIAL_SECRET_MISSING" };
+  }
+  try {
+    const parsed = JSON.parse(vault.decryptSecretRow(tenantId, row)) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { accessToken: null, refreshToken: null, issue: "CREDENTIAL_PAYLOAD_INVALID" };
+    }
+    const candidate = parsed as Record<string, unknown>;
+    const accessToken = boundedStagedToken(candidate.accessToken);
+    const refreshToken = boundedStagedToken(candidate.refreshToken);
+    const issue =
+      typeof candidate.xUserId === "string" && candidate.xUserId !== expectedXUserId
+        ? "CREDENTIAL_BINDING_MISMATCH"
+        : accessToken || refreshToken
+          ? null
+          : "CREDENTIAL_REVOCATION_HANDLE_INVALID";
+    return { accessToken, refreshToken, issue };
+  } catch {
+    return { accessToken: null, refreshToken: null, issue: "CREDENTIAL_DECRYPT_FAILED" };
+  }
 }
 
 async function revokeUpstreamBestEffort(

--- a/packages/db/drizzle/0107_x_disconnect_route_recovery.sql
+++ b/packages/db/drizzle/0107_x_disconnect_route_recovery.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "provider_x_credential_lifecycles"
+  ADD COLUMN "disabled_routes" jsonb NOT NULL DEFAULT '[]'::jsonb,
+  ADD CONSTRAINT "provider_x_lifecycle_disabled_routes_array_check"
+    CHECK (jsonb_typeof("disabled_routes") = 'array');

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -610,6 +610,13 @@
       "when": 1787111200000,
       "tag": "0106_x_disconnect_recovery_bounds",
       "breakpoints": true
+    },
+    {
+      "idx": 107,
+      "version": "7",
+      "when": 1787111201000,
+      "tag": "0107_x_disconnect_route_recovery",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/__tests__/x-disconnect-recovery-migration.test.ts
+++ b/packages/db/src/__tests__/x-disconnect-recovery-migration.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const migration = readFileSync(
+  join(import.meta.dir, "..", "..", "drizzle", "0107_x_disconnect_route_recovery.sql"),
+  "utf8",
+);
+
+describe("X disconnect route recovery migration", () => {
+  test("extends the merged lifecycle without rewriting prior recovery migrations", () => {
+    expect(migration).toContain('ADD COLUMN "disabled_routes" jsonb');
+    expect(migration).not.toContain("DROP CONSTRAINT");
+    expect(migration).not.toContain('ADD COLUMN "kind"');
+    expect(migration).not.toContain('ADD COLUMN "attempts"');
+    expect(migration).not.toContain('ADD COLUMN "next_retry_at"');
+  });
+});

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -2109,9 +2109,9 @@ export const providerGoogleCredentialLifecycles = pgTable(
 );
 
 /**
- * Durable hand-off journal for X OAuth code exchange and refresh rotation.
- * One-time provider responses are encrypted before semantic validation, then
- * either adopted transactionally or retained for bounded revocation recovery.
+ * Durable hand-off journal for X OAuth code exchange, refresh rotation, and
+ * disconnect cleanup. Provider responses and disconnect handles are encrypted
+ * before fallible work, then adopted or revoked through bounded recovery.
  */
 export const providerXCredentialLifecycles = pgTable(
   "provider_x_credential_lifecycles",
@@ -2127,6 +2127,10 @@ export const providerXCredentialLifecycles = pgTable(
     attempts: integer("attempts").notNull().default(0),
     nextRetryAt: timestamp("next_retry_at", { withTimezone: true }),
     lastErrorCode: varchar("last_error_code", { length: 64 }),
+    disabledRoutes: jsonb("disabled_routes")
+      .$type<Array<{ id: string; authorityRevision: number }>>()
+      .notNull()
+      .default([]),
     ...timestamps,
   },
   (table) => ({
@@ -2168,6 +2172,10 @@ export const providerXCredentialLifecycles = pgTable(
     retryCheck: check(
       "provider_x_lifecycle_retry_check",
       sql`${table.attempts} >= 0 AND ${table.attempts} <= 5 AND (${table.state} <> 'revocation_pending' OR ${table.nextRetryAt} IS NOT NULL)`,
+    ),
+    disabledRoutesArrayCheck: check(
+      "provider_x_lifecycle_disabled_routes_array_check",
+      sql`jsonb_typeof(${table.disabledRoutes}) = 'array'`,
     ),
     secretStateCheck: check(
       "provider_x_lifecycle_secret_state_check",

--- a/packages/vault/src/__tests__/secret-vault-lifecycle.test.ts
+++ b/packages/vault/src/__tests__/secret-vault-lifecycle.test.ts
@@ -122,6 +122,37 @@ describe("SecretVault lifecycle semantics", () => {
     expect(oldVersion?.deletedAt).toBeInstanceOf(Date);
   });
 
+  it("requires explicit recovery opt-in to append to a deleted lineage", async () => {
+    const tenantId = `tenant-restore-${crypto.randomUUID()}`;
+    await ensureTenant(tenantId);
+    await ensureAgent(tenantId, "agent-restore");
+    const original = await vault.createSecret(tenantId, "provider", "old-token");
+    const route = await vault.createRoute(tenantId, original.id, {
+      agentId: "agent-restore",
+      hostPattern: "api.openai.com",
+      injectAs: "header",
+      injectKey: "authorization",
+    });
+    await getDb()
+      .update(secrets)
+      .set({ deletedAt: new Date() })
+      .where(and(eq(secrets.tenantId, tenantId), eq(secrets.id, original.id)));
+
+    await expect(
+      getDb().transaction((tx) =>
+        vault.rotateSecretWithinTx(tx, tenantId, "provider", "new-token"),
+      ),
+    ).rejects.toThrow('Secret "provider" not found');
+    const replacement = await getDb().transaction((tx) =>
+      vault.rotateSecretWithinTx(tx, tenantId, "provider", "new-token", {
+        allowDeletedCurrent: true,
+      }),
+    );
+    expect(replacement.version).toBe(2);
+    expect(await vault.decryptSecret(tenantId, replacement.id)).toBe("new-token");
+    expect((await vault.getRoute(tenantId, route.id))?.secretId).toBe(replacement.id);
+  });
+
   it("deletes all dependent routes when deleting a secret family", async () => {
     const tenantId = `tenant-delete-${crypto.randomUUID()}`;
     await ensureTenant(tenantId);

--- a/packages/vault/src/secret-vault.ts
+++ b/packages/vault/src/secret-vault.ts
@@ -318,18 +318,26 @@ export class SecretVault {
    * account refresh that holds a SELECT ... FOR UPDATE lock) without a nested
    * transaction. The single-flight/atomicity guarantee is the CALLER's outer
    * transaction; this method only appends the new version + repoints routes +
-   * soft-deletes the prior version.
+   * soft-deletes the prior version. Deleted lineages stay unavailable by
+   * default; recovery callers must explicitly opt in to append a replacement.
    */
   async rotateSecretWithinTx(
     tx: SecretTxExecutor,
     tenantId: string,
     name: string,
     newValue: string,
+    options?: { allowDeletedCurrent?: boolean },
   ): Promise<SecretMetadata> {
     const [current] = await tx
       .select()
       .from(secrets)
-      .where(and(eq(secrets.tenantId, tenantId), eq(secrets.name, name), isNull(secrets.deletedAt)))
+      .where(
+        and(
+          eq(secrets.tenantId, tenantId),
+          eq(secrets.name, name),
+          options?.allowDeletedCurrent ? undefined : isNull(secrets.deletedAt),
+        ),
+      )
       .orderBy(desc(secrets.version))
       .limit(1);
     if (!current) {


### PR DESCRIPTION
Closes #466.

## Summary

- make local disconnect fail closed without allowing malformed or misbound upstream credentials to block local revocation
- keep disconnect escrow separate from active refresh lifecycle state
- atomically disable currently enabled bound routes, clear the account credential pointer, and soft-delete the old secret
- restore only disconnect-disabled routes whose authority revision remains unchanged
- use leased, bounded revocation recovery with explicit terminal handling
- preserve immutable migration 0106 and add schema follow-up 0107

## Exact-head evidence

Head: `df6221db2fdbbfdb102a022f194ea37a825e3cb5`
Base: `63e0b8ddd705e43e0415651d2880034a8d38ba83`

- focused X, environment/runtime, migration/RLS, and vault lifecycle tests: 78/78, 474 assertions
- API, DB, and Vault builds: pass
- changed-file Biome: pass
- `git diff --check`: pass