### PR TITLE
test(api): replace agent token audit source scans

### DIFF
--- a/packages/api/src/__tests__/agent-admin-mutations-mfa.test.ts
+++ b/packages/api/src/__tests__/agent-admin-mutations-mfa.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
-import { agents, closeDb, getDb, tenants } from "@stwd/db";
+import { agents, auditEvents, closeDb, getDb, tenants } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
+import { and, asc, eq, inArray } from "drizzle-orm";
 import { Hono } from "hono";
 import type { AppVariables } from "../services/context";
 
@@ -93,6 +94,16 @@ describe("agent admin mutations require human session + MFA (SEC-209)", () => {
 
   it("rejects admin sessions without recent MFA", async () => {
     const app = await makeApp("admin-no-mfa");
+    const before = await getDb()
+      .select({ id: auditEvents.id })
+      .from(auditEvents)
+      .where(
+        and(
+          eq(auditEvents.tenantId, TENANT_ID),
+          eq(auditEvents.resourceId, AGENT_ID),
+          inArray(auditEvents.action, ["agent.token.create.authorized", "agent.token.create"]),
+        ),
+      );
     const res = await app.request(`/agents/${AGENT_ID}/token`, {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -103,6 +114,17 @@ describe("agent admin mutations require human session + MFA (SEC-209)", () => {
       ok: false,
       error: "Agent token creation requires recent MFA verification",
     });
+    const after = await getDb()
+      .select({ id: auditEvents.id })
+      .from(auditEvents)
+      .where(
+        and(
+          eq(auditEvents.tenantId, TENANT_ID),
+          eq(auditEvents.resourceId, AGENT_ID),
+          inArray(auditEvents.action, ["agent.token.create.authorized", "agent.token.create"]),
+        ),
+      );
+    expect(after).toEqual(before);
   });
 
   it("rejects non-admin sessions", async () => {
@@ -134,6 +156,25 @@ describe("agent admin mutations require human session + MFA (SEC-209)", () => {
       body: JSON.stringify({ expiresIn: "1h" }),
     });
     expect(tokenRes.status).toBe(200);
+    expect(tokenRes.headers.get("Cache-Control")).toBe("no-store, max-age=0");
+    expect(tokenRes.headers.get("Pragma")).toBe("no-cache");
+    expect(tokenRes.headers.get("Expires")).toBe("0");
+    const tokenAudits = await getDb()
+      .select({ action: auditEvents.action, seq: auditEvents.seq })
+      .from(auditEvents)
+      .where(
+        and(
+          eq(auditEvents.tenantId, TENANT_ID),
+          eq(auditEvents.resourceId, AGENT_ID),
+          inArray(auditEvents.action, ["agent.token.create.authorized", "agent.token.create"]),
+        ),
+      )
+      .orderBy(asc(auditEvents.seq));
+    expect(tokenAudits.map(({ action }) => action)).toEqual([
+      "agent.token.create.authorized",
+      "agent.token.create",
+    ]);
+    expect(tokenAudits[1]?.seq).toBe(tokenAudits[0]?.seq + 1);
 
     const deleteRes = await app.request(`/agents/${AGENT_ID}`, { method: "DELETE" });
     expect(deleteRes.status).toBe(200);

--- a/packages/api/src/__tests__/agent-audit-order.test.ts
+++ b/packages/api/src/__tests__/agent-audit-order.test.ts
@@ -29,7 +29,6 @@ function expectBefore(first: string, second: string) {
 describe("agent route audit ordering", () => {
   it("writes authorization audit events before sensitive agent mutations", () => {
     expectBefore('action: "agent.create.authorized"', "vault.createAgent");
-    expectBefore('action: "agent.token.create.authorized"', "createAgentToken");
     expectBefore('action: "agent.wallet.create.authorized"', "vault.createWallet");
     expectBefore('action: "agent.delete.authorized"', "revokeAgentTokens(agentId");
     expectBefore("revokeAgentTokens(agentId", ".delete(approvalQueue)");
@@ -44,14 +43,10 @@ describe("agent route audit ordering", () => {
     );
   });
 
-  it("requires recent MFA before key provisioning, token minting, signer escalation, and policy rewrites", () => {
+  it("requires recent MFA before key provisioning, signer escalation, and policy rewrites", () => {
     const createStart = routeSource.indexOf('agentRoutes.post("/",');
     expect(createStart).toBeGreaterThanOrEqual(0);
     expect(routeSource.indexOf("Agent creation", createStart)).toBeGreaterThan(createStart);
-
-    const tokenStart = routeSource.indexOf('agentRoutes.post("/:agentId/token"');
-    expect(tokenStart).toBeGreaterThanOrEqual(0);
-    expect(routeSource.indexOf("Agent token creation", tokenStart)).toBeGreaterThan(tokenStart);
 
     const walletStart = routeSource.indexOf('agentRoutes.post("/:agentId/wallets"');
     expect(walletStart).toBeGreaterThanOrEqual(0);
@@ -62,11 +57,6 @@ describe("agent route audit ordering", () => {
 
     const signerPatchStart = routeSource.indexOf('agentRoutes.patch("/:agentId/signers/:signerId"');
     expect(signerPatchStart).toBeGreaterThanOrEqual(0);
-    // The signer PATCH handler consolidates all privileged-field changes
-    // (signerType, address, chainFamily, permissions, metadata, status) behind
-    // a single recent-MFA gate labelled "Signer updates", set via the
-    // privilegedSignerUpdate flag. This is the credential-takeover fix from the
-    // PR #79 audit-gap sweep: previously type/address/chainFamily were ungated.
     expect(routeSource.indexOf("privilegedSignerUpdate", signerPatchStart)).toBeGreaterThan(
       signerPatchStart,
     );
@@ -107,18 +97,7 @@ describe("agent route audit ordering", () => {
     expect(routeSource).toContain("RESERVED_SIGNER_METADATA_KEYS");
   });
 
-  it("marks secret-bearing agent responses as non-cacheable", () => {
-    const tokenStart = routeSource.indexOf('agentRoutes.post("/:agentId/token"');
-    expect(tokenStart).toBeGreaterThanOrEqual(0);
-    const tokenRoute = routeSource.slice(
-      tokenStart,
-      routeSource.indexOf('agentRoutes.get("/:agentId/tokens"', tokenStart),
-    );
-    expect(tokenRoute.indexOf("createAgentToken")).toBeLessThan(
-      tokenRoute.indexOf('"Cache-Control"'),
-    );
-    expect(tokenRoute).toContain('"no-store, max-age=0"');
-
+  it("marks signer credential responses as non-cacheable", () => {
     const signerStart = routeSource.indexOf('agentRoutes.post("/:agentId/signers"');
     expect(signerStart).toBeGreaterThanOrEqual(0);
     const signerRoute = routeSource.slice(

--- a/packages/api/src/__tests__/agent-audit-rollback.test.ts
+++ b/packages/api/src/__tests__/agent-audit-rollback.test.ts
@@ -123,19 +123,6 @@ describe("agent audit rollback hardening", () => {
     expect(deleteRoute).toContain("tx.insert(policies).values(deleteSnapshot.policies)");
   });
 
-  it("server-generates nested policy rule ids instead of probing the global rule namespace", () => {
-    const createRuleStart = routeSource.indexOf('agentRoutes.post("/:agentId/policies/rules"');
-    expect(createRuleStart).toBeGreaterThanOrEqual(0);
-    const createRuleRoute = routeSource.slice(
-      createRuleStart,
-      routeSource.indexOf('agentRoutes.get("/:agentId/policies/rules/:ruleId"', createRuleStart),
-    );
-
-    expect(createRuleRoute).toContain("id: crypto.randomUUID()");
-    expect(createRuleRoute).not.toContain(".where(eq(policies.id, nextRule.id))");
-    expect(createRuleRoute).not.toContain("Policy rule id already exists");
-  });
-
   it("does not let callers probe or reserve global agent or policy ids", () => {
     const createStart = routeSource.indexOf('agentRoutes.post("/",');
     expect(createStart).toBeGreaterThanOrEqual(0);


### PR DESCRIPTION
Refs #500

## Tranche scope
This first behavioral tranche removes only source assertions with executable replacements:

- token mint rejection without recent MFA now proves no authorization/final audit row is written
- successful token mint proves ordered authorization/final audit rows and all three non-cacheable response headers
- the nested policy-rule ID source scan is removed because `agent-policy-rules.test.ts` already calls the route with a colliding caller ID and proves a fresh server-generated ID
- historical PR commentary in the touched signer scan is removed

All uncovered rollback, deletion, wallet, signer, quorum, agent-ID, and remaining MFA source assertions are intentionally retained for later issue #500 tranches. The signer cache scan is also retained; the broader signer behavioral suite is currently not reliable enough on develop to justify deleting it.

## Exact-head validation
Validated at `e579beea5fb0074bced85b21878b923c293821fd` after rebasing onto `f14389fb1ff8c1186b183c08ce59fa46c6373ff2`.

- `bun install --frozen-lockfile`
- `bunx turbo run build --filter=@stwd/api` (24/24 tasks)
- agent audit source suites (8/8)
- agent admin mutation behavior (5/5)
- agent policy-rule behavior (4/4)
- Biome on all changed files
- `git diff --check origin/develop...HEAD`