### PR TITLE
fix(security): repair runtime redaction packaging

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -148,10 +148,9 @@
     },
     "packages/eliza-plugin": {
       "name": "@stwd/eliza-plugin",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "dependencies": {
         "@stwd/sdk": "^0.10.0",
-        "@stwd/shared": "workspace:*",
       },
       "devDependencies": {
         "@elizaos/core": "2.0.0-alpha.77",
@@ -159,6 +158,7 @@
         "@stwd/db": "workspace:*",
         "@stwd/proxy": "workspace:*",
         "@stwd/proxy-client": "workspace:*",
+        "@stwd/shared": "workspace:*",
         "@types/node": "^25.5.0",
         "hono": "^4.12.34",
         "tsup": "^8.0.0",
@@ -493,6 +493,7 @@
       "version": "0.4.0",
       "dependencies": {
         "@stwd/db": "workspace:*",
+        "@stwd/shared": "workspace:*",
         "@stwd/vault": "workspace:*",
         "drizzle-orm": "^0.44.5",
         "viem": "^2.30.0",

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "node:fs";
+import { redactedThrownDiagnostics } from "@stwd/shared";
 import { migrate } from "drizzle-orm/postgres-js/migrator";
 
 import { createDb } from "./client";
@@ -180,7 +181,7 @@ if (isEntrypoint) {
       }
     })
     .catch((error) => {
-      console.error("Failed to run migrations", error);
+      console.error("Failed to run migrations", redactedThrownDiagnostics(error));
       process.exitCode = 1;
     });
 }

--- a/packages/eliza-plugin/CHANGELOG.md
+++ b/packages/eliza-plugin/CHANGELOG.md
@@ -14,6 +14,14 @@
 ### Docs
 - Make the opt-in live integration suite (`STEWARD_LIVE_TESTS=1`) target env-configurable (`STEWARD_URL` / `STEWARD_API_KEY` / `STEWARD_TENANT_ID`) with self-host defaults (`http://localhost:3200`, `my-app`) instead of a hardcoded hosted `api.steward.fi` URL and production tenant/key. Steward is self-host-first today; there is no shared hosted API. Test-fixture only, no runtime change.
 
+## 0.4.4
+
+- Bundle Steward shared runtime helpers into the published package so consumers do not depend on
+  workspace-only package references.
+- Restrict the npm artifact to the compiled distribution and package changelog.
+- Apply bounded diagnostics to runtime rejection paths and extend the telemetry guard to Promise
+  rejection callbacks.
+
 ## 0.4.1
 
 - Security audit hardening release.

--- a/packages/eliza-plugin/package.json
+++ b/packages/eliza-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stwd/eliza-plugin",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "ElizaOS integration for Steward-scoped wallet and provider capabilities",
   "license": "MIT",
   "type": "module",
