### PR TITLE
docs(plugin-trading): describe current invariants

### DIFF
--- a/packages/plugin-trading/src/index.ts
+++ b/packages/plugin-trading/src/index.ts
@@ -67,8 +67,8 @@ export const isOperatorRecoveryPath = (path: string): boolean =>
  * {@link tradingPlugin}'s `webhookEvents` so the plugin host merges them into the
  * core's runtime event registry (core ∪ plugin-declared) — a webhook can then be
  * configured for these event names even though the lean core's closed event
- * union never enumerates them. This is the Phase 2a contribution point proven
- * end-to-end.
+ * union never enumerates them. The host treats this declaration as the
+ * authoritative plugin contribution to the runtime event registry.
  *
  * Naming mirrors the plugin's existing `trade.*` audit-action vocabulary so the
  * webhook stream and the audit log speak the same event language.

--- a/packages/plugin-trading/src/routes/idempotency.ts
+++ b/packages/plugin-trading/src/routes/idempotency.ts
@@ -90,11 +90,9 @@ export class DurableIdempotencyStore<TRecord extends IdempotencyRecord> {
   }
 
   private sweepMemory(now: number): void {
-    // Evict EXPIRED entries only. Previously this also evicted live records
-    // oldest-first once the map hit the cap, which silently dropped replay
-    // protection for in-flight fund movements under key flooding: a retried
-    // request whose record was evicted would re-execute. Saturation with live
-    // records is handled by the claim path failing closed instead.
+    // Evict expired entries only. Live records protect in-flight fund movements
+    // from replay, so capacity saturation must fail closed rather than discard
+    // an active claim.
     for (const [entryKey, entry] of this.memory) {
       if (entry.expiresAt <= now) this.memory.delete(entryKey);
     }

--- a/packages/plugin-trading/src/routes/operator-recovery.ts
+++ b/packages/plugin-trading/src/routes/operator-recovery.ts
@@ -364,8 +364,8 @@ export function createOperatorRecoveryRoutes(
    * getTransactionStats(agentId, chainId): the recent-tx counts feed rate-limit
    * rules, and the spend sums — scoped to Arbitrum so they stay in the same
    * native-wei unit the policy gate denominates `value` in — feed daily/weekly
-   * spending-limit rules. Previously both routes hardcoded zeroes here, which
-   * made every rate-limit and daily/weekly spend rule structurally inert.
+   * spending-limit rules. These authoritative counters keep the policy gate
+   * effective across every operator transfer rail.
    */
   type OperatorQueryDb = Pick<typeof db, "select">;
   async function getOperatorSpendStats(
@@ -1154,10 +1154,9 @@ export function createOperatorRecoveryRoutes(
       );
     }
 
-    // Validate the USDC amount exactly like /withdraw: reject over-precision the
-    // 6-decimal conversion can't represent, and enforce the per-call safety
-    // ceiling so a compromised operator client cannot move the whole venue
-    // balance in one call (previously this rail had NO cap at all).
+    // Reject precision the six-decimal conversion cannot represent and enforce
+    // the per-call safety ceiling so one compromised operator request cannot
+    // move the venue's entire USDC balance.
     if (hasTooManyUsdcDecimals(amount)) {
       return c.json<ApiResponse>(
         { ok: false, error: "amount has more than 6 decimal places" },

--- a/packages/plugin-trading/src/routes/trade.ts
+++ b/packages/plugin-trading/src/routes/trade.ts
@@ -381,14 +381,9 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
     side: "buy" | "sell",
     limitPx: string | number | undefined,
   ): Promise<string | number> {
-    // Respect a caller-supplied limit price for BOTH sides. Previously the sell
-    // branch ignored `limitPx` entirely and always returned a MARKETABLE price,
-    // so a resting limit-sell ABOVE market (e.g. a breakeven take-profit) executed
-    // immediately at the bid instead of resting. A provided limitPx is the caller's
-    // intent for the ORDER price — use it; only synthesize a marketable price when
-    // none is given. NOTE: this is the ORDER price; policy NOTIONAL sizing must be
-    // computed separately via resolveSizingPx (a low sell limit must NOT understate
-    // the notional for cap enforcement).
+    // A supplied limit price is the caller's order-price intent for either side;
+    // synthesize a marketable price only when it is omitted. Policy notional uses
+    // resolveSizingPx separately so a low sell limit cannot understate exposure.
     if (limitPx !== undefined && limitPx !== null && limitPx !== "") return limitPx;
     if (side !== "sell") return getMarketableLimitPx(asset, true);
     try {
@@ -1091,10 +1086,9 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
       reduceOnly: body.reduceOnly,
       ...(body.orderType ? { orderType: body.orderType } : {}),
     };
-    // SEC-184: enforce the adapter contract check (the result was previously
-    // discarded) BEFORE reserving spend or signing. Every field is already
-    // validated upstream, so a failure here is an internal inconsistency —
-    // fail closed.
+    // Revalidate the complete adapter contract before reserving spend or signing.
+    // Any mismatch between the route inputs and adapter schema is an internal
+    // inconsistency and therefore fails closed.
     const parsedOrder = hyperliquidOrderSchema.safeParse(order);
     if (!parsedOrder.success) {
       return rejectPolicy(
@@ -1357,11 +1351,9 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
   // prediction-market policy gate (checkActiveOrder), spend reserve→release-on-
   // failure, the vault→ethers-signer bridge, the venue adapter call, audit events.
   //
-  // Phase C creds-provisioning is NOT wired yet: the L2 CLOB apiCredentials +
-  // funder Safe are resolved from the agent's polymarket venue wallet. Until
-  // provisioning writes them, resolvePolymarketAccount returns null and the route
-  // FAILS CLOSED with a typed 409 ("polymarket creds not provisioned"). We never
-  // invent credentials.
+  // L2 CLOB credentials and the funder Safe must resolve from the agent's
+  // Polymarket venue wallet. Missing provisioning fails closed with a typed 409;
+  // the route never invents or falls back to credentials.
   // ===========================================================================
 
   // Idempotency for the Polymarket body shape. Mirrors getIdempotency() but keyed
@@ -1848,16 +1840,14 @@ export function createTradeRoutes(ctx: StewardAppContext): Hono<{ Variables: App
     // all in one pass. checkActiveOrder loads the session and runs checkOrderAllowed
     // against the allowlist + per-order/daily caps.
     //
-    // SECURITY: we deliberately do NOT forward the caller-supplied `conditionId` to
+    // We deliberately do not forward the caller-supplied `conditionId` to
     // the allowlist check. The order is submitted for `tokenId` only, so trusting an
     // UNVERIFIED conditionId would let an agent pair any non-allowlisted token with
     // an allowlisted `pm:cond:<id>` and bypass the market allowlist. Until the
     // token->condition mapping is resolved from VERIFIED Polymarket metadata, the
     // order route honors ONLY exact `pm:<tokenId>` entries. A `pm:cond:<id>`
-    // session grant therefore requires the per-token entry to also be present to
-    // trade (or a future Phase C resolver that derives + verifies the condition).
-    // TODO(phase-c): resolve the token's true conditionId from venue metadata and
-    // pass it here so market-wide grants can be honored safely.
+    // session grant therefore does not authorize this route by itself; an exact
+    // per-token grant is required.
     const { session, check } = await getSessionManager().checkActiveOrder({
       tenantId,
       id: body.sessionId,


### PR DESCRIPTION
Closes #513.

Rewrites production comments in the trading package so they describe current invariants, trust boundaries, and reconciliation behavior without phase/issue/change-history narration. No executable code changes.

Validation on exact head:
- dependency-aware plugin-trading build: 12/12 tasks
- focused behavioral tests: 62 passed, 0 failed, 216 assertions
- Biome on all four changed files
- git diff --check
