### PR TITLE
fix(security): close ReDoS post-merge regressions

### DIFF
--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -159,7 +159,7 @@ console.log(host.describe()); // loaded plugins + every contribution
 the host refuses to compose an ambiguous or unsafe surface. a plugin:
 
 - cannot shadow a core policy rule type, and cannot reuse a rule type another plugin already registered.
-- cannot write into or read from the core migration journal - its migration ledger lives in its own namespaced table (`drizzle.__drizzle_migrations_plugin_<id>`). migration ids must already be canonical lowercase `[a-z0-9_]` text and fit the PostgreSQL identifier bound; lossy aliases are rejected.
+- cannot write into or read from the core migration journal - its migration ledger lives in its own namespaced table (`drizzle.__drizzle_migrations_plugin_<sanitized id>`). legacy sanitized ids remain supported, while overlong ids and aliases across registered plugins are rejected.
 - cannot silently overwrite a registered adapter - a `(category, provider)` collision throws, as does an unknown category, an empty provider, or a missing adapter instance.
 - cannot register against a half-built dependency - a missing or cyclic `dependsOn`, or a duplicate plugin name, throws before anything registers.
 

--- a/packages/api/src/__tests__/plugin-host.test.ts
+++ b/packages/api/src/__tests__/plugin-host.test.ts
@@ -125,6 +125,31 @@ describe("PluginHost — fail closed", () => {
     const p = recordingPlugin("p", [], { dependsOn: ["absent-dep"] });
     await expect(host.register(app, ctx, p)).rejects.toThrow(/absent-dep/);
   });