@@ -16,8 +16,7 @@
     }
   },
   "dependencies": {
-    "@stwd/sdk": "^0.10.0",
-    "@stwd/shared": "workspace:*"
+    "@stwd/sdk": "^0.10.0"
   },
   "peerDependencies": {
     "@elizaos/core": ">=2.0.0-alpha.50"
@@ -28,6 +27,7 @@
     "@stwd/db": "workspace:*",
     "@stwd/proxy": "workspace:*",
     "@stwd/proxy-client": "workspace:*",
+    "@stwd/shared": "workspace:*",
     "@types/node": "^25.5.0",
     "hono": "^4.12.34",
     "tsup": "^8.0.0",

--- a/packages/eliza-plugin/package.json
+++ b/packages/eliza-plugin/package.json
@@ -4,6 +4,10 @@
   "description": "ElizaOS integration for Steward-scoped wallet and provider capabilities",
   "license": "MIT",
   "type": "module",
+  "files": [
+    "dist",
+    "CHANGELOG.md"
+  ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/eliza-plugin/src/__tests__/package-artifact.test.ts
+++ b/packages/eliza-plugin/src/__tests__/package-artifact.test.ts
@@ -1,0 +1,57 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+
+const PACKAGE_ROOT = join(import.meta.dirname, "../..");
+const REPOSITORY_ROOT = join(PACKAGE_ROOT, "../..");
+const artifactDirectory = mkdtempSync(join(tmpdir(), "steward-eliza-package-"));
+
+let packedPackageJson: {
+  dependencies?: Record<string, string>;
+};
+let packedEntrypoint = "";
+
+beforeAll(() => {
+  execFileSync("bunx", ["turbo", "run", "build", "--filter=@stwd/eliza-plugin"], {
+    cwd: REPOSITORY_ROOT,
+    stdio: "pipe",
+  });
+
+  const packOutput = execFileSync(
+    "npm",
+    ["pack", "--json", "--ignore-scripts", "--pack-destination", artifactDirectory],
+    { cwd: PACKAGE_ROOT, encoding: "utf8" },
+  );
+  const [{ filename }] = JSON.parse(packOutput) as Array<{ filename: string }>;
+  const tarball = join(artifactDirectory, filename);
+  const extracted = join(artifactDirectory, "extracted");
+  mkdirSync(extracted);
+  execFileSync("tar", ["-xzf", tarball, "-C", extracted]);
+
+  packedPackageJson = JSON.parse(
+    readFileSync(join(extracted, "package/package.json"), "utf8"),
+  ) as typeof packedPackageJson;
+  packedEntrypoint = readFileSync(join(extracted, "package/dist/index.js"), "utf8");
+}, 60_000);
+
+afterAll(() => {
+  rmSync(artifactDirectory, { recursive: true, force: true });
+});
+
+describe("published package artifact", () => {
+  test("contains no workspace protocol runtime dependencies", () => {
+    expect(
+      Object.values(packedPackageJson.dependencies ?? {}).some((value) =>
+        value.startsWith("workspace:"),
+      ),
+    ).toBe(false);
+  });
+
+  test("bundles every @stwd/shared runtime import", () => {
+    expect(packedEntrypoint).not.toContain("@stwd/shared");
+    expect(packedEntrypoint).toContain("function redactedThrownDiagnostics(");
+    expect(packedEntrypoint).toContain("function containsSensitiveCredentialKey(");
+  });
+});

--- a/packages/eliza-plugin/src/__tests__/package-artifact.test.ts
+++ b/packages/eliza-plugin/src/__tests__/package-artifact.test.ts
@@ -12,6 +12,7 @@ let packedPackageJson: {
   dependencies?: Record<string, string>;
 };
 let packedEntrypoint = "";
+let packedFiles: string[] = [];
 
 beforeAll(() => {
   execFileSync("bunx", ["turbo", "run", "build", "--filter=@stwd/eliza-plugin"], {
@@ -24,7 +25,11 @@ beforeAll(() => {
     ["pack", "--json", "--ignore-scripts", "--pack-destination", artifactDirectory],
     { cwd: PACKAGE_ROOT, encoding: "utf8" },
   );
-  const [{ filename }] = JSON.parse(packOutput) as Array<{ filename: string }>;
+  const [{ filename, files }] = JSON.parse(packOutput) as Array<{
+    filename: string;
+    files: Array<{ path: string }>;
+  }>;
+  packedFiles = files.map((file) => file.path).sort();
   const tarball = join(artifactDirectory, filename);
   const extracted = join(artifactDirectory, "extracted");
   mkdirSync(extracted);
@@ -41,6 +46,17 @@ afterAll(() => {
 });
 
 describe("published package artifact", () => {
+  test("contains only the manifest, changelog, and built distribution", () => {
+    expect(packedFiles).toContain("package.json");
+    expect(packedFiles).toContain("CHANGELOG.md");
+    expect(packedFiles.some((path) => path.startsWith("dist/"))).toBe(true);
+    expect(
+      packedFiles.every(
+        (path) => path === "package.json" || path === "CHANGELOG.md" || path.startsWith("dist/"),
+      ),
+    ).toBe(true);
+  });
+
   test("contains no workspace protocol runtime dependencies", () => {
     expect(
       Object.values(packedPackageJson.dependencies ?? {}).some((value) =>

--- a/packages/eliza-plugin/tsup.config.ts
+++ b/packages/eliza-plugin/tsup.config.ts
@@ -7,6 +7,9 @@ export default defineConfig({
   clean: true,
   sourcemap: true,
   external: ["@elizaos/core", "@stwd/sdk"],
-  noExternal: ["@stwd/shared/sensitive-keys"],
+  // Keep Steward's shared runtime helpers inside the published artifact. A
+  // workspace protocol dependency cannot be installed from an npm tarball,
+  // and both the root and sensitive-keys subpath are used at runtime.
+  noExternal: ["@stwd/shared", "@stwd/shared/sensitive-keys"],
   target: "node22",
 });

--- a/packages/examples/waifu-integration/src/index.ts
+++ b/packages/examples/waifu-integration/src/index.ts
@@ -1,5 +1,5 @@
 import { type PolicyRule, StewardApiError, StewardClient, type TxRecord } from "@stwd/sdk";
-import type { ApiResponse, WebhookEvent } from "@stwd/shared";
+import { type ApiResponse, redactedThrownDiagnostics, type WebhookEvent } from "@stwd/shared";
 
 const BASE_CHAIN_ID = 8453;
 const USDC_ADDRESS = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
@@ -383,7 +383,7 @@ async function main() {
     } catch (error) {
       console.log("Small tx passed policy but could not be broadcast.");
       detail("likely cause", "fund the demo wallet with ETH on Base so the signer can pay gas");
-      detail("error", error instanceof Error ? error.message : "Unknown error");
+      detail("error diagnostics", redactedThrownDiagnostics(error));
     }
 
     const mediumTxValue = parseEther("0.05").toString();
@@ -471,6 +471,6 @@ async function main() {
 
 await main().catch((error) => {
   console.error("\nWaifu integration example failed.");
-  console.error(error instanceof Error ? (error.stack ?? error.message) : error);
+  console.error(redactedThrownDiagnostics(error));
   process.exitCode = 1;
 });

--- a/packages/seed/package.json
+++ b/packages/seed/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@stwd/db": "workspace:*",
+    "@stwd/shared": "workspace:*",
     "@stwd/vault": "workspace:*",
     "drizzle-orm": "^0.44.5",
     "viem": "^2.30.0"

--- a/packages/seed/src/sol-default-policy.ts
+++ b/packages/seed/src/sol-default-policy.ts
@@ -26,6 +26,7 @@
 import crypto from "node:crypto";
 
 import { agents, getDb, policies } from "@stwd/db";
+import { redactedThrownDiagnostics } from "@stwd/shared";
 import { and, eq } from "drizzle-orm";
 
 export interface SeedSolDefaultPolicyArgs {
@@ -147,7 +148,7 @@ if (isEntrypoint) {
       );
     })
     .catch((err) => {
-      console.error("seedSolDefaultPolicy failed:", err instanceof Error ? err.message : err);
+      console.error("seedSolDefaultPolicy failed:", redactedThrownDiagnostics(err));
       process.exitCode = 1;
     });
 }

--- a/scripts/__tests__/runtime-error-log-safety.test.ts
+++ b/scripts/__tests__/runtime-error-log-safety.test.ts
@@ -35,6 +35,7 @@ function sinkName(expression: ts.LeftHandSideExpression): string {
 function isTelemetrySinkName(name: string): boolean {
   return (
     [
+      "detail",
       "logWarn",
       "dispatchWebhook",
       "trackAuditEvent",
@@ -52,9 +53,14 @@ function isTelemetrySinkName(name: string): boolean {
 
 function unsafeTelemetryArguments(source: ts.SourceFile): string[] {
   const failures: string[] = [];
+  const reported = new Set<string>();
   const report = (node: ts.Node): void => {
     const line = source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1;
-    failures.push(`${source.fileName}:${line}: ${node.getText(source).slice(0, 160)}`);
+    const failure = `${source.fileName}:${line}: ${node.getText(source).slice(0, 160)}`;
+    if (!reported.has(failure)) {
+      reported.add(failure);
+      failures.push(failure);
+    }
   };
   const bindingNames = (name: ts.BindingName): string[] => {
     if (ts.isIdentifier(name)) return [name.text];
@@ -62,8 +68,8 @@ function unsafeTelemetryArguments(source: ts.SourceFile): string[] {
       ts.isOmittedExpression(element) ? [] : bindingNames(element.name),
     );
   };
-  const inspectCatch = (clause: ts.CatchClause, caughtName: string): void => {
-    const tainted = new Set([caughtName]);
+  const inspectTaintedScope = (scope: ts.Node, caughtNames: string[]): void => {
+    const tainted = new Set(caughtNames);
     const taintMutationTarget = (candidate: ts.Expression): void => {
       let target: ts.Expression = candidate;
       while (ts.isPropertyAccessExpression(target) || ts.isElementAccessExpression(target)) {
@@ -87,6 +93,7 @@ function unsafeTelemetryArguments(source: ts.SourceFile): string[] {
             "extractRpcErrorMessage",
             "isDefiniteVenueRejection",
             "isRpcError",
+            "redactSensitiveText",
             "redactedThrownDiagnostics",
             "sanitizeErrorMessage",
           ].includes(name) ||
@@ -112,8 +119,8 @@ function unsafeTelemetryArguments(source: ts.SourceFile): string[] {
       }
       return candidate.getChildren(source).some(isTainted);
     };
-    const visitCatchNode = (node: ts.Node): void => {
-      if (node !== clause.block && ts.isCatchClause(node)) return;
+    const visitTaintedNode = (node: ts.Node): void => {
+      if (node !== scope && ts.isCatchClause(node)) return;
       if (ts.isVariableDeclaration(node)) {
         const names = bindingNames(node.name);
         if (node.initializer && isTainted(node.initializer)) {
@@ -164,14 +171,41 @@ function unsafeTelemetryArguments(source: ts.SourceFile): string[] {
           }
         }
       }
-      ts.forEachChild(node, visitCatchNode);
+      ts.forEachChild(node, visitTaintedNode);
     };
-    visitCatchNode(clause.block);
+    visitTaintedNode(scope);
+  };
+  const inspectRejectionCallback = (candidate: ts.Expression | undefined): void => {
+    if (!candidate) return;
+    if (!ts.isArrowFunction(candidate) && !ts.isFunctionExpression(candidate)) {
+      const isDirectConsoleSink =
+        ts.isPropertyAccessExpression(candidate) &&
+        ts.isIdentifier(candidate.expression) &&
+        candidate.expression.text === "console" &&
+        ["error", "warn", "log"].includes(candidate.name.text);
+      if (
+        isDirectConsoleSink ||
+        ((ts.isIdentifier(candidate) || ts.isPropertyAccessExpression(candidate)) &&
+          isTelemetrySinkName(sinkName(candidate)))
+      ) {
+        report(candidate);
+      }
+      return;
+    }
+    const caughtNames = candidate.parameters.flatMap((parameter) => bindingNames(parameter.name));
+    if (caughtNames.length > 0) inspectTaintedScope(candidate.body, caughtNames);
   };
   const visit = (node: ts.Node): void => {
     if (ts.isCatchClause(node)) {
       const variable = node.variableDeclaration?.name;
-      if (variable && ts.isIdentifier(variable)) inspectCatch(node, variable.text);
+      if (variable) inspectTaintedScope(node.block, bindingNames(variable));
+    }
+    if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
+      if (node.expression.name.text === "catch") {
+        inspectRejectionCallback(node.arguments[0]);
+      } else if (node.expression.name.text === "then") {
+        inspectRejectionCallback(node.arguments[1]);
+      }
     }
     ts.forEachChild(node, visit);
   };
@@ -297,6 +331,44 @@ describe("runtime error logging", () => {
           const diagnostics = redactedThrownDiagnostics(err);
           console.error("failed", diagnostics);
         }
+      `),
+    ).toEqual([]);
+  });
+
+  test("flags raw Promise rejection callback values at telemetry sinks", () => {
+    expect(
+      failuresForSnippet(`
+        doThing().catch((error) => {
+          const payload = { message: error.message };
+          console.error(payload);
+        });
+
+        doOtherThing().then(undefined, (reason) => {
+          writeAuditEvent({ reason: String(reason) });
+        });
+      `),
+    ).toHaveLength(2);
+  });
+
+  test("flags telemetry sinks passed directly as Promise rejection callbacks", () => {
+    expect(
+      failuresForSnippet(`
+        doThing().catch(console.error);
+        doOtherThing().then(undefined, writeAuditEvent);
+      `),
+    ).toHaveLength(2);
+  });
+
+  test("allows bounded diagnostics in Promise rejection callbacks", () => {
+    expect(
+      failuresForSnippet(`
+        doThing().catch((error) => {
+          console.error("failed", redactedThrownDiagnostics(error));
+        });
+
+        doOtherThing().then(undefined, (reason) => {
+          writeAuditEvent({ diagnostics: redactedThrownDiagnostics(reason) });
+        });
       `),
     ).toEqual([]);
   });


### PR DESCRIPTION
## Summary

Corrective follow-up to #464.

- bundle both `@stwd/shared` runtime entrypoints into `@stwd/eliza-plugin` and remove the unpublishable `workspace:*` runtime dependency
- add a tarball-level artifact regression that builds, packs, and inspects the published manifest and bundle
- extend the runtime telemetry guard to Promise `.catch` callbacks, `.then(_, onRejected)` callbacks, direct rejection sinks, aliases, and the Waifu console wrapper
- replace raw rejection logging in the DB migrator, Sol default-policy seed, and Waifu integration example with bounded diagnostics

## Exact-head evidence

Head: `617c950f2ebb9fc576c2b26c15e531cd87108953`
Base: `63e23a0230face5a214855fe28f7f3b814681ddf`

- runtime error-log safety guard: 10/10 tests
- Eliza plugin Vitest: 54 passed, 24 intentional skips across 8 files (includes 2 artifact regressions)
- Sol default-policy seed: 6/6 tests, 18 assertions
- affected dependency build: 10/10 tasks
- `npm pack` artifact `@stwd/eliza-plugin@0.4.4`: clean fresh-consumer install with `--omit=peer`, 4 packages added, 0 vulnerabilities; installed runtime dependencies contain only `@stwd/sdk`
- frozen lockfile install: green
- Biome on all changed source/config files and `git diff --check`: green

This PR is intentionally draft for corrective review and must not be merged until hosted checks and review are complete.