### PR TITLE
fix(eliza): bound authenticated trade transport

### DIFF
--- a/packages/eliza-plugin/src/__tests__/submit-trade.test.ts
+++ b/packages/eliza-plugin/src/__tests__/submit-trade.test.ts
@@ -21,6 +21,7 @@ describe("SUBMIT_TRADE action", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
     process.env = { ...OLD_ENV };
   });
@@ -62,9 +63,14 @@ describe("SUBMIT_TRADE action", () => {
     await expect(
       submitTradeAction.validate({} as any, mockMemory("buy 0.01 BTC") as any),
     ).resolves.toBe(true);
-    expect(fetchMock).toHaveBeenCalledWith("https://steward.example/v1/trade/sessions/ses_test", {
-      headers: { Authorization: "Bearer jwt-test", Accept: "application/json" },
-    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://steward.example/v1/trade/sessions/ses_test",
+      expect.objectContaining({
+        headers: { Authorization: "Bearer jwt-test", Accept: "application/json" },
+        redirect: "error",
+        signal: expect.any(AbortSignal),
+      }),
+    );
   });
 
   it("posts parsed order with Bearer JWT and returns confirmation", async () => {
@@ -92,6 +98,8 @@ describe("SUBMIT_TRADE action", () => {
     const [, request] = fetchMock.mock.calls[0];
     expect(fetchMock.mock.calls[0][0]).toBe("https://steward.example/v1/trade/hyperliquid/order");
     expect(request.headers.Authorization).toBe("Bearer jwt-test");
+    expect(request.redirect).toBe("error");
+    expect(request.signal).toBeInstanceOf(AbortSignal);
     expect(JSON.parse(request.body)).toMatchObject({
       sessionId: "ses_test",
       coin: "BTC",
@@ -141,6 +149,61 @@ describe("SUBMIT_TRADE action", () => {
     const result = await submitTradeAction.handler({} as any, mockMemory("buy 0.01 BTC") as any);
     expect(result?.success).toBe(false);
     expect(result?.text).toBe("venue error, will retry later");
+  });
+
+  it("rejects oversized chunked responses without reflecting their contents", async () => {
+    const secretCanary = "provider-secret-canary";
+    let cancelled = false;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("x".repeat(1024 * 1024)));
+        controller.enqueue(new TextEncoder().encode(secretCanary));
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(body, { status: 502 })),
+    );
+
+    const result = await submitTradeAction.handler({} as any, mockMemory("buy 0.01 BTC") as any);
+
+    expect(result?.success).toBe(false);
+    expect(result?.text).toBe("venue error, will retry later");
+    expect(JSON.stringify(result)).not.toContain(secretCanary);
+    expect(cancelled).toBe(true);
+  });
+
+  it("aborts a stalled request at the bounded deadline", async () => {
+    vi.useFakeTimers();
+    let observedSignal: AbortSignal | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async (_url: string, init?: RequestInit) =>
+          await new Promise<Response>((_resolve, reject) => {
+            observedSignal = init?.signal as AbortSignal;
+            observedSignal.addEventListener(
+              "abort",
+              () => reject(new Error("secret socket error")),
+              {
+                once: true,
+              },
+            );
+          }),
+      ),
+    );
+
+    const pending = submitTradeAction.handler({} as any, mockMemory("buy 0.01 BTC") as any);
+    await vi.advanceTimersByTimeAsync(10_000);
+    const result = await pending;
+
+    expect(observedSignal?.aborted).toBe(true);
+    expect(result?.success).toBe(false);
+    expect(result?.text).toBe("venue error, will retry later");
+    expect(JSON.stringify(result)).not.toContain("secret socket error");
   });
 
   it("rejects a non-localhost plaintext STEWARD_API_URL before any request", async () => {

--- a/packages/eliza-plugin/src/__tests__/submit-trade.test.ts
+++ b/packages/eliza-plugin/src/__tests__/submit-trade.test.ts
@@ -206,6 +206,53 @@ describe("SUBMIT_TRADE action", () => {
     expect(JSON.stringify(result)).not.toContain("secret socket error");
   });
 
+  it("cancels a stalled response body at the same bounded deadline", async () => {
+    vi.useFakeTimers();
+    let cancelled = false;
+    const body = new ReadableStream<Uint8Array>({
+      pull: () => new Promise<void>(() => {}),
+      cancel() {
+        cancelled = true;
+      },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(body, { status: 502 })),
+    );
+
+    const pending = submitTradeAction.handler({} as any, mockMemory("buy 0.01 BTC") as any);
+    await vi.advanceTimersByTimeAsync(10_000);
+    const result = await pending;
+
+    expect(cancelled).toBe(true);
+    expect(result?.success).toBe(false);
+    expect(result?.error).toBe("Steward request timed out");
+    expect(result?.text).toBe("venue error, will retry later");
+  });
+
+  it("removes its response-body abort listener after a completed response", async () => {
+    let signal: AbortSignal | undefined;
+    let addSpy: ReturnType<typeof vi.spyOn> | undefined;
+    let removeSpy: ReturnType<typeof vi.spyOn> | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init?: RequestInit) => {
+        signal = init?.signal as AbortSignal;
+        addSpy = vi.spyOn(signal, "addEventListener");
+        removeSpy = vi.spyOn(signal, "removeEventListener");
+        return new Response(JSON.stringify({ error: "HL unavailable" }), { status: 502 });
+      }),
+    );
+
+    const result = await submitTradeAction.handler({} as any, mockMemory("buy 0.01 BTC") as any);
+
+    expect(result?.success).toBe(false);
+    expect(addSpy).toHaveBeenCalledTimes(1);
+    const listener = addSpy?.mock.calls[0]?.[1];
+    expect(removeSpy).toHaveBeenCalledWith("abort", listener);
+    expect(signal?.aborted).toBe(false);
+  });
+
   it("rejects a non-localhost plaintext STEWARD_API_URL before any request", async () => {
     process.env.STEWARD_API_URL = "http://steward.example";
     const fetchMock = vi.fn();

--- a/packages/eliza-plugin/src/actions/submit-trade.ts
+++ b/packages/eliza-plugin/src/actions/submit-trade.ts
@@ -13,6 +13,8 @@ import { assertSecureApiUrl } from "../services/StewardService.js";
 
 const ACTION_NAME = "SUBMIT_TRADE";
 const DEFAULT_LEVERAGE = 1;
+const STEWARD_REQUEST_TIMEOUT_MS = 10_000;
+const MAX_STEWARD_RESPONSE_BYTES = 1024 * 1024;
 
 type Coin = "BTC" | "ETH";
 type Side = "buy" | "sell";
@@ -186,13 +188,95 @@ export function parseSubmitTrade(
   };
 }
 
-async function parseResponseJson(response: Response): Promise<unknown> {
-  const text = await response.text();
+async function readResponseText(response: Response, signal: AbortSignal): Promise<string> {
+  const declaredLength = response.headers.get("content-length");
+  if (declaredLength !== null) {
+    const parsedLength = Number(declaredLength);
+    if (!Number.isSafeInteger(parsedLength) || parsedLength < 0) {
+      void response.body?.cancel().catch(() => undefined);
+      throw new Error("Invalid Steward response length");
+    }
+    if (parsedLength > MAX_STEWARD_RESPONSE_BYTES) {
+      void response.body?.cancel().catch(() => undefined);
+      throw new Error("Steward response exceeded size limit");
+    }
+  }
+
+  const reader = response.body?.getReader();
+  if (!reader) return "";
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  const onAbort = () => {
+    void reader.cancel().catch(() => undefined);
+  };
+  signal.addEventListener("abort", onAbort, { once: true });
+  const aborted = new Promise<never>((_, reject) => {
+    if (signal.aborted) {
+      reject(new Error("Steward request timed out"));
+      return;
+    }
+    signal.addEventListener("abort", () => reject(new Error("Steward request timed out")), {
+      once: true,
+    });
+  });
+  try {
+    while (true) {
+      const result = await Promise.race([reader.read(), aborted]);
+      if (result.done) break;
+      if (!result.value) continue;
+      totalBytes += result.value.byteLength;
+      if (totalBytes > MAX_STEWARD_RESPONSE_BYTES) {
+        void reader.cancel().catch(() => undefined);
+        throw new Error("Steward response exceeded size limit");
+      }
+      chunks.push(result.value);
+    }
+  } finally {
+    signal.removeEventListener("abort", onAbort);
+  }
+  const bytes = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    throw new Error("Steward response was not valid UTF-8");
+  }
+}
+
+async function parseResponseJson(response: Response, signal: AbortSignal): Promise<unknown> {
+  const text = await readResponseText(response, signal);
   if (!text) return undefined;
   try {
     return JSON.parse(text);
   } catch {
     return { error: text };
+  }
+}
+
+async function fetchStewardJson(
+  url: string,
+  init: RequestInit,
+): Promise<{ status: number; ok: boolean; data: unknown }> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), STEWARD_REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      ...init,
+      redirect: "error",
+      signal: controller.signal,
+    });
+    const data = await parseResponseJson(response, controller.signal);
+    return { status: response.status, ok: response.ok, data };
+  } catch {
+    throw new Error(
+      controller.signal.aborted ? "Steward request timed out" : "Steward request failed",
+    );
+  } finally {
+    clearTimeout(timeout);
   }
 }
 
