### PR TITLE
fix(worker): defer request database cleanup

### DIFF
--- a/packages/api/src/__tests__/worker-runtime-sentinel.test.ts
+++ b/packages/api/src/__tests__/worker-runtime-sentinel.test.ts
@@ -132,7 +132,7 @@ test("every autonomous recovery sweep owns its own request database", () => {
   }
 });
 
-test("Worker drains fire-and-forget webhook work before closing its request pool", async () => {
+test("Worker defers webhook cleanup without delaying its response", async () => {
   let releaseDelivery!: () => void;
   const deliveryGate = new Promise<void>((resolve) => {
     releaseDelivery = resolve;
@@ -140,6 +140,8 @@ test("Worker drains fire-and-forget webhook work before closing its request pool
   let closes = 0;
   let deliveryFinished = false;
   const requestDb = { marker: "worker-webhook" } as unknown as ReturnType<typeof getDb>;
+  let delivery!: Promise<void>;
+  let deferredCleanup!: Promise<unknown>;
   const owner = withWorkerRequestDatabase(
     {
       DATABASE_URL: "postgresql://worker.invalid/steward",
@@ -148,7 +150,7 @@ test("Worker drains fire-and-forget webhook work before closing its request pool
     async () => {
       // dispatchWebhook uses this same request-lifetime hook for its intentionally
       // unawaited configured delivery fan-out.
-      void waitUntilRequestDatabaseTask(async () => {
+      delivery = waitUntilRequestDatabaseTask(async () => {
         await deliveryGate;
         expect((getDb() as unknown as { marker: string }).marker).toBe("worker-webhook");
         deliveryFinished = true;
@@ -164,13 +166,16 @@ test("Worker drains fire-and-forget webhook work before closing its request pool
           closes += 1;
         },
       }),
+      waitUntil(promise) {
+        deferredCleanup = promise;
+      },
     },
   );
 
-  await Promise.resolve();
+  expect((await owner).status).toBe(200);
   expect(closes).toBe(0);
   releaseDelivery();
-  expect((await owner).status).toBe(200);
+  await Promise.all([delivery, deferredCleanup]);
   expect(deliveryFinished).toBe(true);
   expect(closes).toBe(1);
 
@@ -180,7 +185,19 @@ test("Worker drains fire-and-forget webhook work before closing its request pool
   );
   expect(webhookSource).toContain("waitUntilRequestDatabaseTask(");
   const auditSource = readFileSync(join(import.meta.dir, "../services/audit.ts"), "utf8");
-  expect(auditSource).toContain("waitUntilRequestDatabaseTask(");
+  expect(auditSource).toContain("waitUntilRequestDatabaseTask(() =>");
+});
+
+test("best-effort audit registration invokes a task callback", async () => {
+  const { trackAuditEvent } = await import("../services/audit");
+  await expect(
+    trackAuditEvent({
+      tenantId: "system",
+      actorType: "system",
+      action: "system.worker.audit_registration_test",
+      metadata: {},
+    }),
+  ).resolves.toBeUndefined();
 });
 
 test("Worker socket cleanup diagnostics are fixed and cannot replace handler errors", async () => {

--- a/packages/api/src/__tests__/worker-runtime-sentinel.test.ts
+++ b/packages/api/src/__tests__/worker-runtime-sentinel.test.ts
@@ -188,6 +188,37 @@ test("Worker defers webhook cleanup without delaying its response", async () => 
   expect(auditSource).toContain("waitUntilRequestDatabaseTask(() =>");
 });
 
+test("Worker closes a deferred database exactly once when waitUntil registration fails", async () => {
+  const requestDb = { marker: "worker-wait-until-failure" } as unknown as ReturnType<typeof getDb>;
+  let closes = 0;
+
+  await expect(
+    withWorkerRequestDatabase(
+      {
+        DATABASE_URL: "postgresql://worker.invalid/steward",
+        DATABASE_DRIVER: "neon-websocket",
+      },
+      async () => {
+        await waitUntilRequestDatabaseTask(async () => {});
+        return "response";
+      },
+      {
+        createHandle: () => ({
+          driver: "neon-websocket" as const,
+          db: requestDb as never,
+          async close() {
+            closes += 1;
+          },
+        }),
+        waitUntil() {
+          throw new Error("waitUntil registration failed");
+        },
+      },
+    ),
+  ).rejects.toThrow("waitUntil registration failed");
+  expect(closes).toBe(1);
+});
+
 test("best-effort audit registration invokes a task callback", async () => {
   const { trackAuditEvent } = await import("../services/audit");
   await expect(

--- a/packages/api/src/worker.ts
+++ b/packages/api/src/worker.ts
@@ -112,6 +112,7 @@ export async function withWorkerRequestDatabase<T>(
   options?: {
     createHandle?: WorkerDatabaseHandleFactory;
     createHttpDb?: WorkerHttpDatabaseFactory;
+    waitUntil?: (promise: Promise<unknown>) => void;
   },
 ): Promise<T> {
   const driver = env.DATABASE_DRIVER?.trim().toLowerCase();
@@ -122,21 +123,46 @@ export async function withWorkerRequestDatabase<T>(
   }
   if (driver === "neon-http") {
     const db = (options?.createHttpDb ?? createDbForRequest)(env);
-    return withRequestDatabase(db as unknown as ReturnType<typeof getDb>, callback);
+    return withRequestDatabase(
+      db as unknown as ReturnType<typeof getDb>,
+      callback,
+      options?.waitUntil ? { deferCleanup: options.waitUntil } : undefined,
+    );
   }
   const handle = (options?.createHandle ?? createNeonTransactionDbForRequest)(env);
   const noCallbackError = Symbol("no-callback-error");
   let callbackError: unknown | typeof noCallbackError = noCallbackError;
   let result: T | undefined;
+  let closeDeferred = false;
   try {
-    result = await withRequestDatabase(handle.db as unknown as ReturnType<typeof getDb>, callback);
+    result = await withRequestDatabase(
+      handle.db as unknown as ReturnType<typeof getDb>,
+      callback,
+      options?.waitUntil
+        ? {
+            deferCleanup(cleanup) {
+              const deferredClose = cleanup.then(async () => {
+                try {
+                  await handle.close();
+                } catch {
+                  throw new Error("WORKER_DATABASE_CLOSE_FAILED");
+                }
+              });
+              options.waitUntil?.(deferredClose);
+              closeDeferred = true;
+            },
+          }
+        : undefined,
+    );
   } catch (error) {
     callbackError = error;
   }
-  try {
-    await handle.close();
-  } catch {
-    if (callbackError === noCallbackError) throw new Error("WORKER_DATABASE_CLOSE_FAILED");
+  if (!closeDeferred) {
+    try {
+      await handle.close();
+    } catch {
+      if (callbackError === noCallbackError) throw new Error("WORKER_DATABASE_CLOSE_FAILED");
+    }
   }
   if (callbackError !== noCallbackError) throw callbackError;
   return result as T;
@@ -349,11 +375,20 @@ export default {
     // the once-per-isolate init below only bootstraps stores/imports.
     hydrateProcessEnv(env);
     await validateWorkerSecurityEnv();
-    return withWorkerRequestDatabase(env, async () => {
-      await ensureWorkerInit(env);
-      const app = await getComposedApp();
-      return app.fetch(request, env, ctx as never);
-    });
+    const executionCtx = ctx as { waitUntil?: (promise: Promise<unknown>) => void };
+    const waitUntil =
+      typeof executionCtx?.waitUntil === "function"
+        ? executionCtx.waitUntil.bind(executionCtx)
+        : undefined;
+    return withWorkerRequestDatabase(
+      env,
+      async () => {
+        await ensureWorkerInit(env);
+        const app = await getComposedApp();
+        return app.fetch(request, env, ctx as never);
+      },
+      waitUntil ? { waitUntil } : undefined,
+    );
   },
   async scheduled(
     _controller: unknown,

--- a/packages/api/src/worker.ts
+++ b/packages/api/src/worker.ts
@@ -134,6 +134,7 @@ export async function withWorkerRequestDatabase<T>(
   let callbackError: unknown | typeof noCallbackError = noCallbackError;
   let result: T | undefined;
   let closeDeferred = false;
+  let deferredClose: Promise<void> | null = null;
   try {
     result = await withRequestDatabase(
       handle.db as unknown as ReturnType<typeof getDb>,
@@ -141,7 +142,7 @@ export async function withWorkerRequestDatabase<T>(
       options?.waitUntil
         ? {
             deferCleanup(cleanup) {
-              const deferredClose = cleanup.then(async () => {
+              deferredClose = cleanup.then(async () => {
                 try {
                   await handle.close();
                 } catch {
@@ -159,7 +160,11 @@ export async function withWorkerRequestDatabase<T>(
   }
   if (!closeDeferred) {
     try {
-      await handle.close();
+      // `waitUntil` may throw after the close promise has already been
+      // created. Await that exact promise so the handle closes once and its
+      // rejection is observed instead of racing a second close.
+      if (deferredClose) await deferredClose;
+      else await handle.close();
     } catch {
       if (callbackError === noCallbackError) throw new Error("WORKER_DATABASE_CLOSE_FAILED");
     }

--- a/packages/db/src/__tests__/request-database-context.test.ts
+++ b/packages/db/src/__tests__/request-database-context.test.ts
@@ -169,4 +169,26 @@ describe("request-scoped database context", () => {
     release.resolve();
     await Promise.all([owner, registered, unregistered]);
   });
+
+  test("can defer registered cleanup while returning the owner result", async () => {
+    const requestDb = { marker: "request" } as unknown as ReturnType<typeof getDb>;
+    const release = deferred();
+    let cleanup!: Promise<void>;
+    let registered!: Promise<void>;
+    const owner = withRequestDatabase(
+      requestDb,
+      async () => {
+        registered = waitUntilRequestDatabaseTask(async () => {
+          await release.promise;
+          expect((getDb() as unknown as { marker: string }).marker).toBe("request");
+        });
+        return "response";
+      },
+      { deferCleanup: (promise) => (cleanup = promise) },
+    );
+
+    expect(await owner).toBe("response");
+    release.resolve();
+    await Promise.all([registered, cleanup]);
+  });
 });

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -602,6 +602,7 @@ async function drainRequestDatabaseTasks(context: RequestDatabaseContext): Promi
 export async function withRequestDatabase<T>(
   db: RequestDatabase,
   callback: () => Promise<T>,
+  options?: { deferCleanup?: (cleanup: Promise<void>) => void },
 ): Promise<T> {
   if (requestDatabaseStorage.getStore()) {
     throw new Error("REQUEST_DATABASE_CONTEXT_NESTED");
@@ -628,7 +629,17 @@ export async function withRequestDatabase<T>(
       // contexts; unregistered detached work retains this closed owner context.
       context.active = false;
       context.db = undefined;
-      await drainRequestDatabaseTasks(context);
+      const cleanup = drainRequestDatabaseTasks(context);
+      if (options?.deferCleanup) {
+        try {
+          options.deferCleanup(cleanup);
+        } catch (error) {
+          await cleanup;
+          if (callbackError === noCallbackError) throw error;
+        }
+      } else {
+        await cleanup;
+      }
       if (callbackError !== noCallbackError) throw callbackError;
       return result as T;
     });


### PR DESCRIPTION
## Summary

Post-merge corrective for #488.

- hand registered request database cleanup to the Worker execution lifetime so configured webhook delivery does not delay the HTTP response
- keep the WebSocket handle open until registered audit/webhook work settles, then close it exactly once
- preserve immediate owner-capability revocation and isolated registered child contexts
- add a runtime regression for the corrected audit task factory, non-blocking response/close ordering, and deferred cleanup

## Security findings fixed

The merged implementation awaited registered webhook work inside `fetch`, allowing a slow configured webhook to hold the client response. Its initial audit registration also passed an already-started Promise to a callback API; #489 corrected that runtime mismatch, and this PR retains it with an executing regression.

## Exact-head evidence

Head `1cc84004b5ad5c64b742a500c2e71291aa9d18f0`, base `ff6e72a310bd6f0312b2676fab7a3c139c250d45` (the final restack added only SECURITY.md):

- request database context: 9/9, 29 assertions
- Worker runtime sentinel: 14/14, 41 assertions
- API dependency build: 24/24 packages
- Biome: 5 changed files clean
- `git diff --check`: clean

Keep draft until fresh exact-head hosted CI is green.