### PR TITLE
fix(worker): defer request database cleanup

### DIFF
--- a/packages/api/src/__tests__/worker-runtime-sentinel.test.ts
+++ b/packages/api/src/__tests__/worker-runtime-sentinel.test.ts
@@ -13,6 +13,7 @@ import {
 
 test("Worker hydration cannot be overridden by a STEWARD_RUNTIME binding", () => {
   const previous = process.env.STEWARD_RUNTIME;
+  const previousDatabaseUrl = process.env.DATABASE_URL;
   try {
     hydrateProcessEnv({
       DATABASE_URL: "postgresql://worker.invalid/steward",
@@ -22,6 +23,8 @@ test("Worker hydration cannot be overridden by a STEWARD_RUNTIME binding", () =>
   } finally {
     if (previous === undefined) delete process.env.STEWARD_RUNTIME;
     else process.env.STEWARD_RUNTIME = previous;
+    if (previousDatabaseUrl === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = previousDatabaseUrl;
   }
 });
 
@@ -94,7 +97,9 @@ test("Worker HTTP mode binds an exact request database without a persistent hand
 });
 
 test("Worker request membrane preserves real Drizzle query execution", async () => {
-  const { db: pgliteDb, client } = await createPGLiteDb("memory://");
+  const previousPgliteMemory = process.env.STEWARD_PGLITE_MEMORY;
+  process.env.STEWARD_PGLITE_MEMORY = "true";
+  const { db: pgliteDb, client } = await createPGLiteDb();
   try {
     const rows = await withWorkerRequestDatabase(
       {
@@ -107,6 +112,8 @@ test("Worker request membrane preserves real Drizzle query execution", async () 
     expect(Array.isArray(rows)).toBe(true);
   } finally {
     await client.close();
+    if (previousPgliteMemory === undefined) delete process.env.STEWARD_PGLITE_MEMORY;
+    else process.env.STEWARD_PGLITE_MEMORY = previousPgliteMemory;
   }
 });
 
@@ -132,7 +139,7 @@ test("every autonomous recovery sweep owns its own request database", () => {
   }
 });
 
-test("Worker drains fire-and-forget webhook work before closing its request pool", async () => {
+test("Worker returns before background work and closes its pool after waitUntil", async () => {
   let releaseDelivery!: () => void;
   const deliveryGate = new Promise<void>((resolve) => {
     releaseDelivery = resolve;
@@ -140,7 +147,8 @@ test("Worker drains fire-and-forget webhook work before closing its request pool
   let closes = 0;
   let deliveryFinished = false;
   const requestDb = { marker: "worker-webhook" } as unknown as ReturnType<typeof getDb>;
-  const owner = withWorkerRequestDatabase(
+  const deferred: Promise<unknown>[] = [];
+  const response = await withWorkerRequestDatabase(
     {
       DATABASE_URL: "postgresql://worker.invalid/steward",
       DATABASE_DRIVER: "neon-websocket",
@@ -164,13 +172,18 @@ test("Worker drains fire-and-forget webhook work before closing its request pool
           closes += 1;
         },
       }),
+      waitUntil(task) {
+        deferred.push(task);
+      },
     },
   );
 
-  await Promise.resolve();
+  expect(response.status).toBe(200);
+  expect(deferred).toHaveLength(1);
+  expect(deliveryFinished).toBe(false);
   expect(closes).toBe(0);
   releaseDelivery();
-  expect((await owner).status).toBe(200);
+  await Promise.all(deferred);
   expect(deliveryFinished).toBe(true);
   expect(closes).toBe(1);
 
@@ -181,6 +194,50 @@ test("Worker drains fire-and-forget webhook work before closing its request pool
   expect(webhookSource).toContain("waitUntilRequestDatabaseTask(");
   const auditSource = readFileSync(join(import.meta.dir, "../services/audit.ts"), "utf8");
   expect(auditSource).toContain("waitUntilRequestDatabaseTask(");
+});
+
+test("Worker schedules background cleanup even when the request owner fails", async () => {
+  let releaseTask!: () => void;
+  const taskGate = new Promise<void>((resolve) => {
+    releaseTask = resolve;
+  });
+  let closes = 0;
+  const deferred: Promise<unknown>[] = [];
+  const requestDb = { marker: "worker-error" } as unknown as ReturnType<typeof getDb>;
+
+  await expect(
+    withWorkerRequestDatabase(
+      {
+        DATABASE_URL: "postgresql://worker.invalid/steward",
+        DATABASE_DRIVER: "neon-websocket",
+      },
+      async () => {
+        void waitUntilRequestDatabaseTask(async () => {
+          await taskGate;
+          expect((getDb() as unknown as { marker: string }).marker).toBe("worker-error");
+        });
+        throw new Error("handler failed");
+      },
+      {
+        createHandle: () => ({
+          driver: "neon-websocket" as const,
+          db: requestDb as never,
+          async close() {
+            closes += 1;
+          },
+        }),
+        waitUntil(task) {
+          deferred.push(task);
+        },
+      },
+    ),
+  ).rejects.toThrow("handler failed");
+
+  expect(deferred).toHaveLength(1);
+  expect(closes).toBe(0);
+  releaseTask();
+  await Promise.all(deferred);
+  expect(closes).toBe(1);
 });
 
 test("Worker socket cleanup diagnostics are fixed and cannot replace handler errors", async () => {

--- a/packages/api/src/worker.ts
+++ b/packages/api/src/worker.ts
@@ -102,9 +102,9 @@ type WorkerHttpDatabaseFactory = (env: {
  *
  * neon-http remains the shipped default and needs no persistent cleanup. The
  * transaction-capable WebSocket driver is explicit: its handle is bound to the
- * async request so every legacy getDb() call resolves the same Drizzle object,
- * then close() is awaited on success and failure. No handle is cached on the
- * isolate.
+ * async request so every legacy getDb() call resolves the same Drizzle object.
+ * Interactive callers await close directly; fetch callers hand registered work
+ * and close to the Worker lifetime hook. No handle is cached on the isolate.
  */
 export async function withWorkerRequestDatabase<T>(
   env: Env,
@@ -112,6 +112,7 @@ export async function withWorkerRequestDatabase<T>(
   options?: {
     createHandle?: WorkerDatabaseHandleFactory;
     createHttpDb?: WorkerHttpDatabaseFactory;
+    waitUntil?: (task: Promise<unknown>) => void;
   },
 ): Promise<T> {
   const driver = env.DATABASE_DRIVER?.trim().toLowerCase();
@@ -122,9 +123,27 @@ export async function withWorkerRequestDatabase<T>(
   }
   if (driver === "neon-http") {
     const db = (options?.createHttpDb ?? createDbForRequest)(env);
-    return withRequestDatabase(db as unknown as ReturnType<typeof getDb>, callback);
+    const requestOptions = options?.waitUntil
+      ? { deferRegisteredTasks: options.waitUntil }
+      : undefined;
+    return withRequestDatabase(db as unknown as ReturnType<typeof getDb>, callback, requestOptions);
   }
   const handle = (options?.createHandle ?? createNeonTransactionDbForRequest)(env);
+  if (options?.waitUntil) {
+    const waitUntil = options.waitUntil;
+    return withRequestDatabase(handle.db as unknown as ReturnType<typeof getDb>, callback, {
+      deferRegisteredTasks: (drain) => {
+        const cleanup = drain.then(async () => {
+          try {
+            await handle.close();
+          } catch {
+            throw new Error("WORKER_DATABASE_CLOSE_FAILED");
+          }
+        });
+        waitUntil(cleanup);
+      },
+    });
+  }
   const noCallbackError = Symbol("no-callback-error");
   let callbackError: unknown | typeof noCallbackError = noCallbackError;
   let result: T | undefined;
@@ -343,17 +362,25 @@ async function getComposedApp() {
 }
 
 export default {
-  async fetch(request: Request, env: Env, ctx: unknown): Promise<Response> {
+  async fetch(
+    request: Request,
+    env: Env,
+    ctx: { waitUntil(task: Promise<unknown>): void },
+  ): Promise<Response> {
     // SEC-148: refresh process.env from the CURRENT request's bindings on every
     // request (not once per isolate) so rotated bindings take effect promptly;
     // the once-per-isolate init below only bootstraps stores/imports.
     hydrateProcessEnv(env);
     await validateWorkerSecurityEnv();
-    return withWorkerRequestDatabase(env, async () => {
-      await ensureWorkerInit(env);
-      const app = await getComposedApp();
-      return app.fetch(request, env, ctx as never);
-    });
+    return withWorkerRequestDatabase(
+      env,
+      async () => {
+        await ensureWorkerInit(env);
+        const app = await getComposedApp();
+        return app.fetch(request, env, ctx as never);
+      },
+      { waitUntil: (task) => ctx.waitUntil(task) },
+    );
   },
   async scheduled(
     _controller: unknown,

--- a/packages/db/src/__tests__/request-database-context.test.ts
+++ b/packages/db/src/__tests__/request-database-context.test.ts
@@ -148,6 +148,33 @@ describe("request-scoped database context", () => {
     expect(detachedFinished).toBe(true);
   });
 
+  test("hands registered work off without delaying the owner result", async () => {
+    const requestDb = { marker: "request" } as unknown as ReturnType<typeof getDb>;
+    const release = deferred();
+    const deferredTasks: Promise<void>[] = [];
+    let backgroundFinished = false;
+
+    const result = await withRequestDatabase(
+      requestDb,
+      async () => {
+        void waitUntilRequestDatabaseTask(async () => {
+          await release.promise;
+          expect((getDb() as unknown as { marker: string }).marker).toBe("request");
+          backgroundFinished = true;
+        });
+        return "response";
+      },
+      { deferRegisteredTasks: (task) => deferredTasks.push(task) },
+    );
+
+    expect(result).toBe("response");
+    expect(backgroundFinished).toBe(false);
+    expect(deferredTasks).toHaveLength(1);
+    release.resolve();
+    await Promise.all(deferredTasks);
+    expect(backgroundFinished).toBe(true);
+  });
+
   test("does not let unregistered work piggyback on a registered task lifetime", async () => {
     const requestDb = { marker: "request" } as unknown as ReturnType<typeof getDb>;
     const release = deferred();

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -511,10 +511,10 @@ function trackRequestDatabaseTask<T>(
  * Keep explicitly detached work inside the current request database lifetime.
  *
  * Worker services that intentionally start best-effort asynchronous work must
- * register the resulting promise here. The request owner drains registered
- * work before revoking the database capability and closing its socket. Outside
- * a request-owned database context this is a no-op, preserving Bun's existing
- * process-owned background-work behavior.
+ * register the resulting promise here. The request owner either drains that
+ * work directly or hands the drain to its runtime lifetime hook before closing
+ * the database transport. Outside a request-owned database context this is a
+ * no-op, preserving Bun's process-owned background-work behavior.
  */
 export function waitUntilRequestDatabaseTask<T>(task: () => Promise<T>): Promise<T> {
   const context = requestDatabaseStorage.getStore();
@@ -602,6 +602,7 @@ async function drainRequestDatabaseTasks(context: RequestDatabaseContext): Promi
 export async function withRequestDatabase<T>(
   db: RequestDatabase,
   callback: () => Promise<T>,
+  options?: { deferRegisteredTasks?: (task: Promise<void>) => void },
 ): Promise<T> {
   if (requestDatabaseStorage.getStore()) {
     throw new Error("REQUEST_DATABASE_CONTEXT_NESTED");
@@ -628,7 +629,19 @@ export async function withRequestDatabase<T>(
       // contexts; unregistered detached work retains this closed owner context.
       context.active = false;
       context.db = undefined;
-      await drainRequestDatabaseTasks(context);
+      const drain = drainRequestDatabaseTasks(context);
+      if (options?.deferRegisteredTasks) {
+        try {
+          options.deferRegisteredTasks(drain);
+        } catch (error) {
+          // A failed lifetime hand-off must not orphan registered work. Drain
+          // it locally before surfacing the registration failure.
+          await drain;
+          throw error;
+        }
+      } else {
+        await drain;
+      }
       if (callbackError !== noCallbackError) throw callbackError;
       return result as T;
     });


### PR DESCRIPTION
## Summary

Replacement for the closed #481, narrowed after the request-database containment merged in #488 and audit task registration merged in #489.

- return the Worker fetch response before registered webhook, retry, and audit work drains
- retain only registered child database capabilities through `ctx.waitUntil`
- keep the Neon WebSocket pool open until the registered drain finishes, then close it
- revoke the request owner context immediately, including unregistered inherited async work
- schedule the same drain-and-close cleanup when the handler rejects
- add behavioral success/error lifetime tests and preserve the source gate covering both webhook dispatch and `trackAuditEvent`

## Validation

Exact head: `e8c117239d5446ba50c0af75c94bd1d863a69ce5`
Base: `fbc46d42fc3f558528ecba592adb436d5d4f64c8`

- `bun test --timeout 120000 packages/db/src/__tests__/request-database-context.test.ts packages/api/src/__tests__/worker-runtime-sentinel.test.ts` — 23 pass, 0 fail, 79 assertions
- `bunx turbo run build --filter=@stwd/api` — 24/24 tasks successful
- Biome on all four changed files — pass
- `git diff --check origin/develop...HEAD` — pass
