### PR TITLE
fix(provider-x): bind disconnect to deterministic secret lineage

### DIFF
--- a/packages/api/src/__tests__/provider-x-connect.test.ts
+++ b/packages/api/src/__tests__/provider-x-connect.test.ts
@@ -49,6 +49,7 @@ import {
   refreshXProviderCredential,
   runXCredentialLifecycleSweep,
   X_ADAPTER_KEY,
+  X_DEFAULT_SCOPES,
   XConnectError,
   type XCredentialPayload,
   type XForwardRequest,
@@ -2269,22 +2270,57 @@ describe("disconnect", () => {
     });
   });
 
-  test("disconnect revokes exact bounded handles even when identity binding is invalid", async () => {
+  test("a wrong secret pointer cannot revoke, delete, or disable unrelated authority", async () => {
     const { completed } = await connectHappy(new MemoryConnectStore());
-    const current = await decryptCredential(completed.providerAccountId);
-    const misbound = await vault.rotateSecret(
+    const db = getDb();
+    const [before] = await db
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, completed.providerAccountId));
+    const correctRouteId = "50000000-0000-4000-8000-0000000000e1";
+    const unrelatedRouteId = "50000000-0000-4000-8000-0000000000e2";
+    const unrelated = await vault.createSecret(
       TENANT,
-      xCredentialSecretName(WORKSPACE, "1234567890"),
+      "unrelated/provider-credential",
       JSON.stringify({
-        ...current,
-        accessToken: "misbound-access-handle",
-        refreshToken: "misbound-refresh-handle",
+        schemaVersion: "steward.provider-x.credential.v1",
+        accessToken: "unrelated-access-handle",
+        refreshToken: "unrelated-refresh-handle",
+        tokenType: "bearer",
+        scopesGranted: [...X_DEFAULT_SCOPES],
         xUserId: "999999999",
+        xUsername: "unrelated",
+        obtainedAt: new Date().toISOString(),
+        expiresAt: null,
       }),
     );
-    await getDb()
+    await db.insert(secretRoutes).values([
+      {
+        id: correctRouteId,
+        tenantId: TENANT,
+        secretId: before.credentialSecretId as string,
+        hostPattern: "api.x.com",
+        pathPattern: "/2/tweets",
+        method: "POST",
+        injectAs: "header",
+        injectKey: "Authorization",
+        injectFormat: "Bearer {value}",
+      },
+      {
+        id: unrelatedRouteId,
+        tenantId: TENANT,
+        secretId: unrelated.id,
+        hostPattern: "api.unrelated.test",
+        pathPattern: "/live",
+        method: "POST",
+        injectAs: "header",
+        injectKey: "Authorization",
+        injectFormat: "Bearer {value}",
+      },
+    ]);
+    await db
       .update(providerAccounts)
-      .set({ credentialSecretId: misbound.id, credentialVersion: misbound.version })
+      .set({ credentialSecretId: unrelated.id, credentialVersion: unrelated.version })
       .where(eq(providerAccounts.id, completed.providerAccountId));
     const fake = installFakeX();
     await expect(
@@ -2297,15 +2333,52 @@ describe("disconnect", () => {
         config: CONFIG,
       }),
     ).resolves.toMatchObject({ revoked: true });
-    expect(new URLSearchParams(fake.counters.revokeBodies[0]).get("token")).toBe(
-      "misbound-refresh-handle",
-    );
+    expect(new URLSearchParams(fake.counters.revokeBodies[0]).get("token")).toBe("refresh-initial");
     fake.restore();
+
+    const [correctSecret] = await db
+      .select()
+      .from(secrets)
+      .where(eq(secrets.id, before.credentialSecretId as string));
+    expect(correctSecret.deletedAt).not.toBeNull();
+    const [unrelatedSecret] = await db.select().from(secrets).where(eq(secrets.id, unrelated.id));
+    expect(unrelatedSecret.deletedAt).toBeNull();
+    const [correctRoute] = await db
+      .select()
+      .from(secretRoutes)
+      .where(eq(secretRoutes.id, correctRouteId));
+    expect(correctRoute).toMatchObject({ enabled: false, authorityRevision: 2 });
+    const [unrelatedRoute] = await db
+      .select()
+      .from(secretRoutes)
+      .where(eq(secretRoutes.id, unrelatedRouteId));
+    expect(unrelatedRoute).toMatchObject({
+      secretId: unrelated.id,
+      enabled: true,
+      authorityRevision: 1,
+    });
   });
 
-  test("a missing credential link cannot prevent local revocation", async () => {
+  test("a null pointer discovers and revokes the deterministic live X lineage", async () => {
     const { completed } = await connectHappy(new MemoryConnectStore());
-    await getDb()
+    const db = getDb();
+    const [before] = await db
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, completed.providerAccountId));
+    const routeId = "50000000-0000-4000-8000-0000000000e3";
+    await db.insert(secretRoutes).values({
+      id: routeId,
+      tenantId: TENANT,
+      secretId: before.credentialSecretId as string,
+      hostPattern: "api.x.com",
+      pathPattern: "/2/tweets",
+      method: "POST",
+      injectAs: "header",
+      injectKey: "Authorization",
+      injectFormat: "Bearer {value}",
+    });
+    await db
       .update(providerAccounts)
       .set({ credentialSecretId: null, credentialVersion: null })
       .where(eq(providerAccounts.id, completed.providerAccountId));
@@ -2319,9 +2392,10 @@ describe("disconnect", () => {
         vault,
         config: CONFIG,
       }),
-    ).resolves.toMatchObject({ revoked: false });
-    expect(fake.counters.revoke).toBe(0);
-    const [account] = await getDb()
+    ).resolves.toMatchObject({ revoked: true });
+    expect(fake.counters.revoke).toBe(1);
+    expect(new URLSearchParams(fake.counters.revokeBodies[0]).get("token")).toBe("refresh-initial");
+    const [account] = await db
       .select()
       .from(providerAccounts)
       .where(eq(providerAccounts.id, completed.providerAccountId));
@@ -2330,6 +2404,13 @@ describe("disconnect", () => {
       credentialSecretId: null,
       credentialVersion: null,
     });
+    const [lineageSecret] = await db
+      .select()
+      .from(secrets)
+      .where(eq(secrets.id, before.credentialSecretId as string));
+    expect(lineageSecret.deletedAt).not.toBeNull();
+    const [route] = await db.select().from(secretRoutes).where(eq(secretRoutes.id, routeId));
+    expect(route).toMatchObject({ enabled: false, authorityRevision: 2 });
     fake.restore();
   });
 

