### PR TITLE
fix(security): harden OTP and LIKE inputs

### DIFF
--- a/packages/api/src/__tests__/user-tenant-admin-users.test.ts
+++ b/packages/api/src/__tests__/user-tenant-admin-users.test.ts
@@ -51,7 +51,7 @@ describe("user tenant-admin user directory routes", () => {
       .returning({ id: users.id });
     const [member] = await getDb()
       .insert(users)
-      .values({ email: "member@example.test", emailVerified: true, name: "Member" })
+      .values({ email: "member@example.test", emailVerified: true, name: "Member\\Only" })
       .returning({ id: users.id });
     ownerId = owner.id;
     memberId = member.id;
@@ -149,6 +149,18 @@ describe("user tenant-admin user directory routes", () => {
     expect(body.data.users[0]?.linkedAccounts).toBeUndefined();
     expect(body.data.users[0]?.walletAddress).toBeUndefined();
     expect(body.data.users[0]?.customMetadata).toBeUndefined();
+  });
+
+  it("treats backslash-prefixed LIKE metacharacters as literal search text", async () => {
+    const token = await tokenFor(ownerId);
+    const response = await userRoutes.request(
+      `/me/tenants/${TENANT_ID}/users?q=${encodeURIComponent("\\%")}`,
+      { headers: { Authorization: `Bearer ${token}` } },
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { data: { users: unknown[] } };
+    expect(body.data.users).toEqual([]);
   });
 
   it("rejects non-admin tenant members", async () => {

--- a/packages/api/src/routes/user.ts
+++ b/packages/api/src/routes/user.ts
@@ -1136,6 +1136,13 @@ function parseBoundedOffset(value: string | null): number {
   return Math.min(Math.floor(parsed), 100_000);
 }
 
+function escapeLikePattern(value: string): string {
+  // PostgreSQL LIKE uses backslash as its default escape character. Escape it
+  // before '%' and '_' so a caller cannot turn our escaping back into a
+  // wildcard by supplying a preceding backslash.
+  return value.replace(/[\\%_]/g, "\\$&");
+}
+
 function isUuid(value: string): boolean {
   return UUID_RE.test(value);
 }
@@ -6791,7 +6798,7 @@ user.get("/me/tenants/:tenantId/users", async (c) => {
   const whereConditions = [eq(userTenants.tenantId, tenantId)];
   if (email) whereConditions.push(eq(users.email, email));
   if (q) {
-    const like = `%${q.replace(/[%_]/g, "\\$&")}%`;
+    const like = `%${escapeLikePattern(q)}%`;
     whereConditions.push(
       or(ilike(users.email, like), ilike(users.name, like), sql`${users.id}::text ilike ${like}`)!,
     );
@@ -7069,7 +7076,7 @@ user.get("/me/tenants/:tenantId/users/export", async (c) => {
   const whereConditions = [eq(userTenants.tenantId, tenantId)];
   if (email) whereConditions.push(eq(users.email, email));
   if (q) {
-    const like = `%${q.replace(/[%_]/g, "\\$&")}%`;
+    const like = `%${escapeLikePattern(q)}%`;
     whereConditions.push(
       or(ilike(users.email, like), ilike(users.name, like), sql`${users.id}::text ilike ${like}`)!,
     );

--- a/packages/auth/src/email.ts
+++ b/packages/auth/src/email.ts
@@ -1,4 +1,4 @@
-import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+import { createHmac, randomBytes, randomInt, timingSafeEqual } from "node:crypto";
 import { redactedThrownDiagnostics } from "@stwd/shared";
 
 import { hashSha256Hex } from "./crypto";
@@ -92,18 +92,8 @@ function generateOpaqueId(): string {
 }
 
 function generateOtpCode(): string {
-  // Crypto-random 6-digit code with rejection sampling to avoid modulo bias.
-  const max = 10 ** OTP_DIGITS;
-  // 2^32 / 10^6 -> keep draws below the largest multiple of max to stay uniform.
-  const limit = Math.floor(0x1_0000_0000 / max) * max;
-  for (;;) {
-    const bytes = randomBytes(4);
-    const draw =
-      ((bytes[0] << 24) >>> 0) + ((bytes[1] << 16) >>> 0) + ((bytes[2] << 8) >>> 0) + bytes[3];
-    if (draw < limit) {
-      return String(draw % max).padStart(OTP_DIGITS, "0");
-    }
-  }
+  // randomInt uses rejection sampling internally and avoids modulo bias.
+  return String(randomInt(10 ** OTP_DIGITS)).padStart(OTP_DIGITS, "0");
 }
 
 function hashToken(token: string): string {


### PR DESCRIPTION
## Summary

Remediates confirmed CodeQL findings #32, #33, and #35.

- generate six-digit email codes with Node crypto `randomInt`, whose bounded sampling is unbiased
- escape PostgreSQL LIKE backslashes before `%` and `_` for both tenant-directory and CSV-export filters
- add a regression proving `\%` cannot be reinterpreted as a wildcard against a backslash-containing user name

## Exact-head evidence

Head `6ae138e470b7aec0fcba14e92b09f56268995ecc`, base `23556ee4e345c6a351bc9727fe0cd58572c3ed64`:

- email auth suites: 22/22, 92 assertions
- tenant-admin directory: 8/8, 22 assertions
- API dependency graph: 24/24 builds
- Biome and `git diff --check`: clean

Keep draft until exact-head hosted CI and a subsequent CodeQL scan are green.