### PR TITLE
fix(seed): generate demo API credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ __pycache__/
 .env.local
 .env.*.local
 !.env.example
+.steward/
 # Operator-local fleet inventory (SEC-130 — node IPs are never committed)
 scripts/deploy-nodes.local.conf
 

--- a/packages/seed/src/__tests__/demo-api-key.test.ts
+++ b/packages/seed/src/__tests__/demo-api-key.test.ts
@@ -33,6 +33,13 @@ describe("demo API key", () => {
       symlinkSync(path, symlink);
       expect(() => writeDemoCredentials("other", pair.key, symlink)).toThrow();
       expect(readFileSync(path, "utf8")).toContain("STEWARD_TENANT_ID=waifu.fun");
+
+      const linkedParent = join(root, "linked-parent");
+      symlinkSync(dirname(path), linkedParent);
+      expect(() =>
+        writeDemoCredentials("other", pair.key, join(linkedParent, "other.env")),
+      ).toThrow("parent must be a real directory");
+      expect(() => readFileSync(join(dirname(path), "other.env"), "utf8")).toThrow();
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/packages/seed/src/__tests__/demo-api-key.test.ts
+++ b/packages/seed/src/__tests__/demo-api-key.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { validateApiKey } from "../../../auth/src/api-keys";
+import { generateDemoApiKey } from "../demo-api-key";
+
+describe("demo API key", () => {
+  test("is fresh, high-entropy, and verifies only against its own hash", () => {
+    const first = generateDemoApiKey();
+    const second = generateDemoApiKey();
+
+    expect(first.key).toMatch(/^stw_[0-9a-f]{32}$/);
+    expect(first.hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(second.key).not.toBe(first.key);
+    expect(validateApiKey(first.key, first.hash)).toBe(true);
+    expect(validateApiKey(second.key, first.hash)).toBe(false);
+  });
+});

--- a/packages/seed/src/__tests__/demo-api-key.test.ts
+++ b/packages/seed/src/__tests__/demo-api-key.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
+import { lstatSync, mkdtempSync, readFileSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
 import { validateApiKey } from "../../../auth/src/api-keys";
-import { generateDemoApiKey } from "../demo-api-key";
+import { generateDemoApiKey, writeDemoCredentials } from "../demo-api-key";
 
 describe("demo API key", () => {
   test("is fresh, high-entropy, and verifies only against its own hash", () => {
@@ -12,5 +15,26 @@ describe("demo API key", () => {
     expect(second.key).not.toBe(first.key);
     expect(validateApiKey(first.key, first.hash)).toBe(true);
     expect(validateApiKey(second.key, first.hash)).toBe(false);
+  });
+
+  test("writes tenant-bound credentials owner-only and rejects symlink targets", () => {
+    const root = mkdtempSync(join(tmpdir(), "steward-demo-credentials-"));
+    try {
+      const pair = generateDemoApiKey();
+      const path = join(root, "private", "demo.env");
+      expect(writeDemoCredentials("waifu.fun", pair.key, path)).toBe(path);
+      expect(lstatSync(dirname(path)).mode & 0o777).toBe(0o700);
+      expect(lstatSync(path).mode & 0o777).toBe(0o600);
+      expect(readFileSync(path, "utf8")).toBe(
+        `STEWARD_TENANT_ID=waifu.fun\nSTEWARD_API_KEY=${pair.key}\n`,
+      );
+
+      const symlink = join(root, "linked.env");
+      symlinkSync(path, symlink);
+      expect(() => writeDemoCredentials("other", pair.key, symlink)).toThrow();
+      expect(readFileSync(path, "utf8")).toContain("STEWARD_TENANT_ID=waifu.fun");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/seed/src/demo-api-key.ts
+++ b/packages/seed/src/demo-api-key.ts
@@ -1,0 +1,13 @@
+import { generateApiKey } from "../../auth/src/api-keys";
+import type { ApiKeyPair } from "../../auth/src/types";
+
+/**
+ * Mint a fresh credential for each demo seed run.
+ *
+ * Demo data may be loaded into an internet-reachable environment, so a
+ * repository-known key is unsafe even when the package is primarily intended
+ * for local development.
+ */
+export function generateDemoApiKey(): ApiKeyPair {
+  return generateApiKey();
+}

--- a/packages/seed/src/demo-api-key.ts
+++ b/packages/seed/src/demo-api-key.ts
@@ -4,6 +4,7 @@ import {
   constants as fsConstants,
   fstatSync,
   ftruncateSync,
+  lstatSync,
   mkdirSync,
   openSync,
   writeFileSync,
@@ -33,7 +34,15 @@ export function writeDemoCredentials(
     throw new Error("Demo credential tenant id is invalid");
   }
   const path = resolve(outputPath);
-  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  const parentPath = dirname(path);
+  mkdirSync(parentPath, { recursive: true, mode: 0o700 });
+  const parent = lstatSync(parentPath);
+  if (!parent.isDirectory() || parent.isSymbolicLink()) {
+    throw new Error("Demo credentials parent must be a real directory");
+  }
+  if (typeof process.geteuid === "function" && parent.uid !== process.geteuid()) {
+    throw new Error("Demo credentials parent must be owned by the current user");
+  }
   const fd = openSync(
     path,
     fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_NOFOLLOW | fsConstants.O_NONBLOCK,

--- a/packages/seed/src/demo-api-key.ts
+++ b/packages/seed/src/demo-api-key.ts
@@ -1,3 +1,14 @@
+import {
+  closeSync,
+  fchmodSync,
+  constants as fsConstants,
+  fstatSync,
+  ftruncateSync,
+  mkdirSync,
+  openSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, resolve } from "node:path";
 import { generateApiKey } from "../../auth/src/api-keys";
 import type { ApiKeyPair } from "../../auth/src/types";
 
@@ -10,4 +21,37 @@ import type { ApiKeyPair } from "../../auth/src/types";
  */
 export function generateDemoApiKey(): ApiKeyPair {
   return generateApiKey();
+}
+
+/** Persist the one-time credential without exposing it to terminal/CI logs. */
+export function writeDemoCredentials(
+  tenantId: string,
+  apiKey: string,
+  outputPath = process.env.STEWARD_DEMO_CREDENTIALS_FILE ?? ".steward/demo-credentials.env",
+): string {
+  if (!/^[A-Za-z0-9_.:-]{1,64}$/.test(tenantId)) {
+    throw new Error("Demo credential tenant id is invalid");
+  }
+  const path = resolve(outputPath);
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  const fd = openSync(
+    path,
+    fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_NOFOLLOW | fsConstants.O_NONBLOCK,
+    0o600,
+  );
+  try {
+    const stat = fstatSync(fd);
+    if (!stat.isFile() || stat.nlink !== 1) {
+      throw new Error("Demo credentials output must be a regular, non-linked file");
+    }
+    if (typeof process.geteuid === "function" && stat.uid !== process.geteuid()) {
+      throw new Error("Demo credentials output must be owned by the current user");
+    }
+    fchmodSync(fd, 0o600);
+    ftruncateSync(fd, 0);
+    writeFileSync(fd, `STEWARD_TENANT_ID=${tenantId}\nSTEWARD_API_KEY=${apiKey}\n`, "utf8");
+  } finally {
+    closeSync(fd);
+  }
+  return path;
 }

--- a/packages/seed/src/index.ts
+++ b/packages/seed/src/index.ts
@@ -13,7 +13,7 @@ import {
   transactions,
 } from "../../db/src/index.ts";
 import { KeyStore } from "../../vault/src/index.ts";
-import { generateDemoApiKey } from "./demo-api-key";
+import { generateDemoApiKey, writeDemoCredentials } from "./demo-api-key";
 
 /* ──────────────────────────────────────────────────────────────────────────── */
 /*  Constants                                                                  */
@@ -162,6 +162,7 @@ async function seed() {
         updatedAt,
       },
     });
+  const demoCredentialsPath = writeDemoCredentials(TENANT_ID, DEMO_API_KEY.key);
 
   /* ════════════════════════════════════════════════════════════════════════ */
   /*  AGENT DEFINITIONS                                                      */
@@ -1996,7 +1997,7 @@ async function seed() {
 
   /* ── Summary ───────────────────────────────────────────────────────────── */
   console.log(`\nSeeded tenant: ${TENANT_ID}`);
-  console.log(`Demo API key:  ${DEMO_API_KEY.key}`);
+  console.log(`Demo credentials: ${demoCredentialsPath} (mode 0600)`);
   console.log(`Agents:        ${agentDefs.length}`);
   console.log(`Policies:      ${policySeeds.length}`);
   console.log(`Transactions:  ${txSeeds.length}`);

--- a/packages/seed/src/index.ts
+++ b/packages/seed/src/index.ts
@@ -1,4 +1,4 @@
-import crypto, { createHash } from "node:crypto";
+import crypto from "node:crypto";
 import { encodeFunctionData, parseAbi } from "viem";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import {
@@ -13,6 +13,7 @@ import {
   transactions,
 } from "../../db/src/index.ts";
 import { KeyStore } from "../../vault/src/index.ts";
+import { generateDemoApiKey } from "./demo-api-key";
 
 /* ──────────────────────────────────────────────────────────────────────────── */
 /*  Constants                                                                  */
@@ -20,7 +21,7 @@ import { KeyStore } from "../../vault/src/index.ts";
 
 const TENANT_ID = "waifu.fun";
 const TENANT_NAME = "waifu.fun";
-const DEMO_API_KEY = "stw_demo_waifu_fun_dashboard";
+const DEMO_API_KEY = generateDemoApiKey();
 
 const ERC20_ABI = parseAbi(["function transfer(address to, uint256 amount)"]);
 
@@ -89,10 +90,6 @@ type ApprovalSeed = {
 /*  Helpers                                                                    */
 /* ──────────────────────────────────────────────────────────────────────────── */
 
-function hashApiKey(key: string): string {
-  return createHash("sha256").update(key).digest("hex");
-}
-
 function randomTxHash(): `0x${string}` {
   return `0x${crypto.randomBytes(32).toString("hex")}`;
 }
@@ -153,7 +150,7 @@ async function seed() {
     .values({
       id: TENANT_ID,
       name: TENANT_NAME,
-      apiKeyHash: hashApiKey(DEMO_API_KEY),
+      apiKeyHash: DEMO_API_KEY.hash,
       createdAt,
       updatedAt,
     })
@@ -161,7 +158,7 @@ async function seed() {
       target: tenants.id,
       set: {
         name: TENANT_NAME,
-        apiKeyHash: hashApiKey(DEMO_API_KEY),
+        apiKeyHash: DEMO_API_KEY.hash,
         updatedAt,
       },
     });
@@ -1999,7 +1996,7 @@ async function seed() {
 
   /* ── Summary ───────────────────────────────────────────────────────────── */
   console.log(`\nSeeded tenant: ${TENANT_ID}`);
-  console.log(`Demo API key:  ${DEMO_API_KEY}`);
+  console.log(`Demo API key:  ${DEMO_API_KEY.key}`);
   console.log(`Agents:        ${agentDefs.length}`);
   console.log(`Policies:      ${policySeeds.length}`);
   console.log(`Transactions:  ${txSeeds.length}`);


### PR DESCRIPTION
## Summary
- replace the repository-known demo tenant bearer key with a fresh standard Steward API key on every seed run
- store the generated hash and reveal the plaintext only in the interactive seed summary
- add regression coverage for format, uniqueness, verification, and cross-key rejection

## Security context
CodeQL alert #30 points at SHA-256, but SHA-256 is appropriate for lookup of a high-entropy bearer token. The actual weakness was that the input was a repository-known constant, making any seeded tenant immediately authenticatable if the seeder was used in a reachable environment.

## Validation
- `bun test --timeout 30000 packages/seed/src/__tests__/demo-api-key.test.ts`
- `bunx @biomejs/biome check packages/seed/src/index.ts packages/seed/src/demo-api-key.ts packages/seed/src/__tests__/demo-api-key.test.ts`
- `git diff --check origin/develop...HEAD`