### PR TITLE
fix(proxy): retain replay claims after forwarding

### DIFF
--- a/packages/proxy/src/__tests__/zz-proxy-spend-limit.test.ts
+++ b/packages/proxy/src/__tests__/zz-proxy-spend-limit.test.ts
@@ -872,6 +872,102 @@ describe("proxy spend-limit enforcement", () => {
     expect(((await second.json()) as { error: string }).error).toContain("already forwarded");
   });
 
+  test("preserves a successful upstream response when replay completion persistence fails", async () => {
+    spendResult.configured = false;
+    const {
+      __clearProxyReplayClaimsForTests,
+      __setCheckProxySpendLimitForTests,
+      createProxyHandler,
+      handleProxy,
+    } = await loadProxy();
+    __clearProxyReplayClaimsForTests();
+    __setCheckProxySpendLimitForTests(async () => spendResult);
+    const diagnosticCalls: unknown[][] = [];
+    const originalConsoleError = console.error;
+    console.error = (...args: unknown[]) => diagnosticCalls.push(args);
+    let completionAttempts = 0;
+    const request = () =>
+      makeContext("/proxy/example.com/v1/echo", {
+        method: "POST",
+        headers: { "Idempotency-Key": "completion-failure-success" },
+        body: JSON.stringify({ op: "create" }),
+      });
+
+    try {
+      const handler = createProxyHandler({
+        completeReplayClaim: async () => {
+          completionAttempts++;
+          throw new Error("Bearer completion-secret-must-not-be-logged");
+        },
+      });
+      const first = await handler(request());
+      const retry = await handleProxy(request());
+
+      expect(first.status).toBe(200);
+      expect(await first.text()).toBe(JSON.stringify({ ok: true }));
+      expect(retry.status).toBe(409);
+      expect(((await retry.json()) as { error: string }).error).toContain("already processing");
+      expect(fetchCalls).toBe(1);
+      expect(completionAttempts).toBe(1);
+      expect(JSON.stringify(diagnosticCalls)).toContain(
+        "Failed to persist post-forward idempotency completion",
+      );
+      expect(JSON.stringify(diagnosticCalls)).not.toContain("completion-secret-must-not-be-logged");
+    } finally {
+      console.error = originalConsoleError;
+    }
+  });
+
+  test("preserves a sanitized upstream failure when replay completion persistence fails", async () => {
+    spendResult.configured = false;
+    const {
+      __clearProxyReplayClaimsForTests,
+      __setCheckProxySpendLimitForTests,
+      createProxyHandler,
+      handleProxy,
+    } = await loadProxy();
+    __clearProxyReplayClaimsForTests();
+    __setCheckProxySpendLimitForTests(async () => spendResult);
+    globalThis.fetch = (async () => {
+      fetchCalls++;
+      throw new Error("Bearer upstream-secret-must-not-be-logged");
+    }) as typeof fetch;
+    const diagnosticCalls: unknown[][] = [];
+    const originalConsoleError = console.error;
+    console.error = (...args: unknown[]) => diagnosticCalls.push(args);
+    let completionAttempts = 0;
+    const request = () =>
+      makeContext("/proxy/example.com/v1/echo", {
+        method: "POST",
+        headers: { "Idempotency-Key": "completion-failure-upstream" },
+        body: JSON.stringify({ op: "create" }),
+      });
+
+    try {
+      const handler = createProxyHandler({
+        completeReplayClaim: async () => {
+          completionAttempts++;
+          throw new Error("Bearer completion-secret-must-not-be-logged");
+        },
+      });
+      const first = await handler(request());
+      const retry = await handleProxy(request());
+
+      expect(first.status).toBe(502);
+      expect(await first.json()).toEqual({ ok: false, error: "Upstream request failed" });
+      expect(retry.status).toBe(409);
+      expect(((await retry.json()) as { error: string }).error).toContain("already processing");
+      expect(fetchCalls).toBe(1);
+      expect(completionAttempts).toBe(1);
+      const diagnostics = JSON.stringify(diagnosticCalls);
+      expect(diagnostics).toContain("Failed to persist post-forward idempotency completion");
+      expect(diagnostics).not.toContain("upstream-secret-must-not-be-logged");
+      expect(diagnostics).not.toContain("completion-secret-must-not-be-logged");
+    } finally {
+      console.error = originalConsoleError;
+    }
+  });
+
   test("blocks injected credentials reflected in upstream response headers", async () => {
     spendResult.configured = false;
     globalThis.fetch = (async (url: string | URL | Request) => {

--- a/packages/proxy/src/__tests__/zz-proxy-spend-limit.test.ts
+++ b/packages/proxy/src/__tests__/zz-proxy-spend-limit.test.ts
@@ -918,6 +918,68 @@ describe("proxy spend-limit enforcement", () => {
     }
   });
 
+  test("keeps a single winner while replay completion is still unresolved", async () => {
+    spendResult.configured = false;
+    const {
+      __clearProxyReplayClaimsForTests,
+      __setCheckProxySpendLimitForTests,
+      createProxyHandler,
+      handleProxy,
+    } = await loadProxy();
+    __clearProxyReplayClaimsForTests();
+    __setCheckProxySpendLimitForTests(async () => spendResult);
+    let completionStarted!: () => void;
+    const completionStartedPromise = new Promise<void>((resolve) => {
+      completionStarted = resolve;
+    });
+    let rejectCompletion!: (reason: Error) => void;
+    const completionBarrier = new Promise<void>((_resolve, reject) => {
+      rejectCompletion = reject;
+    });
+    const diagnosticCalls: unknown[][] = [];
+    const originalConsoleError = console.error;
+    console.error = (...args: unknown[]) => diagnosticCalls.push(args);
+    const request = () =>
+      makeContext("/proxy/example.com/v1/echo", {
+        method: "POST",
+        headers: { "Idempotency-Key": "completion-in-flight-single-winner" },
+        body: JSON.stringify({ op: "create" }),
+      });
+
+    try {
+      const handler = createProxyHandler({
+        completeReplayClaim: async () => {
+          completionStarted();
+          await completionBarrier;
+        },
+      });
+      const firstPromise = handler(request());
+      await completionStartedPromise;
+
+      const concurrentRetry = await handleProxy(request());
+      expect(concurrentRetry.status).toBe(409);
+      expect(((await concurrentRetry.json()) as { error: string }).error).toContain(
+        "already processing",
+      );
+      expect(fetchCalls).toBe(1);
+
+      rejectCompletion(new Error("Bearer concurrent-completion-secret-must-not-be-logged"));
+      const first = await firstPromise;
+      expect(first.status).toBe(200);
+      expect(await first.text()).toBe(JSON.stringify({ ok: true }));
+      expect(fetchCalls).toBe(1);
+      expect(JSON.stringify(diagnosticCalls)).not.toContain(
+        "concurrent-completion-secret-must-not-be-logged",
+      );
+    } finally {
+      console.error = originalConsoleError;
+      // Avoid an unhandled rejection if an assertion above fails before the
+      // request awaiting the completion barrier can observe it.
+      rejectCompletion(new Error("test cleanup"));
+      await completionBarrier.catch(() => undefined);
+    }
+  });
+
   test("preserves a sanitized upstream failure when replay completion persistence fails", async () => {
     spendResult.configured = false;
     const {

--- a/packages/proxy/src/handlers/proxy.ts
+++ b/packages/proxy/src/handlers/proxy.ts
@@ -423,8 +423,14 @@ type ProxyReplayClaim = {
   expiresAt: number;
 };
 
+export type ProxyReplayCompletionClaim = {
+  ok: true;
+  storageKey: string;
+  storage: "memory" | "redis";
+};
+
 type ProxyReplayClaimResult =
-  | { ok: true; storageKey: string; storage: "memory" | "redis" }
+  | ProxyReplayCompletionClaim
   | { ok: false; status: number; error: string };
 
 const proxyReplayClaims = new Map<string, ProxyReplayClaim>();
@@ -865,6 +871,28 @@ async function completeUnsafeProxyRequest(claimResult: ProxyReplayClaimResult): 
   if (claim) proxyReplayClaims.set(storageKey, { ...claim, status: "completed" });
 }
 
+export type ProxyReplayCompletion = (claimResult: ProxyReplayCompletionClaim) => Promise<void>;
+
+export type ProxyHandlerDependencies = Readonly<{
+  completeReplayClaim?: ProxyReplayCompletion;
+}>;
+
+async function persistPostForwardReplayCompletion(
+  claimResult: ProxyReplayCompletionClaim,
+  completeReplayClaim: ProxyReplayCompletion,
+): Promise<void> {
+  try {
+    await completeReplayClaim(claimResult);
+  } catch (error) {
+    // The upstream attempt has already happened. Preserve its outcome and the
+    // processing claim so a retry cannot repeat a potentially committed side effect.
+    console.error(
+      "[proxy] Failed to persist post-forward idempotency completion",
+      redactedThrownDiagnostics(error),
+    );
+  }
+}
+
 async function releaseUnsafeProxyRequest(claimResult: ProxyReplayClaimResult): Promise<void> {
   if (!claimResult.ok || !claimResult.storageKey) return;
   if (claimResult.storage === "redis") {
@@ -1262,7 +1290,10 @@ export function __resetProxyHandlerTestHooksForTests(): void {
  * This is the catch-all handler mounted on the Hono app.
  * Auth middleware has already run, so agentId and tenantId are available.
  */
-export async function handleProxy(c: Context): Promise<Response> {
+async function handleProxyWithReplayCompletion(
+  c: Context,
+  completeReplayClaim: ProxyReplayCompletion,
+): Promise<Response> {
   setProxyContextNoStore(c);
   const startTime = Date.now();
   const agentId = c.get("agentId") as string;
@@ -2070,7 +2101,7 @@ export async function handleProxy(c: Context): Promise<Response> {
     });
 
     await releaseProxySpendReservation(agentId, tenantId, target.host, spendReservation);
-    await completeUnsafeProxyRequest(replayClaim);
+    await persistPostForwardReplayCompletion(replayClaim, completeReplayClaim);
     proxySlot.release();
     return c.json({ ok: false, error: "Upstream request failed" }, 502);
   } finally {
@@ -2079,7 +2110,7 @@ export async function handleProxy(c: Context): Promise<Response> {
     // The credential variable goes out of scope here.
     credential = "";
   }
-  await completeUnsafeProxyRequest(replayClaim);
+  await persistPostForwardReplayCompletion(replayClaim, completeReplayClaim);
 
   const latencyMs = Date.now() - startTime;
 
@@ -2441,6 +2472,16 @@ export async function handleProxy(c: Context): Promise<Response> {
     headers: responseHeaders,
   });
 }
+
+/** Create an isolated proxy handler with immutable request-lifecycle dependencies. */
+export function createProxyHandler(
+  dependencies: ProxyHandlerDependencies = {},
+): (c: Context) => Promise<Response> {
+  const completeReplayClaim = dependencies.completeReplayClaim ?? completeUnsafeProxyRequest;
+  return (c: Context) => handleProxyWithReplayCompletion(c, completeReplayClaim);
+}
+
+export const handleProxy = createProxyHandler();
 
 /** Null means Slack explicitly attested success; any string is a safe failure code. */
 export function classifySlackWebApiPayload(bodyText: string): string | null {


### PR DESCRIPTION
Closes #493

## Summary
- contain idempotency-completion persistence failures only after an upstream attempt
- preserve the real upstream response or sanitized 502 while retaining the processing claim
- log only bounded redacted diagnostics
- cover success and upstream-failure paths with exact retry and upstream-call assertions

## Validation
- `bun test --timeout 120000 packages/proxy/src/__tests__/zz-proxy-spend-limit.test.ts packages/proxy/src/__tests__/fake-provider-transport-inventory.test.ts` (38 pass)
- `bunx turbo run build --filter=@stwd/proxy... --force` (9/9)
- `bunx biome check packages/proxy/src/handlers/proxy.ts packages/proxy/src/__tests__/zz-proxy-spend-limit.test.ts`
- `git diff --check origin/develop...HEAD`