### PR TITLE
fix(worker): defer audit work into request task context

### DIFF
--- a/packages/api/src/services/audit.ts
+++ b/packages/api/src/services/audit.ts
@@ -219,7 +219,7 @@ function rowsFromExecute<T>(result: unknown): T[] {
  * a durable record.
  */
 export function trackAuditEvent(ev: AuditEventInput): Promise<void> {
-  return waitUntilRequestDatabaseTask(
+  return waitUntilRequestDatabaseTask(() =>
     writeAuditEvent(ev).catch((err) => {
       console.error(
         `[audit] Failed to write event ${ev.action} for tenant ${ev.tenantId}`,


### PR DESCRIPTION
## Summary

Corrective follow-up to externally merged #488. The final additive commit passed an already-started Promise to the thunk-only `waitUntilRequestDatabaseTask` API, breaking TypeScript and bypassing child-context isolation. This wraps the audit write in the required thunk.

## Validation
- direct API TypeScript: green
- Biome: green
- diff-check: green

Refs #343. RLS activation remains open.