### PR TITLE
fix(vault): reconcile ambiguous local EVM broadcasts

### DIFF
--- a/packages/vault/src/__tests__/local-evm-broadcast-wiring.test.ts
+++ b/packages/vault/src/__tests__/local-evm-broadcast-wiring.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+
+describe("local EVM broadcast wiring", () => {
+  test("routes local-key broadcasts through the checkpointed raw-transaction lifecycle", async () => {
+    const source = await readFile(new URL("../vault.ts", import.meta.url), "utf8");
+
+    expect(source).toContain("return executeLocalEvmBroadcast({");
+    expect(source).toContain('status: "outcome_unknown"');
+    expect(source).toContain("publicClient.sendRawTransaction({ serializedTransaction })");
+    expect(source).toContain("transport: http(rpcUrl, { retryCount: 0 })");
+    expect(source).toContain('status: localRecordOptions.status ?? "broadcast"');
+    expect(source).not.toContain("client.sendTransaction({");
+  });
+});

--- a/packages/vault/src/__tests__/local-evm-broadcast.test.ts
+++ b/packages/vault/src/__tests__/local-evm-broadcast.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from "bun:test";
+import { type Hex, keccak256 } from "viem";
+import { ExternalBroadcastOutcomeUnknownError } from "../external-key-custody";
+import { executeLocalEvmBroadcast, type LocalEvmBroadcastLifecycle } from "../local-evm-broadcast";
+
+const SERIALIZED =
+  "0x02f86c0180843b9aca00847735940082520894aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0180c0" as Hex;
+const HASH = keccak256(SERIALIZED);
+
+function lifecycle(
+  overrides: Partial<LocalEvmBroadcastLifecycle> = {},
+): LocalEvmBroadcastLifecycle & { events: string[] } {
+  const events: string[] = [];
+  return {
+    events,
+    prepare: async () => {
+      events.push("prepare");
+      return SERIALIZED;
+    },
+    checkpoint: async (hash) => {
+      events.push(`checkpoint:${hash}`);
+    },
+    broadcast: async () => {
+      events.push("broadcast");
+      return HASH;
+    },
+    reconcile: async () => {
+      events.push("reconcile");
+      return false;
+    },
+    releaseBeforeBroadcast: async () => {
+      events.push("release");
+    },
+    finalizeAccepted: async (hash) => {
+      events.push(`finalize:${hash}`);
+    },
+    ...overrides,
+  };
+}
+
+describe("local EVM deterministic broadcast lifecycle", () => {
+  test("checkpoints the deterministic hash before one broadcast and finalizes success", async () => {
+    const subject = lifecycle();
+    await expect(executeLocalEvmBroadcast(subject)).resolves.toBe(HASH);
+    expect(subject.events).toEqual([
+      "prepare",
+      `checkpoint:${HASH}`,
+      "broadcast",
+      `finalize:${HASH}`,
+    ]);
+  });
+
+  test("releases the nonce when preparation fails before the checkpoint", async () => {
+    const subject = lifecycle({
+      prepare: async () => {
+        subject.events.push("prepare");
+        throw new Error("estimate failed");
+      },
+    });
+    await expect(executeLocalEvmBroadcast(subject)).rejects.toThrow("estimate failed");
+    expect(subject.events).toEqual(["prepare", "release"]);
+  });
+
+  test("releases the nonce when the durable checkpoint fails before broadcast", async () => {
+    const subject = lifecycle({
+      checkpoint: async () => {
+        subject.events.push("checkpoint");
+        throw new Error("database unavailable");
+      },
+    });
+    await expect(executeLocalEvmBroadcast(subject)).rejects.toThrow("database unavailable");
+    expect(subject.events).toEqual(["prepare", "checkpoint", "release"]);
+  });
+
+  test("reconciles a lost RPC response by deterministic hash without rebroadcasting", async () => {
+    let broadcasts = 0;
+    const subject = lifecycle({
+      broadcast: async () => {
+        subject.events.push("broadcast");
+        broadcasts += 1;
+        throw new Error("response lost");
+      },
+      reconcile: async (hash) => {
+        subject.events.push(`reconcile:${hash}`);
+        return true;
+      },
+    });
+    await expect(executeLocalEvmBroadcast(subject)).resolves.toBe(HASH);
+    expect(broadcasts).toBe(1);
+    expect(subject.events).toEqual([
+      "prepare",
+      `checkpoint:${HASH}`,
+      "broadcast",
+      `reconcile:${HASH}`,
+      `finalize:${HASH}`,
+    ]);
+  });
+
+  test("keeps the nonce allocated and returns outcome-unknown when reconciliation fails", async () => {
+    const subject = lifecycle({
+      broadcast: async () => {
+        subject.events.push("broadcast");
+        throw new Error("timeout after submit");
+      },
+      reconcile: async () => {
+        subject.events.push("reconcile");
+        return false;
+      },
+    });
+    const error = await executeLocalEvmBroadcast(subject).catch((cause) => cause);
+    expect(error).toBeInstanceOf(ExternalBroadcastOutcomeUnknownError);
+    expect((error as ExternalBroadcastOutcomeUnknownError).transactionHash).toBe(HASH);
+    expect(subject.events).toEqual(["prepare", `checkpoint:${HASH}`, "broadcast", "reconcile"]);
+    expect(subject.events).not.toContain("release");
+  });
+
+  test("treats mismatched RPC hashes and post-broadcast persistence failures as unknown", async () => {
+    for (const failure of ["mismatch", "finalize"] as const) {
+      const subject = lifecycle(
+        failure === "mismatch"
+          ? { broadcast: async () => `0x${"11".repeat(32)}` as Hex }
+          : {
+              finalizeAccepted: async () => {
+                throw new Error("database unavailable");
+              },
+            },
+      );
+      const error = await executeLocalEvmBroadcast(subject).catch((cause) => cause);
+      expect(error).toBeInstanceOf(ExternalBroadcastOutcomeUnknownError);
+      expect((error as ExternalBroadcastOutcomeUnknownError).transactionHash).toBe(HASH);
+      expect(subject.events).not.toContain("release");
+    }
+  });
+});