@@ -226,7 +310,7 @@ async function postOrder(
   }
 
   const idempotencyKey = crypto.randomUUID();
-  const response = await fetch(`${apiUrl}/v1/trade/hyperliquid/order`, {
+  const response = await fetchStewardJson(`${apiUrl}/v1/trade/hyperliquid/order`, {
     method: "POST",
     headers: {
       Authorization: `Bearer ${jwt}`,
@@ -245,7 +329,7 @@ async function postOrder(
       idempotencyKey,
     }),
   });
-  return { status: response.status, data: await parseResponseJson(response) };
+  return { status: response.status, data: response.data };
 }
 
 async function hasActiveSession(runtime: IAgentRuntime): Promise<boolean> {
@@ -260,11 +344,14 @@ async function hasActiveSession(runtime: IAgentRuntime): Promise<boolean> {
   if (!apiUrl || !jwt || !sessionId) return false;
 
   try {
-    const response = await fetch(`${apiUrl}/v1/trade/sessions/${encodeURIComponent(sessionId)}`, {
-      headers: { Authorization: `Bearer ${jwt}`, Accept: "application/json" },
-    });
+    const response = await fetchStewardJson(
+      `${apiUrl}/v1/trade/sessions/${encodeURIComponent(sessionId)}`,
+      {
+        headers: { Authorization: `Bearer ${jwt}`, Accept: "application/json" },
+      },
+    );
     if (!response.ok) return false;
-    const data = await parseResponseJson(response);
+    const data = response.data;
     const session =
       data && typeof data === "object" && "data" in data
         ? (data as { data?: Record<string, unknown> }).data

--- a/packages/eliza-plugin/src/actions/submit-trade.ts
+++ b/packages/eliza-plugin/src/actions/submit-trade.ts
@@ -206,19 +206,16 @@ async function readResponseText(response: Response, signal: AbortSignal): Promis
   if (!reader) return "";
   const chunks: Uint8Array[] = [];
   let totalBytes = 0;
+  let rejectAborted: (reason: Error) => void = () => {};
+  const aborted = new Promise<never>((_, reject) => {
+    rejectAborted = reject;
+  });
   const onAbort = () => {
     void reader.cancel().catch(() => undefined);
+    rejectAborted(new Error("Steward request timed out"));
   };
   signal.addEventListener("abort", onAbort, { once: true });
-  const aborted = new Promise<never>((_, reject) => {
-    if (signal.aborted) {
-      reject(new Error("Steward request timed out"));
-      return;
-    }
-    signal.addEventListener("abort", () => reject(new Error("Steward request timed out")), {
-      once: true,
-    });
-  });
+  if (signal.aborted) onAbort();
   try {
     while (true) {
       const result = await Promise.race([reader.read(), aborted]);
@@ -233,6 +230,7 @@ async function readResponseText(response: Response, signal: AbortSignal): Promis
     }
   } finally {
     signal.removeEventListener("abort", onAbort);
+    reader.releaseLock();
   }
   const bytes = new Uint8Array(totalBytes);
   let offset = 0;
@@ -270,6 +268,10 @@ async function fetchStewardJson(
       signal: controller.signal,
     });
     const data = await parseResponseJson(response, controller.signal);
+    // cancel() may resolve an outstanding reader.read() with { done: true }
+    // before the abort rejection wins Promise.race. Preserve the deadline as
+    // the outcome even in that ordering instead of accepting a partial body.
+    if (controller.signal.aborted) throw new Error("Steward request timed out");
     return { status: response.status, ok: response.ok, data };
   } catch {
     throw new Error(


### PR DESCRIPTION
## Security findings

The legacy SUBMIT_TRADE action reads a Steward JWT from its configured file/env and sent it with fetch defaults. A redirect could forward the bearer credential to another origin, stalled peers could hold the action indefinitely, and unbounded response.text() allowed memory exhaustion.

## Fix

- refuse redirects on both session validation and order submission
- enforce one 10-second end-to-end AbortController deadline
- stream responses with a 1 MiB decoded-byte cap and fatal UTF-8 decoding
- cancel hostile/oversized bodies and return fixed non-leaking transport errors
- add redirect/signal assertions, chunked oversize cancellation/non-leak coverage, and stalled-request timeout coverage

## Exact-head evidence

- Eliza SUBMIT_TRADE: 12/12
- dependency-aware @stwd/eliza-plugin graph: 12/12 builds
- Biome clean
- git diff --check clean

Keep draft until exact-head hosted CI and CodeQL are green.