### PR TITLE
fix(seed): persist credentials before database rotation

### DIFF
--- a/packages/seed/src/index.ts
+++ b/packages/seed/src/index.ts
@@ -136,6 +136,10 @@ async function seed() {
     throw new Error("STEWARD_MASTER_PASSWORD is required");
   }
 
+  // Persist the one-time credential before touching the database. If the
+  // destination is unsafe or unwritable, fail without rotating the tenant's
+  // stored hash to a key the operator can no longer recover.
+  const demoCredentialsPath = writeDemoCredentials(TENANT_ID, DEMO_API_KEY.key);
   const db = getDb();
   const keyStore = new KeyStore(process.env.STEWARD_MASTER_PASSWORD);
   const createdAt = hoursAgo(168); // 7 days ago — agent creation time
@@ -162,8 +166,6 @@ async function seed() {
         updatedAt,
       },
     });
-  const demoCredentialsPath = writeDemoCredentials(TENANT_ID, DEMO_API_KEY.key);
-
   /* ════════════════════════════════════════════════════════════════════════ */
   /*  AGENT DEFINITIONS                                                      */
   /* ════════════════════════════════════════════════════════════════════════ */


### PR DESCRIPTION
## Summary
- persist the generated one-time demo credential before any database cleanup or tenant update
- fail without rotating the stored tenant API-key hash when the credential destination is unsafe or unwritable

## Validation
- `bun test --timeout 30000 packages/seed/src/__tests__/demo-api-key.test.ts` (2 pass, 13 assertions)
- `bunx biome check packages/seed/src/index.ts packages/seed/src/demo-api-key.ts packages/seed/src/__tests__/demo-api-key.test.ts`
- `git diff --check`

Follow-up to #514.