### PR TITLE
fix(worker): contain request-owned database work

### DIFF
--- a/packages/api/src/__tests__/worker-runtime-sentinel.test.ts
+++ b/packages/api/src/__tests__/worker-runtime-sentinel.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { getDb } from "@stwd/db";
+import { getDb, tenants, waitUntilRequestDatabaseTask } from "@stwd/db";
 import {
   hydrateProcessEnv,
   runWorkerGoogleCredentialLifecycleSweep,
@@ -44,7 +44,8 @@ test("Worker request database is exact, request-owned, and always closed", async
       env,
       async () => {
         await Promise.resolve();
-        expect(getDb()).toBe(requestDb);
+        expect(getDb()).not.toBe(requestDb);
+        expect((getDb() as unknown as { marker: string }).marker).toBe("worker-request");
         return "ok";
       },
       { createHandle },
@@ -56,7 +57,7 @@ test("Worker request database is exact, request-owned, and always closed", async
     withWorkerRequestDatabase(
       env,
       async () => {
-        expect(getDb()).toBe(requestDb);
+        expect((getDb() as unknown as { marker: string }).marker).toBe("worker-request");
         throw new Error("handler failed");
       },
       { createHandle },
@@ -75,7 +76,8 @@ test("Worker HTTP mode binds an exact request database without a persistent hand
     },
     async () => {
       await Promise.resolve();
-      expect(getDb()).toBe(requestDb);
+      expect(getDb()).not.toBe(requestDb);
+      expect((getDb() as unknown as { marker: string }).marker).toBe("worker-http-request");
       return "http";
     },
     {
@@ -88,6 +90,19 @@ test("Worker HTTP mode binds an exact request database without a persistent hand
   );
   expect(result).toBe("http");
   expect(created).toBe(0);
+});
+
+test("Worker request membrane preserves real Drizzle query execution", async () => {
+  const pgliteDb = getDb();
+  const rows = await withWorkerRequestDatabase(
+    {
+      DATABASE_URL: "postgresql://worker.invalid/steward",
+      DATABASE_DRIVER: "neon-http",
+    },
+    () => getDb().select({ id: tenants.id }).from(tenants).limit(1),
+    { createHttpDb: () => pgliteDb },
+  );
+  expect(Array.isArray(rows)).toBe(true);
 });
 
 test("Worker database selection rejects missing or unsupported drivers", async () => {
@@ -110,6 +125,57 @@ test("every autonomous recovery sweep owns its own request database", () => {
   ]) {
     expect(source).toContain(`withWorkerRequestDatabase(env, () => ${sweep}(env))`);
   }
+});
+
+test("Worker drains fire-and-forget webhook work before closing its request pool", async () => {
+  let releaseDelivery!: () => void;
+  const deliveryGate = new Promise<void>((resolve) => {
+    releaseDelivery = resolve;
+  });
+  let closes = 0;
+  let deliveryFinished = false;
+  const requestDb = { marker: "worker-webhook" } as unknown as ReturnType<typeof getDb>;
+  const owner = withWorkerRequestDatabase(
+    {
+      DATABASE_URL: "postgresql://worker.invalid/steward",
+      DATABASE_DRIVER: "neon-websocket",
+    },
+    async () => {
+      // dispatchWebhook uses this same request-lifetime hook for its intentionally
+      // unawaited configured delivery fan-out.
+      void waitUntilRequestDatabaseTask(
+        (async () => {
+          await deliveryGate;
+          expect((getDb() as unknown as { marker: string }).marker).toBe("worker-webhook");
+          deliveryFinished = true;
+        })(),
+      );
+      return new Response("accepted");
+    },
+    {
+      createHandle: () => ({
+        driver: "neon-websocket" as const,
+        db: requestDb as never,
+        async close() {
+          expect(deliveryFinished).toBe(true);
+          closes += 1;
+        },
+      }),
+    },
+  );
+
+  await Promise.resolve();
+  expect(closes).toBe(0);
+  releaseDelivery();
+  expect((await owner).status).toBe(200);
+  expect(deliveryFinished).toBe(true);
+  expect(closes).toBe(1);
+
+  const webhookSource = readFileSync(
+    join(import.meta.dir, "../services/webhook-dispatch.ts"),
+    "utf8",
+  );
+  expect(webhookSource).toContain("waitUntilRequestDatabaseTask(");
 });
 
 test("Worker socket cleanup diagnostics are fixed and cannot replace handler errors", async () => {

--- a/packages/api/src/services/webhook-dispatch.ts
+++ b/packages/api/src/services/webhook-dispatch.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { and, eq, webhookConfigs, webhookDeliveries } from "@stwd/db";
+import { and, eq, waitUntilRequestDatabaseTask, webhookConfigs, webhookDeliveries } from "@stwd/db";
 import { redactedThrownDiagnostics, type WebhookEvent } from "@stwd/shared";
 import {
   decryptWebhookSecret,
@@ -51,13 +51,20 @@ export function dispatchWebhook(
     data: redactedData,
     timestamp: new Date(),
   };
-  void dispatchConfiguredWebhooks(event, configuredType, isPluginEvent ? type : null).catch(
-    (error) => {
-      console.error(
-        "[webhooks] Failed to dispatch configured webhooks",
-        redactedThrownDiagnostics(error),
-      );
-    },
+  // Route callers intentionally do not await webhook delivery. In a Worker,
+  // register that detached promise with the request-owned database lease so
+  // its reads/writes finish before the WebSocket pool is closed. Bun keeps its
+  // existing process-owned fire-and-forget behavior when no request lease is
+  // active.
+  void waitUntilRequestDatabaseTask(
+    dispatchConfiguredWebhooks(event, configuredType, isPluginEvent ? type : null).catch(
+      (error) => {
+        console.error(
+          "[webhooks] Failed to dispatch configured webhooks",
+          redactedThrownDiagnostics(error),
+        );
+      },
+    ),
   );
 
   // SEC-101: the unverifiable tenant-route webhookUrl field is retired. The

--- a/packages/db/src/__tests__/request-database-context.test.ts
+++ b/packages/db/src/__tests__/request-database-context.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { closeDb, getDb, getSql, withRequestDatabase } from "../client";
+import {
+  closeDb,
+  getDb,
+  getSql,
+  waitUntilRequestDatabaseTask,
+  withRequestDatabase,
+} from "../client";
 
 const originalDriver = process.env.DATABASE_DRIVER;
 
@@ -23,9 +29,10 @@ describe("request-scoped database context", () => {
     expect(
       await withRequestDatabase(requestDb, async () => {
         await Promise.resolve();
-        return getDb();
+        expect(getDb()).not.toBe(requestDb);
+        return (getDb() as unknown as { marker: string }).marker;
       }),
-    ).toBe(requestDb);
+    ).toBe("request");
 
     process.env.DATABASE_DRIVER = "neon-websocket";
     expect(() => getDb()).toThrow("RLS_TRANSACTION_HANDLE_REQUIRED");
@@ -38,17 +45,17 @@ describe("request-scoped database context", () => {
     const releaseA = deferred();
 
     const a = withRequestDatabase(dbA, async () => {
-      expect(getDb()).toBe(dbA);
+      expect((getDb() as unknown as { marker: string }).marker).toBe("a");
       aEntered.resolve();
       await releaseA.promise;
-      expect(getDb()).toBe(dbA);
+      expect((getDb() as unknown as { marker: string }).marker).toBe("a");
       return "a";
     });
     await aEntered.promise;
     const b = withRequestDatabase(dbB, async () => {
-      expect(getDb()).toBe(dbB);
+      expect((getDb() as unknown as { marker: string }).marker).toBe("b");
       await Promise.resolve();
-      expect(getDb()).toBe(dbB);
+      expect((getDb() as unknown as { marker: string }).marker).toBe("b");
       return "b";
     });
     expect(await b).toBe("b");
@@ -64,7 +71,7 @@ describe("request-scoped database context", () => {
         "REQUEST_DATABASE_CONTEXT_NESTED",
       );
       expect(() => getSql()).toThrow("REQUEST_DATABASE_RAW_SQL_UNAVAILABLE");
-      expect(getDb()).toBe(outer);
+      expect((getDb() as unknown as { marker: string }).marker).toBe("outer");
     });
   });
 
@@ -81,5 +88,67 @@ describe("request-scoped database context", () => {
     });
     release.resolve();
     await detached;
+  });
+
+  test("revokes a database handle and derived query captured before owner completion", async () => {
+    const rawSelect = () => ({ from: () => Promise.resolve([]) });
+    const requestDb = { select: rawSelect } as unknown as ReturnType<typeof getDb>;
+    let capturedDb!: ReturnType<typeof getDb>;
+    let capturedSelect!: ReturnType<typeof getDb>["select"];
+    let capturedQuery!: ReturnType<ReturnType<typeof getDb>["select"]>;
+
+    await withRequestDatabase(requestDb, async () => {
+      capturedDb = getDb();
+      capturedSelect = capturedDb.select;
+      capturedQuery = capturedDb.select();
+    });
+
+    expect(capturedDb).not.toBe(requestDb);
+    expect(() => capturedDb.select()).toThrow("REQUEST_DATABASE_CONTEXT_CLOSED");
+    expect(() => capturedSelect()).toThrow("REQUEST_DATABASE_CONTEXT_CLOSED");
+    expect(() => capturedQuery.from({} as never)).toThrow("REQUEST_DATABASE_CONTEXT_CLOSED");
+  });
+
+  test("drains registered detached work before revoking its database capability", async () => {
+    const requestDb = { marker: "request" } as unknown as ReturnType<typeof getDb>;
+    const release = deferred();
+    let detachedFinished = false;
+    const owner = withRequestDatabase(requestDb, async () => {
+      void waitUntilRequestDatabaseTask(
+        (async () => {
+          await release.promise;
+          expect(getDb()).not.toBe(requestDb);
+          detachedFinished = true;
+        })(),
+      );
+      return "response";
+    });
+
+    await Promise.resolve();
+    expect(detachedFinished).toBe(false);
+    release.resolve();
+    expect(await owner).toBe("response");
+    expect(detachedFinished).toBe(true);
+  });
+
+  test("drains registered work before propagating the owner error", async () => {
+    const requestDb = { marker: "request" } as unknown as ReturnType<typeof getDb>;
+    const release = deferred();
+    let detachedFinished = false;
+    const owner = withRequestDatabase(requestDb, async () => {
+      void waitUntilRequestDatabaseTask(
+        (async () => {
+          await release.promise;
+          expect((getDb() as unknown as { marker: string }).marker).toBe("request");
+          detachedFinished = true;
+        })(),
+      );
+      throw new Error("owner failed");
+    });
+
+    await Promise.resolve();
+    release.resolve();
+    await expect(owner).rejects.toThrow("owner failed");
+    expect(detachedFinished).toBe(true);
   });
 });

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -480,8 +480,96 @@ type RequestDatabase = ReturnType<typeof createDb>["db"];
 interface RequestDatabaseContext {
   db: RequestDatabase | undefined;
   active: boolean;
+  pendingTasks: Set<Promise<unknown>>;
+  guardedObjects: WeakMap<object, object>;
 }
 const requestDatabaseStorage = new AsyncLocalStorage<RequestDatabaseContext>();
+
+function assertRequestDatabaseContextActive(
+  context: RequestDatabaseContext,
+): asserts context is RequestDatabaseContext & { db: RequestDatabase } {
+  if (!context.active) throw new Error("REQUEST_DATABASE_CONTEXT_CLOSED");
+  if (!context.db) throw new Error("REQUEST_DATABASE_CONTEXT_INVALID");
+}
+
+function trackRequestDatabaseTask<T>(
+  context: RequestDatabaseContext,
+  task: Promise<T>,
+): Promise<T> {
+  assertRequestDatabaseContextActive(context);
+  const tracked = task as Promise<unknown>;
+  context.pendingTasks.add(tracked);
+  void tracked.then(
+    () => context.pendingTasks.delete(tracked),
+    () => context.pendingTasks.delete(tracked),
+  );
+  return task;
+}
+
+/**
+ * Keep explicitly detached work inside the current request database lifetime.
+ *
+ * Worker services that intentionally start best-effort asynchronous work must
+ * register the resulting promise here. The request owner drains registered
+ * work before revoking the database capability and closing its socket. Outside
+ * a request-owned database context this is a no-op, preserving Bun's existing
+ * process-owned background-work behavior.
+ */
+export function waitUntilRequestDatabaseTask<T>(task: Promise<T>): Promise<T> {
+  const context = requestDatabaseStorage.getStore();
+  return context ? trackRequestDatabaseTask(context, task) : task;
+}
+
+/**
+ * Build a revocable membrane around a request-owned Drizzle handle.
+ *
+ * Revoking only AsyncLocalStorage is insufficient: a detached closure can call
+ * getDb() while the request is active, retain the returned handle (or a query
+ * builder/method derived from it), and use that retained capability after the
+ * Worker closes its pool. Every property access and invocation through this
+ * membrane re-checks the owner lease. Promise-returning driver operations are
+ * also tracked so an operation started during the request is drained before
+ * the transport is released.
+ */
+function guardRequestDatabaseValue<T>(value: T, context: RequestDatabaseContext): T {
+  if ((typeof value !== "object" || value === null) && typeof value !== "function") return value;
+  if (value instanceof Promise) {
+    return trackRequestDatabaseTask(context, value) as T;
+  }
+
+  const objectValue = value as object;
+  const existing = context.guardedObjects.get(objectValue);
+  if (existing) return existing as T;
+
+  const guarded = new Proxy(objectValue, {
+    get(target, property) {
+      assertRequestDatabaseContextActive(context);
+      const member = Reflect.get(target, property, target);
+      if (typeof member === "function") {
+        return (...args: unknown[]) => {
+          assertRequestDatabaseContextActive(context);
+          const result = Reflect.apply(member, target, args);
+          return guardRequestDatabaseValue(result, context);
+        };
+      }
+      return guardRequestDatabaseValue(member, context);
+    },
+    set(target, property, nextValue) {
+      assertRequestDatabaseContextActive(context);
+      return Reflect.set(target, property, nextValue, target);
+    },
+  });
+  context.guardedObjects.set(objectValue, guarded);
+  return guarded as T;
+}
+
+async function drainRequestDatabaseTasks(context: RequestDatabaseContext): Promise<void> {
+  // A registered task may enqueue another registered task before it settles.
+  // Keep the owner lease active until the set reaches a stable empty state.
+  while (context.pendingTasks.size > 0) {
+    await Promise.allSettled([...context.pendingTasks]);
+  }
+}
 
 /**
  * Bind one explicitly owned database handle to the current async request.
@@ -499,9 +587,30 @@ export async function withRequestDatabase<T>(
   if (requestDatabaseStorage.getStore()) {
     throw new Error("REQUEST_DATABASE_CONTEXT_NESTED");
   }
-  const context: RequestDatabaseContext = { db, active: true };
+  const context: RequestDatabaseContext = {
+    db: undefined,
+    active: true,
+    pendingTasks: new Set(),
+    guardedObjects: new WeakMap(),
+  };
+  context.db = guardRequestDatabaseValue(db, context);
   try {
-    return await requestDatabaseStorage.run(context, callback);
+    return await requestDatabaseStorage.run(context, async () => {
+      const noCallbackError = Symbol("no-request-database-callback-error");
+      let callbackError: unknown | typeof noCallbackError = noCallbackError;
+      let result: T | undefined;
+      try {
+        result = await callback();
+      } catch (error) {
+        callbackError = error;
+      }
+      // Registered work owns this same capability even when the route fails.
+      // Drain it before revocation so the error path cannot close the pool under
+      // a webhook/audit write that the handler started before throwing.
+      await drainRequestDatabaseTasks(context);
+      if (callbackError !== noCallbackError) throw callbackError;
+      return result as T;
+    });
   } finally {
     // Detached tasks inherit AsyncLocalStorage. Revoke their capability before
     // the owning Worker closes its socket so late getDb() calls fail before I/O.
@@ -544,8 +653,7 @@ function buildGlobalDb(): GlobalDbHandle {
 export function getDb() {
   const requestContext = requestDatabaseStorage.getStore();
   if (requestContext) {
-    if (!requestContext.active) throw new Error("REQUEST_DATABASE_CONTEXT_CLOSED");
-    if (!requestContext.db) throw new Error("REQUEST_DATABASE_CONTEXT_INVALID");
+    assertRequestDatabaseContextActive(requestContext);
     return requestContext.db;
   }
   if (pgliteOverride) return pgliteOverride.db as ReturnType<typeof createDb>["db"];

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -36,6 +36,7 @@ export {
   getDb,
   getSql,
   setPGLiteOverride,
+  waitUntilRequestDatabaseTask,
   withDatabaseDeadline,
   withRequestDatabase,
 } from "./client";


### PR DESCRIPTION
## Summary

Corrective follow-up to merged PR #460 for the SEC-169 program in #343.

- wrap each request-owned Drizzle handle and derived query capability in a revocable lease membrane, so a handle, method, or query builder captured before request completion cannot reach the pool after release
- track database promises started while the lease is active and drain registered detached tasks on both handler success and failure before closing the Worker pool
- register the intentionally fire-and-forget configured webhook fan-out with the request database lifetime while preserving the existing Bun process-owned behavior
- add adversarial captured-handle, captured-method, captured-query, owner-error, real-Drizzle, and Worker webhook lifecycle regressions

This PR deliberately keeps #343 open; it corrects the request-lifetime checkpoint from #460.

## Exact-head validation

Head: `636c053fc7aa3fe0d6e109fed8f0ed95579001b9`
Base tested: `63e23a0230face5a214855fe28f7f3b814681ddf`

- request database context: 7 passed, 25 assertions
- Worker runtime + configured webhook dispatch: 18 passed, 61 assertions
- API dependency build: 24/24 packages successful
- Biome: 5 changed TypeScript files clean
- `git diff --check`: clean

## Independent repair

Exact head `160ec45b91b57b8940969ad876917224546533e9` additionally isolates registered background work in child capability contexts. The prior shared context let unregistered detached work piggyback while a webhook kept the request alive. Regression now proves the unregistered path is revoked immediately. Exact local: request DB 8/8 (27 assertions), dependency build 24/24, Biome/diff clean.