--- a/packages/vault/src/external-key-custody.ts
+++ b/packages/vault/src/external-key-custody.ts
@@ -59,10 +59,13 @@ export interface ExternalKeySignTransactionResult {
 }
 
 /**
- * The signed bytes have been submitted to the provider RPC, but Steward could
- * not prove whether the RPC accepted them. The locally-derived transaction
- * hash is safe to expose and is the only identifier callers may reconcile;
- * provider errors and signed bytes deliberately remain private.
+ * Signed EVM bytes have reached a mutating RPC boundary, but Steward could not
+ * prove whether the RPC accepted them. The locally-derived transaction hash is
+ * safe to expose and is the only identifier callers may reconcile; provider
+ * errors and signed bytes deliberately remain private.
+ *
+ * The historical class and wire-code names are retained for compatibility,
+ * but this fail-closed envelope now covers both external and local EVM custody.
  */
 export class ExternalBroadcastOutcomeUnknownError extends Error {
   readonly code = "external_broadcast_outcome_unknown" as const;
@@ -71,7 +74,7 @@ export class ExternalBroadcastOutcomeUnknownError extends Error {
     readonly transactionHash: string,
     options?: { cause?: unknown },
   ) {
-    super("External custody broadcast outcome is unknown", options);
+    super("EVM broadcast outcome is unknown", options);
     this.name = "ExternalBroadcastOutcomeUnknownError";
   }
 }

