### PR TITLE
fix(auth): persist user link challenges across instances

### DIFF
--- a/packages/api/src/__tests__/user-linked-accounts.test.ts
+++ b/packages/api/src/__tests__/user-linked-accounts.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it, spyOn } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it, mock, spyOn } from "bun:test";
 import { createPrivateKey, sign as cryptoSign, generateKeyPairSync } from "node:crypto";
 
 import { ChallengeStore, MockSmsInbox, signTelegramLoginPayload } from "@stwd/auth";
@@ -21,6 +21,53 @@ import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import bs58 from "bs58";
 import { and, eq } from "drizzle-orm";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+
+type RedisEntry = { value: string; expiresAt: number };
+const redisEntries = new Map<string, RedisEntry>();
+const redisClient = {
+  set: async (key: string, value: string, _mode: "PX", ttlMs: number, condition?: "NX") => {
+    const existing = redisEntries.get(key);
+    if (condition === "NX" && existing && existing.expiresAt > Date.now()) return null;
+    redisEntries.set(key, { value, expiresAt: Date.now() + ttlMs });
+    return "OK";
+  },
+  get: async (key: string) => {
+    const entry = redisEntries.get(key);
+    if (!entry) return null;
+    if (entry.expiresAt <= Date.now()) {
+      redisEntries.delete(key);
+      return null;
+    }
+    return entry.value;
+  },
+  getdel: async (key: string) => {
+    const entry = redisEntries.get(key);
+    redisEntries.delete(key);
+    return entry && entry.expiresAt > Date.now() ? entry.value : null;
+  },
+  del: async (...keys: string[]) => {
+    let removed = 0;
+    for (const key of keys) if (redisEntries.delete(key)) removed += 1;
+    return removed;
+  },
+};
+
+mock.module("../middleware/redis.js", () => ({
+  checkAgentRateLimit: async () => ({ allowed: true, remaining: Infinity, resetMs: 0 }),
+  checkAgentSpendLimit: async (_agentId: string, limitUsd: number) => ({
+    allowed: true,
+    spent: 0,
+    remaining: limitUsd,
+  }),
+  checkProxyRateLimit: async () => ({ allowed: true, remaining: Infinity, resetMs: 0 }),
+  estimateCost: () => 0,
+  getRedisClient: () => redisClient,
+  initRedis: async () => true,
+  isRedisAvailable: () => false,
+  isRedisConfigured: () => false,
+  recordAgentSpend: async () => undefined,
+  shutdownRedis: async () => undefined,
+}));
 
 const TENANT_ID = "user-linked-accounts";
 const SOLANA_TEST_KEYPAIR = {
@@ -88,6 +135,7 @@ function generateSolanaKeypair() {
 describe("user linked account routes", () => {
   let userRoutes: typeof import("../routes/user").userRoutes;
   let createSessionToken: typeof import("../routes/auth").createSessionToken;
+  let initAuthStores: typeof import("../routes/auth").initAuthStores;
   let userId = "";
   let accountOnlyUserId = "";
   let tenantOwnerUserId = "";
@@ -283,12 +331,14 @@ describe("user linked account routes", () => {
         policyResults: [],
       });
 
+    ({ createSessionToken, initAuthStores } = await import("../routes/auth"));
     ({ userRoutes } = await import("../routes/user"));
-    ({ createSessionToken } = await import("../routes/auth"));
+    await initAuthStores(false);
   });
 
   afterAll(async () => {
     await closeDb();
+    redisEntries.clear();
     delete process.env.STEWARD_PGLITE_MEMORY;
     delete process.env.STEWARD_MASTER_PASSWORD;
     delete process.env.STEWARD_JWT_SECRET;
@@ -519,6 +569,58 @@ describe("user linked account routes", () => {
       }),
     });
     expect(crossUser.status).toBe(409);
+  });
+
+  it("redeems an issued wallet proof after account-link stores are reconstructed", async () => {
+    const wallet = privateKeyToAccount(
+      "0x0dbbe8e4ca9a1525c35b248bb6e22cf95d86e0f0276de70cbb35289e587aa307",
+    );
+    const nonceResponse = await userRoutes.request("/me/accounts/wallet/ethereum/nonce", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${await tokenFor(userId)}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ address: wallet.address }),
+    });
+    expect(nonceResponse.status).toBe(200);
+    const nonceBody = (await nonceResponse.json()) as { data: { message: string } };
+    const signature = await wallet.signMessage({ message: nonceBody.data.message });
+    expect(
+      [...redisEntries.keys()].some((key) =>
+        key.startsWith("auth:challenge:16:user-link-wallet:wallet-link:ethereum:"),
+      ),
+    ).toBe(true);
+
+    await initAuthStores(false);
+
+    const linkResponse = await userRoutes.request("/me/accounts/wallet/ethereum", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${await tokenFor(userId)}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        address: wallet.address,
+        message: nonceBody.data.message,
+        signature,
+      }),
+    });
+    expect(linkResponse.status).toBe(200);
+
+    const replay = await userRoutes.request("/me/accounts/wallet/ethereum", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${await tokenFor(userId)}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        address: wallet.address,
+        message: nonceBody.data.message,
+        signature,
+      }),
+    });
+    expect(replay.status).toBe(401);
   });
 
   it("does not persist an Ethereum wallet when redeem-lock cleanup fails", async () => {

--- a/packages/api/src/__tests__/user-linked-accounts.test.ts
+++ b/packages/api/src/__tests__/user-linked-accounts.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it, mock, spyOn } from "bun:test";
 import { createPrivateKey, sign as cryptoSign, generateKeyPairSync } from "node:crypto";
 
-import { ChallengeStore, MockSmsInbox, signTelegramLoginPayload } from "@stwd/auth";
+import { ChallengeStore, MemoryBackend, MockSmsInbox, signTelegramLoginPayload } from "@stwd/auth";
 import {
   accounts,
   agents,
@@ -134,6 +134,7 @@ function generateSolanaKeypair() {
 
 describe("user linked account routes", () => {
   let userRoutes: typeof import("../routes/user").userRoutes;
+  let initUserLinkChallengeStores: typeof import("../routes/user").initUserLinkChallengeStores;
   let createSessionToken: typeof import("../routes/auth").createSessionToken;
   let initAuthStores: typeof import("../routes/auth").initAuthStores;
   let userId = "";
@@ -332,7 +333,7 @@ describe("user linked account routes", () => {
       });
 
     ({ createSessionToken, initAuthStores } = await import("../routes/auth"));
-    ({ userRoutes } = await import("../routes/user"));
+    ({ initUserLinkChallengeStores, userRoutes } = await import("../routes/user"));
     await initAuthStores(false);
   });
 
@@ -621,6 +622,25 @@ describe("user linked account routes", () => {
       }),
     });
     expect(replay.status).toBe(401);
+  });
+
+  it("destroys only a different superseded process-local account-link backend", async () => {
+    const first = new MemoryBackend();
+    const firstDestroy = spyOn(first, "destroy");
+    initUserLinkChallengeStores(first);
+    initUserLinkChallengeStores(first);
+    expect(firstDestroy).not.toHaveBeenCalled();
+
+    const replacement = new MemoryBackend();
+    const replacementDestroy = spyOn(replacement, "destroy");
+    initUserLinkChallengeStores(replacement);
+    expect(firstDestroy).toHaveBeenCalledTimes(1);
+    expect(replacementDestroy).not.toHaveBeenCalled();
+
+    await initAuthStores(false);
+    expect(replacementDestroy).toHaveBeenCalledTimes(1);
+    firstDestroy.mockRestore();
+    replacementDestroy.mockRestore();
   });
 
   it("does not persist an Ethereum wallet when redeem-lock cleanup fails", async () => {

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -1346,6 +1346,9 @@ export async function initAuthStores(usePostgres = false): Promise<void> {
   });
   _importSessionBackend = importSessionBackend;
 
+  const { initUserLinkChallengeStores } = await import("./user.js");
+  initUserLinkChallengeStores(challengeBackend);
+
   // Reset singletons so they pick up the new stores on next use
   _passkeyAuth = null;
   _phoneAuth = null;

--- a/packages/api/src/routes/user.ts
+++ b/packages/api/src/routes/user.ts
@@ -199,12 +199,15 @@ const WALLET_LINK_REDEEM_LOCK_TTL_MS = 10_000;
 const SOCIAL_LINK_CHALLENGE_TTL_MS = 5 * 60_000;
 const OAUTH_LINK_CHALLENGE_TTL_MS = 5 * 60_000;
 const initialUserLinkBackend = new MemoryBackend();
+let currentUserLinkBackend: StoreBackend | null = null;
 let walletLinkChallenges: ChallengeStore;
 let socialLinkChallenges: ChallengeStore;
 let oauthLinkChallenges: ChallengeStore;
 
 /** Bind account-link challenges to auth startup's selected durable backend. */
 export function initUserLinkChallengeStores(backend: StoreBackend): void {
+  const supersededBackend = currentUserLinkBackend;
+  currentUserLinkBackend = backend;
   walletLinkChallenges = new ChallengeStore({
     backend: new NamespacedStoreBackend(backend, "user-link-wallet"),
     ttlMs: WALLET_LINK_CHALLENGE_TTL_MS,
@@ -217,6 +220,9 @@ export function initUserLinkChallengeStores(backend: StoreBackend): void {
     backend: new NamespacedStoreBackend(backend, "user-link-oauth"),
     ttlMs: OAUTH_LINK_CHALLENGE_TTL_MS,
   });
+  if (supersededBackend instanceof MemoryBackend && supersededBackend !== backend) {
+    supersededBackend.destroy();
+  }
 }
 
 // Development and tests remain process-local until auth startup selects the

--- a/packages/api/src/routes/user.ts
+++ b/packages/api/src/routes/user.ts
@@ -35,8 +35,11 @@ import {
   hashSha256Hex,
   isBuiltInProvider,
   isValidE164,
+  MemoryBackend,
+  NamespacedStoreBackend,
   OAuthClient,
   revocationStore,
+  type StoreBackend,
   type TelegramLoginPayload,
   uint8ArrayToBase64url,
   verifyFarcasterLogin,
@@ -193,11 +196,32 @@ const USER_ACCOUNT_CAPABILITIES = [
 const USD_SCALE_DECIMALS = 18;
 const WALLET_LINK_CHALLENGE_TTL_MS = 5 * 60_000;
 const WALLET_LINK_REDEEM_LOCK_TTL_MS = 10_000;
-const walletLinkChallenges = new ChallengeStore({ ttlMs: WALLET_LINK_CHALLENGE_TTL_MS });
 const SOCIAL_LINK_CHALLENGE_TTL_MS = 5 * 60_000;
-const socialLinkChallenges = new ChallengeStore({ ttlMs: SOCIAL_LINK_CHALLENGE_TTL_MS });
 const OAUTH_LINK_CHALLENGE_TTL_MS = 5 * 60_000;
-const oauthLinkChallenges = new ChallengeStore({ ttlMs: OAUTH_LINK_CHALLENGE_TTL_MS });
+const initialUserLinkBackend = new MemoryBackend();
+let walletLinkChallenges: ChallengeStore;
+let socialLinkChallenges: ChallengeStore;
+let oauthLinkChallenges: ChallengeStore;
+
+/** Bind account-link challenges to auth startup's selected durable backend. */
+export function initUserLinkChallengeStores(backend: StoreBackend): void {
+  walletLinkChallenges = new ChallengeStore({
+    backend: new NamespacedStoreBackend(backend, "user-link-wallet"),
+    ttlMs: WALLET_LINK_CHALLENGE_TTL_MS,
+  });
+  socialLinkChallenges = new ChallengeStore({
+    backend: new NamespacedStoreBackend(backend, "user-link-social"),
+    ttlMs: SOCIAL_LINK_CHALLENGE_TTL_MS,
+  });
+  oauthLinkChallenges = new ChallengeStore({
+    backend: new NamespacedStoreBackend(backend, "user-link-oauth"),
+    ttlMs: OAUTH_LINK_CHALLENGE_TTL_MS,
+  });
+}
+
+// Development and tests remain process-local until auth startup selects the
+// shared backend. Every entry is still bounded by the flow-specific TTL.
+initUserLinkChallengeStores(initialUserLinkBackend);
 const TELEGRAM_LINK_MAX_AGE_SEC = 24 * 60 * 60;
 const TENANT_ROLES = ["owner", "admin", "developer", "billing", "viewer", "member"] as const;
 type TenantRole = (typeof TENANT_ROLES)[number];

--- a/packages/auth/src/__tests__/store-backends.test.ts
+++ b/packages/auth/src/__tests__/store-backends.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "bun:test";
 
-import { buildBackend, type RedisLike } from "../store-backends";
+import {
+  buildBackend,
+  MemoryBackend,
+  NamespacedStoreBackend,
+  type RedisLike,
+} from "../store-backends";
 
 function redisLike(overrides: Partial<RedisLike> = {}): RedisLike {
   const store = new Map<string, string>();
@@ -44,5 +49,44 @@ describe("buildBackend Redis smoke test", () => {
     });
     const { source } = await buildBackend("challenge", client, false);
     expect(source).toBe("memory");
+  });
+});
+
+describe("NamespacedStoreBackend", () => {
+  it("shares values across reconstructed stores in the same namespace", async () => {
+    const backend = new MemoryBackend();
+    const first = new NamespacedStoreBackend(backend, "wallet-link");
+    const reconstructed = new NamespacedStoreBackend(backend, "wallet-link");
+
+    await first.set("challenge", "signed-value", 60_000);
+
+    expect(await reconstructed.get("challenge")).toBe("signed-value");
+    backend.destroy();
+  });
+
+  it("isolates identical keys even when namespace boundaries are ambiguous", async () => {
+    const backend = new MemoryBackend();
+    const first = new NamespacedStoreBackend(backend, "wallet");
+    const second = new NamespacedStoreBackend(backend, "wallet:link");
+
+    await first.set("link:challenge", "first", 60_000);
+    await second.set("challenge", "second", 60_000);
+
+    expect(await first.get("link:challenge")).toBe("first");
+    expect(await second.get("challenge")).toBe("second");
+    backend.destroy();
+  });
+
+  it("preserves atomic replay rejection across reconstructed stores", async () => {
+    const backend = new MemoryBackend();
+    const first = new NamespacedStoreBackend(backend, "oauth-link");
+    const reconstructed = new NamespacedStoreBackend(backend, "oauth-link");
+    await first.set("state", "proof", 60_000);
+
+    const results = await Promise.all([first.consume("state"), reconstructed.consume("state")]);
+
+    expect(results.filter((value) => value === "proof")).toHaveLength(1);
+    expect(results.filter((value) => value === null)).toHaveLength(1);
+    backend.destroy();
   });
 });

--- a/packages/auth/src/__tests__/store-backends.test.ts
+++ b/packages/auth/src/__tests__/store-backends.test.ts
@@ -5,6 +5,7 @@ import {
   MemoryBackend,
   NamespacedStoreBackend,
   type RedisLike,
+  type StoreBackend,
 } from "../store-backends";
 
 function redisLike(overrides: Partial<RedisLike> = {}): RedisLike {
@@ -88,5 +89,41 @@ describe("NamespacedStoreBackend", () => {
     expect(results.filter((value) => value === "proof")).toHaveLength(1);
     expect(results.filter((value) => value === null)).toHaveLength(1);
     backend.destroy();
+  });
+
+  it("forwards the exact TTL and collision-safe key to the shared backend", async () => {
+    const writes: Array<{ key: string; value: string; ttlMs: number }> = [];
+    const backend: StoreBackend = {
+      set: async (key, value, ttlMs) => {
+        writes.push({ key, value, ttlMs });
+      },
+      setIfNotExists: async () => true,
+      get: async () => null,
+      consume: async () => null,
+      delete: async () => undefined,
+    };
+    const store = new NamespacedStoreBackend(backend, "oauth-link");
+
+    await store.set("state", "bound-proof", 123_456);
+
+    expect(writes).toEqual([{ key: "10:oauth-link:state", value: "bound-proof", ttlMs: 123_456 }]);
+  });
+
+  it("propagates backend consume failures without replaying or falling back", async () => {
+    let consumeCalls = 0;
+    const backend: StoreBackend = {
+      set: async () => undefined,
+      setIfNotExists: async () => true,
+      get: async () => null,
+      consume: async () => {
+        consumeCalls += 1;
+        throw new Error("durable backend unavailable");
+      },
+      delete: async () => undefined,
+    };
+    const store = new NamespacedStoreBackend(backend, "wallet-link");
+
+    await expect(store.consume("challenge")).rejects.toThrow("durable backend unavailable");
+    expect(consumeCalls).toBe(1);
   });
 });

