### PR TITLE
fix(provider-x): block stale staged connect adoption

### DIFF
--- a/packages/api/src/__tests__/provider-x-connect.test.ts
+++ b/packages/api/src/__tests__/provider-x-connect.test.ts
@@ -834,6 +834,93 @@ describe("connect exchange recovery", () => {
     fake.restore();
   });
 
+  test("a stale staged connect grant is revoked instead of overwriting a newer reconnect", async () => {
+    const firstStore = new MemoryConnectStore();
+    const firstFake = installFakeX({
+      exchangeToken: {
+        access_token: "access-stale-first",
+        refresh_token: "refresh-stale-first",
+      },
+    });
+    const initiated = await initiateXConnect({
+      tenantId: TENANT,
+      workspaceId: WORKSPACE,
+      initiatedByUserId: ADMIN,
+      redirectUri: REDIRECT,
+      config: CONFIG,
+      store: firstStore,
+    });
+    __setAfterXCredentialStageForTests(async () => {
+      throw new Error("simulated process crash after first connect staging");
+    });
+    await expect(
+      completeXConnect({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        callerUserId: ADMIN,
+        code: "auth-code",
+        state: initiated.state,
+        connectToken: initiated.connectToken,
+        redirectUri: REDIRECT,
+        config: CONFIG,
+        store: firstStore,
+        vault,
+      }),
+    ).rejects.toThrow("simulated process crash after first connect staging");
+    __setAfterXCredentialStageForTests(null);
+    firstFake.restore();
+
+    const newer = await connectHappy(new MemoryConnectStore(), {
+      exchangeToken: {
+        access_token: "access-current-second",
+        refresh_token: "refresh-current-second",
+      },
+    });
+    const newerAccountId = newer.completed.providerAccountId;
+    const beforeSweep = await decryptCredential(newerAccountId);
+    expect(beforeSweep.accessToken).toBe("access-current-second");
+
+    // The guard must be database-lineage based, not a comparison against an
+    // application-supplied account timestamp that can move backwards under
+    // replica clock skew.
+    await getDb()
+      .update(providerAccounts)
+      .set({ updatedAt: new Date(0) })
+      .where(eq(providerAccounts.id, newerAccountId));
+
+    const [staleLifecycle] = await getDb()
+      .select()
+      .from(providerXCredentialLifecycles)
+      .where(
+        and(
+          eq(providerXCredentialLifecycles.kind, "connect_exchange"),
+          eq(providerXCredentialLifecycles.state, "credential_staged"),
+        ),
+      );
+    expect(staleLifecycle.providerAccountId).toBeNull();
+
+    const recovery = installFakeX({ revokeStatuses: [200] });
+    const swept = await runXCredentialLifecycleSweep({
+      vault,
+      config: CONFIG,
+      now: new Date(Date.now() + 70_000),
+    });
+    expect(swept).toMatchObject({ processed: 1, revoked: 1, adopted: 0, attention: 0 });
+    expect(recovery.counters).toMatchObject({ exchange: 0, identity: 1, revoke: 1 });
+
+    const afterSweep = await decryptCredential(newerAccountId);
+    expect(afterSweep.accessToken).toBe("access-current-second");
+    expect(afterSweep.refreshToken).toBe("refresh-current-second");
+
+    const [revokedLifecycle] = await getDb()
+      .select()
+      .from(providerXCredentialLifecycles)
+      .where(eq(providerXCredentialLifecycles.id, staleLifecycle.id));
+    expect(revokedLifecycle.state).toBe("revoked");
+    expect(revokedLifecycle.credentialSecretId).toBeNull();
+    recovery.restore();
+  });
+
   test("failed identity revocation is durably retried with backoff and a hard ceiling", async () => {
     const store = new MemoryConnectStore();
     const fake = installFakeX({ identityStatus: 503, revokeStatuses: [503, 503, 503, 503, 503] });

--- a/packages/api/src/services/provider-x-connect.ts
+++ b/packages/api/src/services/provider-x-connect.ts
@@ -2217,7 +2217,24 @@ export async function runXCredentialLifecycleSweep(input: {
         result.attention += 1;
       }
     } catch {
-      result.attention += 1;
+      // Connect reconciliation deliberately rethrows its adoption error after
+      // compensating a stale staged grant. Classify the durable terminal state
+      // instead of reporting a successfully revoked grant as unresolved.
+      const [reconciled] = await (getDb() as DbExecutor)
+        .select({ state: providerXCredentialLifecycles.state })
+        .from(providerXCredentialLifecycles)
+        .where(
+          and(
+            eq(providerXCredentialLifecycles.tenantId, row.tenantId),
+            eq(providerXCredentialLifecycles.id, row.id),
+          ),
+        )
+        .limit(1);
+      if (row.kind === "connect_exchange" && reconciled?.state === "revoked") {
+        result.revoked += 1;
+      } else {
+        result.attention += 1;
+      }
     }
   }
   result.remaining = rows.length === limit && result.attention === 0;

--- a/packages/api/src/services/provider-x-connect.ts
+++ b/packages/api/src/services/provider-x-connect.ts
@@ -1072,6 +1072,36 @@ async function persistConnectedAccount(input: PersistInput): Promise<CompleteCon
       .limit(1)
       .for("update");
 
+    // Do not compare provider_accounts.updatedAt with this lifecycle. Account
+    // timestamps are supplied by application replicas while lifecycle
+    // timestamps are database-owned, so clock skew can let an older staged
+    // response overwrite a reconnect. The adopted connect journal gives us a
+    // database-ordered lineage marker under the account lock instead.
+    const [newerConnectAdoption] = account
+      ? await tx
+          .select({ id: providerXCredentialLifecycles.id })
+          .from(providerXCredentialLifecycles)
+          .where(
+            and(
+              eq(providerXCredentialLifecycles.tenantId, input.tenantId),
+              eq(providerXCredentialLifecycles.workspaceId, input.workspaceId),
+              eq(providerXCredentialLifecycles.providerAccountId, account.id),
+              eq(providerXCredentialLifecycles.kind, "connect_exchange"),
+              eq(providerXCredentialLifecycles.state, "adopted"),
+              sql`${providerXCredentialLifecycles.createdAt} > ${connectLifecycle.createdAt}`,
+            ),
+          )
+          .limit(1)
+          .for("update")
+      : [];
+    if (newerConnectAdoption) {
+      throw new XConnectError(
+        "X_CREDENTIAL_NEEDS_ATTENTION",
+        409,
+        "a newer X credential already superseded this staged connect response",
+      );
+    }
+
     const unresolvedLifecycles = account
       ? await tx
           .select({


### PR DESCRIPTION
## Summary

- block stale staged X connect responses from overwriting a newer successful reconnect
- fail closed when the account changed after the staged connect intent, then revoke the stale exact grant through the existing recovery path
- cover the stale-stage replay case with a regression proving the newer credential stays current while the old staged grant is revoked

## Why this follow-up exists

`#462` made connect exchange grants durable and recoverable, but a staged `connect_exchange` response could still be swept and adopted after a newer reconnect had already succeeded for the same X account. That let an older staged grant rotate the account back to stale credentials instead of being revoked.

This follow-up keeps the newer account state authoritative: once the account has changed after the staged connect intent was created, the old staged response is treated as stale and routed into the existing revocation path.

## Exact-head evidence

Head: `c8b8eade`
Base: `63e0b8dd`

- `bun test --timeout 120000 packages/api/src/__tests__/provider-x-connect.test.ts packages/db/src/__tests__/x-connect-exchange-migration.test.ts`
  - green locally after wiring workspace package resolution in the isolated worktree
- `git diff --check`
  - green
- `bunx turbo run build --filter=@stwd/db --filter=@stwd/api`
  - `@stwd/db` green from shared cache
  - `@stwd/api` blocked in this environment by missing local `@cloudflare/workers-types` type definitions, not by the patch itself

Refs #195.
