### PR TITLE
fix(ci): format dependency security regression

### DIFF
--- a/scripts/__tests__/dependency-security-floors.test.ts
+++ b/scripts/__tests__/dependency-security-floors.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 const root = join(import.meta.dir, "../..");


### PR DESCRIPTION
Corrects the Biome import-order failure in the dependency security-floor regression merged by #494.

Exact evidence: dependency floor test 1/1 (12 assertions), API dependency graph 24/24, full workspace build reached all 39 package tasks and completed the production web build before Turbo output finalization was stopped, Biome clean, diff-check clean.