--- a/packages/auth/src/store-backends.ts
+++ b/packages/auth/src/store-backends.ts
@@ -25,6 +25,47 @@ export interface StoreBackend {
   delete(key: string): Promise<void>;
 }
 
+/**
+ * Adds a collision-safe logical namespace to every key sent to a shared
+ * backend. This lets related stores share one durable backend selection while
+ * preserving independent key spaces and atomic backend operations.
+ */
+export class NamespacedStoreBackend implements StoreBackend {
+  private readonly keyPrefix: string;
+
+  constructor(
+    private readonly backend: StoreBackend,
+    namespace: string,
+  ) {
+    if (namespace.length === 0) throw new Error("Store namespace must not be empty");
+    this.keyPrefix = `${namespace.length}:${namespace}:`;
+  }
+
+  private key(key: string): string {
+    return this.keyPrefix + key;
+  }
+
+  async set(key: string, value: string, ttlMs: number): Promise<void> {
+    await this.backend.set(this.key(key), value, ttlMs);
+  }
+
+  async setIfNotExists(key: string, value: string, ttlMs: number): Promise<boolean> {
+    return this.backend.setIfNotExists(this.key(key), value, ttlMs);
+  }
+
+  async get(key: string): Promise<string | null> {
+    return this.backend.get(this.key(key));
+  }
+
+  async consume(key: string): Promise<string | null> {
+    return this.backend.consume(this.key(key));
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.backend.delete(this.key(key));
+  }
+}
+
 // ─── In-memory backend ─────────────────────────────────────────────────────
 
 interface MemoryEntry {


### PR DESCRIPTION
Closes #487

## Summary
- bind wallet, social, and OAuth account-link challenge stores to the backend selected by `initAuthStores`
- isolate each flow with a collision-safe namespaced backend adapter while preserving atomic backend operations
- destroy a superseded process-local account-link backend without destroying a backend reused by the next generation
- keep development/test startup explicitly memory-backed with the existing flow TTLs; production inherits the auth challenge store durability gate
- prove shared-backend reconstruction, namespace isolation, exact TTL forwarding, atomic replay rejection, fail-closed backend errors, wallet issue/redeem across auth-store reinitialization, and memory-backend lifecycle cleanup

## Security review
- challenge keys and payloads remain bound to authenticated user IDs; OAuth state additionally binds provider, tenant, redirect URI, and PKCE inputs
- OAuth state is hashed before entering the durable key; no provider access or refresh token is persisted in these challenge stores
- namespacing forwards backend `consume` unchanged, preserving Redis `GETDEL` and Postgres atomic `DELETE ... RETURNING` semantics
- backend failures propagate without process-local fallback

## Exact-head validation
Validated at `fd2435edc714d3f891a007169b857ebf18ac1c22` after rebasing onto `f14389fb1ff8c1186b183c08ce59fa46c6373ff2`.

- `bun test packages/auth/src/__tests__/store-backends.test.ts packages/auth/src/__tests__/challenge-store.test.ts` — 10 pass, 0 fail, 13 assertions
- `bun test --timeout 120000 packages/api/src/__tests__/user-linked-accounts.test.ts` — 20 pass, 0 fail, 147 assertions
- `bunx biome check` on all five changed files
- `git diff --check origin/develop...HEAD`
- hosted PR checks and CodeQL are pending on the exact head