### PR TITLE
fix(worker): retain request DB for background writes

### DIFF
--- a/packages/api/src/__tests__/worker-boot-validation.test.ts
+++ b/packages/api/src/__tests__/worker-boot-validation.test.ts
@@ -90,4 +90,27 @@ describe("workers boot JWT env validation (SEC-134)", () => {
       ),
     ).rejects.toThrow('AGENT_TOKEN_EXPIRY "not-a-duration" is not a valid positive duration');
   });
+
+  it("validates scheduled security bindings before opening any database handle", async () => {
+    snapshotEnv();
+    const worker = await freshWorker();
+    let waitUntilCalls = 0;
+    await expect(
+      worker.scheduled(
+        {},
+        {
+          NODE_ENV: "production",
+          STEWARD_JWT_SECRET: "short",
+          DATABASE_DRIVER: "bogus",
+          DATABASE_URL: "postgresql://credential-canary@worker.invalid/steward",
+        },
+        {
+          waitUntil() {
+            waitUntilCalls += 1;
+          },
+        },
+      ),
+    ).rejects.toThrow("at least 32 characters in production");
+    expect(waitUntilCalls).toBe(0);
+  });
 });

--- a/packages/api/src/__tests__/worker-runtime-sentinel.test.ts
+++ b/packages/api/src/__tests__/worker-runtime-sentinel.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { getDb } from "@stwd/db";
+import { getDb, registerRequestDatabaseTask } from "@stwd/db";
 import {
   hydrateProcessEnv,
   runWorkerGoogleCredentialLifecycleSweep,
@@ -88,6 +88,51 @@ test("Worker HTTP mode binds an exact request database without a persistent hand
   );
   expect(result).toBe("http");
   expect(created).toBe(0);
+});
+
+test("Worker waitUntil keeps the request database alive for registered background work", async () => {
+  const requestDb = { marker: "worker-background" } as unknown as ReturnType<typeof getDb>;
+  let closes = 0;
+  let deferredCleanup!: Promise<unknown>;
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  let background!: Promise<void>;
+
+  const result = await withWorkerRequestDatabase(
+    {
+      DATABASE_URL: "postgresql://worker.invalid/steward",
+      DATABASE_DRIVER: "neon-websocket",
+    },
+    async () => {
+      background = registerRequestDatabaseTask(
+        (async () => {
+          await gate;
+          expect(getDb()).toBe(requestDb);
+        })(),
+      );
+      return "response";
+    },
+    {
+      createHandle: () => ({
+        driver: "neon-websocket" as const,
+        db: requestDb as never,
+        async close() {
+          closes += 1;
+        },
+      }),
+      waitUntil(promise) {
+        deferredCleanup = promise;
+      },
+    },
+  );
+
+  expect(result).toBe("response");
+  expect(closes).toBe(0);
+  release();
+  await Promise.all([background, deferredCleanup]);
+  expect(closes).toBe(1);
 });
 
 test("Worker database selection rejects missing or unsupported drivers", async () => {

--- a/packages/api/src/__tests__/worker-runtime-sentinel.test.ts
+++ b/packages/api/src/__tests__/worker-runtime-sentinel.test.ts
@@ -106,12 +106,10 @@ test("Worker waitUntil keeps the request database alive for registered backgroun
       DATABASE_DRIVER: "neon-websocket",
     },
     async () => {
-      background = registerRequestDatabaseTask(
-        (async () => {
-          await gate;
-          expect(getDb()).toBe(requestDb);
-        })(),
-      );
+      background = registerRequestDatabaseTask(async () => {
+        await gate;
+        expect(getDb()).toBe(requestDb);
+      });
       return "response";
     },
     {

--- a/packages/api/src/services/audit.ts
+++ b/packages/api/src/services/audit.ts
@@ -23,6 +23,7 @@ import {
   appendAuditEventWithinTx,
   auditCheckpoints,
   getDb,
+  registerRequestDatabaseTask,
   withTenantAuditedTransaction,
   withTenantAuditQueue,
   writeAuditEvent,
@@ -218,12 +219,14 @@ function rowsFromExecute<T>(result: unknown): T[] {
  * a durable record.
  */
 export function trackAuditEvent(ev: AuditEventInput): Promise<void> {
-  return writeAuditEvent(ev).catch((err) => {
-    console.error(
-      `[audit] Failed to write event ${ev.action} for tenant ${ev.tenantId}`,
-      redactedThrownDiagnostics(err),
-    );
-  });
+  return registerRequestDatabaseTask(
+    writeAuditEvent(ev).catch((err) => {
+      console.error(
+        `[audit] Failed to write event ${ev.action} for tenant ${ev.tenantId}`,
+        redactedThrownDiagnostics(err),
+      );
+    }),
+  );
 }
 
 /**

--- a/packages/api/src/services/audit.ts
+++ b/packages/api/src/services/audit.ts
@@ -219,7 +219,7 @@ function rowsFromExecute<T>(result: unknown): T[] {
  * a durable record.
  */
 export function trackAuditEvent(ev: AuditEventInput): Promise<void> {
-  return registerRequestDatabaseTask(
+  return registerRequestDatabaseTask(() =>
     writeAuditEvent(ev).catch((err) => {
       console.error(
         `[audit] Failed to write event ${ev.action} for tenant ${ev.tenantId}`,

--- a/packages/api/src/services/webhook-dispatch.ts
+++ b/packages/api/src/services/webhook-dispatch.ts
@@ -51,7 +51,7 @@ export function dispatchWebhook(
     data: redactedData,
     timestamp: new Date(),
   };
-  void registerRequestDatabaseTask(
+  void registerRequestDatabaseTask(() =>
     dispatchConfiguredWebhooks(event, configuredType, isPluginEvent ? type : null).catch(
       (error) => {
         console.error(

--- a/packages/api/src/services/webhook-dispatch.ts
+++ b/packages/api/src/services/webhook-dispatch.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { and, eq, webhookConfigs, webhookDeliveries } from "@stwd/db";
+import { and, eq, registerRequestDatabaseTask, webhookConfigs, webhookDeliveries } from "@stwd/db";
 import { redactedThrownDiagnostics, type WebhookEvent } from "@stwd/shared";
 import {
   decryptWebhookSecret,
@@ -51,13 +51,15 @@ export function dispatchWebhook(
     data: redactedData,
     timestamp: new Date(),
   };
-  void dispatchConfiguredWebhooks(event, configuredType, isPluginEvent ? type : null).catch(
-    (error) => {
-      console.error(
-        "[webhooks] Failed to dispatch configured webhooks",
-        redactedThrownDiagnostics(error),
-      );
-    },
+  void registerRequestDatabaseTask(
+    dispatchConfiguredWebhooks(event, configuredType, isPluginEvent ? type : null).catch(
+      (error) => {
+        console.error(
+          "[webhooks] Failed to dispatch configured webhooks",
+          redactedThrownDiagnostics(error),
+        );
+      },
+    ),
   );
 
   // SEC-101: the unverifiable tenant-route webhookUrl field is retired. The

--- a/packages/api/src/worker.ts
+++ b/packages/api/src/worker.ts
@@ -112,6 +112,7 @@ export async function withWorkerRequestDatabase<T>(
   options?: {
     createHandle?: WorkerDatabaseHandleFactory;
     createHttpDb?: WorkerHttpDatabaseFactory;
+    waitUntil?: (promise: Promise<unknown>) => void;
   },
 ): Promise<T> {
   const driver = env.DATABASE_DRIVER?.trim().toLowerCase();
@@ -122,21 +123,46 @@ export async function withWorkerRequestDatabase<T>(
   }
   if (driver === "neon-http") {
     const db = (options?.createHttpDb ?? createDbForRequest)(env);
-    return withRequestDatabase(db as unknown as ReturnType<typeof getDb>, callback);
+    return withRequestDatabase(
+      db as unknown as ReturnType<typeof getDb>,
+      callback,
+      options?.waitUntil ? { deferCleanup: options.waitUntil } : undefined,
+    );
   }
   const handle = (options?.createHandle ?? createNeonTransactionDbForRequest)(env);
   const noCallbackError = Symbol("no-callback-error");
   let callbackError: unknown | typeof noCallbackError = noCallbackError;
   let result: T | undefined;
+  let closeDeferred = false;
   try {
-    result = await withRequestDatabase(handle.db as unknown as ReturnType<typeof getDb>, callback);
+    result = await withRequestDatabase(
+      handle.db as unknown as ReturnType<typeof getDb>,
+      callback,
+      options?.waitUntil
+        ? {
+            deferCleanup(cleanup) {
+              const deferredClose = cleanup.then(async () => {
+                try {
+                  await handle.close();
+                } catch {
+                  throw new Error("WORKER_DATABASE_CLOSE_FAILED");
+                }
+              });
+              options.waitUntil?.(deferredClose);
+              closeDeferred = true;
+            },
+          }
+        : undefined,
+    );
   } catch (error) {
     callbackError = error;
   }
-  try {
-    await handle.close();
-  } catch {
-    if (callbackError === noCallbackError) throw new Error("WORKER_DATABASE_CLOSE_FAILED");
+  if (!closeDeferred) {
+    try {
+      await handle.close();
+    } catch {
+      if (callbackError === noCallbackError) throw new Error("WORKER_DATABASE_CLOSE_FAILED");
+    }
   }
   if (callbackError !== noCallbackError) throw callbackError;
   return result as T;
@@ -349,17 +375,28 @@ export default {
     // the once-per-isolate init below only bootstraps stores/imports.
     hydrateProcessEnv(env);
     await validateWorkerSecurityEnv();
-    return withWorkerRequestDatabase(env, async () => {
-      await ensureWorkerInit(env);
-      const app = await getComposedApp();
-      return app.fetch(request, env, ctx as never);
-    });
+    const executionCtx = ctx as { waitUntil?: (promise: Promise<unknown>) => void };
+    const waitUntil =
+      typeof executionCtx?.waitUntil === "function"
+        ? executionCtx.waitUntil.bind(executionCtx)
+        : undefined;
+    return withWorkerRequestDatabase(
+      env,
+      async () => {
+        await ensureWorkerInit(env);
+        const app = await getComposedApp();
+        return app.fetch(request, env, ctx as never);
+      },
+      waitUntil ? { waitUntil } : undefined,
+    );
   },
   async scheduled(
     _controller: unknown,
     env: Env,
     ctx: { waitUntil(promise: Promise<unknown>): void },
   ) {
+    hydrateProcessEnv(env);
+    await validateWorkerSecurityEnv();
     ctx.waitUntil(
       Promise.all([
         withWorkerRequestDatabase(env, () => runWorkerUpstreamCredentialLeaseSweep(env)),

--- a/packages/db/src/__tests__/request-database-context.test.ts
+++ b/packages/db/src/__tests__/request-database-context.test.ts
@@ -98,12 +98,10 @@ describe("request-scoped database context", () => {
     const result = await withRequestDatabase(
       requestDb,
       async () => {
-        background = registerRequestDatabaseTask(
-          (async () => {
-            await release.promise;
-            expect(getDb()).toBe(requestDb);
-          })(),
-        );
+        background = registerRequestDatabaseTask(async () => {
+          await release.promise;
+          expect(getDb()).toBe(requestDb);
+        });
         return "response";
       },
       {
@@ -123,5 +121,35 @@ describe("request-scoped database context", () => {
     release.resolve();
     await Promise.all([background, cleanup]);
     expect(cleaned).toBe(true);
+  });
+
+  test("does not let unregistered work piggyback on a registered task lifetime", async () => {
+    const requestDb = { marker: "request" } as unknown as ReturnType<typeof getDb>;
+    const release = deferred();
+    let cleanup!: Promise<void>;
+    let registered!: Promise<void>;
+    let detached!: Promise<void>;
+
+    await withRequestDatabase(
+      requestDb,
+      async () => {
+        registered = registerRequestDatabaseTask(async () => {
+          await release.promise;
+          expect(getDb()).toBe(requestDb);
+        });
+        detached = (async () => {
+          await release.promise;
+          expect(() => getDb()).toThrow("REQUEST_DATABASE_CONTEXT_CLOSED");
+        })();
+      },
+      {
+        deferCleanup(promise) {
+          cleanup = promise;
+        },
+      },
+    );
+
+    release.resolve();
+    await Promise.all([registered, detached, cleanup]);
   });
 });

--- a/packages/db/src/__tests__/request-database-context.test.ts
+++ b/packages/db/src/__tests__/request-database-context.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { closeDb, getDb, getSql, withRequestDatabase } from "../client";
+import {
+  closeDb,
+  getDb,
+  getSql,
+  registerRequestDatabaseTask,
+  withRequestDatabase,
+} from "../client";
 
 const originalDriver = process.env.DATABASE_DRIVER;
 
@@ -81,5 +87,41 @@ describe("request-scoped database context", () => {
     });
     release.resolve();
     await detached;
+  });
+
+  test("defers revocation until registered background database work settles", async () => {
+    const requestDb = { marker: "request" } as unknown as ReturnType<typeof getDb>;
+    const release = deferred();
+    let cleanup!: Promise<void>;
+    let background!: Promise<void>;
+
+    const result = await withRequestDatabase(
+      requestDb,
+      async () => {
+        background = registerRequestDatabaseTask(
+          (async () => {
+            await release.promise;
+            expect(getDb()).toBe(requestDb);
+          })(),
+        );
+        return "response";
+      },
+      {
+        deferCleanup(promise) {
+          cleanup = promise;
+        },
+      },
+    );
+
+    expect(result).toBe("response");
+    let cleaned = false;
+    void cleanup.then(() => {
+      cleaned = true;
+    });
+    await Promise.resolve();
+    expect(cleaned).toBe(false);
+    release.resolve();
+    await Promise.all([background, cleanup]);
+    expect(cleaned).toBe(true);
   });
 });

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -480,8 +480,39 @@ type RequestDatabase = ReturnType<typeof createDb>["db"];
 interface RequestDatabaseContext {
   db: RequestDatabase | undefined;
   active: boolean;
+  backgroundTasks: Set<Promise<void>>;
 }
 const requestDatabaseStorage = new AsyncLocalStorage<RequestDatabaseContext>();
+
+async function drainRequestDatabaseTasks(context: RequestDatabaseContext): Promise<void> {
+  while (context.backgroundTasks.size > 0) {
+    await Promise.allSettled([...context.backgroundTasks]);
+  }
+}
+
+/**
+ * Keep a request-owned database capability alive for explicitly registered
+ * background work. Worker entry points hand the resulting drain promise to
+ * `waitUntil`, so the response may return without closing a WebSocket pool out
+ * from under webhook/audit writes. Outside a request context this is a no-op.
+ */
+export function registerRequestDatabaseTask<T>(task: Promise<T>): Promise<T> {
+  const context = requestDatabaseStorage.getStore();
+  if (!context) return task;
+  if (!context.active) return Promise.reject(new Error("REQUEST_DATABASE_CONTEXT_CLOSED"));
+
+  let tracked!: Promise<void>;
+  tracked = Promise.resolve(task)
+    .then(
+      () => undefined,
+      () => undefined,
+    )
+    .finally(() => {
+      context.backgroundTasks.delete(tracked);
+    });
+  context.backgroundTasks.add(tracked);
+  return task;
+}
 
 /**
  * Bind one explicitly owned database handle to the current async request.
@@ -495,19 +526,43 @@ const requestDatabaseStorage = new AsyncLocalStorage<RequestDatabaseContext>();
 export async function withRequestDatabase<T>(
   db: RequestDatabase,
   callback: () => Promise<T>,
+  options?: { deferCleanup?: (cleanup: Promise<void>) => void },
 ): Promise<T> {
   if (requestDatabaseStorage.getStore()) {
     throw new Error("REQUEST_DATABASE_CONTEXT_NESTED");
   }
-  const context: RequestDatabaseContext = { db, active: true };
-  try {
-    return await requestDatabaseStorage.run(context, callback);
-  } finally {
-    // Detached tasks inherit AsyncLocalStorage. Revoke their capability before
-    // the owning Worker closes its socket so late getDb() calls fail before I/O.
-    context.active = false;
-    context.db = undefined;
-  }
+  const context: RequestDatabaseContext = { db, active: true, backgroundTasks: new Set() };
+  return requestDatabaseStorage.run(context, async () => {
+    const noCallbackError = Symbol("no-callback-error");
+    let callbackError: unknown | typeof noCallbackError = noCallbackError;
+    let result: T | undefined;
+    try {
+      result = await callback();
+    } catch (error) {
+      callbackError = error;
+    }
+
+    const cleanup = drainRequestDatabaseTasks(context).finally(() => {
+      // Unregistered detached tasks still inherit AsyncLocalStorage. Revoke
+      // their capability before the owning Worker closes its socket so late
+      // getDb() calls fail before I/O.
+      context.active = false;
+      context.db = undefined;
+    });
+    if (options?.deferCleanup) {
+      try {
+        options.deferCleanup(cleanup);
+      } catch (error) {
+        await cleanup;
+        if (callbackError === noCallbackError) throw error;
+      }
+    } else {
+      await cleanup;
+    }
+
+    if (callbackError !== noCallbackError) throw callbackError;
+    return result as T;
+  });
 }
 
 // ─── Global singleton ─────────────────────────────────────────────────────────

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -496,22 +496,30 @@ async function drainRequestDatabaseTasks(context: RequestDatabaseContext): Promi
  * `waitUntil`, so the response may return without closing a WebSocket pool out
  * from under webhook/audit writes. Outside a request context this is a no-op.
  */
-export function registerRequestDatabaseTask<T>(task: Promise<T>): Promise<T> {
+export function registerRequestDatabaseTask<T>(task: () => Promise<T>): Promise<T> {
   const context = requestDatabaseStorage.getStore();
-  if (!context) return task;
+  if (!context) return task();
   if (!context.active) return Promise.reject(new Error("REQUEST_DATABASE_CONTEXT_CLOSED"));
 
+  const backgroundContext: RequestDatabaseContext = {
+    db: context.db,
+    active: true,
+    backgroundTasks: context.backgroundTasks,
+  };
+  const promise = requestDatabaseStorage.run(backgroundContext, async () => task());
   let tracked!: Promise<void>;
-  tracked = Promise.resolve(task)
+  tracked = promise
     .then(
       () => undefined,
       () => undefined,
     )
     .finally(() => {
+      backgroundContext.active = false;
+      backgroundContext.db = undefined;
       context.backgroundTasks.delete(tracked);
     });
   context.backgroundTasks.add(tracked);
-  return task;
+  return promise;
 }
 
 /**
@@ -542,13 +550,12 @@ export async function withRequestDatabase<T>(
       callbackError = error;
     }
 
-    const cleanup = drainRequestDatabaseTasks(context).finally(() => {
-      // Unregistered detached tasks still inherit AsyncLocalStorage. Revoke
-      // their capability before the owning Worker closes its socket so late
-      // getDb() calls fail before I/O.
-      context.active = false;
-      context.db = undefined;
-    });
+    // Revoke the owner context as soon as its callback settles. Registered
+    // tasks run in child contexts with their own bounded capability lifetime;
+    // unregistered detached work retains this revoked owner context.
+    context.active = false;
+    context.db = undefined;
+    const cleanup = drainRequestDatabaseTasks(context);
     if (options?.deferCleanup) {
       try {
         options.deferCleanup(cleanup);

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -35,6 +35,7 @@ export {
   getDatabaseUrl,
   getDb,
   getSql,
+  registerRequestDatabaseTask,
   setPGLiteOverride,
   withDatabaseDeadline,
   withRequestDatabase,


### PR DESCRIPTION
## Security corrective

Post-merge audit of #460 found that request DB capability was revoked immediately after `app.fetch()` resolved, while existing webhook and best-effort audit paths intentionally start DB-backed work without awaiting it. On Workers this could drop webhook deliveries and token-expiry audit telemetry with `REQUEST_DATABASE_CONTEXT_CLOSED`; the WebSocket driver could also close the pool underneath that work.

This corrective:
- adds explicit request DB background-task registration;
- hands the bounded drain/close promise to Worker `waitUntil`, so responses remain non-blocking while the capability stays valid only for registered work;
- registers all configured-webhook dispatches and best-effort audit writes;
- preserves immediate revocation for unregistered detached work;
- validates cron security bindings before opening any of its three DB handles.

Regression evidence on exact head `be8934eee56d076729eb8ca9a2567452bb5976d2` / base `ce5eabd26950ae13cf7a617b33d2c7061eef9a2b`:
- request DB + Worker lifecycle + boot security: 21/21, 55 assertions;
- direct API typecheck: pass;
- dependency-aware API graph: 24/24 builds (on the immediately preceding current-develop aggregate; the final base-only auth delta is covered by exact API typecheck);
- Biome and diff-check: pass.

Keep draft until exact-head hosted CI is green.