### PR TITLE
fix(api): keep development CORS DB-independent

### DIFF
--- a/packages/api/src/__tests__/tenant-cors-development.test.ts
+++ b/packages/api/src/__tests__/tenant-cors-development.test.ts
@@ -1,0 +1,65 @@
+import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+let databaseReads = 0;
+const originalNodeEnv = process.env.NODE_ENV;
+
+mock.module("@stwd/db", () => ({
+  getDb: () => {
+    databaseReads += 1;
+    throw new Error("database deliberately unavailable");
+  },
+  tenantAppClients: {},
+  tenantConfigs: {},
+}));
+
+describe("tenant CORS development wildcard", () => {
+  let tenantCors: typeof import("../middleware/tenant-cors").tenantCors;
+
+  beforeAll(async () => {
+    ({ tenantCors } = await import("../middleware/tenant-cors"));
+  });
+
+  afterAll(() => {
+    if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  test("does not consult tenant storage for an explicit development wildcard", async () => {
+    process.env.NODE_ENV = "development";
+    databaseReads = 0;
+    const app = new Hono();
+    app.use("*", tenantCors);
+
+    const response = await app.request("/resource", {
+      method: "OPTIONS",
+      headers: {
+        Origin: "https://local-ui.example",
+        "Access-Control-Request-Method": "PATCH",
+      },
+    });
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get("access-control-allow-origin")).toBe("*");
+    expect(databaseReads).toBe(0);
+  });
+
+  test("keeps production fail closed when origin storage is unavailable", async () => {
+    process.env.NODE_ENV = "production";
+    databaseReads = 0;
+    const app = new Hono();
+    app.use("*", tenantCors);
+
+    const response = await app.request("/resource", {
+      method: "OPTIONS",
+      headers: {
+        Origin: "https://console.example.com",
+        "Access-Control-Request-Method": "PATCH",
+      },
+    });
+
+    expect(response.status).toBe(403);
+    expect(response.headers.get("access-control-allow-origin")).toBeNull();
+    expect(databaseReads).toBe(1);
+  });
+});

--- a/packages/api/src/middleware/tenant-cors.ts
+++ b/packages/api/src/middleware/tenant-cors.ts
@@ -156,6 +156,7 @@ function devWildcardAllowed(): boolean {
 export async function tenantCors(c: Context, next: Next): Promise<Response | undefined> {
   const origin = c.req.header("origin") ?? "";
   const tenantId = c.req.header("X-Steward-Tenant");
+  const allowDevelopmentWildcard = devWildcardAllowed();
 
   // Set this before any lookup or early deny. A shared cache must never reuse
   // a 403/error produced for one origin or tenant hint for another request.
@@ -163,9 +164,9 @@ export async function tenantCors(c: Context, next: Next): Promise<Response | und
   // exit path (including DB failures) on the same cache contract.
   c.header("Vary", "Origin, X-Steward-Tenant");
 
-  let allowOrigin = devWildcardAllowed() ? "*" : "";
+  let allowOrigin = allowDevelopmentWildcard ? "*" : "";
 
-  if (!tenantId && origin) {
+  if (!allowDevelopmentWildcard && !tenantId && origin) {
     // No tenant header (true for ALL browser preflights and any SDK call that
     // carries the tenant in the body). Allow the request iff the Origin is in
     // any tenant's allowlist.
@@ -173,14 +174,13 @@ export async function tenantCors(c: Context, next: Next): Promise<Response | und
       const allOrigins = await getAllAllowedOrigins();
       if (allOrigins.has(origin)) {
         allowOrigin = origin;
-      } else if (!devWildcardAllowed()) {
+      } else {
         if (c.req.method === "OPTIONS") {
           return c.newResponse(null, 403);
         }
         await next();
         return;
       }
-      // unknown origin outside production → wildcard fallback below (dev mode)
     } catch (err) {
       console.warn(
         "[tenant-cors] Failed to load global origins, denying CORS",
@@ -192,7 +192,7 @@ export async function tenantCors(c: Context, next: Next): Promise<Response | und
       await next();
       return;
     }
-  } else if (tenantId && origin) {
+  } else if (!allowDevelopmentWildcard && tenantId && origin) {
     try {
       const origins = await getTenantOrigins(tenantId);
       if (origins.length > 0) {
@@ -208,14 +208,13 @@ export async function tenantCors(c: Context, next: Next): Promise<Response | und
           await next();
           return;
         }
-      } else if (!devWildcardAllowed()) {
+      } else {
         if (c.req.method === "OPTIONS") {
           return c.newResponse(null, 403);
         }
         await next();
         return;
       }
-      // origins.length === 0 → no config yet → fall through to wildcard outside production
     } catch (err) {
       console.warn(
         "[tenant-cors] Failed to load origins for tenant, denying CORS",


### PR DESCRIPTION
## Summary
- short-circuit tenant/global origin storage when the explicitly configured `test` or `development` wildcard is active
- prove an origin-bearing browser preflight succeeds without any DB access in development
- prove the same unavailable origin store remains a fail-closed 403 in production

## Validation
Exact head `6f63e1ee`, base `63e23a0230face5a214855fe28f7f3b814681ddf`:
- development/production CORS boundary: 2/2, 6 assertions
- `@stwd/api` TypeScript build: green
- Biome changed surfaces and `git diff --check`: green

This remains separate from #473/#479 as requested.

Closes #483
