### PR TITLE
test(api): make agent signer credential fixture hermetic

### DIFF
--- a/packages/api/src/__tests__/agent-signers.test.ts
+++ b/packages/api/src/__tests__/agent-signers.test.ts
@@ -9,6 +9,7 @@ import type { AppVariables } from "../services/context";
 
 const TENANT_ID = `agent-signers-tenant-${Date.now()}`;
 const AGENT_ID = `agent-signers-agent-${Date.now()}`;
+const savedSignerCredentialPepper = process.env.STEWARD_SIGNER_CREDENTIAL_PEPPER;
 
 setDefaultTimeout(30000);
 
@@ -39,6 +40,8 @@ describe("agent signer API", () => {
     process.env.STEWARD_PGLITE_MEMORY = "true";
     process.env.STEWARD_MASTER_PASSWORD = "agent-signers-master-password";
     process.env.STEWARD_AUDIT_HMAC_KEY = "agent-signers-audit-hmac-key-with-enough-entropy";
+    process.env.STEWARD_SIGNER_CREDENTIAL_PEPPER =
+      "agent-signers-credential-pepper-with-enough-entropy";
     const { db, client } = await createPGLiteDb("memory://");
     setPGLiteOverride(db, async () => {
       await client.close();
@@ -80,6 +83,11 @@ describe("agent signer API", () => {
     delete process.env.STEWARD_PGLITE_MEMORY;
     delete process.env.STEWARD_MASTER_PASSWORD;
     delete process.env.STEWARD_AUDIT_HMAC_KEY;
+    if (savedSignerCredentialPepper === undefined) {
+      delete process.env.STEWARD_SIGNER_CREDENTIAL_PEPPER;
+    } else {
+      process.env.STEWARD_SIGNER_CREDENTIAL_PEPPER = savedSignerCredentialPepper;
+    }
   });
 
   it("creates, lists, updates, and revokes delegated signer metadata", async () => {


### PR DESCRIPTION
Closes #515

## Summary

- configure a production-shaped signer credential pepper inside the agent signer route suite
- restore the incoming pepper after the suite so focused invocations do not leak environment state
- preserve all signer lifecycle, credential secrecy, authorization, MFA, duplicate, and policy-scope assertions

## Diagnosis

This was test harness drift, not a production defect. The credential service correctly fails closed without `STEWARD_SIGNER_CREDENTIAL_PEPPER`. The suite passed from `packages/api`, where Bun loads the package preload, but failed from the repository root, where that preload is not discovered. Making the credential fixture explicit removes the working-directory dependency without changing production behavior or adding a production-global test hook.

## Exact-head validation

Validated commit `8e5ab68ab31521d5cdf158fd75c17630b9f9022d` on base `ccd4dcfdfbbce359f1a99e9c36107c9f026a1066`:

- `bun test --timeout 120000 packages/api/src/__tests__/agent-signers.test.ts` — 9 pass, 0 fail, 66 expectations
- `cd packages/api && bun test --timeout 120000 src/__tests__/agent-signers.test.ts` — 9 pass, 0 fail, 66 expectations
- `cd packages/api && bun run build` — pass (`tsc --noEmit`)
- `bunx biome check packages/api/src/__tests__/agent-signers.test.ts` — pass
- `git diff --check origin/develop...HEAD` — pass
- final diff — one test file, 8 insertions