--- a/packages/api/src/services/provider-x-connect.ts
+++ b/packages/api/src/services/provider-x-connect.ts
@@ -2626,35 +2626,60 @@ export async function disconnectXProviderCredential(
       throw new XConnectError("X_ACCOUNT_NOT_X", 400, "provider account is not an X account");
     }
 
-    if (account.status === "revoked" && !account.credentialSecretId) {
+    const now = new Date();
+    const expectedSecretName = xCredentialSecretName(input.workspaceId, account.externalRef);
+    // The account pointer is mutable bookkeeping, not proof of credential
+    // ownership. Resolve disconnect authority from the deterministic X account
+    // lineage so a corrupt pointer can neither sacrifice an unrelated secret
+    // nor hide the actual X grant from local revocation.
+    const [lineageSecret] = (await tx
+      .select()
+      .from(secrets)
+      .where(
+        and(
+          eq(secrets.tenantId, input.tenantId),
+          eq(secrets.name, expectedSecretName),
+          sql`${secrets.deletedAt} IS NULL`,
+        ),
+      )
+      .orderBy(desc(secrets.version))
+      .limit(1)
+      .for("update")) as Secret[];
+    const lineageSecretId = lineageSecret?.id ?? null;
+
+    if (account.status === "revoked" && !account.credentialSecretId && !lineageSecretId) {
       return { lifecycleId: null, retryAt: null };
     }
 
-    const now = new Date();
-    const material = account.credentialSecretId
+    const pointerIssue = !account.credentialSecretId
+      ? "CREDENTIAL_POINTER_MISSING"
+      : account.credentialSecretId !== lineageSecretId
+        ? "CREDENTIAL_POINTER_MISMATCH"
+        : null;
+    const material = lineageSecretId
       ? await readXDisconnectRevocationMaterial(
           tx,
           input.vault,
           input.tenantId,
-          account.credentialSecretId,
+          lineageSecretId,
           account.externalRef,
         )
       : null;
-    const routesToDisable = account.credentialSecretId
+    const routesToDisable = lineageSecretId
       ? await tx
           .select({ id: secretRoutes.id, authorityRevision: secretRoutes.authorityRevision })
           .from(secretRoutes)
           .where(
             and(
               eq(secretRoutes.tenantId, input.tenantId),
-              eq(secretRoutes.secretId, account.credentialSecretId),
+              eq(secretRoutes.secretId, lineageSecretId),
               eq(secretRoutes.enabled, true),
             ),
           )
           .for("update")
       : [];
 
-    const lifecycleId = account.credentialSecretId ? randomUUID() : null;
+    const lifecycleId = randomUUID();
     let lifecycleSecretId: string | null = null;
     const hasRevocationHandle = Boolean(material?.accessToken || material?.refreshToken);
     if (lifecycleId && hasRevocationHandle) {
@@ -2701,19 +2726,22 @@ export async function disconnectXProviderCredential(
           workspaceId: input.workspaceId,
           providerAccountId: account.id,
           revocationHandleAvailable: hasRevocationHandle,
-          credentialIssue: material?.issue ?? null,
+          credentialIssue:
+            pointerIssue ??
+            material?.issue ??
+            (lineageSecretId ? null : "CREDENTIAL_LINEAGE_MISSING"),
         },
       });
     }
 
