### PR TITLE
test(sdk): declare JWT mock dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -486,6 +486,7 @@
       },
       "devDependencies": {
         "@simplewebauthn/browser": "^13.0.0",
+        "jose": "^6.2.1",
       },
     },
     "packages/seed": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -47,6 +47,7 @@
     "bs58": "^6.0.0"
   },
   "devDependencies": {
-    "@simplewebauthn/browser": "^13.0.0"
+    "@simplewebauthn/browser": "^13.0.0",
+    "jose": "^6.2.1"
   }
 }


### PR DESCRIPTION
Closes #516

## Summary
- declare `jose` in the SDK workspace that imports it from the behavioral agent-client mock server
- regenerate the Bun lockfile through the owning package manager
- remove reliance on unrelated root-workspace hoisting for SDK tests

## Exact-head validation
- frozen Bun install with scripts disabled: no changes
- full SDK suite: 290 pass, 0 fail, 1,349 assertions
- SDK TypeScript build: pass
- package-scoped Knip no longer reports `jose` as unlisted (remaining generated/public-export reports are baseline)
- Biome and `git diff --check`: pass

Keep draft until exact hosted CI and review are green.