### PR TITLE
fix(api): advertise PATCH in tenant CORS preflight

### DIFF
--- a/packages/api/src/__tests__/tenant-cors-preflight.test.ts
+++ b/packages/api/src/__tests__/tenant-cors-preflight.test.ts
@@ -1,0 +1,78 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { getDb, tenantConfigs, tenants } from "@stwd/db";
+import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { Hono } from "hono";
+import { tenantCors } from "../middleware/tenant-cors";
+
+const ALLOWED_ORIGIN = "https://console.example.com";
+const originalNodeEnv = process.env.NODE_ENV;
+const originalPgliteMemory = process.env.STEWARD_PGLITE_MEMORY;
+let closeDb: (() => Promise<void>) | undefined;
+
+describe("tenant CORS preflight", () => {
+  beforeAll(async () => {
+    process.env.NODE_ENV = "production";
+    process.env.STEWARD_PGLITE_MEMORY = "true";
+    const { db, client } = await createPGLiteDb();
+    setPGLiteOverride(db as never, async () => {
+      await client.close();
+    });
+    closeDb = async () => {
+      setPGLiteOverride(null);
+      await client.close();
+    };
+    await getDb().insert(tenants).values({
+      id: "cors-patch-tenant",
+      name: "CORS PATCH tenant",
+      apiKeyHash: "cors-patch-tenant-hash",
+    });
+    await getDb()
+      .insert(tenantConfigs)
+      .values({
+        tenantId: "cors-patch-tenant",
+        allowedOrigins: [ALLOWED_ORIGIN],
+      });
+  });
+
+  afterAll(async () => {
+    if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = originalNodeEnv;
+    if (originalPgliteMemory === undefined) delete process.env.STEWARD_PGLITE_MEMORY;
+    else process.env.STEWARD_PGLITE_MEMORY = originalPgliteMemory;
+    await closeDb?.();
+  });
+
+  test("advertises PATCH to an allowed browser preflight", async () => {
+    const app = new Hono();
+    app.use("*", tenantCors);
+    app.patch("/resource", (c) => c.json({ ok: true }));
+
+    const response = await app.request("/resource", {
+      method: "OPTIONS",
+      headers: {
+        Origin: ALLOWED_ORIGIN,
+        "Access-Control-Request-Method": "PATCH",
+      },
+    });
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get("access-control-allow-origin")).toBe(ALLOWED_ORIGIN);
+    expect(response.headers.get("access-control-allow-methods")?.split(/,\s*/)).toContain("PATCH");
+  });
+
+  test("keeps disallowed origins fail closed", async () => {
+    const app = new Hono();
+    app.use("*", tenantCors);
+
+    const response = await app.request("/resource", {
+      method: "OPTIONS",
+      headers: {
+        Origin: "https://attacker.example",
+        "Access-Control-Request-Method": "PATCH",
+      },
+    });
+
+    expect(response.status).toBe(403);
+    expect(response.headers.get("access-control-allow-origin")).toBeNull();
+  });
+});

--- a/packages/api/src/__tests__/tenant-cors-preflight.test.ts
+++ b/packages/api/src/__tests__/tenant-cors-preflight.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { getDb, tenantConfigs, tenants } from "@stwd/db";
+import { closeDb, getDb, tenantConfigs, tenants } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { Hono } from "hono";
 import { tenantCors } from "../middleware/tenant-cors";
@@ -7,7 +7,6 @@ import { tenantCors } from "../middleware/tenant-cors";
 const ALLOWED_ORIGIN = "https://console.example.com";
 const originalNodeEnv = process.env.NODE_ENV;
 const originalPgliteMemory = process.env.STEWARD_PGLITE_MEMORY;
-let closeDb: (() => Promise<void>) | undefined;
 
 describe("tenant CORS preflight", () => {
   beforeAll(async () => {
@@ -17,10 +16,6 @@ describe("tenant CORS preflight", () => {
     setPGLiteOverride(db as never, async () => {
       await client.close();
     });
-    closeDb = async () => {
-      setPGLiteOverride(null);
-      await client.close();
-    };
     await getDb().insert(tenants).values({
       id: "cors-patch-tenant",
       name: "CORS PATCH tenant",
@@ -39,7 +34,7 @@ describe("tenant CORS preflight", () => {
     else process.env.NODE_ENV = originalNodeEnv;
     if (originalPgliteMemory === undefined) delete process.env.STEWARD_PGLITE_MEMORY;
     else process.env.STEWARD_PGLITE_MEMORY = originalPgliteMemory;
-    await closeDb?.();
+    await closeDb();
   });
 
   test("advertises PATCH to an allowed browser preflight", async () => {
@@ -52,12 +47,18 @@ describe("tenant CORS preflight", () => {
       headers: {
         Origin: ALLOWED_ORIGIN,
         "Access-Control-Request-Method": "PATCH",
+        "Access-Control-Request-Headers": "Authorization, X-Steward-Tenant",
       },
     });
 
     expect(response.status).toBe(204);
     expect(response.headers.get("access-control-allow-origin")).toBe(ALLOWED_ORIGIN);
     expect(response.headers.get("access-control-allow-methods")?.split(/,\s*/)).toContain("PATCH");
+    expect(response.headers.get("access-control-allow-headers")?.split(/,\s*/)).toEqual(
+      expect.arrayContaining(["Authorization", "X-Steward-Tenant"]),
+    );
+    expect(response.headers.get("access-control-allow-credentials")).toBeNull();
+    expect(response.headers.get("vary")).toBe("Origin, X-Steward-Tenant");
   });
 
   test("keeps disallowed origins fail closed", async () => {
@@ -74,5 +75,7 @@ describe("tenant CORS preflight", () => {
 
     expect(response.status).toBe(403);
     expect(response.headers.get("access-control-allow-origin")).toBeNull();
+    expect(response.headers.get("access-control-allow-credentials")).toBeNull();
+    expect(response.headers.get("vary")).toBe("Origin, X-Steward-Tenant");
   });
 });

--- a/packages/api/src/middleware/tenant-cors.ts
+++ b/packages/api/src/middleware/tenant-cors.ts
@@ -133,7 +133,7 @@ async function getAllAllowedOrigins(): Promise<Set<string>> {
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
-const ALLOW_METHODS = "GET, POST, PUT, DELETE, OPTIONS";
+const ALLOW_METHODS = "GET, POST, PUT, PATCH, DELETE, OPTIONS";
 const ALLOW_HEADERS =
   "Content-Type, X-Steward-Tenant, X-Steward-Key, X-Steward-Platform-Key, X-Steward-Signature, X-Steward-Signer-Id, X-Steward-Signer-Secret, X-Steward-Key-Quorum-Id, X-Steward-Key-Quorum-Credentials, X-Steward-Timestamp, X-Steward-Expires, X-Steward-Request-Timestamp, X-Steward-Request-Expires-At, Idempotency-Key, Authorization";
 const EXPOSE_HEADERS = "Content-Length, X-Request-Id";


### PR DESCRIPTION
## Summary
- include `PATCH` in the tenant CORS allow-methods response
- exercise a real Hono `OPTIONS` request with an allowlisted production origin
- retain and assert fail-closed 403 behavior for an untrusted origin
- use the supported database teardown path and assert credential/header/cache boundaries

## Validation
Exact head `93833990c51f8e30c79e15c8af9eafad68e53b23`, base `63e23a0230face5a214855fe28f7f3b814681ddf`:
- tenant CORS preflight: 2/2, 10 assertions
- `@stwd/api` TypeScript build: green
- Biome changed surfaces and `git diff --check`: green

Closes #473