-    if (account.credentialSecretId) {
+    if (lineageSecretId) {
       await tx
         .update(secretRoutes)
         .set({ enabled: false })
         .where(
           and(
             eq(secretRoutes.tenantId, input.tenantId),
-            eq(secretRoutes.secretId, account.credentialSecretId),
+            eq(secretRoutes.secretId, lineageSecretId),
             eq(secretRoutes.enabled, true),
           ),
         );
@@ -2740,14 +2768,14 @@ export async function disconnectXProviderCredential(
       throw new XConnectError("X_REFRESH_FAILED", 409, "account revision conflict on disconnect");
     }
 
-    if (account.credentialSecretId) {
+    if (lineageSecretId) {
       await tx
         .update(secrets)
         .set({ deletedAt: now, updatedAt: now })
         .where(
           and(
             eq(secrets.tenantId, input.tenantId),
-            eq(secrets.id, account.credentialSecretId),
+            eq(secrets.id, lineageSecretId),
             sql`${secrets.deletedAt} IS NULL`,
           ),
         );


### PR DESCRIPTION
Corrective follow-up to #467 and the lifecycle requirements in #466.

## Security correction

- resolve disconnect ownership from the deterministic `provider-x/<workspace>/<x-user>` active secret lineage under the account lock
- treat `provider_accounts.credential_secret_id` as mutable bookkeeping, never as proof of secret ownership
- prevent a wrong pointer from revoking, deleting, or disabling an unrelated secret and its routes
- discover the deterministic lineage when the pointer is null, then durably stage revocation, disable live routes, soft-delete the lineage, and clear local account authority atomically
- retain the existing bounded leased recovery path and immutable 0106/0107 migration history

## Exact-head evidence

Head: `6c08d289338bfe3dc8459f11a1cd09b980d95dcf`
Base: `ce5eabd26950ae13cf7a617b33d2c7061eef9a2b`

- provider-X plus disconnect migration and vault lifecycle: 64/64 tests, 382 assertions
- adversarial wrong-pointer test proves unrelated secret and live route remain unchanged while the deterministic X grant is revoked
- adversarial null-pointer test proves the hidden deterministic live route is disabled and its X lineage is deleted/revoked
- API dependency build: 24/24 tasks
- changed-file Biome: pass
- `git diff HEAD^ --check`: pass

This PR is intentionally draft pending independent review. It does not alter migrations or recovery bounds.