### PR TITLE
fix(auth): bound OAuth lock cleanup

### DIFF
--- a/packages/api/src/__tests__/auth-oauth-nonce-exchange.test.ts
+++ b/packages/api/src/__tests__/auth-oauth-nonce-exchange.test.ts
@@ -43,6 +43,16 @@ function failOAuthLockDeletion() {
   });
 }
 
+function hangOAuthLockDeletion() {
+  const originalDelete = ChallengeStore.prototype.delete;
+  return spyOn(ChallengeStore.prototype, "delete").mockImplementation(async function (key) {
+    if (key.startsWith("oauth-code-lock:")) {
+      return new Promise<void>(() => {});
+    }
+    return originalDelete.call(this, key);
+  });
+}
+
 function makeApp(): Hono {
   const app = new Hono();
   app.route("/auth", authRoutes);
@@ -182,6 +192,32 @@ describe("POST /auth/oauth/exchange", () => {
     expect(second.json.code).toBe("code_invalid");
   });
 
+  it("allows exactly one concurrent redemption of the same code", async () => {
+    const app = makeApp();
+    _seedOAuthExchangeCodeForTests("nonce-concurrent", {
+      token: "concurrent-access",
+      refreshToken: "concurrent-refresh",
+      redirectUri: REDIRECT_URI,
+      tenantId: TENANT_ID,
+    });
+    const redeem = () =>
+      postExchange(app, {
+        code: "nonce-concurrent",
+        redirect_uri: REDIRECT_URI,
+        tenant_id: TENANT_ID,
+      });
+
+    const responses = await Promise.all([redeem(), redeem()]);
+    expect(responses.filter(({ status }) => status === 200)).toHaveLength(1);
+    expect(responses.filter(({ json }) => json.token === "concurrent-access")).toHaveLength(1);
+    const rejected = responses.find(({ status }) => status !== 200);
+    expect([401, 409]).toContain(rejected?.status);
+    expect(rejected?.json.token).toBeUndefined();
+
+    const replay = await redeem();
+    expect(replay).toMatchObject({ status: 401, json: { code: "code_invalid" } });
+  });
+
   it("returns a consumed nonce exchange when ancillary lock cleanup fails", async () => {
     _seedOAuthExchangeCodeForTests("nonce-cleanup-failure", {
       token: "access-after-cleanup-failure",
@@ -221,6 +257,39 @@ describe("POST /auth/oauth/exchange", () => {
     }
   });
 
+  it("bounds a lock cleanup that never settles after consuming the code", async () => {
+    _seedOAuthExchangeCodeForTests("nonce-cleanup-hang", {
+      token: "access-after-cleanup-hang",
+      refreshToken: "refresh-after-cleanup-hang",
+      redirectUri: REDIRECT_URI,
+      tenantId: TENANT_ID,
+    });
+    const deleteHang = hangOAuthLockDeletion();
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const startedAt = Date.now();
+      const response = await postExchange(makeApp(), {
+        code: "nonce-cleanup-hang",
+        redirect_uri: REDIRECT_URI,
+        tenant_id: TENANT_ID,
+      });
+
+      expect(Date.now() - startedAt).toBeLessThan(1_000);
+      expect(response).toMatchObject({
+        status: 200,
+        json: {
+          ok: true,
+          token: "access-after-cleanup-hang",
+          refreshToken: "refresh-after-cleanup-hang",
+        },
+      });
+      expect(JSON.stringify(warn.mock.calls)).not.toContain("access-after-cleanup-hang");
+    } finally {
+      deleteHang.mockRestore();
+      warn.mockRestore();
+    }
+  });
+
   it("returns a consumed provider-token exchange when ancillary lock cleanup fails", async () => {
     process.env.STEWARD_OAUTH_ALLOWED_REDIRECTS = REDIRECT_URI;
     _seedOAuthExchangeCodeForTests("provider-cleanup-failure", {
@@ -247,7 +316,6 @@ describe("POST /auth/oauth/exchange", () => {
       expect(json.token).toBe("provider-access-after-cleanup-failure");
       expect(json.refreshToken).toBe("provider-refresh-after-cleanup-failure");
       expect(JSON.stringify(warn.mock.calls)).not.toContain("sk-cleanup-canary");
-
       const second = await makeApp().request("/auth/oauth/google/token", {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -1432,6 +1432,7 @@ async function peekEmailGrant(grant: string, email: string, tenantId: string): P
 }
 
 const OAUTH_CODE_REDEEM_LOCK_TTL_MS = 10 * 1000;
+const OAUTH_CODE_REDEEM_LOCK_CLEANUP_TIMEOUT_MS = 250;
 
 async function lockOAuthCodeRedemption(code: string): Promise<boolean> {
   return getOAuthCodeStore().setIfNotExists(
@@ -1442,13 +1443,24 @@ async function lockOAuthCodeRedemption(code: string): Promise<boolean> {
 }
 
 async function releaseOAuthCodeRedemptionLock(code: string): Promise<void> {
+  let cleanupTimer: ReturnType<typeof setTimeout> | undefined;
   try {
-    await getOAuthCodeStore().delete(`oauth-code-lock:${code}`);
+    await Promise.race([
+      getOAuthCodeStore().delete(`oauth-code-lock:${code}`),
+      new Promise<never>((_, reject) => {
+        cleanupTimer = setTimeout(
+          () => reject(new Error("OAuth redemption lock cleanup timed out")),
+          OAUTH_CODE_REDEEM_LOCK_CLEANUP_TIMEOUT_MS,
+        );
+      }),
+    ]);
   } catch (error) {
     // Atomic consume is the single-use security boundary. Lock cleanup is
     // advisory because its bounded TTL preserves liveness when deletion is
-    // unavailable after a terminal consume result.
+    // unavailable or does not settle after a terminal consume result.
     console.warn("[OAuthAuth] Redemption lock cleanup failed", redactedThrownDiagnostics(error));
+  } finally {
+    if (cleanupTimer !== undefined) clearTimeout(cleanupTimer);
   }
 }
 
@@ -2046,7 +2058,6 @@ export function _clearOAuthCodeStoreForTests(): void {
   _oauthCodeStore = null;
 }
 
-/** Test-only seam for exercising durable OAuth-code backend failures. */
 // ─── Vault helper ─────────────────────────────────────────────────────────────
 
 function getVault(): Vault {


### PR DESCRIPTION
## Summary

- bound advisory OAuth redemption-lock cleanup so a hung backend cannot strand an already-consumed access/refresh-token handoff
- retain redacted cleanup diagnostics while allowing the 10-second lock TTL to provide eventual liveness
- cover concurrent single-winner redemption and a cleanup promise that never settles
- remove the orphaned test-seam comment left by the merged #490 restack

## Security properties

- atomic consume remains the single-use boundary
- consume failure remains fail-closed and does not return tokens
- replay, redirect, tenant, provider, and PKCE bindings remain intact

## Validation

- `bunx biome check packages/api/src/routes/auth.ts packages/api/src/__tests__/auth-oauth-nonce-exchange.test.ts`
- `bun test --timeout 120000 packages/api/src/__tests__/auth-oauth-nonce-exchange.test.ts` — 17 pass, 0 fail, 58 assertions
- `bunx turbo run build --filter=@stwd/api` — 24/24 tasks successful
- `git diff --check origin/develop...HEAD`

Follow-up to #490.