### PR TITLE
fix(provider-x): revoke complete owned credential lineage

### DIFF
--- a/packages/api/src/__tests__/provider-x-connect.test.ts
+++ b/packages/api/src/__tests__/provider-x-connect.test.ts
@@ -33,7 +33,7 @@ import {
 } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { SecretVault } from "@stwd/vault";
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { providerAuthorityStore } from "../services/provider-authority-store";
 import {
   __runDefaultXForwardForTests,
@@ -2231,7 +2231,7 @@ describe("disconnect", () => {
     });
   });
 
-  test("malformed credentials cannot block local revocation or later reconnect", async () => {
+  test("malformed deterministic lineage fails closed without destructive action", async () => {
     const { completed } = await connectHappy(new MemoryConnectStore());
     const malformed = await vault.rotateSecret(
       TENANT,
@@ -2252,40 +2252,28 @@ describe("disconnect", () => {
         vault,
         config: CONFIG,
       }),
-    ).resolves.toMatchObject({ revoked: false });
+    ).rejects.toMatchObject({ code: "X_CREDENTIAL_NEEDS_ATTENTION" });
     expect(malformedFake.counters.revoke).toBe(0);
     malformedFake.restore();
-    const [locallyRevoked] = await getDb()
+    const [unchangedAccount] = await getDb()
       .select()
       .from(providerAccounts)
       .where(eq(providerAccounts.id, completed.providerAccountId));
-    expect(locallyRevoked).toMatchObject({
-      status: "revoked",
-      credentialSecretId: null,
-      credentialVersion: null,
+    expect(unchangedAccount).toMatchObject({
+      status: "active",
+      credentialSecretId: malformed.id,
+      credentialVersion: malformed.version,
     });
-    const [unrecoverable] = await getDb()
+    const [unchangedSecret] = await getDb()
+      .select()
+      .from(secrets)
+      .where(eq(secrets.id, malformed.id));
+    expect(unchangedSecret.deletedAt).toBeNull();
+    const disconnectLifecycles = await getDb()
       .select()
       .from(providerXCredentialLifecycles)
       .where(eq(providerXCredentialLifecycles.kind, "disconnect_revoke"));
-    expect(unrecoverable).toMatchObject({
-      state: "needs_attention",
-      credentialSecretId: null,
-      lastErrorCode: "DISCONNECT_REVOCATION_HANDLE_UNAVAILABLE",
-    });
-    const reconnect = await connectHappy(new MemoryConnectStore());
-    expect(reconnect.completed).toMatchObject({
-      providerAccountId: completed.providerAccountId,
-      reconnected: true,
-    });
-    const [superseded] = await getDb()
-      .select()
-      .from(providerXCredentialLifecycles)
-      .where(eq(providerXCredentialLifecycles.id, unrecoverable.id));
-    expect(superseded).toMatchObject({
-      state: "superseded",
-      lastErrorCode: "SUPERSEDED_BY_RECONNECT",
-    });
+    expect(disconnectLifecycles).toEqual([]);
   });
 
   test("a wrong secret pointer cannot revoke, delete, or disable unrelated authority", async () => {
@@ -2430,6 +2418,188 @@ describe("disconnect", () => {
     const [route] = await db.select().from(secretRoutes).where(eq(secretRoutes.id, routeId));
     expect(route).toMatchObject({ enabled: false, authorityRevision: 2 });
     fake.restore();
+  });
+
+  test("a null pointer revokes every live owned lineage version and route", async () => {
+    const { completed } = await connectHappy(new MemoryConnectStore());
+    const db = getDb();
+    const [accountBefore] = await db
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, completed.providerAccountId));
+    const firstSecretId = accountBefore.credentialSecretId as string;
+    const firstPayload = await decryptCredential(completed.providerAccountId);
+    const secondSecret = await vault.rotateSecret(
+      TENANT,
+      xCredentialSecretName(WORKSPACE, firstPayload.xUserId),
+      JSON.stringify({
+        ...firstPayload,
+        accessToken: "access-second-live-version",
+        refreshToken: "refresh-second-live-version",
+        obtainedAt: new Date().toISOString(),
+      } satisfies XCredentialPayload),
+    );
+    // Simulate a committed legacy/corrupt state that the real schema permits:
+    // uniqueness is per version, not per live deterministic name.
+    await db.update(secrets).set({ deletedAt: null }).where(eq(secrets.id, firstSecretId));
+    const routeIds = [
+      "50000000-0000-4000-8000-0000000000e4",
+      "50000000-0000-4000-8000-0000000000e5",
+    ];
+    await db.insert(secretRoutes).values([
+      {
+        id: routeIds[0],
+        tenantId: TENANT,
+        secretId: firstSecretId,
+        hostPattern: "api.x.com",
+        pathPattern: "/2/tweets",
+        method: "POST",
+        injectAs: "header",
+        injectKey: "Authorization",
+        injectFormat: "Bearer {value}",
+      },
+      {
+        id: routeIds[1],
+        tenantId: TENANT,
+        secretId: secondSecret.id,
+        hostPattern: "api.x.com",
+        pathPattern: "/2/users/me",
+        method: "GET",
+        injectAs: "header",
+        injectKey: "Authorization",
+        injectFormat: "Bearer {value}",
+      },
+    ]);
+    await db
+      .update(providerAccounts)
+      .set({ credentialSecretId: null, credentialVersion: null })
+      .where(eq(providerAccounts.id, completed.providerAccountId));
+
+    const fake = installFakeX();
+    await expect(
+      disconnectXProviderCredential({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        accountId: completed.providerAccountId,
+        callerUserId: ADMIN,
+        vault,
+        config: CONFIG,
+      }),
+    ).resolves.toMatchObject({ revoked: true });
+    expect(fake.counters.revoke).toBe(2);
+    expect(
+      fake.counters.revokeBodies.map((body) => new URLSearchParams(body).get("token")).sort(),
+    ).toEqual(["refresh-initial", "refresh-second-live-version"].sort());
+    fake.restore();
+
+    const lineage = await db
+      .select()
+      .from(secrets)
+      .where(inArray(secrets.id, [firstSecretId, secondSecret.id]));
+    expect(lineage).toHaveLength(2);
+    expect(lineage.every((secret) => secret.deletedAt !== null)).toBe(true);
+    const routes = await db.select().from(secretRoutes).where(inArray(secretRoutes.id, routeIds));
+    expect(routes).toHaveLength(2);
+    expect(routes.every((route) => !route.enabled && route.authorityRevision === 2)).toBe(true);
+    const lifecycles = await db
+      .select()
+      .from(providerXCredentialLifecycles)
+      .where(eq(providerXCredentialLifecycles.kind, "disconnect_revoke"));
+    expect(lifecycles).toHaveLength(2);
+    expect(
+      lifecycles.every(
+        (lifecycle) => lifecycle.state === "revoked" && lifecycle.credentialSecretId === null,
+      ),
+    ).toBe(true);
+  });
+
+  test("same-name mismatched binding aborts without touching owned or unrelated authority", async () => {
+    const { completed } = await connectHappy(new MemoryConnectStore());
+    const db = getDb();
+    const [accountBefore] = await db
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, completed.providerAccountId));
+    const ownedSecretId = accountBefore.credentialSecretId as string;
+    const ownedPayload = await decryptCredential(completed.providerAccountId);
+    const unrelatedSecret = await vault.rotateSecret(
+      TENANT,
+      xCredentialSecretName(WORKSPACE, ownedPayload.xUserId),
+      JSON.stringify({
+        ...ownedPayload,
+        accessToken: "unrelated-access-handle",
+        refreshToken: "unrelated-refresh-handle",
+        xUserId: "999999999",
+        xUsername: "unrelated",
+        obtainedAt: new Date().toISOString(),
+      } satisfies XCredentialPayload),
+    );
+    await db.update(secrets).set({ deletedAt: null }).where(eq(secrets.id, ownedSecretId));
+    const routeIds = [
+      "50000000-0000-4000-8000-0000000000e6",
+      "50000000-0000-4000-8000-0000000000e7",
+    ];
+    await db.insert(secretRoutes).values([
+      {
+        id: routeIds[0],
+        tenantId: TENANT,
+        secretId: ownedSecretId,
+        hostPattern: "api.x.com",
+        pathPattern: "/2/tweets",
+        method: "POST",
+        injectAs: "header",
+        injectKey: "Authorization",
+        injectFormat: "Bearer {value}",
+      },
+      {
+        id: routeIds[1],
+        tenantId: TENANT,
+        secretId: unrelatedSecret.id,
+        hostPattern: "api.unrelated.test",
+        pathPattern: "/live",
+        method: "POST",
+        injectAs: "header",
+        injectKey: "Authorization",
+        injectFormat: "Bearer {value}",
+      },
+    ]);
+
+    const fake = installFakeX();
+    await expect(
+      disconnectXProviderCredential({
+        tenantId: TENANT,
+        workspaceId: WORKSPACE,
+        accountId: completed.providerAccountId,
+        callerUserId: ADMIN,
+        vault,
+        config: CONFIG,
+      }),
+    ).rejects.toMatchObject({ code: "X_CREDENTIAL_NEEDS_ATTENTION" });
+    expect(fake.counters.revoke).toBe(0);
+    fake.restore();
+
+    const [accountAfter] = await db
+      .select()
+      .from(providerAccounts)
+      .where(eq(providerAccounts.id, completed.providerAccountId));
+    expect(accountAfter).toMatchObject({
+      status: "active",
+      credentialSecretId: ownedSecretId,
+      credentialVersion: accountBefore.credentialVersion,
+      revision: accountBefore.revision,
+    });
+    const lineage = await db
+      .select()
+      .from(secrets)
+      .where(inArray(secrets.id, [ownedSecretId, unrelatedSecret.id]));
+    expect(lineage.every((secret) => secret.deletedAt === null)).toBe(true);
+    const routes = await db.select().from(secretRoutes).where(inArray(secretRoutes.id, routeIds));
+    expect(routes.every((route) => route.enabled && route.authorityRevision === 1)).toBe(true);
+    const disconnectLifecycles = await db
+      .select()
+      .from(providerXCredentialLifecycles)
+      .where(eq(providerXCredentialLifecycles.kind, "disconnect_revoke"));
+    expect(disconnectLifecycles).toEqual([]);
   });
 
   test("disconnect of a missing account => X_ACCOUNT_NOT_FOUND", async () => {

--- a/packages/api/src/services/provider-x-connect.ts
+++ b/packages/api/src/services/provider-x-connect.ts
@@ -2658,7 +2658,7 @@ export async function disconnectXProviderCredential(
     // ownership. Resolve disconnect authority from the deterministic X account
     // lineage so a corrupt pointer can neither sacrifice an unrelated secret
     // nor hide the actual X grant from local revocation.
-    const [lineageSecret] = (await tx
+    const lineageSecrets = (await tx
       .select()
       .from(secrets)
       .where(
@@ -2669,62 +2669,79 @@ export async function disconnectXProviderCredential(
         ),
       )
       .orderBy(desc(secrets.version))
-      .limit(1)
       .for("update")) as Secret[];
-    const lineageSecretId = lineageSecret?.id ?? null;
+    const classifiedLineage = lineageSecrets.map((secret) =>
+      classifyXDisconnectLineageSecret(input.vault, input.tenantId, secret, account.externalRef),
+    );
+    const ambiguousLineage = classifiedLineage.filter((entry) => !entry.owned);
+    if (ambiguousLineage.length > 0) {
+      throw new XConnectError(
+        "X_CREDENTIAL_NEEDS_ATTENTION",
+        409,
+        "X credential lineage ownership is ambiguous",
+      );
+    }
+    const ownedLineage = classifiedLineage.filter(
+      (entry): entry is XOwnedDisconnectLineageSecret => entry.owned,
+    );
+    const ownedLineageIds = ownedLineage.map((entry) => entry.secret.id);
 
-    if (account.status === "revoked" && !account.credentialSecretId && !lineageSecretId) {
-      return { lifecycleId: null, retryAt: null };
+    if (account.status === "revoked" && !account.credentialSecretId && ownedLineage.length === 0) {
+      return { lifecycles: [], allHandlesAvailable: false };
     }
 
     const pointerIssue = !account.credentialSecretId
       ? "CREDENTIAL_POINTER_MISSING"
-      : account.credentialSecretId !== lineageSecretId
+      : !ownedLineageIds.includes(account.credentialSecretId)
         ? "CREDENTIAL_POINTER_MISMATCH"
         : null;
-    const material = lineageSecretId
-      ? await readXDisconnectRevocationMaterial(
-          tx,
-          input.vault,
-          input.tenantId,
-          lineageSecretId,
-          account.externalRef,
-        )
-      : null;
-    const routesToDisable = lineageSecretId
-      ? await tx
-          .select({ id: secretRoutes.id, authorityRevision: secretRoutes.authorityRevision })
-          .from(secretRoutes)
-          .where(
-            and(
-              eq(secretRoutes.tenantId, input.tenantId),
-              eq(secretRoutes.secretId, lineageSecretId),
-              eq(secretRoutes.enabled, true),
-            ),
-          )
-          .for("update")
-      : [];
+    const routesToDisable =
+      ownedLineageIds.length > 0
+        ? await tx
+            .select({ id: secretRoutes.id, authorityRevision: secretRoutes.authorityRevision })
+            .from(secretRoutes)
+            .where(
+              and(
+                eq(secretRoutes.tenantId, input.tenantId),
+                inArray(secretRoutes.secretId, ownedLineageIds),
+                eq(secretRoutes.enabled, true),
+              ),
+            )
+            .for("update")
+        : [];
 
-    const lifecycleId = randomUUID();
-    let lifecycleSecretId: string | null = null;
-    const hasRevocationHandle = Boolean(material?.accessToken || material?.refreshToken);
-    if (lifecycleId && hasRevocationHandle) {
-      const secret = await input.vault.createSecretWithinTx(
-        tx,
-        input.tenantId,
-        `provider-x-lifecycle:${lifecycleId}:disconnect`,
-        JSON.stringify({
-          schemaVersion: "steward.provider-x.lifecycle.v1",
-          token: {
-            access_token: material?.accessToken ?? undefined,
-            refresh_token: material?.refreshToken ?? undefined,
-          },
-        } satisfies XRefreshLifecycleSecret),
-        { description: "Encrypted transient X OAuth revocation material" },
-      );
-      lifecycleSecretId = secret.id;
-    }
-    if (lifecycleId) {
+    const lifecycleMaterials =
+      ownedLineage.length > 0
+        ? ownedLineage
+        : [
+            {
+              secret: null,
+              accessToken: null,
+              refreshToken: null,
+              issue: "CREDENTIAL_LINEAGE_MISSING",
+            },
+          ];
+    const lifecycles: Array<{ lifecycleId: string; retryAt: Date | null }> = [];
+    for (const material of lifecycleMaterials) {
+      const lifecycleId = randomUUID();
+      const hasRevocationHandle = Boolean(material.accessToken || material.refreshToken);
+      let lifecycleSecretId: string | null = null;
+      if (hasRevocationHandle) {
+        const secret = await input.vault.createSecretWithinTx(
+          tx,
+          input.tenantId,
+          `provider-x-lifecycle:${lifecycleId}:disconnect`,
+          JSON.stringify({
+            schemaVersion: "steward.provider-x.lifecycle.v1",
+            token: {
+              access_token: material.accessToken ?? undefined,
+              refresh_token: material.refreshToken ?? undefined,
+            },
+          } satisfies XRefreshLifecycleSecret),
+          { description: "Encrypted transient X OAuth revocation material" },
+        );
+        lifecycleSecretId = secret.id;
+      }
       await tx.insert(providerXCredentialLifecycles).values({
         id: lifecycleId,
         tenantId: input.tenantId,
@@ -2754,20 +2771,21 @@ export async function disconnectXProviderCredential(
           revocationHandleAvailable: hasRevocationHandle,
           credentialIssue:
             pointerIssue ??
-            material?.issue ??
-            (lineageSecretId ? null : "CREDENTIAL_LINEAGE_MISSING"),
+            material.issue ??
+            (ownedLineage.length > 1 ? "CREDENTIAL_LINEAGE_MULTIPLE" : null),
         },
       });
+      lifecycles.push({ lifecycleId, retryAt: lifecycleSecretId ? now : null });
     }
 
-    if (lineageSecretId) {
+    if (ownedLineageIds.length > 0) {
       await tx
         .update(secretRoutes)
         .set({ enabled: false })
         .where(
           and(
             eq(secretRoutes.tenantId, input.tenantId),
-            eq(secretRoutes.secretId, lineageSecretId),
+            inArray(secretRoutes.secretId, ownedLineageIds),
             eq(secretRoutes.enabled, true),
           ),
         );
@@ -2794,14 +2812,14 @@ export async function disconnectXProviderCredential(
       throw new XConnectError("X_REFRESH_FAILED", 409, "account revision conflict on disconnect");
     }
 
-    if (lineageSecretId) {
+    if (ownedLineageIds.length > 0) {
       await tx
         .update(secrets)
         .set({ deletedAt: now, updatedAt: now })
         .where(
           and(
             eq(secrets.tenantId, input.tenantId),
-            eq(secrets.id, lineageSecretId),
+            inArray(secrets.id, ownedLineageIds),
             sql`${secrets.deletedAt} IS NULL`,
           ),
         );
@@ -2818,8 +2836,11 @@ export async function disconnectXProviderCredential(
         workspaceId: input.workspaceId,
         xUserId: account.externalRef,
         revokedAtUpstream: false,
-        upstreamRevocationPending: Boolean(lifecycleSecretId),
-        revocationHandleAvailable: hasRevocationHandle,
+        upstreamRevocationPending: lifecycles.some((entry) => entry.retryAt !== null),
+        revocationHandleAvailable:
+          ownedLineage.length > 0 &&
+          ownedLineage.every((entry) => Boolean(entry.accessToken || entry.refreshToken)),
+        credentialLineageCount: ownedLineage.length,
         disabledRouteCount: routesToDisable.length,
         previousRevision: account.revision,
         newRevision: degraded.revision,
@@ -2828,59 +2849,79 @@ export async function disconnectXProviderCredential(
     });
 
     return {
-      lifecycleId,
-      retryAt: lifecycleSecretId ? now : null,
+      lifecycles,
+      allHandlesAvailable:
+        ownedLineage.length > 0 &&
+        ownedLineage.every((entry) => Boolean(entry.accessToken || entry.refreshToken)),
     };
   });
 
-  if (!prepared.lifecycleId || !prepared.retryAt) {
+  const pendingLifecycles = prepared.lifecycles.filter(
+    (entry): entry is { lifecycleId: string; retryAt: Date } => entry.retryAt !== null,
+  );
+  if (pendingLifecycles.length === 0) {
     return { providerAccountId: input.accountId, revoked: false };
   }
   await afterXDisconnectJournalForTests?.();
-  const revokedAtUpstream = await reconcileStagedXCredentialRevocation({
-    ...input,
-    lifecycleId: prepared.lifecycleId,
-    now: prepared.retryAt,
-  });
-  return { providerAccountId: input.accountId, revoked: revokedAtUpstream };
+  const revocationResults: boolean[] = [];
+  for (const lifecycle of pendingLifecycles) {
+    revocationResults.push(
+      await reconcileStagedXCredentialRevocation({
+        ...input,
+        lifecycleId: lifecycle.lifecycleId,
+        now: lifecycle.retryAt,
+      }),
+    );
+  }
+  return {
+    providerAccountId: input.accountId,
+    revoked: prepared.allHandlesAvailable && revocationResults.every(Boolean),
+  };
 }
 
-async function readXDisconnectRevocationMaterial(
-  tx: DbExecutor,
-  vault: SecretVault,
-  tenantId: string,
-  secretId: string,
-  expectedXUserId: string,
-): Promise<{
+interface XOwnedDisconnectLineageSecret {
+  owned: true;
+  secret: Secret;
   accessToken: string | null;
   refreshToken: string | null;
   issue: string | null;
-}> {
-  const [row] = (await tx
-    .select()
-    .from(secrets)
-    .where(and(eq(secrets.tenantId, tenantId), eq(secrets.id, secretId)))
-    .limit(1)) as Secret[];
-  if (!row) {
-    return { accessToken: null, refreshToken: null, issue: "CREDENTIAL_SECRET_MISSING" };
-  }
+}
+
+interface XAmbiguousDisconnectLineageSecret {
+  owned: false;
+  secret: Secret;
+  issue: "CREDENTIAL_BINDING_MISMATCH" | "CREDENTIAL_PAYLOAD_INVALID" | "CREDENTIAL_DECRYPT_FAILED";
+}
+
+function classifyXDisconnectLineageSecret(
+  vault: SecretVault,
+  tenantId: string,
+  secret: Secret,
+  expectedXUserId: string,
+): XOwnedDisconnectLineageSecret | XAmbiguousDisconnectLineageSecret {
   try {
-    const parsed = JSON.parse(vault.decryptSecretRow(tenantId, row)) as unknown;
+    const parsed = JSON.parse(vault.decryptSecretRow(tenantId, secret)) as unknown;
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-      return { accessToken: null, refreshToken: null, issue: "CREDENTIAL_PAYLOAD_INVALID" };
+      return { owned: false, secret, issue: "CREDENTIAL_PAYLOAD_INVALID" };
     }
     const candidate = parsed as Record<string, unknown>;
+    if (candidate.schemaVersion !== "steward.provider-x.credential.v1") {
+      return { owned: false, secret, issue: "CREDENTIAL_PAYLOAD_INVALID" };
+    }
+    if (candidate.xUserId !== expectedXUserId) {
+      return { owned: false, secret, issue: "CREDENTIAL_BINDING_MISMATCH" };
+    }
     const accessToken = boundedStagedToken(candidate.accessToken);
     const refreshToken = boundedStagedToken(candidate.refreshToken);
-    const issue =
-      typeof candidate.xUserId === "string" && candidate.xUserId !== expectedXUserId
-        ? "CREDENTIAL_BINDING_MISMATCH"
-        : accessToken || refreshToken
-          ? null
-          : "CREDENTIAL_REVOCATION_HANDLE_INVALID";
-    return { accessToken, refreshToken, issue };
+    return {
+      owned: true,
+      secret,
+      accessToken,
+      refreshToken,
+      issue: accessToken || refreshToken ? null : "CREDENTIAL_REVOCATION_HANDLE_INVALID",
+    };
   } catch {
-    return { accessToken: null, refreshToken: null, issue: "CREDENTIAL_DECRYPT_FAILED" };
+    return { owned: false, secret, issue: "CREDENTIAL_DECRYPT_FAILED" };
   }
 }
 


### PR DESCRIPTION
Corrective follow-up to merged PR #478.

## Security correction

- lock and classify every live secret version in the deterministic `provider-x/<workspace>/<x-user>` lineage
- require the credential schema and exact X user binding before any destructive write
- fail closed with `X_CREDENTIAL_NEEDS_ATTENTION` if any same-name row is malformed, undecryptable, or bound to another X user
- durably stage each owned upstream grant, disable all owned live routes, clear account authority, and soft-delete all owned lineage rows in one audited transaction
- retain unrelated secrets and routes unchanged, including when the mutable account pointer is wrong

## Migrated-database regressions

- a null pointer with two schema-permitted live owned versions revokes both upstream handles, soft-deletes both rows, and disables both routes with real trigger-driven authority revision bumps
- a same-name live row with a mismatched X binding aborts before upstream revocation or any account, secret, route, or lifecycle mutation
- malformed deterministic lineage now also fails closed without destructive action

## Exact-head evidence

Head: `d7d6289183be4e516ffcafcc237dc34f493587a9`
Base: `83a7ff1cd61bab8b24f318c887b0ecfb728c7944`

- `bun test src/__tests__/provider-x-connect.test.ts`: 57 pass, 0 fail, 369 assertions
- `bunx turbo run build --filter=@stwd/api`: 24/24 tasks successful
- changed-file Biome check: pass
- `git diff --check`: pass
- `bun install --frozen-lockfile`: no changes

This PR is intentionally draft pending independent review. Do not merge until the complete-lineage and ambiguity guarantees are independently verified.