### PR TITLE
feat(db): bind EVM nonce state to tenant ownership

### DIFF
--- a/docs/security/database-rls-rollout.mdx
+++ b/docs/security/database-rls-rollout.mdx
@@ -85,9 +85,11 @@ a Drizzle table is added without classification.
   reputation cache, and archive chunks) use an `EXISTS` policy through their
   tenant-owned parent. Parent indexes and immutable ownership constraints are
   activation prerequisites.
-- EVM nonce tables cannot safely infer a tenant from wallet address because an
-  address is not tenant-unique. Add and backfill `tenant_id` plus a composite
-  ownership foreign key before enabling their policies.
+- EVM nonce counters are tenant-scoped and reference the globally unique
+  `(wallet_address, chain_id)` claim in `evm_wallet_nonce_owners`. Migration
+  `0108` backfills only namespaces that resolve to exactly one tenant and fails
+  closed on missing or ambiguous legacy ownership; the claim prevents two
+  tenants from allocating the same on-chain nonce independently.
 - `user_push_subscriptions` has intentionally nullable `tenant_id`. Tenant
   subscriptions and global user subscriptions require separate, explicit
   policies; it must not inherit the uniform direct-table policy generator.

--- a/packages/db/drizzle/0108_evm_nonce_tenant_ownership.sql
+++ b/packages/db/drizzle/0108_evm_nonce_tenant_ownership.sql
@@ -1,0 +1,106 @@
+CREATE TABLE "evm_wallet_nonce_owners" (
+  "tenant_id" varchar(64) NOT NULL REFERENCES "tenants"("id") ON DELETE cascade,
+  "wallet_address" varchar(42) NOT NULL,
+  "chain_id" integer NOT NULL,
+  "claimed_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "evm_wallet_nonce_owners_pkey" PRIMARY KEY ("wallet_address", "chain_id"),
+  CONSTRAINT "evm_wallet_nonce_owners_address_chk"
+    CHECK ("wallet_address" ~ '^0x[0-9a-f]{40}$')
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "evm_wallet_nonce_owners_tenant_key_idx"
+  ON "evm_wallet_nonce_owners" ("tenant_id", "wallet_address", "chain_id");
+--> statement-breakpoint
+ALTER TABLE "evm_wallet_nonces" ADD COLUMN "tenant_id" varchar(64);
+--> statement-breakpoint
+ALTER TABLE "evm_wallet_nonce_inflight" ADD COLUMN "tenant_id" varchar(64);
+--> statement-breakpoint
+UPDATE "evm_wallet_nonces" SET "wallet_address" = lower("wallet_address");
+--> statement-breakpoint
+UPDATE "evm_wallet_nonce_inflight" SET "wallet_address" = lower("wallet_address");
+--> statement-breakpoint
+CREATE TEMP TABLE "steward_nonce_owner_resolution" AS
+WITH namespaces AS (
+  SELECT "wallet_address", "chain_id" FROM "evm_wallet_nonces"
+  UNION
+  SELECT "wallet_address", "chain_id" FROM "evm_wallet_nonce_inflight"
+), candidate_tenants AS (
+  SELECT n."wallet_address", n."chain_id", a."tenant_id"
+  FROM namespaces n
+  JOIN "agents" a ON lower(a."wallet_address") = n."wallet_address"
+  WHERE lower(a."wallet_address") ~ '^0x[0-9a-f]{40}$'
+  UNION
+  SELECT n."wallet_address", n."chain_id", a."tenant_id"
+  FROM namespaces n
+  JOIN "agent_wallets" w
+    ON w."chain_family" = 'evm' AND lower(w."address") = n."wallet_address"
+  JOIN "agents" a ON a."id" = w."agent_id"
+)
+SELECT
+  n."wallet_address",
+  n."chain_id",
+  min(c."tenant_id") AS "tenant_id",
+  count(DISTINCT c."tenant_id") AS "tenant_count"
+FROM namespaces n
+LEFT JOIN candidate_tenants c
+  ON c."wallet_address" = n."wallet_address" AND c."chain_id" = n."chain_id"
+GROUP BY n."wallet_address", n."chain_id";
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM "steward_nonce_owner_resolution" WHERE "tenant_count" <> 1
+  ) THEN
+    RAISE EXCEPTION
+      'EVM nonce tenant backfill requires exactly one tenant owner per wallet/chain namespace';
+  END IF;
+END
+$$;
+--> statement-breakpoint
+UPDATE "evm_wallet_nonces" n
+SET "tenant_id" = r."tenant_id"
+FROM "steward_nonce_owner_resolution" r
+WHERE r."wallet_address" = n."wallet_address" AND r."chain_id" = n."chain_id";
+--> statement-breakpoint
+UPDATE "evm_wallet_nonce_inflight" n
+SET "tenant_id" = r."tenant_id"
+FROM "steward_nonce_owner_resolution" r
+WHERE r."wallet_address" = n."wallet_address" AND r."chain_id" = n."chain_id";
+--> statement-breakpoint
+INSERT INTO "evm_wallet_nonce_owners" ("tenant_id", "wallet_address", "chain_id")
+SELECT "tenant_id", "wallet_address", "chain_id"
+FROM "steward_nonce_owner_resolution";
+--> statement-breakpoint
+ALTER TABLE "evm_wallet_nonces" ALTER COLUMN "tenant_id" SET NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "evm_wallet_nonce_inflight" ALTER COLUMN "tenant_id" SET NOT NULL;
+--> statement-breakpoint
+DROP INDEX "evm_wallet_nonces_wallet_chain_idx";
+--> statement-breakpoint
+CREATE UNIQUE INDEX "evm_wallet_nonces_wallet_chain_idx"
+  ON "evm_wallet_nonces" ("tenant_id", "wallet_address", "chain_id");
+--> statement-breakpoint
+DROP INDEX "evm_wallet_nonce_inflight_key_idx";
+--> statement-breakpoint
+CREATE UNIQUE INDEX "evm_wallet_nonce_inflight_key_idx"
+  ON "evm_wallet_nonce_inflight" ("tenant_id", "wallet_address", "chain_id", "nonce");
+--> statement-breakpoint
+DROP INDEX "evm_wallet_nonce_inflight_reclaim_idx";
+--> statement-breakpoint
+CREATE INDEX "evm_wallet_nonce_inflight_reclaim_idx"
+  ON "evm_wallet_nonce_inflight"
+  ("tenant_id", "wallet_address", "chain_id", "state", "nonce");
+--> statement-breakpoint
+ALTER TABLE "evm_wallet_nonces"
+  ADD CONSTRAINT "evm_wallet_nonces_owner_fk"
+  FOREIGN KEY ("tenant_id", "wallet_address", "chain_id")
+  REFERENCES "evm_wallet_nonce_owners" ("tenant_id", "wallet_address", "chain_id")
+  ON DELETE cascade;
+--> statement-breakpoint
+ALTER TABLE "evm_wallet_nonce_inflight"
+  ADD CONSTRAINT "evm_wallet_nonce_inflight_owner_fk"
+  FOREIGN KEY ("tenant_id", "wallet_address", "chain_id")
+  REFERENCES "evm_wallet_nonce_owners" ("tenant_id", "wallet_address", "chain_id")
+  ON DELETE cascade;
+--> statement-breakpoint
+DROP TABLE "steward_nonce_owner_resolution";

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -617,6 +617,13 @@
       "when": 1787111201000,
       "tag": "0107_x_disconnect_route_recovery",
       "breakpoints": true