--- a/packages/vault/src/local-evm-broadcast.ts
+++ b/packages/vault/src/local-evm-broadcast.ts
@@ -1,0 +1,75 @@
+import { type Hex, keccak256 } from "viem";
+import { ExternalBroadcastOutcomeUnknownError } from "./external-key-custody";
+
+export interface LocalEvmBroadcastLifecycle {
+  /** Prepare and locally sign bytes. No mutating RPC may occur here. */
+  prepare: () => Promise<Hex>;
+  /** Durably persist the deterministic hash before the mutating RPC boundary. */
+  checkpoint: (transactionHash: Hex) => Promise<void>;
+  /** Submit the exact signed bytes once. This callback must never retry. */
+  broadcast: (serializedTransaction: Hex) => Promise<Hex>;
+  /** One read-only reconciliation attempt after a lost/failed RPC response. */
+  reconcile: (transactionHash: Hex) => Promise<boolean>;
+  /** Release allocator state only while it is still proven pre-broadcast. */
+  releaseBeforeBroadcast: () => Promise<void>;
+  /** Persist accepted state and confirm allocator bookkeeping. */
+  finalizeAccepted: (transactionHash: Hex) => Promise<void>;
+}
+
+/**
+ * Broadcast a locally signed EVM transaction without ever blindly retrying or
+ * reusing its nonce after the first mutating RPC call.
+ *
+ * The signed bytes make the final transaction hash deterministic. Steward
+ * checkpoints that hash before submission, broadcasts exactly once, and then
+ * performs at most one read-only hash reconciliation if the RPC response is
+ * lost. Any unresolved or post-broadcast failure is surfaced as
+ * outcome-unknown and deliberately does not call `releaseBeforeBroadcast`.
+ */
+export async function executeLocalEvmBroadcast(
+  lifecycle: LocalEvmBroadcastLifecycle,
+): Promise<Hex> {
+  let serializedTransaction: Hex;
+  try {
+    serializedTransaction = await lifecycle.prepare();
+  } catch (error) {
+    await lifecycle.releaseBeforeBroadcast().catch(() => {});
+    throw error;
+  }
+
+  const transactionHash = keccak256(serializedTransaction);
+  try {
+    await lifecycle.checkpoint(transactionHash);
+  } catch (error) {
+    // No mutating RPC has happened, so this is the final safe release point.
+    await lifecycle.releaseBeforeBroadcast().catch(() => {});
+    throw error;
+  }
+
+  let returnedHash: Hex;
+  try {
+    returnedHash = await lifecycle.broadcast(serializedTransaction);
+  } catch (cause) {
+    const reconciled = await lifecycle.reconcile(transactionHash).catch(() => false);
+    if (!reconciled) {
+      throw new ExternalBroadcastOutcomeUnknownError(transactionHash, { cause });
+    }
+    returnedHash = transactionHash;
+  }
+
+  if (returnedHash.toLowerCase() !== transactionHash.toLowerCase()) {
+    throw new ExternalBroadcastOutcomeUnknownError(transactionHash, {
+      cause: new Error("EVM RPC returned a mismatched transaction hash"),
+    });
+  }
+
+  try {
+    await lifecycle.finalizeAccepted(transactionHash);
+  } catch (cause) {
+    // Submission has completed (or was reconciled), and the durable checkpoint
+    // remains the authoritative recovery record. Never make this retryable.
+    throw new ExternalBroadcastOutcomeUnknownError(transactionHash, { cause });
+  }
+
+  return transactionHash;
+}

