### PR TITLE
test(worker): replace database lifetime source scans

### DIFF
--- a/packages/api/src/__tests__/worker-runtime-sentinel.test.ts
+++ b/packages/api/src/__tests__/worker-runtime-sentinel.test.ts
@@ -1,7 +1,11 @@
-import { expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
-import { getDb, tenants, waitUntilRequestDatabaseTask } from "@stwd/db";
+import { expect, spyOn, test } from "bun:test";
+import * as databaseModule from "@stwd/db";
+import {
+  __resetAuditHmacKeyCacheForTests,
+  getDb,
+  tenants,
+  waitUntilRequestDatabaseTask,
+} from "@stwd/db";
 import { createPGLiteDb } from "@stwd/db/pglite";
 import {
   hydrateProcessEnv,
@@ -9,6 +13,7 @@ import {
   runWorkerUpstreamCredentialLeaseSweep,
   runWorkerXCredentialLifecycleSweep,
   withWorkerRequestDatabase,
+  default as worker,
 } from "../worker";
 
 test("Worker hydration cannot be overridden by a STEWARD_RUNTIME binding", () => {
@@ -121,40 +126,144 @@ test("Worker database selection rejects missing or unsupported drivers", async (
   }
 });
 
-test("every autonomous recovery sweep owns its own request database", () => {
-  const source = readFileSync(join(import.meta.dir, "../worker.ts"), "utf8");
-  for (const sweep of [
-    "runWorkerUpstreamCredentialLeaseSweep",
-    "runWorkerGoogleCredentialLifecycleSweep",
-    "runWorkerXCredentialLifecycleSweep",
-  ]) {
-    expect(source).toContain(`withWorkerRequestDatabase(env, () => ${sweep}(env))`);
+test("Worker cron gives every autonomous sweep its own request database", async () => {
+  const upstreamScheduler = await import("../services/upstream-credential-lease-scheduler");
+  const googleScheduler = await import("../services/provider-google-lifecycle-scheduler");
+  const xScheduler = await import("../services/provider-x-lifecycle-scheduler");
+  const seen: string[] = [];
+  let databaseCount = 0;
+  const createDbSpy = spyOn(databaseModule, "createDbForRequest").mockImplementation(() => {
+    databaseCount += 1;
+    return { marker: `cron-db-${databaseCount}` } as unknown as ReturnType<typeof getDb>;
+  });
+  const upstreamSpy = spyOn(
+    upstreamScheduler,
+    "runUpstreamCredentialLeaseSweep",
+  ).mockImplementation(async () => {
+    await Promise.resolve();
+    seen.push((getDb() as unknown as { marker: string }).marker);
+    return { unknown: 0, revoked: 0, attention: 0, expired: 0 };
+  });
+  const googleSpy = spyOn(
+    googleScheduler,
+    "runGoogleCredentialLifecycleRecoverySweep",
+  ).mockImplementation(async () => {
+    await Promise.resolve();
+    seen.push((getDb() as unknown as { marker: string }).marker);
+    return {} as never;
+  });
+  const xSpy = spyOn(xScheduler, "runXCredentialLifecycleRecoverySweep").mockImplementation(
+    async () => {
+      await Promise.resolve();
+      seen.push((getDb() as unknown as { marker: string }).marker);
+      return {} as never;
+    },
+  );
+  let scheduledWork!: Promise<unknown>;
+  const env = {
+    DATABASE_URL: "postgresql://worker.invalid/steward",
+    DATABASE_DRIVER: "neon-http",
+    STEWARD_JWT_SECRET: "worker-cron-test-secret-at-least-32-chars",
+    STEWARD_PLUGINS: "capabilities",
+    GOOGLE_PROVIDER_CLIENT_ID: "google-client",
+    GOOGLE_PROVIDER_CLIENT_SECRET: "google-secret",
+    X_CLIENT_ID: "x-client",
+    X_CLIENT_SECRET: "x-secret",
+    STEWARD_MASTER_PASSWORD: "worker-cron-master-password",
+  };
+  const previousEnv = new Map(Object.keys(env).map((key) => [key, process.env[key]] as const));
+
+  try {
+    await worker.scheduled({}, env, {
+      waitUntil(promise) {
+        scheduledWork = promise;
+      },
+    });
+    await scheduledWork;
+  } finally {
+    createDbSpy.mockRestore();
+    upstreamSpy.mockRestore();
+    googleSpy.mockRestore();
+    xSpy.mockRestore();
+    for (const [key, value] of previousEnv) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
   }
+
+  expect(databaseCount).toBe(3);
+  expect(seen.sort()).toEqual(["cron-db-1", "cron-db-2", "cron-db-3"]);
 });
 
-test("Worker defers webhook cleanup without delaying its response", async () => {
+test("configured webhook work retains its request database until Worker cleanup", async () => {
+  const previousMasterPassword = process.env.STEWARD_MASTER_PASSWORD;
+  const previousDatabaseUrl = process.env.DATABASE_URL;
+  process.env.STEWARD_MASTER_PASSWORD = "worker-webhook-test-master-password";
+  process.env.DATABASE_URL = "postgresql://worker.invalid/steward";
+  let dispatchWebhook: typeof import("../services/webhook-dispatch").dispatchWebhook;
+  let encryptedSecret: string;
+  let WebhookDispatcher: typeof import("@stwd/webhooks").WebhookDispatcher;
+  try {
+    ({ dispatchWebhook } = await import("../services/webhook-dispatch"));
+    const webhooks = await import("@stwd/webhooks");
+    WebhookDispatcher = webhooks.WebhookDispatcher;
+    encryptedSecret = webhooks.encryptWebhookSecret("worker-webhook-signing-secret");
+  } catch (error) {
+    if (previousMasterPassword === undefined) delete process.env.STEWARD_MASTER_PASSWORD;
+    else process.env.STEWARD_MASTER_PASSWORD = previousMasterPassword;
+    throw error;
+  } finally {
+    if (previousDatabaseUrl === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = previousDatabaseUrl;
+  }
   let releaseDelivery!: () => void;
   const deliveryGate = new Promise<void>((resolve) => {
     releaseDelivery = resolve;
   });
   let closes = 0;
   let deliveryFinished = false;
-  const requestDb = { marker: "worker-webhook" } as unknown as ReturnType<typeof getDb>;
-  let delivery!: Promise<void>;
+  const requestDb = {
+    marker: "worker-webhook",
+    select: () => ({
+      from: () => ({
+        where: async () => [
+          {
+            id: "worker-webhook-config",
+            tenantId: "tenant-worker-webhook",
+            url: "https://1.1.1.1/steward-webhook",
+            secret: encryptedSecret,
+            events: ["tx.signed"],
+            enabled: true,
+            maxRetries: 0,
+            retryBackoffMs: 0,
+          },
+        ],
+      }),
+    }),
+    insert: () => ({
+      values: () => ({ returning: async () => [{ id: "worker-webhook-delivery" }] }),
+    }),
+    update: () => ({
+      set: () => ({
+        where: () => ({ returning: async () => [{ id: "worker-webhook-delivery" }] }),
+      }),
+    }),
+  } as unknown as ReturnType<typeof getDb>;
   let deferredCleanup!: Promise<unknown>;
+  const dispatchSpy = spyOn(WebhookDispatcher.prototype, "dispatch").mockImplementation(
+    async () => {
+      await deliveryGate;
+      deliveryFinished = (getDb() as unknown as { marker: string }).marker === "worker-webhook";
+      return { success: true, attempts: 1, deliveredAt: new Date() };
+    },
+  );
   const owner = withWorkerRequestDatabase(
     {
       DATABASE_URL: "postgresql://worker.invalid/steward",
       DATABASE_DRIVER: "neon-websocket",
     },
     async () => {
-      // dispatchWebhook uses this same request-lifetime hook for its intentionally
-      // unawaited configured delivery fan-out.
-      delivery = waitUntilRequestDatabaseTask(async () => {
-        await deliveryGate;
-        expect((getDb() as unknown as { marker: string }).marker).toBe("worker-webhook");
-        deliveryFinished = true;
-      });
+      dispatchWebhook("tenant-worker-webhook", "agent-worker-webhook", "tx_signed", {});
       return new Response("accepted");
     },
     {
@@ -172,20 +281,92 @@ test("Worker defers webhook cleanup without delaying its response", async () => 
     },
   );
 
-  expect((await owner).status).toBe(200);
-  expect(closes).toBe(0);
-  releaseDelivery();
-  await Promise.all([delivery, deferredCleanup]);
-  expect(deliveryFinished).toBe(true);
-  expect(closes).toBe(1);
+  try {
+    expect((await owner).status).toBe(200);
+    expect(deliveryFinished).toBe(false);
+    expect(closes).toBe(0);
+    releaseDelivery();
+    await deferredCleanup;
+    expect(deliveryFinished).toBe(true);
+    expect(closes).toBe(1);
+  } finally {
+    dispatchSpy.mockRestore();
+    if (previousMasterPassword === undefined) delete process.env.STEWARD_MASTER_PASSWORD;
+    else process.env.STEWARD_MASTER_PASSWORD = previousMasterPassword;
+  }
+});
 
-  const webhookSource = readFileSync(
-    join(import.meta.dir, "../services/webhook-dispatch.ts"),
-    "utf8",
-  );
-  expect(webhookSource).toContain("waitUntilRequestDatabaseTask(");
-  const auditSource = readFileSync(join(import.meta.dir, "../services/audit.ts"), "utf8");
-  expect(auditSource).toContain("waitUntilRequestDatabaseTask(() =>");
+test("best-effort audit work retains its request database until Worker cleanup", async () => {
+  const { trackAuditEvent } = await import("../services/audit");
+  const previousAuditKey = process.env.STEWARD_AUDIT_HMAC_KEY;
+  process.env.STEWARD_AUDIT_HMAC_KEY = "a".repeat(64);
+  __resetAuditHmacKeyCacheForTests();
+  try {
+    let releaseAudit!: () => void;
+    const auditGate = new Promise<void>((resolve) => {
+      releaseAudit = resolve;
+    });
+    let auditTransactionFinished = false;
+    let auditGateConsumed = false;
+    let closes = 0;
+    const requestDb = {
+      marker: "worker-audit",
+      transaction: async (callback: (tx: { execute: () => Promise<unknown[]> }) => Promise<void>) =>
+        callback({
+          execute: async () => {
+            if (!auditGateConsumed) {
+              auditGateConsumed = true;
+              await auditGate;
+              auditTransactionFinished =
+                (getDb() as unknown as { marker: string }).marker === "worker-audit";
+            }
+            return [];
+          },
+        }),
+    } as unknown as ReturnType<typeof getDb>;
+    let deferredCleanup!: Promise<unknown>;
+
+    const response = await withWorkerRequestDatabase(
+      {
+        DATABASE_URL: "postgresql://worker.invalid/steward",
+        DATABASE_DRIVER: "neon-websocket",
+      },
+      async () => {
+        void trackAuditEvent({
+          tenantId: "tenant-worker-audit",
+          actorType: "system",
+          action: "system.worker.audit_registration_test",
+          metadata: {},
+        });
+        return new Response("accepted");
+      },
+      {
+        createHandle: () => ({
+          driver: "neon-websocket" as const,
+          db: requestDb as never,
+          async close() {
+            expect(auditTransactionFinished).toBe(true);
+            closes += 1;
+          },
+        }),
+        waitUntil(promise) {
+          deferredCleanup = promise;
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(auditTransactionFinished).toBe(false);
+    expect(closes).toBe(0);
+    releaseAudit();
+    await deferredCleanup;
+    expect(auditTransactionFinished).toBe(true);
+    expect(closes).toBe(1);
+  } finally {
+    if (previousAuditKey === undefined) delete process.env.STEWARD_AUDIT_HMAC_KEY;
+    else process.env.STEWARD_AUDIT_HMAC_KEY = previousAuditKey;
+    __resetAuditHmacKeyCacheForTests();
+  }
 });
 
 test("Worker closes a deferred database exactly once when waitUntil registration fails", async () => {
@@ -217,18 +398,63 @@ test("Worker closes a deferred database exactly once when waitUntil registration
     ),
   ).rejects.toThrow("waitUntil registration failed");
   expect(closes).toBe(1);
+
+  await expect(
+    withWorkerRequestDatabase(
+      {
+        DATABASE_URL: "postgresql://worker.invalid/steward",
+        DATABASE_DRIVER: "neon-websocket",
+      },
+      async () => {
+        void waitUntilRequestDatabaseTask(async () => {});
+        throw new Error("handler failed");
+      },
+      {
+        createHandle: () => ({
+          driver: "neon-websocket" as const,
+          db: requestDb as never,
+          async close() {
+            closes += 1;
+          },
+        }),
+        waitUntil() {
+          throw new Error("waitUntil registration failed");
+        },
+      },
+    ),
+  ).rejects.toThrow("handler failed");
+  expect(closes).toBe(2);
 });
 
-test("best-effort audit registration invokes a task callback", async () => {
-  const { trackAuditEvent } = await import("../services/audit");
-  await expect(
-    trackAuditEvent({
-      tenantId: "system",
-      actorType: "system",
-      action: "system.worker.audit_registration_test",
-      metadata: {},
-    }),
-  ).resolves.toBeUndefined();
+test("Worker reports deferred close failures through waitUntil without delaying its response", async () => {
+  const requestDb = { marker: "worker-close-failure" } as unknown as ReturnType<typeof getDb>;
+  let closes = 0;
+  let deferredCleanup!: Promise<unknown>;
+
+  const response = await withWorkerRequestDatabase(
+    {
+      DATABASE_URL: "postgresql://worker.invalid/steward",
+      DATABASE_DRIVER: "neon-websocket",
+    },
+    async () => new Response("accepted"),
+    {
+      createHandle: () => ({
+        driver: "neon-websocket" as const,
+        db: requestDb as never,
+        async close() {
+          closes += 1;
+          throw new Error("database password canary");
+        },
+      }),
+      waitUntil(promise) {
+        deferredCleanup = promise;
+      },
+    },
+  );
+
+  expect(response.status).toBe(200);
+  await expect(deferredCleanup).rejects.toThrow("WORKER_DATABASE_CLOSE_FAILED");
+  expect(closes).toBe(1);
 });
 
 test("Worker socket cleanup diagnostics are fixed and cannot replace handler errors", async () => {


### PR DESCRIPTION
Closes #501.

## Summary

- replace Worker cron source inspection with execution through the scheduled entrypoint, proving all three autonomous sweeps receive distinct request-owned databases
- execute a configured webhook delivery behind a gate, prove the response returns first, then prove the child request database remains usable until `waitUntil` cleanup closes it exactly once
- execute `trackAuditEvent` behind a gated transaction and prove its callback retains the request database until deferred cleanup
- retain and strengthen hostile `waitUntil` registration and database-close failure coverage
- remove all implementation-file reads and call-substring assertions from the runtime sentinel suite

No production logic changes.

## Validation

Exact head: `7ed3f1c5f9d3eca9ce6899df7b9be1bf5fc122df`
Base: `f14389fb1ff8c1186b183c08ce59fa46c6373ff2`

- focused Worker/request database suites: 25 pass, 0 fail, 79 assertions
- `bunx turbo run build --filter=@stwd/api`: 24/24 tasks successful
- Biome: pass
- `git diff --check`: pass
