### PR TITLE
fix(mcp): redact startup diagnostics and URLs

### DIFF
--- a/packages/mcp/src/__tests__/config.test.ts
+++ b/packages/mcp/src/__tests__/config.test.ts
@@ -31,6 +31,34 @@ describe("assertSecureBaseUrl", () => {
   test("rejects malformed URLs", () => {
     expect(() => assertSecureBaseUrl("not a url")).toThrow(/not a valid URL/);
   });
+
+  test("rejects credential-bearing URLs without reflecting credentials", () => {
+    const credential = "mcp-super-secret";
+    let message = "";
+    try {
+      assertSecureBaseUrl(`https://operator:${credential}@steward.example.com`);
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+    expect(message).toContain("embedded credentials are not allowed");
+    expect(message).not.toContain(credential);
+  });
+
+  test("does not reflect malformed or insecure URL values", () => {
+    const credential = "mcp-query-secret";
+    for (const value of [
+      `not-a-url-${credential}`,
+      `http://steward.example.com/?token=${credential}`,
+    ]) {
+      let message = "";
+      try {
+        assertSecureBaseUrl(value);
+      } catch (error) {
+        message = error instanceof Error ? error.message : String(error);
+      }
+      expect(message).not.toContain(credential);
+    }
+  });
 });
 
 describe("loadConfig", () => {

--- a/packages/mcp/src/cli.ts
+++ b/packages/mcp/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { describeThrown } from "@stwd/shared";
+import { redactedThrownDiagnostics } from "@stwd/shared";
 import { createStewardClient, loadConfig, redactConfig } from "./config.js";
 import { createStewardMcpServer } from "./server.js";
 
@@ -17,8 +17,8 @@ async function main(): Promise<void> {
   try {
     config = loadConfig(process.env);
   } catch (err) {
-    const message = describeThrown(err);
-    process.stderr.write(`[stwd-mcp] Configuration error: ${message}\n`);
+    const diagnostics = redactedThrownDiagnostics(err);
+    process.stderr.write(`[stwd-mcp] Configuration error: ${JSON.stringify(diagnostics)}\n`);
     process.exit(1);
     return;
   }
@@ -49,7 +49,7 @@ async function main(): Promise<void> {
 }
 
 main().catch((err) => {
-  const message = describeThrown(err);
-  process.stderr.write(`[stwd-mcp] Fatal error: ${message}\n`);
+  const diagnostics = redactedThrownDiagnostics(err);
+  process.stderr.write(`[stwd-mcp] Fatal error: ${JSON.stringify(diagnostics)}\n`);
   process.exit(1);
 });

--- a/packages/mcp/src/config.ts
+++ b/packages/mcp/src/config.ts
@@ -36,14 +36,19 @@ export function assertSecureBaseUrl(baseUrl: string): void {
   try {
     parsed = new URL(baseUrl);
   } catch {
-    throw new Error(`Invalid STEWARD_URL: ${JSON.stringify(baseUrl)} is not a valid URL`);
+    // Never reflect the supplied value: operators sometimes accidentally put
+    // credentials in this variable, and validation failures reach stderr.
+    throw new Error("Invalid STEWARD_URL: value is not a valid URL");
+  }
+  if (parsed.username || parsed.password) {
+    throw new Error("Invalid STEWARD_URL: embedded credentials are not allowed");
   }
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-    throw new Error(`Invalid STEWARD_URL protocol "${parsed.protocol}": only http(s) is supported`);
+    throw new Error("Invalid STEWARD_URL protocol: only http(s) is supported");
   }
   if (parsed.protocol === "http:" && !LOCAL_HOSTS.has(parsed.hostname)) {
     throw new Error(
-      `Insecure STEWARD_URL "${baseUrl}": http:// is only allowed for localhost. Use https:// for remote hosts.`,
+      "Insecure STEWARD_URL: http:// is only allowed for localhost. Use https:// for remote hosts.",
     );
   }
 }

--- a/scripts/__tests__/runtime-error-log-safety.test.ts
+++ b/scripts/__tests__/runtime-error-log-safety.test.ts
@@ -164,8 +164,15 @@ function unsafeTelemetryArguments(source: ts.SourceFile): string[] {
           ts.isIdentifier(node.expression.expression) &&
           node.expression.expression.text === "console" &&
           ["error", "warn", "log"].includes(node.expression.name.text);
+        const isProcessStreamSink =
+          ts.isPropertyAccessExpression(node.expression) &&
+          node.expression.name.text === "write" &&
+          ts.isPropertyAccessExpression(node.expression.expression) &&
+          ts.isIdentifier(node.expression.expression.expression) &&
+          node.expression.expression.expression.text === "process" &&
+          ["stderr", "stdout"].includes(node.expression.expression.name.text);
         const name = sinkName(node.expression);
-        if (isConsoleSink || isTelemetrySinkName(name)) {
+        if (isConsoleSink || isProcessStreamSink || isTelemetrySinkName(name)) {
           for (const argument of node.arguments) {
             if (isTainted(argument)) report(argument);
           }
@@ -357,6 +364,28 @@ describe("runtime error logging", () => {
         doOtherThing().then(undefined, writeAuditEvent);
       `),
     ).toHaveLength(2);
+  });
+
+  test("flags raw throwables written to process streams", () => {
+    expect(
+      failuresForSnippet(`
+        doThing().catch((error) => {
+          const message = describeThrown(error);
+          process.stderr.write(\`failed: \${message}\\n\`);
+        });
+      `),
+    ).toHaveLength(1);
+  });
+
+  test("allows bounded diagnostics written to process streams", () => {
+    expect(
+      failuresForSnippet(`
+        doThing().catch((error) => {
+          const diagnostics = redactedThrownDiagnostics(error);
+          process.stderr.write(JSON.stringify(diagnostics));
+        });
+      `),
+    ).toEqual([]);
   });
 
   test("allows bounded diagnostics in Promise rejection callbacks", () => {


### PR DESCRIPTION
## Summary

Corrective follow-up to #484 after its automatic merge.

- never reflect `STEWARD_URL` values into MCP stderr diagnostics
- reject URL userinfo so credentials cannot be accepted in the transport origin
- replace raw startup/config rejection text with bounded error diagnostics
- extend the runtime telemetry guard to cover `process.stderr.write` and `process.stdout.write`

## Exact-head evidence

- `@stwd/mcp`: 68 tests, 225 assertions
- runtime error-log safety: 12 tests
- MCP build: green
- compiled CLI credential-bearing URL wire check: no credential on stderr
- Biome and `git diff --check`: green

Draft: do not merge until hosted checks and review complete.