--- a/packages/vault/src/vault.ts
+++ b/packages/vault/src/vault.ts
@@ -69,6 +69,7 @@ import {
 import { deriveBitcoinKey, deriveEvmKey, deriveSolanaKey, generateMnemonic } from "./hd-wallet";
 import { type EncryptedKey, KeyStore } from "./keystore";
 import { backendFromKeyStore, type KeystoreBackend } from "./keystore-backend";
+import { executeLocalEvmBroadcast } from "./local-evm-broadcast";
 import {
   createMoneroBackendFromEnv,
   generateMoneroWallet,
@@ -1844,7 +1845,10 @@ export class Vault {
         });
         const publicClient = createPublicClient({
           chain,
-          transport: http(rpcUrl),
+          // The signed bytes are submitted exactly once at the application and
+          // transport layers. A lost response is reconciled by hash, never by
+          // replaying eth_sendRawTransaction.
+          transport: http(rpcUrl, { retryCount: 0 }),
         });
         // Track only allocator-issued nonces for in-flight reclaim; a
         // caller-supplied `request.nonce` is the caller's responsibility.
@@ -1860,36 +1864,65 @@ export class Vault {
             : undefined;
         const nonce = request.nonce ?? (allocatedNonce as number);
 
-        try {
-          hash = await client.sendTransaction({
-            to: request.to as `0x${string}`,
-            value: BigInt(request.value),
-            data: request.data as `0x${string}` | undefined,
-            gas: request.gasLimit ? BigInt(request.gasLimit) : undefined,
-            nonce,
-          });
-          if (allocatedNonce !== undefined) {
-            // Best-effort: confirmation bookkeeping must not fail a good send.
-            await confirmEvmNonce({
-              tenantId: request.tenantId,
-              walletAddress: account.address,
-              chainId,
-              nonce: allocatedNonce,
-            }).catch(() => {});
-          }
-        } catch (err) {
-          if (allocatedNonce !== undefined) {
-            // Best-effort: mark the dropped nonce reclaimable so the wallet
-            // doesn't wedge behind a permanent hole.
+        // Keep the pre-broadcast checkpoint and accepted update on one durable
+        // transaction id even for legacy callers that did not supply one.
+        const localRecordOptions: SignTransactionOptions = {
+          ...options,
+          txId: options.txId ?? randomUUID(),
+        };
+
+        return executeLocalEvmBroadcast({
+          prepare: async () => {
+            const prepared = await client.prepareTransactionRequest({
+              to: request.to as `0x${string}`,
+              value: BigInt(request.value),
+              data: request.data as `0x${string}` | undefined,
+              gas: request.gasLimit ? BigInt(request.gasLimit) : undefined,
+              nonce,
+            });
+            return client.signTransaction(prepared);
+          },
+          checkpoint: (transactionHash) =>
+            this.recordSignedTransaction(request, chainId, true, transactionHash, {
+              ...localRecordOptions,
+              status: "outcome_unknown",
+            }),
+          broadcast: (serializedTransaction) =>
+            publicClient.sendRawTransaction({ serializedTransaction }),
+          reconcile: async (transactionHash) => {
+            try {
+              const transaction = await publicClient.getTransaction({ hash: transactionHash });
+              return transaction.hash.toLowerCase() === transactionHash.toLowerCase();
+            } catch {
+              return false;
+            }
+          },
+          releaseBeforeBroadcast: async () => {
+            if (allocatedNonce === undefined) return;
             await markEvmNonceDropped({
               tenantId: request.tenantId,
               walletAddress: account.address,
               chainId,
               nonce: allocatedNonce,
-            }).catch(() => {});
-          }
-          throw err;
-        }
+            });
+          },
+          finalizeAccepted: async (transactionHash) => {
+            if (allocatedNonce !== undefined) {
+              // Best-effort: allocator bookkeeping cannot invalidate an
+              // accepted, deterministically identified transaction.
+              await confirmEvmNonce({
+                tenantId: request.tenantId,
+                walletAddress: account.address,
+                chainId,
+                nonce: allocatedNonce,
+              }).catch(() => {});
+            }
+            await this.recordSignedTransaction(request, chainId, true, transactionHash, {
+              ...localRecordOptions,
+              status: localRecordOptions.status ?? "broadcast",
+            });
+          },
+        });
       } else {
         // Sign without broadcasting - return the serialized signed transaction
         const rpcUrl = CHAIN_RPCS[chainId] ?? this.config.rpcUrl;


### PR DESCRIPTION
## Summary
- locally prepare and sign EVM transaction bytes before the mutating RPC boundary
- derive and durably checkpoint the deterministic transaction hash before submission
- disable transport retries for `eth_sendRawTransaction`, submit the exact bytes once, and reconcile a lost response once by hash
- keep allocator-issued nonces reserved for every unresolved, mismatched-hash, and post-broadcast persistence failure
- release a nonce only when preparation or the durable checkpoint fails before any mutating RPC
- preserve the existing outcome-unknown wire contract for API/SDK compatibility

## Security invariant
After signed bytes can have reached an RPC, Steward must never classify the attempt as safely retryable or make its nonce reclaimable unless chain state proves the exact deterministic hash was accepted. A lost response must produce a durable `outcome_unknown` record and require hash reconciliation.

## Exact local validation
Head `c656f34be32dfeaeb480afc31b7934cfcc53ccef` on develop `f14389fb1ff8c1186b183c08ce59fa46c6373ff2`:
- local deterministic broadcast lifecycle + wiring: 7/7, 25 assertions
- `@stwd/vault` and `@stwd/api` builds: green
- Biome changed surfaces and `git diff --check`: green
- broader compatibility suites and fresh hosted exact-head CI are pending; keep this PR draft until fully green

## Failure semantics
- prepare/checkpoint failure: no mutating RPC occurred, so best-effort nonce release is safe
- RPC response loss + hash found: finalize the deterministic accepted hash without reposting
- RPC response loss + hash absent/unavailable: retain nonce and return outcome-unknown
- mismatched RPC hash: retain nonce and return outcome-unknown
- final persistence failure: retain nonce; the pre-broadcast outcome-unknown checkpoint remains authoritative

Security audit follow-up to #476.