+    },
+    {
+      "idx": 108,
+      "version": "7",
+      "when": 1787111202000,
+      "tag": "0108_evm_nonce_tenant_ownership",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/__tests__/evm-nonce-tenant-ownership-migration.test.ts
+++ b/packages/db/src/__tests__/evm-nonce-tenant-ownership-migration.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, setDefaultTimeout, test } from "bun:test";
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { PGlite } from "@electric-sql/pglite";
+
+setDefaultTimeout(120_000);
+const migrations = new URL("../../drizzle", import.meta.url).pathname;
+const migrationUnderTest = "0108_evm_nonce_tenant_ownership.sql";
+
+async function applyMigration(client: PGlite, file: string) {
+  const migration = await readFile(join(migrations, file), "utf8");
+  for (const statement of migration.split("--> statement-breakpoint")) {
+    if (statement.trim()) await client.exec(statement);
+  }
+}
+
+async function applyBeforeMigration(client: PGlite) {
+  const files = (await readdir(migrations)).filter((file) => file.endsWith(".sql")).sort();
+  for (const file of files) {
+    if (file === migrationUnderTest) break;
+    await applyMigration(client, file);
+  }
+}
+
+describe("0108 EVM nonce tenant ownership", () => {
+  test("is journal-contiguous after X disconnect recovery", async () => {
+    const journal = JSON.parse(
+      await readFile(join(migrations, "meta", "_journal.json"), "utf8"),
+    ) as { entries: Array<{ idx: number; tag: string }> };
+    expect(journal.entries.slice(-2).map(({ idx, tag }) => ({ idx, tag }))).toEqual([
+      { idx: 107, tag: "0107_x_disconnect_route_recovery" },
+      { idx: 108, tag: "0108_evm_nonce_tenant_ownership" },
+    ]);
+  });
+
+  test("backfills an unambiguous owner and enforces the cross-tenant claim", async () => {
+    const client = new PGlite("memory://");
+    try {
+      await applyBeforeMigration(client);
+      await client.exec(`
+        INSERT INTO tenants(id,name,api_key_hash) VALUES
+          ('nonce-owner-a','A','nonce-owner-a-hash'),
+          ('nonce-owner-b','B','nonce-owner-b-hash');
+        INSERT INTO agents(id,tenant_id,name,wallet_address) VALUES
+          ('nonce-agent-a','nonce-owner-a','A','0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA');
+        INSERT INTO evm_wallet_nonces(wallet_address,chain_id,next_nonce)
+          VALUES ('0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',8453,12);
+        INSERT INTO evm_wallet_nonce_inflight(wallet_address,chain_id,nonce,state)
+          VALUES ('0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',8453,11,'allocated');
+      `);
+
+      await applyMigration(client, migrationUnderTest);
+      const rows = await client.query<{ tenant_id: string; wallet_address: string }>(`
+        SELECT tenant_id,wallet_address FROM evm_wallet_nonces
+      `);
+      expect(rows.rows).toEqual([
+        {
+          tenant_id: "nonce-owner-a",
+          wallet_address: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        },
+      ]);
+
+      await expect(
+        client.exec(`
+          INSERT INTO evm_wallet_nonce_owners(tenant_id,wallet_address,chain_id)
+          VALUES ('nonce-owner-b','0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',8453)
+        `),
+      ).rejects.toBeDefined();
+      await expect(
+        client.exec(`
+          INSERT INTO evm_wallet_nonces(tenant_id,wallet_address,chain_id,next_nonce)
+          VALUES ('nonce-owner-b','0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',8453,13)
+        `),
+      ).rejects.toBeDefined();
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("fails closed when legacy ownership is ambiguous or missing", async () => {
+    for (const scenario of ["ambiguous", "missing"] as const) {
+      const client = new PGlite("memory://");
+      try {
+        await applyBeforeMigration(client);
+        await client.exec(`
+          INSERT INTO tenants(id,name,api_key_hash) VALUES
+            ('nonce-${scenario}-a','A','nonce-${scenario}-a-hash'),
+            ('nonce-${scenario}-b','B','nonce-${scenario}-b-hash');
+        `);
+        if (scenario === "ambiguous") {
+          await client.exec(`
+            INSERT INTO agents(id,tenant_id,name,wallet_address) VALUES
+              ('nonce-ambiguous-agent-a','nonce-ambiguous-a','A',
+               '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'),
+              ('nonce-ambiguous-agent-b','nonce-ambiguous-b','B',
+               '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
+          `);
+        }
+        await client.exec(`
+          INSERT INTO evm_wallet_nonces(wallet_address,chain_id,next_nonce)
+          VALUES ('0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',1,2)
+        `);
+
+        await expect(applyMigration(client, migrationUnderTest)).rejects.toThrow(
+          "requires exactly one tenant owner",
+        );
+      } finally {
+        await client.close();
+      }
+    }
+  });
+});

--- a/packages/db/src/rls-inventory.ts
+++ b/packages/db/src/rls-inventory.ts
@@ -20,6 +20,9 @@ export const DIRECT_TENANT_TABLES = [
   "digital_asset_account_aggregations",
   "digital_asset_account_wallets",
   "digital_asset_accounts",
+  "evm_wallet_nonce_inflight",
+  "evm_wallet_nonce_owners",
+  "evm_wallet_nonces",
   "execution_authorization_nonces",
   "global_wallet_action_confirmations",
   "intents",
@@ -74,12 +77,7 @@ export const INDIRECT_TENANT_TABLES = {
   transactions: "EXISTS agents(id = agent_id AND tenant_id = current tenant)",
 } as const;
 
-export const TENANT_COLUMN_BACKFILL_TABLES = {
-  evm_wallet_nonce_inflight:
-    "wallet addresses are not tenant-unique; add tenant_id and a composite ownership FK before RLS",
-  evm_wallet_nonces:
-    "wallet addresses are not tenant-unique; add tenant_id and a composite ownership FK before RLS",
-} as const;
+export const TENANT_COLUMN_BACKFILL_TABLES = {} as const;
 
 export const HYBRID_SCOPE_TABLES = {
   approval_queue:

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -557,9 +557,40 @@ export const vaultSigningFreezes = pgTable(
   }),
 );
 
+/**
+ * Globally claims an EVM (address, chain) nonce namespace for exactly one
+ * tenant. The counter itself is tenant-scoped for RLS, while this claim keeps
+ * duplicate custody of the same address in two tenants from allocating the
+ * same on-chain nonce independently.
+ */
+export const evmWalletNonceOwners = pgTable(
+  "evm_wallet_nonce_owners",
+  {
+    tenantId: varchar("tenant_id", { length: 64 })
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    walletAddress: varchar("wallet_address", { length: 42 }).notNull(),
+    chainId: integer("chain_id").notNull(),
+    claimedAt: timestamp("claimed_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    key: primaryKey({ columns: [table.walletAddress, table.chainId] }),
+    tenantWalletChainUniqueIdx: uniqueIndex("evm_wallet_nonce_owners_tenant_key_idx").on(
+      table.tenantId,
+      table.walletAddress,
+      table.chainId,
+    ),
+    addressCheck: check(
+      "evm_wallet_nonce_owners_address_chk",
+      sql`${table.walletAddress} ~ '^0x[0-9a-f]{40}$'`,
+    ),
+  }),
+);
+
 export const evmWalletNonces = pgTable(
   "evm_wallet_nonces",
   {
+    tenantId: varchar("tenant_id", { length: 64 }).notNull(),
     walletAddress: varchar("wallet_address", { length: 42 }).notNull(),
     chainId: integer("chain_id").notNull(),
     nextNonce: bigint("next_nonce", { mode: "number" }).notNull(),
@@ -570,9 +601,19 @@ export const evmWalletNonces = pgTable(
   },
   (table) => ({
     walletChainUniqueIdx: uniqueIndex("evm_wallet_nonces_wallet_chain_idx").on(
+      table.tenantId,
       table.walletAddress,
       table.chainId,
     ),
+    ownerFk: foreignKey({
+      columns: [table.tenantId, table.walletAddress, table.chainId],
+      foreignColumns: [
+        evmWalletNonceOwners.tenantId,
+        evmWalletNonceOwners.walletAddress,
+        evmWalletNonceOwners.chainId,
+      ],
+      name: "evm_wallet_nonces_owner_fk",
+    }).onDelete("cascade"),
   }),
 );
 
@@ -586,6 +627,7 @@ export const evmWalletNonces = pgTable(
 export const evmWalletNonceInflight = pgTable(
   "evm_wallet_nonce_inflight",
   {
+    tenantId: varchar("tenant_id", { length: 64 }).notNull(),
     walletAddress: varchar("wallet_address", { length: 42 }).notNull(),
     chainId: integer("chain_id").notNull(),
     nonce: bigint("nonce", { mode: "number" }).notNull(),
@@ -598,16 +640,27 @@ export const evmWalletNonceInflight = pgTable(
   },
   (table) => ({
     walletChainNonceUniqueIdx: uniqueIndex("evm_wallet_nonce_inflight_key_idx").on(
+      table.tenantId,
       table.walletAddress,
       table.chainId,
       table.nonce,
     ),
     reclaimIdx: index("evm_wallet_nonce_inflight_reclaim_idx").on(
+      table.tenantId,
       table.walletAddress,
       table.chainId,
       table.state,
       table.nonce,
     ),
+    ownerFk: foreignKey({
+      columns: [table.tenantId, table.walletAddress, table.chainId],
+      foreignColumns: [
+        evmWalletNonceOwners.tenantId,
+        evmWalletNonceOwners.walletAddress,
+        evmWalletNonceOwners.chainId,
+      ],
+      name: "evm_wallet_nonce_inflight_owner_fk",
+    }).onDelete("cascade"),
   }),
 );
 

--- a/packages/vault/src/__tests__/evm-nonce-manager.test.ts
+++ b/packages/vault/src/__tests__/evm-nonce-manager.test.ts
@@ -1,11 +1,21 @@
 import { afterAll, beforeEach, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { and, eq, evmWalletNonceInflight, evmWalletNonces, getDb } from "@stwd/db";
+import {
+  and,
+  eq,
+  evmWalletNonceInflight,
+  evmWalletNonceOwners,
+  evmWalletNonces,
+  getDb,
+  tenants,
+} from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { allocateEvmNonce, confirmEvmNonce, markEvmNonceDropped } from "../evm-nonce-manager";
 
 setDefaultTimeout(30000);
 
 const openClients: Array<{ close: () => Promise<void> }> = [];
+const TENANT_A = "evm-nonce-tenant-a";
+const TENANT_B = "evm-nonce-tenant-b";
 
 async function resetDb(): Promise<void> {
   process.env.STEWARD_PGLITE_MEMORY = "true";
@@ -14,6 +24,12 @@ async function resetDb(): Promise<void> {
   setPGLiteOverride(db as never, async () => {
     await client.close();
   });
+  await getDb()
+    .insert(tenants)
+    .values([
+      { id: TENANT_A, name: "Nonce tenant A", apiKeyHash: "nonce-tenant-a-hash" },
+      { id: TENANT_B, name: "Nonce tenant B", apiKeyHash: "nonce-tenant-b-hash" },
+    ]);
 }
 
 describe("EVM nonce manager", () => {
@@ -34,6 +50,7 @@ describe("EVM nonce manager", () => {
     const allocations = await Promise.all(
       Array.from({ length: 8 }, () =>
         allocateEvmNonce({
+          tenantId: TENANT_A,
           walletAddress,
           chainId: 8453,
           getPendingNonce: async () => 7,
@@ -48,7 +65,13 @@ describe("EVM nonce manager", () => {
 
   test("advances from max(stored next nonce, pending RPC nonce)", async () => {
     const walletAddress = "0x2222222222222222222222222222222222222222";
+    await getDb().insert(evmWalletNonceOwners).values({
+      tenantId: TENANT_A,
+      walletAddress,
+      chainId: 1,
+    });
     await getDb().insert(evmWalletNonces).values({
+      tenantId: TENANT_A,
       walletAddress,
       chainId: 1,
       nextNonce: 3,
@@ -56,6 +79,7 @@ describe("EVM nonce manager", () => {
     });
 
     const nonce = await allocateEvmNonce({
+      tenantId: TENANT_A,
       walletAddress,
       chainId: 1,
       getPendingNonce: async () => 10,
@@ -72,6 +96,7 @@ describe("EVM nonce manager", () => {
     for (let i = 0; i < 5; i++) {
       nonces.push(
         await allocateEvmNonce({
+          tenantId: TENANT_A,
           walletAddress,
           chainId: 137,
           getPendingNonce: async () => 0,
@@ -90,6 +115,7 @@ describe("EVM nonce manager", () => {
     // (wallet, chain) allocator and must receive distinct nonces.
     const agentAllocate = (_agentId: string) =>
       allocateEvmNonce({
+        tenantId: TENANT_A,
         walletAddress,
         chainId: 8453,
         getPendingNonce: async () => 0,
@@ -106,7 +132,12 @@ describe("EVM nonce manager", () => {
     const walletAddress = "0x5555555555555555555555555555555555555555";
     const chainId = 8453;
     const alloc = () =>
-      allocateEvmNonce({ walletAddress, chainId, getPendingNonce: async () => 5 });
+      allocateEvmNonce({
+        tenantId: TENANT_A,
+        walletAddress,
+        chainId,
+        getPendingNonce: async () => 5,
+      });
 
     const n0 = await alloc(); // 5
     const n1 = await alloc(); // 6
@@ -114,7 +145,12 @@ describe("EVM nonce manager", () => {
     expect([n0, n1, n2]).toEqual([5, 6, 7]);
 
     // The middle tx fails -> its nonce becomes reclaimable.
-    await markEvmNonceDropped({ walletAddress, chainId, nonce: 6 });
+    await markEvmNonceDropped({
+      tenantId: TENANT_A,
+      walletAddress,
+      chainId,
+      nonce: 6,
+    });
 
     // Next allocation must reuse 6 (>= pending), not advance to 8.
     const reclaimed = await alloc();
@@ -133,14 +169,19 @@ describe("EVM nonce manager", () => {
     const walletAddress = "0x6666666666666666666666666666666666666666";
     const chainId = 1;
     const alloc = () =>
-      allocateEvmNonce({ walletAddress, chainId, getPendingNonce: async () => 0 });
+      allocateEvmNonce({
+        tenantId: TENANT_A,
+        walletAddress,
+        chainId,
+        getPendingNonce: async () => 0,
+      });
 
     const n0 = await alloc(); // 0
     await alloc(); // 1
     expect(n0).toBe(0);
 
     // Confirm 0 (success) -> removed from in-flight, not reclaimable.
-    await confirmEvmNonce({ walletAddress, chainId, nonce: 0 });
+    await confirmEvmNonce({ tenantId: TENANT_A, walletAddress, chainId, nonce: 0 });
     const remaining = await getDb()
       .select()
       .from(evmWalletNonceInflight)
@@ -155,5 +196,51 @@ describe("EVM nonce manager", () => {
     // Next allocation advances monotonically; the confirmed 0 is never reused.
     const next = await alloc();
     expect(next).toBe(2);
+  });
+
+  test("fails closed when another tenant already owns the wallet nonce namespace", async () => {
+    const walletAddress = "0x7777777777777777777777777777777777777777";
+    const first = await allocateEvmNonce({
+      tenantId: TENANT_A,
+      walletAddress,
+      chainId: 8453,
+      getPendingNonce: async () => 2,
+    });
+    expect(first).toBe(2);
+
+    await expect(
+      allocateEvmNonce({
+        tenantId: TENANT_B,
+        walletAddress,
+        chainId: 8453,
+        getPendingNonce: async () => 2,
+      }),
+    ).rejects.toThrow("not owned by this tenant");
+
+    const owners = await getDb().select().from(evmWalletNonceOwners);
+    expect(owners).toHaveLength(1);
+    expect(owners[0]?.tenantId).toBe(TENANT_A);
+    const counters = await getDb().select().from(evmWalletNonces);
+    expect(counters).toHaveLength(1);
+    expect(counters[0]?.nextNonce).toBe(3);
+  });
+
+  test("allows the same address on a different chain to have a different tenant owner", async () => {
+    const walletAddress = "0x8888888888888888888888888888888888888888";
+    const [baseNonce, mainnetNonce] = await Promise.all([
+      allocateEvmNonce({
+        tenantId: TENANT_A,
+        walletAddress,
+        chainId: 8453,
+        getPendingNonce: async () => 0,
+      }),
+      allocateEvmNonce({
+        tenantId: TENANT_B,
+        walletAddress,
+        chainId: 1,
+        getPendingNonce: async () => 9,
+      }),
+    ]);
+    expect([baseNonce, mainnetNonce]).toEqual([0, 9]);
   });
 });

--- a/packages/vault/src/__tests__/evm-nonce-manager.test.ts
+++ b/packages/vault/src/__tests__/evm-nonce-manager.test.ts
@@ -225,6 +225,90 @@ describe("EVM nonce manager", () => {
     expect(counters[0]?.nextNonce).toBe(3);
   });
 
+  test("serializes simultaneous cross-tenant claims so exactly one tenant owns the namespace", async () => {
+    const walletAddress = "0x9999999999999999999999999999999999999999";
+    const results = await Promise.allSettled([
+      allocateEvmNonce({
+        tenantId: TENANT_A,
+        walletAddress,
+        chainId: 8453,
+        getPendingNonce: async () => 4,
+      }),
+      allocateEvmNonce({
+        tenantId: TENANT_B,
+        walletAddress,
+        chainId: 8453,
+        getPendingNonce: async () => 4,
+      }),
+    ]);
+
+    expect(results.filter(({ status }) => status === "fulfilled")).toHaveLength(1);
+    expect(results.filter(({ status }) => status === "rejected")).toHaveLength(1);
+    const [owner] = await getDb().select().from(evmWalletNonceOwners);
+    expect(owner?.tenantId).toBe(TENANT_A);
+    const [counter] = await getDb().select().from(evmWalletNonces);
+    expect(counter?.tenantId).toBe(TENANT_A);
+    expect(counter?.nextNonce).toBe(5);
+  });
+
+  test("wrong-tenant drop and confirmation cannot mutate the owner's in-flight nonce", async () => {
+    const walletAddress = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const chainId = 8453;
+    const nonce = await allocateEvmNonce({
+      tenantId: TENANT_A,
+      walletAddress,
+      chainId,
+      getPendingNonce: async () => 4,
+    });
+
+    await markEvmNonceDropped({
+      tenantId: TENANT_B,
+      walletAddress,
+      chainId,
+      nonce,
+    });
+    await confirmEvmNonce({
+      tenantId: TENANT_B,
+      walletAddress,
+      chainId,
+      nonce,
+    });
+
+    const [afterCrossTenantMutation] = await getDb()
+      .select()
+      .from(evmWalletNonceInflight)
+      .where(
+        and(
+          eq(evmWalletNonceInflight.tenantId, TENANT_A),
+          eq(evmWalletNonceInflight.walletAddress, walletAddress),
+          eq(evmWalletNonceInflight.chainId, chainId),
+          eq(evmWalletNonceInflight.nonce, nonce),
+        ),
+      );
+    expect(afterCrossTenantMutation?.state).toBe("allocated");
+
+    await markEvmNonceDropped({
+      tenantId: TENANT_A,
+      walletAddress,
+      chainId,
+      nonce,
+    });
+    const [afterOwnerDrop] = await getDb()
+      .select()
+      .from(evmWalletNonceInflight)
+      .where(eq(evmWalletNonceInflight.tenantId, TENANT_A));
+    expect(afterOwnerDrop?.state).toBe("dropped");
+
+    await confirmEvmNonce({
+      tenantId: TENANT_A,
+      walletAddress,
+      chainId,
+      nonce,
+    });
+    const remaining = await getDb().select().from(evmWalletNonceInflight);
+    expect(remaining).toHaveLength(0);
+  });
+
   test("allows the same address on a different chain to have a different tenant owner", async () => {
     const walletAddress = "0x8888888888888888888888888888888888888888";
     const [baseNonce, mainnetNonce] = await Promise.all([

--- a/packages/vault/src/evm-nonce-manager.ts
+++ b/packages/vault/src/evm-nonce-manager.ts
@@ -1,4 +1,13 @@
-import { and, asc, eq, evmWalletNonceInflight, evmWalletNonces, getDb, sql } from "@stwd/db";
+import {
+  and,
+  asc,
+  eq,
+  evmWalletNonceInflight,
+  evmWalletNonceOwners,
+  evmWalletNonces,
+  getDb,
+  sql,
+} from "@stwd/db";
 import type { Address } from "viem";
 
 type PendingNonceReader = (address: Address) => Promise<number>;
@@ -30,6 +39,7 @@ async function withNonceLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
 }
 
 export async function allocateEvmNonce(input: {
+  tenantId: string;
   walletAddress: Address;
   chainId: number;
   getPendingNonce: PendingNonceReader;
@@ -48,6 +58,33 @@ export async function allocateEvmNonce(input: {
         await tx.execute(sql`select pg_advisory_xact_lock(hashtext(${`evm-nonce:${lockKey}`}))`);
       }
 
+      const [newClaim] = await tx
+        .insert(evmWalletNonceOwners)
+        .values({
+          tenantId: input.tenantId,
+          walletAddress,
+          chainId: input.chainId,
+        })
+        .onConflictDoNothing({
+          target: [evmWalletNonceOwners.walletAddress, evmWalletNonceOwners.chainId],
+        })
+        .returning({ tenantId: evmWalletNonceOwners.tenantId });
+      const [existingClaim] = newClaim
+        ? [newClaim]
+        : await tx
+            .select({ tenantId: evmWalletNonceOwners.tenantId })
+            .from(evmWalletNonceOwners)
+            .where(
+              and(
+                eq(evmWalletNonceOwners.walletAddress, walletAddress),
+                eq(evmWalletNonceOwners.chainId, input.chainId),
+              ),
+            )
+            .limit(1);
+      if (existingClaim?.tenantId !== input.tenantId) {
+        throw new Error("EVM nonce namespace is not owned by this tenant");
+      }
+
       // Gap recovery: reclaim the lowest previously-dropped nonce that is still
       // at or ahead of the chain's pending nonce. Dropped nonces below the
       // pending nonce are already consumed/replaced on-chain and must not be
@@ -57,6 +94,7 @@ export async function allocateEvmNonce(input: {
         .from(evmWalletNonceInflight)
         .where(
           and(
+            eq(evmWalletNonceInflight.tenantId, input.tenantId),
             eq(evmWalletNonceInflight.walletAddress, walletAddress),
             eq(evmWalletNonceInflight.chainId, input.chainId),
             eq(evmWalletNonceInflight.state, "dropped"),
@@ -72,6 +110,7 @@ export async function allocateEvmNonce(input: {
           .set({ state: "allocated", updatedAt: new Date() })
           .where(
             and(
+              eq(evmWalletNonceInflight.tenantId, input.tenantId),
               eq(evmWalletNonceInflight.walletAddress, walletAddress),
               eq(evmWalletNonceInflight.chainId, input.chainId),
               eq(evmWalletNonceInflight.nonce, reclaimable.nonce),
@@ -85,6 +124,7 @@ export async function allocateEvmNonce(input: {
         .from(evmWalletNonces)
         .where(
           and(
+            eq(evmWalletNonces.tenantId, input.tenantId),
             eq(evmWalletNonces.walletAddress, walletAddress),
             eq(evmWalletNonces.chainId, input.chainId),
           ),
@@ -95,19 +135,25 @@ export async function allocateEvmNonce(input: {
       await tx
         .insert(evmWalletNonces)
         .values({
+          tenantId: input.tenantId,
           walletAddress,
           chainId: input.chainId,
           nextNonce: nonce + 1,
           updatedAt: new Date(),
         })
         .onConflictDoUpdate({
-          target: [evmWalletNonces.walletAddress, evmWalletNonces.chainId],
+          target: [
+            evmWalletNonces.tenantId,
+            evmWalletNonces.walletAddress,
+            evmWalletNonces.chainId,
+          ],
           set: { nextNonce: nonce + 1, updatedAt: new Date() },
         });
 
       await tx
         .insert(evmWalletNonceInflight)
         .values({
+          tenantId: input.tenantId,
           walletAddress,
           chainId: input.chainId,
           nonce,
@@ -116,6 +162,7 @@ export async function allocateEvmNonce(input: {
         })
         .onConflictDoUpdate({
           target: [
+            evmWalletNonceInflight.tenantId,
             evmWalletNonceInflight.walletAddress,
             evmWalletNonceInflight.chainId,
             evmWalletNonceInflight.nonce,
@@ -135,6 +182,7 @@ export async function allocateEvmNonce(input: {
  * break the caller's error handling.
  */
 export async function markEvmNonceDropped(input: {
+  tenantId: string;
   walletAddress: Address;
   chainId: number;
   nonce: number;
@@ -152,6 +200,7 @@ export async function markEvmNonceDropped(input: {
         .set({ state: "dropped", updatedAt: new Date() })
         .where(
           and(
+            eq(evmWalletNonceInflight.tenantId, input.tenantId),
             eq(evmWalletNonceInflight.walletAddress, walletAddress),
             eq(evmWalletNonceInflight.chainId, input.chainId),
             eq(evmWalletNonceInflight.nonce, input.nonce),
@@ -166,6 +215,7 @@ export async function markEvmNonceDropped(input: {
  * successfully. Best-effort: a failure here must not break a successful send.
  */
 export async function confirmEvmNonce(input: {
+  tenantId: string;
   walletAddress: Address;
   chainId: number;
   nonce: number;
@@ -182,6 +232,7 @@ export async function confirmEvmNonce(input: {
         .delete(evmWalletNonceInflight)
         .where(
           and(
+            eq(evmWalletNonceInflight.tenantId, input.tenantId),
             eq(evmWalletNonceInflight.walletAddress, walletAddress),
             eq(evmWalletNonceInflight.chainId, input.chainId),
             eq(evmWalletNonceInflight.nonce, input.nonce),

--- a/packages/vault/src/vault.ts
+++ b/packages/vault/src/vault.ts
@@ -1851,6 +1851,7 @@ export class Vault {
         const allocatedNonce =
           request.nonce === undefined
             ? await allocateEvmNonce({
+                tenantId: request.tenantId,
                 walletAddress: account.address,
                 chainId,
                 getPendingNonce: (address) =>
@@ -1870,6 +1871,7 @@ export class Vault {
           if (allocatedNonce !== undefined) {
             // Best-effort: confirmation bookkeeping must not fail a good send.
             await confirmEvmNonce({
+              tenantId: request.tenantId,
               walletAddress: account.address,
               chainId,
               nonce: allocatedNonce,
@@ -1880,6 +1882,7 @@ export class Vault {
             // Best-effort: mark the dropped nonce reclaimable so the wallet
             // doesn't wedge behind a permanent hole.
             await markEvmNonceDropped({
+              tenantId: request.tenantId,
               walletAddress: account.address,
               chainId,
               nonce: allocatedNonce,
@@ -1897,6 +1900,7 @@ export class Vault {
         const nonce =
           request.nonce ??
           (await allocateEvmNonce({
+            tenantId: request.tenantId,
             walletAddress: account.address,
             chainId,
             getPendingNonce: (address) =>


### PR DESCRIPTION
## Summary
- add a tenant-owned `evm_wallet_nonce_owners` claim so one `(wallet_address, chain_id)` namespace cannot allocate independently across tenants
- tenant-scope nonce counters and in-flight rows with composite ownership foreign keys while retaining the global allocator lock
- backfill only unambiguous legacy ownership and fail the migration on missing or cross-tenant ambiguous namespaces
- move the nonce tables from the SEC-169 backfill inventory into direct tenant ownership
- prove simultaneous cross-tenant claims serialize to one owner and wrong-tenant drop/confirm operations cannot mutate the owner’s in-flight nonce

## Security invariants
- two tenants cannot claim the same address on the same chain
- the same address on different chains may be owned independently
- legacy missing or ambiguous ownership fails closed for operator reconciliation
- counter/in-flight reads and writes bind the authenticated tenant throughout allocation, confirmation, and gap recovery
- a non-owner cannot force nonce reuse or delete another tenant’s in-flight state

## Validation (exact head `affd5644a4e3b9f3a2495732bef7a31d710a4251`, base `a680098cc5d78127dd802d9cece198fa92a471b9`)
- EVM nonce migration: 3/3, 6 assertions
- EVM nonce manager: 10/10, 30 assertions
- SEC-169 RLS inventory: 2/2, 81 assertions
- `@stwd/shared`, `@stwd/db`, and `@stwd/vault` TypeScript builds: green
- Biome changed surfaces and `git diff --check`: green
- fresh hosted exact-head CI: pending; keep draft until fully green

## Scope
This is a bounded SEC-169 prerequisite checkpoint and intentionally does **not** close #343. FORCE RLS activation still requires restricted bootstrap roles/functions, request-wide transaction propagation (including Workers/background jobs), policies for every direct/derived/hybrid table, and real-Postgres pool/concurrency proofs.

Refs #343