### PR TITLE
test(eliza): allow cold artifact builds to finish

### DIFF
--- a/packages/eliza-plugin/src/__tests__/package-artifact.test.ts
+++ b/packages/eliza-plugin/src/__tests__/package-artifact.test.ts
@@ -39,7 +39,7 @@ beforeAll(() => {
     readFileSync(join(extracted, "package/package.json"), "utf8"),
   ) as typeof packedPackageJson;
   packedEntrypoint = readFileSync(join(extracted, "package/dist/index.js"), "utf8");
-}, 60_000);
+}, 180_000);
 
 afterAll(() => {
   rmSync(artifactDirectory, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- raise the package-artifact setup timeout from 60 seconds to 180 seconds
- keep the heavyweight dependency build, npm pack, tarball inspection, and runtime bundle assertions unchanged

## Failure evidence
A clean local exact run of the merged #484 suite completed the artifact setup after roughly 62 seconds, so Vitest aborted the hook at 60 seconds before any artifact assertion ran. The focused artifact suite passes with the bounded 180-second hook timeout.

## Validation
- package artifact: 3/3
- full Eliza plugin suite before this focused correction: 55 passed, 24 intentional skips
- diff check: clean

Corrective follow-up to #484.