+
+  it("rejects migration ids whose legacy sanitization aliases one journal", async () => {
+    const host = new PluginHost<Ctx>();
+    const first = {
+      name: "first",
+      migrations: { id: "a-b", migrationsFolder: "/tmp/first" },
+    };
+    const second = {
+      name: "second",
+      migrations: { id: "a.b", migrationsFolder: "/tmp/second" },
+    };
+    await expect(host.register(app, ctx, first, second)).rejects.toThrow(/aliases the journal/);
+    expect(host.describe().plugins).toEqual([]);
+  });
+
+  it("preserves legacy sanitized migration ids when they are unique", () => {
+    const host = new PluginHost<Ctx>();
+    host.collectMigrations({
+      name: "legacy",
+      migrations: { id: "Demo-Plugin", migrationsFolder: "/tmp/legacy" },
+    });
+    expect(host.describe().migrationSources).toEqual({
+      legacy: { id: "Demo-Plugin", migrationsTable: "__drizzle_migrations_plugin_demo_plugin" },
+    });
+  });
 });
 
 describe("PluginHost — webhook event contribution", () => {

--- a/packages/api/src/plugin.ts
+++ b/packages/api/src/plugin.ts
@@ -497,6 +497,38 @@ export class PluginHost<Ctx> {
     this.policyRegistry = policyRegistry ?? policyRuleRegistry;
   }
 
+  private prepareMigrationSources(
+    plugins: ReadonlyArray<StewardPlugin<StewardApp, Ctx>>,
+  ): Array<{ pluginName: string; source: PluginMigrationSource }> {
+    const owners = new Map(
+      this.migrationSources.map(({ pluginName, source }) => [
+        pluginMigrationsTable(source.id),
+        pluginName,
+      ]),
+    );
+    const additions: Array<{ pluginName: string; source: PluginMigrationSource }> = [];
+    for (const plugin of plugins) {
+      if (!plugin.migrations) continue;
+      let table: string;
+      try {
+        table = pluginMigrationsTable(plugin.migrations.id);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        throw new PluginHostError(`plugin "${plugin.name}" migration id is invalid: ${message}`);
+      }
+      const owner = owners.get(table);
+      if (owner) {
+        throw new PluginHostError(
+          `plugin "${plugin.name}" migration id aliases the journal already owned by ` +
+            `plugin "${owner}" (${table}); refusing cross-plugin migration state.`,
+        );
+      }
+      owners.set(table, plugin.name);
+      additions.push({ pluginName: plugin.name, source: plugin.migrations });
+    }
+    return additions;
+  }
+
   /** the webhook event registry this host merges plugin events into. */
   get webhookEventRegistry(): WebhookEventRegistry {
     return this.eventRegistry;
@@ -520,6 +552,7 @@ export class PluginHost<Ctx> {
     ...plugins: Array<StewardPlugin<StewardApp, Ctx>>
   ): Promise<void> {
     const ordered = orderByDependencies(plugins);
+    const migrationSources = this.prepareMigrationSources(ordered);
 
     // Phase 1: merge declared webhook events FIRST, so a plugin's `register`
     // (and any concurrent dispatch) sees its own events as already valid.
@@ -645,11 +678,7 @@ export class PluginHost<Ctx> {
     // applied by runMigrations(), called from the boot/migrate path after core
     // migrations. Stored in dependency order so a dependent plugin's migrations
     // apply after the plugins it depends on (it may FK their tables).
-    for (const plugin of ordered) {
-      if (plugin.migrations) {
-        this.migrationSources.push({ pluginName: plugin.name, source: plugin.migrations });
-      }
-    }
+    this.migrationSources.push(...migrationSources);
 
     // Phase 2: run each plugin's imperative register hook in dependency order.
     for (const plugin of ordered) {
@@ -672,11 +701,7 @@ export class PluginHost<Ctx> {
    */
   collectMigrations(...plugins: Array<StewardPlugin<StewardApp, Ctx>>): this {
     const ordered = orderByDependencies(plugins);
-    for (const plugin of ordered) {
-      if (plugin.migrations) {
-        this.migrationSources.push({ pluginName: plugin.name, source: plugin.migrations });
-      }
-    }
+    this.migrationSources.push(...this.prepareMigrationSources(ordered));
     return this;
   }
 

--- a/packages/auth/src/__tests__/authorization-keys.test.ts
+++ b/packages/auth/src/__tests__/authorization-keys.test.ts
@@ -68,5 +68,8 @@ describe("decodeFlexible hex/base64 disambiguation (SEC-063)", () => {
 
   test("oversized base64 padding fails closed without regex backtracking", async () => {
     expect(await importP256PublicKey(`not-a-key${"=".repeat(200_000)}`)).toBeNull();
+    const nearMiss = `not-a-key${"=".repeat(200_000)}!`;
+    expect(await importP256PublicKey(nearMiss)).toBeNull();
+    expect(await verifyP256Signature(nearMiss, "message", nearMiss)).toBe(false);
   });
 });

--- a/packages/auth/src/__tests__/mock-email-provider.test.ts
+++ b/packages/auth/src/__tests__/mock-email-provider.test.ts
@@ -49,7 +49,7 @@ describe("MockEmailProvider", () => {
     expect(MockEmailInbox.all("c@example.com")).toHaveLength(0);
   });
 
-  it("preserves first-token extraction semantics without regex backtracking", async () => {
+  it("preserves the legacy regex's last-token extraction semantics", async () => {
     const provider = new MockEmailProvider();
     await provider.send(
       "tokens@example.com",
@@ -57,8 +57,8 @@ describe("MockEmailProvider", () => {
       "open https://steward.fi/callback?token=first&next=1&token=second&after=ignored",
     );
     const msg = MockEmailInbox.last("tokens@example.com");
-    expect(msg?.token).toBe("first");
-    expect(msg?.magicLink).toBe("https://steward.fi/callback?token=first");
+    expect(msg?.token).toBe("second");
+    expect(msg?.magicLink).toBe("https://steward.fi/callback?token=first&next=1&token=second");
   });
 
   it("handles adversarial scheme runs without regex backtracking", async () => {
@@ -67,5 +67,12 @@ describe("MockEmailProvider", () => {
     const msg = MockEmailInbox.last("redos@example.com");
     expect(msg?.token).toBeUndefined();
     expect(msg?.magicLink).toBeUndefined();
+  });
+
+  it("scans many short no-link segments in linear time", async () => {
+    const provider = new MockEmailProvider();
+    const text = "x ".repeat(100_000);
+    await provider.send("segmented@example.com", "No link", text);
+    expect(MockEmailInbox.last("segmented@example.com")?.token).toBeUndefined();
   });
 });

--- a/packages/auth/src/__tests__/totp.test.ts
+++ b/packages/auth/src/__tests__/totp.test.ts
@@ -139,5 +139,12 @@ describe("TOTP (RFC 6238)", () => {
       secret: `JBSWY3DPEHPK3PXP${"=".repeat(200_000)}`,
     });
     expect(uri).toContain("secret=JBSWY3DPEHPK3PXP&");
+    expect(() =>
+      buildOtpauthUri({
+        issuer: "Steward",
+        accountName: "alice@example.com",
+        secret: `JBSWY3DPEHPK3PXP${"=".repeat(200_000)}!`,
+      }),
+    ).toThrow("invalid character");
   });
 });

--- a/packages/auth/src/email-provider.ts
+++ b/packages/auth/src/email-provider.ts
@@ -160,11 +160,16 @@ function parseMagicLink(text: string): { magicLink?: string; token?: string } {
     while (segmentEnd < text.length && text[segmentEnd].trim().length !== 0) segmentEnd += 1;
     if (segmentEnd === segmentStart) break;
 
-    const http = text.indexOf("http://", segmentStart);
-    const https = text.indexOf("https://", segmentStart);
-    const candidates = [http, https].filter((index) => index >= segmentStart && index < segmentEnd);
-    const schemeStart = candidates.length > 0 ? Math.min(...candidates) : -1;
+    let schemeStart = -1;
+    for (let index = segmentStart; index < segmentEnd; index += 1) {
+      if (text.startsWith("http://", index) || text.startsWith("https://", index)) {
+        schemeStart = index;
+        break;
+      }
+    }
     if (schemeStart !== -1) {
+      let tokenStart = -1;
+      let tokenEnd = -1;
       for (let index = schemeStart; index < segmentEnd; index += 1) {
         if (text.startsWith("?token=", index) || text.startsWith("&token=", index)) {
           const candidate = index + 7;
@@ -176,9 +181,9 @@ function parseMagicLink(text: string): { magicLink?: string; token?: string } {
             code === 0x2d ||
             code === 0x5f
           ) {
-            let tokenEnd = candidate;
-            while (tokenEnd < segmentEnd) {
-              const tokenCode = text.charCodeAt(tokenEnd);
+            let candidateEnd = candidate;
+            while (candidateEnd < segmentEnd) {
+              const tokenCode = text.charCodeAt(candidateEnd);
               if (
                 (tokenCode >= 0x30 && tokenCode <= 0x39) ||
                 (tokenCode >= 0x41 && tokenCode <= 0x5a) ||
@@ -186,17 +191,21 @@ function parseMagicLink(text: string): { magicLink?: string; token?: string } {
                 tokenCode === 0x2d ||
                 tokenCode === 0x5f
               ) {
-                tokenEnd += 1;
+                candidateEnd += 1;
               } else {
                 break;
               }
             }
-            return {
-              magicLink: text.slice(schemeStart, tokenEnd),
-              token: text.slice(candidate, tokenEnd),
-            };
+            tokenStart = candidate;
+            tokenEnd = candidateEnd;
           }
         }
+      }
+      if (tokenStart !== -1) {
+        return {
+          magicLink: text.slice(schemeStart, tokenEnd),
+          token: text.slice(tokenStart, tokenEnd),
+        };
       }
     }
     segmentStart = segmentEnd + 1;

--- a/packages/auth/src/totp.ts
+++ b/packages/auth/src/totp.ts
@@ -184,9 +184,9 @@ export interface OtpauthUriParams {
 export function buildOtpauthUri(params: OtpauthUriParams): string {
   const issuer = encodeURIComponent(params.issuer);
   const account = encodeURIComponent(params.accountName);
-  let paddingStart = params.secret.length;
-  while (paddingStart > 0 && params.secret.charCodeAt(paddingStart - 1) === 0x3d) paddingStart -= 1;
-  const secret = params.secret.slice(0, paddingStart);
+  const decodedSecret = base32Decode(params.secret);
+  if (decodedSecret.length === 0) throw new Error("TOTP secret must contain base32 key material");
+  const secret = base32Encode(decodedSecret);
   return (
     `otpauth://totp/${issuer}:${account}` +
     `?secret=${secret}&issuer=${issuer}&algorithm=SHA1&digits=${DIGITS}&period=${STEP_SEC}`

--- a/packages/db/src/__tests__/plugin-migrate.test.ts
+++ b/packages/db/src/__tests__/plugin-migrate.test.ts
@@ -56,10 +56,10 @@ describe("plugin migrations: namespaced-journal isolation", () => {
     expect(() => sanitizePluginMigrationId("///")).toThrow();
     expect(() => sanitizePluginMigrationId("")).toThrow();
     // the derived table name carries the sanitized id, never raw input
-    expect(pluginMigrationsTable("trading")).toBe("__drizzle_migrations_plugin_trading");
+    expect(pluginMigrationsTable("Trading")).toBe("__drizzle_migrations_plugin_trading");
     expect(sanitizePluginMigrationId(`${"_".repeat(200_000)}safe`)).toBe("safe");
-    expect(() => pluginMigrationsTable("a-b")).toThrow(/canonical lowercase/);
-    expect(() => pluginMigrationsTable("a.b")).toThrow(/canonical lowercase/);
+    expect(pluginMigrationsTable("a-b")).toBe("__drizzle_migrations_plugin_a_b");
+    expect(pluginMigrationsTable("a.b")).toBe("__drizzle_migrations_plugin_a_b");
     expect(() => pluginMigrationsTable("a".repeat(36))).toThrow(/exceeds 35 characters/);
   });
 
@@ -75,7 +75,7 @@ describe("plugin migrations: namespaced-journal isolation", () => {
     );
 
     const result = await runPluginMigrations(
-      { id: "demo_plugin", migrationsFolder: folder },
+      { id: "demo-plugin", migrationsFolder: folder },
       {
         db,
         client,
@@ -84,7 +84,7 @@ describe("plugin migrations: namespaced-journal isolation", () => {
       },
     );
 
-    expect(result.id).toBe("demo_plugin");
+    expect(result.id).toBe("demo-plugin");
     expect(result.migrationsTable).toBe("__drizzle_migrations_plugin_demo_plugin");
 
     // (a) the plugin's table was created
@@ -106,7 +106,7 @@ describe("plugin migrations: namespaced-journal isolation", () => {
 
     // (d) idempotent: a second run applies nothing and does not throw
     const again = await runPluginMigrations(
-      { id: "demo_plugin", migrationsFolder: folder },
+      { id: "demo-plugin", migrationsFolder: folder },
       { db, client, useAdvisoryLock: false, migrateFn: pgliteMigrate as never },
     );
     expect(again.migrationsTable).toBe("__drizzle_migrations_plugin_demo_plugin");

--- a/packages/db/src/plugin-migrate.ts
+++ b/packages/db/src/plugin-migrate.ts
@@ -91,14 +91,8 @@ export function sanitizePluginMigrationId(id: string): string {
   return sanitized;
 }
 
-function canonicalPluginMigrationId(id: string): string {
+function boundedPluginMigrationId(id: string): string {
   const sanitized = sanitizePluginMigrationId(id);
-  if (id !== sanitized) {
-    throw new Error(
-      `plugin migration id "${id}" must already be canonical lowercase [a-z0-9_] text; ` +
-        "lossy sanitization can alias another plugin's migration journal.",
-    );
-  }
   if (sanitized.length > MAX_PLUGIN_MIGRATION_ID_LENGTH) {
     throw new Error(
       `plugin migration id exceeds ${MAX_PLUGIN_MIGRATION_ID_LENGTH} characters; ` +
@@ -114,7 +108,7 @@ function canonicalPluginMigrationId(id: string): string {
  * core's `__drizzle_migrations`.
  */
 export function pluginMigrationsTable(id: string): string {
-  return `${PLUGIN_MIGRATIONS_TABLE_PREFIX}${canonicalPluginMigrationId(id)}`;
+  return `${PLUGIN_MIGRATIONS_TABLE_PREFIX}${boundedPluginMigrationId(id)}`;
 }
 
 /**
@@ -124,7 +118,7 @@ export function pluginMigrationsTable(id: string): string {
  * another plugin's run.
  */
 export function pluginAdvisoryLockKey(id: string): string {
-  return `steward_plugin_migrations_${canonicalPluginMigrationId(id)}`;
+  return `steward_plugin_migrations_${boundedPluginMigrationId(id)}`;
 }
 
 /**

--- a/packages/eliza-plugin/src/__tests__/integration.test.ts
+++ b/packages/eliza-plugin/src/__tests__/integration.test.ts
@@ -411,16 +411,16 @@ describe("approvalRequiredEvaluator", () => {
 
 describe("Amount parsing (via transfer handler)", () => {
   const cases = [
-    { input: "0.01 ETH", shouldFail: false },
-    { input: "1.5 BNB", shouldFail: false },
-    { input: "100 USDC", shouldFail: false },
-    { input: "0.001", shouldFail: false },
-    { input: "", shouldFail: true },
-    { input: "abc xyz", shouldFail: true },
-    { input: "-5 ETH", shouldFail: true },
+    { input: "0.01 ETH", chain: "base", shouldFail: false },
+    { input: "1.5 BNB", chain: "bsc", shouldFail: false },
+    { input: "100 USDC", chain: "base", shouldFail: true },
+    { input: "0.001", chain: "base", shouldFail: false },
+    { input: "", chain: "base", shouldFail: true },
+    { input: "abc xyz", chain: "base", shouldFail: true },
+    { input: "-5 ETH", chain: "base", shouldFail: true },
   ];
 
-  for (const { input, shouldFail } of cases) {
+  for (const { input, chain, shouldFail } of cases) {
     it(`${shouldFail ? "rejects" : "accepts"} "${input}"`, async () => {
       const service = {
         isConnected: () => true,
@@ -434,7 +434,7 @@ describe("Amount parsing (via transfer handler)", () => {
         parameters: {
           to: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
           amount: input,
-          chain: "base",
+          chain,
         },
       });
 

--- a/packages/eliza-plugin/src/actions/transfer.ts
+++ b/packages/eliza-plugin/src/actions/transfer.ts
@@ -112,7 +112,7 @@ export const transferAction: Action = {
     },
     {
       name: "amount",
-      description: 'Human-readable amount (e.g. "0.1 ETH", "50 USDC")',
+      description: 'Native-token amount (e.g. "0.1 ETH", "0.5 BNB")',
       required: true,
       schema: { type: "string" },
     },

--- a/packages/mcp/src/__tests__/provider-tools.test.ts
+++ b/packages/mcp/src/__tests__/provider-tools.test.ts
@@ -308,6 +308,44 @@ describe("credential redaction", () => {
 
     const whitespaceRun = `jwt${" ".repeat(200_000)}`;
     expect(sanitizeProviderPayload(whitespaceRun)).toBe(whitespaceRun);
+    expect(sanitizeProviderPayload("x".repeat(1_048_577))).toBe("[redacted]");
+  });
+
+  test("matches armored key end markers without exposing trailing key material", () => {
+    const text =
+      "-----BEGIN PRIVATE KEY-----canary-before-wrong-end" +
+      "-----END RSA PRIVATE KEY-----canary-after-wrong-end-----END PRIVATE KEY----- public";
+    const clean = sanitizeProviderPayload(text) as string;
+    expect(clean).not.toContain("canary-before-wrong-end");
+    expect(clean).not.toContain("canary-after-wrong-end");
+    expect(clean).toContain(" public");
+
+    const lower = sanitizeProviderPayload(
+      "-----begin encrypted private key-----mixed-case-canary-----end encrypted private key-----",
+    ) as string;
+    expect(lower).not.toContain("mixed-case-canary");
+  });
+
+  test("covers every optional-separator access-key label", () => {
+    const joins = ["-", "_", ""];
+    const labels = [
+      ...joins.flatMap((first) => joins.map((second) => `access${first}key${second}id`)),
+      ...joins.flatMap((first) => joins.map((second) => `secret${first}access${second}key`)),
+    ];
+    for (const label of labels) {
+      const clean = sanitizeProviderPayload(`${label}=separator-canary`) as string;
+      expect(clean).not.toContain("separator-canary");
+    }
+  });
+
+  test("advances across repeated structured-token and armored candidates", () => {
+    for (const input of [
+      "eyj".repeat(100_000),
+      "xoxb-".repeat(100_000),
+      "-----BEGIN PRIVATE KEY-----x-----END PRIVATE KEY-----".repeat(10_000),
+    ]) {
+      expect(typeof sanitizeProviderPayload(input)).toBe("string");
+    }
   });
 
   test("fails closed on accessors and cycles without invoking provider code", () => {

--- a/packages/mcp/src/provider-api.ts
+++ b/packages/mcp/src/provider-api.ts
@@ -29,6 +29,18 @@ function isSensitiveProviderKey(key: string): boolean {
     normalized.endsWith("hmacsignature")
   );
 }
+function joinedLabelVariants(parts: readonly string[]): string[] {
+  let variants = [parts[0]];
+  for (const part of parts.slice(1)) {
+    variants = variants.flatMap((prefix) => [
+      `${prefix}-${part}`,
+      `${prefix}_${part}`,
+      `${prefix}${part}`,
+    ]);
+  }
+  return variants;
+}
+
 const SECRET_LABELS = [
   "authorization",
   "auth",
@@ -67,15 +79,9 @@ const SECRET_LABELS = [
   "client-secret",
   "client_secret",
   "clientsecret",
-  "access-key",
-  "access_key",
-  "accesskey",
-  "access-key-id",
-  "access_key_id",
-  "accesskeyid",
-  "secret-access-key",
-  "secret_access_key",
-  "secretaccesskey",
+  ...joinedLabelVariants(["access", "key"]),
+  ...joinedLabelVariants(["access", "key", "id"]),
+  ...joinedLabelVariants(["secret", "access", "key"]),
   "session-id",
   "session_id",
   "sessionid",
@@ -98,7 +104,16 @@ const SECRET_LABELS = [
   "pat",
 ] as const;
 
+const SECRET_LABELS_BY_FIRST = new Map<number, string[]>();
+for (const label of ["bearer", ...SECRET_LABELS].sort((a, b) => b.length - a.length)) {
+  const first = label.charCodeAt(0);
+  const entries = SECRET_LABELS_BY_FIRST.get(first) ?? [];
+  entries.push(label);
+  SECRET_LABELS_BY_FIRST.set(first, entries);
+}
+
 type TextRange = { start: number; end: number };
+const MAX_PROVIDER_TEXT_LENGTH = 1_048_576;
 
 function isAsciiAlphaNumeric(code: number): boolean {
   return (
@@ -131,6 +146,13 @@ function asciiStartsWithIgnoreCase(value: string, index: number, expected: strin
   return true;
 }
 
+function asciiIndexOfIgnoreCase(value: string, expected: string, from: number): number {
+  for (let index = from; index + expected.length <= value.length; index += 1) {
+    if (asciiStartsWithIgnoreCase(value, index, expected)) return index;
+  }
+  return -1;
+}
+
 function addPrefixedTokenRange(
   value: string,
   ranges: TextRange[],
@@ -138,11 +160,13 @@ function addPrefixedTokenRange(
   prefixLength: number,
   minimumSuffix: number,
   suffixCode: (code: number) => boolean,
-): void {
-  if (start > 0 && isWordCode(value.charCodeAt(start - 1))) return;
+): number | undefined {
+  if (start > 0 && isWordCode(value.charCodeAt(start - 1))) return undefined;
   let end = start + prefixLength;
   while (end < value.length && suffixCode(value.charCodeAt(end))) end += 1;
-  if (end - (start + prefixLength) >= minimumSuffix) ranges.push({ start, end });
+  if (end - (start + prefixLength) < minimumSuffix) return undefined;
+  ranges.push({ start, end });
+  return end;
 }
 
 function collectStructuredSecretRanges(value: string, ranges: TextRange[]): void {
@@ -163,20 +187,26 @@ function collectStructuredSecretRanges(value: string, ranges: TextRange[]): void
           continue;
         }
       }
+      // A nested `eyj` in the same uninterrupted base64url candidate cannot
+      // begin another independently delimited credential. Skip the candidate
+      // once so malformed near-misses remain linear.
+      index = end - 1;
+      continue;
     }
+    let tokenEnd: number | undefined;
     if (asciiStartsWithIgnoreCase(value, index, "sk-")) {
-      addPrefixedTokenRange(value, ranges, index, 3, 8, isBase64UrlCode);
+      tokenEnd = addPrefixedTokenRange(value, ranges, index, 3, 8, isBase64UrlCode);
     } else if (
       asciiStartsWithIgnoreCase(value, index, "ghp_") ||
       asciiStartsWithIgnoreCase(value, index, "gho_")
     ) {
-      addPrefixedTokenRange(value, ranges, index, 4, 8, isAsciiAlphaNumeric);
+      tokenEnd = addPrefixedTokenRange(value, ranges, index, 4, 8, isAsciiAlphaNumeric);
     } else if (
       ["xoxb-", "xoxa-", "xoxp-", "xoxr-", "xoxs-"].some((prefix) =>
         asciiStartsWithIgnoreCase(value, index, prefix),
       )
     ) {
-      addPrefixedTokenRange(
+      tokenEnd = addPrefixedTokenRange(
         value,
         ranges,
         index,
@@ -199,15 +229,20 @@ function collectStructuredSecretRanges(value: string, ranges: TextRange[]): void
         (end === value.length || !isWordCode(value.charCodeAt(end)))
       ) {
         ranges.push({ start: index, end });
+        tokenEnd = end;
       }
     }
+    if (tokenEnd !== undefined) index = tokenEnd - 1;
   }
 }
 
 function collectLabeledSecretRanges(value: string, ranges: TextRange[]): void {
-  const labels = ["bearer", ...SECRET_LABELS] as const;
-  for (const label of labels) {
-    for (let start = 0; start < value.length; start += 1) {
+  for (let start = 0; start < value.length; start += 1) {
+    let first = value.charCodeAt(start);
+    if (first >= 0x41 && first <= 0x5a) first += 0x20;
+    const labels = SECRET_LABELS_BY_FIRST.get(first);
+    if (!labels) continue;
+    for (const label of labels) {
       if (!asciiStartsWithIgnoreCase(value, start, label)) continue;
       let cursor = start + label.length;
       const whitespaceStart = cursor;
@@ -233,45 +268,40 @@ function collectLabeledSecretRanges(value: string, ranges: TextRange[]): void {
       if (cursor > secretStart) {
         ranges.push({ start, end: cursor });
         start = cursor - 1;
+        break;
       }
     }
   }
 }
 
 function collectArmoredKeyRanges(value: string, ranges: TextRange[]): void {
-  const privateBegins = [
-    "-----BEGIN PRIVATE KEY-----",
-    "-----BEGIN ENCRYPTED PRIVATE KEY-----",
-    "-----BEGIN RSA PRIVATE KEY-----",
-    "-----BEGIN EC PRIVATE KEY-----",
-    "-----BEGIN DSA PRIVATE KEY-----",
-    "-----BEGIN OPENSSH PRIVATE KEY-----",
-    "-----BEGIN PGP PRIVATE KEY BLOCK-----",
-  ];
-  const privateEnds = [
-    "-----END PRIVATE KEY-----",
-    "-----END ENCRYPTED PRIVATE KEY-----",
-    "-----END RSA PRIVATE KEY-----",
-    "-----END EC PRIVATE KEY-----",
-    "-----END DSA PRIVATE KEY-----",
-    "-----END OPENSSH PRIVATE KEY-----",
-    "-----END PGP PRIVATE KEY BLOCK-----",
-  ];
-  for (const begin of privateBegins) {
-    let start = value.indexOf(begin);
-    while (start !== -1) {
-      let end = value.length;
-      for (const marker of privateEnds) {
-        const candidate = value.indexOf(marker, start + begin.length);
-        if (candidate !== -1 && candidate + marker.length < end) end = candidate + marker.length;
-      }
+  const markers = [
+    ["-----BEGIN PRIVATE KEY-----", "-----END PRIVATE KEY-----"],
+    ["-----BEGIN ENCRYPTED PRIVATE KEY-----", "-----END ENCRYPTED PRIVATE KEY-----"],
+    ["-----BEGIN RSA PRIVATE KEY-----", "-----END RSA PRIVATE KEY-----"],
+    ["-----BEGIN EC PRIVATE KEY-----", "-----END EC PRIVATE KEY-----"],
+    ["-----BEGIN DSA PRIVATE KEY-----", "-----END DSA PRIVATE KEY-----"],
+    ["-----BEGIN OPENSSH PRIVATE KEY-----", "-----END OPENSSH PRIVATE KEY-----"],
+    ["-----BEGIN PGP PRIVATE KEY BLOCK-----", "-----END PGP PRIVATE KEY BLOCK-----"],
+  ] as const;
+  for (let start = 0; start < value.length; start += 1) {
+    for (const [begin, endMarker] of markers) {
+      if (!asciiStartsWithIgnoreCase(value, start, begin.toLowerCase())) continue;
+      const markerStart = asciiIndexOfIgnoreCase(
+        value,
+        endMarker.toLowerCase(),
+        start + begin.length,
+      );
+      const end = markerStart === -1 ? value.length : markerStart + endMarker.length;
       ranges.push({ start, end });
-      start = value.indexOf(begin, end);
+      start = end - 1;
+      break;
     }
   }
 }
 
 function redactSecretText(value: string): string {
+  if (value.length > MAX_PROVIDER_TEXT_LENGTH) return "[redacted]";
   const ranges: TextRange[] = [];
   collectArmoredKeyRanges(value, ranges);
   collectLabeledSecretRanges(value, ranges);

--- a/packages/ruby/test/client_test.rb
+++ b/packages/ruby/test/client_test.rb
@@ -129,5 +129,9 @@ class StewardClientTest < Minitest::Test
     )
 
     assert_equal "https://api.example.test", client.instance_variable_get(:@base_url)
+
+    near_miss = "https://api.example.test/path#{"/" * 200_000}!"
+    client = Steward::Client.new(base_url: near_miss, api_key: "tenant-key")
+    assert_equal near_miss, client.instance_variable_get(:@base_url)
   end
 end

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -107,9 +107,7 @@ export interface PolicyRuleContribution<Ctx = unknown> {
  * WIRED in Phase 2c. The host applies these via `@stwd/db`'s
  * `runPluginMigrations`, which runs the plugin's drizzle migrations into a
  * SEPARATE, PER-PLUGIN bookkeeping table derived from `id`
- * (`__drizzle_migrations_plugin_<id>` in the `drizzle` schema). The id must
- * already be canonical lowercase `[a-z0-9_]` text and fit PostgreSQL's
- * identifier limit; lossy aliases are rejected rather than sharing a ledger.
+ * (`__drizzle_migrations_plugin_<sanitized id>` in the `drizzle` schema). The
  * isolation guarantee is total: a plugin's applied-migrations ledger is NEVER
  * written into or read from the core's `drizzle.__drizzle_migrations` journal, so
  * a plugin owns its schema and CANNOT clobber the core's migration state. The
@@ -123,9 +121,9 @@ export interface PluginMigrationSource {
    * derive the per-plugin bookkeeping table name + advisory-lock key, so a
    * plugin's migration ledger is isolated from the core's and from every other
    * plugin's. MUST be stable across releases (changing it orphans the prior
-   * ledger and re-applies every migration). It must already be canonical
-   * lowercase `[a-z0-9_]` text and no longer than the runner's documented
-   * PostgreSQL-safe bound; lossy or overlong ids are rejected (fail closed).
+   * ledger and re-applies every migration). sanitized to a safe SQL identifier
+   * by the runner; an id that sanitizes to empty or exceeds the PostgreSQL-safe
+   * bound is rejected. The host rejects aliases across its registered plugins.
    */
   readonly id: string;
   /**

--- a/packages/venue-polymarket/src/index.test.ts
+++ b/packages/venue-polymarket/src/index.test.ts
@@ -258,7 +258,10 @@ describe("signEndpointUrl normalization", () => {
   });
   test("handles adversarial slash runs without regex backtracking", () => {
     const slashes = "/".repeat(200_000);
-    expect(signEndpointUrl(`${slashes}x`)).toBe(`${slashes}x/sign`);
+    expect(signEndpointUrl(`x${slashes}`)).toBe("x/sign");
+    expect(signEndpointUrl(`https://builder.example/path${slashes}`)).toBe(
+      "https://builder.example/path/sign",
+    );
   });
 });
 

--- a/scripts/__tests__/check-ci-test-inventory.test.ts
+++ b/scripts/__tests__/check-ci-test-inventory.test.ts
@@ -242,15 +242,33 @@ describe("CI test inventory", () => {
   });
 
   test("does not accept Ruby filename lookalikes as test commands", () => {
+    for (const command of [
+      "ruby packages/ruby/test/security_test.rbx packages/ruby",
+      "ruby contest/security_test.rb packages/ruby",
+    ]) {
+      const job = extractJob(
+        [
+          "  dedicated:",
+          "    steps:",
+          "      - name: Test package",
+          `        run: ${command}`,
+        ].join("\n"),
+        "dedicated",
+      );
+      expect(jobExecutesPackageTests(job, "packages/ruby")).toBe(false);
+    }
+  });
+
+  test("ignores runner words and package paths in shell comments", () => {
     const job = extractJob(
       [
         "  dedicated:",
         "    steps:",
         "      - name: Test package",
-        "        run: ruby packages/ruby/test/security_test.rbx packages/ruby",
+        "        run: bun --help # test packages/a",
       ].join("\n"),
       "dedicated",
     );
-    expect(jobExecutesPackageTests(job, "packages/ruby")).toBe(false);
+    expect(jobExecutesPackageTests(job, "packages/a")).toBe(false);
   });
 });

--- a/scripts/check-ci-test-inventory.ts
+++ b/scripts/check-ci-test-inventory.ts
@@ -182,7 +182,10 @@ export function jobExecutesPackageTests(job: string, packagePath: string): boole
       .split(/\r?\n/)
       .map((line) => line.trim())
       .some((line) => {
-        const shellSyntax = line.replace(/'(?:[^']*)'/g, "").replace(/"(?:\\.|[^"\\])*"/g, "");
+        const executableLine = stripUnquotedShellComment(line).trimEnd();
+        const shellSyntax = executableLine
+          .replace(/'(?:[^']*)'/g, "")
+          .replace(/"(?:\\.|[^"\\])*"/g, "");
         // A command that masks its own failure or explicitly disables tests is
         // not CI evidence even if its spelling otherwise resembles a runner.
         if (
@@ -190,13 +193,36 @@ export function jobExecutesPackageTests(job: string, packagePath: string): boole
         ) {
           return false;
         }
-        if (!isExecutableTestCommand(line)) return false;
+        if (!isExecutableTestCommand(executableLine)) return false;
         // Bind the package reference to the same executable line. Merely
         // echoing a package name elsewhere in a multiline step cannot make an
         // unrelated test command satisfy this target.
-        return step.workingDirectory === packagePath || line.includes(packagePath);
+        return step.workingDirectory === packagePath || executableLine.includes(packagePath);
       });
   });
+}
+
+function stripUnquotedShellComment(line: string): string {
+  let quote: '"' | "'" | undefined;
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index];
+    if (quote === '"' && char === "\\") {
+      index += 1;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = quote === char ? undefined : quote === undefined ? char : quote;
+      continue;
+    }
+    if (
+      char === "#" &&
+      quote === undefined &&
+      (index === 0 || isShellWhitespace(line[index - 1]))
+    ) {
+      return line.slice(0, index);
+    }
+  }
+  return line;
 }
 
 function isShellWhitespace(char: string | undefined): boolean {
@@ -294,6 +320,7 @@ function isExecutableTestCommand(line: string): boolean {
   if (startsWithWord(command, "ruby")) {
     const testPath = command.indexOf("test/");
     if (testPath === -1) return false;
+    if (testPath > 0 && isWordCode(command.charCodeAt(testPath - 1))) return false;
     const tokenEnd = command.indexOf(" ", testPath);
     const pathToken = command.slice(testPath, tokenEnd === -1 ? undefined : tokenEnd);
     const suffix = pathToken.indexOf("_test.rb");


### PR DESCRIPTION
## Summary

Post-merge audit of #518 found concrete residual regressions in its exact merged tree. This corrective:

- makes mock magic-link scanning linear across many short segments while preserving the original regex's last-token semantics
- makes MCP free-text redaction case-insensitive for armored keys, complete across optional access-key separators, bounded at 1 MiB, and advancing across repeated structured candidates
- preserves deployed legacy sanitized plugin migration IDs while rejecting cross-plugin journal aliases before any host registration side effects
- closes the Ruby CI inventory path-boundary/comment false greens
- validates TOTP URI secrets as canonical base32 and strengthens regex near-miss regressions
- aligns Eliza native-asset documentation/integration expectations and strengthens Polymarket/Ruby adversarial tests

## Merged-byte evidence

PR #518 merged source `05b7cc87fa59c620dd530c7118d3c64754e66303` as `90afd376c8d9dba270b1643f36b56c7803066a75`; source and merge trees are identical (`11e937983e5fcabcca11c43faa6bb0269fa558ce`).

## Validation

- exact-head focused suites: 373 passing, 24 intentionally skipped
- PGLite core/plugin migration coverage green
- exact affected API/plugin/MCP/auth/SDK/shared/venue/Ruby suites green
- 26-package dependency build green after the semantic fixes; final-base focused suites rerun green (latest intervening changes did not overlap)
- Biome and `git diff --check` green

Draft pending exact-head CI and maintainer review. No workflow files changed.
