### PR TITLE
fix(api): audit agent enrollment token issuance

### DIFF
--- a/packages/api/src/__tests__/agent-enroll-route.test.ts
+++ b/packages/api/src/__tests__/agent-enroll-route.test.ts
@@ -7,7 +7,7 @@
 
 import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
 import { generateP256KeyPair, signP256, verifyToken } from "@stwd/auth";
-import { agentSigners, agents, getDb, tenants } from "@stwd/db";
+import { agentSigners, agents, auditEvents, eq, getDb, tenants } from "@stwd/db";
 import { createPGLiteDb, setPGLiteOverride } from "@stwd/db/pglite";
 import { Hono } from "hono";
 import type { AppVariables } from "../services/context";
@@ -18,6 +18,8 @@ const AGENT_ID = `enroll-agent-${Date.now()}`;
 setDefaultTimeout(30000);
 
 let keypair: Awaited<ReturnType<typeof generateP256KeyPair>>;
+let auditTransactionFailure: Error | undefined;
+let successfulAuditTransactionsBeforeFailure = 0;
 
 async function makeApp() {
   const { agentEnrollRoutes } = await import("../routes/agent-enroll");
@@ -44,6 +46,28 @@ async function challenge(
   return body.data;
 }
 
+async function verifyEnrollment(
+  app: Awaited<ReturnType<typeof makeApp>>,
+  agentId = AGENT_ID,
+): Promise<Response> {
+  const { nonce, canonicalString } = await challenge(app, agentId);
+  const signature = await signP256(keypair.privateKey, canonicalString);
+  return app.request("/agent-enroll/verify", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ agentId, nonce, signature }),
+  });
+}
+
+async function enrollmentAuditMetadata(): Promise<Record<string, unknown>[]> {
+  const rows = await getDb()
+    .select({ metadata: auditEvents.metadata })
+    .from(auditEvents)
+    .where(eq(auditEvents.actorId, AGENT_ID))
+    .orderBy(auditEvents.seq);
+  return rows.map((row) => row.metadata);
+}
+
 describe("agent enrollment route (keypair-only boot)", () => {
   let app: Awaited<ReturnType<typeof makeApp>>;
 
@@ -51,8 +75,27 @@ describe("agent enrollment route (keypair-only boot)", () => {
     process.env.STEWARD_PGLITE_MEMORY = "true";
     process.env.STEWARD_MASTER_PASSWORD = "enroll-master-password-32-chars-min";
     process.env.STEWARD_JWT_SECRET = "enroll-jwt-secret-at-least-32-chars-long!!";
+    process.env.STEWARD_AUDIT_HMAC_KEY = "a".repeat(64);
     const { db, client } = await createPGLiteDb("memory://");
-    setPGLiteOverride(db, async () => {
+    const controlledDb = new Proxy(db, {
+      get(target, property) {
+        if (property === "transaction") {
+          return (...args: unknown[]) => {
+            if (auditTransactionFailure) {
+              if (successfulAuditTransactionsBeforeFailure === 0) throw auditTransactionFailure;
+              successfulAuditTransactionsBeforeFailure -= 1;
+            }
+            const transaction = Reflect.get(target, property, target) as (
+              ...params: unknown[]
+            ) => unknown;
+            return Reflect.apply(transaction, target, args);
+          };
+        }
+        const value = Reflect.get(target, property, target);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    });
+    setPGLiteOverride(controlledDb, async () => {
       await client.close();
     });
     keypair = await generateP256KeyPair();
@@ -112,6 +155,148 @@ describe("agent enrollment route (keypair-only boot)", () => {
     expect(payload.agentId).toBe(AGENT_ID);
     expect(payload.tenantId).toBe(TENANT_ID);
     expect(payload.scope).toBe("agent");
+
+    expect((await enrollmentAuditMetadata()).slice(-2)).toEqual([
+      { stage: "authorization", decision: "allow", ttl: "5m" },
+      { stage: "issuance", decision: "issued", ttl: "5m" },
+    ]);
+  });
+
+  it("returns no token when the required authorization audit is unavailable", async () => {
+    const diagnosticCanary = "AUDIT_DATABASE_NONCE_SIGNATURE_TOKEN_CANARY";
+    const originalError = console.error;
+    const diagnostics: unknown[][] = [];
+    console.error = (...args: unknown[]) => diagnostics.push(args);
+    auditTransactionFailure = new Error(diagnosticCanary);
+    const before = await enrollmentAuditMetadata();
+    try {
+      const res = await verifyEnrollment(app);
+      const body = (await res.json()) as { ok: boolean; data?: { token?: string }; error?: string };
+      expect(res.status).toBe(503);
+      expect(body).toEqual({ ok: false, error: "enrollment unavailable" });
+      expect(body.data?.token).toBeUndefined();
+    } finally {
+      auditTransactionFailure = undefined;
+      successfulAuditTransactionsBeforeFailure = 0;
+      console.error = originalError;
+    }
+
+    expect(await enrollmentAuditMetadata()).toEqual(before);
+    expect(JSON.stringify(diagnostics)).not.toContain(diagnosticCanary);
+    expect(diagnostics).toEqual([
+      ["[agent-enroll] authorization audit unavailable", { errorClass: "Error", errorCode: null }],
+    ]);
+  });
+
+  it("returns no token when the issuance audit fails after signing", async () => {
+    const diagnosticCanary = "ISSUANCE_AUDIT_TOKEN_CANARY";
+    const originalError = console.error;
+    const diagnostics: unknown[][] = [];
+    console.error = (...args: unknown[]) => diagnostics.push(args);
+    auditTransactionFailure = new Error(diagnosticCanary);
+    successfulAuditTransactionsBeforeFailure = 1;
+    const before = await enrollmentAuditMetadata();
+    try {
+      const res = await verifyEnrollment(app);
+      const body = (await res.json()) as { ok: boolean; data?: { token?: string }; error?: string };
+      expect(res.status).toBe(503);
+      expect(body).toEqual({ ok: false, error: "enrollment unavailable" });
+      expect(body.data?.token).toBeUndefined();
+    } finally {
+      auditTransactionFailure = undefined;
+      successfulAuditTransactionsBeforeFailure = 0;
+      console.error = originalError;
+    }
+
+    const appended = (await enrollmentAuditMetadata()).slice(before.length);
+    expect(appended).toEqual([{ stage: "authorization", decision: "allow", ttl: "5m" }]);
+    expect(JSON.stringify(diagnostics)).not.toContain(diagnosticCanary);
+    expect(diagnostics).toEqual([
+      ["[agent-enroll] issuance audit unavailable", { errorClass: "Error", errorCode: null }],
+    ]);
+  });
+
+  it("records authorization but never issuance when token signing fails", async () => {
+    const { nonce, canonicalString } = await challenge(app, AGENT_ID);
+    const signature = await signP256(keypair.privateKey, canonicalString);
+    const originalNodeEnv = process.env.NODE_ENV;
+    const originalJwtSecret = process.env.STEWARD_JWT_SECRET;
+    const originalRateLimitSoftFail = process.env.STEWARD_ALLOW_AUTH_RATE_LIMIT_SOFT_FAIL;
+    const originalTrustedProxyHops = process.env.STEWARD_TRUSTED_PROXY_HOPS;
+    const signingCanary = "SIGNATURE_TOKEN_CANARY";
+    const originalError = console.error;
+    const diagnostics: unknown[][] = [];
+    console.error = (...args: unknown[]) => diagnostics.push(args);
+    process.env.NODE_ENV = "production";
+    process.env.STEWARD_JWT_SECRET = signingCanary;
+    process.env.STEWARD_ALLOW_AUTH_RATE_LIMIT_SOFT_FAIL = "true";
+    process.env.STEWARD_TRUSTED_PROXY_HOPS = "1";
+    const before = await enrollmentAuditMetadata();
+    try {
+      const res = await app.request("/agent-enroll/verify", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-forwarded-for": "203.0.113.10",
+        },
+        body: JSON.stringify({ agentId: AGENT_ID, nonce, signature }),
+      });
+      const body = (await res.json()) as { ok: boolean; data?: { token?: string }; error?: string };
+      expect(res.status).toBe(503);
+      expect(body).toEqual({ ok: false, error: "enrollment unavailable" });
+      expect(body.data?.token).toBeUndefined();
+    } finally {
+      if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = originalNodeEnv;
+      if (originalJwtSecret === undefined) delete process.env.STEWARD_JWT_SECRET;
+      else process.env.STEWARD_JWT_SECRET = originalJwtSecret;
+      if (originalRateLimitSoftFail === undefined) {
+        delete process.env.STEWARD_ALLOW_AUTH_RATE_LIMIT_SOFT_FAIL;
+      } else {
+        process.env.STEWARD_ALLOW_AUTH_RATE_LIMIT_SOFT_FAIL = originalRateLimitSoftFail;
+      }
+      if (originalTrustedProxyHops === undefined) delete process.env.STEWARD_TRUSTED_PROXY_HOPS;
+      else process.env.STEWARD_TRUSTED_PROXY_HOPS = originalTrustedProxyHops;
+      console.error = originalError;
+    }
+
+    const appended = (await enrollmentAuditMetadata()).slice(before.length);
+    expect(appended).toEqual([{ stage: "authorization", decision: "allow", ttl: "5m" }]);
+    expect(JSON.stringify(diagnostics)).not.toContain(signingCanary);
+    expect(diagnostics).toEqual([
+      ["[agent-enroll] token signing failed", { errorClass: "Error", errorCode: null }],
+    ]);
+  });
+
+  it("keeps denial uniform and redacts diagnostics when its audit append fails", async () => {
+    const { nonce, canonicalString } = await challenge(app, AGENT_ID);
+    const other = await generateP256KeyPair();
+    const signature = await signP256(other.privateKey, canonicalString);
+    const diagnosticCanary = `DENIAL_${nonce}_${signature}_TOKEN_CANARY`;
+    const originalError = console.error;
+    const diagnostics: unknown[][] = [];
+    console.error = (...args: unknown[]) => diagnostics.push(args);
+    auditTransactionFailure = new Error(diagnosticCanary);
+    try {
+      const res = await app.request("/agent-enroll/verify", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ agentId: AGENT_ID, nonce, signature }),
+      });
+      expect(res.status).toBe(401);
+      expect(await res.json()).toEqual({ ok: false, error: "enrollment denied" });
+    } finally {
+      auditTransactionFailure = undefined;
+      successfulAuditTransactionsBeforeFailure = 0;
+      console.error = originalError;
+    }
+
+    expect(JSON.stringify(diagnostics)).not.toContain(nonce);
+    expect(JSON.stringify(diagnostics)).not.toContain(signature);
+    expect(JSON.stringify(diagnostics)).not.toContain(diagnosticCanary);
+    expect(diagnostics).toEqual([
+      ["[agent-enroll] denial audit unavailable", { errorClass: "Error", errorCode: null }],
+    ]);
   });
 
   it("rejects a wrong-key signature", async () => {

--- a/packages/api/src/routes/agent-enroll.ts
+++ b/packages/api/src/routes/agent-enroll.ts
@@ -34,6 +34,7 @@ import {
   verifyEnrollResponse,
 } from "@stwd/auth";
 import { agentSigners, eq } from "@stwd/db";
+import { redactedThrownDiagnostics } from "@stwd/shared";
 import { Hono } from "hono";
 import { writeAuditEvent } from "../services/audit";
 import {
@@ -78,6 +79,10 @@ function resolveEnrollTokenTtl(): string {
 const ENROLL_TOKEN_TTL = resolveEnrollTokenTtl();
 
 export const agentEnrollRoutes = new Hono<{ Variables: AppVariables }>();
+
+function reportEnrollmentFailure(message: string, error: unknown): void {
+  console.error(`[agent-enroll] ${message}`, redactedThrownDiagnostics(error));
+}
 
 /** Resolve an agent's ACTIVE p256 signer rows (+ its tenant) from agent_signers.
  * Returns the signers for the enrollment core AND the resolved tenantId (set as a
@@ -196,8 +201,10 @@ agentEnrollRoutes.post("/verify", async (c) => {
       action: "capability.enroll",
       resourceType: "agent",
       resourceId: agentId,
-      metadata: { decision: "deny", code: result.code },
-    }).catch(() => {});
+      metadata: { stage: "authorization", decision: "deny", code: result.code },
+    }).catch((error) => {
+      reportEnrollmentFailure("denial audit unavailable", error);
+    });
     return c.json<ApiResponse>({ ok: false, error: "enrollment denied" }, 401);
   }
 
@@ -207,20 +214,46 @@ agentEnrollRoutes.post("/verify", async (c) => {
     return c.json<ApiResponse>({ ok: false, error: "enrollment denied" }, 401);
   }
 
-  const token = await signAgentToken(
-    { agentId, tenantId: resolvedTenant, scopes: ["agent"] },
-    ENROLL_TOKEN_TTL,
-  );
+  try {
+    await writeAuditEvent({
+      tenantId: resolvedTenant,
+      actorType: "agent",
+      actorId: agentId,
+      action: "capability.enroll",
+      resourceType: "agent",
+      resourceId: agentId,
+      metadata: { stage: "authorization", decision: "allow", ttl: ENROLL_TOKEN_TTL },
+    });
+  } catch (error) {
+    reportEnrollmentFailure("authorization audit unavailable", error);
+    return c.json<ApiResponse>({ ok: false, error: "enrollment unavailable" }, 503);
+  }
 
-  await writeAuditEvent({
-    tenantId: resolvedTenant,
-    actorType: "agent",
-    actorId: agentId,
-    action: "capability.enroll",
-    resourceType: "agent",
-    resourceId: agentId,
-    metadata: { decision: "allow", ttl: ENROLL_TOKEN_TTL },
-  }).catch(() => {});
+  let token: string;
+  try {
+    token = await signAgentToken(
+      { agentId, tenantId: resolvedTenant, scopes: ["agent"] },
+      ENROLL_TOKEN_TTL,
+    );
+  } catch (error) {
+    reportEnrollmentFailure("token signing failed", error);
+    return c.json<ApiResponse>({ ok: false, error: "enrollment unavailable" }, 503);
+  }
+
+  try {
+    await writeAuditEvent({
+      tenantId: resolvedTenant,
+      actorType: "agent",
+      actorId: agentId,
+      action: "capability.enroll",
+      resourceType: "agent",
+      resourceId: agentId,
+      metadata: { stage: "issuance", decision: "issued", ttl: ENROLL_TOKEN_TTL },
+    });
+  } catch (error) {
+    reportEnrollmentFailure("issuance audit unavailable", error);
+    return c.json<ApiResponse>({ ok: false, error: "enrollment unavailable" }, 503);
+  }
 
   c.header("Cache-Control", "no-store, max-age=0");
   c.header("Pragma", "no-cache");


### PR DESCRIPTION
Closes #511.

## Summary

- durably record successful enrollment authorization before signing any agent JWT
- record successful issuance separately after signing and before returning the token
- fail closed with no token when either required audit append is unavailable
- ensure signing failures leave only an authorization event, never a false issuance event
- preserve uniform verification denial responses while replacing silent audit catches with bounded redacted diagnostics
- add route-level PGLite failure injection for authorization-audit outage, issuance-audit outage, signing failure, denial-audit outage, and the successful authorization/issuance sequence

No implementation-source scans or new production test hooks.

## Validation

Exact head: `2e668e9c818750e0b79bcbc809ae94146ecafb1b`
Base: `1a3b0d9542db43f638cf2c3bff5fca6e789f5b93`

- `agent-enroll-route.test.ts`: 9 pass, 0 fail, 53 assertions
- `agent-enroll-abuse.test.ts`: 3 pass, 0 fail, 10 assertions
- `bun run --cwd packages/api build`: pass
- Biome on both changed files: pass
- `git diff --check origin/develop...HEAD`: pass
