### PR TITLE
fix(api): classify condition-set persistence failures

### DIFF
--- a/packages/api/src/__tests__/condition-set-audit-rollback.test.ts
+++ b/packages/api/src/__tests__/condition-set-audit-rollback.test.ts
@@ -17,8 +17,13 @@ describe("condition set audit rollback hardening", () => {
     expect(routeSource).toContain("async function restoreConditionSet");
     expect(routeSource).toContain("async function restoreConditionSetItems");
 
+    const createStart = routeSource.indexOf('conditionSetRoutes.post("/",');
+    const createEnd = routeSource.indexOf("conditionSetRoutes.", createStart + 1);
+    const createRoute = routeSource.slice(createStart, createEnd);
+    expect(createRoute).toContain("withTenantAuditedTransaction");
+    expect(createRoute).toContain("appendRequiredAudit");
+
     for (const [marker, rollback] of [
-      ['conditionSetRoutes.post("/",', "db\n        .delete(conditionSets)"],
       ['conditionSetRoutes.patch("/:id",', "restoreConditionSet(tenantId, current"],
       ['conditionSetRoutes.delete("/:id",', "restoreConditionSet(tenantId, current, currentItems)"],
       ['conditionSetRoutes.post("/:id/items",', "restoreConditionSetItems(tenantId, set.id"],

--- a/packages/api/src/__tests__/condition-sets.test.ts
+++ b/packages/api/src/__tests__/condition-sets.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { agents, closeDb, getDb, tenants } from "@stwd/db";
+import { agents, closeDb, conditionSets, getDb, tenants } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { and, eq, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import type { AppVariables } from "../services/context";
 
@@ -229,6 +230,61 @@ describeConditionSets("condition sets", () => {
     expect(response.status).toBe(403);
   });
 
+  it("returns a generic 500 and rolls back creation when the required audit fails", async () => {
+    const canary = "postgres://internal.example/condition-set-secret";
+    await getDb().execute(
+      sql.raw(`
+      CREATE OR REPLACE FUNCTION fail_condition_set_completion_audit()
+      RETURNS trigger AS $$
+      BEGIN
+        IF NEW.action = 'condition_set.create' THEN
+          RAISE EXCEPTION '${canary}';
+        END IF;
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql
+    `),
+    );
+    await getDb().execute(
+      sql.raw(`
+      CREATE TRIGGER condition_set_completion_audit_failure
+      BEFORE INSERT ON audit_events
+      FOR EACH ROW EXECUTE FUNCTION fail_condition_set_completion_audit()
+    `),
+    );
+
+    try {
+      const response = await app.request("/condition-sets", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: "must roll back",
+          ownerId: "owner-key-rollback",
+        }),
+      });
+
+      expect(response.status).toBe(500);
+      const body = (await response.json()) as { ok: boolean; error: string };
+      expect(body).toEqual({ ok: false, error: "Internal server error" });
+      expect(JSON.stringify(body)).not.toContain(canary);
+
+      const surviving = await getDb()
+        .select({ id: conditionSets.id })
+        .from(conditionSets)
+        .where(
+          and(eq(conditionSets.tenantId, TENANT_ID), eq(conditionSets.name, "must roll back")),
+        );
+      expect(surviving).toHaveLength(0);
+    } finally {
+      await getDb().execute(
+        sql.raw("DROP TRIGGER IF EXISTS condition_set_completion_audit_failure ON audit_events"),
+      );
+      await getDb().execute(
+        sql.raw("DROP FUNCTION IF EXISTS fail_condition_set_completion_audit()"),
+      );
+    }
+  });
+
   it("rejects policy templates that reference missing condition sets", async () => {
     const response = await app.request("/policies", {
       method: "POST",
@@ -241,7 +297,7 @@ describeConditionSets("condition sets", () => {
             type: "condition-set",
             enabled: true,
             config: {
-              conditionSetId: "00000000-0000-0000-0000-000000000000",
+              conditionSetId: "10000000-0000-4000-8000-000000000000",
               operator: "not_in_condition_set",
             },
           },
@@ -303,7 +359,7 @@ describeConditionSets("condition sets", () => {
             type: "condition-set",
             enabled: true,
             config: {
-              conditionSetId: "00000000-0000-0000-0000-000000000000",
+              conditionSetId: "10000000-0000-4000-8000-000000000000",
               operator: "not_in_condition_set",
             },
           },

--- a/packages/api/src/routes/condition-sets.ts
+++ b/packages/api/src/routes/condition-sets.ts
@@ -6,9 +6,10 @@
  */
 
 import { randomUUID } from "node:crypto";
+import { redactedThrownDiagnostics } from "@stwd/shared";
 import { and, count, desc, eq, sql } from "drizzle-orm";
 import { Hono } from "hono";
-import { writeAuditEvent } from "../services/audit";
+import { withTenantAuditedTransaction, writeAuditEvent } from "../services/audit";
 import {
   type ApiResponse,
   type AppVariables,
@@ -70,6 +71,16 @@ type ReplaceItemsBody = {
 type ConditionSetRow = typeof conditionSets.$inferSelect;
 type ConditionSetItemRow = typeof conditionSetItems.$inferSelect;
 
+class ConditionSetValidationError extends Error {}
+
+function conditionSetMutationError(c: Parameters<typeof requireTenantLevel>[0], error: unknown) {
+  if (error instanceof ConditionSetValidationError) {
+    return c.json<ApiResponse>({ ok: false, error: error.message }, 400);
+  }
+  console.error("[condition-sets] persistence failure", redactedThrownDiagnostics(error));
+  return c.json<ApiResponse>({ ok: false, error: "Internal server error" }, 500);
+}
+
 function iso(value: Date | string): string {
   return value instanceof Date ? value.toISOString() : String(value);
 }
@@ -103,21 +114,23 @@ function itemToResponse(row: typeof conditionSetItems.$inferSelect): ConditionSe
 function normalizeMetadata(value: unknown): Record<string, unknown> {
   if (value === undefined) return {};
   if (!value || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error("metadata must be an object");
+    throw new ConditionSetValidationError("metadata must be an object");
   }
   if (JSON.stringify(value).length > MAX_ITEM_METADATA_BYTES) {
-    throw new Error(`metadata must not exceed ${MAX_ITEM_METADATA_BYTES} bytes`);
+    throw new ConditionSetValidationError(
+      `metadata must not exceed ${MAX_ITEM_METADATA_BYTES} bytes`,
+    );
   }
   return value as Record<string, unknown>;
 }
 
 function normalizeRequiredText(value: unknown, field: string, maxLength: number): string {
   if (!isNonEmptyString(value)) {
-    throw new Error(`${field} is required`);
+    throw new ConditionSetValidationError(`${field} is required`);
   }
   const trimmed = value.trim();
   if (trimmed.length > maxLength) {
-    throw new Error(`${field} must not exceed ${maxLength} characters`);
+    throw new ConditionSetValidationError(`${field} must not exceed ${maxLength} characters`);
   }
   return trimmed;
 }
@@ -130,22 +143,24 @@ function normalizeOptionalText(
   if (value === undefined) return undefined;
   if (value === null) return null;
   if (typeof value !== "string") {
-    throw new Error(`${field} must be a string`);
+    throw new ConditionSetValidationError(`${field} must be a string`);
   }
   const trimmed = value.trim();
   if (!trimmed) return null;
   if (trimmed.length > maxLength) {
-    throw new Error(`${field} must not exceed ${maxLength} characters`);
+    throw new ConditionSetValidationError(`${field} must not exceed ${maxLength} characters`);
   }
   return trimmed;
 }
 
 function normalizeItem(body: UpsertItemBody): UpsertItemBody {
   if (!isNonEmptyString(body.value)) {
-    throw new Error("item value is required and must be a non-empty string");
+    throw new ConditionSetValidationError("item value is required and must be a non-empty string");
   }
   if (body.value.trim().length > MAX_CONDITION_SET_ITEM_VALUE_LENGTH) {
-    throw new Error(`item value must not exceed ${MAX_CONDITION_SET_ITEM_VALUE_LENGTH} characters`);
+    throw new ConditionSetValidationError(
+      `item value must not exceed ${MAX_CONDITION_SET_ITEM_VALUE_LENGTH} characters`,
+    );
   }
   const label =
     normalizeOptionalText(body.label, "item label", MAX_CONDITION_SET_ITEM_LABEL_LENGTH) ?? null;
@@ -363,7 +378,8 @@ conditionSetRoutes.post("/", async (c) => {
       requestId: c.get("requestId") ?? null,
     });
 
-    const [row] = await db.transaction(async (tx) => {
+    const row = await withTenantAuditedTransaction(tenantId, async (txRaw, appendRequiredAudit) => {
+      const tx = txRaw as typeof db;
       if (shouldUsePostgresAdvisoryLocks()) {
         await tx.execute(
           sql`select pg_advisory_xact_lock(hashtext(${`condition_sets:${tenantId}`}))`,
@@ -375,10 +391,12 @@ conditionSetRoutes.post("/", async (c) => {
         .from(conditionSets)
         .where(eq(conditionSets.tenantId, tenantId));
       if (Number(total) >= MAX_CONDITION_SETS) {
-        throw new Error(`tenant cannot contain more than ${MAX_CONDITION_SETS} condition sets`);
+        throw new ConditionSetValidationError(
+          `tenant cannot contain more than ${MAX_CONDITION_SETS} condition sets`,
+        );
       }
 
-      return tx
+      const [created] = await tx
         .insert(conditionSets)
         .values({
           id: setId,
@@ -389,32 +407,25 @@ conditionSetRoutes.post("/", async (c) => {
           metadata,
         })
         .returning();
-    });
 
-    try {
-      await writeAuditEvent({
+      await appendRequiredAudit({
         tenantId,
         actorType: "user",
         actorId: c.get("userId") ?? tenantId,
         action: "condition_set.create",
         resourceType: "condition_set",
-        resourceId: row.id,
-        metadata: { name: row.name, ownerId: row.ownerId },
+        resourceId: created.id,
+        metadata: { name: created.name, ownerId: created.ownerId },
         ipAddress: c.req.header("x-forwarded-for") ?? null,
         userAgent: c.req.header("user-agent") ?? null,
         requestId: c.get("requestId") ?? null,
       });
-    } catch (error) {
-      await db
-        .delete(conditionSets)
-        .where(and(eq(conditionSets.id, row.id), eq(conditionSets.tenantId, tenantId)));
-      throw error;
-    }
+      return created;
+    });
 
     return c.json<ApiResponse<ConditionSetResponse>>({ ok: true, data: setToResponse(row) }, 201);
   } catch (err) {
-    const message = err instanceof Error ? err.message : "Failed to create condition set";
-    return c.json<ApiResponse>({ ok: false, error: message }, 400);
+    return conditionSetMutationError(c, err);
   }
 });
 
@@ -517,8 +528,7 @@ conditionSetRoutes.patch("/:id", async (c) => {
 
     return c.json<ApiResponse<ConditionSetResponse>>({ ok: true, data: setToResponse(row) });
   } catch (err) {
-    const message = err instanceof Error ? err.message : "Failed to update condition set";
-    return c.json<ApiResponse>({ ok: false, error: message }, 400);
+    return conditionSetMutationError(c, err);
   }
 });
 
@@ -680,7 +690,7 @@ conditionSetRoutes.post("/:id/items", async (c) => {
             ),
           );
         if (Number(total) >= MAX_CONDITION_SET_ITEMS) {
-          throw new Error(
+          throw new ConditionSetValidationError(
             `condition set cannot contain more than ${MAX_CONDITION_SET_ITEMS} items`,
           );
         }
@@ -729,8 +739,7 @@ conditionSetRoutes.post("/:id/items", async (c) => {
       201,
     );
   } catch (err) {
-    const message = err instanceof Error ? err.message : "Failed to add condition set item";
-    return c.json<ApiResponse>({ ok: false, error: message }, 400);
+    return conditionSetMutationError(c, err);
   }
 });
 
@@ -833,8 +842,7 @@ conditionSetRoutes.put("/:id/items", async (c) => {
       data: rows.map(itemToResponse),
     });
   } catch (err) {
-    const message = err instanceof Error ? err.message : "Failed to replace condition set items";
-    return c.json<ApiResponse>({ ok: false, error: message }, 400);
+    return conditionSetMutationError(c, err);
   }
 });
 
@@ -952,8 +960,7 @@ conditionSetRoutes.patch("/:id/items/:itemId", async (c) => {
 
     return c.json<ApiResponse<ConditionSetItemResponse>>({ ok: true, data: itemToResponse(row) });
   } catch (err) {
-    const message = err instanceof Error ? err.message : "Failed to update condition set item";
-    return c.json<ApiResponse>({ ok: false, error: message }, 400);
+    return conditionSetMutationError(c, err);
   }
 });
 


### PR DESCRIPTION
Closes #468

## Summary
- distinguishes closed condition-set validation errors from persistence/audit failures
- returns stable validation 400s and a generic 500 without raw diagnostics
- records only allowlisted redacted telemetry for unexpected failures
- commits condition-set creation and its required completion audit atomically
- proves an injected completion-audit failure returns 500, leaks no canary, and leaves no row

## Exact-head validation
- head: `e81372cced168985dd60dff19910e960cfaf76d1`
- base: `dd073b5aaa32b409917ff27ab2e74105a1469670`
- condition-set integration + rollback: 10/10 tests, 71 assertions
- API dependency build: 24/24 packages
- Biome changed files: green
- `git diff --check`: green