### PR TITLE
test(deps): satisfy security floor formatting

### DIFF
--- a/scripts/__tests__/dependency-security-floors.test.ts
+++ b/scripts/__tests__/dependency-security-floors.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 const root = join(import.meta.dir, "../..");


### PR DESCRIPTION
## Summary

- sort the dependency security-floor test imports according to Biome
- restore the develop lint/typecheck workflow after #494 merged with a formatting violation

## Validation

- `bun test scripts/__tests__/dependency-security-floors.test.ts` (1/1, 12 assertions)
- `bunx biome check scripts/__tests__/dependency-security-floors.test.ts`
- `git diff --check`