### PR TITLE
fix(auth): surface challenge deletion failures

### DIFF
--- a/packages/api/src/__tests__/user-linked-accounts.test.ts
+++ b/packages/api/src/__tests__/user-linked-accounts.test.ts
@@ -1,7 +1,7 @@
-import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it, spyOn } from "bun:test";
 import { createPrivateKey, sign as cryptoSign, generateKeyPairSync } from "node:crypto";
 
-import { MockSmsInbox, signTelegramLoginPayload } from "@stwd/auth";
+import { ChallengeStore, MockSmsInbox, signTelegramLoginPayload } from "@stwd/auth";
 import {
   accounts,
   agents,
@@ -519,6 +519,60 @@ describe("user linked account routes", () => {
       }),
     });
     expect(crossUser.status).toBe(409);
+  });
+
+  it("does not persist an Ethereum wallet when redeem-lock cleanup fails", async () => {
+    const wallet = privateKeyToAccount(
+      "0x8b3a350cf5c34c9194ca3a545d4f2c20d57216345d2a4460a5d4a64e3e2c2712",
+    );
+    const nonceResponse = await userRoutes.request("/me/accounts/wallet/ethereum/nonce", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${await tokenFor(accountOnlyUserId)}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ address: wallet.address }),
+    });
+    expect(nonceResponse.status).toBe(200);
+    const nonceBody = (await nonceResponse.json()) as { data: { message: string } };
+    const signature = await wallet.signMessage({ message: nonceBody.data.message });
+
+    const originalDelete = ChallengeStore.prototype.delete;
+    const deleteSpy = spyOn(ChallengeStore.prototype, "delete").mockImplementation(
+      async function (key) {
+        if (key.startsWith("wallet-link-lock:")) throw new Error("challenge backend unavailable");
+        return originalDelete.call(this, key);
+      },
+    );
+    try {
+      const response = await userRoutes.request("/me/accounts/wallet/ethereum", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${await tokenFor(accountOnlyUserId)}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          address: wallet.address,
+          message: nonceBody.data.message,
+          signature,
+        }),
+      });
+      expect(response.status).toBe(500);
+    } finally {
+      deleteSpy.mockRestore();
+    }
+
+    const linked = await getDb()
+      .select({ id: accounts.id })
+      .from(accounts)
+      .where(
+        and(
+          eq(accounts.userId, accountOnlyUserId),
+          eq(accounts.provider, "wallet:ethereum"),
+          eq(accounts.providerAccountId, wallet.address.toLowerCase()),
+        ),
+      );
+    expect(linked).toHaveLength(0);
   });
 
   it("links a Solana wallet with a one-time user proof and blocks replay/cross-user reuse", async () => {

--- a/packages/api/src/routes/user.ts
+++ b/packages/api/src/routes/user.ts
@@ -2531,7 +2531,7 @@ user.post("/me/accounts/wallet/ethereum", async (c) => {
       return c.json<ApiResponse>({ ok: false, error: "Invalid or expired wallet link nonce" }, 401);
     }
   } finally {
-    walletLinkChallenges.delete(lockKey);
+    await walletLinkChallenges.delete(lockKey);
   }
 
   const normalized = address.toLowerCase();
@@ -2720,7 +2720,7 @@ user.post("/me/accounts/wallet/solana", async (c) => {
       return c.json<ApiResponse>({ ok: false, error: "Invalid or expired wallet link nonce" }, 401);
     }
   } finally {
-    walletLinkChallenges.delete(lockKey);
+    await walletLinkChallenges.delete(lockKey);
   }
 
   const [userRow] = await getDb()

--- a/packages/auth/src/__tests__/challenge-store.test.ts
+++ b/packages/auth/src/__tests__/challenge-store.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, spyOn } from "bun:test";
+import { describe, expect, it } from "bun:test";
 
 import { ChallengeStore } from "../challenge-store";
 import type { StoreBackend } from "../store-backends";
@@ -16,16 +16,9 @@ function failingBackend(): StoreBackend {
 }
 
 describe("ChallengeStore.delete", () => {
-  it("resolves without an unhandled rejection and warns when the backend fails", async () => {
-    const warn = spyOn(console, "warn").mockImplementation(() => {});
-    try {
-      const store = new ChallengeStore({ backend: failingBackend() });
-      await expect(store.delete("key")).resolves.toBeUndefined();
-      expect(warn).toHaveBeenCalledTimes(1);
-      expect(String(warn.mock.calls[0][0])).toContain("[ChallengeStore] delete failed");
-    } finally {
-      warn.mockRestore();
-    }
+  it("surfaces backend failures so security-sensitive cleanup cannot appear successful", async () => {
+    const store = new ChallengeStore({ backend: failingBackend() });
+    await expect(store.delete("key")).rejects.toThrow("backend unavailable");
   });
 
   it("removes the entry on the happy path", async () => {

--- a/packages/auth/src/challenge-store.ts
+++ b/packages/auth/src/challenge-store.ts
@@ -14,7 +14,6 @@
  *   const store = new ChallengeStore({ backend: new RedisBackend(redisClient) });
  */
 
-import { redactedThrownDiagnostics } from "@stwd/shared";
 import type { StoreBackend } from "./store-backends";
 import { MemoryBackend } from "./store-backends";
 
@@ -69,23 +68,9 @@ export class ChallengeStore {
     return this.backend.get(key);
   }
 
-  /**
-   * Delete a challenge explicitly.
-   *
-   * Awaits a best-effort backend delete, but never rejects: a backend outage
-   * is logged as a warning instead of crashing the caller. Callers that need
-   * atomic one-time-use semantics must use consume(); a failed delete can
-   * leave the entry present until its TTL expires.
-   */
+  /** Delete a challenge explicitly and surface backend failures to the caller. */
   async delete(key: string): Promise<void> {
-    try {
-      await this.backend.delete(key);
-    } catch (err) {
-      console.warn(
-        "[ChallengeStore] delete failed; entry will expire via TTL",
-        redactedThrownDiagnostics(err),
-      );
-    }
+    await this.backend.delete(key);
   }
 
   /**


### PR DESCRIPTION
Closes #471

## Summary
- make explicit `ChallengeStore.delete()` reject when its backend cannot remove a challenge
- await wallet-link lock cleanup before either route can continue
- prove a hostile cleanup failure returns 500 before Ethereum wallet persistence
- retain behavioral store success/failure coverage

## Exact-head validation (`8ee83ceb`)
- dependency-aware `@stwd/auth` build: 7/7 tasks
- `challenge-store.test.ts`: 2/2
- `user-linked-accounts.test.ts`: 18/18, 139 assertions
- `packages/api` TypeScript build: pass
- Biome changed files: pass
- `git diff --check`: pass