### PR TITLE
fix(agent-trader): remove untrusted price oracle fetch

### DIFF
--- a/packages/agent-trader/src/__tests__/state-security.test.ts
+++ b/packages/agent-trader/src/__tests__/state-security.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+test("agent state never fetches an operator-controlled price-oracle URL", () => {
+  const source = readFileSync(join(import.meta.dir, "../state.ts"), "utf8");
+  expect(source).not.toContain("PRICE_ORACLE_URL");
+  expect(source).not.toContain("PRICE_ORACLE_");
+  expect(source).not.toContain("fetch(url");
+  expect(source).toContain("getHardenedOracleQuote(tokenAddress, chainId)");
+});

--- a/packages/agent-trader/src/__tests__/state-security.test.ts
+++ b/packages/agent-trader/src/__tests__/state-security.test.ts
@@ -6,6 +6,7 @@ test("agent state never fetches an operator-controlled price-oracle URL", () => 
   const source = readFileSync(join(import.meta.dir, "../state.ts"), "utf8");
   expect(source).not.toContain("PRICE_ORACLE_URL");
   expect(source).not.toContain("PRICE_ORACLE_");
-  expect(source).not.toContain("fetch(url");
+  expect(source).not.toContain("await fetch(");
+  expect(source).not.toContain("globalThis.fetch");
   expect(source).toContain("getHardenedOracleQuote(tokenAddress, chainId)");
 });

--- a/packages/agent-trader/src/state.ts
+++ b/packages/agent-trader/src/state.ts
@@ -131,30 +131,7 @@ async function getTokenPrice(tokenAddress: string, chainId: number): Promise<Pri
   const oracleQuote = await getHardenedOracleQuote(tokenAddress, chainId);
   if (oracleQuote) return { price: oracleQuote, confidence: "high" };
 
-  // 2. External price oracle (env: PRICE_ORACLE_URL or per-token override).
-  //    A single unauthenticated endpoint with no corroboration → LOW confidence.
-  const oracleUrl =
-    process.env[`PRICE_ORACLE_${tokenAddress.toLowerCase()}`] ?? process.env.PRICE_ORACLE_URL;
-
-  if (oracleUrl) {
-    try {
-      const url = oracleUrl.replace("{token}", tokenAddress);
-      const resp = await fetch(url, { signal: AbortSignal.timeout(5000) });
-      if (resp.ok) {
-        const json = (await resp.json()) as { price?: string };
-        if (json.price) {
-          const price = BigInt(json.price);
-          if (price > 0n) return { price, confidence: "low" };
-        }
-      }
-    } catch {
-      logWarn("Env price oracle request failed, falling back to DEX reserves", {
-        tokenAddress,
-      });
-    }
-  }
-
-  // 3. DEX pair reserve ratio — a single-pair spot price is trivially
+  // 2. DEX pair reserve ratio — a single-pair spot price is trivially
   //    manipulable (flash-loan/reserve imbalance), so it is LOW confidence and
   //    cannot, by itself, trigger a trade (gated in the strategy layer).
   const pairAddress =
@@ -195,7 +172,7 @@ async function getTokenPrice(tokenAddress: string, chainId: number): Promise<Pri
     }
   }
 
-  // 4. Fallback — strategies must handle tokenPrice === 0n
+  // 3. Fallback — strategies must handle tokenPrice === 0n
   logWarn("Could not determine token price — returning 0", { tokenAddress });
   return NO_PRICE;
 }

--- a/packages/agent-trader/src/state.ts
+++ b/packages/agent-trader/src/state.ts
@@ -4,18 +4,16 @@
  * Gathers the current on-chain + off-chain state needed by strategies:
  *   - Native balance (ETH/BNB)     ← viem publicClient
  *   - Token balance (ERC-20)       ← viem publicClient
- *   - Token price                  ← hardened price oracle, else env oracle / DEX reserve ratio
+ *   - Token price                  ← hardened price oracle, else DEX reserve ratio
  *   - Last trade age + daily vol   ← Steward history
  *
  * Token price resolution order (each tick is tagged with a confidence level):
  *   1. Hardened @stwd/shared price oracle — liquidity-weighted, multi-pair,
  *      fails to null. Tagged "high"; this is the only source that may, on its
  *      own, trigger a trade.
- *   2. priceOracleUrl env var (simple JSON API returning { price: "1234" }).
- *      Tagged "low" — an arbitrary single endpoint with no corroboration.
- *   3. DEX reserve ratio (single Uniswap-V2 pair getReserves). Tagged "low" —
+ *   2. DEX reserve ratio (single Uniswap-V2 pair getReserves). Tagged "low" —
  *      a single-pair spot ratio is trivially manipulable (flash-loan/imbalance).
- *   4. Fallback: 0n / "none" (strategies hold).
+ *   3. Fallback: 0n / "none" (strategies hold).
  *
  * Low-confidence ticks feed treasury/threshold math but are gated by the
  * strategy layer so a manipulable price cannot, by itself, trigger a swap.


### PR DESCRIPTION
## Summary

Remediates CodeQL alert #39 and a confirmed SSRF/resource-exhaustion surface.

The undocumented `PRICE_ORACLE_URL` fallback accepted an arbitrary environment/file-derived URL, followed redirects, parsed an unbounded body, and authenticated neither the endpoint nor its response. Its output was already low-confidence and could not safely authorize a price-driven trade.

- remove the arbitrary external fetch entirely
- retain the hardened liquidity-weighted oracle as the only high-confidence source
- retain on-chain reserve fallback as low-confidence, strategy-gated telemetry
- correct the trust-order documentation and add a source invariant that blocks direct network-fetch reintroduction in the state resolver

## Exact-head evidence

Head `8773caf24018d612b173a3d79bf92ca5e13825a1`, rebased on current develop at validation time:

- full agent-trader suite: 55/55, 135 assertions
- dependency-aware agent-trader graph: 8/8 builds
- Biome and `git diff --check`: clean

Keep draft until exact-head hosted CI and a subsequent CodeQL scan are green.